### PR TITLE
feat(core): clean office/HTML paste + paste without formatting

### DIFF
--- a/packages/core/src/prosemirror/commands/index.ts
+++ b/packages/core/src/prosemirror/commands/index.ts
@@ -116,6 +116,9 @@ export type { TableContextInfo, BorderPreset, TableBorderPreset } from "./table"
 // Page break
 export { insertPageBreak } from "./pageBreak";
 
+// Paste without formatting
+export { buildPlainTextSlice, pasteWithoutFormatting } from "./pastePlainText";
+
 // Table of Contents
 export { generateTOC } from "./paragraph";
 

--- a/packages/core/src/prosemirror/commands/index.ts
+++ b/packages/core/src/prosemirror/commands/index.ts
@@ -117,7 +117,11 @@ export type { TableContextInfo, BorderPreset, TableBorderPreset } from "./table"
 export { insertPageBreak } from "./pageBreak";
 
 // Paste without formatting
-export { buildPlainTextSlice, pasteWithoutFormatting } from "./pastePlainText";
+export {
+  buildPlainTextSlice,
+  CLIPBOARD_READ_ERROR_EVENT,
+  pasteWithoutFormatting,
+} from "./pastePlainText";
 
 // Table of Contents
 export { generateTOC } from "./paragraph";

--- a/packages/core/src/prosemirror/commands/pastePlainText.test.ts
+++ b/packages/core/src/prosemirror/commands/pastePlainText.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { Schema } from "prosemirror-model";
 import type { Node as PMNode } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
 
-import { buildPlainTextSlice, pasteWithoutFormatting } from "./pastePlainText";
+import {
+  buildPlainTextSlice,
+  CLIPBOARD_READ_ERROR_EVENT,
+  pasteWithoutFormatting,
+} from "./pastePlainText";
 
 // Minimal block schema (no DOM needed to construct or fill it).
 const blockSchema = new Schema({
@@ -113,5 +118,30 @@ describe("pasteWithoutFormatting dry run", () => {
     withClipboard(undefined, () => {
       expect(pasteWithoutFormatting(fakeState)).toBe(false);
     });
+  });
+
+  test("emits a clipboard-read-error event when the read is denied", async () => {
+    const dom = new EventTarget();
+    let firedError: unknown;
+    dom.addEventListener(CLIPBOARD_READ_ERROR_EVENT, (event) => {
+      firedError = (event as CustomEvent).detail?.error;
+    });
+    const view = {
+      dom,
+      isDestroyed: false,
+      state: fakeState,
+      dispatch: () => undefined,
+    } as unknown as EditorView;
+
+    withClipboard(
+      () => Promise.reject(new Error("denied")),
+      () => {
+        expect(pasteWithoutFormatting(fakeState, () => undefined, view)).toBe(true);
+      },
+    );
+
+    // Flush the rejected-read microtasks so the catch handler runs.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(firedError).toBeInstanceOf(Error);
   });
 });

--- a/packages/core/src/prosemirror/commands/pastePlainText.test.ts
+++ b/packages/core/src/prosemirror/commands/pastePlainText.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Schema } from "prosemirror-model";
 import type { Node as PMNode } from "prosemirror-model";
+import type { EditorState } from "prosemirror-state";
 
-import { buildPlainTextSlice } from "./pastePlainText";
+import { buildPlainTextSlice, pasteWithoutFormatting } from "./pastePlainText";
 
 // Minimal block schema (no DOM needed to construct or fill it).
 const blockSchema = new Schema({
@@ -71,5 +72,46 @@ describe("buildPlainTextSlice", () => {
     });
     const slice = buildPlainTextSlice("just text", inlineSchema);
     expect(slice.content.textBetween(0, slice.content.size)).toBe("just text");
+  });
+});
+
+describe("pasteWithoutFormatting dry run", () => {
+  const withClipboard = (readText: (() => Promise<string>) | undefined, run: () => void): void => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { clipboard: readText ? { readText } : undefined },
+    });
+    try {
+      run();
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, "navigator", original);
+      } else {
+        Reflect.deleteProperty(globalThis, "navigator");
+      }
+    }
+  };
+
+  const fakeState = { schema: blockSchema } as unknown as EditorState;
+
+  test("a dispatch-less probe reports available without touching the clipboard", () => {
+    let read = false;
+    withClipboard(
+      () => {
+        read = true;
+        return Promise.resolve("x");
+      },
+      () => {
+        expect(pasteWithoutFormatting(fakeState)).toBe(true);
+        expect(read).toBe(false);
+      },
+    );
+  });
+
+  test("reports unavailable when the runtime has no clipboard reader", () => {
+    withClipboard(undefined, () => {
+      expect(pasteWithoutFormatting(fakeState)).toBe(false);
+    });
   });
 });

--- a/packages/core/src/prosemirror/commands/pastePlainText.test.ts
+++ b/packages/core/src/prosemirror/commands/pastePlainText.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+import type { Node as PMNode } from "prosemirror-model";
+
+import { buildPlainTextSlice } from "./pastePlainText";
+
+// Minimal block schema (no DOM needed to construct or fill it).
+const blockSchema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*" },
+    text: { group: "inline" },
+  },
+  marks: {
+    bold: { toDOM: () => ["strong", 0], parseDOM: [{ tag: "strong" }] },
+  },
+});
+
+function paragraphTexts(fragment: PMNode["content"]): string[] {
+  const texts: string[] = [];
+  fragment.forEach((node) => texts.push(node.textContent));
+  return texts;
+}
+
+function everyTextNodeIsUnmarked(fragment: PMNode["content"]): boolean {
+  let clean = true;
+  fragment.descendants((node) => {
+    if (node.isText && node.marks.length > 0) {
+      clean = false;
+    }
+    return true;
+  });
+  return clean;
+}
+
+describe("buildPlainTextSlice", () => {
+  test("single line becomes one paragraph of unmarked text", () => {
+    const slice = buildPlainTextSlice("hello world", blockSchema);
+    expect(paragraphTexts(slice.content)).toEqual(["hello world"]);
+    expect(everyTextNodeIsUnmarked(slice.content)).toBe(true);
+  });
+
+  test("newline runs split into one paragraph each and collapse blank lines", () => {
+    const slice = buildPlainTextSlice("a\nb\n\nc", blockSchema);
+    expect(paragraphTexts(slice.content)).toEqual(["a", "b", "c"]);
+  });
+
+  test("carriage returns are treated as paragraph breaks", () => {
+    const slice = buildPlainTextSlice("x\r\ny", blockSchema);
+    expect(paragraphTexts(slice.content)).toEqual(["x", "y"]);
+  });
+
+  test("opens both ends so text merges into the surrounding block", () => {
+    const slice = buildPlainTextSlice("merge me", blockSchema);
+    expect(slice.openStart).toBe(1);
+    expect(slice.openEnd).toBe(1);
+  });
+
+  test("carries no source formatting even when text looks like markup", () => {
+    const slice = buildPlainTextSlice("**not bold** <b>either</b>", blockSchema);
+    expect(paragraphTexts(slice.content)).toEqual(["**not bold** <b>either</b>"]);
+    expect(everyTextNodeIsUnmarked(slice.content)).toBe(true);
+  });
+
+  test("falls back to flat text when the schema has no paragraph node", () => {
+    const inlineSchema = new Schema({
+      nodes: {
+        doc: { content: "text*" },
+        text: {},
+      },
+    });
+    const slice = buildPlainTextSlice("just text", inlineSchema);
+    expect(slice.content.textBetween(0, slice.content.size)).toBe("just text");
+  });
+});

