### PR TITLE
fix: ignore unused tab stops in justified wrapping

### DIFF
--- a/.changeset/ignore-unused-tab-stops.md
+++ b/.changeset/ignore-unused-tab-stops.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Use normal justified prose wrapping when tab-stop metadata has no corresponding tab content.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -397,13 +397,13 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("keeps first-line tabbed legal prose on the conservative shrink tolerance", () => {
+  test("ignores unused tab stops when choosing justified prose shrink tolerance", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
           {
             kind: "paragraph",
-            id: "justified-tabbed-first-line",
+            id: "justified-unused-tab-stop",
             runs: [{ kind: "text", text }],
             attrs: {
               alignment: "justify",
@@ -411,10 +411,10 @@ describe("measureParagraph justified shrink tolerance", () => {
               tabs: [{ val: "start", pos: 360 }],
             },
           },
-          100,
+          147.8,
         );
 
-        expect(measure.lines).toHaveLength(2);
+        expect(measure.lines).toHaveLength(1);
       },
       {
         charWidth: fractionalWidth,

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -586,7 +586,7 @@ function justifyShrinkToleranceRatio(
   if (!isFirstLine && hasTabRuns && !hasTabStops) {
     return JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO;
   }
-  if ((isFirstLine || hasTabStops) && (hasTabStops || hasTabRuns)) {
+  if (hasTabRuns && (isFirstLine || hasTabStops)) {
     return (block.attrs?.indent?.firstLine ?? 0) === 0
       ? JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO
       : JUSTIFY_SHRINK_TOLERANCE_RATIO;


### PR DESCRIPTION
## Summary

- apply tab-specific justified shrink tolerances only when a paragraph contains tab content
- keep authored but unused tab-stop metadata from changing normal prose wrapping
- cover the distinction with a focused synthetic regression and a patch changeset

## Validation

- `bun test` in `packages/core` (3,069 passed, 2 optional differential checks skipped)
- `bun audit` (no vulnerabilities found)
- anonymous parity replay: 92.0% to 96.0%, page count preserved at 3/3

CC on behalf of @jan-kubica