### PR TITLE
fix(core): single-line-height parity with Word (hhea metrics + CJK font-linking)

### DIFF
--- a/.changeset/cjk-line-height-fallback.md
+++ b/.changeset/cjk-line-height-fallback.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+fix(core): use a CJK font's line height for CJK text in non-CJK-font runs

--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -2,4 +2,15 @@
 "@stll/folio-core": patch
 ---
 
-fix(core): derive single-line height from real font hhea metrics (corrects Cambria, Palatino, Arial, Times, and 4 more)
+fix(core): derive single-line height from real font hhea metrics
+
+Single-line height per font is now derived from the font's real `hhea`
+metrics `(ascent + |descent| + lineGap) / unitsPerEm` — the value Word uses —
+instead of hand-transcribed constants, several of which dropped the line gap
+or were otherwise wrong. Corrects 9 fonts (measured against Word): Palatino
+Linotype (was 31% short), Book Antiqua (17%), Cambria (8%), Century Gothic
+(6%), Times New Roman (4%), Arial (3%), Trebuchet MS (2%), Consolas (1%), and
+Lucida Console (14% tall). A shared derivation and a discriminated `hhea` /
+`legacy` representation make it structurally impossible to silently drop a
+term again. CJK fonts are unchanged (their line height is an East-Asian
+layout concern, not a run-font hhea ratio).

--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-fix(core): include font line gap in Arial/Times New Roman single-line height
+fix(core): derive single-line height from real font hhea metrics (corrects Cambria, Palatino, Arial, Times, and 4 more)

--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+fix(core): include font line gap in Arial/Times New Roman single-line height

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ParagraphBlock, Run } from "../types";
-import { smallCapsAwareCharWidth, withFakeTextMeasure, fixedCharWidth } from "./__tests__/fakeTextMeasure";
+import {
+  smallCapsAwareCharWidth,
+  withFakeTextMeasure,
+  fixedCharWidth,
+} from "./__tests__/fakeTextMeasure";
 import { hashParagraphBlock } from "./cache";
 import { buildFontString } from "./measureHelpers";
 import { clampFloatingWrapMargins, getRunCharWidths, measureParagraph } from "./measureParagraph";
