### PR TITLE
feat(vue): implement hasPendingChanges ref (29/30 ref members paired)

### DIFF
--- a/.changeset/vue-has-pending-changes.md
+++ b/.changeset/vue-has-pending-changes.md
@@ -1,0 +1,12 @@
+---
+"@stll/folio-vue": minor
+---
+
+Implement `DocxEditorRef.hasPendingChanges()` in the Vue adapter (previously
+stubbed to `false`). It now returns whether the live editor has edits not yet
+serialized by `save()`, mirroring the React adapter's set/clear points: a
+doc-dirty flag set on every doc-changing transaction and cleared on a successful
+`save()` and on document load/swap, OR-ed with a comment-list dirty flag set on
+comment mutations (add/reply/resolve/unresolve/delete) and cleared on load and
+save. Moves `hasPendingChanges` from deferred to paired in the cross-adapter
+parity contract.

--- a/api-reports/vue/composables.api.md
+++ b/api-reports/vue/composables.api.md
@@ -108,6 +108,7 @@ export type UseDocxEditorReturn = {
     editorView: Ref<EditorView | null>;
     editorState: Ref<EditorState | null>;
     isReady: Ref<boolean>;
+    isDirty: Ref<boolean>;
     parseError: Ref<string | null>;
     layout: Ref<Layout | null>;
     blocks: Ref<FlowBlock[]>;

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -36,6 +36,8 @@ export type FolioParityBridge = {
   countAnonymizationRects: () => number;
   /** Serialize to DOCX and return the byte length (0 on failure). */
   save: () => Promise<number>;
+  /** Whether the live editor has edits not yet serialized by save(). */
+  hasPendingChanges: () => boolean;
 };
 
 export function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridge {
@@ -175,5 +177,6 @@ export function buildParityBridge(getRef: () => DocxEditorRef | null): FolioPari
       const buffer = await (getRef()?.save() ?? Promise.resolve(null));
       return buffer?.byteLength ?? 0;
     },
+    hasPendingChanges: () => getRef()?.hasPendingChanges() ?? false,
   };
 }

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -79,6 +79,8 @@ export type FolioParityBridge = {
   countAnonymizationRects: () => number;
   /** Serialize to DOCX and return the byte length (0 on failure). */
   save: () => Promise<number>;
+  /** Whether the live editor has edits not yet serialized by save(). */
+  hasPendingChanges: () => boolean;
 };
 
 function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridge {
@@ -218,6 +220,7 @@ function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridg
       const buffer = await (getRef()?.save() ?? Promise.resolve(null));
       return buffer?.byteLength ?? 0;
     },
