### PR TITLE
fix: preserve anchored paragraph textboxes

### DIFF
--- a/.changeset/calm-shape-textboxes.md
+++ b/.changeset/calm-shape-textboxes.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve anchored text boxes hosted by otherwise empty paragraphs.

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -234,10 +234,6 @@ const enrichParagraphTextBoxes = (
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
 ): void => {
-  if (paragraph.content.length === 0) {
-    return;
-  }
-
   const xmlChildren = getChildElements(paraXml);
   let parsedIndex = 0;
   let lastConsumedRun: Run | undefined;

--- a/packages/core/src/docx/documentParser-alternatecontent.test.ts
+++ b/packages/core/src/docx/documentParser-alternatecontent.test.ts
@@ -174,4 +174,32 @@ describe("parseDocumentBody — AlternateContent text boxes", () => {
 
     expect(cardTitles).toEqual(["Card 1", "Card 2", "Card 3"]);
   });
+
+  test("preserves text boxes when the host paragraph has no flow content", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body>
+    <w:p>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 1")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 2")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+
+    const shapes = paragraph.content
+      .filter((content) => content.type === "run")
+      .flatMap((run) => run.content.filter((content) => content.type === "shape"));
+
+    expect(shapes).toHaveLength(2);
+  });
 });

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2332,6 +2332,9 @@ function convertTextBoxNode(
   if (attrs.position !== undefined) {
     textBox.position = attrs.position;
   }
+  if (attrs._docxGroupId !== undefined) {
+    textBox._docxGroupId = attrs._docxGroupId;
+  }
   return textBox;
 }
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -33,6 +33,7 @@ import type {
   TabStop,
   FloatingTablePosition,
 } from "../../layout-engine/types";
+import { setTextBoxGroupId } from "../../layout-engine/textBoxGroup";
 import { DEFAULT_TEXTBOX_MARGINS, DEFAULT_TEXTBOX_WIDTH } from "../../layout-engine/types";
 import {
   expectBlockSdtAttrs,
@@ -2333,7 +2334,7 @@ function convertTextBoxNode(
     textBox.position = attrs.position;
   }
   if (attrs._docxGroupId !== undefined) {
-    textBox._docxGroupId = attrs._docxGroupId;
+    setTextBoxGroupId(textBox, attrs._docxGroupId);
   }
   return textBox;
 }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -6,6 +6,7 @@
 
 import { panic } from "better-result";
 
