### PR TITLE
fix: preserve final section page geometry

### DIFF
--- a/.changeset/green-owls-sections.md
+++ b/.changeset/green-owls-sections.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve final-section page geometry and clear overflowing first-page headers.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -495,10 +495,7 @@ describe("runLayoutPipeline", () => {
       },
     ];
 
-    const outcome = runLayoutPipeline(
-      makeDeps(createLayoutSession(), { document }),
-      makeState(),
-    );
+    const outcome = runLayoutPipeline(makeDeps(createLayoutSession(), { document }), makeState());
 
     expect(outcome.layout?.pages.at(0)?.size).toEqual({ w: 1124, h: 795 });
   });

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -23,6 +23,7 @@ import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import { LayoutPainter } from "../layout-painter";
 import { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
 import { schema } from "../prosemirror/schema";
+import { createEmptyDocument } from "../utils/createDocument";
 import { runLayoutPipeline } from "./layoutPipeline";
 import type { LayoutPipelineDeps } from "./layoutPipeline";
 import { createLayoutSession } from "./layoutSession";
@@ -444,6 +445,62 @@ describe("runLayoutPipeline", () => {
     expect(withTallFooter.layout?.pages.map((page) => page.fragments.map(({ y }) => y))).toEqual(
       baseline.layout?.pages.map((page) => page.fragments.map(({ y }) => y)),
     );
+  });
+
+  test("moves only the title-page body below an overflowing first-page header", () => {
+    const state = makeState();
+    const baseline = runLayoutPipeline(makeDeps(createLayoutSession()), state);
+    const withTallFirstHeader = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        sectionProperties: { titlePg: true },
+        firstPageHeaderContent: { type: "header", hdrFtrType: "first", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "header"
+            ? {
+                blocks: [],
+                measures: [],
+                height: 120,
+                visualTop: 0,
+                visualBottom: 120,
+                marginPushTop: 0,
+                marginPushBottom: 120,
+              }
+            : undefined,
+      }),
+      state,
+    );
+
+    const baselineFirstPage = baseline.layout?.pages.at(0);
+    const pushedFirstPage = withTallFirstHeader.layout?.pages.at(0);
+    expect(pushedFirstPage?.margins.top).toBe(MARGINS.header + 120);
+    expect(pushedFirstPage?.fragments.at(0)?.y).toBeGreaterThan(
+      baselineFirstPage?.fragments.at(0)?.y ?? 0,
+    );
+  });
+
+  test("threads the final section geometry into layout", () => {
+    const document = createEmptyDocument();
+    document.package.document.sections = [
+      {
+        properties: {
+          pageWidth: 16_860,
+          pageHeight: 11_920,
+          orientation: "landscape",
+          marginTop: 1_134,
+          marginRight: 1_134,
+          marginBottom: 1_134,
+          marginLeft: 1_134,
+        },
+        content: [],
+      },
+    ];
+
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), { document }),
+      makeState(),
+    );
+
+    expect(outcome.layout?.pages.at(0)?.size).toEqual({ w: 1124, h: 795 });
   });
 
   test("discards the outcome and leaves the session unmutated when the paint phase throws", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -56,7 +56,7 @@ import { tryBuildIncrementalMeasures } from "../paged-layout/incrementalMeasure"
 import type { DirtyRange } from "../paged-layout/incrementalMeasure";
 import type { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
 import { computePerBlockMeasureInputs } from "../paged-layout/sectionBlockWidths";
-import { twipsToPixels } from "../paged-layout/sectionGeometry";
+import { getMargins, getPageSize, twipsToPixels } from "../paged-layout/sectionGeometry";
 import { templatePreviewValuesKey } from "../prosemirror/plugins/templatePreviewValues";
 import type { TemplatePreviewEntry } from "../prosemirror/plugins/templatePreviewValues";
 import type {
@@ -406,6 +406,20 @@ export function runLayoutPipeline<THfPMs>(
         margins,
         pageGap,
       };
+      if (hasTitlePg && firstPageHeaderForRender) {
+        const headerDistance = margins.header ?? 0;
+        const headerBottom =
+          headerDistance +
+          (firstPageHeaderForRender.marginPushBottom ?? firstPageHeaderForRender.height);
+        if (headerBottom > margins.top) {
+          nextLayoutOpts.firstPageMargins = { ...margins, top: headerBottom };
+        }
+      }
+      const finalSection = document?.package.document.sections.at(-1);
+      if (finalSection) {
+        nextLayoutOpts.finalPageSize = getPageSize(finalSection.properties);
+        nextLayoutOpts.finalMargins = getMargins(finalSection.properties);
+      }
       if (columns !== undefined) {
         nextLayoutOpts.columns = columns;
       }

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -415,7 +415,7 @@ export function runLayoutPipeline<THfPMs>(
           nextLayoutOpts.firstPageMargins = { ...margins, top: headerBottom };
         }
       }
-      const finalSection = document?.package.document.sections.at(-1);
+      const finalSection = document?.package.document.sections?.at(-1);
       if (finalSection) {
         nextLayoutOpts.finalPageSize = getPageSize(finalSection.properties);
         nextLayoutOpts.finalMargins = getMargins(finalSection.properties);


### PR DESCRIPTION
## Summary
- reserve first-page body space when a `titlePg` header’s measured flow extends below the authored top margin
- thread the document’s final section size and margins into the layout engine
- add focused pipeline regressions for both geometry paths

## Validation
- `bun test src/controller/layoutPipeline.test.ts src/layout-engine/continuousSectionGeometry.test.ts` (12 passed)
- registry support contract: 50.3% to 60.7%, page count 14 to 15 (Word: 15), pagination divergences 119 to 4
- final pages 13–15 remain landscape, matching Word
- `bun audit` (no vulnerabilities)
- lint and typecheck are intentionally delegated to CI

CC on behalf of @jan-kubica