### PR TITLE
fix: anchor default tabs to the text area

### DIFF
--- a/.changeset/fuzzy-tabs-align.md
+++ b/.changeset/fuzzy-tabs-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep default tab stops anchored to the document text-area grid after paragraph indents.

--- a/packages/core/src/prosemirror/utils/tabCalculator.test.ts
+++ b/packages/core/src/prosemirror/utils/tabCalculator.test.ts
@@ -95,6 +95,26 @@ describe("computeTabStops", () => {
     expect(stop1000).toBeDefined();
   });
 
+  it("keeps the default grid anchored to the text-area origin after an indent", () => {
+    const stops = computeTabStops({
+      explicitStops: [{ val: "start", pos: 567 }],
+      leftIndent: 1134,
+    });
+
+    expect(
+      stops
+        .filter((stop) => stop.pos >= 1134)
+        .slice(0, 3)
+        .map((stop) => stop.pos),
+    ).toEqual([1134, 1440, 2160]);
+    expect(
+      calculateTabWidth(twipsToPixels(1573), {
+        explicitStops: [{ val: "start", pos: 567 }],
+        leftIndent: 1134,
+      }).width,
+    ).toBeCloseTo(twipsToPixels(2160 - 1573), 5);
+  });
+
   it("returns stops sorted by position", () => {
     const stops = computeTabStops({
       explicitStops: [

--- a/packages/core/src/prosemirror/utils/tabCalculator.ts
+++ b/packages/core/src/prosemirror/utils/tabCalculator.ts
@@ -133,10 +133,13 @@ export function computeTabStops(context: TabContext): TabStop[] {
     }
   }
 
-  // Generate default stops at regular intervals
-  // Start from leftIndent and go up to ~10 inches
-  const startPos = maxExplicit > 0 ? Math.max(maxExplicit, leftIndent) : leftIndent;
-  let pos = startPos;
+  // Generate default stops on the document-wide grid measured from the text
+  // area's left edge. An indent filters earlier stops, but must not shift the
+  // grid itself: a 1,134-twip indent still advances through 1,440, 2,160, ...,
+  // not 1,854, 2,574, ... . Start at the grid line at or before the rightmost
+  // explicit stop / indent; the loop advances to the first candidate after it.
+  const searchStart = Math.max(maxExplicit, leftIndent);
+  let pos = Math.floor(searchStart / defaultTabInterval) * defaultTabInterval;
   const limitPos = leftIndent + 14_400; // 14400 twips = 10 inches
 
   while (pos < limitPos) {


### PR DESCRIPTION
## Summary
- keep default tab stops on the document-wide grid instead of shifting them by paragraph indent
- preserve explicit-stop and hanging-indent behavior while advancing to the next global default stop
- add a targeted regression for an indented paragraph whose explicit stop falls behind the cursor

: 

## Parity
- fidelity score: 0.876 → 0.890
- divergences: 29 → 24
- appendix missing lines: 4 → 1
- pages remain Word 4 / Folio 4
- resolved-font preflight: matching

## Verification
- focused tab calculator and paragraph tab suites: 39 passed
- lint and typecheck delegated to CI