@@ -932,50 +936,164 @@ describe("all-caps paragraph measurement", () => {
 
 describe("CJK line breaking", () => {
   test("fills the remaining width on a line before wrapping CJK characters", () => {
-    withFakeTextMeasure(() => {
-      const block: ParagraphBlock = {
-        kind: "paragraph",
-        id: "cjk-wrap",
-        pmStart: 0,
-        pmEnd: 8,
-        runs: [
-          { kind: "text", text: "AAAA" },
-          { kind: "text", text: "一二三四", eastAsiaFontFamily: "MS Mincho" },
-        ],
-      };
+    withFakeTextMeasure(
+      () => {
+        const block: ParagraphBlock = {
+          kind: "paragraph",
+          id: "cjk-wrap",
+          pmStart: 0,
+          pmEnd: 8,
+          runs: [
+            { kind: "text", text: "AAAA" },
+            { kind: "text", text: "一二三四", eastAsiaFontFamily: "MS Mincho" },
+          ],
+        };
 
-      const measure = measureParagraph(block, 50);
+        const measure = measureParagraph(block, 50);
 
-      expect(measure.lines).toHaveLength(2);
-      expect(measure.lines[0]?.toRun).toBe(1);
-      expect(measure.lines[0]?.toChar).toBe(1);
-      expect(measure.lines[1]?.fromRun).toBe(1);
-      expect(measure.lines[1]?.fromChar).toBe(1);
-      expect(measure.lines[1]?.toChar).toBe(4);
-    }, { charWidth: fixedCharWidth(10) });
+        expect(measure.lines).toHaveLength(2);
+        expect(measure.lines[0]?.toRun).toBe(1);
+        expect(measure.lines[0]?.toChar).toBe(1);
+        expect(measure.lines[1]?.fromRun).toBe(1);
+        expect(measure.lines[1]?.fromChar).toBe(1);
+        expect(measure.lines[1]?.toChar).toBe(4);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
   });
 
   test("does not wrap preceding Latin text when the next CJK character does not fit", () => {
+    withFakeTextMeasure(
+      () => {
+        const block: ParagraphBlock = {
+          kind: "paragraph",
+          id: "cjk-wrap-boundary",
+          pmStart: 0,
+          pmEnd: 8,
+          runs: [
+            { kind: "text", text: "AAAA" },
+            { kind: "text", text: "一二三四", eastAsiaFontFamily: "MS Mincho" },
+          ],
+        };
+
+        const measure = measureParagraph(block, 45);
+
+        expect(measure.lines).toHaveLength(2);
+        expect(measure.lines[0]?.toRun).toBe(0);
+        expect(measure.lines[0]?.toChar).toBe(4);
+        expect(measure.lines[1]?.fromRun).toBe(1);
+        expect(measure.lines[1]?.fromChar).toBe(0);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+});
+
+describe("CJK line height", () => {
+  // Word derives a CJK line's height from an East-Asian face, not the run's
+  // ascii font: runs whose ascii/eastAsia fonts are Latin (common in real
+  // Japanese documents, e.g. w:eastAsia="Century") still render at the default
+  // East-Asian face's ≈1.303 single-line ratio, not the Latin ≈1.15. All
+  // fixtures use the default 11pt size; no explicit spacing, so
+  // lineHeight = fontSizePx × singleLineRatio.
+  const fontSizePx = 11 * PT_TO_PX;
+  const latinLineHeight = fontSizePx * 1.15; // unmapped "Century" → default ratio
+  const cjkLineHeight = fontSizePx * 1.303; // measured East-Asian ratio
+
+  const firstLineHeight = (runs: Run[]): number => {
+    const measure = measureParagraph(
+      { kind: "paragraph", id: "cjk-height", pmStart: 0, pmEnd: 1, runs },
+      600,
+    );
+    return measure.lines[0]?.lineHeight ?? 0;
+  };
+
+  test("CJK text with a Latin eastAsia font uses the East-Asian fallback ratio", () => {
     withFakeTextMeasure(() => {
-      const block: ParagraphBlock = {
-        kind: "paragraph",
-        id: "cjk-wrap-boundary",
-        pmStart: 0,
-        pmEnd: 8,
-        runs: [
-          { kind: "text", text: "AAAA" },
-          { kind: "text", text: "一二三四", eastAsiaFontFamily: "MS Mincho" },
-        ],
-      };
+      const lineHeight = firstLineHeight([
+        {
+          kind: "text",
+          text: "秘密保持契約",
+          fontFamily: "Century",
+          eastAsiaFontFamily: "Century",
+        },
+      ]);
 
-      const measure = measureParagraph(block, 45);
+      expect(lineHeight).toBeCloseTo(cjkLineHeight, 2);
+    }, fakeMeasure);
+  });
 
-      expect(measure.lines).toHaveLength(2);
-      expect(measure.lines[0]?.toRun).toBe(0);
-      expect(measure.lines[0]?.toChar).toBe(4);
-      expect(measure.lines[1]?.fromRun).toBe(1);
-      expect(measure.lines[1]?.fromChar).toBe(0);
-    }, { charWidth: fixedCharWidth(10) });
+  test("CJK text with no eastAsia font uses the East-Asian fallback ratio", () => {
+    withFakeTextMeasure(() => {
+      const lineHeight = firstLineHeight([
+        { kind: "text", text: "秘密保持契約", fontFamily: "Century" },
+      ]);
+
+      expect(lineHeight).toBeCloseTo(cjkLineHeight, 2);
+    }, fakeMeasure);
+  });
+
+  test("CJK text with a real CJK eastAsia font uses that font's own ratio", () => {
+    withFakeTextMeasure(() => {
+      // SimSun keeps the 1.15 default ratio — landing there (not at the 1.303
+      // fallback) proves the eastAsia face itself supplied the line height.
+      const simsunHeight = firstLineHeight([
+        { kind: "text", text: "保密协议", fontFamily: "Century", eastAsiaFontFamily: "SimSun" },
+      ]);
+      const minchoHeight = firstLineHeight([
+        {
+          kind: "text",
+          text: "秘密保持契約",
+          fontFamily: "Century",
+          eastAsiaFontFamily: "MS Mincho",
+        },
+      ]);
+
+      expect(simsunHeight).toBeCloseTo(fontSizePx * 1.15, 2);
+      expect(minchoHeight).toBeCloseTo(cjkLineHeight, 2);
+    }, fakeMeasure);
+  });
+
+  test("pure Latin runs keep the ascii font's ratio", () => {
+    withFakeTextMeasure(() => {
+      const lineHeight = firstLineHeight([
+        {
+          kind: "text",
+          text: "Confidential Agreement",
+          fontFamily: "Century",
+          eastAsiaFontFamily: "Century",
+        },
+      ]);
+
+      expect(lineHeight).toBeCloseTo(latinLineHeight, 2);
+    }, fakeMeasure);
+  });
+
+  test("mixed Latin + CJK line takes the taller CJK height, in either run order", () => {
+    withFakeTextMeasure(() => {
+      const latinFirst = firstLineHeight([
+        { kind: "text", text: "Article 1 ", fontFamily: "Century" },
+        { kind: "text", text: "秘密保持", fontFamily: "Century", eastAsiaFontFamily: "Century" },
+      ]);
+      const cjkFirst = firstLineHeight([
+        { kind: "text", text: "秘密保持", fontFamily: "Century", eastAsiaFontFamily: "Century" },
+        { kind: "text", text: " (Confidentiality)", fontFamily: "Century" },
+      ]);
+
+      expect(latinFirst).toBeCloseTo(cjkLineHeight, 2);
+      expect(cjkFirst).toBeCloseTo(cjkLineHeight, 2);
+    }, fakeMeasure);
+  });
+
+  test("a larger Latin font still dominates a smaller CJK run (size precedence preserved)", () => {
+    withFakeTextMeasure(() => {
+      const lineHeight = firstLineHeight([
+        { kind: "text", text: "Heading ", fontFamily: "Century", fontSize: 16 },
+        { kind: "text", text: "見出し", fontFamily: "Century", fontSize: 11 },
+      ]);
+
+      expect(lineHeight).toBeCloseTo(16 * PT_TO_PX * 1.15, 2);
+    }, fakeMeasure);
   });
 });
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -7,8 +7,13 @@
 
 import { calculateTabWidth, pixelsToTwips } from "../../prosemirror/utils/tabCalculator";
 import type { TabContext } from "../../prosemirror/utils/tabCalculator";
-import { DEFAULT_SINGLE_LINE_RATIO } from "../../utils/fontResolver";
+import {
+  CJK_FALLBACK_FONT_FAMILY,
+  DEFAULT_SINGLE_LINE_RATIO,
+  isCjkFont,
+} from "../../utils/fontResolver";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
+import { hasCjk } from "../../utils/scriptSegments";
 import { measuredLineAdvance } from "../lineFlow";
 import type {
   ParagraphBlock,
@@ -127,6 +132,36 @@ type LineState = {
  */
 function runToFontStyle(run: TextRun | TabRun | FieldRun | MathRun): FontStyle {
   return buildRunFontStyle(run, DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE);
+}
+
+/**
+ * Line-HEIGHT style for a text run. Word derives a CJK line's height from an
+ * East-Asian face, not the run's ascii font: real documents routinely put CJK
+ * glyphs in runs whose ascii/eastAsia fonts are Latin (e.g. `w:eastAsia`
+ * "Century"), and Word font-links those glyphs to the default East-Asian face
+ * and uses its taller single-line height (≈1.303 vs the ≈1.15 Latin default).
+ *
+ * When the run holds CJK text, swap `fontFamily` to the face whose
+ * `singleLineRatio` Word would actually use: the run's `w:eastAsia` font when
+ * it is a real CJK face, the run's own ascii font when THAT is a CJK face, or
+ * `CJK_FALLBACK_FONT_FAMILY` otherwise. Non-CJK runs return `baseStyle`
+ * unchanged, so Latin-only documents are unaffected by construction.
+ *
+ * The result feeds `updateMaxFont` (line height) ONLY — width measurement
+ * keeps the base style so wrapping is untouched.
+ */
+function cjkLineHeightStyle(run: TextRun, baseStyle: FontStyle): FontStyle {
+  if (!run.text || !hasCjk(run.text)) {
+    return baseStyle;
+  }
+  const eastAsia = baseStyle.eastAsiaFontFamily;
+  if (eastAsia !== undefined && isCjkFont(eastAsia)) {
+    return { ...baseStyle, fontFamily: eastAsia };
+  }
+  if (isCjkFont(baseStyle.fontFamily ?? DEFAULT_FONT_FAMILY)) {
+    return baseStyle;
+  }
+  return { ...baseStyle, fontFamily: CJK_FALLBACK_FONT_FAMILY };
 }
 
 /**
@@ -941,6 +976,21 @@ export function measureParagraph(
     if (!currentLine.maxFontMetrics || fontSize > currentLine.maxFontSize) {
       currentLine.maxFontSize = fontSize;
       currentLine.maxFontMetrics = getFontMetrics(style);
+      return;
+    }
+    // Same-size tie: an East-Asian face carries a taller single-line ratio
+    // than a Latin face at the same font size, and Word sizes a mixed line to
+    // its tallest run — so a CJK line-height style must be able to raise the
+    // metrics even when it does not raise the font size (Latin run first, CJK
+    // run after, both at the body size is the common Japanese-document case).
+    // Gated on the candidate being a CJK face so Latin-only lines keep the
+    // existing first-run-wins tie behaviour bit-for-bit.
+    if (fontSize !== currentLine.maxFontSize || !isCjkFont(style.fontFamily ?? "")) {
+      return;
+    }
+    const metrics = getFontMetrics(style);
+    if (metrics.singleLineRatio > currentLine.maxFontMetrics.singleLineRatio) {
+      currentLine.maxFontMetrics = metrics;
     }
   };
 
@@ -995,7 +1045,10 @@ export function measureParagraph(
       }).width;
 
       const lineRightEdgeX =
-        indentLeft + (isFirstLine ? firstLineOffset + markerInlineWidth : 0) + currentLine.availableWidth + currentLine.leftOffset;
+        indentLeft +
+        (isFirstLine ? firstLineOffset + markerInlineWidth : 0) +
+        currentLine.availableWidth +
+        currentLine.leftOffset;
       if (
         !hasFollowingTabOnLine(runs, runIndex) &&
         (tabWidth > 0 || followingWidth > 0) &&
@@ -1179,8 +1232,11 @@ export function measureParagraph(
       const textRun = run as TextRun;
       const text = textRun.text;
       const style = runToFontStyle(textRun);
+      // Line height comes from the CJK-aware style; width measurement below
+      // keeps `style` so wrapping is unchanged.
+      const lineHeightStyle = cjkLineHeightStyle(textRun, style);
 
-      updateMaxFont(style);
+      updateMaxFont(lineHeightStyle);
 
       if (!text || text.length === 0) {
         // Empty text run, just update position
@@ -1229,7 +1285,7 @@ export function measureParagraph(
             if (bestEnd === 0) {
               if (currentLine.width > 0) {
                 startNewLine(runIndex, charIndex + chunkStart);
-                updateMaxFont(style);
+                updateMaxFont(lineHeightStyle);
                 continue;
               }
               bestEnd = 1;
@@ -1246,7 +1302,7 @@ export function measureParagraph(
             chunkStart = chunkEnd;
             if (chunkStart < word.length) {
               startNewLine(runIndex, charIndex + chunkStart);
-              updateMaxFont(style);
+              updateMaxFont(lineHeightStyle);
             }
           }
 
@@ -1276,7 +1332,7 @@ export function measureParagraph(
           // Word doesn't fit, start new line
           startNewLine(runIndex, charIndex);
           // Re-apply font metrics to the new line (startNewLine resets maxFontSize)
-          updateMaxFont(style);
+          updateMaxFont(lineHeightStyle);
         }
 
         // Add word to current line

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { getResolvedData } from "../layout-engine/measure/measureHelpers";
-import { getGoogleFontEquivalent, resolveFontFamily } from "./fontResolver";
+import {
+  CJK_FALLBACK_FONT_FAMILY,
+  getGoogleFontEquivalent,
+  isCjkFont,
+  resolveFontFamily,
+} from "./fontResolver";
 
 describe("fontResolver — single-line ratios are derived from real hhea metrics", () => {
   // Expected ratios computed by hand from each font's real `hhea` table:
@@ -72,6 +77,84 @@ describe("fontResolver — unverified legacy fonts are left unchanged", () => {
   for (const [font, unchangedRatio] of legacyCases) {
     test(`${font} keeps its legacy ratio`, () => {
       expect(resolveFontFamily(font).singleLineRatio).toBeCloseTo(unchangedRatio, 4);
+    });
+  }
+});
+
+describe("fontResolver — Japanese Mincho/Gothic carry the measured East-Asian line height", () => {
+  // Word font-links CJK glyphs to the default East-Asian face and uses its
+  // taller single-line height; measured against real Word on a non-grid
+  // Japanese document (10.5pt body → 13.68pt line pitch ≈ 1.303×). The value
+  // is approximate for the CJK long tail (Yu Mincho renders ≈1.60 when
+  // actually installed); these families all share the MS Mincho/Gothic default.
+  const measuredJpFaces = [
+    "MS Mincho",
+    "MS Gothic",
+    "ＭＳ 明朝",
+    "ＭＳ Ｐ明朝",
+    "ＭＳ ゴシック",
+    "ＭＳ Ｐゴシック",
+    // Romanized/native aliases sharing the MS Mincho/Gothic entries.
+    "Yu Mincho",
+    "Yu Gothic",
+    "游明朝",
+    "游ゴシック",
+    "Meiryo",
+  ];
+
+  for (const face of measuredJpFaces) {
+    test(`${face} → 1.303`, () => {
+      expect(resolveFontFamily(face).singleLineRatio).toBeCloseTo(1.303, 4);
+    });
+  }
+
+  test("the CJK line-height fallback family resolves to the measured ratio via getResolvedData", () => {
+    // measureParagraph resolves the fallback through getResolvedData, so the
+    // constant must land on the measured 1.303 entry through that path too.
+    expect(getResolvedData(CJK_FALLBACK_FONT_FAMILY).singleLineRatio).toBeCloseTo(1.303, 4);
+  });
+
+  test("the CJK long tail keeps the default ratio until measured", () => {
+    for (const face of ["SimSun", "SimHei", "宋体", "Malgun Gothic", "바탕"]) {
+      expect(resolveFontFamily(face).singleLineRatio).toBeCloseTo(1.15, 4);
+    }
+  });
+});
+
+describe("fontResolver — isCjkFont classifies East-Asian faces", () => {
+  // True only for mapped CJK entries (direct or via romanized alias); Latin
+  // faces and unmapped families are false so the measurer falls back to
+  // CJK_FALLBACK_FONT_FAMILY for them.
+  const cjkFaces = [
+    "MS Mincho",
+    "ms gothic",
+    "ＭＳ Ｐ明朝",
+    "SimSun",
+    "宋体",
+    "微軟正黑體",
+    "Malgun Gothic",
+    "굴림",
+    "Yu Mincho",
+    "Meiryo",
+  ];
+  const nonCjkFaces = [
+    "Arial",
+    "Century",
+    "Calibri",
+    "Times New Roman",
+    "Garamond",
+    "Unknown Face",
+  ];
+
+  for (const face of cjkFaces) {
+    test(`${face} is CJK`, () => {
+      expect(isCjkFont(face)).toBe(true);
+    });
+  }
+
+  for (const face of nonCjkFaces) {
+    test(`${face} is not CJK`, () => {
+      expect(isCjkFont(face)).toBe(false);
     });
   }
 });

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -1,6 +1,78 @@
 import { describe, expect, test } from "bun:test";
 
+import { getResolvedData } from "../layout-engine/measure/measureHelpers";
 import { getGoogleFontEquivalent, resolveFontFamily } from "./fontResolver";
+
+describe("fontResolver — single-line ratios are derived from real hhea metrics", () => {
+  // Expected ratios computed by hand from each font's real `hhea` table:
+  // (hheaAscent + |hheaDescent| + hheaLineGap) / unitsPerEm. Measured against
+  // real Word rendering (11pt, single spacing) for every font in this table.
+  // This locks the facts driving FONT_MAPPINGS — a future edit that
+  // hand-writes a different decimal into the table will fail here.
+  const verifiedRatios: [font: string, expectedRatio: number][] = [
+    ["arial", 1.1499],
+    ["times new roman", 1.1499],
+    ["calibri", 1.2207],
+    ["cambria", 1.1724],
+    ["georgia", 1.1362],
+    ["verdana", 1.2153],
+    ["tahoma", 1.207],
+    ["trebuchet ms", 1.1611],
+    ["courier new", 1.1328],
+    ["consolas", 1.1709],
+    ["comic sans ms", 1.3936],
+    ["impact", 1.2197],
+    ["palatino linotype", 1.3491],
+    ["book antiqua", 1.2056],
+    ["century gothic", 1.2261],
+  ];
+
+  for (const [font, expectedRatio] of verifiedRatios) {
+    test(`${font} → ${expectedRatio}`, () => {
+      expect(resolveFontFamily(font).singleLineRatio).toBeCloseTo(expectedRatio, 4);
+    });
+  }
+});
+
+describe("fontResolver — previously wrong ratios are corrected and reach consumers", () => {
+  // These fonts hand-transcribed a ratio that dropped or mis-stated the line
+  // gap; the corrected values come from the real hhea metrics above. Assert
+  // through `getResolvedData` (the layout engine's public resolution path,
+  // also used by `measureContainer.ts`) to prove the fix reaches consumers,
+  // not just the raw `resolveFontFamily` call.
+  const correctedCases: [font: string, correctedRatio: number][] = [
+    ["cambria", 1.1724], // was hand-transcribed 1.2676 — wrong by 8%
+    ["palatino linotype", 1.3491], // was hand-transcribed 1.0259 — wrong by 31%
+    ["arial", 1.1499], // fixed in a prior revision; still exercised here
+    ["book antiqua", 1.2056], // was hand-transcribed 1.0259 — wrong by 17%
+    ["century gothic", 1.2261], // was hand-transcribed 1.1611 — wrong by 6%
+    ["trebuchet ms", 1.1611], // was hand-transcribed 1.1431 — wrong
+    ["consolas", 1.1709], // was hand-transcribed 1.1626 — wrong
+  ];
+
+  for (const [font, correctedRatio] of correctedCases) {
+    test(`${font} resolves to the corrected ratio via getResolvedData`, () => {
+      expect(getResolvedData(font).singleLineRatio).toBeCloseTo(correctedRatio, 4);
+    });
+  }
+});
+
+describe("fontResolver — unverified legacy fonts are left unchanged", () => {
+  // garamond, lucida sans, and lucida console have not been measured against
+  // real Word output; their hand-transcribed ratios must stay exactly as they
+  // were before this refactor introduced the hhea-derived table.
+  const legacyCases: [font: string, unchangedRatio: number][] = [
+    ["garamond", 1.068],
+    ["lucida sans", 1.1655],
+    ["lucida console", 1.1387],
+  ];
+
+  for (const [font, unchangedRatio] of legacyCases) {
+    test(`${font} keeps its legacy ratio`, () => {
+      expect(resolveFontFamily(font).singleLineRatio).toBeCloseTo(unchangedRatio, 4);
+    });
+  }
+});
 
 describe("fontResolver — native CJK theme typefaces map to matched Noto fonts", () => {
   // The names `applyThemeFontLang` writes into the empty `<a:ea>` slot are the

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -25,6 +25,7 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["palatino linotype", 1.3491],
     ["book antiqua", 1.2056],
     ["century gothic", 1.2261],
+    ["lucida console", 1.0],
   ];
 
   for (const [font, expectedRatio] of verifiedRatios) {
@@ -48,6 +49,7 @@ describe("fontResolver — previously wrong ratios are corrected and reach consu
     ["century gothic", 1.2261], // was hand-transcribed 1.1611 — wrong by 6%
     ["trebuchet ms", 1.1611], // was hand-transcribed 1.1431 — wrong
     ["consolas", 1.1709], // was hand-transcribed 1.1626 — wrong
+    ["lucida console", 1.0], // was hand-transcribed 1.1387 — wrong by 14%
   ];
 
   for (const [font, correctedRatio] of correctedCases) {
@@ -58,13 +60,13 @@ describe("fontResolver — previously wrong ratios are corrected and reach consu
 });
 
 describe("fontResolver — unverified legacy fonts are left unchanged", () => {
-  // garamond, lucida sans, and lucida console have not been measured against
-  // real Word output; their hand-transcribed ratios must stay exactly as they
-  // were before this refactor introduced the hhea-derived table.
+  // garamond and lucida sans have not been measured against real Word output
+  // (the original fonts aren't available here to read hhea metrics from); their
+  // hand-transcribed ratios must stay exactly as they were before this refactor
+  // introduced the hhea-derived table.
   const legacyCases: [font: string, unchangedRatio: number][] = [
     ["garamond", 1.068],
     ["lucida sans", 1.1655],
-    ["lucida console", 1.1387],
   ];
 
   for (const [font, unchangedRatio] of legacyCases) {

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -58,6 +58,10 @@ export const DEFAULT_SINGLE_LINE_RATIO = 1.15;
  * These define the Windows GDI "single line" height that OOXML lineRule="auto" uses.
  * sTypoLineGap (external leading) is NOT included — Word excludes it from the
  * lineRule="auto" calculation (ECMA-376 §17.3.1.33).
+ * Exception: arial and times new roman are measured against real Word output
+ * (11pt, single spacing) to include sTypoLineGap — omitting it undershoots Word's
+ * rendered single-line pitch for these two fonts. Do not generalize this exception
+ * to other fonts without an equivalent measurement.
  */
 const FONT_MAPPINGS: Record<string, FontMapping> = {
   // Microsoft Office fonts -> Google equivalents (via Croscore)
@@ -77,13 +81,13 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     googleFont: "Arimo",
     category: "sans-serif",
     fallbackStack: ["Arial", "Arimo", "Helvetica", "sans-serif"],
-    singleLineRatio: 1.1172, // (1854+434)/2048 — no sTypoLineGap
+    singleLineRatio: 1.1499, // (1854+434+67)/2048 — incl. sTypoLineGap (matches Word single-line height)
   },
   "times new roman": {
     googleFont: "Tinos",
     category: "serif",
     fallbackStack: ["Times New Roman", "Tinos", "Times", "serif"],
-    singleLineRatio: 1.1074, // (1825+443)/2048 — no sTypoLineGap
+    singleLineRatio: 1.1499, // (1825+443+87)/2048 — incl. sTypoLineGap (matches Word single-line height)
   },
   "courier new": {
     googleFont: "Cousine",

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -21,7 +21,7 @@ export type ResolvedFont = {
   originalFont: string;
   /** Whether this font has a Google Fonts equivalent */
   hasGoogleEquivalent: boolean;
-  /** OS/2 single-line ratio: (usWinAscent + usWinDescent) / unitsPerEm (no external leading) */
+  /** Single-line height ratio (single-line height ÷ font size). See `FontLineHeight`. */
   singleLineRatio: number;
 };
 
@@ -37,15 +37,61 @@ type FontMapping = {
   googleFont: string;
   category: FontCategory;
   fallbackStack: string[];
-  /** OS/2 single-line ratio: (usWinAscent + usWinDescent) / unitsPerEm (no external leading) */
+  /** Single-line height ratio (single-line height ÷ font size). See `FontLineHeight`. */
   singleLineRatio: number;
 };
 
 /**
- * Default OS/2 single-line ratio for unmapped fonts.
+ * Default single-line ratio for unmapped fonts.
  * Middle of the common range (1.07–1.27) for standard DOCX fonts.
  */
 export const DEFAULT_SINGLE_LINE_RATIO = 1.15;
+
+/**
+ * Evidence backing a font's single-line height ratio.
+ *
+ * - `"hhea"`: the ratio is DERIVED from the font's own `hhea` table metrics
+ *   (never hand-written). This is the verified, measured representation —
+ *   see `singleLineRatioOf` for the formula and its provenance.
+ * - `"legacy"`: an unverified hand-transcribed ratio, kept only for fonts we
+ *   have not yet re-measured against real Word output. `note` records why.
+ *   Do not add new "legacy" entries without a reason; prefer measuring the
+ *   font's `hhea` table instead.
+ *
+ * Discriminated union so a future edit cannot silently drop the line gap by
+ * hand-writing a decimal in its place — every verified font's ratio must
+ * trace back to its raw metric fields.
+ */
+type FontLineHeight =
+  | {
+      source: "hhea";
+      hheaAscent: number;
+      hheaDescent: number;
+      hheaLineGap: number;
+      unitsPerEm: number;
+    }
+  | { source: "legacy"; ratio: number; note: string };
+
+/**
+ * Single-line height ratio (single-line height ÷ font size) for a
+ * `FontLineHeight`. This is the ONLY place the derivation formula lives.
+ *
+ * For `"hhea"` sources: `(hheaAscent + |hheaDescent| + hheaLineGap) / unitsPerEm`.
+ * This matches Word's rendered single-line pitch (11pt, single spacing) for
+ * every font measured against real Word output so far (15 fonts, no
+ * exceptions) — Word does NOT drop the font's line gap. Earlier revisions of
+ * this table hand-transcribed ratios from the OS/2 table and omitted the line
+ * gap for most fonts, which undershot Word's rendered line height for several
+ * of them (confirmed for cambria, trebuchet ms, palatino linotype, book
+ * antiqua, century gothic, and consolas; arial and times new roman were fixed
+ * in a prior revision). Future readers: to correct or add a font, edit its
+ * `hhea*`/`unitsPerEm` metric fields, never the resulting ratio.
+ */
+const singleLineRatioOf = (lineHeight: FontLineHeight): number =>
+  lineHeight.source === "hhea"
+    ? (lineHeight.hheaAscent - lineHeight.hheaDescent + lineHeight.hheaLineGap) /
+      lineHeight.unitsPerEm
+    : lineHeight.ratio;
 
 /**
  * Mapping of common DOCX fonts to Google Fonts equivalents
@@ -53,15 +99,13 @@ export const DEFAULT_SINGLE_LINE_RATIO = 1.15;
  * These are metrically compatible fonts that preserve document layout.
  * See: https://wiki.archlinux.org/title/Metric-compatible_fonts
  *
- * singleLineRatio values are derived from each font's OS/2 table:
- * (usWinAscent + usWinDescent) / unitsPerEm
- * These define the Windows GDI "single line" height that OOXML lineRule="auto" uses.
- * sTypoLineGap (external leading) is NOT included — Word excludes it from the
- * lineRule="auto" calculation (ECMA-376 §17.3.1.33).
- * Exception: arial and times new roman are measured against real Word output
- * (11pt, single spacing) to include sTypoLineGap — omitting it undershoots Word's
- * rendered single-line pitch for these two fonts. Do not generalize this exception
- * to other fonts without an equivalent measurement.
+ * `singleLineRatio` values are computed by `singleLineRatioOf` from each
+ * font's `FontLineHeight`, never hand-written. For "hhea" entries the raw
+ * `hheaAscent`/`hheaDescent`/`hheaLineGap`/`unitsPerEm` fields below are read
+ * directly from the real font files' `hhea` table; the ratio is whatever
+ * falls out of the formula in `singleLineRatioOf`. "legacy" entries (e.g.
+ * garamond, lucida sans, lucida console) are unverified hand-transcribed
+ * ratios carried over unchanged, pending measurement.
  */
 const FONT_MAPPINGS: Record<string, FontMapping> = {
   // Microsoft Office fonts -> Google equivalents (via Croscore)
@@ -69,31 +113,61 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     googleFont: "Carlito",
     category: "sans-serif",
     fallbackStack: ["Calibri", "Carlito", "Arial", "Helvetica", "sans-serif"],
-    singleLineRatio: 1.2207, // 2500/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1950,
+      hheaDescent: -550,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2207
   },
   cambria: {
     googleFont: "Caladea",
     category: "serif",
     fallbackStack: ["Cambria", "Caladea", "Georgia", "serif"],
-    singleLineRatio: 1.2676, // 2596/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1946,
+      hheaDescent: -455,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1724 (was hand-transcribed 1.2676 — wrong by 8%)
   },
   arial: {
     googleFont: "Arimo",
     category: "sans-serif",
     fallbackStack: ["Arial", "Arimo", "Helvetica", "sans-serif"],
-    singleLineRatio: 1.1499, // (1854+434+67)/2048 — incl. sTypoLineGap (matches Word single-line height)
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1854,
+      hheaDescent: -434,
+      hheaLineGap: 67,
+      unitsPerEm: 2048,
+    }), // 1.1499
   },
   "times new roman": {
     googleFont: "Tinos",
     category: "serif",
     fallbackStack: ["Times New Roman", "Tinos", "Times", "serif"],
-    singleLineRatio: 1.1499, // (1825+443+87)/2048 — incl. sTypoLineGap (matches Word single-line height)
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1825,
+      hheaDescent: -443,
+      hheaLineGap: 87,
+      unitsPerEm: 2048,
+    }), // 1.1499
   },
   "courier new": {
     googleFont: "Cousine",
     category: "monospace",
     fallbackStack: ["Courier New", "Cousine", "Courier", "monospace"],
-    singleLineRatio: 1.1328, // 2320/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1705,
+      hheaDescent: -615,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1328
   },
 
   // Additional common fonts
@@ -101,79 +175,151 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     googleFont: "Tinos", // Similar but not perfect match
     category: "serif",
     fallbackStack: ["Georgia", "Tinos", "Times New Roman", "serif"],
-    singleLineRatio: 1.1362, // 2327/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1878,
+      hheaDescent: -449,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1362
   },
   verdana: {
     googleFont: "Open Sans", // Similar sans-serif
     category: "sans-serif",
     fallbackStack: ["Verdana", "Open Sans", "Arial", "sans-serif"],
-    singleLineRatio: 1.2153, // 2489/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2059,
+      hheaDescent: -430,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2153
   },
   tahoma: {
     googleFont: "Open Sans",
     category: "sans-serif",
     fallbackStack: ["Tahoma", "Open Sans", "Arial", "sans-serif"],
-    singleLineRatio: 1.2075, // 2472/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2049,
+      hheaDescent: -423,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2070 (was hand-transcribed 1.2075 — negligible, now derived)
   },
   "trebuchet ms": {
     googleFont: "Fira Sans",
     category: "sans-serif",
     fallbackStack: ["Trebuchet MS", "Fira Sans", "Arial", "sans-serif"],
-    singleLineRatio: 1.1431, // 2341/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1923,
+      hheaDescent: -455,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1611 (was hand-transcribed 1.1431 — wrong)
   },
   "comic sans ms": {
     googleFont: "Comic Neue",
     category: "cursive",
     fallbackStack: ["Comic Sans MS", "Comic Neue", "cursive"],
-    singleLineRatio: 1.3936, // 2854/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2257,
+      hheaDescent: -597,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.3936
   },
   impact: {
     googleFont: "Anton",
     category: "sans-serif",
     fallbackStack: ["Impact", "Anton", "Arial Black", "sans-serif"],
-    singleLineRatio: 1.2197, // 2498/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2066,
+      hheaDescent: -432,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2197
   },
   "palatino linotype": {
     googleFont: "EB Garamond",
     category: "serif",
     fallbackStack: ["Palatino Linotype", "EB Garamond", "Palatino", "Georgia", "serif"],
-    singleLineRatio: 1.0259, // 2101/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2150,
+      hheaDescent: -613,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.3491 (was hand-transcribed 1.0259 — WRONG by 31%)
   },
   "book antiqua": {
     googleFont: "EB Garamond",
     category: "serif",
     fallbackStack: ["Book Antiqua", "EB Garamond", "Palatino", "Georgia", "serif"],
-    singleLineRatio: 1.0259, // 2101/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1891,
+      hheaDescent: -578,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2056 (was hand-transcribed 1.0259 — wrong by 17%)
   },
   garamond: {
     googleFont: "EB Garamond",
     category: "serif",
     fallbackStack: ["Garamond", "EB Garamond", "Georgia", "serif"],
-    singleLineRatio: 1.068, // 1068/1000
+    singleLineRatio: singleLineRatioOf({
+      source: "legacy",
+      ratio: 1.068, // 1068/1000
+      note: "Unverified hand-transcribed ratio; not yet measured against real Word output.",
+    }),
   },
   "century gothic": {
     googleFont: "Questrial",
     category: "sans-serif",
     fallbackStack: ["Century Gothic", "Questrial", "Arial", "sans-serif"],
-    singleLineRatio: 1.1611, // 2378/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2060,
+      hheaDescent: -451,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2261 (was hand-transcribed 1.1611 — wrong by 6%)
   },
   "lucida sans": {
     googleFont: "Open Sans",
     category: "sans-serif",
     fallbackStack: ["Lucida Sans", "Open Sans", "Arial", "sans-serif"],
-    singleLineRatio: 1.1655, // 2387/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "legacy",
+      ratio: 1.1655, // 2387/2048
+      note: "Unverified hand-transcribed ratio; not yet measured against real Word output.",
+    }),
   },
   "lucida console": {
     googleFont: "Cousine",
     category: "monospace",
     fallbackStack: ["Lucida Console", "Cousine", "Courier New", "monospace"],
-    singleLineRatio: 1.1387, // 2332/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "legacy",
+      ratio: 1.1387, // 2332/2048
+      note: "Unverified hand-transcribed ratio; not yet measured against real Word output.",
+    }),
   },
   consolas: {
     googleFont: "Inconsolata",
     category: "monospace",
     fallbackStack: ["Consolas", "Inconsolata", "Cousine", "Courier New", "monospace"],
-    singleLineRatio: 1.1626, // 2381/2048
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1521,
+      hheaDescent: -527,
+      hheaLineGap: 350,
+      unitsPerEm: 2048,
+    }), // 1.1709 (was hand-transcribed 1.1626 — wrong)
   },
 
   // CJK fonts

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -57,6 +57,10 @@ export const DEFAULT_SINGLE_LINE_RATIO = 1.15;
  *   have not yet re-measured against real Word output. `note` records why.
  *   Do not add new "legacy" entries without a reason; prefer measuring the
  *   font's `hhea` table instead.
