### PR TITLE
fix: normalize adjacent parity table cells

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -57,7 +57,7 @@ describe("compareGeoms", () => {
     expect(merged).toHaveLength(2);
   });
 
-  test("keeps nearby text from different table cells separate", () => {
+  test("merges nearby text from different table cells like Word PDF boxes", () => {
     const merged = mergeVisualRows([
       makeLine({
         text: "Left cell",
@@ -77,10 +77,11 @@ describe("compareGeoms", () => {
       }),
     ]);
 
-    expect(merged).toHaveLength(2);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.normText).toBe(normalizeLineText("Left cell Right cell"));
   });
 
-  test("keeps nearby table and non-table text separate", () => {
+  test("merges nearby table and ungrouped text without Folio-only asymmetry", () => {
     const merged = mergeVisualRows([
       makeLine({ text: "Body text", xPt: 90, yPt: 100, widthPt: 60, heightPt: 12 }),
       makeLine({
@@ -93,7 +94,45 @@ describe("compareGeoms", () => {
       }),
     ]);
 
-    expect(merged).toHaveLength(2);
+    expect(merged).toHaveLength(1);
+  });
+
+  test("normalizes adjacent table cells symmetrically across extractors", () => {
+    const word = makeDoc("word", [
+      makePage({
+        lines: [
+          makeLine({ text: "počet", xPt: 90, yPt: 100, widthPt: 30, heightPt: 12 }),
+          makeLine({ text: "celkem", xPt: 125, yPt: 100, widthPt: 35, heightPt: 12 }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "počet",
+            xPt: 90,
+            yPt: 100,
+            widthPt: 30,
+            heightPt: 12,
+            visualGroup: "table-cell:0",
+          }),
+          makeLine({
+            text: "celkem",
+            xPt: 125,
+            yPt: 100,
+            widthPt: 35,
+            heightPt: 12,
+            visualGroup: "table-cell:1",
+          }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences.filter((divergence) => divergence.kind === "line-break")).toEqual([]);
+    expect(result.score).toBe(1);
   });
 
   test("merges standalone list markers with their body across marker-sized gaps", () => {

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -97,6 +97,15 @@ describe("compareGeoms", () => {
     expect(merged).toHaveLength(1);
   });
 
+  test("keeps nearby boxes from different semantic regions separate", () => {
+    const merged = mergeVisualRows([
+      makeLine({ text: "Header", region: "header", xPt: 90, yPt: 100, widthPt: 60 }),
+      makeLine({ text: "Body", region: "body", xPt: 155, yPt: 100, widthPt: 60 }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+  });
+
   test("normalizes adjacent table cells symmetrically across extractors", () => {
     const word = makeDoc("word", [
       makePage({

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -111,15 +111,17 @@ const ROW_OVERLAP_RATIO = 0.5;
 /** Maximum horizontal gap (pt) between same-row boxes that still merges them.
  * Word emits list markers as separate ink boxes ~10pt left of the item text,
  * and tabbed legal clauses can leave ~23pt between the marker and text; table
- * cells sit farther apart (>25pt) and must stay separate. */
+ * widely separated table cells sit farther apart (>25pt) and stay separate. */
 const ROW_MERGE_GAP_PT = 24;
 const MARKER_ROW_MERGE_GAP_PT = 36;
 
 /** Clusters boxes into visual rows (>= ROW_OVERLAP_RATIO vertical overlap),
  * then merges row neighbours within ROW_MERGE_GAP_PT of each other into a
- * single LineBox — bullet/number markers join their item text the way folio
- * paints them, while table cells (large gaps) stay separate boxes. The result
- * is ordered row-by-row, left-to-right within a row: Word's ink boxes on one
+ * single LineBox — bullet/number markers and tightly adjacent table-cell text
+ * join the way Word's PDF boxes do. Folio's DOM-only cell identity is ignored
+ * here because Word truth has no equivalent metadata; using it would normalize
+ * the two extractors differently. The result is ordered row-by-row,
+ * left-to-right within a row: Word's ink boxes on one
  * visual row can differ by fractions of a pt vertically (e.g. table cells), so
  * a raw (y, x) sort would order the same row differently on the two sides and
  * derail the sequence alignment. Applied to BOTH sides so the pass itself
@@ -154,9 +156,6 @@ export const mergeVisualRows = (lines: LineBox[]): LineBox[] => {
 };
 
 const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
-  if (current.visualGroup !== next.visualGroup) {
-    return false;
-  }
   const gap = horizontalGap(current, next);
   if (gap <= ROW_MERGE_GAP_PT) {
     return true;
@@ -199,7 +198,6 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
     widthPt: Math.max(a.xPt + a.widthPt, b.xPt + b.widthPt) - xPt,
     heightPt: Math.max(a.yPt + a.heightPt, b.yPt + b.heightPt) - yPt,
     region: left.region,
-    ...(left.visualGroup !== undefined ? { visualGroup: left.visualGroup } : {}),
     ...(fontName !== undefined ? { fontName } : {}),
     ...(fontSizePt !== undefined ? { fontSizePt } : {}),
   };

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -156,6 +156,9 @@ export const mergeVisualRows = (lines: LineBox[]): LineBox[] => {
 };
 
 const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
+  if (current.region !== next.region) {
+    return false;
+  }
   const gap = horizontalGap(current, next);
   if (gap <= ROW_MERGE_GAP_PT) {
     return true;


### PR DESCRIPTION
## Summary

- normalize tightly adjacent table-cell boxes identically for Word PDF truth and Folio DOM extraction
- stop Folio-only `visualGroup` metadata from creating asymmetric line-break findings
- add a cross-extractor regression for adjacent `počet` / `celkem` cells

## Parity fixture

: 

- strict font preflight passed
- pages: Word 2, Folio 2
- false line-break findings: 1 -> 0
- score remains 0.5467 because remaining findings are genuine geometry drift

## Validation

- 95 parity unit tests pass
- `bun audit`: no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica