### PR TITLE
fix: keep table separators with following content

### DIFF
--- a/.changeset/calm-pages-follow.md
+++ b/.changeset/calm-pages-follow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep trailing table separators with following page content.

--- a/packages/core/src/layout-engine/keep-together.test.ts
+++ b/packages/core/src/layout-engine/keep-together.test.ts
@@ -16,6 +16,12 @@ const emptyParagraph = (id: string): ParagraphBlock => ({
   runs: [],
 });
 
+const table = (id: string): FlowBlock => ({
+  kind: "table",
+  id,
+  rows: [],
+});
+
 const paragraphMeasure = (...lineHeights: number[]): ParagraphMeasure => ({
   kind: "paragraph",
   lines: lineHeights.map((lineHeight) => ({
@@ -79,6 +85,52 @@ describe("calculateChainHeight", () => {
       ),
     ).toBe(42);
   });
+
+  test("reserves two anchor lines after a trailing table separator", () => {
+    const blocks: FlowBlock[] = [table("table"), emptyParagraph("separator"), paragraph("body")];
+    const measures: Measure[] = [
+      { kind: "table", rows: [], columnWidths: [], totalWidth: 0, totalHeight: 100 },
+      paragraphMeasure(12),
+      paragraphMeasure(14, 14, 14),
+    ];
+
+    expect(
+      calculateChainHeight(
+        {
+          startIndex: 1,
+          endIndex: 1,
+          memberIndices: [1],
+          anchorIndex: 2,
+        },
+        blocks,
+        measures,
+      ),
+    ).toBe(40);
+  });
+
+  test("reserves one anchor line when widow control is disabled", () => {
+    const anchor = paragraph("body");
+    anchor.attrs = { widowControl: false };
+    const blocks: FlowBlock[] = [table("table"), emptyParagraph("separator"), anchor];
+    const measures: Measure[] = [
+      { kind: "table", rows: [], columnWidths: [], totalWidth: 0, totalHeight: 100 },
+      paragraphMeasure(12),
+      paragraphMeasure(14, 14, 14),
+    ];
+
+    expect(
+      calculateChainHeight(
+        {
+          startIndex: 1,
+          endIndex: 1,
+          memberIndices: [1],
+          anchorIndex: 2,
+        },
+        blocks,
+        measures,
+      ),
+    ).toBe(26);
+  });
 });
 
 describe("computeKeepNextChains", () => {
@@ -95,5 +147,26 @@ describe("computeKeepNextChains", () => {
       memberIndices: [0, 1],
       anchorIndex: 2,
     });
+  });
+
+  test("carries a trailing table separator to the next content paragraph", () => {
+    const blocks: FlowBlock[] = [table("table"), emptyParagraph("separator"), paragraph("body")];
+
+    expect(computeKeepNextChains(blocks).get(1)).toEqual({
+      startIndex: 1,
+      endIndex: 1,
+      memberIndices: [1],
+      anchorIndex: 2,
+    });
+  });
+
+  test("does not implicitly keep an ordinary empty paragraph with the next paragraph", () => {
+    const blocks: FlowBlock[] = [
+      paragraph("body before"),
+      emptyParagraph("separator"),
+      paragraph("body after"),
+    ];
+
+    expect(computeKeepNextChains(blocks)).toEqual(new Map());
   });
 });

--- a/packages/core/src/layout-engine/keep-together.ts
+++ b/packages/core/src/layout-engine/keep-together.ts
@@ -8,8 +8,9 @@
 import type { FlowBlock, ParagraphBlock, Measure } from "./types";
 
 /**
- * A chain of keepNext-linked paragraphs, including empty separators Word
- * carries through to the next paragraph with visible content.
+ * A chain of paragraphs that Word keeps with following content. This includes
+ * explicit keepNext links and a trailing table separator that would otherwise
+ * be stranded at the bottom of a page.
  */
 export type KeepNextChain = {
   /** Index of the first paragraph in the chain. */
@@ -33,12 +34,36 @@ function isVisuallyEmptyParagraph(block: ParagraphBlock): boolean {
   return run?.kind === "text" && run.text === "";
 }
 
+function startsTrailingTableSeparatorChain(blocks: FlowBlock[], index: number): boolean {
+  const block = blocks[index];
+  if (
+    block?.kind !== "paragraph" ||
+    !isVisuallyEmptyParagraph(block) ||
+    blocks[index - 1]?.kind !== "table"
+  ) {
+    return false;
+  }
+
+  for (let nextIndex = index + 1; nextIndex < blocks.length; nextIndex++) {
+    const nextBlock = blocks[nextIndex];
+    if (nextBlock?.kind !== "paragraph") {
+      return false;
+    }
+    if (!isVisuallyEmptyParagraph(nextBlock)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Pre-scan blocks to find all keepNext chains.
  *
- * A keepNext chain starts with a paragraph whose keepNext=true and continues
- * through further keepNext paragraphs and structural empty separators. The
- * first visible non-keepNext paragraph is its anchor.
+ * A chain starts with a paragraph whose keepNext=true or with an empty
+ * separator immediately following a table. It continues through further
+ * keepNext paragraphs and structural empty separators. The first visible
+ * non-keepNext paragraph is its anchor.
  *
  * Returns a map from chain start index to chain info.
  */
@@ -60,8 +85,9 @@ export function computeKeepNextChains(blocks: FlowBlock[]): Map<number, KeepNext
     }
 
     const para = block;
-    // Skip paragraphs without keepNext
-    if (!para.attrs?.keepNext) {
+    // Word carries a trailing table separator to the next visible paragraph
+    // instead of leaving the blank at the bottom of the preceding page.
+    if (!para.attrs?.keepNext && !startsTrailingTableSeparatorChain(blocks, i)) {
       continue;
     }
 
@@ -156,6 +182,10 @@ export function calculateChainHeight(
 
   let totalHeight = (firstBlock.attrs?.spacing?.before ?? 0) + firstMeasure.totalHeight;
   let trailingSpacing = firstBlock.attrs?.spacing?.after ?? 0;
+  const startsWithTrailingTableSeparator =
+    blocks[firstMemberIndex - 1]?.kind === "table" &&
+    isVisuallyEmptyParagraph(firstBlock) &&
+    !firstBlock.attrs?.keepNext;
 
   const successorIndices = [...chain.memberIndices.slice(1)];
   if (chain.anchorIndex !== -1) {
@@ -181,6 +211,15 @@ export function calculateChainHeight(
 
     const isAnchor = index === successorIndices.length - 1 && chain.anchorIndex !== -1;
     const isSplittable = successorMeasure.lines.length > 1 && !successorBlock.attrs?.keepLines;
+    if (
+      isAnchor &&
+      startsWithTrailingTableSeparator &&
+      successorBlock.attrs?.widowControl !== false &&
+      successorMeasure.lines.length > 1
+    ) {
+      const secondLine = successorMeasure.lines.at(1);
+      return totalHeight + firstLine.lineHeight + (secondLine?.lineHeight ?? 0);
+    }
     if (isAnchor || isSplittable) {
       return totalHeight + firstLine.lineHeight;
     }


### PR DESCRIPTION
## Summary

- keep a structural separator after a table with its following visible paragraph at natural page boundaries
- reserve the second anchor line when default widow control applies
- leave ordinary blank paragraphs and widow-control-off anchors unchanged

## Verification

- focused pagination tests pass
- an anonymous strict same-font parity replay preserved page count and reduced the targeted page-boundary drift
- dependency audit reports no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica