### PR TITLE
fix(folio): render AI inline bold/italic markdown as real Word formatting

### DIFF
--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1280,6 +1280,137 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.child(2).type.name).toBe("table");
   });
 
+  test("inserted **bold** markdown becomes a real bold run (direct mode)", () => {
+    const state = makeState(["Anchor."]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+          inheritFormatting: false,
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const inserted = view.state.doc.child(1);
+    expect(inserted.textContent).toBe("Date: 2026");
+    const runs: { text: string; marks: string[] }[] = [];
+    inserted.descendants((node) => {
+      if (node.isText) {
+        runs.push({
+          text: node.text ?? "",
+          marks: node.marks.map((m) => m.type.name),
+        });
+      }
+    });
+    expect(runs).toEqual([
+      { text: "Date:", marks: ["bold"] },
+      { text: " 2026", marks: [] },
+    ]);
+  });
+
+  test("inserted **bold** markdown carries both insertion and bold marks (tracked changes)", () => {
+    const state = makeState(["Anchor."]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+          inheritFormatting: false,
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    const inserted = view.state.doc.child(1);
+    expect(inserted.textContent).toBe("Date: 2026");
+    const boldRun = collectMarksByText(view.state)["Date:"];
+    expect(boldRun).toContain("insertion");
+    expect(boldRun).toContain("bold");
+  });
+
+  test("replaceBlock **bold** becomes a real bold run and keeps block attrs (direct mode)", () => {
+    const state = makeState([{ text: "Old line.", paraId: "AAAA0001" }]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "replaceBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const block = view.state.doc.child(0);
+    expect(block.textContent).toBe("Date: 2026");
+    expect(block.attrs["paraId"]).toBe("AAAA0001");
+    const runs: { text: string; marks: string[] }[] = [];
+    block.descendants((node) => {
+      if (node.isText) {
+        runs.push({
+          text: node.text ?? "",
+          marks: node.marks.map((m) => m.type.name),
+        });
+      }
+    });
+    expect(runs).toEqual([
+      { text: "Date:", marks: ["bold"] },
+      { text: " 2026", marks: [] },
+    ]);
+  });
+
+  test("replaceBlock strips markdown markers in tracked-changes mode (no literal asterisks)", () => {
+    const state = makeState([{ text: "Old line.", paraId: "AAAA0001" }]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "replaceBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    // The word-diff redline interleaves the deleted old text with the new
+    // run, so the new text is present but not contiguous. The point here is
+    // that the markdown markers never reach the document as literal text.
+    const text = view.state.doc.textContent;
+    expect(text).toContain("Date:");
+    expect(text).toContain("2026");
+    expect(text).not.toContain("*");
+  });
+
   test("page-break-only inserts are skipped in tracked-changes mode", () => {
     const view = makeView(makeState(["Anchor block."]));
     const snapshot = createFolioAIEditSnapshot(view.state.doc);

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1411,6 +1411,46 @@ describe("Folio AI edit operations", () => {
     expect(text).not.toContain("*");
   });
 
+  test("replaceInBlock **bold** becomes a real bold run mid-block (direct mode)", () => {
+    const state = makeState(["Effective Date: TBD."]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "replaceInBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          find: "Date:",
+          replace: "**Date:**",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const block = view.state.doc.child(0);
+    expect(block.textContent).toBe("Effective Date: TBD.");
+    expect(block.textContent).not.toContain("*");
+    const runs: { text: string; marks: string[] }[] = [];
+    block.descendants((node) => {
+      if (node.isText) {
+        runs.push({
+          text: node.text ?? "",
+          marks: node.marks.map((m) => m.type.name),
+        });
+      }
+    });
+    expect(runs).toEqual([
+      { text: "Effective ", marks: [] },
+      { text: "Date:", marks: ["bold"] },
+      { text: " TBD.", marks: [] },
+    ]);
+  });
+
   test("page-break-only inserts are skipped in tracked-changes mode", () => {
     const view = makeView(makeState(["Anchor block."]));
     const snapshot = createFolioAIEditSnapshot(view.state.doc);

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -723,6 +723,19 @@ const applyTextReplacement = ({
   );
 
   if (mode === "direct") {
+    // Partial-block replacement carrying inline emphasis: rebuild the matched
+    // range as real bold/italic runs instead of stripping the markers to plain
+    // text. Full-block replaceBlock in direct mode is intercepted earlier and
+    // never reaches here with emphasis; the tracked-changes path below still
+    // strips, since its word-diff redline can't carry inline marks.
+    if (item.operation.type === "replaceInBlock" && hasInlineEmphasis(item.operation.replace)) {
+      const content = buildEmphasisInlineContent(
+        nextTr.doc.type.schema,
+        item.operation.replace,
+        commentMark ? [commentMark] : [],
+      );
+      return nextTr.replaceWith(item.from, item.to, content);
+    }
     nextTr = nextTr.insertText(replacement, item.from, item.to);
     if (commentMark && replacement.length > 0) {
       nextTr = nextTr.addMark(item.from, item.from + replacement.length, commentMark);

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -3,6 +3,11 @@ import type { EditorState, Transaction } from "prosemirror-state";
 
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
+import {
+  hasInlineEmphasis,
+  parseInlineEmphasisRuns,
+  stripInlineEmphasisMarkers,
+} from "./inline-emphasis";
 import { hashFolioAIBlockText, normalizeFolioAIBlockText } from "./snapshot";
 import type {
   FolioAIEditAppliedOperation,
@@ -303,6 +308,42 @@ const buildSignatureTableNode = ({
   return tableType.create({}, row);
 };
 
+/**
+ * Build the inline content for an inserted or replaced block, promoting the
+ * model's `**bold**` / `***bold italic***` markdown into real Word marks (the
+ * edit-tool schema has no inline-format channel, so the model improvises with
+ * markdown that would otherwise land as literal asterisks). Falls back to a
+ * single verbatim text node when no emphasis is present, so plain prose is
+ * never reshaped. `baseMarks` (insertion / comment) ride on every run.
+ */
+const buildEmphasisInlineContent = (
+  schema: Schema,
+  text: string,
+  baseMarks: readonly Mark[],
+): PMNode[] => {
+  const runs = parseInlineEmphasisRuns(text);
+  if (!runs.some((run) => run.bold || run.italic)) {
+    return [schema.text(text, [...baseMarks])];
+  }
+  const boldType = schema.marks["bold"];
+  const italicType = schema.marks["italic"];
+  const nodes: PMNode[] = [];
+  for (const run of runs) {
+    if (run.text.length === 0) {
+      continue;
+    }
+    const marks: Mark[] = [...baseMarks];
+    if (run.bold && boldType) {
+      marks.push(boldType.create());
+    }
+    if (run.italic && italicType) {
+      marks.push(italicType.create());
+    }
+    nodes.push(schema.text(run.text, marks));
+  }
+  return nodes.length > 0 ? nodes : [schema.text(text, [...baseMarks])];
+};
+
 export const applyFolioAIEditOperations = ({
   view,
   snapshot,
@@ -432,11 +473,34 @@ export const applyFolioAIEditOperations = ({
               item.operation.styleId !== undefined ? { styleId: item.operation.styleId } : null;
             const node = paragraphType.create(
               replaceAttrs,
-              replacement.length === 0 ? null : view.state.schema.text(replacement),
+              replacement.length === 0
+                ? null
+                : buildEmphasisInlineContent(view.state.schema, replacement, []),
             );
             tr = tr.replaceWith(item.blockFrom, item.blockTo, node);
             break;
           }
+        }
+        // Direct mode, formatting preserved (the default): when the replacement
+        // carries inline emphasis, rebuild the block node keeping its own attrs
+        // so `**bold**` becomes real marks. The tracked-changes path can't carry
+        // inline marks through its word-diff redline, so it still strips them;
+        // plain replacements fall through to the text-only swap below unchanged.
+        if (mode === "direct" && hasInlineEmphasis(item.operation.text)) {
+          const attrs: Record<string, unknown> =
+            item.operation.styleId !== undefined
+              ? { ...item.blockNode.attrs, styleId: item.operation.styleId }
+              : { ...item.blockNode.attrs };
+          const node = item.blockNode.type.create(
+            attrs,
+            buildEmphasisInlineContent(
+              view.state.schema,
+              item.operation.text,
+              commentMark ? [commentMark] : [],
+            ),
+          );
+          tr = tr.replaceWith(item.blockFrom, item.blockTo, node);
+          break;
         }
         tr = applyTextReplacement({
           tr,
@@ -485,7 +549,7 @@ export const applyFolioAIEditOperations = ({
         }
         const content =
           item.insertText && item.insertText.length > 0
-            ? view.state.schema.text(item.insertText, marks)
+            ? buildEmphasisInlineContent(view.state.schema, item.insertText, marks)
             : null;
         // Inherit formatting attrs (listMarker, styleId, …) from
         // the source block but never reuse identity attrs — a new
@@ -646,15 +710,17 @@ const applyTextReplacement = ({
   commentMark,
 }: TextReplacementOptions): Transaction => {
   let nextTr = tr;
-  const replacement = (() => {
-    if (item.operation.type === "replaceInBlock") {
-      return item.operation.replace;
-    }
-    if (item.operation.type === "replaceBlock") {
-      return item.operation.text;
-    }
-    return "";
-  })();
+  const replacement = stripInlineEmphasisMarkers(
+    (() => {
+      if (item.operation.type === "replaceInBlock") {
+        return item.operation.replace;
+      }
+      if (item.operation.type === "replaceBlock") {
+        return item.operation.text;
+      }
+      return "";
+    })(),
+  );
 
   if (mode === "direct") {
     nextTr = nextTr.insertText(replacement, item.from, item.to);

--- a/packages/core/src/ai-edits/inline-emphasis.test.ts
+++ b/packages/core/src/ai-edits/inline-emphasis.test.ts
@@ -1,0 +1,108 @@
+// The chat edit tool has no inline run-format channel, so the model improvises
+// bold with markdown. These tests pin the conservative parse that promotes
+// `**bold**` / `***bold italic***` to runs while leaving ambiguous single
+// delimiters (math, identifiers) and plain prose untouched.
+
+import { describe, expect, test } from "bun:test";
+
+import { parseInlineEmphasisRuns, stripInlineEmphasisMarkers } from "./inline-emphasis";
+
+describe("parseInlineEmphasisRuns", () => {
+  test("promotes a bold span and keeps surrounding literals", () => {
+    expect(parseInlineEmphasisRuns("**Date:** 2026-06-30")).toEqual([
+      { text: "Date:", bold: true, italic: false },
+      { text: " 2026-06-30", bold: false, italic: false },
+    ]);
+  });
+
+  test("handles a bold span mid-sentence", () => {
+    expect(parseInlineEmphasisRuns("(1) **Disclosing Party Name**, with office")).toEqual([
+      { text: "(1) ", bold: false, italic: false },
+      { text: "Disclosing Party Name", bold: true, italic: false },
+      { text: ", with office", bold: false, italic: false },
+    ]);
+  });
+
+  test("triple markers are bold and italic", () => {
+    expect(parseInlineEmphasisRuns("***Term***")).toEqual([
+      { text: "Term", bold: true, italic: true },
+    ]);
+  });
+
+  test("underscore placeholders stay literal (not emphasis)", () => {
+    expect(parseInlineEmphasisRuns("__Borrower__ and ___EffectiveDate___")).toEqual([
+      {
+        text: "__Borrower__ and ___EffectiveDate___",
+        bold: false,
+        italic: false,
+      },
+    ]);
+  });
+
+  test("two bold spans in one line", () => {
+    expect(parseInlineEmphasisRuns("**a** and **b**")).toEqual([
+      { text: "a", bold: true, italic: false },
+      { text: " and ", bold: false, italic: false },
+      { text: "b", bold: true, italic: false },
+    ]);
+  });
+
+  test("plain prose stays a single literal run", () => {
+    expect(parseInlineEmphasisRuns("Date: {{date}}")).toEqual([
+      { text: "Date: {{date}}", bold: false, italic: false },
+    ]);
+  });
+
+  test("single asterisks are left literal (not italic)", () => {
+    expect(parseInlineEmphasisRuns("quantity 5*3*2 units")).toEqual([
+      { text: "quantity 5*3*2 units", bold: false, italic: false },
+    ]);
+  });
+
+  test("unbalanced markers stay literal", () => {
+    expect(parseInlineEmphasisRuns("see **infra")).toEqual([
+      { text: "see **infra", bold: false, italic: false },
+    ]);
+  });
+
+  test("space-flanked markers are not a span", () => {
+    expect(parseInlineEmphasisRuns("a ** b ** c")).toEqual([
+      { text: "a ** b ** c", bold: false, italic: false },
+    ]);
+  });
+
+  test("backslashes are ordinary characters (no markdown escapes)", () => {
+    expect(parseInlineEmphasisRuns("price \\*per unit\\*")).toEqual([
+      { text: "price \\*per unit\\*", bold: false, italic: false },
+    ]);
+  });
+
+  test("a backslash path survives next to a bold span", () => {
+    expect(parseInlineEmphasisRuns("**Note:** path C:\\*.txt")).toEqual([
+      { text: "Note:", bold: true, italic: false },
+      { text: " path C:\\*.txt", bold: false, italic: false },
+    ]);
+  });
+});
+
+describe("stripInlineEmphasisMarkers", () => {
+  test("drops markers from a bold span", () => {
+    expect(stripInlineEmphasisMarkers("**Date:** 2026")).toBe("Date: 2026");
+  });
+
+  test("keeps a backslash path when stripping an adjacent bold span", () => {
+    expect(stripInlineEmphasisMarkers("**Note:** path C:\\*.txt")).toBe("Note: path C:\\*.txt");
+  });
+
+  test("returns plain prose verbatim", () => {
+    for (const input of [
+      "Date: {{date}}",
+      "quantity 5*3*2 units",
+      "path C:\\*.txt",
+      "see **infra",
+      "__Borrower__ pays ___EffectiveDate___",
+    ]) {
+      expect(stripInlineEmphasisMarkers(input)).toBe(input);
+    }
+  });
+});

--- a/packages/core/src/ai-edits/inline-emphasis.ts
+++ b/packages/core/src/ai-edits/inline-emphasis.ts
@@ -1,0 +1,113 @@
+/**
+ * Turn the bold / bold-italic markdown the chat model sometimes emits inside
+ * inserted or replaced block text ("**Date:**", "***Term***") into structured
+ * runs the editor renders as real Word formatting.
+ *
+ * The active-docx-edit tool gives the model no inline run-formatting channel —
+ * only paragraph-level `styleId`. When the model wants a bold label or party
+ * name mid-sentence it improvises with markdown, and because DOCX has no notion
+ * of markdown those markers otherwise reach the document as literal asterisks.
+ *
+ * Deliberately conservative: only paired `**bold**` and `***bold italic***`
+ * asterisk markers with non-space inner content count as emphasis. Underscores
+ * are always literal — `__Borrower__` / snake_case placeholders are common in
+ * legal templates, and a lone `*` is far more likely a multiplication sign than
+ * a delimiter. Nesting is not interpreted; inner content is taken verbatim.
+ * Backslashes are ordinary characters (no markdown escapes), so Windows paths
+ * and regex survive intact.
+ */
+
+export type InlineEmphasisRun = {
+  text: string;
+  bold: boolean;
+  italic: boolean;
+};
+
+const MARKERS: readonly { marker: string; bold: boolean; italic: boolean }[] = [
+  { marker: "***", bold: true, italic: true },
+  { marker: "**", bold: true, italic: false },
+];
+
+const isSpace = (ch: string | undefined): boolean =>
+  ch === undefined || ch === " " || ch === "\t" || ch === "\n";
+
+const matchMarkerAt = (input: string, at: number): (typeof MARKERS)[number] | undefined =>
+  MARKERS.find((m) => input.startsWith(m.marker, at));
+
+const appendLiteral = (runs: InlineEmphasisRun[], text: string): void => {
+  if (text.length === 0) {
+    return;
+  }
+  const last = runs.at(-1);
+  if (last && !last.bold && !last.italic) {
+    last.text += text;
+    return;
+  }
+  runs.push({ text, bold: false, italic: false });
+};
+
+export const parseInlineEmphasisRuns = (input: string): InlineEmphasisRun[] => {
+  const runs: InlineEmphasisRun[] = [];
+  let buffer = "";
+  let i = 0;
+
+  const flushBuffer = () => {
+    appendLiteral(runs, buffer);
+    buffer = "";
+  };
+
+  while (i < input.length) {
+    const ch = input[i];
+    const matched = matchMarkerAt(input, i);
+    if (!matched) {
+      buffer += ch;
+      i += 1;
+      continue;
+    }
+
+    const contentStart = i + matched.marker.length;
+    const closeIdx = input.indexOf(matched.marker, contentStart);
+    const content = closeIdx === -1 ? "" : input.slice(contentStart, closeIdx);
+    const isSpan =
+      closeIdx !== -1 && content.length > 0 && !isSpace(content[0]) && !isSpace(content.at(-1));
+
+    if (!isSpan) {
+      // Not a real span (no close, or space-flanked): emit the marker's first
+      // char as literal and retry from the next position so a `**` inside a
+      // dangling `***` can still pair as bold.
+      buffer += ch;
+      i += 1;
+      continue;
+    }
+
+    flushBuffer();
+    runs.push({ text: content, bold: matched.bold, italic: matched.italic });
+    i = closeIdx + matched.marker.length;
+  }
+
+  flushBuffer();
+  return runs;
+};
+
+const hasEmphasis = (runs: readonly InlineEmphasisRun[]): boolean =>
+  runs.some((run) => run.bold || run.italic);
+
+/** True when `input` contains at least one bold / italic span worth promoting
+ *  to real marks; lets callers skip the run rebuild for plain text. */
+export const hasInlineEmphasis = (input: string): boolean =>
+  hasEmphasis(parseInlineEmphasisRuns(input));
+
+/**
+ * Drop emphasis markers without reconstructing formatting. Used on the
+ * tracked-changes replace path, where the word-diff redline cannot carry inline
+ * marks; stripping at least keeps literal `**` out of the document. Returns the
+ * input verbatim when no real span is present, so plain prose (and stray
+ * single `*` / escaped `\*`) is never reshaped.
+ */
+export const stripInlineEmphasisMarkers = (input: string): string => {
+  const runs = parseInlineEmphasisRuns(input);
+  if (!hasEmphasis(runs)) {
+    return input;
+  }
+  return runs.map((run) => run.text).join("");
+};

--- a/packages/core/src/docx/__tests__/roundtrip.property.test.ts
+++ b/packages/core/src/docx/__tests__/roundtrip.property.test.ts
@@ -315,17 +315,21 @@ describe("DOCX round-trip property tests", () => {
     propertyTestTimeout(15_000),
   );
 
-  test("round-trip preserves document structure", () => {
-    fc.assert(
-      fc.property(arbDocument(), (doc) => {
-        const result = roundTrip(doc);
-        const originalNorm = normalizeDoc(doc);
-        const resultNorm = normalizeDoc(result);
-        expect(resultNorm).toEqual(originalNorm);
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
+  test(
+    "round-trip preserves document structure",
+    () => {
+      fc.assert(
+        fc.property(arbDocument(), (doc) => {
+          const result = roundTrip(doc);
+          const originalNorm = normalizeDoc(doc);
+          const resultNorm = normalizeDoc(result);
+          expect(resultNorm).toEqual(originalNorm);
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
 
   test(
     "round-trip preserves text content exactly",
@@ -344,223 +348,263 @@ describe("DOCX round-trip property tests", () => {
     propertyTestTimeout(15_000),
   );
 
-  test("round-trip preserves bold marks", () => {
-    // Targeted test: paragraphs with bold text
-    const boldDoc = fc.array(safeText, { minLength: 1, maxLength: 5 }).map((texts) => {
-      const nodes = texts.map((t) => schema.text(t, [schema.marks.bold.create()]));
-      return schema.nodes.doc.create(null, [schema.nodes.paragraph.create(null, nodes)]);
-    });
+  test(
+    "round-trip preserves bold marks",
+    () => {
+      // Targeted test: paragraphs with bold text
+      const boldDoc = fc.array(safeText, { minLength: 1, maxLength: 5 }).map((texts) => {
+        const nodes = texts.map((t) => schema.text(t, [schema.marks.bold.create()]));
+        return schema.nodes.doc.create(null, [schema.nodes.paragraph.create(null, nodes)]);
+      });
 
-    fc.assert(
-      fc.property(boldDoc, (doc) => {
-        const result = roundTrip(doc);
-        // Every text node should still be bold
-        result.forEach((node) => {
-          if (node.type.name === "paragraph") {
-            node.forEach((child) => {
-              if (child.isText && child.text?.trim()) {
-                const hasBold = child.marks.some((m) => m.type.name === "bold");
-                expect(hasBold).toBe(true);
-              }
-            });
-          }
-        });
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
+      fc.assert(
+        fc.property(boldDoc, (doc) => {
+          const result = roundTrip(doc);
+          // Every text node should still be bold
+          result.forEach((node) => {
+            if (node.type.name === "paragraph") {
+              node.forEach((child) => {
+                if (child.isText && child.text?.trim()) {
+                  const hasBold = child.marks.some((m) => m.type.name === "bold");
+                  expect(hasBold).toBe(true);
+                }
+              });
+            }
+          });
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
 
-  test("round-trip preserves italic marks", () => {
-    const italicDoc = fc.array(safeText, { minLength: 1, maxLength: 5 }).map((texts) => {
-      const nodes = texts.map((t) => schema.text(t, [schema.marks.italic.create()]));
-      return schema.nodes.doc.create(null, [schema.nodes.paragraph.create(null, nodes)]);
-    });
+  test(
+    "round-trip preserves italic marks",
+    () => {
+      const italicDoc = fc.array(safeText, { minLength: 1, maxLength: 5 }).map((texts) => {
+        const nodes = texts.map((t) => schema.text(t, [schema.marks.italic.create()]));
+        return schema.nodes.doc.create(null, [schema.nodes.paragraph.create(null, nodes)]);
+      });
 
-    fc.assert(
-      fc.property(italicDoc, (doc) => {
-        const result = roundTrip(doc);
-        result.forEach((node) => {
-          if (node.type.name === "paragraph") {
-            node.forEach((child) => {
-              if (child.isText && child.text?.trim()) {
-                const hasItalic = child.marks.some((m) => m.type.name === "italic");
-                expect(hasItalic).toBe(true);
-              }
-            });
-          }
-        });
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
+      fc.assert(
+        fc.property(italicDoc, (doc) => {
+          const result = roundTrip(doc);
+          result.forEach((node) => {
+            if (node.type.name === "paragraph") {
+              node.forEach((child) => {
+                if (child.isText && child.text?.trim()) {
+                  const hasItalic = child.marks.some((m) => m.type.name === "italic");
+                  expect(hasItalic).toBe(true);
+                }
+              });
+            }
+          });
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
 
-  test("empty paragraphs survive round-trip", () => {
-    const emptyParaDoc = fc.integer({ min: 1, max: 10 }).map((count) =>
-      schema.nodes.doc.create(
-        null,
-        Array.from({ length: count }, () => schema.nodes.paragraph.create()),
-      ),
-    );
-
-    fc.assert(
-      fc.property(emptyParaDoc, (doc) => {
-        const result = roundTrip(doc);
-        expect(result.childCount).toBe(doc.childCount);
-      }),
-      propertyConfig({ numRuns: 100 }),
-    );
-  });
-
-  test("alignment attribute survives round-trip", () => {
-    const alignedDoc = fc
-      .tuple(safeText, fc.constantFrom("left", "center", "right", "both"))
-      .map(([text, alignment]) =>
-        schema.nodes.doc.create(null, [
-          schema.nodes.paragraph.create({ alignment }, [schema.text(text)]),
-        ]),
+  test(
+    "empty paragraphs survive round-trip",
+    () => {
+      const emptyParaDoc = fc.integer({ min: 1, max: 10 }).map((count) =>
+        schema.nodes.doc.create(
+          null,
+          Array.from({ length: count }, () => schema.nodes.paragraph.create()),
+        ),
       );
 
-    fc.assert(
-      fc.property(alignedDoc, (doc) => {
-        const result = roundTrip(doc);
-        const originalAlign = doc.firstChild?.attrs.alignment;
-        const resultAlign = result.firstChild?.attrs.alignment;
-        expect(resultAlign).toBe(originalAlign);
-      }),
-      propertyConfig({ numRuns: 100 }),
-    );
-  });
-
-  test("tables survive round-trip", () => {
-    const tableDoc = arbTable().map((table) => schema.nodes.doc.create(null, [table]));
-
-    fc.assert(
-      fc.property(tableDoc, (doc) => {
-        const result = roundTrip(doc);
-        // The document should contain a table
-        let hasTable = false;
-        result.forEach((node) => {
-          if (node.type.name === "table") {
-            hasTable = true;
-          }
-        });
-        expect(hasTable).toBe(true);
-      }),
-      propertyConfig({ numRuns: 100 }),
-    );
-  });
-
-  test("table text content preserved through round-trip", () => {
-    const tableDoc = arbTable().map((table) => schema.nodes.doc.create(null, [table]));
-
-    fc.assert(
-      fc.property(tableDoc, (doc) => {
-        const result = roundTrip(doc);
-        expect(result.textContent).toBe(doc.textContent);
-      }),
-      propertyConfig({ numRuns: 100 }),
-    );
-  });
-
-  test("documents with mixed paragraphs and tables round-trip", () => {
-    fc.assert(
-      fc.property(arbDocument(), (doc) => {
-        const result = roundTrip(doc);
-        expect(result.textContent).toBe(doc.textContent);
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
-
-  test("tracked change marks survive round-trip", () => {
-    fc.assert(
-      fc.property(arbTrackedChangeDocument(), (doc) => {
-        const result = roundTrip(doc);
-        // Count tracked change marks in original
-        let originalChanges = 0;
-        doc.descendants((node) => {
-          if (node.isText) {
-            for (const mark of node.marks) {
-              if (mark.type.name === "insertion" || mark.type.name === "deletion") {
-                originalChanges++;
-              }
-            }
-          }
-        });
-
-        // Count tracked change marks in result
-        let resultChanges = 0;
-        result.descendants((node) => {
-          if (node.isText) {
-            for (const mark of node.marks) {
-              if (mark.type.name === "insertion" || mark.type.name === "deletion") {
-                resultChanges++;
-              }
-            }
-          }
-        });
-
-        // Same number of tracked changes
-        expect(resultChanges).toBe(originalChanges);
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
-
-  test("tracked change author preserved through round-trip", () => {
-    fc.assert(
-      fc.property(arbTrackedChangeDocument(), (doc) => {
-        const result = roundTrip(doc);
-
-        // Collect all authors from original
-        const originalAuthors: string[] = [];
-        doc.descendants((node) => {
-          if (node.isText) {
-            for (const mark of node.marks) {
-              if (mark.type.name === "insertion" || mark.type.name === "deletion") {
-                originalAuthors.push(mark.attrs.author as string);
-              }
-            }
-          }
-        });
-
-        // Collect all authors from result
-        const resultAuthors: string[] = [];
-        result.descendants((node) => {
-          if (node.isText) {
-            for (const mark of node.marks) {
-              if (mark.type.name === "insertion" || mark.type.name === "deletion") {
-                resultAuthors.push(mark.attrs.author as string);
-              }
-            }
-          }
-        });
-
-        expect(resultAuthors).toEqual(originalAuthors);
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
-
-  test("multiple mark combinations survive round-trip", () => {
-    // Generate text with 2-3 marks simultaneously
-    const multiMarkDoc = fc
-      .tuple(safeText, arbMarks())
-      .filter(([, marks]) => marks.length >= 2)
-      .map(([text, marks]) =>
-        schema.nodes.doc.create(null, [
-          schema.nodes.paragraph.create(null, [schema.text(text, marks)]),
-        ]),
+      fc.assert(
+        fc.property(emptyParaDoc, (doc) => {
+          const result = roundTrip(doc);
+          expect(result.childCount).toBe(doc.childCount);
+        }),
+        propertyConfig({ numRuns: 100 }),
       );
+    },
+    propertyTestTimeout(10_000),
+  );
 
-    fc.assert(
-      fc.property(multiMarkDoc, (doc) => {
-        const result = roundTrip(doc);
-        const originalNorm = normalizeDoc(doc);
-        const resultNorm = normalizeDoc(result);
-        expect(resultNorm).toEqual(originalNorm);
-      }),
-      propertyConfig({ numRuns: 200 }),
-    );
-  });
+  test(
+    "alignment attribute survives round-trip",
+    () => {
+      const alignedDoc = fc
+        .tuple(safeText, fc.constantFrom("left", "center", "right", "both"))
+        .map(([text, alignment]) =>
+          schema.nodes.doc.create(null, [
+            schema.nodes.paragraph.create({ alignment }, [schema.text(text)]),
+          ]),
+        );
+
+      fc.assert(
+        fc.property(alignedDoc, (doc) => {
+          const result = roundTrip(doc);
+          const originalAlign = doc.firstChild?.attrs.alignment;
+          const resultAlign = result.firstChild?.attrs.alignment;
+          expect(resultAlign).toBe(originalAlign);
+        }),
+        propertyConfig({ numRuns: 100 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
+
+  test(
+    "tables survive round-trip",
+    () => {
+      const tableDoc = arbTable().map((table) => schema.nodes.doc.create(null, [table]));
+
+      fc.assert(
+        fc.property(tableDoc, (doc) => {
+          const result = roundTrip(doc);
+          // The document should contain a table
+          let hasTable = false;
+          result.forEach((node) => {
+            if (node.type.name === "table") {
+              hasTable = true;
+            }
+          });
+          expect(hasTable).toBe(true);
+        }),
+        propertyConfig({ numRuns: 100 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
+
+  test(
+    "table text content preserved through round-trip",
+    () => {
+      const tableDoc = arbTable().map((table) => schema.nodes.doc.create(null, [table]));
+
+      fc.assert(
+        fc.property(tableDoc, (doc) => {
+          const result = roundTrip(doc);
+          expect(result.textContent).toBe(doc.textContent);
+        }),
+        propertyConfig({ numRuns: 100 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
+
+  test(
+    "documents with mixed paragraphs and tables round-trip",
+    () => {
+      fc.assert(
+        fc.property(arbDocument(), (doc) => {
+          const result = roundTrip(doc);
+          expect(result.textContent).toBe(doc.textContent);
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
+
+  test(
+    "tracked change marks survive round-trip",
+    () => {
+      fc.assert(
+        fc.property(arbTrackedChangeDocument(), (doc) => {
+          const result = roundTrip(doc);
+          // Count tracked change marks in original
+          let originalChanges = 0;
+          doc.descendants((node) => {
+            if (node.isText) {
+              for (const mark of node.marks) {
+                if (mark.type.name === "insertion" || mark.type.name === "deletion") {
+                  originalChanges++;
+                }
+              }
+            }
+          });
+
+          // Count tracked change marks in result
+          let resultChanges = 0;
+          result.descendants((node) => {
+            if (node.isText) {
+              for (const mark of node.marks) {
+                if (mark.type.name === "insertion" || mark.type.name === "deletion") {
+                  resultChanges++;
+                }
+              }
+            }
+          });
+
+          // Same number of tracked changes
+          expect(resultChanges).toBe(originalChanges);
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
+
+  test(
+    "tracked change author preserved through round-trip",
+    () => {
+      fc.assert(
+        fc.property(arbTrackedChangeDocument(), (doc) => {
+          const result = roundTrip(doc);
+
+          // Collect all authors from original
+          const originalAuthors: string[] = [];
+          doc.descendants((node) => {
+            if (node.isText) {
+              for (const mark of node.marks) {
+                if (mark.type.name === "insertion" || mark.type.name === "deletion") {
+                  originalAuthors.push(mark.attrs.author as string);
+                }
+              }
+            }
+          });
+
+          // Collect all authors from result
+          const resultAuthors: string[] = [];
+          result.descendants((node) => {
+            if (node.isText) {
+              for (const mark of node.marks) {
+                if (mark.type.name === "insertion" || mark.type.name === "deletion") {
+                  resultAuthors.push(mark.attrs.author as string);
+                }
+              }
+            }
+          });
+
+          expect(resultAuthors).toEqual(originalAuthors);
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
+
+  test(
+    "multiple mark combinations survive round-trip",
+    () => {
+      // Generate text with 2-3 marks simultaneously
+      const multiMarkDoc = fc
+        .tuple(safeText, arbMarks())
+        .filter(([, marks]) => marks.length >= 2)
+        .map(([text, marks]) =>
+          schema.nodes.doc.create(null, [
+            schema.nodes.paragraph.create(null, [schema.text(text, marks)]),
+          ]),
+        );
+
+      fc.assert(
+        fc.property(multiMarkDoc, (doc) => {
+          const result = roundTrip(doc);
+          const originalNorm = normalizeDoc(doc);
+          const resultNorm = normalizeDoc(result);
+          expect(resultNorm).toEqual(originalNorm);
+        }),
+        propertyConfig({ numRuns: 200 }),
+      );
+    },
+    propertyTestTimeout(10_000),
+  );
 });

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -126,26 +126,29 @@ export function InlineHeaderFooterEditor({
     };
   }, [targetElement, parentElement]);
 
-  // Focus the persistent HF PM when the chrome mounts so typing starts
-  // immediately after double-click. The HF view may not exist yet at
-  // mount: HiddenHeaderFooterPMs creates views inside a useEffect, and
-  // for freshly-created HF parts (empty header on a doc that had none),
-  // the chrome and the view-creation effect can land in either order.
-  // Retry across a short rAF window so focus lands as soon as the view
-  // is available; bail after MAX_FOCUS_ATTEMPTS frames to avoid leaking
-  // a rAF loop in pathological cases.
+  // Latest getActiveView, read through a ref so the focus loop below is never
+  // stuck on a stale mount-time closure if the active HF view resolves later.
+  const getActiveViewRef = useRef(getActiveView);
+  getActiveViewRef.current = getActiveView;
+
+  // Move focus into the persistent HF view when the chrome mounts so typing
+  // starts immediately after double-click. A single focus() is unreliable: the
+  // HF view may not exist yet at mount (HiddenHeaderFooterPMs creates views in
+  // its own effect), AND entering edit mode triggers a relayout/repaint that
+  // re-grabs focus for the body PM — so a one-shot focus() gets stolen back and
+  // typing lands in the body. Keep nudging focus into the HF view across a short
+  // rAF window until it actually holds focus (or the window ends).
   useEffect(() => {
-    const MAX_FOCUS_ATTEMPTS = 10;
+    const MAX_FOCUS_ATTEMPTS = 30;
     let attempts = 0;
     let rafId: number | null = null;
     const tryFocus = () => {
-      const view = getActiveView();
-      if (view) {
+      const view = getActiveViewRef.current();
+      if (view && !view.hasFocus()) {
         view.focus();
-        return;
       }
       attempts++;
-      if (attempts < MAX_FOCUS_ATTEMPTS) {
+      if (attempts < MAX_FOCUS_ATTEMPTS && !view?.hasFocus()) {
         rafId = requestAnimationFrame(tryFocus);
       }
     };
@@ -155,7 +158,7 @@ export function InlineHeaderFooterEditor({
         cancelAnimationFrame(rafId);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- getActiveView is a closure over parent state; focus must fire only on mount, not re-steal focus on every parent re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- focus must fire only on mount; the view is read through a ref to avoid a stale closure
   }, []);
 
   const handleClose = useCallback(() => {

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -148,7 +148,11 @@ export function InlineHeaderFooterEditor({
         view.focus();
       }
       attempts++;
-      if (attempts < MAX_FOCUS_ATTEMPTS && !view?.hasFocus()) {
+      // Keep watching for the whole window, not just until the first successful
+      // focus: entering edit mode triggers a relayout/repaint that can clear or
+      // steal focus *after* it first lands, so re-focus on any frame where the
+      // HF view has lost it.
+      if (attempts < MAX_FOCUS_ATTEMPTS) {
         rafId = requestAnimationFrame(tryFocus);
       }
     };

--- a/packages/react/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/react/src/components/hooks/useHeaderFooterEditor.ts
@@ -9,7 +9,7 @@
  * `pushDocument` routing, and reading the live hidden HF PM doc at save time.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import type { EditorView } from "prosemirror-view";
 
@@ -109,10 +109,21 @@ export const useHeaderFooterEditor = ({
   // Resolved header/footer content
   // -------------------------------------------------------------------------
 
-  const resolution = useMemo(
+  const rawResolution = useMemo(
     () => resolveHeaderFooterContent(history.state?.package),
     [history.state],
   );
+  // `history.state` is transiently null while the document buffer is parsed and
+  // during relayout. Falling through to the empty resolution on those renders
+  // blanks the active H/F rIds, which breaks edit focus (getActiveView returns
+  // null, so typing lands in the body) and flickers the rendered chrome. Hold
+  // the last resolved structure and reuse it until a real document state
+  // arrives again.
+  const lastResolution = useRef(rawResolution);
+  if (history.state?.package) {
+    lastResolution.current = rawResolution;
+  }
+  const resolution = history.state?.package ? rawResolution : lastResolution.current;
   const {
     headerContent,
     footerContent,

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -294,6 +294,62 @@ test.describe("header/footer", () => {
     expect(await savedHeaderText(page)).toContain("HdrMark");
   });
 
+  test("double-clicking an image-only header still routes edits into the header", async ({
+    page,
+  }) => {
+    await mountFixture(page, "podily-bps.docx");
+
+    const header = page.locator(".layout-page-header").first();
+    await header.scrollIntoViewIfNeeded();
+
+    // This first-page header holds only a floating logo image plus an empty
+    // paragraph — there is no body-flow text under the cursor. A double-click in
+    // the header band must still enter header edit mode AND land the caret in the
+    // header content editor, rather than falling through to the body (the nearest
+    // editable text). Regression guard for the title-page / image-only header.
+    await header.dblclick();
+    await page.locator(".hf-inline-editor").waitFor({ state: "visible", timeout: 5000 });
+
+    // Pause before typing: a real user does not type instantly, so focus must
+    // stay in the header view past the brief entry-focus window, not snap back
+    // to the body once the window elapses.
+    await page.waitForTimeout(1200);
+    await page.keyboard.type("HdrMark", { delay: 15 });
+    await page.waitForTimeout(150);
+
+    const result = await page.evaluate(() => {
+      const top = (
+        globalThis as unknown as {
+          __folioPlayground: {
+            getEditorRef: () => {
+              getDocument?: () => { package?: { headers?: unknown } };
+              getEditorRef: () => {
+                getView?: () => { state: { doc: { textContent: string } } } | null;
+              };
+            };
+          };
+        }
+      ).__folioPlayground.getEditorRef();
+      const headers = top.getDocument?.()?.package?.headers;
+      const modelJson = JSON.stringify(
+        headers instanceof Map ? [...headers.values()] : (headers ?? {}),
+      );
+      return {
+        painted:
+          document.querySelector('[data-page-number="1"] .layout-page-header')?.textContent ?? "",
+        modelHasEdit: modelJson.includes("HdrMark"),
+        body: top.getEditorRef().getView?.()?.state.doc.textContent ?? "",
+      };
+    });
+
+    // The edit is visible in the painted header (the user sees what they type)...
+    expect(result.painted).toContain("HdrMark");
+    // ...is persisted into the saved document model (survives save)...
+    expect(result.modelHasEdit).toBe(true);
+    // ...and never leaks into the body (the nearest editable text).
+    expect(result.body).not.toContain("HdrMark");
+  });
+
   // NOTE: the *UI* save-on-body-click / save-on-exit commit path is not driven
   // here. While the inline header overlay is open the painted body paragraph is
   // not hittable, so a synthetic body click times out (a Playwright limitation,


### PR DESCRIPTION
AI edit output uses **bold** / ***bold italic*** markdown (the edit tool has no inline-format channel); this promotes those markers into real Word bold/italic runs on insert/replace and strips them on the tracked-changes word-diff path, so they no longer land as literal asterisks. Also bundles explicit per-test timeouts for the docx round-trip property tests so the scaled nightly sweep can't time out. Stacked on the header-editing fix branch.