### PR TITLE
feat: export standard-schema projection of the document-operation contract

### DIFF
--- a/.changeset/shiny-schemas-export.md
+++ b/.changeset/shiny-schemas-export.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-agents": minor
+---
+
+Export a standard-schema projection of the versioned document-operation contract: `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` (full operation union), `FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA` (versioned batch envelope), and `folioDocumentOperationBatchSchema` — a Standard Schema V1 object whose validation delegates to `parseFolioDocumentOperationBatch` (the parser stays the single source of truth) with the JSON schema attached for LLM tool definitions. The `suggest_changes` tool schema now derives from the shared constants, with its deliberate narrowings expressed explicitly; downstream consumers can drop hand-maintained mirrors of the contract.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -78,6 +78,1474 @@ export const FOLIO_AGENT_TOOL_NAMES: {
 export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[];
 
 // @public
+export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
+    readonly type: "object";
+    readonly description: string;
+    readonly properties: {
+        readonly version: {
+            readonly type: "integer";
+            readonly enum: readonly [1];
+            readonly description: "Document-operation contract version.";
+        };
+        readonly operations: {
+            readonly type: "array";
+            readonly description: "The operations to apply, in order.";
+            readonly items: {
+                readonly description: string;
+                readonly oneOf: readonly [{
+                    readonly type: "object";
+                    readonly description: "Replace an exact text match inside one block.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["replaceInBlock"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly find: {
+                            readonly type: "string";
+                            readonly description: "The exact text to find within the block.";
+                        };
+                        readonly replace: {
+                            readonly type: "string";
+                            readonly description: "The replacement text.";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId", "find", "replace"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Replace the text covered by a range handle.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["replaceRange"];
+                        };
+                        readonly range: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly type: {
+                                    readonly type: "string";
+                                    readonly enum: readonly ["textRange"];
+                                };
+                                readonly story: {
+                                    readonly type: "string";
+                                    readonly enum: readonly ["main"];
+                                };
+                                readonly blockId: {
+                                    readonly type: "string";
+                                    readonly minLength: 1;
+                                };
+                                readonly startOffset: {
+                                    readonly type: "integer";
+                                    readonly minimum: 0;
+                                };
+                                readonly endOffset: {
+                                    readonly type: "integer";
+                                    readonly minimum: 1;
+                                    readonly description: "Exclusive end offset; must be greater than `startOffset`.";
+                                };
+                                readonly selectedTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the selected text, used to detect stale ranges.";
+                                };
+                            };
+                            readonly required: readonly ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly replace: {
+                            readonly type: "string";
+                            readonly description: "The replacement text.";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "range", "replace"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Attach a comment to the text covered by a range handle.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["commentOnRange"];
+                        };
+                        readonly range: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly type: {
+                                    readonly type: "string";
+                                    readonly enum: readonly ["textRange"];
+                                };
+                                readonly story: {
+                                    readonly type: "string";
+                                    readonly enum: readonly ["main"];
+                                };
+                                readonly blockId: {
+                                    readonly type: "string";
+                                    readonly minLength: 1;
+                                };
+                                readonly startOffset: {
+                                    readonly type: "integer";
+                                    readonly minimum: 0;
+                                };
+                                readonly endOffset: {
+                                    readonly type: "integer";
+                                    readonly minimum: 1;
+                                    readonly description: "Exclusive end offset; must be greater than `startOffset`.";
+                                };
+                                readonly selectedTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the selected text, used to detect stale ranges.";
+                                };
+                            };
+                            readonly required: readonly ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "range", "comment"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: string;
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["formatRange"];
+                        };
+                        readonly range: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly type: {
+                                    readonly type: "string";
+                                    readonly enum: readonly ["textRange"];
+                                };
+                                readonly story: {
+                                    readonly type: "string";
+                                    readonly enum: readonly ["main"];
+                                };
+                                readonly blockId: {
+                                    readonly type: "string";
+                                    readonly minLength: 1;
+                                };
+                                readonly startOffset: {
+                                    readonly type: "integer";
+                                    readonly minimum: 0;
+                                };
+                                readonly endOffset: {
+                                    readonly type: "integer";
+                                    readonly minimum: 1;
+                                    readonly description: "Exclusive end offset; must be greater than `startOffset`.";
+                                };
+                                readonly selectedTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the selected text, used to detect stale ranges.";
+                                };
+                            };
+                            readonly required: readonly ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly formatting: {
+                            readonly type: "object";
+                            readonly description: "Inline formatting to apply; at least one property is required.";
+                            readonly properties: {
+                                readonly bold: {
+                                    readonly type: "boolean";
+                                };
+                                readonly italic: {
+                                    readonly type: "boolean";
+                                };
+                                readonly underline: {
+                                    readonly type: "boolean";
+                                };
+                            };
+                            readonly minProperties: 1;
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "range", "formatting"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Insert a new paragraph after the anchor block.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["insertAfterBlock"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly text: {
+                            readonly type: "string";
+                            readonly description: "The paragraph text to insert.";
+                        };
+                        readonly inheritFormatting: {
+                            readonly type: "boolean";
+                            readonly description: "Inherit the anchor block's formatting for the inserted paragraph.";
+                        };
+                        readonly pageBreakBefore: {
+                            readonly type: "boolean";
+                            readonly description: "Start the inserted paragraph on a new page (`pageBreakBefore`).";
+                        };
+                        readonly styleId: {
+                            readonly type: "string";
+                            readonly description: "Paragraph style id for the inserted block (e.g. \"ClauseHeading1\").";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId", "text"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Insert a new paragraph before the anchor block.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["insertBeforeBlock"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly text: {
+                            readonly type: "string";
+                            readonly description: "The paragraph text to insert.";
+                        };
+                        readonly inheritFormatting: {
+                            readonly type: "boolean";
+                            readonly description: "Inherit the anchor block's formatting for the inserted paragraph.";
+                        };
+                        readonly pageBreakBefore: {
+                            readonly type: "boolean";
+                            readonly description: "Start the inserted paragraph on a new page (`pageBreakBefore`).";
+                        };
+                        readonly styleId: {
+                            readonly type: "string";
+                            readonly description: "Paragraph style id for the inserted block (e.g. \"ClauseHeading1\").";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId", "text"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Replace one block's entire text.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["replaceBlock"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly text: {
+                            readonly type: "string";
+                            readonly description: "The new block text.";
+                        };
+                        readonly preserveFormatting: {
+                            readonly type: "boolean";
+                            readonly description: "Keep the block's existing formatting for the replacement text.";
+                        };
+                        readonly styleId: {
+                            readonly type: "string";
+                            readonly description: "Paragraph style id to set on the replaced block.";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId", "text"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Delete one block.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["deleteBlock"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Attach a comment to one block, optionally quoting text within it.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["commentOnBlock"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly quote: {
+                            readonly type: "string";
+                            readonly description: "Exact text within the block the comment is about.";
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId", "comment"];
+                    readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: string;
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["insertSignatureTable"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly position: {
+                            readonly type: "string";
+                            readonly enum: readonly ["after", "before"];
+                            readonly description: "Insert after the anchor block (default) or before it. Defaults to \"after\".";
+                        };
+                        readonly parties: {
+                            readonly type: "array";
+                            readonly description: "The signing parties, one table cell per party.";
+                            readonly items: {
+                                readonly type: "object";
+                                readonly properties: {
+                                    readonly name: {
+                                        readonly type: "string";
+                                        readonly description: "Party name (rendered bold).";
+                                    };
+                                    readonly signatory: {
+                                        readonly type: "string";
+                                        readonly description: "Name of the person signing.";
+                                    };
+                                    readonly title: {
+                                        readonly type: "string";
+                                        readonly description: "Signatory title (rendered in italics).";
+                                    };
+                                };
+                                readonly required: readonly ["name"];
+                                readonly additionalProperties: false;
+                            };
+                        };
+                        readonly comment: {
+                            readonly type: "object";
+                            readonly description: "A comment attached to the text affected by this operation.";
+                            readonly properties: {
+                                readonly text: {
+                                    readonly type: "string";
+                                    readonly description: "The comment body.";
+                                };
+                            };
+                            readonly required: readonly ["text"];
+                            readonly additionalProperties: false;
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId", "parties"];
+                    readonly additionalProperties: false;
+                }];
+            };
+        };
+        readonly mode: {
+            readonly type: "string";
+            readonly enum: readonly ["direct", "tracked-changes"];
+            readonly description: string;
+        };
+        readonly atomic: {
+            readonly type: "boolean";
+            readonly description: "Reject the whole batch when any operation would be skipped.";
+        };
+        readonly dryRun: {
+            readonly type: "boolean";
+            readonly description: "Preview the batch without mutating the document.";
+        };
+    };
+    readonly required: readonly ["version", "operations"];
+    readonly additionalProperties: false;
+};
+
+// @public
+export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
+    readonly description: string;
+    readonly oneOf: readonly [{
+        readonly type: "object";
+        readonly description: "Replace an exact text match inside one block.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["replaceInBlock"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly find: {
+                readonly type: "string";
+                readonly description: "The exact text to find within the block.";
+            };
+            readonly replace: {
+                readonly type: "string";
+                readonly description: "The replacement text.";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId", "find", "replace"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Replace the text covered by a range handle.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["replaceRange"];
+            };
+            readonly range: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly type: {
+                        readonly type: "string";
+                        readonly enum: readonly ["textRange"];
+                    };
+                    readonly story: {
+                        readonly type: "string";
+                        readonly enum: readonly ["main"];
+                    };
+                    readonly blockId: {
+                        readonly type: "string";
+                        readonly minLength: 1;
+                    };
+                    readonly startOffset: {
+                        readonly type: "integer";
+                        readonly minimum: 0;
+                    };
+                    readonly endOffset: {
+                        readonly type: "integer";
+                        readonly minimum: 1;
+                        readonly description: "Exclusive end offset; must be greater than `startOffset`.";
+                    };
+                    readonly selectedTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the selected text, used to detect stale ranges.";
+                    };
+                };
+                readonly required: readonly ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"];
+                readonly additionalProperties: false;
+            };
+            readonly replace: {
+                readonly type: "string";
+                readonly description: "The replacement text.";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "range", "replace"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Attach a comment to the text covered by a range handle.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["commentOnRange"];
+            };
+            readonly range: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly type: {
+                        readonly type: "string";
+                        readonly enum: readonly ["textRange"];
+                    };
+                    readonly story: {
+                        readonly type: "string";
+                        readonly enum: readonly ["main"];
+                    };
+                    readonly blockId: {
+                        readonly type: "string";
+                        readonly minLength: 1;
+                    };
+                    readonly startOffset: {
+                        readonly type: "integer";
+                        readonly minimum: 0;
+                    };
+                    readonly endOffset: {
+                        readonly type: "integer";
+                        readonly minimum: 1;
+                        readonly description: "Exclusive end offset; must be greater than `startOffset`.";
+                    };
+                    readonly selectedTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the selected text, used to detect stale ranges.";
+                    };
+                };
+                readonly required: readonly ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"];
+                readonly additionalProperties: false;
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "range", "comment"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: string;
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["formatRange"];
+            };
+            readonly range: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly type: {
+                        readonly type: "string";
+                        readonly enum: readonly ["textRange"];
+                    };
+                    readonly story: {
+                        readonly type: "string";
+                        readonly enum: readonly ["main"];
+                    };
+                    readonly blockId: {
+                        readonly type: "string";
+                        readonly minLength: 1;
+                    };
+                    readonly startOffset: {
+                        readonly type: "integer";
+                        readonly minimum: 0;
+                    };
+                    readonly endOffset: {
+                        readonly type: "integer";
+                        readonly minimum: 1;
+                        readonly description: "Exclusive end offset; must be greater than `startOffset`.";
+                    };
+                    readonly selectedTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the selected text, used to detect stale ranges.";
+                    };
+                };
+                readonly required: readonly ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"];
+                readonly additionalProperties: false;
+            };
+            readonly formatting: {
+                readonly type: "object";
+                readonly description: "Inline formatting to apply; at least one property is required.";
+                readonly properties: {
+                    readonly bold: {
+                        readonly type: "boolean";
+                    };
+                    readonly italic: {
+                        readonly type: "boolean";
+                    };
+                    readonly underline: {
+                        readonly type: "boolean";
+                    };
+                };
+                readonly minProperties: 1;
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "range", "formatting"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Insert a new paragraph after the anchor block.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["insertAfterBlock"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly text: {
+                readonly type: "string";
+                readonly description: "The paragraph text to insert.";
+            };
+            readonly inheritFormatting: {
+                readonly type: "boolean";
+                readonly description: "Inherit the anchor block's formatting for the inserted paragraph.";
+            };
+            readonly pageBreakBefore: {
+                readonly type: "boolean";
+                readonly description: "Start the inserted paragraph on a new page (`pageBreakBefore`).";
+            };
+            readonly styleId: {
+                readonly type: "string";
+                readonly description: "Paragraph style id for the inserted block (e.g. \"ClauseHeading1\").";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId", "text"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Insert a new paragraph before the anchor block.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["insertBeforeBlock"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly text: {
+                readonly type: "string";
+                readonly description: "The paragraph text to insert.";
+            };
+            readonly inheritFormatting: {
+                readonly type: "boolean";
+                readonly description: "Inherit the anchor block's formatting for the inserted paragraph.";
+            };
+            readonly pageBreakBefore: {
+                readonly type: "boolean";
+                readonly description: "Start the inserted paragraph on a new page (`pageBreakBefore`).";
+            };
+            readonly styleId: {
+                readonly type: "string";
+                readonly description: "Paragraph style id for the inserted block (e.g. \"ClauseHeading1\").";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId", "text"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Replace one block's entire text.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["replaceBlock"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly text: {
+                readonly type: "string";
+                readonly description: "The new block text.";
+            };
+            readonly preserveFormatting: {
+                readonly type: "boolean";
+                readonly description: "Keep the block's existing formatting for the replacement text.";
+            };
+            readonly styleId: {
+                readonly type: "string";
+                readonly description: "Paragraph style id to set on the replaced block.";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId", "text"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Delete one block.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["deleteBlock"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Attach a comment to one block, optionally quoting text within it.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["commentOnBlock"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly quote: {
+                readonly type: "string";
+                readonly description: "Exact text within the block the comment is about.";
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId", "comment"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: string;
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["insertSignatureTable"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly position: {
+                readonly type: "string";
+                readonly enum: readonly ["after", "before"];
+                readonly description: "Insert after the anchor block (default) or before it. Defaults to \"after\".";
+            };
+            readonly parties: {
+                readonly type: "array";
+                readonly description: "The signing parties, one table cell per party.";
+                readonly items: {
+                    readonly type: "object";
+                    readonly properties: {
+                        readonly name: {
+                            readonly type: "string";
+                            readonly description: "Party name (rendered bold).";
+                        };
+                        readonly signatory: {
+                            readonly type: "string";
+                            readonly description: "Name of the person signing.";
+                        };
+                        readonly title: {
+                            readonly type: "string";
+                            readonly description: "Signatory title (rendered in italics).";
+                        };
+                    };
+                    readonly required: readonly ["name"];
+                    readonly additionalProperties: false;
+                };
+            };
+            readonly comment: {
+                readonly type: "object";
+                readonly description: "A comment attached to the text affected by this operation.";
+                readonly properties: {
+                    readonly text: {
+                        readonly type: "string";
+                        readonly description: "The comment body.";
+                    };
+                };
+                readonly required: readonly ["text"];
+                readonly additionalProperties: false;
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId", "parties"];
+        readonly additionalProperties: false;
+    }];
+};
+
+// @public
 export type FolioAgentApplyOperationsSummary = {
     version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
     applied: {
@@ -195,6 +1663,9 @@ export type FolioAgentVersionDiff = FolioVersionDiff;
 
 // @public
 export type FolioAgentVersionDiffSegment = FolioVersionDiffSegment;
+
+// @public
+export const folioDocumentOperationBatchSchema: FolioDocumentOperationBatchSchema;
 
 // @public
 export type FolioToolCallResult = {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -14,6 +14,11 @@ export type {
 } from "./compare";
 export { compareDocxVersions, formatVersionDiffForLLM } from "./compare";
 export { executeFolioToolCall } from "./execute";
+export {
+  FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA,
+  FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA,
+  folioDocumentOperationBatchSchema,
+} from "./operation-schema";
 export type { ParseAddCommentResult, ParseSuggestChangesResult } from "./parse";
 export { parseAddCommentInput, parseSuggestChangesInput } from "./parse";
 export type { AnthropicToolDefinition, OpenAIToolDefinition } from "./providers";

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -3,14 +3,24 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 
 import {
+  FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+  FOLIO_DOCUMENT_OPERATION_TYPES,
   FolioDocxReviewer,
+  InvalidFolioDocumentOperationBatchError,
   parseFolioDocumentOperationBatch,
+  UnsupportedFolioDocumentOperationVersionError,
   type FolioDocumentOperationBatch,
   type FolioDocumentOperationResult,
+  type FolioDocumentOperationType,
 } from "@stll/folio-core/server";
 
 import { createEditorRefBridge, type FolioAgentEditorRefLike } from "./bridges/editor-ref";
 import { createReviewerBridge } from "./bridges/reviewer";
+import {
+  FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA,
+  FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA,
+  folioDocumentOperationBatchSchema,
+} from "./operation-schema";
 
 const AUTHOR = "Conformance";
 const SOURCE_PATH = path.join(
@@ -208,6 +218,325 @@ describe("document operation cross-surface conformance", () => {
       });
       expect(output.contentAfter, output.name).toBe(output.contentBefore);
       expect(output.changes, output.name).toEqual([]);
+    }
+  });
+});
+
+/**
+ * Targeted structural JSON Schema checker (no ajv): supports exactly the
+ * keywords the exported contract schemas use, so a keyword the checker does
+ * not know cannot silently pass.
+ */
+type JsonSchemaNode = {
+  readonly type?: string;
+  readonly enum?: readonly unknown[];
+  readonly pattern?: string;
+  readonly minimum?: number;
+  readonly minLength?: number;
+  readonly minProperties?: number;
+  readonly properties?: Readonly<Record<string, JsonSchemaNode>>;
+  readonly required?: readonly string[];
+  readonly additionalProperties?: boolean;
+  readonly items?: JsonSchemaNode;
+  readonly oneOf?: readonly JsonSchemaNode[];
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const admitsObject = (schema: JsonSchemaNode, value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (schema.required?.some((key) => !(key in value))) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  if (schema.minProperties !== undefined && keys.length < schema.minProperties) {
+    return false;
+  }
+  const properties = schema.properties ?? {};
+  return keys.every((key) => {
+    const propertySchema = properties[key];
+    if (propertySchema === undefined) {
+      return schema.additionalProperties !== false;
+    }
+    return admits(propertySchema, value[key]);
+  });
+};
+
+const admits = (schema: JsonSchemaNode, value: unknown): boolean => {
+  if (schema.oneOf !== undefined) {
+    // oneOf semantics: exactly one variant must admit the value, so the union
+    // stays a real discriminated union.
+    return schema.oneOf.filter((variant) => admits(variant, value)).length === 1;
+  }
+  if (schema.enum !== undefined && !schema.enum.includes(value)) {
+    return false;
+  }
+  switch (schema.type) {
+    case "string":
+      return (
+        typeof value === "string" &&
+        (schema.minLength === undefined || value.length >= schema.minLength) &&
+        (schema.pattern === undefined || new RegExp(schema.pattern, "u").test(value))
+      );
+    case "integer":
+      return (
+        typeof value === "number" &&
+        Number.isInteger(value) &&
+        (schema.minimum === undefined || value >= schema.minimum)
+      );
+    case "boolean":
+      return typeof value === "boolean";
+    case "array": {
+      if (!Array.isArray(value)) {
+        return false;
+      }
+      const { items } = schema;
+      return items === undefined || value.every((item) => admits(items, item));
+    }
+    case "object":
+      return admitsObject(schema, value);
+    default:
+      return true;
+  }
+};
+
+const OPERATION_SCHEMA: JsonSchemaNode = FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA;
+const BATCH_SCHEMA: JsonSchemaNode = FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA;
+
+const CONTRACT_RANGE = {
+  type: "textRange",
+  story: "main",
+  blockId: "0304003A",
+  startOffset: 0,
+  endOffset: 5,
+  selectedTextHash: "h1a2b3",
+} as const;
+
+/**
+ * One representative fixture per contract operation type, exercising every
+ * optional field the parser accepts for that type at least once across the
+ * set.
+ */
+const CONTRACT_OPERATION_FIXTURES: Record<FolioDocumentOperationType, Record<string, unknown>> = {
+  replaceInBlock: {
+    id: "op-replace-in-block",
+    type: "replaceInBlock",
+    blockId: "0304003A",
+    find: "Heading",
+    replace: "Intro",
+    comment: { text: "Tighten the heading." },
+    severity: "low",
+    area: "Style",
+    precondition: { blockTextHash: "h1a2b3" },
+  },
+  replaceRange: {
+    id: "op-replace-range",
+    type: "replaceRange",
+    range: CONTRACT_RANGE,
+    replace: "Intro",
+    comment: { text: "Reworded." },
+  },
+  commentOnRange: {
+    id: "op-comment-on-range",
+    type: "commentOnRange",
+    range: CONTRACT_RANGE,
+    comment: { text: "Check this clause." },
+  },
+  formatRange: {
+    id: "op-format-range",
+    type: "formatRange",
+    range: CONTRACT_RANGE,
+    formatting: { bold: true, underline: false },
+  },
+  insertAfterBlock: {
+    id: "op-insert-after",
+    type: "insertAfterBlock",
+    blockId: "0304003A",
+    text: "New paragraph.",
+    inheritFormatting: true,
+    pageBreakBefore: true,
+    styleId: "Heading1",
+  },
+  insertBeforeBlock: {
+    id: "op-insert-before",
+    type: "insertBeforeBlock",
+    blockId: "0304003A",
+    text: "New paragraph.",
+  },
+  replaceBlock: {
+    id: "op-replace-block",
+    type: "replaceBlock",
+    blockId: "0304003A",
+    text: "Replacement text.",
+    preserveFormatting: true,
+    styleId: "Normal",
+  },
+  deleteBlock: {
+    id: "op-delete-block",
+    type: "deleteBlock",
+    blockId: "0304003A",
+    comment: { text: "Redundant." },
+  },
+  commentOnBlock: {
+    id: "op-comment-on-block",
+    type: "commentOnBlock",
+    blockId: "0304003A",
+    quote: "Heading",
+    comment: { text: "Rename this?" },
+  },
+  insertSignatureTable: {
+    id: "op-signature-table",
+    type: "insertSignatureTable",
+    blockId: "0304003A",
+    position: "before",
+    parties: [{ name: "Acme s.r.o.", signatory: "Jane Doe", title: "CEO" }],
+  },
+};
+
+const variantTypeOf = (variant: JsonSchemaNode): unknown => variant.properties?.["type"]?.enum?.[0];
+
+const variantForType = (type: FolioDocumentOperationType): JsonSchemaNode => {
+  const variant = OPERATION_SCHEMA.oneOf?.find((candidate) => variantTypeOf(candidate) === type);
+  if (variant === undefined) {
+    throw new Error(`no schema variant for operation type "${type}"`);
+  }
+  return variant;
+};
+
+describe("document operation contract JSON schema conformance", () => {
+  test("the schema union covers exactly the contract's operation types", () => {
+    const variantTypes = (OPERATION_SCHEMA.oneOf ?? []).map(variantTypeOf);
+    expect(variantTypes).toEqual([...FOLIO_DOCUMENT_OPERATION_TYPES]);
+  });
+
+  test("every operation type round-trips the parser and is admitted by the schema", () => {
+    for (const type of FOLIO_DOCUMENT_OPERATION_TYPES) {
+      const operation = CONTRACT_OPERATION_FIXTURES[type];
+      const batch = {
+        version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+        operations: [operation],
+        mode: "direct",
+        atomic: true,
+        dryRun: true,
+      };
+      const parsed = parseFolioDocumentOperationBatch(batch);
+      expect(JSON.parse(JSON.stringify(parsed)), type).toEqual(batch);
+      expect(admits(OPERATION_SCHEMA, operation), type).toBe(true);
+      expect(admits(BATCH_SCHEMA, batch), type).toBe(true);
+    }
+  });
+
+  test("rejects a wrong contract version in both the parser and the schema", () => {
+    const wrongVersion = { version: 2, operations: [] };
+    expect(() => parseFolioDocumentOperationBatch(wrongVersion)).toThrow(
+      UnsupportedFolioDocumentOperationVersionError,
+    );
+    expect(admits(BATCH_SCHEMA, wrongVersion)).toBe(false);
+  });
+
+  test("rejects an unknown operation type in both the parser and the schema", () => {
+    const unknownType = { id: "op-unknown", type: "renameBlock", blockId: "0304003A" };
+    expect(() =>
+      parseFolioDocumentOperationBatch({ version: 1, operations: [unknownType] }),
+    ).toThrow(InvalidFolioDocumentOperationBatchError);
+    expect(admits(OPERATION_SCHEMA, unknownType)).toBe(false);
+  });
+
+  test("rejects an unexpected property in both the parser and the schema", () => {
+    const extraProperty = { ...CONTRACT_OPERATION_FIXTURES.deleteBlock, bogus: true };
+    expect(() =>
+      parseFolioDocumentOperationBatch({ version: 1, operations: [extraProperty] }),
+    ).toThrow(InvalidFolioDocumentOperationBatchError);
+    expect(admits(OPERATION_SCHEMA, extraProperty)).toBe(false);
+  });
+
+  test("rejects each missing required field in both the parser and the schema", () => {
+    for (const type of FOLIO_DOCUMENT_OPERATION_TYPES) {
+      for (const missingKey of variantForType(type).required ?? []) {
+        const { [missingKey]: _removed, ...broken } = CONTRACT_OPERATION_FIXTURES[type];
+        const label = `${type} without ${missingKey}`;
+        expect(
+          () => parseFolioDocumentOperationBatch({ version: 1, operations: [broken] }),
+          label,
+        ).toThrow(InvalidFolioDocumentOperationBatchError);
+        expect(admits(OPERATION_SCHEMA, broken), label).toBe(false);
+      }
+    }
+  });
+});
+
+describe("document operation batch standard schema", () => {
+  const validate = folioDocumentOperationBatchSchema["~standard"].validate;
+
+  test("exposes the standard-schema surface and the attached JSON schema", () => {
+    expect(folioDocumentOperationBatchSchema["~standard"].version).toBe(1);
+    expect(folioDocumentOperationBatchSchema["~standard"].vendor).toBe("folio");
+    expect(folioDocumentOperationBatchSchema.jsonSchema).toBe(
+      FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA,
+    );
+  });
+
+  test("returns the parser's exact output for a valid batch", () => {
+    const batch = {
+      version: 1,
+      operations: [CONTRACT_OPERATION_FIXTURES.replaceInBlock],
+      mode: "tracked-changes",
+    };
+    const result = validate(batch);
+    if (result.issues !== undefined) {
+      throw new Error("expected a success result");
+    }
+    expect(result.value).toEqual(parseFolioDocumentOperationBatch(batch));
+  });
+
+  test("returns issues with a path for an invalid operation instead of throwing", () => {
+    const result = validate({
+      version: 1,
+      operations: [{ id: "op-1", type: "deleteBlock" }],
+    });
+    if (result.issues === undefined) {
+      throw new Error("expected a failure result");
+    }
+    expect(result.issues).toEqual([
+      {
+        message: "Invalid document operation batch at $.operations[0].blockId: expected a string.",
+        path: ["operations", 0, "blockId"],
+      },
+    ]);
+  });
+
+  test("returns a version issue for an unsupported contract version", () => {
+    const result = validate({ version: 2, operations: [] });
+    if (result.issues === undefined) {
+      throw new Error("expected a failure result");
+    }
+    expect(result.issues).toEqual([
+      { message: "Unsupported document operation contract version.", path: ["version"] },
+    ]);
+  });
+
+  test("never throws, whatever the input", () => {
+    const inputs: unknown[] = [
+      undefined,
+      null,
+      42,
+      "batch",
+      [],
+      {},
+      { version: "1", operations: [] },
+      { version: 1 },
+      { version: 1, operations: [{}] },
+      { version: 1, operations: [{ id: "a", type: "deleteBlock", blockId: "b" }], mode: "bulk" },
+    ];
+    for (const input of inputs) {
+      const result = validate(input);
+      expect(result.issues, JSON.stringify(input)).toBeDefined();
+      const issue = result.issues?.at(0);
+      expect(typeof issue?.message, JSON.stringify(input)).toBe("string");
+      expect(issue?.message.length, JSON.stringify(input)).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -1,0 +1,467 @@
+/**
+ * Reusable projections of folio's versioned document-operation contract for
+ * tool builders: a JSON Schema for one operation, a JSON Schema for the
+ * versioned batch envelope, and a Standard Schema V1 wrapper around
+ * `parseFolioDocumentOperationBatch` so downstream tool definitions (e.g.
+ * TanStack AI tools) can consume the contract directly instead of
+ * hand-mirroring it in valibot/zod.
+ *
+ * The strict throwing parser in `@stll/folio-core` stays the single source of
+ * truth for semantics; everything here is a projection of it. Constraints
+ * JSON Schema cannot express (`endOffset > startOffset`, unique operation
+ * ids within a batch, per-type mode support) are noted in `description`s and
+ * enforced by the parser.
+ */
+
+import {
+  FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+  FOLIO_DOCUMENT_OPERATION_MODES,
+  InvalidFolioDocumentOperationBatchError,
+  parseFolioDocumentOperationBatch,
+  UnsupportedFolioDocumentOperationVersionError,
+  type FolioDocumentOperationBatch,
+} from "@stll/folio-core/server";
+
+/**
+ * Pattern for the normalized text hashes the contract uses to detect stale
+ * targets (`selectedTextHash`, `precondition.blockTextHash`). Mirrors the
+ * parser's check in `@stll/folio-core`'s `document-operations.ts`.
+ */
+const NORMALIZED_TEXT_HASH_PATTERN = "^h[0-9a-z]+$";
+
+/**
+ * JSON Schema for the contract's `textRange` handle (a serializable range
+ * over the visible text of one main-story block, as returned by `find_text`
+ * style tools). Shared between {@link FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA}
+ * and the `suggest_changes` tool schema in `tools.ts` so the two cannot
+ * drift. `endOffset` must be greater than `startOffset`; JSON Schema cannot
+ * express that relation, the parser enforces it.
+ */
+export const FOLIO_TEXT_RANGE_JSON_SCHEMA = {
+  type: "object",
+  description:
+    "A range over the visible text of one main-story block. Offsets are zero-based UTF-16 " +
+    "boundaries; `endOffset` must be greater than `startOffset`. Copy range objects verbatim " +
+    "from the tool that produced them — `selectedTextHash` makes a shifted or edited " +
+    "selection fail as stale instead of hitting the wrong text.",
+  properties: {
+    type: { type: "string", enum: ["textRange"] },
+    story: { type: "string", enum: ["main"] },
+    blockId: { type: "string", minLength: 1 },
+    startOffset: { type: "integer", minimum: 0 },
+    endOffset: {
+      type: "integer",
+      minimum: 1,
+      description: "Exclusive end offset; must be greater than `startOffset`.",
+    },
+    selectedTextHash: {
+      type: "string",
+      pattern: NORMALIZED_TEXT_HASH_PATTERN,
+      description: "Normalized hash of the selected text, used to detect stale ranges.",
+    },
+  },
+  required: ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"],
+  additionalProperties: false,
+} as const;
+
+const preconditionJsonSchema = {
+  type: "object",
+  description:
+    "Optional guard: the operation is skipped (reason `preconditionFailed`) unless the target " +
+    "block's normalized text hash still matches.",
+  properties: {
+    blockTextHash: {
+      type: "string",
+      pattern: NORMALIZED_TEXT_HASH_PATTERN,
+      description: "Normalized hash of the target block's text.",
+    },
+  },
+  required: ["blockTextHash"],
+  additionalProperties: false,
+} as const;
+
+const commentJsonSchema = {
+  type: "object",
+  description: "A comment attached to the text affected by this operation.",
+  properties: {
+    text: { type: "string", description: "The comment body." },
+  },
+  required: ["text"],
+  additionalProperties: false,
+} as const;
+
+/**
+ * Properties every operation variant accepts: the required `id` plus the
+ * optional review metadata (`severity`, `area`) and `precondition` guard.
+ */
+const operationMetaProperties = {
+  id: {
+    type: "string",
+    description:
+      "Caller-supplied operation id, echoed back in `applied` / `skipped` results. Must be " +
+      "unique within a batch (enforced by the parser).",
+  },
+  severity: {
+    type: "string",
+    enum: ["low", "medium", "high"],
+    description: "Optional review severity for structured-review workflows.",
+  },
+  area: {
+    type: "string",
+    description: 'Optional review area label (e.g. "Penalty") for structured-review workflows.',
+  },
+  precondition: preconditionJsonSchema,
+} as const;
+
+const blockIdProperty = {
+  type: "string",
+  description: "Id of the target block, from a prior document read.",
+} as const;
+
+/**
+ * JSON Schema (draft-07 compatible) for ONE document operation: the full
+ * ten-variant union accepted by `parseFolioDocumentOperationBatch` in
+ * `@stll/folio-core`, one `oneOf` variant per entry in
+ * `FOLIO_DOCUMENT_OPERATION_TYPES`. Intended for LLM tool definitions and
+ * other consumers that need the contract's wire shape without re-declaring
+ * it; note that the `suggest_changes` tool in `tools.ts` deliberately
+ * narrows this union (see the comment there).
+ */
+export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
+  description:
+    "One document operation, discriminated by `type`. Mirrors the operation union accepted by " +
+    "`parseFolioDocumentOperationBatch` in @stll/folio-core.",
+  oneOf: [
+    {
+      type: "object",
+      description: "Replace an exact text match inside one block.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["replaceInBlock"] },
+        blockId: blockIdProperty,
+        find: { type: "string", description: "The exact text to find within the block." },
+        replace: { type: "string", description: "The replacement text." },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId", "find", "replace"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Replace the text covered by a range handle.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["replaceRange"] },
+        range: FOLIO_TEXT_RANGE_JSON_SCHEMA,
+        replace: { type: "string", description: "The replacement text." },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "range", "replace"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Attach a comment to the text covered by a range handle.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["commentOnRange"] },
+        range: FOLIO_TEXT_RANGE_JSON_SCHEMA,
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "range", "comment"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description:
+        "Apply inline formatting to the text covered by a range handle. Direct mode only " +
+        "(formatting is not representable as a tracked change).",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["formatRange"] },
+        range: FOLIO_TEXT_RANGE_JSON_SCHEMA,
+        formatting: {
+          type: "object",
+          description: "Inline formatting to apply; at least one property is required.",
+          properties: {
+            bold: { type: "boolean" },
+            italic: { type: "boolean" },
+            underline: { type: "boolean" },
+          },
+          minProperties: 1,
+          additionalProperties: false,
+        },
+      },
+      required: ["id", "type", "range", "formatting"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Insert a new paragraph after the anchor block.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["insertAfterBlock"] },
+        blockId: blockIdProperty,
+        text: { type: "string", description: "The paragraph text to insert." },
+        inheritFormatting: {
+          type: "boolean",
+          description: "Inherit the anchor block's formatting for the inserted paragraph.",
+        },
+        pageBreakBefore: {
+          type: "boolean",
+          description: "Start the inserted paragraph on a new page (`pageBreakBefore`).",
+        },
+        styleId: {
+          type: "string",
+          description: 'Paragraph style id for the inserted block (e.g. "ClauseHeading1").',
+        },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId", "text"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Insert a new paragraph before the anchor block.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["insertBeforeBlock"] },
+        blockId: blockIdProperty,
+        text: { type: "string", description: "The paragraph text to insert." },
+        inheritFormatting: {
+          type: "boolean",
+          description: "Inherit the anchor block's formatting for the inserted paragraph.",
+        },
+        pageBreakBefore: {
+          type: "boolean",
+          description: "Start the inserted paragraph on a new page (`pageBreakBefore`).",
+        },
+        styleId: {
+          type: "string",
+          description: 'Paragraph style id for the inserted block (e.g. "ClauseHeading1").',
+        },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId", "text"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Replace one block's entire text.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["replaceBlock"] },
+        blockId: blockIdProperty,
+        text: { type: "string", description: "The new block text." },
+        preserveFormatting: {
+          type: "boolean",
+          description: "Keep the block's existing formatting for the replacement text.",
+        },
+        styleId: {
+          type: "string",
+          description: "Paragraph style id to set on the replaced block.",
+        },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId", "text"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Delete one block.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["deleteBlock"] },
+        blockId: blockIdProperty,
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description: "Attach a comment to one block, optionally quoting text within it.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["commentOnBlock"] },
+        blockId: blockIdProperty,
+        quote: {
+          type: "string",
+          description: "Exact text within the block the comment is about.",
+        },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId", "comment"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      description:
+        "Insert a signature table next to the anchor block. Direct mode only (table insertion " +
+        "is not representable as a tracked change).",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["insertSignatureTable"] },
+        blockId: blockIdProperty,
+        position: {
+          type: "string",
+          enum: ["after", "before"],
+          description: 'Insert after the anchor block (default) or before it. Defaults to "after".',
+        },
+        parties: {
+          type: "array",
+          description: "The signing parties, one table cell per party.",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string", description: "Party name (rendered bold)." },
+              signatory: { type: "string", description: "Name of the person signing." },
+              title: { type: "string", description: "Signatory title (rendered in italics)." },
+            },
+            required: ["name"],
+            additionalProperties: false,
+          },
+        },
+        comment: commentJsonSchema,
+      },
+      required: ["id", "type", "blockId", "parties"],
+      additionalProperties: false,
+    },
+  ],
+} as const;
+
+/**
+ * JSON Schema (draft-07 compatible) for the versioned batch envelope accepted
+ * by `parseFolioDocumentOperationBatch`: `version` (always
+ * `FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION`), `operations`, and the
+ * optional `mode` / `atomic` / `dryRun` flags — the exact wire shape of
+ * `FolioDocumentOperationBatch`. Hand this to an LLM tool definition (or any
+ * JSON Schema consumer) instead of re-declaring the contract.
+ */
+export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
+  type: "object",
+  description:
+    "A versioned batch of document operations. Operation ids must be unique within the batch " +
+    "(enforced by the parser, not expressible in JSON Schema).",
+  properties: {
+    version: {
+      type: "integer",
+      enum: [FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION],
+      description: "Document-operation contract version.",
+    },
+    operations: {
+      type: "array",
+      description: "The operations to apply, in order.",
+      items: FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA,
+    },
+    mode: {
+      type: "string",
+      enum: FOLIO_DOCUMENT_OPERATION_MODES,
+      description:
+        'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
+        '"direct" applies immediately. `formatRange` and `insertSignatureTable` support ' +
+        '"direct" only.',
+    },
+    atomic: {
+      type: "boolean",
+      description: "Reject the whole batch when any operation would be skipped.",
+    },
+    dryRun: {
+      type: "boolean",
+      description: "Preview the batch without mutating the document.",
+    },
+  },
+  required: ["version", "operations"],
+  additionalProperties: false,
+} as const;
+
+/**
+ * Minimal structural subset of the Standard Schema V1 interface
+ * (https://standardschema.dev). Declared locally instead of depending on
+ * `@standard-schema/spec` — the spec is a tiny type-only interface designed
+ * to be inlined, and this keeps the package dependency-free. Consumers that
+ * accept the spec type (TanStack AI, tRPC, etc.) match it structurally.
+ */
+type StandardSchemaV1Issue = {
+  readonly message: string;
+  readonly path?: readonly PropertyKey[] | undefined;
+};
+
+type StandardSchemaV1Result<Output> =
+  | { readonly value: Output; readonly issues?: undefined }
+  | { readonly issues: readonly StandardSchemaV1Issue[] };
+
+type StandardSchemaV1<Input = unknown, Output = Input> = {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (value: unknown) => StandardSchemaV1Result<Output>;
+    readonly types?: { readonly input: Input; readonly output: Output } | undefined;
+  };
+};
+
+type FolioDocumentOperationBatchSchema = StandardSchemaV1<unknown, FolioDocumentOperationBatch> & {
+  /**
+   * The batch envelope's JSON Schema
+   * ({@link FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA}), attached so tool
+   * builders get the runtime validator and the LLM-facing schema from one
+   * import.
+   */
+  readonly jsonSchema: typeof FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA;
+};
+
+/**
+ * Convert the parser's JSONPath-style location (`$.operations[0].blockId`)
+ * into a Standard Schema issue path (`["operations", 0, "blockId"]`).
+ * Returns `undefined` for the root path so root-level issues carry no path.
+ */
+const toStandardSchemaPath = (path: string): readonly PropertyKey[] | undefined => {
+  const segments: PropertyKey[] = [];
+  for (const match of path.matchAll(/\.(?<key>[^.[\]]+)|\[(?<index>\d+)\]/gu)) {
+    const { key, index } = match.groups ?? {};
+    if (key !== undefined) {
+      segments.push(key);
+    } else if (index !== undefined) {
+      segments.push(Number(index));
+    }
+  }
+  return segments.length > 0 ? segments : undefined;
+};
+
+const toStandardSchemaIssue = (error: unknown): StandardSchemaV1Issue => {
+  if (error instanceof InvalidFolioDocumentOperationBatchError) {
+    const path = toStandardSchemaPath(error.path);
+    return { message: error.message, ...(path !== undefined && { path }) };
+  }
+  if (error instanceof UnsupportedFolioDocumentOperationVersionError) {
+    return { message: error.message, path: ["version"] };
+  }
+  return { message: error instanceof Error ? error.message : String(error) };
+};
+
+/**
+ * Standard Schema V1 (https://standardschema.dev) validator for a document
+ * operation batch, for spec-aware consumers (TanStack AI tool `inputSchema`,
+ * tRPC input, etc.). Delegates to `parseFolioDocumentOperationBatch` from
+ * `@stll/folio-core`, so the strict parser stays the single source of truth:
+ * `validate` never throws, returning `{ value }` with the parser's exact
+ * output on success and `{ issues }` (message plus a key path when the parser
+ * reported one) on failure. The matching LLM-facing JSON schema is attached
+ * as {@link FolioDocumentOperationBatchSchema.jsonSchema}.
+ */
+export const folioDocumentOperationBatchSchema: FolioDocumentOperationBatchSchema = {
+  "~standard": {
+    version: 1,
+    vendor: "folio",
+    validate: (value) => {
+      // Boundary adapter: the Standard Schema spec mandates a non-throwing
+      // result surface over the intentionally throwing core parser.
+      try {
+        return { value: parseFolioDocumentOperationBatch(value) };
+      } catch (error) {
+        return { issues: [toStandardSchemaIssue(error)] };
+      }
+    },
+  },
+  jsonSchema: FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA,
+};

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { parseAddCommentInput, parseSuggestChangesInput } from "./parse";
+import { SUGGEST_CHANGES_OPERATION_TYPES } from "./tools";
 
 describe("parseAddCommentInput", () => {
   test("valid input builds a commentOnBlock operation", () => {
@@ -260,5 +261,37 @@ describe("parseSuggestChangesInput", () => {
       throw new Error("expected ok:false");
     }
     expect(commentTooLong.error).toContain("100,000-character limit");
+  });
+
+  test("accepts every operation type the suggest_changes tool schema advertises", () => {
+    // Guards the tool-schema derivation in tools.ts: since the schema's type
+    // enum is computed from the contract's operation-type list minus an
+    // exclusion list, a new contract type would silently appear in the enum
+    // even though this parser rejects it. A superset fixture works for every
+    // type because parseSuggestChangesInput ignores fields a type does not use.
+    const supersetOperation = (type: string) => ({
+      type,
+      blockId: "b1",
+      find: "old",
+      replace: "new",
+      text: "inserted",
+      comment: "why",
+      range: {
+        type: "textRange",
+        story: "main",
+        blockId: "b1",
+        startOffset: 0,
+        endOffset: 4,
+        selectedTextHash: "h123",
+      },
+    });
+    for (const type of SUGGEST_CHANGES_OPERATION_TYPES) {
+      const result = parseSuggestChangesInput({ operations: [supersetOperation(type)] });
+      expect(result.ok, type).toBe(true);
+    }
+    for (const excludedType of ["formatRange", "commentOnBlock", "insertSignatureTable"]) {
+      const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
+      expect(result.ok, excludedType).toBe(false);
+    }
   });
 });

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -1,5 +1,44 @@
+import {
+  FOLIO_DOCUMENT_OPERATION_TYPES,
+  type FolioDocumentOperationType,
+} from "@stll/folio-core/server";
+
+import { FOLIO_TEXT_RANGE_JSON_SCHEMA } from "./operation-schema";
 import { FOLIO_AGENT_TOOL_NAMES } from "./types";
 import type { FolioAgentToolDefinition } from "./types";
+
+/**
+ * `suggest_changes` deliberately narrows the full document-operation contract
+ * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
+ * - excluded types: `formatRange` and `insertSignatureTable` (direct-only,
+ *   not representable as tracked changes for human review) and
+ *   `commentOnBlock` (covered by the dedicated `add_comment` tool);
+ * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
+ *   where the contract requires it;
+ * - `comment` is a plain string here; `parse.ts` wraps it into the contract's
+ *   `{ text }` object;
+ * - the review metadata (`severity`, `area`), `precondition` guard, and the
+ *   insert/replace formatting knobs (`inheritFormatting`, `pageBreakBefore`,
+ *   `preserveFormatting`, `styleId`, `position`, `parties`, `quote`,
+ *   `formatting`) are not exposed to the model.
+ */
+const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperationType> = new Set([
+  "formatRange",
+  "commentOnBlock",
+  "insertSignatureTable",
+]);
+
+/**
+ * The contract operation types `suggest_changes` exposes to the model,
+ * derived from the shared contract constant minus the exclusions above.
+ * Exported (module-level only, not from the package index) so
+ * `parse.test.ts` can assert this enum stays in lockstep with what
+ * `parseSuggestChangesInput` actually accepts.
+ */
+export const SUGGEST_CHANGES_OPERATION_TYPES: readonly FolioDocumentOperationType[] =
+  FOLIO_DOCUMENT_OPERATION_TYPES.filter(
+    (type) => !SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES.has(type),
+  );
 
 const suggestChangesOperationSchema = {
   type: "object",
@@ -11,15 +50,7 @@ const suggestChangesOperationSchema = {
     },
     type: {
       type: "string",
-      enum: [
-        "replaceInBlock",
-        "replaceRange",
-        "commentOnRange",
-        "insertAfterBlock",
-        "insertBeforeBlock",
-        "replaceBlock",
-        "deleteBlock",
-      ],
+      enum: SUGGEST_CHANGES_OPERATION_TYPES,
       description: "The kind of edit to make.",
     },
     blockId: {
@@ -27,18 +58,9 @@ const suggestChangesOperationSchema = {
       description: "The block to edit, from `read_document` or `find_text`.",
     },
     range: {
-      type: "object",
-      description: "Required for `replaceRange`: copy the range object returned by `find_text`.",
-      properties: {
-        type: { type: "string", enum: ["textRange"] },
-        story: { type: "string", enum: ["main"] },
-        blockId: { type: "string" },
-        startOffset: { type: "integer", minimum: 0 },
-        endOffset: { type: "integer", minimum: 1 },
-        selectedTextHash: { type: "string" },
-      },
-      required: ["type", "story", "blockId", "startOffset", "endOffset", "selectedTextHash"],
-      additionalProperties: false,
+      ...FOLIO_TEXT_RANGE_JSON_SCHEMA,
+      description:
+        "Required for `replaceRange` and `commentOnRange`: copy the range object returned by `find_text`.",
     },
     find: {
       type: "string",


### PR DESCRIPTION
## What

`@stll/folio-agents` now exports the versioned document-operation contract as reusable schemas, so downstream tool definitions can consume it directly instead of hand-mirroring the shapes:

- `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` — JSON Schema for the full ten-variant operation union (per-variant `required`/`additionalProperties: false`, mirroring `parseFolioDocumentOperationBatch` exactly, including the hash patterns and `formatting` minProperties; constraints JSON Schema cannot express are documented in descriptions and enforced by the parser).
- `FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA` — the versioned batch envelope (`version`, `operations`, optional `mode`/`atomic`/`dryRun`).
- `folioDocumentOperationBatchSchema` — a Standard Schema V1 object (minimal local structural interface, no new dependency) whose `validate` delegates to `parseFolioDocumentOperationBatch` — never throws, converts parser JSONPaths into spec path arrays — with the JSON schema attached for LLM tool builders.

The `suggest_changes` tool schema now derives from the shared constants; its deliberate narrowings (7 of 10 types, string comment, optional id) are expressed as explicit exclusions with comments rather than a forked schema, and a pre-existing looseness is fixed along the way (the tool's range schema was missing the `selectedTextHash` pattern its parser already enforced).

Conformance tests pin schema↔parser agreement per operation type — positive round-trips, wrong-version/unknown-type/unexpected-property rejections, and generated missing-required-field rejections for every variant — plus the standard-schema surface (never throws, issue paths, parser-identical output).

## Why

Consumers embedding folio operations in their own LLM tool definitions had to mirror the contract by hand and keep the mirror honest with their own conformance tests. This makes the contract itself the exported artifact.