### PR TITLE
fix: improve parity capture diagnostics

### DIFF
--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import { PX_TO_PT } from "../config";
 import {
+  CLEAN_SCREENSHOT_CSS,
   computeZoomFactor,
+  formatServerStartFailure,
   meaningfulTextRange,
   parseCssFontFamilies,
   parseFirstFontFamily,
@@ -15,6 +17,34 @@ const rect = (left: number, top: number, width: number, height: number) => ({
   top,
   width,
   height,
+});
+
+describe("clean screenshot style", () => {
+  test("hides editor and playground chrome that can overlap a page", () => {
+    expect(CLEAN_SCREENSHOT_CSS).toContain('[data-folio-toolbar="true"]');
+    expect(CLEAN_SCREENSHOT_CSS).toContain('[data-testid="playground-controls"]');
+  });
+
+  test("keeps the page and its document content visible", () => {
+    expect(CLEAN_SCREENSHOT_CSS).toContain(".layout-page,");
+    expect(CLEAN_SCREENSHOT_CSS).toContain(".layout-page *");
+  });
+});
+
+describe("playground startup diagnostics", () => {
+  test("includes an early exit code and captured output", () => {
+    expect(formatServerStartFailure("http://localhost:4200", 90_000, 127, "vite: not found")).toBe(
+      "playground dev server exited with code 127 before becoming ready at http://localhost:4200\n" +
+        "Playground output:\n" +
+        "vite: not found",
+    );
+  });
+
+  test("reports a quiet startup timeout without an empty output section", () => {
+    expect(formatServerStartFailure("http://localhost:4200", 90_000, undefined, "")).toBe(
+      "playground dev server did not become ready at http://localhost:4200 within 90000ms",
+    );
+  });
 });
 
 describe("parseCssFontFamilies", () => {

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -105,6 +105,7 @@ const VIEWPORT = { width: 1400, height: 1000 };
 const SERVER_PROBE_TIMEOUT_MS = 2000;
 const SERVER_START_TIMEOUT_MS = 90_000;
 const SERVER_POLL_INTERVAL_MS = 500;
+const SERVER_LOG_TAIL_CHARS = 4000;
 
 const PLAYGROUND_NAVIGATION_TIMEOUT_MS = 120_000;
 const EDITOR_RENDER_TIMEOUT_MS = 20_000;
@@ -115,6 +116,43 @@ const STABILITY_SETTLE_MS = 250;
 const CHROMIUM_MISSING_MARKER = "Executable doesn't exist";
 const CHROMIUM_MISSING_MESSAGE =
   "Playwright chromium missing; run: bunx playwright install chromium";
+
+type OutputTail = { read: () => string; done: Promise<void> };
+
+const captureOutputTail = (stream: ReadableStream<Uint8Array>): OutputTail => {
+  const decoder = new TextDecoder();
+  let output = "";
+
+  const done = (async () => {
+    try {
+      for await (const chunk of stream) {
+        output = `${output}${decoder.decode(chunk, { stream: true })}`.slice(
+          -SERVER_LOG_TAIL_CHARS,
+        );
+      }
+      output = `${output}${decoder.decode()}`.slice(-SERVER_LOG_TAIL_CHARS);
+    } catch (error) {
+      output = `${output}\n[log capture failed: ${String(error)}]`.slice(-SERVER_LOG_TAIL_CHARS);
+    }
+  })();
+
+  return { read: () => output.trim(), done };
+};
+
+export const formatServerStartFailure = (
+  url: string,
+  timeoutMs: number,
+  exitCode: number | undefined,
+  output: string,
+): string => {
+  const reason =
+    exitCode === undefined
+      ? `did not become ready at ${url} within ${timeoutMs}ms`
+      : `exited with code ${exitCode} before becoming ready at ${url}`;
+  return output.length === 0
+    ? `playground dev server ${reason}`
+    : `playground dev server ${reason}\nPlayground output:\n${output}`;
+};
 
 /** A raw rect as returned by `getBoundingClientRect()` (visual/CSS px). */
 export type RawRect = { left: number; top: number; width: number; height: number };
@@ -387,10 +425,11 @@ const waitForEditorLayout = async (page: Page): Promise<void> => {
   await page.waitForTimeout(STABILITY_SETTLE_MS);
 };
 
-const installCleanScreenshotStyle = async (page: Page): Promise<void> => {
-  await page.addStyleTag({
-    content: `
+export const CLEAN_SCREENSHOT_CSS = `
       .pg-collab-header,
+      .pg-controls,
+      [data-folio-toolbar="true"],
+      [data-testid="playground-controls"],
       [class*="toolbar" i],
       [class*="ruler" i],
       [style*="position: fixed"],
@@ -402,7 +441,11 @@ const installCleanScreenshotStyle = async (page: Page): Promise<void> => {
       .layout-page * {
         visibility: visible !important;
       }
-    `,
+    `;
+
+const installCleanScreenshotStyle = async (page: Page): Promise<void> => {
+  await page.addStyleTag({
+    content: CLEAN_SCREENSHOT_CSS,
   });
 };
 
@@ -858,18 +901,29 @@ export const createFolioExtractor = async (
       cwd: REPO_ROOT,
       env: { ...process.env, FOLIO_PLAYGROUND_PORT: String(PLAYGROUND_PORT) },
       stdin: "ignore",
-      stdout: "ignore",
-      stderr: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    const ready = await waitForServerReady(
-      PLAYGROUND_URL,
-      SERVER_START_TIMEOUT_MS,
-      SERVER_POLL_INTERVAL_MS,
-    );
-    if (!ready) {
+    const stdoutTail = captureOutputTail(serverProcess.stdout);
+    const stderrTail = captureOutputTail(serverProcess.stderr);
+    const startup = await Promise.race([
+      waitForServerReady(PLAYGROUND_URL, SERVER_START_TIMEOUT_MS, SERVER_POLL_INTERVAL_MS).then(
+        (ready) => ({ type: "probe" as const, ready }),
+      ),
+      serverProcess.exited.then((exitCode) => ({ type: "exit" as const, exitCode })),
+    ]);
+    if (startup.type === "exit" || !startup.ready) {
+      if (startup.type === "exit") {
+        await Promise.all([stdoutTail.done, stderrTail.done]);
+      }
       await killByPort(PLAYGROUND_PORT);
       throw new FolioExtractError(
-        `playground dev server did not become ready at ${PLAYGROUND_URL} within ${SERVER_START_TIMEOUT_MS}ms`,
+        formatServerStartFailure(
+          PLAYGROUND_URL,
+          SERVER_START_TIMEOUT_MS,
+          startup.type === "exit" ? startup.exitCode : undefined,
+          [stdoutTail.read(), stderrTail.read()].filter(Boolean).join("\n"),
+        ),
       );
     }
   }

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -119,9 +119,13 @@ const CHROMIUM_MISSING_MESSAGE =
 
 type OutputTail = { read: () => string; done: Promise<void> };
 
-const captureOutputTail = (stream: ReadableStream<Uint8Array>): OutputTail => {
+const captureOutputTail = (stream: ReadableStream<Uint8Array> | null | undefined): OutputTail => {
   const decoder = new TextDecoder();
   let output = "";
+
+  if (!stream) {
+    return { read: () => "", done: Promise.resolve() };
+  }
 
   const done = (async () => {
     try {
@@ -281,13 +285,17 @@ const waitForServerReady = async (
   url: string,
   timeoutMs: number,
   intervalMs: number,
+  signal?: AbortSignal,
 ): Promise<boolean> => {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
+    if (signal?.aborted) {
+      return false;
+    }
     if (await probeServer(url, SERVER_PROBE_TIMEOUT_MS)) {
       return true;
     }
-    if (Date.now() >= deadline) {
+    if (signal?.aborted || Date.now() >= deadline) {
       return false;
     }
     await Bun.sleep(intervalMs);
@@ -906,17 +914,24 @@ export const createFolioExtractor = async (
     });
     const stdoutTail = captureOutputTail(serverProcess.stdout);
     const stderrTail = captureOutputTail(serverProcess.stderr);
+    const startupProbe = new AbortController();
     const startup = await Promise.race([
-      waitForServerReady(PLAYGROUND_URL, SERVER_START_TIMEOUT_MS, SERVER_POLL_INTERVAL_MS).then(
-        (ready) => ({ type: "probe" as const, ready }),
-      ),
+      waitForServerReady(
+        PLAYGROUND_URL,
+        SERVER_START_TIMEOUT_MS,
+        SERVER_POLL_INTERVAL_MS,
+        startupProbe.signal,
+      ).then((ready) => ({ type: "probe" as const, ready })),
       serverProcess.exited.then((exitCode) => ({ type: "exit" as const, exitCode })),
     ]);
+    startupProbe.abort();
     if (startup.type === "exit" || !startup.ready) {
-      if (startup.type === "exit") {
-        await Promise.all([stdoutTail.done, stderrTail.done]);
-      }
+      await killProcessTree(serverProcess.pid);
       await killByPort(PLAYGROUND_PORT);
+      await Promise.race([
+        Promise.all([stdoutTail.done, stderrTail.done]),
+        Bun.sleep(SERVER_PROBE_TIMEOUT_MS),
+      ]);
       throw new FolioExtractError(
         formatServerStartFailure(
           PLAYGROUND_URL,


### PR DESCRIPTION
## Summary
- hide editor and playground chrome that overlaps element screenshots
- capture a bounded tail of playground startup output
- fail immediately when the playground process exits before readiness
- include startup output in parity infrastructure errors

## Verification
- 24 focused parity extraction tests passed
- visually verified clean page-only screenshot output on an anonymized fixture
- `bun audit` reported no vulnerabilities
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica