### PR TITLE
feat(react): readable, page-aware template directive rails

### DIFF
--- a/.changeset/directive-rails-ux.md
+++ b/.changeset/directive-rails-ux.md
@@ -1,0 +1,13 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-react": minor
+---
+
+Readable template directive rails: gutter rails indent by nesting depth
+within a margin-confined budget, colour by directive kind (loop violet,
+condition teal, theme-aware), render quiet by default and emphasize the
+block containing the caret or under the pointer, split into per-page
+segments so no rail crosses a page header, footer, or gap, and pair
+opener/closer chips on hover with a hint of what a bare closer closes.
+Adds pure helpers `computeBlockDepths` (core) and gutter geometry
+measurement to the paged-layout range projection.

--- a/packages/core/src/paged-layout/rangeProjection.test.ts
+++ b/packages/core/src/paged-layout/rangeProjection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { measureDirectiveGutter } from "./rangeProjection";
+
+describe("measureDirectiveGutter", () => {
+  test("returns null for a non-positive zoom instead of dividing by it", () => {
+    // Every measurement in the function divides by `zoom`; a zero/negative factor
+    // would produce Infinity/NaN rail geometry, so the guard must short-circuit
+    // before touching the element. A bare stub therefore stands in for it.
+    // SAFETY: the guard returns before the container is dereferenced, so its
+    // concrete shape is never read on this path.
+    const stub = {} as unknown as HTMLElement;
+
+    expect(measureDirectiveGutter(stub, 0)).toBeNull();
+    expect(measureDirectiveGutter(stub, -0.5)).toBeNull();
+  });
+});

