### PR TITLE
feat: add reMarkable cloud connector plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,14 +35,14 @@
     },
     "packages/agents": {
       "name": "@stll/folio-agents",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
       },
     },
     "packages/core": {
       "name": "@stll/folio-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@stll/docx-core": "^0.1.0",
         "@stll/docx-utils": "^0.1.0",
@@ -70,7 +70,7 @@
     },
     "packages/nuxt": {
       "name": "@stll/folio-nuxt",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
         "@stll/folio-vue": "workspace:^",
@@ -126,7 +126,7 @@
     },
     "packages/react": {
       "name": "@stll/folio-react",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",
         "@fontsource/arimo": "^5.2.8",
@@ -158,7 +158,7 @@
     },
     "packages/vue": {
       "name": "@stll/folio-vue",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
         "better-result": "2.9.2",
@@ -181,6 +181,14 @@
         "prosemirror-tables": "^1.8.5",
         "prosemirror-view": "^1.41.6",
         "vue": "^3.3.0",
+      },
+    },
+    "plugins/connector": {
+      "name": "@stll/folio-connector-remarkable",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-result": "2.9.2",
+        "rmapi-js": "^11.0.0",
       },
     },
   },
@@ -836,6 +844,8 @@
     "@stll/docx-utils": ["@stll/docx-utils@0.1.0", "", { "dependencies": { "jszip": "3.10.1" } }, "sha512-WUvo0qD8VQa2Ojl4cYSEZCXKTVMqJ9bB+SSx3muo/uHTYSicC3wcwQZd4iZsiRpa2diPC8Sn1O72q7PRhL3K+A=="],
 
     "@stll/folio-agents": ["@stll/folio-agents@workspace:packages/agents"],
+
+    "@stll/folio-connector-remarkable": ["@stll/folio-connector-remarkable@workspace:plugins/connector"],
 
     "@stll/folio-core": ["@stll/folio-core@workspace:packages/core"],
 
@@ -1845,6 +1855,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rmapi-js": ["rmapi-js@11.0.0", "", { "dependencies": { "crc-32": "^1.2.2", "jszip": "^3.10.1", "uuid": "^14.0.0", "zod": "^3.25.76" } }, "sha512-7UXX1vKC/ul40V6xBfPAMOIXhYwWpiA161I//dvyoQo7HvMQCXGfm4DGNGFIfP89z6edeMZVOtb7VMvckGUlBg=="],
+
     "rolldown": ["rolldown@1.1.3", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.3", "@rolldown/binding-darwin-arm64": "1.1.3", "@rolldown/binding-darwin-x64": "1.1.3", "@rolldown/binding-freebsd-x64": "1.1.3", "@rolldown/binding-linux-arm-gnueabihf": "1.1.3", "@rolldown/binding-linux-arm64-gnu": "1.1.3", "@rolldown/binding-linux-arm64-musl": "1.1.3", "@rolldown/binding-linux-ppc64-gnu": "1.1.3", "@rolldown/binding-linux-s390x-gnu": "1.1.3", "@rolldown/binding-linux-x64-gnu": "1.1.3", "@rolldown/binding-linux-x64-musl": "1.1.3", "@rolldown/binding-openharmony-arm64": "1.1.3", "@rolldown/binding-wasm32-wasi": "1.1.3", "@rolldown/binding-win32-arm64-msvc": "1.1.3", "@rolldown/binding-win32-x64-msvc": "1.1.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.26.0", "", { "dependencies": { "@babel/generator": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0", "@babel/parser": "^8.0.0", "ast-kit": "^3.0.0", "birpc": "^4.0.0", "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q=="],
@@ -2069,6 +2081,8 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
     "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
@@ -2150,6 +2164,8 @@
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/stella/folio.git"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "plugins/*"
   ],
   "type": "module",
   "scripts": {
@@ -31,8 +32,8 @@
     "test:property": "bun --filter '*' test:property",
     "typegen": "bun scripts/i18n-typegen.ts packages/core/src/i18n/messages",
     "check:i18n": "bun scripts/i18n-typegen.ts packages/core/src/i18n/messages --check && bun scripts/i18n-check.ts packages/core/src/i18n/messages",
-    "lint": "bun --bun oxlint -c oxlint.config.ts packages scripts test benchmarks parity",
-    "lint:fix": "bun --bun oxlint -c oxlint.config.ts --fix packages scripts test benchmarks parity",
+    "lint": "bun --bun oxlint -c oxlint.config.ts packages plugins scripts test benchmarks parity",
+    "lint:fix": "bun --bun oxlint -c oxlint.config.ts --fix packages plugins scripts test benchmarks parity",
     "format": "oxfmt .",
     "sync-ai": "bash scripts/sync-ai-skills.sh",
     "test:packaged-consumer": "bun scripts/packaged-consumer-build.ts",

--- a/plugins/connector/README.md
+++ b/plugins/connector/README.md
@@ -1,0 +1,82 @@
+# @stll/folio-connector-remarkable
+
+reMarkable cloud connector for folio. List, upload, download, move, rename, and
+delete documents on a reMarkable tablet through the cloud API.
+
+reMarkable accepts PDF and EPUB uploads. folio edits `.docx`; convert to PDF in
+your host app before pushing if you want tablet markup on a Word document.
+
+## Install
+
+```sh
+bun add @stll/folio-connector-remarkable
+```
+
+## Authentication
+
+1. Open https://my.remarkable.com/device/browser/connect and copy the one-time
+   code.
+2. Exchange it for a long-lived device token and persist it.
+
+```ts
+import { registerRemarkableDevice } from "@stll/folio-connector-remarkable";
+
+const deviceToken = await registerRemarkableDevice("abcd1234");
+// store deviceToken securely
+```
+
+For serverless or worker pools, cache a short-lived session token:
+
+```ts
+import {
+  authRemarkableSession,
+  createRemarkableConnectorFromAuth,
+} from "@stll/folio-connector-remarkable";
+
+const sessionToken = await authRemarkableSession(deviceToken);
+const connector = await createRemarkableConnectorFromAuth({ sessionToken });
+```
+
+## Usage
+
+```ts
+import { createRemarkableConnectorFromAuth } from "@stll/folio-connector-remarkable";
+
+const connector = await createRemarkableConnectorFromAuth({ deviceToken });
+
+const library = await connector.listItems();
+const matters = await connector.listItems({ parentId: "folder-uuid" });
+
+const uploaded = await connector.uploadDocument({
+  name: "Settlement.pdf",
+  bytes: pdfBytes,
+  mimeType: "application/pdf",
+  parentId: "folder-uuid",
+});
+
+const originalPdf = await connector.downloadDocument(uploaded);
+```
+
+## Connector contract
+
+`FolioCloudConnector` is provider-neutral. The reMarkable implementation sets
+`providerId` to `"remarkable"` and exposes the underlying `rmapi-js` client as
+`connector.api` when you need provider-specific escape hatches.
+
+## Limitations
+
+- Notebook (`.rm`) downloads are not supported; export from the tablet as PDF
+  first.
+- Downloaded PDFs are the original uploads, not annotated exports with ink.
+- The cloud API is reverse-engineered; upstream changes may require connector
+  updates.
+
+## Development
+
+```sh
+bun --filter @stll/folio-connector-remarkable test
+bun --filter @stll/folio-connector-remarkable typecheck
+```
+
+Live cloud tests are intentionally omitted. Run manual smoke tests with your own
+device token when validating against production.

--- a/plugins/connector/package.json
+++ b/plugins/connector/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@stll/folio-connector-remarkable",
+  "version": "0.1.0",
+  "description": "reMarkable cloud connector for folio: list, upload, download, and organize documents on a reMarkable tablet via the cloud API.",
+  "keywords": [
+    "connector",
+    "docx",
+    "e-ink",
+    "folio",
+    "remarkable",
+    "sync",
+    "tablet"
+  ],
+  "homepage": "https://github.com/stella/folio",
+  "bugs": {
+    "url": "https://github.com/stella/folio/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "STLL",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/folio.git",
+    "directory": "plugins/connector"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsdown",
+    "prepack": "bun run build",
+    "pack:dry-run": "bun pm pack --dry-run",
+    "typecheck": "tsgo --noEmit -p tsconfig.build.json",
+    "test": "bun test src"
+  },
+  "dependencies": {
+    "better-result": "2.9.2",
+    "rmapi-js": "^11.0.0"
+  }
+}

--- a/plugins/connector/src/errors.ts
+++ b/plugins/connector/src/errors.ts
@@ -1,0 +1,16 @@
+import { TaggedError } from "better-result";
+
+export class RemarkableConnectorConfigError extends TaggedError("RemarkableConnectorConfigError")<{
+  message: string;
+}>() {}
+
+export class RemarkableConnectorDownloadError extends TaggedError("RemarkableConnectorDownloadError")<{
+  message: string;
+  itemId: string;
+  documentFormat?: string;
+}>() {}
+
+export class RemarkableConnectorUploadError extends TaggedError("RemarkableConnectorUploadError")<{
+  message: string;
+  mimeType: string;
+}>() {}

--- a/plugins/connector/src/index.ts
+++ b/plugins/connector/src/index.ts
@@ -1,0 +1,32 @@
+export {
+  authRemarkableSession,
+  createRemarkableConnector,
+  createRemarkableConnectorFromAuth,
+  registerRemarkableDevice,
+} from "./remarkable/auth";
+export type {
+  CreateRemarkableConnectorOptions,
+  RegisterRemarkableDeviceOptions,
+  RemarkableConnector,
+} from "./remarkable/auth";
+export { mapRemarkableEntry, REMARKABLE_CONNECTOR_PROVIDER_ID } from "./remarkable/connector";
+export {
+  RemarkableConnectorConfigError,
+  RemarkableConnectorDownloadError,
+  RemarkableConnectorUploadError,
+} from "./errors";
+export {
+  FOLIO_CONNECTOR_ROOT_ID,
+  FOLIO_CONNECTOR_TRASH_ID,
+} from "./types";
+export type {
+  FolioCloudConnector,
+  FolioConnectorCreateFolderOptions,
+  FolioConnectorDocumentFormat,
+  FolioConnectorItem,
+  FolioConnectorItemKind,
+  FolioConnectorListOptions,
+  FolioConnectorParentId,
+  FolioConnectorUploadMimeType,
+  FolioConnectorUploadOptions,
+} from "./types";

--- a/plugins/connector/src/remarkable/auth.test.ts
+++ b/plugins/connector/src/remarkable/auth.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { remarkable } from "rmapi-js";
+
+import {
+  authRemarkableSession,
+  createRemarkableConnectorFromAuth,
+} from "./auth";
+import { RemarkableConnectorConfigError } from "../errors";
+
+describe("createRemarkableConnectorFromAuth", () => {
+  test("requires deviceToken or sessionToken", async () => {
+    await expect(createRemarkableConnectorFromAuth({})).rejects.toBeInstanceOf(
+      RemarkableConnectorConfigError,
+    );
+  });
+
+  test("builds a connector from a session token without network I/O", async () => {
+    const connector = await createRemarkableConnectorFromAuth({
+      sessionToken: "cached-session-token",
+    });
+
+    expect(connector.providerId).toBe("remarkable");
+    expect(typeof connector.api.listItems).toBe("function");
+    expect(typeof connector.api.uploadPdf).toBe("function");
+  });
+
+  test("exports auth helpers that delegate to rmapi-js", () => {
+    expect(authRemarkableSession).toBeDefined();
+    expect(remarkable).toBeDefined();
+  });
+});

--- a/plugins/connector/src/remarkable/auth.ts
+++ b/plugins/connector/src/remarkable/auth.ts
@@ -1,0 +1,56 @@
+import { auth, register, remarkable, session } from "rmapi-js";
+import type { RegisterOptions, RemarkableApi } from "rmapi-js";
+
+import { RemarkableConnectorConfigError } from "../errors";
+import {
+  createRemarkableConnector,
+  type RemarkableConnector,
+} from "./connector";
+
+export type RegisterRemarkableDeviceOptions = RegisterOptions;
+
+/**
+ * Exchange the one-time code from
+ * https://my.remarkable.com/device/browser/connect for a long-lived device
+ * token. Persist the token; it does not expire.
+ */
+export const registerRemarkableDevice = (
+  oneTimeCode: string,
+  options?: RegisterRemarkableDeviceOptions,
+) => register(oneTimeCode, options);
+
+/**
+ * Exchange a device token for a short-lived session token. Cache and reuse the
+ * session token across workers or serverless invocations.
+ */
+export const authRemarkableSession = (deviceToken: string) => auth(deviceToken);
+
+export type CreateRemarkableConnectorOptions = {
+  /** Long-lived device token from {@link registerRemarkableDevice}. */
+  deviceToken?: string;
+  /** Short-lived session token from {@link authRemarkableSession}. */
+  sessionToken?: string;
+};
+
+const resolveRemarkableApi = async (
+  options: CreateRemarkableConnectorOptions,
+): Promise<RemarkableApi> => {
+  if (options.sessionToken) {
+    return session(options.sessionToken);
+  }
+  if (options.deviceToken) {
+    return await remarkable(options.deviceToken);
+  }
+  throw new RemarkableConnectorConfigError({
+    message:
+      "Provide either deviceToken or sessionToken when creating a reMarkable connector",
+  });
+};
+
+/** Build a {@link RemarkableConnector} from persisted auth credentials. */
+export const createRemarkableConnectorFromAuth = async (
+  options: CreateRemarkableConnectorOptions,
+): Promise<RemarkableConnector> => createRemarkableConnector(await resolveRemarkableApi(options));
+
+export { createRemarkableConnector } from "./connector";
+export type { RemarkableConnector } from "./connector";

