### PR TITLE
fix: merge segmented parity lines

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -57,7 +57,51 @@ describe("compareGeoms", () => {
     expect(merged).toHaveLength(2);
   });
 
-  test("merges nearby text from different table cells like Word PDF boxes", () => {
+  test("merges wide tab segments from the same logical line", () => {
+    const merged = mergeVisualRows([
+      makeLine({
+        text: "Left segment",
+        xPt: 45,
+        yPt: 100,
+        widthPt: 90,
+        logicalLineGroup: "layout-line:7",
+      }),
+      makeLine({
+        text: "Right segment",
+        xPt: 350,
+        yPt: 100,
+        widthPt: 100,
+        logicalLineGroup: "layout-line:7",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.normText).toBe(normalizeLineText("Left segment Right segment"));
+    expect(merged[0]?.logicalLineGroup).toBe("layout-line:7");
+  });
+
+  test("keeps wide same-row segments from different logical lines separate", () => {
+    const merged = mergeVisualRows([
+      makeLine({
+        text: "Left column",
+        xPt: 45,
+        yPt: 100,
+        widthPt: 90,
+        logicalLineGroup: "layout-line:7",
+      }),
+      makeLine({
+        text: "Right column",
+        xPt: 350,
+        yPt: 100,
+        widthPt: 100,
+        logicalLineGroup: "layout-line:8",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  test("merges nearby text from different table cells like reference PDF boxes", () => {
     const merged = mergeVisualRows([
       makeLine({
         text: "Left cell",
@@ -417,7 +461,7 @@ describe("compareGeoms", () => {
     expect(result.medianYOffsetPt).toBeCloseTo(4.5);
   });
 
-  test("a Word line split into two folio lines reconciles as a single line-break", () => {
+  test("a reference line split into two folio lines reconciles as a single line-break", () => {
     const word = makeDoc("word", [
       makePage({ lines: [makeLine({ text: "The quick brown fox jumps" })] }),
     ]);
@@ -488,7 +532,7 @@ describe("compareGeoms", () => {
     });
   });
 
-  test("a line only in Word is missing-line; a line only in folio is extra-line", () => {
+  test("a reference-only line is missing; a folio-only line is extra", () => {
     const word = makeDoc("word", [
       makePage({
         lines: [

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -289,6 +289,20 @@ describe("toPageGeom", () => {
     expect(toPageGeom(rawPage).lines.at(0)?.visualGroup).toBe("table-cell:3");
   });
 
+  test("preserves logical line groups", () => {
+    const rawPage = makeRawPage({
+      lines: [
+        makeRawLine({
+          text: "Segment",
+          rect: rect(96, 96, 200, 20),
+          logicalLineGroup: "layout-line:4",
+        }),
+      ],
+    });
+
+    expect(toPageGeom(rawPage).lines.at(0)?.logicalLineGroup).toBe("layout-line:4");
+  });
+
   test("computes fontName/fontSizePt from raw px values, omitting when absent", () => {
     const rawPage = makeRawPage({
       lines: [

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -1,5 +1,5 @@
 /**
- * Word rendering parity engine: pure comparison of two `DocGeom` values into
+ * Rendering parity engine: pure comparison of two `DocGeom` values into
  * a `ParityResult`. No I/O, no browser: this module only manipulates the
  * already-extracted geometry, which keeps it fully unit-testable.
  *
@@ -100,14 +100,14 @@ export const compareGeoms = (
   };
 };
 
-/** Score when the Word side has no lines at all: 1 if folio is also empty
+/** Score when the reference side has no lines at all: 1 if folio is also empty
  * (nothing to diverge on), 0 otherwise (every folio line is unaccounted for). */
 const scoreForEmptyWordDoc = (folioLineCount: number): number => (folioLineCount === 0 ? 1 : 0);
 
 const stripSpaces = (text: string): string => text.replaceAll(" ", "");
 
 /**
- * Word PDF extraction reports glyph-ink bounds while Folio reports the line
+ * Reference PDF extraction reports glyph-ink bounds while Folio reports the line
  * box. Punctuation-only rows (signature rules, ellipses, separators) have no
  * stable cap-height edge, so their top coordinates cannot establish or verify
  * a baseline offset. Horizontal geometry remains comparable.
@@ -118,7 +118,7 @@ const hasStableVerticalInk = (line: LineBox): boolean => /[\p{L}\p{N}]/u.test(li
  * as the same visual row. */
 const ROW_OVERLAP_RATIO = 0.5;
 /** Maximum horizontal gap (pt) between same-row boxes that still merges them.
- * Word emits list markers as separate ink boxes ~10pt left of the item text,
+ * The reference extractor emits list markers as separate ink boxes ~10pt left of the item text,
  * and tabbed legal clauses can leave ~23pt between the marker and text; table
  * widely separated table cells sit farther apart (>25pt) and stay separate. */
 const ROW_MERGE_GAP_PT = 24;
@@ -127,10 +127,11 @@ const MARKER_ROW_MERGE_GAP_PT = 36;
 /** Clusters boxes into visual rows (>= ROW_OVERLAP_RATIO vertical overlap),
  * then merges row neighbours within ROW_MERGE_GAP_PT of each other into a
  * single LineBox — bullet/number markers and tightly adjacent table-cell text
- * join the way Word's PDF boxes do. Folio's DOM-only cell identity is ignored
- * here because Word truth has no equivalent metadata; using it would normalize
- * the two extractors differently. The result is ordered row-by-row,
- * left-to-right within a row: Word's ink boxes on one
+ * join the way the reference PDF boxes do. Folio's DOM-only cell identity is
+ * ignored here because reference geometry has no equivalent metadata; using it
+ * would normalize the two extractors differently. Logical line identity is
+ * used only to recombine segments that came from the same painted line. The
+ * result is ordered row-by-row, left-to-right within a row: reference ink boxes on one
  * visual row can differ by fractions of a pt vertically (e.g. table cells), so
  * a raw (y, x) sort would order the same row differently on the two sides and
  * derail the sequence alignment. Applied to BOTH sides so the pass itself
@@ -168,6 +169,12 @@ const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
   if (current.region !== next.region) {
     return false;
   }
+  if (
+    current.logicalLineGroup !== undefined &&
+    current.logicalLineGroup === next.logicalLineGroup
+  ) {
+    return true;
+  }
   const gap = horizontalGap(current, next);
   if (gap <= ROW_MERGE_GAP_PT) {
     return true;
@@ -202,6 +209,10 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
   // metadata is not discarded when only the right side carries it.
   const fontName = left.fontName ?? right.fontName;
   const fontSizePt = left.fontSizePt ?? right.fontSizePt;
+  const logicalLineGroup =
+    left.logicalLineGroup !== undefined && left.logicalLineGroup === right.logicalLineGroup
+      ? left.logicalLineGroup
+      : undefined;
   return {
     text,
     normText: normalizeLineText(text),
@@ -212,6 +223,7 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
     region: left.region,
     ...(fontName !== undefined ? { fontName } : {}),
     ...(fontSizePt !== undefined ? { fontSizePt } : {}),
+    ...(logicalLineGroup !== undefined ? { logicalLineGroup } : {}),
   };
 };
 
@@ -641,7 +653,7 @@ const diffMatches = ({
       if (!w || !f) continue;
       const samePage = w.page === f.page;
 
-      // Space-insensitive: visual-row merging joins Word's separate marker
+      // Space-insensitive: visual-row merging joins reference marker
       // boxes with a space while folio's painter inlines markers without one,
       // and that spacing difference is not a text fidelity issue.
       if (stripSpaces(w.line.normText) !== stripSpaces(f.line.normText)) {

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -2,7 +2,7 @@
  * Folio-side geometry extraction: loads a .docx in the playground (Playwright
  * + the existing `?file=` fixture route), walks the painted layout DOM
  * (`.layout-page` / `.layout-line`), and normalizes it into the same
- * `DocGeom` shape the Word-side extractor produces. Also captures a per-page
+ * `DocGeom` shape the reference extractor produces. Also captures a per-page
  * PNG screenshot for the HTML report.
  *
  * DOM-only concerns (getBoundingClientRect, closest, getComputedStyle,
@@ -170,7 +170,7 @@ export const formatNavigationFailure = (url: string, error: unknown, output: str
 /** A raw rect as returned by `getBoundingClientRect()` (visual/CSS px). */
 export type RawRect = { left: number; top: number; width: number; height: number };
 
-/** One `.layout-line` element, extracted with DOM-only reads (no math). */
+/** One ink segment extracted from a `.layout-line` with DOM-only reads (no math). */
 export type RawLine = {
   text: string;
   rect: RawRect;
@@ -184,6 +184,8 @@ export type RawLine = {
   fontSizePx?: number;
   /** Stable page-local table-cell identity, when the line is inside a cell. */
   visualGroup?: string;
+  /** Stable page-local identity of the originating `.layout-line`. */
+  logicalLineGroup?: string;
 };
 
 /** One `.layout-page` element and its lines, extracted with DOM-only reads. */
@@ -268,6 +270,9 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
       heightPt: lineHeightPt,
       region: rawLine.region,
       ...(rawLine.visualGroup !== undefined ? { visualGroup: rawLine.visualGroup } : {}),
+      ...(rawLine.logicalLineGroup !== undefined
+        ? { logicalLineGroup: rawLine.logicalLineGroup }
+        : {}),
       ...(fontName !== undefined ? { fontName } : {}),
       ...(fontSizePt !== undefined ? { fontSizePt } : {}),
     });
@@ -595,7 +600,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
         resolvedFontCache.set(computed.fontFamily, fallback);
         return fallback;
       };
-      const lines = lineEls.flatMap((lineEl) => {
+      const lines = lineEls.flatMap((lineEl, lineIndex) => {
         const segmentInkRect = (segmentEl: HTMLElement): DOMRect | null => {
           if (
             segmentEl.matches("img, svg, canvas, video") ||
@@ -670,6 +675,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
         })();
         const tableCell = lineEl.closest(".layout-table-cell");
         const visualGroup = tableCell ? `table-cell:${tableCells.indexOf(tableCell)}` : undefined;
+        const logicalLineGroup = `layout-line:${lineIndex}`;
 
         const fontFrom = (sourceEl: HTMLElement | null) => {
           if (!sourceEl) return {};
@@ -733,6 +739,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
           region,
           ...(isFullyClipped(sourceEl, rect) ? { fullyClipped: true } : {}),
           ...(visualGroup !== undefined ? { visualGroup } : {}),
+          logicalLineGroup,
           ...fontFrom(sourceEl),
         });
 
@@ -825,7 +832,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
 
         // The `.layout-line` box spans the full column width regardless of where
         // the text ink actually sits (centered/right-aligned lines, table cells),
-        // while the Word-side extractor reports glyph-ink bounds. Use the union
+        // while the reference extractor reports glyph-ink bounds. Use the union
         // of the line's run and list-marker boxes as the ink rect so both sides
         // measure the same thing; fall back to the line box for lines without
         // segment children.

--- a/parity/types.ts
+++ b/parity/types.ts
@@ -1,12 +1,12 @@
 /**
- * Word rendering parity engine: shared data contract.
+ * Rendering parity engine: shared data contract.
  *
  * All geometry is expressed in PDF points (1pt = 1/72in), page-relative with
- * the origin at the page's top-left corner. Word-side geometry comes from
- * `mutool draw -F stext` over a Word-exported PDF; folio-side geometry comes
- * from the painted playground DOM (CSS px at 96dpi, converted with the
- * px-to-pt factor 72/96 after normalising against the page element width so
- * playground zoom cannot skew coordinates).
+ * the origin at the page's top-left corner. Reference geometry comes from
+ * `mutool draw -F stext` over the exported PDF; folio-side geometry comes from
+ * the painted playground DOM (CSS px at 96dpi, converted with the px-to-pt
+ * factor 72/96 after normalising against the page element width so playground
+ * zoom cannot skew coordinates).
  */
 
 export type Region = "body" | "header" | "footer" | "footnote" | "unknown";
@@ -18,7 +18,7 @@ export type LineBox = {
   normText: string;
   /** Left edge of the line's ink/text start, in pt from the page left. */
   xPt: number;
-  /** Top edge of the line box, in pt from the page top. Word-side boxes are
+  /** Top edge of the line box, in pt from the page top. Reference boxes are
    * ink bounds and folio-side boxes are line-height boxes, so absolute yPt is
    * only compared after per-page median-offset correction. */
   yPt: number;
@@ -30,6 +30,8 @@ export type LineBox = {
   region: Region;
   /** DOM visual container, used to keep adjacent table cells distinct. */
   visualGroup?: string;
+  /** Page-local identity shared by segments extracted from one logical line. */
+  logicalLineGroup?: string;
 };
 
 export type PageGeom = {
@@ -50,16 +52,16 @@ export type DocGeom = {
   meta: Record<string, string>;
 };
 
-/** A divergence between Word's rendering and folio's rendering. */
+/** A divergence between the reference rendering and folio's rendering. */
 export type Divergence =
   | { kind: "page-count"; word: number; folio: number }
   /** Same line of text landed on different pages. */
   | { kind: "pagination"; text: string; wordPage: number; folioPage: number }
-  /** One Word line corresponds to 2+ folio lines, or vice versa (line-break position differs). */
+  /** One reference line corresponds to 2+ folio lines, or vice versa. */
   | { kind: "line-break"; page: number; wordTexts: string[]; folioTexts: string[] }
-  /** Line present in Word output but never matched in folio. */
+  /** Line present in reference output but never matched in folio. */
   | { kind: "missing-line"; page: number; text: string }
-  /** Line present in folio output but never matched in Word. */
+  /** Line present in folio output but never matched in the reference. */
   | { kind: "extra-line"; page: number; text: string }
   /** Matched line starts at a different horizontal position. */
   | { kind: "x-drift"; page: number; text: string; deltaPt: number }
@@ -94,7 +96,7 @@ export type ComparisonTolerances = {
 
 export type ParityResult = {
   file: string;
-  /** 0..1: fraction of Word lines matched to a folio line on the same page
+  /** 0..1: fraction of reference lines matched to a folio line on the same page
    * with all geometric deltas within tolerance. */
   score: number;
   wordPages: number;


### PR DESCRIPTION
## Summary

- carry a page-local logical-line identity through DOM geometry extraction
- merge widely separated segments only when they originated from the same painted line
- preserve independent table columns and unrelated same-row boxes with explicit cross-case coverage
- make touched comparison comments renderer-neutral

## Validation

- 57 focused comparison and extraction tests pass
- anonymous strict same-font replay: score 90.9% → 91.1%; false line-break divergences 2 → 0; matched lines 369 → 373
- the recombined lines surface three width drifts for direct geometric diagnosis instead of classifying them as line breaks
- `bun audit`: no vulnerabilities
- CI owns lint, typecheck, full tests, build, and package validation

## Security

The change carries page-local in-memory geometry metadata only. It adds no I/O, persistence, authentication surface, dependencies, or source-document logging.

CC on behalf of @jan-kubica