### PR TITLE
fix: measure rowspans across table rows

### DIFF
--- a/.changeset/measure-rowspan-height.md
+++ b/.changeset/measure-rowspan-height.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Measure vertically merged table cells against their combined row height.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -131,6 +131,82 @@ describe("measureBlocks", () => {
 });
 
 describe("measureTableBlock row height", () => {
+  test("measures a row-spanning cell against the combined spanned-row height", () => {
+    withFakeTextMeasure(() => {
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120, 120],
+        rows: [
+          {
+            id: "r0",
+            height: 30,
+            cells: [
+              {
+                id: "span",
+                rowSpan: 2,
+                blocks: [para("span-1", "First"), para("span-2", "Second")],
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              },
+              { id: "r0-cell", blocks: [para("r0-p", "Row zero")] },
+            ],
+          },
+          {
+            id: "r1",
+            height: 30,
+            cells: [{ id: "r1-cell", blocks: [para("r1-p", "Row one")] }],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 240);
+
+      expect(measure.rows.map((row) => row.height)).toEqual([30, 30]);
+      expect(measure.totalHeight).toBe(60);
+    }, fakeMeasure);
+  });
+
+  test("adds a row-spanning content deficit to the last non-exact row", () => {
+    withFakeTextMeasure(() => {
+      const spanningBlocks = Array.from({ length: 6 }, (_, index) =>
+        para(`span-${index}`, `Line ${index}`),
+      );
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120, 120],
+        rows: [
+          {
+            id: "r0",
+            height: 20,
+            heightRule: "exact",
+            cells: [
+              {
+                id: "span",
+                rowSpan: 2,
+                blocks: spanningBlocks,
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              },
+              { id: "r0-cell", blocks: [para("r0-p", "Row zero")] },
+            ],
+          },
+          {
+            id: "r1",
+            height: 20,
+            cells: [{ id: "r1-cell", blocks: [para("r1-p", "Row one")] }],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 240);
+      const spanningCellHeight = measure.rows[0]!.cells[0]!.height;
+
+      expect(measure.rows[0]!.height).toBe(20);
+      expect(measure.rows[1]!.height).toBe(spanningCellHeight - 20);
+      expect(measure.totalHeight).toBe(spanningCellHeight);
+    }, fakeMeasure);
+  });
+
   test("counts a collapsed top border only on the first row", () => {
     withFakeTextMeasure(() => {
       const borderedCell = (id: string) => ({

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -337,6 +337,9 @@ export function measureTableBlock(
       const padTop = sourceCell?.padding?.top ?? DEFAULT_CELL_PADDING_Y;
       const padBottom = sourceCell?.padding?.bottom ?? DEFAULT_CELL_PADDING_Y;
       cell.height += padTop + padBottom;
+      if ((sourceCell?.rowSpan ?? 1) > 1) {
+        continue;
+      }
       const borderHeight = getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0);
       maxCellHeightWithBorders = Math.max(maxCellHeightWithBorders, cell.height + borderHeight);
       maxBorderHeight = Math.max(maxBorderHeight, borderHeight);
@@ -359,6 +362,44 @@ export function measureTableBlock(
     } else {
       // No explicit height — use content height directly.
       row.height = maxCellHeightWithBorders;
+    }
+  }
+
+  // A vertically merged cell occupies the combined height of all rows it
+  // spans. Its content must constrain that combined area, not inflate the
+  // first row independently. Apply any remaining deficit to the last
+  // non-exact row in the span after every row has its own base height.
+  for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+    const sourceRow = tableBlock.rows[rowIdx];
+    const measuredRow = rows[rowIdx];
+    if (!sourceRow || !measuredRow) {
+      continue;
+    }
+    for (let cellIdx = 0; cellIdx < sourceRow.cells.length; cellIdx++) {
+      const sourceCell = sourceRow.cells[cellIdx];
+      const measuredCell = measuredRow.cells[cellIdx];
+      const rowSpan = sourceCell?.rowSpan ?? 1;
+      if (!sourceCell || !measuredCell || rowSpan <= 1) {
+        continue;
+      }
+      const spanEnd = Math.min(rows.length, rowIdx + rowSpan);
+      let combinedHeight = 0;
+      for (let spannedRowIdx = rowIdx; spannedRowIdx < spanEnd; spannedRowIdx++) {
+        combinedHeight += rows[spannedRowIdx]?.height ?? 0;
+      }
+      const requiredHeight =
+        measuredCell.height + getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0);
+      const deficit = requiredHeight - combinedHeight;
+      if (deficit <= 0) {
+        continue;
+      }
+      for (let spannedRowIdx = spanEnd - 1; spannedRowIdx >= rowIdx; spannedRowIdx--) {
+        if (tableBlock.rows[spannedRowIdx]?.heightRule === "exact") {
+          continue;
+        }
+        rows[spannedRowIdx]!.height += deficit;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- constrain vertically merged cell content against the combined spanned-row height
- preserve explicit and exact row-height behavior within the span
- add regressions for satisfied spans and content deficits

CI runs the repository-wide lint, typecheck, build, and test commands.