### PR TITLE
feat(lint): guard render-storm shapes in packages/react

### DIFF
--- a/.changeset/stable-display-mode-items.md
+++ b/.changeset/stable-display-mode-items.md
@@ -2,4 +2,4 @@
 "@stll/folio-react": patch
 ---
 
-Translate the display-mode select trigger label (it was hardcoded English while the popup was localized) and keep the items array referentially stable per locale instead of rebuilding it every render.
+Translate the display-mode select trigger label and stabilize object, array, function, and JSX props across React component boundaries to preserve memoization in the published build.

--- a/.changeset/stable-display-mode-items.md
+++ b/.changeset/stable-display-mode-items.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": patch
+---
+
+Translate the display-mode select trigger label (it was hardcoded English while the popup was localized) and keep the items array referentially stable per locale instead of rebuilding it every render.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -140,6 +140,27 @@ export default library({
       },
     },
     {
+      // Render-storm guards for the React package. folio-react ships WITHOUT
+      // the React Compiler (the tsdown build has no compiler pass, and
+      // consumers import the prebuilt dist), so referential identity is
+      // load-bearing: manual memoization is what keeps the editor's render
+      // pipeline cheap, and an inline value passed as a context `value` (or to
+      // a memoized child) silently defeats every bailout downstream. Consumers
+      // that run the React Compiler over their own app code do not need these
+      // rules; they are scoped to this package's source only.
+      //
+      // The remaining react-perf rules are intentionally off for now; the
+      // existing violation counts are not tractable as a lint gate (measured
+      // at oxlint 1.71.0): jsx-no-new-object-as-prop: 110,
+      // jsx-no-new-function-as-prop: 222. Revisit after a burn-down.
+      files: ["packages/react/src/**/*.{ts,tsx}"],
+      plugins: ["react", "react-perf"],
+      rules: {
+        "react/jsx-no-constructed-context-values": "error",
+        "react-perf/jsx-no-new-array-as-prop": "error",
+      },
+    },
+    {
       // Folio model seam. The model type layer is pure data: forbid it from
       // importing ProseMirror, DOM render, React, @stll/ui, or engine behavior.
       // See the matching test at `src/core/__tests__/model-purity.test.ts`.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -149,15 +149,18 @@ export default library({
       // that run the React Compiler over their own app code do not need these
       // rules; they are scoped to this package's source only.
       //
-      // The remaining react-perf rules are intentionally off for now; the
-      // existing violation counts are not tractable as a lint gate (measured
-      // at oxlint 1.71.0): jsx-no-new-object-as-prop: 110,
-      // jsx-no-new-function-as-prop: 222. Revisit after a burn-down.
       files: ["packages/react/src/**/*.{ts,tsx}"],
       plugins: ["react", "react-perf"],
       rules: {
         "react/jsx-no-constructed-context-values": "error",
-        "react-perf/jsx-no-new-array-as-prop": "error",
+        // Intrinsic elements do not have React memoization boundaries, so a
+        // fresh DOM prop cannot invalidate a child-component bailout. Keep the
+        // rules strict at every component boundary without forcing no-op
+        // memoization around native event handlers and style objects.
+        "react-perf/jsx-no-jsx-as-prop": ["error", { nativeAllowList: "all" }],
+        "react-perf/jsx-no-new-array-as-prop": ["error", { nativeAllowList: "all" }],
+        "react-perf/jsx-no-new-function-as-prop": ["error", { nativeAllowList: "all" }],
+        "react-perf/jsx-no-new-object-as-prop": ["error", { nativeAllowList: "all" }],
       },
     },
     {

--- a/packages/react/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/react/src/components/ContentControlWidgetsOverlay.tsx
@@ -30,6 +30,8 @@ import { useFolioUI } from "../ui/folio-ui";
 
 type ListItem = { displayText: string; value: string };
 
+type FolioMenuItem = ReturnType<typeof useFolioUI>["Menu"]["Item"];
+
 type OpenPicker =
   | {
       kind: "dropdown";
@@ -166,25 +168,41 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
     };
   }, [open]);
 
+  const openPmPos = open?.pmPos;
+  const onDropdownPick = useCallback(
+    (value: string) => {
+      const liveView = getEditorViewRef.current();
+      if (liveView && typeof openPmPos === "number") {
+        dispatchDropdownPick(liveView, openPmPos, value);
+      }
+      close();
+    },
+    [close, openPmPos],
+  );
+
+  const onDatePick = useCallback(
+    (value: string) => {
+      const liveView = getEditorViewRef.current();
+      if (liveView && value.length > 0 && typeof openPmPos === "number") {
+        dispatchDatePick(liveView, openPmPos, value);
+      }
+      close();
+    },
+    [close, openPmPos],
+  );
+
+  const handleDateChange = useCallback(
+    (value: string | null) => {
+      if (value) {
+        onDatePick(value);
+      }
+    },
+    [onDatePick],
+  );
+
   if (!open) {
     return null;
   }
-
-  const onDropdownPick = (value: string): void => {
-    const liveView = getEditorViewRef.current();
-    if (liveView) {
-      dispatchDropdownPick(liveView, open.pmPos, value);
-    }
-    close();
-  };
-
-  const onDatePick = (value: string): void => {
-    const liveView = getEditorViewRef.current();
-    if (liveView && value.length > 0) {
-      dispatchDatePick(liveView, open.pmPos, value);
-    }
-    close();
-  };
 
   // `folio-root` wrapper re-establishes the editor root inside this body portal
   // so, on the standalone-stylesheet path, the design tokens and scoped
@@ -210,12 +228,12 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
               </div>
             ) : (
               open.items.map((item) => (
-                <MenuItem
+                <ContentControlDropdownItem
                   key={`${item.value}::${item.displayText}`}
-                  onClick={() => onDropdownPick(item.value)}
-                >
-                  {item.displayText}
-                </MenuItem>
+                  item={item}
+                  MenuItem={MenuItem}
+                  onPick={onDropdownPick}
+                />
               ))
             )}
           </div>
@@ -224,11 +242,7 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
           <DatePickerPopover
             clearLabel={t("clearDate")}
             defaultOpen
-            onChange={(value) => {
-              if (value) {
-                onDatePick(value);
-              }
-            }}
+            onChange={handleDateChange}
             showIcon={false}
             value={null}
           />
@@ -237,4 +251,16 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
     </div>,
     document.body,
   );
+}
+
+type ContentControlDropdownItemProps = {
+  item: ListItem;
+  MenuItem: FolioMenuItem;
+  onPick: (value: string) => void;
+};
+
+function ContentControlDropdownItem({ item, MenuItem, onPick }: ContentControlDropdownItemProps) {
+  const handleClick = useCallback(() => onPick(item.value), [item.value, onPick]);
+
+  return <MenuItem onClick={handleClick}>{item.displayText}</MenuItem>;
 }

