### PR TITLE
feat: controlled comments props for collaboration sync

### DIFF
--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -38,6 +38,7 @@ import { Checkbox } from '@base-ui/react/checkbox';
 import { clearAutocompleteSuggestion } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
 import { clearTemplateSlashMenu } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
 import { ColorValue } from '@stll/folio-core/types/document';
+import { Comment as Comment_2 } from '@stll/folio-core/types/content';
 import { ComponentProps } from 'react';
 import { ComponentType } from 'react';
 import { consumeTemplateSlashQuery } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
@@ -342,7 +343,9 @@ export type DocxEditorProps = {
     onPaste?: () => void; /** Editor mode: 'editing' (direct edits), 'suggesting' (track changes), or 'viewing' (read-only). Default: 'editing' */
     mode?: EditorMode; /** Callback when the editing mode changes */
     onModeChange?: (mode: EditorMode) => void; /** Callback when a readonly user action would mutate the document. */
-    onReadonlyEditAttempt?: () => void; /** Callback with the parsed document's editing compatibility report. */
+    onReadonlyEditAttempt?: () => void;
+    comments?: Comment_2[]; /** Fires whenever the comments array changes (controlled and uncontrolled). */
+    onCommentsChange?: (comments: Comment_2[]) => void; /** Callback with the parsed document's editing compatibility report. */
     onCompatibilityChange?: (compatibility: DocxCompatibility) => void;
     onEditorViewReady?: (view: EditorView | null) => void; /** Yjs-backed collaboration owner. Experimental and opt-in. */
     collaboration?: DocxEditorCollaboration | undefined;

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -26,6 +26,7 @@ import type {
   TemplateSlashMenuState,
 } from "@stll/folio-core/prosemirror/plugins/templateSlashMenu";
 import type { Document, SdtProperties, Theme, TabStop } from "@stll/folio-core/types/document";
+import type { Comment } from "@stll/folio-core/types/content";
 import type { DocxInput } from "@stll/folio-core/utils/docxInput";
 import type { FontDefinition } from "../paged-editor/hostFonts";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
@@ -207,6 +208,15 @@ export type DocxEditorProps = {
   onModeChange?: (mode: EditorMode) => void;
   /** Callback when a readonly user action would mutate the document. */
   onReadonlyEditAttempt?: () => void;
+  /**
+   * Controlled comments array. When provided, the editor reads comment thread
+   * metadata from this prop and emits every change through `onCommentsChange`.
+   * Use with collaboration backends (Yjs, etc.) so comment threads sync across
+   * peers; PM carries range markers, thread metadata lives outside the doc.
+   */
+  comments?: Comment[];
+  /** Fires whenever the comments array changes (controlled and uncontrolled). */
+  onCommentsChange?: (comments: Comment[]) => void;
   /** Callback with the parsed document's editing compatibility report. */
   onCompatibilityChange?: (compatibility: DocxCompatibility) => void;
   /**

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -473,6 +473,8 @@ export function DocxEditor({
   onSlashMenuKeyAction,
   customContextMenuItems,
   onCustomContextAction,
+  comments: commentsProp,
+  onCommentsChange,
   collaboration,
   featureFlags,
   onSelectiveSaveTripwire,
@@ -891,6 +893,8 @@ export function DocxEditor({
     autoOpenReviewSidebar,
     anchorPositions,
     editorContentRef,
+    commentsProp,
+    onCommentsChange,
   });
   // Cache style resolver to avoid recreating on every selection change
   const styleResolverCacheRef = useRef<{

--- a/packages/react/src/components/useFolioComments.ts
+++ b/packages/react/src/components/useFolioComments.ts
@@ -28,6 +28,14 @@ type UseFolioCommentsOptions = {
   anchorPositions: Map<string, number>;
   /** Editor content root used to locate comment-marked run nodes. */
   editorContentRef: RefObject<HTMLElement | null>;
+  /**
+   * Controlled comments array. When provided, thread metadata is read from
+   * this prop and every mutation routes through `onCommentsChange` (e.g. Yjs
+   * comment sync in collaboration backends).
+   */
+  commentsProp?: Comment[] | undefined;
+  /** Fires whenever the comments array changes (controlled and uncontrolled). */
+  onCommentsChange?: ((comments: Comment[]) => void) | undefined;
 };
 
 export function useFolioComments({
@@ -35,14 +43,39 @@ export function useFolioComments({
   autoOpenReviewSidebar,
   anchorPositions,
   editorContentRef,
+  commentsProp,
+  onCommentsChange,
 }: UseFolioCommentsOptions) {
   const [showCommentsSidebar, setShowCommentsSidebar] = useState(false);
   const [visibleCommentAuthors, setVisibleCommentAuthors] = useState<Set<string> | null>(null);
   const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
-  const [comments, setComments] = useState<Comment[]>([]);
+  const [internalComments, setInternalComments] = useState<Comment[]>([]);
+  const isControlledComments = commentsProp !== undefined;
+  const comments = isControlledComments ? commentsProp : internalComments;
+
   const commentsDirtyRef = useRef(false);
-  const commentsRef = useRef<Comment[]>([]);
+  const commentsRef = useRef(comments);
   commentsRef.current = comments;
+  const onCommentsChangeRef = useRef(onCommentsChange);
+  onCommentsChangeRef.current = onCommentsChange;
+
+  const setComments = useCallback(
+    (next: Comment[] | ((prev: Comment[]) => Comment[])) => {
+      const resolved =
+        typeof next === "function"
+          ? (next as (prev: Comment[]) => Comment[])(commentsRef.current)
+          : next;
+      if (resolved === commentsRef.current) {
+        return;
+      }
+      if (!isControlledComments) {
+        commentsRef.current = resolved;
+        setInternalComments(resolved);
+      }
+      onCommentsChangeRef.current?.(resolved);
+    },
+    [isControlledComments],
+  );
 
   const [isAddingComment, setIsAddingComment] = useState(false);
   const [commentSelectionRange, setCommentSelectionRange] = useState<{
@@ -59,10 +92,10 @@ export function useFolioComments({
     to: number;
   } | null>(null);
 
-  // Extract comments from document model on initial load
+  // Extract comments from document model on initial load (uncontrolled only).
   const commentsLoadedRef = useRef(false);
   useEffect(() => {
-    if (commentsLoadedRef.current) {
+    if (isControlledComments || commentsLoadedRef.current) {
       return;
     }
     if (!doc) {
@@ -78,7 +111,7 @@ export function useFolioComments({
       }
       commentsLoadedRef.current = true;
     }
-  }, [autoOpenReviewSidebar, doc]);
+  }, [autoOpenReviewSidebar, doc, isControlledComments, setComments]);
 
   const commentAuthors = useMemo(() => {
     const seen = new Set<string>();
@@ -193,6 +226,7 @@ export function useFolioComments({
   return {
     comments,
     setComments,
+    isControlledComments,
     commentsRef,
     commentsDirtyRef,
     commentsLoadedRef,

--- a/packages/react/src/components/useFolioComments.ts
+++ b/packages/react/src/components/useFolioComments.ts
@@ -68,8 +68,8 @@ export function useFolioComments({
       if (resolved === commentsRef.current) {
         return;
       }
+      commentsRef.current = resolved;
       if (!isControlledComments) {
-        commentsRef.current = resolved;
         setInternalComments(resolved);
       }
       onCommentsChangeRef.current?.(resolved);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `comments` and `onCommentsChange` to `DocxEditor`, matching the upstream Eigenpal collaboration contract.

When `comments` is provided, the editor treats comment thread metadata as controlled state: it reads from the prop and routes every mutation through `onCommentsChange`. This pairs with the existing `collaboration` prop so Yjs backends can sync comment threads over a `Y.Array` while ProseMirror carries range markers in the document.

Uncontrolled behavior is unchanged: omit `comments` and the editor seeds threads from `comments.xml` on first load as before.

## Changes

- `useFolioComments` gains controlled/uncontrolled routing via `commentsProp` / `onCommentsChange`
- `DocxEditorProps` documents the new props
- Document seeding from parsed `comments.xml` is skipped in controlled mode
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

