### PR TITLE
docs: Yjs collaboration playground demo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,9 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "use-intl": "^4.13.0",
+        "y-prosemirror": "^1.3.7",
+        "y-webrtc": "^10.3.0",
+        "yjs": "^13.6.31",
       },
       "devDependencies": {
         "@tailwindcss/vite": "4.3.1",
@@ -525,6 +528,8 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
@@ -562,6 +567,8 @@
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+
+    "err-code": ["err-code@3.0.1", "", {}, "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -601,6 +608,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-browser-rtc": ["get-browser-rtc@1.1.0", "", {}, "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -624,6 +633,8 @@
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "icu-minify": ["icu-minify@4.13.0", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "^3.4.0" } }, "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
@@ -789,6 +800,10 @@
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
@@ -818,6 +833,8 @@
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "simple-peer": ["simple-peer@9.11.1", "", { "dependencies": { "buffer": "^6.0.3", "debug": "^4.3.2", "err-code": "^3.0.1", "get-browser-rtc": "^1.1.0", "queue-microtask": "^1.2.3", "randombytes": "^2.1.0", "readable-stream": "^3.6.0" } }, "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -883,6 +900,8 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
@@ -892,6 +911,8 @@
     "y-prosemirror": ["y-prosemirror@1.3.7", "", { "dependencies": { "lib0": "^0.2.109" }, "peerDependencies": { "prosemirror-model": "^1.7.1", "prosemirror-state": "^1.2.3", "prosemirror-view": "^1.9.10", "y-protocols": "^1.0.1", "yjs": "^13.5.38" } }, "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg=="],
 
     "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
+
+    "y-webrtc": ["y-webrtc@10.3.0", "", { "dependencies": { "lib0": "^0.2.42", "simple-peer": "^9.11.0", "y-protocols": "^1.0.6" }, "optionalDependencies": { "ws": "^8.14.2" }, "peerDependencies": { "yjs": "^13.6.8" }, "bin": { "y-webrtc-signaling": "bin/server.js" } }, "sha512-KalJr7dCgUgyVFxoG3CQYbpS0O2qybegD0vI4bYnYHI0MOwoVbucED3RZ5f2o1a5HZb1qEssUKS0H/Upc6p1lA=="],
 
     "yjs": ["yjs@13.6.31", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw=="],
 
@@ -920,6 +941,8 @@
     "pizzip/pako": ["pako@2.2.0", "", {}, "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "simple-peer/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "tsdown/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,7 +15,10 @@
     "@stll/folio-react": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "use-intl": "^4.13.0"
+    "use-intl": "^4.13.0",
+    "y-prosemirror": "^1.3.7",
+    "y-webrtc": "^10.3.0",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.3.1",

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -13,6 +13,8 @@ import {
 import type { Document as FolioDocument, DocxEditorRef, EditorMode } from "@stll/folio-react";
 import { FOLIO_LOCALES, getFolioMessages } from "@stll/folio-react/messages";
 
+import { CollaborationApp } from "./CollaborationApp";
+
 const ZOOM_INITIAL = 1;
 const DEFAULT_LOCALE = "en";
 // Only Arabic in the bundled set needs RTL; flip the shell so the editor chrome
@@ -25,6 +27,9 @@ const languageLabel = (locale: string): string => {
   );
   return name ? `${name} (${locale})` : locale;
 };
+
+const isCollaborationDemo = (): boolean =>
+  new URLSearchParams(window.location.search).has("collaboration");
 
 declare global {
   // Test hook: visual + interaction specs read live editor state through this.
@@ -71,6 +76,10 @@ function createLargeDocument(paragraphCount: number): FolioDocument {
 }
 
 export function App() {
+  if (isCollaborationDemo()) {
+    return <CollaborationApp />;
+  }
+
   const editorRef = useRef<DocxEditorRef>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [currentDocument, setCurrentDocument] = useState<FolioDocument | null>(null);

--- a/packages/playground/src/CollaborationApp.tsx
+++ b/packages/playground/src/CollaborationApp.tsx
@@ -82,16 +82,20 @@ export function CollaborationApp() {
           </div>
         </header>
         <main className="pg-editor-area">
-          <DocxEditor
-            document={seedDocument}
-            author={user.name}
-            collaboration={collaboration}
-            comments={comments}
-            onCommentsChange={setComments}
-            showToolbar={true}
-            showRuler={true}
-            initialZoom={1}
-          />
+          {collaboration ? (
+            <DocxEditor
+              document={seedDocument}
+              author={user.name}
+              collaboration={collaboration}
+              comments={comments}
+              onCommentsChange={setComments}
+              showToolbar={true}
+              showRuler={true}
+              initialZoom={1}
+            />
+          ) : (
+            <div className="pg-collab-loading">Connecting...</div>
+          )}
         </main>
       </div>
     </IntlProvider>

--- a/packages/playground/src/CollaborationApp.tsx
+++ b/packages/playground/src/CollaborationApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { IntlProvider } from "use-intl";
 
 import { DocxEditor, createEmptyDocument } from "@stll/folio-react";
@@ -31,6 +31,22 @@ export function CollaborationApp() {
   const [user] = useState(loadOrCreateUser);
   const [room] = useState(getOrCreateRoomFromUrl);
   const [shareCopied, setShareCopied] = useState(false);
+  const shareCopiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!window.location.hash) {
+      window.history.replaceState(null, "", `#${room}`);
+    }
+  }, [room]);
+
+  useEffect(
+    () => () => {
+      if (shareCopiedTimeoutRef.current) {
+        clearTimeout(shareCopiedTimeoutRef.current);
+      }
+    },
+    [],
+  );
 
   const { collaboration, users, status, comments, setComments } = useCollaboration(room, user);
   const seedDocument = useMemo(() => createEmptyDocument(), []);
@@ -39,7 +55,10 @@ export function CollaborationApp() {
     try {
       await navigator.clipboard.writeText(window.location.href);
       setShareCopied(true);
-      setTimeout(() => setShareCopied(false), 1500);
+      if (shareCopiedTimeoutRef.current) {
+        clearTimeout(shareCopiedTimeoutRef.current);
+      }
+      shareCopiedTimeoutRef.current = setTimeout(() => setShareCopied(false), 1500);
     } catch {
       setShareCopied(false);
     }

--- a/packages/playground/src/CollaborationApp.tsx
+++ b/packages/playground/src/CollaborationApp.tsx
@@ -8,6 +8,19 @@ import { AvatarStack } from "./collaboration/AvatarStack";
 import { getOrCreateRoomFromUrl, loadOrCreateUser } from "./collaboration/identity";
 import { useCollaboration } from "./collaboration/useCollaboration";
 
+const collaborationStatusLabel = (
+  status: "connecting" | "connected" | "disconnected",
+  room: string,
+): string => {
+  if (status === "connected") {
+    return `Live · ${room}`;
+  }
+  if (status === "connecting") {
+    return "Connecting…";
+  }
+  return "Offline";
+};
+
 /**
  * Live Yjs + WebRTC collaboration demo.
  *
@@ -39,11 +52,7 @@ export function CollaborationApp() {
           <div className="pg-collab-header__left">
             <strong>folio collaboration demo</strong>
             <span className="pg-collab-status" data-status={status}>
-              {status === "connected"
-                ? `Live · ${room}`
-                : status === "connecting"
-                  ? "Connecting…"
-                  : "Offline"}
+              {collaborationStatusLabel(status, room)}
             </span>
           </div>
           <div className="pg-collab-header__right">

--- a/packages/playground/src/CollaborationApp.tsx
+++ b/packages/playground/src/CollaborationApp.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useMemo, useState } from "react";
+import { IntlProvider } from "use-intl";
+
+import { DocxEditor, createEmptyDocument } from "@stll/folio-react";
+import { getFolioMessages } from "@stll/folio-react/messages";
+
+import { AvatarStack } from "./collaboration/AvatarStack";
+import { getOrCreateRoomFromUrl, loadOrCreateUser } from "./collaboration/identity";
+import { useCollaboration } from "./collaboration/useCollaboration";
+
+/**
+ * Live Yjs + WebRTC collaboration demo.
+ *
+ * Open `/?collaboration=1` in two browser windows (or tabs) and share the
+ * URL hash (`#room-…`) to sync document body and comment threads.
+ */
+export function CollaborationApp() {
+  const [user] = useState(loadOrCreateUser);
+  const [room] = useState(getOrCreateRoomFromUrl);
+  const [shareCopied, setShareCopied] = useState(false);
+
+  const { collaboration, users, status, comments, setComments } = useCollaboration(room, user);
+  const seedDocument = useMemo(() => createEmptyDocument(), []);
+
+  const handleCopyShareLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setShareCopied(true);
+      setTimeout(() => setShareCopied(false), 1500);
+    } catch {
+      setShareCopied(false);
+    }
+  }, []);
+
+  return (
+    <IntlProvider locale="en" messages={getFolioMessages("en")}>
+      <div className="pg-shell pg-shell--collab">
+        <header className="pg-collab-header">
+          <div className="pg-collab-header__left">
+            <strong>folio collaboration demo</strong>
+            <span className="pg-collab-status" data-status={status}>
+              {status === "connected"
+                ? `Live · ${room}`
+                : status === "connecting"
+                  ? "Connecting…"
+                  : "Offline"}
+            </span>
+          </div>
+          <div className="pg-collab-header__right">
+            <AvatarStack users={users} />
+            <button type="button" className="pg-button" onClick={() => void handleCopyShareLink()}>
+              {shareCopied ? "Link copied!" : "Share link"}
+            </button>
+          </div>
+        </header>
+        <main className="pg-editor-area">
+          <DocxEditor
+            document={seedDocument}
+            author={user.name}
+            collaboration={collaboration}
+            comments={comments}
+            onCommentsChange={setComments}
+            showToolbar={true}
+            showRuler={true}
+            initialZoom={1}
+          />
+        </main>
+      </div>
+    </IntlProvider>
+  );
+}

--- a/packages/playground/src/collaboration/AvatarStack.tsx
+++ b/packages/playground/src/collaboration/AvatarStack.tsx
@@ -1,0 +1,44 @@
+import type { CollaborativeUser } from "./useCollaboration";
+
+type AvatarStackProps = {
+  users: CollaborativeUser[];
+  max?: number;
+};
+
+const initials = (name: string): string => {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2);
+  }
+  return (parts[0]![0]! + parts.at(-1)![0]!).slice(0, 2);
+};
+
+export function AvatarStack({ users, max = 5 }: AvatarStackProps) {
+  if (users.length === 0) {
+    return null;
+  }
+
+  const sorted = [...users].sort((a, b) => Number(b.isLocal) - Number(a.isLocal));
+  const visible = sorted.slice(0, max);
+  const overflow = sorted.length - visible.length;
+
+  return (
+    <div className="pg-avatar-stack" aria-label={`${users.length} active collaborator(s)`}>
+      {visible.map((user) => (
+        <div
+          key={user.clientId}
+          className="pg-avatar"
+          style={{ background: user.color }}
+          title={user.isLocal ? `${user.name} (you)` : user.name}
+        >
+          {initials(user.name)}
+        </div>
+      ))}
+      {overflow > 0 && (
+        <div className="pg-avatar pg-avatar--overflow" title={`${overflow} more`}>
+          +{overflow}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/playground/src/collaboration/README.md
+++ b/packages/playground/src/collaboration/README.md
@@ -1,0 +1,22 @@
+# Collaboration demo
+
+Open the playground with `?collaboration=1`:
+
+```text
+http://localhost:4200/?collaboration=1
+```
+
+## What it shows
+
+- **Yjs body sync** via folio's `collaboration` prop (`y-prosemirror` plugins)
+- **Comment thread sync** via controlled `comments` + `onCommentsChange` backed by a `Y.Array`
+- **WebRTC** peer discovery through public Yjs signaling servers (demo only)
+
+## Try it
+
+1. Start the playground: `bun --filter @stll/playground dev`
+2. Open `/?collaboration=1` in two browser windows
+3. Copy the share link (includes the `#room-…` hash) into the second window
+4. Type in one window; edits and comments should appear in the other
+
+Each tab gets a random display name persisted in `sessionStorage` for the session.

--- a/packages/playground/src/collaboration/identity.ts
+++ b/packages/playground/src/collaboration/identity.ts
@@ -1,0 +1,53 @@
+// Lightweight per-tab identity for the collaboration demo. Persisted to
+// sessionStorage so a refresh keeps the same user; a new tab gets a fresh
+// persona for side-by-side multi-user testing.
+
+const NAMES = ["Ada", "Grace", "Linus", "Hedy", "Margaret", "Tim", "Donald", "Barbara", "Alan", "Radia"];
+
+const COLORS = [
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#06b6d4",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+];
+
+export type CollabUser = {
+  name: string;
+  color: string;
+};
+
+const STORAGE_KEY = "folio-playground-collab-user";
+
+const pick = <T,>(arr: readonly T[]): T => arr[Math.floor(Math.random() * arr.length)]!;
+
+export const loadOrCreateUser = (): CollabUser => {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      return JSON.parse(raw) as CollabUser;
+    }
+  } catch {
+    // ignore corrupt storage
+  }
+  const user: CollabUser = { name: pick(NAMES), color: pick(COLORS) };
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+  } catch {
+    // ignore quota errors
+  }
+  return user;
+};
+
+export const getOrCreateRoomFromUrl = (): string => {
+  const hash = window.location.hash.replace(/^#/, "");
+  if (hash) {
+    return hash;
+  }
+  const room = `room-${Math.random().toString(36).slice(2, 10)}`;
+  window.history.replaceState(null, "", `#${room}`);
+  return room;
+};

--- a/packages/playground/src/collaboration/identity.ts
+++ b/packages/playground/src/collaboration/identity.ts
@@ -47,7 +47,5 @@ export const getOrCreateRoomFromUrl = (): string => {
   if (hash) {
     return hash;
   }
-  const room = `room-${Math.random().toString(36).slice(2, 10)}`;
-  window.history.replaceState(null, "", `#${room}`);
-  return room;
+  return `room-${Math.random().toString(36).slice(2, 10)}`;
 };

--- a/packages/playground/src/collaboration/useCollaboration.ts
+++ b/packages/playground/src/collaboration/useCollaboration.ts
@@ -14,7 +14,7 @@ export type CollaborativeUser = {
 };
 
 export type CollaborationState = {
-  collaboration: DocxEditorCollaboration;
+  collaboration: DocxEditorCollaboration | null;
   users: CollaborativeUser[];
   roomName: string;
   status: "connecting" | "connected" | "disconnected";
@@ -42,6 +42,8 @@ const createCollaborationResources = (roomName: string) => {
     yXmlFragment: xmlFragment,
   };
 };
+
+type CollaborationResources = ReturnType<typeof createCollaborationResources>;
 
 const syncYComments = (yComments: Y.Array<Comment>, next: Comment[]): void => {
   const nextIds = new Set(next.map((comment) => comment.id));
@@ -72,29 +74,48 @@ export const useCollaboration = (
   roomName: string,
   localUser: { name: string; color: string },
 ): CollaborationState => {
-  const [{ ydoc, provider, plugins, yComments, yXmlFragment }] = useState(() =>
-    createCollaborationResources(roomName),
-  );
-
+  const [resources, setResources] = useState<CollaborationResources | null>(null);
   const [users, setUsers] = useState<CollaborativeUser[]>([]);
   const [status, setStatus] = useState<CollaborationState["status"]>("connecting");
-  const [comments, setCommentsState] = useState<Comment[]>(() => yComments.toArray());
+  const [comments, setCommentsState] = useState<Comment[]>([]);
 
-  const collaboration = useMemo(
-    (): DocxEditorCollaboration => ({
-      yXmlFragment,
-      plugins,
-      awareness: provider.awareness,
+  const collaboration = useMemo((): DocxEditorCollaboration | null => {
+    if (!resources) {
+      return null;
+    }
+    return {
+      yXmlFragment: resources.yXmlFragment,
+      plugins: resources.plugins,
+      awareness: resources.provider.awareness,
       shouldSeed: true,
-    }),
-    [plugins, provider.awareness, yXmlFragment],
-  );
+    };
+  }, [resources]);
 
   useEffect(() => {
-    provider.awareness.setLocalStateField("user", localUser);
-  }, [localUser.color, localUser.name, provider]);
+    const nextResources = createCollaborationResources(roomName);
+    setResources(nextResources);
+    setStatus("connecting");
+    setUsers([]);
+    setCommentsState(nextResources.yComments.toArray());
+
+    return () => {
+      nextResources.provider.destroy();
+      nextResources.ydoc.destroy();
+    };
+  }, [roomName]);
 
   useEffect(() => {
+    resources?.provider.awareness.setLocalStateField("user", {
+      name: localUser.name,
+      color: localUser.color,
+    });
+  }, [localUser.color, localUser.name, resources]);
+
+  useEffect(() => {
+    if (!resources) {
+      return;
+    }
+    const { provider } = resources;
     const refreshUsers = () => {
       const localId = provider.awareness.clientID;
       const all: CollaborativeUser[] = [];
@@ -124,30 +145,29 @@ export const useCollaboration = (
       provider.awareness.off("change", refreshUsers);
       provider.off("status", handleStatus);
     };
-  }, [provider]);
+  }, [resources]);
 
   useEffect(() => {
+    if (!resources) {
+      return;
+    }
+    const { yComments } = resources;
     const sync = () => setCommentsState(yComments.toArray());
     sync();
     yComments.observeDeep(sync);
     return () => yComments.unobserveDeep(sync);
-  }, [yComments]);
+  }, [resources]);
 
   const setComments = useCallback(
     (next: Comment[]) => {
-      ydoc.transact(() => {
-        syncYComments(yComments, next);
+      if (!resources) {
+        return;
+      }
+      resources.ydoc.transact(() => {
+        syncYComments(resources.yComments, next);
       });
     },
-    [ydoc, yComments],
-  );
-
-  useEffect(
-    () => () => {
-      provider.destroy();
-      ydoc.destroy();
-    },
-    [provider, ydoc],
+    [resources],
   );
 
   return { collaboration, users, roomName, status, comments, setComments };

--- a/packages/playground/src/collaboration/useCollaboration.ts
+++ b/packages/playground/src/collaboration/useCollaboration.ts
@@ -24,22 +24,33 @@ export type CollaborationState = {
 
 const SIGNALING_SERVERS = ["wss://signaling.yjs.dev", "wss://y-webrtc-signaling-eu.herokuapp.com"];
 
+const createCollaborationResources = (roomName: string) => {
+  const doc = new Y.Doc();
+  const collabProvider = new WebrtcProvider(roomName, doc, { signaling: SIGNALING_SERVERS });
+  const xmlFragment = doc.getXmlFragment("prosemirror");
+  const collabPlugins = [
+    ySyncPlugin(xmlFragment),
+    yCursorPlugin(collabProvider.awareness),
+    yUndoPlugin(),
+  ];
+  const commentsArray = doc.getArray<Comment>("comments");
+  return {
+    ydoc: doc,
+    provider: collabProvider,
+    plugins: collabPlugins,
+    yComments: commentsArray,
+    yXmlFragment: xmlFragment,
+  };
+};
+
 export const useCollaboration = (
   roomName: string,
   localUser: { name: string; color: string },
 ): CollaborationState => {
-  const { ydoc, provider, plugins, yComments, yXmlFragment } = useMemo(() => {
-    const ydoc = new Y.Doc();
-    const provider = new WebrtcProvider(roomName, ydoc, { signaling: SIGNALING_SERVERS });
-    const yXmlFragment = ydoc.getXmlFragment("prosemirror");
-    const plugins = [
-      ySyncPlugin(yXmlFragment),
-      yCursorPlugin(provider.awareness),
-      yUndoPlugin(),
-    ];
-    const yComments = ydoc.getArray<Comment>("comments");
-    return { ydoc, provider, plugins, yComments, yXmlFragment };
-  }, [roomName]);
+  const { ydoc, provider, plugins, yComments, yXmlFragment } = useMemo(
+    () => createCollaborationResources(roomName),
+    [roomName],
+  );
 
   const [users, setUsers] = useState<CollaborativeUser[]>([]);
   const [status, setStatus] = useState<CollaborationState["status"]>("connecting");

--- a/packages/playground/src/collaboration/useCollaboration.ts
+++ b/packages/playground/src/collaboration/useCollaboration.ts
@@ -43,13 +43,37 @@ const createCollaborationResources = (roomName: string) => {
   };
 };
 
+const syncYComments = (yComments: Y.Array<Comment>, next: Comment[]): void => {
+  const nextIds = new Set(next.map((comment) => comment.id));
+
+  for (let i = yComments.length - 1; i >= 0; i--) {
+    if (!nextIds.has(yComments.get(i).id)) {
+      yComments.delete(i, 1);
+    }
+  }
+
+  const indexById = new Map(yComments.toArray().map((comment, index) => [comment.id, index]));
+
+  for (const comment of next) {
+    const index = indexById.get(comment.id);
+    if (index === undefined) {
+      yComments.push([comment]);
+      continue;
+    }
+    const existing = yComments.get(index);
+    if (JSON.stringify(existing) !== JSON.stringify(comment)) {
+      yComments.delete(index, 1);
+      yComments.insert(index, [comment]);
+    }
+  }
+};
+
 export const useCollaboration = (
   roomName: string,
   localUser: { name: string; color: string },
 ): CollaborationState => {
-  const { ydoc, provider, plugins, yComments, yXmlFragment } = useMemo(
-    () => createCollaborationResources(roomName),
-    [roomName],
+  const [{ ydoc, provider, plugins, yComments, yXmlFragment }] = useState(() =>
+    createCollaborationResources(roomName),
   );
 
   const [users, setUsers] = useState<CollaborativeUser[]>([]);
@@ -112,12 +136,7 @@ export const useCollaboration = (
   const setComments = useCallback(
     (next: Comment[]) => {
       ydoc.transact(() => {
-        if (yComments.length > 0) {
-          yComments.delete(0, yComments.length);
-        }
-        if (next.length > 0) {
-          yComments.push(next);
-        }
+        syncYComments(yComments, next);
       });
     },
     [ydoc, yComments],

--- a/packages/playground/src/collaboration/useCollaboration.ts
+++ b/packages/playground/src/collaboration/useCollaboration.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import * as Y from "yjs";
+import { WebrtcProvider } from "y-webrtc";
+import { yCursorPlugin, ySyncPlugin, yUndoPlugin } from "y-prosemirror";
+
+import type { Comment } from "@stll/folio-core/types/content";
+import type { DocxEditorCollaboration } from "@stll/folio-react";
+
+export type CollaborativeUser = {
+  clientId: number;
+  name: string;
+  color: string;
+  isLocal: boolean;
+};
+
+export type CollaborationState = {
+  collaboration: DocxEditorCollaboration;
+  users: CollaborativeUser[];
+  roomName: string;
+  status: "connecting" | "connected" | "disconnected";
+  comments: Comment[];
+  setComments: (next: Comment[]) => void;
+};
+
+const SIGNALING_SERVERS = ["wss://signaling.yjs.dev", "wss://y-webrtc-signaling-eu.herokuapp.com"];
+
+export const useCollaboration = (
+  roomName: string,
+  localUser: { name: string; color: string },
+): CollaborationState => {
+  const { ydoc, provider, plugins, yComments, yXmlFragment } = useMemo(() => {
+    const ydoc = new Y.Doc();
+    const provider = new WebrtcProvider(roomName, ydoc, { signaling: SIGNALING_SERVERS });
+    const yXmlFragment = ydoc.getXmlFragment("prosemirror");
+    const plugins = [
+      ySyncPlugin(yXmlFragment),
+      yCursorPlugin(provider.awareness),
+      yUndoPlugin(),
+    ];
+    const yComments = ydoc.getArray<Comment>("comments");
+    return { ydoc, provider, plugins, yComments, yXmlFragment };
+  }, [roomName]);
+
+  const [users, setUsers] = useState<CollaborativeUser[]>([]);
+  const [status, setStatus] = useState<CollaborationState["status"]>("connecting");
+  const [comments, setCommentsState] = useState<Comment[]>(() => yComments.toArray());
+
+  const collaboration = useMemo(
+    (): DocxEditorCollaboration => ({
+      yXmlFragment,
+      plugins,
+      awareness: provider.awareness,
+      shouldSeed: true,
+    }),
+    [plugins, provider.awareness, yXmlFragment],
+  );
+
+  useEffect(() => {
+    provider.awareness.setLocalStateField("user", localUser);
+  }, [localUser.color, localUser.name, provider]);
+
+  useEffect(() => {
+    const refreshUsers = () => {
+      const localId = provider.awareness.clientID;
+      const all: CollaborativeUser[] = [];
+      provider.awareness.getStates().forEach((state, clientId) => {
+        const user = (state as { user?: { name: string; color: string } }).user;
+        if (!user) {
+          return;
+        }
+        all.push({
+          clientId,
+          name: user.name,
+          color: user.color,
+          isLocal: clientId === localId,
+        });
+      });
+      setUsers(all);
+    };
+    const handleStatus = (event: { connected: boolean }) => {
+      setStatus(event.connected ? "connected" : "disconnected");
+    };
+
+    refreshUsers();
+    provider.awareness.on("change", refreshUsers);
+    provider.on("status", handleStatus);
+
+    return () => {
+      provider.awareness.off("change", refreshUsers);
+      provider.off("status", handleStatus);
+    };
+  }, [provider]);
+
+  useEffect(() => {
+    const sync = () => setCommentsState(yComments.toArray());
+    sync();
+    yComments.observeDeep(sync);
+    return () => yComments.unobserveDeep(sync);
+  }, [yComments]);
+
+  const setComments = useCallback(
+    (next: Comment[]) => {
+      ydoc.transact(() => {
+        if (yComments.length > 0) {
+          yComments.delete(0, yComments.length);
+        }
+        if (next.length > 0) {
+          yComments.push(next);
+        }
+      });
+    },
+    [ydoc, yComments],
+  );
+
+  useEffect(
+    () => () => {
+      provider.destroy();
+      ydoc.destroy();
+    },
+    [provider, ydoc],
+  );
+
+  return { collaboration, users, roomName, status, comments, setComments };
+};

--- a/packages/playground/src/styles.css
+++ b/packages/playground/src/styles.css
@@ -196,3 +196,60 @@
 .pg-visually-hidden {
   display: none;
 }
+
+.pg-shell--collab {
+  flex-direction: column;
+}
+
+.pg-collab-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.pg-collab-header__left,
+.pg-collab-header__right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pg-collab-status {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+}
+
+.pg-collab-status[data-status="connected"] {
+  color: var(--success-foreground);
+}
+
+.pg-avatar-stack {
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+}
+
+.pg-avatar {
+  width: 28px;
+  height: 28px;
+  margin-left: -10px;
+  border: 2px solid var(--background);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 12%);
+}
+
+.pg-avatar--overflow {
+  background: #cbd5e1;
+  color: #0f172a;
+}

--- a/packages/playground/src/styles.css
+++ b/packages/playground/src/styles.css
@@ -227,6 +227,13 @@
   color: var(--success-foreground);
 }
 
+.pg-collab-loading {
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  color: var(--muted-foreground);
+}
+
 .pg-avatar-stack {
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an end-to-end Yjs collaboration recipe to the playground at `/?collaboration=1`.

## Demo

```text
bun --filter @stll/playground dev
# open http://localhost:4200/?collaboration=1 in two windows; share the #room-… hash
```

## What it wires

- **Body sync**: folio `collaboration` prop with `y-prosemirror` (`ySyncPlugin`, `yCursorPlugin`, `yUndoPlugin`) over WebRTC
- **Comment sync**: controlled `comments` + `onCommentsChange` backed by a `Y.Array` on the same `Y.Doc`
- See `packages/playground/src/collaboration/README.md` for details

## Dependency

This branch includes the controlled-comments commit from #40 because the demo exercises `comments` / `onCommentsChange`. Merge #40 first, then rebase this branch onto `main` (or merge both together).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-598b4e72-7cf9-47ff-9eb3-a4086f9e1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

