### PR TITLE
fix: render grouped Word drawings

### DIFF
--- a/.changeset/render-grouped-drawings.md
+++ b/.changeset/render-grouped-drawings.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render WordprocessingGroup drawings as safe SVG previews while preserving their OOXML.

--- a/packages/core/src/docx/documentParser-alternatecontent.test.ts
+++ b/packages/core/src/docx/documentParser-alternatecontent.test.ts
@@ -35,6 +35,45 @@ const textBoxDrawingXml = (text: string) => `
   </w:drawing>`;
 
 describe("parseDocumentBody — AlternateContent text boxes", () => {
+  test("renders a wpg Choice as SVG while preserving the complete alternate content", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body><w:p><w:r><mc:AlternateContent>
+    <mc:Choice Requires="wpg"><w:drawing><wp:anchor behindDoc="1">
+      <wp:extent cx="1000000" cy="500000"/><wp:wrapTopAndBottom/>
+      <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"><wpg:wgp>
+        <wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="500000"/></a:xfrm><a:prstGeom prst="rect"/><a:solidFill><a:srgbClr val="DBEDF3"/></a:solidFill></wps:spPr></wps:wsp>
+      </wpg:wgp></a:graphicData></a:graphic>
+    </wp:anchor></w:drawing></mc:Choice>
+    <mc:Fallback><w:pict/></mc:Fallback>
+  </mc:AlternateContent></w:r></w:p></w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const drawing = paragraph.content
+      .filter((content) => content.type === "run")
+      .flatMap((run) => run.content)
+      .find((content) => content.type === "drawing");
+
+    expect(drawing?.type).toBe("drawing");
+    if (drawing?.type !== "drawing") {
+      throw new Error("Expected grouped drawing");
+    }
+    expect(drawing.image.mimeType).toBe("image/svg+xml");
+    expect(drawing.image.src).toStartWith("data:image/svg+xml");
+    expect(drawing.rawXml).toContain("<mc:AlternateContent");
+    expect(drawing.rawXml).toContain("<mc:Fallback>");
+  });
+
   test("extracts text-box drawings wrapped in mc:AlternateContent", () => {
     const body = parseDocumentBody(`${XML_DECLARATION}
 <w:document

--- a/packages/core/src/docx/groupDrawingParser.test.ts
+++ b/packages/core/src/docx/groupDrawingParser.test.ts
@@ -23,6 +23,7 @@ describe("parseGroupDrawing", () => {
                   <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="500000"/></a:xfrm>
                   <a:custGeom><a:pathLst><a:path w="2000000" h="500000"><a:moveTo><a:pt x="0" y="0"/></a:moveTo><a:lnTo><a:pt x="2000000" y="500000"/></a:lnTo></a:path></a:pathLst></a:custGeom>
                   <a:solidFill><a:srgbClr val="DBEDF3"/></a:solidFill>
+                  <a:ln><a:solidFill><a:srgbClr val="123456"/></a:solidFill></a:ln>
                 </wps:spPr>
               </wps:wsp>
               <wps:wsp>
@@ -45,7 +46,9 @@ describe("parseGroupDrawing", () => {
     expect(image?.src).toStartWith("data:image/svg+xml");
     const svg = decodeURIComponent(image?.src?.split(",").at(1) ?? "");
     expect(svg).toContain('<path d="M 0 0 L 2000000 500000"');
+    expect(svg).toContain('stroke="#123456" stroke-width="9525"');
     expect(svg).toContain("A &amp; B");
     expect(svg).not.toContain("A & B");
+    expect(svg).not.toContain('<rect width="2000000" height="1000000" fill="#FFFFFF"');
   });
 });

--- a/packages/core/src/docx/groupDrawingParser.test.ts
+++ b/packages/core/src/docx/groupDrawingParser.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseGroupDrawing } from "./groupDrawingParser";
+import { parseXmlDocument } from "./xmlParser";
+
+describe("parseGroupDrawing", () => {
+  test("renders grouped geometry and text as an anchored SVG image", () => {
+    const drawing = parseXmlDocument(`
+      <w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+        xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+        <wp:anchor behindDoc="1">
+          <wp:positionH relativeFrom="page"><wp:posOffset>914400</wp:posOffset></wp:positionH>
+          <wp:positionV relativeFrom="paragraph"><wp:posOffset>252000</wp:posOffset></wp:positionV>
+          <wp:extent cx="2000000" cy="1000000"/>
+          <wp:wrapTopAndBottom/>
+          <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup">
+            <wpg:wgp>
+              <wps:wsp>
+                <wps:spPr>
+                  <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="500000"/></a:xfrm>
+                  <a:custGeom><a:pathLst><a:path w="2000000" h="500000"><a:moveTo><a:pt x="0" y="0"/></a:moveTo><a:lnTo><a:pt x="2000000" y="500000"/></a:lnTo></a:path></a:pathLst></a:custGeom>
+                  <a:solidFill><a:srgbClr val="DBEDF3"/></a:solidFill>
+                </wps:spPr>
+              </wps:wsp>
+              <wps:wsp>
+                <wps:spPr><a:xfrm><a:off x="100000" y="600000"/><a:ext cx="900000" cy="200000"/></a:xfrm></wps:spPr>
+                <wps:txbx><w:txbxContent><w:p><w:r><w:t>A &amp; B</w:t></w:r></w:p></w:txbxContent></wps:txbx>
+              </wps:wsp>
+            </wpg:wgp>
+          </a:graphicData></a:graphic>
+        </wp:anchor>
+      </w:drawing>
+    `);
+
+    if (!drawing) {
+      throw new Error("Expected drawing fixture");
+    }
+    const image = parseGroupDrawing(drawing);
+
+    expect(image?.size).toEqual({ width: 2_000_000, height: 1_000_000 });
+    expect(image?.wrap.type).toBe("topAndBottom");
+    expect(image?.src).toStartWith("data:image/svg+xml");
+    const svg = decodeURIComponent(image?.src?.split(",").at(1) ?? "");
+    expect(svg).toContain('<path d="M 0 0 L 2000000 500000"');
+    expect(svg).toContain("A &amp; B");
+    expect(svg).not.toContain("A & B");
+  });
+});

--- a/packages/core/src/docx/groupDrawingParser.ts
+++ b/packages/core/src/docx/groupDrawingParser.ts
@@ -15,6 +15,7 @@ import type { XmlElement } from "./xmlParser";
 const HEX_COLOR = /^[0-9A-Fa-f]{6}$/u;
 const DEFAULT_TEXT_COLOR = "000000";
 const DEFAULT_FONT_HALF_POINTS = 22;
+const DEFAULT_LINE_WIDTH_EMU = 9_525;
 const HALF_POINT_TO_EMU = 6_350;
 const MAX_GROUP_SHAPES = 256;
 const MAX_PATH_COMMANDS = 10_000;
@@ -137,7 +138,9 @@ const renderGeometry = (wsp: XmlElement): string => {
   const fill = colorFrom(spPr, "none");
   const line = findChildByLocalName(spPr, "ln");
   const stroke = colorFrom(line, "none");
-  const strokeWidth = numericAttr(line, "w");
+  const strokeWidth = line
+    ? (parseNumericAttribute(line, null, "w") ?? DEFAULT_LINE_WIDTH_EMU)
+    : 0;
   const paths = findAllDeep(findChildByLocalName(spPr, "custGeom"), "a", "path");
   if (paths.length === 0) {
     return `<rect x="${x}" y="${y}" width="${width}" height="${height}" fill="${fill === "none" ? "none" : `#${fill}`}" stroke="${stroke === "none" ? "none" : `#${stroke}`}" stroke-width="${strokeWidth}"/>`;
@@ -191,7 +194,7 @@ const createSvg = (group: XmlElement, width: number, height: number): string => 
       findChildByLocalName(wsp, "txbx") ? renderTextBox(wsp) : renderGeometry(wsp),
     )
     .join("");
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${emuToPixels(width)}" height="${emuToPixels(height)}"><rect width="${width}" height="${height}" fill="#FFFFFF"/>${content}</svg>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${emuToPixels(width)}" height="${emuToPixels(height)}">${content}</svg>`;
 };
 
 /** Parse a WordprocessingGroup drawing into a safe SVG-backed image preview. */

--- a/packages/core/src/docx/groupDrawingParser.ts
+++ b/packages/core/src/docx/groupDrawingParser.ts
@@ -1,0 +1,216 @@
+import type { Image } from "../types/document";
+import { emuToPixels } from "../utils/units";
+import { parseImage } from "./imageParser";
+import {
+  findAllDeep,
+  findChildByLocalName,
+  findChildrenByLocalName,
+  getAttribute,
+  getLocalName,
+  getTextContent,
+  parseNumericAttribute,
+} from "./xmlParser";
+import type { XmlElement } from "./xmlParser";
+
+const HEX_COLOR = /^[0-9A-Fa-f]{6}$/u;
+const DEFAULT_TEXT_COLOR = "000000";
+const DEFAULT_FONT_HALF_POINTS = 22;
+const HALF_POINT_TO_EMU = 6_350;
+const MAX_GROUP_SHAPES = 256;
+const MAX_PATH_COMMANDS = 10_000;
+const MAX_TEXT_CHARACTERS = 20_000;
+const MAX_SVG_CHARACTERS = 1_000_000;
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+const numericAttr = (element: XmlElement | null, name: string): number => {
+  const direct = parseNumericAttribute(element, null, name);
+  if (direct !== undefined) {
+    return direct;
+  }
+  const wordValue = getAttribute(element, "w", name);
+  if (!wordValue) {
+    return 0;
+  }
+  const parsed = Number.parseInt(wordValue, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const childTransform = (wsp: XmlElement): { x: number; y: number; width: number; height: number } => {
+  const spPr = findChildByLocalName(wsp, "spPr");
+  const xfrm = findChildByLocalName(spPr, "xfrm");
+  const off = findChildByLocalName(xfrm, "off");
+  const ext = findChildByLocalName(xfrm, "ext");
+  return {
+    x: numericAttr(off, "x"),
+    y: numericAttr(off, "y"),
+    width: numericAttr(ext, "cx"),
+    height: numericAttr(ext, "cy"),
+  };
+};
+
+const colorFrom = (parent: XmlElement | null, fallback?: string): string | undefined => {
+  if (parent && getLocalName(parent.name ?? "") === "color") {
+    const value = getAttribute(parent, "w", "val");
+    if (value && HEX_COLOR.test(value)) {
+      return value.toUpperCase();
+    }
+  }
+  const solidFill = findChildByLocalName(parent, "solidFill");
+  const srgb = findChildByLocalName(solidFill, "srgbClr");
+  const value = getAttribute(srgb, null, "val");
+  if (value && HEX_COLOR.test(value)) {
+    return value.toUpperCase();
+  }
+  return fallback;
+};
+
+const wrapLine = (line: string, maxCharacters: number): string[] => {
+  const words = line.trim().split(/\s+/u);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (current && candidate.length > maxCharacters) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) {
+    lines.push(current);
+  }
+  return lines;
+};
+
+const pathData = (path: XmlElement): string => {
+  const commands: string[] = [];
+  for (const command of path.elements ?? []) {
+    if (commands.length >= MAX_PATH_COMMANDS) {
+      break;
+    }
+    if (command.type !== "element") {
+      continue;
+    }
+    const point = findChildByLocalName(command, "pt");
+    const x = numericAttr(point, "x");
+    const y = numericAttr(point, "y");
+    const name = command.name?.split(":").at(-1);
+    if (name === "moveTo") {
+      commands.push(`M ${x} ${y}`);
+    } else if (name === "lnTo") {
+      commands.push(`L ${x} ${y}`);
+    } else if (name === "quadBezTo") {
+      const points = findChildrenByLocalName(command, "pt");
+      if (points.length >= 2) {
+        commands.push(
+          `Q ${numericAttr(points[0] ?? null, "x")} ${numericAttr(points[0] ?? null, "y")} ${numericAttr(points[1] ?? null, "x")} ${numericAttr(points[1] ?? null, "y")}`,
+        );
+      }
+    } else if (name === "cubicBezTo") {
+      const points = findChildrenByLocalName(command, "pt");
+      if (points.length >= 3) {
+        commands.push(
+          `C ${numericAttr(points[0] ?? null, "x")} ${numericAttr(points[0] ?? null, "y")} ${numericAttr(points[1] ?? null, "x")} ${numericAttr(points[1] ?? null, "y")} ${numericAttr(points[2] ?? null, "x")} ${numericAttr(points[2] ?? null, "y")}`,
+        );
+      }
+    } else if (name === "close") {
+      commands.push("Z");
+    }
+  }
+  return commands.join(" ");
+};
+
+const renderGeometry = (wsp: XmlElement): string => {
+  const { x, y, width, height } = childTransform(wsp);
+  if (width <= 0 || height <= 0) {
+    return "";
+  }
+  const spPr = findChildByLocalName(wsp, "spPr");
+  const fill = colorFrom(spPr, "none");
+  const line = findChildByLocalName(spPr, "ln");
+  const stroke = colorFrom(line, "none");
+  const strokeWidth = numericAttr(line, "w");
+  const paths = findAllDeep(findChildByLocalName(spPr, "custGeom"), "a", "path");
+  if (paths.length === 0) {
+    return `<rect x="${x}" y="${y}" width="${width}" height="${height}" fill="${fill === "none" ? "none" : `#${fill}`}" stroke="${stroke === "none" ? "none" : `#${stroke}`}" stroke-width="${strokeWidth}"/>`;
+  }
+  return paths
+    .map((path) => {
+      const viewWidth = numericAttr(path, "w") || width;
+      const viewHeight = numericAttr(path, "h") || height;
+      const d = pathData(path);
+      if (!d) {
+        return "";
+      }
+      return `<path d="${d}" transform="translate(${x} ${y}) scale(${width / viewWidth} ${height / viewHeight})" fill="${fill === "none" ? "none" : `#${fill}`}" stroke="${stroke === "none" ? "none" : `#${stroke}`}" stroke-width="${strokeWidth}"/>`;
+    })
+    .join("");
+};
+
+const renderTextBox = (wsp: XmlElement): string => {
+  const { x, y, width, height } = childTransform(wsp);
+  if (width <= 0 || height <= 0) {
+    return "";
+  }
+  const paragraphs = findAllDeep(wsp, "w", "p");
+  const firstSize = findAllDeep(wsp, "w", "sz").at(0);
+  const halfPoints = numericAttr(firstSize ?? null, "val") || DEFAULT_FONT_HALF_POINTS;
+  const color = colorFrom(findAllDeep(wsp, "w", "color").at(0) ?? null, DEFAULT_TEXT_COLOR);
+  const fontSize = halfPoints * HALF_POINT_TO_EMU;
+  const maxCharacters = Math.max(1, Math.floor(width / (fontSize * 0.38)));
+  const lines = paragraphs
+    .flatMap((paragraph) =>
+      wrapLine(getTextContent(paragraph).slice(0, MAX_TEXT_CHARACTERS), maxCharacters),
+    )
+    .map(escapeXml);
+  if (lines.length === 0) {
+    return "";
+  }
+  const lineHeight = fontSize * 1.15;
+  const svgFontSize = 1_000;
+  const scale = fontSize / svgFontSize;
+  const lineStep = (lineHeight / fontSize) * svgFontSize;
+  const tspans = lines
+    .map((line, index) => `<tspan x="0" dy="${index === 0 ? 0 : lineStep}">${line}</tspan>`)
+    .join("");
+  return `<text x="0" y="${svgFontSize}" transform="translate(${x} ${y}) scale(${scale})" font-family="Arial, sans-serif" font-size="${svgFontSize}" fill="#${color}">${tspans}</text>`;
+};
+
+const createSvg = (group: XmlElement, width: number, height: number): string => {
+  const children = findChildrenByLocalName(group, "wsp").slice(0, MAX_GROUP_SHAPES);
+  const content = children
+    .map((wsp) =>
+      findChildByLocalName(wsp, "txbx") ? renderTextBox(wsp) : renderGeometry(wsp),
+    )
+    .join("");
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${emuToPixels(width)}" height="${emuToPixels(height)}"><rect width="${width}" height="${height}" fill="#FFFFFF"/>${content}</svg>`;
+};
+
+/** Parse a WordprocessingGroup drawing into a safe SVG-backed image preview. */
+export const parseGroupDrawing = (drawing: XmlElement): Image | null => {
+  const graphicData = findAllDeep(drawing, "a", "graphicData").at(0);
+  const group = findChildByLocalName(graphicData ?? null, "wgp");
+  if (!group) {
+    return null;
+  }
+  const image = parseImage(drawing, undefined, undefined);
+  if (!image || image.size.width <= 0 || image.size.height <= 0) {
+    return null;
+  }
+  const svg = createSvg(group, image.size.width, image.size.height);
+  if (svg.length > MAX_SVG_CHARACTERS) {
+    return null;
+  }
+  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  image.mimeType = "image/svg+xml";
+  image.filename = "wordprocessing-group.svg";
+  return image;
+};

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -41,6 +41,7 @@ import type {
   MediaFile,
   ShapeContent,
 } from "../types/document";
+import { parseGroupDrawing } from "./groupDrawingParser";
 import { parseImage } from "./imageParser";
 import {
   EmphasisMarkSchema,
@@ -816,6 +817,10 @@ function parseDrawingContent(
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
 ): DrawingContent | ShapeContent | null {
+  const groupImage = parseGroupDrawing(element);
+  if (groupImage) {
+    return { type: "drawing", image: groupImage, rawXml: elementToXml(element) };
+  }
   if (shouldPreserveRawShapeDrawing(element)) {
     return {
       type: "drawing",
@@ -1002,8 +1007,11 @@ function parseRunContents(
               // Keep package-referenced drawings even when the browser cannot render
               // the media. The serializer must preserve the relationship reference.
               if (innerDrawing) {
-                if (innerDrawing.type === "drawing" && !innerDrawing.image.src) {
-                  innerDrawing.rawXml = elementToXml(child);
+                if (
+                  innerDrawing.type === "drawing" &&
+                  (innerDrawing.rawXml !== undefined || !innerDrawing.image.src)
+                ) {
+                  innerDrawing.rawXml = elementToXml(cloneWithXmlnsDeclarations(child, rootXmlns));
                 }
                 contents.push(innerDrawing);
               }

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -1011,7 +1011,7 @@ function parseRunContents(
                   innerDrawing.type === "drawing" &&
                   (innerDrawing.rawXml !== undefined || !innerDrawing.image.src)
                 ) {
-                  innerDrawing.rawXml = elementToXml(cloneWithXmlnsDeclarations(child, rootXmlns));
+                  innerDrawing.rawXml = elementToXml(child);
                 }
                 contents.push(innerDrawing);
               }

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -415,6 +415,57 @@ test.describe("image", () => {
   test.skip("resizing a selected image updates its dimensions", () => {});
 });
 
+test.describe("rendered page-break hints", () => {
+  test("cached hints paginate without duplicating structural breaks", async ({ page }) => {
+    await mountFixture(page, "sample.docx");
+
+    const replaceDocument = async (
+      mode: "hintAfterContent" | "hintAfterBreak" | "explicitAndHintAfterBreak",
+    ) => {
+      await page.evaluate((nextMode) => {
+        const view = globalThis.__folioPlayground
+          ?.getEditorRef()
+          ?.getEditorRef()
+          ?.getView();
+        if (!view) {
+          throw new Error("Editor view unavailable");
+        }
+        const { schema } = view.state;
+        const first = schema.node("paragraph", null, [schema.text("First page")]);
+        const attrs = {
+          renderedPageBreakBefore: true,
+          pageBreakBefore: nextMode === "explicitAndHintAfterBreak",
+        };
+        const hinted = schema.node("paragraph", attrs, [schema.text("Hinted paragraph")]);
+        const nodes =
+          nextMode === "hintAfterContent"
+            ? [first, hinted]
+            : [first, schema.node("pageBreak"), hinted];
+        view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, nodes));
+      }, mode);
+    };
+
+    const waitForPages = async (count: number) => {
+      await page.waitForFunction(
+        (expected) => document.querySelectorAll(".layout-page").length === expected,
+        count,
+      );
+    };
+
+    await replaceDocument("hintAfterContent");
+    await waitForPages(2);
+
+    await replaceDocument("hintAfterBreak");
+    await waitForPages(2);
+
+    await replaceDocument("explicitAndHintAfterBreak");
+    await waitForPages(3);
+    await expect(
+      page.locator(".layout-page").nth(1).locator(".layout-page-content .layout-line"),
+    ).toHaveCount(0);
+  });
+});
+
 test.describe("zoom", () => {
   test("setZoom updates getZoom and scales the rendered page", async ({ page }) => {
     await mountFixture(page, "sample.docx");


### PR DESCRIPTION
## Summary

- render `wpg:wgp` grouped drawings as SVG-backed anchored image previews
- support grouped custom paths, fills, outlines, and text boxes while preserving the original `mc:AlternateContent` for lossless save
- cap generated shape, path, text, and SVG sizes; escape document text and whitelist RGB colors before SVG construction
- add the browser interaction coverage requested on #101 for cached and explicit page-break precedence

## Regression coverage

- grouped DrawingML parser test for paths, text, anchoring, and XML escaping
- AlternateContent integration test verifies SVG rendering plus Choice/Fallback preservation
- Playwright interaction test verifies rendered hints create pages, coalesce with structural breaks, and defer to explicit pageBreakBefore

## Visual result

The Prague City Museum registry agreement now displays the previously missing signature vector, signer text, digital-signature text, blue signature panel, rules, names, and roles. The preview remains one anchored object and the source OOXML round-trips unchanged.

## Validation

- `bun test packages/core/src/docx/groupDrawingParser.test.ts packages/core/src/docx/documentParser-alternatecontent.test.ts`
- `bunx playwright test tests/visual/interactions.spec.ts --project=interactions --grep "cached hints paginate"`
- in-editor Word/Folio visual rerun of the registry DOCX
- full lint, typecheck, build, package, interaction, and differential checks are delegated to CI