### PR TITLE
fix: improve Aptos document layout

### DIFF
--- a/.changeset/quiet-aptos-spacing.md
+++ b/.changeset/quiet-aptos-spacing.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Improve Aptos document layout and preserve document-default spacing on empty paragraphs.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -179,7 +179,8 @@ export type ParagraphAttrs = {
     spaceAfter?: number;
     lineSpacing?: number;
     lineSpacingRule?: import__stll_docx_core_model.LineSpacingRule;
-    spacingExplicit?: SpacingExplicit;
+    spacingExplicit?: SpacingExplicit; /** Layout provenance: document defaults survive on empty paragraphs. */
+    spacingFromDocDefaults?: SpacingExplicit;
     indentLeft?: number;
     indentRight?: number;
     indentFirstLine?: number;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -288,7 +288,8 @@ export type ParagraphAttrs = {
     spaceAfter?: number;
     lineSpacing?: number;
     lineSpacingRule?: import__stll_docx_core_model.LineSpacingRule;
-    spacingExplicit?: SpacingExplicit;
+    spacingExplicit?: SpacingExplicit; /** Layout provenance: document defaults survive on empty paragraphs. */
+    spacingFromDocDefaults?: SpacingExplicit;
     indentLeft?: number;
     indentRight?: number;
     indentFirstLine?: number;

--- a/bun.lock
+++ b/bun.lock
@@ -35,14 +35,14 @@
     },
     "packages/agents": {
       "name": "@stll/folio-agents",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
       },
     },
     "packages/core": {
       "name": "@stll/folio-core",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@stll/docx-core": "^0.1.0",
         "@stll/docx-utils": "^0.1.0",
@@ -70,7 +70,7 @@
     },
     "packages/nuxt": {
       "name": "@stll/folio-nuxt",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@nuxt/kit": "^3.14.0 || ^4.0.0",
         "@stll/folio-vue": "workspace:^",
@@ -126,7 +126,7 @@
     },
     "packages/react": {
       "name": "@stll/folio-react",
-      "version": "0.3.0",
+      "version": "0.6.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",
         "@fontsource/arimo": "^5.2.8",
@@ -134,6 +134,7 @@
         "@fontsource/carlito": "^5.2.8",
         "@fontsource/cousine": "^5.2.7",
         "@fontsource/noto-sans-arabic": "^5.2.7",
+        "@fontsource/source-sans-3": "^5.2.9",
         "@fontsource/tinos": "^5.2.7",
         "@stll/folio-core": "workspace:^",
         "better-result": "2.9.2",
@@ -158,7 +159,7 @@
     },
     "packages/vue": {
       "name": "@stll/folio-vue",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
         "better-result": "2.9.2",
@@ -376,6 +377,8 @@
     "@fontsource/cousine": ["@fontsource/cousine@5.2.7", "", {}, "sha512-2l6qNHghWeQDGqaR1QmS8iR1YWzhZczcVQpR/MJVNSKE8bELI6v2Rqe+d4pFfG+5PY9QhvZ+aKriqlbKubcR8g=="],
 
     "@fontsource/noto-sans-arabic": ["@fontsource/noto-sans-arabic@5.2.10", "", {}, "sha512-Hgj3NwQJ0NquIADW3hFboFjsts4UvEOJQ8tOX0bhQZgpNKHsMawjv/1SZnq0QvRbP6efHTZM/A1k7tdy9S6sbA=="],
+
+    "@fontsource/source-sans-3": ["@fontsource/source-sans-3@5.2.9", "", {}, "sha512-u3ymIq4rfmCCyB9MEw/sFR5lPVJ1yTNXmIMbUz+9kVCFIHvNtfzXOEBuvkg3Tk0zhmioPeJ28ZK5smZ7TurezQ=="],
 
     "@fontsource/tinos": ["@fontsource/tinos@5.2.7", "", {}, "sha512-F+rSTz0CNDZ/nx3BlmVA+wlbfCR1gwXeJTkGxb6pwu5KjeWVyaZ6ioInm533pw2Ha7472Lwb4vLjzo1zT0RXmA=="],
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -261,6 +261,24 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.spacingExplicit?.after).toBe(true);
   });
 
