### PR TITLE
feat: add live document operation undo

### DIFF
--- a/.changeset/live-batches-undo.md
+++ b/.changeset/live-batches-undo.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-react": minor
+"@stll/folio-vue": minor
+"@stll/folio-agents": minor
+---
+
+Add transactional undo for live document-operation batches.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -17,6 +17,8 @@ import { FolioDocumentOperationBatch } from '@stll/folio-core/server';
 import { FolioDocumentOperationIssue } from '@stll/folio-core/server';
 import { FolioDocumentOperationReceipt } from '@stll/folio-core/server';
 import { FolioDocumentOperationResult } from '@stll/folio-core/server';
+import { FolioDocumentOperationUndoHandle } from '@stll/folio-core/server';
+import { FolioDocumentOperationUndoResult } from '@stll/folio-core/server';
 import { FolioDocumentStory } from '@stll/folio-core/server';
 import { FolioDocumentStoryHandle } from '@stll/folio-core/server';
 import { FolioDocxReviewer } from '@stll/folio-core/server';
@@ -1572,7 +1574,8 @@ export type FolioAgentBlockDiff = FolioBlockDiff;
 // @public
 export type FolioAgentBridge = {
     snapshot(): FolioAIEditSnapshot;
-    applyDocumentOperations(batch: FolioDocumentOperationBatch): FolioDocumentOperationResult; /** The comment threads present in the document. */
+    applyDocumentOperations(batch: FolioDocumentOperationBatch): FolioDocumentOperationResult; /** Undo the latest unchanged batch when the execution surface supports it. */
+    undoDocumentOperations?(undoHandle: FolioDocumentOperationUndoHandle): FolioDocumentOperationUndoResult; /** The comment threads present in the document. */
     getComments(): FolioAgentComment[]; /** The pending tracked changes (insertions/deletions) present in the document. */
     getChanges(): FolioAgentChange[]; /** Discover typed document stories when the surface exposes package parts. */
     listStories?(): FolioDocumentStory[]; /** Read one previously discovered story. */
@@ -1631,7 +1634,8 @@ export type FolioAgentEditorRefLike = {
         mode?: FolioAIEditApplyMode;
         author?: string;
     }): FolioAIEditApplyResult; /** `DocxEditorRef.applyDocumentOperations`, when available on newer refs. */
-    applyDocumentOperations?(options: FolioAgentEditorApplyDocumentOperationsOptions): FolioDocumentOperationResult; /** `DocxEditorRef.scrollToBlock`. */
+    applyDocumentOperations?(options: FolioAgentEditorApplyDocumentOperationsOptions): FolioDocumentOperationResult; /** `DocxEditorRef.undoDocumentOperations`, when available on newer refs. */
+    undoDocumentOperations?(undoHandle: FolioDocumentOperationUndoHandle): FolioDocumentOperationUndoResult; /** `DocxEditorRef.scrollToBlock`. */
     scrollToBlock(blockId: string, snapshot?: FolioAIEditSnapshot): boolean; /** `DocxEditorRef.getTotalPages`. */
     getTotalPages(): number;
     getTrackedChanges?(): FolioReviewChange[];

--- a/api-reports/react/compat-eigenpal.api.md
+++ b/api-reports/react/compat-eigenpal.api.md
@@ -28,6 +28,8 @@ import { FolioAIEditSnapshot } from '@stll/folio-core/ai-edits';
 import { FolioCommentAnchor } from '@stll/folio-core/ai-edits';
 import { FolioDocumentOperationBatch } from '@stll/folio-core/server';
 import { FolioDocumentOperationResult } from '@stll/folio-core/server';
+import { FolioDocumentOperationUndoHandle } from '@stll/folio-core/server';
+import { FolioDocumentOperationUndoResult } from '@stll/folio-core/server';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioReviewChange } from '@stll/folio-core/ai-edits';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
@@ -127,7 +129,8 @@ export type DocxEditorRef = {
         focus?: boolean;
     }) => void; /** Create the block snapshot that an external AI editor should reference. */
     createAIEditSnapshot: () => FolioAIEditSnapshot | null; /** Apply a versioned document-operation batch against a previously created block snapshot. */
