### PR TITLE
docs: define DOCX platform ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ packages build on top of it.
 
 Part of [stella](https://github.com/stella/stella), an open-source legal workspace.
 
+See [DOCX platform boundary](./docs/docx-platform.md) for what belongs in folio
+and how editors, headless tools, agents, and hosts share one document model and
+operation contract.
+
 ## Packages
 
 This is a [Bun](https://bun.sh) workspace with these published packages:
 
-| Package                                   | Use it for                                                                            |
-| ----------------------------------------- | ------------------------------------------------------------------------------------- |
-| [`@stll/folio-core`](./packages/core)     | OOXML parsing, document model, ProseMirror integration, and page layout               |
-| [`@stll/folio-react`](./packages/react)   | A React editor UI built on `@stll/folio-core`                                         |
-| [`@stll/folio-vue`](./packages/vue)       | A Vue 3 editor and composables                                                        |
-| [`@stll/folio-nuxt`](./packages/nuxt)     | Nuxt 3/4 registration for the Vue editor                                              |
-| [`@stll/folio-agents`](./packages/agents) | Document review tools for reading `.docx` files and proposing comments or changes     |
+| Package                                   | Use it for                                                                        |
+| ----------------------------------------- | --------------------------------------------------------------------------------- |
+| [`@stll/folio-core`](./packages/core)     | OOXML parsing, document model, ProseMirror integration, and page layout           |
+| [`@stll/folio-react`](./packages/react)   | A React editor UI built on `@stll/folio-core`                                     |
+| [`@stll/folio-vue`](./packages/vue)       | A Vue 3 editor and composables                                                    |
+| [`@stll/folio-nuxt`](./packages/nuxt)     | Nuxt 3/4 registration for the Vue editor                                          |
+| [`@stll/folio-agents`](./packages/agents) | Document review tools for reading `.docx` files and proposing comments or changes |
 
 ## Install
 

--- a/docs/docx-platform.md
+++ b/docs/docx-platform.md
@@ -1,0 +1,134 @@
+# DOCX platform boundary
+
+Folio is the reusable engine and toolkit for working with `.docx` files. It
+provides shared document semantics to interactive editors, headless processes,
+and agent tools. Host products such as stella add workspace and domain
+workflows without maintaining a second DOCX implementation.
+
+This document defines that ownership boundary and the contracts that keep the
+surfaces interoperable. The package boundaries that make it possible are
+described in [Folio seam architecture](./seam-architecture.md).
+
+## Source of truth
+
+DOCX remains the canonical artifact. HTML, Markdown, plain text, JSON, and
+rendered pages are inputs or views of that artifact; they do not silently
+replace its package structure or document semantics.
+
+Folio owns reusable DOCX behavior:
+
+- create a document from structured content or a template;
+- open, validate, inspect, extract, render, edit, and save a document;
+- preserve supported and unknown OOXML that an operation did not intend to
+  change;
+- compare versions and produce machine-readable changes or a redlined DOCX;
+- apply direct edits, tracked changes, and comments with provenance;
+- expose the same capabilities through framework adapters and headless APIs;
+- provide portable host capabilities for browser and server runtimes.
+
+Folio APIs should be deterministic and provider-neutral. Model selection,
+prompting, and agent orchestration are concerns of the caller, not the DOCX
+engine.
+
+## Folio and host ownership
+
+| Folio owns                                                               | A host such as stella owns                                           |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| OOXML package, relationship, and part handling                           | Authentication, authorization, and workspace membership              |
+| Parsing, validation, compatibility profiles, and round-trip preservation | Blob storage, retention, and resolving workspace version identifiers |
+| Document creation, extraction, layout, rendering, editing, and save      | Product-specific file and matter workflows                           |
+| Comments, tracked changes, version comparison, and redlined output       | Model selection, prompts, conversations, approvals, and tool policy  |
+| Template and content-control primitives                                  | Organization template catalogs and legal playbooks                   |
+| A versioned document-operation contract                                  | Product UI outside the reusable editor and its adapters              |
+| Framework-neutral engine, editor controller, adapters, and agents        | Workspace audit events and collaboration service deployment          |
+
+When a DOCX capability is useful outside one product, its implementation and
+tests should originate in Folio. Hosts consume a released Folio API instead of
+copying parsers, transforms, or serializers into application code.
+
+The boundary does not prevent a host from storing Folio operation records in
+its own audit log or presenting domain-specific UI. It prevents storage and
+workflow concerns from leaking into the document engine.
+
+## One document-operation contract
+
+Every mutating surface should converge on a versioned, serializable document
+operation contract. Toolbar commands, headless transforms, and agent tools
+should not implement separate editing semantics.
+
+An operation records at least:
+
+- the contract version and operation kind;
+- a stable document location;
+- the intended mutation and review mode;
+- optional author, timestamp, and source provenance;
+- preconditions that make stale or ambiguous edits fail explicitly.
+
+The review mode is one of:
+
+- `direct`: change the document content immediately;
+- `tracked`: encode the mutation as a WordprocessingML revision;
+- `comment`: leave the content unchanged and attach a review comment.
+
+Operations must produce structured results: applied changes, created object
+identifiers, warnings, and typed failures. The same input document and valid
+operation sequence must produce the same semantic output regardless of the
+calling surface.
+
+Callers must be able to inspect supported contract versions, operation kinds,
+review modes, stories, and OOXML capabilities at runtime. A host should not
+infer support from a package version or discover it only after a destructive
+operation fails.
+
+### Stable addressing
+
+Paragraph indexes and raw ProseMirror positions are not durable document
+addresses. Folio should expose stable handles for a document story and a range
+within it. Stories include the main body, headers, footers, footnotes,
+endnotes, comments, and text inside supported drawing objects.
+
+An address may combine persisted OOXML identifiers with content fingerprints
+and structural context. Resolution must either identify one range or return an
+explicit stale or ambiguous result; it must never guess silently.
+
+## Compatibility is a measured capability
+
+OOXML support is not a single boolean. Folio tracks each feature independently
+through these capability levels:
+
+1. `read`: recognize and represent the source construct;
+2. `render`: display it with documented fidelity;
+3. `edit`: mutate it without corrupting adjacent content;
+4. `create`: author the construct from a Folio API;
+5. `preserve`: round-trip content that Folio does not interpret;
+6. `unsupported`: detect and report a construct that cannot be handled safely.
+
+Compatibility claims should identify the evidence behind them:
+
+- the applicable ECMA-376 or ISO/IEC 29500 rule;
+- Microsoft extension documentation where Word adds behavior;
+- observed behavior from a reproducible Word interoperability fixture.
+
+Tests and public APIs should also name the intended profile: OOXML
+Transitional, OOXML Strict, or Word-compatible behavior. International text,
+bidirectional layout, fonts, locale-dependent fields, and typography require
+explicit fixtures rather than assumptions based on English documents.
+
+Unknown elements, attributes, relationships, and package parts are preserved
+by default. A transformation may discard them only through an explicit policy
+and must report what was removed.
+
+## Change acceptance rules
+
+A new DOCX feature is complete only when:
+
+- its Folio-owned behavior is available through an appropriate reusable API;
+- interactive and headless paths share the same underlying operation;
+- compatibility and preservation behavior are covered by fixtures;
+- failures and unsupported constructs are structured and observable;
+- a host can adopt the capability without copying Folio internals;
+- published package changes include migration notes and a changeset.
+
+These rules apply to vertical slices. A feature should land end to end for a
+specific DOCX capability rather than adding a broad parser, model, or UI layer
+with no usable workflow.

--- a/docs/seam-architecture.md
+++ b/docs/seam-architecture.md
@@ -2,12 +2,11 @@
 
 Target architecture for folio: a layered set of packages joined by explicit,
 typed seams, so that the same engine powers multiple framework adapters
-(React, Vue), multiple hosts (web, desktop, server), a future Rust core, headless
-agentic editing, and — eventually — additional OOXML formats (pptx, xlsx) as
-parallel verticals over a shared substrate.
+(React, Vue), multiple hosts (web, server), and headless document editing.
 
-This doc defines the seams. It is the north star for the phased migration in
-[Phased path](#phased-path); we are not there yet.
+This doc defines the technical seams. The higher-level ownership and
+interoperability contract is defined in
+[DOCX platform boundary](./docx-platform.md).
 
 ## Principle
 
@@ -21,24 +20,24 @@ typed contract.
 
 From most-portable (bottom) to most-framework-specific (top).
 
-| Layer           | Owns                                                                                                                                                                           | Profile                                  |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| `model`         | Pure data shapes: `Document`, `Layout`, `FlowBlock`, `Measure`, content types, ids                                                                                             | Language-agnostic (→ Rust serde)         |
-| `engine`        | Pure compute: OOXML read/write, `Document→FlowBlocks`, pagination/line-break, markdown, pure transforms (fields, content-controls, watermark, style resolution), AI diff/apply | **Rust target.** No DOM, no PM, no React |
-| `document`      | Editable model: PM schema, plugins, commands, extensions, `Document↔ProseMirror`                                                                                               | JS forever (ProseMirror is JS)           |
-| `render-dom`    | Paint `Layout`→DOM, hit-testing, span mapping, scroll, overlay geometry; the canvas measure provider                                                                           | JS forever, **framework-agnostic DOM**   |
-| `controller`    | Headless orchestration: layout loop, incremental measure, hidden PM view, selection/scroll; imperative API + events                                                            | Framework-agnostic JS                    |
-| `react` / `vue` | Thin: lifecycle, event wiring, chrome (toolbar/menus/dialogs)                                                                                                                  | Per-framework                            |
+| Layer           | Owns                                                                                                                                                                           | Profile                                |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| `model`         | Pure data shapes: `Document`, `Layout`, `FlowBlock`, `Measure`, content types, ids                                                                                             | Serializable data                      |
+| `engine`        | Pure compute: OOXML read/write, `Document→FlowBlocks`, pagination/line-break, markdown, pure transforms (fields, content-controls, watermark, style resolution), AI diff/apply | No DOM, no PM, no React                |
+| `document`      | Editable model: PM schema, plugins, commands, extensions, `Document↔ProseMirror`                                                                                               | JS forever (ProseMirror is JS)         |
+| `render-dom`    | Paint `Layout`→DOM, hit-testing, span mapping, scroll, overlay geometry; the canvas measure provider                                                                           | JS forever, **framework-agnostic DOM** |
+| `controller`    | Headless orchestration: layout loop, incremental measure, hidden PM view, selection/scroll; imperative API + events                                                            | Framework-agnostic JS                  |
+| `react` / `vue` | Thin: lifecycle, event wiring, chrome (toolbar/menus/dialogs)                                                                                                                  | Per-framework                          |
 
 `layout-bridge` today **conflates** two concerns: pure `Document→FlowBlocks`
 (belongs in `engine`) and DOM hit-testing (belongs in `render-dom`). Splitting
-it is part of the migration (P3).
+these concerns requires explicit engine, document, and render boundaries.
 
 ## The seams (the contracts)
 
 Everything crosses these; nothing reaches around them.
 
-### Seam 1 — `MeasureProvider` (the Rust linchpin)
+### Seam 1 — `MeasureProvider`
 
 The engine must not know _how_ text is measured.
 
@@ -57,19 +56,18 @@ type MeasureRequest = {
 type FontMetrics = { ascent: number; descent: number; lineHeight: number };
 ```
 
-Browser supplies a canvas-backed impl; Rust supplies a `rustybuzz`/`fontdb`
-impl; a headless/server path supplies either. This single inversion makes the
-layout engine pure and Rust-portable, and lets us swap measurement backends.
+The browser supplies a canvas-backed implementation; a headless/server path
+supplies an appropriate implementation for its environment. This inversion
+makes the layout engine pure and lets us test or swap measurement backends.
 
 > Note: this seam already half-exists as `layout-engine/measure/measureWorkerProtocol.ts`
 > (a serializable `MeasureRequestEntry[] → width[]` contract fulfilled by a
-> stateless worker). P2 generalizes it into `MeasureProvider`.
+> stateless worker). `MeasureProvider` generalizes that contract.
 
 ### Seam 2 — the data lingua franca
 
 `Document`, `Layout`, `FlowBlock`, `Measure` are pure serializable types in
-`model`. They are the FFI payload (Rust mirrors them as serde structs). No
-behavior.
+`model`. They are serializable payloads with no behavior.
 
 ### Seam 3 — `Document ↔ ProseMirror`
 
@@ -90,16 +88,16 @@ to optionally carry positioned-glyph data so Phase-B shaping is additive.
 interface FolioHost {
   measureProvider: MeasureProvider;
   loadFont(spec: FontSpec): Promise<FontResource>;
-  readFile?(path: string): Promise<Uint8Array>; // desktop; absent on web
+  readFile?(path: string): Promise<Uint8Array>; // absent on the web
   writeFile?(path: string, bytes: Uint8Array): Promise<void>;
   schedule(cb: () => void): void; // raf vs immediate
 }
 ```
 
-Web, Tauri/Electrobun, and Node each provide a different host. The engine and
-controller stay identical across web/desktop/server.
+Browser and Node runtimes provide different hosts. The engine and controller
+stay identical across supported environments.
 
-### Seam 6 — `FolioEditor` (headless API + events; the Vue/desktop linchpin)
+### Seam 6 — `FolioEditor` (headless API + events; the adapter linchpin)
 
 ```ts
 interface FolioEditor {
@@ -147,82 +145,22 @@ Seam 1 is the linchpin and the hardest part, because of a fidelity fork:
 
 - **Phase A:** provider returns advance _widths_; engine breaks lines; the
   painter still emits text as DOM and lets the browser shape glyphs. Cheap, but
-  Rust-measured widths can drift from browser rendering.
+  provider-measured widths can drift from browser rendering.
 - **Phase B:** provider returns _positioned glyphs_; painter blits them; the
-  browser does no text layout. Fully deterministic and Rust-owned, and the only
-  honest path for Arabic/RTL/complex-script fidelity (shaping, not just width).
-  Bigger painter change.
+  browser does no text layout. Fully deterministic, and the only honest path
+  for Arabic/RTL/complex-script fidelity (shaping, not just width). Bigger
+  painter change.
 
 Design `Layout` to carry optional glyph positions from day one so B is additive.
 Fonts must be provisioned identically to `measure` and `paint` (same fallback
 chain) or layout drifts — a sub-problem of Seam 5.
 
-## Incremental layout & async transport (desktop)
+## Incremental layout & async transport
 
 Don't re-serialize the whole `Document` per keystroke. Model the
 controller↔engine contract as a stateful `LayoutSession` (which holds cached
 measures and the previous layout, fed dirty ranges). Make its methods
 **async-tolerant** (promise-returning) from the start: in the browser a
-WASM/worker call is effectively in-process, but on desktop the engine may live
-across a Tauri IPC or napi boundary, or off the UI thread. An async interface
-preserves that option at
-no cost to the JS path.
-
-## Multi-format substrate (docx, pptx, …)
-
-docx and pptx share the OOXML container (zip / `[Content_Types].xml` / `.rels` /
-parts), DrawingML (shapes, images, charts, text-in-shapes), and theme/fonts.
-They diverge at the model (flowing WordprocessingML vs spatial PresentationML),
-layout (pagination/reflow vs fixed slide canvas with in-shape autofit), and
-editing (PM flow vs shape canvas). So formats are **parallel verticals over a
-shared substrate**, not a fork:
-
-```
-@folio/ooxml    container (zip/parts/rels), DrawingML, theme/fonts   [shared]
-@folio/measure  text shaping/measure seam                            [shared]
-@folio/host     capabilities                                         [shared]
-   |- docx: model(Document)     + engine(flow/paginate) + render(pages)  + PM-flow editing
-   '- pptx: model(Presentation) + engine(slide layout)  + render(canvas) + shape editing
-```
-
-The `MeasureProvider`, `FolioHost`, the WASM/native build, the controller/event
-pattern, and the agentic op pattern are all format-agnostic. If pptx is a real
-goal, draw the `@folio/ooxml` substrate boundary while carving the docx seams
-(P1–P3) so it is shared by construction.
-
-## Phased path
-
-Each phase ships in the monorepo, CI-checked. P1–P4 are pure TS refactors that
-also improve the current product (testability, clarity); you can stop after any
-phase with a strictly better codebase.
-
-- **P0 (done, #884):** React-free core (`no-react-in-core` rule + arch test),
-  headless `@stll/folio/core` entry, `paged-layout` moved into core.
-- **P1 (done, #887) — model seam:** `core/model.ts` lingua-franca barrel + the
-  `model-is-pure-data` lint rule. Physical `types/`→`model/` relocation (~246
-  imports) deferred to P5.
-- **P2 (done, #887) — measurement seam:** `MeasureProvider` (P2a) + the layout
-  engine's import graph made canvas-free (P2b). Headless-testable, Rust-ready.
-- **P4 (next) — extract the headless `controller`:** pull orchestration (layout
-  loop, incremental measure, hidden PM view, selection/scroll) out of
-  `paged-editor` into a framework-agnostic controller with an imperative API +
-  events. The React adapter becomes a thin wrapper. This is the Vue/desktop
-  linchpin and is self-contained.
-- **P5 — package the boundaries (incl. the bridge split):** form the `engine` /
-  `document` / `render-dom` packages and dissolve `layout-bridge` into them. The
-  bridge split (originally "P3") folds in here: the bridge is a cohesive
-  PM→FlowBlocks→measure cluster, so cleanly separating its pure-compute,
-  PM-conversion, and DOM pieces only works once those three packages exist as
-  homes — doing it earlier would mean throwaway intermediate dirs. The
-  standalone-repo extraction also happens here.
-- **P6 — `@folio/vue`:** small if P4–P5 are right.
-- **P7 — Rust port (profiled):** `docx` I/O first (no font stack), then layout
-  (with a Rust measure provider).
-
-## Status
-
-P0, P1, and P2 are merged (#884, #886, #887): the React-free core, the model
-seam, and the fully-inverted measurement seam are in. **P4 (the headless
-controller) is next** — it's self-contained and is the Vue/desktop enabler. The
-bridge split folded into P5 (see P5 above) because cleanly separating that
-cluster requires the engine/document/render-dom package homes that P5 creates.
+worker call is effectively in-process, but another host may run the engine
+across a process boundary or off the UI thread. An async interface preserves
+that option at little cost to the direct path.


### PR DESCRIPTION
Defines the ownership and API boundaries for reusable DOCX behavior.