### PR TITLE
fix: honor authored default tab grids

### DIFF
--- a/.changeset/brave-tigers-tabs.md
+++ b/.changeset/brave-tigers-tabs.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor authored document default tab intervals in paragraph layout and painting.

--- a/.changeset/calm-lions-justify.md
+++ b/.changeset/calm-lions-justify.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve standard list continuation wrapping while matching custom hanging indents.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -506,9 +506,10 @@ describe("measureParagraph justified shrink tolerance", () => {
             attrs: {
               alignment: "justify",
               listMarker: "1.",
+              indent: { left: 36, hanging: 36 },
             },
           },
-          100,
+          136,
         );
 
         expect(measure.lines).toHaveLength(2);
@@ -536,9 +537,39 @@ describe("measureParagraph justified shrink tolerance", () => {
             attrs: {
               alignment: "justify",
               listMarker: "1.",
+              indent: { left: 36, hanging: 36 },
             },
           },
-          100,
+          136,
+        );
+
+        expect(measure.lines).toHaveLength(3);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("keeps standard-hanging list continuation lines on the conservative tolerance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-standard-list-continuation",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 24, hanging: 24 },
+            },
+          },
+          124,
         );
 
         expect(measure.lines).toHaveLength(3);

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -581,6 +581,33 @@ describe("measureParagraph justified shrink tolerance", () => {
   });
 });
 
+describe("measureParagraph document default tab interval", () => {
+  test("advances consecutive tabs on the authored grid", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "authored-default-tabs",
+            runs: [
+              { kind: "text", text: "a".repeat(41) },
+              { kind: "tab" },
+              { kind: "tab" },
+              { kind: "text", text: "x" },
+            ],
+            attrs: { defaultTabStopTwips: 600 },
+          },
+          200,
+        );
+
+        expect(measure.lines).toHaveLength(1);
+        expect(measure.lines[0]?.width).toBe(121);
+      },
+      { charWidth: () => 1 },
+    );
+  });
+});
+
 describe("inline image paragraph measurement", () => {
   test("image-only line reserves descender room above and below image", () => {
     const imageHeight = 29;

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -56,6 +56,7 @@ const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO = 0.025;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
+const DEFAULT_LIST_HANGING_INDENT_PX = 24;
 const ALL_CAPS_RATIO_THRESHOLD = 0.8;
 
 /**
@@ -560,10 +561,11 @@ function justifyShrinkToleranceRatio(
   nonBreakingSpaceCount: number,
 ): number {
   if (block.attrs?.listMarker !== undefined) {
-    // The marker only participates on the first line. Continuations use the
-    // prose allowance, reduced by the share of fixed non-breaking spaces on
-    // the current line; Word does not compress NBSPs during justification.
-    if (isFirstLine) {
+    // Word keeps its conservative list allowance for the standard 360-twip
+    // hanging slot. Custom, wider slots use prose compression after the marker
+    // line, reduced by fixed non-breaking spaces on the current line.
+    const hanging = block.attrs.indent?.hanging ?? 0;
+    if (isFirstLine || hanging <= DEFAULT_LIST_HANGING_INDENT_PX) {
       return JUSTIFY_SHRINK_TOLERANCE_RATIO;
     }
     const totalSpaces = regularSpaceCount + nonBreakingSpaceCount;

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -1137,6 +1137,9 @@ export function measureParagraph(
       const contentX = indentLeft + (isFirstLine ? firstLineOffset + markerInlineWidth : 0) + lineX;
       const tabContext: TabContext = {
         ...(attrs?.tabs !== undefined ? { explicitStops: attrs.tabs } : {}),
+        ...(attrs?.defaultTabStopTwips !== undefined
+          ? { defaultTabInterval: attrs.defaultTabStopTwips }
+          : {}),
         leftIndent: pixelsToTwips(indentLeft),
       };
       const tabResult = calculateTabWidth(contentX, tabContext, {

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -55,6 +55,10 @@ function findTabEl(lineEl: FakeElement): FakeElement | undefined {
   return lineEl.children.find((child) => child.className.includes("layout-run-tab"));
 }
 
+function findTabEls(lineEl: FakeElement): FakeElement[] {
+  return lineEl.children.filter((child) => child.className.includes("layout-run-tab"));
+}
+
 describe("renderLine box model", () => {
   test("uses content-box and visible overflow so highlighted text is not clipped", () => {
     const block: ParagraphBlock = {
@@ -123,6 +127,43 @@ describe("renderLine box model", () => {
     expect(tabEl).toBeDefined();
     expect(tabEl?.style["borderBottom"]).toBe("1px solid currentColor");
     expect(tabEl?.style["textDecorationLine"]).toBe("");
+  });
+
+  test("paints consecutive tabs on the document default grid", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "authored-default-tabs",
+      runs: [
+        { kind: "text", text: "1234567" },
+        { kind: "tab" },
+        { kind: "tab" },
+        { kind: "text", text: "x" },
+      ],
+      attrs: { defaultTabStopTwips: 600 },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 3,
+      toChar: 1,
+      width: 127,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 200,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+
+    const tabs = findTabEls(lineEl);
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]?.style["width"]).toBe("31px");
+    expect(tabs[1]?.style["width"]).toBe("40px");
   });
 
   test("does not underline raised footnote reference markers", () => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1765,6 +1765,9 @@ export function renderLine(
 
     tabContext = {
       ...(explicitStops !== undefined ? { explicitStops } : {}),
+      ...(block.attrs?.defaultTabStopTwips !== undefined
+        ? { defaultTabInterval: block.attrs.defaultTabStopTwips }
+        : {}),
       leftIndent: leftIndentTwips,
     };
   }


### PR DESCRIPTION
## Summary
- preserve conservative wrapping for Word’s standard 360-twip list hanging slot while retaining custom-slot continuation behavior
- honor `w:defaultTabStop` for ordinary tabs in both measurement and painting
- add regressions for standard/custom list continuations and consecutive authored-grid tabs

## Validation
- `bun test src/layout-engine/measure src/layout-painter/renderParagraph-line-box.test.ts` (170 passed)
- Kroměříž registry contract: 67.7% to 71.9%, pages remain 7/7, x-drift failures fall from 17 to 0
- prior registry contract remains 86.3%, pages 4/4
- `bun audit` (no vulnerabilities)
- lint and typecheck are intentionally delegated to CI

CC on behalf of @jan-kubica