### PR TITLE
feat(vue): review controls — track-changes toggle + markup display-mode (61/64 props paired)

### DIFF
--- a/.changeset/vue-review-controls.md
+++ b/.changeset/vue-review-controls.md
@@ -1,0 +1,11 @@
+---
+"@stll/folio-vue": minor
+---
+
+Wire the review controls in the Vue toolbar, gated on `showReviewControls`
+(default true), matching the React adapter. Adds a track-changes toggle
+(flips editing<->suggesting through the existing `setSuggestionMode` path) and a
+markup display-mode selector (All Markup / Simple / No Markup / Original) that
+applies the same `folio-root--<mode>` root class and tracked-change display CSS
+as React. `showReviewControls` moves from deferred to paired in the
+cross-adapter parity contract.

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -42,6 +42,7 @@
     :class="[
       'docx-editor-vue ep-root paged-editor',
       className,
+      displayModeClass,
       { 'paged-editor--readonly': readOnly },
     ]"
     :style="style"
@@ -68,6 +69,10 @@
         :zoom-presets="ZOOM_PRESETS"
         :show-zoom-control="showZoomControl"
         :editor-mode="editorMode"
+        :show-review-controls="showReviewControls"
+        :track-changes-on="trackChangesOn"
+        :display-mode="displayMode"
+        :read-only="readOnly"
         :comments-sidebar-open="showSidebar"
         :image-context="imageToolbarContext"
         :theme="theme ?? null"
@@ -84,6 +89,8 @@
         @zoom-set="setZoom"
         @toggle-sidebar="showSidebar = !showSidebar"
         @mode-change="setEditorMode"
+        @toggle-track-changes="toggleTrackChanges"
+        @update:display-mode="setDisplayMode"
         @image-properties="showImageProperties = true"
         @image-wrap-type="handleToolbarImageWrap"
         @image-transform="handleImageTransform"
@@ -388,6 +395,11 @@ import DocxEditorDialogs from "./DocxEditor/DocxEditorDialogs.vue";
 import DocxEditorMenuBar from "./DocxEditor/DocxEditorMenuBar.vue";
 import DocxEditorOverlays from "./DocxEditor/DocxEditorOverlays.vue";
 import type { DocxEditorProps, EditorMode } from "./DocxEditor/types";
+import {
+  isTrackChangesMode,
+  toggledTrackChangesMode,
+} from "@stll/folio-core/managers/EditorModeManager";
+import type { DisplayMode } from "@stll/folio-core/managers/EditorModeManager";
 import ImageSelectionOverlay from "./ImageSelectionOverlay.vue";
 import OutlineToggleButton from "./OutlineToggleButton.vue";
 import PageIndicator from "./PageIndicator.vue";
