### PR TITLE
fix: cap hanging list justification width

### DIFF
--- a/.changeset/calm-hanging-justify.md
+++ b/.changeset/calm-hanging-justify.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep justified zero-left hanging list lines within the authored right margin.

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -282,9 +282,51 @@ describe("Issue #868 — justify first line to full content width on indented pa
         isFirstLine: true,
         paragraphEndsWithLineBreak: false,
         firstLineIndentPx: -36,
+        leftIndentPx: 36,
       }) as unknown as FakeElement;
 
       expect(lineEl.style["width"]).toBe("136px");
+    } finally {
+      resetCanvasContext();
+      Object.defineProperty(globalThis, "document", {
+        value: originalDocument,
+        configurable: true,
+      });
+    }
+  });
+
+  test("does not widen a zero-left hanging-list line past the right edge", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-zero-left-list-justify-width",
+      runs: [{ kind: "text", text: "Item text" }],
+      attrs: { alignment: "justify", listMarker: "1.", indent: { left: 0, hanging: 36 } },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 9,
+      width: 90,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const originalDocument = globalThis.document;
+    Object.defineProperty(globalThis, "document", { value: fakeDocument, configurable: true });
+    resetCanvasContext();
+    try {
+      const lineEl = renderLine(block, line, "justify", fakeDocument, {
+        availableWidth: 100,
+        isLastLine: false,
+        isFirstLine: true,
+        paragraphEndsWithLineBreak: false,
+        firstLineIndentPx: -36,
+        leftIndentPx: 0,
+      }) as unknown as FakeElement;
+
+      expect(lineEl.style["width"]).toBe("100px");
     } finally {
       resetCanvasContext();
       Object.defineProperty(globalThis, "document", {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1723,7 +1723,18 @@ export function renderLine(
     if (shouldJustify) {
       const firstLineIndentPx = options.isFirstLine ? (options.firstLineIndentPx ?? 0) : 0;
       const firstLineHangingPx = Math.max(0, -firstLineIndentPx);
-      const justifyCapacityPx = options.availableWidth + firstLineHangingPx;
+      const hasVisibleListMarker =
+        options.isFirstLine && block.attrs?.listMarker && !block.attrs.listMarkerHidden;
+      // A list marker consumes the hanging slot inline. When the marker starts
+      // before the content edge, its negative margin cancels the part of that
+      // slot outside the paragraph; only the portion between the content edge
+      // and the body start can expand the line box. Letting the full hanging
+      // value expand a zero-left list pushed justified text past the right
+      // margin by exactly one hanging slot.
+      const firstLineHangingExpansionPx = hasVisibleListMarker
+        ? Math.min(firstLineHangingPx, Math.max(0, options.leftIndentPx ?? 0))
+        : firstLineHangingPx;
+      const justifyCapacityPx = options.availableWidth + firstLineHangingExpansionPx;
       const overfullPx = line.width - justifyCapacityPx;
       const shrinkableSpaces = countShrinkableSpaces(runsForLine);
       if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
@@ -1745,10 +1756,9 @@ export function renderLine(
         lineEl.style.textAlignLast = "justify";
       }
       // Set explicit width so browser knows how wide to justify/compress to.
-      const listFirstLineOffset =
-        options.isFirstLine && block.attrs?.listMarker && !block.attrs.listMarkerHidden
-          ? (options.firstLineIndentPx ?? 0)
-          : 0;
+      const listFirstLineOffset = hasVisibleListMarker
+        ? Math.max(firstLineIndentPx, -firstLineHangingExpansionPx)
+        : 0;
       lineEl.style.width = `${options.availableWidth - listFirstLineOffset}px`;
     }
   }


### PR DESCRIPTION
## Summary

- cap justified first-line expansion to the authored nonnegative left indent when a hanging list marker starts in the margin
- keep ordinary hanging-list expansion unchanged
- add a focused zero-left hanging-list regression

## Validation

- focused layout-painter tests: 12 passed
- anonymous strict-font replay: 46.7% to 59.0%; width divergences 42 to 27; page count unchanged
- two structurally different anonymous replays stayed stable at 91.7% and 67.9%
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica