### PR TITLE
fix(vue): populate Document Outline + wire Find/Replace (and zoom) shortcuts

### DIFF
--- a/.changeset/vue-outline-findreplace.md
+++ b/.changeset/vue-outline-findreplace.md
@@ -1,0 +1,14 @@
+---
+"@stll/folio-vue": patch
+---
+
+Fix the Document Outline panel always showing "No headings found": `outlineHeadings`
+was declared but never populated. Wire the existing `useOutlineSidebar` composable
+into `DocxEditor.vue` so opening the outline (via the toggle button, toolbar, or File
+menu) collects headings from the document, re-collects them on further edits while the
+panel stays open, and clicking a heading scrolls the visible pages to it.
+
+Fix Find/Replace having no way to open: `useKeyboardShortcuts` existed but was never
+invoked from `DocxEditor.vue`, so Ctrl+F / Ctrl+H / Ctrl+K never opened their dialogs.
+Invoke the composable from the editor shell, and add a Find & Replace entry to the
+File menu as a discoverable, mouse-driven entry point alongside the keyboard shortcut.

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -82,7 +82,7 @@
         @insert-symbol="showInsertSymbol = true"
         @insert-page-break="handleInsertPageBreakAction"
         @page-setup="showPageSetup = true"
-        @toggle-outline="showOutline = !showOutline"
+        @toggle-outline="outlineSidebar.handleToggleOutline"
         @apply-style="handleApplyStyle"
         @zoom-in="zoomIn"
         @zoom-out="zoomOut"
@@ -323,7 +323,11 @@
           </button>
         </div>
 
-        <OutlineToggleButton v-if="!showOutline" :left-offset="12" @toggle="showOutline = true" />
+        <OutlineToggleButton
+          v-if="!showOutline"
+          :left-offset="12"
+          @toggle="outlineSidebar.handleToggleOutline"
+        />
 
         <PageIndicator
           v-if="scrollPageInfo.totalPages > 1"
@@ -337,7 +341,7 @@
           :headings="outlineHeadings"
           :get-scroll-container="() => pagesRef"
           @close="showOutline = false"
-          @navigate="() => {}"
+          @navigate="outlineSidebar.handleOutlineNavigate"
         />
       </div>
     </div>
@@ -423,6 +427,7 @@ import { useDocxEditorRefApi } from "../composables/useDocxEditorRefApi";
 import { useFormattingActions } from "../composables/useFormattingActions";
 import { useHyperlinkManagement } from "../composables/useHyperlinkManagement";
 import { useImageActions } from "../composables/useImageActions";
+import { useOutlineSidebar } from "../composables/useOutlineSidebar";
 import { usePageSetupControls } from "../composables/usePageSetupControls";
 import { usePagesPointer } from "../composables/usePagesPointer";
 import { provideDocxPortalClass } from "../composables/usePortalClass";
@@ -560,7 +565,8 @@ const showSidebar = ref(false);
 const activeSidebarItem = ref<string | null>(null);
 const bookmarks = shallowRef<{ name: string; label?: string }[]>([]);
 