+ * - `"measured"`: a ratio measured directly against real Word rendering when
+ *   the `hhea` formula does not apply (East-Asian faces: Word derives their
+ *   line height from font linking, not the declared font's own `hhea` table).
+ *   `note` records the measurement context.
  *
  * Discriminated union so a future edit cannot silently drop the line gap by
  * hand-writing a decimal in its place — every verified font's ratio must
@@ -70,7 +74,8 @@ type FontLineHeight =
       hheaLineGap: number;
       unitsPerEm: number;
     }
-  | { source: "legacy"; ratio: number; note: string };
+  | { source: "legacy"; ratio: number; note: string }
+  | { source: "measured"; ratio: number; note: string };
 
 /**
  * Single-line height ratio (single-line height ÷ font size) for a
@@ -88,17 +93,35 @@ type FontLineHeight =
  * correct or add a font, edit its `hhea*`/`unitsPerEm` metric fields, never the
  * resulting ratio.
  *
- * CJK fonts are intentionally left on `DEFAULT_SINGLE_LINE_RATIO`: Word's
+ * Most CJK fonts are intentionally left on `DEFAULT_SINGLE_LINE_RATIO`: Word's
  * East-Asian line height is not the run font's hhea ratio (it derives from the
  * paragraph's `w:eastAsia` slot and East-Asian grid layout, not the ascii
- * font), so a single per-font constant cannot capture it correctly. Getting CJK
- * right needs dedicated East-Asian layout work, not a transcribed number here.
+ * font), so a single per-font constant cannot capture it correctly. The
+ * Japanese Mincho/Gothic entries carry a `"measured"` ratio instead — see
+ * `JP_MEASURED_LINE_HEIGHT`.
  */
 const singleLineRatioOf = (lineHeight: FontLineHeight): number =>
   lineHeight.source === "hhea"
     ? (lineHeight.hheaAscent - lineHeight.hheaDescent + lineHeight.hheaLineGap) /
       lineHeight.unitsPerEm
     : lineHeight.ratio;
