### PR TITLE
fix: suppress structural section marker lines

### DIFF
--- a/.changeset/tidy-section-markers.md
+++ b/.changeset/tidy-section-markers.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Avoid painting an extra blank line for empty structural section-break paragraphs.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -29,6 +29,21 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(blocks.map((block) => block.kind)).toEqual(["paragraph", "sectionBreak", "paragraph"]);
   });
 
+  test("paints an empty list item that also ends a section", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", {
+        sectionBreakType: "continuous",
+        numPr: { numId: 1, ilvl: 0 },
+        listMarker: "1.",
+      }),
+      schema.node("paragraph", null, [schema.text("Next section")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["paragraph", "sectionBreak", "paragraph"]);
+  });
+
   test("emits a structural break for a standalone column break paragraph", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First column")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -5,6 +5,30 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("does not paint an empty structural section-break paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { sectionBreakType: "continuous" }),
+      schema.node("paragraph", null, [schema.text("Next section")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["sectionBreak", "paragraph"]);
+  });
+
+  test("paints text in a paragraph that also ends a section", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { sectionBreakType: "continuous" }, [
+        schema.text("Section ending text"),
+      ]),
+      schema.node("paragraph", null, [schema.text("Next section")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["paragraph", "sectionBreak", "paragraph"]);
+  });
+
   test("emits a structural break for a standalone column break paragraph", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First column")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2527,6 +2527,9 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
         const hasSectionBreak =
           secProps !== undefined ||
           (pmAttrs.sectionBreakType !== null && pmAttrs.sectionBreakType !== undefined);
+        const hasListFormatting =
+          (pmAttrs.numPr !== null && pmAttrs.numPr !== undefined) ||
+          (pmAttrs.listMarker !== null && pmAttrs.listMarker !== undefined);
         const onlyChild = node.childCount === 1 ? node.firstChild : null;
         const isStandaloneColumnBreak =
           onlyChild?.type.name === "hardBreak" &&
@@ -2540,7 +2543,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
             pmEnd: pos + node.nodeSize,
           };
           trackedPush(columnBreak);
-        } else if (node.content.size > 0 || !hasSectionBreak) {
+        } else if (node.content.size > 0 || hasListFormatting || !hasSectionBreak) {
           // An empty paragraph carrying w:sectPr is Word's structural section
           // marker; it does not paint an additional blank line. Text-bearing
           // section-ending paragraphs still participate in normal layout.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2523,6 +2523,10 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     switch (node.type.name) {
       case "paragraph": {
         const pmAttrs = expectParagraphAttrs(node);
+        const secProps = pmAttrs._sectionProperties as SectionProperties | undefined;
+        const hasSectionBreak =
+          secProps !== undefined ||
+          (pmAttrs.sectionBreakType !== null && pmAttrs.sectionBreakType !== undefined);
         const onlyChild = node.childCount === 1 ? node.firstChild : null;
         const isStandaloneColumnBreak =
           onlyChild?.type.name === "hardBreak" &&
@@ -2536,13 +2540,15 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
             pmEnd: pos + node.nodeSize,
           };
           trackedPush(columnBreak);
-        } else {
+        } else if (node.content.size > 0 || !hasSectionBreak) {
+          // An empty paragraph carrying w:sectPr is Word's structural section
+          // marker; it does not paint an additional blank line. Text-bearing
+          // section-ending paragraphs still participate in normal layout.
           trackedPush(convertParagraph(node, pos, opts));
         }
 
         // Emit section break block if this paragraph ends a section
-        const secProps = pmAttrs._sectionProperties as SectionProperties | undefined;
-        if (secProps || pmAttrs.sectionBreakType) {
+        if (hasSectionBreak) {
           const sectionBreak: SectionBreakBlock = {
             kind: "sectionBreak",
             id: nextBlockId(),


### PR DESCRIPTION
## Summary

- omit empty section-ending marker paragraphs from painted flow while preserving their structural break
- keep text-bearing and list-formatted section-ending paragraphs in normal layout
- cover structural, text-bearing, and empty-list cases with targeted conversion regressions

## Validation

- focused layout-bridge suite: 54/54
- anonymous strict-font replay retained 2/2 page parity and reduced the targeted downstream vertical offset by 27.8pt
- `bun audit`: clean
- lint, typecheck, full tests, builds, package validation, and interaction coverage run in CI

CC on behalf of @jan-kubica