### PR TITLE
fix: preserve styled empty paragraph spacing

### DIFF
--- a/.changeset/styled-empty-paragraph-spacing.md
+++ b/.changeset/styled-empty-paragraph-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve spacing from explicitly selected paragraph styles on empty paragraphs.

--- a/packages/core/src/layout-engine/emptyParagraphSpacing.test.ts
+++ b/packages/core/src/layout-engine/emptyParagraphSpacing.test.ts
@@ -102,6 +102,24 @@ describe("empty-paragraph spacing collapse (issue #402)", () => {
     expect(fragments[2]!.y).toBe(112);
   });
 
+  test("spacing from an explicitly selected paragraph style is honored", () => {
+    const blocks: FlowBlock[] = [
+      makePara(0, "Heading", { spacing: { after: 0 } }),
+      makePara(1, "", {
+        styleId: "ContractPartyDetails",
+        spacing: { before: 0, after: 8 },
+      }),
+      makePara(2, "Body", { spacing: { before: 0 } }),
+    ];
+    const measures: Measure[] = [makeMeasure(16), makeMeasure(16), makeMeasure(16)];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    const fragments = layout.pages[0]!.fragments;
+
+    expect(fragments[1]!.y).toBe(16);
+    expect(fragments[2]!.y).toBe(40);
+  });
+
   test("non-empty paragraphs always carry their inherited spacing", () => {
     // Sanity: the collapse only applies to empty paragraphs.
     const blocks: FlowBlock[] = [

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -125,6 +125,9 @@ function pageHasVisibleBodyContent(
  */
 function getSpacingBefore(block: ParagraphBlock): number {
   const value = block.attrs?.spacing?.before ?? 0;
+  if (value === 0) {
+    return 0;
+  }
   if (isEmptyParagraph(block) && !block.attrs?.styleId && !block.attrs?.spacingExplicit?.before) {
     return 0;
   }
@@ -137,6 +140,9 @@ function getSpacingBefore(block: ParagraphBlock): number {
  */
 function getSpacingAfter(block: ParagraphBlock): number {
   const value = block.attrs?.spacing?.after ?? 0;
+  if (value === 0) {
+    return 0;
+  }
   if (isEmptyParagraph(block) && !block.attrs?.styleId && !block.attrs?.spacingExplicit?.after) {
     return 0;
   }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -119,24 +119,25 @@ function pageHasVisibleBodyContent(
 
 /**
  * Get spacing before a paragraph block. Empty paragraphs whose
- * `before` was inherited from a paragraph style (not set inline) collapse
- * to zero — Word fidelity for incidental empty separators.
+ * `before` came only from the implicit default paragraph style collapse to
+ * zero. An explicit `w:pStyle` selection is authored paragraph formatting,
+ * so Word keeps the selected style's spacing even when the paragraph is empty.
  */
 function getSpacingBefore(block: ParagraphBlock): number {
   const value = block.attrs?.spacing?.before ?? 0;
-  if (isEmptyParagraph(block) && !block.attrs?.spacingExplicit?.before) {
+  if (isEmptyParagraph(block) && !block.attrs?.styleId && !block.attrs?.spacingExplicit?.before) {
     return 0;
   }
   return value;
 }
 
 /**
- * Get spacing after a paragraph block. Same empty-paragraph collapse rule
- * as `getSpacingBefore`.
+ * Get spacing after a paragraph block. Same implicit-default-style collapse
+ * rule as `getSpacingBefore`.
  */
 function getSpacingAfter(block: ParagraphBlock): number {
   const value = block.attrs?.spacing?.after ?? 0;
-  if (isEmptyParagraph(block) && !block.attrs?.spacingExplicit?.after) {
+  if (isEmptyParagraph(block) && !block.attrs?.styleId && !block.attrs?.spacingExplicit?.after) {
     return 0;
   }
   return value;


### PR DESCRIPTION
## Summary
- preserve inherited spacing on empty paragraphs that explicitly select a paragraph style
- keep implicit default-style empty paragraph spacing collapsed
- add a targeted layout regression and core patch changeset

## Anonymized parity evidence
- score: 0.4813 → 0.5128
- pages: 17/17 → 17/17
- y-drift divergences: 213 → 181
- total divergences: 647 → 615

## Verification
- `bun test src/layout-engine/emptyParagraphSpacing.test.ts` (4 passed)
- `bun audit` (no vulnerabilities)
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica