### PR TITLE
fix(core): recurse into w:smartTag instead of dropping wrapped runs

### DIFF
--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -452,3 +452,24 @@ describe("parseParagraph complex field formatting (#909)", () => {
     expect(field.formatting?.fontSize).toBe(28);
   });
 });
+
+describe("parseParagraph smartTag wrapper", () => {
+  test("recurses into w:smartTag instead of dropping wrapped runs", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:smartTag w:uri="urn:schemas-microsoft-com:office:smarttags" w:element="City">
+          <w:r><w:t>SMARTTAG-CITY</w:t></w:r>
+        </w:smartTag>
+        <w:r><w:t xml:space="preserve">, STATE</w:t></w:r>
+      </w:p>
+    `);
+
+    const text = paragraph.content
+      .flatMap((item) => (item.type === "run" ? item.content : []))
+      .filter((part) => part.type === "text")
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("");
+    expect(text).toContain("SMARTTAG-CITY");
+    expect(text).toContain(", STATE");
+  });
+});

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseParagraph } from "./paragraphParser";
+import { getParagraphText, parseParagraph } from "./paragraphParser";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
 
@@ -464,11 +464,7 @@ describe("parseParagraph smartTag wrapper", () => {
       </w:p>
     `);
 
-    const text = paragraph.content
-      .flatMap((item) => (item.type === "run" ? item.content : []))
-      .filter((part) => part.type === "text")
-      .map((part) => (part.type === "text" ? part.text : ""))
-      .join("");
+    const text = getParagraphText(paragraph);
     expect(text).toContain("SMARTTAG-CITY");
     expect(text).toContain(", STATE");
   });

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1532,8 +1532,23 @@ function parseParagraphContents(
         break;
       }
 
-      case "smartTag":
+      case "smartTag": {
+        // w:smartTag is a transparent inline wrapper (legacy Word smart-tag
+        // recognizer markup). Its children are ordinary paragraph content;
+        // recurse so the wrapped runs are not dropped.
+        const inner = parseParagraphContents(
+          child,
+          styles,
+          theme,
+          null,
+          rels,
+          media,
+          trackedContext,
+          inScopeXmlns,
+        );
+        contents.push(...inner);
         break;
+      }
 
       case "moveFromRangeStart": {
         const id = Number.parseInt(getAttribute(child, "w", "id") ?? "0", 10);

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1536,6 +1536,7 @@ function parseParagraphContents(
         // w:smartTag is a transparent inline wrapper (legacy Word smart-tag
         // recognizer markup). Its children are ordinary paragraph content;
         // recurse so the wrapped runs are not dropped.
+        const smartTagInScopeXmlns = mergeXmlnsDeclarations(inScopeXmlns, child);
         const inner = parseParagraphContents(
           child,
           styles,
@@ -1544,7 +1545,7 @@ function parseParagraphContents(
           rels,
           media,
           trackedContext,
-          inScopeXmlns,
+          smartTagInScopeXmlns,
         );
         contents.push(...inner);
         break;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Legacy Word `w:smartTag` wrappers are transparent inline containers. The paragraph parser treated them as a no-op, which silently dropped any runs nested inside smart-tag markup on import.

## Changes

- Recurse into `w:smartTag` children via `parseParagraphContents`, same as other inline wrappers.
- Add a regression test asserting smart-tag-wrapped text survives parsing.

## Testing

- `bun test packages/core/src/docx/paragraphParser.test.ts`
- `bun run lint`
- `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

