### PR TITLE
feat: distinguish unsupported operation modes

### DIFF
--- a/.changeset/tidy-mice-explain.md
+++ b/.changeset/tidy-mice-explain.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": patch
+---
+
+Report unsupported document operation modes separately from unsupported blocks.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -178,7 +178,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -467,7 +467,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -467,7 +467,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.

--- a/packages/agents/src/execute.test.ts
+++ b/packages/agents/src/execute.test.ts
@@ -265,6 +265,41 @@ describe("executeFolioToolCall: happy path against a real FolioDocxReviewer", ()
     expect(result.skipped[0]?.reason).toContain("re-read the document");
   });
 
+  test("suggest_changes explains an unsupported mutation mode", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
+    const reviewerBridge = createReviewerBridge(reviewer);
+    const bridge = {
+      ...reviewerBridge,
+      applyDocumentOperations: (
+        batch: Parameters<typeof reviewerBridge.applyDocumentOperations>[0],
+      ) => ({
+        version: batch.version,
+        applied: [],
+        skipped: batch.operations.map(({ id }) => ({ id, reason: "unsupportedMode" as const })),
+      }),
+    };
+
+    const result = expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.suggestChanges,
+        {
+          operations: [
+            {
+              id: "custom-1",
+              type: "replaceInBlock",
+              blockId: "seq-0001",
+              find: "x",
+              replace: "y",
+            },
+          ],
+        },
+        bridge,
+      ),
+    ) as { skipped: { reason: string }[] };
+
+    expect(result.skipped[0]?.reason).toContain("mutation mode");
+  });
+
   test("suggest_changes rejects an empty operations array", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
     const bridge = createReviewerBridge(reviewer);

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -208,6 +208,9 @@ const explainSkipReason = (reason: string): string => {
   if (reason === "unsupportedBlock") {
     return "this block kind does not support this operation.";
   }
+  if (reason === "unsupportedMode") {
+    return "this operation does not support the requested mutation mode; inspect document operation capabilities and retry with a supported mode.";
+  }
   if (reason === "emptyOperation") {
     return "this operation has no effect; nothing to apply.";
   }

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1470,7 +1470,7 @@ describe("Folio AI edit operations", () => {
     });
 
     expect(result.applied).toEqual([]);
-    expect(result.skipped).toEqual([{ id: "op-1", reason: "unsupportedBlock" }]);
+    expect(result.skipped).toEqual([{ id: "op-1", reason: "unsupportedMode" }]);
     expect(view.state.doc.childCount).toBe(1);
   });
 
@@ -1492,7 +1492,7 @@ describe("Folio AI edit operations", () => {
     });
 
     expect(result.applied).toEqual([]);
-    expect(result.skipped).toEqual([{ id: "op-1", reason: "unsupportedBlock" }]);
+    expect(result.skipped).toEqual([{ id: "op-1", reason: "unsupportedMode" }]);
     expect(view.state.doc.childCount).toBe(1);
   });
 

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -536,7 +536,7 @@ export const applyFolioAIEditOperations = ({
         ) {
           skipped.push({
             id: item.operation.id,
-            reason: "unsupportedBlock",
+            reason: "unsupportedMode",
           });
           continue;
         }
@@ -597,7 +597,7 @@ export const applyFolioAIEditOperations = ({
         if (mode === "tracked-changes") {
           skipped.push({
             id: item.operation.id,
-            reason: "unsupportedBlock",
+            reason: "unsupportedMode",
           });
           continue;
         }

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -140,6 +140,7 @@ export type FolioAIEditSkipReason =
   | "ambiguousFind"
   | "missingFind"
   | "unsupportedBlock"
+  | "unsupportedMode"
   | "emptyOperation"
   /**
    * The operation would not change the document — find equals


### PR DESCRIPTION
Reports unsupported mutation modes separately from unsupported document blocks.