### PR TITLE
feat: add atomic document operation batches

### DIFF
--- a/.changeset/wise-batches-commit.md
+++ b/.changeset/wise-batches-commit.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-react": patch
+"@stll/folio-agents": patch
+---
+
+Add optional atomic document operation batches.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -37,6 +37,9 @@ export const createFolioAIEditSnapshot: (doc: Node_2) => FolioAIEditSnapshot;
 export const diffWordSegments: (before: string, after: string) => WordDiffSegment[];
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES: readonly ["best-effort", "atomic"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION: 1;
 
 // @public (undocumented)
@@ -188,7 +191,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "preconditionFailed" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "atomicBatchRejected" | "preconditionFailed" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.
@@ -230,6 +233,7 @@ export type FolioDocumentOperationBatch = {
     readonly version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
+    atomic?: boolean;
 };
 
 // @public (undocumented)
@@ -238,6 +242,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -251,9 +256,13 @@ export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 // @public (undocumented)
 export type FolioDocumentOperationResult = {
     version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+    status: FolioDocumentOperationStatus;
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
 };
+
+// @public (undocumented)
+export type FolioDocumentOperationStatus = "committed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -326,6 +326,9 @@ export function extractEmbeddedFonts(buffer: ArrayBuffer): Promise<EmbeddedFont[
 export const finishAutocompleteSuggestion: (tr: Transaction, requestId: string) => Transaction;
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES: readonly ["best-effort", "atomic"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION: 1;
 
 // @public (undocumented)
@@ -477,7 +480,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "preconditionFailed" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "atomicBatchRejected" | "preconditionFailed" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.
@@ -511,6 +514,7 @@ export type FolioDocumentOperationBatch = {
     readonly version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
+    atomic?: boolean;
 };
 
 // @public (undocumented)
@@ -519,6 +523,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -532,9 +537,13 @@ export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 // @public (undocumented)
 export type FolioDocumentOperationResult = {
     version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+    status: FolioDocumentOperationStatus;
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
 };
+
+// @public (undocumented)
+export type FolioDocumentOperationStatus = "committed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -326,6 +326,9 @@ export function extractEmbeddedFonts(buffer: ArrayBuffer): Promise<EmbeddedFont[
 export const finishAutocompleteSuggestion: (tr: Transaction, requestId: string) => Transaction;
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES: readonly ["best-effort", "atomic"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION: 1;
 
 // @public (undocumented)
@@ -477,7 +480,7 @@ export type FolioAIEditSkippedOperation = {
 };
 
 // @public (undocumented)
-export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "preconditionFailed" | "emptyOperation"
+export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguousFind" | "missingFind" | "unsupportedBlock" | "unsupportedMode" | "atomicBatchRejected" | "preconditionFailed" | "emptyOperation"
 /**
 * The operation would not change the document — find equals
 * replace, or replaceBlock's `text` matches the live block.
@@ -511,6 +514,7 @@ export type FolioDocumentOperationBatch = {
     readonly version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
+    atomic?: boolean;
 };
 
 // @public (undocumented)
@@ -519,6 +523,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -532,9 +537,13 @@ export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 // @public (undocumented)
 export type FolioDocumentOperationResult = {
     version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+    status: FolioDocumentOperationStatus;
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
 };
+
+// @public (undocumented)
+export type FolioDocumentOperationStatus = "committed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -62,6 +62,9 @@ export type DeriveBlockIdInput = {
 };
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES: readonly ["best-effort", "atomic"];
+
+// @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION: 1;
 
 // @public (undocumented)
@@ -217,6 +220,7 @@ export type FolioDocumentOperationBatch = {
     readonly version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
+    atomic?: boolean;
 };
 
 // @public (undocumented)
@@ -225,6 +229,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+    readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -238,9 +243,13 @@ export type FolioDocumentOperationPrecondition = FolioAIEditPrecondition;
 // @public (undocumented)
 export type FolioDocumentOperationResult = {
     version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+    status: FolioDocumentOperationStatus;
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
 };
+
+// @public (undocumented)
+export type FolioDocumentOperationStatus = "committed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/packages/agents/src/bridges/editor-ref.test.ts
+++ b/packages/agents/src/bridges/editor-ref.test.ts
@@ -33,7 +33,7 @@ describe("createEditorRefBridge: document operations", () => {
       ...baseRef(),
       applyDocumentOperations: ({ batch }) => {
         receivedVersion = batch.version;
-        return { version: batch.version, applied: [], skipped: [] };
+        return { version: batch.version, status: "committed", applied: [], skipped: [] };
       },
     };
     const bridge = createEditorRefBridge({
@@ -67,8 +67,40 @@ describe("createEditorRefBridge: document operations", () => {
 
     expect(result).toEqual({
       version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      status: "committed",
       ...EMPTY_APPLY_RESULT,
     });
+  });
+
+  test("rejects atomic batches without mutating through an older editor ref", () => {
+    let applyCalls = 0;
+    const ref: FolioAgentEditorRefLike = {
+      ...baseRef(),
+      applyAIEditOperations: () => {
+        applyCalls += 1;
+        return EMPTY_APPLY_RESULT;
+      },
+    };
+    const bridge = createEditorRefBridge({
+      ref,
+      author: "AI",
+      getComments: () => [],
+      setComments: () => {},
+    });
+
+    const result = bridge.applyDocumentOperations({
+      version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      atomic: true,
+      operations: [{ id: "op-1", type: "deleteBlock", blockId: "para-1" }],
+    });
+
+    expect(result).toEqual({
+      version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      status: "rejected",
+      applied: [],
+      skipped: [{ id: "op-1", reason: "unsupportedMode" }],
+    });
+    expect(applyCalls).toBe(0);
   });
 
   test("rejects unsupported serialized versions before using a legacy ref", () => {

--- a/packages/agents/src/bridges/editor-ref.ts
+++ b/packages/agents/src/bridges/editor-ref.ts
@@ -175,8 +175,20 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
       if (ref.applyDocumentOperations) {
         return ref.applyDocumentOperations({ snapshot, batch: versionedBatch, author });
       }
+      if (versionedBatch.atomic === true) {
+        return {
+          version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+          status: "rejected",
+          applied: [],
+          skipped: versionedBatch.operations.map(({ id }) => ({
+            id,
+            reason: "unsupportedMode",
+          })),
+        };
+      }
       return {
         version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+        status: "committed",
         ...ref.applyAIEditOperations({
           snapshot,
           operations: versionedBatch.operations,

--- a/packages/agents/src/execute.test.ts
+++ b/packages/agents/src/execute.test.ts
@@ -281,6 +281,7 @@ describe("executeFolioToolCall: happy path against a real FolioDocxReviewer", ()
         receivedPrecondition = batch.operations.at(0)?.precondition;
         return {
           version: batch.version,
+          status: "committed" as const,
           applied: [],
           skipped: [{ id: "custom-1", reason: "preconditionFailed" as const }],
         };
@@ -320,6 +321,7 @@ describe("executeFolioToolCall: happy path against a real FolioDocxReviewer", ()
         batch: Parameters<typeof reviewerBridge.applyDocumentOperations>[0],
       ) => ({
         version: batch.version,
+        status: "committed" as const,
         applied: [],
         skipped: batch.operations.map(({ id }) => ({ id, reason: "unsupportedMode" as const })),
       }),

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -211,6 +211,9 @@ const explainSkipReason = (reason: string): string => {
   if (reason === "unsupportedMode") {
     return "this operation does not support the requested mutation mode; inspect document operation capabilities and retry with a supported mode.";
   }
+  if (reason === "atomicBatchRejected") {
+    return "another operation in this atomic batch could not be applied; no operations were committed.";
+  }
   if (reason === "preconditionFailed") {
     return "the target block changed after the operation was prepared; re-read the document and retry with a fresh operation.";
   }

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -78,8 +78,9 @@ const createSurfaces = async (): Promise<ConformanceSurface[]> => {
   ];
 };
 
-const normalizeResult = ({ version, applied, skipped }: FolioDocumentOperationResult) => ({
+const normalizeResult = ({ version, status, applied, skipped }: FolioDocumentOperationResult) => ({
   version,
+  status,
   applied: applied.map(({ id }) => ({ id })),
   skipped,
 });
@@ -113,6 +114,7 @@ describe("document operation cross-surface conformance", () => {
     const expected = {
       result: {
         version: 1,
+        status: "committed",
         applied: [{ id: "replace-heading" }],
         skipped: [],
       },

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -171,9 +171,81 @@ describe("headless docx review round-trip", () => {
     });
 
     expect(result.version).toBe(1);
+    expect(result.status).toBe("committed");
     expect(result.applied.map(({ id }) => id)).toEqual(["v1"]);
     expect(result.skipped).toEqual([]);
     expect(await partText(await reviewer.toBuffer(), "word/document.xml")).toContain("<w:ins ");
+  });
+
+  test("atomic batches reject every operation without document or comment changes", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    const contentBefore = reviewer.getContentAsText();
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      atomic: true,
+      mode: "direct",
+      operations: [
+        {
+          id: "valid",
+          type: "replaceInBlock",
+          blockId: target.id,
+          find: "Heading",
+          replace: "Intro",
+          comment: { text: "Review this change." },
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+
+    expect(result).toEqual({
+      version: 1,
+      status: "rejected",
+      applied: [],
+      skipped: [
+        { id: "valid", reason: "atomicBatchRejected" },
+        { id: "missing", reason: "missingBlock" },
+      ],
+    });
+    expect(reviewer.getContentAsText()).toBe(contentBefore);
+    expect(reviewer.getComments()).toEqual([]);
+  });
+
+  test("atomic batches commit all operations after a successful preflight", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      atomic: true,
+      mode: "direct",
+      operations: [
+        {
+          id: "replace",
+          type: "replaceInBlock",
+          blockId: target.id,
+          find: "Heading",
+          replace: "Intro",
+          comment: { text: "Review this change." },
+        },
+        {
+          id: "insert",
+          type: "insertAfterBlock",
+          blockId: target.id,
+          text: "New clause.",
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.applied.map(({ id }) => id).toSorted()).toEqual(["insert", "replace"]);
+    expect(result.skipped).toEqual([]);
+    expect(reviewer.getContentAsText()).toContain("Intro paragraph.");
+    expect(reviewer.getContentAsText()).toContain("New clause.");
+    expect(reviewer.getComments()).toHaveLength(1);
   });
 
   test("insertAfterBlock (direct) adds a sibling paragraph, no tracked marks", async () => {

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -37,6 +37,7 @@ export {
   applyFolioDocumentOperations,
   assertSupportedFolioDocumentOperationVersion,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+  FOLIO_DOCUMENT_OPERATION_BATCH_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
   FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
@@ -56,4 +57,5 @@ export {
   type FolioDocumentOperationPrecondition,
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
+  type FolioDocumentOperationStatus,
 } from "../document-operations";

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -146,6 +146,7 @@ export type FolioAIEditSkipReason =
   | "missingFind"
   | "unsupportedBlock"
   | "unsupportedMode"
+  | "atomicBatchRejected"
   | "preconditionFailed"
   | "emptyOperation"
   /**

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   assertSupportedFolioDocumentOperationVersion,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+  FOLIO_DOCUMENT_OPERATION_BATCH_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
   FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   getFolioDocumentOperationCapabilities,
@@ -27,6 +28,7 @@ describe("document operation contract", () => {
         "insertSignatureTable",
       ],
       modes: ["direct", "tracked-changes"],
+      batchModes: ["best-effort", "atomic"],
       modesByOperationType: {
         replaceInBlock: ["direct", "tracked-changes"],
         insertAfterBlock: ["direct", "tracked-changes"],
@@ -54,6 +56,7 @@ describe("document operation contract", () => {
       getFolioDocumentOperationCapabilities().operationTypes,
     );
     expect(FOLIO_DOCUMENT_OPERATION_PRECONDITIONS).toEqual(["blockTextHash"]);
+    expect(FOLIO_DOCUMENT_OPERATION_BATCH_MODES).toEqual(["best-effort", "atomic"]);
   });
 
   test("checks untyped contract versions at a serialization boundary", () => {
@@ -73,6 +76,7 @@ describe("document operation contract", () => {
     const batch = {
       version: 1,
       mode: "tracked-changes",
+      atomic: true,
       operations: [
         {
           id: "1",
@@ -112,6 +116,18 @@ describe("document operation contract", () => {
     [null, "$", "expected an object"],
     [{ version: 1 }, "$.operations", "expected an array"],
     [{ version: 1, operations: [], mode: "review" }, "$.mode", "expected"],
+    [{ version: 1, operations: [], atomic: "yes" }, "$.atomic", "expected a boolean"],
+    [
+      {
+        version: 1,
+        operations: [
+          { id: "duplicate", type: "deleteBlock", blockId: "a" },
+          { id: "duplicate", type: "deleteBlock", blockId: "b" },
+        ],
+      },
+      "$.operations[1].id",
+      "expected a unique operation id",
+    ],
     [
       {
         version: 1,

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -31,6 +31,10 @@ export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
 
 export const FOLIO_DOCUMENT_OPERATION_STORIES = Object.freeze(["main"] as const);
 export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS = Object.freeze(["blockTextHash"] as const);
+export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES = Object.freeze([
+  "best-effort",
+  "atomic",
+] as const);
 
 export type FolioDocumentOperation = FolioAIEditOperation;
 export type FolioDocumentOperationMode = FolioAIEditApplyMode;
@@ -59,6 +63,7 @@ export type FolioDocumentOperationCapabilities = {
   readonly operationTypes: typeof FOLIO_DOCUMENT_OPERATION_TYPES;
   readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
   readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
+  readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
   readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
   readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -68,6 +73,7 @@ const DOCUMENT_OPERATION_CAPABILITIES = Object.freeze({
   operationTypes: FOLIO_DOCUMENT_OPERATION_TYPES,
   modes: FOLIO_DOCUMENT_OPERATION_MODES,
   modesByOperationType: FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
+  batchModes: FOLIO_DOCUMENT_OPERATION_BATCH_MODES,
   preconditions: FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   stories: FOLIO_DOCUMENT_OPERATION_STORIES,
 } as const satisfies FolioDocumentOperationCapabilities);
@@ -127,6 +133,7 @@ export type FolioDocumentOperationBatch = {
   readonly version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
   operations: FolioDocumentOperation[];
   mode?: FolioDocumentOperationMode;
+  atomic?: boolean;
 };
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
@@ -397,7 +404,7 @@ export const parseFolioDocumentOperationBatch = (value: unknown): FolioDocumentO
   if (!isPlainObject(value)) {
     return invalidBatch("$", "expected an object");
   }
-  assertAllowedKeys(value, "$", ["version", "operations", "mode"]);
+  assertAllowedKeys(value, "$", ["version", "operations", "mode", "atomic"]);
   const version = assertSupportedFolioDocumentOperationVersion(value["version"]);
   const operations = value["operations"];
   if (!Array.isArray(operations)) {
@@ -407,15 +414,28 @@ export const parseFolioDocumentOperationBatch = (value: unknown): FolioDocumentO
   if (mode !== undefined && mode !== "direct" && mode !== "tracked-changes") {
     return invalidBatch("$.mode", 'expected "direct" or "tracked-changes" when provided');
   }
+  const atomic = readOptionalBoolean(value, "atomic", "$");
+  const parsedOperations = operations.map(parseDocumentOperation);
+  const operationIds = new Set<string>();
+  for (const [index, operation] of parsedOperations.entries()) {
+    if (operationIds.has(operation.id)) {
+      return invalidBatch(`$.operations[${index}].id`, "expected a unique operation id");
+    }
+    operationIds.add(operation.id);
+  }
   return {
     version,
-    operations: operations.map(parseDocumentOperation),
+    operations: parsedOperations,
     ...(mode !== undefined && { mode }),
+    ...(atomic !== undefined && { atomic }),
   };
 };
 
+export type FolioDocumentOperationStatus = "committed" | "rejected";
+
 export type FolioDocumentOperationResult = {
   version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+  status: FolioDocumentOperationStatus;
   applied: FolioAIEditAppliedOperation[];
   skipped: FolioAIEditSkippedOperation[];
 };
@@ -436,15 +456,45 @@ export const applyFolioDocumentOperations = ({
   createCommentId,
 }: ApplyFolioDocumentOperationsOptions): FolioDocumentOperationResult => {
   const parsedBatch = parseFolioDocumentOperationBatch(batch);
-  return {
-    version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
-    ...applyFolioAIEditOperations({
-      view,
+  const apply = (targetView: FolioAIEditView, targetCreateCommentId = createCommentId) =>
+    applyFolioAIEditOperations({
+      view: targetView,
       snapshot,
       operations: parsedBatch.operations,
       mode: parsedBatch.mode ?? "tracked-changes",
       ...(author !== undefined && { author }),
-      ...(createCommentId !== undefined && { createCommentId }),
-    }),
+      ...(targetCreateCommentId !== undefined && { createCommentId: targetCreateCommentId }),
+    });
+
+  if (parsedBatch.atomic === true) {
+    let previewCommentId = -1;
+    const previewView: FolioAIEditView = {
+      state: view.state,
+      dispatch: (transaction) => {
+        previewView.state = previewView.state.apply(transaction);
+      },
+    };
+    const preview = apply(
+      previewView,
+      createCommentId === undefined ? undefined : () => previewCommentId--,
+    );
+    if (preview.skipped.length > 0) {
+      const skippedById = new Map(preview.skipped.map((operation) => [operation.id, operation]));
+      return {
+        version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+        status: "rejected",
+        applied: [],
+        skipped: parsedBatch.operations.map(
+          ({ id }): FolioAIEditSkippedOperation =>
+            skippedById.get(id) ?? { id, reason: "atomicBatchRejected" },
+        ),
+      };
+    }
+  }
+
+  return {
+    version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+    status: "committed",
+    ...apply(view),
   };
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export {
   applyFolioDocumentOperations,
   assertSupportedFolioDocumentOperationVersion,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+  FOLIO_DOCUMENT_OPERATION_BATCH_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
   FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
@@ -81,6 +82,7 @@ export {
   type FolioDocumentOperationPrecondition,
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
+  type FolioDocumentOperationStatus,
 } from "./ai-edits";
 export {
   resolveSuggestionAnchor,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -53,6 +53,7 @@ export type {
 export {
   assertSupportedFolioDocumentOperationVersion,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+  FOLIO_DOCUMENT_OPERATION_BATCH_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES,
   FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
   FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
@@ -71,4 +72,5 @@ export {
   type FolioDocumentOperationPrecondition,
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
+  type FolioDocumentOperationStatus,
 } from "./document-operations";

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2826,6 +2826,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         if (!view) {
           return {
             version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+            status: batch.atomic === true ? "rejected" : "committed",
             applied: [],
             skipped: batch.operations.map((operation) => ({
               id: operation.id,

--- a/tests/operations/tracked-replace.v1.json
+++ b/tests/operations/tracked-replace.v1.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "mode": "tracked-changes",
+  "atomic": true,
   "operations": [
     {
       "id": "replace-heading",


### PR DESCRIPTION
Adds optional all-or-nothing execution for versioned document operation batches, with explicit batch outcomes.