### PR TITLE
fix: collapse redundant table cell endings

### DIFF
--- a/.changeset/quiet-cell-end.md
+++ b/.changeset/quiet-cell-end.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Suppress redundant trailing empty paragraph height in populated table cells.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -627,6 +627,29 @@ describe("toFlowBlocks table cell formatting", () => {
     expect(row.cells.at(0)?.noWrap).toBe(true);
     expect(row.cells.at(1)?.noWrap).toBeUndefined();
   });
+
+  test("suppresses a trailing empty paragraph after real cell content", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("content")]),
+            schema.node("paragraph"),
+          ]),
+          schema.node("tableCell", null, [schema.node("paragraph")]),
+        ]),
+      ]),
+    ]);
+
+    const table = toFlowBlocks(doc).at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+
+    const cells = table.rows.at(0)?.cells;
+    expect(cells?.at(0)?.blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBe(true);
+    expect(cells?.at(1)?.blocks.at(0)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
 });
 
 describe("toFlowBlocks list numbering", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1953,6 +1953,19 @@ function convertTableCell(
     offset += child.nodeSize;
   });
 
+  // A structurally empty paragraph appended after real cell content is the
+  // cell-end marker in Word's layout model, not another visible blank line.
+  // Keep the paragraph as a zero-height anchor for editing/positions. A cell
+  // whose only paragraph is empty still needs Word's normal empty-line floor.
+  const trailingBlock = blocks.at(-1);
+  if (
+    blocks.length > 1 &&
+    trailingBlock?.kind === "paragraph" &&
+    trailingBlock.runs.every((run) => run.kind === "text" && run.text.length === 0)
+  ) {
+    trailingBlock.attrs = { ...trailingBlock.attrs, suppressEmptyParagraphHeight: true };
+  }
+
   const attrs = expectTableCellAttrs(node);
 
   // Convert cell margins (twips) to pixel padding


### PR DESCRIPTION
Treats a structurally empty paragraph after populated table-cell content as a zero-height cell-end anchor. A genuinely empty cell retains its normal empty-line height.

Adds focused conversion coverage for both cases.