+import { emuToPixels } from "../utils/units";
 import {
   computeKeepNextChains,
   calculateChainHeight,
@@ -1246,6 +1247,45 @@ function layoutTextBox(
       blockId: block.id,
       x,
       y: state.topMargin + bandTop,
+      width: measure.width,
+      height: measure.height,
+      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+    };
+    state.page.fragments.push(fragment);
+    return;
+  }
+
+  // Any explicitly positioned textbox is an anchored object, including
+  // paragraph/line-relative anchors. Place it from the current text anchor
+  // without advancing normal flow; otherwise several shapes owned by one
+  // shape-only paragraph stack vertically and push the body onto another page.
+  if (block.position !== undefined) {
+    const state = paginator.getCurrentState();
+    const horizontal = block.position.horizontal;
+    const x = horizontal
+      ? bandFragmentX(horizontal, {
+          pageWidth: state.page.size.w,
+          marginLeft: state.page.margins.left,
+          marginRight: state.page.margins.right,
+          boxWidth: measure.width,
+        })
+      : paginator.getColumnX(state.columnIndex);
+    const vertical = block.position.vertical;
+    const y = isPageFrameRelativeAnchor(vertical?.relativeTo)
+      ? state.topMargin +
+        bandTopContentY(vertical, {
+          pageHeight: sectionPageHeight,
+          marginTop: sectionMarginTop,
+          marginBottom: sectionMarginBottom,
+          boxHeight: measure.height,
+        })
+      : state.cursorY + emuToPixels(vertical?.posOffset ?? 0);
+    const fragment: TextBoxFragment = {
+      kind: "textBox",
+      blockId: block.id,
+      x,
+      y,
       width: measure.width,
       height: measure.height,
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { FlowBlock, ImageBlock, ParagraphBlock, TableBlock, TextBoxBlock } from "../types";
+import { setTextBoxGroupId } from "../textBoxGroup";
 import { fixedCharWidth, withFakeTextMeasure } from "./__tests__/fakeTextMeasure";
 import { measureBlock, measureBlocks, measureTableBlock } from "./measureBlocks";
 
@@ -66,13 +67,14 @@ describe("measureBlocks", () => {
         content: [],
         wrapType: "topAndBottom",
         position: { vertical: { relativeTo: "paragraph", posOffset: 0 } },
-        _docxGroupId: "host-paragraph",
       };
       const secondBand: TextBoxBlock = {
         ...firstBand,
         id: "second-band",
         position: { vertical: { relativeTo: "paragraph", posOffset: 285_750 } },
       };
+      setTextBoxGroupId(firstBand, "host-paragraph");
+      setTextBoxGroupId(secondBand, "host-paragraph");
 
       const measures = measureBlocks([firstBand, secondBand, para("after", "after")], 600);
       const paragraphMeasure = measures.at(2);

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -56,6 +56,62 @@ describe("measureBlocks", () => {
     }, fakeMeasure);
   });
 
+  test("keeps paragraph-anchored bands from one textbox group active together", () => {
+    withFakeTextMeasure(() => {
+      const firstBand: TextBoxBlock = {
+        kind: "textBox",
+        id: "first-band",
+        width: 300,
+        height: 30,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "paragraph", posOffset: 0 } },
+        _docxGroupId: "host-paragraph",
+      };
+      const secondBand: TextBoxBlock = {
+        ...firstBand,
+        id: "second-band",
+        position: { vertical: { relativeTo: "paragraph", posOffset: 285_750 } },
+      };
+
+      const measures = measureBlocks([firstBand, secondBand, para("after", "after")], 600);
+      const paragraphMeasure = measures.at(2);
+      if (paragraphMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure");
+      }
+
+      expect(paragraphMeasure.lines.at(0)?.floatSkipBefore).toBeCloseTo(60, 5);
+    }, fakeMeasure);
+  });
+
+  test("keeps an active band across an unspecified continuous section break", () => {
+    withFakeTextMeasure(() => {
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 120,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "paragraph", posOffset: 285_750 } },
+      };
+      const blocks: FlowBlock[] = [
+        band,
+        para("before", "before"),
+        { kind: "sectionBreak", id: "section" },
+        para("after", "after"),
+      ];
+
+      const measures = measureBlocks(blocks, 600);
+      const afterMeasure = measures.at(3);
+      if (afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph after section break");
+      }
+
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore).toBeGreaterThan(0);
+    }, fakeMeasure);
+  });
+
   test("per-block content widths are honoured for parallel arrays", () => {
     withFakeTextMeasure(() => {
       const paragraph: ParagraphBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -402,6 +402,7 @@ function extractFloatingZones(
   pageGeometry?: BandPageGeometry,
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
+  const textBoxGroupAnchors = new Map<string, number>();
   const defaultMarginTop = Array.isArray(marginTop) ? (marginTop[0] ?? 0) : marginTop;
   const pageHeightInput = pageGeometry?.pageHeight ?? 0;
   const marginBottomInput = pageGeometry?.marginBottom ?? 0;
@@ -554,47 +555,52 @@ function extractFloatingZones(
     });
   }
 
-  // Page/margin-anchored topAndBottom text boxes (e.g. a banner pinned to the
-  // page top) reserve a full-width band so body text flows above and below the
-  // box instead of the box dropping into the flow at its anchor paragraph.
-  // Paragraph-anchored topAndBottom boxes keep folio's in-flow handling (they
-  // already render on their own line at the anchor). eigenpal docx-editor #694.
+  // Positioned topAndBottom text boxes reserve a full-width band so body text
+  // flows above and below the anchored shape. Multiple boxes extracted from
+  // one shape-only paragraph share an anchor and remain active together.
   for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
     const block = blocks[blockIndex]!; // SAFETY: blockIndex < blocks.length
     if (block.kind !== "textBox") {
       continue;
     }
     const tb = block as TextBoxBlock;
-    if (!floatingTextBoxReservesBand(tb)) {
+    if (!floatingTextBoxReservesBand(tb) || tb.position === undefined) {
       continue;
     }
     const v = tb.position?.vertical;
-    if (!isPageFrameRelativeAnchor(v?.relativeTo)) {
-      continue;
-    }
 
     const height = measureTextBoxBlock(tb).height;
     const distTop = tb.distTop ?? 0;
     const distBottom = tb.distBottom ?? 0;
     const blockMarginTop = perBlockNumberValue(marginTop, blockIndex, defaultMarginTop);
+    const pageFrameRelative = isPageFrameRelativeAnchor(v?.relativeTo);
     // Shared with layoutTextBox so the reserved band and the painted box agree.
-    const rawTop = bandTopContentY(v, {
-      pageHeight: perBlockNumberValue(pageHeightInput, blockIndex, defaultPageHeight),
-      marginTop: blockMarginTop,
-      marginBottom: perBlockNumberValue(marginBottomInput, blockIndex, defaultMarginBottom),
-      boxHeight: height,
-    });
+    const rawTop = pageFrameRelative
+      ? bandTopContentY(v, {
+          pageHeight: perBlockNumberValue(pageHeightInput, blockIndex, defaultPageHeight),
+          marginTop: blockMarginTop,
+          marginBottom: perBlockNumberValue(marginBottomInput, blockIndex, defaultMarginBottom),
+          boxHeight: height,
+        })
+      : emuToPixels(v?.posOffset ?? 0);
     const bottomY = rawTop + height + distBottom;
     if (bottomY <= 0) {
       continue;
+    }
+    const groupId = tb._docxGroupId;
+    const anchorBlockIndex = groupId
+      ? (textBoxGroupAnchors.get(groupId) ?? blockIndex)
+      : blockIndex;
+    if (groupId && !textBoxGroupAnchors.has(groupId)) {
+      textBoxGroupAnchors.set(groupId, blockIndex);
     }
     zones.push({
       leftMargin: 0,
       rightMargin: 0,
       topY: Math.max(0, rawTop - distTop),
       bottomY,
-      anchorBlockIndex: blockIndex,
-      isMarginRelative: true,
+      anchorBlockIndex,
+      ...(pageFrameRelative ? { isMarginRelative: true } : {}),
       fullWidthBlock: true,
     });
   }
@@ -708,14 +714,15 @@ export function measureTextBoxBlock(
 }
 
 /**
- * `true` for a section break that starts a new page (`nextPage`/`evenPage`/
- * `oddPage`, or an unspecified type, which the layout treats as `nextPage`).
- * A `continuous` break stays on the current page, so it does not open a fresh
- * page frame. Used by `measureBlocks` to reset the running Y for a page-pinned
- * band that lands right after the break. eigenpal #694.
+ * `true` for a section break that explicitly starts a new page
+ * (`nextPage`/`evenPage`/`oddPage`). An absent type follows
+ * `scheduleSectionBreak` and stays continuous, so measurement must retain any
+ * active exclusion zones across it. Used by `measureBlocks` to reset the
+ * running Y for a page-pinned band that lands right after the break.
+ * eigenpal #694.
  */
 function isNextPageSectionBreak(block: FlowBlock): boolean {
-  return block.kind === "sectionBreak" && block.type !== "continuous";
+  return block.kind === "sectionBreak" && block.type !== undefined && block.type !== "continuous";
 }
 
 /**

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -1,5 +1,6 @@
 import { recordMeasureBlock, recordMeasureBlockError } from "../layoutInstrumentation";
 import { bandTopContentY, isPageFrameRelativeAnchor } from "../textBoxFlow";
+import { getTextBoxGroupId } from "../textBoxGroup";
 import { DEFAULT_TEXTBOX_MARGINS, floatingTextBoxReservesBand } from "../types";
 import type {
   FlowBlock,
@@ -587,7 +588,7 @@ function extractFloatingZones(
     if (bottomY <= 0) {
       continue;
     }
-    const groupId = tb._docxGroupId;
+    const groupId = getTextBoxGroupId(tb);
     const anchorBlockIndex = groupId
       ? (textBoxGroupAnchors.get(groupId) ?? blockIndex)
       : blockIndex;

--- a/packages/core/src/layout-engine/textBoxGroup.ts
+++ b/packages/core/src/layout-engine/textBoxGroup.ts
@@ -1,0 +1,10 @@
+import type { TextBoxBlock } from "./types";
+
+const textBoxGroupIds = new WeakMap<TextBoxBlock, string>();
+
+export const setTextBoxGroupId = (textBox: TextBoxBlock, groupId: string): void => {
+  textBoxGroupIds.set(textBox, groupId);
+};
+
+export const getTextBoxGroupId = (textBox: TextBoxBlock): string | undefined =>
+  textBoxGroupIds.get(textBox);

--- a/packages/core/src/layout-engine/textbox-band.test.ts
+++ b/packages/core/src/layout-engine/textbox-band.test.ts
@@ -2,8 +2,9 @@
  * A page/margin-pinned topAndBottom text box (e.g. a "For Internal Use" banner)
  * floats to the page top instead of dropping into the flow at its anchor, and it
  * does not consume flow height (the reserved band in the measure pass — see
- * extractFloatingZones in PagedEditor — pushes body text below it). A
- * paragraph-anchored topAndBottom box keeps the in-flow handling.
+ * extractFloatingZones in PagedEditor — pushes body text below it). An
+ * unpositioned topAndBottom box keeps the in-flow handling, while an explicit
+ * paragraph anchor positions from the current cursor without consuming flow.
  * Regression for eigenpal/docx-editor#694.
  */
 
@@ -173,7 +174,7 @@ describe("topAndBottom band text box layout", () => {
     expect(box?.y).toBe(960);
   });
 
-  test("paragraph-anchored topAndBottom box stays in flow (unchanged)", () => {
+  test("unpositioned topAndBottom box stays in flow", () => {
     const frags = textBoxFragments([banner(undefined), para("p")], [boxMeasure, paraMeasure]);
 
     const box = frags.find((f) => f.kind === "textBox") as TextBoxFragment | undefined;
@@ -182,6 +183,19 @@ describe("topAndBottom band text box layout", () => {
     // In-flow box at the top, paragraph pushed below it by the box height.
     expect(box?.y).toBe(MARGINS.top);
     expect(paragraph?.y).toBe(MARGINS.top + BOX_HEIGHT);
+  });
+
+  test("paragraph-anchored text box positions from the cursor without consuming flow", () => {
+    const anchored = verticalBanner({ relativeTo: "paragraph", posOffset: EMU_PER_INCH });
+    const frags = textBoxFragments([anchored, para("p")], [boxMeasure, paraMeasure]);
+
+    const box = frags.find((fragment) => fragment.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    const paragraph = frags.find((fragment) => fragment.kind === "paragraph");
+
+    expect(box?.y).toBe(MARGINS.top + 96);
+    expect(paragraph?.y).toBe(MARGINS.top);
   });
 
   test("band uses the section top margin, not a page's first-page margin", () => {

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -690,8 +690,6 @@ export type TextBoxBlock = {
   wrapText?: "bothSides" | "left" | "right" | "largest";
   /** Position for floating/anchored text boxes (OOXML EMU offsets). */
   position?: ImageRunPosition;
-  /** Import-only identifier shared by text boxes from the same host paragraph. */
-  _docxGroupId?: string;
   /** Wrap distances in pixels. */
   distTop?: number;
   distBottom?: number;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -690,6 +690,8 @@ export type TextBoxBlock = {
   wrapText?: "bothSides" | "left" | "right" | "largest";
   /** Position for floating/anchored text boxes (OOXML EMU offsets). */
   position?: ImageRunPosition;
+  /** Import-only identifier shared by text boxes from the same host paragraph. */
+  _docxGroupId?: string;
   /** Wrap distances in pixels. */
   distTop?: number;
   distBottom?: number;


### PR DESCRIPTION
Preserves explicitly positioned text boxes when their host paragraph contains no normal flow content. Anchored boxes now retain their shared paragraph frame, reserve top-and-bottom wrap bands together, and keep those bands across same-page section boundaries.

Adds focused parser, measurement, and layout regressions.