### PR TITLE
fix(folio): header/footer editing correctness (double-click add, live text, single caret)

### DIFF
--- a/packages/core/src/layout-bridge/dom/findHfPmSpans.test.ts
+++ b/packages/core/src/layout-bridge/dom/findHfPmSpans.test.ts
@@ -6,6 +6,7 @@ import {
   findHfPmAnchors,
   findHfPmSpans,
   findHfSlotForTarget,
+  findHfSlotKindForTarget,
 } from "./findHfPmSpans";
 
 const headerSpan = {
@@ -283,5 +284,48 @@ describe("findHfSlotForTarget", () => {
       },
     } as unknown as Element;
     expect(findHfSlotForTarget(target)).toBeNull();
+  });
+});
+
+describe("findHfSlotKindForTarget", () => {
+  test("returns null for a null target", () => {
+    expect(findHfSlotKindForTarget(null)).toBeNull();
+  });
+
+  test("resolves an empty header box that has no rId yet (double-click to add)", () => {
+    // The painter renders `.layout-page-header` as the hover-hint / double-click
+    // target even on a page with no header part, so it carries no `data-rid`.
+    const headerEl = {} as unknown as HTMLElement;
+    const target = {
+      closest(selector: string) {
+        return selector === ".layout-page-header" ? headerEl : null;
+      },
+    } as unknown as Element;
+    expect(findHfSlotKindForTarget(target)).toEqual({
+      kind: "header",
+      element: headerEl,
+    });
+  });
+
+  test("resolves an empty footer box when there is no header ancestor", () => {
+    const footerEl = {} as unknown as HTMLElement;
+    const target = {
+      closest(selector: string) {
+        return selector === ".layout-page-footer" ? footerEl : null;
+      },
+    } as unknown as Element;
+    expect(findHfSlotKindForTarget(target)).toEqual({
+      kind: "footer",
+      element: footerEl,
+    });
+  });
+
+  test("returns null for a body target outside any HF box", () => {
+    const target = {
+      closest() {
+        return null;
+      },
+    } as unknown as Element;
+    expect(findHfSlotKindForTarget(target)).toBeNull();
   });
 });

--- a/packages/core/src/layout-bridge/dom/findHfPmSpans.test.ts
+++ b/packages/core/src/layout-bridge/dom/findHfPmSpans.test.ts
@@ -328,4 +328,19 @@ describe("findHfSlotKindForTarget", () => {
     } as unknown as Element;
     expect(findHfSlotKindForTarget(target)).toBeNull();
   });
+
+  test("resolves a moved page-layer HF element by its slot-kind metadata", () => {
+    const associatedEl = {
+      dataset: { hfSlotKind: "footer" },
+    } as unknown as HTMLElement;
+    const target = {
+      closest(selector: string) {
+        return selector === "[data-hf-slot-kind]" ? associatedEl : null;
+      },
+    } as unknown as Element;
+    expect(findHfSlotKindForTarget(target)).toEqual({
+      kind: "footer",
+      element: associatedEl,
+    });
+  });
 });

--- a/packages/core/src/layout-bridge/dom/findHfPmSpans.ts
+++ b/packages/core/src/layout-bridge/dom/findHfPmSpans.ts
@@ -339,5 +339,16 @@ export function findHfSlotKindForTarget(target: Node | null): {
   if (footer) {
     return { kind: "footer", element: footer };
   }
+  // Moved page-layer HF content (a floating image / text box relocated out of
+  // the header/footer box) carries the slot kind on `[data-hf-slot-kind]` — the
+  // same marker `findHfSlotForTarget` resolves — so double-clicking it also
+  // enters edit mode.
+  const associated = target.closest("[data-hf-slot-kind]");
+  if (associated) {
+    const kind = associated.dataset["hfSlotKind"];
+    if (kind === "header" || kind === "footer") {
+      return { kind, element: associated };
+    }
+  }
   return null;
 }

--- a/packages/core/src/layout-bridge/dom/findHfPmSpans.ts
+++ b/packages/core/src/layout-bridge/dom/findHfPmSpans.ts
@@ -310,3 +310,34 @@ export function findHfSlotForTarget(target: Node | null): {
   }
   return null;
 }
+
+/**
+ * Resolve only the header/footer KIND of the slot under `target`, whether or
+ * not it has an assigned rId yet. `findHfSlotForTarget` matches only a slot
+ * that already carries a `data-rid` (an existing HF part); but the painter also
+ * renders an EMPTY `.layout-page-header` / `.layout-page-footer` box — the
+ * hover-hint and double-click-to-add target — that has no rId. Entering edit
+ * mode to *create* a header needs only the kind (the handler mints the part),
+ * so this looser resolver matches that empty box too.
+ */
+export function findHfSlotKindForTarget(target: Node | null): {
+  kind: HfSlotKind;
+  element: HTMLElement;
+} | null {
+  if (!target) {
+    return null;
+  }
+  if (!hasCloset(target)) {
+    const owner = (target as Node).parentElement;
+    return owner ? findHfSlotKindForTarget(owner) : null;
+  }
+  const header = target.closest(".layout-page-header");
+  if (header) {
+    return { kind: "header", element: header };
+  }
+  const footer = target.closest(".layout-page-footer");
+  if (footer) {
+    return { kind: "footer", element: footer };
+  }
+  return null;
+}

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3389,7 +3389,7 @@ export function DocxEditor({
                                   }}
                                   isAddingComment={isAddingComment}
                                   addCommentYPosition={addCommentYPosition}
