### PR TITLE
fix: preserve DOCX redline invariants

### DIFF
--- a/.changeset/calm-comments-parse.md
+++ b/.changeset/calm-comments-parse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Accept DOCX comments with missing or empty author metadata.

--- a/.changeset/empty-base-redlines.md
+++ b/.changeset/empty-base-redlines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Generate tracked additions when comparing against an empty document.

--- a/.changeset/orderly-redlines.md
+++ b/.changeset/orderly-redlines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve the order of consecutive trailing blocks in generated redlines.

--- a/.changeset/tracked-note-references.md
+++ b/.changeset/tracked-note-references.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve footnote and endnote references inside tracked insertions and deletions.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -235,7 +235,8 @@ export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguous
 // @public (undocumented)
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
-    anchors: Record<string, FolioAIBlockAnchor>;
+    anchors: Record<string, FolioAIBlockAnchor>; /** Hidden empty paragraph used to anchor insertions when `blocks` is empty. */
+    emptyDocumentAnchorId?: string;
 };
 
 // @public

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -583,7 +583,8 @@ export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguous
 // @public (undocumented)
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
-    anchors: Record<string, FolioAIBlockAnchor>;
+    anchors: Record<string, FolioAIBlockAnchor>; /** Hidden empty paragraph used to anchor insertions when `blocks` is empty. */
+    emptyDocumentAnchorId?: string;
 };
 
 // @public

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -583,7 +583,8 @@ export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguous
 // @public (undocumented)
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
-    anchors: Record<string, FolioAIBlockAnchor>;
+    anchors: Record<string, FolioAIBlockAnchor>; /** Hidden empty paragraph used to anchor insertions when `blocks` is empty. */
+    emptyDocumentAnchorId?: string;
 };
 
 // @public

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -267,7 +267,8 @@ export type FolioAIEditPrecondition = {
 // @public (undocumented)
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
-    anchors: Record<string, FolioAIBlockAnchor>;
+    anchors: Record<string, FolioAIBlockAnchor>; /** Hidden empty paragraph used to anchor insertions when `blocks` is empty. */
+    emptyDocumentAnchorId?: string;
 };
 
 // @public (undocumented)

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -327,6 +327,36 @@ describe("Folio AI edit operations", () => {
     expect(snapshot.anchors["seq-0001"]?.textHash).toMatch(/^h/u);
   });
 
