### PR TITLE
fix: skip unused XML callback paths

### DIFF
--- a/.changeset/calm-lions-parse.md
+++ b/.changeset/calm-lions-parse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Reduce DOCX parsing time by skipping unused XML callback paths.

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -57,6 +57,9 @@ const fxpParserOptions = {
   parseAttributeValue: false,
   ignoreDeclaration: true,
   ignorePiTags: true,
+  // Folio leaves the parser callbacks at their defaults, which do not consume
+  // the current-node path. Re-enable this if a callback needs a string path.
+  jPath: false,
   // Security: only process the 5 built-in XML entities (&lt; &gt; &amp;
   // &apos; &quot;). Custom/DOCTYPE-defined entities are blocked to
   // prevent Billion Laughs exponential expansion DoS. OOXML does not


### PR DESCRIPTION
Configure `fast-xml-parser` to pass its existing matcher to default callbacks instead of serializing an unused string path for every XML node. Folio does not configure processors that consume the callback path; ordered XML output, namespaces, attributes, entities, and stop-node handling remain unchanged.

In a simultaneous seven-repetition production-browser comparison on `podily-bps.docx`, cold DOCX parsing improved from 141.4 ms to 130.2 ms (7.9%) and warm parsing improved from 155.4 ms to 137.6 ms (11.5%). First usable page improved by 2.6% cold and 4.3% warm. All 31 repository fixtures produced identical serialized document models.

Validated with typecheck, lint, XML and full corpus round-trip tests, the differential harness, core production build, clean-room package validation, `git diff --check`, and `bun audit`.