### PR TITLE
fix: keep body below default headers

### DIFF
--- a/.changeset/default-header-body-clearance.md
+++ b/.changeset/default-header-body-clearance.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep body content below the in-flow extent of default headers.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -530,6 +530,56 @@ describe("runLayoutPipeline", () => {
     );
   });
 
+  test("moves body content below an overflowing default header", () => {
+    const state = makeState();
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        headerContent: { type: "header", hdrFtrType: "default", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "header"
+            ? {
+                blocks: [],
+                measures: [],
+                height: 120,
+                visualTop: 0,
+                visualBottom: 120,
+                marginPushTop: 0,
+                marginPushBottom: 120,
+              }
+            : undefined,
+      }),
+      state,
+    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.top).toBe(MARGINS.header + 120);
+    expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(MARGINS.header + 120);
+  });
+
+  test("keeps authored body margin when a default header stays above it", () => {
+    const state = makeState();
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        headerContent: { type: "header", hdrFtrType: "default", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "header"
+            ? {
+                blocks: [],
+                measures: [],
+                height: 20,
+                visualTop: 0,
+                visualBottom: 20,
+                marginPushTop: 0,
+                marginPushBottom: 20,
+              }
+            : undefined,
+      }),
+      state,
+    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.top).toBe(MARGINS.top);
+    expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(MARGINS.top);
+  });
+
   test("moves only the title-page body below an overflowing first-page header", () => {
     const state = makeState();
     const baseline = runLayoutPipeline(makeDeps(createLayoutSession()), state);

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -150,6 +150,21 @@ export type LayoutPipelineDeps<THfPMs> = {
   emptyTemplatePreviewEntries: readonly TemplatePreviewEntry[];
 };
 
+function bodyMarginsBelowHeader(
+  authoredMargins: PageMargins,
+  preparedHeader: HeaderFooterContent | undefined,
+): PageMargins {
+  if (!preparedHeader) {
+    return authoredMargins;
+  }
+  const headerBottom =
+    (authoredMargins.header ?? 0) + (preparedHeader.marginPushBottom ?? preparedHeader.height);
+  if (headerBottom <= authoredMargins.top) {
+    return authoredMargins;
+  }
+  return { ...authoredMargins, top: headerBottom };
+}
+
 export function runLayoutPipeline<THfPMs>(
   deps: LayoutPipelineDeps<THfPMs>,
   state: EditorState,
@@ -368,23 +383,31 @@ export function runLayoutPipeline<THfPMs>(
       hfOptions,
     );
 
+    const initialBodyMargins = bodyMarginsBelowHeader(margins, headerContentForRender);
+
     recordPhaseDuration("header-footer", phaseStartedAt);
 
-    // Compute per-block widths and band geometry from the authored section
-    // margins. Header/footer paint bounds never redefine the body text area.
+    // Compute per-block widths and band geometry from the effective body
+    // margins after normal in-flow header content has been accounted for.
     phaseStartedAt = performance.now();
     const bodyLayoutConfig: SectionLayoutConfig = {
       pageSize,
-      margins,
+      margins: initialBodyMargins,
     };
     if (columns !== undefined) {
       bodyLayoutConfig.columns = columns;
     }
     const finalSectionProperties = document?.package.document.sections?.at(-1)?.properties;
+    const finalHeaderRId = sectionHeaderFooterRefs?.at(-1)?.headerDefault;
+    const finalHeaderForLayout = finalHeaderRId
+      ? headerContentByRId?.get(finalHeaderRId)
+      : sectionHeaderFooterRefs === undefined
+        ? headerContentForRender
+        : undefined;
     const finalLayoutConfig: SectionLayoutConfig = finalSectionProperties
       ? {
           pageSize: getPageSize(finalSectionProperties),
-          margins: getMargins(finalSectionProperties),
+          margins: bodyMarginsBelowHeader(getMargins(finalSectionProperties), finalHeaderForLayout),
         }
       : bodyLayoutConfig;
     const finalColumns = getColumns(finalSectionProperties);
@@ -444,18 +467,12 @@ export function runLayoutPipeline<THfPMs>(
     const buildLayoutOpts = (): Parameters<typeof layoutDocument>[2] => {
       const nextLayoutOpts: Parameters<typeof layoutDocument>[2] = {
         pageSize,
-        margins,
+        margins: initialBodyMargins,
         pageGap,
         mirrorMargins,
       };
-      if (hasTitlePg && firstPageHeaderForRender) {
-        const headerDistance = margins.header ?? 0;
-        const headerBottom =
-          headerDistance +
-          (firstPageHeaderForRender.marginPushBottom ?? firstPageHeaderForRender.height);
-        if (headerBottom > margins.top) {
-          nextLayoutOpts.firstPageMargins = { ...margins, top: headerBottom };
-        }
+      if (hasTitlePg) {
+        nextLayoutOpts.firstPageMargins = bodyMarginsBelowHeader(margins, firstPageHeaderForRender);
       }
       if (finalSectionProperties) {
         nextLayoutOpts.finalPageSize = finalLayoutConfig.pageSize;

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -399,11 +399,12 @@ export function runLayoutPipeline<THfPMs>(
     }
     const finalSectionProperties = document?.package.document.sections?.at(-1)?.properties;
     const finalHeaderRId = sectionHeaderFooterRefs?.at(-1)?.headerDefault;
-    const finalHeaderForLayout = finalHeaderRId
-      ? headerContentByRId?.get(finalHeaderRId)
-      : sectionHeaderFooterRefs === undefined
-        ? headerContentForRender
-        : undefined;
+    let finalHeaderForLayout = headerContentForRender;
+    if (finalHeaderRId) {
+      finalHeaderForLayout = headerContentByRId?.get(finalHeaderRId);
+    } else if (sectionHeaderFooterRefs !== undefined) {
+      finalHeaderForLayout = undefined;
+    }
     const finalLayoutConfig: SectionLayoutConfig = finalSectionProperties
       ? {
           pageSize: getPageSize(finalSectionProperties),


### PR DESCRIPTION
## Summary

- derive the body start from the header distance and in-flow header extent when that exceeds the authored top margin
- preserve authored margins for contained headers and keep footer behavior unchanged
- add focused positive and cross-case regression coverage

## Verification

- focused layout pipeline tests pass
- an anonymous strict same-font parity replay improved from 86.6% to 93.5% with page count preserved
- a separate anonymous cross-case replay improved from 90.4% to 91.8% with page count preserved
- dependency audit reports no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica