### PR TITLE
fix: resolve sequential block ids positionally in AI edit ranges

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/folio-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Headless, framework-neutral core of folio: the OOXML (.docx) parser, document model, ProseMirror integration, and page-layout engine. No React.",
   "keywords": [
     "document-model",

--- a/packages/core/src/types/block-id.test.ts
+++ b/packages/core/src/types/block-id.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   deriveBlockId,
   getFolioParaIdFromBlockId,
+  getSequentialFolioBlockIdIndex,
   isFolioBlockId,
   isSequentialFolioBlockId,
 } from "./block-id";
@@ -130,5 +131,24 @@ describe("isFolioBlockId", () => {
     expect(isFolioBlockId(undefined)).toBe(false);
     expect(isFolioBlockId(null)).toBe(false);
     expect(isFolioBlockId(42)).toBe(false);
+  });
+});
+
+describe("getSequentialFolioBlockIdIndex", () => {
+  test("returns the 1-based position encoded in a sequential id", () => {
+    expect(getSequentialFolioBlockIdIndex("seq-0001")).toBe(1);
+    expect(getSequentialFolioBlockIdIndex("seq-0011")).toBe(11);
+    expect(getSequentialFolioBlockIdIndex("seq-9999")).toBe(9999);
+  });
+
+  test("handles ids wider than the minimum padding", () => {
+    expect(getSequentialFolioBlockIdIndex("seq-12345")).toBe(12_345);
+  });
+
+  test("returns null for paraId-backed and malformed ids", () => {
+    expect(getSequentialFolioBlockIdIndex("AAAA0001")).toBeNull();
+    expect(getSequentialFolioBlockIdIndex("seq-")).toBeNull();
+    expect(getSequentialFolioBlockIdIndex("seq-abc")).toBeNull();
+    expect(getSequentialFolioBlockIdIndex("seq-001")).toBeNull();
   });
 });

