### PR TITLE
feat: add headless document operation undo

### DIFF
--- a/.changeset/calm-batches-undo.md
+++ b/.changeset/calm-batches-undo.md
@@ -1,0 +1,8 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Add typed undo handles for committed document-operation batches.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -22,6 +22,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     batch: FolioDocumentOperationBatch;
     author?: string;
     createCommentId?: (text: string) => number;
+    createUndoHandle?: () => FolioDocumentOperationUndoHandle;
 };
 
 // @public (undocumented)
@@ -342,7 +343,8 @@ export type FolioDocumentOperationResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
     issues: FolioDocumentOperationIssue[]; /** Successful effects in input-operation order; skipped operations are omitted. */
-    receipts: FolioDocumentOperationReceipt[];
+    receipts: FolioDocumentOperationReceipt[]; /** Present when the execution surface can undo this committed batch. */
+    undoHandle: FolioDocumentOperationUndoHandle | null;
 };
 
 // @public (undocumented)
@@ -350,6 +352,25 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoFailureReason = "unknownHandle" | "notLatest" | "documentChanged";
+
+// @public
+export type FolioDocumentOperationUndoHandle = {
+    type: "documentOperationUndo";
+    id: string;
+};
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoResult = {
+    status: "undone";
+    undoHandle: FolioDocumentOperationUndoHandle;
+} | {
+    status: "rejected";
+    undoHandle: FolioDocumentOperationUndoHandle;
+    reason: FolioDocumentOperationUndoFailureReason;
+};
 
 // @public (undocumented)
 export type FolioDocumentStory = {

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -162,6 +162,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     batch: FolioDocumentOperationBatch;
     author?: string;
     createCommentId?: (text: string) => number;
+    createUndoHandle?: () => FolioDocumentOperationUndoHandle;
 };
 
 // @public (undocumented)
@@ -603,7 +604,8 @@ export type FolioDocumentOperationResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
     issues: FolioDocumentOperationIssue[]; /** Successful effects in input-operation order; skipped operations are omitted. */
-    receipts: FolioDocumentOperationReceipt[];
+    receipts: FolioDocumentOperationReceipt[]; /** Present when the execution surface can undo this committed batch. */
+    undoHandle: FolioDocumentOperationUndoHandle | null;
 };
 
 // @public (undocumented)
@@ -611,6 +613,25 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoFailureReason = "unknownHandle" | "notLatest" | "documentChanged";
+
+// @public
+export type FolioDocumentOperationUndoHandle = {
+    type: "documentOperationUndo";
+    id: string;
+};
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoResult = {
+    status: "undone";
+    undoHandle: FolioDocumentOperationUndoHandle;
+} | {
+    status: "rejected";
+    undoHandle: FolioDocumentOperationUndoHandle;
+    reason: FolioDocumentOperationUndoFailureReason;
+};
 
 // @public
 export function fromMarkdown(markdown: string): import__stll_docx_core_model.Document;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -162,6 +162,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     batch: FolioDocumentOperationBatch;
     author?: string;
     createCommentId?: (text: string) => number;
+    createUndoHandle?: () => FolioDocumentOperationUndoHandle;
 };
 
 // @public (undocumented)
@@ -603,7 +604,8 @@ export type FolioDocumentOperationResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
     issues: FolioDocumentOperationIssue[]; /** Successful effects in input-operation order; skipped operations are omitted. */
-    receipts: FolioDocumentOperationReceipt[];
+    receipts: FolioDocumentOperationReceipt[]; /** Present when the execution surface can undo this committed batch. */
+    undoHandle: FolioDocumentOperationUndoHandle | null;
 };
 
 // @public (undocumented)
@@ -611,6 +613,25 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoFailureReason = "unknownHandle" | "notLatest" | "documentChanged";
+
+// @public
+export type FolioDocumentOperationUndoHandle = {
+    type: "documentOperationUndo";
+    id: string;
+};
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoResult = {
+    status: "undone";
+    undoHandle: FolioDocumentOperationUndoHandle;
+} | {
+    status: "rejected";
+    undoHandle: FolioDocumentOperationUndoHandle;
+    reason: FolioDocumentOperationUndoFailureReason;
+};
 
 // @public
 export function fromMarkdown(markdown: string): import__stll_docx_core_model.Document;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -368,7 +368,8 @@ export type FolioDocumentOperationResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
     issues: FolioDocumentOperationIssue[]; /** Successful effects in input-operation order; skipped operations are omitted. */
-    receipts: FolioDocumentOperationReceipt[];
+    receipts: FolioDocumentOperationReceipt[]; /** Present when the execution surface can undo this committed batch. */
+    undoHandle: FolioDocumentOperationUndoHandle | null;
 };
 
 // @public (undocumented)
@@ -376,6 +377,25 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationType = FolioDocumentOperation["type"];
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoFailureReason = "unknownHandle" | "notLatest" | "documentChanged";
+
+// @public
+export type FolioDocumentOperationUndoHandle = {
+    type: "documentOperationUndo";
+    id: string;
+};
+
+// @public (undocumented)
+export type FolioDocumentOperationUndoResult = {
+    status: "undone";
+    undoHandle: FolioDocumentOperationUndoHandle;
+} | {
+    status: "rejected";
+    undoHandle: FolioDocumentOperationUndoHandle;
+    reason: FolioDocumentOperationUndoFailureReason;
+};
 
 // @public (undocumented)
 export type FolioDocumentStory = {
@@ -418,6 +438,7 @@ export class FolioDocxReviewer {
     snapshot(): FolioAIEditSnapshot;
     toBuffer(): Promise<ArrayBuffer>;
     toDocument(): import__stll_docx_core_model.Document;
+    undoDocumentOperations(undoHandle: FolioDocumentOperationUndoHandle): FolioDocumentOperationUndoResult;
 }
 
 // @public

--- a/packages/agents/src/bridges/editor-ref.test.ts
+++ b/packages/agents/src/bridges/editor-ref.test.ts
@@ -60,6 +60,7 @@ describe("createEditorRefBridge: document operations", () => {
     expect(result.version).toBe(FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION);
     expect(result.issues).toEqual([]);
     expect(result.receipts).toEqual([]);
+    expect(result.undoHandle).toBeNull();
   });
 
   test("preserves the versioned result when adapting an older editor ref", () => {
@@ -81,6 +82,7 @@ describe("createEditorRefBridge: document operations", () => {
       ...EMPTY_APPLY_RESULT,
       issues: [],
       receipts: [],
+      undoHandle: null,
     });
   });
 
@@ -139,6 +141,7 @@ describe("createEditorRefBridge: document operations", () => {
       skipped: [{ id: "op-1", reason: "unsupportedMode" }],
       issues: [UNSUPPORTED_MODE_ISSUE],
       receipts: [],
+      undoHandle: null,
     });
     expect(applyCalls).toBe(0);
   });
@@ -172,6 +175,7 @@ describe("createEditorRefBridge: document operations", () => {
       skipped: [{ id: "op-1", reason: "unsupportedMode" }],
       issues: [UNSUPPORTED_MODE_ISSUE],
       receipts: [],
+      undoHandle: null,
     });
     expect(applyCalls).toBe(0);
   });

--- a/packages/agents/src/bridges/editor-ref.ts
+++ b/packages/agents/src/bridges/editor-ref.ts
@@ -184,6 +184,7 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
           receipts:
             result.receipts ??
             getFolioDocumentOperationReceipts(versionedBatch.operations, result.applied),
+          undoHandle: result.undoHandle ?? null,
         };
       }
       if (versionedBatch.dryRun === true) {
@@ -198,6 +199,7 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
           skipped,
           issues: getFolioDocumentOperationIssues(versionedBatch.operations, skipped),
           receipts: [],
+          undoHandle: null,
         };
       }
       if (versionedBatch.atomic === true) {
@@ -212,6 +214,7 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
           skipped,
           issues: getFolioDocumentOperationIssues(versionedBatch.operations, skipped),
           receipts: [],
+          undoHandle: null,
         };
       }
       const result = ref.applyAIEditOperations({
@@ -226,6 +229,7 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
         ...result,
         issues: getFolioDocumentOperationIssues(versionedBatch.operations, result.skipped),
         receipts: getFolioDocumentOperationReceipts(versionedBatch.operations, result.applied),
+        undoHandle: null,
       };
     },
     getComments: (): FolioAgentComment[] => {

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -155,6 +155,7 @@ describe("headless docx review round-trip", () => {
     const baseline = await makeParaIdBaseline(readFixture());
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
     const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    const contentBefore = reviewer.getContentAsText();
 
     const result = reviewer.applyDocumentOperations({
       version: 1,
@@ -181,7 +182,20 @@ describe("headless docx review round-trip", () => {
         affected: [{ type: "block", story: "main", blockId: target.id, effect: "updated" }],
       },
     ]);
+    expect(result.undoHandle).toEqual({
+      type: "documentOperationUndo",
+      id: expect.any(String),
+    });
     expect(await partText(await reviewer.toBuffer(), "word/document.xml")).toContain("<w:ins ");
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.getContentAsText()).toBe(contentBefore);
+    expect(reviewer.getChanges()).toEqual([]);
   });
 
   test("atomic batches reject every operation without document or comment changes", async () => {
@@ -234,6 +248,7 @@ describe("headless docx review round-trip", () => {
         },
       ],
       receipts: [],
+      undoHandle: null,
     });
     expect(reviewer.getContentAsText()).toBe(contentBefore);
     expect(reviewer.getComments()).toEqual([]);
@@ -243,6 +258,7 @@ describe("headless docx review round-trip", () => {
     const baseline = await makeParaIdBaseline(readFixture());
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });
     const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    const contentBefore = reviewer.getContentAsText();
 
     const result = reviewer.applyDocumentOperations({
       version: 1,
@@ -295,6 +311,115 @@ describe("headless docx review round-trip", () => {
     expect(reviewer.getContentAsText()).toContain("Intro paragraph.");
     expect(reviewer.getContentAsText()).toContain("New clause.");
     expect(reviewer.getComments()).toHaveLength(1);
+    expect(result.undoHandle).toEqual({
+      type: "documentOperationUndo",
+      id: expect.any(String),
+    });
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.getContentAsText()).toBe(contentBefore);
+    expect(reviewer.getComments()).toEqual([]);
+
+    const reparsed = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
+    expect(reparsed.getContentAsText()).toBe(contentBefore);
+    expect(reparsed.getComments()).toEqual([]);
+  });
+
+  test("undo handles reject unknown, out-of-order, and changed document state", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const skipped = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [{ id: "missing", type: "deleteBlock", blockId: "missing" }],
+    });
+    expect(skipped.status).toBe("committed");
+    expect(skipped.undoHandle).toBeNull();
+    const heading = findBlock(reviewer.snapshot().blocks, "Heading");
+    const first = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "first",
+          type: "replaceInBlock",
+          blockId: heading.id,
+          find: "Heading",
+          replace: "Intro",
+        },
+      ],
+    });
+    const trailing = findBlock(reviewer.snapshot().blocks, "Trailing");
+    const second = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "second",
+          type: "replaceInBlock",
+          blockId: trailing.id,
+          find: "Trailing",
+          replace: "Closing",
+        },
+      ],
+    });
+    if (!first.undoHandle || !second.undoHandle) {
+      throw new Error("expected undo handles");
+    }
+
+    expect(reviewer.undoDocumentOperations(first.undoHandle)).toEqual({
+      status: "rejected",
+      undoHandle: first.undoHandle,
+      reason: "notLatest",
+    });
+    expect(reviewer.undoDocumentOperations(second.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: second.undoHandle,
+    });
+    expect(reviewer.undoDocumentOperations(first.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: first.undoHandle,
+    });
+    const unknownHandle = { type: "documentOperationUndo", id: "unknown" } as const;
+    expect(reviewer.undoDocumentOperations(unknownHandle)).toEqual({
+      status: "rejected",
+      undoHandle: unknownHandle,
+      reason: "unknownHandle",
+    });
+
+    const changedReviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const changedTarget = findBlock(changedReviewer.snapshot().blocks, "Heading");
+    const changed = changedReviewer.applyDocumentOperations({
+      version: 1,
+      operations: [
+        {
+          id: "changed",
+          type: "replaceInBlock",
+          blockId: changedTarget.id,
+          find: "Heading",
+          replace: "Intro",
+        },
+      ],
+    });
+    if (!changed.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(changedReviewer.undoDocumentOperations(first.undoHandle)).toEqual({
+      status: "rejected",
+      undoHandle: first.undoHandle,
+      reason: "unknownHandle",
+    });
+    changedReviewer.acceptAll();
+    expect(changedReviewer.undoDocumentOperations(changed.undoHandle)).toEqual({
+      status: "rejected",
+      undoHandle: changed.undoHandle,
+      reason: "documentChanged",
+    });
   });
 
   test("dry runs predict best-effort results without document or comment changes", async () => {
@@ -343,6 +468,7 @@ describe("headless docx review round-trip", () => {
           affected: [{ type: "block", story: "main", blockId: target.id, effect: "updated" }],
         },
       ],
+      undoHandle: null,
     });
     expect(reviewer.getContentAsText()).toBe(contentBefore);
     expect(reviewer.getComments()).toEqual([]);
@@ -407,6 +533,7 @@ describe("headless docx review round-trip", () => {
         },
       ],
       receipts: [],
+      undoHandle: null,
     });
     expect(reviewer.getContentAsText()).toContain("Heading paragraph.");
     expect(reviewer.getChanges()).toEqual([]);

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -414,6 +414,33 @@ describe("headless docx review round-trip", () => {
       undoHandle: first.undoHandle,
       reason: "unknownHandle",
     });
+
+    const commentReviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const commentTarget = findBlock(commentReviewer.snapshot().blocks, "Heading");
+    const commented = commentReviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "commented",
+          type: "commentOnBlock",
+          blockId: commentTarget.id,
+          comment: { text: "Review this." },
+        },
+      ],
+    });
+    const parentComment = commentReviewer.getComments().at(0);
+    if (!commented.undoHandle || !parentComment) {
+      throw new Error("expected an undo handle and comment");
+    }
+    commentReviewer.replyTo(parentComment.id, { text: "Keep this reply." });
+    expect(commentReviewer.undoDocumentOperations(commented.undoHandle)).toEqual({
+      status: "rejected",
+      undoHandle: commented.undoHandle,
+      reason: "documentChanged",
+    });
+    expect(commentReviewer.getComments().at(0)?.replies.at(0)?.text).toBe("Keep this reply.");
+
     changedReviewer.acceptAll();
     expect(changedReviewer.undoDocumentOperations(changed.undoHandle)).toEqual({
       status: "rejected",

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -58,6 +58,8 @@ import {
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   type FolioDocumentOperationBatch,
   type FolioDocumentOperationResult,
+  type FolioDocumentOperationUndoHandle,
+  type FolioDocumentOperationUndoResult,
 } from "../document-operations";
 import { buildAnnotatedBlockText } from "./clean-text";
 import {
@@ -83,6 +85,7 @@ import type {
  * across reviewers created within the same millisecond.
  */
 let commentIdCursor = Date.now();
+let undoHandleCursor = Date.now();
 
 /**
  * Build the note-free comment thread the apply layer references by id.
@@ -102,6 +105,13 @@ const createReviewerComment = (text: string, author: string): Comment => ({
     },
   ],
 });
+
+type FolioDocumentOperationUndoEntry = {
+  undoHandle: FolioDocumentOperationUndoHandle;
+  beforeState: EditorState;
+  afterState: EditorState;
+  createdCommentsLengthBefore: number;
+};
 
 /**
  * Assign a stable `w14:paraId` to every body paragraph that lacks one (or
@@ -317,6 +327,7 @@ export class FolioDocxReviewer {
   private readonly originalBuffer: ArrayBuffer;
   private state: EditorState;
   private readonly createdComments: Comment[] = [];
+  private readonly documentOperationUndoEntries: FolioDocumentOperationUndoEntry[] = [];
   /**
    * Resolved-state overrides recorded by {@link resolveComment}, keyed by
    * comment id. Applied on read ({@link getComments}) and on write
@@ -388,7 +399,7 @@ export class FolioDocxReviewer {
     operations: FolioAIEditOperation[],
     options: FolioApplyOperationsOptions = {},
   ): FolioAIEditApplyResult {
-    const { applied, skipped } = this.applyDocumentOperations(
+    const { applied, skipped } = this.applyDocumentOperationsInternal(
       {
         version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
         operations,
@@ -397,6 +408,7 @@ export class FolioDocxReviewer {
       {
         ...(options.snapshot !== undefined && { snapshot: options.snapshot }),
       },
+      false,
     );
     return { applied, skipped };
   }
@@ -411,6 +423,16 @@ export class FolioDocxReviewer {
     batch: FolioDocumentOperationBatch,
     options: FolioApplyDocumentOperationsOptions = {},
   ): FolioDocumentOperationResult {
+    return this.applyDocumentOperationsInternal(batch, options, true);
+  }
+
+  private applyDocumentOperationsInternal(
+    batch: FolioDocumentOperationBatch,
+    options: FolioApplyDocumentOperationsOptions,
+    createUndoEntry: boolean,
+  ): FolioDocumentOperationResult {
+    const beforeState = this.state;
+    const createdCommentsLengthBefore = this.createdComments.length;
     const view = {
       state: this.state,
       dispatch: (transaction: Transaction) => {
@@ -428,10 +450,52 @@ export class FolioDocxReviewer {
         this.createdComments.push(comment);
         return comment.id;
       },
+      ...(createUndoEntry && {
+        createUndoHandle: () => ({
+          type: "documentOperationUndo",
+          id: `headless-${String(undoHandleCursor++)}`,
+        }),
+      }),
     });
 
     this.state = view.state;
+    if (result.undoHandle !== null) {
+      this.documentOperationUndoEntries.push({
+        undoHandle: result.undoHandle,
+        beforeState,
+        afterState: this.state,
+        createdCommentsLengthBefore,
+      });
+    }
     return result;
+  }
+
+  /** Undo the latest unchanged document-operation batch and its created comments. */
+  undoDocumentOperations(
+    undoHandle: FolioDocumentOperationUndoHandle,
+  ): FolioDocumentOperationUndoResult {
+    const entryIndex = this.documentOperationUndoEntries.findIndex(
+      (entry) => entry.undoHandle.type === undoHandle.type && entry.undoHandle.id === undoHandle.id,
+    );
+    if (entryIndex === -1) {
+      return { status: "rejected", undoHandle, reason: "unknownHandle" };
+    }
+    if (entryIndex !== this.documentOperationUndoEntries.length - 1) {
+      return { status: "rejected", undoHandle, reason: "notLatest" };
+    }
+
+    const entry = this.documentOperationUndoEntries.at(-1);
+    if (!entry) {
+      return { status: "rejected", undoHandle, reason: "unknownHandle" };
+    }
+    if (this.state !== entry.afterState) {
+      return { status: "rejected", undoHandle, reason: "documentChanged" };
+    }
+
+    this.state = entry.beforeState;
+    this.createdComments.length = entry.createdCommentsLengthBefore;
+    this.documentOperationUndoEntries.pop();
+    return { status: "undone", undoHandle };
   }
 
   /**

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -111,6 +111,7 @@ type FolioDocumentOperationUndoEntry = {
   beforeState: EditorState;
   afterState: EditorState;
   createdCommentsLengthBefore: number;
+  createdCommentsLengthAfter: number;
 };
 
 /**
@@ -465,6 +466,7 @@ export class FolioDocxReviewer {
         beforeState,
         afterState: this.state,
         createdCommentsLengthBefore,
+        createdCommentsLengthAfter: this.createdComments.length,
       });
     }
     return result;
@@ -488,7 +490,10 @@ export class FolioDocxReviewer {
     if (!entry) {
       return { status: "rejected", undoHandle, reason: "unknownHandle" };
     }
-    if (this.state !== entry.afterState) {
+    if (
+      this.state !== entry.afterState ||
+      this.createdComments.length !== entry.createdCommentsLengthAfter
+    ) {
       return { status: "rejected", undoHandle, reason: "documentChanged" };
     }
 

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -68,4 +68,7 @@ export {
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
   type FolioDocumentOperationStatus,
+  type FolioDocumentOperationUndoFailureReason,
+  type FolioDocumentOperationUndoHandle,
+  type FolioDocumentOperationUndoResult,
 } from "../document-operations";

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -639,6 +639,28 @@ export type FolioDocumentOperationReceipt = {
   affected: FolioDocumentOperationAffectedTarget[];
 };
 
+/** Opaque handle for undoing one committed document-operation batch. */
+export type FolioDocumentOperationUndoHandle = {
+  type: "documentOperationUndo";
+  id: string;
+};
+
+export type FolioDocumentOperationUndoFailureReason =
+  | "unknownHandle"
+  | "notLatest"
+  | "documentChanged";
+
+export type FolioDocumentOperationUndoResult =
+  | {
+      status: "undone";
+      undoHandle: FolioDocumentOperationUndoHandle;
+    }
+  | {
+      status: "rejected";
+      undoHandle: FolioDocumentOperationUndoHandle;
+      reason: FolioDocumentOperationUndoFailureReason;
+    };
+
 export type FolioDocumentOperationResult = {
   version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
   status: FolioDocumentOperationStatus;
@@ -647,6 +669,8 @@ export type FolioDocumentOperationResult = {
   issues: FolioDocumentOperationIssue[];
   /** Successful effects in input-operation order; skipped operations are omitted. */
   receipts: FolioDocumentOperationReceipt[];
+  /** Present when the execution surface can undo this committed batch. */
+  undoHandle: FolioDocumentOperationUndoHandle | null;
 };
 
 const recoveryByReason = {
@@ -771,6 +795,7 @@ export type ApplyFolioDocumentOperationsOptions = {
   batch: FolioDocumentOperationBatch;
   author?: string;
   createCommentId?: (text: string) => number;
+  createUndoHandle?: () => FolioDocumentOperationUndoHandle;
 };
 
 type ApplyParsedDocumentOperationBatchOptions = {
@@ -785,6 +810,7 @@ export const applyFolioDocumentOperations = ({
   batch,
   author,
   createCommentId,
+  createUndoHandle,
 }: ApplyFolioDocumentOperationsOptions): FolioDocumentOperationResult => {
   const parsedBatch = parseFolioDocumentOperationBatch(batch);
   const apply = ({
@@ -823,6 +849,7 @@ export const applyFolioDocumentOperations = ({
       skipped,
       issues: getFolioDocumentOperationIssues(parsedBatch.operations, skipped),
       receipts: [],
+      undoHandle: null,
     };
   };
 
@@ -838,6 +865,7 @@ export const applyFolioDocumentOperations = ({
       skipped: previewResult.skipped,
       issues: getFolioDocumentOperationIssues(parsedBatch.operations, previewResult.skipped),
       receipts: getFolioDocumentOperationReceipts(parsedBatch.operations, previewResult.applied),
+      undoHandle: null,
     };
   }
 
@@ -855,5 +883,7 @@ export const applyFolioDocumentOperations = ({
     ...result,
     issues: getFolioDocumentOperationIssues(parsedBatch.operations, result.skipped),
     receipts: getFolioDocumentOperationReceipts(parsedBatch.operations, result.applied),
+    undoHandle:
+      result.applied.length > 0 && createUndoHandle !== undefined ? createUndoHandle() : null,
   };
 };

--- a/packages/core/src/i18n/GLOSSARY-NOTES.md
+++ b/packages/core/src/i18n/GLOSSARY-NOTES.md
@@ -41,6 +41,7 @@ per locale below).
 ## Per-locale notes
 
 ### cs (thorough; sourced from cs-cz support articles)
+
 - Sourced: Sledování změn, revize, komentář, poznámka pod čarou, vysvětlivka, záhlaví,
   zápatí, konec stránky, konec oddílu (via search), obsah, hypertextový odkaz, orientace,
   na výšku / na šířku, Vzhled stránky, okraje, tučné, kurzíva, podtržení, přeškrtnutí,
@@ -59,6 +60,7 @@ per locale below).
   only prose descriptions).
 
 ### de (sourced: de-de shortcuts article; LO help for divergences)
+
 - Sourced: Änderungen nachverfolgen, Fußnote, Endnote, Seitenumbruch, Kopfzeile,
   Fußzeile, Formatvorlage, Fett, Kursiv, Unterstrichen, Hochgestellt, Tiefgestellt,
   Wiederholen (redo), Speichern, Ersetzen, Löschen, Kommentar, Hyperlink, Absatz, Tabelle.
@@ -77,12 +79,14 @@ per locale below).
   (standard Windows/Office term).
 
 ### es (sourced: es-es shortcuts article)
+
 - All verbs + formatting sourced. Word vs LO: TOC "Tabla de contenido" (Word) vs
   **"Sumario"** (LO); hyperlink "hipervínculo" (Word) vs "hiperenlace" (LO).
 - forbidden "Salvar" (save): anglicism; both suites use "Guardar".
 - portrait/landscape: Word es uses "Vertical" / "Horizontal" (not "retrato/paisaje").
 
 ### fr (sourced: fr-fr shortcuts article)
+
 - Sourced: Enregistrer, Annuler, Rétablir, note de bas de page, note de fin, saut de
   page, suivi des modifications, lien hypertexte, exposant, indice, gras/italique/souligné.
 - Word vs LO: bookmark **signet** (Word) vs "repère de texte" (LO); reject **Refuser**
@@ -91,6 +95,7 @@ per locale below).
   "Enregistrer". forbidden "indentation" (indent): anglicism; both suites use "retrait".
 
 ### pt-BR (sourced: pt-br shortcuts article)
+
 - Sourced: Salvar, Desfazer, Refazer, Recortar, Excluir, Localizar, Substituir,
   Controle de alterações, nota de rodapé, nota de fim, quebra de página, cabeçalho,
   rodapé, hiperlink, sobrescrito, subscrito.
@@ -107,6 +112,7 @@ per locale below).
   circulates.
 
 ### pl (sourced: pl-pl shortcuts article)
+
 - Sourced: Śledzenie zmian, przypis dolny, przypis końcowy, podział strony, nagłówek,
   stopka, hiperłącze, pogrubienie, kursywa, podkreślenie, indeks górny/dolny, akapit,
   Zapisz-family verbs.
@@ -119,6 +125,7 @@ per locale below).
   no clean single noun attested).
 
 ### tr (sourced: tr-tr shortcuts article)
+
 - Sourced: Kaydet, Geri Al, Yinele, değişiklik izleme, dipnot, son not, sayfa sonu,
   açıklama, üstbilgi/altbilgi (article spells "Üst bilgi"/"Alt bilgi"; ribbon uses the
   closed compounds "Üstbilgi"/"Altbilgi" — closed form kept), köprü, üst/alt simge.
@@ -130,6 +137,7 @@ per locale below).
   (notes only).
 
 ### hu (sourced: hu-hu shortcuts + track-changes articles)
+
 - Sourced: Változások követése (feature), **korrektúra = revision/markup**, Elfogadás,
   Elvetés, lábjegyzet, végjegyzet, oldaltörés, megjegyzés, élőfej, élőláb, hivatkozás,
   félkövér, dőlt, aláhúzott, felső/alsó index, bekezdés, Mentés-family verbs.
@@ -144,6 +152,7 @@ per locale below).
   (Ismét/Ismétlés?) vs LO hu "Újra" could not be attested confidently.
 
 ### sk (sourced: sk-sk shortcuts + footnotes articles)
+
 - Sourced: Sledovanie zmien (article verb form "Sledovať zmeny"), poznámka pod čiarou,
   **vysvetlivka** (endnote — NOT "koncová poznámka"), zlom strany, hlavička, päta,
   hypertextové prepojenie, tučné, kurzíva, podčiarknutie, horný/dolný index, odsek,
@@ -156,6 +165,7 @@ per locale below).
   Nastavenie strany, Hľadať a nahradiť, prečiarknutie.
 
 ### zh-CN (sourced: zh-cn shortcuts, track-changes, footnotes, orientation articles)
+
 - Sourced: 修订/跟踪修订 (see below), 批注, 脚注, 尾注, 页眉, 页脚, 分页符, 超链接, 加粗,
   倾斜, 下划线, 上标, 下标, 样式, 段落, 表格, 页边距, 页面设置, 纵向, 横向, 保存, 撤消,
   重做, 复制, 粘贴, 剪切, 打印, 查找, 替换, 删除, 插入, 接受, 拒绝.
@@ -169,7 +179,7 @@ per locale below).
   (repeat). Canonical 重做.
 - bold/italic: Word zh-CN = **加粗 / 倾斜**; LO zh-CN = 粗体 / 斜体 (notes only, not
   forbidden).
-- Forbidden entries are verified zh-TW Word terms where Taiwan uses a *different word*,
+- Forbidden entries are verified zh-TW Word terms where Taiwan uses a _different word_,
   not merely traditional script: 註解 (comment), 註腳 (footnote), 章節附註 (endnote),
   頁首/頁尾 (header/footer), 分頁符號/分節符號 (breaks), 超連結 (hyperlink), 浮水印
   (watermark), 縮排 (indent), 底線 (underline), 儲存格 (cell), 版面設定 (page setup),
@@ -178,6 +188,7 @@ per locale below).
   Pure same-word traditional spellings (e.g. 刪除, 樣式) were NOT listed as forbidden.
 
 ### ar (sourced: ar-sa shortcuts article)
+
 - Sourced: تعقب التغييرات, حاشية سفلية, **تعليق ختامي** (endnote), فاصل صفحات, رأس الصفحة,
   تذييل الصفحة, ارتباط تشعبي, غامق, مائل, تسطير, نمط, فقرة, جدول, verbs نسخ/لصق/قص/طباعة/
   حذف/استبدال/إدراج (via "إدراج حاشية").
@@ -188,6 +199,7 @@ per locale below).
   بحث واستبدال, قبول/رفض, تراجع/إعادة, حفظ.
 
 ### he (sourced: he-il shortcuts article)
+
 - Sourced: מעקב אחר שינויים, הערת שוליים, הערת סיום, מעבר עמוד, הערה (comment),
   היפר-קישור, מודגש, נטוי, קו תחתון, סגנון, טבלה, שמור/העתק/הדבק/גזור/הדפס/החלף/בצע שוב.
 - Platform knowledge: כותרת עליונה/תחתונה (header/footer — absent from article but
@@ -199,6 +211,7 @@ per locale below).
 - orientation: plain כיוון kept (Word he layout wording; sometimes כיוון הדפסה).
 
 ### et (sourced: et-ee shortcuts article; deliberately sparse)
