### PR TITLE
fix: coalesce empty rendered page markers

### DIFF
--- a/.changeset/coalesce-empty-rendered-break.md
+++ b/.changeset/coalesce-empty-rendered-break.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Coalesce empty rendered page-break markers after natural paragraph overflow.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -395,6 +395,39 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1].fragments.map((fragment) => fragment.blockId)).toEqual([1, 2]);
     });
 
+    test("empty rendered break marker reuses a page opened by the preceding paragraph", () => {
+      const marker: ParagraphBlock = {
+        kind: "paragraph",
+        id: 3,
+        runs: [
+          { kind: "tab", pmStart: 76, pmEnd: 77 },
+          { kind: "tab", pmStart: 77, pmEnd: 78 },
+        ],
+        attrs: { renderedPageBreakBefore: true },
+        pmStart: 25,
+        pmEnd: 26,
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        makeParagraphBlock(1, "Naturally moves to page two", 22),
+        makeParagraphBlock(2, "Trailing content on page two", 50),
+        marker,
+        makeParagraphBlock(4, "After cached boundary", 79),
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 840)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 27, 100, 40)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 28, 100, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 0, 0, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 21, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2, 3, 4]);
+    });
+
     test("successive rendered page breaks remain authoritative after natural reflow", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Fill page one", 1),

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -101,6 +101,15 @@ function isEmptyParagraph(block: ParagraphBlock): boolean {
   return r?.kind === "text" && r.text === "";
 }
 
+function isPaginationEmptyParagraph(block: ParagraphBlock): boolean {
+  return block.runs.every((run) => {
+    if (run.kind === "text") {
+      return run.text.trim().length === 0;
+    }
+    return run.kind === "tab" || run.kind === "lineBreak";
+  });
+}
+
 function pageHasVisibleBodyContent(
   page: Page,
   blocksById: ReadonlyMap<string, FlowBlock>,
@@ -110,7 +119,7 @@ function pageHasVisibleBodyContent(
       return true;
     }
     const block = blocksById.get(String(fragment.blockId));
-    if (block?.kind !== "paragraph" || !isEmptyParagraph(block)) {
+    if (block?.kind !== "paragraph" || !isPaginationEmptyParagraph(block)) {
       return true;
     }
   }
@@ -316,6 +325,7 @@ export function layoutDocument(
   let activeSectionMarginTop = initialConfig.margins.top;
   let activeSectionPageHeight = initialConfig.pageSize.h;
   let activeSectionMarginBottom = initialConfig.margins.bottom;
+  let naturalPageAdvanceSinceRenderedBreak = false;
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
@@ -331,9 +341,19 @@ export function layoutDocument(
       paginator.forcePageBreak();
     } else if (hasRenderedPageBreak) {
       const state = paginator.getCurrentState();
-      if (pageHasVisibleBodyContent(state.page, blocksById)) {
+      const naturalOverflowAlreadyCrossedEmptyMarker =
+        block.kind === "paragraph" &&
+        isPaginationEmptyParagraph(block) &&
+        naturalPageAdvanceSinceRenderedBreak;
+      if (
+        !naturalOverflowAlreadyCrossedEmptyMarker &&
+        pageHasVisibleBodyContent(state.page, blocksById)
+      ) {
         paginator.forcePageBreak();
       }
+    }
+    if (hasRenderedPageBreak) {
+      naturalPageAdvanceSinceRenderedBreak = false;
     }
 
     // Handle keepNext chains - if this is a chain start, check if chain fits
@@ -343,6 +363,7 @@ export function layoutDocument(
       paginator.ensureFits(chainHeight);
     }
 
+    const pageBeforeBlockLayout = paginator.getCurrentState().page.number;
     switch (block.kind) {
       case "paragraph":
         layoutParagraph(
@@ -408,6 +429,16 @@ export function layoutDocument(
       }
       default:
         break;
+    }
+
+    const isVisibleBodyBlock =
+      block.kind === "paragraph"
+        ? !isEmptyParagraph(block)
+        : block.kind !== "pageBreak" &&
+          block.kind !== "columnBreak" &&
+          block.kind !== "sectionBreak";
+    if (isVisibleBodyBlock && paginator.getCurrentState().page.number > pageBeforeBlockLayout) {
+      naturalPageAdvanceSinceRenderedBreak = true;
     }
   }
 

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -352,7 +352,7 @@ export function layoutDocument(
         paginator.forcePageBreak();
       }
     }
-    if (hasRenderedPageBreak) {
+    if (hasRenderedPageBreak || hasPageBreakBefore(block)) {
       naturalPageAdvanceSinceRenderedBreak = false;
     }
 
@@ -437,7 +437,14 @@ export function layoutDocument(
         : block.kind !== "pageBreak" &&
           block.kind !== "columnBreak" &&
           block.kind !== "sectionBreak";
-    if (isVisibleBodyBlock && paginator.getCurrentState().page.number > pageBeforeBlockLayout) {
+    const isStructuralBreak =
+      block.kind === "pageBreak" || block.kind === "columnBreak" || block.kind === "sectionBreak";
+    if (isStructuralBreak) {
+      naturalPageAdvanceSinceRenderedBreak = false;
+    } else if (
+      isVisibleBodyBlock &&
+      paginator.getCurrentState().page.number > pageBeforeBlockLayout
+    ) {
       naturalPageAdvanceSinceRenderedBreak = true;
     }
   }


### PR DESCRIPTION
## Summary
- treat tab-only and whitespace-only paragraphs as pagination-empty without changing their authored layout height
- remember natural page advances between cached Word boundary markers
- coalesce an empty cached marker when natural reflow already crossed that boundary
- keep visible rendered-break markers authoritative
- add a focused integration regression and core patch changeset

## Anonymized parity evidence
- first-four-page score: 0.17 → 0.54
- full Folio page count: 30 → 29 (Word: 28)
- removes the early blank-page offset; a separate later-page gap remains

## Verification
- 48 focused layout integration tests passed
- `bun audit` reported no vulnerabilities
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica