### PR TITLE
fix: preserve inherited spacing on authored blank paragraphs

### DIFF
--- a/.changeset/authored-empty-paragraph-spacing.md
+++ b/.changeset/authored-empty-paragraph-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve inherited spacing on empty paragraphs with direct paragraph formatting.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -557,6 +557,7 @@ export type ParagraphAttrs = {
         before?: boolean;
         after?: boolean;
     };
+    hasDirectParagraphFormatting?: boolean;
     indent?: ParagraphIndent;
     keepNext?: boolean;
     keepLines?: boolean;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -99,6 +99,19 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.hasDirectParagraphFormatting).toBeUndefined();
   });
 
+  test("does not treat paragraph-mark character styling as paragraph formatting", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", {
+        _originalFormatting: { runProperties: { fontSize: 24 } },
+      }),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.hasDirectParagraphFormatting).toBeUndefined();
+  });
+
   test("preserves Word rendered-page-break hints for layout", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { renderedPageBreakBefore: true }, [schema.text("Next page")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -76,6 +76,29 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.defaultFontFamily).toBe("Arial");
   });
 
+  test("marks direct formatting on an empty paragraph for spacing layout", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", {
+        spaceAfter: 200,
+        _originalFormatting: { indentLeft: 720 },
+      }),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.hasDirectParagraphFormatting).toBe(true);
+  });
+
+  test("does not mark a bare empty paragraph as directly formatted", () => {
+    const doc = schema.node("doc", null, [schema.node("paragraph")]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.hasDirectParagraphFormatting).toBeUndefined();
+  });
+
   test("preserves Word rendered-page-break hints for layout", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { renderedPageBreakBefore: true }, [schema.text("Next page")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1794,7 +1794,12 @@ function convertParagraph(
   );
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
   if (runs.length === 0) {
-    if (pmAttrs._originalFormatting && Object.keys(pmAttrs._originalFormatting).length > 0) {
+    const hasDirectParagraphFormatting =
+      pmAttrs._originalFormatting &&
+      Object.entries(pmAttrs._originalFormatting).some(
+        ([key, value]) => key !== "runProperties" && value !== undefined && value !== null,
+      );
+    if (hasDirectParagraphFormatting) {
       attrs.hasDirectParagraphFormatting = true;
     }
     const paragraphMarkFormatting = pmAttrs._originalFormatting?.runProperties;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1794,6 +1794,9 @@ function convertParagraph(
   );
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
   if (runs.length === 0) {
+    if (pmAttrs._originalFormatting && Object.keys(pmAttrs._originalFormatting).length > 0) {
+      attrs.hasDirectParagraphFormatting = true;
+    }
     const paragraphMarkFormatting = pmAttrs._originalFormatting?.runProperties;
     if (paragraphMarkFormatting?.fontSize !== undefined) {
       attrs.defaultFontSize = paragraphMarkFormatting.fontSize / 2;

--- a/packages/core/src/layout-engine/emptyParagraphSpacing.test.ts
+++ b/packages/core/src/layout-engine/emptyParagraphSpacing.test.ts
@@ -11,11 +11,10 @@ import type {
   PageMargins,
 } from "./types";
 
-// Issue #402 (eigenpal): Word collapses style-inherited spacing on empty
-// paragraphs (only direct `<w:pPr><w:spacing>` formatting survives). The
-// engine consults `attrs.spacingExplicit` to distinguish: if the field for
-// `before`/`after` is falsy, an empty paragraph carries no spacing on that
-// side regardless of what the inherited style would have set.
+// Issue #402 (eigenpal): Word collapses style-inherited spacing on bare empty
+// paragraphs. Direct spacing, an explicitly selected style, or other authored
+// paragraph formatting makes the blank meaningful and preserves the inherited
+// spacing.
 
 const PAGE_SIZE = { w: 600, h: 1200 };
 const MARGINS: PageMargins = { top: 0, right: 0, bottom: 0, left: 0 };
@@ -118,6 +117,24 @@ describe("empty-paragraph spacing collapse (issue #402)", () => {
 
     expect(fragments[1]!.y).toBe(16);
     expect(fragments[2]!.y).toBe(40);
+  });
+
+  test("inherited spacing on a directly formatted empty paragraph is honored", () => {
+    const blocks: FlowBlock[] = [
+      makePara(0, "Heading", { spacing: { after: 0 } }),
+      makePara(1, "", {
+        spacing: { before: 0, after: 80 },
+        hasDirectParagraphFormatting: true,
+      }),
+      makePara(2, "Body", { spacing: { before: 0 } }),
+    ];
+    const measures: Measure[] = [makeMeasure(16), makeMeasure(16), makeMeasure(16)];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    const fragments = layout.pages[0]!.fragments;
+
+    expect(fragments[1]!.y).toBe(16);
+    expect(fragments[2]!.y).toBe(112);
   });
 
   test("non-empty paragraphs always carry their inherited spacing", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -87,9 +87,7 @@ export function collectSectionConfigs(
 
 /**
  * Whether a paragraph block has no visible content (no runs, or a single
- * empty text run). Word collapses style-inherited spacing on empty
- * paragraphs (only direct `<w:pPr><w:spacing>` formatting survives) — see
- * eigenpal #402.
+ * empty text run).
  */
 function isEmptyParagraph(block: ParagraphBlock): boolean {
   if (block.runs.length === 0) {
@@ -130,15 +128,20 @@ function pageHasVisibleBodyContent(
 /**
  * Get spacing before a paragraph block. Empty paragraphs whose
  * `before` came only from the implicit default paragraph style collapse to
- * zero. An explicit `w:pStyle` selection is authored paragraph formatting,
- * so Word keeps the selected style's spacing even when the paragraph is empty.
+ * zero. Word keeps inherited spacing when the empty paragraph itself is
+ * authored through direct `w:pPr` formatting or an explicit `w:pStyle`.
  */
 function getSpacingBefore(block: ParagraphBlock): number {
   const value = block.attrs?.spacing?.before ?? 0;
   if (value === 0) {
     return 0;
   }
-  if (isEmptyParagraph(block) && !block.attrs?.styleId && !block.attrs?.spacingExplicit?.before) {
+  if (
+    isEmptyParagraph(block) &&
+    !block.attrs?.styleId &&
+    !block.attrs?.hasDirectParagraphFormatting &&
+    !block.attrs?.spacingExplicit?.before
+  ) {
     return 0;
   }
   return value;
@@ -153,7 +156,12 @@ function getSpacingAfter(block: ParagraphBlock): number {
   if (value === 0) {
     return 0;
   }
-  if (isEmptyParagraph(block) && !block.attrs?.styleId && !block.attrs?.spacingExplicit?.after) {
+  if (
+    isEmptyParagraph(block) &&
+    !block.attrs?.styleId &&
+    !block.attrs?.hasDirectParagraphFormatting &&
+    !block.attrs?.spacingExplicit?.after
+  ) {
     return 0;
   }
   return value;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -379,6 +379,12 @@ export type ParagraphAttrs = {
    * inheritance assumed) when the field is absent.
    */
   spacingExplicit?: { before?: boolean; after?: boolean };
+  /**
+   * Whether an empty paragraph carries direct paragraph formatting in its
+   * source `w:pPr`. Word treats such a blank as authored and keeps its
+   * inherited spacing; a bare empty paragraph still collapses that spacing.
+   */
+  hasDirectParagraphFormatting?: boolean;
   indent?: ParagraphIndent;
   keepNext?: boolean;
   keepLines?: boolean;


### PR DESCRIPTION
Preserves inherited paragraph spacing when a structurally empty paragraph also carries direct paragraph formatting. Bare empty paragraphs continue to collapse inherited style spacing.

Adds focused conversion and layout regressions plus a core patch changeset. An anonymous parity replay reduced the targeted vertical drift while preserving page count.

CC on behalf of @jan-kubica