### PR TITLE
fix: account for fixed spaces in justification

### DIFF
--- a/.changeset/fixed-space-justify.md
+++ b/.changeset/fixed-space-justify.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Exclude non-breaking spaces from the shrink capacity of justified prose.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -441,6 +441,52 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
+  test("does not count non-breaking spaces toward justified shrink capacity", () => {
+    const fixedSpaceText = `${"a".repeat(99)}\u00a0bbb`;
+
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-fixed-space",
+            runs: [{ kind: "text", text: fixedSpaceText }],
+            attrs: { alignment: "justify" },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("keeps regular spaces available for justified shrink beside a fixed space", () => {
+    const mixedSpaceText = `${"a".repeat(97)}  \u00a0bbb`;
+
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-mixed-spaces",
+            runs: [{ kind: "text", text: mixedSpaceText }],
+            attrs: { alignment: "justify" },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(1);
+      },
+      {
+        charWidth: (char) => (char === "b" ? 0.55 : 1),
+      },
+    );
+  });
+
   test("ignores unused tab stops when choosing justified prose shrink tolerance", () => {
     withFakeTextMeasure(
       () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -556,6 +556,26 @@ function uppercaseLetterRatio(text: string): number {
   return letters === 0 ? 0 : uppercase / letters;
 }
 
+type FixedSpaceAdjustedShrinkToleranceOptions = {
+  tolerance: number;
+  regularSpaceCount: number;
+  nonBreakingSpaceCount: number;
+};
+
+function fixedSpaceAdjustedShrinkTolerance({
+  tolerance,
+  regularSpaceCount,
+  nonBreakingSpaceCount,
+}: FixedSpaceAdjustedShrinkToleranceOptions): number {
+  const totalSpaces = regularSpaceCount + nonBreakingSpaceCount;
+  if (totalSpaces === 0) {
+    return tolerance;
+  }
+  // The reference layout contracts ordinary spaces during justification, but
+  // keeps NBSPs fixed. Scale the allowance to the share that can shrink.
+  return Math.max(JUSTIFY_SHRINK_TOLERANCE_RATIO, tolerance * (regularSpaceCount / totalSpaces));
+}
+
 function justifyShrinkToleranceRatio(
   block: ParagraphBlock,
   isFirstLine: boolean,
@@ -572,14 +592,11 @@ function justifyShrinkToleranceRatio(
         ? JUSTIFY_SHRINK_TOLERANCE_RATIO
         : JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO;
     }
-    const totalSpaces = regularSpaceCount + nonBreakingSpaceCount;
-    if (totalSpaces === 0) {
-      return JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO;
-    }
-    return Math.max(
-      JUSTIFY_SHRINK_TOLERANCE_RATIO,
-      JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO * (regularSpaceCount / totalSpaces),
-    );
+    return fixedSpaceAdjustedShrinkTolerance({
+      tolerance: JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO,
+      regularSpaceCount,
+      nonBreakingSpaceCount,
+    });
   }
   const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
   const hasTabRuns = block.runs.some(isTabRun);
@@ -600,7 +617,11 @@ function justifyShrinkToleranceRatio(
     return JUSTIFY_SHRINK_TOLERANCE_RATIO;
   }
 
-  return JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO;
+  return fixedSpaceAdjustedShrinkTolerance({
+    tolerance: JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO,
+    regularSpaceCount,
+    nonBreakingSpaceCount,
+  });
 }
 
 function trimTrailingSpacesAndTabs(text: string): string {


### PR DESCRIPTION
## Summary

- scale justified-prose shrink allowance by the share of spaces that can actually contract
- keep non-breaking spaces fixed while preserving ordinary and mixed-space justification behavior
- add focused positive and cross-case regression coverage

## Verification

- focused justification measurement tests pass
- an anonymous strict same-font parity replay improved from 90.9% to 92.2% with page count preserved
- a separate anonymous cross-case replay improved from 90.4% to 91.8% with page count preserved
- dependency audit reports no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica