### PR TITLE
fix: preserve paragraph run defaults

### DIFF
--- a/.changeset/tiny-runs-inherit.md
+++ b/.changeset/tiny-runs-inherit.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve paragraph run defaults when runs override individual text properties.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -116,6 +116,40 @@ describe("toProseDoc", () => {
     expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(20);
   });
 
+  test("keeps paragraph font size when a run only overrides the font family", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  fontSize: 16,
+                  fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" },
+                  },
+                  content: [{ type: "text", text: " " }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(16);
+  });
+
   test("does not inherit paragraph mark all-caps onto visible text", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -868,7 +868,10 @@ function suppressParagraphMarkFormatting(
     return base;
   }
 
-  const result: TextFormatting = { ...base };
+  const result: TextFormatting = {
+    ...base,
+    ...paragraphMark,
+  };
   suppressBooleanParagraphMark(result, paragraphMark, direct, "bold");
   suppressBooleanParagraphMark(result, paragraphMark, direct, "italic");
   suppressBooleanParagraphMark(result, paragraphMark, direct, "strike");
@@ -890,7 +893,7 @@ function suppressParagraphMarkFormatting(
     // Word. Preserve any real style-level spacing; otherwise emit an explicit
     // zero so the paragraph's defaultTextFormatting cannot leak back into the
     // run when the PM document is converted to layout blocks.
-    result.spacing ??= 0;
+    result.spacing = 0;
   }
 
   return Object.keys(result).length > 0 ? result : undefined;


### PR DESCRIPTION
## Summary
- retain paragraph-level scalar text defaults when a run overrides a different property
- keep direct run values authoritative while preserving existing suppression for paragraph-mark-only bold, underline, and character spacing
- add a regression for paragraph font size plus direct run font family

## Parity impact
- public Czech registry DOCX score: 0.403 to 0.645
- y-drift findings: 26 to 2
- the final clause remains on the same first page as Word

## Validation
- `bun test packages/core/src/prosemirror/conversion/toProseDoc.test.ts packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts`
- `bun parity/cli.ts <registry-docx> --json`
- lint, typecheck, build, distribution validation, interaction tests, and differential parity are delegated to required CI

CC on behalf of @jan-kubica