--- a/packages/core/src/prosemirror/commands/pastePlainText.ts
+++ b/packages/core/src/prosemirror/commands/pastePlainText.ts
@@ -14,6 +14,15 @@ import type { Command } from "prosemirror-state";
 const PARAGRAPH_BREAK = /(?:\r\n?|\n)+/;
 
 /**
+ * Dispatched on the editor view DOM when the clipboard read behind a
+ * "paste without formatting" keystroke fails (e.g. clipboard-read permission
+ * denied). The command owns no UI, so the host shell listens for this bubbling
+ * event and decides how to surface it (toast, telemetry, or no-op) rather than
+ * the keystroke silently doing nothing.
+ */
+export const CLIPBOARD_READ_ERROR_EVENT = "folio:clipboard-read-error";
+
+/**
  * Build a mark-free slice from plain text, one paragraph per run of newlines.
  *
  * Pure and DOM-free so it is unit-testable and reusable from both the keymap
@@ -45,8 +54,10 @@ export function buildPlainTextSlice(text: string, schema: Schema): Slice {
  * `dispatch` (menus/toolbars) returns `true` without touching the clipboard or
  * the document. Only when `dispatch` is provided does it read the clipboard and
  * insert; it then returns `true` (claiming the key) so the browser's own
- * "paste without formatting" shortcut does not also fire. The read is
- * best-effort: a denied or unavailable clipboard is swallowed rather than thrown.
+ * "paste without formatting" shortcut does not also fire. A failed read (denied
+ * permission, unsupported) is surfaced to the host via a
+ * {@link CLIPBOARD_READ_ERROR_EVENT} on the view DOM so the keystroke is never a
+ * silent no-op.
  */
 export const pasteWithoutFormatting: Command = (state, dispatch, view) => {
   if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
@@ -74,8 +85,14 @@ export const pasteWithoutFormatting: Command = (state, dispatch, view) => {
       const slice = buildPlainTextSlice(text, schema);
       view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
     })
