### PR TITLE
fix: use Montserrat line metrics

### DIFF
--- a/.changeset/tidy-font-lines.md
+++ b/.changeset/tidy-font-lines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Use Montserrat's real line metrics for single-spaced document layout.

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -29,6 +29,7 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["georgia", 1.1362],
     ["verdana", 1.2153],
     ["tahoma", 1.207],
+    ["montserrat", 1.219],
     ["trebuchet ms", 1.1611],
     ["courier new", 1.1328],
     ["consolas", 1.1709],

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -267,6 +267,18 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
       unitsPerEm: 2048,
     }), // 1.2070 (was hand-transcribed 1.2075 — negligible, now derived)
   },
+  montserrat: {
+    googleFont: "Montserrat",
+    category: "sans-serif",
+    fallbackStack: ["Montserrat", "Arial", "Helvetica", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 968,
+      hheaDescent: -251,
+      hheaLineGap: 0,
+      unitsPerEm: 1000,
+    }), // 1.2190
+  },
   "trebuchet ms": {
     googleFont: "Fira Sans",
     category: "sans-serif",


### PR DESCRIPTION
Adds Montserrat as a resolved document font using its real hhea ascent, descent, and line-gap metrics. This prevents cumulative vertical drift in single-spaced paragraphs while retaining the authored family as the first CSS fallback.

Adds a regression to the verified font-metrics table.