### PR TITLE
fix: resolve browser fonts in parity checks

### DIFF
--- a/parity/README.md
+++ b/parity/README.md
@@ -51,5 +51,7 @@ resolved CSS family on matching text lines. A requested font may be substituted
 without invalidating the run when both renderers use the same fallback
 (`font-shared:*`). `font-renderer-mismatch` means geometry may primarily reflect
 different font metrics and the document should not drive a layout fix.
+Chromium families are canvas-probed in CSS-stack order; the computed stack alone
+cannot reveal which fallback supplied the glyphs.
 
 Shared data contract: `types.ts`. Tolerances and paths: `config.ts`.

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { chromium } from "@playwright/test";
 
 import { PX_TO_PT } from "../config";
 import {
   computeZoomFactor,
-  extractSinglePage,
   meaningfulTextRange,
+  parseCssFontFamilies,
   parseFirstFontFamily,
   toPageGeom,
 } from "../folioExtract";
@@ -18,26 +17,18 @@ const rect = (left: number, top: number, width: number, height: number) => ({
   height,
 });
 
-describe("extractSinglePage font resolution", () => {
-  test("skips a missing first family and records the generic fallback", async () => {
-    const browser = await chromium.launch({ headless: true });
-    try {
-      const page = await browser.newPage();
-      await page.setContent(`
-        <div class="layout-page" data-page-number="1" style="width: 600px; height: 800px">
-          <div class="layout-line">
-            <span class="layout-run" style="font: 16px 'Definitely, Missing Font', sans-serif">Font probe</span>
-          </div>
-        </div>
-      `);
+describe("parseCssFontFamilies", () => {
+  test("preserves commas inside quoted family names", () => {
+    expect(parseCssFontFamilies('"Definitely, Missing Font", Arial, sans-serif')).toEqual([
+      "Definitely, Missing Font",
+      "Arial",
+      "sans-serif",
+    ]);
+  });
 
-      const rawPage = await extractSinglePage(page, 0);
-
-      expect(rawPage.lines.at(0)?.fontFamilyRaw).toBe("sans-serif");
-    } finally {
-      await browser.close();
-    }
-  }, 15_000);
+  test("handles single-quoted and unquoted families", () => {
+    expect(parseCssFontFamilies("'Times New Roman', serif")).toEqual(["Times New Roman", "serif"]);
+  });
 });
 
 const makeRawLine = (overrides: Partial<RawLine> & Pick<RawLine, "text" | "rect">): RawLine => ({

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -37,7 +37,7 @@ describe("extractSinglePage font resolution", () => {
     } finally {
       await browser.close();
     }
-  });
+  }, 15_000);
 });
 
 const makeRawLine = (overrides: Partial<RawLine> & Pick<RawLine, "text" | "rect">): RawLine => ({

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { chromium } from "@playwright/test";
 
 import { PX_TO_PT } from "../config";
 import {
   computeZoomFactor,
+  extractSinglePage,
   meaningfulTextRange,
   parseFirstFontFamily,
   toPageGeom,
@@ -14,6 +16,28 @@ const rect = (left: number, top: number, width: number, height: number) => ({
   top,
   width,
   height,
+});
+
+describe("extractSinglePage font resolution", () => {
+  test("skips a missing first family and records the generic fallback", async () => {
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(`
+        <div class="layout-page" data-page-number="1" style="width: 600px; height: 800px">
+          <div class="layout-line">
+            <span class="layout-run" style="font: 16px 'Definitely Missing Font', sans-serif">Font probe</span>
+          </div>
+        </div>
+      `);
+
+      const rawPage = await extractSinglePage(page, 0);
+
+      expect(rawPage.lines.at(0)?.fontFamilyRaw).toBe("sans-serif");
+    } finally {
+      await browser.close();
+    }
+  });
 });
 
 const makeRawLine = (overrides: Partial<RawLine> & Pick<RawLine, "text" | "rect">): RawLine => ({

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -26,7 +26,7 @@ describe("extractSinglePage font resolution", () => {
       await page.setContent(`
         <div class="layout-page" data-page-number="1" style="width: 600px; height: 800px">
           <div class="layout-line">
-            <span class="layout-run" style="font: 16px 'Definitely Missing Font', sans-serif">Font probe</span>
+            <span class="layout-run" style="font: 16px 'Definitely, Missing Font', sans-serif">Font probe</span>
           </div>
         </div>
       `);

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -124,7 +124,8 @@ export type RawLine = {
   text: string;
   rect: RawRect;
   region: Region;
-  /** `getComputedStyle(...).fontFamily` of the first `.layout-run`, verbatim. */
+  /** First actually available family from the computed CSS stack of the first
+   * `.layout-run`; falls back to the computed stack when canvas probing is unavailable. */
   fontFamilyRaw?: string;
   /** `getComputedStyle(...).fontSize` of the first `.layout-run`, parsed to a px number. */
   fontSizePx?: number;
@@ -429,7 +430,7 @@ const listPageMeta = (page: Page): Promise<PageMeta[]> =>
  * page into view (and let layout stabilize) before calling this, or it will
  * read an empty/stale shell.
  */
-const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
+export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
   page.evaluate<RawPage, { domIndex: number; meaningfulInkPattern: string }>(
     (input) => {
       const { domIndex: idx, meaningfulInkPattern } = input;
@@ -446,6 +447,53 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
 
       const tableCells = Array.from(el.querySelectorAll(".layout-table-cell"));
       const lineEls = Array.from(el.querySelectorAll(".layout-line")) as HTMLElement[];
+      const resolvedFontCache = new Map<string, string>();
+      const canvasContext = document.createElement("canvas").getContext("2d");
+      const fontProbeText = "mmmmmmmmmmlliWW0123456789";
+      const genericFamilies = new Set([
+        "serif",
+        "sans-serif",
+        "monospace",
+        "cursive",
+        "fantasy",
+        "system-ui",
+      ]);
+      const resolveFontFamily = (computed: CSSStyleDeclaration): string => {
+        const cached = resolvedFontCache.get(computed.fontFamily);
+        if (cached !== undefined) return cached;
+
+        const families =
+          computed.fontFamily
+            .match(/"[^"]*"|'[^']*'|[^,]+/gu)
+            ?.map((family) => family.trim().replace(/^['"]|['"]$/gu, ""))
+            .filter((family) => family.length > 0) ?? [];
+        if (!canvasContext) return families[0] ?? computed.fontFamily;
+
+        const fontSize = computed.fontSize || "16px";
+        const baselines = ["monospace", "serif", "sans-serif"];
+        for (const family of families) {
+          if (genericFamilies.has(family.toLocaleLowerCase())) {
+            resolvedFontCache.set(computed.fontFamily, family);
+            return family;
+          }
+          const escapedFamily = family.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"');
+          const isAvailable = baselines.some((baseline) => {
+            canvasContext.font = `${fontSize} ${baseline}`;
+            const baselineWidth = canvasContext.measureText(fontProbeText).width;
+            canvasContext.font = `${fontSize} "${escapedFamily}", ${baseline}`;
+            const candidateWidth = canvasContext.measureText(fontProbeText).width;
+            return Math.abs(candidateWidth - baselineWidth) > 0.01;
+          });
+          if (isAvailable) {
+            resolvedFontCache.set(computed.fontFamily, family);
+            return family;
+          }
+        }
+
+        const fallback = families.at(-1) ?? computed.fontFamily;
+        resolvedFontCache.set(computed.fontFamily, fallback);
+        return fallback;
+      };
       const lines = lineEls.flatMap((lineEl) => {
         const segmentInkRect = (segmentEl: HTMLElement): DOMRect | null => {
           if (
@@ -520,16 +568,14 @@ const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
           return "body";
         })();
         const tableCell = lineEl.closest(".layout-table-cell");
-        const visualGroup = tableCell
-          ? `table-cell:${tableCells.indexOf(tableCell)}`
-          : undefined;
+        const visualGroup = tableCell ? `table-cell:${tableCells.indexOf(tableCell)}` : undefined;
 
         const fontFrom = (sourceEl: HTMLElement | null) => {
           if (!sourceEl) return {};
           const computed = getComputedStyle(sourceEl);
           const parsedSize = Number.parseFloat(computed.fontSize);
           return {
-            fontFamilyRaw: computed.fontFamily,
+            fontFamilyRaw: resolveFontFamily(computed),
             ...(Number.isFinite(parsedSize) ? { fontSizePx: parsedSize } : {}),
           };
         };

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -168,6 +168,15 @@ export const parseFirstFontFamily = (fontFamilyRaw: string | undefined): string 
   return first.replace(/^["']|["']$/gu, "");
 };
 
+const CSS_FONT_FAMILY_TOKEN_PATTERN = `"[^"]*"|'[^']*'|[^,]+`;
+
+/** Split a computed CSS family stack without treating commas inside quoted
+ * family names as separators. */
+export const parseCssFontFamilies = (fontFamilyRaw: string): string[] =>
+  (fontFamilyRaw.match(new RegExp(CSS_FONT_FAMILY_TOKEN_PATTERN, "gu")) ?? [])
+    .map((family) => family.trim().replace(/^['"]|['"]$/gu, ""))
+    .filter((family) => family.length > 0);
+
 /**
  * Pure transformer from one raw evaluate()-extracted page to the normalized
  * `PageGeom` the comparator consumes: applies the zoom-normalized px→pt
@@ -431,9 +440,12 @@ const listPageMeta = (page: Page): Promise<PageMeta[]> =>
  * read an empty/stale shell.
  */
 export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage> =>
-  page.evaluate<RawPage, { domIndex: number; meaningfulInkPattern: string }>(
+  page.evaluate<
+    RawPage,
+    { domIndex: number; meaningfulInkPattern: string; fontFamilyTokenPattern: string }
+  >(
     (input) => {
-      const { domIndex: idx, meaningfulInkPattern } = input;
+      const { domIndex: idx, meaningfulInkPattern, fontFamilyTokenPattern } = input;
       const meaningfulInkCharacter = new RegExp(meaningfulInkPattern, "u");
       const pageEls = Array.from(document.querySelectorAll(".layout-page")) as HTMLElement[];
       const el = pageEls[idx];
@@ -464,7 +476,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
 
         const families =
           computed.fontFamily
-            .match(/"[^"]*"|'[^']*'|[^,]+/gu)
+            .match(new RegExp(fontFamilyTokenPattern, "gu"))
             ?.map((family) => family.trim().replace(/^['"]|['"]$/gu, ""))
             .filter((family) => family.length > 0) ?? [];
         if (!canvasContext) return families[0] ?? computed.fontFamily;
@@ -735,7 +747,11 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
         lines,
       };
     },
-    { domIndex, meaningfulInkPattern: MEANINGFUL_INK_CHARACTER.source },
+    {
+      domIndex,
+      meaningfulInkPattern: MEANINGFUL_INK_CHARACTER.source,
+      fontFamilyTokenPattern: CSS_FONT_FAMILY_TOKEN_PATTERN,
+    },
   );
 
 const inspectSinglePage = (page: Page, domIndex: number): Promise<FolioPageInspection> =>


### PR DESCRIPTION
## Summary
- canvas-probe computed CSS stacks to record the first family Chromium can actually draw
- keep the raw stack only as a fallback when canvas probing is unavailable
- add a Chromium regression for a missing first family and document the preflight behavior

## Verification
- focused parity tests: 60 passed
- Kbely registry attachment remains font-valid with the stricter resolved-face probe
- lint and typecheck delegated to CI