### PR TITLE
refactor: centralize async overlay request gating

### DIFF
--- a/.changeset/calm-overlays-wait.md
+++ b/.changeset/calm-overlays-wait.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Prevent stale asynchronous overlay projections through a shared framework-neutral request gate.

--- a/packages/core/src/controller/latestRequestGate.test.ts
+++ b/packages/core/src/controller/latestRequestGate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLatestRequestGate } from "./latestRequestGate";
+
+describe("createLatestRequestGate", () => {
+  test("keeps the newest request current", () => {
+    const gate = createLatestRequestGate();
+    const first = gate.begin();
+
+    expect(first()).toBe(true);
+
+    const second = gate.begin();
+
+    expect(first()).toBe(false);
+    expect(second()).toBe(true);
+  });
+
+  test("invalidates a request without starting another one", () => {
+    const gate = createLatestRequestGate();
+    const request = gate.begin();
+
+    gate.invalidate();
+
+    expect(request()).toBe(false);
+  });
+
+  test("an old guard never becomes current again", () => {
+    const gate = createLatestRequestGate();
+    const first = gate.begin();
+
+    gate.invalidate();
+    const second = gate.begin();
+
+    expect(first()).toBe(false);
+    expect(second()).toBe(true);
+  });
+});

--- a/packages/core/src/controller/latestRequestGate.ts
+++ b/packages/core/src/controller/latestRequestGate.ts
@@ -1,0 +1,26 @@
+/**
+ * Coordinates async work where only the most recently started request may
+ * commit a result. Each guard closes over an opaque identity, so callers
+ * cannot accidentally make an older request current again.
+ */
+export type LatestRequestGate = {
+  /** Start a request and return a guard that remains true while it is latest. */
+  begin: () => () => boolean;
+  /** Supersede the current request without starting another one. */
+  invalidate: () => void;
+};
+
+export const createLatestRequestGate = (): LatestRequestGate => {
+  let current = Symbol();
+
+  return {
+    begin: () => {
+      const request = Symbol();
+      current = request;
+      return () => current === request;
+    },
+    invalidate: () => {
+      current = Symbol();
+    },
+  };
+};

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -39,6 +39,7 @@ import type { AISuggestion } from "@stll/folio-core/ai-suggestions/types";
 import { createFolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { FolioEditor } from "@stll/folio-core/controller/folioEditor";
 import { createFolioEditorEmitter } from "@stll/folio-core/controller/folioEditorEvents";
+import { createLatestRequestGate } from "@stll/folio-core/controller/latestRequestGate";
 import { runLayoutPipeline as runLayoutPipelineCompute } from "@stll/folio-core/controller/layoutPipeline";
 import {
   browserClock,
@@ -1487,7 +1488,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // doesn't depend on a state setter callback that would trigger
     // its own re-run.
     const anonymizationMatchesRef = useRef<readonly AnonymizationMatch[]>([]);
-    const anonymizationOverlayRequestSeqRef = useRef(0);
+    const anonymizationOverlayRequestGateRef = useRef(createLatestRequestGate());
     // Autocomplete (inline ghost-text) overlay state. Mirrors the
     // anonymization pattern: a ref tracks the latest plugin
     // suggestion, a derived caret-rect lives in state and drives
@@ -1499,7 +1500,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       text: "",
       requestId: null,
     });
-    const autocompleteOverlayRequestSeqRef = useRef(0);
+    const autocompleteOverlayRequestGateRef = useRef(createLatestRequestGate());
     const [autocompleteCaret, setAutocompleteCaret] = useState<AutocompleteCaretRect | null>(null);
     const [autocompleteText, setAutocompleteText] = useState<string>("");
     const [autocompleteIsStreaming, setAutocompleteIsStreaming] = useState<boolean>(false);
@@ -1509,7 +1510,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // block directives — drives the innermost-block rail emphasis in the overlay.
     const [directiveCaretPos, setDirectiveCaretPos] = useState<number | null>(null);
     const directivesRef = useRef<readonly DirectiveRange[]>([]);
-    const directivesOverlayRequestSeqRef = useRef(0);
+    const directivesOverlayRequestGateRef = useRef(createLatestRequestGate());
     // Template fill preview — the hidden editor's plugin keeps marker↔value
     // entries in sync; the layout pipeline substitutes them into the flow
     // blocks so the painted pages reflow as if the values were the text.
@@ -1529,13 +1530,13 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       suggestions: readonly AISuggestion[];
       focusedId: string | null;
     }>({ suggestions: EMPTY_AI_SUGGESTIONS, focusedId: null });
-    const aiSuggestionsOverlayRequestSeqRef = useRef(0);
+    const aiSuggestionsOverlayRequestGateRef = useRef(createLatestRequestGate());
     const [remoteSelections, setRemoteSelections] = useState<HiddenProseMirrorRemoteSelection[]>(
       [],
     );
     const suppressSelectionOverlayRef = useRef(false);
     const revealSelectionOverlayTimerRef = useRef<number | null>(null);
-    const selectionOverlayRequestSeqRef = useRef(0);
+    const selectionOverlayRequestGateRef = useRef(createLatestRequestGate());
 
     const validPrecomputedInitialState =
       precomputedInitialDocumentRef.current === document ? precomputedInitialState : null;
@@ -2136,9 +2137,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     const updateSelectionOverlay = useCallback(
       (state: EditorState) => {
         const { from, to } = state.selection;
-        const requestSeq = selectionOverlayRequestSeqRef.current + 1;
-        selectionOverlayRequestSeqRef.current = requestSeq;
-        const isCurrentRequest = () => selectionOverlayRequestSeqRef.current === requestSeq;
+        const isCurrentRequest = selectionOverlayRequestGateRef.current.begin();
 
         // Feed the template-directives overlay the caret head so it can emphasise
         // the innermost block around it. Gated on there being directives at all,
@@ -2390,9 +2389,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // ProseMirror's spans are not used — they sit at -9999px and
     // would yield bogus coordinates.
     const updateAnonymizationOverlay = useCallback(() => {
-      const requestSeq = anonymizationOverlayRequestSeqRef.current + 1;
-      anonymizationOverlayRequestSeqRef.current = requestSeq;
-      const isCurrentRequest = () => anonymizationOverlayRequestSeqRef.current === requestSeq;
+      const isCurrentRequest = anonymizationOverlayRequestGateRef.current.begin();
       const matches = anonymizationMatchesRef.current;
       if (matches.length === 0) {
         setAnonymizationRectGroups([]);
@@ -2542,11 +2539,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // ref so this can run from a transaction handler without
     // re-creating callbacks per render.
     const updateAutocompleteOverlay = useCallback(() => {
-      const requestSeq = autocompleteOverlayRequestSeqRef.current + 1;
-      autocompleteOverlayRequestSeqRef.current = requestSeq;
+      const requestIsLatest = autocompleteOverlayRequestGateRef.current.begin();
       const current = autocompleteSuggestionRef.current;
       const isCurrentRequest = () =>
-        autocompleteOverlayRequestSeqRef.current === requestSeq &&
+        requestIsLatest() &&
         autocompleteSuggestionRef.current === current &&
         current.status !== "idle" &&
         current.text.length > 0;
@@ -2628,8 +2624,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // the projection pipeline with anonymization via
     // `projectRangesToRects`.
     const updateDirectivesOverlay = useCallback(() => {
-      const requestSeq = directivesOverlayRequestSeqRef.current + 1;
-      directivesOverlayRequestSeqRef.current = requestSeq;
+      const isCurrentRequest = directivesOverlayRequestGateRef.current.begin();
       // A marker with an active fill-preview value already reads as filled
       // (orange substituted run); suppress its blue marker tint so filled and
       // to-be-filled markers are visually disjoint.
@@ -2654,7 +2649,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           blocks,
           measures,
         });
-        if (directivesOverlayRequestSeqRef.current === requestSeq) {
+        if (isCurrentRequest()) {
           setDirectiveRectGroups(projected);
         }
       })();
@@ -2665,8 +2660,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // severity underlines, plus the focused suggestion's in-text diff
     // (struck-through original + adjacent replacement text).
     const updateAISuggestionsOverlay = useCallback(() => {
-      const requestSeq = aiSuggestionsOverlayRequestSeqRef.current + 1;
-      aiSuggestionsOverlayRequestSeqRef.current = requestSeq;
+      const isCurrentRequest = aiSuggestionsOverlayRequestGateRef.current.begin();
       const { suggestions, focusedId } = aiSuggestionsRef.current;
       const pending = suggestions.filter(
         (suggestion) =>
@@ -2688,7 +2682,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           })),
           { pagesContainer, zoom, layout, blocks, measures },
         );
-        if (aiSuggestionsOverlayRequestSeqRef.current !== requestSeq) {
+        if (!isCurrentRequest()) {
           return;
         }
         const focused = projected.find(({ range }) => range.suggestion.id === focusedId);
@@ -2709,7 +2703,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
 
     const hideSelectionOverlayDuringInput = useCallback(
       (state: EditorState) => {
-        selectionOverlayRequestSeqRef.current += 1;
+        selectionOverlayRequestGateRef.current.invalidate();
         suppressSelectionOverlayRef.current = true;
         setCaretPosition(null);
         setSelectionRects([]);

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -2723,12 +2723,24 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
 
     useEffect(
       () => () => {
+        selectionOverlayRequestGate.invalidate();
+        anonymizationOverlayRequestGate.invalidate();
+        autocompleteOverlayRequestGate.invalidate();
+        directivesOverlayRequestGate.invalidate();
+        aiSuggestionsOverlayRequestGate.invalidate();
+
         if (revealSelectionOverlayTimerRef.current !== null) {
           window.clearTimeout(revealSelectionOverlayTimerRef.current);
           revealSelectionOverlayTimerRef.current = null;
         }
       },
-      [],
+      [
+        aiSuggestionsOverlayRequestGate,
+        anonymizationOverlayRequestGate,
+        autocompleteOverlayRequestGate,
+        directivesOverlayRequestGate,
+        selectionOverlayRequestGate,
+      ],
     );
 
     // =========================================================================

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -1488,7 +1488,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // doesn't depend on a state setter callback that would trigger
     // its own re-run.
     const anonymizationMatchesRef = useRef<readonly AnonymizationMatch[]>([]);
-    const anonymizationOverlayRequestGateRef = useRef(createLatestRequestGate());
+    const [anonymizationOverlayRequestGate] = useState(createLatestRequestGate);
     // Autocomplete (inline ghost-text) overlay state. Mirrors the
     // anonymization pattern: a ref tracks the latest plugin
     // suggestion, a derived caret-rect lives in state and drives
@@ -1500,7 +1500,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       text: "",
       requestId: null,
     });
-    const autocompleteOverlayRequestGateRef = useRef(createLatestRequestGate());
+    const [autocompleteOverlayRequestGate] = useState(createLatestRequestGate);
     const [autocompleteCaret, setAutocompleteCaret] = useState<AutocompleteCaretRect | null>(null);
     const [autocompleteText, setAutocompleteText] = useState<string>("");
     const [autocompleteIsStreaming, setAutocompleteIsStreaming] = useState<boolean>(false);
@@ -1510,7 +1510,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // block directives — drives the innermost-block rail emphasis in the overlay.
     const [directiveCaretPos, setDirectiveCaretPos] = useState<number | null>(null);
     const directivesRef = useRef<readonly DirectiveRange[]>([]);
-    const directivesOverlayRequestGateRef = useRef(createLatestRequestGate());
+    const [directivesOverlayRequestGate] = useState(createLatestRequestGate);
     // Template fill preview — the hidden editor's plugin keeps marker↔value
     // entries in sync; the layout pipeline substitutes them into the flow
     // blocks so the painted pages reflow as if the values were the text.
@@ -1530,13 +1530,13 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       suggestions: readonly AISuggestion[];
       focusedId: string | null;
     }>({ suggestions: EMPTY_AI_SUGGESTIONS, focusedId: null });
-    const aiSuggestionsOverlayRequestGateRef = useRef(createLatestRequestGate());
+    const [aiSuggestionsOverlayRequestGate] = useState(createLatestRequestGate);
     const [remoteSelections, setRemoteSelections] = useState<HiddenProseMirrorRemoteSelection[]>(
       [],
     );
     const suppressSelectionOverlayRef = useRef(false);
     const revealSelectionOverlayTimerRef = useRef<number | null>(null);
-    const selectionOverlayRequestGateRef = useRef(createLatestRequestGate());
+    const [selectionOverlayRequestGate] = useState(createLatestRequestGate);
 
     const validPrecomputedInitialState =
       precomputedInitialDocumentRef.current === document ? precomputedInitialState : null;
@@ -2137,7 +2137,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     const updateSelectionOverlay = useCallback(
       (state: EditorState) => {
         const { from, to } = state.selection;
-        const isCurrentRequest = selectionOverlayRequestGateRef.current.begin();
+        const isCurrentRequest = selectionOverlayRequestGate.begin();
 
         // Feed the template-directives overlay the caret head so it can emphasise
         // the innermost block around it. Gated on there being directives at all,
@@ -2374,7 +2374,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           setCaretPosition(null);
         }
       },
-      [layout, blocks, measures, getCaretFromDom, zoom],
+      [layout, blocks, measures, getCaretFromDom, selectionOverlayRequestGate, zoom],
       // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
     );
     const updateSelectionOverlayRef = useRef(updateSelectionOverlay);
@@ -2389,7 +2389,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // ProseMirror's spans are not used — they sit at -9999px and
     // would yield bogus coordinates.
     const updateAnonymizationOverlay = useCallback(() => {
-      const isCurrentRequest = anonymizationOverlayRequestGateRef.current.begin();
+      const isCurrentRequest = anonymizationOverlayRequestGate.begin();
       const matches = anonymizationMatchesRef.current;
       if (matches.length === 0) {
         setAnonymizationRectGroups([]);
@@ -2531,7 +2531,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         },
         () => undefined,
       );
-    }, [layout, blocks, measures, zoom]);
+    }, [anonymizationOverlayRequestGate, layout, blocks, measures, zoom]);
 
     // Project the autocomplete suggestion's anchor onto container
     // coordinates so {@link AutocompleteCaretOverlay} can paint the
@@ -2539,7 +2539,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     // ref so this can run from a transaction handler without
     // re-creating callbacks per render.
     const updateAutocompleteOverlay = useCallback(() => {
-      const requestIsLatest = autocompleteOverlayRequestGateRef.current.begin();
+      const requestIsLatest = autocompleteOverlayRequestGate.begin();
       const current = autocompleteSuggestionRef.current;
       const isCurrentRequest = () =>
         requestIsLatest() &&
@@ -2617,14 +2617,14 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         },
         () => undefined,
       );
-    }, [layout, blocks, measures, zoom]);
+    }, [autocompleteOverlayRequestGate, layout, blocks, measures, zoom]);
 
     // Project template-directive ranges (kept in sync by the
     // templateDirectives plugin) onto container-space rects. Shares
     // the projection pipeline with anonymization via
     // `projectRangesToRects`.
     const updateDirectivesOverlay = useCallback(() => {
-      const isCurrentRequest = directivesOverlayRequestGateRef.current.begin();
+      const isCurrentRequest = directivesOverlayRequestGate.begin();
       // A marker with an active fill-preview value already reads as filled
       // (orange substituted run); suppress its blue marker tint so filled and
       // to-be-filled markers are visually disjoint.
@@ -2653,14 +2653,14 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           setDirectiveRectGroups(projected);
         }
       })();
