### PR TITLE
feat(vue): FolioUIProvider UI-injection layer + exports

### DIFF
--- a/.changeset/vue-ui-provider.md
+++ b/.changeset/vue-ui-provider.md
@@ -1,0 +1,12 @@
+---
+"@stll/folio-vue": minor
+---
+
+Add the Vue UI-injection layer (`FolioUIProvider` / `provideFolioUI` / `useFolioUI`
+/ `resolveFolioComponents` / `DEFAULT_COMPONENTS`), mirroring the React adapter's
+`FolioUIComponents` contract. `DocxEditor` now provides the resolved primitive map
+from its `components` prop, and the toolbar / formatting-bar chrome resolve their
+`ColorPicker` through the provider, so a host override takes effect. Exports the
+`FolioUIComponents`, `ColorPreset`, `FolioButtonProps`, and `OutlineItem` types plus
+the `FolioUIProvider` component, closing the corresponding React↔Vue export-parity
+gaps.

--- a/api-reports/vue/index.api.md
+++ b/api-reports/vue/index.api.md
@@ -38,6 +38,9 @@ import { buildPositionalText } from '@stll/folio-core/ai-suggestions/text-positi
 import { clearAutocompleteSuggestion } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
 import { clearTemplateSlashMenu } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
 import { Comment as Comment_2 } from '@stll/folio-core/types/content';
+import { Component } from 'vue';
+import { ComponentOptionsMixin } from 'vue';
+import { ComponentProvideOptions } from 'vue';
 import { ComputedRef } from 'vue';
 import { consumeTemplateSlashQuery } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
 import { ContentControlFilter } from '@stll/folio-core/content-controls';
@@ -49,6 +52,7 @@ import { createFolioAIEditSnapshot } from '@stll/folio-core/ai-edits';
 import { CSSProperties } from 'vue';
 import { DEFAULT_AI_SUGGESTION_PRESETS } from '@stll/folio-core/ai-suggestions/types';
 import { DEFAULT_AUTOCOMPLETE_DEAD_ZONE_NODES } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
+import { DefineComponent } from 'vue';
 import { deriveBlockId } from '@stll/folio-core/types/block-id';
 import { DeriveBlockIdInput } from '@stll/folio-core/types/block-id';
 import { diffWordSegments } from '@stll/folio-core/ai-edits';
@@ -61,6 +65,7 @@ import { DocxInput } from '@stll/folio-core/utils/docxInput';
 import { EditorMode } from '@stll/folio-core/managers/EditorModeManager';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
+import { ExtractPropTypes } from 'vue';
 import { finishAutocompleteSuggestion } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
 import { FolioAIBlock } from '@stll/folio-core/ai-edits';
 import { FolioAIBlockAnchor } from '@stll/folio-core/ai-edits';
@@ -106,7 +111,10 @@ import { MaybeRefOrGetter } from 'vue';
 import { normalizeFolioAIBlockText } from '@stll/folio-core/ai-edits';
 import { Plugin as Plugin_2 } from 'prosemirror-state';
 import { PositionalText } from '@stll/folio-core/ai-suggestions/text-positions';
+import { PublicProps } from 'vue';
 import { Ref } from 'vue';
+import { RendererElement } from 'vue';
+import { RendererNode } from 'vue';
 import { resetTemplateSlashQuery } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
 import { ResolvedAnchor } from '@stll/folio-core/ai-suggestions/conflict';
 import { resolveSuggestionAnchor } from '@stll/folio-core/ai-suggestions/conflict';
@@ -136,6 +144,7 @@ import { toMarkdown } from '@stll/folio-core/markdown';
 import { toMarkdownResult } from '@stll/folio-core/markdown';
 import { Transaction } from 'prosemirror-state';
 import { TripwireResult } from '@stll/folio-core/docx/selectiveSaveTripwire';
+import { VNode } from 'vue';
 import { VNodeChild } from 'vue';
 import { WordDiffSegment } from '@stll/folio-core/ai-edits';
 import { XmlFragment } from 'yjs';
@@ -204,6 +213,13 @@ export { buildPositionalText }
 export { clearAutocompleteSuggestion }
 
 export { clearTemplateSlashMenu }
