### PR TITLE
fix: coalesce rendered reflow boundaries

### DIFF
--- a/.changeset/calm-rendered-boundaries.md
+++ b/.changeset/calm-rendered-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Coalesce cached page markers with pages opened by keep-next chains and paragraph continuations.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -482,6 +482,120 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2, 3, 4]);
     });
 
+    test("rendered page break reuses a page opened by a keep-next chain", () => {
+      const marker = {
+        ...makeParagraphBlock(3, "Cached boundary", 61),
+        attrs: { renderedPageBreakBefore: true },
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        makeParagraphBlock(1, "Heading", 23, { keepNext: true }),
+        makeParagraphBlock(2, "Kept body", 31),
+        marker,
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 810)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 7, 100, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 9, 100, 40)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 15, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2, 3]);
+    });
+
+    test("rendered page break reuses a page containing a paragraph continuation", () => {
+      const continued = makeParagraphBlock(
+        1,
+        "A paragraph whose measured lines continue across the page boundary",
+        23,
+      );
+      const marker = {
+        ...makeParagraphBlock(2, "Cached boundary", 90),
+        attrs: { renderedPageBreakBefore: true },
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        continued,
+        marker,
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 800)]),
+        makeParagraphMeasure([
+          makeLine(0, 0, 0, 31, 200, 40),
+          makeLine(0, 32, 0, 64, 200, 40),
+        ]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 15, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0, 1]);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
+    });
+
+    test("rendered page break remains authoritative after a whole paragraph moves", () => {
+      const previousItem = {
+        ...makeParagraphBlock(1, "Moves intact", 23),
+        attrs: { numPr: { numId: 4, ilvl: 1 } },
+      };
+      const marker = {
+        ...makeParagraphBlock(2, "Cached boundary", 50),
+        attrs: {
+          numPr: { numId: 4, ilvl: 0 },
+          renderedPageBreakBefore: true,
+        },
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        previousItem,
+        marker,
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 840)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 40)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 15, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(3);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
+      expect(layout.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual([2]);
+    });
+
+    test("rendered page break reuses a page opened within one numbered sequence", () => {
+      const previousItem = {
+        ...makeParagraphBlock(1, "Moves intact", 23),
+        attrs: { numPr: { numId: 4, ilvl: 1 } },
+      };
+      const marker = {
+        ...makeParagraphBlock(2, "Cached boundary", 50),
+        attrs: {
+          numPr: { numId: 4, ilvl: 1 },
+          renderedPageBreakBefore: true,
+        },
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        previousItem,
+        marker,
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 840)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 40)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 15, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
+    });
+
     test("successive rendered page breaks remain authoritative after natural reflow", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Fill page one", 1),

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -523,10 +523,7 @@ describe("Layout Engine - Page Production", () => {
       ];
       const measures: Measure[] = [
         makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 800)]),
-        makeParagraphMeasure([
-          makeLine(0, 0, 0, 31, 200, 40),
-          makeLine(0, 32, 0, 64, 200, 40),
-        ]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 31, 200, 40), makeLine(0, 32, 0, 64, 200, 40)]),
         makeParagraphMeasure([makeLine(0, 0, 0, 15, 100, 24)]),
       ];
 

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -125,6 +125,20 @@ function pageHasVisibleBodyContent(
   return false;
 }
 
