### PR TITLE
fix(core): persist numbering-definition edits on save (both paths)

### DIFF
--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -106,16 +106,23 @@ const documentRelsXml = `${XML_DECLARATION}
   <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.numbering}" Target="numbering.xml"/>
 </Relationships>`;
 
-async function createNumberingFixture(): Promise<ArrayBuffer> {
+async function buildDocx(parts: {
+  numberingXml: string;
+  documentXml: string;
+}): Promise<ArrayBuffer> {
   const zip = new JSZip();
   zip.file("[Content_Types].xml", contentTypesXml);
   zip.file("_rels/.rels", packageRelsXml);
   zip.file("word/_rels/document.xml.rels", documentRelsXml);
-  zip.file("word/document.xml", documentXml);
+  zip.file("word/document.xml", parts.documentXml);
   zip.file("word/styles.xml", stylesXml);
-  zip.file("word/numbering.xml", numberingXml);
+  zip.file("word/numbering.xml", parts.numberingXml);
   zip.file("docProps/core.xml", corePropertiesXml);
   return zip.generateAsync({ type: "arraybuffer" });
+}
+
+async function createNumberingFixture(): Promise<ArrayBuffer> {
+  return buildDocx({ numberingXml, documentXml });
 }
 
 async function readPart(buffer: ArrayBuffer, path: string): Promise<string> {
@@ -278,5 +285,128 @@ describe("numbering-definition write path (full repack)", () => {
     expect(await readPart(selective, "word/numbering.xml")).toBe(
       await readPart(full, "word/numbering.xml"),
     );
+  });
+});
+
+// A document referencing a single numbering instance, for the focused fixtures
+// below.
+const singleListDocumentXml = (numId: number) => `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p w14:paraId="C0000001"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">Item</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+describe("numbering-definition write path (newline-formatted opening tags)", () => {
+  // The abstractNum / num opening tags carry a newline before their id
+  // attribute, which is valid XML. The element scanner must treat it as a name
+  // boundary (not a longer-named sibling) or the patch silently no-ops.
+  const newlineNumberingXml =
+    `${XML_DECLARATION}\n` +
+    '<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+    '<w:abstractNum\n    w:abstractNumId="0"><w:multiLevelType w:val="hybridMultilevel"/>' +
+    `<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="${ORIGINAL_LVL_TEXT}"/><w:lvlJc w:val="left"/></w:lvl></w:abstractNum>` +
+    '<w:num\n    w:numId="1"><w:abstractNumId w:val="0"/></w:num>' +
+    "</w:numbering>";
+
+  test("edit persists through both save paths despite newline-formatted tags", async () => {
+    const buffer = await buildDocx({
+      numberingXml: newlineNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+
+    const selectiveDoc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(selectiveDoc, 0, EDITED_LVL_TEXT);
+    const selective = await attemptSelectiveSave(selectiveDoc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(selective).not.toBeNull();
+    if (!selective) {
+      throw new Error("selective save returned null");
+    }
+    expect(levelText(await parseDocx(selective, { preloadFonts: false }), 0)).toBe(EDITED_LVL_TEXT);
+    expect(await readPart(selective, "word/numbering.xml")).toContain(
+      `<w:lvlText w:val="${EDITED_LVL_TEXT}"/>`,
+    );
+
+    const fullDoc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(fullDoc, 0, EDITED_LVL_TEXT);
+    const full = await repackDocx({ ...fullDoc, originalBuffer: buffer });
+    expect(levelText(await parseDocx(full, { preloadFonts: false }), 0)).toBe(EDITED_LVL_TEXT);
+  });
+});
+
+describe("numbering-definition write path (custom / AlternateContent numFmt)", () => {
+  // abstractNum 0 level 0 carries a Word custom number format wrapped in
+  // mc:AlternateContent. folio's model flattens it to a synthetic decimalZero4
+  // it cannot re-emit as valid OOXML, so editing an UNRELATED field (lvlText)
+  // must preserve the original numFmt element rather than write the synthetic.
+  const CUSTOM_ALT_CONTENT =
+    '<mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">' +
+    '<mc:Choice Requires="w14"><w:numFmt w:val="custom" w:format="0001, 0002, 0003"/></mc:Choice>' +
+    '<mc:Fallback><w:numFmt w:val="decimal"/></mc:Fallback></mc:AlternateContent>';
+  const customNumberingXml =
+    `${XML_DECLARATION}\n` +
+    '<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+    'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" ' +
+    'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">' +
+    '<w:abstractNum w:abstractNumId="0"><w:multiLevelType w:val="hybridMultilevel"/>' +
+    `<w:lvl w:ilvl="0"><w:start w:val="1"/>${CUSTOM_ALT_CONTENT}<w:lvlText w:val="${ORIGINAL_LVL_TEXT}"/><w:lvlJc w:val="left"/></w:lvl></w:abstractNum>` +
+    '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>' +
+    "</w:numbering>";
+
+  const expectCustomFormatSurvives = async (saved: ArrayBuffer): Promise<void> => {
+    const savedNumberingXml = await readPart(saved, "word/numbering.xml");
+    // The original custom numFmt element is preserved verbatim...
+    expect(savedNumberingXml).toContain(CUSTOM_ALT_CONTENT);
+    // ...and no synthetic (non-OOXML) value leaked into the saved file.
+    expect(savedNumberingXml).not.toContain("decimalZero4");
+    // The edit landed and the format still round-trips to the synthetic model value.
+    expect(savedNumberingXml).toContain(`<w:lvlText w:val="${EDITED_LVL_TEXT}"/>`);
+    const reparsed = await parseDocx(saved, { preloadFonts: false });
+    expect(levelText(reparsed, 0)).toBe(EDITED_LVL_TEXT);
+    const level = reparsed.package.numbering?.abstractNums
+      .find((a) => a.abstractNumId === 0)
+      ?.levels.find((l) => l.ilvl === 0);
+    expect(level?.numFmt).toBe("decimalZero4");
+  };
+
+  test("selective save preserves the custom format when a different field is edited", async () => {
+    const buffer = await buildDocx({
+      numberingXml: customNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    // Sanity: the model flattened the custom format to the synthetic value.
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const level = doc.package.numbering?.abstractNums
+      .find((a) => a.abstractNumId === 0)
+      ?.levels.find((l) => l.ilvl === 0);
+    expect(level?.numFmt).toBe("decimalZero4");
+
+    editFirstLevelText(doc, 0, EDITED_LVL_TEXT);
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+    await expectCustomFormatSurvives(result);
+  });
+
+  test("full repack preserves the custom format when a different field is edited", async () => {
+    const buffer = await buildDocx({
+      numberingXml: customNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(doc, 0, EDITED_LVL_TEXT);
+    const result = await repackDocx({ ...doc, originalBuffer: buffer });
+    await expectCustomFormatSurvives(result);
   });
 });

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Round-trip tests for the numbering-definition write path.
+ *
+ * Parses a DOCX carrying a `word/numbering.xml` with two abstract numberings
+ * (plus a `w:numPicBullet` and `w:nsid`/`w:tmpl` the model does NOT represent),
+ * mutates one numbering definition in the model, saves through BOTH save paths,
+ * re-parses, and asserts:
+ * - the edited definition persists on save, and
+ * - the UNEDITED definition plus the model-omitted parts (numPicBullet, the
+ *   untouched abstractNum's nsid/tmpl) and every other package part stay
+ *   byte-exact.
+ *
+ * Sibling of the footnote/endnote body write path (see noteSave.test.ts): a
+ * save that changes only a body paragraph must leave numbering.xml verbatim.
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { Document } from "../types/document";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx } from "./rezip";
+import { attemptSelectiveSave } from "./selectiveSave";
+
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+// Numbering ids used by the fixture. `EDITED_ABSTRACT_ID` is the definition the
+// tests mutate; `UNTOUCHED_ABSTRACT_ID` must survive byte-exact.
+const EDITED_ABSTRACT_ID = 0;
+const UNTOUCHED_ABSTRACT_ID = 1;
+const EDITED_NUM_ID = 1;
+
+const ORIGINAL_LVL_TEXT = "%1.";
+const EDITED_LVL_TEXT = "%1)";
+
+// A picture-bullet definition and per-abstractNum nsid/tmpl — none of which the
+// model represents. They must round-trip verbatim through both save paths.
+const NUM_PIC_BULLET =
+  '<w:numPicBullet w:numPicBulletId="0"><w:pict><v:shape id="_x0000_i1025" style="width:9pt;height:9pt"/></w:pict></w:numPicBullet>';
+const UNTOUCHED_ABSTRACT =
+  `<w:abstractNum w:abstractNumId="${UNTOUCHED_ABSTRACT_ID}" w15:restartNumberingAfterBreak="0">` +
+  '<w:nsid w:val="1A2B3C4D"/><w:multiLevelType w:val="hybridMultilevel"/><w:tmpl w:val="0409000F"/>' +
+  '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="bullet"/><w:lvlText w:val="•"/>' +
+  '<w:lvlJc w:val="left"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr>' +
+  '<w:rPr><w:rFonts w:ascii="Symbol" w:hAnsi="Symbol" w:hint="default"/></w:rPr></w:lvl></w:abstractNum>';
+// The edited abstractNum also carries nsid/tmpl the model omits; editing it
+// re-emits it from the model (the documented safe-subset), so those are lost on
+// the CHANGED definition only — the assertions below check the untouched one.
+const EDITED_ABSTRACT =
+  `<w:abstractNum w:abstractNumId="${EDITED_ABSTRACT_ID}" w15:restartNumberingAfterBreak="0">` +
+  '<w:nsid w:val="0F1E2D3C"/><w:multiLevelType w:val="hybridMultilevel"/><w:tmpl w:val="04090001"/>' +
+  `<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="${ORIGINAL_LVL_TEXT}"/>` +
+  '<w:lvlJc w:val="left"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>';
+
+const numberingXml =
+  `${XML_DECLARATION}\n` +
+  '<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" ' +
+  'xmlns:v="urn:schemas-microsoft-com:vml">' +
+  NUM_PIC_BULLET +
+  EDITED_ABSTRACT +
+  UNTOUCHED_ABSTRACT +
+  `<w:num w:numId="${EDITED_NUM_ID}"><w:abstractNumId w:val="${EDITED_ABSTRACT_ID}"/></w:num>` +
+  `<w:num w:numId="2"><w:abstractNumId w:val="${UNTOUCHED_ABSTRACT_ID}"/></w:num>` +
+  "</w:numbering>";
+
+const BODY_PARA_ID = "B0000001";
+const documentXml = `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p w14:paraId="${BODY_PARA_ID}"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${EDITED_NUM_ID}"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">First item</w:t></w:r></w:p>
+    <w:p w14:paraId="B0000002"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">Bullet item</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const stylesXml = `${XML_DECLARATION}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`;
+
+const corePropertiesXml = `${XML_DECLARATION}
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dcterms:modified xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00.000Z</dcterms:modified>
+</cp:coreProperties>`;
+
+const contentTypesXml = `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+</Types>`;
+
+const packageRelsXml = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+</Relationships>`;
+
+const documentRelsXml = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.numbering}" Target="numbering.xml"/>
+</Relationships>`;
+
+async function createNumberingFixture(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypesXml);
+  zip.file("_rels/.rels", packageRelsXml);
+  zip.file("word/_rels/document.xml.rels", documentRelsXml);
+  zip.file("word/document.xml", documentXml);
+  zip.file("word/styles.xml", stylesXml);
+  zip.file("word/numbering.xml", numberingXml);
+  zip.file("docProps/core.xml", corePropertiesXml);
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+async function readPart(buffer: ArrayBuffer, path: string): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(path);
+  if (!file) {
+    throw new Error(`No ${path} in package`);
+  }
+  return file.async("text");
+}
+
+function editFirstLevelText(doc: Document, abstractNumId: number, newText: string): void {
+  const abstractNum = doc.package.numbering?.abstractNums.find(
+    (a) => a.abstractNumId === abstractNumId,
+  );
+  const level = abstractNum?.levels.find((l) => l.ilvl === 0);
+  if (!level) {
+    throw new Error(`expected level 0 on abstractNum ${abstractNumId}`);
+  }
+  level.lvlText = newText;
+}
+
+function levelText(doc: Document, abstractNumId: number): string | undefined {
+  return doc.package.numbering?.abstractNums
+    .find((a) => a.abstractNumId === abstractNumId)
+    ?.levels.find((l) => l.ilvl === 0)?.lvlText;
+}
+
+describe("numbering-definition write path (selective save)", () => {
+  test("edited numbering definition persists; untouched definition + omitted parts stay byte-exact", async () => {
+    const buffer = await createNumberingFixture();
+    const originalDocumentXml = await readPart(buffer, "word/document.xml");
+    const originalStylesXml = await readPart(buffer, "word/styles.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(doc, EDITED_ABSTRACT_ID, EDITED_LVL_TEXT);
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+
+    // The edit round-trips through re-parse.
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(levelText(reparsed, EDITED_ABSTRACT_ID)).toBe(EDITED_LVL_TEXT);
+
+    // Other parts are untouched.
+    expect(await readPart(result, "word/document.xml")).toBe(originalDocumentXml);
+    expect(await readPart(result, "word/styles.xml")).toBe(originalStylesXml);
+
+    // Within numbering.xml: the edit landed, the old marker is gone, and the
+    // untouched definition + the model-omitted picture bullet stay byte-exact.
+    const savedNumberingXml = await readPart(result, "word/numbering.xml");
+    expect(savedNumberingXml).toContain(`<w:lvlText w:val="${EDITED_LVL_TEXT}"/>`);
+    expect(savedNumberingXml).not.toContain(`<w:lvlText w:val="${ORIGINAL_LVL_TEXT}"/>`);
+    expect(savedNumberingXml).toContain(UNTOUCHED_ABSTRACT);
+    expect(savedNumberingXml).toContain(NUM_PIC_BULLET);
+  });
+
+  test("a body-only edit leaves numbering.xml byte-exact", async () => {
+    const buffer = await createNumberingFixture();
+    const originalNumberingXml = await readPart(buffer, "word/numbering.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const bodyPara = doc.package.document.content[0];
+    if (!bodyPara || bodyPara.type !== "paragraph") {
+      throw new Error("expected a body paragraph");
+    }
+    for (const item of bodyPara.content) {
+      if (item.type === "run") {
+        for (const runContent of item.content) {
+          if (runContent.type === "text") {
+            runContent.text = "First item edited";
+          }
+        }
+      }
+    }
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set([BODY_PARA_ID]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+
+    // numbering.xml is never touched by a body-only edit.
+    expect(await readPart(result, "word/numbering.xml")).toBe(originalNumberingXml);
+    expect(await readPart(result, "word/document.xml")).toContain("First item edited");
+  });
+});
+
+describe("numbering-definition write path (full repack)", () => {
+  test("edited numbering definition persists through repackDocx; untouched parts intact", async () => {
+    const buffer = await createNumberingFixture();
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(doc, EDITED_ABSTRACT_ID, EDITED_LVL_TEXT);
+
+    const result = await repackDocx(doc);
+
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(levelText(reparsed, EDITED_ABSTRACT_ID)).toBe(EDITED_LVL_TEXT);
+
+    const savedNumberingXml = await readPart(result, "word/numbering.xml");
+    expect(savedNumberingXml).toContain(`<w:lvlText w:val="${EDITED_LVL_TEXT}"/>`);
+    expect(savedNumberingXml).not.toContain(`<w:lvlText w:val="${ORIGINAL_LVL_TEXT}"/>`);
+    expect(savedNumberingXml).toContain(UNTOUCHED_ABSTRACT);
+    expect(savedNumberingXml).toContain(NUM_PIC_BULLET);
+  });
+
+  test("a repack with no numbering edit leaves numbering.xml byte-exact", async () => {
+    const buffer = await createNumberingFixture();
+    const originalNumberingXml = await readPart(buffer, "word/numbering.xml");
+
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const result = await repackDocx(doc);
+
+    // Byte-exact preservation includes the parts the model does not represent:
+    // an unedited numbering is never re-serialized, so numPicBullet, nsid, and
+    // tmpl all survive even though the model drops them.
+    const savedNumberingXml = await readPart(result, "word/numbering.xml");
+    expect(savedNumberingXml).toBe(originalNumberingXml);
+    expect(savedNumberingXml).toContain(NUM_PIC_BULLET);
+    expect(savedNumberingXml).toContain('<w:tmpl w:val="04090001"/>');
+
+    // The definitions still round-trip unchanged.
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(levelText(reparsed, EDITED_ABSTRACT_ID)).toBe(ORIGINAL_LVL_TEXT);
+  });
+
+  test("selective and full repack produce the same numbering.xml after an edit", async () => {
+    const buffer = await createNumberingFixture();
+
+    const docForSelective = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(docForSelective, EDITED_ABSTRACT_ID, EDITED_LVL_TEXT);
+    const selective = await attemptSelectiveSave(docForSelective, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(selective).not.toBeNull();
+    if (!selective) {
+      throw new Error("selective save returned null");
+    }
+
+    const docForFull = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(docForFull, EDITED_ABSTRACT_ID, EDITED_LVL_TEXT);
+    const full = await repackDocx({ ...docForFull, originalBuffer: buffer });
+
+    expect(await readPart(selective, "word/numbering.xml")).toBe(
+      await readPart(full, "word/numbering.xml"),
+    );
+  });
+});

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -534,3 +534,63 @@ describe("numbering-definition write path (ancestor-scoped xmlns on restored num
     await expectSelfContainedFormat(result);
   });
 });
+
+describe("numbering-definition write path (non-w: prefix graceful degradation)", () => {
+  // numbering.xml binds the WordprocessingML namespace to a non-conventional
+  // prefix (`wp:`). The splice matches definitions by the literal `w:` prefix,
+  // so it finds nothing to splice: the edit is not applied, but the part is left
+  // byte-exact verbatim (no corruption / malformed output on either save path).
+  // Real Word always uses `w:`; this only guards the pathological input.
+  const WML_URI = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+  const altPrefixNumberingXml =
+    `${XML_DECLARATION}\n` +
+    `<wp:numbering xmlns:wp="${WML_URI}">` +
+    '<wp:abstractNum wp:abstractNumId="0"><wp:multiLevelType wp:val="hybridMultilevel"/>' +
+    `<wp:lvl wp:ilvl="0"><wp:start wp:val="1"/><wp:numFmt wp:val="decimal"/><wp:lvlText wp:val="${ORIGINAL_LVL_TEXT}"/><wp:lvlJc wp:val="left"/></wp:lvl></wp:abstractNum>` +
+    '<wp:num wp:numId="1"><wp:abstractNumId wp:val="0"/></wp:num>' +
+    "</wp:numbering>";
+
+  const expectNumberingByteExact = async (saved: ArrayBuffer, original: string): Promise<void> => {
+    // The alt-prefix part is left verbatim (edit not applied, nothing corrupted).
+    expect(await readPart(saved, "word/numbering.xml")).toBe(original);
+    // And the saved document still parses.
+    await expect(parseDocx(saved, { preloadFonts: false })).resolves.toBeDefined();
+  };
+
+  // The parser resolves element/attribute NAMES by local name, so the abstract
+  // numbering still populates from the `wp:` part; change a modeled field so the
+  // write path attempts a splice, then finds no `<w:abstractNum` to match.
+  const forceModelChange = (doc: Document): void => {
+    const abstractNum = doc.package.numbering?.abstractNums[0];
+    if (!abstractNum) {
+      throw new Error("expected the parser to populate at least one abstractNum");
+    }
+    abstractNum.multiLevelType = "multilevel";
+  };
+
+  test("edit degrades to a byte-exact no-op on both save paths", async () => {
+    const buffer = await buildDocx({
+      numberingXml: altPrefixNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    const originalNumberingXml = await readPart(buffer, "word/numbering.xml");
+
+    const selectiveDoc = await parseDocx(buffer, { preloadFonts: false });
+    forceModelChange(selectiveDoc);
+    const selective = await attemptSelectiveSave(selectiveDoc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(selective).not.toBeNull();
+    if (!selective) {
+      throw new Error("selective save returned null");
+    }
+    await expectNumberingByteExact(selective, originalNumberingXml);
+
+    const fullDoc = await parseDocx(buffer, { preloadFonts: false });
+    forceModelChange(fullDoc);
+    const full = await repackDocx({ ...fullDoc, originalBuffer: buffer });
+    await expectNumberingByteExact(full, originalNumberingXml);
+  });
+});

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -409,6 +409,63 @@ describe("numbering-definition write path (custom / AlternateContent numFmt)", (
     const result = await repackDocx({ ...doc, originalBuffer: buffer });
     await expectCustomFormatSurvives(result);
   });
+
+  // A genuine format edit (decimalZero4 -> decimalZero5) must NOT be reverted to
+  // the original element, and must never emit the non-OOXML synthetic literal.
+  const editLevelNumFmt = (doc: Document, numFmt: "decimalZero5"): void => {
+    const level = doc.package.numbering?.abstractNums
+      .find((a) => a.abstractNumId === 0)
+      ?.levels.find((l) => l.ilvl === 0);
+    if (!level) {
+      throw new Error("expected level 0 on abstractNum 0");
+    }
+    level.numFmt = numFmt;
+  };
+
+  const expectWidthChangedToFive = async (saved: ArrayBuffer): Promise<void> => {
+    const savedNumberingXml = await readPart(saved, "word/numbering.xml");
+    // The NEW width (5) is emitted as a valid OOXML custom format...
+    expect(savedNumberingXml).toContain('<w:numFmt w:val="custom" w:format="00001"/>');
+    // ...not the synthetic literal, and not the original width-4 format.
+    expect(savedNumberingXml).not.toContain("decimalZero5");
+    expect(savedNumberingXml).not.toContain("0001, 0002, 0003");
+    // It round-trips to the edited synthetic value.
+    const reparsed = await parseDocx(saved, { preloadFonts: false });
+    const level = reparsed.package.numbering?.abstractNums
+      .find((a) => a.abstractNumId === 0)
+      ?.levels.find((l) => l.ilvl === 0);
+    expect(level?.numFmt).toBe("decimalZero5");
+  };
+
+  test("selective save honors an intentional synthetic width change (4 -> 5)", async () => {
+    const buffer = await buildDocx({
+      numberingXml: customNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editLevelNumFmt(doc, "decimalZero5");
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+    await expectWidthChangedToFive(result);
+  });
+
+  test("full repack honors an intentional synthetic width change (4 -> 5)", async () => {
+    const buffer = await buildDocx({
+      numberingXml: customNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editLevelNumFmt(doc, "decimalZero5");
+    const result = await repackDocx({ ...doc, originalBuffer: buffer });
+    await expectWidthChangedToFive(result);
+  });
 });
 
 describe("numbering-definition write path (ancestor-scoped xmlns on restored numFmt)", () => {

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -410,3 +410,70 @@ describe("numbering-definition write path (custom / AlternateContent numFmt)", (
     await expectCustomFormatSurvives(result);
   });
 });
+
+describe("numbering-definition write path (ancestor-scoped xmlns on restored numFmt)", () => {
+  // The custom format's `mc:` prefix (and the `w14` its Choice requires) are
+  // declared on the w:abstractNum ancestor, NOT the numbering root. Re-emitting
+  // the definition drops those ancestor declarations, so the restored numFmt
+  // element must carry them or the saved part has an undefined prefix.
+  const MC_URI = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+  const W14_URI = "http://schemas.microsoft.com/office/word/2010/wordml";
+  const SCOPED_ALT_CONTENT =
+    "<mc:AlternateContent>" +
+    '<mc:Choice Requires="w14"><w:numFmt w:val="custom" w:format="0001, 0002, 0003"/></mc:Choice>' +
+    '<mc:Fallback><w:numFmt w:val="decimal"/></mc:Fallback></mc:AlternateContent>';
+  const scopedNumberingXml =
+    `${XML_DECLARATION}\n` +
+    '<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+    `<w:abstractNum w:abstractNumId="0" xmlns:mc="${MC_URI}" xmlns:w14="${W14_URI}">` +
+    '<w:multiLevelType w:val="hybridMultilevel"/>' +
+    `<w:lvl w:ilvl="0"><w:start w:val="1"/>${SCOPED_ALT_CONTENT}<w:lvlText w:val="${ORIGINAL_LVL_TEXT}"/><w:lvlJc w:val="left"/></w:lvl></w:abstractNum>` +
+    '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>' +
+    "</w:numbering>";
+
+  const expectSelfContainedFormat = async (saved: ArrayBuffer): Promise<void> => {
+    const savedNumberingXml = await readPart(saved, "word/numbering.xml");
+    // The restored numFmt element now declares the prefixes its ancestor used,
+    // so no dangling mc:/w14 prefix survives in the saved part.
+    expect(savedNumberingXml).toContain(`<mc:AlternateContent xmlns:mc="${MC_URI}"`);
+    expect(savedNumberingXml).toContain(`xmlns:w14="${W14_URI}"`);
+    expect(savedNumberingXml).not.toContain("decimalZero4");
+    expect(savedNumberingXml).toContain(`<w:lvlText w:val="${EDITED_LVL_TEXT}"/>`);
+    const reparsed = await parseDocx(saved, { preloadFonts: false });
+    expect(levelText(reparsed, 0)).toBe(EDITED_LVL_TEXT);
+    const level = reparsed.package.numbering?.abstractNums
+      .find((a) => a.abstractNumId === 0)
+      ?.levels.find((l) => l.ilvl === 0);
+    expect(level?.numFmt).toBe("decimalZero4");
+  };
+
+  test("selective save makes the restored custom format self-contained", async () => {
+    const buffer = await buildDocx({
+      numberingXml: scopedNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(doc, 0, EDITED_LVL_TEXT);
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("selective save returned null");
+    }
+    await expectSelfContainedFormat(result);
+  });
+
+  test("full repack makes the restored custom format self-contained", async () => {
+    const buffer = await buildDocx({
+      numberingXml: scopedNumberingXml,
+      documentXml: singleListDocumentXml(1),
+    });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    editFirstLevelText(doc, 0, EDITED_LVL_TEXT);
+    const result = await repackDocx({ ...doc, originalBuffer: buffer });
+    await expectSelfContainedFormat(result);
+  });
+});

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -37,8 +37,15 @@ import type { Document, Watermark } from "../types/document";
 import { applyReplyThreadMarkers } from "./commentReplyMarkers";
 import { parseEndnotes, parseFootnotes } from "./footnoteParser";
 import { assertValidFolioDocumentModel } from "./modelValidation";
+import { parseNumbering } from "./numberingParser";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
-import { buildPatchedNoteXml, collectParaIds, extractParagraphXml } from "./selectiveXmlPatch";
+import {
+  buildPatchedNoteXml,
+  buildPatchedNumberingXml,
+  collectChangedNumberingDefs,
+  collectParaIds,
+  extractParagraphXml,
+} from "./selectiveXmlPatch";
 import {
   ensureThreadedCommentParaIds,
   serializeComments,
@@ -47,6 +54,7 @@ import {
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
+import { serializeNumberingXml } from "./serializer/numberingSerializer";
 import { escapeXml } from "./serializer/xmlUtils";
 import { isPreservableDocxEntry } from "./unzip";
 import type { RawDocxContent } from "./unzip";
@@ -754,6 +762,10 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
   // unedited notes stay byte-exact).
   await serializeNotesToZip(exportDocument, originalZip, newZip, compressionLevel);
 
+  // Splice edited numbering definitions back into word/numbering.xml (untouched
+  // definitions and the parts the model omits stay byte-exact).
+  await serializeNumberingIntoZip(exportDocument, originalZip, newZip, compressionLevel);
+
   // Serialize comments
   await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
 
@@ -864,6 +876,10 @@ export async function repackDocxFromRaw(
   // Splice edited footnote/endnote bodies back into their parts (separators and
   // unedited notes stay byte-exact).
   await serializeNotesToZip(exportDocument, rawContent.originalZip, newZip, compressionLevel);
+
+  // Splice edited numbering definitions back into word/numbering.xml (untouched
+  // definitions and the parts the model omits stay byte-exact).
+  await serializeNumberingIntoZip(exportDocument, rawContent.originalZip, newZip, compressionLevel);
 
   // Serialize comments
   await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
@@ -1697,6 +1713,52 @@ async function serializeNotesToZip(
       compressionLevel,
     );
   }
+}
+
+/**
+ * Write edited numbering definitions into word/numbering.xml.
+ *
+ * Like the note parts, numbering.xml is preserved verbatim by the copy loop:
+ * the model does not faithfully retain it (abstractNums drop `w:nsid`/`w:tmpl`,
+ * custom number formats collapse, level `w:pPr`/`w:rPr` keep only a subset), so
+ * re-emitting the whole part would lose those pieces. Instead each edited
+ * `w:abstractNum` / `w:num` is spliced by id into the ORIGINAL part.
+ *
+ * Full repack has no change-tracking signal, so "edited" is detected by
+ * comparing the model's numbering serialization against a BASELINE that
+ * re-parses and re-serializes the original part. Both go through the same
+ * (lossy) parse+serialize, so an unedited definition matches its baseline and
+ * is left byte-exact; only a genuine definition edit differs and is spliced.
+ */
+async function serializeNumberingIntoZip(
+  doc: Document,
+  originalZip: JSZip,
+  newZip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const numbering = doc.package.numbering;
+  if (!numbering || (numbering.abstractNums.length === 0 && numbering.nums.length === 0)) {
+    return;
+  }
+  const file = findNotePartEntry(originalZip, "word/numbering.xml");
+  if (!file) {
+    return;
+  }
+  const originalXml = await file.async("text");
+  const baselineXml = serializeNumberingXml(parseNumbering(originalXml).definitions);
+  const currentXml = serializeNumberingXml(numbering);
+  const changed = collectChangedNumberingDefs(baselineXml, currentXml);
+  if (changed.abstractNums.size === 0 && changed.nums.size === 0) {
+    return;
+  }
+  const patched = buildPatchedNumberingXml(originalXml, currentXml, changed);
+  if (patched === null) {
+    return;
+  }
+  newZip.file(file.name, patched, {
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
 }
 
 async function patchNotePartIntoZip(

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -14,6 +14,7 @@ import type { Document, BlockContent, Comment } from "../types/document";
 import { parseCommentsExtended, type CommentExtendedInfo } from "./commentParser";
 import { hasUnsynthesizedReplyRanges } from "./commentReplyMarkers";
 import { validateFolioDocumentModel } from "./modelValidation";
+import { parseNumbering } from "./numberingParser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import {
   applyUpdatesToZip,
@@ -29,7 +30,13 @@ import {
   addCommentsExtendedRelationship,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
-import { buildPatchedDocumentXml, buildPatchedNoteXml, collectParaIds } from "./selectiveXmlPatch";
+import {
+  buildPatchedDocumentXml,
+  buildPatchedNoteXml,
+  buildPatchedNumberingXml,
+  collectChangedNumberingDefs,
+  collectParaIds,
+} from "./selectiveXmlPatch";
 import {
   ensureThreadedCommentParaIds,
   serializeComments,
@@ -37,6 +44,7 @@ import {
 } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
+import { serializeNumberingXml } from "./serializer/numberingSerializer";
 
 const SYNTHETIC_IMAGE_RID_PREFIX = "rId_img_";
 
@@ -288,6 +296,58 @@ async function ensureCommentsExtendedPackaging(
   return true;
 }
 
+/**
+ * Splice edited numbering definitions into word/numbering.xml when the model's
+ * numbering differs from the original part.
+ *
+ * Numbering definitions carry no `paraId`, so this is NOT keyed off
+ * `changedParaIds` — it always runs (like the comments/header updates) and uses
+ * a re-parse+re-serialize baseline to detect which `w:abstractNum` / `w:num`
+ * definitions actually changed. The model omits parts of numbering.xml
+ * (`w:nsid`/`w:tmpl`, custom formats, level sub-elements), so only the changed
+ * definitions are spliced by id; every other definition stays byte-exact.
+ *
+ * Any absent numbering part, unchanged numbering, or unsplittable edit leaves
+ * the original part untouched — the file is simply not added to `updates`.
+ */
+async function patchNumberingPart(
+  zip: JSZip,
+  doc: Document,
+  updates: Map<string, string>,
+): Promise<void> {
+  const numbering = doc.package.numbering;
+  if (!numbering || (numbering.abstractNums.length === 0 && numbering.nums.length === 0)) {
+    return;
+  }
+
+  const conventionalLowerPath = "word/numbering.xml";
+  let file = zip.file(conventionalLowerPath);
+  if (!file) {
+    for (const [path, entry] of Object.entries(zip.files)) {
+      if (!entry.dir && path.toLowerCase() === conventionalLowerPath) {
+        file = entry;
+        break;
+      }
+    }
+  }
+  if (!file) {
+    return;
+  }
+
+  const originalXml = await file.async("text");
+  const baselineXml = serializeNumberingXml(parseNumbering(originalXml).definitions);
+  const currentXml = serializeNumberingXml(numbering);
+  const changed = collectChangedNumberingDefs(baselineXml, currentXml);
+  if (changed.abstractNums.size === 0 && changed.nums.size === 0) {
+    return;
+  }
+  const patched = buildPatchedNumberingXml(originalXml, currentXml, changed);
+  if (patched === null) {
+    return;
+  }
+  updates.set(file.name, patched);
+}
+
 export type SelectiveSaveOptions = {
   /** Changed paragraph IDs to selectively patch */
   changedParaIds: Set<string>;
@@ -464,6 +524,11 @@ export async function attemptSelectiveSave(
     if (!(await patchCommentsExtended(zip, comments, updates))) {
       return null;
     }
+
+    // Splice edited numbering definitions into word/numbering.xml. Numbering
+    // carries no paraId, so this always runs and self-detects changes (like the
+    // comments/header updates above); a no-op when numbering is unchanged.
+    await patchNumberingPart(zip, doc, updates);
 
     // Serialize modified headers/footers
     for (const [path, xml] of headerFooterUpdates) {

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -483,6 +483,15 @@ function collectElementIds(xml: string, openLiteral: string, idAttr: string): Ma
 
 type NumberingElementKind = "abstractNum" | "num";
 
+// LIMITATION: these matchers assume the WordprocessingML namespace is bound to
+// the conventional `w:` prefix (as the folio serializers themselves always
+// emit). numbering.xml could in theory bind it to a different prefix (e.g.
+// `<wp:abstractNum>`); real Word never does. On such a part the splice simply
+// finds nothing to match, so `buildPatchedNumberingXml` returns null and both
+// save paths leave numbering.xml byte-exact verbatim — the edit is not applied,
+// but there is no corruption or malformed output. Making this prefix-agnostic
+// would also require every folio serializer to emit the document's actual
+// prefix, which is out of proportion for an input that never occurs in practice.
 const NUMBERING_OPEN_LITERAL: Record<NumberingElementKind, string> = {
   abstractNum: "<w:abstractNum",
   num: "<w:num",

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -599,6 +599,45 @@ function reconstructCustomNumFmt(width: string): string {
 }
 
 /**
+ * Collect the `xmlns` / `xmlns:*` declarations from an element's opening tag
+ * (the substring up to its first `>`).
+ */
+function collectXmlnsFromOpeningTag(elementXml: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const tagEnd = elementXml.indexOf(">");
+  const openTag = tagEnd === -1 ? elementXml : elementXml.slice(0, tagEnd);
+  const pattern = /\s(?<name>xmlns(?::[\w.-]+)?)="(?<uri>[^"]*)"/gu;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(openTag)) !== null) {
+    // SAFETY: named groups `name`/`uri` present when the regex matches
+    out[match.groups!["name"]!] = match.groups!["uri"]!;
+  }
+  return out;
+}
+
+/**
+ * Carry the given `xmlns` declarations onto `fragmentXml`'s root element so it
+ * resolves every prefix even after the ancestor that declared them is replaced.
+ * Declarations the fragment already carries win (mirrors the VML
+ * `cloneWithXmlnsDeclarations` self-contained-clone behaviour, in the string
+ * domain the byte-exact splice needs).
+ */
+function withXmlnsDeclarations(fragmentXml: string, xmlnsDecls: Record<string, string>): string {
+  const own = collectXmlnsFromOpeningTag(fragmentXml);
+  const additions = Object.entries(xmlnsDecls)
+    .filter(([name]) => !(name in own))
+    .map(([name, uri]) => ` ${name}="${uri}"`);
+  if (additions.length === 0) {
+    return fragmentXml;
+  }
+  let nameEnd = 1; // skip the opening "<"
+  while (nameEnd < fragmentXml.length && !isXmlNameBoundary(fragmentXml[nameEnd])) {
+    nameEnd += 1;
+  }
+  return fragmentXml.slice(0, nameEnd) + additions.join("") + fragmentXml.slice(nameEnd);
+}
+
+/**
  * Swap each synthetic `decimalZero{3,4,5}` numFmt in a re-serialized definition
  * back to the original level's number-format element.
  *
@@ -641,8 +680,20 @@ function restoreLevelNumFmts(originalDefXml: string, currentDefXml: string): str
       ilvl,
     );
     const original = origLevel ? extractLevelNumFmtElement(origLevel) : null;
-    // SAFETY: named group `width` present because SYNTHETIC_NUM_FMT_PATTERN matched
-    const replacement = original ?? reconstructCustomNumFmt(synthetic.groups!["width"]!);
+    let replacement: string;
+    if (original && origLevel) {
+      // The restored element (e.g. mc:AlternateContent) may use a prefix bound
+      // on the replaced ancestors (w:abstractNum / w:lvl) instead of the
+      // numbering root; carry those declarations onto it so it stays resolvable.
+      const ancestorXmlns = {
+        ...collectXmlnsFromOpeningTag(originalDefXml),
+        ...collectXmlnsFromOpeningTag(origLevel),
+      };
+      replacement = withXmlnsDeclarations(original, ancestorXmlns);
+    } else {
+      // SAFETY: named group `width` present because SYNTHETIC_NUM_FMT_PATTERN matched
+      replacement = reconstructCustomNumFmt(synthetic.groups!["width"]!);
+    }
     const restoredLevel =
       curLevel.slice(0, synthetic.index) +
       replacement +

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -7,6 +7,20 @@
  */
 
 /**
+ * Whether `char` ends an element's tag name in XML — a whitespace separator
+ * (space, tab, CR, or LF, all valid before attributes per XML 1.0 §3.1), the
+ * tag close `>`, or a self-close `/`. Manual tag scanners must accept every
+ * whitespace form, not just a literal space, so newline-formatted markup
+ * (`<w:p\n  w14:paraId="…">`) is still recognized as the element rather than
+ * mistaken for a longer-named sibling.
+ */
+function isXmlNameBoundary(char: string | undefined): boolean {
+  return (
+    char === " " || char === "\t" || char === "\n" || char === "\r" || char === ">" || char === "/"
+  );
+}
+
+/**
  * Find the exact string start and end offsets of a <w:p> element
  * identified by its w14:paraId attribute.
  *
@@ -58,7 +72,7 @@ export function findParagraphOffsets(
     if (xml.startsWith("<w:p", tagStart)) {
       const charAfterTag = xml[tagStart + 4];
       // Must be <w:p> or <w:p or <w:p/ (not <w:pPr, <w:pStyle, etc.)
-      if (charAfterTag === ">" || charAfterTag === " " || charAfterTag === "/") {
+      if (isXmlNameBoundary(charAfterTag)) {
         // Check for self-closing: <w:p ... />
         const tagEnd = xml.indexOf(">", tagStart);
         if (tagEnd === -1) {
@@ -116,10 +130,11 @@ export function countParagraphElements(xml: string): number {
   const pattern = /<w:p[\s>]/gu;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(xml)) !== null) {
-    // Verify this is actually <w:p and not <w:pPr etc.
+    // Verify this is actually <w:p and not <w:pPr etc. The regex already
+    // required a whitespace-or-`>` boundary, so this rejects only <w:pPr-style
+    // names while accepting every whitespace form (space, tab, CR, LF).
     const idx = match.index;
-    const charAfter = xml[idx + 4];
-    if (charAfter === ">" || charAfter === " ") {
+    if (isXmlNameBoundary(xml[idx + 4])) {
       count++;
     }
   }
@@ -329,63 +344,19 @@ function spliceChangedParagraphs(
 // untouched definition (and the parts the model omits — `w:nsid`, `w:tmpl`,
 // `w:numPicBullet`, unmodeled level sub-elements) stays byte-exact.
 
-type NumberingElementKind = "abstractNum" | "num";
-
-const NUMBERING_OPEN_LITERAL: Record<NumberingElementKind, string> = {
-  abstractNum: "<w:abstractNum",
-  num: "<w:num",
-};
-
-const NUMBERING_CLOSE_TAG: Record<NumberingElementKind, string> = {
-  abstractNum: "</w:abstractNum>",
-  num: "</w:num>",
-};
-
-const NUMBERING_ID_ATTR: Record<NumberingElementKind, string> = {
-  abstractNum: "w:abstractNumId",
-  num: "w:numId",
-};
-
 /**
- * Whether the character after an opening `<w:num` / `<w:abstractNum` literal
- * marks the actual element rather than a longer-named sibling — `<w:num ` /
- * `<w:num>` (the instance) but not `<w:numFmt` / `<w:numbering`, and
- * `<w:abstractNum ` but not the `<w:abstractNumId>` child of an instance.
+ * Depth-count the end of the element that opens at `start` (an `<openLiteral…>`
+ * offset), returning its full range. Nested same-name opens increment depth;
+ * the matching `closeTag` (or a self-close) at depth 0 ends it. The boundary
+ * check skips longer-named siblings (`<w:numFmt>` when scanning `<w:num`).
  */
-function isElementBoundaryChar(char: string | undefined): boolean {
-  return char === ">" || char === " " || char === "/";
-}
-
-/**
- * Find the exact start/end offsets of a numbering definition element identified
- * by its id attribute, depth-counting the matching close tag. Returns null when
- * the id is absent or appears more than once (ambiguous).
- */
-function findNumberingElementOffsets(
+function scanElementRange(
   xml: string,
-  kind: NumberingElementKind,
-  id: string,
+  start: number,
+  openLiteral: string,
+  closeTag: string,
 ): { start: number; end: number } | null {
-  const openLiteral = NUMBERING_OPEN_LITERAL[kind];
-  const closeTag = NUMBERING_CLOSE_TAG[kind];
-  const idAttr = NUMBERING_ID_ATTR[kind];
-
-  const pattern = new RegExp(
-    `${escapeRegExp(openLiteral)}[\\s][^>]*${escapeRegExp(idAttr)}="${escapeRegExp(id)}"`,
-    "gu",
-  );
-  const matches: number[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(xml)) !== null) {
-    matches.push(match.index);
-  }
-  if (matches.length !== 1) {
-    return null;
-  }
-  // SAFETY: matches.length === 1 verified above
-  const start = matches[0]!;
   const afterOpenIndex = openLiteral.length;
-
   let pos = start;
   let depth = 0;
   while (pos < xml.length) {
@@ -394,8 +365,7 @@ function findNumberingElementOffsets(
       break;
     }
     if (xml.startsWith(openLiteral, tagStart)) {
-      if (!isElementBoundaryChar(xml[tagStart + afterOpenIndex])) {
-        // A longer-named sibling like <w:numFmt> — not our element.
+      if (!isXmlNameBoundary(xml[tagStart + afterOpenIndex])) {
         pos = tagStart + 1;
         continue;
       }
@@ -426,29 +396,80 @@ function findNumberingElementOffsets(
 }
 
 /**
- * Extract the serialized XML for a single numbering definition element by id.
+ * Find the exact start/end offsets of the element `<openLiteral … idAttr="id">`,
+ * depth-counting its matching close tag. Returns null when the id is absent or
+ * ambiguous (appears more than once).
  */
-function extractNumberingElementXml(
+function findElementByIdAttr(
   xml: string,
-  kind: NumberingElementKind,
+  openLiteral: string,
+  closeTag: string,
+  idAttr: string,
   id: string,
-): string | null {
-  const offsets = findNumberingElementOffsets(xml, kind, id);
-  if (!offsets) {
+): { start: number; end: number } | null {
+  const pattern = new RegExp(
+    `${escapeRegExp(openLiteral)}[\\s][^>]*${escapeRegExp(idAttr)}="${escapeRegExp(id)}"`,
+    "gu",
+  );
+  const matches: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(xml)) !== null) {
+    matches.push(match.index);
+  }
+  if (matches.length !== 1) {
     return null;
   }
-  return xml.slice(offsets.start, offsets.end);
+  // SAFETY: matches.length === 1 verified above
+  return scanElementRange(xml, matches[0]!, openLiteral, closeTag);
 }
 
 /**
- * Collect the ids carried by opening tags of a numbering definition element,
- * with counts so duplicates can be rejected. Only real element opening tags
- * match (the `[\s]` after the literal excludes `<w:numFmt` and the like).
+ * Extract the serialized XML for `<openLiteral … idAttr="id">…`, or null when it
+ * cannot be resolved uniquely.
  */
-function collectNumberingElementIds(xml: string, kind: NumberingElementKind): Map<string, number> {
+function extractElementByIdAttr(
+  xml: string,
+  openLiteral: string,
+  closeTag: string,
+  idAttr: string,
+  id: string,
+): string | null {
+  const offsets = findElementByIdAttr(xml, openLiteral, closeTag, idAttr, id);
+  return offsets ? xml.slice(offsets.start, offsets.end) : null;
+}
+
+/**
+ * The full range of the first `<openLiteral …>…</closeTag>` element, or null.
+ * Used to locate an unkeyed sub-element (a level's `mc:AlternateContent`).
+ */
+function findFirstElement(
+  xml: string,
+  openLiteral: string,
+  closeTag: string,
+): { start: number; end: number } | null {
+  let pos = 0;
+  while (pos < xml.length) {
+    const idx = xml.indexOf(openLiteral, pos);
+    if (idx === -1) {
+      return null;
+    }
+    if (isXmlNameBoundary(xml[idx + openLiteral.length])) {
+      return scanElementRange(xml, idx, openLiteral, closeTag);
+    }
+    pos = idx + 1;
+  }
+  return null;
+}
+
+/**
+ * Collect the ids carried by opening `<openLiteral … idAttr="…">` tags, with
+ * counts so duplicates can be rejected. The `[\s]` after the literal restricts
+ * matches to the exact element (excluding `<w:numFmt` when scanning `<w:num`).
+ */
+function collectElementIds(xml: string, openLiteral: string, idAttr: string): Map<string, number> {
   const ids = new Map<string, number>();
   const pattern = new RegExp(
-    `${escapeRegExp(NUMBERING_OPEN_LITERAL[kind])}[\\s][^>]*?${escapeRegExp(NUMBERING_ID_ATTR[kind])}="(?<id>[^"]+)"`,
+    `${escapeRegExp(openLiteral)}[\\s][^>]*?${escapeRegExp(idAttr)}="(?<id>[^"]+)"`,
     "gu",
   );
   let match: RegExpExecArray | null;
@@ -459,6 +480,64 @@ function collectNumberingElementIds(xml: string, kind: NumberingElementKind): Ma
   }
   return ids;
 }
+
+type NumberingElementKind = "abstractNum" | "num";
+
+const NUMBERING_OPEN_LITERAL: Record<NumberingElementKind, string> = {
+  abstractNum: "<w:abstractNum",
+  num: "<w:num",
+};
+
+const NUMBERING_CLOSE_TAG: Record<NumberingElementKind, string> = {
+  abstractNum: "</w:abstractNum>",
+  num: "</w:num>",
+};
+
+const NUMBERING_ID_ATTR: Record<NumberingElementKind, string> = {
+  abstractNum: "w:abstractNumId",
+  num: "w:numId",
+};
+
+const LEVEL_OPEN_LITERAL = "<w:lvl";
+const LEVEL_CLOSE_TAG = "</w:lvl>";
+const LEVEL_ID_ATTR = "w:ilvl";
+
+function findNumberingElementOffsets(
+  xml: string,
+  kind: NumberingElementKind,
+  id: string,
+): { start: number; end: number } | null {
+  return findElementByIdAttr(
+    xml,
+    NUMBERING_OPEN_LITERAL[kind],
+    NUMBERING_CLOSE_TAG[kind],
+    NUMBERING_ID_ATTR[kind],
+    id,
+  );
+}
+
+function extractNumberingElementXml(
+  xml: string,
+  kind: NumberingElementKind,
+  id: string,
+): string | null {
+  return extractElementByIdAttr(
+    xml,
+    NUMBERING_OPEN_LITERAL[kind],
+    NUMBERING_CLOSE_TAG[kind],
+    NUMBERING_ID_ATTR[kind],
+    id,
+  );
+}
+
+function collectNumberingElementIds(xml: string, kind: NumberingElementKind): Map<string, number> {
+  return collectElementIds(xml, NUMBERING_OPEN_LITERAL[kind], NUMBERING_ID_ATTR[kind]);
+}
+
+// Synthetic number formats folio's parser mints from custom / mc:AlternateContent
+// formats (`decimalZero3/4/5`). These are NOT valid OOXML values, so a changed
+// definition must never emit them verbatim — see restoreLevelNumFmts.
+const SYNTHETIC_NUM_FMT_PATTERN = /<w:numFmt w:val="decimalZero(?<width>[345])"\/>/u;
 
 export type ChangedNumberingDefs = {
   abstractNums: Set<string>;
@@ -495,6 +574,91 @@ export function collectChangedNumberingDefs(
 }
 
 /**
+ * The element representing a level's number format in the source XML: the
+ * `<mc:AlternateContent>` block Word wraps a custom format in, else a
+ * self-closing `<w:numFmt …/>` (covers `<w:numFmt w:val="custom" w:format=…/>`).
+ */
+function extractLevelNumFmtElement(levelXml: string): string | null {
+  const alt = findFirstElement(levelXml, "<mc:AlternateContent", "</mc:AlternateContent>");
+  if (alt) {
+    return levelXml.slice(alt.start, alt.end);
+  }
+  const match = /<w:numFmt\b[^>]*\/>/u.exec(levelXml);
+  return match ? match[0] : null;
+}
+
+/**
+ * A valid OOXML custom number format equivalent to a `decimalZero{width}`
+ * synthetic value: a zero-padded first token folio's parser reads back to the
+ * same width. Used only when the original element cannot be resolved, so a
+ * changed definition never emits a non-OOXML synthetic value.
+ */
+function reconstructCustomNumFmt(width: string): string {
+  const token = `${"0".repeat(Number.parseInt(width, 10) - 1)}1`;
+  return `<w:numFmt w:val="custom" w:format="${token}"/>`;
+}
+
+/**
+ * Swap each synthetic `decimalZero{3,4,5}` numFmt in a re-serialized definition
+ * back to the original level's number-format element.
+ *
+ * folio's parser collapses a Word custom / mc:AlternateContent number format
+ * into a synthetic `decimalZero{3,4,5}` value the model cannot re-emit as valid
+ * OOXML. When an unrelated field of the definition is edited, the whole
+ * definition is re-serialized, so without this pass the level's custom format
+ * would be replaced by an invalid value and lost on reparse. For each level
+ * whose re-emitted numFmt is synthetic, restore the original level's numFmt
+ * element by ilvl; when the original cannot be resolved, fall back to a valid
+ * OOXML custom format that preserves the zero-pad width rather than leaving a
+ * synthetic value.
+ */
+function restoreLevelNumFmts(originalDefXml: string, currentDefXml: string): string {
+  const replacements: { start: number; end: number; newXml: string }[] = [];
+  for (const [ilvl, count] of collectElementIds(currentDefXml, LEVEL_OPEN_LITERAL, LEVEL_ID_ATTR)) {
+    if (count !== 1) {
+      continue;
+    }
+    const curOffsets = findElementByIdAttr(
+      currentDefXml,
+      LEVEL_OPEN_LITERAL,
+      LEVEL_CLOSE_TAG,
+      LEVEL_ID_ATTR,
+      ilvl,
+    );
+    if (!curOffsets) {
+      continue;
+    }
+    const curLevel = currentDefXml.slice(curOffsets.start, curOffsets.end);
+    const synthetic = SYNTHETIC_NUM_FMT_PATTERN.exec(curLevel);
+    if (!synthetic) {
+      continue;
+    }
+    const origLevel = extractElementByIdAttr(
+      originalDefXml,
+      LEVEL_OPEN_LITERAL,
+      LEVEL_CLOSE_TAG,
+      LEVEL_ID_ATTR,
+      ilvl,
+    );
+    const original = origLevel ? extractLevelNumFmtElement(origLevel) : null;
+    // SAFETY: named group `width` present because SYNTHETIC_NUM_FMT_PATTERN matched
+    const replacement = original ?? reconstructCustomNumFmt(synthetic.groups!["width"]!);
+    const restoredLevel =
+      curLevel.slice(0, synthetic.index) +
+      replacement +
+      curLevel.slice(synthetic.index + synthetic[0].length);
+    replacements.push({ start: curOffsets.start, end: curOffsets.end, newXml: restoredLevel });
+  }
+
+  replacements.sort((a, b) => b.start - a.start);
+  let result = currentDefXml;
+  for (const { start, end, newXml } of replacements) {
+    result = result.slice(0, start) + newXml + result.slice(end);
+  }
+  return result;
+}
+
+/**
  * Build a patched `word/numbering.xml` by splicing the changed `w:abstractNum` /
  * `w:num` definitions from `currentXml` (the model's serialization) into
  * `originalXml`, preserving every other byte. Returns the original unchanged
@@ -517,10 +681,14 @@ export function buildPatchedNumberingXml(
       if (!origOffsets) {
         return false;
       }
-      const newXml = extractNumberingElementXml(currentXml, kind, id);
-      if (newXml === null) {
+      const reserialized = extractNumberingElementXml(currentXml, kind, id);
+      if (reserialized === null) {
         return false;
       }
+      // Restore any custom/mc:AlternateContent numFmt the model flattened to a
+      // synthetic value, so editing an unrelated field never corrupts the format.
+      const originalDefXml = originalXml.slice(origOffsets.start, origOffsets.end);
+      const newXml = restoreLevelNumFmts(originalDefXml, reserialized);
       replacements.push({ start: origOffsets.start, end: origOffsets.end, newXml });
     }
     return true;

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -599,6 +599,30 @@ function reconstructCustomNumFmt(width: string): string {
 }
 
 /**
+ * The synthetic `decimalZero{width}` width the parser would derive from an
+ * original level's number-format element (its custom `w:format` first token),
+ * as the same digit-count string the SYNTHETIC_NUM_FMT_PATTERN captures. Mirrors
+ * `parseCustomNumberFormat` (first comma-separated token, `^0+1$`, clamped to 5).
+ * Returns null when the element carries no zero-padded custom format, so a
+ * genuine format change is never mistaken for the original.
+ */
+function originalNumFmtWidth(numFmtElement: string): string | null {
+  for (const match of numFmtElement.matchAll(/<w:numFmt\b[^>]*\/>/gu)) {
+    const tag = match[0];
+    if (!/\bw:val="custom"/u.test(tag)) {
+      continue;
+    }
+    const format = /\bw:format="(?<format>[^"]*)"/u.exec(tag)?.groups?.["format"];
+    if (format === undefined) {
+      continue;
+    }
+    const firstToken = format.split(",")[0]?.trim() ?? "";
+    return /^0+1$/u.test(firstToken) ? String(Math.min(firstToken.length, 5)) : null;
+  }
+  return null;
+}
+
+/**
  * Collect the `xmlns` / `xmlns:*` declarations from an element's opening tag
  * (the substring up to its first `>`).
  */
@@ -647,8 +671,11 @@ function withXmlnsDeclarations(fragmentXml: string, xmlnsDecls: Record<string, s
  * definition is re-serialized, so without this pass the level's custom format
  * would be replaced by an invalid value and lost on reparse. For each level
  * whose re-emitted numFmt is synthetic, restore the original level's numFmt
- * element by ilvl; when the original cannot be resolved, fall back to a valid
- * OOXML custom format that preserves the zero-pad width rather than leaving a
+ * element by ilvl ONLY when the model's synthetic value still matches the
+ * original's (the format was not edited, just preserved past an unrelated
+ * change). When the model deliberately changed the width (e.g. decimalZero4 ->
+ * decimalZero5), or the original cannot be resolved, emit a valid OOXML custom
+ * format for the CURRENT width instead — honoring the edit and never leaving a
  * synthetic value.
  */
 function restoreLevelNumFmts(originalDefXml: string, currentDefXml: string): string {
@@ -679,20 +706,24 @@ function restoreLevelNumFmts(originalDefXml: string, currentDefXml: string): str
       LEVEL_ID_ATTR,
       ilvl,
     );
+    // SAFETY: named group `width` present because SYNTHETIC_NUM_FMT_PATTERN matched
+    const currentWidth = synthetic.groups!["width"]!;
     const original = origLevel ? extractLevelNumFmtElement(origLevel) : null;
     let replacement: string;
-    if (original && origLevel) {
-      // The restored element (e.g. mc:AlternateContent) may use a prefix bound
-      // on the replaced ancestors (w:abstractNum / w:lvl) instead of the
-      // numbering root; carry those declarations onto it so it stays resolvable.
+    if (original && origLevel && originalNumFmtWidth(original) === currentWidth) {
+      // Format unchanged — restore the original element verbatim. It (e.g.
+      // mc:AlternateContent) may use a prefix bound on the replaced ancestors
+      // (w:abstractNum / w:lvl) instead of the numbering root; carry those
+      // declarations onto it so it stays resolvable.
       const ancestorXmlns = {
         ...collectXmlnsFromOpeningTag(originalDefXml),
         ...collectXmlnsFromOpeningTag(origLevel),
       };
       replacement = withXmlnsDeclarations(original, ancestorXmlns);
     } else {
-      // SAFETY: named group `width` present because SYNTHETIC_NUM_FMT_PATTERN matched
-      replacement = reconstructCustomNumFmt(synthetic.groups!["width"]!);
+      // The model changed the width (or the original is unresolvable): honor the
+      // current value via a valid OOXML custom format, never the synthetic literal.
+      replacement = reconstructCustomNumFmt(currentWidth);
     }
     const restoredLevel =
       curLevel.slice(0, synthetic.index) +

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -318,6 +318,228 @@ function spliceChangedParagraphs(
   return result;
 }
 
+// ============================================================================
+// NUMBERING DEFINITION PATCHING (word/numbering.xml)
+// ============================================================================
+//
+// Numbering definitions carry no `w14:paraId`; a `w:abstractNum` is keyed by its
+// `w:abstractNumId` attribute and a `w:num` by its `w:numId`. These helpers
+// mirror the paragraph splice above but target whole definition elements by id,
+// so an edited list definition is re-emitted from the model while every
+// untouched definition (and the parts the model omits — `w:nsid`, `w:tmpl`,
+// `w:numPicBullet`, unmodeled level sub-elements) stays byte-exact.
+
+type NumberingElementKind = "abstractNum" | "num";
+
+const NUMBERING_OPEN_LITERAL: Record<NumberingElementKind, string> = {
+  abstractNum: "<w:abstractNum",
+  num: "<w:num",
+};
+
+const NUMBERING_CLOSE_TAG: Record<NumberingElementKind, string> = {
+  abstractNum: "</w:abstractNum>",
+  num: "</w:num>",
+};
+
+const NUMBERING_ID_ATTR: Record<NumberingElementKind, string> = {
+  abstractNum: "w:abstractNumId",
+  num: "w:numId",
+};
+
+/**
+ * Whether the character after an opening `<w:num` / `<w:abstractNum` literal
+ * marks the actual element rather than a longer-named sibling — `<w:num ` /
+ * `<w:num>` (the instance) but not `<w:numFmt` / `<w:numbering`, and
+ * `<w:abstractNum ` but not the `<w:abstractNumId>` child of an instance.
+ */
+function isElementBoundaryChar(char: string | undefined): boolean {
+  return char === ">" || char === " " || char === "/";
+}
+
+/**
+ * Find the exact start/end offsets of a numbering definition element identified
+ * by its id attribute, depth-counting the matching close tag. Returns null when
+ * the id is absent or appears more than once (ambiguous).
+ */
+function findNumberingElementOffsets(
+  xml: string,
+  kind: NumberingElementKind,
+  id: string,
+): { start: number; end: number } | null {
+  const openLiteral = NUMBERING_OPEN_LITERAL[kind];
+  const closeTag = NUMBERING_CLOSE_TAG[kind];
+  const idAttr = NUMBERING_ID_ATTR[kind];
+
+  const pattern = new RegExp(
+    `${escapeRegExp(openLiteral)}[\\s][^>]*${escapeRegExp(idAttr)}="${escapeRegExp(id)}"`,
+    "gu",
+  );
+  const matches: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(xml)) !== null) {
+    matches.push(match.index);
+  }
+  if (matches.length !== 1) {
+    return null;
+  }
+  // SAFETY: matches.length === 1 verified above
+  const start = matches[0]!;
+  const afterOpenIndex = openLiteral.length;
+
+  let pos = start;
+  let depth = 0;
+  while (pos < xml.length) {
+    const tagStart = xml.indexOf("<", pos);
+    if (tagStart === -1) {
+      break;
+    }
+    if (xml.startsWith(openLiteral, tagStart)) {
+      if (!isElementBoundaryChar(xml[tagStart + afterOpenIndex])) {
+        // A longer-named sibling like <w:numFmt> — not our element.
+        pos = tagStart + 1;
+        continue;
+      }
+      const tagEnd = xml.indexOf(">", tagStart);
+      if (tagEnd === -1) {
+        break;
+      }
+      if (xml[tagEnd - 1] === "/") {
+        if (depth === 0) {
+          return { start, end: tagEnd + 1 };
+        }
+        pos = tagEnd + 1;
+      } else {
+        depth++;
+        pos = tagEnd + 1;
+      }
+    } else if (xml.startsWith(closeTag, tagStart)) {
+      depth--;
+      if (depth === 0) {
+        return { start, end: tagStart + closeTag.length };
+      }
+      pos = tagStart + closeTag.length;
+    } else {
+      pos = tagStart + 1;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the serialized XML for a single numbering definition element by id.
+ */
+function extractNumberingElementXml(
+  xml: string,
+  kind: NumberingElementKind,
+  id: string,
+): string | null {
+  const offsets = findNumberingElementOffsets(xml, kind, id);
+  if (!offsets) {
+    return null;
+  }
+  return xml.slice(offsets.start, offsets.end);
+}
+
+/**
+ * Collect the ids carried by opening tags of a numbering definition element,
+ * with counts so duplicates can be rejected. Only real element opening tags
+ * match (the `[\s]` after the literal excludes `<w:numFmt` and the like).
+ */
+function collectNumberingElementIds(xml: string, kind: NumberingElementKind): Map<string, number> {
+  const ids = new Map<string, number>();
+  const pattern = new RegExp(
+    `${escapeRegExp(NUMBERING_OPEN_LITERAL[kind])}[\\s][^>]*?${escapeRegExp(NUMBERING_ID_ATTR[kind])}="(?<id>[^"]+)"`,
+    "gu",
+  );
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(xml)) !== null) {
+    // SAFETY: named group `id` always present when the regex matches
+    const id = match.groups!["id"]!;
+    ids.set(id, (ids.get(id) ?? 0) + 1);
+  }
+  return ids;
+}
+
+export type ChangedNumberingDefs = {
+  abstractNums: Set<string>;
+  nums: Set<string>;
+};
+
+/**
+ * The numbering definitions whose current serialization differs from the
+ * baseline (re-parsed original) serialization — the ones actually edited. An id
+ * is only considered when it resolves uniquely in BOTH inputs, so a definition
+ * added or removed relative to the original (which cannot be spliced by id) is
+ * left out; both save paths defer those to the byte-exact original part.
+ */
+export function collectChangedNumberingDefs(
+  baselineXml: string,
+  currentXml: string,
+): ChangedNumberingDefs {
+  const changedForKind = (kind: NumberingElementKind): Set<string> => {
+    const changed = new Set<string>();
+    const baselineIds = collectNumberingElementIds(baselineXml, kind);
+    for (const [id, count] of collectNumberingElementIds(currentXml, kind)) {
+      if (count !== 1 || baselineIds.get(id) !== 1) {
+        continue;
+      }
+      const before = extractNumberingElementXml(baselineXml, kind, id);
+      const after = extractNumberingElementXml(currentXml, kind, id);
+      if (before !== null && after !== null && before !== after) {
+        changed.add(id);
+      }
+    }
+    return changed;
+  };
+  return { abstractNums: changedForKind("abstractNum"), nums: changedForKind("num") };
+}
+
+/**
+ * Build a patched `word/numbering.xml` by splicing the changed `w:abstractNum` /
+ * `w:num` definitions from `currentXml` (the model's serialization) into
+ * `originalXml`, preserving every other byte. Returns the original unchanged
+ * when nothing changed, or null when a changed id cannot be resolved uniquely
+ * in either input (so the caller preserves the original part verbatim).
+ */
+export function buildPatchedNumberingXml(
+  originalXml: string,
+  currentXml: string,
+  changed: ChangedNumberingDefs,
+): string | null {
+  if (changed.abstractNums.size === 0 && changed.nums.size === 0) {
+    return originalXml;
+  }
+
+  const replacements: { start: number; end: number; newXml: string }[] = [];
+  const collect = (kind: NumberingElementKind, ids: Set<string>): boolean => {
+    for (const id of ids) {
+      const origOffsets = findNumberingElementOffsets(originalXml, kind, id);
+      if (!origOffsets) {
+        return false;
+      }
+      const newXml = extractNumberingElementXml(currentXml, kind, id);
+      if (newXml === null) {
+        return false;
+      }
+      replacements.push({ start: origOffsets.start, end: origOffsets.end, newXml });
+    }
+    return true;
+  };
+
+  if (!collect("abstractNum", changed.abstractNums) || !collect("num", changed.nums)) {
+    return null;
+  }
+
+  // Splice end-to-start so earlier offsets stay valid. abstractNum and num
+  // elements are disjoint siblings, so descending-by-start ordering is total.
+  replacements.sort((a, b) => b.start - a.start);
+  let result = originalXml;
+  for (const { start, end, newXml } of replacements) {
+    result = result.slice(0, start) + newXml + result.slice(end);
+  }
+  return result;
+}
+
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }

--- a/packages/core/src/docx/serializer/numberingSerializer.ts
+++ b/packages/core/src/docx/serializer/numberingSerializer.ts
@@ -1,0 +1,182 @@
+/**
+ * Numbering Serializer - Serialize numbering definitions back to OOXML XML
+ *
+ * Converts the parsed {@link NumberingDefinitions} model (abstract numberings
+ * and concrete numbering instances) back into `word/numbering.xml` fragments.
+ * The inverse of `numberingParser`.
+ *
+ * OOXML Reference:
+ * - Root: w:numbering
+ * - Templates: w:abstractNum[@w:abstractNumId] with 0..8 w:lvl children
+ * - Instances: w:num[@w:numId] referencing an abstractNum (+ optional overrides)
+ *
+ * The document model does NOT faithfully retain everything `numbering.xml`
+ * carries: abstract numberings drop `w:nsid` / `w:tmpl`, custom number formats
+ * (`w:numFmt w:val="custom"` wrapped in mc:AlternateContent) collapse to a
+ * decimalZero family value, and a level's `w:pPr` / `w:rPr` keep only the subset
+ * the parser models. Callers therefore must NOT overwrite the whole part with
+ * this output — it would drop those pieces. The save paths use this serializer
+ * only to detect which `w:abstractNum` / `w:num` definitions the model actually
+ * changed (by comparing against a re-parse+re-serialize baseline so the lossy
+ * parse cancels out) and to splice just those definitions into the original
+ * part, keeping every untouched definition and sub-element byte-exact.
+ */
+
+import type {
+  AbstractNumbering,
+  ListLevel,
+  NumberingDefinitions,
+  NumberingInstance,
+  ParagraphFormatting,
+} from "../../types/document";
+import { serializeTextFormatting } from "./runSerializer";
+import { escapeXml, intAttr } from "./xmlUtils";
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+/**
+ * Serialize a level's paragraph properties — the modeled subset is indentation
+ * plus tab stops (see `parseLevelParagraphProps`). Returns "" when neither is
+ * present so an empty `<w:pPr/>` is not emitted.
+ */
+function serializeLevelParagraphProps(pPr: ParagraphFormatting): string {
+  const indAttrs: string[] = [];
+  if (pPr.indentLeft !== undefined) {
+    indAttrs.push(`w:left="${intAttr(pPr.indentLeft)}"`);
+  }
+  if (pPr.indentRight !== undefined) {
+    indAttrs.push(`w:right="${intAttr(pPr.indentRight)}"`);
+  }
+  if (pPr.indentFirstLine !== undefined) {
+    if (pPr.hangingIndent) {
+      indAttrs.push(`w:hanging="${intAttr(Math.abs(pPr.indentFirstLine))}"`);
+    } else if (pPr.indentFirstLine !== 0) {
+      indAttrs.push(`w:firstLine="${intAttr(pPr.indentFirstLine)}"`);
+    }
+  }
+
+  const parts: string[] = [];
+  if (pPr.tabs && pPr.tabs.length > 0) {
+    const tabs = pPr.tabs
+      .map((tab) => {
+        const attrs = [`w:val="${tab.alignment}"`, `w:pos="${intAttr(tab.position)}"`];
+        if (tab.leader) {
+          attrs.push(`w:leader="${tab.leader}"`);
+        }
+        return `<w:tab ${attrs.join(" ")}/>`;
+      })
+      .join("");
+    parts.push(`<w:tabs>${tabs}</w:tabs>`);
+  }
+  if (indAttrs.length > 0) {
+    parts.push(`<w:ind ${indAttrs.join(" ")}/>`);
+  }
+
+  if (parts.length === 0) {
+    return "";
+  }
+  return `<w:pPr>${parts.join("")}</w:pPr>`;
+}
+
+/**
+ * Serialize one `w:lvl`. Children follow the ECMA-376 §17.9.6 CT_Lvl order
+ * (start, numFmt, lvlRestart, isLgl, suff, lvlText, legacy, lvlJc, pPr, rPr) so
+ * a re-emitted level parses back into an equivalent model.
+ */
+function serializeLevel(level: ListLevel): string {
+  const parts: string[] = [];
+
+  if (level.start !== undefined) {
+    parts.push(`<w:start w:val="${intAttr(level.start)}"/>`);
+  }
+  parts.push(`<w:numFmt w:val="${escapeXml(level.numFmt)}"/>`);
+  if (level.lvlRestart !== undefined) {
+    parts.push(`<w:lvlRestart w:val="${intAttr(level.lvlRestart)}"/>`);
+  }
+  if (level.isLgl) {
+    parts.push("<w:isLgl/>");
+  }
+  if (level.suffix) {
+    parts.push(`<w:suff w:val="${level.suffix}"/>`);
+  }
+  parts.push(`<w:lvlText w:val="${escapeXml(level.lvlText)}"/>`);
+  if (level.legacy) {
+    const legacyAttrs: string[] = [`w:legacy="${level.legacy.legacy ? 1 : 0}"`];
+    if (level.legacy.legacySpace !== undefined) {
+      legacyAttrs.push(`w:legacySpace="${intAttr(level.legacy.legacySpace)}"`);
+    }
+    if (level.legacy.legacyIndent !== undefined) {
+      legacyAttrs.push(`w:legacyIndent="${intAttr(level.legacy.legacyIndent)}"`);
+    }
+    parts.push(`<w:legacy ${legacyAttrs.join(" ")}/>`);
+  }
+  if (level.lvlJc) {
+    parts.push(`<w:lvlJc w:val="${level.lvlJc}"/>`);
+  }
+  if (level.pPr) {
+    parts.push(serializeLevelParagraphProps(level.pPr));
+  }
+  // A level's run properties reuse the run rPr serializer, so bullet fonts,
+  // colors, and the vanish marker come out identical to body runs.
+  parts.push(serializeTextFormatting(level.rPr));
+
+  return `<w:lvl w:ilvl="${intAttr(level.ilvl)}">${parts.join("")}</w:lvl>`;
+}
+
+/**
+ * Serialize one `w:abstractNum` (the reusable list template). Children follow
+ * ECMA-376 §17.9.1 CT_AbstractNum order for the modeled subset (multiLevelType,
+ * name, styleLink, numStyleLink, lvl+); `w:nsid` / `w:tmpl` are not modeled.
+ */
+function serializeAbstractNum(abstractNum: AbstractNumbering): string {
+  const parts: string[] = [];
+  if (abstractNum.multiLevelType) {
+    parts.push(`<w:multiLevelType w:val="${abstractNum.multiLevelType}"/>`);
+  }
+  if (abstractNum.name !== undefined) {
+    parts.push(`<w:name w:val="${escapeXml(abstractNum.name)}"/>`);
+  }
+  if (abstractNum.styleLink !== undefined) {
+    parts.push(`<w:styleLink w:val="${escapeXml(abstractNum.styleLink)}"/>`);
+  }
+  if (abstractNum.numStyleLink !== undefined) {
+    parts.push(`<w:numStyleLink w:val="${escapeXml(abstractNum.numStyleLink)}"/>`);
+  }
+  const levels = [...abstractNum.levels].sort((a, b) => a.ilvl - b.ilvl);
+  for (const level of levels) {
+    parts.push(serializeLevel(level));
+  }
+  return `<w:abstractNum w:abstractNumId="${intAttr(abstractNum.abstractNumId)}">${parts.join("")}</w:abstractNum>`;
+}
+
+/**
+ * Serialize one `w:num` (a concrete numbering instance referenced by `numId`).
+ */
+function serializeNum(instance: NumberingInstance): string {
+  const parts: string[] = [`<w:abstractNumId w:val="${intAttr(instance.abstractNumId)}"/>`];
+  for (const override of instance.levelOverrides ?? []) {
+    const overrideParts: string[] = [];
+    if (override.startOverride !== undefined) {
+      overrideParts.push(`<w:startOverride w:val="${intAttr(override.startOverride)}"/>`);
+    }
+    if (override.lvl) {
+      overrideParts.push(serializeLevel(override.lvl));
+    }
+    parts.push(
+      `<w:lvlOverride w:ilvl="${intAttr(override.ilvl)}">${overrideParts.join("")}</w:lvlOverride>`,
+    );
+  }
+  return `<w:num w:numId="${intAttr(instance.numId)}">${parts.join("")}</w:num>`;
+}
+
+/**
+ * Serialize {@link NumberingDefinitions} to a complete `word/numbering.xml`
+ * string. `w:abstractNum` elements precede `w:num` elements as ECMA-376 §17.9
+ * requires. See the module note: this whole-part output is used only for
+ * change detection and per-definition splicing, never to overwrite the part.
+ */
+export function serializeNumberingXml(numbering: NumberingDefinitions): string {
+  const abstractNums = numbering.abstractNums.map(serializeAbstractNum).join("");
+  const nums = numbering.nums.map(serializeNum).join("");
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:numbering xmlns:w="${W_NS}">${abstractNums}${nums}</w:numbering>`;
+}


### PR DESCRIPTION
Closes folio's remaining save-fidelity hole: a model change to a `word/numbering.xml` list definition was dropped because numbering.xml round-tripped verbatim. Mirrors the footnote/endnote save fix (#15) on **both** save paths.

Like note edits, numbering definitions are parsed read-only today (nothing in product code mutates them), so the write path is reachable only via direct/AI model mutation — this is foundation work. The model is lossy for numbering (drops `w:nsid`/`w:tmpl`, collapses custom formats, doesn't model `w:numPicBullet`), so a whole-file re-emit would lose those — instead this **splices only the changed definition** (same caution as the note fix).

- New `serializer/numberingSerializer.ts` — emits modeled fields in ECMA-376 order (reusing `serializeTextFormatting`); used only for detection/splicing, never to overwrite the part.
- `selectiveXmlPatch.ts` — element-boundary splice-by-id for `w:abstractNum`/`w:num` + baseline-vs-current per-definition diff (so lossy parse cancels out).
- `selectiveSave.ts` + `rezip.ts` — `patchNumberingPart` / `serializeNumberingIntoZip` on both the selective and full-repack paths, producing byte-identical numbering.xml; byte-exact when nothing changed.

Scope: editing an existing definition's modeled fields. Deferred (reported): a *changed* definition loses its own `nsid`/`tmpl`/custom-format on re-emit; untouched definitions + unmodeled siblings stay fully byte-exact; add/remove of a whole definition is skipped (matches the note fix's new-note handling).

Tests: edit a definition, save via both paths, re-parse → edit persists; untouched definition + model-omitted parts (`numPicBullet`/`nsid`/`tmpl`) stay byte-exact; body-only edit leaves numbering.xml verbatim; selective ≡ full produce identical numbering.xml.
