### PR TITLE
feat: normalize durable paragraph IDs at DOCX ingest

### DIFF
--- a/.changeset/ensure-para-ids-ingest.md
+++ b/.changeset/ensure-para-ids-ingest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add `ensureParaIds` to the server entry: a headless, in-place `w14:paraId` backfill for `.docx` buffers (document body, headers, footers, footnotes, endnotes; table-cell and text-box paragraphs included). Deterministic, idempotent, and namespace-aware, so hosts can normalize documents once at ingest and block anchors never fall back to positional `seq-` ids.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -94,6 +94,20 @@ export type ExtractedDocxText = {
     view: "accepted";
 };
 
+// @public
+export const ensureParaIds: (docx: Uint8Array | ArrayBuffer) => Promise<EnsureParaIdsResult>;
+
+// @public
+export class EnsureParaIdsError extends EnsureParaIdsError_base {}
+
+// @public
+export type EnsureParaIdsResult = {
+    docx: Uint8Array; /** Paragraphs that received a paraId (missing or all-zero before). */
+    assigned: number; /** Duplicate paraIds reassigned (the first occurrence keeps the id). */
+    deduplicated: number; /** True when the input already had full, unique coverage. */
+    alreadyComplete: boolean;
+};
+
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES: readonly ["best-effort", "atomic"];
 

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -74,6 +74,25 @@ export class DocxArchiveError extends DocxArchiveError_base {}
 export type DocxParagraphSource = "header" | "body" | "footer";
 
 // @public
+export const ensureParaIds: (docx: Uint8Array | ArrayBuffer, options?: EnsureParaIdsOptions) => Promise<EnsureParaIdsResult>;
+
+// @public
+export class EnsureParaIdsError extends EnsureParaIdsError_base {}
+
+// @public
+export type EnsureParaIdsOptions = {
+    allowSignedPackageMutation?: boolean;
+};
+
+// @public
+export type EnsureParaIdsResult = {
+    docx: Uint8Array; /** Paragraphs that received a paraId (missing or all-zero before). */
+    assigned: number; /** Duplicate paraIds reassigned (the first occurrence keeps the id). */
+    deduplicated: number; /** True when the input already had full, unique coverage. */
+    alreadyComplete: boolean;
+};
+
+// @public
 export const extractDocxText: (bytes: ArrayBuffer | Uint8Array) => Promise<ExtractedDocxText>;
 
 // @public
@@ -92,20 +111,6 @@ export type ExtractedDocxText = {
     paragraphs: ExtractedDocxParagraph[];
     charCount: number;
     view: "accepted";
-};
-
-// @public
-export const ensureParaIds: (docx: Uint8Array | ArrayBuffer) => Promise<EnsureParaIdsResult>;
-
-// @public
-export class EnsureParaIdsError extends EnsureParaIdsError_base {}
-
-// @public
-export type EnsureParaIdsResult = {
-    docx: Uint8Array; /** Paragraphs that received a paraId (missing or all-zero before). */
-    assigned: number; /** Duplicate paraIds reassigned (the first occurrence keeps the id). */
-    deduplicated: number; /** True when the input already had full, unique coverage. */
-    alreadyComplete: boolean;
 };
 
 // @public (undocumented)

--- a/docs/durable-block-ids.md
+++ b/docs/durable-block-ids.md
@@ -1,0 +1,155 @@
+# Durable block IDs in DOCX
+
+Goal: every block in every DOCX is addressable by a stable ID that survives
+editing in folio and in Microsoft Word, so the positional `seq-NNNN` fallback
+(known bug class: sequential IDs renumber after structural edits) becomes
+unreachable in practice. This unlocks per-block blame, robust comment and
+citation anchors, and AI-edit targeting for host applications.
+
+Provenance note: the direction was inspired by ideas in macro-inc/macro
+(AGPL-3.0). Ideas only; no code was read or ported. Everything here is
+original work against the OOXML spec and the existing folio code.
+
+## Status
+
+| Work item                                   | Status                                                                                                                                                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| WI-1 ingest normalization (`ensureParaIds`) | Implemented — `packages/core/src/docx/ensureParaIds.ts`, exported from `@stll/folio-core/server`                                                       |
+| WI-2 editor ID lifecycle spec + tests       | Implemented — `packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts` (header documents the rules; co-located tests lock them) |
+| Table identity                              | Decided against durable table-level IDs — see below                                                                                                    |
+| WI-5 touched-paraIds change reporting       | Design only — see below                                                                                                                                |
+
+## What already existed (do not rebuild)
+
+| Piece                                                                              | Where                                                                                                                        |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `w14:paraId` / `w14:textId` parsed off `<w:p>` (with a `w:paraId` prefix fallback) | `packages/core/src/docx/paragraphParser.ts`                                                                                  |
+| Both serialized back, emitted only when truthy                                     | `packages/core/src/docx/serializer/paragraphSerializer.ts`                                                                   |
+| In-editor allocator backfilling null/duplicate paraIds per doc-changed transaction | `packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts`                                              |
+| Hex ID generation with the OOXML `ST_LongHexNumber` bound                          | `packages/core/src/utils/hexId.ts`                                                                                           |
+| Deterministic load-time backfill in the headless reviewer                          | `packages/core/src/ai-edits/headless.ts` (`ensureDeterministicParaIdsInState`)                                               |
+| Live lookup by paraId                                                              | `packages/core/src/prosemirror/utils/findParagraphByParaId.ts`                                                               |
+| Live-first block resolution, snapshot fallback for `seq-`                          | `packages/react/src/components/aiEditRange.ts` (`resolveFolioAIBlockRange`; `scrollToBlock` in `DocxEditor.tsx` is a caller) |
+| String-offset part patching without the PM model                                   | `packages/core/src/docx/selectiveXmlPatch.ts`                                                                                |
+| Deterministic comment-part paraIds at save                                         | `packages/core/src/docx/serializer/commentSerializer.ts`                                                                     |
+
+## WI-1: `ensureParaIds` (implemented)
+
+`ensureParaIds(docx: Uint8Array | ArrayBuffer) -> Promise<{ docx: Uint8Array,
+assigned, deduplicated, alreadyComplete }>`. Hosts call it once at
+ingest/upload so every stored version has full ID coverage. Word 2010+ writes
+paraIds; Google Docs exports, LibreOffice, and python-docx/docx4j output
+generally do not — those are exactly the documents that fell into `seq-`.
+
+Contract highlights (the module doc in `ensureParaIds.ts` is normative):
+
+- Patches part XML in place with string splices (no model round-trip), so
+  unmodeled features survive byte-identical. Covers `word/document.xml`,
+  headers, footers, footnotes, endnotes; table-cell and `mc:Choice` text-box
+  paragraphs are nested `<w:p>` in those parts and are covered by the same
+  scan. The comments part mints its own deterministic paraIds at save time
+  and is left untouched (its IDs still count toward uniqueness).
+- `mc:Fallback` content is never modified: Word regenerates the fallback
+  branch (duplicating the `mc:Choice` IDs) on save, so stamping there would
+  churn on every Word round-trip.
+- Fresh IDs are deterministic (`deterministicHexId` over a document
+  fingerprint, part path, and paragraph ordinal): the pass is a pure function
+  of the input bytes, so retried ingests produce identical output.
+- Deviation from the original proposal: later duplicates ARE reassigned
+  (first occurrence keeps the ID). The proposal said "existing IDs are never
+  rewritten", but that conflicts with its own zero-`seq-` acceptance goal,
+  and duplicated IDs already break `findParagraphOffsets` (ambiguous → null)
+  and the editor allocator rewrites them on first edit anyway. Reassigning at
+  ingest matches what the document becomes after one editor session.
+- The reserved all-zero paraId is treated as unassigned (Word semantics).
+  `generateHexId` / `deterministicHexId` now exclude `00000000` at the
+  source.
+- Patched parts get `xmlns:w14`, `xmlns:mc`, and an `mc:Ignorable` listing
+  `w14` injected on the root when absent; non-Word producers declare none of
+  the three.
+- `w14:textId` is written alongside a newly minted paraId (same value),
+  never touched otherwise. It is a text-revision marker, not identity; never
+  key anything on it.
+- Idempotent: full-coverage input returns the original bytes
+  (`alreadyComplete: true`), byte-identical by construction. (A no-op rezip
+  would NOT be byte-identical — JSZip regenerates the container — which is
+  why the short-circuit exists.)
+
+Remaining validation beyond unit tests: a real-Word round-trip check (open,
+edit, save, confirm assigned IDs survive) via the parity harness; run against
+a corpus of Google-Docs/python-docx exports before wiring it into hosts.
+
+## WI-2: editor ID lifecycle (implemented)
+
+The rules are documented in the `ParaIdAllocatorExtension` header and locked
+by its tests:
+
+- Split: the half holding the paragraph's original start position keeps the
+  ID (anchors living in the content stay resolvable); the other half gets a
+  fresh one.
+- Merge/join: the survivor keeps its ID; the absorbed ID dangles by design
+  (consumers degrade to snapshot fallback).
+- Paste/duplicate of an ID already in the doc: resolved by mapping the
+  original paragraph's position through the transaction, so pasting a copy
+  ABOVE its source no longer steals the source's ID (a real bug under the
+  previous first-in-document-order rule). Fallback when nothing maps back:
+  first occurrence keeps.
+- Paste of an ID unknown to the doc (cross-doc paste, cut-then-paste move):
+  kept, so moving a paragraph preserves its anchors.
+- Undo/redo: allocation applies with `addToHistory: false`; redoing a split
+  mints a different fresh ID than before the undo. Accepted: an ID is stable
+  across saves, not across redo-recreation.
+- The appended allocation transaction is excluded from paragraph change
+  tracking (`ignoreTrackedChanges`), matching `ensureParaIdsInState`;
+  backfilling an untouched paragraph must not mark it as user-changed.
+
+Both changes are deliberate divergences from the eigenpal upstream; the file
+header notes them.
+
+## Table identity: decided against durable table-level IDs
+
+The framing document called out that tables/rows/cells carry no identity
+(`TableExtension.ts` node specs have no id attrs) but lost the work items
+covering it. Decision: do not add them. OOXML has no `paraId` equivalent for
+`<w:tbl>` / `<w:tr>` / `<w:tc>`, and Word strips unknown attributes on save,
+so any invented table ID would be durable only inside folio — a false sense
+of stability that dies on the first Word round-trip, which is exactly the
+failure mode this effort exists to remove. Tables are addressed indirectly
+through the paraIds of their contained paragraphs, which `ensureParaIds`
+guarantees exist (including in cells). If a session-scoped table identity is
+ever needed for UI purposes, it must be clearly non-persistent.
+
+## WI-5: touched-paraIds change reporting (design only)
+
+For downstream per-block blame (host-side, keyed by entity + paraId + author
+
+- timestamp), folio needs to report which blocks a change touched.
+  `applyAIEditOperations` / `applyDocumentOperations` return `{ applied,
+skipped }` where each applied entry carries `revisionIds` (note: nested per
+  entry, not top-level). Design: extend each applied entry with the affected
+  `blockIds` (paragraph-granular), and add a ref method returning paraIds
+  touched since a given snapshot. Implement when the host blame schema lands;
+  do not ship the surface speculatively.
+
+## Constraints and gotchas
+
+- `w14:paraId` validity: 8 uppercase hex chars, not `00000000`, below
+  `0x80000000`, unique document-wide. `hexId.ts` constants are the single
+  source of truth; reuse, don't reimplement.
+- `deriveBlockId` (`packages/core/src/types/block-id.ts`) returns the paraId
+  VERBATIM when present and non-duplicate; it does not mint hex. Its
+  contract is published (host server extractors and prompts consume it);
+  `seq-` support must remain for legacy snapshots. The goal is that new
+  snapshots never contain it.
+- `w:rsid*` attributes on `<w:p>` are dropped on import. Out of scope; leave
+  as-is.
+- The serializer emits `w14:paraId` only when truthy; after ingest
+  normalization plus the allocator that is always, but keep the guard.
+- `ParaIdAllocatorExtension` and `hexId.ts` carry upstream-sync headers for
+  the eigenpal fork; divergences must be noted there (both now are).
+
+## Host-side follow-ups (separate work, not in this repo)
+
+Calling `ensureParaIds` at upload/ingest and collaborative finalize; the
+blame storage and UI; migrating any paragraph-index-based redline tooling
+onto paraId addressing.

