### PR TITLE
feat(react): restore opt-in horizontal + vertical rulers

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -251,6 +251,7 @@ export function App() {
             author="Folio User"
             onError={handleError}
             showToolbar={true}
+            showRuler={true}
             initialZoom={ZOOM_INITIAL}
             mode={editorMode}
             onModeChange={setEditorMode}

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -116,6 +116,14 @@ export type DocxEditorProps = {
   showMarginGuides?: boolean;
   /** Color for margin guides (default: '#c0c0c0') */
   marginGuideColor?: string;
+  /**
+   * Whether the horizontal and vertical rulers start visible (default: false).
+   * Seeds the initial state of the toolbar's ruler toggle; users show/hide the
+   * rulers at runtime from there (like Word's View > Ruler).
+   */
+  showRuler?: boolean;
+  /** Measurement unit shown on the rulers (default: 'inch'). */
+  rulerUnit?: "inch" | "cm";
   /** Initial zoom level (default: 1.0) */
   initialZoom?: number;
   /** Whether Ctrl/Cmd+wheel and trackpad-pinch zoom are enabled (default: true) */

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -820,7 +820,7 @@ export function DocxEditor({
   // Keep history.state accessible in stable callbacks without stale closures
   const historyStateRef = useRef(history.state);
   historyStateRef.current = history.state;
-  // Track current border color/width for border presets (like Google Docs)
+  // Track current border color/width for border presets
   const borderSpecRef = useRef({
     style: "single",
     size: 4,
@@ -3711,7 +3711,7 @@ export function DocxEditor({
                 </div>
                 {/* end scroll container */}
 
-                {/* Page indicator — Google Docs style, next to scrollbar while scrolling */}
+                {/* Page indicator — next to scrollbar while scrolling */}
                 {scrollPageInfo.totalPages > 1 && (
                   <div
                     style={{
@@ -3779,7 +3779,7 @@ export function DocxEditor({
               {/* end wrapper for scroll container + outline */}
             </div>
 
-            {/* Hyperlink popup (Google Docs-style) */}
+            {/* Hyperlink popup */}
             <HyperlinkPopup
               data={hyperlinkPopupData}
               onNavigate={handleHyperlinkPopupNavigate}

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3260,7 +3260,7 @@ export function DocxEditor({
                       scrolls horizontally with the document. paddingRight biases
                       the centered ruler left by the comments-sidebar scroll gutter
                       so it tracks the page when the sidebar shifts it. */}
-                  {rulerVisible && (
+                  {rulerVisible && !readOnly && (
                     <div
                       style={{
                         position: "sticky",
@@ -3329,7 +3329,7 @@ export function DocxEditor({
                           inset is needed). paddingTop tracks the viewport's
                           scaled top padding so the ruler's zero aligns with the
                           first page's top edge across zoom levels. */}
-                      {rulerVisible && !readOnlyProp && (
+                      {rulerVisible && !readOnly && (
                         <div
                           style={{
                             position: "absolute",

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -40,6 +40,7 @@ import { applyFolioAIEditOperations, createFolioAIEditSnapshot } from "@stll/fol
 import { normalizeBaseDirection } from "@stll/folio-core/docx/normalizeBaseDirection";
 import { getCachedNumberingMap } from "@stll/folio-core/docx/numberingParser";
 import { updateScrollPageTotal } from "@stll/folio-core/paged-layout/scrollPageInfo";
+import { getPageSize } from "@stll/folio-core/paged-layout/sectionGeometry";
 // ProseMirror editor
 import {
   TextSelection,
@@ -3176,6 +3177,14 @@ export function DocxEditor({
 
   const imagePropertiesCurrentData = buildImagePropertiesData(state.pmImageContext);
 
+  // Mirror PagedEditor's centered-viewport width so the vertical ruler can share
+  // the page's horizontal centering offset (see scaledViewportStyle in PagedEditor).
+  const scaledViewportWidth = Math.max(
+    1,
+    getPageSize(effectiveSectionProperties ?? null).w * zoom +
+      (showCommentsSidebar ? COMMENTS_SIDEBAR_SCROLL_GUTTER : 0),
+  );
+
   return (
     <FolioUIProvider components={components}>
       <ErrorProvider>
@@ -3292,6 +3301,7 @@ export function DocxEditor({
                         indentRight={state.paragraphIndentRight}
                         onIndentLeftChange={handleIndentLeftChange}
                         onIndentRightChange={handleIndentRightChange}
+                        showFirstLineIndent={!readOnly}
                         firstLineIndent={state.paragraphFirstLineIndent}
                         hangingIndent={state.paragraphHangingIndent}
                         onFirstLineIndentChange={handleFirstLineIndentChange}
@@ -3324,16 +3334,16 @@ export function DocxEditor({
                       })}
                       onContextMenu={handleEditorContextMenu}
                     >
-                      {/* Vertical ruler — pinned at the editor content's left
-                          edge (folio's outline rail is right-aligned, so no left
-                          inset is needed). paddingTop tracks the viewport's
-                          scaled top padding so the ruler's zero aligns with the
-                          first page's top edge across zoom levels. */}
+                      {/* Vertical ruler — shares the centered page's horizontal
+                          offset so its margin handles line up with the document
+                          on viewports wider than the page. paddingTop tracks the
+                          viewport's scaled top padding so the ruler's zero aligns
+                          with the first page's top edge across zoom levels. */}
                       {rulerVisible && !readOnly && (
                         <div
                           style={{
                             position: "absolute",
-                            left: 0,
+                            left: `max(0px, calc((100% - ${String(scaledViewportWidth)}px) / 2))`,
                             top: 0,
                             zIndex: 20,
                             paddingTop: VIEWPORT_PADDING_TOP * zoom,

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -61,6 +61,10 @@ import {
   toggleNumberedList,
   increaseIndent,
   decreaseIndent,
+  setIndentLeft,
+  setIndentRight,
+  setIndentFirstLine,
+  removeTabStop,
   increaseListLevel,
   decreaseListLevel,
   clearFormatting,
@@ -156,11 +160,17 @@ import { queryHtmlElement } from "@stll/folio-core/utils/domGuards";
 import { onFontsLoaded } from "@stll/folio-core/utils/fontLoader";
 import type { HeadingInfo } from "@stll/folio-core/utils/headingCollector";
 import { collectHeadings } from "@stll/folio-core/utils/headingCollector";
-import { pointsToHalfPoints } from "@stll/folio-core/utils/units";
+import { pointsToHalfPoints, twipsToPixels } from "@stll/folio-core/utils/units";
 import { useDocumentHistory } from "../hooks/useHistory";
 import { useTableSelection } from "../hooks/useTableSelection";
-import { PagedEditor } from "../paged-editor/PagedEditor";
+import {
+  PagedEditor,
+  VIEWPORT_PADDING_TOP,
+  COMMENTS_SIDEBAR_SCROLL_GUTTER,
+} from "../paged-editor/PagedEditor";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
+import { HorizontalRuler } from "./ui/HorizontalRuler";
+import { VerticalRuler } from "./ui/VerticalRuler";
 import { FolioUIProvider, DEFAULT_COMPONENTS } from "../ui/folio-ui";
 import { containedHandler } from "../utils/contained-handler";
 import { clampRangeToDocSize, resolveFolioAIBlockRange } from "./aiEditRange";
@@ -415,6 +425,8 @@ export function DocxEditor({
   showHeaderFooterEditing = true,
   showMarginGuides: _showMarginGuides = false,
   marginGuideColor: _marginGuideColor,
+  showRuler: showRulerProp = false,
+  rulerUnit = "inch",
   initialZoom = 1,
   enableWheelZoom = true,
   readOnly: readOnlyProp = false,
@@ -497,6 +509,9 @@ export function DocxEditor({
   const [tablePropsOpen, setTablePropsOpen] = useState(false);
   // Footnote properties dialog state
   const [footnotePropsOpen, setFootnotePropsOpen] = useState(false);
+  // Ruler visibility — seeded from the prop, then user-driven via the toolbar toggle.
+  const [rulerVisible, setRulerVisible] = useState(showRulerProp);
+  const toggleRuler = useCallback(() => setRulerVisible((visible) => !visible), []);
   // Document outline sidebar state
   const [showOutline, setShowOutline] = useState(showOutlineProp);
   const showOutlineRef = useRef(false);
@@ -2423,6 +2438,64 @@ export function DocxEditor({
     [history.state, readOnly, handleDocumentChange],
   );
 
+  // Ruler drag handlers. Page-margin drags go through the section-properties
+  // updater so they land in undo/redo; paragraph indent and tab-stop changes
+  // dispatch through the active editor view (ported from docx-editor's
+  // usePageSetupControls).
+  const handleLeftMarginChange = useCallback(
+    (twips: number) => handlePageSetupApply({ marginLeft: twips }),
+    [handlePageSetupApply],
+  );
+  const handleRightMarginChange = useCallback(
+    (twips: number) => handlePageSetupApply({ marginRight: twips }),
+    [handlePageSetupApply],
+  );
+  const handleTopMarginChange = useCallback(
+    (twips: number) => handlePageSetupApply({ marginTop: twips }),
+    [handlePageSetupApply],
+  );
+  const handleBottomMarginChange = useCallback(
+    (twips: number) => handlePageSetupApply({ marginBottom: twips }),
+    [handlePageSetupApply],
+  );
+  const handleIndentLeftChange = useCallback(
+    (twips: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      setIndentLeft(twips)(view.state, view.dispatch);
+    },
+    [getActiveEditorView],
+  );
+  const handleIndentRightChange = useCallback(
+    (twips: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      setIndentRight(twips)(view.state, view.dispatch);
+    },
+    [getActiveEditorView],
+  );
+  const handleFirstLineIndentChange = useCallback(
+    (twips: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      // Negative twips encode a hanging indent.
+      if (twips < 0) {
+        setIndentFirstLine(-twips, true)(view.state, view.dispatch);
+      } else {
+        setIndentFirstLine(twips, false)(view.state, view.dispatch);
+      }
+    },
+    [getActiveEditorView],
+  );
+  const handleTabStopRemove = useCallback(
+    (positionTwips: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      removeTabStop(positionTwips)(view.state, view.dispatch);
+    },
+    [getActiveEditorView],
+  );
+
   // Handle save
   const handleSave = useCallback(
     async (options?: { selective?: boolean }): Promise<ArrayBuffer | null> => {
@@ -3145,6 +3218,8 @@ export function DocxEditor({
                       showZoomControl={showZoomControl}
                       zoom={zoom}
                       onZoomChange={setZoomWithViewportAnchor}
+                      rulerVisible={rulerVisible}
+                      onToggleRuler={toggleRuler}
                       editorRef={editorContentRef}
                       onRefocusEditor={focusActiveEditor}
                       onImageWrapType={handleImageWrapType}
@@ -3181,6 +3256,50 @@ export function DocxEditor({
                     requestAnimationFrame(syncCommentHighlightStyles);
                   }}
                 >
+                  {/* Horizontal ruler — sticky-top, centered over the page so it
+                      scrolls horizontally with the document. paddingRight biases
+                      the centered ruler left by the comments-sidebar scroll gutter
+                      so it tracks the page when the sidebar shifts it. */}
+                  {rulerVisible && (
+                    <div
+                      style={{
+                        position: "sticky",
+                        top: 0,
+                        zIndex: 20,
+                        display: "flex",
+                        justifyContent: "center",
+                        flexShrink: 0,
+                        paddingBlock: 4,
+                        paddingLeft: 20,
+                        paddingRight:
+                          20 + (showCommentsSidebar ? COMMENTS_SIDEBAR_SCROLL_GUTTER : 0),
+                        minWidth:
+                          twipsToPixels(effectiveSectionProperties?.pageWidth ?? 12240) * zoom +
+                          40 +
+                          (showCommentsSidebar ? COMMENTS_SIDEBAR_SCROLL_GUTTER : 0),
+                        backgroundColor: "var(--muted)",
+                        transition: "padding 0.2s ease",
+                      }}
+                    >
+                      <HorizontalRuler
+                        sectionProps={effectiveSectionProperties ?? null}
+                        zoom={zoom}
+                        unit={rulerUnit}
+                        editable={!readOnly}
+                        onLeftMarginChange={handleLeftMarginChange}
+                        onRightMarginChange={handleRightMarginChange}
+                        indentLeft={state.paragraphIndentLeft}
+                        indentRight={state.paragraphIndentRight}
+                        onIndentLeftChange={handleIndentLeftChange}
+                        onIndentRightChange={handleIndentRightChange}
+                        firstLineIndent={state.paragraphFirstLineIndent}
+                        hangingIndent={state.paragraphHangingIndent}
+                        onFirstLineIndentChange={handleFirstLineIndentChange}
+                        tabStops={state.paragraphTabs}
+                        onTabStopRemove={handleTabStopRemove}
+                      />
+                    </div>
+                  )}
                   {/* Editor content wrapper */}
                   <div
                     style={{
@@ -3205,6 +3324,31 @@ export function DocxEditor({
                       })}
                       onContextMenu={handleEditorContextMenu}
                     >
+                      {/* Vertical ruler — pinned at the editor content's left
+                          edge (folio's outline rail is right-aligned, so no left
+                          inset is needed). paddingTop tracks the viewport's
+                          scaled top padding so the ruler's zero aligns with the
+                          first page's top edge across zoom levels. */}
+                      {rulerVisible && !readOnlyProp && (
+                        <div
+                          style={{
+                            position: "absolute",
+                            left: 0,
+                            top: 0,
+                            zIndex: 20,
+                            paddingTop: VIEWPORT_PADDING_TOP * zoom,
+                          }}
+                        >
+                          <VerticalRuler
+                            sectionProps={effectiveSectionProperties ?? null}
+                            zoom={zoom}
+                            unit={rulerUnit}
+                            editable={!readOnly}
+                            onTopMarginChange={handleTopMarginChange}
+                            onBottomMarginChange={handleBottomMarginChange}
+                          />
+                        </div>
+                      )}
                       <PagedEditor
                         ref={pagedEditorRef}
                         document={history.state}

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -20,6 +20,7 @@ import {
   MoreHorizontalIcon,
   PilcrowIcon,
   Redo2Icon,
+  RulerIcon,
   SeparatorHorizontalIcon,
   TableIcon,
   TableOfContentsIcon,
@@ -105,6 +106,8 @@ export function FormattingBar(props: FormattingBarProps) {
     showZoomControl,
     zoom,
     onZoomChange,
+    rulerVisible = false,
+    onToggleRuler,
     documentStyles,
     theme,
     onRefocusEditor,
@@ -697,6 +700,19 @@ export function FormattingBar(props: FormattingBarProps) {
 
       {/* Host extras (zoom, track changes, etc.) */}
       <div className="ms-auto flex shrink-0 items-center gap-1">
+        {onToggleRuler && (
+          <ToolbarGroup label={t("viewGroup")}>
+            <ToolbarButton
+              active={rulerVisible}
+              onClick={onToggleRuler}
+              title={t("ruler.toggle")}
+              ariaLabel={t("ruler.toggle")}
+              testId="toolbar-toggle-ruler"
+            >
+              <RulerIcon size={ICON_SIZE} />
+            </ToolbarButton>
+          </ToolbarGroup>
+        )}
         {showZoomControl !== false && zoom !== undefined && onZoomChange !== undefined && (
           <ToolbarGroup label={t("zoomGroup")}>
             <ZoomControl value={zoom} onChange={onZoomChange} disabled={disabled} compact />

--- a/packages/react/src/components/toolbarPrimitives.tsx
+++ b/packages/react/src/components/toolbarPrimitives.tsx
@@ -141,6 +141,10 @@ export type ToolbarProps = {
   zoom?: number | undefined;
   /** Callback when zoom changes */
   onZoomChange?: ((zoom: number) => void) | undefined;
+  /** Whether the rulers are currently visible (drives the toggle's active state) */
+  rulerVisible?: boolean | undefined;
+  /** Toggle the rulers on/off. The ruler control renders only when this is provided. */
+  onToggleRuler?: (() => void) | undefined;
   /** Callback to refocus the editor after toolbar interactions */
   onRefocusEditor?: (() => void) | undefined;
   /** Callback when a table should be inserted */

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -10,7 +10,7 @@
  * Drag tooltip shows value during any drag.
  */
 
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import type { CSSProperties } from "react";
 import type { SectionProperties, TabStop } from "@stll/folio-core/types/document";
 import { twipsToPixels, pixelsToTwips, formatPx } from "@stll/folio-core/utils/units";
@@ -132,6 +132,27 @@ export function HorizontalRuler({
   const rightIndentPosPx = pageWidthPx - rightMarginPx - indentRightPx;
   const firstLinePosPx = leftMarginPx + indentLeftPx + firstLineIndentPx;
 
+  // Values handleDrag reads change on every margin/indent update while a drag
+  // is in flight. Stash them in a ref read inside the (stable) handler so the
+  // mousemove/mouseup effect binds document listeners once per drag, not per frame.
+  const dragParams = {
+    dragging,
+    zoom,
+    pageWidthTwips,
+    leftMarginTwips,
+    rightMarginTwips,
+    contentTwips,
+    indentLeft,
+    indentRight,
+    onLeftMarginChange,
+    onRightMarginChange,
+    onFirstLineIndentChange,
+    onIndentLeftChange,
+    onIndentRightChange,
+  };
+  const dragParamsRef = useRef(dragParams);
+  dragParamsRef.current = dragParams;
+
   const handleDragStart = useCallback(
     (e: React.MouseEvent, marker: MarkerType) => {
       if (!editable) return;
@@ -142,64 +163,48 @@ export function HorizontalRuler({
     [editable],
   );
 
-  const handleDrag = useCallback(
-    (e: MouseEvent) => {
-      if (!dragging || !rulerRef.current) return;
+  const handleDrag = useCallback((e: MouseEvent) => {
+    const params = dragParamsRef.current;
+    if (!params.dragging || !rulerRef.current) return;
 
-      const rect = rulerRef.current.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      setDragPositionPx(x);
-      const positionTwips = pixelsToTwips(x / zoom);
+    const rect = rulerRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    setDragPositionPx(x);
+    const positionTwips = pixelsToTwips(x / params.zoom);
 
-      if (dragging === "leftMargin") {
-        const maxMargin = pageWidthTwips - rightMarginTwips - 720;
-        const rounded = Math.round(Math.max(0, Math.min(positionTwips, maxMargin)));
-        setDragValue(rounded);
-        onLeftMarginChange?.(rounded);
-      } else if (dragging === "rightMargin") {
-        const fromRight = pageWidthTwips - positionTwips;
-        const maxMargin = pageWidthTwips - leftMarginTwips - 720;
-        const rounded = Math.round(Math.max(0, Math.min(fromRight, maxMargin)));
-        setDragValue(rounded);
-        onRightMarginChange?.(rounded);
-      } else if (dragging === "firstLineIndent") {
-        const base = leftMarginTwips + indentLeft;
-        const indentFromBase = positionTwips - base;
-        const maxIndent = contentTwips - indentLeft - indentRight - 720;
-        const rounded = Math.round(Math.max(-indentLeft, Math.min(indentFromBase, maxIndent)));
-        setDragValue(rounded);
-        onFirstLineIndentChange?.(rounded);
-      } else if (dragging === "leftIndent") {
-        const indentFromMargin = positionTwips - leftMarginTwips;
-        const maxIndent = contentTwips - indentRight - 720;
-        const rounded = Math.round(Math.max(0, Math.min(indentFromMargin, maxIndent)));
-        setDragValue(rounded);
-        onIndentLeftChange?.(rounded);
-      } else if (dragging === "rightIndent") {
-        const rightEdge = pageWidthTwips - rightMarginTwips;
-        const indentFromRight = rightEdge - positionTwips;
-        const maxIndent = contentTwips - indentLeft - 720;
-        const rounded = Math.round(Math.max(0, Math.min(indentFromRight, maxIndent)));
-        setDragValue(rounded);
-        onIndentRightChange?.(rounded);
-      }
-    },
-    [
-      dragging,
-      zoom,
-      pageWidthTwips,
-      leftMarginTwips,
-      rightMarginTwips,
-      contentTwips,
-      indentLeft,
-      indentRight,
-      onLeftMarginChange,
-      onRightMarginChange,
-      onFirstLineIndentChange,
-      onIndentLeftChange,
-      onIndentRightChange,
-    ],
-  );
+    if (params.dragging === "leftMargin") {
+      const maxMargin = params.pageWidthTwips - params.rightMarginTwips - 720;
+      const rounded = Math.round(Math.max(0, Math.min(positionTwips, maxMargin)));
+      setDragValue(rounded);
+      params.onLeftMarginChange?.(rounded);
+    } else if (params.dragging === "rightMargin") {
+      const fromRight = params.pageWidthTwips - positionTwips;
+      const maxMargin = params.pageWidthTwips - params.leftMarginTwips - 720;
+      const rounded = Math.round(Math.max(0, Math.min(fromRight, maxMargin)));
+      setDragValue(rounded);
+      params.onRightMarginChange?.(rounded);
+    } else if (params.dragging === "firstLineIndent") {
+      const base = params.leftMarginTwips + params.indentLeft;
+      const indentFromBase = positionTwips - base;
+      const maxIndent = params.contentTwips - params.indentLeft - params.indentRight - 720;
+      const rounded = Math.round(Math.max(-params.indentLeft, Math.min(indentFromBase, maxIndent)));
+      setDragValue(rounded);
+      params.onFirstLineIndentChange?.(rounded);
+    } else if (params.dragging === "leftIndent") {
+      const indentFromMargin = positionTwips - params.leftMarginTwips;
+      const maxIndent = params.contentTwips - params.indentRight - 720;
+      const rounded = Math.round(Math.max(0, Math.min(indentFromMargin, maxIndent)));
+      setDragValue(rounded);
+      params.onIndentLeftChange?.(rounded);
+    } else if (params.dragging === "rightIndent") {
+      const rightEdge = params.pageWidthTwips - params.rightMarginTwips;
+      const indentFromRight = rightEdge - positionTwips;
+      const maxIndent = params.contentTwips - params.indentLeft - 720;
+      const rounded = Math.round(Math.max(0, Math.min(indentFromRight, maxIndent)));
+      setDragValue(rounded);
+      params.onIndentRightChange?.(rounded);
+    }
+  }, []);
 
   const handleDragEnd = useCallback(() => {
     setDragging(null);
@@ -219,7 +224,10 @@ export function HorizontalRuler({
     return undefined;
   }, [dragging, handleDrag, handleDragEnd]);
 
-  const ticks = generateTicks(pageWidthTwips, zoom, unit);
+  const ticks = useMemo(
+    () => generateTicks(pageWidthTwips, zoom, unit),
+    [pageWidthTwips, zoom, unit],
+  );
 
   return (
     <div

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -1,0 +1,632 @@
+/**
+ * HorizontalRuler Component — Google Docs style
+ *
+ * 3 handles only:
+ * - Left side: first-line indent (▼ down at top) + left indent (▲ up at bottom)
+ * - Right side: right indent (▼ down at top)
+ *
+ * Margins shown as gray zones on the ruler edges.
+ * Drag the boundary between gray/white to adjust page margins.
+ * Drag tooltip shows value during any drag.
+ */
+
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import type { CSSProperties } from "react";
+import type { SectionProperties, TabStop } from "@stll/folio-core/types/document";
+import { twipsToPixels, pixelsToTwips, formatPx } from "@stll/folio-core/utils/units";
+import { useTranslations } from "use-intl";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type HorizontalRulerProps = {
+  sectionProps?: SectionProperties | null;
+  zoom?: number;
+  editable?: boolean;
+  onLeftMarginChange?: (marginTwips: number) => void;
+  onRightMarginChange?: (marginTwips: number) => void;
+  onFirstLineIndentChange?: (indentTwips: number) => void;
+  showFirstLineIndent?: boolean;
+  firstLineIndent?: number;
+  hangingIndent?: boolean;
+  indentLeft?: number;
+  indentRight?: number;
+  onIndentLeftChange?: (indentTwips: number) => void;
+  onIndentRightChange?: (indentTwips: number) => void;
+  unit?: "inch" | "cm";
+  className?: string;
+  style?: CSSProperties;
+  tabStops?: TabStop[] | null;
+  onTabStopRemove?: (positionTwips: number) => void;
+};
+
+type MarkerType = "leftMargin" | "rightMargin" | "firstLineIndent" | "leftIndent" | "rightIndent";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_PAGE_WIDTH_TWIPS = 12240;
+const DEFAULT_MARGIN_TWIPS = 1440;
+const TWIPS_PER_INCH = 1440;
+const TWIPS_PER_CM = 567;
+
+const RULER_HEIGHT = 22;
+const RULER_TEXT_COLOR = "var(--doc-text-muted)";
+const RULER_TICK_COLOR = "var(--doc-text-subtle)";
+const MARGIN_ZONE_COLOR = "var(--doc-shadow-subtle)";
+const INDENT_COLOR = "var(--doc-primary)";
+const INDENT_HOVER_COLOR = "var(--doc-primary-hover)";
+const INDENT_ACTIVE_COLOR = "var(--doc-primary-hover)";
+
+const TRI_SIZE = 5; // triangle half-width in px
+
+function resolveIndentColor(isDragging: boolean, isHovered: boolean): string {
+  if (isDragging) return INDENT_ACTIVE_COLOR;
+  if (isHovered) return INDENT_HOVER_COLOR;
+  return INDENT_COLOR;
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function formatValueForTooltip(twips: number, unit: "inch" | "cm"): string {
+  if (unit === "inch") {
+    return (twips / TWIPS_PER_INCH).toFixed(2) + '"';
+  }
+  return (twips / TWIPS_PER_CM).toFixed(1) + " cm";
+}
+
+// ============================================================================
+// MAIN COMPONENT
+// ============================================================================
+
+export function HorizontalRuler({
+  sectionProps,
+  zoom = 1,
+  editable = false,
+  onLeftMarginChange,
+  onRightMarginChange,
+  onFirstLineIndentChange,
+  showFirstLineIndent = false,
+  firstLineIndent = 0,
+  hangingIndent = false,
+  indentLeft = 0,
+  indentRight = 0,
+  onIndentLeftChange,
+  onIndentRightChange,
+  unit = "inch",
+  className = "",
+  style,
+  tabStops,
+  onTabStopRemove,
+}: HorizontalRulerProps): React.ReactElement {
+  const t = useTranslations("folio");
+  const [dragging, setDragging] = useState<MarkerType | null>(null);
+  const [hoveredMarker, setHoveredMarker] = useState<MarkerType | null>(null);
+  const [dragValue, setDragValue] = useState<number | null>(null);
+  const [dragPositionPx, setDragPositionPx] = useState<number | null>(null);
+  const rulerRef = useRef<HTMLDivElement>(null);
+
+  // Page dimensions
+  const pageWidthTwips = sectionProps?.pageWidth ?? DEFAULT_PAGE_WIDTH_TWIPS;
+  const leftMarginTwips = sectionProps?.marginLeft ?? DEFAULT_MARGIN_TWIPS;
+  const rightMarginTwips = sectionProps?.marginRight ?? DEFAULT_MARGIN_TWIPS;
+  const contentTwips = pageWidthTwips - leftMarginTwips - rightMarginTwips;
+
+  // Pixel conversions
+  const pageWidthPx = twipsToPixels(pageWidthTwips) * zoom;
+  const leftMarginPx = twipsToPixels(leftMarginTwips) * zoom;
+  const rightMarginPx = twipsToPixels(rightMarginTwips) * zoom;
+  const indentLeftPx = twipsToPixels(indentLeft) * zoom;
+  const indentRightPx = twipsToPixels(indentRight) * zoom;
+
+  // First line indent: hanging goes left, normal goes right
+  const effectiveFirstLineIndent = hangingIndent ? -firstLineIndent : firstLineIndent;
+  const firstLineIndentPx = twipsToPixels(effectiveFirstLineIndent) * zoom;
+
+  // Handle positions (in px from ruler left edge)
+  const leftIndentPosPx = leftMarginPx + indentLeftPx;
+  const rightIndentPosPx = pageWidthPx - rightMarginPx - indentRightPx;
+  const firstLinePosPx = leftMarginPx + indentLeftPx + firstLineIndentPx;
+
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent, marker: MarkerType) => {
+      if (!editable) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setDragging(marker);
+    },
+    [editable],
+  );
+
+  const handleDrag = useCallback(
+    (e: MouseEvent) => {
+      if (!dragging || !rulerRef.current) return;
+
+      const rect = rulerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      setDragPositionPx(x);
+      const positionTwips = pixelsToTwips(x / zoom);
+
+      if (dragging === "leftMargin") {
+        const maxMargin = pageWidthTwips - rightMarginTwips - 720;
+        const rounded = Math.round(Math.max(0, Math.min(positionTwips, maxMargin)));
+        setDragValue(rounded);
+        onLeftMarginChange?.(rounded);
+      } else if (dragging === "rightMargin") {
+        const fromRight = pageWidthTwips - positionTwips;
+        const maxMargin = pageWidthTwips - leftMarginTwips - 720;
+        const rounded = Math.round(Math.max(0, Math.min(fromRight, maxMargin)));
+        setDragValue(rounded);
+        onRightMarginChange?.(rounded);
+      } else if (dragging === "firstLineIndent") {
+        const base = leftMarginTwips + indentLeft;
+        const indentFromBase = positionTwips - base;
+        const maxIndent = contentTwips - indentLeft - indentRight - 720;
+        const rounded = Math.round(Math.max(-indentLeft, Math.min(indentFromBase, maxIndent)));
+        setDragValue(rounded);
+        onFirstLineIndentChange?.(rounded);
+      } else if (dragging === "leftIndent") {
+        const indentFromMargin = positionTwips - leftMarginTwips;
+        const maxIndent = contentTwips - indentRight - 720;
+        const rounded = Math.round(Math.max(0, Math.min(indentFromMargin, maxIndent)));
+        setDragValue(rounded);
+        onIndentLeftChange?.(rounded);
+      } else if (dragging === "rightIndent") {
+        const rightEdge = pageWidthTwips - rightMarginTwips;
+        const indentFromRight = rightEdge - positionTwips;
+        const maxIndent = contentTwips - indentLeft - 720;
+        const rounded = Math.round(Math.max(0, Math.min(indentFromRight, maxIndent)));
+        setDragValue(rounded);
+        onIndentRightChange?.(rounded);
+      }
+    },
+    [
+      dragging,
+      zoom,
+      pageWidthTwips,
+      leftMarginTwips,
+      rightMarginTwips,
+      contentTwips,
+      indentLeft,
+      indentRight,
+      onLeftMarginChange,
+      onRightMarginChange,
+      onFirstLineIndentChange,
+      onIndentLeftChange,
+      onIndentRightChange,
+    ],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDragging(null);
+    setDragValue(null);
+    setDragPositionPx(null);
+  }, []);
+
+  useEffect(() => {
+    if (dragging) {
+      document.addEventListener("mousemove", handleDrag);
+      document.addEventListener("mouseup", handleDragEnd);
+      return () => {
+        document.removeEventListener("mousemove", handleDrag);
+        document.removeEventListener("mouseup", handleDragEnd);
+      };
+    }
+    return undefined;
+  }, [dragging, handleDrag, handleDragEnd]);
+
+  const ticks = generateTicks(pageWidthTwips, zoom, unit);
+
+  return (
+    <div
+      ref={rulerRef}
+      className={`docx-horizontal-ruler ${className}`}
+      style={{
+        position: "relative",
+        width: formatPx(pageWidthPx),
+        height: RULER_HEIGHT,
+        backgroundColor: "transparent",
+        overflow: "visible",
+        userSelect: "none",
+        cursor: dragging ? "ew-resize" : "default",
+        ...style,
+      }}
+      role="slider"
+      aria-label={t("ruler.horizontal")}
+      aria-valuemin={0}
+      aria-valuemax={pageWidthTwips}
+    >
+      {/* Gray margin zones — click & drag anywhere in the gray area to adjust margin */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: formatPx(leftMarginPx),
+          height: RULER_HEIGHT,
+          backgroundColor: MARGIN_ZONE_COLOR,
+          borderRight: "1px solid var(--doc-shadow-subtle)",
+          cursor: editable ? "ew-resize" : "default",
+          zIndex: 1,
+        }}
+        onMouseDown={
+          editable && onLeftMarginChange ? (e) => handleDragStart(e, "leftMargin") : undefined
+        }
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          width: formatPx(rightMarginPx),
+          height: RULER_HEIGHT,
+          backgroundColor: MARGIN_ZONE_COLOR,
+          borderLeft: "1px solid var(--doc-shadow-subtle)",
+          cursor: editable ? "ew-resize" : "default",
+          zIndex: 1,
+        }}
+        onMouseDown={
+          editable && onRightMarginChange ? (e) => handleDragStart(e, "rightMargin") : undefined
+        }
+      />
+
+      {/* Tick marks */}
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+        {ticks.map((tick, i) => (
+          <RulerTick key={i} tick={tick} />
+        ))}
+      </div>
+
+      {/* === 3 INDENT HANDLES (Google Docs style) === */}
+
+      {/* First-line indent — ▼ down triangle at top-left */}
+      {showFirstLineIndent && (
+        <IndentTriangle
+          direction="down"
+          positionPx={firstLinePosPx}
+          editable={editable}
+          isDragging={dragging === "firstLineIndent"}
+          isHovered={hoveredMarker === "firstLineIndent"}
+          onMouseEnter={() => setHoveredMarker("firstLineIndent")}
+          onMouseLeave={() => setHoveredMarker(null)}
+          onMouseDown={(e) => handleDragStart(e, "firstLineIndent")}
+          label={t("ruler.firstLineIndent")}
+        />
+      )}
+
+      {/* Left indent — ▲ up triangle at bottom-left */}
+      {editable && onIndentLeftChange && (
+        <IndentTriangle
+          direction="up"
+          positionPx={leftIndentPosPx}
+          editable={editable}
+          isDragging={dragging === "leftIndent"}
+          isHovered={hoveredMarker === "leftIndent"}
+          onMouseEnter={() => setHoveredMarker("leftIndent")}
+          onMouseLeave={() => setHoveredMarker(null)}
+          onMouseDown={(e) => handleDragStart(e, "leftIndent")}
+          label={t("ruler.leftIndent")}
+        />
+      )}
+
+      {/* Right indent — ▼ down triangle at top-right */}
+      {editable && onIndentRightChange && (
+        <IndentTriangle
+          direction="down"
+          positionPx={rightIndentPosPx}
+          editable={editable}
+          isDragging={dragging === "rightIndent"}
+          isHovered={hoveredMarker === "rightIndent"}
+          onMouseEnter={() => setHoveredMarker("rightIndent")}
+          onMouseLeave={() => setHoveredMarker(null)}
+          onMouseDown={(e) => handleDragStart(e, "rightIndent")}
+          label={t("ruler.rightIndent")}
+        />
+      )}
+
+      {/* Tab stop markers (display only) */}
+      {tabStops?.map((tab) => (
+        <TabStopMarker
+          key={tab.position}
+          tabStop={tab}
+          positionPx={twipsToPixels(tab.position) * zoom}
+          onDoubleClick={() => onTabStopRemove?.(tab.position)}
+        />
+      ))}
+
+      {/* Drag tooltip */}
+      {dragging && dragValue !== null && dragPositionPx !== null && (
+        <DragTooltip value={formatValueForTooltip(dragValue, unit)} positionPx={dragPositionPx} />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// SUB-COMPONENTS
+// ============================================================================
+
+type TickData = {
+  position: number;
+  height: number;
+  label?: string | undefined;
+};
+
+function RulerTick({ tick }: { tick: TickData }): React.ReactElement {
+  return (
+    <>
+      <div
+        style={{
+          position: "absolute",
+          left: formatPx(tick.position),
+          bottom: 0,
+          width: 1,
+          height: tick.height,
+          backgroundColor: RULER_TICK_COLOR,
+        }}
+      />
+      {tick.label && (
+        <div
+          style={{
+            position: "absolute",
+            left: formatPx(tick.position),
+            top: 3,
+            transform: "translateX(-50%)",
+            fontSize: "9px",
+            color: RULER_TEXT_COLOR,
+            fontFamily: "sans-serif",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {tick.label}
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * Indent triangle handle — Google Docs style.
+ * direction="down": ▼ anchored at top (first-line indent, right indent)
+ * direction="up":   ▲ anchored at bottom (left indent)
+ */
+type IndentTriangleProps = {
+  direction: "up" | "down";
+  positionPx: number;
+  editable: boolean;
+  isDragging: boolean;
+  isHovered: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onMouseDown: (e: React.MouseEvent) => void;
+  label: string;
+};
+
+function IndentTriangle({
+  direction,
+  positionPx,
+  editable,
+  isDragging,
+  isHovered,
+  onMouseEnter,
+  onMouseLeave,
+  onMouseDown,
+  label,
+}: IndentTriangleProps): React.ReactElement {
+  const color = resolveIndentColor(isDragging, isHovered);
+  const triHeight = Math.round(TRI_SIZE * 1.6);
+
+  const containerStyle: CSSProperties = {
+    position: "absolute",
+    left: formatPx(positionPx - TRI_SIZE),
+    width: TRI_SIZE * 2,
+    height: triHeight + 2,
+    cursor: editable ? "ew-resize" : "default",
+    zIndex: isDragging ? 10 : 4,
+    ...(direction === "down" ? { top: 0 } : { bottom: 0 }),
+  };
+
+  const triangleStyle: CSSProperties =
+    direction === "down"
+      ? {
+          position: "absolute",
+          top: 1,
+          left: 0,
+          width: 0,
+          height: 0,
+          borderLeft: `${TRI_SIZE}px solid transparent`,
+          borderRight: `${TRI_SIZE}px solid transparent`,
+          borderTop: `${triHeight}px solid ${color}`,
+          transition: "border-top-color 0.1s",
+        }
+      : {
+          position: "absolute",
+          bottom: 1,
+          left: 0,
+          width: 0,
+          height: 0,
+          borderLeft: `${TRI_SIZE}px solid transparent`,
+          borderRight: `${TRI_SIZE}px solid transparent`,
+          borderBottom: `${triHeight}px solid ${color}`,
+          transition: "border-bottom-color 0.1s",
+        };
+
+  return (
+    <div
+      className="docx-ruler-indent"
+      style={containerStyle}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onMouseDown={onMouseDown}
+      role="slider"
+      aria-label={label}
+      aria-orientation="horizontal"
+      tabIndex={editable ? 0 : -1}
+    >
+      <div style={triangleStyle} />
+    </div>
+  );
+}
+
+function DragTooltip({
+  value,
+  positionPx,
+}: {
+  value: string;
+  positionPx: number;
+}): React.ReactElement {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: formatPx(positionPx),
+        top: -22,
+        transform: "translateX(-50%)",
+        backgroundColor: "var(--doc-text)",
+        color: "var(--doc-on-primary)",
+        fontSize: "10px",
+        fontFamily: "sans-serif",
+        padding: "2px 6px",
+        borderRadius: 3,
+        whiteSpace: "nowrap",
+        pointerEvents: "none",
+        zIndex: 20,
+      }}
+    >
+      {value}
+    </div>
+  );
+}
+
+type TabStopMarkerProps = {
+  tabStop: TabStop;
+  positionPx: number;
+  onDoubleClick: () => void;
+};
+
+const TAB_SYMBOLS: Record<string, string> = {
+  left: "L",
+  center: "C",
+  right: "R",
+  decimal: "D",
+  bar: "|",
+};
+
+function TabStopMarker({
+  tabStop,
+  positionPx,
+  onDoubleClick,
+}: TabStopMarkerProps): React.ReactElement {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: formatPx(positionPx - 5),
+        bottom: 0,
+        width: 10,
+        height: 12,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 8,
+        fontWeight: 700,
+        color: "var(--doc-text-muted)",
+        cursor: "pointer",
+        userSelect: "none",
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onDoubleClick();
+      }}
+      title={`${tabStop.alignment} tab at ${(tabStop.position / 1440).toFixed(2)}"`}
+    >
+      {TAB_SYMBOLS[tabStop.alignment] || "L"}
+    </div>
+  );
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+function generateTicks(pageWidthTwips: number, zoom: number, unit: "inch" | "cm"): TickData[] {
+  const ticks: TickData[] = [];
+
+  if (unit === "inch") {
+    const eighthInchTwips = TWIPS_PER_INCH / 8;
+    const totalEighths = Math.ceil(pageWidthTwips / eighthInchTwips);
+    for (let i = 0; i <= totalEighths; i++) {
+      const twipsPos = i * eighthInchTwips;
+      if (twipsPos > pageWidthTwips) break;
+      const pxPos = twipsToPixels(twipsPos) * zoom;
+      if (i % 8 === 0) {
+        ticks.push({ position: pxPos, height: 10, label: i / 8 > 0 ? String(i / 8) : undefined });
+      } else if (i % 4 === 0) {
+        ticks.push({ position: pxPos, height: 6 });
+      } else if (i % 2 === 0) {
+        ticks.push({ position: pxPos, height: 4 });
+      } else {
+        ticks.push({ position: pxPos, height: 2 });
+      }
+    }
+  } else {
+    const mmTwips = TWIPS_PER_CM / 10;
+    const totalMm = Math.ceil(pageWidthTwips / mmTwips);
+    for (let i = 0; i <= totalMm; i++) {
+      const twipsPos = i * mmTwips;
+      if (twipsPos > pageWidthTwips) break;
+      const pxPos = twipsToPixels(twipsPos) * zoom;
+      if (i % 10 === 0) {
+        ticks.push({ position: pxPos, height: 10, label: i / 10 > 0 ? String(i / 10) : undefined });
+      } else if (i % 5 === 0) {
+        ticks.push({ position: pxPos, height: 6 });
+      } else {
+        ticks.push({ position: pxPos, height: 3 });
+      }
+    }
+  }
+
+  return ticks;
+}
+
+export function positionToMargin(
+  positionPx: number,
+  side: "left" | "right",
+  pageWidthPx: number,
+  zoom: number,
+): number {
+  const positionTwips = pixelsToTwips(positionPx / zoom);
+  if (side === "left") return Math.max(0, positionTwips);
+  return Math.max(0, pixelsToTwips(pageWidthPx / zoom) - positionTwips);
+}
+
+export function getRulerDimensions(
+  sectionProps?: SectionProperties | null,
+  zoom: number = 1,
+): { width: number; leftMargin: number; rightMargin: number; contentWidth: number } {
+  const pw = sectionProps?.pageWidth ?? DEFAULT_PAGE_WIDTH_TWIPS;
+  const lm = sectionProps?.marginLeft ?? DEFAULT_MARGIN_TWIPS;
+  const rm = sectionProps?.marginRight ?? DEFAULT_MARGIN_TWIPS;
+  const width = twipsToPixels(pw) * zoom;
+  const leftMargin = twipsToPixels(lm) * zoom;
+  const rightMargin = twipsToPixels(rm) * zoom;
+  return { width, leftMargin, rightMargin, contentWidth: width - leftMargin - rightMargin };
+}
+
+export function getMarginInUnits(marginTwips: number, unit: "inch" | "cm"): string {
+  return unit === "inch"
+    ? (marginTwips / TWIPS_PER_INCH).toFixed(2) + '"'
+    : (marginTwips / TWIPS_PER_CM).toFixed(1) + " cm";
+}
+
+export function parseMarginFromUnits(value: string, unit: "inch" | "cm"): number | null {
+  const num = parseFloat(value.replace(/[^\d.]/g, ""));
+  if (isNaN(num)) return null;
+  return Math.round(num * (unit === "inch" ? TWIPS_PER_INCH : TWIPS_PER_CM));
+}
+
+export default HorizontalRuler;

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -336,12 +336,14 @@ export function HorizontalRuler({
         />
       )}
 
-      {/* Tab stop markers (display only) */}
+      {/* Tab stop markers (display only). TabStop.position is measured from the
+          text area's left edge, so offset by the left margin to place the marker
+          on the physical page; removal still receives the raw text-area position. */}
       {tabStops?.map((tab) => (
         <TabStopMarker
           key={tab.position}
           tabStop={tab}
-          positionPx={twipsToPixels(tab.position) * zoom}
+          positionPx={twipsToPixels(leftMarginTwips + tab.position) * zoom}
           onDoubleClick={() => onTabStopRemove?.(tab.position)}
         />
       ))}

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -1,5 +1,5 @@
 /**
- * HorizontalRuler Component — Google Docs style
+ * HorizontalRuler Component — word-processor style
  *
  * 3 handles only:
  * - Left side: first-line indent (▼ down at top) + left indent (▲ up at bottom)
@@ -289,7 +289,7 @@ export function HorizontalRuler({
         ))}
       </div>
 
-      {/* === 3 INDENT HANDLES (Google Docs style) === */}
+      {/* === 3 INDENT HANDLES (word-processor style) === */}
 
       {/* First-line indent — ▼ down triangle at top-left */}
       {showFirstLineIndent && (
@@ -400,7 +400,7 @@ function RulerTick({ tick }: { tick: TickData }): React.ReactElement {
 }
 
 /**
- * Indent triangle handle — Google Docs style.
+ * Indent triangle handle — word-processor style.
  * direction="down": ▼ anchored at top (first-line indent, right indent)
  * direction="up":   ▲ anchored at bottom (left indent)
  */

--- a/packages/react/src/components/ui/VerticalRuler.tsx
+++ b/packages/react/src/components/ui/VerticalRuler.tsx
@@ -1,0 +1,391 @@
+/**
+ * VerticalRuler Component
+ *
+ * A vertical ruler that displays alongside the document with:
+ * - Page height scale with tick marks
+ * - Top and bottom margin indicators
+ * - Optional dragging to adjust margins
+ * - Support for zoom levels
+ *
+ * Similar to Google Docs' vertical ruler.
+ */
+
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import type { CSSProperties } from "react";
+import type { SectionProperties } from "@stll/folio-core/types/document";
+import { twipsToPixels, pixelsToTwips, formatPx } from "@stll/folio-core/utils/units";
+import { useTranslations } from "use-intl";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type VerticalRulerProps = {
+  /** Section properties for page layout */
+  sectionProps?: SectionProperties | null;
+  /** Zoom level (1.0 = 100%) */
+  zoom?: number;
+  /** Whether margins can be dragged to adjust */
+  editable?: boolean;
+  /** Callback when top margin changes (in twips) */
+  onTopMarginChange?: (marginTwips: number) => void;
+  /** Callback when bottom margin changes (in twips) */
+  onBottomMarginChange?: (marginTwips: number) => void;
+  /** Unit to display (inches or cm) */
+  unit?: "inch" | "cm";
+  /** Additional CSS class name */
+  className?: string;
+  /** Additional inline styles */
+  style?: CSSProperties;
+};
+
+type MarkerType = "topMargin" | "bottomMargin";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_PAGE_HEIGHT_TWIPS = 15840; // 11 inches
+const DEFAULT_MARGIN_TWIPS = 1440; // 1 inch
+const TWIPS_PER_INCH = 1440;
+const TWIPS_PER_CM = 567;
+
+// Ruler styling - Google Docs style
+// Exported so the outline toggle/panel can inset past the vertical ruler
+// (it overlays the editor's left edge) instead of rendering on top of it.
+export const RULER_WIDTH = 20;
+const RULER_TEXT_COLOR = "var(--doc-text-muted)";
+const RULER_TICK_COLOR = "var(--doc-text-subtle)";
+const MARKER_COLOR = "var(--doc-primary)";
+const MARKER_HOVER_COLOR = "var(--doc-primary)";
+const MARKER_ACTIVE_COLOR = "var(--doc-primary-hover)";
+
+function resolveMarkerColor(isDragging: boolean, isHovered: boolean): string {
+  if (isDragging) return MARKER_ACTIVE_COLOR;
+  if (isHovered) return MARKER_HOVER_COLOR;
+  return MARKER_COLOR;
+}
+
+// ============================================================================
+// MAIN COMPONENT
+// ============================================================================
+
+export function VerticalRuler({
+  sectionProps,
+  zoom = 1,
+  editable = false,
+  onTopMarginChange,
+  onBottomMarginChange,
+  unit = "inch",
+  className = "",
+  style,
+}: VerticalRulerProps): React.ReactElement {
+  const t = useTranslations("folio");
+  const [dragging, setDragging] = useState<MarkerType | null>(null);
+  const [hoveredMarker, setHoveredMarker] = useState<MarkerType | null>(null);
+  const rulerRef = useRef<HTMLDivElement>(null);
+
+  // Get page dimensions
+  const pageHeightTwips = sectionProps?.pageHeight ?? DEFAULT_PAGE_HEIGHT_TWIPS;
+  const topMarginTwips = sectionProps?.marginTop ?? DEFAULT_MARGIN_TWIPS;
+  const bottomMarginTwips = sectionProps?.marginBottom ?? DEFAULT_MARGIN_TWIPS;
+
+  // Convert to pixels with zoom
+  const pageHeightPx = twipsToPixels(pageHeightTwips) * zoom;
+  const topMarginPx = twipsToPixels(topMarginTwips) * zoom;
+  const bottomMarginPx = twipsToPixels(bottomMarginTwips) * zoom;
+
+  // Handle drag start
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent, marker: MarkerType) => {
+      if (!editable) return;
+      e.preventDefault();
+      setDragging(marker);
+    },
+    [editable],
+  );
+
+  // Handle drag
+  const handleDrag = useCallback(
+    (e: MouseEvent) => {
+      if (!dragging || !rulerRef.current) return;
+
+      const rect = rulerRef.current.getBoundingClientRect();
+      const y = e.clientY - rect.top;
+
+      const positionTwips = pixelsToTwips(y / zoom);
+
+      if (dragging === "topMargin") {
+        const maxMargin = pageHeightTwips - bottomMarginTwips - 720;
+        const newMargin = Math.max(0, Math.min(positionTwips, maxMargin));
+        onTopMarginChange?.(Math.round(newMargin));
+      } else if (dragging === "bottomMargin") {
+        const fromBottom = pageHeightTwips - positionTwips;
+        const maxMargin = pageHeightTwips - topMarginTwips - 720;
+        const newMargin = Math.max(0, Math.min(fromBottom, maxMargin));
+        onBottomMarginChange?.(Math.round(newMargin));
+      }
+    },
+    [
+      dragging,
+      zoom,
+      pageHeightTwips,
+      topMarginTwips,
+      bottomMarginTwips,
+      onTopMarginChange,
+      onBottomMarginChange,
+    ],
+  );
+
+  // Handle drag end
+  const handleDragEnd = useCallback(() => {
+    setDragging(null);
+  }, []);
+
+  // Add/remove document event listeners
+  useEffect(() => {
+    if (dragging) {
+      document.addEventListener("mousemove", handleDrag);
+      document.addEventListener("mouseup", handleDragEnd);
+      return () => {
+        document.removeEventListener("mousemove", handleDrag);
+        document.removeEventListener("mouseup", handleDragEnd);
+      };
+    }
+    return undefined;
+  }, [dragging, handleDrag, handleDragEnd]);
+
+  // Generate tick marks
+  const ticks = generateVerticalTicks(pageHeightTwips, zoom, unit);
+
+  const rulerStyle: CSSProperties = {
+    position: "relative",
+    width: RULER_WIDTH,
+    height: formatPx(pageHeightPx),
+    backgroundColor: "transparent",
+    overflow: "visible",
+    userSelect: "none",
+    cursor: dragging ? "ns-resize" : "default",
+    ...style,
+  };
+
+  return (
+    <div
+      ref={rulerRef}
+      className={`docx-vertical-ruler ${className}`}
+      style={rulerStyle}
+      role="slider"
+      aria-label={t("ruler.vertical")}
+      aria-orientation="vertical"
+    >
+      {/* Tick marks */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          pointerEvents: "none",
+        }}
+      >
+        {ticks.map((tick, index) => (
+          <VerticalTick key={index} tick={tick} />
+        ))}
+      </div>
+
+      {/* Top margin marker */}
+      <VerticalMarginMarker
+        type="topMargin"
+        position={topMarginPx}
+        editable={editable}
+        isDragging={dragging === "topMargin"}
+        isHovered={hoveredMarker === "topMargin"}
+        onMouseEnter={() => setHoveredMarker("topMargin")}
+        onMouseLeave={() => setHoveredMarker(null)}
+        onMouseDown={(e) => handleDragStart(e, "topMargin")}
+      />
+
+      {/* Bottom margin marker */}
+      <VerticalMarginMarker
+        type="bottomMargin"
+        position={pageHeightPx - bottomMarginPx}
+        editable={editable}
+        isDragging={dragging === "bottomMargin"}
+        isHovered={hoveredMarker === "bottomMargin"}
+        onMouseEnter={() => setHoveredMarker("bottomMargin")}
+        onMouseLeave={() => setHoveredMarker(null)}
+        onMouseDown={(e) => handleDragStart(e, "bottomMargin")}
+      />
+    </div>
+  );
+}
+
+// ============================================================================
+// SUB-COMPONENTS
+// ============================================================================
+
+type VerticalTickData = {
+  position: number;
+  width: number;
+  label?: string | undefined;
+};
+
+function VerticalTick({ tick }: { tick: VerticalTickData }): React.ReactElement {
+  const tickStyle: CSSProperties = {
+    position: "absolute",
+    top: formatPx(tick.position),
+    right: 0,
+    height: 1,
+    width: tick.width,
+    backgroundColor: RULER_TICK_COLOR,
+  };
+
+  const labelStyle: CSSProperties = {
+    position: "absolute",
+    top: formatPx(tick.position),
+    left: 2,
+    transform: "translateY(-50%)",
+    fontSize: "9px",
+    color: RULER_TEXT_COLOR,
+    fontFamily: "sans-serif",
+    whiteSpace: "nowrap",
+  };
+
+  return (
+    <>
+      <div style={tickStyle} />
+      {tick.label && <div style={labelStyle}>{tick.label}</div>}
+    </>
+  );
+}
+
+type VerticalMarginMarkerProps = {
+  type: "topMargin" | "bottomMargin";
+  position: number;
+  editable: boolean;
+  isDragging: boolean;
+  isHovered: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onMouseDown: (e: React.MouseEvent) => void;
+};
+
+function VerticalMarginMarker({
+  type,
+  position,
+  editable,
+  isDragging,
+  isHovered,
+  onMouseEnter,
+  onMouseLeave,
+  onMouseDown,
+}: VerticalMarginMarkerProps): React.ReactElement {
+  const t = useTranslations("folio");
+  const color = resolveMarkerColor(isDragging, isHovered);
+
+  const markerStyle: CSSProperties = {
+    position: "absolute",
+    top: formatPx(position - 5),
+    right: 0,
+    width: RULER_WIDTH,
+    height: 10,
+    cursor: editable ? "ns-resize" : "default",
+    zIndex: isDragging ? 10 : 1,
+  };
+
+  // Triangle pointing left (for top) or right (for bottom)
+  const triangleStyle: CSSProperties = {
+    position: "absolute",
+    top: 0,
+    right: 2,
+    width: 0,
+    height: 0,
+    borderTop: "5px solid transparent",
+    borderBottom: "5px solid transparent",
+    borderRight: `8px solid ${color}`,
+    transition: "border-right-color 0.1s",
+  };
+
+  return (
+    <div
+      className={`docx-ruler-marker docx-ruler-marker-${type}`}
+      style={markerStyle}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onMouseDown={onMouseDown}
+      role="slider"
+      aria-label={type === "topMargin" ? t("ruler.topMargin") : t("ruler.bottomMargin")}
+      aria-orientation="vertical"
+      tabIndex={editable ? 0 : -1}
+    >
+      <div style={triangleStyle} />
+    </div>
+  );
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+function generateVerticalTicks(
+  pageHeightTwips: number,
+  zoom: number,
+  unit: "inch" | "cm",
+): VerticalTickData[] {
+  const ticks: VerticalTickData[] = [];
+
+  if (unit === "inch") {
+    const eighthInchTwips = TWIPS_PER_INCH / 8;
+    const totalEighths = Math.ceil(pageHeightTwips / eighthInchTwips);
+
+    for (let i = 0; i <= totalEighths; i++) {
+      const twipsPos = i * eighthInchTwips;
+      if (twipsPos > pageHeightTwips) break;
+
+      const pxPos = twipsToPixels(twipsPos) * zoom;
+
+      if (i % 8 === 0) {
+        const inches = i / 8;
+        ticks.push({
+          position: pxPos,
+          width: 10,
+          label: inches > 0 ? String(inches) : undefined,
+        });
+      } else if (i % 4 === 0) {
+        ticks.push({ position: pxPos, width: 6 });
+      } else if (i % 2 === 0) {
+        ticks.push({ position: pxPos, width: 4 });
+      } else {
+        ticks.push({ position: pxPos, width: 2 });
+      }
+    }
+  } else {
+    const mmTwips = TWIPS_PER_CM / 10;
+    const totalMm = Math.ceil(pageHeightTwips / mmTwips);
+
+    for (let i = 0; i <= totalMm; i++) {
+      const twipsPos = i * mmTwips;
+      if (twipsPos > pageHeightTwips) break;
+
+      const pxPos = twipsToPixels(twipsPos) * zoom;
+
+      if (i % 10 === 0) {
+        const cm = i / 10;
+        ticks.push({
+          position: pxPos,
+          width: 10,
+          label: cm > 0 ? String(cm) : undefined,
+        });
+      } else if (i % 5 === 0) {
+        ticks.push({ position: pxPos, width: 6 });
+      } else {
+        ticks.push({ position: pxPos, width: 3 });
+      }
+    }
+  }
+
+  return ticks;
+}
+
+export default VerticalRuler;

--- a/packages/react/src/components/ui/VerticalRuler.tsx
+++ b/packages/react/src/components/ui/VerticalRuler.tsx
@@ -10,7 +10,7 @@
  * Similar to Google Docs' vertical ruler.
  */
 
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import type { CSSProperties } from "react";
 import type { SectionProperties } from "@stll/folio-core/types/document";
 import { twipsToPixels, pixelsToTwips, formatPx } from "@stll/folio-core/utils/units";
@@ -95,6 +95,21 @@ export function VerticalRuler({
   const topMarginPx = twipsToPixels(topMarginTwips) * zoom;
   const bottomMarginPx = twipsToPixels(bottomMarginTwips) * zoom;
 
+  // Values handleDrag reads change on every margin update while a drag is in
+  // flight. Stash them in a ref read inside the (stable) handler so the
+  // mousemove/mouseup effect binds document listeners once per drag, not per frame.
+  const dragParams = {
+    dragging,
+    zoom,
+    pageHeightTwips,
+    topMarginTwips,
+    bottomMarginTwips,
+    onTopMarginChange,
+    onBottomMarginChange,
+  };
+  const dragParamsRef = useRef(dragParams);
+  dragParamsRef.current = dragParams;
+
   // Handle drag start
   const handleDragStart = useCallback(
     (e: React.MouseEvent, marker: MarkerType) => {
@@ -106,36 +121,26 @@ export function VerticalRuler({
   );
 
   // Handle drag
-  const handleDrag = useCallback(
-    (e: MouseEvent) => {
-      if (!dragging || !rulerRef.current) return;
+  const handleDrag = useCallback((e: MouseEvent) => {
+    const params = dragParamsRef.current;
+    if (!params.dragging || !rulerRef.current) return;
 
-      const rect = rulerRef.current.getBoundingClientRect();
-      const y = e.clientY - rect.top;
+    const rect = rulerRef.current.getBoundingClientRect();
+    const y = e.clientY - rect.top;
 
-      const positionTwips = pixelsToTwips(y / zoom);
+    const positionTwips = pixelsToTwips(y / params.zoom);
 
-      if (dragging === "topMargin") {
-        const maxMargin = pageHeightTwips - bottomMarginTwips - 720;
-        const newMargin = Math.max(0, Math.min(positionTwips, maxMargin));
-        onTopMarginChange?.(Math.round(newMargin));
-      } else if (dragging === "bottomMargin") {
-        const fromBottom = pageHeightTwips - positionTwips;
-        const maxMargin = pageHeightTwips - topMarginTwips - 720;
-        const newMargin = Math.max(0, Math.min(fromBottom, maxMargin));
-        onBottomMarginChange?.(Math.round(newMargin));
-      }
-    },
-    [
-      dragging,
-      zoom,
-      pageHeightTwips,
-      topMarginTwips,
-      bottomMarginTwips,
-      onTopMarginChange,
-      onBottomMarginChange,
-    ],
-  );
+    if (params.dragging === "topMargin") {
+      const maxMargin = params.pageHeightTwips - params.bottomMarginTwips - 720;
+      const newMargin = Math.max(0, Math.min(positionTwips, maxMargin));
+      params.onTopMarginChange?.(Math.round(newMargin));
+    } else if (params.dragging === "bottomMargin") {
+      const fromBottom = params.pageHeightTwips - positionTwips;
+      const maxMargin = params.pageHeightTwips - params.topMarginTwips - 720;
+      const newMargin = Math.max(0, Math.min(fromBottom, maxMargin));
+      params.onBottomMarginChange?.(Math.round(newMargin));
+    }
+  }, []);
 
   // Handle drag end
   const handleDragEnd = useCallback(() => {
@@ -156,7 +161,10 @@ export function VerticalRuler({
   }, [dragging, handleDrag, handleDragEnd]);
 
   // Generate tick marks
-  const ticks = generateVerticalTicks(pageHeightTwips, zoom, unit);
+  const ticks = useMemo(
+    () => generateVerticalTicks(pageHeightTwips, zoom, unit),
+    [pageHeightTwips, zoom, unit],
+  );
 
   const rulerStyle: CSSProperties = {
     position: "relative",

--- a/packages/react/src/components/ui/VerticalRuler.tsx
+++ b/packages/react/src/components/ui/VerticalRuler.tsx
@@ -7,7 +7,7 @@
  * - Optional dragging to adjust margins
  * - Support for zoom levels
  *
- * Similar to Google Docs' vertical ruler.
+ * Similar to a word processor's vertical ruler.
  */
 
 import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
@@ -50,7 +50,7 @@ const DEFAULT_MARGIN_TWIPS = 1440; // 1 inch
 const TWIPS_PER_INCH = 1440;
 const TWIPS_PER_CM = 567;
 
-// Ruler styling - Google Docs style
+// Ruler styling — word-processor style
 // Exported so the outline toggle/panel can inset past the vertical ruler
 // (it overlays the editor's left edge) instead of rendering on top of it.
 export const RULER_WIDTH = 20;

--- a/packages/react/src/i18n/messages/ar.json
+++ b/packages/react/src/i18n/messages/ar.json
@@ -115,6 +115,16 @@
     "rejectChange": "رفض التغيير",
     "removeLink": "إزالة الرابط",
     "renderErrorDescription": "حدث خطأ ما أثناء عرض هذا الجزء من المستند. أعد تحميل الصفحة، وإذا استمر الأمر فأخبرنا بذلك.",
+    "ruler": {
+      "bottomMargin": "الهامش السفلي",
+      "firstLineIndent": "المسافة البادئة للسطر الأول",
+      "horizontal": "المسطرة الأفقية",
+      "leftIndent": "المسافة البادئة اليسرى",
+      "rightIndent": "المسافة البادئة اليمنى",
+      "toggle": "المسطرة",
+      "topMargin": "الهامش العلوي",
+      "vertical": "المسطرة العمودية"
+    },
     "saveCheckpointFailedDescription": "تم إنشاء ملف DOCX محليًا، لكن تعذّر على stella رفع نقطة الحفظ. أبقِ المحرر مفتوحًا وحاول الحفظ مرة أخرى.",
     "saveCheckpointFailedTitle": "تعذّر رفع الحفظ",
     "saveEditorUnavailableDescription": "المحرر غير جاهز بعد. انتظر حتى ينتهي تحميل المستند، ثم حاول الحفظ مرة أخرى.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "إلغاء القفل للتعديل",
     "unsupportedDocxEditDescription": "يحتوي ملف DOCX هذا على بِنى لا يستطيع Folio إعادة كتابتها بأمان. لتجنّب إتلاف الملف، نزّله وعدّله في Word.",
     "unsupportedDocxEditTitle": "التعديل محظور",
+    "viewGroup": "عرض",
     "zoomGroup": "تكبير/تصغير"
   }
 }

--- a/packages/react/src/i18n/messages/cs.json
+++ b/packages/react/src/i18n/messages/cs.json
@@ -115,6 +115,16 @@
     "rejectChange": "Odmítnout změnu",
     "removeLink": "Odebrat odkaz",
     "renderErrorDescription": "Při vykreslování této komponenty došlo k chybě. Zkuste to znovu nebo kontaktujte podporu, pokud problém přetrvává.",
+    "ruler": {
+      "bottomMargin": "Dolní okraj",
+      "firstLineIndent": "Odsazení prvního řádku",
+      "horizontal": "Vodorovné pravítko",
+      "leftIndent": "Odsazení zleva",
+      "rightIndent": "Odsazení zprava",
+      "toggle": "Pravítko",
+      "topMargin": "Horní okraj",
+      "vertical": "Svislé pravítko"
+    },
     "saveCheckpointFailedDescription": "DOCX se lokálně vytvořil, ale Stelle se nepodařilo nahrát checkpoint. Nechte editor otevřený a zkuste uložit znovu.",
     "saveCheckpointFailedTitle": "Uložení se nepodařilo nahrát",
     "saveEditorUnavailableDescription": "Editor ještě není připravený. Počkejte, až se dokument načte, a zkuste uložit znovu.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Odemknout pro možnost úprav",
     "unsupportedDocxEditDescription": "Tento DOCX obsahuje struktury, které Folio neumí bezpečně přepsat. Aby se soubor nepoškodil, stáhněte ho a upravte ve Wordu.",
     "unsupportedDocxEditTitle": "Úpravy zablokovány",
+    "viewGroup": "Zobrazení",
     "zoomGroup": "Přiblížení"
   }
 }

--- a/packages/react/src/i18n/messages/de.json
+++ b/packages/react/src/i18n/messages/de.json
@@ -115,6 +115,16 @@
     "rejectChange": "Änderung ablehnen",
     "removeLink": "Link entfernen",
     "renderErrorDescription": "Beim Rendern dieser Komponente ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support, falls das Problem weiterhin besteht.",
+    "ruler": {
+      "bottomMargin": "Unterer Rand",
+      "firstLineIndent": "Erstzeileneinzug",
+      "horizontal": "Horizontales Lineal",
+      "leftIndent": "Linker Einzug",
+      "rightIndent": "Rechter Einzug",
+      "toggle": "Lineal",
+      "topMargin": "Oberer Rand",
+      "vertical": "Vertikales Lineal"
+    },
     "saveCheckpointFailedDescription": "Die DOCX-Datei wurde lokal erstellt, aber stella konnte den Speicherpunkt nicht hochladen. Lassen Sie den Editor geöffnet und versuchen Sie erneut zu speichern.",
     "saveCheckpointFailedTitle": "Speicherstand konnte nicht hochgeladen werden",
     "saveEditorUnavailableDescription": "Der Editor ist noch nicht bereit. Warten Sie, bis das Dokument vollständig geladen ist, und versuchen Sie dann erneut zu speichern.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Zum Bearbeiten entsperren",
     "unsupportedDocxEditDescription": "Diese DOCX enthält Strukturen, die Folio nicht sicher umschreiben kann. Laden Sie sie herunter und bearbeiten Sie sie in Word, um eine Beschädigung der Datei zu vermeiden.",
     "unsupportedDocxEditTitle": "Bearbeitung gesperrt",
+    "viewGroup": "Ansicht",
     "zoomGroup": "Zoomstufe"
   }
 }

--- a/packages/react/src/i18n/messages/en.json
+++ b/packages/react/src/i18n/messages/en.json
@@ -115,6 +115,16 @@
     "rejectChange": "Reject Change",
     "removeLink": "Remove link",
     "renderErrorDescription": "Something went wrong showing this part of the document. Reload the page — if it keeps happening, let us know.",
+    "ruler": {
+      "bottomMargin": "Bottom margin",
+      "firstLineIndent": "First line indent",
+      "horizontal": "Horizontal ruler",
+      "leftIndent": "Left indent",
+      "rightIndent": "Right indent",
+      "toggle": "Ruler",
+      "topMargin": "Top margin",
+      "vertical": "Vertical ruler"
+    },
     "saveCheckpointFailedDescription": "The DOCX was created locally, but stella could not upload the checkpoint. Keep the editor open and try saving again.",
     "saveCheckpointFailedTitle": "Could not upload save",
     "saveEditorUnavailableDescription": "The editor is not ready yet. Wait for the document to finish loading, then try saving again.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Unlock to edit",
     "unsupportedDocxEditDescription": "This DOCX contains structures Folio cannot safely rewrite. To avoid corrupting the file, download it and edit it in Word.",
     "unsupportedDocxEditTitle": "Editing blocked",
+    "viewGroup": "View",
     "zoomGroup": "Zoom"
   }
 }

--- a/packages/react/src/i18n/messages/es.json
+++ b/packages/react/src/i18n/messages/es.json
@@ -115,6 +115,16 @@
     "rejectChange": "Rechazar cambio",
     "removeLink": "Eliminar enlace",
     "renderErrorDescription": "Se produjo un error al renderizar este componente. Inténtalo de nuevo o contacta con soporte si el problema persiste.",
+    "ruler": {
+      "bottomMargin": "Margen inferior",
+      "firstLineIndent": "Sangría de primera línea",
+      "horizontal": "Regla horizontal",
+      "leftIndent": "Sangría izquierda",
+      "rightIndent": "Sangría derecha",
+      "toggle": "Regla",
+      "topMargin": "Margen superior",
+      "vertical": "Regla vertical"
+    },
     "saveCheckpointFailedDescription": "El DOCX se creó localmente, pero stella no pudo subir el punto de control. Mantén el editor abierto e intenta guardar de nuevo.",
     "saveCheckpointFailedTitle": "No se pudo subir el guardado",
     "saveEditorUnavailableDescription": "El editor aún no está listo. Espera a que el documento termine de cargarse y vuelve a intentar guardar.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Desbloquear para editar",
     "unsupportedDocxEditDescription": "Este DOCX contiene estructuras que Folio no puede reescribir de forma segura. Para no dañar el archivo, descárgalo y edítalo en Word.",
     "unsupportedDocxEditTitle": "Edición bloqueada",
+    "viewGroup": "Vista",
     "zoomGroup": "Nivel de zoom"
   }
 }

--- a/packages/react/src/i18n/messages/et.json
+++ b/packages/react/src/i18n/messages/et.json
@@ -115,6 +115,16 @@
     "rejectChange": "Lükka muudatus tagasi",
     "removeLink": "Eemalda link",
     "renderErrorDescription": "Selle komponendi kuvamisel tekkis viga. Proovige uuesti või võtke ühendust toega, kui probleem püsib.",
+    "ruler": {
+      "bottomMargin": "Alaveeris",
+      "firstLineIndent": "Esimese rea taane",
+      "horizontal": "Horisontaalne joonlaud",
+      "leftIndent": "Vasak taane",
+      "rightIndent": "Parem taane",
+      "toggle": "Joonlaud",
+      "topMargin": "Ülaveeris",
+      "vertical": "Vertikaalne joonlaud"
+    },
     "saveCheckpointFailedDescription": "DOCX loodi kohapeal, kuid stella ei saanud kontrollpunkti üles laadida. Hoia redaktor avatuna ja proovi uuesti salvestada.",
     "saveCheckpointFailedTitle": "Salvestust ei saanud üles laadida",
     "saveEditorUnavailableDescription": "Redaktor pole veel valmis. Oota, kuni dokument on laadinud, ja proovi siis uuesti salvestada.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Ava muutmiseks",
     "unsupportedDocxEditDescription": "See DOCX sisaldab struktuure, mida Folio ei suuda turvaliselt ümber kirjutada. Faili rikkumise vältimiseks laadi see alla ja muuda Wordis.",
     "unsupportedDocxEditTitle": "Muutmine on blokeeritud",
+    "viewGroup": "Vaade",
     "zoomGroup": "Suum"
   }
 }

--- a/packages/react/src/i18n/messages/fr.json
+++ b/packages/react/src/i18n/messages/fr.json
@@ -115,6 +115,16 @@
     "rejectChange": "Rejeter la modification",
     "removeLink": "Supprimer le lien",
     "renderErrorDescription": "Une erreur s'est produite lors du rendu de ce composant. Réessayez ou contactez le support si le problème persiste.",
+    "ruler": {
+      "bottomMargin": "Marge inférieure",
+      "firstLineIndent": "Retrait de première ligne",
+      "horizontal": "Règle horizontale",
+      "leftIndent": "Retrait à gauche",
+      "rightIndent": "Retrait à droite",
+      "toggle": "Règle",
+      "topMargin": "Marge supérieure",
+      "vertical": "Règle verticale"
+    },
     "saveCheckpointFailedDescription": "Le DOCX a été créé localement, mais stella n’a pas pu téléverser le point de sauvegarde. Laissez l’éditeur ouvert et réessayez d’enregistrer.",
     "saveCheckpointFailedTitle": "Impossible de téléverser la sauvegarde",
     "saveEditorUnavailableDescription": "L’éditeur n’est pas encore prêt. Attendez la fin du chargement du document, puis réessayez d’enregistrer.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Déverrouiller pour modifier",
     "unsupportedDocxEditDescription": "Ce fichier DOCX contient des structures que Folio ne peut pas réécrire sans risque. Pour éviter de corrompre le fichier, téléchargez-le et modifiez-le dans Word.",
     "unsupportedDocxEditTitle": "Modification bloquée",
+    "viewGroup": "Affichage",
     "zoomGroup": "Niveau de zoom"
   }
 }

--- a/packages/react/src/i18n/messages/hu.json
+++ b/packages/react/src/i18n/messages/hu.json
@@ -115,6 +115,16 @@
     "rejectChange": "Módosítás elutasítása",
     "removeLink": "Hivatkozás eltávolítása",
     "renderErrorDescription": "Hiba történt az összetevő megjelenítése közben. Próbálja újra, vagy forduljon az ügyfélszolgálathoz, ha a probléma továbbra is fennáll.",
+    "ruler": {
+      "bottomMargin": "Alsó margó",
+      "firstLineIndent": "Első sor behúzása",
+      "horizontal": "Vízszintes vonalzó",
+      "leftIndent": "Bal oldali behúzás",
+      "rightIndent": "Jobb oldali behúzás",
+      "toggle": "Vonalzó",
+      "topMargin": "Felső margó",
+      "vertical": "Függőleges vonalzó"
+    },
     "saveCheckpointFailedDescription": "A DOCX helyben létrejött, de a stella nem tudta feltölteni a mentési pontot. Hagyja nyitva a szerkesztőt, és próbálja újra a mentést.",
     "saveCheckpointFailedTitle": "A mentés feltöltése sikertelen",
     "saveEditorUnavailableDescription": "A szerkesztő még nem áll készen. Várja meg, amíg a dokumentum betöltődik, majd próbálja újra a mentést.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Feloldás szerkesztéshez",
     "unsupportedDocxEditDescription": "Ez a DOCX olyan szerkezeteket tartalmaz, amelyeket a Folio nem tud biztonságosan átírni. A fájl sérülésének elkerülése érdekében töltse le, és szerkessze Wordben.",
     "unsupportedDocxEditTitle": "A szerkesztés letiltva",
+    "viewGroup": "Nézet",
     "zoomGroup": "Nagyítás"
   }
 }

--- a/packages/react/src/i18n/messages/lt.json
+++ b/packages/react/src/i18n/messages/lt.json
@@ -115,6 +115,16 @@
     "rejectChange": "Atmesti keitimą",
     "removeLink": "Pašalinti nuorodą",
     "renderErrorDescription": "Atvaizduojant šį komponentą įvyko klaida. Bandykite dar kartą arba susisiekite su pagalba, jei problema kartojasi.",
+    "ruler": {
+      "bottomMargin": "Apatinė paraštė",
+      "firstLineIndent": "Pirmosios eilutės įtrauka",
+      "horizontal": "Horizontali liniuotė",
+      "leftIndent": "Kairioji įtrauka",
+      "rightIndent": "Dešinioji įtrauka",
+      "toggle": "Liniuotė",
+      "topMargin": "Viršutinė paraštė",
+      "vertical": "Vertikali liniuotė"
+    },
     "saveCheckpointFailedDescription": "DOCX buvo sukurtas vietiniame įrenginyje, tačiau stella nepavyko įkelti kontrolinio taško. Palikite redaktorių atidarytą ir bandykite išsaugoti dar kartą.",
     "saveCheckpointFailedTitle": "Nepavyko įkelti išsaugojimo",
     "saveEditorUnavailableDescription": "Redaktorius dar nepasiruošęs. Palaukite, kol dokumentas bus įkeltas, ir bandykite išsaugoti dar kartą.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Atrakinti redagavimui",
     "unsupportedDocxEditDescription": "Šiame DOCX yra struktūrų, kurių Folio negali saugiai perrašyti. Kad failas nesugadintumėte, atsisiųskite jį ir redaguokite programoje Word.",
     "unsupportedDocxEditTitle": "Redagavimas užblokuotas",
+    "viewGroup": "Rodinys",
     "zoomGroup": "Mastelis"
   }
 }

--- a/packages/react/src/i18n/messages/lv.json
+++ b/packages/react/src/i18n/messages/lv.json
@@ -115,6 +115,16 @@
     "rejectChange": "Noraidīt izmaiņu",
     "removeLink": "Noņemt saiti",
     "renderErrorDescription": "Renderējot šo komponentu, radās kļūda. Mēģiniet vēlreiz vai sazinieties ar atbalstu, ja problēma atkārtojas.",
+    "ruler": {
+      "bottomMargin": "Apakšējā mala",
+      "firstLineIndent": "Pirmās rindas atkāpe",
+      "horizontal": "Horizontālais lineāls",
+      "leftIndent": "Kreisā atkāpe",
+      "rightIndent": "Labā atkāpe",
+      "toggle": "Lineāls",
+      "topMargin": "Augšējā mala",
+      "vertical": "Vertikālais lineāls"
+    },
     "saveCheckpointFailedDescription": "DOCX tika izveidots lokāli, taču stella nevarēja augšupielādēt kontrolpunktu. Atstājiet redaktoru atvērtu un mēģiniet saglabāt vēlreiz.",
     "saveCheckpointFailedTitle": "Neizdevās augšupielādēt saglabāto",
     "saveEditorUnavailableDescription": "Redaktors vēl nav gatavs. Pagaidiet, līdz dokuments ir ielādēts, un tad mēģiniet saglabāt vēlreiz.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Atbloķēt rediģēšanai",
     "unsupportedDocxEditDescription": "Šajā DOCX failā ir struktūras, ko Folio nevar droši pārrakstīt. Lai nesabojātu failu, lejupielādējiet to un rediģējiet programmā Word.",
     "unsupportedDocxEditTitle": "Rediģēšana bloķēta",
+    "viewGroup": "Skats",
     "zoomGroup": "Tālummaiņa"
   }
 }

--- a/packages/react/src/i18n/messages/pl.json
+++ b/packages/react/src/i18n/messages/pl.json
@@ -115,6 +115,16 @@
     "rejectChange": "Odrzuć zmianę",
     "removeLink": "Usuń link",
     "renderErrorDescription": "Wystąpił błąd podczas renderowania tego komponentu. Spróbuj ponownie albo skontaktuj się z pomocą techniczną, jeśli problem będzie się powtarzał.",
+    "ruler": {
+      "bottomMargin": "Margines dolny",
+      "firstLineIndent": "Wcięcie pierwszego wiersza",
+      "horizontal": "Linijka pozioma",
+      "leftIndent": "Wcięcie z lewej",
+      "rightIndent": "Wcięcie z prawej",
+      "toggle": "Linijka",
+      "topMargin": "Margines górny",
+      "vertical": "Linijka pionowa"
+    },
     "saveCheckpointFailedDescription": "Plik DOCX został utworzony lokalnie, ale stella nie mogła przesłać punktu kontrolnego. Pozostaw edytor otwarty i spróbuj zapisać ponownie.",
     "saveCheckpointFailedTitle": "Nie udało się przesłać zapisu",
     "saveEditorUnavailableDescription": "Edytor nie jest jeszcze gotowy. Poczekaj, aż dokument zakończy ładowanie, a następnie spróbuj zapisać ponownie.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Odblokuj, aby edytować",
     "unsupportedDocxEditDescription": "Ten plik DOCX zawiera struktury, których Folio nie może bezpiecznie przepisać. Aby nie uszkodzić pliku, pobierz go i edytuj w programie Word.",
     "unsupportedDocxEditTitle": "Edycja zablokowana",
+    "viewGroup": "Widok",
     "zoomGroup": "Powiększenie"
   }
 }

--- a/packages/react/src/i18n/messages/pt-BR.json
+++ b/packages/react/src/i18n/messages/pt-BR.json
@@ -115,6 +115,16 @@
     "rejectChange": "Rejeitar alteração",
     "removeLink": "Remover link",
     "renderErrorDescription": "Ocorreu um erro ao renderizar este componente. Tente novamente ou entre em contato com o suporte se o problema persistir.",
+    "ruler": {
+      "bottomMargin": "Margem inferior",
+      "firstLineIndent": "Recuo da primeira linha",
+      "horizontal": "Régua horizontal",
+      "leftIndent": "Recuo à esquerda",
+      "rightIndent": "Recuo à direita",
+      "toggle": "Régua",
+      "topMargin": "Margem superior",
+      "vertical": "Régua vertical"
+    },
     "saveCheckpointFailedDescription": "O DOCX foi criado localmente, mas stella não conseguiu fazer upload do checkpoint. Mantenha o editor aberto e tente salvar novamente.",
     "saveCheckpointFailedTitle": "Não foi possível fazer upload do salvamento",
     "saveEditorUnavailableDescription": "O editor ainda não está pronto. Aguarde o documento terminar de carregar e tente salvar novamente.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Desbloquear para editar",
     "unsupportedDocxEditDescription": "Este DOCX contém estruturas que o Folio não pode reescrever com segurança. Para evitar corromper o arquivo, baixe-o e edite-o no Word.",
     "unsupportedDocxEditTitle": "Edição bloqueada",
+    "viewGroup": "Exibir",
     "zoomGroup": "Nível de zoom"
   }
 }

--- a/packages/react/src/i18n/messages/sk.json
+++ b/packages/react/src/i18n/messages/sk.json
@@ -115,6 +115,16 @@
     "rejectChange": "Odmietnuť zmenu",
     "removeLink": "Odstrániť odkaz",
     "renderErrorDescription": "Pri vykresľovaní tejto komponenty došlo k chybe. Skúste to znova alebo kontaktujte podporu, ak problém pretrváva.",
+    "ruler": {
+      "bottomMargin": "Dolný okraj",
+      "firstLineIndent": "Odsadenie prvého riadka",
+      "horizontal": "Vodorovné pravítko",
+      "leftIndent": "Odsadenie zľava",
+      "rightIndent": "Odsadenie sprava",
+      "toggle": "Pravítko",
+      "topMargin": "Horný okraj",
+      "vertical": "Zvislé pravítko"
+    },
     "saveCheckpointFailedDescription": "DOCX bol vytvorený lokálne, ale Stelle sa nepodarilo nahrať kontrolný bod. Nechajte editor otvorený a skúste uložiť znova.",
     "saveCheckpointFailedTitle": "Uloženie sa nepodarilo nahrať",
     "saveEditorUnavailableDescription": "Editor ešte nie je pripravený. Počkajte, kým sa dokument načíta, a skúste uložiť znova.",
@@ -144,6 +154,7 @@
     "unlockForEditing": "Odomknúť pre úpravy",
     "unsupportedDocxEditDescription": "Tento DOCX obsahuje štruktúry, ktoré Folio nedokáže bezpečne prepísať. Aby sa súbor nepoškodil, stiahnite ho a upravte vo Worde.",
     "unsupportedDocxEditTitle": "Úpravy zablokované",
+    "viewGroup": "Zobraziť",
     "zoomGroup": "Priblíženie"
   }
 }

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -405,7 +405,7 @@ type TextInputDispatchTarget<TView> = {
 // =============================================================================
 
 export const DEFAULT_PAGE_GAP = 24;
-const COMMENTS_SIDEBAR_SCROLL_GUTTER = 304;
+export const COMMENTS_SIDEBAR_SCROLL_GUTTER = 304;
 
 /** Distance in px from a row/column boundary that triggers the insert button */
 /** Distance in px from the table edge where boundary detection is active */


### PR DESCRIPTION
Restores the on-screen horizontal and vertical rulers as an opt-in feature.

- `showRuler` / `rulerUnit` props (default off), plus a **View** toggle button in the toolbar to show/hide the rulers at runtime.
- Ruler components ported from the upstream `@eigenpal/docx-editor` React package and adapted to folio's shell: twips↔px math, inch/cm tick generation, margin-zone drag, left / right / first-line indent drag with hanging-indent encoding, and tab-stop double-click-to-remove.
- Horizontal ruler is a sticky centered row in the scroll container; vertical ruler is left-aligned in the content area. Offsets track zoom and the comments-sidebar gutter so alignment holds.
- Playground enables `showRuler` so the demo shows rulers by default.

Behavior matches upstream, including that the first-line-indent handle is not rendered by default (the handler is wired; enabling it is a one-prop change). Opt-in by handler, mirroring the previously restored Zoom and Insert controls.
