### PR TITLE
fix: improve legal document display parity

### DIFF
--- a/.changeset/fix-legal-layout-parity.md
+++ b/.changeset/fix-legal-layout-parity.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Improve Word parity for tabbed legal paragraphs and splittable keep-next chains.

--- a/packages/core/src/layout-engine/keep-together.test.ts
+++ b/packages/core/src/layout-engine/keep-together.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { calculateChainHeight } from "./keep-together";
+import type { FlowBlock, Measure, ParagraphBlock, ParagraphMeasure } from "./types";
+
+const paragraph = (id: string, keepNext = false): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: [{ kind: "text", text: id }],
+  attrs: { keepNext },
+});
+
+const paragraphMeasure = (...lineHeights: number[]): ParagraphMeasure => ({
+  kind: "paragraph",
+  lines: lineHeights.map((lineHeight) => ({
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: 1,
+    width: 10,
+    ascent: lineHeight * 0.8,
+    descent: lineHeight * 0.2,
+    lineHeight,
+  })),
+  totalHeight: lineHeights.reduce((total, lineHeight) => total + lineHeight, 0),
+});
+
+describe("calculateChainHeight", () => {
+  test("reserves only the first line of a splittable successor", () => {
+    const blocks: FlowBlock[] = [
+      paragraph("first", true),
+      paragraph("splittable", true),
+      paragraph("anchor"),
+    ];
+    const measures: Measure[] = [
+      paragraphMeasure(12, 12),
+      paragraphMeasure(14, 14, 14, 14),
+      paragraphMeasure(16),
+    ];
+
+    expect(
+      calculateChainHeight(
+        {
+          startIndex: 0,
+          endIndex: 1,
+          memberIndices: [0, 1],
+          anchorIndex: 2,
+        },
+        blocks,
+        measures,
+      ),
+    ).toBe(38);
+  });
+});

--- a/packages/core/src/layout-engine/keep-together.ts
+++ b/packages/core/src/layout-engine/keep-together.ts
@@ -5,7 +5,7 @@
  * (keep all lines together) properties that affect pagination.
  */
 
