### PR TITLE
fix: resolve property-change revisions on accept/reject

### DIFF
--- a/.changeset/calm-rejects-restore.md
+++ b/.changeset/calm-rejects-restore.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Property-change tracked revisions now resolve fully. Rejecting a `w:pPrChange` restores the stored old paragraph properties wholesale within CT_PPrBase scope (properties the change added are cleared, out-of-scope attrs like the inline `sectPr` still preserved). `w:sectPrChange` and table property changes (`w:tblPrChange`/`w:trPrChange`/`w:tcPrChange`) — previously display-only — now accept and reject: accept keeps live values and clears the record, reject restores the stored previous properties (section rejects keep live header/footer references, which CT_SectPrBase cannot carry). Table property-change records also survive the ProseMirror round-trip instead of being dropped on save, and `acceptAll()`/`rejectAll()` counts include section and table property changes.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -342,7 +342,8 @@ export type TableAttrs = {
     }; /** Table look flags for conditional formatting (w:tblLook) */
     look?: import__stll_docx_core_model.TableLook; /** Table-level borders (w:tblBorders) — full BorderSpec per side */
     borders?: import__stll_docx_core_model.TableBorders; /** Original table formatting from DOCX for lossless round-trip serialization */
-    _originalFormatting?: import__stll_docx_core_model.TableFormatting;
+    _originalFormatting?: import__stll_docx_core_model.TableFormatting; /** Tracked table property changes (w:tblPrChange) for round-trip + accept/reject */
+    tblPrChange?: import__stll_docx_core_model.TablePropertyChange[];
 };
 
 // @public
@@ -368,7 +369,8 @@ export type TableCellAttrs = {
         left?: number;
         right?: number;
     }; /** Original cell formatting from DOCX for lossless round-trip serialization */
-    _originalFormatting?: import__stll_docx_core_model.TableCellFormatting; /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
+    _originalFormatting?: import__stll_docx_core_model.TableCellFormatting; /** Tracked cell property changes (w:tcPrChange) for round-trip + accept/reject */
+    tcPrChange?: import__stll_docx_core_model.TableCellPropertyChange[]; /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
     _preserveVMergeRestart?: boolean; /** Original DOCX vMerge continuation cells skipped into this PM rowspan. */
     _docxVMergeContinuationCells?: import__stll_docx_core_model.TableCell[];
 };
