### PR TITLE
fix: preserve hanging indent tab anchors

### DIFF
--- a/.changeset/calm-tabs-anchor.md
+++ b/.changeset/calm-tabs-anchor.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve hanging-indent body tab positions during line wrapping.

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -53,6 +53,58 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
     });
   });
 
+  test("keeps a hanging-indent tab anchored at the paragraph body edge", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "hanging-body-left-tab",
+          runs: [
+            { kind: "text", text: "abc", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "a".repeat(25), fontSize: 11 },
+          ],
+          attrs: {
+            indent: { left: 30, hanging: 30 },
+          },
+        },
+        150,
+      );
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines[0]?.toRun).toBe(1);
+      expect(measure.lines[1]?.fromRun).toBe(2);
+    });
+  });
+
+  test("uses conservative justification after a hanging-indent body tab", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-hanging-body-tab",
+            runs: [
+              { kind: "text", text: "abc", fontSize: 11 },
+              { kind: "tab" },
+              { kind: "text", text: `${"a".repeat(24)}z`, fontSize: 11 },
+            ],
+            attrs: {
+              alignment: "justify",
+              indent: { left: 30, hanging: 30 },
+            },
+          },
+          150,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: (char) => (char === "z" ? 2.7 : 5),
+      },
+    );
+  });
+
   test("non-leading left tab keeps its stop before multi-line prose", () => {
     withFakeTextMeasure(() => {
       const measure = measureParagraph(

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -583,6 +583,9 @@ function justifyShrinkToleranceRatio(
   }
   const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
   const hasTabRuns = block.runs.some(isTabRun);
+  if (isFirstLine && hasTabRuns && (block.attrs?.indent?.hanging ?? 0) > 0) {
+    return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  }
   if (!isFirstLine && hasTabRuns && !hasTabStops) {
     return JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO;
   }
@@ -1153,6 +1156,10 @@ export function measureParagraph(
         decimalPrefixWidth,
       });
       let tabWidth = tabResult.width;
+      const landsOnLeftIndent =
+        tabResult.alignment === "start" &&
+        indentLeft > 0 &&
+        Math.abs(contentX + tabWidth - indentLeft) <= WIDTH_TOLERANCE;
 
       const lineRightEdgeX =
         indentLeft +
@@ -1160,6 +1167,7 @@ export function measureParagraph(
         currentLine.availableWidth +
         currentLine.leftOffset;
       if (
+        !landsOnLeftIndent &&
         !hasFollowingTabOnLine(runs, runIndex) &&
         canClampTabToRightEdge(
           tabResult.alignment,

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -145,6 +145,41 @@ describe("renderLine right-tab flex anchor", () => {
     expect(tabEl?.style["width"]).toBe("3px");
   });
 
+  test("does not clamp the tab that anchors a hanging-indent body", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "hanging-body-left-tab",
+      runs: [
+        { kind: "text", text: "abc" },
+        { kind: "tab" },
+        { kind: "text", text: "abcdefghijklmnopqr" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 18,
+      width: 150,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 150,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      firstLineIndentPx: -30,
+      leftIndentPx: 30,
+      lineRightEdgePx: 150,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl?.style["width"]).toBe("9px");
+  });
+
   test("does not clamp a non-leading left tab on a non-final line", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1962,7 +1962,12 @@ export function renderLine(
       // the content area (Word TOC styles author stops a hair beyond the
       // margin); without this, the painted tab spills into the right margin.
       let tabWidth = tabResult.width;
+      const landsOnLeftIndent =
+        tabResult.alignment === "start" &&
+        leftIndentPx > 0 &&
+        Math.abs(currentX + tabWidth - leftIndentPx) <= RIGHT_EDGE_EPSILON_PX;
       if (
+        !landsOnLeftIndent &&
         lineRightEdgeX !== undefined &&
         canClampTabToRightEdge(
           tabResult.alignment,


### PR DESCRIPTION
## Summary

- keep start tabs that land on the paragraph left indent at their authored position during measurement and painting
- use the conservative justification threshold for first-line literal tabs in hanging-indent paragraphs
- add paired measurement and painter regressions

## Validation

- focused tests: 18 passed
- anonymous strict same-font replay: 90.7% to 96.2%; pages remain 7/7; pagination divergences drop from 6 to 1
- `bun audit`: no vulnerabilities found
- lint, typecheck, full tests, and build are delegated to CI

## Security

- no new I/O, persistence, authentication, authorization, or data-handling paths
- change is limited to deterministic tab geometry and line wrapping

CC on behalf of @jan-kubica