### PR TITLE
fix: avoid punctuation-only parity y drift

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -242,6 +242,60 @@ describe("compareGeoms", () => {
     expect(result.score).toBeCloseTo(2 / 3);
   });
 
+  test("punctuation-only rows do not create y-drift or bias the extractor offset", () => {
+    const word = makeDoc("word", [
+      makePage({
+        lines: [
+          makeLine({ text: "____________________", yPt: 72 }),
+          makeLine({ text: "....................", yPt: 90 }),
+          makeLine({ text: "Baseline text", yPt: 108 }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "____________________", yPt: 82 }),
+          makeLine({ text: "....................", yPt: 100 }),
+          makeLine({ text: "Baseline text", yPt: 114 }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences.filter((divergence) => divergence.kind === "y-drift")).toEqual([]);
+    expect(result.medianYOffsetPt).toBe(6);
+    expect(result.score).toBe(1);
+  });
+
+  test("punctuation-only rows still report horizontal geometry drift", () => {
+    const word = makeDoc("word", [
+      makePage({
+        lines: [
+          makeLine({ text: "Baseline text", yPt: 72 }),
+          makeLine({ text: "____________________", yPt: 90, widthPt: 100 }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "Baseline text", yPt: 72 }),
+          makeLine({ text: "____________________", yPt: 96, widthPt: 120 }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences.filter((divergence) => divergence.kind === "y-drift")).toEqual([]);
+    expect(
+      result.divergences.filter((divergence) => divergence.kind === "width-drift"),
+    ).toHaveLength(1);
+    expect(result.score).toBe(0.5);
+  });
+
   test("absorbs each page's extractor offset independently", () => {
     const word = makeDoc("word", [
       makePage({

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -105,6 +105,14 @@ const scoreForEmptyWordDoc = (folioLineCount: number): number => (folioLineCount
 
 const stripSpaces = (text: string): string => text.replaceAll(" ", "");
 
+/**
+ * Word PDF extraction reports glyph-ink bounds while Folio reports the line
+ * box. Punctuation-only rows (signature rules, ellipses, separators) have no
+ * stable cap-height edge, so their top coordinates cannot establish or verify
+ * a baseline offset. Horizontal geometry remains comparable.
+ */
+const hasStableVerticalInk = (line: LineBox): boolean => /[\p{L}\p{N}]/u.test(line.normText);
+
 /** Minimum vertical-overlap ratio (of the shorter box) for two boxes to count
  * as the same visual row. */
 const ROW_OVERLAP_RATIO = 0.5;
@@ -503,7 +511,15 @@ const pageRegionMedianYOffsets = (
   for (const m of matches) {
     const w = wordFlat[m.wordIdx];
     const f = folioFlat[m.folioIdx];
-    if (!w || !f || w.page !== f.page) continue;
+    if (
+      !w ||
+      !f ||
+      w.page !== f.page ||
+      !hasStableVerticalInk(w.line) ||
+      !hasStableVerticalInk(f.line)
+    ) {
+      continue;
+    }
     const key = matchedPageRegionKey(w, f);
     const deltas = deltasByPageRegion.get(key) ?? [];
     deltas.push(f.line.yPt - w.line.yPt);
@@ -589,7 +605,7 @@ const diffMatches = ({
       }
 
       let yDelta: number | null = null;
-      if (samePage) {
+      if (samePage && hasStableVerticalInk(w.line) && hasStableVerticalInk(f.line)) {
         yDelta = checkYDrift(
           w.line,
           f.line,


### PR DESCRIPTION
## Summary

- exclude punctuation-only rows from vertical-offset calibration and y-drift checks
- continue checking their text, x position, and width
- add regressions for offset calibration and retained horizontal diagnostics

Word truth exposes glyph-ink bounds while Folio exposes line boxes. Rows without letters or numbers have no comparable cap-height edge, so treating their top coordinates as baselines creates false vertical divergences.

## Verification

- parity unit suite: 110 passing
- focused comparator suite after formatting: 22 passing
- changed-file format check: passing
- anonymous two-page replay: 91.9% to 94.6%; two false y divergences removed, all text/line/width divergences retained
- lint and typecheck: CI only

## Security

- pure in-memory comparison change; no new I/O, persistence, or external input surface

CC on behalf of @jan-kubica