### PR TITLE
fix(core): normalize percent-suffixed pct table widths

### DIFF
--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -66,6 +66,7 @@ import {
   getLocalName,
   parseBooleanElement,
   parseNumericAttribute,
+  parseTableMeasurementValue,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
@@ -787,9 +788,9 @@ function parseTableMeasurement(element: XmlElement | null): TableMeasurement | u
     return undefined;
   }
 
-  const w = parseNumericAttribute(element, "w", "w");
   const rawType = getAttribute(element, "w", "type");
   const type = rawType === null ? "dxa" : narrowEnum(rawType, TableWidthTypeSchema);
+  const w = type ? parseTableMeasurementValue(element, type) : undefined;
 
   if (w !== undefined && type) {
     return { value: w, type };

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseTable } from "./tableParser";
+import { parseTable, parseTableMeasurement } from "./tableParser";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
 
@@ -13,6 +13,22 @@ function parseTableXml(xml: string) {
 }
 
 const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+describe("parseTableMeasurement", () => {
+  const tblW = (w: string, type = "pct") => {
+    const root = parseXmlDocument(`<w:tblW ${NS} w:w="${w}" w:type="${type}"/>`) as XmlElement;
+    return parseTableMeasurement(root);
+  };
+
+  test("normalizes percent-suffixed pct widths to 50ths-of-percent", () => {
+    expect(tblW("100%")).toEqual({ value: 5000, type: "pct" });
+    expect(tblW("50%")).toEqual({ value: 2500, type: "pct" });
+  });
+
+  test("keeps canonical pct integers unchanged", () => {
+    expect(tblW("5000")).toEqual({ value: 5000, type: "pct" });
+  });
+});
 
 describe("inferImplicitSingleCellRowSpans", () => {
   test("does not expand a vMerge continuation single-cell row", () => {
@@ -186,5 +202,17 @@ describe("table bookmark placement", () => {
       type: "bookmarkEnd",
       id: 2,
     });
+  });
+});
+
+describe("parseTable pct width", () => {
+  test("parses a full-width pct table from a percent-suffixed tblW", () => {
+    const table = parseTableXml(`<w:tbl ${NS}>
+      <w:tblPr><w:tblW w:w="100%" w:type="pct"/></w:tblPr>
+      <w:tblGrid><w:gridCol w:w="5000" w:type="pct"/></w:tblGrid>
+      <w:tr><w:tc><w:tcPr><w:tcW w:w="5000" w:type="pct"/></w:tcPr><w:p/></w:tc></w:tr>
+    </w:tbl>`);
+
+    expect(table.formatting?.width).toEqual({ value: 5000, type: "pct" });
   });
 });

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -23,6 +23,7 @@ describe("parseTableMeasurement", () => {
   test("normalizes percent-suffixed pct widths to 50ths-of-percent", () => {
     expect(tblW("100%")).toEqual({ value: 5000, type: "pct" });
     expect(tblW("50%")).toEqual({ value: 2500, type: "pct" });
+    expect(tblW(" 100% ")).toEqual({ value: 5000, type: "pct" });
   });
 
   test("keeps canonical pct integers unchanged", () => {

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -76,6 +76,7 @@ import {
   getChildElements,
   mergeXmlnsDeclarations,
   parseNumericAttribute,
+  parseTableMeasurementValue,
   parseBooleanElement,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -95,13 +96,14 @@ export function parseTableMeasurement(element: XmlElement | null): TableMeasurem
     return undefined;
   }
 
-  const value = parseNumericAttribute(element, "w", "w") ?? 0;
   const typeStr = getAttribute(element, "w", "type") ?? "dxa";
 
   let type: TableWidthType = "dxa";
   if (typeStr === "auto" || typeStr === "dxa" || typeStr === "nil" || typeStr === "pct") {
     type = typeStr;
   }
+
+  const value = parseTableMeasurementValue(element, type) ?? 0;
 
   return { value, type };
 }

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -718,14 +718,16 @@ export function parseTableMeasurementValue(
     return undefined;
   }
 
-  if (widthType === "pct" && raw.endsWith("%")) {
-    const pct = Number.parseFloat(raw.slice(0, -1));
+  const trimmed = raw.trim();
+
+  if (widthType === "pct" && trimmed.endsWith("%")) {
+    const pct = Number.parseFloat(trimmed.slice(0, -1));
     if (!Number.isNaN(pct)) {
       return Math.round(pct * 50);
     }
   }
 
-  const num = Number.parseInt(raw, 10);
+  const num = Number.parseInt(trimmed, 10);
   return Number.isNaN(num) ? undefined : num;
 }
 

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -705,6 +705,31 @@ export function parseNumericAttribute(
 }
 
 /**
+ * Parse `w:w` on a table width/height element. For `w:type="pct"`, producers
+ * sometimes emit human-readable percentages (`100%`) instead of 50ths-of-percent
+ * (`5000`); normalize those to the ECMA-376 unit the layout engine expects.
+ */
+export function parseTableMeasurementValue(
+  element: XmlElement | null | undefined,
+  widthType: string,
+): number | undefined {
+  const raw = getAttribute(element, "w", "w");
+  if (raw === null) {
+    return undefined;
+  }
+
+  if (widthType === "pct" && raw.endsWith("%")) {
+    const pct = Number.parseFloat(raw.slice(0, -1));
+    if (!Number.isNaN(pct)) {
+      return Math.round(pct * 50);
+    }
+  }
+
+  const num = Number.parseInt(raw, 10);
+  return Number.isNaN(num) ? undefined : num;
+}
+
+/**
  * Parse a boolean value from an attribute or element presence
  *
  * OOXML boolean conventions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Normalize `w:w="NN%"` values on `w:type="pct"` table measurements to ECMA-376 50ths-of-percent integers (`100%` → `5000`).
- Apply the same parsing in both `tableParser` and `styleParser` via a shared `parseTableMeasurementValue` helper.

## Test plan

- [x] `bun test packages/core/src/docx/tableParser.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

