### PR TITLE
feat(vue): wire selective-save flags + tripwire (60/64 props paired)

### DIFF
--- a/.changeset/vue-selective-save.md
+++ b/.changeset/vue-selective-save.md
@@ -1,0 +1,14 @@
+---
+"@stll/folio-vue": minor
+---
+
+Wire selective-save feature flags and the tripwire callback into the Vue
+`DocxEditor` save path, matching the React adapter. `featureFlags` is threaded
+into `useDocxEditor`'s `save()`: when `selectiveSave` is on it runs
+`attemptSelectiveSave` (patching only changed paragraphs, with the shared
+`ParagraphChangeTracker` inputs) and falls back to a full repack; the ref
+`save({ selective })` option now gates that path. When `selectiveSaveTripwire`
+is on it also computes the full repack, runs `compareSelectiveVsFull`, and fires
+`onSelectiveSaveTripwire(result)` for observability. The comparison never blocks
+or poisons the save. Both props move from deferred to paired in the cross-adapter
+parity contract.

--- a/api-reports/vue/composables.api.md
+++ b/api-reports/vue/composables.api.md
@@ -19,6 +19,7 @@ import { EditorView } from 'prosemirror-view';
 import { extractTrackedChanges } from '@stll/folio-core/prosemirror/utils/extractTrackedChanges';
 import { FlowBlock } from '@stll/folio-core/layout-engine/types';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
+import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
 import { getSelectionRuns } from '@stll/folio-core/managers/ClipboardManager';
 import { Layout } from '@stll/folio-core/layout-engine/types';
 import { MaybeRefOrGetter } from 'vue';
@@ -31,6 +32,7 @@ import { TemplateSlashMenuKeyAction } from '@stll/folio-core/prosemirror/plugins
 import { TemplateSlashMenuState } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
 import { TrackedChangeEntry } from '@stll/folio-core/prosemirror/utils/extractTrackedChanges';
 import { TrackedChangesResult } from '@stll/folio-core/prosemirror/utils/extractTrackedChanges';
+import { TripwireResult } from '@stll/folio-core/docx/selectiveSaveTripwire';
 
 export { ClipboardSelection }
 
@@ -96,6 +98,8 @@ export type UseDocxEditorOptions = {
     onSelectionUpdate?: (state: EditorState) => void;
     onEditorViewReady?: (view: EditorView | null) => void;
     onReadOnlyEditAttempt?: () => void;
+    featureFlags?: MaybeRefOrGetter<FolioSelectiveSaveFlags | undefined>;
+    onSelectiveSaveTripwire?: (result: TripwireResult) => void;
 };
 
 // @public (undocumented)
