### PR TITLE
fix: constrain inset list continuations

### DIFF
--- a/.changeset/inset-list-continuations.md
+++ b/.changeset/inset-list-continuations.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep justified inset list continuations within their authored body width.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -702,7 +702,7 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("uses prose tolerance for standard-hanging list continuation lines", () => {
+  test("keeps full-hanging list continuation lines on the prose tolerance", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
@@ -724,6 +724,35 @@ describe("measureParagraph justified shrink tolerance", () => {
         );
 
         expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("keeps inset list continuation lines on the conservative tolerance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-inset-list-continuation",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+
+        expect(measure.lines).toHaveLength(3);
       },
       {
         charWidth: fractionalWidth,

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -592,6 +592,13 @@ function justifyShrinkToleranceRatio(
         ? JUSTIFY_SHRINK_TOLERANCE_RATIO
         : JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO;
     }
+    const left = block.attrs.indent?.left ?? 0;
+    if (hanging > 0 && left > hanging) {
+      // A marker that remains inset leaves a narrower continuation body.
+      // Keep those lines on the marker-line allowance; full-hanging lists
+      // retain the broader prose allowance below.
+      return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+    }
     return fixedSpaceAdjustedShrinkTolerance({
       tolerance: JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO,
       regularSpaceCount,


### PR DESCRIPTION
## Summary

- use the conservative justified shrink allowance when a numbered continuation remains inset from the content edge
- retain the prose allowance for full-hanging list geometry
- add paired regression coverage and a core patch changeset

## Validation

- `bun test src/layout-engine/measure/measureParagraph.test.ts` (74 passed)
- `bun audit` (no vulnerabilities)
- anonymous parity replay: 87.9% to 88.9%; page count remained 3/3 and all 99 reference lines remained matched
- lint and typecheck deferred to CI

CC on behalf of @jan-kubica