### PR TITLE
fix: avoid whitespace-only soft-wrap lines

### DIFF
--- a/.changeset/soft-space-wrap.md
+++ b/.changeset/soft-space-wrap.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Avoid whitespace-only lines when preserved spaces overflow a soft wrap.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -270,6 +270,50 @@ describe("measureParagraph cross-run line breaking", () => {
     }, fakeMeasure);
   });
 
+  test("does not soft-wrap overflowed preserved spaces onto their own lines", () => {
+    withFakeTextMeasure(() => {
+      const spaces = " ".repeat(12);
+      const text = `alpha${spaces}beta`;
+      const { lines } = measureParagraph(paragraph([{ kind: "text", text }]), width("alpha"));
+
+      expect(lines).toHaveLength(2);
+      expect(lines[0]?.width).toBe(width("alpha"));
+      expect(lines[1]).toMatchObject({
+        fromRun: 0,
+        fromChar: "alpha".length + spaces.length,
+      });
+      expect(lines[1]?.width).toBe(width("beta"));
+    }, fakeMeasure);
+  });
+
+  test("preserves leading and fitting internal spaces", () => {
+    withFakeTextMeasure(() => {
+      const text = "  alpha   beta";
+      const { lines } = measureParagraph(paragraph([{ kind: "text", text }]), width(text));
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ fromRun: 0, fromChar: 0, width: width(text) });
+    }, fakeMeasure);
+  });
+
+  test("preserves leading spaces after an explicit line break", () => {
+    withFakeTextMeasure(() => {
+      const runs: Run[] = [
+        { kind: "text", text: "alpha" },
+        { kind: "lineBreak" },
+        { kind: "text", text: "  beta" },
+      ];
+      const { lines } = measureParagraph(paragraph(runs), width("  beta"));
+
+      expect(lines).toHaveLength(2);
+      expect(lines[1]).toMatchObject({
+        fromRun: 2,
+        fromChar: 0,
+        width: width("  beta"),
+      });
+    }, fakeMeasure);
+  });
+
   test("keeps a split leading hyphen glued to the preceding run", () => {
     withFakeTextMeasure(() => {
       const runs: Run[] = [

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -1484,7 +1484,11 @@ export function measureParagraph(
           wordWidth + rawGlueWidth <= getPostWrapAvailableWidth() + widthTolerance
             ? rawGlueWidth
             : 0;
+        // Let collapsible whitespace remain at the previous line's tail until
+        // visible content decides whether to wrap. Starting a line from an
+        // overflowed space creates whitespace-only soft-wrap lines.
         if (
+          wordWidth > 0 &&
           currentLine.width > 0 &&
           currentLine.width + wordWidth + glueWidth > currentLine.availableWidth + widthTolerance
         ) {
@@ -1496,7 +1500,13 @@ export function measureParagraph(
 
         // Add word to current line
         currentLine.width += fullWordWidth;
-        currentLine.trailingWhitespaceWidth = fullWordWidth - wordWidth;
+        const wordTrailingWhitespaceWidth = fullWordWidth - wordWidth;
+        // `findWordBreaks` yields each ASCII space separately, so consecutive
+        // trailing segments must accumulate until visible content follows.
+        currentLine.trailingWhitespaceWidth =
+          wordWidth === 0
+            ? currentLine.trailingWhitespaceWidth + wordTrailingWhitespaceWidth
+            : wordTrailingWhitespaceWidth;
         currentLine.regularSpaceCount += word.split(" ").length - 1;
         currentLine.nonBreakingSpaceCount += word.split("\u00a0").length - 1;
         currentLine.toRun = runIndex;


### PR DESCRIPTION
## Summary

- keep overflowed preserved spaces at the previous soft-wrap boundary in measurement
- avoid allocating whitespace-only measured line boxes before the next visible content
- preserve intentional leading spaces, fitting internal spaces, and spaces after explicit line breaks

## Verification

- focused line-breaking tests pass
- after rebasing onto the complementary painter fix, an anonymous strict same-font parity replay improved from 89.5% to 90.4% while preserving page count
- dependency audit reports no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica