### PR TITLE
fix(core): CJK line break opportunities in paragraph measurer

### DIFF
--- a/packages/core/src/layout-engine/measure/__tests__/fakeTextMeasure.ts
+++ b/packages/core/src/layout-engine/measure/__tests__/fakeTextMeasure.ts
@@ -1,6 +1,6 @@
 import { clearAllCaches } from "../cache";
 import { installCanvasMeasureProvider, resetCanvasContext } from "../measureContainer";
-import { resetMeasureProvider } from "../measureProvider";
+import { getMeasureProvider, setMeasureProvider } from "../measureProvider";
 
 /** Width contribution of a single character, given the active canvas font. */
 export type FakeCharWidth = (char: string, font: string) => number;
@@ -45,6 +45,7 @@ export function withFakeTextMeasure(
 ): void {
   const charWidth = options.charWidth ?? uppercaseAwareCharWidth;
   const originalDocument = globalThis.document;
+  const originalMeasureProvider = getMeasureProvider();
   let measureCount = 0;
   const fakeDocument = {
     createElement() {
@@ -80,7 +81,7 @@ export function withFakeTextMeasure(
   try {
     runTest(() => measureCount);
   } finally {
-    resetMeasureProvider();
+    setMeasureProvider(originalMeasureProvider);
     resetCanvasContext();
     clearAllCaches();
     Object.defineProperty(globalThis, "document", {

--- a/packages/core/src/layout-engine/measure/__tests__/fakeTextMeasure.ts
+++ b/packages/core/src/layout-engine/measure/__tests__/fakeTextMeasure.ts
@@ -1,5 +1,6 @@
 import { clearAllCaches } from "../cache";
-import { resetCanvasContext } from "../measureContainer";
+import { installCanvasMeasureProvider, resetCanvasContext } from "../measureContainer";
+import { resetMeasureProvider } from "../measureProvider";
 
 /** Width contribution of a single character, given the active canvas font. */
 export type FakeCharWidth = (char: string, font: string) => number;
@@ -75,9 +76,11 @@ export function withFakeTextMeasure(
   });
   clearAllCaches();
   resetCanvasContext();
+  installCanvasMeasureProvider();
   try {
     runTest(() => measureCount);
   } finally {
+    resetMeasureProvider();
     resetCanvasContext();
     clearAllCaches();
     Object.defineProperty(globalThis, "document", {

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { findWordBreaks } from "./lineBreaks";
+
+describe("findWordBreaks", () => {
+  test("breaks after spaces and hyphens in Latin text", () => {
+    expect(findWordBreaks("hello world")).toEqual([6]);
+    expect(findWordBreaks("well-known")).toEqual([5]);
+  });
+
+  test("adds a break after every CJK code point", () => {
+    expect(findWordBreaks("日本語")).toEqual([1, 2, 3]);
+    expect(findWordBreaks("A世")).toEqual([2]);
+  });
+
+  test("handles astral CJK ideographs as single break units", () => {
+    const text = "𠀀文";
+    const breaks = findWordBreaks(text);
+    expect(breaks).toEqual([2, 3]);
+  });
+});

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { findWordBreaks } from "./lineBreaks";
+import { findWordBreaks, isBreakChar } from "./lineBreaks";
 
 describe("findWordBreaks", () => {
   test("breaks after spaces and hyphens in Latin text", () => {
@@ -17,5 +17,13 @@ describe("findWordBreaks", () => {
     const text = "𠀀文";
     const breaks = findWordBreaks(text);
     expect(breaks).toEqual([2, 3]);
+  });
+});
+
+describe("isBreakChar", () => {
+  test("treats CJK code points and low surrogates as break chars", () => {
+    expect(isBreakChar("世")).toBe(true);
+    expect(isBreakChar("A")).toBe(false);
+    expect(isBreakChar("\uDC00")).toBe(true);
   });
 });

--- a/packages/core/src/layout-engine/measure/lineBreaks.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.ts
@@ -29,5 +29,20 @@ export function findWordBreaks(text: string): number[] {
 }
 
 export function isBreakChar(char: string | undefined): boolean {
-  return char === " " || char === "-" || char === "\t";
+  if (char === undefined) {
+    return false;
+  }
+  if (char === " " || char === "-" || char === "\t") {
+    return true;
+  }
+  const codePoint = char.codePointAt(0);
+  if (codePoint === undefined) {
+    return false;
+  }
+  // Astral CJK ends on a low surrogate; treat it as a break so run glue does
+  // not span ideograph boundaries.
+  if (char >= "\uDC00" && char <= "\uDFFF") {
+    return true;
+  }
+  return isCjkCodePoint(codePoint);
 }

--- a/packages/core/src/layout-engine/measure/lineBreaks.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.ts
@@ -1,0 +1,33 @@
+import { isCjkCodePoint } from "../../utils/scriptSegments";
+
+/**
+ * Indices in `text` where a line may end. Latin text breaks after
+ * whitespace or hyphen; CJK text can break after every ideograph so a
+ * partial line is filled instead of pushing the whole run to the next line.
+ */
+export function findWordBreaks(text: string): number[] {
+  const breaks: number[] = [];
+
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) {
+      break;
+    }
+    const charLength = codePoint > 0xffff ? 2 : 1;
+    const char = text[index];
+
+    if (char === " " || char === "-" || char === "\t") {
+      breaks.push(index + charLength);
+    } else if (isCjkCodePoint(codePoint)) {
+      breaks.push(index + charLength);
+    }
+
+    index += charLength;
+  }
+
+  return breaks;
+}
+
+export function isBreakChar(char: string | undefined): boolean {
+  return char === " " || char === "-" || char === "\t";
+}

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -954,6 +954,29 @@ describe("CJK line breaking", () => {
       expect(measure.lines[1]?.toChar).toBe(4);
     }, { charWidth: fixedCharWidth(10) });
   });
+
+  test("does not wrap preceding Latin text when the next CJK character does not fit", () => {
+    withFakeTextMeasure(() => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: "cjk-wrap-boundary",
+        pmStart: 0,
+        pmEnd: 8,
+        runs: [
+          { kind: "text", text: "AAAA" },
+          { kind: "text", text: "一二三四", eastAsiaFontFamily: "MS Mincho" },
+        ],
+      };
+
+      const measure = measureParagraph(block, 45);
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines[0]?.toRun).toBe(0);
+      expect(measure.lines[0]?.toChar).toBe(4);
+      expect(measure.lines[1]?.fromRun).toBe(1);
+      expect(measure.lines[1]?.fromChar).toBe(0);
+    }, { charWidth: fixedCharWidth(10) });
+  });
 });
 
 describe("clampFloatingWrapMargins", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ParagraphBlock, Run } from "../types";
-import { smallCapsAwareCharWidth, withFakeTextMeasure } from "./__tests__/fakeTextMeasure";
+import { smallCapsAwareCharWidth, withFakeTextMeasure, fixedCharWidth } from "./__tests__/fakeTextMeasure";
 import { hashParagraphBlock } from "./cache";
 import { buildFontString } from "./measureHelpers";
 import { clampFloatingWrapMargins, getRunCharWidths, measureParagraph } from "./measureParagraph";
@@ -927,6 +927,32 @@ describe("all-caps paragraph measurement", () => {
     });
 
     expect(minchoHash).not.toBe(gothicHash);
+  });
+});
+
+describe("CJK line breaking", () => {
+  test("fills the remaining width on a line before wrapping CJK characters", () => {
+    withFakeTextMeasure(() => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: "cjk-wrap",
+        pmStart: 0,
+        pmEnd: 8,
+        runs: [
+          { kind: "text", text: "AAAA" },
+          { kind: "text", text: "一二三四", eastAsiaFontFamily: "MS Mincho" },
+        ],
+      };
+
+      const measure = measureParagraph(block, 50);
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines[0]?.toRun).toBe(1);
+      expect(measure.lines[0]?.toChar).toBe(1);
+      expect(measure.lines[1]?.fromRun).toBe(1);
+      expect(measure.lines[1]?.fromChar).toBe(1);
+      expect(measure.lines[1]?.toChar).toBe(4);
+    }, { charWidth: fixedCharWidth(10) });
   });
 });
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -34,6 +34,7 @@ import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import { buildRunFontStyle, ptToPx } from "./measureHelpers";
 import { getFontMetrics, measureRun, measureTextWidth } from "./measureProvider";
 import type { FontMetrics, FontStyle } from "./measureTypes";
