### PR TITLE
fix(folio): header editing on title-page / image-only headers

### DIFF
--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -126,26 +126,29 @@ export function InlineHeaderFooterEditor({
     };
   }, [targetElement, parentElement]);
 
-  // Focus the persistent HF PM when the chrome mounts so typing starts
-  // immediately after double-click. The HF view may not exist yet at
-  // mount: HiddenHeaderFooterPMs creates views inside a useEffect, and
-  // for freshly-created HF parts (empty header on a doc that had none),
-  // the chrome and the view-creation effect can land in either order.
-  // Retry across a short rAF window so focus lands as soon as the view
-  // is available; bail after MAX_FOCUS_ATTEMPTS frames to avoid leaking
-  // a rAF loop in pathological cases.
+  // Latest getActiveView, read through a ref so the focus loop below is never
+  // stuck on a stale mount-time closure if the active HF view resolves later.
+  const getActiveViewRef = useRef(getActiveView);
+  getActiveViewRef.current = getActiveView;
+
+  // Move focus into the persistent HF view when the chrome mounts so typing
+  // starts immediately after double-click. A single focus() is unreliable: the
+  // HF view may not exist yet at mount (HiddenHeaderFooterPMs creates views in
+  // its own effect), AND entering edit mode triggers a relayout/repaint that
+  // re-grabs focus for the body PM — so a one-shot focus() gets stolen back and
+  // typing lands in the body. Keep nudging focus into the HF view across a short
+  // rAF window until it actually holds focus (or the window ends).
   useEffect(() => {
-    const MAX_FOCUS_ATTEMPTS = 10;
+    const MAX_FOCUS_ATTEMPTS = 30;
     let attempts = 0;
     let rafId: number | null = null;
     const tryFocus = () => {
-      const view = getActiveView();
-      if (view) {
+      const view = getActiveViewRef.current();
+      if (view && !view.hasFocus()) {
         view.focus();
-        return;
       }
       attempts++;
-      if (attempts < MAX_FOCUS_ATTEMPTS) {
+      if (attempts < MAX_FOCUS_ATTEMPTS && !view?.hasFocus()) {
         rafId = requestAnimationFrame(tryFocus);
       }
     };
@@ -155,7 +158,7 @@ export function InlineHeaderFooterEditor({
         cancelAnimationFrame(rafId);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- getActiveView is a closure over parent state; focus must fire only on mount, not re-steal focus on every parent re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- focus must fire only on mount; the view is read through a ref to avoid a stale closure
   }, []);
 
   const handleClose = useCallback(() => {

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -148,7 +148,11 @@ export function InlineHeaderFooterEditor({
         view.focus();
       }
       attempts++;
-      if (attempts < MAX_FOCUS_ATTEMPTS && !view?.hasFocus()) {
+      // Keep watching for the whole window, not just until the first successful
+      // focus: entering edit mode triggers a relayout/repaint that can clear or
+      // steal focus *after* it first lands, so re-focus on any frame where the
+      // HF view has lost it.
+      if (attempts < MAX_FOCUS_ATTEMPTS) {
         rafId = requestAnimationFrame(tryFocus);
       }
     };

--- a/packages/react/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/react/src/components/hooks/useHeaderFooterEditor.ts
@@ -9,7 +9,7 @@
  * `pushDocument` routing, and reading the live hidden HF PM doc at save time.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import type { EditorView } from "prosemirror-view";
 
@@ -109,10 +109,21 @@ export const useHeaderFooterEditor = ({
   // Resolved header/footer content
   // -------------------------------------------------------------------------
 
-  const resolution = useMemo(
+  const rawResolution = useMemo(
     () => resolveHeaderFooterContent(history.state?.package),
     [history.state],
   );
+  // `history.state` is transiently null while the document buffer is parsed and
+  // during relayout. Falling through to the empty resolution on those renders
+  // blanks the active H/F rIds, which breaks edit focus (getActiveView returns
+  // null, so typing lands in the body) and flickers the rendered chrome. Hold
+  // the last resolved structure and reuse it until a real document state
+  // arrives again.
+  const lastResolution = useRef(rawResolution);
+  if (history.state?.package) {
+    lastResolution.current = rawResolution;
+  }
+  const resolution = history.state?.package ? rawResolution : lastResolution.current;
   const {
     headerContent,
     footerContent,

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -294,6 +294,62 @@ test.describe("header/footer", () => {
     expect(await savedHeaderText(page)).toContain("HdrMark");
   });
 
+  test("double-clicking an image-only header still routes edits into the header", async ({
+    page,
+  }) => {
+    await mountFixture(page, "podily-bps.docx");
+
+    const header = page.locator(".layout-page-header").first();
+    await header.scrollIntoViewIfNeeded();
+
+    // This first-page header holds only a floating logo image plus an empty
+    // paragraph — there is no body-flow text under the cursor. A double-click in
+    // the header band must still enter header edit mode AND land the caret in the
+    // header content editor, rather than falling through to the body (the nearest
+    // editable text). Regression guard for the title-page / image-only header.
+    await header.dblclick();
+    await page.locator(".hf-inline-editor").waitFor({ state: "visible", timeout: 5000 });
+
+    // Pause before typing: a real user does not type instantly, so focus must
+    // stay in the header view past the brief entry-focus window, not snap back
+    // to the body once the window elapses.
+    await page.waitForTimeout(1200);
+    await page.keyboard.type("HdrMark", { delay: 15 });
+    await page.waitForTimeout(150);
+
+    const result = await page.evaluate(() => {
+      const top = (
+        globalThis as unknown as {
+          __folioPlayground: {
+            getEditorRef: () => {
+              getDocument?: () => { package?: { headers?: unknown } };
+              getEditorRef: () => {
+                getView?: () => { state: { doc: { textContent: string } } } | null;
+              };
+            };
+          };
+        }
+      ).__folioPlayground.getEditorRef();
+      const headers = top.getDocument?.()?.package?.headers;
+      const modelJson = JSON.stringify(
+        headers instanceof Map ? [...headers.values()] : (headers ?? {}),
+      );
+      return {
+        painted:
+          document.querySelector('[data-page-number="1"] .layout-page-header')?.textContent ?? "",
+        modelHasEdit: modelJson.includes("HdrMark"),
+        body: top.getEditorRef().getView?.()?.state.doc.textContent ?? "",
+      };
+    });
+
+    // The edit is visible in the painted header (the user sees what they type)...
+    expect(result.painted).toContain("HdrMark");
+    // ...is persisted into the saved document model (survives save)...
+    expect(result.modelHasEdit).toBe(true);
+    // ...and never leaks into the body (the nearest editable text).
+    expect(result.body).not.toContain("HdrMark");
+  });
+
   // NOTE: the *UI* save-on-body-click / save-on-exit commit path is not driven
   // here. While the inline header overlay is open the painted body paragraph is
   // not hittable, so a synthetic body click times out (a Playwright limitation,


### PR DESCRIPTION
Fixes header editing on docs whose first page uses a title-page / image-only header: stabilizes the header/footer resolution against a transient-null document state (it was blanking the active rIds, so keystrokes went to the body), and keeps focus in the H/F view across the edit-entry repaint. Adds an e2e regression guard for the image-only header.