-import type { FlowBlock, ParagraphBlock, Measure, ParagraphMeasure } from "./types";
+import type { FlowBlock, ParagraphBlock, Measure } from "./types";
 
 /**
  * A chain of consecutive keepNext paragraphs.
@@ -117,9 +117,13 @@ export function computeKeepNextChains(blocks: FlowBlock[]): Map<number, KeepNext
 }
 
 /**
- * Calculate the total height needed to keep a chain together.
+ * Calculate the height needed to keep the chain's first paragraph with the
+ * first line of its successor.
  *
- * Includes all chain members plus the first line of the anchor paragraph.
+ * `keepNext` prevents a break between paragraphs; it does not imply
+ * `keepLines`. A later chain member may therefore split across pages. Reserving
+ * every line of every member moves otherwise splittable legal clauses as one
+ * oversized unit.
  */
 export function calculateChainHeight(
   chain: KeepNextChain,
@@ -128,39 +132,26 @@ export function calculateChainHeight(
 ): number {
   let totalHeight = 0;
 
-  // Sum heights of all chain members
-  for (const memberIndex of chain.memberIndices) {
-    const block = blocks[memberIndex];
-    const measure = measures[memberIndex];
-
-    if (!block || !measure || block.kind !== "paragraph" || measure.kind !== "paragraph") {
-      continue;
-    }
-
-    const para = block as ParagraphBlock;
-    const paraMeasure = measure as ParagraphMeasure;
-
-    // Add spacing before (simplified - could be more sophisticated with collapse)
-    const spacingBefore = para.attrs?.spacing?.before ?? 0;
-    totalHeight += spacingBefore;
-
-    // Add paragraph height
-    totalHeight += paraMeasure.totalHeight;
-
-    // Add spacing after
-    const spacingAfter = para.attrs?.spacing?.after ?? 0;
-    totalHeight += spacingAfter;
+  const firstMemberIndex = chain.memberIndices.at(0);
+  if (firstMemberIndex === undefined) {
+    return 0;
+  }
+  const firstBlock = blocks[firstMemberIndex];
+  const firstMeasure = measures[firstMemberIndex];
+  if (firstBlock?.kind !== "paragraph" || firstMeasure?.kind !== "paragraph") {
+    return 0;
   }
 
-  // Add first line height of anchor (if any)
-  if (chain.anchorIndex !== -1) {
-    const anchorMeasure = measures[chain.anchorIndex];
-    if (anchorMeasure?.kind === "paragraph") {
-      const anchorPara = anchorMeasure as ParagraphMeasure;
-      if (anchorPara.lines.length > 0) {
-        // SAFETY: length > 0 guarantees index 0 exists
-        totalHeight += anchorPara.lines[0]!.lineHeight;
-      }
+  totalHeight += firstBlock.attrs?.spacing?.before ?? 0;
+  totalHeight += firstMeasure.totalHeight;
+  totalHeight += firstBlock.attrs?.spacing?.after ?? 0;
+
+  const successorIndex = chain.memberIndices.at(1) ?? chain.anchorIndex;
+  const successorMeasure = successorIndex === -1 ? undefined : measures[successorIndex];
+  if (successorMeasure?.kind === "paragraph") {
+    const firstSuccessorLine = successorMeasure.lines.at(0);
+    if (firstSuccessorLine) {
+      totalHeight += firstSuccessorLine.lineHeight;
     }
   }
 

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -53,6 +53,30 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
     });
   });
 
+  test("non-leading left tab keeps its stop before multi-line prose", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "multi-line-label-left-tab",
+          runs: [
+            { kind: "text", text: "(i)", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "word ".repeat(12), fontSize: 11 },
+          ],
+          attrs: {
+            tabs: [{ val: "start", pos: 1500 }],
+          },
+        },
+        150,
+      );
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      expect(measure.lines[0]?.toRun).toBe(2);
+      expect(measure.lines[0]?.width).toBeGreaterThan(100);
+    });
+  });
+
   test("right tab followed by short text does not wrap", () => {
     withFakeTextMeasure(() => {
       // Right tab stop at 5000 twips ≈ 333.33px. With the bug, the measurer
@@ -171,11 +195,15 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
 
       const titleWidth = 25;
       const followingWidth = 20;
-      const tabResult = calculateTabWidth(titleWidth, {
-        explicitStops: [{ val: "end", pos: 5000 }],
-      }, {
-        followingWidth,
-      });
+      const tabResult = calculateTabWidth(
+        titleWidth,
+        {
+          explicitStops: [{ val: "end", pos: 5000 }],
+        },
+        {
+          followingWidth,
+        },
+      );
       const painterLineWidth = titleWidth + tabResult.width + followingWidth;
       expect(Math.abs((line?.width ?? 0) - painterLineWidth)).toBeLessThanOrEqual(0.5);
     });

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -434,6 +434,62 @@ describe("measureParagraph justified shrink tolerance", () => {
       },
     );
   });
