### PR TITLE
fix: collapse automatic list spacing

### DIFF
--- a/.changeset/automatic-list-spacing.md
+++ b/.changeset/automatic-list-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Suppress automatic paragraph gaps inside continuous numbered sequences.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -553,7 +553,11 @@ export type PaginatorOptions = {
 export type ParagraphAttrs = {
     alignment?: "left" | "center" | "right" | "justify"; /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
     outlineLevel?: number;
-    spacing?: ParagraphSpacing;
+    spacing?: ParagraphSpacing; /** Spacing sides resolved from OOXML automatic paragraph spacing. */
+    automaticSpacing?: {
+        before?: boolean;
+        after?: boolean;
+    };
     spacingExplicit?: {
         before?: boolean;
         after?: boolean;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -285,6 +285,7 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.kind).toBe("paragraph");
     expect(paragraph?.attrs?.spacing?.before).toBe(AUTO_PARAGRAPH_SPACING_PX);
     expect(paragraph?.attrs?.spacing?.after).toBe(AUTO_PARAGRAPH_SPACING_PX);
+    expect(paragraph?.attrs?.automaticSpacing).toEqual({ before: true, after: true });
   });
 
   test("an explicit spacing edit overrides imported auto-spacing (#823)", () => {
@@ -308,6 +309,7 @@ describe("toFlowBlocks paragraph formatting", () => {
     const paragraph = toFlowBlocks(doc).at(0);
 
     expect(paragraph?.attrs?.spacing?.before).toBe(16); // 240 twips, not the 14pt auto gap
+    expect(paragraph?.attrs?.automaticSpacing).toBeUndefined();
   });
 
   test("auto spacing still applies when a style supplies spacing the import lacked (#823)", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1410,6 +1410,12 @@ function convertParagraphAttrs(
     } else if (typeof spaceAfter === "number") {
       attrs.spacing.after = twipsToPixels(spaceAfter);
     }
+    if (autoBefore || autoAfter) {
+      attrs.automaticSpacing = {
+        ...(autoBefore ? { before: true } : {}),
+        ...(autoAfter ? { after: true } : {}),
+      };
+    }
     // Propagate the `spacingExplicit` flag the PM schema carries — empty
     // paragraphs inherit zero spacing unless the side was set inline (Word
     // fidelity, eigenpal #402). Auto spacing counts as explicit: an imported

--- a/packages/core/src/layout-engine/automaticListSpacing.test.ts
+++ b/packages/core/src/layout-engine/automaticListSpacing.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { layoutDocument } from "./index";
+import type { LayoutOptions, ParagraphBlock, ParagraphMeasure } from "./types";
+
+const layoutOptions: LayoutOptions = {
+  pageSize: { w: 600, h: 1200 },
+  margins: { top: 0, right: 0, bottom: 0, left: 0 },
+  pageGap: 20,
+};
+
+const paragraphMeasure: ParagraphMeasure = {
+  kind: "paragraph",
+  lines: [
+    {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 0,
+      width: 100,
+      ascent: 14,
+      descent: 4,
+      lineHeight: 18,
+    },
+  ],
+  totalHeight: 18,
+};
+
+type NumberedParagraphOptions = {
+  id: string;
+  numId: number;
+  automaticSpacing?: { before?: boolean; after?: boolean };
+};
+
+const numberedParagraph = ({
+  id,
+  numId,
+  automaticSpacing,
+}: NumberedParagraphOptions): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: [{ kind: "text", text: id }],
+  attrs: {
+    spacing: { before: 18, after: 18 },
+    ...(automaticSpacing ? { automaticSpacing } : {}),
+    numPr: { numId, ilvl: 0 },
+  },
+});
+
+describe("automatic numbered-list spacing", () => {
+  test("suppresses automatic spacing inside one sequence", () => {
+    const first = numberedParagraph({
+      id: "first",
+      numId: 4,
+      automaticSpacing: { after: true },
+    });
+    const second = numberedParagraph({
+      id: "second",
+      numId: 4,
+      automaticSpacing: { before: true },
+    });
+
+    layoutDocument([first, second], [paragraphMeasure, paragraphMeasure], layoutOptions);
+
+    expect(first.attrs?.spacing).toEqual({ before: 18, after: 0 });
+    expect(second.attrs?.spacing).toEqual({ before: 0, after: 18 });
+  });
+
+  test("keeps automatic spacing at a sequence boundary", () => {
+    const first = numberedParagraph({
+      id: "first",
+      numId: 4,
+      automaticSpacing: { after: true },
+    });
+    const second = numberedParagraph({
+      id: "second",
+      numId: 5,
+      automaticSpacing: { before: true },
+    });
+
+    layoutDocument([first, second], [paragraphMeasure, paragraphMeasure], layoutOptions);
+
+    expect(first.attrs?.spacing).toEqual({ before: 18, after: 18 });
+    expect(second.attrs?.spacing).toEqual({ before: 18, after: 18 });
+  });
+
+  test("keeps explicit spacing inside one sequence", () => {
+    const first = numberedParagraph({ id: "first", numId: 4 });
+    const second = numberedParagraph({ id: "second", numId: 4 });
+
+    layoutDocument([first, second], [paragraphMeasure, paragraphMeasure], layoutOptions);
+
+    expect(first.attrs?.spacing).toEqual({ before: 18, after: 18 });
+    expect(second.attrs?.spacing).toEqual({ before: 18, after: 18 });
+  });
+});

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -356,6 +356,40 @@ export function applyContextualSpacing(blocks: FlowBlock[]): void {
   }
 }
 
