### PR TITLE
fix: preserve named paragraph run fonts

### DIFF
--- a/.changeset/quiet-headers-inherit.md
+++ b/.changeset/quiet-headers-inherit.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep named paragraph style fonts on unformatted runs when the paragraph mark has separate formatting.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -150,6 +150,77 @@ describe("toProseDoc", () => {
     expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(16);
   });
 
+  test("keeps named paragraph style fonts ahead of paragraph-mark formatting", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                styleId: "Header",
+                runProperties: {
+                  fontSize: 11,
+                  fontFamily: { ascii: "Calibri", hAnsi: "Calibri" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {},
+                  content: [{ type: "text", text: "   " }],
+                },
+                {
+                  type: "run",
+                  formatting: {
+                    fontSize: 11,
+                    fontFamily: { ascii: "Calibri", hAnsi: "Calibri" },
+                  },
+                  content: [{ type: "text", text: "reference" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: {
+                fontSize: 12,
+                fontFamily: { ascii: "Times New Roman", hAnsi: "Times New Roman" },
+              },
+            },
+            {
+              styleId: "Header",
+              type: "paragraph",
+              basedOn: "Normal",
+              rPr: {
+                fontSize: 12,
+                fontFamily: { ascii: "Times New Roman", hAnsi: "Times New Roman" },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const spaces = doc.firstChild?.firstChild;
+    const reference = doc.firstChild?.maybeChild(1);
+
+    expect(spaces?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(12);
+    expect(spaces?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe(
+      "Times New Roman",
+    );
+    expect(reference?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(11);
+    expect(reference?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe(
+      "Calibri",
+    );
+  });
+
   test("does not inherit paragraph mark all-caps onto visible text", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -248,10 +248,13 @@ function convertParagraph(
     inheritableParagraphRunFormatting = stripParagraphMarkOnlyFormatting(paragraphRunFormatting);
   }
   const baseRunFormatting = mergeTextFormatting(styleRunFormatting, extraRunFormatting);
-  const defaultRunFormatting = mergeTextFormatting(
-    baseRunFormatting,
-    inheritableParagraphRunFormatting,
-  );
+  // With a named paragraph style, w:pPr/w:rPr formats the paragraph mark and
+  // only fills gaps in the style's body-run defaults. Style-less generated
+  // documents use the paragraph mark as their highest-precedence run default.
+  const paragraphMarkPrecedesStyle = paragraph.formatting?.styleId !== undefined;
+  const defaultRunFormatting = paragraphMarkPrecedesStyle
+    ? mergeTextFormatting(inheritableParagraphRunFormatting, baseRunFormatting)
+    : mergeTextFormatting(baseRunFormatting, inheritableParagraphRunFormatting);
   const getInheritedRunFormatting = (
     formatting: TextFormatting | undefined,
     fieldType?: string,
@@ -268,6 +271,7 @@ function convertParagraph(
       baseRunFormatting,
       inheritableParagraphRunFormatting,
       formatting,
+      paragraphMarkPrecedesStyle,
     );
   };
   const emitTrackedChange = (
@@ -863,15 +867,16 @@ function suppressParagraphMarkFormatting(
   base: TextFormatting | undefined,
   paragraphMark: TextFormatting | undefined,
   direct: TextFormatting | undefined,
+  paragraphMarkPrecedesStyle = false,
 ): TextFormatting | undefined {
   if (!paragraphMark) {
     return base;
   }
 
-  const result: TextFormatting = {
-    ...base,
-    ...paragraphMark,
-  };
+  const result =
+    (paragraphMarkPrecedesStyle
+      ? mergeTextFormatting(paragraphMark, base)
+      : mergeTextFormatting(base, paragraphMark)) ?? {};
   suppressBooleanParagraphMark(result, paragraphMark, direct, "bold");
   suppressBooleanParagraphMark(result, paragraphMark, direct, "italic");
   suppressBooleanParagraphMark(result, paragraphMark, direct, "strike");
@@ -968,16 +973,16 @@ function resolveParagraphDefaultTextFormatting(
       )
     : undefined;
 
-  return mergeTextFormatting(
+  const bodyRunDefaults = mergeTextFormatting(
     mergeTextFormatting(
-      mergeTextFormatting(
-        styleResolver.getDocDefaults()?.rPr,
-        styleResolver.getDefaultCharacterStyle()?.rPr,
-      ),
-      paragraphStyleRpr,
+      styleResolver.getDocDefaults()?.rPr,
+      styleResolver.getDefaultCharacterStyle()?.rPr,
     ),
-    paragraphRunProperties,
+    paragraphStyleRpr,
   );
+  return styleId === undefined
+    ? mergeTextFormatting(bodyRunDefaults, paragraphRunProperties)
+    : mergeTextFormatting(paragraphRunProperties, bodyRunDefaults);
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep named paragraph style run properties authoritative over paragraph-mark-only formatting
- retain the existing paragraph-mark fallback for style-less generated documents
- add a regression covering a styled header with separately formatted text

## Parity evidence
- Pages: 2 Word / 2 Folio
- Matched lines: 68 / 68
- Deterministic score: 0.6912 -> 0.7206
- Removes the repeated header x-drift on both pages

## Validation
- `bun test packages/core/src/prosemirror/conversion/toProseDoc.test.ts` (24 pass)
- parity CLI on the registry DOCX
- lint and typecheck intentionally delegated to CI