+
 - Sourced: allmärkus, lõpumärkus, leheküljepiir, kommentaar, muutuste jälitus, päis,
   jalus (article rendered the inflected/typo "jalas"; nominative is jalus), hüperlink,
   lõik, tabel, **laad** (style — distinctive; LO et uses "stiil"), paks, kursiiv,
@@ -212,6 +225,7 @@ per locale below).
   portrait/landscape, page setup, find-and-replace, accept, reject.
 
 ### lt (sourced: lt-lt shortcuts article; deliberately sparse)
+
 - Sourced: **puslapio išnaša** (footnote) / **dokumento išnaša** (endnote) — Word lt
   qualifies both, plain "išnaša" is the generic word; puslapio lūžis, komentaras,
   keitimų sekimas (article verb "Sekti keitimus"), antraštė, poraštė, hipersaitas,
@@ -226,6 +240,7 @@ per locale below).
   find-and-replace, accept, reject.
 
 ### lv (sourced: lv-lv shortcuts article; deliberately sparse)
+
 - Sourced: **izmaiņu reģistrēšana** (Track Changes — distinctive Word lv term),
   lappuses pārtraukums, komentārs, galvene, kājene, hipersaite, rindkopa, tabula, stils,
   treknraksts, slīpraksts, pasvītrojums, augšraksts, apakšraksts, Saglabāt, Atsaukt,
