### PR TITLE
fix: preserve zero-sized Word images

### DIFF
--- a/.changeset/quiet-images-keep-size.md
+++ b/.changeset/quiet-images-keep-size.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve zero-sized Word image dimensions during layout conversion.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1100,10 +1100,48 @@ describe("toFlowBlocks list numbering", () => {
 // Regression guard for the eigenpal #424 opacity render pipeline. PR #517
 // review (gemini-code-assist) flagged that `attrs.opacity !== undefined` in
 // buildImageRun allowed the PM schema's null default to leak into
-// ImageRun.opacity (typed `number | undefined`). The bridge now gates with
-// `!= null`; these tests pin the contract for inline images, which is the
-// only path the schema permits (images are inline-only in PM).
-describe("toFlowBlocks image opacity null-default leak", () => {
+// ImageRun.opacity (typed `number | undefined`). Inline image attributes also
+// carry rounded OOXML dimensions, where zero is a valid subpixel result rather
+// than an absent value that should receive the default size.
+describe("toFlowBlocks image attribute normalization", () => {
+  test("preserves zero-sized inline image dimensions", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.nodes.image.create({
+          src: "media/subpixel-placeholder.png",
+          width: 1,
+          height: 0,
+        }),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const imageRun = paragraph.runs.find((run) => run.kind === "image");
+
+    expect(imageRun?.height).toBe(0);
+  });
+
+  test("preserves zero-sized standalone image dimensions", () => {
+    const image = schema.nodes.image.create({
+      src: "media/subpixel-placeholder.png",
+      width: 1,
+      height: 0,
+    });
+    // The schema currently declares images inline-only, but the layout bridge
+    // retains a standalone-image conversion path for structural callers.
+    const doc = schema.topNodeType.create(null, [image]);
+
+    const block = toFlowBlocks(doc).at(0);
+
+    expect(block?.kind).toBe("image");
+    if (block?.kind === "image") {
+      expect(block.height).toBe(0);
+    }
+  });
+
   test("drops PM null default for inline image opacity (ImageRun)", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -976,8 +976,8 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
     if (child.type.name === "image") {
       const attrs = expectImageAttrs(child);
       const constrained = constrainImageToPage(
-        attrs.width || 100,
-        attrs.height || 100,
+        attrs.width ?? 100,
+        attrs.height ?? 100,
         _options.pageContentHeight,
       );
       // Lift tracked-change marks off the image node so an inserted/deleted
@@ -2156,8 +2156,8 @@ function convertImage(node: PMNode, startPos: number, pageContentHeight?: number
   const shouldAnchor = wrapType === "behind" || wrapType === "inFront";
 
   const constrained = constrainImageToPage(
-    attrs.width || 100,
-    attrs.height || 100,
+    attrs.width ?? 100,
+    attrs.height ?? 100,
     pageContentHeight,
   );
 


### PR DESCRIPTION
## Summary
- preserve zero-valued image dimensions instead of replacing them with the 100 px fallback
- prevent subpixel OOXML placeholder images from inflating paragraph and header layout
- add a focused flow-conversion regression test

## Validation
- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts packages/core/src/paged-layout/headerFooterMargins.test.ts`
- visual parity rerun against a public Czech registry DOCX
- lint, typecheck, build, distribution validation, interaction tests, and differential parity are delegated to required CI

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved zero-sized image dimensions when converting Word documents.
  * Improved inline and standalone image layout handling so explicitly defined dimensions are retained.

* **Tests**
  * Added regression coverage for images with a height of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->