### PR TITLE
fix: align paragraph mark font inheritance

### DIFF
--- a/.changeset/calm-runs-inherit.md
+++ b/.changeset/calm-runs-inherit.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Fix paragraph-style font-size inheritance for directly formatted DOCX runs.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -170,6 +170,101 @@ describe("toProseDoc", () => {
     expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(16);
   });
 
+  test("keeps the default paragraph style size when paragraph and run only set a font family", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+                  },
+                  content: [{ type: "text", text: "Default style text" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          docDefaults: { rPr: { fontSize: 22 } },
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: { fontSize: 24 },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = doc.firstChild;
+    const text = paragraph?.firstChild;
+
+    expect(paragraph?.attrs.defaultTextFormatting.fontSize).toBe(24);
+    expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(24);
+    expect(text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe("Arial");
+  });
+
+  test("does not leak a paragraph-mark-only size into directly formatted body text", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  fontSize: 52,
+                  fontSizeCs: 52,
+                  fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+                  },
+                  content: [{ type: "text", text: "Body text" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          docDefaults: { rPr: { fontSize: 22, fontSizeCs: 22 } },
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: { fontSize: 24, fontSizeCs: 24 },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = doc.firstChild;
+    const text = paragraph?.firstChild;
+
+    expect(paragraph?.attrs.defaultTextFormatting.fontSize).toBe(52);
+    expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(24);
+  });
+
   test("keeps named paragraph style fonts ahead of paragraph-mark formatting", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -236,9 +236,10 @@ function convertParagraph(
     styleRunFormatting = resolved.runFormatting;
   }
 
-  const paragraphRunFormatting = paragraph.formatting?.runProperties
-    ? resolveTextFormatting(paragraph.formatting.runProperties, styleResolver)
-    : undefined;
+  const paragraphRunFormatting = resolveParagraphMarkRunFormatting(
+    paragraph.formatting?.runProperties,
+    styleResolver,
+  );
   // Word does not propagate paragraph-mark-only visual decorations
   // (highlight, shading) to body runs — they paint the pilcrow alone. Strip
   // them off the inheritance path so a `<w:pPr><w:rPr><w:highlight/></w:rPr>`
@@ -920,6 +921,24 @@ function suppressParagraphMarkFormatting(
   suppressBooleanParagraphMark(result, paragraphMark, direct, "outline");
   suppressBooleanParagraphMark(result, paragraphMark, direct, "rtl");
 
+  // A direct run suppresses a size stored only on the paragraph mark. Restore
+  // the resolved paragraph-style size instead of letting the pilcrow size leak
+  // into visible text.
+  if (
+    paragraphMark.fontSize !== undefined &&
+    direct?.fontSize === undefined &&
+    base?.fontSize !== undefined
+  ) {
+    result.fontSize = base.fontSize;
+  }
+  if (
+    paragraphMark.fontSizeCs !== undefined &&
+    direct?.fontSizeCs === undefined &&
+    base?.fontSizeCs !== undefined
+  ) {
+    result.fontSizeCs = base.fontSizeCs;
+  }
+
   if (paragraphMark.underline !== undefined && direct?.underline === undefined) {
     result.underline = { style: "none" };
   }
@@ -975,6 +994,20 @@ function resolveTextFormatting(
   return mergeTextFormatting(styleFormatting, formatting);
 }
 
+function resolveParagraphMarkRunFormatting(
+  formatting: TextFormatting | undefined,
+  styleResolver: StyleEngine | null,
+): TextFormatting | undefined {
+  if (!formatting || !styleResolver) {
+    return formatting;
+  }
+
+  const characterStyleFormatting = formatting.styleId
+    ? styleResolver.getRunStyleOwnProperties(formatting.styleId)
+    : undefined;
+  return mergeTextFormatting(characterStyleFormatting, formatting);
+}
+
 function resolveParagraphDefaultTextFormatting(
   styleId: string | undefined,
   formatting: Paragraph["formatting"] | undefined,
@@ -993,13 +1026,9 @@ function resolveParagraphDefaultTextFormatting(
   // merged into the cascade below.
   const rawParagraphMarkRpr =
     options.includeParagraphMarkRunProperties === false ? undefined : formatting?.runProperties;
-  const characterStyleRpr =
-    rawParagraphMarkRpr?.styleId !== undefined
-      ? styleResolver.getRunStyleOwnProperties(rawParagraphMarkRpr.styleId)
-      : undefined;
   const paragraphRunProperties = rawParagraphMarkRpr
     ? stripParagraphMarkOnlyFormatting(
-        mergeTextFormatting(characterStyleRpr, rawParagraphMarkRpr) ?? {},
+        resolveParagraphMarkRunFormatting(rawParagraphMarkRpr, styleResolver) ?? {},
       )
     : undefined;
 


### PR DESCRIPTION
## Summary

- preserve the default paragraph style size when direct formatting only changes the font family
- prevent paragraph-mark-only font sizes from leaking into directly formatted visible runs
- add focused regression coverage for both OOXML cascade cases

## Anonymized parity evidence

- fidelity score: 0.108 → 0.858
- page count: 6/6
- pagination divergences: 2 → 0
- total divergences: 295 → 71

Local focused tests and dependency audit pass. Lint and typecheck run in CI.