### PR TITLE
feat(vue): standalone FormattingBar + ZoomControl (close export-parity divergence)

### DIFF
--- a/.changeset/vue-formatbar-zoom.md
+++ b/.changeset/vue-formatbar-zoom.md
@@ -1,0 +1,11 @@
+---
+"@stll/folio-vue": minor
+---
+
+Add standalone `FormattingBar` and `ZoomControl` Vue components, matching the
+React adapter's public surface. Both are controlled and own no editor view, so a
+host can render them outside `<DocxEditor>`. `FormattingBar` (`FormattingBarProps`)
+composes the existing Vue pickers into the minimal rail (undo/redo | style |
+B/I/U | color | align/lists/indent) and emits `format` / `undo` / `redo`;
+`ZoomControl` (`ZoomControlProps`, `ZoomLevel`) is a compact zoom-level dropdown.
+This closes the corresponding React/Vue export-parity divergence entries.

--- a/api-reports/vue/index.api.md
+++ b/api-reports/vue/index.api.md
@@ -81,7 +81,6 @@ import { FolioBlockId } from '@stll/folio-core/types/block-id';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
 import { default as FormattingBar } from './components/FormattingBar.vue';
-import { FormattingBarProps } from './components/FormattingBar.vue';
 import { fromMarkdown } from '@stll/folio-core/markdown';
 import { getAnonymizationMatches } from '@stll/folio-core/prosemirror/plugins/anonymizationDecorations';
 import { getAutocompleteSuggestion } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
@@ -141,8 +140,6 @@ import { VNodeChild } from 'vue';
 import { WordDiffSegment } from '@stll/folio-core/ai-edits';
 import { XmlFragment } from 'yjs';
 import { default as ZoomControl } from './components/ui/ZoomControl.vue';
-import { ZoomControlProps } from './components/ui/ZoomControl.vue';
-import { ZoomLevel } from './components/ui/ZoomControl.vue';
 
 export { AcceptAutocompleteResult }
 
