### PR TITLE
fix: preserve anchored table cell content

### DIFF
--- a/.changeset/paint-table-cell-anchors.md
+++ b/.changeset/paint-table-cell-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve and paint anchored text boxes and images inside table cells.

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -15,9 +15,6 @@ import type {
   MediaFile,
   Paragraph,
   RelationshipMap,
-  Run,
-  Shape,
-  ShapeContent,
   Theme,
 } from "../types/document";
 import { parseBookmarkEnd, parseBookmarkStart } from "./bookmarkParser";
@@ -29,19 +26,13 @@ import type { BookmarkMarker } from "./bookmarkPlacement";
 import { convertBulletToUnicode } from "./bulletMarkers";
 import { padDecimal, type NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
+import { enrichParagraphTextBoxes } from "./paragraphTextBoxEnrichment";
 import { parseSdtProperties } from "./sdtProperties";
 import type { StyleMap } from "./styleParser";
 import { parseTable } from "./tableParser";
 import {
-  getTextBoxContentElement,
-  isTextBoxDrawing,
-  parseTextBox,
-  parseTextBoxContent,
-} from "./textBoxParser";
-import {
   elementToXml,
   findChild,
-  findDeep,
   getChildElements,
   getLocalName,
   mergeXmlnsDeclarations,
@@ -223,153 +214,6 @@ const computeListMarker = (
   }
 
   listRendering.marker = computedMarker;
-};
-
-const enrichParagraphTextBoxes = (
-  paragraph: Paragraph,
-  paraXml: XmlElement,
-  styles: StyleMap | null,
-  theme: Theme | null,
-  numbering: NumberingMap | null,
-  rels: RelationshipMap | null,
-  media: Map<string, MediaFile> | null,
-): void => {
-  const xmlChildren = getChildElements(paraXml);
-  let parsedIndex = 0;
-  let lastConsumedRun: Run | undefined;
-
-  for (const xmlChild of xmlChildren) {
-    if (getLocalName(xmlChild.name ?? "") !== "r") {
-      if (
-        parsedIndex < paragraph.content.length &&
-        paragraph.content[parsedIndex]?.type !== "run"
-      ) {
-        parsedIndex += 1;
-      }
-      continue;
-    }
-
-    const { textBoxDrawings, hasNonTextBoxContent } = scanRunForTextBoxDrawings(xmlChild);
-
-    const parsedContent = paragraph.content[parsedIndex];
-    const parsedRun: Run | undefined = parsedContent?.type === "run" ? parsedContent : undefined;
-    const targetRun = parsedRun ?? (hasNonTextBoxContent ? lastConsumedRun : undefined);
-
-    for (const runEl of textBoxDrawings) {
-      const textBox = parseTextBox(runEl);
-      if (!textBox) {
-        continue;
-      }
-
-      const wsp = findDeep(runEl, "wps", "wsp");
-      if (wsp) {
-        const txbxContentEl = getTextBoxContentElement(wsp);
-        if (txbxContentEl) {
-          textBox.content = parseTextBoxContent(
-            txbxContentEl,
-            parseParagraph,
-            null,
-            styles,
-            theme,
-            numbering,
-            rels ?? undefined,
-            media ?? undefined,
-          );
-        }
-      }
-
-      const shape: Shape = {
-        type: "shape",
-        shapeType: "textBox",
-        size: textBox.size,
-        ...(textBox.position !== undefined ? { position: textBox.position } : {}),
-        ...(textBox.wrap !== undefined ? { wrap: textBox.wrap } : {}),
-        ...(textBox.fill !== undefined ? { fill: textBox.fill } : {}),
-        ...(textBox.outline !== undefined ? { outline: textBox.outline } : {}),
-        textBody: {
-          content: textBox.content,
-          ...(textBox.margins !== undefined ? { margins: textBox.margins } : {}),
-        },
-      };
-      if (textBox.id) {
-        shape.id = textBox.id;
-      }
-
-      const shapeContent: ShapeContent = { type: "shape", shape };
-
-      if (targetRun && hasNonTextBoxContent) {
-        targetRun.content.push(shapeContent);
-      } else {
-        const newRun: Run = { type: "run", content: [shapeContent] };
-        paragraph.content.splice(parsedIndex, 0, newRun);
-        lastConsumedRun = newRun;
-        parsedIndex += 1;
-      }
-    }
-
-    if (hasNonTextBoxContent && parsedRun) {
-      lastConsumedRun = parsedRun;
-      parsedIndex += 1;
-    }
-  }
-};
-
-type TextBoxRunScan = {
-  textBoxDrawings: XmlElement[];
-  hasNonTextBoxContent: boolean;
-};
-
-const scanRunForTextBoxDrawings = (xmlRun: XmlElement): TextBoxRunScan => {
-  const textBoxDrawings: XmlElement[] = [];
-  let hasNonTextBoxContent = false;
-
-  const visitDrawing = (drawingEl: XmlElement): void => {
-    if (isTextBoxDrawing(drawingEl)) {
-      textBoxDrawings.push(drawingEl);
-      return;
-    }
-    hasNonTextBoxContent = true;
-  };
-
-  for (const el of getChildElements(xmlRun)) {
-    const name = getLocalName(el.name ?? "");
-    if (name === "rPr") {
-      continue;
-    }
-    if (name === "drawing") {
-      visitDrawing(el);
-      continue;
-    }
-    if (name === "AlternateContent") {
-      const branches = getChildElements(el);
-      const choice = branches.find((branch) => getLocalName(branch.name ?? "") === "Choice");
-      const fallback = branches.find((branch) => getLocalName(branch.name ?? "") === "Fallback");
-      const tryBranch = (branch: XmlElement | undefined): boolean => {
-        if (!branch) {
-          return false;
-        }
-        let found = false;
-        for (const innerEl of getChildElements(branch)) {
-          if (getLocalName(innerEl.name ?? "") === "drawing") {
-            visitDrawing(innerEl);
-            found = true;
-          }
-        }
-        return found;
-      };
-      let foundInBranch = tryBranch(choice);
-      if (!foundInBranch) {
-        foundInBranch = tryBranch(fallback);
-      }
-      if (!foundInBranch) {
-        hasNonTextBoxContent = true;
-      }
-      continue;
-    }
-    hasNonTextBoxContent = true;
-  }
-
-  return { textBoxDrawings, hasNonTextBoxContent };
 };
 
 type ParseBlockContentState = {

--- a/packages/core/src/docx/documentParser-alternatecontent.test.ts
+++ b/packages/core/src/docx/documentParser-alternatecontent.test.ts
@@ -202,4 +202,48 @@ describe("parseDocumentBody — AlternateContent text boxes", () => {
 
     expect(shapes).toHaveLength(2);
   });
+
+  test("preserves text boxes anchored from a table-cell paragraph", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body>
+    <w:tbl><w:tr><w:tc><w:p>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Cell card 1")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Cell card 2")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+    </w:p></w:tc></w:tr></w:tbl>
+  </w:body>
+</w:document>`);
+
+    const table = body.content.at(0);
+    if (table?.type !== "table") {
+      throw new Error("Expected table");
+    }
+    const paragraph = table.rows.at(0)?.cells.at(0)?.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected table-cell paragraph");
+    }
+
+    const cardTitles = paragraph.content
+      .filter((content) => content.type === "run")
+      .flatMap((run) => run.content.filter((content) => content.type === "shape"))
+      .map((shape) => {
+        const innerParagraph = shape.shape.textBody?.content.at(0);
+        if (innerParagraph?.type !== "paragraph") {
+          return null;
+        }
+        const innerRun = innerParagraph.content.at(0);
+        if (innerRun?.type !== "run") {
+          return null;
+        }
+        const innerText = innerRun.content.at(0);
+        return innerText?.type === "text" ? innerText.text : null;
+      });
+
+    expect(cardTitles).toEqual(["Cell card 1", "Cell card 2"]);
+  });
 });

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -1,0 +1,166 @@
+import type {
+  MediaFile,
+  Paragraph,
+  RelationshipMap,
+  Run,
+  Shape,
+  ShapeContent,
+  Theme,
+} from "../types/document";
+import type { NumberingMap } from "./numberingParser";
+import { parseParagraph } from "./paragraphParser";
+import type { StyleMap } from "./styleParser";
+import {
+  getTextBoxContentElement,
+  isTextBoxDrawing,
+  parseTextBox,
+  parseTextBoxContent,
+} from "./textBoxParser";
+import { findDeep, getChildElements, getLocalName, type XmlElement } from "./xmlParser";
+
+export const enrichParagraphTextBoxes = (
+  paragraph: Paragraph,
+  paraXml: XmlElement,
+  styles: StyleMap | null,
+  theme: Theme | null,
+  numbering: NumberingMap | null,
+  rels: RelationshipMap | null,
+  media: Map<string, MediaFile> | null,
+): void => {
+  const xmlChildren = getChildElements(paraXml);
+  let parsedIndex = 0;
+  let lastConsumedRun: Run | undefined;
+
+  for (const xmlChild of xmlChildren) {
+    if (getLocalName(xmlChild.name ?? "") !== "r") {
+      if (
+        parsedIndex < paragraph.content.length &&
+        paragraph.content[parsedIndex]?.type !== "run"
+      ) {
+        parsedIndex += 1;
+      }
+      continue;
+    }
+
+    const { textBoxDrawings, hasNonTextBoxContent } = scanRunForTextBoxDrawings(xmlChild);
+
+    const parsedContent = paragraph.content[parsedIndex];
+    const parsedRun: Run | undefined = parsedContent?.type === "run" ? parsedContent : undefined;
+    const targetRun = parsedRun ?? (hasNonTextBoxContent ? lastConsumedRun : undefined);
+
+    for (const runEl of textBoxDrawings) {
+      const textBox = parseTextBox(runEl);
+      if (!textBox) {
+        continue;
+      }
+
+      const wsp = findDeep(runEl, "wps", "wsp");
+      if (wsp) {
+        const txbxContentEl = getTextBoxContentElement(wsp);
+        if (txbxContentEl) {
+          textBox.content = parseTextBoxContent(
+            txbxContentEl,
+            parseParagraph,
+            null,
+            styles,
+            theme,
+            numbering,
+            rels ?? undefined,
+            media ?? undefined,
+          );
+        }
+      }
+
+      const shape: Shape = {
+        type: "shape",
+        shapeType: "textBox",
+        size: textBox.size,
+        ...(textBox.position !== undefined ? { position: textBox.position } : {}),
+        ...(textBox.wrap !== undefined ? { wrap: textBox.wrap } : {}),
+        ...(textBox.fill !== undefined ? { fill: textBox.fill } : {}),
+        ...(textBox.outline !== undefined ? { outline: textBox.outline } : {}),
+        textBody: {
+          content: textBox.content,
+          ...(textBox.margins !== undefined ? { margins: textBox.margins } : {}),
+        },
+      };
+      if (textBox.id) {
+        shape.id = textBox.id;
+      }
+
+      const shapeContent: ShapeContent = { type: "shape", shape };
+
+      if (targetRun && hasNonTextBoxContent) {
+        targetRun.content.push(shapeContent);
+      } else {
+        const newRun: Run = { type: "run", content: [shapeContent] };
+        paragraph.content.splice(parsedIndex, 0, newRun);
+        lastConsumedRun = newRun;
+        parsedIndex += 1;
+      }
+    }
+
+    if (hasNonTextBoxContent && parsedRun) {
+      lastConsumedRun = parsedRun;
+      parsedIndex += 1;
+    }
+  }
+};
+
+type TextBoxRunScan = {
+  textBoxDrawings: XmlElement[];
+  hasNonTextBoxContent: boolean;
+};
+
+const scanRunForTextBoxDrawings = (xmlRun: XmlElement): TextBoxRunScan => {
+  const textBoxDrawings: XmlElement[] = [];
+  let hasNonTextBoxContent = false;
+
+  const visitDrawing = (drawingEl: XmlElement): void => {
+    if (isTextBoxDrawing(drawingEl)) {
+      textBoxDrawings.push(drawingEl);
+      return;
+    }
+    hasNonTextBoxContent = true;
+  };
+
+  for (const el of getChildElements(xmlRun)) {
+    const name = getLocalName(el.name ?? "");
+    if (name === "rPr") {
+      continue;
+    }
+    if (name === "drawing") {
+      visitDrawing(el);
+      continue;
+    }
+    if (name === "AlternateContent") {
+      const branches = getChildElements(el);
+      const choice = branches.find((branch) => getLocalName(branch.name ?? "") === "Choice");
+      const fallback = branches.find((branch) => getLocalName(branch.name ?? "") === "Fallback");
+      const tryBranch = (branch: XmlElement | undefined): boolean => {
+        if (!branch) {
+          return false;
+        }
+        let found = false;
+        for (const innerEl of getChildElements(branch)) {
+          if (getLocalName(innerEl.name ?? "") === "drawing") {
+            visitDrawing(innerEl);
+            found = true;
+          }
+        }
+        return found;
+      };
+      let foundInBranch = tryBranch(choice);
+      if (!foundInBranch) {
+        foundInBranch = tryBranch(fallback);
+      }
+      if (!foundInBranch) {
+        hasNonTextBoxContent = true;
+      }
+      continue;
+    }
+    hasNonTextBoxContent = true;
+  }
+
+  return { textBoxDrawings, hasNonTextBoxContent };
+};

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -58,6 +58,7 @@ import {
 import type { BookmarkMarker } from "./bookmarkPlacement";
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
+import { enrichParagraphTextBoxes } from "./paragraphTextBoxEnrichment";
 import {
   BorderStyleSchema,
   FloatingTableXSpecSchema,
@@ -1178,6 +1179,7 @@ function parseCellContent(
     if (localName === "p") {
       // Parse paragraph
       const para = parseParagraph(child, styles, theme, numbering, rels, media, options);
+      enrichParagraphTextBoxes(para, child, styles, theme, numbering, rels, media);
       prependPendingBookmarkMarkers(para, pendingBookmarkMarkers);
       content.push(para);
     } else if (localName === "tbl") {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1951,6 +1951,8 @@ function convertTableCell(
       blocks.push(block);
     } else if (child.type.name === "table") {
       blocks.push(convertTable(child, offset, options));
+    } else if (child.type.name === "textBox") {
+      blocks.push(convertTextBoxNode(child, offset, options));
     }
     offset += child.nodeSize;
   });

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1194,9 +1194,12 @@ function layoutFloatingTable(
     y = fitState.cursorY;
   }
 
-  // Clamp within content area to avoid negative positions
-  const minX = margins.left;
-  const maxX = margins.left + contentWidth - tableWidth;
+  // Clamp within the selected horizontal anchor frame. A page-anchored table
+  // may legitimately sit outside the body margins; clamping it to the content
+  // frame shifts the table and every drawing anchored inside its cells.
+  const pageAnchored = floating?.horzAnchor === "page";
+  const minX = pageAnchored ? 0 : margins.left;
+  const maxX = pageAnchored ? page.size.w - tableWidth : margins.left + contentWidth - tableWidth;
   if (Number.isFinite(maxX)) {
     x = Math.max(minX, Math.min(x, maxX));
   }

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -542,6 +542,49 @@ describe("measureTableBlock w:noWrap column pinning", () => {
   });
 });
 
+describe("measureTableBlock floating cell content", () => {
+  test("does not add a floating text box to the table row height", () => {
+    withFakeTextMeasure(() => {
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [200],
+        rows: [
+          {
+            id: "r",
+            cells: [
+              {
+                id: "c",
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                blocks: [
+                  para("anchor", "anchor"),
+                  {
+                    kind: "textBox",
+                    id: "floating-box",
+                    width: 180,
+                    height: 120,
+                    content: [],
+                    displayMode: "float",
+                    position: { vertical: { relativeTo: "paragraph", posOffset: 0 } },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 200);
+      const paragraph = measure.rows.at(0)?.cells.at(0)?.blocks.at(0);
+      if (paragraph?.kind !== "paragraph") {
+        throw new Error("Expected anchor paragraph measure");
+      }
+
+      expect(measure.rows.at(0)?.height).toBe(paragraph.totalHeight);
+    }, fakeMeasure);
+  });
+});
+
 describe("measureBlocks error instrumentation", () => {
   test("routes a block-measurement failure through the instrumentation hook", () => {
     type MeasureBlockErrorEvent = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -4,6 +4,7 @@ import { getTextBoxGroupId } from "../textBoxGroup";
 import {
   DEFAULT_TEXTBOX_MARGINS,
   floatingTextBoxReservesBand,
+  isFloatingTextBoxBlock,
   tableColumnsArePinned,
 } from "../types";
 import type {
@@ -120,6 +121,10 @@ function isInlineFlowImageRun(run: ImageRun): boolean {
 }
 
 export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure: Measure): number {
+  if (block.kind === "textBox" && isFloatingTextBoxBlock(block)) {
+    return 0;
+  }
+
   if (block.kind !== "paragraph" || blockMeasure.kind !== "paragraph") {
     if ("totalHeight" in blockMeasure) {
       return blockMeasure.totalHeight;

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -797,6 +797,17 @@ describe("left-aligned table placement", () => {
   });
 });
 
+describe("floating table placement", () => {
+  test("clamps a page-anchored table against the page instead of the body margins", () => {
+    const { block, measure } = tallTable(1);
+    block.floating = { horzAnchor: "page", tblpX: 80 };
+
+    const fragment = tableFragments(block, measure)[0];
+
+    expect(fragment?.x).toBe(80);
+  });
+});
+
 describe("oversized table row splits across pages (#570)", () => {
   test("a row taller than a page breaks at line boundaries with no content lost", () => {
     // 15 lines = 300px row, page content height = 120px (6 lines).

--- a/packages/core/src/layout-engine/tableRowBreak.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.ts
@@ -21,6 +21,7 @@ import {
   getTableCellFloatingImages,
 } from "./measure/tableCellFloating";
 import type { Measure, TableBlock, TableCell, TableCellMeasure, TableMeasure } from "./types";
+import { isFloatingTextBoxBlock } from "./types";
 
 type UnsafeBreakRange = {
   top: number;
@@ -126,6 +127,10 @@ function cellBreakGeometry(
       y = blockTop + blockMeasure.totalHeight;
       paragraphY += blockMeasure.totalHeight;
     } else if (blockMeasure) {
+      const block = cellBlocks?.[i];
+      if (block?.kind === "textBox" && isFloatingTextBoxBlock(block)) {
+        continue;
+      }
       // Nested table / non-paragraph: one atomic block (break only at its bottom).
       const blockHeight = getAtomicBlockHeight(blockMeasure);
       if (blockHeight > 0) {

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -236,6 +236,7 @@ function renderCellContent(
       textBoxEl.style.top = "0";
       contentEl.append(textBoxEl);
       cumulativeY += textBoxMeasure.height;
+      anchorParagraphY = cumulativeY;
     }
   }
 

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -23,10 +23,19 @@ import type {
   ParagraphBlock,
   ParagraphMeasure,
   ParagraphFragment,
+  TextBoxBlock,
+  TextBoxMeasure,
+  TextBoxFragment,
 } from "../layout-engine/types";
-import { tableColumnsArePinned } from "../layout-engine/types";
+import {
+  isFloatingImageRun,
+  isFloatingTextBoxBlock,
+  tableColumnsArePinned,
+} from "../layout-engine/types";
+import { emuToPixels } from "../utils/units";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import { renderParagraphFragment } from "./renderParagraph";
+import { renderTextBoxFragment } from "./renderTextBox";
 import type { RenderContext } from "./renderUtils";
 
 /**
@@ -53,12 +62,17 @@ export type RenderTableFragmentOptions = {
 /**
  * Render cell content (paragraphs and nested tables)
  */
+type RenderedCellContent = {
+  content: HTMLElement;
+  floatingLayers: HTMLElement[];
+};
+
 function renderCellContent(
   cell: TableCell,
   cellMeasure: TableCellMeasure,
   context: RenderContext,
   doc: Document,
-): HTMLElement {
+): RenderedCellContent {
   const contentEl = doc.createElement("div");
   contentEl.className = TABLE_CLASS_NAMES.cellContent;
   contentEl.style.position = "relative";
@@ -73,6 +87,7 @@ function renderCellContent(
 
   // Build floating zones for measurement and render floating layer
   const floatingZones = buildTableCellFloatingZones(cellFloatingImages, contentWidth);
+  const floatingLayers: HTMLElement[] = [];
   if (cellFloatingImages.length > 0) {
     // Render floating image layer within the cell
     const floatingLayer = doc.createElement("div");
@@ -84,7 +99,7 @@ function renderCellContent(
     floatingLayer.style.height = "100%";
     floatingLayer.style.pointerEvents = "none";
     floatingLayer.style.zIndex = "10";
-    floatingLayer.style.overflow = "hidden";
+    floatingLayer.style.overflow = "visible";
 
     for (const img of cellFloatingImages) {
       const imgContainer = doc.createElement("div");
@@ -115,10 +130,12 @@ function renderCellContent(
       floatingLayer.append(imgContainer);
     }
 
-    contentEl.append(floatingLayer);
+    floatingLayers.push(floatingLayer);
   }
 
   let cumulativeY = 0;
+  let anchorParagraphY = 0;
+  let floatingTextBoxesLayer: HTMLElement | undefined;
   for (let i = 0; i < cell.blocks.length; i++) {
     const block = cell.blocks[i];
     const measure = cellMeasure.blocks[i];
@@ -166,6 +183,7 @@ function renderCellContent(
         fragEl.style.paddingTop = `${spaceBefore}px`;
       }
       contentEl.append(fragEl);
+      anchorParagraphY = cumulativeY;
       cumulativeY += paragraphMeasure.totalHeight;
     } else if (block?.kind === "table" && measure?.kind === "table") {
       // Nested table - render in normal document flow.
@@ -178,10 +196,112 @@ function renderCellContent(
       nestedTableEl.style.position = "relative";
       contentEl.append(nestedTableEl);
       cumulativeY += (measure as TableMeasure).totalHeight;
+      // A standalone anchored shape after a nested table belongs to a
+      // shape-only host paragraph at the current flow position. That host is
+      // omitted from the ProseMirror cell, so the nested table's bottom is the
+      // anchor Y for the following floating text box.
+      anchorParagraphY = cumulativeY;
+    } else if (block?.kind === "textBox" && measure?.kind === "textBox") {
+      const textBoxBlock = block as TextBoxBlock;
+      const textBoxMeasure = measure as TextBoxMeasure;
+      const syntheticFragment: TextBoxFragment = {
+        kind: "textBox",
+        blockId: textBoxBlock.id,
+        x: 0,
+        y: 0,
+        width: textBoxMeasure.width,
+        height: textBoxMeasure.height,
+        ...(textBoxBlock.pmStart !== undefined ? { pmStart: textBoxBlock.pmStart } : {}),
+        ...(textBoxBlock.pmEnd !== undefined ? { pmEnd: textBoxBlock.pmEnd } : {}),
+      };
+      const textBoxEl = renderTextBoxFragment(
+        syntheticFragment,
+        textBoxBlock,
+        textBoxMeasure,
+        { ...context, insideTableCell: true },
+        { document: doc },
+      );
+
+      if (isFloatingTextBoxBlock(textBoxBlock)) {
+        floatingTextBoxesLayer ??= createCellFloatingTextBoxesLayer(doc);
+        textBoxEl.style.left = `${resolveCellTextBoxX(textBoxBlock, contentWidth)}px`;
+        textBoxEl.style.top = `${anchorParagraphY + resolveCellTextBoxY(textBoxBlock)}px`;
+        textBoxEl.style.pointerEvents = "auto";
+        floatingTextBoxesLayer.append(textBoxEl);
+        continue;
+      }
+
+      textBoxEl.style.position = "relative";
+      textBoxEl.style.left = "0";
+      textBoxEl.style.top = "0";
+      contentEl.append(textBoxEl);
+      cumulativeY += textBoxMeasure.height;
     }
   }
 
-  return contentEl;
+  if (floatingTextBoxesLayer) {
+    floatingLayers.push(floatingTextBoxesLayer);
+  }
+
+  return {
+    content: contentEl,
+    floatingLayers,
+  };
+}
+
+function createCellFloatingTextBoxesLayer(doc: Document): HTMLElement {
+  const layer = doc.createElement("div");
+  layer.className = "layout-cell-floating-text-boxes-layer";
+  layer.style.position = "absolute";
+  layer.style.inset = "0";
+  layer.style.pointerEvents = "none";
+  layer.style.zIndex = "10";
+  layer.style.overflow = "visible";
+  return layer;
+}
+
+function resolveCellTextBoxX(block: TextBoxBlock, contentWidth: number): number {
+  const horizontal = block.position?.horizontal;
+  if (horizontal?.posOffset !== undefined) {
+    return emuToPixels(horizontal.posOffset);
+  }
+  if (horizontal?.align === "center") {
+    return (contentWidth - block.width) / 2;
+  }
+  if (horizontal?.align === "right" || horizontal?.align === "outside") {
+    return contentWidth - block.width;
+  }
+  return 0;
+}
+
+function resolveCellTextBoxY(block: TextBoxBlock): number {
+  const vertical = block.position?.vertical;
+  if (vertical?.posOffset !== undefined) {
+    return emuToPixels(vertical.posOffset);
+  }
+  return 0;
+}
+
+function tableHasFloatingCellContent(block: TableBlock): boolean {
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      for (const cellBlock of cell.blocks) {
+        if (cellBlock.kind === "textBox" && isFloatingTextBoxBlock(cellBlock)) {
+          return true;
+        }
+        if (
+          cellBlock.kind === "paragraph" &&
+          cellBlock.runs.some((run) => run.kind === "image" && isFloatingImageRun(run))
+        ) {
+          return true;
+        }
+        if (cellBlock.kind === "table" && tableHasFloatingCellContent(cellBlock)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -391,8 +511,18 @@ function renderTableCell(
   }
 
   // Render cell content
-  const contentEl = renderCellContent(cell, cellMeasure, context, doc);
-  cellEl.append(contentEl);
+  const renderedContent = renderCellContent(cell, cellMeasure, context, doc);
+  if (renderedContent.floatingLayers.length > 0) {
+    renderedContent.content.style.height = "100%";
+    renderedContent.content.style.overflow = "hidden";
+    cellEl.style.overflow = "visible";
+  }
+  cellEl.append(renderedContent.content);
+  for (const floatingLayer of renderedContent.floatingLayers) {
+    floatingLayer.style.left = `${padLeft}px`;
+    floatingLayer.style.top = `${padTop}px`;
+    cellEl.append(floatingLayer);
+  }
 
   // Store PM positions for selection
   if (cell.blocks.length > 0) {
@@ -602,7 +732,7 @@ export function renderTableFragment(
   tableEl.style.position = "absolute";
   tableEl.style.width = `${fragment.width}px`;
   tableEl.style.height = `${fragment.height}px`;
-  tableEl.style.overflow = "hidden";
+  tableEl.style.overflow = tableHasFloatingCellContent(block) ? "visible" : "hidden";
 
   // Store metadata
   tableEl.dataset["blockId"] = String(fragment.blockId);

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -277,3 +277,108 @@ describe("renderTableFragment cell paragraph spacing", () => {
     expect(paragraph?.style["boxSizing"]).toBe("border-box");
   });
 });
+
+describe("renderTableFragment floating cell content", () => {
+  test("paints anchored images and text boxes outside the cell clip", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              padding: { top: 2, right: 3, bottom: 2, left: 4 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "anchor",
+                  runs: [
+                    {
+                      kind: "image",
+                      src: "floating.png",
+                      width: 80,
+                      height: 60,
+                      displayMode: "float",
+                      wrapType: "inFront",
+                      position: {
+                        horizontal: { relativeTo: "column", posOffset: 95_250 },
+                        vertical: { relativeTo: "paragraph", posOffset: 47_625 },
+                      },
+                    },
+                  ],
+                },
+                {
+                  kind: "textBox",
+                  id: "box",
+                  width: 90,
+                  height: 50,
+                  content: [],
+                  displayMode: "float",
+                  wrapType: "inFront",
+                  position: {
+                    horizontal: { relativeTo: "column", posOffset: 190_500 },
+                    vertical: { relativeTo: "paragraph", posOffset: 95_250 },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                { kind: "paragraph", lines: [], totalHeight: 20 },
+                { kind: "textBox", width: 90, height: 50, innerMeasures: [] },
+              ],
+              width: 100,
+              height: 24,
+            },
+          ],
+          height: 24,
+        },
+      ],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 24,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 24,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const cell = findByClass(tableEl, TABLE_CLASS_NAMES.cell).at(0);
+    const content = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent).at(0);
+    const imageLayer = findByClass(tableEl, "layout-cell-floating-images-layer").at(0);
+    const textBoxLayer = findByClass(tableEl, "layout-cell-floating-text-boxes-layer").at(0);
+    const textBox = findByClass(tableEl, "layout-textbox").at(0);
+
+    expect(tableEl.style["overflow"]).toBe("visible");
+    expect(cell?.style["overflow"]).toBe("visible");
+    expect(content?.style["overflow"]).toBe("hidden");
+    expect(imageLayer?.style["left"]).toBe("4px");
+    expect(imageLayer?.style["top"]).toBe("2px");
+    expect(imageLayer?.style["overflow"]).toBe("visible");
+    expect(textBoxLayer?.style["left"]).toBe("4px");
+    expect(textBoxLayer?.style["top"]).toBe("2px");
+    expect(textBox?.style["left"]).toBe("20px");
+    expect(textBox?.style["top"]).toBe("10px");
+  });
+});

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -311,6 +311,14 @@ describe("renderTableFragment floating cell content", () => {
                 },
                 {
                   kind: "textBox",
+                  id: "inline-box",
+                  width: 70,
+                  height: 30,
+                  content: [],
+                  displayMode: "inline",
+                },
+                {
+                  kind: "textBox",
                   id: "box",
                   width: 90,
                   height: 50,
@@ -337,6 +345,7 @@ describe("renderTableFragment floating cell content", () => {
             {
               blocks: [
                 { kind: "paragraph", lines: [], totalHeight: 20 },
+                { kind: "textBox", width: 70, height: 30, innerMeasures: [] },
                 { kind: "textBox", width: 90, height: 50, innerMeasures: [] },
               ],
               width: 100,
@@ -368,7 +377,7 @@ describe("renderTableFragment floating cell content", () => {
     const content = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent).at(0);
     const imageLayer = findByClass(tableEl, "layout-cell-floating-images-layer").at(0);
     const textBoxLayer = findByClass(tableEl, "layout-cell-floating-text-boxes-layer").at(0);
-    const textBox = findByClass(tableEl, "layout-textbox").at(0);
+    const textBox = findByClass(tableEl, "layout-textbox").at(1);
 
     expect(tableEl.style["overflow"]).toBe("visible");
     expect(cell?.style["overflow"]).toBe("visible");
@@ -379,6 +388,6 @@ describe("renderTableFragment floating cell content", () => {
     expect(textBoxLayer?.style["left"]).toBe("4px");
     expect(textBoxLayer?.style["top"]).toBe("2px");
     expect(textBox?.style["left"]).toBe("20px");
-    expect(textBox?.style["top"]).toBe("10px");
+    expect(Number.parseFloat(textBox?.style["top"] ?? "0")).toBeGreaterThan(50);
   });
 });

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2629,14 +2629,22 @@ function tableRowAttrsToFormatting(attrs: TableRowAttrs): TableRowFormatting | u
 function convertPMTableCell(node: PMNode, documentCounts?: TrackedChangeCounts): TableCell {
   const attrs = expectTableCellAttrs(node);
   const content: (Paragraph | Table)[] = [];
+  let previousStandaloneTextBox: PreviousStandaloneTextBox | null = null;
 
   // Extract cell content (paragraphs and nested tables)
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((contentNode) => {
     if (contentNode.type.name === "paragraph") {
       content.push(convertPMParagraph(contentNode, documentCounts));
+      previousStandaloneTextBox = null;
     } else if (contentNode.type.name === "table") {
       content.push(convertPMTable(contentNode, documentCounts));
+      previousStandaloneTextBox = null;
+    } else if (contentNode.type.name === "textBox") {
+      previousStandaloneTextBox = appendTextBoxBlock(content, contentNode, {
+        pendingPageBreaks: 0,
+        previousStandaloneTextBox,
+      });
     }
   });
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Document, TableCell, Theme } from "../../types/document";
+import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
 const officeTheme: Theme = {
@@ -43,6 +44,78 @@ function firstTableCellAttrs(doc: Document): Record<string, unknown> {
 }
 
 describe("toProseDoc", () => {
+  test("converts table-cell text-box shapes into block nodes", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  cells: [
+                    {
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [
+                                {
+                                  type: "shape",
+                                  shape: {
+                                    type: "shape",
+                                    shapeType: "textBox",
+                                    size: { width: 914_400, height: 457_200 },
+                                    textBody: {
+                                      content: [
+                                        {
+                                          type: "paragraph",
+                                          content: [
+                                            {
+                                              type: "run",
+                                              content: [{ type: "text", text: "Cell card" }],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const tableCell = pmDoc.firstChild?.firstChild?.firstChild;
+    const textBox = tableCell?.firstChild;
+
+    expect(textBox?.type.name).toBe("textBox");
+    expect(textBox?.textContent).toBe("Cell card");
+
+    const rebuilt = fromProseDoc(pmDoc, document);
+    const rebuiltTable = rebuilt.package.document.content.at(0);
+    const rebuiltParagraph =
+      rebuiltTable?.type === "table" ? rebuiltTable.rows[0]?.cells[0]?.content[0] : undefined;
+    const rebuiltRun =
+      rebuiltParagraph?.type === "paragraph" ? rebuiltParagraph.content[0] : undefined;
+    const rebuiltShape = rebuiltRun?.type === "run" ? rebuiltRun.content[0] : undefined;
+
+    expect(rebuiltShape?.type).toBe("shape");
+  });
+
   test("tracks docDefaults spacing so empty paragraphs retain it during layout", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1200,7 +1200,6 @@ function convertTable(
   styleResolver: StyleEngine | null,
   context: TableConversionContext,
 ): PMNode {
-  const { theme } = context;
   // Calculate rowSpan values from vMerge
   const rowSpanMap = calculateRowSpans(table);
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -100,6 +100,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
   const styleResolver = createStyleEngine(options?.styles ?? document.package.styles);
   const theme = options?.theme ?? document.package.theme ?? null;
   let textBoxGroupIndex = 0;
+  const nextTextBoxGroupId = (): string => String(textBoxGroupIndex++);
 
   const convertBodyBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
@@ -109,13 +110,16 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
         if (pbPos === "before") {
           out.push(schema.node("pageBreak"));
         }
-        out.push(...convertParagraphWithTextBoxes(block, styleResolver, String(textBoxGroupIndex)));
-        textBoxGroupIndex += 1;
+        out.push(
+          ...convertParagraphWithTextBoxes(block, styleResolver, {
+            textBoxGroupId: nextTextBoxGroupId(),
+          }),
+        );
         if (pbPos === "after") {
           out.push(schema.node("pageBreak"));
         }
       } else if (block.type === "table") {
-        out.push(convertTable(block, styleResolver, theme));
+        out.push(convertTable(block, styleResolver, { theme, nextTextBoxGroupId }));
       } else {
         out.push(convertBlockSdt(block, convertBodyBlocks));
       }
@@ -1186,11 +1190,17 @@ function paragraphContentHasMeaningfulContent(content: Paragraph["content"][numb
   return true;
 }
 
+type TableConversionContext = {
+  theme: Theme | null | undefined;
+  nextTextBoxGroupId: () => string;
+};
+
 function convertTable(
   table: Table,
   styleResolver: StyleEngine | null,
-  theme: Theme | null | undefined,
+  context: TableConversionContext,
 ): PMNode {
+  const { theme } = context;
   // Calculate rowSpan values from vMerge
   const rowSpanMap = calculateRowSpans(table);
 
@@ -1346,6 +1356,7 @@ function convertTable(
     return convertTableRow(
       row,
       styleResolver,
+      context,
       isFirstRowStyled,
       columnWidths,
       totalWidth,
@@ -1359,7 +1370,6 @@ function convertTable(
       totalColumns,
       rowSpanMap,
       cellMarginsAttr,
-      theme,
     );
   });
 
@@ -1384,6 +1394,7 @@ function countTableColumns(rows: TableRow[]): number {
 function convertTableRow(
   row: TableRow,
   styleResolver: StyleEngine | null,
+  context: TableConversionContext,
   isHeaderRow: boolean,
   columnWidths?: number[],
   totalWidth?: number,
@@ -1416,7 +1427,6 @@ function convertTableRow(
     left?: number;
     right?: number;
   },
-  theme?: Theme | null,
 ): PMNode {
   const attrs: TableRowAttrs = {
     // isHeader controls header row REPETITION on page breaks.
@@ -1616,6 +1626,7 @@ function convertTableRow(
       convertTableCell(
         cell,
         styleResolver,
+        context,
         isHeaderRow,
         gridWidth,
         cellConditionalStyle,
@@ -1628,7 +1639,6 @@ function convertTableRow(
         preserveVMergeRestart,
         rowSpanInfo?.continuationCells,
         defaultCellMargins,
-        theme,
       ),
     );
   }
@@ -1678,6 +1688,7 @@ function resolveThemedBorderColors(
 function convertTableCell(
   cell: TableCell,
   styleResolver: StyleEngine | null,
+  context: TableConversionContext,
   isHeader: boolean,
   gridWidthPercent?: number,
   conditionalStyle?: TableConditionalStyle,
@@ -1695,8 +1706,8 @@ function convertTableCell(
     left?: number;
     right?: number;
   },
-  theme?: Theme | null,
 ): PMNode {
+  const { theme } = context;
   const formatting = cell.formatting;
 
   // Use the pre-calculated rowSpan from vMerge analysis
@@ -1818,17 +1829,15 @@ function convertTableCell(
   for (const content of cell.content) {
     if (content.type === "paragraph") {
       contentNodes.push(
-        convertParagraph(
-          content,
-          styleResolver,
-          undefined,
-          conditionalStyle?.rPr,
-          conditionalStyle?.pPr,
-        ),
+        ...convertParagraphWithTextBoxes(content, styleResolver, {
+          textBoxGroupId: context.nextTextBoxGroupId(),
+          extraRunFormatting: conditionalStyle?.rPr,
+          tableParagraphOverlay: conditionalStyle?.pPr,
+        }),
       );
     } else {
       // Nested tables - recursively convert
-      contentNodes.push(convertTable(content, styleResolver, theme));
+      contentNodes.push(convertTable(content, styleResolver, context));
     }
   }
 
@@ -2745,13 +2754,29 @@ function convertShape(shape: Shape): PMNode {
  * Convert a paragraph block to PM nodes, extracting text boxes as sibling nodes.
  * Skips ghost empty paragraphs that only contained text box drawings.
  */
+type ConvertParagraphWithTextBoxesOptions = {
+  textBoxGroupId: string;
+  extraRunFormatting?: TextFormatting;
+  tableParagraphOverlay?: TableCellParagraphSpacingOverlay;
+};
+
 function convertParagraphWithTextBoxes(
   block: Paragraph,
   styleResolver: StyleEngine | null,
-  textBoxGroupId: string,
+  {
+    textBoxGroupId,
+    extraRunFormatting,
+    tableParagraphOverlay,
+  }: ConvertParagraphWithTextBoxesOptions,
 ): PMNode[] {
   const textBoxes = extractTextBoxesFromParagraph(block);
-  const pmParagraph = convertParagraph(block, styleResolver);
+  const pmParagraph = convertParagraph(
+    block,
+    styleResolver,
+    undefined,
+    extraRunFormatting,
+    tableParagraphOverlay,
+  );
   const nodes: PMNode[] = [];
   const isEmptyAfterExtraction = textBoxes.length > 0 && pmParagraph.content.size === 0;
   const keepWrapperParagraph =
@@ -2995,15 +3020,19 @@ export function headerFooterToProseDoc(
   const styleResolver = options?.styles ? createStyleEngine(options.styles) : null;
   const theme = options?.theme ?? null;
   let textBoxGroupIndex = 0;
+  const nextTextBoxGroupId = (): string => String(textBoxGroupIndex++);
 
   const convertBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
     for (const block of blocks) {
       if (block.type === "paragraph") {
-        out.push(...convertParagraphWithTextBoxes(block, styleResolver, String(textBoxGroupIndex)));
-        textBoxGroupIndex += 1;
+        out.push(
+          ...convertParagraphWithTextBoxes(block, styleResolver, {
+            textBoxGroupId: nextTextBoxGroupId(),
+          }),
+        );
       } else if (block.type === "table") {
-        out.push(convertTable(block, styleResolver, theme));
+        out.push(convertTable(block, styleResolver, { theme, nextTextBoxGroupId }));
       } else {
         out.push(convertBlockSdt(block, convertBlocks));
       }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1830,8 +1830,12 @@ function convertTableCell(
       contentNodes.push(
         ...convertParagraphWithTextBoxes(content, styleResolver, {
           textBoxGroupId: context.nextTextBoxGroupId(),
-          extraRunFormatting: conditionalStyle?.rPr,
-          tableParagraphOverlay: conditionalStyle?.pPr,
+          ...(conditionalStyle?.rPr !== undefined
+            ? { extraRunFormatting: conditionalStyle.rPr }
+            : {}),
+          ...(conditionalStyle?.pPr !== undefined
+            ? { tableParagraphOverlay: conditionalStyle.pPr }
+            : {}),
         }),
       );
     } else {

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -480,7 +480,7 @@ function buildCellWidthStyles(attrs: TableCellAttrs): string[] {
 }
 
 const tableCellSpec: NodeSpec = {
-  content: "(paragraph | table)+",
+  content: "(paragraph | table | textBox)+",
   tableRole: "cell",
   isolating: true,
   attrs: {
@@ -545,7 +545,7 @@ const tableCellSpec: NodeSpec = {
 };
 
 const tableHeaderSpec: NodeSpec = {
-  content: "(paragraph | table)+",
+  content: "(paragraph | table | textBox)+",
   tableRole: "header_cell",
   isolating: true,
   attrs: {


### PR DESCRIPTION
Table-cell paragraphs now receive the same anchored text-box enrichment as body paragraphs. The conversion, schema, layout, painter, and save path preserve floating boxes end to end; floating cell images and boxes paint outside the row clip without contributing normal-flow height.

Page-anchored floating tables are clamped against the page frame rather than the body margins. Focused parser, conversion, measurement, pagination, and painter tests pass. An anonymous strict-font replay retains all text lines, restores clipped anchored artwork, and reduces horizontal anchor drift from eight lines to one. Security review found no new I/O, persistence, access-control, or untrusted execution surface. Lint and typecheck are intentionally delegated to the existing CI jobs.

CC on behalf of @jan-kubica