### PR TITLE
feat: add document operation dry runs

### DIFF
--- a/.changeset/brave-runs-preview.md
+++ b/.changeset/brave-runs-preview.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-react": patch
+"@stll/folio-agents": patch
+---
+
+Add dry-run previews for document operation batches.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -10,7 +10,7 @@ import { TaggedErrorClass } from 'better-result';
 import { Transaction } from 'prosemirror-state';
 
 // @public (undocumented)
-export const applyFolioAIEditOperations: (input: ApplyFolioAIEditOperationsOptions) => FolioAIEditApplyResult;
+export const applyFolioAIEditOperations: (options: ApplyFolioAIEditOperationsOptions) => FolioAIEditApplyResult;
 
 // @public (undocumented)
 export const applyFolioDocumentOperations: (input: ApplyFolioDocumentOperationsOptions) => FolioDocumentOperationResult;
@@ -234,6 +234,7 @@ export type FolioDocumentOperationBatch = {
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
     atomic?: boolean;
+    dryRun?: boolean;
 };
 
 // @public (undocumented)
@@ -243,6 +244,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
     readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
+    readonly dryRun: true;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -262,7 +264,7 @@ export type FolioDocumentOperationResult = {
 };
 
 // @public (undocumented)
-export type FolioDocumentOperationStatus = "committed" | "rejected";
+export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -150,7 +150,7 @@ export type AnonymizationTerm = {
 export const appendAutocompleteToken: (tr: Transaction, requestId: string, delta: string) => Transaction;
 
 // @public (undocumented)
-export const applyFolioAIEditOperations: (input: ApplyFolioAIEditOperationsOptions) => FolioAIEditApplyResult;
+export const applyFolioAIEditOperations: (options: ApplyFolioAIEditOperationsOptions) => FolioAIEditApplyResult;
 
 // @public (undocumented)
 export const applyFolioDocumentOperations: (input: ApplyFolioDocumentOperationsOptions) => FolioDocumentOperationResult;
@@ -515,6 +515,7 @@ export type FolioDocumentOperationBatch = {
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
     atomic?: boolean;
+    dryRun?: boolean;
 };
 
 // @public (undocumented)
@@ -524,6 +525,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
     readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
+    readonly dryRun: true;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -543,7 +545,7 @@ export type FolioDocumentOperationResult = {
 };
 
 // @public (undocumented)
-export type FolioDocumentOperationStatus = "committed" | "rejected";
+export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -150,7 +150,7 @@ export type AnonymizationTerm = {
 export const appendAutocompleteToken: (tr: Transaction, requestId: string, delta: string) => Transaction;
 
 // @public (undocumented)
-export const applyFolioAIEditOperations: (input: ApplyFolioAIEditOperationsOptions) => FolioAIEditApplyResult;
+export const applyFolioAIEditOperations: (options: ApplyFolioAIEditOperationsOptions) => FolioAIEditApplyResult;
 
 // @public (undocumented)
 export const applyFolioDocumentOperations: (input: ApplyFolioDocumentOperationsOptions) => FolioDocumentOperationResult;
@@ -515,6 +515,7 @@ export type FolioDocumentOperationBatch = {
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
     atomic?: boolean;
+    dryRun?: boolean;
 };
 
 // @public (undocumented)
@@ -524,6 +525,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
     readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
+    readonly dryRun: true;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -543,7 +545,7 @@ export type FolioDocumentOperationResult = {
 };
 
 // @public (undocumented)
-export type FolioDocumentOperationStatus = "committed" | "rejected";
+export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -221,6 +221,7 @@ export type FolioDocumentOperationBatch = {
     operations: FolioDocumentOperation[];
     mode?: FolioDocumentOperationMode;
     atomic?: boolean;
+    dryRun?: boolean;
 };
 
 // @public (undocumented)
@@ -230,6 +231,7 @@ export type FolioDocumentOperationCapabilities = {
     readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
     readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
     readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
+    readonly dryRun: true;
     readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
     readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -249,7 +251,7 @@ export type FolioDocumentOperationResult = {
 };
 
 // @public (undocumented)
-export type FolioDocumentOperationStatus = "committed" | "rejected";
+export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected";
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];

--- a/packages/agents/src/bridges/editor-ref.test.ts
+++ b/packages/agents/src/bridges/editor-ref.test.ts
@@ -103,6 +103,37 @@ describe("createEditorRefBridge: document operations", () => {
     expect(applyCalls).toBe(0);
   });
 
+  test("reports dry runs as unsupported without mutating through an older editor ref", () => {
+    let applyCalls = 0;
+    const ref: FolioAgentEditorRefLike = {
+      ...baseRef(),
+      applyAIEditOperations: () => {
+        applyCalls += 1;
+        return EMPTY_APPLY_RESULT;
+      },
+    };
+    const bridge = createEditorRefBridge({
+      ref,
+      author: "AI",
+      getComments: () => [],
+      setComments: () => {},
+    });
+
+    const result = bridge.applyDocumentOperations({
+      version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      dryRun: true,
+      operations: [{ id: "op-1", type: "deleteBlock", blockId: "para-1" }],
+    });
+
+    expect(result).toEqual({
+      version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      status: "previewed",
+      applied: [],
+      skipped: [{ id: "op-1", reason: "unsupportedMode" }],
+    });
+    expect(applyCalls).toBe(0);
+  });
+
   test("rejects unsupported serialized versions before using a legacy ref", () => {
     const bridge = createEditorRefBridge({
       ref: baseRef(),

--- a/packages/agents/src/bridges/editor-ref.ts
+++ b/packages/agents/src/bridges/editor-ref.ts
@@ -175,6 +175,17 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
       if (ref.applyDocumentOperations) {
         return ref.applyDocumentOperations({ snapshot, batch: versionedBatch, author });
       }
+      if (versionedBatch.dryRun === true) {
+        return {
+          version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+          status: "previewed",
+          applied: [],
+          skipped: versionedBatch.operations.map(({ id }) => ({
+            id,
+            reason: "unsupportedMode",
+          })),
+        };
+      }
       if (versionedBatch.atomic === true) {
         return {
           version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -143,4 +143,32 @@ describe("document operation cross-surface conformance", () => {
       expect(output.savedChanges, output.name).toEqual(expected.changes);
     }
   });
+
+  test("previews equivalent results without mutating any surface", async () => {
+    const batch = { ...readOperationFixture(), dryRun: true };
+    const outputs = [];
+
+    for (const surface of await createSurfaces()) {
+      const contentBefore = surface.reviewer.getContentAsText();
+      const result = surface.apply(batch);
+      outputs.push({
+        name: surface.name,
+        result: normalizeResult(result),
+        contentBefore,
+        contentAfter: surface.reviewer.getContentAsText(),
+        changes: normalizeChanges(surface.reviewer),
+      });
+    }
+
+    for (const output of outputs) {
+      expect(output.result, output.name).toEqual({
+        version: 1,
+        status: "previewed",
+        applied: [{ id: "replace-heading" }],
+        skipped: [],
+      });
+      expect(output.contentAfter, output.name).toBe(output.contentBefore);
+      expect(output.changes, output.name).toEqual([]);
+    }
+  });
 });

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -44,6 +44,10 @@ type ApplyFolioAIEditOperationsOptions = {
   createCommentId?: (text: string) => number;
 };
 
+type ApplyFolioAIEditOperationsInternalOptions = ApplyFolioAIEditOperationsOptions & {
+  revisionIdSeed?: number;
+};
+
 type ResolvedOperation = {
   operation: FolioAIEditOperation;
   from: number;
@@ -353,14 +357,15 @@ const buildEmphasisInlineContent = (
   return nodes.length > 0 ? nodes : [schema.text(text, [...baseMarks])];
 };
 
-export const applyFolioAIEditOperations = ({
+const applyFolioAIEditOperationsInternal = ({
   view,
   snapshot,
   operations,
   mode = "tracked-changes",
   author = "AI",
   createCommentId,
-}: ApplyFolioAIEditOperationsOptions): FolioAIEditApplyResult => {
+  revisionIdSeed,
+}: ApplyFolioAIEditOperationsInternalOptions): FolioAIEditApplyResult => {
   const applied: FolioAIEditAppliedOperation[] = [];
   const skipped: FolioAIEditSkippedOperation[] = [];
   const resolved: ResolvedOperation[] = [];
@@ -417,7 +422,7 @@ export const applyFolioAIEditOperations = ({
   }
 
   let tr = view.state.tr;
-  let revisionSeed = nextRevisionSeed(resolved.length);
+  let revisionSeed = revisionIdSeed ?? nextRevisionSeed(resolved.length);
   const date = new Date().toISOString();
 
   // Sort right-to-left so each tr.insert / tr.delete leaves
@@ -687,6 +692,35 @@ export const applyFolioAIEditOperations = ({
   }
 
   return { applied, skipped };
+};
+
+export const applyFolioAIEditOperations = (
+  options: ApplyFolioAIEditOperationsOptions,
+): FolioAIEditApplyResult => applyFolioAIEditOperationsInternal(options);
+
+export const previewFolioAIEditOperations = (
+  options: ApplyFolioAIEditOperationsOptions,
+): FolioAIEditApplyResult => {
+  const { view, createCommentId, ...applyOptions } = options;
+  let previewCommentId = -1;
+  const previewView: FolioAIEditView = {
+    state: view.state,
+    dispatch: (transaction) => {
+      previewView.state = previewView.state.apply(transaction);
+    },
+  };
+  const result = applyFolioAIEditOperationsInternal({
+    ...applyOptions,
+    view: previewView,
+    ...(createCommentId !== undefined && {
+      createCommentId: () => previewCommentId--,
+    }),
+    revisionIdSeed: -1_000_000_000,
+  });
+  return {
+    applied: result.applied.map(({ id }) => ({ id })),
+    skipped: result.skipped,
+  };
 };
 
 type TextReplacementOptions = {

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -248,6 +248,85 @@ describe("headless docx review round-trip", () => {
     expect(reviewer.getComments()).toHaveLength(1);
   });
 
+  test("dry runs predict best-effort results without document or comment changes", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    const contentBefore = reviewer.getContentAsText();
+    const operations = [
+      {
+        id: "valid",
+        type: "replaceInBlock" as const,
+        blockId: target.id,
+        find: "Heading",
+        replace: "Intro",
+        comment: { text: "Review this change." },
+      },
+      { id: "missing", type: "deleteBlock" as const, blockId: "para-missing" },
+    ];
+
+    const preview = reviewer.applyDocumentOperations({
+      version: 1,
+      dryRun: true,
+      mode: "direct",
+      operations,
+    });
+
+    expect(preview).toEqual({
+      version: 1,
+      status: "previewed",
+      applied: [{ id: "valid" }],
+      skipped: [{ id: "missing", reason: "missingBlock" }],
+    });
+    expect(reviewer.getContentAsText()).toBe(contentBefore);
+    expect(reviewer.getComments()).toEqual([]);
+
+    const committed = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations,
+    });
+    expect(committed.status).toBe("committed");
+    expect(committed.applied.map(({ id }) => id)).toEqual(["valid"]);
+    expect(committed.skipped).toEqual([{ id: "missing", reason: "missingBlock" }]);
+    expect(reviewer.getContentAsText()).toContain("Intro paragraph.");
+    expect(reviewer.getComments()).toHaveLength(1);
+  });
+
+  test("dry runs predict atomic rejection without exposing generated ids", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+
+    const preview = reviewer.applyDocumentOperations({
+      version: 1,
+      atomic: true,
+      dryRun: true,
+      operations: [
+        {
+          id: "valid",
+          type: "replaceInBlock",
+          blockId: target.id,
+          find: "Heading",
+          replace: "Intro",
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+
+    expect(preview).toEqual({
+      version: 1,
+      status: "previewed",
+      applied: [],
+      skipped: [
+        { id: "valid", reason: "atomicBatchRejected" },
+        { id: "missing", reason: "missingBlock" },
+      ],
+    });
+    expect(reviewer.getContentAsText()).toContain("Heading paragraph.");
+    expect(reviewer.getChanges()).toEqual([]);
+  });
+
   test("insertAfterBlock (direct) adds a sibling paragraph, no tracked marks", async () => {
     const baseline = await makeParaIdBaseline(readFixture());
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline);

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -29,6 +29,7 @@ describe("document operation contract", () => {
       ],
       modes: ["direct", "tracked-changes"],
       batchModes: ["best-effort", "atomic"],
+      dryRun: true,
       modesByOperationType: {
         replaceInBlock: ["direct", "tracked-changes"],
         insertAfterBlock: ["direct", "tracked-changes"],
@@ -77,6 +78,7 @@ describe("document operation contract", () => {
       version: 1,
       mode: "tracked-changes",
       atomic: true,
+      dryRun: true,
       operations: [
         {
           id: "1",
@@ -117,6 +119,7 @@ describe("document operation contract", () => {
     [{ version: 1 }, "$.operations", "expected an array"],
     [{ version: 1, operations: [], mode: "review" }, "$.mode", "expected"],
     [{ version: 1, operations: [], atomic: "yes" }, "$.atomic", "expected a boolean"],
+    [{ version: 1, operations: [], dryRun: "yes" }, "$.dryRun", "expected a boolean"],
     [
       {
         version: 1,

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -1,9 +1,14 @@
 import { TaggedError } from "better-result";
 
-import { applyFolioAIEditOperations, type FolioAIEditView } from "./ai-edits/apply";
+import {
+  applyFolioAIEditOperations,
+  type FolioAIEditView,
+  previewFolioAIEditOperations,
+} from "./ai-edits/apply";
 import type {
   FolioAIEditAppliedOperation,
   FolioAIEditApplyMode,
+  FolioAIEditApplyResult,
   FolioAIEditOperation,
   FolioAIEditPrecondition,
   FolioAIEditReviewMeta,
@@ -64,6 +69,7 @@ export type FolioDocumentOperationCapabilities = {
   readonly modes: typeof FOLIO_DOCUMENT_OPERATION_MODES;
   readonly modesByOperationType: typeof FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE;
   readonly batchModes: typeof FOLIO_DOCUMENT_OPERATION_BATCH_MODES;
+  readonly dryRun: true;
   readonly preconditions: typeof FOLIO_DOCUMENT_OPERATION_PRECONDITIONS;
   readonly stories: typeof FOLIO_DOCUMENT_OPERATION_STORIES;
 };
@@ -74,6 +80,7 @@ const DOCUMENT_OPERATION_CAPABILITIES = Object.freeze({
   modes: FOLIO_DOCUMENT_OPERATION_MODES,
   modesByOperationType: FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE,
   batchModes: FOLIO_DOCUMENT_OPERATION_BATCH_MODES,
+  dryRun: true,
   preconditions: FOLIO_DOCUMENT_OPERATION_PRECONDITIONS,
   stories: FOLIO_DOCUMENT_OPERATION_STORIES,
 } as const satisfies FolioDocumentOperationCapabilities);
@@ -134,6 +141,7 @@ export type FolioDocumentOperationBatch = {
   operations: FolioDocumentOperation[];
   mode?: FolioDocumentOperationMode;
   atomic?: boolean;
+  dryRun?: boolean;
 };
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
@@ -404,7 +412,7 @@ export const parseFolioDocumentOperationBatch = (value: unknown): FolioDocumentO
   if (!isPlainObject(value)) {
     return invalidBatch("$", "expected an object");
   }
-  assertAllowedKeys(value, "$", ["version", "operations", "mode", "atomic"]);
+  assertAllowedKeys(value, "$", ["version", "operations", "mode", "atomic", "dryRun"]);
   const version = assertSupportedFolioDocumentOperationVersion(value["version"]);
   const operations = value["operations"];
   if (!Array.isArray(operations)) {
@@ -415,6 +423,7 @@ export const parseFolioDocumentOperationBatch = (value: unknown): FolioDocumentO
     return invalidBatch("$.mode", 'expected "direct" or "tracked-changes" when provided');
   }
   const atomic = readOptionalBoolean(value, "atomic", "$");
+  const dryRun = readOptionalBoolean(value, "dryRun", "$");
   const parsedOperations = operations.map(parseDocumentOperation);
   const operationIds = new Set<string>();
   for (const [index, operation] of parsedOperations.entries()) {
@@ -428,10 +437,11 @@ export const parseFolioDocumentOperationBatch = (value: unknown): FolioDocumentO
     operations: parsedOperations,
     ...(mode !== undefined && { mode }),
     ...(atomic !== undefined && { atomic }),
+    ...(dryRun !== undefined && { dryRun }),
   };
 };
 
-export type FolioDocumentOperationStatus = "committed" | "rejected";
+export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected";
 
 export type FolioDocumentOperationResult = {
   version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
@@ -448,6 +458,12 @@ export type ApplyFolioDocumentOperationsOptions = {
   createCommentId?: (text: string) => number;
 };
 
+type ApplyParsedDocumentOperationBatchOptions = {
+  targetView: FolioAIEditView;
+  targetCreateCommentId?: (text: string) => number;
+  preview?: boolean;
+};
+
 export const applyFolioDocumentOperations = ({
   view,
   snapshot,
@@ -456,8 +472,15 @@ export const applyFolioDocumentOperations = ({
   createCommentId,
 }: ApplyFolioDocumentOperationsOptions): FolioDocumentOperationResult => {
   const parsedBatch = parseFolioDocumentOperationBatch(batch);
-  const apply = (targetView: FolioAIEditView, targetCreateCommentId = createCommentId) =>
-    applyFolioAIEditOperations({
+  const apply = ({
+    targetView,
+    targetCreateCommentId = createCommentId,
+    preview = false,
+  }: ApplyParsedDocumentOperationBatchOptions) => {
+    const applyOperations = preview
+      ? previewFolioAIEditOperations
+      : applyFolioAIEditOperations;
+    return applyOperations({
       view: targetView,
       snapshot,
       operations: parsedBatch.operations,
@@ -465,36 +488,51 @@ export const applyFolioDocumentOperations = ({
       ...(author !== undefined && { author }),
       ...(targetCreateCommentId !== undefined && { createCommentId: targetCreateCommentId }),
     });
+  };
+
+  const preview = () => apply({ targetView: view, preview: true });
+
+  const atomicResult = (
+    previewResult: FolioAIEditApplyResult,
+    status: "previewed" | "rejected",
+  ): FolioDocumentOperationResult => {
+    const skippedById = new Map(
+      previewResult.skipped.map((operation) => [operation.id, operation]),
+    );
+    return {
+      version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      status,
+      applied: [],
+      skipped: parsedBatch.operations.map(
+        ({ id }): FolioAIEditSkippedOperation =>
+          skippedById.get(id) ?? { id, reason: "atomicBatchRejected" },
+      ),
+    };
+  };
+
+  if (parsedBatch.dryRun === true) {
+    const previewResult = preview();
+    if (parsedBatch.atomic === true && previewResult.skipped.length > 0) {
+      return atomicResult(previewResult, "previewed");
+    }
+    return {
+      version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+      status: "previewed",
+      applied: previewResult.applied.map(({ id }) => ({ id })),
+      skipped: previewResult.skipped,
+    };
+  }
 
   if (parsedBatch.atomic === true) {
-    let previewCommentId = -1;
-    const previewView: FolioAIEditView = {
-      state: view.state,
-      dispatch: (transaction) => {
-        previewView.state = previewView.state.apply(transaction);
-      },
-    };
-    const preview = apply(
-      previewView,
-      createCommentId === undefined ? undefined : () => previewCommentId--,
-    );
-    if (preview.skipped.length > 0) {
-      const skippedById = new Map(preview.skipped.map((operation) => [operation.id, operation]));
-      return {
-        version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
-        status: "rejected",
-        applied: [],
-        skipped: parsedBatch.operations.map(
-          ({ id }): FolioAIEditSkippedOperation =>
-            skippedById.get(id) ?? { id, reason: "atomicBatchRejected" },
-        ),
-      };
+    const previewResult = preview();
+    if (previewResult.skipped.length > 0) {
+      return atomicResult(previewResult, "rejected");
     }
   }
 
   return {
     version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
     status: "committed",
-    ...apply(view),
+    ...apply({ targetView: view }),
   };
 };

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -45,6 +45,7 @@ import {
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   getCommentAnchorsFromDoc,
   getTrackedChangesFromDoc,
+  type FolioDocumentOperationStatus,
 } from "@stll/folio-core/ai-edits";
 import { normalizeBaseDirection } from "@stll/folio-core/docx/normalizeBaseDirection";
 import { getCachedNumberingMap } from "@stll/folio-core/docx/numberingParser";
@@ -2824,9 +2825,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         assertSupportedFolioDocumentOperationVersion(batch.version);
         const view = pagedEditorRef.current?.getView();
         if (!view) {
+          let status: FolioDocumentOperationStatus = "committed";
+          if (batch.dryRun === true) {
+            status = "previewed";
+          } else if (batch.atomic === true) {
+            status = "rejected";
+          }
           return {
             version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
-            status: batch.atomic === true ? "rejected" : "committed",
+            status,
             applied: [],
             skipped: batch.operations.map((operation) => ({
               id: operation.id,


### PR DESCRIPTION
Adds non-mutating previews for versioned document operation batches with predicted operation outcomes.