### PR TITLE
fix: reduce DOCX XML conversion allocations

### DIFF
--- a/.changeset/quick-dingos-parse.md
+++ b/.changeset/quick-dingos-parse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Reduce DOCX parsing allocations while converting ordered XML trees.

--- a/packages/core/src/docx/xmlParser.test.ts
+++ b/packages/core/src/docx/xmlParser.test.ts
@@ -3,6 +3,44 @@ import { describe, expect, test } from "bun:test";
 import { elementToXml, parseXmlDocument } from "./xmlParser";
 
 describe("OOXML parsing", () => {
+  test("preserves ordered nested elements and attributes", () => {
+    const document = parseXmlDocument(
+      '<w:p xmlns:w="urn" w:rsidR="1234"><w:r w:rsidRPr="5678"><w:t xml:space="preserve"> first </w:t></w:r><w:r><w:t>second</w:t></w:r></w:p>',
+    );
+
+    expect(document).toEqual({
+      type: "element",
+      name: "w:p",
+      attributes: { "xmlns:w": "urn", "w:rsidR": "1234" },
+      elements: [
+        {
+          type: "element",
+          name: "w:r",
+          attributes: { "w:rsidRPr": "5678" },
+          elements: [
+            {
+              type: "element",
+              name: "w:t",
+              attributes: { "xml:space": "preserve" },
+              elements: [{ type: "text", text: " first " }],
+            },
+          ],
+        },
+        {
+          type: "element",
+          name: "w:r",
+          elements: [
+            {
+              type: "element",
+              name: "w:t",
+              elements: [{ type: "text", text: "second" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   test("preserves legacy inline binary payloads", () => {
     const document = parseXmlDocument(
       '<w:p xmlns:w="urn"><w:binData w:name="image1">QUJDRA==</w:binData><w:r><w:t>after</w:t></w:r></w:p>',

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -110,8 +110,9 @@ function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
   // Element node: { "w:p": [...children], ":@": { ...attrs } }
   const attrs = node[ATTR_KEY] as Record<string, string> | undefined;
 
-  // The tag name is the first key that is neither #text nor :@
-  for (const key of Object.keys(node)) {
+  // fast-xml-parser creates these nodes and rejects prototype-polluting tag
+  // names. Iterating directly avoids allocating a keys array for every node.
+  for (const key in node) {
     if (key === ATTR_KEY) {
       continue;
     }
@@ -119,12 +120,18 @@ function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
     const children = node[key] as Record<string, unknown>[];
     const element: XmlElement = { type: "element", name: key };
 
-    if (attrs && Object.keys(attrs).length > 0) {
+    // fast-xml-parser only emits the attribute group when it contains an
+    // attribute, so a second Object.keys allocation is unnecessary.
+    if (attrs) {
       element.attributes = attrs;
     }
 
     if (children.length > 0) {
-      element.elements = children.map(fxpNodeToElement);
+      const elements: XmlElement[] = [];
+      for (const child of children) {
+        elements.push(fxpNodeToElement(child));
+      }
+      element.elements = elements;
     }
 
     return element;
@@ -140,8 +147,13 @@ function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
  * `{ elements: [...] }`.
  */
 function fxpToRootElement(nodes: Record<string, unknown>[]): XmlElement {
+  const elements: XmlElement[] = [];
+  for (const node of nodes) {
+    elements.push(fxpNodeToElement(node));
+  }
+
   return {
-    elements: nodes.map(fxpNodeToElement),
+    elements,
   };
 }
 


### PR DESCRIPTION
Replace allocation-heavy array transforms in the ordered XML conversion path with imperative accumulation while preserving the existing `XmlElement` shape. Add a regression test covering nested element order, attributes, and whitespace-sensitive text, plus a patch changeset.

In a simultaneous seven-repetition production-browser comparison on `podily-bps.docx`, warm-load median DOCX parsing improved from 263.2 ms to 249.7 ms (5.1%), pipeline time after bytes improved from 585.3 ms to 540.4 ms (7.7%), and first usable page improved from 885.0 ms to 861.6 ms (2.6%). Cold parsing was effectively unchanged (210.3 ms to 211.8 ms); the host was under substantial unrelated load, so these results are directional rather than a universal baseline.

Validated with the full unit suite, typecheck, lint, interaction tests, differential harness (optional external backends unavailable and skipped), core production build, clean-room dist validation, `git diff --check`, and `bun audit`.