### PR TITLE
feat(core): render legacy VML w:pict inline images

### DIFF
--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -44,6 +44,7 @@ import {
   findDeep,
   getChildElements,
   getLocalName,
+  mergeXmlnsDeclarations,
   type XmlElement,
 } from "./xmlParser";
 
@@ -370,7 +371,12 @@ export const parseBlockContent = (
   parseBlockContentWithState(parent, styles, theme, numbering, rels, media, {
     listCounters: new Map(),
     abstractCounters: new Map(),
-    options,
+    // Accumulate the container's own xmlns onto the inherited in-scope set so a
+    // captured VML `w:pict` replay resolves prefixes scoped on this level too.
+    options: {
+      ...options,
+      rootXmlns: mergeXmlnsDeclarations(options?.rootXmlns ?? {}, parent),
+    },
   });
 
 const parseBlockContentWithState = (

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -49,6 +49,9 @@ import {
 
 type ParseBlockContentOptions = {
   inHeaderFooter?: boolean;
+  // Source root `xmlns:*` declarations, threaded to the run parser so a captured
+  // VML `w:pict` replay stays self-contained under non-canonical prefixes.
+  rootXmlns?: Record<string, string>;
 };
 
 const toRoman = (numParam: number): string => {

--- a/packages/core/src/docx/documentParser.ts
+++ b/packages/core/src/docx/documentParser.ts
@@ -27,7 +27,7 @@ import type { NumberingMap } from "./numberingParser";
 import { getParagraphText } from "./paragraphParser";
 import { parseSectionProperties, getDefaultSectionProperties } from "./sectionParser";
 import type { StyleMap } from "./styleParser";
-import { parseXml, findChild } from "./xmlParser";
+import { parseXml, findChild, collectXmlnsDeclarations } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 // ============================================================================
@@ -226,8 +226,12 @@ export function parseDocumentBody(
     return result;
   }
 
-  // Parse all block content (paragraphs, tables)
-  result.content = parseBlockContent(bodyEl, styles, theme, numbering, rels, media);
+  // Parse all block content (paragraphs, tables). The root `xmlns:*`
+  // declarations travel with it so a captured VML `w:pict` replay stays
+  // self-contained under non-canonical namespace prefixes.
+  result.content = parseBlockContent(bodyEl, styles, theme, numbering, rels, media, {
+    rootXmlns: collectXmlnsDeclarations(documentEl),
+  });
 
   // Parse final section properties (w:body/w:sectPr)
   const finalSectPr = findChild(bodyEl, "w", "sectPr");

--- a/packages/core/src/docx/headerFooterParser.ts
+++ b/packages/core/src/docx/headerFooterParser.ts
@@ -41,7 +41,7 @@ import { parseBlockContent } from "./blockContentParser";
 import type { NumberingMap } from "./numberingParser";
 import type { StyleMap } from "./styleParser";
 import { parseWatermark } from "./watermarkParser";
-import { parseXml } from "./xmlParser";
+import { collectXmlnsDeclarations, parseXml } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 // Re-export reference parsers for backward compatibility
@@ -137,6 +137,7 @@ export function parseHeader(
 
   result.content = parseBlockContent(contentRoot, styles, theme, numbering, rels, media, {
     inHeaderFooter: true,
+    rootXmlns: collectXmlnsDeclarations(rootElement),
   });
 
   return result;
@@ -200,6 +201,7 @@ export function parseFooter(
 
   result.content = parseBlockContent(rootElement, styles, theme, numbering, rels, media, {
     inHeaderFooter: true,
+    rootXmlns: collectXmlnsDeclarations(rootElement),
   });
 
   return result;

--- a/packages/core/src/docx/imageParser.ts
+++ b/packages/core/src/docx/imageParser.ts
@@ -461,7 +461,7 @@ function getMimeType(path: string): string {
  * @param media - Media files map
  * @returns Object with src (data URL or blob), mimeType, and filename
  */
-function resolveImageData(
+export function resolveImageData(
   rId: string,
   rels: RelationshipMap | undefined,
   media: Map<string, MediaFile> | undefined,

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -65,6 +65,7 @@ import {
   findChildren,
   getAttribute,
   getChildElements,
+  mergeXmlnsDeclarations,
   parseBooleanElement,
   parseNumericAttribute,
   elementToXml,
@@ -1183,11 +1184,12 @@ function parseSimpleField(
   }
 
   // Parse child runs (the display value)
+  const inScopeXmlns = mergeXmlnsDeclarations(rootXmlns, node);
   const children = getChildElements(node);
   for (const child of children) {
     const localName = getLocalName(child.name);
     if (localName === "r") {
-      field.content.push(parseRun(child, styles, theme, rels, media, rootXmlns));
+      field.content.push(parseRun(child, styles, theme, rels, media, inScopeXmlns));
     }
   }
 
@@ -1211,6 +1213,10 @@ function parseParagraphContents(
 ): ParagraphContent[] {
   const contents: ParagraphContent[] = [];
   const children = getChildElements(paraElement);
+  // Accumulate this container's own xmlns (a paragraph or tracked-change /
+  // SDT wrapper may scope non-canonical prefixes) onto the inherited set, so a
+  // captured VML `w:pict` replay resolves prefixes scoped at this level too.
+  const inScopeXmlns = mergeXmlnsDeclarations(rootXmlns, paraElement);
 
   // State for tracking complex fields
   let inComplexField = false;
@@ -1232,7 +1238,7 @@ function parseParagraphContents(
         // Check for field characters in this run
         const runElement =
           trackedContext === "deletion" ? normalizeDeletionContentElement(child) : child;
-        const run = parseRun(runElement, styles, theme, rels, media, rootXmlns);
+        const run = parseRun(runElement, styles, theme, rels, media, inScopeXmlns);
         const commentReferenceId = getCommentReferenceId(runElement);
 
         // Look for field characters
@@ -1395,7 +1401,7 @@ function parseParagraphContents(
         break;
 
       case "fldSimple":
-        contents.push(parseSimpleField(child, styles, theme, rels, media, rootXmlns));
+        contents.push(parseSimpleField(child, styles, theme, rels, media, inScopeXmlns));
         break;
 
       case "pPr":
@@ -1423,7 +1429,7 @@ function parseParagraphContents(
             rels,
             media,
             trackedContext,
-            rootXmlns,
+            inScopeXmlns,
           );
           const properties = parseSdtProperties(sdtPr, sdtEndPr);
           pushInlineSdtSegments({
@@ -1446,7 +1452,7 @@ function parseParagraphContents(
           rels,
           media,
           "default",
-          rootXmlns,
+          inScopeXmlns,
         );
         pushTrackedChangeSegments({
           contents,
@@ -1467,7 +1473,7 @@ function parseParagraphContents(
           rels,
           media,
           "deletion",
-          rootXmlns,
+          inScopeXmlns,
         );
         pushTrackedChangeSegments({
           contents,
@@ -1487,7 +1493,7 @@ function parseParagraphContents(
           rels,
           media,
           "deletion",
-          rootXmlns,
+          inScopeXmlns,
         );
         pushTrackedChangeSegments({
           contents,
@@ -1508,7 +1514,7 @@ function parseParagraphContents(
           rels,
           media,
           "default",
-          rootXmlns,
+          inScopeXmlns,
         );
         pushTrackedChangeSegments({
           contents,

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1158,6 +1158,7 @@ function parseSimpleField(
   theme: Theme | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
+  rootXmlns: Record<string, string> = {},
 ): SimpleField {
   const instruction = getAttribute(node, "w", "instr") ?? "";
   const fieldType = parseFieldType(instruction);
@@ -1186,7 +1187,7 @@ function parseSimpleField(
   for (const child of children) {
     const localName = getLocalName(child.name);
     if (localName === "r") {
-      field.content.push(parseRun(child, styles, theme, rels, media));
+      field.content.push(parseRun(child, styles, theme, rels, media, rootXmlns));
     }
   }
 
@@ -1206,6 +1207,7 @@ function parseParagraphContents(
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
   trackedContext: TrackedChangeParseContext = "default",
+  rootXmlns: Record<string, string> = {},
 ): ParagraphContent[] {
   const contents: ParagraphContent[] = [];
   const children = getChildElements(paraElement);
@@ -1230,7 +1232,7 @@ function parseParagraphContents(
         // Check for field characters in this run
         const runElement =
           trackedContext === "deletion" ? normalizeDeletionContentElement(child) : child;
-        const run = parseRun(runElement, styles, theme, rels, media);
+        const run = parseRun(runElement, styles, theme, rels, media, rootXmlns);
         const commentReferenceId = getCommentReferenceId(runElement);
 
         // Look for field characters
@@ -1393,7 +1395,7 @@ function parseParagraphContents(
         break;
 
       case "fldSimple":
-        contents.push(parseSimpleField(child, styles, theme, rels, media));
+        contents.push(parseSimpleField(child, styles, theme, rels, media, rootXmlns));
         break;
 
       case "pPr":
@@ -1421,6 +1423,7 @@ function parseParagraphContents(
             rels,
             media,
             trackedContext,
+            rootXmlns,
           );
           const properties = parseSdtProperties(sdtPr, sdtEndPr);
           pushInlineSdtSegments({
@@ -1435,7 +1438,16 @@ function parseParagraphContents(
       case "ins": {
         // Track change: insertion — parse content and wrap
         const insInfo = parseTrackedChangeInfo(child);
-        const insContent = parseParagraphContents(child, styles, theme, null, rels, media);
+        const insContent = parseParagraphContents(
+          child,
+          styles,
+          theme,
+          null,
+          rels,
+          media,
+          "default",
+          rootXmlns,
+        );
         pushTrackedChangeSegments({
           contents,
           type: "insertion",
@@ -1455,6 +1467,7 @@ function parseParagraphContents(
           rels,
           media,
           "deletion",
+          rootXmlns,
         );
         pushTrackedChangeSegments({
           contents,
@@ -1474,6 +1487,7 @@ function parseParagraphContents(
           rels,
           media,
           "deletion",
+          rootXmlns,
         );
         pushTrackedChangeSegments({
           contents,
@@ -1486,7 +1500,16 @@ function parseParagraphContents(
 
       case "moveTo": {
         const moveToInfo = parseTrackedChangeInfo(child);
-        const moveToContent = parseParagraphContents(child, styles, theme, null, rels, media);
+        const moveToContent = parseParagraphContents(
+          child,
+          styles,
+          theme,
+          null,
+          rels,
+          media,
+          "default",
+          rootXmlns,
+        );
         pushTrackedChangeSegments({
           contents,
           type: "moveTo",
@@ -1600,7 +1623,7 @@ export function parseParagraph(
   numbering: NumberingMap | null,
   rels: RelationshipMap | null = null,
   media: Map<string, MediaFile> | null = null,
-  options?: { inHeaderFooter?: boolean },
+  options?: { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> },
 ): Paragraph {
   const paragraph: Paragraph = {
     type: "paragraph",
@@ -1652,7 +1675,16 @@ export function parseParagraph(
   }
 
   // Parse paragraph contents (runs, hyperlinks, bookmarks, fields)
-  const rawContent = parseParagraphContents(node, styles, theme, numbering, rels, media);
+  const rawContent = parseParagraphContents(
+    node,
+    styles,
+    theme,
+    numbering,
+    rels,
+    media,
+    "default",
+    options?.rootXmlns ?? {},
+  );
 
   // Consolidate consecutive runs with identical formatting
   // This reduces fragmentation (e.g., 252 tiny runs → a few larger runs)

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -54,6 +54,7 @@ import {
 } from "./parserEnums";
 import { parseShapeFromDrawing, shouldPreserveRawShapeDrawing } from "./shapeParser";
 import type { StyleMap } from "./styleParser";
+import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
 import {
   findChild,
@@ -935,9 +936,20 @@ function parseRunContents(
         break;
       }
 
-      case "pict":
+      case "pict": {
+        // Legacy VML inline picture (e.g. an old-format header logo). Resolve
+        // it to the same drawing/image node a DrawingML image produces so it
+        // renders through the existing image path; the original VML round-trips
+        // verbatim via the drawing's rawXml.
+        const vmlDrawing = parseVmlImageContent(child, rels, media);
+        if (vmlDrawing) {
+          contents.push(vmlDrawing);
+        }
+        break;
+      }
+
       case "object":
-        // Legacy VML pictures/objects are not part of the active DrawingML path.
+        // Legacy OLE objects remain outside the active image path.
         break;
 
       case "rPr":

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -57,11 +57,13 @@ import type { StyleMap } from "./styleParser";
 import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
 import {
+  cloneWithXmlnsDeclarations,
   findChild,
   findChildren,
   getAttribute,
   getChildElements,
   getTextContent,
+  mergeXmlnsDeclarations,
   parseBooleanElement,
   parseNumericAttribute,
   elementToXml,
@@ -969,10 +971,28 @@ function parseRunContents(
       }
 
       case "AlternateContent": {
-        // mc:AlternateContent — prefer mc:Choice over mc:Fallback
-        const choiceEl = getChildElements(child).find((el) => getLocalName(el.name) === "Choice");
-        const targetEl =
-          choiceEl ?? getChildElements(child).find((el) => getLocalName(el.name) === "Fallback");
+        // mc:AlternateContent — folio cannot evaluate `mc:Requires`, so it
+        // renders the Choice by default. A VML `w:pict` in the Fallback is the
+        // compatibility image folio can always show; prefer it when the Fallback
+        // carries a real VML picture (not a textbox / empty pict), and keep the
+        // whole AlternateContent on save so the Choice is not lost.
+        const alternateChildren = getChildElements(child);
+        const choiceEl = alternateChildren.find((el) => getLocalName(el.name) === "Choice");
+        const fallbackEl = alternateChildren.find((el) => getLocalName(el.name) === "Fallback");
+
+        const fallbackPict = fallbackEl
+          ? getChildElements(fallbackEl).find((el) => getLocalName(el.name) === "pict")
+          : undefined;
+        const fallbackVml = fallbackPict
+          ? parseVmlImageContent(fallbackPict, rels, media, rootXmlns)
+          : null;
+        if (fallbackVml) {
+          fallbackVml.rawXml = elementToXml(cloneWithXmlnsDeclarations(child, rootXmlns));
+          contents.push(fallbackVml);
+          break;
+        }
+
+        const targetEl = choiceEl ?? fallbackEl;
         if (targetEl) {
           for (const innerChild of getChildElements(targetEl)) {
             const innerName = getLocalName(innerChild.name);
@@ -985,6 +1005,13 @@ function parseRunContents(
                   innerDrawing.rawXml = elementToXml(child);
                 }
                 contents.push(innerDrawing);
+              }
+            } else if (innerName === "pict") {
+              // A VML picture in the chosen Choice (no Fallback image present).
+              const innerVml = parseVmlImageContent(innerChild, rels, media, rootXmlns);
+              if (innerVml) {
+                innerVml.rawXml = elementToXml(cloneWithXmlnsDeclarations(child, rootXmlns));
+                contents.push(innerVml);
               }
             }
           }
@@ -1049,8 +1076,10 @@ export function parseRun(
     }
   }
 
-  // Parse run contents (text, tabs, breaks, images, etc.)
-  run.content = parseRunContents(node, rels, media, rootXmlns);
+  // Parse run contents (text, tabs, breaks, images, etc.). Accumulate the run's
+  // own xmlns onto the inherited set so a captured VML `w:pict` replay resolves
+  // any prefix scoped on the run itself.
+  run.content = parseRunContents(node, rels, media, mergeXmlnsDeclarations(rootXmlns, node));
 
   return run;
 }

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -867,6 +867,7 @@ function parseRunContents(
   runElement: XmlElement,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
+  rootXmlns: Record<string, string> = {},
 ): RunContent[] {
   const contents: RunContent[] = [];
   const children = getChildElements(runElement);
@@ -941,7 +942,7 @@ function parseRunContents(
         // it to the same drawing/image node a DrawingML image produces so it
         // renders through the existing image path; the original VML round-trips
         // verbatim via the drawing's rawXml.
-        const vmlDrawing = parseVmlImageContent(child, rels, media);
+        const vmlDrawing = parseVmlImageContent(child, rels, media, rootXmlns);
         if (vmlDrawing) {
           contents.push(vmlDrawing);
         }
@@ -1028,6 +1029,7 @@ export function parseRun(
   theme: Theme | null,
   rels: RelationshipMap | null = null,
   media: Map<string, MediaFile> | null = null,
+  rootXmlns: Record<string, string> = {},
 ): Run {
   const run: Run = {
     type: "run",
@@ -1048,7 +1050,7 @@ export function parseRun(
   }
 
   // Parse run contents (text, tabs, breaks, images, etc.)
-  run.content = parseRunContents(node, rels, media);
+  run.content = parseRunContents(node, rels, media, rootXmlns);
 
   return run;
 }

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -973,9 +973,10 @@ function parseRunContents(
       case "AlternateContent": {
         // mc:AlternateContent — folio cannot evaluate `mc:Requires`, so it
         // renders the Choice by default. A VML `w:pict` in the Fallback is the
-        // compatibility image folio can always show; prefer it when the Fallback
-        // carries a real VML picture (not a textbox / empty pict), and keep the
-        // whole AlternateContent on save so the Choice is not lost.
+        // compatibility image folio can always show; prefer it only when it
+        // resolves to a real media part (not a textbox / empty pict / broken
+        // relationship), otherwise fall through to the Choice's DrawingML image.
+        // The whole AlternateContent is kept on save so the Choice is not lost.
         const alternateChildren = getChildElements(child);
         const choiceEl = alternateChildren.find((el) => getLocalName(el.name) === "Choice");
         const fallbackEl = alternateChildren.find((el) => getLocalName(el.name) === "Fallback");
@@ -986,7 +987,7 @@ function parseRunContents(
         const fallbackVml = fallbackPict
           ? parseVmlImageContent(fallbackPict, rels, media, rootXmlns)
           : null;
-        if (fallbackVml) {
+        if (fallbackVml?.image.src) {
           fallbackVml.rawXml = elementToXml(cloneWithXmlnsDeclarations(child, rootXmlns));
           contents.push(fallbackVml);
           break;

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -74,6 +74,7 @@ import {
   findChildren,
   getAttribute,
   getChildElements,
+  mergeXmlnsDeclarations,
   parseNumericAttribute,
   parseBooleanElement,
 } from "./xmlParser";
@@ -1136,6 +1137,20 @@ export function parseTableCellProperties(
  * @param media - Media files for images
  * @returns Array of content blocks
  */
+type TableParseOptions = { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> };
+
+/**
+ * Accumulate a table container's own `xmlns:*` onto the inherited in-scope set,
+ * so a `w:pict` nested inside a cell still resolves prefixes scoped on the
+ * `w:tbl` / `w:tr` / `w:tc` wrapper.
+ */
+function withContainerXmlns(
+  options: TableParseOptions | undefined,
+  element: XmlElement,
+): TableParseOptions {
+  return { ...options, rootXmlns: mergeXmlnsDeclarations(options?.rootXmlns ?? {}, element) };
+}
+
 function parseCellContent(
   tcElement: XmlElement,
   styles: StyleMap | null,
@@ -1143,7 +1158,7 @@ function parseCellContent(
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
-  options?: { inHeaderFooter?: boolean },
+  options?: { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> },
 ): (Paragraph | Table)[] {
   const content: (Paragraph | Table)[] = [];
   const pendingBookmarkMarkers: BookmarkMarker[] = [];
@@ -1214,7 +1229,7 @@ export function parseTableCell(
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
-  options?: { inHeaderFooter?: boolean },
+  options?: { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> },
 ): TableCell {
   const cell: TableCell = {
     type: "tableCell",
@@ -1236,8 +1251,16 @@ export function parseTableCell(
     cell.structuralChange = cellStructChange;
   }
 
-  // Parse content
-  cell.content = parseCellContent(tcElement, styles, theme, numbering, rels, media, options);
+  // Parse content, threading the cell's own xmlns down the in-scope set.
+  cell.content = parseCellContent(
+    tcElement,
+    styles,
+    theme,
+    numbering,
+    rels,
+    media,
+    withContainerXmlns(options, tcElement),
+  );
 
   return cell;
 }
@@ -1264,7 +1287,7 @@ export function parseTableRow(
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
-  options?: { inHeaderFooter?: boolean },
+  options?: { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> },
 ): TableRow {
   const row: TableRow = {
     type: "tableRow",
@@ -1286,12 +1309,13 @@ export function parseTableRow(
     row.structuralChange = rowStructChange;
   }
 
-  // Parse cells
+  // Parse cells, threading the row's own xmlns down the in-scope set.
+  const rowOptions = withContainerXmlns(options, trElement);
   const pendingBookmarkMarkers: BookmarkMarker[] = [];
   const parseRowChild = (child: XmlElement): void => {
     const localName = getLocalName(child.name);
     if (localName === "tc") {
-      const cell = parseTableCell(child, styles, theme, numbering, rels, media, options);
+      const cell = parseTableCell(child, styles, theme, numbering, rels, media, rowOptions);
       if (pendingBookmarkMarkers.length > 0) {
         prependBookmarkMarkersToFirstParagraphInCell(cell, pendingBookmarkMarkers);
         pendingBookmarkMarkers.length = 0;
@@ -1510,7 +1534,7 @@ export function parseTable(
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
-  options?: { inHeaderFooter?: boolean },
+  options?: { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> },
 ): Table {
   const table: Table = {
     type: "table",
@@ -1534,13 +1558,14 @@ export function parseTable(
     table.columnWidths = columnWidths;
   }
 
-  // Parse rows
+  // Parse rows, threading the table's own xmlns down the in-scope set.
+  const tableOptions = withContainerXmlns(options, tblElement);
   const rowsWithGridOffsets = new Set<number>();
   const parseTableChild = (child: XmlElement): void => {
     const localName = getLocalName(child.name);
     if (localName === "tr") {
       const rowIndex = table.rows.length;
-      const row = parseTableRow(child, styles, theme, numbering, rels, media, options);
+      const row = parseTableRow(child, styles, theme, numbering, rels, media, tableOptions);
       table.rows.push(row);
       if (hasRowGridOffsets(child)) {
         rowsWithGridOffsets.add(rowIndex);

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
-import type { DrawingContent, Paragraph, Run } from "../types/document";
+import type { DrawingContent, Paragraph, Run, Table } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { repackDocx, validateDocx } from "./rezip";
@@ -80,12 +80,12 @@ ${imageRel ? `  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Tar
   return zip.generateAsync({ type: "arraybuffer" });
 }
 
-/** Pull the first drawing content out of the first body paragraph's first run. */
-function firstDrawing(paragraph: Paragraph | undefined): DrawingContent | undefined {
-  if (paragraph?.type !== "paragraph") {
+/** Pull the first drawing content out of a paragraph's first run. */
+function firstDrawing(block: Paragraph | Table | undefined): DrawingContent | undefined {
+  if (block?.type !== "paragraph") {
     return undefined;
   }
-  const run = paragraph.content.find((c): c is Run => c.type === "run");
+  const run = block.content.find((c): c is Run => c.type === "run");
   return run?.content.find((c): c is DrawingContent => c.type === "drawing");
 }
 
@@ -415,5 +415,140 @@ describe("VML w:pict inline images", () => {
     const reDrawing = firstDrawing(reparsed.package.document.content.at(0));
     expect(reDrawing?.image.rId).toBe("rIdImg");
     expect(reDrawing?.image.src?.startsWith("data:image/png")).toBe(true);
+  });
+
+  test("uses the Choice image when the Fallback pict's relationship cannot be resolved", async () => {
+    // The Fallback VML references a missing relationship, so it cannot resolve
+    // to a media part; the resolvable Choice DrawingML image must win.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    // Only the Choice image resolves; the Fallback's rIdMissing is absent.
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdChoice" Type="${RELATIONSHIP_TYPES.image}" Target="media/choice.png"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r>
+      <mc:AlternateContent>
+        <mc:Choice Requires="wps"><w:drawing><wp:inline><wp:extent cx="914400" cy="914400"/><wp:docPr id="1" name="choice"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic><pic:nvPicPr><pic:cNvPr id="1" name="choice"/><pic:cNvPicPr/></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdChoice"/></pic:blipFill><pic:spPr/></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></mc:Choice>
+        <mc:Fallback><w:pict><v:shape style="width:2in;height:1in"><v:imagedata r:id="rIdMissing"/></v:shape></w:pict></mc:Fallback>
+      </mc:AlternateContent>
+    </w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file("word/media/choice.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    // The resolvable Choice image is used, not the unresolvable Fallback pict.
+    expect(drawing?.image.rId).toBe("rIdChoice");
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+  });
+
+  test("captures xmlns declarations scoped on a table cell containing a w:pict", async () => {
+    // The non-canonical VML / relationship prefixes are bound on the <w:tc>, so
+    // the in-scope set must accumulate through tbl -> tr -> tc into the cell.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/image1.png"/>
+</Relationships>`,
+    );
+    // Root declares only w; v2/r2 are scoped on the <w:tc>.
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:tbl>
+      <w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>
+      <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+      <w:tr><w:tc xmlns:v2="urn:schemas-microsoft-com:vml" xmlns:r2="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr>
+        <w:p><w:r><w:pict><v2:shape style="width:2in;height:1in"><v2:imagedata r2:id="rIdImg"/></v2:shape></w:pict></w:r></w:p>
+      </w:tc></w:tr>
+    </w:tbl>
+    <w:p/>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file("word/media/image1.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const table = doc.package.document.content.at(0);
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      throw new Error("expected a table");
+    }
+    const drawing = firstDrawing(table.rows.at(0)?.cells.at(0)?.content.at(0));
+    expect(drawing?.image.rId).toBe("rIdImg");
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const docXml = await outZip.file("word/document.xml")!.async("text");
+    // The cell-scoped bindings are carried onto the captured pict.
+    expect(docXml).toContain('xmlns:v2="urn:schemas-microsoft-com:vml"');
+    expect(docXml).toContain("<v2:shape");
+    expect(docXml).toContain('r2:id="rIdImg"');
   });
 });

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -163,4 +163,116 @@ describe("VML w:pict inline images", () => {
     expect(docXml).toContain("<w:pict");
     expect(docXml).toContain('r:id="rIdImg"');
   });
+
+  test("parses shape dimensions with case-insensitive units", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape style="width:2IN;height:1Pt"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    // 2IN = 192px = 1,828,800 EMU; 1Pt = 96/72 px = 12,700 EMU.
+    expect(drawing?.image.size.width).toBe(1_828_800);
+    expect(drawing?.image.size.height).toBe(12_700);
+  });
+
+  test("rejects a malformed length rather than mis-parsing it", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape style="width:1.2.3in;height:1in"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    // `1.2.3in` is not a valid length, so the width is dropped (0), not truncated
+    // to `1.2`; the valid height still parses.
+    expect(drawing?.image.size.width).toBe(0);
+    expect(drawing?.image.size.height).toBe(914_400);
+  });
+
+  test("resolves the relationship id from o:relid when r:id is absent", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape style="width:1in;height:1in"><v:imagedata o:relid="rIdImg"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.rId).toBe("rIdImg");
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+  });
+
+  test("round-trips a w:pict that binds VML/relationship namespaces to non-canonical prefixes", async () => {
+    // A DOCX whose root binds VML (`v2`), office (`o2`), and relationship (`r2`)
+    // namespaces to non-canonical prefixes the serializer's root does not
+    // declare. The captured VML must carry those declarations so it resolves.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/image1.png"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v2="urn:schemas-microsoft-com:vml" xmlns:o2="urn:schemas-microsoft-com:office:office" xmlns:r2="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r><w:pict><v2:shape style="width:2in;height:1in"><v2:imagedata r2:id="rIdImg" o2:title="logo"/></v2:shape></w:pict></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file("word/media/image1.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.rId).toBe("rIdImg");
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+    expect(drawing?.image.size.width).toBe(1_828_800);
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const docXml = await outZip.file("word/document.xml")!.async("text");
+    // The non-canonical prefix bindings travel with the captured VML.
+    expect(docXml).toContain('xmlns:v2="urn:schemas-microsoft-com:vml"');
+    expect(docXml).toContain("<v2:shape");
+    expect(docXml).toContain('r2:id="rIdImg"');
+
+    // Re-parsing the saved output still resolves the picture (lossless).
+    const reparsed = await parseDocx(out, { preloadFonts: false });
+    const reDrawing = firstDrawing(reparsed.package.document.content.at(0));
+    expect(reDrawing?.image.rId).toBe("rIdImg");
+    expect(reDrawing?.image.src?.startsWith("data:image/png")).toBe(true);
+  });
 });

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Legacy VML `w:pict` inline images.
+ *
+ * Older Word files embed inline pictures (e.g. header logos) as VML instead of
+ * DrawingML. The run parser used to drop `w:pict`, so these never rendered.
+ * These tests cover: resolving `<v:imagedata r:id>` to the same drawing/image
+ * node a DrawingML image produces (with style-derived dimensions and resolved
+ * media), byte-preserving the original VML on save, and skipping degenerate
+ * shapes (no imagedata, unresolved relationship) without throwing.
+ *
+ * Ported alongside eigenpal/docx-editor `vmlImageParser.ts`.
+ */
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { DrawingContent, Paragraph, Run } from "../types/document";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx, validateDocx } from "./rezip";
+
+const XML = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const ONE_PIXEL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+type PictDocxOptions = {
+  /** The `<w:r>` inner XML placed in the body paragraph. */
+  runXml: string;
+  /** When false, omit the image relationship so the r:id does not resolve. */
+  imageRel?: boolean;
+  /** When false, omit the media part. */
+  media?: boolean;
+};
+
+async function pictDocx(options: PictDocxOptions): Promise<ArrayBuffer> {
+  const imageRel = options.imageRel ?? true;
+  const withMedia = options.media ?? true;
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+${imageRel ? `  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/image1.png"/>` : ""}
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r>${options.runXml}</w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+  );
+  if (withMedia) {
+    zip.file("word/media/image1.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+  }
+  zip.file(
+    "word/styles.xml",
+    `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+/** Pull the first drawing content out of the first body paragraph's first run. */
+function firstDrawing(paragraph: Paragraph | undefined): DrawingContent | undefined {
+  if (paragraph?.type !== "paragraph") {
+    return undefined;
+  }
+  const run = paragraph.content.find((c): c is Run => c.type === "run");
+  return run?.content.find((c): c is DrawingContent => c.type === "drawing");
+}
+
+const PICT_WITH_IMAGE = `<w:pict><v:shape id="Picture 1" type="#_x0000_t75" style="width:2in;height:1in"><v:imagedata r:id="rIdImg" o:title="logo"/></v:shape></w:pict>`;
+
+describe("VML w:pict inline images", () => {
+  test("parses a w:pict into a drawing/image node with style dimensions + resolved media", async () => {
+    const doc = await parseDocx(await pictDocx({ runXml: PICT_WITH_IMAGE }), {
+      preloadFonts: false,
+    });
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing).toBeDefined();
+    expect(drawing?.image.type).toBe("image");
+    expect(drawing?.image.rId).toBe("rIdImg");
+
+    // 2in = 192px = 1,828,800 EMU; 1in = 96px = 914,400 EMU (1px = 9525 EMU).
+    expect(drawing?.image.size.width).toBe(1_828_800);
+    expect(drawing?.image.size.height).toBe(914_400);
+    expect(drawing?.image.wrap.type).toBe("inline");
+
+    // The <v:imagedata r:id> resolved to the media part's bytes.
+    expect(drawing?.image.src).toBeDefined();
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+    expect(drawing?.image.mimeType).toBe("image/png");
+    expect(drawing?.image.filename).toBe("image1.png");
+    expect(drawing?.image.title).toBe("logo");
+  });
+
+  test("preserves the original VML verbatim on save (no DrawingML conversion)", async () => {
+    const original = await pictDocx({ runXml: PICT_WITH_IMAGE });
+    const doc = await parseDocx(original, { preloadFonts: false });
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const docXml = await zip.file("word/document.xml")!.async("text");
+    // The VML round-trips as VML, not a synthesized <w:drawing>.
+    expect(docXml).toContain("<w:pict");
+    expect(docXml).toContain("<v:imagedata");
+    expect(docXml).toContain('r:id="rIdImg"');
+    expect(docXml).not.toContain("<w:drawing");
+    expect(docXml).not.toContain("wp:inline");
+    // The referenced media part survives the round-trip.
+    expect(zip.file("word/media/image1.png")).not.toBeNull();
+  });
+
+  test("skips a w:pict with no imagedata without throwing", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:rect style="width:1in;height:1in"/></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    // No image node is produced; the run simply carries no drawing content.
+    expect(firstDrawing(doc.package.document.content.at(0))).toBeUndefined();
+  });
+
+  test("keeps a w:pict whose relationship does not resolve (no src) and preserves it on save", async () => {
+    const doc = await parseDocx(await pictDocx({ runXml: PICT_WITH_IMAGE, imageRel: false }), {
+      preloadFonts: false,
+    });
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing).toBeDefined();
+    expect(drawing?.image.rId).toBe("rIdImg");
+    // Unresolved relationship: no binary, but the reference is not dropped.
+    expect(drawing?.image.src).toBeUndefined();
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const zip = await JSZip.loadAsync(out);
+    const docXml = await zip.file("word/document.xml")!.async("text");
+    expect(docXml).toContain("<w:pict");
+    expect(docXml).toContain('r:id="rIdImg"');
+  });
+});

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -275,4 +275,145 @@ describe("VML w:pict inline images", () => {
     expect(reDrawing?.image.rId).toBe("rIdImg");
     expect(reDrawing?.image.src?.startsWith("data:image/png")).toBe(true);
   });
+
+  test("routes a w:pict inside mc:AlternateContent/mc:Fallback and prefers the fallback image", async () => {
+    // A common compatibility form: a modern DrawingML Choice plus a VML `w:pict`
+    // Fallback carrying the picture. folio renders (and keeps) the Fallback image.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdChoice" Type="${RELATIONSHIP_TYPES.image}" Target="media/choice.png"/>
+  <Relationship Id="rIdFallback" Type="${RELATIONSHIP_TYPES.image}" Target="media/fallback.png"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r>
+      <mc:AlternateContent>
+        <mc:Choice Requires="wps"><w:drawing><wp:inline><wp:extent cx="914400" cy="914400"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic><pic:blipFill><a:blip r:embed="rIdChoice"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></mc:Choice>
+        <mc:Fallback><w:pict><v:shape style="width:2in;height:1in"><v:imagedata r:id="rIdFallback" o:title="fallback"/></v:shape></w:pict></mc:Fallback>
+      </mc:AlternateContent>
+    </w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file("word/media/choice.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file("word/media/fallback.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    // The Fallback's VML picture is preferred over the Choice's DrawingML image.
+    expect(drawing?.image.rId).toBe("rIdFallback");
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+    expect(drawing?.image.size.width).toBe(1_828_800);
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const docXml = await outZip.file("word/document.xml")!.async("text");
+    expect(docXml).toContain("<w:pict");
+    expect(docXml).toContain('r:id="rIdFallback"');
+    // The whole mc:AlternateContent is preserved on save (the Choice is not lost).
+    expect(docXml).toContain('r:embed="rIdChoice"');
+    expect(outZip.file("word/media/fallback.png")).not.toBeNull();
+  });
+
+  test("captures xmlns declarations scoped on an ancestor paragraph (not just the root)", async () => {
+    // The non-canonical VML / relationship prefixes are bound on the <w:p>, not
+    // the document root. The in-scope set must accumulate down the ancestor
+    // chain so the captured pict still carries them.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/image1.png"/>
+</Relationships>`,
+    );
+    // Root declares only w; v2/r2 are scoped on the paragraph.
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p xmlns:v2="urn:schemas-microsoft-com:vml" xmlns:r2="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:r><w:pict><v2:shape style="width:2in;height:1in"><v2:imagedata r2:id="rIdImg"/></v2:shape></w:pict></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file("word/media/image1.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.rId).toBe("rIdImg");
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const docXml = await outZip.file("word/document.xml")!.async("text");
+    // The paragraph-scoped bindings are carried onto the captured pict.
+    expect(docXml).toContain('xmlns:v2="urn:schemas-microsoft-com:vml"');
+    expect(docXml).toContain("<v2:shape");
+    expect(docXml).toContain('r2:id="rIdImg"');
+
+    const reparsed = await parseDocx(out, { preloadFonts: false });
+    const reDrawing = firstDrawing(reparsed.package.document.content.at(0));
+    expect(reDrawing?.image.rId).toBe("rIdImg");
+    expect(reDrawing?.image.src?.startsWith("data:image/png")).toBe(true);
+  });
 });

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -1,0 +1,178 @@
+/**
+ * VML image parser — legacy `w:pict` inline pictures.
+ *
+ * Older Word documents (and some exporters) embed inline pictures such as
+ * header logos as VML instead of DrawingML:
+ *
+ *   <w:r><w:pict>
+ *     <v:shape id="Picture 1" type="#_x0000_t75" style="width:120pt;height:40pt">
+ *       <v:imagedata r:id="rId7" o:title="logo"/>
+ *     </v:shape>
+ *   </w:pict></w:r>
+ *
+ * The run parser used to drop `w:pict` entirely, so these pictures never
+ * rendered. This resolves `<v:imagedata r:id>` to the same media part a
+ * DrawingML image uses and produces the identical `DrawingContent` / `Image`
+ * node, so the rest of the pipeline (ProseMirror conversion, layout, painter)
+ * renders it through the existing inline-image path.
+ *
+ * The original VML is preserved verbatim on the returned drawing's `rawXml`:
+ * the serializer has no VML synthesis path (it only emits DrawingML), so
+ * without this a `w:pict` would round-trip as a `<w:drawing>`. Emitting the
+ * captured XML keeps save byte-for-byte for these runs.
+ *
+ * Picture watermarks (`WordPictureWatermark…` shapes) are owned by
+ * watermarkParser and stripped before body parsing; the `isWatermarkShape`
+ * guard here is defensive so such a shape is never rendered twice.
+ *
+ * Ported from eigenpal/docx-editor `vmlImageParser.ts`.
+ */
+
+import type { DrawingContent, Image, MediaFile, RelationshipMap } from "../types/document";
+import { pixelsToEmu } from "../utils/units";
+import { resolveImageData } from "./imageParser";
+import { isWatermarkShape } from "./watermarkParser";
+import { elementToXml, findAllDeep, findChild, getAttribute, type XmlElement } from "./xmlParser";
+
+/** Convert a CSS length (pt/in/px/cm/mm/pc, default px) to pixels. */
+function cssLengthToPx(raw: string | undefined): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const match = /^(?<amount>-?[\d.]+)\s*(?<unit>pt|in|px|cm|mm|pc)?$/u.exec(raw.trim());
+  const amountText = match?.groups?.["amount"];
+  if (amountText === undefined) {
+    return undefined;
+  }
+  const value = Number.parseFloat(amountText);
+  if (Number.isNaN(value)) {
+    return undefined;
+  }
+  switch (match?.groups?.["unit"]) {
+    case "pt":
+      return (value / 72) * 96;
+    case "in":
+      return value * 96;
+    case "cm":
+      return (value / 2.54) * 96;
+    case "mm":
+      return (value / 25.4) * 96;
+    case "pc":
+      return (value / 6) * 96;
+    case "px":
+    case undefined:
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+/** Read a `style="k1:v1;k2:v2"` attribute into a lowercased key/value record. */
+function parseStyleAttr(style: string | null): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!style) {
+    return out;
+  }
+  for (const decl of style.split(";")) {
+    const colon = decl.indexOf(":");
+    if (colon < 0) {
+      continue;
+    }
+    const key = decl.slice(0, colon).trim().toLowerCase();
+    const value = decl.slice(colon + 1).trim();
+    if (key) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/** Read the `r:id` (or fallbacks) off a `v:imagedata` element. */
+function readImageDataRId(imagedata: XmlElement): string {
+  return (
+    getAttribute(imagedata, "r", "id") ??
+    getAttribute(imagedata, "r", "embed") ??
+    getAttribute(imagedata, null, "id") ??
+    ""
+  );
+}
+
+/**
+ * Parse a `w:pict` element into an inline image, or null when it carries no
+ * ordinary VML picture (no resolvable `<v:imagedata>`, or a watermark shape).
+ */
+export function parseVmlImageContent(
+  pictElement: XmlElement,
+  rels: RelationshipMap | null,
+  media: Map<string, MediaFile> | null,
+): DrawingContent | null {
+  // A VML picture's image lives in <v:imagedata r:id> inside a shape
+  // (v:shape / v:rect / v:roundrect / v:oval). Walk each shape kind and look
+  // for an imagedata child within it.
+  const shapes = [
+    ...findAllDeep(pictElement, "v", "shape"),
+    ...findAllDeep(pictElement, "v", "rect"),
+    ...findAllDeep(pictElement, "v", "roundrect"),
+    ...findAllDeep(pictElement, "v", "oval"),
+  ];
+
+  for (const shape of shapes) {
+    const imagedata = findChild(shape, "v", "imagedata");
+    if (!imagedata) {
+      continue;
+    }
+
+    const rId = readImageDataRId(imagedata);
+    if (!rId) {
+      continue;
+    }
+
+    // Watermarks are owned by watermarkParser; rendering them here too would
+    // duplicate them.
+    if (isWatermarkShape(shape)) {
+      continue;
+    }
+
+    const { src, mimeType, filename } = resolveImageData(
+      rId,
+      rels ?? undefined,
+      media ?? undefined,
+    );
+
+    const shapeStyle = parseStyleAttr(getAttribute(shape, null, "style"));
+    const widthPx = cssLengthToPx(shapeStyle["width"]);
+    const heightPx = cssLengthToPx(shapeStyle["height"]);
+
+    // VML pictures in a run are inline-flow. Absolute-positioned VML is treated
+    // as inline here too: rendering the picture in flow is far better than
+    // dropping it, and the original XML round-trips verbatim via rawXml.
+    const image: Image = {
+      type: "image",
+      rId,
+      size: {
+        width: widthPx != null ? pixelsToEmu(widthPx) : 0,
+        height: heightPx != null ? pixelsToEmu(heightPx) : 0,
+      },
+      wrap: { type: "inline" },
+    };
+    if (src) {
+      image.src = src;
+    }
+    if (mimeType) {
+      image.mimeType = mimeType;
+    }
+    if (filename) {
+      image.filename = filename;
+    }
+    const title = getAttribute(imagedata, "o", "title");
+    if (title) {
+      image.title = title;
+    }
+
+    // Preserve the exact VML so the serializer replays it instead of emitting a
+    // synthesized DrawingML `<w:drawing>`.
+    return { type: "drawing", image, rawXml: elementToXml(pictElement) };
+  }
+
+  return null;
+}

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -32,14 +32,28 @@ import type { DrawingContent, Image, MediaFile, RelationshipMap } from "../types
 import { pixelsToEmu } from "../utils/units";
 import { resolveImageData } from "./imageParser";
 import { isWatermarkShape } from "./watermarkParser";
-import { elementToXml, findAllDeep, findChild, getAttribute, type XmlElement } from "./xmlParser";
+import {
+  cloneWithXmlnsDeclarations,
+  elementToXml,
+  findAllDeep,
+  findChild,
+  getAttribute,
+  type XmlElement,
+} from "./xmlParser";
 
-/** Convert a CSS length (pt/in/px/cm/mm/pc, default px) to pixels. */
+/**
+ * Convert a CSS length (pt/in/px/cm/mm/pc, default px) to pixels. Units are
+ * matched case-insensitively (`2IN`, `2Pt` are valid VML). The numeric part
+ * must be a single well-formed decimal, so malformed input like `1.2.3` is
+ * rejected rather than truncated to `1.2`.
+ */
 function cssLengthToPx(raw: string | undefined): number | undefined {
   if (!raw) {
     return undefined;
   }
-  const match = /^(?<amount>-?[\d.]+)\s*(?<unit>pt|in|px|cm|mm|pc)?$/u.exec(raw.trim());
+  const match = /^(?<amount>-?(?:\d+(?:\.\d+)?|\.\d+))\s*(?<unit>pt|in|px|cm|mm|pc)?$/iu.exec(
+    raw.trim(),
+  );
   const amountText = match?.groups?.["amount"];
   if (amountText === undefined) {
     return undefined;
@@ -48,7 +62,7 @@ function cssLengthToPx(raw: string | undefined): number | undefined {
   if (Number.isNaN(value)) {
     return undefined;
   }
-  switch (match?.groups?.["unit"]) {
+  switch (match?.groups?.["unit"]?.toLowerCase()) {
     case "pt":
       return (value / 72) * 96;
     case "in":
@@ -87,11 +101,16 @@ function parseStyleAttr(style: string | null): Record<string, string> {
   return out;
 }
 
-/** Read the `r:id` (or fallbacks) off a `v:imagedata` element. */
+/**
+ * Read the relationship id off a `v:imagedata` element. Word writes `r:id`;
+ * some legacy / third-party generators use `r:embed` or the office-namespace
+ * `o:relid` instead, so fall back through those before the bare `id`.
+ */
 function readImageDataRId(imagedata: XmlElement): string {
   return (
     getAttribute(imagedata, "r", "id") ??
     getAttribute(imagedata, "r", "embed") ??
+    getAttribute(imagedata, "o", "relid") ??
     getAttribute(imagedata, null, "id") ??
     ""
   );
@@ -100,11 +119,17 @@ function readImageDataRId(imagedata: XmlElement): string {
 /**
  * Parse a `w:pict` element into an inline image, or null when it carries no
  * ordinary VML picture (no resolvable `<v:imagedata>`, or a watermark shape).
+ *
+ * `rootXmlns` carries the source document/header namespace declarations. They
+ * are injected onto the captured VML so the raw replay stays self-contained
+ * when the producer bound WordprocessingML / relationship / VML namespaces to
+ * non-canonical prefixes the serializer's root does not declare.
  */
 export function parseVmlImageContent(
   pictElement: XmlElement,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
+  rootXmlns: Record<string, string> = {},
 ): DrawingContent | null {
   // A VML picture's image lives in <v:imagedata r:id> inside a shape
   // (v:shape / v:rect / v:roundrect / v:oval). Walk each shape kind and look
@@ -170,8 +195,13 @@ export function parseVmlImageContent(
     }
 
     // Preserve the exact VML so the serializer replays it instead of emitting a
-    // synthesized DrawingML `<w:drawing>`.
-    return { type: "drawing", image, rawXml: elementToXml(pictElement) };
+    // synthesized DrawingML `<w:drawing>`. Inject the source root's namespace
+    // declarations so a non-canonical prefix still resolves in the replay.
+    return {
+      type: "drawing",
+      image,
+      rawXml: elementToXml(cloneWithXmlnsDeclarations(pictElement, rootXmlns)),
+    };
   }
 
   return null;

--- a/packages/core/src/docx/watermarkParser.ts
+++ b/packages/core/src/docx/watermarkParser.ts
@@ -22,6 +22,8 @@
 
 import type { Watermark } from "../types/document";
 import {
+  cloneWithXmlnsDeclarations,
+  collectXmlnsDeclarations,
   elementToXml,
   findChild,
   findChildren,
@@ -120,48 +122,6 @@ export function parseWatermark(header: XmlElement): ParsedWatermark | undefined 
     }
   }
   return undefined;
-}
-
-/**
- * Collect every `xmlns:*` declaration from a header element's
- * attributes. The serializer's hard-coded root namespaces only cover
- * canonical prefixes (`a`, `w`, `wp`, …); a DOCX that binds an
- * extension namespace to a non-canonical prefix would replay an
- * unbound prefix when the captured paragraph alone is emitted. We
- * carry the source declarations forward onto the captured paragraph
- * so the raw replay is self-contained regardless of prefix choice.
- */
-function collectXmlnsDeclarations(header: XmlElement): Record<string, string> {
-  const out: Record<string, string> = {};
-  const attrs = header.attributes;
-  if (!attrs) {
-    return out;
-  }
-  for (const [key, value] of Object.entries(attrs)) {
-    if ((key === "xmlns" || key.startsWith("xmlns:")) && value !== undefined) {
-      out[key] = String(value);
-    }
-  }
-  return out;
-}
-
-/**
- * Return a shallow clone of `element` whose attributes carry every
- * `xmlns:*` declaration in `xmlnsDecls`. Existing attributes (including
- * any namespace declarations the paragraph already carries) win over
- * the header-level ones.
- */
-function cloneWithXmlnsDeclarations(
-  element: XmlElement,
-  xmlnsDecls: Record<string, string>,
-): XmlElement {
-  if (Object.keys(xmlnsDecls).length === 0) {
-    return element;
-  }
-  return {
-    ...element,
-    attributes: { ...xmlnsDecls, ...element.attributes },
-  };
 }
 
 /**

--- a/packages/core/src/docx/watermarkParser.ts
+++ b/packages/core/src/docx/watermarkParser.ts
@@ -64,6 +64,22 @@ const VML_TEXT_WATERMARK_SHAPETYPE = "#_x0000_t136";
 const VML_PICTURE_WATERMARK_ID_PREFIX = "WordPictureWatermark";
 
 /**
+ * Whether a VML `<v:shape>` is a watermark rather than ordinary inline
+ * imagery. Text watermarks use the WordArt shapetype; picture watermarks
+ * carry a `WordPictureWatermark…` id. The VML image parser uses this to
+ * leave watermark shapes to this module, so a header watermark is not also
+ * rendered as an inline picture.
+ */
+export function isWatermarkShape(shape: XmlElement): boolean {
+  const shapeType = getAttribute(shape, null, "type") ?? "";
+  if (shapeType === VML_TEXT_WATERMARK_SHAPETYPE) {
+    return true;
+  }
+  const shapeId = getAttribute(shape, null, "id") ?? "";
+  return shapeId.startsWith(VML_PICTURE_WATERMARK_ID_PREFIX);
+}
+
+/**
  * Walk a parsed `<w:hdr>` element and return the watermark it carries,
  * or `undefined` when none is present. Scans every candidate shape /
  * anchor in the header so a non-watermark shape (e.g. a logo image)

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -842,3 +842,44 @@ export function findAllDeep(
   search(root);
   return results;
 }
+
+/**
+ * Collect every `xmlns` / `xmlns:*` declaration from an element's attributes.
+ *
+ * The serializer's hard-coded root namespaces only cover canonical prefixes
+ * (`a`, `w`, `wp`, `v`, `o`, …); a DOCX that binds a namespace to a
+ * non-canonical prefix would replay an unbound prefix when a captured subtree
+ * is emitted on its own. Carrying the source declarations forward keeps the
+ * raw replay self-contained regardless of the producer's prefix choice.
+ */
+export function collectXmlnsDeclarations(element: XmlElement): Record<string, string> {
+  const out: Record<string, string> = {};
+  const attrs = element.attributes;
+  if (!attrs) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(attrs)) {
+    if ((key === "xmlns" || key.startsWith("xmlns:")) && value !== undefined) {
+      out[key] = String(value);
+    }
+  }
+  return out;
+}
+
+/**
+ * Return a shallow clone of `element` whose attributes carry every declaration
+ * in `xmlnsDecls`. Existing attributes (including any namespace declarations the
+ * element already carries) win over the injected ones.
+ */
+export function cloneWithXmlnsDeclarations(
+  element: XmlElement,
+  xmlnsDecls: Record<string, string>,
+): XmlElement {
+  if (Object.keys(xmlnsDecls).length === 0) {
+    return element;
+  }
+  return {
+    ...element,
+    attributes: { ...xmlnsDecls, ...element.attributes },
+  };
+}

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -867,6 +867,25 @@ export function collectXmlnsDeclarations(element: XmlElement): Record<string, st
 }
 
 /**
+ * Merge an element's own `xmlns` / `xmlns:*` declarations onto an inherited
+ * in-scope set, returning the accumulated set. Threaded down the ancestor
+ * chain (root -> paragraph -> run -> pict), the element's own declarations
+ * override an inherited binding for the same prefix, matching XML scoping. The
+ * inherited object is not mutated; the same reference is returned unchanged when
+ * the element declares nothing.
+ */
+export function mergeXmlnsDeclarations(
+  inherited: Record<string, string>,
+  element: XmlElement,
+): Record<string, string> {
+  const own = collectXmlnsDeclarations(element);
+  if (Object.keys(own).length === 0) {
+    return inherited;
+  }
+  return { ...inherited, ...own };
+}
+
+/**
  * Return a shallow clone of `element` whose attributes carry every declaration
  * in `xmlnsDecls`. Existing attributes (including any namespace declarations the
  * element already carries) win over the injected ones.


### PR DESCRIPTION
Renders legacy VML `w:pict` inline images (old-format header logos etc.) that folio previously dropped (`runParser.ts` had `case "pict"` sharing a no-op `break`, so the picture never rendered and was lost on re-serialize).

- New `vmlImageParser.ts` (ported from `eigenpal/docx-editor` with attribution): resolves `<v:imagedata r:id>` to the same media part a DrawingML image uses and returns the identical `{ type: "drawing", image, rawXml }` node — so it flows unchanged through `toProseDoc` → `convertImage` → `renderImage`, no painter/layout changes.
- Reuses folio's media resolver (`resolveImageData`) and parses the `<v:shape>` `style="width:..;height:.."` to px → EMU via `pixelsToEmu`.
- **Save is byte-exact:** the drawing node carries `rawXml = elementToXml(pict)`, and the serializer replays it verbatim (folio has no VML synthesis path), so save preserves the original `<w:pict>` rather than converting it. The root serializer already declares `xmlns:v`/`xmlns:o`.
- Watermark de-dup: an `isWatermarkShape` guard prevents a watermark shape from also rendering as an inline picture.
- `w:object` keeps its existing skip (out of scope).

Tests: parse a `width:2in;height:1in` pict → correct EMU size + resolved `data:image/png` src; save preserves the VML (media survives, no `wp:inline`); no-imagedata skipped without throwing; unresolved rel keeps the node and still round-trips.
