### PR TITLE
fix(react): toolbar overflow collapse + control polish

### DIFF
--- a/.changeset/toolbar-overflow-polish.md
+++ b/.changeset/toolbar-overflow-polish.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": patch
+---
+
+Fix `FormattingBar` overflow collapse: the secondary control group (font, color, alignment, lists) now collapses into the "More" popover based on live measurement of the toolbar's actual content width (via `ResizeObserver`), instead of a fixed bar-width breakpoint that ignored host `priorityExtra`/`inlineExtra` width and could leave controls scrolled out of view with no visible affordance; the "More" trigger is now rendered outside the scrollable region so it can never scroll away. Also fixes the zoom control and font-size picker truncating their labels, normalizes the alignment/list active-state affordance and icon sizes to match bold/italic/underline.

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -2,13 +2,17 @@
  * FormattingBar — clean, minimal toolbar for legal document editing.
  *
  * Controls (left to right):
- * Undo Redo | Style ▾ | B I U | A▾ | ≡▾ 1. • ◁ ▷
+ * Undo Redo | Style ▾ | [host priorityExtra] | B I U [Format Painter] | Insert |
+ * Font A▾ size Color | Alignment ¶ | Lists ◁ ▷ | ⋯ More (when collapsed) |
+ * [host extras: ruler, zoom, ...]
  *
