### PR TITLE
fix: honor rendered page break hints

### DIFF
--- a/.changeset/honor-rendered-page-breaks.md
+++ b/.changeset/honor-rendered-page-breaks.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor Word rendered-page-break hints during pagination without duplicating structural breaks.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -554,7 +554,7 @@ export type ParagraphAttrs = {
     keepNext?: boolean;
     keepLines?: boolean;
     widowControl?: boolean;
-    pageBreakBefore?: boolean;
+    pageBreakBefore?: boolean; /** Word's cached pagination hint (`w:lastRenderedPageBreak`). */
     renderedPageBreakBefore?: boolean;
     styleId?: string;
     contextualSpacing?: boolean;

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -555,6 +555,7 @@ export type ParagraphAttrs = {
     keepLines?: boolean;
     widowControl?: boolean;
     pageBreakBefore?: boolean;
+    renderedPageBreakBefore?: boolean;
     styleId?: string;
     contextualSpacing?: boolean;
     runInWithNext?: boolean; /** Right-to-left paragraph direction */

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -346,6 +346,28 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages.length).toBe(2);
       expect(layout.pages[1].fragments[0].blockId).toBe(1);
     });
+
+    test("explicit pageBreakBefore takes priority over a rendered page break hint", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before break", 1),
+        { kind: "pageBreak", id: 1, pmStart: 15, pmEnd: 16 },
+        {
+          ...makeParagraphBlock(2, "After intentional blank page", 17),
+          attrs: { pageBreakBefore: true, renderedPageBreakBefore: true },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+        { kind: "pageBreak" },
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages.length).toBe(3);
+      expect(layout.pages[1].fragments).toEqual([]);
+      expect(layout.pages[2].fragments[0].blockId).toBe(2);
+    });
   });
 
   describe("paragraph splitting across pages", () => {

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -306,6 +306,46 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1].fragments).toEqual([]);
       expect(layout.pages[2].fragments[0].blockId).toBe(2);
     });
+
+    test("rendered page break reuses a page opened by a structural break", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before break", 1),
+        { kind: "pageBreak", id: 1, pmStart: 15, pmEnd: 16 },
+        {
+          ...makeParagraphBlock(2, "Cached next page", 17),
+          attrs: { renderedPageBreakBefore: true },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+        { kind: "pageBreak" },
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages.length).toBe(2);
+      expect(layout.pages[1].fragments[0].blockId).toBe(2);
+    });
+
+    test("rendered page break starts a new page after content", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before break", 1),
+        {
+          ...makeParagraphBlock(1, "Cached next page", 15),
+          attrs: { renderedPageBreakBefore: true },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages.length).toBe(2);
+      expect(layout.pages[1].fragments[0].blockId).toBe(1);
+    });
   });
 
   describe("paragraph splitting across pages", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -5,6 +5,17 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("preserves Word rendered-page-break hints for layout", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { renderedPageBreakBefore: true }, [schema.text("Next page")]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.renderedPageBreakBefore).toBe(true);
+  });
+
   test("assigns stable block ids for repeated conversions of the same document", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First paragraph")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1536,6 +1536,9 @@ function convertParagraphAttrs(
   if (pmAttrs.pageBreakBefore) {
     attrs.pageBreakBefore = true;
   }
+  if (pmAttrs.renderedPageBreakBefore) {
+    attrs.renderedPageBreakBefore = true;
+  }
   if (pmAttrs.keepNext) {
     attrs.keepNext = true;
   }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -299,10 +299,10 @@ export function layoutDocument(
 
     // A cached Word pagination marker is advisory: honor it unless another
     // structural break already opened an empty page for the paragraph.
-    if (block.kind === "paragraph" && block.attrs?.renderedPageBreakBefore) {
-      paginator.forcePageBreak({ coalesceBlankPage: true });
-    } else if (hasPageBreakBefore(block)) {
+    if (hasPageBreakBefore(block)) {
       paginator.forcePageBreak();
+    } else if (block.kind === "paragraph" && block.attrs?.renderedPageBreakBefore) {
+      paginator.forcePageBreak({ coalesceBlankPage: true });
     }
 
     // Handle keepNext chains - if this is a chain start, check if chain fits

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -297,8 +297,11 @@ export function layoutDocument(
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
 
-    // Handle pageBreakBefore on paragraphs
-    if (hasPageBreakBefore(block)) {
+    // A cached Word pagination marker is advisory: honor it unless another
+    // structural break already opened an empty page for the paragraph.
+    if (block.kind === "paragraph" && block.attrs?.renderedPageBreakBefore) {
+      paginator.forcePageBreak({ coalesceBlankPage: true });
+    } else if (hasPageBreakBefore(block)) {
       paginator.forcePageBreak();
     }
 

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -384,6 +384,8 @@ export type ParagraphAttrs = {
   keepLines?: boolean;
   widowControl?: boolean;
   pageBreakBefore?: boolean;
+  /** Word's cached pagination hint (`w:lastRenderedPageBreak`). */
+  renderedPageBreakBefore?: boolean;
   styleId?: string;
   contextualSpacing?: boolean;
   /**


### PR DESCRIPTION
## Summary

- carry imported `w:lastRenderedPageBreak` markers into the layout engine
- treat cached markers as advisory so they coalesce with an already-open structural-break page
- preserve authored `pageBreakBefore` behavior, including intentional blank pages

## Regression coverage

- verifies the DOCX-to-flow conversion retains the rendered break hint
- verifies a hint starts a page after content
- verifies a hint does not duplicate an explicit structural break

## Parity result

A public Czech registry service agreement now renders 7 pages, matching Word (previously 6). Page-count and pagination divergences fell from 6 to 0; score improved from 0.474 to 0.507.

## Validation

- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts packages/core/src/__tests__/layout-pipeline.integration.test.ts packages/core/src/docx/paragraphParser.test.ts`
- parity rerun against the registry DOCX
- full lint, typecheck, build, package, interaction, and differential checks are delegated to CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination now respects Word-rendered page-break hints, helping content appear on the expected page more reliably.
  * Paragraphs can now carry an additional pagination hint that is preserved through layout processing.

* **Bug Fixes**
  * Improved page-break handling so hinted breaks work alongside existing structural breaks without creating extra blank pages.
  * Explicit page-breaks still take priority when both break signals are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->