@@ -426,6 +438,7 @@ const props = withDefaults(defineProps<DocxEditorProps>(), {
   document: null,
   showToolbar: true,
   showZoomControl: true,
+  showReviewControls: true,
   readOnly: false,
   author: "User",
   mode: "editing",
@@ -459,6 +472,33 @@ provideDocxPortalClass(isDark);
 
 const editorMode = ref<EditorMode>(props.mode);
 const readOnly = computed(() => props.readOnly || editorMode.value === "viewing");
+
+// Review controls (mirrors React's `useEditorMode` display state + toggle):
+//  - `showReviewControls` gates the toolbar's track-changes toggle + markup
+//    display-mode selector (documented default: true).
+//  - `trackChangesOn` derives from the editing mode (suggesting === on).
+//  - `displayMode` is independent local state controlling how tracked changes
+//    render; the host applies the `folio-root--<mode>` class, exactly as React.
+// Documented default (true) is supplied via `withDefaults`; Vue's boolean-prop
+// casting resolves an absent boolean to `false`, so the default must live there
+// rather than a `?? true` fallback (which the cast would pre-empt).
+const showReviewControls = computed(() => props.showReviewControls);
+const trackChangesOn = computed(() => isTrackChangesMode(editorMode.value));
+const displayMode = ref<DisplayMode>("all-markup");
+
+function toggleTrackChanges(): void {
+  setEditorMode(toggledTrackChangesMode(editorMode.value));
+}
+
+function setDisplayMode(mode: DisplayMode): void {
+  displayMode.value = mode;
+}
+
+// Root modifier class driving the tracked-change display CSS (mirrors React's
+// `folio-root--<mode>`). `all-markup` is the default render, so it adds no class.
+const displayModeClass = computed(() =>
+  displayMode.value === "all-markup" ? "" : `folio-root--${displayMode.value}`
+);
 
 const { t } = useTranslation();
 
@@ -1282,5 +1322,50 @@ defineExpose(exposed);
   left: 0;
   top: 0;
   z-index: 20;
+}
+</style>
+
+<!--
+  Track-changes display modes. Non-scoped: the `.docx-insertion` /
+  `.docx-deletion` spans are painted by ProseMirror's `toDOM` (with inline
+  author-color styles), so they never carry this SFC's scope attribute; these
+  overrides must be global to win against the inline styles via `!important`.
+  Ported verbatim from packages/react/src/styles/editor.css so both adapters
+  render each display mode identically.
+
+  All Markup: default — per-author colored underline / strikethrough (inline)
+  No Markup: hide change styling, show final result
+  Original: hide insertions, show deletions as normal text
+  Simple Markup: hide inline marks, show clean text
+-->
+<style>
+/* --- No Markup: show accepted result without change marks --- */
+.folio-root--no-markup .docx-insertion {
+  color: inherit !important;
+  text-decoration: none !important;
+  background: none !important;
+}
+.folio-root--no-markup .docx-deletion {
+  display: none !important;
+}
+
+/* --- Original: show pre-change state --- */
+.folio-root--original .docx-insertion {
+  display: none !important;
+}
+.folio-root--original .docx-deletion {
+  color: inherit !important;
+  text-decoration: none !important;
+  background: none !important;
+}
+
+/* --- Simple Markup: clean text (hide inline marks) --- */
+.folio-root--simple-markup .docx-insertion {
+  color: inherit !important;
+  text-decoration: none !important;
+  background: none !important;
+}
+.folio-root--simple-markup .docx-deletion {
+  display: none !important;
 }
 </style>

