### PR TITLE
chore: publish hygiene 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,13 @@ name: Publish
 # that version. The hardened action is idempotent: it skips a name@version
 # already on the registry, so bumping only one package republishes only it.
 # Manual dispatch with `publish` unchecked builds + packs only (a dry run).
+#
+# Each successful publish also cuts a GitHub Release (tag `<name>@<version>`)
+# with the exact tarball that went to npm attached as an asset. That tarball is
+# the content-addressed link between the public GitHub reference and the npm
+# artifact: downstream users can verify byte-for-byte that what they install
+# matches this release. Release creation is idempotent — it skips if the tag
+# already exists, mirroring the hardened action's version-level idempotency.
 
 env:
   NODE_VERSION: "22"
@@ -96,8 +103,10 @@ jobs:
   publish:
     name: Publish @stll/folio-${{ matrix.pkg }}
     needs: pack
-    # Auto-publish on a version-bump push; on manual dispatch, only when ticked.
-    if: ${{ github.event_name == 'push' || inputs.publish }}
+    # Auto-publish only from main: a version-bump push to main, or a manual
+    # dispatch from main with the publish checkbox ticked. A dispatch from any
+    # other branch is a dry run (pack only), never a publish.
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish) }}
     runs-on: ubuntu-latest
     strategy:
       # core before react: react's published dep on @stll/folio-core must already
@@ -106,7 +115,11 @@ jobs:
       matrix:
         pkg: [core, react]
     permissions:
-      contents: read
+      # contents: write cuts the per-version GitHub Release below. Safe to grant
+      # alongside id-token here: this job runs no untrusted build scripts (they
+      # ran in the pack job); it only downloads a prebuilt tarball, publishes it,
+      # and creates the release.
+      contents: write
       id-token: write # OIDC only here; build scripts already ran in the pack job
       attestations: write # build provenance attestation for the published tarball
     steps:
@@ -127,15 +140,54 @@ jobs:
           name: npm-tarball-${{ matrix.pkg }}
           path: release-artifacts/
 
-      - name: Resolve tarball path
+      - name: Resolve tarball metadata
         id: tarball
         shell: bash
         run: |
           set -euo pipefail
           tgz="$(ls release-artifacts/*.tgz)"
-          echo "path=${tgz}" >> "${GITHUB_OUTPUT}"
+          # Read name and version from the tarball's bundled package.json — the
+          # published artifact is whatever bytes are in the .tgz, so the release
+          # tag must reflect that (and `bun pm pack` has already rewritten any
+          # `workspace:`/`catalog:` deps to concrete versions inside it).
+          tar -xOf "${tgz}" package/package.json > "${RUNNER_TEMP}/pkg.json"
+          name="$(node -p "require('${RUNNER_TEMP}/pkg.json').name")"
+          version="$(node -p "require('${RUNNER_TEMP}/pkg.json').version")"
+          {
+            echo "path=${tgz}"
+            echo "name=${name}"
+            echo "version=${version}"
+            echo "tag=${name}@${version}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Publish to npm
         uses: stella/.github/.github/actions/npm-publish-hardened@96b8912e0786548c4e62046ce3965769991dd0e0
         with:
+          # Real releases ship as `latest`, promoting past the one-time
+          # `placeholder`-tagged bootstrap stubs. `latest` is the action default,
+          # set here explicitly so the intent is visible at the call site.
           tarball: ${{ steps.tarball.outputs.path }}
+          tag: latest
+
+      - name: Create GitHub Release
+        # Attach the exact tarball published to npm so the GitHub Release is the
+        # content-addressed public reference for the artifact. Idempotent: on a
+        # re-run (or when the sibling package was not bumped and npm publish was
+        # skipped), the tag already exists and we skip.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tarball.outputs.tag }}
+          NAME: ${{ steps.tarball.outputs.name }}
+          VERSION: ${{ steps.tarball.outputs.version }}
+          TARBALL: ${{ steps.tarball.outputs.path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::notice::Release ${TAG} already exists; skipping."
+            exit 0
+          fi
+          gh release create "${TAG}" "${TARBALL}" \
+            --target "${GITHUB_SHA}" \
+            --title "${NAME}@${VERSION}" \
+            --notes "\`${NAME}@${VERSION}\` published to npm via OIDC trusted publishing with SLSA provenance. The attached tarball is the exact artifact published to the registry."

--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ bun run validate-dist   # clean-room publish-shape validation for both packages
 folio began as a private fork of [Eigenpal](https://eigenpal.com)'s
 [docx-editor](https://github.com/eigenpal/docx-editor) by
 [Jedr Blaszyk](https://github.com/jedrazb). The code has since been extended
-(mostly to match the needs of [stella](https://github.com/stella/stella). After the upstream
-repository was taken down, we're publishing folio fork. The original license and copyright are
-preserved in [`NOTICE.md`](./NOTICE.md).
+(mostly to match the needs of [stella](https://github.com/stella/stella)). After the upstream
+repository was taken down, we are publishing the folio fork as an independently maintained
+continuation. The original license and copyright are preserved in
+[`NOTICE.md`](./NOTICE.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Publish-hygiene pass ahead of flipping this repo public and shipping
`@stll/folio-core` and `@stll/folio-react` to npm.

### 1. README Acknowledgements grammar (docs)

Fixes only grammar/typography in the Acknowledgements paragraph; the message
is unchanged:

- Balances the prose parenthesis: `(mostly to match the needs of [stella](...))`
  previously had no closing `)` (the `)` present was the markdown link's).
- `we're publishing folio fork` -> `we are publishing the folio fork as an
  independently maintained continuation`.

Eigenpal attribution and the `NOTICE.md` reference are untouched.

### 2. Align the npm publish workflow with the org convention (chore)

Reference: the stella monorepo's publish workflow plus the shared
`stella/.github` `npm-publish-hardened` composite action. The workflow already
matched the convention on trigger shape (version-bump push to `main` + manual
dispatch), the two-job pack/publish split (untrusted build has no `id-token`),
`bun pm pack` (rewrites `workspace:`/`catalog:` deps to concrete versions;
`npm pack` does not), OIDC trusted publishing with provenance, and the pinned
hardened action. Two gaps closed:

- **GitHub Releases from publishes.** The hardened action only publishes to
  npm; per its design the caller attaches the same tarball to a GitHub Release
  so the release is the content-addressed public reference for the npm
  artifact. Added a `Create GitHub Release` step in the publish job: it reads
  `name`/`version` from the tarball's bundled `package.json`, creates tag
  `<name>@<version>` (package-scoped, so core and react never collide) targeted
  at the publishing commit, and attaches the exact `.tgz`. Idempotent: skips if
  the tag already exists, mirroring the action's version-level idempotency, so a
  single-package bump (where the sibling's npm publish is skipped) also skips
  the sibling's release. This needs `contents: write`, added to the publish job
  only; safe there since the job runs no untrusted build scripts (those ran in
  the `pack` job without `id-token`).
- **Restrict manual publish to `main`.** The publish `if` gained
  `github.ref == 'refs/heads/main' &&`, matching the monorepo. Previously a
  `workflow_dispatch` from any branch with `publish` ticked could publish; now
  off-`main` dispatches are pack-only dry runs. (Push was already `main`-only
  via the branch filter.)
- Made the `latest` dist-tag explicit at the hardened-action call site. It is
  the action default, but stating it documents that real releases promote past
  the one-time `placeholder`-tagged bootstrap stubs currently on the registry.

Versions are not bumped and nothing is published by this PR; wiring only.

Sanity-checked with `actionlint` (clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published packages now also create a matching GitHub Release for the exact npm tarball version.
  * Release tagging and attachment are aligned with the published package version for easier download and tracking.

* **Bug Fixes**
  * Publishing is now more restrictive: automatic publishing only runs from the main branch, and manual publishing requires explicit confirmation.
  * Repeated release attempts are handled safely by skipping creation if the tag already exists.

* **Documentation**
  * Updated project acknowledgements wording to reflect the repository’s current maintenance status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->