--- a/packages/react/src/components/DocumentOutline.tsx
+++ b/packages/react/src/components/DocumentOutline.tsx
@@ -132,6 +132,8 @@ export const DocumentOutline: React.FC<DocumentOutlineProps> = ({
     [onHeadingClick],
   );
 
+  const resolvePct = useCallback((id: string) => pctByPmPos.get(id) ?? null, [pctByPmPos]);
+
   if (headings.length < 2) {
     return null;
   }
@@ -143,7 +145,7 @@ export const DocumentOutline: React.FC<DocumentOutlineProps> = ({
       items={items}
       onJump={handleJump}
       panelWidth={320}
-      resolvePct={(id) => pctByPmPos.get(id) ?? null}
+      resolvePct={resolvePct}
       scrollContainerRef={scrollContainerRef}
       topOffset={topOffset}
     />

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -227,7 +227,7 @@ import { useContextMenu } from "./hooks/useContextMenu";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
 import { useDocumentLoader } from "./hooks/useDocumentLoader";
 import type { DisplayMode } from "./hooks/useEditorMode";
-import { useEditorMode } from "./hooks/useEditorMode";
+import { DISPLAY_MODES, useEditorMode } from "./hooks/useEditorMode";
 import { useFindReplace } from "./hooks/useFindReplace";
 import { useHeaderFooterEditor } from "./hooks/useHeaderFooterEditor";
 import { useHyperlinkHandlers } from "./hooks/useHyperlinkHandlers";
@@ -280,6 +280,14 @@ const loadRepackDocx = async () => {
 // (`src/index.ts`) imports them from those canonical homes directly; no
 // re-export shim here.
 // ============================================================================
+
+/** Translation key for each display mode's label (trigger and popup). */
+const DISPLAY_MODE_LABEL_KEYS = {
+  "all-markup": "markupView.allMarkup",
+  "simple-markup": "markupView.simple",
+  "no-markup": "markupView.noMarkup",
+  original: "markupView.original",
+} as const satisfies Record<DisplayMode, string>;
 
 // ============================================================================
 // MAIN COMPONENT
@@ -3079,6 +3087,16 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     return pagesContainer.querySelector(selector);
   }, []);
 
+  // The display-mode Select derives its trigger label from `items` (Base UI),
+  // so feed it the same translated labels the popup renders. Memoized per
+  // locale (`t` is stable until the locale changes): the toolbar re-renders on
+  // every editor state change, and a fresh inline array would churn the Select
+  // subtree's props identity each time.
+  const displayModeItems = useMemo(
+    () => DISPLAY_MODES.map((mode) => ({ value: mode, label: t(DISPLAY_MODE_LABEL_KEYS[mode]) })),
+    [t],
+  );
+
   // Container styles - using overflow: auto so sticky toolbar works
   const containerStyle: CSSProperties = {
     display: "flex",
@@ -3153,13 +3171,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     );
   }
 
-  const DISPLAY_MODE_LABELS = {
-    "all-markup": t("markupView.allMarkup"),
-    "simple-markup": t("markupView.simple"),
-    "no-markup": t("markupView.noMarkup"),
-    original: t("markupView.original"),
-  } as const satisfies Record<DisplayMode, string>;
-
   const toolbarChildren = toolbarExtra ?? null;
   const visibleCommentAuthorCount = commentAuthors.filter((commentAuthor) =>
     visibleCommentAuthorSet.has(commentAuthor),
@@ -3220,12 +3231,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       <StSelect
         value={displayMode}
         onValueChange={(val) => setDisplayMode(val as DisplayMode)}
-        items={[
-          { value: "all-markup", label: "All Markup" },
-          { value: "simple-markup", label: "Simple" },
-          { value: "no-markup", label: "No Markup" },
-          { value: "original", label: "Original" },
-        ]}
+        items={displayModeItems}
       >
         <StSelectTrigger
           size="sm"
@@ -3235,9 +3241,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           <StSelectValue />
         </StSelectTrigger>
         <StSelectPopup>
-          {(["all-markup", "simple-markup", "no-markup", "original"] as const).map((mode) => (
-            <StSelectItem key={mode} value={mode}>
-              {DISPLAY_MODE_LABELS[mode]}
+          {displayModeItems.map((item) => (
+            <StSelectItem key={item.value} value={item.value}>
+              {item.label}
             </StSelectItem>
           ))}
         </StSelectPopup>

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2568,6 +2568,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       setFloatingCommentBtn,
       setIsAddingComment,
       setShowCommentsSidebar,
+      t,
     ],
   );
 

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -289,6 +289,12 @@ const DISPLAY_MODE_LABEL_KEYS = {
   original: "markupView.original",
 } as const satisfies Record<DisplayMode, string>;
 
+const preventMouseDownDefault = (event: React.MouseEvent) => event.preventDefault();
+
+function isDisplayMode(value: unknown): value is DisplayMode {
+  return typeof value === "string" && DISPLAY_MODES.some((mode) => mode === value);
+}
+
 // ============================================================================
 // MAIN COMPONENT
 // ============================================================================
@@ -3098,6 +3104,649 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [t],
   );
 
+  const toolbarChildren = toolbarExtra ?? null;
+  const visibleCommentAuthorCount = commentAuthors.filter((commentAuthor) =>
+    visibleCommentAuthorSet.has(commentAuthor),
+  ).length;
+  const allCommentAuthorsVisible =
+    commentAuthors.length > 0 &&
+    showCommentsSidebar &&
+    visibleCommentAuthorCount === commentAuthors.length;
+  const commentVisibilityLabel =
+    visibleCommentAuthorCount === commentAuthors.length
+      ? t("comments.showAll")
+      : `${visibleCommentAuthorCount}/${commentAuthors.length}`;
+
+  const showAllCommentAuthors = useCallback(() => {
+    setVisibleCommentAuthors(null);
+    setShowCommentsSidebar(true);
+  }, [setShowCommentsSidebar, setVisibleCommentAuthors]);
+  const hideAllCommentAuthors = useCallback(() => {
+    setVisibleCommentAuthors(new Set());
+    setShowCommentsSidebar(false);
+    setActiveCommentId(null);
+  }, [setActiveCommentId, setShowCommentsSidebar, setVisibleCommentAuthors]);
+  const setCommentAuthorVisible = useCallback(
+    (commentAuthor: string, visible: boolean) => {
+      const next = new Set(visibleCommentAuthorSet);
+      if (visible) {
+        next.add(commentAuthor);
+      } else {
+        next.delete(commentAuthor);
+      }
+      setVisibleCommentAuthors(next);
+      setShowCommentsSidebar(next.size > 0);
+      if (next.size === 0) {
+        setActiveCommentId(null);
+      }
+    },
+    [setActiveCommentId, setShowCommentsSidebar, setVisibleCommentAuthors, visibleCommentAuthorSet],
+  );
+  const handleAllCommentAuthorsCheckedChange = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        showAllCommentAuthors();
+        return;
+      }
+      hideAllCommentAuthors();
+    },
+    [hideAllCommentAuthors, showAllCommentAuthors],
+  );
+  const handleDisplayModeChange = useCallback(
+    (value: unknown) => {
+      if (isDisplayMode(value)) {
+        setDisplayMode(value);
+      }
+    },
+    [setDisplayMode],
+  );
+  const handleAcceptActiveChange = useCallback(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (!view) {
+      return;
+    }
+    const { from, to } = view.state.selection;
+    const range = findChangeAtPosition(view.state, from, to);
+    acceptChange(range.from, range.to)(view.state, view.dispatch);
+  }, []);
+  const handleRejectActiveChange = useCallback(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (!view) {
+      return;
+    }
+    const { from, to } = view.state.selection;
+    const range = findChangeAtPosition(view.state, from, to);
+    rejectChange(range.from, range.to)(view.state, view.dispatch);
+  }, []);
+  const handlePreviousChange = useCallback(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (!view) {
+      return;
+    }
+    const { from } = view.state.selection;
+    const change = findPreviousChange(view.state, from);
+    if (!change) {
+      return;
+    }
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.create(view.state.doc, change.from, change.to)),
+    );
+    view.focus();
+    requestAnimationFrame(() => {
+      pagedEditorRef.current?.scrollToPosition(change.from);
+    });
+  }, []);
+  const handleNextChange = useCallback(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (!view) {
+      return;
+    }
+    const { to } = view.state.selection;
+    const change = findNextChange(view.state, to);
+    if (!change) {
+      return;
+    }
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.create(view.state.doc, change.from, change.to)),
+    );
+    view.focus();
+    requestAnimationFrame(() => {
+      pagedEditorRef.current?.scrollToPosition(change.from);
+    });
+  }, []);
+  const handleOpenInsertSymbol = useCallback(() => setShowInsertSymbol(true), []);
+
+  const toolbarPriorityExtra = useMemo(() => {
+    if (!showReviewControls) {
+      return null;
+    }
+    return (
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          onClick={toggleTrackChanges}
+          onMouseDown={preventMouseDownDefault}
+          disabled={readOnly}
+          aria-pressed={trackChangesOn}
+          aria-label={t("toggleTrackChanges")}
+          className={`h-8 min-w-[140px] justify-start gap-1.5 rounded-md px-2 text-xs text-[var(--doc-text-muted)] shadow-none disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.35] ${
+            trackChangesOn
+              ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)] shadow-[0_0_0_1px_var(--doc-primary)]"
+              : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
+          }`}
+          size="xs"
+          title={t("toggleTrackChanges")}
+          variant="ghost"
+        >
+          <PenLineIcon className="size-3.5" />
+          <span className="truncate whitespace-nowrap">
+            {trackChangesOn ? t("trackingOn") : t("trackingOff")}
+          </span>
+        </Button>
+        <StSelect
+          value={displayMode}
+          onValueChange={handleDisplayModeChange}
+          items={displayModeItems}
+        >
+          <StSelectTrigger
+            size="sm"
+            className="h-8 min-h-0 w-[132px] min-w-0 shrink-0 border-transparent bg-transparent text-xs text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
+          >
+            <EyeIcon size={14} className="shrink-0" />
+            <StSelectValue />
+          </StSelectTrigger>
+          <StSelectPopup>
+            {displayModeItems.map((item) => (
+              <StSelectItem key={item.value} value={item.value}>
+                {item.label}
+              </StSelectItem>
+            ))}
+          </StSelectPopup>
+        </StSelect>
+      </div>
+    );
+  }, [
+    Button,
+    StSelect,
+    StSelectItem,
+    StSelectPopup,
+    StSelectTrigger,
+    StSelectValue,
+    displayMode,
+    displayModeItems,
+    handleDisplayModeChange,
+    readOnly,
+    showReviewControls,
+    t,
+    toggleTrackChanges,
+    trackChangesOn,
+  ]);
+
+  const toolbarInlineExtra = useMemo(
+    () => (
+      <>
+        <Menu>
+          <MenuTrigger
+            type="button"
+            disabled={comments.length === 0}
+            aria-label={t("comments.visibility")}
+            onMouseDown={preventMouseDownDefault}
+            className={`flex h-8 min-w-0 items-center gap-1.5 rounded-md border px-2.5 text-xs transition-colors duration-100 disabled:cursor-not-allowed disabled:border-transparent disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.16] disabled:hover:bg-transparent disabled:hover:text-[var(--doc-text-subtle)] ${
+              showCommentsSidebar && visibleCommentAuthorCount > 0
+                ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
+                : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
+            }`}
+          >
+            <StickyNoteIcon size={14} className="shrink-0" />
+            <span className="max-w-24 truncate">{commentVisibilityLabel}</span>
+          </MenuTrigger>
+          <MenuPopup align="start" className="min-w-52">
+            <MenuGroup>
+              <MenuGroupLabel>{t("comments.visibility")}</MenuGroupLabel>
+              <MenuCheckboxItem
+                checked={allCommentAuthorsVisible}
+                onCheckedChange={handleAllCommentAuthorsCheckedChange}
+              >
+                {t("comments.showAll")}
+              </MenuCheckboxItem>
+              <MenuItem onClick={hideAllCommentAuthors}>{t("comments.hideAll")}</MenuItem>
+            </MenuGroup>
+            {commentAuthors.length > 0 && (
+              <>
+                <MenuSeparator />
+                <MenuGroup>
+                  {commentAuthors.map((commentAuthor) => (
+                    <CommentAuthorVisibilityItem
+                      key={commentAuthor}
+                      author={commentAuthor}
+                      checked={showCommentsSidebar && visibleCommentAuthorSet.has(commentAuthor)}
+                      label={
+                        commentAuthor === "Unknown" ? t("comments.unknownAuthor") : commentAuthor
+                      }
+                      MenuCheckboxItem={MenuCheckboxItem}
+                      onVisibilityChange={setCommentAuthorVisible}
+                    />
+                  ))}
+                </MenuGroup>
+              </>
+            )}
+          </MenuPopup>
+        </Menu>
+        <ToolbarSeparator />
+        {state.activeTrackedChange && (
+          <span
+            className="flex items-center gap-1 px-2 text-xs text-[var(--doc-text-muted)]"
+            style={{ maxWidth: 260 }}
+          >
+            <span className="truncate">
+              <span className="font-medium text-[var(--doc-text)]">
+                {state.activeTrackedChange.author}
+              </span>
+              {state.activeTrackedChange.date && (
+                <>
+                  {" · "}
+                  {new Date(state.activeTrackedChange.date).toLocaleDateString()}
+                </>
+              )}
+              {" · "}
+              {state.activeTrackedChange.type === "insertion" ? t("inserted") : t("deleted")}
+            </span>
+          </span>
+        )}
+        <ToolbarButton
+          onClick={handleAcceptActiveChange}
+          disabled={readOnly || !state.activeTrackedChange}
+          title={t("acceptChange")}
+          ariaLabel={t("acceptChange")}
+        >
+          <CheckIcon size={16} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={handleRejectActiveChange}
+          disabled={readOnly || !state.activeTrackedChange}
+          title={t("rejectChange")}
+          ariaLabel={t("rejectChange")}
+        >
+          <XIcon size={16} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={handlePreviousChange}
+          disabled={readOnly}
+          title={t("previousChange")}
+          ariaLabel={t("previousChange")}
+        >
+          <ChevronLeftIcon size={16} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={handleNextChange}
+          disabled={readOnly}
+          title={t("nextChange")}
+          ariaLabel={t("nextChange")}
+        >
+          <ChevronRightIcon size={16} />
+        </ToolbarButton>
+      </>
+    ),
+    [
+      Menu,
+      MenuCheckboxItem,
+      MenuGroup,
+      MenuGroupLabel,
+      MenuItem,
+      MenuPopup,
+      MenuSeparator,
+      MenuTrigger,
+      allCommentAuthorsVisible,
+      commentAuthors,
+      commentVisibilityLabel,
+      comments.length,
+      handleAcceptActiveChange,
+      handleAllCommentAuthorsCheckedChange,
+      handleNextChange,
+      handlePreviousChange,
+      handleRejectActiveChange,
+      hideAllCommentAuthors,
+      readOnly,
+      setCommentAuthorVisible,
+      showCommentsSidebar,
+      state.activeTrackedChange,
+      t,
+      visibleCommentAuthorCount,
+      visibleCommentAuthorSet,
+    ],
+  );
+
+  const handleEditorScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      onScrollTopChange?.(event.currentTarget.scrollTop);
+      requestAnimationFrame(syncCommentHighlightStyles);
+    },
+    [onScrollTopChange, syncCommentHighlightStyles],
+  );
+  const handlePagedSelectionChange = useCallback(
+    (_from: number, _to: number) => {
+      // Extract full selection state from whichever PM is active. When the
+      // user is editing HF the persistent hidden HF view owns the selection;
+      // reading body PM here would leave the toolbar showing stale body state.
+      const view = getActiveEditorView() ?? pagedEditorRef.current?.getView() ?? null;
+      handleSelectionChange(view ? extractSelectionState(view.state) : null);
+    },
+    [getActiveEditorView, handleSelectionChange],
+  );
+  const handleTotalPagesChange = useCallback(
+    (totalPages: number) => {
+      setScrollPageInfo((previous) => updateScrollPageTotal(previous, totalPages));
+    },
+    [setScrollPageInfo],
+  );
+  const handleCommentClick = useCallback(
+    (id: number | null) => setActiveCommentId(id),
+    [setActiveCommentId],
+  );
+  const handleCommentResolve = useCallback(
+    (id: number) => {
+      updateComments((previous) =>
+        previous.map((comment) => (comment.id === id ? { ...comment, done: true } : comment)),
+      );
+    },
+    [updateComments],
+  );
+  const handleCommentDelete = useCallback(
+    (id: number) => {
+      updateComments((previous) =>
+        previous.filter((comment) => comment.id !== id && comment.parentId !== id),
+      );
+      if (activeCommentId === id) {
+        setActiveCommentId(null);
+      }
+    },
+    [activeCommentId, setActiveCommentId, updateComments],
+  );
+  const handleCommentReply = useCallback(
+    (id: number, text: string) => {
+      updateComments((previous) => [...previous, createComment(text, author, id)]);
+    },
+    [author, updateComments],
+  );
+  const handleAddComment = useCallback(
+    (addText: string) => {
+      const comment = createComment(addText, author);
+      const view = pagedEditorRef.current?.getView();
+      if (!view || !commentSelectionRange) {
+        return false;
+      }
+      const marked = applyCommentMarkRange(view, commentSelectionRange, comment.id, {
+        replacePending: true,
+      });
+      if (!marked) {
+        return false;
+      }
+      const commentAuthor = getCommentAuthorKey(comment.author);
+      setVisibleCommentAuthors((current) => {
+        if (current === null) {
+          return null;
+        }
+        const next = new Set(current);
+        next.add(commentAuthor);
+        return next;
+      });
+      setActiveCommentId(comment.id);
+      updateComments((previous) => [...previous, comment]);
+      pagedEditorRef.current?.relayout();
+      requestAnimationFrame(() => {
+        syncCommentHighlightStyles();
+        requestAnimationFrame(syncCommentHighlightStyles);
+      });
+      setIsAddingComment(false);
+      setCommentSelectionRange(null);
+      setAddCommentYPosition(null);
+      return true;
+    },
+    [
+      author,
+      commentSelectionRange,
+      setActiveCommentId,
+      setAddCommentYPosition,
+      setCommentSelectionRange,
+      setIsAddingComment,
+      setVisibleCommentAuthors,
+      syncCommentHighlightStyles,
+      updateComments,
+    ],
+  );
+  const handleTrackedChangeReply = useCallback(
+    (revisionId: number, text: string) => {
+      updateComments((previous) => [...previous, createComment(text, author, revisionId)]);
+    },
+    [author, updateComments],
+  );
+  const handleCancelAddComment = useCallback(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (view && commentSelectionRange) {
+      removePendingCommentMarkRange(view, commentSelectionRange);
+    }
+    setIsAddingComment(false);
+    setCommentSelectionRange(null);
+    setAddCommentYPosition(null);
+  }, [commentSelectionRange, setAddCommentYPosition, setCommentSelectionRange, setIsAddingComment]);
+  const handleSidebarAcceptChange = useCallback(
+    (from: number, to: number) => {
+      const view = pagedEditorRef.current?.getView();
+      if (!view) {
+        return;
+      }
+      acceptChange(from, to)(view.state, view.dispatch);
+      extractTrackedChanges();
+    },
+    [extractTrackedChanges],
+  );
+  const handleSidebarRejectChange = useCallback(
+    (from: number, to: number) => {
+      const view = pagedEditorRef.current?.getView();
+      if (!view) {
+        return;
+      }
+      rejectChange(from, to)(view.state, view.dispatch);
+      extractTrackedChanges();
+    },
+    [extractTrackedChanges],
+  );
+  const commentsPageWidth = history.state?.package.document.finalSectionProperties?.pageWidth;
+  const commentsSidebarOverlay = useMemo(() => {
+    if (!showCommentsSidebar) {
+      return undefined;
+    }
+    return (
+      <Suspense fallback={null}>
+        <CommentsSidebar
+          activeCommentId={activeCommentId}
+          comments={visibleComments}
+          anchorPositions={anchorPositions}
+          pageWidth={commentsPageWidth ? Math.round(commentsPageWidth / 15) : 816}
+          editorContainerRef={scrollContainerRef}
+          onCommentClick={handleCommentClick}
+          onCommentResolve={handleCommentResolve}
+          onCommentDelete={handleCommentDelete}
+          onCommentReply={handleCommentReply}
+          onAddComment={handleAddComment}
+          onTrackedChangeReply={handleTrackedChangeReply}
+          onCancelAddComment={handleCancelAddComment}
+          onAcceptChange={handleSidebarAcceptChange}
+          onRejectChange={handleSidebarRejectChange}
+          isAddingComment={isAddingComment}
+          addCommentYPosition={addCommentYPosition}
+          topOffset={0}
+        />
+      </Suspense>
+    );
+  }, [
+    activeCommentId,
+    addCommentYPosition,
+    anchorPositions,
+    commentsPageWidth,
+    handleAddComment,
+    handleCancelAddComment,
+    handleCommentClick,
+    handleCommentDelete,
+    handleCommentReply,
+    handleCommentResolve,
+    handleSidebarAcceptChange,
+    handleSidebarRejectChange,
+    handleTrackedChangeReply,
+    isAddingComment,
+    showCommentsSidebar,
+    visibleComments,
+  ]);
+  let activeHfRId = hfEditIsFirstPage ? activeFirstFooterRId : activeFooterRId;
+  if (hfEditPosition === "header") {
+    activeHfRId = hfEditIsFirstPage ? activeFirstHeaderRId : activeHeaderRId;
+  }
+  const getActiveHfView = useCallback(
+    () => (activeHfRId ? (pagedEditorRef.current?.getHfView(activeHfRId) ?? null) : null),
+    [activeHfRId],
+  );
+  const handleOutlineHeadingClick = useCallback((pmPos: number) => {
+    pagedEditorRef.current?.scrollToPosition(pmPos);
+    let attempts = 0;
+    const flash = () => {
+      attempts++;
+      const container = scrollContainerRef.current;
+      if (!container) {
+        return;
+      }
+      const element = container.querySelector<HTMLElement>(
+        `.layout-page-content [data-pm-start="${String(pmPos)}"]`,
+      );
+      if (element) {
+        delete element.dataset["folioOutlineFlash"];
+        void element.offsetWidth;
+        element.dataset["folioOutlineFlash"] = "";
+        return;
+      }
+      if (attempts < 30) {
+        requestAnimationFrame(flash);
+      }
+    };
+    requestAnimationFrame(flash);
+  }, []);
+  const handleTextContextAction = useCallback(
+    (action: TextContextAction) => {
+      void handleContextMenuAction(action);
+    },
+    [handleContextMenuAction],
+  );
+  const getBodyEditorView = useCallback(() => pagedEditorRef.current?.getView() ?? null, []);
+
+  const closeTableProperties = useCallback(() => setTablePropsOpen(false), []);
+  const applyTableProperties = useCallback(
+    (props: Parameters<typeof setTableProperties>[0]) => {
+      const view = getActiveEditorView();
+      if (view) {
+        setTableProperties(props)(view.state, view.dispatch);
+      }
+    },
+    [getActiveEditorView],
+  );
+  const closeImagePosition = useCallback(() => setImagePositionOpen(false), [setImagePositionOpen]);
+  const closeImageProperties = useCallback(() => setImagePropsOpen(false), [setImagePropsOpen]);
+  const closePageSetup = useCallback(() => setShowPageSetup(false), []);
+  const closeFootnoteProperties = useCallback(() => setFootnotePropsOpen(false), []);
+  const closeInsertSymbol = useCallback(() => setShowInsertSymbol(false), []);
+  const insertSymbol = useCallback(
+    (symbol: string) => {
+      const view = getActiveEditorView();
+      if (view) {
+        view.dispatch(view.state.tr.insertText(symbol).scrollIntoView());
+      }
+    },
+    [getActiveEditorView],
+  );
+  const imagePropertiesCurrentData = useMemo(
+    () => buildImagePropertiesData(state.pmImageContext),
+    [state.pmImageContext],
+  );
+  const currentFindResult = findResultRef.current;
+  const findReplaceDialog = useMemo(
+    () => ({
+      state: findReplace.state,
+      onClose: findReplace.close,
+      onFind: handleFind,
+      onFindNext: handleFindNext,
+      onFindPrevious: handleFindPrevious,
+      onReplace: handleReplace,
+      onReplaceAll: handleReplaceAll,
+      currentResult: currentFindResult,
+    }),
+    [
+      currentFindResult,
+      findReplace.close,
+      findReplace.state,
+      handleFind,
+      handleFindNext,
+      handleFindPrevious,
+      handleReplace,
+      handleReplaceAll,
+    ],
+  );
+  const tablePropertiesDialog = useMemo(
+    () => ({
+      isOpen: tablePropsOpen,
+      onClose: closeTableProperties,
+      onApply: applyTableProperties,
+      currentProps: state.pmTableContext?.table?.attrs as Record<string, unknown> | undefined,
+    }),
+    [applyTableProperties, closeTableProperties, state.pmTableContext, tablePropsOpen],
+  );
+  const imagePositionDialog = useMemo(
+    () => ({
+      isOpen: imagePositionOpen,
+      onClose: closeImagePosition,
+      onApply: handleApplyImagePosition,
+    }),
+    [closeImagePosition, handleApplyImagePosition, imagePositionOpen],
+  );
+  const imagePropertiesDialog = useMemo(
+    () => ({
+      isOpen: imagePropsOpen,
+      onClose: closeImageProperties,
+      onApply: handleApplyImageProperties,
+      currentData: imagePropertiesCurrentData,
+    }),
+    [closeImageProperties, handleApplyImageProperties, imagePropertiesCurrentData, imagePropsOpen],
+  );
+  const finalSectionProperties = history.state?.package.document.finalSectionProperties;
+  const pageSetupDialog = useMemo(
+    () => ({
+      isOpen: showPageSetup,
+      onClose: closePageSetup,
+      onApply: handlePageSetupApply,
+      currentProps: finalSectionProperties,
+    }),
+    [closePageSetup, finalSectionProperties, handlePageSetupApply, showPageSetup],
+  );
+  const footnotePropertiesDialog = useMemo(
+    () => ({
+      isOpen: footnotePropsOpen,
+      onClose: closeFootnoteProperties,
+      onApply: handleApplyFootnoteProperties,
+      footnotePr: finalSectionProperties?.footnotePr,
+      endnotePr: finalSectionProperties?.endnotePr,
+    }),
+    [
+      closeFootnoteProperties,
+      finalSectionProperties,
+      footnotePropsOpen,
+      handleApplyFootnoteProperties,
+    ],
+  );
+  const insertSymbolDialog = useMemo(
+    () => ({
+      isOpen: showInsertSymbol,
+      onClose: closeInsertSymbol,
+      onInsert: insertSymbol,
+    }),
+    [closeInsertSymbol, insertSymbol, showInsertSymbol],
+  );
+
   // Container styles - using overflow: auto so sticky toolbar works
   const containerStyle: CSSProperties = {
     display: "flex",
@@ -3172,257 +3821,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     );
   }
 
