### PR TITLE
fix: collapse terminal table anchors

### DIFF
--- a/.changeset/quiet-terminal-anchors.md
+++ b/.changeset/quiet-terminal-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Prevent paintless terminal table anchors from creating blank pages.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -757,6 +757,89 @@ describe("toFlowBlocks table cell formatting", () => {
     expect(cells?.at(0)?.blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBe(true);
     expect(cells?.at(1)?.blocks.at(0)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
   });
+
+  test("suppresses a terminal run of empty body paragraphs after a final table", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("content")]),
+          ]),
+        ]),
+      ]),
+      schema.node("paragraph", { tabs: [{ position: 360, alignment: "left" }] }),
+      schema.node("paragraph", {
+        _originalFormatting: { runProperties: { italic: true } },
+      }),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["table", "paragraph", "paragraph"]);
+    expect(
+      blocks
+        .slice(1)
+        .map((block) =>
+          block.kind === "paragraph" ? block.attrs?.suppressEmptyParagraphHeight : undefined,
+        ),
+    ).toEqual([true, true]);
+  });
+
+  test("keeps terminal empty paragraph height when the preceding block is prose", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("content")]),
+        schema.node("paragraph"),
+      ]),
+    );
+
+    expect(blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
+
+  test("keeps terminal empty paragraph height when the document contains only empty paragraphs", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [schema.node("paragraph"), schema.node("paragraph")]),
+    );
+
+    expect(blocks.map((block) => block.attrs?.suppressEmptyParagraphHeight)).toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
+  test("keeps a visible empty list item after a final table", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("table", null, [
+          schema.node("tableRow", null, [
+            schema.node("tableCell", null, [schema.node("paragraph")]),
+          ]),
+        ]),
+        schema.node("paragraph", {
+          numPr: { numId: 1, ilvl: 0 },
+          listMarker: "1.",
+        }),
+      ]),
+    );
+
+    expect(blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
+
+  test("keeps empty paragraphs between a table and later body content", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("table", null, [
+          schema.node("tableRow", null, [
+            schema.node("tableCell", null, [schema.node("paragraph")]),
+          ]),
+        ]),
+        schema.node("paragraph"),
+        schema.node("paragraph", null, [schema.text("later content")]),
+      ]),
+    );
+
+    expect(blocks.at(1)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
 });
 
 describe("toFlowBlocks list numbering", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1834,6 +1834,56 @@ function convertParagraph(
 }
 
 /**
+ * Word keeps terminal empty body paragraphs after a final table as editable
+ * anchors, but they do not create a page of their own. Preserve every block
+ * and PM range while collapsing only the contiguous, run-free suffix; empty
+ * paragraphs elsewhere still retain their normal line height.
+ */
+function isPaintlessTerminalParagraph(block: FlowBlock | undefined): block is ParagraphBlock {
+  if (block?.kind !== "paragraph" || block.runs.length !== 0) {
+    return false;
+  }
+
+  const attrs = block.attrs;
+  return !(
+    (attrs?.listMarker !== undefined && !attrs.listMarkerHidden) ||
+    attrs?.borders?.top ||
+    attrs?.borders?.bottom ||
+    attrs?.borders?.left ||
+    attrs?.borders?.right ||
+    attrs?.borders?.between ||
+    attrs?.borders?.bar ||
+    attrs?.shading ||
+    attrs?.spacingExplicit?.before ||
+    attrs?.spacingExplicit?.after ||
+    attrs?.pageBreakBefore ||
+    attrs?.renderedPageBreakBefore
+  );
+}
+
+function suppressTerminalEmptyParagraphsAfterTable(blocks: FlowBlock[]): void {
+  let suffixStart = blocks.length;
+  while (suffixStart > 0 && isPaintlessTerminalParagraph(blocks[suffixStart - 1])) {
+    suffixStart -= 1;
+  }
+
+  if (
+    suffixStart === blocks.length ||
+    suffixStart === 0 ||
+    blocks[suffixStart - 1]?.kind !== "table"
+  ) {
+    return;
+  }
+
+  for (let index = suffixStart; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    if (isPaintlessTerminalParagraph(block)) {
+      block.attrs = { ...block.attrs, suppressEmptyParagraphHeight: true };
+    }
+  }
+}
+
+/**
  * Convert border width from eighths of a point to pixels.
  * OOXML stores border widths in eighths of a point.
  */
@@ -2669,6 +2719,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     visit(node, offset + nodeOffset);
   });
 
+  suppressTerminalEmptyParagraphsAfterTable(blocks);
   return mergeRunInParagraphs(blocks);
 }
 


### PR DESCRIPTION
## Summary

- keep a contiguous run-free suffix after a final table as zero-height editable anchors
- preserve normal layout for empty prose, list items, explicit spacing, borders, shading, and authored page breaks
- add positive and cross-case conversion regressions

## Validation

- focused conversion tests: 62 passed
- anonymous strict same-font replay: 89.3% to 91.4%; Folio pagination changes from 10 pages to the matching 9 pages; divergences drop from 85 to 59
- `bun audit`: no vulnerabilities found
- lint, typecheck, full tests, and build are delegated to CI

## Security

- no new I/O, persistence, authentication, authorization, or data-handling paths
- existing document and PM ranges remain intact; only terminal layout height changes

CC on behalf of @jan-kubica