### PR TITLE
fix: omit source-less image placeholders

### DIFF
--- a/.changeset/quiet-shapes-flow.md
+++ b/.changeset/quiet-shapes-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Ignore source-less shape placeholders when constructing paragraph image runs.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1205,6 +1205,25 @@ describe("toFlowBlocks list numbering", () => {
 // carry rounded OOXML dimensions, where zero is a valid subpixel result rather
 // than an absent value that should receive the default size.
 describe("toFlowBlocks image attribute normalization", () => {
+  test("omits inline image nodes without a paintable source", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.nodes.image.create({
+          src: "",
+          width: 100,
+          height: 100,
+        }),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind === "paragraph") {
+      expect(paragraph.runs).toEqual([]);
+    }
+  });
+
   test("preserves zero-sized inline image dimensions", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -985,6 +985,13 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
     }
     if (child.type.name === "image") {
       const attrs = expectImageAttrs(child);
+      if (!attrs.src) {
+        // Unsupported DrawingML shapes can survive the parser as image nodes
+        // without a relationship target. They have no paintable payload; a
+        // 100x100 fallback box would render a broken image and incorrectly
+        // consume paragraph flow. Keep the host paragraph, but omit the run.
+        return;
+      }
       const constrained = constrainImageToPage(
         attrs.width ?? 100,
         attrs.height ?? 100,


### PR DESCRIPTION
## Summary

- omit image runs that have no relationship/source payload
- keep the host paragraph so unsupported DrawingML shapes do not create broken 100×100 flow placeholders
- add focused layout-bridge regression coverage

## Display parity

: 

- strict font preflight passed
- score: 0.3010 -> 0.4951
- pagination divergences: 60 -> 24
- reported divergences: 87 -> 64

The remaining page-count difference is attributable to unsupported floating paragraph frames (`w:framePr`), which needs its own model/layout support rather than a file-specific pagination exception.

## Validation

- 49 focused unit tests pass
- `bun audit`: no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica