### PR TITLE
feat(react): format painter (copy/paste character formatting)

### DIFF
--- a/packages/core/src/prosemirror/commands/formatPainter.test.ts
+++ b/packages/core/src/prosemirror/commands/formatPainter.test.ts
@@ -76,6 +76,33 @@ describe("captureFormatMarks", () => {
     });
     expect(captureFormatMarks(select(plain, 1, 6))).toEqual([]);
   });
+
+  test("does not paint an override mark that only carries excluded (hidden/rtl) attrs", () => {
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("x", [mark("runFormattingOverride", { hidden: false, rtl: false })]),
+        ]),
+      ]),
+    });
+    expect(captureFormatMarks(select(state, 1, 2))).toEqual([]);
+  });
+
+  test("strips excluded attrs but keeps the rest of a mixed override mark", () => {
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("x", [mark("runFormattingOverride", { bold: false, rtl: false })]),
+        ]),
+      ]),
+    });
+    const captured = captureFormatMarks(select(state, 1, 2));
+    const override = findMark(captured, "runFormattingOverride");
+    expect(override?.attrs["bold"]).toBe(false);
+    expect(override?.attrs["rtl"]).toBeNull();
+  });
 });
 
 describe("applyFormatMarks", () => {

--- a/packages/core/src/prosemirror/commands/formatPainter.test.ts
+++ b/packages/core/src/prosemirror/commands/formatPainter.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import type { Mark } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+
+import { schema } from "../schema";
+import { applyFormatMarks, captureFormatMarks } from "./formatPainter";
+
+const mark = (name: string, attrs?: Record<string, unknown>): Mark => {
+  const type = schema.marks[name];
+  if (!type) {
+    throw new Error(`Expected mark type in schema: ${name}`);
+  }
+  return type.create(attrs);
+};
+
+/** Marks of the first text node inside [from, to). */
+const marksInRange = (state: EditorState, from: number, to: number): readonly Mark[] => {
+  let found: readonly Mark[] | null = null;
+  state.doc.nodesBetween(from, to, (node) => {
+    if (found) {
+      return false;
+    }
+    if (node.isText) {
+      found = node.marks;
+      return false;
+    }
+    return true;
+  });
+  return found ?? [];
+};
+
+const markNames = (marks: readonly Mark[]): string[] => marks.map((m) => m.type.name).toSorted();
+
+const findMark = (marks: readonly Mark[], name: string): Mark | undefined =>
+  marks.find((m) => m.type.name === name);
+
+/**
+ * doc: paragraph["Georgia"(bold, Georgia, 24) + "Arial"(Arial, 20)]
+ * positions: "Georgia" = [1, 8), "Arial" = [8, 13)
+ */
+const buildState = (): EditorState =>
+  EditorState.create({
+    schema,
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("Georgia", [
+          mark("bold"),
+          mark("fontFamily", { ascii: "Georgia", hAnsi: "Georgia" }),
+          mark("fontSize", { size: 24 }),
+        ]),
+        schema.text("Arial", [
+          mark("fontFamily", { ascii: "Arial", hAnsi: "Arial" }),
+          mark("fontSize", { size: 20 }),
+        ]),
+      ]),
+    ]),
+  });
+
+const select = (state: EditorState, from: number, to: number): EditorState =>
+  state.apply(state.tr.setSelection(TextSelection.create(state.doc, from, to)));
+
+describe("captureFormatMarks", () => {
+  test("captures multiple marks at once with their attrs", () => {
+    const state = select(buildState(), 1, 8);
+    const captured = captureFormatMarks(state);
+
+    expect(markNames(captured)).toEqual(["bold", "fontFamily", "fontSize"]);
+    expect(findMark(captured, "fontFamily")?.attrs["ascii"]).toBe("Georgia");
+    expect(findMark(captured, "fontSize")?.attrs["size"]).toBe(24);
+  });
+
+  test("returns an empty array when the selection carries no direct formatting", () => {
+    const plain = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("paragraph", null, [schema.text("plain")])]),
+    });
+    expect(captureFormatMarks(select(plain, 1, 6))).toEqual([]);
+  });
+});
+
+describe("applyFormatMarks", () => {
+  test("paints captured marks onto the target range", () => {
+    let state = buildState();
+    const captured = captureFormatMarks(select(state, 1, 8));
+
+    state = select(state, 8, 13);
+    const handled = applyFormatMarks(captured)(state, (tr) => {
+      state = state.apply(tr);
+    });
+
+    expect(handled).toBe(true);
+    const target = marksInRange(state, 8, 13);
+    expect(markNames(target)).toEqual(["bold", "fontFamily", "fontSize"]);
+    expect(findMark(target, "fontFamily")?.attrs["ascii"]).toBe("Georgia");
+    expect(findMark(target, "fontSize")?.attrs["size"]).toBe(24);
+  });
+
+  test("replaces conflicting same-type marks instead of merging duplicates", () => {
+    let state = buildState();
+    const captured = captureFormatMarks(select(state, 1, 8));
+
+    state = select(state, 8, 13);
+    applyFormatMarks(captured)(state, (tr) => {
+      state = state.apply(tr);
+    });
+
+    const fontFamilies = marksInRange(state, 8, 13).filter((m) => m.type.name === "fontFamily");
+    expect(fontFamilies).toHaveLength(1);
+    expect(fontFamilies[0]?.attrs["ascii"]).toBe("Georgia");
+    const fontSizes = marksInRange(state, 8, 13).filter((m) => m.type.name === "fontSize");
+    expect(fontSizes).toHaveLength(1);
+    expect(fontSizes[0]?.attrs["size"]).toBe(24);
+  });
+
+  test("leaves structural marks (comments) untouched while painting", () => {
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("src", [mark("bold")]),
+          schema.text("dst", [mark("comment", { commentId: 7 })]),
+        ]),
+      ]),
+    });
+    const captured = captureFormatMarks(select(state, 1, 4));
+
+    state = select(state, 4, 7);
+    applyFormatMarks(captured)(state, (tr) => {
+      state = state.apply(tr);
+    });
+
+    const target = marksInRange(state, 4, 7);
+    expect(findMark(target, "bold")).toBeDefined();
+    expect(findMark(target, "comment")?.attrs["commentId"]).toBe(7);
+  });
+
+  test("empty capture is a no-op and does not clear the target", () => {
+    let state = buildState();
+    state = select(state, 8, 13);
+    const before = state.doc.toJSON();
+
+    const handled = applyFormatMarks([])(state, (tr) => {
+      state = state.apply(tr);
+    });
+
+    expect(handled).toBe(false);
+    expect(state.doc.toJSON()).toEqual(before);
+  });
+
+  test("collapsed target selection is a no-op", () => {
+    let state = buildState();
+    const captured = captureFormatMarks(select(state, 1, 8));
+
+    state = select(state, 10, 10);
+    const before = state.doc.toJSON();
+    const handled = applyFormatMarks(captured)(state, (tr) => {
+      state = state.apply(tr);
+    });
+
+    expect(handled).toBe(false);
+    expect(state.doc.toJSON()).toEqual(before);
+  });
+});

