### PR TITLE
fix: position list marker for negative left indent with hanging

### DIFF
--- a/.changeset/negative-left-indent-list-marker.md
+++ b/.changeset/negative-left-indent-list-marker.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Fix list marker position for paragraphs with a negative left indent and a hanging indent (`w:ind w:left="-180" w:hanging="360"`). The marker was painted at the left indent instead of `left - hanging`, shifting it one hanging-indent (e.g. 18pt) too far right and mis-indenting continuation lines. The negative left indent is now realized by the line's own `margin-left`, and the marker's remaining negative offset rides on its `margin-left`; positive and zero left-indent lists are unchanged.

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -172,3 +172,96 @@ describe("Issue #729 — list hanging indent exceeding left indent", () => {
     expect(line.style.paddingLeft).toBe("0px");
   });
 });
+
+describe("negative left indent with hanging (w:ind w:left<0 w:hanging)", () => {
+  test("marker hangs to indentLeft - hanging, accounting for the line's margin-left", () => {
+    // `w:ind w:left="-180" w:hanging="360"` -> left = -9px, hanging = 18px.
+    // Word puts the marker at left - hanging = -27px (deep in the left margin)
+    // and the body at left = -9px. The line element already carries
+    // margin-left = min(left, 0) = -9px, so the marker only needs the
+    // remaining -18px on its own margin-left.
+    const { line, marker } = renderListItem({ left: -9, hanging: 18 });
+    expect(marker?.className).toContain("layout-list-marker");
+    expect(Number.parseFloat(marker?.style.marginLeft ?? "")).toBeCloseTo(-18, 1);
+    // padding clamps to 0 (markerStart is negative); the -9px negative left
+    // indent rides on the line's own margin-left, not padding.
+    expect(line.style.paddingLeft).toBe("0px");
+    expect(line.style.textIndent).toBe("0");
+    expect(Number.parseFloat(line.style.marginLeft ?? "")).toBeCloseTo(-9, 1);
+  });
+
+  test("continuation line sits at the negative left indent, not left + hanging", () => {
+    // Guard against double-shifting: the body/continuation line must land at
+    // `left` (-9px, via the line margin-left), NOT get an extra `hanging`
+    // padding on top of it.
+    const { continuation } = renderMultiLineListItem({ left: -9, hanging: 18 });
+    // No hanging padding added; the negative indent is realized by margin-left.
+    expect(continuation.style.paddingLeft).toBeFalsy();
+    expect(Number.parseFloat(continuation.style.marginLeft ?? "")).toBeCloseTo(-9, 1);
+  });
+});
+
+function renderMultiLineListItem(indent: { left: number; hanging: number }): {
+  first: HTMLElement;
+  continuation: HTMLElement;
+} {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p1",
+    runs: [{ kind: "text", text: "TEST1TEST2" }],
+    attrs: { listMarker: "1.", indent },
+  };
+  const line = {
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: 5,
+    width: 40,
+    ascent: 10,
+    descent: 3,
+    lineHeight: 14,
+  };
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [line, { ...line, fromChar: 5, toChar: 10 }],
+    totalHeight: 28,
+  };
+  const fragment: ParagraphFragment = {
+    kind: "paragraph",
+    blockId: "p1",
+    x: 0,
+    y: 0,
+    width: 400,
+    height: 28,
+    fromLine: 0,
+    toLine: 2,
+  };
+
+  const originalDocument = globalThis.document;
+  Object.defineProperty(globalThis, "document", {
+    value: fakeDocument,
+    configurable: true,
+  });
+  clearTextWidthCache();
+  resetCanvasContext();
+  try {
+    const fragmentEl = renderParagraphFragment(
+      fragment,
+      block,
+      measure,
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument },
+    );
+    return {
+      first: fragmentEl.children[0] as HTMLElement,
+      continuation: fragmentEl.children[1] as HTMLElement,
+    };
+  } finally {
+    clearTextWidthCache();
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      value: originalDocument,
+      configurable: true,
+    });
+  }
+}

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2515,8 +2515,12 @@ export function renderParagraphFragment(
     } else if (indentLeft > 0) {
       // Body lines (not first line)
       lineEl.style.paddingLeft = `${indentLeft}px`;
-    } else if (hasHanging) {
-      // Hanging indent without left indent: body lines need padding = hanging
+    } else if (hasHanging && indentLeft === 0) {
+      // Zero left indent + hanging: body lines need padding = hanging so
+      // continuation text aligns with the first line's post-marker body.
+      // A NEGATIVE left indent is realized by the line's own margin-left
+      // (`min(indentLeft, 0)` below); adding hanging padding there would
+      // double-shift the continuation right of where Word places it.
       lineEl.style.paddingLeft = `${indent.hanging ?? 0}px`;
     }
 
@@ -2587,15 +2591,21 @@ export function renderParagraphFragment(
         block.attrs.listMarkerRevision,
         block.attrs.listMarkerSecondSlotOffsetTwips,
       );
-      // When the hang exceeds the left indent the marker belongs in the left
-      // margin — exactly where Word puts it (a list whose direct `w:ind` has
-      // `hanging` > `left`, eigenpal #730 / #729). CSS padding can't be
-      // negative, so the negative portion rides on the marker's own margin-left.
-      // Gated to `indentLeft > 0`: with no left indent the body/continuation
-      // lines already sit at `hanging` (see body-line branch above), so hanging
-      // the marker into the margin there would misalign the first line.
-      if (markerStart < 0 && indentLeft > 0) {
-        marker.style.marginLeft = `${markerStart}px`;
+      // When the marker sits left of the line's own start it belongs in the
+      // left margin — exactly where Word puts it (a list whose direct `w:ind`
+      // has `hanging` > `left`, eigenpal #730 / #729, OR a NEGATIVE `left`, e.g.
+      // `w:ind w:left="-180" w:hanging="360"`). CSS padding can't be negative,
+      // so the negative portion rides on the marker's own margin-left. The line
+      // element already carries `margin-left = min(indentLeft, 0)`, so subtract
+      // that so the marker only takes the REMAINING negative offset: for a
+      // positive left indent the line margin is 0 and this is just `markerStart`;
+      // for a negative left indent it is `markerStart - indentLeft = -hanging`.
+      // The zero-left-indent case keeps its existing model (marker at the box
+      // edge, body at `hanging` via padding), so it is excluded.
+      const markerLineMargin = Math.min(indentLeft, 0);
+      const markerMarginLeft = markerStart - markerLineMargin;
+      if (markerMarginLeft < 0 && indentLeft !== 0) {
+        marker.style.marginLeft = `${markerMarginLeft}px`;
       }
       lineEl.prepend(marker);
     }


### PR DESCRIPTION
## Problem

A paragraph whose numbering level (or direct `w:ind`) has a **negative left indent combined with a hanging indent** — e.g. `<w:ind w:left="-180" w:hanging="360"/>` — rendered its list marker one hanging-indent too far right.

The DOM paint path realizes a negative left indent via the line element's `margin-left = min(indentLeft, 0)`, but the list-marker and body-continuation logic assumed a non-negative left indent:

- The marker's negative hang offset was gated on `indentLeft > 0`, so with a negative left indent it was never applied and the marker clamped to the (already margin-shifted) line start.
- Continuation lines added `padding-left = hanging` on top of the negative `margin-left`, double-shifting the body right.

Net effect: for `w:left="-180" w:hanging="360"` the marker landed at `left` instead of `left - hanging` (~18pt too far right), and continuation text was mis-indented.

## Fix

In `renderParagraph.ts`:

- The marker's `margin-left` now carries `markerStart - min(indentLeft, 0)` whenever the marker sits left of the line's own start, for any non-zero left indent. For a positive left indent the line margin is 0, so this is the existing `markerStart`; for a negative left indent it is the remaining `-hanging` offset. The zero-left-indent model (marker at the box edge, body at `hanging` via padding) is preserved by excluding `indentLeft === 0`.
- The `padding-left = hanging` on continuation lines is now applied only when `indentLeft === 0`; for a negative left indent the line's own `margin-left` already positions the body, so the extra padding is dropped.

Positive and zero left-indent lists are unchanged.

## Tests

Extended `renderParagraph-list-hanging-indent.test.ts` with synthetic cases:

- **new:** negative left indent (`left=-9, hanging=18`) hangs the marker to `-hanging` on its own margin-left, with the negative left indent on the line's `margin-left` and `padding-left: 0`.
- **new:** the continuation line sits at the negative left indent (no extra hanging padding).
- **unchanged (guards):** `hanging > left`, `hanging <= left`, and `left == 0` cases still assert their existing marker/padding behavior.

All 5 tests pass; the full `layout-painter` (244) and `layout-engine` (281) suites stay green.