-    .catch(() => {
-      // Best-effort: clipboard read can be denied or unsupported.
+    .catch((error: unknown) => {
+      // Surface the failure to the shell instead of swallowing it; guard the
+      // constructor so importing this module stays safe in non-DOM contexts.
+      if (typeof CustomEvent === "function" && !view.isDestroyed) {
+        view.dom.dispatchEvent(
+          new CustomEvent(CLIPBOARD_READ_ERROR_EVENT, { detail: { error }, bubbles: true }),
+        );
+      }
     });
 
   return true;

--- a/packages/core/src/prosemirror/commands/pastePlainText.ts
+++ b/packages/core/src/prosemirror/commands/pastePlainText.ts
@@ -39,16 +39,26 @@ export function buildPlainTextSlice(text: string, schema: Schema): Slice {
 /**
  * Read the clipboard and insert it as unformatted text at the current selection.
  *
- * Returns `true` (claiming the key) whenever a clipboard read can be attempted,
- * so the browser's own "paste without formatting" shortcut does not also fire.
- * The read is best-effort: a denied or unavailable clipboard is swallowed
- * rather than thrown.
+ * Dry-runnable per the ProseMirror command convention: applicability does not
+ * depend on the (asynchronously read) clipboard contents, so the command is
+ * "available" whenever the runtime exposes a clipboard reader. A probe with no
+ * `dispatch` (menus/toolbars) returns `true` without touching the clipboard or
+ * the document. Only when `dispatch` is provided does it read the clipboard and
+ * insert; it then returns `true` (claiming the key) so the browser's own
+ * "paste without formatting" shortcut does not also fire. The read is
+ * best-effort: a denied or unavailable clipboard is swallowed rather than thrown.
  */
 export const pasteWithoutFormatting: Command = (state, dispatch, view) => {
-  if (!dispatch || !view) {
+  if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
     return false;
   }
-  if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+  // Dry run: report availability without side effects.
+  if (!dispatch) {
+    return true;
+  }
+  // Executing needs the view so the async clipboard result dispatches against
+  // fresh state once it resolves; a captured stale state would misplace it.
+  if (!view) {
     return false;
   }
 
@@ -56,7 +66,9 @@ export const pasteWithoutFormatting: Command = (state, dispatch, view) => {
   void navigator.clipboard
     .readText()
     .then((text) => {
-      if (!text) {
+      // The clipboard read is async: the editor may have been torn down while
+      // it was in flight, so re-check before dispatching against a dead view.
+      if (!text || view.isDestroyed) {
         return;
       }
       const slice = buildPlainTextSlice(text, schema);

--- a/packages/core/src/prosemirror/commands/pastePlainText.ts
+++ b/packages/core/src/prosemirror/commands/pastePlainText.ts
@@ -1,0 +1,70 @@
+/**
+ * Paste without formatting
+ *
+ * Inserts clipboard text as unformatted paragraphs, dropping every source mark
+ * (bold, colour, font, links) so the pasted text takes on the destination
+ * paragraph's own style. This is the "paste without formatting" escape hatch,
+ * distinct from the default rich paste that preserves source formatting.
+ */
+
+import { Fragment, Slice } from "prosemirror-model";
+import type { Schema } from "prosemirror-model";
+import type { Command } from "prosemirror-state";
+
+const PARAGRAPH_BREAK = /(?:\r\n?|\n)+/;
+
+/**
+ * Build a mark-free slice from plain text, one paragraph per run of newlines.
+ *
+ * Pure and DOM-free so it is unit-testable and reusable from both the keymap
+ * command and the context menu. The slice is opened at both ends
+ * ({@link Slice.maxOpen}) so its first and last paragraphs merge into the
+ * surrounding block on {@link Transaction.replaceSelection}, matching how the
+ * editor's default text paste flows into the current line.
+ */
+export function buildPlainTextSlice(text: string, schema: Schema): Slice {
+  const paragraphType = schema.nodes["paragraph"];
+  if (!paragraphType) {
+    // No paragraph node (e.g. an inline-only schema): fall back to flat text.
+    return text ? new Slice(Fragment.from(schema.text(text)), 0, 0) : Slice.empty;
+  }
+
+  const paragraphs = text
+    .split(PARAGRAPH_BREAK)
+    .map((block) => paragraphType.create(null, block ? schema.text(block) : null));
+
+  return Slice.maxOpen(Fragment.fromArray(paragraphs));
+}
+
+/**
+ * Read the clipboard and insert it as unformatted text at the current selection.
+ *
+ * Returns `true` (claiming the key) whenever a clipboard read can be attempted,
+ * so the browser's own "paste without formatting" shortcut does not also fire.
+ * The read is best-effort: a denied or unavailable clipboard is swallowed
+ * rather than thrown.
+ */
+export const pasteWithoutFormatting: Command = (state, dispatch, view) => {
+  if (!dispatch || !view) {
+    return false;
+  }
+  if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+    return false;
+  }
+
+  const { schema } = state;
+  void navigator.clipboard
+    .readText()
+    .then((text) => {
+      if (!text) {
+        return;
+      }
+      const slice = buildPlainTextSlice(text, schema);
+      view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+    })
+    .catch(() => {
+      // Best-effort: clipboard read can be denied or unsupported.
+    });
+
+  return true;
+};

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -28,6 +28,7 @@ import { ImagePasteExtension } from "./features/ImagePasteExtension";
 import { ListExtension } from "./features/ListExtension";
 import { ParagraphChangeTrackerExtension } from "./features/ParagraphChangeTrackerExtension";
 import { ParaIdAllocatorExtension } from "./features/ParaIdAllocatorExtension";
+import { PasteCleanupExtension } from "./features/PasteCleanupExtension";
 import { PasteStyleInlinerExtension } from "./features/PasteStyleInlinerExtension";
 import { SelectionTrackerExtension } from "./features/SelectionTrackerExtension";
 import { AllCapsExtension } from "./marks/AllCapsExtension";
@@ -172,6 +173,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   }
 
   // Features
+  add("pasteCleanup", PasteCleanupExtension());
   add("pasteStyleInliner", PasteStyleInlinerExtension());
   add("list", ListExtension());
   add("baseKeymap", BaseKeymapExtension());

--- a/packages/core/src/prosemirror/extensions/features/PasteCleanupExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/PasteCleanupExtension.ts
@@ -9,7 +9,7 @@
  *    default clipboard parser; ProseMirror chains every plugin's
  *    `transformPastedHTML`, so this cooperates with the inliner rather than
  *    replacing it, and `<style>` blocks are left intact for it to resolve.
- * 2. `Mod-Shift-v` — "paste without formatting", inserting clipboard text with
+ * 2. `Mod-Alt-v` — "paste without formatting", inserting clipboard text with
  *    the source formatting stripped (see {@link pasteWithoutFormatting}).
  */
 
@@ -36,7 +36,9 @@ export const PasteCleanupExtension = createExtension({
     return {
       plugins: [plugin],
       keyboardShortcuts: {
-        "Mod-Shift-v": pasteWithoutFormatting,
+        // Ctrl/Cmd+Alt+V (the plain-paste convention on the web); Ctrl/Cmd+Shift+V
+        // is reserved for the format painter.
+        "Mod-Alt-v": pasteWithoutFormatting,
       },
     };
   },

--- a/packages/core/src/prosemirror/extensions/features/PasteCleanupExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/PasteCleanupExtension.ts
@@ -1,0 +1,43 @@
+/**
+ * Paste Cleanup Extension
+ *
+ * Wires two paste-handling behaviors into the editor:
+ *
+ * 1. `transformPastedHTML` — strips Office/web producer cruft from pasted HTML
+ *    (see {@link cleanPastedHtml}) before the schema parser reads it. Runs at
+ *    `Highest` priority so the cleanup happens before the style inliner and the
+ *    default clipboard parser; ProseMirror chains every plugin's
+ *    `transformPastedHTML`, so this cooperates with the inliner rather than
+ *    replacing it, and `<style>` blocks are left intact for it to resolve.
+ * 2. `Mod-Shift-v` — "paste without formatting", inserting clipboard text with
+ *    the source formatting stripped (see {@link pasteWithoutFormatting}).
+ */
+
+import { Plugin } from "prosemirror-state";
+
+import { pasteWithoutFormatting } from "../../commands/pastePlainText";
+import { createExtension } from "../create";
+import type { ExtensionRuntime } from "../types";
+import { Priority } from "../types";
+import { cleanPastedHtml } from "./pasteCleanup";
+
+export const PasteCleanupExtension = createExtension({
+  name: "pasteCleanup",
+  priority: Priority.Highest,
+  onSchemaReady(): ExtensionRuntime {
+    const plugin = new Plugin({
+      props: {
+        transformPastedHTML(html: string): string {
+          return cleanPastedHtml(html);
+        },
+      },
+    });
+
+    return {
+      plugins: [plugin],
+      keyboardShortcuts: {
+        "Mod-Shift-v": pasteWithoutFormatting,
+      },
+    };
+  },
+});

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -62,6 +62,25 @@ describe("cleanPastedHtml — Office cruft removal", () => {
     expect(cleanPastedHtml('<span title="x>y"></span>keep')).toBe("keep");
   });
 
+  test("keeps a stylesheet hidden inside comment delimiters inside <style>", () => {
+    const out = cleanPastedHtml('<style><!-- .keep{color:red} --></style><p class="keep">x</p>');
+    // The style block (and its class rule) must survive the comment strip so the
+    // downstream inliner can still resolve `.keep`.
+    expect(out).toContain("<style>");
+    expect(out).toContain(".keep{color:red}");
+    expect(out).toContain('<p class="keep">x</p>');
+  });
+
+  test("still strips comments that sit outside a <style> block", () => {
+    const out = cleanPastedHtml(
+      "<!-- drop me --><style>.a{color:red}</style><!-- and me --><p>x</p>",
+    );
+    expect(out).not.toContain("drop me");
+    expect(out).not.toContain("and me");
+    expect(out).toContain("<style>.a{color:red}</style>");
+    expect(out).toContain("<p>x</p>");
+  });
+
   test("removes conditional comments including the Office xml island", () => {
     const html = "<!--[if gte mso 9]><xml><o:OfficeDocumentSettings/></xml><![endif]--><p>Body</p>";
     const out = cleanPastedHtml(html);

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -37,11 +37,23 @@ describe("cleanPastedHtml — Office cruft removal", () => {
     expect(out).toContain(">x</span>");
   });
 
-  test("drops producer class tokens but preserves real ones", () => {
-    expect(cleanPastedHtml('<p class="MsoNormal">a</p>')).toBe("<p>a</p>");
+  test("keeps producer class tokens so the style inliner can match them", () => {
+    // The inliner resolves `.MsoNormal { ... }` rules against these classes; the
+    // schema parser ignores class names, so they are harmless after parsing.
+    expect(cleanPastedHtml('<p class="MsoNormal">a</p>')).toBe('<p class="MsoNormal">a</p>');
     expect(cleanPastedHtml('<p class="MsoListParagraph highlighted">a</p>')).toBe(
-      '<p class="highlighted">a</p>',
+      '<p class="MsoListParagraph highlighted">a</p>',
     );
+  });
+
+  test("preserves both the <style> rule and its class so the inliner can apply it", () => {
+    // Regression: cleanup runs before the style inliner, so it must keep the
+    // MsoNormal class AND the stylesheet, or the class rule's formatting is lost.
+    const out = cleanPastedHtml(
+      '<style>.MsoNormal{font-size:18pt}</style><p class="MsoNormal">x</p>',
+    );
+    expect(out).toContain("<style>.MsoNormal{font-size:18pt}</style>");
+    expect(out).toContain('<p class="MsoNormal">x</p>');
   });
 
   test("removes namespaced Office tags and smart tags but keeps their text", () => {
@@ -122,7 +134,9 @@ describe("cleanPastedHtml — Office cruft removal", () => {
     expect(out).toContain("<td");
     expect(out).toContain("padding:5pt");
     expect(out).not.toContain("mso-");
-    expect(out).not.toContain("MsoNormal");
+    // Producer classes stay on the elements for the inliner to match.
+    expect(out).toContain('class="MsoTableGrid"');
+    expect(out).toContain('class="MsoNormal"');
     expect(out).toContain("Cell");
   });
 
@@ -132,7 +146,8 @@ describe("cleanPastedHtml — Office cruft removal", () => {
       '<p class="MsoListParagraph" style="mso-list:l0 level1 lfo1; margin-left:36pt">Second</p>';
     const out = cleanPastedHtml(html);
     expect(out).not.toContain("mso-list");
-    expect(out).not.toContain("MsoListParagraph");
+    // The list class is kept so the inliner can resolve its `<style>` rule.
+    expect(out).toContain('class="MsoListParagraph"');
     expect(out).toContain("margin-left:36pt");
     expect(out).toContain("First");
     expect(out).toContain("Second");

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -18,6 +18,16 @@ describe("cleanPastedHtml — Office cruft removal", () => {
     expect(out).toBe("<span>text</span>");
   });
 
+  test("does not corrupt a declaration whose value contains semicolons", () => {
+    const out = cleanPastedHtml(
+      `<div style="mso-foo:bar; background:url('data:image/png;base64,AAAB');color:red">x</div>`,
+    );
+    expect(out).not.toContain("mso-foo");
+    expect(out).toContain("data:image/png;base64,AAAB");
+    expect(out).toContain("color:red");
+    expect(out).toContain(">x</div>");
+  });
+
   test("keeps a quoted font name that uses the other quote character", () => {
     const out = cleanPastedHtml(
       `<span style="mso-bidi-font-family:'Times New Roman'; font-family:'Times New Roman'">x</span>`,
@@ -42,6 +52,14 @@ describe("cleanPastedHtml — Office cruft removal", () => {
     expect(out).not.toContain("o:p");
     expect(out).toContain("Berlin");
     expect(out).toContain("today");
+  });
+
+  test("removes a namespaced tag whose attribute value contains a quoted '>'", () => {
+    expect(cleanPastedHtml('<o:p data-x="a>b">keep</o:p>')).toBe("keep");
+  });
+
+  test("removes an empty span whose attribute value contains a quoted '>'", () => {
+    expect(cleanPastedHtml('<span title="x>y"></span>keep')).toBe("keep");
   });
 
   test("removes conditional comments including the Office xml island", () => {

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+
+import { cleanPastedHtml } from "./pasteCleanup";
+
+describe("cleanPastedHtml — Office cruft removal", () => {
+  test("strips mso-* declarations but keeps real CSS", () => {
+    const out = cleanPastedHtml(
+      '<p style="mso-margin-top-alt:auto; color:#FF0000; mso-pagination:widow-orphan; font-weight:bold">Hi</p>',
+    );
+    expect(out).not.toContain("mso-");
+    expect(out).toContain("color:#FF0000");
+    expect(out).toContain("font-weight:bold");
+    expect(out).toContain(">Hi</p>");
+  });
+
+  test("removes a style attribute that held only mso declarations", () => {
+    const out = cleanPastedHtml('<span style="mso-spacerun:yes">text</span>');
+    expect(out).toBe("<span>text</span>");
+  });
+
+  test("keeps a quoted font name that uses the other quote character", () => {
+    const out = cleanPastedHtml(
+      `<span style="mso-bidi-font-family:'Times New Roman'; font-family:'Times New Roman'">x</span>`,
+    );
+    expect(out).not.toContain("mso-bidi");
+    expect(out).toContain("font-family:'Times New Roman'");
+    expect(out).toContain(">x</span>");
+  });
+
+  test("drops producer class tokens but preserves real ones", () => {
+    expect(cleanPastedHtml('<p class="MsoNormal">a</p>')).toBe("<p>a</p>");
+    expect(cleanPastedHtml('<p class="MsoListParagraph highlighted">a</p>')).toBe(
+      '<p class="highlighted">a</p>',
+    );
+  });
+
+  test("removes namespaced Office tags and smart tags but keeps their text", () => {
+    const out = cleanPastedHtml(
+      "<p>See <st1:place><st1:City>Berlin</st1:City></st1:place> today<o:p></o:p></p>",
+    );
+    expect(out).not.toContain("st1:");
+    expect(out).not.toContain("o:p");
+    expect(out).toContain("Berlin");
+    expect(out).toContain("today");
+  });
+
+  test("removes conditional comments including the Office xml island", () => {
+    const html = "<!--[if gte mso 9]><xml><o:OfficeDocumentSettings/></xml><![endif]--><p>Body</p>";
+    const out = cleanPastedHtml(html);
+    expect(out).not.toContain("mso");
+    expect(out).not.toContain("<xml");
+    expect(out).not.toContain("OfficeDocumentSettings");
+    expect(out).toBe("<p>Body</p>");
+  });
+
+  test("strips XML processing instructions, meta/link, and font tags (unwrapping content)", () => {
+    const out = cleanPastedHtml(
+      '<?xml version="1.0"?><meta charset="utf-8"><link rel="x"><font face="Arial">Word</font>',
+    );
+    expect(out).not.toContain("<?xml");
+    expect(out).not.toContain("<meta");
+    expect(out).not.toContain("<link");
+    expect(out).not.toContain("<font");
+    expect(out).toContain("Word");
+  });
+
+  test("removes empty spans, including nested ones, but keeps spans with content", () => {
+    expect(cleanPastedHtml("<p><span></span><span>keep</span></p>")).toBe(
+      "<p><span>keep</span></p>",
+    );
+    expect(cleanPastedHtml("<p><span><span></span></span>x</p>")).toBe("<p>x</p>");
+  });
+
+  test("keeps whitespace-only spans so adjacent words never merge", () => {
+    const out = cleanPastedHtml("word<span> </span>word");
+    expect(out).toContain("word<span> </span>word");
+  });
+
+  test("preserves a pasted table structure while stripping cell cruft", () => {
+    const html =
+      '<table class="MsoTableGrid"><tr><td style="mso-border-alt:solid; padding:5pt"><p class="MsoNormal">Cell</p></td></tr></table>';
+    const out = cleanPastedHtml(html);
+    expect(out).toContain("<table");
+    expect(out).toContain("<tr>");
+    expect(out).toContain("<td");
+    expect(out).toContain("padding:5pt");
+    expect(out).not.toContain("mso-");
+    expect(out).not.toContain("MsoNormal");
+    expect(out).toContain("Cell");
+  });
+
+  test("preserves a pasted Word list as ordered paragraphs", () => {
+    const html =
+      '<p class="MsoListParagraph" style="mso-list:l0 level1 lfo1; margin-left:36pt">First</p>' +
+      '<p class="MsoListParagraph" style="mso-list:l0 level1 lfo1; margin-left:36pt">Second</p>';
+    const out = cleanPastedHtml(html);
+    expect(out).not.toContain("mso-list");
+    expect(out).not.toContain("MsoListParagraph");
+    expect(out).toContain("margin-left:36pt");
+    expect(out).toContain("First");
+    expect(out).toContain("Second");
+  });
+});
+
+describe("cleanPastedHtml — safety and robustness", () => {
+  test("leaves non-Office HTML essentially untouched", () => {
+    const html = "<p>Plain <strong>bold</strong> text</p>";
+    expect(cleanPastedHtml(html)).toBe(html);
+  });
+
+  test("does not rewrite typographic characters or non-Latin scripts", () => {
+    const html = "<p>“quoted” — مرحبا</p>";
+    expect(cleanPastedHtml(html)).toBe(html);
+  });
+
+  test("drops an unterminated comment without leaving a stray opener", () => {
+    expect(cleanPastedHtml("safe<!--dangling")).toBe("safe");
+  });
+
+  test("empty input returns empty", () => {
+    expect(cleanPastedHtml("")).toBe("");
+  });
+
+  test("handles a hostile run of namespace openers in linear time", () => {
+    const evil = "<o:p>".repeat(100_000);
+    const start = performance.now();
+    const out = cleanPastedHtml(evil);
+    expect(performance.now() - start).toBeLessThan(2000);
+    expect(out).toBe("");
+  });
+});

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -1,0 +1,150 @@
+/**
+ * Office / web paste cleanup
+ *
+ * Content pasted from word processors and web pages arrives wrapped in a large
+ * amount of producer-specific cruft: conditional comments, XML processing
+ * instructions, namespaced markup (`<o:p>`, `<w:sdt>`, smart tags), `mso-*`
+ * style declarations, producer-only class names, and empty spans. None of it
+ * maps to the editor schema, and some of it confuses the browser HTML parser
+ * that ProseMirror's clipboard pipeline relies on.
+ *
+ * `cleanPastedHtml` normalizes the raw clipboard HTML string into something the
+ * schema's `parseDOM` rules can read cleanly. It is a pure string transform so
+ * it runs in the editor and in tests without a DOM, and it is deliberately
+ * conservative: it strips producer metadata but never rewrites visible text
+ * (curly quotes, non-Latin scripts, and whitespace between words are left
+ * untouched, since this editor targets an international, typography-sensitive
+ * audience).
+ */
+
+/**
+ * Remove every HTML comment, including downlevel conditional comments
+ * (`<!--[if gte mso 9]> ... <![endif]-->`) that carry the Office `<xml>` island.
+ *
+ * A single linear scan rather than a regex: clipboard HTML is untrusted, and a
+ * lazy `<!--[\s\S]*?-->` against the multi-character `-->` terminator backtracks
+ * polynomially on hostile input. The scan also drops an unterminated comment
+ * through end-of-string so no stray `<!--` can survive.
+ */
+function stripHtmlComments(html: string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const start = html.indexOf("<!--", cursor);
+    if (start === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    result += html.slice(cursor, start);
+    const end = html.indexOf("-->", start + 4);
+    if (end === -1) {
+      break;
+    }
+
+    cursor = end + 3;
+  }
+
+  return result;
+}
+
+/**
+ * Drop `mso-*` declarations from every inline `style` attribute while keeping
+ * legitimate CSS. Operates per attribute (bounded `[^"]*` / `[^']*` inside the
+ * quotes) so it can never run past the attribute into unrelated markup, and
+ * splits on `;` rather than quotes so font names containing the other quote
+ * character survive. An attribute left empty is removed entirely.
+ */
+function stripMsoStyles(html: string): string {
+  // Capture the leading whitespace too so dropping an emptied attribute does not
+  // leave a dangling space (`<span >`).
+  return html.replace(
+    /(\s+)style=(?:"([^"]*)"|'([^']*)')/gi,
+    (_match, ws: string, dq: string | undefined, sq: string | undefined) => {
+      const raw = dq ?? sq ?? "";
+      const quote = dq === undefined ? "'" : '"';
+      const kept = raw
+        .split(";")
+        .map((declaration) => declaration.trim())
+        .filter((declaration) => declaration.length > 0 && !/^mso-/i.test(declaration))
+        .join("; ");
+      return kept ? `${ws}style=${quote}${kept}${quote}` : "";
+    },
+  );
+}
+
+/**
+ * Drop producer-only class tokens (`MsoNormal`, `MsoListParagraph`, ...) while
+ * keeping any real class names. Bounded per attribute like {@link stripMsoStyles}.
+ */
+function stripMsoClasses(html: string): string {
+  return html.replace(
+    /(\s+)class=(?:"([^"]*)"|'([^']*)')/gi,
+    (_match, ws: string, dq: string | undefined, sq: string | undefined) => {
+      const raw = dq ?? sq ?? "";
+      const quote = dq === undefined ? "'" : '"';
+      const kept = raw
+        .split(/\s+/)
+        .filter((token) => token.length > 0 && !/^mso/i.test(token))
+        .join(" ");
+      return kept ? `${ws}class=${quote}${kept}${quote}` : "";
+    },
+  );
+}
+
+// Word/Office/VML/OMML namespaced tags and smart tags (`<o:p>`, `<w:sdt>`,
+// `<v:shape>`, `<m:oMath>`, `<st1:place>`). Tag-only removal keeps any inner
+// text so wrapped user content is never deleted.
+const NAMESPACED_TAG = /<\/?(?:[owvm]|st\d+):[^>]*>/gi;
+const XML_PROCESSING_INSTRUCTION = /<\?xml[^>]*>/gi;
+const STRAY_XML_TAG = /<\/?xml[^>]*>/gi;
+const NOISE_TAG = /<\/?(?:font|meta|link)[^>]*>/gi;
+const EMPTY_SPAN = /<span(?:\s[^>]*)?><\/span>/gi;
+const MAX_EMPTY_SPAN_PASSES = 5;
+
+/**
+ * Remove empty spans left behind after stripping `mso-*` styles. Only truly
+ * empty spans are removed (whitespace-only spans are kept so word-separating
+ * spacer runs never collapse two words together). Repeated a bounded number of
+ * times to unwrap nested empties (`<span><span></span></span>`).
+ */
+function stripEmptySpans(html: string): string {
+  let current = html;
+  for (let pass = 0; pass < MAX_EMPTY_SPAN_PASSES; pass++) {
+    const next = current.replace(EMPTY_SPAN, "");
+    if (next === current) {
+      break;
+    }
+    current = next;
+  }
+  return current;
+}
+
+/**
+ * Strip Office/web producer cruft from a raw clipboard HTML string.
+ *
+ * Best-effort and non-throwing: any unexpected failure returns the original
+ * markup so a paste degrades to the browser default rather than losing content.
+ * `<style>` blocks are intentionally left in place for the downstream style
+ * inliner, which resolves class-based CSS before the schema parser runs.
+ */
+export function cleanPastedHtml(html: string): string {
+  if (!html) {
+    return html;
+  }
+
+  try {
+    let cleaned = stripHtmlComments(html);
+    cleaned = cleaned.replace(XML_PROCESSING_INSTRUCTION, "");
+    cleaned = cleaned.replace(NAMESPACED_TAG, "");
+    cleaned = cleaned.replace(STRAY_XML_TAG, "");
+    cleaned = cleaned.replace(NOISE_TAG, "");
+    cleaned = stripMsoStyles(cleaned);
+    cleaned = stripMsoClasses(cleaned);
+    cleaned = stripEmptySpans(cleaned);
+    return cleaned.trim();
+  } catch {
+    return html;
+  }
+}

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -19,7 +19,14 @@
 
 /**
  * Remove every HTML comment, including downlevel conditional comments
- * (`<!--[if gte mso 9]> ... <![endif]-->`) that carry the Office `<xml>` island.
+ * (`<!--[if gte mso 9]> ... <![endif]-->`) that carry the Office `<xml>` island,
+ * while leaving the contents of `<style>` elements untouched.
+ *
+ * The `<style>` carve-out matters because legacy pasted HTML hides stylesheet
+ * CSS inside comment delimiters (`<style><!-- .c { ... } --></style>`, the old
+ * CDATA-hiding trick). This cleanup runs before the style inliner and must hand
+ * it an intact stylesheet, so a blanket comment strip would drop class rules
+ * that used to be inlined. Style blocks are copied through verbatim.
  *
  * A single linear scan rather than a regex: clipboard HTML is untrusted, and a
  * lazy `<!--[\s\S]*?-->` against the multi-character `-->` terminator backtracks
@@ -27,23 +34,41 @@
  * through end-of-string so no stray `<!--` can survive.
  */
 function stripHtmlComments(html: string): string {
+  const lower = html.toLowerCase();
   let result = "";
   let cursor = 0;
 
   while (cursor < html.length) {
-    const start = html.indexOf("<!--", cursor);
-    if (start === -1) {
+    const commentStart = html.indexOf("<!--", cursor);
+    if (commentStart === -1) {
       result += html.slice(cursor);
       break;
     }
 
-    result += html.slice(cursor, start);
-    const end = html.indexOf("-->", start + 4);
-    if (end === -1) {
+    // A `<style>` element that opens before the next comment is copied through
+    // verbatim (delimiters and all) so the downstream inliner still sees its CSS.
+    const styleStart = lower.indexOf("<style", cursor);
+    if (styleStart !== -1 && styleStart < commentStart) {
+      const openTagEnd = html.indexOf(">", styleStart);
+      const closeStart = openTagEnd === -1 ? -1 : lower.indexOf("</style", openTagEnd + 1);
+      const closeTagEnd = closeStart === -1 ? -1 : html.indexOf(">", closeStart);
+      if (closeTagEnd === -1) {
+        // Malformed/unterminated <style>: keep the remainder as-is and stop.
+        result += html.slice(cursor);
+        break;
+      }
+      result += html.slice(cursor, closeTagEnd + 1);
+      cursor = closeTagEnd + 1;
+      continue;
+    }
+
+    result += html.slice(cursor, commentStart);
+    const commentEnd = html.indexOf("-->", commentStart + 4);
+    if (commentEnd === -1) {
       break;
     }
 
-    cursor = end + 3;
+    cursor = commentEnd + 3;
   }
 
   return result;

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -4,9 +4,10 @@
  * Content pasted from word processors and web pages arrives wrapped in a large
  * amount of producer-specific cruft: conditional comments, XML processing
  * instructions, namespaced markup (`<o:p>`, `<w:sdt>`, smart tags), `mso-*`
- * style declarations, producer-only class names, and empty spans. None of it
- * maps to the editor schema, and some of it confuses the browser HTML parser
- * that ProseMirror's clipboard pipeline relies on.
+ * style declarations, and empty spans. None of it maps to the editor schema,
+ * and some of it confuses the browser HTML parser that ProseMirror's clipboard
+ * pipeline relies on. Producer class names (`MsoNormal`, ...) are deliberately
+ * kept so the downstream style inliner can match `<style>` rules against them.
  *
  * `cleanPastedHtml` normalizes the raw clipboard HTML string into something the
  * schema's `parseDOM` rules can read cleanly. It is a pure string transform so
@@ -139,24 +140,13 @@ function splitStyleDeclarations(value: string): string[] {
   return declarations;
 }
 
-/**
- * Drop producer-only class tokens (`MsoNormal`, `MsoListParagraph`, ...) while
- * keeping any real class names. Bounded per attribute like {@link stripMsoStyles}.
- */
-function stripMsoClasses(html: string): string {
-  return html.replace(
-    /(\s+)class=(?:"([^"]*)"|'([^']*)')/gi,
-    (_match, ws: string, dq: string | undefined, sq: string | undefined) => {
-      const raw = dq ?? sq ?? "";
-      const quote = dq === undefined ? "'" : '"';
-      const kept = raw
-        .split(/\s+/)
-        .filter((token) => token.length > 0 && !/^mso/i.test(token))
-        .join(" ");
-      return kept ? `${ws}class=${quote}${kept}${quote}` : "";
-    },
-  );
-}
+// Producer-only class names (`MsoNormal`, `MsoListParagraph`, ...) are left in
+// place on purpose. The downstream style inliner matches them against `<style>`
+// rules to inline real Word formatting (e.g. `.MsoNormal { font-size: 18pt }`),
+// and the schema's `parseDOM` keys off tags, marks, and specific attributes —
+// never arbitrary class names — so leftover producer classes are dropped on
+// parse and cause no harm. Stripping them here (before the inliner runs) would
+// break class-based paste, so it is intentionally not done.
 
 // Matches the local name and attributes after a tag's prefix, treating quoted
 // attribute values as opaque so a `>` inside a value (e.g. `title="a>b"`) does
@@ -212,7 +202,6 @@ export function cleanPastedHtml(html: string): string {
     cleaned = cleaned.replace(STRAY_XML_TAG, "");
     cleaned = cleaned.replace(NOISE_TAG, "");
     cleaned = stripMsoStyles(cleaned);
-    cleaned = stripMsoClasses(cleaned);
     cleaned = stripEmptySpans(cleaned);
     return cleaned.trim();
   } catch {

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -52,9 +52,8 @@ function stripHtmlComments(html: string): string {
 /**
  * Drop `mso-*` declarations from every inline `style` attribute while keeping
  * legitimate CSS. Operates per attribute (bounded `[^"]*` / `[^']*` inside the
- * quotes) so it can never run past the attribute into unrelated markup, and
- * splits on `;` rather than quotes so font names containing the other quote
- * character survive. An attribute left empty is removed entirely.
+ * quotes) so it can never run past the attribute into unrelated markup. An
+ * attribute left with no non-`mso-*` declarations is removed entirely.
  */
 function stripMsoStyles(html: string): string {
   // Capture the leading whitespace too so dropping an emptied attribute does not
@@ -64,14 +63,55 @@ function stripMsoStyles(html: string): string {
     (_match, ws: string, dq: string | undefined, sq: string | undefined) => {
       const raw = dq ?? sq ?? "";
       const quote = dq === undefined ? "'" : '"';
-      const kept = raw
-        .split(";")
+      const kept = splitStyleDeclarations(raw)
         .map((declaration) => declaration.trim())
         .filter((declaration) => declaration.length > 0 && !/^mso-/i.test(declaration))
         .join("; ");
       return kept ? `${ws}style=${quote}${kept}${quote}` : "";
     },
   );
+}
+
+/**
+ * Split a CSS `style` value into declarations on top-level `;` only.
+ *
+ * A naive `split(";")` corrupts values that legitimately contain a semicolon
+ * inside a function or a quoted string (e.g. `background:url("data:...;base64,...")`).
+ * This scan ignores `;` while inside parentheses or a quoted string, so such
+ * declarations stay intact.
+ */
+function splitStyleDeclarations(value: string): string[] {
+  const declarations: string[] = [];
+  let current = "";
+  let parenDepth = 0;
+  let quote: '"' | "'" | null = null;
+
+  for (const char of value) {
+    if (quote !== null) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === "(") {
+      parenDepth++;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === ";" && parenDepth === 0) {
+      declarations.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) {
+    declarations.push(current);
+  }
+  return declarations;
 }
 
 /**
@@ -93,14 +133,20 @@ function stripMsoClasses(html: string): string {
   );
 }
 
+// Matches the local name and attributes after a tag's prefix, treating quoted
+// attribute values as opaque so a `>` inside a value (e.g. `title="a>b"`) does
+// not truncate the tag mid-attribute. Stays linear: each alternative begins on
+// a distinct character (`"`, `'`, or any other non-`>` char).
+const TAG_TAIL = `(?:"[^"]*"|'[^']*'|[^>"'])*`;
+
 // Word/Office/VML/OMML namespaced tags and smart tags (`<o:p>`, `<w:sdt>`,
 // `<v:shape>`, `<m:oMath>`, `<st1:place>`). Tag-only removal keeps any inner
 // text so wrapped user content is never deleted.
-const NAMESPACED_TAG = /<\/?(?:[owvm]|st\d+):[^>]*>/gi;
-const XML_PROCESSING_INSTRUCTION = /<\?xml[^>]*>/gi;
-const STRAY_XML_TAG = /<\/?xml[^>]*>/gi;
-const NOISE_TAG = /<\/?(?:font|meta|link)[^>]*>/gi;
-const EMPTY_SPAN = /<span(?:\s[^>]*)?><\/span>/gi;
+const NAMESPACED_TAG = new RegExp(`<\\/?(?:[owvm]|st\\d+):${TAG_TAIL}>`, "gi");
+const XML_PROCESSING_INSTRUCTION = new RegExp(`<\\?xml${TAG_TAIL}>`, "gi");
+const STRAY_XML_TAG = new RegExp(`<\\/?xml${TAG_TAIL}>`, "gi");
+const NOISE_TAG = new RegExp(`<\\/?(?:font|meta|link)${TAG_TAIL}>`, "gi");
+const EMPTY_SPAN = new RegExp(`<span(?:\\s${TAG_TAIL})?><\\/span>`, "gi");
 const MAX_EMPTY_SPAN_PASSES = 5;
 
 /**

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2303,7 +2303,9 @@ export function DocxEditor({
         case "pasteAsPlainText":
           try {
             const text = await navigator.clipboard.readText();
-            if (text) {
+            // The clipboard read is async: bail if the editor unmounted while it
+            // was in flight rather than dispatching against a destroyed view.
+            if (text && !view.isDestroyed) {
               // replaceSelection with a paragraph slice preserves line breaks;
               // insertText would flatten them into one paragraph.
               const slice = buildPlainTextSlice(text, view.state.schema);

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -126,7 +126,10 @@ import {
   setContentControlValueTr,
 } from "@stll/folio-core/prosemirror/commands/contentControls";
 import { setContentControlContentBlocksTr } from "@stll/folio-core/prosemirror/commands/contentControlsBlockFill";
-import { buildPlainTextSlice } from "@stll/folio-core/prosemirror/commands/pastePlainText";
+import {
+  buildPlainTextSlice,
+  CLIPBOARD_READ_ERROR_EVENT,
+} from "@stll/folio-core/prosemirror/commands/pastePlainText";
 import { proseDocToBlocks } from "@stll/folio-core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "@stll/folio-core/prosemirror/extensions/ExtensionManager";
 import {
@@ -470,6 +473,19 @@ export function DocxEditor({
   onSelectiveSaveTripwire,
 }: DocxEditorProps & { ref?: Ref<DocxEditorRef> }) {
   const t = useTranslations("folio");
+
+  // Surface a failed clipboard read behind the "paste without formatting"
+  // keystroke: the core command owns no UI and emits a bubbling event instead.
+  useEffect(() => {
+    const onClipboardReadError = (): void => {
+      toast(t("clipboardReadFailed"));
+    };
+    document.addEventListener(CLIPBOARD_READ_ERROR_EVENT, onClipboardReadError);
+    return () => {
+      document.removeEventListener(CLIPBOARD_READ_ERROR_EVENT, onClipboardReadError);
+    };
+  }, [t]);
+
   // DocxEditor renders FolioUIProvider itself, so it can't consume its own
   // provider via useFolioUI() (that resolves to the default context). Resolve
   // from the `components` prop directly, with the built-in default as fallback.
@@ -2312,7 +2328,8 @@ export function DocxEditor({
               view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
             }
           } catch {
-            // Clipboard access denied
+            // Surface the failure instead of leaving a dead menu action.
+            toast(t("clipboardReadFailed"));
           }
           break;
         case "delete": {

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -126,6 +126,7 @@ import {
   setContentControlValueTr,
 } from "@stll/folio-core/prosemirror/commands/contentControls";
 import { setContentControlContentBlocksTr } from "@stll/folio-core/prosemirror/commands/contentControlsBlockFill";
+import { buildPlainTextSlice } from "@stll/folio-core/prosemirror/commands/pastePlainText";
 import { proseDocToBlocks } from "@stll/folio-core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "@stll/folio-core/prosemirror/extensions/ExtensionManager";
 import {
@@ -2303,7 +2304,10 @@ export function DocxEditor({
           try {
             const text = await navigator.clipboard.readText();
             if (text) {
-              view.dispatch(view.state.tr.insertText(text));
+              // replaceSelection with a paragraph slice preserves line breaks;
+              // insertText would flatten them into one paragraph.
+              const slice = buildPlainTextSlice(text, view.state.schema);
+              view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
             }
           } catch {
             // Clipboard access denied

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2153,7 +2153,7 @@ export function DocxEditor({
       {
         action: "pasteAsPlainText",
         label: t("pasteUnformatted"),
-        shortcut: `${mod}+Shift+V`,
+        shortcut: `${mod}+Alt+V`,
         dividerAfter: true,
       },
       {

--- a/packages/react/src/components/TextContextMenu.tsx
+++ b/packages/react/src/components/TextContextMenu.tsx
@@ -149,7 +149,7 @@ const DEFAULT_MENU_ITEMS: TextContextMenuItem[] = [
   {
     action: "pasteAsPlainText",
     label: "Paste as Plain Text",
-    shortcut: "Ctrl+Shift+V",
+    shortcut: "Ctrl+Alt+V",
     dividerAfter: true,
   },
   { action: "delete", label: "Delete", shortcut: "Del", dividerAfter: true },
@@ -762,7 +762,7 @@ export function getTextActionShortcut(action: TextContextAction): string {
     cut: "Ctrl+X",
     copy: "Ctrl+C",
     paste: "Ctrl+V",
-    pasteAsPlainText: "Ctrl+Shift+V",
+    pasteAsPlainText: "Ctrl+Alt+V",
     selectAll: "Ctrl+A",
     delete: "Del",
     separator: "",

--- a/packages/react/src/i18n/messages/ar.json
+++ b/packages/react/src/i18n/messages/ar.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "لا تزال stella تتحقق مما إذا كان يمكن تعديل ملف DOCX هذا بأمان. حاول مرة أخرى عند انتهاء تحميل المستند.",
     "checkingDocxEditTitle": "جارٍ فحص المستند",
     "clearDate": "مسح التاريخ",
+    "clipboardReadFailed": "تعذّرت قراءة الحافظة. تحقّق من أذونات الحافظة وحاول مرة أخرى.",
     "comment": "تعليق",
     "comments": {
       "addPlaceholder": "أضف تعليقًا...",

--- a/packages/react/src/i18n/messages/cs.json
+++ b/packages/react/src/i18n/messages/cs.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella ještě ověřuje, jestli lze tento DOCX bezpečně upravovat. Zkuste to znovu, až se dokument načte.",
     "checkingDocxEditTitle": "Kontrola dokumentu",
     "clearDate": "Vymazat datum",
+    "clipboardReadFailed": "Nepodařilo se přečíst schránku. Zkontrolujte oprávnění ke schránce a zkuste to znovu.",
     "comment": "Komentář",
     "comments": {
       "addPlaceholder": "Přidat komentář...",

--- a/packages/react/src/i18n/messages/de.json
+++ b/packages/react/src/i18n/messages/de.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella prüft noch, ob diese DOCX-Datei sicher bearbeitet werden kann. Versuchen Sie es erneut, sobald das Dokument vollständig geladen ist.",
     "checkingDocxEditTitle": "Dokument wird geprüft",
     "clearDate": "Datum löschen",
+    "clipboardReadFailed": "Zwischenablage konnte nicht gelesen werden. Prüfen Sie die Berechtigungen für die Zwischenablage und versuchen Sie es erneut.",
     "comment": "Kommentar",
     "comments": {
       "addPlaceholder": "Kommentar hinzufügen...",

--- a/packages/react/src/i18n/messages/en.json
+++ b/packages/react/src/i18n/messages/en.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella is still checking whether this DOCX can be edited safely. Try again when the document finishes loading.",
     "checkingDocxEditTitle": "Checking document",
     "clearDate": "Clear date",
+    "clipboardReadFailed": "Couldn't read the clipboard. Check clipboard permissions and try again.",
     "comment": "Comment",
     "comments": {
       "addPlaceholder": "Add a comment...",

--- a/packages/react/src/i18n/messages/es.json
+++ b/packages/react/src/i18n/messages/es.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella sigue comprobando si este DOCX se puede editar de forma segura. Vuelve a intentarlo cuando el documento termine de cargarse.",
     "checkingDocxEditTitle": "Comprobando el documento",
     "clearDate": "Borrar fecha",
+    "clipboardReadFailed": "No se pudo leer el portapapeles. Comprueba los permisos del portapapeles e inténtalo de nuevo.",
     "comment": "Comentario",
     "comments": {
       "addPlaceholder": "Añadir comentario...",

--- a/packages/react/src/i18n/messages/et.json
+++ b/packages/react/src/i18n/messages/et.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella kontrollib veel, kas seda DOCX-i saab turvaliselt muuta. Proovige uuesti, kui dokument on laadimise lõpetanud.",
     "checkingDocxEditTitle": "Dokumendi kontrollimine",
     "clearDate": "Tühjenda kuupäev",
+    "clipboardReadFailed": "Lõikelauda ei õnnestunud lugeda. Kontrollige lõikelaua õigusi ja proovige uuesti.",
     "comment": "Kommenteeri",
     "comments": {
       "addPlaceholder": "Lisa kommentaar…",

--- a/packages/react/src/i18n/messages/fr.json
+++ b/packages/react/src/i18n/messages/fr.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella vérifie encore si ce DOCX peut être modifié en toute sécurité. Réessayez une fois le document chargé.",
     "checkingDocxEditTitle": "Vérification du document",
     "clearDate": "Effacer la date",
+    "clipboardReadFailed": "Impossible de lire le presse-papiers. Vérifiez les autorisations du presse-papiers et réessayez.",
     "comment": "Commenter",
     "comments": {
       "addPlaceholder": "Ajouter un commentaire...",

--- a/packages/react/src/i18n/messages/hu.json
+++ b/packages/react/src/i18n/messages/hu.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "A stella még ellenőrzi, hogy ez a DOCX biztonságosan szerkeszthető-e. Próbálja újra, amikor a dokumentum betöltődött.",
     "checkingDocxEditTitle": "Dokumentum ellenőrzése",
     "clearDate": "Dátum törlése",
+    "clipboardReadFailed": "A vágólap nem olvasható. Ellenőrizze a vágólap engedélyeit, és próbálja újra.",
     "comment": "Megjegyzés",
     "comments": {
       "addPlaceholder": "Megjegyzés hozzáadása…",

--- a/packages/react/src/i18n/messages/lt.json
+++ b/packages/react/src/i18n/messages/lt.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella vis dar tikrina, ar šį DOCX galima saugiai redaguoti. Bandykite dar kartą, kai dokumentas baigs krautis.",
     "checkingDocxEditTitle": "Tikrinamas dokumentas",
     "clearDate": "Išvalyti datą",
+    "clipboardReadFailed": "Nepavyko nuskaityti iškarpinės. Patikrinkite iškarpinės leidimus ir bandykite dar kartą.",
     "comment": "Komentaras",
     "comments": {
       "addPlaceholder": "Pridėti komentarą…",

--- a/packages/react/src/i18n/messages/lv.json
+++ b/packages/react/src/i18n/messages/lv.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella vēl pārbauda, vai šo DOCX var droši rediģēt. Mēģiniet vēlreiz, kad dokuments būs pilnībā ielādēts.",
     "checkingDocxEditTitle": "Pārbauda dokumentu",
     "clearDate": "Notīrīt datumu",
+    "clipboardReadFailed": "Neizdevās nolasīt starpliktuvi. Pārbaudiet starpliktuves atļaujas un mēģiniet vēlreiz.",
     "comment": "Komentārs",
     "comments": {
       "addPlaceholder": "Pievienot komentāru…",

--- a/packages/react/src/i18n/messages/pl.json
+++ b/packages/react/src/i18n/messages/pl.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella nadal sprawdza, czy ten DOCX można bezpiecznie edytować. Spróbuj ponownie, gdy dokument się załaduje.",
     "checkingDocxEditTitle": "Sprawdzanie dokumentu",
     "clearDate": "Wyczyść datę",
+    "clipboardReadFailed": "Nie udało się odczytać schowka. Sprawdź uprawnienia do schowka i spróbuj ponownie.",
     "comment": "Komentarz",
     "comments": {
       "addPlaceholder": "Dodaj komentarz...",

--- a/packages/react/src/i18n/messages/pt-BR.json
+++ b/packages/react/src/i18n/messages/pt-BR.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella ainda está verificando se este DOCX pode ser editado com segurança. Tente novamente quando o documento terminar de carregar.",
     "checkingDocxEditTitle": "Verificando documento",
     "clearDate": "Limpar data",
+    "clipboardReadFailed": "Não foi possível ler a área de transferência. Verifique as permissões da área de transferência e tente novamente.",
     "comment": "Comentário",
     "comments": {
       "addPlaceholder": "Adicione um comentário...",

--- a/packages/react/src/i18n/messages/sk.json
+++ b/packages/react/src/i18n/messages/sk.json
@@ -12,6 +12,7 @@
     "checkingDocxEditDescription": "stella ešte kontroluje, či možno tento DOCX bezpečne upravovať. Skúste to znova, keď sa dokument načíta.",
     "checkingDocxEditTitle": "Kontrola dokumentu",
     "clearDate": "Vymazať dátum",
+    "clipboardReadFailed": "Nepodarilo sa prečítať schránku. Skontrolujte povolenia schránky a skúste to znova.",
     "comment": "Komentár",
     "comments": {
       "addPlaceholder": "Pridať komentár...",


### PR DESCRIPTION
Cleans office/HTML paste and adds a paste-without-formatting path. Previously the live ProseMirror paste ran the default clipboard parser with only class-CSS inlining — office cruft (`<o:p>`, namespaced `w:`/`v:`/`m:` tags, conditional comments, `mso-*` styles, `Mso*` classes, empty spans) went straight into the schema.

- **`cleanPastedHtml(html)`** (pure, `prosemirror/extensions/features/pasteCleanup.ts`) wired via `PasteCleanupExtension` (`transformPastedHTML`, highest priority — runs *before* the existing class-CSS inliner, leaving `<style>` for it). Strips comments/conditional-comment islands, XML PIs, namespaced tags (tag-only, keeps inner text), `mso-*` declarations (quote-safe), producer class tokens (keeps real classes), `<font>/<meta>/<link>`, truly-empty spans. ReDoS-safe (linear comment scan, bounded regexes). **Non-destructive to visible text** — no smart-quote/entity rewriting (folio is an international, typography-sensitive editor); table and list structure preserved.
- **Paste without formatting** — `buildPlainTextSlice` + `pasteWithoutFormatting` command bound to `Mod-Shift-v`; also re-routes the existing context-menu handler through it, fixing a pre-existing multi-paragraph flattening bug.

Pure-tested: 22 cases (cruft stripping, table/list preservation, non-office HTML untouched, typography/Arabic preserved, unterminated comment, linear-time on 100k openers; plain-text splitting/no-marks/depths). Live paste UX + keybinding are visual (folio has no DOM tests).