@@ -236,6 +251,7 @@ per locale below).
   break, strikethrough, orientation set, page setup, find-and-replace, accept, reject.
 
 ### hi (deliberately very sparse)
+
 - support.microsoft.com hi-in serves English-only content (verified on two articles), so
   no article attestation was possible. Only high-confidence Microsoft Hindi LIP/Office
   terms are included: टिप्पणी (comment), तालिका (table), अनुच्छेद (paragraph), शैली
@@ -248,25 +264,25 @@ per locale below).
 
 ## Word-vs-LibreOffice divergence summary (LO variant NOT forbidden)
 
-| Locale | Concept | Word (canonical) | LibreOffice |
-|---|---|---|---|
-| cs | page break | Konec stránky | Zalomení stránky (sourced) |
-| de | track changes | Änderungen nachverfolgen | Änderungen (verfolgen)/Aufzeichnen (sourced) |
-| de | bookmark | Textmarke | Lesezeichen |
-| de | style | Formatvorlage | (Absatz)Vorlage |
-| de | redo | Wiederholen | Wiederherstellen |
-| es | TOC | Tabla de contenido | Sumario |
-| es | hyperlink | Hipervínculo | Hiperenlace |
-| fr | bookmark | Signet | Repère de texte |
-| fr | reject | Refuser | Rejeter |
-| pt-BR | bookmark | Indicador | Marcador / Marca-página |
-| pl | find & replace | Znajdowanie i zamienianie | Znajdź i zamień |
-| pl | redo | Wykonaj ponownie | Ponów |
-| sk | watermark | Vodotlač | Vodoznak |
-| sk | redo | Zopakovať | Znova |
-| zh-CN | bold / italic | 加粗 / 倾斜 | 粗体 / 斜体 |
-| zh-CN | undo spelling | 撤消 | 撤销 |
-| et | style | Laad | Stiil |
+| Locale | Concept        | Word (canonical)          | LibreOffice                                  |
+| ------ | -------------- | ------------------------- | -------------------------------------------- |
+| cs     | page break     | Konec stránky             | Zalomení stránky (sourced)                   |
+| de     | track changes  | Änderungen nachverfolgen  | Änderungen (verfolgen)/Aufzeichnen (sourced) |
+| de     | bookmark       | Textmarke                 | Lesezeichen                                  |
+| de     | style          | Formatvorlage             | (Absatz)Vorlage                              |
+| de     | redo           | Wiederholen               | Wiederherstellen                             |
+| es     | TOC            | Tabla de contenido        | Sumario                                      |
+| es     | hyperlink      | Hipervínculo              | Hiperenlace                                  |
+| fr     | bookmark       | Signet                    | Repère de texte                              |
+| fr     | reject         | Refuser                   | Rejeter                                      |
+| pt-BR  | bookmark       | Indicador                 | Marcador / Marca-página                      |
+| pl     | find & replace | Znajdowanie i zamienianie | Znajdź i zamień                              |
+| pl     | redo           | Wykonaj ponownie          | Ponów                                        |
+| sk     | watermark      | Vodotlač                  | Vodoznak                                     |
+| sk     | redo           | Zopakovať                 | Znova                                        |
+| zh-CN  | bold / italic  | 加粗 / 倾斜               | 粗体 / 斜体                                  |
+| zh-CN  | undo spelling  | 撤消                      | 撤销                                         |
+| et     | style          | Laad                      | Stiil                                        |
 
 ## Coverage summary
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,9 @@ export {
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
   type FolioDocumentOperationStatus,
+  type FolioDocumentOperationUndoFailureReason,
+  type FolioDocumentOperationUndoHandle,
+  type FolioDocumentOperationUndoResult,
 } from "./ai-edits";
 export {
   resolveSuggestionAnchor,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -96,4 +96,7 @@ export {
   type FolioDocumentOperationType,
   type FolioDocumentOperationResult,
   type FolioDocumentOperationStatus,
+  type FolioDocumentOperationUndoFailureReason,
+  type FolioDocumentOperationUndoHandle,
+  type FolioDocumentOperationUndoResult,
 } from "./document-operations";

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2831,6 +2831,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             skipped,
             issues: getFolioDocumentOperationIssues(batch.operations, skipped),
             receipts: [],
+            undoHandle: null,
           };
         }
 

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -321,6 +321,7 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
           skipped,
           issues: getFolioDocumentOperationIssues(batch.operations, skipped),
           receipts: [],
+          undoHandle: null,
         };
       }
       return applyFolioDocumentOperations({


### PR DESCRIPTION
Adds typed undo handles for committed document-operation batches and strict headless reversal semantics. Includes API snapshots and coverage for stale, out-of-order, unknown, and comment-restoring undo paths.