### PR TITLE
fix: add parity cli help

### DIFF
--- a/parity/__tests__/cli.test.ts
+++ b/parity/__tests__/cli.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, test } from "bun:test";
 import { parseArgs } from "../cli";
 
 describe("parity CLI args", () => {
+  test("parses --help without treating it as an input document", () => {
+    const flags = parseArgs(["--help"]);
+
+    expect(flags.help).toBe(true);
+    expect(flags.paths).toEqual([]);
+  });
+
   test("parses an explicit JSON output path without treating it as an input document", () => {
     const flags = parseArgs(["fixture.docx", "--max-pages", "3", "--output", "/tmp/out.json"]);
 

--- a/parity/__tests__/cli.test.ts
+++ b/parity/__tests__/cli.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, test } from "bun:test";
 import { parseArgs } from "../cli";
 
 describe("parity CLI args", () => {
-  test("parses --help without treating it as an input document", () => {
-    const flags = parseArgs(["--help"]);
+  test("parses --help and -h without treating them as input documents", () => {
+    for (const arg of ["--help", "-h"]) {
+      const flags = parseArgs([arg]);
 
-    expect(flags.help).toBe(true);
-    expect(flags.paths).toEqual([]);
+      expect(flags.help).toBe(true);
+      expect(flags.paths).toEqual([]);
+    }
   });
 
   test("parses an explicit JSON output path without treating it as an input document", () => {

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -5,6 +5,7 @@
  * Usage:
  *   bun parity/cli.ts                          # full default corpus, HTML report
  *   bun parity/cli.ts path/to/file.docx        # one document
+ *   bun parity/cli.ts --help                   # print usage
  *   bun parity/cli.ts some/dir --json          # machine-readable output
  *   bun parity/cli.ts path/to/file.docx --output parity.json
  *   bun parity/cli.ts --refresh-truth          # ignore cached Word exports
@@ -53,6 +54,7 @@ const DOCX_GLOB = "**/*.docx";
 const isRealDocxName = (name: string): boolean => !name.startsWith("~$") && !name.startsWith(".");
 
 type CliFlags = {
+  help: boolean;
   json: boolean;
   refreshTruth: boolean;
   headed: boolean;
@@ -64,6 +66,7 @@ type CliFlags = {
 
 export const parseArgs = (argv: string[]): CliFlags => {
   const flags: CliFlags = {
+    help: false,
     json: false,
     refreshTruth: false,
     headed: false,
@@ -72,7 +75,9 @@ export const parseArgs = (argv: string[]): CliFlags => {
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === "--json") {
+    if (arg === "--help" || arg === "-h") {
+      flags.help = true;
+    } else if (arg === "--json") {
       flags.json = true;
     } else if (arg === "--refresh-truth") {
       flags.refreshTruth = true;
@@ -101,6 +106,25 @@ export const parseArgs = (argv: string[]): CliFlags => {
   }
   return flags;
 };
+
+const HELP_TEXT = `Word rendering parity engine
+
+Usage:
+  bun parity/cli.ts [doc-or-dir ...] [options]
+
+Options:
+  -h, --help           Print this help and exit.
+  --json               Print the machine-readable report to stdout.
+  --output <path>      Write the JSON report to a file.
+  --max-pages <n>      Compare only the first n pages.
+  --refresh-truth      Re-render Word ground truth instead of using cache.
+  --headed             Show the Folio browser window.
+  --no-report          Skip writing the HTML report.
+
+Examples:
+  bun parity/cli.ts path/to/file.docx --max-pages 20
+  bun parity/cli.ts some/dir --json --output /tmp/parity.json
+`;
 
 const limitGeomPages = (geom: DocGeom, maxPages: number | undefined): DocGeom => {
   if (maxPages === undefined) {
@@ -324,6 +348,11 @@ const writeJsonReport = async (report: CorpusReport, outputPath: string): Promis
 
 const main = async (argv: string[]): Promise<number> => {
   const flags = parseArgs(argv);
+
+  if (flags.help) {
+    console.log(HELP_TEXT);
+    return EXIT_OK;
+  }
 
   if (!(await isWordAvailable())) {
     console.error(


### PR DESCRIPTION
## Summary
- add -h/--help handling to the visual parity CLI
- exit before Word/document setup when help is requested
- cover help parsing so it is not treated as an input document

## Verification
- bun parity/cli.ts --help
- bun test parity/__tests__/cli.test.ts
- bun run lint
- bun run typecheck
- bun audit