### PR TITLE
feat(core): render embedded (obfuscated) .docx fonts

### DIFF
--- a/packages/core/src/fonts/embeddedFontTable.ts
+++ b/packages/core/src/fonts/embeddedFontTable.ts
@@ -1,0 +1,119 @@
+/**
+ * Parses the embedded-font references out of `word/fontTable.xml`.
+ *
+ * The shared docx model (`@stll/docx-core`) keeps only the embed relationship
+ * ids and drops the `w:fontKey` GUID, which is exactly the value needed to
+ * de-obfuscate the `.odttf` binary. This parser therefore reads the font table
+ * directly and keeps the full embed reference (rel id, key, subsetted flag).
+ *
+ * Structure:
+ * ```xml
+ * <w:fonts>
+ *   <w:font w:name="My Brand Sans">
+ *     <w:embedRegular r:id="rId1" w:fontKey="{GUID}" w:subsetted="true"/>
+ *   </w:font>
+ * </w:fonts>
+ * ```
+ *
+ * Ported from eigenpal/docx-editor (see NOTICE.md).
+ */
+
+import { findChild, findChildren, getAttribute, parseXmlDocument } from "../docx/xmlParser";
+import type { XmlElement } from "../docx/xmlParser";
+
+/** A single embedded face referenced from a `w:embed*` element. */
+export type EmbeddedFontFaceRef = {
+  /** Relationship id (`r:id`) resolved via `word/_rels/fontTable.xml.rels`. */
+  relId: string;
+  /** Obfuscation key GUID (`w:fontKey`), e.g. `{XXXXXXXX-...}`. */
+  fontKey?: string;
+  /** Whether the embedded face is subsetted (`w:subsetted`). */
+  subsetted?: boolean;
+};
+
+/** One `<w:font>` entry with whichever of the four embed faces it declares. */
+export type EmbeddedFontEntry = {
+  name: string;
+  embedRegular?: EmbeddedFontFaceRef;
+  embedBold?: EmbeddedFontFaceRef;
+  embedItalic?: EmbeddedFontFaceRef;
+  embedBoldItalic?: EmbeddedFontFaceRef;
+};
+
+/** The four `w:embed*` local names paired with the entry field they populate. */
+const EMBED_ELEMENTS = [
+  { element: "embedRegular", field: "embedRegular" },
+  { element: "embedBold", field: "embedBold" },
+  { element: "embedItalic", field: "embedItalic" },
+  { element: "embedBoldItalic", field: "embedBoldItalic" },
+] as const;
+
+function parseEmbed(font: XmlElement, localName: string): EmbeddedFontFaceRef | undefined {
+  const el = findChild(font, "w", localName);
+  if (!el) {
+    return undefined;
+  }
+
+  const relId = getAttribute(el, "r", "id");
+  if (!relId) {
+    // An embed with no relationship cannot resolve to a binary; skip it.
+    return undefined;
+  }
+
+  const ref: EmbeddedFontFaceRef = { relId };
+
+  const fontKey = getAttribute(el, "w", "fontKey");
+  if (fontKey) {
+    ref.fontKey = fontKey;
+  }
+
+  const subsetted = getAttribute(el, "w", "subsetted");
+  if (subsetted === "true" || subsetted === "1") {
+    ref.subsetted = true;
+  }
+
+  return ref;
+}
+
+function parseFontEntry(font: XmlElement): EmbeddedFontEntry | null {
+  const name = getAttribute(font, "w", "name");
+  if (!name) {
+    return null;
+  }
+
+  const entry: EmbeddedFontEntry = { name };
+  for (const { element, field } of EMBED_ELEMENTS) {
+    const ref = parseEmbed(font, element);
+    if (ref) {
+      entry[field] = ref;
+    }
+  }
+  return entry;
+}
+
+/**
+ * Parse `word/fontTable.xml` into the list of font entries that declare at
+ * least one embedded face. Entries with no embeds are still returned (callers
+ * filter), and missing/unparseable input yields an empty list.
+ */
+export function parseEmbeddedFontTable(
+  fontTableXml: string | null | undefined,
+): EmbeddedFontEntry[] {
+  if (!fontTableXml || fontTableXml.trim().length === 0) {
+    return [];
+  }
+
+  const root = parseXmlDocument(fontTableXml);
+  if (!root) {
+    return [];
+  }
+
+  const entries: EmbeddedFontEntry[] = [];
+  for (const font of findChildren(root, "w", "font")) {
+    const entry = parseFontEntry(font);
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+  return entries;
+}

--- a/packages/core/src/fonts/embeddedFonts.test.ts
+++ b/packages/core/src/fonts/embeddedFonts.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "../docx/parser";
+import { repackDocx } from "../docx/rezip";
+import { extractEmbeddedFonts, getEmbeddedFontFaces } from "./embeddedFonts";
+import { parseEmbeddedFontTable } from "./embeddedFontTable";
+import { deobfuscateFont, isValidFontKey } from "./fontDeobfuscation";
+
+const XML_DECLARATION = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`;
+const GUID = "{001B70DC-AA60-4AD5-90EC-18A0948E1EAE}";
+
+/**
+ * A 64-byte stand-in font: a TrueType sfnt signature (`00 01 00 00`) followed
+ * by deterministic filler. We obfuscate it so the extract path must
+ * de-obfuscate to recover the recognizable header.
+ */
+function makeFont(): Uint8Array {
+  const font = new Uint8Array(64);
+  font.set([0x00, 0x01, 0x00, 0x00], 0);
+  for (let i = 4; i < font.length; i++) {
+    font[i] = (i * 17 + 5) & 0xff;
+  }
+  return font;
+}
+
+/** Whether the first four bytes are a known SFNT/OpenType signature. */
+function hasSfntSignature(bytes: Uint8Array): boolean {
+  const tag =
+    ((bytes[0] ?? 0) << 24) | ((bytes[1] ?? 0) << 16) | ((bytes[2] ?? 0) << 8) | (bytes[3] ?? 0);
+  const SIGNATURES = [
+    0x00010000, // TrueType
+    0x4f54544f, // 'OTTO' (CFF/OpenType)
+    0x74727565, // 'true'
+    0x74746366, // 'ttcf' (TrueType collection)
+  ];
+  return SIGNATURES.includes(tag >>> 0);
+}
+
+const CONTENT_TYPES = `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="odttf" ContentType="application/vnd.openxmlformats-officedocument.obfuscatedFont"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/fontTable.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const DOCUMENT_XML = `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:rPr><w:rFonts w:ascii="My Brand Sans" w:hAnsi="My Brand Sans"/></w:rPr><w:t>Hello</w:t></w:r></w:p>
+    <w:sectPr/>
+  </w:body>
+</w:document>`;
+
+const FONT_TABLE_XML = `${XML_DECLARATION}
+<w:fonts xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+         xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:font w:name="My Brand Sans">
+    <w:family w:val="swiss"/>
+    <w:pitch w:val="variable"/>
+    <w:embedRegular r:id="rId1" w:fontKey="${GUID}" w:subsetted="true"/>
+    <w:embedBold r:id="rId2" w:fontKey="${GUID}"/>
+  </w:font>
+</w:fonts>`;
+
+const FONT_TABLE_RELS = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="fonts/font1.odttf"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="fonts/font2.odttf"/>
+</Relationships>`;
+
+async function buildDocx(options?: {
+  regular?: Uint8Array;
+  bold?: Uint8Array;
+  fontTableRels?: string;
+}): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", CONTENT_TYPES);
+  zip.file("_rels/.rels", PACKAGE_RELS);
+  zip.file("word/document.xml", DOCUMENT_XML);
+  zip.file("word/fontTable.xml", FONT_TABLE_XML);
+  zip.file("word/_rels/fontTable.xml.rels", options?.fontTableRels ?? FONT_TABLE_RELS);
+  if (options?.regular) {
+    zip.file("word/fonts/font1.odttf", options.regular);
+  }
+  if (options?.bold) {
+    zip.file("word/fonts/font2.odttf", options.bold);
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+describe("deobfuscateFont", () => {
+  test("XOR is symmetric: obfuscate then de-obfuscate returns the original", () => {
+    const font = makeFont();
+    const obfuscated = deobfuscateFont(font, GUID);
+    // The header bytes change; the tail past byte 32 is untouched.
+    expect(Array.from(obfuscated.slice(0, 4))).not.toEqual([0x00, 0x01, 0x00, 0x00]);
+    expect(Array.from(obfuscated.slice(32))).toEqual(Array.from(font.slice(32)));
+
+    const restored = deobfuscateFont(obfuscated, GUID);
+    expect(Array.from(restored)).toEqual(Array.from(font));
+  });
+
+  test("does not mutate its input", () => {
+    const font = makeFont();
+    const copy = new Uint8Array(font);
+    deobfuscateFont(font, GUID);
+    expect(Array.from(font)).toEqual(Array.from(copy));
+  });
+
+  test("throws on an invalid key", () => {
+    expect(() => deobfuscateFont(makeFont(), "not-a-guid")).toThrow();
+  });
+
+  test("isValidFontKey accepts a GUID with or without braces/hyphens, rejects junk", () => {
+    expect(isValidFontKey(GUID)).toBe(true);
+    expect(isValidFontKey("001B70DCAA604AD590EC18A0948E1EAE")).toBe(true);
+    expect(isValidFontKey(undefined)).toBe(false);
+    expect(isValidFontKey("{too-short}")).toBe(false);
+  });
+});
+
+describe("parseEmbeddedFontTable", () => {
+  test("reads the font name and each embed's rel id / key / subsetted flag", () => {
+    const entries = parseEmbeddedFontTable(FONT_TABLE_XML);
+    expect(entries).toHaveLength(1);
+    const brand = entries[0];
+    expect(brand?.name).toBe("My Brand Sans");
+    expect(brand?.embedRegular).toEqual({ relId: "rId1", fontKey: GUID, subsetted: true });
+    expect(brand?.embedBold).toEqual({ relId: "rId2", fontKey: GUID });
+    expect(brand?.embedItalic).toBeUndefined();
+  });
+
+  test("returns an empty list for missing/blank input", () => {
+    expect(parseEmbeddedFontTable(null)).toEqual([]);
+    expect(parseEmbeddedFontTable("   ")).toEqual([]);
+  });
+});
+
+describe("getEmbeddedFontFaces", () => {
+  const font = makeFont();
+  const obfuscated = deobfuscateFont(font, GUID);
+
+  test("de-obfuscates each declared face with the right family/style/weight", () => {
+    const fonts = new Map<string, ArrayBuffer>([
+      ["word/fonts/font1.odttf", obfuscated.buffer],
+      ["word/fonts/font2.odttf", obfuscated.buffer],
+    ]);
+    const faces = getEmbeddedFontFaces({
+      fontTableXml: FONT_TABLE_XML,
+      fontTableRelsXml: FONT_TABLE_RELS,
+      fonts,
+    });
+
+    expect(faces).toHaveLength(2);
+    const regular = faces.find((f) => f.weight === 400 && f.style === "normal");
+    const bold = faces.find((f) => f.weight === 700 && f.style === "normal");
+    expect(regular?.family).toBe("My Brand Sans");
+    expect(regular?.subsetted).toBe(true);
+    expect(bold?.subsetted).toBe(false);
+    // The de-obfuscated bytes are a valid SFNT font, byte-identical to the input.
+    expect(hasSfntSignature(regular?.bytes ?? new Uint8Array())).toBe(true);
+    expect(Array.from(regular?.bytes ?? new Uint8Array())).toEqual(Array.from(font));
+  });
+
+  test("skips a face whose binary is missing, keeps the resolvable one", () => {
+    const fonts = new Map<string, ArrayBuffer>([["word/fonts/font1.odttf", obfuscated.buffer]]);
+    const faces = getEmbeddedFontFaces({
+      fontTableXml: FONT_TABLE_XML,
+      fontTableRelsXml: FONT_TABLE_RELS,
+      fonts,
+    });
+    expect(faces.map((f) => f.weight)).toEqual([400]);
+  });
+
+  test("no rels or no font binaries → no faces", () => {
+    const fonts = new Map<string, ArrayBuffer>([["word/fonts/font1.odttf", obfuscated.buffer]]);
+    expect(
+      getEmbeddedFontFaces({ fontTableXml: FONT_TABLE_XML, fontTableRelsXml: null, fonts }),
+    ).toEqual([]);
+    expect(
+      getEmbeddedFontFaces({
+        fontTableXml: FONT_TABLE_XML,
+        fontTableRelsXml: FONT_TABLE_RELS,
+        fonts: new Map(),
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("extractEmbeddedFonts (buffer)", () => {
+  test("end-to-end: unzips, resolves rels, de-obfuscates to a valid font", async () => {
+    const font = makeFont();
+    const obfuscated = deobfuscateFont(font, GUID);
+    const buffer = await buildDocx({ regular: obfuscated, bold: obfuscated });
+
+    const faces = await extractEmbeddedFonts(buffer);
+    expect(faces).toHaveLength(2);
+    const regular = faces.find((f) => f.weight === 400 && f.style === "normal");
+    expect(regular?.family).toBe("My Brand Sans");
+    expect(hasSfntSignature(regular?.bytes ?? new Uint8Array())).toBe(true);
+    expect(Array.from(regular?.bytes ?? new Uint8Array())).toEqual(Array.from(font));
+  });
+
+  test("a document with no embedded fonts yields an empty list", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", CONTENT_TYPES);
+    zip.file("_rels/.rels", PACKAGE_RELS);
+    zip.file("word/document.xml", DOCUMENT_XML);
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+    expect(await extractEmbeddedFonts(buffer)).toEqual([]);
+  });
+});
+
+describe("round-trip preservation", () => {
+  test("save keeps fontTable.xml and word/fonts/* byte-identical", async () => {
+    const font = makeFont();
+    const obfuscated = deobfuscateFont(font, GUID);
+    const buffer = await buildDocx({ regular: obfuscated, bold: obfuscated });
+
+    const originalZip = await JSZip.loadAsync(buffer);
+    const originalFontTable = await originalZip.file("word/fontTable.xml")!.async("text");
+    const originalFontBytes = new Uint8Array(
+      await originalZip.file("word/fonts/font1.odttf")!.async("arraybuffer"),
+    );
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const repacked = await repackDocx(doc, { updateModifiedDate: false });
+
+    const outZip = await JSZip.loadAsync(repacked);
+    const outFontTable = await outZip.file("word/fontTable.xml")!.async("text");
+    const outFontBytes = new Uint8Array(
+      await outZip.file("word/fonts/font1.odttf")!.async("arraybuffer"),
+    );
+
+    expect(outFontTable).toBe(originalFontTable);
+    // Still obfuscated, byte-identical to what we packed.
+    expect(Array.from(outFontBytes)).toEqual(Array.from(originalFontBytes));
+  });
+});

--- a/packages/core/src/fonts/embeddedFonts.test.ts
+++ b/packages/core/src/fonts/embeddedFonts.test.ts
@@ -193,6 +193,49 @@ describe("getEmbeddedFontFaces", () => {
       }),
     ).toEqual([]);
   });
+
+  test("resolves a rel target relative to word/ against a leading-slash ZIP key", () => {
+    // `Target="fonts/font1.odttf"` is relative to the fontTable part base
+    // (`word/`) and must resolve to `word/fonts/font1.odttf`, matched even when
+    // the ZIP entry carries a leading slash.
+    const fonts = new Map<string, ArrayBuffer>([["/word/fonts/font1.odttf", obfuscated.buffer]]);
+    const faces = getEmbeddedFontFaces({
+      fontTableXml: FONT_TABLE_XML,
+      fontTableRelsXml: FONT_TABLE_RELS,
+      fonts,
+    });
+    expect(faces.map((f) => f.weight)).toEqual([400]);
+    expect(faces[0]?.family).toBe("My Brand Sans");
+  });
+
+  test("resolves a leading-slash absolute rel target", () => {
+    const absoluteRels = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="/word/fonts/font1.odttf"/>
+</Relationships>`;
+    const fonts = new Map<string, ArrayBuffer>([["word/fonts/font1.odttf", obfuscated.buffer]]);
+    const faces = getEmbeddedFontFaces({
+      fontTableXml: FONT_TABLE_XML,
+      fontTableRelsXml: absoluteRels,
+      fonts,
+    });
+    expect(faces.map((f) => f.weight)).toEqual([400]);
+  });
+
+  test("resolves a rel target that walks up out of word/ (../fonts/...)", () => {
+    const traversalRels = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="../fonts/font1.odttf"/>
+</Relationships>`;
+    // `word/` + `../fonts/font1.odttf` collapses to `fonts/font1.odttf`.
+    const fonts = new Map<string, ArrayBuffer>([["fonts/font1.odttf", obfuscated.buffer]]);
+    const faces = getEmbeddedFontFaces({
+      fontTableXml: FONT_TABLE_XML,
+      fontTableRelsXml: traversalRels,
+      fonts,
+    });
+    expect(faces.map((f) => f.weight)).toEqual([400]);
+  });
 });
 
 describe("extractEmbeddedFonts (buffer)", () => {

--- a/packages/core/src/fonts/embeddedFonts.ts
+++ b/packages/core/src/fonts/embeddedFonts.ts
@@ -15,7 +15,7 @@
  * Ported from eigenpal/docx-editor (see NOTICE.md).
  */
 
-import { parseRelationships } from "../docx/relsParser";
+import { parseRelationships, resolveRelativePath } from "../docx/relsParser";
 import { unzipDocx } from "../docx/unzip";
 import type { RelationshipMap } from "../types";
 import { deobfuscateFont, isValidFontKey } from "./fontDeobfuscation";
@@ -61,22 +61,28 @@ const EMBED_KINDS = [
   { ref: "embedBoldItalic", weight: 700, style: "italic" },
 ] as const satisfies readonly EmbedKind[];
 
+// The font table's relationships always live at this OPC part path; embed
+// targets resolve relative to it (see `resolveRelativePath`).
+const FONTTABLE_RELS_BASE_PATH = "word/_rels/fontTable.xml.rels";
 const FONTTABLE_RELS_PATH = "word/_rels/fonttable.xml.rels";
 
+/** Normalize a package path for comparison: drop leading slashes, lowercase. */
+function normalizePackagePath(path: string): string {
+  return path.replace(/^\/+/u, "").toLowerCase();
+}
+
 /**
- * Resolve a relationship target (e.g. `fonts/font1.odttf`, relative to the
- * `word/` folder) to the matching key in the unzipped font map, matched
- * case-insensitively (ZIP entry casing varies across producers).
+ * Find the font binary for an already-resolved package path (e.g.
+ * `word/fonts/font1.odttf`) in the unzipped font map, matched case- and
+ * leading-slash-insensitively (ZIP entry casing/prefixes vary across producers).
  */
 function lookupFontData(
-  target: string,
+  resolvedPath: string,
   fonts: ReadonlyMap<string, ArrayBuffer>,
 ): ArrayBuffer | undefined {
-  const cleaned = target.replace(/^\/+/u, "");
-  const fullPath = cleaned.toLowerCase().startsWith("word/") ? cleaned : `word/${cleaned}`;
-  const wanted = fullPath.toLowerCase();
+  const wanted = normalizePackagePath(resolvedPath);
   for (const [path, data] of fonts) {
-    if (path.toLowerCase() === wanted) {
+    if (normalizePackagePath(path) === wanted) {
       return data;
     }
   }
@@ -95,7 +101,11 @@ function resolveFace(
     return null;
   }
 
-  const raw = lookupFontData(target, fonts);
+  // Resolve the rel target against the font-table part base the same way the
+  // rest of the package resolves rels, so `fonts/font1.odttf`, `../media/...`,
+  // and leading-slash absolute targets all land on the right ZIP entry.
+  const resolvedPath = resolveRelativePath(FONTTABLE_RELS_BASE_PATH, target);
+  const raw = lookupFontData(resolvedPath, fonts);
   if (!raw) {
     return null;
   }
@@ -149,7 +159,7 @@ export function getEmbeddedFontFaces(parts: EmbeddedFontParts): EmbeddedFont[] {
 
 function findFontTableRels(allXml: ReadonlyMap<string, string>): string | undefined {
   for (const [path, xml] of allXml) {
-    if (path.toLowerCase() === FONTTABLE_RELS_PATH) {
+    if (normalizePackagePath(path) === FONTTABLE_RELS_PATH) {
       return xml;
     }
   }

--- a/packages/core/src/fonts/embeddedFonts.ts
+++ b/packages/core/src/fonts/embeddedFonts.ts
@@ -1,0 +1,172 @@
+/**
+ * Embedded-font extraction.
+ *
+ * Turns the obfuscated `word/fonts/*.odttf` binaries a `.docx` carries into
+ * de-obfuscated OpenType/TrueType faces the renderer can register as
+ * `@font-face`s, so documents whose fonts are embedded (rather than installed)
+ * render in their authored fonts instead of a fallback.
+ *
+ * The core is pure and framework-free: {@link getEmbeddedFontFaces} works over
+ * already-unzipped package parts; {@link extractEmbeddedFonts} is the buffer
+ * convenience that unzips first. Neither touches the DOM. Round-trip
+ * preservation is unaffected: the serializer copies `word/fonts/*` and
+ * `fontTable.xml` from the original ZIP untouched, so this is a read-only view.
+ *
+ * Ported from eigenpal/docx-editor (see NOTICE.md).
+ */
+
+import { parseRelationships } from "../docx/relsParser";
+import { unzipDocx } from "../docx/unzip";
+import type { RelationshipMap } from "../types";
+import { deobfuscateFont, isValidFontKey } from "./fontDeobfuscation";
+import { parseEmbeddedFontTable, type EmbeddedFontFaceRef } from "./embeddedFontTable";
+
+/** A single de-obfuscated embedded font face, ready to register as `@font-face`. */
+export type EmbeddedFont = {
+  /** Word font name to register the face under (`w:font w:name`). */
+  family: string;
+  /** CSS `font-style` the face maps to (`embed*Italic` → `italic`). */
+  style: "normal" | "italic";
+  /** CSS `font-weight` the face maps to (`embedBold*` → `700`). */
+  weight: 400 | 700;
+  /** De-obfuscated OpenType/TrueType bytes (backed by a fresh, non-shared buffer). */
+  bytes: Uint8Array<ArrayBuffer>;
+  /** Whether the source face was subsetted (`w:subsetted`). */
+  subsetted: boolean;
+};
+
+/** Already-unzipped package parts the pure extractor needs. */
+export type EmbeddedFontParts = {
+  /** Raw `word/fontTable.xml`. */
+  fontTableXml: string | null | undefined;
+  /** Raw `word/_rels/fontTable.xml.rels`. */
+  fontTableRelsXml: string | null | undefined;
+  /** Unzipped font binaries keyed by package path (e.g. `word/fonts/font1.odttf`). */
+  fonts: ReadonlyMap<string, ArrayBuffer>;
+};
+
+type EmbedField = "embedRegular" | "embedBold" | "embedItalic" | "embedBoldItalic";
+
+type EmbedKind = {
+  ref: EmbedField;
+  weight: 400 | 700;
+  style: "normal" | "italic";
+};
+
+/** Pairs each embed field with the CSS weight/style it renders as. */
+const EMBED_KINDS = [
+  { ref: "embedRegular", weight: 400, style: "normal" },
+  { ref: "embedBold", weight: 700, style: "normal" },
+  { ref: "embedItalic", weight: 400, style: "italic" },
+  { ref: "embedBoldItalic", weight: 700, style: "italic" },
+] as const satisfies readonly EmbedKind[];
+
+const FONTTABLE_RELS_PATH = "word/_rels/fonttable.xml.rels";
+
+/**
+ * Resolve a relationship target (e.g. `fonts/font1.odttf`, relative to the
+ * `word/` folder) to the matching key in the unzipped font map, matched
+ * case-insensitively (ZIP entry casing varies across producers).
+ */
+function lookupFontData(
+  target: string,
+  fonts: ReadonlyMap<string, ArrayBuffer>,
+): ArrayBuffer | undefined {
+  const cleaned = target.replace(/^\/+/u, "");
+  const fullPath = cleaned.toLowerCase().startsWith("word/") ? cleaned : `word/${cleaned}`;
+  const wanted = fullPath.toLowerCase();
+  for (const [path, data] of fonts) {
+    if (path.toLowerCase() === wanted) {
+      return data;
+    }
+  }
+  return undefined;
+}
+
+function resolveFace(
+  family: string,
+  ref: EmbeddedFontFaceRef,
+  kind: EmbedKind,
+  fonts: ReadonlyMap<string, ArrayBuffer>,
+  rels: RelationshipMap,
+): EmbeddedFont | null {
+  const target = rels.get(ref.relId)?.target;
+  if (!target) {
+    return null;
+  }
+
+  const raw = lookupFontData(target, fonts);
+  if (!raw) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(raw);
+  const data =
+    ref.fontKey && isValidFontKey(ref.fontKey)
+      ? deobfuscateFont(bytes, ref.fontKey)
+      : // No usable key: some producers embed a non-obfuscated face verbatim.
+        bytes;
+
+  return {
+    family,
+    style: kind.style,
+    weight: kind.weight,
+    bytes: data,
+    subsetted: ref.subsetted ?? false,
+  };
+}
+
+/**
+ * Resolve and de-obfuscate every embedded font face declared in a font table.
+ * Pure and DOM-free. Faces whose relationship or binary is missing are skipped,
+ * so the result only contains faces that produced usable bytes.
+ */
+export function getEmbeddedFontFaces(parts: EmbeddedFontParts): EmbeddedFont[] {
+  const entries = parseEmbeddedFontTable(parts.fontTableXml);
+  if (entries.length === 0) {
+    return [];
+  }
+  if (!parts.fontTableRelsXml || parts.fonts.size === 0) {
+    return [];
+  }
+
+  const rels = parseRelationships(parts.fontTableRelsXml);
+  const faces: EmbeddedFont[] = [];
+  for (const entry of entries) {
+    for (const kind of EMBED_KINDS) {
+      const ref = entry[kind.ref];
+      if (!ref) {
+        continue;
+      }
+      const face = resolveFace(entry.name, ref, kind, parts.fonts, rels);
+      if (face) {
+        faces.push(face);
+      }
+    }
+  }
+  return faces;
+}
+
+function findFontTableRels(allXml: ReadonlyMap<string, string>): string | undefined {
+  for (const [path, xml] of allXml) {
+    if (path.toLowerCase() === FONTTABLE_RELS_PATH) {
+      return xml;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract every embedded font face from a raw `.docx` buffer. Unzips the
+ * package, then resolves + de-obfuscates the faces via
+ * {@link getEmbeddedFontFaces}. Returns an empty list for documents with no
+ * embedded fonts.
+ */
+export async function extractEmbeddedFonts(buffer: ArrayBuffer): Promise<EmbeddedFont[]> {
+  const raw = await unzipDocx(buffer);
+  return getEmbeddedFontFaces({
+    fontTableXml: raw.fontTableXml,
+    fontTableRelsXml: findFontTableRels(raw.allXml),
+    fonts: raw.fonts,
+  });
+}

--- a/packages/core/src/fonts/fontDeobfuscation.ts
+++ b/packages/core/src/fonts/fontDeobfuscation.ts
@@ -1,0 +1,75 @@
+/**
+ * Embedded-font de-obfuscation (ECMA-376 Part 4 §2.8.1, "Font Embedding").
+ *
+ * Word ships embedded fonts as obfuscated OpenType (`.odttf`): the first 32
+ * bytes of the font binary are XOR-scrambled with a 16-byte key; the rest of
+ * the file is untouched. The key is the font's `w:fontKey` GUID with its byte
+ * order reversed, applied to bytes 0-15 and again to bytes 16-31.
+ *
+ * Example (from the spec): GUID `001B70DC-AA60-4AD5-90EC-18A0948E1EAE` yields
+ * key bytes `AE 1E 8E 94 A0 18 EC 90 D5 4A 60 AA DC 70 1B 00`. The scheme is a
+ * pure XOR, so the same operation obfuscates and de-obfuscates.
+ *
+ * Ported from eigenpal/docx-editor (see NOTICE.md). The ODTTF scheme is an
+ * OOXML interop format, so the algorithm is reproduced faithfully.
+ */
+
+const HEADER_LENGTH = 32;
+const KEY_LENGTH = 16;
+
+/**
+ * Strip a `w:fontKey` GUID down to its 16 key bytes, in the reversed order the
+ * obfuscation applies. Returns null when the value is not a 32-hex-digit GUID.
+ */
+function fontKeyToReversedBytes(fontKey: string): Uint8Array | null {
+  const hex = fontKey.replace(/[^0-9a-fA-F]/gu, "");
+  if (hex.length !== KEY_LENGTH * 2) {
+    return null;
+  }
+
+  const reversed = new Uint8Array(KEY_LENGTH);
+  for (let i = 0; i < KEY_LENGTH; i++) {
+    const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) {
+      return null;
+    }
+    // Reverse the byte order while writing — this is the actual XOR key.
+    reversed[KEY_LENGTH - 1 - i] = byte;
+  }
+  return reversed;
+}
+
+/**
+ * Whether a string is a usable embedded-font obfuscation key: a 128-bit GUID,
+ * with or without braces and hyphens.
+ */
+export function isValidFontKey(fontKey: string | undefined | null): boolean {
+  if (!fontKey) {
+    return false;
+  }
+  return fontKeyToReversedBytes(fontKey) !== null;
+}
+
+/**
+ * De-obfuscate an embedded `.odttf` font into a usable OpenType/TrueType binary
+ * by XOR-ing its first 32 bytes with the reversed `w:fontKey` GUID. Returns a
+ * new array; the input is not mutated. Throws when `fontKey` is not a valid
+ * 128-bit GUID (guard with {@link isValidFontKey} first).
+ */
+export function deobfuscateFont(data: Uint8Array, fontKey: string): Uint8Array<ArrayBuffer> {
+  const key = fontKeyToReversedBytes(fontKey);
+  if (!key) {
+    throw new Error(`Invalid embedded-font key: "${fontKey}"`);
+  }
+
+  const out = new Uint8Array(data);
+  const end = Math.min(HEADER_LENGTH, out.length);
+  for (let i = 0; i < end; i++) {
+    // In-bounds by construction: i < end <= out.length, and i % KEY_LENGTH
+    // indexes the 16-byte key; `?? 0` only satisfies noUncheckedIndexedAccess.
+    const source = out[i] ?? 0;
+    const keyByte = key[i % KEY_LENGTH] ?? 0;
+    out[i] = source ^ keyByte;
+  }
+  return out;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,3 +139,13 @@ export {
   type MarkdownOptions,
   type MarkdownResult,
 } from "./markdown";
+
+// Embedded fonts: de-obfuscate the `word/fonts/*.odttf` binaries a document
+// carries so it can render in its authored (embedded-only) fonts. Pure and
+// DOM-free; the React editor registers the result as `@font-face`s.
+export {
+  extractEmbeddedFonts,
+  getEmbeddedFontFaces,
+  type EmbeddedFont,
+  type EmbeddedFontParts,
+} from "./fonts/embeddedFonts";

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -180,6 +180,7 @@ import { AnonymizationRectsOverlay } from "./AnonymizationRectsOverlay";
 import type { AnonymizationRectGroup } from "./AnonymizationRectsOverlay";
 import { AutocompleteCaretOverlay } from "./AutocompleteCaretOverlay";
 import type { AutocompleteCaretRect } from "./AutocompleteCaretOverlay";
+import { loadEmbeddedFontFaces, removeEmbeddedFontFaces } from "./embeddedFonts";
 import { createHiddenEditorState, HiddenProseMirror } from "./HiddenProseMirror";
 import type {
   HiddenProseMirrorCollaboration,
@@ -5511,6 +5512,44 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       fontSet.removeEventListener("loadingerror", handleFontsLoaded);
     };
   }, []);
+
+  // Register the document's embedded fonts (obfuscated `word/fonts/*.odttf`) as
+  // `@font-face`s so text renders in its authored fonts instead of fallbacks,
+  // then re-layout once they load so glyph advances use the real metrics. Keyed
+  // on the source buffer: registration happens per loaded document, and the
+  // cleanup unregisters the faces so one document's family cannot bleed into the
+  // next. The 250ms font-ready suppression window can swallow the shared
+  // loadingdone re-layout, so this path relays out explicitly.
+  const embeddedFontBuffer = document?.originalBuffer ?? null;
+  useEffect(() => {
+    if (!embeddedFontBuffer) {
+      return undefined;
+    }
+    let cancelled = false;
+    let registered: FontFace[] = [];
+    void loadEmbeddedFontFaces(embeddedFontBuffer).then((faces) => {
+      if (cancelled) {
+        removeEmbeddedFontFaces(faces);
+        return;
+      }
+      registered = faces;
+      if (faces.length === 0) {
+        return;
+      }
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+      resetCanvasContext();
+      clearAllCaches();
+      runLayoutPipelineRef.current(view.state, { reason: "font-ready" });
+      updateSelectionOverlayRef.current(view.state);
+    });
+    return () => {
+      cancelled = true;
+      removeEmbeddedFontFaces(registered);
+    };
+  }, [embeddedFontBuffer]);
 
   // Re-layout when non-document layout inputs change (e.g., after HF editor save
   // or parent-driven page setup/theme updates).

--- a/packages/react/src/paged-editor/embeddedFonts.test.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.test.ts
@@ -45,13 +45,31 @@ class FakeFontFace {
   }
 }
 
-type Global = {
-  document?: unknown;
-  FontFace?: unknown;
-};
+type StubbedGlobal = "document" | "FontFace";
 
-let priorDocument: unknown;
-let priorFontFace: unknown;
+// CI runners expose `document`/`FontFace` as readonly globals, so a plain
+// assignment throws. Redefine them via a configurable descriptor (matching
+// folio-core's global-stub tests) and delete/restore afterwards.
+function stubGlobal(prop: StubbedGlobal, value: unknown): void {
+  Object.defineProperty(globalThis, prop, { value, configurable: true, writable: true });
+}
+
+function restoreGlobal(prop: StubbedGlobal, had: boolean, original: unknown): void {
+  if (had) {
+    Object.defineProperty(globalThis, prop, {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    Reflect.deleteProperty(globalThis, prop);
+  }
+}
+
+let hadDocument: boolean;
+let originalDocument: unknown;
+let hadFontFace: boolean;
+let originalFontFace: unknown;
 
 beforeEach(() => {
   fontFaceMode = "load-ok";
@@ -59,10 +77,12 @@ beforeEach(() => {
   deletedFaces = [];
   extractImpl = () => Promise.resolve([fakeFont()]);
 
-  priorDocument = (globalThis as Global).document;
-  priorFontFace = (globalThis as Global).FontFace;
+  hadDocument = "document" in globalThis;
+  originalDocument = (globalThis as { document?: unknown }).document;
+  hadFontFace = "FontFace" in globalThis;
+  originalFontFace = (globalThis as { FontFace?: unknown }).FontFace;
 
-  (globalThis as Global).document = {
+  stubGlobal("document", {
     fonts: {
       add: (face: unknown) => addedFaces.push(face),
       delete: (face: unknown) => {
@@ -70,13 +90,13 @@ beforeEach(() => {
         return true;
       },
     },
-  };
-  (globalThis as Global).FontFace = FakeFontFace;
+  });
+  stubGlobal("FontFace", FakeFontFace);
 });
 
 afterEach(() => {
-  (globalThis as Global).document = priorDocument;
-  (globalThis as Global).FontFace = priorFontFace;
+  restoreGlobal("document", hadDocument, originalDocument);
+  restoreGlobal("FontFace", hadFontFace, originalFontFace);
 });
 
 describe("loadEmbeddedFontFaces (best-effort)", () => {
@@ -107,7 +127,7 @@ describe("loadEmbeddedFontFaces (best-effort)", () => {
   });
 
   test("returns [] outside a DOM (no document.fonts)", async () => {
-    (globalThis as Global).document = undefined;
+    stubGlobal("document", undefined);
     expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
   });
 });

--- a/packages/react/src/paged-editor/embeddedFonts.test.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
+
+// Stub the headless extractor so this test targets only the DOM-registration
+// guard logic; the real extract/de-obfuscate path is covered in folio-core.
+let extractImpl: (buffer: ArrayBuffer) => Promise<EmbeddedFont[]>;
+void mock.module("@stll/folio-core/fonts/embeddedFonts", () => ({
+  extractEmbeddedFonts: (buffer: ArrayBuffer) => extractImpl(buffer),
+}));
+
+const { loadEmbeddedFontFaces } = await import("./embeddedFonts");
+
+function fakeFont(): EmbeddedFont {
+  return {
+    family: "My Brand Sans",
+    style: "normal",
+    weight: 400,
+    bytes: new Uint8Array([0x00, 0x01, 0x00, 0x00]),
+    subsetted: false,
+  };
+}
+
+type FontFaceMode = "load-ok" | "load-reject" | "ctor-throw";
+
+let fontFaceMode: FontFaceMode;
+let addedFaces: unknown[];
+let deletedFaces: unknown[];
+
+class FakeFontFace {
+  family: string;
+
+  constructor(family: string, _source: unknown, _descriptors: unknown) {
+    if (fontFaceMode === "ctor-throw") {
+      throw new SyntaxError("invalid font family");
+    }
+    this.family = family;
+  }
+
+  load(): Promise<FakeFontFace> {
+    if (fontFaceMode === "load-reject") {
+      return Promise.reject(new Error("load failed"));
+    }
+    return Promise.resolve(this);
+  }
+}
+
+type Global = {
+  document?: unknown;
+  FontFace?: unknown;
+};
+
+let priorDocument: unknown;
+let priorFontFace: unknown;
+
+beforeEach(() => {
+  fontFaceMode = "load-ok";
+  addedFaces = [];
+  deletedFaces = [];
+  extractImpl = () => Promise.resolve([fakeFont()]);
+
+  priorDocument = (globalThis as Global).document;
+  priorFontFace = (globalThis as Global).FontFace;
+
+  (globalThis as Global).document = {
+    fonts: {
+      add: (face: unknown) => addedFaces.push(face),
+      delete: (face: unknown) => {
+        deletedFaces.push(face);
+        return true;
+      },
+    },
+  };
+  (globalThis as Global).FontFace = FakeFontFace;
+});
+
+afterEach(() => {
+  (globalThis as Global).document = priorDocument;
+  (globalThis as Global).FontFace = priorFontFace;
+});
+
+describe("loadEmbeddedFontFaces (best-effort)", () => {
+  test("registers and returns the loaded faces on success", async () => {
+    const faces = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    expect(faces).toHaveLength(1);
+    expect(addedFaces).toHaveLength(1);
+    expect(deletedFaces).toHaveLength(0);
+  });
+
+  test("does not throw and returns [] when extraction throws", async () => {
+    extractImpl = () => Promise.reject(new Error("corrupt zip"));
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(addedFaces).toHaveLength(0);
+  });
+
+  test("does not throw and skips a face when FontFace construction throws", async () => {
+    fontFaceMode = "ctor-throw";
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(addedFaces).toHaveLength(0);
+  });
+
+  test("drops a face whose load() rejects", async () => {
+    fontFaceMode = "load-reject";
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(addedFaces).toHaveLength(1);
+    expect(deletedFaces).toHaveLength(1);
+  });
+
+  test("returns [] outside a DOM (no document.fonts)", async () => {
+    (globalThis as Global).document = undefined;
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+  });
+});

--- a/packages/react/src/paged-editor/embeddedFonts.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.ts
@@ -1,0 +1,69 @@
+/**
+ * Registers a document's embedded fonts with the browser via the `FontFace`
+ * API, so runs render in their authored faces instead of the fallback stack.
+ *
+ * The extraction + de-obfuscation is done headlessly in `@stll/folio-core`;
+ * this module only performs the DOM registration and cleanup. Faces are kept as
+ * `FontFace` handles so the caller can remove them on document change/unmount,
+ * preventing one document's embedded family from bleeding into the next.
+ */
+
+import { extractEmbeddedFonts } from "@stll/folio-core/fonts/embeddedFonts";
+
+function getDocumentFontSet(): FontFaceSet | null {
+  if (typeof document === "undefined" || !("fonts" in document)) {
+    return null;
+  }
+  return document.fonts;
+}
+
+/**
+ * Extract, register, and load the embedded font faces from a raw `.docx`
+ * buffer. No-op (returns `[]`) outside a DOM or when the document has no
+ * embedded fonts. Returns the `FontFace` handles that loaded successfully;
+ * faces the browser rejects (malformed/subsetted binaries) are dropped so the
+ * run falls back to the CSS font stack.
+ */
+export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFace[]> {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return [];
+  }
+
+  const fonts = await extractEmbeddedFonts(buffer);
+  if (fonts.length === 0) {
+    return [];
+  }
+
+  const loaded: FontFace[] = [];
+  await Promise.all(
+    fonts.map(async (font) => {
+      const face = new FontFace(font.family, font.bytes, {
+        weight: String(font.weight),
+        style: font.style,
+      });
+      fontSet.add(face);
+      const ready = await face.load().then(
+        () => true,
+        () => false,
+      );
+      if (ready) {
+        loaded.push(face);
+        return;
+      }
+      fontSet.delete(face);
+    }),
+  );
+  return loaded;
+}
+
+/** Remove previously registered embedded faces from the document font set. */
+export function removeEmbeddedFontFaces(faces: readonly FontFace[]): void {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return;
+  }
+  for (const face of faces) {
+    fontSet.delete(face);
+  }
+}

--- a/packages/react/src/paged-editor/embeddedFonts.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.ts
@@ -8,7 +8,7 @@
  * preventing one document's embedded family from bleeding into the next.
  */
 
-import { extractEmbeddedFonts } from "@stll/folio-core/fonts/embeddedFonts";
+import { extractEmbeddedFonts, type EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
 
 function getDocumentFontSet(): FontFaceSet | null {
   if (typeof document === "undefined" || !("fonts" in document)) {
@@ -30,7 +30,14 @@ export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFa
     return [];
   }
 
-  const fonts = await extractEmbeddedFonts(buffer);
+  // Embedded fonts are best-effort: a corrupt/oversized package makes unzip
+  // throw. Never let that break rendering — fall back to the CSS font stack.
+  let fonts: EmbeddedFont[];
+  try {
+    fonts = await extractEmbeddedFonts(buffer);
+  } catch {
+    return [];
+  }
   if (fonts.length === 0) {
     return [];
   }
@@ -38,11 +45,18 @@ export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFa
   const loaded: FontFace[] = [];
   await Promise.all(
     fonts.map(async (font) => {
-      const face = new FontFace(font.family, font.bytes, {
-        weight: String(font.weight),
-        style: font.style,
-      });
-      fontSet.add(face);
+      let face: FontFace;
+      try {
+        // `new FontFace` throws synchronously (SyntaxError) on an invalid family
+        // or descriptor; `fontSet.add` can reject a face too. Skip on failure.
+        face = new FontFace(font.family, font.bytes, {
+          weight: String(font.weight),
+          style: font.style,
+        });
+        fontSet.add(face);
+      } catch {
+        return;
+      }
       const ready = await face.load().then(
         () => true,
         () => false,


### PR DESCRIPTION
Renders `.docx` files whose fonts are **embedded** (obfuscated `.odttf`) in their authored fonts instead of falling back. Previously folio preserved `fontTable.xml` byte-exact but had no font model, so embedded-only-font documents rendered wrong.

**core (`packages/core/src/fonts/`, framework-free):**
- `deobfuscateFont` — the ODTTF de-obfuscation scheme (first 32 bytes XOR the reversed 16-byte `w:fontKey` GUID). Ported from upstream with attribution.
- `parseEmbeddedFontTable` — reads `w:embedRegular/Bold/Italic/BoldItalic` (r-id, `w:fontKey`, `w:subsetted`) from `fontTable.xml`.
- `extractEmbeddedFonts(buffer)` / `getEmbeddedFontFaces(parts)` → `EmbeddedFont { family, style, weight, bytes, subsetted }`. (folio's model type carries no `fontKey`/bytes, so extraction parses `fontTable.xml` + reads the zip directly.)

**react:** registers the extracted faces via the `FontFace` API on load, re-lays-out so measurement uses real metrics, and unregisters on doc change/unmount (no cross-document family bleed). Edge cases: no embedded fonts → no-op; family also installed → embedded face still registered + preferred; missing/invalid `.odttf` or key → skip that face, never throw.

**Save unaffected:** the extractor is a read-only view; `fontTable.xml` + `word/fonts/*` are still copied byte-exact on save (asserted by a round-trip test).

**Coverage:** 12 core tests (XOR symmetry/non-mutation, `fontKey` validation, table parse, de-obfuscation to a valid SFNT signature with correct family/style/weight, skip-edges, end-to-end extract, byte-exact round-trip). The DOM `FontFace` registration/re-layout is visual (folio has no DOM tests) — kept small; the de-obfuscation carries the coverage.
