### PR TITLE
feat(vue): wire AI-edit + content-control ref methods (28/30 ref members paired)

### DIFF
--- a/.changeset/vue-ref-ai-content-controls.md
+++ b/.changeset/vue-ref-ai-content-controls.md
@@ -1,0 +1,13 @@
+---
+"@stll/folio-vue": minor
+---
+
+Wire the AI-edit and content-control `DocxEditorRef` methods in the Vue adapter
+over `@stll/folio-core`, mirroring the React adapter. `createAIEditSnapshot`,
+`applyAIEditOperations`, `acceptAIEditOperation`, `rejectAIEditOperation`,
+`scrollToAIEditOperation`, `scrollToBlock`, `getContentControls`,
+`scrollToContentControl`, `setContentControlContent`, `setContentControlValue`,
+and `removeContentControl` were previously stubbed to `null` / `false` / `[]`;
+they now drive the live editor view. Only `getEditorRef` and `hasPendingChanges`
+remain deferred pending the Vue `PagedEditor` component and PM-serialized-vs-live
+tracking.

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -28,6 +28,8 @@ export type FolioParityBridge = {
   commentFirstWord: () => boolean;
   /** Count painted `[data-comment-id]` anchors in the pages (shared painter attr). */
   countCommentAnchors: () => number;
+  /** Block count of the AI-edit snapshot over the live doc (0 with no live view). */
+  aiSnapshotBlockCount: () => number;
   /** Serialize to DOCX and return the byte length (0 on failure). */
   save: () => Promise<number>;
 };
@@ -134,6 +136,7 @@ export function buildParityBridge(getRef: () => DocxEditorRef | null): FolioPari
     },
     countCommentAnchors: () =>
       document.querySelectorAll(".paged-editor__pages [data-comment-id]").length,
+    aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
     save: async () => {
       const buffer = await (getRef()?.save() ?? Promise.resolve(null));
       return buffer?.byteLength ?? 0;

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -70,6 +70,8 @@ export type FolioParityBridge = {
   commentFirstWord: () => boolean;
   /** Count painted `[data-comment-id]` anchors in the pages (shared painter attr). */
   countCommentAnchors: () => number;
+  /** Block count of the AI-edit snapshot over the live doc (0 with no live view). */
+  aiSnapshotBlockCount: () => number;
   /** Serialize to DOCX and return the byte length (0 on failure). */
   save: () => Promise<number>;
 };
@@ -176,6 +178,7 @@ function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridg
     },
     countCommentAnchors: () =>
       document.querySelectorAll(".paged-editor__pages [data-comment-id]").length,
+    aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
     save: async () => {
       const buffer = await (getRef()?.save() ?? Promise.resolve(null));
       return buffer?.byteLength ?? 0;

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -439,6 +439,7 @@ const {
   scrollPageInfo,
   resolvePos,
   setPmSelection,
+  scrollVisiblePositionIntoView,
   handlePagesMouseDown,
   handlePagesMouseMove,
   handlePagesClick,
@@ -782,6 +783,16 @@ const { exposed } = useDocxEditorRefApi({
   pagesRef,
   pagesViewportRef,
   zoom,
+  scrollVisiblePositionIntoView,
+  author: () => props.author,
+  // Mirror React's applyAIEditOperations comment closure: mint the comment,
+  // append it to the thread list, and hand back its id for the tracked-change
+  // mark that references it.
+  createAIEditComment: (text) => {
+    const comment = commentManagement.createComment(text);
+    commentManagement.pushComment(comment);
+    return comment.id;
+  },
   focus,
   getDocument,
   setZoom,

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -9,17 +9,20 @@
  * so any drift from the React contract is a typecheck error here rather than a
  * runtime surprise at the call site.
  *
- * PORT-BLOCKED: several ref methods depend on adapter surfaces the fork has not
- * ported yet (comment/AI-edit/content-control composables, the Vue PagedEditor,
- * a `scrollVisiblePositionIntoView` from a pages-pointer composable). Those are
- * stubbed to a sensible default (null / false / empty) with a per-method note.
- * The assembled object still `satisfies DocxEditorRef`.
+ * PORT-BLOCKED: a few ref methods still depend on adapter surfaces the fork has
+ * not ported yet (`hasPendingChanges` needs PM-serialized-vs-live tracking;
+ * `getEditorRef` needs the Vue PagedEditor component). Those stay stubbed to a
+ * sensible default (null / false) with a per-method note. The AI-edit and
+ * content-control methods are wired over folio-core directly, mirroring the
+ * React adapter. The assembled object `satisfies DocxEditorRef`.
  */
 
 import type { Ref } from "vue";
 
+import { TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import { applyFolioAIEditOperations, createFolioAIEditSnapshot } from "@stll/folio-core/ai-edits";
 import type { FolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { Layout } from "@stll/folio-core/layout-engine";
 import { findPageIndexContainingPmPos } from "@stll/folio-core/layout-engine";
@@ -28,10 +31,25 @@ import {
   flashParagraphElements,
 } from "@stll/folio-core/paged-layout/paragraphFlash";
 import type { ScrollToParaIdOptions } from "@stll/folio-core/paged-layout/paragraphFlash";
+import {
+  acceptAIEditRevision,
+  findAIEditRevisionRange,
+  rejectAIEditRevision,
+} from "@stll/folio-core/prosemirror/commands/comments";
+import {
+  blockSdtAttrsToSdtProperties,
+  findBlockSdtMatch,
+  findBlockSdtMatches,
+  removeContentControlTr,
+  setContentControlContentTr,
+  setContentControlValueTr,
+} from "@stll/folio-core/prosemirror/commands/contentControls";
+import { setContentControlContentBlocksTr } from "@stll/folio-core/prosemirror/commands/contentControlsBlockFill";
 import type { Document } from "@stll/folio-core/types/document";
 import type { DocxInput } from "@stll/folio-core/utils/docxInput";
 
 import type { DocxEditorRef } from "../components/DocxEditor/types";
+import { clampRangeToDocSize, resolveFolioAIBlockRange } from "../utils/aiEditRange";
 
 export type UseDocxEditorRefApiOptions = {
   /** Headless controller handle (imperative API + events; Seam 6). */
@@ -46,6 +64,20 @@ export type UseDocxEditorRefApiOptions = {
   pagesViewportRef: Ref<HTMLElement | null>;
   /** Current zoom factor (1 = 100%). */
   zoom: Ref<number>;
+  /**
+   * Scroll the pages viewport so a PM document position is visible (from
+   * usePagesPointer). Backs the AI-edit / content-control scroll methods, the
+   * Vue analogue of React's `PagedEditorRef.scrollToPosition`.
+   */
+  scrollVisiblePositionIntoView: (pmPos: number) => void;
+  /** Editor author, used as the default operation author for AI edits. */
+  author: () => string;
+  /**
+   * Mint a comment for an AI-edit operation that carries comment text, append
+   * it to the thread list, and return its id (mirrors React's `createCommentId`
+   * closure over the comment manager). Wired from useCommentManagement.
+   */
+  createAIEditComment: (text: string) => number;
   // Action handles from useDocxEditor.
   focus: () => void;
   getDocument: () => Document | null;
@@ -157,23 +189,158 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
     // The fork's controller ensureView() takes no focus argument yet; the
     // { focus } option is accepted for React parity but ignored (PORT-BLOCKED).
     ensureEditorView: () => opts.editor.ensureView(),
-    // PORT-BLOCKED: AI-edit surface (snapshot/apply/accept/reject/scroll) needs
-    // the folio-core ai-edits bridge wired through a composable; not ported.
-    createAIEditSnapshot: () => null,
-    applyAIEditOperations: () => ({ applied: [], skipped: [] }),
-    acceptAIEditOperation: () => false,
-    rejectAIEditOperation: () => false,
+    createAIEditSnapshot: () => {
+      const view = opts.editorView.value;
+      return view ? createFolioAIEditSnapshot(view.state.doc) : null;
+    },
+    applyAIEditOperations: ({
+      snapshot,
+      operations,
+      mode = "tracked-changes",
+      author: operationAuthor = opts.author(),
+    }) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return {
+          applied: [],
+          skipped: operations.map((operation) => ({
+            id: operation.id,
+            reason: "unsupportedBlock",
+          })),
+        };
+      }
+      return applyFolioAIEditOperations({
+        view,
+        snapshot,
+        operations,
+        mode,
+        author: operationAuthor,
+        createCommentId: opts.createAIEditComment,
+      });
+    },
+    acceptAIEditOperation: (revisionIds) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      return acceptAIEditRevision(revisionIds)(view.state, view.dispatch);
+    },
+    rejectAIEditOperation: (revisionIds) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      return rejectAIEditRevision(revisionIds)(view.state, view.dispatch);
+    },
     undo: () => opts.editor.undo(),
     redo: () => opts.editor.redo(),
-    scrollToAIEditOperation: () => false,
-    scrollToBlock: () => false,
-    // PORT-BLOCKED: content-control ref methods need transaction wrappers over
-    // folio-core/content-controls; not ported.
-    getContentControls: () => [],
-    scrollToContentControl: () => false,
-    setContentControlContent: () => false,
-    setContentControlValue: () => false,
-    removeContentControl: () => false,
+    scrollToAIEditOperation: (revisionIds) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      const range = findAIEditRevisionRange(view.state, revisionIds);
+      if (!range) {
+        return false;
+      }
+      // `TextSelection.between` clamps to the nearest valid inline position;
+      // `create` throws when from/to land on a block boundary, which is exactly
+      // what happens for marks that wrap an entire paragraph.
+      // `clampRangeToDocSize` guards against a revision range whose endpoints
+      // fell past the doc end after concurrent edits.
+      const { from, to } = clampRangeToDocSize(view.state.doc.content.size, range);
+      const $from = view.state.doc.resolve(from);
+      const $to = view.state.doc.resolve(to);
+      view.dispatch(view.state.tr.setSelection(TextSelection.between($from, $to)));
+      requestAnimationFrame(() => opts.scrollVisiblePositionIntoView(from));
+      return true;
+    },
+    scrollToBlock: (blockId, snapshot) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      // ParaId-backed ids resolve against the live document so queued
+      // suggestions still navigate correctly after earlier accepts insert or
+      // delete paragraphs above them. `seq-*` fallback ids keep using the
+      // snapshot the AI saw.
+      const range = resolveFolioAIBlockRange({ blockId, doc: view.state.doc, snapshot });
+      if (range === null) {
+        return false;
+      }
+      const { from, to } = range;
+      const $from = view.state.doc.resolve(from);
+      const $to = view.state.doc.resolve(to);
+      view.dispatch(view.state.tr.setSelection(TextSelection.between($from, $to)));
+      requestAnimationFrame(() => opts.scrollVisiblePositionIntoView(from));
+      return true;
+    },
+    getContentControls: (filter = {}) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return [];
+      }
+      return findBlockSdtMatches(view.state.doc, filter).map((match) => ({
+        properties: blockSdtAttrsToSdtProperties(match.node),
+        path: match.path,
+        pmPos: match.pos,
+      }));
+    },
+    scrollToContentControl: (filter) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      const match = findBlockSdtMatch(view.state.doc, filter);
+      if (!match) {
+        return false;
+      }
+      // Place selection just inside the SDT (after its opening token).
+      const inside = match.pos + 1;
+      const $pos = view.state.doc.resolve(inside);
+      view.dispatch(view.state.tr.setSelection(TextSelection.near($pos)));
+      requestAnimationFrame(() => opts.scrollVisiblePositionIntoView(inside));
+      return true;
+    },
+    setContentControlContent: (filter, input, options = {}) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      const tr =
+        typeof input === "string"
+          ? setContentControlContentTr(view.state, filter, input, options)
+          : setContentControlContentBlocksTr(view.state, filter, input, options);
+      if (!tr) {
+        return false;
+      }
+      view.dispatch(tr);
+      return true;
+    },
+    setContentControlValue: (filter, input, options = {}) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      const tr = setContentControlValueTr(view.state, filter, input, options);
+      if (!tr) {
+        return false;
+      }
+      view.dispatch(tr);
+      return true;
+    },
+    removeContentControl: (filter, options = {}) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      const tr = removeContentControlTr(view.state, filter, options);
+      if (!tr) {
+        return false;
+      }
+      view.dispatch(tr);
+      return true;
+    },
   } satisfies DocxEditorRef;
 
   return { exposed };