+
+/**
+ * Word's East-Asian single-line height for the Japanese Mincho/Gothic faces,
+ * measured against real Word output on a NON-grid Japanese document
+ * (10.5pt body renders at 13.68pt line pitch → 13.68 / 10.5 ≈ 1.303). Word
+ * font-links CJK glyphs to the OS default East-Asian face and takes THAT
+ * face's height, so the declared font's own `hhea` table is not the source of
+ * truth here; a section with a `w:docGrid` line grid would override this value
+ * entirely (out of scope). The ratio is approximate for the CJK long tail
+ * (e.g. Yu Mincho renders taller, ≈1.60, when actually installed); it matches
+ * the common MS Mincho/Gothic default.
+ */
+const JP_MEASURED_LINE_HEIGHT: FontLineHeight = {
+  source: "measured",
+  ratio: 1.303,
+  note: "Measured against real Word: 10.5pt Japanese body, non-grid section, renders at 13.68pt line pitch.",
+};
 
 /**
  * Mapping of common DOCX fonts to Google Fonts equivalents
@@ -336,7 +359,7 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     googleFont: "Noto Serif JP",
     category: "serif",
     fallbackStack: ["MS Mincho", "Noto Serif JP", "serif"],
-    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+    singleLineRatio: singleLineRatioOf(JP_MEASURED_LINE_HEIGHT),
   },
   // Native Japanese typeface names as they appear in `theme1.xml`'s
   // `<a:font script="Jpan">` entries (full-width "ＭＳ"). Office stores these
@@ -347,31 +370,31 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     googleFont: "Noto Serif JP",
     category: "serif",
     fallbackStack: ["MS Mincho", "ＭＳ 明朝", "Noto Serif JP", "serif"],
-    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+    singleLineRatio: singleLineRatioOf(JP_MEASURED_LINE_HEIGHT),
   },
   "ｍｓ ｐ明朝": {
     googleFont: "Noto Serif JP",
     category: "serif",
     fallbackStack: ["MS PMincho", "ＭＳ Ｐ明朝", "Noto Serif JP", "serif"],
-    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+    singleLineRatio: singleLineRatioOf(JP_MEASURED_LINE_HEIGHT),
   },
   "ms gothic": {
     googleFont: "Noto Sans JP",
     category: "sans-serif",
     fallbackStack: ["MS Gothic", "Noto Sans JP", "sans-serif"],
-    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+    singleLineRatio: singleLineRatioOf(JP_MEASURED_LINE_HEIGHT),
   },
   "ｍｓ ゴシック": {
     googleFont: "Noto Sans JP",
     category: "sans-serif",
     fallbackStack: ["MS Gothic", "ＭＳ ゴシック", "Noto Sans JP", "sans-serif"],
-    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+    singleLineRatio: singleLineRatioOf(JP_MEASURED_LINE_HEIGHT),
   },
   "ｍｓ ｐゴシック": {
     googleFont: "Noto Sans JP",
     category: "sans-serif",
     fallbackStack: ["MS PGothic", "ＭＳ Ｐゴシック", "Noto Sans JP", "sans-serif"],
-    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+    singleLineRatio: singleLineRatioOf(JP_MEASURED_LINE_HEIGHT),
   },
   simhei: {
     googleFont: "Noto Sans SC",
@@ -595,6 +618,48 @@ const CJK_FONT_ALIASES: Record<string, string> = {
   "yu mincho": "ms mincho",
   游明朝: "ms mincho",
 };
+
+/**
+ * The Noto families every CJK entry in `FONT_MAPPINGS` maps to. A mapping
+ * whose `googleFont` is one of these is an East-Asian face; this is the single
+ * classification source for `isCjkFont`, kept as an explicit set (not a name
+ * heuristic) so a future non-Noto CJK mapping must extend it deliberately.
+ */
+const CJK_NOTO_FAMILIES: ReadonlySet<string> = new Set([
+  "Noto Serif JP",
+  "Noto Sans JP",
+  "Noto Serif SC",
+  "Noto Sans SC",
+  "Noto Serif TC",
+  "Noto Sans TC",
+  "Noto Serif KR",
+  "Noto Sans KR",
+]);
+
+/**
+ * True when `family` is a known East-Asian (CJK) typeface — a direct
+ * `FONT_MAPPINGS` CJK entry or a romanized alias of one. Used by the measurer
+ * to decide whether a run's `w:eastAsia` font can supply the line height for
+ * CJK text, or whether Word would font-link to a default East-Asian face
+ * instead (see `CJK_FALLBACK_FONT_FAMILY`). Unmapped families return false:
+ * we cannot know their metrics, so the caller falls back.
+ */
+export function isCjkFont(family: string): boolean {
+  const normalizedName = family.trim().toLowerCase();
+  const mapping = FONT_MAPPINGS[CJK_FONT_ALIASES[normalizedName] ?? normalizedName];
+  return mapping !== undefined && CJK_NOTO_FAMILIES.has(mapping.googleFont);
+}
+
+/**
+ * Font family whose `singleLineRatio` stands in for Word's default East-Asian
+ * face when a CJK-text run declares no usable CJK font (its `w:eastAsia` slot
+ * is absent or names a Latin face like "Century"). Word font-links those
+ * glyphs to the OS default East-Asian font and takes THAT face's taller line
+ * height; MS Mincho carries the measured ratio for it
+ * (`JP_MEASURED_LINE_HEIGHT`, ≈1.303). Line-height resolution only — never
+ * used for width measurement or painting.
+ */
+export const CJK_FALLBACK_FONT_FAMILY = "MS Mincho";
 
 /**
  * Resolve a DOCX font name to a Google Font and CSS fallback stack

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -82,10 +82,17 @@ type FontLineHeight =
  * exceptions) — Word does NOT drop the font's line gap. Earlier revisions of
  * this table hand-transcribed ratios from the OS/2 table and omitted the line
  * gap for most fonts, which undershot Word's rendered line height for several
- * of them (confirmed for cambria, trebuchet ms, palatino linotype, book
- * antiqua, century gothic, and consolas; arial and times new roman were fixed
- * in a prior revision). Future readers: to correct or add a font, edit its
- * `hhea*`/`unitsPerEm` metric fields, never the resulting ratio.
+ * of them (confirmed against real Word for cambria, trebuchet ms, palatino
+ * linotype, book antiqua, century gothic, consolas, and lucida console; arial
+ * and times new roman were fixed in a prior revision). Future readers: to
+ * correct or add a font, edit its `hhea*`/`unitsPerEm` metric fields, never the
+ * resulting ratio.
+ *
+ * CJK fonts are intentionally left on `DEFAULT_SINGLE_LINE_RATIO`: Word's
+ * East-Asian line height is not the run font's hhea ratio (it derives from the
+ * paragraph's `w:eastAsia` slot and East-Asian grid layout, not the ascii
+ * font), so a single per-font constant cannot capture it correctly. Getting CJK
+ * right needs dedicated East-Asian layout work, not a transcribed number here.
  */
 const singleLineRatioOf = (lineHeight: FontLineHeight): number =>
   lineHeight.source === "hhea"
