### PR TITLE
fix: reduce typing layout latency

### DIFF
--- a/.changeset/fast-dots-layout.md
+++ b/.changeset/fast-dots-layout.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Reduce typing latency by coalescing incremental layout on the next animation frame.

--- a/packages/core/src/controller/layoutScheduler.test.ts
+++ b/packages/core/src/controller/layoutScheduler.test.ts
@@ -104,6 +104,42 @@ describe("layoutScheduler", () => {
     expect(optionsSeen[0]?.dirtyRange).toEqual({ from: 10, to: 40 });
   });
 
+  test("leading-frame mode paints the first edit immediately and debounces the rest", () => {
+    const fc = makeFakeClock();
+    const runs: TestState[] = [];
+    const scheduler = createLayoutScheduler<TestState>({
+      runLayout: (state) => {
+        runs.push(state);
+      },
+      debounceMs: 32,
+      leadingFrame: true,
+      maxDelayMs: 96,
+      clock: fc.clock,
+    });
+
+    scheduler.schedule({ id: 1 }, { from: 10, to: 20 });
+    scheduler.schedule({ id: 2 }, { from: 30, to: 40 });
+
+    expect(fc.pendingTimers()).toBe(0);
+    expect(fc.pendingFrames()).toBe(1);
+    expect(runs).toHaveLength(0);
+
+    fc.fireFrames();
+
+    expect(runs).toEqual([{ id: 2 }]);
+
+    scheduler.schedule({ id: 3 }, { from: 50, to: 60 });
+    scheduler.schedule({ id: 4 }, { from: 70, to: 80 });
+
+    expect(fc.pendingTimers()).toBe(1);
+    expect(fc.pendingFrames()).toBe(0);
+
+    fc.fireTimers();
+    fc.fireFrames();
+
+    expect(runs).toEqual([{ id: 2 }, { id: 4 }]);
+  });
+
   test("exceeding maxDelay flushes with zero debounce", () => {
     const fc = makeFakeClock();
     const runs: TestState[] = [];
@@ -144,6 +180,27 @@ describe("layoutScheduler", () => {
 
     expect(runs).toHaveLength(0);
     expect(fc.pendingTimers()).toBe(0);
+    expect(fc.pendingFrames()).toBe(0);
+  });
+
+  test("dispose cancels a pending leading frame", () => {
+    const fc = makeFakeClock();
+    const runs: TestState[] = [];
+    const scheduler = createLayoutScheduler<TestState>({
+      runLayout: (state) => {
+        runs.push(state);
+      },
+      debounceMs: 32,
+      leadingFrame: true,
+      maxDelayMs: 96,
+      clock: fc.clock,
+    });
+
+    scheduler.schedule({ id: 1 }, null);
+    scheduler.dispose();
+    fc.fireFrames();
+
+    expect(runs).toHaveLength(0);
     expect(fc.pendingFrames()).toBe(0);
   });
 });

--- a/packages/core/src/controller/layoutScheduler.ts
+++ b/packages/core/src/controller/layoutScheduler.ts
@@ -43,6 +43,8 @@ export type LayoutSchedulerConfig<TState> = {
   runLayout: RunLayout<TState>;
   /** Quiet-window debounce before an interactive layout pass. */
   debounceMs: number;
+  /** Run the first edit after a max-delay-sized idle period on the next frame. */
+  leadingFrame?: boolean;
   /** Hard cap on latency from the first edit in a burst. */
   maxDelayMs: number;
   /**
@@ -76,6 +78,7 @@ export const createLayoutScheduler = <TState>(
   config: LayoutSchedulerConfig<TState>,
 ): LayoutScheduler<TState> => {
   const clock = config.clock;
+  let lastRunAt: number | null = null;
   let pending: PendingLayoutRequest<TState> | null = null;
 
   const flushPending = (): void => {
@@ -89,6 +92,7 @@ export const createLayoutScheduler = <TState>(
       if (!latest) {
         return;
       }
+      lastRunAt = clock.now();
       const options: LayoutRunOptions = { reason: "transaction" };
       if (latest.dirtyRange) {
         options.dirtyRange = latest.dirtyRange;
@@ -128,6 +132,13 @@ export const createLayoutScheduler = <TState>(
         timerId: null,
       };
       pending = next;
+      if (
+        config.leadingFrame &&
+        (lastRunAt === null || clock.now() - lastRunAt >= config.maxDelayMs)
+      ) {
+        flushPending();
+        return;
+      }
       armTimer(next);
     },
     dispose() {

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -435,7 +435,7 @@ const TABLE_INSERT_EDGE_PROXIMITY = 30;
 const TABLE_INSERT_HIDE_DELAY = 200;
 /** Delay before converting PM state back to the Folio document model. */
 const DOCUMENT_CHANGE_NOTIFY_DELAY = 250;
-/** Short window for coalescing rapid typing transactions into one visual layout. */
+/** Quiet window for coalescing follow-up transactions after the leading frame. */
 const TRANSACTION_LAYOUT_DEBOUNCE_MS = 32;
 /** Upper bound for how long visible layout can trail the hidden editor. */
 const TRANSACTION_LAYOUT_MAX_DELAY_MS = 96;
@@ -2240,6 +2240,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(function
     layoutSchedulerRef.current = createLayoutScheduler<EditorState>({
       runLayout: (state, options) => runLayoutPipelineRef.current(state, options),
       debounceMs: TRANSACTION_LAYOUT_DEBOUNCE_MS,
+      leadingFrame: true,
       maxDelayMs: TRANSACTION_LAYOUT_MAX_DELAY_MS,
       clock: browserClock,
     });


### PR DESCRIPTION
Summary\n\n- run the first transaction after an idle period on the next animation frame\n- retain the existing quiet-window debounce and hard latency cap for follow-up burst edits\n- add scheduler regressions for leading-frame coalescing and cancellation\n\n## Measured impact\n\nA local production smoke profile showed input-to-layout-start median improving from 45.3 ms to 14.7 ms, and key-to-painted-update median from 96.9 ms to 62.9 ms. The candidate run recorded higher host load, so these results are directional and do not establish a CI budget. Incremental measurement remained at one block for the single-key scenario; the three-key performance regression remained at two layout passes.\n\nThis draft is stacked on #103 so its diff contains only the focused scheduling change.