--- a/packages/core/src/paged-layout/rangeProjection.ts
+++ b/packages/core/src/paged-layout/rangeProjection.ts
@@ -131,6 +131,73 @@ export const measureContentLeft = (pagesContainer: HTMLElement, zoom: number): n
 };
 
 /**
+ * One page's body-content vertical extent in container space. `.layout-page-content`
+ * is inset by the page margins, so its box excludes the header/footer and the
+ * inter-page gap — exactly the region a gutter rail is allowed to paint over.
+ */
+export type PageContentBand = {
+  /** 0-based page index (from `data-page-number` minus one). */
+  pageIndex: number;
+  /** Top of the body content area, container space. */
+  top: number;
+  /** Bottom of the body content area, container space. */
+  bottom: number;
+};
+
+/**
+ * Left-margin geometry the block-directive rails need in one measurement pass:
+ * the text-column left edge (rail anchor), the usable left-margin width (gutter
+ * budget), and each page's body-content band (so a rail can be clipped per page
+ * instead of running across page breaks). Measured O(pages), never per-range.
+ */
+export type DirectiveGutterGeometry = {
+  /** Text-column left edge, container space. Rails anchor here. */
+  contentLeft: number;
+  /** Usable left-margin width: `contentLeft - pageLeftEdge`. Drives the budget. */
+  marginWidth: number;
+  /** Per-page body-content vertical bands, in document order. */
+  pageBands: PageContentBand[];
+};
+
+export const measureDirectiveGutter = (
+  pagesContainer: HTMLElement,
+  zoom: number,
+): DirectiveGutterGeometry | null => {
+  const overlay = pagesContainer.parentElement?.querySelector('[data-testid="selection-overlay"]');
+  const pages = pagesContainer.querySelectorAll<HTMLElement>(".layout-page");
+  if (!overlay || pages.length === 0) {
+    return null;
+  }
+  const overlayRect = overlay.getBoundingClientRect();
+  const pageBands: PageContentBand[] = [];
+  let contentLeft: number | null = null;
+  let marginWidth: number | null = null;
+  for (const [domIndex, page] of pages.entries()) {
+    const contentEl = page.querySelector<HTMLElement>(".layout-page-content");
+    if (!contentEl) {
+      continue;
+    }
+    const pageNumberRaw = page.dataset["pageNumber"];
+    const pageIndex = pageNumberRaw ? Number(pageNumberRaw) - 1 : domIndex;
+    const contentRect = contentEl.getBoundingClientRect();
+    pageBands.push({
+      pageIndex,
+      top: (contentRect.top - overlayRect.top) / zoom,
+      bottom: (contentRect.bottom - overlayRect.top) / zoom,
+    });
+    if (contentLeft === null) {
+      const pageRect = page.getBoundingClientRect();
+      contentLeft = (contentRect.left - overlayRect.left) / zoom;
+      marginWidth = Math.max(0, (contentRect.left - pageRect.left) / zoom);
+    }
+  }
+  if (contentLeft === null || marginWidth === null) {
+    return null;
+  }
+  return { contentLeft, marginWidth, pageBands };
+};
+
+/**
  * Computed text style of the painted run at a PM position. Overlays
  * that paint substituted text over the pages (template fill preview,
  * AI suggestion replacement) copy these so the injected text matches

--- a/packages/core/src/paged-layout/rangeProjection.ts
+++ b/packages/core/src/paged-layout/rangeProjection.ts
@@ -163,6 +163,12 @@ export const measureDirectiveGutter = (
   pagesContainer: HTMLElement,
   zoom: number,
 ): DirectiveGutterGeometry | null => {
+  // Every measurement below divides by `zoom`; a zero/negative factor (seen
+  // transiently before the viewport settles, guarded the same way in the caret
+  // path) would yield Infinity/NaN geometry. Suppress the rails until it is sane.
+  if (zoom <= 0) {
+    return null;
+  }
   const overlay = pagesContainer.parentElement?.querySelector('[data-testid="selection-overlay"]');
   const pages = pagesContainer.querySelectorAll<HTMLElement>(".layout-page");
   if (!overlay || pages.length === 0) {

--- a/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
@@ -147,4 +147,37 @@ describe("computeBlockDepths", () => {
 
     expect(depths.get(10)).toBe(0);
   });
+
+  test("kind-aware: a stray {{/each}} does not shrink a foreign block's depth", () => {
+    // {{#if}} {{/each}}(stray, no open each) {{#each}} {{/if}}
+    // A blind open/close counter decrements on the stray {{/each}} and pulls the
+    // nested {{#each}} back to depth 0; kind-aware matching leaves it at depth 1.
+    const ranges: DirectiveRange[] = [
+      blockRange(0, "if"),
+      blockRange(10, "endeach"), // stray: no open each to close
+      blockRange(20, "each"),
+      blockRange(30, "endif"),
+    ];
+
+    const depths = computeBlockDepths(ranges);
+
+    expect(depths.get(0)).toBe(0); // outer if
+    expect(depths.get(20)).toBe(1); // each is still nested inside the open if
+  });
+
+  test("kind-aware: interleaved if/each closers keep opener depths intact", () => {
+    // {{#if}} {{#each}} {{/if}} {{/each}} (crossed nesting): the {{/if}} closes the
+    // if and discards the improperly-nested each, but recorded depths do not shift.
+    const ranges: DirectiveRange[] = [
+      blockRange(0, "if"),
+      blockRange(10, "each"),
+      blockRange(20, "endif"),
+      blockRange(30, "endeach"),
+    ];
+
+    const depths = computeBlockDepths(ranges);
+
+    expect(depths.get(0)).toBe(0);
+    expect(depths.get(10)).toBe(1);
+  });
 });

--- a/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { schema } from "../schema";
-import { scanDirectives } from "./templateDirectives";
+import type { DirectiveRange } from "./templateDirectives";
+import { computeBlockDepths, scanDirectives } from "./templateDirectives";
 
 const docOf = (...paragraphs: string[]) =>
   schema.node(
@@ -72,5 +73,78 @@ describe("scanDirectives", () => {
     expect(tokens).toContain("endeach::false");
     // The field inside the inline loop still gets its chip.
     expect(tokens).toContain("placeholder:items.name:false");
+  });
+});
+
+describe("computeBlockDepths", () => {
+  // Builds a block opener/closer range at a given position. Only `from`, `kind`,
+  // and `block` drive the depth math, so the rest is filler.
+  const blockRange = (from: number, kind: DirectiveRange["kind"]): DirectiveRange => ({
+    from,
+    to: from + 1,
+    kind,
+    expr: "",
+    block: true,
+  });
+
+  test("assigns 0-based depth by containment", () => {
+    // {{#each}} > {{#if}} > {{#if}}  (outer loop, two nested conditions)
+    const ranges: DirectiveRange[] = [
+      blockRange(0, "each"),
+      blockRange(10, "if"),
+      blockRange(20, "endif"),
+      blockRange(30, "if"),
+      blockRange(40, "endif"),
+      blockRange(50, "endeach"),
+    ];
+
+    const depths = computeBlockDepths(ranges);
+
+    expect(depths.get(0)).toBe(0); // each
+    expect(depths.get(10)).toBe(1); // first nested if
+    expect(depths.get(30)).toBe(1); // sibling nested if (back to depth 1)
+  });
+
+  test("deeply nested openers keep climbing (visual cap is the overlay's job)", () => {
+    const ranges: DirectiveRange[] = [
+      blockRange(0, "if"),
+      blockRange(1, "each"),
+      blockRange(2, "if"),
+      blockRange(3, "each"),
+      blockRange(4, "if"),
+      blockRange(5, "each"),
+    ];
+
+    const depths = computeBlockDepths(ranges);
+
+    expect([...depths.values()]).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  test("ignores order of input and inline (block:false) markers", () => {
+    const ranges: DirectiveRange[] = [
+      blockRange(30, "endif"),
+      blockRange(0, "each"),
+      { from: 5, to: 6, kind: "if", expr: "x", block: false }, // inline: no rail
+      blockRange(10, "if"),
+      blockRange(40, "endeach"),
+    ];
+
+    const depths = computeBlockDepths(ranges);
+
+    expect(depths.get(0)).toBe(0); // each
+    expect(depths.get(10)).toBe(1); // if nested inside each
+    expect(depths.has(5)).toBe(false); // inline if excluded
+  });
+
+  test("tolerates unbalanced closers without going negative", () => {
+    const ranges: DirectiveRange[] = [
+      blockRange(0, "endif"), // stray closer, no opener
+      blockRange(10, "if"),
+      blockRange(20, "endif"),
+    ];
+
+    const depths = computeBlockDepths(ranges);
+
+    expect(depths.get(10)).toBe(0);
   });
 });

--- a/packages/core/src/prosemirror/plugins/templateDirectives.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.ts
@@ -81,10 +81,16 @@ const BLOCK_CLOSER_KINDS = new Set<DirectiveKind>(["endif", "endeach"]);
 /**
  * Nesting depth (0-based) of every block-directive opener, derived purely from
  * the scanned ranges by containment: walk the block openers/closers in document
- * order with a stack, and record each opener's depth as the stack size before it
- * is pushed. Only `block:true` if/each pairs participate (inline markers resolve
- * within a paragraph and get no rail). Unbalanced markers are tolerated: a closer
- * with no open opener is ignored, and any still-open openers keep their depth.
+ * order with a kind-aware stack, and record each opener's depth as the stack size
+ * before it is pushed. Only `block:true` if/each pairs participate (inline markers
+ * resolve within a paragraph and get no rail).
+ *
+ * Matching is kind-aware so a mid-edit / unbalanced template stays sane: a closer
+ * pops the nearest opener of the *same family* ({{/if}} ⇒ {{#if}}, {{/each}} ⇒
+ * {{#each}}), dropping any still-open openers nested above it; a closer with no
+ * matching opener is ignored (never decrements a foreign block's depth). A blind
+ * open/close counter would mis-count here: e.g. a stray {{/each}} between {{#if}}
+ * and a nested {{#each}} would wrongly pull the inner {{#each}} back to depth 0.
  *
  * Keyed by the opener's `from` PM position, which is unique per marker, so the
  * overlay can look a band's depth up from its opener range. This is a pure
@@ -93,19 +99,21 @@ const BLOCK_CLOSER_KINDS = new Set<DirectiveKind>(["endif", "endeach"]);
  */
 export const computeBlockDepths = (ranges: readonly DirectiveRange[]): Map<number, number> => {
   const depths = new Map<number, number>();
-  let openCount = 0;
+  const stack: DirectiveKind[] = [];
   const ordered = ranges
     .filter((r) => r.block && (BLOCK_OPENER_KINDS.has(r.kind) || BLOCK_CLOSER_KINDS.has(r.kind)))
     .slice()
     .sort((a, b) => a.from - b.from);
   for (const range of ordered) {
     if (BLOCK_OPENER_KINDS.has(range.kind)) {
-      depths.set(range.from, openCount);
-      openCount += 1;
+      depths.set(range.from, stack.length);
+      stack.push(range.kind);
       continue;
     }
-    if (openCount > 0) {
-      openCount -= 1;
+    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "each";
+    const matchIdx = stack.lastIndexOf(wantOpener);
+    if (matchIdx !== -1) {
+      stack.length = matchIdx;
     }
   }
   return depths;

--- a/packages/core/src/prosemirror/plugins/templateDirectives.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.ts
@@ -73,6 +73,44 @@ const directiveExpr = (meta: MarkerMeta): string => {
   }
 };
 
+/** Block-directive openers ({{#if}}, {{#each}}) that start a gutter-rail band. */
+const BLOCK_OPENER_KINDS = new Set<DirectiveKind>(["if", "each"]);
+/** Block-directive closers ({{/if}}, {{/each}}) that end a gutter-rail band. */
+const BLOCK_CLOSER_KINDS = new Set<DirectiveKind>(["endif", "endeach"]);
+
+/**
+ * Nesting depth (0-based) of every block-directive opener, derived purely from
+ * the scanned ranges by containment: walk the block openers/closers in document
+ * order with a stack, and record each opener's depth as the stack size before it
+ * is pushed. Only `block:true` if/each pairs participate (inline markers resolve
+ * within a paragraph and get no rail). Unbalanced markers are tolerated: a closer
+ * with no open opener is ignored, and any still-open openers keep their depth.
+ *
+ * Keyed by the opener's `from` PM position, which is unique per marker, so the
+ * overlay can look a band's depth up from its opener range. This is a pure
+ * function of the ranges (no layout), hence unit-testable in isolation; the
+ * overlay caps the *visual* indentation separately.
+ */
+export const computeBlockDepths = (ranges: readonly DirectiveRange[]): Map<number, number> => {
+  const depths = new Map<number, number>();
+  let openCount = 0;
+  const ordered = ranges
+    .filter((r) => r.block && (BLOCK_OPENER_KINDS.has(r.kind) || BLOCK_CLOSER_KINDS.has(r.kind)))
+    .slice()
+    .sort((a, b) => a.from - b.from);
+  for (const range of ordered) {
+    if (BLOCK_OPENER_KINDS.has(range.kind)) {
+      depths.set(range.from, openCount);
+      openCount += 1;
+      continue;
+    }
+    if (openCount > 0) {
+      openCount -= 1;
+    }
+  }
+  return depths;
+};
+
 export const scanDirectives = (doc: PMNode): DirectiveRange[] => {
   const ranges: DirectiveRange[] = [];
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -5857,7 +5857,13 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
         return bestNumber;
       },
     }),
-    [ensureHiddenEditorView, folioEditor, scrollToPageImpl, scrollToParaIdImpl, scrollToPositionImpl],
+    [
+      ensureHiddenEditorView,
+      folioEditor,
+      scrollToPageImpl,
+      scrollToParaIdImpl,
+      scrollToPositionImpl,
+    ],
   );
 
   useEffect(() => {
@@ -6030,6 +6036,7 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
               gutter={directiveGutter}
               groups={directiveRectGroups}
               caretPos={directiveCaretPos}
+              ranges={directivesRef.current}
             />
           )}
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -112,7 +112,8 @@ import type { DirtyRange } from "@stll/folio-core/paged-layout/incrementalMeasur
 import { LayoutSelectionGate } from "@stll/folio-core/paged-layout/LayoutSelectionGate";
 import {
   collectRunFontsAtPmPositions,
-  measureContentLeft,
+  type DirectiveGutterGeometry,
+  measureDirectiveGutter,
   projectRangesToRects,
 } from "@stll/folio-core/paged-layout/rangeProjection";
 import { isReadOnlyEditKey } from "@stll/folio-core/paged-layout/readOnlyEditAttempt";
@@ -1789,7 +1790,10 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
   const [autocompleteText, setAutocompleteText] = useState<string>("");
   const [autocompleteIsStreaming, setAutocompleteIsStreaming] = useState<boolean>(false);
   const [directiveRectGroups, setDirectiveRectGroups] = useState<DirectiveRectGroup[]>([]);
