### PR TITLE
feat: renderAsync imperative mount API

### DIFF
--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -291,6 +291,13 @@ export type DocxEditorCollaboration = {
     yXmlFragment: XmlFragment;
 };
 
+// @public
+export type DocxEditorHandle = EditorHandle & {
+    setZoom: (zoom: number) => void; /** Scroll the visible pages to a raw ProseMirror document position. */
+    scrollToPosition: (pmPos: number) => void; /** Scroll the visible pages to a 1-indexed page number. */
+    scrollToPage: (pageNumber: number) => void;
+};
+
 // @public (undocumented)
 export type DocxEditorProps = {
     documentBuffer?: DocxInput | null; /** Pre-parsed document (alternative to documentBuffer) */
@@ -423,6 +430,14 @@ export type DocxEditorRef = {
         keepContent?: boolean;
         force?: boolean;
     }) => boolean;
+};
+
+// @public
+export type EditorHandle = {
+    save: () => Promise<Blob | null>; /** Get the current parsed document model. */
+    getDocument: () => Document_2 | null; /** Focus the editor. */
+    focus: () => void; /** Unmount the editor and clean up. */
+    destroy: () => void;
 };
 
 export { EditorMode }
@@ -572,6 +587,14 @@ export type OutlineItem = {
 export function parseZoom(zoomString: string): number | null;
 
 export { PositionalText }
+
+// @public
+export const renderAsync: (input: DocxInput, container: HTMLElement, options?: RenderAsyncOptions) => Promise<DocxEditorHandle>;
+
+// @public
+export type RenderAsyncOptions = Omit<DocxEditorProps, "documentBuffer" | "document"> & {
+    locale?: string;
+};
 
 export { resetTemplateSlashQuery }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,10 @@
 export { DocxEditor } from "./components/DocxEditor";
+export {
+  renderAsync,
+  type DocxEditorHandle,
+  type EditorHandle,
+  type RenderAsyncOptions,
+} from "./renderAsync";
 export type { DocxEditorCollaboration, DocxEditorProps, DocxEditorRef } from "./components/DocxEditor.props";
 export type { ScrollToParaIdOptions } from "@stll/folio-core/paged-layout/paragraphFlash";
 export type { EditorMode } from "./components/hooks/useEditorMode";

--- a/packages/react/src/renderAsync.tsx
+++ b/packages/react/src/renderAsync.tsx
@@ -1,0 +1,142 @@
+/**
+ * Imperative API for mounting a DOCX editor into a DOM element.
+ *
+ * Returns a framework-agnostic {@link EditorHandle} extended with zoom and
+ * scroll helpers. Wraps the editor in `IntlProvider` so `use-intl` works
+ * without extra host setup.
+ *
+ * ```ts
+ * import { renderAsync } from "@stll/folio-react";
+ * import "@stll/folio-react/standalone.css";
+ *
+ * const editor = await renderAsync(buffer, document.getElementById("host")!, {
+ *   readOnly: false,
+ *   showToolbar: true,
+ * });
+ *
+ * const blob = await editor.save();
+ * editor.destroy();
+ * ```
+ */
+
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+
+import type { Document } from "@stll/folio-core/types/document";
+import type { DocxInput } from "@stll/folio-core/utils/docxInput";
+
+import { DocxEditor } from "./components/DocxEditor";
+import type { DocxEditorProps, DocxEditorRef } from "./components/DocxEditor.props";
+import { getFolioMessages } from "./i18n/messages";
+
+/** Framework-agnostic handle for an imperatively mounted editor instance. */
+export type EditorHandle = {
+  /** Save the document and return the DOCX as a Blob. */
+  save: () => Promise<Blob | null>;
+  /** Get the current parsed document model. */
+  getDocument: () => Document | null;
+  /** Focus the editor. */
+  focus: () => void;
+  /** Unmount the editor and clean up. */
+  destroy: () => void;
+};
+
+/** React-specific handle with zoom and scroll helpers. */
+export type DocxEditorHandle = EditorHandle & {
+  /** Set zoom level (1.0 = 100%). */
+  setZoom: (zoom: number) => void;
+  /** Scroll the visible pages to a raw ProseMirror document position. */
+  scrollToPosition: (pmPos: number) => void;
+  /** Scroll the visible pages to a 1-indexed page number. */
+  scrollToPage: (pageNumber: number) => void;
+};
+
+/** Options for {@link renderAsync}. */
+export type RenderAsyncOptions = Omit<DocxEditorProps, "documentBuffer" | "document"> & {
+  /** BCP-47 locale for bundled folio UI strings (default: `en`). */
+  locale?: string;
+};
+
+/**
+ * Render a DOCX editor into a container element.
+ *
+ * Resolves once the document has parsed and the first `onChange` fires.
+ * Rejects if `onError` runs before that milestone.
+ */
+export const renderAsync = (
+  input: DocxInput,
+  container: HTMLElement,
+  options: RenderAsyncOptions = {},
+): Promise<DocxEditorHandle> => {
+  const { locale = "en", ...editorOptions } = options;
+
+  return new Promise<DocxEditorHandle>((resolve, reject) => {
+    const ref = React.createRef<DocxEditorRef>();
+    let root: Root | null = null;
+
+    try {
+      root = createRoot(container);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const handle: DocxEditorHandle = {
+      save: async () => {
+        const buffer = await (ref.current?.save() ?? Promise.resolve(null));
+        if (!buffer) {
+          return null;
+        }
+        return new Blob([buffer], {
+          type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        });
+      },
+      getDocument: () => ref.current?.getDocument() ?? null,
+      focus: () => {
+        ref.current?.focus();
+      },
+      setZoom: (zoom) => {
+        ref.current?.setZoom(zoom);
+      },
+      scrollToPosition: (pmPos) => {
+        ref.current?.getEditorRef()?.scrollToPosition(pmPos);
+      },
+      scrollToPage: (pageNumber) => {
+        ref.current?.scrollToPage(pageNumber);
+      },
+      destroy: () => {
+        root?.unmount();
+        root = null;
+      },
+    };
+
+    let settled = false;
+
+    const element = (
+      <IntlProvider locale={locale} messages={getFolioMessages(locale)}>
+        <DocxEditor
+          {...editorOptions}
+          documentBuffer={input}
+          onError={(error) => {
+            editorOptions["onError"]?.(error);
+            if (!settled) {
+              settled = true;
+              reject(error);
+            }
+          }}
+          onChange={(doc) => {
+            editorOptions["onChange"]?.(doc);
+            if (!settled) {
+              settled = true;
+              resolve(handle);
+            }
+          }}
+          ref={ref}
+        />
+      </IntlProvider>
+    );
+
+    root.render(element);
+  });
+};

--- a/packages/react/src/renderAsync.tsx
+++ b/packages/react/src/renderAsync.tsx
@@ -74,6 +74,7 @@ export const renderAsync = (
   return new Promise<DocxEditorHandle>((resolve, reject) => {
     const ref = React.createRef<DocxEditorRef>();
     let root: Root | null = null;
+    let settled = false;
 
     try {
       root = createRoot(container);
@@ -106,12 +107,14 @@ export const renderAsync = (
         ref.current?.scrollToPage(pageNumber);
       },
       destroy: () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error("Editor was destroyed before mounting completed."));
+        }
         root?.unmount();
         root = null;
       },
     };
-
-    let settled = false;
 
     const element = (
       <IntlProvider locale={locale} messages={getFolioMessages(locale)}>
@@ -122,6 +125,8 @@ export const renderAsync = (
             editorOptions["onError"]?.(error);
             if (!settled) {
               settled = true;
+              root?.unmount();
+              root = null;
               reject(error);
             }
           }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `renderAsync()` for imperative embedding of the React editor in non-SPA hosts (scripts, legacy apps, quick demos).

## API

```ts
import { renderAsync } from "@stll/folio-react";
import "@stll/folio-react/standalone.css";

const editor = await renderAsync(buffer, container, { locale: "en" });
await editor.save();
editor.destroy();
```

## Details

- `EditorHandle`: `save`, `getDocument`, `focus`, `destroy`
- `DocxEditorHandle` extends with `setZoom`, `scrollToPosition`, `scrollToPage`
- Wraps `IntlProvider` with `getFolioMessages(locale)` so `use-intl` works without host setup
- Resolves on first successful `onChange` (document parsed); rejects on early `onError`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