--- a/packages/vue/src/components/ReviewControls.vue
+++ b/packages/vue/src/components/ReviewControls.vue
@@ -1,0 +1,220 @@
+<!--
+  Mirror of React's review controls (DocxEditor.tsx `toolbarPriorityExtra`,
+  gated on `showReviewControls`). Two pieces:
+
+    1. Track-changes toggle — a pill button flipping the editor between
+       `editing` and `suggesting`. Active (suggesting) state gets the primary
+       accent; disabled while read-only. Label mirrors React's
+       `trackingOn` / `trackingOff` catalog strings.
+    2. Markup display-mode selector — an eye-icon dropdown choosing how tracked
+       changes render (All Markup / Simple / No Markup / Original). Emits the
+       chosen `DisplayMode`; the host applies the `folio-root--<mode>` class,
+       exactly as React does.
+
+  The toggle only reflects/sets track-changes; it never touches the third
+  `viewing` mode (that stays reachable through the separate EditingModeDropdown).
+-->
+<template>
+  <div class="review-controls">
+    <button
+      type="button"
+      class="review-controls__toggle"
+      :class="{ 'review-controls__toggle--on': trackChangesOn }"
+      :disabled="readOnly"
+      :aria-pressed="trackChangesOn"
+      :aria-label="t('toggleTrackChanges')"
+      :title="t('toggleTrackChanges')"
+      @mousedown.prevent
+      @click.prevent="$emit('toggle-track-changes')"
+    >
+      <MaterialSymbol name="edit_note" :size="18" />
+      <span class="review-controls__toggle-label">{{
+        trackChangesOn ? t('trackingOn') : t('trackingOff')
+      }}</span>
+    </button>
+
+    <Popover
+      :open="isOpen"
+      placement="bottom-right"
+      @update:open="(v) => (isOpen = v)"
+      @close="isOpen = false"
+    >
+      <template #trigger="{ toggle }">
+        <button
+          type="button"
+          class="review-controls__display"
+          :class="{ 'review-controls__display--open': isOpen }"
+          :title="currentLabel"
+          @mousedown.prevent
+          @click.prevent="toggle"
+        >
+          <MaterialSymbol name="visibility" :size="16" />
+          <span class="review-controls__display-label">{{ currentLabel }}</span>
+          <MaterialSymbol name="arrow_drop_down" :size="16" />
+        </button>
+      </template>
+      <template #panel>
+        <div class="review-controls__panel" @mousedown.prevent>
+          <button
+            v-for="mode in DISPLAY_MODES"
+            :key="mode"
+            type="button"
+            class="review-controls__option"
+            @click.prevent="select(mode)"
+          >
+            <span class="review-controls__option-label">{{ labelFor(mode) }}</span>
+            <MaterialSymbol
+              v-if="mode === displayMode"
+              name="check"
+              :size="18"
+              class="review-controls__check"
+            />
+          </button>
+        </div>
+      </template>
+    </Popover>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { DISPLAY_MODES } from '@stll/folio-core/managers/EditorModeManager';
+import type { DisplayMode } from '@stll/folio-core/managers/EditorModeManager';
+import MaterialSymbol from './ui/MaterialSymbol.vue';
+import Popover from './ui/Popover.vue';
+import { useTranslation } from '../i18n';
+
+const { t } = useTranslation();
+
+const props = withDefaults(
+  defineProps<{
+    trackChangesOn: boolean;
+    displayMode: DisplayMode;
+    readOnly?: boolean;
+  }>(),
+  { readOnly: false }
+);
+
+const emit = defineEmits<{
+  (e: 'toggle-track-changes'): void;
+  (e: 'update:display-mode', mode: DisplayMode): void;
+}>();
+
+const isOpen = ref(false);
+
+// Catalog keys mirror React's `DISPLAY_MODE_LABELS` (markupView.* namespace).
+const DISPLAY_MODE_LABEL_KEYS: Record<DisplayMode, string> = {
+  'all-markup': 'markupView.allMarkup',
+  'simple-markup': 'markupView.simple',
+  'no-markup': 'markupView.noMarkup',
+  original: 'markupView.original',
+};
+
+function labelFor(mode: DisplayMode): string {
+  return t(DISPLAY_MODE_LABEL_KEYS[mode]);
+}
+
+const currentLabel = computed(() => labelFor(props.displayMode));
+
+function select(mode: DisplayMode): void {
+  emit('update:display-mode', mode);
+  isOpen.value = false;
+}
+</script>
+
+<style scoped>
+.review-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+/* --- Track-changes toggle ------------------------------------------------ */
+.review-controls__toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 2px 8px 2px 6px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--doc-text-muted);
+  white-space: nowrap;
+}
+.review-controls__toggle:hover:not(:disabled) {
+  border-color: var(--doc-border);
+  background: var(--doc-bg-hover);
+  color: var(--doc-text);
+}
+.review-controls__toggle--on {
+  border-color: var(--doc-primary);
+  background: var(--doc-bg-hover);
+  color: var(--doc-text);
+  box-shadow: 0 0 0 1px var(--doc-primary);
+}
+.review-controls__toggle:disabled {
+  opacity: 0.35;
+  cursor: default;
+  color: var(--doc-text-subtle);
+}
+.review-controls__toggle-label {
+  padding: 0 2px;
+}
+
+/* --- Display-mode selector ----------------------------------------------- */
+.review-controls__display {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 2px 4px 2px 6px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--doc-text-muted);
+  white-space: nowrap;
+}
+.review-controls__display:hover,
+.review-controls__display--open {
+  background: var(--doc-bg-hover);
+  color: var(--doc-text);
+}
+.review-controls__display-label {
+  padding: 0 2px;
+}
+.review-controls__panel {
+  padding: 4px 0;
+  min-width: 180px;
+}
+.review-controls__option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--doc-text);
+  width: 100%;
+  text-align: left;
+}
+.review-controls__option:hover {
+  background: var(--doc-bg-hover);
+}
+.review-controls__option-label {
+  flex: 1 1 auto;
+}
+.review-controls__check {
+  margin-left: auto;
+  color: var(--doc-primary);
+}
+</style>

--- a/packages/vue/src/components/Toolbar.vue
+++ b/packages/vue/src/components/Toolbar.vue
@@ -465,7 +465,22 @@
          inside this pill instead of a separate row. -->
     <slot name="table-context" />
 