--- a/packages/core/src/types/block-id.ts
+++ b/packages/core/src/types/block-id.ts
@@ -77,6 +77,21 @@ export const getFolioParaIdFromBlockId = (id: string): string | null =>
   isSequentialFolioBlockId(id) ? null : id;
 
 /**
+ * The 1-based document position encoded in a sequential fallback id
+ * (`seq-0011` -> 11), or `null` for paraId-backed ids. The number is
+ * the block's position in the same non-empty-block walk both the
+ * server DOCX extractor and `createFolioAIEditSnapshot` use, so it
+ * indexes a snapshot's ordered `blocks` array directly.
+ */
+export const getSequentialFolioBlockIdIndex = (id: string): number | null => {
+  if (!SEQUENTIAL_BLOCK_ID_PATTERN.test(id)) {
+    return null;
+  }
+  const index = Number(id.slice(SEQUENTIAL_BLOCK_ID_PREFIX.length));
+  return Number.isInteger(index) && index > 0 ? index : null;
+};
+
+/**
  * Runtime refinement for ids coming back from the DB / API. Accepts
  * the same two shapes {@link deriveBlockId} produces and nothing
  * else — so legacy `b-NNNN` rows stop counting as valid here.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/folio-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React editor for folio: a Word-document (.docx) editor for the browser, built on @stll/folio-core and ProseMirror.",
   "keywords": [
     "document-editor",

--- a/packages/react/src/components/aiEditRange.test.ts
+++ b/packages/react/src/components/aiEditRange.test.ts
@@ -121,4 +121,36 @@ describe("resolveFolioAIBlockRange", () => {
     }
     expect(liveDoc.resolve(range.from + 1).parent.textContent).toBe("Inserted");
   });
+
+  test("resolves a seq fallback id positionally when the live doc allocated hex paraIds", () => {
+    // The docx-justification scroll path passes no snapshot, so the
+    // resolver builds one from the live doc. By then `ParaIdAllocator`
+    // has minted a fresh hex paraId for every paragraph the source DOCX
+    // left without a `w14:paraId`, so the live-doc snapshot keys those
+    // blocks by hex and never reproduces the server's `seq-NNNN`: the
+    // direct anchor lookup misses and no node carries a `seq-` paraId.
+    // The seq number is the block's 1-based document position, so it
+    // must still resolve there.
+    const liveDoc = makeDoc([
+      { paraId: "0A0A0A0A", text: "Title" },
+      { paraId: "0B0B0B0B", text: "Before" },
+      { paraId: "0C0C0C0C", text: "Target" },
+    ]);
+
+    const range = resolveFolioAIBlockRange({
+      blockId: "seq-0003",
+      doc: liveDoc,
+    });
+
+    if (range === null) {
+      throw new Error("Expected seq fallback to resolve positionally");
+    }
+    expect(liveDoc.resolve(range.from + 1).parent.textContent).toBe("Target");
+  });
+
+  test("returns null for a seq id past the end of the document", () => {
+    const liveDoc = makeDoc([{ paraId: "0A0A0A0A", text: "Only" }]);
+
+    expect(resolveFolioAIBlockRange({ blockId: "seq-0009", doc: liveDoc })).toBeNull();
+  });
 });

--- a/packages/react/src/components/aiEditRange.ts
+++ b/packages/react/src/components/aiEditRange.ts
@@ -9,9 +9,12 @@
 import type { Node as PMNode } from "prosemirror-model";
 
 import { createFolioAIEditSnapshot } from "@stll/folio-core/ai-edits/snapshot";
-import type { FolioAIEditSnapshot } from "@stll/folio-core/ai-edits/types";
+import type { FolioAIBlockAnchor, FolioAIEditSnapshot } from "@stll/folio-core/ai-edits/types";
 import { findParagraphByParaId } from "@stll/folio-core/prosemirror/utils/findParagraphByParaId";
-import { getFolioParaIdFromBlockId } from "@stll/folio-core/types/block-id";
+import {
+  getFolioParaIdFromBlockId,
+  getSequentialFolioBlockIdIndex,
+} from "@stll/folio-core/types/block-id";
 
 export type DocPositionRange = { from: number; to: number };
 
@@ -35,11 +38,38 @@ export const resolveFolioAIBlockRange = ({
   }
 
   const resolvedSnapshot = snapshot ?? createFolioAIEditSnapshot(doc);
-  const anchor = resolvedSnapshot.anchors[blockId];
+  const anchor =
+    resolvedSnapshot.anchors[blockId] ?? resolveSequentialBlockAnchor(blockId, resolvedSnapshot);
   if (!anchor) {
     return null;
   }
   return clampRangeToDocSize(doc.content.size, anchor);
+};
+
+/**
+ * Resolve a `seq-NNNN` fallback id by document position.
+ *
+ * A sequential id is only minted for a paragraph the source DOCX left
+ * without a `w14:paraId`. The live editor's `ParaIdAllocator` fills
+ * that gap with a fresh random hex paraId, so a snapshot of the live
+ * document keys the block by that hex and never reproduces the
+ * server's `seq-NNNN`: the direct anchor lookup misses, and a
+ * paraId-based live lookup can't match either (no node carries a
+ * `seq-` paraId). The seq number is the block's 1-based position in
+ * the same non-empty-block walk the server extractor and
+ * `createFolioAIEditSnapshot` share, so it indexes the snapshot's
+ * ordered `blocks` directly.
+ */
+const resolveSequentialBlockAnchor = (
+  blockId: string,
+  snapshot: FolioAIEditSnapshot,
+): FolioAIBlockAnchor | undefined => {
+  const index = getSequentialFolioBlockIdIndex(blockId);
+  if (index === null) {
+    return undefined;
+  }
+  const block = snapshot.blocks.at(index - 1);
+  return block ? snapshot.anchors[block.id] : undefined;
 };
 
 /**

--- a/packages/react/src/paged-editor/AutocompleteCaretOverlay.tsx
+++ b/packages/react/src/paged-editor/AutocompleteCaretOverlay.tsx
@@ -26,6 +26,14 @@ export type AutocompleteCaretRect = {
   y: number;
   /** Line height in pixels at the anchor. */
   lineHeight: number;
+  /**
+   * Available width from the caret to the page's right content margin,
+   * in the overlay's coordinate space. Bounds the ghost text so it wraps
+   * within the page instead of running off the right edge. Omitted when
+   * the page geometry can't be resolved (the ghost then renders unbounded,
+   * matching the legacy behavior).
+   */
+  maxWidth?: number | undefined;
 };
 
 export type AutocompleteCaretOverlayProps = {
@@ -69,6 +77,7 @@ export const AutocompleteCaretOverlay = ({
           left: caret.x,
           top: caret.y,
           lineHeight: `${caret.lineHeight}px`,
+          ...(caret.maxWidth !== undefined ? { maxWidth: `${caret.maxWidth}px` } : {}),
         }}
       >
         {text}

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -429,6 +429,13 @@ const TRANSACTION_LAYOUT_DEBOUNCE_MS = 32;
 const TRANSACTION_LAYOUT_MAX_DELAY_MS = 96;
 /** Keep the visual caret hidden briefly while typed content relayouts. */
 const SELECTION_REVEAL_AFTER_INPUT_DELAY = 120;
+/**
+ * Readability floor for the autocomplete ghost width: with the caret at the
+ * right content boundary, an unfloored width plus `overflow-wrap: anywhere`
+ * would wrap the suggestion into a one-character-wide vertical column. Near
+ * the margin the ghost overflows slightly past it instead.
+ */
+const AUTOCOMPLETE_GHOST_MIN_WIDTH = 100;
 // Stable empty array to avoid re-creating on each render
 const EMPTY_PLUGINS: Plugin[] = [];
 
@@ -2840,7 +2847,10 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
         // `size.w - margins.right`; `pageOffsetX` cancels between the two.
         const caretPage = layout.pages.at(caret.pageIndex);
         const maxWidth = caretPage
-          ? Math.max(0, caretPage.size.w - caretPage.margins.right - caret.x)
+          ? Math.max(
+              AUTOCOMPLETE_GHOST_MIN_WIDTH,
+              caretPage.size.w - caretPage.margins.right - caret.x,
+            )
           : undefined;
 
         setAutocompleteCaret({

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -2833,10 +2833,21 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
           return undefined;
         }
 
+        // Bound the ghost text to the caret's page content column so a
+        // multi-line suggestion wraps inside the page instead of running
+        // off the right edge. `caret.x` is page-left relative (same origin
+        // as the page geometry), so the right content boundary is
+        // `size.w - margins.right`; `pageOffsetX` cancels between the two.
+        const caretPage = layout.pages.at(caret.pageIndex);
+        const maxWidth = caretPage
+          ? Math.max(0, caretPage.size.w - caretPage.margins.right - caret.x)
+          : undefined;
+
         setAutocompleteCaret({
           x: caret.x + pageOffsetX,
           y: caret.y + pageOffsetY,
           lineHeight: caret.height,
+          maxWidth,
         });
         setAutocompleteText(current.text);
         setAutocompleteIsStreaming(current.status === "streaming");

--- a/packages/react/src/styles/autocomplete.css
+++ b/packages/react/src/styles/autocomplete.css
@@ -13,6 +13,7 @@
   pointer-events: none;
   user-select: none;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   color: color-mix(in oklch, var(--doc-text, currentColor) 38%, transparent);
   font: inherit;
   letter-spacing: inherit;


### PR DESCRIPTION
## Summary

Two editor fixes ported into the standalone folio packages, plus a patch release bump.

### Sequential block ids resolve positionally

A citation whose source paragraph carried no Word `w14:paraId` is minted as a sequential `seq-NNNN` block id (its 1-based position in the non-empty-block walk). When the live editor loads that document, `ParaIdAllocator` fills the missing paraId with a fresh random hex value, so a snapshot taken from the live document keys the block by that hex and never reproduces the `seq-NNNN` id. The direct anchor lookup in `resolveFolioAIBlockRange` then missed, no live node carried a `seq-` paraId, and the scroll-to-block retry loop gave up with no highlight.

The `seq` number is the block's position in the same ordered walk that `createFolioAIEditSnapshot` produces, so we can index the snapshot's ordered `blocks` array directly when the direct anchor lookup misses:

- `@stll/folio-core` gains `getSequentialFolioBlockIdIndex(id)`: the 1-based index encoded in a `seq-NNNN` id, or `null` for paraId-backed / malformed ids.
- `resolveFolioAIBlockRange` adds a `resolveSequentialBlockAnchor` fallback: `anchors[blockId] ?? resolveSequentialBlockAnchor(...)`. paraId-backed anchoring is unchanged; only the previously-unresolvable seq fallback path is affected.

### Ghost-text width bounding

The autocomplete ghost text was rendered unbounded and a multi-line suggestion could run off the right edge of the page. It is now bounded to the caret's page content column: `maxWidth = page.size.w - page.margins.right - caret.x` (the `pageOffsetX` term cancels between caret and page geometry). `maxWidth` is optional on `AutocompleteCaretRect`; when the page geometry can't be resolved the ghost renders unbounded as before. Paired with `overflow-wrap: anywhere` on `.folio-autocomplete-ghost` so long tokens wrap within the column.

### Release

Bumps `@stll/folio-core` and `@stll/folio-react` from `0.1.0` to `0.1.1` (separate `chore` commit).

## Tests

New unit tests, all green locally:
- `getSequentialFolioBlockIdIndex` — index extraction, wide ids, and rejection of paraId-backed / malformed ids.
- `resolveFolioAIBlockRange` — resolves a seq fallback positionally when the live doc allocated hex paraIds, and returns `null` for a seq id past the end of the document.

`bun run lint`, `bun run typecheck`, and `bun run test` all pass.