+import { findWordBreaks, isBreakChar } from "./lineBreaks";
 
 export { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
 export type { FloatingImageZone } from "./floatingZones";
@@ -432,28 +433,6 @@ function measureDecimalPrefixWidthAfterTab(
     return 0;
   }
   return measureTextWidth(text.slice(0, decimalIndex), runToFontStyle(firstRun));
-}
-
-/**
- * Find word break points in text
- * Returns array of indices where words end (after space/punctuation)
- */
-function findWordBreaks(text: string): number[] {
-  const breaks: number[] = [];
-
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i];
-    // Break after space or certain punctuation
-    if (char === " " || char === "-" || char === "\t") {
-      breaks.push(i + 1);
-    }
-  }
-
-  return breaks;
-}
-
-function isBreakChar(char: string | undefined): boolean {
-  return char === " " || char === "-" || char === "\t";
 }
 
 function isSpaceOrTab(char: string | undefined): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extract `findWordBreaks` into `lineBreaks.ts`.
- Treat each CJK code point as a wrap boundary so the measurer fills remaining line width before pushing an entire CJK run to the next line.

## Test plan

- [x] `bun test packages/core/src/layout-engine/measure/lineBreaks.test.ts`
- [x] `bun test packages/core/src/layout-engine/measure/measureParagraph.test.ts -t "CJK"`
- [x] `bun run lint`
- [x] `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