@@ -379,7 +381,8 @@ export type TableRowAttrs = {
     heightRule?: NonNullable<import__stll_docx_core_model.TableRowFormatting["heightRule"]>; /** Is header row */
     isHeader?: boolean; /** Whether the row is hidden (`w:hidden`) */
     hidden?: boolean; /** Original row formatting from DOCX for lossless round-trip serialization */
-    _originalFormatting?: import__stll_docx_core_model.TableRowFormatting;
+    _originalFormatting?: import__stll_docx_core_model.TableRowFormatting; /** Tracked row property changes (w:trPrChange) for round-trip + accept/reject */
+    trPrChange?: import__stll_docx_core_model.TableRowPropertyChange[];
 };
 
 // @public

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -801,22 +801,44 @@ export class FolioDocxReviewer {
 
   /**
    * Count every tracked change an accept-all / reject-all sweep resolves: the
-   * inline insertion / deletion groups {@link getChanges} enumerates, plus
-   * paragraph-level changes (`pPrMark`, `_propertyChanges`) that live on
-   * paragraph attrs rather than inline marks.
+   * inline insertion / deletion groups {@link getChanges} enumerates, plus the
+   * property-change records living on node attrs rather than inline marks —
+   * paragraph-level (`pPrMark`, `_propertyChanges`, the inline sectPr's
+   * `propertyChanges`) and table-level (`tblPrChange` / `trPrChange` /
+   * `tcPrChange`).
    */
   private countTrackedChanges(): number {
+    const hasEntries = (value: unknown): boolean => Array.isArray(value) && value.length > 0;
     let count = this.getChanges().length;
     this.state.doc.descendants((node) => {
-      if (node.type.name !== "paragraph") {
+      const typeName = node.type.name;
+      if (typeName === "table" && hasEntries(node.attrs["tblPrChange"])) {
+        count += 1;
+      }
+      if (typeName === "tableRow" && hasEntries(node.attrs["trPrChange"])) {
+        count += 1;
+      }
+      if (
+        (typeName === "tableCell" || typeName === "tableHeader") &&
+        hasEntries(node.attrs["tcPrChange"])
+      ) {
+        count += 1;
+      }
+      if (typeName !== "paragraph") {
         return undefined;
       }
       const pPrMark = node.attrs["pPrMark"];
       if (pPrMark !== null && pPrMark !== undefined) {
         count += 1;
       }
-      const propertyChanges = node.attrs["_propertyChanges"];
-      if (Array.isArray(propertyChanges) && propertyChanges.length > 0) {
+      if (hasEntries(node.attrs["_propertyChanges"])) {
+        count += 1;
+      }
+      const sectionProperties = node.attrs["_sectionProperties"] as
+        | { propertyChanges?: unknown }
+        | null
+        | undefined;
+      if (hasEntries(sectionProperties?.propertyChanges)) {
         count += 1;
       }
       return false;

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -288,6 +288,188 @@ describe("findChangeAtPosition", () => {
     expect(attrs["_propertyChanges"]).toBeNull();
     expect(attrs["_sectionProperties"]).toEqual(sectionProperties);
   });
+
+  test("rejecting a pPrChange resets a property the change ADDED", () => {
+    // Word stores the complete old pPr inside the pPrChange. A property
+    // present on the live paragraph but absent from the stored old pPr was
+    // ADDED by the tracked change — rejecting must reset it to the schema
+    // default, not let it survive because no stored key overwrites it.
+    const initial = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            alignment: "center",
+            numPr: { numId: 4, ilvl: 0 },
+            _propertyChanges: [
+              {
+                type: "paragraphPropertyChange",
+                info: { id: 11, author: "Alice", date: "2026-01-01" },
+                // Old pPr only carried numbering — no alignment.
+                previousFormatting: { numPr: { numId: 4, ilvl: 0 } },
+              },
+            ],
+          },
+          [schema.text("alpha")],
+        ),
+      ]),
+    });
+    const view = dispatcher(initial);
+
+    expect(rejectChange(0, initial.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    expect(attrs["alignment"]).toBeNull();
+    expect(attrs["numPr"]).toEqual({ numId: 4, ilvl: 0 });
+    expect(attrs["_propertyChanges"]).toBeNull();
+  });
+
+  test("accepting a pPrChange keeps a change-added property and only clears the record", () => {
+    const initial = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            alignment: "center",
+            _propertyChanges: [
+              {
+                type: "paragraphPropertyChange",
+                info: { id: 11, author: "Alice", date: "2026-01-01" },
+                previousFormatting: {},
+              },
+            ],
+          },
+          [schema.text("alpha")],
+        ),
+      ]),
+    });
+    const view = dispatcher(initial);
+
+    expect(acceptChange(0, initial.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    expect(attrs["alignment"]).toBe("center");
+    expect(attrs["_propertyChanges"]).toBeNull();
+  });
+
+  test("rejecting a sectPrChange restores the old sectPr but keeps live header references", () => {
+    // CT_SectPrBase (the payload w:sectPrChange stores) cannot carry
+    // header/footer references — rejecting the section-property change must
+    // restore the stored old properties wholesale while the live
+    // headerReferences survive.
+    const initial = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            _sectionProperties: {
+              sectionStart: "nextPage",
+              pageWidth: 12_240,
+              marginTop: 1440,
+              headerReferences: [{ type: "default", relationshipId: "rId7" }],
+              propertyChanges: [
+                {
+                  type: "sectionPropertyChange",
+                  info: { id: 21, author: "Alice", date: "2026-01-01" },
+                  previousProperties: { sectionStart: "continuous", pageWidth: 15_840 },
+                },
+              ],
+            },
+          },
+          [schema.text("alpha")],
+        ),
+      ]),
+    });
+    const view = dispatcher(initial);
+
+    expect(rejectChange(0, initial.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({
+      sectionStart: "continuous",
+      pageWidth: 15_840,
+      headerReferences: [{ type: "default", relationshipId: "rId7" }],
+    });
+  });
+
+  test("accepting a sectPrChange keeps the live sectPr and clears the record", () => {
+    const initial = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            _sectionProperties: {
+              sectionStart: "nextPage",
+              pageWidth: 12_240,
+              propertyChanges: [
+                {
+                  type: "sectionPropertyChange",
+                  info: { id: 21, author: "Alice", date: "2026-01-01" },
+                  previousProperties: { sectionStart: "continuous", pageWidth: 15_840 },
+                },
+              ],
+            },
+          },
+          [schema.text("alpha")],
+        ),
+      ]),
+    });
+    const view = dispatcher(initial);
+
+    expect(acceptChange(0, initial.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({
+      sectionStart: "nextPage",
+      pageWidth: 12_240,
+    });
+  });
+
+  test("a revision-scoped reject leaves other sectPrChange records in place", () => {
+    // Revision 21 spans two paragraphs (its inline marks derive the range, so
+    // the range covers the first paragraph's boundary); revision 99's section
+    // record on the same paragraph must survive the scoped reject untouched.
+    const insertion = schema.marks["insertion"];
+    const otherChange = {
+      type: "sectionPropertyChange",
+      info: { id: 99, author: "Bob", date: "2026-01-02" },
+      previousProperties: { pageWidth: 11_906 },
+    };
+    const revisionAttrs = { revisionId: 21, author: "AI", date: "2026-01-01" };
+    const initial = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            _sectionProperties: {
+              pageWidth: 12_240,
+              propertyChanges: [
+                {
+                  type: "sectionPropertyChange",
+                  info: { id: 21, author: "Alice", date: "2026-01-01" },
+                  previousProperties: { pageWidth: 15_840 },
+                },
+                otherChange,
+              ],
+            },
+          },
+          [schema.text("one", [insertion.create(revisionAttrs)])],
+        ),
+        schema.node("paragraph", null, [schema.text("two", [insertion.create(revisionAttrs)])]),
+      ]),
+    });
+    const view = dispatcher(initial);
+
+    expect(rejectAIEditRevision(21)(view.state, view.dispatch)).toBe(true);
+
+    expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({
+      pageWidth: 15_840,
+      propertyChanges: [otherChange],
+    });
+  });
 });
 
 describe("tracked change navigation", () => {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -7,6 +7,21 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState } from "prosemirror-state";
 
+import type {
+  SectionProperties,
+  TableCellFormatting,
+  TableFormatting,
+  TableRowFormatting,
+} from "../../types/document";
+import {
+  paragraphRejectAttrPatch,
+  paragraphRejectOriginalFormatting,
+  sectionRejectProperties,
+  tableCellRejectAttrPatch,
+  tableRejectAttrPatch,
+  tableRowRejectAttrPatch,
+} from "./propertyChangeScope";
+
 /**
  * Add a comment mark to the current selection.
  */
@@ -102,6 +117,9 @@ function resolveChange(
             pPrMarkOps.push(op);
           }
 
+          const boundaryCovered = rangeCoversParagraphBoundary(from, to, pos, node);
+          let nextAttrs: Record<string, unknown> | null = null;
+
           // Process paragraph property changes (w:pPrChange)
           const propertyChanges = node.attrs["_propertyChanges"] as
             | {
@@ -110,11 +128,7 @@ function resolveChange(
               }[]
             | undefined;
 
-          if (
-            Array.isArray(propertyChanges) &&
-            propertyChanges.length > 0 &&
-            rangeCoversParagraphBoundary(from, to, pos, node)
-          ) {
+          if (Array.isArray(propertyChanges) && propertyChanges.length > 0 && boundaryCovered) {
             const matches = propertyChanges.filter(
               (c) => revisionSet === null || (c.info && revisionSet.has(c.info.id)),
             );
@@ -122,23 +136,88 @@ function resolveChange(
               const remaining = propertyChanges.filter(
                 (c) => revisionSet !== null && (!c.info || !revisionSet.has(c.info.id)),
               );
-              const nextAttrs: Record<string, unknown> = {
+              nextAttrs = {
                 ...node.attrs,
                 _propertyChanges: remaining.length > 0 ? remaining : null,
               };
               if (mode === "reject") {
+                // Word stores the complete old pPr in the pPrChange, so a
+                // reject restores it WHOLESALE within CT_PPrBase scope: a
+                // property the change ADDED resets too. Out-of-scope attrs
+                // (inline sectPr, paragraph-mark rPr, identity) survive —
+                // see propertyChangeScope.ts. Iterating end → start makes
+                // the earliest change's stored pPr win for scoped keys.
                 for (const change of matches.toReversed()) {
-                  if (change.previousFormatting) {
-                    for (const [key, val] of Object.entries(change.previousFormatting)) {
-                      nextAttrs[key] = val;
-                    }
-                  }
+                  Object.assign(nextAttrs, paragraphRejectAttrPatch(change.previousFormatting));
+                  nextAttrs["_originalFormatting"] = paragraphRejectOriginalFormatting(
+                    change.previousFormatting,
+                    node.attrs["_originalFormatting"],
+                  );
                 }
               }
-              tr.setNodeMarkup(pos, undefined, nextAttrs);
             }
           }
 
+          // Process inline section-property changes (w:sectPrChange) carried
+          // on the paragraph's `_sectionProperties` attr.
+          const sectionProperties = node.attrs["_sectionProperties"] as
+            | SectionProperties
+            | null
+            | undefined;
+          const sectionChanges = sectionProperties?.propertyChanges;
+          if (
+            sectionProperties &&
+            Array.isArray(sectionChanges) &&
+            sectionChanges.length > 0 &&
+            boundaryCovered
+          ) {
+            const matches = sectionChanges.filter(
+              (c) => revisionSet === null || revisionSet.has(c.info.id),
+            );
+            if (matches.length > 0) {
+              const remaining = sectionChanges.filter(
+                (c) => revisionSet !== null && !revisionSet.has(c.info.id),
+              );
+              let restored: SectionProperties = { ...sectionProperties };
+              if (mode === "reject") {
+                for (const change of matches.toReversed()) {
+                  restored = sectionRejectProperties(restored, change.previousProperties);
+                }
+              }
+              delete restored.propertyChanges;
+              if (remaining.length > 0) {
+                restored.propertyChanges = remaining;
+              }
+              nextAttrs = nextAttrs ?? { ...node.attrs };
+              nextAttrs["_sectionProperties"] = restored;
+              nextAttrs["sectionBreakType"] = sectionBreakTypeFromSectionStart(
+                restored.sectionStart,
+              );
+            }
+          }
+
+          if (nextAttrs) {
+            tr.setNodeMarkup(pos, undefined, nextAttrs);
+          }
+
+          return true;
+        }
+
+        // Table property changes (w:tblPrChange / w:trPrChange / w:tcPrChange)
+        // carried on the table / row / cell node attrs.
+        const tableChangeAttrName = TABLE_PROPERTY_CHANGE_ATTR_BY_NODE[node.type.name];
+        if (tableChangeAttrName !== undefined) {
+          if (rangeCoversNode(from, to, pos, node)) {
+            const nextAttrs = resolveTablePropertyChangeAttrs(
+              node,
+              tableChangeAttrName,
+              mode,
+              revisionSet,
+            );
+            if (nextAttrs) {
+              tr.setNodeMarkup(pos, undefined, nextAttrs);
+            }
+          }
           return true;
         }
         // Text AND inline atoms (image, shape, hardBreak, tab) can carry
@@ -267,6 +346,98 @@ function rangeCoversParagraphBoundary(
   const boundaryFrom = pos + node.nodeSize - 1;
   const boundaryTo = pos + node.nodeSize;
   return from <= boundaryFrom && to >= boundaryTo;
+}
+
+/** Whether [from, to] fully covers the node — the range property-change cards
+ * and accept-all / reject-all sweeps supply for table-level records. */
+function rangeCoversNode(
+  from: number,
+  to: number,
+  pos: number,
+  node: { nodeSize: number },
+): boolean {
+  return from <= pos && to >= pos + node.nodeSize;
+}
+
+const SECTION_BREAK_TYPE_VALUES = ["nextPage", "continuous", "oddPage", "evenPage"] as const;
+
+function sectionBreakTypeFromSectionStart(
+  sectionStart: SectionProperties["sectionStart"],
+): (typeof SECTION_BREAK_TYPE_VALUES)[number] | null {
+  const match = SECTION_BREAK_TYPE_VALUES.find((value) => value === sectionStart);
+  return match ?? null;
+}
+
+/** PM node type name → the attr its tracked property-change records live on. */
+const TABLE_PROPERTY_CHANGE_ATTR_BY_NODE: Record<
+  string,
+  "tblPrChange" | "trPrChange" | "tcPrChange" | undefined
+> = {
+  table: "tblPrChange",
+  tableRow: "trPrChange",
+  tableCell: "tcPrChange",
+  tableHeader: "tcPrChange",
+};
+
+type TablePropertyChangeEntry = {
+  info?: { id: number; author: string; date?: string };
+  previousFormatting?: TableFormatting | TableRowFormatting | TableCellFormatting;
+};
+
+/**
+ * Resolve the tracked property-change records on one table / row / cell node.
+ * Accept keeps the live formatting and clears the matched records; reject
+ * additionally restores the stored previous formatting wholesale (the change
+ * element stores the complete old property set — see propertyChangeScope.ts).
+ * Returns the next attrs, or `null` when no record matches.
+ */
+function resolveTablePropertyChangeAttrs(
+  node: PMNode,
+  attrName: "tblPrChange" | "trPrChange" | "tcPrChange",
+  mode: "accept" | "reject",
+  revisionSet: Set<number> | null,
+): Record<string, unknown> | null {
+  const changes = node.attrs[attrName] as TablePropertyChangeEntry[] | null | undefined;
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return null;
+  }
+  const matches = changes.filter(
+    (c) => revisionSet === null || (c.info && revisionSet.has(c.info.id)),
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+  const remaining = changes.filter(
+    (c) => revisionSet !== null && (!c.info || !revisionSet.has(c.info.id)),
+  );
+  const nextAttrs: Record<string, unknown> = {
+    ...node.attrs,
+    [attrName]: remaining.length > 0 ? remaining : null,
+  };
+  if (mode === "reject") {
+    for (const change of matches.toReversed()) {
+      if (attrName === "tblPrChange") {
+        Object.assign(
+          nextAttrs,
+          tableRejectAttrPatch(change.previousFormatting as TableFormatting | undefined),
+        );
+      } else if (attrName === "trPrChange") {
+        Object.assign(
+          nextAttrs,
+          tableRowRejectAttrPatch(change.previousFormatting as TableRowFormatting | undefined),
+        );
+      } else {
+        Object.assign(
+          nextAttrs,
+          tableCellRejectAttrPatch(
+            change.previousFormatting as TableCellFormatting | undefined,
+            node.attrs["_originalFormatting"] as TableCellFormatting | null | undefined,
+          ),
+        );
+      }
+    }
+  }
+  return nextAttrs;
 }
 
 function isPPrMarkAttr(value: unknown): value is { kind: "ins" | "del"; info: { id: number } } {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -172,11 +172,11 @@ function resolveChange(
             boundaryCovered
           ) {
             const matches = sectionChanges.filter(
-              (c) => revisionSet === null || revisionSet.has(c.info.id),
+              (c) => revisionSet === null || (c.info && revisionSet.has(c.info.id)),
             );
             if (matches.length > 0) {
               const remaining = sectionChanges.filter(
-                (c) => revisionSet !== null && !revisionSet.has(c.info.id),
+                (c) => revisionSet !== null && (!c.info || !revisionSet.has(c.info.id)),
               );
               let restored: SectionProperties = { ...sectionProperties };
               if (mode === "reject") {

--- a/packages/core/src/prosemirror/commands/propertyChangeResolve.test.ts
+++ b/packages/core/src/prosemirror/commands/propertyChangeResolve.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Accept/reject of tracked property changes (w:pPrChange, w:sectPrChange,
+ * w:tblPrChange, w:trPrChange, w:tcPrChange) against the REAL editor schema,
+ * built via toProseDoc so the attr names under test are the ones the parser
+ * actually produces — and round-tripped through fromProseDoc so the
+ * serializer provably no longer re-emits a resolved change.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import type {
+  Document,
+  Paragraph,
+  Table,
+  TableCellPropertyChange,
+  TablePropertyChange,
+  TableRowPropertyChange,
+} from "../../types/document";
+import { fromProseDoc } from "../conversion/fromProseDoc";
+import { toProseDoc } from "../conversion/toProseDoc";
+import { acceptChange, rejectChange } from "./comments";
+
+const CHANGE_INFO = { id: 42, author: "Reviewer", date: "2026-05-15T12:00:00Z" };
+
+const makeDocument = (content: (Paragraph | Table)[]): Document =>
+  ({
+    package: {
+      document: {
+        content,
+        finalSectionProperties: {},
+      },
+    },
+  }) as never;
+
+const makeState = (content: (Paragraph | Table)[]): EditorState =>
+  EditorState.create({ doc: toProseDoc(makeDocument(content)) });
+
+const dispatcher = (state: EditorState) => {
+  const view = {
+    state,
+    dispatch(tr: Transaction) {
+      view.state = view.state.apply(tr);
+    },
+  };
+  return view;
+};
+
+const paragraphText = (text: string): Paragraph["content"] => [
+  { type: "run", content: [{ type: "text", text }] },
+];
+
+describe("pPrChange accept/reject (real schema)", () => {
+  const makeParagraph = (): Paragraph => ({
+    type: "paragraph",
+    // The tracked change set alignment AND indentLeft; the stored old pPr
+    // only had indentLeft — so alignment was ADDED, indentLeft was CHANGED.
+    formatting: { alignment: "center", indentLeft: 720 },
+    propertyChanges: [
+      {
+        type: "paragraphPropertyChange",
+        info: CHANGE_INFO,
+        previousFormatting: { indentLeft: 1440 },
+      },
+    ],
+    content: paragraphText("body"),
+  });
+
+  test("reject restores the old pPr wholesale and the save path drops the pPrChange", () => {
+    const view = dispatcher(makeState([makeParagraph()]));
+
+    expect(rejectChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    // Changed key: restored to the stored old value.
+    expect(attrs["indentLeft"]).toBe(1440);
+    // Added key: reset — the old pPr did not carry it.
+    expect(attrs["alignment"]).toBeNull();
+    expect(attrs["_propertyChanges"]).toBeNull();
+
+    const roundtripped = fromProseDoc(view.state.doc).package.document.content[0] as Paragraph;
+    expect(roundtripped.propertyChanges).toBeUndefined();
+    expect(roundtripped.formatting?.indentLeft).toBe(1440);
+    expect(roundtripped.formatting?.alignment).toBeUndefined();
+  });
+
+  test("accept keeps the live pPr and only clears the record", () => {
+    const view = dispatcher(makeState([makeParagraph()]));
+
+    expect(acceptChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    expect(attrs["alignment"]).toBe("center");
+    expect(attrs["indentLeft"]).toBe(720);
+    expect(attrs["_propertyChanges"]).toBeNull();
+
+    const roundtripped = fromProseDoc(view.state.doc).package.document.content[0] as Paragraph;
+    expect(roundtripped.propertyChanges).toBeUndefined();
+    expect(roundtripped.formatting?.alignment).toBe("center");
+    expect(roundtripped.formatting?.indentLeft).toBe(720);
+  });
+
+  test("reject is a no-op when the paragraph carries no change records", () => {
+    const plain: Paragraph = {
+      type: "paragraph",
+      formatting: { alignment: "center" },
+      content: paragraphText("body"),
+    };
+    const view = dispatcher(makeState([plain]));
+    const before = view.state.doc;
+
+    expect(rejectChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    expect(view.state.doc.eq(before)).toBe(true);
+  });
+});
+
+describe("sectPrChange accept/reject (real schema)", () => {
+  const makeSectionParagraph = (): Paragraph => ({
+    type: "paragraph",
+    content: paragraphText("section end"),
+    sectionProperties: {
+      sectionStart: "nextPage",
+      pageWidth: 12_240,
+      pageHeight: 15_840,
+      marginTop: 1440,
+      headerReferences: [{ type: "default", relationshipId: "rId7" }],
+      propertyChanges: [
+        {
+          type: "sectionPropertyChange",
+          info: CHANGE_INFO,
+          previousProperties: {
+            sectionStart: "continuous",
+            pageWidth: 11_906,
+            pageHeight: 16_838,
+          },
+        },
+      ],
+    },
+  });
+
+  test("reject restores the old sectPr, keeps live header references, updates sectionBreakType", () => {
+    const view = dispatcher(makeState([makeSectionParagraph()]));
+
+    expect(rejectChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    expect(attrs["_sectionProperties"]).toEqual({
+      sectionStart: "continuous",
+      pageWidth: 11_906,
+      pageHeight: 16_838,
+      headerReferences: [{ type: "default", relationshipId: "rId7" }],
+    });
+    expect(attrs["sectionBreakType"]).toBe("continuous");
+
+    const roundtripped = fromProseDoc(view.state.doc).package.document.content[0] as Paragraph;
+    expect(roundtripped.sectionProperties?.propertyChanges).toBeUndefined();
+    expect(roundtripped.sectionProperties?.pageWidth).toBe(11_906);
+    expect(roundtripped.sectionProperties?.headerReferences).toEqual([
+      { type: "default", relationshipId: "rId7" },
+    ]);
+  });
+
+  test("accept keeps the live sectPr and clears the record", () => {
+    const view = dispatcher(makeState([makeSectionParagraph()]));
+
+    expect(acceptChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const attrs = view.state.doc.child(0).attrs;
+    expect(attrs["_sectionProperties"]).toEqual({
+      sectionStart: "nextPage",
+      pageWidth: 12_240,
+      pageHeight: 15_840,
+      marginTop: 1440,
+      headerReferences: [{ type: "default", relationshipId: "rId7" }],
+    });
+    expect(attrs["sectionBreakType"]).toBe("nextPage");
+
+    const roundtripped = fromProseDoc(view.state.doc).package.document.content[0] as Paragraph;
+    expect(roundtripped.sectionProperties?.propertyChanges).toBeUndefined();
+    expect(roundtripped.sectionProperties?.pageWidth).toBe(12_240);
+  });
+});
+
+describe("table property-change accept/reject (real schema)", () => {
+  const tblChange: TablePropertyChange = {
+    type: "tablePropertyChange",
+    info: CHANGE_INFO,
+    // The old tblPr had a narrower width and no justification (the change
+    // ADDED the centering).
+    previousFormatting: { width: { value: 4000, type: "pct" } },
+  };
+  const trChange: TableRowPropertyChange = {
+    type: "tableRowPropertyChange",
+    info: CHANGE_INFO,
+    previousFormatting: { height: { value: 300, type: "dxa" }, heightRule: "atLeast" },
+  };
+  const tcChange: TableCellPropertyChange = {
+    type: "tableCellPropertyChange",
+    info: CHANGE_INFO,
+    previousFormatting: { shading: { fill: { rgb: "00FF00" } } },
+  };
+
+  const makeTable = (): Table => ({
+    type: "table",
+    formatting: { width: { value: 5000, type: "pct" }, justification: "center" },
+    propertyChanges: [tblChange],
+    columnWidths: [4680],
+    rows: [
+      {
+        type: "tableRow",
+        formatting: { height: { value: 500, type: "dxa" }, heightRule: "exact" },
+        propertyChanges: [trChange],
+        cells: [
+          {
+            type: "tableCell",
+            formatting: { shading: { fill: { rgb: "FF0000" } } },
+            propertyChanges: [tcChange],
+            content: [{ type: "paragraph", content: paragraphText("cell") }],
+          },
+        ],
+      },
+    ],
+  });
+
+  test("toProseDoc/fromProseDoc round-trips unresolved table property changes", () => {
+    const state = makeState([makeTable()]);
+    const roundtripped = fromProseDoc(state.doc).package.document.content[0] as Table;
+
+    expect(roundtripped.propertyChanges).toEqual([tblChange]);
+    expect(roundtripped.rows[0]?.propertyChanges).toEqual([trChange]);
+    expect(roundtripped.rows[0]?.cells[0]?.propertyChanges).toEqual([tcChange]);
+  });
+
+  test("reject restores previous table/row/cell formatting and drops the records", () => {
+    const view = dispatcher(makeState([makeTable()]));
+
+    expect(rejectChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.child(0);
+    expect(table.attrs["width"]).toBe(4000);
+    expect(table.attrs["widthType"]).toBe("pct");
+    // The change ADDED the justification — reject resets it.
+    expect(table.attrs["justification"]).toBeNull();
+    expect(table.attrs["tblPrChange"]).toBeNull();
+
+    const row = table.child(0);
+    expect(row.attrs["height"]).toBe(300);
+    expect(row.attrs["heightRule"]).toBe("atLeast");
+    expect(row.attrs["trPrChange"]).toBeNull();
+
+    const cell = row.child(0);
+    expect(cell.attrs["backgroundColor"]).toBe("00FF00");
+    expect(cell.attrs["tcPrChange"]).toBeNull();
+
+    const roundtripped = fromProseDoc(view.state.doc).package.document.content[0] as Table;
+    expect(roundtripped.propertyChanges).toBeUndefined();
+    expect(roundtripped.formatting?.width).toEqual({ value: 4000, type: "pct" });
+    expect(roundtripped.formatting?.justification).toBeUndefined();
+    expect(roundtripped.rows[0]?.propertyChanges).toBeUndefined();
+    expect(roundtripped.rows[0]?.formatting?.height).toEqual({ value: 300, type: "dxa" });
+    expect(roundtripped.rows[0]?.cells[0]?.propertyChanges).toBeUndefined();
+    expect(roundtripped.rows[0]?.cells[0]?.formatting?.shading).toEqual({
+      fill: { rgb: "00FF00" },
+    });
+  });
+
+  test("accept keeps current table/row/cell formatting and drops the records", () => {
+    const view = dispatcher(makeState([makeTable()]));
+
+    expect(acceptChange(0, view.state.doc.content.size)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.child(0);
+    expect(table.attrs["width"]).toBe(5000);
+    expect(table.attrs["justification"]).toBe("center");
+    expect(table.attrs["tblPrChange"]).toBeNull();
+
+    const row = table.child(0);
+    expect(row.attrs["height"]).toBe(500);
+    expect(row.attrs["heightRule"]).toBe("exact");
+    expect(row.attrs["trPrChange"]).toBeNull();
+
+    const cell = row.child(0);
+    expect(cell.attrs["backgroundColor"]).toBe("FF0000");
+    expect(cell.attrs["tcPrChange"]).toBeNull();
+
+    const roundtripped = fromProseDoc(view.state.doc).package.document.content[0] as Table;
+    expect(roundtripped.propertyChanges).toBeUndefined();
+    expect(roundtripped.formatting?.justification).toBe("center");
+    expect(roundtripped.rows[0]?.propertyChanges).toBeUndefined();
+    expect(roundtripped.rows[0]?.cells[0]?.propertyChanges).toBeUndefined();
+  });
+});

--- a/packages/core/src/prosemirror/commands/propertyChangeScope.ts
+++ b/packages/core/src/prosemirror/commands/propertyChangeScope.ts
@@ -1,0 +1,364 @@
+/**
+ * Property-change reject scope + patch builders.
+ *
+ * Word tracks formatting changes by storing the COMPLETE old property set
+ * inside the change element (`w:pPrChange` stores the old `CT_PPrBase`,
+ * `w:sectPrChange` the old `CT_SectPrBase`, `w:tblPrChange`/`w:trPrChange`/
+ * `w:tcPrChange` the old tblPr/trPr/tcPr). Rejecting such a change therefore
+ * replaces the live properties WHOLESALE within that scope: a property the
+ * change ADDED (present on the live node, absent from the stored old set)
+ * must reset, not survive. Properties OUTSIDE the stored scope (an inline
+ * sectPr on a paragraph, header/footer references inside a sectPr, the
+ * paragraph-mark rPr) are separately modeled and must survive a reject.
+ *
+ * This module is the single place that maps stored "previous" records onto
+ * ProseMirror node attrs. Records come in two shapes:
+ *
+ * - parser-shaped: `parseParagraphPropertyChanges` (docx/paragraphParser.ts)
+ *   stores a `ParagraphFormatting`, whose keys mostly match paragraph attr
+ *   names except `bidi` (attr `direction`) and the autospacing flags (attr
+ *   `_autospacingBase`); table records store `TableFormatting` /
+ *   `TableRowFormatting` / `TableCellFormatting`.
+ * - attr-shaped: editor-created suggestions (ListExtension) snapshot the
+ *   paragraph attrs directly (including list-rendering bookkeeping attrs).
+ *
+ * Both shapes normalize here; per key, an attr-shaped value wins when present.
+ */
+
+import type {
+  BorderSpec,
+  CellMargins,
+  ParagraphFormatting,
+  SectionProperties,
+  TableCellFormatting,
+  TableFormatting,
+  TableRowFormatting,
+} from "../../types/document";
+import { setAutospacingBaseValue } from "../autospacingBase";
+import { directionFromBidi } from "../paragraphDirection";
+import type { ParagraphAttrs } from "../schema/nodes";
+
+type AttrPatch = Record<string, unknown>;
+
+/**
+ * Paragraph attrs governed by a `w:pPrChange` — the attrs
+ * `paragraphFormattingToAttrs` (conversion/toProseDoc.ts) can produce from a
+ * parsed `CT_PPrBase` (ECMA-376 §17.13.5.29). Rejecting a pPrChange restores
+ * the stored old pPr wholesale for exactly these keys: a key absent from the
+ * stored record resets to the schema default (`null`).
+ *
+ * Deliberately OUT of scope (preserved across a reject):
+ * - identity/structure: `paraId`, `textId`, `sectionBreakType`,
+ *   `_sectionProperties`, `_propertyChanges`, `pPrMark`, `bookmarks`,
+ *   `_emptyHyperlinks`, `renderedPageBreakBefore`
+ * - paragraph-mark run properties — `pPr/rPr` is CT_PPr-only, not part of the
+ *   CT_PPrBase payload a pPrChange stores: `defaultTextFormatting`,
+ *   `runInWithNext` (`w:specVanish` lives in that rPr)
+ * - load-time style/numbering bookkeeping the command layer cannot recompute
+ *   without a style resolver: `numPrFromStyle`, the `list*` rendering attrs,
+ *   `spacingFromDocDefaults`
+ */
+export const PPR_CHANGE_SCOPED_ATTR_KEYS = [
+  "styleId",
+  "numPr",
+  "alignment",
+  "spaceBefore",
+  "spaceAfter",
+  "lineSpacing",
+  "lineSpacingRule",
+  "spacingExplicit",
+  "indentLeft",
+  "indentRight",
+  "indentFirstLine",
+  "hangingIndent",
+  "borders",
+  "shading",
+  "tabs",
+  "pageBreakBefore",
+  "keepNext",
+  "keepLines",
+  "widowControl",
+  "contextualSpacing",
+  "outlineLevel",
+  "direction",
+  "_autospacingBase",
+] as const satisfies readonly (keyof ParagraphAttrs)[];
+
+const PPR_CHANGE_SCOPED_ATTR_KEY_SET: ReadonlySet<string> = new Set(PPR_CHANGE_SCOPED_ATTR_KEYS);
+
+/**
+ * Parser-shaped `ParagraphFormatting` keys that must NOT merge through to
+ * attrs verbatim: they either normalize to a differently named attr
+ * (`bidi` → `direction`, autospacing flags → `_autospacingBase`), have no
+ * attr representation and round-trip via `_originalFormatting` only
+ * (`frame`, `suppressLineNumbers`, `suppressAutoHyphens`), or sit outside
+ * the CT_PPrBase scope entirely (`runProperties`, `runInWithNext` — the
+ * paragraph-mark rPr) and so must never overwrite the live value on reject.
+ */
+const PPR_PARSER_ONLY_KEYS: ReadonlySet<string> = new Set([
+  "bidi",
+  "beforeAutospacing",
+  "afterAutospacing",
+  "runProperties",
+  "runInWithNext",
+  "frame",
+  "suppressLineNumbers",
+  "suppressAutoHyphens",
+  "numPrFromStyle",
+]);
+
+/**
+ * `ParagraphFormatting` keys inside the CT_PPrBase scope, used to rebuild
+ * `_originalFormatting` after a reject (old pPr wholesale within scope,
+ * paragraph-mark rPr fields preserved from the live original).
+ */
+const PPR_CHANGE_SCOPED_FORMATTING_KEYS = [
+  "styleId",
+  "numPr",
+  "alignment",
+  "bidi",
+  "spaceBefore",
+  "spaceAfter",
+  "lineSpacing",
+  "lineSpacingRule",
+  "beforeAutospacing",
+  "afterAutospacing",
+  "spacingExplicit",
+  "indentLeft",
+  "indentRight",
+  "indentFirstLine",
+  "hangingIndent",
+  "borders",
+  "shading",
+  "tabs",
+  "pageBreakBefore",
+  "keepNext",
+  "keepLines",
+  "widowControl",
+  "contextualSpacing",
+  "outlineLevel",
+  "frame",
+  "suppressLineNumbers",
+  "suppressAutoHyphens",
+] as const satisfies readonly (keyof ParagraphFormatting)[];
+
+/**
+ * Build the attr patch that rejecting one pPrChange applies to a paragraph:
+ * every in-scope key set to the stored previous value, or reset to `null`
+ * when the stored old pPr does not carry it. Keys the record captured beyond
+ * the scoped set (editor-created list suggestions snapshot list-rendering
+ * bookkeeping attrs) merge through 1:1 so their pre-change values restore too.
+ */
+export function paragraphRejectAttrPatch(
+  previousFormatting: Record<string, unknown> | null | undefined,
+): AttrPatch {
+  const prev = previousFormatting ?? {};
+  const patch: AttrPatch = {};
+  for (const key of PPR_CHANGE_SCOPED_ATTR_KEYS) {
+    patch[key] = Object.hasOwn(prev, key) ? (prev[key] ?? null) : null;
+  }
+  // Parser-shaped fallbacks for the two renamed attrs (attr-shaped records
+  // carrying `direction` / `_autospacingBase` already won above).
+  if (!Object.hasOwn(prev, "direction")) {
+    patch["direction"] = directionFromBidi(prev["bidi"] as boolean | null | undefined);
+  }
+  if (!Object.hasOwn(prev, "_autospacingBase")) {
+    patch["_autospacingBase"] = autospacingBaseFromFormatting(prev);
+  }
+  for (const [key, value] of Object.entries(prev)) {
+    if (PPR_CHANGE_SCOPED_ATTR_KEY_SET.has(key) || PPR_PARSER_ONLY_KEYS.has(key)) {
+      continue;
+    }
+    patch[key] = value ?? null;
+  }
+  return patch;
+}
+
+/**
+ * Rebuild the paragraph's `_originalFormatting` (the serializer's pPr source)
+ * after a reject: the stored old pPr wholesale within CT_PPrBase scope, with
+ * the paragraph-mark rPr fields (`runProperties`, `runInWithNext`) preserved
+ * from the live original — a pPrChange cannot store them, so a reject must
+ * not drop them.
+ */
+export function paragraphRejectOriginalFormatting(
+  previousFormatting: Record<string, unknown> | null | undefined,
+  liveOriginal: unknown,
+): ParagraphFormatting | null {
+  const prev = previousFormatting ?? {};
+  const result: Record<string, unknown> = {};
+  for (const key of PPR_CHANGE_SCOPED_FORMATTING_KEYS) {
+    const value = Object.hasOwn(prev, key) ? prev[key] : undefined;
+    if (value != null) {
+      result[key] = value;
+    }
+  }
+  const live = isRecord(liveOriginal) ? liveOriginal : {};
+  if (live["runProperties"] != null) {
+    result["runProperties"] = live["runProperties"];
+  }
+  if (live["runInWithNext"] != null) {
+    result["runInWithNext"] = live["runInWithNext"];
+  }
+  if (Object.keys(result).length === 0) {
+    return null;
+  }
+  // SAFETY: every key written above is a ParagraphFormatting key; values come
+  // from a stored ParagraphFormatting (or an attr-shaped snapshot whose
+  // overlapping keys share the same value shapes).
+  return result as ParagraphFormatting;
+}
+
+function autospacingBaseFromFormatting(prev: Record<string, unknown>): AttrPatch | null {
+  const before = prev["beforeAutospacing"] === true;
+  const after = prev["afterAutospacing"] === true;
+  if (!before && !after) {
+    return null;
+  }
+  const base: NonNullable<ParagraphAttrs["_autospacingBase"]> = {};
+  if (before) {
+    setAutospacingBaseValue(base, "before", prev["spaceBefore"]);
+  }
+  if (after) {
+    setAutospacingBaseValue(base, "after", prev["spaceAfter"]);
+  }
+  return base;
+}
+
+/**
+ * Rejected section properties: the stored old sectPr wholesale, preserving
+ * the live header/footer references — `EG_HdrFtrReferences` is not part of
+ * the `CT_SectPrBase` payload a `w:sectPrChange` stores (ECMA-376
+ * §17.13.5.32), so those children survive a reject. The caller re-attaches
+ * whatever `propertyChanges` remain unresolved.
+ */
+export function sectionRejectProperties(
+  live: SectionProperties,
+  previousProperties: SectionProperties | undefined,
+): SectionProperties {
+  const restored: SectionProperties = { ...previousProperties };
+  delete restored.propertyChanges;
+  if (live.headerReferences) {
+    restored.headerReferences = live.headerReferences;
+  } else {
+    delete restored.headerReferences;
+  }
+  if (live.footerReferences) {
+    restored.footerReferences = live.footerReferences;
+  } else {
+    delete restored.footerReferences;
+  }
+  return restored;
+}
+
+/**
+ * Attr patch for rejecting a `w:tblPrChange`: the stored old tblPr wholesale
+ * (`w:tblPrChange` stores the complete previous tblPr, so every tblPr-derived
+ * attr resets when absent). `columnWidths` comes from `w:tblGrid`, not tblPr,
+ * and is untouched.
+ */
+export function tableRejectAttrPatch(previousFormatting: TableFormatting | undefined): AttrPatch {
+  return {
+    styleId: previousFormatting?.styleId ?? null,
+    width: previousFormatting?.width?.value ?? null,
+    widthType: previousFormatting?.width?.type ?? null,
+    justification: previousFormatting?.justification ?? null,
+    floating: previousFormatting?.floating ?? null,
+    cellMargins: previousFormatting?.cellMargins
+      ? cellMarginsToAttr(previousFormatting.cellMargins)
+      : null,
+    look: previousFormatting?.look ?? null,
+    borders: previousFormatting?.borders ?? null,
+    _originalFormatting: previousFormatting ?? null,
+  };
+}
+
+/** Attr patch for rejecting a `w:trPrChange`: the stored old trPr wholesale. */
+export function tableRowRejectAttrPatch(
+  previousFormatting: TableRowFormatting | undefined,
+): AttrPatch {
+  return {
+    height: previousFormatting?.height?.value ?? null,
+    heightRule: previousFormatting?.heightRule ?? null,
+    isHeader: previousFormatting?.header ?? false,
+    hidden: previousFormatting?.hidden ?? null,
+    _originalFormatting: previousFormatting ?? null,
+  };
+}
+
+/**
+ * Attr patch for rejecting a `w:tcPrChange`: the stored old tcPr wholesale
+ * for the non-structural attrs. `gridSpan` / `vMerge` are structural in
+ * ProseMirror (`colspan` / `rowspan` shape the table grid); restoring them
+ * from the record would desync the grid without a full table restructure, so
+ * the live structure is kept and the rebuilt `_originalFormatting` inherits
+ * the live original's `gridSpan` / `vMerge` to stay consistent with it.
+ * (Word would also restore tracked merges; folio deliberately does not.)
+ */
+export function tableCellRejectAttrPatch(
+  previousFormatting: TableCellFormatting | undefined,
+  liveOriginalFormatting: TableCellFormatting | null | undefined,
+): AttrPatch {
+  const restoredOriginal: TableCellFormatting = { ...previousFormatting };
+  delete restoredOriginal.gridSpan;
+  delete restoredOriginal.vMerge;
+  if (liveOriginalFormatting?.gridSpan !== undefined) {
+    restoredOriginal.gridSpan = liveOriginalFormatting.gridSpan;
+  }
+  if (liveOriginalFormatting?.vMerge !== undefined) {
+    restoredOriginal.vMerge = liveOriginalFormatting.vMerge;
+  }
+  return {
+    width: previousFormatting?.width?.value ?? null,
+    widthType: previousFormatting?.width?.type ?? null,
+    verticalAlign: previousFormatting?.verticalAlign ?? null,
+    backgroundColor: previousFormatting?.shading?.fill?.rgb ?? null,
+    textDirection: previousFormatting?.textDirection ?? null,
+    noWrap: previousFormatting?.noWrap ?? null,
+    borders: previousFormatting?.borders ? cellBordersToAttr(previousFormatting.borders) : null,
+    margins: previousFormatting?.margins ? cellMarginsToAttr(previousFormatting.margins) : null,
+    _originalFormatting: Object.keys(restoredOriginal).length > 0 ? restoredOriginal : null,
+  };
+}
+
+type SideMargins = { top?: number; bottom?: number; left?: number; right?: number };
+
+function cellMarginsToAttr(margins: CellMargins): SideMargins {
+  const result: SideMargins = {};
+  if (margins.top?.value !== undefined) {
+    result.top = margins.top.value;
+  }
+  if (margins.bottom?.value !== undefined) {
+    result.bottom = margins.bottom.value;
+  }
+  if (margins.left?.value !== undefined) {
+    result.left = margins.left.value;
+  }
+  if (margins.right?.value !== undefined) {
+    result.right = margins.right.value;
+  }
+  return result;
+}
+
+type SideBorders = { top?: BorderSpec; bottom?: BorderSpec; left?: BorderSpec; right?: BorderSpec };
+
+function cellBordersToAttr(borders: NonNullable<TableCellFormatting["borders"]>): SideBorders {
+  const result: SideBorders = {};
+  if (borders.top) {
+    result.top = borders.top;
+  }
+  if (borders.bottom) {
+    result.bottom = borders.bottom;
+  }
+  if (borders.left) {
+    result.left = borders.left;
+  }
+  if (borders.right) {
+    result.right = borders.right;
+  }
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2281,6 +2281,7 @@ function convertPMTable(node: PMNode, documentCounts?: TrackedChangeCounts): Tab
         if (attrs.columnWidths) {
           minTable.columnWidths = attrs.columnWidths;
         }
+        restoreTablePropertyChanges(minTable, attrs);
         return minTable;
       }
     }
@@ -2293,7 +2294,19 @@ function convertPMTable(node: PMNode, documentCounts?: TrackedChangeCounts): Tab
   if (formatting) {
     table.formatting = formatting;
   }
+  restoreTablePropertyChanges(table, attrs);
   return table;
+}
+
+/**
+ * Restore `w:tblPrChange` entries that PM carried opaquely on the table attrs
+ * (same rationale as the paragraph `_propertyChanges` attr): they must survive
+ * an edit so the saved DOCX keeps the tracked property-change history.
+ */
+function restoreTablePropertyChanges(table: Table, attrs: TableAttrs): void {
+  if (Array.isArray(attrs.tblPrChange) && attrs.tblPrChange.length > 0) {
+    table.propertyChanges = [...attrs.tblPrChange];
+  }
 }
 
 type ActiveVerticalMerge = {
@@ -2523,6 +2536,11 @@ function convertPMTableRow(
   if (rowFormatting) {
     row.formatting = rowFormatting;
   }
+  // Restore `w:trPrChange` entries PM carried opaquely (see the paragraph
+  // `_propertyChanges` attr for the rationale).
+  if (Array.isArray(attrs.trPrChange) && attrs.trPrChange.length > 0) {
+    row.propertyChanges = [...attrs.trPrChange];
+  }
   return row;
 }
 
@@ -2626,6 +2644,11 @@ function convertPMTableCell(node: PMNode, documentCounts?: TrackedChangeCounts):
   const cellFormatting = tableCellAttrsToFormatting(attrs);
   if (cellFormatting) {
     cell.formatting = cellFormatting;
+  }
+  // Restore `w:tcPrChange` entries PM carried opaquely (see the paragraph
+  // `_propertyChanges` attr for the rationale).
+  if (Array.isArray(attrs.tcPrChange) && attrs.tcPrChange.length > 0) {
+    cell.propertyChanges = [...attrs.tcPrChange];
   }
   return cell;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1266,6 +1266,12 @@ function convertTable(
   if (table.formatting) {
     attrs._originalFormatting = table.formatting;
   }
+  // Carry `w:tblPrChange` opaquely through PM (same rationale as the
+  // paragraph `_propertyChanges` attr) so edits don't strip the tracked
+  // property-change history and accept/reject can resolve it.
+  if (table.propertyChanges && table.propertyChanges.length > 0) {
+    attrs.tblPrChange = [...table.propertyChanges];
+  }
 
   const conditionalStyles: {
     wholeTable?: TableConditionalStyle;
@@ -1429,6 +1435,10 @@ function convertTableRow(
   }
   if (row.formatting) {
     attrs._originalFormatting = row.formatting;
+  }
+  // Carry `w:trPrChange` opaquely through PM for round-trip + accept/reject.
+  if (row.propertyChanges && row.propertyChanges.length > 0) {
+    attrs.trPrChange = [...row.propertyChanges];
   }
 
   const numCells = row.cells.length;
@@ -1791,6 +1801,10 @@ function convertTableCell(
   }
   if (formatting) {
     attrs._originalFormatting = formatting;
+  }
+  // Carry `w:tcPrChange` opaquely through PM for round-trip + accept/reject.
+  if (cell.propertyChanges && cell.propertyChanges.length > 0) {
+    attrs.tcPrChange = [...cell.propertyChanges];
   }
   if (preserveVMergeRestart) {
     attrs._preserveVMergeRestart = true;

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -7,6 +7,7 @@
 
 import type { Command, EditorState } from "prosemirror-state";
 
+import { PPR_CHANGE_SCOPED_ATTR_KEYS } from "../../commands/propertyChangeScope";
 import { makeRevisionInfo, SUGGESTION_META } from "../../plugins/suggestionMode";
 import { createExtension } from "../create";
 import { goToNextCell, goToPrevCell } from "../nodes/TableExtension";
@@ -71,6 +72,18 @@ const LIST_FORMATTING_ATTRS = [
 
 function getPreviousListFormatting(attrs: Record<string, unknown>): Record<string, unknown> {
   const previousFormatting: Record<string, unknown> = {};
+  // Rejecting a pPrChange restores the stored record WHOLESALE within the
+  // CT_PPrBase scope (a scoped key absent from the record resets to null —
+  // see propertyChangeScope.ts). Snapshot every non-null in-scope attr so a
+  // reject cannot wipe formatting the list toggle never touched.
+  for (const key of PPR_CHANGE_SCOPED_ATTR_KEYS) {
+    const value = attrs[key];
+    if (value != null) {
+      previousFormatting[key] = value;
+    }
+  }
+  // List-rendering bookkeeping snapshots with explicit nulls: these attrs are
+  // outside the wholesale scope, so only recorded keys restore on reject.
   for (const key of LIST_FORMATTING_ATTRS) {
     previousFormatting[key] = attrs[key] ?? null;
   }

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -273,6 +273,7 @@ const tableSpec: NodeSpec = {
     look: { default: null },
     borders: { default: null },
     _originalFormatting: { default: null },
+    tblPrChange: { default: null },
   },
   parseDOM: [
     {
@@ -334,6 +335,7 @@ const tableRowSpec: NodeSpec = {
     isHeader: { default: false },
     hidden: { default: false },
     _originalFormatting: { default: null },
+    trPrChange: { default: null },
   },
   parseDOM: [{ tag: "tr" }],
   toDOM(node) {
@@ -494,6 +496,7 @@ const tableCellSpec: NodeSpec = {
     textDirection: { default: null },
     noWrap: { default: false },
     _originalFormatting: { default: null },
+    tcPrChange: { default: null },
     _preserveVMergeRestart: { default: null },
     _docxVMergeContinuationCells: { default: null },
   },
@@ -558,6 +561,7 @@ const tableHeaderSpec: NodeSpec = {
     textDirection: { default: null },
     noWrap: { default: false },
     _originalFormatting: { default: null },
+    tcPrChange: { default: null },
     _preserveVMergeRestart: { default: null },
     _docxVMergeContinuationCells: { default: null },
   },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -24,9 +24,12 @@ import type {
   NumberFormat,
   TableBorders,
   TableFormatting,
+  TablePropertyChange,
   TableRowFormatting,
+  TableRowPropertyChange,
   TableCell,
   TableCellFormatting,
+  TableCellPropertyChange,
   TableWidthType,
   SectionProperties,
   ShapeFill,
@@ -554,6 +557,8 @@ export type TableAttrs = {
   borders?: TableBorders;
   /** Original table formatting from DOCX for lossless round-trip serialization */
   _originalFormatting?: TableFormatting;
+  /** Tracked table property changes (w:tblPrChange) for round-trip + accept/reject */
+  tblPrChange?: TablePropertyChange[];
 };
 
 /**
@@ -570,6 +575,8 @@ export type TableRowAttrs = {
   hidden?: boolean;
   /** Original row formatting from DOCX for lossless round-trip serialization */
   _originalFormatting?: TableRowFormatting;
+  /** Tracked row property changes (w:trPrChange) for round-trip + accept/reject */
+  trPrChange?: TableRowPropertyChange[];
 };
 
 /**
@@ -605,6 +612,8 @@ export type TableCellAttrs = {
   margins?: { top?: number; bottom?: number; left?: number; right?: number };
   /** Original cell formatting from DOCX for lossless round-trip serialization */
   _originalFormatting?: TableCellFormatting;
+  /** Tracked cell property changes (w:tcPrChange) for round-trip + accept/reject */
+  tcPrChange?: TableCellPropertyChange[];
   /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
   _preserveVMergeRestart?: boolean;
   /** Original DOCX vMerge continuation cells skipped into this PM rowspan. */


### PR DESCRIPTION
## What

Stacked on #174. Completes tracked-change resolution for property changes, which were previously partial (pPrChange: merge-only) or display-only (sectPrChange, table property changes).

- **`w:pPrChange` reject restores the old pPr wholesale within CT_PPrBase scope.** Previously only keys present in the stored old properties were merged back, so a property the tracked change *added* survived rejection. A change-scoped attr key set (derived from `paragraphFormattingToAttrs`) now resets change-added keys while still preserving out-of-scope attrs (inline `sectPr`, paragraph-mark rPr → `defaultTextFormatting`, identity attrs). Reject also rebuilds `_originalFormatting` so the serializer emits the restored pPr rather than the rejected one.
- **`w:sectPrChange` accept/reject implemented** (was display-only). Reject restores the stored previous section properties while keeping live header/footer references, which `CT_SectPrBase` cannot carry; accept keeps live values. Both clear only the matched records.
- **Table property changes (`w:tblPrChange`/`w:trPrChange`/`w:tcPrChange`) accept/reject implemented.** These records previously never reached the ProseMirror document at all, so they were silently dropped on any save; they are now carried on table/row/cell node attrs (activating the existing `extractTrackedChanges` read paths), survive the round-trip, and resolve on accept/reject. Cell rejects deliberately keep live `gridSpan`/`vMerge` (structural in PM; restoring them would desync the grid) — documented inline.
- `FolioDocxReviewer.acceptAll()`/`rejectAll()` counts now include section and table property changes.

## Notes for review
- Known approximation (pre-existing, now documented): reject resets scoped keys to `null` even when a paragraph style would supply a value; the style-resolved value returns on reload, since the command layer has no style resolver.
- `getPreviousListFormatting` (suggestion-mode list edits) now snapshots all non-null scoped attrs, not just list attrs — otherwise the wholesale reject would wipe untouched formatting recorded nowhere.
- A body-level trailing `sectPr` change is unreachable by reject-all (that sectPr never travels through PM); unchanged behavior, out of scope.