### PR TITLE
fix: position header footer text boxes vertically

### DIFF
--- a/.changeset/soft-footer-anchor.md
+++ b/.changeset/soft-footer-anchor.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor vertical page and margin anchors for positioned header and footer text boxes.

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -668,6 +668,45 @@ describe("header and footer rendering", () => {
     expect(afterParagraph?.style.top).toBe("40px");
   });
 
+  test("honors page-relative vertical positions for footer text boxes", () => {
+    const emusPerPixel = 9_525;
+    const anchoredTop = 900;
+    const textBoxBlock: TextBoxBlock = {
+      kind: "textBox",
+      id: "positioned-footer-box",
+      width: 80,
+      height: 20,
+      content: [],
+      wrapType: "behind",
+      position: {
+        vertical: {
+          relativeTo: "page",
+          posOffset: anchoredTop * emusPerPixel,
+        },
+      },
+    };
+
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        footerContent: {
+          rId: "rIdFooter",
+          blocks: [textBoxBlock],
+          measures: [textBoxMeasure(textBoxBlock.width, textBoxBlock.height)],
+          height: 0,
+        },
+      },
+    ) as unknown as FakeElement;
+
+    const textBox = findByClass(pageElement, "layout-textbox");
+    expect(textBox?.parent).toBe(pageElement);
+    expect(textBox?.style.top).toBe(`${anchoredTop}px`);
+    expect(textBox?.dataset["hfSlotKind"]).toBe("footer");
+    expect(textBox?.dataset["hfRid"]).toBe("rIdFooter");
+  });
+
   test("interactive header/footer box tracks the flow band, not a floating shape's extent (#869)", () => {
     const para = (id: string): ParagraphBlock => ({
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -1299,11 +1299,21 @@ function renderHeaderFooterContent(
       const fragEl = renderTextBoxFragment(syntheticFragment, block, measure, hfContext, {
         document: doc,
       });
-      fragEl.style.top = `${cursorY}px`;
+      const textBoxTop = block.position
+        ? resolveHeaderFooterFloatTop(
+            {
+              height: measure.height,
+              paragraphY: cursorY,
+              position: block.position,
+            },
+            layout,
+          )
+        : cursorY;
+      fragEl.style.top = `${textBoxTop}px`;
       // Honor the anchor's horizontal position (e.g. centered relative to the
-      // page) instead of pinning the box to the left. The vertical position
-      // stays on the H/F flow cursor (positionV is not yet honored for H/F text
-      // boxes). eigenpal/docx-editor#700.
+      // page) instead of pinning the box to the left. Vertical page/margin
+      // anchors use the same resolver as floating H/F images so positioned
+      // text boxes do not fall back to the H/F flow cursor.
       fragEl.style.left = resolveHeaderFooterFloatLeft(
         measure.width,
         block.position?.horizontal,


### PR DESCRIPTION
## Summary

- honor page- and margin-relative vertical anchors for positioned header/footer text boxes
- share the existing floating header/footer anchor resolver instead of falling back to the flow cursor
- preserve page-layer positioning when behind-document text boxes leave the footer container
- add a focused footer regression

## Validation

- focused renderer suite: 18 passed
- anonymous strict-font replay: 94.4% to 97.2%; missing line removed; page count unchanged
- two structurally different anonymous replays stayed stable at 67.9% and 59.0%
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header and footer text box positioning by honoring vertical page and margin anchors.
  * Ensured positioned footer text boxes render at their intended vertical offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->