+function continuesNumberedSequence(previous: FlowBlock | undefined, current: FlowBlock): boolean {
+  if (previous?.kind !== "paragraph" || current.kind !== "paragraph") {
+    return false;
+  }
+  const previousNumPr = previous.attrs?.numPr;
+  const currentNumPr = current.attrs?.numPr;
+  if (previousNumPr?.numId === undefined || currentNumPr?.numId === undefined) {
+    return false;
+  }
+  return previousNumPr.numId === currentNumPr.numId && previousNumPr.ilvl === currentNumPr.ilvl;
+}
+
+type NaturalPageAdvance = "none" | "ordinary" | "reflowBoundary";
+
 /**
  * Get spacing before a paragraph block. Empty paragraphs whose
  * `before` came only from the implicit default paragraph style collapse to
@@ -442,7 +456,7 @@ export function layoutDocument(
   let activeSectionMarginTop = initialConfig.margins.top;
   let activeSectionPageHeight = initialConfig.pageSize.h;
   let activeSectionMarginBottom = initialConfig.margins.bottom;
-  let naturalPageAdvanceSinceRenderedBreak = false;
+  let naturalPageAdvanceSinceRenderedBreak: NaturalPageAdvance = "none";
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
@@ -458,26 +472,35 @@ export function layoutDocument(
       paginator.forcePageBreak();
     } else if (hasRenderedPageBreak) {
       const state = paginator.getCurrentState();
-      const naturalOverflowAlreadyCrossedEmptyMarker =
-        block.kind === "paragraph" &&
-        isPaginationEmptyParagraph(block) &&
-        naturalPageAdvanceSinceRenderedBreak;
+      const naturalAdvanceAlreadyCrossedMarker =
+        naturalPageAdvanceSinceRenderedBreak === "reflowBoundary" ||
+        (block.kind === "paragraph" &&
+          isPaginationEmptyParagraph(block) &&
+          naturalPageAdvanceSinceRenderedBreak !== "none") ||
+        (naturalPageAdvanceSinceRenderedBreak !== "none" &&
+          continuesNumberedSequence(blocks[i - 1], block));
       if (
-        !naturalOverflowAlreadyCrossedEmptyMarker &&
+        !naturalAdvanceAlreadyCrossedMarker &&
         pageHasVisibleBodyContent(state.page, blocksById)
       ) {
         paginator.forcePageBreak();
       }
     }
     if (hasRenderedPageBreak || hasPageBreakBefore(block)) {
-      naturalPageAdvanceSinceRenderedBreak = false;
+      naturalPageAdvanceSinceRenderedBreak = "none";
     }
 
     // Handle keepNext chains - if this is a chain start, check if chain fits
     const chain = keepNextChains.get(i);
     if (chain && !midChainIndices.has(i)) {
       const chainHeight = calculateChainHeight(chain, blocks, measures);
+      const pageBeforeChainLayout = paginator.getCurrentState().page.number;
       paginator.ensureFits(chainHeight);
+      if (paginator.getCurrentState().page.number > pageBeforeChainLayout) {
+        // The chain moved as one unit across the cached boundary. A rendered
+        // marker immediately after it describes the page Folio just opened.
+        naturalPageAdvanceSinceRenderedBreak = "reflowBoundary";
+      }
     }
 
     const pageBeforeBlockLayout = paginator.getCurrentState().page.number;
@@ -578,12 +601,18 @@ export function layoutDocument(
     const isStructuralBreak =
       block.kind === "pageBreak" || block.kind === "columnBreak" || block.kind === "sectionBreak";
     if (isStructuralBreak) {
-      naturalPageAdvanceSinceRenderedBreak = false;
+      naturalPageAdvanceSinceRenderedBreak = "none";
     } else if (
       isVisibleBodyBlock &&
       paginator.getCurrentState().page.number > pageBeforeBlockLayout
     ) {
-      naturalPageAdvanceSinceRenderedBreak = true;
+      const previousPage = paginator.pages.find(({ number }) => number === pageBeforeBlockLayout);
+      const blockContinuedAcrossBoundary = previousPage?.fragments.some(
+        ({ blockId }) => blockId === block.id,
+      );
+      naturalPageAdvanceSinceRenderedBreak = blockContinuedAcrossBoundary
+        ? "reflowBoundary"
+        : "ordinary";
     }
   }
 

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -606,7 +606,7 @@ export function layoutDocument(
       isVisibleBodyBlock &&
       paginator.getCurrentState().page.number > pageBeforeBlockLayout
     ) {
-      const previousPage = paginator.pages.find(({ number }) => number === pageBeforeBlockLayout);
+      const previousPage = paginator.pages[pageBeforeBlockLayout - 1];
       const blockContinuedAcrossBoundary = previousPage?.fragments.some(
         ({ blockId }) => blockId === block.id,
       );


### PR DESCRIPTION
## Summary

- distinguish ordinary page advances from boundaries crossed by keep-next chains and paragraph continuations
- coalesce cached rendered-page markers when natural reflow already opened the described page
- coalesce adjacent same-level numbering items while preserving markers across list-level changes and ordinary standalone moves
- add focused positive and cross-case pagination regressions plus a core patch changeset

## Anonymous parity replay

- score: 20.2% → 49.3%
- pathological sparse pages caused by duplicated cached boundaries are removed
- exact-family and metric preflight remains eligible

## Validation

- `bun test packages/core/src/__tests__/layout-pipeline.integration.test.ts` (53 passed)
- `bun audit` (no vulnerabilities)
- lint, typecheck, build, packaging, interaction, and differential checks are delegated to CI

CC on behalf of @jan-kubica