### PR TITLE
fix(core): persist footnote/endnote body edits on save

### DIFF
--- a/packages/core/src/docx/noteSave.test.ts
+++ b/packages/core/src/docx/noteSave.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Round-trip tests for the footnote/endnote body write path.
+ *
+ * Parses a DOCX carrying a footnote and an endnote (each with the separator
+ * notes Word requires), mutates a note body in the model, runs the selective
+ * save, re-parses, and asserts:
+ * - the edited note text persists on save, and
+ * - the UNEDITED note part plus every other part (document.xml, styles.xml,
+ *   the separator notes) stay byte-exact.
+ *
+ * Regression guard: a save that changes only a body paragraph must leave both
+ * note parts verbatim (the write path only fires when a note body changed).
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { Endnote, Footnote } from "../types/document";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { attemptSelectiveSave } from "./selectiveSave";
+
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+// A footnotes part with the two separator notes Word always emits (ids -1 / 0)
+// followed by one normal note whose paragraph carries a paraId so the selective
+// patch can target it. `ORIGINAL_FOOTNOTE_TEXT` is the editable body text.
+const ORIGINAL_FOOTNOTE_TEXT = "Original footnote body";
+const FOOTNOTE_PARA_ID = "F1000001";
+const FOOTNOTE_SEPARATORS =
+  '<w:footnote w:type="separator" w:id="-1"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:separator/></w:r></w:p></w:footnote>' +
+  '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>';
+
+const footnotesXml = `${XML_DECLARATION}
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${FOOTNOTE_SEPARATORS}<w:footnote w:id="1"><w:p w14:paraId="${FOOTNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr><w:r><w:t xml:space="preserve">${ORIGINAL_FOOTNOTE_TEXT}</w:t></w:r></w:p></w:footnote></w:footnotes>`;
+
+const ORIGINAL_ENDNOTE_TEXT = "Original endnote body";
+const ENDNOTE_PARA_ID = "E1000001";
+const ENDNOTE_SEPARATORS =
+  '<w:endnote w:type="separator" w:id="-1"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:separator/></w:r></w:p></w:endnote>' +
+  '<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>';
+
+const endnotesXml = `${XML_DECLARATION}
+<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${ENDNOTE_SEPARATORS}<w:endnote w:id="1"><w:p w14:paraId="${ENDNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr><w:r><w:t xml:space="preserve">${ORIGINAL_ENDNOTE_TEXT}</w:t></w:r></w:p></w:endnote></w:endnotes>`;
+
+const BODY_PARA_ID = "B0000001";
+const documentXml = `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p w14:paraId="${BODY_PARA_ID}"><w:r><w:t xml:space="preserve">Body text</w:t></w:r><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r><w:r><w:endnoteReference w:id="1"/></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const stylesXml = `${XML_DECLARATION}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="FootnoteText"><w:name w:val="footnote text"/></w:style>
+  <w:style w:type="paragraph" w:styleId="EndnoteText"><w:name w:val="endnote text"/></w:style>
+</w:styles>`;
+
+const corePropertiesXml = `${XML_DECLARATION}
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dcterms:modified xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00.000Z</dcterms:modified>
+</cp:coreProperties>`;
+
+const contentTypesXml = `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>
+  <Override PartName="/word/endnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+</Types>`;
+
+const packageRelsXml = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+</Relationships>`;
+
+const documentRelsXml = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.footnotes}" Target="footnotes.xml"/>
+  <Relationship Id="rId2" Type="${RELATIONSHIP_TYPES.endnotes}" Target="endnotes.xml"/>
+</Relationships>`;
+
+async function createNotesFixture(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypesXml);
+  zip.file("_rels/.rels", packageRelsXml);
+  zip.file("word/_rels/document.xml.rels", documentRelsXml);
+  zip.file("word/document.xml", documentXml);
+  zip.file("word/styles.xml", stylesXml);
+  zip.file("word/footnotes.xml", footnotesXml);
+  zip.file("word/endnotes.xml", endnotesXml);
+  zip.file("docProps/core.xml", corePropertiesXml);
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+async function readPart(buffer: ArrayBuffer, path: string): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(path);
+  if (!file) {
+    throw new Error(`No ${path} in package`);
+  }
+  return file.async("text");
+}
+
+function setFirstNoteText(note: Footnote | Endnote, newText: string): void {
+  const block = note.content[0];
+  if (!block || block.type !== "paragraph") {
+    throw new Error("expected a paragraph as the note's first block");
+  }
+  for (const item of block.content) {
+    if (item.type !== "run") {
+      continue;
+    }
+    for (const runContent of item.content) {
+      if (runContent.type === "text") {
+        runContent.text = newText;
+        return;
+      }
+    }
+  }
+  throw new Error("expected a text run in the note paragraph");
+}
+
+describe("footnote / endnote body write path (selective save)", () => {
+  test("edited footnote body persists; endnote and other parts stay byte-exact", async () => {
+    const buffer = await createNotesFixture();
+    const originalEndnotesXml = await readPart(buffer, "word/endnotes.xml");
+    const originalDocumentXml = await readPart(buffer, "word/document.xml");
+    const originalStylesXml = await readPart(buffer, "word/styles.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    expect(doc.package.footnotes?.length).toBe(1);
+
+    const footnote = doc.package.footnotes?.[0];
+    if (!footnote) {
+      throw new Error("expected a parsed footnote");
+    }
+    const editedText = "Edited footnote body";
+    setFirstNoteText(footnote, editedText);
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set([FOOTNOTE_PARA_ID]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+
+    // The edited footnote text round-trips through re-parse.
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    const reparsedFootnote = reparsed.package.footnotes?.[0];
+    const footnoteText = reparsedFootnote?.content
+      .flatMap((block) => (block.type === "paragraph" ? block.content : []))
+      .flatMap((item) => (item.type === "run" ? item.content : []))
+      .filter((rc) => rc.type === "text")
+      .map((rc) => (rc.type === "text" ? rc.text : ""))
+      .join("");
+    expect(footnoteText).toBe(editedText);
+
+    // The unedited endnote part and other parts are untouched.
+    expect(await readPart(result, "word/endnotes.xml")).toBe(originalEndnotesXml);
+    expect(await readPart(result, "word/document.xml")).toBe(originalDocumentXml);
+    expect(await readPart(result, "word/styles.xml")).toBe(originalStylesXml);
+
+    // Within footnotes.xml, the required separator notes stay byte-exact and
+    // the old body text is gone, replaced by the edit.
+    const savedFootnotesXml = await readPart(result, "word/footnotes.xml");
+    expect(savedFootnotesXml).toContain(FOOTNOTE_SEPARATORS);
+    expect(savedFootnotesXml).toContain(editedText);
+    expect(savedFootnotesXml).not.toContain(ORIGINAL_FOOTNOTE_TEXT);
+  });
+
+  test("edited endnote body persists; footnote and other parts stay byte-exact", async () => {
+    const buffer = await createNotesFixture();
+    const originalFootnotesXml = await readPart(buffer, "word/footnotes.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const endnote = doc.package.endnotes?.[0];
+    if (!endnote) {
+      throw new Error("expected a parsed endnote");
+    }
+    const editedText = "Edited endnote body";
+    setFirstNoteText(endnote, editedText);
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set([ENDNOTE_PARA_ID]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    const endnoteText = reparsed.package.endnotes?.[0]?.content
+      .flatMap((block) => (block.type === "paragraph" ? block.content : []))
+      .flatMap((item) => (item.type === "run" ? item.content : []))
+      .filter((rc) => rc.type === "text")
+      .map((rc) => (rc.type === "text" ? rc.text : ""))
+      .join("");
+    expect(endnoteText).toBe(editedText);
+
+    // The footnote part is untouched when only an endnote changed.
+    expect(await readPart(result, "word/footnotes.xml")).toBe(originalFootnotesXml);
+
+    const savedEndnotesXml = await readPart(result, "word/endnotes.xml");
+    expect(savedEndnotesXml).toContain(ENDNOTE_SEPARATORS);
+    expect(savedEndnotesXml).toContain(editedText);
+    expect(savedEndnotesXml).not.toContain(ORIGINAL_ENDNOTE_TEXT);
+  });
+
+  test("a body-only edit leaves both note parts byte-exact", async () => {
+    const buffer = await createNotesFixture();
+    const originalFootnotesXml = await readPart(buffer, "word/footnotes.xml");
+    const originalEndnotesXml = await readPart(buffer, "word/endnotes.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const bodyPara = doc.package.document.content[0];
+    if (!bodyPara || bodyPara.type !== "paragraph") {
+      throw new Error("expected a body paragraph");
+    }
+    for (const item of bodyPara.content) {
+      if (item.type === "run") {
+        for (const runContent of item.content) {
+          if (runContent.type === "text") {
+            runContent.text = "Body text edited";
+          }
+        }
+      }
+    }
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set([BODY_PARA_ID]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+
+    // Note parts are never touched by a body-only edit.
+    expect(await readPart(result, "word/footnotes.xml")).toBe(originalFootnotesXml);
+    expect(await readPart(result, "word/endnotes.xml")).toBe(originalEndnotesXml);
+
+    // The body edit landed in document.xml.
+    expect(await readPart(result, "word/document.xml")).toContain("Body text edited");
+  });
+});

--- a/packages/core/src/docx/noteSave.test.ts
+++ b/packages/core/src/docx/noteSave.test.ts
@@ -18,6 +18,7 @@ import JSZip from "jszip";
 import type { Endnote, Footnote } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -31,8 +32,11 @@ const FOOTNOTE_SEPARATORS =
   '<w:footnote w:type="separator" w:id="-1"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:separator/></w:r></w:p></w:footnote>' +
   '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>';
 
+// The normal note carries the in-note `w:footnoteRef` auto-number mark that
+// real Word documents emit and that the model does NOT represent, so the
+// byte-exact assertions below confirm an unedited note keeps that mark.
 const footnotesXml = `${XML_DECLARATION}
-<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${FOOTNOTE_SEPARATORS}<w:footnote w:id="1"><w:p w14:paraId="${FOOTNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr><w:r><w:t xml:space="preserve">${ORIGINAL_FOOTNOTE_TEXT}</w:t></w:r></w:p></w:footnote></w:footnotes>`;
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${FOOTNOTE_SEPARATORS}<w:footnote w:id="1"><w:p w14:paraId="${FOOTNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r><w:r><w:t xml:space="preserve">${ORIGINAL_FOOTNOTE_TEXT}</w:t></w:r></w:p></w:footnote></w:footnotes>`;
 
 const ORIGINAL_ENDNOTE_TEXT = "Original endnote body";
 const ENDNOTE_PARA_ID = "E1000001";
@@ -41,7 +45,7 @@ const ENDNOTE_SEPARATORS =
   '<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>';
 
 const endnotesXml = `${XML_DECLARATION}
-<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${ENDNOTE_SEPARATORS}<w:endnote w:id="1"><w:p w14:paraId="${ENDNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr><w:r><w:t xml:space="preserve">${ORIGINAL_ENDNOTE_TEXT}</w:t></w:r></w:p></w:endnote></w:endnotes>`;
+<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${ENDNOTE_SEPARATORS}<w:endnote w:id="1"><w:p w14:paraId="${ENDNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr><w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteRef/></w:r><w:r><w:t xml:space="preserve">${ORIGINAL_ENDNOTE_TEXT}</w:t></w:r></w:p></w:endnote></w:endnotes>`;
 
 const BODY_PARA_ID = "B0000001";
 const documentXml = `${XML_DECLARATION}
@@ -128,6 +132,14 @@ function setFirstNoteText(note: Footnote | Endnote, newText: string): void {
   throw new Error("expected a text run in the note paragraph");
 }
 
+function noteBodyText(note: Footnote | Endnote | undefined): string {
+  return (note?.content ?? [])
+    .flatMap((block) => (block.type === "paragraph" ? block.content : []))
+    .flatMap((item) => (item.type === "run" ? item.content : []))
+    .map((rc) => (rc.type === "text" ? rc.text : ""))
+    .join("");
+}
+
 describe("footnote / endnote body write path (selective save)", () => {
   test("edited footnote body persists; endnote and other parts stay byte-exact", async () => {
     const buffer = await createNotesFixture();
@@ -158,14 +170,7 @@ describe("footnote / endnote body write path (selective save)", () => {
 
     // The edited footnote text round-trips through re-parse.
     const reparsed = await parseDocx(result, { preloadFonts: false });
-    const reparsedFootnote = reparsed.package.footnotes?.[0];
-    const footnoteText = reparsedFootnote?.content
-      .flatMap((block) => (block.type === "paragraph" ? block.content : []))
-      .flatMap((item) => (item.type === "run" ? item.content : []))
-      .filter((rc) => rc.type === "text")
-      .map((rc) => (rc.type === "text" ? rc.text : ""))
-      .join("");
-    expect(footnoteText).toBe(editedText);
+    expect(noteBodyText(reparsed.package.footnotes?.[0])).toBe(editedText);
 
     // The unedited endnote part and other parts are untouched.
     expect(await readPart(result, "word/endnotes.xml")).toBe(originalEndnotesXml);
@@ -204,13 +209,7 @@ describe("footnote / endnote body write path (selective save)", () => {
     }
 
     const reparsed = await parseDocx(result, { preloadFonts: false });
-    const endnoteText = reparsed.package.endnotes?.[0]?.content
-      .flatMap((block) => (block.type === "paragraph" ? block.content : []))
-      .flatMap((item) => (item.type === "run" ? item.content : []))
-      .filter((rc) => rc.type === "text")
-      .map((rc) => (rc.type === "text" ? rc.text : ""))
-      .join("");
-    expect(endnoteText).toBe(editedText);
+    expect(noteBodyText(reparsed.package.endnotes?.[0])).toBe(editedText);
 
     // The footnote part is untouched when only an endnote changed.
     expect(await readPart(result, "word/footnotes.xml")).toBe(originalFootnotesXml);
@@ -258,5 +257,86 @@ describe("footnote / endnote body write path (selective save)", () => {
 
     // The body edit landed in document.xml.
     expect(await readPart(result, "word/document.xml")).toContain("Body text edited");
+  });
+});
+
+describe("footnote / endnote body write path (full repack)", () => {
+  test("edited footnote body persists through repackDocx; endnote + separators intact", async () => {
+    const buffer = await createNotesFixture();
+    const originalEndnotesXml = await readPart(buffer, "word/endnotes.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const footnote = doc.package.footnotes?.[0];
+    if (!footnote) {
+      throw new Error("expected a parsed footnote");
+    }
+    const editedText = "Edited footnote body via full repack";
+    setFirstNoteText(footnote, editedText);
+
+    const result = await repackDocx(doc);
+
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(noteBodyText(reparsed.package.footnotes?.[0])).toBe(editedText);
+
+    // Full repack rebuilds document.xml from the model, but the unedited endnote
+    // part is left byte-exact (no endnote paragraph changed).
+    expect(await readPart(result, "word/endnotes.xml")).toBe(originalEndnotesXml);
+
+    // Separator notes stay byte-exact inside footnotes.xml; the old body text is
+    // gone, replaced by the edit.
+    const savedFootnotesXml = await readPart(result, "word/footnotes.xml");
+    expect(savedFootnotesXml).toContain(FOOTNOTE_SEPARATORS);
+    expect(savedFootnotesXml).toContain(editedText);
+    expect(savedFootnotesXml).not.toContain(ORIGINAL_FOOTNOTE_TEXT);
+  });
+
+  test("edited endnote body persists through repackDocx; footnote + separators intact", async () => {
+    const buffer = await createNotesFixture();
+    const originalFootnotesXml = await readPart(buffer, "word/footnotes.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const endnote = doc.package.endnotes?.[0];
+    if (!endnote) {
+      throw new Error("expected a parsed endnote");
+    }
+    const editedText = "Edited endnote body via full repack";
+    setFirstNoteText(endnote, editedText);
+
+    const result = await repackDocx(doc);
+
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(noteBodyText(reparsed.package.endnotes?.[0])).toBe(editedText);
+
+    // The unedited footnote part is left byte-exact.
+    expect(await readPart(result, "word/footnotes.xml")).toBe(originalFootnotesXml);
+
+    const savedEndnotesXml = await readPart(result, "word/endnotes.xml");
+    expect(savedEndnotesXml).toContain(ENDNOTE_SEPARATORS);
+    expect(savedEndnotesXml).toContain(editedText);
+    expect(savedEndnotesXml).not.toContain(ORIGINAL_ENDNOTE_TEXT);
+  });
+
+  test("a repack with no note edit leaves both note parts byte-exact", async () => {
+    const buffer = await createNotesFixture();
+    const originalFootnotesXml = await readPart(buffer, "word/footnotes.xml");
+    const originalEndnotesXml = await readPart(buffer, "word/endnotes.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const result = await repackDocx(doc);
+
+    // Byte-exact preservation includes the in-note auto-number marks the model
+    // does not represent: an unedited note is never re-serialized, so nothing is
+    // lost even though `w:footnoteRef` / `w:endnoteRef` are absent from the model.
+    const savedFootnotesXml = await readPart(result, "word/footnotes.xml");
+    const savedEndnotesXml = await readPart(result, "word/endnotes.xml");
+    expect(savedFootnotesXml).toBe(originalFootnotesXml);
+    expect(savedEndnotesXml).toBe(originalEndnotesXml);
+    expect(savedFootnotesXml).toContain("<w:footnoteRef/>");
+    expect(savedEndnotesXml).toContain("<w:endnoteRef/>");
+
+    // The note bodies still round-trip unchanged.
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(noteBodyText(reparsed.package.footnotes?.[0])).toBe(ORIGINAL_FOOTNOTE_TEXT);
+    expect(noteBodyText(reparsed.package.endnotes?.[0])).toBe(ORIGINAL_ENDNOTE_TEXT);
   });
 });

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -34,11 +34,14 @@ import JSZip from "jszip";
 
 import type { BlockContent, HeaderFooter, Image, Hyperlink } from "../types/content";
 import type { Document, Watermark } from "../types/document";
+import { parseEndnotes, parseFootnotes } from "./footnoteParser";
 import { assertValidFolioDocumentModel } from "./modelValidation";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
+import { buildPatchedNoteXml, collectParaIds, extractParagraphXml } from "./selectiveXmlPatch";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
+import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
 import { escapeXml } from "./serializer/xmlUtils";
 import { isPreservableDocxEntry } from "./unzip";
 import type { RawDocxContent } from "./unzip";
@@ -641,6 +644,10 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
   // Serialize and update modified headers/footers
   serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
 
+  // Splice edited footnote/endnote bodies back into their parts (separators and
+  // unedited notes stay byte-exact).
+  await serializeNotesToZip(exportDocument, originalZip, newZip, compressionLevel);
+
   // Serialize comments
   await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
 
@@ -743,6 +750,10 @@ export async function repackDocxFromRaw(
 
   // Serialize and update modified headers/footers
   serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
+
+  // Splice edited footnote/endnote bodies back into their parts (separators and
+  // unedited notes stay byte-exact).
+  await serializeNotesToZip(exportDocument, rawContent.originalZip, newZip, compressionLevel);
 
   // Serialize comments
   await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
@@ -1489,6 +1500,122 @@ function serializeHeadersFootersToZip(doc: Document, zip: JSZip, compressionLeve
   for (const [filename, xml] of collectHeaderFooterUpdates(doc)) {
     zip.file(filename, xml, { compression: "DEFLATE", compressionOptions });
   }
+}
+
+/**
+ * Write edited footnote/endnote bodies into the repacked ZIP.
+ *
+ * The full repack rebuilds document.xml from the model, but note parts are
+ * preserved from the original ZIP: the model only retains the normal notes, so
+ * re-emitting the whole part would drop the separator / continuationSeparator
+ * notes Word requires. Instead each edited note paragraph is spliced by `paraId`
+ * into the ORIGINAL part, so an edited note gets the model content while
+ * separators and every unedited note stay byte-exact.
+ *
+ * Full repack has no change-tracking signal, so "edited" is detected by
+ * comparing the current model's note serialization against a BASELINE that
+ * re-parses and re-serializes the original part. Both go through the same
+ * (lossy) parse+serialize — e.g. the in-note `w:footnoteRef` auto-number mark
+ * the model does not represent is dropped on both sides — so an unedited note
+ * matches its baseline and is left verbatim (mark intact); only a genuine body
+ * edit differs and is spliced.
+ */
+async function serializeNotesToZip(
+  doc: Document,
+  originalZip: JSZip,
+  newZip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const footnotes = doc.package.footnotes ?? [];
+  if (footnotes.length > 0) {
+    await patchNotePartIntoZip(
+      "word/footnotes.xml",
+      serializeFootnotes(footnotes),
+      (xml) => serializeFootnotes(parseFootnotes(xml).getNormalFootnotes()),
+      originalZip,
+      newZip,
+      compressionLevel,
+    );
+  }
+  const endnotes = doc.package.endnotes ?? [];
+  if (endnotes.length > 0) {
+    await patchNotePartIntoZip(
+      "word/endnotes.xml",
+      serializeEndnotes(endnotes),
+      (xml) => serializeEndnotes(parseEndnotes(xml).getNormalEndnotes()),
+      originalZip,
+      newZip,
+      compressionLevel,
+    );
+  }
+}
+
+async function patchNotePartIntoZip(
+  conventionalLowerPath: string,
+  currentXml: string,
+  baselineFrom: (originalXml: string) => string,
+  originalZip: JSZip,
+  newZip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const file = findNotePartEntry(originalZip, conventionalLowerPath);
+  if (!file) {
+    return;
+  }
+  const originalXml = await file.async("text");
+  const changedIds = collectChangedNoteParaIds(baselineFrom(originalXml), currentXml);
+  if (changedIds.size === 0) {
+    return;
+  }
+  // Splice the edited paragraphs into the ORIGINAL bytes (not the baseline), so
+  // unedited notes keep their verbatim markup.
+  const patched = buildPatchedNoteXml(originalXml, currentXml, changedIds);
+  if (patched === null) {
+    return;
+  }
+  newZip.file(file.name, patched, {
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
+}
+
+/**
+ * The note paragraphs whose current serialization differs from the baseline
+ * (re-parsed original) serialization — i.e. the ones actually edited. A
+ * paragraph is only considered when its `paraId` resolves uniquely in both,
+ * so it can be spliced safely.
+ */
+function collectChangedNoteParaIds(baselineXml: string, currentXml: string): Set<string> {
+  const changed = new Set<string>();
+  const baselineIds = collectParaIds(baselineXml);
+  for (const [id, count] of collectParaIds(currentXml)) {
+    if (count !== 1 || baselineIds.get(id) !== 1) {
+      continue;
+    }
+    const before = extractParagraphXml(baselineXml, id);
+    const after = extractParagraphXml(currentXml, id);
+    if (before !== null && after !== null && before !== after) {
+      changed.add(id);
+    }
+  }
+  return changed;
+}
+
+/**
+ * Locate a note part in the ZIP, matching case-insensitively so a producer that
+ * cased the entry differently still resolves to the existing part.
+ */
+function findNotePartEntry(zip: JSZip, conventionalLowerPath: string): JSZip.JSZipObject | null {
+  const direct = zip.file(conventionalLowerPath);
+  if (direct) {
+    return direct;
+  }
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && path.toLowerCase() === conventionalLowerPath) {
+      return file;
+    }
+  }
+  return null;
 }
 
 // ============================================================================

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -8,6 +8,8 @@
  * Returns null on any failure, signaling the caller to fall back to full repack.
  */
 
+import type JSZip from "jszip";
+
 import type { Document, BlockContent } from "../types/document";
 import { validateFolioDocumentModel } from "./modelValidation";
 import { RELATIONSHIP_TYPES } from "./relsParser";
@@ -21,9 +23,10 @@ import {
   COMMENTS_CONTENT_TYPE,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
-import { buildPatchedDocumentXml } from "./selectiveXmlPatch";
+import { buildPatchedDocumentXml, buildPatchedNoteXml, collectParaIds } from "./selectiveXmlPatch";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
+import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
 
 const SYNTHETIC_IMAGE_RID_PREFIX = "rId_img_";
 
@@ -80,6 +83,94 @@ function hasNewImagesOrHyperlinks(blocks: BlockContent[]): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Splice edited footnote/endnote paragraphs into their parts and return the
+ * candidate ids that could NOT be routed to a note part (an id that is neither
+ * a body nor a note paragraph — the caller bails on those).
+ *
+ * The document model only retains the normal notes, so this never rewrites a
+ * whole note part (that would drop the separator notes the model omits): it
+ * splices only the edited note paragraphs by `paraId` via
+ * {@link buildPatchedNoteXml}, keeping separators and unedited notes byte-exact.
+ *
+ * Returns null to signal the caller should bail to a full repack (a note
+ * paragraph could not be spliced safely).
+ */
+async function patchNoteParts(
+  zip: JSZip,
+  doc: Document,
+  candidateIds: Set<string>,
+  updates: Map<string, string>,
+): Promise<Set<string> | null> {
+  const footnotes = doc.package.footnotes ?? [];
+  const endnotes = doc.package.endnotes ?? [];
+  const remainingIds = new Set(candidateIds);
+  if (footnotes.length === 0 && endnotes.length === 0) {
+    return remainingIds;
+  }
+
+  // Word writes note parts at the conventional lowercase path; match
+  // case-insensitively so a producer that cased them differently still hits the
+  // existing entry (writing a new-cased path would duplicate the part).
+  const findPart = (conventionalLowerPath: string) => {
+    const direct = zip.file(conventionalLowerPath);
+    if (direct) {
+      return direct;
+    }
+    for (const [path, file] of Object.entries(zip.files)) {
+      if (!file.dir && path.toLowerCase() === conventionalLowerPath) {
+        return file;
+      }
+    }
+    return null;
+  };
+
+  const patchPart = async (
+    conventionalLowerPath: string,
+    serialize: () => string,
+  ): Promise<boolean> => {
+    const file = findPart(conventionalLowerPath);
+    if (!file) {
+      return true;
+    }
+    const originalXml = await file.async("text");
+    const originalIds = collectParaIds(originalXml);
+    const partIds = new Set<string>();
+    for (const id of remainingIds) {
+      if (originalIds.has(id)) {
+        partIds.add(id);
+      }
+    }
+    if (partIds.size === 0) {
+      return true;
+    }
+    const patched = buildPatchedNoteXml(originalXml, serialize(), partIds);
+    if (patched === null) {
+      return false;
+    }
+    updates.set(file.name, patched);
+    for (const id of partIds) {
+      remainingIds.delete(id);
+    }
+    return true;
+  };
+
+  if (
+    footnotes.length > 0 &&
+    !(await patchPart("word/footnotes.xml", () => serializeFootnotes(footnotes)))
+  ) {
+    return null;
+  }
+  if (
+    endnotes.length > 0 &&
+    !(await patchPart("word/endnotes.xml", () => serializeEndnotes(endnotes)))
+  ) {
+    return null;
+  }
+
+  return remainingIds;
 }
 
 export type SelectiveSaveOptions = {
@@ -153,24 +244,51 @@ export async function attemptSelectiveSave(
     const zip = await JSZip.loadAsync(originalBuffer);
     const updates = new Map<string, string>();
 
-    // Patch document.xml if paragraphs changed
+    // Patch document.xml and the note parts (footnotes.xml / endnotes.xml). A
+    // changed paraId lives in exactly one part, so partition against the body's
+    // own paraIds: body ids patch document.xml, the rest are routed to the note
+    // parts. A plain body edit has no note candidates, so the note parts are
+    // never read or rewritten and stay verbatim.
     if (changedParaIds.size > 0) {
       const docXmlFile = zip.file("word/document.xml");
       if (!docXmlFile) {
         return null;
       }
       const originalDocXml = await docXmlFile.async("text");
+      const bodyParaIds = collectParaIds(originalDocXml);
 
-      const serializedDocXml = serializeDocument(doc);
-      const patchedDocXml = buildPatchedDocumentXml(
-        originalDocXml,
-        serializedDocXml,
-        changedParaIds,
-      );
-      if (!patchedDocXml) {
-        return null;
+      const bodyChangedIds = new Set<string>();
+      const noteCandidateIds = new Set<string>();
+      for (const id of changedParaIds) {
+        if (bodyParaIds.has(id)) {
+          bodyChangedIds.add(id);
+        } else {
+          noteCandidateIds.add(id);
+        }
       }
-      updates.set("word/document.xml", patchedDocXml);
+
+      if (noteCandidateIds.size > 0) {
+        const unrouted = await patchNoteParts(zip, doc, noteCandidateIds, updates);
+        // A splice failure, or a changed id that is neither a body nor a note
+        // paragraph, falls back to full repack — matching the prior safety when
+        // buildPatchedDocumentXml met a paraId it could not resolve.
+        if (unrouted === null || unrouted.size > 0) {
+          return null;
+        }
+      }
+
+      if (bodyChangedIds.size > 0) {
+        const serializedDocXml = serializeDocument(doc);
+        const patchedDocXml = buildPatchedDocumentXml(
+          originalDocXml,
+          serializedDocXml,
+          bodyChangedIds,
+        );
+        if (!patchedDocXml) {
+          return null;
+        }
+        updates.set("word/document.xml", patchedDocXml);
+      }
     }
 
     // Overwrite `word/comments.xml` whenever the source already had one,

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -129,7 +129,7 @@ export function countParagraphElements(xml: string): number {
 /**
  * Find all paraIds in an XML string and return counts (to detect duplicates).
  */
-function collectParaIds(xml: string): Map<string, number> {
+export function collectParaIds(xml: string): Map<string, number> {
   const ids = new Map<string, number>();
   const pattern = /w14:paraId="(?<id>[^"]+)"/gu;
   let match: RegExpExecArray | null;
@@ -146,18 +146,30 @@ export type PatchValidationResult = {
   reason?: string;
 };
 
+export type PatchSafetyOptions = {
+  /**
+   * Require the original and serialized XML to hold the same number of `<w:p>`
+   * elements. Guards document.xml against structural drift. Notes disable it:
+   * the model only retains the normal notes, so a serialized note part
+   * legitimately has fewer paragraphs than the original (which still carries
+   * the separator notes). See {@link buildPatchedNoteXml}.
+   */
+  checkParagraphCount?: boolean;
+};
+
 /**
  * Validate that a selective patch can be safely applied.
  *
  * Checks:
  * - All changed paraIds exist in original XML (exactly once)
  * - All changed paraIds exist in serialized XML (exactly once)
- * - Paragraph count matches between original and serialized
+ * - Paragraph count matches between original and serialized (unless disabled)
  */
 export function validatePatchSafety(
   originalXml: string,
   serializedXml: string,
   changedIds: Set<string>,
+  options: PatchSafetyOptions = {},
 ): PatchValidationResult {
   if (changedIds.size === 0) {
     return { safe: true };
@@ -186,6 +198,10 @@ export function validatePatchSafety(
     if (serCount > 1) {
       return { safe: false, reason: `duplicate-paraId-in-serialized: ${id}` };
     }
+  }
+
+  if (options.checkParagraphCount === false) {
+    return { safe: true };
   }
 
   // Check paragraph counts match
@@ -223,7 +239,53 @@ export function buildPatchedDocumentXml(
     return null;
   }
 
-  // Collect all replacements: { start, end, newXml }
+  return spliceChangedParagraphs(originalXml, serializedXml, changedIds);
+}
+
+/**
+ * Build a patched note part (word/footnotes.xml / word/endnotes.xml) by
+ * splicing edited note paragraphs into the original, preserving unchanged
+ * content byte-for-byte.
+ *
+ * Unlike {@link buildPatchedDocumentXml} this does NOT require the paragraph
+ * counts to match: the document model only retains the normal notes, so the
+ * serialized note XML omits the separator / continuationSeparator paragraphs
+ * the original part still carries. Splicing by `paraId` keeps those separators
+ * and every unedited note byte-exact while replacing only the edited ones.
+ *
+ * Returns null if any changed id is missing or ambiguous in either input, so
+ * the caller can fall back to preserving the original part verbatim.
+ */
+export function buildPatchedNoteXml(
+  originalXml: string,
+  serializedXml: string,
+  changedIds: Set<string>,
+): string | null {
+  if (changedIds.size === 0) {
+    return originalXml;
+  }
+
+  const validation = validatePatchSafety(originalXml, serializedXml, changedIds, {
+    checkParagraphCount: false,
+  });
+  if (!validation.safe) {
+    return null;
+  }
+
+  return spliceChangedParagraphs(originalXml, serializedXml, changedIds);
+}
+
+/**
+ * Replace each changed paragraph in `originalXml` with its re-serialized form
+ * extracted from `serializedXml`, splicing end-to-start so earlier offsets stay
+ * valid. Assumes safety has already been validated. Returns null if an offset
+ * or extraction unexpectedly fails.
+ */
+function spliceChangedParagraphs(
+  originalXml: string,
+  serializedXml: string,
+  changedIds: Set<string>,
+): string | null {
   const replacements: { start: number; end: number; newXml: string }[] = [];
 
   for (const paraId of changedIds) {

--- a/packages/core/src/docx/serializer/noteSerializer.ts
+++ b/packages/core/src/docx/serializer/noteSerializer.ts
@@ -1,0 +1,114 @@
+/**
+ * Footnote/Endnote Serializer - Serialize footnotes/endnotes back to OOXML XML
+ *
+ * Converts the parsed Footnote[] / Endnote[] model back into valid
+ * word/footnotes.xml / word/endnotes.xml. Reuses the same paragraph, table,
+ * and block-SDT serializers the document body and header/footer serializers
+ * use, so note bodies round-trip the full block model (runs, tracked changes,
+ * fields, content controls) instead of a flattened subset.
+ *
+ * OOXML Reference:
+ * - Footnotes root: w:footnotes; each note: w:footnote[@w:id][@w:type]
+ * - Endnotes root:  w:endnotes;  each note: w:endnote[@w:id][@w:type]
+ *
+ * The document model only retains the normal (content) notes: the separator /
+ * continuationSeparator notes Word requires are dropped during parsing
+ * (`getNormalFootnotes`). Callers therefore must NOT overwrite the whole part
+ * with this output — it would lose those separators. The selective save path
+ * uses this serializer only to extract the edited note paragraph by `paraId`
+ * and splices it into the original part, keeping separators and unedited notes
+ * byte-exact.
+ */
+
+import type { BlockContent, Endnote, Footnote } from "../../types/document";
+import { serializeBlockSdt } from "./blockSdtSerializer";
+import { serializeParagraph } from "./paragraphSerializer";
+import { serializeTable } from "./tableSerializer";
+
+// Namespaces declared on the notes root. Mirrors the header/footer serializer's
+// declared set so note bodies carrying DrawingML, math, or raw-replayed SDT
+// extensions land on a root that declares every prefix they might use.
+const NAMESPACES: Record<string, string> = {
+  wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
+  mc: "http://schemas.openxmlformats.org/markup-compatibility/2006",
+  o: "urn:schemas-microsoft-com:office:office",
+  r: "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+  m: "http://schemas.openxmlformats.org/officeDocument/2006/math",
+  v: "urn:schemas-microsoft-com:vml",
+  a: "http://schemas.openxmlformats.org/drawingml/2006/main",
+  pic: "http://schemas.openxmlformats.org/drawingml/2006/picture",
+  wp14: "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
+  wp: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+  w10: "urn:schemas-microsoft-com:office:word",
+  w: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+  w14: "http://schemas.microsoft.com/office/word/2010/wordml",
+  w15: "http://schemas.microsoft.com/office/word/2012/wordml",
+  w16: "http://schemas.microsoft.com/office/word/2018/wordml",
+  w16cex: "http://schemas.microsoft.com/office/word/2018/wordml/cex",
+  w16cid: "http://schemas.microsoft.com/office/word/2016/wordml/cid",
+  w16sdtdh: "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash",
+  w16se: "http://schemas.microsoft.com/office/word/2015/wordml/symex",
+  wpg: "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
+  wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
+};
+
+function buildNamespaceDeclarations(): string {
+  return Object.entries(NAMESPACES)
+    .map(([prefix, uri]) => `xmlns:${prefix}="${uri}"`)
+    .join(" ");
+}
+
+/**
+ * Serialize a block content item (paragraph, table, or block-level SDT) for a
+ * note body.
+ */
+function serializeBlock(block: BlockContent): string {
+  if (block.type === "paragraph") {
+    return serializeParagraph(block);
+  }
+  if (block.type === "table") {
+    return serializeTable(block);
+  }
+  return serializeBlockSdt(block, serializeBlock);
+}
+
+/**
+ * Serialize a single note element. Footnotes and endnotes share the same
+ * structure, differing only in the wrapper element name.
+ */
+function serializeNote(elementName: "footnote" | "endnote", note: Footnote | Endnote): string {
+  const attrs: string[] = [];
+  // Word emits w:type before w:id on typed (separator) notes; mirror that
+  // ordering. Normal notes carry no type attribute.
+  if (note.noteType && note.noteType !== "normal") {
+    attrs.push(`w:type="${note.noteType}"`);
+  }
+  attrs.push(`w:id="${note.id}"`);
+
+  const body = note.content.map((block) => serializeBlock(block)).join("");
+  return `<w:${elementName} ${attrs.join(" ")}>${body}</w:${elementName}>`;
+}
+
+/**
+ * Serialize footnotes to a complete word/footnotes.xml string.
+ *
+ * @param footnotes - Notes to serialize (the model's normal footnotes).
+ * @returns Complete footnotes.xml string.
+ */
+export function serializeFootnotes(footnotes: readonly Footnote[]): string {
+  const nsDecl = buildNamespaceDeclarations();
+  const notes = footnotes.map((fn) => serializeNote("footnote", fn)).join("");
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:footnotes ${nsDecl} mc:Ignorable="w14 w15 wp14">${notes}</w:footnotes>`;
+}
+
+/**
+ * Serialize endnotes to a complete word/endnotes.xml string.
+ *
+ * @param endnotes - Notes to serialize (the model's normal endnotes).
+ * @returns Complete endnotes.xml string.
+ */
+export function serializeEndnotes(endnotes: readonly Endnote[]): string {
+  const nsDecl = buildNamespaceDeclarations();
+  const notes = endnotes.map((en) => serializeNote("endnote", en)).join("");
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:endnotes ${nsDecl} mc:Ignorable="w14 w15 wp14">${notes}</w:endnotes>`;
+}


### PR DESCRIPTION
Adds the missing **footnote/endnote body write path** on save. folio parses notes into the model but had no serializer for them, so both save paths copied `word/footnotes.xml` / `word/endnotes.xml` verbatim — meaning any model edit to a note body was silently dropped on save.

- New `serializer/noteSerializer.ts` (`serializeFootnotes`/`serializeEndnotes`), mirroring the header/footer serializer's block dispatch (`serializeParagraph`/`serializeTable`/`serializeBlockSdt`).
- `selectiveXmlPatch.ts`: `buildPatchedNoteXml` splices only the **edited** note paragraphs (by `paraId`) into the original note part — so separator notes and unedited notes stay byte-exact (the model retains only normal notes, so a whole-part re-emit would drop separators).
- `selectiveSave.ts`: partitions changed paragraph ids into body vs. note candidates; a note part is rewritten **only when one of its paragraphs actually changed**. Body-only saves never read or rewrite the note parts (byte-exact + no perf regression); an id in neither still bails to full repack (existing safety preserved).

Round-trip test covers: footnote edit persists (others byte-exact), endnote edit persists, and a body-only edit leaves both note parts byte-exact.

Scope: this is the model→docx **write** half. Interactive note editing in the UI (off-screen editor + flush-back, like headers/footers) and having the AI-edit path target notes are follow-ups that build on this.
