### PR TITLE
feat(react): undo/redo tracked-change resolutions + external comment-id adoption via the editor ref

### DIFF
--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { history, redo, undo, undoDepth } from "prosemirror-history";
 import { Schema } from "prosemirror-model";
-import { EditorState } from "prosemirror-state";
-import type { Transaction } from "prosemirror-state";
+import type { Node as PMNode } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Command, Transaction } from "prosemirror-state";
 
 import {
   acceptChange,
@@ -400,5 +402,133 @@ describe("tracked change navigation", () => {
       to: 10,
       type: "insertion",
     });
+  });
+});
+
+/**
+ * Undoing / redoing an id-scoped accept/reject IN PLACE, through
+ * prosemirror-history — the mechanism the editor ref's `undo()` / `redo()`
+ * drive (ports upstream docx-editor ff971a7b). folio's id-scoped resolver is
+ * `acceptAIEditRevision` / `rejectAIEditRevision`; each dispatches a single
+ * transaction, so one `undo()` reverses the whole resolution — even a coalesced
+ * revision whose sites span multiple paragraphs — with no document reload.
+ */
+describe("undo / redo of an id-scoped resolution — in-place reversal, no reload", () => {
+  const REV = 7;
+
+  /** One paragraph: `keep `, then `tracked` carrying `markName`@REV, then ` tail`. */
+  const docWith = (markName: "insertion" | "deletion"): PMNode => {
+    const markType = schema.marks[markName]!;
+    const attrs = { revisionId: REV, author: "AI", date: "2026-01-01" };
+    return schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("keep "),
+        schema.text("tracked", [markType.create(attrs)]),
+        schema.text(" tail"),
+      ]),
+    ]);
+  };
+
+  /** An editor with history(), so undo/redo run the ref's real mechanism. */
+  const editor = (doc: PMNode) => {
+    let state = EditorState.create({ schema, doc, plugins: [history()] });
+    return {
+      get state() {
+        return state;
+      },
+      run(cmd: Command) {
+        return cmd(state, (tr) => {
+          state = state.apply(tr);
+        });
+      },
+    };
+  };
+
+  const text = (state: EditorState) => state.doc.textContent;
+  const hasMark = (state: EditorState, name: string) => {
+    let found = false;
+    state.doc.descendants((node) => {
+      if (node.marks.some((mark) => mark.type.name === name)) {
+        found = true;
+      }
+    });
+    return found;
+  };
+
+  test("undo restores an accepted insertion mark; redo drops it again", () => {
+    const ed = editor(docWith("insertion"));
+    expect(ed.run(acceptAIEditRevision(REV))).toBe(true);
+    expect(hasMark(ed.state, "insertion")).toBe(false);
+
+    ed.run(undo);
+    expect(hasMark(ed.state, "insertion")).toBe(true);
+    expect(text(ed.state)).toBe("keep tracked tail");
+
+    ed.run(redo);
+    expect(hasMark(ed.state, "insertion")).toBe(false);
+  });
+
+  test("undo restores text removed by accepting a deletion", () => {
+    const ed = editor(docWith("deletion"));
+    expect(ed.run(acceptAIEditRevision(REV))).toBe(true);
+    expect(text(ed.state)).toBe("keep  tail");
+
+    ed.run(undo);
+    expect(text(ed.state)).toBe("keep tracked tail");
+    expect(hasMark(ed.state, "deletion")).toBe(true);
+  });
+
+  test("undo restores text + mark removed by rejecting an insertion; redo re-removes", () => {
+    const ed = editor(docWith("insertion"));
+    expect(ed.run(rejectAIEditRevision(REV))).toBe(true);
+    expect(text(ed.state)).toBe("keep  tail");
+    expect(hasMark(ed.state, "insertion")).toBe(false);
+
+    ed.run(undo);
+    expect(text(ed.state)).toBe("keep tracked tail");
+    expect(hasMark(ed.state, "insertion")).toBe(true);
+
+    ed.run(redo);
+    expect(text(ed.state)).toBe("keep  tail");
+  });
+
+  test("resolves every site of a coalesced revision in one undoable step", () => {
+    const insertion = schema.marks["insertion"]!;
+    const attrs = { revisionId: REV, author: "AI", date: "2026-01-01" };
+    // The same revisionId on two non-contiguous runs across two paragraphs.
+    const ed = editor(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("a "),
+          schema.text("one", [insertion.create(attrs)]),
+          schema.text(" b"),
+        ]),
+        schema.node("paragraph", null, [
+          schema.text("c "),
+          schema.text("two", [insertion.create(attrs)]),
+          schema.text(" d"),
+        ]),
+      ]),
+    );
+    const before = undoDepth(ed.state);
+    expect(ed.run(acceptAIEditRevision(REV))).toBe(true);
+    expect(hasMark(ed.state, "insertion")).toBe(false); // every site resolved...
+    expect(undoDepth(ed.state)).toBe(before + 1); // ...in a single history step,
+    ed.run(undo);
+    expect(hasMark(ed.state, "insertion")).toBe(true); // so one undo restores them all.
+  });
+
+  test("a selection-only change is never recorded, so undo() still targets the last edit", () => {
+    const ed = editor(docWith("insertion"));
+    ed.run(acceptAIEditRevision(REV));
+    expect(hasMark(ed.state, "insertion")).toBe(false);
+    // Move the selection — no document steps, so prosemirror-history ignores it
+    // (the ref undo()'s documented guarantee that scroll/locate isn't undone).
+    ed.run((state, dispatch) => {
+      dispatch?.(state.tr.setSelection(TextSelection.create(state.doc, 1)));
+      return true;
+    });
+    ed.run(undo);
+    expect(hasMark(ed.state, "insertion")).toBe(true); // reverted the ACCEPT, not the selection
   });
 });

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -374,6 +374,23 @@ export type DocxEditorRef = {
    */
   rejectAIEditOperation: (revisionIds: number | readonly number[]) => boolean;
   /**
+   * Undo / redo the last history-recorded edit IN PLACE — e.g. an
+   * `acceptAIEditOperation` / `rejectAIEditOperation` resolution — without
+   * reloading the document, so the view and scroll position are preserved.
+   * Routes to whichever surface is active: the inline header/footer editor
+   * when one is being edited, otherwise the document body. Only edits that
+   * produce document changes are recorded; selection-only changes (scroll /
+   * locate) carry no steps and are never undone. Returns `false` when there
+   * is nothing to undo / redo.
+   *
+   * Ports upstream docx-editor `feat(react): accept/reject and undo/redo
+   * tracked changes via the editor ref` (ff971a7b): folio already exposes
+   * id-scoped accept/reject through `acceptAIEditOperation` /
+   * `rejectAIEditOperation`, so only the in-place undo/redo surface is new.
+   */
+  undo: () => boolean;
+  redo: () => boolean;
+  /**
    * Scroll the editor viewport so the tracked-change marks belonging to the
    * given `revisionIds` come into view, and select them. No-op when none of the
    * revisions are present.

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2853,6 +2853,28 @@ export function DocxEditor({
         }
         return rejectAIEditRevision(revisionId)(view.state, view.dispatch);
       },
+      // In-place undo/redo of the last history-recorded edit (e.g. an
+      // accept/reject resolution), routed to the active surface — the inline
+      // header/footer editor when one is being edited, otherwise the body.
+      // Mirrors `undoActiveEditor`/`redoActiveEditor` but returns the
+      // prosemirror-history result so a host can tell whether anything was
+      // reversed. Ports upstream docx-editor ff971a7b.
+      undo: () => {
+        if (hfEditPosition && hfEditorRef.current) {
+          return hfEditorRef.current.undo();
+        }
+        const undone = pagedEditorRef.current?.undo() ?? false;
+        requestAnimationFrame(refreshBodyHistoryAvailability);
+        return undone;
+      },
+      redo: () => {
+        if (hfEditPosition && hfEditorRef.current) {
+          return hfEditorRef.current.redo();
+        }
+        const redone = pagedEditorRef.current?.redo() ?? false;
+        requestAnimationFrame(refreshBodyHistoryAvailability);
+        return redone;
+      },
       scrollToAIEditOperation: (revisionId) => {
         const view = pagedEditorRef.current?.getView();
         if (!view) {
@@ -2985,6 +3007,8 @@ export function DocxEditor({
       loadBuffer,
       updateComments,
       commentsDirtyRef,
+      hfEditPosition,
+      refreshBodyHistoryAvailability,
     ],
   );
 

--- a/packages/react/src/components/commentsHelpers.test.ts
+++ b/packages/react/src/components/commentsHelpers.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Comment } from "@stll/folio-core/types/content";
-import { collectCommentIdsFromSources, pruneOrphanedComments } from "./commentsHelpers";
+import {
+  allocateCommentId,
+  collectCommentIdsFromSources,
+  createComment,
+  pruneOrphanedComments,
+  seedCommentIdAbove,
+} from "./commentsHelpers";
 
 function makeComment(id: number, parentId?: number): Comment {
   return {
@@ -237,5 +243,39 @@ describe("pruneOrphanedComments", () => {
     expect(
       pruneOrphanedComments([anchoredParent, unparsedReplyA, unparsedReplyB], new Set([1])),
     ).toEqual([anchoredParent, unparsedReplyA, unparsedReplyB]);
+  });
+});
+
+/**
+ * Adopting an externally-assigned OOXML comment id (ports upstream docx-editor
+ * 05f2ab84, adapted to folio's `createComment` factory). folio's allocator is a
+ * process-global monotonic counter, so absolute ids aren't fixed; the invariant
+ * is that a comment can adopt a supplied id AND that the counter is seeded above
+ * it so a later mint can never re-issue it.
+ */
+describe("createComment: external comment id adoption", () => {
+  test("adopts a supplied commentId instead of minting one", () => {
+    const comment = createComment("Please confirm the carve-out.", "CLM", undefined, 9999);
+    expect(comment.id).toBe(9999);
+  });
+
+  test("still mints a fresh, monotonically increasing id when none is supplied", () => {
+    const first = createComment("a", "CLM").id;
+    const second = createComment("b", "CLM").id;
+    expect(second).toBe(first + 1);
+  });
+
+  test("seeds the allocator above an adopted id that exceeds the counter", () => {
+    const base = allocateCommentId();
+    const adopted = base + 5000;
+    createComment("note", "CLM", undefined, adopted);
+    // The next fresh mint must clear the adopted id, not collide with it.
+    expect(allocateCommentId()).toBe(adopted + 1);
+  });
+
+  test("seedCommentIdAbove is a no-op for an id below the current counter", () => {
+    const a = allocateCommentId();
+    seedCommentIdAbove(a - 1000);
+    expect(allocateCommentId()).toBe(a + 1);
   });
 });

--- a/packages/react/src/components/commentsHelpers.ts
+++ b/packages/react/src/components/commentsHelpers.ts
@@ -21,6 +21,19 @@ export function allocateCommentId(): number {
   return nextCommentId++;
 }
 
+/**
+ * Bump the in-process comment-id counter above `id` so a later
+ * `allocateCommentId()` can never re-mint an id that was adopted from an
+ * external source-of-truth model. No-op when `id` is already below the
+ * current counter. Mirrors the allocator-seeding behaviour of upstream
+ * docx-editor's `CommentIdAllocator.seedAbove` (05f2ab84).
+ */
+export function seedCommentIdAbove(id: number): void {
+  if (id >= nextCommentId) {
+    nextCommentId = id + 1;
+  }
+}
+
 export function getCommentAuthorKey(author?: string): string {
   const trimmed = author?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : "Unknown";
@@ -69,9 +82,25 @@ export function getFallbackCommentYPosition(scrollContainer: HTMLElement | null)
   );
 }
 
