### PR TITLE
fix: paginate oversized keep-next chains

### DIFF
--- a/.changeset/oversized-keep-next-chain.md
+++ b/.changeset/oversized-keep-next-chain.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Move oversized keep-with-next chains to a fresh page before paginating them naturally.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -564,6 +564,10 @@ describe("Layout Engine - Page Production", () => {
 
       expect(chainStartPage).toBe(1);
       expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
+      const chainPageCount = layout.pages.filter((page) =>
+        page.fragments.some(({ blockId }) => blockId !== 0),
+      ).length;
+      expect(chainPageCount).toBeGreaterThan(1);
     });
   });
 

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -547,6 +547,24 @@ describe("Layout Engine - Page Production", () => {
       expect(headingPage).toBe(1);
       expect(bodyPage).toBe(headingPage);
     });
+
+    test("moves an oversized keepNext chain before paginating it naturally", () => {
+      const blocks: FlowBlock[] = [makeParagraphBlock(0, "Filler", 0)];
+      const measures: Measure[] = [makeParagraphMeasure([makeLine(0, 0, 0, 6, 80, 400)])];
+
+      for (let id = 1; id <= 6; id++) {
+        blocks.push(makeParagraphBlock(id, `Chain ${id}`, id * 10, { keepNext: id < 6 }));
+        measures.push(makeParagraphMeasure([makeLine(0, 0, 0, 7, 80, 200)]));
+      }
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+      const chainStartPage = layout.pages.findIndex((page) =>
+        page.fragments.some(({ blockId }) => blockId === 1),
+      );
+
+      expect(chainStartPage).toBe(1);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
+    });
   });
 
   describe("margin and positioning", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -342,17 +342,10 @@ export function layoutDocument(
       const chainHeight = calculateChainHeight(chain, blocks, measures);
       const state = paginator.getCurrentState();
       const availableHeight = paginator.getAvailableHeight();
-      const pageContentHeight = state.contentBottom - state.topMargin;
-
-      // Only move to new page if:
-      // 1. Chain fits on a blank page (avoid infinite loop for oversized chains)
-      // 2. Chain doesn't fit in current available space
-      // 3. Current page already has content
-      if (
-        chainHeight <= pageContentHeight &&
-        chainHeight > availableHeight &&
-        state.page.fragments.length > 0
-      ) {
+      // Word moves an oversized keepNext chain to a fresh page, then paginates
+      // the chain naturally. The populated-page guard prevents an extra blank
+      // page when the chain still cannot fit in a single page.
+      if (chainHeight > availableHeight && state.page.fragments.length > 0) {
         paginator.forcePageBreak();
       }
     }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -340,14 +340,7 @@ export function layoutDocument(
     const chain = keepNextChains.get(i);
     if (chain && !midChainIndices.has(i)) {
       const chainHeight = calculateChainHeight(chain, blocks, measures);
-      const state = paginator.getCurrentState();
-      const availableHeight = paginator.getAvailableHeight();
-      // Word moves an oversized keepNext chain to a fresh page, then paginates
-      // the chain naturally. The populated-page guard prevents an extra blank
-      // page when the chain still cannot fit in a single page.
-      if (chainHeight > availableHeight && state.page.fragments.length > 0) {
-        paginator.forcePageBreak();
-      }
+      paginator.ensureFits(chainHeight);
     }
 
     switch (block.kind) {


### PR DESCRIPTION
## Summary
- move an oversized keep-with-next chain to a fresh page when it cannot fit the current remainder
- paginate the oversized chain naturally from that fresh page
- retain the populated-page guard that prevents blank-page loops
- add a focused integration regression and core patch changeset

## Anonymized parity evidence
- score: 0.2917 → 0.7562
- pages: Word 12; Folio 11 → 12
- pagination findings: 281 → 10
- total findings: 464 → 206

## Verification
- 47 focused layout integration tests passed
- `bun audit` reported no vulnerabilities
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination for oversized “keep together” content chains.
  - Chains that cannot fit in the remaining space now move to the next page instead of being split unexpectedly.
  - Prevented unnecessary blank pages while preserving the intended sequence of connected content.

- **Tests**
  - Added coverage for oversized keep-together chains to verify correct page placement during natural pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->