--- a/packages/core/src/prosemirror/commands/formatPainter.ts
+++ b/packages/core/src/prosemirror/commands/formatPainter.ts
@@ -45,6 +45,51 @@ export const PAINTABLE_MARK_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Formatting that must never be painted — whether it arrives as its own mark or
+ * is smuggled in as a `runFormattingOverride` attr (e.g. `rtl: false`,
+ * `hidden: false`). Single source of truth: it gates both the mark-type
+ * exclusion and the override-attr filtering below, so an exclusion can't leak
+ * back in through the override mark as new override attrs are added.
+ */
+const NON_PAINTABLE_FORMATS: ReadonlySet<string> = new Set(["rtl", "hidden"]);
+
+/** A mark is paintable when it is in the allowlist and not a hard exclusion. */
+function isPaintableMark(mark: Mark): boolean {
+  const name = mark.type.name;
+  return PAINTABLE_MARK_NAMES.has(name) && !NON_PAINTABLE_FORMATS.has(name);
+}
+
+/**
+ * Strip excluded overrides (`rtl`/`hidden`) from a `runFormattingOverride` mark
+ * so they cannot be re-smuggled past the mark-type exclusion. Returns the mark
+ * unchanged when it carries no excluded attr, a trimmed mark when it carries a
+ * mix, or null when only excluded overrides remain (nothing paintable left).
+ */
+function sanitizeOverrideMark(mark: Mark): Mark | null {
+  const kept: Record<string, unknown> = {};
+  let removedExcluded = false;
+
+  for (const [key, value] of Object.entries(mark.attrs)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (NON_PAINTABLE_FORMATS.has(key)) {
+      removedExcluded = true;
+      continue;
+    }
+    kept[key] = value;
+  }
+
+  if (!removedExcluded) {
+    return mark;
+  }
+  if (Object.keys(kept).length === 0) {
+    return null;
+  }
+  return mark.type.create(kept);
+}
+
+/**
  * Marks of the first text node inside [from, to). A word processor's format
  * brush copies from the start of the source selection, so a mixed selection
  * yields the formatting of its leading run.
@@ -75,7 +120,22 @@ function firstTextMarks(state: EditorState, from: number, to: number): readonly 
 export function captureFormatMarks(state: EditorState): Mark[] {
   const { empty, $from, from, to } = state.selection;
   const source = empty ? (state.storedMarks ?? $from.marks()) : firstTextMarks(state, from, to);
-  return source.filter((mark) => PAINTABLE_MARK_NAMES.has(mark.type.name));
+
+  const captured: Mark[] = [];
+  for (const mark of source) {
+    if (!isPaintableMark(mark)) {
+      continue;
+    }
+    if (mark.type.name === "runFormattingOverride") {
+      const sanitized = sanitizeOverrideMark(mark);
+      if (sanitized) {
+        captured.push(sanitized);
+      }
+      continue;
+    }
+    captured.push(mark);
+  }
+  return captured;
 }
 
 /**

--- a/packages/core/src/prosemirror/commands/formatPainter.ts
+++ b/packages/core/src/prosemirror/commands/formatPainter.ts
@@ -1,0 +1,115 @@
+/**
+ * Format Painter commands — copy the character formatting of one selection and
+ * apply ("paint") it onto another, mirroring a word processor's copy/paste
+ * formatting (Ctrl+Shift+C / Ctrl+Shift+V).
+ *
+ * These are pure, headless commands: capture reads the marks at the current
+ * selection, apply lays a captured mark set onto the current selection's range.
+ * The armed/sticky toolbar interaction lives in the React layer; all editor-state
+ * logic is here so it can be unit-tested without a DOM.
+ */
+
+import type { Mark } from "prosemirror-model";
+import type { Command, EditorState } from "prosemirror-state";
+
+/**
+ * Character-formatting marks the painter copies. Structural marks — comments,
+ * hyperlinks, tracked changes (insertion/deletion), footnote references — are
+ * deliberately excluded so painting never moves an anchor, link, or revision.
+ * `rtl` (run direction) and `hidden` are excluded too: painting them could flip
+ * text direction or hide content, which is surprising for a formatting brush.
+ */
+export const PAINTABLE_MARK_NAMES: ReadonlySet<string> = new Set([
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "textColor",
+  "highlight",
+  "fontSize",
+  "fontFamily",
+  "superscript",
+  "subscript",
+  "allCaps",
+  "smallCaps",
+  "characterSpacing",
+  "runShading",
+  "runFormattingOverride",
+  "emboss",
+  "imprint",
+  "textShadow",
+  "emphasisMark",
+  "textOutline",
+  "textEffect",
+  "characterStyle",
+]);
+
+/**
+ * Marks of the first text node inside [from, to). A word processor's format
+ * brush copies from the start of the source selection, so a mixed selection
+ * yields the formatting of its leading run.
+ */
+function firstTextMarks(state: EditorState, from: number, to: number): readonly Mark[] {
+  let marks: readonly Mark[] | null = null;
+
+  state.doc.nodesBetween(from, to, (node) => {
+    if (marks) {
+      return false;
+    }
+    if (node.isText) {
+      marks = node.marks;
+      return false;
+    }
+    return true;
+  });
+
+  return marks ?? [];
+}
+
+/**
+ * Capture the paintable character marks active over the current selection.
+ * Returns the marks (with their attrs) to hand to `applyFormatMarks`. An empty
+ * selection reads the stored/insertion marks; a range reads its leading run.
+ * Returns an empty array when the source carries no direct character formatting.
+ */
+export function captureFormatMarks(state: EditorState): Mark[] {
+  const { empty, $from, from, to } = state.selection;
+  const source = empty ? (state.storedMarks ?? $from.marks()) : firstTextMarks(state, from, to);
+  return source.filter((mark) => PAINTABLE_MARK_NAMES.has(mark.type.name));
+}
+
+/**
+ * Apply captured marks onto the current selection's range: clear every paintable
+ * mark type first (replace, not merge — so painting Georgia-12-bold onto
+ * Arial-10 leaves only Georgia-12-bold), then lay down the captured marks.
+ *
+ * Best-effort: a collapsed selection or an empty capture is a no-op (returns
+ * false so a keymap binding stays unclaimed and the keystroke passes through).
+ * Never throws.
+ */
+export function applyFormatMarks(marks: readonly Mark[]): Command {
+  return (state, dispatch) => {
+    const { from, to, empty } = state.selection;
+    if (empty || marks.length === 0) {
+      return false;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    let tr = state.tr;
+    for (const name of PAINTABLE_MARK_NAMES) {
+      const markType = state.schema.marks[name];
+      if (markType) {
+        tr = tr.removeMark(from, to, markType);
+      }
+    }
+    for (const mark of marks) {
+      tr = tr.addMark(from, to, mark);
+    }
+
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+}

--- a/packages/core/src/prosemirror/commands/index.ts
+++ b/packages/core/src/prosemirror/commands/index.ts
@@ -113,6 +113,9 @@ export {
 } from "./table";
 export type { TableContextInfo, BorderPreset, TableBorderPreset } from "./table";
 
+// Format painter (copy/paste character formatting)
+export { captureFormatMarks, applyFormatMarks, PAINTABLE_MARK_NAMES } from "./formatPainter";
+
 // Page break
 export { insertPageBreak } from "./pageBreak";
 

--- a/packages/core/src/prosemirror/index.ts
+++ b/packages/core/src/prosemirror/index.ts
@@ -153,6 +153,10 @@ export {
   setCellFillColor,
   setTableBorderColor,
   setTableBorderWidth,
+  // Format painter (copy/paste character formatting)
+  captureFormatMarks,
+  applyFormatMarks,
+  PAINTABLE_MARK_NAMES,
   // Page break
   insertPageBreak,
   // Table of Contents

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -33,6 +33,7 @@ import {
   XIcon,
 } from "lucide-react";
 // Paginated editor
+import type { Mark } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
@@ -68,6 +69,8 @@ import {
   increaseListLevel,
   decreaseListLevel,
   clearFormatting,
+  captureFormatMarks,
+  applyFormatMarks,
   applyStyle,
   createStyleResolver,
   toggleBidi,
@@ -824,6 +827,21 @@ export function DocxEditor({
   const imageInputRef = useRef<HTMLInputElement>(null);
   const editorContentRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Format painter: "armed" paints the next selection once then disarms;
+  // "sticky" keeps painting until Esc or the button is toggled off. The ref
+  // mirrors the mode for the imperative mouseup/keydown listeners (which fire
+  // outside React render); the captured marks live in a ref so they survive
+  // between the copy and the paint.
+  const [formatPainterMode, setFormatPainterModeState] = useState<"off" | "armed" | "sticky">(
+    "off",
+  );
+  const formatPainterModeRef = useRef<"off" | "armed" | "sticky">("off");
+  const capturedFormatMarksRef = useRef<readonly Mark[]>([]);
+  const setFormatPainterMode = useCallback((next: "off" | "armed" | "sticky") => {
+    formatPainterModeRef.current = next;
+    setFormatPainterModeState(next);
+  }, []);
 
   const {
     contextMenu,
@@ -2125,6 +2143,110 @@ export function DocxEditor({
     [getActiveEditorView, getCachedStyleResolver],
   );
 
+  // Capture the current selection's character formatting into the buffer used
+  // by the paint step (toolbar mouseup / Ctrl+Shift+V).
+  const captureFormatPainter = useCallback(() => {
+    const view = getActiveEditorView();
+    capturedFormatMarksRef.current = view ? captureFormatMarks(view.state) : [];
+  }, [getActiveEditorView]);
+
+  // Paint the captured formatting onto the current selection. Returns whether a
+  // paint actually happened (nothing captured / collapsed selection ⇒ false).
+  const paintFormatToSelection = useCallback((): boolean => {
+    const view = getActiveEditorView();
+    if (!view) {
+      return false;
+    }
+    const applied = applyFormatMarks(capturedFormatMarksRef.current)(view.state, view.dispatch);
+    if (applied) {
+      requestAnimationFrame(() => view.focus());
+    }
+    return applied;
+  }, [getActiveEditorView]);
+
+  // Toolbar button: single click (sticky=false) arms a one-shot paint,
+  // double-click (sticky=true) keeps it on. Clicking while armed toggles off.
+  const handleFormatPainter = useCallback(
+    (sticky: boolean) => {
+      if (formatPainterModeRef.current !== "off") {
+        capturedFormatMarksRef.current = [];
+        setFormatPainterMode("off");
+        return;
+      }
+      captureFormatPainter();
+      setFormatPainterMode(sticky ? "sticky" : "armed");
+    },
+    [captureFormatPainter, setFormatPainterMode],
+  );
+
+  // Paint on the mouseup that completes a new selection inside the editor. A
+  // one-shot arm disarms after a successful paint; sticky stays armed.
+  useEffect(() => {
+    const handleMouseUp = (event: MouseEvent) => {
+      if (formatPainterModeRef.current === "off") {
+        return;
+      }
+      const editor = editorContentRef.current;
+      if (!editor || !(event.target instanceof Node) || !editor.contains(event.target)) {
+        return;
+      }
+      // Defer so ProseMirror's own mouseup selection sync settles first.
+      requestAnimationFrame(() => {
+        const painted = paintFormatToSelection();
+        if (painted && formatPainterModeRef.current === "armed") {
+          setFormatPainterMode("off");
+        }
+      });
+    };
+
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => document.removeEventListener("mouseup", handleMouseUp);
+  }, [paintFormatToSelection, setFormatPainterMode]);
+
+  // Keyboard: Ctrl/Cmd+Shift+C copies formatting, Ctrl/Cmd+Shift+V paints it,
+  // Esc disarms. The paint binding only claims the keystroke once something has
+  // been copied, so an untouched Ctrl/Cmd+Shift+V still reaches the browser /
+  // paste handling instead of being swallowed here.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (formatPainterModeRef.current !== "off") {
+          capturedFormatMarksRef.current = [];
+          setFormatPainterMode("off");
+        }
+        return;
+      }
+
+      const isCtrl = event.ctrlKey || event.metaKey;
+      if (!isCtrl || !event.shiftKey || event.altKey) {
+        return;
+      }
+
+      const target = event.target;
+      const withinEditor =
+        target instanceof Node && editorContentRef.current?.contains(target) === true;
+      if (!withinEditor) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key === "c") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        captureFormatPainter();
+        return;
+      }
+      if (key === "v" && capturedFormatMarksRef.current.length > 0) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        paintFormatToSelection();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [captureFormatPainter, paintFormatToSelection, setFormatPainterMode]);
+
   const handleContextMenu = useCallback(
     (data: { x: number; y: number; hasSelection: boolean }) => {
       openContextMenu({ x: data.x, y: data.y }, data.hasSelection);
@@ -3208,6 +3330,7 @@ export function DocxEditor({
             className={`folio-root folio-editor${displayMode !== "all-markup" ? ` folio-root--${displayMode}` : ""}${showHeaderFooterEditing ? "" : " folio-no-hf-edit"} ${className}`}
             style={containerStyle}
             data-testid="folio-editor"
+            data-folio-format-painter={formatPainterMode !== "off" ? "armed" : undefined}
           >
             {/* Main content area */}
             <div style={mainContentStyle}>
@@ -3245,6 +3368,8 @@ export function DocxEditor({
                       onToggleRuler={toggleRuler}
                       editorRef={editorContentRef}
                       onRefocusEditor={focusActiveEditor}
+                      formatPainterActive={formatPainterMode !== "off"}
+                      onFormatPainter={handleFormatPainter}
                       onImageWrapType={handleImageWrapType}
                       onImageTransform={handleImageTransform}
                       onOpenImageProperties={handleOpenImageProperties}

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2179,15 +2179,18 @@ export function DocxEditor({
     [captureFormatPainter, setFormatPainterMode],
   );
 
-  // Paint on the mouseup that completes a new selection inside the editor. A
-  // one-shot arm disarms after a successful paint; sticky stays armed.
+  // Paint on the mouseup that completes a new selection. A one-shot arm disarms
+  // after a successful paint; sticky stays armed.
   useEffect(() => {
     const handleMouseUp = (event: MouseEvent) => {
       if (formatPainterModeRef.current === "off") {
         return;
       }
-      const editor = editorContentRef.current;
-      if (!editor || !(event.target instanceof Node) || !editor.contains(event.target)) {
+      // Paint on any release except one on the toolbar: a drag often ends on the
+      // scrollbar, ruler, or page margin rather than strictly inside the editor
+      // content. The toolbar guard keeps the arming click from self-painting.
+      const target = event.target;
+      if (target instanceof Element && target.closest("[data-folio-toolbar]")) {
         return;
       }
       // Defer so ProseMirror's own mouseup selection sync settles first.
@@ -2209,8 +2212,18 @@ export function DocxEditor({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        if (formatPainterModeRef.current !== "off") {
-          capturedFormatMarksRef.current = [];
+        const armed = formatPainterModeRef.current !== "off";
+        const hasCopiedFormat = capturedFormatMarksRef.current.length > 0;
+        // Nothing to cancel — let Esc bubble so it can close a parent modal etc.
+        if (!armed && !hasCopiedFormat) {
+          return;
+        }
+        // Esc disarms and clears the copied format; claim it so the same
+        // keystroke does not also bubble up to close a parent modal or sidebar.
+        event.preventDefault();
+        event.stopPropagation();
+        capturedFormatMarksRef.current = [];
+        if (armed) {
           setFormatPainterMode("off");
         }
         return;

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2204,9 +2204,8 @@ export function DocxEditor({
   }, [paintFormatToSelection, setFormatPainterMode]);
 
   // Keyboard: Ctrl/Cmd+Shift+C copies formatting, Ctrl/Cmd+Shift+V paints it,
-  // Esc disarms. The paint binding only claims the keystroke once something has
-  // been copied, so an untouched Ctrl/Cmd+Shift+V still reaches the browser /
-  // paste handling instead of being swallowed here.
+  // Esc disarms. Both chords belong to the format painter (the word-processor
+  // convention); painting with nothing copied is simply a no-op.
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -2236,7 +2235,7 @@ export function DocxEditor({
         captureFormatPainter();
         return;
       }
-      if (key === "v" && capturedFormatMarksRef.current.length > 0) {
+      if (key === "v") {
         event.preventDefault();
         event.stopImmediatePropagation();
         paintFormatToSelection();

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -156,38 +156,19 @@ export function FormattingBar(props: FormattingBarProps) {
   }, [disabled, canRedo, onRedo]);
 
   // Format painter: a single click arms a one-shot paint, a double-click arms
-  // the sticky (keep-on) mode. The one-shot arm is deferred so a double-click
-  // can pre-empt it — otherwise the first click of a double would fire first.
-  const painterClickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(
-    () => () => {
-      if (painterClickTimer.current) {
-        clearTimeout(painterClickTimer.current);
-      }
-    },
-    [],
-  );
-
+  // the sticky (keep-on) mode. The native `dblclick` event drives sticky mode,
+  // so there is no single-vs-double timing race: the intermediate click just
+  // re-toggles and `dblclick` settles the mode.
   const handleFormatPainterClick = useCallback(() => {
     if (disabled || !onFormatPainter) {
       return;
     }
-    if (painterClickTimer.current) {
-      clearTimeout(painterClickTimer.current);
-    }
-    painterClickTimer.current = setTimeout(() => {
-      painterClickTimer.current = null;
-      onFormatPainter(false);
-    }, 220);
+    onFormatPainter(false);
   }, [disabled, onFormatPainter]);
 
   const handleFormatPainterDoubleClick = useCallback(() => {
     if (disabled || !onFormatPainter) {
       return;
-    }
-    if (painterClickTimer.current) {
-      clearTimeout(painterClickTimer.current);
-      painterClickTimer.current = null;
     }
     onFormatPainter(true);
   }, [disabled, onFormatPainter]);

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -156,19 +156,40 @@ export function FormattingBar(props: FormattingBarProps) {
   }, [disabled, canRedo, onRedo]);
 
   // Format painter: a single click arms a one-shot paint, a double-click arms
-  // the sticky (keep-on) mode. The native `dblclick` event drives sticky mode,
-  // so there is no single-vs-double timing race: the intermediate click just
-  // re-toggles and `dblclick` settles the mode.
+  // the sticky (keep-on) mode. A real double-click also fires `click` first, so
+  // native `click`/`dblclick` race on one button (arm → toggle-off → sticky) and
+  // settle wrong; the one-shot arm is deferred instead, letting a second click
+  // within the window pre-empt it. 300ms matches the platform double-click feel.
+  const painterClickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (painterClickTimer.current) {
+        clearTimeout(painterClickTimer.current);
+      }
+    },
+    [],
+  );
+
   const handleFormatPainterClick = useCallback(() => {
     if (disabled || !onFormatPainter) {
       return;
     }
-    onFormatPainter(false);
+    if (painterClickTimer.current) {
+      clearTimeout(painterClickTimer.current);
+    }
+    painterClickTimer.current = setTimeout(() => {
+      painterClickTimer.current = null;
+      onFormatPainter(false);
+    }, 300);
   }, [disabled, onFormatPainter]);
 
   const handleFormatPainterDoubleClick = useCallback(() => {
     if (disabled || !onFormatPainter) {
       return;
+    }
+    if (painterClickTimer.current) {
+      clearTimeout(painterClickTimer.current);
+      painterClickTimer.current = null;
     }
     onFormatPainter(true);
   }, [disabled, onFormatPainter]);

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -18,6 +18,7 @@ import {
   ImageIcon,
   ItalicIcon,
   MoreHorizontalIcon,
+  PaintbrushIcon,
   PilcrowIcon,
   Redo2Icon,
   RulerIcon,
@@ -98,6 +99,9 @@ export function FormattingBar(props: FormattingBarProps) {
     editorRef,
     children,
     showStylePicker = true,
+    showFormatPainter = true,
+    formatPainterActive = false,
+    onFormatPainter,
     showFontPicker = true,
     showFontSizePicker = true,
     showTextColorPicker = true,
@@ -150,6 +154,43 @@ export function FormattingBar(props: FormattingBarProps) {
       onRedo();
     }
   }, [disabled, canRedo, onRedo]);
+
+  // Format painter: a single click arms a one-shot paint, a double-click arms
+  // the sticky (keep-on) mode. The one-shot arm is deferred so a double-click
+  // can pre-empt it — otherwise the first click of a double would fire first.
+  const painterClickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (painterClickTimer.current) {
+        clearTimeout(painterClickTimer.current);
+      }
+    },
+    [],
+  );
+
+  const handleFormatPainterClick = useCallback(() => {
+    if (disabled || !onFormatPainter) {
+      return;
+    }
+    if (painterClickTimer.current) {
+      clearTimeout(painterClickTimer.current);
+    }
+    painterClickTimer.current = setTimeout(() => {
+      painterClickTimer.current = null;
+      onFormatPainter(false);
+    }, 220);
+  }, [disabled, onFormatPainter]);
+
+  const handleFormatPainterDoubleClick = useCallback(() => {
+    if (disabled || !onFormatPainter) {
+      return;
+    }
+    if (painterClickTimer.current) {
+      clearTimeout(painterClickTimer.current);
+      painterClickTimer.current = null;
+    }
+    onFormatPainter(true);
+  }, [disabled, onFormatPainter]);
 
   const handleFontFamilyChange = useCallback(
     (fontFamily: string) => {
@@ -614,6 +655,19 @@ export function FormattingBar(props: FormattingBarProps) {
           >
             <UnderlineIcon size={ICON_SIZE} />
           </ToolbarButton>
+          {showFormatPainter && onFormatPainter && (
+            <ToolbarButton
+              onClick={handleFormatPainterClick}
+              onDoubleClick={handleFormatPainterDoubleClick}
+              active={formatPainterActive}
+              disabled={disabled}
+              title={t("formatPainterShortcut")}
+              ariaLabel={t("formatPainter")}
+              testId="toolbar-format-painter"
+            >
+              <PaintbrushIcon size={ICON_SIZE} />
+            </ToolbarButton>
+          )}
         </ToolbarGroup>
 
         {/* Insert group — each control is opt-in: it renders only when its

--- a/packages/react/src/components/toolbarPrimitives.tsx
+++ b/packages/react/src/components/toolbarPrimitives.tsx
@@ -127,6 +127,16 @@ export type ToolbarProps = {
   showLineSpacingPicker?: boolean | undefined;
   /** Whether to show style picker (default: true) */
   showStylePicker?: boolean | undefined;
+  /** Whether to show the format painter button (default: true) */
+  showFormatPainter?: boolean | undefined;
+  /** Whether the format painter is armed (drives the button's active state) */
+  formatPainterActive?: boolean | undefined;
+  /**
+   * Arm the format painter: capture the current selection's formatting so the
+   * next selection is painted. `sticky` (double-click) keeps it armed until Esc
+   * or a toggle off; a single click disarms after one paint.
+   */
+  onFormatPainter?: ((sticky: boolean) => void) | undefined;
   /** Document styles for the style picker */
   documentStyles?: Style[] | undefined;
   /** Theme for the style picker */
@@ -207,6 +217,8 @@ export type ToolbarButtonProps = {
   title?: string | undefined;
   /** Click handler */
   onClick?: (() => void) | undefined;
+  /** Double-click handler (e.g. format painter sticky mode) */
+  onDoubleClick?: (() => void) | undefined;
   /** Button content */
   children: ReactNode;
   /** Additional CSS class name */
@@ -245,6 +257,7 @@ export function ToolbarButton({
   disabled = false,
   title,
   onClick,
+  onDoubleClick,
   children,
   className,
   ariaLabel,
@@ -274,6 +287,7 @@ export function ToolbarButton({
       )}
       onMouseDown={handleMouseDown}
       onClick={disabled ? undefined : onClick}
+      onDoubleClick={disabled ? undefined : onDoubleClick}
       disabled={disabled}
       aria-pressed={active}
       aria-label={ariaLabel || title}

--- a/packages/react/src/i18n/messages/ar.json
+++ b/packages/react/src/i18n/messages/ar.json
@@ -74,6 +74,8 @@
     "fontColor": "لون الخط",
     "fontGroup": "الخط",
     "fontSize": "حجم الخط",
+    "formatPainter": "نسخ التنسيق",
+    "formatPainterShortcut": "نسخ التنسيق (Ctrl+Shift+C)",
     "formattingToolbar": "شريط أدوات التنسيق",
     "hideDetails": "إخفاء التفاصيل",
     "historyGroup": "السجل",

--- a/packages/react/src/i18n/messages/cs.json
+++ b/packages/react/src/i18n/messages/cs.json
@@ -74,6 +74,8 @@
     "fontColor": "Barva písma",
     "fontGroup": "Písmo",
     "fontSize": "Velikost písma",
+    "formatPainter": "Kopírovat formát",
+    "formatPainterShortcut": "Kopírovat formát (Ctrl+Shift+C)",
     "formattingToolbar": "Panel formátování",
     "hideDetails": "Skrýt podrobnosti",
     "historyGroup": "Historie",

--- a/packages/react/src/i18n/messages/de.json
+++ b/packages/react/src/i18n/messages/de.json
@@ -74,6 +74,8 @@
     "fontColor": "Schriftfarbe",
     "fontGroup": "Schriftart",
     "fontSize": "Schriftgröße",
+    "formatPainter": "Format übertragen",
+    "formatPainterShortcut": "Format übertragen (Strg+Umschalt+C)",
     "formattingToolbar": "Formatierungsleiste",
     "hideDetails": "Details ausblenden",
     "historyGroup": "Verlauf",

--- a/packages/react/src/i18n/messages/en.json
+++ b/packages/react/src/i18n/messages/en.json
@@ -74,6 +74,8 @@
     "fontColor": "Font color",
     "fontGroup": "Font",
     "fontSize": "Font size",
+    "formatPainter": "Format Painter",
+    "formatPainterShortcut": "Format Painter (Ctrl+Shift+C)",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/packages/react/src/i18n/messages/es.json
+++ b/packages/react/src/i18n/messages/es.json
@@ -74,6 +74,8 @@
     "fontColor": "Color de fuente",
     "fontGroup": "Fuente",
     "fontSize": "Tamaño de fuente",
+    "formatPainter": "Copiar formato",
+    "formatPainterShortcut": "Copiar formato (Ctrl+Shift+C)",
     "formattingToolbar": "Barra de formato",
     "hideDetails": "Ocultar detalles",
     "historyGroup": "Historial",

--- a/packages/react/src/i18n/messages/et.json
+++ b/packages/react/src/i18n/messages/et.json
@@ -74,6 +74,8 @@
     "fontColor": "Fondi värv",
     "fontGroup": "Fondid",
     "fontSize": "Fondi suurus",
+    "formatPainter": "Vormingupintsel",
+    "formatPainterShortcut": "Vormingupintsel (Ctrl+Shift+C)",
     "formattingToolbar": "Vormindusriba",
     "hideDetails": "Peida üksikasjad",
     "historyGroup": "Ajalugu",

--- a/packages/react/src/i18n/messages/fr.json
+++ b/packages/react/src/i18n/messages/fr.json
@@ -74,6 +74,8 @@
     "fontColor": "Couleur de police",
     "fontGroup": "Police",
     "fontSize": "Taille de police",
+    "formatPainter": "Reproduire la mise en forme",
+    "formatPainterShortcut": "Reproduire la mise en forme (Ctrl+Maj+C)",
     "formattingToolbar": "Barre d’outils de mise en forme",
     "hideDetails": "Masquer les détails",
     "historyGroup": "Historique",

--- a/packages/react/src/i18n/messages/hu.json
+++ b/packages/react/src/i18n/messages/hu.json
@@ -74,6 +74,8 @@
     "fontColor": "Betűszín",
     "fontGroup": "Betűtípus",
     "fontSize": "Betűméret",
+    "formatPainter": "Formátummásoló",
+    "formatPainterShortcut": "Formátummásoló (Ctrl+Shift+C)",
     "formattingToolbar": "Formázási eszköztár",
     "hideDetails": "Részletek elrejtése",
     "historyGroup": "Előzmények",

--- a/packages/react/src/i18n/messages/lt.json
+++ b/packages/react/src/i18n/messages/lt.json
@@ -74,6 +74,8 @@
     "fontColor": "Šrifto spalva",
     "fontGroup": "Šriftas",
     "fontSize": "Šrifto dydis",
+    "formatPainter": "Formato kopijavimas",
+    "formatPainterShortcut": "Formato kopijavimas (Ctrl+Shift+C)",
     "formattingToolbar": "Formatavimo įrankių juosta",
     "hideDetails": "Slėpti detales",
     "historyGroup": "Istorija",

--- a/packages/react/src/i18n/messages/lv.json
+++ b/packages/react/src/i18n/messages/lv.json
@@ -74,6 +74,8 @@
     "fontColor": "Fonta krāsa",
     "fontGroup": "Fonts",
     "fontSize": "Fonta lielums",
+    "formatPainter": "Formāta otiņa",
+    "formatPainterShortcut": "Formāta otiņa (Ctrl+Shift+C)",
     "formattingToolbar": "Formatēšanas rīkjosla",
     "hideDetails": "Slēpt detaļas",
     "historyGroup": "Vēsture",

--- a/packages/react/src/i18n/messages/pl.json
+++ b/packages/react/src/i18n/messages/pl.json
@@ -74,6 +74,8 @@
     "fontColor": "Kolor czcionki",
     "fontGroup": "Czcionka",
     "fontSize": "Rozmiar czcionki",
+    "formatPainter": "Malarz formatów",
+    "formatPainterShortcut": "Malarz formatów (Ctrl+Shift+C)",
     "formattingToolbar": "Pasek formatowania",
     "hideDetails": "Ukryj szczegóły",
     "historyGroup": "Historia",

--- a/packages/react/src/i18n/messages/pt-BR.json
+++ b/packages/react/src/i18n/messages/pt-BR.json
@@ -74,6 +74,8 @@
     "fontColor": "Cor da fonte",
     "fontGroup": "Fonte",
     "fontSize": "Tamanho da fonte",
+    "formatPainter": "Pincel de Formatação",
+    "formatPainterShortcut": "Pincel de Formatação (Ctrl+Shift+C)",
     "formattingToolbar": "Barra de ferramentas de formatação",
     "hideDetails": "Ocultar detalhes",
     "historyGroup": "Histórico",

--- a/packages/react/src/i18n/messages/sk.json
+++ b/packages/react/src/i18n/messages/sk.json
@@ -74,6 +74,8 @@
     "fontColor": "Farba písma",
     "fontGroup": "Písmo",
     "fontSize": "Veľkosť písma",
+    "formatPainter": "Kopírovať formát",
+    "formatPainterShortcut": "Kopírovať formát (Ctrl+Shift+C)",
     "formattingToolbar": "Panel formátovania",
     "hideDetails": "Skryť detaily",
     "historyGroup": "História",

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -1445,3 +1445,13 @@
   align-items: center;
   justify-content: center;
 }
+
+/* ============================================================================
+ * FORMAT PAINTER — armed cursor affordance
+ * ============================================================================ */
+
+/* While the format painter is armed, the editor shows a copy cursor so the next
+ * drag reads as "paint formatting here". */
+.folio-editor[data-folio-format-painter="armed"] [contenteditable="true"] {
+  cursor: copy;
+}


### PR DESCRIPTION
Adds a **Format Painter** to the primary toolbar: copy a selection's character formatting and paint it onto another selection (Word-style).

- **Core (pure, tested):** `captureFormatMarks(state)` reads the paintable marks (with attrs) at the selection's leading run (excludes structural marks — comments, hyperlinks, tracked changes, footnote refs, and rtl/hidden); `applyFormatMarks(marks)` clears every paintable mark type over the target range then adds the captured set — **replace, not merge** (Word parity). No-op on empty capture / collapsed selection; never throws.
- **Toolbar (visual):** paintbrush button after B/I/U. Single click = capture + arm one-shot (next drag paints, then disarms); double-click = sticky; click-while-armed or **Esc** = off. Armed state drives the button `active` styling + a copy cursor.
- **Shortcuts:** Ctrl/Cmd+Shift+C copies formatting. Paint is Ctrl/Cmd+Shift+V, **guarded to only claim the chord after a copy** so it doesn't swallow ordinary paste.
- **i18n:** `formatPainter` + shortcut label in all 12 locales; `check:i18n` green.

Paragraph-level formatting (alignment/style/lists) is intentionally out of scope (not a mark). 7 core tests; the button/armed interaction is visual (folio has no DOM tests).

Note: the paint chord overlaps `feat/paste-special`'s Ctrl/Cmd+Shift+V (paste-without-formatting) — see PR discussion for the chosen reconciliation.
