### PR TITLE
fix: justify numbered continuations like Word

### DIFF
--- a/.changeset/wise-dogs-justify.md
+++ b/.changeset/wise-dogs-justify.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Match Word's justification of numbered-list continuation lines.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -490,6 +490,64 @@ describe("measureParagraph justified shrink tolerance", () => {
       },
     );
   });
+
+  test("uses prose shrink tolerance for justified list continuation lines", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-continuation",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("does not treat non-breaking spaces as compressible list-continuation spaces", () => {
+    const continuationText = `${"a".repeat(50)} ${"a".repeat(47)} \u00a0bbb`;
+
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-nonbreaking-space",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: continuationText },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(3);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
 });
 
 describe("inline image paragraph measurement", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -114,6 +114,10 @@ type LineState = {
   toRun: number;
   toChar: number;
   width: number;
+  /** Spaces Word may compress while justifying this line. */
+  regularSpaceCount: number;
+  /** Fixed-width spaces excluded from the line's justification budget. */
+  nonBreakingSpaceCount: number;
   maxFontSize: number;
   maxFontMetrics: FontMetrics | null;
   /** Maximum inline image height in pixels (already in px, not points) */
@@ -549,9 +553,27 @@ function uppercaseLetterRatio(text: string): number {
   return letters === 0 ? 0 : uppercase / letters;
 }
 
-function justifyShrinkToleranceRatio(block: ParagraphBlock, isFirstLine: boolean): number {
+function justifyShrinkToleranceRatio(
+  block: ParagraphBlock,
+  isFirstLine: boolean,
+  regularSpaceCount: number,
+  nonBreakingSpaceCount: number,
+): number {
   if (block.attrs?.listMarker !== undefined) {
-    return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+    // The marker only participates on the first line. Continuations use the
+    // prose allowance, reduced by the share of fixed non-breaking spaces on
+    // the current line; Word does not compress NBSPs during justification.
+    if (isFirstLine) {
+      return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+    }
+    const totalSpaces = regularSpaceCount + nonBreakingSpaceCount;
+    if (totalSpaces === 0) {
+      return JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO;
+    }
+    return Math.max(
+      JUSTIFY_SHRINK_TOLERANCE_RATIO,
+      JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO * (regularSpaceCount / totalSpaces),
+    );
   }
   const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
   const hasTabRuns = block.runs.some(isTabRun);
@@ -885,6 +907,8 @@ export function measureParagraph(
     toRun: 0,
     toChar: 0,
     width: 0,
+    regularSpaceCount: 0,
+    nonBreakingSpaceCount: 0,
     maxFontSize: DEFAULT_FONT_SIZE,
     maxFontMetrics: null,
     maxImageHeightPx: 0,
@@ -1026,6 +1050,8 @@ export function measureParagraph(
       toRun: runIndex,
       toChar: charIndex,
       width: 0,
+      regularSpaceCount: 0,
+      nonBreakingSpaceCount: 0,
       maxFontSize: DEFAULT_FONT_SIZE,
       maxFontMetrics: null,
       maxImageHeightPx: 0,
@@ -1344,10 +1370,18 @@ export function measureParagraph(
         // Extract word (includes trailing space if present)
         const word = text.slice(charIndex, nextBreak);
         const wordWidth = measureTextWidth(word, style);
+        const regularSpaces = word.split(" ").length - 1;
+        const nonBreakingSpaces = word.split("\u00a0").length - 1;
         const widthTolerance = isJustifiedParagraph
           ? Math.max(
               WIDTH_TOLERANCE,
-              currentLine.availableWidth * justifyShrinkToleranceRatio(block, lines.length === 0),
+              currentLine.availableWidth *
+                justifyShrinkToleranceRatio(
+                  block,
+                  lines.length === 0,
+                  currentLine.regularSpaceCount + regularSpaces,
+                  currentLine.nonBreakingSpaceCount + nonBreakingSpaces,
+                ),
             )
           : WIDTH_TOLERANCE;
 
@@ -1382,6 +1416,8 @@ export function measureParagraph(
             const chunkWidth = measureTextWidth(chunk, style);
 
             currentLine.width += chunkWidth;
+            currentLine.regularSpaceCount += chunk.split(" ").length - 1;
+            currentLine.nonBreakingSpaceCount += chunk.split("\u00a0").length - 1;
             currentLine.toRun = runIndex;
             currentLine.toChar = charIndex + chunkEnd;
 
@@ -1423,6 +1459,8 @@ export function measureParagraph(
 
         // Add word to current line
         currentLine.width += wordWidth;
+        currentLine.regularSpaceCount += regularSpaces;
+        currentLine.nonBreakingSpaceCount += nonBreakingSpaces;
         currentLine.toRun = runIndex;
         currentLine.toChar = nextBreak;
 


### PR DESCRIPTION
## Summary
- apply the conservative list-marker allowance only to the first rendered line
- scale continuation-line justification by compressible spaces, excluding non-breaking spaces
- add focused regressions for ordinary and non-breaking continuation spaces

## Validation
- `bun test src/layout-engine/measure` (162 passed)
- display parity: registry contract improves from 81.7% to 86.3%; pagination remains 4/4 and missing/extra/line-break divergences fall from 6 to 0
- `bun audit` (no vulnerabilities)
- lint and typecheck are intentionally delegated to CI

CC on behalf of @jan-kubica