-  const toolbarChildren = toolbarExtra ?? null;
-  const visibleCommentAuthorCount = commentAuthors.filter((commentAuthor) =>
-    visibleCommentAuthorSet.has(commentAuthor),
-  ).length;
-  const allCommentAuthorsVisible =
-    commentAuthors.length > 0 &&
-    showCommentsSidebar &&
-    visibleCommentAuthorCount === commentAuthors.length;
-  const commentVisibilityLabel =
-    visibleCommentAuthorCount === commentAuthors.length
-      ? t("comments.showAll")
-      : `${visibleCommentAuthorCount}/${commentAuthors.length}`;
-  const showAllCommentAuthors = () => {
-    setVisibleCommentAuthors(null);
-    setShowCommentsSidebar(true);
-  };
-  const hideAllCommentAuthors = () => {
-    setVisibleCommentAuthors(new Set());
-    setShowCommentsSidebar(false);
-    setActiveCommentId(null);
-  };
-  const setCommentAuthorVisible = (commentAuthor: string, visible: boolean) => {
-    const next = new Set(visibleCommentAuthorSet);
-    if (visible) {
-      next.add(commentAuthor);
-    } else {
-      next.delete(commentAuthor);
-    }
-    setVisibleCommentAuthors(next);
-    setShowCommentsSidebar(next.size > 0);
-    if (next.size === 0) {
-      setActiveCommentId(null);
-    }
-  };
-
-  const toolbarPriorityExtra = !showReviewControls ? null : (
-    <div className="flex shrink-0 items-center gap-1">
-      <Button
-        onClick={toggleTrackChanges}
-        onMouseDown={(e) => e.preventDefault()}
-        disabled={readOnly}
-        aria-pressed={trackChangesOn}
-        aria-label={t("toggleTrackChanges")}
-        className={`h-8 min-w-[140px] justify-start gap-1.5 rounded-md px-2 text-xs text-[var(--doc-text-muted)] shadow-none disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.35] ${
-          trackChangesOn
-            ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)] shadow-[0_0_0_1px_var(--doc-primary)]"
-            : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
-        }`}
-        size="xs"
-        title={t("toggleTrackChanges")}
-        variant="ghost"
-      >
-        <PenLineIcon className="size-3.5" />
-        <span className="truncate whitespace-nowrap">
-          {trackChangesOn ? t("trackingOn") : t("trackingOff")}
-        </span>
-      </Button>
-      <StSelect
-        value={displayMode}
-        onValueChange={(val) => setDisplayMode(val as DisplayMode)}
-        items={displayModeItems}
-      >
-        <StSelectTrigger
-          size="sm"
-          className="h-8 min-h-0 w-[132px] min-w-0 shrink-0 border-transparent bg-transparent text-xs text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
-        >
-          <EyeIcon size={14} className="shrink-0" />
-          <StSelectValue />
-        </StSelectTrigger>
-        <StSelectPopup>
-          {displayModeItems.map((item) => (
-            <StSelectItem key={item.value} value={item.value}>
-              {item.label}
-            </StSelectItem>
-          ))}
-        </StSelectPopup>
-      </StSelect>
-    </div>
-  );
-
-  const toolbarInlineExtra = (
-    <>
-      <Menu>
-        <MenuTrigger
-          type="button"
-          disabled={comments.length === 0}
-          aria-label={t("comments.visibility")}
-          onMouseDown={(e) => e.preventDefault()}
-          className={`flex h-8 min-w-0 items-center gap-1.5 rounded-md border px-2.5 text-xs transition-colors duration-100 disabled:cursor-not-allowed disabled:border-transparent disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.16] disabled:hover:bg-transparent disabled:hover:text-[var(--doc-text-subtle)] ${
-            showCommentsSidebar && visibleCommentAuthorCount > 0
-              ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
-              : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
-          }`}
-        >
-          <StickyNoteIcon size={14} className="shrink-0" />
-          <span className="max-w-24 truncate">{commentVisibilityLabel}</span>
-        </MenuTrigger>
-        <MenuPopup align="start" className="min-w-52">
-          <MenuGroup>
-            <MenuGroupLabel>{t("comments.visibility")}</MenuGroupLabel>
-            <MenuCheckboxItem
-              checked={allCommentAuthorsVisible}
-              onCheckedChange={(checked) => {
-                if (checked) {
-                  showAllCommentAuthors();
-                } else {
-                  hideAllCommentAuthors();
-                }
-              }}
-            >
-              {t("comments.showAll")}
-            </MenuCheckboxItem>
-            <MenuItem onClick={hideAllCommentAuthors}>{t("comments.hideAll")}</MenuItem>
-          </MenuGroup>
-          {(() => {
-            if (commentAuthors.length > 0) {
-              return (
-                <>
-                  <MenuSeparator />
-                  <MenuGroup>
-                    {commentAuthors.map((commentAuthor) => (
-                      <MenuCheckboxItem
-                        checked={showCommentsSidebar && visibleCommentAuthorSet.has(commentAuthor)}
-                        key={commentAuthor}
-                        onCheckedChange={(checked) =>
-                          setCommentAuthorVisible(commentAuthor, checked)
-                        }
-                      >
-                        {commentAuthor === "Unknown" ? t("comments.unknownAuthor") : commentAuthor}
-                      </MenuCheckboxItem>
-                    ))}
-                  </MenuGroup>
-                </>
-              );
-            }
-            return null;
-          })()}
-        </MenuPopup>
-      </Menu>
-      <ToolbarSeparator />
-      {state.activeTrackedChange && (
-        <span
-          className="flex items-center gap-1 px-2 text-xs text-[var(--doc-text-muted)]"
-          style={{ maxWidth: 260 }}
-        >
-          <span className="truncate">
-            <span className="font-medium text-[var(--doc-text)]">
-              {state.activeTrackedChange.author}
-            </span>
-            {state.activeTrackedChange.date && (
-              <>
-                {" · "}
-                {new Date(state.activeTrackedChange.date).toLocaleDateString()}
-              </>
-            )}
-            {" · "}
-            {state.activeTrackedChange.type === "insertion" ? t("inserted") : t("deleted")}
-          </span>
-        </span>
-      )}
-      <ToolbarButton
-        onClick={() => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return;
-          }
-          const { from, to } = view.state.selection;
-          const range = findChangeAtPosition(view.state, from, to);
-          acceptChange(range.from, range.to)(view.state, view.dispatch);
-        }}
-        disabled={readOnly || !state.activeTrackedChange}
-        title={t("acceptChange")}
-        ariaLabel={t("acceptChange")}
-      >
-        <CheckIcon size={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return;
-          }
-          const { from, to } = view.state.selection;
-          const range = findChangeAtPosition(view.state, from, to);
-          rejectChange(range.from, range.to)(view.state, view.dispatch);
-        }}
-        disabled={readOnly || !state.activeTrackedChange}
-        title={t("rejectChange")}
-        ariaLabel={t("rejectChange")}
-      >
-        <XIcon size={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return;
-          }
-          const { from } = view.state.selection;
-          const change = findPreviousChange(view.state, from);
-          if (change) {
-            view.dispatch(
-              view.state.tr.setSelection(
-                TextSelection.create(view.state.doc, change.from, change.to),
-              ),
-            );
-            view.focus();
-            // Scroll the rendered page to the change position
-            requestAnimationFrame(() => {
-              pagedEditorRef.current?.scrollToPosition(change.from);
-            });
-          }
-        }}
-        disabled={readOnly}
-        title={t("previousChange")}
-        ariaLabel={t("previousChange")}
-      >
-        <ChevronLeftIcon size={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return;
-          }
-          const { to } = view.state.selection;
-          const change = findNextChange(view.state, to);
-          if (change) {
-            view.dispatch(
-              view.state.tr.setSelection(
-                TextSelection.create(view.state.doc, change.from, change.to),
-              ),
-            );
-            view.focus();
-            // Scroll the rendered page to the change position
-            requestAnimationFrame(() => {
-              pagedEditorRef.current?.scrollToPosition(change.from);
-            });
-          }
-        }}
-        disabled={readOnly}
-        title={t("nextChange")}
-        ariaLabel={t("nextChange")}
-      >
-        <ChevronRightIcon size={16} />
-      </ToolbarButton>
-    </>
-  );
-
-  const imagePropertiesCurrentData = buildImagePropertiesData(state.pmImageContext);
-
   return (
     <FolioUIProvider components={components}>
       <ErrorProvider>
@@ -3482,7 +3880,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                       showTableInsert={showTableInsert}
                       onInsertPageBreak={onInsertPageBreak}
                       onInsertTOC={onInsertTOC}
-                      onInsertSymbol={() => setShowInsertSymbol(true)}
+                      onInsertSymbol={handleOpenInsertSymbol}
                       priorityExtra={toolbarPriorityExtra}
                       inlineExtra={toolbarInlineExtra}
                       {...(history.state.package.styles?.styles
@@ -3503,10 +3901,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                   ref={scrollContainerRef}
                   style={editorContainerStyle}
                   data-folio-scroll=""
-                  onScroll={(event) => {
-                    onScrollTopChange?.(event.currentTarget.scrollTop);
-                    requestAnimationFrame(syncCommentHighlightStyles);
-                  }}
+                  onScroll={handleEditorScroll}
                 >
                   {/* Horizontal ruler — sticky-top, centered over the page so it
                       scrolls horizontally with the document. paddingRight biases
@@ -3632,24 +4027,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                         {...(onReadonlyEditAttempt !== undefined
                           ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
                           : {})}
-                        onSelectionChange={(_from, _to) => {
-                          // Extract full selection state from whichever PM
-                          // is active. When the user is editing HF the
-                          // hfEditorRef delegates to the persistent hidden
-                          // HF view via pagedEditorRef.getHfView(activeRId);
-                          // reading body PM here would leave the toolbar
-                          // (FormattingBar, table / image context) showing
-                          // stale body-selection state while its actions
-                          // target the HF view (post-eigenpal#611).
-                          const view =
-                            getActiveEditorView() ?? pagedEditorRef.current?.getView() ?? null;
-                          if (view) {
-                            const selectionState = extractSelectionState(view.state);
-                            handleSelectionChange(selectionState);
-                          } else {
-                            handleSelectionChange(null);
-                          }
-                        }}
+                        onSelectionChange={handlePagedSelectionChange}
                         {...(onSelectionTextChange !== undefined ? { onSelectionTextChange } : {})}
                         {...(onEditorViewReady !== undefined
                           ? { onEditorViewReady: reportEditorViewReady }
@@ -3667,133 +4045,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                         {...(showCommentsSidebar
                           ? { onAnchorPositionsChange: setAnchorPositions }
                           : {})}
-                        onTotalPagesChange={(totalPages) => {
-                          setScrollPageInfo((previous) =>
-                            updateScrollPageTotal(previous, totalPages),
-                          );
-                        }}
+                        onTotalPagesChange={handleTotalPagesChange}
                         scrollContainerRef={scrollContainerRef}
-                        sidebarOverlay={(() => {
-                          if (showCommentsSidebar) {
-                            return (
-                              <Suspense fallback={null}>
-                                <CommentsSidebar
-                                  activeCommentId={activeCommentId}
-                                  comments={visibleComments}
-                                  anchorPositions={anchorPositions}
-                                  pageWidth={(() => {
-                                    const sp =
-                                      history.state.package.document.finalSectionProperties;
-                                    return sp?.pageWidth ? Math.round(sp.pageWidth / 15) : 816;
-                                  })()}
-                                  editorContainerRef={scrollContainerRef}
-                                  onCommentClick={(id) => {
-                                    setActiveCommentId(id);
-                                  }}
-                                  onCommentResolve={(id) => {
-                                    updateComments((prev) =>
-                                      prev.map((c) =>
-                                        c.id === id
-                                          ? {
-                                              ...c,
-                                              done: true,
-                                            }
-                                          : c,
-                                      ),
-                                    );
-                                  }}
-                                  onCommentDelete={(id) => {
-                                    updateComments((prev) =>
-                                      prev.filter((c) => c.id !== id && c.parentId !== id),
-                                    );
-                                    if (activeCommentId === id) {
-                                      setActiveCommentId(null);
-                                    }
-                                  }}
-                                  onCommentReply={(id, text) => {
-                                    updateComments((prev) => [
-                                      ...prev,
-                                      createComment(text, author, id),
-                                    ]);
-                                  }}
-                                  onAddComment={(addText) => {
-                                    const comment = createComment(addText, author);
-                                    // Replace pending comment mark with the real comment ID
-                                    const view = pagedEditorRef.current?.getView();
-                                    if (!view || !commentSelectionRange) {
-                                      return false;
-                                    }
-                                    const marked = applyCommentMarkRange(
-                                      view,
-                                      commentSelectionRange,
-                                      comment.id,
-                                      {
-                                        replacePending: true,
-                                      },
-                                    );
-                                    if (!marked) {
-                                      return false;
-                                    }
-                                    const commentAuthor = getCommentAuthorKey(comment.author);
-                                    setVisibleCommentAuthors((current) => {
-                                      if (current === null) {
-                                        return null;
-                                      }
-                                      const next = new Set(current);
-                                      next.add(commentAuthor);
-                                      return next;
-                                    });
-                                    setActiveCommentId(comment.id);
-                                    updateComments((prev) => [...prev, comment]);
-                                    pagedEditorRef.current?.relayout();
-                                    requestAnimationFrame(() => {
-                                      syncCommentHighlightStyles();
-                                      requestAnimationFrame(syncCommentHighlightStyles);
-                                    });
-                                    setIsAddingComment(false);
-                                    setCommentSelectionRange(null);
-                                    setAddCommentYPosition(null);
-                                    return true;
-                                  }}
-                                  onTrackedChangeReply={(revisionId, text) => {
-                                    updateComments((prev) => [
-                                      ...prev,
-                                      createComment(text, author, revisionId),
-                                    ]);
-                                  }}
-                                  onCancelAddComment={() => {
-                                    // Remove pending comment highlight
-                                    const view = pagedEditorRef.current?.getView();
-                                    if (view && commentSelectionRange) {
-                                      removePendingCommentMarkRange(view, commentSelectionRange);
-                                    }
-                                    setIsAddingComment(false);
-                                    setCommentSelectionRange(null);
-                                    setAddCommentYPosition(null);
-                                  }}
-                                  onAcceptChange={(from, to) => {
-                                    const view = pagedEditorRef.current?.getView();
-                                    if (view) {
-                                      acceptChange(from, to)(view.state, view.dispatch);
-                                      extractTrackedChanges();
-                                    }
-                                  }}
-                                  onRejectChange={(from, to) => {
-                                    const view = pagedEditorRef.current?.getView();
-                                    if (view) {
-                                      rejectChange(from, to)(view.state, view.dispatch);
-                                      extractTrackedChanges();
-                                    }
-                                  }}
-                                  isAddingComment={isAddingComment}
-                                  addCommentYPosition={addCommentYPosition}
-                                  topOffset={0}
-                                />
-                              </Suspense>
-                            );
-                          }
-                          return undefined;
-                        })()}
+                        sidebarOverlay={commentsSidebarOverlay}
                       />
 
                       {/* Floating "add comment" button — appears on right edge of page at selection */}
@@ -3920,30 +4174,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                           if (!targetEl || !parentEl) {
                             return null;
                           }
-                          // Resolve the active HF rId for this edit session;
-                          // the chrome delegates getView/focus/undo/redo to the
-                          // persistent hidden HF EditorView mounted by
-                          // HiddenHeaderFooterPMs (post-eigenpal#611). The
-                          // inline overlay no longer mounts its own visible PM.
-                          const activeRId = (() => {
-                            if (hfEditIsFirstPage) {
-                              return hfEditPosition === "header"
-                                ? activeFirstHeaderRId
-                                : activeFirstFooterRId;
-                            }
-                            return hfEditPosition === "header" ? activeHeaderRId : activeFooterRId;
-                          })();
-                          const getActiveView = () =>
-                            activeRId
-                              ? (pagedEditorRef.current?.getHfView(activeRId) ?? null)
-                              : null;
                           return (
                             <InlineHeaderFooterEditor
                               ref={hfEditorRef}
                               position={hfEditPosition}
                               targetElement={targetEl}
                               parentElement={parentEl}
-                              getActiveView={getActiveView}
+                              getActiveView={getActiveHfView}
                               onClose={handleBodyClick}
                               onRemove={handleRemoveHeaderFooter}
                             />
@@ -3990,33 +4227,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                     scrollContainerRef={scrollContainerRef}
                     topOffset={toolbarHeight}
                     docSize={pagedEditorRef.current?.getView()?.state.doc.content.size ?? 0}
-                    onHeadingClick={(pmPos) => {
-                      pagedEditorRef.current?.scrollToPosition(pmPos);
-                      // Wait for the paged editor to mount the target paragraph
-                      // (smooth-scroll + virtualisation buffer warm-up), then
-                      // trigger the CSS flash animation.
-                      let attempts = 0;
-                      const flash = () => {
-                        attempts++;
-                        const container = scrollContainerRef.current;
-                        if (!container) {
-                          return;
-                        }
-                        const el = container.querySelector<HTMLElement>(
-                          `.layout-page-content [data-pm-start="${String(pmPos)}"]`,
-                        );
-                        if (el) {
-                          delete el.dataset["folioOutlineFlash"];
-                          void el.offsetWidth;
-                          el.dataset["folioOutlineFlash"] = "";
-                          return;
-                        }
-                        if (attempts < 30) {
-                          requestAnimationFrame(flash);
-                        }
-                      };
-                      requestAnimationFrame(flash);
-                    }}
+                    onHeadingClick={handleOutlineHeadingClick}
                   />
                 )}
               </div>
@@ -4043,80 +4254,26 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                   hasSelection={contextMenu.hasSelection}
                   isEditable={!readOnly}
                   items={contextMenuItems}
-                  onAction={(action) => {
-                    void handleContextMenuAction(action);
-                  }}
+                  onAction={handleTextContextAction}
                   onClose={handleContextMenuClose}
                 />
               </Suspense>
             )}
 
             {/* Dropdown / date pickers for content controls */}
-            <ContentControlWidgetsOverlay
-              getEditorView={() => pagedEditorRef.current?.getView() ?? null}
-            />
+            <ContentControlWidgetsOverlay getEditorView={getBodyEditorView} />
 
             {/* Toast notifications */}
             {/* Toast notifications provided by host app */}
 
             <DocxEditorDialogs
-              findReplace={{
-                state: findReplace.state,
-                onClose: findReplace.close,
-                onFind: handleFind,
-                onFindNext: handleFindNext,
-                onFindPrevious: handleFindPrevious,
-                onReplace: handleReplace,
-                onReplaceAll: handleReplaceAll,
-                currentResult: findResultRef.current,
-              }}
-              tableProperties={{
-                isOpen: tablePropsOpen,
-                onClose: () => setTablePropsOpen(false),
-                onApply: (props) => {
-                  const view = getActiveEditorView();
-                  if (view) {
-                    setTableProperties(props)(view.state, view.dispatch);
-                  }
-                },
-                currentProps: state.pmTableContext?.table?.attrs as
-                  | Record<string, unknown>
-                  | undefined,
-              }}
-              imagePosition={{
-                isOpen: imagePositionOpen,
-                onClose: () => setImagePositionOpen(false),
-                onApply: handleApplyImagePosition,
-              }}
-              imageProperties={{
-                isOpen: imagePropsOpen,
-                onClose: () => setImagePropsOpen(false),
-                onApply: handleApplyImageProperties,
-                currentData: imagePropertiesCurrentData,
-              }}
-              pageSetup={{
-                isOpen: showPageSetup,
-                onClose: () => setShowPageSetup(false),
-                onApply: handlePageSetupApply,
-                currentProps: history.state.package.document.finalSectionProperties,
-              }}
-              footnoteProperties={{
-                isOpen: footnotePropsOpen,
-                onClose: () => setFootnotePropsOpen(false),
-                onApply: handleApplyFootnoteProperties,
-                footnotePr: history.state.package.document.finalSectionProperties?.footnotePr,
-                endnotePr: history.state.package.document.finalSectionProperties?.endnotePr,
-              }}
-              insertSymbol={{
-                isOpen: showInsertSymbol,
-                onClose: () => setShowInsertSymbol(false),
-                onInsert: (symbol) => {
-                  const view = getActiveEditorView();
-                  if (view) {
-                    view.dispatch(view.state.tr.insertText(symbol).scrollIntoView());
-                  }
-                },
-              }}
+              findReplace={findReplaceDialog}
+              tableProperties={tablePropertiesDialog}
+              imagePosition={imagePositionDialog}
+              imageProperties={imagePropertiesDialog}
+              pageSetup={pageSetupDialog}
+              footnoteProperties={footnotePropertiesDialog}
+              insertSymbol={insertSymbolDialog}
             />
             {/* InlineHeaderFooterEditor is rendered inside the editor content area (position:relative div) */}
             {/* Hidden file input for image insertion */}
@@ -4133,6 +4290,35 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     </FolioUIProvider>
   );
 });
+
+type MenuCheckboxItemComponent = typeof DEFAULT_COMPONENTS.Menu.CheckboxItem;
+
+type CommentAuthorVisibilityItemProps = {
+  author: string;
+  checked: boolean;
+  label: string;
+  MenuCheckboxItem: MenuCheckboxItemComponent;
+  onVisibilityChange: (author: string, visible: boolean) => void;
+};
+
+function CommentAuthorVisibilityItem({
+  author,
+  checked,
+  label,
+  MenuCheckboxItem,
+  onVisibilityChange,
+}: CommentAuthorVisibilityItemProps) {
+  const handleCheckedChange = useCallback(
+    (visible: boolean) => onVisibilityChange(author, visible),
+    [author, onVisibilityChange],
+  );
+
+  return (
+    <MenuCheckboxItem checked={checked} onCheckedChange={handleCheckedChange}>
+      {label}
+    </MenuCheckboxItem>
+  );
+}
 
 // ============================================================================
 // EXPORTS

--- a/packages/react/src/components/ErrorBoundary.tsx
+++ b/packages/react/src/components/ErrorBoundary.tsx
@@ -184,7 +184,7 @@ function NotificationContainer({ notifications, onDismiss }: NotificationContain
         <NotificationToast
           key={notification.id}
           notification={notification}
-          onDismiss={() => onDismiss(notification.id)}
+          onDismiss={onDismiss}
         />
       ))}
     </div>
