### PR TITLE
fix(react): position the header/footer edit label outside the content, not over it

### DIFF
--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -134,10 +134,17 @@ export function InlineHeaderFooterEditor({
     };
     computePosition();
 
+    // The HF box grows/shrinks as the user types, and the footer bar is
+    // anchored to the box bottom (`top: 100%`), so the overlay height must
+    // track the box — recompute on target resize, not just scroll/window.
+    const resizeObserver = new ResizeObserver(computePosition);
+    resizeObserver.observe(targetElement);
+
     const scrollParent = parentElement.closest('[style*="overflow"]') || parentElement;
     scrollParent.addEventListener("scroll", computePosition);
     window.addEventListener("resize", computePosition);
     return () => {
+      resizeObserver.disconnect();
       scrollParent.removeEventListener("scroll", computePosition);
       window.removeEventListener("resize", computePosition);
     };

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -265,6 +265,7 @@ export function InlineHeaderFooterEditor({
         <div className="hf-separator-bar" style={footerBarStyle}>
           <span style={labelStyle}>{label}</span>
           <OptionsMenu
+            position={position}
             label={label}
             showOptions={showOptions}
             setShowOptions={setShowOptions}
@@ -280,6 +281,7 @@ export function InlineHeaderFooterEditor({
         <div className="hf-separator-bar" style={separatorBarStyle}>
           <span style={labelStyle}>{label}</span>
           <OptionsMenu
+            position={position}
             label={label}
             showOptions={showOptions}
             setShowOptions={setShowOptions}
@@ -299,6 +301,7 @@ export function InlineHeaderFooterEditor({
 // ============================================================================
 
 function OptionsMenu({
+  position,
   label,
   showOptions,
   setShowOptions,
@@ -307,6 +310,7 @@ function OptionsMenu({
   onClose,
   getActiveView,
 }: {
+  position: "header" | "footer";
   label: string;
   showOptions: boolean;
   setShowOptions: (v: boolean | ((prev: boolean) => boolean)) => void;
@@ -347,7 +351,9 @@ function OptionsMenu({
         Options ▾
       </button>
       {showOptions && (
-        <div className="hf-options-dropdown">
+        <div
+          className={`hf-options-dropdown${position === "footer" ? " hf-options-dropdown--up" : ""}`}
+        >
           <button
             type="button"
             className="hf-options-item"

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -67,6 +67,14 @@ export type InlineHeaderFooterEditorRef = {
 // ============================================================================
 
 const separatorBarStyle: CSSProperties = {
+  position: "absolute",
+  left: 0,
+  right: 0,
+  // Anchor the bar's bottom edge to the container's top so the "Header" label
+  // and Options sit ABOVE the painted HF content. The painter shows through the
+  // overlay now, so an in-flow bar would render right on top of the first row
+  // of HF text; hoisting it outside the content box keeps them from overlapping.
+  bottom: "100%",
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
@@ -74,7 +82,14 @@ const separatorBarStyle: CSSProperties = {
   fontSize: 11,
   color: "var(--doc-link)",
   userSelect: "none",
+  // Container is pointer-events: none so the painter beneath receives clicks;
+  // restore events on the chrome bar so the label + Options stay interactive.
+  pointerEvents: "auto",
 };
+
+// Footer bar mirrors the header bar but sits BELOW its painted content (its top
+// edge anchored to the container's bottom) so it never overlaps the footer text.
+const footerBarStyle: CSSProperties = { ...separatorBarStyle, bottom: "auto", top: "100%" };
 
 const labelStyle: CSSProperties = {
   fontWeight: 500,
@@ -103,6 +118,7 @@ export function InlineHeaderFooterEditor({
     top: number;
     left: number;
     width: number;
+    height: number;
   } | null>(null);
 
   useEffect(() => {
@@ -113,6 +129,7 @@ export function InlineHeaderFooterEditor({
         top: targetRect.top - parentRect.top + parentElement.scrollTop,
         left: targetRect.left - parentRect.left + parentElement.scrollLeft,
         width: targetRect.width,
+        height: targetRect.height,
       });
     };
     computePosition();
@@ -224,6 +241,10 @@ export function InlineHeaderFooterEditor({
     top: overlayPos.top,
     left: overlayPos.left,
     width: overlayPos.width,
+    // Match the painted HF rect height so the chrome bar (anchored via
+    // `bottom: 100%` for the header, `top: 100%` for the footer) sits flush
+    // against the content box instead of collapsing onto the first text row.
+    height: overlayPos.height,
     zIndex: 10,
     // No pointer events on the chrome container itself — the painted HF
     // beneath must receive clicks so the pointer pipeline routes them to
@@ -234,7 +255,7 @@ export function InlineHeaderFooterEditor({
   return (
     <div role="presentation" className="hf-inline-editor" style={containerStyle}>
       {position === "footer" && (
-        <div className="hf-separator-bar" style={{ ...separatorBarStyle, pointerEvents: "auto" }}>
+        <div className="hf-separator-bar" style={footerBarStyle}>
           <span style={labelStyle}>{label}</span>
           <OptionsMenu
             label={label}
@@ -249,7 +270,7 @@ export function InlineHeaderFooterEditor({
       )}
 
       {position === "header" && (
-        <div className="hf-separator-bar" style={{ ...separatorBarStyle, pointerEvents: "auto" }}>
+        <div className="hf-separator-bar" style={separatorBarStyle}>
           <span style={labelStyle}>{label}</span>
           <OptionsMenu
             label={label}

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -102,6 +102,14 @@
   box-shadow: 0 2px 6px var(--doc-shadow-sm);
 }
 
+/* Footer options open upward: the footer bar sits below its content, so a
+   downward menu near the bottom of a page would push Remove/Close past the
+   page extent and clip them. */
+.hf-options-dropdown--up {
+  top: auto;
+  bottom: 100%;
+}
+
 .hf-options-item {
   display: block;
   width: 100%;


### PR DESCRIPTION
While editing a header/footer, the blue "Header"/"Footer" label + Options bar rendered in-flow at the top of the painted HF box — i.e. right on the first row of header/footer text — so the label overlapped the content.

Since the painter now shows through the chrome overlay (post-eigenpal#611), the bar has to be hoisted outside the content box. Match upstream's positioning:

- Give the overlay container the painted HF rect `height` (measured in `computePosition`).
- Anchor the header bar to the container's top edge (`position: absolute; bottom: 100%`) so it sits **above** the content; a `footerBarStyle` variant anchors the footer bar **below** (`top: 100%`).
- Bake `pointerEvents: "auto"` into the bar style (the container stays `pointer-events: none` so painter clicks still route to the HF editor).

One file; positioning/CSS only.
