### PR TITLE
fix(core): apply table style paragraph spacing to cell paragraphs

### DIFF
--- a/.changeset/tame-plants-nap.md
+++ b/.changeset/tame-plants-nap.md
@@ -1,0 +1,17 @@
+---
+"@stll/folio-core": patch
+---
+
+fix(core): apply table style paragraph spacing to cell paragraphs
+
+Table cells now inherit paragraph spacing (space-after, line spacing,
+contextual spacing) from the enclosing table style's `w:pPr` — and from the
+applicable `w:tblStylePr` conditional region (first row, banding, etc.) —
+instead of falling through to `docDefaults`. Per ECMA-376 §17.7.2 this table
+style layer sits between docDefaults and the cell paragraph's own style
+chain/direct formatting, so an explicit paragraph style or direct spacing on
+the paragraph still wins. Previously, cell paragraphs with neither a
+`w:pStyle` nor a direct `w:pPr` picked up the document's default paragraph
+spacing (e.g. Word's default ~10pt space-after and 1.15x line spacing)
+instead of the table style's typically compact spacing (e.g. `TableGrid`'s
+zero space-after / single line), inflating table row heights.

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -563,6 +563,7 @@ export class StyleResolver {
     getTableStyles(): import__stll_docx_core_model.Style[];
     hasStyle(styleId: string): boolean;
     resolveParagraphStyle(styleId: string | undefined | null): ResolvedParagraphStyle;
+    resolveParagraphStyleInTable(styleId: string | undefined | null, tableParagraphOverlay: TableCellParagraphSpacingOverlay | undefined): ResolvedParagraphStyle;
     resolveRunStyle(styleId: string | undefined | null): import__stll_docx_core_model.TextFormatting | undefined;
 }
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -594,3 +594,136 @@ describe("toFlowBlocks style cascade", () => {
     }
   });
 });
+
+describe("table style paragraph spacing cascade (cell paragraphs)", () => {
+  // Mirrors the real-world TableNormal -> TableGrid cascade: docDefaults
+  // give every paragraph 200-twip space-after and 1.15x (276) line spacing;
+  // TableGrid (based on TableNormal) zeroes both out for its cells. Per
+  // ECMA-376 §17.7.2 the table style's own `w:pPr` sits between docDefaults
+  // and the paragraph's style chain/direct formatting — see
+  // `resolveParagraphStyleInTable` in styleResolver.ts.
+  const styles: StyleDefinitions = {
+    docDefaults: {
+      pPr: { spaceAfter: 200, lineSpacing: 276, lineSpacingRule: "auto" },
+    },
+    styles: [
+      {
+        styleId: "TableNormal",
+        type: "table",
+        name: "Table Normal",
+      },
+      {
+        styleId: "TableGrid",
+        type: "table",
+        name: "Table Grid",
+        basedOn: "TableNormal",
+        pPr: { spaceAfter: 0, lineSpacing: 240, lineSpacingRule: "auto" },
+      },
+      {
+        styleId: "CellStyle",
+        type: "paragraph",
+        name: "Cell Style",
+        pPr: { spaceAfter: 100 },
+      },
+    ],
+  };
+
+  function buildDocument(): Document {
+    const table: Table = {
+      type: "table",
+      formatting: { styleId: "TableGrid" },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              // (a) No pStyle, no direct pPr — must resolve to the table
+              // style's spacing, not docDefaults. This is the bug.
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "run", content: [{ type: "text", text: "no style" }] }],
+                },
+              ],
+            },
+            {
+              // (b) Explicit paragraph style sets its own space-after — the
+              // style must win over the table overlay for that field.
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  formatting: { styleId: "CellStyle" },
+                  content: [{ type: "run", content: [{ type: "text", text: "styled" }] }],
+                },
+              ],
+            },
+            {
+              // (c) Direct pPr spacing — must win over the table overlay
+              // (and over any style).
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  formatting: { spaceAfter: 50 },
+                  content: [{ type: "run", content: [{ type: "text", text: "direct" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const baselineParagraph: Paragraph = {
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text: "outside the table" }] }],
+    };
+    return {
+      package: {
+        document: { content: [baselineParagraph, table] },
+        styles,
+      },
+    };
+  }
+
+  test("cell paragraph with no style and no direct pPr resolves to the table style's spacing", () => {
+    const pmDoc = toProseDoc(buildDocument(), { styles });
+    const table = pmDoc.content.child(1);
+    const cell = table.content.child(0).content.child(0);
+    const paragraph = cell.content.child(0);
+
+    expect(paragraph.attrs["spaceAfter"]).toBe(0);
+    expect(paragraph.attrs["lineSpacing"]).toBe(240);
+    expect(paragraph.attrs["lineSpacingRule"]).toBe("auto");
+  });
+
+  test("an explicit paragraph style still wins over the table overlay", () => {
+    const pmDoc = toProseDoc(buildDocument(), { styles });
+    const table = pmDoc.content.child(1);
+    const cell = table.content.child(0).content.child(1);
+    const paragraph = cell.content.child(0);
+
+    // The style only sets spaceAfter — it wins for that field...
+    expect(paragraph.attrs["spaceAfter"]).toBe(100);
+    // ...but the table overlay still supplies fields the style leaves unset.
+    expect(paragraph.attrs["lineSpacing"]).toBe(240);
+  });
+
+  test("direct paragraph formatting wins over both the table overlay and any style", () => {
+    const pmDoc = toProseDoc(buildDocument(), { styles });
+    const table = pmDoc.content.child(1);
+    const cell = table.content.child(0).content.child(2);
+    const paragraph = cell.content.child(0);
+
+    expect(paragraph.attrs["spaceAfter"]).toBe(50);
+  });
+
+  test("a non-table paragraph is unaffected and still resolves to docDefaults", () => {
+    const pmDoc = toProseDoc(buildDocument(), { styles });
+    const baselineParagraph = pmDoc.content.child(0);
+
+    expect(baselineParagraph.attrs["spaceAfter"]).toBe(200);
+    expect(baselineParagraph.attrs["lineSpacing"]).toBe(276);
+  });
+});

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -15,12 +15,13 @@
 import type { MarkType, Node as PMNode } from "prosemirror-model";
 
 import { createStyleEngine } from "../../style-engine";