@@ -110,7 +114,9 @@ export type UseDocxEditorReturn = {
     measures: Ref<Measure[]>;
     loadBuffer: (buffer: DocxInput) => Promise<void>;
     loadDocument: (doc: Document_2) => void;
-    save: () => Promise<Blob | null>;
+    save: (options?: {
+        selective?: boolean;
+    }) => Promise<Blob | null>;
     getDocument: () => Document_2 | null;
     setDocument: (doc: Document_2) => void;
     getCommands: () => CommandMap;

--- a/api-reports/vue/composables.api.md
+++ b/api-reports/vue/composables.api.md
@@ -99,7 +99,7 @@ export type UseDocxEditorOptions = {
     onEditorViewReady?: (view: EditorView | null) => void;
     onReadOnlyEditAttempt?: () => void;
     featureFlags?: MaybeRefOrGetter<FolioSelectiveSaveFlags | undefined>;
-    onSelectiveSaveTripwire?: (result: TripwireResult) => void;
+    onSelectiveSaveTripwire?: ((result: TripwireResult) => void) | undefined;
 };
 
 // @public (undocumented)

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -597,6 +597,10 @@ const {
   },
   onEditorViewReady: (view) => props.onEditorViewReady?.(view),
   onReadOnlyEditAttempt: () => props.onReadonlyEditAttempt?.(),
+  // Selective-save feature flags + tripwire observability, mirroring React's
+  // DocxEditor save path. Read fresh on each save() so prop updates are honored.
+  featureFlags: () => props.featureFlags,
+  onSelectiveSaveTripwire: (result) => props.onSelectiveSaveTripwire?.(result),
 });
 
 // Show the loading interstitial while a document is loading, EXCEPT when the host

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -600,7 +600,13 @@ const {
   // Selective-save feature flags + tripwire observability, mirroring React's
   // DocxEditor save path. Read fresh on each save() so prop updates are honored.
   featureFlags: () => props.featureFlags,
-  onSelectiveSaveTripwire: (result) => props.onSelectiveSaveTripwire?.(result),
+  // Pass through only when the host actually provided a callback so it stays
+  // `undefined` otherwise, mirroring React where the tripwire comparison is
+  // gated on `onSelectiveSaveTripwire` being defined (an absent callback must
+  // skip the expensive compareSelectiveVsFull, not run it into a no-op).
+  onSelectiveSaveTripwire: props.onSelectiveSaveTripwire
+    ? (result) => props.onSelectiveSaveTripwire?.(result)
+    : undefined,
 });
 
 // Show the loading interstitial while a document is loading, EXCEPT when the host

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -470,7 +470,7 @@ export type UseDocxEditorOptions = {
    * {@link FolioSelectiveSaveFlags.selectiveSaveTripwire} is on. Observability
    * only — never blocks or poisons the save. Mirrors React's callback.
    */
-  onSelectiveSaveTripwire?: (result: TripwireResult) => void;
+  onSelectiveSaveTripwire?: ((result: TripwireResult) => void) | undefined;
 }
 
 export type UseDocxEditorReturn = {
@@ -963,12 +963,18 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       return null;
     }
 
+    // Snapshot the editor state once, before any awaited dynamic imports, so
+    // the document we serialize and the selective-save change signals are all
+    // read from the same snapshot. A later `view.state` read could pick up an
+    // edit that landed mid-save and diff against the wrong baseline.
+    const state = view.state;
+
     const { resolveSelectiveSaveFlags } = await import(
       "@stll/folio-core/docx/selectiveSaveFlags"
     );
     const flags = resolveSelectiveSaveFlags(toValue(featureFlags));
 
-    const updatedDoc = fromProseDoc(view.state.doc, base);
+    const updatedDoc = fromProseDoc(state.doc, base);
     const baselineBuffer = updatedDoc.originalBuffer ?? null;
 
     // The tripwire observes the selective path independently of the user-visible
