### PR TITLE
chore: version packages

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @stll/folio-core
+
+## 0.1.3
+
+### Patch Changes
+
+- Fix DOCX parsing and layout edge cases: smartTag-wrapped runs, EMF header
+  previews, percent-suffixed table widths, CJK line breaks, off-page
+  header/footer floats, and right-tab trailing width reservation.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/folio-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Headless, framework-neutral core of folio: the OOXML (.docx) parser, document model, ProseMirror integration, and page-layout engine. No React.",
   "keywords": [
     "document-model",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @stll/folio-react
+
+## 0.2.0
+
+### Minor Changes
+
+- Add controlled comment props for collaboration sync, `scrollToParaId`,
+  `renderAsync`, and Hebrew, Hindi, Turkish, and Simplified Chinese UI locales.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @stll/folio-core@0.1.3

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/folio-react",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "React editor for folio: a Word-document (.docx) editor for the browser, built on @stll/folio-core and ProseMirror.",
   "keywords": [
     "document-editor",


### PR DESCRIPTION
## What

Version the packages for the merged release batch:

- @stll/folio-core: 0.1.2 -> 0.1.3
- @stll/folio-react: 0.1.1 -> 0.2.0

This adds package changelogs and updates the package.json versions. Merging this PR should trigger the existing publish workflow through the packages/{core,react}/package.json path filter.

## Checks

- bun install --frozen-lockfile
- bun run changeset:check
- bun run lint
- bun run typecheck
- bun run build
- bun run validate-dist
- bun run api:check