### PR TITLE
feat(core): threaded comment replies

### DIFF
--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -397,6 +397,44 @@ describe("headless docx review discovery + resolve", () => {
     expect(reviewer.getComments({ author: "Nobody" })).toEqual([]);
   });
 
+  test("replyTo threads a reply under a comment and round-trips it", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    reviewer.applyOperations([
+      { id: "c1", type: "commentOnBlock", blockId: target.id, comment: { text: "Parent note." } },
+    ]);
+    const parent = reviewer.getComments()[0];
+    expect(parent).toBeDefined();
+    if (!parent) {
+      return;
+    }
+
+    const reply = reviewer.replyTo(parent, { text: "Threaded response.", author: "Second" });
+    expect(reply).not.toBeNull();
+
+    // The thread now carries the reply.
+    const thread = reviewer.getComments()[0];
+    expect(thread?.replies).toHaveLength(1);
+    expect(thread?.replies[0]?.text).toBe("Threaded response.");
+
+    // Round-trips as a real reply: linked in commentsExtended.xml and anchored.
+    const saved = await reviewer.toBuffer();
+    const reparsed = await parseDocx(saved, { preloadFonts: false });
+    const savedComments = reparsed.package.document.comments ?? [];
+    const savedReply = savedComments.find((c) => c.parentId !== undefined);
+    expect(savedReply?.parentId).toBe(parent.id);
+
+    const extended = await partText(saved, "word/commentsExtended.xml");
+    expect(extended).toContain("w15:paraIdParent");
+    const documentXml = await partText(saved, "word/document.xml");
+    expect(documentXml).toContain(`<w:commentRangeStart w:id="${savedReply?.id}"/>`);
+    expect(documentXml).toContain(`<w:commentReference w:id="${savedReply?.id}"/>`);
+
+    // A reply to an unknown comment is refused.
+    expect(reviewer.replyTo(9999, { text: "orphan" })).toBeNull();
+  });
+
   test("ops from one parse's snapshot resolve on a separate parse of a paraId-less doc", async () => {
     // The raw corpus fixture ships without `w14:paraId`s. Two independent
     // parses must mint identical block ids so ops built against the first

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -431,6 +431,16 @@ describe("headless docx review discovery + resolve", () => {
     expect(documentXml).toContain(`<w:commentRangeStart w:id="${savedReply?.id}"/>`);
     expect(documentXml).toContain(`<w:commentReference w:id="${savedReply?.id}"/>`);
 
+    // Adding comments.xml AND commentsExtended.xml in one repack must wire both
+    // parts' content-type overrides and relationships (they edit the same two
+    // packaging files, so a concurrent write would drop one).
+    const contentTypes = await partText(saved, "[Content_Types].xml");
+    expect(contentTypes).toContain("/word/comments.xml");
+    expect(contentTypes).toContain("/word/commentsExtended.xml");
+    const rels = await partText(saved, "word/_rels/document.xml.rels");
+    expect(rels.toLowerCase()).toContain('target="comments.xml"');
+    expect(rels.toLowerCase()).toContain("commentsextended.xml");
+
     // A reply to an unknown comment is refused.
     expect(reviewer.replyTo(9999, { text: "orphan" })).toBeNull();
   });

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -24,6 +24,7 @@ import type { Command } from "prosemirror-state";
 import type { Plugin } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 
+import { createReply } from "../docx/replyToComment";
 import { attemptSelectiveSave } from "../docx/selectiveSave";
 import { parseDocx } from "../docx/parser";
 import { repackDocx } from "../docx/rezip";
@@ -198,6 +199,15 @@ export type FolioReviewCommentReply = {
   author: string;
   date: string | null;
   text: string;
+};
+
+/** Input for {@link FolioDocxReviewer.replyTo}. */
+export type FolioReviewReplyInput = {
+  /** Reply body text. */
+  text: string;
+  /** Reply author; defaults to the reviewer's author. */
+  author?: string;
+  initials?: string;
 };
 
 /** A comment thread discovered in the document. */
@@ -514,6 +524,36 @@ export class FolioDocxReviewer {
         (filter.author === undefined || thread.author === filter.author) &&
         (filter.done === undefined || thread.done === filter.done),
     );
+  }
+
+  /**
+   * Add a reply to a comment thread. Pass a {@link FolioReviewComment} from
+   * {@link getComments} or its id; the reply threads under that comment's root
+   * (Word threads are flat). On {@link toBuffer} the reply is written as a real
+   * Word reply — linked via `commentsExtended.xml` and given its own
+   * `commentRange` markers + reference anchored on the parent's range. Returns
+   * the created reply, or `null` when the target comment is absent.
+   */
+  replyTo(
+    target: FolioReviewComment | number,
+    input: FolioReviewReplyInput,
+  ): FolioReviewCommentReply | null {
+    const parentId = typeof target === "number" ? target : target.id;
+    const existing = [
+      ...(this.baseDocument.package.document.comments ?? []),
+      ...this.createdComments,
+    ];
+    try {
+      const reply = createReply(existing, parentId, {
+        author: input.author ?? this.author,
+        text: input.text,
+        ...(input.initials !== undefined ? { initials: input.initials } : {}),
+      });
+      this.createdComments.push(reply);
+      return { id: reply.id, author: reply.author, date: reply.date ?? null, text: input.text };
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -45,7 +45,7 @@ import {
 import { schema, singletonManager } from "../prosemirror/schema";
 import type { Comment } from "../types/content";
 import type { Document } from "../types/document";
-import { MAX_HEX_ID_EXCLUSIVE } from "../utils/hexId";
+import { deterministicHexId } from "../utils/hexId";
 import { applyFolioAIEditOperations } from "./apply";
 import { createFolioAIEditSnapshot } from "./snapshot";
 import type {
@@ -83,15 +83,6 @@ const createReviewerComment = (text: string, author: string): Comment => ({
     },
   ],
 });
-
-/** Deterministic 8-char uppercase hex id (FNV-1a over `seed`), `< 0x7FFFFFFF`. */
-const deterministicHexId = (seed: string): string => {
-  let hash = 2_166_136_261;
-  for (const character of seed) {
-    hash = Math.imul(hash ^ (character.codePointAt(0) ?? 0), 16_777_619) >>> 0;
-  }
-  return (hash % MAX_HEX_ID_EXCLUSIVE).toString(16).toUpperCase().padStart(8, "0");
-};
 
 /**
  * Assign a stable `w14:paraId` to every body paragraph that lacks one (or
@@ -543,17 +534,16 @@ export class FolioDocxReviewer {
       ...(this.baseDocument.package.document.comments ?? []),
       ...this.createdComments,
     ];
-    try {
-      const reply = createReply(existing, parentId, {
-        author: input.author ?? this.author,
-        text: input.text,
-        ...(input.initials !== undefined ? { initials: input.initials } : {}),
-      });
-      this.createdComments.push(reply);
-      return { id: reply.id, author: reply.author, date: reply.date ?? null, text: input.text };
-    } catch {
+    const reply = createReply(existing, parentId, {
+      author: input.author ?? this.author,
+      text: input.text,
+      ...(input.initials !== undefined ? { initials: input.initials } : {}),
+    });
+    if (!reply) {
       return null;
     }
+    this.createdComments.push(reply);
+    return { id: reply.id, author: reply.author, date: reply.date ?? null, text: input.text };
   }
 
   /**

--- a/packages/core/src/docx/commentParser.test.ts
+++ b/packages/core/src/docx/commentParser.test.ts
@@ -241,10 +241,9 @@ describe("commentParser", () => {
       expect(comments[1].parentId).toBeUndefined();
     });
 
-    test("falls back to first-paragraph paraId when w:comment has none", () => {
-      // Some Word exporters put the join key on the first `w:p` child,
-      // not on `w:comment` itself. The reply-thread metadata still has
-      // to be applied.
+    test("falls back to the comment paragraph's paraId when w:comment has none", () => {
+      // Some Word exporters put the join key on the `w:p` child, not on
+      // `w:comment` itself. The reply-thread metadata still has to be applied.
       const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
             xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
@@ -276,6 +275,40 @@ describe("commentParser", () => {
       );
 
       expect(comments[0].done).toBe(true);
+      expect(comments[1].parentId).toBe(1);
+    });
+
+    test("uses the LAST paragraph's paraId to join a multi-paragraph comment", () => {
+      // Word keys commentsExtended on the comment's final paragraph; a reply's
+      // parent link must resolve against that id, not the first paragraph's.
+      const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:comment w:id="1" w:author="Alice" w:date="2024-02-10T15:30:00">
+    <w:p w14:paraId="F1RST000"><w:r><w:t>parent line one</w:t></w:r></w:p>
+    <w:p w14:paraId="1A2B3C4D"><w:r><w:t>parent line two</w:t></w:r></w:p>
+  </w:comment>
+  <w:comment w:id="2" w:author="Bob" w:date="2024-03-05T09:15:00">
+    <w:p w14:paraId="5E6F7A8B"><w:r><w:t>reply</w:t></w:r></w:p>
+  </w:comment>
+</w:comments>`;
+      const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">
+  <w15:commentEx w15:paraId="1A2B3C4D" w15:done="0"/>
+  <w15:commentEx w15:paraId="5E6F7A8B" w15:paraIdParent="1A2B3C4D" w15:done="0"/>
+</w15:commentsEx>`;
+
+      const comments = parseComments(
+        commentsXml,
+        emptyStyles,
+        emptyTheme,
+        emptyRels,
+        emptyMedia,
+        null,
+        extendedXml,
+      );
+
+      // paraIdParent points at the parent's LAST paragraph (1A2B3C4D).
       expect(comments[1].parentId).toBe(1);
     });
 

--- a/packages/core/src/docx/commentParser.ts
+++ b/packages/core/src/docx/commentParser.ts
@@ -64,7 +64,7 @@ function parseCommentsExtensible(xml: string): Map<string, string> {
   return dateUtcByParaId;
 }
 
-type CommentExtendedInfo = {
+export type CommentExtendedInfo = {
   parentParaId?: string;
   done?: boolean;
 };
@@ -83,7 +83,7 @@ type CommentExtendedInfo = {
  * `w15:paraIdParent` points at the parent thread's paraId; `w15:done`
  * (`"1"` / `"true"`) marks the thread resolved.
  */
-function parseCommentsExtended(xml: string): Map<string, CommentExtendedInfo> {
+export function parseCommentsExtended(xml: string): Map<string, CommentExtendedInfo> {
   const infoByParaId = new Map<string, CommentExtendedInfo>();
 
   const root = parseXml(xml);
@@ -184,19 +184,22 @@ export function parseComments(
       child.attributes?.["w15:paraId"] ??
       getAttribute(child, "w", "paraId");
     if (!rawParaId) {
+      // commentsExtensible (UTC dates) and commentsExtended (reply links) key
+      // on the LAST paragraph's `w14:paraId`, so walk every `w:p` and keep the
+      // final one — for a single-paragraph comment first and last coincide.
       for (const sub of getChildElements(child)) {
         const subLocal = sub.name?.replace(/^.*:/u, "") ?? "";
         if (subLocal !== "p") {
           continue;
         }
-        rawParaId =
+        const subParaId =
           getAttribute(sub, "w14", "paraId") ??
           sub.attributes?.["w14:paraId"] ??
           getAttribute(sub, "w15", "paraId") ??
           sub.attributes?.["w15:paraId"] ??
           getAttribute(sub, "w", "paraId");
-        if (rawParaId) {
-          break;
+        if (subParaId) {
+          rawParaId = subParaId;
         }
       }
     }

--- a/packages/core/src/docx/commentReplyMarkers.ts
+++ b/packages/core/src/docx/commentReplyMarkers.ts
@@ -1,0 +1,218 @@
+/**
+ * Reply-range marker synthesis for serialization.
+ *
+ * Word anchors every comment — including a REPLY — with
+ * `commentRangeStart` / `commentRangeEnd` markers plus a
+ * `commentReference` run in `document.xml`. A reply shares its parent
+ * thread's text, so a freshly created reply (see {@link replyToComment})
+ * has no markers of its own yet. Before serialization we walk the
+ * comment-bearing surfaces and, for each reply that lacks its own
+ * markers, duplicate the parent's range markers next to the parent's so
+ * the reply gets an identical anchor. The paragraph serializer then
+ * emits the reply's `commentReference` run from its `commentRangeEnd`.
+ *
+ * This is the save-time counterpart to `normalizeCommentReferences`
+ * (parse time): it produces BALANCED ranges referencing valid comment
+ * ids, so a later parse+normalize leaves them intact rather than
+ * re-anchoring them. Idempotent — a reply that already has a marker
+ * (parsed from a Word thread, or synthesized on a prior save) is skipped.
+ *
+ * Approach adapted from `injectReplyRangeMarkers` in
+ * eigenpal/docx-editor (Apache-2.0).
+ */
+
+import type {
+  BlockContent,
+  Comment,
+  Document,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Paragraph,
+} from "../types/document";
+
+type ReplyThreadSurfaces = {
+  body: BlockContent[];
+  comments: readonly Comment[];
+  headers?: Map<string, HeaderFooter>;
+  footers?: Map<string, HeaderFooter>;
+  footnotes?: readonly Footnote[];
+  endnotes?: readonly Endnote[];
+};
+
+const surfacesFromDocument = (doc: Document): ReplyThreadSurfaces => ({
+  body: doc.package.document.content,
+  comments: doc.package.document.comments ?? [],
+  ...(doc.package.headers !== undefined ? { headers: doc.package.headers } : {}),
+  ...(doc.package.footers !== undefined ? { footers: doc.package.footers } : {}),
+  ...(doc.package.footnotes !== undefined ? { footnotes: doc.package.footnotes } : {}),
+  ...(doc.package.endnotes !== undefined ? { endnotes: doc.package.endnotes } : {}),
+});
+
+const surfaceBlockGroups = (surfaces: ReplyThreadSurfaces): BlockContent[][] => {
+  const groups: BlockContent[][] = [surfaces.body];
+  for (const header of surfaces.headers?.values() ?? []) {
+    groups.push(header.content);
+  }
+  for (const footer of surfaces.footers?.values() ?? []) {
+    groups.push(footer.content);
+  }
+  for (const footnote of surfaces.footnotes ?? []) {
+    groups.push(footnote.content);
+  }
+  for (const endnote of surfaces.endnotes ?? []) {
+    groups.push(endnote.content);
+  }
+  return groups;
+};
+
+const eachParagraph = (blocks: BlockContent[], visit: (paragraph: Paragraph) => void): void => {
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      visit(block);
+      continue;
+    }
+    if (block.type === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          eachParagraph(cell.content, visit);
+        }
+      }
+      continue;
+    }
+    eachParagraph(block.content, visit);
+  }
+};
+
+type AnchorScan = {
+  /** Comment ids that carry a `commentRangeStart` (a real text range). */
+  rangeIds: Set<number>;
+  /** Comment ids with any anchor (range start OR a `commentReference` run). */
+  anchoredIds: Set<number>;
+};
+
+const scanAnchors = (surfaces: ReplyThreadSurfaces): AnchorScan => {
+  const rangeIds = new Set<number>();
+  const anchoredIds = new Set<number>();
+  for (const group of surfaceBlockGroups(surfaces)) {
+    eachParagraph(group, (paragraph) => {
+      for (const item of paragraph.content) {
+        if (item.type === "commentRangeStart") {
+          rangeIds.add(item.id);
+          anchoredIds.add(item.id);
+        } else if (item.type === "commentReference") {
+          anchoredIds.add(item.id);
+        }
+      }
+    });
+  }
+  return { rangeIds, anchoredIds };
+};
+
+/** Replies whose parent is another comment (the threaded-discussion shape). */
+const commentParentedReplies = (comments: readonly Comment[]): Comment[] => {
+  const commentIds = new Set(comments.map((comment) => comment.id));
+  return comments.filter(
+    (comment) => comment.parentId !== undefined && commentIds.has(comment.parentId),
+  );
+};
+
+const injectIntoParagraph = (
+  paragraph: Paragraph,
+  replyIdsByParent: Map<number, number[]>,
+  parentsWithRange: ReadonlySet<number>,
+): number => {
+  const touchesReplyParent = paragraph.content.some((item) => {
+    if (item.type === "commentRangeStart" || item.type === "commentRangeEnd") {
+      return replyIdsByParent.has(item.id);
+    }
+    // A point comment (bare reference, no range) needs a duplicated reference.
+    return item.type === "commentReference" && !parentsWithRange.has(item.id)
+      ? replyIdsByParent.has(item.id)
+      : false;
+  });
+  if (!touchesReplyParent) {
+    return 0;
+  }
+
+  const next: Paragraph["content"] = [];
+  let injected = 0;
+  for (const item of paragraph.content) {
+    next.push(item);
+    if (item.type === "commentRangeStart") {
+      for (const replyId of replyIdsByParent.get(item.id) ?? []) {
+        next.push({ type: "commentRangeStart", id: replyId });
+        injected += 1;
+      }
+    } else if (item.type === "commentRangeEnd") {
+      for (const replyId of replyIdsByParent.get(item.id) ?? []) {
+        next.push({ type: "commentRangeEnd", id: replyId });
+      }
+    } else if (item.type === "commentReference" && !parentsWithRange.has(item.id)) {
+      for (const replyId of replyIdsByParent.get(item.id) ?? []) {
+        next.push({ type: "commentReference", id: replyId });
+        injected += 1;
+      }
+    }
+  }
+  paragraph.content = next;
+  return injected;
+};
+
+const synthesizeReplyRangeMarkers = (surfaces: ReplyThreadSurfaces): number => {
+  const replies = commentParentedReplies(surfaces.comments);
+  if (replies.length === 0) {
+    return 0;
+  }
+
+  const { rangeIds, anchoredIds } = scanAnchors(surfaces);
+
+  // Only replies that have no anchor of their own need synthesis.
+  const replyIdsByParent = new Map<number, number[]>();
+  for (const reply of replies) {
+    if (anchoredIds.has(reply.id) || reply.parentId === undefined) {
+      continue;
+    }
+    const siblings = replyIdsByParent.get(reply.parentId) ?? [];
+    siblings.push(reply.id);
+    replyIdsByParent.set(reply.parentId, siblings);
+  }
+  if (replyIdsByParent.size === 0) {
+    return 0;
+  }
+
+  let injected = 0;
+  const visit = (paragraph: Paragraph): void => {
+    injected += injectIntoParagraph(paragraph, replyIdsByParent, rangeIds);
+  };
+  for (const group of surfaceBlockGroups(surfaces)) {
+    eachParagraph(group, visit);
+  }
+  return injected;
+};
+
+/**
+ * Synthesize reply range markers into a document model in place, so every
+ * reply comment picks up its parent's anchor before `document.xml` is
+ * serialized. Idempotent and safe to call on both save paths. Returns the
+ * number of markers injected.
+ */
+export const applyReplyThreadMarkers = (doc: Document): number =>
+  synthesizeReplyRangeMarkers(surfacesFromDocument(doc));
+
+/**
+ * Whether the model holds a reply comment that has no anchor of its own yet —
+ * i.e. one that still needs {@link applyReplyThreadMarkers} to run. The
+ * selective-save path uses this to bail to a full repack, which is the path
+ * that owns marker synthesis (selective only patches individually-changed
+ * paragraphs, so it cannot add a reply's markers to the parent's paragraph).
+ */
+export const hasUnsynthesizedReplyRanges = (doc: Document): boolean => {
+  const surfaces = surfacesFromDocument(doc);
+  const replies = commentParentedReplies(surfaces.comments);
+  if (replies.length === 0) {
+    return false;
+  }
+  const { anchoredIds } = scanAnchors(surfaces);
+  return replies.some((reply) => !anchoredIds.has(reply.id));
+};

--- a/packages/core/src/docx/commentReplyMarkers.ts
+++ b/packages/core/src/docx/commentReplyMarkers.ts
@@ -49,38 +49,40 @@ const surfacesFromDocument = (doc: Document): ReplyThreadSurfaces => ({
   ...(doc.package.endnotes !== undefined ? { endnotes: doc.package.endnotes } : {}),
 });
 
+// Malformed input can omit a container's children; guard every content / rows /
+// cells access with the same `?? []` so a walk never crashes on a bad model.
 const surfaceBlockGroups = (surfaces: ReplyThreadSurfaces): BlockContent[][] => {
-  const groups: BlockContent[][] = [surfaces.body];
+  const groups: BlockContent[][] = [surfaces.body ?? []];
   for (const header of surfaces.headers?.values() ?? []) {
-    groups.push(header.content);
+    groups.push(header.content ?? []);
   }
   for (const footer of surfaces.footers?.values() ?? []) {
-    groups.push(footer.content);
+    groups.push(footer.content ?? []);
   }
   for (const footnote of surfaces.footnotes ?? []) {
-    groups.push(footnote.content);
+    groups.push(footnote.content ?? []);
   }
   for (const endnote of surfaces.endnotes ?? []) {
-    groups.push(endnote.content);
+    groups.push(endnote.content ?? []);
   }
   return groups;
 };
 
 const eachParagraph = (blocks: BlockContent[], visit: (paragraph: Paragraph) => void): void => {
-  for (const block of blocks) {
+  for (const block of blocks ?? []) {
     if (block.type === "paragraph") {
       visit(block);
       continue;
     }
     if (block.type === "table") {
-      for (const row of block.rows) {
-        for (const cell of row.cells) {
-          eachParagraph(cell.content, visit);
+      for (const row of block.rows ?? []) {
+        for (const cell of row.cells ?? []) {
+          eachParagraph(cell.content ?? [], visit);
         }
       }
       continue;
     }
-    eachParagraph(block.content, visit);
+    eachParagraph(block.content ?? [], visit);
   }
 };
 
@@ -96,7 +98,7 @@ const scanAnchors = (surfaces: ReplyThreadSurfaces): AnchorScan => {
   const anchoredIds = new Set<number>();
   for (const group of surfaceBlockGroups(surfaces)) {
     eachParagraph(group, (paragraph) => {
-      for (const item of paragraph.content) {
+      for (const item of paragraph.content ?? []) {
         if (item.type === "commentRangeStart") {
           rangeIds.add(item.id);
           anchoredIds.add(item.id);
@@ -122,7 +124,8 @@ const injectIntoParagraph = (
   replyIdsByParent: Map<number, number[]>,
   parentsWithRange: ReadonlySet<number>,
 ): number => {
-  const touchesReplyParent = paragraph.content.some((item) => {
+  const content = paragraph.content ?? [];
+  const touchesReplyParent = content.some((item) => {
     if (item.type === "commentRangeStart" || item.type === "commentRangeEnd") {
       return replyIdsByParent.has(item.id);
     }
@@ -137,7 +140,7 @@ const injectIntoParagraph = (
 
   const next: Paragraph["content"] = [];
   let injected = 0;
-  for (const item of paragraph.content) {
+  for (const item of content) {
     next.push(item);
     if (item.type === "commentRangeStart") {
       for (const replyId of replyIdsByParent.get(item.id) ?? []) {

--- a/packages/core/src/docx/commentReplyThreads.test.ts
+++ b/packages/core/src/docx/commentReplyThreads.test.ts
@@ -12,12 +12,18 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import type { BlockContent, Comment, Document, Paragraph } from "../types/document";
+import { applyReplyThreadMarkers } from "./commentReplyMarkers";
+import { parseComments } from "./commentParser";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { replyToComment } from "./replyToComment";
-import { repackDocx } from "./rezip";
+import { repackDocx, validateDocx } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
-import { serializeCommentsExtended } from "./serializer/commentSerializer";
+import {
+  ensureThreadedCommentParaIds,
+  serializeComments,
+  serializeCommentsExtended,
+} from "./serializer/commentSerializer";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
@@ -291,6 +297,10 @@ describe("comment reply threads — create-reply API", () => {
     const doc = await parse(buffer);
 
     const reply = replyToComment(doc, PARENT_ID, { author: "Reviewer", text: "a fresh reply" });
+    expect(reply).not.toBeNull();
+    if (!reply) {
+      return;
+    }
     expect(reply.parentId).toBe(PARENT_ID);
 
     // A created reply has no anchor yet, so save goes through the full repack.
@@ -304,6 +314,20 @@ describe("comment reply threads — create-reply API", () => {
     expect(markers.reference.has(reply.id)).toBe(true);
   });
 
+  test("replyToComment returns null for an unknown or paragraph-less parent", () => {
+    const parentless: Document = {
+      package: {
+        document: {
+          content: [],
+          comments: [{ id: PARENT_ID, author: "Alice", content: [] }],
+        },
+      },
+    };
+    // Unknown parent id, and a parent with no paragraphs to anchor the thread.
+    expect(replyToComment(parentless, 9999, { author: "R", text: "x" })).toBeNull();
+    expect(replyToComment(parentless, PARENT_ID, { author: "R", text: "x" })).toBeNull();
+  });
+
   test("serializeCommentsExtended is null for a document with no threads or resolved state", () => {
     const plain: Comment[] = [
       {
@@ -314,6 +338,118 @@ describe("comment reply threads — create-reply API", () => {
     ];
     expect(serializeCommentsExtended(plain)).toBeNull();
   });
+});
+
+describe("comment reply threads — package lifecycle + deterministic ids", () => {
+  test("removing a thread drops commentsExtended.xml + its content-type + rel", async () => {
+    // No reply markers in the body, so removing the reply comments leaves no
+    // dangling references (only the parent's anchor, which survives).
+    const buffer = await buildThreadedDocx({ includeReplyMarkers: false, parentDone: true });
+    const doc = await parse(buffer);
+
+    // Simulate the whole thread being removed from the model: keep only the
+    // parent, and clear its resolved state so nothing needs a commentEx entry.
+    const parent = commentById(doc, PARENT_ID);
+    expect(parent).toBeDefined();
+    if (!parent) {
+      return;
+    }
+    delete parent.done;
+    doc.package.document.comments = [parent];
+
+    const saved = await repackDocx({ ...doc, originalBuffer: buffer });
+    const zip = await JSZip.loadAsync(saved);
+    expect(zip.file("word/commentsExtended.xml")).toBeNull();
+
+    const contentTypes = await readPart(saved, "[Content_Types].xml");
+    expect(contentTypes.toLowerCase()).not.toContain("commentsextended.xml");
+    const rels = await readPart(saved, "word/_rels/document.xml.rels");
+    expect(rels.toLowerCase()).not.toContain("commentsextended.xml");
+
+    // The package must still be a valid DOCX after the removal.
+    const validation = await validateDocx(saved);
+    expect(validation.valid).toBe(true);
+  });
+
+  test("selective save bails to full repack when a thread must be removed", async () => {
+    const buffer = await buildThreadedDocx({ includeReplyMarkers: false, parentDone: true });
+    const doc = await parse(buffer);
+    const parent = commentById(doc, PARENT_ID);
+    if (!parent) {
+      return;
+    }
+    delete parent.done;
+    doc.package.document.comments = [parent];
+
+    const saved = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(saved).toBeNull();
+  });
+
+  test("synthesis does not crash on a malformed paragraph with no content", () => {
+    const doc: Document = {
+      package: {
+        document: {
+          content: [{ type: "paragraph", formatting: {} } as Paragraph],
+          comments: [
+            { id: 1, author: "A", content: [{ type: "paragraph", formatting: {}, content: [] }] },
+            {
+              id: 2,
+              author: "B",
+              parentId: 1,
+              content: [{ type: "paragraph", formatting: {}, content: [] }],
+            },
+          ],
+        },
+      },
+    };
+    expect(() => applyReplyThreadMarkers(doc)).not.toThrow();
+  });
+
+  test("paraId-less threaded comments get deterministic ids and thread correctly", () => {
+    // A model with threading but NO comment paraIds (e.g. built programmatically).
+    const makeComments = (): Comment[] => [
+      { id: 1, author: "Alice", content: [textParagraph("parent")] },
+      { id: 2, author: "Bob", parentId: 1, content: [textParagraph("reply")] },
+    ];
+
+    const comments = makeComments();
+    ensureThreadedCommentParaIds(comments);
+    const parentParaId = comments[0]?.content.at(-1)?.paraId;
+    const replyParaId = comments[1]?.content.at(-1)?.paraId;
+    expect(parentParaId).toBeTruthy();
+    expect(replyParaId).toBeTruthy();
+    expect(replyParaId).not.toBe(parentParaId);
+
+    // Deterministic: a second run mints the same ids.
+    const again = makeComments();
+    ensureThreadedCommentParaIds(again);
+    expect(again[0]?.content.at(-1)?.paraId).toBe(parentParaId);
+    expect(again[1]?.content.at(-1)?.paraId).toBe(replyParaId);
+
+    // The serialized commentsExtended references those real ids and threads.
+    const extendedXml = serializeCommentsExtended(comments);
+    expect(extendedXml).not.toBeNull();
+    const parsed = parseComments(
+      serializeComments(comments),
+      null,
+      null,
+      new Map(),
+      new Map(),
+      null,
+      extendedXml,
+    );
+    expect(parsed.find((c) => c.id === 2)?.parentId).toBe(1);
+  });
+});
+
+const textParagraph = (text: string): Paragraph => ({
+  type: "paragraph",
+  formatting: {},
+  content: [{ type: "run", formatting: {}, content: [{ type: "text", text }] }],
 });
 
 async function readPart(buffer: ArrayBuffer, path: string): Promise<string> {

--- a/packages/core/src/docx/commentReplyThreads.test.ts
+++ b/packages/core/src/docx/commentReplyThreads.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Reply-thread round-trip tests.
+ *
+ * A threaded comment (a parent + replies, linked in commentsExtended.xml) must
+ * survive a save→re-parse: the reply keeps its `parentId` / `done`, and its
+ * `document.xml` anchor (commentRange markers + reference) is present after both
+ * the selective and the full-repack save paths. Also covers the create-reply
+ * API producing a reply that round-trips as a proper reply.
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { BlockContent, Comment, Document, Paragraph } from "../types/document";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { replyToComment } from "./replyToComment";
+import { repackDocx } from "./rezip";
+import { attemptSelectiveSave } from "./selectiveSave";
+import { serializeCommentsExtended } from "./serializer/commentSerializer";
+
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const BODY_PARA_ID = "B0000001";
+const PARENT_PARA_ID = "AAAA0001";
+const REPLY1_PARA_ID = "AAAA0002";
+const REPLY2_PARA_ID = "AAAA0003";
+
+const PARENT_ID = 1;
+const REPLY1_ID = 2;
+const REPLY2_ID = 3;
+
+type FixtureOptions = {
+  /** Emit the replies' own commentRange markers in document.xml (Word's shape).
+   *  When false, only the parent is anchored so save must synthesize them. */
+  includeReplyMarkers: boolean;
+  /** Mark the parent thread resolved (`w15:done="1"`). */
+  parentDone: boolean;
+};
+
+const anchorParagraph = (includeReplyMarkers: boolean): string => {
+  const starts = includeReplyMarkers
+    ? `<w:commentRangeStart w:id="${PARENT_ID}"/><w:commentRangeStart w:id="${REPLY1_ID}"/><w:commentRangeStart w:id="${REPLY2_ID}"/>`
+    : `<w:commentRangeStart w:id="${PARENT_ID}"/>`;
+  const ref = (id: number): string =>
+    `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="${id}"/></w:r>`;
+  const ends = includeReplyMarkers
+    ? `<w:commentRangeEnd w:id="${PARENT_ID}"/>${ref(PARENT_ID)}<w:commentRangeEnd w:id="${REPLY1_ID}"/>${ref(REPLY1_ID)}<w:commentRangeEnd w:id="${REPLY2_ID}"/>${ref(REPLY2_ID)}`
+    : `<w:commentRangeEnd w:id="${PARENT_ID}"/>${ref(PARENT_ID)}`;
+  return `<w:p w14:paraId="${BODY_PARA_ID}">${starts}<w:r><w:t xml:space="preserve">anchored text</w:t></w:r>${ends}</w:p>`;
+};
+
+const documentXmlFor = (includeReplyMarkers: boolean): string =>
+  `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    ${anchorParagraph(includeReplyMarkers)}
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const comment = (id: number, paraId: string, author: string, text: string): string =>
+  `<w:comment w:id="${id}" w:author="${author}" w:initials="${author[0]}" w:date="2026-05-15T00:00:00Z"><w:p w14:paraId="${paraId}"><w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:annotationRef/></w:r><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p></w:comment>`;
+
+const commentsXml = `${XML_DECLARATION}
+<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${comment(PARENT_ID, PARENT_PARA_ID, "Alice", "parent question")}${comment(REPLY1_ID, REPLY1_PARA_ID, "Bob", "first reply")}${comment(REPLY2_ID, REPLY2_PARA_ID, "Cara", "second reply")}</w:comments>`;
+
+const commentsExtendedXmlFor = (parentDone: boolean): string =>
+  `${XML_DECLARATION}
+<w15:commentsEx xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="${PARENT_PARA_ID}" w15:done="${parentDone ? "1" : "0"}"/><w15:commentEx w15:paraId="${REPLY1_PARA_ID}" w15:paraIdParent="${PARENT_PARA_ID}" w15:done="0"/><w15:commentEx w15:paraId="${REPLY2_PARA_ID}" w15:paraIdParent="${PARENT_PARA_ID}" w15:done="0"/></w15:commentsEx>`;
+
+const stylesXml = `${XML_DECLARATION}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style></w:styles>`;
+
+const corePropertiesXml = `${XML_DECLARATION}
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dcterms:modified xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00.000Z</dcterms:modified></cp:coreProperties>`;
+
+const contentTypesXml = `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/comments.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml"/>
+  <Override PartName="/word/commentsExtended.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+</Types>`;
+
+const packageRelsXml = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+</Relationships>`;
+
+const documentRelsXml = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.styles}" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="${RELATIONSHIP_TYPES.comments}" Target="comments.xml"/>
+  <Relationship Id="rId3" Type="${RELATIONSHIP_TYPES.commentsExtended}" Target="commentsExtended.xml"/>
+</Relationships>`;
+
+const buildThreadedDocx = (options: FixtureOptions): Promise<ArrayBuffer> => {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypesXml);
+  zip.file("_rels/.rels", packageRelsXml);
+  zip.file("word/_rels/document.xml.rels", documentRelsXml);
+  zip.file("word/document.xml", documentXmlFor(options.includeReplyMarkers));
+  zip.file("word/styles.xml", stylesXml);
+  zip.file("word/comments.xml", commentsXml);
+  zip.file("word/commentsExtended.xml", commentsExtendedXmlFor(options.parentDone));
+  zip.file("docProps/core.xml", corePropertiesXml);
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+// A single-comment (non-threaded) document, for the create-reply-via-API case.
+const singleCommentDocumentXml = `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p w14:paraId="${BODY_PARA_ID}"><w:commentRangeStart w:id="${PARENT_ID}"/><w:r><w:t xml:space="preserve">anchored text</w:t></w:r><w:commentRangeEnd w:id="${PARENT_ID}"/><w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="${PARENT_ID}"/></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const singleCommentXml = `${XML_DECLARATION}
+<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${comment(PARENT_ID, PARENT_PARA_ID, "Alice", "parent question")}</w:comments>`;
+
+const singleCommentContentTypes = contentTypesXml.replace(
+  /\s*<Override PartName="\/word\/commentsExtended.xml"[^>]*\/>/u,
+  "",
+);
+
+const singleCommentDocumentRels = `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.styles}" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="${RELATIONSHIP_TYPES.comments}" Target="comments.xml"/>
+</Relationships>`;
+
+const buildSingleCommentDocx = (): Promise<ArrayBuffer> => {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", singleCommentContentTypes);
+  zip.file("_rels/.rels", packageRelsXml);
+  zip.file("word/_rels/document.xml.rels", singleCommentDocumentRels);
+  zip.file("word/document.xml", singleCommentDocumentXml);
+  zip.file("word/styles.xml", stylesXml);
+  zip.file("word/comments.xml", singleCommentXml);
+  zip.file("docProps/core.xml", corePropertiesXml);
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+// ============================================================================
+// MODEL PROJECTIONS
+// ============================================================================
+
+type MarkerIds = {
+  rangeStart: Set<number>;
+  rangeEnd: Set<number>;
+  reference: Set<number>;
+};
+
+const eachParagraph = (blocks: readonly BlockContent[], visit: (p: Paragraph) => void): void => {
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      visit(block);
+    } else if (block.type === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          eachParagraph(cell.content, visit);
+        }
+      }
+    } else {
+      eachParagraph(block.content, visit);
+    }
+  }
+};
+
+const collectMarkerIds = (doc: Document): MarkerIds => {
+  const ids: MarkerIds = { rangeStart: new Set(), rangeEnd: new Set(), reference: new Set() };
+  eachParagraph(doc.package.document.content, (paragraph) => {
+    for (const item of paragraph.content) {
+      if (item.type === "commentRangeStart") {
+        ids.rangeStart.add(item.id);
+      } else if (item.type === "commentRangeEnd") {
+        ids.rangeEnd.add(item.id);
+      } else if (item.type === "commentReference") {
+        ids.reference.add(item.id);
+      }
+    }
+  });
+  return ids;
+};
+
+const commentById = (doc: Document, id: number): Comment | undefined =>
+  (doc.package.document.comments ?? []).find((c) => c.id === id);
+
+const parse = (buffer: ArrayBuffer): Promise<Document> =>
+  parseDocx(buffer, { preloadFonts: false });
+
+const assertRepliesThreaded = (doc: Document): void => {
+  expect(commentById(doc, REPLY1_ID)?.parentId).toBe(PARENT_ID);
+  expect(commentById(doc, REPLY2_ID)?.parentId).toBe(PARENT_ID);
+  // A reply is fully anchored: it has a range AND a reference of its own.
+  const markers = collectMarkerIds(doc);
+  for (const replyId of [REPLY1_ID, REPLY2_ID]) {
+    expect(markers.rangeStart.has(replyId)).toBe(true);
+    expect(markers.rangeEnd.has(replyId)).toBe(true);
+    expect(markers.reference.has(replyId)).toBe(true);
+  }
+};
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe("comment reply threads — parse", () => {
+  test("parses parentId and done from commentsExtended.xml", async () => {
+    const doc = await parse(
+      await buildThreadedDocx({ includeReplyMarkers: true, parentDone: true }),
+    );
+
+    expect(commentById(doc, PARENT_ID)?.parentId).toBeUndefined();
+    expect(commentById(doc, PARENT_ID)?.done).toBe(true);
+    expect(commentById(doc, REPLY1_ID)?.parentId).toBe(PARENT_ID);
+    expect(commentById(doc, REPLY1_ID)?.done).toBe(false);
+    expect(commentById(doc, REPLY2_ID)?.parentId).toBe(PARENT_ID);
+  });
+});
+
+describe("comment reply threads — round-trip", () => {
+  test("full repack keeps replies threaded and anchored", async () => {
+    const buffer = await buildThreadedDocx({ includeReplyMarkers: true, parentDone: true });
+    const doc = await parse(buffer);
+
+    const saved = await repackDocx({ ...doc, originalBuffer: buffer });
+    const reparsed = await parse(saved);
+
+    assertRepliesThreaded(reparsed);
+    expect(commentById(reparsed, PARENT_ID)?.done).toBe(true);
+  });
+
+  test("selective save keeps replies threaded (commentsExtended byte-exact)", async () => {
+    const buffer = await buildThreadedDocx({ includeReplyMarkers: true, parentDone: false });
+    const doc = await parse(buffer);
+
+    const saved = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(saved).not.toBeNull();
+    if (!saved) {
+      return;
+    }
+
+    const originalExtended = await readPart(buffer, "word/commentsExtended.xml");
+    const savedExtended = await readPart(saved, "word/commentsExtended.xml");
+    expect(savedExtended).toBe(originalExtended);
+
+    assertRepliesThreaded(await parse(saved));
+  });
+
+  test("full repack synthesizes reply markers when only the parent is anchored", async () => {
+    const buffer = await buildThreadedDocx({ includeReplyMarkers: false, parentDone: false });
+    const doc = await parse(buffer);
+
+    // The parsed model has the replies threaded but WITHOUT their own markers.
+    const beforeMarkers = collectMarkerIds(doc);
+    expect(beforeMarkers.rangeStart.has(REPLY1_ID)).toBe(false);
+    expect(commentById(doc, REPLY1_ID)?.parentId).toBe(PARENT_ID);
+
+    const saved = await repackDocx({ ...doc, originalBuffer: buffer });
+    assertRepliesThreaded(await parse(saved));
+  });
+
+  test("selective save bails when a reply lacks its own anchor", async () => {
+    const buffer = await buildThreadedDocx({ includeReplyMarkers: false, parentDone: false });
+    const doc = await parse(buffer);
+    const saved = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    // The reply's anchor must be synthesized on the parent's paragraph, which
+    // the selective path cannot do — it hands off to the full repack.
+    expect(saved).toBeNull();
+  });
+});
+
+describe("comment reply threads — create-reply API", () => {
+  test("replyToComment produces a reply that round-trips as a proper reply", async () => {
+    const buffer = await buildSingleCommentDocx();
+    const doc = await parse(buffer);
+
+    const reply = replyToComment(doc, PARENT_ID, { author: "Reviewer", text: "a fresh reply" });
+    expect(reply.parentId).toBe(PARENT_ID);
+
+    // A created reply has no anchor yet, so save goes through the full repack.
+    const saved = await repackDocx({ ...doc, originalBuffer: buffer });
+    const reparsed = await parse(saved);
+
+    const created = commentById(reparsed, reply.id);
+    expect(created?.parentId).toBe(PARENT_ID);
+    const markers = collectMarkerIds(reparsed);
+    expect(markers.rangeStart.has(reply.id)).toBe(true);
+    expect(markers.reference.has(reply.id)).toBe(true);
+  });
+
+  test("serializeCommentsExtended is null for a document with no threads or resolved state", () => {
+    const plain: Comment[] = [
+      {
+        id: 1,
+        author: "Alice",
+        content: [{ type: "paragraph", formatting: {}, content: [] }],
+      },
+    ];
+    expect(serializeCommentsExtended(plain)).toBeNull();
+  });
+});
+
+async function readPart(buffer: ArrayBuffer, path: string): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(path);
+  if (!file) {
+    throw new Error(`No ${path} in package`);
+  }
+  return file.async("text");
+}

--- a/packages/core/src/docx/commentReplyThreads.test.ts
+++ b/packages/core/src/docx/commentReplyThreads.test.ts
@@ -42,6 +42,8 @@ type FixtureOptions = {
   includeReplyMarkers: boolean;
   /** Mark the parent thread resolved (`w15:done="1"`). */
   parentDone: boolean;
+  /** Omit the optional `w15:done` attribute entirely (defaults to "0"/false). */
+  omitDone?: boolean;
 };
 
 const anchorParagraph = (includeReplyMarkers: boolean): string => {
@@ -71,9 +73,11 @@ const comment = (id: number, paraId: string, author: string, text: string): stri
 const commentsXml = `${XML_DECLARATION}
 <w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${comment(PARENT_ID, PARENT_PARA_ID, "Alice", "parent question")}${comment(REPLY1_ID, REPLY1_PARA_ID, "Bob", "first reply")}${comment(REPLY2_ID, REPLY2_PARA_ID, "Cara", "second reply")}</w:comments>`;
 
-const commentsExtendedXmlFor = (parentDone: boolean): string =>
-  `${XML_DECLARATION}
-<w15:commentsEx xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="${PARENT_PARA_ID}" w15:done="${parentDone ? "1" : "0"}"/><w15:commentEx w15:paraId="${REPLY1_PARA_ID}" w15:paraIdParent="${PARENT_PARA_ID}" w15:done="0"/><w15:commentEx w15:paraId="${REPLY2_PARA_ID}" w15:paraIdParent="${PARENT_PARA_ID}" w15:done="0"/></w15:commentsEx>`;
+const commentsExtendedXmlFor = (parentDone: boolean, omitDone = false): string => {
+  const done = (value: "0" | "1"): string => (omitDone ? "" : ` w15:done="${value}"`);
+  return `${XML_DECLARATION}
+<w15:commentsEx xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="${PARENT_PARA_ID}"${done(parentDone ? "1" : "0")}/><w15:commentEx w15:paraId="${REPLY1_PARA_ID}" w15:paraIdParent="${PARENT_PARA_ID}"${done("0")}/><w15:commentEx w15:paraId="${REPLY2_PARA_ID}" w15:paraIdParent="${PARENT_PARA_ID}"${done("0")}/></w15:commentsEx>`;
+};
 
 const stylesXml = `${XML_DECLARATION}
 <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style></w:styles>`;
@@ -113,7 +117,10 @@ const buildThreadedDocx = (options: FixtureOptions): Promise<ArrayBuffer> => {
   zip.file("word/document.xml", documentXmlFor(options.includeReplyMarkers));
   zip.file("word/styles.xml", stylesXml);
   zip.file("word/comments.xml", commentsXml);
-  zip.file("word/commentsExtended.xml", commentsExtendedXmlFor(options.parentDone));
+  zip.file(
+    "word/commentsExtended.xml",
+    commentsExtendedXmlFor(options.parentDone, options.omitDone),
+  );
   zip.file("docProps/core.xml", corePropertiesXml);
   return zip.generateAsync({ type: "arraybuffer" });
 };
@@ -213,6 +220,27 @@ const assertRepliesThreaded = (doc: Document): void => {
   }
 };
 
+/** Rewrite the first text run in the first body paragraph; returns whether it hit. */
+const editFirstBodyText = (doc: Document, newText: string): boolean => {
+  for (const block of doc.package.document.content) {
+    if (block.type !== "paragraph") {
+      continue;
+    }
+    for (const item of block.content) {
+      if (item.type !== "run") {
+        continue;
+      }
+      for (const runItem of item.content) {
+        if (runItem.type === "text") {
+          runItem.text = newText;
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+};
+
 // ============================================================================
 // TESTS
 // ============================================================================
@@ -261,6 +289,36 @@ describe("comment reply threads — round-trip", () => {
     const savedExtended = await readPart(saved, "word/commentsExtended.xml");
     expect(savedExtended).toBe(originalExtended);
 
+    assertRepliesThreaded(await parse(saved));
+  });
+
+  test("a done-less commentsExtended.xml stays byte-exact after an unrelated edit", async () => {
+    // The source omits the optional `w15:done` (defaults to "0"); an unrelated
+    // body edit must not rewrite commentsExtended.xml just because the serializer
+    // would write `w15:done="0"` explicitly.
+    const buffer = await buildThreadedDocx({
+      includeReplyMarkers: true,
+      parentDone: false,
+      omitDone: true,
+    });
+    const doc = await parse(buffer);
+    expect(editFirstBodyText(doc, "anchored text (edited)")).toBe(true);
+
+    const saved = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set([BODY_PARA_ID]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(saved).not.toBeNull();
+    if (!saved) {
+      return;
+    }
+
+    // The edit landed, but commentsExtended.xml is untouched (byte-exact).
+    expect(await readPart(saved, "word/document.xml")).toContain("anchored text (edited)");
+    expect(await readPart(saved, "word/commentsExtended.xml")).toBe(
+      await readPart(buffer, "word/commentsExtended.xml"),
+    );
     assertRepliesThreaded(await parse(saved));
   });
 

--- a/packages/core/src/docx/relsParser.ts
+++ b/packages/core/src/docx/relsParser.ts
@@ -54,6 +54,7 @@ export const RELATIONSHIP_TYPES = {
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties",
   customXml: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml",
   comments: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments",
+  commentsExtended: "http://schemas.microsoft.com/office/2011/relationships/commentsExtended",
 } as const;
 
 /**

--- a/packages/core/src/docx/replyToComment.ts
+++ b/packages/core/src/docx/replyToComment.ts
@@ -56,30 +56,37 @@ const freshParaId = (used: Set<string>): string => {
  * return it, mutating the thread root's last paragraph to guarantee it has a
  * paraId. Does NOT append the reply to `comments` — the caller owns storage
  * (the standalone {@link replyToComment} writes it back to the document model;
- * the headless reviewer keeps its own created-comment list). Throws when the
- * parent comment does not exist. A reply to a reply re-parents onto the same
- * thread as the target (Word threads are flat: every reply links to the root).
+ * the headless reviewer keeps its own created-comment list). Returns `null` when
+ * the parent comment does not exist, or is malformed (no paragraphs) so it
+ * cannot anchor a thread. A reply to a reply re-parents onto the same thread as
+ * the target (Word threads are flat: every reply links to the root).
  */
 export const createReply = (
   comments: readonly Comment[],
   parentCommentId: number,
   input: CreateCommentReplyInput,
-): Comment => {
+): Comment | null => {
   const parent = comments.find((comment) => comment.id === parentCommentId);
   if (!parent) {
-    throw new Error(`replyToComment: no comment with id ${parentCommentId}`);
+    return null;
   }
   // Word models replies as a flat list under the thread root, so a reply to a
   // reply attaches to that reply's parent rather than nesting.
   const threadRootId = parent.parentId ?? parent.id;
 
-  const used = usedParaIds(comments);
+  // The root's last paragraph is the thread key; a comment with no paragraphs
+  // (malformed / empty) cannot anchor a reply, so refuse rather than index into
+  // an empty array.
+  const threadRoot = comments.find((comment) => comment.id === threadRootId) ?? parent;
+  const rootLastParagraph = (threadRoot.content ?? []).at(-1);
+  if (!rootLastParagraph) {
+    return null;
+  }
 
+  const used = usedParaIds(comments);
   // The root's last paragraph must carry a paraId so the reply can reference it
   // via `w15:paraIdParent`; a doc authored without paraIds gets one now.
-  const threadRoot = comments.find((comment) => comment.id === threadRootId) ?? parent;
-  const rootLastParagraph = threadRoot.content.at(-1);
-  if (rootLastParagraph && !rootLastParagraph.paraId) {
+  if (!rootLastParagraph.paraId) {
     rootLastParagraph.paraId = freshParaId(used);
   }
 
@@ -102,16 +109,20 @@ export const createReply = (
 
 /**
  * Append a reply to `parentCommentId` in `doc`'s comment list, mutating the
- * document model in place, and return the created reply. Throws when the parent
- * comment does not exist.
+ * document model in place, and return the created reply. Returns `null` when the
+ * parent comment does not exist or cannot anchor a thread (see
+ * {@link createReply}).
  */
 export const replyToComment = (
   doc: Document,
   parentCommentId: number,
   input: CreateCommentReplyInput,
-): Comment => {
+): Comment | null => {
   const comments = doc.package.document.comments ?? [];
   const reply = createReply(comments, parentCommentId, input);
+  if (!reply) {
+    return null;
+  }
   doc.package.document.comments = [...comments, reply];
   return reply;
 };

--- a/packages/core/src/docx/replyToComment.ts
+++ b/packages/core/src/docx/replyToComment.ts
@@ -1,0 +1,117 @@
+/**
+ * Create a threaded reply to an existing comment.
+ *
+ * Produces a new `Comment` whose `parentId` points at the target comment and
+ * whose last paragraph carries a fresh `w14:paraId`, and guarantees the parent
+ * has a paraId too — the two ids Word uses to link a reply to its thread in
+ * `commentsExtended.xml` (`w15:paraId` / `w15:paraIdParent`). The reply's
+ * `document.xml` range markers are synthesized at save time by
+ * {@link applyReplyThreadMarkers}, so no anchor work is needed here.
+ */
+
+import type { Comment, Document, Paragraph } from "../types/document";
+import { generateHexId } from "../utils/hexId";
+
+export type CreateCommentReplyInput = {
+  author: string;
+  text: string;
+  initials?: string;
+  /** ISO date; defaults to now. */
+  date?: string;
+};
+
+const nextCommentId = (comments: readonly Comment[]): number => {
+  let max = 0;
+  for (const comment of comments) {
+    if (comment.id > max) {
+      max = comment.id;
+    }
+  }
+  return max + 1;
+};
+
+const usedParaIds = (comments: readonly Comment[]): Set<string> => {
+  const ids = new Set<string>();
+  for (const comment of comments) {
+    for (const paragraph of comment.content) {
+      if (paragraph.paraId) {
+        ids.add(paragraph.paraId.toUpperCase());
+      }
+    }
+  }
+  return ids;
+};
+
+const freshParaId = (used: Set<string>): string => {
+  let id = generateHexId();
+  while (used.has(id.toUpperCase())) {
+    id = generateHexId();
+  }
+  used.add(id.toUpperCase());
+  return id;
+};
+
+/**
+ * Build a reply to `parentCommentId` against an existing comment list and
+ * return it, mutating the thread root's last paragraph to guarantee it has a
+ * paraId. Does NOT append the reply to `comments` — the caller owns storage
+ * (the standalone {@link replyToComment} writes it back to the document model;
+ * the headless reviewer keeps its own created-comment list). Throws when the
+ * parent comment does not exist. A reply to a reply re-parents onto the same
+ * thread as the target (Word threads are flat: every reply links to the root).
+ */
+export const createReply = (
+  comments: readonly Comment[],
+  parentCommentId: number,
+  input: CreateCommentReplyInput,
+): Comment => {
+  const parent = comments.find((comment) => comment.id === parentCommentId);
+  if (!parent) {
+    throw new Error(`replyToComment: no comment with id ${parentCommentId}`);
+  }
+  // Word models replies as a flat list under the thread root, so a reply to a
+  // reply attaches to that reply's parent rather than nesting.
+  const threadRootId = parent.parentId ?? parent.id;
+
+  const used = usedParaIds(comments);
+
+  // The root's last paragraph must carry a paraId so the reply can reference it
+  // via `w15:paraIdParent`; a doc authored without paraIds gets one now.
+  const threadRoot = comments.find((comment) => comment.id === threadRootId) ?? parent;
+  const rootLastParagraph = threadRoot.content.at(-1);
+  if (rootLastParagraph && !rootLastParagraph.paraId) {
+    rootLastParagraph.paraId = freshParaId(used);
+  }
+
+  const replyParagraph: Paragraph = {
+    type: "paragraph",
+    formatting: {},
+    paraId: freshParaId(used),
+    content: [{ type: "run", formatting: {}, content: [{ type: "text", text: input.text }] }],
+  };
+
+  return {
+    id: nextCommentId(comments),
+    author: input.author,
+    date: input.date ?? new Date().toISOString(),
+    parentId: threadRootId,
+    content: [replyParagraph],
+    ...(input.initials !== undefined ? { initials: input.initials } : {}),
+  };
+};
+
+/**
+ * Append a reply to `parentCommentId` in `doc`'s comment list, mutating the
+ * document model in place, and return the created reply. Throws when the parent
+ * comment does not exist.
+ */
+export const replyToComment = (
+  doc: Document,
+  parentCommentId: number,
+  input: CreateCommentReplyInput,
+): Comment => {
+  const comments = doc.package.document.comments ?? [];
+  const reply = createReply(comments, parentCommentId, input);
+  doc.package.document.comments = [...comments, reply];
+  return reply;
+};

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -32,13 +32,14 @@
 import { panic } from "better-result";
 import JSZip from "jszip";
 
-import type { BlockContent, HeaderFooter, Image, Hyperlink } from "../types/content";
+import type { BlockContent, Comment, HeaderFooter, Image, Hyperlink } from "../types/content";
 import type { Document, Watermark } from "../types/document";
+import { applyReplyThreadMarkers } from "./commentReplyMarkers";
 import { parseEndnotes, parseFootnotes } from "./footnoteParser";
 import { assertValidFolioDocumentModel } from "./modelValidation";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import { buildPatchedNoteXml, collectParaIds, extractParagraphXml } from "./selectiveXmlPatch";
-import { serializeComments } from "./serializer/commentSerializer";
+import { serializeComments, serializeCommentsExtended } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
@@ -157,7 +158,54 @@ async function serializeCommentsToZip(
   await Promise.all([
     ensureCommentsContentType(zip, compressionLevel),
     ensureCommentsRelationship(zip, compressionLevel),
+    writeCommentsExtendedToZip(comments, zip, compressionLevel),
   ]);
+}
+
+/**
+ * Write `word/commentsExtended.xml` (reply threading + resolved state) plus its
+ * content-type override and relationship, or remove a stale part when the model
+ * no longer needs one. The reply-thread markers in `document.xml` are
+ * synthesized separately (see {@link applyReplyThreadMarkers}); this is the part
+ * that links each reply to its parent.
+ */
+async function writeCommentsExtendedToZip(
+  comments: Comment[],
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const xml = serializeCommentsExtended(comments);
+  const existing = findZipEntryCaseInsensitive(zip, "word/commentsextended.xml");
+  if (!xml) {
+    // No thread/resolved state to record. Drop a stale baseline part so a
+    // removed thread does not resurrect on the next open.
+    if (existing) {
+      zip.remove(existing.name);
+    }
+    return;
+  }
+
+  zip.file(existing?.name ?? "word/commentsExtended.xml", xml, {
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
+  await Promise.all([
+    ensureCommentsExtendedContentType(zip, compressionLevel),
+    ensureCommentsExtendedRelationship(zip, compressionLevel),
+  ]);
+}
+
+function findZipEntryCaseInsensitive(zip: JSZip, lowerPath: string): JSZip.JSZipObject | null {
+  const direct = zip.file(lowerPath);
+  if (direct) {
+    return direct;
+  }
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && path.toLowerCase() === lowerPath) {
+      return file;
+    }
+  }
+  return null;
 }
 
 // ============================================================================
@@ -625,6 +673,10 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
 
   assertValidFolioDocumentModel(exportDocument, "Cannot repack invalid DOCX document model");
 
+  // Give every reply comment its parent's anchor before serializing, so the
+  // reply round-trips with matching commentRange markers + reference.
+  applyReplyThreadMarkers(exportDocument);
+
   // Serialize and update document.xml (after image/hyperlink rIds have been rewritten)
   const documentXml = serializeDocument(exportDocument);
   const originalDocumentXml = await originalZip.file("word/document.xml")?.async("text");
@@ -734,6 +786,10 @@ export async function repackDocxFromRaw(
 
   assertValidFolioDocumentModel(exportDocument, "Cannot repack invalid DOCX document model");
 
+  // Give every reply comment its parent's anchor before serializing, so the
+  // reply round-trips with matching commentRange markers + reference.
+  applyReplyThreadMarkers(exportDocument);
+
   const documentXml = serializeDocument(exportDocument);
   if (rawContent.documentXml) {
     assertDocumentPackageFidelity(rawContent.documentXml, documentXml, exportDocument);
@@ -788,6 +844,9 @@ export async function repackDocxFromRaw(
 export const COMMENTS_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml";
 
+export const COMMENTS_EXTENDED_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml";
+
 /**
  * Ensure [Content_Types].xml contains an Override for word/comments.xml.
  * If the document already had comments, this is a no-op.
@@ -841,6 +900,62 @@ async function ensureCommentsRelationship(zip: JSZip, compressionLevel: number):
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
+}
+
+/** Ensure [Content_Types].xml overrides word/commentsExtended.xml. No-op if present. */
+async function ensureCommentsExtendedContentType(
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const ctFile = zip.file("[Content_Types].xml");
+  if (!ctFile) {
+    return;
+  }
+
+  const ctXml = await ctFile.async("text");
+  if (ctXml.toLowerCase().includes("/word/commentsextended.xml")) {
+    return;
+  }
+
+  zip.file(
+    "[Content_Types].xml",
+    ctXml.replace(
+      "</Types>",
+      `<Override PartName="/word/commentsExtended.xml" ContentType="${COMMENTS_EXTENDED_CONTENT_TYPE}"/></Types>`,
+    ),
+    { compression: "DEFLATE", compressionOptions: { level: compressionLevel } },
+  );
+}
+
+/**
+ * Ensure word/_rels/document.xml.rels references commentsExtended.xml. No-op if
+ * present. Word reaches the part through this relationship, so a freshly added
+ * part (a reply created on a document that had none) needs it wired up.
+ */
+async function ensureCommentsExtendedRelationship(
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const relsPath = "word/_rels/document.xml.rels";
+  const relsFile = zip.file(relsPath);
+  if (!relsFile) {
+    return;
+  }
+
+  const relsXml = await relsFile.async("text");
+  if (relsXml.toLowerCase().includes("commentsextended.xml")) {
+    return;
+  }
+
+  const newRId = `rId${findMaxRId(relsXml) + 1}`;
+  zip.file(
+    relsPath,
+    relsXml.replace(
+      "</Relationships>",
+      `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.commentsExtended}" Target="commentsExtended.xml"/></Relationships>`,
+    ),
+    { compression: "DEFLATE", compressionOptions: { level: compressionLevel } },
+  );
 }
 
 // ============================================================================

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -39,7 +39,11 @@ import { parseEndnotes, parseFootnotes } from "./footnoteParser";
 import { assertValidFolioDocumentModel } from "./modelValidation";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import { buildPatchedNoteXml, collectParaIds, extractParagraphXml } from "./selectiveXmlPatch";
-import { serializeComments, serializeCommentsExtended } from "./serializer/commentSerializer";
+import {
+  ensureThreadedCommentParaIds,
+  serializeComments,
+  serializeCommentsExtended,
+} from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
@@ -149,50 +153,100 @@ async function serializeCommentsToZip(
     return;
   }
 
+  // Threaded/resolved comments need a stable last-paragraph paraId so
+  // comments.xml and commentsExtended.xml reference the same key.
+  ensureThreadedCommentParaIds(comments);
+
   const commentsXml = serializeComments(comments);
   zip.file("word/comments.xml", commentsXml, {
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
 
-  await Promise.all([
-    ensureCommentsContentType(zip, compressionLevel),
-    ensureCommentsRelationship(zip, compressionLevel),
-    writeCommentsExtendedToZip(comments, zip, compressionLevel),
-  ]);
+  // Sequential, not Promise.all: comments.xml and commentsExtended.xml both
+  // edit [Content_Types].xml and document.xml.rels, so concurrent
+  // read-modify-write would drop one part's override/relationship.
+  await ensureCommentsContentType(zip, compressionLevel);
+  await ensureCommentsRelationship(zip, compressionLevel);
+  await syncCommentsExtendedPart(comments, zip, compressionLevel);
 }
 
 /**
- * Write `word/commentsExtended.xml` (reply threading + resolved state) plus its
- * content-type override and relationship, or remove a stale part when the model
- * no longer needs one. The reply-thread markers in `document.xml` are
- * synthesized separately (see {@link applyReplyThreadMarkers}); this is the part
- * that links each reply to its parent.
+ * Bring `word/commentsExtended.xml` and its packaging (content-type override +
+ * relationship) in line with the model: write the part when there is thread /
+ * resolved state to record, or remove the part AND its override AND its
+ * relationship together when there is none. Managing all three consistently
+ * keeps the package valid (a dangling override or a relationship pointing at a
+ * removed part triggers Word's repair prompt). The reply-thread markers in
+ * `document.xml` are synthesized separately (see {@link applyReplyThreadMarkers}).
  */
-async function writeCommentsExtendedToZip(
+async function syncCommentsExtendedPart(
   comments: Comment[],
   zip: JSZip,
   compressionLevel: number,
 ): Promise<void> {
   const xml = serializeCommentsExtended(comments);
-  const existing = findZipEntryCaseInsensitive(zip, "word/commentsextended.xml");
+  const existing = findZipEntryCaseInsensitive(zip, COMMENTS_EXTENDED_PART_LOWER);
+
   if (!xml) {
-    // No thread/resolved state to record. Drop a stale baseline part so a
-    // removed thread does not resurrect on the next open.
-    if (existing) {
-      zip.remove(existing.name);
+    // No thread/resolved state to record. Drop the part with its override and
+    // relationship so a removed thread neither resurrects nor dangles.
+    if (!existing) {
+      return;
     }
+    zip.remove(existing.name);
+    await transformPackagingFile(
+      zip,
+      "[Content_Types].xml",
+      removeCommentsExtendedOverride,
+      compressionLevel,
+    );
+    await transformPackagingFile(
+      zip,
+      "word/_rels/document.xml.rels",
+      removeCommentsExtendedRelationship,
+      compressionLevel,
+    );
     return;
   }
 
-  zip.file(existing?.name ?? "word/commentsExtended.xml", xml, {
+  zip.file(existing?.name ?? COMMENTS_EXTENDED_PART, xml, {
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
-  await Promise.all([
-    ensureCommentsExtendedContentType(zip, compressionLevel),
-    ensureCommentsExtendedRelationship(zip, compressionLevel),
-  ]);
+  await transformPackagingFile(
+    zip,
+    "[Content_Types].xml",
+    addCommentsExtendedOverride,
+    compressionLevel,
+  );
+  await transformPackagingFile(
+    zip,
+    "word/_rels/document.xml.rels",
+    addCommentsExtendedRelationship,
+    compressionLevel,
+  );
+}
+
+/** Read a packaging file, apply a pure transform, and write it back if it changed. */
+async function transformPackagingFile(
+  zip: JSZip,
+  path: string,
+  transform: (xml: string) => string,
+  compressionLevel: number,
+): Promise<void> {
+  const file = zip.file(path);
+  if (!file) {
+    return;
+  }
+  const xml = await file.async("text");
+  const next = transform(xml);
+  if (next !== xml) {
+    zip.file(path, next, {
+      compression: "DEFLATE",
+      compressionOptions: { level: compressionLevel },
+    });
+  }
 }
 
 function findZipEntryCaseInsensitive(zip: JSZip, lowerPath: string): JSZip.JSZipObject | null {
@@ -847,6 +901,42 @@ export const COMMENTS_CONTENT_TYPE =
 export const COMMENTS_EXTENDED_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml";
 
+export const COMMENTS_EXTENDED_PART = "word/commentsExtended.xml";
+export const COMMENTS_EXTENDED_PART_LOWER = "word/commentsextended.xml";
+
+// Pure [Content_Types].xml / .rels transforms for the commentsExtended part.
+// Shared by the full-repack and selective save paths so both add and remove the
+// part's override + relationship the same way (see syncCommentsExtendedPart).
+
+export function addCommentsExtendedOverride(contentTypesXml: string): string {
+  if (contentTypesXml.toLowerCase().includes("/word/commentsextended.xml")) {
+    return contentTypesXml;
+  }
+  return contentTypesXml.replace(
+    "</Types>",
+    `<Override PartName="/word/commentsExtended.xml" ContentType="${COMMENTS_EXTENDED_CONTENT_TYPE}"/></Types>`,
+  );
+}
+
+export function removeCommentsExtendedOverride(contentTypesXml: string): string {
+  return contentTypesXml.replace(/<Override\b[^>]*commentsExtended\.xml[^>]*\/>/giu, "");
+}
+
+export function addCommentsExtendedRelationship(relsXml: string): string {
+  if (relsXml.toLowerCase().includes("commentsextended.xml")) {
+    return relsXml;
+  }
+  const newRId = `rId${findMaxRId(relsXml) + 1}`;
+  return relsXml.replace(
+    "</Relationships>",
+    `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.commentsExtended}" Target="commentsExtended.xml"/></Relationships>`,
+  );
+}
+
+export function removeCommentsExtendedRelationship(relsXml: string): string {
+  return relsXml.replace(/<Relationship\b[^>]*commentsExtended\.xml[^>]*\/>/giu, "");
+}
+
 /**
  * Ensure [Content_Types].xml contains an Override for word/comments.xml.
  * If the document already had comments, this is a no-op.
@@ -900,62 +990,6 @@ async function ensureCommentsRelationship(zip: JSZip, compressionLevel: number):
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
-}
-
-/** Ensure [Content_Types].xml overrides word/commentsExtended.xml. No-op if present. */
-async function ensureCommentsExtendedContentType(
-  zip: JSZip,
-  compressionLevel: number,
-): Promise<void> {
-  const ctFile = zip.file("[Content_Types].xml");
-  if (!ctFile) {
-    return;
-  }
-
-  const ctXml = await ctFile.async("text");
-  if (ctXml.toLowerCase().includes("/word/commentsextended.xml")) {
-    return;
-  }
-
-  zip.file(
-    "[Content_Types].xml",
-    ctXml.replace(
-      "</Types>",
-      `<Override PartName="/word/commentsExtended.xml" ContentType="${COMMENTS_EXTENDED_CONTENT_TYPE}"/></Types>`,
-    ),
-    { compression: "DEFLATE", compressionOptions: { level: compressionLevel } },
-  );
-}
-
-/**
- * Ensure word/_rels/document.xml.rels references commentsExtended.xml. No-op if
- * present. Word reaches the part through this relationship, so a freshly added
- * part (a reply created on a document that had none) needs it wired up.
- */
-async function ensureCommentsExtendedRelationship(
-  zip: JSZip,
-  compressionLevel: number,
-): Promise<void> {
-  const relsPath = "word/_rels/document.xml.rels";
-  const relsFile = zip.file(relsPath);
-  if (!relsFile) {
-    return;
-  }
-
-  const relsXml = await relsFile.async("text");
-  if (relsXml.toLowerCase().includes("commentsextended.xml")) {
-    return;
-  }
-
-  const newRId = `rId${findMaxRId(relsXml) + 1}`;
-  zip.file(
-    relsPath,
-    relsXml.replace(
-      "</Relationships>",
-      `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.commentsExtended}" Target="commentsExtended.xml"/></Relationships>`,
-    ),
-    { compression: "DEFLATE", compressionOptions: { level: compressionLevel } },
-  );
 }
 
 // ============================================================================

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -23,11 +23,18 @@ import {
   hasUnmaterializedHeaderFooter,
   hasModelDrivenPictureWatermark,
   COMMENTS_CONTENT_TYPE,
-  COMMENTS_EXTENDED_CONTENT_TYPE,
+  COMMENTS_EXTENDED_PART,
+  COMMENTS_EXTENDED_PART_LOWER,
+  addCommentsExtendedOverride,
+  addCommentsExtendedRelationship,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
 import { buildPatchedDocumentXml, buildPatchedNoteXml, collectParaIds } from "./selectiveXmlPatch";
-import { serializeComments, serializeCommentsExtended } from "./serializer/commentSerializer";
+import {
+  ensureThreadedCommentParaIds,
+  serializeComments,
+  serializeCommentsExtended,
+} from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
 
@@ -206,61 +213,72 @@ const commentsExtendedInfoEqual = (
 };
 
 /**
- * Add commentsExtended.xml to `updates` only when the model's reply threading /
- * resolved state differs from what the existing part encodes (compared through
- * the same parser, so attribute-order noise is ignored). An unchanged thread
- * leaves the part byte-exact; a removed one is left to the full repack.
+ * Reconcile commentsExtended.xml on the selective path. Returns `false` to
+ * signal the caller must bail to a full repack (which owns removing / rewiring
+ * the part + content-type + relationship as a unit); `true` when the part is
+ * unchanged or was safely patched into `updates`.
+ *
+ * - Threading unchanged (compared through the same parser, so attribute-order
+ *   noise is ignored): leave the part byte-exact.
+ * - Threading removed (no desired part but a baseline exists): bail — removing
+ *   the part plus its dangling override/relationship cleanly is the full
+ *   repack's job.
+ * - Threading changed: write the part and ensure its override + relationship,
+ *   bailing if the packaging files needed to wire it are absent.
  */
 async function patchCommentsExtended(
   zip: JSZip,
   comments: Comment[],
   updates: Map<string, string>,
-): Promise<void> {
+): Promise<boolean> {
   const desiredXml = serializeCommentsExtended(comments);
+  const existing = findZipEntryCaseInsensitive(zip, COMMENTS_EXTENDED_PART_LOWER);
+
   if (!desiredXml) {
-    return;
+    return existing === null;
   }
 
-  const existing = findZipEntryCaseInsensitive(zip, "word/commentsextended.xml");
   const baselineInfo = existing
     ? parseCommentsExtended(await existing.async("text"))
     : new Map<string, CommentExtendedInfo>();
   if (commentsExtendedInfoEqual(parseCommentsExtended(desiredXml), baselineInfo)) {
-    return;
+    return true;
   }
 
-  updates.set(existing?.name ?? "word/commentsExtended.xml", desiredXml);
-  await ensureCommentsExtendedPackaging(zip, updates);
+  updates.set(existing?.name ?? COMMENTS_EXTENDED_PART, desiredXml);
+  return ensureCommentsExtendedPackaging(zip, updates);
 }
 
-/** Add the content-type override + relationship for commentsExtended.xml if absent. */
+/**
+ * Add the content-type override + relationship for commentsExtended.xml if
+ * absent, composing over any pending `updates`. Returns `false` when a packaging
+ * file needed to wire the part is missing (the caller then bails to full repack
+ * rather than write a part nothing references).
+ */
 async function ensureCommentsExtendedPackaging(
   zip: JSZip,
   updates: Map<string, string>,
-): Promise<void> {
+): Promise<boolean> {
   const ctPath = "[Content_Types].xml";
   const ctXml = updates.get(ctPath) ?? (await zip.file(ctPath)?.async("text"));
-  if (ctXml && !ctXml.toLowerCase().includes("/word/commentsextended.xml")) {
-    updates.set(
-      ctPath,
-      ctXml.replace(
-        "</Types>",
-        `<Override PartName="/word/commentsExtended.xml" ContentType="${COMMENTS_EXTENDED_CONTENT_TYPE}"/></Types>`,
-      ),
-    );
+  if (ctXml === undefined) {
+    return false;
+  }
+  const nextCt = addCommentsExtendedOverride(ctXml);
+  if (nextCt !== ctXml) {
+    updates.set(ctPath, nextCt);
   }
 
   const relsPath = "word/_rels/document.xml.rels";
   const relsXml = updates.get(relsPath) ?? (await zip.file(relsPath)?.async("text"));
-  if (relsXml && !relsXml.toLowerCase().includes("commentsextended.xml")) {
-    updates.set(
-      relsPath,
-      relsXml.replace(
-        "</Relationships>",
-        `<Relationship Id="rId${findMaxRId(relsXml) + 1}" Type="${RELATIONSHIP_TYPES.commentsExtended}" Target="commentsExtended.xml"/></Relationships>`,
-      ),
-    );
+  if (relsXml === undefined) {
+    return false;
   }
+  const nextRels = addCommentsExtendedRelationship(relsXml);
+  if (nextRels !== relsXml) {
+    updates.set(relsPath, nextRels);
+  }
+  return true;
 }
 
 export type SelectiveSaveOptions = {
@@ -393,6 +411,9 @@ export async function attemptSelectiveSave(
     // previous part as-is) and round-trip back as phantom threads.
     const hadCommentsFile = zip.file("word/comments.xml") !== null;
     if (hasComments || hadCommentsFile) {
+      // Threaded/resolved comments need a stable last-paragraph paraId so
+      // comments.xml and commentsExtended.xml reference the same key.
+      ensureThreadedCommentParaIds(comments);
       updates.set("word/comments.xml", serializeComments(comments));
     }
     if (hasComments) {
@@ -431,8 +452,11 @@ export async function attemptSelectiveSave(
 
     // Reply threading / resolved state lives in commentsExtended.xml. Rewrite it
     // only when the model's threading differs from what the file already
-    // encodes, so an unrelated body edit leaves the part byte-exact.
-    await patchCommentsExtended(zip, comments, updates);
+    // encodes, so an unrelated body edit leaves the part byte-exact. Bail to
+    // full repack when the part cannot be reconciled safely (e.g. a removal).
+    if (!(await patchCommentsExtended(zip, comments, updates))) {
+      return null;
+    }
 
     // Serialize modified headers/footers
     for (const [path, xml] of headerFooterUpdates) {

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -205,7 +205,14 @@ const commentsExtendedInfoEqual = (
   }
   for (const [paraId, infoA] of a) {
     const infoB = b.get(paraId);
-    if (!infoB || infoA.parentParaId !== infoB.parentParaId || infoA.done !== infoB.done) {
+    // `w15:done` is optional and defaults to "0"/false, so a source that omits
+    // it must compare equal to one that writes `w15:done="0"` — otherwise an
+    // unchanged, done-less thread is flagged as changed and needlessly rewritten.
+    if (
+      !infoB ||
+      infoA.parentParaId !== infoB.parentParaId ||
+      (infoA.done ?? false) !== (infoB.done ?? false)
+    ) {
       return false;
     }
   }

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -10,7 +10,9 @@
 
 import type JSZip from "jszip";
 
-import type { Document, BlockContent } from "../types/document";
+import type { Document, BlockContent, Comment } from "../types/document";
+import { parseCommentsExtended, type CommentExtendedInfo } from "./commentParser";
+import { hasUnsynthesizedReplyRanges } from "./commentReplyMarkers";
 import { validateFolioDocumentModel } from "./modelValidation";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import {
@@ -21,10 +23,11 @@ import {
   hasUnmaterializedHeaderFooter,
   hasModelDrivenPictureWatermark,
   COMMENTS_CONTENT_TYPE,
+  COMMENTS_EXTENDED_CONTENT_TYPE,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
 import { buildPatchedDocumentXml, buildPatchedNoteXml, collectParaIds } from "./selectiveXmlPatch";
-import { serializeComments } from "./serializer/commentSerializer";
+import { serializeComments, serializeCommentsExtended } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
 
@@ -173,6 +176,93 @@ async function patchNoteParts(
   return remainingIds;
 }
 
+const findZipEntryCaseInsensitive = (zip: JSZip, lowerPath: string): JSZip.JSZipObject | null => {
+  const direct = zip.file(lowerPath);
+  if (direct) {
+    return direct;
+  }
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && path.toLowerCase() === lowerPath) {
+      return file;
+    }
+  }
+  return null;
+};
+
+const commentsExtendedInfoEqual = (
+  a: Map<string, CommentExtendedInfo>,
+  b: Map<string, CommentExtendedInfo>,
+): boolean => {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const [paraId, infoA] of a) {
+    const infoB = b.get(paraId);
+    if (!infoB || infoA.parentParaId !== infoB.parentParaId || infoA.done !== infoB.done) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Add commentsExtended.xml to `updates` only when the model's reply threading /
+ * resolved state differs from what the existing part encodes (compared through
+ * the same parser, so attribute-order noise is ignored). An unchanged thread
+ * leaves the part byte-exact; a removed one is left to the full repack.
+ */
+async function patchCommentsExtended(
+  zip: JSZip,
+  comments: Comment[],
+  updates: Map<string, string>,
+): Promise<void> {
+  const desiredXml = serializeCommentsExtended(comments);
+  if (!desiredXml) {
+    return;
+  }
+
+  const existing = findZipEntryCaseInsensitive(zip, "word/commentsextended.xml");
+  const baselineInfo = existing
+    ? parseCommentsExtended(await existing.async("text"))
+    : new Map<string, CommentExtendedInfo>();
+  if (commentsExtendedInfoEqual(parseCommentsExtended(desiredXml), baselineInfo)) {
+    return;
+  }
+
+  updates.set(existing?.name ?? "word/commentsExtended.xml", desiredXml);
+  await ensureCommentsExtendedPackaging(zip, updates);
+}
+
+/** Add the content-type override + relationship for commentsExtended.xml if absent. */
+async function ensureCommentsExtendedPackaging(
+  zip: JSZip,
+  updates: Map<string, string>,
+): Promise<void> {
+  const ctPath = "[Content_Types].xml";
+  const ctXml = updates.get(ctPath) ?? (await zip.file(ctPath)?.async("text"));
+  if (ctXml && !ctXml.toLowerCase().includes("/word/commentsextended.xml")) {
+    updates.set(
+      ctPath,
+      ctXml.replace(
+        "</Types>",
+        `<Override PartName="/word/commentsExtended.xml" ContentType="${COMMENTS_EXTENDED_CONTENT_TYPE}"/></Types>`,
+      ),
+    );
+  }
+
+  const relsPath = "word/_rels/document.xml.rels";
+  const relsXml = updates.get(relsPath) ?? (await zip.file(relsPath)?.async("text"));
+  if (relsXml && !relsXml.toLowerCase().includes("commentsextended.xml")) {
+    updates.set(
+      relsPath,
+      relsXml.replace(
+        "</Relationships>",
+        `<Relationship Id="rId${findMaxRId(relsXml) + 1}" Type="${RELATIONSHIP_TYPES.commentsExtended}" Target="commentsExtended.xml"/></Relationships>`,
+      ),
+    );
+  }
+}
+
 export type SelectiveSaveOptions = {
   /** Changed paragraph IDs to selectively patch */
   changedParaIds: Set<string>;
@@ -229,6 +319,12 @@ export async function attemptSelectiveSave(
   // A picture watermark spanning multiple headers needs per-header image
   // relationship rebinding, which only the full repack path performs.
   if (hasModelDrivenPictureWatermark(doc)) {
+    return null;
+  }
+  // A reply with no anchor of its own must get its parent's commentRange
+  // markers, which means editing the parent's paragraph — not necessarily one of
+  // `changedParaIds`. The full repack owns that synthesis, so hand off to it.
+  if (hasUnsynthesizedReplyRanges(doc)) {
     return null;
   }
   if (!validateFolioDocumentModel(doc).valid) {
@@ -332,6 +428,11 @@ export async function attemptSelectiveSave(
         }
       }
     }
+
+    // Reply threading / resolved state lives in commentsExtended.xml. Rewrite it
+    // only when the model's threading differs from what the file already
+    // encodes, so an unrelated body edit leaves the part byte-exact.
+    await patchCommentsExtended(zip, comments, updates);
 
     // Serialize modified headers/footers
     for (const [path, xml] of headerFooterUpdates) {

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -4,6 +4,7 @@
  * Serializes Comment[] to OOXML comments.xml format.
  */
 
+import { deterministicHexId } from "../../utils/hexId";
 import type { Comment, Paragraph, Run } from "../../types/content";
 import { escapeXml } from "./xmlUtils";
 
@@ -157,7 +158,91 @@ export function serializeComments(comments: Comment[]): string {
 
 /** The `w14:paraId` Word threads a comment by: its LAST paragraph's paraId. */
 function commentThreadParaId(comment: Comment): string | undefined {
-  return comment.content.at(-1)?.paraId;
+  return comment.content?.at(-1)?.paraId;
+}
+
+/**
+ * The ids of comments that need a `commentsExtended.xml` entry: a reply, a
+ * reply's parent (the thread root), or any comment carrying a resolved state.
+ * A plain top-level comment set yields an empty set, so no part is written.
+ */
+function threadedCommentIds(comments: readonly Comment[]): Set<number> {
+  const replyParents = new Set<number>();
+  for (const comment of comments) {
+    if (comment.parentId !== undefined) {
+      replyParents.add(comment.parentId);
+    }
+  }
+  const ids = new Set<number>();
+  for (const comment of comments) {
+    if (
+      comment.parentId !== undefined ||
+      replyParents.has(comment.id) ||
+      comment.done !== undefined
+    ) {
+      ids.add(comment.id);
+    }
+  }
+  return ids;
+}
+
+const commentPlainText = (comment: Comment): string => {
+  let text = "";
+  for (const paragraph of comment.content ?? []) {
+    for (const item of paragraph.content ?? []) {
+      if (item.type !== "run") {
+        continue;
+      }
+      for (const runItem of item.content ?? []) {
+        if (runItem.type === "text") {
+          text += runItem.text;
+        }
+      }
+    }
+  }
+  return text;
+};
+
+/**
+ * Assign a deterministic `w14:paraId` to the LAST paragraph of every comment
+ * that needs a commentsExtended entry (a reply, a reply's parent, or a resolved
+ * comment) but has none. A document authored or loaded without comment paraIds
+ * would otherwise have no stable key to thread through commentsExtended.xml, and
+ * the thread link would be silently dropped. Word-authored ids are preserved;
+ * only threaded, id-less paragraphs are filled. Deterministic (content- and
+ * id-derived) so repeated saves mint the SAME id. MUST run before serializing
+ * BOTH comments.xml and commentsExtended.xml so the two reference the same id.
+ */
+export function ensureThreadedCommentParaIds(comments: readonly Comment[]): void {
+  const threaded = threadedCommentIds(comments);
+  if (threaded.size === 0) {
+    return;
+  }
+
+  const used = new Set<string>();
+  for (const comment of comments) {
+    for (const paragraph of comment.content ?? []) {
+      if (paragraph.paraId) {
+        used.add(paragraph.paraId.toUpperCase());
+      }
+    }
+  }
+
+  for (const comment of comments) {
+    if (!threaded.has(comment.id)) {
+      continue;
+    }
+    const last = (comment.content ?? []).at(-1);
+    if (!last || last.paraId) {
+      continue;
+    }
+    let paraId = deterministicHexId(`comment:${comment.id}:${commentPlainText(comment)}`);
+    for (let salt = 1; used.has(paraId.toUpperCase()); salt++) {
+      paraId = deterministicHexId(`comment:${comment.id}:${salt}`);
+    }
+    used.add(paraId.toUpperCase());
+    last.paraId = paraId;
+  }
 }
 
 type CommentExtendedEntry = {
@@ -174,29 +259,27 @@ type CommentExtendedEntry = {
  * `commentsExtended.xml`, matching how Word omits it.
  *
  * A `w15:commentEx` keys on the comment's LAST paragraph paraId; a reply's
- * `w15:paraIdParent` points at its parent comment's last-paragraph paraId. A
- * comment lacking a resolvable paraId is skipped (it cannot be keyed), which is
- * only reachable for a malformed model since {@link replyToComment} assigns
- * paraIds to every threaded comment.
+ * `w15:paraIdParent` points at its parent comment's last-paragraph paraId. Ids
+ * are guaranteed present by {@link ensureThreadedCommentParaIds}; the `!paraId`
+ * skip is a last-ditch safety for a malformed model.
  */
 function buildCommentExtendedEntries(comments: readonly Comment[]): CommentExtendedEntry[] | null {
+  const threaded = threadedCommentIds(comments);
+  if (threaded.size === 0) {
+    return null;
+  }
+
   const paraIdByCommentId = new Map<number, string>();
-  const isReplyParent = new Set<number>();
   for (const comment of comments) {
     const paraId = commentThreadParaId(comment);
     if (paraId) {
       paraIdByCommentId.set(comment.id, paraId);
     }
-    if (comment.parentId !== undefined) {
-      isReplyParent.add(comment.parentId);
-    }
   }
 
   const entries: CommentExtendedEntry[] = [];
   for (const comment of comments) {
-    const isReply = comment.parentId !== undefined;
-    const needsEntry = isReply || isReplyParent.has(comment.id) || comment.done !== undefined;
-    if (!needsEntry) {
+    if (!threaded.has(comment.id)) {
       continue;
     }
     const paraId = paraIdByCommentId.get(comment.id);

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -35,8 +35,25 @@ function serializeRunContent(run: Run): string {
   return xml;
 }
 
+/**
+ * `w14:paraId` / `w14:textId` open tag for a comment paragraph. Word keys
+ * commentsExtended.xml (reply threading) and commentsExtensible.xml (UTC
+ * dates) on the paraId of a comment's LAST paragraph, so the id must survive
+ * serialization; the parser stores it on `Paragraph.paraId`.
+ */
+function commentParagraphOpenTag(p: Paragraph): string {
+  const attrs: string[] = [];
+  if (p.paraId) {
+    attrs.push(`w14:paraId="${p.paraId}"`);
+  }
+  if (p.textId) {
+    attrs.push(`w14:textId="${p.textId}"`);
+  }
+  return attrs.length > 0 ? `<w:p ${attrs.join(" ")}>` : "<w:p>";
+}
+
 function serializeParagraph(p: Paragraph): string {
-  let xml = "<w:p>";
+  let xml = commentParagraphOpenTag(p);
   for (const item of p.content) {
     if (item.type === "run") {
       xml += serializeRunContent(item);
@@ -48,7 +65,7 @@ function serializeParagraph(p: Paragraph): string {
 
 /** Serialize a paragraph, prepending an annotationRef run (required by Word in first paragraph of a comment) */
 function serializeParagraphWithAnnotationRef(p: Paragraph): string {
-  let xml = "<w:p>";
+  let xml = commentParagraphOpenTag(p);
   xml += '<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:annotationRef/></w:r>';
   for (const item of p.content) {
     if (item.type === "run") {
@@ -135,5 +152,94 @@ export function serializeComments(comments: Comment[]): string {
   }
 
   xml += "</w:comments>";
+  return xml;
+}
+
+/** The `w14:paraId` Word threads a comment by: its LAST paragraph's paraId. */
+function commentThreadParaId(comment: Comment): string | undefined {
+  return comment.content.at(-1)?.paraId;
+}
+
+type CommentExtendedEntry = {
+  paraId: string;
+  paraIdParent?: string;
+  done: boolean;
+};
+
+/**
+ * Build the `commentsExtended.xml` entries for the comments that participate in
+ * a thread or carry a resolved state. Returns `null` when no comment needs an
+ * entry (no replies, no parents-of-replies, no `done` state) so callers can
+ * leave any existing part untouched — a plain top-level comment set gets no
+ * `commentsExtended.xml`, matching how Word omits it.
+ *
+ * A `w15:commentEx` keys on the comment's LAST paragraph paraId; a reply's
+ * `w15:paraIdParent` points at its parent comment's last-paragraph paraId. A
+ * comment lacking a resolvable paraId is skipped (it cannot be keyed), which is
+ * only reachable for a malformed model since {@link replyToComment} assigns
+ * paraIds to every threaded comment.
+ */
+function buildCommentExtendedEntries(comments: readonly Comment[]): CommentExtendedEntry[] | null {
+  const paraIdByCommentId = new Map<number, string>();
+  const isReplyParent = new Set<number>();
+  for (const comment of comments) {
+    const paraId = commentThreadParaId(comment);
+    if (paraId) {
+      paraIdByCommentId.set(comment.id, paraId);
+    }
+    if (comment.parentId !== undefined) {
+      isReplyParent.add(comment.parentId);
+    }
+  }
+
+  const entries: CommentExtendedEntry[] = [];
+  for (const comment of comments) {
+    const isReply = comment.parentId !== undefined;
+    const needsEntry = isReply || isReplyParent.has(comment.id) || comment.done !== undefined;
+    if (!needsEntry) {
+      continue;
+    }
+    const paraId = paraIdByCommentId.get(comment.id);
+    if (!paraId) {
+      continue;
+    }
+    const parentParaId =
+      comment.parentId !== undefined ? paraIdByCommentId.get(comment.parentId) : undefined;
+    entries.push({
+      paraId,
+      ...(parentParaId !== undefined ? { paraIdParent: parentParaId } : {}),
+      done: comment.done ?? false,
+    });
+  }
+
+  return entries.length > 0 ? entries : null;
+}
+
+const COMMENTS_EXTENDED_HEADER =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+  '<w15:commentsEx xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" ' +
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" ' +
+  'mc:Ignorable="w15">';
+
+/**
+ * Serialize `commentsExtended.xml` (`w15:commentsEx`) for reply threading and
+ * resolved state, or `null` when no comment needs an entry (see
+ * {@link buildCommentExtendedEntries}). This is the part that makes Word render
+ * a comment as a REPLY rather than a separate top-level thread.
+ */
+export function serializeCommentsExtended(comments: readonly Comment[]): string | null {
+  const entries = buildCommentExtendedEntries(comments);
+  if (!entries) {
+    return null;
+  }
+
+  let xml = COMMENTS_EXTENDED_HEADER;
+  for (const entry of entries) {
+    const parentAttr =
+      entry.paraIdParent !== undefined ? ` w15:paraIdParent="${entry.paraIdParent}"` : "";
+    xml += `<w15:commentEx w15:paraId="${entry.paraId}"${parentAttr} w15:done="${entry.done ? "1" : "0"}"/>`;
+  }
+  xml += "</w15:commentsEx>";
   return xml;
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -25,6 +25,7 @@ export {
   type FolioBlockId,
 } from "./types/block-id";
 export { createDocx } from "./docx/rezip";
+export { replyToComment, type CreateCommentReplyInput } from "./docx/replyToComment";
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
 export {
   FolioDocxReviewer,
@@ -39,6 +40,7 @@ export {
   type FolioReviewComment,
   type FolioReviewCommentFilter,
   type FolioReviewCommentReply,
+  type FolioReviewReplyInput,
 } from "./ai-edits/headless";
 export type {
   FolioAIComment,

--- a/packages/core/src/utils/hexId.ts
+++ b/packages/core/src/utils/hexId.ts
@@ -29,3 +29,16 @@ export const generateHexId = (): string =>
     .toString(16)
     .toUpperCase()
     .padStart(8, "0");
+
+/**
+ * Deterministic 8-char uppercase hex id (FNV-1a over `seed`), `< 0x7FFFFFFF`.
+ * Re-deriving from the same seed mints the same id, so content/position-derived
+ * ids (block paraIds, comment thread keys) are stable across saves.
+ */
+export const deterministicHexId = (seed: string): string => {
+  let hash = 2_166_136_261;
+  for (const character of seed) {
+    hash = Math.imul(hash ^ (character.codePointAt(0) ?? 0), 16_777_619) >>> 0;
+  }
+  return (hash % MAX_HEX_ID_EXCLUSIVE).toString(16).toUpperCase().padStart(8, "0");
+};


### PR DESCRIPTION
Adds threaded comment **reply** round-tripping. folio already parsed the thread structure (`commentsExtended.xml` → `Comment.parentId`/`done`), but on save it dropped comment-paragraph `w14:paraId`s, never re-wrote `commentsExtended.xml`, and reply comments got no `commentRange`/`commentReference` markers — so threading was lost on any save and a new reply never rendered as a reply.

- **Parse:** join threads on the **last** paragraph's `paraId` (Word's convention; fixes multi-paragraph parents).
- **paraId survival:** `commentSerializer` emits `w14:paraId`/`textId`; `serializeCommentsExtended` returns `null` for non-threaded docs (fixed point).
- **Reply-range synthesis:** new `commentReplyMarkers.ts` idempotently duplicates the parent's range markers for each un-anchored reply (body/headers/footers/notes); ported from `eigenpal/docx-editor` with attribution. Integrates with the existing `normalizeCommentReferences` pass (produces balanced ranges) and the serializer's auto-emit of the reference run.
- **Both save paths:** full repack injects markers + writes/removes `commentsExtended.xml` (+ content-type/rel); selective save rewrites it only when threading changed (else byte-exact) and bails to full repack when a reply lacks an anchor.
- **Create-reply API:** `replyToComment(doc, parentId, {author,text,initials?})` (exported from `@stll/folio-core/server`) + `FolioDocxReviewer.replyTo(...)`.

Deferred: interactive reply UI; replies anchored on tracked-change parents.

Tests: parse `parentId`/`done`; replies stay threaded + anchored through both save paths (with byte-exact assertions on the no-op path); marker synthesis when only the parent is anchored; `replyToComment` + headless `replyTo` round-trip as proper replies.