-  const [directiveContentLeft, setDirectiveContentLeft] = useState<number | null>(null);
+  const [directiveGutter, setDirectiveGutter] = useState<DirectiveGutterGeometry | null>(null);
+  // Caret/selection head PM position, kept only while a template document has
+  // block directives — drives the innermost-block rail emphasis in the overlay.
+  const [directiveCaretPos, setDirectiveCaretPos] = useState<number | null>(null);
   const directivesRef = useRef<readonly DirectiveRange[]>([]);
   const directivesOverlayRequestSeqRef = useRef(0);
   // Template fill preview — the hidden editor's plugin keeps marker↔value
@@ -2401,6 +2405,13 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       selectionOverlayRequestSeqRef.current = requestSeq;
       const isCurrentRequest = () => selectionOverlayRequestSeqRef.current === requestSeq;
 
+      // Feed the template-directives overlay the caret head so it can emphasise
+      // the innermost block around it. Gated on there being directives at all,
+      // so a plain (non-template) document pays no extra re-render per keystroke.
+      if (directivesRef.current.length > 0) {
+        setDirectiveCaretPos(state.selection.head);
+      }
+
       // Always notify selection change (for toolbar sync) even if layout not ready
       // Use ref to avoid infinite loops when callback is unstable
       onSelectionChangeRef.current?.(from, to);
@@ -2894,10 +2905,10 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
     const pagesContainer = pagesContainerRef.current;
     if (ranges.length === 0 || !pagesContainer) {
       setDirectiveRectGroups([]);
-      setDirectiveContentLeft(null);
+      setDirectiveGutter(null);
       return;
     }