--- a/plugins/connector/src/remarkable/connector.test.ts
+++ b/plugins/connector/src/remarkable/connector.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import type { Entry, RemarkableApi } from "rmapi-js";
+
+import { createRemarkableConnector, mapRemarkableEntry } from "./connector";
+import { FOLIO_CONNECTOR_ROOT_ID } from "../types";
+
+const samplePdf: Entry = {
+  id: "doc-1",
+  hash: "hash-doc-1",
+  visibleName: "Contract.pdf",
+  lastModified: "2026-07-01T12:00:00.000Z",
+  pinned: false,
+  parent: "",
+  type: "DocumentType",
+  fileType: "pdf",
+  lastOpened: "2026-07-01T12:00:00.000Z",
+};
+
+const sampleFolder: Entry = {
+  id: "folder-1",
+  hash: "hash-folder-1",
+  visibleName: "Matters",
+  lastModified: "2026-06-30T08:00:00.000Z",
+  pinned: true,
+  parent: "",
+  type: "CollectionType",
+};
+
+const createMockApi = (overrides: Partial<RemarkableApi> = {}): RemarkableApi =>
+  ({
+    listItems: async () => [sampleFolder, samplePdf],
+    uploadPdf: async () => ({ id: "doc-2", hash: "hash-doc-2" }),
+    uploadEpub: async () => ({ id: "doc-3", hash: "hash-doc-3" }),
+    uploadFolder: async () => ({ id: "folder-2", hash: "hash-folder-2" }),
+    putFolder: async () => ({ id: "folder-3", hash: "hash-folder-3" }),
+    move: async () => ({ hash: "hash-moved" }),
+    rename: async () => ({ hash: "hash-renamed" }),
+    delete: async () => ({ hash: "hash-deleted" }),
+    stared: async () => ({ hash: "hash-starred" }),
+    getPdf: async () => new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+    getEpub: async () => new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    ...overrides,
+  }) as RemarkableApi;
+
+describe("mapRemarkableEntry", () => {
+  test("maps folders and documents into connector items", () => {
+    expect(mapRemarkableEntry(sampleFolder)).toEqual({
+      id: "folder-1",
+      hash: "hash-folder-1",
+      name: "Matters",
+      parentId: FOLIO_CONNECTOR_ROOT_ID,
+      kind: "folder",
+      modifiedAt: "2026-06-30T08:00:00.000Z",
+      starred: true,
+    });
+
+    expect(mapRemarkableEntry(samplePdf)).toEqual({
+      id: "doc-1",
+      hash: "hash-doc-1",
+      name: "Contract.pdf",
+      parentId: FOLIO_CONNECTOR_ROOT_ID,
+      kind: "document",
+      modifiedAt: "2026-07-01T12:00:00.000Z",
+      starred: false,
+      documentFormat: "pdf",
+    });
+  });
+});
+
+describe("createRemarkableConnector", () => {
+  test("filters listItems by parentId", async () => {
+    const nestedPdf: Entry = {
+      ...samplePdf,
+      id: "doc-nested",
+      hash: "hash-doc-nested",
+      parent: "folder-1",
+    };
+    const connector = createRemarkableConnector(
+      createMockApi({
+        listItems: async () => [sampleFolder, nestedPdf],
+      }),
+    );
+
+    const rootItems = await connector.listItems();
+    expect(rootItems).toHaveLength(2);
+
+    const folderChildren = await connector.listItems({ parentId: "folder-1" });
+    expect(folderChildren).toHaveLength(1);
+    expect(folderChildren[0]?.id).toBe("doc-nested");
+  });
+
+  test("uploads PDFs and moves them into the target folder", async () => {
+    const moveCalls: Array<{ hash: string; parent: string }> = [];
+    const connector = createRemarkableConnector(
+      createMockApi({
+        move: async (hash, parent) => {
+          moveCalls.push({ hash, parent });
+          return { hash: "hash-moved" };
+        },
+      }),
+    );
+
+    const uploaded = await connector.uploadDocument({
+      name: "Brief.pdf",
+      bytes: new Uint8Array([1, 2, 3]),
+      mimeType: "application/pdf",
+      parentId: "folder-1",
+    });
+
+    expect(uploaded).toMatchObject({
+      id: "doc-2",
+      hash: "hash-moved",
+      name: "Brief.pdf",
+      parentId: "folder-1",
+      kind: "document",
+      documentFormat: "pdf",
+    });
+    expect(moveCalls).toEqual([{ hash: "hash-doc-2", parent: "folder-1" }]);
+  });
+
+  test("downloads PDF bytes for pdf documents", async () => {
+    const connector = createRemarkableConnector(createMockApi());
+    const bytes = await connector.downloadDocument({
+      id: "doc-1",
+      hash: "hash-doc-1",
+      name: "Contract.pdf",
+      parentId: FOLIO_CONNECTOR_ROOT_ID,
+      kind: "document",
+      modifiedAt: "2026-07-01T12:00:00.000Z",
+      starred: false,
+      documentFormat: "pdf",
+    });
+
+    expect(bytes).toEqual(new Uint8Array([0x25, 0x50, 0x44, 0x46]));
+  });
+});

