### PR TITLE
feat: version-diff move/format detection and tracked-changes redline generator

### DIFF
--- a/.changeset/tidy-lamps-compare.md
+++ b/.changeset/tidy-lamps-compare.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Version comparison upgrades and a redline generator. `compareDocxVersions` now detects relocated blocks (`movedFrom`/`movedTo` pairs sharing a `moveGroupId`) instead of reporting them as unrelated delete + insert, and reports text-equal blocks whose run formatting differs as `formatChanged` with the changed property names. New `generateRedlineDocx(base, revised)` produces a third `.docx` whose base → revised differences are recorded as real Word tracked changes (`w:ins`/`w:del`), reusing the comparer alignment and the headless tracked-changes apply path. `formatVersionDiffForLLM` renders the new change types.

--- a/.changeset/witty-notes-number.md
+++ b/.changeset/witty-notes-number.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Footnote and endnote body reference marks now display the sequential reference-order number (1, 2, 3…) instead of the raw `w:id`, matching Word for documents with non-contiguous or out-of-order note ids. The body marker and the footnote-area number derive from one shared display-number map, and reserved notes (separators, continuation notices at positive ids) no longer shift numbering.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -265,6 +265,24 @@ export type FolioBlockDiff = {
     blockId: string;
     kind: string;
     segments: FolioVersionDiffSegment[];
+} | {
+    type: "formatChanged";
+    blockId: string;
+    kind: string;
+    text: string;
+    changedProperties: FolioFormatProperty[];
+} | {
+    type: "movedFrom";
+    blockId: string;
+    kind: string;
+    text: string;
+    moveGroupId: number;
+} | {
+    type: "movedTo";
+    blockId: string;
+    kind: string;
+    text: string;
+    moveGroupId: number;
 };
 
 // @public
@@ -409,6 +427,9 @@ export type FolioDocxReviewerOptions = {
 };
 
 // @public
