### PR TITLE
fix: suppress hidden empty list paragraphs

### DIFF
--- a/.changeset/fix-hidden-empty-lists.md
+++ b/.changeset/fix-hidden-empty-lists.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Suppress empty hidden list paragraphs and their markers during layout.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -231,6 +231,25 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.spacingExplicit?.after).toBe(true);
   });
 
+  test("suppresses empty hidden list paragraphs and their markers", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: { hidden: true },
+          listMarker: "1.",
+          listIsBullet: false,
+        },
+        [],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.suppressEmptyParagraphHeight).toBe(true);
+    expect(paragraph?.attrs?.listMarkerHidden).toBe(true);
+  });
+
   test("preserves explicit automatic line spacing", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { lineSpacing: 240, lineSpacingRule: "auto" }, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1757,6 +1757,13 @@ function convertParagraph(
     options.originalListAbstractCounters,
     options.originalListSeenNumIds,
   );
+  const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
+  if (runs.length === 0 && defaultTextFormatting?.hidden === true) {
+    attrs.suppressEmptyParagraphHeight = true;
+    if (attrs.listMarker !== undefined) {
+      attrs.listMarkerHidden = true;
+    }
+  }
 
   const bookmarkNames = pmAttrs.bookmarks?.map((b) => b.name);
 


### PR DESCRIPTION
## Summary

- collapse empty paragraphs whose paragraph-default formatting is hidden
- hide their computed list markers while preserving zero-height position anchors
- add a targeted flow-block regression and a core patch changeset

## Verification

- 101 targeted conversion and paragraph-measurement tests
- registry parity improves from 0.62069 to 0.85517
- page count improves from 4 Folio / 3 Word to 3 / 3
- all 145 Word lines match; extra, missing, page-count, and pagination divergences are eliminated
- full repository gates run in CI
