### PR TITLE
fix: preserve paragraph IDs through editor lifecycle

### DIFF
--- a/.changeset/para-id-lifecycle-fixes.md
+++ b/.changeset/para-id-lifecycle-fixes.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Harden the paraId lifecycle: duplicate resolution in the allocator now maps the original paragraph's position through the transaction (pasting a copy above its source no longer steals the source's id), allocation transactions are excluded from paragraph change tracking, and the hex id generators can no longer mint the reserved `00000000` value.

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
@@ -6,11 +6,17 @@
  * ends up with a non-empty `paraId` and no two paragraphs share one,
  * including after paste-style Slice insertions that import a
  * paragraph carrying an id that already exists in the doc.
+ *
+ * The "Id lifecycle rules" block in the extension header is the spec;
+ * the tests below lock each rule (split, merge, paste above/below,
+ * cross-doc paste, undo/redo, change-tracker isolation).
  */
 
 import { describe, test, expect } from "bun:test";
+import { history, redo, undo } from "prosemirror-history";
 import { Schema, Slice, Fragment } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
+import type { Command } from "prosemirror-state";
 
 import {
   getChangedParagraphIds,
@@ -62,6 +68,21 @@ const createTrackedState = (...paras: ReturnType<typeof para>[]) =>
     doc: schema.node("doc", null, paras),
     plugins: [plugin, changeTrackerPlugin],
   });
+
+const createHistoryState = (...paras: ReturnType<typeof para>[]) =>
+  EditorState.create({
+    doc: schema.node("doc", null, paras),
+    plugins: [plugin, history()],
+  });
+
+const applyCommand = (state: EditorState, command: Command): EditorState => {
+  let next = state;
+  const applied = command(state, (tr) => {
+    next = state.apply(tr);
+  });
+  expect(applied).toBe(true);
+  return next;
+};
 
 const collectParaIds = (state: EditorState): (string | null)[] => {
   const out: (string | null)[] = [];
@@ -145,5 +166,104 @@ describe("ParaIdAllocatorExtension", () => {
     // Trigger any doc-changed transaction.
     const next = initial.apply(initial.tr.insertText("!", 6));
     expect(collectParaIds(next)).toEqual(["11111111", "22222222"]);
+  });
+
+  test("split: the first half keeps the id, the second half gets a fresh one", () => {
+    const initial = createState(para("Hello", "5117AB1E"));
+    // Split after "He": paragraph starts at 0, content at 1.
+    const next = initial.apply(initial.tr.split(3));
+    const ids = collectParaIds(next);
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toBe("5117AB1E");
+    expect(ids[1]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[1]).not.toBe("5117AB1E");
+  });
+
+  test("merge: the surviving paragraph keeps its id; the absorbed id dangles", () => {
+    const initial = createState(para("First", "AAAA1111"), para("Second", "BBBB2222"));
+    // Boundary between the two paragraphs: nodeSize of the first = 7.
+    const next = initial.apply(initial.tr.join(7));
+    expect(collectParaIds(next)).toEqual(["AAAA1111"]);
+  });
+
+  test("paste above the source: the source keeps its id, the pasted copy gets a fresh one", () => {
+    const initial = createState(para("Original", "0R161NA1"));
+    const dupe = para("Pasted copy", "0R161NA1");
+    // Insert the duplicate BEFORE the source. Naive first-occurrence
+    // dedupe would hand the pasted copy the source's id; the keeper
+    // mapping must keep it on the original.
+    const next = initial.apply(initial.tr.replace(0, 0, new Slice(Fragment.from(dupe), 0, 0)));
+    const ids = collectParaIds(next);
+    expect(ids).toHaveLength(2);
+    // ids[0] is the pasted copy, ids[1] the original.
+    expect(ids[1]).toBe("0R161NA1");
+    expect(ids[0]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[0]).not.toBe("0R161NA1");
+    const texts: string[] = [];
+    next.doc.descendants((node) => {
+      if (node.type.name === "paragraph") {
+        texts.push(node.textContent);
+        return false;
+      }
+      return true;
+    });
+    expect(texts).toEqual(["Pasted copy", "Original"]);
+  });
+
+  test("paste of an id unknown to this doc is kept (cut-then-paste keeps anchors)", () => {
+    const initial = createState(para("Existing", "EX157175"));
+    const moved = para("Moved from elsewhere", "C0FFEE01");
+    const next = initial.apply(
+      initial.tr.replace(
+        initial.doc.content.size,
+        initial.doc.content.size,
+        new Slice(Fragment.from(moved), 0, 0),
+      ),
+    );
+    expect(collectParaIds(next)).toEqual(["EX157175", "C0FFEE01"]);
+  });
+
+  test("undo/redo: redoing a split mints a fresh id again (stable across saves, not redo)", () => {
+    const initial = createHistoryState(para("Hello", "5117AB1E"));
+    const afterSplit = initial.apply(initial.tr.split(3));
+    const idsAfterSplit = collectParaIds(afterSplit);
+    expect(idsAfterSplit[0]).toBe("5117AB1E");
+    const mintedBeforeUndo = idsAfterSplit[1];
+    expect(mintedBeforeUndo).toMatch(/^[0-9A-F]{8}$/u);
+
+    const afterUndo = applyCommand(afterSplit, undo);
+    expect(collectParaIds(afterUndo)).toEqual(["5117AB1E"]);
+
+    const afterRedo = applyCommand(afterUndo, redo);
+    const idsAfterRedo = collectParaIds(afterRedo);
+    expect(idsAfterRedo).toHaveLength(2);
+    expect(idsAfterRedo[0]).toBe("5117AB1E");
+    // The redo-minted id is valid and unique, but NOT guaranteed to
+    // equal the pre-undo id: the allocation transaction is outside
+    // history (addToHistory: false), so redo re-creates the paragraph
+    // and a fresh id is minted. Accepted behavior — an id is stable
+    // across saves, not across redo-recreation.
+    expect(idsAfterRedo[1]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(idsAfterRedo[1]).not.toBe("5117AB1E");
+  });
+
+  test("allocation via appendTransaction does not mark untouched paragraphs as changed", () => {
+    const initial = createTrackedState(
+      para("Never touched by the user"),
+      para("Edited", "ED17ED01"),
+    );
+    // The user edits only the second paragraph; the allocator backfills
+    // the first paragraph's missing id in the appended transaction.
+    const editPos = initial.doc.content.size - 2;
+    const next = initial.apply(initial.tr.insertText("!", editPos));
+
+    const ids = collectParaIds(next);
+    expect(ids[0]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[1]).toBe("ED17ED01");
+
+    const changed = getChangedParagraphIds(next);
+    expect(changed.has("ED17ED01")).toBe(true);
+    // SAFETY: asserted 8-hex above
+    expect(changed.has(ids[0]!)).toBe(false);
   });
 });

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
@@ -12,7 +12,7 @@
  * cross-doc paste, undo/redo, change-tracker isolation).
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { history, redo, undo } from "prosemirror-history";
 import { Schema, Slice, Fragment } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
@@ -161,6 +161,23 @@ describe("ParaIdAllocatorExtension", () => {
     expect(ids[1]).not.toBe("ABCDEFGH");
   });
 