-    }, [layout, blocks, measures, zoom]);
+    }, [directivesOverlayRequestGate, layout, blocks, measures, zoom]);
 
     // Project pending AI suggestions (kept in sync by the
     // aiSuggestionDecorations plugin) onto container-space rects: dotted
     // severity underlines, plus the focused suggestion's in-text diff
     // (struck-through original + adjacent replacement text).
     const updateAISuggestionsOverlay = useCallback(() => {
-      const isCurrentRequest = aiSuggestionsOverlayRequestGateRef.current.begin();
+      const isCurrentRequest = aiSuggestionsOverlayRequestGate.begin();
       const { suggestions, focusedId } = aiSuggestionsRef.current;
       const pending = suggestions.filter(
         (suggestion) =>
@@ -2699,11 +2699,11 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           })),
         );
       })();
-    }, [layout, blocks, measures, zoom]);
+    }, [aiSuggestionsOverlayRequestGate, layout, blocks, measures, zoom]);
 
     const hideSelectionOverlayDuringInput = useCallback(
       (state: EditorState) => {
-        selectionOverlayRequestGateRef.current.invalidate();
+        selectionOverlayRequestGate.invalidate();
         suppressSelectionOverlayRef.current = true;
         setCaretPosition(null);
         setSelectionRects([]);
@@ -2718,7 +2718,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           updateSelectionOverlay(hiddenPMRef.current?.getState() ?? state);
         }, SELECTION_REVEAL_AFTER_INPUT_DELAY);
       },
-      [updateSelectionOverlay],
+      [selectionOverlayRequestGate, updateSelectionOverlay],
     );
 
     useEffect(

--- a/packages/vue/src/components/AnonymizationRectsOverlay.vue
+++ b/packages/vue/src/components/AnonymizationRectsOverlay.vue
@@ -51,6 +51,7 @@ import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import { createLatestRequestGate } from "@stll/folio-core/controller/latestRequestGate";
 import type { FlowBlock, Layout, Measure } from "@stll/folio-core/layout-engine/types";
 import { projectRangesToRects } from "@stll/folio-core/paged-layout/rangeProjection";
 import { prefersReducedMotionBehavior } from "@stll/folio-core/paged-layout/scrollNavigation";
@@ -85,8 +86,7 @@ const props = defineProps<{
 const rootRef = ref<HTMLDivElement | null>(null);
 const groups = ref<AnonymizationRectGroup[]>([]);
 
-// Monotonic guard: a stale async projection must not overwrite a newer one.
-let requestSeq = 0;
+const requestGate = createLatestRequestGate();
 let rafId: number | null = null;
 
 function scheduleProject(): void {
@@ -100,7 +100,7 @@ function scheduleProject(): void {
 }
 
 async function project(): Promise<void> {
-  const seq = ++requestSeq;
+  const isCurrentRequest = requestGate.begin();
   const view = props.getView();
   const pagesContainer = props.getPagesContainer();
   const state = props.editorState;
@@ -120,7 +120,7 @@ async function project(): Promise<void> {
     blocks: props.blocks,
     measures: props.measures,
   });
-  if (seq !== requestSeq) {
+  if (!isCurrentRequest()) {
     return;
   }
   const z = props.zoom;
@@ -214,6 +214,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  requestGate.invalidate();
   document.removeEventListener("click", handleDocumentClick);
   if (rafId !== null) {
     cancelAnimationFrame(rafId);

--- a/packages/vue/src/components/TemplateDirectivesOverlay.vue
+++ b/packages/vue/src/components/TemplateDirectivesOverlay.vue
@@ -64,6 +64,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import { createLatestRequestGate } from "@stll/folio-core/controller/latestRequestGate";
 import type { SelectionRect } from "@stll/folio-core/layout-bridge/engine/selectionRects";
 import type { FlowBlock, Layout, Measure } from "@stll/folio-core/layout-engine/types";
 import type {
@@ -261,7 +262,7 @@ const gutter = ref<DirectiveGutterGeometry | null>(null);
 const caretPos = ref<number | null>(null);
 const hoveredBlockId = ref<number | null>(null);
 
-let requestSeq = 0;
+const requestGate = createLatestRequestGate();
 let rafId: number | null = null;
 
 function scheduleProject(): void {
@@ -275,7 +276,7 @@ function scheduleProject(): void {
 }
 
 async function project(): Promise<void> {
-  const seq = ++requestSeq;
+  const isCurrentRequest = requestGate.begin();
   const view = props.getView();
   const pagesContainer = props.getPagesContainer();
   const state = props.editorState;
@@ -302,7 +303,7 @@ async function project(): Promise<void> {
     blocks: props.blocks,
     measures: props.measures,
   });
-  if (seq !== requestSeq) {
+  if (!isCurrentRequest()) {
     return;
   }
   // Commit all reactive state together after the sequence guard so a superseded
@@ -400,6 +401,7 @@ function handlePointerOut(event: PointerEvent): void {
 
 onMounted(() => scheduleProject());
 onBeforeUnmount(() => {
+  requestGate.invalidate();
   if (rafId !== null) {
     cancelAnimationFrame(rafId);
     rafId = null;


### PR DESCRIPTION
## Summary

- add a framework-neutral latest-request gate to the editor controller layer
- migrate React selection, anonymization, autocomplete, template directive, and AI suggestion overlays
- migrate Vue anonymization and template directive projections, including unmount invalidation
- add controller tests and release changesets for core, React, and Vue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated asynchronous results from overwriting newer overlay updates.
  * Improved reliability of selection, anonymization, autocomplete, template directive, and AI suggestion overlays in React.
  * Improved anonymization and template directive overlays in Vue by ignoring stale projection results.
  * Prevented in-flight overlay updates from being applied after components are closed or unmounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->