### PR TITLE
fix: improve legal template visual parity

### DIFF
--- a/.changeset/fix-postmoney-parity.md
+++ b/.changeset/fix-postmoney-parity.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Improve Word parity for leading tabs and justified paragraph wrapping.
+Improve Word parity for legal-template tabs, justified shrink, paragraph spacing collapse, and widow-controlled splits.

--- a/.changeset/fix-postmoney-parity.md
+++ b/.changeset/fix-postmoney-parity.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Improve Word parity for leading tabs and justified paragraph wrapping.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -553,6 +553,7 @@ export type ParagraphAttrs = {
     indent?: ParagraphIndent;
     keepNext?: boolean;
     keepLines?: boolean;
+    widowControl?: boolean;
     pageBreakBefore?: boolean;
     styleId?: string;
     contextualSpacing?: boolean;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -220,7 +220,8 @@ export type ParagraphAttrs = {
     pageBreakBefore?: boolean; /** Word's cached rendered-page-break marker; preserved for round-trip only. */
     renderedPageBreakBefore?: boolean;
     keepNext?: boolean;
-    keepLines?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */
+    keepLines?: boolean;
+    widowControl?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */
     contextualSpacing?: boolean;
     defaultTextFormatting?: import__stll_docx_core_model.TextFormatting;
     sectionBreakType?: "nextPage" | "continuous" | "oddPage" | "evenPage";

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -329,7 +329,8 @@ export type ParagraphAttrs = {
     pageBreakBefore?: boolean; /** Word's cached rendered-page-break marker; preserved for round-trip only. */
     renderedPageBreakBefore?: boolean;
     keepNext?: boolean;
-    keepLines?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */
+    keepLines?: boolean;
+    widowControl?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */
     contextualSpacing?: boolean;
     defaultTextFormatting?: import__stll_docx_core_model.TextFormatting;
     sectionBreakType?: "nextPage" | "continuous" | "oddPage" | "evenPage";

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -1034,9 +1034,9 @@ describe("Layout Engine - Contextual Spacing", () => {
     const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
     const frags = layout.pages[0].fragments;
-    // Gap = spaceAfter + spaceBefore = 18 (Word-style additive spacing)
+    // Gap = max(spaceAfter, spaceBefore) = 13 (Word-style collapsed spacing)
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(18);
+    expect(gap).toBe(13);
   });
 
   test("does NOT suppress spacing when styles differ", () => {
@@ -1062,9 +1062,9 @@ describe("Layout Engine - Contextual Spacing", () => {
 
     const frags = layout.pages[0].fragments;
     // Different styles — spacing should NOT be suppressed
-    // gap = spaceAfter + spaceBefore = 18
+    // gap = max(spaceAfter, spaceBefore) = 13
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(18);
+    expect(gap).toBe(13);
   });
 
   test("does NOT suppress when only one paragraph has contextualSpacing", () => {
@@ -1089,9 +1089,9 @@ describe("Layout Engine - Contextual Spacing", () => {
     const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
     const frags = layout.pages[0].fragments;
-    // gap = spaceAfter + spaceBefore = 18
+    // gap = max(spaceAfter, spaceBefore) = 13
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(18);
+    expect(gap).toBe(13);
   });
 
   test("suppresses spacing in a chain of 3+ same-style paragraphs", () => {
@@ -1170,18 +1170,18 @@ describe("Layout Engine - Contextual Spacing", () => {
     expect(frags.length).toBe(4);
 
     // Gap between Normal and Bullet 1 — Normal has no contextualSpacing, so
-    // gap = spaceAfter + spaceBefore = 18
+    // gap = max(spaceAfter, spaceBefore) = 13
     const gap0to1 = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap0to1).toBe(18);
+    expect(gap0to1).toBe(13);
 
     // Gap between Bullet 1 and Bullet 2 — both contextual, same style → suppressed
     const gap1to2 = frags[2].y - (frags[1].y + frags[1].height);
     expect(gap1to2).toBe(0);
 
     // Gap between Bullet 2 and Normal 2 — Normal 2 has no contextualSpacing
-    // gap = spaceAfter + spaceBefore = 18
+    // gap = max(spaceAfter, spaceBefore) = 13
     const gap2to3 = frags[3].y - (frags[2].y + frags[2].height);
-    expect(gap2to3).toBe(18);
+    expect(gap2to3).toBe(13);
   });
 
   test("does NOT suppress when styleId is undefined", () => {
@@ -1207,8 +1207,8 @@ describe("Layout Engine - Contextual Spacing", () => {
 
     const frags = layout.pages[0].fragments;
     // Without styleId, contextual spacing should NOT be applied
-    // gap = spaceAfter + spaceBefore = 15
+    // gap = max(spaceAfter, spaceBefore) = 10
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(15);
+    expect(gap).toBe(10);
   });
 });

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1538,6 +1538,9 @@ function convertParagraphAttrs(
   if (pmAttrs.keepLines) {
     attrs.keepLines = true;
   }
+  if (pmAttrs.widowControl === false) {
+    attrs.widowControl = false;
+  }
   if (pmAttrs.contextualSpacing) {
     attrs.contextualSpacing = true;
   }

--- a/packages/core/src/layout-engine/footnoteLineReservation.test.ts
+++ b/packages/core/src/layout-engine/footnoteLineReservation.test.ts
@@ -31,7 +31,7 @@ function makePara(
     kind: "paragraph",
     id,
     runs,
-    attrs: {},
+    attrs: { widowControl: false },
     pmStart: 1,
     pmEnd: 100,
   };

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -125,6 +125,10 @@ function getSpacingAfter(block: ParagraphBlock): number {
   return value;
 }
 
+function hasWidowControl(block: ParagraphBlock): boolean {
+  return block.attrs?.widowControl !== false;
+}
+
 /**
  * Apply contextual spacing suppression (OOXML §17.3.1.9).
  *
@@ -514,7 +518,7 @@ function layoutParagraph(
         footnoteHeightById,
       );
       const firstLineHeight = measuredLineAdvance(firstLine) + firstLineRefs.height;
-      const collapsedLead = spaceBefore + state.trailingSpacing;
+      const collapsedLead = Math.max(spaceBefore, state.trailingSpacing);
       const columnCapacity = state.contentBottom - state.topMargin;
       if (
         collapsedLead + firstLineHeight > availableHeight &&
@@ -537,16 +541,16 @@ function layoutParagraph(
     // only when `j === currentLineIndex`; subsequent lines compared bare
     // line totals against the full available height. That let the loop
     // claim more lines than would actually fit, then `addFragment` (which
-    // correctly sums `spaceBefore + linesHeight`) refused the placement
+    // correctly reserves collapsed spacing + line height) refused the placement
     // and bumped the *whole* fragment to the next page. Result: page-end
     // paragraphs with multi-line content didn't split — they jumped the
     // page boundary, leaving a chunk of empty space above.
     //
-    // `addFragment` composes `spaceBefore` with the previous block's trailing
+    // `addFragment` collapses `spaceBefore` with the previous block's trailing
     // spacing, so the fit loop must reserve the same amount; otherwise a large
     // preceding `spaceAfter` repeats the same over-count (eigenpal/docx-editor#782).
     const firstFragmentSpaceBefore =
-      currentLineIndex === 0 ? spaceBefore + state.trailingSpacing : 0;
+      currentLineIndex === 0 ? Math.max(spaceBefore, state.trailingSpacing) : 0;
 
     for (let j = currentLineIndex; j < lines.length; j++) {
       const line = lines[j]!; // SAFETY: j < lines.length
@@ -565,6 +569,27 @@ function layoutParagraph(
         fittingLines++;
       } else {
         break;
+      }
+    }
+
+    let forceBreakAfterFragment = false;
+    if (hasWidowControl(block)) {
+      const remainingAfter = lines.length - (currentLineIndex + fittingLines);
+      if (fittingLines > 1 && remainingAfter === 1) {
+        fittingLines -= 1;
+        forceBreakAfterFragment = true;
+        linesHeight = 0;
+        linesFnHeight = 0;
+        linesFnIds.length = 0;
+        for (let j = currentLineIndex; j < currentLineIndex + fittingLines; j++) {
+          const line = lines[j]!; // SAFETY: j is within adjusted fitting range
+          linesHeight += measuredLineAdvance(line);
+          const lineRefs = getLineFootnoteRefs(block, line.fromRun, line.toRun, footnoteHeightById);
+          linesFnHeight += lineRefs.height;
+          for (const id of lineRefs.ids) {
+            linesFnIds.push(id);
+          }
+        }
       }
     }
 
@@ -651,7 +676,11 @@ function layoutParagraph(
 
     // If more lines remain, advance to next column/page
     if (currentLineIndex < lines.length) {
-      paginator.ensureFits(measuredLineAdvance(lines[currentLineIndex]!)); // SAFETY: guarded by length check
+      if (forceBreakAfterFragment) {
+        paginator.forceColumnBreak();
+      } else {
+        paginator.ensureFits(measuredLineAdvance(lines[currentLineIndex]!)); // SAFETY: guarded by length check
+      }
     }
   }
 }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -576,6 +576,10 @@ function layoutParagraph(
     if (hasWidowControl(block)) {
       const remainingAfter = lines.length - (currentLineIndex + fittingLines);
       if (fittingLines > 1 && remainingAfter === 1) {
+        if (currentLineIndex === 0 && fittingLines === 2 && state.cursorY !== state.topMargin) {
+          paginator.forceColumnBreak();
+          continue;
+        }
         fittingLines -= 1;
         forceBreakAfterFragment = true;
         linesHeight = 0;

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -11,6 +11,48 @@ import { measureParagraph } from "./measureParagraph";
 // such content via `calculateTabWidth`, so the wrap fired in the measurer
 // but not in the painter. See eigenpal #576.
 describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
+  test("leading left tab does not shrink to make following text fit the line", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "leading-left-tab-wrap",
+          runs: [{ kind: "tab" }, { kind: "text", text: "abcdefghijklmno", fontSize: 11 }],
+          attrs: {
+            tabs: [{ val: "start", pos: 1500 }],
+          },
+        },
+        150,
+      );
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines[0]?.toRun).toBe(0);
+      expect(measure.lines[1]?.fromRun).toBe(1);
+    });
+  });
+
+  test("non-leading left tab may shrink to keep tabbed label text on the line", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "label-left-tab",
+          runs: [
+            { kind: "text", text: "(a)", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "abcdefghijklmno", fontSize: 11 },
+          ],
+          attrs: {
+            tabs: [{ val: "start", pos: 1500 }],
+          },
+        },
+        150,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+    });
+  });
+
   test("right tab followed by short text does not wrap", () => {
     withFakeTextMeasure(() => {
       // Right tab stop at 5000 twips ≈ 333.33px. With the bug, the measurer

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -336,6 +336,106 @@ describe("measureParagraph cross-run line breaking", () => {
   });
 });
 
+describe("measureParagraph justified shrink tolerance", () => {
+  const fractionalWidth = (char: string): number => (char === "b" ? 0.6 : 1);
+  const text = `${"a".repeat(99)} bbb`;
+
+  test("allows normal justified prose to use Word-style shrink before wrapping", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-prose-shrink",
+            runs: [{ kind: "text", text }],
+            attrs: { alignment: "justify" },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(1);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("keeps first-line tabbed legal prose on the conservative shrink tolerance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-tabbed-first-line",
+            runs: [{ kind: "text", text }],
+            attrs: {
+              alignment: "justify",
+              indent: { firstLine: 48 },
+              tabs: [{ val: "start", pos: 360 }],
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("keeps literal-tab first-line legal prose on the conservative shrink tolerance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-literal-tabbed-first-line",
+            runs: [{ kind: "text", text: "x" }, { kind: "tab" }, { kind: "text", text }],
+            attrs: {
+              alignment: "justify",
+              indent: { firstLine: 48 },
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("allows hanging tabbed justified prose a small additional shrink", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-hanging-tab",
+            runs: [{ kind: "text", text }],
+            attrs: {
+              alignment: "justify",
+              indent: { firstLine: 0 },
+              tabs: [{ val: "start", pos: 360 }],
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(1);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+});
+
 describe("inline image paragraph measurement", () => {
   test("image-only line reserves descender room above and below image", () => {
     const imageHeight = 29;

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -52,7 +52,7 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Floating-point tolerance for line breaking (0.5px)
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
-const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.012;
+const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 
 /**
  * Find the longest prefix of `text` that fits within `maxWidth` pixels.
@@ -457,6 +457,13 @@ function hasFollowingTabOnLine(runs: Run[], tabIndex: number): boolean {
     }
   }
   return false;
+}
+
+function canClampTabToRightEdge(alignment: string, currentLineWidth: number): boolean {
+  if (alignment === "start" || alignment === "default") {
+    return currentLineWidth > WIDTH_TOLERANCE;
+  }
+  return true;
 }
 
 /**
@@ -1041,10 +1048,11 @@ export function measureParagraph(
         ...(attrs?.tabs !== undefined ? { explicitStops: attrs.tabs } : {}),
         leftIndent: pixelsToTwips(indentLeft),
       };
-      let tabWidth = calculateTabWidth(contentX, tabContext, {
+      const tabResult = calculateTabWidth(contentX, tabContext, {
         followingWidth,
         decimalPrefixWidth,
-      }).width;
+      });
+      let tabWidth = tabResult.width;
 
       const lineRightEdgeX =
         indentLeft +
@@ -1053,6 +1061,7 @@ export function measureParagraph(
         currentLine.leftOffset;
       if (
         !hasFollowingTabOnLine(runs, runIndex) &&
+        canClampTabToRightEdge(tabResult.alignment, currentLine.width) &&
         (tabWidth > 0 || followingWidth > 0) &&
         contentX + tabWidth + followingWidth > lineRightEdgeX + WIDTH_TOLERANCE
       ) {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -538,7 +538,7 @@ function justifyShrinkToleranceRatio(block: ParagraphBlock): number {
       : JUSTIFY_SHRINK_TOLERANCE_RATIO;
   }
 
-  const text = block.runs.map((run) => (isTextRun(run) ? run.text : "")).join("");
+  const text = block.runs.map((run) => (isTextRun(run) ? (run.text ?? "") : "")).join("");
   if (uppercaseLetterRatio(text) > ALL_CAPS_RATIO_THRESHOLD) {
     return JUSTIFY_SHRINK_TOLERANCE_RATIO;
   }

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -53,6 +53,9 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
+const JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO = 0.025;
+const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
+const ALL_CAPS_RATIO_THRESHOLD = 0.8;
 
 /**
  * Find the longest prefix of `text` that fits within `maxWidth` pixels.
@@ -509,6 +512,40 @@ function isSpaceOrTab(char: string | undefined): boolean {
   return char === " " || char === "\t";
 }
 
+function uppercaseLetterRatio(text: string): number {
+  let letters = 0;
+  let uppercase = 0;
+  for (const char of text) {
+    const lower = char.toLocaleLowerCase();
+    const upper = char.toLocaleUpperCase();
+    if (lower === upper) {
+      continue;
+    }
+    letters++;
+    if (char === upper) {
+      uppercase++;
+    }
+  }
+  return letters === 0 ? 0 : uppercase / letters;
+}
+
+function justifyShrinkToleranceRatio(block: ParagraphBlock): number {
+  const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
+  const hasTabRuns = block.runs.some(isTabRun);
+  if (hasTabStops || hasTabRuns) {
+    return (block.attrs?.indent?.firstLine ?? 0) === 0
+      ? JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO
+      : JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  }
+
+  const text = block.runs.map((run) => (isTextRun(run) ? run.text : "")).join("");
+  if (uppercaseLetterRatio(text) > ALL_CAPS_RATIO_THRESHOLD) {
+    return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  }
+
+  return JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO;
+}
+
 function trimTrailingSpacesAndTabs(text: string): string {
   let end = text.length;
   while (end > 0) {
@@ -638,6 +675,7 @@ export function measureParagraph(
   const attrs = block.attrs;
   const spacing = attrs?.spacing;
   const isJustifiedParagraph = attrs?.alignment === "justify";
+  const justifyToleranceRatio = justifyShrinkToleranceRatio(block);
 
   // Floating image support
   const floatingZones = options?.floatingZones;
@@ -1276,7 +1314,7 @@ export function measureParagraph(
         const word = text.slice(charIndex, nextBreak);
         const wordWidth = measureTextWidth(word, style);
         const widthTolerance = isJustifiedParagraph
-          ? Math.max(WIDTH_TOLERANCE, currentLine.availableWidth * JUSTIFY_SHRINK_TOLERANCE_RATIO)
+          ? Math.max(WIDTH_TOLERANCE, currentLine.availableWidth * justifyToleranceRatio)
           : WIDTH_TOLERANCE;
 
         // If the word itself is longer than a line, hard-break by characters.

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -88,6 +88,18 @@ describe("paginator forcePageBreak", () => {
 });
 
 describe("paginator block spacing", () => {
+  test("collapses adjacent paragraph spacing to the larger side", () => {
+    const paginator = createPaginator({
+      pageSize: { w: 100, h: 100 },
+      margins: { top: 10, right: 10, bottom: 10, left: 10 },
+    });
+
+    paginator.addFragment({ kind: "paragraph" } as never, 10, 0, 20);
+    const result = paginator.addFragment({ kind: "paragraph" } as never, 10, 10, 0);
+
+    expect(result.y).toBe(40);
+  });
+
   test("does not carry trailing spacing to the top of a new page", () => {
     const paginator = createPaginator({
       pageSize: { w: 100, h: 100 },
@@ -113,5 +125,4 @@ describe("paginator block spacing", () => {
     expect(paginator.pages.length).toBe(2);
     expect(result.y).toBe(15);
   });
-
 });

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -333,10 +333,10 @@ export function createPaginator(options: PaginatorOptions) {
     const initialState = getCurrentState();
     const initialColumnIndex = initialState.columnIndex;
 
-    // Word composes adjacent paragraph spacing additively: the previous
-    // paragraph's `spaceAfter` and the next paragraph's `spaceBefore` both
-    // contribute to the inter-paragraph gap.
-    const effectiveSpaceBefore = spaceBefore + initialState.trailingSpacing;
+    // Word collapses adjacent paragraph spacing: the inter-paragraph gap is
+    // the larger of the previous paragraph's `spaceAfter` and the next
+    // paragraph's `spaceBefore`.
+    const effectiveSpaceBefore = Math.max(spaceBefore, initialState.trailingSpacing);
     const totalHeight = effectiveSpaceBefore + height;
 
     // Ensure we have space

--- a/packages/core/src/layout-engine/paragraphFragmentRange.test.ts
+++ b/packages/core/src/layout-engine/paragraphFragmentRange.test.ts
@@ -59,6 +59,7 @@ function splitParagraph(): ParagraphBlock {
     ],
     pmStart: 9,
     pmEnd: 30,
+    attrs: { widowControl: false },
   };
 }
 
@@ -76,6 +77,7 @@ function singleRunSplitParagraph(): ParagraphBlock {
     ],
     pmStart: 9,
     pmEnd: 41,
+    attrs: { widowControl: false },
   };
 }
 

--- a/packages/core/src/layout-engine/paragraphSplitWithSpaceBefore.test.ts
+++ b/packages/core/src/layout-engine/paragraphSplitWithSpaceBefore.test.ts
@@ -90,6 +90,33 @@ describe("paragraph split with spaceBefore", () => {
     expect(page2Second).toMatchObject({ fromLine: 2, toLine: 4 });
   });
 
+  test("widow control moves a three-line paragraph instead of leaving one orphan line", () => {
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 30 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    const first = makePara(0, "filler", { after: 0 }, 1, 10);
+    const second = makePara(1, "threeLineWidowControlled", { before: 0 }, 3, 10);
+
+    const layout = layoutDocument(
+      [first.block, second.block],
+      [first.measure, second.measure],
+      layoutOptions,
+    );
+
+    const page1Second = layout.pages[0]!.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    const page2Second = layout.pages[1]!.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+
+    expect(page1Second).toBeUndefined();
+    expect(page2Second).toMatchObject({ fromLine: 0, toLine: 3 });
+  });
+
   test("multi-line paragraph splits at page boundary and fills page-end space", () => {
     // Page content area = 200 px. First paragraph fills 180 px, leaving
     // 20 px below it. Second paragraph has spaceBefore=10 and 5 lines of

--- a/packages/core/src/layout-engine/paragraphSplitWithSpaceBefore.test.ts
+++ b/packages/core/src/layout-engine/paragraphSplitWithSpaceBefore.test.ts
@@ -63,6 +63,33 @@ function makePara(
 }
 
 describe("paragraph split with spaceBefore", () => {
+  test("widow control avoids leaving one trailing line on the next page", () => {
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 50 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    const first = makePara(0, "filler", { after: 0 }, 1, 15);
+    const second = makePara(1, "widowControlled", { before: 0 }, 4, 10);
+
+    const layout = layoutDocument(
+      [first.block, second.block],
+      [first.measure, second.measure],
+      layoutOptions,
+    );
+
+    const page1Second = layout.pages[0]!.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    const page2Second = layout.pages[1]!.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+
+    expect(page1Second).toMatchObject({ fromLine: 0, toLine: 2 });
+    expect(page2Second).toMatchObject({ fromLine: 2, toLine: 4 });
+  });
+
   test("multi-line paragraph splits at page boundary and fills page-end space", () => {
     // Page content area = 200 px. First paragraph fills 180 px, leaving
     // 20 px below it. Second paragraph has spaceBefore=10 and 5 lines of

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -382,6 +382,7 @@ export type ParagraphAttrs = {
   indent?: ParagraphIndent;
   keepNext?: boolean;
   keepLines?: boolean;
+  widowControl?: boolean;
   pageBreakBefore?: boolean;
   styleId?: string;
   contextualSpacing?: boolean;

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, test } from "bun:test";
 import { clearTextWidthCache } from "../layout-engine/measure/cache";
 import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import type { ParagraphBlock, ParagraphFragment, ParagraphMeasure } from "../layout-engine/types";
-import { renderParagraphFragment } from "./renderParagraph";
+import { renderLine, renderParagraphFragment } from "./renderParagraph";
 
 function createFakeStyle(): Record<string, string> {
   const store: Record<string, string> = {};
@@ -147,5 +147,36 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(firstLineEl.style.width).toBe("400px");
     expect(firstLineEl.style.textIndent).toBe("30px");
     expect(firstLineEl.style.textAlign).toBe("justify");
+  });
+
+  test("overfull justified lines use negative word spacing instead of browser expansion", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-overfull",
+      runs: [{ kind: "text", text: "alpha beta gamma" }],
+      attrs: { alignment: "justify" },
+    };
+    const line = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 110,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+    });
+
+    expect(lineEl.style.width).toBe("100px");
+    expect(lineEl.style.textAlign).toBe("left");
+    expect(lineEl.style.textAlignLast).toBe("auto");
+    expect(lineEl.style.wordSpacing).toBe("-5px");
   });
 });

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -79,6 +79,72 @@ function findFieldOrTextEls(lineEl: FakeElement): FakeElement[] {
 }
 
 describe("renderLine right-tab flex anchor", () => {
+  test("does NOT clamp a leading left tab to fit following text at the right edge", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "leading-left-tab",
+      runs: [{ kind: "tab" }, { kind: "text", text: "wide trailing text" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: 18,
+      width: 150,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 150,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "start", pos: 1500 }],
+      leftIndentPx: 0,
+      lineRightEdgePx: 150,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl?.style["width"]).toBe("100px");
+  });
+
+  test("clamps a non-leading left tab when tabbed label text would overshoot", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "label-left-tab",
+      runs: [
+        { kind: "text", text: "(a)" },
+        { kind: "tab" },
+        { kind: "text", text: "wide trailing text" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 18,
+      width: 150,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 150,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "start", pos: 1500 }],
+      leftIndentPx: 0,
+      lineRightEdgePx: 150,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl?.style["width"]).toBe("3px");
+  });
+
   // TOC1-style line: title text + right-aligned tab + page-number field.
   // Tab stop sits at the line's right edge; with no trailing tab and a tab
   // alignment of "end", the painter must promote the line to flex layout.

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -626,6 +626,13 @@ function renderTabRun(run: TabRun, doc: Document, width: number, leader?: string
   return span;
 }
 
+function canClampTabToRightEdge(alignment: string, hasPriorRenderedContent: boolean): boolean {
+  if (alignment === "start" || alignment === "default") {
+    return hasPriorRenderedContent;
+  }
+  return true;
+}
+
 function applyTabUnderline(element: HTMLElement, run: TabRun): void {
   if (!run.underline) {
     return;
@@ -1895,6 +1902,7 @@ export function renderLine(
       let tabWidth = tabResult.width;
       if (
         lineRightEdgeX !== undefined &&
+        canClampTabToRightEdge(tabResult.alignment, i > 0) &&
         currentX + tabWidth + followingWidthForCheck > lineRightEdgeX
       ) {
         tabWidth = Math.max(1, lineRightEdgeX - currentX - followingWidthForCheck);

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1298,6 +1298,26 @@ type RenderLineOptions = {
  */
 const RIGHT_EDGE_EPSILON_PX = 0.5;
 
+function countShrinkableSpaces(runs: Run[]): number {
+  let count = 0;
+  for (const run of runs) {
+    if (isTextRun(run)) {
+      for (const char of run.text) {
+        if (char === " ") count++;
+      }
+    } else if (isFieldRun(run)) {
+      for (const char of run.fallback ?? "") {
+        if (char === " ") count++;
+      }
+    } else if (isMathRun(run)) {
+      for (const char of run.plainText) {
+        if (char === " ") count++;
+      }
+    }
+  }
+  return count;
+}
+
 /**
  * Build a TextMeasureStyle from a TextRun or FieldRun's relevant fields.
  */
@@ -1694,11 +1714,19 @@ export function renderLine(
     const shouldJustify = !options.isLastLine || options.paragraphEndsWithLineBreak;
 
     if (shouldJustify) {
-      // Use CSS text-align: justify with text-align-last: justify
-      // This forces the browser to justify even single-line blocks
-      lineEl.style.textAlign = "justify";
-      lineEl.style.textAlignLast = "justify";
-      // Set explicit width so browser knows how wide to justify to
+      const overfullPx = line.width - options.availableWidth;
+      const shrinkableSpaces = countShrinkableSpaces(runsForLine);
+      if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
+        lineEl.style.textAlign = "left";
+        lineEl.style.textAlignLast = "auto";
+        lineEl.style.wordSpacing = `${-overfullPx / shrinkableSpaces}px`;
+      } else {
+        // Use CSS text-align: justify with text-align-last: justify
+        // This forces the browser to justify even single-line blocks
+        lineEl.style.textAlign = "justify";
+        lineEl.style.textAlignLast = "justify";
+      }
+      // Set explicit width so browser knows how wide to justify/compress to.
       lineEl.style.width = `${options.availableWidth}px`;
     }
   }

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1302,7 +1302,7 @@ function countShrinkableSpaces(runs: Run[]): number {
   let count = 0;
   for (const run of runs) {
     if (isTextRun(run)) {
-      for (const char of run.text) {
+      for (const char of run.text ?? "") {
         if (char === " ") count++;
       }
     } else if (isFieldRun(run)) {
@@ -1310,7 +1310,7 @@ function countShrinkableSpaces(runs: Run[]): number {
         if (char === " ") count++;
       }
     } else if (isMathRun(run)) {
-      for (const char of run.plainText) {
+      for (const char of run.plainText ?? "") {
         if (char === " ") count++;
       }
     }

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -663,7 +663,7 @@ function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
 // "inherit", dropping the user's decision on save. Branch on `== null` so every
 // toggle routed through here preserves `false`. (Direction is handled
 // separately via the `direction` discriminated union, not this helper.)
-type BooleanToggleKey = "pageBreakBefore";
+type BooleanToggleKey = "pageBreakBefore" | "widowControl";
 
 function assignBooleanToggle(
   result: ParagraphFormatting,
@@ -765,6 +765,7 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
       }
     }
     assignBooleanToggle(result, attrs, orig, "pageBreakBefore");
+    assignBooleanToggle(result, attrs, orig, "widowControl");
     if (attrs.spacingExplicit !== orig.spacingExplicit) {
       if (attrs.spacingExplicit) {
         result.spacingExplicit = attrs.spacingExplicit;
@@ -813,7 +814,8 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     // Tri-state toggles: an explicit `false` is meaningful formatting and must
     // keep the paragraph from short-circuiting to "no formatting".
     bidi != null ||
-    attrs.pageBreakBefore != null;
+    attrs.pageBreakBefore != null ||
+    attrs.widowControl != null;
 
   if (!hasFormatting) {
     return undefined;
@@ -884,6 +886,9 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
   }
   if (attrs.pageBreakBefore != null) {
     f.pageBreakBefore = attrs.pageBreakBefore;
+  }
+  if (attrs.widowControl != null) {
+    f.widowControl = attrs.widowControl;
   }
   return f;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -570,6 +570,7 @@ function paragraphFormattingToAttrs(
     set("pageBreakBefore", formatting?.pageBreakBefore ?? stylePpr?.pageBreakBefore);
     set("keepNext", formatting?.keepNext ?? stylePpr?.keepNext);
     set("keepLines", formatting?.keepLines ?? stylePpr?.keepLines);
+    set("widowControl", formatting?.widowControl ?? stylePpr?.widowControl);
     set("contextualSpacing", formatting?.contextualSpacing ?? stylePpr?.contextualSpacing);
     // Run-in heading (`<w:specVanish/>` on the paragraph mark) — see
     // ParagraphAttrs.runInWithNext.
@@ -615,6 +616,7 @@ function paragraphFormattingToAttrs(
     set("pageBreakBefore", formatting?.pageBreakBefore);
     set("keepNext", formatting?.keepNext);
     set("keepLines", formatting?.keepLines);
+    set("widowControl", formatting?.widowControl);
     set("runInWithNext", formatting?.runInWithNext);
 
     // Outline level
@@ -1728,7 +1730,13 @@ function convertTableCell(
   for (const content of cell.content) {
     if (content.type === "paragraph") {
       contentNodes.push(
-        convertParagraph(content, styleResolver, undefined, conditionalStyle?.rPr, conditionalStyle?.pPr),
+        convertParagraph(
+          content,
+          styleResolver,
+          undefined,
+          conditionalStyle?.rPr,
+          conditionalStyle?.pPr,
+        ),
       );
     } else {
       // Nested tables - recursively convert

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -353,6 +353,7 @@ const paragraphNodeSpec: NodeSpec = {
     renderedPageBreakBefore: { default: null },
     keepNext: { default: null },
     keepLines: { default: null },
+    widowControl: { default: null },
     contextualSpacing: { default: null },
     runInWithNext: { default: null },
     defaultTextFormatting: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -149,6 +149,7 @@ export type ParagraphAttrs = {
   renderedPageBreakBefore?: boolean;
   keepNext?: boolean;
   keepLines?: boolean;
+  widowControl?: boolean;
   /** Contextual spacing — suppress space between same-style paragraphs */
   contextualSpacing?: boolean;
 

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { compareGeoms } from "../compare";
+import { compareGeoms, mergeVisualRows } from "../compare";
 import { DEFAULT_TOLERANCES } from "../config";
 import { normalizeLineText } from "../textNorm";
 import type { DocGeom, LineBox, PageGeom } from "../types";
@@ -30,6 +30,33 @@ const makeDoc = (source: "word" | "folio", pages: PageGeom[]): DocGeom => ({
 });
 
 describe("compareGeoms", () => {
+  test("merges tabbed legal markers on the same visual row", () => {
+    const merged = mergeVisualRows([
+      makeLine({ text: "(b)", xPt: 90, yPt: 100, widthPt: 12.8, heightPt: 12 }),
+      makeLine({
+        text: "Liquidity Event. If there is a Liquidity Event",
+        xPt: 126,
+        yPt: 100,
+        widthPt: 250,
+        heightPt: 12,
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.normText).toBe(
+      normalizeLineText("(b) Liquidity Event. If there is a Liquidity Event"),
+    );
+  });
+
+  test("keeps wider same-row columns separate", () => {
+    const merged = mergeVisualRows([
+      makeLine({ text: "Left cell", xPt: 90, yPt: 100, widthPt: 40, heightPt: 12 }),
+      makeLine({ text: "Right cell", xPt: 155, yPt: 100, widthPt: 60, heightPt: 12 }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+  });
+
   test("identical docs score 1 with zero divergences and zero median offset", () => {
     const pages = [
       makePage({

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -57,6 +57,22 @@ describe("compareGeoms", () => {
     expect(merged).toHaveLength(2);
   });
 
+  test("merges standalone list markers with their body across marker-sized gaps", () => {
+    const merged = mergeVisualRows([
+      makeLine({ text: "(i)", xPt: 108, yPt: 100, widthPt: 10.4, heightPt: 12 }),
+      makeLine({
+        text: "Junior to payment",
+        xPt: 144,
+        yPt: 100,
+        widthPt: 90,
+        heightPt: 12,
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.normText).toBe(normalizeLineText("(i) Junior to payment"));
+  });
+
   test("identical docs score 1 with zero divergences and zero median offset", () => {
     const pages = [
       makePage({

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -109,9 +109,9 @@ const stripSpaces = (text: string): string => text.replaceAll(" ", "");
 const ROW_OVERLAP_RATIO = 0.5;
 /** Maximum horizontal gap (pt) between same-row boxes that still merges them.
  * Word emits list markers as separate ink boxes ~10pt left of the item text,
- * while folio inlines the marker into the line; table cells sit far apart
- * (>25pt) and must stay separate. */
-const ROW_MERGE_GAP_PT = 18;
+ * and tabbed legal clauses can leave ~23pt between the marker and text; table
+ * cells sit farther apart (>25pt) and must stay separate. */
+const ROW_MERGE_GAP_PT = 24;
 
 /** Clusters boxes into visual rows (>= ROW_OVERLAP_RATIO vertical overlap),
  * then merges row neighbours within ROW_MERGE_GAP_PT of each other into a

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -112,6 +112,7 @@ const ROW_OVERLAP_RATIO = 0.5;
  * and tabbed legal clauses can leave ~23pt between the marker and text; table
  * cells sit farther apart (>25pt) and must stay separate. */
 const ROW_MERGE_GAP_PT = 24;
+const MARKER_ROW_MERGE_GAP_PT = 36;
 
 /** Clusters boxes into visual rows (>= ROW_OVERLAP_RATIO vertical overlap),
  * then merges row neighbours within ROW_MERGE_GAP_PT of each other into a
@@ -139,7 +140,7 @@ export const mergeVisualRows = (lines: LineBox[]): LineBox[] => {
     let current = row[0];
     if (!current) continue;
     for (const next of row.slice(1)) {
-      if (horizontalGap(current, next) <= ROW_MERGE_GAP_PT) {
+      if (shouldMergeRowBoxes(current, next)) {
         current = mergeBoxes(current, next);
         continue;
       }
@@ -149,6 +150,19 @@ export const mergeVisualRows = (lines: LineBox[]): LineBox[] => {
     merged.push(current);
   }
   return merged;
+};
+
+const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
+  const gap = horizontalGap(current, next);
+  if (gap <= ROW_MERGE_GAP_PT) {
+    return true;
+  }
+  return isStandaloneListMarker(current.text) && gap <= MARKER_ROW_MERGE_GAP_PT;
+};
+
+const isStandaloneListMarker = (text: string): boolean => {
+  const normalized = normalizeLineText(text);
+  return /^((\([A-Za-z0-9ivxlcdm]+\))|([A-Za-z0-9ivxlcdm]+[.)])|[•·])$/iu.test(normalized);
 };
 
 const isSameVisualRow = (a: LineBox, b: LineBox): boolean => {

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -41,12 +41,44 @@ export class FolioExtractError extends Error {
 
 export type FolioExtraction = { geom: DocGeom; screenshotPaths: string[] };
 
+export type FolioSpanInspection = {
+  text: string;
+  className: string;
+  rect: RawRect;
+  pmStart?: number;
+  pmEnd?: number;
+  fontFamilyRaw?: string;
+  fontSizePx?: number;
+  fontWeight?: string;
+  fontStyle?: string;
+  textTransform?: string;
+};
+
+export type FolioLineInspection = {
+  index: number;
+  text: string;
+  rect: RawRect;
+  region: Region;
+  spans: FolioSpanInspection[];
+};
+
+export type FolioPageInspection = {
+  pageNumber: number;
+  domIndex: number;
+  pageRect: RawRect;
+  offsetWidth: number;
+  offsetHeight: number;
+  zoomFactor: number;
+  lines: FolioLineInspection[];
+};
+
 export type FolioExtractOptions = {
   maxPages?: number;
 };
 
 export type FolioExtractor = {
   extract: (docxPath: string, options?: FolioExtractOptions) => Promise<FolioExtraction>;
+  inspectPage: (docxPath: string, pageNumber: number) => Promise<FolioPageInspection>;
   close: () => Promise<void>;
 };
 
@@ -453,10 +485,7 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
       const textFor = (sourceEl: HTMLElement): string => {
         const text = sourceEl.textContent ?? "";
         const computed = getComputedStyle(sourceEl);
-        if (
-          computed.textTransform === "uppercase" ||
-          computed.fontVariant.includes("small-caps")
-        ) {
+        if (computed.textTransform === "uppercase" || computed.fontVariant.includes("small-caps")) {
           return text.toLocaleUpperCase();
         }
         return text;
@@ -600,6 +629,83 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
     };
   }, domIndex);
 
+const inspectSinglePage = (page: Page, domIndex: number): Promise<FolioPageInspection> =>
+  page.evaluate<FolioPageInspection, number>((idx) => {
+    const pageEls = Array.from(document.querySelectorAll(".layout-page")) as HTMLElement[];
+    const el = pageEls[idx];
+    if (!el) {
+      throw new Error(`layout-page at domIndex ${idx} disappeared`);
+    }
+
+    const toRawRect = (rect: DOMRect) => ({
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+    });
+    const numberAttr = Number(el.dataset["pageNumber"]);
+    const pageNumber = Number.isFinite(numberAttr) ? numberAttr : idx + 1;
+    const pageRect = el.getBoundingClientRect();
+    const zoomFactor =
+      Number.isFinite(pageRect.width) && pageRect.width > 0 ? el.offsetWidth / pageRect.width : 1;
+
+    const lineEls = Array.from(el.querySelectorAll(".layout-line")) as HTMLElement[];
+    const lines = lineEls.map((lineEl, lineIndex) => {
+      const region = (() => {
+        if (lineEl.closest(".layout-page-header")) {
+          return "header";
+        }
+        if (lineEl.closest(".layout-page-footer")) {
+          return "footer";
+        }
+        return "body";
+      })();
+
+      const spanEls = Array.from(
+        lineEl.querySelectorAll(".layout-run, .layout-list-marker"),
+      ) as HTMLElement[];
+      const spans = spanEls.map((spanEl) => {
+        const computed = getComputedStyle(spanEl);
+        const pmStart = Number(spanEl.dataset["pmStart"]);
+        const pmEnd = Number(spanEl.dataset["pmEnd"]);
+        const fontSizePx = Number.parseFloat(computed.fontSize);
+        return {
+          text: spanEl.textContent ?? "",
+          className: spanEl.className,
+          rect: toRawRect(spanEl.getBoundingClientRect()),
+          ...(Number.isFinite(pmStart) ? { pmStart } : {}),
+          ...(Number.isFinite(pmEnd) ? { pmEnd } : {}),
+          fontFamilyRaw: computed.fontFamily,
+          ...(Number.isFinite(fontSizePx) ? { fontSizePx } : {}),
+          fontWeight: computed.fontWeight,
+          fontStyle: computed.fontStyle,
+          textTransform: computed.textTransform,
+        };
+      });
+
+      return {
+        index: lineIndex + 1,
+        text:
+          spanEls.length > 0
+            ? spanEls.map((spanEl) => spanEl.textContent ?? "").join("")
+            : (lineEl.textContent ?? ""),
+        rect: toRawRect(lineEl.getBoundingClientRect()),
+        region,
+        spans,
+      };
+    });
+
+    return {
+      pageNumber,
+      domIndex: idx,
+      pageRect: toRawRect(pageRect),
+      offsetWidth: el.offsetWidth,
+      offsetHeight: el.offsetHeight,
+      zoomFactor,
+      lines,
+    };
+  }, domIndex);
+
 const stagedFixtureName = (sha256: string): string =>
   `${TMP_FIXTURE_PREFIX}${sha256.slice(0, 12)}.docx`;
 
@@ -616,7 +722,8 @@ export const createFolioExtractor = async (
   const reuseServer = opts.reuseServer ?? false;
 
   let serverProcess: ReturnType<typeof Bun.spawn> | null = null;
-  const serverAlreadyUp = reuseServer && (await probeServer(PLAYGROUND_URL, SERVER_PROBE_TIMEOUT_MS));
+  const serverAlreadyUp =
+    reuseServer && (await probeServer(PLAYGROUND_URL, SERVER_PROBE_TIMEOUT_MS));
   if (!serverAlreadyUp) {
     // Clear any leftover server on OUR per-worktree port (see killByPort:
     // port-scoped, so other worktrees' servers are untouched), then start
@@ -739,6 +846,43 @@ export const createFolioExtractor = async (
     }
   };
 
+  const inspectPage = async (
+    docxPath: string,
+    pageNumber: number,
+  ): Promise<FolioPageInspection> => {
+    const absoluteDocxPath = path.resolve(docxPath);
+    const docxBuffer = await fs.readFile(absoluteDocxPath);
+    const sha256 = createHash("sha256").update(docxBuffer).digest("hex");
+    const stagedName = stagedFixtureName(sha256);
+    const stagedPath = path.join(FIXTURES_DIR, stagedName);
+
+    await fs.copyFile(absoluteDocxPath, stagedPath);
+    try {
+      await page.goto(`${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`, {
+        waitUntil: "domcontentloaded",
+        timeout: PLAYGROUND_NAVIGATION_TIMEOUT_MS,
+      });
+      await waitForEditorLayout(page);
+
+      const pageMeta = await listPageMeta(page);
+      const target = pageMeta.find((meta) => meta.pageNumber === pageNumber);
+      if (!target) {
+        throw new FolioExtractError(
+          `folio did not render page ${pageNumber} for ${absoluteDocxPath}`,
+        );
+      }
+
+      const locator = page.locator(PAGE_SELECTOR).nth(target.domIndex);
+      await locator.scrollIntoViewIfNeeded();
+      await waitForLayoutStability(page);
+      await page.waitForTimeout(STABILITY_SETTLE_MS);
+
+      return await inspectSinglePage(page, target.domIndex);
+    } finally {
+      await fs.unlink(stagedPath).catch(() => {});
+    }
+  };
+
   const close = async (): Promise<void> => {
     await context.close();
     await browser.close();
@@ -751,5 +895,5 @@ export const createFolioExtractor = async (
     }
   };
 
-  return { extract, close };
+  return { extract, inspectPage, close };
 };

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -525,7 +525,7 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
         }
         flushSegment();
 
-        if (segments.length > 1) {
+        if (segments.length > 0) {
           const splitLines = [];
           for (const segment of segments) {
             const segmentRect = rectFor(segment);

--- a/parity/folioInspect.ts
+++ b/parity/folioInspect.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+/**
+ * Folio DOM/page inspector for visual parity debugging.
+ *
+ * This complements `parity/inspect.ts`: the parity inspector compares Word vs
+ * Folio line boxes, while this command dumps Folio's source-linked painted
+ * lines and spans so an agent can trace a visual line back to PM positions and
+ * computed CSS without manually reading browser DevTools.
+ */
+import path from "node:path";
+
+import { createFolioExtractor } from "./folioExtract";
+
+type InspectFlags = {
+  doc?: string;
+  page: number;
+  text?: string;
+  maxSpans: number;
+};
+
+const usage = (): string =>
+  [
+    "Usage:",
+    "  bun parity/folioInspect.ts --doc file.docx --page 1",
+    "  bun parity/folioInspect.ts --doc file.docx --page 1 --text 'terms described'",
+    "",
+    "Options:",
+    "  --doc <path>        DOCX to inspect",
+    "  --page <n>          1-based page number (default: 1)",
+    "  --text <text>       only include matching lines",
+    "  --max-spans <n>     max spans per line (default: 20)",
+  ].join("\n");
+
+const parseArgs = (argv: string[]): InspectFlags => {
+  const flags: InspectFlags = { page: 1, maxSpans: 20 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--doc") {
+      flags.doc = argv[++i];
+    } else if (arg === "--page") {
+      flags.page = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--text") {
+      flags.text = argv[++i];
+    } else if (arg === "--max-spans") {
+      flags.maxSpans = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else if (!flags.doc) {
+      flags.doc = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!flags.doc) {
+    throw new Error("--doc is required");
+  }
+  if (!Number.isInteger(flags.page) || flags.page <= 0) {
+    throw new Error("--page must be a positive integer");
+  }
+  if (!Number.isInteger(flags.maxSpans) || flags.maxSpans <= 0) {
+    throw new Error("--max-spans must be a positive integer");
+  }
+  return flags;
+};
+
+const round = (value: number): number => Number(value.toFixed(3));
+
+const main = async (): Promise<void> => {
+  const flags = parseArgs(process.argv.slice(2));
+  const doc = path.resolve(flags.doc!);
+  const extractor = await createFolioExtractor();
+  try {
+    const page = await extractor.inspectPage(doc, flags.page);
+    const needle = flags.text?.toLocaleLowerCase();
+    const lines = page.lines
+      .filter((line) => !needle || line.text.toLocaleLowerCase().includes(needle))
+      .map((line) => ({
+        index: line.index,
+        text: line.text,
+        region: line.region,
+        rect: {
+          left: round(line.rect.left),
+          top: round(line.rect.top),
+          width: round(line.rect.width),
+          height: round(line.rect.height),
+        },
+        spans: line.spans.slice(0, flags.maxSpans).map((span) => ({
+          text: span.text,
+          className: span.className,
+          pmStart: span.pmStart,
+          pmEnd: span.pmEnd,
+          rect: {
+            left: round(span.rect.left),
+            top: round(span.rect.top),
+            width: round(span.rect.width),
+            height: round(span.rect.height),
+          },
+          fontFamilyRaw: span.fontFamilyRaw,
+          fontSizePx: span.fontSizePx === undefined ? undefined : round(span.fontSizePx),
+          fontWeight: span.fontWeight,
+          fontStyle: span.fontStyle,
+          textTransform: span.textTransform,
+        })),
+        omittedSpans: Math.max(0, line.spans.length - flags.maxSpans),
+      }));
+
+    console.log(
+      JSON.stringify(
+        {
+          doc,
+          page: {
+            pageNumber: page.pageNumber,
+            domIndex: page.domIndex,
+            offsetWidth: page.offsetWidth,
+            offsetHeight: page.offsetHeight,
+            zoomFactor: round(page.zoomFactor),
+            lineCount: page.lines.length,
+          },
+          query: flags.text,
+          lines,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await extractor.close();
+  }
+};
+
+try {
+  await main();
+} catch (error) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(`folio inspect failed: ${err.message}`);
+  console.error(usage());
+  process.exitCode = 2;
+}


### PR DESCRIPTION
## Summary

Improve DOCX visual parity for legal templates by refining tabbed and justified paragraph layout, paragraph spacing collapse, and widow-controlled pagination.

Add parity diagnostics for inspecting Folio-rendered page lines and spans, and make the comparator merge standalone list markers with their body text in Word geometry reports.