-    applyDocumentOperations: (options: DocxEditorApplyDocumentOperationsOptions) => FolioDocumentOperationResult; /** Apply AI-authored operations against a previously created block snapshot. */
+    applyDocumentOperations: (options: DocxEditorApplyDocumentOperationsOptions) => FolioDocumentOperationResult; /** Undo the latest unchanged document-operation batch. */
+    undoDocumentOperations: (undoHandle: FolioDocumentOperationUndoHandle) => FolioDocumentOperationUndoResult; /** Apply AI-authored operations against a previously created block snapshot. */
     applyAIEditOperations: (options: {
         snapshot: FolioAIEditSnapshot;
         operations: FolioAIEditOperation[];

--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -84,6 +84,8 @@ import { FolioBlockId } from '@stll/folio-core/types/block-id';
 import { FolioCommentAnchor } from '@stll/folio-core/ai-edits';
 import { FolioDocumentOperationBatch } from '@stll/folio-core/server';
 import { FolioDocumentOperationResult } from '@stll/folio-core/server';
+import { FolioDocumentOperationUndoHandle } from '@stll/folio-core/server';
+import { FolioDocumentOperationUndoResult } from '@stll/folio-core/server';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioReviewChange } from '@stll/folio-core/ai-edits';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
@@ -421,7 +423,8 @@ export type DocxEditorRef = {
         focus?: boolean;
     }) => void; /** Create the block snapshot that an external AI editor should reference. */
     createAIEditSnapshot: () => FolioAIEditSnapshot | null; /** Apply a versioned document-operation batch against a previously created block snapshot. */
-    applyDocumentOperations: (options: DocxEditorApplyDocumentOperationsOptions) => FolioDocumentOperationResult; /** Apply AI-authored operations against a previously created block snapshot. */
+    applyDocumentOperations: (options: DocxEditorApplyDocumentOperationsOptions) => FolioDocumentOperationResult; /** Undo the latest unchanged document-operation batch. */
+    undoDocumentOperations: (undoHandle: FolioDocumentOperationUndoHandle) => FolioDocumentOperationUndoResult; /** Apply AI-authored operations against a previously created block snapshot. */
     applyAIEditOperations: (options: {
         snapshot: FolioAIEditSnapshot;
         operations: FolioAIEditOperation[];

--- a/api-reports/vue/index.api.md
+++ b/api-reports/vue/index.api.md
@@ -86,6 +86,8 @@ import { FolioBlockId } from '@stll/folio-core/types/block-id';
 import { FolioCommentAnchor } from '@stll/folio-core/ai-edits';
 import { FolioDocumentOperationBatch } from '@stll/folio-core/ai-edits';
 import { FolioDocumentOperationResult } from '@stll/folio-core/ai-edits';
+import { FolioDocumentOperationUndoHandle } from '@stll/folio-core/ai-edits';
+import { FolioDocumentOperationUndoResult } from '@stll/folio-core/ai-edits';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioReviewChange } from '@stll/folio-core/ai-edits';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
@@ -399,6 +401,7 @@ export type DocxEditorRef = {
     }) => void;
     createAIEditSnapshot: () => FolioAIEditSnapshot | null;
     applyDocumentOperations: (options: DocxEditorApplyDocumentOperationsOptions) => FolioDocumentOperationResult;
+    undoDocumentOperations: (undoHandle: FolioDocumentOperationUndoHandle) => FolioDocumentOperationUndoResult;
     applyAIEditOperations: (options: {
         snapshot: FolioAIEditSnapshot;
         operations: FolioAIEditOperation[];

--- a/packages/agents/src/bridge.ts
+++ b/packages/agents/src/bridge.ts
@@ -2,6 +2,8 @@ import type {
   FolioAIEditSnapshot,
   FolioDocumentOperationBatch,
   FolioDocumentOperationResult,
+  FolioDocumentOperationUndoHandle,
+  FolioDocumentOperationUndoResult,
   FolioDocumentStory,
   FolioDocumentStoryHandle,
 } from "@stll/folio-core/server";
@@ -29,6 +31,10 @@ export type FolioAgentBridge = {
    * bridge decides mode (tracked-changes by default) and author internally.
    */
   applyDocumentOperations(batch: FolioDocumentOperationBatch): FolioDocumentOperationResult;
+  /** Undo the latest unchanged batch when the execution surface supports it. */
+  undoDocumentOperations?(
+    undoHandle: FolioDocumentOperationUndoHandle,
+  ): FolioDocumentOperationUndoResult;
   /** The comment threads present in the document. */
   getComments(): FolioAgentComment[];
   /** The pending tracked changes (insertions/deletions) present in the document. */

--- a/packages/agents/src/bridges/editor-ref.test.ts
+++ b/packages/agents/src/bridges/editor-ref.test.ts
@@ -35,6 +35,34 @@ const baseRef = (): FolioAgentEditorRefLike => ({
 });
 
 describe("createEditorRefBridge: document operations", () => {
+  test("exposes transactional undo only when the editor ref supports it", () => {
+    const undoHandle = { type: "documentOperationUndo", id: "live-1" } as const;
+    const currentBridge = createEditorRefBridge({
+      ref: {
+        ...baseRef(),
+        undoDocumentOperations: (receivedHandle) => ({
+          status: "undone",
+          undoHandle: receivedHandle,
+        }),
+      },
+      author: "AI",
+      getComments: () => [],
+      setComments: () => {},
+    });
+    const legacyBridge = createEditorRefBridge({
+      ref: baseRef(),
+      author: "AI",
+      getComments: () => [],
+      setComments: () => {},
+    });
+
+    expect(currentBridge.undoDocumentOperations?.(undoHandle)).toEqual({
+      status: "undone",
+      undoHandle,
+    });
+    expect(legacyBridge.undoDocumentOperations).toBeUndefined();
+  });
+
   test("delegates a versioned batch to a current editor ref", () => {
     let receivedVersion: number | undefined;
     const ref: FolioAgentEditorRefLike = {

--- a/packages/agents/src/bridges/editor-ref.ts
+++ b/packages/agents/src/bridges/editor-ref.ts
@@ -5,6 +5,8 @@ import type {
   FolioAIEditSnapshot,
   FolioDocumentOperationBatch,
   FolioDocumentOperationResult,
+  FolioDocumentOperationUndoHandle,
+  FolioDocumentOperationUndoResult,
 } from "@stll/folio-core/server";
 import {
   assertSupportedFolioDocumentOperationVersion,
@@ -53,6 +55,10 @@ export type FolioAgentEditorRefLike = {
   applyDocumentOperations?(
     options: FolioAgentEditorApplyDocumentOperationsOptions,
   ): FolioDocumentOperationResult;
+  /** `DocxEditorRef.undoDocumentOperations`, when available on newer refs. */
+  undoDocumentOperations?(
+    undoHandle: FolioDocumentOperationUndoHandle,
+  ): FolioDocumentOperationUndoResult;
   /** `DocxEditorRef.scrollToBlock`. */
   scrollToBlock(blockId: string, snapshot?: FolioAIEditSnapshot): boolean;
   /** `DocxEditorRef.getTotalPages`. */
@@ -158,6 +164,7 @@ const paragraphPlainText = (paragraph: Comment["content"][number]): string => {
  */
 export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): FolioAgentBridge => {
   const { ref, author, getComments, setComments } = options;
+  const undoDocumentOperations = ref.undoDocumentOperations;
   const mode = options.mode ?? "tracked-changes";
 
   const requireSnapshot = (): FolioAIEditSnapshot => {
@@ -232,6 +239,10 @@ export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): Fo
         undoHandle: null,
       };
     },
+    ...(undoDocumentOperations && {
+      undoDocumentOperations: (undoHandle: FolioDocumentOperationUndoHandle) =>
+        undoDocumentOperations(undoHandle),
+    }),
     getComments: (): FolioAgentComment[] => {
       const comments = getComments();
       const anchors = ref.getCommentAnchors?.();

--- a/packages/agents/src/bridges/editor-ref.ts
+++ b/packages/agents/src/bridges/editor-ref.ts
@@ -164,7 +164,7 @@ const paragraphPlainText = (paragraph: Comment["content"][number]): string => {
  */
 export const createEditorRefBridge = (options: CreateEditorRefBridgeOptions): FolioAgentBridge => {
   const { ref, author, getComments, setComments } = options;
-  const undoDocumentOperations = ref.undoDocumentOperations;
+  const undoDocumentOperations = ref.undoDocumentOperations?.bind(ref);
   const mode = options.mode ?? "tracked-changes";
 
   const requireSnapshot = (): FolioAIEditSnapshot => {

--- a/packages/agents/src/bridges/reviewer.ts
+++ b/packages/agents/src/bridges/reviewer.ts
@@ -57,6 +57,7 @@ export const createReviewerBridge = (
   return {
     snapshot: () => reviewer.snapshot(),
     applyDocumentOperations: (batch) => reviewer.applyDocumentOperations({ ...batch, mode }),
+    undoDocumentOperations: (undoHandle) => reviewer.undoDocumentOperations(undoHandle),
     getComments: () => reviewer.getComments().map(toAgentComment),
     getChanges: () => reviewer.getChanges().map(toAgentChange),
     listStories: () => reviewer.listStories(),

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -30,6 +30,8 @@ export type FolioParityBridge = {
   countCommentAnchors: () => number;
   /** Block count of the AI-edit snapshot over the live doc (0 with no live view). */
   aiSnapshotBlockCount: () => number;
+  /** Apply and undo one direct document-operation batch; true only when content restores. */
+  applyAndUndoDocumentOperation: () => boolean;
   /** Push an anonymization term matching the first word. Returns whether one was pushed. */
   anonymizeFirstWord: () => boolean;
   /** Count painted anonymization highlight rects in the overlay. */
@@ -154,6 +156,35 @@ export function buildParityBridge(getRef: () => DocxEditorRef | null): FolioPari
     countCommentAnchors: () =>
       document.querySelectorAll(".paged-editor__pages [data-comment-id]").length,
     aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
+    applyAndUndoDocumentOperation: () => {
+      const ref = getRef();
+      const snapshot = ref?.createAIEditSnapshot();
+      const block = snapshot?.blocks.at(0);
+      const before = liveView()?.state.doc.textContent;
+      if (!ref || !snapshot || !block || before === undefined) {
+        return false;
+      }
+      const result = ref.applyDocumentOperations({
+        snapshot,
+        batch: {
+          version: 1,
+          mode: "direct",
+          operations: [
+            {
+              id: "parity-undo",
+              type: "insertAfterBlock",
+              blockId: block.id,
+              text: "Temporary undo paragraph.",
+            },
+          ],
+        },
+      });
+      if (!result.undoHandle || liveView()?.state.doc.textContent === before) {
+        return false;
+      }
+      const undoResult = ref.undoDocumentOperations(result.undoHandle);
+      return undoResult.status === "undone" && liveView()?.state.doc.textContent === before;
+    },
     anonymizeFirstWord: () => {
       const view = liveView();
       if (!view) {

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -158,32 +158,60 @@ export function buildParityBridge(getRef: () => DocxEditorRef | null): FolioPari
     aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
     applyAndUndoDocumentOperation: () => {
       const ref = getRef();
-      const snapshot = ref?.createAIEditSnapshot();
-      const block = snapshot?.blocks.at(0);
+      const firstSnapshot = ref?.createAIEditSnapshot();
+      const firstBlock = firstSnapshot?.blocks.at(0);
       const before = liveView()?.state.doc.textContent;
-      if (!ref || !snapshot || !block || before === undefined) {
+      if (!ref || !firstSnapshot || !firstBlock || before === undefined) {
         return false;
       }
-      const result = ref.applyDocumentOperations({
-        snapshot,
+      const first = ref.applyDocumentOperations({
+        snapshot: firstSnapshot,
         batch: {
           version: 1,
           mode: "direct",
           operations: [
             {
-              id: "parity-undo",
+              id: "parity-undo-first",
               type: "insertAfterBlock",
-              blockId: block.id,
-              text: "Temporary undo paragraph.",
+              blockId: firstBlock.id,
+              text: "First temporary undo paragraph.",
             },
           ],
         },
       });
-      if (!result.undoHandle || liveView()?.state.doc.textContent === before) {
+      const secondSnapshot = ref.createAIEditSnapshot();
+      const secondBlock = secondSnapshot?.blocks.at(0);
+      if (!first.undoHandle || !secondSnapshot || !secondBlock) {
         return false;
       }
-      const undoResult = ref.undoDocumentOperations(result.undoHandle);
-      return undoResult.status === "undone" && liveView()?.state.doc.textContent === before;
+      const second = ref.applyDocumentOperations({
+        snapshot: secondSnapshot,
+        batch: {
+          version: 1,
+          mode: "direct",
+          operations: [
+            {
+              id: "parity-undo-second",
+              type: "insertAfterBlock",
+              blockId: secondBlock.id,
+              text: "Second temporary undo paragraph.",
+            },
+          ],
+        },
+      });
+      const view = liveView();
+      if (!second.undoHandle || !view || view.state.doc.textContent === before) {
+        return false;
+      }
+
+      view.dispatch(view.state.tr.setMeta("folioParitySelectionOnly", true));
+      const secondUndo = ref.undoDocumentOperations(second.undoHandle);
+      const firstUndo = ref.undoDocumentOperations(first.undoHandle);
+      return (
+        secondUndo.status === "undone" &&
+        firstUndo.status === "undone" &&
+        liveView()?.state.doc.textContent === before
+      );
     },
     anonymizeFirstWord: () => {
       const view = liveView();

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -201,32 +201,60 @@ function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridg
     aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
     applyAndUndoDocumentOperation: () => {
       const ref = getRef();
-      const snapshot = ref?.createAIEditSnapshot();
-      const block = snapshot?.blocks.at(0);
+      const firstSnapshot = ref?.createAIEditSnapshot();
+      const firstBlock = firstSnapshot?.blocks.at(0);
       const before = liveView()?.state.doc.textContent;
-      if (!ref || !snapshot || !block || before === undefined) {
+      if (!ref || !firstSnapshot || !firstBlock || before === undefined) {
         return false;
       }
-      const result = ref.applyDocumentOperations({
-        snapshot,
+      const first = ref.applyDocumentOperations({
+        snapshot: firstSnapshot,
         batch: {
           version: 1,
           mode: "direct",
           operations: [
             {
-              id: "parity-undo",
+              id: "parity-undo-first",
               type: "insertAfterBlock",
-              blockId: block.id,
-              text: "Temporary undo paragraph.",
+              blockId: firstBlock.id,
+              text: "First temporary undo paragraph.",
             },
           ],
         },
       });
-      if (!result.undoHandle || liveView()?.state.doc.textContent === before) {
+      const secondSnapshot = ref.createAIEditSnapshot();
+      const secondBlock = secondSnapshot?.blocks.at(0);
+      if (!first.undoHandle || !secondSnapshot || !secondBlock) {
         return false;
       }
-      const undoResult = ref.undoDocumentOperations(result.undoHandle);
-      return undoResult.status === "undone" && liveView()?.state.doc.textContent === before;
+      const second = ref.applyDocumentOperations({
+        snapshot: secondSnapshot,
+        batch: {
+          version: 1,
+          mode: "direct",
+          operations: [
+            {
+              id: "parity-undo-second",
+              type: "insertAfterBlock",
+              blockId: secondBlock.id,
+              text: "Second temporary undo paragraph.",
+            },
+          ],
+        },
+      });
+      const view = liveView();
+      if (!second.undoHandle || !view || view.state.doc.textContent === before) {
+        return false;
+      }
+
+      view.dispatch(view.state.tr.setMeta("folioParitySelectionOnly", true));
+      const secondUndo = ref.undoDocumentOperations(second.undoHandle);
+      const firstUndo = ref.undoDocumentOperations(first.undoHandle);
+      return (
+        secondUndo.status === "undone" &&
+        firstUndo.status === "undone" &&
+        liveView()?.state.doc.textContent === before
+      );
     },
     anonymizeFirstWord: () => {
       const view = liveView();

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -73,6 +73,8 @@ export type FolioParityBridge = {
   countCommentAnchors: () => number;
   /** Block count of the AI-edit snapshot over the live doc (0 with no live view). */
   aiSnapshotBlockCount: () => number;
+  /** Apply and undo one direct document-operation batch; true only when content restores. */
+  applyAndUndoDocumentOperation: () => boolean;
   /** Push an anonymization term matching the first word. Returns whether one was pushed. */
   anonymizeFirstWord: () => boolean;
   /** Count painted anonymization highlight rects in the overlay. */
@@ -197,6 +199,35 @@ function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridg
     countCommentAnchors: () =>
       document.querySelectorAll(".paged-editor__pages [data-comment-id]").length,
     aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
+    applyAndUndoDocumentOperation: () => {
+      const ref = getRef();
+      const snapshot = ref?.createAIEditSnapshot();
+      const block = snapshot?.blocks.at(0);
+      const before = liveView()?.state.doc.textContent;
+      if (!ref || !snapshot || !block || before === undefined) {
+        return false;
+      }
+      const result = ref.applyDocumentOperations({
+        snapshot,
+        batch: {
+          version: 1,
+          mode: "direct",
+          operations: [
+            {
+              id: "parity-undo",
+              type: "insertAfterBlock",
+              blockId: block.id,
+              text: "Temporary undo paragraph.",
+            },
+          ],
+        },
+      });
+      if (!result.undoHandle || liveView()?.state.doc.textContent === before) {
+        return false;
+      }
+      const undoResult = ref.undoDocumentOperations(result.undoHandle);
+      return undoResult.status === "undone" && liveView()?.state.doc.textContent === before;
+    },
     anonymizeFirstWord: () => {
       const view = liveView();
       if (!view) {

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -15,6 +15,8 @@ import type {
 import type {
   FolioDocumentOperationBatch,
   FolioDocumentOperationResult,
+  FolioDocumentOperationUndoHandle,
+  FolioDocumentOperationUndoResult,
 } from "@stll/folio-core/server";
 import type {
   ContentControlFilter,
@@ -388,6 +390,10 @@ export type DocxEditorRef = {
   applyDocumentOperations: (
     options: DocxEditorApplyDocumentOperationsOptions,
   ) => FolioDocumentOperationResult;
+  /** Undo the latest unchanged document-operation batch. */
+  undoDocumentOperations: (
+    undoHandle: FolioDocumentOperationUndoHandle,
+  ) => FolioDocumentOperationUndoResult;
   /** Apply AI-authored operations against a previously created block snapshot. */
   applyAIEditOperations: (options: {
     snapshot: FolioAIEditSnapshot;

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -36,6 +36,7 @@ import {
 // Paginated editor
 import type { Mark } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import { closeHistory } from "prosemirror-history";
 import { useTranslations } from "use-intl";
 
 import {
@@ -47,6 +48,8 @@ import {
   getFolioDocumentOperationIssues,
   getTrackedChangesFromDoc,
   type FolioDocumentOperationStatus,
+  type FolioDocumentOperationUndoHandle,
+  type FolioDocumentOperationUndoResult,
 } from "@stll/folio-core/ai-edits";
 import { normalizeBaseDirection } from "@stll/folio-core/docx/normalizeBaseDirection";
 import { getCachedNumberingMap } from "@stll/folio-core/docx/numberingParser";
@@ -290,6 +293,15 @@ const DISPLAY_MODE_LABEL_KEYS = {
 } as const satisfies Record<DisplayMode, string>;
 
 const preventMouseDownDefault = (event: React.MouseEvent) => event.preventDefault();
+
+type LiveDocumentOperationUndoEntry = {
+  undoHandle: FolioDocumentOperationUndoHandle;
+  afterState: EditorView["state"];
+  commentsBefore: Comment[];
+  commentsAfter: Comment[];
+};
+
+let documentOperationUndoHandleCursor = Date.now();
 
 function isDisplayMode(value: unknown): value is DisplayMode {
   return typeof value === "string" && DISPLAY_MODES.some((mode) => mode === value);
@@ -896,6 +908,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     commentsProp,
     onCommentsChange,
   });
+  const documentOperationUndoEntriesRef = useRef<LiveDocumentOperationUndoEntry[]>([]);
   // Cache style resolver to avoid recreating on every selection change
   const styleResolverCacheRef = useRef<{
     styles: unknown;
@@ -2835,9 +2848,25 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           };
         }
 
+        const existingUndoEntry = documentOperationUndoEntriesRef.current.at(-1);
+        if (
+          existingUndoEntry &&
+          (view.state !== existingUndoEntry.afterState ||
+            commentsRef.current !== existingUndoEntry.commentsAfter)
+        ) {
+          documentOperationUndoEntriesRef.current.length = 0;
+        }
+        const commentsBefore = commentsRef.current;
         const createdComments: Comment[] = [];
+        const operationView = {
+          state: view.state,
+          dispatch: (transaction: Parameters<EditorView["dispatch"]>[0]) => {
+            view.dispatch(closeHistory(transaction));
+            operationView.state = view.state;
+          },
+        };
         const result = applyFolioDocumentOperations({
-          view,
+          view: operationView,
           snapshot,
           batch,
           author: operationAuthor,
@@ -2846,13 +2875,56 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             createdComments.push(comment);
             return comment.id;
           },
+          createUndoHandle: () => ({
+            type: "documentOperationUndo",
+            id: `react-${String(documentOperationUndoHandleCursor++)}`,
+          }),
         });
 
         if (createdComments.length > 0) {
           updateComments((currentComments) => [...currentComments, ...createdComments]);
         }
 
+        if (result.undoHandle !== null) {
+          documentOperationUndoEntriesRef.current.push({
+            undoHandle: result.undoHandle,
+            afterState: view.state,
+            commentsBefore,
+            commentsAfter: commentsRef.current,
+          });
+        }
+
         return result;
+      },
+      undoDocumentOperations: (undoHandle): FolioDocumentOperationUndoResult => {
+        const entries = documentOperationUndoEntriesRef.current;
+        const entryIndex = entries.findIndex(
+          (entry) =>
+            entry.undoHandle.type === undoHandle.type && entry.undoHandle.id === undoHandle.id,
+        );
+        if (entryIndex === -1) {
+          return { status: "rejected", undoHandle, reason: "unknownHandle" };
+        }
+        if (entryIndex !== entries.length - 1) {
+          return { status: "rejected", undoHandle, reason: "notLatest" };
+        }
+
+        const entry = entries.at(-1);
+        const view = pagedEditorRef.current?.getView();
+        if (!entry || !view) {
+          return { status: "rejected", undoHandle, reason: "unknownHandle" };
+        }
+        if (view.state !== entry.afterState || commentsRef.current !== entry.commentsAfter) {
+          return { status: "rejected", undoHandle, reason: "documentChanged" };
+        }
+        if (!(pagedEditorRef.current?.undo() ?? false)) {
+          return { status: "rejected", undoHandle, reason: "documentChanged" };
+        }
+
+        replaceComments(entry.commentsBefore);
+        entries.pop();
+        requestAnimationFrame(refreshBodyHistoryAvailability);
+        return { status: "undone", undoHandle };
       },
       applyAIEditOperations: ({
         snapshot,
@@ -3081,6 +3153,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       loadParsedDocument,
       loadBuffer,
       updateComments,
+      replaceComments,
+      commentsRef,
       commentsDirtyRef,
       hfEditPosition,
       refreshBodyHistoryAvailability,

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2851,7 +2851,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         const existingUndoEntry = documentOperationUndoEntriesRef.current.at(-1);
         if (
           existingUndoEntry &&
-          (view.state !== existingUndoEntry.afterState ||
+          (!view.state.doc.eq(existingUndoEntry.afterState.doc) ||
             commentsRef.current !== existingUndoEntry.commentsAfter)
         ) {
           documentOperationUndoEntriesRef.current.length = 0;
@@ -2914,7 +2914,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         if (!entry || !view) {
           return { status: "rejected", undoHandle, reason: "unknownHandle" };
         }
-        if (view.state !== entry.afterState || commentsRef.current !== entry.commentsAfter) {
+        if (
+          !view.state.doc.eq(entry.afterState.doc) ||
+          commentsRef.current !== entry.commentsAfter
+        ) {
           return { status: "rejected", undoHandle, reason: "documentChanged" };
         }
         if (!(pagedEditorRef.current?.undo() ?? false)) {

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -1251,6 +1251,8 @@ const { exposed } = useDocxEditorRefApi({
     commentManagement.pushComment(comment);
     return comment.id;
   },
+  getComments: () => commentManagement.comments.value,
+  setComments: commentManagement.setComments,
   focus,
   getDocument,
   setZoom,

--- a/packages/vue/src/components/DocxEditor/types.ts
+++ b/packages/vue/src/components/DocxEditor/types.ts
@@ -12,6 +12,8 @@ import type {
   FolioCommentAnchor,
   FolioDocumentOperationBatch,
   FolioDocumentOperationResult,
+  FolioDocumentOperationUndoHandle,
+  FolioDocumentOperationUndoResult,
   FolioReviewChange,
 } from "@stll/folio-core/ai-edits";
 import type {
@@ -395,6 +397,10 @@ export type DocxEditorRef = {
   applyDocumentOperations: (
     options: DocxEditorApplyDocumentOperationsOptions,
   ) => FolioDocumentOperationResult;
+  /** Undo the latest unchanged document-operation batch. */
+  undoDocumentOperations: (
+    undoHandle: FolioDocumentOperationUndoHandle,
+  ) => FolioDocumentOperationUndoResult;
   /** Apply AI-authored operations against a previously created block snapshot. */
   applyAIEditOperations: (options: {
     snapshot: FolioAIEditSnapshot;

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -30,6 +30,7 @@ import type { Ref } from "vue";
 import { TextSelection } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
+import { closeHistory } from "prosemirror-history";
 
 import {
   applyFolioAIEditOperations,
@@ -41,6 +42,8 @@ import {
   getFolioDocumentOperationIssues,
   getTrackedChangesFromDoc,
   type FolioDocumentOperationStatus,
+  type FolioDocumentOperationUndoHandle,
+  type FolioDocumentOperationUndoResult,
 } from "@stll/folio-core/ai-edits";
 import type { FolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { Layout } from "@stll/folio-core/layout-engine";
@@ -66,6 +69,7 @@ import {
 } from "@stll/folio-core/prosemirror/commands/contentControls";
 import { setContentControlContentBlocksTr } from "@stll/folio-core/prosemirror/commands/contentControlsBlockFill";
 import type { Document } from "@stll/folio-core/types/document";
+import type { Comment } from "@stll/folio-core/types/content";
 import type { DocxInput } from "@stll/folio-core/utils/docxInput";
 
 import type { DocxEditorRef } from "../components/DocxEditor/types";
@@ -75,6 +79,15 @@ import {
   resolveFolioAIBlockRange,
 } from "@stll/folio-core/ai-edits/blockRange";
 import { getPageTextFromLayout } from "@stll/folio-core/paged-layout/pageText";
+
+type LiveDocumentOperationUndoEntry = {
+  undoHandle: FolioDocumentOperationUndoHandle;
+  afterState: EditorView["state"];
+  commentsBefore: Comment[];
+  commentsAfter: Comment[];
+};
+
+let documentOperationUndoHandleCursor = Date.now();
 
 export type UseDocxEditorRefApiOptions = {
   /** Headless controller handle (imperative API + events; Seam 6). */
@@ -120,6 +133,9 @@ export type UseDocxEditorRefApiOptions = {
    * closure over the comment manager). Wired from useCommentManagement.
    */
   createAIEditComment: (text: string) => number;
+  /** Read and replace the current comment array for transactional undo. */
+  getComments: () => Comment[];
+  setComments: (comments: Comment[]) => void;
   // Action handles from useDocxEditor.
   focus: () => void;
   getDocument: () => Document | null;
@@ -137,6 +153,7 @@ export type UseDocxEditorRefApiOptions = {
 export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
   exposed: DocxEditorRef;
 } {
+  const documentOperationUndoEntries: LiveDocumentOperationUndoEntry[] = [];
   function print(): void {
     opts.onPrint?.();
     window.print();
@@ -324,13 +341,70 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
           undoHandle: null,
         };
       }
-      return applyFolioDocumentOperations({
-        view,
+      const existingUndoEntry = documentOperationUndoEntries.at(-1);
+      if (
+        existingUndoEntry &&
+        (view.state !== existingUndoEntry.afterState ||
+          opts.getComments() !== existingUndoEntry.commentsAfter)
+      ) {
+        documentOperationUndoEntries.length = 0;
+      }
+      const commentsBefore = opts.getComments();
+      const operationView = {
+        state: view.state,
+        dispatch: (transaction: Parameters<EditorView["dispatch"]>[0]) => {
+          view.dispatch(closeHistory(transaction));
+          operationView.state = view.state;
+        },
+      };
+      const result = applyFolioDocumentOperations({
+        view: operationView,
         snapshot,
         batch,
         author: operationAuthor,
         createCommentId: opts.createAIEditComment,
+        createUndoHandle: () => ({
+          type: "documentOperationUndo",
+          id: `vue-${String(documentOperationUndoHandleCursor++)}`,
+        }),
       });
+      if (result.undoHandle !== null) {
+        documentOperationUndoEntries.push({
+          undoHandle: result.undoHandle,
+          afterState: view.state,
+          commentsBefore,
+          commentsAfter: opts.getComments(),
+        });
+      }
+      return result;
+    },
+    undoDocumentOperations: (undoHandle): FolioDocumentOperationUndoResult => {
+      const entryIndex = documentOperationUndoEntries.findIndex(
+        (entry) =>
+          entry.undoHandle.type === undoHandle.type && entry.undoHandle.id === undoHandle.id,
+      );
+      if (entryIndex === -1) {
+        return { status: "rejected", undoHandle, reason: "unknownHandle" };
+      }
+      if (entryIndex !== documentOperationUndoEntries.length - 1) {
+        return { status: "rejected", undoHandle, reason: "notLatest" };
+      }
+
+      const entry = documentOperationUndoEntries.at(-1);
+      const view = opts.editorView.value;
+      if (!entry || !view) {
+        return { status: "rejected", undoHandle, reason: "unknownHandle" };
+      }
+      if (view.state !== entry.afterState || opts.getComments() !== entry.commentsAfter) {
+        return { status: "rejected", undoHandle, reason: "documentChanged" };
+      }
+      if (!opts.editor.undo()) {
+        return { status: "rejected", undoHandle, reason: "documentChanged" };
+      }
+
+      opts.setComments(entry.commentsBefore);
+      documentOperationUndoEntries.pop();
+      return { status: "undone", undoHandle };
     },
     applyAIEditOperations: ({
       snapshot,

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -344,7 +344,7 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
       const existingUndoEntry = documentOperationUndoEntries.at(-1);
       if (
         existingUndoEntry &&
-        (view.state !== existingUndoEntry.afterState ||
+        (!view.state.doc.eq(existingUndoEntry.afterState.doc) ||
           opts.getComments() !== existingUndoEntry.commentsAfter)
       ) {
         documentOperationUndoEntries.length = 0;
@@ -395,7 +395,7 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
       if (!entry || !view) {
         return { status: "rejected", undoHandle, reason: "unknownHandle" };
       }
-      if (view.state !== entry.afterState || opts.getComments() !== entry.commentsAfter) {
+      if (!view.state.doc.eq(entry.afterState.doc) || opts.getComments() !== entry.commentsAfter) {
         return { status: "rejected", undoHandle, reason: "documentChanged" };
       }
       if (!opts.editor.undo()) {

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -124,7 +124,8 @@
       "setContentControlContent",
       "setContentControlValue",
       "setZoom",
-      "undo"
+      "undo",
+      "undoDocumentOperations"
     ],
     "pairedNotes": {
       "applyDocumentOperations": "Both wired against the shared core `applyFolioDocumentOperations`, mirroring the adjacent (already-paired) `applyAIEditOperations`. Both assert the batch version (`assertSupportedFolioDocumentOperationVersion`), return an all-skipped `unsupportedBlock` result at the contract version when no view is mounted, and otherwise delegate to core with the same snapshot/batch/author. Comment-creation idiom differs like the AI-edit method: React's `createCommentId` closure calls `createComment` and folds the results in via `updateComments`, while Vue passes `opts.createAIEditComment`, which mints the comment and appends it to the thread list internally (from useCommentManagement) — same observable effect.",

--- a/tests/parity/document-operation-undo.spec.ts
+++ b/tests/parity/document-operation-undo.spec.ts
@@ -1,0 +1,10 @@
+import { ensureLiveView, expect, forEachAdapter, openEditor } from "./parity-fixture";
+
+forEachAdapter("document operations: committed batch can be undone", async (adapter, { page }) => {
+  await openEditor(page, adapter);
+  await ensureLiveView(page);
+
+  expect(await page.evaluate(() => window.__folioParity?.applyAndUndoDocumentOperation())).toBe(
+    true,
+  );
+});

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -25,6 +25,7 @@ type FolioParityBridge = {
   commentFirstWord: () => boolean;
   countCommentAnchors: () => number;
   aiSnapshotBlockCount: () => number;
+  applyAndUndoDocumentOperation: () => boolean;
   anonymizeFirstWord: () => boolean;
   countAnonymizationRects: () => number;
   save: () => Promise<number>;


### PR DESCRIPTION
Adds handle-based undo for committed document-operation batches across React, Vue, and agent bridges. Includes cross-adapter interaction coverage and public API snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transactional undo for live document-operation batches in React, Vue, and agent integrations.
  * Undo restores document content and comments when no subsequent changes have occurred.
  * Added public editor and bridge APIs for undoing the latest eligible operation batch.
  * Added Vue editor methods for reading and updating comments.

* **Tests**
  * Added parity coverage verifying document operations can be applied and successfully undone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->