--- a/docs/durable-block-ids.md
+++ b/docs/durable-block-ids.md
@@ -1,10 +1,10 @@
 # Durable block IDs in DOCX
 
 Goal: every block in every DOCX is addressable by a stable ID that survives
-editing in folio and in Microsoft Word, so the positional `seq-NNNN` fallback
-(known bug class: sequential IDs renumber after structural edits) becomes
-unreachable in practice. This unlocks per-block blame, robust comment and
-citation anchors, and AI-edit targeting for host applications.
+editing in folio and identity-preserving DOCX round-trips, so the positional
+`seq-NNNN` fallback (known bug class: sequential IDs renumber after structural
+edits) becomes unreachable in practice. This unlocks per-block blame, robust
+comment and citation anchors, and AI-edit targeting for host applications.
 
 Provenance note: the direction was inspired by ideas in macro-inc/macro
 (AGPL-3.0). Ideas only; no code was read or ported. Everything here is
@@ -75,9 +75,24 @@ Contract highlights (the module doc in `ensureParaIds.ts` is normative):
   would NOT be byte-identical — JSZip regenerates the container — which is
   why the short-circuit exists.)
 
-Remaining validation beyond unit tests: a real-Word round-trip check (open,
-edit, save, confirm assigned IDs survive) via the parity harness; run against
-a corpus of Google-Docs/python-docx exports before wiring it into hosts.
+### Microsoft Word round-trip result
+
+A real Word edit/save check established the boundary of the durability
+contract:
+
+- When a Word-saved package had one paragraph ID pair removed,
+  `ensureParaIds` restored it and Word preserved all 26 paragraph IDs on the
+  next edit/save. This is the normal identity-preserving round-trip.
+- On the first Word save of a non-Word-produced package, Word replaced
+  `w14:docId` and every paragraph ID. Supplying a valid, previously unseen
+  `w15:docId` did not change that behavior. IDs minted before Word adopts the
+  package therefore do not survive that first save.
+
+The second case is outside this function's control: the IDs are valid OOXML,
+but Word elects to establish a new document identity. Hosts that accept an
+externally edited package must normalize it again; if anchors must cross that
+first Word save, they need content-based reconciliation rather than assuming
+the old and new paraIds match.
 
 ## WI-2: editor ID lifecycle (implemented)
 
@@ -96,9 +111,9 @@ by its tests:
   first occurrence keeps.
 - Paste of an ID unknown to the doc (cross-doc paste, cut-then-paste move):
   kept, so moving a paragraph preserves its anchors.
-- Undo/redo: allocation applies with `addToHistory: false`; redoing a split
-  mints a different fresh ID than before the undo. Accepted: an ID is stable
-  across saves, not across redo-recreation.
+- Undo/redo: allocation applies with `addToHistory: false`; ProseMirror remaps
+  the allocation into the originating history event, so redoing a split
+  restores the same allocated ID.
 - The appended allocation transaction is excluded from paragraph change
   tracking (`ignoreTrackedChanges`), matching `ensureParaIdsInState`;
   backfilling an untouched paragraph must not mark it as user-changed.
@@ -136,6 +151,9 @@ skipped }` where each applied entry carries `revisionIds` (note: nested per
 - `w14:paraId` validity: 8 uppercase hex chars, not `00000000`, below
   `0x80000000`, unique document-wide. `hexId.ts` constants are the single
   source of truth; reuse, don't reimplement.
+- Durability follows the document identity. Microsoft Word can replace
+  `w14:docId` and all paraIds on its first save of a non-Word-produced package;
+  never promise pre-save paraId continuity across that boundary.
 - `deriveBlockId` (`packages/core/src/types/block-id.ts`) returns the paraId
   VERBATIM when present and non-duplicate; it does not mint hex. Its
   contract is published (host server extractors and prompts consume it);

--- a/docs/durable-block-ids.md
+++ b/docs/durable-block-ids.md
@@ -37,7 +37,8 @@ original work against the OOXML spec and the existing folio code.
 
 `ensureParaIds(docx: Uint8Array | ArrayBuffer) -> Promise<{ docx: Uint8Array,
 assigned, deduplicated, alreadyComplete }>`. Hosts call it once at
-ingest/upload so every stored version has full ID coverage. Word 2010+ writes
+ingest/upload, before deriving or storing any block anchors, so every stored
+working version has full ID coverage. Word 2010+ writes
 paraIds; Google Docs exports, LibreOffice, and python-docx/docx4j output
 generally do not — those are exactly the documents that fell into `seq-`.
 
@@ -74,6 +75,10 @@ Contract highlights (the module doc in `ensureParaIds.ts` is normative):
   (`alreadyComplete: true`), byte-identical by construction. (A no-op rezip
   would NOT be byte-identical — JSZip regenerates the container — which is
   why the short-circuit exists.)
+- OPC digital signatures cover package bytes and become invalid when a signed
+  package is rewritten. A signed document that is already complete is returned
+  untouched. If normalization is required, the default is to reject it;
+  callers may set `allowSignedPackageMutation` only after warning the user.
 
 ### Microsoft Word round-trip result
 

--- a/packages/core/src/docx/ensureParaIds.test.ts
+++ b/packages/core/src/docx/ensureParaIds.test.ts
@@ -51,7 +51,14 @@ const getPart = async (docx: Uint8Array, path: string): Promise<string> => {
 };
 
 const collectIds = (xml: string): string[] =>
-  [...xml.matchAll(/w14:paraId="(?<id>[^"]*)"/gu)].map((match) => match.groups!["id"]!);
+  [...xml.matchAll(/w14:paraId=(?<quote>["'])(?<id>[\s\S]*?)\k<quote>/gu)].map(
+    (match) => match.groups!["id"]!,
+  );
+
+const collectTextIds = (xml: string): string[] =>
+  [...xml.matchAll(/w14:textId=(?<quote>["'])(?<id>[\s\S]*?)\k<quote>/gu)].map(
+    (match) => match.groups!["id"]!,
+  );
 
 const PARA = (text: string, attrs = ""): string =>
   `<w:p${attrs}><w:r><w:t>${text}</w:t></w:r></w:p>`;
@@ -112,6 +119,24 @@ describe("ensureParaIds", () => {
     expect(xml.match(/xmlns:w14=/gu)).toHaveLength(1);
   });
 
+  test("supports single-quoted ids, namespaces, and mc:Ignorable values", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        `${PARA("Kept", " w14:paraId='1A2B3C4D' w14:textId='1A2B3C4D'")}${PARA("Needs one")}`,
+        " xmlns:mc='http://schemas.openxmlformats.org/markup-compatibility/2006' xmlns:w14='http://schemas.microsoft.com/office/word/2010/wordml' xmlns:w15='urn:x' mc:Ignorable='w15'",
+      ),
+    });
+
+    const result = await ensureParaIds(input);
+    const xml = await getPart(result.docx, "word/document.xml");
+
+    expect(result.assigned).toBe(1);
+    expect(collectIds(xml)[0]).toBe("1A2B3C4D");
+    expect(xml).toContain("mc:Ignorable='w15 w14'");
+    expect(xml.match(/xmlns:mc=/gu)).toHaveLength(1);
+    expect(xml.match(/xmlns:w14=/gu)).toHaveLength(1);
+  });
+
   test("is deterministic: same input bytes produce identical output bytes", async () => {
     const input = await buildDocx({
       "word/document.xml": documentXml(`${PARA("One")}${PARA("Two")}`),
@@ -157,20 +182,24 @@ describe("ensureParaIds", () => {
 
   test("treats the reserved all-zero paraId as unassigned", async () => {
     const input = await buildDocx({
-      "word/document.xml": documentXml(PARA("Zeroed", ' w14:paraId="00000000"')),
+      "word/document.xml": documentXml(
+        PARA("Zeroed", ' w14:paraId="00000000" w14:textId="DEADBEEF"'),
+      ),
     });
 
     const result = await ensureParaIds(input);
     expect(result.assigned).toBe(1);
 
     const xml = await getPart(result.docx, "word/document.xml");
-    expect(collectIds(xml)[0]).not.toBe("00000000");
+    const id = collectIds(xml)[0];
+    expect(id).not.toBe("00000000");
+    expect(collectTextIds(xml)[0]).toBe(id);
   });
 
   test("reassigns later duplicates; the first occurrence keeps the id", async () => {
     const input = await buildDocx({
       "word/document.xml": documentXml(
-        `${PARA("Original", ' w14:paraId="ABCD1234"')}${PARA("Copy", ' w14:paraId="ABCD1234"')}`,
+        `${PARA("Original", ' w14:paraId="ABCD1234"')}${PARA("Copy", ' w14:paraId="ABCD1234" w14:textId="DEADBEEF"')}`,
       ),
     });
 
@@ -182,13 +211,29 @@ describe("ensureParaIds", () => {
     expect(ids[0]).toBe("ABCD1234");
     expect(ids[1]).not.toBe("ABCD1234");
     expect(ids[1]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(collectTextIds(xml)[0]).toBe(ids[1]);
+  });
+
+  test("ignores comments, CDATA, and processing instructions during the XML scan", async () => {
+    const opaque =
+      '<!-- <w:p w14:paraId="AAAA0001"/> --><![CDATA[<w:p w14:paraId="BBBB0002"/>]]><?folio <w:p w14:paraId="CCCC0003"/> ?>';
+    const input = await buildDocx({
+      "word/document.xml": documentXml(`${opaque}${PARA("Real paragraph")}`),
+    });
+
+    const result = await ensureParaIds(input);
+    const xml = await getPart(result.docx, "word/document.xml");
+
+    expect(result.assigned).toBe(1);
+    expect(collectIds(xml)).toHaveLength(4);
+    expect(xml).toContain(opaque);
   });
 
   test("never modifies paragraphs inside mc:Fallback", async () => {
     const fallbackParagraph = PARA("Shadow copy", ' w14:paraId="FEED0001"');
     const input = await buildDocx({
       "word/document.xml": documentXml(
-        `<w:p><w:r><mc:AlternateContent><mc:Choice Requires="wps">${PARA("Box text")}</mc:Choice><mc:Fallback>${fallbackParagraph}${PARA("No id either")}</mc:Fallback></mc:AlternateContent></w:r></w:p>`,
+        `<w:p w14:paraId="FEED0001"><w:r><mc:AlternateContent><mc:Choice Requires="wps">${PARA("Box text")}</mc:Choice><mc:Fallback>${fallbackParagraph}${PARA("No id either")}</mc:Fallback></mc:AlternateContent></w:r></w:p>`,
       ),
     });
 
@@ -198,30 +243,42 @@ describe("ensureParaIds", () => {
     // The fallback branch is byte-identical: the id-less paragraph stays
     // id-less and the existing id is not treated as a duplicate to rewrite.
     expect(xml).toContain(`<mc:Fallback>${fallbackParagraph}${PARA("No id either")}</mc:Fallback>`);
-    // The outer paragraph and the mc:Choice paragraph both got ids.
-    expect(result.assigned).toBe(2);
+    // The fallback ID owns its value, so the conflicting outer paragraph is
+    // reminted even though it appears first; the mc:Choice paragraph gets an ID.
+    expect(result.assigned).toBe(1);
+    expect(result.deduplicated).toBe(1);
   });
 
-  test("covers headers and footnotes with document-wide uniqueness", async () => {
+  test("covers headers, footers, footnotes, and endnotes with document-wide uniqueness", async () => {
     const headerXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:hdr ${W_NS}>${PARA("Header text")}</w:hdr>`;
