### PR TITLE
docs: add stella-style badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
   <img src=".github/assets/banner.png" alt="@stll/folio" width="100%" />
 </p>
 
+<p align="center">
+  <strong>Browser editor and framework-neutral engine for Word <code>.docx</code> files.</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/stella/stella">stella</a> &middot;
+  <a href="https://www.npmjs.com/package/@stll/folio-core">npm</a> &middot;
+  <a href="https://github.com/stella/folio/issues">Issues</a> &middot;
+  <a href="https://discord.gg/8dZjmVFjTK">Discord</a>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@stll/folio-core"><img src="https://img.shields.io/npm/v/@stll/folio-core?label=%40stll%2Ffolio-core" alt="npm version" /></a>
+  <a href="https://github.com/stella/folio/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
+  <a href="https://github.com/stella/folio/issues"><img src="https://img.shields.io/github/issues/stella/folio" alt="Issues" /></a>
+  <a href="https://discord.gg/8dZjmVFjTK"><img src="https://img.shields.io/badge/discord-join%20chat-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+</p>
+
 # folio
 
 Browser editor and framework-neutral engine for `.docx` files. It opens, edits,


### PR DESCRIPTION
Adds stella-style header badges to the folio README, mirroring the badge row in `stella/stella`.

- Tagline plus a nav row: stella · npm · Issues · Discord
- shields.io badges: npm version (`@stll/folio-core`), Apache-2.0 license, GitHub issues, Discord

Docs-only; no package `src` change, so no changeset.