+  test("keeps document-default spacing on an empty paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceAfter: 160,
+          spacingFromDocDefaults: { after: true },
+        },
+        [],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.after).toBe(160 / 15);
+    expect(paragraph?.attrs?.spacingExplicit?.after).toBe(true);
+  });
+
   test("suppresses empty hidden list paragraphs and their markers", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1388,11 +1388,15 @@ function convertParagraphAttrs(
       | { before?: boolean; after?: boolean }
       | null
       | undefined;
+    const spacingFromDocDefaults = pmAttrs.spacingFromDocDefaults as
+      | { before?: boolean; after?: boolean }
+      | null
+      | undefined;
     const explicit: { before?: boolean; after?: boolean } = {};
-    if (autoBefore || pmSpacingExplicit?.before) {
+    if (autoBefore || pmSpacingExplicit?.before || spacingFromDocDefaults?.before) {
       explicit.before = true;
     }
-    if (autoAfter || pmSpacingExplicit?.after) {
+    if (autoAfter || pmSpacingExplicit?.after || spacingFromDocDefaults?.after) {
       explicit.after = true;
     }
     if (explicit.before !== undefined || explicit.after !== undefined) {

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -314,6 +314,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   optionalShading(attrs, "shading", "paragraph.attrs.shading", issues);
   optionalTabStops(attrs, "tabs", "paragraph.attrs.tabs", issues);
   optionalRecord(attrs, "spacingExplicit", "paragraph.attrs.spacingExplicit", issues);
+  optionalRecord(attrs, "spacingFromDocDefaults", "paragraph.attrs.spacingFromDocDefaults", issues);
   optionalTextFormatting(
     attrs,
     "defaultTextFormatting",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -43,6 +43,26 @@ function firstTableCellAttrs(doc: Document): Record<string, unknown> {
 }
 
 describe("toProseDoc", () => {
+  test("tracks docDefaults spacing so empty paragraphs retain it during layout", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [{ type: "paragraph", content: [] }],
+        },
+        styles: {
+          docDefaults: { pPr: { spaceAfter: 160 } },
+          styles: [],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+
+    expect(doc.firstChild?.attrs.spaceAfter).toBe(160);
+    expect(doc.firstChild?.attrs.spacingFromDocDefaults).toEqual({ after: true });
+    expect(doc.firstChild?.attrs.spacingExplicit).toBeNull();
+  });
+
   test("applies oneNDA paragraph mark defaults to unformatted visible text like Word", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -552,6 +552,30 @@ function paragraphFormattingToAttrs(
     set("lineSpacing", formatting?.lineSpacing ?? stylePpr?.lineSpacing);
     set("lineSpacingRule", formatting?.lineSpacingRule ?? stylePpr?.lineSpacingRule);
     set("spacingExplicit", formatting?.spacingExplicit);
+    const paragraphStyle = styleId
+      ? (styleResolver.getStyle(styleId) ?? styleResolver.getDefaultParagraphStyle())
+      : styleResolver.getDefaultParagraphStyle();
+    const docDefaultSpacing = styleResolver.getDocDefaults()?.pPr;
+    const spacingFromDocDefaults: NonNullable<ParagraphAttrs["spacingFromDocDefaults"]> = {};
+    if (
+      formatting?.spaceBefore === undefined &&
+      tableParagraphOverlay?.spaceBefore === undefined &&
+      paragraphStyle?.pPr?.spaceBefore === undefined &&
+      docDefaultSpacing?.spaceBefore !== undefined
+    ) {
+      spacingFromDocDefaults.before = true;
+    }
+    if (
+      formatting?.spaceAfter === undefined &&
+      tableParagraphOverlay?.spaceAfter === undefined &&
+      paragraphStyle?.pPr?.spaceAfter === undefined &&
+      docDefaultSpacing?.spaceAfter !== undefined
+    ) {
+      spacingFromDocDefaults.after = true;
+    }
+    if (spacingFromDocDefaults.before || spacingFromDocDefaults.after) {
+      attrs.spacingFromDocDefaults = spacingFromDocDefaults;
+    }
     set("indentLeft", formatting?.indentLeft ?? stylePpr?.indentLeft);
     set("indentRight", formatting?.indentRight ?? stylePpr?.indentRight);
     // When the paragraph explicitly removes the style's numbering (direct

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -325,6 +325,7 @@ const paragraphNodeSpec: NodeSpec = {
     lineSpacing: { default: null },
     lineSpacingRule: { default: null },
     spacingExplicit: { default: null },
+    spacingFromDocDefaults: { default: null },
     indentLeft: { default: null },
     indentRight: { default: null },
     indentFirstLine: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -59,6 +59,8 @@ export type ParagraphAttrs = {
   lineSpacing?: number;
   lineSpacingRule?: LineSpacingRule;
   spacingExplicit?: SpacingExplicit;
+  /** Layout provenance: document defaults survive on empty paragraphs. */
+  spacingFromDocDefaults?: SpacingExplicit;
 
   // Indentation (in twips)
   indentLeft?: number;

--- a/packages/core/src/utils/fontLoader.ts
+++ b/packages/core/src/utils/fontLoader.ts
@@ -25,6 +25,8 @@ let isLoadingAny = false;
  * this map is used for font availability checks and preloading.
  */
 export const FONT_MAPPING: Record<string, string> = {
+  Aptos: "Source Sans 3",
+  "Aptos Display": "Source Sans 3",
   Calibri: "Carlito",
   Cambria: "Caladea",
   Arial: "Arimo",
@@ -48,6 +50,7 @@ const BUNDLED_FONTS = new Set([
   "Arimo",
   "Tinos",
   "Cousine",
+  "Source Sans 3",
   // Also register the Microsoft names since @font-face aliases exist
   "Calibri",
   "Cambria",

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -19,6 +19,8 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
   // This locks the facts driving FONT_MAPPINGS — a future edit that
   // hand-writes a different decimal into the table will fail here.
   const verifiedRatios: [font: string, expectedRatio: number][] = [
+    ["aptos", 1.2207],
+    ["aptos display", 1.2207],
     ["arial", 1.1499],
     ["times new roman", 1.1499],
     ["cg times", 1.1499],
@@ -43,6 +45,16 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
       expect(resolveFontFamily(font).singleLineRatio).toBeCloseTo(expectedRatio, 4);
     });
   }
+});
+
+describe("fontResolver — Aptos falls back to bundled Source Sans 3", () => {
+  test.each(["Aptos", "Aptos Display"])("%s keeps an Office-compatible fallback", (font) => {
+    const resolved = resolveFontFamily(font);
+
+    expect(resolved.googleFont).toBe("Source Sans 3");
+    expect(resolved.cssFallback).toContain("Source Sans 3");
+    expect(resolved.hasGoogleEquivalent).toBe(true);
+  });
 });
 
 describe("fontResolver — legacy Times-compatible faces", () => {

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -123,6 +123,12 @@ const JP_MEASURED_LINE_HEIGHT: FontLineHeight = {
   note: "Measured against real Word: 10.5pt Japanese body, non-grid section, renders at 13.68pt line pitch.",
 };
 
+const APTOS_MEASURED_LINE_HEIGHT: FontLineHeight = {
+  source: "measured",
+  ratio: 1.2207,
+  note: "Measured against real Word: 11pt Aptos body, non-grid section, renders at 13.43pt line pitch.",
+};
+
 /**
  * Mapping of common DOCX fonts to Google Fonts equivalents
  *
@@ -139,6 +145,18 @@ const JP_MEASURED_LINE_HEIGHT: FontLineHeight = {
  */
 const FONT_MAPPINGS: Record<string, FontMapping> = {
   // Microsoft Office fonts -> Google equivalents (via Croscore)
+  aptos: {
+    googleFont: "Source Sans 3",
+    category: "sans-serif",
+    fallbackStack: ["Aptos", "Source Sans 3", "Arial", "Helvetica", "sans-serif"],
+    singleLineRatio: singleLineRatioOf(APTOS_MEASURED_LINE_HEIGHT),
+  },
+  "aptos display": {
+    googleFont: "Source Sans 3",
+    category: "sans-serif",
+    fallbackStack: ["Aptos Display", "Source Sans 3", "Arial", "Helvetica", "sans-serif"],
+    singleLineRatio: singleLineRatioOf(APTOS_MEASURED_LINE_HEIGHT),
+  },
   calibri: {
     googleFont: "Carlito",
     category: "sans-serif",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,6 +53,7 @@
     "@fontsource/carlito": "^5.2.8",
     "@fontsource/cousine": "^5.2.7",
     "@fontsource/noto-sans-arabic": "^5.2.7",
+    "@fontsource/source-sans-3": "^5.2.9",
     "@fontsource/tinos": "^5.2.7",
     "@stll/folio-core": "workspace:^",
     "better-result": "2.9.2",

--- a/packages/react/src/styles/fonts.css
+++ b/packages/react/src/styles/fonts.css
@@ -14,6 +14,12 @@
 @import "@fontsource/carlito/700.css";
 @import "@fontsource/carlito/700-italic.css";
 
+/* Source Sans 3 → Aptos (default Word font since 2023) */
+@import "@fontsource/source-sans-3/400.css";
+@import "@fontsource/source-sans-3/400-italic.css";
+@import "@fontsource/source-sans-3/700.css";
+@import "@fontsource/source-sans-3/700-italic.css";
+
 /* Caladea → Cambria */
 @import "@fontsource/caladea/400.css";
 @import "@fontsource/caladea/400-italic.css";


### PR DESCRIPTION
## Summary
- map Aptos and Aptos Display to a bundled Source Sans 3 fallback with Word-measured line metrics
- preserve document-default paragraph spacing on empty paragraphs without serializing it as direct formatting
- add focused resolver and conversion regressions

## Parity
- score: `0.0000` → `0.2273`
- matched text lines: `22/22`
- pages: Word `1`, Folio `1`
- divergence count: `37` → `17`

## Local verification
- `bun test packages/core/src/utils/fontResolver.test.ts packages/core/src/prosemirror/conversion/toProseDoc.test.ts packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts`
- targeted layout parity run

Lint and typecheck are delegated to CI as requested.