### PR TITLE
fix(core): cull off-page header/footer floats from visual bounds

### DIFF
--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -284,6 +284,35 @@ describe("calculateHeaderFooterVisualBounds", () => {
 
     expect(bounds).toEqual({ visualTop: 0, visualBottom: 12 });
   });
+
+  test("ignores floating images whose top touches the page bottom edge", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "edge",
+        runs: [
+          {
+            kind: "image",
+            src: "edge.png",
+            width: 100,
+            height: 80,
+            position: {
+              vertical: { relativeTo: "page", posOffset: 7_620_000 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: 0, visualBottom: 12 });
+  });
 });
 
 describe("calculateHeaderFooterMarginPushBounds", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -218,6 +218,39 @@ describe("calculateHeaderFooterVisualBounds", () => {
     // image bottom = top + 1117 = 1016.
     expect(bounds).toEqual({ visualTop: -101, visualBottom: 1016 });
   });
+
+  test("ignores floating images positioned entirely below the page", () => {
+    const footerMetrics: HeaderFooterMetrics = {
+      ...metrics,
+      section: "footer",
+    };
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "footer",
+        runs: [
+          {
+            kind: "image",
+            src: "off-page.png",
+            width: 100,
+            height: 80,
+            position: {
+              vertical: { relativeTo: "page", posOffset: 8_000_000 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      footerMetrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: 0, visualBottom: 12 });
+  });
 });
 
 describe("calculateHeaderFooterMarginPushBounds", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -181,6 +181,39 @@ describe("calculateHeaderFooterVisualBounds", () => {
     expect(bounds).toEqual({ visualTop: 0, visualBottom: 1100 });
   });
 
+  test("uses page-anchored vertical position for floating text box visual bounds", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "textBox",
+        id: "letterhead-box",
+        width: 560,
+        height: 200,
+        displayMode: "float",
+        position: {
+          vertical: { relativeTo: "margin", posOffset: -1_460_500 },
+        },
+        content: [],
+      },
+      {
+        kind: "paragraph",
+        id: "title",
+        runs: [{ kind: "text", text: "Header" }],
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [
+        { kind: "textBox", width: 560, height: 200, innerMeasures: [] },
+        { kind: "paragraph", lines: [], totalHeight: 12 },
+      ],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: -101, visualBottom: 99 });
+  });
+
   test("includes behindDoc images in visualBottom (render+hash signal)", () => {
     // Full-page letterhead: anchored to "margin", posOffset -1460500 EMU
     // (≈ -153px) places the image just above the body margin and its 1117px

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -284,6 +284,31 @@ export function resolveHeaderFooterVisualTop(
   return paragraphY;
 }
 
+function pageBandInHeaderFooterCoords(
+  metrics: HeaderFooterMetrics,
+  flowHeight: number,
+): { top: number; bottom: number } {
+  const flowTop =
+    metrics.section === "header"
+      ? (metrics.margins.header ?? 48)
+      : metrics.pageSize.h - (metrics.margins.footer ?? 48) - flowHeight;
+  return {
+    top: -flowTop,
+    bottom: metrics.pageSize.h - flowTop,
+  };
+}
+
+/** True when a float's box overlaps the page band in header/footer coordinates. */
+function floatIntersectsPageBand(
+  blockTop: number,
+  blockBottom: number,
+  metrics: HeaderFooterMetrics,
+  flowHeight: number,
+): boolean {
+  const band = pageBandInHeaderFooterCoords(metrics, flowHeight);
+  return blockBottom > band.top && blockTop <= band.bottom;
+}
+
 function resolveHeaderFooterFloatingTableVisualTop(
   floating: FloatingTablePosition,
   measure: TableMeasure,
@@ -370,8 +395,12 @@ export function calculateHeaderFooterVisualBounds(
           continue;
         }
         const runTop = resolveHeaderFooterVisualTop(run, paragraphStartY, flowHeight, metrics);
+        const runBottom = runTop + run.height;
+        if (!floatIntersectsPageBand(runTop, runBottom, metrics, flowHeight)) {
+          continue;
+        }
         visualTop = Math.min(visualTop, runTop);
-        visualBottom = Math.max(visualBottom, runTop + run.height);
+        visualBottom = Math.max(visualBottom, runBottom);
       }
 
       cursorY = paragraphBottomY;
@@ -412,15 +441,22 @@ export function calculateHeaderFooterVisualBounds(
           flowHeight,
           metrics,
         );
-        visualTop = Math.min(visualTop, blockTop);
-        visualBottom = Math.max(visualBottom, blockTop + blockHeight);
+        const blockBottom = blockTop + blockHeight;
+        if (floatIntersectsPageBand(blockTop, blockBottom, metrics, flowHeight)) {
+          visualTop = Math.min(visualTop, blockTop);
+          visualBottom = Math.max(visualBottom, blockBottom);
+        }
       } else if (
         block.kind === "textBox" &&
         isPositionedHeaderFooterTextBoxBlock(block) &&
         measure.kind === "textBox"
       ) {
-        visualTop = Math.min(visualTop, cursorY);
-        visualBottom = Math.max(visualBottom, cursorY + measure.height);
+        const blockTop = cursorY;
+        const blockBottom = blockTop + measure.height;
+        if (floatIntersectsPageBand(blockTop, blockBottom, metrics, flowHeight)) {
+          visualTop = Math.min(visualTop, blockTop);
+          visualBottom = Math.max(visualBottom, blockBottom);
+        }
       }
     }
   }

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -24,6 +24,7 @@ import type {
   FloatingTablePosition,
   HeaderFooterContent,
   ImageRun,
+  ImageRunPosition,
   Measure,
   PageMargins,
   Run,
@@ -226,9 +227,10 @@ function getPositionAlignment(axis: PositionedAxis | undefined): string | undefi
   return axis?.align ?? axis?.alignment;
 }
 
