### PR TITLE
fix: use paragraph mark metrics for empty lines

### DIFF
--- a/.changeset/small-paragraphs-measure.md
+++ b/.changeset/small-paragraphs-measure.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Measure empty paragraphs with their direct paragraph-mark font metrics.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -5,6 +5,25 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("empty paragraph measurement uses direct paragraph-mark font metrics", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", {
+        styleId: "Heading6",
+        defaultTextFormatting: { fontSize: 22, fontFamily: { ascii: "Calibri" } },
+        _originalFormatting: {
+          styleId: "Heading6",
+          runProperties: { fontSize: 2, fontFamily: { ascii: "Arial" } },
+        },
+      }),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.defaultFontSize).toBe(1);
+    expect(paragraph?.attrs?.defaultFontFamily).toBe("Arial");
+  });
+
   test("preserves Word rendered-page-break hints for layout", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { renderedPageBreakBefore: true }, [schema.text("Next page")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1761,6 +1761,17 @@ function convertParagraph(
     options.originalListSeenNumIds,
   );
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
+  if (runs.length === 0) {
+    const paragraphMarkFormatting = pmAttrs._originalFormatting?.runProperties;
+    if (paragraphMarkFormatting?.fontSize !== undefined) {
+      attrs.defaultFontSize = paragraphMarkFormatting.fontSize / 2;
+    }
+    const paragraphMarkFontFamily =
+      paragraphMarkFormatting?.fontFamily?.ascii ?? paragraphMarkFormatting?.fontFamily?.hAnsi;
+    if (paragraphMarkFontFamily) {
+      attrs.defaultFontFamily = paragraphMarkFontFamily;
+    }
+  }
   if (runs.length === 0 && defaultTextFormatting?.hidden === true) {
     attrs.suppressEmptyParagraphHeight = true;
     if (attrs.listMarker !== undefined) {


### PR DESCRIPTION
## Summary
- measure empty paragraphs with direct paragraph-mark font metrics
- keep named paragraph style precedence unchanged for visible body runs
- add a focused conversion regression for a 1pt styled spacer

## Parity evidence
- Pages: 2 Word / 2 Folio
- Matched lines: 32 / 34
- Deterministic score: 0.5588 -> 0.8235
- Y-drift divergences: 12 -> 4
- Restores the final signature line to Word page 1

## Validation
- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts` (45 pass)
- parity CLI on the registry DOCX
- lint and typecheck intentionally delegated to CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout measurement for empty paragraphs by using their direct paragraph-mark font settings.
  * Empty paragraphs now preserve the correct font size and family during document conversion.

* **Tests**
  * Added coverage to verify accurate formatting and paragraph conversion for empty paragraphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->