### PR TITLE
fix: detect media parity segments

### DIFF
--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -443,7 +443,10 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
     const lineEls = Array.from(el.querySelectorAll(".layout-line")) as HTMLElement[];
     const lines = lineEls.flatMap((lineEl) => {
       const segmentInkRect = (segmentEl: HTMLElement): DOMRect | null => {
-        if (segmentEl.querySelector("img, svg, canvas, video")) {
+        if (
+          segmentEl.matches("img, svg, canvas, video") ||
+          segmentEl.querySelector("img, svg, canvas, video")
+        ) {
           const rect = segmentEl.getBoundingClientRect();
           return rect.width > 0 && rect.height > 0 ? rect : null;
         }


### PR DESCRIPTION
## Summary
- detect media when the parity segment is itself an image, SVG, canvas, or video element
- retain the existing descendant-media detection and full visual bounds
- follow up on late review feedback from PR #111

## Validation
- `bun test parity/__tests__/folioExtract.test.ts`
- lint, typecheck, build, and the full test matrix are delegated to required CI

CC on behalf of @jan-kubica