### PR TITLE
fix: improve parity iteration diagnostics

### DIFF
--- a/parity/README.md
+++ b/parity/README.md
@@ -19,6 +19,18 @@ bun parity/cli.ts --refresh-truth          # ignore cached Word exports
 
 The HTML report lands in `parity/report/index.html`.
 
+For repeated runs in one worktree, start a current-source playground once and
+explicitly reuse it:
+
+```sh
+FOLIO_PLAYGROUND_PORT=$(bun -e 'import { PLAYGROUND_PORT } from "./parity/config"; process.stdout.write(String(PLAYGROUND_PORT))') \
+  bun --filter @stll/playground dev
+bun parity/cli.ts path/to/file.docx --reuse-server
+```
+
+Fresh-server mode remains the default. Reuse is an opt-in for iterative work
+where the caller owns the server and knows it reflects the current worktree.
+
 ## How it works
 
 1. **Ground truth** (`wordTruth.ts`): the docx is exported to PDF by scripting

--- a/parity/__tests__/cli.test.ts
+++ b/parity/__tests__/cli.test.ts
@@ -20,6 +20,13 @@ describe("parity CLI args", () => {
     expect(flags.outputPath).toBe("/tmp/out.json");
   });
 
+  test("parses the explicit playground server reuse opt-in", () => {
+    const flags = parseArgs(["fixture.docx", "--reuse-server"]);
+
+    expect(flags.paths).toEqual(["fixture.docx"]);
+    expect(flags.reuseServer).toBe(true);
+  });
+
   test("requires a path after --output", () => {
     expect(() => parseArgs(["fixture.docx", "--output"])).toThrow("--output requires a file path");
     expect(() => parseArgs(["fixture.docx", "--output", "--json"])).toThrow(

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -4,6 +4,7 @@ import { PX_TO_PT } from "../config";
 import {
   CLEAN_SCREENSHOT_CSS,
   computeZoomFactor,
+  formatNavigationFailure,
   formatServerStartFailure,
   meaningfulTextRange,
   parseCssFontFamilies,
@@ -43,6 +44,26 @@ describe("playground startup diagnostics", () => {
   test("reports a quiet startup timeout without an empty output section", () => {
     expect(formatServerStartFailure("http://localhost:4200", 90_000, undefined, "")).toBe(
       "playground dev server did not become ready at http://localhost:4200 within 90000ms",
+    );
+  });
+
+  test("includes captured playground output in navigation failures", () => {
+    expect(
+      formatNavigationFailure(
+        "http://localhost:4200/?file=fixture.docx",
+        new Error("goto timed out"),
+        "vite transform error",
+      ),
+    ).toBe(
+      "playground navigation failed for http://localhost:4200/?file=fixture.docx: goto timed out\n" +
+        "Playground output:\n" +
+        "vite transform error",
+    );
+  });
+
+  test("omits an empty playground output section from navigation failures", () => {
+    expect(formatNavigationFailure("http://localhost:4200", "connection reset", "")).toBe(
+      "playground navigation failed for http://localhost:4200: connection reset",
     );
   });
 });

--- a/parity/__tests__/stextParse.test.ts
+++ b/parity/__tests__/stextParse.test.ts
@@ -132,6 +132,34 @@ describe("parseStextXml", () => {
     expect(box?.fontSizePt).toBe(12.5);
   });
 
+  test("normalizes a Wingdings square marker without rewriting a real section sign", () => {
+    const xml = documentEl(
+      pageEl(
+        1,
+        "612",
+        "792",
+        [
+          lineEl({
+            bbox: "0 0 10 10",
+            chars: "§ ",
+            font: { name: "ABCDEF+Wingdings-Regular", size: "9.12" },
+          }),
+          lineEl({
+            bbox: "0 20 50 30",
+            chars: "§ 12",
+            font: { name: "ArialMT", size: "9.12" },
+          }),
+        ].join(""),
+      ),
+    );
+
+    const pages = parseStextXml(xml);
+
+    expect(pages[0]?.lines[0]?.text).toBe("■ ");
+    expect(pages[0]?.lines[0]?.normText).toBe("■");
+    expect(pages[0]?.lines[1]?.text).toBe("§ 12");
+  });
+
   test("reconstructs text from <char> elements when the line has no text attribute", () => {
     const xml = documentEl(
       pageEl(1, "612", "792", lineEl({ bbox: "0 0 60 10", chars: "NoTextAttr" })),

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -58,6 +58,7 @@ type CliFlags = {
   json: boolean;
   refreshTruth: boolean;
   headed: boolean;
+  reuseServer: boolean;
   noReport: boolean;
   outputPath?: string;
   maxPages?: number;
@@ -70,6 +71,7 @@ export const parseArgs = (argv: string[]): CliFlags => {
     json: false,
     refreshTruth: false,
     headed: false,
+    reuseServer: false,
     noReport: false,
     paths: [],
   };
@@ -83,6 +85,8 @@ export const parseArgs = (argv: string[]): CliFlags => {
       flags.refreshTruth = true;
     } else if (arg === "--headed") {
       flags.headed = true;
+    } else if (arg === "--reuse-server") {
+      flags.reuseServer = true;
     } else if (arg === "--no-report") {
       flags.noReport = true;
     } else if (arg === "--output") {
@@ -119,6 +123,7 @@ Options:
   --max-pages <n>      Compare only the first n pages.
   --refresh-truth      Re-render Word ground truth instead of using cache.
   --headed             Show the Folio browser window.
+  --reuse-server       Reuse a healthy current-worktree playground server.
   --no-report          Skip writing the HTML report.
 
 Examples:
@@ -221,7 +226,10 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
 
         if (!extractor) {
           // oxlint-disable-next-line no-await-in-loop -- created lazily on first use, before any folio extraction
-          extractor = await createFolioExtractor({ headless: !flags.headed });
+          extractor = await createFolioExtractor({
+            headless: !flags.headed,
+            reuseServer: flags.reuseServer,
+          });
         }
 
         process.stderr.write("folio… ");

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -103,6 +103,7 @@ const PAGE_SELECTOR = ".layout-page";
 const VIEWPORT = { width: 1400, height: 1000 };
 
 const SERVER_PROBE_TIMEOUT_MS = 2000;
+const SERVER_REUSE_PROBE_TIMEOUT_MS = 15_000;
 const SERVER_START_TIMEOUT_MS = 90_000;
 const SERVER_POLL_INTERVAL_MS = 500;
 const SERVER_LOG_TAIL_CHARS = 4000;
@@ -156,6 +157,13 @@ export const formatServerStartFailure = (
   return output.length === 0
     ? `playground dev server ${reason}`
     : `playground dev server ${reason}\nPlayground output:\n${output}`;
+};
+
+export const formatNavigationFailure = (url: string, error: unknown, output: string): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  return output.length === 0
+    ? `playground navigation failed for ${url}: ${message}`
+    : `playground navigation failed for ${url}: ${message}\nPlayground output:\n${output}`;
 };
 
 /** A raw rect as returned by `getBoundingClientRect()` (visual/CSS px). */
@@ -898,8 +906,10 @@ export const createFolioExtractor = async (
   const reuseServer = opts.reuseServer ?? false;
 
   let serverProcess: ReturnType<typeof Bun.spawn> | null = null;
+  let serverStdoutTail: OutputTail | null = null;
+  let serverStderrTail: OutputTail | null = null;
   const serverAlreadyUp =
-    reuseServer && (await probeServer(PLAYGROUND_URL, SERVER_PROBE_TIMEOUT_MS));
+    reuseServer && (await probeServer(PLAYGROUND_URL, SERVER_REUSE_PROBE_TIMEOUT_MS));
   if (!serverAlreadyUp) {
     // Clear any leftover server on OUR per-worktree port (see killByPort:
     // port-scoped, so other worktrees' servers are untouched), then start
@@ -912,8 +922,8 @@ export const createFolioExtractor = async (
       stdout: "pipe",
       stderr: "pipe",
     });
-    const stdoutTail = captureOutputTail(serverProcess.stdout);
-    const stderrTail = captureOutputTail(serverProcess.stderr);
+    serverStdoutTail = captureOutputTail(serverProcess.stdout);
+    serverStderrTail = captureOutputTail(serverProcess.stderr);
     const startupProbe = new AbortController();
     const startup = await Promise.race([
       waitForServerReady(
@@ -929,7 +939,7 @@ export const createFolioExtractor = async (
       await killProcessTree(serverProcess.pid);
       await killByPort(PLAYGROUND_PORT);
       await Promise.race([
-        Promise.all([stdoutTail.done, stderrTail.done]),
+        Promise.all([serverStdoutTail.done, serverStderrTail.done]),
         Bun.sleep(SERVER_PROBE_TIMEOUT_MS),
       ]);
       throw new FolioExtractError(
@@ -937,7 +947,7 @@ export const createFolioExtractor = async (
           PLAYGROUND_URL,
           SERVER_START_TIMEOUT_MS,
           startup.type === "exit" ? startup.exitCode : undefined,
-          [stdoutTail.read(), stderrTail.read()].filter(Boolean).join("\n"),
+          [serverStdoutTail.read(), serverStderrTail.read()].filter(Boolean).join("\n"),
         ),
       );
     }
@@ -965,6 +975,21 @@ export const createFolioExtractor = async (
   });
   const page = await context.newPage();
 
+  const navigateToDocument = async (stagedName: string): Promise<void> => {
+    const documentUrl = `${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`;
+    try {
+      await page.goto(documentUrl, {
+        waitUntil: "domcontentloaded",
+        timeout: PLAYGROUND_NAVIGATION_TIMEOUT_MS,
+      });
+    } catch (error) {
+      const output = [serverStdoutTail?.read(), serverStderrTail?.read()]
+        .filter(Boolean)
+        .join("\n");
+      throw new FolioExtractError(formatNavigationFailure(documentUrl, error, output));
+    }
+  };
+
   const extract = async (
     docxPath: string,
     options: FolioExtractOptions = {},
@@ -977,10 +1002,7 @@ export const createFolioExtractor = async (
 
     await fs.copyFile(absoluteDocxPath, stagedPath);
     try {
-      await page.goto(`${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`, {
-        waitUntil: "domcontentloaded",
-        timeout: PLAYGROUND_NAVIGATION_TIMEOUT_MS,
-      });
+      await navigateToDocument(stagedName);
       await waitForEditorLayout(page);
 
       const pageMeta = await listPageMeta(page);
@@ -1052,10 +1074,7 @@ export const createFolioExtractor = async (
 
     await fs.copyFile(absoluteDocxPath, stagedPath);
     try {
-      await page.goto(`${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`, {
-        waitUntil: "domcontentloaded",
-        timeout: PLAYGROUND_NAVIGATION_TIMEOUT_MS,
-      });
+      await navigateToDocument(stagedName);
       await waitForEditorLayout(page);
 
       const pageMeta = await listPageMeta(page);

--- a/parity/stextParse.ts
+++ b/parity/stextParse.ts
@@ -67,6 +67,19 @@ const parseBbox = (bboxAttr: string): Bbox | null => {
 
 type LineFont = { name?: string; sizePt?: number };
 
+const normalizeFontEncodedText = (text: string, fontName: string | undefined): string => {
+  // mutool exposes the character code behind Word's Wingdings square marker
+  // as a section sign even though the rendered glyph is a black square.
+  if (
+    fontName !== undefined &&
+    /^(?:[A-Z]{6}\+)?Wingdings(?:-|$)/iu.test(fontName) &&
+    normalizeLineText(text) === "§"
+  ) {
+    return text.replace("§", "■");
+  }
+  return text;
+};
+
 /** The line's primary font: the first `<font>` element it contains. */
 const extractFirstFont = (lineContent: string): LineFont => {
   const fontMatch = FONT_OPEN_RE.exec(lineContent);
@@ -150,14 +163,15 @@ const parseLines = (pageContent: string): LineBox[] => {
     const lineBbox = bboxAttr === null ? null : parseBbox(bboxAttr);
 
     const { text: charText, inkBbox } = parseChars(lineContent);
-    const text = charText !== "" ? charText : (extractAttr(lineAttrs, "text") ?? "");
+    const font = extractFirstFont(lineContent);
+    const extractedText = charText !== "" ? charText : (extractAttr(lineAttrs, "text") ?? "");
+    const text = normalizeFontEncodedText(extractedText, font.name);
     const bbox = inkBbox ?? lineBbox;
     if (bbox === null) continue;
 
     const normText = normalizeLineText(text);
     if (normText === "") continue;
 
-    const font = extractFirstFont(lineContent);
     lines.push({
       text,
       normText,


### PR DESCRIPTION
## Summary

- add an explicit current-worktree playground reuse option for iterative parity runs
- include captured playground output when browser navigation fails
- normalize a font-encoded square marker in Word text extraction without rewriting real section signs
- document the warmed-server workflow and add focused regression coverage

## Anonymized parity evidence

- false marker mismatches: 9 → 0
- total text mismatches: 18 → 9
- page count remains aligned at 3/3

All 104 parity unit tests and the dependency audit pass. Lint and typecheck run in CI.