### PR TITLE
feat: document Folio package set and support React 18

### DIFF
--- a/.changeset/bright-react-bridges.md
+++ b/.changeset/bright-react-bridges.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": minor
+---
+
+Support React 18 alongside React 19.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,13 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources
+          bunx playwright install --with-deps chromium
 
       # Behaviour specs only (assert document content + editor state). The
       # screenshot baselines (rendering.spec) and perf budgets
@@ -139,7 +145,13 @@ jobs:
         run: bun run test:packaged-consumer
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources
+          bunx playwright install --with-deps chromium
 
       # Runtime half of the same gate: serve the built consumer and drive it in a
       # browser. Catches failures the build cannot see — a worker that resolves at

--- a/README.md
+++ b/README.md
@@ -4,29 +4,43 @@
 
 # folio
 
-A Word-document editor for the browser. It opens a `.docx`, lets you edit
-it, and writes a `.docx` back — preserving pagination, tables, headers and
-footers, tracked changes, and footnotes.
+A framework-neutral DOCX engine and browser editor toolkit. It opens a `.docx`,
+lets you edit it, and writes a `.docx` back — preserving pagination, tables,
+headers and footers, tracked changes, and footnotes.
 
-The OOXML parser, document model, and page-layout engine are React-free, so they
-run on a server or under any framework. The React editor is one layer on top.
+The OOXML parser, document model, and page-layout engine are framework-neutral,
+so they run on a server or under any UI adapter. The React and Vue editors are
+thin layers on top, with a Nuxt module for Vue/Nuxt apps and an agent-tooling
+package for document review workflows.
 
 Part of [stella](https://github.com/stella/stella), an open-source legal workspace.
 
 ## Packages
 
-This is a [bun](https://bun.sh) workspace monorepo with two published packages:
+This is a [bun](https://bun.sh) workspace monorepo with these published packages:
 
-| Package                                 | What it is                                                                                                                                                                                        |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@stll/folio-core`](./packages/core)   | the headless, framework-neutral core — OOXML parsing, the document model, the ProseMirror integration, and the layout engine; no React in the import graph, so non-React adapters can build on it |
-| [`@stll/folio-react`](./packages/react) | the React editor and its components, built on `@stll/folio-core`                                                                                                                                  |
+| Package                                 | What it is                                                                                                                                                                                             |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`@stll/folio-core`](./packages/core)   | the headless, framework-neutral core — OOXML parsing, the document model, the ProseMirror integration, and the layout engine; no framework UI in the import graph                                     |
+| [`@stll/folio-react`](./packages/react) | the React editor and its components, built on `@stll/folio-core`                                                                                                                                       |
+| [`@stll/folio-vue`](./packages/vue)     | the Vue 3 editor and composables, built on the same core and layout engine                                                                                                                             |
+| [`@stll/folio-nuxt`](./packages/nuxt)   | a Nuxt 3/4 module that registers the Vue editor safely for Nuxt apps                                                                                                                                   |
+| [`@stll/folio-agents`](./packages/agents) | framework-neutral LLM tool definitions and executors for reading `.docx` documents and proposing tracked changes or comments through `@stll/folio-core`                                             |
 
 ## Install
 
 ```sh
 # the React editor (pulls in @stll/folio-core)
 bun add @stll/folio-react react react-dom use-intl
+
+# the Vue editor
+bun add @stll/folio-vue vue
+
+# Nuxt integration
+bun add @stll/folio-nuxt
+
+# agent/review tooling
+bun add @stll/folio-agents
 
 # or just the headless engine
 bun add @stll/folio-core
@@ -147,20 +161,20 @@ language switcher you can use to preview every bundled locale.
 
 ```sh
 bun install
-bun run build       # builds both packages (core first)
+bun run build       # builds all published packages
 bun run typecheck
-bun run test        # unit suite for both packages
+bun run test        # unit suites across the workspace
 bun run lint
-bun run validate-dist   # clean-room publish-shape validation for both packages
+bun run validate-dist   # clean-room publish-shape validation for published packages
 ```
 
 ## Releasing
 
 Releases are driven by [Changesets](https://github.com/changesets/changesets).
-The two packages are versioned independently.
+The published packages are versioned independently.
 
-**Every PR that edits `packages/core/src` or `packages/react/src` must add a
-changeset.** CI enforces this (`bun run changeset:check`):
+**Every PR that edits published package source under `packages/{core,react,agents,vue,nuxt}/src`
+must add a changeset.** CI enforces this (`bun run changeset:check`):
 
 ```sh
 bunx changeset          # pick packages + bump level, write a summary
@@ -182,8 +196,8 @@ How a version reaches npm:
    pending changesets — bumping the affected `package.json` versions, updating
    changelogs, and re-syncing `bun.lock`.
 3. Merging that PR lands the version bumps on `main`, which trips
-   `publish.yml`'s `packages/{core,react}/package.json` path filter and runs the
-   hardened OIDC publish + GitHub Release for the bumped package(s).
+   `publish.yml`'s package path filter and runs the hardened OIDC publish +
+   GitHub Release for the bumped package(s).
 
 Changesets never publishes; `publish.yml` is the sole publish mechanism.
 

--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -84,6 +84,7 @@ import { FolioCommentAnchor } from '@stll/folio-core/ai-edits';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioReviewChange } from '@stll/folio-core/ai-edits';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
+import { ForwardRefExoticComponent } from 'react';
 import { fromMarkdown } from '@stll/folio-core/markdown';
 import { getAnonymizationMatches } from '@stll/folio-core/prosemirror/plugins/anonymizationDecorations';
 import { getAutocompleteSuggestion } from '@stll/folio-core/prosemirror/plugins/autocompleteSuggestion';
@@ -114,7 +115,6 @@ import { Popover } from '@base-ui/react/popover';
 import { PositionalText } from '@stll/folio-core/ai-suggestions/text-positions';
 import React$1 from 'react';
 import { ReactNode } from 'react';
-import { Ref } from 'react';
 import { RefAttributes } from 'react';
 import { RefObject } from 'react';
 import { resetTemplateSlashQuery } from '@stll/folio-core/prosemirror/plugins/templateSlashMenu';
@@ -275,9 +275,7 @@ export { Document_2 as Document }
 export { DocxCompatibility }
 
 // @public
-export function DocxEditor(input: DocxEditorProps & {
-    ref?: Ref<DocxEditorRef>;
-}): JSX.Element;
+export const DocxEditor: ForwardRefExoticComponent<DocxEditorProps & RefAttributes<DocxEditorRef>>;
 
 // @public (undocumented)
 export type DocxEditorCollaboration = {

--- a/bun.lock
+++ b/bun.lock
@@ -35,14 +35,14 @@
     },
     "packages/agents": {
       "name": "@stll/folio-agents",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
       },
     },
     "packages/core": {
       "name": "@stll/folio-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@stll/docx-core": "^0.1.0",
         "@stll/docx-utils": "^0.1.0",
@@ -70,7 +70,7 @@
     },
     "packages/nuxt": {
       "name": "@stll/folio-nuxt",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
         "@stll/folio-vue": "workspace:^",
@@ -126,7 +126,7 @@
     },
     "packages/react": {
       "name": "@stll/folio-react",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",
         "@fontsource/arimo": "^5.2.8",
@@ -151,14 +151,14 @@
         "y-prosemirror": "^1.3.7",
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "use-intl": ">=4.0.0",
       },
     },
     "packages/vue": {
       "name": "@stll/folio-vue",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
         "better-result": "2.9.2",

--- a/bun.lock
+++ b/bun.lock
@@ -35,14 +35,14 @@
     },
     "packages/agents": {
       "name": "@stll/folio-agents",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
       },
     },
     "packages/core": {
       "name": "@stll/folio-core",
-      "version": "0.3.0",
+      "version": "0.2.0",
       "dependencies": {
         "@stll/docx-core": "^0.1.0",
         "@stll/docx-utils": "^0.1.0",
@@ -70,7 +70,7 @@
     },
     "packages/nuxt": {
       "name": "@stll/folio-nuxt",
-      "version": "0.2.0",
+      "version": "0.1.0",
       "dependencies": {
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
         "@stll/folio-vue": "workspace:^",
@@ -126,7 +126,7 @@
     },
     "packages/react": {
       "name": "@stll/folio-react",
-      "version": "0.4.0",
+      "version": "0.3.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",
         "@fontsource/arimo": "^5.2.8",
@@ -158,7 +158,7 @@
     },
     "packages/vue": {
       "name": "@stll/folio-vue",
-      "version": "0.3.0",
+      "version": "0.2.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
         "better-result": "2.9.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stll/folio-monorepo",
   "version": "0.1.0",
   "private": true,
-  "description": "folio monorepo: @stll/folio-core (headless .docx engine) + @stll/folio-react (React editor).",
+  "description": "folio monorepo: framework-neutral DOCX engine, React/Vue editors, Nuxt module, and agent tooling.",
   "homepage": "https://github.com/stella/folio",
   "bugs": {
     "url": "https://github.com/stella/folio/issues"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,8 +12,8 @@ changes, and footnotes.
 
 There is **no React** in the import graph, so the core runs on a server or under
 any framework. The React editor lives in
-[`@stll/folio-react`](https://www.npmjs.com/package/@stll/folio-react); a Vue or
-Tauri adapter could build on this same core.
+[`@stll/folio-react`](https://www.npmjs.com/package/@stll/folio-react), and the
+Vue editor lives in [`@stll/folio-vue`](https://www.npmjs.com/package/@stll/folio-vue).
 
 Part of [stella](https://github.com/stella/stella), an open-source legal workspace.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -48,7 +48,7 @@ layout engine, DOCX ↔ Markdown), depend on `@stll/folio-core` directly.
 
 ## Peer dependencies
 
-`react` ^19 · `react-dom` ^19 · `use-intl` >=4
+`react` ^18 or ^19 · `react-dom` ^18 or ^19 · `use-intl` >=4
 
 ## Acknowledgements
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,8 +68,8 @@
     "y-prosemirror": "^1.3.7"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "use-intl": ">=4.0.0"
   }
 }

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -19,8 +19,9 @@ import {
   useLayoutEffect,
   useMemo,
   useImperativeHandle,
+  forwardRef,
 } from "react";
-import type { CSSProperties, Ref } from "react";
+import type { CSSProperties } from "react";
 
 import {
   CheckIcon,
@@ -421,8 +422,7 @@ function areActiveTrackedChangesEqual(
 /**
  * DocxEditor - Complete DOCX editor component
  */
-export function DocxEditor({
-  ref,
+export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function DocxEditor({
   documentBuffer,
   document: initialDocument,
   documentKey,
@@ -486,7 +486,7 @@ export function DocxEditor({
   collaboration,
   featureFlags,
   onSelectiveSaveTripwire,
-}: DocxEditorProps & { ref?: Ref<DocxEditorRef> }) {
+}: DocxEditorProps, ref) {
   const t = useTranslations("folio");
 
   // Surface a failed clipboard read behind the "paste without formatting"
@@ -4091,7 +4091,7 @@ export function DocxEditor({
       </ErrorProvider>
     </FolioUIProvider>
   );
-}
+});
 
 // ============================================================================
 // EXPORTS

--- a/packages/react/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/react/src/components/HiddenHeaderFooterPMs.tsx
@@ -21,8 +21,8 @@
  * Document changes through history.
  */
 
-import { memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
-import type { CSSProperties, Ref } from "react";
+import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import type { CSSProperties } from "react";
 
 import { EditorState } from "prosemirror-state";
 import type { EditorState as EditorStateT } from "prosemirror-state";
@@ -72,7 +72,6 @@ export type HiddenHeaderFooterPMsRef = {
 };
 
 export type HiddenHeaderFooterPMsProps = {
-  ref?: Ref<HiddenHeaderFooterPMsRef>;
   /** Loaded document — its `package.headers`/`.footers` drives slot enumeration. */
   document: Document | null;
   /** Document styles, threaded into `headerFooterToProseDoc` for style resolution. */
@@ -207,7 +206,7 @@ const HOST_STYLES: CSSProperties = {
 // =============================================================================
 
 export const HiddenHeaderFooterPMs = memo(
-  ({ document, styles, theme, onTransaction, ref }: HiddenHeaderFooterPMsProps) => {
+  forwardRef<HiddenHeaderFooterPMsRef, HiddenHeaderFooterPMsProps>(function HiddenHeaderFooterPMs({ document, styles, theme, onTransaction }, ref) {
     // Stable callback ref so re-renders don't recreate every EditorView.
     const onTransactionRef = useRef(onTransaction);
     onTransactionRef.current = onTransaction;
@@ -365,7 +364,7 @@ export const HiddenHeaderFooterPMs = memo(
     );
 
     return <div ref={hostRef} style={HOST_STYLES} />;
-  },
+  }),
 );
 
 HiddenHeaderFooterPMs.displayName = "HiddenHeaderFooterPMs";

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -19,8 +19,8 @@
  * methods now delegate to the active HF PM via `getActiveView`.
  */
 
-import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
-import type { CSSProperties, Ref } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 
 import { redo, undo } from "prosemirror-history";
 import type { EditorView } from "prosemirror-view";
@@ -100,17 +100,14 @@ const labelStyle: CSSProperties = {
 // COMPONENT
 // ============================================================================
 
-export function InlineHeaderFooterEditor({
-  ref,
+export const InlineHeaderFooterEditor = forwardRef<InlineHeaderFooterEditorRef, InlineHeaderFooterEditorProps>(function InlineHeaderFooterEditor({
   position,
   targetElement,
   parentElement,
   getActiveView,
   onClose,
   onRemove,
-}: InlineHeaderFooterEditorProps & {
-  ref?: Ref<InlineHeaderFooterEditorRef>;
-}) {
+}: InlineHeaderFooterEditorProps, ref) {
   const [showOptions, setShowOptions] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
 
@@ -294,7 +291,7 @@ export function InlineHeaderFooterEditor({
       )}
     </div>
   );
-}
+});
 
 // ============================================================================
 // OPTIONS MENU SUB-COMPONENT

--- a/packages/react/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/react/src/paged-editor/HiddenProseMirror.tsx
@@ -22,8 +22,9 @@ import {
   useCallback,
   useImperativeHandle,
   useState,
+  forwardRef,
 } from "react";
-import type { CSSProperties, Ref } from "react";
+import type { CSSProperties } from "react";
 
 import { panic } from "better-result";
 import type { Transaction, Command, Plugin, EditorState } from "prosemirror-state";
@@ -193,11 +194,8 @@ const HIDDEN_HOST_STYLES: CSSProperties = {
 /**
  * HiddenProseMirror - Off-screen ProseMirror editor for keyboard input
  */
-export function HiddenProseMirror(
-  props: HiddenProseMirrorProps & { ref?: Ref<HiddenProseMirrorRef> },
-) {
+export const HiddenProseMirror = forwardRef<HiddenProseMirrorRef, HiddenProseMirrorProps>(function HiddenProseMirror(props, ref) {
   const {
-    ref,
     document,
     documentKey,
     styles,
@@ -431,4 +429,4 @@ export function HiddenProseMirror(
       />
     </div>
   );
-}
+});

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -22,8 +22,9 @@ import React, {
   useLayoutEffect,
   useMemo,
   useImperativeHandle,
+  forwardRef,
 } from "react";
-import type { CSSProperties, Ref } from "react";
+import type { CSSProperties } from "react";
 import { createPortal } from "react-dom";
 
 import type { Mark, Node as PMNode } from "prosemirror-model";
@@ -1634,9 +1635,8 @@ function buildFootnoteRenderItems(
 /**
  * PagedEditor - Main paginated editing component.
  */
-export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef> }) {
+export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(function PagedEditor(props, ref) {
   const {
-    ref,
     document,
     documentKey,
     fonts: hostFonts,
@@ -6149,4 +6149,4 @@ export function PagedEditor(props: PagedEditorProps & { ref?: Ref<PagedEditorRef
       {sidebarOverlay}
     </div>
   );
-}
+});

--- a/scripts/packaged-consumer-build.ts
+++ b/scripts/packaged-consumer-build.ts
@@ -29,10 +29,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  REACT_PEER_MAJORS,
   buildAndPack,
   consumerSrc,
   coreDir,
+  reactPeerInstallArgs,
   reactDir,
+  type ReactPeerMajor,
   writeConsumerPackageJson,
 } from "./packaged-consumer-lib";
 
@@ -41,51 +44,69 @@ import {
 // be skipped — the exact leak this structure exists to prevent. Any thrown
 // error still propagates (Bun exits non-zero on it) after cleanup runs.
 let failure: string | null = null;
-let workerChunk: string | undefined;
+const workerChunks: string[] = [];
 
 let corePackDir = "";
 let reactPackDir = "";
-let consumerDir = "";
+const consumerDirs: string[] = [];
 try {
   corePackDir = await mkdtemp(path.join(tmpdir(), "folio-core-pack-"));
   reactPackDir = await mkdtemp(path.join(tmpdir(), "folio-react-pack-"));
-  consumerDir = await mkdtemp(path.join(tmpdir(), "folio-packaged-consumer-"));
 
   const coreTarball = await buildAndPack(coreDir, corePackDir);
   const reactTarball = await buildAndPack(reactDir, reactPackDir);
 
-  // Copy the checked-in consumer app out of the monorepo so no workspace
-  // linkage leaks in; install the packed artifacts npm-style.
-  console.log(`→ staging consumer in ${consumerDir}`);
-  await cp(path.join(consumerSrc, "src"), path.join(consumerDir, "src"), { recursive: true });
-  await cp(path.join(consumerSrc, "vite.config.ts"), path.join(consumerDir, "vite.config.ts"));
+  const runBuild = async (reactMajor: ReactPeerMajor): Promise<void> => {
+    const consumerDir = await mkdtemp(
+      path.join(tmpdir(), `folio-packaged-consumer-r${reactMajor}-`),
+    );
+    consumerDirs.push(consumerDir);
 
-  await writeConsumerPackageJson(consumerDir, coreTarball);
+    // Copy the checked-in consumer app out of the monorepo so no workspace
+    // linkage leaks in; install the packed artifacts npm-style.
+    console.log(`→ staging React ${reactMajor} consumer in ${consumerDir}`);
+    await cp(path.join(consumerSrc, "src"), path.join(consumerDir, "src"), { recursive: true });
+    await cp(path.join(consumerSrc, "vite.config.ts"), path.join(consumerDir, "vite.config.ts"));
 
-  console.log("→ installing tarballs + peers");
-  await $`bun add ${reactTarball} ${coreTarball} react@^19 react-dom@^19 use-intl@^4 vite@^8 @types/react@^19 @types/react-dom@^19`
-    .cwd(consumerDir)
-    .quiet();
+    await writeConsumerPackageJson(consumerDir, coreTarball);
 
-  console.log("→ production vite build over the packed tarballs");
-  const build = await $`bun x vite build`.cwd(consumerDir).nothrow();
-  if (build.exitCode === 0) {
+    console.log(`→ installing tarballs + React ${reactMajor} peers`);
+    await $`bun add ${reactTarball} ${coreTarball} ${reactPeerInstallArgs(reactMajor)} use-intl@^4 vite@^8`
+      .cwd(consumerDir)
+      .quiet();
+
+    console.log(`→ production vite build over the packed tarballs (React ${reactMajor})`);
+    const build = await $`bun x vite build`.cwd(consumerDir).nothrow();
+    if (build.exitCode !== 0) {
+      console.error(build.stderr.toString() || build.stdout.toString());
+      failure = `\n✗ packaged-consumer: React ${reactMajor} production vite build FAILED against the packed tarballs.`;
+      return;
+    }
+
     // The worker must have resolved and emitted its own chunk; otherwise the
     // URL target silently vanished (e.g. externalized away) and the gate would
     // be moot.
     const distFiles = await readdir(path.join(consumerDir, "dist"), { recursive: true });
-    workerChunk = distFiles.find((f) => f.includes("font-metrics.worker") && f.endsWith(".js"));
+    const workerChunk = distFiles.find(
+      (f) => f.includes("font-metrics.worker") && f.endsWith(".js"),
+    );
     if (!workerChunk) {
-      failure = `✗ packaged-consumer: build produced no worker chunk. dist: ${distFiles.join(", ")}`;
+      failure = `✗ packaged-consumer: React ${reactMajor} build produced no worker chunk. dist: ${distFiles.join(", ")}`;
+      return;
     }
-  } else {
-    console.error(build.stderr.toString() || build.stdout.toString());
-    failure = "\n✗ packaged-consumer: production vite build FAILED against the packed tarballs.";
+    workerChunks.push(`React ${reactMajor}: ${workerChunk}`);
+  };
+
+  for (const reactMajor of REACT_PEER_MAJORS) {
+    await runBuild(reactMajor);
+    if (failure !== null) {
+      break;
+    }
   }
 } finally {
   // `rm` with `force` tolerates a dir that was never created (empty string is
   // guarded); cleanup runs on success, on failure, and on a thrown step.
-  for (const dir of [corePackDir, reactPackDir, consumerDir]) {
+  for (const dir of [corePackDir, reactPackDir, ...consumerDirs]) {
     if (dir !== "") {
       await rm(dir, { recursive: true, force: true });
     }
@@ -98,5 +119,5 @@ if (failure !== null) {
 }
 
 console.log(
-  `\n✓ packaged-consumer: production vite build succeeded; worker chunk emitted (${workerChunk}).`,
+  `\n✓ packaged-consumer: production vite build succeeded for React 18 and 19; worker chunks emitted (${workerChunks.join(", ")}).`,
 );

--- a/scripts/packaged-consumer-lib.ts
+++ b/scripts/packaged-consumer-lib.ts
@@ -23,6 +23,16 @@ export const coreDir = path.join(repoRoot, "packages", "core");
 export const reactDir = path.join(repoRoot, "packages", "react");
 export const consumerSrc = path.join(repoRoot, "test", "packaged-consumer");
 
+export const REACT_PEER_MAJORS = ["18", "19"] as const;
+export type ReactPeerMajor = (typeof REACT_PEER_MAJORS)[number];
+
+export const reactPeerInstallArgs = (major: ReactPeerMajor): string[] => [
+  `react@^${major}`,
+  `react-dom@^${major}`,
+  `@types/react@^${major}`,
+  `@types/react-dom@^${major}`,
+];
+
 // Build a package, transform its package.json to the published dist shape
 // (reversibly), pack a tarball into destDir, and return the tarball path.
 export const buildAndPack = async (pkgDir: string, destDir: string): Promise<string> => {

--- a/scripts/packaged-consumer-smoke.ts
+++ b/scripts/packaged-consumer-smoke.ts
@@ -22,16 +22,20 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  REACT_PEER_MAJORS,
   buildAndPack,
   consumerSrc,
   coreDir,
+  reactPeerInstallArgs,
   reactDir,
   repoRoot,
+  type ReactPeerMajor,
   writeConsumerPackageJson,
 } from "./packaged-consumer-lib";
 
-const PREVIEW_PORT = 4300;
-const PREVIEW_URL = `http://localhost:${PREVIEW_PORT}`;
+const previewPortForReactMajor = (reactMajor: ReactPeerMajor): number => 4300 + Number(reactMajor);
+const previewUrlForReactMajor = (reactMajor: ReactPeerMajor): string =>
+  `http://localhost:${previewPortForReactMajor(reactMajor)}`;
 
 // Poll the preview server until it answers or the deadline passes.
 const waitForServer = async (url: string, timeoutMs: number): Promise<boolean> => {
@@ -69,95 +73,119 @@ const dumpLog = async (label: string, logPath: string): Promise<void> => {
 };
 
 let failure: string | null = null;
-let succeeded = false;
 
 let corePackDir = "";
 let reactPackDir = "";
-let consumerDir = "";
-let previewStdoutPath = "";
-let previewStderrPath = "";
-let preview: ReturnType<typeof Bun.spawn> | null = null;
+const consumerDirs: string[] = [];
 try {
   corePackDir = await mkdtemp(path.join(tmpdir(), "folio-core-pack-"));
   reactPackDir = await mkdtemp(path.join(tmpdir(), "folio-react-pack-"));
-  consumerDir = await mkdtemp(path.join(tmpdir(), "folio-packaged-consumer-smoke-"));
 
   const coreTarball = await buildAndPack(coreDir, corePackDir);
   const reactTarball = await buildAndPack(reactDir, reactPackDir);
 
-  // Stage the checked-in consumer OUT of the monorepo so no workspace linkage
-  // leaks in. The runtime build needs index.html, the runtime config, the app
-  // source, and the served fixture.
-  console.log(`→ staging runtime consumer in ${consumerDir}`);
-  await cp(path.join(consumerSrc, "src"), path.join(consumerDir, "src"), { recursive: true });
-  await cp(path.join(consumerSrc, "public"), path.join(consumerDir, "public"), { recursive: true });
-  await cp(path.join(consumerSrc, "index.html"), path.join(consumerDir, "index.html"));
-  await cp(
-    path.join(consumerSrc, "vite.runtime.config.ts"),
-    path.join(consumerDir, "vite.runtime.config.ts"),
-  );
-  await writeConsumerPackageJson(consumerDir, coreTarball);
+  const runSmoke = async (reactMajor: ReactPeerMajor): Promise<void> => {
+    let succeeded = false;
+    let previewStdoutPath = "";
+    let previewStderrPath = "";
+    let preview: ReturnType<typeof Bun.spawn> | null = null;
+    const consumerDir = await mkdtemp(
+      path.join(tmpdir(), `folio-packaged-consumer-smoke-r${reactMajor}-`),
+    );
+    consumerDirs.push(consumerDir);
+    const previewUrl = previewUrlForReactMajor(reactMajor);
+    const previewPort = previewPortForReactMajor(reactMajor);
 
-  console.log("→ installing tarballs + peers");
-  await $`bun add ${reactTarball} ${coreTarball} react@^19 react-dom@^19 use-intl@^4 vite@^8 @vitejs/plugin-react@^6 @types/react@^19 @types/react-dom@^19`
-    .cwd(consumerDir)
-    .quiet();
+    try {
+      // Stage the checked-in consumer OUT of the monorepo so no workspace linkage
+      // leaks in. The runtime build needs index.html, the runtime config, the app
+      // source, and the served fixture.
+      console.log(`→ staging React ${reactMajor} runtime consumer in ${consumerDir}`);
+      await cp(path.join(consumerSrc, "src"), path.join(consumerDir, "src"), { recursive: true });
+      await cp(path.join(consumerSrc, "public"), path.join(consumerDir, "public"), {
+        recursive: true,
+      });
+      await cp(path.join(consumerSrc, "index.html"), path.join(consumerDir, "index.html"));
+      await cp(
+        path.join(consumerSrc, "vite.runtime.config.ts"),
+        path.join(consumerDir, "vite.runtime.config.ts"),
+      );
+      await writeConsumerPackageJson(consumerDir, coreTarball);
 
-  console.log("→ production SPA build over the packed tarballs");
-  const build = await $`bun x vite build --config vite.runtime.config.ts`
-    .cwd(consumerDir)
-    .nothrow();
-  if (build.exitCode !== 0) {
-    console.error(build.stderr.toString() || build.stdout.toString());
-    throw new Error("packaged-consumer-smoke: production vite build FAILED against the tarballs.");
-  }
+      console.log(`→ installing tarballs + React ${reactMajor} peers`);
+      await $`bun add ${reactTarball} ${coreTarball} ${reactPeerInstallArgs(reactMajor)} use-intl@^4 vite@^8 @vitejs/plugin-react@^6`
+        .cwd(consumerDir)
+        .quiet();
 
-  console.log(`→ serving the built app on ${PREVIEW_URL}`);
-  // Redirect the server's stdio to files rather than piping: an unread pipe
-  // blocks the child once the OS buffer fills, and the files double as CI
-  // debugging output — they are dumped below whenever the smoke fails.
-  previewStdoutPath = path.join(consumerDir, "vite-preview.stdout.log");
-  previewStderrPath = path.join(consumerDir, "vite-preview.stderr.log");
-  preview = Bun.spawn(
-    [
-      "bun",
-      "x",
-      "vite",
-      "preview",
-      "--config",
-      "vite.runtime.config.ts",
-      "--port",
-      `${PREVIEW_PORT}`,
-    ],
-    {
-      cwd: consumerDir,
-      stdout: Bun.file(previewStdoutPath),
-      stderr: Bun.file(previewStderrPath),
-    },
-  );
-  if (!(await waitForServer(PREVIEW_URL, 30_000))) {
-    throw new Error(`packaged-consumer-smoke: preview server never came up on ${PREVIEW_URL}.`);
-  }
+      console.log(`→ production SPA build over the packed tarballs (React ${reactMajor})`);
+      const build = await $`bun x vite build --config vite.runtime.config.ts`
+        .cwd(consumerDir)
+        .nothrow();
+      if (build.exitCode !== 0) {
+        console.error(build.stderr.toString() || build.stdout.toString());
+        throw new Error(
+          `packaged-consumer-smoke: React ${reactMajor} production vite build FAILED against the tarballs.`,
+        );
+      }
 
-  console.log("→ running the runtime smoke (Playwright chromium)");
-  const smoke = await $`bun x playwright test --config playwright.smoke.config.ts`
-    .cwd(repoRoot)
-    .env({ ...process.env, PLAYWRIGHT_BASE_URL: PREVIEW_URL })
-    .nothrow();
-  if (smoke.exitCode === 0) {
-    succeeded = true;
-  } else {
-    failure = "\n✗ packaged-consumer-smoke: the runtime smoke FAILED against the served tarballs.";
+      console.log(`→ serving the React ${reactMajor} built app on ${previewUrl}`);
+      // Redirect the server's stdio to files rather than piping: an unread pipe
+      // blocks the child once the OS buffer fills, and the files double as CI
+      // debugging output; they are dumped below whenever the smoke fails.
+      previewStdoutPath = path.join(consumerDir, "vite-preview.stdout.log");
+      previewStderrPath = path.join(consumerDir, "vite-preview.stderr.log");
+      preview = Bun.spawn(
+        [
+          "bun",
+          "x",
+          "vite",
+          "preview",
+          "--config",
+          "vite.runtime.config.ts",
+          "--port",
+          `${previewPort}`,
+        ],
+        {
+          cwd: consumerDir,
+          stdout: Bun.file(previewStdoutPath),
+          stderr: Bun.file(previewStderrPath),
+        },
+      );
+      if (!(await waitForServer(previewUrl, 30_000))) {
+        throw new Error(
+          `packaged-consumer-smoke: React ${reactMajor} preview server never came up on ${previewUrl}.`,
+        );
+      }
+
+      console.log(`→ running the React ${reactMajor} runtime smoke (Playwright chromium)`);
+      const smoke = await $`bun x playwright test --config playwright.smoke.config.ts`
+        .cwd(repoRoot)
+        .env({ ...process.env, PLAYWRIGHT_BASE_URL: previewUrl })
+        .nothrow();
+      if (smoke.exitCode === 0) {
+        succeeded = true;
+        return;
+      }
+      failure = `\n✗ packaged-consumer-smoke: the React ${reactMajor} runtime smoke FAILED against the served tarballs.`;
+    } finally {
+      preview?.kill();
+      // On any failure (assertion or thrown step), surface the preview server's
+      // captured output for CI debugging before the staging dir is removed.
+      if (!succeeded) {
+        await dumpLog("vite preview stdout", previewStdoutPath);
+        await dumpLog("vite preview stderr", previewStderrPath);
+      }
+    }
+  };
+
+  for (const reactMajor of REACT_PEER_MAJORS) {
+    await runSmoke(reactMajor);
+    if (failure !== null) {
+      break;
+    }
   }
 } finally {
-  preview?.kill();
-  // On any failure (assertion or thrown step), surface the preview server's
-  // captured output for CI debugging before the staging dir is removed.
-  if (!succeeded) {
-    await dumpLog("vite preview stdout", previewStdoutPath);
-    await dumpLog("vite preview stderr", previewStderrPath);
-  }
-  for (const dir of [corePackDir, reactPackDir, consumerDir]) {
+  for (const dir of [corePackDir, reactPackDir, ...consumerDirs]) {
     if (dir !== "") {
       await rm(dir, { recursive: true, force: true });
     }
@@ -169,4 +197,6 @@ if (failure !== null) {
   process.exit(1);
 }
 
-console.log("\n✓ packaged-consumer-smoke: the served build ran clean (worker + catalog verified).");
+console.log(
+  "\n✓ packaged-consumer-smoke: React 18 and 19 served builds ran clean (worker + catalog verified).",
+);

--- a/scripts/validate-dist.ts
+++ b/scripts/validate-dist.ts
@@ -63,6 +63,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { scanDistUrlTargets } from "./dist-url-targets";
+import {
+  REACT_PEER_MAJORS,
+  reactPeerInstallArgs,
+  type ReactPeerMajor,
+} from "./packaged-consumer-lib";
 import { findUncoveredUtilities } from "./standalone-css-coverage";
 
 const repoRoot = path.resolve(import.meta.dir, "..");
@@ -159,14 +164,7 @@ await writeFile(
 const installArgs: string[] = [tarball];
 if (target === "react") {
   if (!coreTarball) panic("validate-dist: react needs a @stll/folio-core tarball");
-  installArgs.push(
-    coreTarball,
-    "react@^19",
-    "react-dom@^19",
-    "use-intl@^4",
-    "@types/react@^19",
-    "@types/react-dom@^19",
-  );
+  installArgs.push(coreTarball, ...reactPeerInstallArgs("19"), "use-intl@^4");
 }
 if (target === "agents") {
   if (!coreTarball) panic("validate-dist: agents needs a @stll/folio-core tarball");
@@ -343,32 +341,42 @@ const typeCheckModes =
   target === "vue"
     ? Object.entries(tsconfigs).filter(([mode]) => mode === "bundler")
     : Object.entries(tsconfigs);
-const typeChecks = await Promise.all(
-  typeCheckModes.map(async ([mode, opts]) => {
-    const file = path.join(consumerDir, `tsconfig.${mode}.json`);
-    await writeFile(
-      file,
-      `${JSON.stringify(
-        {
-          compilerOptions: { ...baseCompilerOptions, ...opts },
-          files: ["consumer.ts"],
-        },
-        null,
-        2,
-      )}\n`,
-    );
-    const tc = await $`${tscBin} -p ${file}`.cwd(consumerDir).nothrow().quiet();
-    return { mode, tc };
-  }),
-);
-for (const { mode, tc } of typeChecks) {
-  record(
-    `types: tsc --noEmit (moduleResolution: ${mode})`,
-    tc.exitCode === 0,
-    tc.exitCode === 0
-      ? "consumer typechecks against published .d.ts"
-      : `${tc.stdout.toString().trim()}${tc.stderr.toString().trim()}`.slice(0, 400),
+const typeCheckReactMajors: (ReactPeerMajor | null)[] =
+  target === "react" ? [...REACT_PEER_MAJORS] : [null];
+for (const reactMajor of typeCheckReactMajors) {
+  if (reactMajor !== null) {
+    await $`bun add ${reactPeerInstallArgs(reactMajor)}`.cwd(consumerDir).quiet();
+  }
+
+  const typeChecks = await Promise.all(
+    typeCheckModes.map(async ([mode, opts]) => {
+      const reactSuffix = reactMajor === null ? "" : `.react-${reactMajor}`;
+      const file = path.join(consumerDir, `tsconfig.${mode}${reactSuffix}.json`);
+      await writeFile(
+        file,
+        `${JSON.stringify(
+          {
+            compilerOptions: { ...baseCompilerOptions, ...opts },
+            files: ["consumer.ts"],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      const tc = await $`${tscBin} -p ${file}`.cwd(consumerDir).nothrow().quiet();
+      return { mode, tc };
+    }),
   );
+  for (const { mode, tc } of typeChecks) {
+    const reactLabel = reactMajor === null ? "" : `, React ${reactMajor} types`;
+    record(
+      `types: tsc --noEmit (moduleResolution: ${mode}${reactLabel})`,
+      tc.exitCode === 0,
+      tc.exitCode === 0
+        ? "consumer typechecks against published .d.ts"
+        : `${tc.stdout.toString().trim()}${tc.stderr.toString().trim()}`.slice(0, 400),
+    );
+  }
 }
 
 // --- Check 3 (react only): bundled stylesheet -------------------------------


### PR DESCRIPTION
## Summary
- refresh README/package descriptions to describe folio as a framework-neutral DOCX engine with React/Vue editors, Nuxt integration, and agent tooling
- widen @stll/folio-react peer support to React 18 and React 19
- switch ref-bearing React components to forwardRef so refs work in React 18 consumers
- run packaged-consumer build, runtime smoke, and dist type validation against both React 18 and React 19
- make Playwright browser installation resilient to stale Microsoft apt sources on GitHub runners
- update the React API report snapshot for the public forwardRef type

## Validation
- bun install --frozen-lockfile
- bun --filter '@stll/folio-react' typecheck
- bun --bun oxlint -c oxlint.config.ts packages/react/src/components/DocxEditor.tsx packages/react/src/components/HiddenHeaderFooterPMs.tsx packages/react/src/components/InlineHeaderFooterEditor.tsx packages/react/src/paged-editor/HiddenProseMirror.tsx packages/react/src/paged-editor/PagedEditor.tsx scripts/packaged-consumer-lib.ts scripts/packaged-consumer-build.ts scripts/packaged-consumer-smoke.ts scripts/validate-dist.ts
- bun run changeset:check
- bun audit
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- bun run test:interactions
- bun run test:packaged-consumer
- bun run test:packaged-consumer-smoke
- bun run validate-dist:react
- bun run api:check