### PR TITLE
fix: align authored table indentation

### DIFF
--- a/.changeset/calm-table-borders.md
+++ b/.changeset/calm-table-borders.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align explicitly indented table borders with Word layout.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -937,15 +937,14 @@ function layoutTable(
       x += (paginator.columnWidth - measure.totalWidth) / 2;
     } else if (block.justification === "right") {
       x = x + paginator.columnWidth - measure.totalWidth;
+    } else if (block.indent !== undefined) {
+      // An authored w:tblInd offsets the table border from the content margin.
+      // Keep the absent-value path separate because Word's inherited default
+      // aligns the first-cell text edge instead.
+      x += block.indent;
     } else {
       const leadingCellMargin = block.rows.at(0)?.cells.at(0)?.padding?.left ?? 0;
-      // With no w:tblInd, Word aligns the first cell's text edge with the
-      // content margin. An authored zero indent is distinct: it aligns the
-      // table border itself with the margin. Preserve non-zero indentation's
-      // existing text-edge behavior while retaining that zero-valued signal.
-      if (block.indent !== 0) {
-        x += (block.indent ?? 0) - leadingCellMargin;
-      }
+      x -= leadingCellMargin;
     }
     return x;
   };

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -780,7 +780,7 @@ describe("left-aligned table placement", () => {
     const { block, measure } = tallTable(1);
     block.rows[0]!.cells[0]!.padding.left = 7;
 
-    const fragment = tableFragments(block, measure)[0];
+    const fragment = tableFragments(block, measure).at(0);
 
     expect(fragment?.x).toBe(OPTIONS.margins.left - 7);
     expect((fragment?.x ?? 0) + block.rows[0]!.cells[0]!.padding.left).toBe(OPTIONS.margins.left);
@@ -791,7 +791,7 @@ describe("left-aligned table placement", () => {
     block.indent = 10;
     block.rows[0]!.cells[0]!.padding.left = 7;
 
-    const fragment = tableFragments(block, measure)[0];
+    const fragment = tableFragments(block, measure).at(0);
 
     expect(fragment?.x).toBe(OPTIONS.margins.left + 10);
   });
@@ -801,7 +801,7 @@ describe("left-aligned table placement", () => {
     block.indent = 0;
     block.rows[0]!.cells[0]!.padding.left = 7;
 
-    const fragment = tableFragments(block, measure)[0];
+    const fragment = tableFragments(block, measure).at(0);
 
     expect(fragment?.x).toBe(OPTIONS.margins.left);
   });
@@ -812,7 +812,7 @@ describe("floating table placement", () => {
     const { block, measure } = tallTable(1);
     block.floating = { horzAnchor: "page", tblpX: 80 };
 
-    const fragment = tableFragments(block, measure)[0];
+    const fragment = tableFragments(block, measure).at(0);
 
     expect(fragment?.x).toBe(80);
   });

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -786,14 +786,14 @@ describe("left-aligned table placement", () => {
     expect((fragment?.x ?? 0) + block.rows[0]!.cells[0]!.padding.left).toBe(OPTIONS.margins.left);
   });
 
-  test("applies w:tblInd to the first cell text edge", () => {
+  test("applies an authored w:tblInd to the table border", () => {
     const { block, measure } = tallTable(1);
     block.indent = 10;
     block.rows[0]!.cells[0]!.padding.left = 7;
 
     const fragment = tableFragments(block, measure)[0];
 
-    expect(fragment?.x).toBe(OPTIONS.margins.left + 10 - 7);
+    expect(fragment?.x).toBe(OPTIONS.margins.left + 10);
   });
 
   test("aligns an authored zero-indent table border with the content edge", () => {


### PR DESCRIPTION
## Summary

- treat an explicitly authored nonzero `w:tblInd` as an offset for the table border
- retain the absent-indent text-edge behavior and explicit-zero signal already preserved on main
- update synthetic placement coverage for all three cases

## Anonymous parity evidence

- horizontal drifts: 228 → 1
- latest combined score after the fix: 0.892
- page counts remained exact at 2/2

## Validation

- `cd packages/core && bun test src/layout-engine/tableRowBreak.test.ts src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts src/__tests__/layout-pipeline.integration.test.ts` (91 passed)
- `bun audit` (no vulnerabilities)
- lint and typecheck delegated to CI

CC on behalf of @jan-kubica