@@ -461,7 +458,20 @@ export type FontOption = {
 
 export { FormattingBar }
 
-export { FormattingBarProps }
+// @public (undocumented)
+export type FormattingBarProps = {
+    currentFormatting?: SelectionFormatting;
+    disabled?: boolean;
+    canUndo?: boolean;
+    canRedo?: boolean;
+    className?: string;
+    showStylePicker?: boolean;
+    showTextColorPicker?: boolean;
+    showAlignmentButtons?: boolean;
+    showListButtons?: boolean;
+    documentStyles?: StyleOption[];
+    theme?: Theme | null;
+};
 
 export { fromMarkdown }
 
@@ -579,8 +589,19 @@ export { WordDiffSegment }
 
 export { ZoomControl }
 
-export { ZoomControlProps }
+// @public (undocumented)
+export type ZoomControlProps = {
+    value?: number;
+    levels?: ZoomLevel[];
+    disabled?: boolean;
+    className?: string;
+    compact?: boolean;
+};
 
-export { ZoomLevel }
+// @public
+export type ZoomLevel = {
+    value: number;
+    label: string;
+};
 
 ```

--- a/api-reports/vue/index.api.md
+++ b/api-reports/vue/index.api.md
@@ -80,6 +80,8 @@ import { FolioAISignatureParty } from '@stll/folio-core/ai-edits';
 import { FolioBlockId } from '@stll/folio-core/types/block-id';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
+import { default as FormattingBar } from './components/FormattingBar.vue';
+import { FormattingBarProps } from './components/FormattingBar.vue';
 import { fromMarkdown } from '@stll/folio-core/markdown';
 import { getAnonymizationMatches } from '@stll/folio-core/prosemirror/plugins/anonymizationDecorations';
 import { getAutocompleteSuggestion } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
@@ -138,6 +140,9 @@ import { TripwireResult } from '@stll/folio-core/docx/selectiveSaveTripwire';
 import { VNodeChild } from 'vue';
 import { WordDiffSegment } from '@stll/folio-core/ai-edits';
 import { XmlFragment } from 'yjs';
+import { default as ZoomControl } from './components/ui/ZoomControl.vue';
+import { ZoomControlProps } from './components/ui/ZoomControl.vue';
+import { ZoomLevel } from './components/ui/ZoomControl.vue';
 
 export { AcceptAutocompleteResult }
 
@@ -454,6 +459,10 @@ export type FontOption = {
     category?: "sans-serif" | "serif" | "monospace" | "other";
 };
 
+export { FormattingBar }
+
+export { FormattingBarProps }
+
 export { fromMarkdown }
 
 export { getAnonymizationMatches }
@@ -567,5 +576,11 @@ export const useTranslation: () => {
 export function useWheelZoom(initialZoom?: number): UseZoomReturn;
 
 export { WordDiffSegment }
+
+export { ZoomControl }
+
+export { ZoomControlProps }
+
+export { ZoomLevel }
 
 ```

--- a/packages/vue/src/components/FormattingBar.types.ts
+++ b/packages/vue/src/components/FormattingBar.types.ts
@@ -1,0 +1,79 @@
+/**
+ * Types for `FormattingBar.vue`, kept in a plain `.ts` module so the package's
+ * public `index.ts` can re-export `FormattingBarProps` without resolving a
+ * `.vue` SFC. A plain `tsc` (e.g. the Nuxt adapter's typecheck) sees `.vue`
+ * imports only through an ambient default-export shim, so named type exports
+ * must live in `.ts` files.
+ */
+
+import type { ColorValue, Theme } from "@stll/folio-core/types/document";
+import type { ListState } from "../utils/listState";
+import type { ParagraphAlignment } from "./ui/AlignmentButtons.types";
+import type { StyleOption } from "./ui/StylePicker.types";
+
+/**
+ * The controls the minimal bar can emit. Mirrors the relevant subset of
+ * React's `FormattingAction` (packages/react/src/components/toolbarPrimitives.tsx):
+ * mark toggles + list/indent verbs, plus the object-shaped alignment / style /
+ * text-color intents.
+ */
+export type FormattingAction =
+  | "bold"
+  | "italic"
+  | "underline"
+  | "bulletList"
+  | "numberedList"
+  | "indent"
+  | "outdent"
+  | { type: "alignment"; value: ParagraphAlignment }
+  | { type: "applyStyle"; value: string }
+  | { type: "textColor"; value: ColorValue | string };
+
+/**
+ * Current formatting of the selection driving the bar's active states.
+ * Mirrors the fields React's `SelectionFormatting` exposes that the minimal
+ * bar reads.
+ */
+export type SelectionFormatting = {
+  /** Whether selected text is bold. */
+  bold?: boolean | undefined;
+  /** Whether selected text is italic. */
+  italic?: boolean | undefined;
+  /** Whether selected text is underlined. */
+  underline?: boolean | undefined;
+  /** Text color (hex, with or without a leading `#`). */
+  color?: string | undefined;
+  /** Paragraph alignment. */
+  alignment?: ParagraphAlignment | undefined;
+  /** List state of the current paragraph. */
+  listState?: ListState | undefined;
+  /** Paragraph style id. */
+  styleId?: string | undefined;
+  /** Paragraph left indentation in twips. */
+  indentLeft?: number | undefined;
+};
+
+export type FormattingBarProps = {
+  /** Current formatting of the selection (drives active states). */
+  currentFormatting?: SelectionFormatting;
+  /** Whether the bar is disabled. */
+  disabled?: boolean;
+  /** Whether undo is available. */
+  canUndo?: boolean;
+  /** Whether redo is available. */
+  canRedo?: boolean;
+  /** Additional CSS class name. */
+  className?: string;
+  /** Whether to show the paragraph-style picker (default: true). */
+  showStylePicker?: boolean;
+  /** Whether to show the text-color picker (default: true). */
+  showTextColorPicker?: boolean;
+  /** Whether to show the alignment control (default: true). */
+  showAlignmentButtons?: boolean;
+  /** Whether to show the list + indent controls (default: true). */
+  showListButtons?: boolean;
+  /** Document styles for the style picker (Vue `StylePicker` option shape). */
+  documentStyles?: StyleOption[];
+  /** Document theme — feeds the color picker's theme-color matrix. */
+  theme?: Theme | null;
+};

--- a/packages/vue/src/components/FormattingBar.vue
+++ b/packages/vue/src/components/FormattingBar.vue
@@ -1,0 +1,338 @@
+<!--
+  Vue port of packages/react/src/components/FormattingBar.tsx —
+  a clean, minimal, controlled formatting bar for legal document editing.
+
+  Controls (left to right):
+  Undo Redo | Style ▾ | B I U | A▾ | ≡ 1. ◁ ▷
+
+  Standalone + controlled, mirroring React: it owns no editor view. The host
+  passes the selection's current formatting via `currentFormatting` and wires
+  the emitted `format` / `undo` / `redo` events back into the document (React
+  threads the same intent through its `onFormat` / `onUndo` / `onRedo` props).
+  Everything else (font, size, highlight, comments) is reachable via keyboard
+  shortcuts or the host app's chrome, matching React's minimal subset.
+
+  Composes the same Vue `ui/` pickers the full <Toolbar> uses (StylePicker,
+  ColorPicker, AlignmentButtons, ListButtons) so the two rails stay visually
+  and behaviourally aligned.
+-->
+<template>
+  <div
+    class="docx-formatting-bar"
+    :class="className"
+    role="toolbar"
+    :aria-label="t('formattingToolbar')"
+    data-folio-toolbar="true"
+  >
+    <!-- Undo / Redo -->
+    <span class="docx-formatting-bar__group" role="group" :aria-label="t('historyGroup')">
+      <button
+        type="button"
+        class="docx-formatting-bar__btn"
+        :disabled="disabled || !canUndo"
+        :title="t('undoShortcut')"
+        :aria-label="t('undo')"
+        @mousedown.prevent="$emit('undo')"
+      >
+        <MaterialSymbol name="undo" :size="18" />
+      </button>
+      <button
+        type="button"
+        class="docx-formatting-bar__btn"
+        :disabled="disabled || !canRedo"
+        :title="t('redoShortcut')"
+        :aria-label="t('redo')"
+        @mousedown.prevent="$emit('redo')"
+      >
+        <MaterialSymbol name="redo" :size="18" />
+      </button>
+    </span>
+
+    <span class="docx-formatting-bar__divider" role="separator" />
+
+    <!-- Paragraph style -->
+    <template v-if="showStylePicker">
+      <!-- `styles` is passed only when supplied so StylePicker keeps its own
+           default-preset fallback (its prop is non-`undefined` under
+           exactOptionalPropertyTypes). -->
+      <StylePicker
+        :value="currentFormatting.styleId ?? 'Normal'"
+        v-bind="stylePickerStyles"
+        :disabled="disabled"
+        @change="(styleId: string) => emit('format', { type: 'applyStyle', value: styleId })"
+      />
+      <span class="docx-formatting-bar__divider" role="separator" />
+    </template>
+
+    <!-- Bold / Italic / Underline -->
+    <span class="docx-formatting-bar__group" role="group" :aria-label="t('textFormattingGroup')">
+      <button
+        type="button"
+        class="docx-formatting-bar__btn"
+        :class="{ 'docx-formatting-bar__btn--active': currentFormatting.bold }"
+        :disabled="disabled"
+        :title="t('boldShortcut')"
+        :aria-label="t('bold')"
+        :aria-pressed="!!currentFormatting.bold"
+        @mousedown.prevent="emit('format', 'bold')"
+      >
+        <MaterialSymbol name="format_bold" :size="18" />
+      </button>
+      <button
+        type="button"
+        class="docx-formatting-bar__btn"
+        :class="{ 'docx-formatting-bar__btn--active': currentFormatting.italic }"
+        :disabled="disabled"
+        :title="t('italicShortcut')"
+        :aria-label="t('italic')"
+        :aria-pressed="!!currentFormatting.italic"
+        @mousedown.prevent="emit('format', 'italic')"
+      >
+        <MaterialSymbol name="format_italic" :size="18" />
+      </button>
+      <button
+        type="button"
+        class="docx-formatting-bar__btn"
+        :class="{ 'docx-formatting-bar__btn--active': currentFormatting.underline }"
+        :disabled="disabled"
+        :title="t('underlineShortcut')"
+        :aria-label="t('underline')"
+        :aria-pressed="!!currentFormatting.underline"
+        @mousedown.prevent="emit('format', 'underline')"
+      >
+        <MaterialSymbol name="format_underlined" :size="18" />
+      </button>
+    </span>
+
+    <!-- Text color -->
+    <template v-if="showTextColorPicker">
+      <span class="docx-formatting-bar__divider" role="separator" />
+      <ColorPicker
+        mode="text"
+        :value="textColorHex"
+        :theme="theme ?? null"
+        :disabled="disabled"
+        @change="onTextColor"
+      />
+    </template>
+
+    <span class="docx-formatting-bar__divider" role="separator" />
+
+    <!-- Alignment -->
+    <AlignmentButtons
+      v-if="showAlignmentButtons"
+      :value="currentFormatting.alignment ?? 'left'"
+      :disabled="disabled"
+      @change="
+        (alignment: ParagraphAlignment) => emit('format', { type: 'alignment', value: alignment })
+      "
+    />
+
+    <!-- Lists + indent -->
+    <ListButtons
+      v-if="showListButtons"
+      :list-state="listState"
+      :disabled="disabled"
+      :can-outdent="canOutdent"
+      @bullet-list="emit('format', 'bulletList')"
+      @numbered-list="emit('format', 'numberedList')"
+      @indent="emit('format', 'indent')"
+      @outdent="emit('format', 'outdent')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import type { ColorValue, Theme } from "@stll/folio-core/types/document";
+import type { ListState } from "../utils/listState";
+import type { ParagraphAlignment } from "./ui/AlignmentButtons.vue";
+import type { StyleOption } from "./ui/StylePicker.vue";
+
+/**
+ * The controls the minimal bar can emit. Mirrors the relevant subset of
+ * React's `FormattingAction` (packages/react/src/components/toolbarPrimitives.tsx):
+ * mark toggles + list/indent verbs, plus the object-shaped alignment / style /
+ * text-color intents.
+ */
+export type FormattingAction =
+  | "bold"
+  | "italic"
+  | "underline"
+  | "bulletList"
+  | "numberedList"
+  | "indent"
+  | "outdent"
+  | { type: "alignment"; value: ParagraphAlignment }
+  | { type: "applyStyle"; value: string }
+  | { type: "textColor"; value: ColorValue | string };
+
+/**
+ * Current formatting of the selection driving the bar's active states.
+ * Mirrors the fields React's `SelectionFormatting` exposes that the minimal
+ * bar reads.
+ */
+export type SelectionFormatting = {
+  /** Whether selected text is bold. */
+  bold?: boolean | undefined;
+  /** Whether selected text is italic. */
+  italic?: boolean | undefined;
+  /** Whether selected text is underlined. */
+  underline?: boolean | undefined;
+  /** Text color (hex, with or without a leading `#`). */
+  color?: string | undefined;
+  /** Paragraph alignment. */
+  alignment?: ParagraphAlignment | undefined;
+  /** List state of the current paragraph. */
+  listState?: ListState | undefined;
+  /** Paragraph style id. */
+  styleId?: string | undefined;
+  /** Paragraph left indentation in twips. */
+  indentLeft?: number | undefined;
+};
+
+export type FormattingBarProps = {
+  /** Current formatting of the selection (drives active states). */
+  currentFormatting?: SelectionFormatting;
+  /** Whether the bar is disabled. */
+  disabled?: boolean;
+  /** Whether undo is available. */
+  canUndo?: boolean;
+  /** Whether redo is available. */
+  canRedo?: boolean;
+  /** Additional CSS class name. */
+  className?: string;
+  /** Whether to show the paragraph-style picker (default: true). */
+  showStylePicker?: boolean;
+  /** Whether to show the text-color picker (default: true). */
+  showTextColorPicker?: boolean;
+  /** Whether to show the alignment control (default: true). */
+  showAlignmentButtons?: boolean;
+  /** Whether to show the list + indent controls (default: true). */
+  showListButtons?: boolean;
+  /** Document styles for the style picker (Vue `StylePicker` option shape). */
+  documentStyles?: StyleOption[];
+  /** Document theme — feeds the color picker's theme-color matrix. */
+  theme?: Theme | null;
+};
+</script>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import MaterialSymbol from "./ui/MaterialSymbol.vue";
+import StylePicker from "./ui/StylePicker.vue";
+import ColorPicker from "./ui/ColorPicker.vue";
+import AlignmentButtons from "./ui/AlignmentButtons.vue";
+import ListButtons from "./ui/ListButtons.vue";
+import { createDefaultListState } from "../utils/listState";
+import { useTranslation } from "../i18n";
+
+const props = withDefaults(defineProps<FormattingBarProps>(), {
+  disabled: false,
+  canUndo: false,
+  canRedo: false,
+  showStylePicker: true,
+  showTextColorPicker: true,
+  showAlignmentButtons: true,
+  showListButtons: true,
+});
+
+const emit = defineEmits<{
+  (e: "format", action: FormattingAction): void;
+  (e: "undo"): void;
+  (e: "redo"): void;
+}>();
+
+const { t } = useTranslation();
+
+const currentFormatting = computed<SelectionFormatting>(() => props.currentFormatting ?? {});
+
+// Omit `styles` entirely when the host passes none, so StylePicker falls back
+// to its built-in presets instead of receiving `undefined`.
+const stylePickerStyles = computed<{ styles: StyleOption[] } | Record<string, never>>(() =>
+  props.documentStyles ? { styles: props.documentStyles } : {},
+);
+
+// ListButtons requires a concrete ListState (its prop is non-`undefined` under
+// exactOptionalPropertyTypes); fall back to the empty default like React does.
+const listState = computed<ListState>(
+  () => currentFormatting.value.listState ?? createDefaultListState(),
+);
+
+// Hex (no `#`, uppercase) of the applied text color, matching the active
+// swatch in the picker — mirrors Toolbar.vue's `currentTextColorHex`.
+const textColorHex = computed<string | undefined>(() => {
+  const color = currentFormatting.value.color;
+  return color ? color.replace(/^#/, "").toUpperCase() : undefined;
+});
+
+// Outdent is only meaningful in a nested list level or when the paragraph
+// already carries a left indent — mirrors Toolbar.vue's `canOutdent`.
+const canOutdent = computed(() => {
+  const current = listState.value;
+  const inNestedList = current.isInList && current.level > 0;
+  return inNestedList || (currentFormatting.value.indentLeft ?? 0) > 0;
+});
+
+function onTextColor(color: ColorValue | string) {
+  emit("format", { type: "textColor", value: color });
+}
+</script>
+
+<style scoped>
+.docx-formatting-bar {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--doc-border);
+  background: var(--doc-page);
+  scrollbar-width: none;
+}
+.docx-formatting-bar::-webkit-scrollbar {
+  display: none;
+}
+.docx-formatting-bar__group {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.docx-formatting-bar__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--doc-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
+}
+.docx-formatting-bar__btn:hover:not(:disabled) {
+  background: var(--doc-primary-light);
+  color: var(--doc-text);
+}
+.docx-formatting-bar__btn--active,
+.docx-formatting-bar__btn--active:hover {
+  background: var(--doc-primary-light);
+  color: var(--doc-text);
+}
+.docx-formatting-bar__btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+.docx-formatting-bar__divider {
+  width: 1px;
+  height: 24px;
+  margin: 0 8px;
+  background: var(--doc-border);
+  flex-shrink: 0;
+}
+</style>

--- a/packages/vue/src/components/FormattingBar.vue
+++ b/packages/vue/src/components/FormattingBar.vue
@@ -142,80 +142,6 @@
   </div>
 </template>
 
-<script lang="ts">
-import type { ColorValue, Theme } from "@stll/folio-core/types/document";
-import type { ListState } from "../utils/listState";
-import type { ParagraphAlignment } from "./ui/AlignmentButtons.vue";
-import type { StyleOption } from "./ui/StylePicker.vue";
-
-/**
- * The controls the minimal bar can emit. Mirrors the relevant subset of
- * React's `FormattingAction` (packages/react/src/components/toolbarPrimitives.tsx):
- * mark toggles + list/indent verbs, plus the object-shaped alignment / style /
- * text-color intents.
- */
-export type FormattingAction =
-  | "bold"
-  | "italic"
-  | "underline"
-  | "bulletList"
-  | "numberedList"
-  | "indent"
-  | "outdent"
-  | { type: "alignment"; value: ParagraphAlignment }
-  | { type: "applyStyle"; value: string }
-  | { type: "textColor"; value: ColorValue | string };
-
-/**
- * Current formatting of the selection driving the bar's active states.
- * Mirrors the fields React's `SelectionFormatting` exposes that the minimal
- * bar reads.
- */
-export type SelectionFormatting = {
-  /** Whether selected text is bold. */
-  bold?: boolean | undefined;
-  /** Whether selected text is italic. */
-  italic?: boolean | undefined;
-  /** Whether selected text is underlined. */
-  underline?: boolean | undefined;
-  /** Text color (hex, with or without a leading `#`). */
-  color?: string | undefined;
-  /** Paragraph alignment. */
-  alignment?: ParagraphAlignment | undefined;
-  /** List state of the current paragraph. */
-  listState?: ListState | undefined;
-  /** Paragraph style id. */
-  styleId?: string | undefined;
-  /** Paragraph left indentation in twips. */
-  indentLeft?: number | undefined;
-};
-
-export type FormattingBarProps = {
-  /** Current formatting of the selection (drives active states). */
-  currentFormatting?: SelectionFormatting;
-  /** Whether the bar is disabled. */
-  disabled?: boolean;
-  /** Whether undo is available. */
-  canUndo?: boolean;
-  /** Whether redo is available. */
-  canRedo?: boolean;
-  /** Additional CSS class name. */
-  className?: string;
-  /** Whether to show the paragraph-style picker (default: true). */
-  showStylePicker?: boolean;
-  /** Whether to show the text-color picker (default: true). */
-  showTextColorPicker?: boolean;
-  /** Whether to show the alignment control (default: true). */
-  showAlignmentButtons?: boolean;
-  /** Whether to show the list + indent controls (default: true). */
-  showListButtons?: boolean;
-  /** Document styles for the style picker (Vue `StylePicker` option shape). */
-  documentStyles?: StyleOption[];
-  /** Document theme — feeds the color picker's theme-color matrix. */
-  theme?: Theme | null;
-};
-</script>
-
 <script setup lang="ts">
 import { computed } from "vue";
 import MaterialSymbol from "./ui/MaterialSymbol.vue";
@@ -225,6 +151,11 @@ import AlignmentButtons from "./ui/AlignmentButtons.vue";
 import ListButtons from "./ui/ListButtons.vue";
 import { createDefaultListState } from "../utils/listState";
 import { useTranslation } from "../i18n";
+import type { ColorValue } from "@stll/folio-core/types/document";
+import type { ListState } from "../utils/listState";
+import type { ParagraphAlignment } from "./ui/AlignmentButtons.types";
+import type { StyleOption } from "./ui/StylePicker.types";
+import type { FormattingAction, FormattingBarProps, SelectionFormatting } from "./FormattingBar.types";
 
 const props = withDefaults(defineProps<FormattingBarProps>(), {
   disabled: false,

--- a/packages/vue/src/components/FormattingBar.vue
+++ b/packages/vue/src/components/FormattingBar.vue
@@ -32,7 +32,7 @@
         :disabled="disabled || !canUndo"
         :title="t('undoShortcut')"
         :aria-label="t('undo')"
-        @mousedown.prevent="$emit('undo')"
+        @mousedown.prevent="emit('undo')"
       >
         <MaterialSymbol name="undo" :size="18" />
       </button>
@@ -42,7 +42,7 @@
         :disabled="disabled || !canRedo"
         :title="t('redoShortcut')"
         :aria-label="t('redo')"
-        @mousedown.prevent="$emit('redo')"
+        @mousedown.prevent="emit('redo')"
       >
         <MaterialSymbol name="redo" :size="18" />
       </button>
@@ -245,6 +245,10 @@ function onTextColor(color: ColorValue | string) {
   transition:
     background-color 0.1s ease,
     color 0.1s ease;
+}
+.docx-formatting-bar__btn:focus-visible {
+  outline: 2px solid var(--doc-primary);
+  outline-offset: 2px;
 }
 .docx-formatting-bar__btn:hover:not(:disabled) {
   background: var(--doc-primary-light);

--- a/packages/vue/src/components/ui/AlignmentButtons.types.ts
+++ b/packages/vue/src/components/ui/AlignmentButtons.types.ts
@@ -1,0 +1,14 @@
+/**
+ * Types for `AlignmentButtons.vue`, kept in a plain `.ts` module so downstream
+ * `.ts` consumers (and the standalone `FormattingBar`) can import the type
+ * without resolving a `.vue` SFC. A plain `tsc` (e.g. the Nuxt adapter's
+ * typecheck) sees `.vue` imports only through an ambient default-export shim, so
+ * named type exports must live in `.ts` files.
+ */
+
+/**
+ * Paragraph alignment the picker offers. Intentionally the narrow subset the
+ * minimal toolbar exposes; core's `ParagraphAlignment` is a wider superset
+ * (distribute + Kashida variants) that this control does not surface.
+ */
+export type ParagraphAlignment = "left" | "center" | "right" | "both";

--- a/packages/vue/src/components/ui/AlignmentButtons.vue
+++ b/packages/vue/src/components/ui/AlignmentButtons.vue
@@ -43,8 +43,7 @@
 import { ref, computed } from 'vue';
 import MaterialSymbol from './MaterialSymbol.vue';
 import Popover from './Popover.vue';
-
-export type ParagraphAlignment = 'left' | 'center' | 'right' | 'both';
+import type { ParagraphAlignment } from './AlignmentButtons.types';
 
 const props = withDefaults(
   defineProps<{

--- a/packages/vue/src/components/ui/StylePicker.types.ts
+++ b/packages/vue/src/components/ui/StylePicker.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Types for `StylePicker.vue`, kept in a plain `.ts` module so downstream `.ts`
+ * consumers (and the standalone `FormattingBar`) can import the type without
+ * resolving a `.vue` SFC. A plain `tsc` (e.g. the Nuxt adapter's typecheck) sees
+ * `.vue` imports only through an ambient default-export shim, so named type
+ * exports must live in `.ts` files.
+ */
+
+/** A single paragraph-style option the picker can offer. */
+export type StyleOption = {
+  styleId: string;
+  name: string;
+  fontSize?: number;
+  bold?: boolean;
+  italic?: boolean;
+  color?: string;
+};

--- a/packages/vue/src/components/ui/StylePicker.vue
+++ b/packages/vue/src/components/ui/StylePicker.vue
@@ -25,15 +25,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-
-export type StyleOption = {
-  styleId: string;
-  name: string;
-  fontSize?: number;
-  bold?: boolean;
-  italic?: boolean;
-  color?: string;
-}
+import type { StyleOption } from './StylePicker.types';
 
 const props = withDefaults(
   defineProps<{

--- a/packages/vue/src/components/ui/ZoomControl.types.ts
+++ b/packages/vue/src/components/ui/ZoomControl.types.ts
@@ -1,0 +1,23 @@
+/**
+ * Types for `ZoomControl.vue`, kept in a plain `.ts` module so the package's
+ * public `index.ts` can re-export them without resolving a `.vue` SFC. A plain
+ * `tsc` (e.g. the Nuxt adapter's typecheck) sees `.vue` imports only through an
+ * ambient default-export shim, so named type exports must live in `.ts` files.
+ */
+
+/** A single zoom preset: `value` is a scale factor (1 = 100%). */
+export type ZoomLevel = {
+  value: number;
+  label: string;
+};
+
+export type ZoomControlProps = {
+  /** Current zoom (1 = 100%). */
+  value?: number;
+  /** Override the preset levels offered in the dropdown. */
+  levels?: ZoomLevel[];
+  disabled?: boolean;
+  className?: string;
+  /** Render the trigger at the smaller toolbar-chrome size. */
+  compact?: boolean;
+};

--- a/packages/vue/src/components/ui/ZoomControl.vue
+++ b/packages/vue/src/components/ui/ZoomControl.vue
@@ -1,0 +1,125 @@
+<!--
+  Vue port of packages/react/src/components/ui/ZoomControl.tsx —
+  a compact, controlled dropdown for choosing the editor's document zoom
+  level. Same DEFAULT_ZOOM_LEVELS (50/75/100/125/150/200%) and same
+  near-preset matching as React so a continuous-zoom float (e.g. 0.9999)
+  still highlights the 100% preset.
+
+  Controlled + standalone, mirroring React: it neither owns zoom state nor
+  consumes `useZoom` (that composable owns the wheel/keyboard path). The host
+  passes the current `value` and reacts to `@change`.
+-->
+<template>
+  <select
+    class="docx-zoom-control"
+    :class="[{ 'docx-zoom-control--compact': compact }, className]"
+    :value="selectValue"
+    :disabled="disabled"
+    aria-label="Zoom level"
+    @change="onChange"
+  >
+    <!-- A near-preset float has no matching <option>, so surface it as a
+         transient option (e.g. "97%") that stays selected until the next
+         preset is picked. -->
+    <option v-if="!matchingLevel" :value="selectValue">{{ displayLabel }}</option>
+    <option v-for="level in resolvedLevels" :key="level.value" :value="String(level.value)">
+      {{ level.label }}
+    </option>
+  </select>
+</template>
+
+<script lang="ts">
+/** A single zoom preset: `value` is a scale factor (1 = 100%). */
+export type ZoomLevel = {
+  value: number;
+  label: string;
+};
+
+export type ZoomControlProps = {
+  /** Current zoom (1 = 100%). */
+  value?: number;
+  /** Override the preset levels offered in the dropdown. */
+  levels?: ZoomLevel[];
+  disabled?: boolean;
+  className?: string;
+  /** Render the trigger at the smaller toolbar-chrome size. */
+  compact?: boolean;
+};
+
+const DEFAULT_ZOOM_LEVELS: ZoomLevel[] = [
+  { value: 0.5, label: "50%" },
+  { value: 0.75, label: "75%" },
+  { value: 1, label: "100%" },
+  { value: 1.25, label: "125%" },
+  { value: 1.5, label: "150%" },
+  { value: 2, label: "200%" },
+];
+</script>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(defineProps<ZoomControlProps>(), {
+  value: 1,
+  disabled: false,
+  compact: false,
+});
+
+const emit = defineEmits<{
+  (e: "change", zoom: number): void;
+}>();
+
+const resolvedLevels = computed(() => props.levels ?? DEFAULT_ZOOM_LEVELS);
+
+const matchingLevel = computed(() =>
+  resolvedLevels.value.find((level) => Math.abs(level.value - props.value) < 0.001),
+);
+
+const displayLabel = computed(() =>
+  matchingLevel.value ? matchingLevel.value.label : `${Math.round(props.value * 100)}%`,
+);
+
+// Use the matched preset's exact string so the active item highlights even
+// when `value` is a near-preset float (e.g. 0.9999 from continuous zoom).
+const selectValue = computed(() =>
+  matchingLevel.value ? String(matchingLevel.value.value) : String(props.value),
+);
+
+function onChange(e: Event) {
+  if (!(e.target instanceof HTMLSelectElement)) return;
+  const zoom = Number.parseFloat(e.target.value);
+  if (!Number.isNaN(zoom)) emit("change", zoom);
+}
+</script>
+
+<style scoped>
+.docx-zoom-control {
+  height: 32px;
+  width: 70px;
+  padding: 0 4px;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  color: var(--doc-text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  outline: none;
+}
+.docx-zoom-control--compact {
+  height: 28px;
+  width: 55px;
+  font-size: 12px;
+}
+.docx-zoom-control:hover:not(:disabled) {
+  background: var(--doc-primary-light);
+  color: var(--doc-text);
+}
+.docx-zoom-control:focus-visible {
+  border-color: var(--doc-primary);
+}
+.docx-zoom-control:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+</style>

--- a/packages/vue/src/components/ui/ZoomControl.vue
+++ b/packages/vue/src/components/ui/ZoomControl.vue
@@ -29,22 +29,7 @@
 </template>
 
 <script lang="ts">
-/** A single zoom preset: `value` is a scale factor (1 = 100%). */
-export type ZoomLevel = {
-  value: number;
-  label: string;
-};
-
-export type ZoomControlProps = {
-  /** Current zoom (1 = 100%). */
-  value?: number;
-  /** Override the preset levels offered in the dropdown. */
-  levels?: ZoomLevel[];
-  disabled?: boolean;
-  className?: string;
-  /** Render the trigger at the smaller toolbar-chrome size. */
-  compact?: boolean;
-};
+import type { ZoomLevel, ZoomControlProps } from "./ZoomControl.types";
 
 const DEFAULT_ZOOM_LEVELS: ZoomLevel[] = [
   { value: 0.5, label: "50%" },

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -18,12 +18,10 @@
 export { default as DocxEditor } from "./components/DocxEditor.vue";
 // Standalone chrome components (mirror React's index): a host can render these
 // outside DocxEditor. Both are controlled — they own no editor view.
-export { default as FormattingBar, type FormattingBarProps } from "./components/FormattingBar.vue";
-export {
-  default as ZoomControl,
-  type ZoomControlProps,
-  type ZoomLevel,
-} from "./components/ui/ZoomControl.vue";
+export { default as FormattingBar } from "./components/FormattingBar.vue";
+export type { FormattingBarProps } from "./components/FormattingBar.types";
+export { default as ZoomControl } from "./components/ui/ZoomControl.vue";
+export type { ZoomControlProps, ZoomLevel } from "./components/ui/ZoomControl.types";
 export {
   renderAsync,
   type DocxEditorHandle,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -16,6 +16,14 @@
 
 // ─── Editor component + imperative API (Vue-specific) ───────────────────────
 export { default as DocxEditor } from "./components/DocxEditor.vue";
+// Standalone chrome components (mirror React's index): a host can render these
+// outside DocxEditor. Both are controlled — they own no editor view.
+export { default as FormattingBar, type FormattingBarProps } from "./components/FormattingBar.vue";
+export {
+  default as ZoomControl,
+  type ZoomControlProps,
+  type ZoomLevel,
+} from "./components/ui/ZoomControl.vue";
 export {
   renderAsync,
   type DocxEditorHandle,

--- a/scripts/parity/export-divergence.md
+++ b/scripts/parity/export-divergence.md
@@ -23,11 +23,6 @@ no React equivalent.
 
 Known Vue gaps (React-only chrome/components not yet ported to Vue):
 
-- `FormattingBar` — React chrome component; no Vue equivalent yet.
-- `FormattingBarProps` — type for the React-only FormattingBar.
-- `ZoomControl` — React chrome component; no Vue equivalent yet.
-- `ZoomControlProps` — type for the React-only ZoomControl.
-- `ZoomLevel` — type for the React-only ZoomControl.
 - `FolioUIProvider` — React UI-injection provider; the Vue map is a placeholder.
 - `ColorPreset` — React folio-ui type; no Vue equivalent yet.
 - `FolioButtonProps` — React folio-ui type; no Vue equivalent yet.


### PR DESCRIPTION
Adds Vue FormattingBar + ZoomControl components matching React's standalone exports, composing existing ui/ pickers + useZoom. Exports FormattingBar/FormattingBarProps + ZoomControl/ZoomControlProps/ZoomLevel; removes the 5 export-divergence opt-outs (check-export-parity now 127 shared exports). test:e2e:parity 18/18.