### PR TITLE
refactor: extract font-readiness from PagedEditor into core controller

### DIFF
--- a/.changeset/extract-font-readiness-controller.md
+++ b/.changeset/extract-font-readiness-controller.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Move the initial-layout font-readiness logic (`collectInitialLayoutFontFaces`, `collectInitialLayoutFontFamilies`, `documentFontsAreLoaded`, `getDocumentFontSet`, `waitForInitialLayoutFonts`) out of React's `PagedEditor.tsx` into a framework-neutral `@stll/folio-core/controller/fontReadiness` module. First slice of extracting orchestration from the React God component into the core controller; behavior is unchanged (the existing font-collection test moves to core alongside the code). No public API change.

--- a/packages/core/src/controller/fontReadiness.test.ts
+++ b/packages/core/src/controller/fontReadiness.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { toProseDoc } from "@stll/folio-core/prosemirror";
-import { schema } from "@stll/folio-core/prosemirror/schema";
-import { createEmptyDocument } from "@stll/folio-core/utils/createDocument";
-import { collectInitialLayoutFontFaces, collectInitialLayoutFontFamilies } from "./PagedEditor";
+import { toProseDoc } from "../prosemirror";
+import { schema } from "../prosemirror/schema";
+import { createEmptyDocument } from "../utils/createDocument";
+import {
+  collectInitialLayoutFontFaces,
+  collectInitialLayoutFontFamilies,
+  documentFontsAreLoaded,
+} from "./fontReadiness";
 
 describe("initial layout font loading", () => {
   test("loads only document-driven font families plus metric-compatible fallbacks", () => {
@@ -78,6 +82,20 @@ describe("initial layout font loading", () => {
 
     expect(faces).toContain("Cambria|italic|700");
     expect(faces).toContain("Caladea|italic|700");
+  });
+
+  test("reports fonts loaded when the document font set is unavailable (SSR/headless)", () => {
+    // Under the bun runner `document` is undefined, so getDocumentFontSet()
+    // returns null and the gate must resolve to "loaded" rather than block the
+    // first layout forever in a non-browser host.
+    expect(documentFontsAreLoaded()).toBe(true);
+  });
+
+  test("always includes the default layout font family for a null document model", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("plain")]),
+    ]);
+    expect(collectInitialLayoutFontFamilies(null, pmDoc)).toContain("Calibri");
   });
 });
 

