### PR TITLE
fix: align cached page boundaries

### DIFF
--- a/.changeset/calm-outline-anchors.md
+++ b/.changeset/calm-outline-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Match reference leading empty-outline height and avoid replaying cached page breaks after a natural paragraph continuation.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -551,7 +551,8 @@ export type PaginatorOptions = {
 
 // @public
 export type ParagraphAttrs = {
-    alignment?: "left" | "center" | "right" | "justify";
+    alignment?: "left" | "center" | "right" | "justify"; /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
+    outlineLevel?: number;
     spacing?: ParagraphSpacing;
     spacingExplicit?: {
         before?: boolean;
@@ -571,7 +572,8 @@ export type ParagraphAttrs = {
     borders?: ParagraphBorders;
     shading?: string;
     tabs?: TabStop[]; /** Render structural empty paragraphs as zero-height anchors. */
-    suppressEmptyParagraphHeight?: boolean;
+    suppressEmptyParagraphHeight?: boolean; /** Reserve the reference extra line advance for a story-leading empty level-0 outline paragraph. */
+    reserveEmptyOutlineHeight?: boolean;
     numPr?: ListNumPr;
     listMarker?: string;
     listIsBullet?: boolean;

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -421,6 +421,26 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1].fragments[0].blockId).toBe(1);
     });
 
+    test("rendered page break reuses a page opened by the preceding paragraph continuation", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Paragraph split across the boundary", 1),
+        {
+          ...makeParagraphBlock(1, "Cached next page", 38),
+          attrs: { renderedPageBreakBefore: true },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 850), makeLine(0, 20, 0, 37, 300, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1].fragments.map((fragment) => fragment.blockId)).toEqual([0, 1]);
+      expect(layout.pages[1].fragments[0]).toMatchObject({ continuesFromPrev: true });
+    });
+
     test("rendered page break reuses a page containing only an overflowed empty paragraph", () => {
       const emptyParagraph: ParagraphBlock = {
         kind: "paragraph",

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -80,6 +80,7 @@ describe("toFlowBlocks paragraph formatting", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", {
         styleId: "Heading6",
+        outlineLevel: 0,
         defaultTextFormatting: { fontSize: 22, fontFamily: { ascii: "Calibri" } },
         _originalFormatting: {
           styleId: "Heading6",
@@ -93,6 +94,29 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.kind).toBe("paragraph");
     expect(paragraph?.attrs?.defaultFontSize).toBe(1);
     expect(paragraph?.attrs?.defaultFontFamily).toBe("Arial");
+    expect(paragraph?.attrs?.outlineLevel).toBe(0);
+    expect(paragraph?.attrs?.reserveEmptyOutlineHeight).toBe(true);
+  });
+
+  test("does not reserve extra outline height away from the start of the story", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("content")]),
+        schema.node("paragraph", { outlineLevel: 0 }),
+      ]),
+    );
+
+    expect(blocks.at(1)?.attrs?.outlineLevel).toBe(0);
+    expect(blocks.at(1)?.attrs?.reserveEmptyOutlineHeight).toBeUndefined();
+  });
+
+  test("ignores a null outline attribute at the layout boundary", () => {
+    const paragraph = toFlowBlocks(
+      schema.node("doc", null, [schema.node("paragraph", { outlineLevel: null })]),
+    ).at(0);
+
+    expect(paragraph?.attrs?.outlineLevel).toBeUndefined();
+    expect(paragraph?.attrs?.reserveEmptyOutlineHeight).toBeUndefined();
   });
 
   test("marks direct formatting on an empty paragraph for spacing layout", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1377,6 +1377,10 @@ function convertParagraphAttrs(
     // default to no alignment set (inherits from style or defaults to left)
   }
 
+  if (typeof pmAttrs.outlineLevel === "number") {
+    attrs.outlineLevel = pmAttrs.outlineLevel;
+  }
+
   // Spacing. HTML-origin auto spacing (w:beforeAutospacing/afterAutospacing)
   // renders Word's 14pt auto gap, overriding the imported before/after (which
   // Word writes as `0`) — surface it here so pagination matches the rendered
@@ -1881,6 +1885,19 @@ function suppressTerminalEmptyParagraphsAfterTable(blocks: FlowBlock[]): void {
       block.attrs = { ...block.attrs, suppressEmptyParagraphHeight: true };
     }
   }
