### PR TITLE
fix: collapse measured table row borders

### DIFF
--- a/.changeset/tidy-table-borders.md
+++ b/.changeset/tidy-table-borders.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Measure collapsed table borders consistently with the table painter.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -73,6 +73,33 @@ describe("measureBlocks", () => {
 });
 
 describe("measureTableBlock row height", () => {
+  test("counts a collapsed top border only on the first row", () => {
+    withFakeTextMeasure(() => {
+      const borderedCell = (id: string) => ({
+        id,
+        blocks: [para(`${id}-p`, "One line")],
+        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+        borders: { top: { width: 2 }, bottom: { width: 2 } },
+      });
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120],
+        rows: [
+          { id: "r0", cells: [borderedCell("first")] },
+          { id: "r1", cells: [borderedCell("second")] },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 120);
+      const firstContentHeight = measure.rows[0]?.cells[0]?.height ?? 0;
+      const secondContentHeight = measure.rows[1]?.cells[0]?.height ?? 0;
+
+      expect(measure.rows[0]?.height).toBe(firstContentHeight + 4);
+      expect(measure.rows[1]?.height).toBe(secondContentHeight + 2);
+    }, fakeMeasure);
+  });
+
   test("maxes per-cell content+border, not summed independent maxes", () => {
     withFakeTextMeasure(() => {
       // Cell A: more content (two paragraphs), thin border.

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -157,8 +157,11 @@ export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure
   return spacingBefore + maxImageHeight + spacingAfter;
 }
 
-function getTableCellVerticalBorderHeight(cell: TableCell | undefined): number {
-  const top = cell?.borders?.top?.width ?? 0;
+function getTableCellVerticalBorderHeight(
+  cell: TableCell | undefined,
+  isFirstRow: boolean,
+): number {
+  const top = isFirstRow ? (cell?.borders?.top?.width ?? 0) : 0;
   const bottom = cell?.borders?.bottom?.width ?? 0;
   return top + bottom;
 }
@@ -324,7 +327,7 @@ export function measureTableBlock(
       cell.height += padTop + padBottom;
       maxCellHeightWithBorders = Math.max(
         maxCellHeightWithBorders,
-        cell.height + getTableCellVerticalBorderHeight(sourceCell),
+        cell.height + getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0),
       );
     }
 


### PR DESCRIPTION
## Summary
- measure shared table-row borders once, matching the painter’s collapsed-border behavior
- add a targeted regression for multi-row table height
- improve layout fidelity on a an anonymized parity fixture from 0.169 to 0.663; y-drift findings fall from 49 to 8

: 

## Verification
- `bun test packages/core/src/layout-engine/measure/measureBlocks.test.ts` (11 passed)
- layout parity: Word 1 page / Folio 1 page; line-break findings unchanged at 20
- lint and typecheck delegated to CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected table row height calculations when borders are collapsed.
  * Shared borders between adjacent rows are now counted consistently, preventing excess spacing and ensuring accurate table layout.

* **Tests**
  * Added coverage verifying that collapsed top borders are counted only for the first row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->