### PR TITLE
feat(react): custom font props (fonts / fontFamilies)

### DIFF
--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -27,8 +27,10 @@ import type {
 } from "@stll/folio-core/prosemirror/plugins/templateSlashMenu";
 import type { Document, SdtProperties, Theme, TabStop } from "@stll/folio-core/types/document";
 import type { DocxInput } from "@stll/folio-core/utils/docxInput";
+import type { FontDefinition } from "../paged-editor/hostFonts";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
 import type { FolioUIComponents } from "../ui/folio-ui";
+import type { FontOption } from "./ui/FontPicker";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
 // `EditorMode` is owned by `./hooks/useEditorMode`. Re-imported here for use
 // in `DocxEditorProps`; the canonical export is from the hook module.
@@ -92,6 +94,23 @@ export type DocxEditorProps = {
   onError?: (error: Error) => void;
   /** Callback when fonts are loaded */
   onFontsLoaded?: () => void;
+  /**
+   * Custom families shown in the toolbar's font-family dropdown. Strings render
+   * as plain family names; pass `FontOption` objects for a CSS fallback chain
+   * and category grouping. Omit to use folio's built-in defaults; an empty
+   * array renders an empty (but enabled) dropdown. Pass a stable reference — an
+   * inline array is a fresh identity every render.
+   */
+  fontFamilies?: ReadonlyArray<string | FontOption>;
+  /**
+   * Custom font faces the host registers with the browser (its own brand/web
+   * fonts) so runs render in them. Each entry injects one face via the
+   * `FontFace` API; multiple entries can share `family` for different weights.
+   * Registration is best-effort: a malformed entry is skipped, never thrown.
+   * Match `family` to the `fontFamilies` name a user applies. Pass a stable
+   * reference — a new array identity re-registers on every render.
+   */
+  fonts?: ReadonlyArray<FontDefinition>;
   /** Theme for styling */
   theme?: Theme | null;
   /** Whether to show toolbar (default: true) */

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -176,6 +176,8 @@ import {
   COMMENTS_SIDEBAR_SCROLL_GUTTER,
 } from "../paged-editor/PagedEditor";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
+import { removeFontFaces } from "../paged-editor/embeddedFonts";
+import { loadHostFontFaces } from "../paged-editor/hostFonts";
 import { HorizontalRuler } from "./ui/HorizontalRuler";
 import { VerticalRuler } from "./ui/VerticalRuler";
 import { FolioUIProvider, DEFAULT_COMPONENTS } from "../ui/folio-ui";
@@ -425,6 +427,8 @@ export function DocxEditor({
   onSelectionTextChange,
   onError,
   onFontsLoaded: onFontsLoadedCallback,
+  fontFamilies,
+  fonts,
   theme,
   showToolbar = true,
   showZoomControl = true,
@@ -1188,6 +1192,29 @@ export function DocxEditor({
     });
     return cleanup;
   }, [onFontsLoadedCallback]);
+
+  // Register the host app's custom font faces (the `fonts` prop) via the same
+  // best-effort FontFace path as embedded document fonts. Keyed on the prop
+  // identity (pass a stable reference); unregisters on change/unmount so a
+  // removed font cannot linger in the document font set.
+  useEffect(() => {
+    if (!fonts || fonts.length === 0) {
+      return undefined;
+    }
+    let cancelled = false;
+    let registered: FontFace[] = [];
+    void loadHostFontFaces(fonts).then((faces) => {
+      if (cancelled) {
+        removeFontFaces(faces);
+        return;
+      }
+      registered = faces;
+    });
+    return () => {
+      cancelled = true;
+      removeFontFaces(registered);
+    };
+  }, [fonts]);
 
   // Sync editing mode to ProseMirror suggestion mode plugin
   useEffect(() => {
@@ -3373,6 +3400,7 @@ export function DocxEditor({
                       canRedo={hfEditPosition ? history.canRedo : bodyHistoryAvailability.canRedo}
                       disabled={readOnly}
                       theme={history.state.package.theme || theme || null}
+                      fontFamilies={fontFamilies}
                       showZoomControl={showZoomControl}
                       zoom={zoom}
                       onZoomChange={setZoomWithViewportAnchor}

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -176,8 +176,6 @@ import {
   COMMENTS_SIDEBAR_SCROLL_GUTTER,
 } from "../paged-editor/PagedEditor";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
-import { removeFontFaces } from "../paged-editor/embeddedFonts";
-import { loadHostFontFaces } from "../paged-editor/hostFonts";
 import { HorizontalRuler } from "./ui/HorizontalRuler";
 import { VerticalRuler } from "./ui/VerticalRuler";
 import { FolioUIProvider, DEFAULT_COMPONENTS } from "../ui/folio-ui";
@@ -1192,29 +1190,6 @@ export function DocxEditor({
     });
     return cleanup;
   }, [onFontsLoadedCallback]);
-
-  // Register the host app's custom font faces (the `fonts` prop) via the same
-  // best-effort FontFace path as embedded document fonts. Keyed on the prop
-  // identity (pass a stable reference); unregisters on change/unmount so a
-  // removed font cannot linger in the document font set.
-  useEffect(() => {
-    if (!fonts || fonts.length === 0) {
-      return undefined;
-    }
-    let cancelled = false;
-    let registered: FontFace[] = [];
-    void loadHostFontFaces(fonts).then((faces) => {
-      if (cancelled) {
-        removeFontFaces(faces);
-        return;
-      }
-      registered = faces;
-    });
-    return () => {
-      cancelled = true;
-      removeFontFaces(registered);
-    };
-  }, [fonts]);
 
   // Sync editing mode to ProseMirror suggestion mode plugin
   useEffect(() => {
@@ -3542,6 +3517,7 @@ export function DocxEditor({
                         ref={pagedEditorRef}
                         document={history.state}
                         {...(documentKey !== undefined ? { documentKey } : {})}
+                        {...(fonts !== undefined ? { fonts } : {})}
                         theme={history.state.package.theme || theme || null}
                         sectionProperties={effectiveSectionProperties ?? null}
                         headerContent={headerContent}

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -8,7 +8,7 @@
  * editing mode) is accessible via keyboard shortcuts or host app chrome.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import {
@@ -39,6 +39,7 @@ import { ToolbarButton, ToolbarGroup, ToolbarSeparator } from "./toolbarPrimitiv
 import type { ToolbarProps, FormattingAction } from "./toolbarPrimitives";
 import { AlignmentButtons } from "./ui/AlignmentButtons";
 import { FontPicker } from "./ui/FontPicker";
+import { normalizeFontFamilies } from "./ui/normalizeFontFamilies";
 import { FontSizePicker } from "./ui/FontSizePicker";
 import { ListButtons, createDefaultListState } from "./ui/ListButtons";
 import { StylePicker } from "./ui/StylePicker";
@@ -103,6 +104,7 @@ export function FormattingBar(props: FormattingBarProps) {
     formatPainterActive = false,
     onFormatPainter,
     showFontPicker = true,
+    fontFamilies,
     showFontSizePicker = true,
     showTextColorPicker = true,
     showAlignmentButtons = true,
@@ -193,6 +195,11 @@ export function FormattingBar(props: FormattingBarProps) {
     }
     onFormatPainter(true);
   }, [disabled, onFormatPainter]);
+
+  // Normalize the host's `fontFamilies` prop into the picker's FontOption[].
+  // folio runs no React Compiler, so this memo is load-bearing: it keeps a
+  // stable list reference across renders (undefined falls back to defaults).
+  const fontPickerOptions = useMemo(() => normalizeFontFamilies(fontFamilies), [fontFamilies]);
 
   const handleFontFamilyChange = useCallback(
     (fontFamily: string) => {
@@ -473,6 +480,7 @@ export function FormattingBar(props: FormattingBarProps) {
           <FontPicker
             value={currentFormatting.fontFamily || "Arial"}
             onChange={handleFontFamilyChange}
+            fonts={fontPickerOptions}
             disabled={disabled}
             width={108}
             placeholder="Arial"

--- a/packages/react/src/components/toolbarPrimitives.tsx
+++ b/packages/react/src/components/toolbarPrimitives.tsx
@@ -10,6 +10,7 @@ import type { CSSProperties, ReactNode } from "react";
 
 import type { ColorValue, ParagraphAlignment, Style, Theme } from "@stll/folio-core/types/document";
 import { cn } from "../lib/utils";
+import type { FontOption } from "./ui/FontPicker";
 import type { ListState } from "./ui/ListButtons";
 import type { TableAction } from "@stll/folio-core/utils/tableOperations";
 import { Tooltip } from "./ui/Tooltip";
@@ -113,6 +114,12 @@ export type ToolbarProps = {
   children?: ReactNode | undefined;
   /** Whether to show font family picker (default: true) */
   showFontPicker?: boolean | undefined;
+  /**
+   * Custom families for the font-family dropdown (strings and/or `FontOption`
+   * objects). Omit to use the built-in defaults; an empty array renders an
+   * empty dropdown. Normalized to `FontOption[]` before reaching the picker.
+   */
+  fontFamilies?: ReadonlyArray<string | FontOption> | undefined;
   /** Whether to show font size picker (default: true) */
   showFontSizePicker?: boolean | undefined;
   /** Whether to show text color picker (default: true) */

--- a/packages/react/src/components/ui/FontPicker.tsx
+++ b/packages/react/src/components/ui/FontPicker.tsx
@@ -18,7 +18,7 @@ export type FontOption = {
 export type FontPickerProps = {
   value?: string;
   onChange?: (fontFamily: string) => void;
-  fonts?: FontOption[];
+  fonts?: FontOption[] | undefined;
   disabled?: boolean;
   className?: string;
   placeholder?: string;

--- a/packages/react/src/components/ui/normalizeFontFamilies.test.ts
+++ b/packages/react/src/components/ui/normalizeFontFamilies.test.ts
@@ -35,4 +35,24 @@ describe("normalizeFontFamilies", () => {
       option,
     ]);
   });
+
+  test("skips null / undefined / blank / malformed entries", () => {
+    const option: FontOption = { name: "Keep", fontFamily: "Keep, serif", category: "serif" };
+    // Simulate an untrusted plain-JS host slipping in invalid entries.
+    const messy = [
+      null,
+      undefined,
+      "",
+      "   ",
+      42,
+      { fontFamily: "No Name, serif" },
+      { name: "No Family" },
+      "Arial",
+      option,
+    ] as unknown as ReadonlyArray<string | FontOption>;
+    expect(normalizeFontFamilies(messy)).toEqual([
+      { name: "Arial", fontFamily: "Arial", category: "other" },
+      option,
+    ]);
+  });
 });

--- a/packages/react/src/components/ui/normalizeFontFamilies.test.ts
+++ b/packages/react/src/components/ui/normalizeFontFamilies.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FontOption } from "./FontPicker";
+import { normalizeFontFamilies } from "./normalizeFontFamilies";
+
+describe("normalizeFontFamilies", () => {
+  test("returns undefined for undefined so the picker keeps its defaults", () => {
+    expect(normalizeFontFamilies(undefined)).toBeUndefined();
+  });
+
+  test("returns an empty list for an empty array (empty, enabled dropdown)", () => {
+    expect(normalizeFontFamilies([])).toEqual([]);
+  });
+
+  test("expands a plain string into an 'other'-category FontOption", () => {
+    expect(normalizeFontFamilies(["Roboto"])).toEqual([
+      { name: "Roboto", fontFamily: "Roboto", category: "other" },
+    ]);
+  });
+
+  test("passes a FontOption object through unchanged", () => {
+    const option: FontOption = {
+      name: "Roboto",
+      fontFamily: "Roboto, sans-serif",
+      category: "sans-serif",
+    };
+    const [normalized] = normalizeFontFamilies([option]) ?? [];
+    expect(normalized).toBe(option);
+  });
+
+  test("normalizes a mixed string / FontOption array in order", () => {
+    const option: FontOption = { name: "Georgia", fontFamily: "Georgia, serif", category: "serif" };
+    expect(normalizeFontFamilies(["Arial", option])).toEqual([
+      { name: "Arial", fontFamily: "Arial", category: "other" },
+      option,
+    ]);
+  });
+});

--- a/packages/react/src/components/ui/normalizeFontFamilies.ts
+++ b/packages/react/src/components/ui/normalizeFontFamilies.ts
@@ -5,12 +5,32 @@
 
 import type { FontOption } from "./FontPicker";
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Structural guard for one `fontFamilies` entry. The prop is typed, but a
+ * plain-JS host can slip in null / a bare value / an object missing its name
+ * or family, so validate at the boundary rather than trusting the type.
+ */
+function isFontOption(value: unknown): value is FontOption {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  return (
+    isNonEmptyString(Reflect.get(value, "name")) &&
+    isNonEmptyString(Reflect.get(value, "fontFamily"))
+  );
+}
+
 /**
  * Normalize the `fontFamilies` prop (a mix of plain family-name strings and
  * {@link FontOption} objects) into a uniform `FontOption[]`. Returns
  * `undefined` for `undefined` input so the picker falls back to its built-in
  * defaults; an empty array stays empty (an empty, enabled dropdown). Strings
  * expand into the `"other"` category with the name used as the CSS family.
+ * Null / undefined / malformed entries are skipped, never crashing the picker.
  */
 export function normalizeFontFamilies(
   fontFamilies: ReadonlyArray<string | FontOption> | undefined,
@@ -18,8 +38,15 @@ export function normalizeFontFamilies(
   if (fontFamilies === undefined) {
     return undefined;
   }
-  return fontFamilies.map(
-    (font): FontOption =>
-      typeof font === "string" ? { name: font, fontFamily: font, category: "other" } : font,
-  );
+  const normalized: FontOption[] = [];
+  for (const font of fontFamilies) {
+    if (isNonEmptyString(font)) {
+      normalized.push({ name: font, fontFamily: font, category: "other" });
+      continue;
+    }
+    if (isFontOption(font)) {
+      normalized.push(font);
+    }
+  }
+  return normalized;
 }

--- a/packages/react/src/components/ui/normalizeFontFamilies.ts
+++ b/packages/react/src/components/ui/normalizeFontFamilies.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalizer for the `fontFamilies` prop (the font-family picker list). Pure,
+ * so it is unit-testable; shared by DocxEditor's toolbar wiring.
+ */
+
+import type { FontOption } from "./FontPicker";
+
+/**
+ * Normalize the `fontFamilies` prop (a mix of plain family-name strings and
+ * {@link FontOption} objects) into a uniform `FontOption[]`. Returns
+ * `undefined` for `undefined` input so the picker falls back to its built-in
+ * defaults; an empty array stays empty (an empty, enabled dropdown). Strings
+ * expand into the `"other"` category with the name used as the CSS family.
+ */
+export function normalizeFontFamilies(
+  fontFamilies: ReadonlyArray<string | FontOption> | undefined,
+): FontOption[] | undefined {
+  if (fontFamilies === undefined) {
+    return undefined;
+  }
+  return fontFamilies.map(
+    (font): FontOption =>
+      typeof font === "string" ? { name: font, fontFamily: font, category: "other" } : font,
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,9 @@ export type {
   DocxEditorRef,
 } from "./components/DocxEditor.props";
 export type { EditorMode } from "./components/hooks/useEditorMode";
+// Custom-font prop types: `fontFamilies` (picker list) + `fonts` (FontFace registration).
+export type { FontOption } from "./components/ui/FontPicker";
+export type { FontDefinition } from "./paged-editor/hostFonts";
 export type { ColorPreset, FolioButtonProps, FolioUIComponents, OutlineItem } from "./ui/folio-ui";
 // Consumers rendering folio chrome (e.g. FormattingBar) outside DocxEditor wrap
 // it in this provider to inject their own UI components.

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -180,7 +180,7 @@ import { AnonymizationRectsOverlay } from "./AnonymizationRectsOverlay";
 import type { AnonymizationRectGroup } from "./AnonymizationRectsOverlay";
 import { AutocompleteCaretOverlay } from "./AutocompleteCaretOverlay";
 import type { AutocompleteCaretRect } from "./AutocompleteCaretOverlay";
-import { loadEmbeddedFontFaces, removeEmbeddedFontFaces } from "./embeddedFonts";
+import { loadEmbeddedFontFaces, removeFontFaces } from "./embeddedFonts";
 import { createHiddenEditorState, HiddenProseMirror } from "./HiddenProseMirror";
 import type {
   HiddenProseMirrorCollaboration,
@@ -5529,7 +5529,7 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
     let registered: FontFace[] = [];
     void loadEmbeddedFontFaces(embeddedFontBuffer).then((faces) => {
       if (cancelled) {
-        removeEmbeddedFontFaces(faces);
+        removeFontFaces(faces);
         return;
       }
       registered = faces;
@@ -5547,7 +5547,7 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
     });
     return () => {
       cancelled = true;
-      removeEmbeddedFontFaces(registered);
+      removeFontFaces(registered);
     };
   }, [embeddedFontBuffer]);
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -5572,6 +5572,22 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
     }
     let cancelled = false;
     let registered: FontFace[] = [];
+
+    // Drop cached font metrics and re-run layout so measurements reflect the
+    // current faces — or, on the cleanup path, their absence. Shared by the
+    // register and unregister paths so both re-measure identically. No-op when
+    // the view is gone (e.g. during unmount), so it is safe to call in cleanup.
+    const remeasureForFontChange = () => {
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+      resetCanvasContext();
+      clearAllCaches();
+      runLayoutPipelineRef.current(view.state, { reason: "font-ready" });
+      updateSelectionOverlayRef.current(view.state);
+    };
+
     void loadHostFontFaces(hostFonts).then((faces) => {
       if (cancelled) {
         removeFontFaces(faces);
@@ -5581,18 +5597,19 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       if (faces.length === 0) {
         return;
       }
-      const view = hiddenPMRef.current?.getView();
-      if (!view) {
-        return;
-      }
-      resetCanvasContext();
-      clearAllCaches();
-      runLayoutPipelineRef.current(view.state, { reason: "font-ready" });
-      updateSelectionOverlayRef.current(view.state);
+      remeasureForFontChange();
     });
+
     return () => {
       cancelled = true;
+      if (registered.length === 0) {
+        return;
+      }
+      // Fonts were cleared or changed: unregister the faces, then re-measure so
+      // the document drops the now-removed custom metrics immediately instead
+      // of keeping them until the next edit.
       removeFontFaces(registered);
+      remeasureForFontChange();
     };
   }, [hostFonts]);
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -181,6 +181,7 @@ import type { AnonymizationRectGroup } from "./AnonymizationRectsOverlay";
 import { AutocompleteCaretOverlay } from "./AutocompleteCaretOverlay";
 import type { AutocompleteCaretRect } from "./AutocompleteCaretOverlay";
 import { loadEmbeddedFontFaces, removeFontFaces } from "./embeddedFonts";
+import { loadHostFontFaces, type FontDefinition } from "./hostFonts";
 import { createHiddenEditorState, HiddenProseMirror } from "./HiddenProseMirror";
 import type {
   HiddenProseMirrorCollaboration,
@@ -209,6 +210,13 @@ export type PagedEditorProps = {
    * edited document passed back. Falls back to a metadata signature when omitted.
    */
   documentKey?: string;
+  /**
+   * Host-provided custom font faces to register with the browser (the
+   * DocxEditor `fonts` prop). Registered on the same best-effort FontFace path
+   * as embedded document fonts, with the same font-ready re-layout so first
+   * paint measures against the real metrics.
+   */
+  fonts?: ReadonlyArray<FontDefinition>;
   /** Document styles for style resolution. */
   styles?: StyleDefinitions | null;
   /** Theme for styling. */
@@ -1613,6 +1621,7 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
     ref,
     document,
     documentKey,
+    fonts: hostFonts,
     styles,
     theme: _theme,
     sectionProperties,
@@ -5550,6 +5559,42 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       removeFontFaces(registered);
     };
   }, [embeddedFontBuffer]);
+
+  // Register the host app's custom font faces (the `fonts` prop) on the same
+  // best-effort FontFace path, then re-layout via the identical font-ready tail
+  // as the embedded path above. Without the explicit re-layout, faces supplied
+  // on initial mount register after the first layout has run, so the document
+  // would keep its fallback-font metrics until the next edit. Keyed on the prop
+  // identity; the cleanup unregisters the faces on change / unmount.
+  useEffect(() => {
+    if (!hostFonts || hostFonts.length === 0) {
+      return undefined;
+    }
+    let cancelled = false;
+    let registered: FontFace[] = [];
+    void loadHostFontFaces(hostFonts).then((faces) => {
+      if (cancelled) {
+        removeFontFaces(faces);
+        return;
+      }
+      registered = faces;
+      if (faces.length === 0) {
+        return;
+      }
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+      resetCanvasContext();
+      clearAllCaches();
+      runLayoutPipelineRef.current(view.state, { reason: "font-ready" });
+      updateSelectionOverlayRef.current(view.state);
+    });
+    return () => {
+      cancelled = true;
+      removeFontFaces(registered);
+    };
+  }, [hostFonts]);
 
   // Re-layout when non-document layout inputs change (e.g., after HF editor save
   // or parent-driven page setup/theme updates).

--- a/packages/react/src/paged-editor/embeddedFonts.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.ts
@@ -10,11 +10,44 @@
 
 import { extractEmbeddedFonts, type EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
 
-function getDocumentFontSet(): FontFaceSet | null {
+export function getDocumentFontSet(): FontFaceSet | null {
   if (typeof document === "undefined" || !("fonts" in document)) {
     return null;
   }
   return document.fonts;
+}
+
+/**
+ * Register one font face on the document font set, best-effort. Returns the
+ * loaded `FontFace`, or `null` when construction throws (invalid family or
+ * descriptor) or the binary/URL fails to load (malformed / subsetted). Shared
+ * by the embedded-document-font and host-provided-font (`fonts` prop) paths so
+ * both skip a bad face identically instead of throwing.
+ */
+export async function registerFontFace(
+  fontSet: FontFaceSet,
+  family: string,
+  source: string | BufferSource,
+  descriptors: FontFaceDescriptors,
+): Promise<FontFace | null> {
+  let face: FontFace;
+  try {
+    // `new FontFace` throws synchronously (SyntaxError) on an invalid family
+    // or descriptor; `fontSet.add` can reject a face too. Skip on failure.
+    face = new FontFace(family, source, descriptors);
+    fontSet.add(face);
+  } catch {
+    return null;
+  }
+  const ready = await face.load().then(
+    () => true,
+    () => false,
+  );
+  if (ready) {
+    return face;
+  }
+  fontSet.delete(face);
+  return null;
 }
 
 /**
@@ -45,34 +78,20 @@ export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFa
   const loaded: FontFace[] = [];
   await Promise.all(
     fonts.map(async (font) => {
-      let face: FontFace;
-      try {
-        // `new FontFace` throws synchronously (SyntaxError) on an invalid family
-        // or descriptor; `fontSet.add` can reject a face too. Skip on failure.
-        face = new FontFace(font.family, font.bytes, {
-          weight: String(font.weight),
-          style: font.style,
-        });
-        fontSet.add(face);
-      } catch {
-        return;
-      }
-      const ready = await face.load().then(
-        () => true,
-        () => false,
-      );
-      if (ready) {
+      const face = await registerFontFace(fontSet, font.family, font.bytes, {
+        weight: String(font.weight),
+        style: font.style,
+      });
+      if (face) {
         loaded.push(face);
-        return;
       }
-      fontSet.delete(face);
     }),
   );
   return loaded;
 }
 
-/** Remove previously registered embedded faces from the document font set. */
-export function removeEmbeddedFontFaces(faces: readonly FontFace[]): void {
+/** Remove previously registered faces from the document font set. */
+export function removeFontFaces(faces: readonly FontFace[]): void {
   const fontSet = getDocumentFontSet();
   if (!fontSet) {
     return;

--- a/packages/react/src/paged-editor/hostFonts.test.ts
+++ b/packages/react/src/paged-editor/hostFonts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { toFontFaceInputs } from "./hostFonts";
+import { toFontFaceInputs, type FontDefinition } from "./hostFonts";
 
 describe("toFontFaceInputs", () => {
   test("returns [] for undefined and empty input", () => {
@@ -52,5 +52,32 @@ describe("toFontFaceInputs", () => {
   test("escapes quotes in src via JSON.stringify", () => {
     const [input] = toFontFaceInputs([{ family: "Brand Sans", src: '/a".woff2' }]);
     expect(input?.source).toBe('url("/a\\".woff2")');
+  });
+
+  test("skips malformed host entries (null, non-object, wrong field types)", () => {
+    // Simulate an untrusted plain-JS host passing values the type forbids.
+    const malformed = [
+      null,
+      undefined,
+      42,
+      "Arial",
+      { src: "/no-family.woff2" },
+      { family: "No Src" },
+      { family: 123, src: "/bad-family.woff2" },
+      { family: "Bad Src", src: 456 },
+      { family: "Keep", src: "/keep.woff2" },
+    ] as unknown as ReadonlyArray<FontDefinition>;
+    const inputs = toFontFaceInputs(malformed);
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]?.family).toBe("Keep");
+  });
+
+  test("drops a non-number/string weight instead of throwing", () => {
+    const withSymbolWeight = [
+      { family: "Sym", src: "/s.woff2", weight: Symbol("x") },
+    ] as unknown as ReadonlyArray<FontDefinition>;
+    const [input] = toFontFaceInputs(withSymbolWeight);
+    expect(input?.family).toBe("Sym");
+    expect(input?.descriptors).not.toHaveProperty("weight");
   });
 });

--- a/packages/react/src/paged-editor/hostFonts.test.ts
+++ b/packages/react/src/paged-editor/hostFonts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { toFontFaceInputs } from "./hostFonts";
+
+describe("toFontFaceInputs", () => {
+  test("returns [] for undefined and empty input", () => {
+    expect(toFontFaceInputs(undefined)).toEqual([]);
+    expect(toFontFaceInputs([])).toEqual([]);
+  });
+
+  test("wraps src in a CSS url() source and defaults display to swap", () => {
+    const [input] = toFontFaceInputs([{ family: "Brand Sans", src: "/fonts/BrandSans.woff2" }]);
+    expect(input).toEqual({
+      family: "Brand Sans",
+      source: 'url("/fonts/BrandSans.woff2")',
+      descriptors: { display: "swap" },
+    });
+  });
+
+  test("stringifies a numeric weight and keeps a keyword weight", () => {
+    const inputs = toFontFaceInputs([
+      { family: "Brand Sans", src: "/a.woff2", weight: 700 },
+      { family: "Brand Sans", src: "/b.woff2", weight: "bold" },
+    ]);
+    expect(inputs[0]?.descriptors.weight).toBe("700");
+    expect(inputs[1]?.descriptors.weight).toBe("bold");
+  });
+
+  test("omits the weight descriptor when weight is absent", () => {
+    const [input] = toFontFaceInputs([{ family: "Brand Sans", src: "/a.woff2" }]);
+    expect(input?.descriptors).not.toHaveProperty("weight");
+  });
+
+  test("trims surrounding whitespace on family and src", () => {
+    const [input] = toFontFaceInputs([{ family: "  Brand Sans  ", src: "  /a.woff2  " }]);
+    expect(input?.family).toBe("Brand Sans");
+    expect(input?.source).toBe('url("/a.woff2")');
+  });
+
+  test("skips entries with a blank family or src, never throwing", () => {
+    const inputs = toFontFaceInputs([
+      { family: "", src: "/a.woff2" },
+      { family: "  ", src: "/b.woff2" },
+      { family: "Brand Sans", src: "" },
+      { family: "Brand Sans", src: "   " },
+      { family: "Keep", src: "/keep.woff2" },
+    ]);
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]?.family).toBe("Keep");
+  });
+
+  test("escapes quotes in src via JSON.stringify", () => {
+    const [input] = toFontFaceInputs([{ family: "Brand Sans", src: '/a".woff2' }]);
+    expect(input?.source).toBe('url("/a\\".woff2")');
+  });
+});

--- a/packages/react/src/paged-editor/hostFonts.ts
+++ b/packages/react/src/paged-editor/hostFonts.ts
@@ -1,0 +1,90 @@
+/**
+ * Host-app custom fonts — the `fonts` prop on `DocxEditor`.
+ *
+ * The host passes its own brand/web font faces; they register with the browser
+ * through the same best-effort `FontFace` path as embedded document fonts
+ * ({@link registerFontFace}), so a bad entry is skipped rather than throwing.
+ * Once registered, the family name is available for rendering and can be listed
+ * in the font-family picker via the `fontFamilies` prop.
+ *
+ * The prop normalizer ({@link toFontFaceInputs}) is pure (no DOM), so it is
+ * unit-tested directly; the DOM registration is visual-only.
+ */
+
+import { getDocumentFontSet, registerFontFace } from "./embeddedFonts";
+
+/**
+ * Declarative description of one custom font face the host registers with the
+ * editor. Multiple entries can share `family` to register distinct weights.
+ */
+export type FontDefinition = {
+  /** CSS `font-family` name to expose; match the family your documents reference. */
+  family: string;
+  /** URL to the font file (woff2, woff, ttf, or otf). */
+  src: string;
+  /** CSS `font-weight` for this face (a number like `700`, or a keyword). Defaults to `normal`. */
+  weight?: number | string;
+};
+
+/** `FontFace` constructor inputs derived from a {@link FontDefinition}. */
+export type FontFaceInput = {
+  family: string;
+  source: string;
+  descriptors: FontFaceDescriptors;
+};
+
+/**
+ * Normalize the `fonts` prop into `FontFace` constructor inputs. Pure: no DOM
+ * work, so it is unit-testable. Entries missing a family or src are skipped
+ * (best-effort); `src` becomes a CSS `url(...)` source string.
+ */
+export function toFontFaceInputs(
+  fonts: ReadonlyArray<FontDefinition> | undefined,
+): FontFaceInput[] {
+  if (!fonts) {
+    return [];
+  }
+  const inputs: FontFaceInput[] = [];
+  for (const font of fonts) {
+    const family = font.family.trim();
+    const src = font.src.trim();
+    if (!family || !src) {
+      continue;
+    }
+    const descriptors: FontFaceDescriptors = { display: "swap" };
+    if (font.weight !== undefined) {
+      descriptors.weight = String(font.weight);
+    }
+    inputs.push({ family, source: `url(${JSON.stringify(src)})`, descriptors });
+  }
+  return inputs;
+}
+
+/**
+ * Register the host's custom font faces with the browser via the `FontFace`
+ * API. No-op (returns `[]`) outside a DOM or when no valid fonts are given.
+ * Returns the faces that loaded successfully; each bad entry is skipped, never
+ * thrown. Pair with {@link removeFontFaces} to unregister on change/unmount.
+ */
+export async function loadHostFontFaces(
+  fonts: ReadonlyArray<FontDefinition> | undefined,
+): Promise<FontFace[]> {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return [];
+  }
+  const inputs = toFontFaceInputs(fonts);
+  if (inputs.length === 0) {
+    return [];
+  }
+  const loaded: FontFace[] = [];
+  await Promise.all(
+    inputs.map(async ({ family, source, descriptors }) => {
+      const face = await registerFontFace(fontSet, family, source, descriptors);
+      if (face) {
+        loaded.push(face);
+      }
+    }),
+  );
+  return loaded;
+}

--- a/packages/react/src/paged-editor/hostFonts.ts
+++ b/packages/react/src/paged-editor/hostFonts.ts
@@ -33,10 +33,29 @@ export type FontFaceInput = {
   descriptors: FontFaceDescriptors;
 };
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Structural guard for one `fonts` entry. The prop is typed, but a plain-JS
+ * host can pass anything (null, a bare value, wrong field types), so validate
+ * at the boundary instead of trusting the declared type.
+ */
+function isValidFontDefinition(font: unknown): font is FontDefinition {
+  if (typeof font !== "object" || font === null) {
+    return false;
+  }
+  return (
+    isNonEmptyString(Reflect.get(font, "family")) && isNonEmptyString(Reflect.get(font, "src"))
+  );
+}
+
 /**
  * Normalize the `fonts` prop into `FontFace` constructor inputs. Pure: no DOM
- * work, so it is unit-testable. Entries missing a family or src are skipped
- * (best-effort); `src` becomes a CSS `url(...)` source string.
+ * work, so it is unit-testable. Entries that are not objects with non-empty
+ * string family/src are skipped (best-effort — never throw on host input);
+ * `src` becomes a CSS `url(...)` source string.
  */
 export function toFontFaceInputs(
   fonts: ReadonlyArray<FontDefinition> | undefined,
@@ -46,16 +65,20 @@ export function toFontFaceInputs(
   }
   const inputs: FontFaceInput[] = [];
   for (const font of fonts) {
-    const family = font.family.trim();
-    const src = font.src.trim();
-    if (!family || !src) {
+    if (!isValidFontDefinition(font)) {
       continue;
     }
     const descriptors: FontFaceDescriptors = { display: "swap" };
-    if (font.weight !== undefined) {
+    // Only a number/string weight is representable; anything else (a symbol
+    // would even make `String()` throw) is dropped to the default.
+    if (typeof font.weight === "number" || typeof font.weight === "string") {
       descriptors.weight = String(font.weight);
     }
-    inputs.push({ family, source: `url(${JSON.stringify(src)})`, descriptors });
+    inputs.push({
+      family: font.family.trim(),
+      source: `url(${JSON.stringify(font.src.trim())})`,
+      descriptors,
+    });
   }
   return inputs;
 }


### PR DESCRIPTION
Adds host-provided font props to `DocxEditor`, matching upstream's shape:
- **`fontFamilies?: ReadonlyArray<string | FontOption>`** — the font-family picker list (`FontOption = { name, fontFamily, category? }`; strings expand to the `other` category; `undefined` → built-in defaults; `[]` → empty-but-enabled).
- **`fonts?: ReadonlyArray<FontDefinition>`** — faces the host registers with the browser (`{ family, src, weight? }`; multiple entries can share a `family` for different weights).

Implementation reuses the embedded-font loader from #17 rather than a parallel path: the per-face best-effort registration is extracted into a shared `registerFontFace`, `loadEmbeddedFontFaces` now calls it (behavior identical, its regression test unchanged). Host fonts register in a `useEffect` keyed on the `fonts` prop and unregister on change/unmount. Picker families thread `DocxEditor → FormattingBar → FontPicker`. Bad entries are skipped, never throw.

Pure-tested: `toFontFaceInputs` (url wrapping/escaping, weight forms, skip-blank) and `normalizeFontFamilies` (undefined/empty/string-expansion/passthrough). The DOM `FontFace` registration + picker rendering are visual (folio has no DOM tests).
