### PR TITLE
feat(core): headless DocxReviewer (buffer to review to buffer, no browser)

### DIFF
--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -21,7 +21,16 @@ import type {
 } from "./types";
 import { diffWordSegments } from "./word-diff";
 
-type FolioAIEditView = {
+/**
+ * The only editor surface the apply logic touches: a current `state`
+ * and a `dispatch` that swaps in the next one. A live `EditorView`
+ * satisfies this structurally, and so does a headless seam
+ * (`{ state, dispatch: (tr) => { state = state.apply(tr); } }`) — the
+ * apply path never reaches for anything DOM-bound on the view, which is
+ * what lets the same operation applier drive both the React editor and
+ * the server-side reviewer in `./headless`.
+ */
+export type FolioAIEditView = {
   state: EditorState;
   dispatch: (transaction: Transaction) => void;
 };

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Headless `.docx` review round-trip: parse a fixture, apply body-block edits
+ * with no editor view, serialise back, and re-parse to assert the edits landed.
+ *
+ * Covers `replaceInBlock` and `insertAfterBlock` in both `direct` and
+ * `tracked-changes` modes, that tracked mode emits ins/del marks, and that
+ * unedited parts survive byte-exact (selective save for the non-structural
+ * case; the copied-through package parts for the structural full-repack case).
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import { EditorState } from "prosemirror-state";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { parseDocx } from "../docx/parser";
+import { repackDocx } from "../docx/rezip";
+import { updateDocumentContent } from "../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
+import { schema, singletonManager } from "../prosemirror/schema";
+import { FolioDocxReviewer, applyFolioAIEditsToBuffer } from "./headless";
+import type { FolioAIBlock } from "./types";
+
+const FIXTURE = path.join(
+  import.meta.dir,
+  "../docx/__tests__/__fixtures__/corpus/authored-empty-paragraph.docx",
+);
+
+const readFixture = (): ArrayBuffer => {
+  const bytes = readFileSync(FIXTURE);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+};
+
+/**
+ * Corpus fixtures ship without `w14:paraId`s. The editor allocates them on load
+ * and its first save is a full repack that writes them out; only subsequent
+ * saves take the selective path. Reproduce that here so the reviewer under test
+ * sees a paraId-bearing baseline and can exercise selective save.
+ */
+const makeParaIdBaseline = async (source: ArrayBuffer): Promise<ArrayBuffer> => {
+  const document = await parseDocx(source, { detectVariables: false, preloadFonts: false });
+  const state = ensureParaIdsInState(
+    EditorState.create({
+      schema,
+      doc: toProseDoc(document),
+      plugins: singletonManager.getPlugins(),
+    }),
+  );
+  return repackDocx({ ...updateDocumentContent(document, state.doc), originalBuffer: source });
+};
+
+const partText = async (buffer: ArrayBuffer, part: string): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(part);
+  if (!file) {
+    throw new Error(`missing part: ${part}`);
+  }
+  return file.async("text");
+};
+
+const partBytes = async (buffer: ArrayBuffer, part: string): Promise<Uint8Array> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(part);
+  if (!file) {
+    throw new Error(`missing part: ${part}`);
+  }
+  return file.async("uint8array");
+};
+
+/** Extract the `<w:p …>…</w:p>` element that contains `needle`. */
+const paragraphContaining = (documentXml: string, needle: string): string => {
+  const at = documentXml.indexOf(needle);
+  const start = documentXml.lastIndexOf("<w:p ", at);
+  const startAlt = documentXml.lastIndexOf("<w:p>", at);
+  const from = Math.max(start, startAlt);
+  const end = documentXml.indexOf("</w:p>", at);
+  if (from === -1 || end === -1) {
+    throw new Error(`no <w:p> around ${JSON.stringify(needle)}`);
+  }
+  return documentXml.slice(from, end + "</w:p>".length);
+};
+
+const blockText = (block: FolioAIBlock): string => block.text;
+
+const findBlock = (blocks: FolioAIBlock[], needle: string): FolioAIBlock => {
+  const block = blocks.find((b) => b.text.includes(needle));
+  if (!block) {
+    throw new Error(`no block containing ${JSON.stringify(needle)}`);
+  }
+  return block;
+};
+
+describe("headless docx review round-trip", () => {
+  test("replaceInBlock (direct) rewrites the text with no tracked marks", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+
+    const result = reviewer.applyOperations(
+      [{ id: "r1", type: "replaceInBlock", blockId: target.id, find: "Heading", replace: "Intro" }],
+      { mode: "direct" },
+    );
+    expect(result.applied.map((a) => a.id)).toEqual(["r1"]);
+    expect(result.skipped).toEqual([]);
+
+    const out = await reviewer.toBuffer();
+    const outXml = await partText(out, "word/document.xml");
+    expect(outXml).toContain("Intro paragraph.");
+    expect(outXml).not.toContain("Heading paragraph.");
+    // Direct mode is an in-place edit: no redline marks introduced.
+    expect(outXml).not.toContain("<w:ins ");
+    expect(outXml).not.toContain("<w:del ");
+
+    // Selective save leaves the untouched paragraph byte-for-byte identical.
+    const baseXml = await partText(baseline, "word/document.xml");
+    expect(outXml).toContain(paragraphContaining(baseXml, "Trailing paragraph."));
+  });
+
+  test("replaceInBlock (tracked-changes) redlines old vs new and preserves untouched parts", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+
+    const result = reviewer.applyOperations([
+      { id: "t1", type: "replaceInBlock", blockId: target.id, find: "Heading", replace: "Intro" },
+    ]);
+    expect(result.applied).toHaveLength(1);
+    expect(result.applied[0]?.revisionIds?.length).toBe(2);
+
+    const out = await reviewer.toBuffer();
+    const outXml = await partText(out, "word/document.xml");
+    // Tracked change: the deletion carries the old word, the insertion the new.
+    expect(outXml).toContain("<w:ins ");
+    expect(outXml).toContain("<w:del ");
+    expect(outXml).toContain('w:author="AI Reviewer"');
+    const editedPara = paragraphContaining(outXml, "Intro");
+    expect(editedPara).toContain("<w:ins ");
+    expect(editedPara).toContain("<w:del ");
+    // Re-parse round-trips to a valid package.
+    const reparsed = await parseDocx(out);
+    expect(reparsed.package.document.content.length).toBeGreaterThan(0);
+
+    // Byte-exact: the untouched paragraph and unrelated parts survive intact.
+    const baseXml = await partText(baseline, "word/document.xml");
+    expect(outXml).toContain(paragraphContaining(baseXml, "Trailing paragraph."));
+    expect(await partBytes(out, "word/styles.xml")).toEqual(
+      await partBytes(baseline, "word/styles.xml"),
+    );
+  });
+
+  test("insertAfterBlock (direct) adds a sibling paragraph, no tracked marks", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+
+    const result = reviewer.applyOperations(
+      [
+        {
+          id: "i1",
+          type: "insertAfterBlock",
+          blockId: target.id,
+          text: "Newly inserted clause.",
+        },
+      ],
+      { mode: "direct" },
+    );
+    expect(result.applied.map((a) => a.id)).toEqual(["i1"]);
+
+    const out = await reviewer.toBuffer();
+    const outXml = await partText(out, "word/document.xml");
+    expect(outXml).toContain("Newly inserted clause.");
+    expect(outXml).not.toContain("<w:ins ");
+    expect(outXml).not.toContain("<w:del ");
+
+    const reparsed = await parseDocx(out);
+    const blocks = reparsed.package.document.content.filter((b) => b.type === "paragraph");
+    const joined = blocks.map((b) => (b.type === "paragraph" ? JSON.stringify(b) : "")).join(" ");
+    expect(joined).toContain("Newly inserted clause.");
+    expect(joined).toContain("Heading paragraph.");
+    expect(joined).toContain("Trailing paragraph.");
+  });
+
+  test("insertAfterBlock (tracked-changes) marks the new paragraph as an insertion", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+
+    const result = reviewer.applyOperations([
+      {
+        id: "i2",
+        type: "insertAfterBlock",
+        blockId: target.id,
+        text: "Newly inserted clause.",
+      },
+    ]);
+    expect(result.applied.map((a) => a.id)).toEqual(["i2"]);
+    expect(result.applied[0]?.revisionId).toBeDefined();
+
+    const out = await reviewer.toBuffer();
+    const outXml = await partText(out, "word/document.xml");
+    expect(outXml).toContain("Newly inserted clause.");
+    expect(outXml).toContain("<w:ins ");
+    // The inserted run sits inside a tracked insertion.
+    expect(paragraphContaining(outXml, "Newly inserted clause.")).toContain("<w:ins ");
+
+    // A structural edit falls back to full repack, which copies unrelated parts
+    // through untouched.
+    expect(await partBytes(out, "word/styles.xml")).toEqual(
+      await partBytes(baseline, "word/styles.xml"),
+    );
+    const reparsed = await parseDocx(out);
+    expect(reparsed.package.document.content.length).toBeGreaterThan(0);
+  });
+
+  test("applyFolioAIEditsToBuffer one-shot convenience applies against a fresh snapshot", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    // Derive the operation's blockId from a snapshot of the same buffer.
+    const snapshot = (await FolioDocxReviewer.fromBuffer(baseline)).snapshot();
+    const target = findBlock(snapshot.blocks, "Heading");
+
+    const { buffer, applied, skipped } = await applyFolioAIEditsToBuffer(
+      baseline,
+      [{ id: "o1", type: "replaceInBlock", blockId: target.id, find: "Heading", replace: "Intro" }],
+      { mode: "direct", snapshot },
+    );
+    expect(applied.map((a) => a.id)).toEqual(["o1"]);
+    expect(skipped).toEqual([]);
+    expect(blockText(target)).toContain("Heading");
+    expect(await partText(buffer, "word/document.xml")).toContain("Intro paragraph.");
+  });
+});

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -21,6 +21,7 @@ import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { schema, singletonManager } from "../prosemirror/schema";
 import { FolioDocxReviewer, applyFolioAIEditsToBuffer } from "./headless";