--- a/packages/core/src/controller/fontReadiness.ts
+++ b/packages/core/src/controller/fontReadiness.ts
@@ -1,0 +1,267 @@
+/**
+ * Font-readiness helpers for the initial layout pass.
+ *
+ * Framework-neutral so both adapters share one implementation: collecting the
+ * font faces a document needs (from its model + ProseMirror content), gating
+ * the first layout on those faces having loaded, and reporting whether the
+ * browser's font set is settled. Browser globals (`document.fonts`, `window`)
+ * are only touched at call time, so importing this module in a non-browser host
+ * is safe (mirrors the `browserClock` precedent in `layoutScheduler.ts`).
+ */
+
+import type { Mark, Node as PMNode } from "prosemirror-model";
+import type { EditorState } from "prosemirror-state";
+
+import { expectFontFamilyMarkAttrs } from "../prosemirror/attrs";
+import type { Document, TextFormatting } from "../types/document";
+
+export function getDocumentFontSet(): FontFaceSet | null {
+  if (typeof document === "undefined" || !("fonts" in document)) {
+    return null;
+  }
+  return document.fonts;
+}
+
+export function documentFontsAreLoaded(): boolean {
+  const fontSet = getDocumentFontSet();
+  return !fontSet || fontSet.status === "loaded";
+}
+
+const INITIAL_LAYOUT_FONT_TIMEOUT_MS = 2000;
+const DEFAULT_LAYOUT_FONT_FAMILY = "Calibri";
+const OFFICE_FONT_FAMILY_MAP: Record<string, string> = {
+  Arial: "Arimo",
+  Calibri: "Carlito",
+  Cambria: "Caladea",
+  "Times New Roman": "Tinos",
+  "Courier New": "Cousine",
+};
+const CSS_GENERIC_FONT_FAMILIES = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+]);
+const LAYOUT_FONT_DESCRIPTORS = [
+  { style: "normal", weight: 400 },
+  { style: "italic", weight: 400 },
+  { style: "normal", weight: 700 },
+  { style: "italic", weight: 700 },
+] as const;
+const REGULAR_LAYOUT_FONT_DESCRIPTOR = LAYOUT_FONT_DESCRIPTORS[0];
+
+export type LayoutFontFace = {
+  family: string;
+  style: (typeof LAYOUT_FONT_DESCRIPTORS)[number]["style"];
+  weight: (typeof LAYOUT_FONT_DESCRIPTORS)[number]["weight"];
+};
+
+export function waitForInitialLayoutFonts(
+  documentModel: Document | null,
+  pmDoc: EditorState["doc"],
+): Promise<boolean> {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return Promise.resolve(true);
+  }
+
+  const loadChecks: string[] = [];
+  for (const face of collectInitialLayoutFontFaces(documentModel, pmDoc)) {
+    loadChecks.push(`${face.style} ${face.weight} 16px "${escapeCssFontFamily(face.family)}"`);
+  }
+
+  const loadFonts = Promise.allSettled(loadChecks.map((check) => fontSet.load(check)))
+    .then(() => fontSet.ready)
+    .then(() => true);
+  return Promise.race([
+    loadFonts,
+    new Promise<boolean>((resolve) => {
+      window.setTimeout(() => resolve(false), INITIAL_LAYOUT_FONT_TIMEOUT_MS);
+    }),
+  ]);
+}
+
+export function collectInitialLayoutFontFamilies(
+  documentModel: Document | null,
+  pmDoc: EditorState["doc"],
+): Set<string> {
+  return new Set(collectInitialLayoutFontFaces(documentModel, pmDoc).map(({ family }) => family));
+}
+
+export function collectInitialLayoutFontFaces(
+  documentModel: Document | null,
+  pmDoc: EditorState["doc"],
+): LayoutFontFace[] {
+  const faces = new Map<string, LayoutFontFace>();
+  addLayoutFontFamilyFace(faces, DEFAULT_LAYOUT_FONT_FAMILY, REGULAR_LAYOUT_FONT_DESCRIPTOR);
+
+  for (const family of documentModel?.requiredFonts ?? []) {
+    addLayoutFontFamilyFace(faces, family, REGULAR_LAYOUT_FONT_DESCRIPTOR);
+  }
+
+  addLayoutFontFamilyFace(
+    faces,
+    documentModel?.package.theme?.fontScheme?.majorFont?.latin,
+    REGULAR_LAYOUT_FONT_DESCRIPTOR,
+  );
+  addLayoutFontFamilyFace(
+    faces,
+    documentModel?.package.theme?.fontScheme?.minorFont?.latin,
+    REGULAR_LAYOUT_FONT_DESCRIPTOR,
+  );
+  addTextFormattingFontFaces(faces, documentModel?.package.styles?.docDefaults?.rPr);
+  for (const style of documentModel?.package.styles?.styles ?? []) {
+    addTextFormattingFontFaces(faces, style.rPr);
+  }
+
+  collectProseMirrorFontFaces(faces, pmDoc, undefined);
+
+  return Array.from(faces.values());
+}
+
+function addTextFormattingFontFaces(
+  faces: Map<string, LayoutFontFace>,
+  formatting: TextFormatting | undefined,
+): void {
+  addLayoutFontFamilyFace(
+    faces,
+    formatting?.fontFamily,
+    layoutDescriptorFromFormatting(formatting),
+  );
+}
+
+function collectProseMirrorFontFaces(
+  faces: Map<string, LayoutFontFace>,
+  node: PMNode,
+  inheritedTextFormatting: TextFormatting | undefined,
+): void {
+  const paragraphDefaults = readParagraphDefaultTextFormatting(node);
+  const textFormatting = paragraphDefaults ?? inheritedTextFormatting;
+  if (paragraphDefaults) {
+    addTextFormattingFontFaces(faces, paragraphDefaults);
+  }
+
+  if (node.attrs["listMarkerFontFamily"]) {
+    addLayoutFontFamilyFace(
+      faces,
+      node.attrs["listMarkerFontFamily"],
+      REGULAR_LAYOUT_FONT_DESCRIPTOR,
+    );
+  }
+
+  if (node.isText) {
+    const descriptor = layoutDescriptorFromFormattingAndMarks(textFormatting, node.marks);
+    const markFontFamily = readFontFamilyMarkAttrs(node.marks);
+    addLayoutFontFamilyFace(
+      faces,
+      markFontFamily ?? textFormatting?.fontFamily ?? DEFAULT_LAYOUT_FONT_FAMILY,
+      descriptor,
+    );
+  }
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((child) => {
+    collectProseMirrorFontFaces(faces, child, textFormatting);
+  });
+}
+
+function readParagraphDefaultTextFormatting(node: PMNode): TextFormatting | undefined {
+  const value = node.attrs["defaultTextFormatting"];
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return value as TextFormatting;
+}
+
+function readFontFamilyMarkAttrs(marks: readonly Mark[]): unknown {
+  for (const mark of marks) {
+    if (mark.type.name === "fontFamily") {
+      return expectFontFamilyMarkAttrs(mark);
+    }
+  }
+  return undefined;
+}
+
+function layoutDescriptorFromFormatting(
+  formatting: Pick<TextFormatting, "bold" | "italic"> | undefined,
+): Omit<LayoutFontFace, "family"> {
+  return {
+    style: formatting?.italic ? "italic" : "normal",
+    weight: formatting?.bold ? 700 : 400,
+  };
+}
+
+function layoutDescriptorFromFormattingAndMarks(
+  formatting: Pick<TextFormatting, "bold" | "italic"> | undefined,
+  marks: readonly Mark[],
+): Omit<LayoutFontFace, "family"> {
+  let bold = formatting?.bold === true;
+  let italic = formatting?.italic === true;
+
+  for (const mark of marks) {
+    if (mark.type.name === "bold") {
+      bold = true;
+    }
+    if (mark.type.name === "italic") {
+      italic = true;
+    }
+  }
+
+  return {
+    style: italic ? "italic" : "normal",
+    weight: bold ? 700 : 400,
+  };
+}
+
+function addLayoutFontFamilyFace(
+  faces: Map<string, LayoutFontFace>,
+  value: unknown,
+  descriptor: Omit<LayoutFontFace, "family">,
+): void {
+  if (typeof value === "string") {
+    addLayoutFontFamilyNameFace(faces, value, descriptor);
+    return;
+  }
+
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  const fontFamily = value as { ascii?: unknown; hAnsi?: unknown };
+  addLayoutFontFamilyFace(faces, fontFamily.ascii, descriptor);
+  addLayoutFontFamilyFace(faces, fontFamily.hAnsi, descriptor);
+}
+
+function addLayoutFontFamilyNameFace(
+  faces: Map<string, LayoutFontFace>,
+  family: string,
+  descriptor: Omit<LayoutFontFace, "family">,
+): void {
+  const normalized = family.trim();
+  if (!normalized || CSS_GENERIC_FONT_FAMILIES.has(normalized)) {
+    return;
+  }
+
+  addLayoutFontFace(faces, normalized, descriptor);
+  const mappedFamily = OFFICE_FONT_FAMILY_MAP[normalized];
+  if (mappedFamily) {
+    addLayoutFontFace(faces, mappedFamily, descriptor);
+  }
+}
+
+function addLayoutFontFace(
+  faces: Map<string, LayoutFontFace>,
+  family: string,
+  descriptor: Omit<LayoutFontFace, "family">,
+): void {
+  faces.set(`${family}|${descriptor.style}|${descriptor.weight}`, {
+    family,
+    ...descriptor,
+  });
+}
+
+function escapeCssFontFamily(family: string): string {
+  return family.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"');
+}

