### PR TITLE
fix: render footnotes referenced in tables

### DIFF
--- a/.changeset/tables-render-footnotes.md
+++ b/.changeset/tables-render-footnotes.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render and reserve footnotes referenced from table cells.

--- a/packages/core/src/layout-engine/footnoteLineReservation.test.ts
+++ b/packages/core/src/layout-engine/footnoteLineReservation.test.ts
@@ -9,6 +9,8 @@ import type {
   ParagraphMeasure,
   PageMargins,
   TextRun,
+  TableBlock,
+  TableMeasure,
 } from "./types";
 
 // Single-pass footnote layout: each body line carrying a footnote ref
@@ -67,6 +69,73 @@ function textRun(pmStart: number, text: string, footnoteRefId?: number): TextRun
 }
 
 describe("footnote line-level reservation", () => {
+  test("reserves and records footnotes referenced inside table cells", () => {
+    const paragraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "cell-paragraph",
+      runs: [textRun(1, "cell"), textRun(5, "1", 9)],
+    };
+    const table: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [{ id: "row", cells: [{ id: "cell", blocks: [paragraph] }] }],
+    };
+    const tableMeasure: TableMeasure = {
+      kind: "table",
+      rows: [{ cells: [{ blocks: [], width: 100, height: 20 }], height: 20 }],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 20,
+    };
+
+    const layout = layoutDocument([table], [tableMeasure], {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[9, 30]]),
+    });
+
+    expect(layout.pages[0]!.footnoteIds).toEqual([9]);
+    expect(layout.pages[0]!.footnoteReservedHeight).toBeGreaterThanOrEqual(30);
+  });
+
+  test("moves a footnote-bearing table row with its footnote reservation", () => {
+    const { block: paragraph, measure: paragraphMeasure } = makePara(
+      1,
+      [textRun(1, "body")],
+      2,
+      10,
+    );
+    const cellParagraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "cell-paragraph",
+      runs: [textRun(10, "cell"), textRun(14, "1", 9)],
+    };
+    const table: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [{ id: "row", cells: [{ id: "cell", blocks: [cellParagraph] }] }],
+    };
+    const tableMeasure: TableMeasure = {
+      kind: "table",
+      rows: [{ cells: [{ blocks: [], width: 100, height: 20 }], height: 20 }],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 20,
+    };
+
+    const layout = layoutDocument([paragraph, table], [paragraphMeasure, tableMeasure], {
+      pageSize: { w: 600, h: 60 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[9, 30]]),
+    });
+
+    expect(layout.pages[0]!.footnoteIds).toBeUndefined();
+    expect(layout.pages[1]!.footnoteIds).toEqual([9]);
+    expect(layout.pages[1]!.fragments.some((fragment) => fragment.blockId === "table")).toBe(true);
+  });
+
   test("page reserves fn-content space for each line carrying a fn ref", () => {
     // Page 100 px tall. Line height 10 px. Fn 1 height 30 px.
     // A 5-line para where line 3 carries fn ref 1 should keep all

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -789,6 +789,9 @@ function layoutTable(
   if (rows.length === 0) {
     return;
   }
+  const rowFootnoteIds = block.rows.map((row) =>
+    collectTableRowFootnoteIds(row, footnoteHeightById),
+  );
 
   // Detect header rows (consecutive rows at start with isHeader: true)
   const headerRowCount = countHeaderRows(block);
@@ -963,10 +966,10 @@ function layoutTable(
 
     for (let j = currentRowIndex; j < rows.length; j++) {
       const rowHeight = rows[j]!.height; // SAFETY: j < rows.length
-      const rowFootnoteIds = collectTableRowFootnoteIds(block.rows[j], footnoteHeightById);
+      const currentRowFootnoteIds = rowFootnoteIds[j] ?? [];
       const fragmentFootnoteCountBeforeRow = fragmentFootnoteIds.length;
       let rowFootnoteHeight = 0;
-      for (const id of rowFootnoteIds) {
+      for (const id of currentRowFootnoteIds) {
         if (pageFootnoteIds.has(id) || fragmentFootnoteIds.includes(id)) {
           continue;
         }
@@ -990,16 +993,15 @@ function layoutTable(
         fragmentFootnoteHeight += rowFootnoteHeight;
         fittingRows++;
       } else if (fittingRows === 0) {
-        fragmentFootnoteIds.splice(fragmentFootnoteCountBeforeRow);
         const isFreshFlowRegion =
           state.cursorY === state.topMargin && state.page.fragments.length === 0;
         if (isFreshFlowRegion) {
           rowsHeight += rowHeight;
           fragmentFootnoteHeight += rowFootnoteHeight;
-          fragmentFootnoteIds.push(...rowFootnoteIds);
           fittingRows++;
           break;
         }
+        fragmentFootnoteIds.splice(fragmentFootnoteCountBeforeRow);
         paginator.forceColumnBreak();
         retryOnNextFlowRegion = true;
         break;

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -386,7 +386,7 @@ export function layoutDocument(
             paginator.getContentWidth(),
           );
         } else {
-          layoutTable(block, measure as TableMeasure, paginator);
+          layoutTable(block, measure as TableMeasure, paginator, options.footnoteHeightById);
         }
         break;
 
@@ -783,6 +783,7 @@ function layoutTable(
   block: TableBlock,
   measure: TableMeasure,
   paginator: ReturnType<typeof createPaginator>,
+  footnoteHeightById?: Map<number, number>,
 ): void {
   const rows = measure.rows;
   if (rows.length === 0) {
@@ -955,17 +956,61 @@ function layoutTable(
     // Calculate how many rows fit (excluding header rows which are prepended separately)
     let rowsHeight = 0;
     let fittingRows = 0;
+    const pageFootnoteIds = new Set(state.page.footnoteIds ?? []);
+    const fragmentFootnoteIds: number[] = [];
+    let fragmentFootnoteHeight = 0;
+    let retryOnNextFlowRegion = false;
 
     for (let j = currentRowIndex; j < rows.length; j++) {
       const rowHeight = rows[j]!.height; // SAFETY: j < rows.length
-      const totalWithRow = rowsHeight + rowHeight + normalHeaderOverhead;
+      const rowFootnoteIds = collectTableRowFootnoteIds(block.rows[j], footnoteHeightById);
+      const fragmentFootnoteCountBeforeRow = fragmentFootnoteIds.length;
+      let rowFootnoteHeight = 0;
+      for (const id of rowFootnoteIds) {
+        if (pageFootnoteIds.has(id) || fragmentFootnoteIds.includes(id)) {
+          continue;
+        }
+        fragmentFootnoteIds.push(id);
+        rowFootnoteHeight += footnoteHeightById?.get(id) ?? 0;
+      }
+      const separatorHeight =
+        pageFootnoteIds.size === 0 && fragmentFootnoteHeight + rowFootnoteHeight > 0
+          ? FOOTNOTE_SEPARATOR_HEIGHT
+          : 0;
+      const totalWithRow =
+        rowsHeight +
+        rowHeight +
+        normalHeaderOverhead +
+        fragmentFootnoteHeight +
+        rowFootnoteHeight +
+        separatorHeight;
 
-      if (totalWithRow <= availableHeight || fittingRows === 0) {
+      if (totalWithRow <= availableHeight) {
         rowsHeight += rowHeight;
+        fragmentFootnoteHeight += rowFootnoteHeight;
         fittingRows++;
+      } else if (fittingRows === 0) {
+        fragmentFootnoteIds.splice(fragmentFootnoteCountBeforeRow);
+        const isFreshFlowRegion =
+          state.cursorY === state.topMargin && state.page.fragments.length === 0;
+        if (isFreshFlowRegion) {
+          rowsHeight += rowHeight;
+          fragmentFootnoteHeight += rowFootnoteHeight;
+          fragmentFootnoteIds.push(...rowFootnoteIds);
+          fittingRows++;
+          break;
+        }
+        paginator.forceColumnBreak();
+        retryOnNextFlowRegion = true;
+        break;
       } else {
+        fragmentFootnoteIds.splice(fragmentFootnoteCountBeforeRow);
         break;
       }
+    }
+
+    if (retryOnNextFlowRegion) {
+      continue;
     }
 
     // Total fragment height includes header rows for continuation fragments
@@ -994,6 +1039,9 @@ function layoutTable(
       ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
     };
 
+    if (fragmentFootnoteHeight > 0) {
+      paginator.addFootnoteHeight(fragmentFootnoteHeight, fragmentFootnoteIds);
+    }
     const result = paginator.addFragment(fragment, fragmentHeight, bandSkip, 0);
     fragment.y = result.y;
     fragment.x = desiredX;
@@ -1021,6 +1069,50 @@ function layoutTable(
       paginator.ensureFits(nextRowHeight);
     }
   }
+}
+
+function collectTableRowFootnoteIds(
+  row: TableBlock["rows"][number] | undefined,
+  footnoteHeightById: Map<number, number> | undefined,
+): number[] {
+  if (!row || !footnoteHeightById) {
+    return [];
+  }
+
+  const ids: number[] = [];
+  const walk = (blocks: FlowBlock[]): void => {
+    for (const block of blocks) {
+      if (block.kind === "paragraph") {
+        for (const run of block.runs) {
+          if (
+            run.kind === "text" &&
+            run.footnoteRefId !== undefined &&
+            footnoteHeightById.has(run.footnoteRefId) &&
+            !ids.includes(run.footnoteRefId)
+          ) {
+            ids.push(run.footnoteRefId);
+          }
+        }
+        continue;
+      }
+      if (block.kind === "table") {
+        for (const nestedRow of block.rows) {
+          for (const cell of nestedRow.cells) {
+            walk(cell.blocks);
+          }
+        }
+        continue;
+      }
+      if (block.kind === "textBox") {
+        walk(block.content);
+      }
+    }
+  };
+
+  for (const cell of row.cells) {
+    walk(cell.blocks);
+  }
+  return ids;
 }
 
 /**


### PR DESCRIPTION
## Summary

- reserve footnote space for references inside table rows
- record table-cell footnotes on the page that contains their row
- keep a footnote-bearing row with its reservation when pagination advances

CI runs the repository-wide lint, typecheck, build, and test commands.