+import type { FolioReviewChange } from "./headless";
 import type { FolioAIBlock } from "./types";
 
 const FIXTURE = path.join(
@@ -229,5 +230,170 @@ describe("headless docx review round-trip", () => {
     expect(skipped).toEqual([]);
     expect(blockText(target)).toContain("Heading");
     expect(await partText(buffer, "word/document.xml")).toContain("Intro paragraph.");
+  });
+});
+
+const insertionChange = (reviewer: FolioDocxReviewer): FolioReviewChange => {
+  const change = reviewer.getChanges().find((c) => c.type === "insertion");
+  if (!change) {
+    throw new Error("expected an insertion change");
+  }
+  return change;
+};
+
+describe("headless docx review discovery + resolve", () => {
+  test("getContentAsText labels every block with its stable id", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const blocks = reviewer.getContent();
+    const heading = findBlock(blocks, "Heading");
+
+    const text = reviewer.getContentAsText();
+    expect(text).toContain(`[${heading.id}] `);
+    expect(text).toContain("Heading paragraph.");
+    for (const block of blocks) {
+      expect(text).toContain(`[${block.id}]`);
+    }
+  });
+
+  test("getChanges surfaces the deletion and insertion of a tracked replace", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    reviewer.applyOperations([
+      { id: "t1", type: "replaceInBlock", blockId: target.id, find: "Heading", replace: "Intro" },
+    ]);
+
+    const changes = reviewer.getChanges();
+    const insertion = changes.find((c) => c.type === "insertion");
+    const deletion = changes.find((c) => c.type === "deletion");
+    expect(insertion?.text).toContain("Intro");
+    expect(deletion?.text).toContain("Heading");
+    expect(insertion?.author).toBe("AI Reviewer");
+    expect(insertion?.blockId).toBe(target.id);
+    // The two sides carry distinct revision ids.
+    expect(insertion?.id).not.toBe(deletion?.id);
+    // Filtering narrows to one kind.
+    const onlyInsertions = reviewer.getChanges({ type: "insertion" });
+    expect(onlyInsertions.every((c) => c.type === "insertion")).toBe(true);
+    expect(reviewer.getChanges({ author: "Nobody" })).toEqual([]);
+  });
+
+  test("acceptChange keeps the insertion as plain text; rejectChange drops it", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+
+    const accepting = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI" });
+    const acceptTarget = findBlock(accepting.snapshot().blocks, "Heading");
+    accepting.applyOperations([
+      {
+        id: "a1",
+        type: "replaceInBlock",
+        blockId: acceptTarget.id,
+        find: "Heading",
+        replace: "Intro",
+      },
+    ]);
+    expect(accepting.acceptChange(insertionChange(accepting))).toBe(true);
+    const acceptedXml = await partText(await accepting.toBuffer(), "word/document.xml");
+    expect(acceptedXml).toContain("Intro");
+    expect(acceptedXml).not.toContain("<w:ins ");
+    // The accepted change no longer shows up in discovery.
+    expect(accepting.getChanges().some((c) => c.type === "insertion")).toBe(false);
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI" });
+    const rejectTarget = findBlock(rejecting.snapshot().blocks, "Heading");
+    rejecting.applyOperations([
+      {
+        id: "r1",
+        type: "replaceInBlock",
+        blockId: rejectTarget.id,
+        find: "Heading",
+        replace: "Intro",
+      },
+    ]);
+    expect(rejecting.rejectChange(insertionChange(rejecting))).toBe(true);
+    const rejectedXml = await partText(await rejecting.toBuffer(), "word/document.xml");
+    expect(rejectedXml).not.toContain("Intro");
+    expect(rejectedXml).not.toContain("<w:ins ");
+  });
+
+  test("acceptAll and rejectAll resolve every tracked change", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+
+    const accepting = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI" });
+    const acceptBlocks = accepting.snapshot().blocks;
+    accepting.applyOperations([
+      {
+        id: "m1",
+        type: "replaceInBlock",
+        blockId: findBlock(acceptBlocks, "Heading").id,
+        find: "Heading",
+        replace: "Intro",
+      },
+      {
+        id: "m2",
+        type: "replaceInBlock",
+        blockId: findBlock(acceptBlocks, "Trailing").id,
+        find: "Trailing",
+        replace: "Closing",
+      },
+    ]);
+    expect(accepting.getChanges().length).toBeGreaterThanOrEqual(4);
+    expect(accepting.acceptAll()).toBeGreaterThanOrEqual(4);
+    const acceptedXml = await partText(await accepting.toBuffer(), "word/document.xml");
+    expect(acceptedXml).toContain("Intro paragraph.");
+    expect(acceptedXml).toContain("Closing paragraph.");
+    expect(acceptedXml).not.toContain("<w:ins ");
+    expect(acceptedXml).not.toContain("<w:del ");
+    expect(accepting.getChanges()).toEqual([]);
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI" });
+    const rejectBlocks = rejecting.snapshot().blocks;
+    rejecting.applyOperations([
+      {
+        id: "m3",
+        type: "replaceInBlock",
+        blockId: findBlock(rejectBlocks, "Heading").id,
+        find: "Heading",
+        replace: "Intro",
+      },
+      {
+        id: "m4",
+        type: "replaceInBlock",
+        blockId: findBlock(rejectBlocks, "Trailing").id,
+        find: "Trailing",
+        replace: "Closing",
+      },
+    ]);
+    expect(rejecting.rejectAll()).toBeGreaterThanOrEqual(4);
+    const rejectedXml = await partText(await rejecting.toBuffer(), "word/document.xml");
+    expect(rejectedXml).toContain("Heading paragraph.");
+    expect(rejectedXml).toContain("Trailing paragraph.");
+    expect(rejectedXml).not.toContain("Intro");
+    expect(rejectedXml).not.toContain("Closing");
+    expect(rejectedXml).not.toContain("<w:ins ");
+    expect(rejectedXml).not.toContain("<w:del ");
+  });
+
+  test("getComments returns authored comments with their anchor", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    reviewer.applyOperations([
+      {
+        id: "c1",
+        type: "commentOnBlock",
+        blockId: target.id,
+        comment: { text: "Clarify this clause." },
+      },
+    ]);
+
+    const comments = reviewer.getComments();
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.text).toBe("Clarify this clause.");
+    expect(comments[0]?.author).toBe("AI Reviewer");
+    expect(comments[0]?.blockId).toBe(target.id);
+    expect(comments[0]?.anchoredText).toContain("Heading paragraph.");
+    expect(reviewer.getComments({ author: "Nobody" })).toEqual([]);
   });
 });

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -396,4 +396,26 @@ describe("headless docx review discovery + resolve", () => {
     expect(comments[0]?.anchoredText).toContain("Heading paragraph.");
     expect(reviewer.getComments({ author: "Nobody" })).toEqual([]);
   });
