### PR TITLE
fix: improve visual parity diagnostics and layout

### DIFF
--- a/.changeset/fix-lma-layout-parity.md
+++ b/.changeset/fix-lma-layout-parity.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Fix hidden table row layout, table-cell paragraph spacing, cached field rendering, TOC font inheritance, paragraph-mark caps handling, and parity diagnostics for imported document parity.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -494,6 +494,7 @@ export type PageBreakMeasure = {
 // @public (undocumented)
 export type PageHeaderFooterRefs = {
     titlePg?: boolean;
+    evenAndOddHeaders?: boolean;
     headerDefault?: string;
     headerFirst?: string;
     headerEven?: string;
@@ -838,6 +839,7 @@ export type TableRow = {
     height?: number;
     heightRule?: "auto" | "atLeast" | "exact";
     isHeader?: boolean;
+    hidden?: boolean;
 };
 
 // @public

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -374,7 +374,8 @@ export type TableCellAttrs = {
 export type TableRowAttrs = {
     height?: number; /** Height rule ('auto', 'exact', 'atLeast') */
     heightRule?: NonNullable<import__stll_docx_core_model.TableRowFormatting["heightRule"]>; /** Is header row */
-    isHeader?: boolean; /** Original row formatting from DOCX for lossless round-trip serialization */
+    isHeader?: boolean; /** Whether the row is hidden (`w:hidden`) */
+    hidden?: boolean; /** Original row formatting from DOCX for lossless round-trip serialization */
     _originalFormatting?: import__stll_docx_core_model.TableRowFormatting;
 };
 

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -1034,9 +1034,9 @@ describe("Layout Engine - Contextual Spacing", () => {
     const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
     const frags = layout.pages[0].fragments;
-    // Gap = max(spaceAfter=13, spaceBefore=5) = 13 (paginator collapses spacing)
+    // Gap = spaceAfter + spaceBefore = 18 (Word-style additive spacing)
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(13);
+    expect(gap).toBe(18);
   });
 
   test("does NOT suppress spacing when styles differ", () => {
@@ -1062,9 +1062,9 @@ describe("Layout Engine - Contextual Spacing", () => {
 
     const frags = layout.pages[0].fragments;
     // Different styles — spacing should NOT be suppressed
-    // gap = max(spaceAfter=13, spaceBefore=5) = 13
+    // gap = spaceAfter + spaceBefore = 18
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(13);
+    expect(gap).toBe(18);
   });
 
   test("does NOT suppress when only one paragraph has contextualSpacing", () => {
@@ -1089,9 +1089,9 @@ describe("Layout Engine - Contextual Spacing", () => {
     const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
     const frags = layout.pages[0].fragments;
-    // gap = max(spaceAfter=13, spaceBefore=5) = 13
+    // gap = spaceAfter + spaceBefore = 18
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(13);
+    expect(gap).toBe(18);
   });
 
   test("suppresses spacing in a chain of 3+ same-style paragraphs", () => {
@@ -1170,18 +1170,18 @@ describe("Layout Engine - Contextual Spacing", () => {
     expect(frags.length).toBe(4);
 
     // Gap between Normal and Bullet 1 — Normal has no contextualSpacing, so
-    // gap = max(spaceAfter=13, spaceBefore=5) = 13
+    // gap = spaceAfter + spaceBefore = 18
     const gap0to1 = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap0to1).toBe(13);
+    expect(gap0to1).toBe(18);
 
     // Gap between Bullet 1 and Bullet 2 — both contextual, same style → suppressed
     const gap1to2 = frags[2].y - (frags[1].y + frags[1].height);
     expect(gap1to2).toBe(0);
 
     // Gap between Bullet 2 and Normal 2 — Normal 2 has no contextualSpacing
-    // gap = max(spaceAfter=13, spaceBefore=5) = 13
+    // gap = spaceAfter + spaceBefore = 18
     const gap2to3 = frags[3].y - (frags[2].y + frags[2].height);
-    expect(gap2to3).toBe(13);
+    expect(gap2to3).toBe(18);
   });
 
   test("does NOT suppress when styleId is undefined", () => {
@@ -1207,8 +1207,8 @@ describe("Layout Engine - Contextual Spacing", () => {
 
     const frags = layout.pages[0].fragments;
     // Without styleId, contextual spacing should NOT be applied
-    // gap = max(spaceAfter=10, spaceBefore=5) = 10
+    // gap = spaceAfter + spaceBefore = 15
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(10);
+    expect(gap).toBe(15);
   });
 });

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -371,6 +371,27 @@ export function runLayoutPipeline<THfPMs>(
       firstPageHeaderContent: firstPageHeaderForRender,
       firstPageFooterContent: firstPageFooterForRender,
     };
+    const buildSectionHfExtenderContent = (): typeof hfExtenderContent[] | undefined => {
+      if (!sectionHeaderFooterRefs) {
+        return undefined;
+      }
+      return sectionHeaderFooterRefs.map((refs) => ({
+        headerContent: pickSectionHeaderFooterContent(
+          headerContentByRId,
+          refs.headerDefault,
+          refs.evenAndOddHeaders === true ? refs.headerEven : undefined,
+        ),
+        footerContent: pickSectionHeaderFooterContent(
+          footerContentByRId,
+          refs.footerDefault,
+          refs.evenAndOddHeaders === true ? refs.footerEven : undefined,
+        ),
+        firstPageHeaderContent:
+          refs.titlePg === true ? headerContentByRId?.get(refs.headerFirst ?? "") : undefined,
+        firstPageFooterContent:
+          refs.titlePg === true ? footerContentByRId?.get(refs.footerFirst ?? "") : undefined,
+      }));
+    };
     const hfWarn = (msg: string): void => {
       // eslint-disable-next-line no-console -- standalone editor package has no logger in scope
       console.warn(`[PagedEditor] ${msg}`);
@@ -426,6 +447,7 @@ export function runLayoutPipeline<THfPMs>(
       // section. (Eigenpal #400.)
       extendSectionBreakMargins(sectionBreaks, {
         content,
+        sectionContent: buildSectionHfExtenderContent(),
         bodyPageSize: pageSize,
         bodyMargins,
         warn: hfWarn,
@@ -951,4 +973,28 @@ export function runLayoutPipeline<THfPMs>(
   syncCoordinator.onLayoutComplete(currentEpoch);
 
   return outcome;
+}
+
+function pickSectionHeaderFooterContent(
+  byRId: ReadonlyMap<string, HeaderFooterContent> | undefined,
+  defaultRId: string | undefined,
+  evenRId: string | undefined,
+): HeaderFooterContent | undefined {
+  const defaultContent = defaultRId ? byRId?.get(defaultRId) : undefined;
+  const evenContent = evenRId ? byRId?.get(evenRId) : undefined;
+  if (!defaultContent) {
+    return evenContent;
+  }
+  if (!evenContent) {
+    return defaultContent;
+  }
+  return headerFooterMarginPushHeight(evenContent) > headerFooterMarginPushHeight(defaultContent)
+    ? evenContent
+    : defaultContent;
+}
+
+function headerFooterMarginPushHeight(content: HeaderFooterContent): number {
+  const bottom = content.marginPushBottom ?? content.visualBottom ?? content.height;
+  const top = content.marginPushTop ?? content.visualTop ?? 0;
+  return Math.max(bottom - top, content.height);
 }

--- a/packages/core/src/docx/__tests__/differential.test.ts
+++ b/packages/core/src/docx/__tests__/differential.test.ts
@@ -30,6 +30,8 @@ import {
 } from "../../../scripts/differential/diff";
 
 const REQUIRED = process.env.DIFFERENTIAL_REQUIRED === "1";
+const PYTHON_DOCX_TIMEOUT_MS = 5_000;
+const OPEN_XML_SDK_TIMEOUT_MS = 15_000;
 
 // The corpus: the parser fixtures plus the visual fixtures (repo root).
 const FIXTURE_DIRS = [
@@ -54,6 +56,8 @@ const referenceSetupHints: Record<DifferentialReference, string> = {
 
 for (const reference of DIFFERENTIAL_REFERENCES) {
   const isAvailable = referenceAvailability[reference];
+  const fixtureTimeoutMs =
+    reference === "open-xml-sdk" ? OPEN_XML_SDK_TIMEOUT_MS : PYTHON_DOCX_TIMEOUT_MS;
 
   describe(`differential parser harness (folio vs ${reference})`, () => {
     if (!isAvailable()) {
@@ -85,7 +89,7 @@ for (const reference of DIFFERENTIAL_REFERENCES) {
           );
         }
         expect(result.ok).toBe(true);
-      });
+      }, fixtureTimeoutMs);
     }
   });
 }

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -620,6 +620,42 @@ describe("header/footer layout conversion", () => {
     expect((blocks[1] as ParagraphBlock).attrs?.suppressEmptyParagraphHeight).toBeUndefined();
     expect((blocks[4] as ParagraphBlock).attrs?.suppressEmptyParagraphHeight).toBe(true);
   });
+
+  test("keeps top-level footer trailing empty paragraph height for bottom anchoring", () => {
+    const blocks = normalizeHeaderFooterMeasureBlocks(
+      [table(), emptyParagraph({ id: "trailing-footer" })],
+      "footer",
+    );
+
+    expect((blocks[1] as ParagraphBlock).attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
+
+  test("excludes canonical trailing empty paragraph from header/footer margin push", () => {
+    const blocks = [table(), emptyParagraph({ id: "trailing-footer" })];
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [tableMeasure(24), { kind: "paragraph", lines: [], totalHeight: 12 }],
+      36,
+      { ...metrics, section: "footer" },
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 24 });
+  });
+
+  test("treats an empty text run as canonical trailing empty paragraph for margin push", () => {
+    const blocks = [
+      table(),
+      paragraph({ id: "trailing-footer", runs: [{ kind: "text", text: "" }] }),
+    ];
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [tableMeasure(24), { kind: "paragraph", lines: [], totalHeight: 12 }],
+      36,
+      { ...metrics, section: "footer" },
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 24 });
+  });
 });
 
 describe("convertHeaderFooterPmDocToContent", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -9,7 +9,8 @@
  *   HF.content -> headerFooterToProseDoc -> toFlowBlocks
  *     -> normalizeHeaderFooterMeasureBlocks (measure copy: drops floats and
  *        style-inherited spacing the renderer zeroes anyway, marks the
- *        canonical trailing-empty-paragraph-after-table as zero-height)
+ *        canonical trailing-empty-paragraph-after-table as zero-height in
+ *        headers)
  *     -> measureBlocks (caller-supplied)
  *     -> HeaderFooterContent (blocks, measures, height, visualTop/Bottom)
  *
@@ -65,17 +66,16 @@ export type HeaderFooterMetrics = {
 //    spacing via `spacingExplicit.before` / `.after`; anything not flagged
 //    was inherited and is zeroed for measurement.
 //
-// 3. Zero trailing empty paragraph after a table (#381). OOXML requires a
+// 3. Zero trailing empty paragraph after a table in headers (#381). OOXML requires a
 //    trailing block-level element after the last `<w:tbl>` in any block
 //    container, including `<w:hdr>` / `<w:ftr>`. Word renders that empty
-//    paragraph as a zero-height anchor when it has no runs AND no authored
-//    visual content (no paragraph borders, no explicit spacing). Marking
-//    its measure with `suppressEmptyParagraphHeight` keeps the BLOCK so
-//    click-to-position into the empty space below the table places the
-//    cursor in the trailing paragraph (matching Word) but the measure
-//    returns zero height. Empty paragraphs with authored `pBdr` or
-//    explicit spacing are NOT suppressed — they exist for their visual
-//    side effect, not just as a structural anchor.
+//    paragraph as a zero-height anchor in headers when it has no runs AND no
+//    authored visual content (no paragraph borders, no explicit spacing).
+//    Footers are bottom-anchored, so the same invisible paragraph still
+//    contributes to the footer flow height: it moves the visible table upward
+//    while not painting visible text. Empty paragraphs with authored `pBdr` or
+//    explicit spacing are NOT suppressed — they exist for their visual side
+//    effect, not just as a structural anchor.
 
 function isAnchoredImageRun(run: Run): boolean {
   if (run.kind !== "image") {
@@ -110,11 +110,21 @@ function hasAuthoredVisualContent(block: FlowBlock): boolean {
   return false;
 }
 
-export function normalizeHeaderFooterMeasureBlocks(blocks: FlowBlock[]): FlowBlock[] {
-  return normalizeFlowBlockArray(blocks);
+export function normalizeHeaderFooterMeasureBlocks(
+  blocks: FlowBlock[],
+  section: HeaderFooterMetrics["section"] = "header",
+): FlowBlock[] {
+  return normalizeFlowBlockArray(blocks, { suppressTrailingEmptyAfterTable: section === "header" });
 }
 
-function normalizeFlowBlockArray(blocks: FlowBlock[]): FlowBlock[] {
+type HeaderFooterMeasureNormalization = {
+  suppressTrailingEmptyAfterTable: boolean;
+};
+
+function normalizeFlowBlockArray(
+  blocks: FlowBlock[],
+  normalization: HeaderFooterMeasureNormalization,
+): FlowBlock[] {
   // Only the *canonical trailing* OOXML paragraph after the LAST block
   // qualifies for height suppression. Empty paragraphs used as authored
   // spacers in the middle of an HF (e.g. `[table, blank, paragraph,
@@ -122,7 +132,7 @@ function normalizeFlowBlockArray(blocks: FlowBlock[]): FlowBlock[] {
   // collapsed.
   const trailingEmptyAfterTable = new Set<number>();
   const lastIndex = blocks.length - 1;
-  if (lastIndex > 0) {
+  if (normalization.suppressTrailingEmptyAfterTable && lastIndex > 0) {
     const cur = blocks[lastIndex];
     const prev = blocks[lastIndex - 1];
     if (
@@ -186,12 +196,33 @@ function normalizeFlowBlockArray(blocks: FlowBlock[]): FlowBlock[] {
   });
 }
 
+function isCanonicalTrailingEmptyParagraphAfterTable(blocks: FlowBlock[], index: number): boolean {
+  const cur = blocks[index];
+  const prev = blocks[index - 1];
+  return (
+    index === blocks.length - 1 &&
+    prev?.kind === "table" &&
+    cur?.kind === "paragraph" &&
+    isVisuallyEmptyParagraph(cur) &&
+    !hasAuthoredVisualContent(cur)
+  );
+}
+
+function isVisuallyEmptyParagraph(block: FlowBlock): boolean {
+  if (block.kind !== "paragraph") {
+    return false;
+  }
+  return block.runs.every((run) => run.kind === "text" && run.text.trim().length === 0);
+}
+
 function normalizeTableBlock(block: TableBlock): TableBlock {
   const blockState = { changed: false };
   const rows = block.rows.map((row) => {
     const rowState = { changed: false };
     const cells = row.cells.map((cell) => {
-      const normalizedBlocks = normalizeFlowBlockArray(cell.blocks);
+      const normalizedBlocks = normalizeFlowBlockArray(cell.blocks, {
+        suppressTrailingEmptyAfterTable: true,
+      });
       const cellChanged = normalizedBlocks.some(
         (normalizedBlock, idx) => normalizedBlock !== cell.blocks[idx],
       );
@@ -389,7 +420,6 @@ export function calculateHeaderFooterVisualBounds(
     if (!block || !measure) {
       continue;
     }
-
     if (block.kind === "paragraph" && measure.kind === "paragraph") {
       const paragraphStartY = cursorY;
       const paragraphBottomY = paragraphStartY + measure.totalHeight;
@@ -510,6 +540,9 @@ export function calculateHeaderFooterMarginPushBounds(
     const block = blocks[i];
     const measure = measures[i];
     if (!block || !measure) {
+      continue;
+    }
+    if (isCanonicalTrailingEmptyParagraphAfterTable(blocks, i)) {
       continue;
     }
 
@@ -693,7 +726,7 @@ function finalizeHeaderFooterContent(
     return undefined;
   }
 
-  const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks);
+  const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks, metrics.section);
   const measures = options.measureBlocks(blocksForMeasure, contentWidth);
   let flowHeight = 0;
   for (let i = 0; i < measures.length; i++) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1988,6 +1988,9 @@ function convertTableRow(
   if (attrs.isHeader) {
     row.isHeader = attrs.isHeader;
   }
+  if (attrs.hidden) {
+    row.hidden = attrs.hidden;
+  }
   return row;
 }
 

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -514,7 +514,7 @@ function layoutParagraph(
         footnoteHeightById,
       );
       const firstLineHeight = measuredLineAdvance(firstLine) + firstLineRefs.height;
-      const collapsedLead = Math.max(spaceBefore, state.trailingSpacing);
+      const collapsedLead = spaceBefore + state.trailingSpacing;
       const columnCapacity = state.contentBottom - state.topMargin;
       if (
         collapsedLead + firstLineHeight > availableHeight &&
@@ -542,12 +542,11 @@ function layoutParagraph(
     // paragraphs with multi-line content didn't split — they jumped the
     // page boundary, leaving a chunk of empty space above.
     //
-    // `addFragment` collapses `spaceBefore` with the previous block's trailing
-    // spacing (`max(spaceBefore, trailingSpacing)`), so the fit loop must
-    // reserve the same collapsed amount; otherwise a large preceding
-    // `spaceAfter` repeats the same over-count (eigenpal/docx-editor#782).
+    // `addFragment` composes `spaceBefore` with the previous block's trailing
+    // spacing, so the fit loop must reserve the same amount; otherwise a large
+    // preceding `spaceAfter` repeats the same over-count (eigenpal/docx-editor#782).
     const firstFragmentSpaceBefore =
-      currentLineIndex === 0 ? Math.max(spaceBefore, state.trailingSpacing) : 0;
+      currentLineIndex === 0 ? spaceBefore + state.trailingSpacing : 0;
 
     for (let j = currentLineIndex; j < lines.length; j++) {
       const line = lines[j]!; // SAFETY: j < lines.length

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -151,7 +151,7 @@ describe("measureTableBlock row height", () => {
     }, fakeMeasure);
   });
 
-  test("image-only table cell paragraphs reserve the measured line box", () => {
+  test("image-only table cell paragraphs use the image visual height", () => {
     withFakeTextMeasure(() => {
       const table: TableBlock = {
         kind: "table",
@@ -198,7 +198,7 @@ describe("measureTableBlock row height", () => {
         throw new Error("Expected paragraph measure");
       }
       expect(paragraph.totalHeight).toBeGreaterThan(40);
-      expect(cell?.height).toBeGreaterThan(40);
+      expect(cell?.height).toBe(40);
       expect(cell?.height).toBeLessThan(paragraph.totalHeight);
       expect(row?.height).toBe(cell?.height);
     }, fakeMeasure);

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -121,6 +121,88 @@ describe("measureTableBlock row height", () => {
       expect(row.height).toBeLessThan(summedMaxes);
     }, fakeMeasure);
   });
+
+  test("hidden rows remain addressable but contribute zero height", () => {
+    withFakeTextMeasure(() => {
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120],
+        rows: [
+          {
+            id: "visible",
+            cells: [{ id: "a", blocks: [para("p1", "visible")] }],
+          },
+          {
+            id: "hidden",
+            hidden: true,
+            height: 40,
+            cells: [{ id: "b", blocks: [para("p2", "hidden but measured as absent")] }],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 120);
+
+      expect(measure.rows).toHaveLength(2);
+      expect(measure.rows[0]?.height).toBeGreaterThan(0);
+      expect(measure.rows[1]?.height).toBe(0);
+      expect(measure.totalHeight).toBe(measure.rows[0]?.height);
+    }, fakeMeasure);
+  });
+
+  test("image-only table cell paragraphs reserve the measured line box", () => {
+    withFakeTextMeasure(() => {
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [240],
+        rows: [
+          {
+            id: "logo-row",
+            cells: [
+              {
+                id: "logo-cell",
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                blocks: [
+                  {
+                    kind: "paragraph",
+                    id: "logo",
+                    runs: [
+                      {
+                        kind: "image",
+                        src: "data:image/png;base64,",
+                        width: 80,
+                        height: 40,
+                      },
+                    ],
+                    attrs: {
+                      defaultFontFamily: "Calibri",
+                      defaultFontSize: 11,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 240);
+      const row = measure.rows[0];
+      const cell = row?.cells[0];
+      const paragraph = cell?.blocks[0];
+
+      expect(paragraph?.kind).toBe("paragraph");
+      if (paragraph?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure");
+      }
+      expect(paragraph.totalHeight).toBeGreaterThan(40);
+      expect(cell?.height).toBeGreaterThan(40);
+      expect(cell?.height).toBeLessThan(paragraph.totalHeight);
+      expect(row?.height).toBe(cell?.height);
+    }, fakeMeasure);
+  });
 });
 
 describe("measureBlocks error instrumentation", () => {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -149,8 +149,7 @@ export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure
   if (inlineImageRuns.length === 1) {
     const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
     const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
-    const descent = paragraphMeasure.lines.at(0)?.descent ?? 0;
-    return spacingBefore + maxImageHeight + descent + spacingAfter;
+    return spacingBefore + maxImageHeight + spacingAfter;
   }
   const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
   const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
@@ -293,6 +292,11 @@ export function measureTableBlock(
     const sourceRow = tableBlock.rows[rowIdx];
     if (sourceRow?.hidden) {
       row.height = 0;
+      row.cells = sourceRow.cells.map(() => ({
+        blocks: [],
+        width: 0,
+        height: 0,
+      }));
       continue;
     }
     const sourceRowCells = tableBlock.rows[rowIdx]?.cells;

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -146,6 +146,12 @@ export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure
   for (const run of inlineImageRuns) {
     maxImageHeight = Math.max(maxImageHeight, run.height);
   }
+  if (inlineImageRuns.length === 1) {
+    const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
+    const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
+    const descent = paragraphMeasure.lines.at(0)?.descent ?? 0;
+    return spacingBefore + maxImageHeight + descent + spacingAfter;
+  }
   const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
   const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
 
@@ -284,6 +290,11 @@ export function measureTableBlock(
   // Calculate cell heights, respecting explicit row height rules
   for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
     const row = rows[rowIdx]!; // SAFETY: rowIdx < rows.length
+    const sourceRow = tableBlock.rows[rowIdx];
+    if (sourceRow?.hidden) {
+      row.height = 0;
+      continue;
+    }
     const sourceRowCells = tableBlock.rows[rowIdx]?.cells;
     // Take the max over per-cell totals (content + padding + vertical borders),
     // not the sum of an independent content-max and border-max: those two maxes
@@ -314,7 +325,6 @@ export function measureTableBlock(
     }
 
     // Apply heightRule from the source row
-    const sourceRow = tableBlock.rows[rowIdx];
     const explicitHeight = sourceRow?.height;
     const heightRule = sourceRow?.heightRule;
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -314,6 +314,26 @@ describe("measureParagraph cross-run line breaking", () => {
       expect(lineStartsAtRun(lines, 2)).toBe(false);
     }, fakeMeasure);
   });
+
+  test("allows justified lines to keep a slightly overfull word", () => {
+    withFakeTextMeasure(() => {
+      const text = "alpha beta gamma delta";
+      const runs: Run[] = [{ kind: "text", text }];
+      const tightWidth = width(text) - 0.8;
+
+      const leftMeasure = measureParagraph(paragraph(runs), tightWidth);
+      const justifiedMeasure = measureParagraph(
+        {
+          ...paragraph(runs),
+          attrs: { alignment: "justify" },
+        },
+        tightWidth,
+      );
+
+      expect(leftMeasure.lines).toHaveLength(2);
+      expect(justifiedMeasure.lines).toHaveLength(1);
+    }, fakeMeasure);
+  });
 });
 
 describe("inline image paragraph measurement", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -722,13 +722,6 @@ export function measureParagraph(
 
   const lines: MeasuredLine[] = [];
 
-  const lineWidthTolerance = (): number => {
-    if (!isJustifiedParagraph) {
-      return WIDTH_TOLERANCE;
-    }
-    return Math.max(WIDTH_TOLERANCE, currentLine.availableWidth * JUSTIFY_SHRINK_TOLERANCE_RATIO);
-  };
-
   // Handle empty paragraph
   if (runs.length === 0) {
     if (attrs?.suppressEmptyParagraphHeight) {
@@ -1273,7 +1266,9 @@ export function measureParagraph(
         // Extract word (includes trailing space if present)
         const word = text.slice(charIndex, nextBreak);
         const wordWidth = measureTextWidth(word, style);
-        const widthTolerance = lineWidthTolerance();
+        const widthTolerance = isJustifiedParagraph
+          ? Math.max(WIDTH_TOLERANCE, currentLine.availableWidth * JUSTIFY_SHRINK_TOLERANCE_RATIO)
+          : WIDTH_TOLERANCE;
 
         // If the word itself is longer than a line, hard-break by characters.
         // Use substring measurement (not char-by-char accumulation) to preserve

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -52,6 +52,7 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Floating-point tolerance for line breaking (0.5px)
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
+const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.012;
 
 /**
  * Find the longest prefix of `text` that fits within `maxWidth` pixels.
@@ -629,6 +630,7 @@ export function measureParagraph(
   const runs = block.runs;
   const attrs = block.attrs;
   const spacing = attrs?.spacing;
+  const isJustifiedParagraph = attrs?.alignment === "justify";
 
   // Floating image support
   const floatingZones = options?.floatingZones;
@@ -719,6 +721,13 @@ export function measureParagraph(
   );
 
   const lines: MeasuredLine[] = [];
+
+  const lineWidthTolerance = (): number => {
+    if (!isJustifiedParagraph) {
+      return WIDTH_TOLERANCE;
+    }
+    return Math.max(WIDTH_TOLERANCE, currentLine.availableWidth * JUSTIFY_SHRINK_TOLERANCE_RATIO);
+  };
 
   // Handle empty paragraph
   if (runs.length === 0) {
@@ -1264,12 +1273,13 @@ export function measureParagraph(
         // Extract word (includes trailing space if present)
         const word = text.slice(charIndex, nextBreak);
         const wordWidth = measureTextWidth(word, style);
+        const widthTolerance = lineWidthTolerance();
 
         // If the word itself is longer than a line, hard-break by characters.
         // Use substring measurement (not char-by-char accumulation) to preserve
         // kerning accuracy. Char-by-char accumulation overestimates width by
         // ~1-2px per line due to lost kerning, causing extra wraps in narrow cells.
-        if (wordWidth > currentLine.availableWidth + WIDTH_TOLERANCE) {
+        if (wordWidth > currentLine.availableWidth + widthTolerance) {
           // Long word that needs hard-breaking. DON'T start a new line first —
           // fill the remaining space on the current line with as many characters
           // as possible. This prevents wasting a full line when a small run
@@ -1322,12 +1332,12 @@ export function measureParagraph(
             : 0;
         const glueWidth =
           rawGlueWidth > 0 &&
-          wordWidth + rawGlueWidth <= getPostWrapAvailableWidth() + WIDTH_TOLERANCE
+          wordWidth + rawGlueWidth <= getPostWrapAvailableWidth() + widthTolerance
             ? rawGlueWidth
             : 0;
         if (
           currentLine.width > 0 &&
-          currentLine.width + wordWidth + glueWidth > currentLine.availableWidth + WIDTH_TOLERANCE
+          currentLine.width + wordWidth + glueWidth > currentLine.availableWidth + widthTolerance
         ) {
           // Word doesn't fit, start new line
           startNewLine(runIndex, charIndex);

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -113,4 +113,5 @@ describe("paginator block spacing", () => {
     expect(paginator.pages.length).toBe(2);
     expect(result.y).toBe(15);
   });
+
 });

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -333,8 +333,10 @@ export function createPaginator(options: PaginatorOptions) {
     const initialState = getCurrentState();
     const initialColumnIndex = initialState.columnIndex;
 
-    // Collapse space before with trailing spacing from previous block
-    const effectiveSpaceBefore = Math.max(spaceBefore, initialState.trailingSpacing);
+    // Word composes adjacent paragraph spacing additively: the previous
+    // paragraph's `spaceAfter` and the next paragraph's `spaceBefore` both
+    // contribute to the inter-paragraph gap.
+    const effectiveSpaceBefore = spaceBefore + initialState.trailingSpacing;
     const totalHeight = effectiveSpaceBefore + height;
 
     // Ensure we have space

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -522,6 +522,7 @@ export type TableRow = {
   height?: number;
   heightRule?: "auto" | "atLeast" | "exact";
   isHeader?: boolean;
+  hidden?: boolean;
 };
 
 /**
@@ -619,6 +620,7 @@ export type SectionBreakBlock = {
 
 export type PageHeaderFooterRefs = {
   titlePg?: boolean;
+  evenAndOddHeaders?: boolean;
   headerDefault?: string;
   headerFirst?: string;
   headerEven?: string;

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -545,7 +545,7 @@ describe("header and footer rendering", () => {
     ).toBe("0.62");
   });
 
-  test("resolves even headers and footers from the section page number", () => {
+  test("ignores even footers unless odd/even headers are enabled", () => {
     const pageOptions = {};
     const applied = applySectionHeaderFooterOptions(
       {
@@ -570,6 +570,35 @@ describe("header and footer rendering", () => {
     expect(applied).toBe(true);
     expect(pageOptions).toEqual({
       footerContent: headerFooterTextContent("Default footer"),
+    });
+  });
+
+  test("resolves even footers from the section page number when enabled", () => {
+    const pageOptions = {};
+    const applied = applySectionHeaderFooterOptions(
+      {
+        ...page,
+        number: 2,
+        sectionPageNumber: 2,
+        headerFooterRefs: {
+          evenAndOddHeaders: true,
+          footerDefault: "default-footer",
+          footerEven: "even-footer",
+        },
+        fragments: [],
+      },
+      pageOptions,
+      {
+        footerContentByRId: new Map([
+          ["default-footer", headerFooterTextContent("Default footer")],
+          ["even-footer", headerFooterTextContent("Even footer")],
+        ]),
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(pageOptions).toEqual({
+      footerContent: headerFooterTextContent("Even footer"),
     });
   });
 

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -2301,7 +2301,7 @@ export function applySectionHeaderFooterOptions(
   const isFirstSectionPage = page.sectionPageNumber === 1;
   const useFirst = refs.titlePg === true && isFirstSectionPage;
   const sectionPageNumber = page.sectionPageNumber ?? page.number;
-  const useEven = sectionPageNumber % 2 === 0;
+  const useEven = refs.evenAndOddHeaders === true && sectionPageNumber % 2 === 0;
 
   const headerRId = (() => {
     if (useFirst) {

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -218,6 +218,43 @@ describe("renderLine right-tab flex anchor", () => {
 
     expect(lineEl.dataset["flexLine"]).toBeUndefined();
   });
+
+  test("uses cached fallback text for non-live fields even with render context", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "cached-pageref",
+      runs: [
+        {
+          kind: "field",
+          fieldType: "OTHER",
+          instruction: " PAGEREF _Toc1 \\h ",
+          fallback: "2",
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 7,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      context: {
+        pageNumber: 1,
+        totalPages: 10,
+        section: "body",
+        bookmarkPages: new Map([["_Toc1", 6]]),
+      },
+    }) as unknown as FakeElement;
+
+    expect(findFieldOrTextEls(lineEl).at(0)?.textContent).toBe("2");
+  });
 });
 
 describe("renderTabRun leader rendering", () => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -959,7 +959,7 @@ const EMPTY_SEQ_VALUES: ReadonlyMap<number, number> = new Map();
  */
 function resolveFieldText(run: FieldRun, context: RenderContext | undefined): string {
   const fallback = run.fallback ?? "";
-  if (run.fieldType === "OTHER") {
+  if (run.fieldType === "OTHER" && run.pmStart === undefined) {
     return fallback;
   }
   if (!context) {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -958,8 +958,12 @@ const EMPTY_SEQ_VALUES: ReadonlyMap<number, number> = new Map();
  * Returns the cached fallback when no render context is available.
  */
 function resolveFieldText(run: FieldRun, context: RenderContext | undefined): string {
+  const fallback = run.fallback ?? "";
+  if (run.fieldType === "OTHER") {
+    return fallback;
+  }
   if (!context) {
-    return run.fallback ?? "";
+    return fallback;
   }
   const fieldContext: FieldContext = {
     pageNumber: context.pageNumber,
@@ -971,7 +975,7 @@ function resolveFieldText(run: FieldRun, context: RenderContext | undefined): st
     ...(context.sectionPages === undefined ? {} : { sectionPages: context.sectionPages }),
   };
   return evaluateFieldInstruction(run.instruction || run.fieldType, fieldContext, {
-    fallback: run.fallback ?? "",
+    fallback,
     ...(run.pmStart === undefined ? {} : { instanceId: run.pmStart }),
     ...(run.fldLock ? { locked: true } : {}),
   });

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -158,6 +158,12 @@ function renderCellContent(
       );
 
       fragEl.style.position = "relative";
+      fragEl.style.boxSizing = "border-box";
+      fragEl.style.height = `${paragraphMeasure.totalHeight}px`;
+      const spaceBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
+      if (spaceBefore > 0) {
+        fragEl.style.paddingTop = `${spaceBefore}px`;
+      }
       contentEl.append(fragEl);
       cumulativeY += paragraphMeasure.totalHeight;
     } else if (block?.kind === "table" && measure?.kind === "table") {
@@ -232,6 +238,10 @@ function renderNestedTable(
     const rowMeasure = measure.rows[rowIndex];
 
     if (!row || !rowMeasure) {
+      continue;
+    }
+    if (row.hidden) {
+      y += rowMeasure.height;
       continue;
     }
 
@@ -655,6 +665,10 @@ export function renderTableFragment(
       if (!hdrRow || !hdrRowMeasure) {
         continue;
       }
+      if (hdrRow.hidden) {
+        y += hdrRowMeasure.height;
+        continue;
+      }
 
       const rowEl = renderTableRow(
         hdrRow,
@@ -701,6 +715,10 @@ export function renderTableFragment(
     if (!row || !rowMeasure) {
       continue;
     }
+    if (row.hidden) {
+      y += rowMeasure.height;
+      continue;
+    }
 
     // First content row in a continuation fragment with headers should draw top border
     const isFirstRowInFragment =
@@ -730,6 +748,9 @@ export function renderTableFragment(
   // Add row resize handles at each row boundary (between consecutive rows)
   let handleY = 0;
   for (let rowIdx = fragment.fromRow; rowIdx < fragment.toRow; rowIdx++) {
+    if (block.rows[rowIdx]?.hidden) {
+      continue;
+    }
     handleY += measure.rows[rowIdx]?.height ?? 0;
 
     // Don't add a handle after the last row in this fragment (unless it's the table's last row — that's the bottom edge)

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -71,6 +71,17 @@ function findRows(element: FakeElement): FakeElement[] {
   return matches;
 }
 
+function findByClass(element: FakeElement, className: string): FakeElement[] {
+  const matches: FakeElement[] = [];
+  if (element.className.split(" ").includes(className)) {
+    matches.push(element);
+  }
+  for (const child of element.children) {
+    matches.push(...findByClass(child, className));
+  }
+  return matches;
+}
+
 function buildHeaderContinuation(): {
   fragment: TableFragment;
   block: TableBlock;
@@ -192,5 +203,77 @@ describe("renderTableFragment clipped header continuations", () => {
     expect(headerRow?.style["top"]).toBe("0px");
     expect(bodyRow?.style["top"]).toBe("-40px");
     expect(clipElement).toBeDefined();
+  });
+});
+
+describe("renderTableFragment cell paragraph spacing", () => {
+  test("reserves measured paragraph spacing inside table cells", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "para",
+                  attrs: { spacing: { before: 6, after: 12 } },
+                  runs: [{ kind: "text", text: "Cell text" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                {
+                  kind: "paragraph",
+                  lines: [],
+                  totalHeight: 30,
+                },
+              ],
+              width: 100,
+              height: 30,
+            },
+          ],
+          height: 30,
+        },
+      ],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 30,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 30,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+
+    const paragraph = findByClass(tableEl, "layout-paragraph").at(0);
+
+    expect(paragraph?.style["height"]).toBe("30px");
+    expect(paragraph?.style["paddingTop"]).toBe("6px");
+    expect(paragraph?.style["boxSizing"]).toBe("border-box");
   });
 });

--- a/packages/core/src/paged-layout/headerFooterMargins.ts
+++ b/packages/core/src/paged-layout/headerFooterMargins.ts
@@ -183,6 +183,7 @@ export type HeaderFooterExtenderContent = Omit<
 
 type ExtendSectionBreakMarginsInput = {
   content: HeaderFooterExtenderContent;
+  sectionContent?: HeaderFooterExtenderContent[] | undefined;
   /** Body page size and effective margins — the inheritance seed. */
   bodyPageSize: { w: number; h: number };
   bodyMargins: PageMargins;
@@ -203,16 +204,21 @@ type ExtendSectionBreakMarginsInput = {
  */
 export function extendSectionBreakMargins(
   sectionBreaks: SectionBreakBlock[],
-  { content, bodyPageSize, bodyMargins, warn }: ExtendSectionBreakMarginsInput,
+  { content, sectionContent, bodyPageSize, bodyMargins, warn }: ExtendSectionBreakMarginsInput,
 ): void {
   let pageSize = bodyPageSize;
   let margins = bodyMargins;
-  for (const sb of sectionBreaks) {
+  for (let index = 0; index < sectionBreaks.length; index++) {
+    const sb = sectionBreaks[index];
+    if (!sb) {
+      continue;
+    }
     if (!sb.pageSize && !sb.margins) {
       continue;
     }
     pageSize = sb.pageSize ?? pageSize;
-    margins = computeHeaderFooterMarginExtender({ ...content, pageSize, warn })(
+    const targetSectionContent = sectionContent?.[index + 1] ?? content;
+    margins = computeHeaderFooterMarginExtender({ ...targetSectionContent, pageSize, warn })(
       sb.margins ?? margins,
     );
     sb.margins = margins;

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -403,6 +403,7 @@ export const readTableRowAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Tabl
     TABLE_ROW_HEIGHT_RULE_VALUES,
   );
   optionalBoolean(attrs, "isHeader", "tableRow.attrs.isHeader", issues);
+  optionalBoolean(attrs, "hidden", "tableRow.attrs.hidden", issues);
   optionalRecord(attrs, "_originalFormatting", "tableRow.attrs._originalFormatting", issues);
 
   return attrsResult(attrs, issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2567,12 +2567,19 @@ function tableRowAttrsToFormatting(attrs: TableRowAttrs): TableRowFormatting | u
         delete result.header;
       }
     }
+    if (attrs.hidden !== (orig.hidden ?? undefined)) {
+      if (attrs.hidden) {
+        result.hidden = attrs.hidden;
+      } else {
+        delete result.hidden;
+      }
+    }
 
     return result;
   }
 
   // Fallback: reconstruct formatting from individual attrs
-  const hasFormatting = attrs.height || attrs.isHeader;
+  const hasFormatting = attrs.height || attrs.isHeader || attrs.hidden;
 
   if (!hasFormatting) {
     return undefined;
@@ -2587,6 +2594,9 @@ function tableRowAttrsToFormatting(attrs: TableRowAttrs): TableRowFormatting | u
   }
   if (attrs.isHeader) {
     f.header = attrs.isHeader;
+  }
+  if (attrs.hidden) {
+    f.hidden = attrs.hidden;
   }
   return f;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -116,6 +116,70 @@ describe("toProseDoc", () => {
     expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(20);
   });
 
+  test("does not inherit paragraph mark all-caps onto visible text", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  allCaps: true,
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    italic: true,
+                  },
+                  content: [{ type: "text", text: "mandated lead arranger" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "allCaps")).toBe(false);
+    expect(text?.marks.some((mark) => mark.type.name === "italic")).toBe(true);
+  });
+
+  test("preserves explicit run-level all-caps", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    allCaps: true,
+                    italic: true,
+                  },
+                  content: [{ type: "text", text: "mandated lead arranger" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "allCaps")).toBe(true);
+    expect(text?.marks.some((mark) => mark.type.name === "italic")).toBe(true);
+  });
+
   test("preserves direct run marks on tab nodes", () => {
     const document: Document = {
       package: {
@@ -636,6 +700,70 @@ describe("toProseDoc", () => {
     expect(field?.attrs.instruction).toBe(' MERGEFIELD "Client Name" \\* MERGEFORMAT ');
     expect(field?.attrs.displayText).toBe("Acme s.r.o.");
     expect(field?.attrs.fieldKind).toBe("simple");
+  });
+
+  test("does not apply TOC paragraph-mark font defaults to field result text", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: {
+                fontFamily: { ascii: "CG Times", hAnsi: "CG Times" },
+              },
+            },
+            {
+              styleId: "TOC1",
+              type: "paragraph",
+              basedOn: "Normal",
+              rPr: {
+                fontFamily: { ascii: "CG Times", hAnsi: "CG Times" },
+              },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                styleId: "TOC1",
+                runProperties: {
+                  fontFamily: { ascii: "Calibri", hAnsi: "Calibri" },
+                },
+              },
+              content: [
+                {
+                  type: "complexField",
+                  fieldType: "TOC",
+                  instruction: ' TOC \\o "1-1" ',
+                  fieldResult: [
+                    {
+                      type: "run",
+                      formatting: {},
+                      content: [{ type: "text", text: "Definitions and Interpretation" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = doc.firstChild;
+    const field = paragraph?.firstChild;
+    const fieldFont = field?.marks.find((mark) => mark.type.name === "fontFamily");
+    const defaultTextFormatting = paragraph?.attrs.defaultTextFormatting;
+
+    expect(field?.type.name).toBe("field");
+    expect(fieldFont?.attrs.ascii).toBe("CG Times");
+    expect(defaultTextFormatting?.fontFamily?.ascii).toBe("CG Times");
   });
 
   test("converts inline content controls without synthetic marks", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -75,7 +75,12 @@ export type ToProseDocOptions = {
   theme?: Theme | null;
 };
 
-type RunFormattingResolver = (formatting: TextFormatting | undefined) => TextFormatting | undefined;
+type RunFormattingResolver = (
+  formatting: TextFormatting | undefined,
+  fieldType?: string,
+) => TextFormatting | undefined;
+
+const TOC_STYLE_ID = /^TOC\d*$/iu;
 
 /**
  * Convert a Document to a ProseMirror document
@@ -198,6 +203,7 @@ function convertParagraph(
   tableParagraphOverlay?: TableCellParagraphSpacingOverlay,
 ): PMNode {
   const attrs = paragraphFormattingToAttrs(paragraph, styleResolver, tableParagraphOverlay);
+  const isTocParagraph = TOC_STYLE_ID.test(paragraph.formatting?.styleId ?? "");
   const inlineNodes: PMNode[] = [];
   let inlineOffset = 0;
   let bookmarksArr: { id: number; name: string }[] | undefined;
@@ -237,9 +243,10 @@ function convertParagraph(
   // (highlight, shading) to body runs — they paint the pilcrow alone. Strip
   // them off the inheritance path so a `<w:pPr><w:rPr><w:highlight/></w:rPr>`
   // used to mark just the paragraph glyph doesn't bleed onto every run.
-  const inheritableParagraphRunFormatting = paragraphRunFormatting
-    ? stripParagraphMarkOnlyFormatting(paragraphRunFormatting)
-    : undefined;
+  let inheritableParagraphRunFormatting: TextFormatting | undefined;
+  if (paragraphRunFormatting && !isTocParagraph) {
+    inheritableParagraphRunFormatting = stripParagraphMarkOnlyFormatting(paragraphRunFormatting);
+  }
   const baseRunFormatting = mergeTextFormatting(styleRunFormatting, extraRunFormatting);
   const defaultRunFormatting = mergeTextFormatting(
     baseRunFormatting,
@@ -247,7 +254,13 @@ function convertParagraph(
   );
   const getInheritedRunFormatting = (
     formatting: TextFormatting | undefined,
+    fieldType?: string,
   ): TextFormatting | undefined => {
+    if (fieldType === "TOC") {
+      return hasDirectRunFormatting(formatting)
+        ? suppressParagraphMarkFormatting(baseRunFormatting, undefined, formatting)
+        : baseRunFormatting;
+    }
     if (!hasDirectRunFormatting(formatting)) {
       return defaultRunFormatting;
     }
@@ -571,7 +584,9 @@ function paragraphFormattingToAttrs(
 
     set(
       "defaultTextFormatting",
-      resolveParagraphDefaultTextFormatting(styleId, formatting, styleResolver),
+      resolveParagraphDefaultTextFormatting(styleId, formatting, styleResolver, {
+        includeParagraphMarkRunProperties: !TOC_STYLE_ID.test(styleId ?? ""),
+      }),
     );
 
     // If style defines numPr but inline doesn't, use style's numPr
@@ -838,7 +853,7 @@ function hasDirectRunFormatting(formatting: TextFormatting | undefined): boolean
 }
 
 function stripParagraphMarkOnlyFormatting(formatting: TextFormatting): TextFormatting | undefined {
-  const { highlight: _h, shading: _s, ...rest } = formatting;
+  const { allCaps: _ac, highlight: _h, shading: _s, smallCaps: _sc, ...rest } = formatting;
   return Object.keys(rest).length > 0 ? rest : undefined;
 }
 
@@ -917,6 +932,7 @@ function resolveParagraphDefaultTextFormatting(
   styleId: string | undefined,
   formatting: Paragraph["formatting"] | undefined,
   styleResolver: StyleEngine,
+  options: { includeParagraphMarkRunProperties?: boolean } = {},
 ): TextFormatting | undefined {
   const style = styleId
     ? (styleResolver.getStyle(styleId) ?? styleResolver.getDefaultParagraphStyle())
@@ -928,7 +944,8 @@ function resolveParagraphDefaultTextFormatting(
   // the run properties and then overwrites the paragraph style's font
   // (e.g. FootnoteText's Times New Roman) with the docDefault Calibri when
   // merged into the cascade below.
-  const rawParagraphMarkRpr = formatting?.runProperties;
+  const rawParagraphMarkRpr =
+    options.includeParagraphMarkRunProperties === false ? undefined : formatting?.runProperties;
   const characterStyleRpr =
     rawParagraphMarkRpr?.styleId !== undefined
       ? styleResolver.getRunStyleOwnProperties(rawParagraphMarkRpr.styleId)
@@ -1330,6 +1347,9 @@ function convertTableRow(
   }
   if (row.formatting?.heightRule) {
     attrs.heightRule = row.formatting.heightRule;
+  }
+  if (row.formatting?.hidden) {
+    attrs.hidden = true;
   }
   if (row.formatting) {
     attrs._originalFormatting = row.formatting;
@@ -1770,7 +1790,7 @@ function convertField(
   // styled only by a `w:rStyle` (e.g. a PAGE/REF field) keeps its style-derived
   // marks, so the save-side `w:rStyle` reconciliation does not treat the field
   // as diverging and strip the link (eigenpal/docx-editor#833).
-  const inheritedFormatting = getInheritedRunFormatting(fieldFormatting);
+  const inheritedFormatting = getInheritedRunFormatting(fieldFormatting, field.fieldType);
   const { marks } = buildRunMarks(fieldFormatting, inheritedFormatting, styleResolver);
 
   return schema.node(

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -334,6 +334,7 @@ const tableRowSpec: NodeSpec = {
     height: { default: null },
     heightRule: { default: null },
     isHeader: { default: false },
+    hidden: { default: false },
     _originalFormatting: { default: null },
   },
   parseDOM: [{ tag: "tr" }],
@@ -344,6 +345,9 @@ const tableRowSpec: NodeSpec = {
     if (typeof attrs.height === "number") {
       const heightPx = Math.round((attrs.height / 20) * 1.333);
       domAttrs["style"] = `height: ${heightPx}px`;
+    }
+    if (attrs.hidden) {
+      domAttrs["style"] = `${domAttrs["style"] ? `${domAttrs["style"]}; ` : ""}display: none`;
     }
 
     return ["tr", domAttrs, 0];

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -561,6 +561,8 @@ export type TableRowAttrs = {
   heightRule?: NonNullable<TableRowFormatting["heightRule"]>;
   /** Is header row */
   isHeader?: boolean;
+  /** Whether the row is hidden (`w:hidden`) */
+  hidden?: boolean;
   /** Original row formatting from DOCX for lossless round-trip serialization */
   _originalFormatting?: TableRowFormatting;
 };

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -21,6 +21,7 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
   const verifiedRatios: [font: string, expectedRatio: number][] = [
     ["arial", 1.1499],
     ["times new roman", 1.1499],
+    ["cg times", 1.1499],
     ["calibri", 1.2207],
     ["cambria", 1.1724],
     ["georgia", 1.1362],
@@ -42,6 +43,17 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
       expect(resolveFontFamily(font).singleLineRatio).toBeCloseTo(expectedRatio, 4);
     });
   }
+});
+
+describe("fontResolver — legacy Times-compatible faces", () => {
+  test("CG Times uses Times New Roman metrics and CSS fallback", () => {
+    const resolved = resolveFontFamily("CG Times");
+
+    expect(resolved.originalFont).toBe("CG Times");
+    expect(resolved.googleFont).toBe("Tinos");
+    expect(resolved.cssFallback.startsWith('"Times New Roman", Tinos')).toBe(true);
+    expect(getResolvedData("CG Times").singleLineRatio).toBeCloseTo(1.1499, 4);
+  });
 });
 
 describe("fontResolver — previously wrong ratios are corrected and reach consumers", () => {

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -187,6 +187,18 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
       unitsPerEm: 2048,
     }), // 1.1499
   },
+  "cg times": {
+    googleFont: "Tinos",
+    category: "serif",
+    fallbackStack: ["Times New Roman", "Tinos", "Times", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1825,
+      hheaDescent: -443,
+      hheaLineGap: 87,
+      unitsPerEm: 2048,
+    }), // Metric-compatible Times New Roman substitute used by Word/LibreOffice.
+  },
   "courier new": {
     googleFont: "Cousine",
     category: "monospace",

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -908,22 +908,29 @@ function getSectionHeaderFooterRefs(
   if (!body) {
     return undefined;
   }
+  const documentEvenAndOddHeaders = documentModel.package.settings?.evenAndOddHeaders === true;
   const sections = body.sections;
   if (sections && sections.length > 0) {
-    return sections.map((section) => getHeaderFooterRefsFromSectionProperties(section.properties));
+    return sections.map((section) =>
+      getHeaderFooterRefsFromSectionProperties(section.properties, documentEvenAndOddHeaders),
+    );
   }
   const finalProps = body.finalSectionProperties;
   if (!finalProps) {
     return undefined;
   }
-  return [getHeaderFooterRefsFromSectionProperties(finalProps)];
+  return [getHeaderFooterRefsFromSectionProperties(finalProps, documentEvenAndOddHeaders)];
 }
 
-function getHeaderFooterRefsFromSectionProperties(props: SectionProperties): PageHeaderFooterRefs {
+function getHeaderFooterRefsFromSectionProperties(
+  props: SectionProperties,
+  documentEvenAndOddHeaders: boolean,
+): PageHeaderFooterRefs {
   const refs: PageHeaderFooterRefs = {};
   if (props.titlePg !== undefined) {
     refs.titlePg = props.titlePg;
   }
+  refs.evenAndOddHeaders = props.evenAndOddHeaders ?? documentEvenAndOddHeaders;
   for (const ref of props.headerReferences ?? []) {
     if (ref.type === "default") {
       refs.headerDefault = ref.rId;

--- a/parity/__tests__/cli.test.ts
+++ b/parity/__tests__/cli.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseArgs } from "../cli";
+
+describe("parity CLI args", () => {
+  test("parses an explicit JSON output path without treating it as an input document", () => {
+    const flags = parseArgs(["fixture.docx", "--max-pages", "3", "--output", "/tmp/out.json"]);
+
+    expect(flags.paths).toEqual(["fixture.docx"]);
+    expect(flags.maxPages).toBe(3);
+    expect(flags.outputPath).toBe("/tmp/out.json");
+  });
+
+  test("requires a path after --output", () => {
+    expect(() => parseArgs(["fixture.docx", "--output"])).toThrow("--output requires a file path");
+    expect(() => parseArgs(["fixture.docx", "--output", "--json"])).toThrow(
+      "--output requires a file path",
+    );
+  });
+});

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -134,6 +134,27 @@ describe("compareGeoms", () => {
     ).toBe(false);
   });
 
+  test("a normalized 1-to-1 gap is treated as a match, not a line-break", () => {
+    const word = makeDoc("word", [
+      makePage({
+        lines: [
+          makeLine({ text: "1.", xPt: 10 }),
+          makeLine({ text: "Definitions ................ 2", xPt: 40 }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [makeLine({ text: "1.", xPt: 10 }), makeLine({ text: "Definitions … 2", xPt: 40 })],
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences).toEqual([]);
+    expect(result.score).toBe(1);
+  });
+
   test("an extra folio page with a shifted line reports page-count and pagination", () => {
     const word = makeDoc("word", [
       makePage({

--- a/parity/__tests__/textNorm.test.ts
+++ b/parity/__tests__/textNorm.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeLineText } from "../textNorm";
+
+describe("normalizeLineText", () => {
+  test("collapses long dot leaders for stable TOC matching", () => {
+    expect(normalizeLineText("Definitions ................ 2")).toBe("Definitions … 2");
+    expect(normalizeLineText("Definitions ................................................ 2")).toBe(
+      "Definitions … 2",
+    );
+  });
+
+  test("normalizes Symbol-font copyright extraction noise", () => {
+    expect(normalizeLineText("\uf0e3 Loan Market Association")).toBe("ã Loan Market Association");
+  });
+});

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -6,15 +6,17 @@
  *   bun parity/cli.ts                          # full default corpus, HTML report
  *   bun parity/cli.ts path/to/file.docx        # one document
  *   bun parity/cli.ts some/dir --json          # machine-readable output
+ *   bun parity/cli.ts path/to/file.docx --output parity.json
  *   bun parity/cli.ts --refresh-truth          # ignore cached Word exports
  *   bun parity/cli.ts --headed                 # show the folio browser window
  *   bun parity/cli.ts --no-report              # skip writing the HTML report
+ *   bun parity/cli.ts path/to/file.docx --max-pages 20
  *
  * Ground truth requires Microsoft Word for Mac plus `mutool`
  * (`brew install mupdf-tools`); the CLI exits 2 with a clear message when
  * either is missing, mirroring the differential-test skip ergonomics.
  */
-import { stat } from "node:fs/promises";
+import { mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 import { DEFAULT_CORPUS_DIRS } from "./config";
@@ -31,7 +33,13 @@ import { compareGeoms } from "./compare";
 import { writeHtmlReport } from "./report";
 import type { DocAssets } from "./report";
 import { getWordPagePngs, getWordTruth, getWordVersion, isWordAvailable } from "./wordTruth";
-import type { CorpusReport, Divergence, DivergenceKind, FeatureAttributedResult } from "./types";
+import type {
+  CorpusReport,
+  Divergence,
+  DivergenceKind,
+  DocGeom,
+  FeatureAttributedResult,
+} from "./types";
 
 const EXIT_OK = 0;
 const EXIT_DIVERGENT = 1;
@@ -49,10 +57,12 @@ type CliFlags = {
   refreshTruth: boolean;
   headed: boolean;
   noReport: boolean;
+  outputPath?: string;
+  maxPages?: number;
   paths: string[];
 };
 
-const parseArgs = (argv: string[]): CliFlags => {
+export const parseArgs = (argv: string[]): CliFlags => {
   const flags: CliFlags = {
     json: false,
     refreshTruth: false,
@@ -60,7 +70,8 @@ const parseArgs = (argv: string[]): CliFlags => {
     noReport: false,
     paths: [],
   };
-  for (const arg of argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
     if (arg === "--json") {
       flags.json = true;
     } else if (arg === "--refresh-truth") {
@@ -69,12 +80,37 @@ const parseArgs = (argv: string[]): CliFlags => {
       flags.headed = true;
     } else if (arg === "--no-report") {
       flags.noReport = true;
+    } else if (arg === "--output") {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("--output requires a file path");
+      }
+      flags.outputPath = value;
+      i += 1;
+    } else if (arg === "--max-pages") {
+      const value = argv[i + 1];
+      const maxPages = value === undefined ? Number.NaN : Number.parseInt(value, 10);
+      if (!Number.isInteger(maxPages) || maxPages <= 0) {
+        throw new Error("--max-pages requires a positive integer");
+      }
+      flags.maxPages = maxPages;
+      i += 1;
     } else {
       flags.paths.push(arg);
     }
   }
   return flags;
 };
+
+const limitGeomPages = (geom: DocGeom, maxPages: number | undefined): DocGeom => {
+  if (maxPages === undefined) {
+    return geom;
+  }
+  return { ...geom, pages: geom.pages.slice(0, maxPages) };
+};
+
+const limitPaths = (paths: string[], maxPages: number | undefined): string[] =>
+  maxPages === undefined ? paths : paths.slice(0, maxPages);
 
 const isDirectory = async (candidate: string): Promise<boolean> => {
   try {
@@ -154,7 +190,10 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
 
       try {
         // oxlint-disable-next-line no-await-in-loop -- Word is a single-instance app; docs are exported one at a time
-        const wordGeom = await getWordTruth(doc, { refresh: flags.refreshTruth });
+        const wordGeom = limitGeomPages(
+          await getWordTruth(doc, { refresh: flags.refreshTruth }),
+          flags.maxPages,
+        );
 
         if (!extractor) {
           // oxlint-disable-next-line no-await-in-loop -- created lazily on first use, before any folio extraction
@@ -163,7 +202,7 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
 
         process.stderr.write("folio… ");
         // oxlint-disable-next-line no-await-in-loop -- the extractor shares one browser page across docs
-        const folio = await extractor.extract(doc);
+        const folio = await extractor.extract(doc, { maxPages: flags.maxPages });
 
         const result = compareGeoms(wordGeom, folio.geom);
 
@@ -180,7 +219,10 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
         const attributed = attributeDivergences(result, docFeatures);
 
         // oxlint-disable-next-line no-await-in-loop -- sequential per-doc pipeline
-        const wordPagePngs = await getWordPagePngs(doc);
+        const wordPagePngs = limitPaths(
+          await getWordPagePngs(doc, { maxPages: flags.maxPages }),
+          flags.maxPages,
+        );
 
         results.push(attributed);
         paragraphsByDoc.push(docFeatures.paragraphs);
@@ -273,6 +315,13 @@ const isFullyClean = (report: CorpusReport, failures: DocFailure[]): boolean =>
     (result) => result.score === PERFECT_SCORE && result.divergences.length === 0,
   );
 
+const writeJsonReport = async (report: CorpusReport, outputPath: string): Promise<string> => {
+  const resolved = path.resolve(outputPath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await Bun.write(resolved, `${JSON.stringify(report, null, 2)}\n`);
+  return resolved;
+};
+
 const main = async (argv: string[]): Promise<number> => {
   const flags = parseArgs(argv);
 
@@ -303,9 +352,14 @@ const main = async (argv: string[]): Promise<number> => {
     clusters,
   };
 
-  if (flags.json) {
+  if (flags.outputPath) {
+    const outputPath = await writeJsonReport(report, flags.outputPath);
+    console.error(`JSON: ${outputPath}`);
+  }
+
+  if (flags.json && !flags.outputPath) {
     console.log(JSON.stringify(report, null, 2));
-  } else {
+  } else if (!flags.json) {
     printHumanSummary(report, failures);
   }
 

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -447,6 +447,17 @@ const reconcileGap = ({
     const folioConcat = normalizeLineText(
       folioIdxs.map((idx) => folioFlat[idx]?.line.normText ?? "").join(" "),
     );
+    if (
+      wordIdxs.length === 1 &&
+      folioIdxs.length === 1 &&
+      stripSpaces(wordConcat) === stripSpaces(folioConcat)
+    ) {
+      const wordIdx = wordIdxs[0];
+      const folioIdx = folioIdxs[0];
+      if (wordIdx !== undefined && folioIdx !== undefined) {
+        return [{ kind: "match", wordIdx, folioIdx }];
+      }
+    }
     if (textSimilarity(wordConcat, folioConcat) >= CONCAT_THRESHOLD) {
       return [{ kind: "line-break", wordIdxs, folioIdxs }];
     }

--- a/parity/diffReport.ts
+++ b/parity/diffReport.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+/**
+ * Compare two parity JSON reports and print deterministic score/count deltas.
+ */
+import path from "node:path";
+
+import type { CorpusReport, DivergenceKind, FeatureAttributedResult } from "./types";
+
+type DiffFlags = {
+  before?: string;
+  after?: string;
+};
+
+type DocSummary = {
+  file: string;
+  score: number;
+  total: number;
+  counts: Partial<Record<DivergenceKind, number>>;
+};
+
+const KIND_ORDER: DivergenceKind[] = [
+  "page-count",
+  "pagination",
+  "missing-line",
+  "extra-line",
+  "line-break",
+  "text-mismatch",
+  "y-drift",
+  "x-drift",
+  "width-drift",
+];
+
+const usage = (): string =>
+  [
+    "Usage:",
+    "  bun parity/diffReport.ts before.json after.json",
+    "  bun parity/diffReport.ts --before before.json --after after.json",
+  ].join("\n");
+
+const parseArgs = (argv: string[]): DiffFlags => {
+  const flags: DiffFlags = {};
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--before") {
+      flags.before = argv[++i];
+    } else if (arg === "--after") {
+      flags.after = argv[++i];
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else {
+      positional.push(arg);
+    }
+  }
+  flags.before ??= positional[0];
+  flags.after ??= positional[1];
+  if (!flags.before || !flags.after) {
+    throw new Error("before and after report paths are required");
+  }
+  return flags;
+};
+
+const readReport = async (file: string): Promise<CorpusReport> => {
+  const report = (await Bun.file(path.resolve(file)).json()) as CorpusReport;
+  if (!Array.isArray(report.results)) {
+    throw new Error(`${file} is not a parity JSON report`);
+  }
+  return report;
+};
+
+const summarize = (result: FeatureAttributedResult): DocSummary => {
+  const counts: Partial<Record<DivergenceKind, number>> = {};
+  for (const divergence of result.divergences) {
+    counts[divergence.kind] = (counts[divergence.kind] ?? 0) + 1;
+  }
+  return {
+    file: result.file,
+    score: result.score,
+    total: result.divergences.length,
+    counts,
+  };
+};
+
+const delta = (after: number, before: number): string => {
+  const value = after - before;
+  if (value > 0) return `+${value}`;
+  return String(value);
+};
+
+const formatScoreDelta = (after: number, before: number): string => {
+  const value = after - before;
+  const fixed = value.toFixed(6);
+  return value > 0 ? `+${fixed}` : fixed;
+};
+
+const main = async (): Promise<void> => {
+  const flags = parseArgs(process.argv.slice(2));
+  const [before, after] = await Promise.all([readReport(flags.before!), readReport(flags.after!)]);
+  const beforeByFile = new Map(before.results.map((result) => [result.file, summarize(result)]));
+  const afterByFile = new Map(after.results.map((result) => [result.file, summarize(result)]));
+  const files = Array.from(new Set([...beforeByFile.keys(), ...afterByFile.keys()])).toSorted();
+
+  const docs = files.map((file) => {
+    const b = beforeByFile.get(file);
+    const a = afterByFile.get(file);
+    return {
+      file,
+      before: b,
+      after: a,
+      scoreDelta: b && a ? formatScoreDelta(a.score, b.score) : null,
+      totalDelta: b && a ? delta(a.total, b.total) : null,
+      counts: Object.fromEntries(
+        KIND_ORDER.map((kind) => {
+          const beforeCount = b?.counts[kind] ?? 0;
+          const afterCount = a?.counts[kind] ?? 0;
+          return [
+            kind,
+            {
+              before: beforeCount,
+              after: afterCount,
+              delta: delta(afterCount, beforeCount),
+            },
+          ];
+        }),
+      ),
+    };
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        before: path.resolve(flags.before!),
+        after: path.resolve(flags.after!),
+        docs,
+      },
+      null,
+      2,
+    ),
+  );
+};
+
+try {
+  await main();
+} catch (error) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(`parity diff failed: ${err.message}`);
+  console.error(usage());
+  process.exitCode = 2;
+}

--- a/parity/divergences.ts
+++ b/parity/divergences.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+/**
+ * Static parity-report slicer for agent diagnostics.
+ *
+ * Reads an existing `parity/cli.ts --json` report and prints a deterministic,
+ * filterable list of divergences plus ready-to-run follow-up commands. This
+ * avoids re-running Word/Folio when the next step is just choosing a target.
+ */
+import path from "node:path";
+
+import { normalizeLineText } from "./textNorm";
+import type { CorpusReport, Divergence, DivergenceKind } from "./types";
+
+type Flags = {
+  report?: string;
+  doc?: string;
+  page?: number;
+  kind?: DivergenceKind;
+  text?: string;
+  limit: number;
+};
+
+const KIND_ORDER: DivergenceKind[] = [
+  "page-count",
+  "pagination",
+  "missing-line",
+  "extra-line",
+  "line-break",
+  "text-mismatch",
+  "y-drift",
+  "x-drift",
+  "width-drift",
+];
+
+const usage = (): string =>
+  [
+    "Usage:",
+    "  bun parity/divergences.ts --report /tmp/run.json --page 3 --limit 20",
+    "  bun parity/divergences.ts --report /tmp/run.json --kind text-mismatch --text 'Schedule 1'",
+    "",
+    "Options:",
+    "  --report <path>     parity JSON report from parity/cli.ts --json",
+    "  --doc <path|name>    filter to one doc by absolute path or basename",
+    "  --page <n>          filter divergences by page",
+    "  --kind <kind>       filter by divergence kind",
+    "  --text <text>       substring filter after parity text normalization",
+    "  --limit <n>         max rows (default: 25)",
+  ].join("\n");
+
+const parseArgs = (argv: string[]): Flags => {
+  const flags: Flags = { limit: 25 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--report") {
+      flags.report = argv[++i];
+    } else if (arg === "--doc") {
+      flags.doc = argv[++i];
+    } else if (arg === "--page") {
+      flags.page = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--kind") {
+      const kind = argv[++i] as DivergenceKind | undefined;
+      if (!kind || !KIND_ORDER.includes(kind)) {
+        throw new Error(`--kind must be one of: ${KIND_ORDER.join(", ")}`);
+      }
+      flags.kind = kind;
+    } else if (arg === "--text") {
+      flags.text = argv[++i];
+    } else if (arg === "--limit") {
+      flags.limit = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else if (!flags.report) {
+      flags.report = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!flags.report) {
+    throw new Error("--report is required");
+  }
+  if (flags.page !== undefined && (!Number.isInteger(flags.page) || flags.page <= 0)) {
+    throw new Error("--page must be a positive integer");
+  }
+  if (!Number.isInteger(flags.limit) || flags.limit <= 0) {
+    throw new Error("--limit must be a positive integer");
+  }
+  return flags;
+};
+
+const readReport = async (file: string): Promise<CorpusReport> => {
+  const report = (await Bun.file(path.resolve(file)).json()) as CorpusReport;
+  if (!Array.isArray(report.results)) {
+    throw new Error(`${file} is not a parity JSON report`);
+  }
+  return report;
+};
+
+const divergencePage = (divergence: Divergence): number | undefined => {
+  switch (divergence.kind) {
+    case "page-count":
+      return undefined;
+    case "pagination":
+      return divergence.wordPage;
+    case "line-break":
+    case "missing-line":
+    case "extra-line":
+    case "x-drift":
+    case "y-drift":
+    case "width-drift":
+    case "text-mismatch":
+      return divergence.page;
+  }
+};
+
+const divergenceText = (divergence: Divergence): string => {
+  switch (divergence.kind) {
+    case "page-count":
+      return `word=${divergence.word} folio=${divergence.folio}`;
+    case "pagination":
+    case "missing-line":
+    case "extra-line":
+    case "x-drift":
+    case "y-drift":
+    case "width-drift":
+      return divergence.text;
+    case "line-break":
+      return `${divergence.wordTexts.join(" ")} | ${divergence.folioTexts.join(" ")}`;
+    case "text-mismatch":
+      return `${divergence.wordText} -> ${divergence.folioText}`;
+  }
+};
+
+const divergenceQueryText = (divergence: Divergence): string => {
+  switch (divergence.kind) {
+    case "page-count":
+      return divergenceText(divergence);
+    case "pagination":
+    case "missing-line":
+    case "extra-line":
+    case "x-drift":
+    case "y-drift":
+    case "width-drift":
+      return divergence.text;
+    case "line-break":
+      return divergence.wordTexts.join(" ");
+    case "text-mismatch":
+      return divergence.wordText;
+  }
+};
+
+const divergenceMagnitude = (divergence: Divergence): number | undefined => {
+  switch (divergence.kind) {
+    case "x-drift":
+    case "width-drift":
+      return divergence.deltaPt;
+    case "y-drift":
+      return divergence.residualPt;
+    default:
+      return undefined;
+  }
+};
+
+const matchesDoc = (file: string, filter: string | undefined): boolean => {
+  if (!filter) {
+    return true;
+  }
+  return file === path.resolve(filter) || path.basename(file) === filter;
+};
+
+const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
+
+const main = async (): Promise<void> => {
+  const flags = parseArgs(process.argv.slice(2));
+  const reportPath = path.resolve(flags.report!);
+  const report = await readReport(reportPath);
+  const textNeedle = flags.text ? normalizeLineText(flags.text).toLocaleLowerCase() : undefined;
+
+  const rows = report.results
+    .filter((result) => matchesDoc(result.file, flags.doc))
+    .flatMap((result) =>
+      result.divergences.map((divergence, index) => ({
+        doc: result.file,
+        index: index + 1,
+        page: divergencePage(divergence),
+        kind: divergence.kind,
+        text: divergenceText(divergence),
+        queryText: divergenceQueryText(divergence),
+        magnitudePt: divergenceMagnitude(divergence),
+      })),
+    )
+    .filter((row) => flags.page === undefined || row.page === flags.page)
+    .filter((row) => flags.kind === undefined || row.kind === flags.kind)
+    .filter(
+      (row) =>
+        textNeedle === undefined ||
+        normalizeLineText(row.text).toLocaleLowerCase().includes(textNeedle),
+    )
+    .toSorted(
+      (a, b) =>
+        (a.page ?? Number.MAX_SAFE_INTEGER) - (b.page ?? Number.MAX_SAFE_INTEGER) ||
+        KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind) ||
+        a.index - b.index,
+    );
+
+  const selected = rows.slice(0, flags.limit);
+  const counts: Partial<Record<DivergenceKind, number>> = {};
+  for (const row of rows) {
+    counts[row.kind] = (counts[row.kind] ?? 0) + 1;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        report: reportPath,
+        total: rows.length,
+        counts,
+        rows: selected.map((row) => ({
+          ...row,
+          inspectCommand:
+            row.page === undefined
+              ? undefined
+              : `bun parity/inspect.ts --doc ${shellQuote(row.doc)} --page ${row.page} --text ${shellQuote(row.queryText)} --max-pages ${row.page}`,
+          sourceTraceCommand: `bun parity/sourceTrace.ts --doc ${shellQuote(row.doc)} --text ${shellQuote(row.queryText)}`,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+};
+
+try {
+  await main();
+} catch (error) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(`parity divergences failed: ${err.message}`);
+  console.error(usage());
+  process.exitCode = 2;
+}

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -41,8 +41,12 @@ export class FolioExtractError extends Error {
 
 export type FolioExtraction = { geom: DocGeom; screenshotPaths: string[] };
 
+export type FolioExtractOptions = {
+  maxPages?: number;
+};
+
 export type FolioExtractor = {
-  extract: (docxPath: string) => Promise<FolioExtraction>;
+  extract: (docxPath: string, options?: FolioExtractOptions) => Promise<FolioExtraction>;
   close: () => Promise<void>;
 };
 
@@ -55,6 +59,7 @@ const SERVER_PROBE_TIMEOUT_MS = 2000;
 const SERVER_START_TIMEOUT_MS = 90_000;
 const SERVER_POLL_INTERVAL_MS = 500;
 
+const PLAYGROUND_NAVIGATION_TIMEOUT_MS = 120_000;
 const EDITOR_RENDER_TIMEOUT_MS = 20_000;
 const STABILITY_POLL_INTERVAL_MS = 250;
 const STABILITY_MAX_MS = 15_000;
@@ -322,6 +327,25 @@ const waitForEditorLayout = async (page: Page): Promise<void> => {
   await page.waitForTimeout(STABILITY_SETTLE_MS);
 };
 
+const installCleanScreenshotStyle = async (page: Page): Promise<void> => {
+  await page.addStyleTag({
+    content: `
+      .pg-collab-header,
+      [class*="toolbar" i],
+      [class*="ruler" i],
+      [style*="position: fixed"],
+      [style*="position: sticky"] {
+        visibility: hidden !important;
+      }
+
+      .layout-page,
+      .layout-page * {
+        visibility: visible !important;
+      }
+    `,
+  });
+};
+
 /** One `.layout-page` element's identity, listed before any scrolling so the
  * per-page extraction loop below knows what to visit and in what order. */
 type PageMeta = { domIndex: number; pageNumber: number };
@@ -368,7 +392,164 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
     const pageNumber = Number.isFinite(dataPageNumber) ? dataPageNumber : idx + 1;
 
     const lineEls = Array.from(el.querySelectorAll(".layout-line")) as HTMLElement[];
-    const lines = lineEls.map((lineEl) => {
+    const lines = lineEls.flatMap((lineEl) => {
+      const rectFor = (segmentEls: HTMLElement[]): DOMRect | null => {
+        let inkLeft = Number.POSITIVE_INFINITY;
+        let inkTop = Number.POSITIVE_INFINITY;
+        let inkRight = Number.NEGATIVE_INFINITY;
+        let inkBottom = Number.NEGATIVE_INFINITY;
+        for (const segmentEl of segmentEls) {
+          const segmentRect = segmentEl.getBoundingClientRect();
+          if (segmentRect.width <= 0 || segmentRect.height <= 0) continue;
+          inkLeft = Math.min(inkLeft, segmentRect.left);
+          inkTop = Math.min(inkTop, segmentRect.top);
+          inkRight = Math.max(inkRight, segmentRect.right);
+          inkBottom = Math.max(inkBottom, segmentRect.bottom);
+        }
+        return inkRight > inkLeft && inkBottom > inkTop
+          ? new DOMRect(inkLeft, inkTop, inkRight - inkLeft, inkBottom - inkTop)
+          : null;
+      };
+      const textRectFor = (segmentEls: HTMLElement[]): DOMRect | null => {
+        let inkLeft = Number.POSITIVE_INFINITY;
+        let inkTop = Number.POSITIVE_INFINITY;
+        let inkRight = Number.NEGATIVE_INFINITY;
+        let inkBottom = Number.NEGATIVE_INFINITY;
+        for (const segmentEl of segmentEls) {
+          const range = document.createRange();
+          range.selectNodeContents(segmentEl);
+          const segmentRect = range.getBoundingClientRect();
+          range.detach();
+          if (segmentRect.width <= 0 || segmentRect.height <= 0) continue;
+          inkLeft = Math.min(inkLeft, segmentRect.left);
+          inkTop = Math.min(inkTop, segmentRect.top);
+          inkRight = Math.max(inkRight, segmentRect.right);
+          inkBottom = Math.max(inkBottom, segmentRect.bottom);
+        }
+        return inkRight > inkLeft && inkBottom > inkTop
+          ? new DOMRect(inkLeft, inkTop, inkRight - inkLeft, inkBottom - inkTop)
+          : null;
+      };
+
+      const region = (() => {
+        if (lineEl.closest(".layout-page-header")) {
+          return "header";
+        }
+        if (lineEl.closest(".layout-page-footer")) {
+          return "footer";
+        }
+        return "body";
+      })();
+
+      const fontFrom = (sourceEl: HTMLElement | null) => {
+        if (!sourceEl) return {};
+        const computed = getComputedStyle(sourceEl);
+        const parsedSize = Number.parseFloat(computed.fontSize);
+        return {
+          fontFamilyRaw: computed.fontFamily,
+          ...(Number.isFinite(parsedSize) ? { fontSizePx: parsedSize } : {}),
+        };
+      };
+      const textFor = (sourceEl: HTMLElement): string => {
+        const text = sourceEl.textContent ?? "";
+        const computed = getComputedStyle(sourceEl);
+        if (
+          computed.textTransform === "uppercase" ||
+          computed.fontVariant.includes("small-caps")
+        ) {
+          return text.toLocaleUpperCase();
+        }
+        return text;
+      };
+
+      const toRawLine = (text: string, rect: DOMRect, sourceEl: HTMLElement | null) => ({
+        text,
+        rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
+        region,
+        ...fontFrom(sourceEl),
+      });
+
+      const markerEls = Array.from(lineEl.querySelectorAll(".layout-list-marker")) as HTMLElement[];
+      const runEls = Array.from(lineEl.querySelectorAll(".layout-run")) as HTMLElement[];
+      if (markerEls.length > 0 && runEls.length > 0) {
+        const markerRect = textRectFor(markerEls) ?? rectFor(markerEls);
+        const runsRect = rectFor(runEls);
+        const splitLines = [];
+        if (markerRect) {
+          splitLines.push(
+            toRawLine(
+              markerEls.map((markerEl) => textFor(markerEl)).join(""),
+              markerRect,
+              markerEls[0] ?? null,
+            ),
+          );
+        }
+        if (runsRect) {
+          splitLines.push(
+            toRawLine(runEls.map((runEl) => textFor(runEl)).join(""), runsRect, runEls[0] ?? null),
+          );
+        }
+        if (splitLines.length > 0) {
+          return splitLines;
+        }
+      }
+
+      const visualRunEls = Array.from(lineEl.children).filter(
+        (child): child is HTMLElement =>
+          child instanceof HTMLElement && child.classList.contains("layout-run"),
+      );
+      if (visualRunEls.some((runEl) => runEl.classList.contains("layout-run-tab"))) {
+        const segments: HTMLElement[][] = [];
+        let currentSegment: HTMLElement[] = [];
+        const flushSegment = () => {
+          if (currentSegment.length === 0) {
+            return;
+          }
+          segments.push(currentSegment);
+          currentSegment = [];
+        };
+
+        for (const runEl of visualRunEls) {
+          if (!runEl.classList.contains("layout-run-tab")) {
+            currentSegment.push(runEl);
+            continue;
+          }
+
+          const tabText = (runEl.textContent ?? "").replace(/[­​-‍﻿\s]/gu, "");
+          if (tabText.length > 0) {
+            currentSegment.push(runEl);
+            continue;
+          }
+
+          flushSegment();
+        }
+        flushSegment();
+
+        if (segments.length > 1) {
+          const splitLines = [];
+          for (const segment of segments) {
+            const segmentRect = rectFor(segment);
+            if (!segmentRect) {
+              continue;
+            }
+            const sourceEl =
+              segment.find((segmentEl) => !segmentEl.classList.contains("layout-run-tab")) ??
+              segment[0] ??
+              null;
+            splitLines.push(
+              toRawLine(
+                segment.map((segmentEl) => textFor(segmentEl)).join(""),
+                segmentRect,
+                sourceEl,
+              ),
+            );
+          }
+          if (splitLines.length > 0) {
+            return splitLines;
+          }
+        }
+      }
+
       // The `.layout-line` box spans the full column width regardless of where
       // the text ink actually sits (centered/right-aligned lines, table cells),
       // while the Word-side extractor reports glyph-ink bounds. Use the union
@@ -394,32 +575,14 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
       if (inkRight > inkLeft && inkBottom > inkTop) {
         rect = new DOMRect(inkLeft, inkTop, inkRight - inkLeft, inkBottom - inkTop);
       }
-      let region: "header" | "footer" | "body" = "body";
-      if (lineEl.closest(".layout-page-header")) {
-        region = "header";
-      } else if (lineEl.closest(".layout-page-footer")) {
-        region = "footer";
-      }
 
       const runEl = lineEl.querySelector(".layout-run");
-      let fontFamilyRaw: string | undefined;
-      let fontSizePx: number | undefined;
-      if (runEl) {
-        const computed = getComputedStyle(runEl);
-        fontFamilyRaw = computed.fontFamily;
-        const parsedSize = Number.parseFloat(computed.fontSize);
-        if (Number.isFinite(parsedSize)) {
-          fontSizePx = parsedSize;
-        }
-      }
 
-      return {
-        text: lineEl.textContent ?? "",
-        rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
-        region,
-        ...(fontFamilyRaw !== undefined ? { fontFamilyRaw } : {}),
-        ...(fontSizePx !== undefined ? { fontSizePx } : {}),
-      };
+      const text =
+        segmentEls.length > 0
+          ? segmentEls.map((segmentEl) => textFor(segmentEl)).join("")
+          : textFor(lineEl);
+      return [toRawLine(text, rect, runEl)];
     });
 
     return {
@@ -501,7 +664,10 @@ export const createFolioExtractor = async (
   });
   const page = await context.newPage();
 
-  const extract = async (docxPath: string): Promise<FolioExtraction> => {
+  const extract = async (
+    docxPath: string,
+    options: FolioExtractOptions = {},
+  ): Promise<FolioExtraction> => {
     const absoluteDocxPath = path.resolve(docxPath);
     const docxBuffer = await fs.readFile(absoluteDocxPath);
     const sha256 = createHash("sha256").update(docxBuffer).digest("hex");
@@ -512,6 +678,7 @@ export const createFolioExtractor = async (
     try {
       await page.goto(`${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`, {
         waitUntil: "domcontentloaded",
+        timeout: PLAYGROUND_NAVIGATION_TIMEOUT_MS,
       });
       await waitForEditorLayout(page);
 
@@ -519,6 +686,9 @@ export const createFolioExtractor = async (
       if (pageMeta.length === 0) {
         throw new FolioExtractError(`folio rendered zero pages for ${absoluteDocxPath}`);
       }
+      await installCleanScreenshotStyle(page);
+      const pagesToExtract =
+        options.maxPages === undefined ? pageMeta : pageMeta.slice(0, options.maxPages);
 
       // Large documents virtualize: pages scroll into (and back out of) a
       // populated state as an IntersectionObserver crosses them, so each
@@ -530,7 +700,7 @@ export const createFolioExtractor = async (
       await fs.mkdir(screenshotDir, { recursive: true });
       const rawPages: RawPage[] = [];
       const screenshotPaths: string[] = [];
-      for (const { domIndex, pageNumber } of pageMeta) {
+      for (const { domIndex, pageNumber } of pagesToExtract) {
         const locator = page.locator(PAGE_SELECTOR).nth(domIndex);
         await locator.scrollIntoViewIfNeeded();
         await waitForLayoutStability(page);

--- a/parity/inspect.ts
+++ b/parity/inspect.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env bun
+/**
+ * Deterministic parity inspector for one document/page/text.
+ *
+ * This is intentionally outside the HTML report path: it gives an agent a
+ * small, stable JSON artifact for a single question instead of forcing manual
+ * screenshot reading from the aggregate report.
+ */
+import path from "node:path";
+
+import { compareGeoms, mergeVisualRows } from "./compare";
+import { createFolioExtractor } from "./folioExtract";
+import { getWordPagePngs, getWordTruth } from "./wordTruth";
+import { normalizeLineText, textSimilarity } from "./textNorm";
+import type { DocGeom, LineBox, PageGeom } from "./types";
+
+type InspectFlags = {
+  doc?: string;
+  page: number;
+  text?: string;
+  maxPages?: number;
+  ledger: boolean;
+  limit: number;
+};
+
+type Candidate = {
+  rank: number;
+  similarity: number;
+  lineIndex: number;
+  line: LineBox;
+};
+
+type LedgerRow = {
+  index: number;
+  wordText?: string;
+  folioText?: string;
+  similarity?: number;
+  wordY?: number;
+  folioY?: number;
+  deltaY?: number;
+  wordX?: number;
+  folioX?: number;
+  deltaX?: number;
+  wordWidth?: number;
+  folioWidth?: number;
+  deltaWidth?: number;
+};
+
+type FolioExtractResult = Awaited<ReturnType<Awaited<ReturnType<typeof createFolioExtractor>>["extract"]>>;
+
+const usage = (): string =>
+  [
+    "Usage:",
+    "  bun parity/inspect.ts --doc file.docx --page 1 --text 'Definitions'",
+    "  bun parity/inspect.ts --doc file.docx --page 1 --ledger --max-pages 3",
+    "",
+    "Options:",
+    "  --doc <path>        DOCX to inspect",
+    "  --page <n>          1-based page number (default: 1)",
+    "  --text <text>       line text to search for",
+    "  --max-pages <n>     cap Folio extraction",
+    "  --ledger            include index-by-index page ledger",
+    "  --limit <n>         candidate count per side (default: 5)",
+  ].join("\n");
+
+const parseArgs = (argv: string[]): InspectFlags => {
+  const flags: InspectFlags = { page: 1, ledger: false, limit: 5 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--doc") {
+      flags.doc = argv[++i];
+    } else if (arg === "--page") {
+      flags.page = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--text") {
+      flags.text = argv[++i];
+    } else if (arg === "--max-pages") {
+      flags.maxPages = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--ledger") {
+      flags.ledger = true;
+    } else if (arg === "--limit") {
+      flags.limit = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else if (!flags.doc) {
+      flags.doc = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!flags.doc) {
+    throw new Error("--doc is required");
+  }
+  if (!Number.isInteger(flags.page) || flags.page <= 0) {
+    throw new Error("--page must be a positive integer");
+  }
+  if (flags.maxPages !== undefined && (!Number.isInteger(flags.maxPages) || flags.maxPages <= 0)) {
+    throw new Error("--max-pages must be a positive integer");
+  }
+  if (!Number.isInteger(flags.limit) || flags.limit <= 0) {
+    throw new Error("--limit must be a positive integer");
+  }
+  return flags;
+};
+
+const pageLines = (geom: DocGeom, pageNumber: number): LineBox[] => {
+  const page = geom.pages.find((candidate) => candidate.number === pageNumber);
+  return page ? mergeVisualRows(page.lines) : [];
+};
+
+const pageInfo = (geom: DocGeom, pageNumber: number): PageGeom | undefined =>
+  geom.pages.find((candidate) => candidate.number === pageNumber);
+
+const candidatesFor = (lines: LineBox[], text: string, limit: number): Candidate[] => {
+  const needle = normalizeLineText(text);
+  return lines
+    .map((line, index) => {
+      const contains = line.normText.includes(needle) || needle.includes(line.normText);
+      const similarity = contains ? 1 : textSimilarity(needle, line.normText);
+      return { rank: 0, similarity, lineIndex: index + 1, line };
+    })
+    .toSorted((a, b) => b.similarity - a.similarity || a.lineIndex - b.lineIndex)
+    .slice(0, limit)
+    .map((candidate, index) => ({ ...candidate, rank: index + 1 }));
+};
+
+const round = (value: number | undefined): number | undefined =>
+  value === undefined ? undefined : Number(value.toFixed(3));
+
+const ledgerFor = (wordLines: LineBox[], folioLines: LineBox[]): LedgerRow[] => {
+  const max = Math.max(wordLines.length, folioLines.length);
+  const rows: LedgerRow[] = [];
+  for (let i = 0; i < max; i++) {
+    const word = wordLines[i];
+    const folio = folioLines[i];
+    rows.push({
+      index: i + 1,
+      ...(word ? { wordText: word.text, wordY: round(word.yPt), wordX: round(word.xPt), wordWidth: round(word.widthPt) } : {}),
+      ...(folio
+        ? {
+            folioText: folio.text,
+            folioY: round(folio.yPt),
+            folioX: round(folio.xPt),
+            folioWidth: round(folio.widthPt),
+          }
+        : {}),
+      ...(word && folio
+        ? {
+            similarity: round(textSimilarity(word.normText, folio.normText)),
+            deltaY: round(folio.yPt - word.yPt),
+            deltaX: round(folio.xPt - word.xPt),
+            deltaWidth: round(folio.widthPt - word.widthPt),
+          }
+        : {}),
+    });
+  }
+  return rows;
+};
+
+const main = async (): Promise<void> => {
+  const flags = parseArgs(process.argv.slice(2));
+  const doc = path.resolve(flags.doc!);
+  const maxPages = flags.maxPages ?? Math.max(flags.page, 1);
+
+  const wordGeom = await getWordTruth(doc, {});
+  const extractor = await createFolioExtractor();
+  let folio: FolioExtractResult;
+  try {
+    folio = await extractor.extract(doc, { maxPages });
+  } finally {
+    await extractor.close();
+  }
+
+  const limitedWordGeom = { ...wordGeom, pages: wordGeom.pages.slice(0, maxPages) };
+  const comparison = compareGeoms(limitedWordGeom, folio.geom);
+  const wordLines = pageLines(wordGeom, flags.page);
+  const folioLines = pageLines(folio.geom, flags.page);
+  const wordPage = pageInfo(wordGeom, flags.page);
+  const folioPage = pageInfo(folio.geom, flags.page);
+  const wordPngs = await getWordPagePngs(doc, { maxPages });
+  const counts: Record<string, number> = {};
+  for (const divergence of comparison.divergences) {
+    counts[divergence.kind] = (counts[divergence.kind] ?? 0) + 1;
+  }
+
+  const result = {
+    doc,
+    page: flags.page,
+    score: comparison.score,
+    counts,
+    pages: {
+      word: wordPage && { widthPt: wordPage.widthPt, heightPt: wordPage.heightPt, lines: wordLines.length },
+      folio: folioPage && { widthPt: folioPage.widthPt, heightPt: folioPage.heightPt, lines: folioLines.length },
+    },
+    assets: {
+      wordPng: wordPngs[flags.page - 1],
+      folioPng: folio.screenshotPaths[flags.page - 1],
+    },
+    ...(flags.text
+      ? {
+          query: flags.text,
+          wordCandidates: candidatesFor(wordLines, flags.text, flags.limit),
+          folioCandidates: candidatesFor(folioLines, flags.text, flags.limit),
+        }
+      : {}),
+    ...(flags.ledger ? { ledger: ledgerFor(wordLines, folioLines) } : {}),
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+};
+
+try {
+  await main();
+} catch (error) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(`parity inspect failed: ${err.message}`);
+  console.error(usage());
+  process.exitCode = 2;
+}

--- a/parity/sourceTrace.ts
+++ b/parity/sourceTrace.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env bun
+/**
+ * Static source-pipeline trace for one text query.
+ *
+ * Parses a DOCX and searches the parsed document model, ProseMirror document,
+ * and FlowBlock conversion output. It does not render Word or Folio. The goal
+ * is a deterministic causal-chain artifact for a divergence's source data.
+ */
+import path from "node:path";
+
+import type { Node as PMNode } from "prosemirror-model";
+
+import { parseDocx } from "../packages/core/src/docx/parser";
+import { toFlowBlocks } from "../packages/core/src/layout-bridge/convert/toFlowBlocks";
+import type { FlowBlock, Run } from "../packages/core/src/layout-engine/types";
+import { toProseDoc } from "../packages/core/src/prosemirror/conversion/toProseDoc";
+import { normalizeLineText } from "./textNorm";
+
+type Flags = {
+  doc?: string;
+  text?: string;
+  limit: number;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+const usage = (): string =>
+  [
+    "Usage:",
+    "  bun parity/sourceTrace.ts --doc file.docx --text 'Optional Currencies'",
+    "",
+    "Options:",
+    "  --doc <path>      DOCX to parse",
+    "  --text <text>     normalized substring to search",
+    "  --limit <n>       max matches per layer (default: 8)",
+  ].join("\n");
+
+const parseArgs = (argv: string[]): Flags => {
+  const flags: Flags = { limit: 8 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--doc") {
+      flags.doc = argv[++i];
+    } else if (arg === "--text") {
+      flags.text = argv[++i];
+    } else if (arg === "--limit") {
+      flags.limit = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else if (!flags.doc) {
+      flags.doc = arg;
+    } else if (!flags.text) {
+      flags.text = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!flags.doc) {
+    throw new Error("--doc is required");
+  }
+  if (!flags.text) {
+    throw new Error("--text is required");
+  }
+  if (!Number.isInteger(flags.limit) || flags.limit <= 0) {
+    throw new Error("--limit must be a positive integer");
+  }
+  return flags;
+};
+
+const truncate = (value: string, max = 240): string =>
+  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const pickFormatting = (value: unknown): unknown => {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const keys = [
+    "styleId",
+    "alignment",
+    "spacing",
+    "spacingExplicit",
+    "indentLeft",
+    "indentFirstLine",
+    "hangingIndent",
+    "tabs",
+    "runProperties",
+    "numPr",
+    "pageBreakBefore",
+    "keepNext",
+    "keepLines",
+    "outlineLevel",
+  ];
+  return Object.fromEntries(keys.flatMap((key) => (key in value ? [[key, value[key]]] : [])));
+};
+
+const textFromDocContent = (content: unknown): string => {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  let text = "";
+  for (const item of content) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    if (item["type"] === "run") {
+      text += textFromDocContent(item["content"]);
+    } else if (item["type"] === "text" && typeof item["text"] === "string") {
+      text += item["text"];
+    } else if (
+      (item["type"] === "complexField" || item["type"] === "simpleField") &&
+      Array.isArray(item["fieldResult"])
+    ) {
+      text += textFromDocContent(item["fieldResult"]);
+    } else if (item["type"] === "simpleField" && Array.isArray(item["content"])) {
+      text += textFromDocContent(item["content"]);
+    } else if (item["type"] === "tab") {
+      text += "\t";
+    }
+  }
+  return text;
+};
+
+const summarizeDocContent = (content: unknown): unknown[] => {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.flatMap((item): unknown[] => {
+    if (!isRecord(item)) {
+      return [];
+    }
+    const type = item["type"];
+    if (type === "run") {
+      return summarizeDocContent(item["content"]);
+    }
+    if (type === "text") {
+      return [{ type, text: truncate(String(item["text"] ?? "")) }];
+    }
+    if (type === "tab") {
+      return [{ type }];
+    }
+    if (type === "complexField" || type === "simpleField") {
+      return [
+        {
+          type,
+          fieldType: item["fieldType"],
+          instruction: item["instruction"],
+          resultText: truncate(textFromDocContent(item["fieldResult"] ?? item["content"])),
+          fldLock: item["fldLock"],
+          dirty: item["dirty"],
+        },
+      ];
+    }
+    return [{ type }];
+  });
+};
+
+const pmMarks = (node: PMNode): unknown[] =>
+  node.marks.map((mark) => ({ type: mark.type.name, attrs: mark.attrs }));
+
+const summarizePmChild = (node: PMNode, pos: number): unknown => ({
+  pos,
+  type: node.type.name,
+  text: node.isText ? truncate(node.text ?? "") : undefined,
+  attrs: node.attrs,
+  marks: pmMarks(node),
+});
+
+const summarizeRun = (run: Run): unknown => {
+  const base = {
+    kind: run.kind,
+    pmStart: run.pmStart,
+    pmEnd: run.pmEnd,
+    fontFamily: "fontFamily" in run ? run.fontFamily : undefined,
+    fontSize: "fontSize" in run ? run.fontSize : undefined,
+    bold: "bold" in run ? run.bold : undefined,
+    allCaps: "allCaps" in run ? run.allCaps : undefined,
+    smallCaps: "smallCaps" in run ? run.smallCaps : undefined,
+  };
+  if (run.kind === "text") {
+    return { ...base, text: truncate(run.text) };
+  }
+  if (run.kind === "field") {
+    return {
+      ...base,
+      fieldType: run.fieldType,
+      instruction: run.instruction,
+      fallback: run.fallback,
+      fldLock: run.fldLock,
+    };
+  }
+  if (run.kind === "tab") {
+    return base;
+  }
+  if (run.kind === "lineBreak") {
+    return base;
+  }
+  if (run.kind === "image") {
+    return { ...base, width: run.width, height: run.height, wrapType: run.wrapType };
+  }
+  if (run.kind === "math") {
+    return { ...base, plainText: run.plainText };
+  }
+  return base;
+};
+
+const blockText = (block: FlowBlock): string => {
+  if (block.kind === "paragraph") {
+    return block.runs
+      .map((run) => {
+        if (run.kind === "text") return run.text;
+        if (run.kind === "field") return run.fallback ?? "";
+        if (run.kind === "tab") return "\t";
+        return "";
+      })
+      .join("");
+  }
+  if (block.kind === "table") {
+    return block.rows
+      .flatMap((row) => row.cells)
+      .flatMap((cell) => cell.blocks)
+      .map(blockText)
+      .join(" ");
+  }
+  return "";
+};
+
+const normalizedSearchText = (value: string): string => normalizeLineText(value).toLocaleLowerCase();
+
+const main = async (): Promise<void> => {
+  const flags = parseArgs(process.argv.slice(2));
+  const docPath = path.resolve(flags.doc!);
+  const needle = normalizedSearchText(flags.text!);
+  const parsed = await parseDocx(await Bun.file(docPath).arrayBuffer(), {
+    preloadFonts: false,
+    detectVariables: false,
+  });
+  const pmDoc = toProseDoc(parsed, {
+    styles: parsed.package.styles,
+    theme: parsed.package.theme,
+  });
+  const flowBlocks = toFlowBlocks(pmDoc, {
+    styles: parsed.package.styles,
+    theme: parsed.package.theme,
+  });
+
+  const docMatches: unknown[] = [];
+  for (const [index, block] of parsed.package.document.content.entries()) {
+    if (!isRecord(block)) {
+      continue;
+    }
+    const text = textFromDocContent(block["content"]);
+    if (!normalizedSearchText(text).includes(needle)) {
+      continue;
+    }
+    docMatches.push({
+      index,
+      type: block["type"],
+      text: truncate(text),
+      formatting: pickFormatting(block["formatting"]),
+      content: summarizeDocContent(block["content"]),
+    });
+    if (docMatches.length >= flags.limit) {
+      break;
+    }
+  }
+
+  const pmMatches: unknown[] = [];
+  pmDoc.descendants((node, pos) => {
+    if (pmMatches.length >= flags.limit || node.type.name !== "paragraph") {
+      return undefined;
+    }
+    if (!normalizedSearchText(node.textContent).includes(needle)) {
+      return undefined;
+    }
+    const children: unknown[] = [];
+    node.descendants((child, childPos) => {
+      if (child.isText || child.type.name === "field" || child.type.name === "tab") {
+        children.push(summarizePmChild(child, pos + 1 + childPos));
+      }
+      return undefined;
+    });
+    pmMatches.push({
+      pos,
+      text: truncate(node.textContent),
+      attrs: node.attrs,
+      children,
+    });
+    return undefined;
+  });
+
+  const flowMatches = flowBlocks
+    .map((block, index) => ({ block, index, text: blockText(block) }))
+    .filter(({ text }) => normalizedSearchText(text).includes(needle))
+    .slice(0, flags.limit)
+    .map(({ block, index, text }) => ({
+      index,
+      id: "id" in block ? block.id : undefined,
+      kind: block.kind,
+      text: truncate(text),
+      attrs: block.kind === "paragraph" ? block.attrs : undefined,
+      runs: block.kind === "paragraph" ? block.runs.map(summarizeRun) : undefined,
+    }));
+
+  console.log(
+    JSON.stringify(
+      {
+        doc: docPath,
+        query: flags.text,
+        normalizedQuery: needle,
+        counts: {
+          documentMatches: docMatches.length,
+          pmMatches: pmMatches.length,
+          flowMatches: flowMatches.length,
+        },
+        documentMatches: docMatches,
+        pmMatches,
+        flowMatches,
+      },
+      null,
+      2,
+    ),
+  );
+};
+
+try {
+  await main();
+} catch (error) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(`parity source trace failed: ${err.message}`);
+  console.error(usage());
+  process.exitCode = 2;
+}

--- a/parity/textNorm.ts
+++ b/parity/textNorm.ts
@@ -9,6 +9,8 @@ export const normalizeLineText = (text: string): string =>
   text
     .normalize("NFC")
     .replace(/[­​-‍﻿]/gu, "")
+    .replace(/\uf0e3/gu, "ã")
+    .replace(/\s*\.{3,}\s*/gu, " … ")
     .replace(/\s+/gu, " ")
     .trim();
 

--- a/parity/wordTruth.ts
+++ b/parity/wordTruth.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 
 import { CACHE_DIR } from "./config";
 import { parseStextXml } from "./stextParse";
+import { normalizeLineText } from "./textNorm";
 import type { DocGeom } from "./types";
 
 const WORD_APP_PATH = "/Applications/Microsoft Word.app";
@@ -215,7 +216,14 @@ const readCachedGeom = async (geomPath: string, absDocxPath: string): Promise<Do
   const file = Bun.file(geomPath);
   if (!(await file.exists())) return null;
   const geom = (await file.json()) as DocGeom;
-  return { ...geom, file: absDocxPath };
+  return {
+    ...geom,
+    file: absDocxPath,
+    pages: geom.pages.map((page) => ({
+      ...page,
+      lines: page.lines.map((line) => ({ ...line, normText: normalizeLineText(line.text) })),
+    })),
+  };
 };
 
 /** Word ground truth for `docxPath`: exports via Word, extracts geometry via
@@ -288,9 +296,23 @@ const pageNumberOfPngName = (filename: string): number => {
   return match?.[1] === undefined ? 0 : Number(match[1]);
 };
 
-const renderPagePngs = async (pdfPath: string, pagesDir: string): Promise<void> => {
+const renderPagePngs = async (
+  pdfPath: string,
+  pagesDir: string,
+  options: { maxPages?: number } = {},
+): Promise<void> => {
+  const pageRange = options.maxPages === undefined ? [] : [`1-${options.maxPages}`];
   const proc = Bun.spawn(
-    ["mutool", "draw", "-r", String(PNG_DPI), "-o", path.join(pagesDir, "p%d.png"), pdfPath],
+    [
+      "mutool",
+      "draw",
+      "-r",
+      String(PNG_DPI),
+      "-o",
+      path.join(pagesDir, "p%d.png"),
+      pdfPath,
+      ...pageRange,
+    ],
     { stdout: "pipe", stderr: "pipe" },
   );
   const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
@@ -305,7 +327,10 @@ const renderPagePngs = async (pdfPath: string, pagesDir: string): Promise<void> 
 /** Absolute paths of the cached per-page PNGs for `docxPath`, in page order,
  * rendering them from the cached `word.pdf` (via `getWordTruth`, if needed)
  * at 96dpi on first use. */
-export const getWordPagePngs = async (docxPath: string): Promise<string[]> => {
+export const getWordPagePngs = async (
+  docxPath: string,
+  options: { maxPages?: number } = {},
+): Promise<string[]> => {
   const absDocxPath = path.resolve(docxPath);
   const sha256 = await sha256OfFile(absDocxPath);
   const dir = cacheDirFor(sha256);
@@ -319,8 +344,12 @@ export const getWordPagePngs = async (docxPath: string): Promise<string[]> => {
   await mkdir(pagesDir, { recursive: true });
 
   const existing = await listPagePngs(pagesDir);
-  if (existing.length > 0) return existing;
+  if (options.maxPages !== undefined && existing.length >= options.maxPages) {
+    return existing.slice(0, options.maxPages);
+  }
+  if (options.maxPages === undefined && existing.length > 0) return existing;
 
-  await renderPagePngs(pdfPath, pagesDir);
-  return await listPagePngs(pagesDir);
+  await renderPagePngs(pdfPath, pagesDir, options);
+  const rendered = await listPagePngs(pagesDir);
+  return options.maxPages === undefined ? rendered : rendered.slice(0, options.maxPages);
 };


### PR DESCRIPTION
## Summary
- tighten imported DOCX layout parity around table rows, table-cell paragraph spacing, header/footer margins, field fallback rendering, and font handling
- add deterministic visual parity diagnostics, divergence slicing, before/after report comparison, and JSON output support
- add focused regression coverage for the layout and parity cases

## Verification
- bun test src/layout-engine/measure/measureBlocks.test.ts src/layout-engine/measure/measureParagraph.test.ts src/layout-engine/paginator.test.ts src/layout-engine/paragraphSplitWithSpaceBefore.test.ts src/layout-bridge/convert/headerFooterLayout.test.ts src/paged-layout/headerFooterMargins.test.ts src/layout-painter/renderPage.test.ts src/layout-painter/renderTableFragment.test.ts src/layout-painter/renderParagraph-right-tab.test.ts src/prosemirror/conversion/toProseDoc.test.ts src/utils/fontResolver.test.ts
- bun test parity/__tests__/cli.test.ts parity/__tests__/compare.test.ts parity/__tests__/textNorm.test.ts parity/__tests__/folioExtract.test.ts
- bun run typecheck
- bun run lint
- bun run changeset:check
- bun audit
- bun parity/cli.ts /Users/sok0/coding_projects/msword-xml-parser/rooka-word-parser/tests/data/DOCX/lma.docx --max-pages 3 --output /tmp/lma-pr-smoke.json --no-report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hidden table rows now properly rendered with zero height.
  * Even/odd headers and footers can be applied per section.
  * Improved justified paragraph text fitting and wrapping.
  * Added parity diagnostic tools for layout validation.

* **Bug Fixes**
  * Fixed table cell paragraph spacing and layout in rendered output.
  * Header/footer trailing empty paragraphs no longer affect margin extension.
  * Non-live fields now correctly use cached fallback text.
  * Paragraph spacing now additive instead of collapsing.
  * TOC paragraph formatting no longer inherited to generated field text.
  * Table row measurement improved for cells with inline images.
  * Font support added for CG Times variant.

* **Tests**
  * Expanded test coverage for new features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->