### PR TITLE
fix: honor numeric floating table offsets

### DIFF
--- a/.changeset/position-numeric-floating-tables.md
+++ b/.changeset/position-numeric-floating-tables.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Allow numeric floating-table offsets to extend into page margins.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1359,12 +1359,16 @@ function layoutFloatingTable(
     y = fitState.cursorY;
   }
 
-  // Clamp within the selected horizontal anchor frame. A page-anchored table
-  // may legitimately sit outside the body margins; clamping it to the content
-  // frame shifts the table and every drawing anchored inside its cells.
+  // Alignment keywords stay inside their selected anchor frame. A numeric
+  // offset may deliberately move a margin-anchored table into the page margin,
+  // so clamp that resolved position only against the physical page.
+  const usesNumericOffset = floating?.tblpX !== undefined;
   const pageAnchored = floating?.horzAnchor === "page";
-  const minX = pageAnchored ? 0 : margins.left;
-  const maxX = pageAnchored ? page.size.w - tableWidth : margins.left + contentWidth - tableWidth;
+  const clampToPage = pageAnchored || usesNumericOffset;
+  const minX = clampToPage ? 0 : margins.left;
+  const maxX = clampToPage
+    ? page.size.w - tableWidth
+    : margins.left + contentWidth - tableWidth;
   if (Number.isFinite(maxX)) {
     x = Math.max(minX, Math.min(x, maxX));
   }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1366,9 +1366,7 @@ function layoutFloatingTable(
   const pageAnchored = floating?.horzAnchor === "page";
   const clampToPage = pageAnchored || usesNumericOffset;
   const minX = clampToPage ? 0 : margins.left;
-  const maxX = clampToPage
-    ? page.size.w - tableWidth
-    : margins.left + contentWidth - tableWidth;
+  const maxX = clampToPage ? page.size.w - tableWidth : margins.left + contentWidth - tableWidth;
   if (Number.isFinite(maxX)) {
     x = Math.max(minX, Math.min(x, maxX));
   }

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -808,6 +808,33 @@ describe("left-aligned table placement", () => {
 });
 
 describe("floating table placement", () => {
+  test("allows a numeric margin-relative offset to enter the page margin", () => {
+    const { block, measure } = tallTable(1);
+    block.floating = { horzAnchor: "margin", tblpX: -20 };
+
+    const fragment = tableFragments(block, measure).at(0);
+
+    expect(fragment?.x).toBe(OPTIONS.margins.left - 20);
+  });
+
+  test("keeps an aligned margin-relative table inside the body margin", () => {
+    const { block, measure } = tallTable(1);
+    block.floating = { horzAnchor: "margin", tblpXSpec: "left" };
+
+    const fragment = tableFragments(block, measure).at(0);
+
+    expect(fragment?.x).toBe(OPTIONS.margins.left);
+  });
+
+  test("clamps a numeric margin-relative offset against the physical page", () => {
+    const { block, measure } = tallTable(1);
+    block.floating = { horzAnchor: "margin", tblpX: -80 };
+
+    const fragment = tableFragments(block, measure).at(0);
+
+    expect(fragment?.x).toBe(0);
+  });
+
   test("clamps a page-anchored table against the page instead of the body margins", () => {
     const { block, measure } = tallTable(1);
     block.floating = { horzAnchor: "page", tblpX: 80 };


### PR DESCRIPTION
Numeric floating-table offsets can deliberately move a margin-anchored table into the page margin. Resolve those offsets from their anchor and clamp them against the physical page while preserving anchor-frame clamping for alignment keywords.

Adds positive, aligned-anchor, and page-boundary regression coverage. An anonymous parity replay confirms the targeted geometry change.

CC on behalf of @jan-kubica