+    hasPendingChanges: () => getRef()?.hasPendingChanges() ?? false,
   };
 }
 

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -589,6 +589,7 @@ const {
   editorView,
   editorState,
   isReady,
+  isDirty,
   parseError,
   layout,
   blocks,
@@ -1176,6 +1177,13 @@ onMounted(() => {
 const { exposed } = useDocxEditorRefApi({
   editor,
   editorView,
+  // Doc-dirty flag (any doc-changing transaction; cleared on save + load) and
+  // comment-list dirty flag together back `hasPendingChanges`, mirroring React's
+  // ParagraphChangeTracker signals OR-ed with commentsDirtyRef. The ref API's
+  // save wrapper clears the comment flag; useDocxEditor clears the doc flag.
+  isDirty,
+  commentsDirty: commentManagement.commentsDirty,
+  clearCommentsDirty: commentManagement.clearCommentsDirty,
   layout,
   pagesRef,
   pagesViewportRef,

--- a/packages/vue/src/composables/useCommentManagement.ts
+++ b/packages/vue/src/composables/useCommentManagement.ts
@@ -40,6 +40,17 @@ export type UseCommentManagementOptions = {
 
 export type UseCommentManagementReturn = {
   comments: ComputedRef<Comment[]>;
+  /**
+   * True when the comment thread list has user mutations not yet serialized by
+   * `save()`. Mirrors React's `commentsDirtyRef`: comment edits (add / reply /
+   * resolve / unresolve / delete) do not touch the PM document, so they are
+   * invisible to the doc-dirty flag; this surfaces them. Set on every user
+   * comment mutation, cleared on document load (`seedFromDocument`) and on a
+   * successful save (`clearCommentsDirty`).
+   */
+  commentsDirty: ComputedRef<boolean>;
+  /** Clear {@link commentsDirty} after a successful save. */
+  clearCommentsDirty: () => void;
   /** Build a comment with a freshly-allocated, collision-seeded id. */
   createComment: (text: string, parentId?: number) => Comment;
   /** Append a comment and emit the change. */
@@ -64,6 +75,19 @@ export function useCommentManagement(
 ): UseCommentManagementReturn {
   const allocator = createCommentIdAllocator();
   const internalComments = ref<Comment[]>([]);
+  // Dirty flag for comment-only edits (see the return type doc). Not set inside
+  // `setComments`, which is also the load-seed path — only the user-driven
+  // mutation handlers below mark it, matching React (where the low-level comment
+  // setter is clean and only `replaceComments` sets `commentsDirtyRef`).
+  const commentsDirty = ref(false);
+
+  function markCommentsDirty(): void {
+    commentsDirty.value = true;
+  }
+
+  function clearCommentsDirty(): void {
+    commentsDirty.value = false;
+  }
 
   const isControlled = computed(() => options.commentsProp() !== undefined);
   const comments = computed<Comment[]>(() =>
@@ -76,6 +100,7 @@ export function useCommentManagement(
   }
 
   function pushComment(comment: Comment): void {
+    markCommentsDirty();
     setComments([...comments.value, comment]);
   }
 
@@ -87,6 +112,11 @@ export function useCommentManagement(
   }
 
   function seedFromDocument(): void {
+    // A document load/swap is a clean baseline: the seeded comments came from the
+    // just-loaded file, so nothing is pending (mirrors React clearing
+    // `commentsDirtyRef` on document reset). Cleared unconditionally so a
+    // controlled host's swap resets the flag too.
+    clearCommentsDirty();
     if (isControlled.value) return;
     const bodyComments = options.getDocument()?.package.document.comments;
     seedCommentAllocator(allocator, bodyComments, options.editorView.value);
@@ -101,10 +131,12 @@ export function useCommentManagement(
   }
 
   function handleResolve(commentId: number): void {
+    markCommentsDirty();
     setComments(comments.value.map((c) => (c.id === commentId ? { ...c, done: true } : c)));
   }
 
   function handleUnresolve(commentId: number): void {
+    markCommentsDirty();
     setComments(comments.value.map((c) => (c.id === commentId ? { ...c, done: false } : c)));
   }
 
@@ -112,6 +144,7 @@ export function useCommentManagement(
     // Drop the comment and any direct replies threaded under it (matches React's
     // onCommentDelete). The orphaned comment mark left in the doc is pruned at
     // save time.
+    markCommentsDirty();
     setComments(comments.value.filter((c) => c.id !== commentId && c.parentId !== commentId));
   }
 
@@ -150,6 +183,8 @@ export function useCommentManagement(
 
   return {
     comments,
+    commentsDirty: computed(() => commentsDirty.value),
+    clearCommentsDirty,
     createComment,
     pushComment,
     setComments,

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -482,6 +482,13 @@ export type UseDocxEditorReturn = {
   editorState: Ref<EditorState | null>;
   /** True once the hidden view is mounted and a document is loaded. */
   isReady: Ref<boolean>;
+  /**
+   * True when the live PM state has doc edits not yet serialized by `save()`.
+   * Set on every doc-changing transaction, cleared on a successful save and on
+   * document load/swap. Backs the ref API's `hasPendingChanges` (OR-ed with the
+   * comment-list dirty flag).
+   */
+  isDirty: Ref<boolean>;
   /** Last parse error message, or null if the most recent load succeeded. */
   parseError: Ref<string | null>;
   /** Computed page layout, or null before first paint. */
@@ -546,6 +553,14 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
   const measures = shallowRef<Measure[]>([]);
   const isReady = ref(false);
   const parseError = ref<string | null>(null);
+  // "Live PM state has edits not yet serialized" flag, the Vue analogue of the
+  // signals React derives from the ParagraphChangeTracker in `hasPendingChanges`.
+  // Set on every doc-changing transaction (the same signal that drives the
+  // debounced writeback/`onChange`) and cleared on a successful `save()` and on
+  // document load/swap. Vue keeps the change tracker uncleared across saves (it
+  // is the selective-save baseline; see the featureFlags parity note), so this
+  // flag — not the tracker — is what surfaces pending edits to the ref API.
+  const isDirty = ref(false);
 
   // ---- Long-lived controller singletons -----------------------------------
   // One ExtensionManager owns the schema + plugins + commands for the body view.
@@ -775,6 +790,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
   function handleTransaction(transaction: Transaction, newState: EditorState): void {
     editorState.value = newState;
     if (transaction.docChanged) {
+      isDirty.value = true;
       syncCoordinator.incrementStateSeq();
       scheduler.schedule(newState, getTransactionDirtyRange(transaction));
       scheduleDocumentChangeNotification();
@@ -885,6 +901,9 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     // A new document is a truly external swap. Rather than rely on the manager's
     // metadata-signature heuristic (which can skip a same-metadata reload), tear
     // the view down and rebuild it so the seed state + initial layout run fresh.
+    // The freshly loaded document has no unsaved edits yet (mirrors React
+    // clearing its dirty signals on document reset).
+    isDirty.value = false;
     scheduler.dispose();
     manager.destroyView();
     manager.ensureView();
@@ -1023,6 +1042,14 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       }
     }
 
+    // The bytes are produced: the live doc state is now serialized, so no doc
+    // edits are pending. Mirrors React's handleSave clearing the change tracker.
+    // (The tracker itself is intentionally left uncleared — it is the
+    // selective-save baseline; see the featureFlags parity note.) The comment-
+    // list dirty flag lives in useCommentManagement and is cleared by the ref
+    // API's save wrapper, the single public save entry point.
+    isDirty.value = false;
+
     return new Blob([buffer], {
       type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     });
@@ -1072,6 +1099,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     editorView,
     editorState,
     isReady,
+    isDirty,
     parseError,
     layout,
     blocks,

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -9,12 +9,14 @@
  * so any drift from the React contract is a typecheck error here rather than a
  * runtime surprise at the call site.
  *
- * PORT-BLOCKED: a few ref methods still depend on adapter surfaces the fork has
- * not ported yet (`hasPendingChanges` needs PM-serialized-vs-live tracking;
- * `getEditorRef` needs the Vue PagedEditor component). Those stay stubbed to a
- * sensible default (null / false) with a per-method note. The AI-edit and
+ * PORT-BLOCKED: one ref method still depends on an adapter surface the fork has
+ * not ported yet (`getEditorRef` needs the Vue PagedEditor component). It stays
+ * stubbed to a sensible default (null) with a per-method note. The AI-edit and
  * content-control methods are wired over folio-core directly, mirroring the
- * React adapter. The assembled object `satisfies DocxEditorRef`.
+ * React adapter. `hasPendingChanges` is wired from the doc-dirty flag
+ * (`useDocxEditor`) OR-ed with the comment-list dirty flag
+ * (`useCommentManagement`); see its per-method note. The assembled object
+ * `satisfies DocxEditorRef`.
  */
 
 import type { Ref } from "vue";
@@ -56,6 +58,23 @@ export type UseDocxEditorRefApiOptions = {
   editor: FolioEditor;
   /** Off-screen ProseMirror EditorView, or null before mount. */
   editorView: Ref<EditorView | null>;
+  /**
+   * Doc-dirty flag from useDocxEditor: live PM edits not yet serialized. Backs
+   * the doc side of `hasPendingChanges` (React's ParagraphChangeTracker signals).
+   */
+  isDirty: Readonly<Ref<boolean>>;
+  /**
+   * Comment-list dirty flag from useCommentManagement: comment mutations not yet
+   * serialized. Backs the comment side of `hasPendingChanges` (React's
+   * `commentsDirtyRef`).
+   */
+  commentsDirty: Readonly<Ref<boolean>>;
+  /**
+   * Clear {@link commentsDirty} after a successful save. Called from the `save`
+   * wrapper below — the single public save entry point — so the comment flag is
+   * reset alongside useDocxEditor's doc-dirty flag, mirroring React's handleSave.
+   */
+  clearCommentsDirty: () => void;
   /** Computed page layout, or null before first paint. */
   layout: Ref<Layout | null>;
   /** Painted pages container (the `HTMLDivElement` the painter writes into). */
@@ -106,6 +125,10 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
       return null;
     }
     const buffer = await blob.arrayBuffer();
+    // Save succeeded: clear the comment-list dirty flag (useDocxEditor already
+    // cleared the doc-dirty flag when it produced the bytes). Mirrors React's
+    // handleSave resetting commentsDirtyRef.
+    opts.clearCommentsDirty();
     // Mirror React's handleSave: notify the host with the serialized bytes.
     opts.onSave?.(buffer);
     return buffer;
@@ -167,9 +190,20 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
 
   const exposed = {
     getDocument: opts.getDocument,
-    // PORT-BLOCKED: hasPendingChanges needs the PM-serialized-vs-live tracking
-    // the React shell keeps; useDocxEditor does not surface it yet.
-    hasPendingChanges: () => false,
+    // React derives this live from the ParagraphChangeTracker plugin
+    // (getChangedParagraphIds/hasStructuralChanges/hasUntrackedChanges) OR-ed
+    // with commentsDirtyRef, clearing the tracker on save. Vue keeps the tracker
+    // uncleared across saves (it is the selective-save baseline), so instead of
+    // reading the tracker we track two flags with the same set/clear points as
+    // React: `isDirty` (any doc-changing transaction; cleared on save + load) and
+    // `commentsDirty` (any comment mutation; cleared on save + load). Same net
+    // semantics: pending edits after typing/comment changes, clean after save.
+    hasPendingChanges: () => {
+      if (!opts.editorView.value) {
+        return false;
+      }
+      return opts.isDirty.value || opts.commentsDirty.value;
+    },
     // PORT-BLOCKED: getEditorRef needs the Vue PagedEditor component, not ported.
     getEditorRef: () => null,
     getEditor: () => opts.editor,

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -99,6 +99,7 @@
       "getEditor",
       "getTotalPages",
       "getZoom",
+      "hasPendingChanges",
       "loadDocument",
       "loadDocumentBuffer",
       "openPrintPreview",
@@ -117,9 +118,11 @@
       "setZoom",
       "undo"
     ],
+    "pairedNotes": {
+      "hasPendingChanges": "Both wired, same set/clear points, different-idiom implementation. React derives it live each call from the ParagraphChangeTracker plugin (getChangedParagraphIds/hasStructuralChanges/hasUntrackedChanges) OR-ed with commentsDirtyRef, and clears the tracker after each successful save. Vue cannot read the tracker for this because it deliberately leaves the tracker uncleared across saves (the tracker is the selective-save baseline; see the featureFlags props note) and re-editing an already-tracked paragraph would not grow the set, so a tracker read could never go false after save. Instead Vue tracks two boolean flags with the same set/clear points as React's underlying signals: `isDirty` in useDocxEditor (set on every doc-changing transaction — the same signal that drives the writeback/onChange; cleared on a successful save() and on document load/swap) and `commentsDirty` in useCommentManagement (set on every user comment mutation add/reply/resolve/unresolve/delete; cleared on document load via seedFromDocument and on a successful save via the ref API's save wrapper). useDocxEditorRefApi returns `isDirty || commentsDirty` (false before the view mounts, matching React's no-view guard). Net semantics match: pending after typing or a comment edit, clean after save or load. Housekeeping transactions (paraId allocation, auto-bidi) only run as appendTransactions to a real user edit or imperatively at initial-state build (never through the runtime transaction handler on a plain load), so they never set isDirty spuriously."
+    },
     "deferredInVue": {
-      "getEditorRef": "Requires the Vue PagedEditor component, not ported; stubbed to return null.",
-      "hasPendingChanges": "Requires PM-serialized-vs-live tracking the Vue pipeline does not surface; stubbed to false."
+      "getEditorRef": "Requires the Vue PagedEditor component, not ported; stubbed to return null."
     }
   }
 }

--- a/tests/parity/has-pending-changes.spec.ts
+++ b/tests/parity/has-pending-changes.spec.ts
@@ -1,0 +1,28 @@
+import { ensureLiveView, expect, forEachAdapter, openEditor } from "./parity-fixture";
+
+// hasPendingChanges tracks whether the live editor has edits not yet serialized:
+// clean on load, dirty after an edit, clean again after a save. Both adapters
+// must agree (React derives it from the change tracker + comments-dirty flag;
+// Vue from equivalent doc-dirty + comments-dirty flags with the same set/clear
+// points).
+forEachAdapter("hasPendingChanges: clean -> edit -> save", async (adapter, { page }) => {
+  await openEditor(page, adapter);
+  await ensureLiveView(page);
+
+  // Freshly loaded document: nothing pending.
+  expect(await page.evaluate(() => window.__folioParity?.hasPendingChanges() ?? true)).toBe(false);
+
+  // A doc edit makes changes pending.
+  const inserted = await page.evaluate(() => window.__folioParity?.insertText(" pending") ?? false);
+  expect(inserted).toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => window.__folioParity?.hasPendingChanges() ?? false))
+    .toBe(true);
+
+  // A successful save clears the pending flag.
+  const byteLength = await page.evaluate(() => window.__folioParity?.save() ?? 0);
+  expect(byteLength).toBeGreaterThan(1000);
+  await expect
+    .poll(() => page.evaluate(() => window.__folioParity?.hasPendingChanges() ?? true))
+    .toBe(false);
+});

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -28,6 +28,7 @@ type FolioParityBridge = {
   anonymizeFirstWord: () => boolean;
   countAnonymizationRects: () => number;
   save: () => Promise<number>;
+  hasPendingChanges: () => boolean;
 };
 
 declare global {


### PR DESCRIPTION
Implements DocxEditorRef.hasPendingChanges via isDirty (doc-changing transactions) + commentsDirty flags at React's exact set/clear points (cleared on save + load/swap). pairedNotes documents the flag-vs-tracker divergence (Vue keeps the tracker as selective-save baseline). Moves hasPendingChanges deferred->paired (ref 28->29). Adds clean->edit->save parity spec; test:e2e:parity 20/20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “pending changes” indicator for the editor, so it can now report when there are unsaved edits.
  * The indicator now updates after document edits, comment changes, saves, and document loads.

* **Bug Fixes**
  * Fixed the editor status so it no longer always reports a clean state.
  * Improved consistency between Vue and React editor behavior.

* **Tests**
  * Added coverage to verify the pending-changes state goes from clean to dirty and back to clean after saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->