### PR TITLE
fix: exclude clipped text from parity geometry

### DIFF
--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -9,6 +9,7 @@ import {
   meaningfulTextRange,
   parseCssFontFamilies,
   parseFirstFontFamily,
+  screenshotViewportHeight,
   toPageGeom,
 } from "../folioExtract";
 import type { RawLine, RawPage } from "../folioExtract";
@@ -29,6 +30,20 @@ describe("clean screenshot style", () => {
   test("keeps the page and its document content visible", () => {
     expect(CLEAN_SCREENSHOT_CSS).toContain(".layout-page,");
     expect(CLEAN_SCREENSHOT_CSS).toContain(".layout-page *");
+  });
+});
+
+describe("screenshot viewport height", () => {
+  test("grows enough to paint the tallest page above playground chrome", () => {
+    expect(screenshotViewportHeight([1123, 794], 1000)).toBe(1323);
+  });
+
+  test("does not shrink an already tall viewport", () => {
+    expect(screenshotViewportHeight([1123], 1600)).toBe(1600);
+  });
+
+  test("ignores invalid page heights", () => {
+    expect(screenshotViewportHeight([Number.NaN, Number.POSITIVE_INFINITY], 1000)).toBe(1000);
   });
 });
 

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -200,6 +200,19 @@ describe("toPageGeom", () => {
     expect(page.lines[0]?.text).toBe("Visible");
   });
 
