### PR TITLE
fix: justify hanging tab lines

### DIFF
--- a/.changeset/bright-tabs-justify.md
+++ b/.changeset/bright-tabs-justify.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Fix justified spacing on hanging first lines that contain tabs.

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -185,6 +185,75 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(lineEl.style.wordSpacing).toBe("-5px");
   });
 
+  test("underfull justified tab lines distribute their remaining width explicitly", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-underfull-tab",
+      runs: [
+        { kind: "text", text: "6.3.2" },
+        { kind: "tab" },
+        { kind: "text", text: "alpha beta" },
+      ],
+      attrs: { alignment: "justify" },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 10,
+      width: 80,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+    });
+
+    expect(lineEl.style.width).toBe("100px");
+    expect(lineEl.style.textAlign).toBe("left");
+    expect(lineEl.style.textAlignLast).toBe("auto");
+    expect(lineEl.style.wordSpacing).toBe("20px");
+  });
+
+  test("includes a hanging first-line region in justified tab capacity", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-underfull-hanging-tab",
+      runs: [
+        { kind: "text", text: "6.3.2" },
+        { kind: "tab" },
+        { kind: "text", text: "alpha beta" },
+      ],
+      attrs: { alignment: "justify", indent: { left: 20, hanging: 20 } },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 10,
+      width: 110,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      firstLineIndentPx: -20,
+    });
+
+    expect(lineEl.style.width).toBe("100px");
+    expect(lineEl.style.wordSpacing).toBe("10px");
+  });
+
   test("justifies a hanging-list marker line through the full right edge", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1711,6 +1711,8 @@ export function renderLine(
     return lineEl;
   }
 
+  const hasTabRuns = runsForLine.some(isTabRun);
+
   // Calculate justify spacing if needed
   const isJustify = alignment === "justify";
 
@@ -1719,9 +1721,20 @@ export function renderLine(
     const shouldJustify = !options.isLastLine || options.paragraphEndsWithLineBreak;
 
     if (shouldJustify) {
-      const overfullPx = line.width - options.availableWidth;
+      const firstLineIndentPx = options.isFirstLine ? (options.firstLineIndentPx ?? 0) : 0;
+      const firstLineHangingPx = Math.max(0, -firstLineIndentPx);
+      const justifyCapacityPx = options.availableWidth + firstLineHangingPx;
+      const overfullPx = line.width - justifyCapacityPx;
       const shrinkableSpaces = countShrinkableSpaces(runsForLine);
       if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
+        lineEl.style.textAlign = "left";
+        lineEl.style.textAlignLast = "auto";
+        lineEl.style.wordSpacing = `${-overfullPx / shrinkableSpaces}px`;
+      } else if (hasTabRuns && shrinkableSpaces > 0 && -overfullPx > RIGHT_EDGE_EPSILON_PX) {
+        // CSS justification does not expand preserved spaces reliably when a
+        // line also contains an inline tab span. The layout engine has already
+        // fixed the line break, so distribute the remaining width explicitly;
+        // this is paint-only and cannot change pagination.
         lineEl.style.textAlign = "left";
         lineEl.style.textAlignLast = "auto";
         lineEl.style.wordSpacing = `${-overfullPx / shrinkableSpaces}px`;
@@ -1751,7 +1764,6 @@ export function renderLine(
   // renderParagraphFragment via MeasuredLine offsets from re-measurement.
 
   // Build tab context if we have tab runs - also create for text measurement
-  const hasTabRuns = runsForLine.some(isTabRun);
   let tabContext: TabContext | undefined;
 
   // Always create text measurer for accurate X position tracking


### PR DESCRIPTION
## Summary

- explicitly distribute remaining word spacing on justified lines containing inline tabs
- account for a hanging first-line region when calculating the available justification width
- keep the correction paint-only so line breaking and pagination remain unchanged

## Parity evidence

On the anonymized regression case:

- score: 0.933 → 0.948
- width drifts: 5 → 3
- pages matched: 3/3
- pagination drift: 0

## Verification

- `bun test src/layout-painter/renderParagraph-justify-first-line-indent.test.ts` (5 passed)
- layout-painter suite (241 passed)
- `bun audit` (no vulnerabilities)
- lint and typecheck: CI