+
+  test("ops from one parse's snapshot resolve on a separate parse of a paraId-less doc", async () => {
+    // The raw corpus fixture ships without `w14:paraId`s. Two independent
+    // parses must mint identical block ids so ops built against the first
+    // snapshot resolve against the second rather than skipping as missingBlock.
+    const first = await FolioDocxReviewer.fromBuffer(readFixture());
+    const snapshot = first.snapshot();
+    const target = findBlock(snapshot.blocks, "Heading");
+
+    const second = await FolioDocxReviewer.fromBuffer(readFixture());
+    expect(second.getContent().map((b) => b.id)).toEqual(first.getContent().map((b) => b.id));
+
+    const result = second.applyOperations(
+      [{ id: "d1", type: "replaceInBlock", blockId: target.id, find: "Heading", replace: "Intro" }],
+      { mode: "direct" },
+    );
+    expect(result.skipped).toEqual([]);
+    expect(result.applied.map((a) => a.id)).toEqual(["d1"]);
+
+    const outXml = await partText(await second.toBuffer(), "word/document.xml");
+    expect(outXml).toContain("Intro paragraph.");
+  });
 });

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -20,12 +20,19 @@
  */
 
 import { EditorState } from "prosemirror-state";
+import type { Command } from "prosemirror-state";
 import type { Plugin } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 
 import { attemptSelectiveSave } from "../docx/selectiveSave";
 import { parseDocx } from "../docx/parser";
 import { repackDocx } from "../docx/rezip";
+import {
+  acceptAIEditRevision,
+  acceptAllChanges,
+  rejectAIEditRevision,
+  rejectAllChanges,
+} from "../prosemirror/commands/comments";
 import { updateDocumentContent } from "../prosemirror/conversion/fromProseDoc";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
@@ -40,6 +47,7 @@ import type { Document } from "../types/document";
 import { applyFolioAIEditOperations } from "./apply";
 import { createFolioAIEditSnapshot } from "./snapshot";
 import type {
+  FolioAIBlock,
   FolioAIEditApplyMode,
   FolioAIEditApplyResult,
   FolioAIEditOperation,
@@ -90,6 +98,109 @@ export type FolioApplyOperationsOptions = {
    * `snapshot()` -> build ops -> `applyOperations()` on the same reviewer.
    */
   snapshot?: FolioAIEditSnapshot;
+};
+
+export type FolioReviewChangeKind = "insertion" | "deletion";
+
+/** A tracked change (insertion or deletion) discovered in the document body. */
+export type FolioReviewChange = {
+  /**
+   * The tracked-change revision id — the OOXML `w:id` carried on the
+   * insertion / deletion mark. Pass it (or the whole change) to
+   * {@link FolioDocxReviewer.acceptChange} / `rejectChange`. A replace produces
+   * two changes (a deletion side and an insertion side) with distinct ids.
+   */
+  id: number;
+  type: FolioReviewChangeKind;
+  author: string;
+  /** ISO date the change was authored, or `null` when the source omitted it. */
+  date: string | null;
+  /** Inserted text for insertions, removed text for deletions. */
+  text: string;
+  /**
+   * Stable id of the containing body block (Word `w14:paraId` or `seq-NNNN`),
+   * matching {@link FolioDocxReviewer.getContent}. `null` when the change sits
+   * in a block with no surviving visible text, which has no snapshot block.
+   */
+  blockId: string | null;
+};
+
+/** Filter for {@link FolioDocxReviewer.getChanges}. */
+export type FolioReviewChangeFilter = {
+  author?: string;
+  type?: FolioReviewChangeKind;
+};
+
+export type FolioReviewCommentReply = {
+  id: number;
+  author: string;
+  date: string | null;
+  text: string;
+};
+
+/** A comment thread discovered in the document. */
+export type FolioReviewComment = {
+  id: number;
+  author: string;
+  date: string | null;
+  /** The comment body text, its paragraphs joined by newlines. */
+  text: string;
+  /** The document text the comment is anchored to, or `""` when unanchored. */
+  anchoredText: string;
+  /** Stable id of the anchored body block, or `null` when the anchor is absent. */
+  blockId: string | null;
+  replies: FolioReviewCommentReply[];
+  /** Whether the comment is marked resolved / done. */
+  done: boolean;
+};
+
+/** Filter for {@link FolioDocxReviewer.getComments}. */
+export type FolioReviewCommentFilter = {
+  author?: string;
+  done?: boolean;
+};
+
+/**
+ * One LLM-ready line for a block: `[<blockId>] text`, with an `(h<level>)` tag
+ * for headings and the list marker for list items, so a model can copy the
+ * block id straight back into an operation.
+ */
+const formatBlockForLLM = (block: FolioAIBlock): string => {
+  const label = `[${block.id}]`;
+  if (block.kind === "heading") {
+    return `${label} (h${headingLevel(block)}) ${block.text}`;
+  }
+  if (block.kind === "listItem") {
+    return `${label} ${block.displayLabel ?? "•"} ${block.text}`;
+  }
+  return `${label} ${block.text}`;
+};
+
+const headingLevel = (block: FolioAIBlock): number => {
+  const digits = /(\d+)/u.exec(block.styleId ?? block.displayLabel ?? "")?.[1];
+  const level = digits ? Number.parseInt(digits, 10) : 1;
+  return level >= 1 && level <= 9 ? level : 1;
+};
+
+const revisionIdOf = (target: FolioReviewChange | number): number =>
+  typeof target === "number" ? target : target.id;
+
+const commentPlainText = (comment: Comment): string =>
+  comment.content.map(paragraphPlainText).join("\n");
+
+const paragraphPlainText = (paragraph: Comment["content"][number]): string => {
+  const parts: string[] = [];
+  for (const item of paragraph.content) {
+    if (item.type !== "run") {
+      continue;
+    }
+    for (const runItem of item.content) {
+      if (runItem.type === "text") {
+        parts.push(runItem.text);
+      }
+    }
+  }
+  return parts.join("");
 };
 
 /**
@@ -198,6 +309,187 @@ export class FolioDocxReviewer {
     return result;
   }
 
+  /**
+   * The body blocks with their stable ids, in document order — the same
+   * `FolioAIBlock` shape {@link snapshot} builds, reused verbatim so the ids
+   * feed straight back into {@link applyOperations} and accept / reject.
+   */
+  getContent(): FolioAIBlock[] {
+    return this.snapshot().blocks;
+  }
+
+  /**
+   * The body as LLM-ready plain text: one line per block, each prefixed with
+   * its stable block id (`[<blockId>] text`). Copyable verbatim into a prompt
+   * without JSON quote-escaping.
+   */
+  getContentAsText(): string {
+    return this.getContent().map(formatBlockForLLM).join("\n");
+  }
+
+  /**
+   * The tracked changes (insertions and deletions) present in the body, read
+   * from the same `insertion` / `deletion` marks the editor renders. Each
+   * carries the revision id {@link acceptChange} / {@link rejectChange} resolve
+   * against. Runs of one revision within a block fold into a single entry.
+   */
+  getChanges(filter?: FolioReviewChangeFilter): FolioReviewChange[] {
+    const insertionType = this.state.schema.marks["insertion"];
+    const deletionType = this.state.schema.marks["deletion"];
+    const blockStarts = this.blockStartIds();
+    const grouped = new Map<string, FolioReviewChange>();
+    let currentBlockId: string | null = null;
+
+    this.state.doc.descendants((node, pos) => {
+      if (node.isTextblock) {
+        currentBlockId = blockStarts.get(pos) ?? null;
+        return true;
+      }
+      if (!node.isInline || node.text === undefined) {
+        return undefined;
+      }
+      const text = node.text;
+      for (const mark of node.marks) {
+        if (typeof mark.attrs["revisionId"] !== "number") {
+          continue;
+        }
+        let kind: FolioReviewChangeKind;
+        if (mark.type === insertionType) {
+          kind = "insertion";
+        } else if (mark.type === deletionType) {
+          kind = "deletion";
+        } else {
+          continue;
+        }
+        const revisionId = mark.attrs["revisionId"];
+        const key = `${currentBlockId ?? ""}:${kind}:${revisionId}`;
+        const existing = grouped.get(key);
+        if (existing) {
+          existing.text += text;
+          continue;
+        }
+        const author = mark.attrs["author"];
+        const date = mark.attrs["date"];
+        grouped.set(key, {
+          id: revisionId,
+          type: kind,
+          author: typeof author === "string" ? author : "",
+          date: typeof date === "string" ? date : null,
+          text,
+          blockId: currentBlockId,
+        });
+      }
+      return undefined;
+    });
+
+    const changes = [...grouped.values()];
+    if (!filter) {
+      return changes;
+    }
+    return changes.filter(
+      (change) =>
+        (filter.author === undefined || change.author === filter.author) &&
+        (filter.type === undefined || change.type === filter.type),
+    );
+  }
+
+  /**
+   * The comment threads in the document — comments parsed from the package plus
+   * any the reviewer authored — with their anchored text and containing block
+   * id. Only run text is read from a comment body; richer comment content
+   * (nested tracked changes, hyperlinks) is out of scope.
+   */
+  getComments(filter?: FolioReviewCommentFilter): FolioReviewComment[] {
+    const definitions = [
+      ...(this.baseDocument.package.document.comments ?? []),
+      ...this.createdComments,
+    ];
+    if (definitions.length === 0) {
+      return [];
+    }
+
+    const anchors = this.commentAnchors();
+    const repliesByParent = new Map<number, Comment[]>();
+    const topLevel: Comment[] = [];
+    for (const comment of definitions) {
+      if (comment.parentId === undefined) {
+        topLevel.push(comment);
+        continue;
+      }
+      const siblings = repliesByParent.get(comment.parentId) ?? [];
+      siblings.push(comment);
+      repliesByParent.set(comment.parentId, siblings);
+    }
+
+    const threads = topLevel.map<FolioReviewComment>((comment) => {
+      const anchor = anchors.get(comment.id);
+      return {
+        id: comment.id,
+        author: comment.author,
+        date: comment.date ?? null,
+        text: commentPlainText(comment),
+        anchoredText: anchor?.text ?? "",
+        blockId: anchor?.blockId ?? null,
+        replies: (repliesByParent.get(comment.id) ?? []).map((reply) => ({
+          id: reply.id,
+          author: reply.author,
+          date: reply.date ?? null,
+          text: commentPlainText(reply),
+        })),
+        done: comment.done ?? false,
+      };
+    });
+
+    if (!filter) {
+      return threads;
+    }
+    return threads.filter(
+      (thread) =>
+        (filter.author === undefined || thread.author === filter.author) &&
+        (filter.done === undefined || thread.done === filter.done),
+    );
+  }
+
+  /**
+   * Accept an existing tracked change, keeping its text and dropping the
+   * redline. Pass a {@link FolioReviewChange} from {@link getChanges} or its
+   * revision id. Reuses the editor's own accept command headlessly, so the
+   * resolved state persists on {@link toBuffer}. Returns `false` when the
+   * revision is no longer present (already resolved, or never existed).
+   */
+  acceptChange(target: FolioReviewChange | number): boolean {
+    return this.runCommand(acceptAIEditRevision(revisionIdOf(target)));
+  }
+
+  /**
+   * Reject an existing tracked change: an insertion's text is removed, a
+   * deletion's text is restored. See {@link acceptChange} for targeting.
+   */
+  rejectChange(target: FolioReviewChange | number): boolean {
+    return this.runCommand(rejectAIEditRevision(revisionIdOf(target)));
+  }
+
+  /**
+   * Accept every tracked change in the body. Returns the number of changes
+   * present before the sweep. Note-body changes are out of scope.
+   */
+  acceptAll(): number {
+    const count = this.getChanges().length;
+    if (count > 0) {
+      this.runCommand(acceptAllChanges());
+    }
+    return count;
+  }
+
+  /** Reject every tracked change in the body. See {@link acceptAll}. */
+  rejectAll(): number {
+    const count = this.getChanges().length;
+    if (count > 0) {
+      this.runCommand(rejectAllChanges());
+    }
+    return count;
+  }
+
   /** The current document model with edits merged back in. */
   toDocument(): Document {
     const document = updateDocumentContent(this.baseDocument, this.state.doc);
@@ -227,6 +519,70 @@ export class FolioDocxReviewer {
       return selective;
     }
     return repackDocx({ ...document, originalBuffer: this.originalBuffer });
+  }
+
+  /** Map each snapshot block's start position to its stable id. */
+  private blockStartIds(): Map<number, string> {
+    const starts = new Map<number, string>();
+    for (const anchor of Object.values(this.snapshot().anchors)) {
+      starts.set(anchor.from, anchor.id);
+    }
+    return starts;
+  }
+
+  /** Map each anchored comment id to its anchored text and containing block id. */
+  private commentAnchors(): Map<number, { text: string; blockId: string | null }> {
+    const commentType = this.state.schema.marks["comment"];
+    const anchors = new Map<number, { text: string; blockId: string | null }>();
+    if (!commentType) {
+      return anchors;
+    }
+    const blockStarts = this.blockStartIds();
+    let currentBlockId: string | null = null;
+
+    this.state.doc.descendants((node, pos) => {
+      if (node.isTextblock) {
+        currentBlockId = blockStarts.get(pos) ?? null;
+        return true;
+      }
+      if (!node.isInline || node.text === undefined) {
+        return undefined;
+      }
+      const text = node.text;
+      for (const mark of node.marks) {
+        if (mark.type !== commentType || typeof mark.attrs["commentId"] !== "number") {
+          continue;
+        }
+        const commentId = mark.attrs["commentId"];
+        const existing = anchors.get(commentId);
+        if (!existing) {
+          anchors.set(commentId, { text, blockId: currentBlockId });
+          continue;
+        }
+        existing.text += text;
+        existing.blockId ??= currentBlockId;
+      }
+      return undefined;
+    });
+
+    return anchors;
+  }
+
+  /**
+   * Drive a ProseMirror command against the reviewer's headless state via the
+   * same `{ state, dispatch }` seam {@link applyOperations} uses, retaining the
+   * resulting state for {@link toBuffer}.
+   */
+  private runCommand(command: Command): boolean {
+    const view = {
+      state: this.state,
+      dispatch: (transaction: Transaction) => {
+        view.state = view.state.apply(transaction);
+      },
+    };
+    const handled = command(view.state, view.dispatch);
+    this.state = view.state;
+    return handled;
   }
 }
 

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -1,0 +1,274 @@
+/**
+ * Headless `.docx` review path: buffer -> apply AI edits -> buffer, with
+ * no `EditorView` and no DOM. A queue worker or agent can read a document,
+ * apply `FolioAIEditOperation`s (tracked-changes or direct), and write a
+ * reviewed `.docx` back out — the server-side counterpart to the React
+ * editor's live apply flow.
+ *
+ * The operation applier is shared, not forked: {@link applyFolioAIEditOperations}
+ * only needs a {@link FolioAIEditView} seam (`{ state, dispatch }`), which a
+ * headless `EditorState` satisfies via `state.apply(tr)`. The React editor and
+ * this reviewer therefore run byte-for-byte the same anchor resolution,
+ * word-diff redlines, and tracked-change bookkeeping.
+ *
+ * Save mirrors the editor's own path: a selective patch of only the changed
+ * paragraphs in `document.xml` (leaving every untouched part byte-exact), with
+ * a full repack as the fallback for structural edits.
+ *
+ * Scope: BODY blocks. Footnote / endnote note-body apply is intentionally out
+ * of scope here and can build on the note serialization work separately.
+ */
+
+import { EditorState } from "prosemirror-state";
+import type { Plugin } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import { attemptSelectiveSave } from "../docx/selectiveSave";
+import { parseDocx } from "../docx/parser";
+import { repackDocx } from "../docx/rezip";
+import { updateDocumentContent } from "../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
+import {
+  getChangedParagraphIds,
+  hasStructuralChanges,
+  hasUntrackedChanges,
+} from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
+import { schema, singletonManager } from "../prosemirror/schema";
+import type { Comment } from "../types/content";
+import type { Document } from "../types/document";
+import { applyFolioAIEditOperations } from "./apply";
+import { createFolioAIEditSnapshot } from "./snapshot";
+import type {
+  FolioAIEditApplyMode,
+  FolioAIEditApplyResult,
+  FolioAIEditOperation,
+  FolioAIEditSnapshot,
+} from "./types";
+
+/**
+ * Standalone comment-id allocator for the reviewer. The React editor uses
+ * `Date.now()`-seeded ids from `commentsHelpers`; that module is DOM-bound
+ * (`EditorView`, `findBodyPmAnchors`) and unimportable here, so the reviewer
+ * mints its own. Seeded once per realm and incremented so ids stay unique
+ * across reviewers created within the same millisecond.
+ */
+let commentIdCursor = Date.now();
+
+/**
+ * Build the note-free comment thread the apply layer references by id.
+ * Mirrors `commentsHelpers.createComment` (a pure object literal there) so a
+ * headless `commentOnBlock` / `comment` op serialises the same `comments.xml`
+ * shape the editor produces.
+ */
+const createReviewerComment = (text: string, author: string): Comment => ({
+  id: commentIdCursor++,
+  author,
+  date: new Date().toISOString(),
+  content: [
+    {
+      type: "paragraph",
+      formatting: {},
+      content: [{ type: "run", formatting: {}, content: [{ type: "text", text }] }],
+    },
+  ],
+});
+
+/** Options for {@link FolioDocxReviewer.fromBuffer}. */
+export type FolioDocxReviewerOptions = {
+  /** Default author for tracked changes and comments. (default: `"AI"`) */
+  author?: string;
+};
+
+/** Options for {@link FolioDocxReviewer.applyOperations}. */
+export type FolioApplyOperationsOptions = {
+  /** `"tracked-changes"` (default) produces ins/del redlines; `"direct"` edits in place. */
+  mode?: FolioAIEditApplyMode;
+  /**
+   * The snapshot the `operations`' block ids were built against. Omit to
+   * snapshot the reviewer's current state — correct for the common flow of
+   * `snapshot()` -> build ops -> `applyOperations()` on the same reviewer.
+   */
+  snapshot?: FolioAIEditSnapshot;
+};
+
+/**
+ * Headless `.docx` reviewer. Parse a buffer, read blocks, apply
+ * `FolioAIEditOperation`s against the document model, and write the reviewed
+ * `.docx` back out — no editor instance, no DOM.
+ *
+ * @example
+ * ```ts
+ * const reviewer = await FolioDocxReviewer.fromBuffer(buffer, { author: "AI" });
+ * const { blocks } = reviewer.snapshot();
+ * reviewer.applyOperations([
+ *   { id: "1", type: "replaceInBlock", blockId: blocks[0].id, find: "$50k", replace: "$500k" },
+ * ]);
+ * const reviewed = await reviewer.toBuffer();
+ * ```
+ */
+export class FolioDocxReviewer {
+  /** Default author for tracked changes and comments. */
+  readonly author: string;
+  private readonly baseDocument: Document;
+  private readonly originalBuffer: ArrayBuffer;
+  private state: EditorState;
+  private readonly createdComments: Comment[] = [];
+
+  private constructor(args: {
+    baseDocument: Document;
+    originalBuffer: ArrayBuffer;
+    state: EditorState;
+    author: string;
+  }) {
+    this.baseDocument = args.baseDocument;
+    this.originalBuffer = args.originalBuffer;
+    this.state = args.state;
+    this.author = args.author;
+  }
+
+  /** Parse a `.docx` buffer into a reviewer. */
+  static async fromBuffer(
+    buffer: ArrayBuffer,
+    options: FolioDocxReviewerOptions = {},
+  ): Promise<FolioDocxReviewer> {
+    const baseDocument = await parseDocx(buffer, {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    // Same plugin set the live editor mounts: the change tracker feeds the
+    // selective-save key set, and the paraId allocator hands freshly inserted
+    // paragraphs a stable `w14:paraId`. No plugin `view()` runs headlessly, so
+    // the DOM-facing halves stay dormant.
+    const plugins: Plugin[] = singletonManager.getPlugins();
+    // Allocate paraIds up front (the editor does this on load) so every block
+    // anchors on a stable id and the selective-save path can key changed
+    // paragraphs by paraId. `ensureParaIdsInState` marks its transaction
+    // ignore-tracked, so the change baseline stays clean.
+    const state = ensureParaIdsInState(
+      EditorState.create({ schema, doc: toProseDoc(baseDocument), plugins }),
+    );
+    return new FolioDocxReviewer({
+      baseDocument,
+      originalBuffer: buffer,
+      state,
+      author: options.author ?? "AI",
+    });
+  }
+
+  /**
+   * Snapshot the current document into AI-facing blocks (id, kind, text) plus
+   * the anchor map the apply layer resolves operations against.
+   */
+  snapshot(): FolioAIEditSnapshot {
+    return createFolioAIEditSnapshot(this.state.doc);
+  }
+
+  /**
+   * Apply operations against the current state. Reuses the live-editor applier
+   * verbatim via a headless `{ state, dispatch }` seam; the resulting state
+   * (including any comments) is retained for {@link toBuffer}.
+   */
+  applyOperations(
+    operations: FolioAIEditOperation[],
+    options: FolioApplyOperationsOptions = {},
+  ): FolioAIEditApplyResult {
+    const snapshot = options.snapshot ?? this.snapshot();
+    const view = {
+      state: this.state,
+      dispatch: (transaction: Transaction) => {
+        view.state = view.state.apply(transaction);
+      },
+    };
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations,
+      mode: options.mode ?? "tracked-changes",
+      author: this.author,
+      createCommentId: (text) => {
+        const comment = createReviewerComment(text, this.author);
+        this.createdComments.push(comment);
+        return comment.id;
+      },
+    });
+
+    this.state = view.state;
+    return result;
+  }
+
+  /** The current document model with edits merged back in. */
+  toDocument(): Document {
+    const document = updateDocumentContent(this.baseDocument, this.state.doc);
+    if (this.createdComments.length > 0) {
+      document.package.document.comments = [
+        ...(document.package.document.comments ?? []),
+        ...this.createdComments,
+      ];
+    }
+    return document;
+  }
+
+  /**
+   * Serialise the reviewed document to a new `.docx` buffer. Tries a selective
+   * patch first (only changed paragraphs are rewritten; every other byte of the
+   * original package is preserved), falling back to a full repack for
+   * structural edits — the same two-tier path the editor's save uses.
+   */
+  async toBuffer(): Promise<ArrayBuffer> {
+    const document = this.toDocument();
+    const selective = await attemptSelectiveSave(document, this.originalBuffer, {
+      changedParaIds: getChangedParagraphIds(this.state),
+      structuralChange: hasStructuralChanges(this.state),
+      hasUntrackedChanges: hasUntrackedChanges(this.state),
+    });
+    if (selective) {
+      return selective;
+    }
+    return repackDocx({ ...document, originalBuffer: this.originalBuffer });
+  }
+}
+
+/** Options for {@link applyFolioAIEditsToBuffer}. */
+export type ApplyFolioAIEditsToBufferOptions = {
+  /** Default author for tracked changes and comments. (default: `"AI"`) */
+  author?: string;
+  /** `"tracked-changes"` (default) produces ins/del redlines; `"direct"` edits in place. */
+  mode?: FolioAIEditApplyMode;
+  /**
+   * The snapshot the `operations`' block ids were built against. Omit to
+   * snapshot the freshly parsed buffer. Pass it when the ids were derived in a
+   * separate process (e.g. server-side `@stll/folio-core/server` block ids) so
+   * anchor resolution matches exactly.
+   */
+  snapshot?: FolioAIEditSnapshot;
+};
+
+/** Result of {@link applyFolioAIEditsToBuffer}. */
+export type ApplyFolioAIEditsToBufferResult = FolioAIEditApplyResult & {
+  /** The reviewed `.docx` as a new buffer. */
+  buffer: ArrayBuffer;
+};
+
+/**
+ * One-shot headless review: parse `buffer`, apply `operations`, and return the
+ * reviewed `.docx` buffer alongside the applied / skipped breakdown. Convenience
+ * wrapper over {@link FolioDocxReviewer} for callers that already hold the
+ * operations to run.
+ */
+export const applyFolioAIEditsToBuffer = async (
+  buffer: ArrayBuffer,
+  operations: FolioAIEditOperation[],
+  options: ApplyFolioAIEditsToBufferOptions = {},
+): Promise<ApplyFolioAIEditsToBufferResult> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(buffer, {
+    ...(options.author !== undefined && { author: options.author }),
+  });
+  const { applied, skipped } = reviewer.applyOperations(operations, {
+    ...(options.mode !== undefined && { mode: options.mode }),
+    ...(options.snapshot !== undefined && { snapshot: options.snapshot }),
+  });
+  const reviewed = await reviewer.toBuffer();
+  return { buffer: reviewed, applied, skipped };
+};

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -35,15 +35,16 @@ import {
 } from "../prosemirror/commands/comments";
 import { updateDocumentContent } from "../prosemirror/conversion/fromProseDoc";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
-import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
 import {
   getChangedParagraphIds,
   hasStructuralChanges,
   hasUntrackedChanges,
+  ignoreTrackedChanges,
 } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { schema, singletonManager } from "../prosemirror/schema";
 import type { Comment } from "../types/content";
 import type { Document } from "../types/document";
+import { MAX_HEX_ID_EXCLUSIVE } from "../utils/hexId";
 import { applyFolioAIEditOperations } from "./apply";
 import { createFolioAIEditSnapshot } from "./snapshot";
 import type {
@@ -81,6 +82,67 @@ const createReviewerComment = (text: string, author: string): Comment => ({
     },
   ],
 });
+
+/** Deterministic 8-char uppercase hex id (FNV-1a over `seed`), `< 0x7FFFFFFF`. */
+const deterministicHexId = (seed: string): string => {
+  let hash = 2_166_136_261;
+  for (const character of seed) {
+    hash = Math.imul(hash ^ (character.codePointAt(0) ?? 0), 16_777_619) >>> 0;
+  }
+  return (hash % MAX_HEX_ID_EXCLUSIVE).toString(16).toUpperCase().padStart(8, "0");
+};
+
+/**
+ * Assign a stable `w14:paraId` to every body paragraph that lacks one (or
+ * duplicates an earlier id), derived deterministically from the paragraph's
+ * text plus its document ordinal. Re-parsing the SAME bytes mints the SAME ids,
+ * so the block ids a snapshot exposes are reproducible across
+ * {@link FolioDocxReviewer.fromBuffer} calls — the documented "snapshot on one
+ * parse, apply on another" flow resolves instead of skipping every op as a
+ * stale anchor. Word-authored paraIds are preserved; only gaps and collisions
+ * get a fresh id.
+ *
+ * The shared `ParaIdAllocatorExtension` mints RANDOM ids (correct for freshly
+ * typed paragraphs in the live editor); this load-time pass is deterministic so
+ * a paraId-less corpus document anchors reproducibly. The transaction is marked
+ * ignore-tracked so the change baseline stays clean.
+ */
+const ensureDeterministicParaIdsInState = (state: EditorState): EditorState => {
+  const seen = new Set<string>();
+  const updates: { pos: number; attrs: Record<string, unknown> }[] = [];
+  let ordinal = 0;
+
+  state.doc.descendants((node, pos) => {
+    if (node.type.name !== "paragraph") {
+      return undefined;
+    }
+    ordinal += 1;
+    const existing = node.attrs["paraId"];
+    if (typeof existing === "string" && existing.length > 0 && !seen.has(existing)) {
+      seen.add(existing);
+      return false;
+    }
+    let paraId = deterministicHexId(`${node.textContent}:${ordinal}`);
+    for (let salt = 1; seen.has(paraId); salt++) {
+      paraId = deterministicHexId(`${node.textContent}:${ordinal}:${salt}`);
+    }
+    seen.add(paraId);
+    updates.push({ pos, attrs: { ...node.attrs, paraId } });
+    return false;
+  });
+
+  if (updates.length === 0) {
+    return state;
+  }
+
+  const tr = state.tr;
+  for (const update of updates) {
+    tr.setNodeMarkup(update.pos, undefined, update.attrs);
+  }
+  ignoreTrackedChanges(tr);
+  tr.setMeta("addToHistory", false);
+  return state.apply(tr);
+};
 
 /** Options for {@link FolioDocxReviewer.fromBuffer}. */
 export type FolioDocxReviewerOptions = {
@@ -186,15 +248,17 @@ const revisionIdOf = (target: FolioReviewChange | number): number =>
   typeof target === "number" ? target : target.id;
 
 const commentPlainText = (comment: Comment): string =>
-  comment.content.map(paragraphPlainText).join("\n");
+  // A comment parsed from a malformed package can omit `content`; the model
+  // types it as required, so guard at this untrusted boundary.
+  (comment.content ?? []).map(paragraphPlainText).join("\n");
 
 const paragraphPlainText = (paragraph: Comment["content"][number]): string => {
   const parts: string[] = [];
-  for (const item of paragraph.content) {
+  for (const item of paragraph.content ?? []) {
     if (item.type !== "run") {
       continue;
     }
-    for (const runItem of item.content) {
+    for (const runItem of item.content ?? []) {
       if (runItem.type === "text") {
         parts.push(runItem.text);
       }
@@ -254,9 +318,11 @@ export class FolioDocxReviewer {
     const plugins: Plugin[] = singletonManager.getPlugins();
     // Allocate paraIds up front (the editor does this on load) so every block
     // anchors on a stable id and the selective-save path can key changed
-    // paragraphs by paraId. `ensureParaIdsInState` marks its transaction
-    // ignore-tracked, so the change baseline stays clean.
-    const state = ensureParaIdsInState(
+    // paragraphs by paraId. Deterministic (not random) allocation so a
+    // paraId-less document yields the SAME block ids on every parse: ops built
+    // from one parse's snapshot then resolve against another parse of the same
+    // bytes instead of skipping as stale anchors.
+    const state = ensureDeterministicParaIdsInState(
       EditorState.create({ schema, doc: toProseDoc(baseDocument), plugins }),
     );
     return new FolioDocxReviewer({
@@ -471,22 +537,21 @@ export class FolioDocxReviewer {
 
   /**
    * Accept every tracked change in the body. Returns the number of changes
-   * present before the sweep. Note-body changes are out of scope.
+   * present before the sweep. Runs unconditionally: the underlying command also
+   * resolves paragraph-level changes (`w:pPrChange`, paragraph-boundary
+   * ins/del) that {@link getChanges} does not enumerate. Note-body changes are
+   * out of scope.
    */
   acceptAll(): number {
-    const count = this.getChanges().length;
-    if (count > 0) {
-      this.runCommand(acceptAllChanges());
-    }
+    const count = this.countTrackedChanges();
+    this.runCommand(acceptAllChanges());
     return count;
   }
 
   /** Reject every tracked change in the body. See {@link acceptAll}. */
   rejectAll(): number {
-    const count = this.getChanges().length;
-    if (count > 0) {
-      this.runCommand(rejectAllChanges());
-    }
+    const count = this.countTrackedChanges();
+    this.runCommand(rejectAllChanges());
     return count;
   }
 
@@ -510,15 +575,54 @@ export class FolioDocxReviewer {
    */
   async toBuffer(): Promise<ArrayBuffer> {
     const document = this.toDocument();
-    const selective = await attemptSelectiveSave(document, this.originalBuffer, {
-      changedParaIds: getChangedParagraphIds(this.state),
-      structuralChange: hasStructuralChanges(this.state),
-      hasUntrackedChanges: hasUntrackedChanges(this.state),
-    });
+    const selective = await this.trySelectiveSave(document);
     if (selective) {
       return selective;
     }
     return repackDocx({ ...document, originalBuffer: this.originalBuffer });
+  }
+
+  /**
+   * Attempt the selective patch, treating a throw the same as a decline. Odd
+   * source XML can make the paragraph diff throw rather than return `null`; a
+   * full repack is the correct lossless fallback in both cases, so the fallback
+   * is the graceful handling — no separate error surface is needed here.
+   */
+  private async trySelectiveSave(document: Document): Promise<ArrayBuffer | null> {
+    try {
+      return await attemptSelectiveSave(document, this.originalBuffer, {
+        changedParaIds: getChangedParagraphIds(this.state),
+        structuralChange: hasStructuralChanges(this.state),
+        hasUntrackedChanges: hasUntrackedChanges(this.state),
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Count every tracked change an accept-all / reject-all sweep resolves: the
+   * inline insertion / deletion groups {@link getChanges} enumerates, plus
+   * paragraph-level changes (`pPrMark`, `_propertyChanges`) that live on
+   * paragraph attrs rather than inline marks.
+   */
+  private countTrackedChanges(): number {
+    let count = this.getChanges().length;
+    this.state.doc.descendants((node) => {
+      if (node.type.name !== "paragraph") {
+        return undefined;
+      }
+      const pPrMark = node.attrs["pPrMark"];
+      if (pPrMark !== null && pPrMark !== undefined) {
+        count += 1;
+      }
+      const propertyChanges = node.attrs["_propertyChanges"];
+      if (Array.isArray(propertyChanges) && propertyChanges.length > 0) {
+        count += 1;
+      }
+      return false;
+    });
+    return count;
   }
 
   /** Map each snapshot block's start position to its stable id. */

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -1,4 +1,4 @@
-export { applyFolioAIEditOperations } from "./apply";
+export { applyFolioAIEditOperations, type FolioAIEditView } from "./apply";
 export {
   createFolioAIEditSnapshot,
   hashFolioAIBlockText,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -26,3 +26,17 @@ export {
 } from "./types/block-id";
 export { createDocx } from "./docx/rezip";
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
+export {
+  FolioDocxReviewer,
+  applyFolioAIEditsToBuffer,
+  type ApplyFolioAIEditsToBufferOptions,
+  type ApplyFolioAIEditsToBufferResult,
+  type FolioApplyOperationsOptions,
+  type FolioDocxReviewerOptions,
+} from "./ai-edits/headless";
+export type {
+  FolioAIComment,
+  FolioAIEditApplyMode,
+  FolioAIEditApplyResult,
+  FolioAIEditOperation,
+} from "./ai-edits/types";

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -33,6 +33,12 @@ export {
   type ApplyFolioAIEditsToBufferResult,
   type FolioApplyOperationsOptions,
   type FolioDocxReviewerOptions,
+  type FolioReviewChange,
+  type FolioReviewChangeFilter,
+  type FolioReviewChangeKind,
+  type FolioReviewComment,
+  type FolioReviewCommentFilter,
+  type FolioReviewCommentReply,
 } from "./ai-edits/headless";
 export type {
   FolioAIComment,

--- a/scripts/validate-dist.ts
+++ b/scripts/validate-dist.ts
@@ -137,7 +137,13 @@ const runtimeExpect: Record<string, Record<string, string[]>> = {
   core: {
     "@stll/folio-core": ["createEmptyDocument", "createDocx", "deriveBlockId"],
     "@stll/folio-core/markdown": ["toMarkdown", "fromMarkdown", "toMarkdownResult"],
-    "@stll/folio-core/server": ["deriveBlockId", "createEmptyDocument", "createDocx"],
+    "@stll/folio-core/server": [
+      "deriveBlockId",
+      "createEmptyDocument",
+      "createDocx",
+      "FolioDocxReviewer",
+      "applyFolioAIEditsToBuffer",
+    ],
     "@stll/folio-core/types/block-id": ["deriveBlockId", "isFolioBlockId"],
   },
   react: {


### PR DESCRIPTION
Adds a **headless `.docx` review path** to core: buffer → apply/accept/reject → buffer, with **no browser and no ProseMirror view**. Exported from `@stll/folio-core/server`, so a queue worker / CI job / agent can review a `.docx` server-side.

### `FolioDocxReviewer`
- `static fromBuffer(buffer, { author? })` · `snapshot()` · `toDocument()` · `toBuffer()`
- **Apply:** `applyOperations(ops, { mode: 'tracked-changes' | 'direct', snapshot? })` (folio's `FolioAIEditOperation` model, body blocks) — plus a one-shot `applyFolioAIEditsToBuffer(buffer, ops, opts)`.
- **Read / discover:** `getContent()` · `getContentAsText()` (block-id-labelled, LLM-ready) · `getChanges(filter?)` · `getComments(filter?)`.
- **Accept / reject existing changes:** `acceptChange` · `rejectChange` · `acceptAll` · `rejectAll`.

It's implemented entirely off the existing view-agnostic `{ state, dispatch }` seam — no apply/accept/reject logic is forked; the reviewer reuses the same snapshot extraction, `applyFolioAIEditOperations`, and the editor's revision/comment commands. The live-view `applyFolioAIEditOperations({ view, ... })` signature is unchanged.

This closes the highest-value gap vs upstream's `agents` package and reaches parity with its `DocxReviewer` API. Scope is **body blocks** (footnote/endnote bodies ride the separate note-serialization work). Known limits documented in code: `getChanges().blockId` is `null` for deletion-only blocks; comment bodies read run text only; targeting is by `revisionId`.

Round-trip tests cover apply (both modes), read, and accept/reject → `toBuffer` → re-parse.