--- a/plugins/connector/src/remarkable/connector.ts
+++ b/plugins/connector/src/remarkable/connector.ts
@@ -1,0 +1,186 @@
+import type { Entry, RemarkableApi, SimpleEntry } from "rmapi-js";
+
+import {
+  FOLIO_CONNECTOR_ROOT_ID,
+  type FolioConnectorDocumentFormat,
+  type FolioConnectorItem,
+  type FolioConnectorItemKind,
+  type FolioConnectorParentId,
+  type FolioConnectorUploadMimeType,
+  type FolioCloudConnector,
+} from "../types";
+import {
+  RemarkableConnectorDownloadError,
+  RemarkableConnectorUploadError,
+} from "../errors";
+
+export const REMARKABLE_CONNECTOR_PROVIDER_ID = "remarkable" as const;
+
+export type RemarkableConnector = FolioCloudConnector & {
+  readonly providerId: typeof REMARKABLE_CONNECTOR_PROVIDER_ID;
+  /** Escape hatch to the underlying rmapi-js client. */
+  readonly api: RemarkableApi;
+};
+
+const toParentId = (parent: string | undefined): FolioConnectorParentId =>
+  parent === undefined || parent === "" ? FOLIO_CONNECTOR_ROOT_ID : parent;
+
+const mapEntryKind = (entry: Entry): FolioConnectorItemKind => {
+  if (entry.type === "CollectionType") {
+    return "folder";
+  }
+  if (entry.type === "TemplateType") {
+    return "template";
+  }
+  return "document";
+};
+
+export const mapRemarkableEntry = (entry: Entry): FolioConnectorItem => {
+  const kind = mapEntryKind(entry);
+  const documentFormat =
+    entry.type === "DocumentType" ? entry.fileType : undefined;
+
+  return {
+    id: entry.id,
+    hash: entry.hash,
+    name: entry.visibleName,
+    parentId: toParentId(entry.parent),
+    kind,
+    modifiedAt: entry.lastModified,
+    starred: entry.pinned,
+    ...(documentFormat ? { documentFormat } : {}),
+  };
+};
+
+const mapSimpleEntry = (
+  entry: SimpleEntry,
+  fallback: Pick<FolioConnectorItem, "name" | "parentId" | "kind" | "documentFormat">,
+): FolioConnectorItem => ({
+  id: entry.id,
+  hash: entry.hash,
+  name: fallback.name,
+  parentId: fallback.parentId,
+  kind: fallback.kind,
+  modifiedAt: new Date().toISOString(),
+  starred: false,
+  ...(fallback.documentFormat ? { documentFormat: fallback.documentFormat } : {}),
+});
+
+const refreshItemHash = (
+  item: FolioConnectorItem,
+  nextHash: string,
+): FolioConnectorItem => ({
+  ...item,
+  hash: nextHash,
+});
+
+const uploadMimeToDocumentFormat = (
+  mimeType: FolioConnectorUploadMimeType,
+): FolioConnectorDocumentFormat => {
+  if (mimeType === "application/pdf") {
+    return "pdf";
+  }
+  return "epub";
+};
+
+export const createRemarkableConnector = (api: RemarkableApi): RemarkableConnector => ({
+  providerId: REMARKABLE_CONNECTOR_PROVIDER_ID,
+  api,
+
+  async listItems(options = {}) {
+    const entries = await api.listItems(options.refresh);
+    const mapped = entries.map(mapRemarkableEntry);
+    if (options.parentId === undefined) {
+      return mapped;
+    }
+    return mapped.filter((item) => item.parentId === options.parentId);
+  },
+
+  async uploadDocument({ name, bytes, mimeType, parentId = FOLIO_CONNECTOR_ROOT_ID }) {
+    const documentFormat = uploadMimeToDocumentFormat(mimeType);
+    let entry;
+    if (mimeType === "application/pdf") {
+      entry = await api.uploadPdf(name, bytes);
+    } else if (mimeType === "application/epub+zip") {
+      entry = await api.uploadEpub(name, bytes);
+    } else {
+      throw new RemarkableConnectorUploadError({
+        message: "Unsupported upload mime type",
+        mimeType,
+      });
+    }
+
+    let hash = entry.hash;
+    if (parentId !== FOLIO_CONNECTOR_ROOT_ID) {
+      const moved = await api.move(entry.hash, parentId);
+      hash = moved.hash;
+    }
+
+    return mapSimpleEntry(
+      { id: entry.id, hash },
+      {
+        name,
+        parentId,
+        kind: "document",
+        documentFormat,
+      },
+    );
+  },
+
+  async downloadDocument(item) {
+    if (item.kind !== "document") {
+      throw new RemarkableConnectorDownloadError({
+        message: "Only documents can be downloaded",
+        itemId: item.id,
+      });
+    }
+
+    if (item.documentFormat === "pdf") {
+      return await api.getPdf(item.id, item.hash);
+    }
+    if (item.documentFormat === "epub") {
+      return await api.getEpub(item.id, item.hash);
+    }
+
+    throw new RemarkableConnectorDownloadError({
+      message:
+        "Notebook downloads are not supported yet; export the notebook from reMarkable as PDF first",
+      itemId: item.id,
+      ...(item.documentFormat
+        ? { documentFormat: item.documentFormat }
+        : {}),
+    });
+  },
+
+  async createFolder({ name, parentId = FOLIO_CONNECTOR_ROOT_ID }) {
+    const entry =
+      parentId === FOLIO_CONNECTOR_ROOT_ID
+        ? await api.uploadFolder(name)
+        : await api.putFolder(name, { parent: parentId });
+
+    return mapSimpleEntry(entry, {
+      name,
+      parentId,
+      kind: "folder",
+    });
+  },
+
+  async moveItem(item, parentId) {
+    const moved = await api.move(item.hash, parentId);
+    return refreshItemHash({ ...item, parentId }, moved.hash);
+  },
+
+  async renameItem(item, name) {
+    const renamed = await api.rename(item.hash, name);
+    return refreshItemHash({ ...item, name }, renamed.hash);
+  },
+
+  async deleteItem(item) {
+    await api.delete(item.hash);
+  },
+
+  async setStarred(item, starred) {
+    const updated = await api.stared(item.hash, starred);
+    return refreshItemHash({ ...item, starred }, updated.hash);
+  },
+});

