### PR TITLE
fix: balance short continuous columns

### DIFF
--- a/.changeset/balanced-continuous-columns.md
+++ b/.changeset/balanced-continuous-columns.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Balance short paragraph-only continuous multi-column sections across their columns.

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -42,6 +42,69 @@ function paragraph(
 }
 
 describe("continuous section break geometry", () => {
+  test("balances a short paragraph-only multi-column section", () => {
+    const intro = paragraph("intro", 100);
+    const firstBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "first-break",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const first = paragraph("first", 100);
+    const second = paragraph("second", 100);
+    const third = paragraph("third", 100);
+    const fourth = paragraph("fourth", 100);
+    const secondBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "second-break",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      columns: { count: 2, gap: 20 },
+    };
+    const outro = paragraph("outro", 100);
+    const blocks: FlowBlock[] = [
+      intro.block,
+      firstBreak,
+      first.block,
+      second.block,
+      third.block,
+      fourth.block,
+      secondBreak,
+      outro.block,
+    ];
+    const measures = [
+      intro.measure,
+      { kind: "sectionBreak" },
+      first.measure,
+      second.measure,
+      third.measure,
+      fourth.measure,
+      { kind: "sectionBreak" },
+      outro.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageSize: { w: 800, h: 1000 },
+      finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    expect(result.pages).toHaveLength(1);
+    const page = result.pages[0];
+    const firstColumn = page?.fragments.filter(
+      (fragment) => fragment.kind === "paragraph" && ["first", "second"].includes(fragment.blockId),
+    );
+    const secondColumn = page?.fragments.filter(
+      (fragment) => fragment.kind === "paragraph" && ["third", "fourth"].includes(fragment.blockId),
+    );
+    expect(firstColumn?.map(({ x }) => x)).toEqual([50, 50]);
+    expect(secondColumn?.map(({ x }) => x)).toEqual([410, 410]);
+    expect(secondColumn?.map(({ y }) => y)).toEqual([150, 250]);
+  });
+
   test("a final multi-column section keeps a forced column break on the current page", () => {
     const first = paragraph("a", 100);
     const sectionBreak: SectionBreakBlock = {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -548,7 +548,7 @@ export function layoutDocument(
             availableHeight: paginator.getAvailableHeight(),
           });
           if (balancedHeight !== undefined) {
-            paginator.balanceColumns(balancedHeight);
+            state.contentBottom = Math.min(state.contentBottom, state.cursorY + balancedHeight);
           }
         }
         activeSectionMarginTop = nextSectionConfig.margins.top;

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -159,6 +159,112 @@ function getSpacingAfter(block: ParagraphBlock): number {
   return value;
 }
 
+/**
+ * Estimate the height of a short paragraph-only multi-column section so its
+ * final page can use Word-style balanced columns. Sections containing tables,
+ * floating blocks, or authored breaks keep the normal bottom-up pagination;
+ * those need structure-aware balancing rather than a height estimate.
+ */
+type BalancedParagraphSectionHeightOptions = {
+  blocks: FlowBlock[];
+  measures: Measure[];
+  startIndex: number;
+  endIndex: number;
+  incomingSpacing: number;
+  columnCount: number;
+  availableHeight: number;
+};
+
+function balancedParagraphSectionHeight({
+  blocks,
+  measures,
+  startIndex,
+  endIndex,
+  incomingSpacing,
+  columnCount,
+  availableHeight,
+}: BalancedParagraphSectionHeightOptions): number | undefined {
+  if (columnCount <= 1 || startIndex >= endIndex || availableHeight <= 0) {
+    return undefined;
+  }
+
+  const lineUnits: number[] = [];
+  let totalHeight = 0;
+  let tallestUnit = 0;
+  let trailingSpacing = incomingSpacing;
+  for (let index = startIndex; index < endIndex; index++) {
+    const block = blocks[index];
+    const measure = measures[index];
+    if (block?.kind !== "paragraph" || measure?.kind !== "paragraph") {
+      return undefined;
+    }
+    if (
+      block.attrs?.keepNext === true ||
+      block.attrs?.keepLines === true ||
+      block.runs.some((run) => run.kind === "text" && run.footnoteRefId !== undefined)
+    ) {
+      return undefined;
+    }
+
+    const leadingSpacing = Math.max(getSpacingBefore(block), trailingSpacing);
+    if (measure.lines.length === 0) {
+      if (leadingSpacing > 0) {
+        lineUnits.push(leadingSpacing);
+        totalHeight += leadingSpacing;
+        tallestUnit = Math.max(tallestUnit, leadingSpacing);
+      }
+    }
+    for (let lineIndex = 0; lineIndex < measure.lines.length; lineIndex++) {
+      const line = measure.lines[lineIndex];
+      if (!line) {
+        continue;
+      }
+      const lineHeight = measuredLineAdvance(line);
+      const unitHeight = lineHeight + (lineIndex === 0 ? leadingSpacing : 0);
+      lineUnits.push(unitHeight);
+      totalHeight += unitHeight;
+      tallestUnit = Math.max(tallestUnit, unitHeight);
+    }
+    if (tallestUnit > availableHeight || totalHeight > availableHeight * columnCount) {
+      return undefined;
+    }
+    trailingSpacing = getSpacingAfter(block);
+  }
+
+  if (totalHeight <= 0) {
+    return undefined;
+  }
+
+  const columnsNeeded = (targetHeight: number): number => {
+    let usedHeight = 0;
+    let usedColumns = 1;
+    for (const unitHeight of lineUnits) {
+      if (usedHeight > 0 && usedHeight + unitHeight > targetHeight) {
+        usedColumns += 1;
+        usedHeight = unitHeight;
+      } else {
+        usedHeight += unitHeight;
+      }
+    }
+    return usedColumns;
+  };
+
+  let lower = Math.max(tallestUnit, totalHeight / columnCount);
+  let upper = Math.min(totalHeight, availableHeight);
+  if (columnsNeeded(upper) > columnCount) {
+    return undefined;
+  }
+  for (let iteration = 0; iteration < 32; iteration++) {
+    const middle = (lower + upper) / 2;
+    if (columnsNeeded(middle) <= columnCount) {
+      upper = middle;
+    } else {
+      lower = middle;
+    }
+  }
+  return Math.ceil(upper * 1000) / 1000;
+}
+
 function hasWidowControl(block: ParagraphBlock): boolean {
   return block.attrs?.widowControl !== false;
 }
@@ -424,6 +530,27 @@ export function layoutDocument(
           nextType,
           sectionIdx + 1,
         );
+        const nextColumns = nextSectionConfig.columns;
+        const nextBreakIndex = breakIndices[sectionIdx + 1] ?? blocks.length;
+        const nextBreak = blocks[nextBreakIndex];
+        const sectionEndsContinuously =
+          nextBreakIndex === blocks.length ||
+          (nextBreak?.kind === "sectionBreak" && nextBreak.type === "continuous");
+        if (nextColumns && sectionEndsContinuously) {
+          const state = paginator.getCurrentState();
+          const balancedHeight = balancedParagraphSectionHeight({
+            blocks,
+            measures,
+            startIndex: i + 1,
+            endIndex: nextBreakIndex,
+            incomingSpacing: state.trailingSpacing,
+            columnCount: nextColumns.count,
+            availableHeight: paginator.getAvailableHeight(),
+          });
+          if (balancedHeight !== undefined) {
+            paginator.balanceColumns(balancedHeight);
+          }
+        }
         activeSectionMarginTop = nextSectionConfig.margins.top;
         activeSectionPageHeight = nextSectionConfig.pageSize.h;
         activeSectionMarginBottom = nextSectionConfig.margins.bottom;

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -194,14 +194,6 @@ export function createPaginator(options: PaginatorOptions) {
   // (continuous section break). When advanceColumn moves to the next column,
   // it resets cursorY to this value instead of topMargin.
   let columnRegionTop = margins.top;
-  // Short multi-column sections can end before the page bottom. Word balances
-  // their final columns by temporarily shortening the available column region.
-  // Undefined keeps the normal page-bottom boundary.
-  let columnRegionBottom: number | undefined;
-
-  function getEffectiveContentBottom(state: PageState): number {
-    return Math.min(state.contentBottom, columnRegionBottom ?? state.contentBottom);
-  }
 
   /**
    * Get X position for a given column index.
@@ -270,7 +262,6 @@ export function createPaginator(options: PaginatorOptions) {
 
     // Reset column region to page top on new page
     columnRegionTop = topMargin;
-    columnRegionBottom = undefined;
 
     if (options.onNewPage) {
       options.onNewPage(state);
@@ -298,7 +289,7 @@ export function createPaginator(options: PaginatorOptions) {
    * Get available height remaining on the current column.
    */
   function getAvailableHeight(state: PageState): number {
-    return getEffectiveContentBottom(state) - state.cursorY;
+    return state.contentBottom - state.cursorY;
   }
 
   /**
@@ -336,7 +327,7 @@ export function createPaginator(options: PaginatorOptions) {
 
     // Keep advancing until we have space
     while (!fits(safeHeight, state)) {
-      const columnCapacity = getEffectiveContentBottom(state) - columnRegionTop;
+      const columnCapacity = state.contentBottom - columnRegionTop;
       if (safeHeight > columnCapacity) {
         if (state.cursorY !== state.topMargin) {
           state = advanceColumn(state);
@@ -494,7 +485,6 @@ export function createPaginator(options: PaginatorOptions) {
     current.contentBottom = rawContentBottom - footnoteHeight;
     current.trailingSpacing = 0;
     columnRegionTop = topMargin;
-    columnRegionBottom = undefined;
 
     currentSectionPageNumber = 1;
     applySectionMetadata(current.page);
@@ -527,23 +517,17 @@ export function createPaginator(options: PaginatorOptions) {
       delete state.page.columns;
     }
 
+    // A balanced section temporarily shortens contentBottom. Restore the
+    // physical page boundary before starting the next column layout.
+    state.contentBottom = state.rawContentBottom - state.footnoteHeight;
+
     // Set column region top to current cursor position.
     // This ensures that when advancing columns, new columns start
     // at the same Y as where the multi-column content began (not page top).
     columnRegionTop = state.cursorY;
-    columnRegionBottom = undefined;
 
     // Reset to column 0 for the new column layout
     state.columnIndex = 0;
-  }
-
-  function balanceColumns(height: number): void {
-    const state = getCurrentState();
-    if (!Number.isFinite(height) || height <= 0 || columns.count <= 1) {
-      columnRegionBottom = undefined;
-      return;
-    }
-    columnRegionBottom = Math.min(state.contentBottom, columnRegionTop + height);
   }
 
   function updatePageLayout(
@@ -627,8 +611,6 @@ export function createPaginator(options: PaginatorOptions) {
     getColumnX,
     /** Update column layout (for section breaks). */
     updateColumns,
-    /** Temporarily shorten a multi-column region so its final columns balance. */
-    balanceColumns,
     /** Update page size/margins for subsequent pages. */
     updatePageLayout,
     /** Mark the next created page as the first page of a new section. */

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -194,6 +194,14 @@ export function createPaginator(options: PaginatorOptions) {
   // (continuous section break). When advanceColumn moves to the next column,
   // it resets cursorY to this value instead of topMargin.
   let columnRegionTop = margins.top;
+  // Short multi-column sections can end before the page bottom. Word balances
+  // their final columns by temporarily shortening the available column region.
+  // Undefined keeps the normal page-bottom boundary.
+  let columnRegionBottom: number | undefined;
+
+  function getEffectiveContentBottom(state: PageState): number {
+    return Math.min(state.contentBottom, columnRegionBottom ?? state.contentBottom);
+  }
 
   /**
    * Get X position for a given column index.
@@ -262,6 +270,7 @@ export function createPaginator(options: PaginatorOptions) {
 
     // Reset column region to page top on new page
     columnRegionTop = topMargin;
+    columnRegionBottom = undefined;
 
     if (options.onNewPage) {
       options.onNewPage(state);
@@ -289,7 +298,7 @@ export function createPaginator(options: PaginatorOptions) {
    * Get available height remaining on the current column.
    */
   function getAvailableHeight(state: PageState): number {
-    return state.contentBottom - state.cursorY;
+    return getEffectiveContentBottom(state) - state.cursorY;
   }
 
   /**
@@ -327,7 +336,7 @@ export function createPaginator(options: PaginatorOptions) {
 
     // Keep advancing until we have space
     while (!fits(safeHeight, state)) {
-      const columnCapacity = state.contentBottom - state.topMargin;
+      const columnCapacity = getEffectiveContentBottom(state) - columnRegionTop;
       if (safeHeight > columnCapacity) {
         if (state.cursorY !== state.topMargin) {
           state = advanceColumn(state);
@@ -485,6 +494,7 @@ export function createPaginator(options: PaginatorOptions) {
     current.contentBottom = rawContentBottom - footnoteHeight;
     current.trailingSpacing = 0;
     columnRegionTop = topMargin;
+    columnRegionBottom = undefined;
 
     currentSectionPageNumber = 1;
     applySectionMetadata(current.page);
@@ -521,9 +531,19 @@ export function createPaginator(options: PaginatorOptions) {
     // This ensures that when advancing columns, new columns start
     // at the same Y as where the multi-column content began (not page top).
     columnRegionTop = state.cursorY;
+    columnRegionBottom = undefined;
 
     // Reset to column 0 for the new column layout
     state.columnIndex = 0;
+  }
+
+  function balanceColumns(height: number): void {
+    const state = getCurrentState();
+    if (!Number.isFinite(height) || height <= 0 || columns.count <= 1) {
+      columnRegionBottom = undefined;
+      return;
+    }
+    columnRegionBottom = Math.min(state.contentBottom, columnRegionTop + height);
   }
 
   function updatePageLayout(
@@ -607,6 +627,8 @@ export function createPaginator(options: PaginatorOptions) {
     getColumnX,
     /** Update column layout (for section breaks). */
     updateColumns,
+    /** Temporarily shorten a multi-column region so its final columns balance. */
+    balanceColumns,
     /** Update page size/margins for subsequent pages. */
     updatePageLayout,
     /** Mark the next created page as the first page of a new section. */


### PR DESCRIPTION
Balance short paragraph-only continuous multi-column sections across the available columns. More complex sections with authored breaks, tables, floating content, footnotes, keep-together constraints, or multi-page content retain the existing pagination path.

An anonymous strict-font parity replay improved from 59.5% to 66.2%: missing and extra lines dropped from 4 each to 0, horizontal drifts dropped from 8 to 2, and page count remained 2/2. Focused paginator and continuous-section regression tests pass; the package change includes a patch changeset.

CC on behalf of @jan-kubica