+    const footerXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:ftr ${W_NS}>${PARA("Footer text")}</w:ftr>`;
     const footnotesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:footnotes ${W_NS}><w:footnote w:id="1">${PARA("Footnote text")}</w:footnote></w:footnotes>`;
+    const endnotesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:endnotes ${W_NS}><w:endnote w:id="1">${PARA("Endnote text")}</w:endnote></w:endnotes>`;
     const input = await buildDocx({
       "word/document.xml": documentXml(PARA("Body")),
       "word/header1.xml": headerXml,
+      "word/footer1.xml": footerXml,
       "word/footnotes.xml": footnotesXml,
+      "word/endnotes.xml": endnotesXml,
     });
 
     const result = await ensureParaIds(input);
-    expect(result.assigned).toBe(3);
+    expect(result.assigned).toBe(5);
 
     const bodyIds = collectIds(await getPart(result.docx, "word/document.xml"));
     const headerIds = collectIds(await getPart(result.docx, "word/header1.xml"));
+    const footerIds = collectIds(await getPart(result.docx, "word/footer1.xml"));
     const footnoteIds = collectIds(await getPart(result.docx, "word/footnotes.xml"));
+    const endnoteIds = collectIds(await getPart(result.docx, "word/endnotes.xml"));
     expect(headerIds).toHaveLength(1);
+    expect(footerIds).toHaveLength(1);
     expect(footnoteIds).toHaveLength(1);
-    const all = [...bodyIds, ...headerIds, ...footnoteIds];
+    expect(endnoteIds).toHaveLength(1);
+    const all = [...bodyIds, ...headerIds, ...footerIds, ...footnoteIds, ...endnoteIds];
     expect(new Set(all).size).toBe(all.length);
 
     const headerOut = await getPart(result.docx, "word/header1.xml");
@@ -230,14 +287,28 @@ describe("ensureParaIds", () => {
 
   test("leaves the comments part untouched while honoring its ids as taken", async () => {
     const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:comments ${W_NS}><w:comment w:id="0"><w:p><w:r><w:t>A comment</w:t></w:r></w:p></w:comment></w:comments>`;
