### PR TITLE
feat: scrollToParaId on DocxEditorRef

### DIFF
--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -577,7 +577,8 @@ export type ParagraphAttrs = {
 // @public
 export type ParagraphBlock = {
     kind: "paragraph";
-    id: BlockId;
+    id: BlockId; /** Stable Word `w14:paraId` / PM `paraId`, when available. */
+    paraId?: string;
     runs: Run[];
     attrs?: ParagraphAttrs;
     bookmarks?: string[]; /** ProseMirror start position for this block. */

--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -119,6 +119,7 @@ import { ResolvedAnchor } from '@stll/folio-core/ai-suggestions/conflict';
 import { resolveSuggestionAnchor } from '@stll/folio-core/ai-suggestions/conflict';
 import { scanDirectives } from '@stll/folio-core/prosemirror/plugins/templateDirectives';
 import { scrollFolioPositionIntoView } from '@stll/folio-core/paged-layout/scrollToPmPosition';
+import { ScrollToParaIdOptions } from '@stll/folio-core/paged-layout/paragraphFlash';
 import { SdtProperties } from '@stll/folio-core/types/document';
 import { Select } from '@base-ui/react/select';
 import { SelectionState } from '@stll/folio-core/prosemirror';
@@ -381,7 +382,8 @@ export type DocxEditorRef = {
     focus: () => void; /** Get current page number */
     getCurrentPage: () => number; /** Get total page count */
     getTotalPages: () => number; /** Scroll to a specific page */
-    scrollToPage: (pageNumber: number) => void; /** Open print preview */
+    scrollToPage: (pageNumber: number) => void;
+    scrollToParaId: (paraId: string, options?: ScrollToParaIdOptions) => boolean; /** Open print preview */
     openPrintPreview: () => void; /** Print the document directly */
     print: () => void; /** Load a pre-parsed document programmatically */
     loadDocument: (doc: Document_2) => void; /** Load a DOCX buffer programmatically (ArrayBuffer, Uint8Array, Blob, or File) */
@@ -577,6 +579,8 @@ export { resolveSuggestionAnchor }
 export { scanDirectives }
 
 export { scrollFolioPositionIntoView }
+
+export { ScrollToParaIdOptions }
 
 export { setActiveCitationMeta }
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -17,6 +17,17 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(second).toEqual(first);
   });
 
+  test("carries stable PM paraId onto paragraph blocks", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: "1A2B3C4D" }, [schema.text("Locate me")]),
+    ]);
+    const para = toFlowBlocks(doc)[0];
+    expect(para?.kind).toBe("paragraph");
+    if (para?.kind === "paragraph") {
+      expect(para.paraId).toBe("1A2B3C4D");
+    }
+  });
+
   test("rejects malformed paragraph attrs at the layout boundary", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { lineSpacing: "240" }, [schema.text("Invalid paragraph")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1758,6 +1758,7 @@ function convertParagraph(
     id: nextBlockId(),
     runs,
     attrs,
+    ...(pmAttrs.paraId ? { paraId: pmAttrs.paraId } : {}),
     ...(bookmarkNames && bookmarkNames.length > 0 ? { bookmarks: bookmarkNames } : {}),
     pmStart: startPos,
     pmEnd: startPos + node.nodeSize,

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -450,6 +450,8 @@ export type ParagraphAttrs = {
 export type ParagraphBlock = {
   kind: "paragraph";
   id: BlockId;
+  /** Stable Word `w14:paraId` / PM `paraId`, when available. */
+  paraId?: string;
   runs: Run[];
   attrs?: ParagraphAttrs;
   /** Names of bookmarks anchored to this paragraph; used to map a bookmark to

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2101,6 +2101,9 @@ export function renderParagraphFragment(
 
   // Store block and fragment metadata
   fragmentEl.dataset["blockId"] = String(fragment.blockId);
+  if (block.paraId) {
+    fragmentEl.dataset["paraId"] = block.paraId;
+  }
   fragmentEl.dataset["fromLine"] = String(fragment.fromLine);
   fragmentEl.dataset["toLine"] = String(fragment.toLine);
 

--- a/packages/core/src/paged-layout/paragraphFlash.ts
+++ b/packages/core/src/paged-layout/paragraphFlash.ts
@@ -1,0 +1,97 @@
+/**
+ * DOM helpers for transient paragraph flashes on the painted layout surface.
+ */
+
+import type { ParagraphHighlightOptions } from "./paragraphFlashTypes";
+
+export type { ParagraphHighlightOptions, ScrollToParaIdOptions } from "./paragraphFlashTypes";
+
+/** Default color used by paragraph flashes. */
+export const DEFAULT_PARAGRAPH_FLASH_COLOR = "rgba(255, 235, 59, 0.55)";
+/** Default duration for paragraph flashes. */
+export const DEFAULT_PARAGRAPH_FLASH_DURATION_MS = 1200;
+/** CSS class applied to paragraph fragments during a transient flash. */
+export const PARAGRAPH_FLASH_CLASS_NAME = "folio-paragraph-flash";
+
+const timers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>();
+
+const escapeAttributeValue = (value: string): string => {
+  const cssGlobal = globalThis as typeof globalThis & {
+    CSS?: { escape?: (value: string) => string };
+  };
+  if (typeof cssGlobal.CSS?.escape === "function") {
+    return cssGlobal.CSS.escape(value);
+  }
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+};
+
+const normalizedColor = (options?: ParagraphHighlightOptions): string => {
+  const color = options?.color?.trim();
+  return color || DEFAULT_PARAGRAPH_FLASH_COLOR;
+};
+
+const normalizedDurationMs = (options?: ParagraphHighlightOptions): number => {
+  const duration = options?.durationMs;
+  if (duration == null) {
+    return DEFAULT_PARAGRAPH_FLASH_DURATION_MS;
+  }
+  if (!Number.isFinite(duration) || duration < 0) {
+    return DEFAULT_PARAGRAPH_FLASH_DURATION_MS;
+  }
+  return duration;
+};
+
+/** Find all painted paragraph fragments with a stable `data-para-id`. */
+export const findParagraphFragmentsByParaId = (
+  root: ParentNode,
+  paraId: string,
+): HTMLElement[] => {
+  if (!paraId || !paraId.trim()) {
+    return [];
+  }
+  const escaped = escapeAttributeValue(paraId);
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(`.layout-paragraph[data-para-id="${escaped}"]`),
+  );
+};
+
+/** Apply a transient flash to a collection of paragraph elements. */
+export const flashParagraphElements = (
+  elements: Iterable<HTMLElement>,
+  options?: ParagraphHighlightOptions,
+): number => {
+  let count = 0;
+  const color = normalizedColor(options);
+  const durationMs = normalizedDurationMs(options);
+
+  for (const el of elements) {
+    count++;
+    const existingTimer = timers.get(el);
+    if (existingTimer !== undefined) {
+      clearTimeout(existingTimer);
+    }
+
+    el.classList.remove(PARAGRAPH_FLASH_CLASS_NAME);
+    void el.offsetWidth;
+    el.style.setProperty("--folio-paragraph-flash-color", color);
+    el.style.setProperty("--folio-paragraph-flash-duration", `${durationMs}ms`);
+    el.classList.add(PARAGRAPH_FLASH_CLASS_NAME);
+
+    const timer = setTimeout(() => {
+      el.classList.remove(PARAGRAPH_FLASH_CLASS_NAME);
+      el.style.removeProperty("--folio-paragraph-flash-color");
+      el.style.removeProperty("--folio-paragraph-flash-duration");
+      timers.delete(el);
+    }, durationMs);
+    timers.set(el, timer);
+  }
+
+  return count;
+};
+
+/** Find paragraph fragments by `paraId` and flash them. */
+export const flashParagraphFragmentsByParaId = (
+  root: ParentNode,
+  paraId: string,
+  options?: ParagraphHighlightOptions,
+): boolean => flashParagraphElements(findParagraphFragmentsByParaId(root, paraId), options) > 0;

--- a/packages/core/src/paged-layout/paragraphFlashTypes.ts
+++ b/packages/core/src/paged-layout/paragraphFlashTypes.ts
@@ -1,0 +1,20 @@
+/**
+ * Option shapes for `scrollToParaId(paraId, { highlight })`.
+ *
+ * DOM-free so non-browser consumers can type-import without pulling in
+ * paragraph-flash DOM helpers.
+ */
+
+/** Customization for the transient paragraph flash applied by `scrollToParaId`. */
+export type ParagraphHighlightOptions = {
+  /** CSS color used for the transient paragraph flash. Defaults to yellow. */
+  color?: string;
+  /** How long the flash remains visible before it is removed. Defaults to 1200ms. */
+  durationMs?: number;
+};
+
+/** Optional reveal behavior for `scrollToParaId`. */
+export type ScrollToParaIdOptions = {
+  /** Flash rendered paragraph fragments after scrolling to the paragraph. */
+  highlight?: ParagraphHighlightOptions;
+};

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -27,6 +27,7 @@ import type {
 } from "@stll/folio-core/prosemirror/plugins/templateSlashMenu";
 import type { Document, SdtProperties, Theme, TabStop } from "@stll/folio-core/types/document";
 import type { DocxInput } from "@stll/folio-core/utils/docxInput";
+import type { ScrollToParaIdOptions } from "@stll/folio-core/paged-layout/paragraphFlash";
 import type { FontDefinition } from "../paged-editor/hostFonts";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
 import type { FolioUIComponents } from "../ui/folio-ui";
@@ -335,6 +336,11 @@ export type DocxEditorRef = {
   getTotalPages: () => number;
   /** Scroll to a specific page */
   scrollToPage: (pageNumber: number) => void;
+  /**
+   * Scroll the paginated view to the paragraph with the given Word `w14:paraId`.
+   * Pass `options.highlight` to briefly flash it in a custom color.
+   */
+  scrollToParaId: (paraId: string, options?: ScrollToParaIdOptions) => boolean;
   /** Open print preview */
   openPrintPreview: () => void;
   /** Print the document directly */

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -41,6 +41,7 @@ import { applyFolioAIEditOperations, createFolioAIEditSnapshot } from "@stll/fol
 import { normalizeBaseDirection } from "@stll/folio-core/docx/normalizeBaseDirection";
 import { getCachedNumberingMap } from "@stll/folio-core/docx/numberingParser";
 import { updateScrollPageTotal } from "@stll/folio-core/paged-layout/scrollPageInfo";
+import type { ScrollToParaIdOptions } from "@stll/folio-core/paged-layout/paragraphFlash";
 // ProseMirror editor
 import {
   TextSelection,
@@ -2791,6 +2792,8 @@ export function DocxEditor({
       scrollToPage: (pageNumber: number) => {
         pagedEditorRef.current?.scrollToPage(pageNumber);
       },
+      scrollToParaId: (paraId: string, options?: ScrollToParaIdOptions) =>
+        pagedEditorRef.current?.scrollToParaId(paraId, options) ?? false,
       openPrintPreview: handleDirectPrint,
       print: handleDirectPrint,
       loadDocument: loadParsedDocument,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,9 +1,6 @@
 export { DocxEditor } from "./components/DocxEditor";
-export type {
-  DocxEditorCollaboration,
-  DocxEditorProps,
-  DocxEditorRef,
-} from "./components/DocxEditor.props";
+export type { DocxEditorCollaboration, DocxEditorProps, DocxEditorRef } from "./components/DocxEditor.props";
+export type { ScrollToParaIdOptions } from "@stll/folio-core/paged-layout/paragraphFlash";
 export type { EditorMode } from "./components/hooks/useEditorMode";
 // Custom-font prop types: `fontFamilies` (picker list) + `fonts` (FontFace registration).
 export type { FontOption } from "./components/ui/FontPicker";

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -122,6 +122,10 @@ import {
   scrollPagesToPmPosition,
 } from "@stll/folio-core/paged-layout/scrollToPmPosition";
 import {
+  flashParagraphFragmentsByParaId,
+  type ScrollToParaIdOptions,
+} from "@stll/folio-core/paged-layout/paragraphFlash";
+import {
   DEFAULT_PAGE_HEIGHT_PX,
   getMargins,
   getPageSize,
@@ -132,6 +136,7 @@ import { tableInsertButtonOffset } from "@stll/folio-core/paged-layout/tableInse
 import { getTransactionDirtyRange } from "@stll/folio-core/paged-layout/transactionDirtyRange";
 // Table commands (for quick-action insert buttons)
 import { addRowBelow, addColumnRight } from "@stll/folio-core/prosemirror";
+import { findStartPosForParaId } from "@stll/folio-core/prosemirror/utils/findParagraphByParaId";
 import {
   expectFontFamilyMarkAttrs,
   expectImageAttrs,
@@ -373,6 +378,11 @@ export type PagedEditorRef = {
   scrollToPosition: (pmPos: number) => void;
   /** Scroll the visible pages to bring a page into view. */
   scrollToPage: (pageNumber: number) => void;
+  /**
+   * Scroll the paginated view to the paragraph with the given Word `w14:paraId`.
+   * Returns whether a matching paragraph exists in the ProseMirror document.
+   */
+  scrollToParaId: (paraId: string, options?: ScrollToParaIdOptions) => boolean;
   /** Resolve the page number (1-indexed) that contains the given PM position,
    *  or null if no layout is available yet. Works for unrendered pages too via
    *  the page shell map. */
@@ -3426,6 +3436,43 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
     [layout, scrollToPositionImpl],
   );
 
+  const scrollToParaIdImpl = useCallback(
+    (paraId: string, options?: ScrollToParaIdOptions): boolean => {
+      const state = hiddenPMRef.current?.getState();
+      if (!state) {
+        return false;
+      }
+      const startPos = findStartPosForParaId(state.doc, paraId);
+      if (startPos == null || startPos < 0) {
+        return false;
+      }
+      scrollToPositionImpl(startPos);
+      const flashPara = (): void => {
+        if (!options?.highlight) {
+          return;
+        }
+        const pages = pagesContainerRef.current;
+        if (!pages) {
+          return;
+        }
+        flashParagraphFragmentsByParaId(pages, paraId, options.highlight);
+      };
+      flashPara();
+      requestAnimationFrame(() => {
+        flashPara();
+        const targetNode = state.doc.nodeAt(startPos);
+        const inner =
+          targetNode?.isTextblock === true
+            ? Math.min(startPos + 1 + targetNode.content.size, state.doc.content.size)
+            : Math.min(startPos + 1, state.doc.content.size);
+        hiddenPMRef.current?.setSelection(inner);
+        hiddenPMRef.current?.focus();
+      });
+      return true;
+    },
+    [scrollToPositionImpl],
+  );
+
   const focusHiddenEditor = useCallback(() => {
     if (readOnly) {
       containerRef.current?.focus({ preventScroll: true });
@@ -5746,6 +5793,7 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       },
       scrollToPosition: scrollToPositionImpl,
       scrollToPage: scrollToPageImpl,
+      scrollToParaId: scrollToParaIdImpl,
       getPageNumberForPmPos(pmPos) {
         const container = pagesContainerRef.current;
         if (!container) {
@@ -5804,7 +5852,7 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
         return bestNumber;
       },
     }),
-    [ensureHiddenEditorView, folioEditor, scrollToPageImpl, scrollToPositionImpl],
+    [ensureHiddenEditorView, folioEditor, scrollToPageImpl, scrollToParaIdImpl, scrollToPositionImpl],
   );
 
   useEffect(() => {

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -3447,19 +3447,13 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
         return false;
       }
       scrollToPositionImpl(startPos);
-      const flashPara = (): void => {
-        if (!options?.highlight) {
-          return;
-        }
-        const pages = pagesContainerRef.current;
-        if (!pages) {
-          return;
-        }
-        flashParagraphFragmentsByParaId(pages, paraId, options.highlight);
-      };
-      flashPara();
       requestAnimationFrame(() => {
-        flashPara();
+        if (options?.highlight) {
+          const pages = pagesContainerRef.current;
+          if (pages) {
+            flashParagraphFragmentsByParaId(pages, paraId, options.highlight);
+          }
+        }
         const targetNode = state.doc.nodeAt(startPos);
         const inner =
           targetNode?.isTextblock === true

--- a/packages/react/src/styles/prosemirror-layer.css
+++ b/packages/react/src/styles/prosemirror-layer.css
@@ -620,6 +620,20 @@
   cursor: text;
 }
 
+.layout-paragraph.folio-paragraph-flash {
+  animation: folio-paragraph-flash-fade var(--folio-paragraph-flash-duration, 1200ms) ease-out
+    both;
+}
+
+@keyframes folio-paragraph-flash-fade {
+  from {
+    box-shadow: inset 0 0 0 9999px var(--folio-paragraph-flash-color, rgba(255, 235, 59, 0.55));
+  }
+  to {
+    box-shadow: inset 0 0 0 9999px transparent;
+  }
+}
+
 /* Header/footer areas — double-click hint */
 .layout-page-header,
 .layout-page-footer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `scrollToParaId(paraId, options?)` to `DocxEditorRef` and `PagedEditorRef` for navigation by Word `w14:paraId`.

## Changes

- `findStartPosForParaId` (existing) drives scroll; optional `highlight` flashes painted fragments
- `ParagraphBlock.paraId` is carried through `toFlowBlocks` and emitted as `data-para-id` on `.layout-paragraph`
- New `@stll/folio-core/paged-layout/paragraphFlash` helpers and CSS animation for the transient highlight
- `ScrollToParaIdOptions` exported from `@stll/folio-react`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

