### PR TITLE
feat(react): restore opt-in zoom control + wheel/pinch zoom

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -11,14 +11,7 @@ import {
 } from "@stll/folio-react";
 import type { Document as FolioDocument, DocxEditorRef, EditorMode } from "@stll/folio-react";
 
-const ZOOM_MIN = 0.25;
-const ZOOM_MAX = 2;
-const ZOOM_STEP = 0.1;
 const ZOOM_INITIAL = 1;
-
-function clampZoom(zoom: number): number {
-  return Math.min(Math.max(zoom, ZOOM_MIN), ZOOM_MAX);
-}
 
 declare global {
   // Test hook: visual + interaction specs read live editor state through this.
@@ -72,7 +65,6 @@ export function App() {
   const [fileName, setFileName] = useState("Untitled.docx");
   const [status, setStatus] = useState("");
   const [editorMode, setEditorMode] = useState<EditorMode>("editing");
-  const [zoom, setZoom] = useState(ZOOM_INITIAL);
 
   // Load fixture from ?file= query param (visual + interaction tests) or
   // generate a body from ?paragraphs= (performance tests).
@@ -176,15 +168,6 @@ export function App() {
   const handleError = useCallback((error: Error) => {
     setStatus(`Error: ${error.message}`);
   }, []);
-
-  const applyZoom = useCallback((next: number) => {
-    const clamped = clampZoom(next);
-    setZoom(clamped);
-    editorRef.current?.setZoom(clamped);
-  }, []);
-  const handleZoomIn = useCallback(() => applyZoom(zoom + ZOOM_STEP), [applyZoom, zoom]);
-  const handleZoomOut = useCallback(() => applyZoom(zoom - ZOOM_STEP), [applyZoom, zoom]);
-  const handleZoomReset = useCallback(() => applyZoom(ZOOM_INITIAL), [applyZoom]);
 
   const handleInsertImage = useCallback(() => {
     const view = editorRef.current?.getEditorRef()?.getView();
@@ -297,37 +280,6 @@ export function App() {
         </button>
         <button type="button" className="pg-button" onClick={() => void handleSave()}>
           Save
-        </button>
-
-        <span className="pg-sep" aria-hidden="true" />
-
-        <button
-          type="button"
-          className="pg-button"
-          onClick={handleZoomOut}
-          disabled={zoom <= ZOOM_MIN}
-          aria-label="Zoom out"
-          title="Zoom out"
-        >
-          −
-        </button>
-        <button
-          type="button"
-          className="pg-button pg-zoom"
-          onClick={handleZoomReset}
-          title="Reset zoom"
-        >
-          {Math.round(zoom * 100)}%
-        </button>
-        <button
-          type="button"
-          className="pg-button"
-          onClick={handleZoomIn}
-          disabled={zoom >= ZOOM_MAX}
-          aria-label="Zoom in"
-          title="Zoom in"
-        >
-          +
         </button>
 
         <span className="pg-sep" aria-hidden="true" />

--- a/packages/playground/src/messages/en.json
+++ b/packages/playground/src/messages/en.json
@@ -349,6 +349,7 @@
     "unlockFile": "Unlock file",
     "unlockForEditing": "Unlock to edit",
     "unsupportedDocxEditDescription": "This DOCX contains structures Folio cannot safely rewrite. To avoid corrupting the file, download it and edit it in Word.",
-    "unsupportedDocxEditTitle": "Editing blocked"
+    "unsupportedDocxEditTitle": "Editing blocked",
+    "zoomGroup": "Zoom"
   }
 }

--- a/packages/playground/src/styles.css
+++ b/packages/playground/src/styles.css
@@ -175,12 +175,6 @@
   cursor: not-allowed;
 }
 
-.pg-zoom {
-  min-width: 3rem;
-  font-variant-numeric: tabular-nums;
-  text-align: center;
-}
-
 .pg-sep {
   width: 1px;
   height: 1.25rem;

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -118,6 +118,8 @@ export type DocxEditorProps = {
   marginGuideColor?: string;
   /** Initial zoom level (default: 1.0) */
   initialZoom?: number;
+  /** Whether Ctrl/Cmd+wheel and trackpad-pinch zoom are enabled (default: true) */
+  enableWheelZoom?: boolean;
   /** Whether the editor is read-only. When true, hides toolbar and rulers */
   readOnly?: boolean;
   /** Whether comments/tracked changes should auto-open the review sidebar (default: true) */

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -200,6 +200,7 @@ import { useHyperlinkHandlers } from "./hooks/useHyperlinkHandlers";
 import { useImageHandlers } from "./hooks/useImageHandlers";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useZoomAndPageInfo } from "./hooks/useZoomAndPageInfo";
+import { useWheelZoom } from "../hooks/useWheelZoom";
 import { InlineHeaderFooterEditor } from "./InlineHeaderFooterEditor";
 import type { InlineHeaderFooterEditorRef } from "./InlineHeaderFooterEditor";
 import { detectActiveTrackedChange, detectImageContext } from "./selectionDetection";
@@ -415,6 +416,7 @@ export function DocxEditor({
   showMarginGuides: _showMarginGuides = false,
   marginGuideColor: _marginGuideColor,
   initialZoom = 1,
+  enableWheelZoom = true,
   readOnly: readOnlyProp = false,
   autoOpenReviewSidebar = true,
   components,
@@ -862,6 +864,19 @@ export function DocxEditor({
       pagedEditorRef,
       initialZoom,
     });
+
+  // Ctrl/Cmd+wheel and trackpad-pinch zoom. Controlled by DocxEditor's
+  // viewport-anchored zoom (a single source of truth): the hook reads the live
+  // value and emits the next one through setZoomWithViewportAnchor, so it never
+  // diverges from the toolbar control or the imperative setZoom. Keyboard
+  // shortcuts stay off here to avoid clashing with the editor's own Ctrl chords.
+  useWheelZoom({
+    containerRef: scrollContainerRef,
+    enabled: enableWheelZoom,
+    getCurrentZoom: () => zoomRef.current,
+    onZoomChange: setZoomWithViewportAnchor,
+    enableKeyboardShortcuts: false,
+  });
   const [bodyHistoryAvailability, setBodyHistoryAvailability] = useState({
     canRedo: false,
     canUndo: false,

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -40,6 +40,7 @@ import { FontPicker } from "./ui/FontPicker";
 import { FontSizePicker } from "./ui/FontSizePicker";
 import { ListButtons, createDefaultListState } from "./ui/ListButtons";
 import { StylePicker } from "./ui/StylePicker";
+import { ZoomControl } from "./ui/ZoomControl";
 
 const ICON_SIZE = 16;
 const INLINE_SECONDARY_CONTROLS_MIN_WIDTH = 760;
@@ -101,6 +102,9 @@ export function FormattingBar(props: FormattingBarProps) {
     showTextColorPicker = true,
     showAlignmentButtons = true,
     showListButtons = true,
+    showZoomControl,
+    zoom,
+    onZoomChange,
     documentStyles,
     theme,
     onRefocusEditor,
@@ -691,8 +695,15 @@ export function FormattingBar(props: FormattingBarProps) {
         )}
       </div>
 
-      {/* Host extras (track changes, etc.) */}
-      <div className="ms-auto flex shrink-0 items-center gap-1">{children}</div>
+      {/* Host extras (zoom, track changes, etc.) */}
+      <div className="ms-auto flex shrink-0 items-center gap-1">
+        {showZoomControl !== false && zoom !== undefined && onZoomChange !== undefined && (
+          <ToolbarGroup label={t("zoomGroup")}>
+            <ZoomControl value={zoom} onChange={onZoomChange} disabled={disabled} compact />
+          </ToolbarGroup>
+        )}
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/react/src/components/ui/ZoomControl.tsx
+++ b/packages/react/src/components/ui/ZoomControl.tsx
@@ -1,0 +1,106 @@
+/**
+ * Zoom Control
+ *
+ * A compact dropdown for choosing the editor's document zoom level. Renders the
+ * injectable folio Select primitive (so a consumer's design-system Select can
+ * override it), mirroring FontSizePicker. Opt-in: folio chrome renders this only
+ * when both a zoom value and an onChange handler are supplied (see
+ * FormattingBar).
+ */
+
+import { useFolioUI } from "../../ui/folio-ui";
+import { cn } from "../../lib/utils";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type ZoomLevel = {
+  value: number;
+  label: string;
+};
+
+export type ZoomControlProps = {
+  /** Current zoom (1 = 100%). */
+  value?: number;
+  /** Called with the chosen zoom level. */
+  onChange?: (zoom: number) => void;
+  /** Override the preset levels offered in the dropdown. */
+  levels?: ZoomLevel[];
+  disabled?: boolean;
+  className?: string;
+  /** Render the trigger at the smaller toolbar-chrome size. */
+  compact?: boolean;
+};
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_ZOOM_LEVELS: ZoomLevel[] = [
+  { value: 0.5, label: "50%" },
+  { value: 0.75, label: "75%" },
+  { value: 1, label: "100%" },
+  { value: 1.25, label: "125%" },
+  { value: 1.5, label: "150%" },
+  { value: 2, label: "200%" },
+];
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+export function ZoomControl({
+  value = 1,
+  onChange,
+  levels = DEFAULT_ZOOM_LEVELS,
+  disabled = false,
+  className,
+  compact = false,
+}: ZoomControlProps) {
+  const {
+    Root: Select,
+    Trigger: SelectTrigger,
+    Value: SelectValue,
+    Popup: SelectPopup,
+    Item: SelectItem,
+  } = useFolioUI().Select;
+
+  const matchingLevel = levels.find((level) => Math.abs(level.value - value) < 0.001);
+  const displayLabel = matchingLevel ? matchingLevel.label : `${Math.round(value * 100)}%`;
+
+  return (
+    <Select
+      value={value.toString()}
+      onValueChange={(newValue) => {
+        if (typeof newValue !== "string") {
+          return;
+        }
+        const zoom = Number.parseFloat(newValue);
+        if (!Number.isNaN(zoom)) {
+          onChange?.(zoom);
+        }
+      }}
+      disabled={disabled}
+    >
+      <SelectTrigger
+        size="sm"
+        className={cn(
+          "min-h-0 min-w-0 border-transparent bg-transparent text-[var(--doc-text-muted)] tabular-nums shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]",
+          compact ? "text-xs" : "text-sm",
+          className,
+        )}
+        style={{ width: compact ? 55 : 70, height: compact ? 28 : 32 }}
+      >
+        <SelectValue placeholder="100%">{displayLabel}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup>
+        {levels.map((level) => (
+          <SelectItem key={level.value} value={level.value.toString()}>
+            {level.label}
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+}

--- a/packages/react/src/components/ui/ZoomControl.tsx
+++ b/packages/react/src/components/ui/ZoomControl.tsx
@@ -68,10 +68,13 @@ export function ZoomControl({
 
   const matchingLevel = levels.find((level) => Math.abs(level.value - value) < 0.001);
   const displayLabel = matchingLevel ? matchingLevel.label : `${Math.round(value * 100)}%`;
+  // Use the matched preset's exact string so the active item highlights even
+  // when `value` is a near-preset float (e.g. 0.9999 from continuous zoom).
+  const selectValue = matchingLevel ? matchingLevel.value.toString() : value.toString();
 
   return (
     <Select
-      value={value.toString()}
+      value={selectValue}
       onValueChange={(newValue) => {
         if (typeof newValue !== "string") {
           return;

--- a/packages/react/src/hooks/useWheelZoom.ts
+++ b/packages/react/src/hooks/useWheelZoom.ts
@@ -94,6 +94,13 @@ const DEFAULT_MAX_ZOOM = 4;
 const DEFAULT_ZOOM_STEP = 0.1;
 
 /**
+ * Per-event zoom sensitivity for Ctrl/Cmd+wheel and trackpad pinch. Multiplies
+ * deltaY inside an exponential so zoom scales continuously: small pinch deltas
+ * nudge gently while a coarse mouse-wheel notch still moves a perceptible amount.
+ */
+const WHEEL_ZOOM_SENSITIVITY = 0.003;
+
+/**
  * Preset zoom levels for snapping
  */
 export const ZOOM_PRESETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
@@ -207,7 +214,11 @@ export function useWheelZoom(options: UseWheelZoomOptions = {}): UseWheelZoomRet
         return;
       }
       // Controlled mode does not own state; the external owner re-renders us.
+      // Uncontrolled mode mirrors the new value into the ref synchronously (like
+      // DocxEditor's controlled path) so a fast second delta in the same tick
+      // composes from the fresh value, not the still-stale pre-render state.
       if (!getCurrentZoom) {
+        zoomRef.current = clampedZoom;
         setZoomState(clampedZoom);
       }
       onZoomChange?.(clampedZoom);
@@ -276,20 +287,17 @@ export function useWheelZoom(options: UseWheelZoomOptions = {}): UseWheelZoomRet
         event.preventDefault();
       }
 
-      // Determine zoom direction
-      // deltaY > 0 means scrolling down (zoom out)
-      // deltaY < 0 means scrolling up (zoom in)
+      // Scale by a continuous factor proportional to deltaY rather than a fixed
+      // step. Trackpad pinch arrives as a stream of small-deltaY ctrlKey wheel
+      // events; a discrete step per event would slam between min and max. The
+      // exponential keeps zoom multiplicative (symmetric in/out) and smooth for
+      // both pinch and discrete mouse-wheel notches. deltaY < 0 = zoom in.
       const delta = event.deltaY;
-
-      if (delta < 0) {
-        // Scroll up = zoom in
-        setZoom(readZoom() + zoomStep);
-      } else if (delta > 0) {
-        // Scroll down = zoom out
-        setZoom(readZoom() - zoomStep);
+      if (delta !== 0) {
+        setZoom(readZoom() * Math.exp(-delta * WHEEL_ZOOM_SENSITIVITY));
       }
     },
-    [enabled, preventDefault, zoomStep, setZoom, readZoom],
+    [enabled, preventDefault, setZoom, readZoom],
   );
 
   /**
@@ -330,11 +338,12 @@ export function useWheelZoom(options: UseWheelZoomOptions = {}): UseWheelZoomRet
     [enabled, enableKeyboardShortcuts, zoomIn, zoomOut, zoomTo100],
   );
 
-  // Attach wheel listener to container. Read `.current` in render scope so the
-  // effect re-runs when the container mounts on a later render (it starts null
-  // until the document loads), mirroring useZoomAndPageInfo's scroll listener.
-  const container = containerRef?.current ?? null;
+  // Attach wheel listener to container. Read `.current` inside the effect (it
+  // runs after the DOM is mutated, so the ref is populated by then); handleWheel
+  // is rebuilt on render, so the effect re-runs and picks up the container once
+  // it mounts on a later render (it starts null until the document loads).
   useEffect(() => {
+    const container = containerRef?.current;
     if (!enabled || !container) {
       return;
     }
@@ -345,7 +354,7 @@ export function useWheelZoom(options: UseWheelZoomOptions = {}): UseWheelZoomRet
     return () => {
       container.removeEventListener("wheel", handleWheel);
     };
-  }, [enabled, container, handleWheel]);
+  }, [enabled, containerRef, handleWheel]);
 
   // Attach keyboard listener
   useEffect(() => {

--- a/packages/react/src/hooks/useWheelZoom.ts
+++ b/packages/react/src/hooks/useWheelZoom.ts
@@ -1,0 +1,451 @@
+/**
+ * useWheelZoom Hook
+ *
+ * Enables Ctrl+scroll (or Cmd+scroll on Mac) to zoom in/out.
+ * Features:
+ * - Configurable zoom range and step
+ * - Smooth zoom transitions
+ * - Pinch-to-zoom support on trackpads (browsers report pinch as a
+ *   `ctrlKey` wheel event)
+ * - Zoom reset (Ctrl+0)
+ * - Zoom in/out shortcuts (Ctrl++, Ctrl+-)
+ *
+ * The hook is uncontrolled by default (owns its own zoom state). Pass
+ * `getCurrentZoom` to run it controlled: deltas then compose against an external
+ * zoom owner (e.g. DocxEditor's viewport-anchored zoom) and the hook only emits
+ * through `onZoomChange`, so the two never diverge.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/**
+ * Options for useWheelZoom hook
+ */
+export type UseWheelZoomOptions = {
+  /** Initial zoom level (default: 1.0) */
+  initialZoom?: number;
+  /** Minimum zoom level (default: 0.25) */
+  minZoom?: number;
+  /** Maximum zoom level (default: 4.0) */
+  maxZoom?: number;
+  /** Zoom step for each scroll event (default: 0.1) */
+  zoomStep?: number;
+  /** Whether zoom is enabled (default: true) */
+  enabled?: boolean;
+  /** Container element ref to attach wheel listener */
+  containerRef?: RefObject<HTMLElement | null>;
+  /**
+   * Live current zoom getter. When provided the hook runs controlled: it reads
+   * the current zoom from here (instead of its own state) when computing deltas
+   * and only emits the next value through `onZoomChange`. Lets the hook compose
+   * with an external zoom owner without a second, divergent source of truth.
+   */
+  getCurrentZoom?: () => number;
+  /** Callback when zoom changes */
+  onZoomChange?: (zoom: number) => void;
+  /** Whether to enable keyboard shortcuts (Ctrl++, Ctrl+-, Ctrl+0) */
+  enableKeyboardShortcuts?: boolean;
+  /** Whether to prevent default browser zoom behavior */
+  preventDefault?: boolean;
+};
+
+/**
+ * Return value of useWheelZoom hook
+ */
+export type UseWheelZoomReturn = {
+  /** Current zoom level */
+  zoom: number;
+  /** Set zoom level directly */
+  setZoom: (zoom: number) => void;
+  /** Zoom in by step */
+  zoomIn: () => void;
+  /** Zoom out by step */
+  zoomOut: () => void;
+  /** Reset zoom to initial level */
+  resetZoom: () => void;
+  /** Reset zoom to 100% */
+  zoomTo100: () => void;
+  /** Zoom to fit width */
+  zoomToFit: (containerWidth: number, contentWidth: number) => void;
+  /** Whether currently at minimum zoom */
+  isMinZoom: boolean;
+  /** Whether currently at maximum zoom */
+  isMaxZoom: boolean;
+  /** Zoom percentage (e.g., 100 for zoom level 1.0) */
+  zoomPercent: number;
+  /** Wheel event handler (for manual attachment) */
+  handleWheel: (event: WheelEvent) => void;
+  /** Keyboard event handler (for manual attachment) */
+  handleKeyDown: (event: KeyboardEvent) => void;
+};
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_INITIAL_ZOOM = 1;
+const DEFAULT_MIN_ZOOM = 0.25;
+const DEFAULT_MAX_ZOOM = 4;
+const DEFAULT_ZOOM_STEP = 0.1;
+
+/**
+ * Preset zoom levels for snapping
+ */
+export const ZOOM_PRESETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Clamp a value between min and max
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Round zoom to 2 decimal places
+ */
+function roundZoom(zoom: number): number {
+  return Math.round(zoom * 100) / 100;
+}
+
+/**
+ * Find nearest preset zoom level
+ */
+function nearestPreset(zoom: number): number {
+  // SAFETY: ZOOM_PRESETS is a non-empty constant array
+  let nearest = ZOOM_PRESETS[0]!;
+  let minDiff = Math.abs(zoom - nearest);
+
+  for (const preset of ZOOM_PRESETS) {
+    const diff = Math.abs(zoom - preset);
+    if (diff < minDiff) {
+      minDiff = diff;
+      nearest = preset;
+    }
+  }
+
+  return nearest;
+}
+
+/**
+ * Get next preset zoom level (for zoom in)
+ */
+function nextPreset(currentZoom: number): number {
+  for (const preset of ZOOM_PRESETS) {
+    if (preset > currentZoom + 0.01) {
+      return preset;
+    }
+  }
+  // oxlint-disable-next-line typescript/no-non-null-assertion
+  return ZOOM_PRESETS.at(-1)!;
+}
+
+/**
+ * Get previous preset zoom level (for zoom out)
+ */
+function prevPreset(currentZoom: number): number {
+  for (let i = ZOOM_PRESETS.length - 1; i >= 0; i--) {
+    // SAFETY: i is bounded by ZOOM_PRESETS.length
+    if (ZOOM_PRESETS[i]! < currentZoom - 0.01) {
+      return ZOOM_PRESETS[i]!;
+    }
+  }
+  // SAFETY: ZOOM_PRESETS is a non-empty constant array
+  return ZOOM_PRESETS[0]!;
+}
+
+// ============================================================================
+// USE WHEEL ZOOM HOOK
+// ============================================================================
+
+/**
+ * React hook for Ctrl+scroll zoom functionality
+ */
+export function useWheelZoom(options: UseWheelZoomOptions = {}): UseWheelZoomReturn {
+  const {
+    initialZoom = DEFAULT_INITIAL_ZOOM,
+    minZoom = DEFAULT_MIN_ZOOM,
+    maxZoom = DEFAULT_MAX_ZOOM,
+    zoomStep = DEFAULT_ZOOM_STEP,
+    enabled = true,
+    containerRef,
+    getCurrentZoom,
+    onZoomChange,
+    enableKeyboardShortcuts = true,
+    preventDefault = true,
+  } = options;
+
+  const [zoom, setZoomState] = useState(initialZoom);
+  const zoomRef = useRef(zoom);
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    zoomRef.current = zoom;
+  }, [zoom]);
+
+  /**
+   * Live current zoom. Controlled mode reads the external owner; uncontrolled
+   * mode reads the hook's own mirror.
+   */
+  const readZoom = useCallback(() => getCurrentZoom?.() ?? zoomRef.current, [getCurrentZoom]);
+
+  /**
+   * Set zoom with clamping and callback
+   */
+  const setZoom = useCallback(
+    (newZoom: number) => {
+      const clampedZoom = roundZoom(clamp(newZoom, minZoom, maxZoom));
+      if (clampedZoom === readZoom()) {
+        return;
+      }
+      // Controlled mode does not own state; the external owner re-renders us.
+      if (!getCurrentZoom) {
+        setZoomState(clampedZoom);
+      }
+      onZoomChange?.(clampedZoom);
+    },
+    [minZoom, maxZoom, onZoomChange, getCurrentZoom, readZoom],
+  );
+
+  /**
+   * Zoom in by step
+   */
+  const zoomIn = useCallback(() => {
+    setZoom(readZoom() + zoomStep);
+  }, [zoomStep, setZoom, readZoom]);
+
+  /**
+   * Zoom out by step
+   */
+  const zoomOut = useCallback(() => {
+    setZoom(readZoom() - zoomStep);
+  }, [zoomStep, setZoom, readZoom]);
+
+  /**
+   * Reset zoom to initial level
+   */
+  const resetZoom = useCallback(() => {
+    setZoom(initialZoom);
+  }, [initialZoom, setZoom]);
+
+  /**
+   * Reset zoom to 100%
+   */
+  const zoomTo100 = useCallback(() => {
+    setZoom(1);
+  }, [setZoom]);
+
+  /**
+   * Zoom to fit width
+   */
+  const zoomToFit = useCallback(
+    (containerWidth: number, contentWidth: number) => {
+      if (contentWidth > 0) {
+        const fitZoom = containerWidth / contentWidth;
+        setZoom(fitZoom);
+      }
+    },
+    [setZoom],
+  );
+
+  /**
+   * Handle wheel event
+   */
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (!enabled) {
+        return;
+      }
+
+      // Check for Ctrl/Cmd key (trackpad pinch also reports ctrlKey)
+      const isCtrlOrMeta = event.ctrlKey || event.metaKey;
+      if (!isCtrlOrMeta) {
+        return;
+      }
+
+      // Prevent default browser zoom
+      if (preventDefault) {
+        event.preventDefault();
+      }
+
+      // Determine zoom direction
+      // deltaY > 0 means scrolling down (zoom out)
+      // deltaY < 0 means scrolling up (zoom in)
+      const delta = event.deltaY;
+
+      if (delta < 0) {
+        // Scroll up = zoom in
+        setZoom(readZoom() + zoomStep);
+      } else if (delta > 0) {
+        // Scroll down = zoom out
+        setZoom(readZoom() - zoomStep);
+      }
+    },
+    [enabled, preventDefault, zoomStep, setZoom, readZoom],
+  );
+
+  /**
+   * Handle keyboard shortcuts
+   */
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled || !enableKeyboardShortcuts) {
+        return;
+      }
+
+      const isCtrlOrMeta = event.ctrlKey || event.metaKey;
+      if (!isCtrlOrMeta) {
+        return;
+      }
+
+      // Ctrl+0 - Reset zoom to 100%
+      if (event.key === "0") {
+        event.preventDefault();
+        zoomTo100();
+        return;
+      }
+
+      // Ctrl++ or Ctrl+= - Zoom in
+      if (event.key === "+" || event.key === "=") {
+        event.preventDefault();
+        zoomIn();
+        return;
+      }
+
+      // Ctrl+- - Zoom out
+      if (event.key === "-") {
+        event.preventDefault();
+        zoomOut();
+        return;
+      }
+    },
+    [enabled, enableKeyboardShortcuts, zoomIn, zoomOut, zoomTo100],
+  );
+
+  // Attach wheel listener to container. Read `.current` in render scope so the
+  // effect re-runs when the container mounts on a later render (it starts null
+  // until the document loads), mirroring useZoomAndPageInfo's scroll listener.
+  const container = containerRef?.current ?? null;
+  useEffect(() => {
+    if (!enabled || !container) {
+      return;
+    }
+
+    // Use passive: false to allow preventDefault
+    container.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      container.removeEventListener("wheel", handleWheel);
+    };
+  }, [enabled, container, handleWheel]);
+
+  // Attach keyboard listener
+  useEffect(() => {
+    if (!enabled || !enableKeyboardShortcuts) {
+      return;
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [enabled, enableKeyboardShortcuts, handleKeyDown]);
+
+  const currentZoom = getCurrentZoom ? getCurrentZoom() : zoom;
+
+  return {
+    zoom: currentZoom,
+    setZoom,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    zoomTo100,
+    zoomToFit,
+    isMinZoom: currentZoom <= minZoom,
+    isMaxZoom: currentZoom >= maxZoom,
+    zoomPercent: Math.round(currentZoom * 100),
+    handleWheel,
+    handleKeyDown,
+  };
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/**
+ * Get zoom presets
+ */
+export function getZoomPresets(): number[] {
+  return [...ZOOM_PRESETS];
+}
+
+/**
+ * Find nearest zoom preset
+ */
+export function findNearestZoomPreset(zoom: number): number {
+  return nearestPreset(zoom);
+}
+
+/**
+ * Get next zoom preset (for zoom in)
+ */
+export function getNextZoomPreset(zoom: number): number {
+  return nextPreset(zoom);
+}
+
+/**
+ * Get previous zoom preset (for zoom out)
+ */
+export function getPreviousZoomPreset(zoom: number): number {
+  return prevPreset(zoom);
+}
+
+/**
+ * Format zoom level for display
+ */
+export function formatZoom(zoom: number): string {
+  return `${Math.round(zoom * 100)}%`;
+}
+
+/**
+ * Parse zoom from percentage string
+ */
+export function parseZoom(zoomString: string): number | null {
+  const match = zoomString.match(/(\d+(\.\d+)?)/);
+  if (match) {
+    // SAFETY: group 1 always captures in this regex
+    const value = Number.parseFloat(match[1]!);
+    if (!Number.isNaN(value)) {
+      return value / 100;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if zoom level is at a preset
+ */
+export function isZoomPreset(zoom: number): boolean {
+  return ZOOM_PRESETS.some((preset) => Math.abs(preset - zoom) < 0.01);
+}
+
+/**
+ * Clamp zoom to valid range
+ */
+export function clampZoom(
+  zoom: number,
+  minZoom: number = DEFAULT_MIN_ZOOM,
+  maxZoom: number = DEFAULT_MAX_ZOOM,
+): number {
+  return roundZoom(clamp(zoom, minZoom, maxZoom));
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,6 +18,16 @@ export {
   insertTableInView,
   insertTableOfContentsInView,
 } from "@stll/folio-core/prosemirror";
+export { ZoomControl, type ZoomControlProps, type ZoomLevel } from "./components/ui/ZoomControl";
+export {
+  clampZoom,
+  formatZoom,
+  parseZoom,
+  useWheelZoom,
+  ZOOM_PRESETS,
+  type UseWheelZoomOptions,
+  type UseWheelZoomReturn,
+} from "./hooks/useWheelZoom";
 export {
   createEmptyDocument,
   type CreateEmptyDocumentOptions,

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -456,4 +456,29 @@ test.describe("zoom", () => {
       1.5,
     );
   });
+
+  test("Ctrl/Cmd+wheel pinch zooms in smoothly without slamming to the max", async ({ page }) => {
+    await mountFixture(page, "sample.docx");
+    expect(await page.evaluate(() => globalThis.__folioPlayground?.getEditorRef()?.getZoom())).toBe(
+      1,
+    );
+
+    // Simulate a trackpad pinch-in: a burst of small-deltaY ctrlKey wheel events
+    // over the scroll container. The continuous factor must nudge zoom up gently
+    // (proving the listener attached past the container's late mount), not jump
+    // it toward the max the way a discrete per-event step would.
+    await page.evaluate(() => {
+      const el = document.querySelector("[data-folio-scroll]");
+      for (let i = 0; i < 20; i += 1) {
+        el?.dispatchEvent(
+          new WheelEvent("wheel", { deltaY: -4, ctrlKey: true, bubbles: true, cancelable: true }),
+        );
+      }
+    });
+    await page.waitForTimeout(200);
+
+    const zoom = await page.evaluate(() => globalThis.__folioPlayground?.getEditorRef()?.getZoom());
+    expect(zoom).toBeGreaterThan(1);
+    expect(zoom).toBeLessThan(1.6);
+  });
 });

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -210,14 +210,20 @@ test.describe("table", () => {
     expect(cols0).toBeGreaterThan(0);
 
     // Insert a row below -> row count grows.
-    await (await openTableCellMenu(page)).getByRole("menuitem", { name: "Insert row below" }).click();
+    await (
+      await openTableCellMenu(page)
+    )
+      .getByRole("menuitem", { name: "Insert row below" })
+      .click();
     await page.waitForTimeout(250);
     const rowsAfterInsert = await countNodes(page, "tableRow");
     expect(rowsAfterInsert).toBeGreaterThan(rows0);
 
     // Insert a column right -> the first row gains exactly one cell (a collapsed
     // caret must add a single column, uniformly, not one per existing column).
-    await (await openTableCellMenu(page))
+    await (
+      await openTableCellMenu(page)
+    )
       .getByRole("menuitem", { name: "Insert column right" })
       .click();
     await page.waitForTimeout(250);
@@ -283,9 +289,7 @@ test.describe("header/footer", () => {
   // Reads the header's hidden content editor (the `[data-hf-r-id]` ProseMirror
   // that backs the painted `.layout-page-header`).
   const headerContent = (page: Page) =>
-    page.evaluate(
-      () => document.querySelector("[data-hf-r-id] .ProseMirror")?.textContent ?? "",
-    );
+    page.evaluate(() => document.querySelector("[data-hf-r-id] .ProseMirror")?.textContent ?? "");
 
   // Text of every header in the *saved* document model. `getDocument()`
   // (buildCurrentDocument) flushes the persistent hidden header/footer views
@@ -293,9 +297,9 @@ test.describe("header/footer", () => {
   // serialise — the round-trip persistence path, independent of any UI commit.
   const savedHeaderText = (page: Page) =>
     page.evaluate(() => {
-      const doc = globalThis.__folioPlayground?.getEditorRef()?.getDocument() as
-        | { package?: { headers?: unknown } }
-        | null;
+      const doc = globalThis.__folioPlayground?.getEditorRef()?.getDocument() as {
+        package?: { headers?: unknown };
+      } | null;
       const collect = (node: unknown): string => {
         if (typeof node === "string") return node;
         if (node === null || typeof node !== "object") return "";
@@ -415,7 +419,8 @@ test.describe("zoom", () => {
   test("setZoom updates getZoom and scales the rendered page", async ({ page }) => {
     await mountFixture(page, "sample.docx");
 
-    const pageWidth = async () => (await page.locator(".layout-page").first().boundingBox())?.width ?? 0;
+    const pageWidth = async () =>
+      (await page.locator(".layout-page").first().boundingBox())?.width ?? 0;
 
     expect(await page.evaluate(() => globalThis.__folioPlayground?.getEditorRef()?.getZoom())).toBe(
       1,
@@ -433,13 +438,22 @@ test.describe("zoom", () => {
     expect(ratio).toBeLessThan(1.7);
   });
 
-  test("the playground zoom-in control drives the editor zoom", async ({ page }) => {
+  test("the in-toolbar zoom control changes the editor zoom", async ({ page }) => {
     await mountFixture(page, "sample.docx");
-    await page.getByRole("button", { name: "Zoom in" }).click();
-    await page.waitForTimeout(150);
-    const zoom = await page.evaluate(() =>
-      globalThis.__folioPlayground?.getEditorRef()?.getZoom(),
+
+    expect(await page.evaluate(() => globalThis.__folioPlayground?.getEditorRef()?.getZoom())).toBe(
+      1,
     );
-    expect(zoom).toBeGreaterThan(1);
+
+    // The toolbar zoom widget (a labelled "Zoom" group holding a Select) is the
+    // canonical zoom UI. Open it and pick 150%; the editor zoom must follow.
+    const zoomGroup = page.getByRole("group", { name: "Zoom" });
+    await zoomGroup.getByRole("combobox").click();
+    await page.getByRole("option", { name: "150%" }).click();
+    await page.waitForTimeout(200);
+
+    expect(await page.evaluate(() => globalThis.__folioPlayground?.getEditorRef()?.getZoom())).toBe(
+      1.5,
+    );
   });
 });


### PR DESCRIPTION
Restores the in-toolbar zoom control (50-200% preset dropdown) and Ctrl/Cmd+wheel / pinch zoom, both recovered from history. Opt-in via showZoomControl/zoom/onZoomChange + enableWheelZoom; the playground drops its external zoom buttons for the single in-toolbar control. Reviewed + addressed in #4, which GitHub auto-closed when the stacked base branch was deleted; re-opened against main (rebased; conflicts with the insert group resolved, typecheck+lint green).