### PR TITLE
fix(core): right-tab trailing width reservation in measurer

### DIFF
--- a/packages/core/src/layout-engine/measure/measureParagraph-decimal-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-decimal-tab.test.ts
@@ -272,4 +272,42 @@ describe("measureInlineWidthAfterTab — floating images (PR #512 codex P2)", ()
       expect(Math.abs((lineA?.width ?? 0) - (lineB?.width ?? 0))).toBeLessThanOrEqual(0.5);
     });
   });
+
+  test("a block image after a right tab does not contribute to following width", () => {
+    withFakeTextMeasure(() => {
+      const baseAttrs = { tabs: [{ val: "end" as const, pos: 5000 }] };
+
+      const withBlockImage = {
+        kind: "paragraph" as const,
+        id: "tab-block-img",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "image" as const,
+            src: "img.png",
+            width: 300,
+            height: 100,
+            wrapType: "topAndBottom" as const,
+          },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const withoutImage = {
+        kind: "paragraph" as const,
+        id: "tab-no-block-img",
+        runs: [{ kind: "text" as const, text: "Title", fontSize: 11 }, { kind: "tab" as const }],
+        attrs: baseAttrs,
+      };
+
+      const a = measureParagraph(withBlockImage, 400);
+      const b = measureParagraph(withoutImage, 400);
+      const lineA = a.lines.at(0);
+      const lineB = b.lines.at(0);
+      expect(lineA).toBeDefined();
+      expect(lineB).toBeDefined();
+      expect(Math.abs((lineA?.width ?? 0) - (lineB?.width ?? 0))).toBeLessThanOrEqual(0.5);
+    });
+  });
 });

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -101,4 +101,41 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
       expect(Math.abs((line?.width ?? 0) - painterLineWidth)).toBeLessThanOrEqual(0.5);
     });
   });
+
+  test("right tab reserves rotated inline image bbox width in following width", () => {
+    withFakeTextMeasure(() => {
+      const block = {
+        kind: "paragraph" as const,
+        id: "tab-rotated-inline",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "image" as const,
+            src: "img.png",
+            width: 40,
+            height: 20,
+            rotation: 90,
+          },
+        ],
+        attrs: {
+          tabs: [{ val: "end" as const, pos: 5000 }],
+        },
+      };
+
+      const measure = measureParagraph(block, 400);
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+
+      const titleWidth = 25;
+      const followingWidth = 20;
+      const tabResult = calculateTabWidth(titleWidth, {
+        explicitStops: [{ val: "end", pos: 5000 }],
+      }, {
+        followingWidth,
+      });
+      const painterLineWidth = titleWidth + tabResult.width + followingWidth;
+      expect(Math.abs((line?.width ?? 0) - painterLineWidth)).toBeLessThanOrEqual(0.5);
+    });
+  });
 });

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -372,6 +372,10 @@ function isEmptyTextRun(run: TextRun): boolean {
  * desync measurer and painter on tab advance for paragraphs with a tab
  * preceding a floating image.
  */
+function isBlockLayoutImageRun(run: ImageRun): boolean {
+  return run.wrapType === "topAndBottom" || run.displayMode === "block";
+}
+
 function measureInlineWidthAfterTab(
   runs: Run[],
   tabIndex: number,
@@ -383,12 +387,19 @@ function measureInlineWidthAfterTab(
     if (!next || isTabRun(next) || isLineBreakRun(next)) {
       break;
     }
+    if (isImageRun(next)) {
+      if (isBlockLayoutImageRun(next)) {
+        break;
+      }
+      if (!isFloatingImageRun(next)) {
+        width += inlineImageBoundingBox(next).width || 0;
+      }
+      continue;
+    }
     if (isTextRun(next)) {
       width += measureTextWidth(next.text || "", runToFontStyle(next));
     } else if (isFieldRun(next)) {
       width += measureTextWidth(fieldMeasureText(next, fieldValues), runToFontStyle(next));
-    } else if (isImageRun(next) && !isFloatingImageRun(next)) {
-      width += inlineImageBoundingBox(next).width || 0;
     } else if (isMathRun(next)) {
       width += measureTextWidth(next.plainText || "[equation]", runToFontStyle(next));
     }
@@ -400,6 +411,9 @@ function hasFollowingTabOnLine(runs: Run[], tabIndex: number): boolean {
   for (let i = tabIndex + 1; i < runs.length; i++) {
     const next = runs[i];
     if (!next || isLineBreakRun(next)) {
+      break;
+    }
+    if (isImageRun(next) && isBlockLayoutImageRun(next)) {
       break;
     }
     if (isTabRun(next)) {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -388,12 +388,25 @@ function measureInlineWidthAfterTab(
     } else if (isFieldRun(next)) {
       width += measureTextWidth(fieldMeasureText(next, fieldValues), runToFontStyle(next));
     } else if (isImageRun(next) && !isFloatingImageRun(next)) {
-      width += next.width || 0;
+      width += inlineImageBoundingBox(next).width || 0;
     } else if (isMathRun(next)) {
       width += measureTextWidth(next.plainText || "[equation]", runToFontStyle(next));
     }
   }
   return width;
+}
+
+function hasFollowingTabOnLine(runs: Run[], tabIndex: number): boolean {
+  for (let i = tabIndex + 1; i < runs.length; i++) {
+    const next = runs[i];
+    if (!next || isLineBreakRun(next)) {
+      break;
+    }
+    if (isTabRun(next)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -962,10 +975,20 @@ export function measureParagraph(
         ...(attrs?.tabs !== undefined ? { explicitStops: attrs.tabs } : {}),
         leftIndent: pixelsToTwips(indentLeft),
       };
-      const tabWidth = calculateTabWidth(contentX, tabContext, {
+      let tabWidth = calculateTabWidth(contentX, tabContext, {
         followingWidth,
         decimalPrefixWidth,
       }).width;
+
+      const lineRightEdgeX =
+        indentLeft + (isFirstLine ? firstLineOffset + markerInlineWidth : 0) + currentLine.availableWidth + currentLine.leftOffset;
+      if (
+        !hasFollowingTabOnLine(runs, runIndex) &&
+        (tabWidth > 0 || followingWidth > 0) &&
+        contentX + tabWidth + followingWidth > lineRightEdgeX + WIDTH_TOLERANCE
+      ) {
+        tabWidth = Math.max(1, lineRightEdgeX - contentX - followingWidth);
+      }
 
       if (currentLine.width + tabWidth > currentLine.availableWidth + WIDTH_TOLERANCE) {
         // Tab doesn't fit, start new line


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Measure trailing content after a right tab with rotated inline image bounding boxes, matching the painter.
- Clamp tab advance when tab plus trailing content would exceed the line's right edge, mirroring the painter's right-tab anchor clamp.

## Test plan

- [x] `bun test packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts`
- [x] `bun test packages/core/src/layout-engine/measure/measureParagraph-decimal-tab.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579f9603-afad-4052-a2f6-5d4f69a47083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

