### PR TITLE
ci: open Version Packages PR with an app token

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,16 +20,31 @@ concurrency:
   group: release-pr-${{ github.ref }}
   cancel-in-progress: true
 
+# The default GITHUB_TOKEN cannot open PRs ("GitHub Actions is not permitted to
+# create or approve pull requests"), so the branch push and PR are done with an
+# app token (stella-provenance-updater, via the org CHANGELOG_APP_* secrets — the
+# same app the org's npm-version-finalize workflow uses). The workflow token here
+# stays read-only; all writes go through the app token.
 permissions:
-  contents: write # push the changeset-release/main branch and its commits
-  pull-requests: write # open / update the Version Packages PR
+  contents: read
 
 jobs:
   version:
     name: Maintain Version Packages PR
     runs-on: ubuntu-latest
     steps:
+      - name: Mint stella-provenance-updater token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Persist the app token so the changesets branch push authenticates as
+          # the app (not the unusable default GITHUB_TOKEN).
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -48,4 +63,4 @@ jobs:
           commit: "chore: version packages"
           # No `publish:` input: this action only maintains the version PR.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

The **Release PR** workflow was failing at the changesets step:

> HttpError: GitHub Actions is not permitted to create or approve pull requests.

The default `GITHUB_TOKEN` cannot open pull requests, so the "Version Packages" PR was never created.

## Change

`release-pr.yml` now mints a `stella-provenance-updater` app token (via the org `CHANGELOG_APP_*` secrets — the same app the org's version workflow already uses) and uses it for both the branch push (`checkout.token`) and the changesets step (`GITHUB_TOKEN` env). The default workflow token is dropped to `contents: read` since all writes now go through the app token.

As a side benefit, a PR opened by the app (rather than `GITHUB_TOKEN`) will trigger downstream CI.

## Verified

- `actionlint` clean on the workflow.
- Action pinned to a full commit SHA (`create-github-app-token` v3.2.0), matching the org's existing pin.
- App has `repository_selection: all`, so it covers this repo; `CHANGELOG_APP_*` are `ALL`-visibility org secrets readable from a public repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use GitHub App credentials for creating and updating release pull requests.
  * Reduced workflow permissions to read-only for safer access handling.
  * Improved checkout and write steps to use the newly minted token for branch and pull request updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->