### PR TITLE
fix: honor mirrored page margins

### DIFF
--- a/.changeset/gentle-mirrored-margins.md
+++ b/.changeset/gentle-mirrored-margins.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Honor mirrored left and right margins on facing document pages.

--- a/.changeset/gentle-mirrored-margins.md
+++ b/.changeset/gentle-mirrored-margins.md
@@ -1,6 +1,7 @@
 ---
 "@stll/folio-core": patch
 "@stll/folio-react": patch
+"@stll/folio-vue": patch
 ---
 
 Honor mirrored left and right margins on facing document pages.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -412,7 +412,8 @@ export type LayoutOptions = {
     headerContentHeights?: HeaderFooterContentHeights; /** Footer content heights by variant. */
     footerContentHeights?: HeaderFooterContentHeights; /** Whether section has different first page header/footer. */
     titlePage?: boolean; /** Whether section has different even/odd headers/footers. */
-    evenAndOddHeaders?: boolean; /** Per-page footnote reserved heights (pageNumber → height in pixels). */
+    evenAndOddHeaders?: boolean; /** Swap left/right margins on even physical pages. */
+    mirrorMargins?: boolean; /** Per-page footnote reserved heights (pageNumber → height in pixels). */
     footnoteReservedHeights?: Map<number, number>;
     footnoteHeightById?: Map<number, number>; /** Section break type for the body-level (final) section (for section transition logic). */
     bodyBreakType?: "continuous" | "nextPage" | "evenPage" | "oddPage"; /** Header/footer references for each document section, by section index. */
@@ -534,7 +535,8 @@ export type PaginatorOptions = {
         w: number;
         h: number;
     }; /** Page margins. */
-    margins: PageMargins;
+    margins: PageMargins; /** Swap left/right margins on even physical pages. */
+    mirrorMargins?: boolean;
     firstPageMargins?: PageMargins; /** Column configuration (optional). */
     columns?: ColumnLayout; /** Per-page footnote reserved heights (pageNumber → height in pixels). */
     footnoteReservedHeights?: Map<number, number>; /** Header/footer refs by section index. */

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -321,6 +321,7 @@ const makeDeps = (
   sectionProperties: null,
   document: null,
   defaultTabStop: undefined,
+  mirrorMargins: false,
   styles: null,
   layout: null,
   hfPMs: null,

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -110,6 +110,7 @@ export type LayoutPipelineDeps<THfPMs> = {
   sectionProperties: SectionProperties | null | undefined;
   document: Document | null;
   defaultTabStop: number | undefined;
+  mirrorMargins: boolean;
   styles: StyleDefinitions | null | undefined;
   layout: Layout | null;
   // Refs read as their current value; `session` is the object itself because
@@ -170,6 +171,7 @@ export function runLayoutPipeline<THfPMs>(
     sectionProperties,
     document,
     defaultTabStop,
+    mirrorMargins,
     styles,
     layout,
     hfPMs,
@@ -405,6 +407,7 @@ export function runLayoutPipeline<THfPMs>(
         pageSize,
         margins,
         pageGap,
+        mirrorMargins,
       };
       if (hasTitlePg && firstPageHeaderForRender) {
         const headerDistance = margins.header ?? 0;

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -63,6 +63,14 @@ describe("parseSettings — w:evenAndOddHeaders (§17.10.1)", () => {
   });
 });
 
+describe("parseSettings — w:mirrorMargins (§17.15.1.57)", () => {
+  test("records only the enabled state", () => {
+    expect(parseSettings(wrap(`<w:mirrorMargins/>`)).mirrorMargins).toBe(true);
+    expect(parseSettings(wrap(`<w:mirrorMargins w:val="0"/>`)).mirrorMargins).toBeUndefined();
+    expect(parseSettings(wrap("")).mirrorMargins).toBeUndefined();
+  });
+});
+
 describe("parseSettings — w:themeFontLang (§17.15.1.88)", () => {
   test("reads eastAsia and bidi tags", () => {
     expect(

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -14,7 +14,10 @@ import type { DocumentSettings } from "../types/document";
 import { findChild, getAttribute, parseBooleanElement, parseXmlDocument } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
-export type { DocumentSettings };
+export type FolioDocumentSettings = DocumentSettings & {
+  /** Swap left/right section margins on even physical pages. */
+  mirrorMargins?: boolean;
+};
 
 /** OOXML default per §17.6.13 when `w:defaultTabStop` is absent. */
 export const DEFAULT_TAB_STOP_TWIPS = 720;
@@ -26,9 +29,9 @@ export const DEFAULT_TAB_STOP_TWIPS = 720;
  */
 const MAX_TAB_STOP_TWIPS = 31_680;
 
-export function parseSettings(xml: string | null): DocumentSettings {
+export function parseSettings(xml: string | null): FolioDocumentSettings {
   const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
-  const settings: DocumentSettings = {
+  const settings: FolioDocumentSettings = {
     defaultTabStop: parseDefaultTabStop(root),
   };
   // `w:evenAndOddHeaders` lives in settings.xml, not sectPr. Only record the
@@ -36,6 +39,10 @@ export function parseSettings(xml: string | null): DocumentSettings {
   const evenAndOddHeaders = root ? findChild(root, "w", "evenAndOddHeaders") : null;
   if (evenAndOddHeaders && parseBooleanElement(evenAndOddHeaders)) {
     settings.evenAndOddHeaders = true;
+  }
+  const mirrorMargins = root ? findChild(root, "w", "mirrorMargins") : null;
+  if (mirrorMargins && parseBooleanElement(mirrorMargins)) {
+    settings.mirrorMargins = true;
   }
 
   // `w:themeFontLang` selects the concrete typeface for the empty `<a:ea>` /

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -291,6 +291,7 @@ export function layoutDocument(
   const paginator = createPaginator({
     pageSize: initialConfig.pageSize,
     margins: initialConfig.margins,
+    ...(options.mirrorMargins === true ? { mirrorMargins: true } : {}),
     ...(options.firstPageMargins !== undefined
       ? { firstPageMargins: options.firstPageMargins }
       : {}),

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -5,6 +5,25 @@ import { createPaginator } from "./paginator";
 const SIZE = { w: 800, h: 1000 };
 const MARGINS = { top: 50, right: 50, bottom: 50, left: 50 };
 
+describe("paginator mirrored margins", () => {
+  test("swaps left and right margins on even physical pages", () => {
+    const paginator = createPaginator({
+      pageSize: SIZE,
+      margins: { ...MARGINS, left: 90, right: 72 },
+      mirrorMargins: true,
+    });
+
+    const first = paginator.getCurrentState();
+    expect(first.page.margins.left).toBe(90);
+    expect(paginator.getColumnX(0)).toBe(90);
+
+    const second = paginator.forcePageBreak();
+    expect(second.page.margins.left).toBe(72);
+    expect(second.page.margins.right).toBe(90);
+    expect(paginator.getColumnX(0)).toBe(72);
+  });
+});
+
 describe("paginator forcePageBreak", () => {
   test("two consecutive forcePageBreak calls preserve an explicit blank page", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -53,6 +53,8 @@ export type PaginatorOptions = {
   pageSize: { w: number; h: number };
   /** Page margins. */
   margins: PageMargins;
+  /** Swap left/right margins on even physical pages. */
+  mirrorMargins?: boolean;
   /**
    * Margins applied only to the very first page (page 1) of the paginator.
    * Used when a `<w:titlePg/>`-enabled section needs different margins for
@@ -138,7 +140,8 @@ export function createPaginator(options: PaginatorOptions) {
       return false;
     }
     return (
-      arePageSizesEqual(state.page.size, pageSize) && areMarginsEqual(state.page.margins, margins)
+      arePageSizesEqual(state.page.size, pageSize) &&
+      areMarginsEqual(state.page.margins, getPageMargins(state.page.number))
     );
   }
 
@@ -169,9 +172,14 @@ export function createPaginator(options: PaginatorOptions) {
   }
 
   function getPageMargins(pageNumber: number): PageMargins {
-    return pageNumber === 1 && options.firstPageMargins
-      ? { ...options.firstPageMargins }
-      : { ...margins };
+    const pageMargins =
+      pageNumber === 1 && options.firstPageMargins
+        ? { ...options.firstPageMargins }
+        : { ...margins };
+    if (options.mirrorMargins === true && pageNumber % 2 === 0) {
+      return { ...pageMargins, left: pageMargins.right, right: pageMargins.left };
+    }
+    return pageMargins;
   }
 
   // Track where column content starts on the current page.
@@ -184,7 +192,8 @@ export function createPaginator(options: PaginatorOptions) {
    * Get X position for a given column index.
    */
   function getColumnX(columnIndex: number): number {
-    return margins.left + columnIndex * (columnWidth + columns.gap);
+    const activeLeftMargin = states.at(-1)?.page.margins.left ?? getPageMargins(1).left;
+    return activeLeftMargin + columnIndex * (columnWidth + columns.gap);
   }
 
   /**

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1141,6 +1141,8 @@ export type LayoutOptions = {
   titlePage?: boolean;
   /** Whether section has different even/odd headers/footers. */
   evenAndOddHeaders?: boolean;
+  /** Swap left/right margins on even physical pages. */
+  mirrorMargins?: boolean;
   /** Per-page footnote reserved heights (pageNumber → height in pixels). */
   footnoteReservedHeights?: Map<number, number>;
   /**

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -956,6 +956,7 @@ type LayoutInputSignatureOptions = {
   columns: ColumnLayout | undefined;
   contentWidth: number;
   defaultTabStop: number | undefined;
+  mirrorMargins: boolean;
   firstPageFooterContent: HeaderFooter | null | undefined;
   firstPageHeaderContent: HeaderFooter | null | undefined;
   footerContent: HeaderFooter | null | undefined;
@@ -2054,6 +2055,11 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     const columns = useMemo(() => getColumns(sectionProperties), [sectionProperties]);
     const contentWidth = pageSize.w - margins.left - margins.right;
     const defaultTabStop = document?.package.settings?.defaultTabStop;
+    const documentSettings = document?.package.settings;
+    const mirrorMargins =
+      documentSettings !== undefined &&
+      "mirrorMargins" in documentSettings &&
+      documentSettings.mirrorMargins === true;
     const sectionHeaderFooterRefs = useMemo(() => getSectionHeaderFooterRefs(document), [document]);
     const layoutInputSignature = useMemo(
       () =>
@@ -2061,6 +2067,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           columns,
           contentWidth,
           defaultTabStop,
+          mirrorMargins,
           firstPageFooterContent,
           firstPageHeaderContent,
           footerContent,
@@ -2081,6 +2088,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         columns,
         contentWidth,
         defaultTabStop,
+        mirrorMargins,
         firstPageFooterContent,
         firstPageHeaderContent,
         footerContent,
@@ -2153,6 +2161,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
             sectionProperties,
             document,
             defaultTabStop,
+            mirrorMargins,
             styles,
             layout: layoutRef.current,
             hfPMs: hfPMsRef.current,
@@ -2218,6 +2227,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         sectionProperties,
         document,
         defaultTabStop,
+        mirrorMargins,
         styles,
       ],
     );

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -652,6 +652,11 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     const styles = model?.package.styles ?? null;
     const theme = model?.package.theme ?? null;
     const defaultTabStop = model?.package.settings?.defaultTabStop;
+    const documentSettings = model?.package.settings;
+    const mirrorMargins =
+      documentSettings !== undefined &&
+      "mirrorMargins" in documentSettings &&
+      documentSettings.mirrorMargins === true;
     const hf = resolveHeaderFooters(model, sectionProps);
 
     try {
@@ -676,6 +681,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
           sectionProperties: sectionProps,
           document: model,
           defaultTabStop,
+          mirrorMargins,
           styles,
           layout: layout.value,
           hfPMs: null,


### PR DESCRIPTION
## Summary

- parse the document-wide mirrored-margin setting
- swap section left/right margins on even physical pages
- use the active page margin when positioning columns and fragments
- include the setting in layout invalidation and pipeline inputs

## Parity evidence

On the anonymized regression case:

- score: 0.473 → 0.721
- horizontal drifts: 58 → 22
- matched lines: 124/129
- pages matched: 3/3

The remaining repeated horizontal signal is associated with content that currently paginates onto a different physical page or has an independent list-indent difference.

## Verification

- parser, paginator, layout pipeline, and layout integration suites (80 passed)
- `bun audit` (no vulnerabilities)
- lint and typecheck: CI
