### PR TITLE
fix: skip CLA workflow while private

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,8 @@ permissions:
 jobs:
   cla:
     if: >-
-      (
+      !github.event.repository.private && (
+
         github.event_name == 'pull_request_target'
         && github.event.pull_request.user.login != 'dependabot[bot]'
       ) || (

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,16 +16,18 @@ permissions:
 jobs:
   cla:
     if: >-
-      !github.event.repository.private && (
-
-        github.event_name == 'pull_request_target'
-        && github.event.pull_request.user.login != 'dependabot[bot]'
-      ) || (
-        github.event_name == 'issue_comment'
-        && github.event.issue.pull_request
-        && (
-          github.event.comment.body == 'recheck'
-          || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+      !github.event.repository.private
+      && (
+        (
+          github.event_name == 'pull_request_target'
+          && github.event.pull_request.user.login != 'dependabot[bot]'
+        ) || (
+          github.event_name == 'issue_comment'
+          && github.event.issue.pull_request
+          && (
+            github.event.comment.body == 'recheck'
+            || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          )
         )
       )
     uses: stella/.github/.github/workflows/cla.yml@44c8092f11c2f454916c320aa7d2144c173329d8


### PR DESCRIPTION
## Summary

Skips the CLA Assistant workflow while `folio` is still a private repository.

The shared CLA workflow requires `CLA_APP_PRIVATE_KEY`; the current org secret works for the public repositories but resolves empty in `folio` while it is private. This keeps the workflow present and lets it start enforcing automatically once the repository is public.

## Validation

- Inspected the failed Actions run: `[@octokit/auth-app] privateKey option is required`.
- Verified the failure is isolated to `stella/folio` among the CLA rollout PRs.

CC on behalf of @jan-kubica
