### PR TITLE
fix: detect parity font metric mismatches

### DIFF
--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -581,6 +581,48 @@ describe("assessFontEnvironment", () => {
     });
   });
 
+  test("rejects matching family names with persistently different metrics", () => {
+    const lines = Array.from({ length: 8 }, (_, index): [string, string] => [
+      `Line ${index}`,
+      "Arial",
+    ]);
+    const word = fontGeom("word", lines);
+    const folio = fontGeom("folio", lines);
+    for (const line of folio.pages[0]?.lines ?? []) {
+      line.widthPt = 110;
+    }
+
+    const assessment = assessFontEnvironment(["Arial"], word, folio);
+
+    expect(assessment).toEqual({
+      status: "mismatch",
+      tags: ["font-renderer-metric-mismatch"],
+      comparedLines: 8,
+      matchingLines: 8,
+    });
+  });
+
+  test("detects a repeated metric cluster hidden by otherwise stable lines", () => {
+    const lines = Array.from({ length: 32 }, (_, index): [string, string] => [
+      `Line ${index}`,
+      "Arial",
+    ]);
+    const word = fontGeom("word", lines);
+    const folio = fontGeom("folio", lines);
+    for (const line of folio.pages[0]?.lines.slice(0, 8) ?? []) {
+      line.widthPt = 110;
+    }
+
+    const assessment = assessFontEnvironment(["Arial"], word, folio);
+
+    expect(assessment).toEqual({
+      status: "mismatch",
+      tags: ["font-renderer-metric-mismatch"],
+      comparedLines: 32,
+      matchingLines: 32,
+    });
+  });
+
   test("reports unverified when no font-bearing text can be paired", () => {
     const assessment = assessFontEnvironment(
       ["Arial"],

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -249,9 +249,15 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
             `(shared substituted font: ${fontEnvironment.tags.join(", ")}; ${fontEnvironment.comparedLines} lines) `,
           );
         } else if (fontEnvironment.status === "mismatch") {
-          process.stderr.write(
-            `(Word/Folio font mismatch: ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} lines match) `,
-          );
+          if (fontEnvironment.tags.includes("font-renderer-metric-mismatch")) {
+            process.stderr.write(
+              `(Word/Folio font metric mismatch despite ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} matching family names) `,
+            );
+          } else {
+            process.stderr.write(
+              `(Word/Folio font mismatch: ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} lines match) `,
+            );
+          }
         } else if (fontEnvironment.status === "unverified") {
           process.stderr.write("(Word/Folio font parity unverified) ");
         }

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -444,11 +444,13 @@ const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): FontPair[] => 
     }
   }
 