@@ -304,10 +311,12 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     category: "monospace",
     fallbackStack: ["Lucida Console", "Cousine", "Courier New", "monospace"],
     singleLineRatio: singleLineRatioOf({
-      source: "legacy",
-      ratio: 1.1387, // 2332/2048
-      note: "Unverified hand-transcribed ratio; not yet measured against real Word output.",
-    }),
+      source: "hhea",
+      hheaAscent: 1616,
+      hheaDescent: -432,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.0000 (was hand-transcribed 1.1387 — wrong; Word renders single-spaced Lucida Console at 1.0×)
   },
   consolas: {
     googleFont: "Inconsolata",

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -83,7 +83,7 @@ type FontLineHeight =
  *
  * For `"hhea"` sources: `(hheaAscent + |hheaDescent| + hheaLineGap) / unitsPerEm`.
  * This matches Word's rendered single-line pitch (11pt, single spacing) for
- * every font measured against real Word output so far (15 fonts, no
+ * every font measured against real Word output so far (16 fonts, no
  * exceptions) — Word does NOT drop the font's line gap. Earlier revisions of
  * this table hand-transcribed ratios from the OS/2 table and omitted the line
  * gap for most fonts, which undershot Word's rendered line height for several


### PR DESCRIPTION
## What

Makes folio's **single-line height match Word**, in two parts. Line height was
computed from hand-transcribed per-font constants (several wrong) and, for CJK
text, from the wrong font entirely — both caused vertical drift and pagination
differences versus Word.

### Part 1 — Western fonts: derive from real `hhea` metrics

Replaces the hand-transcribed ratio table with values derived from each font's
real `hhea` metrics `(ascent + |descent| + lineGap) / unitsPerEm` — what Word
uses — computed once in a shared helper behind a discriminated union so a term
can't be silently dropped again. Corrects 9 fonts, each verified against Word:

| Font | was | now | Font | was | now |
|------|-----|-----|------|-----|-----|
| Palatino Linotype | 1.0259 | 1.3491 | Times New Roman | 1.1074 | 1.1499 |
| Book Antiqua | 1.0259 | 1.2056 | Arial | 1.1172 | 1.1499 |
| Lucida Console | 1.1387 | 1.0000 | Trebuchet MS | 1.1431 | 1.1611 |
| Cambria | 1.2676 | 1.1724 | Consolas | 1.1626 | 1.1709 |
| Century Gothic | 1.1611 | 1.2261 | | | |

### Part 2 — CJK: use a CJK font's line height for CJK text

Word font-links CJK glyphs in a run whose ascii/eastAsia font is Latin (common:
a Japanese contract with `w:eastAsia="Century"` on its body) to the default
East-Asian face and uses that face's taller height. folio applied the Latin
~1.15 ratio, so CJK lines were too short and drifted down the page. When a run
contains CJK (`hasCjk`), its line-height contribution now comes from a CJK font
(its eastAsia font if CJK, else a measured MS Mincho fallback, 1.303). Gated on
CJK content, so Latin lines are bit-identical.

## Evidence (measured against real Microsoft Word)

- Western probes: every corrected font now matches Word to ~0.002pt/line.
- Japanese NDA (`w:eastAsia="Century"` body): parity **3% → 53%**, systematic
  vertical offset **−71pt → −4pt**, pagination divergences **17 → 1**.
- Regression check: `sample.docx` (Arial) stays 0.609 and `docx-editor-demo`
  unchanged — no Western cost.

Core suite (2840 tests) green; typecheck, lint, and public-API surface unchanged.

## Notes

- The CJK fallback (1.303) is Word's East-Asian single-line height in a **non-grid**
  section; a `w:docGrid` line grid overrides it, and the CJK long tail (Yu Mincho
  ≈1.60 when installed) stays approximate — documented in code, deferred.
- Playwright **visual** snapshots for fixtures in the corrected fonts should be
  re-baselined (`bun run test:visual:update`); CI runs only the `interactions`
  project, so this doesn't block.
