### PR TITLE
fix: collapse paintless trailing spaces

### DIFF
--- a/.changeset/collapse-line-end-spaces.md
+++ b/.changeset/collapse-line-end-spaces.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Collapse paintless trailing spaces when positioning aligned paragraph lines.

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -95,6 +95,110 @@ describe("renderLine box model", () => {
     expect(lineEl.style["overflow"]).toBe("visible");
   });
 
+  test("collapses paintless trailing spaces without losing their document positions", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "right-aligned-reference",
+      runs: [{ kind: "text", text: "Reference   ", pmStart: 10, pmEnd: 22 }],
+      attrs: { alignment: "right" },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: "Reference   ".length,
+      width: 63,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const [text, spaces] = lineEl.children;
+
+    expect(text?.textContent).toBe("Reference");
+    expect(text?.dataset["pmStart"]).toBe("10");
+    expect(text?.dataset["pmEnd"]).toBe("19");
+    expect(spaces?.textContent).toBe("   ");
+    expect(spaces?.dataset["pmStart"]).toBe("19");
+    expect(spaces?.dataset["pmEnd"]).toBe("22");
+    expect(spaces?.dataset["collapsedTrailingSpaces"]).toBe("true");
+    expect(spaces?.style["fontSize"]).toBe("0");
+  });
+
+  test("collapses trailing spaces split across authored runs", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "split-trailing-spaces",
+      runs: [
+        { kind: "text", text: "Reference", pmStart: 10, pmEnd: 19 },
+        { kind: "text", text: " ", pmStart: 19, pmEnd: 20 },
+        { kind: "text", text: "  ", pmStart: 20, pmEnd: 22 },
+      ],
+      attrs: { alignment: "right" },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 2,
+      width: 63,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.children.map((child) => child.textContent)).toEqual(["Reference", " ", "  "]);
+    expect(lineEl.children.map((child) => child.style["fontSize"])).toEqual([undefined, "0", "0"]);
+  });
+
+  test("keeps decorated trailing spaces paintable", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "underlined-signature",
+      runs: [{ kind: "text", text: "Signature   ", underline: true }],
+      attrs: { alignment: "right" },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: "Signature   ".length,
+      width: 84,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const [text] = lineEl.children;
+
+    expect(lineEl.children).toHaveLength(1);
+    expect(text?.textContent).toBe("Signature   ");
+    expect(text?.dataset["collapsedTrailingSpaces"]).toBeUndefined();
+    expect(text?.style["fontSize"]).toBeUndefined();
+  });
+
   test("renders underlined tabs as a continuous rule without a text underline mark", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1262,6 +1262,78 @@ export function splitTextRunsByEastAsia(runs: Run[]): Run[] {
   return result;
 }
 
+type CollapsibleTrailingSpacesResult = {
+  runs: Run[];
+  collapsedRuns: Set<TextRun>;
+};
+
+const paintsTrailingSpaces = (run: TextRun): boolean =>
+  Boolean(
+    run.underline ||
+    run.strike ||
+    run.highlight ||
+    run.shading ||
+    run.hyperlink ||
+    run.hidden ||
+    run.templatePreview ||
+    run.isInsertion ||
+    run.isDeletion ||
+    run.commentIds?.length ||
+    run.textEffect ||
+    run.emphasisMark,
+  );
+
+const splitTextRunAt = (run: TextRun, index: number): [TextRun, TextRun] => {
+  const leading = { ...run, text: run.text.slice(0, index) };
+  const trailing = { ...run, text: run.text.slice(index) };
+  if (run.pmStart === undefined) {
+    return [leading, trailing];
+  }
+
+  const splitPosition = Math.min(run.pmStart + index, run.pmEnd ?? Number.POSITIVE_INFINITY);
+  leading.pmEnd = splitPosition;
+  trailing.pmStart = splitPosition;
+  return [leading, trailing];
+};
+
+/**
+ * Word keeps ordinary trailing spaces addressable in the document model but
+ * gives them no painted advance at a visual line end. Measurement already
+ * excludes that advance; split the paint runs to preserve exact PM ranges
+ * while allowing the trailing suffix to collapse in the DOM as well.
+ */
+const splitCollapsibleTrailingSpaces = (sourceRuns: Run[]): CollapsibleTrailingSpacesResult => {
+  const runs = [...sourceRuns];
+  const collapsedRuns = new Set<TextRun>();
+
+  for (let index = runs.length - 1; index >= 0; index--) {
+    const run = runs[index];
+    if (!run || !isTextRun(run)) {
+      break;
+    }
+    if (run.text.length === 0) {
+      continue;
+    }
+
+    const trailingSpaces = / +$/u.exec(run.text);
+    if (!trailingSpaces || paintsTrailingSpaces(run)) {
+      break;
+    }
+
+    if (trailingSpaces.index === 0) {
+      collapsedRuns.add(run);
+      continue;
+    }
+
+    const [leading, trailing] = splitTextRunAt(run, trailingSpaces.index);
+    runs.splice(index, 1, leading, trailing);
+    collapsedRuns.add(trailing);
+    break;
+  }
+
+  return { runs, collapsedRuns };
+};
+
 /**
  * Options for rendering a line with justify support
  */
@@ -1615,7 +1687,17 @@ export function renderLine(
   lineEl.style.lineHeight = `${line.lineHeight}px`;
 
   // Get runs for this line
-  const runsForLine = splitTextRunsByEastAsia(sliceRunsForLine(block, line));
+  const splitRuns = splitTextRunsByEastAsia(sliceRunsForLine(block, line));
+  const { runs: runsForLine, collapsedRuns: collapsedTrailingSpaceRuns } =
+    splitCollapsibleTrailingSpaces(splitRuns);
+  const renderLineTextRun = (run: TextRun): HTMLElement => {
+    const runEl = renderTextRun(run, doc);
+    if (collapsedTrailingSpaceRuns.has(run)) {
+      runEl.dataset["collapsedTrailingSpaces"] = "true";
+      runEl.style.fontSize = "0";
+    }
+    return runEl;
+  };
   // OOXML `<m:oMathPara>` (display math) defaults to `jc="centerGroup"` —
   // Word renders display math centred on its own paragraph. When the line
   // holds a single block math run, centre it horizontally so the equation
@@ -1934,7 +2016,7 @@ export function renderLine(
             break;
           }
           if (isTextRun(next)) {
-            lineEl.append(renderTextRun(next, doc));
+            lineEl.append(renderLineTextRun(next));
           } else if (isFieldRun(next) && options?.context) {
             lineEl.append(renderFieldRun(next, doc, options.context));
           } else if (isImageRun(next)) {
@@ -1986,11 +2068,14 @@ export function renderLine(
       // Update X position
       currentX += tabWidth;
     } else if (isTextRun(run)) {
-      const runEl = renderTextRun(run, doc);
+      const runEl = renderLineTextRun(run);
 
       lineEl.append(runEl);
 
       // Measure text width for accurate tab position tracking
+      if (collapsedTrailingSpaceRuns.has(run)) {
+        continue;
+      }
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
       const measuredWidth = measureText(


### PR DESCRIPTION
## Summary

- collapse ordinary line-end spaces so aligned visible text uses the measured width
- preserve document-position spans for editing and keep decorated spaces paintable
- add focused rendering regression coverage

CC on behalf of @jan-kubica