### PR TITLE
fix: justify numbered list continuations

### DIFF
--- a/.changeset/prose-list-continuations.md
+++ b/.changeset/prose-list-continuations.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Match prose justification tolerance on numbered-list continuation lines.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -612,7 +612,7 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("keeps standard-hanging list continuation lines on the conservative tolerance", () => {
+  test("uses prose tolerance for standard-hanging list continuation lines", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
@@ -633,7 +633,7 @@ describe("measureParagraph justified shrink tolerance", () => {
           124,
         );
 
-        expect(measure.lines).toHaveLength(3);
+        expect(measure.lines).toHaveLength(2);
       },
       {
         charWidth: fractionalWidth,

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -563,16 +563,14 @@ function justifyShrinkToleranceRatio(
   nonBreakingSpaceCount: number,
 ): number {
   if (block.attrs?.listMarker !== undefined) {
-    // Word keeps its conservative list allowance for the standard 360-twip
-    // hanging slot. Custom, wider slots use the tabbed allowance on their
-    // marker line and prose compression on continuations, reduced by fixed
-    // non-breaking spaces on the current line.
+    // Word keeps a conservative allowance on the marker line. Continuation
+    // lines use prose compression, reduced by fixed non-breaking spaces on the
+    // current line.
     const hanging = block.attrs.indent?.hanging ?? 0;
-    if (hanging <= DEFAULT_LIST_HANGING_INDENT_PX) {
-      return JUSTIFY_SHRINK_TOLERANCE_RATIO;
-    }
     if (isFirstLine) {
-      return JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO;
+      return hanging <= DEFAULT_LIST_HANGING_INDENT_PX
+        ? JUSTIFY_SHRINK_TOLERANCE_RATIO
+        : JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO;
     }
     const totalSpaces = regularSpaceCount + nonBreakingSpaceCount;
     if (totalSpaces === 0) {


### PR DESCRIPTION
## Summary

- keep conservative justification tolerance on numbered-list marker lines
- use prose tolerance on continuation lines, including the standard hanging slot
- retain non-breaking-space weighting and custom-hanging behavior
- add a focused continuation regression

An anonymous parity replay restored page-count parity and removed a cascading page offset.

CC on behalf of @jan-kubica