### PR TITLE
fix: compare parity font environments

### DIFF
--- a/parity/README.md
+++ b/parity/README.md
@@ -46,4 +46,10 @@ The HTML report lands in `parity/report/index.html`.
 5. **Report** (`report.ts`): per-doc fidelity scores, the cluster ranking, and
    per-page Word-vs-folio renderings with both sets of line boxes overlaid.
 
+Font preflight compares the family Word embedded in its PDF with Chromium's
+resolved CSS family on matching text lines. A requested font may be substituted
+without invalidating the run when both renderers use the same fallback
+(`font-shared:*`). `font-renderer-mismatch` means geometry may primarily reflect
+different font metrics and the document should not drive a layout fix.
+
 Shared data contract: `types.ts`. Tolerances and paths: `config.ts`.

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  assessFontEnvironment,
   attributeDivergences,
   clusterCorpus,
   computeFontSubstitutionTags,
+  fontFamiliesMatch,
   scanDocumentXml,
 } from "../features";
 import type { DocFeatures, ParagraphFeatures } from "../features";
-import type { Divergence, FeatureAttributedResult, ParityResult } from "../types";
+import type { Divergence, DocGeom, FeatureAttributedResult, ParityResult } from "../types";
 
 const wrapBody = (body: string): string =>
   `<?xml version="1.0"?><w:document><w:body>${body}</w:body></w:document>`;
@@ -501,5 +503,92 @@ describe("computeFontSubstitutionTags", () => {
     expect(
       computeFontSubstitutionTags(["Calibri", "calibri", "Missing Font"], ["ABCDEF+Calibri-Bold"]),
     ).toEqual(["font-substituted:missingfont"]);
+  });
+});
+
+const fontGeom = (source: "word" | "folio", lines: Array<[string, string]>): DocGeom => ({
+  source,
+  file: "/font-test.docx",
+  pages: [
+    {
+      number: 1,
+      widthPt: 600,
+      heightPt: 800,
+      lines: lines.map(([text, fontName], index) => ({
+        text,
+        normText: text,
+        xPt: 0,
+        yPt: index * 12,
+        widthPt: 100,
+        heightPt: 12,
+        fontName,
+        region: "body",
+      })),
+    },
+  ],
+  meta: {},
+});
+
+describe("assessFontEnvironment", () => {
+  test("recognizes equivalent PDF and CSS family names", () => {
+    expect(fontFamiliesMatch("ArialMT", "Arial")).toBe(true);
+    expect(fontFamiliesMatch("ABCDEF+Calibri-BoldItalic", "Calibri")).toBe(true);
+    expect(fontFamiliesMatch("Interstate-Bold", "Inter")).toBe(false);
+  });
+
+  test("accepts a shared substituted family", () => {
+    const assessment = assessFontEnvironment(
+      ["Times New Roman"],
+      fontGeom("word", [["Shared line", "Tinos-Regular"]]),
+      fontGeom("folio", [["Shared line", "Tinos"]]),
+    );
+
+    expect(assessment).toEqual({
+      status: "shared-substitution",
+      tags: ["font-shared:timesnewroman"],
+      comparedLines: 1,
+      matchingLines: 1,
+    });
+  });
+
+  test("rejects a cross-renderer family mismatch", () => {
+    const assessment = assessFontEnvironment(
+      ["Times New Roman"],
+      fontGeom("word", [["Same text", "LiberationSerif"]]),
+      fontGeom("folio", [["Same text", "Tinos"]]),
+    );
+
+    expect(assessment).toEqual({
+      status: "mismatch",
+      tags: ["font-renderer-mismatch", "font-substituted:timesnewroman"],
+      comparedLines: 1,
+      matchingLines: 0,
+    });
+  });
+
+  test("rejects a renderer mismatch even when Word used the requested font", () => {
+    const assessment = assessFontEnvironment(
+      ["Arial"],
+      fontGeom("word", [["Same text", "ArialMT"]]),
+      fontGeom("folio", [["Same text", "Helvetica"]]),
+    );
+
+    expect(assessment).toEqual({
+      status: "mismatch",
+      tags: ["font-renderer-mismatch"],
+      comparedLines: 1,
+      matchingLines: 0,
+    });
+  });
+
+  test("reports unverified when no font-bearing text can be paired", () => {
+    const assessment = assessFontEnvironment(
+      ["Arial"],
+      fontGeom("word", [["Word only", "ArialMT"]]),
+      fontGeom("folio", [["Folio only", "Arial"]]),
+    );
+
+    expect(assessment.status).toBe("unverified");
+    expect(assessment.tags).toEqual(["font-parity-unverified"]);
   });
 });

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -24,7 +24,7 @@ import { DEFAULT_CORPUS_DIRS } from "./config";
 import {
   attributeDivergences,
   clusterCorpus,
-  detectFontSubstitution,
+  detectFontEnvironment,
   extractDocFeatures,
 } from "./features";
 import type { ParagraphFeatures } from "./features";
