### PR TITLE
feat: expose version comparison from core

### DIFF
--- a/.changeset/tidy-version-comparison.md
+++ b/.changeset/tidy-version-comparison.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": patch
+---
+
+Expose document version comparison from folio-core while preserving the agents API.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -11,6 +11,7 @@ import { FolioAIEditApplyResult } from '@stll/folio-core/server';
 import { FolioAIEditOperation } from '@stll/folio-core/server';
 import { FolioAIEditSnapshot } from '@stll/folio-core/server';
 import { FolioAITextRangeHandle } from '@stll/folio-core/server';
+import { FolioBlockDiff } from '@stll/folio-core/server';
 import { FolioCommentAnchor } from '@stll/folio-core/ai-edits';
 import { FolioDocumentOperationBatch } from '@stll/folio-core/server';
 import { FolioDocumentOperationIssue } from '@stll/folio-core/server';
@@ -19,7 +20,8 @@ import { FolioDocumentStory } from '@stll/folio-core/server';
 import { FolioDocumentStoryHandle } from '@stll/folio-core/server';
 import { FolioDocxReviewer } from '@stll/folio-core/server';
 import { FolioReviewChange } from '@stll/folio-core/ai-edits';
-import { WordDiffSegment } from '@stll/folio-core/ai-edits';
+import { FolioVersionDiff } from '@stll/folio-core/server';
+import { FolioVersionDiffSegment } from '@stll/folio-core/server';
 
 // @public
 export type AnthropicToolDefinition = {
@@ -95,22 +97,7 @@ export type FolioAgentBlock = {
 };
 
 // @public
-export type FolioAgentBlockDiff = {
-    type: "added";
-    blockId: string;
-    kind: string;
-    text: string;
-} | {
-    type: "deleted";
-    blockId: string;
-    kind: string;
-    text: string;
-} | {
-    type: "modified";
-    blockId: string;
-    kind: string;
-    segments: FolioAgentVersionDiffSegment[];
-};
+export type FolioAgentBlockDiff = FolioBlockDiff;
 
 // @public
 export type FolioAgentBridge = {
@@ -202,18 +189,10 @@ export type FolioAgentToolDefinition = {
 export type FolioAgentToolName = (typeof FOLIO_AGENT_TOOL_NAMES)[keyof typeof FOLIO_AGENT_TOOL_NAMES];
 
 // @public
-export type FolioAgentVersionDiff = {
-    changes: FolioAgentBlockDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. */
-    summaryCounts: {
-        added: number;
-        deleted: number;
-        modified: number;
-        unchanged: number;
-    };
-};
+export type FolioAgentVersionDiff = FolioVersionDiff;
 
 // @public
-export type FolioAgentVersionDiffSegment = WordDiffSegment;
+export type FolioAgentVersionDiffSegment = FolioVersionDiffSegment;
 
 // @public
 export type FolioToolCallResult = {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -25,6 +25,9 @@ export type ApplyFolioAIEditsToBufferResult = FolioAIEditApplyResult & {
 // @public (undocumented)
 export const assertSupportedFolioDocumentOperationVersion: (value: unknown) => typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
 
+// @public
+export const compareDocxVersions: (base: ArrayBuffer, revised: ArrayBuffer) => Promise<FolioVersionDiff>;
+
 // @public (undocumented)
 export type CreateCommentReplyInput = {
     author: string;
@@ -247,6 +250,24 @@ export type FolioApplyOperationsOptions = {
 };
 
 // @public
+export type FolioBlockDiff = {
+    type: "added";
+    blockId: string;
+    kind: string;
+    text: string;
+} | {
+    type: "deleted";
+    blockId: string;
+    kind: string;
+    text: string;
+} | {
+    type: "modified";
+    blockId: string;
+    kind: string;
+    segments: FolioVersionDiffSegment[];
+};
+
+// @public
 export type FolioBlockId = string & {
     readonly __brand: "folio.blockId";
 };
@@ -409,6 +430,20 @@ export type FolioReviewReplyInput = {
     author?: string;
     initials?: string;
 };
+
+// @public
+export type FolioVersionDiff = {
+    changes: FolioBlockDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. */
+    summaryCounts: {
+        added: number;
+        deleted: number;
+        modified: number;
+        unchanged: number;
+    };
+};
+
+// @public
+export type FolioVersionDiffSegment = WordDiffSegment;
 
 // @public (undocumented)
 export const getFolioDocumentOperationCapabilities: () => FolioDocumentOperationCapabilities;

--- a/packages/agents/src/compare.test.ts
+++ b/packages/agents/src/compare.test.ts
@@ -1,246 +1,43 @@
-/**
- * Version-diff engine tests: real-paraId alignment, the deterministic-fallback-id
- * regression guard (same text, shifted ordinal must still pair as unchanged via
- * the text-LCS pass), identical-buffer no-op, the LLM text format, and the
- * as-accepted semantics over a revised document that carries pending tracked
- * changes.
- *
- * Buffers are built directly from the typed `Document` model (`createEmptyDocument`
- * as a template, `createDocx` to serialize) rather than a fixture file, since each
- * case needs precise control over paragraph text/paraId and no existing corpus
- * fixture has more than two named paragraphs.
- */
-
 import { describe, expect, test } from "bun:test";
 
-import { createDocx, createEmptyDocument, FolioDocxReviewer } from "@stll/folio-core/server";
-
-import { compareDocxVersions, exceedsLcsBudget, formatVersionDiffForLLM } from "./compare";
-import type { FolioAgentBlockDiff } from "./compare";
-
-type ParagraphSpec = { text: string; paraId?: string };
-
-const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuffer> => {
-  const template = createEmptyDocument();
-  return createDocx({
-    ...template,
-    package: {
-      ...template.package,
-      document: {
-        ...template.package.document,
-        content: paragraphs.map(({ text, paraId }) => ({
-          type: "paragraph",
-          content: [{ type: "run", content: [{ type: "text", text }] }],
-          ...(paraId !== undefined && { paraId }),
-        })),
-      },
-    },
-  });
-};
-
-const findChange = (
-  changes: readonly FolioAgentBlockDiff[],
-  blockId: string,
-): FolioAgentBlockDiff => {
-  const change = changes.find((c) => c.blockId === blockId);
-  if (!change) {
-    throw new Error(`no change for block ${blockId}`);
-  }
-  return change;
-};
-
-describe("compareDocxVersions: real w14:paraId alignment", () => {
-  test("classifies unchanged, modified, added, and deleted blocks by stable id", async () => {
-    const base = await buildDocxBuffer([
-      { text: "Alpha paragraph.", paraId: "00000001" },
-      { text: "Beta paragraph.", paraId: "00000002" },
-      { text: "Gamma paragraph.", paraId: "00000003" },
-      { text: "Zeta paragraph.", paraId: "00000005" },
-    ]);
-    const revised = await buildDocxBuffer([
-      { text: "Alpha paragraph.", paraId: "00000001" },
-      { text: "Beta clause.", paraId: "00000002" },
-      { text: "Zeta paragraph.", paraId: "00000005" },
-      { text: "Epsilon paragraph.", paraId: "00000006" },
-    ]);
-
-    const diff = await compareDocxVersions(base, revised);
-
-    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 1, modified: 1, unchanged: 2 });
-    // Unchanged blocks (Alpha, Zeta) never appear in `changes`.
-    expect(diff.changes).toHaveLength(3);
-    expect(diff.changes.map((c) => c.type)).toEqual(["modified", "deleted", "added"]);
-
-    const modified = findChange(diff.changes, "00000002");
-    if (modified.type !== "modified") {
-      throw new Error("expected a modified change");
-    }
-    expect(modified.kind).toBe("paragraph");
-    expect(modified.segments).toEqual([
-      { type: "equal", text: "Beta " },
-      { type: "del", text: "paragraph." },
-      { type: "ins", text: "clause." },
-    ]);
-
-    const deleted = findChange(diff.changes, "00000003");
-    expect(deleted).toEqual({
-      type: "deleted",
-      blockId: "00000003",
-      kind: "paragraph",
-      text: "Gamma paragraph.",
-    });
-
-    const added = findChange(diff.changes, "00000006");
-    expect(added).toEqual({
-      type: "added",
-      blockId: "00000006",
-      kind: "paragraph",
-      text: "Epsilon paragraph.",
-    });
-  });
-});
-
-describe("compareDocxVersions: deterministic fallback ids (no w14:paraId)", () => {
-  test("a same-text block whose ordinal shifted still pairs as unchanged via the text-LCS pass", async () => {
-    // Neither buffer carries a w14:paraId, so FolioDocxReviewer assigns each
-    // block a deterministic fallback id derived from hash(text + ordinal). The
-    // "Epsilon" paragraph inserted before "Gamma" shifts Gamma's ordinal (3rd
-    // -> 4th), which changes its fallback id even though its text is
-    // untouched. Pass 1 (stable-id pairing) therefore CANNOT pair Gamma across
-    // versions; only the text-LCS pass (pass 2) recovers it as unchanged. This
-    // is the regression guard for the deterministic-id pitfall.
-    const base = await buildDocxBuffer([
-      { text: "Alpha paragraph." },
-      { text: "Beta paragraph." },
-      { text: "Gamma paragraph." },
-    ]);
-    const revised = await buildDocxBuffer([
-      { text: "Alpha paragraph." },
-      { text: "Beta paragraph modified." },
-      { text: "Epsilon paragraph." },
-      { text: "Gamma paragraph." },
-    ]);
-
-    const diff = await compareDocxVersions(base, revised);
-
-    // Alpha (unshifted, same fallback id both sides) and Gamma (shifted,
-    // recovered via text-LCS) are both unchanged and absent from `changes`.
-    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 0, modified: 1, unchanged: 2 });
-    expect(diff.changes.map((c) => c.type)).toEqual(["modified", "added"]);
-
-    const modified = diff.changes[0];
-    if (!modified || modified.type !== "modified") {
-      throw new Error("expected a modified change");
-    }
-    // Reconstruct the revised text from the `equal` + `ins` segments (the
-    // `del` segments carry the superseded base-side text, not part of either
-    // whole string on their own).
-    const reconstructedRevised = modified.segments
-      .filter((s) => s.type !== "del")
-      .map((s) => s.text)
-      .join("");
-    expect(reconstructedRevised).toBe("Beta paragraph modified.");
-
-    const added = diff.changes[1];
-    if (!added || added.type !== "added") {
-      throw new Error("expected an added change");
-    }
-    expect(added.text).toBe("Epsilon paragraph.");
-  });
-});
-
-describe("compareDocxVersions: no-op", () => {
-  test("identical documents produce zero changes and every block counts as unchanged", async () => {
-    const paragraphs: ParagraphSpec[] = [{ text: "Alpha paragraph." }, { text: "Beta paragraph." }];
-    const base = await buildDocxBuffer(paragraphs);
-    const revised = await buildDocxBuffer(paragraphs);
-
-    const diff = await compareDocxVersions(base, revised);
-
-    expect(diff.changes).toEqual([]);
-    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 0, unchanged: 2 });
-  });
-});
+import type { FolioAgentVersionDiff } from "./compare";
+import { formatVersionDiffForLLM } from "./compare";
 
 describe("formatVersionDiffForLLM", () => {
-  test("renders a stable header + one line per change, using word-diff porcelain markers", async () => {
-    const base = await buildDocxBuffer([
-      { text: "Alpha paragraph.", paraId: "00000001" },
-      { text: "Beta paragraph.", paraId: "00000002" },
-      { text: "Gamma paragraph.", paraId: "00000003" },
-      { text: "Zeta paragraph.", paraId: "00000005" },
+  test("renders summary counts and word-diff markers", () => {
+    const diff: FolioAgentVersionDiff = {
+      summaryCounts: { added: 1, deleted: 1, modified: 1, unchanged: 2 },
+      changes: [
+        {
+          type: "modified",
+          blockId: "00000002",
+          kind: "paragraph",
+          segments: [
+            { type: "equal", text: "Beta " },
+            { type: "del", text: "paragraph." },
+            { type: "ins", text: "clause." },
+          ],
+        },
+        {
+          type: "deleted",
+          blockId: "00000003",
+          kind: "paragraph",
+          text: "Gamma paragraph.",
+        },
+        {
+          type: "added",
+          blockId: "00000006",
+          kind: "paragraph",
+          text: "Epsilon paragraph.",
+        },
+      ],
+    };
+
+    expect(formatVersionDiffForLLM(diff).split("\n")).toEqual([
+      "Version diff: 1 added, 1 deleted, 1 modified, 2 unchanged",
+      "~ [00000002] modified: Beta [-paragraph.-]{+clause.+}",
+      "- [00000003] deleted: Gamma paragraph.",
+      "+ [00000006] added: Epsilon paragraph.",
     ]);
-    const revised = await buildDocxBuffer([
-      { text: "Alpha paragraph.", paraId: "00000001" },
-      { text: "Beta clause.", paraId: "00000002" },
-      { text: "Zeta paragraph.", paraId: "00000005" },
-      { text: "Epsilon paragraph.", paraId: "00000006" },
-    ]);
-
-    const diff = await compareDocxVersions(base, revised);
-    const formatted = formatVersionDiffForLLM(diff);
-    const lines = formatted.split("\n");
-
-    expect(lines[0]).toBe("Version diff: 1 added, 1 deleted, 1 modified, 2 unchanged");
-    expect(lines).toContain("~ [00000002] modified: Beta [-paragraph.-]{+clause.+}");
-    expect(lines).toContain("- [00000003] deleted: Gamma paragraph.");
-    expect(lines).toContain("+ [00000006] added: Epsilon paragraph.");
-  });
-});
-
-describe("exceedsLcsBudget: pass 2's LCS cell-budget guard", () => {
-  test("flags unpaired-block counts whose product would exceed the LCS cell budget (4,000,000)", () => {
-    // A degenerate/adversarial document with no w14:paraIds can leave
-    // thousands of blocks unpaired on both sides; this guard is what stops
-    // pairByExactText from allocating an O(m*n) table for it. Exercise the
-    // predicate directly rather than constructing a multi-million-block
-    // fixture, which would make this test slow for no extra coverage.
-    expect(exceedsLcsBudget(2000, 2000)).toBe(false); // exactly at budget: 4,000,000 cells
-    expect(exceedsLcsBudget(2001, 2001)).toBe(true); // just over budget: 4,004,001 cells
-  });
-});
-
-describe("compareDocxVersions: as-accepted semantics", () => {
-  test("a pending tracked insertion in the revised document counts as already applied", async () => {
-    const base = await buildDocxBuffer([{ text: "Payment is due." }]);
-
-    // Build the revised buffer by applying a tracked-changes (default mode)
-    // replace against a fresh reviewer over `base` — the revised buffer still
-    // carries real w:ins/w:del marks on disk.
-    const revisedReviewer = await FolioDocxReviewer.fromBuffer(base, { author: "AI" });
-    const target = revisedReviewer.snapshot().blocks[0];
-    if (!target) {
-      throw new Error("expected a block in the base document");
-    }
-    revisedReviewer.applyOperations([
-      {
-        id: "t1",
-        type: "replaceInBlock",
-        blockId: target.id,
-        find: "due.",
-        replace: "due promptly.",
-      },
-    ]);
-    const revised = await revisedReviewer.toBuffer();
-
-    // Sanity: the revised snapshot's clean text is already the accepted view.
-    expect(revisedReviewer.snapshot().blocks[0]?.text).toBe("Payment is due promptly.");
-
-    const diff = await compareDocxVersions(base, revised);
-
-    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 1, unchanged: 0 });
-    const [change] = diff.changes;
-    if (!change || change.type !== "modified") {
-      throw new Error("expected a single modified change");
-    }
-    // The diff runs over the as-accepted text: reconstructing the revised
-    // side from `equal` + `ins` segments reproduces the clean accepted
-    // string, not raw tracked-change markup.
-    const reconstructedRevised = change.segments
-      .filter((s) => s.type !== "del")
-      .map((s) => s.text)
-      .join("");
-    expect(reconstructedRevised).toBe("Payment is due promptly.");
-    expect(change.segments.some((s) => s.type === "ins" && s.text.includes("promptly"))).toBe(true);
   });
 });

--- a/packages/agents/src/compare.ts
+++ b/packages/agents/src/compare.ts
@@ -1,232 +1,28 @@
-/**
- * Document version-diff engine: compare two `.docx` buffers block by block
- * and produce a structured, LLM-summarizable diff.
- *
- * Both buffers are parsed through {@link FolioDocxReviewer} — the same
- * headless parsing + clean-text path `read_document` / `read_changes` use —
- * so the comparison runs over each document's AS-ACCEPTED view: any pending
- * tracked changes already present in EITHER buffer count as applied before
- * the two are compared. Two documents that agree once their own pending
- * redlines are accepted report as unchanged, even if the underlying
- * tracked-change history differs.
- *
- * ## Alignment
- *
- * Blocks are paired across the two snapshots in three passes, each only
- * considering blocks the previous pass left unpaired:
- *
- * 1. **Stable-id pairing.** Blocks whose ids are equal AND not a `seq-NNNN`
- *    positional fallback ({@link getFolioParaIdFromBlockId} returns non-null)
- *    are paired directly. This covers both id shapes a snapshot can carry:
- *    - A real Word `w14:paraId`: stable identity, independent of text — an
- *      equal-id pair with different text is a genuine edit (`modified`).
- *    - `FolioDocxReviewer`'s deterministic fallback id (assigned when the
- *      source paragraph has no `w14:paraId`), which hashes the paragraph's
- *      TEXT plus its document ordinal. It is structurally indistinguishable
- *      from a real paraId ({@link getFolioParaIdFromBlockId} can't tell them
- *      apart), but pairing on equality is still safe: two equal deterministic
- *      ids necessarily came from identical text at an identical ordinal, so
- *      the pair is always text-equal (`unchanged`) — never a false
- *      `modified`. What it can't do is FIND a paragraph whose ordinal shifted
- *      (an insertion/deletion earlier in the document) even though its text
- *      is unchanged: that pair has two different fallback ids and falls
- *      through to pass 2.
- * 2. **Exact-text pairing.** An order-preserving LCS over remaining blocks,
- *    matched by exact text equality. This is what recovers same-text blocks
- *    that pass 1 missed because a fallback id shifted with the ordinal. Its
- *    O(m·n) table is skipped ({@link exceedsLcsBudget}) once the unpaired
- *    counts on both sides would exceed a fixed cell budget, so a document
- *    with few/no stable ids can't force a quadratic-sized allocation; those
- *    blocks fall through to pass 3 instead.
- * 3. **Positional fallback.** Whatever a monotonicity filter leaves
- *    unpaired is split into the gaps between anchored pairs (pass 1 + 2,
- *    time-ordered); within each gap the shorter side is zipped positionally
- *    against the longer one (`modified`), and any excess on either side is
- *    reported as `added` / `deleted`.
- *
- * The combined anchor set from passes 1 and 2 is re-filtered to the longest
- * increasing subsequence by revised-side index before pass 3 runs, so a
- * pathological crossing match (content reordered across versions) can't
- * produce an out-of-order gap — the alignment always walks both documents
- * forward.
- */
+import type {
+  FolioBlockDiff,
+  FolioVersionDiff,
+  FolioVersionDiffSegment,
+} from "@stll/folio-core/server";
+import { compareDocxVersions as compareDocxVersionsCore } from "@stll/folio-core/server";
 
-import { diffWordSegments } from "@stll/folio-core/ai-edits";
-import type { WordDiffSegment } from "@stll/folio-core/ai-edits";
-import { FolioDocxReviewer, getFolioParaIdFromBlockId } from "@stll/folio-core/server";
-import type { FolioAIBlock } from "@stll/folio-core/server";
+/** Backward-compatible name for a core word-level version-diff segment. */
+export type FolioAgentVersionDiffSegment = FolioVersionDiffSegment;
 
-/** One word-level diff segment within a `modified` block. Mirrors {@link WordDiffSegment}. */
-export type FolioAgentVersionDiffSegment = WordDiffSegment;
+/** Backward-compatible name for a core block-level version diff. */
+export type FolioAgentBlockDiff = FolioBlockDiff;
 
-/** One block-level change between two document versions, in revised-side document order. */
-export type FolioAgentBlockDiff =
-  | { type: "added"; blockId: string; kind: string; text: string }
-  | { type: "deleted"; blockId: string; kind: string; text: string }
-  | { type: "modified"; blockId: string; kind: string; segments: FolioAgentVersionDiffSegment[] };
+/** Backward-compatible name for a structured core version diff. */
+export type FolioAgentVersionDiff = FolioVersionDiff;
 
-/** Result of {@link compareDocxVersions}. */
-export type FolioAgentVersionDiff = {
-  /** Every added, deleted, or modified block, in revised-side document order (deletions slotted where they sat). */
-  changes: FolioAgentBlockDiff[];
-  /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. */
-  summaryCounts: { added: number; deleted: number; modified: number; unchanged: number };
-};
-
-type BlockPair = { baseIndex: number; revisedIndex: number };
-type IndexedBlock = { block: FolioAIBlock; index: number };
-
-const isStableBlockId = (id: string): boolean => getFolioParaIdFromBlockId(id) !== null;
-
-const index = (blocks: readonly FolioAIBlock[]): IndexedBlock[] =>
-  blocks.map((block, blockIndex) => ({ block, index: blockIndex }));
-
-/**
- * Longest increasing subsequence by `revisedIndex`, assuming `pairs` is
- * already sorted by `baseIndex` ascending. Drops any pair that would make
- * the alignment walk backward in the revised document — the guard against
- * both id collisions (pass 1) and any crossing match (pass 1 + 2 combined).
- */
-const longestIncreasingByRevisedIndex = (pairs: readonly BlockPair[]): BlockPair[] => {
-  if (pairs.length === 0) {
-    return [];
-  }
-  const lengths = Array.from<number>({ length: pairs.length }).fill(1);
-  const predecessors = Array.from<number>({ length: pairs.length }).fill(-1);
-  let bestEnd = 0;
-  for (let i = 0; i < pairs.length; i++) {
-    for (let j = 0; j < i; j++) {
-      const current = pairs[j];
-      const candidate = pairs[i];
-      if (!current || !candidate) {
-        continue;
-      }
-      if (
-        current.revisedIndex < candidate.revisedIndex &&
-        (lengths[j] ?? 0) + 1 > (lengths[i] ?? 0)
-      ) {
-        lengths[i] = (lengths[j] ?? 0) + 1;
-        predecessors[i] = j;
-      }
-    }
-    if ((lengths[i] ?? 0) > (lengths[bestEnd] ?? 0)) {
-      bestEnd = i;
-    }
-  }
-  const ordered: BlockPair[] = [];
-  for (let cursor = bestEnd; cursor !== -1; cursor = predecessors[cursor] ?? -1) {
-    const pair = pairs[cursor];
-    if (pair) {
-      ordered.push(pair);
-    }
-  }
-  return ordered.toReversed();
-};
-
-/** Pass 1: pair blocks with equal, non-`seq-NNNN` ids. See the module doc comment. */
-const pairByStableId = (
-  base: readonly FolioAIBlock[],
-  revised: readonly FolioAIBlock[],
-): BlockPair[] => {
-  const revisedIndexById = new Map<string, number>();
-  revised.forEach((block, revisedIndex) => {
-    if (isStableBlockId(block.id)) {
-      revisedIndexById.set(block.id, revisedIndex);
-    }
-  });
-
-  const candidates: BlockPair[] = [];
-  base.forEach((block, baseIndex) => {
-    if (!isStableBlockId(block.id)) {
-      return;
-    }
-    const revisedIndex = revisedIndexById.get(block.id);
-    if (revisedIndex !== undefined) {
-      candidates.push({ baseIndex, revisedIndex });
-    }
-  });
-  return longestIncreasingByRevisedIndex(candidates);
-};
-
-/**
- * Cell budget for pass 2's O(m·n) exact-text LCS table (`dp` below allocates
- * `(m + 1) * (n + 1)` numbers). A document with no `w14:paraId`s — or an
- * adversarial one crafted to defeat pass 1 — can leave thousands of blocks
- * unpaired on both sides; without a cap, `pairByExactText` would allocate a
- * quadratic-sized table for it. Past this budget, {@link exceedsLcsBudget}
- * makes pass 2 back off entirely so alignment falls through to pass 3's
- * linear positional zip instead — pairing is less precise for these
- * degenerate inputs, but memory use stays bounded.
- */
-const MAX_LCS_CELLS = 4_000_000;
-
-/** True when an `unpairedBaseCount * unpairedRevisedCount` LCS table would exceed {@link MAX_LCS_CELLS}. */
-export const exceedsLcsBudget = (
-  unpairedBaseCount: number,
-  unpairedRevisedCount: number,
-): boolean => unpairedBaseCount * unpairedRevisedCount > MAX_LCS_CELLS;
-
-/** Pass 2: order-preserving LCS by exact text equality over the blocks pass 1 left unpaired. */
-const pairByExactText = (
-  base: readonly IndexedBlock[],
-  revised: readonly IndexedBlock[],
-): BlockPair[] => {
-  const m = base.length;
-  const n = revised.length;
-  if (m === 0 || n === 0) {
-    return [];
-  }
-  if (exceedsLcsBudget(m, n)) {
-    return [];
-  }
-  // A single flat Int32Array (indexed `i * (n + 1) + j`) instead of `m + 1`
-  // separately-allocated rows: one contiguous allocation instead of thousands
-  // of small ones, which matters once `m` and `n` approach the budget above.
-  const stride = n + 1;
-  const dp = new Int32Array((m + 1) * stride);
-  for (let i = m - 1; i >= 0; i--) {
-    const rowOffset = i * stride;
-    const nextRowOffset = (i + 1) * stride;
-    for (let j = n - 1; j >= 0; j--) {
-      const baseText = base[i]?.block.text;
-      const revisedText = revised[j]?.block.text;
-      dp[rowOffset + j] =
-        baseText === revisedText
-          ? (dp[nextRowOffset + j + 1] ?? 0) + 1
-          : Math.max(dp[nextRowOffset + j] ?? 0, dp[rowOffset + j + 1] ?? 0);
-    }
-  }
-
-  const pairs: BlockPair[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < m && j < n) {
-    const baseEntry = base[i];
-    const revisedEntry = revised[j];
-    if (!baseEntry || !revisedEntry) {
-      break;
-    }
-    if (baseEntry.block.text === revisedEntry.block.text) {
-      pairs.push({ baseIndex: baseEntry.index, revisedIndex: revisedEntry.index });
-      i++;
-      j++;
-      continue;
-    }
-    const down = dp[(i + 1) * stride + j] ?? 0;
-    const right = dp[i * stride + j + 1] ?? 0;
-    if (down >= right) {
-      i++;
-    } else {
-      j++;
-    }
-  }
-  return pairs;
-};
+/** Compare two `.docx` buffers using folio-core's version comparison semantics. */
+export const compareDocxVersions = (
+  base: ArrayBuffer,
+  revised: ArrayBuffer,
+): Promise<FolioAgentVersionDiff> => compareDocxVersionsCore(base, revised);
 
 const ELLIPSIS = "…";
 const UNCHANGED_EDGE_CHARS = 30;
 
-/** Collapse a long `equal`-type run to ~30 chars on each side with an ellipsis in between. */
 const truncateUnchangedRun = (text: string): string => {
   if (text.length <= UNCHANGED_EDGE_CHARS * 2 + ELLIPSIS.length) {
     return text;
@@ -234,8 +30,7 @@ const truncateUnchangedRun = (text: string): string => {
   return `${text.slice(0, UNCHANGED_EDGE_CHARS)}${ELLIPSIS}${text.slice(-UNCHANGED_EDGE_CHARS)}`;
 };
 
-/** Render one word-diff segment: plain for `equal` (truncated if long), bracketed for `del` / `ins`. */
-const renderSegment = (segment: FolioAgentVersionDiffSegment): string => {
+const renderSegment = (segment: FolioVersionDiffSegment): string => {
   switch (segment.type) {
     case "equal":
       return truncateUnchangedRun(segment.text);
@@ -248,7 +43,7 @@ const renderSegment = (segment: FolioAgentVersionDiffSegment): string => {
   }
 };
 
-const formatChangeLine = (change: FolioAgentBlockDiff): string => {
+const formatChangeLine = (change: FolioBlockDiff): string => {
   if (change.type === "added") {
     return `+ [${change.blockId}] added: ${change.text}`;
   }
@@ -258,135 +53,7 @@ const formatChangeLine = (change: FolioAgentBlockDiff): string => {
   return `~ [${change.blockId}] modified: ${change.segments.map(renderSegment).join("")}`;
 };
 
-/**
- * Compare two `.docx` buffers and return a structured, block-level diff.
- * See the module doc comment for the as-accepted comparison semantics and
- * the three-pass alignment algorithm.
- */
-export const compareDocxVersions = async (
-  base: ArrayBuffer,
-  revised: ArrayBuffer,
-): Promise<FolioAgentVersionDiff> => {
-  const [baseReviewer, revisedReviewer] = await Promise.all([
-    FolioDocxReviewer.fromBuffer(base),
-    FolioDocxReviewer.fromBuffer(revised),
-  ]);
-  const baseBlocks = baseReviewer.snapshot().blocks;
-  const revisedBlocks = revisedReviewer.snapshot().blocks;
-
-  const stableIdAnchors = pairByStableId(baseBlocks, revisedBlocks);
-  const usedBaseIndexes = new Set(stableIdAnchors.map((anchor) => anchor.baseIndex));
-  const usedRevisedIndexes = new Set(stableIdAnchors.map((anchor) => anchor.revisedIndex));
-
-  const baseRemaining = index(baseBlocks).filter(({ index: i }) => !usedBaseIndexes.has(i));
-  const revisedRemaining = index(revisedBlocks).filter(
-    ({ index: i }) => !usedRevisedIndexes.has(i),
-  );
-  const exactTextAnchors = pairByExactText(baseRemaining, revisedRemaining);
-
-  const anchors = longestIncreasingByRevisedIndex(
-    [...stableIdAnchors, ...exactTextAnchors].toSorted((a, b) => a.baseIndex - b.baseIndex),
-  );
-
-  const changes: FolioAgentBlockDiff[] = [];
-  const counts = { added: 0, deleted: 0, modified: 0, unchanged: 0 };
-
-  /** Pass 3: positionally zip the leftover blocks in one gap between anchors. */
-  const emitGap = (
-    baseFrom: number,
-    baseTo: number,
-    revisedFrom: number,
-    revisedTo: number,
-  ): void => {
-    const baseSlice = baseBlocks.slice(baseFrom, baseTo);
-    const revisedSlice = revisedBlocks.slice(revisedFrom, revisedTo);
-    const pairedCount = Math.min(baseSlice.length, revisedSlice.length);
-
-    for (let k = 0; k < pairedCount; k++) {
-      const baseBlock = baseSlice[k];
-      const revisedBlock = revisedSlice[k];
-      if (!baseBlock || !revisedBlock) {
-        continue;
-      }
-      if (baseBlock.text === revisedBlock.text) {
-        counts.unchanged++;
-        continue;
-      }
-      counts.modified++;
-      changes.push({
-        type: "modified",
-        blockId: revisedBlock.id,
-        kind: revisedBlock.kind,
-        segments: diffWordSegments(baseBlock.text, revisedBlock.text),
-      });
-    }
-    for (let k = pairedCount; k < baseSlice.length; k++) {
-      const baseBlock = baseSlice[k];
-      if (!baseBlock) {
-        continue;
-      }
-      counts.deleted++;
-      changes.push({
-        type: "deleted",
-        blockId: baseBlock.id,
-        kind: baseBlock.kind,
-        text: baseBlock.text,
-      });
-    }
-    for (let k = pairedCount; k < revisedSlice.length; k++) {
-      const revisedBlock = revisedSlice[k];
-      if (!revisedBlock) {
-        continue;
-      }
-      counts.added++;
-      changes.push({
-        type: "added",
-        blockId: revisedBlock.id,
-        kind: revisedBlock.kind,
-        text: revisedBlock.text,
-      });
-    }
-  };
-
-  let baseCursor = 0;
-  let revisedCursor = 0;
-  for (const anchor of anchors) {
-    emitGap(baseCursor, anchor.baseIndex, revisedCursor, anchor.revisedIndex);
-
-    const baseBlock = baseBlocks[anchor.baseIndex];
-    const revisedBlock = revisedBlocks[anchor.revisedIndex];
-    if (baseBlock && revisedBlock) {
-      if (baseBlock.text === revisedBlock.text) {
-        counts.unchanged++;
-      } else {
-        counts.modified++;
-        changes.push({
-          type: "modified",
-          blockId: revisedBlock.id,
-          kind: revisedBlock.kind,
-          segments: diffWordSegments(baseBlock.text, revisedBlock.text),
-        });
-      }
-    }
-
-    baseCursor = anchor.baseIndex + 1;
-    revisedCursor = anchor.revisedIndex + 1;
-  }
-  emitGap(baseCursor, baseBlocks.length, revisedCursor, revisedBlocks.length);
-
-  return { changes, summaryCounts: counts };
-};
-
-/**
- * Render a {@link FolioAgentVersionDiff} as compact, deterministic text for a
- * model prompt: a header line with the summary counts, then one line per
- * change — `~ [blockId] modified: …`, `+ [blockId] added: …`,
- * `- [blockId] deleted: …`. A modified block's segments render inline using
- * `git diff --word-diff` porcelain conventions (`[-removed-]`, `{+added+}`,
- * plain text for unchanged runs, truncated to ~30 characters on each side
- * when long). The format is stable across calls — do not change it without
- * checking `compare.test.ts`.
- */
+/** Render a structured version diff as compact, deterministic model input. */
 export const formatVersionDiffForLLM = (diff: FolioAgentVersionDiff): string => {
   const { added, deleted, modified, unchanged } = diff.summaryCounts;
   const header = `Version diff: ${added} added, ${deleted} deleted, ${modified} modified, ${unchanged} unchanged`;

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -48,6 +48,12 @@ export {
   type FolioReviewCommentReply,
   type FolioReviewReplyInput,
 } from "./ai-edits/headless";
+export {
+  compareDocxVersions,
+  type FolioBlockDiff,
+  type FolioVersionDiff,
+  type FolioVersionDiffSegment,
+} from "./version-comparison";
 export type {
   FolioAIComment,
   FolioAIEditApplyMode,

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -179,7 +179,7 @@ describe("compareDocxVersions: as-accepted semantics", () => {
     // replace against a fresh reviewer over `base` — the revised buffer still
     // carries real w:ins/w:del marks on disk.
     const revisedReviewer = await FolioDocxReviewer.fromBuffer(base, { author: "AI" });
-    const target = revisedReviewer.snapshot().blocks[0];
+    const target = revisedReviewer.snapshot().blocks.at(0);
     if (!target) {
       throw new Error("expected a block in the base document");
     }
@@ -195,7 +195,7 @@ describe("compareDocxVersions: as-accepted semantics", () => {
     const revised = await revisedReviewer.toBuffer();
 
     // Sanity: the revised snapshot's clean text is already the accepted view.
-    expect(revisedReviewer.snapshot().blocks[0]?.text).toBe("Payment is due promptly.");
+    expect(revisedReviewer.snapshot().blocks.at(0)?.text).toBe("Payment is due promptly.");
 
     const diff = await compareDocxVersions(base, revised);
 

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Version-diff engine tests: real-paraId alignment, the deterministic-fallback-id
+ * regression guard (same text, shifted ordinal must still pair as unchanged via
+ * the text-LCS pass), identical-buffer no-op, and the as-accepted semantics
+ * over a revised document that carries pending tracked changes.
+ *
+ * Buffers are built directly from the typed `Document` model (`createEmptyDocument`
+ * as a template, `createDocx` to serialize) rather than a fixture file, since each
+ * case needs precise control over paragraph text/paraId and no existing corpus
+ * fixture has more than two named paragraphs.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { FolioDocxReviewer } from "./ai-edits/headless";
+import { createDocx } from "./docx/rezip";
+import { createEmptyDocument } from "./utils/createDocument";
+import { compareDocxVersions, exceedsLcsBudget } from "./version-comparison";
+import type { FolioBlockDiff } from "./version-comparison";
+
+type ParagraphSpec = { text: string; paraId?: string };
+
+const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuffer> => {
+  const template = createEmptyDocument();
+  return createDocx({
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: paragraphs.map(({ text, paraId }) => ({
+          type: "paragraph",
+          content: [{ type: "run", content: [{ type: "text", text }] }],
+          ...(paraId !== undefined && { paraId }),
+        })),
+      },
+    },
+  });
+};
+
+const findChange = (changes: readonly FolioBlockDiff[], blockId: string): FolioBlockDiff => {
+  const change = changes.find((c) => c.blockId === blockId);
+  if (!change) {
+    throw new Error(`no change for block ${blockId}`);
+  }
+  return change;
+};
+
+describe("compareDocxVersions: real w14:paraId alignment", () => {
+  test("classifies unchanged, modified, added, and deleted blocks by stable id", async () => {
+    const base = await buildDocxBuffer([
+      { text: "Alpha paragraph.", paraId: "00000001" },
+      { text: "Beta paragraph.", paraId: "00000002" },
+      { text: "Gamma paragraph.", paraId: "00000003" },
+      { text: "Zeta paragraph.", paraId: "00000005" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Alpha paragraph.", paraId: "00000001" },
+      { text: "Beta clause.", paraId: "00000002" },
+      { text: "Zeta paragraph.", paraId: "00000005" },
+      { text: "Epsilon paragraph.", paraId: "00000006" },
+    ]);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 1, modified: 1, unchanged: 2 });
+    // Unchanged blocks (Alpha, Zeta) never appear in `changes`.
+    expect(diff.changes).toHaveLength(3);
+    expect(diff.changes.map((c) => c.type)).toEqual(["modified", "deleted", "added"]);
+
+    const modified = findChange(diff.changes, "00000002");
+    if (modified.type !== "modified") {
+      throw new Error("expected a modified change");
+    }
+    expect(modified.kind).toBe("paragraph");
+    expect(modified.segments).toEqual([
+      { type: "equal", text: "Beta " },
+      { type: "del", text: "paragraph." },
+      { type: "ins", text: "clause." },
+    ]);
+
+    const deleted = findChange(diff.changes, "00000003");
+    expect(deleted).toEqual({
+      type: "deleted",
+      blockId: "00000003",
+      kind: "paragraph",
+      text: "Gamma paragraph.",
+    });
+
+    const added = findChange(diff.changes, "00000006");
+    expect(added).toEqual({
+      type: "added",
+      blockId: "00000006",
+      kind: "paragraph",
+      text: "Epsilon paragraph.",
+    });
+  });
+});
+
+describe("compareDocxVersions: deterministic fallback ids (no w14:paraId)", () => {
+  test("a same-text block whose ordinal shifted still pairs as unchanged via the text-LCS pass", async () => {
+    // Neither buffer carries a w14:paraId, so FolioDocxReviewer assigns each
+    // block a deterministic fallback id derived from hash(text + ordinal). The
+    // "Epsilon" paragraph inserted before "Gamma" shifts Gamma's ordinal (3rd
+    // -> 4th), which changes its fallback id even though its text is
+    // untouched. Pass 1 (stable-id pairing) therefore CANNOT pair Gamma across
+    // versions; only the text-LCS pass (pass 2) recovers it as unchanged. This
+    // is the regression guard for the deterministic-id pitfall.
+    const base = await buildDocxBuffer([
+      { text: "Alpha paragraph." },
+      { text: "Beta paragraph." },
+      { text: "Gamma paragraph." },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Alpha paragraph." },
+      { text: "Beta paragraph modified." },
+      { text: "Epsilon paragraph." },
+      { text: "Gamma paragraph." },
+    ]);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    // Alpha (unshifted, same fallback id both sides) and Gamma (shifted,
+    // recovered via text-LCS) are both unchanged and absent from `changes`.
+    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 0, modified: 1, unchanged: 2 });
+    expect(diff.changes.map((c) => c.type)).toEqual(["modified", "added"]);
+
+    const modified = diff.changes[0];
+    if (!modified || modified.type !== "modified") {
+      throw new Error("expected a modified change");
+    }
+    // Reconstruct the revised text from the `equal` + `ins` segments (the
+    // `del` segments carry the superseded base-side text, not part of either
+    // whole string on their own).
+    const reconstructedRevised = modified.segments
+      .filter((s) => s.type !== "del")
+      .map((s) => s.text)
+      .join("");
+    expect(reconstructedRevised).toBe("Beta paragraph modified.");
+
+    const added = diff.changes[1];
+    if (!added || added.type !== "added") {
+      throw new Error("expected an added change");
+    }
+    expect(added.text).toBe("Epsilon paragraph.");
+  });
+});
+
+describe("compareDocxVersions: no-op", () => {
+  test("identical documents produce zero changes and every block counts as unchanged", async () => {
+    const paragraphs: ParagraphSpec[] = [{ text: "Alpha paragraph." }, { text: "Beta paragraph." }];
+    const base = await buildDocxBuffer(paragraphs);
+    const revised = await buildDocxBuffer(paragraphs);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.changes).toEqual([]);
+    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 0, unchanged: 2 });
+  });
+});
+
+describe("exceedsLcsBudget: pass 2's LCS cell-budget guard", () => {
+  test("flags unpaired-block counts whose product would exceed the LCS cell budget (4,000,000)", () => {
+    // A degenerate/adversarial document with no w14:paraIds can leave
+    // thousands of blocks unpaired on both sides; this guard is what stops
+    // pairByExactText from allocating an O(m*n) table for it. Exercise the
+    // predicate directly rather than constructing a multi-million-block
+    // fixture, which would make this test slow for no extra coverage.
+    expect(exceedsLcsBudget(2000, 2000)).toBe(false); // exactly at budget: 4,000,000 cells
+    expect(exceedsLcsBudget(2001, 2001)).toBe(true); // just over budget: 4,004,001 cells
+  });
+});
+
+describe("compareDocxVersions: as-accepted semantics", () => {
+  test("a pending tracked insertion in the revised document counts as already applied", async () => {
+    const base = await buildDocxBuffer([{ text: "Payment is due." }]);
+
+    // Build the revised buffer by applying a tracked-changes (default mode)
+    // replace against a fresh reviewer over `base` — the revised buffer still
+    // carries real w:ins/w:del marks on disk.
+    const revisedReviewer = await FolioDocxReviewer.fromBuffer(base, { author: "AI" });
+    const target = revisedReviewer.snapshot().blocks[0];
+    if (!target) {
+      throw new Error("expected a block in the base document");
+    }
+    revisedReviewer.applyOperations([
+      {
+        id: "t1",
+        type: "replaceInBlock",
+        blockId: target.id,
+        find: "due.",
+        replace: "due promptly.",
+      },
+    ]);
+    const revised = await revisedReviewer.toBuffer();
+
+    // Sanity: the revised snapshot's clean text is already the accepted view.
+    expect(revisedReviewer.snapshot().blocks[0]?.text).toBe("Payment is due promptly.");
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 1, unchanged: 0 });
+    const [change] = diff.changes;
+    if (!change || change.type !== "modified") {
+      throw new Error("expected a single modified change");
+    }
+    // The diff runs over the as-accepted text: reconstructing the revised
+    // side from `equal` + `ins` segments reproduces the clean accepted
+    // string, not raw tracked-change markup.
+    const reconstructedRevised = change.segments
+      .filter((s) => s.type !== "del")
+      .map((s) => s.text)
+      .join("");
+    expect(reconstructedRevised).toBe("Payment is due promptly.");
+    expect(change.segments.some((s) => s.type === "ins" && s.text.includes("promptly"))).toBe(true);
+  });
+});

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -1,0 +1,343 @@
+/**
+ * Document version-diff engine: compare two `.docx` buffers block by block
+ * and produce a structured, LLM-summarizable diff.
+ *
+ * Both buffers are parsed through {@link FolioDocxReviewer} — the same
+ * headless parsing + clean-text path `read_document` / `read_changes` use —
+ * so the comparison runs over each document's AS-ACCEPTED view: any pending
+ * tracked changes already present in EITHER buffer count as applied before
+ * the two are compared. Two documents that agree once their own pending
+ * redlines are accepted report as unchanged, even if the underlying
+ * tracked-change history differs.
+ *
+ * ## Alignment
+ *
+ * Blocks are paired across the two snapshots in three passes, each only
+ * considering blocks the previous pass left unpaired:
+ *
+ * 1. **Stable-id pairing.** Blocks whose ids are equal AND not a `seq-NNNN`
+ *    positional fallback ({@link getFolioParaIdFromBlockId} returns non-null)
+ *    are paired directly. This covers both id shapes a snapshot can carry:
+ *    - A real Word `w14:paraId`: stable identity, independent of text — an
+ *      equal-id pair with different text is a genuine edit (`modified`).
+ *    - `FolioDocxReviewer`'s deterministic fallback id (assigned when the
+ *      source paragraph has no `w14:paraId`), which hashes the paragraph's
+ *      TEXT plus its document ordinal. It is structurally indistinguishable
+ *      from a real paraId ({@link getFolioParaIdFromBlockId} can't tell them
+ *      apart), but pairing on equality is still safe: two equal deterministic
+ *      ids necessarily came from identical text at an identical ordinal, so
+ *      the pair is always text-equal (`unchanged`) — never a false
+ *      `modified`. What it can't do is FIND a paragraph whose ordinal shifted
+ *      (an insertion/deletion earlier in the document) even though its text
+ *      is unchanged: that pair has two different fallback ids and falls
+ *      through to pass 2.
+ * 2. **Exact-text pairing.** An order-preserving LCS over remaining blocks,
+ *    matched by exact text equality. This is what recovers same-text blocks
+ *    that pass 1 missed because a fallback id shifted with the ordinal. Its
+ *    O(m·n) table is skipped ({@link exceedsLcsBudget}) once the unpaired
+ *    counts on both sides would exceed a fixed cell budget, so a document
+ *    with few/no stable ids can't force a quadratic-sized allocation; those
+ *    blocks fall through to pass 3 instead.
+ * 3. **Positional fallback.** Whatever a monotonicity filter leaves
+ *    unpaired is split into the gaps between anchored pairs (pass 1 + 2,
+ *    time-ordered); within each gap the shorter side is zipped positionally
+ *    against the longer one (`modified`), and any excess on either side is
+ *    reported as `added` / `deleted`.
+ *
+ * The combined anchor set from passes 1 and 2 is re-filtered to the longest
+ * increasing subsequence by revised-side index before pass 3 runs, so a
+ * pathological crossing match (content reordered across versions) can't
+ * produce an out-of-order gap — the alignment always walks both documents
+ * forward.
+ */
+
+import { FolioDocxReviewer } from "./ai-edits/headless";
+import type { FolioAIBlock } from "./ai-edits/types";
+import { diffWordSegments, type WordDiffSegment } from "./ai-edits/word-diff";
+import { getFolioParaIdFromBlockId } from "./types/block-id";
+
+/** One word-level diff segment within a `modified` block. Mirrors {@link WordDiffSegment}. */
+export type FolioVersionDiffSegment = WordDiffSegment;
+
+/** One block-level change between two document versions, in revised-side document order. */
+export type FolioBlockDiff =
+  | { type: "added"; blockId: string; kind: string; text: string }
+  | { type: "deleted"; blockId: string; kind: string; text: string }
+  | { type: "modified"; blockId: string; kind: string; segments: FolioVersionDiffSegment[] };
+
+/** Result of {@link compareDocxVersions}. */
+export type FolioVersionDiff = {
+  /** Every added, deleted, or modified block, in revised-side document order (deletions slotted where they sat). */
+  changes: FolioBlockDiff[];
+  /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. */
+  summaryCounts: { added: number; deleted: number; modified: number; unchanged: number };
+};
+
+type BlockPair = { baseIndex: number; revisedIndex: number };
+type IndexedBlock = { block: FolioAIBlock; index: number };
+
+const isStableBlockId = (id: string): boolean => getFolioParaIdFromBlockId(id) !== null;
+
+const index = (blocks: readonly FolioAIBlock[]): IndexedBlock[] =>
+  blocks.map((block, blockIndex) => ({ block, index: blockIndex }));
+
+/**
+ * Longest increasing subsequence by `revisedIndex`, assuming `pairs` is
+ * already sorted by `baseIndex` ascending. Drops any pair that would make
+ * the alignment walk backward in the revised document — the guard against
+ * both id collisions (pass 1) and any crossing match (pass 1 + 2 combined).
+ */
+const longestIncreasingByRevisedIndex = (pairs: readonly BlockPair[]): BlockPair[] => {
+  if (pairs.length === 0) {
+    return [];
+  }
+  const lengths = Array.from<number>({ length: pairs.length }).fill(1);
+  const predecessors = Array.from<number>({ length: pairs.length }).fill(-1);
+  let bestEnd = 0;
+  for (let i = 0; i < pairs.length; i++) {
+    for (let j = 0; j < i; j++) {
+      const current = pairs[j];
+      const candidate = pairs[i];
+      if (!current || !candidate) {
+        continue;
+      }
+      if (
+        current.revisedIndex < candidate.revisedIndex &&
+        (lengths[j] ?? 0) + 1 > (lengths[i] ?? 0)
+      ) {
+        lengths[i] = (lengths[j] ?? 0) + 1;
+        predecessors[i] = j;
+      }
+    }
+    if ((lengths[i] ?? 0) > (lengths[bestEnd] ?? 0)) {
+      bestEnd = i;
+    }
+  }
+  const ordered: BlockPair[] = [];
+  for (let cursor = bestEnd; cursor !== -1; cursor = predecessors[cursor] ?? -1) {
+    const pair = pairs[cursor];
+    if (pair) {
+      ordered.push(pair);
+    }
+  }
+  return ordered.toReversed();
+};
+
+/** Pass 1: pair blocks with equal, non-`seq-NNNN` ids. See the module doc comment. */
+const pairByStableId = (
+  base: readonly FolioAIBlock[],
+  revised: readonly FolioAIBlock[],
+): BlockPair[] => {
+  const revisedIndexById = new Map<string, number>();
+  revised.forEach((block, revisedIndex) => {
+    if (isStableBlockId(block.id)) {
+      revisedIndexById.set(block.id, revisedIndex);
+    }
+  });
+
+  const candidates: BlockPair[] = [];
+  base.forEach((block, baseIndex) => {
+    if (!isStableBlockId(block.id)) {
+      return;
+    }
+    const revisedIndex = revisedIndexById.get(block.id);
+    if (revisedIndex !== undefined) {
+      candidates.push({ baseIndex, revisedIndex });
+    }
+  });
+  return longestIncreasingByRevisedIndex(candidates);
+};
+
+/**
+ * Cell budget for pass 2's O(m·n) exact-text LCS table (`dp` below allocates
+ * `(m + 1) * (n + 1)` numbers). A document with no `w14:paraId`s — or an
+ * adversarial one crafted to defeat pass 1 — can leave thousands of blocks
+ * unpaired on both sides; without a cap, `pairByExactText` would allocate a
+ * quadratic-sized table for it. Past this budget, {@link exceedsLcsBudget}
+ * makes pass 2 back off entirely so alignment falls through to pass 3's
+ * linear positional zip instead — pairing is less precise for these
+ * degenerate inputs, but memory use stays bounded.
+ */
+const MAX_LCS_CELLS = 4_000_000;
+
+/** True when an `unpairedBaseCount * unpairedRevisedCount` LCS table would exceed {@link MAX_LCS_CELLS}. */
+export const exceedsLcsBudget = (
+  unpairedBaseCount: number,
+  unpairedRevisedCount: number,
+): boolean => unpairedBaseCount * unpairedRevisedCount > MAX_LCS_CELLS;
+
+/** Pass 2: order-preserving LCS by exact text equality over the blocks pass 1 left unpaired. */
+const pairByExactText = (
+  base: readonly IndexedBlock[],
+  revised: readonly IndexedBlock[],
+): BlockPair[] => {
+  const m = base.length;
+  const n = revised.length;
+  if (m === 0 || n === 0) {
+    return [];
+  }
+  if (exceedsLcsBudget(m, n)) {
+    return [];
+  }
+  // A single flat Int32Array (indexed `i * (n + 1) + j`) instead of `m + 1`
+  // separately-allocated rows: one contiguous allocation instead of thousands
+  // of small ones, which matters once `m` and `n` approach the budget above.
+  const stride = n + 1;
+  const dp = new Int32Array((m + 1) * stride);
+  for (let i = m - 1; i >= 0; i--) {
+    const rowOffset = i * stride;
+    const nextRowOffset = (i + 1) * stride;
+    for (let j = n - 1; j >= 0; j--) {
+      const baseText = base[i]?.block.text;
+      const revisedText = revised[j]?.block.text;
+      dp[rowOffset + j] =
+        baseText === revisedText
+          ? (dp[nextRowOffset + j + 1] ?? 0) + 1
+          : Math.max(dp[nextRowOffset + j] ?? 0, dp[rowOffset + j + 1] ?? 0);
+    }
+  }
+
+  const pairs: BlockPair[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    const baseEntry = base[i];
+    const revisedEntry = revised[j];
+    if (!baseEntry || !revisedEntry) {
+      break;
+    }
+    if (baseEntry.block.text === revisedEntry.block.text) {
+      pairs.push({ baseIndex: baseEntry.index, revisedIndex: revisedEntry.index });
+      i++;
+      j++;
+      continue;
+    }
+    const down = dp[(i + 1) * stride + j] ?? 0;
+    const right = dp[i * stride + j + 1] ?? 0;
+    if (down >= right) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return pairs;
+};
+
+/**
+ * Compare two `.docx` buffers and return a structured, block-level diff.
+ * See the module doc comment for the as-accepted comparison semantics and
+ * the three-pass alignment algorithm.
+ */
+export const compareDocxVersions = async (
+  base: ArrayBuffer,
+  revised: ArrayBuffer,
+): Promise<FolioVersionDiff> => {
+  const [baseReviewer, revisedReviewer] = await Promise.all([
+    FolioDocxReviewer.fromBuffer(base),
+    FolioDocxReviewer.fromBuffer(revised),
+  ]);
+  const baseBlocks = baseReviewer.snapshot().blocks;
+  const revisedBlocks = revisedReviewer.snapshot().blocks;
+
+  const stableIdAnchors = pairByStableId(baseBlocks, revisedBlocks);
+  const usedBaseIndexes = new Set(stableIdAnchors.map((anchor) => anchor.baseIndex));
+  const usedRevisedIndexes = new Set(stableIdAnchors.map((anchor) => anchor.revisedIndex));
+
+  const baseRemaining = index(baseBlocks).filter(({ index: i }) => !usedBaseIndexes.has(i));
+  const revisedRemaining = index(revisedBlocks).filter(
+    ({ index: i }) => !usedRevisedIndexes.has(i),
+  );
+  const exactTextAnchors = pairByExactText(baseRemaining, revisedRemaining);
+
+  const anchors = longestIncreasingByRevisedIndex(
+    [...stableIdAnchors, ...exactTextAnchors].toSorted((a, b) => a.baseIndex - b.baseIndex),
+  );
+
+  const changes: FolioBlockDiff[] = [];
+  const counts = { added: 0, deleted: 0, modified: 0, unchanged: 0 };
+
+  /** Pass 3: positionally zip the leftover blocks in one gap between anchors. */
+  const emitGap = (
+    baseFrom: number,
+    baseTo: number,
+    revisedFrom: number,
+    revisedTo: number,
+  ): void => {
+    const baseSlice = baseBlocks.slice(baseFrom, baseTo);
+    const revisedSlice = revisedBlocks.slice(revisedFrom, revisedTo);
+    const pairedCount = Math.min(baseSlice.length, revisedSlice.length);
+
+    for (let k = 0; k < pairedCount; k++) {
+      const baseBlock = baseSlice[k];
+      const revisedBlock = revisedSlice[k];
+      if (!baseBlock || !revisedBlock) {
+        continue;
+      }
+      if (baseBlock.text === revisedBlock.text) {
+        counts.unchanged++;
+        continue;
+      }
+      counts.modified++;
+      changes.push({
+        type: "modified",
+        blockId: revisedBlock.id,
+        kind: revisedBlock.kind,
+        segments: diffWordSegments(baseBlock.text, revisedBlock.text),
+      });
+    }
+    for (let k = pairedCount; k < baseSlice.length; k++) {
+      const baseBlock = baseSlice[k];
+      if (!baseBlock) {
+        continue;
+      }
+      counts.deleted++;
+      changes.push({
+        type: "deleted",
+        blockId: baseBlock.id,
+        kind: baseBlock.kind,
+        text: baseBlock.text,
+      });
+    }
+    for (let k = pairedCount; k < revisedSlice.length; k++) {
+      const revisedBlock = revisedSlice[k];
+      if (!revisedBlock) {
+        continue;
+      }
+      counts.added++;
+      changes.push({
+        type: "added",
+        blockId: revisedBlock.id,
+        kind: revisedBlock.kind,
+        text: revisedBlock.text,
+      });
+    }
+  };
+
+  let baseCursor = 0;
+  let revisedCursor = 0;
+  for (const anchor of anchors) {
+    emitGap(baseCursor, anchor.baseIndex, revisedCursor, anchor.revisedIndex);
+
+    const baseBlock = baseBlocks[anchor.baseIndex];
+    const revisedBlock = revisedBlocks[anchor.revisedIndex];
+    if (baseBlock && revisedBlock) {
+      if (baseBlock.text === revisedBlock.text) {
+        counts.unchanged++;
+      } else {
+        counts.modified++;
+        changes.push({
+          type: "modified",
+          blockId: revisedBlock.id,
+          kind: revisedBlock.kind,
+          segments: diffWordSegments(baseBlock.text, revisedBlock.text),
+        });
+      }
+    }
+
+    baseCursor = anchor.baseIndex + 1;
+    revisedCursor = anchor.revisedIndex + 1;
+  }
+  emitGap(baseCursor, baseBlocks.length, revisedCursor, revisedBlocks.length);
+
+  return { changes, summaryCounts: counts };
+};

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -78,9 +78,6 @@ type IndexedBlock = { block: FolioAIBlock; index: number };
 
 const isStableBlockId = (id: string): boolean => getFolioParaIdFromBlockId(id) !== null;
 
-const index = (blocks: readonly FolioAIBlock[]): IndexedBlock[] =>
-  blocks.map((block, blockIndex) => ({ block, index: blockIndex }));
-
 /**
  * Longest increasing subsequence by `revisedIndex`, assuming `pairs` is
  * already sorted by `baseIndex` ascending. Drops any pair that would make
@@ -91,8 +88,8 @@ const longestIncreasingByRevisedIndex = (pairs: readonly BlockPair[]): BlockPair
   if (pairs.length === 0) {
     return [];
   }
-  const lengths = Array.from<number>({ length: pairs.length }).fill(1);
-  const predecessors = Array.from<number>({ length: pairs.length }).fill(-1);
+  const lengths = new Int32Array(pairs.length).fill(1);
+  const predecessors = new Int32Array(pairs.length).fill(-1);
   let bestEnd = 0;
   for (let i = 0; i < pairs.length; i++) {
     for (let j = 0; j < i; j++) {
@@ -179,6 +176,8 @@ const pairByExactText = (
   if (exceedsLcsBudget(m, n)) {
     return [];
   }
+  const baseTexts = base.map(({ block }) => block.text);
+  const revisedTexts = revised.map(({ block }) => block.text);
   // A single flat Int32Array (indexed `i * (n + 1) + j`) instead of `m + 1`
   // separately-allocated rows: one contiguous allocation instead of thousands
   // of small ones, which matters once `m` and `n` approach the budget above.
@@ -187,9 +186,9 @@ const pairByExactText = (
   for (let i = m - 1; i >= 0; i--) {
     const rowOffset = i * stride;
     const nextRowOffset = (i + 1) * stride;
+    const baseText = baseTexts[i];
     for (let j = n - 1; j >= 0; j--) {
-      const baseText = base[i]?.block.text;
-      const revisedText = revised[j]?.block.text;
+      const revisedText = revisedTexts[j];
       dp[rowOffset + j] =
         baseText === revisedText
           ? (dp[nextRowOffset + j + 1] ?? 0) + 1
@@ -206,7 +205,7 @@ const pairByExactText = (
     if (!baseEntry || !revisedEntry) {
       break;
     }
-    if (baseEntry.block.text === revisedEntry.block.text) {
+    if (baseTexts[i] === revisedTexts[j]) {
       pairs.push({ baseIndex: baseEntry.index, revisedIndex: revisedEntry.index });
       i++;
       j++;
@@ -243,10 +242,18 @@ export const compareDocxVersions = async (
   const usedBaseIndexes = new Set(stableIdAnchors.map((anchor) => anchor.baseIndex));
   const usedRevisedIndexes = new Set(stableIdAnchors.map((anchor) => anchor.revisedIndex));
 
-  const baseRemaining = index(baseBlocks).filter(({ index: i }) => !usedBaseIndexes.has(i));
-  const revisedRemaining = index(revisedBlocks).filter(
-    ({ index: i }) => !usedRevisedIndexes.has(i),
-  );
+  const baseRemaining: IndexedBlock[] = [];
+  baseBlocks.forEach((block, blockIndex) => {
+    if (!usedBaseIndexes.has(blockIndex)) {
+      baseRemaining.push({ block, index: blockIndex });
+    }
+  });
+  const revisedRemaining: IndexedBlock[] = [];
+  revisedBlocks.forEach((block, blockIndex) => {
+    if (!usedRevisedIndexes.has(blockIndex)) {
+      revisedRemaining.push({ block, index: blockIndex });
+    }
+  });
   const exactTextAnchors = pairByExactText(baseRemaining, revisedRemaining);
 
   const anchors = longestIncreasingByRevisedIndex(


### PR DESCRIPTION
Moves structured DOCX version comparison into folio-core while preserving the agents API.