### PR TITLE
fix: preserve grouped OOXML picture geometry

### DIFF
--- a/.changeset/compose-grouped-pictures.md
+++ b/.changeset/compose-grouped-pictures.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render grouped OOXML pictures within their authored coordinate system and extent.

--- a/packages/core/src/docx/documentParser-alternatecontent.test.ts
+++ b/packages/core/src/docx/documentParser-alternatecontent.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 
+import type { MediaFile, RelationshipMap } from "../types/document";
 import { parseDocumentBody } from "./documentParser";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -35,6 +36,91 @@ const textBoxDrawingXml = (text: string) => `
   </w:drawing>`;
 
 describe("parseDocumentBody — AlternateContent text boxes", () => {
+  test("prefers a renderable grouped Choice over a flattened fallback picture", () => {
+    const rels: RelationshipMap = new Map([
+      [
+        "rIdChoice",
+        {
+          id: "rIdChoice",
+          type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+          target: "media/choice.png",
+        },
+      ],
+      [
+        "rIdFallback",
+        {
+          id: "rIdFallback",
+          type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+          target: "media/fallback.png",
+        },
+      ],
+    ]);
+    const media = new Map<string, MediaFile>([
+      [
+        "word/media/choice.png",
+        {
+          path: "word/media/choice.png",
+          mimeType: "image/png",
+          data: new ArrayBuffer(0),
+          dataUrl: "data:image/png;base64,Y2hvaWNl",
+        },
+      ],
+      [
+        "word/media/fallback.png",
+        {
+          path: "word/media/fallback.png",
+          mimeType: "image/png",
+          data: new ArrayBuffer(0),
+          dataUrl: "data:image/png;base64,ZmFsbGJhY2s=",
+        },
+      ],
+    ]);
+    const body = parseDocumentBody(
+      `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+  xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:r><mc:AlternateContent>
+    <mc:Choice Requires="wpg"><w:drawing><wp:anchor behindDoc="1">
+      <wp:extent cx="2000000" cy="1000000"/><wp:wrapNone/>
+      <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"><wpg:wgp>
+        <pic:pic><pic:blipFill><a:blip r:embed="rIdChoice"/></pic:blipFill><pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="1000000"/></a:xfrm></pic:spPr></pic:pic>
+      </wpg:wgp></a:graphicData></a:graphic>
+    </wp:anchor></w:drawing></mc:Choice>
+    <mc:Fallback><w:pict><v:shape style="width:9000;height:4000"><v:imagedata r:id="rIdFallback"/></v:shape></w:pict></mc:Fallback>
+  </mc:AlternateContent></w:r></w:p></w:body>
+</w:document>`,
+      null,
+      null,
+      null,
+      rels,
+      media,
+    );
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const drawing = paragraph.content
+      .filter((content) => content.type === "run")
+      .flatMap((run) => run.content)
+      .find((content) => content.type === "drawing");
+    expect(drawing?.type).toBe("drawing");
+    if (drawing?.type !== "drawing") {
+      throw new Error("Expected drawing");
+    }
+    expect(drawing.image.mimeType).toBe("image/svg+xml");
+    expect(drawing.image.size).toEqual({ width: 2_000_000, height: 1_000_000 });
+    expect(decodeURIComponent(drawing.image.src ?? "")).toContain("Y2hvaWNl");
+    expect(decodeURIComponent(drawing.image.src ?? "")).not.toContain("ZmFsbGJhY2s=");
+    expect(drawing.rawXml).toContain("<mc:Fallback>");
+  });
+
   test("renders a wpg Choice as SVG while preserving the complete alternate content", () => {
     const body = parseDocumentBody(`${XML_DECLARATION}
 <w:document

--- a/packages/core/src/docx/groupDrawingParser.test.ts
+++ b/packages/core/src/docx/groupDrawingParser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { MediaFile, RelationshipMap } from "../types/document";
 import { parseGroupDrawing } from "./groupDrawingParser";
 import { parseXmlDocument } from "./xmlParser";
 
@@ -50,5 +51,84 @@ describe("parseGroupDrawing", () => {
     expect(svg).toContain("A &amp; B");
     expect(svg).not.toContain("A & B");
     expect(svg).not.toContain('<rect width="2000000" height="1000000" fill="#FFFFFF"');
+  });
+
+  test("composes grouped pictures within the authored group extent", () => {
+    const drawing = parseXmlDocument(`
+      <w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+        xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+        xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup">
+        <wp:anchor behindDoc="1">
+          <wp:extent cx="2000000" cy="1000000"/>
+          <wp:wrapNone/>
+          <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup">
+            <wpg:wgp>
+              <wpg:grpSpPr><a:xfrm><a:chOff x="100" y="200"/><a:chExt cx="1800000" cy="800000"/></a:xfrm></wpg:grpSpPr>
+              <pic:pic>
+                <pic:blipFill><a:blip r:embed="rId1"/><a:srcRect l="25000"/></pic:blipFill>
+                <pic:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="900000" cy="800000"/></a:xfrm></pic:spPr>
+              </pic:pic>
+              <pic:pic>
+                <pic:blipFill><a:blip r:embed="rId2"/></pic:blipFill>
+                <pic:spPr><a:xfrm><a:off x="1000000" y="200"/><a:ext cx="900000" cy="800000"/></a:xfrm></pic:spPr>
+              </pic:pic>
+            </wpg:wgp>
+          </a:graphicData></a:graphic>
+        </wp:anchor>
+      </w:drawing>
+    `);
+    if (!drawing) {
+      throw new Error("Expected drawing fixture");
+    }
+    const rels: RelationshipMap = new Map([
+      [
+        "rId1",
+        {
+          id: "rId1",
+          type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+          target: "media/first.png",
+        },
+      ],
+      [
+        "rId2",
+        {
+          id: "rId2",
+          type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+          target: "media/second.png",
+        },
+      ],
+    ]);
+    const media = new Map<string, MediaFile>([
+      [
+        "word/media/first.png",
+        {
+          path: "word/media/first.png",
+          mimeType: "image/png",
+          data: new ArrayBuffer(0),
+          dataUrl: "data:image/png;base64,Zmlyc3Q=",
+        },
+      ],
+      [
+        "word/media/second.png",
+        {
+          path: "word/media/second.png",
+          mimeType: "image/png",
+          data: new ArrayBuffer(0),
+          dataUrl: "data:image/png;base64,c2Vjb25k",
+        },
+      ],
+    ]);
+
+    const image = parseGroupDrawing(drawing, rels, media);
+    expect(image?.size).toEqual({ width: 2_000_000, height: 1_000_000 });
+    const svg = decodeURIComponent(image?.src?.split(",").at(1) ?? "");
+    expect(svg).toContain('viewBox="100 200 1800000 800000"');
+    expect(svg.match(/<image /gu)).toHaveLength(2);
+    expect(svg).toContain('href="data:image/png;base64,Zmlyc3Q="');
+    expect(svg).toContain('href="data:image/png;base64,c2Vjb25k"');
+    expect(svg).toContain('<clipPath id="group-picture-1">');
   });
 });

--- a/packages/core/src/docx/groupDrawingParser.ts
+++ b/packages/core/src/docx/groupDrawingParser.ts
@@ -1,10 +1,11 @@
-import type { Image } from "../types/document";
+import type { Image, MediaFile, RelationshipMap } from "../types/document";
 import { emuToPixels } from "../utils/units";
-import { parseImage } from "./imageParser";
+import { parseImage, resolveImageData } from "./imageParser";
 import {
   findAllDeep,
   findChildByLocalName,
   findChildrenByLocalName,
+  getChildElements,
   getAttribute,
   getLocalName,
   getTextContent,
@@ -18,6 +19,7 @@ const DEFAULT_FONT_HALF_POINTS = 22;
 const DEFAULT_LINE_WIDTH_EMU = 9_525;
 const HALF_POINT_TO_EMU = 6_350;
 const MAX_GROUP_SHAPES = 256;
+const CROP_SCALE = 100_000;
 const MAX_PATH_COMMANDS = 10_000;
 const MAX_TEXT_CHARACTERS = 20_000;
 const MAX_SVG_CHARACTERS = 1_000_000;
@@ -187,16 +189,99 @@ const renderTextBox = (wsp: XmlElement): string => {
   return `<text x="0" y="${svgFontSize}" transform="translate(${x} ${y}) scale(${scale})" font-family="Arial, sans-serif" font-size="${svgFontSize}" fill="#${color}">${tspans}</text>`;
 };
 
-const createSvg = (group: XmlElement, width: number, height: number): string => {
-  const children = findChildrenByLocalName(group, "wsp").slice(0, MAX_GROUP_SHAPES);
+const renderPicture = (
+  picture: XmlElement,
+  index: number,
+  rels: RelationshipMap | undefined,
+  media: Map<string, MediaFile> | undefined,
+): string => {
+  const { x, y, width, height } = childTransform(picture);
+  if (width <= 0 || height <= 0) {
+    return "";
+  }
+  const blipFill = findChildByLocalName(picture, "blipFill");
+  const blip = findChildByLocalName(blipFill, "blip");
+  const rId = getAttribute(blip, "r", "embed") ?? getAttribute(blip, "r", "link") ?? "";
+  const { src } = resolveImageData(rId, rels, media);
+  if (!src) {
+    return "";
+  }
+
+  const sourceRect = findChildByLocalName(blipFill, "srcRect");
+  const left = Math.max(0, numericAttr(sourceRect, "l")) / CROP_SCALE;
+  const top = Math.max(0, numericAttr(sourceRect, "t")) / CROP_SCALE;
+  const right = Math.max(0, numericAttr(sourceRect, "r")) / CROP_SCALE;
+  const bottom = Math.max(0, numericAttr(sourceRect, "b")) / CROP_SCALE;
+  const visibleWidth = 1 - left - right;
+  const visibleHeight = 1 - top - bottom;
+  if (visibleWidth <= 0 || visibleHeight <= 0) {
+    return "";
+  }
+
+  const imageX = x - (width * left) / visibleWidth;
+  const imageY = y - (height * top) / visibleHeight;
+  const imageWidth = width / visibleWidth;
+  const imageHeight = height / visibleHeight;
+  const image = `<image x="${imageX}" y="${imageY}" width="${imageWidth}" height="${imageHeight}" href="${escapeXml(src)}" preserveAspectRatio="none"/>`;
+  if (left === 0 && top === 0 && right === 0 && bottom === 0) {
+    return image;
+  }
+  const clipId = `group-picture-${index}`;
+  return `<defs><clipPath id="${clipId}"><rect x="${x}" y="${y}" width="${width}" height="${height}"/></clipPath></defs><g clip-path="url(#${clipId})">${image}</g>`;
+};
+
+const groupViewBox = (
+  group: XmlElement,
+  width: number,
+  height: number,
+): { x: number; y: number; width: number; height: number } => {
+  const groupProperties = findChildByLocalName(group, "grpSpPr");
+  const transform = findChildByLocalName(groupProperties, "xfrm");
+  const childOffset = findChildByLocalName(transform, "chOff");
+  const childExtent = findChildByLocalName(transform, "chExt");
+  const childWidth = numericAttr(childExtent, "cx");
+  const childHeight = numericAttr(childExtent, "cy");
+  return {
+    x: numericAttr(childOffset, "x"),
+    y: numericAttr(childOffset, "y"),
+    width: childWidth > 0 ? childWidth : width,
+    height: childHeight > 0 ? childHeight : height,
+  };
+};
+
+const createSvg = (
+  group: XmlElement,
+  width: number,
+  height: number,
+  rels: RelationshipMap | undefined,
+  media: Map<string, MediaFile> | undefined,
+): string | null => {
+  const children = getChildElements(group).slice(0, MAX_GROUP_SHAPES);
   const content = children
-    .map((wsp) => (findChildByLocalName(wsp, "txbx") ? renderTextBox(wsp) : renderGeometry(wsp)))
+    .map((child, index) => {
+      const localName = getLocalName(child.name ?? "");
+      if (localName === "pic") {
+        return renderPicture(child, index, rels, media);
+      }
+      if (localName !== "wsp") {
+        return "";
+      }
+      return findChildByLocalName(child, "txbx") ? renderTextBox(child) : renderGeometry(child);
+    })
     .join("");
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${emuToPixels(width)}" height="${emuToPixels(height)}">${content}</svg>`;
+  if (!content) {
+    return null;
+  }
+  const viewBox = groupViewBox(group, width, height);
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}" width="${emuToPixels(width)}" height="${emuToPixels(height)}">${content}</svg>`;
 };
 
 /** Parse a WordprocessingGroup drawing into a safe SVG-backed image preview. */
-export const parseGroupDrawing = (drawing: XmlElement): Image | null => {
+export const parseGroupDrawing = (
+  drawing: XmlElement,
+  rels?: RelationshipMap,
+  media?: Map<string, MediaFile>,
+): Image | null => {
   const graphicData = findAllDeep(drawing, "a", "graphicData").at(0);
   const group = findChildByLocalName(graphicData ?? null, "wgp");
   if (!group) {
@@ -206,8 +291,8 @@ export const parseGroupDrawing = (drawing: XmlElement): Image | null => {
   if (!image || image.size.width <= 0 || image.size.height <= 0) {
     return null;
   }
-  const svg = createSvg(group, image.size.width, image.size.height);
-  if (svg.length > MAX_SVG_CHARACTERS) {
+  const svg = createSvg(group, image.size.width, image.size.height, rels, media);
+  if (!svg || svg.length > MAX_SVG_CHARACTERS) {
     return null;
   }
   image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -59,6 +59,7 @@ import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
 import {
   cloneWithXmlnsDeclarations,
+  findAllDeep,
   findChild,
   findChildren,
   getAttribute,
@@ -817,7 +818,7 @@ function parseDrawingContent(
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
 ): DrawingContent | ShapeContent | null {
-  const groupImage = parseGroupDrawing(element);
+  const groupImage = parseGroupDrawing(element, rels ?? undefined, media ?? undefined);
   if (groupImage) {
     return { type: "drawing", image: groupImage, rawXml: elementToXml(element) };
   }
@@ -977,14 +978,31 @@ function parseRunContents(
 
       case "AlternateContent": {
         // mc:AlternateContent — folio cannot evaluate `mc:Requires`, so it
-        // renders the Choice by default. A VML `w:pict` in the Fallback is the
-        // compatibility image folio can always show; prefer it only when it
-        // resolves to a real media part (not a textbox / empty pict / broken
-        // relationship), otherwise fall through to the Choice's DrawingML image.
+        // renders the Choice by default. A supported grouped Choice retains
+        // authored group geometry, so it takes priority over a flattened
+        // fallback. Otherwise, prefer a VML `w:pict` in the Fallback only when
+        // it resolves to a real media part (not a textbox / empty pict / broken
+        // relationship), then fall through to the Choice's DrawingML image.
         // The whole AlternateContent is kept on save so the Choice is not lost.
         const alternateChildren = getChildElements(child);
         const choiceEl = alternateChildren.find((el) => getLocalName(el.name) === "Choice");
         const fallbackEl = alternateChildren.find((el) => getLocalName(el.name) === "Fallback");
+
+        const groupedChoiceDrawing = choiceEl
+          ? getChildElements(choiceEl).find(
+              (element) =>
+                getLocalName(element.name) === "drawing" &&
+                findAllDeep(element, "wpg", "wgp").length > 0,
+            )
+          : undefined;
+        if (groupedChoiceDrawing) {
+          const groupedDrawing = parseDrawingContent(groupedChoiceDrawing, rels, media);
+          if (groupedDrawing?.type === "drawing" && groupedDrawing.image.src) {
+            groupedDrawing.rawXml = elementToXml(child);
+            contents.push(groupedDrawing);
+            break;
+          }
+        }
 
         const fallbackPict = fallbackEl
           ? getChildElements(fallbackEl).find((el) => getLocalName(el.name) === "pict")


### PR DESCRIPTION
Summary:
- compose grouped OOXML picture members into a single SVG preview
- preserve group coordinates, authored extent, and picture crops
- prefer a renderable grouped Choice over a flattened compatibility fallback

Validation:
- focused parser and fallback-image tests: 22 passed
- dependency audit: no vulnerabilities
- anonymous strict-font parity replay: missing lines reduced from 2 to 0; matched lines increased from 39 to 41
- lint, typecheck, and full suites are delegated to CI

CC on behalf of @jan-kubica