### PR TITLE
fix(nuxt): prepack uses bun run build (fixes Publish pack step)

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "build": "nuxt-module-build build",
-    "prepack": "nuxt-module-build build",
+    "prepack": "bun run build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
The nuxt package's prepack called nuxt-module-build directly, which bun pm pack can't resolve (no hoisted .bin on PATH), failing the Publish workflow's pack step. Changed to 'bun run build' matching core/react/vue. Verified bun pm pack now succeeds.