### PR TITLE
feat: self-sufficient standalone.css for @stll/folio-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bun add @stll/folio-core
 
 ```tsx
 import { DocxEditor } from "@stll/folio-react";
-import "@stll/folio-react/editor.css";
+import "@stll/folio-react/standalone.css";
 
 export function Editor({ docx }: { docx: ArrayBuffer }) {
   return <DocxEditor documentBuffer={docx} onSave={(out) => download(out)} />;
@@ -45,6 +45,56 @@ export function Editor({ docx }: { docx: ArrayBuffer }) {
 
 The editor renders to the DOM; under SSR, load it from a client-only/dynamic
 import.
+
+### Styling: two integration modes
+
+The editor's chrome (toolbar, menus, dialogs) is authored with Tailwind utility
+classes and semantic design tokens. Pick the stylesheet that matches your app.
+
+**1. `standalone.css` — no Tailwind required (default).** A single,
+self-contained import: the bundled document/ProseMirror styles plus a
+pre-compiled copy of every utility folio's own components use. The utilities are
+scoped under `.folio-root`, so they cannot leak into or restyle your app, and
+the design tokens ship as low-specificity fallbacks you can override.
+
+```tsx
+import "@stll/folio-react/standalone.css";
+```
+
+Override the theme by setting the tokens on `.folio-root` (a normal class rule
+outranks the shipped `:where(.folio-root)` fallbacks):
+
+```css
+.folio-root {
+  --background: #fdfdfc;
+  --foreground: #1c1c1a;
+  --primary: #3b5bdb;
+  /* ...only the tokens you want to change... */
+}
+```
+
+For dark mode, add a `.dark` class to an ancestor (e.g. `<html>`); the editor
+and its body-portalled overlays theme themselves from it.
+
+**2. `editor.css` — you already run Tailwind.** Import only the bundled document
++ chrome styles and let your own Tailwind build generate the utilities. Point a
+`@source` at folio's shipped code so the classes its components use are scanned,
+and supply the semantic tokens (`--background`, `--foreground`, `--popover`, …)
+from your design system:
+
+```css
+/* your app's Tailwind entry */
+@import "tailwindcss";
+@source "../node_modules/@stll/folio-react/dist/**/*.js";
+```
+
+```tsx
+import "@stll/folio-react/editor.css";
+```
+
+Use this mode when your app's tokens and folio's should stay in lockstep. Do not
+import both stylesheets: `standalone.css` already contains everything
+`editor.css` does.
 
 ## Internationalization
 

--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,8 @@
         "yjs": "^13.6.31",
       },
       "devDependencies": {
+        "@tailwindcss/cli": "4.3.1",
+        "tailwindcss": "4.3.1",
         "y-prosemirror": "^1.3.7",
       },
       "peerDependencies": {
@@ -327,6 +329,34 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.71.0", "", { "os": "win32", "cpu": "x64" }, "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ=="],
 
+    "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.1", "", { "os": "android", "cpu": "arm64" }, "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
+
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
@@ -390,6 +420,8 @@
     "@stll/playground": ["@stll/playground@workspace:packages/playground"],
 
     "@stll/template-conditions": ["@stll/template-conditions@0.1.0", "", { "dependencies": { "@stll/conditions": "^0.1.0", "better-result": "2.9.2" } }, "sha512-GkgzEDiSqpzG3GexlOfVXHgYiQSME8osQIZ645F9ooQbvDcsTVX5YVpfvmPwe3EOhRol6WjEyO2t/39+hNvQsg=="],
+
+    "@tailwindcss/cli": ["@tailwindcss/cli@4.3.1", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "enhanced-resolve": "5.21.6", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.1" }, "bin": { "tailwindcss": "dist/index.mjs" } }, "sha512-ZWPy20rF+TBfTImxDMG3Wr75Y3RpaPlo9lc+oJbInlMyjT+XPkTVKVIL5RZ7JirXuIahcfHoLNFRmDorKi+JQQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.1" } }, "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A=="],
 
@@ -491,6 +523,8 @@
 
     "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
@@ -553,6 +587,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
     "find-up": ["find-up@6.3.0", "", { "dependencies": { "locate-path": "^7.1.0", "path-exists": "^5.0.0" } }, "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw=="],
 
     "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
@@ -600,6 +636,12 @@
     "intl-messageformat": ["intl-messageformat@11.2.9", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.6", "@formatjs/icu-messageformat-parser": "3.5.12" } }, "sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA=="],
 
     "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-unsafe": ["is-unsafe@1.0.1", "", {}, "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA=="],
 
@@ -661,15 +703,21 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "minimatch": ["minimatch@10.2.3", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
@@ -801,6 +849,8 @@
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "tsdown": ["tsdown@0.22.3", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.3", "picomatch": "^4.0.4", "rolldown": "~1.1.1", "rolldown-plugin-dts": "^0.26.0", "semver": "^7.8.4", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.3", "@tsdown/exe": "0.22.3", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg=="],
@@ -849,6 +899,8 @@
 
     "@microsoft/api-extractor/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -862,6 +914,8 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "docxtemplater/@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "pizzip/pako": ["pako@2.2.0", "", {}, "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w=="],
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./messages": "./src/i18n/messages.ts",
-    "./editor.css": "./src/styles/editor.css"
+    "./editor.css": "./src/styles/editor.css",
+    "./standalone.css": "./src/styles/standalone.css"
   },
   "publishConfig": {
     "access": "public"
@@ -62,6 +63,8 @@
     "yjs": "^13.6.31"
   },
   "devDependencies": {
+    "@tailwindcss/cli": "4.3.1",
+    "tailwindcss": "4.3.1",
     "y-prosemirror": "^1.3.7"
   },
   "peerDependencies": {

--- a/packages/react/scripts/build-css.ts
+++ b/packages/react/scripts/build-css.ts
@@ -13,7 +13,9 @@
 // `dist/editor.css`.
 
 import { panic } from "better-result";
+import { $ } from "bun";
 import { bundleAsync, transform } from "lightningcss";
+import { rm } from "node:fs/promises";
 import path from "node:path";
 
 const pkgDir = path.resolve(import.meta.dir, "..");
@@ -83,7 +85,8 @@ if (fontImports.size === 0) {
 }
 
 const fontImportBlock = Array.from(fontImports, (spec) => `@import "${spec}";`).join("\n");
-const composed = `${fontImportBlock}\n${new TextDecoder().decode(bundled.code)}`;
+const bundledBody = new TextDecoder().decode(bundled.code);
+const composed = `${fontImportBlock}\n${bundledBody}`;
 
 // Final validation + minification pass over the combined stylesheet. `transform`
 // (unlike `bundle`) preserves `@import` rules, so the hoisted @fontsource lines
@@ -97,4 +100,54 @@ const { code } = transform({
 await Bun.write(outFile, code);
 console.log(
   `built dist/editor.css (${(code.length / 1024).toFixed(1)} kB, ${fontImports.size} @fontsource imports preserved)`,
+);
+
+// ---------------------------------------------------------------------------
+// `dist/standalone.css` — the self-sufficient stylesheet.
+//
+// Same document + chrome CSS as `editor.css`, PLUS a pre-compiled copy of every
+// Tailwind utility folio's own components use, scoped under `.folio-root` (see
+// `src/styles/standalone.css` + `../tailwind.config.js`). A consumer imports
+// this one file and needs no Tailwind pipeline of their own. `editor.css` and
+// its own-Tailwind contract are untouched.
+//
+// Compilation runs the local `@tailwindcss/cli`: it scans the package source
+// (`@source` in the entry) and emits utilities in a canonical, deterministic
+// order, so the output is reproducible from the source alone.
+const standaloneEntry = path.join(stylesDir, "standalone.css");
+const standaloneOut = path.join(pkgDir, "dist", "standalone.css");
+// Resolve the CLI entry from the installed package (its `exports` map does not
+// expose the dist path directly, so resolve via package.json + its `bin`).
+const tailwindCliPkgJson = Bun.resolveSync("@tailwindcss/cli/package.json", pkgDir);
+const tailwindCliBin = (await Bun.file(tailwindCliPkgJson).json()).bin;
+const tailwindCli = path.resolve(
+  path.dirname(tailwindCliPkgJson),
+  typeof tailwindCliBin === "string" ? tailwindCliBin : tailwindCliBin.tailwindcss,
+);
+const utilitiesTmp = path.join(pkgDir, "dist", ".standalone-utilities.css");
+
+const twResult =
+  await $`bun ${tailwindCli} --input ${standaloneEntry} --output ${utilitiesTmp} --minify`
+    .cwd(pkgDir)
+    .nothrow();
+if (twResult.exitCode !== 0) {
+  panic(`build-css: tailwindcss failed to compile standalone utilities\n${twResult.stderr}`);
+}
+const utilitiesCss = await Bun.file(utilitiesTmp).text();
+await rm(utilitiesTmp, { force: true });
+
+// Order: hoisted @fontsource imports (must lead the file), then the bundled
+// document/chrome CSS, then the compiled utilities layer last so a component's
+// utility className wins over the chrome defaults it decorates. The compiled
+// utilities carry no `@import`, so the @fontsource lines stay at the top.
+const standaloneComposed = `${fontImportBlock}\n${bundledBody}\n${utilitiesCss}`;
+const { code: standaloneCode } = transform({
+  filename: "standalone.css",
+  code: Buffer.from(standaloneComposed),
+  minify: true,
+});
+
+await Bun.write(standaloneOut, standaloneCode);
+console.log(
+  `built dist/standalone.css (${(standaloneCode.length / 1024).toFixed(1)} kB, self-sufficient: editor.css + scoped Tailwind utilities)`,
 );

--- a/packages/react/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/react/src/components/ContentControlWidgetsOverlay.tsx
@@ -186,48 +186,54 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
     close();
   };
 
+  // `folio-root` wrapper re-establishes the editor root inside this body portal
+  // so, on the standalone-stylesheet path, the design tokens and scoped
+  // utilities (`bg-popover`, ...) below resolve (and `.dark .folio-root` themes
+  // it). `display: contents` keeps the positioned widget's own layout intact.
   return createPortal(
-    <div
-      role="dialog"
-      aria-label={
-        open.kind === "dropdown"
-          ? t("contentControlDropdownAriaLabel")
-          : t("contentControlDateAriaLabel")
-      }
-      style={style}
-      className="bg-popover text-popover-foreground min-w-[10rem] rounded-md border p-1 shadow-md"
-    >
-      {open.kind === "dropdown" && (
-        <div role="menu" className="flex flex-col">
-          {open.items.length === 0 ? (
-            <div className="text-muted-foreground px-2 py-1 text-sm">
-              {t("contentControlDropdownNoOptions")}
-            </div>
-          ) : (
-            open.items.map((item) => (
-              <MenuItem
-                key={`${item.value}::${item.displayText}`}
-                onClick={() => onDropdownPick(item.value)}
-              >
-                {item.displayText}
-              </MenuItem>
-            ))
-          )}
-        </div>
-      )}
-      {open.kind === "date" && (
-        <DatePickerPopover
-          clearLabel={t("clearDate")}
-          defaultOpen
-          onChange={(value) => {
-            if (value) {
-              onDatePick(value);
-            }
-          }}
-          showIcon={false}
-          value={null}
-        />
-      )}
+    <div className="folio-root" style={{ display: "contents" }}>
+      <div
+        role="dialog"
+        aria-label={
+          open.kind === "dropdown"
+            ? t("contentControlDropdownAriaLabel")
+            : t("contentControlDateAriaLabel")
+        }
+        style={style}
+        className="bg-popover text-popover-foreground min-w-[10rem] rounded-md border p-1 shadow-md"
+      >
+        {open.kind === "dropdown" && (
+          <div role="menu" className="flex flex-col">
+            {open.items.length === 0 ? (
+              <div className="text-muted-foreground px-2 py-1 text-sm">
+                {t("contentControlDropdownNoOptions")}
+              </div>
+            ) : (
+              open.items.map((item) => (
+                <MenuItem
+                  key={`${item.value}::${item.displayText}`}
+                  onClick={() => onDropdownPick(item.value)}
+                >
+                  {item.displayText}
+                </MenuItem>
+              ))
+            )}
+          </div>
+        )}
+        {open.kind === "date" && (
+          <DatePickerPopover
+            clearLabel={t("clearDate")}
+            defaultOpen
+            onChange={(value) => {
+              if (value) {
+                onDatePick(value);
+              }
+            }}
+            showIcon={false}
+            value={null}
+          />
+        )}
+      </div>
     </div>,
     document.body,
   );

--- a/packages/react/src/components/TextContextMenu.tsx
+++ b/packages/react/src/components/TextContextMenu.tsx
@@ -564,7 +564,16 @@ export const TextContextMenu: React.FC<TextContextMenuProps> = ({
     return menu;
   }
 
-  return createPortal(menu, document.body);
+  // Wrap in `folio-root` so, on the standalone-stylesheet path, the editor's
+  // design tokens and scoped utilities apply to this body-portalled menu (and
+  // `.dark .folio-root` themes it). `display: contents` keeps the fixed menu's
+  // own layout intact.
+  return createPortal(
+    <div className="folio-root" style={{ display: "contents" }}>
+      {menu}
+    </div>,
+    document.body,
+  );
 };
 
 // ============================================================================

--- a/packages/react/src/components/dialogs/ImagePropertiesDialog.tsx
+++ b/packages/react/src/components/dialogs/ImagePropertiesDialog.tsx
@@ -101,7 +101,7 @@ export function ImagePropertiesDialog({
             <div className="flex flex-col gap-2">
               <div className={sectionLabelCls}>Alt Text</div>
               <textarea
-                className="border-input bg-background text-foreground font-inherit min-h-[60px] resize-y rounded border px-1.5 py-1 text-xs outline-none"
+                className="border-input bg-background text-foreground font-[inherit] min-h-[60px] resize-y rounded border px-1.5 py-1 text-xs outline-none"
                 value={alt}
                 onChange={(e) => setAlt(e.target.value)}
                 placeholder="Describe this image for accessibility..."

--- a/packages/react/src/components/toolbarPrimitives.tsx
+++ b/packages/react/src/components/toolbarPrimitives.tsx
@@ -284,7 +284,7 @@ export function ToolbarButton({
       className={cn(
         "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
         "transition-colors duration-100",
-        "-webkit-font-smoothing-antialiased",
+        "antialiased",
         "text-[var(--doc-text-muted)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]",
         active &&
           "bg-[var(--doc-primary-light)] text-[var(--doc-text)] hover:bg-[var(--doc-primary-light)]",

--- a/packages/react/src/styles/standalone.css
+++ b/packages/react/src/styles/standalone.css
@@ -1,0 +1,170 @@
+/**
+ * Tailwind entry for the self-sufficient `@stll/folio-react/standalone.css`.
+ *
+ * This file is the INPUT the build compiles (see `scripts/build-css.ts`); it is
+ * never shipped as-is. The compiler:
+ *   - scans folio's own React source (`@source`) for utility class names,
+ *   - generates every one of those utilities, scoped under `.folio-root` via
+ *     `@config` (`important: ".folio-root"`), so they cannot bleed into a host,
+ *   - inlines the semantic-token -> Tailwind-color mapping (`@theme inline`),
+ *   - and emits the low-specificity token fallbacks + minimal reset below.
+ *
+ * The build then concatenates the compiled utilities with the bundled
+ * `editor.css` (document + ProseMirror + chrome styles) to produce one
+ * self-contained `dist/standalone.css` a consumer can import with no Tailwind
+ * of their own. The `editor.css` export and its own-Tailwind contract are
+ * unchanged.
+ *
+ * Preflight is intentionally excluded: Tailwind's `important` selector does not
+ * scope the base reset, so a full preflight would restyle the host app's
+ * elements globally. The scoped `@layer base` reset below covers only what the
+ * generated utilities require (`box-sizing`, `border-style: solid` so
+ * `border-*` widths render, form-control normalization), confined to
+ * `.folio-root`.
+ */
+
+@layer theme, base, components, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
+
+/* `important: ".folio-root"` scopes generated utilities under the editor root. */
+@config "../../tailwind.config.js";
+
+/* Scan folio's React chrome for the utility classes to generate. */
+@source "../**/*.{ts,tsx}";
+
+/* folio toggles dark mode with a `.dark` class on an ancestor (host `<html>`),
+ * matching the primary own-Tailwind path. */
+@custom-variant dark (&:is(.dark *));
+
+/* Map folio's semantic tokens onto Tailwind color names so `bg-popover`,
+ * `text-muted-foreground`, `border-input`, ... resolve to the tokens below (or
+ * to a consumer's overrides). `inline` keeps these out of `:root` and inlines
+ * `var(--token)` straight into each utility. Mirrors the token set the primary
+ * (own-Tailwind) path expects the host to provide. */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-highlight: var(--highlight);
+  --color-highlight-foreground: var(--highlight-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+/* Base design tokens as LOW-SPECIFICITY fallbacks: `:where(.folio-root)` has
+ * zero specificity, so a consumer theme (`.folio-root { --background: ... }`,
+ * or their own token layer) always wins. `editor.css` maps its `--doc-*`
+ * aliases onto these. Values mirror the neutral palette the primary path uses.
+ * These are the only tokens the standalone path must supply itself; the primary
+ * path gets them from the host design system. */
+:where(.folio-root) {
+  --background: #ffffff;
+  --foreground: #262626;
+  --card: #ffffff;
+  --card-foreground: #262626;
+  --popover: #ffffff;
+  --popover-foreground: #262626;
+  --primary: #262626;
+  --primary-foreground: #fafafa;
+  --secondary: rgb(0 0 0 / 4%);
+  --secondary-foreground: #262626;
+  --muted: rgb(0 0 0 / 4%);
+  --muted-foreground: #525252;
+  --accent: rgb(0 0 0 / 4%);
+  --accent-foreground: #262626;
+  --destructive: #ef4444;
+  --destructive-foreground: #b91c1c;
+  --info: #3b82f6;
+  --info-foreground: #1d4ed8;
+  --success: #10b981;
+  --success-foreground: #047857;
+  --warning: #f59e0b;
+  --warning-foreground: #b45309;
+  --highlight: rgb(253 224 71 / 50%);
+  --highlight-foreground: #262626;
+  --border: rgb(0 0 0 / 10%);
+  --input: rgb(0 0 0 / 12%);
+  --ring: #a3a3a3;
+}
+
+:where(.folio-root.dark, .dark .folio-root) {
+  --background: #0a0a0a;
+  --foreground: #f5f5f5;
+  --card: #171717;
+  --card-foreground: #f5f5f5;
+  --popover: #171717;
+  --popover-foreground: #f5f5f5;
+  --primary: #f5f5f5;
+  --primary-foreground: #262626;
+  --secondary: rgb(255 255 255 / 4%);
+  --secondary-foreground: #f5f5f5;
+  --muted: rgb(255 255 255 / 4%);
+  --muted-foreground: #a3a3a3;
+  --accent: rgb(255 255 255 / 4%);
+  --accent-foreground: #f5f5f5;
+  --destructive: #f87171;
+  --destructive-foreground: #f87171;
+  --info: #3b82f6;
+  --info-foreground: #60a5fa;
+  --success: #10b981;
+  --success-foreground: #34d399;
+  --warning: #f59e0b;
+  --warning-foreground: #fbbf24;
+  --highlight: rgb(234 179 8 / 20%);
+  --highlight-foreground: #f5f5f5;
+  --border: rgb(255 255 255 / 8%);
+  --input: rgb(255 255 255 / 10%);
+  --ring: #737373;
+}
+
+/* Minimal scoped reset (standalone path only). Utilities live in the later
+ * `utilities` layer, so they always win over these base defaults. Confined to
+ * `.folio-root` and written with `:where()` so nothing here can outrank a
+ * consumer rule. */
+@layer base {
+  :where(.folio-root) *,
+  :where(.folio-root) *::before,
+  :where(.folio-root) *::after {
+    box-sizing: border-box;
+    /* Tailwind's `border-*` utilities set only width and assume this default. */
+    border: 0 solid;
+  }
+
+  :where(.folio-root) button,
+  :where(.folio-root) input,
+  :where(.folio-root) select,
+  :where(.folio-root) optgroup,
+  :where(.folio-root) textarea {
+    font: inherit;
+    color: inherit;
+    background-color: transparent;
+    border-radius: 0;
+  }
+
+  :where(.folio-root) button,
+  :where(.folio-root) input:where([type="button"], [type="reset"], [type="submit"]) {
+    appearance: button;
+  }
+}

--- a/packages/react/src/ui/defaults/color-picker.tsx
+++ b/packages/react/src/ui/defaults/color-picker.tsx
@@ -37,7 +37,10 @@ export function DefaultColorPicker({
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Positioner
           align="start"
-          className="folio-default-popover-positioner"
+          // `folio-root` re-establishes the editor root inside the body portal
+          // so design tokens and the standalone stylesheet's scoped utilities
+          // apply to the portalled content (and `.dark .folio-root` themes it).
+          className="folio-default-popover-positioner folio-root"
           side="bottom"
           sideOffset={4}
         >

--- a/packages/react/src/ui/defaults/dialog.tsx
+++ b/packages/react/src/ui/defaults/dialog.tsx
@@ -23,8 +23,18 @@ function DefaultDialogRoot(props: FolioDialogRootProps) {
   return <DialogPrimitive.Root {...props} />;
 }
 
-function DefaultDialogPortal(props: FolioDialogPortalProps) {
-  return <DialogPrimitive.Portal {...props} />;
+function DefaultDialogPortal({ children, ...props }: FolioDialogPortalProps) {
+  // `folio-root` re-establishes the editor root inside the body portal so design
+  // tokens and the standalone stylesheet's scoped utilities apply to the dialog
+  // (and `.dark .folio-root` themes it). `display: contents` keeps the wrapper
+  // out of layout, so the fixed-position backdrop/popup are unaffected.
+  return (
+    <DialogPrimitive.Portal {...props}>
+      <div className="folio-root" style={{ display: "contents" }}>
+        {children}
+      </div>
+    </DialogPrimitive.Portal>
+  );
 }
 
 function DefaultDialogBackdrop({ className, ...props }: FolioDialogBackdropProps) {

--- a/packages/react/src/ui/defaults/menu.tsx
+++ b/packages/react/src/ui/defaults/menu.tsx
@@ -42,7 +42,10 @@ function DefaultMenuPopup({
       <MenuPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
-        className="folio-default-menu-positioner"
+        // `folio-root` re-establishes the editor root inside the body portal so
+        // design tokens and the standalone stylesheet's scoped utilities apply
+        // to the portalled content (and `.dark .folio-root` themes it).
+        className="folio-default-menu-positioner folio-root"
         side={side}
         sideOffset={sideOffset}
       >

--- a/packages/react/src/ui/defaults/popover.tsx
+++ b/packages/react/src/ui/defaults/popover.tsx
@@ -38,7 +38,10 @@ function DefaultPopoverPopup({
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
-        className="folio-default-popover-positioner"
+        // `folio-root` re-establishes the editor root inside the body portal so
+        // design tokens and the standalone stylesheet's scoped utilities apply
+        // to the portalled content (and `.dark .folio-root` themes it).
+        className="folio-default-popover-positioner folio-root"
         side={side}
         sideOffset={sideOffset}
       >

--- a/packages/react/src/ui/defaults/select.tsx
+++ b/packages/react/src/ui/defaults/select.tsx
@@ -61,7 +61,10 @@ function DefaultSelectPopup({ className, children, ...props }: FolioSelectPopupP
     <SelectPrimitive.Portal>
       <SelectPrimitive.Positioner
         align="start"
-        className="folio-default-select-positioner"
+        // `folio-root` re-establishes the editor root inside the body portal so
+        // design tokens and the standalone stylesheet's scoped utilities apply
+        // to the portalled content (and `.dark .folio-root` themes it).
+        className="folio-default-select-positioner folio-root"
         side="bottom"
         sideOffset={4}
       >

--- a/packages/react/tailwind.config.js
+++ b/packages/react/tailwind.config.js
@@ -1,0 +1,19 @@
+// Tailwind config for the self-sufficient `standalone.css` build only.
+//
+// The primary `editor.css` path does NOT use this: a host app runs its own
+// Tailwind, scans folio's dist for utility classes, and supplies the semantic
+// design tokens. `standalone.css` is the second path — it ships a pre-compiled
+// copy of every utility folio's own components use so a consumer needs no
+// Tailwind pipeline at all.
+//
+// `important: ".folio-root"` scopes every generated utility under the editor
+// root (Tailwind v4 nests them as `.folio-root .<utility>`), so the compiled
+// utilities can never leak into and restyle the host app. This is the v4
+// equivalent of the v3 selector-string `important` option, loaded via the
+// `@config` directive in `src/styles/standalone.css` (v4 dropped the CSS-side
+// selector form; a legacy JS config still honors it). Pattern used by the
+// upstream docx-editor's `.ep-root` scoping.
+/** @type {import('tailwindcss').Config} */
+export default {
+  important: ".folio-root",
+};

--- a/scripts/standalone-css-coverage.test.ts
+++ b/scripts/standalone-css-coverage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import { findUncoveredUtilities } from "./standalone-css-coverage";
+
+// A miniature packed standalone.css: scoped utilities (`.folio-root .<util>`),
+// low-specificity token fallbacks, and a couple of hand-written doc classes.
+const STANDALONE_CSS = `
+@import "@fontsource/carlito/400.css";
+:where(.folio-root){--popover:#fff;--muted:#eee}
+.folio-root .flex{display:flex}
+.folio-root .bg-popover{background-color:var(--popover)}
+.folio-root .text-muted-foreground{color:var(--muted-foreground)}
+.folio-root .hover\\:bg-muted\\/80:hover{background-color:var(--muted)}
+.folio-root .h-\\[var\\(--x\\)\\]{height:var(--x)}
+.folio-root .\\[\\&_svg\\]\\:text-destructive svg{color:red}
+.folio-root .antialiased{-webkit-font-smoothing:antialiased}
+.docx-insertion{color:green}
+.folio-default-button{border:1px solid}
+`;
+
+const js = (code: string) => [{ file: "index.js", code }];
+
+describe("findUncoveredUtilities", () => {
+  test("passes when every className utility has a generated rule", () => {
+    const result = findUncoveredUtilities({
+      jsFiles: js(
+        'jsx("div",{className:"flex bg-popover text-muted-foreground hover:bg-muted/80"})',
+      ),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual([]);
+    expect(result.candidates).toBeGreaterThan(0);
+  });
+
+  test("resolves utilities from cn()/clsx() arguments", () => {
+    const result = findUncoveredUtilities({
+      jsFiles: js('className: cn("flex antialiased", active && "bg-popover", "h-[var(--x)]")'),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual([]);
+  });
+
+  test("reports a utility used in JS but absent from the sheet (the drift it guards)", () => {
+    const result = findUncoveredUtilities({
+      jsFiles: js('className:"flex mt-[12345px]"'),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual(["mt-[12345px]"]);
+  });
+
+  test("arbitrary-value and arbitrary-variant utilities match through CSS escaping", () => {
+    const result = findUncoveredUtilities({
+      jsFiles: js('className:"h-[var(--x)] [&_svg]:text-destructive"'),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual([]);
+  });
+
+  test("ignores import specifiers, i18n keys, and element/attribute names", () => {
+    // None of these appear in a className/cn context, so none are candidates.
+    const result = findUncoveredUtilities({
+      jsFiles: js(
+        'import x from "@stll/folio-core/prosemirror/schema";\n' +
+          't("acceptChange"); jsx("svg",{role:"img","aria-label":"x"});\n' +
+          'const mode="all-markup";',
+      ),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.candidates).toBe(0);
+    expect(result.uncovered).toEqual([]);
+  });
+
+  test("skips folio's own semantic classes and inert/marker classes", () => {
+    const result = findUncoveredUtilities({
+      jsFiles: js(
+        'className: cn("folio-root folio-editor docx-insertion", "group peer", "animate-in slide-in-from-right")',
+      ),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual([]);
+  });
+});

--- a/scripts/standalone-css-coverage.test.ts
+++ b/scripts/standalone-css-coverage.test.ts
@@ -56,6 +56,46 @@ describe("findUncoveredUtilities", () => {
     expect(result.uncovered).toEqual([]);
   });
 
+  test("extracts literals nested inside template-literal interpolations", () => {
+    // The dist bundle keeps conditionals inside className templates; the
+    // branches' classes must count, or a compile miss would ship silently.
+    const result = findUncoveredUtilities({
+      jsFiles: js('className: `flex antialiased ${on ? "bg-popover" : "text-muted-foreground"}`'),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.candidates).toBe(4);
+    expect(result.uncovered).toEqual([]);
+  });
+
+  test("comparison operands inside interpolations are not class tokens", () => {
+    // `position === "footer"` is a discriminator, not a class; only the branch
+    // literal counts.
+    const result = findUncoveredUtilities({
+      jsFiles: js('className: `flex${position === "footer" ? " bg-popover" : ""}`'),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.candidates).toBe(2);
+    expect(result.uncovered).toEqual([]);
+  });
+
+  test("reports drift for an uncovered utility inside an interpolation", () => {
+    const result = findUncoveredUtilities({
+      jsFiles: js('className: `flex ${on ? "mt-[12345px]" : "bg-popover"}`'),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual(["mt-[12345px]"]);
+  });
+
+  test("an interpolation splitting a class never tokenizes as a complete class", () => {
+    // `w-[${size}px]` is runtime-assembled; its static fragments must not be
+    // reported (no static sheet could ever cover them).
+    const result = findUncoveredUtilities({
+      jsFiles: js("className: `flex w-[${size}px]`"),
+      standaloneCss: STANDALONE_CSS,
+    });
+    expect(result.uncovered).toEqual([]);
+  });
+
   test("ignores import specifiers, i18n keys, and element/attribute names", () => {
     // None of these appear in a className/cn context, so none are candidates.
     const result = findUncoveredUtilities({

--- a/scripts/standalone-css-coverage.ts
+++ b/scripts/standalone-css-coverage.ts
@@ -1,0 +1,166 @@
+// Completeness guard for the self-sufficient `standalone.css`.
+//
+// `standalone.css` ships a PRE-COMPILED copy of every Tailwind utility folio's
+// own React components use, scoped under `.folio-root` (see
+// `src/styles/standalone.css` + `../tailwind.config.js`). The compile scans the
+// package source; if that scan ever drifts from what actually ships in the dist
+// JS (a new component dir the `@source` glob misses, a class assembled in a way
+// the scanner cannot see, a stale build), a consumer on the standalone path
+// gets an unstyled control with no error.
+//
+// This pure helper closes that gap: it extracts Tailwind-ish class tokens from
+// the packed dist JS (only from `className:` values and `cn()`/`clsx()`/`cx()`
+// arguments, so import specifiers and i18n keys are never mistaken for classes)
+// and asserts each one has a generated rule in the packed `standalone.css`.
+// Kept separate from `validate-dist.ts` so the extraction rules are unit tested
+// in `standalone-css-coverage.test.ts`, mirroring `dist-url-targets.ts`.
+
+import type { DistJsFile } from "./dist-url-targets";
+
+export type StandaloneCoverageResult = {
+  /** Distinct Tailwind-ish class tokens found in the dist JS. */
+  candidates: number;
+  /** Class tokens used in the JS that have no rule in `standalone.css`. */
+  uncovered: string[];
+};
+
+type CoverageInput = {
+  jsFiles: DistJsFile[];
+  standaloneCss: string;
+};
+
+// folio's own semantic class prefixes (styled by `editor.css`, not utilities).
+const CUSTOM_CLASS_PREFIXES = [
+  "folio",
+  "docx",
+  "hf-",
+  "pg-",
+  "paged-editor",
+  "prosemirror",
+  "image-",
+  "layout-",
+  "band-",
+  "cm-",
+  "tiptap",
+];
+
+// Marker/inert classes that neither the own-Tailwind path nor the standalone
+// path generates a rule for: Tailwind state markers (`group`, `peer`) and
+// animation utilities that require a plugin folio does not enable (so they are
+// equally no-ops on both paths).
+const IGNORED_CLASSES = new Set(["group", "peer", "sr-only", "not-prose", "prose", "dark"]);
+const INERT_CLASS_RE =
+  /^(?:animate-|slide-(?:in|out)|fade-(?:in|out)|zoom-(?:in|out)|spin$|pulse$)/u;
+
+// Structural shape of a Tailwind utility, optionally prefixed with variants
+// (`hover:`, `dark:`, `data-[state=open]:`, `[&_svg]:`) and an opacity/arbitrary
+// suffix. Deliberately loose on the utility body; the authoritative check is
+// membership in the generated set, this only screens out non-class strings.
+const TAILWIND_TOKEN_RE =
+  /^(?:(?:[-a-z0-9]*(?:\[[^\]]*\])?[-a-z0-9]*):)*!?-?[a-z][a-z0-9]*(?:-[a-z0-9.]+)*(?:-?\[[^\]]*\])?(?:\/[0-9.]+)?$/u;
+
+// Class selector token in the compiled CSS, capturing the escaped class name.
+const SCOPED_UTILITY_RE = /\.folio-root \.((?:\\.|[^\\{,:>~+\s[])+)/gu;
+const ANY_CLASS_RE = /\.((?:\\.|[^\s.,{}()>~+:#[\]])+)/gu;
+
+const unescapeClass = (escaped: string): string => escaped.replace(/\\(.)/gu, "$1");
+
+// Pull the contents of every `"..."`, `'...'`, and `` `...` `` literal from a
+// snippet; template interpolations (`${...}`) are runtime values, not classes,
+// so they are blanked to a separator.
+const collectLiteralContents = (snippet: string, out: string[]): void => {
+  const re = /(["'`])((?:\\.|(?!\1)[^\\])*)\1/gu;
+  for (const match of snippet.matchAll(re)) {
+    const quote = match[1];
+    const value = match[2] ?? "";
+    out.push(quote === "`" ? value.replace(/\$\{[^}]*\}/gu, " ") : value);
+  }
+};
+
+// Return the argument list of each `cn(` / `clsx(` / `cx(` call, using balanced
+// paren matching (string-aware) so nested calls and following JSX are excluded.
+const collectCallArgumentBlocks = (code: string): string[] => {
+  const blocks: string[] = [];
+  const callRe = /\b(?:cn|clsx|cx|twMerge|twJoin)\(/gu;
+  let match: RegExpExecArray | null = callRe.exec(code);
+  while (match !== null) {
+    let i = callRe.lastIndex;
+    const start = i;
+    let depth = 1;
+    while (i < code.length && depth > 0) {
+      const c = code[i];
+      if (c === '"' || c === "'" || c === "`") {
+        i += 1;
+        while (i < code.length && code[i] !== c) {
+          if (code[i] === "\\") {
+            i += 1;
+          }
+          i += 1;
+        }
+      } else if (c === "(") {
+        depth += 1;
+      } else if (c === ")") {
+        depth -= 1;
+      }
+      i += 1;
+    }
+    blocks.push(code.slice(start, i - 1));
+    callRe.lastIndex = i;
+    match = callRe.exec(code);
+  }
+  return blocks;
+};
+
+const extractClassStrings = (jsFiles: DistJsFile[]): string[] => {
+  const strings: string[] = [];
+  const classNameLiteralRe =
+    /className:\s*(`(?:\\.|[^`\\])*`|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')/gu;
+  for (const { code } of jsFiles) {
+    for (const match of code.matchAll(classNameLiteralRe)) {
+      collectLiteralContents(match[1] ?? "", strings);
+    }
+    for (const block of collectCallArgumentBlocks(code)) {
+      collectLiteralContents(block, strings);
+    }
+  }
+  return strings;
+};
+
+export const findUncoveredUtilities = ({
+  jsFiles,
+  standaloneCss,
+}: CoverageInput): StandaloneCoverageResult => {
+  const generated = new Set<string>();
+  for (const match of standaloneCss.matchAll(SCOPED_UTILITY_RE)) {
+    generated.add(unescapeClass(match[1] ?? ""));
+  }
+  const anyCssClass = new Set<string>();
+  for (const match of standaloneCss.matchAll(ANY_CLASS_RE)) {
+    anyCssClass.add(unescapeClass(match[1] ?? ""));
+  }
+
+  const candidates = new Set<string>();
+  for (const classString of extractClassStrings(jsFiles)) {
+    for (const token of classString.split(/\s+/u)) {
+      if (!token || IGNORED_CLASSES.has(token) || INERT_CLASS_RE.test(token)) {
+        continue;
+      }
+      if (CUSTOM_CLASS_PREFIXES.some((prefix) => token.startsWith(prefix))) {
+        continue;
+      }
+      if (!TAILWIND_TOKEN_RE.test(token)) {
+        continue;
+      }
+      // A token that has a non-utility rule in the bundled `editor.css` portion
+      // (e.g. a hand-written `.docx-*` doc class reached via `cn`) is covered by
+      // that rule, not a utility.
+      if (anyCssClass.has(token) && !generated.has(token)) {
+        continue;
+      }
+      candidates.add(token);
+    }
+  }
+
+  const uncovered = [...candidates].filter((token) => !generated.has(token)).sort();
+  return { candidates: candidates.size, uncovered };
+};

--- a/scripts/standalone-css-coverage.ts
+++ b/scripts/standalone-css-coverage.ts
@@ -65,15 +65,77 @@ const ANY_CLASS_RE = /\.((?:\\.|[^\s.,{}()>~+:#[\]])+)/gu;
 
 const unescapeClass = (escaped: string): string => escaped.replace(/\\(.)/gu, "$1");
 
+// Split a template-literal body into its static text (interpolations replaced
+// by a separator, so a partial class like `w-[${size}px]` never tokenizes as a
+// complete one) and the code inside each balanced `${...}` (brace-counted,
+// string-aware). An unbalanced `${` means the outer literal regex chopped a
+// template that itself nests another template; the tail is dropped rather than
+// recursed, so half an expression cannot masquerade as a class token.
+const splitTemplate = (body: string): { staticText: string; interpolations: string[] } => {
+  let staticText = "";
+  const interpolations: string[] = [];
+  let i = 0;
+  while (i < body.length) {
+    if (body[i] !== "$" || body[i + 1] !== "{") {
+      staticText += body[i];
+      i += 1;
+      continue;
+    }
+    let j = i + 2;
+    let depth = 1;
+    while (j < body.length && depth > 0) {
+      const c = body[j];
+      if (c === '"' || c === "'" || c === "`") {
+        j += 1;
+        while (j < body.length && body[j] !== c) {
+          if (body[j] === "\\") {
+            j += 1;
+          }
+          j += 1;
+        }
+      } else if (c === "{") {
+        depth += 1;
+      } else if (c === "}") {
+        depth -= 1;
+      }
+      j += 1;
+    }
+    if (depth > 0) {
+      break; // unbalanced: chopped template, drop the tail
+    }
+    interpolations.push(body.slice(i + 2, j - 1));
+    staticText += " ";
+    i = j;
+  }
+  return { staticText, interpolations };
+};
+
+// A string literal adjacent to a comparison operator inside an interpolation is
+// an operand (`position === "footer"`), not a class; strip those before
+// extracting, or discriminator values would surface as phantom class tokens.
+const COMPARISON_OPERAND_RE =
+  /[!=]==?\s*(["'])(?:\\.|(?!\1).)*\1|(["'])(?:\\.|(?!\2).)*\2\s*[!=]==?/gu;
+
 // Pull the contents of every `"..."`, `'...'`, and `` `...` `` literal from a
-// snippet; template interpolations (`${...}`) are runtime values, not classes,
-// so they are blanked to a separator.
+// snippet. Template interpolations are recursed into, so literals nested in a
+// conditional (`` `base ${on ? "border-transparent" : "bg-muted"}` ``) still
+// count — missing them would be a silent false negative, the exact failure this
+// guard exists to catch. The interpolation expression itself is replaced by a
+// separator in the static text (runtime values are not classes).
 const collectLiteralContents = (snippet: string, out: string[]): void => {
   const re = /(["'`])((?:\\.|(?!\1)[^\\])*)\1/gu;
   for (const match of snippet.matchAll(re)) {
     const quote = match[1];
     const value = match[2] ?? "";
-    out.push(quote === "`" ? value.replace(/\$\{[^}]*\}/gu, " ") : value);
+    if (quote !== "`") {
+      out.push(value);
+      continue;
+    }
+    const { staticText, interpolations } = splitTemplate(value);
+    out.push(staticText);
+    for (const code of interpolations) {
+      collectLiteralContents(code.replace(COMPARISON_OPERAND_RE, " "), out);
+    }
   }
 };
 

--- a/scripts/validate-dist.ts
+++ b/scripts/validate-dist.ts
@@ -42,6 +42,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { scanDistUrlTargets } from "./dist-url-targets";
+import { findUncoveredUtilities } from "./standalone-css-coverage";
 
 const repoRoot = path.resolve(import.meta.dir, "..");
 const prepareScript = path.join(repoRoot, "scripts", "prepare-publish.ts");
@@ -311,6 +312,63 @@ if (target === "react") {
           .join("; ");
     record("css: bundled, valid, @fontsource preserved", ok, detail);
   }
+
+  // --- Check 3b: self-sufficient standalone.css -----------------------------
+  // Same document + chrome CSS as editor.css PLUS pre-compiled Tailwind
+  // utilities scoped under `.folio-root`, so a consumer needs no Tailwind of
+  // their own. Must be fully compiled (no un-expanded `@tailwind`/`@config`/
+  // `@source` directives), carry scoped utilities + token fallbacks, and still
+  // preserve the @fontsource `@import`s.
+  const standalonePath = path.join(installedDist, "standalone.css");
+  if (!existsSync(standalonePath)) {
+    record("css: dist/standalone.css present", false, "missing from tarball");
+  } else {
+    const css = await readFile(standalonePath, "utf-8");
+    const fontImports = css.match(/@import\s+["']@fontsource\/[^"']+["']/gu) ?? [];
+    // Scoped utilities (`.folio-root .<utility>`) plus low-specificity token
+    // fallbacks are what make the sheet self-sufficient.
+    const hasScopedUtilities = /\.folio-root \.[a-z]/u.test(css);
+    const hasTokenFallback = /:where\(\.folio-root\)/u.test(css) && css.includes("--popover:");
+    const hasDocRules = css.includes(".ProseMirror") && css.includes(".folio-default-button");
+    // No Tailwind source directive may survive into the shipped file.
+    const uncompiled = /@tailwind\b|@config\b|@source\b|@apply\b/u.test(css);
+    const fontsourceInlined =
+      /url\([^)]*@fontsource/u.test(css) || /url\(["']?data:font/u.test(css);
+
+    let parses = true;
+    let parseDetail = "";
+    try {
+      transform({ filename: "standalone.css", code: Buffer.from(css), minify: false });
+    } catch (error) {
+      parses = false;
+      parseDetail = error instanceof Error ? error.message : String(error);
+    }
+
+    const ok =
+      css.length > 10_000 &&
+      parses &&
+      hasScopedUtilities &&
+      hasTokenFallback &&
+      hasDocRules &&
+      !uncompiled &&
+      fontImports.length >= 20 &&
+      !fontsourceInlined;
+    const detail = ok
+      ? `${(css.length / 1024).toFixed(1)} kB, scoped utilities + token fallbacks + doc rules, ${fontImports.length} @fontsource imports preserved`
+      : [
+          css.length <= 10_000 && `too small (${css.length}B)`,
+          !parses && `invalid CSS: ${parseDetail}`,
+          !hasScopedUtilities && "no `.folio-root .<utility>` rules",
+          !hasTokenFallback && "no `:where(.folio-root)` token fallbacks",
+          !hasDocRules && "missing bundled document/chrome rules",
+          uncompiled && "un-expanded Tailwind directive present",
+          fontImports.length < 20 && `only ${fontImports.length} @fontsource imports`,
+          fontsourceInlined && "@fontsource appears inlined as font data",
+        ]
+          .filter(Boolean)
+          .join("; ");
+    record("css: standalone.css self-sufficient (scoped utilities + tokens)", ok, detail);
+  }
 }
 
 // --- Check 4: externals not bundled into the JS -----------------------------
@@ -358,6 +416,29 @@ record(
         .filter(Boolean)
         .join("; "),
 );
+
+// --- Check (react only): standalone.css covers every utility the JS uses ----
+// Every Tailwind utility a shipped component references must have a generated
+// rule in the packed standalone.css. Fails if a class in the dist JS was not
+// picked up by the standalone compile (a `@source` glob that missed a new
+// component dir, a stale build), which would leave a consumer on the standalone
+// path with an unstyled control and no error.
+if (target === "react") {
+  const standalonePath = path.join(installedDist, "standalone.css");
+  if (!existsSync(standalonePath)) {
+    record("css: standalone.css utility coverage", false, "standalone.css missing from tarball");
+  } else {
+    const standaloneCss = await readFile(standalonePath, "utf-8");
+    const { candidates, uncovered } = findUncoveredUtilities({ jsFiles: jsContents, standaloneCss });
+    record(
+      "css: standalone.css covers every utility used in dist JS",
+      uncovered.length === 0,
+      uncovered.length === 0
+        ? `${candidates} utility class(es) referenced, all present in standalone.css`
+        : `missing from standalone.css: ${uncovered.join(", ")}`,
+    );
+  }
+}
 
 // --- Check: `new URL(..., import.meta.url)` targets ship in dist ------------
 // Every asset a published module references via `new URL("<rel>",


### PR DESCRIPTION
## Why

`@stll/folio-react`'s chrome (toolbar, menus, dialogs) is authored with Tailwind utility classes plus semantic design tokens, but the published `editor.css` ships only the document / ProseMirror / chrome rules. To render the editor a consumer had to:

1. run Tailwind themselves, and
2. `@source`-scan this package's dist JS so the utilities its components use get generated, and
3. supply the semantic token set.

That is a hard requirement of Tailwind and fragile: a stale or dangling `@source` glob is silently tolerated, so a missed class just renders unstyled with no error.

## What

A second, self-sufficient stylesheet that needs no Tailwind pipeline on the consumer side, added **without changing the existing `editor.css` export or its own-Tailwind contract** (that path stays byte-identical).

### New export: `@stll/folio-react/standalone.css`
- `editor.css`'s bundled content **plus** a pre-compiled copy of every Tailwind utility folio's own components use.
- Utilities are scoped under `.folio-root` so they cannot bleed into or restyle the host app.
- Base tokens ship as low-specificity `:where(.folio-root)` fallbacks, so a consumer theme (`.folio-root { --background: … }`) always overrides them. `.dark` on an ancestor themes the editor and its portalled overlays.

### v4 scoping mechanism
Tailwind v4 dropped the CSS-side selector form of `important`. This uses the `@config`-loaded **legacy JS config** (`tailwind.config.js`, `important: ".folio-root"`), which v4 still honors — it nests every generated utility as `.folio-root .<utility>`. This is the v4 equivalent of the `.ep-root` important-selector scoping the upstream docx-editor used.

Preflight is intentionally excluded: the `important` selector does **not** scope the base reset, so a full preflight would restyle host elements globally. A minimal `.folio-root`-scoped reset in `@layer base` covers only what the generated utilities require (`box-sizing`, `border-style: solid` so `border-*` widths render, form-control normalization).

### Portals
folio's overlays (menu / popover / select / dialog defaults, the text context menu, the content-control widget) render through `document.body` portals. Their content is re-wrapped in `.folio-root` so the tokens and scoped utilities resolve inside the portal. Additive; the own-Tailwind path is unaffected (a `display: contents` wrapper keeps fixed-position layout intact).

### Build
`packages/react/scripts/build-css.ts` now compiles the scoped utilities with the local `@tailwindcss/cli` (deterministic, canonical utility order, scans the package's own `src`) and emits `dist/standalone.css` next to the unchanged `dist/editor.css`.

### Guard
`scripts/validate-dist.ts` gains a completeness check backed by the pure, unit-tested `scripts/standalone-css-coverage.ts`: it extracts Tailwind-ish class tokens from the packed dist JS (only from `className:` values and `cn()`/`clsx()` args, so import specifiers and i18n keys are never mistaken for classes) and asserts each has a generated rule in the packed `standalone.css`. It fails if a component gains a utility class the compiled sheet did not pick up. Building the guard surfaced two pre-existing dead no-op classes, fixed in the first commit.

### Docs
README documents both integration modes (own-Tailwind + `@source`, vs single `standalone.css` import).

## Validation
- `bun run lint`, `bun run check:i18n`, `bun --filter @stll/folio-react typecheck`, `bun --filter @stll/playground typecheck` — green
- `bun --filter @stll/folio-react test` (164), `bun test scripts` (22, incl. the new coverage tests) — green
- `bun run validate-dist` — core 5/5, react **9/9** (incl. `standalone.css self-sufficient` and `standalone.css covers every utility used in dist JS — 220 utility classes referenced, all present`)
- `bun run test:packaged-consumer` — green
- Extra: a throwaway Vite consumer with **no** Tailwind that imports only `dist/standalone.css` builds and emits the scoped `.folio-root .bg-popover` / `.folio-root .flex` rules, the `:where(.folio-root)` token fallbacks, and the bundled doc rules.

Guard proof: injecting an unused utility (`bg-fuchsia-500`) into the packed dist JS makes the coverage check fail (`missing from standalone.css: bg-fuchsia-500`); it passes again once removed.