@@ -981,7 +987,6 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     let selectiveBuffer: ArrayBuffer | null = null;
     if (shouldAttemptSelective && baselineBuffer) {
       const { attemptSelectiveSave } = await import("@stll/folio-core/docx/selectiveSave");
-      const state = view.state;
       selectiveBuffer = await attemptSelectiveSave(updatedDoc, baselineBuffer, {
         changedParaIds: getChangedParagraphIds(state),
         structuralChange: hasStructuralChanges(state),

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -48,6 +48,8 @@ import type { LayoutScheduler } from "@stll/folio-core/controller/layoutSchedule
 import { createLayoutSession } from "@stll/folio-core/controller/layoutSession";
 import { parseDocx } from "@stll/folio-core/docx/parser";
 import { getFootnoteText } from "@stll/folio-core/docx/footnoteParser";
+import type { FolioSelectiveSaveFlags } from "@stll/folio-core/docx/selectiveSaveFlags";
+import type { TripwireResult } from "@stll/folio-core/docx/selectiveSaveTripwire";
 import type {
   ConvertHeaderFooterOptions,
   HeaderFooterMetrics,
@@ -76,6 +78,11 @@ import {
 import { getTransactionDirtyRange } from "@stll/folio-core/paged-layout/transactionDirtyRange";
 import { fromProseDoc } from "@stll/folio-core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "@stll/folio-core/prosemirror/extensions/ExtensionManager";
+import {
+  getChangedParagraphIds,
+  hasStructuralChanges,
+  hasUntrackedChanges,
+} from "@stll/folio-core/prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { createStarterKit } from "@stll/folio-core/prosemirror/extensions/StarterKit";
 import type { CommandMap } from "@stll/folio-core/prosemirror/extensions/types";
 import {
@@ -452,6 +459,18 @@ export type UseDocxEditorOptions = {
   onEditorViewReady?: (view: EditorView | null) => void;
   /** Callback when a read-only user action would mutate the document. */
   onReadOnlyEditAttempt?: () => void;
+  /**
+   * Operational flags for the save path. Selective save and its tripwire mode
+   * are off by default; hosts opt in once their rollout pipeline is ready.
+   * Reactive — read fresh on each `save()`. Mirrors React's `featureFlags`.
+   */
+  featureFlags?: MaybeRefOrGetter<FolioSelectiveSaveFlags | undefined>;
+  /**
+   * Fired with the structured selective-vs-full comparison after a save when
+   * {@link FolioSelectiveSaveFlags.selectiveSaveTripwire} is on. Observability
+   * only — never blocks or poisons the save. Mirrors React's callback.
+   */
+  onSelectiveSaveTripwire?: (result: TripwireResult) => void;
 }
 
 export type UseDocxEditorReturn = {
@@ -476,7 +495,7 @@ export type UseDocxEditorReturn = {
   /** Load an already-parsed `Document` directly. */
   loadDocument: (doc: Document) => void;
   /** Serialize the current document to a DOCX blob. */
-  save: () => Promise<Blob | null>;
+  save: (options?: { selective?: boolean }) => Promise<Blob | null>;
   /** Snapshot the current document model. */
   getDocument: () => Document | null;
   /** Publish a fresh Document object (e.g. after HF materialisation). */
@@ -510,6 +529,8 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     onSelectionUpdate,
     onEditorViewReady,
     onReadOnlyEditAttempt,
+    featureFlags,
+    onSelectiveSaveTripwire,
   } = options;
 
   // ---- Reactive state -----------------------------------------------------
@@ -935,17 +956,68 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
 
   // ---- Public API ---------------------------------------------------------
 
-  async function save(): Promise<Blob | null> {
+  async function save(saveOptions?: { selective?: boolean }): Promise<Blob | null> {
     const view = editorView.value;
     const base = docModel.value;
     if (!view || !base) {
       return null;
     }
-    const { repackDocx, createDocx } = await import("@stll/folio-core/docx/rezip");
+
+    const { resolveSelectiveSaveFlags } = await import(
+      "@stll/folio-core/docx/selectiveSaveFlags"
+    );
+    const flags = resolveSelectiveSaveFlags(toValue(featureFlags));
+
     const updatedDoc = fromProseDoc(view.state.doc, base);
-    const buffer = updatedDoc.originalBuffer
-      ? await repackDocx(updatedDoc)
-      : await createDocx(updatedDoc);
+    const baselineBuffer = updatedDoc.originalBuffer ?? null;
+
+    // The tripwire observes the selective path independently of the user-visible
+    // save mode. Only `useSelectiveForSave` is allowed to pick the returned bytes.
+    const useSelectiveForSave = flags.selectiveSave && saveOptions?.selective !== false;
+    const shouldAttemptSelective = useSelectiveForSave || flags.selectiveSaveTripwire;
+
+    const { repackDocx, createDocx } = await import("@stll/folio-core/docx/rezip");
+
+    let selectiveBuffer: ArrayBuffer | null = null;
+    if (shouldAttemptSelective && baselineBuffer) {
+      const { attemptSelectiveSave } = await import("@stll/folio-core/docx/selectiveSave");
+      const state = view.state;
+      selectiveBuffer = await attemptSelectiveSave(updatedDoc, baselineBuffer, {
+        changedParaIds: getChangedParagraphIds(state),
+        structuralChange: hasStructuralChanges(state),
+        hasUntrackedChanges: hasUntrackedChanges(state),
+        maxBytes: flags.selectiveSaveMaxBytes,
+      });
+    }
+
+    let buffer: ArrayBuffer | null = useSelectiveForSave ? selectiveBuffer : null;
+    let fullBuffer: ArrayBuffer | null = null;
+
+    if (!buffer) {
+      // No original buffer means a from-scratch document — build one via createDocx.
+      fullBuffer = baselineBuffer ? await repackDocx(updatedDoc) : await createDocx(updatedDoc);
+      buffer = fullBuffer;
+    } else if (flags.selectiveSaveTripwire) {
+      try {
+        fullBuffer = await repackDocx(updatedDoc);
+      } catch {
+        // Tripwire-only full repack failures must never poison a successful
+        // selective save.
+      }
+    }
+
+    if (flags.selectiveSaveTripwire && fullBuffer && onSelectiveSaveTripwire) {
+      // The comparison itself never blocks the save path.
+      try {
+        const { compareSelectiveVsFull } = await import(
+          "@stll/folio-core/docx/selectiveSaveTripwire"
+        );
+        onSelectiveSaveTripwire(await compareSelectiveVsFull(selectiveBuffer, fullBuffer));
+      } catch {
+        // Comparison failures must never poison the save path.
+      }
+    }
+
     return new Blob([buffer], {
       type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     });

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -83,7 +83,7 @@ export type UseDocxEditorRefApiOptions = {
   getDocument: () => Document | null;
   setZoom: (zoom: number) => void;
   /** useDocxEditor.save returns a Blob; the ref surface exposes an ArrayBuffer. */
-  save: () => Promise<Blob | null>;
+  save: (options?: { selective?: boolean }) => Promise<Blob | null>;
   loadDocument: (doc: Document) => void;
   loadDocumentBuffer: (buffer: DocxInput) => Promise<void>;
   /** Optional host hook for print. */
@@ -100,8 +100,8 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
     window.print();
   }
 
-  async function save(): Promise<ArrayBuffer | null> {
-    const blob = await opts.save();
+  async function save(options?: { selective?: boolean }): Promise<ArrayBuffer | null> {
+    const blob = await opts.save(options);
     if (!blob) {
       return null;
     }
@@ -173,7 +173,7 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
     // PORT-BLOCKED: getEditorRef needs the Vue PagedEditor component, not ported.
     getEditorRef: () => null,
     getEditor: () => opts.editor,
-    // options.selective is ignored until selective save is wired (PORT-BLOCKED).
+    // Threads `options.selective` into useDocxEditor.save (selective-save gate).
     save,
     setZoom: opts.setZoom,
     getZoom,

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -13,6 +13,7 @@
       "documentBuffer",
       "documentKey",
       "enableWheelZoom",
+      "featureFlags",
       "fontFamilies",
       "fonts",
       "initialScrollTop",
@@ -43,6 +44,7 @@
       "onScrollTopChange",
       "onSelectionChange",
       "onSelectionTextChange",
+      "onSelectiveSaveTripwire",
       "onSlashMenuChange",
       "onSlashMenuKeyAction",
       "placeholder",
@@ -65,8 +67,6 @@
     "deferredInVue": {
       "collaboration": "Yjs collaboration owner is not threaded through the Vue pipeline yet.",
       "components": "Partially wired: DocxEditor.vue calls provideFolioUI(components) and the ColorPicker override resolves in the toolbar/formatting-bar chrome, but the remaining primitives are not yet threaded (Button/Popover/Menu chrome consumers still import statically; Dialog/Select/Input/Checkbox/DatePickerPopover/OutlineRail have no Vue default to inject), so it is not full parity with React's 10-primitive override surface.",
-      "featureFlags": "Selective-save feature flags are not plumbed into the Vue save path.",
-      "onSelectiveSaveTripwire": "Selective-save tripwire observability is not plumbed into the Vue save path.",
       "showHeaderFooterEditing": "Header/footer inline editing is not ported to Vue.",
       "showReviewControls": "REAL GAP: React's DocxEditor renders review controls (track-changes toggle + markup display-mode selector) gated by this flag via FormattingBar `priorityExtra` (DocxEditor.tsx `toolbarPriorityExtra = !showReviewControls ? null : (...)`). The Vue toolbar renders no such controls, so there is nothing to gate; not paired because React's behavior is not matched."
     },
@@ -79,7 +79,9 @@
       "onPaste": "No-op in both. React's DocxEditor destructures `onPaste: _onPaste` (never called); Vue's DocxEditor.vue does not thread it. Same verification as onCopy.",
       "toolbarExtra": "Different-idiom match, both wired. React renders the `toolbarExtra` ReactNode as FormattingBar children (`toolbarChildren = toolbarExtra ?? null`). Vue renders the `toolbarExtra` VNodeChild prop into the toolbar's `#toolbar-extra` outlet via VNodeRenderer, with a host-provided `#toolbar-extra` slot taking precedence. Same capability (inject custom toolbar content); the prop is now functional in Vue, not just the slot.",
       "preserveDocumentWhileLoading": "Both wired. React skips its loading early-return when the flag is set and a document already loaded (`status === 'loading' && (!preserveDocumentWhileLoading || !history.state)`), keeping the prior document mounted. Vue suppresses the loading interstitial when `preserveDocumentWhileLoading && hasRenderedDocumentOnce`; the previous pages stay painted in `pagesRef` (the swap tears down the PM view but does not clear the paint) until the new layout replaces them.",
-      "fonts": "Both wired. React registers host FontFace entries via paged-editor/hostFonts + a font-ready re-layout. Vue ports the same DOM-only FontFace path (packages/vue/src/utils/hostFonts.ts) and registers on mount / prop change in DocxEditor.vue, then re-measures (resetCanvasContext + clearAllCaches + reLayout), unregistering on change/unmount — mirroring React's hostFonts effect."
+      "fonts": "Both wired. React registers host FontFace entries via paged-editor/hostFonts + a font-ready re-layout. Vue ports the same DOM-only FontFace path (packages/vue/src/utils/hostFonts.ts) and registers on mount / prop change in DocxEditor.vue, then re-measures (resetCanvasContext + clearAllCaches + reLayout), unregistering on change/unmount — mirroring React's hostFonts effect.",
+      "featureFlags": "Both wired. React resolves the flags in handleSave (resolveSelectiveSaveFlags), and when selectiveSave is on runs attemptSelectiveSave(doc, baselineBuffer, { changedParaIds, structuralChange, hasUntrackedChanges, maxBytes }) with a full-repack fallback. Vue threads props.featureFlags into useDocxEditor via a getter and its save() runs the identical branch: resolveSelectiveSaveFlags(toValue(featureFlags)), the same shouldAttemptSelective/useSelectiveForSave gates, attemptSelectiveSave with the same ParagraphChangeTracker inputs (getChangedParagraphIds/hasStructuralChanges/hasUntrackedChanges from the shared StarterKit extension), and falls back to repackDocx (or createDocx for from-scratch docs with no originalBuffer). Divergence: React re-baselines originalBufferRef and clears tracked changes after each save; Vue keeps the original buffer as the selective baseline and does not clear, so every save diffs the full change set against the original — functionally correct output, just non-incremental across repeated saves.",
+      "onSelectiveSaveTripwire": "Both wired. When flags.selectiveSaveTripwire is on, React computes both selective and full buffers and fires onSelectiveSaveTripwire(compareSelectiveVsFull(selective, full)); the comparison is wrapped so it never poisons the save. Vue's save() mirrors this exactly (same tripwire-only full-repack, same compareSelectiveVsFull call, same swallow-on-error guards) and invokes props.onSelectiveSaveTripwire threaded through useDocxEditor. Timing divergence: React fires onSave then the tripwire; Vue fires the tripwire at the end of the core save() (after the bytes are produced) and onSave at the ref-API boundary once save() resolves, so the tripwire fires just before onSave. Both fire only after a successful save and neither blocks it."
     }
   },
   "ref": {


### PR DESCRIPTION
Threads featureFlags + onSelectiveSaveTripwire into the Vue save() path exactly as React: resolveSelectiveSaveFlags -> attemptSelectiveSave with ParagraphChangeTracker (full-repack fallback); tripwire runs compareSelectiveVsFull and fires onSelectiveSaveTripwire (observability only, never blocks). Moves both deferred->paired (58->60 props). Two honest divergences documented in pairedNotes. test:e2e:parity 18/18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional selective save support for documents, allowing saves to use a lighter-weight path when available.
  * Added a new save option to explicitly choose selective or full saving.

* **Bug Fixes**
  * Improved save reliability by automatically falling back to a full save when selective saving can’t be completed.
  * Added non-blocking save comparisons for better visibility into save behavior without interrupting users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->