### PR TITLE
fix: preserve expanded autofit table grids

### DIFF
--- a/.changeset/wider-autofit-grid.md
+++ b/.changeset/wider-autofit-grid.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve autofit table grids that exceed their preferred width.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -473,13 +473,12 @@ describe("measureTableBlock row height", () => {
 });
 
 describe("measureTableBlock preferred width", () => {
-  const tableWithPreferredWidth = (layout?: TableBlock["layout"]): TableBlock => ({
+  const tableWithPreferredWidth = (widthType?: TableBlock["widthType"]): TableBlock => ({
     kind: "table",
     id: "t",
     columnWidths: [60],
     width: 750,
-    widthType: "dxa",
-    ...(layout ? { layout } : {}),
+    ...(widthType ? { widthType } : {}),
     rows: [
       {
         id: "r",
@@ -496,6 +495,15 @@ describe("measureTableBlock preferred width", () => {
 
   test("preserves an autofit grid that exceeds the preferred dxa width", () => {
     withFakeTextMeasure(() => {
+      const measure = measureTableBlock(tableWithPreferredWidth("dxa"), 500);
+
+      expect(measure.columnWidths).toEqual([60]);
+      expect(measure.totalWidth).toBe(60);
+    }, fakeMeasure);
+  });
+
+  test("uses dxa preferred-width semantics when the width type is omitted", () => {
+    withFakeTextMeasure(() => {
       const measure = measureTableBlock(tableWithPreferredWidth(), 500);
 
       expect(measure.columnWidths).toEqual([60]);
@@ -505,7 +513,9 @@ describe("measureTableBlock preferred width", () => {
 
   test("continues to scale a fixed grid to its explicit dxa width", () => {
     withFakeTextMeasure(() => {
-      const measure = measureTableBlock(tableWithPreferredWidth("fixed"), 500);
+      const table = tableWithPreferredWidth("dxa");
+      table.layout = "fixed";
+      const measure = measureTableBlock(table, 500);
 
       expect(measure.columnWidths).toEqual([50]);
       expect(measure.totalWidth).toBe(50);

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -472,6 +472,47 @@ describe("measureTableBlock row height", () => {
   });
 });
 
+describe("measureTableBlock preferred width", () => {
+  const tableWithPreferredWidth = (layout?: TableBlock["layout"]): TableBlock => ({
+    kind: "table",
+    id: "t",
+    columnWidths: [60],
+    width: 750,
+    widthType: "dxa",
+    ...(layout ? { layout } : {}),
+    rows: [
+      {
+        id: "r",
+        cells: [
+          {
+            id: "c",
+            padding: { top: 0, right: 0, bottom: 0, left: 0 },
+            blocks: [para("p", "content")],
+          },
+        ],
+      },
+    ],
+  });
+
+  test("preserves an autofit grid that exceeds the preferred dxa width", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureTableBlock(tableWithPreferredWidth(), 500);
+
+      expect(measure.columnWidths).toEqual([60]);
+      expect(measure.totalWidth).toBe(60);
+    }, fakeMeasure);
+  });
+
+  test("continues to scale a fixed grid to its explicit dxa width", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureTableBlock(tableWithPreferredWidth("fixed"), 500);
+
+      expect(measure.columnWidths).toEqual([50]);
+      expect(measure.totalWidth).toBe(50);
+    }, fakeMeasure);
+  });
+});
+
 describe("measureTableBlock w:noWrap column pinning", () => {
   // Column content width is 60px (no padding) and each char is 5px, so this
   // three-word phrase (75px unbroken) must wrap when the column is pinned and

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -199,7 +199,7 @@ export function measureTableBlock(
     // already wider, Word preserves that grid instead of scaling it down.
     const preserveExpandedGrid =
       tableBlock.layout !== "fixed" &&
-      tableBlock.widthType === "dxa" &&
+      (tableBlock.widthType === undefined || tableBlock.widthType === "dxa") &&
       totalWidth - explicitWidthPx > 1;
     if (!preserveExpandedGrid && totalWidth > 0 && Math.abs(totalWidth - explicitWidthPx) > 1) {
       const scale = explicitWidthPx / totalWidth;

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -195,7 +195,13 @@ export function measureTableBlock(
     columnWidths = Array.from({ length: colCount }, () => equalWidth);
   } else if (columnWidths.length > 0 && explicitWidthPx) {
     const totalWidth = columnWidths.reduce((sum, w) => sum + w, 0);
-    if (totalWidth > 0 && Math.abs(totalWidth - explicitWidthPx) > 1) {
+    // `w:tblW` is a preferred width under autofit. When the imported grid is
+    // already wider, Word preserves that grid instead of scaling it down.
+    const preserveExpandedGrid =
+      tableBlock.layout !== "fixed" &&
+      tableBlock.widthType === "dxa" &&
+      totalWidth - explicitWidthPx > 1;
+    if (!preserveExpandedGrid && totalWidth > 0 && Math.abs(totalWidth - explicitWidthPx) > 1) {
       const scale = explicitWidthPx / totalWidth;
       columnWidths = columnWidths.map((w) => w * scale);
     }


### PR DESCRIPTION
## Summary

- preserve imported autofit column grids when they exceed a preferred dxa table width
- keep fixed-layout scaling unchanged
- add focused measurement regressions for both cases

An anonymous parity replay showed fewer table line-structure mismatches while retaining page-count parity.

CC on behalf of @jan-kubica