-// Outline headings stay empty until the outline composable is ported.
+// Populated by `useOutlineSidebar` — collected lazily on outline open and
+// re-collected on doc changes while the panel stays open (see below).
 const outlineHeadings = shallowRef<HeadingInfo[]>([]);
 
 const {
@@ -761,6 +767,22 @@ const {
   reLayout,
   emit: () => {},
   clearOverlay: () => {},
+});
+
+// Document Outline: heading collection + navigate-to-heading, driven off the
+// visible pages viewport (the hidden PM is off-screen — see
+// `scrollVisiblePositionIntoView`'s doc comment). `extractCommentsAndChanges`
+// is unused here: DocxEditor.vue's own sidebar toggle (below) already reads
+// comments reactively off `commentManagement.comments`, so only the
+// outline-specific handlers from this composable are wired.
+const outlineSidebar = useOutlineSidebar({
+  editorView,
+  showOutline,
+  showSidebar,
+  outlineHeadings,
+  activeSidebarItem,
+  extractCommentsAndChanges: () => {},
+  scrollToVisiblePosition: scrollVisiblePositionIntoView,
 });
 
 const {
@@ -1027,7 +1049,7 @@ function handleMenuAction(action: string): void {
       showPageSetup.value = true;
       break;
     case "toggleOutline":
-      showOutline.value = !showOutline.value;
+      outlineSidebar.handleToggleOutline();
       break;
     case "toggleSidebar":
       showSidebar.value = !showSidebar.value;
@@ -1082,6 +1104,9 @@ watch(
   () => props.showOutline,
   (next) => {
     showOutline.value = !!next;
+    // Host-driven open (as opposed to a user click through
+    // `handleToggleOutline`) still needs headings collected.
+    outlineSidebar.recomputeHeadingsIfOpen();
   },
 );
 
@@ -1121,6 +1146,12 @@ watch(isReady, (ready) => {
   // swap keeps the prior pages visible instead of flashing the loading state.
   hasRenderedDocumentOnce.value = true;
 
+  // A document just (re)painted: re-collect headings if the outline panel is
+  // already open — covers the initial-mount `showOutline` prop and a document
+  // swap while the panel stays open (an outline toggle can't fire in either
+  // case, since it was already open before the view existed).
+  outlineSidebar.recomputeHeadingsIfOpen();
+
   // Populate the sidebar from comments embedded in the loaded document
   // (uncontrolled only); controlled hosts own the array via `comments`.
   commentManagement.seedFromDocument();
@@ -1155,6 +1186,7 @@ onMounted(() => {
   });
   const offDoc = editor.on("docChange", () => {
     stateTick.value++;
+    outlineSidebar.recomputeHeadingsIfOpen();
   });
   const offLayout = editor.on("layoutComplete", () => {
     stateTick.value++;

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -427,6 +427,7 @@ import { useDocxEditorRefApi } from "../composables/useDocxEditorRefApi";
 import { useFormattingActions } from "../composables/useFormattingActions";
 import { useHyperlinkManagement } from "../composables/useHyperlinkManagement";
 import { useImageActions } from "../composables/useImageActions";
+import { useKeyboardShortcuts } from "../composables/useKeyboardShortcuts";
 import { useOutlineSidebar } from "../composables/useOutlineSidebar";
 import { usePageSetupControls } from "../composables/usePageSetupControls";
 import { usePagesPointer } from "../composables/usePagesPointer";
@@ -557,6 +558,9 @@ const rulerVisible = computed(() => props.showRuler ?? false);
 const stateTick = ref(0);
 const showFindReplace = ref(false);
 const showHyperlink = ref(false);
+// PORT-BLOCKED: no KeyboardShortcutsDialog component ported yet, so F1 / Ctrl+/
+// toggle inert local state (mirrors the colorMode / externalPlugins stubs above).
+const showKeyboardShortcuts = ref(false);
 const showInsertSymbol = ref(false);
 const showImageProperties = ref(false);
 const showPageSetup = ref(false);
@@ -578,6 +582,7 @@ const {
   zoomIn,
   zoomOut,
   handleWheel: handleZoomWheel,
+  handleKeyDown: handleZoomKeyDown,
   ZOOM_PRESETS,
 } = useZoom(props.initialZoom);
 
@@ -589,6 +594,19 @@ function handleWheelZoomGated(event: WheelEvent): void {
   }
   handleZoomWheel(event);
 }
+
+// Global keyboard shortcuts (F1 keyboard-shortcuts dialog, Ctrl+=/-/0 zoom,
+// Ctrl+F/H find-replace, Ctrl+K hyperlink, Ctrl+/ shortcuts toggle). Installs
+// its own window-level listener on mount and tears it down on unmount, so no
+// further wiring is needed here. Mirrors React's Cmd/Ctrl+F find-open path
+// (`useKeyboardShortcuts` in `packages/react/src/components/hooks`), extended
+// with the Vue adapter's additional shortcuts.
+useKeyboardShortcuts({
+  showKeyboardShortcuts,
+  showFindReplace,
+  showHyperlink,
+  handleZoomKeyDown,
+});
 
 // ---- Pipeline -----------------------------------------------------------
 const {

--- a/packages/vue/src/components/MenuBar.vue
+++ b/packages/vue/src/components/MenuBar.vue
@@ -99,6 +99,12 @@ const fileItems = computed<MenuEntry[]>(() => {
       onClick: act('save'),
     },
     { type: 'separator' },
+    {
+      label: t('toolbar.findReplace'),
+      shortcut: t('toolbar.findReplaceShortcut'),
+      onClick: act('findReplace'),
+    },
+    { type: 'separator' },
     { icon: 'settings', label: t('toolbar.pageSetup'), onClick: act('pageSetup') }
   );
   return items;

--- a/packages/vue/src/composables/useOutlineSidebar.ts
+++ b/packages/vue/src/composables/useOutlineSidebar.ts
@@ -29,15 +29,33 @@ export type UseOutlineSidebarOptions = {
 }
 
 export function useOutlineSidebar(opts: UseOutlineSidebarOptions) {
+  function recomputeHeadings() {
+    const view = opts.editorView.value;
+    if (view) {
+      opts.outlineHeadings.value = collectHeadings(view.state.doc);
+    }
+  }
+
   function handleToggleOutline() {
     if (!opts.showOutline.value) {
-      // Opening: collect headings
-      const view = opts.editorView.value;
-      if (view) {
-        opts.outlineHeadings.value = collectHeadings(view.state.doc);
-      }
+      // Opening: collect headings so the panel isn't stale from before the
+      // panel existed (or from before the doc-change recompute below fired).
+      recomputeHeadings();
     }
     opts.showOutline.value = !opts.showOutline.value;
+  }
+
+  /**
+   * Re-collect headings after a document change, but only while the outline
+   * panel is open — a closed panel re-collects lazily on next open via
+   * `handleToggleOutline`. Mirrors React's doc-change-triggered heading
+   * recompute (`DocxEditor.tsx`'s `handleDocumentChange`, gated on
+   * `showOutlineRef.current`).
+   */
+  function recomputeHeadingsIfOpen() {
+    if (opts.showOutline.value) {
+      recomputeHeadings();
+    }
   }
 
   function handleOutlineNavigate(pmPos: number) {
@@ -79,5 +97,6 @@ export function useOutlineSidebar(opts: UseOutlineSidebarOptions) {
     handleOutlineNavigate,
     handleToggleSidebar,
     handleEditorScrollMouseDown,
+    recomputeHeadingsIfOpen,
   };
 }


### PR DESCRIPTION
Two pre-existing Vue bugs (confirmed via live playground). (1) outlineHeadings was never populated -> Document Outline always empty; now wired via useOutlineSidebar, recomputed on docChange/showOutline/isReady, navigate wired. (2) useKeyboardShortcuts was never invoked -> Find/Replace had no entry point; now invoked (also fixes zoom shortcuts) + File>Find & Replace menu entry. Both verified in-browser. test:e2e:parity 22/22.