+<w:comments ${W_NS} xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:comment w:id="0">${PARA("A comment", ' w14:paraId="C0FFEE01"')}</w:comment></w:comments>`;
     const input = await buildDocx({
-      "word/document.xml": documentXml(PARA("Body")),
+      "word/document.xml": documentXml(PARA("Body", ' w14:paraId="C0FFEE01"')),
       "word/comments.xml": commentsXml,
     });
 
     const result = await ensureParaIds(input);
+    expect(result.deduplicated).toBe(1);
+    const bodyIds = collectIds(await getPart(result.docx, "word/document.xml"));
+    expect(bodyIds[0]).not.toBe("C0FFEE01");
     expect(await getPart(result.docx, "word/comments.xml")).toBe(commentsXml);
+  });
+
+  test("rejects conflicting w14 or mc namespace bindings before patching", async () => {
+    const conflictingRoots = [' xmlns:w14="urn:wrong"', ' xmlns:mc="urn:wrong"'];
+
+    for (const rootAttrs of conflictingRoots) {
+      const input = await buildDocx({
+        "word/document.xml": documentXml(PARA("Body"), rootAttrs),
+      });
+      await expect(ensureParaIds(input)).rejects.toThrow(EnsureParaIdsError);
+    }
   });
 
   test("a normalized document snapshots with zero seq- block ids", async () => {
@@ -263,6 +334,21 @@ describe("ensureParaIds", () => {
     zip.file("hello.txt", "not a docx");
     const notDocx = await zip.generateAsync({ type: "uint8array" });
 
-    expect(ensureParaIds(notDocx)).rejects.toThrow(EnsureParaIdsError);
+    await expect(ensureParaIds(notDocx)).rejects.toThrow(EnsureParaIdsError);
+  });
+
+  test("wraps malformed ZIP input in EnsureParaIdsError", async () => {
+    const malformed = new Uint8Array([0, 1, 2, 3]);
+
+    const error = await ensureParaIds(malformed).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(EnsureParaIdsError);
+    if (!(error instanceof EnsureParaIdsError)) {
+      throw new Error("Expected EnsureParaIdsError");
+    }
+    expect(error.message).toContain("Failed to normalize paragraph IDs");
+    expect(error.cause).toBeInstanceOf(Error);
   });
 });

--- a/packages/core/src/docx/ensureParaIds.test.ts
+++ b/packages/core/src/docx/ensureParaIds.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for the headless `ensureParaIds` ingest pass.
+ *
+ * Fixtures are built in-test as minimal WordprocessingML packages in the
+ * shape python-docx / Google Docs exports produce: no `w14` namespace, no
+ * `mc:Ignorable`, no paraIds anywhere.
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { createFolioAIEditSnapshot } from "../ai-edits/snapshot";
+import { isSequentialFolioBlockId } from "../types/block-id";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import { ensureParaIds, EnsureParaIdsError } from "./ensureParaIds";
+import { parseDocx } from "./parser";
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`;
+
+const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`;
+
+const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`;
+
+const W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+const documentXml = (body: string, extraRootAttrs = ""): string =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document ${W_NS}${extraRootAttrs}><w:body>${body}<w:sectPr/></w:body></w:document>`;
+
+const buildDocx = async (parts: Record<string, string>): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", CONTENT_TYPES);
+  zip.file("_rels/.rels", ROOT_RELS);
+  zip.file("word/_rels/document.xml.rels", DOCUMENT_RELS);
+  for (const [path, content] of Object.entries(parts)) {
+    zip.file(path, content);
+  }
+  return zip.generateAsync({ type: "uint8array" });
+};
+
+const getPart = async (docx: Uint8Array, path: string): Promise<string> => {
+  const zip = await JSZip.loadAsync(docx);
+  const entry = zip.file(path);
+  if (!entry) {
+    throw new Error(`missing part: ${path}`);
+  }
+  return entry.async("text");
+};
+
+const collectIds = (xml: string): string[] =>
+  [...xml.matchAll(/w14:paraId="(?<id>[^"]*)"/gu)].map((match) => match.groups!["id"]!);
+
+const PARA = (text: string, attrs = ""): string =>
+  `<w:p${attrs}><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+describe("ensureParaIds", () => {
+  test("backfills paraId + textId on every paragraph, including table cells", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        `${PARA("First")}<w:p/><w:tbl><w:tr><w:tc><w:tcPr/>${PARA("Cell")}</w:tc></w:tr></w:tbl>`,
+      ),
+    });
+
+    const result = await ensureParaIds(input);
+    expect(result.alreadyComplete).toBe(false);
+    expect(result.assigned).toBe(3);
+    expect(result.deduplicated).toBe(0);
+
+    const xml = await getPart(result.docx, "word/document.xml");
+    const ids = collectIds(xml);
+    expect(ids).toHaveLength(3);
+    for (const id of ids) {
+      expect(id).toMatch(/^[0-9A-F]{8}$/u);
+      expect(id).not.toBe("00000000");
+    }
+    expect(new Set(ids).size).toBe(3);
+    // textId minted alongside, same value.
+    for (const id of ids) {
+      expect(xml).toContain(`w14:paraId="${id}" w14:textId="${id}"`);
+    }
+  });
+
+  test("declares xmlns:w14 / xmlns:mc and mc:Ignorable on a root that lacks them", async () => {
+    const input = await buildDocx({ "word/document.xml": documentXml(PARA("Hello")) });
+
+    const { docx } = await ensureParaIds(input);
+    const xml = await getPart(docx, "word/document.xml");
+
+    expect(xml).toContain('xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"');
+    expect(xml).toContain('xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"');
+    expect(xml).toContain('mc:Ignorable="w14"');
+    // Declarations land on the root element, before its first child.
+    expect(xml.indexOf("xmlns:w14")).toBeLessThan(xml.indexOf("<w:body>"));
+  });
+
+  test("appends w14 to an existing mc:Ignorable and keeps declared namespaces single", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        PARA("Hello"),
+        ' xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:w15="urn:x" mc:Ignorable="w15"',
+      ),
+    });
+
+    const { docx } = await ensureParaIds(input);
+    const xml = await getPart(docx, "word/document.xml");
+
+    expect(xml).toContain('mc:Ignorable="w15 w14"');
+    expect(xml.match(/xmlns:mc=/gu)).toHaveLength(1);
+    expect(xml.match(/xmlns:w14=/gu)).toHaveLength(1);
+  });
+
+  test("is deterministic: same input bytes produce identical output bytes", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(`${PARA("One")}${PARA("Two")}`),
+    });
+
+    const first = await ensureParaIds(input);
+    const second = await ensureParaIds(input);
+    expect(first.docx).toEqual(second.docx);
+  });
+
+  test("is idempotent: a normalized document short-circuits to the input bytes", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(`${PARA("One")}${PARA("Two")}`),
+    });
+
+    const first = await ensureParaIds(input);
+    const second = await ensureParaIds(first.docx);
+
+    expect(second.alreadyComplete).toBe(true);
+    expect(second.assigned).toBe(0);
+    expect(second.deduplicated).toBe(0);
+    // Byte-identical by construction: the very same buffer comes back.
+    expect(second.docx).toBe(first.docx);
+  });
+
+  test("preserves existing ids verbatim and only fills gaps", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        `${PARA("Kept", ' w14:paraId="1A2B3C4D" w14:textId="1A2B3C4D"')}${PARA("Needs one")}`,
+        ' xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14"',
+      ),
+    });
+
+    const result = await ensureParaIds(input);
+    expect(result.assigned).toBe(1);
+
+    const xml = await getPart(result.docx, "word/document.xml");
+    const ids = collectIds(xml);
+    expect(ids[0]).toBe("1A2B3C4D");
+    expect(ids[1]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[1]).not.toBe("1A2B3C4D");
+  });
+
+  test("treats the reserved all-zero paraId as unassigned", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(PARA("Zeroed", ' w14:paraId="00000000"')),
+    });
+
+    const result = await ensureParaIds(input);
+    expect(result.assigned).toBe(1);
+
+    const xml = await getPart(result.docx, "word/document.xml");
+    expect(collectIds(xml)[0]).not.toBe("00000000");
+  });
+
+  test("reassigns later duplicates; the first occurrence keeps the id", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        `${PARA("Original", ' w14:paraId="ABCD1234"')}${PARA("Copy", ' w14:paraId="ABCD1234"')}`,
+      ),
+    });
+
+    const result = await ensureParaIds(input);
+    expect(result.deduplicated).toBe(1);
+
+    const xml = await getPart(result.docx, "word/document.xml");
+    const ids = collectIds(xml);
+    expect(ids[0]).toBe("ABCD1234");
+    expect(ids[1]).not.toBe("ABCD1234");
+    expect(ids[1]).toMatch(/^[0-9A-F]{8}$/u);
+  });
+
+  test("never modifies paragraphs inside mc:Fallback", async () => {
+    const fallbackParagraph = PARA("Shadow copy", ' w14:paraId="FEED0001"');
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        `<w:p><w:r><mc:AlternateContent><mc:Choice Requires="wps">${PARA("Box text")}</mc:Choice><mc:Fallback>${fallbackParagraph}${PARA("No id either")}</mc:Fallback></mc:AlternateContent></w:r></w:p>`,
+      ),
+    });
+
+    const result = await ensureParaIds(input);
+    const xml = await getPart(result.docx, "word/document.xml");
+
+    // The fallback branch is byte-identical: the id-less paragraph stays
+    // id-less and the existing id is not treated as a duplicate to rewrite.
+    expect(xml).toContain(`<mc:Fallback>${fallbackParagraph}${PARA("No id either")}</mc:Fallback>`);
+    // The outer paragraph and the mc:Choice paragraph both got ids.
+    expect(result.assigned).toBe(2);
+  });
+
+  test("covers headers and footnotes with document-wide uniqueness", async () => {
+    const headerXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr ${W_NS}>${PARA("Header text")}</w:hdr>`;
+    const footnotesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes ${W_NS}><w:footnote w:id="1">${PARA("Footnote text")}</w:footnote></w:footnotes>`;
+    const input = await buildDocx({
+      "word/document.xml": documentXml(PARA("Body")),
+      "word/header1.xml": headerXml,
+      "word/footnotes.xml": footnotesXml,
+    });
+
+    const result = await ensureParaIds(input);
+    expect(result.assigned).toBe(3);
+
+    const bodyIds = collectIds(await getPart(result.docx, "word/document.xml"));
+    const headerIds = collectIds(await getPart(result.docx, "word/header1.xml"));
+    const footnoteIds = collectIds(await getPart(result.docx, "word/footnotes.xml"));
+    expect(headerIds).toHaveLength(1);
+    expect(footnoteIds).toHaveLength(1);
+    const all = [...bodyIds, ...headerIds, ...footnoteIds];
+    expect(new Set(all).size).toBe(all.length);
+
+    const headerOut = await getPart(result.docx, "word/header1.xml");
+    expect(headerOut).toContain('mc:Ignorable="w14"');
+  });
+
+  test("leaves the comments part untouched while honoring its ids as taken", async () => {
+    const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments ${W_NS}><w:comment w:id="0"><w:p><w:r><w:t>A comment</w:t></w:r></w:p></w:comment></w:comments>`;
+    const input = await buildDocx({
+      "word/document.xml": documentXml(PARA("Body")),
+      "word/comments.xml": commentsXml,
+    });
+
+    const result = await ensureParaIds(input);
+    expect(await getPart(result.docx, "word/comments.xml")).toBe(commentsXml);
+  });
+
+  test("a normalized document snapshots with zero seq- block ids", async () => {
+    const input = await buildDocx({
+      "word/document.xml": documentXml(
+        `${PARA("First paragraph")}${PARA("Second paragraph")}<w:tbl><w:tr><w:tc><w:tcPr/>${PARA("Cell paragraph")}</w:tc></w:tr></w:tbl>`,
+      ),
+    });
+
+    const { docx } = await ensureParaIds(input);
+    const buffer = docx.buffer.slice(docx.byteOffset, docx.byteOffset + docx.byteLength);
+    const parsed = await parseDocx(buffer, { detectVariables: false, preloadFonts: false });
+    const snapshot = createFolioAIEditSnapshot(toProseDoc(parsed));
+
+    expect(snapshot.blocks.length).toBeGreaterThanOrEqual(3);
+    for (const block of snapshot.blocks) {
+      expect(isSequentialFolioBlockId(block.id)).toBe(false);
+    }
+  });
+
+  test("rejects a buffer without word/document.xml", async () => {
+    const zip = new JSZip();
+    zip.file("hello.txt", "not a docx");
+    const notDocx = await zip.generateAsync({ type: "uint8array" });
+
+    expect(ensureParaIds(notDocx)).rejects.toThrow(EnsureParaIdsError);
+  });
+});

--- a/packages/core/src/docx/ensureParaIds.test.ts
+++ b/packages/core/src/docx/ensureParaIds.test.ts
@@ -24,6 +24,11 @@ const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`;
 
+const DIGITAL_SIGNATURE_PARTS = {
+  "_xmlsignatures/origin.sigs": "",
+  "_xmlsignatures/sig1.xml": '<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"/>',
+};
+
 const W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 
 const documentXml = (body: string, extraRootAttrs = ""): string =>
@@ -309,6 +314,34 @@ describe("ensureParaIds", () => {
       });
       await expect(ensureParaIds(input)).rejects.toThrow(EnsureParaIdsError);
     }
+  });
+
+  test("requires explicit opt-in before invalidating package signatures", async () => {
+    const input = await buildDocx({
+      ...DIGITAL_SIGNATURE_PARTS,
+      "word/document.xml": documentXml(PARA("Needs an ID")),
+    });
+
+    await expect(ensureParaIds(input)).rejects.toThrow("digitally signed package");
+
+    const result = await ensureParaIds(input, { allowSignedPackageMutation: true });
+    expect(result.assigned).toBe(1);
+    expect(result.alreadyComplete).toBe(false);
+  });
+
+  test("returns an already-complete signed package byte-identically", async () => {
+    const input = await buildDocx({
+      ...DIGITAL_SIGNATURE_PARTS,
+      "word/document.xml": documentXml(
+        PARA("Already identified", ' w14:paraId="12345678" w14:textId="12345678"'),
+        ' xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14"',
+      ),
+    });
+
+    const result = await ensureParaIds(input);
+
+    expect(result.alreadyComplete).toBe(true);
+    expect(result.docx).toBe(input);
   });
 
   test("a normalized document snapshots with zero seq- block ids", async () => {

--- a/packages/core/src/docx/ensureParaIds.ts
+++ b/packages/core/src/docx/ensureParaIds.ts
@@ -9,6 +9,12 @@
  * once at ingest so every stored version has full id coverage before any
  * snapshot is taken.
  *
+ * IDs remain stable in folio and identity-preserving DOCX round-trips.
+ * Microsoft Word can establish a new `w14:docId` and replace all paragraph
+ * IDs on its first save of a non-Word-produced package; callers that ingest
+ * such an externally edited version must normalize it again and cannot assume
+ * the pre-save IDs still match.
+ *
  * The pass patches part XML in place (string splices, no model round-trip),
  * so documents carrying features folio's parser does not model come back
  * with those features byte-identical. Contract:
@@ -39,15 +45,19 @@
  * - Idempotent: a document that already has full coverage is returned as the
  *   original bytes, untouched (`alreadyComplete: true`).
  */
+import { TaggedError } from "better-result";
 import JSZip from "jszip";
 
 import { deterministicHexId } from "../utils/hexId";
 import { isXmlNameBoundary } from "./selectiveXmlPatch";
 
-export class EnsureParaIdsError extends Error {
-  override name = "EnsureParaIdsError";
-}
+/** A malformed or unsupported package prevented paragraph-ID normalization. */
+export class EnsureParaIdsError extends TaggedError("EnsureParaIdsError")<{
+  message: string;
+  cause?: unknown;
+}>() {}
 
+/** Counts and normalized bytes returned by {@link ensureParaIds}. */
 export type EnsureParaIdsResult = {
   /** The normalized `.docx`; the input bytes verbatim when `alreadyComplete`. */
   docx: Uint8Array;
@@ -77,17 +87,22 @@ const TARGET_PART_PATTERNS = [
 const PARAGRAPH_OPEN = "<w:p";
 const FALLBACK_OPEN = "<mc:Fallback";
 const FALLBACK_CLOSE = "</mc:Fallback>";
+const OPAQUE_XML_REGIONS = [
+  { open: "<!--", close: "-->" },
+  { open: "<![CDATA[", close: "]]>" },
+  { open: "<?", close: "?>" },
+] as const;
 
 /**
  * The parser accepts the `w:` fallback prefix for paraId, and comment parts
  * link replies via `w15:paraId` — all three count toward uniqueness.
  */
-const ANY_PARA_ID_PATTERN = /\bw(?:14|15)?:paraId="(?<id>[^"]*)"/gu;
-const OPEN_TAG_PARA_ID_PATTERN = /\sw(?:14)?:paraId="(?<id>[^"]*)"/u;
-const OPEN_TAG_TEXT_ID_PATTERN = /\sw(?:14)?:textId="/u;
-const XMLNS_W14_PATTERN = /\sxmlns:w14="/u;
-const XMLNS_MC_PATTERN = /\sxmlns:mc="/u;
-const MC_IGNORABLE_PATTERN = /\smc:Ignorable="(?<value>[^"]*)"/u;
+const ANY_PARA_ID_PATTERN = /\bw(?:14|15)?:paraId=(?<quote>["'])(?<id>[\s\S]*?)\k<quote>/gu;
+const OPEN_TAG_PARA_ID_PATTERN = /\sw(?:14)?:paraId=(?<quote>["'])(?<id>[\s\S]*?)\k<quote>/u;
+const OPEN_TAG_TEXT_ID_PATTERN = /\sw(?:14)?:textId=(?<quote>["'])(?<id>[\s\S]*?)\k<quote>/u;
+const XMLNS_W14_PATTERN = /\sxmlns:w14=(?<quote>["'])(?<value>[\s\S]*?)\k<quote>/u;
+const XMLNS_MC_PATTERN = /\sxmlns:mc=(?<quote>["'])(?<value>[\s\S]*?)\k<quote>/u;
+const MC_IGNORABLE_PATTERN = /\smc:Ignorable=(?<quote>["'])(?<value>[\s\S]*?)\k<quote>/u;
 
 type SpliceEdit = { start: number; end: number; text: string };
 
@@ -100,6 +115,35 @@ const applySplices = (xml: string, edits: SpliceEdit[]): string => {
   return result;
 };
 
+const createEnsureParaIdsError = (message: string, cause?: unknown): EnsureParaIdsError =>
+  new EnsureParaIdsError({ message, ...(cause === undefined ? {} : { cause }) });
+
+const skipOpaqueXmlRegion = (xml: string, start: number, partPath: string): number | null => {
+  for (const { open, close } of OPAQUE_XML_REGIONS) {
+    if (!xml.startsWith(open, start)) {
+      continue;
+    }
+    const closeStart = xml.indexOf(close, start + open.length);
+    if (closeStart === -1) {
+      throw createEnsureParaIdsError(`Unterminated ${open} region in ${partPath}`);
+    }
+    return closeStart + close.length;
+  }
+  return null;
+};
+
+const attributeValueRange = (
+  match: RegExpExecArray,
+  absoluteOffset: number,
+  group: "id" | "value",
+): { start: number; end: number } => {
+  // SAFETY: every attribute pattern has matching `quote` and requested value groups.
+  const quote = match.groups!["quote"]!;
+  const value = match.groups![group]!;
+  const start = absoluteOffset + match.index + match[0].indexOf(quote) + 1;
+  return { start, end: start + value.length };
+};
+
 const collectExistingParaIds = (xml: string, into: Set<string>): void => {
   for (const match of xml.matchAll(ANY_PARA_ID_PATTERN)) {
     // SAFETY: named group `id` always present when the pattern matches
@@ -107,6 +151,65 @@ const collectExistingParaIds = (xml: string, into: Set<string>): void => {
     if (id.length > 0) {
       into.add(id.toUpperCase());
     }
+  }
+};
+
+const collectFallbackParaIds = (xml: string, partPath: string, into: Set<string>): void => {
+  let fallbackDepth = 0;
+  let pos = 0;
+
+  while (pos < xml.length) {
+    const tagStart = xml.indexOf("<", pos);
+    if (tagStart === -1) {
+      return;
+    }
+
+    const opaqueEnd = skipOpaqueXmlRegion(xml, tagStart, partPath);
+    if (opaqueEnd !== null) {
+      pos = opaqueEnd;
+      continue;
+    }
+
+    if (
+      xml.startsWith(FALLBACK_OPEN, tagStart) &&
+      isXmlNameBoundary(xml[tagStart + FALLBACK_OPEN.length])
+    ) {
+      const tagEnd = xml.indexOf(">", tagStart);
+      if (tagEnd === -1) {
+        throw createEnsureParaIdsError(`Unterminated <mc:Fallback> tag in ${partPath}`);
+      }
+      if (xml[tagEnd - 1] !== "/") {
+        fallbackDepth += 1;
+      }
+      pos = tagEnd + 1;
+      continue;
+    }
+
+    if (xml.startsWith(FALLBACK_CLOSE, tagStart)) {
+      fallbackDepth = Math.max(0, fallbackDepth - 1);
+      pos = tagStart + FALLBACK_CLOSE.length;
+      continue;
+    }
+
+    if (
+      fallbackDepth === 0 ||
+      !xml.startsWith(PARAGRAPH_OPEN, tagStart) ||
+      !isXmlNameBoundary(xml[tagStart + PARAGRAPH_OPEN.length])
+    ) {
+      pos = tagStart + 1;
+      continue;
+    }
+
+    const tagEnd = xml.indexOf(">", tagStart);
+    if (tagEnd === -1) {
+      throw createEnsureParaIdsError(`Unterminated <w:p> tag in ${partPath}`);
+    }
+    const match = OPEN_TAG_PARA_ID_PATTERN.exec(xml.slice(tagStart, tagEnd + 1));
+    const id = match?.groups?.["id"];
+    if (id) {
+      into.add(id.toUpperCase());
+    }
+    pos = tagEnd + 1;
   }
 };
 
@@ -162,13 +265,19 @@ const scanPart = (
       break;
     }
 
+    const opaqueEnd = skipOpaqueXmlRegion(xml, tagStart, partPath);
+    if (opaqueEnd !== null) {
+      pos = opaqueEnd;
+      continue;
+    }
+
     if (
       xml.startsWith(FALLBACK_OPEN, tagStart) &&
       isXmlNameBoundary(xml[tagStart + FALLBACK_OPEN.length])
     ) {
       const tagEnd = xml.indexOf(">", tagStart);
       if (tagEnd === -1) {
-        throw new EnsureParaIdsError(`Unterminated <mc:Fallback> tag in ${partPath}`);
+        throw createEnsureParaIdsError(`Unterminated <mc:Fallback> tag in ${partPath}`);
       }
       if (xml[tagEnd - 1] !== "/") {
         fallbackDepth += 1;
@@ -193,7 +302,7 @@ const scanPart = (
 
     const tagEnd = xml.indexOf(">", tagStart);
     if (tagEnd === -1) {
-      throw new EnsureParaIdsError(`Unterminated <w:p> tag in ${partPath}`);
+      throw createEnsureParaIdsError(`Unterminated <w:p> tag in ${partPath}`);
     }
     pos = tagEnd + 1;
     if (fallbackDepth > 0) {
@@ -205,9 +314,19 @@ const scanPart = (
     const paraIdMatch = OPEN_TAG_PARA_ID_PATTERN.exec(openTag);
     if (!paraIdMatch) {
       const id = mintParaId(context, partPath, ordinal);
-      const textId = OPEN_TAG_TEXT_ID_PATTERN.test(openTag) ? "" : ` w14:textId="${id}"`;
       const insertAt = tagStart + PARAGRAPH_OPEN.length;
-      edits.push({ start: insertAt, end: insertAt, text: ` w14:paraId="${id}"${textId}` });
+      const textIdMatch = OPEN_TAG_TEXT_ID_PATTERN.exec(openTag);
+      if (textIdMatch) {
+        edits.push({ start: insertAt, end: insertAt, text: ` w14:paraId="${id}"` });
+        const range = attributeValueRange(textIdMatch, tagStart, "id");
+        edits.push({ ...range, text: id });
+      } else {
+        edits.push({
+          start: insertAt,
+          end: insertAt,
+          text: ` w14:paraId="${id}" w14:textId="${id}"`,
+        });
+      }
       assigned += 1;
       seen.add(id);
       continue;
@@ -223,8 +342,14 @@ const scanPart = (
     }
 
     const id = mintParaId(context, partPath, ordinal);
-    const valueStart = tagStart + paraIdMatch.index + paraIdMatch[0].indexOf('"') + 1;
-    edits.push({ start: valueStart, end: valueStart + rawValue.length, text: id });
+    edits.push({ ...attributeValueRange(paraIdMatch, tagStart, "id"), text: id });
+    const textIdMatch = OPEN_TAG_TEXT_ID_PATTERN.exec(openTag);
+    if (textIdMatch) {
+      edits.push({ ...attributeValueRange(textIdMatch, tagStart, "id"), text: id });
+    } else {
+      const insertAt = tagStart + PARAGRAPH_OPEN.length;
+      edits.push({ start: insertAt, end: insertAt, text: ` w14:textId="${id}"` });
+    }
     if (unassigned) {
       assigned += 1;
     } else {
@@ -249,11 +374,16 @@ const ensureRootNamespaces = (xml: string, partPath: string): SpliceEdit[] => {
     if (lt === -1) {
       break;
     }
+    const opaqueEnd = skipOpaqueXmlRegion(xml, lt, partPath);
+    if (opaqueEnd !== null) {
+      pos = opaqueEnd;
+      continue;
+    }
     const next = xml[lt + 1];
-    if (next === "?" || next === "!") {
-      const skipTo = xml.startsWith("<!--", lt) ? xml.indexOf("-->", lt) : xml.indexOf(">", lt);
+    if (next === "!") {
+      const skipTo = xml.indexOf(">", lt);
       if (skipTo === -1) {
-        throw new EnsureParaIdsError(`Unterminated prolog in ${partPath}`);
+        throw createEnsureParaIdsError(`Unterminated prolog in ${partPath}`);
       }
       pos = skipTo + 1;
       continue;
@@ -262,20 +392,30 @@ const ensureRootNamespaces = (xml: string, partPath: string): SpliceEdit[] => {
     break;
   }
   if (rootStart === -1) {
-    throw new EnsureParaIdsError(`No root element in ${partPath}`);
+    throw createEnsureParaIdsError(`No root element in ${partPath}`);
   }
   const rootEnd = xml.indexOf(">", rootStart);
   if (rootEnd === -1) {
-    throw new EnsureParaIdsError(`Unterminated root element in ${partPath}`);
+    throw createEnsureParaIdsError(`Unterminated root element in ${partPath}`);
   }
   const rootTag = xml.slice(rootStart, rootEnd + 1);
 
   const edits: SpliceEdit[] = [];
   const declarations: string[] = [];
-  if (!XMLNS_MC_PATTERN.test(rootTag)) {
+  const mcNamespace = XMLNS_MC_PATTERN.exec(rootTag);
+  if (mcNamespace) {
+    if (mcNamespace.groups!["value"] !== MC_NAMESPACE_URI) {
+      throw createEnsureParaIdsError(`xmlns:mc has an unexpected namespace URI in ${partPath}`);
+    }
+  } else {
     declarations.push(` xmlns:mc="${MC_NAMESPACE_URI}"`);
   }
-  if (!XMLNS_W14_PATTERN.test(rootTag)) {
+  const w14Namespace = XMLNS_W14_PATTERN.exec(rootTag);
+  if (w14Namespace) {
+    if (w14Namespace.groups!["value"] !== W14_NAMESPACE_URI) {
+      throw createEnsureParaIdsError(`xmlns:w14 has an unexpected namespace URI in ${partPath}`);
+    }
+  } else {
     declarations.push(` xmlns:w14="${W14_NAMESPACE_URI}"`);
   }
 
@@ -285,10 +425,9 @@ const ensureRootNamespaces = (xml: string, partPath: string): SpliceEdit[] => {
     const value = ignorable.groups!["value"]!;
     const tokens = value.split(/\s+/u).filter((token) => token.length > 0);
     if (!tokens.includes(MC_IGNORABLE_W14)) {
-      const valueStart = rootStart + ignorable.index + ignorable[0].indexOf('"') + 1;
-      const valueEnd = valueStart + value.length;
+      const { end } = attributeValueRange(ignorable, rootStart, "value");
       const text = tokens.length === 0 ? MC_IGNORABLE_W14 : ` ${MC_IGNORABLE_W14}`;
-      edits.push({ start: valueEnd, end: valueEnd, text });
+      edits.push({ start: end, end, text });
     }
   } else {
     declarations.push(` mc:Ignorable="${MC_IGNORABLE_W14}"`);
@@ -317,7 +456,7 @@ const toUint8Array = (docx: Uint8Array | ArrayBuffer): Uint8Array =>
  * module doc for the exact contract. Throws {@link EnsureParaIdsError} when
  * the buffer is not a WordprocessingML package or a part is malformed.
  */
-export const ensureParaIds = async (
+const ensureParaIdsInternal = async (
   docx: Uint8Array | ArrayBuffer,
 ): Promise<EnsureParaIdsResult> => {
   const zip = await JSZip.loadAsync(docx);
@@ -331,7 +470,7 @@ export const ensureParaIds = async (
   });
   const documentPartName = xmlPartNames.find((name) => name.toLowerCase() === DOCUMENT_PART);
   if (documentPartName === undefined) {
-    throw new EnsureParaIdsError("word/document.xml not found — not a WordprocessingML package");
+    throw createEnsureParaIdsError("word/document.xml not found: not a WordprocessingML package");
   }
 
   const partTexts = new Map<string, string>();
@@ -360,7 +499,18 @@ export const ensureParaIds = async (
       .sort((a, b) => a.localeCompare(b)),
   ];
 
+  // IDs in parts or fallback branches that this pass deliberately leaves
+  // untouched own their values. Seed duplicate resolution with them so an
+  // editable paragraph cannot preserve a conflicting ID.
   const seen = new Set<string>();
+  for (const [partPath, xml] of partTexts) {
+    if (isTargetPart(partPath)) {
+      collectFallbackParaIds(xml, partPath, seen);
+    } else {
+      collectExistingParaIds(xml, seen);
+    }
+  }
+
   const updates = new Map<string, string>();
   let assigned = 0;
   let deduplicated = 0;
@@ -394,4 +544,22 @@ export const ensureParaIds = async (
   });
 
   return { docx: output, assigned, deduplicated, alreadyComplete: false };
+};
+
+/**
+ * Backfill `w14:paraId` on every paragraph of a `.docx` buffer. All package,
+ * XML, and compression failures are surfaced as {@link EnsureParaIdsError}.
+ */
+export const ensureParaIds = async (
+  docx: Uint8Array | ArrayBuffer,
+): Promise<EnsureParaIdsResult> => {
+  try {
+    return await ensureParaIdsInternal(docx);
+  } catch (error) {
+    if (error instanceof EnsureParaIdsError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw createEnsureParaIdsError(`Failed to normalize paragraph IDs: ${message}`, error);
+  }
 };

--- a/packages/core/src/docx/ensureParaIds.ts
+++ b/packages/core/src/docx/ensureParaIds.ts
@@ -1,0 +1,397 @@
+/**
+ * Headless `w14:paraId` normalization for a `.docx` buffer.
+ *
+ * Word 2010+ stamps every paragraph with a `w14:paraId`, but Google Docs
+ * exports, LibreOffice, python-docx, and docx4j generally do not. Paragraphs
+ * without one are invisible to everything that anchors on paraId (block ids,
+ * comment threads, AI-edit targeting) and fall back to positional `seq-NNNN`
+ * ids that renumber after structural edits. Hosts call {@link ensureParaIds}
+ * once at ingest so every stored version has full id coverage before any
+ * snapshot is taken.
+ *
+ * The pass patches part XML in place (string splices, no model round-trip),
+ * so documents carrying features folio's parser does not model come back
+ * with those features byte-identical. Contract:
+ *
+ * - Parts covered: `word/document.xml`, `word/header*.xml`, `word/footer*.xml`,
+ *   `word/footnotes.xml`, `word/endnotes.xml`. Paragraphs nested in table
+ *   cells and in `mc:Choice` text boxes are plain `<w:p>` elements inside
+ *   those parts and are covered by the same scan. The comments part mints its
+ *   own deterministic paraIds at save time (see `commentSerializer`) and is
+ *   left untouched; its ids still count toward uniqueness.
+ * - Paragraphs inside `mc:Fallback` are never modified: Word regenerates the
+ *   fallback branch (duplicating the `mc:Choice` ids) on save, so stamping or
+ *   deduplicating there would churn on every Word round-trip.
+ * - Existing ids are preserved. Only three cases get a fresh id: a missing
+ *   `paraId`, the reserved all-zero value (Word reads `00000000` as "no id"),
+ *   and a duplicate of an id already seen earlier in the scan (first
+ *   occurrence keeps it — the same rule `ParaIdAllocatorExtension` applies in
+ *   the editor). `w14:textId` is written alongside a newly minted `paraId`
+ *   (same value) and never touched otherwise; it is a text-revision marker,
+ *   not identity.
+ * - Fresh ids are deterministic (`deterministicHexId` over document content,
+ *   part path, and paragraph ordinal), so the pass is a pure function of the
+ *   input bytes: retrying an ingest produces identical output.
+ * - Each patched part's root element gets `xmlns:w14` / `xmlns:mc`
+ *   declarations and a `mc:Ignorable` listing `w14` when missing — non-Word
+ *   producers declare neither, and absent `mc:Ignorable` handling is what
+ *   makes pre-2010 consumers choke on the new attributes.
+ * - Idempotent: a document that already has full coverage is returned as the
+ *   original bytes, untouched (`alreadyComplete: true`).
+ */
+import JSZip from "jszip";
+
+import { deterministicHexId } from "../utils/hexId";
+import { isXmlNameBoundary } from "./selectiveXmlPatch";
+
+export class EnsureParaIdsError extends Error {
+  override name = "EnsureParaIdsError";
+}
+
+export type EnsureParaIdsResult = {
+  /** The normalized `.docx`; the input bytes verbatim when `alreadyComplete`. */
+  docx: Uint8Array;
+  /** Paragraphs that received a paraId (missing or all-zero before). */
+  assigned: number;
+  /** Duplicate paraIds reassigned (the first occurrence keeps the id). */
+  deduplicated: number;
+  /** True when the input already had full, unique coverage. */
+  alreadyComplete: boolean;
+};
+
+const W14_NAMESPACE_URI = "http://schemas.microsoft.com/office/word/2010/wordml";
+const MC_NAMESPACE_URI = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+const MC_IGNORABLE_W14 = "w14";
+/** Word reads an all-zero `w14:paraId` as "no id assigned". */
+const RESERVED_ZERO_ID_PATTERN = /^0*$/u;
+
+const DOCUMENT_PART = "word/document.xml";
+const TARGET_PART_PATTERNS = [
+  /^word\/document\.xml$/u,
+  /^word\/header\d*\.xml$/u,
+  /^word\/footer\d*\.xml$/u,
+  /^word\/footnotes\.xml$/u,
+  /^word\/endnotes\.xml$/u,
+];
+
+const PARAGRAPH_OPEN = "<w:p";
+const FALLBACK_OPEN = "<mc:Fallback";
+const FALLBACK_CLOSE = "</mc:Fallback>";
+
+/**
+ * The parser accepts the `w:` fallback prefix for paraId, and comment parts
+ * link replies via `w15:paraId` — all three count toward uniqueness.
+ */
+const ANY_PARA_ID_PATTERN = /\bw(?:14|15)?:paraId="(?<id>[^"]*)"/gu;
+const OPEN_TAG_PARA_ID_PATTERN = /\sw(?:14)?:paraId="(?<id>[^"]*)"/u;
+const OPEN_TAG_TEXT_ID_PATTERN = /\sw(?:14)?:textId="/u;
+const XMLNS_W14_PATTERN = /\sxmlns:w14="/u;
+const XMLNS_MC_PATTERN = /\sxmlns:mc="/u;
+const MC_IGNORABLE_PATTERN = /\smc:Ignorable="(?<value>[^"]*)"/u;
+
+type SpliceEdit = { start: number; end: number; text: string };
+
+const applySplices = (xml: string, edits: SpliceEdit[]): string => {
+  const ordered = [...edits].sort((a, b) => b.start - a.start);
+  let result = xml;
+  for (const { start, end, text } of ordered) {
+    result = result.slice(0, start) + text + result.slice(end);
+  }
+  return result;
+};
+
+const collectExistingParaIds = (xml: string, into: Set<string>): void => {
+  for (const match of xml.matchAll(ANY_PARA_ID_PATTERN)) {
+    // SAFETY: named group `id` always present when the pattern matches
+    const id = match.groups!["id"]!;
+    if (id.length > 0) {
+      into.add(id.toUpperCase());
+    }
+  }
+};
+
+type MintContext = {
+  /** Every id in the document (all parts) plus every id minted so far. */
+  taken: Set<string>;
+  /** `deterministicHexId` fingerprint of the original document.xml. */
+  docKey: string;
+};
+
+/**
+ * Deterministic fresh id for the paragraph at `ordinal` in `partPath`,
+ * salted past collisions with any id anywhere in the document.
+ */
+const mintParaId = (context: MintContext, partPath: string, ordinal: number): string => {
+  const seed = `${context.docKey}:${partPath}:${ordinal}`;
+  let id = deterministicHexId(seed);
+  for (let salt = 1; context.taken.has(id); salt += 1) {
+    id = deterministicHexId(`${seed}:${salt}`);
+  }
+  context.taken.add(id);
+  return id;
+};
+
+type PartScanResult = {
+  edits: SpliceEdit[];
+  assigned: number;
+  deduplicated: number;
+};
+
+/**
+ * One forward scan over a part: every `<w:p>` open tag outside `mc:Fallback`
+ * either keeps its paraId (valid, first occurrence) or gets a splice edit
+ * minting / replacing one. `seen` spans parts so the first-occurrence rule is
+ * document-wide across the scan order.
+ */
+const scanPart = (
+  xml: string,
+  partPath: string,
+  context: MintContext,
+  seen: Set<string>,
+): PartScanResult => {
+  const edits: SpliceEdit[] = [];
+  let assigned = 0;
+  let deduplicated = 0;
+  let ordinal = 0;
+  let fallbackDepth = 0;
+  let pos = 0;
+
+  while (pos < xml.length) {
+    const tagStart = xml.indexOf("<", pos);
+    if (tagStart === -1) {
+      break;
+    }
+
+    if (
+      xml.startsWith(FALLBACK_OPEN, tagStart) &&
+      isXmlNameBoundary(xml[tagStart + FALLBACK_OPEN.length])
+    ) {
+      const tagEnd = xml.indexOf(">", tagStart);
+      if (tagEnd === -1) {
+        throw new EnsureParaIdsError(`Unterminated <mc:Fallback> tag in ${partPath}`);
+      }
+      if (xml[tagEnd - 1] !== "/") {
+        fallbackDepth += 1;
+      }
+      pos = tagEnd + 1;
+      continue;
+    }
+
+    if (xml.startsWith(FALLBACK_CLOSE, tagStart)) {
+      fallbackDepth = Math.max(0, fallbackDepth - 1);
+      pos = tagStart + FALLBACK_CLOSE.length;
+      continue;
+    }
+
+    if (
+      !xml.startsWith(PARAGRAPH_OPEN, tagStart) ||
+      !isXmlNameBoundary(xml[tagStart + PARAGRAPH_OPEN.length])
+    ) {
+      pos = tagStart + 1;
+      continue;
+    }
+
+    const tagEnd = xml.indexOf(">", tagStart);
+    if (tagEnd === -1) {
+      throw new EnsureParaIdsError(`Unterminated <w:p> tag in ${partPath}`);
+    }
+    pos = tagEnd + 1;
+    if (fallbackDepth > 0) {
+      continue;
+    }
+    ordinal += 1;
+
+    const openTag = xml.slice(tagStart, tagEnd + 1);
+    const paraIdMatch = OPEN_TAG_PARA_ID_PATTERN.exec(openTag);
+    if (!paraIdMatch) {
+      const id = mintParaId(context, partPath, ordinal);
+      const textId = OPEN_TAG_TEXT_ID_PATTERN.test(openTag) ? "" : ` w14:textId="${id}"`;
+      const insertAt = tagStart + PARAGRAPH_OPEN.length;
+      edits.push({ start: insertAt, end: insertAt, text: ` w14:paraId="${id}"${textId}` });
+      assigned += 1;
+      seen.add(id);
+      continue;
+    }
+
+    // SAFETY: named group `id` always present when the pattern matches
+    const rawValue = paraIdMatch.groups!["id"]!;
+    const value = rawValue.toUpperCase();
+    const unassigned = RESERVED_ZERO_ID_PATTERN.test(value);
+    if (!unassigned && !seen.has(value)) {
+      seen.add(value);
+      continue;
+    }
+
+    const id = mintParaId(context, partPath, ordinal);
+    const valueStart = tagStart + paraIdMatch.index + paraIdMatch[0].indexOf('"') + 1;
+    edits.push({ start: valueStart, end: valueStart + rawValue.length, text: id });
+    if (unassigned) {
+      assigned += 1;
+    } else {
+      deduplicated += 1;
+    }
+    seen.add(id);
+  }
+
+  return { edits, assigned, deduplicated };
+};
+
+/**
+ * Splice edits ensuring the part's root element declares `xmlns:w14` /
+ * `xmlns:mc` and lists `w14` in `mc:Ignorable`, so consumers that predate the
+ * 2010 extensions skip the new attributes instead of rejecting the part.
+ */
+const ensureRootNamespaces = (xml: string, partPath: string): SpliceEdit[] => {
+  let pos = 0;
+  let rootStart = -1;
+  while (pos < xml.length) {
+    const lt = xml.indexOf("<", pos);
+    if (lt === -1) {
+      break;
+    }
+    const next = xml[lt + 1];
+    if (next === "?" || next === "!") {
+      const skipTo = xml.startsWith("<!--", lt) ? xml.indexOf("-->", lt) : xml.indexOf(">", lt);
+      if (skipTo === -1) {
+        throw new EnsureParaIdsError(`Unterminated prolog in ${partPath}`);
+      }
+      pos = skipTo + 1;
+      continue;
+    }
+    rootStart = lt;
+    break;
+  }
+  if (rootStart === -1) {
+    throw new EnsureParaIdsError(`No root element in ${partPath}`);
+  }
+  const rootEnd = xml.indexOf(">", rootStart);
+  if (rootEnd === -1) {
+    throw new EnsureParaIdsError(`Unterminated root element in ${partPath}`);
+  }
+  const rootTag = xml.slice(rootStart, rootEnd + 1);
+
+  const edits: SpliceEdit[] = [];
+  const declarations: string[] = [];
+  if (!XMLNS_MC_PATTERN.test(rootTag)) {
+    declarations.push(` xmlns:mc="${MC_NAMESPACE_URI}"`);
+  }
+  if (!XMLNS_W14_PATTERN.test(rootTag)) {
+    declarations.push(` xmlns:w14="${W14_NAMESPACE_URI}"`);
+  }
+
+  const ignorable = MC_IGNORABLE_PATTERN.exec(rootTag);
+  if (ignorable) {
+    // SAFETY: named group `value` always present when the pattern matches
+    const value = ignorable.groups!["value"]!;
+    const tokens = value.split(/\s+/u).filter((token) => token.length > 0);
+    if (!tokens.includes(MC_IGNORABLE_W14)) {
+      const valueStart = rootStart + ignorable.index + ignorable[0].indexOf('"') + 1;
+      const valueEnd = valueStart + value.length;
+      const text = tokens.length === 0 ? MC_IGNORABLE_W14 : ` ${MC_IGNORABLE_W14}`;
+      edits.push({ start: valueEnd, end: valueEnd, text });
+    }
+  } else {
+    declarations.push(` mc:Ignorable="${MC_IGNORABLE_W14}"`);
+  }
+
+  if (declarations.length > 0) {
+    let nameEnd = rootStart + 1;
+    while (nameEnd < xml.length && !isXmlNameBoundary(xml[nameEnd])) {
+      nameEnd += 1;
+    }
+    edits.push({ start: nameEnd, end: nameEnd, text: declarations.join("") });
+  }
+
+  return edits;
+};
+
+/** OPC part names are case-insensitive; compare lowercased. */
+const isTargetPart = (path: string): boolean =>
+  TARGET_PART_PATTERNS.some((pattern) => pattern.test(path.toLowerCase()));
+
+const toUint8Array = (docx: Uint8Array | ArrayBuffer): Uint8Array =>
+  docx instanceof Uint8Array ? docx : new Uint8Array(docx);
+
+/**
+ * Backfill `w14:paraId` on every paragraph of a `.docx` buffer. See the
+ * module doc for the exact contract. Throws {@link EnsureParaIdsError} when
+ * the buffer is not a WordprocessingML package or a part is malformed.
+ */
+export const ensureParaIds = async (
+  docx: Uint8Array | ArrayBuffer,
+): Promise<EnsureParaIdsResult> => {
+  const zip = await JSZip.loadAsync(docx);
+
+  const xmlPartNames: string[] = [];
+  zip.forEach((relativePath, entry) => {
+    const lower = relativePath.toLowerCase();
+    if (!entry.dir && lower.startsWith("word/") && lower.endsWith(".xml")) {
+      xmlPartNames.push(relativePath);
+    }
+  });
+  const documentPartName = xmlPartNames.find((name) => name.toLowerCase() === DOCUMENT_PART);
+  if (documentPartName === undefined) {
+    throw new EnsureParaIdsError("word/document.xml not found — not a WordprocessingML package");
+  }
+
+  const partTexts = new Map<string, string>();
+  for (const name of xmlPartNames) {
+    const entry = zip.file(name);
+    if (entry) {
+      partTexts.set(name, await entry.async("text"));
+    }
+  }
+
+  const taken = new Set<string>();
+  for (const text of partTexts.values()) {
+    collectExistingParaIds(text, taken);
+  }
+
+  // SAFETY: documentPartName came out of partTexts' key set
+  const documentXml = partTexts.get(documentPartName)!;
+  const context: MintContext = { taken, docKey: deterministicHexId(documentXml) };
+
+  // document.xml first so its paragraphs win the first-occurrence rule, then
+  // the auxiliary parts in a deterministic order.
+  const targetParts = [
+    documentPartName,
+    ...xmlPartNames
+      .filter((name) => name !== documentPartName && isTargetPart(name))
+      .sort((a, b) => a.localeCompare(b)),
+  ];
+
+  const seen = new Set<string>();
+  const updates = new Map<string, string>();
+  let assigned = 0;
+  let deduplicated = 0;
+
+  for (const partPath of targetParts) {
+    // SAFETY: every target part name came out of partTexts' key set
+    const xml = partTexts.get(partPath)!;
+    const scan = scanPart(xml, partPath, context, seen);
+    if (scan.edits.length === 0) {
+      continue;
+    }
+    assigned += scan.assigned;
+    deduplicated += scan.deduplicated;
+    updates.set(
+      partPath,
+      applySplices(xml, [...scan.edits, ...ensureRootNamespaces(xml, partPath)]),
+    );
+  }
+
+  if (updates.size === 0) {
+    return { docx: toUint8Array(docx), assigned: 0, deduplicated: 0, alreadyComplete: true };
+  }
+
+  for (const [partPath, content] of updates) {
+    zip.file(partPath, content, { compression: "DEFLATE", compressionOptions: { level: 6 } });
+  }
+  const output = await zip.generateAsync({
+    type: "uint8array",
+    compression: "DEFLATE",
+    compressionOptions: { level: 6 },
+  });
+
+  return { docx: output, assigned, deduplicated, alreadyComplete: false };
+};

--- a/packages/core/src/docx/ensureParaIds.ts
+++ b/packages/core/src/docx/ensureParaIds.ts
@@ -7,7 +7,7 @@
  * comment threads, AI-edit targeting) and fall back to positional `seq-NNNN`
  * ids that renumber after structural edits. Hosts call {@link ensureParaIds}
  * once at ingest so every stored version has full id coverage before any
- * snapshot is taken.
+ * snapshot or external anchor is created.
  *
  * IDs remain stable in folio and identity-preserving DOCX round-trips.
  * Microsoft Word can establish a new `w14:docId` and replace all paragraph
@@ -44,6 +44,9 @@
  *   makes pre-2010 consumers choke on the new attributes.
  * - Idempotent: a document that already has full coverage is returned as the
  *   original bytes, untouched (`alreadyComplete: true`).
+ * - Digitally signed packages are returned untouched when already complete.
+ *   When normalization would rewrite the package, it fails unless the caller
+ *   explicitly allows signature invalidation after warning the user.
  */
 import { TaggedError } from "better-result";
 import JSZip from "jszip";
@@ -69,9 +72,19 @@ export type EnsureParaIdsResult = {
   alreadyComplete: boolean;
 };
 
+/** Controls mutation of package metadata that has security implications. */
+export type EnsureParaIdsOptions = {
+  /**
+   * Allow normalization to invalidate existing OPC digital signatures.
+   * Callers must warn the user before opting in.
+   */
+  allowSignedPackageMutation?: boolean;
+};
+
 const W14_NAMESPACE_URI = "http://schemas.microsoft.com/office/word/2010/wordml";
 const MC_NAMESPACE_URI = "http://schemas.openxmlformats.org/markup-compatibility/2006";
 const MC_IGNORABLE_W14 = "w14";
+const DIGITAL_SIGNATURE_PART_PREFIX = "_xmlsignatures/";
 /** Word reads an all-zero `w14:paraId` as "no id assigned". */
 const RESERVED_ZERO_ID_PATTERN = /^0*$/u;
 
@@ -451,6 +464,11 @@ const isTargetPart = (path: string): boolean =>
 const toUint8Array = (docx: Uint8Array | ArrayBuffer): Uint8Array =>
   docx instanceof Uint8Array ? docx : new Uint8Array(docx);
 
+const hasDigitalSignatureParts = (zip: JSZip): boolean =>
+  Object.values(zip.files).some(
+    ({ dir, name }) => !dir && name.toLowerCase().startsWith(DIGITAL_SIGNATURE_PART_PREFIX),
+  );
+
 /**
  * Backfill `w14:paraId` on every paragraph of a `.docx` buffer. See the
  * module doc for the exact contract. Throws {@link EnsureParaIdsError} when
@@ -458,6 +476,7 @@ const toUint8Array = (docx: Uint8Array | ArrayBuffer): Uint8Array =>
  */
 const ensureParaIdsInternal = async (
   docx: Uint8Array | ArrayBuffer,
+  options: EnsureParaIdsOptions,
 ): Promise<EnsureParaIdsResult> => {
   const zip = await JSZip.loadAsync(docx);
 
@@ -534,6 +553,12 @@ const ensureParaIdsInternal = async (
     return { docx: toUint8Array(docx), assigned: 0, deduplicated: 0, alreadyComplete: true };
   }
 
+  if (hasDigitalSignatureParts(zip) && options.allowSignedPackageMutation !== true) {
+    throw createEnsureParaIdsError(
+      "Refusing to normalize a digitally signed package because rewriting OOXML invalidates its signatures. Warn the user and pass allowSignedPackageMutation only if invalidation is acceptable.",
+    );
+  }
+
   for (const [partPath, content] of updates) {
     zip.file(partPath, content, { compression: "DEFLATE", compressionOptions: { level: 6 } });
   }
@@ -552,9 +577,10 @@ const ensureParaIdsInternal = async (
  */
 export const ensureParaIds = async (
   docx: Uint8Array | ArrayBuffer,
+  options: EnsureParaIdsOptions = {},
 ): Promise<EnsureParaIdsResult> => {
   try {
-    return await ensureParaIdsInternal(docx);
+    return await ensureParaIdsInternal(docx, options);
   } catch (error) {
     if (error instanceof EnsureParaIdsError) {
       throw error;

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -14,7 +14,7 @@
  * (`<w:p\n  w14:paraId="…">`) is still recognized as the element rather than
  * mistaken for a longer-named sibling.
  */
-function isXmlNameBoundary(char: string | undefined): boolean {
+export function isXmlNameBoundary(char: string | undefined): boolean {
   return (
     char === " " || char === "\t" || char === "\n" || char === "\r" || char === ">" || char === "/"
   );

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -28,6 +28,7 @@ export {
   type FolioBlockId,
 } from "./types/block-id";
 export { createDocx } from "./docx/rezip";
+export { ensureParaIds, EnsureParaIdsError, type EnsureParaIdsResult } from "./docx/ensureParaIds";
 export { replyToComment, type CreateCommentReplyInput } from "./docx/replyToComment";
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
 export {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -28,7 +28,12 @@ export {
   type FolioBlockId,
 } from "./types/block-id";
 export { createDocx } from "./docx/rezip";
-export { ensureParaIds, EnsureParaIdsError, type EnsureParaIdsResult } from "./docx/ensureParaIds";
+export {
+  ensureParaIds,
+  EnsureParaIdsError,
+  type EnsureParaIdsOptions,
+  type EnsureParaIdsResult,
+} from "./docx/ensureParaIds";
 export { replyToComment, type CreateCommentReplyInput } from "./docx/replyToComment";
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
 export {


### PR DESCRIPTION
## Summary

Normalizes durable paragraph IDs at DOCX ingest, before Folio derives or stores block anchors, so snapshots do not fall back to positional `seq-NNNN` IDs.

- adds the headless `ensureParaIds` API for document, header, footer, footnote, and endnote parts
- preserves valid existing IDs; assigns deterministic IDs only for missing or all-zero values and resolves duplicates
- is idempotent and returns already-complete input byte-identically
- preserves unmodeled XML with targeted string splices and leaves `mc:Fallback` content untouched
- validates namespace bindings, supports both XML quote styles, and skips comments, CDATA, and processing instructions
- reserves IDs from comments and other excluded content during duplicate resolution
- surfaces malformed packages through a typed `EnsureParaIdsError`
- refuses to rewrite digitally signed packages by default; callers must explicitly allow signature invalidation after warning the user
- documents the Word round-trip boundary: Word preserves backfilled IDs for identity-preserving saves, but can replace all IDs when it first adopts a non-Word-produced package

PR #193 is merged and provides the editor allocator lifecycle and reserved-zero handling that this ingest normalization builds on.

## Verification

- `bun run format`
- `bun run lint`
- `bun run typecheck`
- focused normalization and allocator tests
- `bun run build`
- `bun run api:update`
- `bun run api:check`
- `bun run validate-dist`
- Microsoft Word edit/save round trips for both an existing Word identity and a non-Word-produced package

CC on behalf of @jan-kubica