-export function resolveHeaderFooterVisualTop(
-  run: ImageRun,
-  paragraphY: number,
+export function resolveHeaderFooterPositionedVisualTop(
+  position: ImageRunPosition | undefined,
+  elementHeight: number,
+  sourceY: number,
   flowHeight: number,
   metrics: HeaderFooterMetrics,
 ): number {
@@ -236,10 +238,10 @@ export function resolveHeaderFooterVisualTop(
     metrics.section === "header"
       ? (metrics.margins.header ?? 48)
       : metrics.pageSize.h - (metrics.margins.footer ?? 48) - flowHeight;
-  const vertical = run.position?.vertical;
+  const vertical = position?.vertical;
 
   if (!vertical) {
-    return paragraphY;
+    return sourceY;
   }
 
   const align = getPositionAlignment(vertical);
@@ -253,10 +255,10 @@ export function resolveHeaderFooterVisualTop(
       return -flowTop;
     }
     if (align === "bottom") {
-      return metrics.pageSize.h - run.height - flowTop;
+      return metrics.pageSize.h - elementHeight - flowTop;
     }
     if (align === "center") {
-      return (metrics.pageSize.h - run.height) / 2 - flowTop;
+      return (metrics.pageSize.h - elementHeight) / 2 - flowTop;
     }
   }
 
@@ -270,18 +272,33 @@ export function resolveHeaderFooterVisualTop(
       return marginTop - flowTop;
     }
     if (align === "bottom") {
-      return marginTop + marginHeight - run.height - flowTop;
+      return marginTop + marginHeight - elementHeight - flowTop;
     }
     if (align === "center") {
-      return marginTop + (marginHeight - run.height) / 2 - flowTop;
+      return marginTop + (marginHeight - elementHeight) / 2 - flowTop;
     }
   }
 
   if (offsetPx !== undefined) {
-    return paragraphY + offsetPx;
+    return sourceY + offsetPx;
   }
 
-  return paragraphY;
+  return sourceY;
+}
+
+export function resolveHeaderFooterVisualTop(
+  run: ImageRun,
+  paragraphY: number,
+  flowHeight: number,
+  metrics: HeaderFooterMetrics,
+): number {
+  return resolveHeaderFooterPositionedVisualTop(
+    run.position,
+    run.height,
+    paragraphY,
+    flowHeight,
+    metrics,
+  );
 }
 
 function pageBandInHeaderFooterCoords(
@@ -451,7 +468,13 @@ export function calculateHeaderFooterVisualBounds(
         isPositionedHeaderFooterTextBoxBlock(block) &&
         measure.kind === "textBox"
       ) {
-        const blockTop = cursorY;
+        const blockTop = resolveHeaderFooterPositionedVisualTop(
+          block.position,
+          measure.height,
+          cursorY,
+          flowHeight,
+          metrics,
+        );
         const blockBottom = blockTop + measure.height;
         if (floatIntersectsPageBand(blockTop, blockBottom, metrics, flowHeight)) {
           visualTop = Math.min(visualTop, blockTop);

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -323,7 +323,7 @@ function floatIntersectsPageBand(
   flowHeight: number,
 ): boolean {
   const band = pageBandInHeaderFooterCoords(metrics, flowHeight);
-  return blockBottom > band.top && blockTop <= band.bottom;
+  return blockBottom > band.top && blockTop < band.bottom;
 }
 
 function resolveHeaderFooterFloatingTableVisualTop(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Skip anchored header/footer floats whose bounding box sits entirely outside the page band when computing `visualTop` / `visualBottom`.
- Prevents footer visual bounds (and downstream margin extension) from being inflated by decorative images positioned below the page.

## Test plan

- [x] `bun test packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

