### PR TITLE
fix: add table cell borders on top of atLeast/auto row minimum height

### DIFF
--- a/.changeset/table-row-border-on-min-height.md
+++ b/.changeset/table-row-border-on-min-height.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Add horizontal cell borders on top of a table row's `atLeast`/`auto` minimum height instead of absorbing them. When an explicit row height (ECMA-376 §17.4.81 `w:trHeight` without an `hRule`, or `hRule="atLeast"`) exceeds the cell content, the border thickness now extends the row as Word renders it, fixing cumulative vertical drift in tables of short, bordered rows.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -207,6 +207,112 @@ describe("measureTableBlock row height", () => {
     }, fakeMeasure);
   });
 
+  test("adds horizontal cell borders on top of an atLeast/auto minimum height", () => {
+    withFakeTextMeasure(() => {
+      // A short single-line cell whose content is well under an explicit
+      // (atLeast) row height, but which carries a horizontal border. Word treats
+      // the explicit height as the minimum of the cell content+padding region;
+      // the border sits on the grid line and adds on top. So the row must be
+      // taller than the explicit height by the border thickness — the border
+      // must not be absorbed by `max(content + border, explicit)`.
+      const border = 6;
+      const tallMinHeight = 400;
+      const build = (rule: "atLeast" | undefined): TableBlock => ({
+        kind: "table",
+        id: "t",
+        columnWidths: [120],
+        rows: [
+          {
+            id: "r0",
+            height: tallMinHeight,
+            ...(rule ? { heightRule: rule } : {}),
+            cells: [
+              {
+                id: "a",
+                blocks: [para("a1", "One line")],
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                // First row: top+bottom both collapse in, so 2 * border.
+                borders: { top: { width: border }, bottom: { width: border } },
+              },
+            ],
+          },
+        ],
+      });
+
+      for (const rule of ["atLeast", undefined] as const) {
+        const measure = measureTableBlock(build(rule), 120);
+        const contentHeight = measure.rows[0]?.cells[0]?.height ?? 0;
+        expect(contentHeight).toBeLessThan(tallMinHeight); // content is the shorter term
+        // Border (2 * 6 on the first row) added on top of the minimum height.
+        expect(measure.rows[0]?.height).toBe(tallMinHeight + 2 * border);
+        expect(measure.rows[0]?.height).toBeGreaterThan(tallMinHeight);
+      }
+    }, fakeMeasure);
+  });
+
+  test("does not double-count borders when content already exceeds the minimum height", () => {
+    withFakeTextMeasure(() => {
+      // Guard against over-correction: when content+border already exceeds the
+      // explicit minimum, the row is content+border (the border is not added a
+      // second time), matching the no-explicit-height case.
+      const border = 4;
+      const cell = () => ({
+        id: "a",
+        blocks: [para("a1", "One line")],
+        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+        borders: { top: { width: border }, bottom: { width: border } },
+      });
+      const withMin: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120],
+        rows: [{ id: "r0", height: 1, heightRule: "atLeast", cells: [cell()] }],
+      };
+      const noMin: TableBlock = {
+        kind: "table",
+        id: "t2",
+        columnWidths: [120],
+        rows: [{ id: "r0", cells: [cell()] }],
+      };
+
+      const withMinHeight = measureTableBlock(withMin, 120).rows[0]?.height ?? 0;
+      const noMinHeight = measureTableBlock(noMin, 120).rows[0]?.height ?? 0;
+      const contentHeight = measureTableBlock(noMin, 120).rows[0]?.cells[0]?.height ?? 0;
+
+      expect(withMinHeight).toBe(contentHeight + 2 * border);
+      expect(withMinHeight).toBe(noMinHeight);
+    }, fakeMeasure);
+  });
+
+  test("exact height rule stays exact and ignores cell borders", () => {
+    withFakeTextMeasure(() => {
+      // `hRule=exact` fixes the whole row height; borders do not extend it.
+      const exactHeight = 300;
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120],
+        rows: [
+          {
+            id: "r0",
+            height: exactHeight,
+            heightRule: "exact",
+            cells: [
+              {
+                id: "a",
+                blocks: [para("a1", "One line")],
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                borders: { top: { width: 8 }, bottom: { width: 8 } },
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(measureTableBlock(table, 120).rows[0]?.height).toBe(exactHeight);
+    }, fakeMeasure);
+  });
+
   test("hidden rows remain addressable but contribute zero height", () => {
     withFakeTextMeasure(() => {
       const table: TableBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -311,6 +311,7 @@ export function measureTableBlock(
     // stays content + padding (the painter lays cell content out within it); the
     // border only contributes to the row total here.
     let maxCellHeightWithBorders = 0;
+    let maxBorderHeight = 0;
     for (let cellIdx = 0; cellIdx < row.cells.length; cellIdx++) {
       const cell = row.cells[cellIdx]!; // SAFETY: cellIdx < row.cells.length
       const sourceCell = sourceRowCells?.[cellIdx];
@@ -326,10 +327,9 @@ export function measureTableBlock(
       const padTop = sourceCell?.padding?.top ?? DEFAULT_CELL_PADDING_Y;
       const padBottom = sourceCell?.padding?.bottom ?? DEFAULT_CELL_PADDING_Y;
       cell.height += padTop + padBottom;
-      maxCellHeightWithBorders = Math.max(
-        maxCellHeightWithBorders,
-        cell.height + getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0),
-      );
+      const borderHeight = getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0);
+      maxCellHeightWithBorders = Math.max(maxCellHeightWithBorders, cell.height + borderHeight);
+      maxBorderHeight = Math.max(maxBorderHeight, borderHeight);
     }
 
     // Apply heightRule from the source row
@@ -339,9 +339,13 @@ export function measureTableBlock(
     if (explicitHeight && heightRule === "exact") {
       row.height = explicitHeight;
     } else if (explicitHeight) {
-      // Both 'atLeast' and 'auto' (OOXML default) treat the value as minimum height.
-      // ECMA-376 §17.4.81: when hRule is absent or "auto", val is the minimum row height.
-      row.height = Math.max(maxCellHeightWithBorders, explicitHeight);
+      // Both 'atLeast' and 'auto' (OOXML default) treat the value as a minimum.
+      // ECMA-376 §17.4.81: when hRule is absent or "auto", val is the minimum row
+      // height. In Word that minimum governs the cell content+padding region only;
+      // horizontal cell borders sit on the grid lines and add on top of it. So when
+      // the explicit height wins over content, the border must still be added rather
+      // than absorbed (`Math.max(content + border, explicit)` would swallow it).
+      row.height = Math.max(maxCellHeightWithBorders, explicitHeight + maxBorderHeight);
     } else {
       // No explicit height — use content height directly.
       row.height = maxCellHeightWithBorders;


### PR DESCRIPTION
## Problem

In a table row with an explicit height and no height rule, ECMA-376 §17.4.81
(`w:trHeight` without `w:hRule`) defaults to `auto`, and `auto`/`atLeast` treat
the value as the **minimum** height of the cell content+padding region. Word
draws the horizontal cell borders on the grid lines between rows, so the border
thickness extends the row **on top of** that minimum.

The row-height measurement folded each cell's border into the `content + padding
+ border` total that competes with the explicit height through `Math.max(...)`.
When the explicit minimum won (short content, e.g. a single line under a
`w:trHeight` floor), the border was absorbed rather than added, so a short
bordered row measured one border-thickness too short.

For a long table made of many short bordered rows, this under-measurement
accumulates: content creeps upward row by row and can eventually drop a page
from the paginated output.

## Fix

`measureTableBlock` now tracks the row's maximum horizontal border height
separately and adds it on top of the `atLeast`/`auto` minimum:

```
row.height = max(maxContentPlusBorder, explicitMinHeight + maxBorderHeight)
```

Behaviour preserved:
- When content wins (no/low explicit height), the result is the existing
  per-cell `content + border` max (borders are not double-counted, and mixed
  content/border cells are not over-allocated).
- `hRule="exact"` still fixes the row to exactly the specified height; borders
  do not extend it.

## Tests

Synthetic unit tests in `measureBlocks.test.ts`:
- a short single-line bordered cell under a tall `atLeast`/`auto` minimum: the
  row is the minimum plus the border, not just the minimum (the failing case);
- content that already exceeds the minimum: row equals content+border and
  matches the no-explicit-height case (guards against double-counting /
  over-correction);
- `hRule="exact"`: row stays exact and ignores borders.

Existing row-height tests (collapsed first-row top border, per-cell
content+border max) still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table row height calculations so horizontal cell borders are preserved when rows use minimum or automatic heights.
  * Prevented cumulative vertical drift in tables with short, bordered rows.
  * Ensured borders are not double-counted when content already exceeds the minimum row height.
  * Preserved exact row heights while correctly accounting for border thickness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->