--- a/plugins/connector/src/types.ts
+++ b/plugins/connector/src/types.ts
@@ -1,0 +1,67 @@
+/** Root collection id in reMarkable's cloud file tree. */
+export const FOLIO_CONNECTOR_ROOT_ID = "" as const;
+
+/** Trash collection id in reMarkable's cloud file tree. */
+export const FOLIO_CONNECTOR_TRASH_ID = "trash" as const;
+
+export type FolioConnectorParentId =
+  | typeof FOLIO_CONNECTOR_ROOT_ID
+  | typeof FOLIO_CONNECTOR_TRASH_ID
+  | (string & {});
+
+export type FolioConnectorItemKind = "folder" | "document" | "template";
+
+export type FolioConnectorDocumentFormat = "pdf" | "epub" | "notebook";
+
+export type FolioConnectorUploadMimeType = "application/pdf" | "application/epub+zip";
+
+/**
+ * Provider-neutral view of a remote item. Every connector maps its native entry
+ * shape into this so hosts can drive multiple backends with one UI.
+ */
+export type FolioConnectorItem = {
+  id: string;
+  hash: string;
+  name: string;
+  parentId: FolioConnectorParentId;
+  kind: FolioConnectorItemKind;
+  modifiedAt: string;
+  starred: boolean;
+  documentFormat?: FolioConnectorDocumentFormat;
+};
+
+export type FolioConnectorListOptions = {
+  /** When set, only children of this folder are returned. */
+  parentId?: FolioConnectorParentId;
+  /** Ask the provider to refresh its remote index before listing. */
+  refresh?: boolean;
+};
+
+export type FolioConnectorUploadOptions = {
+  name: string;
+  bytes: Uint8Array;
+  mimeType: FolioConnectorUploadMimeType;
+  parentId?: FolioConnectorParentId;
+};
+
+export type FolioConnectorCreateFolderOptions = {
+  name: string;
+  parentId?: FolioConnectorParentId;
+};
+
+/**
+ * The structural contract every folio cloud connector implements. Host apps
+ * (Stella, scripts, agents) call these methods to sync documents without
+ * depending on a provider SDK.
+ */
+export type FolioCloudConnector = {
+  readonly providerId: string;
+  listItems(options?: FolioConnectorListOptions): Promise<FolioConnectorItem[]>;
+  uploadDocument(options: FolioConnectorUploadOptions): Promise<FolioConnectorItem>;
+  downloadDocument(item: FolioConnectorItem): Promise<Uint8Array>;
+  createFolder(options: FolioConnectorCreateFolderOptions): Promise<FolioConnectorItem>;
+  moveItem(item: FolioConnectorItem, parentId: FolioConnectorParentId): Promise<FolioConnectorItem>;
+  renameItem(item: FolioConnectorItem, name: string): Promise<FolioConnectorItem>;
+  deleteItem(item: FolioConnectorItem): Promise<void>;
+  setStarred(item: FolioConnectorItem, starred: boolean): Promise<FolioConnectorItem>;
+};

