### PR TITLE
fix: position text-anchored floating tables

### DIFF
--- a/.changeset/tidy-floating-tables.md
+++ b/.changeset/tidy-floating-tables.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Position text-anchored floating tables from their text cursor and keep following text outside full-width table bands.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -23,6 +23,8 @@ import type {
   Measure,
   PageMargins,
   LayoutOptions,
+  TableBlock,
+  TableMeasure,
 } from "../layout-engine/types";
 
 // =============================================================================
@@ -150,6 +152,58 @@ describe("Layout Engine - Page Production", () => {
       const fragment = layout.pages[0].fragments[0];
       expect(fragment.kind).toBe("paragraph");
       expect(fragment.blockId).toBe(0);
+    });
+
+    test("positions a text-anchored floating table from the current text cursor", () => {
+      const paragraph = makeParagraphBlock(0, "Anchor", 1);
+      const table: TableBlock = {
+        kind: "table",
+        id: 1,
+        rows: [
+          {
+            id: "row",
+            cells: [
+              {
+                id: "cell",
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                blocks: [makeParagraphBlock(2, "Value", 8)],
+              },
+            ],
+          },
+        ],
+        columnWidths: [200],
+        floating: { vertAnchor: "text", tblpY: 10 },
+      };
+      const paragraphMeasure = makeParagraphMeasure([makeLine(0, 0, 0, 6, 50, 40)]);
+      const tableMeasure: TableMeasure = {
+        kind: "table",
+        rows: [
+          {
+            cells: [
+              {
+                blocks: [makeParagraphMeasure([makeLine(0, 0, 0, 5, 40, 20)])],
+                width: 200,
+                height: 20,
+              },
+            ],
+            height: 20,
+          },
+        ],
+        columnWidths: [200],
+        totalWidth: 200,
+        totalHeight: 20,
+      };
+
+      const layout = layoutDocument(
+        [paragraph, table],
+        [paragraphMeasure, tableMeasure],
+        makeLayoutOptions(),
+      );
+      const tableFragment = layout.pages[0]?.fragments.find(
+        (fragment) => fragment.kind === "table",
+      );
+
+      expect(tableFragment?.y).toBe(DEFAULT_MARGINS.top + 40 + 10);
     });
 
     test("first paragraph on a page honors explicit spaceBefore", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1042,6 +1042,11 @@ function layoutFloatingTable(
   }
   if (floating?.vertAnchor === "page") {
     baseY = 0;
+  } else if (floating?.vertAnchor === "text") {
+    // A text-relative table position is offset from the current text
+    // anchor, not from the page's body margin. Using the margin here lifts
+    // later floating tables to the top of the page and overlays earlier text.
+    baseY = state.cursorY;
   }
 
   // Determine X position

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -18,10 +18,34 @@ import type { BlockLookup } from "./index";
 import {
   applySectionHeaderFooterOptions,
   computePageFingerprint,
+  floatingTableReservesBand,
   getDefaultPageFontFamily,
   renderPage,
   renderFootnoteArea,
 } from "./renderPage";
+
+describe("floating table wrap zones", () => {
+  test("reserves a top-and-bottom band when neither side can hold text", () => {
+    expect(
+      floatingTableReservesBand({
+        contentX: 0,
+        tableWidth: 577,
+        contentWidth: 578,
+        distLeft: 12,
+        distRight: 12,
+      }),
+    ).toBe(true);
+    expect(
+      floatingTableReservesBand({
+        contentX: 0,
+        tableWidth: 300,
+        contentWidth: 578,
+        distLeft: 12,
+        distRight: 12,
+      }),
+    ).toBe(false);
+  });
+});
 
 class FakeElement {
   className = "";

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -9,6 +9,7 @@ import { panic } from "better-result";
 
 import { measureParagraph, rectsToFloatingZones } from "../layout-engine/measure";
 import type { FloatingExclusionRect, FloatingImageZone } from "../layout-engine/measure";
+import { MIN_WRAP_SEGMENT_WIDTH } from "../layout-engine/measure/measureParagraph";
 import {
   FOOTNOTE_ENTRY_MARGIN_BOTTOM,
   FOOTNOTE_FALLBACK_LINE_HEIGHT,
@@ -101,6 +102,26 @@ export type PageFloatingImage = {
    * above-text layer so wrapNone semantics survive in the DOM.
    */
   behindDoc: boolean;
+};
+
+type FloatingTableBandOptions = {
+  contentX: number;
+  tableWidth: number;
+  contentWidth: number;
+  distLeft: number;
+  distRight: number;
+};
+
+export const floatingTableReservesBand = ({
+  contentX,
+  tableWidth,
+  contentWidth,
+  distLeft,
+  distRight,
+}: FloatingTableBandOptions): boolean => {
+  const leftClearance = Math.max(0, contentX - distLeft);
+  const rightClearance = Math.max(0, contentWidth - contentX - tableWidth - distRight);
+  return Math.max(leftClearance, rightClearance) < MIN_WRAP_SEGMENT_WIDTH;
 };
 
 type ScopedFloatingRect = {
@@ -1764,7 +1785,8 @@ export function renderPage(
 
   // Collect floating table exclusion rectangles
   if (options.blockLookup) {
-    for (const fragment of page.fragments) {
+    for (let fragmentIndex = 0; fragmentIndex < page.fragments.length; fragmentIndex++) {
+      const fragment = page.fragments[fragmentIndex]!; // SAFETY: bounded by page.fragments.length
       if (fragment.kind !== "table") {
         continue;
       }
@@ -1788,7 +1810,7 @@ export function renderPage(
 
       const side = contentX < contentWidth / 2 ? "left" : "right";
 
-      floatingRects.push({
+      const rect: FloatingExclusionRect = {
         side,
         x: contentX,
         y: contentY,
@@ -1798,7 +1820,23 @@ export function renderPage(
         distBottom,
         distLeft,
         distRight,
-      });
+      };
+      if (
+        floatingTableReservesBand({
+          contentX,
+          tableWidth: fragment.width,
+          contentWidth,
+          distLeft,
+          distRight,
+        })
+      ) {
+        rect.wrapType = "topAndBottom";
+      }
+      if (floating.vertAnchor === "text") {
+        scopedFloatingRects.push({ startsAtFragmentIndex: fragmentIndex, rect });
+      } else {
+        floatingRects.push(rect);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- resolve `vertAnchor="text"` table offsets from the current text cursor
- reserve a top-and-bottom wrap band when neither side of a floating table can hold text
- scope text-relative table exclusion zones to the anchor and following fragments
- prevent full-width floating tables from overlaying earlier or following body text

## Parity evidence

On the anonymized regression case:

- the misplaced full-width table no longer overlays page content
- matched lines: 115/129 → 124/129
- pages matched: 3/3
- score remains 0.473 because the remaining dominant signal is a separate mirrored-margin offset

## Verification

- layout-painter and layout-pipeline suites (291 passed)
- `bun audit` (no vulnerabilities)
- lint and typecheck: CI
