### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -41,3 +41,32 @@ the browser, built on ProseMirror. Two published packages plus a dev playground:
   differential parity gate — extend them when you change parsing, layout, or
   editor interactions.
 - Return minimal data from public APIs; do not export types that have no consumer.
+
+## Cursor Cloud specific instructions
+
+Toolchain and standard commands live under `## Repository Specifics` → `### Commands`
+above; this section only records the non-obvious cloud-VM caveats.
+
+- **Toolchain lives in the user profile, not the base image.** Bun `1.3.14` is at
+  `~/.bun/bin` and Node is provided by nvm (default `v22.22.2`). A login/interactive
+  shell sources `~/.bashrc` and puts both on `PATH` (and activates the nvm Node). A
+  plain non-login `bash -c` does **not**, and falls back to `/exec-daemon/node`
+  (Node 22.14). Prefer a login shell, or reference bun explicitly as
+  `~/.bun/bin/bun`.
+- **`bun run build` / `bun run validate-dist` need Node ≥ 22.18.** tsdown loads
+  `packages/*/tsdown.config.ts` with a config loader that requires native TS
+  type-stripping. The default `/exec-daemon/node` (22.14) lacks it and the optional
+  `unrun` loader is not installed, so building under that node fails with
+  `Failed to import module "unrun"`. Run these with the nvm Node 22.22.2 active (it
+  is the nvm default; a login shell or `nvm use default` selects it). lint,
+  typecheck (`tsgo`), and `bun test` are unaffected by the node version.
+- **Dev server:** `bun --filter @stll/playground dev` serves the editor at
+  http://localhost:4200 (Vite, `strictPort`). It loads an empty document by default;
+  `?file=<name>` loads a fixture from `tests/visual/fixtures` (e.g.
+  `?file=sample.docx`). The product is fully client-side — there is no backend,
+  database, or external service to start.
+- **Optional test dependencies (not installed by the update script):** Playwright
+  chromium (`bunx playwright install chromium`) for `test:interactions` /
+  `test:visual`; `python-docx` for `test:differential` (the test auto-skips if it is
+  missing). `bun run sync-ai` needs the private `.ai/shared` git submodule, which is
+  not initialized here, so do not run it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,3 +288,32 @@ the browser, built on ProseMirror. Two published packages plus a dev playground:
   differential parity gate — extend them when you change parsing, layout, or
   editor interactions.
 - Return minimal data from public APIs; do not export types that have no consumer.
+
+## Cursor Cloud specific instructions
+
+Toolchain and standard commands live under `## Repository Specifics` → `### Commands`
+above; this section only records the non-obvious cloud-VM caveats.
+
+- **Toolchain lives in the user profile, not the base image.** Bun `1.3.14` is at
+  `~/.bun/bin` and Node is provided by nvm (default `v22.22.2`). A login/interactive
+  shell sources `~/.bashrc` and puts both on `PATH` (and activates the nvm Node). A
+  plain non-login `bash -c` does **not**, and falls back to `/exec-daemon/node`
+  (Node 22.14). Prefer a login shell, or reference bun explicitly as
+  `~/.bun/bin/bun`.
+- **`bun run build` / `bun run validate-dist` need Node ≥ 22.18.** tsdown loads
+  `packages/*/tsdown.config.ts` with a config loader that requires native TS
+  type-stripping. The default `/exec-daemon/node` (22.14) lacks it and the optional
+  `unrun` loader is not installed, so building under that node fails with
+  `Failed to import module "unrun"`. Run these with the nvm Node 22.22.2 active (it
+  is the nvm default; a login shell or `nvm use default` selects it). lint,
+  typecheck (`tsgo`), and `bun test` are unaffected by the node version.
+- **Dev server:** `bun --filter @stll/playground dev` serves the editor at
+  http://localhost:4200 (Vite, `strictPort`). It loads an empty document by default;
+  `?file=<name>` loads a fixture from `tests/visual/fixtures` (e.g.
+  `?file=sample.docx`). The product is fully client-side — there is no backend,
+  database, or external service to start.
+- **Optional test dependencies (not installed by the update script):** Playwright
+  chromium (`bunx playwright install chromium`) for `test:interactions` /
+  `test:visual`; `python-docx` for `test:differential` (the test auto-skips if it is
+  missing). `bun run sync-ai` needs the private `.ai/shared` git submodule, which is
+  not initialized here, so do not run it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the folio monorepo and documents the non-obvious VM caveats discovered while doing so. No product code changed — only `AGENTS.md` and its generator source `.ai/local/agents.md`.

The dev environment (Bun `1.3.14`, nvm Node `v22.22.2`) is installed on the VM; the startup update script is just `bun install`. All standard commands were verified end to end, and the playground editor was exercised with a hello-world edit.

## Non-obvious caveats captured in `AGENTS.md`

- Bun and nvm Node live in the user profile (`~/.bun/bin`, nvm default `v22.22.2`); a login/interactive shell puts them on `PATH`, a plain `bash -c` does not (it falls back to `/exec-daemon/node` 22.14).
- `bun run build` / `bun run validate-dist` need Node ≥ 22.18: tsdown's config loader requires native TS type-stripping, and the default 22.14 node (with no `unrun` installed) fails with `Failed to import module "unrun"`. The nvm Node 22.22.2 (the default) handles it.
- Dev server: `bun --filter @stll/playground dev` → http://localhost:4200 (Vite, `strictPort`); fully client-side, no backend/DB. `?file=<name>` loads a fixture from `tests/visual/fixtures`.
- `bun run sync-ai` needs the uninitialized private `.ai/shared` submodule, so `AGENTS.md` was edited directly (and its source in `.ai/local/agents.md`).

## Verification

- ✅ `bun install`
- ✅ `bun run lint`
- ✅ `bun run typecheck`
- ✅ `bun run test`
- ✅ `bun run build` (Node 22.22.2)
- ✅ `bun run validate-dist` (Node 22.22.2)
- ✅ `bun --filter @stll/playground dev` (editor loads at :4200, typing + bold formatting work)

### Hello-world walkthrough

[folio_editor_hello_world_demo.mp4](https://cursor.com/agents/bc-2f7581e0-dea1-488a-8fae-b29deedee19c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolio_editor_hello_world_demo.mp4)

Typed two paragraphs into a blank document and applied bold to the first line.

[Editor loaded](https://cursor.com/agents/bc-2f7581e0-dea1-488a-8fae-b29deedee19c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolio_editor_loaded.webp)
[First paragraph bolded](https://cursor.com/agents/bc-2f7581e0-dea1-488a-8fae-b29deedee19c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolio_editor_bold_paragraph.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f7581e0-dea1-488a-8fae-b29deedee19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f7581e0-dea1-488a-8fae-b29deedee19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cloud-specific guidance for the development environment, including where Bun and Node are available, required Node versions, and how login shells affect `PATH`.
  * Clarified local playground server behavior and URL access.
  * Noted optional test dependencies and prerequisites needed before running certain sync tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->