+
+  test("uses the literal-tab continuation tolerance after the first line", () => {
+    const continuationText = `${"a".repeat(101)}c`;
+    const continuationWidth = (char: string): number => (char === "c" ? 0.65 : 1);
+
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-tabbed-continuation",
+            runs: [
+              { kind: "text", text: "x" },
+              { kind: "tab" },
+              { kind: "lineBreak" },
+              { kind: "text", text: continuationText },
+            ],
+            attrs: {
+              alignment: "justify",
+              indent: { firstLine: 48 },
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: continuationWidth,
+      },
+    );
+  });
+
+  test("keeps justified list items on the conservative shrink tolerance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-item",
+            runs: [{ kind: "text", text }],
+            attrs: {
+              alignment: "justify",
+              listMarker: "•",
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
 });
 
 describe("inline image paragraph measurement", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -53,6 +53,7 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
+const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO = 0.025;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
 const ALL_CAPS_RATIO_THRESHOLD = 0.8;
@@ -462,9 +463,28 @@ function hasFollowingTabOnLine(runs: Run[], tabIndex: number): boolean {
   return false;
 }
 
-function canClampTabToRightEdge(alignment: string, currentLineWidth: number): boolean {
+function hasPriorTabOnLine(runs: Run[], tabIndex: number): boolean {
+  for (let i = tabIndex - 1; i >= 0; i--) {
+    const prior = runs[i];
+    if (!prior || isLineBreakRun(prior) || (isImageRun(prior) && isBlockLayoutImageRun(prior))) {
+      break;
+    }
+    if (isTabRun(prior)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function canClampTabToRightEdge(
+  alignment: string,
+  currentLineWidth: number,
+  hasPriorTab: boolean,
+  followingWidth: number,
+  availableWidth: number,
+): boolean {
   if (alignment === "start" || alignment === "default") {
-    return currentLineWidth > WIDTH_TOLERANCE;
+    return currentLineWidth > WIDTH_TOLERANCE && (hasPriorTab || followingWidth <= availableWidth);
   }
   return true;
 }
@@ -529,10 +549,16 @@ function uppercaseLetterRatio(text: string): number {
   return letters === 0 ? 0 : uppercase / letters;
 }
 
-function justifyShrinkToleranceRatio(block: ParagraphBlock): number {
+function justifyShrinkToleranceRatio(block: ParagraphBlock, isFirstLine: boolean): number {
+  if (block.attrs?.listMarker !== undefined) {
+    return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  }
   const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
   const hasTabRuns = block.runs.some(isTabRun);
-  if (hasTabStops || hasTabRuns) {
+  if (!isFirstLine && hasTabRuns && !hasTabStops) {
+    return JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO;
+  }
+  if ((isFirstLine || hasTabStops) && (hasTabStops || hasTabRuns)) {
     return (block.attrs?.indent?.firstLine ?? 0) === 0
       ? JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO
       : JUSTIFY_SHRINK_TOLERANCE_RATIO;
@@ -675,7 +701,6 @@ export function measureParagraph(
   const attrs = block.attrs;
   const spacing = attrs?.spacing;
   const isJustifiedParagraph = attrs?.alignment === "justify";
-  const justifyToleranceRatio = justifyShrinkToleranceRatio(block);
 
   // Floating image support
   const floatingZones = options?.floatingZones;
@@ -1099,7 +1124,13 @@ export function measureParagraph(
         currentLine.leftOffset;
       if (
         !hasFollowingTabOnLine(runs, runIndex) &&
-        canClampTabToRightEdge(tabResult.alignment, currentLine.width) &&
+        canClampTabToRightEdge(
+          tabResult.alignment,
+          currentLine.width,
+          hasPriorTabOnLine(runs, runIndex),
+          followingWidth,
+          currentLine.availableWidth,
+        ) &&
         (tabWidth > 0 || followingWidth > 0) &&
         contentX + tabWidth + followingWidth > lineRightEdgeX + WIDTH_TOLERANCE
       ) {
@@ -1314,7 +1345,10 @@ export function measureParagraph(
         const word = text.slice(charIndex, nextBreak);
         const wordWidth = measureTextWidth(word, style);
         const widthTolerance = isJustifiedParagraph
-          ? Math.max(WIDTH_TOLERANCE, currentLine.availableWidth * justifyToleranceRatio)
+          ? Math.max(
+              WIDTH_TOLERANCE,
+              currentLine.availableWidth * justifyShrinkToleranceRatio(block, lines.length === 0),
+            )
           : WIDTH_TOLERANCE;
 
         // If the word itself is longer than a line, hard-break by characters.

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -145,6 +145,41 @@ describe("renderLine right-tab flex anchor", () => {
     expect(tabEl?.style["width"]).toBe("3px");
   });
 
+  test("does not clamp a non-leading left tab on a non-final line", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "multi-line-label-left-tab",
+      runs: [
+        { kind: "text", text: "(i)" },
+        { kind: "tab" },
+        { kind: "text", text: "wide trailing text" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 18,
+      width: 150,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 150,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "start", pos: 1500 }],
+      leftIndentPx: 0,
+      lineRightEdgePx: 150,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl?.style["width"]).toBe("79px");
+  });
+
   // TOC1-style line: title text + right-aligned tab + page-number field.
   // Tab stop sits at the line's right edge; with no trailing tab and a tab
   // alignment of "end", the painter must promote the line to flex layout.

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -626,9 +626,14 @@ function renderTabRun(run: TabRun, doc: Document, width: number, leader?: string
   return span;
 }
 
-function canClampTabToRightEdge(alignment: string, hasPriorRenderedContent: boolean): boolean {
+function canClampTabToRightEdge(
+  alignment: string,
+  hasPriorRenderedContent: boolean,
+  hasPriorTab: boolean,
+  isLastLine: boolean,
+): boolean {
   if (alignment === "start" || alignment === "default") {
-    return hasPriorRenderedContent;
+    return hasPriorRenderedContent && (hasPriorTab || isLastLine);
   }
   return true;
 }
@@ -1930,7 +1935,12 @@ export function renderLine(
       let tabWidth = tabResult.width;
       if (
         lineRightEdgeX !== undefined &&
-        canClampTabToRightEdge(tabResult.alignment, i > 0) &&
+        canClampTabToRightEdge(
+          tabResult.alignment,
+          i > 0,
+          runsForLine.slice(0, i).some(isTabRun),
+          options?.isLastLine === true,
+        ) &&
         currentX + tabWidth + followingWidthForCheck > lineRightEdgeX
       ) {
         tabWidth = Math.max(1, lineRightEdgeX - currentX - followingWidthForCheck);

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -151,6 +151,74 @@ describe("compareGeoms", () => {
     expect(result.score).toBeCloseTo(2 / 3);
   });
 
+  test("absorbs each page's extractor offset independently", () => {
+    const word = makeDoc("word", [
+      makePage({
+        number: 1,
+        lines: [
+          makeLine({ text: "Page one A", yPt: 72 }),
+          makeLine({ text: "Page one B", yPt: 90 }),
+        ],
+      }),
+      makePage({
+        number: 2,
+        lines: [
+          makeLine({ text: "Page two A", yPt: 72 }),
+          makeLine({ text: "Page two B", yPt: 90 }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        number: 1,
+        lines: [
+          makeLine({ text: "Page one A", yPt: 69 }),
+          makeLine({ text: "Page one B", yPt: 87 }),
+        ],
+      }),
+      makePage({
+        number: 2,
+        lines: [
+          makeLine({ text: "Page two A", yPt: 84 }),
+          makeLine({ text: "Page two B", yPt: 102 }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences.filter((divergence) => divergence.kind === "y-drift")).toEqual([]);
+    expect(result.score).toBe(1);
+    expect(result.medianYOffsetPt).toBeCloseTo(4.5);
+  });
+
+  test("uses Folio regions to absorb header and body extractor offsets independently", () => {
+    const word = makeDoc("word", [
+      makePage({
+        lines: [
+          makeLine({ text: "Header", yPt: 20 }),
+          makeLine({ text: "Body A", yPt: 72 }),
+          makeLine({ text: "Body B", yPt: 90 }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "Header", region: "header", yPt: 17 }),
+          makeLine({ text: "Body A", region: "body", yPt: 84 }),
+          makeLine({ text: "Body B", region: "body", yPt: 102 }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences.filter((divergence) => divergence.kind === "y-drift")).toEqual([]);
+    expect(result.score).toBe(1);
+    expect(result.medianYOffsetPt).toBeCloseTo(4.5);
+  });
+
   test("a Word line split into two folio lines reconciles as a single line-break", () => {
     const word = makeDoc("word", [
       makePage({ lines: [makeLine({ text: "The quick brown fox jumps" })] }),

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -69,14 +69,15 @@ export const compareGeoms = (
   const matches = resolved.filter(
     (item): item is Extract<ResolvedItem, { kind: "match" }> => item.kind === "match",
   );
-  const medianYOffsetPt = median(samePageYDeltas(matches, wordFlat, folioFlat));
+  const medianYOffsetsByPageRegion = pageRegionMedianYOffsets(matches, wordFlat, folioFlat);
+  const medianYOffsetPt = median([...medianYOffsetsByPageRegion.values()]);
 
   const { orderedDivergences, matchedGeomPass } = diffMatches({
     resolved,
     wordFlat,
     folioFlat,
     tolerances,
-    medianYOffsetPt,
+    medianYOffsetsByPageRegion,
   });
   divergences.push(...orderedDivergences);
 
@@ -482,18 +483,28 @@ const reconcileGap = ({
   ];
 };
 
-const samePageYDeltas = (
+const pageRegionKey = (page: number, region: LineBox["region"]): string =>
+  `${page}:${region ?? "unknown"}`;
+
+const matchedPageRegionKey = (word: FlatLine, folio: FlatLine): string =>
+  pageRegionKey(word.page, folio.line.region);
+
+const pageRegionMedianYOffsets = (
   matches: Extract<ResolvedItem, { kind: "match" }>[],
   wordFlat: FlatLine[],
   folioFlat: FlatLine[],
-): number[] => {
-  const deltas: number[] = [];
+): Map<string, number> => {
+  const deltasByPageRegion = new Map<string, number[]>();
   for (const m of matches) {
     const w = wordFlat[m.wordIdx];
     const f = folioFlat[m.folioIdx];
-    if (w && f && w.page === f.page) deltas.push(f.line.yPt - w.line.yPt);
+    if (!w || !f || w.page !== f.page) continue;
+    const key = matchedPageRegionKey(w, f);
+    const deltas = deltasByPageRegion.get(key) ?? [];
+    deltas.push(f.line.yPt - w.line.yPt);
+    deltasByPageRegion.set(key, deltas);
   }
-  return deltas;
+  return new Map([...deltasByPageRegion].map(([key, deltas]) => [key, median(deltas)]));
 };
 
 const median = (values: number[]): number => {
@@ -513,7 +524,7 @@ type DiffMatchesOptions = {
   wordFlat: FlatLine[];
   folioFlat: FlatLine[];
   tolerances: ComparisonTolerances;
-  medianYOffsetPt: number;
+  medianYOffsetsByPageRegion: ReadonlyMap<string, number>;
 };
 
 const diffMatches = ({
@@ -521,7 +532,7 @@ const diffMatches = ({
   wordFlat,
   folioFlat,
   tolerances,
-  medianYOffsetPt,
+  medianYOffsetsByPageRegion,
 }: DiffMatchesOptions): DiffMatchesResult => {
   const orderedDivergences: Divergence[] = [];
   let matchedGeomPass = 0;
@@ -574,7 +585,12 @@ const diffMatches = ({
 
       let yDelta: number | null = null;
       if (samePage) {
-        yDelta = checkYDrift(w.line, f.line, medianYOffsetPt, tolerances);
+        yDelta = checkYDrift(
+          w.line,
+          f.line,
+          medianYOffsetsByPageRegion.get(matchedPageRegionKey(w, f)) ?? 0,
+          tolerances,
+        );
         if (yDelta !== null) {
           orderedDivergences.push({
             kind: "y-drift",


### PR DESCRIPTION
## Summary

- preserve non-leading start tab stops for multiline legal paragraphs while retaining label clamping
- paginate splittable `keepNext` chains using the first successor line instead of reserving every chained paragraph
- normalize parity y-offsets per page and Folio region to avoid cross-page/header diagnostic noise
- add targeted regression coverage and a core patch changeset

## Verification

- targeted layout, painter, keep-next, and parity regression tests
- full monorepo unit suite
- document parity: 7 Word pages / 7 Folio pages, with pagination divergences eliminated
- CI provides lint, typecheck, build, API, dist, interaction, differential, and packaged-consumer gates