--- a/packages/vue/src/utils/aiEditRange.ts
+++ b/packages/vue/src/utils/aiEditRange.ts
@@ -1,0 +1,95 @@
+/**
+ * Helpers shared by the AI-edit imperative API methods.
+ *
+ * Lives outside `useDocxEditorRefApi.ts` so the bounds-checking logic that
+ * protects `TextSelection.between` from "endpoint not pointing into a node
+ * with inline content" can be unit-tested without spinning up a real PM view.
+ *
+ * Ported verbatim from the React adapter's `components/aiEditRange.ts` so the
+ * two adapters resolve block/revision ranges identically (React ≡ Vue).
+ */
+
+import type { Node as PMNode } from "prosemirror-model";
+
+import { createFolioAIEditSnapshot } from "@stll/folio-core/ai-edits/snapshot";
+import type { FolioAIBlockAnchor, FolioAIEditSnapshot } from "@stll/folio-core/ai-edits/types";
+import { findParagraphByParaId } from "@stll/folio-core/prosemirror/utils/findParagraphByParaId";
+import {
+  getFolioParaIdFromBlockId,
+  getSequentialFolioBlockIdIndex,
+} from "@stll/folio-core/types/block-id";
+
+export type DocPositionRange = { from: number; to: number };
+
+type ResolveFolioAIBlockRangeOptions = {
+  blockId: string;
+  doc: PMNode;
+  snapshot?: FolioAIEditSnapshot | null | undefined;
+};
+
+export const resolveFolioAIBlockRange = ({
+  blockId,
+  doc,
+  snapshot,
+}: ResolveFolioAIBlockRangeOptions): DocPositionRange | null => {
+  const paraId = getFolioParaIdFromBlockId(blockId);
+  if (paraId !== null) {
+    const liveRange = findParagraphByParaId(doc, paraId);
+    if (liveRange !== null) {
+      return { from: liveRange.from, to: liveRange.to };
+    }
+  }
+
+  const resolvedSnapshot = snapshot ?? createFolioAIEditSnapshot(doc);
+  const anchor =
+    resolvedSnapshot.anchors[blockId] ?? resolveSequentialBlockAnchor(blockId, resolvedSnapshot);
+  if (!anchor) {
+    return null;
+  }
+  return clampRangeToDocSize(doc.content.size, anchor);
+};
+
+/**
+ * Resolve a `seq-NNNN` fallback id by document position.
+ *
+ * A sequential id is only minted for a paragraph the source DOCX left
+ * without a `w14:paraId`. The live editor's `ParaIdAllocator` fills
+ * that gap with a fresh random hex paraId, so a snapshot of the live
+ * document keys the block by that hex and never reproduces the
+ * server's `seq-NNNN`: the direct anchor lookup misses, and a
+ * paraId-based live lookup can't match either (no node carries a
+ * `seq-` paraId). The seq number is the block's 1-based position in
+ * the same non-empty-block walk the server extractor and
+ * `createFolioAIEditSnapshot` share, so it indexes the snapshot's
+ * ordered `blocks` directly.
+ */
+const resolveSequentialBlockAnchor = (
+  blockId: string,
+  snapshot: FolioAIEditSnapshot,
+): FolioAIBlockAnchor | undefined => {
+  const index = getSequentialFolioBlockIdIndex(blockId);
+  if (index === null) {
+    return undefined;
+  }
+  const block = snapshot.blocks.at(index - 1);
+  return block ? snapshot.anchors[block.id] : undefined;
+};
+
+/**
+ * Clamp a `{from, to}` pair so both endpoints fit inside a document of
+ * `docSize` (in PM content positions). Block-boundary snapshots and stale
+ * range data sometimes produce a `to` one past the last inline position;
+ * `view.state.doc.resolve(...)` rejects that with
+ * "Position … out of range", and `TextSelection.between` doesn't help — it
+ * needs *valid* resolved positions. Clamping before resolution is the cheap
+ * defensive step.
+ *
+ * Order is preserved: if both endpoints exceed `docSize`, the returned
+ * `from` may equal `to`, yielding a cursor selection at the doc end.
+ */
+export function clampRangeToDocSize(docSize: number, range: DocPositionRange): DocPositionRange {
+  return {
+    from: Math.min(Math.max(range.from, 0), docSize),
+    to: Math.min(Math.max(range.to, 0), docSize),
+  };
+}

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -74,8 +74,12 @@
   "ref": {
     "comment": "DocxEditorRef parity. Both adapters declare an identical DocxEditorRef type surface (Vue's assembled object `satisfies DocxEditorRef`). `paired` members have a real implementation in useDocxEditorRefApi.ts; `deferredInVue` members are stubbed to a constant (null / false / [] / no-op) with a PORT-BLOCKED note in that file, pending the backing composable/component.",
     "paired": [
+      "acceptAIEditOperation",
+      "applyAIEditOperations",
+      "createAIEditSnapshot",
       "ensureEditorView",
       "focus",
+      "getContentControls",
       "getCurrentPage",
       "getDocument",
       "getEditor",
@@ -86,26 +90,22 @@
       "openPrintPreview",
       "print",
       "redo",
+      "rejectAIEditOperation",
+      "removeContentControl",
       "save",
+      "scrollToAIEditOperation",
+      "scrollToBlock",
+      "scrollToContentControl",
       "scrollToPage",
       "scrollToParaId",
+      "setContentControlContent",
+      "setContentControlValue",
       "setZoom",
       "undo"
     ],
     "deferredInVue": {
-      "acceptAIEditOperation": "AI-edit surface is not ported; stubbed to return false.",
-      "applyAIEditOperations": "AI-edit surface is not ported; stubbed to an empty apply result.",
-      "createAIEditSnapshot": "AI-edit surface is not ported; stubbed to return null.",
-      "getContentControls": "Content-control ref methods need transaction wrappers over folio-core/content-controls; stubbed to [].",
       "getEditorRef": "Requires the Vue PagedEditor component, not ported; stubbed to return null.",
-      "hasPendingChanges": "Requires PM-serialized-vs-live tracking the Vue pipeline does not surface; stubbed to false.",
-      "rejectAIEditOperation": "AI-edit surface is not ported; stubbed to return false.",
-      "removeContentControl": "Content-control mutation is not ported; stubbed to return false.",
-      "scrollToAIEditOperation": "AI-edit surface is not ported; stubbed to return false.",
-      "scrollToBlock": "Block-scroll navigation is not ported; stubbed to return false.",
-      "scrollToContentControl": "Content-control navigation is not ported; stubbed to return false.",
-      "setContentControlContent": "Content-control mutation is not ported; stubbed to return false.",
-      "setContentControlValue": "Content-control mutation is not ported; stubbed to return false."
+      "hasPendingChanges": "Requires PM-serialized-vs-live tracking the Vue pipeline does not surface; stubbed to false."
     }
   }
 }