+  test("replaces the reserved zero id carried by a pasted paragraph", () => {
+    const initial = createState(para("Original", "ABCDEFGH"));
+    const pasted = para("Pasted", "00000000");
+    const next = initial.apply(
+      initial.tr.replace(
+        initial.doc.content.size,
+        initial.doc.content.size,
+        new Slice(Fragment.from(pasted), 0, 0),
+      ),
+    );
+
+    const ids = collectParaIds(next);
+    expect(ids[0]).toBe("ABCDEFGH");
+    expect(ids[1]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[1]).not.toBe("00000000");
+  });
+
   test("preserves existing distinct ids untouched", () => {
     const initial = createState(para("First", "11111111"), para("Second", "22222222"));
     // Trigger any doc-changed transaction.
@@ -223,28 +240,29 @@ describe("ParaIdAllocatorExtension", () => {
     expect(collectParaIds(next)).toEqual(["EX157175", "C0FFEE01"]);
   });
 
-  test("undo/redo: redoing a split mints a fresh id again (stable across saves, not redo)", () => {
-    const initial = createHistoryState(para("Hello", "5117AB1E"));
-    const afterSplit = initial.apply(initial.tr.split(3));
-    const idsAfterSplit = collectParaIds(afterSplit);
-    expect(idsAfterSplit[0]).toBe("5117AB1E");
-    const mintedBeforeUndo = idsAfterSplit[1];
-    expect(mintedBeforeUndo).toMatch(/^[0-9A-F]{8}$/u);
+  test("undo/redo: redoing a split restores the allocated id", () => {
+    const random = spyOn(Math, "random");
+    try {
+      random.mockReturnValue(0);
+      const initial = createHistoryState(para("Hello", "5117AB1E"));
+      const afterSplit = initial.apply(initial.tr.split(3));
+      const idsAfterSplit = collectParaIds(afterSplit);
+      expect(idsAfterSplit[0]).toBe("5117AB1E");
+      const mintedBeforeUndo = idsAfterSplit[1];
+      expect(mintedBeforeUndo).toBe("00000001");
 
-    const afterUndo = applyCommand(afterSplit, undo);
-    expect(collectParaIds(afterUndo)).toEqual(["5117AB1E"]);
+      const afterUndo = applyCommand(afterSplit, undo);
+      expect(collectParaIds(afterUndo)).toEqual(["5117AB1E"]);
 
-    const afterRedo = applyCommand(afterUndo, redo);
-    const idsAfterRedo = collectParaIds(afterRedo);
-    expect(idsAfterRedo).toHaveLength(2);
-    expect(idsAfterRedo[0]).toBe("5117AB1E");
-    // The redo-minted id is valid and unique, but NOT guaranteed to
-    // equal the pre-undo id: the allocation transaction is outside
-    // history (addToHistory: false), so redo re-creates the paragraph
-    // and a fresh id is minted. Accepted behavior — an id is stable
-    // across saves, not across redo-recreation.
-    expect(idsAfterRedo[1]).toMatch(/^[0-9A-F]{8}$/u);
-    expect(idsAfterRedo[1]).not.toBe("5117AB1E");
+      const afterRedo = applyCommand(afterUndo, redo);
+      const idsAfterRedo = collectParaIds(afterRedo);
+      expect(idsAfterRedo).toHaveLength(2);
+      expect(idsAfterRedo[0]).toBe("5117AB1E");
+      expect(idsAfterRedo[1]).toBe(mintedBeforeUndo);
+      expect(random).toHaveBeenCalledTimes(1);
+    } finally {
+      random.mockRestore();
+    }
   });
 
   test("allocation via appendTransaction does not mark untouched paragraphs as changed", () => {

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -4,7 +4,10 @@
  * Lifted from
  * https://github.com/eigenpal/docx-editor/blob/main/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
  * (Apache-2.0). Adapted to folio's `createExtension` + import style;
- * keep behaviour in sync upstream.
+ * keep behaviour in sync upstream. folio divergences: duplicate
+ * resolution maps the original paragraph's position through the
+ * transaction (see below), and the appended allocation transaction is
+ * excluded from paragraph change tracking like `ensureParaIdsInState`.
  *
  * Why: AI tooling, chat citation chips, and the change tracker all
  * anchor on `paraId`. A paragraph with `paraId: null` is invisible
@@ -12,10 +15,28 @@
  * Enter-split, or content pasted from another doc) silently desyncs
  * their anchors. This plugin closes both gaps by allocating fresh
  * ids in an `appendTransaction` hook after every doc-changed step.
+ *
+ * Id lifecycle rules (locked by the co-located tests):
+ * - Missing/empty id: a fresh random id is minted.
+ * - Split: the half holding the paragraph's original start position
+ *   keeps the id; the other half gets a fresh one. Anchors inside the
+ *   content stay resolvable on the half that carries them.
+ * - Merge/join: the surviving paragraph keeps its id; the absorbed id
+ *   dangles by design (consumers degrade to snapshot fallback).
+ * - Paste/duplicate carrying an id already in the doc: the paragraph
+ *   whose mapped pre-transaction position matches keeps it — pasting a
+ *   copy above its source no longer steals the source's id. When no
+ *   occurrence maps back (e.g. both are new), the first in document
+ *   order keeps it.
+ * - Paste of an id unknown to this doc (cross-doc paste, cut-then-
+ *   paste move): the id is kept, so a moved paragraph stays anchored.
+ * - Undo/redo: allocation applies with `addToHistory: false`, so
+ *   redoing a split mints a different fresh id than before the undo.
+ *   An id is stable across saves, not across redo-recreation.
  */
 import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
-import type { EditorState } from "prosemirror-state";
+import type { EditorState, Transaction } from "prosemirror-state";
 
 import { generateHexId } from "../../../utils/hexId";
 import { createExtension } from "../create";
@@ -29,34 +50,104 @@ type ParaIdUpdate = {
   attrs: Record<string, unknown>;
 };
 
-const collectParaIdUpdates = (doc: PMNode): ParaIdUpdate[] => {
-  const seen = new Set<string>();
-  const updates: ParaIdUpdate[] = [];
+type ParagraphOccurrence = {
+  pos: number;
+  attrs: Record<string, unknown>;
+};
+
+/**
+ * For every valid paraId in the pre-transaction doc, the position its
+ * paragraph ends up at after `transactions` — the occurrence that
+ * rightfully keeps the id when the new doc holds duplicates. Ids whose
+ * paragraph start was deleted by the steps are left out.
+ */
+const mapKeeperPositions = (
+  oldDoc: PMNode,
+  transactions: readonly Transaction[],
+): Map<string, number> => {
+  const keepers = new Map<string, number>();
+  oldDoc.descendants((node, pos) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    const id = node.attrs["paraId"];
+    if (typeof id === "string" && id.length > 0 && !keepers.has(id)) {
+      let mapped = pos;
+      let deleted = false;
+      for (const tr of transactions) {
+        const result = tr.mapping.mapResult(mapped);
+        if (result.deleted) {
+          deleted = true;
+          break;
+        }
+        mapped = result.pos;
+      }
+      if (!deleted) {
+        keepers.set(id, mapped);
+      }
+    }
+    return false;
+  });
+  return keepers;
+};
+
+const collectParaIdUpdates = (
+  doc: PMNode,
+  keeperPositions?: Map<string, number>,
+): ParaIdUpdate[] => {
+  // Pass 1: paragraphs without a usable id, and occurrences per id.
+  const missing: ParagraphOccurrence[] = [];
+  const occurrencesById = new Map<string, ParagraphOccurrence[]>();
 
   doc.descendants((node, pos) => {
     // Non-paragraph: recurse — paragraphs nested in tables / cells
     // are still in scope.
     if (node.type.name !== "paragraph") {
-      return;
+      return true;
     }
-
     const id = node.attrs["paraId"];
-    if (typeof id !== "string" || id.length === 0 || seen.has(id)) {
-      let newId = generateHexId();
-      while (seen.has(newId)) {
-        newId = generateHexId();
-      }
-      seen.add(newId);
-      updates.push({ pos, attrs: { ...node.attrs, paraId: newId } });
+    if (typeof id !== "string" || id.length === 0) {
+      missing.push({ pos, attrs: node.attrs });
     } else {
-      seen.add(id);
+      const occurrences = occurrencesById.get(id) ?? [];
+      occurrences.push({ pos, attrs: node.attrs });
+      occurrencesById.set(id, occurrences);
     }
-
     // Paragraphs only contain inline content (text / runs) — nothing
     // we'd ever paraId. Skip the subtree.
     return false;
   });
 
+  // Pass 2: keeper resolution. A unique id always stays put; among
+  // duplicates, the occurrence at the id's mapped pre-transaction
+  // position keeps it, falling back to document order.
+  const needFreshId: ParagraphOccurrence[] = [...missing];
+  for (const [id, occurrences] of occurrencesById) {
+    if (occurrences.length === 1) {
+      continue;
+    }
+    const keeperPos = keeperPositions?.get(id);
+    const keeper = occurrences.find((occurrence) => occurrence.pos === keeperPos) ?? occurrences[0];
+    for (const occurrence of occurrences) {
+      if (occurrence !== keeper) {
+        needFreshId.push(occurrence);
+      }
+    }
+  }
+
+  const taken = new Set(occurrencesById.keys());
+  const updates: ParaIdUpdate[] = [];
+  for (const { pos, attrs } of needFreshId) {
+    let newId = generateHexId();
+    while (taken.has(newId)) {
+      newId = generateHexId();
+    }
+    taken.add(newId);
+    updates.push({ pos, attrs: { ...attrs, paraId: newId } });
+  }
+
+  // Document order keeps transaction step order deterministic.
+  updates.sort((a, b) => a.pos - b.pos);
   return updates;
 };
 
@@ -79,14 +170,15 @@ export const ensureParaIdsInState = (state: EditorState): EditorState => {
 const createParaIdAllocatorPlugin = (): Plugin =>
   new Plugin({
     key: paraIdAllocatorKey,
-    appendTransaction(transactions, _oldState, newState) {
+    appendTransaction(transactions, oldState, newState) {
       // Skip selection-only / mark-only transactions — they can't have
       // created or duplicated a paragraph.
       if (!transactions.some((t) => t.docChanged)) {
         return null;
       }
 
-      const updates = collectParaIdUpdates(newState.doc);
+      const keeperPositions = mapKeeperPositions(oldState.doc, transactions);
+      const updates = collectParaIdUpdates(newState.doc, keeperPositions);
       if (updates.length === 0) {
         return null;
       }
@@ -95,6 +187,10 @@ const createParaIdAllocatorPlugin = (): Plugin =>
       for (const u of updates) {
         tr.setNodeMarkup(u.pos, undefined, u.attrs);
       }
+      // Allocation is bookkeeping, not a user edit: it must not mark
+      // untouched paragraphs as changed (the user's own transaction
+      // already recorded any real edits).
+      ignoreTrackedChanges(tr);
       tr.setMeta(paraIdAllocatorKey, "allocated");
       tr.setMeta("addToHistory", false);
       return tr;

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -75,20 +75,21 @@ const mapKeeperPositions = (
       return true;
     }
     const id = node.attrs["paraId"];
-    if (isUsableParaId(id) && !keepers.has(id)) {
-      let mapped = pos;
-      let deleted = false;
-      for (const tr of transactions) {
-        const result = tr.mapping.mapResult(mapped);
-        if (result.deleted) {
-          deleted = true;
-          break;
-        }
-        mapped = result.pos;
+    if (!isUsableParaId(id) || keepers.has(id)) {
+      return false;
+    }
+    let mapped = pos;
+    let deleted = false;
+    for (const tr of transactions) {
+      const result = tr.mapping.mapResult(mapped);
+      if (result.deleted) {
+        deleted = true;
+        break;
       }
-      if (!deleted) {
-        keepers.set(id, mapped);
-      }
+      mapped = result.pos;
+    }
+    if (!deleted) {
+      keepers.set(id, mapped);
     }
     return false;
   });

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -17,7 +17,7 @@
  * ids in an `appendTransaction` hook after every doc-changed step.
  *
  * Id lifecycle rules (locked by the co-located tests):
- * - Missing/empty id: a fresh random id is minted.
+ * - Missing/empty/reserved-zero id: a fresh random id is minted.
  * - Split: the half holding the paragraph's original start position
  *   keeps the id; the other half gets a fresh one. Anchors inside the
  *   content stay resolvable on the half that carries them.
@@ -30,9 +30,10 @@
  *   order keeps it.
  * - Paste of an id unknown to this doc (cross-doc paste, cut-then-
  *   paste move): the id is kept, so a moved paragraph stays anchored.
- * - Undo/redo: allocation applies with `addToHistory: false`, so
- *   redoing a split mints a different fresh id than before the undo.
- *   An id is stable across saves, not across redo-recreation.
+ * - Undo/redo: allocation applies with `addToHistory: false`, and
+ *   ProseMirror remaps it into the originating history event. Redoing a
+ *   split therefore restores the same allocated id instead of minting
+ *   another one.
  */
 import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
@@ -55,6 +56,9 @@ type ParagraphOccurrence = {
   attrs: Record<string, unknown>;
 };
 
+const isUsableParaId = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0 && value !== "00000000";
+
 /**
  * For every valid paraId in the pre-transaction doc, the position its
  * paragraph ends up at after `transactions` — the occurrence that
@@ -71,7 +75,7 @@ const mapKeeperPositions = (
       return true;
     }
     const id = node.attrs["paraId"];
-    if (typeof id === "string" && id.length > 0 && !keepers.has(id)) {
+    if (isUsableParaId(id) && !keepers.has(id)) {
       let mapped = pos;
       let deleted = false;
       for (const tr of transactions) {
@@ -106,7 +110,7 @@ const collectParaIdUpdates = (
       return true;
     }
     const id = node.attrs["paraId"];
-    if (typeof id !== "string" || id.length === 0) {
+    if (!isUsableParaId(id)) {
       missing.push({ pos, attrs: node.attrs });
     } else {
       const occurrences = occurrencesById.get(id) ?? [];

--- a/packages/core/src/utils/hexId.test.ts
+++ b/packages/core/src/utils/hexId.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
-import { generateHexId, MAX_HEX_ID_EXCLUSIVE } from "./hexId";
+import { deterministicHexId, generateHexId, MAX_HEX_ID_EXCLUSIVE } from "./hexId";
 
 describe("generateHexId", () => {
   test("returns an 8-character uppercase hex string", () => {
@@ -12,8 +12,21 @@ describe("generateHexId", () => {
   test("stays strictly below MAX_HEX_ID_EXCLUSIVE so Word doesn't reject", () => {
     for (let i = 0; i < 200; i++) {
       const id = Number.parseInt(generateHexId(), 16);
-      expect(id).toBeGreaterThanOrEqual(0);
+      expect(id).toBeGreaterThanOrEqual(1);
       expect(id).toBeLessThan(MAX_HEX_ID_EXCLUSIVE);
+    }
+  });
+
+  test("never mints 00000000 — Word reads a zero paraId as unassigned", () => {
+    const random = spyOn(Math, "random");
+    try {
+      random.mockReturnValue(0);
+      expect(generateHexId()).toBe("00000001");
+      // Largest possible Math.random() output still stays below the bound.
+      random.mockReturnValue(1 - Number.EPSILON);
+      expect(Number.parseInt(generateHexId(), 16)).toBeLessThan(MAX_HEX_ID_EXCLUSIVE);
+    } finally {
+      random.mockRestore();
     }
   });
 
@@ -23,5 +36,22 @@ describe("generateHexId", () => {
       seen.add(generateHexId());
     }
     expect(seen.size).toBeGreaterThan(95);
+  });
+});
+
+describe("deterministicHexId", () => {
+  test("is stable for the same seed and 8-char uppercase hex", () => {
+    const id = deterministicHexId("some:seed");
+    expect(id).toMatch(/^[0-9A-F]{8}$/u);
+    expect(deterministicHexId("some:seed")).toBe(id);
+    expect(deterministicHexId("some:other-seed")).not.toBe(id);
+  });
+
+  test("never returns 00000000 and stays below the bound", () => {
+    for (let i = 0; i < 500; i++) {
+      const id = deterministicHexId(`seed:${i}`);
+      expect(id).not.toBe("00000000");
+      expect(Number.parseInt(id, 16)).toBeLessThan(MAX_HEX_ID_EXCLUSIVE);
+    }
   });
 });

--- a/packages/core/src/utils/hexId.ts
+++ b/packages/core/src/utils/hexId.ts
@@ -2,6 +2,8 @@
  * Lifted from
  * https://github.com/eigenpal/docx-editor/blob/main/packages/core/src/utils/hexId.ts
  * (Apache-2.0). Keep the bound and the comments in sync upstream.
+ * folio divergence: `00000000` is excluded from both generators — Word
+ * treats a zero `w14:paraId` as unassigned, so it must never be minted.
  */
 
 /**
@@ -19,13 +21,14 @@ export const MAX_HEX_ID_EXCLUSIVE = 0x7fffffff;
  * Random 8-char uppercase hex id, matching Microsoft's `w14:paraId`
  * extension format (also reused for comment `paraId` / `durableId`).
  *
- * Range is `[0, MAX_HEX_ID_EXCLUSIVE)` = `[0, 0x7FFFFFFE]`.
+ * Range is `[1, MAX_HEX_ID_EXCLUSIVE)` = `[1, 0x7FFFFFFE]` — zero is
+ * excluded because Word reads `w14:paraId="00000000"` as "no id".
  *
  * Uses `Math.random()` rather than `crypto.randomUUID()` so the
  * generator works in non-secure contexts (file://, web workers).
  */
 export const generateHexId = (): string =>
-  Math.floor(Math.random() * MAX_HEX_ID_EXCLUSIVE)
+  (Math.floor(Math.random() * (MAX_HEX_ID_EXCLUSIVE - 1)) + 1)
     .toString(16)
     .toUpperCase()
     .padStart(8, "0");
@@ -34,11 +37,16 @@ export const generateHexId = (): string =>
  * Deterministic 8-char uppercase hex id (FNV-1a over `seed`), `< 0x7FFFFFFF`.
  * Re-deriving from the same seed mints the same id, so content/position-derived
  * ids (block paraIds, comment thread keys) are stable across saves.
+ *
+ * A hash of exactly zero is remapped to `1`: `00000000` is Word's "no id"
+ * sentinel, and remapping only that one (already invalid) output keeps every
+ * previously shipped deterministic id unchanged.
  */
 export const deterministicHexId = (seed: string): string => {
   let hash = 2_166_136_261;
   for (const character of seed) {
     hash = Math.imul(hash ^ (character.codePointAt(0) ?? 0), 16_777_619) >>> 0;
   }
-  return (hash % MAX_HEX_ID_EXCLUSIVE).toString(16).toUpperCase().padStart(8, "0");
+  const value = hash % MAX_HEX_ID_EXCLUSIVE;
+  return (value === 0 ? 1 : value).toString(16).toUpperCase().padStart(8, "0");
 };


### PR DESCRIPTION
## Summary

Split the editor-lifecycle portion out of #163 so it can land independently of the raw DOCX ingest normalizer.

- preserve the original paragraph's `paraId` when a duplicate is pasted above it
- reject the reserved `00000000` value in both allocator passes
- prevent the random and deterministic hex generators from minting the reserved zero ID
- keep allocator bookkeeping out of paragraph change tracking
- lock split, merge, paste, cross-document paste, and undo/redo behavior with focused tests

The undo/redo test also corrects the previous assumption: ProseMirror remaps the non-history allocator transaction into the originating history event, so redo restores the allocated ID rather than minting another one.

## Verification

- `bun test packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts packages/core/src/utils/hexId.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

CC on behalf of @jan-kubica