+  test("drops lines fully clipped by an overflow ancestor", () => {
+    const rawPage = makeRawPage({
+      lines: [
+        makeRawLine({ text: "Visible", rect: rect(0, 0, 100, 10) }),
+        makeRawLine({ text: "Clipped", rect: rect(0, 20, 100, 10), fullyClipped: true }),
+      ],
+    });
+
+    const page = toPageGeom(rawPage);
+
+    expect(page.lines.map((line) => line.text)).toEqual(["Visible"]);
+  });
+
   test("drops lines whose normalized text is empty (whitespace-only / soft hyphen only)", () => {
     const rawPage = makeRawPage({
       lines: [

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -174,6 +174,8 @@ export type RawLine = {
   text: string;
   rect: RawRect;
   region: Region;
+  /** True when the line's ink box falls fully outside an overflow-clipping ancestor. */
+  fullyClipped?: boolean;
   /** First actually available family from the computed CSS stack of the first
    * `.layout-run`; falls back to the computed stack when canvas probing is unavailable. */
   fontFamilyRaw?: string;
@@ -240,7 +242,7 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
 
   const lines: LineBox[] = [];
   for (const rawLine of rawPage.lines) {
-    if (rawLine.rect.width <= 0 || rawLine.rect.height <= 0) {
+    if (rawLine.fullyClipped || rawLine.rect.width <= 0 || rawLine.rect.height <= 0) {
       continue;
     }
     const normText = normalizeLineText(rawLine.text);
@@ -662,10 +664,35 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
           return text;
         };
 
+        const isFullyClipped = (sourceEl: HTMLElement | null, rect: DOMRect): boolean => {
+          const clippingValues = new Set(["auto", "clip", "hidden", "scroll"]);
+          let ancestor = (sourceEl ?? lineEl).parentElement;
+          while (ancestor && el.contains(ancestor)) {
+            const computed = getComputedStyle(ancestor);
+            const clipsX = clippingValues.has(computed.overflowX);
+            const clipsY = clippingValues.has(computed.overflowY);
+            if (clipsX || clipsY) {
+              const ancestorRect = ancestor.getBoundingClientRect();
+              if (
+                (clipsX && (rect.right <= ancestorRect.left || rect.left >= ancestorRect.right)) ||
+                (clipsY && (rect.bottom <= ancestorRect.top || rect.top >= ancestorRect.bottom))
+              ) {
+                return true;
+              }
+            }
+            if (ancestor === el) {
+              break;
+            }
+            ancestor = ancestor.parentElement;
+          }
+          return false;
+        };
+
         const toRawLine = (text: string, rect: DOMRect, sourceEl: HTMLElement | null) => ({
           text,
           rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
           region,
+          ...(isFullyClipped(sourceEl, rect) ? { fullyClipped: true } : {}),
           ...(visualGroup !== undefined ? { visualGroup } : {}),
           ...fontFrom(sourceEl),
         });

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -101,6 +101,7 @@ const EDITOR_SELECTOR = '[data-testid="folio-editor"]';
 const PAGE_SELECTOR = ".layout-page";
 
 const VIEWPORT = { width: 1400, height: 1000 };
+const SCREENSHOT_VIEWPORT_VERTICAL_CHROME_PX = 200;
 
 const SERVER_PROBE_TIMEOUT_MS = 2000;
 const SERVER_REUSE_PROBE_TIMEOUT_MS = 15_000;
@@ -465,6 +466,28 @@ const installCleanScreenshotStyle = async (page: Page): Promise<void> => {
   await page.addStyleTag({
     content: CLEAN_SCREENSHOT_CSS,
   });
+};
+
+export const screenshotViewportHeight = (pageHeights: number[], currentHeight: number): number => {
+  const tallestPage = Math.max(0, ...pageHeights.filter(Number.isFinite));
+  return Math.max(currentHeight, Math.ceil(tallestPage + SCREENSHOT_VIEWPORT_VERTICAL_CHROME_PX));
+};
+
+const fitViewportToPages = async (page: Page): Promise<void> => {
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    return;
+  }
+  const pageHeights = await page
+    .locator(PAGE_SELECTOR)
+    .evaluateAll((pageEls) => pageEls.map((pageEl) => (pageEl as HTMLElement).offsetHeight));
+  const height = screenshotViewportHeight(pageHeights, viewport.height);
+  if (height === viewport.height) {
+    return;
+  }
+  await page.setViewportSize({ width: viewport.width, height });
+  await waitForLayoutStability(page);
+  await page.waitForTimeout(STABILITY_SETTLE_MS);
 };
 
 /** One `.layout-page` element's identity, listed before any scrolling so the
@@ -1036,6 +1059,7 @@ export const createFolioExtractor = async (
       if (pageMeta.length === 0) {
         throw new FolioExtractError(`folio rendered zero pages for ${absoluteDocxPath}`);
       }
+      await fitViewportToPages(page);
       await installCleanScreenshotStyle(page);
       const pagesToExtract =
         options.maxPages === undefined ? pageMeta : pageMeta.slice(0, options.maxPages);

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -544,6 +544,11 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
       const tableCells = Array.from(el.querySelectorAll(".layout-table-cell"));
       const lineEls = Array.from(el.querySelectorAll(".layout-line")) as HTMLElement[];
       const resolvedFontCache = new Map<string, string>();
+      const clippingValues = new Set(["auto", "clip", "hidden", "scroll"]);
+      const ancestorClipCache = new Map<
+        HTMLElement,
+        { clipsX: boolean; clipsY: boolean; rect?: DOMRect }
+      >();
       const canvasContext = document.createElement("canvas").getContext("2d");
       const fontProbeText = "mmmmmmmmmmlliWW0123456789";
       const genericFamilies = new Set([
@@ -688,14 +693,25 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
         };
 
         const isFullyClipped = (sourceEl: HTMLElement | null, rect: DOMRect): boolean => {
-          const clippingValues = new Set(["auto", "clip", "hidden", "scroll"]);
           let ancestor = (sourceEl ?? lineEl).parentElement;
           while (ancestor && el.contains(ancestor)) {
-            const computed = getComputedStyle(ancestor);
-            const clipsX = clippingValues.has(computed.overflowX);
-            const clipsY = clippingValues.has(computed.overflowY);
+            let clipInfo = ancestorClipCache.get(ancestor);
+            if (!clipInfo) {
+              const computed = getComputedStyle(ancestor);
+              const clipsX = clippingValues.has(computed.overflowX);
+              const clipsY = clippingValues.has(computed.overflowY);
+              clipInfo = {
+                clipsX,
+                clipsY,
+                ...(clipsX || clipsY ? { rect: ancestor.getBoundingClientRect() } : {}),
+              };
+              ancestorClipCache.set(ancestor, clipInfo);
+            }
+            const { clipsX, clipsY, rect: ancestorRect } = clipInfo;
             if (clipsX || clipsY) {
-              const ancestorRect = ancestor.getBoundingClientRect();
+              if (!ancestorRect) {
+                throw new Error("clipping ancestor is missing cached geometry");
+              }
               if (
                 (clipsX && (rect.right <= ancestorRect.left || rect.left >= ancestorRect.right)) ||
                 (clipsY && (rect.bottom <= ancestorRect.top || rect.top >= ancestorRect.bottom))


### PR DESCRIPTION
## Summary
- detect line ink that falls fully outside document-level overflow clipping
- size the browser viewport so parity screenshots capture complete pages above playground chrome
- add focused regression coverage for clipped-line filtering and viewport sizing

## Validation
- `bun test parity/__tests__/folioExtract.test.ts`
- `bun audit`
- replayed an anonymous parity case and visually verified the complete page screenshot
- full lint and typecheck are delegated to CI

CC on behalf of @jan-kubica