+/** Suppress automatic inter-item spacing within one numbered sequence. */
+const applyAutomaticListSpacing = (blocks: FlowBlock[]): void => {
+  for (let index = 1; index < blocks.length; index++) {
+    const previous = blocks[index - 1];
+    const current = blocks[index];
+    if (
+      previous?.kind !== "paragraph" ||
+      current?.kind !== "paragraph" ||
+      !continuesNumberedSequence(previous, current)
+    ) {
+      continue;
+    }
+
+    if (previous.attrs?.automaticSpacing?.after && previous.attrs.spacing) {
+      previous.attrs.spacing = { ...previous.attrs.spacing, after: 0 };
+    }
+    if (current.attrs?.automaticSpacing?.before && current.attrs.spacing) {
+      current.attrs.spacing = { ...current.attrs.spacing, before: 0 };
+    }
+  }
+
+  for (const block of blocks) {
+    if (block.kind === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          applyAutomaticListSpacing(cell.blocks);
+        }
+      }
+    } else if (block.kind === "textBox") {
+      applyAutomaticListSpacing(block.content);
+    }
+  }
+};
+
 /**
  * Layout a document: convert blocks + measures into pages with positioned fragments.
  *
@@ -453,6 +487,7 @@ export function layoutDocument(
   // consecutive paragraphs that both have contextualSpacing=true and share
   // the same styleId (OOXML spec 17.3.1.9 / ECMA-376 §17.3.1.9).
   applyContextualSpacing(blocks);
+  applyAutomaticListSpacing(blocks);
 
   // Pre-compute keepNext chains for pagination decisions
   const keepNextChains = computeKeepNextChains(blocks);

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -372,6 +372,8 @@ export type ParagraphAttrs = {
   /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
   outlineLevel?: number;
   spacing?: ParagraphSpacing;
+  /** Spacing sides resolved from OOXML automatic paragraph spacing. */
+  automaticSpacing?: { before?: boolean; after?: boolean };
   /**
    * Tracks which `spacing` sides came from inline (`<w:pPr><w:spacing>`)
    * formatting versus inherited via paragraph style. Word collapses


### PR DESCRIPTION
## Summary

- preserve which paragraph gaps came from OOXML automatic spacing when building layout blocks
- suppress only automatic inter-item gaps between adjacent paragraphs in one numbered sequence
- retain explicit gaps and automatic spacing at sequence boundaries
- add focused regression and cross-case coverage plus a core patch changeset

## Validation

- `bun test src/layout-engine/automaticListSpacing.test.ts src/layout-bridge/convert/toFlowBlocks.test.ts` (68 passed)
- `bun audit` (no vulnerabilities)
- anonymous parity replay: 84.7% to 90.3%; page count improved from 2/3 to 2/2 while 70 of 72 reference lines remained matched
- lint and typecheck deferred to CI

CC on behalf of @jan-kubica