-    <!-- 17. Editing-mode dropdown — flows inline after the comments
+    <!-- 17. Review controls — track-changes toggle + markup display-mode
+         selector, gated on `showReviewControls` (mirrors React's
+         `toolbarPriorityExtra`). Flows inline before the editing-mode
+         dropdown with a divider. -->
+    <template v-if="showReviewControls">
+      <span class="divider" />
+      <ReviewControls
+        :track-changes-on="trackChangesOn"
+        :display-mode="displayMode"
+        :read-only="readOnly"
+        @toggle-track-changes="$emit('toggle-track-changes')"
+        @update:display-mode="(m: DisplayMode) => $emit('update:display-mode', m)"
+      />
+    </template>
+
+    <!-- 18. Editing-mode dropdown — flows inline after the comments
          button with a divider before it. -->
     <span class="divider" />
     <EditingModeDropdown
@@ -492,7 +507,9 @@ import MaterialSymbol from './ui/MaterialSymbol.vue';
 import ImageWrapDropdown from './ui/ImageWrapDropdown.vue';
 import ImageTransformDropdown from './ui/ImageTransformDropdown.vue';
 import EditingModeDropdown from './EditingModeDropdown.vue';
+import ReviewControls from './ReviewControls.vue';
 import type { EditorMode } from './DocxEditor/types';