@@ -232,13 +232,20 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
 
         // oxlint-disable-next-line no-await-in-loop -- sequential per-doc pipeline
         const docFeatures = await extractDocFeatures(doc);
-        // Ground truth rendered with substituted fonts (doc requests a font
-        // this machine's Word lacks) is a first-class doc-level condition:
-        // its divergences may be font availability, not folio layout bugs.
-        const substitutionTags = detectFontSubstitution(doc, wordGeom);
-        if (substitutionTags.length > 0) {
-          docFeatures.docFeatures.push(...substitutionTags);
-          process.stderr.write(`(ground truth font-substituted: ${substitutionTags.join(", ")}) `);
+        const fontEnvironment = detectFontEnvironment(doc, wordGeom, folio.geom);
+        if (fontEnvironment.tags.length > 0) {
+          docFeatures.docFeatures.push(...fontEnvironment.tags);
+        }
+        if (fontEnvironment.status === "shared-substitution") {
+          process.stderr.write(
+            `(shared substituted font: ${fontEnvironment.tags.join(", ")}; ${fontEnvironment.comparedLines} lines) `,
+          );
+        } else if (fontEnvironment.status === "mismatch") {
+          process.stderr.write(
+            `(Word/Folio font mismatch: ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} lines match) `,
+          );
+        } else if (fontEnvironment.status === "unverified") {
+          process.stderr.write("(Word/Folio font parity unverified) ");
         }
         const attributed = attributeDivergences(result, docFeatures);
 

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -395,6 +395,95 @@ export const computeFontSubstitutionTags = (
   return tags;
 };
 
+export type FontEnvironmentAssessment = {
+  status: "native" | "shared-substitution" | "mismatch" | "unverified";
+  tags: string[];
+  comparedLines: number;
+  matchingLines: number;
+};
+
+/** Whether two renderer-reported names identify the same font family. PDF
+ * PostScript names commonly carry style suffixes (`ArialMT`,
+ * `Calibri-Bold`), while CSS reports the undecorated family. */
+export const fontFamiliesMatch = (leftRaw: string, rightRaw: string): boolean => {
+  const left = normalizeFontName(leftRaw);
+  const right = normalizeFontName(rightRaw);
+  if (left.length === 0 || right.length === 0) return false;
+  return observedSatisfiesRequested(left, right) || observedSatisfiesRequested(right, left);
+};
+
+const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): Array<[string, string]> => {
+  const folioFontsByText = new Map<string, string[]>();
+  for (const page of folioGeom.pages) {
+    for (const line of page.lines) {
+      if (line.fontName === undefined) continue;
+      const fonts = folioFontsByText.get(line.normText);
+      if (fonts) {
+        fonts.push(line.fontName);
+      } else {
+        folioFontsByText.set(line.normText, [line.fontName]);
+      }
+    }
+  }
+
+  const pairs: Array<[string, string]> = [];
+  for (const page of wordGeom.pages) {
+    for (const line of page.lines) {
+      if (line.fontName === undefined) continue;
+      const folioFonts = folioFontsByText.get(line.normText);
+      const folioFont = folioFonts?.shift();
+      if (folioFont !== undefined) {
+        pairs.push([line.fontName, folioFont]);
+      }
+    }
+  }
+  return pairs;
+};
+
+/** Classify the actual fonts resolved by Word and Chromium. Requested-font
+ * substitution is harmless for geometric parity when both renderers resolve
+ * every comparable line to the same family. */
+export const assessFontEnvironment = (
+  requestedFonts: string[],
+  wordGeom: DocGeom,
+  folioGeom: DocGeom,
+): FontEnvironmentAssessment => {
+  const observedWordFonts = wordGeom.pages.flatMap((page) =>
+    page.lines.flatMap((line) => (line.fontName === undefined ? [] : [line.fontName])),
+  );
+  const substitutionTags = computeFontSubstitutionTags(requestedFonts, observedWordFonts);
+  const pairs = collectFontPairs(wordGeom, folioGeom);
+  const matchingLines = pairs.filter(([wordFont, folioFont]) =>
+    fontFamiliesMatch(wordFont, folioFont),
+  ).length;
+
+  if (pairs.length === 0) {
+    return {
+      status: "unverified",
+      tags: ["font-parity-unverified"],
+      comparedLines: 0,
+      matchingLines: 0,
+    };
+  }
+  if (matchingLines !== pairs.length) {
+    return {
+      status: "mismatch",
+      tags: ["font-renderer-mismatch", ...substitutionTags],
+      comparedLines: pairs.length,
+      matchingLines,
+    };
+  }
+  if (substitutionTags.length > 0) {
+    return {
+      status: "shared-substitution",
+      tags: substitutionTags.map((tag) => tag.replace("font-substituted:", "font-shared:")),
+      comparedLines: pairs.length,
+      matchingLines,
+    };
+  }
+  return { status: "native", tags: [], comparedLines: pairs.length, matchingLines };
+};
+
 const RFONTS_ASCII_RE = /<w:rFonts\b[^>]*\bw:(?:ascii|hAnsi)="([^"]+)"/g;
 
 /** Font families the document actually asks for: every `w:rFonts` ascii/hAnsi
@@ -424,12 +513,12 @@ const collectRequestedFonts = (docxPath: string): string[] => {
  * warning. Returned tags (e.g. "font-substituted:inter") are meant to be
  * appended to `DocFeatures.docFeatures` before attribution.
  */