+  for (const lines of folioLinesByText.values()) lines.reverse();
+
   const pairs: FontPair[] = [];
   for (const page of wordGeom.pages) {
     for (const line of page.lines) {
       if (line.fontName === undefined) continue;
-      const folioLine = folioLinesByText.get(line.normText)?.shift();
+      const folioLine = folioLinesByText.get(line.normText)?.pop();
       if (folioLine?.fontName !== undefined) {
         pairs.push({
           wordFont: line.fontName,
@@ -479,8 +481,8 @@ const hasFontMetricMismatch = (pairs: FontPair[]): boolean => {
   const middle = Math.floor(ratios.length / 2);
   const median =
     ratios.length % 2 === 0
-      ? ((ratios.at(middle - 1) ?? 1) + (ratios.at(middle) ?? 1)) / 2
-      : (ratios.at(middle) ?? 1);
+      ? ((ratios[middle - 1] ?? 1) + (ratios[middle] ?? 1)) / 2
+      : (ratios[middle] ?? 1);
   if (Math.abs(median - 1) > FONT_METRIC_RELATIVE_TOLERANCE) return true;
 
   const wider = ratios.filter((ratio) => ratio > 1 + FONT_METRIC_RELATIVE_TOLERANCE).length;

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -25,6 +25,7 @@ import type {
   DivergenceKind,
   DocGeom,
   FeatureAttributedResult,
+  LineBox,
   ParityResult,
 } from "./types";
 
@@ -412,32 +413,79 @@ export const fontFamiliesMatch = (leftRaw: string, rightRaw: string): boolean =>
   return observedSatisfiesRequested(left, right) || observedSatisfiesRequested(right, left);
 };
 
-const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): Array<[string, string]> => {
-  const folioFontsByText = new Map<string, string[]>();
+type FontPair = {
+  wordFont: string;
+  folioFont: string;
+  wordWidthPt: number;
+  folioWidthPt: number;
+};
+
+const MIN_FONT_METRIC_SAMPLES = 8;
+// Short glyph runs are useful probes; very narrow boxes amplify extractor
+// rounding, while long/justified lines mostly measure their container width.
+const MIN_FONT_METRIC_WIDTH_PT = 20;
+const MAX_FONT_METRIC_WIDTH_PT = 200;
+const FONT_METRIC_RELATIVE_TOLERANCE = 0.05;
+// A repeated directional cluster can be hidden by justified lines whose
+// measured width stays stable even when their glyph metrics do not.
+const MIN_FONT_METRIC_OUTLIER_SHARE = 0.25;
+
+const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): FontPair[] => {
+  const folioLinesByText = new Map<string, LineBox[]>();
   for (const page of folioGeom.pages) {
     for (const line of page.lines) {
       if (line.fontName === undefined) continue;
-      const fonts = folioFontsByText.get(line.normText);
-      if (fonts) {
-        fonts.push(line.fontName);
+      const lines = folioLinesByText.get(line.normText);
+      if (lines) {
+        lines.push(line);
       } else {
-        folioFontsByText.set(line.normText, [line.fontName]);
+        folioLinesByText.set(line.normText, [line]);
       }
     }
   }
 
-  const pairs: Array<[string, string]> = [];
+  const pairs: FontPair[] = [];
   for (const page of wordGeom.pages) {
     for (const line of page.lines) {
       if (line.fontName === undefined) continue;
-      const folioFonts = folioFontsByText.get(line.normText);
-      const folioFont = folioFonts?.shift();
-      if (folioFont !== undefined) {
-        pairs.push([line.fontName, folioFont]);
+      const folioLine = folioLinesByText.get(line.normText)?.shift();
+      if (folioLine?.fontName !== undefined) {
+        pairs.push({
+          wordFont: line.fontName,
+          folioFont: folioLine.fontName,
+          wordWidthPt: line.widthPt,
+          folioWidthPt: folioLine.widthPt,
+        });
       }
     }
   }
   return pairs;
+};
+
+const hasFontMetricMismatch = (pairs: FontPair[]): boolean => {
+  const ratios = pairs
+    .filter(
+      ({ wordFont, folioFont, wordWidthPt, folioWidthPt }) =>
+        fontFamiliesMatch(wordFont, folioFont) &&
+        wordWidthPt >= MIN_FONT_METRIC_WIDTH_PT &&
+        folioWidthPt >= MIN_FONT_METRIC_WIDTH_PT &&
+        wordWidthPt <= MAX_FONT_METRIC_WIDTH_PT &&
+        folioWidthPt <= MAX_FONT_METRIC_WIDTH_PT,
+    )
+    .map(({ wordWidthPt, folioWidthPt }) => folioWidthPt / wordWidthPt)
+    .toSorted((a, b) => a - b);
+  if (ratios.length < MIN_FONT_METRIC_SAMPLES) return false;
+
+  const middle = Math.floor(ratios.length / 2);
+  const median =
+    ratios.length % 2 === 0
+      ? ((ratios.at(middle - 1) ?? 1) + (ratios.at(middle) ?? 1)) / 2
+      : (ratios.at(middle) ?? 1);
+  if (Math.abs(median - 1) > FONT_METRIC_RELATIVE_TOLERANCE) return true;
+
+  const wider = ratios.filter((ratio) => ratio > 1 + FONT_METRIC_RELATIVE_TOLERANCE).length;
+  const narrower = ratios.filter((ratio) => ratio < 1 - FONT_METRIC_RELATIVE_TOLERANCE).length;
+  return Math.max(wider, narrower) / ratios.length >= MIN_FONT_METRIC_OUTLIER_SHARE;
 };
 
 /** Classify the actual fonts resolved by Word and Chromium. Requested-font
@@ -453,9 +501,10 @@ export const assessFontEnvironment = (
   );
   const substitutionTags = computeFontSubstitutionTags(requestedFonts, observedWordFonts);
   const pairs = collectFontPairs(wordGeom, folioGeom);
-  const matchingLines = pairs.filter(([wordFont, folioFont]) =>
+  const matchingLines = pairs.filter(({ wordFont, folioFont }) =>
     fontFamiliesMatch(wordFont, folioFont),
   ).length;
+  const metricMismatch = hasFontMetricMismatch(pairs);
 
   if (pairs.length === 0) {
     return {
@@ -465,10 +514,14 @@ export const assessFontEnvironment = (
       matchingLines: 0,
     };
   }
-  if (matchingLines !== pairs.length) {
+  if (matchingLines !== pairs.length || metricMismatch) {
     return {
       status: "mismatch",
-      tags: ["font-renderer-mismatch", ...substitutionTags],
+      tags: [
+        ...(matchingLines !== pairs.length ? ["font-renderer-mismatch"] : []),
+        ...(metricMismatch ? ["font-renderer-metric-mismatch"] : []),
+        ...substitutionTags,
+      ],
       comparedLines: pairs.length,
       matchingLines,
     };


### PR DESCRIPTION
## Summary

- compare paired short-line ink widths in addition to renderer-reported font family names
- flag persistent metric disagreement even when Word and Chromium report the same family
- distinguish metric mismatches in CLI diagnostics so layout agents do not chase typography-environment noise

## Validation

- parity tooling suite: 118/118
- anonymous replay now identifies a repeated 9.8% metric discrepancy despite 98/98 matching family names
- three anonymous control replays remain accepted without metric-mismatch warnings
- `bun audit`: clean
- lint and typecheck run in CI

CC on behalf of @jan-kubica