### PR TITLE
fix(core): preserve inline content-control sdtPr on save + edit

### DIFF
--- a/packages/core/src/docx/serializer/paragraphSerializer-inlineSdtRawPr.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer-inlineSdtRawPr.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Round-trip guard for inline SDT (`w:sdt`) property fidelity.
+ *
+ * The inline serializer used to re-synthesize `<w:sdtPr>` from the modeled
+ * projection alone, silently dropping every unmodeled OOXML feature (`w:id`,
+ * `w:dataBinding`, `w15:*`, custom XML mappings) and `<w:sdtEndPr>` on save.
+ * These tests lock the fix: the captured raw properties are replayed verbatim
+ * (mirroring the block-SDT serializer), while a modeled interactive edit is
+ * still reconciled into the raw string before replay.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import type { Document, InlineSdt, Paragraph } from "../../types/document";
+import { parseParagraph } from "../paragraphParser";
+import type { XmlElement } from "../xmlParser";
+import { parseXmlDocument } from "../xmlParser";
+import { serializeParagraph } from "./paragraphSerializer";
+
+const W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+const W15_NS = 'xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"';
+
+function parseParagraphXml(xml: string): Paragraph {
+  const root = parseXmlDocument(xml) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  return parseParagraph(root, null, null, null, null, null);
+}
+
+function firstInlineSdt(paragraph: Paragraph): InlineSdt {
+  const sdt = paragraph.content.find((content) => content.type === "inlineSdt");
+  if (sdt?.type !== "inlineSdt") {
+    throw new Error("Expected an inlineSdt in paragraph content");
+  }
+  return sdt;
+}
+
+describe("inline SDT raw-property round-trip", () => {
+  test("preserves unmodeled w:sdtPr features and w:sdtEndPr through parse → serialize → re-parse", () => {
+    const xml =
+      `<w:p ${W_NS} ${W15_NS}>` +
+      "<w:r><w:t>before </w:t></w:r>" +
+      "<w:sdt><w:sdtPr>" +
+      '<w:alias w:val="Party Name"/><w:tag w:val="party"/><w:id w:val="123456789"/>' +
+      '<w:dataBinding w:xpath="/ns0:root/ns0:party" w:storeItemID="{GUID}"/>' +
+      "<w:text/>" +
+      "</w:sdtPr>" +
+      "<w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>" +
+      "<w:sdtContent><w:r><w:t>Acme Corp</w:t></w:r></w:sdtContent>" +
+      "</w:sdt>" +
+      "<w:r><w:t> after</w:t></w:r></w:p>";
+
+    const serialized = serializeParagraph(parseParagraphXml(xml));
+
+    // Unmodeled markers and the end-properties block must survive save.
+    expect(serialized).toContain('<w:id w:val="123456789"/>');
+    expect(serialized).toContain("<w:dataBinding");
+    expect(serialized).toContain('w:xpath="/ns0:root/ns0:party"');
+    expect(serialized).toContain('w:storeItemID="{GUID}"');
+    expect(serialized).toContain("<w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>");
+    expect(serialized).toContain("Acme Corp");
+
+    // Re-parsing the saved XML must recover an equivalent inline SDT: same
+    // inner text, same verbatim raw properties, same modeled projection.
+    const reparsed = firstInlineSdt(
+      parseParagraphXml(
+        `<w:p ${W_NS} ${W15_NS}>${serialized.replace(/^<w:p>/u, "").replace(/<\/w:p>$/u, "")}</w:p>`,
+      ),
+    );
+    expect(reparsed.properties.id).toBe(123456789);
+    expect(reparsed.properties.alias).toBe("Party Name");
+    expect(reparsed.properties.tag).toBe("party");
+    expect(reparsed.properties.rawPropertiesXml).toContain("<w:dataBinding");
+    expect(reparsed.properties.rawEndPropertiesXml).toContain("<w:rPr><w:b/></w:rPr>");
+    const innerText = reparsed.content
+      .flatMap((c) => (c.type === "run" ? c.content : []))
+      .map((rc) => (rc.type === "text" ? rc.text : ""))
+      .join("");
+    expect(innerText).toBe("Acme Corp");
+  });
+
+  test("reconciles a modeled checkbox toggle into the replayed raw properties", () => {
+    const xml =
+      `<w:p ${W_NS} xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+      "<w:sdt><w:sdtPr>" +
+      '<w:tag w:val="agree"/>' +
+      '<w14:checkbox><w14:checked w14:val="0"/></w14:checkbox>' +
+      "</w:sdtPr>" +
+      "<w:sdtContent><w:r><w:t>☐</w:t></w:r></w:sdtContent>" +
+      "</w:sdt></w:p>";
+
+    const paragraph = parseParagraphXml(xml);
+    const sdt = firstInlineSdt(paragraph);
+    expect(sdt.properties.sdtType).toBe("checkbox");
+    expect(sdt.properties.checked).toBe(false);
+
+    // Flip the modeled state (as an interactive checkbox toggle would) and
+    // confirm the replayed raw XML reflects the new value, not the stale one.
+    sdt.properties.checked = true;
+    const serialized = serializeParagraph(paragraph);
+    expect(serialized).toContain('w14:val="1"');
+    expect(serialized).not.toContain('w14:val="0"');
+    // The unmodeled tag inside the raw properties is untouched.
+    expect(serialized).toContain('<w:tag w:val="agree"/>');
+  });
+
+  test("preserves raw w:sdtPr through the full ProseMirror round-trip", () => {
+    const xml =
+      `<w:p ${W_NS}>` +
+      "<w:sdt><w:sdtPr>" +
+      '<w:alias w:val="clause"/><w:id w:val="42"/>' +
+      '<w:dataBinding w:xpath="/root/clause" w:storeItemID="{ABC}"/>' +
+      "<w:text/>" +
+      "</w:sdtPr>" +
+      "<w:sdtContent><w:r><w:t>Value</w:t></w:r></w:sdtContent>" +
+      "</w:sdt></w:p>";
+
+    const paragraph = parseParagraphXml(xml);
+    const baseDocument = {
+      package: { document: { content: [paragraph] } } as Document["package"],
+    } as Document;
+
+    const roundTripped = fromProseDoc(toProseDoc(baseDocument), baseDocument);
+    const rtParagraph = roundTripped.package.document.content.find(
+      (c): c is Paragraph => c.type === "paragraph",
+    );
+    expect(rtParagraph).toBeDefined();
+    if (!rtParagraph) {
+      return;
+    }
+
+    const serialized = serializeParagraph(rtParagraph);
+    expect(serialized).toContain('<w:id w:val="42"/>');
+    expect(serialized).toContain("<w:dataBinding");
+    expect(serialized).toContain('w:xpath="/root/clause"');
+    expect(serialized).toContain("Value");
+  });
+});

--- a/packages/core/src/docx/serializer/paragraphSerializer-inlineSdtRawPr.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer-inlineSdtRawPr.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 
 import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { schema } from "../../prosemirror/schema";
 import type { Document, InlineSdt, Paragraph } from "../../types/document";
 import { parseParagraph } from "../paragraphParser";
 import type { XmlElement } from "../xmlParser";
@@ -137,5 +138,68 @@ describe("inline SDT raw-property round-trip", () => {
     expect(serialized).toContain("<w:dataBinding");
     expect(serialized).toContain('w:xpath="/root/clause"');
     expect(serialized).toContain("Value");
+  });
+});
+
+describe("inline SDT null-default normalization", () => {
+  test("PM null-default attrs never enter the model or the serialized XML", () => {
+    // A control with no id / dropdownLastValue / checked: `toProseDoc`
+    // materializes these as PM null defaults on the `sdt` node.
+    const original: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "inlineSdt",
+          properties: { sdtType: "richText", alias: "x" },
+          content: [{ type: "run", content: [{ type: "text", text: "v" }] }],
+        },
+      ],
+    };
+    const baseDocument = {
+      package: { document: { content: [original] } } as Document["package"],
+    } as Document;
+
+    // Confirm the scenario: the PM `sdt` node really carries null defaults.
+    const pmDoc = toProseDoc(baseDocument);
+    let sdtNode: { attrs: Record<string, unknown> } | undefined;
+    pmDoc.descendants((node) => {
+      if (node.type.name === "sdt") {
+        sdtNode = node;
+        return false;
+      }
+      return true;
+    });
+    expect(sdtNode?.attrs["id"]).toBeNull();
+    expect(sdtNode?.attrs["dropdownLastValue"]).toBeNull();
+    expect(sdtNode?.attrs["checked"]).toBeNull();
+
+    // The null defaults must not survive back into the typed model.
+    const roundTripped = fromProseDoc(pmDoc, baseDocument);
+    const rtParagraph = roundTripped.package.document.content.find(
+      (c): c is Paragraph => c.type === "paragraph",
+    );
+    const sdt = rtParagraph ? firstInlineSdt(rtParagraph) : undefined;
+    expect(sdt?.properties.id).toBeUndefined();
+    expect(sdt?.properties.dropdownLastValue).toBeUndefined();
+    expect(sdt?.properties.checked).toBeUndefined();
+    expect(sdt?.properties.id).not.toBeNull();
+
+    // And no stray `null` reaches the serialized XML (e.g. `<w:id w:val="null"/>`).
+    const serialized = rtParagraph ? serializeParagraph(rtParagraph) : "";
+    expect(serialized).not.toContain("<w:id");
+    expect(serialized).not.toContain("null");
+  });
+
+  test("toDOM omits data-sdt-id when the id is a null default", () => {
+    const toDOM = schema.nodes["sdt"]?.spec.toDOM;
+    expect(toDOM).toBeDefined();
+    if (!toDOM) {
+      return;
+    }
+    const node = schema.node("sdt", {}, undefined);
+    const rendered = toDOM(node) as [string, Record<string, string>, number];
+    const domAttrs = rendered[1];
+    expect("data-sdt-id" in domAttrs).toBe(false);
+    expect(Object.values(domAttrs)).not.toContain("null");
   });
 });

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -733,7 +733,7 @@ function serializeComplexField(field: ComplexField): string {
 function synthesizeInlineSdtPr(props: SdtProperties): string {
   const prParts: string[] = [];
 
-  if (props.id !== undefined) {
+  if (typeof props.id === "number") {
     prParts.push(`<w:id w:val="${props.id}"/>`);
   }
   if (props.alias) {
@@ -871,7 +871,8 @@ function serializeInlineSdt(sdt: InlineSdt): string {
   const dateFullDate =
     props.sdtType === "date" && props.dateValueISO ? props.dateValueISO : undefined;
   const dropdownLastValue =
-    props.sdtType === "dropdown" || props.sdtType === "comboBox"
+    (props.sdtType === "dropdown" || props.sdtType === "comboBox") &&
+    typeof props.dropdownLastValue === "string"
       ? props.dropdownLastValue
       : undefined;
   const sdtPrXml = reconcileRawSdtPr(baseSdtPr, props, {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -29,12 +29,14 @@ import type {
   MoveFromRangeStart,
   MoveToRangeStart,
   ParagraphPropertyChange,
+  SdtProperties,
   TabStop,
   ShadingProperties,
   TextFormatting,
   TrackedChangeInfo,
 } from "../../types/document";
 import { numPrEqual } from "../numberingParser";
+import { reconcileRawSdtPr } from "../sdtPropertiesPatch";
 import { serializeBorder } from "./borderSerializer";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: paragraphs hold runs, shape-textbox runs hold paragraphs
 import { serializeRun, serializeTextFormatting } from "./runSerializer";
@@ -721,12 +723,19 @@ function serializeComplexField(field: ComplexField): string {
 }
 
 /**
- * Serialize an inline SDT (w:sdt)
+ * Synthesize a `<w:sdtPr>` from the modeled {@link SdtProperties}.
+ *
+ * Only reached for an inline SDT that carries no captured `rawPropertiesXml`
+ * (constructed programmatically rather than parsed from a DOCX). Mirrors the
+ * block-SDT fallback: emit `w:id` first so the parsed numeric id survives,
+ * then the shared identity fields, then the type-defining marker.
  */
-function serializeInlineSdt(sdt: InlineSdt): string {
-  const props = sdt.properties;
+function synthesizeInlineSdtPr(props: SdtProperties): string {
   const prParts: string[] = [];
 
+  if (props.id !== undefined) {
+    prParts.push(`<w:id w:val="${props.id}"/>`);
+  }
   if (props.alias) {
     prParts.push(`<w:alias w:val="${escapeXml(props.alias)}"/>`);
   }
@@ -810,6 +819,21 @@ function serializeInlineSdt(sdt: InlineSdt): string {
       break;
   }
 
+  return `<w:sdtPr>${prParts.join("")}</w:sdtPr>`;
+}
+
+/**
+ * Serialize an inline SDT (w:sdt).
+ *
+ * Replays the captured `<w:sdtPr>` / `<w:sdtEndPr>` verbatim so unmodeled
+ * OOXML features (`w:id`, `w:dataBinding`, `w15:*`, custom XML mappings)
+ * survive the round-trip, mirroring the block-SDT serializer. Without this
+ * the properties block was re-synthesized from the modeled projection alone,
+ * silently dropping every unmodeled feature (and `w:sdtEndPr`) on save.
+ */
+function serializeInlineSdt(sdt: InlineSdt): string {
+  const props = sdt.properties;
+
   const contentXml = sdt.content
     .map((item): string => {
       switch (item.type) {
@@ -839,7 +863,24 @@ function serializeInlineSdt(sdt: InlineSdt): string {
     })
     .join("");
 
-  return `<w:sdt><w:sdtPr>${prParts.join("")}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
+  // Reconcile any modeled interactive edit (checkbox toggle, date pick,
+  // dropdown selection) into the raw properties before replay so it is not
+  // discarded, exactly as the block-SDT serializer does. Unmodeled markers
+  // inside the raw string are left untouched.
+  const baseSdtPr = props.rawPropertiesXml ?? synthesizeInlineSdtPr(props);
+  const dateFullDate =
+    props.sdtType === "date" && props.dateValueISO ? props.dateValueISO : undefined;
+  const dropdownLastValue =
+    props.sdtType === "dropdown" || props.sdtType === "comboBox"
+      ? props.dropdownLastValue
+      : undefined;
+  const sdtPrXml = reconcileRawSdtPr(baseSdtPr, props, {
+    ...(dateFullDate !== undefined ? { dateFullDate } : {}),
+    ...(dropdownLastValue !== undefined ? { dropdownLastValue } : {}),
+  });
+  const sdtEndPrXml = props.rawEndPropertiesXml ?? "";
+
+  return `<w:sdt>${sdtPrXml}${sdtEndPrXml}<w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
 }
 
 function serializeMoveRangeStart(

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -540,6 +540,7 @@ export const readSdtAttrs = (node: PMNode): ReadProseMirrorAttrsResult<SdtAttrs>
   requiredOneOf(attrs, "sdtType", "sdt.attrs.sdtType", issues, SDT_TYPE_VALUES);
   optionalString(attrs, "alias", "sdt.attrs.alias", issues);
   optionalString(attrs, "tag", "sdt.attrs.tag", issues);
+  optionalNumber(attrs, "id", "sdt.attrs.id", issues);
   optionalOneOf(attrs, "lock", "sdt.attrs.lock", issues, SDT_LOCK_VALUES);
   optionalString(attrs, "placeholder", "sdt.attrs.placeholder", issues);
   optionalBoolean(attrs, "showingPlaceholder", "sdt.attrs.showingPlaceholder", issues);
@@ -548,6 +549,8 @@ export const readSdtAttrs = (node: PMNode): ReadProseMirrorAttrsResult<SdtAttrs>
   optionalSdtListItems(attrs, "listItems", "sdt.attrs.listItems", issues);
   optionalString(attrs, "dropdownLastValue", "sdt.attrs.dropdownLastValue", issues);
   optionalBoolean(attrs, "checked", "sdt.attrs.checked", issues);
+  optionalString(attrs, "rawPropertiesXml", "sdt.attrs.rawPropertiesXml", issues);
+  optionalString(attrs, "rawEndPropertiesXml", "sdt.attrs.rawEndPropertiesXml", issues);
 
   return attrsResult(attrs, issues);
 };

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1563,6 +1563,9 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   if (attrs.tag) {
     properties.tag = attrs.tag;
   }
+  if (attrs.id !== undefined) {
+    properties.id = attrs.id;
+  }
   if (attrs.lock) {
     properties.lock = attrs.lock;
   }
@@ -1581,8 +1584,17 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   if (attrs.listItems) {
     properties.listItems = parseSdtListItems(attrs.listItems);
   }
+  if (attrs.dropdownLastValue !== undefined) {
+    properties.dropdownLastValue = attrs.dropdownLastValue;
+  }
   if (attrs.checked !== undefined) {
     properties.checked = attrs.checked;
+  }
+  if (attrs.rawPropertiesXml) {
+    properties.rawPropertiesXml = attrs.rawPropertiesXml;
+  }
+  if (attrs.rawEndPropertiesXml) {
+    properties.rawEndPropertiesXml = attrs.rawEndPropertiesXml;
   }
 
   // Extract content from the sdt node's children. OOXML allows runs,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1563,7 +1563,10 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   if (attrs.tag) {
     properties.tag = attrs.tag;
   }
-  if (attrs.id !== undefined) {
+  // `typeof` guards (not `!== undefined`) so a ProseMirror null default can
+  // never enter the `number` / `string` / `boolean`-typed model property,
+  // matching the block-SDT reader (`convertPMBlockSdt`).
+  if (typeof attrs.id === "number") {
     properties.id = attrs.id;
   }
   if (attrs.lock) {
@@ -1584,10 +1587,10 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   if (attrs.listItems) {
     properties.listItems = parseSdtListItems(attrs.listItems);
   }
-  if (attrs.dropdownLastValue !== undefined) {
+  if (typeof attrs.dropdownLastValue === "string") {
     properties.dropdownLastValue = attrs.dropdownLastValue;
   }
-  if (attrs.checked !== undefined) {
+  if (typeof attrs.checked === "boolean") {
     properties.checked = attrs.checked;
   }
   if (attrs.rawPropertiesXml) {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1788,13 +1788,20 @@ function convertInlineSdt(
       sdtType: props.sdtType,
       alias: props.alias ?? null,
       tag: props.tag ?? null,
+      id: props.id ?? null,
       lock: props.lock ?? null,
       placeholder: props.placeholder ?? null,
       showingPlaceholder: props.showingPlaceholder ?? false,
       dateFormat: props.dateFormat ?? null,
       dateValueISO: props.dateValueISO ?? null,
       listItems: props.listItems ? JSON.stringify(props.listItems) : null,
+      dropdownLastValue: props.dropdownLastValue ?? null,
       checked: props.checked ?? null,
+      // Pass the captured `w:sdtPr` / `w:sdtEndPr` through as attrs so the
+      // serializer replays them verbatim after a save, keeping unmodeled
+      // OOXML features lossless — the same contract as `convertBlockSdt`.
+      rawPropertiesXml: props.rawPropertiesXml ?? null,
+      rawEndPropertiesXml: props.rawEndPropertiesXml ?? null,
     },
     inlineNodes.length > 0 ? inlineNodes : undefined,
   );

--- a/packages/core/src/prosemirror/extensions/nodes/SdtExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/SdtExtension.ts
@@ -100,7 +100,7 @@ export const SdtExtension = createNodeExtension({
       if (attrs.tag) {
         dataAttrs["data-tag"] = attrs.tag;
       }
-      if (attrs.id !== undefined) {
+      if (typeof attrs.id === "number") {
         dataAttrs["data-sdt-id"] = String(attrs.id);
       }
       if (attrs.lock) {

--- a/packages/core/src/prosemirror/extensions/nodes/SdtExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/SdtExtension.ts
@@ -22,6 +22,8 @@ export const SdtExtension = createNodeExtension({
       alias: { default: null },
       /** Tag (developer identifier) */
       tag: { default: null },
+      /** Numeric `w:id/@w:val`. */
+      id: { default: null },
       /** Lock setting */
       lock: { default: null },
       /** Placeholder text */
@@ -38,6 +40,13 @@ export const SdtExtension = createNodeExtension({
       dropdownLastValue: { default: null },
       /** Checkbox checked state */
       checked: { default: null },
+      /**
+       * Verbatim `<w:sdtPr>` / `<w:sdtEndPr>` captured by the parser so
+       * unmodeled OOXML features (`w:dataBinding`, `w15:*`, custom XML
+       * mappings) round-trip after a save, mirroring the block-SDT node.
+       */
+      rawPropertiesXml: { default: null },
+      rawEndPropertiesXml: { default: null },
     },
     parseDOM: [
       {
@@ -47,10 +56,13 @@ export const SdtExtension = createNodeExtension({
             return false;
           }
           const el = dom;
+          const idRaw = el.dataset["sdtId"];
+          const id = idRaw ? Number.parseInt(idRaw, 10) : null;
           return {
             sdtType: el.dataset["sdtType"] || "richText",
             alias: el.dataset["alias"] || null,
             tag: el.dataset["tag"] || null,
+            id: id !== null && !Number.isNaN(id) ? id : null,
             lock: el.dataset["lock"] || null,
             placeholder: el.dataset["placeholder"] || null,
             showingPlaceholder: el.dataset["showingPlaceholder"] === "true",
@@ -67,6 +79,10 @@ export const SdtExtension = createNodeExtension({
               }
               return null;
             })(),
+            // Raw XML is preserved on the model, not the DOM; consumers that
+            // round-trip through PM re-attach it from the source.
+            rawPropertiesXml: null,
+            rawEndPropertiesXml: null,
           };
         },
       },
@@ -83,6 +99,9 @@ export const SdtExtension = createNodeExtension({
       }
       if (attrs.tag) {
         dataAttrs["data-tag"] = attrs.tag;
+      }
+      if (attrs.id !== undefined) {
+        dataAttrs["data-sdt-id"] = String(attrs.id);
       }
       if (attrs.lock) {
         dataAttrs["data-lock"] = attrs.lock;

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -338,6 +338,8 @@ export type SdtAttrs = {
   alias?: string;
   /** Tag (developer identifier) */
   tag?: string;
+  /** Numeric `w:id/@w:val`. */
+  id?: number;
   /** Lock setting */
   lock?: NonNullable<SdtProperties["lock"]>;
   /** Placeholder text */
@@ -354,6 +356,10 @@ export type SdtAttrs = {
   dropdownLastValue?: string;
   /** Checkbox checked state */
   checked?: boolean;
+  /** Captured `<w:sdtPr>…</w:sdtPr>` for round-trip replay. */
+  rawPropertiesXml?: string;
+  /** Captured `<w:sdtEndPr>…</w:sdtEndPr>` for round-trip replay. */
+  rawEndPropertiesXml?: string;
 };
 
 /**


### PR DESCRIPTION
Fixes a fidelity/data-loss gap in **inline** content controls (`w:sdt` inside a paragraph): the inner runs round-tripped, but the `sdtPr` did not. Folio's parser captured `rawPropertiesXml`/`rawEndPropertiesXml`/`id`, but `serializeInlineSdt` re-synthesized `<w:sdtPr>` from modeled fields alone — so `w:id`, `w:dataBinding`/`w:xpath`, and `w:sdtEndPr` were **dropped** on save, and also lost through a ProseMirror edit cycle (the inline PM node didn't carry the raw props). Folio's **block**-SDT path already preserves all of this — this was an inline-vs-block parity gap.

- `serializeInlineSdt` now builds `props.rawPropertiesXml ?? synthesizeInlineSdtPr(props)`, runs it through `reconcileRawSdtPr` (so a modeled checkbox/date/dropdown edit still applies), and appends `props.rawEndPropertiesXml` — mirroring the block-SDT serializer. The modeled synthesis stays as the fallback for programmatically-built controls (now also emits `w:id`).
- Threads `id`/`rawPropertiesXml`/`rawEndPropertiesXml` through the inline `SdtAttrs`, `readSdtAttrs`, the `sdt` node schema, `convertInlineSdt`, and `createInlineSdtFromNode`, so raw survives an edit cycle.
- Matches upstream fidelity (no inline sibling-range-marker capture — that's folio's block-only enhancement; upstream omits it inline too). No UI change.

Tests: unmodeled `sdtPr` + `sdtEndPr` survive parse→serialize→re-parse; a modeled checkbox toggle reconciles into the replayed raw while an unmodeled `w:tag` is untouched; raw survives the full PM round-trip.
