### PR TITLE
fix: localize parity y-offset transitions

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -242,6 +242,29 @@ describe("compareGeoms", () => {
     expect(result.score).toBeCloseTo(2 / 3);
   });
 
+  test("an outlier on the first line is attributed to the first line", () => {
+    const texts = ["Alpha line", "Bravo line", "Charlie line"];
+    const word = makeDoc("word", [
+      makePage({
+        lines: texts.map((text, index) => makeLine({ text, yPt: 72 + index * 18 })),
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({ text, yPt: 72 + index * 18 + (index === 0 ? 6 : 0) }),
+        ),
+      }),
+    ]);
+
+    const result = compareGeoms(word, folio);
+
+    expect(result.divergences.filter((item) => item.kind === "y-drift")).toEqual([
+      { kind: "y-drift", page: 1, text: "Alpha line", residualPt: 6 },
+    ]);
+    expect(result.score).toBeCloseTo(2 / 3);
+  });
+
   test("persistent offset transitions stay localized when the page median shifts", () => {
     const texts = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"];
     const word = makeDoc("word", [

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -188,7 +188,7 @@ describe("compareGeoms", () => {
     expect(result.matchedLines).toBe(2);
   });
 
-  test("constant +6pt y offset on every folio line is absorbed by the median (no y-drift)", () => {
+  test("constant +6pt y offset on every folio line is absorbed as an extractor baseline", () => {
     const word = makeDoc("word", [
       makePage({
         lines: [
@@ -240,6 +240,36 @@ describe("compareGeoms", () => {
     expect(yDrifts[0]).toMatchObject({ kind: "y-drift", text: "Bravo line" });
     expect(result.medianYOffsetPt).toBe(0);
     expect(result.score).toBeCloseTo(2 / 3);
+  });
+
+  test("persistent offset transitions stay localized when the page median shifts", () => {
+    const texts = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"];
+    const word = makeDoc("word", [
+      makePage({
+        lines: texts.map((text, index) => makeLine({ text, yPt: 72 + index * 18 })),
+      }),
+    ]);
+    const makeFolio = (offsets: number[]) =>
+      makeDoc("folio", [
+        makePage({
+          lines: texts.map((text, index) =>
+            makeLine({ text, yPt: 72 + index * 18 + (offsets[index] ?? 0) }),
+          ),
+        }),
+      ]);
+
+    const before = compareGeoms(word, makeFolio([-3, -3, 1, 1, -4, -4]));
+    const after = compareGeoms(word, makeFolio([-3, -3, 1, 1, 1, 1]));
+    const beforeYDrifts = before.divergences.filter((item) => item.kind === "y-drift");
+    const afterYDrifts = after.divergences.filter((item) => item.kind === "y-drift");
+
+    expect(beforeYDrifts).toEqual([
+      { kind: "y-drift", page: 1, text: "Charlie", residualPt: 4 },
+      { kind: "y-drift", page: 1, text: "Echo", residualPt: -5 },
+    ]);
+    expect(afterYDrifts).toEqual([{ kind: "y-drift", page: 1, text: "Charlie", residualPt: 4 }]);
+    expect(after.score).toBeGreaterThan(before.score);
+    expect(after.medianYOffsetPt).not.toBe(before.medianYOffsetPt);
   });
 
   test("punctuation-only rows do not create y-drift or bias the extractor offset", () => {

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -583,6 +583,19 @@ const segmentedYResiduals = (
     const first = stableMatches.at(0);
     if (!first) continue;
     let baselinePt = first.offsetPt;
+
+    const second = stableMatches.at(1);
+    const third = stableMatches.at(2);
+    const firstIsIsolated =
+      second !== undefined &&
+      third !== undefined &&
+      Math.abs(first.offsetPt - second.offsetPt) > tolerances.yResidualPt &&
+      Math.abs(third.offsetPt - second.offsetPt) <= tolerances.yResidualPt;
+    if (firstIsIsolated && second) {
+      residuals.set(matchKey(first.match), first.offsetPt - second.offsetPt);
+      baselinePt = second.offsetPt;
+    }
+
     for (let index = 1; index < stableMatches.length; index += 1) {
       const current = stableMatches[index];
       if (!current) continue;

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -71,13 +71,14 @@ export const compareGeoms = (
   );
   const medianYOffsetsByPageRegion = pageRegionMedianYOffsets(matches, wordFlat, folioFlat);
   const medianYOffsetPt = median([...medianYOffsetsByPageRegion.values()]);
+  const yResidualsByMatch = segmentedYResiduals(matches, wordFlat, folioFlat, tolerances);
 
   const { orderedDivergences, matchedGeomPass } = diffMatches({
     resolved,
     wordFlat,
     folioFlat,
     tolerances,
-    medianYOffsetsByPageRegion,
+    yResidualsByMatch,
   });
   divergences.push(...orderedDivergences);
 
@@ -536,6 +537,68 @@ const median = (values: number[]): number => {
   return sorted[mid] ?? 0;
 };
 
+const matchKey = ({ wordIdx, folioIdx }: Extract<ResolvedItem, { kind: "match" }>): string =>
+  `${wordIdx}:${folioIdx}`;
+
+type StableYMatch = {
+  match: Extract<ResolvedItem, { kind: "match" }>;
+  offsetPt: number;
+};
+
+/**
+ * Finds vertical-offset transitions without letting a page-wide median move
+ * the goalposts. A constant extractor offset is ignored. When the offset
+ * changes persistently, the first line of the new segment reports the gap
+ * and becomes the new baseline; downstream lines are not relabelled for the
+ * same spacing discontinuity. A one-line excursion reports only that line
+ * and keeps the previous segment baseline.
+ */
+const segmentedYResiduals = (
+  matches: Extract<ResolvedItem, { kind: "match" }>[],
+  wordFlat: FlatLine[],
+  folioFlat: FlatLine[],
+  tolerances: ComparisonTolerances,
+): Map<string, number> => {
+  const matchesByPageRegion = new Map<string, StableYMatch[]>();
+  for (const match of matches) {
+    const word = wordFlat[match.wordIdx];
+    const folio = folioFlat[match.folioIdx];
+    if (
+      !word ||
+      !folio ||
+      word.page !== folio.page ||
+      !hasStableVerticalInk(word.line) ||
+      !hasStableVerticalInk(folio.line)
+    ) {
+      continue;
+    }
+    const key = matchedPageRegionKey(word, folio);
+    const stableMatches = matchesByPageRegion.get(key) ?? [];
+    stableMatches.push({ match, offsetPt: folio.line.yPt - word.line.yPt });
+    matchesByPageRegion.set(key, stableMatches);
+  }
+
+  const residuals = new Map<string, number>();
+  for (const stableMatches of matchesByPageRegion.values()) {
+    const first = stableMatches.at(0);
+    if (!first) continue;
+    let baselinePt = first.offsetPt;
+    for (let index = 1; index < stableMatches.length; index += 1) {
+      const current = stableMatches[index];
+      if (!current) continue;
+      const residualPt = current.offsetPt - baselinePt;
+      if (Math.abs(residualPt) <= tolerances.yResidualPt) continue;
+
+      residuals.set(matchKey(current.match), residualPt);
+      const next = stableMatches[index + 1];
+      const returnsToBaseline =
+        next !== undefined && Math.abs(next.offsetPt - baselinePt) <= tolerances.yResidualPt;
+      if (!returnsToBaseline) baselinePt = current.offsetPt;
+    }
+  }
+  return residuals;
+};
+
 /** Result of walking the resolved items into divergences: the divergences
  * in document order, plus the count of matched pairs that pass every
  * geometric check (used for the parity score numerator). */
@@ -545,7 +608,7 @@ type DiffMatchesOptions = {
   wordFlat: FlatLine[];
   folioFlat: FlatLine[];
   tolerances: ComparisonTolerances;
-  medianYOffsetsByPageRegion: ReadonlyMap<string, number>;
+  yResidualsByMatch: ReadonlyMap<string, number>;
 };
 
 const diffMatches = ({
@@ -553,7 +616,7 @@ const diffMatches = ({
   wordFlat,
   folioFlat,
   tolerances,
-  medianYOffsetsByPageRegion,
+  yResidualsByMatch,
 }: DiffMatchesOptions): DiffMatchesResult => {
   const orderedDivergences: Divergence[] = [];
   let matchedGeomPass = 0;
@@ -606,12 +669,7 @@ const diffMatches = ({
 
       let yDelta: number | null = null;
       if (samePage && hasStableVerticalInk(w.line) && hasStableVerticalInk(f.line)) {
-        yDelta = checkYDrift(
-          w.line,
-          f.line,
-          medianYOffsetsByPageRegion.get(matchedPageRegionKey(w, f)) ?? 0,
-          tolerances,
-        );
+        yDelta = yResidualsByMatch.get(matchKey(item)) ?? null;
         if (yDelta !== null) {
           orderedDivergences.push({
             kind: "y-drift",
@@ -667,21 +725,4 @@ const checkWidthDrift = (
   const withinAbsolute = Math.abs(delta) <= tolerances.widthPt;
   const withinRelative = Math.abs(delta) <= tolerances.widthRelative * wordLine.widthPt;
   return withinAbsolute || withinRelative ? null : delta;
-};
-
-/**
- * y-drift residual: word-side boxes are glyph-ink bounds and folio-side
- * boxes are line-height boxes, so a constant vertical offset between the two
- * extractors is expected. `medianOffsetPt` (the median of folio-minus-word y
- * across every same-page matched pair) absorbs that constant; only the
- * residual after subtracting it is a real divergence.
- */
-const checkYDrift = (
-  wordLine: LineBox,
-  folioLine: LineBox,
-  medianOffsetPt: number,
-  tolerances: ComparisonTolerances,
-): number | null => {
-  const residual = folioLine.yPt - wordLine.yPt - medianOffsetPt;
-  return Math.abs(residual) > tolerances.yResidualPt ? residual : null;
 };


### PR DESCRIPTION
Makes vertical parity diagnostics segment-aware: a persistent offset transition is attributed to its boundary instead of allowing a page-wide median to relabel every downstream line. Single-line excursions remain isolated, and constant extractor offsets stay absorbed.

Synthetic tests cover median movement, persistent transitions, and isolated outliers.

CC on behalf of @jan-kubica