--- a/packages/core/src/controller/fontReadiness.ts
+++ b/packages/core/src/controller/fontReadiness.ts
@@ -78,7 +78,7 @@ export function waitForInitialLayoutFonts(
   return Promise.race([
     loadFonts,
     new Promise<boolean>((resolve) => {
-      window.setTimeout(() => resolve(false), INITIAL_LAYOUT_FONT_TIMEOUT_MS);
+      globalThis.setTimeout(() => resolve(false), INITIAL_LAYOUT_FONT_TIMEOUT_MS);
     }),
   ]);
 }

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -27,7 +27,7 @@ import React, {
 import type { CSSProperties } from "react";
 import { createPortal } from "react-dom";
 
-import type { Mark, Node as PMNode } from "prosemirror-model";
+import type { Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction, Plugin } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
@@ -46,6 +46,11 @@ import {
   type LayoutScheduler,
 } from "@stll/folio-core/controller/layoutScheduler";
 import { createLayoutSession } from "@stll/folio-core/controller/layoutSession";
+import {
+  documentFontsAreLoaded,
+  getDocumentFontSet,
+  waitForInitialLayoutFonts,
+} from "@stll/folio-core/controller/fontReadiness";
 import { getFootnoteText } from "@stll/folio-core/docx/footnoteParser";
 import {
   convertHeaderFooterPmDocToContent,
@@ -140,7 +145,6 @@ import { getTransactionDirtyRange } from "@stll/folio-core/paged-layout/transact
 import { addRowBelow, addColumnRight } from "@stll/folio-core/prosemirror";
 import { findStartPosForParaId } from "@stll/folio-core/prosemirror/utils/findParagraphByParaId";
 import {
-  expectFontFamilyMarkAttrs,
   expectImageAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
@@ -172,7 +176,6 @@ import type {
   StyleDefinitions,
   SectionProperties,
   HeaderFooter,
-  TextFormatting,
 } from "@stll/folio-core/types/document";
 import {
   closestHtmlElement,
@@ -1009,257 +1012,7 @@ function stableJsonStringify(value: unknown): string {
   });
 }
 
-function getDocumentFontSet(): FontFaceSet | null {
-  if (typeof document === "undefined" || !("fonts" in document)) {
-    return null;
-  }
-  return document.fonts;
-}
-
-function documentFontsAreLoaded(): boolean {
-  const fontSet = getDocumentFontSet();
-  return !fontSet || fontSet.status === "loaded";
-}
-
-const INITIAL_LAYOUT_FONT_TIMEOUT_MS = 2000;
 const INITIAL_FONT_READY_SUPPRESSION_MS = 250;
-const DEFAULT_LAYOUT_FONT_FAMILY = "Calibri";
-const OFFICE_FONT_FAMILY_MAP: Record<string, string> = {
-  Arial: "Arimo",
-  Calibri: "Carlito",
-  Cambria: "Caladea",
-  "Times New Roman": "Tinos",
-  "Courier New": "Cousine",
-};
-const CSS_GENERIC_FONT_FAMILIES = new Set([
-  "serif",
-  "sans-serif",
-  "monospace",
-  "cursive",
-  "fantasy",
-  "system-ui",
-]);
-const LAYOUT_FONT_DESCRIPTORS = [
-  { style: "normal", weight: 400 },
-  { style: "italic", weight: 400 },
-  { style: "normal", weight: 700 },
-  { style: "italic", weight: 700 },
-] as const;
-const REGULAR_LAYOUT_FONT_DESCRIPTOR = LAYOUT_FONT_DESCRIPTORS[0];
-
-export type LayoutFontFace = {
-  family: string;
-  style: (typeof LAYOUT_FONT_DESCRIPTORS)[number]["style"];
-  weight: (typeof LAYOUT_FONT_DESCRIPTORS)[number]["weight"];
-};
-
-function waitForInitialLayoutFonts(
-  documentModel: Document | null,
-  pmDoc: EditorState["doc"],
-): Promise<boolean> {
-  const fontSet = getDocumentFontSet();
-  if (!fontSet) {
-    return Promise.resolve(true);
-  }
-
-  const loadChecks: string[] = [];
-  for (const face of collectInitialLayoutFontFaces(documentModel, pmDoc)) {
-    loadChecks.push(`${face.style} ${face.weight} 16px "${escapeCssFontFamily(face.family)}"`);
-  }
-
-  const loadFonts = Promise.allSettled(loadChecks.map((check) => fontSet.load(check)))
-    .then(() => fontSet.ready)
-    .then(() => true);
-  return Promise.race([
-    loadFonts,
-    new Promise<boolean>((resolve) => {
-      window.setTimeout(() => resolve(false), INITIAL_LAYOUT_FONT_TIMEOUT_MS);
-    }),
-  ]);
-}
-
-export function collectInitialLayoutFontFamilies(
-  documentModel: Document | null,
-  pmDoc: EditorState["doc"],
-): Set<string> {
-  return new Set(collectInitialLayoutFontFaces(documentModel, pmDoc).map(({ family }) => family));
-}
-
-export function collectInitialLayoutFontFaces(
-  documentModel: Document | null,
-  pmDoc: EditorState["doc"],
-): LayoutFontFace[] {
-  const faces = new Map<string, LayoutFontFace>();
-  addLayoutFontFamilyFace(faces, DEFAULT_LAYOUT_FONT_FAMILY, REGULAR_LAYOUT_FONT_DESCRIPTOR);
-
-  for (const family of documentModel?.requiredFonts ?? []) {
-    addLayoutFontFamilyFace(faces, family, REGULAR_LAYOUT_FONT_DESCRIPTOR);
-  }
-
-  addLayoutFontFamilyFace(
-    faces,
-    documentModel?.package.theme?.fontScheme?.majorFont?.latin,
-    REGULAR_LAYOUT_FONT_DESCRIPTOR,
-  );
-  addLayoutFontFamilyFace(
-    faces,
-    documentModel?.package.theme?.fontScheme?.minorFont?.latin,
-    REGULAR_LAYOUT_FONT_DESCRIPTOR,
-  );
-  addTextFormattingFontFaces(faces, documentModel?.package.styles?.docDefaults?.rPr);
-  for (const style of documentModel?.package.styles?.styles ?? []) {
-    addTextFormattingFontFaces(faces, style.rPr);
-  }
-
-  collectProseMirrorFontFaces(faces, pmDoc, undefined);
-
-  return Array.from(faces.values());
-}
-
-function addTextFormattingFontFaces(
-  faces: Map<string, LayoutFontFace>,
-  formatting: TextFormatting | undefined,
-): void {
-  addLayoutFontFamilyFace(
-    faces,
-    formatting?.fontFamily,
-    layoutDescriptorFromFormatting(formatting),
-  );
-}
-
-function collectProseMirrorFontFaces(
-  faces: Map<string, LayoutFontFace>,
-  node: PMNode,
-  inheritedTextFormatting: TextFormatting | undefined,
-): void {
-  const paragraphDefaults = readParagraphDefaultTextFormatting(node);
-  const textFormatting = paragraphDefaults ?? inheritedTextFormatting;
-  if (paragraphDefaults) {
-    addTextFormattingFontFaces(faces, paragraphDefaults);
-  }
-
-  if (node.attrs["listMarkerFontFamily"]) {
-    addLayoutFontFamilyFace(
-      faces,
-      node.attrs["listMarkerFontFamily"],
-      REGULAR_LAYOUT_FONT_DESCRIPTOR,
-    );
-  }
-
-  if (node.isText) {
-    const descriptor = layoutDescriptorFromFormattingAndMarks(textFormatting, node.marks);
-    const markFontFamily = readFontFamilyMarkAttrs(node.marks);
-    addLayoutFontFamilyFace(
-      faces,
-      markFontFamily ?? textFormatting?.fontFamily ?? DEFAULT_LAYOUT_FONT_FAMILY,
-      descriptor,
-    );
-  }
-
-  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-  node.forEach((child) => {
-    collectProseMirrorFontFaces(faces, child, textFormatting);
-  });
-}
-
-function readParagraphDefaultTextFormatting(node: PMNode): TextFormatting | undefined {
-  const value = node.attrs["defaultTextFormatting"];
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  return value as TextFormatting;
-}
-
-function readFontFamilyMarkAttrs(marks: readonly Mark[]): unknown {
-  for (const mark of marks) {
-    if (mark.type.name === "fontFamily") {
-      return expectFontFamilyMarkAttrs(mark);
-    }
-  }
-  return undefined;
-}
-
-function layoutDescriptorFromFormatting(
-  formatting: Pick<TextFormatting, "bold" | "italic"> | undefined,
-): Omit<LayoutFontFace, "family"> {
-  return {
-    style: formatting?.italic ? "italic" : "normal",
-    weight: formatting?.bold ? 700 : 400,
-  };
-}
-
-function layoutDescriptorFromFormattingAndMarks(
-  formatting: Pick<TextFormatting, "bold" | "italic"> | undefined,
-  marks: readonly Mark[],
-): Omit<LayoutFontFace, "family"> {
-  let bold = formatting?.bold === true;
-  let italic = formatting?.italic === true;
-
-  for (const mark of marks) {
-    if (mark.type.name === "bold") {
-      bold = true;
-    }
-    if (mark.type.name === "italic") {
-      italic = true;
-    }
-  }
-
-  return {
-    style: italic ? "italic" : "normal",
-    weight: bold ? 700 : 400,
-  };
-}
-
-function addLayoutFontFamilyFace(
-  faces: Map<string, LayoutFontFace>,
-  value: unknown,
-  descriptor: Omit<LayoutFontFace, "family">,
-): void {
-  if (typeof value === "string") {
-    addLayoutFontFamilyNameFace(faces, value, descriptor);
-    return;
-  }
-
-  if (!value || typeof value !== "object") {
-    return;
-  }
-
-  const fontFamily = value as { ascii?: unknown; hAnsi?: unknown };
-  addLayoutFontFamilyFace(faces, fontFamily.ascii, descriptor);
-  addLayoutFontFamilyFace(faces, fontFamily.hAnsi, descriptor);
-}
-
-function addLayoutFontFamilyNameFace(
-  faces: Map<string, LayoutFontFace>,
-  family: string,
-  descriptor: Omit<LayoutFontFace, "family">,
-): void {
-  const normalized = family.trim();
-  if (!normalized || CSS_GENERIC_FONT_FAMILIES.has(normalized)) {
-    return;
-  }
-
-  addLayoutFontFace(faces, normalized, descriptor);
-  const mappedFamily = OFFICE_FONT_FAMILY_MAP[normalized];
-  if (mappedFamily) {
-    addLayoutFontFace(faces, mappedFamily, descriptor);
-  }
-}
-
-function addLayoutFontFace(
-  faces: Map<string, LayoutFontFace>,
-  family: string,
-  descriptor: Omit<LayoutFontFace, "family">,
-): void {
-  faces.set(`${family}|${descriptor.style}|${descriptor.weight}`, {
-    family,
-    ...descriptor,
-  });
-}
-
-function escapeCssFontFamily(family: string): string {
-  return family.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"');
-}
 
 function describeInvalidHighlightMarks(doc: EditorState["doc"]): string {
   const invalidHighlights: string[] = [];


### PR DESCRIPTION
**First slice of the God-module extraction** (audit's #1 structural item): carve orchestration out of `packages/react/src/paged-editor/PagedEditor.tsx` (~6,150 lines) into the framework-neutral core controller, leaving the React file as a lifecycle+DOM shell.

## What moved
`collectInitialLayoutFontFaces`, `collectInitialLayoutFontFamilies`, `documentFontsAreLoaded`, `getDocumentFontSet`, `waitForInitialLayoutFonts` (+ their private helpers/constants) → **`@stll/folio-core/controller/fontReadiness`**. This logic decides which font faces a document needs (from its model + ProseMirror content), gates the first layout on them loading, and probes the browser font set.

## Why this slice first
- **Already framework-agnostic** — imported only React-free core modules; nothing React/JSX touched it, it just lived in the `.tsx`.
- **Behavior-preserving by construction** — the existing font-collection unit test (which exercised these functions directly, no editor view) moves to core alongside the code and still passes. Call sites in PagedEditor are byte-identical; only the import source changed.
- **Removes a latent dup** — `documentFontsAreLoaded` is duplicated in the Vue adapter and is already an injected dependency of the core layout pipeline; a fast-follow can point Vue at this same module.
- **Not the hot path** — font collection runs once per load / on `loadingdone`, never in the pagination inner loop.

## Boundary safety
`document.fonts` / `window` are only touched at call time (same pattern as the existing `browserClock`), so the module stays importable in non-browser hosts. `react-free-core`, `layer-boundaries`, and `model-purity` arch tests all stay green.

## Verification
- Moved test passes (6 cases incl. 2 new: SSR/headless guard + null-model default floor)
- `typecheck` (all 7 packages), `lint`, `format:check` clean
- Arch tests green; `layoutPipeline` test (consumes the `documentFontsAreLoaded` seam) green
- Interaction behavior (font-ready re-layout) covered by the CI `interactions` job
- Changeset: core + react patch (internal refactor, no public API change)

Follow-ups (separate PRs): point the Vue adapter's `documentFontsAreLoaded` at this module; then the next slices (`buildLayoutInputSignature`, pointer pipeline, HF lifecycle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial document layout reliability by ensuring required fonts are detected and loaded before rendering.
  * Added support for server-side and headless environments where browser font APIs are unavailable.
  * Ensured the default layout font is included when document content is missing.

* **Refactor**
  * Centralized font-readiness handling for consistent behavior across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->