+
+// @public
+export type ColorPreset = {
+    label: string;
+    value: string;
+    color?: string;
+};
 
 export { consumeTemplateSlashQuery }
 
@@ -440,7 +456,37 @@ export { FolioAISignatureParty }
 export { FolioBlockId }
 
 // @public
-export type FolioUIComponents = Record<string, unknown>;
+export type FolioButtonProps = {
+    variant?: "default" | "ghost";
+    size?: "sm" | "xs" | "icon-xs";
+    disabled?: boolean;
+    className?: string;
+};
+
+// @public
+export type FolioUIComponents = {
+    Button: Component;
+    ColorPicker: Component;
+    Popover: Component;
+    Menu: Component;
+};
+
+// @public
+export const FolioUIProvider: DefineComponent<ExtractPropTypes<    {
+components: {
+type: () => Partial<FolioUIComponents> | undefined;
+default: undefined;
+};
+}>, () => VNode<RendererNode, RendererElement, {
+[key: string]: any;
+}>[] | undefined, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, PublicProps, Readonly<ExtractPropTypes<    {
+components: {
+type: () => Partial<FolioUIComponents> | undefined;
+default: undefined;
+};
+}>> & Readonly<{}>, {
+components: Partial<FolioUIComponents> | undefined;
+}, {}, {}, {}, string, ComponentProvideOptions, true, {}, any>;
 
 // @public
 export type FontDefinition = {
@@ -519,6 +565,15 @@ export { MarkdownOptions }
 export { MarkdownResult }
 
 export { normalizeFolioAIBlockText }
+
+// @public
+export type OutlineItem = {
+    id: string;
+    label: string;
+    level: number;
+    meta?: string;
+    color?: string;
+};
 
 export { PositionalText }
 

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -403,6 +403,7 @@ import { useTrackedChanges } from "../composables/useTrackedChanges";
 import { useZoom } from "../composables/useZoom";
 import type { FontOption } from "../utils/fontOptions";
 import { provideLocale, useTranslation } from "../i18n";
+import { provideFolioUI } from "../ui/folio-ui";
 
 const props = withDefaults(defineProps<DocxEditorProps>(), {
   documentBuffer: null,
@@ -431,6 +432,11 @@ const emit = defineEmits<{
 
 // PORT-BLOCKED: no i18n/locale prop on the fork's DocxEditorProps yet — default to `en`.
 provideLocale();
+// Provide the consumer's UI-injection overrides (or the built-in defaults) to
+// the chrome subtree. Descendant chrome (Toolbar, FormattingBar) resolves the
+// injected primitives via `useFolioUI`, so `components.ColorPicker` etc. take
+// effect. Provided once at setup; the prop is not expected to change identity.
+provideFolioUI(props.components);
 // PORT-BLOCKED: no colorMode prop; share a fixed-light token scope with teleported chrome.
 const isDark = ref(false);
 provideDocxPortalClass(isDark);

--- a/packages/vue/src/components/FormattingBar.vue
+++ b/packages/vue/src/components/FormattingBar.vue
@@ -146,11 +146,16 @@
 import { computed } from "vue";
 import MaterialSymbol from "./ui/MaterialSymbol.vue";
 import StylePicker from "./ui/StylePicker.vue";
-import ColorPicker from "./ui/ColorPicker.vue";
 import AlignmentButtons from "./ui/AlignmentButtons.vue";
 import ListButtons from "./ui/ListButtons.vue";
 import { createDefaultListState } from "../utils/listState";
 import { useTranslation } from "../i18n";
+import { useFolioUI } from "../ui/folio-ui";
+
+// Resolve ColorPicker from the FolioUI injection provider so a host
+// `components.ColorPicker` override renders here; falls back to the package
+// default (ui/ColorPicker.vue) when rendered outside a provider.
+const { ColorPicker } = useFolioUI();
 import type { ColorValue } from "@stll/folio-core/types/document";
 import type { ListState } from "../utils/listState";
 import type { ParagraphAlignment } from "./ui/AlignmentButtons.types";

--- a/packages/vue/src/components/Toolbar.vue
+++ b/packages/vue/src/components/Toolbar.vue
@@ -489,7 +489,6 @@ import {
 import { clearFormatting } from '@stll/folio-core/prosemirror/commands/formatting';
 import type { ColorValue, Theme, Style } from '@stll/folio-core/types/document';
 import MaterialSymbol from './ui/MaterialSymbol.vue';
-import ColorPicker from './ui/ColorPicker.vue';
 import ImageWrapDropdown from './ui/ImageWrapDropdown.vue';
 import ImageTransformDropdown from './ui/ImageTransformDropdown.vue';
 import EditingModeDropdown from './EditingModeDropdown.vue';
@@ -510,6 +509,12 @@ import { useToolbarDropdowns } from '../composables/useToolbarDropdowns';
 import { useToolbarFontSize } from '../composables/useToolbarFontSize';
 import { useParagraphStyleOptions } from '../composables/useParagraphStyleOptions';
 import { useTranslation } from '../i18n';
+import { useFolioUI } from '../ui/folio-ui';
+
+// Resolve the ColorPicker primitive from the FolioUI injection provider so a
+// host `components.ColorPicker` override renders here; falls back to the
+// package default (ui/ColorPicker.vue) when rendered outside DocxEditor.
+const { ColorPicker } = useFolioUI();
 
 /**
  * A toolbar command factory: called with whatever arguments the specific

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -39,10 +39,17 @@ export type { ScrollToParaIdOptions } from "@stll/folio-core/paged-layout/paragr
 export type { FontOption } from "./utils/fontOptions";
 export type { FontDefinition } from "./components/DocxEditor/types";
 // Consumer UI-injection contract (mirrors React's `FolioUIComponents`). The Vue
-// injectable-component map is a placeholder until Phase E; ColorPreset,
-// FolioButtonProps, OutlineItem, and the FolioUIProvider component have no Vue
-// equivalent yet (see the parity report).
-export type { FolioUIComponents } from "./ui/folio-ui";
+// adapter injects overrides through `DocxEditor`'s `components` prop; the chrome
+// resolves primitives via the FolioUI provider. `FolioUIProvider` is a Vue
+// component (defined in the `.ts` module so Nuxt's `tsc` typecheck resolves the
+// named export). See the parity report for the primitives without a Vue default.
+export { FolioUIProvider } from "./ui/folio-ui";
+export type {
+  ColorPreset,
+  FolioButtonProps,
+  FolioUIComponents,
+  OutlineItem,
+} from "./ui/folio-ui";
 
 // i18n runtime (Vue-specific — React consumes `use-intl` directly). Locale-string
 // types live in the shared catalog; import them from `@stll/folio-core` if needed.

--- a/packages/vue/src/ui/folio-ui.test.ts
+++ b/packages/vue/src/ui/folio-ui.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { defineComponent } from "vue";
+
+import { DEFAULT_COMPONENTS, resolveFolioComponents } from "./folio-ui";
+
+// A sentinel override component; identity is all the resolution test checks.
+const InjectedColorPicker = defineComponent({ name: "InjectedColorPicker", render: () => null });
+
+describe("resolveFolioComponents", () => {
+  test("returns the defaults when nothing is injected", () => {
+    expect(resolveFolioComponents()).toBe(DEFAULT_COMPONENTS);
+    expect(resolveFolioComponents(undefined)).toBe(DEFAULT_COMPONENTS);
+  });
+
+  test("an empty override still resolves every contract key to a default", () => {
+    // A non-undefined override forces a fresh merged object, so identity differs
+    // but every value equals its default.
+    expect(resolveFolioComponents({})).toEqual(DEFAULT_COMPONENTS);
+  });
+
+  test("an injected component wins; unspecified keys fall back to defaults", () => {
+    const resolved = resolveFolioComponents({ ColorPicker: InjectedColorPicker });
+    expect(resolved.ColorPicker).toBe(InjectedColorPicker);
+    // Every other key is untouched.
+    expect(resolved.Button).toBe(DEFAULT_COMPONENTS.Button);
+    expect(resolved.Popover).toBe(DEFAULT_COMPONENTS.Popover);
+    expect(resolved.Menu).toBe(DEFAULT_COMPONENTS.Menu);
+  });
+
+  test("resolution does not mutate the shared defaults object", () => {
+    const before = { ...DEFAULT_COMPONENTS };
+    resolveFolioComponents({ ColorPicker: InjectedColorPicker });
+    expect(DEFAULT_COMPONENTS).toEqual(before);
+    expect(DEFAULT_COMPONENTS.ColorPicker).not.toBe(InjectedColorPicker);
+  });
+
+  test("every contract key has a non-null default (no gaps standalone)", () => {
+    for (const component of Object.values(DEFAULT_COMPONENTS)) {
+      expect(component).toBeDefined();
+    }
+  });
+});

--- a/packages/vue/src/ui/folio-ui.ts
+++ b/packages/vue/src/ui/folio-ui.ts
@@ -1,15 +1,214 @@
 /**
- * Vue UI-injection layer (placeholder).
+ * Vue UI-injection layer (mirrors `packages/react/src/ui/folio-ui.tsx`).
  *
- * folio lets a host override the editor's built-in chrome primitives (Button,
- * …) with its own design-system components. The React package models this as a
- * `FolioUIComponents` record of injectable components.
+ * folio's chrome (toolbars, pickers, dialogs) renders a small set of UI
+ * primitives a host can override with its own design system. React models this
+ * as a {@link FolioUIComponents} record injected through a context provider and
+ * read with `useFolioUI`; the Vue adapter mirrors the contract with Vue's
+ * provide/inject.
  *
- * TODO(vue, Phase E): replace this placeholder with the real injectable-component
- * contract (the concrete component map keyed by primitive name, typed against the
- * Vue component surface). Until then `DocxEditorProps.components` accepts an
- * open record so the props contract can mirror React's shape.
+ * Standalone folio uses {@link DEFAULT_COMPONENTS} (the package's own `ui/*`
+ * single-file components); consumers inject overrides through `DocxEditor`'s
+ * `components` prop, which calls {@link provideFolioUI}.
+ *
+ * Scope note (vs. the React contract): the React map ships ten primitives, some
+ * as base-ui compound part-objects (Dialog/Select/Menu/Popover). The Vue adapter
+ * ships bespoke single-file components rather than base-ui parts, so the Vue
+ * contract carries the primitives that have a real Vue default and are consumed
+ * by the ported chrome: Button, ColorPicker, Popover, and Menu. The remaining
+ * React primitives (Dialog, Select, Input, Checkbox, DatePickerPopover,
+ * OutlineRail) have no Vue default primitive to inject yet; their shared value
+ * types ({@link ColorPreset}, {@link OutlineItem}) are still exported for
+ * cross-framework parity.
  */
 
-// eslint-disable-next-line no-restricted-syntax -- placeholder until Phase E lands the real contract
-export type FolioUIComponents = Record<string, unknown>;
+import { defineComponent, inject, provide, type Component, type InjectionKey } from "vue";
+
+import DefaultButton from "../components/ui/Button.vue";
+import DefaultColorPicker from "../components/ui/ColorPicker.vue";
+import DefaultMenuDropdown from "../components/ui/MenuDropdown.vue";
+import DefaultPopover from "../components/ui/Popover.vue";
+
+// ============================================================================
+// Button
+// ============================================================================
+
+/**
+ * The Button prop subset folio's chrome relies on. `variant` and `size` are
+ * narrow string-literal unions (a subset of the design-system Button's options)
+ * so an external Button stays assignable as an override. Native `<button>`
+ * attributes fall through Vue's attribute inheritance and are not re-declared.
+ */
+export type FolioButtonProps = {
+  variant?: "default" | "ghost";
+  size?: "sm" | "xs" | "icon-xs";
+  disabled?: boolean;
+  className?: string;
+};
+
+// ============================================================================
+// ColorPicker
+// ============================================================================
+
+/**
+ * A color preset rendered as a swatch in the picker. Mirrors the React contract
+ * so a cross-framework design system can share the preset shape; `color` is the
+ * optional CSS color for the swatch (falls back to `#${value}`), and `value` is
+ * what selection emits.
+ */
+export type ColorPreset = {
+  label: string;
+  value: string;
+  color?: string;
+};
+
+/**
+ * The ColorPicker prop subset folio's chrome relies on. Mirrors the Vue
+ * `ui/ColorPicker.vue` surface: `mode` selects the text/highlight/border
+ * behaviour, `value` is the current color, `theme` resolves theme colors, and
+ * the component emits `change` with the picked color. A design-system picker
+ * accepting a superset stays assignable as an override.
+ */
+export type FolioColorPickerProps = {
+  mode: "text" | "highlight" | "border";
+  value?: string | undefined;
+  disabled?: boolean;
+  className?: string;
+};
+
+// ============================================================================
+// Popover
+// ============================================================================
+
+/**
+ * The Popover prop subset folio's chrome relies on. Mirrors the Vue
+ * `ui/Popover.vue` surface: `open` controls visibility, `placement` positions
+ * the panel, and the component emits `close` / `update:open`. Consumers supply
+ * the trigger and panel via the `trigger` / `panel` slots.
+ */
+export type FolioPopoverProps = {
+  open: boolean;
+  placement?: "bottom-left" | "bottom-right" | "top-left" | "top-right";
+  closeOnScroll?: boolean;
+};
+
+// ============================================================================
+// Menu
+// ============================================================================
+
+/**
+ * One entry in a folio menu. Mirrors the Vue `ui/MenuDropdown.vue` `MenuEntry`
+ * shape so an external Menu stays assignable as an override.
+ */
+export type FolioMenuItem = {
+  type?: "item";
+  label: string;
+  onSelect?: () => void;
+  disabled?: boolean;
+  shortcut?: string;
+};
+
+export type FolioMenuProps = {
+  label: string;
+  items: ReadonlyArray<FolioMenuItem | { type: "separator" }>;
+};
+
+// ============================================================================
+// OutlineRail (shared value type only; no Vue default primitive yet)
+// ============================================================================
+
+/**
+ * One entry in the document outline. Mirrors the React contract's item shape so
+ * a cross-framework design system can share it. The Vue adapter does not yet
+ * inject an OutlineRail primitive (no Vue default exists); the type is exported
+ * for parity with the React surface.
+ */
+export type OutlineItem = {
+  id: string;
+  label: string;
+  /** Nesting depth; drives indent + tick taper. */
+  level: number;
+  /** Optional trailing annotation in the panel (e.g. a page number). */
+  meta?: string;
+  /** Optional CSS custom-property name colouring this entry. */
+  color?: string;
+};
+
+// ============================================================================
+// Contract + provide/inject
+// ============================================================================
+
+/**
+ * The injectable chrome primitives. Each entry is a Vue component the chrome
+ * renders; a host overrides any subset through `DocxEditor`'s `components` prop.
+ *
+ * Values are typed as the loose Vue {@link Component} rather than
+ * `Component<FolioButtonProps>` etc.: Vue's `Component<P>` is invariant in `P`
+ * (unlike React's contravariant `ComponentType<P>`), so a default or override
+ * accepting a *superset* of props would not be assignable to a prop-parameterized
+ * slot. The per-primitive prop contract a host implements is documented by the
+ * exported `Folio*Props` types ({@link FolioButtonProps},
+ * {@link FolioColorPickerProps}, {@link FolioPopoverProps}, {@link FolioMenuProps});
+ * consumers render the resolved component and pass those props at the call site.
+ */
+export type FolioUIComponents = {
+  Button: Component;
+  ColorPicker: Component;
+  Popover: Component;
+  Menu: Component;
+};
+
+export const DEFAULT_COMPONENTS: FolioUIComponents = {
+  Button: DefaultButton,
+  ColorPicker: DefaultColorPicker,
+  Popover: DefaultPopover,
+  Menu: DefaultMenuDropdown,
+};
+
+const FOLIO_UI_KEY: InjectionKey<FolioUIComponents> = Symbol("folio-ui-components");
+
+/**
+ * Merge a consumer's partial overrides over the built-in defaults: every key is
+ * present (defaults fill the gaps), and each provided override wins. Pure, so
+ * the resolution contract is testable independently of Vue.
+ */
+export function resolveFolioComponents(components?: Partial<FolioUIComponents>): FolioUIComponents {
+  return components ? { ...DEFAULT_COMPONENTS, ...components } : DEFAULT_COMPONENTS;
+}
+
+/**
+ * Provide the resolved primitive map to descendants. `DocxEditor` calls this in
+ * setup with its `components` prop; chrome descendants read it via
+ * {@link useFolioUI}.
+ */
+export function provideFolioUI(components?: Partial<FolioUIComponents>): void {
+  provide(FOLIO_UI_KEY, resolveFolioComponents(components));
+}
+
+/**
+ * Read the resolved primitive map. Falls back to {@link DEFAULT_COMPONENTS} when
+ * no provider is present (chrome rendered standalone, outside `DocxEditor`).
+ */
+export function useFolioUI(): FolioUIComponents {
+  return inject(FOLIO_UI_KEY, DEFAULT_COMPONENTS);
+}
+
+/**
+ * Provider component mirroring React's `FolioUIProvider`. Wraps a subtree and
+ * provides the resolved primitive map; renders its default slot unchanged.
+ * Defined here (a `.ts` module) rather than as a `.vue` SFC so it re-exports as
+ * a named export the Nuxt `tsc` typecheck can resolve.
+ */
+export const FolioUIProvider = defineComponent({
+  name: "FolioUIProvider",
+  props: {
+    components: {
+      type: Object as () => Partial<FolioUIComponents> | undefined,
+      default: undefined,
+    },
+  },
+  setup(props, { slots }) {
+    provideFolioUI(props.components);
+    return () => slots["default"]?.();
+  },
+});

--- a/scripts/parity/export-divergence.md
+++ b/scripts/parity/export-divergence.md
@@ -23,10 +23,6 @@ no React equivalent.
 
 Known Vue gaps (React-only chrome/components not yet ported to Vue):
 
-- `FolioUIProvider` — React UI-injection provider; the Vue map is a placeholder.
-- `ColorPreset` — React folio-ui type; no Vue equivalent yet.
-- `FolioButtonProps` — React folio-ui type; no Vue equivalent yet.
-- `OutlineItem` — React folio-ui type; no Vue equivalent yet.
 - `AutocompleteCaretOverlay` — React overlay component; no Vue equivalent yet.
 - `AutocompleteCaretOverlayProps` — type for the React-only overlay.
 - `AutocompleteCaretRect` — type for the React-only overlay.

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -55,7 +55,7 @@
     ],
     "deferredInVue": {
       "collaboration": "Yjs collaboration owner is not threaded through the Vue pipeline yet.",
-      "components": "Consumer UI-injection map (FolioUIComponents) is not consumed by the Vue chrome yet.",
+      "components": "Partially wired: DocxEditor.vue calls provideFolioUI(components) and the ColorPicker override resolves in the toolbar/formatting-bar chrome, but the remaining primitives are not yet threaded (Button/Popover/Menu chrome consumers still import statically; Dialog/Select/Input/Checkbox/DatePickerPopover/OutlineRail have no Vue default to inject), so it is not full parity with React's 10-primitive override surface.",
       "featureFlags": "Selective-save feature flags are not plumbed into the Vue save path.",
       "fonts": "Host FontFace registration (registerFontFace / getDocumentFontSet, React's hostFonts) is not ported to the Vue pipeline; custom faces are not injected.",
       "marginGuideColor": "Pairs with showMarginGuides; React declares both but renders no margin guides (unused, underscore-prefixed), so there is nothing to mirror.",


### PR DESCRIPTION
Replaces the FolioUIComponents placeholder with a real Vue injection layer (provideFolioUI/useFolioUI, DEFAULT_COMPONENTS from existing ui/* SFCs, FolioUIProvider). DocxEditor provides props.components; ColorPicker override resolves in toolbar/formatting-bar. Exports FolioUIProvider + ColorPreset/FolioButtonProps/OutlineItem; removes 4 export-divergence opt-outs (131 shared names). components prop kept deferred (honest partial — not all 10 primitives threaded). test:e2e:parity 18/18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vue UI override support for editor chrome, including a provider and fallback defaults.
  * Color picker controls in the editor toolbar and formatting bar can now use host-provided replacements.

* **Bug Fixes**
  * Improved consistency between Vue and React UI customization options.
  * Ensured editor UI overrides are properly passed through the editor shell.

* **Tests**
  * Added coverage for UI component resolution, default fallback behavior, and override handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->