### PR TITLE
fix: align automatic paragraph spacing

### DIFF
--- a/.changeset/word-auto-spacing-points.md
+++ b/.changeset/word-auto-spacing-points.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render automatic paragraph spacing using Word's 14pt gap.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -140,10 +140,10 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.indent).toBeUndefined();
   });
 
-  test("surfaces auto spacing (beforeAutospacing/afterAutospacing) as ~14px for pagination", () => {
+  test("surfaces auto spacing (beforeAutospacing/afterAutospacing) as 14pt for pagination", () => {
     // eigenpal/docx-editor#823: the paged layout reads spacing from the flow
     // block, so auto spacing must override the imported before/after (Word
-    // writes `0`) and render the ~14px auto gap while still unedited.
+    // writes `0`) and render the 14pt auto gap while still unedited.
     const doc = schema.node("doc", null, [
       schema.node(
         "paragraph",
@@ -189,7 +189,7 @@ describe("toFlowBlocks paragraph formatting", () => {
 
     const paragraph = toFlowBlocks(doc).at(0);
 
-    expect(paragraph?.attrs?.spacing?.before).toBe(16); // 240 twips, not the 14px auto gap
+    expect(paragraph?.attrs?.spacing?.before).toBe(16); // 240 twips, not the 14pt auto gap
   });
 
   test("auto spacing still applies when a style supplies spacing the import lacked (#823)", () => {
@@ -251,7 +251,7 @@ describe("toFlowBlocks paragraph formatting", () => {
 
   test("keeps auto spacing on an empty paragraph by marking it explicit (#823)", () => {
     // An imported empty paragraph whose only spacing is auto-spacing must keep
-    // the ~14px gap; without `spacingExplicit` the empty-paragraph collapse
+    // the 14pt gap; without `spacingExplicit` the empty-paragraph collapse
     // rule in the layout engine would suppress it.
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1378,7 +1378,7 @@ function convertParagraphAttrs(
   }
 
   // Spacing. HTML-origin auto spacing (w:beforeAutospacing/afterAutospacing)
-  // renders Word's ~14px auto gap, overriding the imported before/after (which
+  // renders Word's 14pt auto gap, overriding the imported before/after (which
   // Word writes as `0`) — surface it here so pagination matches the rendered
   // margins (eigenpal/docx-editor#823). But only while the effective spacing
   // still matches the import baseline; any later command or style change that
@@ -1410,7 +1410,7 @@ function convertParagraphAttrs(
     // paragraphs inherit zero spacing unless the side was set inline (Word
     // fidelity, eigenpal #402). Auto spacing counts as explicit: an imported
     // empty paragraph whose only spacing is `w:beforeAutospacing`/
-    // `afterAutospacing` must keep the ~14px gap rather than collapse to zero
+    // `afterAutospacing` must keep the 14pt gap rather than collapse to zero
     // (eigenpal/docx-editor#823).
     const pmSpacingExplicit = pmAttrs.spacingExplicit as
       | { before?: boolean; after?: boolean }

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.test.ts
@@ -3,7 +3,7 @@ import { EditorState, TextSelection } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 
 import { toFlowBlocks } from "../../../layout-bridge/convert/toFlowBlocks";
-import { AUTO_PARAGRAPH_SPACING_PX } from "../../../utils/units";
+import { AUTO_PARAGRAPH_SPACING_PX, formatPx } from "../../../utils/units";
 import { schema, singletonManager } from "../../schema";
 
 const paragraphDomAttrs = (attrs: Record<string, unknown>): Record<string, string> => {
@@ -82,7 +82,7 @@ describe("ParagraphExtension", () => {
 
     const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
     expect(domAttrs["style"]).toContain("margin-top: 16px");
-    expect(domAttrs["style"]).not.toContain(`margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`);
+    expect(domAttrs["style"]).not.toContain(`margin-top: ${formatPx(AUTO_PARAGRAPH_SPACING_PX)}`);
   });
 
   test("applying a style with spacing overrides imported auto-spacing (#823)", () => {
@@ -121,7 +121,7 @@ describe("ParagraphExtension", () => {
 
     const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
     expect(domAttrs["style"]).toContain("margin-top: 24px");
-    expect(domAttrs["style"]).not.toContain(`margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`);
+    expect(domAttrs["style"]).not.toContain(`margin-top: ${formatPx(AUTO_PARAGRAPH_SPACING_PX)}`);
 
     const block = toFlowBlocks(state.doc).at(0);
     expect(block?.attrs?.spacing?.before).toBe(24);
@@ -161,7 +161,9 @@ describe("ParagraphExtension", () => {
     expect(para?.attrs["_autospacingBase"]).toBeNull();
 
     const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
-    expect(domAttrs["style"] ?? "").not.toContain(`margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`);
+    expect(domAttrs["style"] ?? "").not.toContain(
+      `margin-top: ${formatPx(AUTO_PARAGRAPH_SPACING_PX)}`,
+    );
 
     const block = toFlowBlocks(state.doc).at(0);
     expect(block?.attrs?.spacing?.before).not.toBe(AUTO_PARAGRAPH_SPACING_PX);
@@ -173,6 +175,6 @@ describe("ParagraphExtension", () => {
       _autospacingBase: { before: null },
     });
 
-    expect(domAttrs["style"]).toContain(`margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`);
+    expect(domAttrs["style"]).toContain(`margin-top: ${formatPx(AUTO_PARAGRAPH_SPACING_PX)}`);
   });
 });

--- a/packages/core/src/utils/formatToStyle-autospacing.test.ts
+++ b/packages/core/src/utils/formatToStyle-autospacing.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { paragraphToStyle } from "./formatToStyle";
-import { AUTO_PARAGRAPH_SPACING_PX } from "./units";
+import { AUTO_PARAGRAPH_SPACING_PX, formatPx } from "./units";
 
 // eigenpal/docx-editor#823 — HTML-origin paragraphs carry
 // `w:beforeAutospacing`/`w:afterAutospacing`. Word ignores any explicit
-// before/after on such paragraphs and renders ~14px. The editor previously
+// before/after on such paragraphs and renders a 14pt gap. The editor previously
 // honored only the explicit values, so imports rendered too tight.
 describe("paragraphToStyle auto spacing", () => {
   test("auto spacing overrides explicit before/after", () => {
@@ -16,8 +16,8 @@ describe("paragraphToStyle auto spacing", () => {
       spaceAfter: 100,
     });
 
-    expect(style.marginTop).toBe(`${AUTO_PARAGRAPH_SPACING_PX}px`);
-    expect(style.marginBottom).toBe(`${AUTO_PARAGRAPH_SPACING_PX}px`);
+    expect(style.marginTop).toBe(formatPx(AUTO_PARAGRAPH_SPACING_PX));
+    expect(style.marginBottom).toBe(formatPx(AUTO_PARAGRAPH_SPACING_PX));
   });
 
   test("explicit spacing is still used when no auto flag is set", () => {

--- a/packages/core/src/utils/formatToStyle.ts
+++ b/packages/core/src/utils/formatToStyle.ts
@@ -304,7 +304,7 @@ export function paragraphToStyle(
   // ============================================================================
 
   // Space before (marginTop). HTML-origin `w:beforeAutospacing` overrides any
-  // explicit before with Word's ~14px auto gap (eigenpal/docx-editor#823).
+  // explicit before with Word's 14pt auto gap (eigenpal/docx-editor#823).
   if (formatting.beforeAutospacing) {
     style.marginTop = formatPx(AUTO_PARAGRAPH_SPACING_PX);
   } else if (formatting.spaceBefore !== undefined) {

--- a/packages/core/src/utils/units.test.ts
+++ b/packages/core/src/utils/units.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
-import { emuToPixels, emuToTwips, pixelsToEmu, twipsToEmu } from "./units";
+import {
+  AUTO_PARAGRAPH_SPACING_PX,
+  emuToPixels,
+  emuToTwips,
+  pixelsToEmu,
+  pointsToPixels,
+  twipsToEmu,
+} from "./units";
+
+test("Word automatic paragraph spacing uses a 14pt gap", () => {
+  expect(AUTO_PARAGRAPH_SPACING_PX).toBe(pointsToPixels(14));
+});
 
 // Microsoft Word treats EMU/twip attributes as integer-typed (xs:long /
 // xs:unsignedInt). IEEE-754 drift such as `(52 / 96) * 914400 ===

--- a/packages/core/src/utils/units.ts
+++ b/packages/core/src/utils/units.ts
@@ -43,7 +43,7 @@ export const PIXELS_PER_INCH = STANDARD_DPI;
  * The value is empirical (Word's rendered auto gap), not derivable from a
  * twips conversion. See eigenpal/docx-editor#823.
  */
-export const AUTO_PARAGRAPH_SPACING_PX = (14 / POINTS_PER_INCH) * PIXELS_PER_INCH;
+export const AUTO_PARAGRAPH_SPACING_PX = pointsToPixels(14);
 
 // ============================================================================
 // TWIPS CONVERSIONS

--- a/packages/core/src/utils/units.ts
+++ b/packages/core/src/utils/units.ts
@@ -21,15 +21,6 @@ const STANDARD_DPI = 96;
 /** Twips per inch (1 inch = 1440 twips) */
 export const TWIPS_PER_INCH = 1440;
 
-/**
- * Word's auto paragraph spacing in px. HTML-origin paragraphs use
- * `w:beforeAutospacing`/`w:afterAutospacing` instead of explicit before/after;
- * Word ignores any explicit value on such paragraphs and renders ~14px. The
- * value is empirical (Word's rendered auto gap), not derivable from a twips
- * conversion. See eigenpal/docx-editor#823.
- */
-export const AUTO_PARAGRAPH_SPACING_PX = 14;
-
 /** EMUs per inch (1 inch = 914400 EMUs) */
 const EMUS_PER_INCH = 914_400;
 
@@ -44,6 +35,15 @@ const EIGHTHS_PER_INCH = 576;
 
 /** Pixels per inch at standard DPI */
 export const PIXELS_PER_INCH = STANDARD_DPI;
+
+/**
+ * Word's auto paragraph spacing in px. HTML-origin paragraphs use
+ * `w:beforeAutospacing`/`w:afterAutospacing` instead of explicit before/after;
+ * Word ignores any explicit value on such paragraphs and renders a 14pt gap.
+ * The value is empirical (Word's rendered auto gap), not derivable from a
+ * twips conversion. See eigenpal/docx-editor#823.
+ */
+export const AUTO_PARAGRAPH_SPACING_PX = (14 / POINTS_PER_INCH) * PIXELS_PER_INCH;
 
 // ============================================================================
 // TWIPS CONVERSIONS


### PR DESCRIPTION
Resolves authored `beforeAutospacing` and `afterAutospacing` flags to Word’s 14pt automatic gap instead of treating that value as CSS pixels. Explicit twip spacing and spacing edits continue to use their authored values.

In an anonymous fidelity replay, the affected lines’ absolute vertical error narrowed from roughly 1.6–4.9pt to 0.4–0.7pt.

CC on behalf of @jan-kubica