+export type FolioFormatProperty = (typeof FORMAT_PROPERTIES)[number];
+
+// @public
 export type FolioReviewChange = {
     id: number;
     type: FolioReviewChangeKind;
@@ -462,17 +483,32 @@ export type FolioReviewReplyInput = {
 
 // @public
 export type FolioVersionDiff = {
-    changes: FolioBlockDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. */
+    changes: FolioBlockDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
     summaryCounts: {
         added: number;
         deleted: number;
         modified: number;
+        formatChanged: number;
+        moved: number;
         unchanged: number;
     };
 };
 
 // @public
 export type FolioVersionDiffSegment = WordDiffSegment;
+
+// @public
+export const generateRedlineDocx: (base: ArrayBuffer, revised: ArrayBuffer, options?: GenerateRedlineDocxOptions) => Promise<GenerateRedlineDocxResult>;
+
+// @public
+export type GenerateRedlineDocxOptions = {
+    author?: string;
+};
+
+// @public
+export type GenerateRedlineDocxResult = FolioAIEditApplyResult & {
+    buffer: ArrayBuffer;
+};
 
 // @public (undocumented)
 export const getFolioDocumentOperationCapabilities: () => FolioDocumentOperationCapabilities;

--- a/packages/agents/src/compare.test.ts
+++ b/packages/agents/src/compare.test.ts
@@ -6,7 +6,14 @@ import { formatVersionDiffForLLM } from "./compare";
 describe("formatVersionDiffForLLM", () => {
   test("renders summary counts and word-diff markers", () => {
     const diff: FolioAgentVersionDiff = {
-      summaryCounts: { added: 1, deleted: 1, modified: 1, unchanged: 2 },
+      summaryCounts: {
+        added: 1,
+        deleted: 1,
+        modified: 1,
+        formatChanged: 1,
+        moved: 1,
+        unchanged: 2,
+      },
       changes: [
         {
           type: "modified",
@@ -30,14 +37,38 @@ describe("formatVersionDiffForLLM", () => {
           kind: "paragraph",
           text: "Epsilon paragraph.",
         },
+        {
+          type: "formatChanged",
+          blockId: "00000007",
+          kind: "paragraph",
+          text: "Delta paragraph.",
+          changedProperties: ["bold", "color"],
+        },
+        {
+          type: "movedFrom",
+          blockId: "00000008",
+          kind: "paragraph",
+          text: "Zeta paragraph moved somewhere else.",
+          moveGroupId: 1,
+        },
+        {
+          type: "movedTo",
+          blockId: "00000008",
+          kind: "paragraph",
+          text: "Zeta paragraph moved somewhere else.",
+          moveGroupId: 1,
+        },
       ],
     };
 
     expect(formatVersionDiffForLLM(diff).split("\n")).toEqual([
-      "Version diff: 1 added, 1 deleted, 1 modified, 2 unchanged",
+      "Version diff: 1 added, 1 deleted, 1 modified, 1 format-changed, 1 moved, 2 unchanged",
       "~ [00000002] modified: Beta [-paragraph.-]{+clause.+}",
       "- [00000003] deleted: Gamma paragraph.",
       "+ [00000006] added: Epsilon paragraph.",
+      "~ [00000007] format changed (bold, color): Delta paragraph.",
+      "< [00000008] moved away (move 1): Zeta paragraph moved somewhere else.",
+      "> [00000008] moved here (move 1): Zeta paragraph moved somewhere else.",
     ]);
   });
 });

--- a/packages/agents/src/compare.ts
+++ b/packages/agents/src/compare.ts
@@ -44,18 +44,27 @@ const renderSegment = (segment: FolioVersionDiffSegment): string => {
 };
 
 const formatChangeLine = (change: FolioBlockDiff): string => {
-  if (change.type === "added") {
-    return `+ [${change.blockId}] added: ${change.text}`;
+  switch (change.type) {
+    case "added":
+      return `+ [${change.blockId}] added: ${change.text}`;
+    case "deleted":
+      return `- [${change.blockId}] deleted: ${change.text}`;
+    case "modified":
+      return `~ [${change.blockId}] modified: ${change.segments.map(renderSegment).join("")}`;
+    case "formatChanged":
+      return `~ [${change.blockId}] format changed (${change.changedProperties.join(", ")}): ${truncateUnchangedRun(change.text)}`;
+    case "movedFrom":
+      return `< [${change.blockId}] moved away (move ${change.moveGroupId}): ${truncateUnchangedRun(change.text)}`;
+    case "movedTo":
+      return `> [${change.blockId}] moved here (move ${change.moveGroupId}): ${truncateUnchangedRun(change.text)}`;
+    default:
+      return "";
   }
-  if (change.type === "deleted") {
-    return `- [${change.blockId}] deleted: ${change.text}`;
-  }
-  return `~ [${change.blockId}] modified: ${change.segments.map(renderSegment).join("")}`;
 };
 
 /** Render a structured version diff as compact, deterministic model input. */
 export const formatVersionDiffForLLM = (diff: FolioAgentVersionDiff): string => {
-  const { added, deleted, modified, unchanged } = diff.summaryCounts;
-  const header = `Version diff: ${added} added, ${deleted} deleted, ${modified} modified, ${unchanged} unchanged`;
+  const { added, deleted, modified, formatChanged, moved, unchanged } = diff.summaryCounts;
+  const header = `Version diff: ${added} added, ${deleted} deleted, ${modified} modified, ${formatChanged} format-changed, ${moved} moved, ${unchanged} unchanged`;
   return [header, ...diff.changes.map(formatChangeLine)].join("\n");
 };

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -19,10 +19,12 @@ import { EditorState } from "prosemirror-state";
 
 import type { LayoutInstrumentation } from "../layout-engine/layoutInstrumentation";
 import { clearAllCaches } from "../layout-engine/measure/cache";
+import type { FootnoteContent } from "../layout-engine/types";
 import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import { LayoutPainter } from "../layout-painter";
 import { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
 import { schema } from "../prosemirror/schema";
+import type { Footnote } from "../types/document";
 import { createEmptyDocument } from "../utils/createDocument";
 import { runLayoutPipeline } from "./layoutPipeline";
 import type { LayoutPipelineDeps } from "./layoutPipeline";
@@ -417,6 +419,86 @@ describe("runLayoutPipeline", () => {
     expect(session.artifacts).not.toBeNull();
     expect(session.lastEditorState).toBe(state);
     expect(layoutCompletes).toHaveLength(1);
+  });
+
+  test("remaps body note markers to sequential reference-order display numbers", () => {
+    // Non-contiguous, out-of-order footnote ids (5, 2, 9 referenced in that
+    // order) must display 1, 2, 3 in both the body marker and the footnote
+    // area; the positive-id continuationNotice must not shift the numbering.
+    const session = createLayoutSession();
+    const footnoteMark = (id: number, noteType: "footnote" | "endnote") =>
+      schema.mark("footnoteRef", { id: String(id), noteType });
+    const state = EditorState.create({
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("Alpha"),
+          schema.text("5", [footnoteMark(5, "footnote")]),
+          schema.text(" beta"),
+          schema.text("2", [footnoteMark(2, "footnote")]),
+          schema.text(" gamma"),
+          schema.text("9", [footnoteMark(9, "footnote")]),
+          schema.text(" delta"),
+          schema.text("8", [footnoteMark(8, "endnote")]),
+        ]),
+      ]),
+    });
+
+    const noteParagraph = (text: string): Footnote["content"] => [
+      { type: "paragraph", content: [{ type: "run", content: [{ type: "text", text }] }] },
+    ];
+    const doc = createEmptyDocument();
+    doc.package.footnotes = [
+      { type: "footnote", id: 1, noteType: "continuationNotice", content: noteParagraph("cont") },
+      { type: "footnote", id: 2, noteType: "normal", content: noteParagraph("two") },
+      { type: "footnote", id: 5, noteType: "normal", content: noteParagraph("five") },
+      { type: "footnote", id: 9, noteType: "normal", content: noteParagraph("nine") },
+    ];
+    doc.package.endnotes = [
+      { type: "endnote", id: 8, noteType: "normal", content: noteParagraph("end") },
+    ];
+
+    let capturedContentMap: Map<number, FootnoteContent> | undefined;
+    const container = fakeDocument.createElement("div");
+    const deps = makeDeps(session, {
+      document: doc,
+      painter: new LayoutPainter(),
+      pagesContainer: asContainer(container),
+      buildFootnoteRenderItems: (_pageMap, contentMap) => {
+        capturedContentMap = contentMap;
+        return new Map();
+      },
+    });
+
+    const outcome = runLayoutPipeline(deps, state);
+
+    const bodyMarkers: { noteId: number; text: string }[] = [];
+    for (const block of outcome.blocks ?? []) {
+      if (block.kind !== "paragraph") {
+        continue;
+      }
+      for (const run of block.runs) {
+        if (run.kind !== "text") {
+          continue;
+        }
+        const noteId = run.footnoteRefId ?? run.endnoteRefId;
+        if (noteId !== undefined) {
+          bodyMarkers.push({ noteId, text: run.text });
+        }
+      }
+    }
+    expect(bodyMarkers).toEqual([
+      { noteId: 5, text: "1" },
+      { noteId: 2, text: "2" },
+      { noteId: 9, text: "3" },
+      { noteId: 8, text: "1" },
+    ]);
+
+    // The footnote area numbering comes from the same map as the body markers.
+    expect(capturedContentMap?.get(5)?.displayNumber).toBe(1);
+    expect(capturedContentMap?.get(2)?.displayNumber).toBe(2);
+    expect(capturedContentMap?.get(9)?.displayNumber).toBe(3);
+    expect(capturedContentMap?.has(1)).toBe(false);
+    expect(layoutErrors).toHaveLength(0);
   });
 
   test("keeps authored body margins when footer content extends beyond them", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -13,7 +13,10 @@ import { buildSeqValues } from "../fields/seqValues";
 import {
   FOOTNOTE_ENTRY_MARGIN_BOTTOM,
   buildFootnoteContentMap,
+  collectEndnoteRefs,
   collectFootnoteRefs,
+  computeNoteDisplayNumbers,
+  remapNoteMarkerText,
 } from "../layout-bridge/convert/footnoteLayout";
 import type { MeasureBlocksFn } from "../layout-bridge/convert/footnoteLayout";
 import type {
@@ -250,6 +253,30 @@ export function runLayoutPipeline<THfPMs>(
     const footnoteRefs = collectFootnoteRefs(newBlocks);
     const documentFootnotes = document?.package.footnotes;
     const hasFootnotes = footnoteRefs.length > 0 && documentFootnotes !== undefined;
+
+    // Body note markers carry the raw `w:id` as their run text (the PM doc
+    // stores it that way; the save path serializes from the mark attrs).
+    // Remap them to Word's sequential reference-order numbers here, before
+    // measurement, so the measured widths match the painted digits and the
+    // marker agrees with the footnote-area number built from the same map.
+    const footnoteDisplayNumbers = documentFootnotes
+      ? computeNoteDisplayNumbers(
+          documentFootnotes,
+          footnoteRefs.map((ref) => ref.footnoteId),
+        )
+      : undefined;
+    const documentEndnotes = document?.package.endnotes;
+    const endnoteDisplayNumbers = documentEndnotes
+      ? computeNoteDisplayNumbers(
+          documentEndnotes,
+          collectEndnoteRefs(newBlocks).map((ref) => ref.endnoteId),
+        )
+      : undefined;
+    newBlocks = remapNoteMarkerText(newBlocks, {
+      ...(footnoteDisplayNumbers ? { footnoteNumbers: footnoteDisplayNumbers } : {}),
+      ...(endnoteDisplayNumbers ? { endnoteNumbers: endnoteDisplayNumbers } : {}),
+    });
+    outcome.blocks = newBlocks;
 
     // Step 2.75: Prepare header/footer content for rendering. Headers and
     // footers are positioned independently from the authored body margins,

--- a/packages/core/src/docx/footnoteParser.ts
+++ b/packages/core/src/docx/footnoteParser.ts
@@ -467,57 +467,9 @@ export function isSeparatorEndnote(endnote: Endnote): boolean {
   );
 }
 
-/**
- * Get footnote number for display (excluding separators)
- * @param footnote - The footnote to get the number for
- * @param footnoteMap - The footnote map
- * @param startNumber - Starting number (default 1)
- * @returns The display number, or null for separator footnotes
- */
-export function getFootnoteDisplayNumber(
-  footnote: Footnote,
-  footnoteMap: FootnoteMap,
-  startNumber: number = 1,
-): number | null {
-  if (isSeparatorFootnote(footnote)) {
-    return null;
-  }
-
-  const normalFootnotes = footnoteMap.getNormalFootnotes();
-  const index = normalFootnotes.findIndex((fn) => fn.id === footnote.id);
-
-  if (index === -1) {
-    return null;
-  }
-
-  return startNumber + index;
-}
-
-/**
- * Get endnote number for display (excluding separators)
- * @param endnote - The endnote to get the number for
- * @param endnoteMap - The endnote map
- * @param startNumber - Starting number (default 1)
- * @returns The display number, or null for separator endnotes
- */
-export function getEndnoteDisplayNumber(
-  endnote: Endnote,
-  endnoteMap: EndnoteMap,
-  startNumber: number = 1,
-): number | null {
-  if (isSeparatorEndnote(endnote)) {
-    return null;
-  }
-
-  const normalEndnotes = endnoteMap.getNormalEndnotes();
-  const index = normalEndnotes.findIndex((en) => en.id === endnote.id);
-
-  if (index === -1) {
-    return null;
-  }
-
-  return startNumber + index;
-}
+// Note: display numbers are NOT derivable from footnotes.xml file order.
+// Word numbers notes by reference order in the document body; see
+// `computeNoteDisplayNumbers` in `layout-bridge/convert/footnoteLayout.ts`.
 
 /**
  * Create an empty footnote map

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression coverage for sequential note numbering.
+ *
+ * Word numbers footnotes/endnotes by reference order in the body, not by
+ * their `w:id` values. Documents with non-contiguous or out-of-order ids
+ * (e.g. ids 5, 2, 9 referenced in that order) must display 1, 2, 3 in BOTH
+ * the body marker and the footnote area; separator/continuation notes must
+ * not consume numbers even when they carry a positive id.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FlowBlock,
+  ParagraphBlock,
+  TableBlock,
+  TextBoxBlock,
+} from "../../layout-engine/types";
+import type { Footnote } from "../../types/document";
+import {
+  buildFootnoteContentMap,
+  computeNoteDisplayNumbers,
+  remapNoteMarkerText,
+} from "./footnoteLayout";
+
+const normalFootnote = (id: number, text: string): Footnote => ({
+  type: "footnote",
+  id,
+  noteType: "normal",
+  content: [{ type: "paragraph", content: [{ type: "run", content: [{ type: "text", text }] }] }],
+});
+
+const continuationNotice = (id: number): Footnote => ({
+  type: "footnote",
+  id,
+  noteType: "continuationNotice",
+  content: [{ type: "paragraph", content: [] }],
+});
+
+function paragraphWithFootnoteRef(id: string, footnoteId: number, pmStart: number): ParagraphBlock {
+  return {
+    kind: "paragraph",
+    id,
+    runs: [
+      {
+        kind: "text",
+        text: footnoteId.toString(),
+        footnoteRefId: footnoteId,
+        pmStart,
+        pmEnd: pmStart + footnoteId.toString().length,
+      },
+    ],
+  };
+}
+
+describe("computeNoteDisplayNumbers", () => {
+  test("numbers non-contiguous out-of-order ids by reference order", () => {
+    const notes = [normalFootnote(2, "two"), normalFootnote(5, "five"), normalFootnote(9, "nine")];
+
+    const numbers = computeNoteDisplayNumbers(notes, [5, 2, 9]);
+
+    expect(numbers.get(5)).toBe(1);
+    expect(numbers.get(2)).toBe(2);
+    expect(numbers.get(9)).toBe(3);
+  });
+
+  test("repeated references keep the first number and consume no new one", () => {
+    const notes = [normalFootnote(2, "two"), normalFootnote(5, "five"), normalFootnote(9, "nine")];
+
+    const numbers = computeNoteDisplayNumbers(notes, [5, 2, 5, 9]);
+
+    expect(numbers.get(5)).toBe(1);
+    expect(numbers.get(2)).toBe(2);
+    expect(numbers.get(9)).toBe(3);
+  });
+
+  test("positive-id continuation notices and unknown ids do not shift numbering", () => {
+    const notes = [continuationNotice(1), normalFootnote(5, "five"), normalFootnote(2, "two")];
+
+    const numbers = computeNoteDisplayNumbers(notes, [1, 5, 7, 2]);
+
+    expect(numbers.has(1)).toBe(false);
+    expect(numbers.has(7)).toBe(false);
+    expect(numbers.get(5)).toBe(1);
+    expect(numbers.get(2)).toBe(2);
+  });
+});
+
+describe("remapNoteMarkerText", () => {
+  test("rewrites body marker text from raw w:id to the display number", () => {
+    const blocks: FlowBlock[] = [
+      paragraphWithFootnoteRef("p1", 5, 10),
+      paragraphWithFootnoteRef("p2", 2, 20),
+      paragraphWithFootnoteRef("p3", 9, 30),
+    ];
+    const footnoteNumbers = new Map([
+      [5, 1],
+      [2, 2],
+      [9, 3],
+    ]);
+
+    const remapped = remapNoteMarkerText(blocks, { footnoteNumbers });
+
+    const texts = remapped.map((block) =>
+      block.kind === "paragraph" ? block.runs.at(0) : undefined,
+    );
+    expect(texts.at(0)).toMatchObject({ text: "1", footnoteRefId: 5, pmStart: 10, pmEnd: 11 });
+    expect(texts.at(1)).toMatchObject({ text: "2", footnoteRefId: 2, pmStart: 20, pmEnd: 21 });
+    expect(texts.at(2)).toMatchObject({ text: "3", footnoteRefId: 9, pmStart: 30, pmEnd: 31 });
+  });
+
+  test("returns untouched blocks and runs by reference", () => {
+    const plain: ParagraphBlock = {
+      kind: "paragraph",
+      id: "plain",
+      runs: [{ kind: "text", text: "no refs here" }],
+    };
+    const marker = paragraphWithFootnoteRef("marker", 5, 10);
+    const blocks: FlowBlock[] = [plain, marker];
+
+    const remapped = remapNoteMarkerText(blocks, { footnoteNumbers: new Map([[5, 1]]) });
+
+    expect(remapped.at(0)).toBe(plain);
+    expect(remapped.at(1)).not.toBe(marker);
+  });
+
+  test("returns the input array when there is nothing to remap", () => {
+    const blocks: FlowBlock[] = [paragraphWithFootnoteRef("p1", 5, 10)];
+
+    expect(remapNoteMarkerText(blocks, {})).toBe(blocks);
+    expect(remapNoteMarkerText(blocks, { footnoteNumbers: new Map() })).toBe(blocks);
+  });
+
+  test("leaves markers without a display number unchanged", () => {
+    const blocks: FlowBlock[] = [paragraphWithFootnoteRef("p1", 7, 10)];
+
+    const remapped = remapNoteMarkerText(blocks, { footnoteNumbers: new Map([[5, 1]]) });
+
+    expect(remapped.at(0)).toBe(blocks[0]);
+  });
+
+  test("recurses into table cells and text boxes", () => {
+    const table: TableBlock = {
+      kind: "table",
+      id: "t1",
+      rows: [
+        {
+          id: "r1",
+          cells: [{ id: "c1", blocks: [paragraphWithFootnoteRef("cell-p", 5, 100)] }],
+        },
+      ],
+    };
+    const textBox: TextBoxBlock = {
+      kind: "textBox",
+      id: "tb1",
+      width: 200,
+      content: [paragraphWithFootnoteRef("tb-p", 9, 200)],
+    };
+    const footnoteNumbers = new Map([
+      [5, 1],
+      [9, 2],
+    ]);
+
+    const remapped = remapNoteMarkerText([table, textBox], { footnoteNumbers });
+
+    const remappedTable = remapped.at(0);
+    if (remappedTable?.kind !== "table") {
+      throw new Error("Expected a table block");
+    }
+    const cellParagraph = remappedTable.rows.at(0)?.cells.at(0)?.blocks.at(0);
+    if (cellParagraph?.kind !== "paragraph") {
+      throw new Error("Expected a paragraph in the table cell");
+    }
+    expect(cellParagraph.runs.at(0)).toMatchObject({ text: "1", footnoteRefId: 5 });
+
+    const remappedBox = remapped.at(1);
+    if (remappedBox?.kind !== "textBox") {
+      throw new Error("Expected a text box block");
+    }
+    expect(remappedBox.content.at(0)?.runs.at(0)).toMatchObject({ text: "2", footnoteRefId: 9 });
+  });
+
+  test("remaps endnote markers independently of footnote markers", () => {
+    const blocks: FlowBlock[] = [
+      paragraphWithFootnoteRef("fn", 5, 10),
+      {
+        kind: "paragraph",
+        id: "en",
+        runs: [{ kind: "text", text: "8", endnoteRefId: 8, pmStart: 20, pmEnd: 21 }],
+      },
+    ];
+
+    const remapped = remapNoteMarkerText(blocks, {
+      footnoteNumbers: new Map([[5, 1]]),
+      endnoteNumbers: new Map([[8, 1]]),
+    });
+
+    const footnoteParagraph = remapped.at(0);
+    const endnoteParagraph = remapped.at(1);
+    if (footnoteParagraph?.kind !== "paragraph" || endnoteParagraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph blocks");
+    }
+    expect(footnoteParagraph.runs.at(0)).toMatchObject({ text: "1", footnoteRefId: 5 });
+    expect(endnoteParagraph.runs.at(0)).toMatchObject({ text: "1", endnoteRefId: 8 });
+  });
+});
+
+describe("buildFootnoteContentMap", () => {
+  const measureBlocks = (blocks: FlowBlock[]) =>
+    blocks.map(() => ({ kind: "paragraph" as const, lines: [], totalHeight: 12 }));
+
+  test("assigns area display numbers by reference order, not id order", () => {
+    const footnotes = [
+      continuationNotice(1),
+      normalFootnote(2, "two"),
+      normalFootnote(5, "five"),
+      normalFootnote(9, "nine"),
+    ];
+    const refs = [{ footnoteId: 5 }, { footnoteId: 2 }, { footnoteId: 9 }];
+
+    const contentMap = buildFootnoteContentMap(footnotes, refs, 400, { measureBlocks });
+
+    expect(contentMap.get(5)?.displayNumber).toBe(1);
+    expect(contentMap.get(2)?.displayNumber).toBe(2);
+    expect(contentMap.get(9)?.displayNumber).toBe(3);
+    expect(contentMap.has(1)).toBe(false);
+
+    const firstBlock = contentMap.get(5)?.blocks.at(0);
+    if (firstBlock?.kind !== "paragraph") {
+      throw new Error("Expected the footnote content to start with a paragraph");
+    }
+    expect(firstBlock.runs.at(0)).toMatchObject({ kind: "text", text: "1 " });
+  });
+});

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -62,17 +62,39 @@ export type ConvertFootnoteOptions = {
  * area.
  */
 export function collectFootnoteRefs(blocks: FlowBlock[]): { footnoteId: number; pmPos: number }[] {
-  const refs: { footnoteId: number; pmPos: number }[] = [];
+  return collectNoteRefs(blocks, "footnoteRefId").map(({ noteId, pmPos }) => ({
+    footnoteId: noteId,
+    pmPos,
+  }));
+}
+
+/**
+ * Scan FlowBlocks for runs with endnoteRefId set, in document order.
+ * Same recursive walk as `collectFootnoteRefs`.
+ */
+export function collectEndnoteRefs(blocks: FlowBlock[]): { endnoteId: number; pmPos: number }[] {
+  return collectNoteRefs(blocks, "endnoteRefId").map(({ noteId, pmPos }) => ({
+    endnoteId: noteId,
+    pmPos,
+  }));
+}
+
+function collectNoteRefs(
+  blocks: FlowBlock[],
+  idKey: "footnoteRefId" | "endnoteRefId",
+): { noteId: number; pmPos: number }[] {
+  const refs: { noteId: number; pmPos: number }[] = [];
 
   const walk = (containerBlocks: FlowBlock[]): void => {
     for (const block of containerBlocks) {
       if (block.kind === "paragraph") {
         for (const run of block.runs) {
-          if (run.kind === "text" && run.footnoteRefId !== undefined) {
-            refs.push({
-              footnoteId: run.footnoteRefId,
-              pmPos: run.pmStart ?? 0,
-            });
+          if (run.kind !== "text") {
+            continue;
+          }
+          const noteId = run[idKey];
+          if (noteId !== undefined) {
+            refs.push({ noteId, pmPos: run.pmStart ?? 0 });
           }
         }
       } else if (block.kind === "table") {
@@ -89,6 +111,147 @@ export function collectFootnoteRefs(blocks: FlowBlock[]): { footnoteId: number; 
 
   walk(blocks);
   return refs;
+}
+
+// ============================================================================
+// 1.5 Sequential display numbers + body marker remap
+// ============================================================================
+
+type NumberableNote = {
+  id: number;
+  noteType?: Footnote["noteType"];
+};
+
+/**
+ * Assign sequential display numbers (1, 2, 3, …) to notes in order of first
+ * reference. Word numbers footnotes/endnotes by reference order, not by their
+ * `w:id` values, which may be non-contiguous or out of document order. Only
+ * `normal` notes are numbered; separator/continuation notes and refs to
+ * missing notes consume no number.
+ */
+export function computeNoteDisplayNumbers(
+  notes: readonly NumberableNote[],
+  refNoteIds: readonly number[],
+): Map<number, number> {
+  const numberable = new Set<number>();
+  for (const note of notes) {
+    if (note.noteType === "normal") {
+      numberable.add(note.id);
+    }
+  }
+
+  const displayNumbers = new Map<number, number>();
+  let nextNumber = 1;
+  for (const noteId of refNoteIds) {
+    if (displayNumbers.has(noteId) || !numberable.has(noteId)) {
+      continue;
+    }
+    displayNumbers.set(noteId, nextNumber);
+    nextNumber++;
+  }
+  return displayNumbers;
+}
+
+export type NoteDisplayNumberMaps = {
+  /** footnote `w:id` → sequential display number */
+  footnoteNumbers?: ReadonlyMap<number, number>;
+  /** endnote `w:id` → sequential display number */
+  endnoteNumbers?: ReadonlyMap<number, number>;
+};
+
+/**
+ * Rewrite body reference-marker run text from the raw `w:id` (which the PM
+ * doc stores as the marker text; the save path serializes from the mark
+ * attrs, never from this text) to the sequential display number, so the
+ * inline marker matches the number rendered in the note area. Must run
+ * before measurement so marker widths match the painted digits. Untouched
+ * blocks/runs are returned by reference so the painter's fingerprinting and
+ * the incremental measure path see them unchanged. Runs keep their PM range,
+ * so click-to-position still resolves into the marker (same contract as the
+ * template preview substitution).
+ */
+export function remapNoteMarkerText(blocks: FlowBlock[], maps: NoteDisplayNumberMaps): FlowBlock[] {
+  if ((maps.footnoteNumbers?.size ?? 0) === 0 && (maps.endnoteNumbers?.size ?? 0) === 0) {
+    return blocks;
+  }
+
+  let changed = false;
+  const next = blocks.map((block) => {
+    const remapped = remapNoteMarkerBlock(block, maps);
+    changed ||= remapped !== block;
+    return remapped;
+  });
+  return changed ? next : blocks;
+}
+
+function remapNoteMarkerBlock(block: FlowBlock, maps: NoteDisplayNumberMaps): FlowBlock {
+  if (block.kind === "paragraph") {
+    return remapNoteMarkerParagraph(block, maps);
+  }
+  if (block.kind === "table") {
+    let tableChanged = false;
+    const rows = block.rows.map((row) => {
+      let rowChanged = false;
+      const cells = row.cells.map((cell) => {
+        let cellChanged = false;
+        const cellBlocks = cell.blocks.map((cellBlock) => {
+          const remapped = remapNoteMarkerBlock(cellBlock, maps);
+          cellChanged ||= remapped !== cellBlock;
+          return remapped;
+        });
+        return cellChanged ? { ...cell, blocks: cellBlocks } : cell;
+      });
+      rowChanged = cells.some((cell, index) => cell !== row.cells[index]);
+      tableChanged ||= rowChanged;
+      return rowChanged ? { ...row, cells } : row;
+    });
+    return tableChanged ? { ...block, rows } : block;
+  }
+  if (block.kind === "textBox") {
+    let boxChanged = false;
+    const content = block.content.map((paragraph) => {
+      const remapped = remapNoteMarkerParagraph(paragraph, maps);
+      boxChanged ||= remapped !== paragraph;
+      return remapped;
+    });
+    return boxChanged ? { ...block, content } : block;
+  }
+  return block;
+}
+
+function remapNoteMarkerParagraph(
+  block: ParagraphBlock,
+  maps: NoteDisplayNumberMaps,
+): ParagraphBlock {
+  let changed = false;
+  const runs = block.runs.map((run) => {
+    const remapped = remapNoteMarkerRun(run, maps);
+    changed ||= remapped !== run;
+    return remapped;
+  });
+  return changed ? { ...block, runs } : block;
+}
+
+function remapNoteMarkerRun(run: Run, maps: NoteDisplayNumberMaps): Run {
+  if (run.kind !== "text") {
+    return run;
+  }
+  const displayNumber = getRunDisplayNumber(run, maps);
+  if (displayNumber === undefined) {
+    return run;
+  }
+  const text = String(displayNumber);
+  return run.text === text ? run : { ...run, text };
+}
+
+function getRunDisplayNumber(run: TextRun, maps: NoteDisplayNumberMaps): number | undefined {
+  if (run.footnoteRefId !== undefined) {
+    return maps.footnoteNumbers?.get(run.footnoteRefId);
+  }
+  if (run.endnoteRefId !== undefined) {
+    return maps.endnoteNumbers?.get(run.endnoteRefId);
+  }
+  return undefined;
 }
 
 // ============================================================================
@@ -515,24 +678,22 @@ export function buildFootnoteContentMap(
     }
   }
 
-  // Assign display numbers in order of first appearance
-  let displayNumber = 1;
-  const seen = new Set<number>();
+  // Display numbers follow first-appearance order — the same map that
+  // drives the body marker remap, so area and marker can never disagree.
+  const displayNumbers = computeNoteDisplayNumbers(
+    footnotes,
+    footnoteRefs.map((ref) => ref.footnoteId),
+  );
 
-  for (const ref of footnoteRefs) {
-    if (seen.has(ref.footnoteId)) {
-      continue;
-    }
-    seen.add(ref.footnoteId);
-
-    const footnote = footnoteById.get(ref.footnoteId);
+  for (const [footnoteId, displayNumber] of displayNumbers) {
+    const footnote = footnoteById.get(footnoteId);
     if (!footnote) {
       continue;
     }
-
-    const content = convertFootnoteToContent(footnote, displayNumber, contentWidth, options);
-    contentMap.set(ref.footnoteId, content);
-    displayNumber++;
+    contentMap.set(
+      footnoteId,
+      convertFootnoteToContent(footnote, displayNumber, contentWidth, options),
+    );
   }
 
   return contentMap;

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -12,6 +12,7 @@ import {
   findNextChange,
   findPreviousChange,
   rejectAIEditRevision,
+  rejectChange,
 } from "./comments";
 
 const schema = new Schema({
@@ -22,7 +23,9 @@ const schema = new Schema({
       group: "block",
       attrs: {
         numPr: { default: null },
+        alignment: { default: null },
         _propertyChanges: { default: null },
+        _sectionProperties: { default: null },
         pPrMark: { default: null },
       },
     },
@@ -243,6 +246,47 @@ describe("findChangeAtPosition", () => {
     expect(acceptChange(range.from, range.to)(view.state, view.dispatch)).toBe(true);
 
     expect(view.state.doc.child(0).attrs["_propertyChanges"]).toBeNull();
+  });
+
+  test("rejecting a pPrChange restores only in-scope properties and preserves out-of-scope attrs", () => {
+    // Word stores a pPrChange's old properties as CT_PPrBase, which cannot
+    // carry an inline sectPr (or its header/footer references). Rejecting a
+    // paragraph-property change must therefore MERGE the stored old
+    // properties over the live attrs, not replace the pPr wholesale — a
+    // wholesale replace would drop the separately-modeled inline section
+    // break. Regression guard for the OOXML corner case.
+    const sectionProperties = {
+      type: "nextPage",
+      headerReferences: [{ type: "default", relationshipId: "rId7" }],
+    };
+    const initial = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            alignment: "left",
+            _sectionProperties: sectionProperties,
+            _propertyChanges: [
+              {
+                type: "paragraphPropertyChange",
+                info: { id: 10, author: "Alice", date: "2026-01-01" },
+                previousFormatting: { alignment: "center" },
+              },
+            ],
+          },
+          [schema.text("alpha")],
+        ),
+      ]),
+    });
+    const view = dispatcher(initial);
+
+    expect(rejectChange(0, initial.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    expect(attrs["alignment"]).toBe("center");
+    expect(attrs["_propertyChanges"]).toBeNull();
+    expect(attrs["_sectionProperties"]).toEqual(sectionProperties);
   });
 });
 

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Redline-generator tests, built around the two invariants that define a
+ * correct redline document:
+ *
+ * 1. **Accept-all equals revised.** The redline's as-accepted view (what a
+ *    reviewer sees after accepting every tracked change) must reproduce the
+ *    revised document's block texts.
+ * 2. **Reject-all equals base.** Rejecting every tracked change must restore
+ *    the base document's block texts.
+ *
+ * Buffers are built from the typed `Document` model like the comparer tests,
+ * and the generated redline is inspected through a fresh `FolioDocxReviewer`
+ * (whose snapshot IS the as-accepted view).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { FolioDocxReviewer } from "./ai-edits/headless";
+import { createDocx } from "./docx/rezip";
+import { generateRedlineDocx } from "./redline";
+import { createEmptyDocument } from "./utils/createDocument";
+
+type ParagraphSpec = { text: string; paraId?: string };
+
+const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuffer> => {
+  const template = createEmptyDocument();
+  return createDocx({
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: paragraphs.map(({ text, paraId }) => ({
+          type: "paragraph",
+          content: [{ type: "run", content: [{ type: "text", text }] }],
+          ...(paraId !== undefined && { paraId }),
+        })),
+      },
+    },
+  });
+};
+
+const blockTexts = (reviewer: FolioDocxReviewer): string[] =>
+  reviewer.snapshot().blocks.map((block) => block.text);
+
+describe("generateRedlineDocx", () => {
+  test("accept-all reproduces the revised document; reject-all restores the base", async () => {
+    const base = await buildDocxBuffer([
+      { text: "Alpha paragraph stays untouched.", paraId: "00000001" },
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+      { text: "This clause is removed entirely.", paraId: "00000003" },
+      { text: "Omega paragraph closes the document.", paraId: "00000004" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Alpha paragraph stays untouched.", paraId: "00000001" },
+      { text: "First inserted clause about notices.", paraId: "00000005" },
+      { text: "Second inserted clause about liability.", paraId: "00000006" },
+      { text: "Payment is due within sixty days.", paraId: "00000002" },
+      { text: "Omega paragraph closes the document.", paraId: "00000004" },
+      { text: "Trailing signature paragraph.", paraId: "00000007" },
+    ]);
+    const revisedTexts = [
+      "Alpha paragraph stays untouched.",
+      "First inserted clause about notices.",
+      "Second inserted clause about liability.",
+      "Payment is due within sixty days.",
+      "Omega paragraph closes the document.",
+      "Trailing signature paragraph.",
+    ];
+    const baseTexts = [
+      "Alpha paragraph stays untouched.",
+      "Payment is due within thirty days.",
+      "This clause is removed entirely.",
+      "Omega paragraph closes the document.",
+    ];
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.skipped).toEqual([]);
+    expect(result.applied.length).toBeGreaterThan(0);
+
+    // The redline carries real tracked changes attributed to the default author.
+    const acceptView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    const changes = acceptView.getChanges();
+    expect(changes.length).toBeGreaterThan(0);
+    expect(new Set(changes.map((change) => change.author))).toEqual(new Set(["folio compare"]));
+
+    // Invariant 1: the as-accepted view (snapshot) equals the revised document.
+    expect(blockTexts(acceptView)).toEqual(revisedTexts);
+
+    // Invariant 2: rejecting every change restores the base document.
+    const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    rejectView.rejectAll();
+    expect(blockTexts(rejectView)).toEqual(baseTexts);
+  });
+
+  test("a relocated block redlines as delete + insert and still satisfies both invariants", async () => {
+    const base = await buildDocxBuffer([
+      { text: "Governing law shall be Czech law.", paraId: "00000001" },
+      { text: "Notices must be delivered in writing.", paraId: "00000002" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Notices must be delivered in writing.", paraId: "00000002" },
+      { text: "Governing law shall be Czech law.", paraId: "00000001" },
+    ]);
+
+    const result = await generateRedlineDocx(base, revised);
+    expect(result.skipped).toEqual([]);
+
+    const acceptView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    expect(blockTexts(acceptView)).toEqual([
+      "Notices must be delivered in writing.",
+      "Governing law shall be Czech law.",
+    ]);
+
+    const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    rejectView.rejectAll();
+    expect(blockTexts(rejectView)).toEqual([
+      "Governing law shall be Czech law.",
+      "Notices must be delivered in writing.",
+    ]);
+  });
+
+  test("identical documents produce a redline with no tracked changes", async () => {
+    const paragraphs: ParagraphSpec[] = [
+      { text: "Alpha paragraph.", paraId: "00000001" },
+      { text: "Beta paragraph.", paraId: "00000002" },
+    ];
+    const base = await buildDocxBuffer(paragraphs);
+    const revised = await buildDocxBuffer(paragraphs);
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.applied).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    const view = await FolioDocxReviewer.fromBuffer(result.buffer);
+    expect(view.getChanges()).toEqual([]);
+    expect(blockTexts(view)).toEqual(["Alpha paragraph.", "Beta paragraph."]);
+  });
+
+  test("an empty base document reports unanchorable additions as skipped", async () => {
+    const base = await buildDocxBuffer([]);
+    const revised = await buildDocxBuffer([{ text: "Only paragraph.", paraId: "00000001" }]);
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.applied).toEqual([]);
+    expect(result.skipped.map((op) => op.reason)).toEqual(["missingBlock"]);
+  });
+
+  test("a custom author is recorded on the generated changes", async () => {
+    const base = await buildDocxBuffer([{ text: "Payment is due.", paraId: "00000001" }]);
+    const revised = await buildDocxBuffer([
+      { text: "Payment is due promptly.", paraId: "00000001" },
+    ]);
+
+    const result = await generateRedlineDocx(base, revised, { author: "Jan Kubica" });
+
+    const view = await FolioDocxReviewer.fromBuffer(result.buffer);
+    const authors = new Set(view.getChanges().map((change) => change.author));
+    expect(authors).toEqual(new Set(["Jan Kubica"]));
+  });
+});

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -1,0 +1,161 @@
+/**
+ * Redline generator: compare two `.docx` buffers and produce a THIRD `.docx`
+ * whose differences are recorded as real Word tracked changes (`w:ins` /
+ * `w:del`), ready for review in Word or the folio editor — the
+ * document-producing counterpart to {@link compareDocxVersions}'s structured
+ * diff.
+ *
+ * The pipeline is a composition of existing machinery, not a new engine:
+ * the base buffer is opened in a headless {@link FolioDocxReviewer}, the two
+ * snapshots are aligned with {@link alignFolioBlocks} (the same three-pass
+ * alignment the comparer uses), each alignment event maps onto a
+ * tracked-changes {@link FolioAIEditOperation}, and the reviewer's shared
+ * apply path records them as redlines. Word-level minimality comes free:
+ * the apply engine word-diffs a `replaceBlock` and only marks the divergent
+ * tokens.
+ *
+ * ## Semantics and limitations
+ *
+ * - **As-accepted inputs.** Pending tracked changes in either input count as
+ *   applied before comparison (mirroring {@link compareDocxVersions}): the
+ *   base's own pending redlines are accepted in the output, so the tracked
+ *   changes it carries are exactly base → revised. This is intentionally
+ *   lossy about the inputs' own revision history and authorship.
+ * - **Text redlines only.** Format-only changes and relocated blocks are
+ *   redlined as plain edits (a move becomes a delete + insert, like Word
+ *   compare with move detection off); block-level formatting is carried via
+ *   the revised block's `styleId` on inserted blocks.
+ * - **Anchoring.** Insertions anchor `before` the next surviving base block
+ *   so consecutive additions keep their order; additions past the last base
+ *   block anchor `after` it. A base document with no content blocks offers
+ *   no anchor at all — such additions surface in `skipped` rather than
+ *   silently vanishing.
+ */
+
+import { FolioDocxReviewer } from "./ai-edits/headless";
+import type { FolioAIEditApplyResult, FolioAIEditOperation } from "./ai-edits/types";
+import { alignFolioBlocks, type FolioAlignedBlockEvent } from "./version-comparison";
+
+/** Options for {@link generateRedlineDocx}. */
+export type GenerateRedlineDocxOptions = {
+  /** Author recorded on the generated tracked changes. (default: `"folio compare"`) */
+  author?: string;
+};
+
+/** Result of {@link generateRedlineDocx}. */
+export type GenerateRedlineDocxResult = FolioAIEditApplyResult & {
+  /** The redline `.docx`: the base document with base → revised tracked changes. */
+  buffer: ArrayBuffer;
+};
+
+/**
+ * The base block id the next `revisedOnly` event at `startIndex` should
+ * anchor before: the base side of the nearest later `pair` or `baseOnly`
+ * event, or `null` when only additions remain until the end of the document.
+ */
+const nextBaseBlockId = (
+  events: readonly FolioAlignedBlockEvent[],
+  startIndex: number,
+): string | null => {
+  for (let i = startIndex; i < events.length; i++) {
+    const event = events[i];
+    if (!event) {
+      continue;
+    }
+    if (event.type === "pair") {
+      return event.baseBlock.id;
+    }
+    if (event.type === "baseOnly") {
+      return event.block.id;
+    }
+  }
+  return null;
+};
+
+/**
+ * Compare `base` and `revised` and return the base document with every
+ * difference recorded as a tracked change. See the module doc comment for
+ * semantics and limitations; `skipped` reports any block the generator could
+ * not redline (e.g. additions with no anchor in an empty base document).
+ */
+export const generateRedlineDocx = async (
+  base: ArrayBuffer,
+  revised: ArrayBuffer,
+  options: GenerateRedlineDocxOptions = {},
+): Promise<GenerateRedlineDocxResult> => {
+  const [baseReviewer, revisedReviewer] = await Promise.all([
+    FolioDocxReviewer.fromBuffer(base, { author: options.author ?? "folio compare" }),
+    FolioDocxReviewer.fromBuffer(revised),
+  ]);
+  // As-accepted semantics: resolve the base's own pending redlines first so
+  // the output's tracked changes describe exactly base -> revised.
+  baseReviewer.acceptAll();
+  const baseSnapshot = baseReviewer.snapshot();
+  const revisedBlocks = revisedReviewer.snapshot().blocks;
+
+  const events = alignFolioBlocks(baseSnapshot.blocks, revisedBlocks);
+
+  const operations: FolioAIEditOperation[] = [];
+  let operationSeq = 0;
+  const nextOperationId = () => `redline-${++operationSeq}`;
+  /** Additions past the last base block, inserted after it in reverse so the final order matches the revised document. */
+  const trailingAdditions: { text: string; styleId?: string }[] = [];
+  const lastBaseBlockId = baseSnapshot.blocks.at(-1)?.id ?? null;
+
+  events.forEach((event, eventIndex) => {
+    if (event.type === "pair") {
+      if (event.baseBlock.text !== event.revisedBlock.text) {
+        operations.push({
+          id: nextOperationId(),
+          type: "replaceBlock",
+          blockId: event.baseBlock.id,
+          text: event.revisedBlock.text,
+        });
+      }
+      return;
+    }
+    if (event.type === "baseOnly") {
+      operations.push({
+        id: nextOperationId(),
+        type: "deleteBlock",
+        blockId: event.block.id,
+      });
+      return;
+    }
+    const anchorId = nextBaseBlockId(events, eventIndex + 1);
+    if (anchorId === null) {
+      trailingAdditions.push({
+        text: event.block.text,
+        ...(event.block.styleId !== undefined && { styleId: event.block.styleId }),
+      });
+      return;
+    }
+    operations.push({
+      id: nextOperationId(),
+      type: "insertBeforeBlock",
+      blockId: anchorId,
+      text: event.block.text,
+      ...(event.block.styleId !== undefined && { styleId: event.block.styleId }),
+    });
+  });
+
+  for (const addition of trailingAdditions.toReversed()) {
+    operations.push({
+      id: nextOperationId(),
+      type: "insertAfterBlock",
+      // An empty base document has no anchor block at all; an unresolvable
+      // id makes the shared applier report the addition in `skipped`
+      // (missingBlock) instead of dropping it silently.
+      blockId: lastBaseBlockId ?? "redline-unanchored",
+      text: addition.text,
+      ...(addition.styleId !== undefined && { styleId: addition.styleId }),
+    });
+  }
+
+  const { applied, skipped } = baseReviewer.applyOperations(operations, {
+    mode: "tracked-changes",
+    snapshot: baseSnapshot,
+  });
+  const buffer = await baseReviewer.toBuffer();
+  return { buffer, applied, skipped };
+};

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -49,27 +49,26 @@ export type GenerateRedlineDocxResult = FolioAIEditApplyResult & {
 };
 
 /**
- * The base block id the next `revisedOnly` event at `startIndex` should
- * anchor before: the base side of the nearest later `pair` or `baseOnly`
- * event, or `null` when only additions remain until the end of the document.
+ * For each event index, the base block id the next `revisedOnly` event
+ * should anchor before: the base side of the nearest later `pair` or
+ * `baseOnly` event, or `null` when only additions remain until the end of
+ * the document. One backward pass, so a long run of trailing additions
+ * (huge revised document vs. a small base) stays linear instead of
+ * re-scanning the tail per added block.
  */
-const nextBaseBlockId = (
-  events: readonly FolioAlignedBlockEvent[],
-  startIndex: number,
-): string | null => {
-  for (let i = startIndex; i < events.length; i++) {
+const nextBaseBlockIdByIndex = (events: readonly FolioAlignedBlockEvent[]): (string | null)[] => {
+  const nextIds = Array.from<string | null>({ length: events.length });
+  let nextId: string | null = null;
+  for (let i = events.length - 1; i >= 0; i--) {
+    nextIds[i] = nextId;
     const event = events[i];
-    if (!event) {
-      continue;
-    }
-    if (event.type === "pair") {
-      return event.baseBlock.id;
-    }
-    if (event.type === "baseOnly") {
-      return event.block.id;
+    if (event?.type === "pair") {
+      nextId = event.baseBlock.id;
+    } else if (event?.type === "baseOnly") {
+      nextId = event.block.id;
     }
   }
-  return null;
+  return nextIds;
 };
 
 /**
@@ -94,6 +93,7 @@ export const generateRedlineDocx = async (
   const revisedBlocks = revisedReviewer.snapshot().blocks;
 
   const events = alignFolioBlocks(baseSnapshot.blocks, revisedBlocks);
+  const anchorIds = nextBaseBlockIdByIndex(events);
 
   const operations: FolioAIEditOperation[] = [];
   let operationSeq = 0;
@@ -122,7 +122,7 @@ export const generateRedlineDocx = async (
       });
       return;
     }
-    const anchorId = nextBaseBlockId(events, eventIndex + 1);
+    const anchorId = anchorIds[eventIndex] ?? null;
     if (anchorId === null) {
       trailingAdditions.push({
         text: event.block.text,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -51,9 +51,15 @@ export {
 export {
   compareDocxVersions,
   type FolioBlockDiff,
+  type FolioFormatProperty,
   type FolioVersionDiff,
   type FolioVersionDiffSegment,
 } from "./version-comparison";
+export {
+  generateRedlineDocx,
+  type GenerateRedlineDocxOptions,
+  type GenerateRedlineDocxResult,
+} from "./redline";
 export type {
   FolioAIComment,
   FolioAIEditApplyMode,

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -73,7 +73,14 @@ describe("compareDocxVersions: real w14:paraId alignment", () => {
 
     const diff = await compareDocxVersions(base, revised);
 
-    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 1, modified: 1, formatChanged: 0, moved: 0, unchanged: 2 });
+    expect(diff.summaryCounts).toEqual({
+      added: 1,
+      deleted: 1,
+      modified: 1,
+      formatChanged: 0,
+      moved: 0,
+      unchanged: 2,
+    });
     // Unchanged blocks (Alpha, Zeta) never appear in `changes`.
     expect(diff.changes).toHaveLength(3);
     expect(diff.changes.map((c) => c.type)).toEqual(["modified", "deleted", "added"]);
@@ -132,7 +139,14 @@ describe("compareDocxVersions: deterministic fallback ids (no w14:paraId)", () =
 
     // Alpha (unshifted, same fallback id both sides) and Gamma (shifted,
     // recovered via text-LCS) are both unchanged and absent from `changes`.
-    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 0, modified: 1, formatChanged: 0, moved: 0, unchanged: 2 });
+    expect(diff.summaryCounts).toEqual({
+      added: 1,
+      deleted: 0,
+      modified: 1,
+      formatChanged: 0,
+      moved: 0,
+      unchanged: 2,
+    });
     expect(diff.changes.map((c) => c.type)).toEqual(["modified", "added"]);
 
     const modified = diff.changes[0];
@@ -165,7 +179,14 @@ describe("compareDocxVersions: no-op", () => {
     const diff = await compareDocxVersions(base, revised);
 
     expect(diff.changes).toEqual([]);
-    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 0, formatChanged: 0, moved: 0, unchanged: 2 });
+    expect(diff.summaryCounts).toEqual({
+      added: 0,
+      deleted: 0,
+      modified: 0,
+      formatChanged: 0,
+      moved: 0,
+      unchanged: 2,
+    });
   });
 });
 
@@ -314,7 +335,14 @@ describe("compareDocxVersions: as-accepted semantics", () => {
 
     const diff = await compareDocxVersions(base, revised);
 
-    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 1, formatChanged: 0, moved: 0, unchanged: 0 });
+    expect(diff.summaryCounts).toEqual({
+      added: 0,
+      deleted: 0,
+      modified: 1,
+      formatChanged: 0,
+      moved: 0,
+      unchanged: 0,
+    });
     const [change] = diff.changes;
     if (!change || change.type !== "modified") {
       throw new Error("expected a single modified change");

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -18,7 +18,11 @@ import { createEmptyDocument } from "./utils/createDocument";
 import { compareDocxVersions, exceedsLcsBudget } from "./version-comparison";
 import type { FolioBlockDiff } from "./version-comparison";
 
-type ParagraphSpec = { text: string; paraId?: string };
+type ParagraphSpec = {
+  text: string;
+  paraId?: string;
+  formatting?: { bold?: boolean; italic?: boolean };
+};
 
 const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuffer> => {
   const template = createEmptyDocument();
@@ -28,9 +32,15 @@ const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuf
       ...template.package,
       document: {
         ...template.package.document,
-        content: paragraphs.map(({ text, paraId }) => ({
+        content: paragraphs.map(({ text, paraId, formatting }) => ({
           type: "paragraph",
-          content: [{ type: "run", content: [{ type: "text", text }] }],
+          content: [
+            {
+              type: "run",
+              ...(formatting !== undefined && { formatting }),
+              content: [{ type: "text", text }],
+            },
+          ],
           ...(paraId !== undefined && { paraId }),
         })),
       },
@@ -63,7 +73,7 @@ describe("compareDocxVersions: real w14:paraId alignment", () => {
 
     const diff = await compareDocxVersions(base, revised);
 
-    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 1, modified: 1, unchanged: 2 });
+    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 1, modified: 1, formatChanged: 0, moved: 0, unchanged: 2 });
     // Unchanged blocks (Alpha, Zeta) never appear in `changes`.
     expect(diff.changes).toHaveLength(3);
     expect(diff.changes.map((c) => c.type)).toEqual(["modified", "deleted", "added"]);
@@ -122,7 +132,7 @@ describe("compareDocxVersions: deterministic fallback ids (no w14:paraId)", () =
 
     // Alpha (unshifted, same fallback id both sides) and Gamma (shifted,
     // recovered via text-LCS) are both unchanged and absent from `changes`.
-    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 0, modified: 1, unchanged: 2 });
+    expect(diff.summaryCounts).toEqual({ added: 1, deleted: 0, modified: 1, formatChanged: 0, moved: 0, unchanged: 2 });
     expect(diff.changes.map((c) => c.type)).toEqual(["modified", "added"]);
 
     const modified = diff.changes[0];
@@ -155,7 +165,112 @@ describe("compareDocxVersions: no-op", () => {
     const diff = await compareDocxVersions(base, revised);
 
     expect(diff.changes).toEqual([]);
-    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 0, unchanged: 2 });
+    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 0, formatChanged: 0, moved: 0, unchanged: 2 });
+  });
+});
+
+describe("compareDocxVersions: move detection", () => {
+  test("a relocated block re-classifies as movedFrom/movedTo sharing a moveGroupId", async () => {
+    const base = await buildDocxBuffer([
+      { text: "Governing law shall be Czech law.", paraId: "00000001" },
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+      { text: "Notices must be delivered in writing.", paraId: "00000003" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Notices must be delivered in writing.", paraId: "00000003" },
+      { text: "Governing law shall be Czech law.", paraId: "00000001" },
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+    ]);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({
+      added: 0,
+      deleted: 0,
+      modified: 0,
+      formatChanged: 0,
+      moved: 1,
+      unchanged: 2,
+    });
+    const movedTo = diff.changes.find((c) => c.type === "movedTo");
+    const movedFrom = diff.changes.find((c) => c.type === "movedFrom");
+    if (!movedTo || movedTo.type !== "movedTo" || !movedFrom || movedFrom.type !== "movedFrom") {
+      throw new Error("expected a movedTo + movedFrom pair");
+    }
+    expect(movedTo.moveGroupId).toBe(movedFrom.moveGroupId);
+    expect(movedTo.text).toBe("Notices must be delivered in writing.");
+    expect(movedFrom.text).toBe("Notices must be delivered in writing.");
+    expect(movedTo.blockId).toBe("00000003");
+    expect(movedFrom.blockId).toBe("00000003");
+  });
+
+  test("identical short boilerplate below the word floor stays added + deleted", async () => {
+    // "Confidential" is one word — under the move word-count floor — so the
+    // deleted instance and the (differently-identified) added instance must
+    // NOT pair as a move. Two long stable anchors around it keep the
+    // alignment from treating anything else as relocated.
+    const base = await buildDocxBuffer([
+      { text: "Confidential", paraId: "00000001" },
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+      { text: "Notices must be delivered in writing.", paraId: "00000003" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+      { text: "Notices must be delivered in writing.", paraId: "00000003" },
+      { text: "Confidential", paraId: "00000009" },
+    ]);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({
+      added: 1,
+      deleted: 1,
+      modified: 0,
+      formatChanged: 0,
+      moved: 0,
+      unchanged: 2,
+    });
+    expect(diff.changes.map((c) => c.type).toSorted()).toEqual(["added", "deleted"]);
+  });
+});
+
+describe("compareDocxVersions: format-only changes", () => {
+  test("equal text with different run formatting reports formatChanged with the changed properties", async () => {
+    const base = await buildDocxBuffer([{ text: "Payment is due.", paraId: "00000001" }]);
+    const revised = await buildDocxBuffer([
+      { text: "Payment is due.", paraId: "00000001", formatting: { bold: true, italic: true } },
+    ]);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({
+      added: 0,
+      deleted: 0,
+      modified: 0,
+      formatChanged: 1,
+      moved: 0,
+      unchanged: 0,
+    });
+    const [change] = diff.changes;
+    if (!change || change.type !== "formatChanged") {
+      throw new Error("expected a formatChanged change");
+    }
+    expect(change.blockId).toBe("00000001");
+    expect(change.changedProperties).toEqual(["bold", "italic"]);
+    expect(change.text).toBe("Payment is due.");
+  });
+
+  test("identical formatting on both sides stays unchanged", async () => {
+    const paragraphs: ParagraphSpec[] = [
+      { text: "Payment is due.", paraId: "00000001", formatting: { bold: true } },
+    ];
+    const base = await buildDocxBuffer(paragraphs);
+    const revised = await buildDocxBuffer(paragraphs);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.changes).toEqual([]);
+    expect(diff.summaryCounts.unchanged).toBe(1);
   });
 });
 
@@ -199,7 +314,7 @@ describe("compareDocxVersions: as-accepted semantics", () => {
 
     const diff = await compareDocxVersions(base, revised);
 
-    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 1, unchanged: 0 });
+    expect(diff.summaryCounts).toEqual({ added: 0, deleted: 0, modified: 1, formatChanged: 0, moved: 0, unchanged: 0 });
     const [change] = diff.changes;
     if (!change || change.type !== "modified") {
       throw new Error("expected a single modified change");

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -414,10 +414,7 @@ const diffPreviewRunFormatting = (
         changed.add(property);
       }
     }
-    const step = Math.min(
-      baseRun.text.length - baseOffset,
-      revisedRun.text.length - revisedOffset,
-    );
+    const step = Math.min(baseRun.text.length - baseOffset, revisedRun.text.length - revisedOffset);
     baseOffset += step;
     revisedOffset += step;
     if (baseOffset >= baseRun.text.length) {

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -49,28 +49,80 @@
  * pathological crossing match (content reordered across versions) can't
  * produce an out-of-order gap — the alignment always walks both documents
  * forward.
+ *
+ * ## Move detection
+ *
+ * Relocated content would otherwise report as an unrelated `deleted` +
+ * `added` pair (both order-preserving passes drop crossing matches by
+ * design). A post-pass re-classifies such pairs: an `added` and a `deleted`
+ * block with identical text and at least {@link MOVE_MINIMUM_WORD_COUNT}
+ * words become `movedFrom` / `movedTo` entries sharing a `moveGroupId`. The
+ * word-count floor keeps boilerplate one-liners ("Confidential", empty
+ * headings) from pairing as spurious moves. Blocks a positional zip already
+ * mis-paired as `modified` are out of this pass's reach — a known limitation
+ * of the gap fallback, not of the move pass.
+ *
+ * ## Format-only changes
+ *
+ * A paired block whose text is byte-equal but whose run-level formatting
+ * (bold, italic, underline, strike, font family, font size, color) differs
+ * reports as `formatChanged` with the set of properties that differ, instead
+ * of silently counting as `unchanged`. Detection walks the two blocks'
+ * preview runs character-aligned; when a block carries non-text inline
+ * content that makes the preview texts disagree, detection backs off to
+ * `unchanged` rather than misattribute properties.
  */
 
 import { FolioDocxReviewer } from "./ai-edits/headless";
-import type { FolioAIBlock } from "./ai-edits/types";
+import type { FolioAIBlock, FolioAIBlockPreviewRun } from "./ai-edits/types";
 import { diffWordSegments, type WordDiffSegment } from "./ai-edits/word-diff";
 import { getFolioParaIdFromBlockId } from "./types/block-id";
 
 /** One word-level diff segment within a `modified` block. Mirrors {@link WordDiffSegment}. */
 export type FolioVersionDiffSegment = WordDiffSegment;
 
+/** Run-level formatting properties compared for `formatChanged` detection. */
+const FORMAT_PROPERTIES = [
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "fontFamily",
+  "fontSizePt",
+  "color",
+] as const;
+
+/** A run-level formatting property that can differ in a `formatChanged` block. */
+export type FolioFormatProperty = (typeof FORMAT_PROPERTIES)[number];
+
 /** One block-level change between two document versions, in revised-side document order. */
 export type FolioBlockDiff =
   | { type: "added"; blockId: string; kind: string; text: string }
   | { type: "deleted"; blockId: string; kind: string; text: string }
-  | { type: "modified"; blockId: string; kind: string; segments: FolioVersionDiffSegment[] };
+  | { type: "modified"; blockId: string; kind: string; segments: FolioVersionDiffSegment[] }
+  | {
+      type: "formatChanged";
+      blockId: string;
+      kind: string;
+      text: string;
+      changedProperties: FolioFormatProperty[];
+    }
+  | { type: "movedFrom"; blockId: string; kind: string; text: string; moveGroupId: number }
+  | { type: "movedTo"; blockId: string; kind: string; text: string; moveGroupId: number };
 
 /** Result of {@link compareDocxVersions}. */
 export type FolioVersionDiff = {
-  /** Every added, deleted, or modified block, in revised-side document order (deletions slotted where they sat). */
+  /** Every changed block, in revised-side document order (deletions and move sources slotted where they sat). */
   changes: FolioBlockDiff[];
-  /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. */
-  summaryCounts: { added: number; deleted: number; modified: number; unchanged: number };
+  /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
+  summaryCounts: {
+    added: number;
+    deleted: number;
+    modified: number;
+    formatChanged: number;
+    moved: number;
+    unchanged: number;
+  };
 };
 
 type BlockPair = { baseIndex: number; revisedIndex: number };
@@ -223,21 +275,26 @@ const pairByExactText = (
 };
 
 /**
- * Compare two `.docx` buffers and return a structured, block-level diff.
- * See the module doc comment for the as-accepted comparison semantics and
- * the three-pass alignment algorithm.
+ * One step of a completed alignment, in revised-side document order with
+ * base-only blocks slotted where they sat. `pair` events cover pass 1/2
+ * anchors and pass 3's positional zip alike; whether the pair is unchanged,
+ * modified, or format-changed is the consumer's call.
  */
-export const compareDocxVersions = async (
-  base: ArrayBuffer,
-  revised: ArrayBuffer,
-): Promise<FolioVersionDiff> => {
-  const [baseReviewer, revisedReviewer] = await Promise.all([
-    FolioDocxReviewer.fromBuffer(base),
-    FolioDocxReviewer.fromBuffer(revised),
-  ]);
-  const baseBlocks = baseReviewer.snapshot().blocks;
-  const revisedBlocks = revisedReviewer.snapshot().blocks;
+export type FolioAlignedBlockEvent =
+  | { type: "pair"; baseBlock: FolioAIBlock; revisedBlock: FolioAIBlock }
+  | { type: "baseOnly"; block: FolioAIBlock }
+  | { type: "revisedOnly"; block: FolioAIBlock };
 
+/**
+ * Run the three-pass alignment (see the module doc comment) over two block
+ * snapshots and flatten it into an ordered event stream. Shared by
+ * {@link compareDocxVersions} and the redline generator so both interpret
+ * one document walk instead of re-deriving it.
+ */
+export const alignFolioBlocks = (
+  baseBlocks: readonly FolioAIBlock[],
+  revisedBlocks: readonly FolioAIBlock[],
+): FolioAlignedBlockEvent[] => {
   const stableIdAnchors = pairByStableId(baseBlocks, revisedBlocks);
   const usedBaseIndexes = new Set(stableIdAnchors.map((anchor) => anchor.baseIndex));
   const usedRevisedIndexes = new Set(stableIdAnchors.map((anchor) => anchor.revisedIndex));
@@ -260,8 +317,7 @@ export const compareDocxVersions = async (
     [...stableIdAnchors, ...exactTextAnchors].toSorted((a, b) => a.baseIndex - b.baseIndex),
   );
 
-  const changes: FolioBlockDiff[] = [];
-  const counts = { added: 0, deleted: 0, modified: 0, unchanged: 0 };
+  const events: FolioAlignedBlockEvent[] = [];
 
   /** Pass 3: positionally zip the leftover blocks in one gap between anchors. */
   const emitGap = (
@@ -270,53 +326,25 @@ export const compareDocxVersions = async (
     revisedFrom: number,
     revisedTo: number,
   ): void => {
-    const baseSlice = baseBlocks.slice(baseFrom, baseTo);
-    const revisedSlice = revisedBlocks.slice(revisedFrom, revisedTo);
-    const pairedCount = Math.min(baseSlice.length, revisedSlice.length);
-
+    const pairedCount = Math.min(baseTo - baseFrom, revisedTo - revisedFrom);
     for (let k = 0; k < pairedCount; k++) {
-      const baseBlock = baseSlice[k];
-      const revisedBlock = revisedSlice[k];
-      if (!baseBlock || !revisedBlock) {
-        continue;
+      const baseBlock = baseBlocks[baseFrom + k];
+      const revisedBlock = revisedBlocks[revisedFrom + k];
+      if (baseBlock && revisedBlock) {
+        events.push({ type: "pair", baseBlock, revisedBlock });
       }
-      if (baseBlock.text === revisedBlock.text) {
-        counts.unchanged++;
-        continue;
-      }
-      counts.modified++;
-      changes.push({
-        type: "modified",
-        blockId: revisedBlock.id,
-        kind: revisedBlock.kind,
-        segments: diffWordSegments(baseBlock.text, revisedBlock.text),
-      });
     }
-    for (let k = pairedCount; k < baseSlice.length; k++) {
-      const baseBlock = baseSlice[k];
-      if (!baseBlock) {
-        continue;
+    for (let k = baseFrom + pairedCount; k < baseTo; k++) {
+      const block = baseBlocks[k];
+      if (block) {
+        events.push({ type: "baseOnly", block });
       }
-      counts.deleted++;
-      changes.push({
-        type: "deleted",
-        blockId: baseBlock.id,
-        kind: baseBlock.kind,
-        text: baseBlock.text,
-      });
     }
-    for (let k = pairedCount; k < revisedSlice.length; k++) {
-      const revisedBlock = revisedSlice[k];
-      if (!revisedBlock) {
-        continue;
+    for (let k = revisedFrom + pairedCount; k < revisedTo; k++) {
+      const block = revisedBlocks[k];
+      if (block) {
+        events.push({ type: "revisedOnly", block });
       }
-      counts.added++;
-      changes.push({
-        type: "added",
-        blockId: revisedBlock.id,
-        kind: revisedBlock.kind,
-        text: revisedBlock.text,
-      });
     }
   };
 
@@ -324,13 +352,193 @@ export const compareDocxVersions = async (
   let revisedCursor = 0;
   for (const anchor of anchors) {
     emitGap(baseCursor, anchor.baseIndex, revisedCursor, anchor.revisedIndex);
-
     const baseBlock = baseBlocks[anchor.baseIndex];
     const revisedBlock = revisedBlocks[anchor.revisedIndex];
     if (baseBlock && revisedBlock) {
-      if (baseBlock.text === revisedBlock.text) {
-        counts.unchanged++;
-      } else {
+      events.push({ type: "pair", baseBlock, revisedBlock });
+    }
+    baseCursor = anchor.baseIndex + 1;
+    revisedCursor = anchor.revisedIndex + 1;
+  }
+  emitGap(baseCursor, baseBlocks.length, revisedCursor, revisedBlocks.length);
+
+  return events;
+};
+
+const previewRunsText = (runs: readonly FolioAIBlockPreviewRun[]): string =>
+  runs.map((run) => run.text).join("");
+
+/**
+ * Character-aligned formatting diff of two text-equal blocks. Walks both
+ * blocks' preview runs in parallel and collects every property whose value
+ * differs anywhere in the overlap. A side with `previewRuns === undefined`
+ * (the snapshot omits them when every run is unstyled) counts as one
+ * unstyled run spanning the whole text. When both sides carry runs but
+ * their concatenated texts disagree (non-text inline content can make the
+ * preview text drift from the block text), positions can't be aligned, so
+ * detection backs off and reports no change.
+ */
+const diffPreviewRunFormatting = (
+  base: FolioAIBlock,
+  revised: FolioAIBlock,
+): FolioFormatProperty[] => {
+  if (base.previewRuns === undefined && revised.previewRuns === undefined) {
+    return [];
+  }
+  const baseText = base.previewRuns === undefined ? null : previewRunsText(base.previewRuns);
+  const revisedText =
+    revised.previewRuns === undefined ? null : previewRunsText(revised.previewRuns);
+  if (baseText !== null && revisedText !== null && baseText !== revisedText) {
+    return [];
+  }
+  const text = baseText ?? revisedText;
+  if (text === null || text.length === 0) {
+    return [];
+  }
+  const baseRuns: readonly FolioAIBlockPreviewRun[] = base.previewRuns ?? [{ text }];
+  const revisedRuns: readonly FolioAIBlockPreviewRun[] = revised.previewRuns ?? [{ text }];
+
+  const changed = new Set<FolioFormatProperty>();
+  let baseRunIndex = 0;
+  let revisedRunIndex = 0;
+  let baseOffset = 0;
+  let revisedOffset = 0;
+  while (baseRunIndex < baseRuns.length && revisedRunIndex < revisedRuns.length) {
+    const baseRun = baseRuns[baseRunIndex];
+    const revisedRun = revisedRuns[revisedRunIndex];
+    if (!baseRun || !revisedRun) {
+      break;
+    }
+    for (const property of FORMAT_PROPERTIES) {
+      if (baseRun[property] !== revisedRun[property]) {
+        changed.add(property);
+      }
+    }
+    const step = Math.min(
+      baseRun.text.length - baseOffset,
+      revisedRun.text.length - revisedOffset,
+    );
+    baseOffset += step;
+    revisedOffset += step;
+    if (baseOffset >= baseRun.text.length) {
+      baseRunIndex++;
+      baseOffset = 0;
+    }
+    if (revisedOffset >= revisedRun.text.length) {
+      revisedRunIndex++;
+      revisedOffset = 0;
+    }
+  }
+  // Report in the stable FORMAT_PROPERTIES order, not set-insertion order.
+  return FORMAT_PROPERTIES.filter((property) => changed.has(property));
+};
+
+/**
+ * Floor for move detection: an added/deleted text must hold at least this
+ * many whitespace-separated words before an identical pair re-classifies as
+ * a move. Short boilerplate ("Confidential", a bare heading word) recurs
+ * throughout real documents and would otherwise pair as spurious moves.
+ */
+const MOVE_MINIMUM_WORD_COUNT = 3;
+
+const meetsMoveWordCount = (text: string): boolean => {
+  let words = 0;
+  for (const token of text.split(/\s+/u)) {
+    if (token.length > 0 && ++words >= MOVE_MINIMUM_WORD_COUNT) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Re-classify `deleted` + `added` pairs with identical text as
+ * `movedFrom` / `movedTo` entries sharing a `moveGroupId`, in place, so each
+ * side keeps its slot in the revised-side document order. Matching is FIFO
+ * per text, so duplicated boilerplate above the word floor pairs
+ * first-to-first rather than fanning out.
+ */
+const detectMoves = (
+  changes: FolioBlockDiff[],
+  counts: FolioVersionDiff["summaryCounts"],
+): void => {
+  const deletedIndexesByText = new Map<string, number[]>();
+  changes.forEach((change, index) => {
+    if (change.type === "deleted" && meetsMoveWordCount(change.text)) {
+      const queue = deletedIndexesByText.get(change.text) ?? [];
+      queue.push(index);
+      deletedIndexesByText.set(change.text, queue);
+    }
+  });
+  if (deletedIndexesByText.size === 0) {
+    return;
+  }
+
+  let moveGroupId = 0;
+  changes.forEach((change, index) => {
+    if (change.type !== "added") {
+      return;
+    }
+    const deletedIndex = deletedIndexesByText.get(change.text)?.shift();
+    if (deletedIndex === undefined) {
+      return;
+    }
+    const deleted = changes[deletedIndex];
+    if (!deleted || deleted.type !== "deleted") {
+      return;
+    }
+    moveGroupId++;
+    changes[deletedIndex] = {
+      type: "movedFrom",
+      blockId: deleted.blockId,
+      kind: deleted.kind,
+      text: deleted.text,
+      moveGroupId,
+    };
+    changes[index] = {
+      type: "movedTo",
+      blockId: change.blockId,
+      kind: change.kind,
+      text: change.text,
+      moveGroupId,
+    };
+    counts.deleted--;
+    counts.added--;
+    counts.moved++;
+  });
+};
+
+/**
+ * Compare two `.docx` buffers and return a structured, block-level diff.
+ * See the module doc comment for the as-accepted comparison semantics, the
+ * three-pass alignment algorithm, move detection, and format-only change
+ * detection.
+ */
+export const compareDocxVersions = async (
+  base: ArrayBuffer,
+  revised: ArrayBuffer,
+): Promise<FolioVersionDiff> => {
+  const [baseReviewer, revisedReviewer] = await Promise.all([
+    FolioDocxReviewer.fromBuffer(base),
+    FolioDocxReviewer.fromBuffer(revised),
+  ]);
+  const baseBlocks = baseReviewer.snapshot().blocks;
+  const revisedBlocks = revisedReviewer.snapshot().blocks;
+
+  const changes: FolioBlockDiff[] = [];
+  const counts: FolioVersionDiff["summaryCounts"] = {
+    added: 0,
+    deleted: 0,
+    modified: 0,
+    formatChanged: 0,
+    moved: 0,
+    unchanged: 0,
+  };
+
+  for (const event of alignFolioBlocks(baseBlocks, revisedBlocks)) {
+    if (event.type === "pair") {
+      const { baseBlock, revisedBlock } = event;
+      if (baseBlock.text !== revisedBlock.text) {
         counts.modified++;
         changes.push({
           type: "modified",
@@ -338,13 +546,43 @@ export const compareDocxVersions = async (
           kind: revisedBlock.kind,
           segments: diffWordSegments(baseBlock.text, revisedBlock.text),
         });
+        continue;
       }
+      const changedProperties = diffPreviewRunFormatting(baseBlock, revisedBlock);
+      if (changedProperties.length > 0) {
+        counts.formatChanged++;
+        changes.push({
+          type: "formatChanged",
+          blockId: revisedBlock.id,
+          kind: revisedBlock.kind,
+          text: revisedBlock.text,
+          changedProperties,
+        });
+        continue;
+      }
+      counts.unchanged++;
+      continue;
     }
-
-    baseCursor = anchor.baseIndex + 1;
-    revisedCursor = anchor.revisedIndex + 1;
+    if (event.type === "baseOnly") {
+      counts.deleted++;
+      changes.push({
+        type: "deleted",
+        blockId: event.block.id,
+        kind: event.block.kind,
+        text: event.block.text,
+      });
+      continue;
+    }
+    counts.added++;
+    changes.push({
+      type: "added",
+      blockId: event.block.id,
+      kind: event.block.kind,
+      text: event.block.text,
+    });
   }
-  emitGap(baseCursor, baseBlocks.length, revisedCursor, revisedBlocks.length);
+
+  detectMoves(changes, counts);
 
   return { changes, summaryCounts: counts };
 };

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -409,12 +409,14 @@ const diffPreviewRunFormatting = (
     if (!baseRun || !revisedRun) {
       break;
     }
-    for (const property of FORMAT_PROPERTIES) {
-      if (baseRun[property] !== revisedRun[property]) {
-        changed.add(property);
+    const step = Math.min(baseRun.text.length - baseOffset, revisedRun.text.length - revisedOffset);
+    if (step > 0) {
+      for (const property of FORMAT_PROPERTIES) {
+        if (baseRun[property] !== revisedRun[property]) {
+          changed.add(property);
+        }
       }
     }
-    const step = Math.min(baseRun.text.length - baseOffset, revisedRun.text.length - revisedOffset);
     baseOffset += step;
     revisedOffset += step;
     if (baseOffset >= baseRun.text.length) {
@@ -439,9 +441,12 @@ const diffPreviewRunFormatting = (
 const MOVE_MINIMUM_WORD_COUNT = 3;
 
 const meetsMoveWordCount = (text: string): boolean => {
-  let words = 0;
-  for (const token of text.split(/\s+/u)) {
-    if (token.length > 0 && ++words >= MOVE_MINIMUM_WORD_COUNT) {
+  // Iterate matches instead of split(): a large block would otherwise
+  // allocate its entire token array just to count to the floor.
+  const words = text.matchAll(/\S+/gu);
+  let count = 0;
+  while (!words.next().done) {
+    if (++count >= MOVE_MINIMUM_WORD_COUNT) {
       return true;
     }
   }


### PR DESCRIPTION
## What

Three related upgrades to the comparison/review surface, plus a Word-behavior note-numbering fix.

### `compareDocxVersions`
- **Move detection.** A deleted + added block pair with identical text (3+ words, so recurring boilerplate can't pair spuriously) now re-classifies as `movedFrom`/`movedTo` entries sharing a `moveGroupId`, instead of reporting an unrelated delete and insert. Matching is FIFO per text; both entries keep their slots in revised-side document order.
- **Format-only change detection.** A paired block whose text is byte-equal but whose run formatting differs now reports as `formatChanged` with the changed property names (bold, italic, underline, strike, font family, size, color), detected by walking preview runs character-aligned. Detection backs off to `unchanged` when preview texts disagree (non-text inline content) rather than misattribute properties.
- The three-pass alignment is extracted as `alignFolioBlocks` and shared with the redline generator; `summaryCounts` gains `moved` and `formatChanged`, and `formatVersionDiffForLLM` renders the new change types.

### `generateRedlineDocx(base, revised)` (new)
Produces a third `.docx` whose base → revised differences are recorded as real Word tracked changes (`w:ins`/`w:del`), by mapping alignment events onto tracked-changes document operations applied through the headless reviewer — word-level minimality comes from the existing apply-path word diff. Inputs are compared as-accepted (matching `compareDocxVersions`). Tests pin the defining invariants: accept-all reproduces the revised document; reject-all restores the base. v1 limitations are documented in the module: format-only changes and moves redline as plain edits; additions to an empty base surface in `skipped`.

### Note numbering (Word behavior)
Footnote/endnote body reference marks painted the raw `w:id` while the footnote area numbered sequentially by reference order, so non-contiguous or out-of-order ids mismatched. Body markers and area numbers now derive from one `computeNoteDisplayNumbers` map, remapped at the flow-block stage before measurement; reserved notes (separators, positive-id continuation notices) consume no number. Removes the unused file-order display-number helpers that encoded the wrong model.

Also adds a regression test that rejecting a `w:pPrChange` merges the stored old properties key-by-key and preserves the separately-modeled inline `sectPr`.

## Notes for review
- `FolioBlockDiff` and `summaryCounts` are extended (union gains three variants); `@stll/folio-agents` rendering updated accordingly. Changesets: core minor + patch, agents minor.
- An earlier revision of this branch also changed multi-level list-marker rendering for "orphan" deeper levels; that commit was dropped after verification against real Word (via `bun run parity`) showed Word renders the literal multi-level format in every reproducible case.
- Known follow-ups (intentionally out of scope): reject handling for `sectPrChange`/table property changes is display-only today; pPrChange reject does not clear properties the change added.