### PR TITLE
fix: honor nested list start values

### DIFF
--- a/.changeset/calm-nested-starts.md
+++ b/.changeset/calm-nested-starts.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor authored numbering starts when a document begins at a nested list level.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -204,7 +204,8 @@ export type ParagraphAttrs = {
     listMarkerAllCaps?: boolean;
     listImplicitChildLevelAdvances?: number;
     listMarkerSecondSlotOffsetTwips?: number; /** Number format for each level used by multi-level marker templates. */
-    listLevelNumFmts?: import__stll_docx_core_model.NumberFormat[]; /** Abstract numbering ID shared by numbering instances. */
+    listLevelNumFmts?: import__stll_docx_core_model.NumberFormat[]; /** Initial counter for each level used by multi-level marker templates. */
+    listLevelStarts?: number[]; /** Abstract numbering ID shared by numbering instances. */
     listAbstractNumId?: number; /** Numbering start override for this numId/level. */
     listStartOverride?: number;
     styleId?: string;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -313,7 +313,8 @@ export type ParagraphAttrs = {
     listMarkerAllCaps?: boolean;
     listImplicitChildLevelAdvances?: number;
     listMarkerSecondSlotOffsetTwips?: number; /** Number format for each level used by multi-level marker templates. */
-    listLevelNumFmts?: import__stll_docx_core_model.NumberFormat[]; /** Abstract numbering ID shared by numbering instances. */
+    listLevelNumFmts?: import__stll_docx_core_model.NumberFormat[]; /** Initial counter for each level used by multi-level marker templates. */
+    listLevelStarts?: number[]; /** Abstract numbering ID shared by numbering instances. */
     listAbstractNumId?: number; /** Numbering start override for this numId/level. */
     listStartOverride?: number;
     styleId?: string;

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -585,6 +585,7 @@ export const applyFolioAIEditOperations = ({
             attrs["listMarker"] = null;
             attrs["listMarkerHidden"] = null;
             attrs["listLevelNumFmts"] = null;
+            attrs["listLevelStarts"] = null;
             attrs["listAbstractNumId"] = null;
             attrs["listStartOverride"] = null;
           }

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -136,7 +136,7 @@ const computeListMarker = (
   }
 
   if (!listCounters.has(numId)) {
-    listCounters.set(numId, Array.from<number>({ length: 9 }).fill(0));
+    listCounters.set(numId, Array.from<number>({ length: 9 }).fill(Number.NaN));
   }
 
   const counters = listCounters.get(numId);
@@ -147,21 +147,25 @@ const computeListMarker = (
   const abstractNumId = numbering.getAbstractNumId(numId);
   if (abstractNumId !== null && level > 0) {
     const latestAbstractCounters = abstractCounters.get(abstractNumId);
-    const missingParentCounters = counters.slice(0, level).every((value) => value === 0);
+    const missingParentCounters = counters.slice(0, level).every(Number.isNaN);
     if (missingParentCounters) {
       for (let i = 0; i < level; i += 1) {
-        counters[i] = latestAbstractCounters?.[i] ?? numbering.getLevel(numId, i)?.start ?? 0;
+        const latestCounter = latestAbstractCounters?.[i];
+        counters[i] =
+          latestCounter !== undefined && !Number.isNaN(latestCounter)
+            ? latestCounter
+            : (numbering.getLevel(numId, i)?.start ?? 1);
       }
     }
   }
 
-  if (counters[level] === 0) {
+  if (Number.isNaN(counters[level])) {
     counters[level] = (numbering.getLevel(numId, level)?.start ?? 1) - 1;
   }
-  counters[level] = (counters[level] || 0) + 1;
+  counters[level] = (counters[level] ?? 0) + 1;
 
   for (let i = level + 1; i < counters.length; i += 1) {
-    counters[i] = 0;
+    counters[i] = Number.NaN;
   }
 
   // Word's default LISTNUM field advances the counter at one ilvl deeper
@@ -171,7 +175,9 @@ const computeListMarker = (
   // pre-substituted "(a)" instead of "(b)".
   const childAdvances = listRendering.implicitChildLevelAdvances ?? 0;
   if (childAdvances > 0 && level + 1 < counters.length) {
-    counters[level + 1] = (counters[level + 1] ?? 0) + childAdvances;
+    const childCounter = counters[level + 1];
+    counters[level + 1] =
+      (childCounter === undefined || Number.isNaN(childCounter) ? 0 : childCounter) + childAdvances;
   }
 
   if (abstractNumId !== null) {

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -148,13 +148,16 @@ const computeListMarker = (
   if (abstractNumId !== null && level > 0) {
     const latestAbstractCounters = abstractCounters.get(abstractNumId);
     const missingParentCounters = counters.slice(0, level).every((value) => value === 0);
-    if (latestAbstractCounters && missingParentCounters) {
+    if (missingParentCounters) {
       for (let i = 0; i < level; i += 1) {
-        counters[i] = latestAbstractCounters[i] ?? 0;
+        counters[i] = latestAbstractCounters?.[i] ?? numbering.getLevel(numId, i)?.start ?? 0;
       }
     }
   }
 
+  if (counters[level] === 0) {
+    counters[level] = (numbering.getLevel(numId, level)?.start ?? 1) - 1;
+  }
   counters[level] = (counters[level] || 0) + 1;
 
   for (let i = level + 1; i < counters.length; i += 1) {

--- a/packages/core/src/docx/numbering-shared-abstract.test.ts
+++ b/packages/core/src/docx/numbering-shared-abstract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { parseBlockContent } from "./blockContentParser";
 import { parseNumbering } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
 import type { XmlElement } from "./xmlParser";
@@ -61,4 +62,34 @@ describe("paragraphParser exposes abstractNumId and startOverride for sharing", 
     const level = numbering.getLevel(1, 0);
     expect(level?.pPr?.indentLeft).toBe(0);
   });
+});
+
+test("nested numbering starts from authored levels when no parent paragraph exists", () => {
+  const numbering = parseNumbering(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="8">
+    <w:lvl w:ilvl="0"><w:start w:val="3"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="3"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2."/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="3"><w:abstractNumId w:val="8"/></w:num>
+</w:numbering>`);
+  const root = parseXmlDocument(
+    `<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="3"/></w:numPr></w:pPr><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="3"/></w:numPr></w:pPr><w:r><w:t>Second</w:t></w:r></w:p>
+    </w:body>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse body XML");
+  }
+
+  const paragraphs = parseBlockContent(root, null, null, numbering, null, null);
+
+  expect(paragraphs.at(0)?.type).toBe("paragraph");
+  expect(paragraphs.at(0)?.type === "paragraph" && paragraphs.at(0)?.listRendering?.marker).toBe(
+    "3.3.",
+  );
+  expect(paragraphs.at(1)?.type === "paragraph" && paragraphs.at(1)?.listRendering?.marker).toBe(
+    "3.4.",
+  );
 });

--- a/packages/core/src/docx/numbering-shared-abstract.test.ts
+++ b/packages/core/src/docx/numbering-shared-abstract.test.ts
@@ -93,3 +93,32 @@ test("nested numbering starts from authored levels when no parent paragraph exis
     "3.4.",
   );
 });
+
+test("zero-based numbering advances instead of repeatedly reinitializing", () => {
+  const numbering = parseNumbering(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="9">
+    <w:lvl w:ilvl="0"><w:start w:val="0"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2."/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="0"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2."/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="4"><w:abstractNumId w:val="9"/></w:num>
+</w:numbering>`);
+  const root = parseXmlDocument(
+    `<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="4"/></w:numPr></w:pPr><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="4"/></w:numPr></w:pPr><w:r><w:t>Second</w:t></w:r></w:p>
+    </w:body>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse body XML");
+  }
+
+  const paragraphs = parseBlockContent(root, null, null, numbering, null, null);
+
+  expect(paragraphs.at(0)?.type === "paragraph" && paragraphs.at(0)?.listRendering?.marker).toBe(
+    "0.0.",
+  );
+  expect(paragraphs.at(1)?.type === "paragraph" && paragraphs.at(1)?.listRendering?.marker).toBe(
+    "0.1.",
+  );
+});

--- a/packages/core/src/docx/numberingParser-custom-format.test.ts
+++ b/packages/core/src/docx/numberingParser-custom-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { resolveListTemplate } from "../layout-bridge/convert/toFlowBlocks";
-import { formatNumber, parseNumbering } from "./numberingParser";
+import { computeListRendering, formatNumber, parseNumbering } from "./numberingParser";
 
 const W = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 const MC = 'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"';
@@ -107,4 +107,18 @@ describe("custom numFmt inside mc:AlternateContent (#765)", () => {
     expect(formatNumber(7, "decimalZero4")).toBe("0007");
     expect(formatNumber(7, "decimalZero5")).toBe("00007");
   });
+});
+
+test("computeListRendering carries parent and current level starts", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W}>
+  <w:abstractNum w:abstractNumId="8">
+    <w:lvl w:ilvl="0"><w:start w:val="3"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="3"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2."/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="3"><w:abstractNumId w:val="8"/></w:num>
+</w:numbering>`;
+  const numbering = parseNumbering(xml);
+
+  expect(computeListRendering({ numId: 3, ilvl: 1 }, numbering)?.levelStarts).toEqual([3, 3]);
 });

--- a/packages/core/src/docx/numberingParser.ts
+++ b/packages/core/src/docx/numberingParser.ts
@@ -919,7 +919,7 @@ export function createNumberingMap(definitions: NumberingDefinitions): Numbering
 export function computeListRendering(
   numPr: { numId?: number; ilvl?: number },
   numbering: NumberingMap,
-): ListRendering | null {
+): (ListRendering & { levelStarts: number[] }) | null {
   const { numId, ilvl = 0 } = numPr;
   if (numId === undefined || numId === 0) {
     return null;
@@ -933,22 +933,24 @@ export function computeListRendering(
   // Collect numFmts for levels 0..ilvl so multi-level templates like "%1.%2."
   // can resolve each %N with its own format (legal numbering forces decimal).
   const levelNumFmts: NumberFormat[] = [];
+  const levelStarts: number[] = [];
   for (let i = 0; i <= ilvl; i += 1) {
-    levelNumFmts.push(
-      level.isLgl ? "decimal" : (numbering.getLevel(numId, i)?.numFmt ?? "decimal"),
-    );
+    const listLevel = numbering.getLevel(numId, i);
+    levelNumFmts.push(level.isLgl ? "decimal" : (listLevel?.numFmt ?? "decimal"));
+    levelStarts.push(listLevel?.start ?? 1);
   }
 
   const instance = numbering.getInstance(numId);
   const overrideForLevel = instance?.levelOverrides?.find((override) => override.ilvl === ilvl);
 
-  const rendering: ListRendering = {
+  const rendering: ListRendering & { levelStarts: number[] } = {
     level: ilvl,
     numId,
     marker: level.lvlText,
     isBullet: level.numFmt === "bullet",
     numFmt: level.isLgl ? "decimal" : level.numFmt,
     levelNumFmts,
+    levelStarts,
   };
   if (level.isLgl) {
     rendering.isLegal = true;

--- a/packages/core/src/docx/paragraphParser-numbering-indent.test.ts
+++ b/packages/core/src/docx/paragraphParser-numbering-indent.test.ts
@@ -102,6 +102,26 @@ describe("paragraphParser direct ind vs numbering level indent", () => {
   });
 });
 
+test("carries every relevant numbering-level start into list rendering", () => {
+  const numbering = parseNumbering(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="8">
+    <w:lvl w:ilvl="0"><w:start w:val="3"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="3"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2."/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="3"><w:abstractNumId w:val="8"/></w:num>
+</w:numbering>`);
+  const paragraph = parseParagraphXml(
+    `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="3"/></w:numPr></w:pPr>
+      <w:r><w:t>First visible child</w:t></w:r>
+    </w:p>`,
+    numbering,
+  );
+
+  expect(paragraph.listRendering).toHaveProperty("levelStarts", [3, 3]);
+});
+
 const W = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 
 // abstractNum 10 / numId 2 — level 0 carries a 360/360 hanging slot, the same

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1743,17 +1743,21 @@ export function parseParagraph(
       const level = numbering.getLevel(numId, ilvl);
       if (level) {
         const levelNumFmts: NonNullable<typeof paragraph.listRendering>["levelNumFmts"] = [];
+        const levelStarts: number[] = [];
         for (let levelIndex = 0; levelIndex <= ilvl; levelIndex += 1) {
-          levelNumFmts.push(
-            level.isLgl ? "decimal" : (numbering.getLevel(numId, levelIndex)?.numFmt ?? "decimal"),
-          );
+          const listLevel = numbering.getLevel(numId, levelIndex);
+          levelNumFmts.push(level.isLgl ? "decimal" : (listLevel?.numFmt ?? "decimal"));
+          levelStarts.push(listLevel?.start ?? 1);
         }
-        const listRendering: typeof paragraph.listRendering & object = {
+        const listRendering: NonNullable<typeof paragraph.listRendering> & {
+          levelStarts: number[];
+        } = {
           level: ilvl,
           numId,
           marker: level.lvlText,
           isBullet: level.numFmt === "bullet",
           levelNumFmts,
+          levelStarts,
         };
         const instance = numbering.getInstance(numId);
         const overrideForLevel = instance?.levelOverrides?.find(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1044,6 +1044,38 @@ describe("toFlowBlocks list numbering", () => {
     expect(blocks.at(1)?.attrs?.listMarker).toBe("3.4.");
   });
 
+  test("advances nested lists whose authored start is zero", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 4, ilvl: 1 },
+          listMarker: "%1.%2.",
+          listNumFmt: "decimal",
+          listLevelStarts: [0, 0],
+          listLevelNumFmts: ["decimal", "decimal"],
+        },
+        [schema.text("First")],
+      ),
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 4, ilvl: 1 },
+          listMarker: "%1.%2.",
+          listNumFmt: "decimal",
+          listLevelStarts: [0, 0],
+          listLevelNumFmts: ["decimal", "decimal"],
+        },
+        [schema.text("Second")],
+      ),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.at(0)?.attrs?.listMarker).toBe("0.0.");
+    expect(blocks.at(1)?.attrs?.listMarker).toBe("0.1.");
+  });
+
   test("formats legal multilevel markers with decimal parent placeholders", () => {
     const paragraphs = [];
     for (let index = 1; index <= 7; index += 1) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1012,6 +1012,38 @@ describe("toFlowBlocks list numbering", () => {
     expect(blocks.at(1)?.attrs?.listMarker).toBe("I.a)");
   });
 
+  test("uses authored starts when a nested list begins without parent paragraphs", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 8, ilvl: 1 },
+          listMarker: "%1.%2.",
+          listNumFmt: "decimal",
+          listLevelNumFmts: ["decimal", "decimal"],
+          listLevelStarts: [3, 3],
+        },
+        [schema.text("First visible child")],
+      ),
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 8, ilvl: 1 },
+          listMarker: "%1.%2.",
+          listNumFmt: "decimal",
+          listLevelNumFmts: ["decimal", "decimal"],
+          listLevelStarts: [3, 3],
+        },
+        [schema.text("Second visible child")],
+      ),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.at(0)?.attrs?.listMarker).toBe("3.3.");
+    expect(blocks.at(1)?.attrs?.listMarker).toBe("3.4.");
+  });
+
   test("formats legal multilevel markers with decimal parent placeholders", () => {
     const paragraphs = [];
     for (let index = 1; index <= 7; index += 1) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -238,7 +238,7 @@ function toLetter(value: number, upper: boolean): string {
 }
 
 export function formatCounter(value: number, format: NumberFormat | undefined): string {
-  if (value <= 0) {
+  if (!Number.isFinite(value)) {
     return "";
   }
   // NumberFormat is the OOXML w:numFmt enum (70+ values). This switch
@@ -284,10 +284,11 @@ export function resolveListTemplate(
     if (index < 0) {
       return "";
     }
-    const formatted = formatCounter(
-      counters[index] ?? 0,
-      forceDecimal ? "decimal" : levelFormats?.[index],
-    );
+    const counter = counters[index];
+    if (counter === undefined || Number.isNaN(counter)) {
+      return "";
+    }
+    const formatted = formatCounter(counter, forceDecimal ? "decimal" : levelFormats?.[index]);
     return formatted ? `${formatted}${punct}` : "";
   });
 }
@@ -334,14 +335,19 @@ function computeListMarker(
   }
 
   const level = pmAttrs.numPr?.ilvl ?? 0;
-  const counters = listCounters.get(numId) ?? (Array.from({ length: 9 }, () => 0) as number[]);
+  const counters =
+    listCounters.get(numId) ?? (Array.from({ length: 9 }, () => Number.NaN) as number[]);
   const abstractNumId = pmAttrs.listAbstractNumId;
   if (level > 0) {
     const latestAbstractCounters =
       abstractNumId === undefined ? undefined : abstractCounters.get(abstractNumId);
-    if (counters.slice(0, level).every((value) => value === 0)) {
+    if (counters.slice(0, level).every(Number.isNaN)) {
       for (let i = 0; i < level; i += 1) {
-        counters[i] = latestAbstractCounters?.[i] ?? pmAttrs.listLevelStarts?.[i] ?? 0;
+        const latestCounter = latestAbstractCounters?.[i];
+        counters[i] =
+          latestCounter !== undefined && !Number.isNaN(latestCounter)
+            ? latestCounter
+            : (pmAttrs.listLevelStarts?.[i] ?? 1);
       }
     }
   }
@@ -351,14 +357,14 @@ function computeListMarker(
     seenNumIds.add(seenKey);
     if (pmAttrs.listStartOverride != null) {
       counters[level] = pmAttrs.listStartOverride - 1;
-    } else if (counters[level] === 0) {
+    } else if (Number.isNaN(counters[level])) {
       counters[level] = (pmAttrs.listLevelStarts?.[level] ?? 1) - 1;
     }
   }
 
   counters[level] = (counters[level] ?? 0) + 1;
   for (let i = level + 1; i < counters.length; i += 1) {
-    counters[i] = 0;
+    counters[i] = Number.NaN;
   }
   // Word's default LISTNUM field advances the counter at one ilvl deeper
   // than the host paragraph. Carrying the consumed advances forward here
@@ -366,7 +372,9 @@ function computeListMarker(
   // OutNum2 "(a)") picks up the next letter instead of restarting at "(a)".
   const childAdvances = pmAttrs.listImplicitChildLevelAdvances ?? 0;
   if (childAdvances > 0 && level + 1 < counters.length) {
-    counters[level + 1] = (counters[level + 1] ?? 0) + childAdvances;
+    const childCounter = counters[level + 1];
+    counters[level + 1] =
+      (childCounter === undefined || Number.isNaN(childCounter) ? 0 : childCounter) + childAdvances;
   }
   listCounters.set(numId, counters);
   if (abstractNumId !== undefined) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -336,12 +336,12 @@ function computeListMarker(
   const level = pmAttrs.numPr?.ilvl ?? 0;
   const counters = listCounters.get(numId) ?? (Array.from({ length: 9 }, () => 0) as number[]);
   const abstractNumId = pmAttrs.listAbstractNumId;
-  if (abstractNumId !== undefined && level > 0) {
-    const latestAbstractCounters = abstractCounters.get(abstractNumId);
-    const missingParentCounters = counters.slice(0, level).every((value) => value === 0);
-    if (latestAbstractCounters && missingParentCounters) {
+  if (level > 0) {
+    const latestAbstractCounters =
+      abstractNumId === undefined ? undefined : abstractCounters.get(abstractNumId);
+    if (counters.slice(0, level).every((value) => value === 0)) {
       for (let i = 0; i < level; i += 1) {
-        counters[i] = latestAbstractCounters[i] ?? 0;
+        counters[i] = latestAbstractCounters?.[i] ?? pmAttrs.listLevelStarts?.[i] ?? 0;
       }
     }
   }
@@ -351,6 +351,8 @@ function computeListMarker(
     seenNumIds.add(seenKey);
     if (pmAttrs.listStartOverride != null) {
       counters[level] = pmAttrs.listStartOverride - 1;
+    } else if (counters[level] === 0) {
+      counters[level] = (pmAttrs.listLevelStarts?.[level] ?? 1) - 1;
     }
   }
 
@@ -1210,6 +1212,14 @@ function toPreviousListAttrs(previousFormatting: Record<string, unknown>): PMPar
   const listLevelNumFmts = readNumberFormats(previousFormatting["listLevelNumFmts"]);
   if (listLevelNumFmts) {
     attrs.listLevelNumFmts = listLevelNumFmts;
+  }
+
+  const listLevelStarts = previousFormatting["listLevelStarts"];
+  if (
+    Array.isArray(listLevelStarts) &&
+    listLevelStarts.every((value) => typeof value === "number")
+  ) {
+    attrs.listLevelStarts = listLevelStarts;
   }
 
   const listAbstractNumId = previousFormatting["listAbstractNumId"];

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -302,6 +302,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
     SECTION_BREAK_TYPES,
   );
   optionalStringArray(attrs, "listLevelNumFmts", "paragraph.attrs.listLevelNumFmts", issues);
+  optionalNumberArray(attrs, "listLevelStarts", "paragraph.attrs.listLevelStarts", issues);
   optionalNumber(attrs, "listAbstractNumId", "paragraph.attrs.listAbstractNumId", issues);
   optionalBorderMap(attrs, "borders", "paragraph.attrs.borders", issues, [
     "top",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -503,6 +503,12 @@ function paragraphFormattingToAttrs(
   if (paragraph.listRendering?.levelNumFmts) {
     attrs.listLevelNumFmts = paragraph.listRendering.levelNumFmts;
   }
+  if (paragraph.listRendering && "levelStarts" in paragraph.listRendering) {
+    const { levelStarts } = paragraph.listRendering;
+    if (Array.isArray(levelStarts) && levelStarts.every((value) => typeof value === "number")) {
+      attrs.listLevelStarts = levelStarts;
+    }
+  }
   if (paragraph.listRendering?.abstractNumId !== undefined) {
     attrs.listAbstractNumId = paragraph.listRendering.abstractNumId;
   }

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -344,6 +344,7 @@ const paragraphNodeSpec: NodeSpec = {
     listImplicitChildLevelAdvances: { default: null },
     listMarkerSecondSlotOffsetTwips: { default: null },
     listLevelNumFmts: { default: null },
+    listLevelStarts: { default: null },
     listAbstractNumId: { default: null },
     listStartOverride: { default: null },
     styleId: { default: null },

--- a/packages/core/src/prosemirror/extensions/features/ListExtension-suggestion.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension-suggestion.test.ts
@@ -84,6 +84,7 @@ describe("ListExtension suggestion mode integration", () => {
       listMarkerFontSize: null,
       listMarkerSuffix: null,
       listLevelNumFmts: null,
+      listLevelStarts: null,
       listAbstractNumId: null,
       listStartOverride: null,
     });

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -64,6 +64,7 @@ const LIST_FORMATTING_ATTRS = [
   "listMarkerFontSize",
   "listMarkerSuffix",
   "listLevelNumFmts",
+  "listLevelStarts",
   "listAbstractNumId",
   "listStartOverride",
 ] as const;

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -121,6 +121,8 @@ export type ParagraphAttrs = {
   listMarkerSecondSlotOffsetTwips?: number;
   /** Number format for each level used by multi-level marker templates. */
   listLevelNumFmts?: NumberFormat[];
+  /** Initial counter for each level used by multi-level marker templates. */
+  listLevelStarts?: number[];
   /** Abstract numbering ID shared by numbering instances. */
   listAbstractNumId?: number;
   /** Numbering start override for this numId/level. */

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -115,6 +115,7 @@ export function listAttrsFromResolvedStyle(
     listImplicitChildLevelAdvances: null,
     listMarkerSecondSlotOffsetTwips: null,
     listLevelNumFmts: rendering?.levelNumFmts ?? null,
+    listLevelStarts: rendering?.levelStarts ?? null,
     listAbstractNumId: rendering?.abstractNumId ?? null,
     listStartOverride: rendering?.startOverride ?? null,
   };


### PR DESCRIPTION
## Summary
- seed unseen parent counters from authored OOXML level starts instead of zero
- apply the current level start when a document begins directly at a nested level
- carry level-start metadata through ProseMirror for style-applied and edited lists
- add parser and layout regressions for `3.3`, `3.4` nested numbering

## Parity
- incorrect `0.x` markers: eliminated
- text mismatches: `28` → `22`
- total divergences: `129` → `126`
- score: `0.5889` → `0.5722` (three additional comparator pagination flags offset the corrected marker text)
- pages: Word `4`, Folio `5` (unchanged)

## Local verification
- focused numbering parser and flow-layout tests (68 passing)
- targeted layout parity run
- API snapshots regenerated after a core build

Lint and typecheck are delegated to CI as requested.