-    setDirectiveContentLeft(measureContentLeft(pagesContainer, zoom));
+    setDirectiveGutter(measureDirectiveGutter(pagesContainer, zoom));
     void (async () => {
       const projected = await projectRangesToRects(ranges, {
         pagesContainer,
@@ -6016,8 +6027,9 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
               the directives plugin isn't installed. */}
           {showTemplateDirectives && (
             <TemplateDirectivesOverlay
-              contentLeft={directiveContentLeft}
+              gutter={directiveGutter}
               groups={directiveRectGroups}
+              caretPos={directiveCaretPos}
             />
           )}
 

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.rails.test.ts
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.rails.test.ts
@@ -137,6 +137,50 @@ describe("pairBlockRanges", () => {
     expect(pairings).toHaveLength(1);
     expect(pairings[0]).toMatchObject({ blockId: 10, openerExpr: "kept" });
   });
+
+  test("carries the nesting depth from the same walk", () => {
+    // {{#each}} > {{#if}} ... {{/if}} {{/each}}: depth rides on the pairing so the
+    // rail's indentation and its opener→closer span can never diverge.
+    const pairings = pairBlockRanges([
+      blockRange(0, "each", "items"),
+      blockRange(10, "if", "cond"),
+      blockRange(20, "endif"),
+      blockRange(30, "endeach"),
+    ]);
+
+    expect(pairings.find((p) => p.kind === "if")?.depth).toBe(1);
+    expect(pairings.find((p) => p.kind === "each")?.depth).toBe(0);
+  });
+
+  test("kind-aware: a {{/if}} pairs with its {{#if}}, not an intervening {{#each}}", () => {
+    // {{#if}} {{#each}} {{/if}} {{/each}} (crossed nesting). Blind popping would
+    // pair the {{/if}} with the {{#each}} (an each-kind band) and the {{/each}}
+    // with the {{#if}}. Kind-aware matching closes the if correctly and drops the
+    // improperly-nested each rather than mislabelling a band.
+    const pairings = pairBlockRanges([
+      blockRange(0, "if", "A"),
+      blockRange(10, "each", "B"),
+      blockRange(20, "endif"),
+      blockRange(30, "endeach"),
+    ]);
+
+    expect(pairings).toHaveLength(1);
+    expect(pairings[0]).toMatchObject({
+      blockId: 0,
+      kind: "if",
+      openerFrom: 0,
+      closerFrom: 20,
+      openerExpr: "A",
+    });
+  });
+
+  test("kind-aware: a {{/if}} never closes an {{#each}}", () => {
+    // {{#each}} {{/if}}: mismatched families must not pair (would be an each-kind
+    // band closed by a /if). Blind popping paired them; kind-aware drops both.
+    const pairings = pairBlockRanges([blockRange(0, "each", "B"), blockRange(10, "endif")]);
+
+    expect(pairings).toHaveLength(0);
+  });
 });
 
 describe("closerHintLabel", () => {

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.rails.test.ts
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.rails.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PageContentBand } from "@stll/folio-core/paged-layout/rangeProjection";
+import type { DirectiveRange } from "@stll/folio-core/prosemirror/plugins/templateDirectives";
+
+import {
+  closerHintLabel,
+  innermostBlockAt,
+  pairBlockRanges,
+  railBudgetDepth,
+  railXForDepth,
+  segmentBandByPages,
+} from "./TemplateDirectivesOverlay";
+
+/**
+ * Presentation math for the block-directive rails. The rendering itself is DOM;
+ * these are the pure pieces the overlay leans on, so a regression in the gutter
+ * budget, page segmentation, pairing, or caret containment fails here first.
+ *
+ * Constants that pin the expected numbers (must match the overlay):
+ *   RAIL_WIDTH 2.5, RAIL_DEPTH_GAP 5, RAIL_TEXT_CLEARANCE 6, RAIL_EDGE_PAD 2.
+ * usable = margin - 6 - 2.5 - 2 = margin - 10.5;  budget = floor(usable / 5).
+ */
+
+const blockRange = (from: number, kind: DirectiveRange["kind"], expr = ""): DirectiveRange => ({
+  from,
+  to: from + 1,
+  kind,
+  expr,
+  block: true,
+});
+
+describe("railBudgetDepth", () => {
+  test("no usable margin yields depth 0 (never negative)", () => {
+    expect(railBudgetDepth(0)).toBe(0);
+    expect(railBudgetDepth(-40)).toBe(0);
+    expect(railBudgetDepth(10)).toBe(0); // usable -0.5
+  });
+
+  test("counts how many 5px steps fit after the clearances", () => {
+    expect(railBudgetDepth(20)).toBe(1); // usable 9.5 -> 1
+    expect(railBudgetDepth(25)).toBe(2); // usable 14.5 -> 2
+    expect(railBudgetDepth(50)).toBe(7); // usable 39.5 -> 7
+  });
+});
+
+describe("railXForDepth", () => {
+  const CONTENT_LEFT = 100;
+  const MARGIN = 50; // budget 7, pageLeft = 50
+
+  test("deepest budgeted rail keeps a >=6px clearance to the text edge", () => {
+    const x = railXForDepth(7, CONTENT_LEFT, MARGIN);
+    expect(x).toBe(91.5); // 100 - 6 - 2.5
+    const railRightEdge = x + 2.5; // + RAIL_WIDTH
+    expect(CONTENT_LEFT - railRightEdge).toBeGreaterThanOrEqual(6);
+  });
+
+  test("outermost rail stays inside the page margin", () => {
+    const x = railXForDepth(0, CONTENT_LEFT, MARGIN);
+    expect(x).toBe(56.5); // 91.5 - 7*5
+    const pageLeft = CONTENT_LEFT - MARGIN;
+    expect(x).toBeGreaterThanOrEqual(pageLeft + 2); // + RAIL_EDGE_PAD
+  });
+
+  test("depths beyond the budget reuse the deepest offset (no march into text)", () => {
+    expect(railXForDepth(99, CONTENT_LEFT, MARGIN)).toBe(railXForDepth(7, CONTENT_LEFT, MARGIN));
+  });
+
+  test("deeper depth sits closer to the text than a shallower one", () => {
+    expect(railXForDepth(3, CONTENT_LEFT, MARGIN)).toBeGreaterThan(
+      railXForDepth(1, CONTENT_LEFT, MARGIN),
+    );
+  });
+});
+
+describe("segmentBandByPages", () => {
+  // Two pages with a 20px inter-page gap (page 0 body 0..100, page 1 body 120..220).
+  const pages: PageContentBand[] = [
+    { pageIndex: 0, top: 0, bottom: 100 },
+    { pageIndex: 1, top: 120, bottom: 220 },
+  ];
+
+  test("a single-page band is clipped to that page", () => {
+    expect(segmentBandByPages({ top: 10, bottom: 60 }, pages)).toEqual([{ top: 10, bottom: 60 }]);
+  });
+
+  test("a cross-page band splits and never paints over the inter-page gap", () => {
+    expect(segmentBandByPages({ top: 50, bottom: 180 }, pages)).toEqual([
+      { top: 50, bottom: 100 },
+      { top: 120, bottom: 180 },
+    ]);
+  });
+
+  test("a band that lands entirely in the gap/footer/header draws nothing", () => {
+    expect(segmentBandByPages({ top: 104, bottom: 116 }, pages)).toEqual([]);
+  });
+
+  test("sub-2px slivers at a seam are dropped", () => {
+    expect(segmentBandByPages({ top: 99, bottom: 100 }, pages)).toEqual([]);
+  });
+
+  test("with no page geometry the whole span is one segment (fallback)", () => {
+    expect(segmentBandByPages({ top: 10, bottom: 60 }, [])).toEqual([{ top: 10, bottom: 60 }]);
+  });
+});
+
+describe("pairBlockRanges", () => {
+  test("pairs nested openers with their closers and carries id/kind/expr", () => {
+    // {{#each contracts.risks}} > {{#if hasVerdicts}} ... {{/if}} {{/each}}
+    const ranges = [
+      blockRange(0, "each", "contracts.risks"),
+      blockRange(10, "if", "hasVerdicts"),
+      blockRange(20, "endif"),
+      blockRange(30, "endeach"),
+    ];
+
+    const pairings = pairBlockRanges(ranges);
+
+    expect(pairings).toHaveLength(2);
+    const inner = pairings.find((p) => p.kind === "if");
+    const outer = pairings.find((p) => p.kind === "each");
+    expect(inner).toMatchObject({ blockId: 10, openerFrom: 10, closerFrom: 20, closerTo: 21 });
+    expect(inner?.openerExpr).toBe("hasVerdicts");
+    expect(outer).toMatchObject({ blockId: 0, closerFrom: 30, openerExpr: "contracts.risks" });
+  });
+
+  test("drops inline (block:false) markers and unbalanced closers", () => {
+    const ranges: DirectiveRange[] = [
+      blockRange(0, "endif"), // stray closer, no opener
+      { from: 5, to: 6, kind: "if", expr: "inline", block: false },
+      blockRange(10, "if", "kept"),
+      blockRange(20, "endif"),
+    ];
+
+    const pairings = pairBlockRanges(ranges);
+
+    expect(pairings).toHaveLength(1);
+    expect(pairings[0]).toMatchObject({ blockId: 10, openerExpr: "kept" });
+  });
+});
+
+describe("closerHintLabel", () => {
+  test("names what the closer closes", () => {
+    expect(closerHintLabel("if", "hasVerdicts")).toBe("/if · hasVerdicts");
+    expect(closerHintLabel("each", "contracts.risks")).toBe("/each · contracts.risks");
+  });
+
+  test("falls back to the bare keyword when there is no expression", () => {
+    expect(closerHintLabel("if", "")).toBe("/if");
+    expect(closerHintLabel("each", "")).toBe("/each");
+  });
+});
+
+describe("innermostBlockAt", () => {
+  const pairings = pairBlockRanges([
+    blockRange(0, "each", "items"),
+    blockRange(10, "if", "cond"),
+    blockRange(20, "endif"),
+    blockRange(30, "endeach"),
+  ]);
+
+  test("picks the deepest block whose span contains the caret", () => {
+    expect(innermostBlockAt(pairings, 15)).toBe(10); // inside inner if
+  });
+
+  test("falls back to the enclosing block when outside the inner one", () => {
+    expect(innermostBlockAt(pairings, 25)).toBe(0); // between /if and /each
+  });
+
+  test("returns null outside every block or with no caret", () => {
+    expect(innermostBlockAt(pairings, 100)).toBeNull();
+    expect(innermostBlockAt(pairings, null)).toBeNull();
+  });
+});

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
@@ -6,15 +6,27 @@
  * highlight is faint and `pointer-events: none`, so the real text shows through
  * and the caret lands in it normally. Because it's a tint (not an opaque cover),
  * minor misalignment during reflow is invisible — no flicker. Block directives
- * additionally get a thin left gutter rail spanning opener→closer.
+ * additionally get a thin left-margin gutter rail spanning opener→closer.
+ *
+ * Rails are quiet by default and loud on intent: every rail renders faint until
+ * the block either contains the caret (innermost wins) or is hovered (via its
+ * rail or one of its {{#if}}/{{/if}} chips), at which point that one block's
+ * rail and both chips brighten so it can be traced end-to-end. Rails are clipped
+ * per page (never across the inter-page gap, header, or footer) and confined to
+ * the left margin by a depth budget derived from the margin width.
  *
  * Appearance lives in editor.css (`.folio-template-*`, --doc-* tokens); only
  * positioning is inline.
  */
 
-import type { CSSProperties } from "react";
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
+import { useState } from "react";
 
 import type { SelectionRect } from "@stll/folio-core/layout-bridge/engine/selectionRects";
+import type {
+  DirectiveGutterGeometry,
+  PageContentBand,
+} from "@stll/folio-core/paged-layout/rangeProjection";
 import {
   computeBlockDepths,
   type DirectiveKind,
@@ -29,11 +41,15 @@ export type DirectiveRectGroup = {
 export type TemplateDirectivesOverlayProps = {
   groups: DirectiveRectGroup[];
   /**
-   * Stable text-column left edge (container space). The rail anchors to this
-   * rather than the block opener's re-projected `rects[0].x`, so it doesn't
-   * drift sideways as text above it reflows during editing.
+   * Left-margin geometry: text-column anchor, usable margin width, and per-page
+   * content bands. Null until the pages are measured; rails are suppressed then.
    */
-  contentLeft: number | null;
+  gutter: DirectiveGutterGeometry | null;
+  /**
+   * Current caret/selection head PM position, or null. The innermost block
+   * containing it is emphasised (the "loud on caret" half of the interaction).
+   */
+  caretPos: number | null;
 };
 
 const overlayStyles: CSSProperties = {
@@ -49,103 +65,290 @@ const overlayStyles: CSSProperties = {
 
 const BLOCK_OPENERS = new Set<DirectiveKind>(["if", "each"]);
 const BLOCK_CLOSERS = new Set<DirectiveKind>(["endif", "endeach"]);
-const RAIL_BASE_GUTTER = 12;
-const RAIL_DEPTH_GAP = 5;
+
 const RAIL_WIDTH = 2.5;
-/**
- * Cap the *visual* indentation: past this depth, deeper rails reuse the last
- * offset instead of marching further right (and off the page). Colour + hover
- * still disambiguate the rare deep nest; the containment depth itself is uncapped.
- */
-const RAIL_VISUAL_DEPTH_CAP = 5;
+/** Horizontal gap between adjacent nesting depths' rails. */
+const RAIL_DEPTH_GAP = 5;
+/** Minimum clear space between the innermost (deepest) rail and the text edge. */
+const RAIL_TEXT_CLEARANCE = 6;
+/** Keep the outermost rail this far off the physical page-left edge. */
+const RAIL_EDGE_PAD = 2;
+/** Drop per-page segments thinner than this (sub-pixel slivers at a page seam). */
+const RAIL_SEGMENT_MIN_HEIGHT = 2;
 
 /** Opener kind of a band ("if" ⇒ condition family, "each" ⇒ loop family). */
 type BandKind = "if" | "each";
 
-type Band = {
-  top: number;
-  bottom: number;
-  railX: number;
-  kind: BandKind;
+const bandKindOf = (kind: DirectiveKind): BandKind => (kind === "each" ? "each" : "if");
+
+/**
+ * Deepest nesting level whose rail still fits inside the left margin with a
+ * `RAIL_TEXT_CLEARANCE` gap to the text and a `RAIL_EDGE_PAD` gap to the page
+ * edge. Depths past this reuse the deepest offset, so a 5-level nest can never
+ * march a rail into the text column. Pure function of the measured margin width.
+ */
+export const railBudgetDepth = (marginWidth: number): number => {
+  const usable = marginWidth - RAIL_TEXT_CLEARANCE - RAIL_WIDTH - RAIL_EDGE_PAD;
+  if (usable <= 0) {
+    return 0;
+  }
+  return Math.floor(usable / RAIL_DEPTH_GAP);
 };
 
 /**
- * Pair opener/closer block directives with a stack so each conditional/loop
- * region knows its top, bottom, and opener kind (for the gutter rail). Nesting
- * depth comes from the shared pure {@link computeBlockDepths} helper (keyed by
- * opener `from`) so the offset math is unit-testable and identical to the tests.
- * Unbalanced directives are skipped. The rail's horizontal position comes from
- * the stable `contentLeft` anchor (not the opener's re-projected rect), so it
- * stays put while text above reflows; only its vertical span tracks the rects.
+ * Left edge (container space) of a depth-`depth` rail. The deepest rail the
+ * budget allows sits `RAIL_TEXT_CLEARANCE + RAIL_WIDTH` left of the text edge;
+ * shallower (outer) blocks fan further left into the margin — nested blocks read
+ * as concentric brackets `[ [ [ text ] ] ]`. Depths beyond the budget clamp to
+ * the deepest offset.
  */
-const computeBands = (groups: DirectiveRectGroup[], contentLeft: number | null): Band[] => {
-  const depths = computeBlockDepths(groups.map((g) => g.range));
-  const blocks = groups
-    .filter(
-      // Inline if/endif markers (block:false, resolved within one paragraph)
-      // get the tint only; pairing them into rails would draw a band for a
-      // phrase-level span.
-      (g) => g.range.block && (BLOCK_OPENERS.has(g.range.kind) || BLOCK_CLOSERS.has(g.range.kind)),
-    )
-    .sort((a, b) => a.range.from - b.range.from);
+export const railXForDepth = (depth: number, contentLeft: number, marginWidth: number): number => {
+  const budget = railBudgetDepth(marginWidth);
+  const capped = Math.min(Math.max(0, depth), budget);
+  const deepestX = contentLeft - RAIL_TEXT_CLEARANCE - RAIL_WIDTH;
+  return deepestX - (budget - capped) * RAIL_DEPTH_GAP;
+};
 
-  const bands: Band[] = [];
-  const stack: DirectiveRectGroup[] = [];
-  for (const group of blocks) {
-    if (BLOCK_OPENERS.has(group.range.kind)) {
-      stack.push(group);
+export type BandSegment = { top: number; bottom: number };
+
+/**
+ * Clip a band's vertical span to each page's body-content band so a rail is
+ * drawn as one rounded segment per page and never paints across the inter-page
+ * gap, header, or footer. With no page bands (geometry not ready) the whole span
+ * is returned as a single segment so rails still show. Pure math.
+ */
+export const segmentBandByPages = (
+  band: BandSegment,
+  pageBands: readonly PageContentBand[],
+): BandSegment[] => {
+  if (pageBands.length === 0) {
+    return band.bottom - band.top >= RAIL_SEGMENT_MIN_HEIGHT ? [band] : [];
+  }
+  const segments: BandSegment[] = [];
+  for (const page of pageBands) {
+    const top = Math.max(band.top, page.top);
+    const bottom = Math.min(band.bottom, page.bottom);
+    if (bottom - top >= RAIL_SEGMENT_MIN_HEIGHT) {
+      segments.push({ top, bottom });
+    }
+  }
+  return segments;
+};
+
+/** A matched block opener→closer pair, derived purely from the scanned ranges. */
+export type BlockPairing = {
+  /** Stable block id: the opener's `from` PM position. */
+  blockId: number;
+  kind: BandKind;
+  openerFrom: number;
+  closerFrom: number;
+  /** Exclusive PM end of the closer marker (band bottom / caret containment). */
+  closerTo: number;
+  /** Opener expression, e.g. `hasVerdicts` or `contracts.risks`, for the hint. */
+  openerExpr: string;
+};
+
+/**
+ * Pair block openers with their closers via a stack (same walk as
+ * {@link computeBlockDepths}), so both chips of a pair share a `blockId` and the
+ * rail knows its opener→closer PM span. Inline (block:false) and unbalanced
+ * markers are dropped. Pure function of the ranges, unit-tested in isolation.
+ */
+export const pairBlockRanges = (ranges: readonly DirectiveRange[]): BlockPairing[] => {
+  const blocks = ranges
+    .filter((r) => r.block && (BLOCK_OPENERS.has(r.kind) || BLOCK_CLOSERS.has(r.kind)))
+    .slice()
+    .sort((a, b) => a.from - b.from);
+
+  const pairings: BlockPairing[] = [];
+  const stack: DirectiveRange[] = [];
+  for (const range of blocks) {
+    if (BLOCK_OPENERS.has(range.kind)) {
+      stack.push(range);
       continue;
     }
-    const open = stack.pop();
-    const openerRect = open?.rects[0];
-    const closerRect = group.rects[0];
-    if (!open || !openerRect || !closerRect) {
+    const opener = stack.pop();
+    if (!opener) {
       continue;
     }
-    const railBase = contentLeft ?? openerRect.x;
-    const depth = depths.get(open.range.from) ?? 0;
-    const visualDepth = Math.min(depth, RAIL_VISUAL_DEPTH_CAP);
+    pairings.push({
+      blockId: opener.from,
+      kind: bandKindOf(opener.kind),
+      openerFrom: opener.from,
+      closerFrom: range.from,
+      closerTo: range.to,
+      openerExpr: opener.expr,
+    });
+  }
+  return pairings;
+};
+
+/** Hover hint for a closer chip: what it closes, e.g. `/if · hasVerdicts`. */
+export const closerHintLabel = (kind: BandKind, openerExpr: string): string => {
+  const head = kind === "each" ? "/each" : "/if";
+  return openerExpr ? `${head} · ${openerExpr}` : head;
+};
+
+/**
+ * Block id of the innermost pairing whose opener→closer span contains `caretPos`
+ * (largest opener position wins), or null. Drives the caret emphasis.
+ */
+export const innermostBlockAt = (
+  pairings: readonly BlockPairing[],
+  caretPos: number | null,
+): number | null => {
+  if (caretPos === null) {
+    return null;
+  }
+  let bestBlockId: number | null = null;
+  let bestOpener = Number.NEGATIVE_INFINITY;
+  for (const pairing of pairings) {
+    const contains = caretPos >= pairing.openerFrom && caretPos <= pairing.closerTo;
+    if (contains && pairing.openerFrom > bestOpener) {
+      bestOpener = pairing.openerFrom;
+      bestBlockId = pairing.blockId;
+    }
+  }
+  return bestBlockId;
+};
+
+type RailBand = {
+  blockId: number;
+  kind: BandKind;
+  railX: number;
+  segments: BandSegment[];
+};
+
+/**
+ * Assemble the per-page rail segments for every balanced block: pair the ranges,
+ * look up opener/closer rects by `from`, place the rail by its budgeted depth,
+ * and clip its span to each page. O(ranges); all geometry comes from the props.
+ */
+const computeRailBands = (
+  pairings: readonly BlockPairing[],
+  groups: DirectiveRectGroup[],
+  gutter: DirectiveGutterGeometry,
+): RailBand[] => {
+  const depths = computeBlockDepths(groups.map((g) => g.range));
+  const groupByFrom = new Map(groups.map((group) => [group.range.from, group]));
+
+  const bands: RailBand[] = [];
+  for (const pairing of pairings) {
+    const openerRect = groupByFrom.get(pairing.openerFrom)?.rects[0];
+    const closerRect = groupByFrom.get(pairing.closerFrom)?.rects[0];
+    if (!openerRect || !closerRect) {
+      continue;
+    }
+    const depth = depths.get(pairing.openerFrom) ?? 0;
+    const segments = segmentBandByPages(
+      { top: openerRect.y, bottom: closerRect.y + closerRect.height },
+      gutter.pageBands,
+    );
+    if (segments.length === 0) {
+      continue;
+    }
     bands.push({
-      top: openerRect.y,
-      bottom: closerRect.y + closerRect.height,
-      railX: railBase - RAIL_BASE_GUTTER + visualDepth * RAIL_DEPTH_GAP,
-      // Openers are only ever "if" or "each" (BLOCK_OPENERS); narrow for the class.
-      kind: open.range.kind === "each" ? "each" : "if",
+      blockId: pairing.blockId,
+      kind: pairing.kind,
+      railX: railXForDepth(depth, gutter.contentLeft, gutter.marginWidth),
+      segments,
     });
   }
   return bands;
 };
 
+const blockIdFromTarget = (target: EventTarget | null): number | null => {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+  const raw = target.dataset["folioBlockId"];
+  return raw === undefined ? null : Number(raw);
+};
+
 export const TemplateDirectivesOverlay = ({
   groups,
-  contentLeft,
+  gutter,
+  caretPos,
 }: TemplateDirectivesOverlayProps) => {
+  const [hoveredBlockId, setHoveredBlockId] = useState<number | null>(null);
+
   if (groups.length === 0) {
     return null;
   }
 
-  const bands = computeBands(groups, contentLeft);
+  const pairings = pairBlockRanges(groups.map((g) => g.range));
+  const railBands = gutter ? computeRailBands(pairings, groups, gutter) : [];
+
+  // Block id for every opener/closer chip (both share the opener's id) and the
+  // closer chips' hover hints, so a chip can pair-highlight and label itself.
+  const blockIdByFrom = new Map<number, number>();
+  const closerLabelByFrom = new Map<number, string>();
+  for (const pairing of pairings) {
+    blockIdByFrom.set(pairing.openerFrom, pairing.blockId);
+    blockIdByFrom.set(pairing.closerFrom, pairing.blockId);
+    closerLabelByFrom.set(pairing.closerFrom, closerHintLabel(pairing.kind, pairing.openerExpr));
+  }
+
+  const caretBlockId = innermostBlockAt(pairings, caretPos);
+  const isActive = (blockId: number): boolean =>
+    blockId === hoveredBlockId || blockId === caretBlockId;
+
+  // Delegated hover: only rails and block chips carry a data-block-id and
+  // pointer-events, so one pair of container listeners tracks the hovered block
+  // without a closure per element. Staying within the same block keeps it lit.
+  const handlePointerOver = (event: ReactPointerEvent) => {
+    const blockId = blockIdFromTarget(event.target);
+    if (blockId !== null) {
+      setHoveredBlockId(blockId);
+    }
+  };
+  const handlePointerOut = (event: ReactPointerEvent) => {
+    const from = blockIdFromTarget(event.target);
+    if (from === null) {
+      return;
+    }
+    const to = blockIdFromTarget(event.relatedTarget);
+    if (to === from) {
+      return;
+    }
+    setHoveredBlockId((current) => (current === from ? to : current));
+  };
 
   return (
-    <div style={overlayStyles} data-folio-template-directives-overlay="">
-      {bands.map((band, bandIdx) => (
-        <div
-          key={`rail:${bandIdx}`}
-          className={`folio-template-band-rail folio-template-band-rail--${band.kind}`}
-          style={{
-            left: band.railX,
-            top: band.top,
-            width: RAIL_WIDTH,
-            height: Math.max(0, band.bottom - band.top),
-          }}
-        />
-      ))}
+    <div
+      style={overlayStyles}
+      data-folio-template-directives-overlay=""
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
+    >
+      {railBands.flatMap((band) =>
+        band.segments.map((segment, segmentIdx) => (
+          <div
+            key={`rail:${band.blockId}:${segmentIdx}`}
+            className={`folio-template-band-rail folio-template-band-rail--${band.kind}${isActive(band.blockId) ? " folio-template-band-rail--active" : ""}`}
+            data-folio-block-id={band.blockId}
+            style={{
+              left: band.railX,
+              top: segment.top,
+              width: RAIL_WIDTH,
+              height: Math.max(0, segment.bottom - segment.top),
+            }}
+          />
+        )),
+      )}
 
-      {groups.flatMap(({ range, rects }, groupIdx) =>
-        rects.map((rect, idx) => (
+      {groups.flatMap(({ range, rects }, groupIdx) => {
+        const blockId = range.block ? blockIdByFrom.get(range.from) : undefined;
+        const isBlockChip =
+          range.block && (BLOCK_OPENERS.has(range.kind) || BLOCK_CLOSERS.has(range.kind));
+        const closerLabel = range.block ? closerLabelByFrom.get(range.from) : undefined;
+        const active = blockId !== undefined && isActive(blockId);
+        return rects.map((rect, idx) => (
           <span
             key={`d:${groupIdx}:${idx}`}
-            className={`folio-template-directive folio-template-directive--${range.kind}`}
+            className={`folio-template-directive folio-template-directive--${range.kind}${isBlockChip ? " folio-template-directive--block" : ""}${active ? " folio-template-directive--active" : ""}`}
+            {...(blockId !== undefined ? { "data-folio-block-id": blockId } : {})}
+            {...(closerLabel !== undefined ? { title: closerLabel } : {})}
             style={{
               left: rect.x - 1,
               top: rect.y + 1,
@@ -153,8 +356,8 @@ export const TemplateDirectivesOverlay = ({
               height: Math.max(0, rect.height - 2),
             }}
           />
-        )),
-      )}
+        ));
+      })}
     </div>
   );
 };

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
@@ -15,9 +15,10 @@
 import type { CSSProperties } from "react";
 
 import type { SelectionRect } from "@stll/folio-core/layout-bridge/engine/selectionRects";
-import type {
-  DirectiveKind,
-  DirectiveRange,
+import {
+  computeBlockDepths,
+  type DirectiveKind,
+  type DirectiveRange,
 } from "@stll/folio-core/prosemirror/plugins/templateDirectives";
 
 export type DirectiveRectGroup = {
@@ -50,22 +51,35 @@ const BLOCK_OPENERS = new Set<DirectiveKind>(["if", "each"]);
 const BLOCK_CLOSERS = new Set<DirectiveKind>(["endif", "endeach"]);
 const RAIL_BASE_GUTTER = 12;
 const RAIL_DEPTH_GAP = 5;
-const RAIL_WIDTH = 2;
+const RAIL_WIDTH = 2.5;
+/**
+ * Cap the *visual* indentation: past this depth, deeper rails reuse the last
+ * offset instead of marching further right (and off the page). Colour + hover
+ * still disambiguate the rare deep nest; the containment depth itself is uncapped.
+ */
+const RAIL_VISUAL_DEPTH_CAP = 5;
+
+/** Opener kind of a band ("if" ⇒ condition family, "each" ⇒ loop family). */
+type BandKind = "if" | "each";
 
 type Band = {
   top: number;
   bottom: number;
   railX: number;
+  kind: BandKind;
 };
 
 /**
  * Pair opener/closer block directives with a stack so each conditional/loop
- * region knows its top, bottom, and nesting depth (for the gutter rail).
+ * region knows its top, bottom, and opener kind (for the gutter rail). Nesting
+ * depth comes from the shared pure {@link computeBlockDepths} helper (keyed by
+ * opener `from`) so the offset math is unit-testable and identical to the tests.
  * Unbalanced directives are skipped. The rail's horizontal position comes from
  * the stable `contentLeft` anchor (not the opener's re-projected rect), so it
  * stays put while text above reflows; only its vertical span tracks the rects.
  */
 const computeBands = (groups: DirectiveRectGroup[], contentLeft: number | null): Band[] => {
+  const depths = computeBlockDepths(groups.map((g) => g.range));
   const blocks = groups
     .filter(
       // Inline if/endif markers (block:false, resolved within one paragraph)
@@ -76,23 +90,27 @@ const computeBands = (groups: DirectiveRectGroup[], contentLeft: number | null):
     .sort((a, b) => a.range.from - b.range.from);
 
   const bands: Band[] = [];
-  const stack: { group: DirectiveRectGroup; depth: number }[] = [];
+  const stack: DirectiveRectGroup[] = [];
   for (const group of blocks) {
     if (BLOCK_OPENERS.has(group.range.kind)) {
-      stack.push({ group, depth: stack.length });
+      stack.push(group);
       continue;
     }
     const open = stack.pop();
-    const openerRect = open?.group.rects[0];
+    const openerRect = open?.rects[0];
     const closerRect = group.rects[0];
     if (!open || !openerRect || !closerRect) {
       continue;
     }
     const railBase = contentLeft ?? openerRect.x;
+    const depth = depths.get(open.range.from) ?? 0;
+    const visualDepth = Math.min(depth, RAIL_VISUAL_DEPTH_CAP);
     bands.push({
       top: openerRect.y,
       bottom: closerRect.y + closerRect.height,
-      railX: railBase - RAIL_BASE_GUTTER + open.depth * RAIL_DEPTH_GAP,
+      railX: railBase - RAIL_BASE_GUTTER + visualDepth * RAIL_DEPTH_GAP,
+      // Openers are only ever "if" or "each" (BLOCK_OPENERS); narrow for the class.
+      kind: open.range.kind === "each" ? "each" : "if",
     });
   }
   return bands;
@@ -113,7 +131,7 @@ export const TemplateDirectivesOverlay = ({
       {bands.map((band, bandIdx) => (
         <div
           key={`rail:${bandIdx}`}
-          className="folio-template-band-rail"
+          className={`folio-template-band-rail folio-template-band-rail--${band.kind}`}
           style={{
             left: band.railX,
             top: band.top,

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
@@ -27,10 +27,9 @@ import type {
   DirectiveGutterGeometry,
   PageContentBand,
 } from "@stll/folio-core/paged-layout/rangeProjection";
-import {
-  computeBlockDepths,
-  type DirectiveKind,
-  type DirectiveRange,
+import type {
+  DirectiveKind,
+  DirectiveRange,
 } from "@stll/folio-core/prosemirror/plugins/templateDirectives";
 
 export type DirectiveRectGroup = {
@@ -50,6 +49,13 @@ export type TemplateDirectivesOverlayProps = {
    * containing it is emphasised (the "loud on caret" half of the interaction).
    */
   caretPos: number | null;
+  /**
+   * Full list of scanned directive ranges in the document. Pairing and nesting
+   * depth are derived from this authoritative list (not from `groups`, which is
+   * the projected/visible subset), so depth and pairing always reflect what the
+   * document actually contains even while pages are off-screen or unprojected.
+   */
+  ranges: readonly DirectiveRange[];
 };
 
 const overlayStyles: CSSProperties = {
@@ -140,6 +146,12 @@ export type BlockPairing = {
   /** Stable block id: the opener's `from` PM position. */
   blockId: number;
   kind: BandKind;
+  /**
+   * 0-based nesting depth of the opener, recorded during the same pairing walk
+   * (stack size at push time). Sharing one walk with the pairing guarantees the
+   * rail's depth and its opener→closer span can never disagree.
+   */
+  depth: number;
   openerFrom: number;
   closerFrom: number;
   /** Exclusive PM end of the closer marker (band bottom / caret containment). */
@@ -148,11 +160,18 @@ export type BlockPairing = {
   openerExpr: string;
 };
 
+/** One open block awaiting its closer, plus the depth captured when it was pushed. */
+type OpenBlock = { range: DirectiveRange; depth: number };
+
 /**
- * Pair block openers with their closers via a stack (same walk as
- * {@link computeBlockDepths}), so both chips of a pair share a `blockId` and the
- * rail knows its opener→closer PM span. Inline (block:false) and unbalanced
- * markers are dropped. Pure function of the ranges, unit-tested in isolation.
+ * Pair block openers with their closers via a kind-aware stack, so both chips of
+ * a pair share a `blockId`, the rail knows its opener→closer PM span, and each
+ * pairing carries the `depth` recorded in this very walk (never a second,
+ * possibly-divergent depth pass). A closer matches the nearest opener of the same
+ * family ({{/if}} ⇒ {{#if}}, {{/each}} ⇒ {{#each}}) and drops any still-open
+ * openers nested above it; a closer with no matching opener is ignored. This keeps
+ * a mid-edit / unbalanced template from pairing a {{/if}} with an {{#each}}.
+ * Inline (block:false) markers are excluded. Pure function of the ranges.
  */
 export const pairBlockRanges = (ranges: readonly DirectiveRange[]): BlockPairing[] => {
   const blocks = ranges
@@ -161,23 +180,35 @@ export const pairBlockRanges = (ranges: readonly DirectiveRange[]): BlockPairing
     .sort((a, b) => a.from - b.from);
 
   const pairings: BlockPairing[] = [];
-  const stack: DirectiveRange[] = [];
+  const stack: OpenBlock[] = [];
   for (const range of blocks) {
     if (BLOCK_OPENERS.has(range.kind)) {
-      stack.push(range);
+      stack.push({ range, depth: stack.length });
       continue;
     }
-    const opener = stack.pop();
-    if (!opener) {
+    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "each";
+    let matched: OpenBlock | undefined;
+    let matchIdx = -1;
+    for (let i = stack.length - 1; i >= 0; i -= 1) {
+      const entry = stack[i];
+      if (entry?.range.kind === wantOpener) {
+        matched = entry;
+        matchIdx = i;
+        break;
+      }
+    }
+    if (!matched) {
       continue;
     }
+    stack.length = matchIdx;
     pairings.push({
-      blockId: opener.from,
-      kind: bandKindOf(opener.kind),
-      openerFrom: opener.from,
+      blockId: matched.range.from,
+      kind: bandKindOf(matched.range.kind),
+      depth: matched.depth,
+      openerFrom: matched.range.from,
       closerFrom: range.from,
       closerTo: range.to,
-      openerExpr: opener.expr,
+      openerExpr: matched.range.expr,
     });
   }
   return pairings;
@@ -220,16 +251,17 @@ type RailBand = {
 };
 
 /**
- * Assemble the per-page rail segments for every balanced block: pair the ranges,
- * look up opener/closer rects by `from`, place the rail by its budgeted depth,
- * and clip its span to each page. O(ranges); all geometry comes from the props.
+ * Assemble the per-page rail segments for every balanced block: look up
+ * opener/closer rects by `from`, place the rail by the pairing's own budgeted
+ * depth, and clip its span to each page. Depth comes from the pairing (same walk
+ * that matched opener→closer), so a rail's indentation and its span always agree.
+ * O(pairings); all geometry comes from the props.
  */
 const computeRailBands = (
   pairings: readonly BlockPairing[],
   groups: DirectiveRectGroup[],
   gutter: DirectiveGutterGeometry,
 ): RailBand[] => {
-  const depths = computeBlockDepths(groups.map((g) => g.range));
   const groupByFrom = new Map(groups.map((group) => [group.range.from, group]));
 
   const bands: RailBand[] = [];
@@ -239,7 +271,6 @@ const computeRailBands = (
     if (!openerRect || !closerRect) {
       continue;
     }
-    const depth = depths.get(pairing.openerFrom) ?? 0;
     const segments = segmentBandByPages(
       { top: openerRect.y, bottom: closerRect.y + closerRect.height },
       gutter.pageBands,
@@ -250,7 +281,7 @@ const computeRailBands = (
     bands.push({
       blockId: pairing.blockId,
       kind: pairing.kind,
-      railX: railXForDepth(depth, gutter.contentLeft, gutter.marginWidth),
+      railX: railXForDepth(pairing.depth, gutter.contentLeft, gutter.marginWidth),
       segments,
     });
   }
@@ -269,6 +300,7 @@ export const TemplateDirectivesOverlay = ({
   groups,
   gutter,
   caretPos,
+  ranges,
 }: TemplateDirectivesOverlayProps) => {
   const [hoveredBlockId, setHoveredBlockId] = useState<number | null>(null);
 
@@ -276,7 +308,10 @@ export const TemplateDirectivesOverlay = ({
     return null;
   }
 
-  const pairings = pairBlockRanges(groups.map((g) => g.range));
+  // Pair over the full scanned `ranges` (the authoritative document list), not
+  // the projected `groups` subset, so pairing/depth reflect the whole document;
+  // `groups` only supplies rect geometry, looked up by `from` in computeRailBands.
+  const pairings = pairBlockRanges(ranges);
   const railBands = gutter ? computeRailBands(pairings, groups, gutter) : [];
 
   // Block id for every opener/closer chip (both share the opener's id) and the

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -1009,10 +1009,34 @@
   background: color-mix(in srgb, var(--doc-tmpl-loop) 26%, transparent);
 }
 
-/* Left gutter rail spanning a block opener→closer. Kind sets the hue (loop vs
-   condition); nesting depth sets the horizontal offset (inline, in the overlay).
-   pointer-events:auto only on the thin rail — it lives in the left margin, clear
-   of the text column, so hover works without intercepting caret/selection. */
+/* Whole-line block directive chips are hover targets for the paired affordance
+   (hovering a chip lights its twin + rail; closers carry a title hint). They
+   still sit in the text column, so keep the tint faint and only these — inline
+   and field chips stay pointer-events:none so the caret drops through them. */
+.folio-template-directive--block {
+  pointer-events: auto;
+  transition: background-color 120ms ease;
+}
+
+/* Chip emphasis mirrors the rail: brighten the twin chips of the active pair. */
+.folio-template-directive--if.folio-template-directive--active,
+.folio-template-directive--elseif.folio-template-directive--active,
+.folio-template-directive--else.folio-template-directive--active,
+.folio-template-directive--endif.folio-template-directive--active {
+  background: color-mix(in srgb, var(--doc-tmpl-cond) 44%, transparent);
+}
+
+.folio-template-directive--each.folio-template-directive--active,
+.folio-template-directive--endeach.folio-template-directive--active {
+  background: color-mix(in srgb, var(--doc-tmpl-loop) 44%, transparent);
+}
+
+/* Left-margin gutter rail spanning a block opener→closer, one segment per page.
+   Kind sets the hue (loop vs condition); depth sets the horizontal offset and
+   page clipping happen in the overlay. Quiet by default: rails render faint so a
+   deeply nested document is not crowded with loud lines. pointer-events:auto
+   only on the thin rail — it lives in the left margin, clear of the text column,
+   so hover works without intercepting caret/selection. */
 .folio-template-band-rail {
   position: absolute;
   border-radius: 2px;
@@ -1023,23 +1047,23 @@
 }
 
 .folio-template-band-rail--each {
-  background: color-mix(in srgb, var(--doc-tmpl-loop) 52%, transparent);
+  background: color-mix(in srgb, var(--doc-tmpl-loop) 22%, transparent);
 }
 
 .folio-template-band-rail--if {
-  background: color-mix(in srgb, var(--doc-tmpl-cond) 52%, transparent);
+  background: color-mix(in srgb, var(--doc-tmpl-cond) 22%, transparent);
 }
 
-/* Hover intensifies one rail so a single block is easy to trace end-to-end.
-   Pure CSS: alpha bump + a hairline glow that widens the rail without shifting
-   layout (no JS event plumbing). */
-.folio-template-band-rail--each:hover {
-  background: color-mix(in srgb, var(--doc-tmpl-loop) 88%, transparent);
+/* Loud on intent: the innermost block around the caret, or the block whose rail
+   or chip is hovered, gets full strength plus a hairline glow that widens the
+   rail without shifting layout — so one block is easy to trace end-to-end. */
+.folio-template-band-rail--each.folio-template-band-rail--active {
+  background: color-mix(in srgb, var(--doc-tmpl-loop) 90%, transparent);
   box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--doc-tmpl-loop) 45%, transparent);
 }
 
-.folio-template-band-rail--if:hover {
-  background: color-mix(in srgb, var(--doc-tmpl-cond) 88%, transparent);
+.folio-template-band-rail--if.folio-template-band-rail--active {
+  background: color-mix(in srgb, var(--doc-tmpl-cond) 90%, transparent);
   box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--doc-tmpl-cond) 45%, transparent);
 }
 

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -50,6 +50,12 @@
 
   --doc-selection: rgba(37, 99, 235, 0.25);
   --doc-selection-dark-bg: rgba(96, 165, 250, 0.4);
+
+  /* Template block-directive rail/marker hue families: loops read violet,
+     conditions read teal, so a rail's kind is legible before its label. Base
+     hues; overlay CSS mixes them with transparent for the translucent tint. */
+  --doc-tmpl-loop: #7c3aed;
+  --doc-tmpl-cond: #0d9488;
   --doc-find-highlight: rgba(250, 204, 21, 0.5);
   --doc-find-current: rgba(249, 115, 22, 0.6);
   --doc-image-selection: var(--doc-link);
@@ -71,6 +77,10 @@
 .folio-root.dark {
   --doc-link: #60a5fa;
   --doc-selection: rgba(96, 165, 250, 0.3);
+  /* Lift the rail/marker hues on dark canvas so the translucent tint keeps
+     the same perceived contrast (mirrors --doc-link's dark flip). */
+  --doc-tmpl-loop: #a78bfa;
+  --doc-tmpl-cond: #2dd4bf;
 }
 
 .hf-options-button {
@@ -976,24 +986,61 @@
   background: color-mix(in srgb, #0000ff 42%, transparent);
 }
 
-/* Clause slots, numbering markers, and block-directive lines sit a touch
-   softer than fields. */
+/* Clause slots and numbering markers sit a touch softer than fields, still in
+   the blue field family. */
 .folio-template-directive--clause,
 .folio-template-directive--num,
-.folio-template-directive--ref,
-.folio-template-directive--if,
-.folio-template-directive--elseif,
-.folio-template-directive--else,
-.folio-template-directive--endif,
-.folio-template-directive--each,
-.folio-template-directive--endeach {
+.folio-template-directive--ref {
   background: color-mix(in srgb, #0000ff 24%, transparent);
 }
 
+/* Condition directives (if / elseif / else / endif) tint teal, matching their
+   rail, so a marker's role is legible at the chip. */
+.folio-template-directive--if,
+.folio-template-directive--elseif,
+.folio-template-directive--else,
+.folio-template-directive--endif {
+  background: color-mix(in srgb, var(--doc-tmpl-cond) 26%, transparent);
+}
+
+/* Loop directives (each / endeach) tint violet, matching their rail. */
+.folio-template-directive--each,
+.folio-template-directive--endeach {
+  background: color-mix(in srgb, var(--doc-tmpl-loop) 26%, transparent);
+}
+
+/* Left gutter rail spanning a block opener→closer. Kind sets the hue (loop vs
+   condition); nesting depth sets the horizontal offset (inline, in the overlay).
+   pointer-events:auto only on the thin rail — it lives in the left margin, clear
+   of the text column, so hover works without intercepting caret/selection. */
 .folio-template-band-rail {
   position: absolute;
   border-radius: 2px;
-  background: color-mix(in srgb, #0000ff 50%, transparent);
+  pointer-events: auto;
+  transition:
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.folio-template-band-rail--each {
+  background: color-mix(in srgb, var(--doc-tmpl-loop) 52%, transparent);
+}
+
+.folio-template-band-rail--if {
+  background: color-mix(in srgb, var(--doc-tmpl-cond) 52%, transparent);
+}
+
+/* Hover intensifies one rail so a single block is easy to trace end-to-end.
+   Pure CSS: alpha bump + a hairline glow that widens the rail without shifting
+   layout (no JS event plumbing). */
+.folio-template-band-rail--each:hover {
+  background: color-mix(in srgb, var(--doc-tmpl-loop) 88%, transparent);
+  box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--doc-tmpl-loop) 45%, transparent);
+}
+
+.folio-template-band-rail--if:hover {
+  background: color-mix(in srgb, var(--doc-tmpl-cond) 88%, transparent);
+  box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--doc-tmpl-cond) 45%, transparent);
 }
 
 /* ── Template fill preview ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Reworks the template-directives overlay so nested block directives read as structure instead of a wall of identical vertical lines:

- **Depth-indented rails in a margin budget.** Rails fan left from a fixed clearance off the text edge (never into the text column), offset per nesting level with the budget derived from the actual page margin width. Pure helpers (`computeBlockDepths`, `railBudgetDepth`, `railXForDepth`) are exported and unit-tested.
- **Kind-based colour.** Loops (`{{#each}}`) render in a violet family, conditions (`{{#if}}`) in teal; tokens follow the existing `--doc-*` dark-flip pattern so both themes stay correct.
- **Quiet by default, loud on intent.** All rails render faint; the block containing the caret, or the block whose rail/chip is hovered, renders at full strength. Deeply nested documents no longer show a picket fence.
- **Page-aware segments.** Bands are clipped to each page's content box (`measureDirectiveGutter` reads the page-content rects once per overlay update), so no rail crosses a page header, footer, or the inter-page gap; each segment has rounded caps.
- **Paired chips.** Hovering an opener or closer chip highlights both plus their rail; bare closers carry a hover hint of what they close (e.g. `/if · hasVerdicts`). Only whole-line block chips become pointer targets; inline and field chips keep `pointer-events: none`.

## Tests

- Core plugin + paged-layout: 219 pass (includes 5 new depth tests).
- React paged-editor: 76 pass, including 18 new tests for the pure segmentation/budget/pairing/caret-containment helpers.
- Typecheck + oxlint + oxfmt clean on all changed files.

Changeset: minor for both packages.