### PR TITLE
fix: unify adapter zoom range and narrow clipboard errors

### DIFF
--- a/.changeset/fix-clipboard-error-narrowing.md
+++ b/.changeset/fix-clipboard-error-narrowing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Narrow clipboard copy/read failures with an `instanceof Error` check instead of an unchecked `as Error` cast, so `onError` callbacks always receive a real `Error` even when a non-Error value is thrown.

--- a/.changeset/unify-adapter-zoom-range.md
+++ b/.changeset/unify-adapter-zoom-range.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-vue": minor
+"@stll/folio-react": patch
+---
+
+Unify the reachable zoom range across adapters. A new `@stll/folio-core/utils/zoom` module exports the canonical `ZOOM_MIN` (0.25), `ZOOM_MAX` (4), and `ZOOM_STEP` (0.1); React and Vue now source their clamp from it. The Vue adapter previously clamped zoom to 0.5-2x and now matches React at 0.25-4x. Each adapter's curated toolbar zoom-level dropdown (50-200%) is unchanged and remains an intentional subset of the reachable range.

--- a/packages/core/src/utils/clipboard.ts
+++ b/packages/core/src/utils/clipboard.ts
@@ -201,7 +201,7 @@ export async function copyRuns(runs: Run[], options: ClipboardOptions = {}): Pro
     const content = runsToClipboardContent(runs, includeFormatting);
     return await writeToClipboard(content);
   } catch (error) {
-    onError?.(error as Error);
+    onError?.(error instanceof Error ? error : new Error(String(error)));
     return false;
   }
 }
@@ -219,7 +219,7 @@ export async function copyParagraphs(
     const content = paragraphsToClipboardContent(paragraphs, includeFormatting);
     return await writeToClipboard(content);
   } catch (error) {
-    onError?.(error as Error);
+    onError?.(error instanceof Error ? error : new Error(String(error)));
     return false;
   }
 }
@@ -323,7 +323,7 @@ export async function readFromClipboard(
     const items = await navigator.clipboard.read();
     return await parseClipboardItems(items, cleanWordFormatting);
   } catch (error) {
-    onError?.(error as Error);
+    onError?.(error instanceof Error ? error : new Error(String(error)));
     return null;
   }
 }

--- a/packages/core/src/utils/zoom.ts
+++ b/packages/core/src/utils/zoom.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical zoom limits shared by every folio adapter (React, Vue, ...).
+ *
+ * Adapters must source their zoom range from here rather than hard-coding their
+ * own, so the reachable zoom span stays identical across framework hosts.
+ * Historically React clamped 0.25-4x while Vue clamped 0.5-2x; this module is
+ * the single source of truth that keeps them from drifting again.
+ *
+ * Note: the discrete zoom-level menu each adapter shows in its toolbar dropdown
+ * is a separate, deliberately curated subset (50-200%); it is not derived from
+ * these limits.
+ */
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Minimum reachable zoom level (25%). */
+export const ZOOM_MIN = 0.25;
+
+/** Maximum reachable zoom level (400%). */
+export const ZOOM_MAX = 4;
+
+/** Step applied per zoom-in / zoom-out action and per keyboard shortcut. */
+export const ZOOM_STEP = 0.1;

--- a/packages/react/src/hooks/useWheelZoom.ts
+++ b/packages/react/src/hooks/useWheelZoom.ts
@@ -18,6 +18,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
+import { ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "@stll/folio-core/utils/zoom";
 
 // ============================================================================
 // TYPES
@@ -89,9 +90,9 @@ export type UseWheelZoomReturn = {
 // ============================================================================
 
 const DEFAULT_INITIAL_ZOOM = 1;
-const DEFAULT_MIN_ZOOM = 0.25;
-const DEFAULT_MAX_ZOOM = 4;
-const DEFAULT_ZOOM_STEP = 0.1;
+const DEFAULT_MIN_ZOOM = ZOOM_MIN;
+const DEFAULT_MAX_ZOOM = ZOOM_MAX;
+const DEFAULT_ZOOM_STEP = ZOOM_STEP;
 
 /**
  * Per-event zoom sensitivity for Ctrl/Cmd+wheel and trackpad pinch. Multiplies
@@ -101,7 +102,8 @@ const DEFAULT_ZOOM_STEP = 0.1;
 const WHEEL_ZOOM_SENSITIVITY = 0.003;
 
 /**
- * Preset zoom levels for snapping
+ * Preset zoom levels for wheel/keyboard snapping within the shared
+ * `[ZOOM_MIN, ZOOM_MAX]` range (see `@stll/folio-core/utils/zoom`).
  */
 export const ZOOM_PRESETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
 

--- a/packages/vue/src/composables/useZoom.ts
+++ b/packages/vue/src/composables/useZoom.ts
@@ -7,12 +7,14 @@
  */
 
 import { ref, computed, onMounted, onBeforeUnmount, type Ref, type ComputedRef } from "vue";
+import { ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "@stll/folio-core/utils/zoom";
 
-// Range + presets match React (Toolbar.tsx minZoom=0.5/maxZoom=2 +
-// ZoomControl DEFAULT_ZOOM_LEVELS) so both adapters offer the same zoom levels.
-const MIN_ZOOM = 0.5;
-const MAX_ZOOM = 2.0;
-const ZOOM_STEP = 0.1;
+// Reachable range comes from folio-core so React and Vue clamp to the same span
+// (0.25-4x); see `@stll/folio-core/utils/zoom` (single source of truth). The
+// dropdown presets below are the curated toolbar menu (50-200%), matching
+// React's ZoomControl, and are intentionally a subset of the reachable range.
+const MIN_ZOOM = ZOOM_MIN;
+const MAX_ZOOM = ZOOM_MAX;
 const ZOOM_PRESETS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
 
 export type UseZoomReturn = {
@@ -28,7 +30,7 @@ export type UseZoomReturn = {
   handleKeyDown: (e: KeyboardEvent) => void;
   installShortcuts: () => void;
   ZOOM_PRESETS: number[];
-}
+};
 
 export function useZoom(initialZoom = 1.0): UseZoomReturn {
   const zoom = ref(Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, initialZoom)));


### PR DESCRIPTION
Two small, independent adapter/core fixes surfaced by a tech-debt audit.

## 1. Unify the reachable zoom range across adapters
React clamped zoom to `0.25-4x` (`useWheelZoom`) while Vue clamped to `0.5-2x` (`useZoom`), with no shared source of truth. Adds `@stll/folio-core/utils/zoom` exporting canonical `ZOOM_MIN` (0.25), `ZOOM_MAX` (4), and `ZOOM_STEP` (0.1); both adapters now source their clamp from it.

- **Vue behavior changes**: reachable zoom widens `0.5-2x` -> `0.25-4x`, matching React.
- **React behavior unchanged** (values were already 0.25-4x; now deduplicated).
- Each adapter's curated toolbar zoom-level dropdown (50-200%) is intentionally left as-is: it is a separate concept from the reachable range and already matches across adapters. The core module's doc comment records this distinction.

## 2. Narrow clipboard errors
Three `onError?.(error as Error)` casts in clipboard copy/read paths become `error instanceof Error ? error : new Error(String(error))`, matching the existing `DocumentLoaderManager` pattern, so a thrown non-`Error` reaches callbacks as a real `Error`.

## Verification
- `bun run typecheck` clean for core / react / vue
- `bunx oxlint` clean on touched files; `oxfmt --check` clean on touched files
- Clipboard unit suite passes (11 tests)
- Changesets included (core minor + patch, vue minor, react patch)