### PR TITLE
feat: add document operation preconditions

### DIFF
--- a/.changeset/calm-mails-guard.md
+++ b/.changeset/calm-mails-guard.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": patch
+---
+
+Add serialized block text preconditions to document operations.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -54,6 +54,9 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 }>;
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
 
 // @public (undocumented)
@@ -118,7 +121,9 @@ export type FolioAIEditApplyResult = {
 };
 
 // @public (undocumented)
-export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
+export type FolioAIEditOperation = FolioAIEditReviewMeta & {
+    precondition?: FolioAIEditPrecondition;
+} & ({
     id: string;
     type: "replaceInBlock";
     blockId: string;
@@ -162,6 +167,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
     comment?: FolioAIComment;
 });
 
+// @public (undocumented)
+export type FolioAIEditPrecondition = {
+    blockTextHash: string;
+};
+
 // @public
 export type FolioAIEditReviewMeta = {
     severity?: FolioAIEditSeverity;
@@ -178,7 +188,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "preconditionFailed" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.
@@ -228,11 +238,15 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
 
 // @public (undocumented)
 export type FolioDocumentOperationMode = FolioAIEditApplyMode;
+
+// @public (undocumented)
+export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 
 // @public (undocumented)
 export type FolioDocumentOperationResult = {

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -343,6 +343,9 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 }>;
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
 
 // @public (undocumented)
@@ -407,7 +410,9 @@ export type FolioAIEditApplyResult = {
 };
 
 // @public (undocumented)
-export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
+export type FolioAIEditOperation = FolioAIEditReviewMeta & {
+    precondition?: FolioAIEditPrecondition;
+} & ({
     id: string;
     type: "replaceInBlock";
     blockId: string;
@@ -451,6 +456,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
     comment?: FolioAIComment;
 });
 
+// @public (undocumented)
+export type FolioAIEditPrecondition = {
+    blockTextHash: string;
+};
+
 // @public
 export type FolioAIEditReviewMeta = {
     severity?: FolioAIEditSeverity;
@@ -467,7 +477,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "preconditionFailed" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.
@@ -509,11 +519,15 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
 
 // @public (undocumented)
 export type FolioDocumentOperationMode = FolioAIEditApplyMode;
+
+// @public (undocumented)
+export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 
 // @public (undocumented)
 export type FolioDocumentOperationResult = {

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -343,6 +343,9 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 }>;
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
 
 // @public (undocumented)
@@ -407,7 +410,9 @@ export type FolioAIEditApplyResult = {
 };
 
 // @public (undocumented)
-export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
+export type FolioAIEditOperation = FolioAIEditReviewMeta & {
+    precondition?: FolioAIEditPrecondition;
+} & ({
     id: string;
     type: "replaceInBlock";
     blockId: string;
@@ -451,6 +456,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
     comment?: FolioAIComment;
 });
 
+// @public (undocumented)
+export type FolioAIEditPrecondition = {
+    blockTextHash: string;
+};
+
 // @public
 export type FolioAIEditReviewMeta = {
     severity?: FolioAIEditSeverity;
@@ -467,7 +477,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "preconditionFailed" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.
@@ -509,11 +519,15 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
 
 // @public (undocumented)
 export type FolioDocumentOperationMode = FolioAIEditApplyMode;
+
+// @public (undocumented)
+export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 
 // @public (undocumented)
 export type FolioDocumentOperationResult = {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -79,6 +79,9 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 }>;
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
 
 // @public (undocumented)
@@ -135,7 +138,9 @@ export type FolioAIEditApplyResult = {
 };
 
 // @public (undocumented)
-export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
+export type FolioAIEditOperation = FolioAIEditReviewMeta & {
+    precondition?: FolioAIEditPrecondition;
+} & ({
     id: string;
     type: "replaceInBlock";
     blockId: string;
@@ -180,6 +185,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & ({
 });
 
 // @public (undocumented)
+export type FolioAIEditPrecondition = {
+    blockTextHash: string;
+};
+
+// @public (undocumented)
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
     anchors: Record<string, FolioAIBlockAnchor>;
@@ -215,11 +225,15 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
 
 // @public (undocumented)
 export type FolioDocumentOperationMode = FolioAIEditApplyMode;
+
+// @public (undocumented)
+export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 
 // @public (undocumented)
 export type FolioDocumentOperationResult = {

--- a/packages/agents/src/execute.test.ts
+++ b/packages/agents/src/execute.test.ts
@@ -265,6 +265,52 @@ describe("executeFolioToolCall: happy path against a real FolioDocxReviewer", ()
     expect(result.skipped[0]?.reason).toContain("re-read the document");
   });
 
+  test("suggest_changes attaches a block-text precondition and explains a stale target", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
+    const reviewerBridge = createReviewerBridge(reviewer);
+    const heading = reviewer.snapshot().blocks.find(({ text }) => text.includes("Heading"));
+    if (!heading) {
+      throw new Error("expected a heading block");
+    }
+    let receivedPrecondition: { blockTextHash: string } | undefined;
+    const bridge = {
+      ...reviewerBridge,
+      applyDocumentOperations: (
+        batch: Parameters<typeof reviewerBridge.applyDocumentOperations>[0],
+      ) => {
+        receivedPrecondition = batch.operations.at(0)?.precondition;
+        return {
+          version: batch.version,
+          applied: [],
+          skipped: [{ id: "custom-1", reason: "preconditionFailed" as const }],
+        };
+      },
+    };
+
+    const result = expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.suggestChanges,
+        {
+          operations: [
+            {
+              id: "custom-1",
+              type: "replaceInBlock",
+              blockId: heading.id,
+              find: "Heading",
+              replace: "Intro",
+            },
+          ],
+        },
+        bridge,
+      ),
+    ) as { skipped: { reason: string }[] };
+
+    expect(receivedPrecondition).toEqual({
+      blockTextHash: reviewer.snapshot().anchors[heading.id]?.textHash,
+    });
+    expect(result.skipped[0]?.reason).toContain("re-read the document");
+  });
+
   test("suggest_changes explains an unsupported mutation mode", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
     const reviewerBridge = createReviewerBridge(reviewer);

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -211,6 +211,9 @@ const explainSkipReason = (reason: string): string => {
   if (reason === "unsupportedMode") {
     return "this operation does not support the requested mutation mode; inspect document operation capabilities and retry with a supported mode.";
   }
+  if (reason === "preconditionFailed") {
+    return "the target block changed after the operation was prepared; re-read the document and retry with a fresh operation.";
+  }
   if (reason === "emptyOperation") {
     return "this operation has no effect; nothing to apply.";
   }
@@ -236,13 +239,23 @@ const summarizeApplyResult = (result: {
 const applyOperations = (
   bridge: FolioAgentBridge,
   operations: FolioDocumentOperation[],
-): FolioAgentApplyOperationsSummary =>
-  summarizeApplyResult(
+): FolioAgentApplyOperationsSummary => {
+  const snapshot = bridge.snapshot();
+  const guardedOperations: FolioDocumentOperation[] = [];
+  for (const operation of operations) {
+    const blockTextHash = snapshot.anchors[operation.blockId]?.textHash;
+    guardedOperations.push({
+      ...operation,
+      ...(blockTextHash !== undefined && { precondition: { blockTextHash } }),
+    });
+  }
+  return summarizeApplyResult(
     bridge.applyDocumentOperations({
       version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
-      operations,
+      operations: guardedOperations,
     }),
   );
+};
 
 const addComment = (args: unknown, bridge: FolioAgentBridge): FolioToolCallResult => {
   const parsed = parseAddCommentInput(args);

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -506,6 +506,39 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.child(0).textContent).toBe("Payment changed.");
   });
 
+  test("serialized precondition detects a stale target with a fresh apply snapshot", () => {
+    const originalState = makeState([{ text: "Payment.", paraId: "AAAA0001" }]);
+    const originalSnapshot = createFolioAIEditSnapshot(originalState.doc);
+    const view = makeView(makeState([{ text: "Payment changed.", paraId: "AAAA0001" }]));
+    const currentSnapshot = createFolioAIEditSnapshot(view.state.doc);
+    const blockTextHash = originalSnapshot.anchors["AAAA0001"]?.textHash;
+    if (blockTextHash === undefined) {
+      throw new Error("expected the original block anchor");
+    }
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: currentSnapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "replaceInBlock",
+          blockId: "AAAA0001",
+          find: "Payment changed",
+          replace: "Charge",
+          precondition: { blockTextHash },
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "op-1", reason: "preconditionFailed" }],
+    });
+    expect(view.state.doc.child(0).textContent).toBe("Payment changed.");
+  });
+
   test("paraId-anchored op skips when the live paraId is gone", () => {
     const originalState = makeState([{ text: "Payment.", paraId: "AAAA0001" }]);
     const snapshot = createFolioAIEditSnapshot(originalState.doc);

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -933,6 +933,12 @@ const resolveOperation = ({
   const cleanBlock = buildCleanBlockText(blockNode, blockFrom);
   const currentText = cleanBlock.text;
   const currentTextHash = hashFolioAIBlockText(normalizeFolioAIBlockText(currentText));
+  if (
+    operation.precondition !== undefined &&
+    currentTextHash !== operation.precondition.blockTextHash
+  ) {
+    return { type: "skip", reason: "preconditionFailed" };
+  }
   if (currentTextHash !== anchor.textHash) {
     return { type: "skip", reason: "changedBlock" };
   }

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -25,6 +25,7 @@ export type {
   FolioAIEditApplyMode,
   FolioAIEditApplyResult,
   FolioAIEditOperation,
+  FolioAIEditPrecondition,
   FolioAIEditReviewMeta,
   FolioAIEditSeverity,
   FolioAIEditSkipReason,
@@ -38,6 +39,7 @@ export {
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   FOLIO_DOCUMENT_OPERATION_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
+  FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   FOLIO_DOCUMENT_OPERATION_STORIES,
   FOLIO_DOCUMENT_OPERATION_TYPES,
   getFolioDocumentOperationCapabilities,
@@ -51,6 +53,7 @@ export {
   type FolioDocumentOperationBatch,
   type FolioDocumentOperationCapabilities,
   type FolioDocumentOperationMode,
+  type FolioDocumentOperationPrecondition,
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
 } from "../document-operations";

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -52,6 +52,10 @@ export type FolioAIEditReviewMeta = {
   area?: string;
 };
 
+export type FolioAIEditPrecondition = {
+  blockTextHash: string;
+};
+
 /**
  * A party in an `insertSignatureTable` op. Mirrors the
  * `signatureTable` helper in `docx-core/legal-source/compile.ts`:
@@ -64,8 +68,9 @@ export type FolioAISignatureParty = {
   title?: string;
 };
 
-export type FolioAIEditOperation = FolioAIEditReviewMeta &
-  (
+export type FolioAIEditOperation = FolioAIEditReviewMeta & {
+  precondition?: FolioAIEditPrecondition;
+} & (
     | {
         id: string;
         type: "replaceInBlock";
@@ -141,6 +146,7 @@ export type FolioAIEditSkipReason =
   | "missingFind"
   | "unsupportedBlock"
   | "unsupportedMode"
+  | "preconditionFailed"
   | "emptyOperation"
   /**
    * The operation would not change the document — find equals

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -4,6 +4,7 @@ import {
   assertSupportedFolioDocumentOperationVersion,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
+  FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   getFolioDocumentOperationCapabilities,
   isFolioDocumentOperationModeSupported,
   InvalidFolioDocumentOperationBatchError,
@@ -35,6 +36,7 @@ describe("document operation contract", () => {
         commentOnBlock: ["direct", "tracked-changes"],
         insertSignatureTable: ["direct"],
       },
+      preconditions: ["blockTextHash"],
       stories: ["main"],
     });
   });
@@ -51,6 +53,7 @@ describe("document operation contract", () => {
     expect(Object.keys(FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE)).toEqual(
       getFolioDocumentOperationCapabilities().operationTypes,
     );
+    expect(FOLIO_DOCUMENT_OPERATION_PRECONDITIONS).toEqual(["blockTextHash"]);
   });
 
   test("checks untyped contract versions at a serialization boundary", () => {
@@ -71,7 +74,14 @@ describe("document operation contract", () => {
       version: 1,
       mode: "tracked-changes",
       operations: [
-        { id: "1", type: "replaceInBlock", blockId: "a", find: "old", replace: "new" },
+        {
+          id: "1",
+          type: "replaceInBlock",
+          blockId: "a",
+          find: "old",
+          replace: "new",
+          precondition: { blockTextHash: "h123" },
+        },
         { id: "2", type: "insertAfterBlock", blockId: "a", text: "after" },
         { id: "3", type: "insertBeforeBlock", blockId: "a", text: "before" },
         { id: "4", type: "replaceBlock", blockId: "a", text: "replacement" },
@@ -102,6 +112,21 @@ describe("document operation contract", () => {
     [null, "$", "expected an object"],
     [{ version: 1 }, "$.operations", "expected an array"],
     [{ version: 1, operations: [], mode: "review" }, "$.mode", "expected"],
+    [
+      {
+        version: 1,
+        operations: [
+          {
+            id: "1",
+            type: "deleteBlock",
+            blockId: "a",
+            precondition: { blockTextHash: "not-a-hash" },
+          },
+        ],
+      },
+      "$.operations[0].precondition.blockTextHash",
+      "expected a normalized block text hash",
+    ],
     [
       { version: 1, operations: [{ id: "1", type: "unknown", blockId: "a" }] },
       "$.operations[0].type",

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -5,6 +5,7 @@ import type {
   FolioAIEditAppliedOperation,
   FolioAIEditApplyMode,
   FolioAIEditOperation,
+  FolioAIEditPrecondition,
   FolioAIEditReviewMeta,
   FolioAIEditSeverity,
   FolioAIEditSkippedOperation,
@@ -29,9 +30,11 @@ export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
 ] as const satisfies readonly FolioAIEditApplyMode[]);
 
 export const FOLIO_DOCUMENT_OPERATION_STORIES = Object.freeze(["main"] as const);
+export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS = Object.freeze(["blockTextHash"] as const);
 
 export type FolioDocumentOperation = FolioAIEditOperation;
 export type FolioDocumentOperationMode = FolioAIEditApplyMode;
+export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];
 
 const DIRECT_AND_TRACKED_MODES = FOLIO_DOCUMENT_OPERATION_MODES;
@@ -56,6 +59,7 @@ export type FolioDocumentOperationCapabilities = {
   readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
   readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
   readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+  readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
   readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
 
@@ -64,6 +68,7 @@ const DOCUMENT_OPERATION_CAPABILITIES = Object.freeze({
   operationTypes: FOLIO_DOCUMENT_OPERATION_TYPES,
   modes: FOLIO_DOCUMENT_OPERATION_MODES,
   modesByOperationType: FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
+  preconditions: FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   stories: FOLIO_DOCUMENT_OPERATION_STORIES,
 } as const satisfies FolioDocumentOperationCapabilities);
 
@@ -199,6 +204,29 @@ const readOptionalComment = (
   return invalidBatch(`${path}.comment`, "expected an object when provided");
 };
 
+const readOptionalPrecondition = (
+  value: Record<string, unknown>,
+  path: string,
+): FolioAIEditPrecondition | undefined => {
+  const candidate = value["precondition"];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(candidate)) {
+    return invalidBatch(`${path}.precondition`, "expected an object when provided");
+  }
+  const preconditionPath = `${path}.precondition`;
+  assertAllowedKeys(candidate, preconditionPath, ["blockTextHash"]);
+  const blockTextHash = readString(candidate, "blockTextHash", preconditionPath);
+  if (!/^h[0-9a-z]+$/.test(blockTextHash)) {
+    return invalidBatch(
+      `${preconditionPath}.blockTextHash`,
+      "expected a normalized block text hash",
+    );
+  }
+  return { blockTextHash };
+};
+
 const isReviewSeverity = (value: unknown): value is FolioAIEditSeverity =>
   value === "low" || value === "medium" || value === "high";
 
@@ -214,7 +242,14 @@ const readReviewMeta = (value: Record<string, unknown>, path: string): FolioAIEd
   };
 };
 
-const COMMON_OPERATION_KEYS = ["id", "type", "blockId", "severity", "area"] as const;
+const COMMON_OPERATION_KEYS = [
+  "id",
+  "type",
+  "blockId",
+  "severity",
+  "area",
+  "precondition",
+] as const;
 
 const parseSignatureParties = (
   value: Record<string, unknown>,
@@ -250,12 +285,17 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
   const type = readString(value, "type", path);
   const blockId = readString(value, "blockId", path);
   const reviewMeta = readReviewMeta(value, path);
+  const precondition = readOptionalPrecondition(value, path);
   const comment = readOptionalComment(value, path);
+  const operationMeta = {
+    ...reviewMeta,
+    ...(precondition !== undefined && { precondition }),
+  };
 
   if (type === "replaceInBlock") {
     assertAllowedKeys(value, path, [...COMMON_OPERATION_KEYS, "find", "replace", "comment"]);
     return {
-      ...reviewMeta,
+      ...operationMeta,
       id,
       type,
       blockId,
@@ -278,7 +318,7 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     const pageBreakBefore = readOptionalBoolean(value, "pageBreakBefore", path);
     const styleId = readOptionalString(value, "styleId", path);
     return {
-      ...reviewMeta,
+      ...operationMeta,
       id,
       type,
       blockId,
@@ -301,7 +341,7 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     const preserveFormatting = readOptionalBoolean(value, "preserveFormatting", path);
     const styleId = readOptionalString(value, "styleId", path);
     return {
-      ...reviewMeta,
+      ...operationMeta,
       id,
       type,
       blockId,
@@ -314,7 +354,7 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
 
   if (type === "deleteBlock") {
     assertAllowedKeys(value, path, [...COMMON_OPERATION_KEYS, "comment"]);
-    return { ...reviewMeta, id, type, blockId, ...(comment !== undefined && { comment }) };
+    return { ...operationMeta, id, type, blockId, ...(comment !== undefined && { comment }) };
   }
 
   if (type === "commentOnBlock") {
@@ -324,7 +364,7 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     }
     const quote = readOptionalString(value, "quote", path);
     return {
-      ...reviewMeta,
+      ...operationMeta,
       id,
       type,
       blockId,
@@ -340,7 +380,7 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
       return invalidBatch(`${path}.position`, 'expected "after" or "before" when provided');
     }
     return {
-      ...reviewMeta,
+      ...operationMeta,
       id,
       type,
       blockId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export {
   type FolioAIEditApplyMode,
   type FolioAIEditApplyResult,
   type FolioAIEditOperation,
+  type FolioAIEditPrecondition,
   type FolioAIEditReviewMeta,
   type FolioAIEditSeverity,
   type FolioAIEditSkipReason,
@@ -63,6 +64,7 @@ export {
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   FOLIO_DOCUMENT_OPERATION_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
+  FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   FOLIO_DOCUMENT_OPERATION_STORIES,
   FOLIO_DOCUMENT_OPERATION_TYPES,
   getFolioDocumentOperationCapabilities,
@@ -76,6 +78,7 @@ export {
   type FolioDocumentOperationBatch,
   type FolioDocumentOperationCapabilities,
   type FolioDocumentOperationMode,
+  type FolioDocumentOperationPrecondition,
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
 } from "./ai-edits";

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -48,12 +48,14 @@ export type {
   FolioAIEditApplyMode,
   FolioAIEditApplyResult,
   FolioAIEditOperation,
+  FolioAIEditPrecondition,
 } from "./ai-edits/types";
 export {
   assertSupportedFolioDocumentOperationVersion,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   FOLIO_DOCUMENT_OPERATION_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
+  FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   FOLIO_DOCUMENT_OPERATION_STORIES,
   FOLIO_DOCUMENT_OPERATION_TYPES,
   getFolioDocumentOperationCapabilities,
@@ -66,6 +68,7 @@ export {
   type FolioDocumentOperationBatch,
   type FolioDocumentOperationCapabilities,
   type FolioDocumentOperationMode,
+  type FolioDocumentOperationPrecondition,
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
 } from "./document-operations";

--- a/tests/operations/tracked-replace.v1.json
+++ b/tests/operations/tracked-replace.v1.json
@@ -6,6 +6,7 @@
       "id": "replace-heading",
       "type": "replaceInBlock",
       "blockId": "0304003A",
+      "precondition": { "blockTextHash": "hnoenbg" },
       "find": "Heading",
       "replace": "Intro"
     }


### PR DESCRIPTION
Adds validated block-text preconditions to serialized document operations and agent-generated batches.