-export const detectFontSubstitution = (docxPath: string, wordGeom: DocGeom): string[] => {
-  const observedPdfFonts = wordGeom.pages.flatMap((page) =>
-    page.lines.flatMap((line) => (line.fontName === undefined ? [] : [line.fontName])),
-  );
-  return computeFontSubstitutionTags(collectRequestedFonts(docxPath), observedPdfFonts);
-};
+export const detectFontEnvironment = (
+  docxPath: string,
+  wordGeom: DocGeom,
+  folioGeom: DocGeom,
+): FontEnvironmentAssessment =>
+  assessFontEnvironment(collectRequestedFonts(docxPath), wordGeom, folioGeom);
 
 // ---------------------------------------------------------------------------
 // divergence -> paragraph attribution


### PR DESCRIPTION
## Summary
- compare Word PDF fonts with Chromium-resolved fonts on matching text lines
- accept shared substitutions while flagging real cross-renderer mismatches
- document the font preflight and cover native, shared, mismatched, and unverified cases

## Verification
- `bun test parity/__tests__/features.test.ts parity/__tests__/folioExtract.test.ts parity/__tests__/stextParse.test.ts` (66 passed)
- validated against five public Czech registry attachments: shared Times New Roman fallbacks are accepted while differing renderer families are rejected
- lint and typecheck delegated to CI