--- a/plugins/connector/tsconfig.build.json
+++ b/plugins/connector/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/plugins/connector/tsconfig.json
+++ b/plugins/connector/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/connector/tsdown.config.ts
+++ b/plugins/connector/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsdown";
+
+const entry = ["src/**/*.ts", "!src/**/*.test.ts", "!src/**/__tests__/**"];
+
+const shared = {
+  entry,
+  format: ["esm"] as const,
+  platform: "neutral" as const,
+  outDir: "dist",
+  unbundle: true,
+};
+
+export default defineConfig([
+  { ...shared, dts: false, clean: false },
+  { ...shared, dts: { emitDtsOnly: true }, clean: false },
+]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `@stll/folio-connector-remarkable` under `plugins/connector`: a provider-neutral `FolioCloudConnector` contract plus a reMarkable cloud implementation backed by `rmapi-js`.

## What's included

- **Auth helpers**: `registerRemarkableDevice`, `authRemarkableSession`, `createRemarkableConnectorFromAuth`
- **Library operations**: list (with optional parent filter), upload PDF/EPUB, download PDF/EPUB, create folder, move, rename, delete, star
- **Unit tests** with mocked `rmapi-js` clients (no live cloud calls)
- **Workspace wiring**: `plugins/*` added to bun workspaces; lint covers `plugins/`

## Usage sketch

```ts
import { createRemarkableConnectorFromAuth } from "@stll/folio-connector-remarkable";

const connector = await createRemarkableConnectorFromAuth({ deviceToken });
const items = await connector.listItems();
await connector.uploadDocument({
  name: "Brief.pdf",
  bytes: pdfBytes,
  mimeType: "application/pdf",
});
```

## Notes

- reMarkable accepts PDF/EPUB, not `.docx`; hosts should convert before upload.
- Notebook (`.rm`) downloads are intentionally unsupported; export from the tablet as PDF first.
- Downloaded PDFs are the original uploads, not annotated exports with ink.

## Checks

- `bun --filter @stll/folio-connector-remarkable test`
- `bun --filter @stll/folio-connector-remarkable typecheck`
- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e92-8dfb-7d73-8ec9-d3f85e56ca33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e92-8dfb-7d73-8ec9-d3f85e56ca33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