+  test("an entirely empty document exposes an operation anchor without a visible block", () => {
+    const state = makeState([""]);
+
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+
+    expect(snapshot.blocks).toEqual([]);
+    expect(snapshot.emptyDocumentAnchorId).toBe("seq-0001");
+    expect(snapshot.anchors["seq-0001"]).toMatchObject({
+      id: "seq-0001",
+      text: "",
+      normalizedText: "",
+      hashOccurrenceCount: 1,
+    });
+  });
+
+  test("an empty table cell is not treated as an empty-document operation anchor", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [schema.node("tableCell", null, [schema.node("paragraph")])]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc });
+
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+
+    expect(snapshot.blocks).toEqual([]);
+    expect(snapshot.emptyDocumentAnchorId).toBeUndefined();
+    expect(snapshot.anchors).toEqual({});
+  });
+
   test("snapshot uses sequential fallback ids for duplicate paraIds", () => {
     const state = makeState([
       { text: "First paragraph.", paraId: "AAAA0001" },

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1113,14 +1113,25 @@ const resolveOperation = ({
   if (operation.type === "deleteBlock" || operation.type === "replaceBlock") {
     const range = getTextRangeFromCleanBlock(cleanBlock);
     if (!range) {
-      // Empty block. The AI never sees these — the snapshot
-      // explicitly skips blocks whose normalised text is empty,
-      // so by construction the resolver only ever lands here on a
-      // block that was non-empty at snapshot time and got emptied
-      // between snapshot and apply. The textHash gate above already
-      // rejects that case as `changedBlock`, so this branch is
-      // unreachable through the real flow; keeping the skip as a
-      // defensive guard.
+      const insertionPoint = cleanBlock.offsets.at(0);
+      if (
+        operation.type === "replaceBlock" &&
+        currentText.length === 0 &&
+        operation.text.length > 0 &&
+        insertionPoint !== undefined
+      ) {
+        return {
+          type: "resolved",
+          operation: {
+            operation,
+            from: insertionPoint,
+            to: insertionPoint,
+            blockFrom,
+            blockTo,
+            blockNode,
+          },
+        };
+      }
       return { type: "skip", reason: "unsupportedBlock" };
     }
     // The model occasionally emits replaceBlock with text identical

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -62,9 +62,13 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   }[] = [];
   const hashCounts = new Map<string, number>();
   const usedBlockIds = new Set<string>();
+  const emptyAnchorState: {
+    candidate: { from: number; to: number; paraId: string | null } | null;
+    textblockCount: number;
+  } = { candidate: null, textblockCount: 0 };
 
   let blockIndex = 0;
-  doc.descendants((node, pos) => {
+  doc.descendants((node, pos, parent) => {
     if (!node.isTextblock) {
       return;
     }
@@ -79,6 +83,18 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     const { text } = buildCleanBlockText(node, pos);
     const normalizedText = normalizeFolioAIBlockText(text);
     if (normalizedText.length === 0) {
+      if (parent?.type !== doc.type) {
+        return;
+      }
+      emptyAnchorState.textblockCount++;
+      if (emptyAnchorState.candidate === null) {
+        const paraIdAttr: unknown = node.attrs["paraId"];
+        emptyAnchorState.candidate = {
+          from: pos,
+          to: pos + node.nodeSize,
+          paraId: typeof paraIdAttr === "string" && paraIdAttr.length > 0 ? paraIdAttr : null,
+        };
+      }
       return;
     }
 
@@ -141,7 +157,27 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     };
   }
 
-  return { blocks, anchors };
+  const emptyAnchorCandidate = emptyAnchorState.candidate;
+  if (blocks.length > 0 || emptyAnchorCandidate === null) {
+    return { blocks, anchors };
+  }
+
+  const emptyDocumentAnchorId = deriveBlockId({
+    paraId: emptyAnchorCandidate.paraId,
+    index: 1,
+    taken: usedBlockIds,
+  });
+  const normalizedText = "";
+  anchors[emptyDocumentAnchorId] = {
+    id: emptyDocumentAnchorId,
+    from: emptyAnchorCandidate.from,
+    to: emptyAnchorCandidate.to,
+    text: "",
+    normalizedText,
+    textHash: hashFolioAIBlockText(normalizedText),
+    hashOccurrenceCount: emptyAnchorState.textblockCount,
+  };
+  return { blocks, anchors, emptyDocumentAnchorId };
 };
 
 const getBlockKind = (node: PMNode, headingLevel: number | undefined): FolioAIBlockKind => {

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -25,6 +25,8 @@ export type FolioAIBlock = {
 export type FolioAIEditSnapshot = {
   blocks: FolioAIBlock[];
   anchors: Record<string, FolioAIBlockAnchor>;
+  /** Hidden empty paragraph used to anchor insertions when `blocks` is empty. */
+  emptyDocumentAnchorId?: string;
 };
 
 export type FolioAIBlockAnchor = {

--- a/packages/core/src/docx/commentParser.test.ts
+++ b/packages/core/src/docx/commentParser.test.ts
@@ -104,6 +104,19 @@ describe("commentParser", () => {
       expect(comments[0].author).toBe("Charlie");
       expect(comments[0].date).toBeUndefined();
     });
+
+    test("normalizes missing and empty comment authors", () => {
+      const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:comment w:id="1" w:author=""><w:p/></w:comment>
+  <w:comment w:id="2" w:author="   "><w:p/></w:comment>
+  <w:comment w:id="3"><w:p/></w:comment>
+</w:comments>`;
+
+      const comments = parseComments(commentsXml, emptyStyles, emptyTheme, emptyRels, emptyMedia);
+
+      expect(comments.map(({ author }) => author)).toEqual(["Unknown", "Unknown", "Unknown"]);
+    });
   });
 
   describe("UTC timestamp cross-referencing", () => {

--- a/packages/core/src/docx/commentParser.ts
+++ b/packages/core/src/docx/commentParser.ts
@@ -166,7 +166,8 @@ export function parseComments(
     }
 
     const id = Number.parseInt(getAttribute(child, "w", "id") ?? "0", 10);
-    const author = getAttribute(child, "w", "author") ?? "Unknown";
+    const rawAuthor = getAttribute(child, "w", "author");
+    const author = rawAuthor?.trim() || "Unknown";
     const rawInitials = getAttribute(child, "w", "initials");
     const initials = rawInitials !== null ? String(rawInitials) : undefined;
     const rawDate = getAttribute(child, "w", "date");

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -476,6 +476,36 @@ describe("fromProseDoc", () => {
     expect(run.formatting?.vertAlign).toBe("subscript");
   });
 
+  test("keeps a deleted footnote reference inside the tracked-change wrapper", () => {
+    const footnoteRef = schema.mark("footnoteRef", {
+      id: "7",
+      noteType: "footnote",
+      vertAlign: "superscript",
+    });
+    const deletion = schema.mark("deletion", {
+      revisionId: 42,
+      author: "Reviewer",
+      date: null,
+    });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("7", [footnoteRef, deletion])]),
+    ]);
+
+    const roundTripped = fromProseDoc(pmDoc);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    const trackedChange = block.content.at(0);
+    expect(trackedChange?.type).toBe("deletion");
+    if (trackedChange?.type !== "deletion") {
+      return;
+    }
+    expect(trackedChange.content.at(0)?.content).toEqual([{ type: "footnoteRef", id: 7 }]);
+  });
+
   test("round-trips tracked-change image atoms", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1016,16 +1016,7 @@ function extractParagraphContent(
     syncCommentRanges(node, offset);
     const linkMark = node.marks.find((m) => m.type.name === "hyperlink");
 
-    // Check for footnote/endnote reference mark
     const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
-    if (noteRefMark && !linkMark) {
-      // Finish any current content
-      flushCurrentInline();
-      content.push(createNoteReferenceRun(noteRefMark, node.marks));
-      return;
-    }
-
-    // Check for tracked change marks (insertion/deletion)
     const insertionMark = node.marks.find((m) => m.type.name === "insertion");
     const deletionMark = node.marks.find((m) => m.type.name === "deletion");
     if (insertionMark || deletionMark) {
@@ -1072,6 +1063,14 @@ function extractParagraphContent(
       } else {
         content.push({ type: "deletion", info, content: [run] });
       }
+      return;
+    }
+
+    // A tracked note reference must reach the branch above so it stays inside
+    // the w:ins/w:del wrapper. Plain references serialize directly.
+    if (noteRefMark && !linkMark) {
+      flushCurrentInline();
+      content.push(createNoteReferenceRun(noteRefMark, node.marks));
       return;
     }
 
@@ -1190,6 +1189,10 @@ function extractParagraphContent(
 }
 
 function createTrackedChangeRun(node: PMNode, marks: readonly Mark[]): Run | null {
+  const noteRefMark = marks.find((mark) => mark.type.name === "footnoteRef");
+  if (noteRefMark) {
+    return createNoteReferenceRun(noteRefMark, marks);
+  }
   if (node.isText) {
     const formatting = marksToTextFormatting(marks);
     return {

--- a/packages/core/src/prosemirror/extensions/marks/FootnoteRefExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/marks/FootnoteRefExtension.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
 
 import { schema } from "../../schema";
 
 describe("FootnoteRefExtension parseDOM", () => {
+  test("does not extend a note reference mark onto adjacent typed text", () => {
+    const footnoteRef = schema.marks["footnoteRef"];
+    if (!footnoteRef) {
+      throw new Error("expected footnoteRef mark");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("1", [footnoteRef.create({ id: "1", noteType: "footnote" })]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc });
+
+    const next = state.apply(state.tr.insertText("replacement", 1, 1));
+    const inserted = next.doc.firstChild?.firstChild;
+
+    expect(footnoteRef.spec.inclusive).toBe(false);
+    expect(inserted?.text).toBe("replacement");
+    expect(inserted?.marks.some((mark) => mark.type === footnoteRef)).toBe(false);
+  });
+
   test("parses superscript footnote refs rendered as sup", () => {
     const footnoteRef = schema.marks["footnoteRef"];
     if (!footnoteRef) {

--- a/packages/core/src/prosemirror/extensions/marks/FootnoteRefExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/FootnoteRefExtension.ts
@@ -25,6 +25,7 @@ export const FootnoteRefExtension = createMarkExtension({
   name: "footnoteRef",
   schemaMarkName: "footnoteRef",
   markSpec: {
+    inclusive: false,
     attrs: {
       id: {},
       noteType: { default: "footnote" },

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -121,6 +121,36 @@ describe("generateRedlineDocx", () => {
     ]);
   });
 
+  test("consecutive additions after the final base block keep revised-document order", async () => {
+    const base = await buildDocxBuffer([
+      { text: "Agreement terms.", paraId: "00000001" },
+      { text: "Final existing clause.", paraId: "00000002" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Agreement terms.", paraId: "00000001" },
+      { text: "Final existing clause.", paraId: "00000002" },
+      { text: "First appendix.", paraId: "00000003" },
+      { text: "Second appendix.", paraId: "00000004" },
+      { text: "Third appendix.", paraId: "00000005" },
+    ]);
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.skipped).toEqual([]);
+    const acceptView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    expect(blockTexts(acceptView)).toEqual([
+      "Agreement terms.",
+      "Final existing clause.",
+      "First appendix.",
+      "Second appendix.",
+      "Third appendix.",
+    ]);
+
+    const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    rejectView.rejectAll();
+    expect(blockTexts(rejectView)).toEqual(["Agreement terms.", "Final existing clause."]);
+  });
+
   test("identical documents produce a redline with no tracked changes", async () => {
     const paragraphs: ParagraphSpec[] = [
       { text: "Alpha paragraph.", paraId: "00000001" },
@@ -138,14 +168,22 @@ describe("generateRedlineDocx", () => {
     expect(blockTexts(view)).toEqual(["Alpha paragraph.", "Beta paragraph."]);
   });
 
-  test("an empty base document reports unanchorable additions as skipped", async () => {
+  test("an empty base document redlines additions and preserves accept/reject invariants", async () => {
     const base = await buildDocxBuffer([]);
-    const revised = await buildDocxBuffer([{ text: "Only paragraph.", paraId: "00000001" }]);
+    const revised = await buildDocxBuffer([
+      { text: "First paragraph.", paraId: "00000001" },
+      { text: "Second paragraph.", paraId: "00000002" },
+    ]);
 
     const result = await generateRedlineDocx(base, revised);
 
-    expect(result.applied).toEqual([]);
-    expect(result.skipped.map((op) => op.reason)).toEqual(["missingBlock"]);
+    expect(result.skipped).toEqual([]);
+    const acceptView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    expect(blockTexts(acceptView)).toEqual(["First paragraph.", "Second paragraph."]);
+
+    const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    rejectView.rejectAll();
+    expect(blockTexts(rejectView)).toEqual([]);
   });
 
   test("a custom author is recorded on the generated changes", async () => {

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -98,7 +98,7 @@ export const generateRedlineDocx = async (
   const operations: FolioAIEditOperation[] = [];
   let operationSeq = 0;
   const nextOperationId = () => `redline-${++operationSeq}`;
-  /** Additions past the last base block, inserted after it in reverse so the final order matches the revised document. */
+  /** Additions past the last base block, kept in revised-document order. */
   const trailingAdditions: { text: string; styleId?: string }[] = [];
   const lastBaseBlockId = baseSnapshot.blocks.at(-1)?.id ?? null;
 
@@ -139,14 +139,24 @@ export const generateRedlineDocx = async (
     });
   });
 
-  for (const addition of trailingAdditions.toReversed()) {
+  if (lastBaseBlockId === null && baseSnapshot.emptyDocumentAnchorId !== undefined) {
+    const firstAddition = trailingAdditions.shift();
+    if (firstAddition !== undefined) {
+      operations.push({
+        id: nextOperationId(),
+        type: "replaceBlock",
+        blockId: baseSnapshot.emptyDocumentAnchorId,
+        text: firstAddition.text,
+        ...(firstAddition.styleId !== undefined && { styleId: firstAddition.styleId }),
+      });
+    }
+  }
+
+  for (const addition of trailingAdditions) {
     operations.push({
       id: nextOperationId(),
       type: "insertAfterBlock",
-      // An empty base document has no anchor block at all; an unresolvable
-      // id makes the shared applier report the addition in `skipped`
-      // (missingBlock) instead of dropping it silently.
-      blockId: lastBaseBlockId ?? "redline-unanchored",
+      blockId: lastBaseBlockId ?? baseSnapshot.emptyDocumentAnchorId ?? "redline-unanchored",
       text: addition.text,
       ...(addition.styleId !== undefined && { styleId: addition.styleId }),
     });


### PR DESCRIPTION
Preserve document semantics across several independent DOCX edge cases:

- normalize missing or whitespace-only comment authors
- retain revised-document order for trailing additions
- support tracked additions when the base document is empty
- keep footnote and endnote references inside tracked-change wrappers

Includes focused regression coverage and package changesets.