-import type { StyleEngine } from "../../style-engine";
+import type { StyleEngine, TableCellParagraphSpacingOverlay } from "../../style-engine";
 import type {
   BlockContent,
   BlockSdt,
   Document,
   Paragraph,
+  ParagraphFormatting,
   Run,
   TextFormatting,
   RunContent,
@@ -46,6 +47,7 @@ import type {
   Theme,
 } from "../../types/document";
 import { resolveColor } from "../../utils/colorResolver";
+import { mergeParagraphFormatting } from "../../utils/paragraphFormattingMerge";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
 import { setAutospacingBaseValue } from "../autospacingBase";
@@ -193,8 +195,9 @@ function convertParagraph(
   styleResolver: StyleEngine | null,
   activeCommentIds?: Set<number>,
   extraRunFormatting?: TextFormatting,
+  tableParagraphOverlay?: TableCellParagraphSpacingOverlay,
 ): PMNode {
-  const attrs = paragraphFormattingToAttrs(paragraph, styleResolver);
+  const attrs = paragraphFormattingToAttrs(paragraph, styleResolver, tableParagraphOverlay);
   const inlineNodes: PMNode[] = [];
   let inlineOffset = 0;
   let bookmarksArr: { id: number; name: string }[] | undefined;
@@ -423,6 +426,7 @@ function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
 function paragraphFormattingToAttrs(
   paragraph: Paragraph,
   styleResolver: StyleEngine | null,
+  tableParagraphOverlay?: TableCellParagraphSpacingOverlay,
 ): ParagraphAttrs {
   const formatting = paragraph.formatting;
   const styleId = formatting?.styleId;
@@ -515,10 +519,13 @@ function paragraphFormattingToAttrs(
     }
   };
 
-  // If we have a style resolver, resolve the style and get base properties
+  // If we have a style resolver, resolve the style and get base properties.
+  // Cell paragraphs (`tableParagraphOverlay` set) layer the enclosing table
+  // style's paragraph-spacing fields in between docDefaults and this
+  // paragraph's own style chain — see resolveParagraphStyleInTable.
   let stylePpr: Paragraph["formatting"] | undefined;
   if (styleResolver) {
-    const resolved = styleResolver.resolveParagraphStyle(styleId);
+    const resolved = styleResolver.resolveParagraphStyleInTable(styleId, tableParagraphOverlay);
     stylePpr = resolved.paragraphFormatting;
 
     // Apply style-based values as defaults (inline overrides)
@@ -638,13 +645,56 @@ function paragraphFormattingToAttrs(
 // ============================================================================
 
 /**
+ * A table style's (or one of its `w:tblStylePr` conditional regions')
+ * contribution to cell formatting: cell properties, run defaults, and — for
+ * the table-row-height fix — the paragraph-spacing overlay described on
+ * {@link TableCellParagraphSpacingOverlay}.
+ */
+type TableConditionalStyle = {
+  tcPr?: TableCellFormatting;
+  rPr?: TextFormatting;
+  pPr?: TableCellParagraphSpacingOverlay;
+};
+
+/**
+ * Pick the paragraph-spacing fields out of a table style's (or conditional
+ * region's) `w:pPr` for use as the cell-paragraph cascade overlay. Narrower
+ * than the full `ParagraphFormatting` bag — see
+ * {@link TableCellParagraphSpacingOverlay}.
+ */
+function extractTableParagraphSpacingOverlay(
+  pPr: ParagraphFormatting | undefined,
+): TableCellParagraphSpacingOverlay | undefined {
+  if (!pPr) {
+    return undefined;
+  }
+  const overlay: TableCellParagraphSpacingOverlay = {};
+  if (pPr.spaceBefore !== undefined) {
+    overlay.spaceBefore = pPr.spaceBefore;
+  }
+  if (pPr.spaceAfter !== undefined) {
+    overlay.spaceAfter = pPr.spaceAfter;
+  }
+  if (pPr.lineSpacing !== undefined) {
+    overlay.lineSpacing = pPr.lineSpacing;
+  }
+  if (pPr.lineSpacingRule !== undefined) {
+    overlay.lineSpacingRule = pPr.lineSpacingRule;
+  }
+  if (pPr.contextualSpacing !== undefined) {
+    overlay.contextualSpacing = pPr.contextualSpacing;
+  }
+  return Object.keys(overlay).length > 0 ? overlay : undefined;
+}
+
+/**
  * Resolve table style conditional formatting
  */
 function resolveTableStyleConditional(
   styleResolver: StyleEngine | null,
   tableStyleId: string | undefined,
   conditionType: string,
-): { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined {
+): TableConditionalStyle | undefined {
   if (!styleResolver || !tableStyleId) {
     return undefined;
   }
@@ -666,13 +716,17 @@ function resolveTableStyleConditional(
     ? resolveTextFormatting(conditional.rPr, styleResolver)
     : undefined;
   const mergedRunProps = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
+  const paragraphSpacingOverlay = extractTableParagraphSpacingOverlay(conditional.pPr);
 
-  const result: { tcPr?: TableCellFormatting; rPr?: TextFormatting } = {};
+  const result: TableConditionalStyle = {};
   if (conditional.tcPr) {
     result.tcPr = conditional.tcPr;
   }
   if (mergedRunProps) {
     result.rPr = mergedRunProps;
+  }
+  if (paragraphSpacingOverlay) {
+    result.pPr = paragraphSpacingOverlay;
   }
   return result;
 }
@@ -680,7 +734,7 @@ function resolveTableStyleConditional(
 function resolveTableBaseStyle(
   styleResolver: StyleEngine | null,
   tableStyleId: string | undefined,
-): { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined {
+): TableConditionalStyle | undefined {
   if (!styleResolver || !tableStyleId) {
     return undefined;
   }
@@ -695,21 +749,25 @@ function resolveTableBaseStyle(
     : undefined;
   const resolvedRpr = style.rPr ? resolveTextFormatting(style.rPr, styleResolver) : undefined;
   const mergedRunProps = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
+  const paragraphSpacingOverlay = extractTableParagraphSpacingOverlay(style.pPr);
 
-  const result: { tcPr?: TableCellFormatting; rPr?: TextFormatting } = {};
+  const result: TableConditionalStyle = {};
   if (style.tcPr) {
     result.tcPr = style.tcPr;
   }
   if (mergedRunProps) {
     result.rPr = mergedRunProps;
   }
-  return result.tcPr || result.rPr ? result : undefined;
+  if (paragraphSpacingOverlay) {
+    result.pPr = paragraphSpacingOverlay;
+  }
+  return result.tcPr || result.rPr || result.pPr ? result : undefined;
 }
 
 function mergeConditionalStyles(
-  base?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
-  override?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
-): { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined {
+  base?: TableConditionalStyle,
+  override?: TableConditionalStyle,
+): TableConditionalStyle | undefined {
   if (!base && !override) {
     return undefined;
   }
@@ -720,7 +778,7 @@ function mergeConditionalStyles(
     return base;
   }
 
-  const merged: { tcPr?: TableCellFormatting; rPr?: TextFormatting } = {};
+  const merged: TableConditionalStyle = {};
 
   const baseTcPr = base.tcPr;
   const overrideTcPr = override.tcPr;
@@ -757,6 +815,14 @@ function mergeConditionalStyles(
   const mergedRPr = mergeTextFormatting(base.rPr, override.rPr);
   if (mergedRPr) {
     merged.rPr = mergedRPr;
+  }
+
+  // `override` (a more specific conditional region, e.g. firstRow) wins per
+  // field over `base` (e.g. the table's wholeTable region or base style),
+  // matching the tcPr/rPr merges above — see extractTableParagraphSpacingOverlay.
+  const mergedPPr = mergeParagraphFormatting(base.pPr, override.pPr);
+  if (mergedPPr) {
+    merged.pPr = mergedPPr;
   }
 
   return merged;
@@ -1108,21 +1174,20 @@ function convertTable(
     attrs._originalFormatting = table.formatting;
   }
 
-  type CondStyle = { tcPr?: TableCellFormatting; rPr?: TextFormatting };
   const conditionalStyles: {
-    wholeTable?: CondStyle;
-    firstRow?: CondStyle;
-    lastRow?: CondStyle;
-    firstCol?: CondStyle;
-    lastCol?: CondStyle;
-    band1Horz?: CondStyle;
-    band2Horz?: CondStyle;
-    band1Vert?: CondStyle;
-    band2Vert?: CondStyle;
-    nwCell?: CondStyle;
-    neCell?: CondStyle;
-    swCell?: CondStyle;
-    seCell?: CondStyle;
+    wholeTable?: TableConditionalStyle;
+    firstRow?: TableConditionalStyle;
+    lastRow?: TableConditionalStyle;
+    firstCol?: TableConditionalStyle;
+    lastCol?: TableConditionalStyle;
+    band1Horz?: TableConditionalStyle;
+    band2Horz?: TableConditionalStyle;
+    band1Vert?: TableConditionalStyle;
+    band2Vert?: TableConditionalStyle;
+    nwCell?: TableConditionalStyle;
+    neCell?: TableConditionalStyle;
+    swCell?: TableConditionalStyle;
+    seCell?: TableConditionalStyle;
   } = {};
   const setCS = (key: keyof typeof conditionalStyles, type: string): void => {
     const val = resolveTableStyleConditional(styleResolver, conditionalTableStyleId, type);
@@ -1224,21 +1289,21 @@ function convertTableRow(
   columnWidths?: number[],
   totalWidth?: number,
   conditionalStyles?: {
-    wholeTable?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    firstRow?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    lastRow?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    firstCol?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    lastCol?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    band1Horz?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    band2Horz?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    band1Vert?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    band2Vert?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    nwCell?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    neCell?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    swCell?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
-    seCell?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
+    wholeTable?: TableConditionalStyle;
+    firstRow?: TableConditionalStyle;
+    lastRow?: TableConditionalStyle;
+    firstCol?: TableConditionalStyle;
+    lastCol?: TableConditionalStyle;
+    band1Horz?: TableConditionalStyle;
+    band2Horz?: TableConditionalStyle;
+    band1Vert?: TableConditionalStyle;
+    band2Vert?: TableConditionalStyle;
+    nwCell?: TableConditionalStyle;
+    neCell?: TableConditionalStyle;
+    swCell?: TableConditionalStyle;
+    seCell?: TableConditionalStyle;
   },
-  rowBandStyle?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
+  rowBandStyle?: TableConditionalStyle,
   bandingEnabledV?: boolean,
   tableLook?: TableLook,
   tableBorders?: TableBorders,
@@ -1336,7 +1401,7 @@ function convertTableRow(
     const cellIsLastCol = cellCnf?.lastColumn ?? isLastCol;
 
     // Determine vertical banding style based on column index
-    let vertBandStyle: { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined;
+    let vertBandStyle: TableConditionalStyle | undefined;
     if (bandingEnabledV) {
       const firstColOffset = tableLook?.firstColumn ? 1 : 0;
       const bandColIndex = colIndex - colspan - firstColOffset;
@@ -1509,7 +1574,7 @@ function convertTableCell(
   styleResolver: StyleEngine | null,
   isHeader: boolean,
   gridWidthPercent?: number,
-  conditionalStyle?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
+  conditionalStyle?: TableConditionalStyle,
   tableBorders?: TableBorders,
   isFirstRow?: boolean,
   isLastRow?: boolean,
@@ -1642,7 +1707,9 @@ function convertTableCell(
   const contentNodes: PMNode[] = [];
   for (const content of cell.content) {
     if (content.type === "paragraph") {
-      contentNodes.push(convertParagraph(content, styleResolver, undefined, conditionalStyle?.rPr));
+      contentNodes.push(
+        convertParagraph(content, styleResolver, undefined, conditionalStyle?.rPr, conditionalStyle?.pPr),
+      );
     } else {
       // Nested tables - recursively convert
       contentNodes.push(convertTable(content, styleResolver, theme));

--- a/packages/core/src/prosemirror/styles/styleResolver.ts
+++ b/packages/core/src/prosemirror/styles/styleResolver.ts
@@ -8,6 +8,11 @@
  * 3. Style chain (basedOn inheritance - already resolved by styleParser)
  * 4. Inline properties
  *
+ * For paragraphs inside a table cell, `resolveParagraphStyleInTable` inserts
+ * an additional layer between docDefaults and the Normal/style chain: the
+ * enclosing table style's own paragraph-spacing (`w:pPr`). See its doc
+ * comment for the full cascade order.
+ *
  * Based on ECMA-376 style cascade rules.
  */
 
@@ -30,6 +35,26 @@ export type ResolvedParagraphStyle = {
   /** Default run formatting from the style */
   runFormatting?: TextFormatting;
 };
+
+/**
+ * Paragraph-spacing fields sourced from the table style enclosing a cell
+ * paragraph: the table style's own `w:pPr`, then the applicable
+ * `w:tblStylePr` conditional region's `w:pPr` layered on top (already merged
+ * by the caller — see `resolveTableBaseStyle`/`resolveTableStyleConditional`
+ * in toProseDoc.ts).
+ *
+ * Deliberately narrower than the full {@link ParagraphFormatting}: this is
+ * the layer-2 overlay described on {@link StyleResolver.resolveParagraphStyleInTable}
+ * and is scoped to the spacing fields responsible for folio's table-row
+ * height bug (table styles like Word's `TableGrid` zero these out relative
+ * to `docDefaults`). Alignment, indentation, borders, etc. are out of scope
+ * here — applying the whole `pPr` would risk regressing unrelated cell
+ * layout that isn't part of this fix.
+ */
+export type TableCellParagraphSpacingOverlay = Pick<
+  ParagraphFormatting,
+  "spaceBefore" | "spaceAfter" | "lineSpacing" | "lineSpacingRule" | "contextualSpacing"
+>;
 
 /**
  * Word's default-template Normal style, used as a last-resort fallback for a
@@ -120,9 +145,47 @@ export class StyleResolver {
    * @returns Resolved paragraph and run formatting
    */
   resolveParagraphStyle(styleId: string | undefined | null): ResolvedParagraphStyle {
+    return this.resolveParagraphStyleCascade(styleId, undefined);
+  }
+
+  /**
+   * Resolve paragraph style properties for a paragraph inside a table cell,
+   * layering the enclosing table style's paragraph-spacing fields into the
+   * cascade between docDefaults and the paragraph's own style chain.
+   *
+   * Per ECMA-376 §17.7.2, a cell paragraph's properties resolve in this
+   * order (later wins):
+   *   1. docDefaults (`w:pPrDefault`)
+   *   2. the enclosing table style's `w:pPr` (`tableParagraphOverlay`, here)
+   *   3. the paragraph's own style chain (`w:pStyle` + `basedOn` ancestors)
+   *   4. direct formatting on the paragraph (`w:pPr`)
+   *
+   * Layer 4 is applied by the caller (`paragraphFormattingToAttrs`), which
+   * already prefers the paragraph's direct formatting over this method's
+   * result. Layer 3 is applied below, after the overlay, so an explicit
+   * paragraph style still wins over the table for any field it sets.
+   *
+   * @param styleId - The paragraph's style ID (e.g., 'Heading1', 'Normal')
+   * @param tableParagraphOverlay - Paragraph-spacing fields from the
+   *   enclosing table style (base `pPr` merged with the applicable
+   *   conditional region), or `undefined` when the paragraph isn't in a
+   *   table cell, the table has no style, or the style sets no spacing.
+   * @returns Resolved paragraph and run formatting
+   */
+  resolveParagraphStyleInTable(
+    styleId: string | undefined | null,
+    tableParagraphOverlay: TableCellParagraphSpacingOverlay | undefined,
+  ): ResolvedParagraphStyle {
+    return this.resolveParagraphStyleCascade(styleId, tableParagraphOverlay);
+  }
+
+  private resolveParagraphStyleCascade(
+    styleId: string | undefined | null,
+    tableParagraphOverlay: TableCellParagraphSpacingOverlay | undefined,
+  ): ResolvedParagraphStyle {
     const result: ResolvedParagraphStyle = {};
 
-    // Start with document defaults
+    // Layer 1: document defaults
     if (this.docDefaults?.pPr) {
       result.paragraphFormatting = { ...this.docDefaults.pPr };
     }
@@ -130,7 +193,16 @@ export class StyleResolver {
       result.runFormatting = { ...this.docDefaults.rPr };
     }
 
-    // If no styleId, apply Normal style (if exists)
+    // Layer 2: enclosing table style's paragraph spacing (cell paragraphs
+    // only — undefined for everything else, a no-op here).
+    if (tableParagraphOverlay) {
+      const merged = mergeParagraphFormatting(result.paragraphFormatting, tableParagraphOverlay);
+      if (merged !== undefined) {
+        result.paragraphFormatting = merged;
+      }
+    }
+
+    // Layer 3: the paragraph's own style chain (Normal when styleId is absent)
     if (!styleId) {
       if (this.defaultParagraphStyle) {
         this.mergeStyleIntoResult(result, this.defaultParagraphStyle);

--- a/packages/core/src/style-engine/index.ts
+++ b/packages/core/src/style-engine/index.ts
@@ -10,4 +10,7 @@ export {
   type StyleEngineCacheStats,
   type StyleEngineOptions,
 } from "./styleEngine";
-export type { ResolvedParagraphStyle } from "../prosemirror/styles/styleResolver";
+export type {
+  ResolvedParagraphStyle,
+  TableCellParagraphSpacingOverlay,
+} from "../prosemirror/styles/styleResolver";

--- a/packages/core/src/style-engine/styleEngine.ts
+++ b/packages/core/src/style-engine/styleEngine.ts
@@ -16,7 +16,11 @@
  * one at a time.
  */
 
-import type { ResolvedParagraphStyle, StyleResolver } from "../prosemirror/styles/styleResolver";
+import type {
+  ResolvedParagraphStyle,
+  StyleResolver,
+  TableCellParagraphSpacingOverlay,
+} from "../prosemirror/styles/styleResolver";
 import { createStyleResolver } from "../prosemirror/styles/styleResolver";
 import type { DocDefaults, Style, StyleDefinitions, TextFormatting } from "../types/document";
 
@@ -86,6 +90,22 @@ export type StyleEngine = {
    */
   resolveParagraphStyle: (styleId: string | undefined | null) => ResolvedParagraphStyle;
   /**
+   * Resolve the paragraph cascade for a paragraph inside a table cell,
+   * layering the enclosing table style's paragraph-spacing fields between
+   * docDefaults and the paragraph's own style chain — see
+   * {@link StyleResolver.resolveParagraphStyleInTable}.
+   *
+   * Pass the *same* `tableParagraphOverlay` object reference for every
+   * paragraph governed by the same table style region (folio's table
+   * conversion already computes it once per region) — the cache below keys
+   * on object identity, so a fresh object per call defeats memoization.
+   * Returned object is cached and must not be mutated.
+   */
+  resolveParagraphStyleInTable: (
+    styleId: string | undefined | null,
+    tableParagraphOverlay: TableCellParagraphSpacingOverlay | undefined,
+  ) => ResolvedParagraphStyle;
+  /**
    * Resolve a run/character style with docDefaults applied.
    * Returns `undefined` when the cascade yields nothing.
    */
@@ -126,6 +146,16 @@ export function createStyleEngine(
   const paragraphCache = new Map<string, Cached<ResolvedParagraphStyle>>();
   const runCache = new Map<string, Cached<TextFormatting | undefined>>();
   const ownPropsCache = new Map<string, Cached<TextFormatting | undefined>>();
+  // Keyed by the overlay object's identity (not its contents) since table
+  // conversion computes one overlay object per style region and reuses it
+  // across every cell/paragraph in that region — see the interface doc
+  // comment on `resolveParagraphStyleInTable`. A `let` (not `const`) so
+  // `invalidate()` can drop every entry without a `WeakMap.clear()`, which
+  // doesn't exist.
+  let tableOverlayCache = new WeakMap<
+    TableCellParagraphSpacingOverlay,
+    Map<string, Cached<ResolvedParagraphStyle>>
+  >();
 
   let hits = 0;
   let misses = 0;
@@ -146,6 +176,24 @@ export function createStyleEngine(
     return value;
   };
 
+  const memoizeInTable = (
+    styleId: string | undefined | null,
+    tableParagraphOverlay: TableCellParagraphSpacingOverlay,
+  ): ResolvedParagraphStyle => {
+    if (!cacheEnabled) {
+      misses += 1;
+      return resolver.resolveParagraphStyleInTable(styleId, tableParagraphOverlay);
+    }
+    let overlayCache = tableOverlayCache.get(tableParagraphOverlay);
+    if (!overlayCache) {
+      overlayCache = new Map();
+      tableOverlayCache.set(tableParagraphOverlay, overlayCache);
+    }
+    return memoize(overlayCache, cacheKey(styleId), () =>
+      resolver.resolveParagraphStyleInTable(styleId, tableParagraphOverlay),
+    );
+  };
+
   return {
     getStyle: (styleId) => resolver.getStyle(styleId),
     hasStyle: (styleId) => resolver.hasStyle(styleId),
@@ -158,6 +206,12 @@ export function createStyleEngine(
 
     resolveParagraphStyle: (styleId) =>
       memoize(paragraphCache, cacheKey(styleId), () => resolver.resolveParagraphStyle(styleId)),
+    resolveParagraphStyleInTable: (styleId, tableParagraphOverlay) =>
+      tableParagraphOverlay === undefined
+        ? memoize(paragraphCache, cacheKey(styleId), () =>
+            resolver.resolveParagraphStyleInTable(styleId, undefined),
+          )
+        : memoizeInTable(styleId, tableParagraphOverlay),
     resolveRunStyle: (styleId) =>
       memoize(runCache, cacheKey(styleId), () => resolver.resolveRunStyle(styleId)),
     getRunStyleOwnProperties: (styleId) =>
@@ -167,12 +221,19 @@ export function createStyleEngine(
       paragraphCache.clear();
       runCache.clear();
       ownPropsCache.clear();
+      // WeakMap has no `.clear()` — drop the whole map so stale per-overlay
+      // caches from a previous style resolution can't leak forward.
+      tableOverlayCache = new WeakMap();
       hits = 0;
       misses = 0;
     },
     stats: () => ({
       hits,
       misses,
+      // Table-overlay entries live in a WeakMap keyed by overlay object
+      // identity and aren't enumerable, so they're intentionally excluded
+      // from this count — it undercounts total cache size whenever
+      // resolveParagraphStyleInTable has been used with an overlay.
       size: paragraphCache.size + runCache.size + ownPropsCache.size,
     }),
   };


### PR DESCRIPTION
## What

Table rows rendered ~2× taller than Microsoft Word on documents whose
`docDefaults` carry non-trivial paragraph spacing. A cell paragraph with no
`w:pStyle` and no direct `w:pPr` fell straight through to `docDefaults`,
skipping the enclosing table style's own `w:pPr` — the layer Word uses to
compact cells (e.g. `TableGrid` zeroing space-after and line spacing relative
to `docDefaults`). Each cell paragraph therefore picked up ~10pt space-after
plus inflated line spacing, cascading down the page.

## Fix

Add `resolveParagraphStyleInTable` (a sibling of `resolveParagraphStyle`) that
layers a table-style paragraph-spacing overlay into the cascade per
ECMA-376 §17.7.2:

1. docDefaults
2. enclosing table style's `pPr` (new)
3. paragraph style chain (`pStyle` + `basedOn`)
4. direct formatting

Layers 3 and 4 still win over the overlay for any field they set, so an
explicit paragraph style or direct spacing on a cell paragraph is unaffected.
The overlay is scoped to `spaceBefore` / `spaceAfter` / `lineSpacing` /
`lineSpacingRule` / `contextualSpacing` — not the whole `pPr` — to avoid
touching unrelated cell layout (alignment, indentation, borders).

`resolveTableBaseStyle` / `resolveTableStyleConditional` now surface these
fields from the table style's own `pPr` and the applicable `tblStylePr`
conditional region instead of discarding them; the merged overlay threads
through `convertTableCell` → `convertParagraph` → `paragraphFormattingToAttrs`.

## Tests

New regression tests in `toFlowBlocks-style-cascade.test.ts` cover the
precedence: (a) no style / no direct `pPr` resolves to the table overlay (the
bug), (b) an explicit paragraph style wins over the overlay, (c) direct
formatting wins over both, and (d) a non-table paragraph is unaffected.

Full `@stll/folio-core` suite (2783 tests) green; `test:differential` (parse
parity) 31/31 green; typecheck and lint clean.