+import type { DisplayMode } from '@stll/folio-core/managers/EditorModeManager';
 import {
   normalizeFontFamilies,
   excludeFontsByName,
@@ -551,6 +568,16 @@ const props = withDefaults(
   zoomPresets?: number[];
   showZoomControl?: boolean;
   editorMode?: EditorMode;
+  /** Whether to render the review controls (track-changes toggle + markup
+      display-mode selector). Mirrors React's `showReviewControls` gate. */
+  showReviewControls?: boolean;
+  /** Whether track-changes (suggesting mode) is active — drives the toggle's
+      pressed state and label. */
+  trackChangesOn?: boolean;
+  /** Current markup display mode — drives the display-mode selector's label. */
+  displayMode?: DisplayMode;
+  /** Whether the editor is read-only — disables the track-changes toggle. */
+  readOnly?: boolean;
   /** Whether the comments sidebar is currently open — drives the
       active state on the comments toolbar button. */
   commentsSidebarOpen?: boolean;
@@ -575,7 +602,17 @@ const props = withDefaults(
   // Defaults for the container-level props let this render as an inert empty
   // rail when unconfigured (e.g. the EditorToolbar default `#toolbar` slot
   // forwarding `$attrs`); Toolbar already `v-if="view"` gates its content.
-  { view: null, stateTick: 0, getCommands: () => ({}) }
+  // `showReviewControls` defaults off here — DocxEditor.vue owns the
+  // documented `default: true` and always passes the resolved value.
+  {
+    view: null,
+    stateTick: 0,
+    getCommands: () => ({}),
+    showReviewControls: false,
+    trackChangesOn: false,
+    displayMode: 'all-markup',
+    readOnly: false,
+  }
 );
 
 const { t } = useTranslation();
@@ -596,6 +633,8 @@ const emit = defineEmits<{
   (e: 'toggle-sidebar'): void;
   (e: 'apply-style', styleId: string): void;
   (e: 'mode-change', mode: EditorMode): void;
+  (e: 'toggle-track-changes'): void;
+  (e: 'update:display-mode', mode: DisplayMode): void;
   (e: 'image-wrap-type', wrapType: string): void;
   (e: 'image-properties'): void;
   (e: 'image-transform', action: ImageTransformAction): void;

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -55,6 +55,7 @@
       "showMarginGuides",
       "showOutline",
       "showPrintButton",
+      "showReviewControls",
       "showRuler",
       "showTableInsert",
       "showTemplateDirectives",
@@ -67,13 +68,13 @@
     "deferredInVue": {
       "collaboration": "Yjs collaboration owner is not threaded through the Vue pipeline yet.",
       "components": "Partially wired: DocxEditor.vue calls provideFolioUI(components) and the ColorPicker override resolves in the toolbar/formatting-bar chrome, but the remaining primitives are not yet threaded (Button/Popover/Menu chrome consumers still import statically; Dialog/Select/Input/Checkbox/DatePickerPopover/OutlineRail have no Vue default to inject), so it is not full parity with React's 10-primitive override surface.",
-      "showHeaderFooterEditing": "Header/footer inline editing is not ported to Vue.",
-      "showReviewControls": "REAL GAP: React's DocxEditor renders review controls (track-changes toggle + markup display-mode selector) gated by this flag via FormattingBar `priorityExtra` (DocxEditor.tsx `toolbarPriorityExtra = !showReviewControls ? null : (...)`). The Vue toolbar renders no such controls, so there is nothing to gate; not paired because React's behavior is not matched."
+      "showHeaderFooterEditing": "Header/footer inline editing is not ported to Vue."
     },
     "pairedNotes": {
       "showMarginGuides": "No-op in both. React's DocxEditor destructures this as `_showMarginGuides = false` (underscore-prefixed, never read) and renders no margin-guide overlay anywhere; Vue declares it and likewise renders none. Verified: only occurrence in React src is the unused destructure in DocxEditor.tsx.",
       "marginGuideColor": "No-op in both. Pairs with showMarginGuides; React's DocxEditor destructures `_marginGuideColor` (underscore-prefixed, never read), so no color is ever applied; Vue matches. Verified: only occurrence in React src is the unused destructure.",
       "showPrintButton": "No-op in both. React's classic `Toolbar` component reads this flag, but `DocxEditor` renders `FormattingBar` (not `Toolbar`) and never passes `showPrintButton`; FormattingBar has no print button, so no toolbar print button is rendered regardless of the flag. Vue's Toolbar likewise renders none (print is driven from the menu bar / Cmd+P). Verified: `showPrintButton` appears only in Toolbar.tsx/toolbarPrimitives.tsx (the unmounted classic toolbar), never in DocxEditor.tsx or FormattingBar.tsx.",
+      "showReviewControls": "Both wired. React gates its `toolbarPriorityExtra` (a track-changes toggle flipping editing<->suggesting via `toggleTrackChanges`, plus a markup display-mode `StSelect` calling `setDisplayMode`) on this flag; `displayMode` drives the `folio-root--<mode>` root class that the editor.css tracked-change rules key off. Vue's Toolbar renders ReviewControls.vue (same track-changes toggle + display-mode selector) gated on `showReviewControls` (default true), the toggle emits through `setEditorMode(toggledTrackChangesMode(...))` into the same core `setSuggestionMode` path, and the selector sets a local `displayMode` that DocxEditor.vue applies as the identical `folio-root--<mode>` class, with the same tracked-change display CSS ported verbatim into a non-scoped style block. Divergence: Vue additionally keeps its EditingModeDropdown (a Vue-only three-mode editing/suggesting/viewing picker React lacks), so `viewing` stays reachable there; the toggle itself only flips editing<->suggesting, matching React exactly. Vue holds `displayMode` in a local ref rather than core's EditorModeManager (which React binds via useEditorMode), same observable behavior.",
       "onCopy": "No-op in both. React's DocxEditor destructures `onCopy: _onCopy` (underscore-prefixed, never called); there is no `useClipboard` hook in the React package. Vue's DocxEditor.vue does not thread the prop either (its `useClipboard` composable is standalone and unused by the editor). The line-3972 `onCopy` in React is HyperlinkPopup's own copy-link-href prop, unrelated to DocxEditorProps.onCopy.",
       "onCut": "No-op in both. React's DocxEditor destructures `onCut: _onCut` (never called); Vue's DocxEditor.vue does not thread it. Same verification as onCopy.",
       "onPaste": "No-op in both. React's DocxEditor destructures `onPaste: _onPaste` (never called); Vue's DocxEditor.vue does not thread it. Same verification as onCopy.",


### PR DESCRIPTION
Adds ReviewControls.vue (track-changes toggle via setSuggestionMode + markup display-mode selector All/Simple/No Markup/Original via root class), gated by showReviewControls, ported tracked-change display CSS. Moves showReviewControls deferred->paired (60->61). pairedNotes documents the Vue-only EditingModeDropdown + local displayMode divergence. test:e2e:parity 18/18.