- * Everything else (font, size, strikethrough, highlight, comments,
- * editing mode) is accessible via keyboard shortcuts or host app chrome.
+ * The font/color/alignment/list group collapses behind a "⋯ More" popover
+ * whenever the bar is too narrow to show it inline (measured live, not a
+ * fixed breakpoint); everything not shown here is still reachable via
+ * keyboard shortcuts or host app chrome.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import {
@@ -46,7 +50,9 @@ import { StylePicker } from "./ui/StylePicker";
 import { ZoomControl } from "./ui/ZoomControl";
 
 const ICON_SIZE = 16;
-const INLINE_SECONDARY_CONTROLS_MIN_WIDTH = 760;
+/** Buffer added to the measured content width before deciding it overflows,
+ * absorbing sub-pixel rounding so the collapse decision does not flap. */
+const OVERFLOW_EPSILON_PX = 1;
 
 /** Default grid the Insert Table button requests (the toolbar has no size picker). */
 const DEFAULT_TABLE_ROWS = 2;
@@ -134,7 +140,23 @@ export function FormattingBar(props: FormattingBarProps) {
   const ColorPicker = folioUI.ColorPicker;
   const t = useTranslations("folio");
   const barRef = useRef<HTMLDivElement>(null);
-  const [showSecondaryInline, setShowSecondaryInline] = useState(false);
+  // `scrollRef` is the horizontally-scrollable region holding the primary
+  // controls (and the secondary group when it fits inline); `primaryRef`
+  // wraps only the always-visible primary controls so its natural width can
+  // be measured independent of whether the secondary group is shown.
+  // `secondaryRef` wraps the secondary group only while it is rendered
+  // inline; its last-measured width is cached in `secondaryWidthRef` so the
+  // collapse decision still has a number to compare against once the group
+  // moves into the overflow popover (its width is effectively constant: the
+  // group is all fixed-size icon controls, no localized text driving it).
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const primaryRef = useRef<HTMLDivElement>(null);
+  const secondaryRef = useRef<HTMLDivElement>(null);
+  const secondaryWidthRef = useRef(0);
+  // Start optimistic (assume the secondary group fits): the layout effect
+  // below measures and corrects this before the first paint, so a narrow
+  // initial width never flashes overflowing content.
+  const [showSecondaryInline, setShowSecondaryInline] = useState(true);
 
   const handleFormat = useCallback(
     (action: FormattingAction) => {
@@ -437,26 +459,54 @@ export function FormattingBar(props: FormattingBarProps) {
     editorRef,
   ]);
 
-  useEffect(() => {
-    const bar = barRef.current;
-    if (!bar || inline) {
-      setShowSecondaryInline(inline);
+  // Decide whether the secondary group (font, color, alignment, lists) fits
+  // inline by comparing the scroll container's real available width
+  // (`clientWidth`, which already accounts for host `priorityExtra` and the
+  // right-side host extras taking their share of the bar) against the
+  // measured natural width of the primary controls plus the secondary
+  // group. This replaces a fixed bar-width breakpoint, which ignored
+  // however much room `priorityExtra` actually consumed and left a gap
+  // between "too narrow to fit inline" and "narrow enough to show the ⋯
+  // fallback" with no affordance in between.
+  //
+  // `useLayoutEffect` (not `useEffect`) so the very first measurement — and
+  // any correction it makes to the optimistic initial state — happens
+  // before the browser paints, avoiding a flash of overflowing content.
+  useLayoutEffect(() => {
+    if (inline) {
+      setShowSecondaryInline(true);
+      return undefined;
+    }
+
+    const scrollEl = scrollRef.current;
+    const primaryEl = primaryRef.current;
+    if (!scrollEl || !primaryEl) {
       return undefined;
     }
 
     const update = () => {
-      const shouldShow = bar.getBoundingClientRect().width >= INLINE_SECONDARY_CONTROLS_MIN_WIDTH;
-      setShowSecondaryInline((current) => (current === shouldShow ? current : shouldShow));
+      const secondaryEl = secondaryRef.current;
+      if (secondaryEl) {
+        secondaryWidthRef.current = secondaryEl.offsetWidth;
+      }
+      const available = scrollEl.clientWidth;
+      const required = primaryEl.offsetWidth + secondaryWidthRef.current;
+      const fits = required <= available + OVERFLOW_EPSILON_PX;
+      setShowSecondaryInline((current) => (current === fits ? current : fits));
     };
 
     update();
     const observer = new ResizeObserver(update);
-    observer.observe(bar);
+    observer.observe(scrollEl);
+    observer.observe(primaryEl);
+    if (secondaryRef.current) {
+      observer.observe(secondaryRef.current);
+    }
 
     return () => {
       observer.disconnect();
     };
-  }, [inline]);
+  }, [inline, showSecondaryInline]);
 
   const handleBarMouseDown = useCallback((e: React.MouseEvent) => {
     if (!(e.target instanceof HTMLElement)) {
@@ -493,7 +543,7 @@ export function FormattingBar(props: FormattingBarProps) {
             }
             onChange={handleFontSizeChange}
             disabled={disabled}
-            placeholder={t("fontSize")}
+            ariaLabel={t("fontSize")}
           />
         )}
         {showTextColorPicker && (
@@ -585,182 +635,200 @@ export function FormattingBar(props: FormattingBarProps) {
       onMouseDown={inline ? undefined : containedHandler(barRef, handleBarMouseDown)}
       onMouseUp={inline ? undefined : containedHandler(barRef, handleBarMouseUp)}
     >
-      {/* Formatting controls */}
-      <div className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-0.5 overflow-x-auto overflow-y-hidden overscroll-x-contain [&::-webkit-scrollbar]:hidden">
-        {/* Undo / Redo */}
-        <ToolbarGroup className="gap-0" label={t("historyGroup")}>
-          <ToolbarButton
-            className="h-8 w-7 rounded-e-none disabled:opacity-[0.35]"
-            onClick={handleUndo}
-            disabled={disabled || !canUndo}
-            title={t("undoShortcut")}
-            ariaLabel={t("undo")}
-          >
-            <Undo2Icon size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            className="h-8 w-7 rounded-s-none disabled:opacity-[0.35]"
-            onClick={handleRedo}
-            disabled={disabled || !canRedo}
-            title={t("redoShortcut")}
-            ariaLabel={t("redo")}
-          >
-            <Redo2Icon size={ICON_SIZE} />
-          </ToolbarButton>
-        </ToolbarGroup>
-
-        <ToolbarSeparator />
-
-        {/* Paragraph style gallery */}
-        {showStylePicker && (
-          <>
-            <StylePicker
-              value={currentFormatting.styleId || "Normal"}
-              onChange={handleStyleChange}
-              styles={documentStyles}
-              theme={theme}
-              disabled={disabled}
-              displayLabel={stylePickerLabel}
-              displayLabelStyle={stylePickerLabelStyle}
-              className="shrink-0"
-              width="clamp(112px, 15vw, 140px)"
-            />
-            <ToolbarSeparator />
-          </>
-        )}
-
-        {priorityExtra && (
-          <>
-            {priorityExtra}
-            <ToolbarSeparator />
-          </>
-        )}
-
-        {/* Bold, Italic, Underline */}
-        <ToolbarGroup label={t("textFormattingGroup")}>
-          <ToolbarButton
-            onClick={() => handleFormat("bold")}
-            active={currentFormatting.bold}
-            disabled={disabled}
-            title={t("boldShortcut")}
-            ariaLabel={t("bold")}
-          >
-            <BoldIcon size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            onClick={() => handleFormat("italic")}
-            active={currentFormatting.italic}
-            disabled={disabled}
-            title={t("italicShortcut")}
-            ariaLabel={t("italic")}
-          >
-            <ItalicIcon size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            onClick={() => handleFormat("underline")}
-            active={currentFormatting.underline}
-            disabled={disabled}
-            title={t("underlineShortcut")}
-            ariaLabel={t("underline")}
-          >
-            <UnderlineIcon size={ICON_SIZE} />
-          </ToolbarButton>
-          {showFormatPainter && onFormatPainter && (
+      {/* Formatting controls: horizontally scrollable when the primary
+          controls alone still overflow (the secondary group never scrolls —
+          it either shows inline here or collapses into the ⋯ popover below). */}
+      <div
+        ref={scrollRef}
+        className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-0.5 overflow-x-auto overflow-y-hidden overscroll-x-contain [&::-webkit-scrollbar]:hidden"
+      >
+        {/* Primary controls: always visible; wrapped so their combined
+            natural width can be measured independent of the secondary
+            group (see the layout effect above). */}
+        <div ref={primaryRef} className="flex shrink-0 items-center gap-0.5">
+          {/* Undo / Redo */}
+          <ToolbarGroup className="gap-0" label={t("historyGroup")}>
             <ToolbarButton
-              onClick={handleFormatPainterClick}
-              onDoubleClick={handleFormatPainterDoubleClick}
-              active={formatPainterActive}
-              disabled={disabled}
-              title={t("formatPainterShortcut")}
-              ariaLabel={t("formatPainter")}
-              testId="toolbar-format-painter"
+              className="h-8 w-7 rounded-e-none disabled:opacity-[0.35]"
+              onClick={handleUndo}
+              disabled={disabled || !canUndo}
+              title={t("undoShortcut")}
+              ariaLabel={t("undo")}
             >
-              <PaintbrushIcon size={ICON_SIZE} />
+              <Undo2Icon size={ICON_SIZE} />
             </ToolbarButton>
+            <ToolbarButton
+              className="h-8 w-7 rounded-s-none disabled:opacity-[0.35]"
+              onClick={handleRedo}
+              disabled={disabled || !canRedo}
+              title={t("redoShortcut")}
+              ariaLabel={t("redo")}
+            >
+              <Redo2Icon size={ICON_SIZE} />
+            </ToolbarButton>
+          </ToolbarGroup>
+
+          <ToolbarSeparator />
+
+          {/* Paragraph style gallery */}
+          {showStylePicker && (
+            <>
+              <StylePicker
+                value={currentFormatting.styleId || "Normal"}
+                onChange={handleStyleChange}
+                styles={documentStyles}
+                theme={theme}
+                disabled={disabled}
+                displayLabel={stylePickerLabel}
+                displayLabelStyle={stylePickerLabelStyle}
+                className="shrink-0"
+                width="clamp(112px, 15vw, 140px)"
+              />
+              <ToolbarSeparator />
+            </>
           )}
-        </ToolbarGroup>
 
-        {/* Insert group — each control is opt-in: it renders only when its
-            handler (and flag, for tables) is provided by the consumer. */}
-        {hasInsertControls && (
-          <>
-            <ToolbarSeparator />
-            <ToolbarGroup label={t("insertGroup")}>
-              {onInsertImage && (
-                <ToolbarButton
-                  onClick={handleInsertImage}
-                  disabled={disabled}
-                  title={t("insertImage")}
-                  ariaLabel={t("insertImage")}
-                >
-                  <ImageIcon size={ICON_SIZE} />
-                </ToolbarButton>
-              )}
-              {showTableButton && (
-                <ToolbarButton
-                  onClick={handleInsertTable}
-                  disabled={disabled}
-                  title={t("insertTable")}
-                  ariaLabel={t("insertTable")}
-                  testId="toolbar-insert-table"
-                >
-                  <TableIcon size={ICON_SIZE} />
-                </ToolbarButton>
-              )}
-              {onInsertPageBreak && (
-                <ToolbarButton
-                  onClick={handleInsertPageBreak}
-                  disabled={disabled}
-                  title={t("insertPageBreak")}
-                  ariaLabel={t("insertPageBreak")}
-                >
-                  <SeparatorHorizontalIcon size={ICON_SIZE} />
-                </ToolbarButton>
-              )}
-              {onInsertTOC && (
-                <ToolbarButton
-                  onClick={handleInsertTOC}
-                  disabled={disabled}
-                  title={t("insertTableOfContents")}
-                  ariaLabel={t("insertTableOfContents")}
-                >
-                  <TableOfContentsIcon size={ICON_SIZE} />
-                </ToolbarButton>
-              )}
-            </ToolbarGroup>
-          </>
-        )}
+          {priorityExtra && (
+            <>
+              {priorityExtra}
+              <ToolbarSeparator />
+            </>
+          )}
 
-        {showSecondaryInline ? (
-          <>
-            <ToolbarSeparator />
-            {secondaryControls}
-          </>
-        ) : (
-          <>
-            <ToolbarSeparator />
-            <Menu>
-              <MenuTrigger
-                render={
-                  <button
-                    type="button"
-                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--doc-text-muted)] transition-colors duration-100 hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
-                    aria-label={t("moreFormatting")}
-                    title={t("moreFormatting")}
-                  />
-                }
+          {/* Bold, Italic, Underline */}
+          <ToolbarGroup label={t("textFormattingGroup")}>
+            <ToolbarButton
+              onClick={() => handleFormat("bold")}
+              active={currentFormatting.bold}
+              disabled={disabled}
+              title={t("boldShortcut")}
+              ariaLabel={t("bold")}
+            >
+              <BoldIcon size={ICON_SIZE} />
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => handleFormat("italic")}
+              active={currentFormatting.italic}
+              disabled={disabled}
+              title={t("italicShortcut")}
+              ariaLabel={t("italic")}
+            >
+              <ItalicIcon size={ICON_SIZE} />
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => handleFormat("underline")}
+              active={currentFormatting.underline}
+              disabled={disabled}
+              title={t("underlineShortcut")}
+              ariaLabel={t("underline")}
+            >
+              <UnderlineIcon size={ICON_SIZE} />
+            </ToolbarButton>
+            {showFormatPainter && onFormatPainter && (
+              <ToolbarButton
+                onClick={handleFormatPainterClick}
+                onDoubleClick={handleFormatPainterDoubleClick}
+                active={formatPainterActive}
+                disabled={disabled}
+                title={t("formatPainterShortcut")}
+                ariaLabel={t("formatPainter")}
+                testId="toolbar-format-painter"
               >
-                <MoreHorizontalIcon size={ICON_SIZE} />
-              </MenuTrigger>
-              <MenuPopup align="end" className="max-w-[min(520px,calc(100vw-24px))]">
-                <div className="flex w-[min(480px,calc(100vw-48px))] flex-wrap items-center gap-1 p-1">
-                  {secondaryControls}
-                </div>
-              </MenuPopup>
-            </Menu>
+                <PaintbrushIcon size={ICON_SIZE} />
+              </ToolbarButton>
+            )}
+          </ToolbarGroup>
+
+          {/* Insert group — each control is opt-in: it renders only when its
+            handler (and flag, for tables) is provided by the consumer. */}
+          {hasInsertControls && (
+            <>
+              <ToolbarSeparator />
+              <ToolbarGroup label={t("insertGroup")}>
+                {onInsertImage && (
+                  <ToolbarButton
+                    onClick={handleInsertImage}
+                    disabled={disabled}
+                    title={t("insertImage")}
+                    ariaLabel={t("insertImage")}
+                  >
+                    <ImageIcon size={ICON_SIZE} />
+                  </ToolbarButton>
+                )}
+                {showTableButton && (
+                  <ToolbarButton
+                    onClick={handleInsertTable}
+                    disabled={disabled}
+                    title={t("insertTable")}
+                    ariaLabel={t("insertTable")}
+                    testId="toolbar-insert-table"
+                  >
+                    <TableIcon size={ICON_SIZE} />
+                  </ToolbarButton>
+                )}
+                {onInsertPageBreak && (
+                  <ToolbarButton
+                    onClick={handleInsertPageBreak}
+                    disabled={disabled}
+                    title={t("insertPageBreak")}
+                    ariaLabel={t("insertPageBreak")}
+                  >
+                    <SeparatorHorizontalIcon size={ICON_SIZE} />
+                  </ToolbarButton>
+                )}
+                {onInsertTOC && (
+                  <ToolbarButton
+                    onClick={handleInsertTOC}
+                    disabled={disabled}
+                    title={t("insertTableOfContents")}
+                    ariaLabel={t("insertTableOfContents")}
+                  >
+                    <TableOfContentsIcon size={ICON_SIZE} />
+                  </ToolbarButton>
+                )}
+              </ToolbarGroup>
+            </>
+          )}
+        </div>
+
+        {showSecondaryInline && (
+          <>
+            <ToolbarSeparator />
+            <div ref={secondaryRef} className="flex shrink-0 items-center gap-0.5">
+              {secondaryControls}
+            </div>
           </>
         )}
       </div>
+
+      {/* Overflow trigger for the secondary (font, color, alignment, lists)
+          group: a sibling of the scrollable region above, not a child of it,
+          so it is pinned in place and can never be scrolled out of view.
+          Rendered only when that group has been measured to not fit inline. */}
+      {!showSecondaryInline && (
+        <>
+          <ToolbarSeparator />
+          <Menu>
+            <MenuTrigger
+              render={
+                <button
+                  type="button"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--doc-text-muted)] transition-colors duration-100 hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
+                  aria-label={t("moreFormatting")}
+                  title={t("moreFormatting")}
+                />
+              }
+            >
+              <MoreHorizontalIcon size={ICON_SIZE} />
+            </MenuTrigger>
+            <MenuPopup align="end" className="max-w-[min(520px,calc(100vw-24px))]">
+              <div className="flex w-[min(480px,calc(100vw-48px))] flex-wrap items-center gap-1 p-1">
+                {secondaryControls}
+              </div>
+            </MenuPopup>
+          </Menu>
+        </>
+      )}
 
       {/* Host extras (zoom, track changes, etc.) */}
       <div className="ms-auto flex shrink-0 items-center gap-1">

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -144,11 +144,11 @@ export function FormattingBar(props: FormattingBarProps) {
   // controls (and the secondary group when it fits inline); `primaryRef`
   // wraps only the always-visible primary controls so its natural width can
   // be measured independent of whether the secondary group is shown.
-  // `secondaryRef` wraps the secondary group only while it is rendered
-  // inline; its last-measured width is cached in `secondaryWidthRef` so the
-  // collapse decision still has a number to compare against once the group
-  // moves into the overflow popover (its width is effectively constant: the
-  // group is all fixed-size icon controls, no localized text driving it).
+  // `secondaryRef` wraps the inline separator plus secondary group while it is
+  // rendered inline. Its last-measured width is cached in `secondaryWidthRef`,
+  // so the collapse decision still has a number to compare against once the
+  // group moves into the overflow popover (its width is effectively constant:
+  // the group is all fixed-size icon controls, no localized text driving it).
   const scrollRef = useRef<HTMLDivElement>(null);
   const primaryRef = useRef<HTMLDivElement>(null);
   const secondaryRef = useRef<HTMLDivElement>(null);
@@ -469,8 +469,8 @@ export function FormattingBar(props: FormattingBarProps) {
   // between "too narrow to fit inline" and "narrow enough to show the ⋯
   // fallback" with no affordance in between.
   //
-  // `useLayoutEffect` (not `useEffect`) so the very first measurement — and
-  // any correction it makes to the optimistic initial state — happens
+  // `useLayoutEffect` (not `useEffect`) so the very first measurement, and
+  // any correction it makes to the optimistic initial state, happens
   // before the browser paints, avoiding a flash of overflowing content.
   useLayoutEffect(() => {
     if (inline) {
@@ -490,7 +490,11 @@ export function FormattingBar(props: FormattingBarProps) {
         secondaryWidthRef.current = secondaryEl.offsetWidth;
       }
       const available = scrollEl.clientWidth;
-      const required = primaryEl.offsetWidth + secondaryWidthRef.current;
+      const scrollGap = Number.parseFloat(getComputedStyle(scrollEl).columnGap);
+      const required =
+        primaryEl.offsetWidth +
+        secondaryWidthRef.current +
+        (Number.isFinite(scrollGap) ? scrollGap : 0);
       const fits = required <= available + OVERFLOW_EPSILON_PX;
       setShowSecondaryInline((current) => (current === fits ? current : fits));
     };
@@ -792,12 +796,10 @@ export function FormattingBar(props: FormattingBarProps) {
         </div>
 
         {showSecondaryInline && (
-          <>
+          <div ref={secondaryRef} className="flex shrink-0 items-center gap-0.5">
             <ToolbarSeparator />
-            <div ref={secondaryRef} className="flex shrink-0 items-center gap-0.5">
-              {secondaryControls}
-            </div>
-          </>
+            <div className="flex shrink-0 items-center gap-0.5">{secondaryControls}</div>
+          </div>
         )}
       </div>
 

--- a/packages/react/src/components/ui/AlignmentButtons.tsx
+++ b/packages/react/src/components/ui/AlignmentButtons.tsx
@@ -26,7 +26,7 @@ export type AlignmentButtonsProps = {
   style?: CSSProperties;
 };
 
-const ICON_SIZE = 18;
+const ICON_SIZE = 16;
 
 const OPTIONS = [
   {
@@ -101,7 +101,7 @@ export function AlignmentButtons({
                 className={cn(
                   "flex size-8 items-center justify-center rounded transition-colors",
                   value === opt.value
-                    ? "bg-[var(--doc-primary-light)] text-[var(--doc-primary)]"
+                    ? "bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
                     : "text-[var(--doc-text)] hover:bg-[var(--doc-primary-light)]",
                 )}
                 data-testid={`alignment-${opt.value}`}

--- a/packages/react/src/components/ui/FontSizePicker.tsx
+++ b/packages/react/src/components/ui/FontSizePicker.tsx
@@ -17,7 +17,14 @@ export type FontSizePickerProps = {
   /** Override the default size list. Values in points. */
   sizes?: number[] | undefined;
   disabled?: boolean | undefined;
+  /**
+   * Text shown only while no size is selected. Keep this short (or empty):
+   * the trigger is narrow and a long localized word truncates to a
+   * near-illegible ellipsis. Prefer `ariaLabel` for the descriptive name.
+   */
   placeholder?: string | undefined;
+  /** Accessible name for the trigger (does not affect the visible label). */
+  ariaLabel?: string | undefined;
   width?: number | string | undefined;
 };
 
@@ -39,6 +46,7 @@ export function FontSizePicker({
   sizes,
   disabled = false,
   placeholder = "",
+  ariaLabel,
   width = 56,
 }: FontSizePickerProps) {
   const {
@@ -67,6 +75,7 @@ export function FontSizePicker({
       disabled={disabled}
     >
       <SelectTrigger
+        aria-label={ariaLabel}
         size="sm"
         className="min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] tabular-nums shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
         style={{

--- a/packages/react/src/components/ui/ListButtons.tsx
+++ b/packages/react/src/components/ui/ListButtons.tsx
@@ -34,15 +34,15 @@ export const createDefaultListState = (): ListState => ({
   isInList: false,
 });
 
-const ICON_SIZE = 20;
+const ICON_SIZE = 16;
 
 const btnCls = (active: boolean, disabled: boolean, compact: boolean) =>
   cn(
     "flex items-center justify-center rounded transition-colors",
     compact ? "size-7" : "size-8",
     active
-      ? "bg-[var(--doc-primary-light)] text-[var(--doc-primary)]"
-      : "text-[var(--doc-text-muted)] hover:bg-[var(--doc-bg-hover)]",
+      ? "bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
+      : "text-[var(--doc-text-muted)] hover:bg-[var(--doc-primary-light)]",
     disabled &&
       "cursor-not-allowed text-[var(--doc-text-subtle)] opacity-[0.16] disabled:hover:bg-transparent disabled:hover:text-[var(--doc-text-subtle)]",
   );

--- a/packages/react/src/components/ui/ZoomControl.tsx
+++ b/packages/react/src/components/ui/ZoomControl.tsx
@@ -93,7 +93,7 @@ export function ZoomControl({
           compact ? "text-xs" : "text-sm",
           className,
         )}
-        style={{ width: compact ? 55 : 70, height: compact ? 28 : 32 }}
+        style={{ width: compact ? 76 : 80, height: compact ? 28 : 32 }}
       >
         <SelectValue placeholder="100%">{displayLabel}</SelectValue>
       </SelectTrigger>

--- a/packages/react/src/ui/folio-ui.tsx
+++ b/packages/react/src/ui/folio-ui.tsx
@@ -111,7 +111,7 @@ export type FolioSelectRootProps = Pick<
   SelectPrimitive.Root.Props<string>,
   "value" | "onValueChange" | "disabled" | "items"
 > & { children?: ReactNode };
-export type FolioSelectTriggerProps = Pick<SelectPrimitive.Trigger.Props, "style"> & {
+export type FolioSelectTriggerProps = Pick<SelectPrimitive.Trigger.Props, "style" | "aria-label"> & {
   className?: string;
   children?: ReactNode;
   size?: "sm" | "default" | "lg";

--- a/tests/visual/editing-flows.spec.ts
+++ b/tests/visual/editing-flows.spec.ts
@@ -43,6 +43,22 @@ async function mountFixture(page: Page, fixture: string): Promise<void> {
   await page.waitForTimeout(250);
 }
 
+/**
+ * Click a toolbar button by its accessible name. The font/color/alignment/
+ * list group collapses behind the "More formatting" overflow trigger
+ * whenever the bar is too narrow to show it inline (measured live against
+ * the toolbar's actual content, not a fixed viewport breakpoint) — open that
+ * popover first when the button is not already on screen.
+ */
+async function clickToolbarButton(page: Page, name: string): Promise<void> {
+  const button = page.getByRole("button", { name });
+  const visible = await button.isVisible().catch(() => false);
+  if (!visible) {
+    await page.getByRole("button", { name: "More formatting" }).click();
+  }
+  await button.click();
+}
+
 /** Live body ProseMirror document text. */
 function bodyText(page: Page): Promise<string> {
   return page.evaluate(
@@ -333,15 +349,15 @@ test.describe("lists", () => {
     await page.locator(".layout-paragraph").first().click();
 
     // Bullet list applies numbering id 1 to the caret paragraph.
-    await page.getByRole("button", { name: "Bullet List" }).click();
+    await clickToolbarButton(page, "Bullet List");
     await expect.poll(() => caretParagraphNumId(page)).toBe(1);
 
     // Switching to a numbered list moves it to a distinct numbering id (2).
-    await page.getByRole("button", { name: "Numbered List" }).click();
+    await clickToolbarButton(page, "Numbered List");
     await expect.poll(() => caretParagraphNumId(page)).toBe(2);
 
     // Clicking the already-active numbered-list button clears list formatting.
-    await page.getByRole("button", { name: "Numbered List" }).click();
+    await clickToolbarButton(page, "Numbered List");
     await expect.poll(() => caretParagraphNumId(page)).toBeNull();
   });
 });

--- a/tests/visual/editing-flows.spec.ts
+++ b/tests/visual/editing-flows.spec.ts
@@ -47,7 +47,7 @@ async function mountFixture(page: Page, fixture: string): Promise<void> {
  * Click a toolbar button by its accessible name. The font/color/alignment/
  * list group collapses behind the "More formatting" overflow trigger
  * whenever the bar is too narrow to show it inline (measured live against
- * the toolbar's actual content, not a fixed viewport breakpoint) — open that
+ * the toolbar's actual content, not a fixed viewport breakpoint); open that
  * popover first when the button is not already on screen.
  */
 async function clickToolbarButton(page: Page, name: string): Promise<void> {


### PR DESCRIPTION
## Summary

- **P0 — overflow collapse rework** (`FormattingBar.tsx`): the secondary control group (font, color, alignment, lists) collapsed into the "More" popover only below a fixed 760px bar-width threshold. This ignored however much room host `priorityExtra`/`inlineExtra` content actually consumed, so between roughly 760–1250px (and, with a wide `inlineExtra`, even well beyond that) the group could be shown inline while genuinely not fitting — scrolling off into a `scrollbar-width:none` overflow region with no visible affordance. Below ~700px the "More" trigger itself lived inside that same scrollable region and could scroll out of view.

  Reworked to measure real content width via `ResizeObserver` (the scroll container's `clientWidth` vs. the primary controls' + secondary group's measured natural width) instead of a fixed breakpoint, and moved the "More" trigger to a sibling of the scrollable region so it can never scroll away. Verified with a local Playwright script at 700/900/1000/1440/1800px: the trigger stays reachable at every width, and the group correctly stays inline once it actually fits (crossover verified stable, no flicker, in the 1500–1520px range for the demo playground's toolbar content).

- **P1 — zoom control label clipping** (`ZoomControl.tsx`): the compact trigger (55px) clipped "100%" to "1..". Widened to 76px (80px non-compact) — verified "100%" and "200%" render in full.
- **P1 — font-size placeholder clipping** (`FormattingBar.tsx`, `FontSizePicker.tsx`): the long localized "Font Size" placeholder truncated to "F..." in the narrow trigger. Stopped passing it as the visible placeholder (falls back to empty, or shows the computed size); added an `ariaLabel` prop so the accessible name is preserved.
- **P1 — active-state consistency**: `AlignmentButtons`/`ListButtons` used a `--doc-primary`-colored icon for the active state while bold/italic/underline use a text-colored icon on a grey background. Normalized alignment/lists to match.
- **P1 — icon sizes**: `AlignmentButtons` (18px) and `ListButtons` (20px) normalized to the shared 16px `ICON_SIZE` used elsewhere in the toolbar.
- **P2/P3**: fixed the stale `FormattingBar` header comment (described controls no longer matched reality) and unified `ListButtons`' hover token to `--doc-primary-light` (was `--doc-bg-hover`).
- **Format Painter shortcut**: verified Ctrl+Shift+C is bound (`DocxEditor.tsx`, global keydown handler) — no fix needed, tooltip and binding already match.

Also updates `tests/visual/editing-flows.spec.ts`: the one interaction test that clicked "Bullet List"/"Numbered List" directly now opens the "More formatting" popover first when the button isn't already visible inline, since at the suite's 1280px viewport the secondary group correctly collapses given the demo toolbar's `inlineExtra` content — this is the accurate behavior the old fixed-threshold logic was masking.

Out of scope (per review): did not wire `showHighlightColorPicker`/`showLineSpacingPicker`, and did not build a shared tooltip component.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run --filter '@stll/folio-react' test src` (180 pass)
- [x] `bunx playwright test --project=interactions` (17 pass, 2 pre-existing skips)
- [x] Manual visual check via `bun --filter @stll/playground dev` (`?file=sample.docx`) at 700/900/1000/1440/1800px — "More" trigger always reachable, no control invisible without an affordance, zoom/font-size labels render without clipping, active-state colors consistent across B/I/U/alignment/lists
- [ ] `bun run test:visual` (rendering project has no local baselines for this platform yet — pre-existing, unrelated to this change; the rendering spec hides the toolbar before its screenshots anyway)