+}
+
+function reserveLeadingEmptyOutlineHeight(blocks: FlowBlock[]): void {
+  const firstBlock = blocks.at(0);
+  if (
+    firstBlock?.kind !== "paragraph" ||
+    firstBlock.runs.length !== 0 ||
+    firstBlock.attrs?.outlineLevel !== 0
+  ) {
+    return;
+  }
+
+  firstBlock.attrs = { ...firstBlock.attrs, reserveEmptyOutlineHeight: true };
 }
 
 /**
@@ -2719,6 +2736,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     visit(node, offset + nodeOffset);
   });
 
+  reserveLeadingEmptyOutlineHeight(blocks);
   suppressTerminalEmptyParagraphsAfterTable(blocks);
   return mergeRunInParagraphs(blocks);
 }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -139,10 +139,25 @@ function continuesNumberedSequence(previous: FlowBlock | undefined, current: Flo
 
 type NaturalPageAdvance = "none" | "ordinary" | "reflowBoundary";
 
+function pageStartsWithPreviousParagraphContinuation(
+  page: Page,
+  previousBlock: FlowBlock | undefined,
+): boolean {
+  if (previousBlock?.kind !== "paragraph") {
+    return false;
+  }
+
+  return page.fragments.some(
+    (fragment) =>
+      fragment.kind === "paragraph" &&
+      String(fragment.blockId) === String(previousBlock.id) &&
+      fragment.continuesFromPrev === true,
+  );
+}
 /**
  * Get spacing before a paragraph block. Empty paragraphs whose
  * `before` came only from the implicit default paragraph style collapse to
- * zero. Word keeps inherited spacing when the empty paragraph itself is
+ * zero. Reference layout keeps inherited spacing when the empty paragraph itself is
  * authored through direct `w:pPr` formatting or an explicit `w:pStyle`.
  */
 function getSpacingBefore(block: ParagraphBlock): number {
@@ -461,8 +476,8 @@ export function layoutDocument(
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
 
-    // A cached Word pagination marker records a break at this paragraph, not
-    // an ordinal page target: Word does not emit markers for every physical
+    // A cached pagination marker records a break at this paragraph, not an
+    // ordinal page target: the source does not emit markers for every physical
     // page. Honor the break whenever visible content precedes it on Folio's
     // current page. A structural/natural break that opened an empty page, or a
     // page containing only overflowed empty paragraphs, already satisfies it.
@@ -472,7 +487,12 @@ export function layoutDocument(
       paginator.forcePageBreak();
     } else if (hasRenderedPageBreak) {
       const state = paginator.getCurrentState();
+      const previousParagraphAlreadyCrossedMarker = pageStartsWithPreviousParagraphContinuation(
+        state.page,
+        blocks[i - 1],
+      );
       const naturalAdvanceAlreadyCrossedMarker =
+        previousParagraphAlreadyCrossedMarker ||
         naturalPageAdvanceSinceRenderedBreak === "reflowBoundary" ||
         (block.kind === "paragraph" &&
           isPaginationEmptyParagraph(block) &&

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -303,6 +303,9 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     if (attrs.alignment) {
       parts.push(`align:${attrs.alignment}`);
     }
+    if (attrs.outlineLevel !== undefined) {
+      parts.push(`outline:${attrs.outlineLevel}`);
+    }
     if (attrs.indent) {
       parts.push(
         `indent:${attrs.indent.left}|${attrs.indent.right}|${attrs.indent.firstLine}|${attrs.indent.hanging}`,
@@ -323,6 +326,9 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     }
     if (attrs.suppressEmptyParagraphHeight) {
       parts.push("sup");
+    }
+    if (attrs.reserveEmptyOutlineHeight) {
+      parts.push("outline-empty-reserve");
     }
     const borders = attrs.borders;
     if (borders) {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -68,6 +68,21 @@ describe("font metrics cache", () => {
       expect(getMeasureCount()).toBe(2);
     }, fakeMeasure);
   });
+
+  test("keeps outline level in the paragraph measurement cache key", () => {
+    const paragraph = {
+      kind: "paragraph" as const,
+      id: "outline-cache",
+      runs: [],
+    };
+
+    expect(hashParagraphBlock(paragraph)).not.toBe(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: { outlineLevel: 0, reserveEmptyOutlineHeight: true },
+      }),
+    );
+  });
 });
 
 describe("empty paragraph line-height floor", () => {
@@ -135,6 +150,54 @@ describe("empty paragraph line-height floor", () => {
     );
 
     expect(measure.totalHeight).toBeCloseTo(11 * PT_TO_PX * 1.15 + 12, 1);
+  });
+
+  test("empty top-level outline paragraph reserves two line boxes", () => {
+    const paragraph = {
+      kind: "paragraph" as const,
+      id: "t3-outline",
+      pmStart: 0,
+      pmEnd: 0,
+      runs: [],
+      attrs: {
+        defaultFontSize: 18,
+        defaultFontFamily: "Arial",
+      },
+    };
+    const ordinary = measureParagraph(paragraph, 600);
+    const outlined = measureParagraph(
+      {
+        ...paragraph,
+        attrs: {
+          ...paragraph.attrs,
+          outlineLevel: 0,
+          reserveEmptyOutlineHeight: true,
+        },
+      },
+      600,
+    );
+
+    expect(outlined.lines).toHaveLength(1);
+    expect(outlined.lines[0]?.lineHeight).toBeCloseTo((ordinary.lines[0]?.lineHeight ?? 0) * 2, 1);
+    expect(outlined.totalHeight).toBeCloseTo(outlined.lines[0]?.lineHeight ?? 0, 1);
+  });
+
+  test("outline metadata does not change non-empty paragraph height", () => {
+    const base = {
+      kind: "paragraph" as const,
+      id: "t3-outline-content",
+      pmStart: 0,
+      pmEnd: 4,
+      runs: [{ kind: "text" as const, text: "text" }],
+    };
+
+    withFakeTextMeasure(() => {
+      const ordinary = measureParagraph(base, 600);
+      const outlined = measureParagraph({ ...base, attrs: { outlineLevel: 0 } }, 600);
+
+      expect(outlined.totalHeight).toBe(ordinary.totalHeight);
+      expect(outlined.lines).toEqual(ordinary.lines);
+    }, fakeMeasure);
   });
 
   for (const text of ["", " ", "\u00a0"]) {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -875,6 +875,13 @@ export function measureParagraph(
     const emptyFontSize = attrs?.defaultFontSize ?? DEFAULT_FONT_SIZE;
     const emptyFontFamily = attrs?.defaultFontFamily ?? DEFAULT_FONT_FAMILY;
     const emptyMetrics = calculateEmptyParagraphMetrics(emptyFontSize, spacing, emptyFontFamily);
+    // Reference layout reserves a second line box for a story-leading empty top-level
+    // outline paragraph. Keep it as one logical/caret line while expanding
+    // the line's advance; later and ordinary empty paragraphs stay at the
+    // normal single-line height.
+    const outlineLineHeight = attrs?.reserveEmptyOutlineHeight
+      ? emptyMetrics.lineHeight * 2
+      : emptyMetrics.lineHeight;
     lines.push({
       fromRun: 0,
       fromChar: 0,
@@ -882,9 +889,10 @@ export function measureParagraph(
       toChar: 0,
       width: 0,
       ...emptyMetrics,
+      lineHeight: outlineLineHeight,
     });
 
-    let totalHeight = emptyMetrics.lineHeight;
+    let totalHeight = outlineLineHeight;
     if (spacing?.before) {
       totalHeight += spacing.before;
     }

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -369,6 +369,8 @@ export type ListNumPr = {
  */
 export type ParagraphAttrs = {
   alignment?: "left" | "center" | "right" | "justify";
+  /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
+  outlineLevel?: number;
   spacing?: ParagraphSpacing;
   /**
    * Tracks which `spacing` sides came from inline (`<w:pPr><w:spacing>`)
@@ -408,6 +410,8 @@ export type ParagraphAttrs = {
   tabs?: TabStop[]; // Custom tab stops
   /** Render structural empty paragraphs as zero-height anchors. */
   suppressEmptyParagraphHeight?: boolean;
+  /** Reserve the reference extra line advance for a story-leading empty level-0 outline paragraph. */
+  reserveEmptyOutlineHeight?: boolean;
   // List properties
   numPr?: ListNumPr;
   listMarker?: string; // Pre-computed marker text (e.g., "1.", "•", "a)")


### PR DESCRIPTION
## Summary

- preserve authored paragraph outline metadata and reserve reference-compatible height for a story-leading empty top-level outline paragraph
- reuse a page already opened by the preceding paragraph continuation instead of replaying a cached rendered-page-break hint
- add focused measurement, conversion, cache, and pagination regressions plus cross-cases for ordinary later blanks, non-empty outlines, and authoritative break hints

## Validation

- 193 focused layout, measurement, and conversion tests pass
- anonymous strict same-font replay: score 82.5% → 86.8%; pagination divergences 9 → 3; matched lines 231 → 236
- `bun audit`: no vulnerabilities
- CI owns lint, typecheck, full tests, build, and package validation

## Security

The change is confined to deterministic in-memory document conversion, measurement, cache identity, and pagination. It adds no I/O, persistence, authentication surface, dependencies, or data exposure.

CC on behalf of @jan-kubica