### PR TITLE
fix: preserve forced section column layout

### DIFF
--- a/.changeset/quiet-columns-flow.md
+++ b/.changeset/quiet-columns-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve standalone column breaks and authored unequal section columns during layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -78,7 +78,9 @@ export type ColumnBreakMeasure = {
 export type ColumnLayout = {
     count: number;
     gap: number;
-    equalWidth?: boolean; /** Draw vertical separator line between columns (w:sep). */
+    equalWidth?: boolean; /** Authored widths for unequal-width section columns. */
+    widths?: number[]; /** Authored space after each column except the last. */
+    gaps?: number[]; /** Draw vertical separator line between columns (w:sep). */
     separator?: boolean;
 };
 
@@ -100,6 +102,8 @@ export function createPaginator(options: PaginatorOptions): {
         count: number;
         gap: number;
         equalWidth?: boolean;
+        widths?: number[];
+        gaps?: number[];
         separator?: boolean;
     }; /** Get current state. */
     getCurrentState: () => PageState; /** Get available height in current column. */
@@ -405,7 +409,8 @@ export type LayoutOptions = {
         w: number;
         h: number;
     }; /** Body-level final section margins. */
-    finalMargins?: PageMargins; /** Column configuration. */
+    finalMargins?: PageMargins; /** Body-level final section column configuration. */
+    finalColumns?: ColumnLayout; /** Column configuration. */
     columns?: ColumnLayout; /** Gap between rendered pages (for UI). */
     pageGap?: number; /** Default line height multiplier. */
     defaultLineHeight?: number; /** Header content heights by variant. */

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -26,6 +26,7 @@ import type {
 import { applyTemplatePreviewToBlocks } from "../layout-bridge/convert/templatePreviewFlow";
 import { toFlowBlocks } from "../layout-bridge/convert/toFlowBlocks";
 import type { ToFlowBlocksOptions } from "../layout-bridge/convert/toFlowBlocks";
+import { getColumns } from "../layout-bridge/sectionColumns";
 import { layoutDocument } from "../layout-engine";
 import type { ColumnLayout, SectionLayoutConfig } from "../layout-engine";
 import {
@@ -379,10 +380,21 @@ export function runLayoutPipeline<THfPMs>(
     if (columns !== undefined) {
       bodyLayoutConfig.columns = columns;
     }
+    const finalSectionProperties = document?.package.document.sections?.at(-1)?.properties;
+    const finalLayoutConfig: SectionLayoutConfig = finalSectionProperties
+      ? {
+          pageSize: getPageSize(finalSectionProperties),
+          margins: getMargins(finalSectionProperties),
+        }
+      : bodyLayoutConfig;
+    const finalColumns = getColumns(finalSectionProperties);
+    if (finalColumns !== undefined) {
+      finalLayoutConfig.columns = finalColumns;
+    }
     const blockMeasureInputs = computePerBlockMeasureInputs({
       blocks: newBlocks,
       bodyConfig: bodyLayoutConfig,
-      finalConfig: bodyLayoutConfig,
+      finalConfig: finalLayoutConfig,
     });
     const blockWidths = blockMeasureInputs.widths;
     const previousArtifacts = session.artifacts;
@@ -445,10 +457,10 @@ export function runLayoutPipeline<THfPMs>(
           nextLayoutOpts.firstPageMargins = { ...margins, top: headerBottom };
         }
       }
-      const finalSection = document?.package.document.sections?.at(-1);
-      if (finalSection) {
-        nextLayoutOpts.finalPageSize = getPageSize(finalSection.properties);
-        nextLayoutOpts.finalMargins = getMargins(finalSection.properties);
+      if (finalSectionProperties) {
+        nextLayoutOpts.finalPageSize = finalLayoutConfig.pageSize;
+        nextLayoutOpts.finalMargins = finalLayoutConfig.margins;
+        nextLayoutOpts.finalColumns = finalLayoutConfig.columns ?? { count: 1, gap: 0 };
       }
       if (columns !== undefined) {
         nextLayoutOpts.columns = columns;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -5,6 +5,19 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("emits a structural break for a standalone column break paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("First column")]),
+      schema.node("paragraph", null, [schema.node("hardBreak", { breakType: "column" })]),
+      schema.node("paragraph", null, [schema.text("Second column")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["paragraph", "columnBreak", "paragraph"]);
+    expect(blocks.at(1)).toMatchObject({ kind: "columnBreak", pmStart: 14, pmEnd: 17 });
+  });
+
   test("empty paragraph measurement uses direct paragraph-mark font metrics", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -20,8 +20,8 @@ import type {
   ImageBlock,
   TextBoxBlock,
   PageBreakBlock,
+  ColumnBreakBlock,
   SectionBreakBlock,
-  ColumnLayout,
   Run,
   TextRun,
   TabRun,
@@ -35,6 +35,7 @@ import type {
 } from "../../layout-engine/types";
 import { setTextBoxGroupId } from "../../layout-engine/textBoxGroup";
 import { DEFAULT_TEXTBOX_MARGINS, DEFAULT_TEXTBOX_WIDTH } from "../../layout-engine/types";
+import { getColumns } from "../sectionColumns";
 import {
   expectBlockSdtAttrs,
   expectCharacterSpacingMarkAttrs,
@@ -44,6 +45,7 @@ import {
   expectFontFamilyMarkAttrs,
   expectFontSizeMarkAttrs,
   expectFootnoteRefMarkAttrs,
+  expectHardBreakAttrs,
   expectHighlightMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
@@ -2518,10 +2520,23 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
 
     switch (node.type.name) {
       case "paragraph": {
-        const block = convertParagraph(node, pos, opts);
         const pmAttrs = expectParagraphAttrs(node);
+        const onlyChild = node.childCount === 1 ? node.firstChild : null;
+        const isStandaloneColumnBreak =
+          onlyChild?.type.name === "hardBreak" &&
+          expectHardBreakAttrs(onlyChild).breakType === "column";
 
-        trackedPush(block);
+        if (isStandaloneColumnBreak) {
+          const columnBreak: ColumnBreakBlock = {
+            kind: "columnBreak",
+            id: nextBlockId(),
+            pmStart: pos,
+            pmEnd: pos + node.nodeSize,
+          };
+          trackedPush(columnBreak);
+        } else {
+          trackedPush(convertParagraph(node, pos, opts));
+        }
 
         // Emit section break block if this paragraph ends a section
         const secProps = pmAttrs._sectionProperties as SectionProperties | undefined;
@@ -2570,17 +2585,9 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
               }
             }
             // Populate columns
-            const colCount = secProps.columnCount ?? 1;
-            if (colCount > 1) {
-              const cols: ColumnLayout = {
-                count: colCount,
-                gap: twipsToPixels(secProps.columnSpace ?? 720),
-                equalWidth: secProps.equalWidth ?? true,
-              };
-              if (secProps.separator !== undefined) {
-                cols.separator = secProps.separator;
-              }
-              sectionBreak.columns = cols;
+            const columns = getColumns(secProps);
+            if (columns) {
+              sectionBreak.columns = columns;
             }
           }
 

--- a/packages/core/src/layout-bridge/sectionColumns.test.ts
+++ b/packages/core/src/layout-bridge/sectionColumns.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { getColumns } from "./sectionColumns";
+
+describe("getColumns", () => {
+  test("preserves authored unequal widths and per-column spacing", () => {
+    const columns = getColumns({
+      columnCount: 2,
+      columnSpace: 300,
+      equalWidth: false,
+      columns: [{ width: 1500, space: 750 }, { width: 3000 }],
+    });
+
+    expect(columns).toEqual({
+      count: 2,
+      gap: 20,
+      equalWidth: false,
+      widths: [100, 200],
+      gaps: [50],
+    });
+  });
+});

--- a/packages/core/src/layout-bridge/sectionColumns.ts
+++ b/packages/core/src/layout-bridge/sectionColumns.ts
@@ -22,7 +22,8 @@ const DEFAULT_COLUMN_SPACE_TWIPS = 720;
 export function getColumns(
   sectionProps: SectionProperties | null | undefined,
 ): ColumnLayout | undefined {
-  const count = sectionProps?.columnCount ?? 1;
+  const authoredColumns = sectionProps?.columns;
+  const count = sectionProps?.columnCount ?? authoredColumns?.length ?? 1;
   if (count <= 1) return undefined;
   const gap = twipsToPixels(sectionProps?.columnSpace ?? DEFAULT_COLUMN_SPACE_TWIPS);
   const columns: ColumnLayout = {
@@ -30,6 +31,18 @@ export function getColumns(
     gap,
     equalWidth: sectionProps?.equalWidth ?? true,
   };
+  if (
+    sectionProps?.equalWidth === false &&
+    authoredColumns?.length === count &&
+    authoredColumns.every(({ width }) => width !== undefined)
+  ) {
+    columns.widths = authoredColumns.map(({ width }) => twipsToPixels(width ?? 0));
+    columns.gaps = authoredColumns
+      .slice(0, -1)
+      .map(({ space }) =>
+        twipsToPixels(space ?? sectionProps.columnSpace ?? DEFAULT_COLUMN_SPACE_TWIPS),
+      );
+  }
   // exactOptionalPropertyTypes: only attach `separator` when explicitly set.
   if (sectionProps?.separator !== undefined) columns.separator = sectionProps.separator;
   return columns;

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { layoutDocument } from "./index";
-import type { FlowBlock, ParagraphBlock, ParagraphMeasure, SectionBreakBlock } from "./types";
+import type {
+  ColumnBreakBlock,
+  FlowBlock,
+  ParagraphBlock,
+  ParagraphMeasure,
+  SectionBreakBlock,
+} from "./types";
 
 function paragraph(
   id: string,
@@ -36,6 +42,46 @@ function paragraph(
 }
 
 describe("continuous section break geometry", () => {
+  test("a final multi-column section keeps a forced column break on the current page", () => {
+    const first = paragraph("a", 100);
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "sb",
+      type: "continuous",
+    };
+    const firstColumn = paragraph("b", 100);
+    const columnBreak: ColumnBreakBlock = { kind: "columnBreak", id: "cb" };
+    const secondColumn = paragraph("c", 100);
+    const blocks: FlowBlock[] = [
+      first.block,
+      sectionBreak,
+      firstColumn.block,
+      columnBreak,
+      secondColumn.block,
+    ];
+    const measures = [
+      first.measure,
+      { kind: "sectionBreak" },
+      firstColumn.measure,
+      { kind: "columnBreak" },
+      secondColumn.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalColumns: { count: 2, gap: 20, widths: [200, 300], gaps: [100] },
+      bodyBreakType: "continuous",
+    });
+
+    expect(result.pages).toHaveLength(1);
+    const secondColumnFragment = result.pages[0]?.fragments.find(
+      (fragment) => fragment.kind === "paragraph" && fragment.blockId === "c",
+    );
+    expect(secondColumnFragment?.x).toBe(350);
+    expect(secondColumnFragment?.width).toBe(300);
+  });
+
   test("current page keeps old geometry and overflow page picks up new geometry", () => {
     const first = paragraph("a", 200);
     const sectionBreak: SectionBreakBlock = {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -274,8 +274,9 @@ export function layoutDocument(
     pageSize: finalPageSize,
     margins: finalMargins,
   };
-  if (options.columns !== undefined) {
-    finalConfig.columns = options.columns;
+  const finalColumns = options.finalColumns ?? options.columns;
+  if (finalColumns !== undefined) {
+    finalConfig.columns = finalColumns;
   }
   const { configs: sectionConfigs, breakIndices } = collectSectionConfigs(
     blocks,
@@ -372,7 +373,7 @@ export function layoutDocument(
           block,
           measure as ParagraphMeasure,
           paginator,
-          paginator.getContentWidth(),
+          paginator.columnWidth,
           options.footnoteHeightById,
         );
         break;

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -76,19 +76,27 @@ type ForcePageBreakOptions = {
   coalesceBlankPage?: boolean;
 };
 
-/**
- * Calculate the width of a single column.
- */
-function calculateColumnWidth(
+/** Calculate active column widths, preferring authored unequal widths. */
+function calculateColumnWidths(
   pageWidth: number,
   leftMargin: number,
   rightMargin: number,
   columns: ColumnLayout,
-): number {
+): number[] {
+  if (
+    columns.widths?.length === columns.count &&
+    columns.widths.every((width) => Number.isFinite(width) && width > 0)
+  ) {
+    return [...columns.widths];
+  }
   const contentWidth = pageWidth - leftMargin - rightMargin;
   const totalGaps = (columns.count - 1) * columns.gap;
-  return (contentWidth - totalGaps) / columns.count;
+  const equalWidth = (contentWidth - totalGaps) / columns.count;
+  return Array.from({ length: columns.count }, () => equalWidth);
 }
+
+const gapAfterColumn = (columns: ColumnLayout, columnIndex: number): number =>
+  columns.gaps?.[columnIndex] ?? columns.gap;
 
 function arePageSizesEqual(
   left: { w: number; h: number },
@@ -149,11 +157,10 @@ export function createPaginator(options: PaginatorOptions) {
     panic("Paginator: page size and margins yield no content area");
   }
 
-  // Calculate column width
-  let columnWidth = calculateColumnWidth(pageSize.w, margins.left, margins.right, columns);
+  let columnWidths = calculateColumnWidths(pageSize.w, margins.left, margins.right, columns);
 
-  function recalculateColumnWidth(): void {
-    columnWidth = calculateColumnWidth(pageSize.w, margins.left, margins.right, columns);
+  function recalculateColumnWidths(): void {
+    columnWidths = calculateColumnWidths(pageSize.w, margins.left, margins.right, columns);
   }
 
   function applyPendingLayout(): void {
@@ -168,7 +175,7 @@ export function createPaginator(options: PaginatorOptions) {
     if (getContentHeight() <= 0) {
       panic("Paginator: section page size and margins yield no content area");
     }
-    recalculateColumnWidth();
+    recalculateColumnWidths();
   }
 
   function getPageMargins(pageNumber: number): PageMargins {
@@ -193,7 +200,11 @@ export function createPaginator(options: PaginatorOptions) {
    */
   function getColumnX(columnIndex: number): number {
     const activeLeftMargin = states.at(-1)?.page.margins.left ?? getPageMargins(1).left;
-    return activeLeftMargin + columnIndex * (columnWidth + columns.gap);
+    let x = activeLeftMargin;
+    for (let index = 0; index < columnIndex; index++) {
+      x += (columnWidths[index] ?? columnWidths[0] ?? 0) + gapAfterColumn(columns, index);
+    }
+    return x;
   }
 
   /**
@@ -496,7 +507,7 @@ export function createPaginator(options: PaginatorOptions) {
    */
   function updateColumns(newColumns: ColumnLayout): void {
     columns = newColumns;
-    columnWidth = calculateColumnWidth(pageSize.w, margins.left, margins.right, columns);
+    recalculateColumnWidths();
 
     // Update current page's column info for rendering
     const state = getCurrentState();
@@ -535,7 +546,7 @@ export function createPaginator(options: PaginatorOptions) {
     if (getContentHeight() <= 0) {
       panic("Paginator: section page size and margins yield no content area");
     }
-    recalculateColumnWidth();
+    recalculateColumnWidths();
     pendingPageSize = undefined;
     pendingMargins = undefined;
   }
@@ -563,7 +574,8 @@ export function createPaginator(options: PaginatorOptions) {
     states,
     /** Column width in pixels (use getColumnWidth() for current value after updates). */
     get columnWidth() {
-      return columnWidth;
+      const columnIndex = states.at(-1)?.columnIndex ?? 0;
+      return columnWidths[columnIndex] ?? columnWidths[0] ?? getContentWidth();
     },
     /** Get current column layout (returns copy to prevent external mutation). */
     get columns() {

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1058,6 +1058,10 @@ export type ColumnLayout = {
   count: number;
   gap: number;
   equalWidth?: boolean;
+  /** Authored widths for unequal-width section columns. */
+  widths?: number[];
+  /** Authored space after each column except the last. */
+  gaps?: number[];
   /** Draw vertical separator line between columns (w:sep). */
   separator?: boolean;
 };
@@ -1134,6 +1138,8 @@ export type LayoutOptions = {
   finalPageSize?: { w: number; h: number };
   /** Body-level final section margins. */
   finalMargins?: PageMargins;
+  /** Body-level final section column configuration. */
+  finalColumns?: ColumnLayout;
   /** Column configuration. */
   columns?: ColumnLayout;
   /** Gap between rendered pages (for UI). */

--- a/packages/core/src/paged-layout/sectionBlockWidths.test.ts
+++ b/packages/core/src/paged-layout/sectionBlockWidths.test.ts
@@ -59,4 +59,23 @@ describe("section block measurement inputs", () => {
 
     expect(inputs.marginTops).toEqual([64, 64, BODY_CONFIG.margins.top]);
   });
+
+  test("uses the authored width after a forced break in unequal columns", () => {
+    const blocks: FlowBlock[] = [
+      paragraph("first-column"),
+      { kind: "columnBreak", id: "column-break" },
+      paragraph("second-column"),
+    ];
+
+    const widths = computePerBlockWidths({
+      blocks,
+      bodyConfig: BODY_CONFIG,
+      finalConfig: {
+        ...BODY_CONFIG,
+        columns: { count: 2, gap: 20, widths: [200, 300], gaps: [100] },
+      },
+    });
+
+    expect(widths).toEqual([200, 200, 300]);
+  });
 });

--- a/packages/core/src/paged-layout/sectionBlockWidths.ts
+++ b/packages/core/src/paged-layout/sectionBlockWidths.ts
@@ -45,9 +45,13 @@ export function computePerBlockMeasureInputs({
   bodyConfig,
   finalConfig,
 }: ComputePerBlockMeasureInput): PerBlockMeasureInputs {
-  function colWidth(cw: number, cols: ColumnLayout): number {
+  function colWidth(cw: number, cols: ColumnLayout, columnIndex: number): number {
     if (cols.count <= 1) {
       return cw;
+    }
+    const authoredWidth = cols.widths?.[columnIndex];
+    if (authoredWidth !== undefined) {
+      return authoredWidth;
     }
     return Math.floor((cw - (cols.count - 1) * cols.gap) / cols.count);
   }
@@ -63,6 +67,7 @@ export function computePerBlockMeasureInputs({
   );
 
   let sectionIdx = 0;
+  let columnIndex = 0;
   const widths: number[] = [];
   const marginTops: number[] = [];
   const pageHeights: number[] = [];
@@ -70,13 +75,19 @@ export function computePerBlockMeasureInputs({
 
   for (let i = 0; i < blocks.length; i++) {
     const config = sectionConfigs[sectionIdx] ?? finalConfig;
-    widths.push(colWidth(contentWidth(config), config.columns ?? SINGLE_COLUMN_LAYOUT));
+    const columns = config.columns ?? SINGLE_COLUMN_LAYOUT;
+    widths.push(colWidth(contentWidth(config), columns, columnIndex));
     marginTops.push(config.margins.top);
     pageHeights.push(config.pageSize.h);
     marginBottoms.push(config.margins.bottom);
 
     if (sectionIdx < breakIndices.length && i === breakIndices[sectionIdx]) {
       sectionIdx++;
+      columnIndex = 0;
+    } else if (blocks[i]?.kind === "pageBreak") {
+      columnIndex = 0;
+    } else if (blocks[i]?.kind === "columnBreak") {
+      columnIndex = (columnIndex + 1) % columns.count;
     }
   }
 


### PR DESCRIPTION
## Summary
- emit standalone OOXML column breaks as structural flow breaks
- thread final-section columns through measurement and pagination
- preserve authored unequal column widths and gaps, and paint paragraphs at active column width
- add focused conversion, measurement, and continuous-section regressions

## Validation
- focused core tests: 71 passed
- `bun audit`
- anonymous strict-font parity replay: page count now matches and the column line-break divergence is removed
- full lint, typecheck, test, build, and package validation are delegated to CI

CC on behalf of @jan-kubica