-                                  topOffset={toolbarHeight}
+                                  topOffset={0}
                                 />
                               </Suspense>
                             );

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3389,7 +3389,7 @@ export function DocxEditor({
                                   }}
                                   isAddingComment={isAddingComment}
                                   addCommentYPosition={addCommentYPosition}
-                                  topOffset={0}
+                                  topOffset={toolbarHeight}
                                 />
                               </Suspense>
                             );

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -66,6 +66,7 @@ import {
   findHfCaretSpan,
   findHfPmSpans,
   findHfSlotForTarget,
+  findHfSlotKindForTarget,
 } from "@stll/folio-core/layout-bridge/dom/findHfPmSpans";
 import { clickToPosition } from "@stll/folio-core/layout-bridge/engine/clickToPosition";
 import {
@@ -4593,7 +4594,11 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       // instead of pointlessly re-firing `onHeaderFooterDoubleClick`
       // (Codex #487 P2: 21:49 review).
       if (!readOnly && !hfEditMode && e.detail === 2 && onHeaderFooterDoubleClick) {
-        const slot = findHfSlotForTarget(target);
+        // Kind-only, not `findHfSlotForTarget`: an empty header/footer box has
+        // no `data-rid` yet, so the rId-gated resolver misses it and adding a
+        // header via double-click never fires. Entering edit mode to create one
+        // needs only the kind (the handler mints the part).
+        const slot = findHfSlotKindForTarget(target);
         if (slot) {
           const pageEl = closestHtmlElement(target, "[data-page-number]");
           const pageNum = pageEl ? Number(pageEl.dataset["pageNumber"]) : 1;

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -428,6 +428,7 @@ const EMPTY_PLUGINS: Plugin[] = [];
 // (a fresh `[]` per transaction would fail every identity comparison).
 const EMPTY_TEMPLATE_PREVIEW_ENTRIES: readonly TemplatePreviewEntry[] = [];
 const EMPTY_AI_SUGGESTIONS: readonly AISuggestion[] = [];
+const EMPTY_SELECTION_RECTS: SelectionRect[] = [];
 
 const DEFERRED_KEYDOWN_REPLAY_KEYS = new Set([
   "ArrowDown",
@@ -5861,10 +5862,13 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
               painter lays out and paints them (with the accent chip in
               highlighted mode) as part of the pages themselves. */}
 
-          {/* Selection overlay */}
+          {/* Selection overlay. In HF edit mode the body caret/selection is
+              suppressed so it does not linger beside the HF caret — the
+              HfCaretOverlay below owns the caret while a header/footer is
+              being edited. */}
           <SelectionOverlay
-            selectionRects={selectionRects}
-            caretPosition={caretPosition}
+            selectionRects={hfEditMode ? EMPTY_SELECTION_RECTS : selectionRects}
+            caretPosition={hfEditMode ? null : caretPosition}
             isFocused={isFocused}
             pageGap={pageGap}
             markCaretRect

--- a/packages/react/src/styles/prosemirror-layer.css
+++ b/packages/react/src/styles/prosemirror-layer.css
@@ -754,13 +754,11 @@
   border-top: 1px dotted var(--doc-primary);
 }
 
-/* Hide the original layout-painter content in the area being edited */
-.paged-editor--editing-header .layout-page-header > * {
-  visibility: hidden;
-}
-.paged-editor--editing-footer .layout-page-footer > * {
-  visibility: hidden;
-}
+/* Post-eigenpal#611 the painter is the sole visible HF renderer in edit mode
+   too (the inline overlay no longer mounts its own PM), so the old
+   `.paged-editor--editing-{header,footer} > * { visibility: hidden }` patch that
+   hid the painter under that overlay is gone — it would now hide the live text
+   being typed. Kept in sync with editor.css. */
 
 /* Remove hover effect on header/footer when in editing mode */
 .paged-editor--hf-editing .layout-page-header:hover,


### PR DESCRIPTION
Four fixes to header/footer editing and the editor chrome.

### Enter HF edit on an empty area
The painter always renders the `.layout-page-header` / `.layout-page-footer` box (the hover hint and double-click target), but an area with no HF part yet carries no `data-rid`. The click resolver was `[data-rid]`-gated, so double-clicking an empty header resolved no slot and never entered edit mode. A kind-only resolver handles that case; the existing handler mints the part. Covered by a unit test.

### Show live text while editing
Post-eigenpal#611 the painter is the sole visible HF renderer, and the old `.paged-editor--editing-{header,footer} > * { visibility: hidden }` patch was removed from `editor.css`. The equivalent rule in `prosemirror-layer.css` (the stylesheet actually imported by `HiddenProseMirror`) remained, so it kept hiding the live painted text until blur dropped the editing class. Removed there too, and noted the two stylesheets must stay in sync.

### One caret while editing
The body `SelectionOverlay` kept painting the body caret during HF editing, alongside the HF caret overlay. The body caret and selection are now suppressed while `hfEditMode` is active.

### Comments / tracked-change sidebar overlap
`CommentsSidebar` was positioned with `topOffset={0}` while its sibling `DocumentOutline` uses `topOffset={toolbarHeight}` in the same overlay coordinate space, so its top card overlapped the toolbar. Matched.
