### PR TITLE
fix: position zero-left hanging lists

### DIFF
--- a/.changeset/zero-left-hanging-list.md
+++ b/.changeset/zero-left-hanging-list.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Position zero-left hanging list markers in the page margin.

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -164,12 +164,16 @@ describe("Issue #729 — list hanging indent exceeding left indent", () => {
     expect(line.style.textIndent).toBe("0");
   });
 
-  test("left == 0 with hanging: no negative margin (continuation lines sit at hanging)", () => {
-    // Gating on indentLeft > 0 avoids misaligning the first line with the
-    // continuation lines, which the body-line branch places at `hanging`.
+  test("left == 0 with hanging: marker hangs left and body stays at the content edge", () => {
     const { line, marker } = renderListItem({ left: 0, hanging: 24 });
-    expect(marker?.style.marginLeft).toBeFalsy();
+    expect(marker?.style.marginLeft).toBe("-24px");
     expect(line.style.paddingLeft).toBe("0px");
+  });
+
+  test("left == 0 with hanging: continuation lines stay at the content edge", () => {
+    const { continuation } = renderMultiLineListItem({ left: 0, hanging: 24 });
+    expect(continuation.style.paddingLeft).toBeFalsy();
+    expect(continuation.style.marginLeft).toBeFalsy();
   });
 });
 

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2515,13 +2515,6 @@ export function renderParagraphFragment(
     } else if (indentLeft > 0) {
       // Body lines (not first line)
       lineEl.style.paddingLeft = `${indentLeft}px`;
-    } else if (hasHanging && indentLeft === 0) {
-      // Zero left indent + hanging: body lines need padding = hanging so
-      // continuation text aligns with the first line's post-marker body.
-      // A NEGATIVE left indent is realized by the line's own margin-left
-      // (`min(indentLeft, 0)` below); adding hanging padding there would
-      // double-shift the continuation right of where Word places it.
-      lineEl.style.paddingLeft = `${indent.hanging ?? 0}px`;
     }
 
     if (indentRight > 0) {
@@ -2600,11 +2593,9 @@ export function renderParagraphFragment(
       // that so the marker only takes the REMAINING negative offset: for a
       // positive left indent the line margin is 0 and this is just `markerStart`;
       // for a negative left indent it is `markerStart - indentLeft = -hanging`.
-      // The zero-left-indent case keeps its existing model (marker at the box
-      // edge, body at `hanging` via padding), so it is excluded.
       const markerLineMargin = Math.min(indentLeft, 0);
       const markerMarginLeft = markerStart - markerLineMargin;
-      if (markerMarginLeft < 0 && indentLeft !== 0) {
+      if (markerMarginLeft < 0) {
         marker.style.marginLeft = `${markerMarginLeft}px`;
       }
       lineEl.prepend(marker);


### PR DESCRIPTION
## Summary

- hang list markers into the margin when a paragraph has zero left indent
- keep first-line and continuation text at the content edge
- add focused painter regressions for both line positions

CI runs the repository-wide lint, typecheck, build, and test commands.