### PR TITLE
fix: prevent paragraph mark spacing leakage

### DIFF
--- a/.changeset/fix-paragraph-mark-spacing.md
+++ b/.changeset/fix-paragraph-mark-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Prevent paragraph-mark character spacing from compressing directly formatted text runs.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
@@ -151,6 +151,20 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(run.kerningMinPt).toBeUndefined();
   });
 
+  test("explicit zero spacing suppresses paragraph-default character spacing", () => {
+    const mark = schema.marks.characterSpacing?.create({ spacing: 0 });
+    if (!mark) {
+      throw new Error("characterSpacing mark is unavailable");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { defaultTextFormatting: { spacing: -60 } }, [
+        schema.text("Signature name", [mark]),
+      ]),
+    ]);
+
+    expect(firstRun(toFlowBlocks(doc, {})).letterSpacing).toBeUndefined();
+  });
+
   test("propagates rtl mark to run formatting", () => {
     // eigenpal #424 (gap 10) — the painter needs `rtl` on the flow run to
     // emit `dir="rtl"`; without this case the PM mark would survive the

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -496,7 +496,7 @@ function extractRunFormatting(marks: readonly Mark[], theme?: Theme | null): Run
 
       case "characterSpacing": {
         const attrs = expectCharacterSpacingMarkAttrs(mark);
-        if (attrs.spacing !== undefined && attrs.spacing !== 0) {
+        if (attrs.spacing !== undefined) {
           formatting.letterSpacing = twipsToPixels(attrs.spacing);
         }
         if (attrs.position !== undefined && attrs.position !== 0) {
@@ -665,10 +665,14 @@ function markDefaultBlackTextColorSource(
 }
 
 function mergeRunFormatting(paraDefaults: RunFormatting, formatting: RunFormatting): RunFormatting {
-  return {
+  const merged = {
     ...paraDefaults,
     ...markDefaultBlackTextColorSource(formatting, paraDefaults),
   };
+  if (merged.letterSpacing === 0) {
+    delete merged.letterSpacing;
+  }
+  return merged;
 }
 
 function applyRunFormattingOverrides(

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -290,6 +290,39 @@ describe("toProseDoc", () => {
     );
   });
 
+  test("does not leak paragraph mark character spacing onto a directly formatted run", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: { spacing: -60 },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: { boldCs: true },
+                  content: [{ type: "text", text: "Signature name" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const paragraph = doc.firstChild;
+    const text = paragraph?.firstChild;
+
+    expect(paragraph?.attrs.defaultTextFormatting.spacing).toBe(-60);
+    expect(text?.marks.find((mark) => mark.type.name === "characterSpacing")?.attrs.spacing).toBe(
+      0,
+    );
+  });
+
   test("applies oneNDA table style run properties before direct run properties", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -885,6 +885,13 @@ function suppressParagraphMarkFormatting(
   if (paragraphMark.underline !== undefined && direct?.underline === undefined) {
     result.underline = { style: "none" };
   }
+  if (paragraphMark.spacing !== undefined && direct?.spacing === undefined) {
+    // A directly formatted run suppresses paragraph-mark character spacing in
+    // Word. Preserve any real style-level spacing; otherwise emit an explicit
+    // zero so the paragraph's defaultTextFormatting cannot leak back into the
+    // run when the PM document is converted to layout blocks.
+    result.spacing ??= 0;
+  }
 
   return Object.keys(result).length > 0 ? result : undefined;
 }


### PR DESCRIPTION
## Summary

- suppress paragraph-mark character spacing when a visible run has direct formatting
- preserve the paragraph default for unformatted runs while using explicit zero spacing as the layout override
- add targeted conversion and flow-block regressions plus a core patch changeset

## Verification

- 41 targeted conversion/layout tests
- registry parity remains 3 Word pages / 3 Folio pages
- removes the signature overlap and its associated x/width divergences
- full lint, typecheck, test, build, API, dist, interaction, differential, benchmark, and packaged-consumer gates run in CI
