### PR TITLE
fix: align unindented table text edge

### DIFF
--- a/.changeset/true-table-origin.md
+++ b/.changeset/true-table-origin.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align the leading text edge of unindented tables with the document content margin.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -812,13 +812,11 @@ function layoutTable(
       x = x + paginator.columnWidth - measure.totalWidth;
     } else {
       // w:tblInd positions the leading edge of the first cell's text, not
-      // the table border. The border therefore extends left by that cell's
-      // leading margin. An absent w:tblInd leaves the table border at the
-      // content edge, so only translate explicitly authored indent values.
-      if (block.indent !== undefined) {
-        const leadingCellMargin = block.rows[0]?.cells[0]?.padding?.left ?? 0;
-        x += block.indent - leadingCellMargin;
-      }
+      // the table border. Its inherited/default value is zero, so an absent
+      // property still aligns that text edge with the content margin and the
+      // border extends left by the leading cell margin.
+      const leadingCellMargin = block.rows[0]?.cells[0]?.padding?.left ?? 0;
+      x += (block.indent ?? 0) - leadingCellMargin;
     }
     return x;
   };

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -776,13 +776,16 @@ function tableFragments(block: TableBlock, measure: TableMeasure): TableFragment
 }
 
 describe("left-aligned table placement", () => {
-  test("keeps an unindented table border at the content edge", () => {
+  test("aligns an unindented first-cell text edge with the content edge", () => {
     const { block, measure } = tallTable(1);
     block.rows[0]!.cells[0]!.padding.left = 7;
 
     const fragment = tableFragments(block, measure)[0];
 
-    expect(fragment?.x).toBe(OPTIONS.margins.left);
+    expect(fragment?.x).toBe(OPTIONS.margins.left - 7);
+    expect((fragment?.x ?? 0) + block.rows[0]!.cells[0]!.padding.left).toBe(
+      OPTIONS.margins.left,
+    );
   });
 
   test("applies w:tblInd to the first cell text edge", () => {

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -783,9 +783,7 @@ describe("left-aligned table placement", () => {
     const fragment = tableFragments(block, measure)[0];
 
     expect(fragment?.x).toBe(OPTIONS.margins.left - 7);
-    expect((fragment?.x ?? 0) + block.rows[0]!.cells[0]!.padding.left).toBe(
-      OPTIONS.margins.left,
-    );
+    expect((fragment?.x ?? 0) + block.rows[0]!.cells[0]!.padding.left).toBe(OPTIONS.margins.left);
   });
 
   test("applies w:tblInd to the first cell text edge", () => {


### PR DESCRIPTION
## Summary

- apply the inherited zero table indent to the leading text edge, matching authored `w:tblInd` semantics
- retain the existing default and authored cell margins
- update the table placement regression to assert text-edge alignment

## Validation

- focused table conversion/layout suites: 40 passed
- anonymous strict-font replay: 88.4% to 95.3%; three repeated x divergences removed; page count unchanged
- dense-table anonymous replay stayed stable at 43.5%
- separate five-page anonymous replay stayed stable at 89.1%
- lint and typecheck intentionally delegated to CI

CC on behalf of @jan-kubica