--- a/tests/parity/ai-edit-snapshot.spec.ts
+++ b/tests/parity/ai-edit-snapshot.spec.ts
@@ -1,0 +1,16 @@
+import { ensureLiveView, expect, forEachAdapter, openEditor } from "./parity-fixture";
+
+// Both adapters now wire `createAIEditSnapshot` over the shared
+// `@stll/folio-core/ai-edits` snapshot builder. Driving it through the bridge
+// proves the AI-edit snapshot surface is present and produces a non-empty block
+// list in each adapter — the precondition the AI chat composer gates "send" on.
+// Because both playgrounds parse the same fixture with the same core builder,
+// the block count is deterministic and identical across React and Vue.
+forEachAdapter("ai-edit: createAIEditSnapshot yields blocks", async (adapter, { page }) => {
+  await openEditor(page, adapter);
+  await ensureLiveView(page);
+
+  const blockCount = await page.evaluate(() => window.__folioParity?.aiSnapshotBlockCount() ?? -1);
+
+  expect(blockCount).toBeGreaterThan(0);
+});

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -24,6 +24,7 @@ type FolioParityBridge = {
   countTables: () => number;
   commentFirstWord: () => boolean;
   countCommentAnchors: () => number;
+  aiSnapshotBlockCount: () => number;
   save: () => Promise<number>;
 };
 


### PR DESCRIPTION
Wires all 11 stubbed DocxEditorRef methods (createAIEditSnapshot/applyAIEditOperations/accept-reject/scrollTo*/scrollToBlock + getContentControls/scrollToContentControl/setContentControlContent/setContentControlValue/removeContentControl) over core ai-edits + content-controls, mirroring React. Only getEditorRef + hasPendingChanges remain deferred (need a Vue PagedEditor / PM-serialized tracking). Adds ai-edit-snapshot parity spec; test:e2e:parity 14/14.