@@ -209,13 +209,14 @@ const SEVERITY_ICONS = {
 
 type NotificationToastProps = {
   notification: ErrorNotification;
-  onDismiss: () => void;
+  onDismiss: (id: string) => void;
 };
 
 function NotificationToast({ notification, onDismiss }: NotificationToastProps) {
   const t = useTranslations("folio");
   const [isExpanded, setIsExpanded] = useState(false);
   const SeverityIcon = SEVERITY_ICONS[notification.severity];
+  const handleDismiss = useCallback(() => onDismiss(notification.id), [notification.id, onDismiss]);
 
   return (
     <div
@@ -247,7 +248,7 @@ function NotificationToast({ notification, onDismiss }: NotificationToastProps) 
         </div>
         <button
           type="button"
-          onClick={onDismiss}
+          onClick={handleDismiss}
           className="shrink-0 cursor-pointer rounded p-1 opacity-60 hover:opacity-100"
           title={t("dismiss")}
         >

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -168,6 +168,9 @@ export function FormattingBar(props: FormattingBarProps) {
     },
     [disabled, onFormat],
   );
+  const handleBold = useCallback(() => handleFormat("bold"), [handleFormat]);
+  const handleItalic = useCallback(() => handleFormat("italic"), [handleFormat]);
+  const handleUnderline = useCallback(() => handleFormat("underline"), [handleFormat]);
 
   const handleUndo = useCallback(() => {
     if (!disabled && canUndo && onUndo) {
@@ -540,6 +543,19 @@ export function FormattingBar(props: FormattingBarProps) {
     requestAnimationFrame(() => onRefocusEditor?.());
   }, [onRefocusEditor]);
 
+  const moreFormattingLabel = t("moreFormatting");
+  const overflowTrigger = useMemo(
+    () => (
+      <button
+        type="button"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--doc-text-muted)] transition-colors duration-100 hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
+        aria-label={moreFormattingLabel}
+        title={moreFormattingLabel}
+      />
+    ),
+    [moreFormattingLabel],
+  );
+
   const secondaryControls = (
     <>
       <ToolbarGroup label={t("fontGroup")}>
@@ -715,7 +731,7 @@ export function FormattingBar(props: FormattingBarProps) {
           {/* Bold, Italic, Underline */}
           <ToolbarGroup label={t("textFormattingGroup")}>
             <ToolbarButton
-              onClick={() => handleFormat("bold")}
+              onClick={handleBold}
               active={currentFormatting.bold}
               disabled={disabled}
               title={t("boldShortcut")}
@@ -724,7 +740,7 @@ export function FormattingBar(props: FormattingBarProps) {
               <BoldIcon size={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
-              onClick={() => handleFormat("italic")}
+              onClick={handleItalic}
               active={currentFormatting.italic}
               disabled={disabled}
               title={t("italicShortcut")}
@@ -733,7 +749,7 @@ export function FormattingBar(props: FormattingBarProps) {
               <ItalicIcon size={ICON_SIZE} />
             </ToolbarButton>
             <ToolbarButton
-              onClick={() => handleFormat("underline")}
+              onClick={handleUnderline}
               active={currentFormatting.underline}
               disabled={disabled}
               title={t("underlineShortcut")}
@@ -834,16 +850,7 @@ export function FormattingBar(props: FormattingBarProps) {
         <>
           <ToolbarSeparator />
           <Menu>
-            <MenuTrigger
-              render={
-                <button
-                  type="button"
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--doc-text-muted)] transition-colors duration-100 hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
-                  aria-label={t("moreFormatting")}
-                  title={t("moreFormatting")}
-                />
-              }
-            >
+            <MenuTrigger render={overflowTrigger}>
               <MoreHorizontalIcon size={ICON_SIZE} />
             </MenuTrigger>
             <MenuPopup align="end" className="max-w-[min(520px,calc(100vw-24px))]">

--- a/packages/react/src/components/TextContextMenu.tsx
+++ b/packages/react/src/components/TextContextMenu.tsx
@@ -238,17 +238,26 @@ function itemIconColor(item: TextContextMenuItem): string {
 
 type MenuItemComponentProps = {
   item: TextContextMenuItem;
-  onClick: () => void;
   isHighlighted: boolean;
-  onMouseEnter: () => void;
+  navigableIndex: number;
+  onItemClick: (item: TextContextMenuItem) => void;
+  onItemEnter: (index: number) => void;
 };
 
 const MenuItemComponent: React.FC<MenuItemComponentProps> = ({
   item,
-  onClick,
   isHighlighted,
-  onMouseEnter,
+  navigableIndex,
+  onItemClick,
+  onItemEnter,
 }) => {
+  const handleClick = useCallback(() => onItemClick(item), [item, onItemClick]);
+  const handleMouseEnter = useCallback(() => {
+    if (navigableIndex !== -1 && !item.disabled) {
+      onItemEnter(navigableIndex);
+    }
+  }, [item.disabled, navigableIndex, onItemEnter]);
+
   if (item.action === "separator") {
     return (
       <div
@@ -267,8 +276,8 @@ const MenuItemComponent: React.FC<MenuItemComponentProps> = ({
       <button
         type="button"
         className={`docx-text-context-menu-item ${isHighlighted ? "docx-text-context-menu-item-highlighted" : ""} ${item.disabled ? "docx-text-context-menu-item-disabled" : ""}`}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
         disabled={item.disabled}
         role="menuitem"
         aria-disabled={item.disabled}
@@ -519,13 +528,16 @@ export const TextContextMenu: React.FC<TextContextMenuProps> = ({
     } satisfies React.CSSProperties;
   }, [hasSelection, position, menuItems.length]);
 
-  const handleItemClick = (item: TextContextMenuItem) => {
-    if (item.disabled) {
-      return;
-    }
-    onAction(item.action);
-    onClose();
-  };
+  const handleItemClick = useCallback(
+    (item: TextContextMenuItem) => {
+      if (item.disabled) {
+        return;
+      }
+      onAction(item.action);
+      onClose();
+    },
+    [onAction, onClose],
+  );
 
   if (!isOpen) {
     return null;
@@ -547,13 +559,10 @@ export const TextContextMenu: React.FC<TextContextMenuProps> = ({
           <MenuItemComponent
             key={`${item.action}-${index}`}
             item={item}
-            onClick={() => handleItemClick(item)}
             isHighlighted={navigableIndex === highlightedIndex}
-            onMouseEnter={() => {
-              if (navigableIndex !== -1 && !item.disabled) {
-                setHighlightedIndex(navigableIndex);
-              }
-            }}
+            navigableIndex={navigableIndex}
+            onItemClick={handleItemClick}
+            onItemEnter={setHighlightedIndex}
           />
         );
       })}

--- a/packages/react/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/react/src/components/dialogs/FindReplaceDialog.tsx
@@ -283,6 +283,12 @@ export function FindReplaceDialog({
     [searchText, result, performSearch, handleFindPrevious, handleFindNext, onClose],
   );
 
+  const handleSearchBlur = useCallback(() => {
+    if (searchText.trim() && !result) {
+      performSearch();
+    }
+  }, [performSearch, result, searchText]);
+
   const handleOverlayClick = useCallback((e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
       // Don't close on overlay click - this is a non-modal dialog
@@ -355,11 +361,7 @@ export function FindReplaceDialog({
               value={searchText}
               onChange={handleSearchChange}
               onKeyDown={handleSearchKeyDown}
-              onBlur={() => {
-                if (searchText.trim() && !result) {
-                  performSearch();
-                }
-              }}
+              onBlur={handleSearchBlur}
               placeholder={t("findReplace.findPlaceholder")}
               aria-label={t("findReplace.findText")}
             />

--- a/packages/react/src/components/dialogs/FootnotePropertiesDialog.tsx
+++ b/packages/react/src/components/dialogs/FootnotePropertiesDialog.tsx
@@ -15,6 +15,7 @@ import type {
   NumberFormat,
 } from "@stll/folio-core/types/document";
 import { useFolioUI } from "../../ui/folio-ui";
+import { useCloseOnDialogOpenChange } from "./dialogChrome";
 
 // ============================================================================
 // TYPES
@@ -60,6 +61,7 @@ export function FootnotePropertiesDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [fnPosition, setFnPosition] = useState<FootnotePosition>(
     footnotePr?.position ?? "pageBottom",
@@ -113,14 +115,7 @@ export function FootnotePropertiesDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className="fixed inset-0 z-[10000] bg-black/50" />
         <DialogPopup className="bg-popover fixed start-1/2 top-1/2 z-[10001] w-full max-w-[500px] min-w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-lg border shadow-xl">

--- a/packages/react/src/components/dialogs/HyperlinkDialog.tsx
+++ b/packages/react/src/components/dialogs/HyperlinkDialog.tsx
@@ -11,6 +11,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type HyperlinkBookmarkOption = {
@@ -53,6 +54,7 @@ export function HyperlinkDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [targetType, setTargetType] = useState<HyperlinkTargetType>("url");
   const [url, setUrl] = useState("");
@@ -114,14 +116,7 @@ export function HyperlinkDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/ImagePositionDialog.tsx
+++ b/packages/react/src/components/dialogs/ImagePositionDialog.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useId, useState } from "react";
 
 import { useFolioUI } from "../../ui/folio-ui";
+import { useCloseOnDialogOpenChange } from "./dialogChrome";
 
 // ============================================================================
 // TYPES
@@ -57,6 +58,7 @@ export function ImagePositionDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [hMode, setHMode] = useState<"align" | "offset">("align");
   const [hAlign, setHAlign] = useState("center");
@@ -146,14 +148,7 @@ export function ImagePositionDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className="fixed inset-0 z-[10000] bg-black/50" />
         <DialogPopup className="bg-popover fixed start-1/2 top-1/2 z-[10001] w-full max-w-[480px] min-w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-lg border shadow-xl">

--- a/packages/react/src/components/dialogs/ImagePropertiesDialog.tsx
+++ b/packages/react/src/components/dialogs/ImagePropertiesDialog.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useId, useState } from "react";
 
 import { useFolioUI } from "../../ui/folio-ui";
+import { useCloseOnDialogOpenChange } from "./dialogChrome";
 
 // ============================================================================
 // TYPES
@@ -46,6 +47,7 @@ export function ImagePropertiesDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [alt, setAlt] = useState("");
   const [borderWidth, setBorderWidth] = useState(0);
@@ -81,14 +83,7 @@ export function ImagePropertiesDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className="fixed inset-0 z-[10000] bg-black/50" />
         <DialogPopup className="bg-popover fixed start-1/2 top-1/2 z-[10001] w-full max-w-[440px] min-w-[380px] -translate-x-1/2 -translate-y-1/2 rounded-lg border shadow-xl">

--- a/packages/react/src/components/dialogs/InsertImageDialog.tsx
+++ b/packages/react/src/components/dialogs/InsertImageDialog.tsx
@@ -11,6 +11,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type InsertImageDialogData = {
@@ -41,6 +42,7 @@ export function InsertImageDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [file, setFile] = useState<File | null>(null);
   const [alt, setAlt] = useState("");
@@ -80,14 +82,7 @@ export function InsertImageDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/InsertSymbolDialog.tsx
+++ b/packages/react/src/components/dialogs/InsertSymbolDialog.tsx
@@ -13,6 +13,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type InsertSymbolDialogProps = {
@@ -36,6 +37,7 @@ export function InsertSymbolDialog({ isOpen, onClose, onInsert }: InsertSymbolDi
     Popup: DialogPopup,
     Title: DialogTitle,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const t = useTranslations("folio");
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState("Common");
@@ -59,14 +61,7 @@ export function InsertSymbolDialog({ isOpen, onClose, onInsert }: InsertSymbolDi
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/InsertTableDialog.tsx
+++ b/packages/react/src/components/dialogs/InsertTableDialog.tsx
@@ -11,6 +11,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type InsertTableDialogData = {
@@ -62,6 +63,7 @@ export function InsertTableDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [rows, setRows] = useState(defaultRows);
   const [columns, setColumns] = useState(defaultColumns);
@@ -106,14 +108,7 @@ export function InsertTableDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/PageSetupDialog.tsx
+++ b/packages/react/src/components/dialogs/PageSetupDialog.tsx
@@ -12,6 +12,7 @@ import { useEffect, useId, useState } from "react";
 import type { SectionProperties } from "@stll/folio-core/types/document";
 import { TWIPS_PER_INCH } from "@stll/folio-core/utils/units";
 import { useFolioUI } from "../../ui/folio-ui";
+import { useCloseOnDialogOpenChange } from "./dialogChrome";
 
 /** Common page sizes in twips (width x height in portrait orientation) */
 const PAGE_SIZES = [
@@ -73,6 +74,7 @@ export function PageSetupDialog({ isOpen, onClose, onApply, currentProps }: Page
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [pageWidth, setPageWidth] = useState(DEFAULT_WIDTH);
   const [pageHeight, setPageHeight] = useState(DEFAULT_HEIGHT);
@@ -154,14 +156,7 @@ export function PageSetupDialog({ isOpen, onClose, onApply, currentProps }: Page
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className="fixed inset-0 z-[10000] bg-black/50" />
         <DialogPopup className="bg-popover fixed start-1/2 top-1/2 z-[10001] w-full max-w-[480px] min-w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-lg border shadow-xl">

--- a/packages/react/src/components/dialogs/PasteSpecialDialog.tsx
+++ b/packages/react/src/components/dialogs/PasteSpecialDialog.tsx
@@ -10,6 +10,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type PasteSpecialMode = "keepFormatting" | "mergeFormatting" | "plainText";
@@ -53,6 +54,7 @@ export function PasteSpecialDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [mode, setMode] = useState<PasteSpecialMode>(defaultMode);
 
@@ -68,14 +70,7 @@ export function PasteSpecialDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/SplitCellDialog.tsx
+++ b/packages/react/src/components/dialogs/SplitCellDialog.tsx
@@ -11,6 +11,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type SplitCellDialogData = {
@@ -45,6 +46,7 @@ export function SplitCellDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [rows, setRows] = useState(defaultRows);
   const [columns, setColumns] = useState(defaultColumns);
@@ -77,14 +79,7 @@ export function SplitCellDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/TablePropertiesDialog.tsx
+++ b/packages/react/src/components/dialogs/TablePropertiesDialog.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useId, useState } from "react";
 
 import { useFolioUI } from "../../ui/folio-ui";
+import { useCloseOnDialogOpenChange } from "./dialogChrome";
 
 export type TableProperties = {
   width?: number | null;
@@ -37,6 +38,7 @@ export function TablePropertiesDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [width, setWidth] = useState(currentProps?.width ?? 0);
   const [widthType, setWidthType] = useState(currentProps?.widthType ?? "auto");
@@ -79,14 +81,7 @@ export function TablePropertiesDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className="fixed inset-0 z-[10000] bg-black/50" />
         <DialogPopup className="bg-popover fixed start-1/2 top-1/2 z-[10001] w-full max-w-[440px] min-w-[360px] -translate-x-1/2 -translate-y-1/2 rounded-lg border shadow-xl">

--- a/packages/react/src/components/dialogs/WatermarkDialog.tsx
+++ b/packages/react/src/components/dialogs/WatermarkDialog.tsx
@@ -12,6 +12,7 @@ import {
   DIALOG_PRIMARY_BUTTON_CLASS,
   DIALOG_SECONDARY_BUTTON_CLASS,
   DIALOG_TITLE_CLASS,
+  useCloseOnDialogOpenChange,
 } from "./dialogChrome";
 
 export type WatermarkDialogProps = {
@@ -39,6 +40,7 @@ export function WatermarkDialog({
     Title: DialogTitle,
     Close: DialogClose,
   } = useFolioUI().Dialog;
+  const handleOpenChange = useCloseOnDialogOpenChange(onClose);
   const id = useId();
   const [mode, setMode] = useState<WatermarkMode>("text");
   const [text, setText] = useState("CONFIDENTIAL");
@@ -138,14 +140,7 @@ export function WatermarkDialog({
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogBackdrop className={DIALOG_BACKDROP_CLASS} />
         <DialogPopup className={DIALOG_POPUP_CLASS}>

--- a/packages/react/src/components/dialogs/dialogChrome.ts
+++ b/packages/react/src/components/dialogs/dialogChrome.ts
@@ -1,3 +1,16 @@
+import { useCallback } from "react";
+
+export function useCloseOnDialogOpenChange(onClose: () => void) {
+  return useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+}
+
 export const DIALOG_BACKDROP_CLASS = "fixed inset-0 z-[10000] bg-black/50";
 
 export const DIALOG_POPUP_CLASS =

--- a/packages/react/src/components/ui/AlignmentButtons.tsx
+++ b/packages/react/src/components/ui/AlignmentButtons.tsx
@@ -3,7 +3,8 @@
  * with left/center/right/justify options.
  */
 
-import type { CSSProperties } from "react";
+import { useCallback, useMemo } from "react";
+import type { CSSProperties, MouseEvent } from "react";
 
 import { panic } from "better-result";
 import {
@@ -27,6 +28,8 @@ export type AlignmentButtonsProps = {
 };
 
 const ICON_SIZE = 16;
+
+const stopMouseDownPropagation = (event: MouseEvent) => event.stopPropagation();
 
 const OPTIONS = [
   {
@@ -91,31 +94,57 @@ export function AlignmentButtons({
         side="bottom"
         sideOffset={4}
         className="flex gap-0.5 p-1"
-        onMouseDown={(e) => e.stopPropagation()}
+        onMouseDown={stopMouseDownPropagation}
       >
         {OPTIONS.map((opt) => (
-          <PopoverClose
+          <AlignmentOption
             key={opt.value}
-            render={
-              <button
-                className={cn(
-                  "flex size-8 items-center justify-center rounded transition-colors",
-                  value === opt.value
-                    ? "bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
-                    : "text-[var(--doc-text)] hover:bg-[var(--doc-primary-light)]",
-                )}
-                data-testid={`alignment-${opt.value}`}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onChange?.(opt.value)}
-                title={`${opt.label} (${opt.shortcut})`}
-                type="button"
-              />
-            }
-          >
-            <opt.Icon size={ICON_SIZE} />
-          </PopoverClose>
+            PopoverClose={PopoverClose}
+            option={opt}
+            selected={value === opt.value}
+            onChange={onChange}
+          />
         ))}
       </PopoverPopup>
     </Popover>
+  );
+}
+
+type AlignmentOptionValue = (typeof OPTIONS)[number];
+type PopoverCloseComponent = ReturnType<typeof useFolioUI>["Popover"]["Close"];
+
+type AlignmentOptionProps = {
+  PopoverClose: PopoverCloseComponent;
+  option: AlignmentOptionValue;
+  selected: boolean;
+  onChange: AlignmentButtonsProps["onChange"];
+};
+
+function AlignmentOption({ PopoverClose, option, selected, onChange }: AlignmentOptionProps) {
+  const handleMouseDown = useCallback((event: MouseEvent) => event.preventDefault(), []);
+  const handleClick = useCallback(() => onChange?.(option.value), [onChange, option.value]);
+  const trigger = useMemo(
+    () => (
+      <button
+        className={cn(
+          "flex size-8 items-center justify-center rounded transition-colors",
+          selected
+            ? "bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
+            : "text-[var(--doc-text)] hover:bg-[var(--doc-primary-light)]",
+        )}
+        data-testid={`alignment-${option.value}`}
+        onMouseDown={handleMouseDown}
+        onClick={handleClick}
+        title={`${option.label} (${option.shortcut})`}
+        type="button"
+      />
+    ),
+    [handleClick, handleMouseDown, option.label, option.shortcut, option.value, selected],
+  );
+
+  return (
+    <PopoverClose render={trigger}>
+      <option.Icon size={ICON_SIZE} />
+    </PopoverClose>
   );
 }

--- a/packages/react/src/components/ui/FontPicker.tsx
+++ b/packages/react/src/components/ui/FontPicker.tsx
@@ -3,6 +3,8 @@
  * Each item rendered in its own font for preview.
  */
 
+import { useCallback, useMemo } from "react";
+
 import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
@@ -110,25 +112,33 @@ export function FontPicker({
     Item: SelectItem,
   } = useFolioUI().Select;
   const fontOptions = fonts ?? DEFAULT_FONTS;
+  const handleValueChange = useCallback(
+    (name: string | null) => {
+      const font = fontOptions.find((option) => option.name === name);
+      if (font) {
+        onChange?.(font.name);
+      }
+    },
+    [fontOptions, onChange],
+  );
+  const triggerStyle = useMemo(
+    () => ({
+      width: typeof width === "number" ? `${width}px` : width,
+      height: 28,
+    }),
+    [width],
+  );
 
   return (
     <Select
       value={value ? toDisplayName(value, fontOptions) : undefined}
-      onValueChange={(name) => {
-        const font = fontOptions.find((f) => f.name === name);
-        if (font) {
-          onChange?.(font.name);
-        }
-      }}
+      onValueChange={handleValueChange}
       disabled={disabled}
     >
       <SelectTrigger
         size="sm"
         className="min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
-        style={{
-          width: typeof width === "number" ? `${width}px` : width,
-          height: 28,
-        }}
+        style={triggerStyle}
       >
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/packages/react/src/components/ui/FontSizePicker.tsx
+++ b/packages/react/src/components/ui/FontSizePicker.tsx
@@ -3,6 +3,8 @@
  * Values are points; internally the editor stores half-points (OOXML w:sz).
  */
 
+import { useCallback, useMemo } from "react";
+
 import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
@@ -58,30 +60,34 @@ export function FontSizePicker({
   } = useFolioUI().Select;
   const sizeOptions = sizes ?? Array.from(DEFAULT_SIZES);
   const selectedLabel = value === undefined ? undefined : formatSize(value);
+  const handleValueChange = useCallback(
+    (label: string | null) => {
+      if (typeof label !== "string") {
+        return;
+      }
+      const parsed = Number.parseFloat(label);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return;
+      }
+      onChange?.(parsed);
+    },
+    [onChange],
+  );
+  const triggerStyle = useMemo(
+    () => ({
+      width: typeof width === "number" ? `${width}px` : width,
+      height: 28,
+    }),
+    [width],
+  );
 
   return (
-    <Select
-      value={selectedLabel}
-      onValueChange={(label) => {
-        if (typeof label !== "string") {
-          return;
-        }
-        const parsed = Number.parseFloat(label);
-        if (!Number.isFinite(parsed) || parsed <= 0) {
-          return;
-        }
-        onChange?.(parsed);
-      }}
-      disabled={disabled}
-    >
+    <Select value={selectedLabel} onValueChange={handleValueChange} disabled={disabled}>
       <SelectTrigger
         aria-label={ariaLabel}
         size="sm"
         className="min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] tabular-nums shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
-        style={{
-          width: typeof width === "number" ? `${width}px` : width,
-          height: 28,
-        }}
+        style={triggerStyle}
       >
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -299,9 +299,9 @@ export function HorizontalRuler({
           editable={editable}
           isDragging={dragging === "firstLineIndent"}
           isHovered={hoveredMarker === "firstLineIndent"}
-          onMouseEnter={() => setHoveredMarker("firstLineIndent")}
-          onMouseLeave={() => setHoveredMarker(null)}
-          onMouseDown={(e) => handleDragStart(e, "firstLineIndent")}
+          marker="firstLineIndent"
+          onDragStart={handleDragStart}
+          onHoverChange={setHoveredMarker}
           label={t("ruler.firstLineIndent")}
         />
       )}
@@ -314,9 +314,9 @@ export function HorizontalRuler({
           editable={editable}
           isDragging={dragging === "leftIndent"}
           isHovered={hoveredMarker === "leftIndent"}
-          onMouseEnter={() => setHoveredMarker("leftIndent")}
-          onMouseLeave={() => setHoveredMarker(null)}
-          onMouseDown={(e) => handleDragStart(e, "leftIndent")}
+          marker="leftIndent"
+          onDragStart={handleDragStart}
+          onHoverChange={setHoveredMarker}
           label={t("ruler.leftIndent")}
         />
       )}
@@ -329,9 +329,9 @@ export function HorizontalRuler({
           editable={editable}
           isDragging={dragging === "rightIndent"}
           isHovered={hoveredMarker === "rightIndent"}
-          onMouseEnter={() => setHoveredMarker("rightIndent")}
-          onMouseLeave={() => setHoveredMarker(null)}
-          onMouseDown={(e) => handleDragStart(e, "rightIndent")}
+          marker="rightIndent"
+          onDragStart={handleDragStart}
+          onHoverChange={setHoveredMarker}
           label={t("ruler.rightIndent")}
         />
       )}
@@ -344,7 +344,7 @@ export function HorizontalRuler({
           key={tab.position}
           tabStop={tab}
           positionPx={twipsToPixels(leftMarginTwips + tab.position) * zoom}
-          onDoubleClick={() => onTabStopRemove?.(tab.position)}
+          onRemove={onTabStopRemove}
         />
       ))}
 
@@ -410,9 +410,9 @@ type IndentTriangleProps = {
   editable: boolean;
   isDragging: boolean;
   isHovered: boolean;
-  onMouseEnter: () => void;
-  onMouseLeave: () => void;
-  onMouseDown: (e: React.MouseEvent) => void;
+  marker: MarkerType;
+  onDragStart: (event: React.MouseEvent, marker: MarkerType) => void;
+  onHoverChange: (marker: MarkerType | null) => void;
   label: string;
 };
 
@@ -422,13 +422,19 @@ function IndentTriangle({
   editable,
   isDragging,
   isHovered,
-  onMouseEnter,
-  onMouseLeave,
-  onMouseDown,
+  marker,
+  onDragStart,
+  onHoverChange,
   label,
 }: IndentTriangleProps): React.ReactElement {
   const color = resolveIndentColor(isDragging, isHovered);
   const triHeight = Math.round(TRI_SIZE * 1.6);
+  const handleMouseEnter = useCallback(() => onHoverChange(marker), [marker, onHoverChange]);
+  const handleMouseLeave = useCallback(() => onHoverChange(null), [onHoverChange]);
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => onDragStart(event, marker),
+    [marker, onDragStart],
+  );
 
   const containerStyle: CSSProperties = {
     position: "absolute",
@@ -469,9 +475,9 @@ function IndentTriangle({
     <div
       className="docx-ruler-indent"
       style={containerStyle}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      onMouseDown={onMouseDown}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onMouseDown={handleMouseDown}
       role="slider"
       aria-label={label}
       aria-orientation="horizontal"
@@ -515,7 +521,7 @@ function DragTooltip({
 type TabStopMarkerProps = {
   tabStop: TabStop;
   positionPx: number;
-  onDoubleClick: () => void;
+  onRemove?: ((positionTwips: number) => void) | undefined;
 };
 
 const TAB_SYMBOLS: Record<string, string> = {
@@ -526,11 +532,15 @@ const TAB_SYMBOLS: Record<string, string> = {
   bar: "|",
 };
 
-function TabStopMarker({
-  tabStop,
-  positionPx,
-  onDoubleClick,
-}: TabStopMarkerProps): React.ReactElement {
+function TabStopMarker({ tabStop, positionPx, onRemove }: TabStopMarkerProps): React.ReactElement {
+  const handleDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      onRemove?.(tabStop.position);
+    },
+    [onRemove, tabStop.position],
+  );
+
   return (
     <div
       style={{
@@ -548,10 +558,7 @@ function TabStopMarker({
         cursor: "pointer",
         userSelect: "none",
       }}
-      onDoubleClick={(e) => {
-        e.stopPropagation();
-        onDoubleClick();
-      }}
+      onDoubleClick={handleDoubleClick}
       title={`${tabStop.alignment} tab at ${(tabStop.position / 1440).toFixed(2)}"`}
     >
       {TAB_SYMBOLS[tabStop.alignment] || "L"}

--- a/packages/react/src/components/ui/StylePicker.tsx
+++ b/packages/react/src/components/ui/StylePicker.tsx
@@ -189,19 +189,23 @@ export function StylePicker({
     }
     return styles?.find((s) => s.styleId === current)?.name || current;
   }, [displayLabel, value, styleOptions, styles]);
+  const handleValueChange = React.useCallback(
+    (nextValue: string | null) => onChange?.(nextValue ?? ""),
+    [onChange],
+  );
+  const triggerStyle = React.useMemo(
+    () => ({
+      width: typeof width === "number" ? `${width}px` : width,
+    }),
+    [width],
+  );
 
   return (
-    <Select
-      value={value || "Normal"}
-      onValueChange={(val) => onChange?.(val ?? "")}
-      disabled={disabled}
-    >
+    <Select value={value || "Normal"} onValueChange={handleValueChange} disabled={disabled}>
       <SelectTrigger
         size="sm"
         className={`folio-style-picker h-8 min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)] ${className ?? ""}`}
-        style={{
-          width: typeof width === "number" ? `${width}px` : width,
-        }}
+        style={triggerStyle}
       >
         {triggerLabel !== undefined ? (
           <span

--- a/packages/react/src/components/ui/VerticalRuler.tsx
+++ b/packages/react/src/components/ui/VerticalRuler.tsx
@@ -209,9 +209,8 @@ export function VerticalRuler({
         editable={editable}
         isDragging={dragging === "topMargin"}
         isHovered={hoveredMarker === "topMargin"}
-        onMouseEnter={() => setHoveredMarker("topMargin")}
-        onMouseLeave={() => setHoveredMarker(null)}
-        onMouseDown={(e) => handleDragStart(e, "topMargin")}
+        onDragStart={handleDragStart}
+        onHoverChange={setHoveredMarker}
       />
 
       {/* Bottom margin marker */}
@@ -221,9 +220,8 @@ export function VerticalRuler({
         editable={editable}
         isDragging={dragging === "bottomMargin"}
         isHovered={hoveredMarker === "bottomMargin"}
-        onMouseEnter={() => setHoveredMarker("bottomMargin")}
-        onMouseLeave={() => setHoveredMarker(null)}
-        onMouseDown={(e) => handleDragStart(e, "bottomMargin")}
+        onDragStart={handleDragStart}
+        onHoverChange={setHoveredMarker}
       />
     </div>
   );
@@ -274,9 +272,8 @@ type VerticalMarginMarkerProps = {
   editable: boolean;
   isDragging: boolean;
   isHovered: boolean;
-  onMouseEnter: () => void;
-  onMouseLeave: () => void;
-  onMouseDown: (e: React.MouseEvent) => void;
+  onDragStart: (event: React.MouseEvent, marker: MarkerType) => void;
+  onHoverChange: (marker: MarkerType | null) => void;
 };
 
 function VerticalMarginMarker({
@@ -285,12 +282,17 @@ function VerticalMarginMarker({
   editable,
   isDragging,
   isHovered,
-  onMouseEnter,
-  onMouseLeave,
-  onMouseDown,
+  onDragStart,
+  onHoverChange,
 }: VerticalMarginMarkerProps): React.ReactElement {
   const t = useTranslations("folio");
   const color = resolveMarkerColor(isDragging, isHovered);
+  const handleMouseEnter = useCallback(() => onHoverChange(type), [onHoverChange, type]);
+  const handleMouseLeave = useCallback(() => onHoverChange(null), [onHoverChange]);
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => onDragStart(event, type),
+    [onDragStart, type],
+  );
 
   const markerStyle: CSSProperties = {
     position: "absolute",
@@ -319,9 +321,9 @@ function VerticalMarginMarker({
     <div
       className={`docx-ruler-marker docx-ruler-marker-${type}`}
       style={markerStyle}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      onMouseDown={onMouseDown}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onMouseDown={handleMouseDown}
       role="slider"
       aria-label={type === "topMargin" ? t("ruler.topMargin") : t("ruler.bottomMargin")}
       aria-orientation="vertical"

--- a/packages/react/src/components/ui/ZoomControl.tsx
+++ b/packages/react/src/components/ui/ZoomControl.tsx
@@ -8,6 +8,8 @@
  * FormattingBar).
  */
 
+import { useCallback, useMemo } from "react";
+
 import { useFolioUI } from "../../ui/folio-ui";
 import { cn } from "../../lib/utils";
 
@@ -71,21 +73,25 @@ export function ZoomControl({
   // Use the matched preset's exact string so the active item highlights even
   // when `value` is a near-preset float (e.g. 0.9999 from continuous zoom).
   const selectValue = matchingLevel ? matchingLevel.value.toString() : value.toString();
+  const handleValueChange = useCallback(
+    (newValue: string | null) => {
+      if (typeof newValue !== "string") {
+        return;
+      }
+      const zoom = Number.parseFloat(newValue);
+      if (!Number.isNaN(zoom)) {
+        onChange?.(zoom);
+      }
+    },
+    [onChange],
+  );
+  const triggerStyle = useMemo(
+    () => ({ width: compact ? 76 : 80, height: compact ? 28 : 32 }),
+    [compact],
+  );
 
   return (
-    <Select
-      value={selectValue}
-      onValueChange={(newValue) => {
-        if (typeof newValue !== "string") {
-          return;
-        }
-        const zoom = Number.parseFloat(newValue);
-        if (!Number.isNaN(zoom)) {
-          onChange?.(zoom);
-        }
-      }}
-      disabled={disabled}
-    >
+    <Select value={selectValue} onValueChange={handleValueChange} disabled={disabled}>
       <SelectTrigger
         size="sm"
         className={cn(
@@ -93,7 +99,7 @@ export function ZoomControl({
           compact ? "text-xs" : "text-sm",
           className,
         )}
-        style={{ width: compact ? 76 : 80, height: compact ? 28 : 32 }}
+        style={triggerStyle}
       >
         <SelectValue placeholder="100%">{displayLabel}</SelectValue>
       </SelectTrigger>

--- a/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
+++ b/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
@@ -540,10 +540,8 @@ export function ImageSelectionOverlay({
         <Handle
           key={pos}
           handle={pos}
-          style={{
-            left: left + width * x - HANDLE_HALF,
-            top: top + height * y - HANDLE_HALF,
-          }}
+          left={left + width * x - HANDLE_HALF}
+          top={top + height * y - HANDLE_HALF}
           onMouseDown={handleResizeStart}
         />
       ))}
@@ -570,17 +568,19 @@ export function ImageSelectionOverlay({
 
 type HandleProps = {
   handle: ResizeHandle;
-  style: CSSProperties;
+  left: number;
+  top: number;
   onMouseDown: (handle: ResizeHandle, e: React.MouseEvent) => void;
 };
 
-function Handle({ handle, style, onMouseDown }: HandleProps): React.ReactElement {
+function Handle({ handle, left, top, onMouseDown }: HandleProps): React.ReactElement {
   return (
     <div
       role="presentation"
       style={{
         ...handleBaseStyles,
-        ...style,
+        left,
+        top,
         cursor: HANDLE_CURSORS[handle],
       }}
       onMouseDown={(e) => onMouseDown(handle, e)}

--- a/packages/react/src/renderAsync.tsx
+++ b/packages/react/src/renderAsync.tsx
@@ -116,27 +116,32 @@ export const renderAsync = (
       },
     };
 
+    const lifecycle = {
+      onError(error: Error) {
+        editorOptions["onError"]?.(error);
+        if (!settled) {
+          settled = true;
+          root?.unmount();
+          root = null;
+          reject(error);
+        }
+      },
+      onChange(doc: Document) {
+        editorOptions["onChange"]?.(doc);
+        if (!settled) {
+          settled = true;
+          resolve(handle);
+        }
+      },
+    };
+
     const element = (
       <IntlProvider locale={locale} messages={getFolioMessages(locale)}>
         <DocxEditor
           {...editorOptions}
           documentBuffer={input}
-          onError={(error) => {
-            editorOptions["onError"]?.(error);
-            if (!settled) {
-              settled = true;
-              root?.unmount();
-              root = null;
-              reject(error);
-            }
-          }}
-          onChange={(doc) => {
-            editorOptions["onChange"]?.(doc);
-            if (!settled) {
-              settled = true;
-              resolve(handle);
-            }
-          }}
+          onError={lifecycle.onError}
+          onChange={lifecycle.onChange}
           ref={ref}
         />
       </IntlProvider>

--- a/packages/react/src/ui/defaults/color-picker.tsx
+++ b/packages/react/src/ui/defaults/color-picker.tsx
@@ -1,4 +1,5 @@
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import { useCallback, useMemo } from "react";
 
 import { cn } from "../../lib/utils";
 import type { ColorPreset, FolioColorPickerProps } from "../folio-ui";
@@ -26,12 +27,11 @@ export function DefaultColorPicker({
   columns = 8,
   children,
 }: FolioColorPickerProps) {
+  const trigger = useMemo(() => <div className="folio-default-color-picker-trigger" />, []);
+
   return (
     <PopoverPrimitive.Root>
-      <PopoverPrimitive.Trigger
-        nativeButton={false}
-        render={<div className="folio-default-color-picker-trigger" />}
-      >
+      <PopoverPrimitive.Trigger nativeButton={false} render={trigger}>
         {children}
       </PopoverPrimitive.Trigger>
       <PopoverPrimitive.Portal>
@@ -58,16 +58,11 @@ export function DefaultColorPicker({
               style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
             >
               {presets.map((preset) => (
-                <PopoverPrimitive.Close
-                  aria-label={preset.label}
-                  className={cn(
-                    "folio-default-color-picker-swatch",
-                    value === preset.value && "folio-default-color-picker-swatch--selected",
-                  )}
+                <ColorSwatch
                   key={preset.value}
-                  onClick={() => onSelect?.(preset.value)}
-                  style={{ backgroundColor: swatchColor(preset) }}
-                  title={preset.label}
+                  onSelect={onSelect}
+                  preset={preset}
+                  selected={value === preset.value}
                 />
               ))}
             </div>
@@ -84,5 +79,29 @@ export function DefaultColorPicker({
         </PopoverPrimitive.Positioner>
       </PopoverPrimitive.Portal>
     </PopoverPrimitive.Root>
+  );
+}
+
+type ColorSwatchProps = {
+  onSelect: FolioColorPickerProps["onSelect"];
+  preset: ColorPreset;
+  selected: boolean;
+};
+
+function ColorSwatch({ onSelect, preset, selected }: ColorSwatchProps) {
+  const handleClick = useCallback(() => onSelect?.(preset.value), [onSelect, preset.value]);
+  const style = useMemo(() => ({ backgroundColor: swatchColor(preset) }), [preset]);
+
+  return (
+    <PopoverPrimitive.Close
+      aria-label={preset.label}
+      className={cn(
+        "folio-default-color-picker-swatch",
+        selected && "folio-default-color-picker-swatch--selected",
+      )}
+      onClick={handleClick}
+      style={style}
+      title={preset.label}
+    />
   );
 }


### PR DESCRIPTION
## Summary

`@stll/folio-react` ships prebuilt output without the React Compiler, so referential identity at component boundaries is load-bearing. This PR enables the complete React performance lint family for package source and burns down every existing component-boundary finding.

## Lint policy

The `packages/react/src/**` override now enforces these rules as errors:

- `react/jsx-no-constructed-context-values`
- `react-perf/jsx-no-jsx-as-prop`
- `react-perf/jsx-no-new-array-as-prop`
- `react-perf/jsx-no-new-function-as-prop`
- `react-perf/jsx-no-new-object-as-prop`

All react-perf rules use `nativeAllowList: "all"`. Intrinsic DOM elements do not introduce a memoized child-component boundary, so native event handlers and style objects are intentionally exempt; injected and package component boundaries remain strict.

The original raw inventory contained 332 object/function findings. After excluding intrinsic-element false positives, 89 actionable component-boundary findings remained, including the additionally enabled JSX-as-prop rule. The final count is zero.

## Implementation

- Stabilizes callbacks and derived prop objects with `useCallback` / `useMemo` where the published package requires referential identity.
- Moves per-item bindings into focused child components for comment authors, content-control options, color swatches, ruler markers, and alignment options.
- Shares controlled-dialog close behavior through one stable hook.
- Stabilizes `DocxEditor` toolbar chrome, comments sidebar bindings, PagedEditor callbacks, dialog configurations, outline navigation, and editor-view resolvers.
- Keeps imperative `renderAsync` callbacks stable for the lifetime of one mount.
- Localizes the display-mode trigger label and keeps its item list stable per locale.

## Verification

- `bun --bun oxlint -c oxlint.config.ts packages scripts test benchmarks parity`
- `bun run format:check`
- `bun --filter '@stll/folio-react' typecheck`
- `bun --filter '@stll/folio-react' test`
- `bun --filter '@stll/folio-react' build`
- `bun run check:i18n`
- `bun run check:parity-contract`
- `bun run check:export-parity`
- `CHANGESET_BASE_REF=origin/main bun run changeset:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional selective-save setting for editor integrations.
  * Display-mode selection labels are now translated.

* **Bug Fixes**
  * Improved dropdown, date picker, formatting, ruler, and context-menu interactions.
  * Dialogs now close more consistently when dismissed.
  * Find-and-replace searches trigger reliably when leaving the search field.

* **Performance**
  * Improved editor responsiveness and memoization across controls, selections, and overlays, reducing unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->