### PR TITLE
chore: add CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,45 @@
+name: CLA Assistant
+
+# SECURITY INVARIANT — DO NOT BREAK.
+# This workflow runs under `pull_request_target` and therefore executes in
+# the base-repo trust context with access to secrets (CLA_APP_PRIVATE_KEY,
+# write tokens on issues/PRs). It MUST NOT check out PR head code, MUST
+# NOT run any script, build, or install step from the PR, and MUST NOT
+# pass `github.event.pull_request.head.sha` / `head.ref` into any step
+# that executes code. The only safe operation here is to call the pinned
+# reusable workflow that performs CLA signature verification.
+# Background: pull_request_target + checkout(head) is the same attack
+# shape that led to the tj-actions / Ultralytics / Nx compromises.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target: # zizmor: ignore[dangerous-triggers] pinned reusable CLA workflow does not check out or execute PR code
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    if: >-
+      (
+        github.event_name == 'pull_request_target'
+        && github.event.pull_request.user.login != 'dependabot[bot]'
+      ) || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (
+          github.event.comment.body == 'recheck'
+          || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        )
+      )
+    uses: stella/.github/.github/workflows/cla.yml@44c8092f11c2f454916c320aa7d2144c173329d8
+    with:
+      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],cursoragent
+    secrets:
+      CLA_APP_PRIVATE_KEY: ${{ secrets.CLA_APP_PRIVATE_KEY }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,20 +1,9 @@
 name: CLA Assistant
 
-# SECURITY INVARIANT — DO NOT BREAK.
-# This workflow runs under `pull_request_target` and therefore executes in
-# the base-repo trust context with access to secrets (CLA_APP_PRIVATE_KEY,
-# write tokens on issues/PRs). It MUST NOT check out PR head code, MUST
-# NOT run any script, build, or install step from the PR, and MUST NOT
-# pass `github.event.pull_request.head.sha` / `head.ref` into any step
-# that executes code. The only safe operation here is to call the pinned
-# reusable workflow that performs CLA signature verification.
-# Background: pull_request_target + checkout(head) is the same attack
-# shape that led to the tj-actions / Ultralytics / Nx compromises.
-
 on:
   issue_comment:
     types: [created]
-  pull_request_target: # zizmor: ignore[dangerous-triggers] pinned reusable CLA workflow does not check out or execute PR code
+  pull_request_target: # zizmor: ignore[dangerous-triggers] delegates to pinned reusable CLA workflow; never check out PR code here
     types: [opened, synchronize, reopened, closed]
 
 permissions:


### PR DESCRIPTION
## Summary

Adds the standard Stella CLA Assistant workflow for pull requests and CLA signature rechecks.

## Validation

- Compared the workflow content against the canonical Stella workflow.
- No code tests run; this is a GitHub Actions workflow-only change.

CC on behalf of @jan-kubica
