### PR TITLE
fix: honor authored column boundaries

### DIFF
--- a/.changeset/respect-authored-column-boundaries.md
+++ b/.changeset/respect-authored-column-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor leading authored column breaks and resume continuous-section content below the tallest column.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -57,6 +57,25 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(blocks.at(1)).toMatchObject({ kind: "columnBreak", pmStart: 14, pmEnd: 17 });
   });
 
+  test("emits a structural break before text after a leading column break", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("First column")]),
+      schema.node("paragraph", null, [
+        schema.node("hardBreak", { breakType: "column" }),
+        schema.text("Second column"),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["paragraph", "columnBreak", "paragraph"]);
+    expect(blocks.at(1)).toMatchObject({ kind: "columnBreak", pmStart: 15, pmEnd: 16 });
+    expect(blocks.at(2)).toMatchObject({
+      kind: "paragraph",
+      runs: [{ kind: "text", text: "Second column" }],
+    });
+  });
+
   test("empty paragraph measurement uses direct paragraph-mark font metrics", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2535,10 +2535,11 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
         const hasListFormatting =
           (pmAttrs.numPr !== null && pmAttrs.numPr !== undefined) ||
           (pmAttrs.listMarker !== null && pmAttrs.listMarker !== undefined);
-        const onlyChild = node.childCount === 1 ? node.firstChild : null;
-        const isStandaloneColumnBreak =
-          onlyChild?.type.name === "hardBreak" &&
-          expectHardBreakAttrs(onlyChild).breakType === "column";
+        const firstChild = node.firstChild;
+        const startsWithColumnBreak =
+          firstChild?.type.name === "hardBreak" &&
+          expectHardBreakAttrs(firstChild).breakType === "column";
+        const isStandaloneColumnBreak = node.childCount === 1 && startsWithColumnBreak;
 
         if (isStandaloneColumnBreak) {
           const columnBreak: ColumnBreakBlock = {
@@ -2548,6 +2549,20 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
             pmEnd: pos + node.nodeSize,
           };
           trackedPush(columnBreak);
+        } else if (startsWithColumnBreak && firstChild) {
+          const columnBreak: ColumnBreakBlock = {
+            kind: "columnBreak",
+            id: nextBlockId(),
+            pmStart: pos + 1,
+            pmEnd: pos + 1 + firstChild.nodeSize,
+          };
+          trackedPush(columnBreak);
+
+          const paragraph = convertParagraph(node, pos, opts);
+          if (paragraph.runs.at(0)?.kind === "lineBreak") {
+            paragraph.runs.shift();
+          }
+          trackedPush(paragraph);
         } else if (node.content.size > 0 || hasListFormatting || !hasSectionBreak) {
           // An empty paragraph carrying w:sectPr is Word's structural section
           // marker; it does not paint an additional blank line. Text-bearing

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -145,6 +145,62 @@ describe("continuous section break geometry", () => {
     expect(secondColumnFragment?.width).toBe(300);
   });
 
+  test("content after a continuous column section resumes below its tallest column", () => {
+    const intro = paragraph("intro", 100);
+    const firstBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "first-break",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const first = paragraph("first", 100);
+    const second = paragraph("second", 100);
+    const columnBreak: ColumnBreakBlock = { kind: "columnBreak", id: "column-break" };
+    const third = paragraph("third", 50);
+    const secondBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "second-break",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      columns: { count: 2, gap: 20 },
+    };
+    const outro = paragraph("outro", 100);
+    const blocks: FlowBlock[] = [
+      intro.block,
+      firstBreak,
+      first.block,
+      second.block,
+      columnBreak,
+      third.block,
+      secondBreak,
+      outro.block,
+    ];
+    const measures = [
+      intro.measure,
+      { kind: "sectionBreak" },
+      first.measure,
+      second.measure,
+      { kind: "columnBreak" },
+      third.measure,
+      { kind: "sectionBreak" },
+      outro.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageSize: { w: 800, h: 1000 },
+      finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    const outroFragment = result.pages[0]?.fragments.find(
+      (fragment) => fragment.kind === "paragraph" && fragment.blockId === "outro",
+    );
+    expect(outroFragment?.y).toBe(350);
+  });
+
   test("current page keeps old geometry and overflow page picks up new geometry", () => {
     const first = paragraph("a", 200);
     const sectionBreak: SectionBreakBlock = {

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -194,6 +194,7 @@ export function createPaginator(options: PaginatorOptions) {
   // (continuous section break). When advanceColumn moves to the next column,
   // it resets cursorY to this value instead of topMargin.
   let columnRegionTop = margins.top;
+  let columnRegionMaxBottom = margins.top;
 
   /**
    * Get X position for a given column index.
@@ -262,6 +263,7 @@ export function createPaginator(options: PaginatorOptions) {
 
     // Reset column region to page top on new page
     columnRegionTop = topMargin;
+    columnRegionMaxBottom = topMargin;
 
     if (options.onNewPage) {
       options.onNewPage(state);
@@ -306,6 +308,7 @@ export function createPaginator(options: PaginatorOptions) {
   function advanceColumn(state: PageState): PageState {
     // Check if there are more columns on this page
     if (state.columnIndex < columns.count - 1) {
+      columnRegionMaxBottom = Math.max(columnRegionMaxBottom, state.cursorY);
       state.columnIndex += 1;
       state.cursorY = columnRegionTop;
       state.trailingSpacing = 0;
@@ -506,11 +509,14 @@ export function createPaginator(options: PaginatorOptions) {
    * column advancement stays below existing content (for continuous breaks).
    */
   function updateColumns(newColumns: ColumnLayout): void {
+    const previousColumnCount = columns.count;
+    const state = getCurrentState();
+    const previousRegionBottom = Math.max(columnRegionMaxBottom, state.cursorY);
+
     columns = newColumns;
     recalculateColumnWidths();
 
     // Update current page's column info for rendering
-    const state = getCurrentState();
     if (columns.count > 1) {
       state.page.columns = { ...columns };
     } else {
@@ -521,10 +527,15 @@ export function createPaginator(options: PaginatorOptions) {
     // physical page boundary before starting the next column layout.
     state.contentBottom = state.rawContentBottom - state.footnoteHeight;
 
+    if (previousColumnCount > 1) {
+      state.cursorY = previousRegionBottom;
+    }
+
     // Set column region top to current cursor position.
     // This ensures that when advancing columns, new columns start
     // at the same Y as where the multi-column content began (not page top).
     columnRegionTop = state.cursorY;
+    columnRegionMaxBottom = state.cursorY;
 
     // Reset to column 0 for the new column layout
     state.columnIndex = 0;


### PR DESCRIPTION
## Summary

- preserve leading authored column breaks as structural flow boundaries
- resume continuous-section content below the tallest completed column
- add focused conversion and geometry regression coverage

CC on behalf of @jan-kubica