-export function createComment(text: string, authorName: string, parentId?: number): Comment {
+/**
+ * Build a Comment. By default the id is freshly allocated; pass `id` to adopt a
+ * specific OOXML comment id (e.g. one an external source-of-truth model already
+ * assigned) so the preview mirrors the comment under the SAME id — the counter
+ * is then seeded above it so later mints never collide. Ports upstream
+ * docx-editor `feat(ref): proposeChange/addComment can adopt an external OOXML
+ * id` (05f2ab84), adapted to folio's `createComment` factory.
+ */
+export function createComment(
+  text: string,
+  authorName: string,
+  parentId?: number,
+  id?: number,
+): Comment {
+  if (id !== undefined) {
+    seedCommentIdAbove(id);
+  }
   return {
-    id: allocateCommentId(),
+    id: id ?? allocateCommentId(),
     author: authorName,
     date: new Date().toISOString(),
     content: [


### PR DESCRIPTION
## Summary

Ports the newer-than-last-sync work from upstream docx-editor branch
`claude/ref-accept-reject-undo` into folio, adapted to folio's diverged
architecture. Only the pieces folio actually lacks are ported; the parts
folio already has (id-scoped accept/reject on the editor ref) are left
untouched.

Upstream commits ported:
- `ff971a7b` feat(react): accept/reject and undo/redo tracked changes via the editor ref
- `05f2ab84` feat(ref): proposeChange/addComment can adopt an external OOXML id

## What's new

### 1. `undo()` / `redo()` on `DocxEditorRef`

A host driving tracked-change review through the imperative ref could
already resolve a change (`acceptAIEditOperation` / `rejectAIEditOperation`)
but could only take a resolution back by reloading the whole document, which
flashes the view and loses scroll position.

`ref.current?.undo()` / `redo()` now reverse the last history-recorded edit
IN PLACE through prosemirror-history, no reload. They route to the active
surface: the inline header/footer editor when one is being edited, otherwise
the document body (mirroring the existing `undoActiveEditor` /
`redoActiveEditor` toolbar handlers), and return a `boolean` so the caller
can tell whether anything was reversed. Selection-only changes (scroll /
locate) carry no document steps and are never undone.

### 2. `createComment` can adopt an external OOXML comment id

`createComment(text, author, parentId?, id?)` gains an optional `id`. When
supplied, the comment adopts that id (so a preview can mirror a comment an
external source-of-truth model already authored, under the same OOXML id)
and the in-process allocator is seeded above it (`seedCommentIdAbove`) so a
later mint can never re-issue it. With no `id`, the allocator mints as
before, unchanged.

## API surface

```ts
interface DocxEditorRef {
  // ...existing
  undo: () => boolean;
  redo: () => boolean;
}

// commentsHelpers
function createComment(text: string, author: string, parentId?: number, id?: number): Comment;
function seedCommentIdAbove(id: number): void;
```

## Tests

- `packages/core/src/prosemirror/commands/comments.test.ts`: a new
  command+history block proving an id-scoped `acceptAIEditRevision` /
  `rejectAIEditRevision` is a single undoable step (including a coalesced
  revision whose sites span two paragraphs), that undo/redo restore/re-remove
  text and marks, and that a selection-only change is never recorded — the
  exact mechanism the ref's `undo()` drives.
- `packages/react/src/components/commentsHelpers.test.ts`: adopting a supplied
  comment id, seeding the allocator above it, and unchanged minting when no id
  is supplied.

## Adapted vs. copied (folio has diverged)

- Upstream exposes `acceptChange(id)` / `rejectChange(id)` on the ref; folio
  already has `acceptAIEditOperation` / `rejectAIEditOperation`, so those were
  NOT re-ported. Only the in-place undo/redo surface is added.
- Upstream's `resolveById` / `resolveTrackedChangeById` operate on a different
  tracked-change data model (`pPrIns` / `pPrDel`, table row/cell markers);
  folio uses `pPrMark` / `_propertyChanges` and its own range-based
  `resolveChange` + `acceptAIEditRevision`. The undo/redo tests target folio's
  commands, not upstream's.
- Upstream's `proposeChange` / `addComment` external-id adoption lives in a
  `commentOps.ts` + agents `bridge.ts` that folio does not have. folio's
  tracked-change authoring (`applyAIEditOperations`) mints and returns
  revision ids by design, so the revision-id half does not map cleanly; the
  comment-id half is ported at folio's `createComment` factory, which is the
  direct analog of upstream's `createComment` change.

## Checks

Local: lint (clean), typecheck (core + react, clean), unit tests
(core 2745 pass, react 162 pass, 0 fail). No browser/live verification.

Note: the CLA Assistant check is expected to fail/skip while the repo is
private; that is deliberate and unrelated to this change.
