### PR TITLE
fix: wrap noWrap table cells in pinned columns

### DIFF
--- a/.changeset/nowrap-fixed-column-wrap.md
+++ b/.changeset/nowrap-fixed-column-wrap.md
@@ -1,0 +1,12 @@
+---
+"@stll/folio-core": patch
+---
+
+Wrap `w:noWrap` table cells whose content overflows a pinned column. When the
+table layout is fixed or an explicit `w:tblW` (`dxa`/`pct`) width pins the
+columns, Word cannot honor `w:noWrap` by widening the column, so it wraps the
+content. Measurement now measures such cells at their real column width (instead
+of an unbounded width), and the painter drops `white-space: nowrap` for them so
+the painted height matches. Auto-width tables still keep `w:noWrap` cells on a
+single line. This corrects under-measured rows that previously let extra rows
+fit per page and dropped a page.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -774,7 +774,8 @@ export type TableBlock = {
     rows: TableRow[];
     columnWidths?: number[]; /** Table width value (twips for dxa, 50ths of percent for pct). */
     width?: number; /** Table width type ('auto', 'pct', 'dxa', 'nil'). */
-    widthType?: TableWidthType; /** Table horizontal alignment */
+    widthType?: TableWidthType;
+    layout?: "fixed" | "autofit"; /** Table horizontal alignment */
     justification?: "left" | "center" | "right"; /** Table indent from left margin (in pixels, from w:tblInd) */
     indent?: number; /** Right-to-left column order (w:bidiVisual): logical column 0 paints on the right. */
     bidi?: boolean; /** Floating table properties (pixel values). */
@@ -811,6 +812,9 @@ export type TableCellMeasure = {
     colSpan?: number;
     rowSpan?: number;
 };
+
+// @public
+export function tableColumnsArePinned(table: TableBlock): boolean;
 
 // @public
 export type TableFragment = FragmentBase & {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2108,7 +2108,11 @@ function convertTable(node: PMNode, startPos: number, options: ToFlowBlocksOptio
   // toggle it — so reading the preserved formatting is sufficient
   // (eigenpal/docx-editor#940).
   const originalFormatting = attrs._originalFormatting as
-    | { indent?: { value: number; type: string }; bidi?: boolean }
+    | {
+        indent?: { value: number; type: string };
+        bidi?: boolean;
+        layout?: "fixed" | "autofit";
+      }
     | undefined;
   const indentPx =
     originalFormatting?.indent?.value && originalFormatting.indent.type === "dxa"
@@ -2181,6 +2185,9 @@ function convertTable(node: PMNode, startPos: number, options: ToFlowBlocksOptio
   }
   if (widthType !== undefined) {
     tableBlock.widthType = widthType;
+  }
+  if (originalFormatting?.layout !== undefined) {
+    tableBlock.layout = originalFormatting.layout;
   }
   if (justification) {
     tableBlock.justification = justification;

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -396,6 +396,76 @@ describe("measureTableBlock row height", () => {
   });
 });
 
+describe("measureTableBlock w:noWrap column pinning", () => {
+  // Column content width is 60px (no padding) and each char is 5px, so this
+  // three-word phrase (75px unbroken) must wrap when the column is pinned and
+  // must stay on one line when the cell is allowed to keep noWrap.
+  const OVERFLOW_TEXT = "wordone wordtwo wordthree";
+  const FIT_TEXT = "hi";
+
+  const noWrapTable = (opts: {
+    text: string;
+    widthType?: TableBlock["widthType"];
+    layout?: TableBlock["layout"];
+  }): TableBlock => ({
+    kind: "table",
+    id: "t",
+    columnWidths: [60],
+    ...(opts.widthType ? { widthType: opts.widthType } : {}),
+    ...(opts.layout ? { layout: opts.layout } : {}),
+    rows: [
+      {
+        id: "r",
+        cells: [
+          {
+            id: "c",
+            noWrap: true,
+            padding: { top: 0, right: 0, bottom: 0, left: 0 },
+            blocks: [para("p", opts.text)],
+          },
+        ],
+      },
+    ],
+  });
+
+  const cellLineCount = (table: TableBlock): number => {
+    const paragraph = measureTableBlock(table, 500).rows[0]?.cells[0]?.blocks[0];
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph measure");
+    }
+    return paragraph.lines.length;
+  };
+
+  test("wraps an overflowing noWrap cell when an explicit dxa width pins the column", () => {
+    withFakeTextMeasure(() => {
+      expect(cellLineCount(noWrapTable({ text: OVERFLOW_TEXT, widthType: "dxa" }))).toBeGreaterThan(
+        1,
+      );
+    }, fakeMeasure);
+  });
+
+  test("wraps an overflowing noWrap cell under a fixed table layout", () => {
+    withFakeTextMeasure(() => {
+      expect(cellLineCount(noWrapTable({ text: OVERFLOW_TEXT, layout: "fixed" }))).toBeGreaterThan(
+        1,
+      );
+    }, fakeMeasure);
+  });
+
+  test("keeps an overflowing noWrap cell on one line in an auto-width table", () => {
+    withFakeTextMeasure(() => {
+      // Auto layout: Word would widen the column, so noWrap stays single-line.
+      expect(cellLineCount(noWrapTable({ text: OVERFLOW_TEXT, widthType: "auto" }))).toBe(1);
+    }, fakeMeasure);
+  });
+
+  test("keeps a fitting noWrap cell on one line even when the column is pinned", () => {
+    withFakeTextMeasure(() => {
+      expect(cellLineCount(noWrapTable({ text: FIT_TEXT, widthType: "dxa" }))).toBe(1);
+    }, fakeMeasure);
+  });
+});
+
 describe("measureBlocks error instrumentation", () => {
   test("routes a block-measurement failure through the instrumentation hook", () => {
     type MeasureBlockErrorEvent = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -1,7 +1,11 @@
 import { recordMeasureBlock, recordMeasureBlockError } from "../layoutInstrumentation";
 import { bandTopContentY, isPageFrameRelativeAnchor } from "../textBoxFlow";
 import { getTextBoxGroupId } from "../textBoxGroup";
-import { DEFAULT_TEXTBOX_MARGINS, floatingTextBoxReservesBand } from "../types";
+import {
+  DEFAULT_TEXTBOX_MARGINS,
+  floatingTextBoxReservesBand,
+  tableColumnsArePinned,
+} from "../types";
 import type {
   FlowBlock,
   ImageBlock,
@@ -234,6 +238,12 @@ export function measureTableBlock(
     }
   }
 
+  // When the columns are pinned (fixed layout or a fully-consumed explicit
+  // width), Word cannot widen a column to satisfy `w:noWrap`, so overflowing
+  // content wraps. Only an auto-width table honors `w:noWrap` by keeping the
+  // cell on one line. The painter reads the same predicate for `white-space`.
+  const columnsPinned = tableColumnsArePinned(tableBlock);
+
   // Calculate cell widths based on colSpan and columnWidths,
   // skipping columns occupied by spanning cells from previous rows.
   const rows = tableBlock.rows.map((row, rowIdx) => {
@@ -263,14 +273,14 @@ export function measureTableBlock(
         const padLeft = cell.padding?.left ?? DEFAULT_CELL_PADDING_X;
         const padRight = cell.padding?.right ?? DEFAULT_CELL_PADDING_X;
         const cellContentWidth = Math.max(1, cellWidth - padLeft - padRight);
-        // `w:noWrap` (§17.4.30): measure cell paragraphs against an effectively
-        // unbounded width so the line breaker never splits a single Word line
-        // into multiple MeasuredLines. The painter still constrains the cell
-        // box to `cellWidth`; `white-space: nowrap` keeps inline content on
-        // one line, and `overflow-x` lets it extend past the column. Without
-        // this, `renderTable.ts`'s nowrap style only prevents inline wrapping
-        // and the precomputed line splits would still render as stacked rows.
-        const measureWidth = cell.noWrap ? NO_WRAP_MEASURE_WIDTH : cellContentWidth;
+        // `w:noWrap` (§17.4.30): in an auto-width table Word honors it by
+        // widening the column, so measure against an effectively unbounded
+        // width and the line breaker keeps the cell on one MeasuredLine (the
+        // painter pairs this with `white-space: nowrap`). When the columns are
+        // pinned Word cannot widen, so overflowing content wraps: measure at the
+        // real content width like an ordinary cell.
+        const keepSingleLine = cell.noWrap === true && !columnsPinned;
+        const measureWidth = keepSingleLine ? NO_WRAP_MEASURE_WIDTH : cellContentWidth;
         const cellMeasure: TableCellMeasure = {
           blocks: cell.blocks.map((b) =>
             measureBlock(b, measureWidth, undefined, undefined, fieldValues),

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -556,6 +556,13 @@ export type TableBlock = {
   width?: number;
   /** Table width type ('auto', 'pct', 'dxa', 'nil'). */
   widthType?: TableWidthType;
+  /**
+   * Table layout algorithm (`w:tblLayout`). "fixed" pins columns to their grid
+   * widths; "autofit" (the default when absent) lets Word size columns to
+   * content. Consulted alongside `widthType` to decide whether `w:noWrap` cells
+   * can be honored (see `tableColumnsArePinned`).
+   */
+  layout?: "fixed" | "autofit";
   /** Table horizontal alignment */
   justification?: "left" | "center" | "right";
   /** Table indent from left margin (in pixels, from w:tblInd) */
@@ -1340,4 +1347,24 @@ export function floatingTextBoxWrapsText(block: TextBoxFlowAttrs): boolean {
  */
 export function floatingTextBoxReservesBand(block: TextBoxFlowAttrs): boolean {
   return isFloatingTextBoxBlock(block) && block.wrapType === "topAndBottom";
+}
+
+/**
+ * A table's columns are pinned when the layout engine cannot widen a column to
+ * fit content that overflows it: either the layout is explicitly fixed
+ * (`w:tblLayout w:type="fixed"`) or an explicit total width (`w:tblW` `dxa`/
+ * `pct`) is fully consumed by the grid.
+ *
+ * In OOXML, `w:noWrap` (§17.4.30) asks Word not to soft-wrap a cell, but Word
+ * can only honor it by widening the column. When the columns are pinned it
+ * cannot, so overflowing content wraps despite `w:noWrap`. An auto-width table
+ * (`w:tblW` `auto`/`nil`/absent with autofit layout) lets Word widen the column
+ * instead, so there `w:noWrap` genuinely keeps content on one line. Measurement
+ * and the painter both consult this so their line count and `white-space` agree.
+ */
+export function tableColumnsArePinned(table: TableBlock): boolean {
+  if (table.layout === "fixed") {
+    return true;
+  }
+  return table.widthType === "dxa" || table.widthType === "pct";
 }

--- a/packages/core/src/layout-painter/renderTable-noWrap.test.ts
+++ b/packages/core/src/layout-painter/renderTable-noWrap.test.ts
@@ -71,7 +71,10 @@ function findCells(element: FakeElement): FakeElement[] {
   return matches;
 }
 
-function buildSingleCellTable(noWrap?: boolean): {
+function buildSingleCellTable(
+  noWrap?: boolean,
+  tableProps?: { widthType?: TableBlock["widthType"]; layout?: TableBlock["layout"] },
+): {
   fragment: TableFragment;
   block: TableBlock;
   measure: TableMeasure;
@@ -99,6 +102,8 @@ function buildSingleCellTable(noWrap?: boolean): {
       },
     ],
     columnWidths: [100],
+    ...(tableProps?.widthType ? { widthType: tableProps.widthType } : {}),
+    ...(tableProps?.layout ? { layout: tableProps.layout } : {}),
   };
   const measure: TableMeasure = {
     kind: "table",
@@ -189,5 +194,45 @@ describe("renderTable cell w:noWrap (eigenpal #424 gap 14)", () => {
     const cells = findCells(tableEl);
     expect(cells.length).toBe(1);
     expect(cells[0]?.style["whiteSpace"]).toBeUndefined();
+  });
+
+  // Coherence with measurement: when the columns are pinned (fixed layout or an
+  // explicit dxa/pct width), Word cannot honor noWrap and measurement wrapped
+  // the cell, so the painter must NOT emit `white-space: nowrap` (that would
+  // collapse the wrapped lines and desync painted vs measured height).
+  test("does NOT set white-space on a noWrap cell when an explicit dxa width pins the column", () => {
+    const { fragment, block, measure } = buildSingleCellTable(true, { widthType: "dxa" });
+
+    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+
+    const cells = findCells(tableEl);
+    expect(cells.length).toBe(1);
+    expect(cells[0]?.style["whiteSpace"]).toBeUndefined();
+  });
+
+  test("does NOT set white-space on a noWrap cell under a fixed table layout", () => {
+    const { fragment, block, measure } = buildSingleCellTable(true, { layout: "fixed" });
+
+    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+
+    const cells = findCells(tableEl);
+    expect(cells.length).toBe(1);
+    expect(cells[0]?.style["whiteSpace"]).toBeUndefined();
+  });
+
+  test("still sets white-space: nowrap on a noWrap cell in an auto-width table", () => {
+    const { fragment, block, measure } = buildSingleCellTable(true, { widthType: "auto" });
+
+    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+
+    const cells = findCells(tableEl);
+    expect(cells.length).toBe(1);
+    expect(cells[0]?.style["whiteSpace"]).toBe("nowrap");
   });
 });

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -24,6 +24,7 @@ import type {
   ParagraphMeasure,
   ParagraphFragment,
 } from "../layout-engine/types";
+import { tableColumnsArePinned } from "../layout-engine/types";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import { renderParagraphFragment } from "./renderParagraph";
 import type { RenderContext } from "./renderUtils";
@@ -232,6 +233,7 @@ function renderNestedTable(
   const spanningCells = new Map<string, SpanningCell>();
 
   // Render all rows
+  const columnsPinned = tableColumnsArePinned(block);
   let y = 0;
   for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
     const row = block.rows[rowIndex];
@@ -258,6 +260,7 @@ function renderNestedTable(
       rowYPositions,
       undefined,
       block.bidi,
+      columnsPinned,
     );
     tableEl.append(rowEl);
     y += rowMeasure.height;
@@ -306,6 +309,7 @@ function renderTableCell(
     isFirstCol: boolean;
     isLastCol: boolean;
   },
+  columnsPinned: boolean,
   context: RenderContext,
   doc: Document,
 ): HTMLElement {
@@ -355,14 +359,15 @@ function renderTableCell(
     }
   }
 
-  // `w:noWrap` (§17.4.30): forbid soft-wrapping inside the cell. The
-  // measurement phase already collapses noWrap cell paragraphs to a single
-  // MeasuredLine (see NO_WRAP_MEASURE_WIDTH in PagedEditor.tsx), so each cell
-  // paints as one row. This style is the inline-content guard: it prevents
-  // the browser from re-wrapping inside a single line div if the painted
-  // content would overflow (e.g., user zoom, font fallback widening).
-  // eigenpal #424 (cell noWrap).
-  if (cell.noWrap) {
+  // `w:noWrap` (§17.4.30): forbid soft-wrapping inside the cell. This applies
+  // only when the columns can grow to honor it (auto-width table); measurement
+  // then collapses the cell to a single MeasuredLine (see NO_WRAP_MEASURE_WIDTH)
+  // and this style is the inline-content guard that stops the browser from
+  // re-wrapping the single line div (e.g. user zoom, font fallback widening).
+  // When the columns are pinned Word cannot honor `w:noWrap`, so measurement
+  // wrapped the cell; emitting `nowrap` here would collapse those lines and
+  // desync the painted height from the measured height. eigenpal #424.
+  if (cell.noWrap && !columnsPinned) {
     cellEl.style.whiteSpace = "nowrap";
   }
 
@@ -436,6 +441,7 @@ function renderTableRow(
   rowYPositions?: number[],
   isFirstRowInFragment?: boolean,
   bidi = false,
+  columnsPinned = false,
 ): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
@@ -525,6 +531,7 @@ function renderTableRow(
       cellLeft,
       cellHeight,
       { isFirstRow, isLastRow, isFirstCol, isLastCol },
+      columnsPinned,
       context,
       doc,
     );
@@ -652,6 +659,7 @@ export function renderTableFragment(
 
   // Track spanning cells across rows
   const spanningCells = new Map<string, SpanningCell>();
+  const columnsPinned = tableColumnsArePinned(block);
 
   // Render repeated header rows for continuation fragments. For a mid-content
   // row break (eigenpal #698), keep repeated headers pinned to the fragment top
@@ -683,6 +691,7 @@ export function renderTableFragment(
         rowYPositions,
         hdrIdx === 0, // first header row draws top border
         block.bidi,
+        columnsPinned,
       );
       rowEl.dataset["repeatedHeader"] = "true";
       tableEl.append(rowEl);
@@ -739,6 +748,7 @@ export function renderTableFragment(
       rowYPositions,
       isFirstRowInFragment,
       block.bidi,
+      columnsPinned,
     );
 
     contentParent.append(rowEl);


### PR DESCRIPTION
## Problem

A table cell with `w:noWrap` (§17.4.30) asks Word not to soft-wrap its content. Word can only honor that by *widening the column*. When the table's columns are pinned — `w:tblLayout w:type="fixed"`, or an explicit `w:tblW` (`dxa`/`pct`) total width that the grid columns fully consume — there is no room to widen, so Word **wraps** the overflowing content onto a second line.

folio measured every `noWrap` cell against an effectively unbounded width, forcing a single line. In a fixed-width table that under-measures the affected rows (each wrapped row is ~one line shorter than reality), which lets an extra row fit on a page and can drop a page versus Word.

## Fix

Thread the table layout signal (`w:tblLayout`) through to the layout engine and introduce a shared `tableColumnsArePinned(table)` predicate (fixed layout, or a `dxa`/`pct` width). Both sides consult it:

- **Measurement** (`measureBlocks`): a `noWrap` cell in a pinned-column table is measured at its real content width, so the line breaker wraps overflowing content like an ordinary cell. Auto-width tables still measure `noWrap` cells against an unbounded width (Word widens the column, content stays on one line).
- **Painter** (`renderTable`): `white-space: nowrap` is emitted only for the auto-width case. For pinned columns the measurement wrapped the cell, so emitting `nowrap` would collapse those lines and desync painted vs. measured height. Keeping the predicate identical on both sides keeps them coherent.

Content that fits its pinned column still renders on one line (measuring at the real width yields a single line).

## Tests

Synthetic regression coverage (generic content):

- **measureBlocks**: overflowing `noWrap` cell wraps under (1) an explicit `dxa` width and (2) `layout: "fixed"`; (3) stays single-line in an auto-width table; (4) a fitting `noWrap` cell stays single-line even when pinned.
- **renderTable-noWrap**: painter omits `white-space: nowrap` for a pinned-column `noWrap` cell (dxa width and fixed layout) and still emits it for an auto-width `noWrap` cell.

All existing layout-engine / layout-painter / layout-bridge suites pass; `@stll/folio-core` builds.