### PR TITLE
fix: preserve authored list marker positions

### DIFF
--- a/.changeset/steady-list-anchors.md
+++ b/.changeset/steady-list-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored first-line list positions when deriving layout indentation.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -27,11 +27,9 @@ describe("toFlowBlocks paragraph formatting", () => {
   test("keeps the default indent for a list without authored positioning", () => {
     const paragraph = toFlowBlocks(
       schema.node("doc", null, [
-        schema.node(
-          "paragraph",
-          { numPr: { numId: 1, ilvl: 1 }, listMarker: "%1.%2." },
-          [schema.text("Nested item")],
-        ),
+        schema.node("paragraph", { numPr: { numId: 1, ilvl: 1 }, listMarker: "%1.%2." }, [
+          schema.text("Nested item"),
+        ]),
       ]),
     ).at(0);
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -5,6 +5,39 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("does not add a default list indent to an authored first-line position", () => {
+    const paragraph = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            numPr: { numId: 1, ilvl: 0 },
+            listMarker: "%1)",
+            indentFirstLine: 780,
+            tabs: [{ position: 1200, alignment: "left" }],
+          },
+          [schema.text("First item")],
+        ),
+      ]),
+    ).at(0);
+
+    expect(paragraph?.attrs?.indent).toEqual({ firstLine: 52 });
+  });
+
+  test("keeps the default indent for a list without authored positioning", () => {
+    const paragraph = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          { numPr: { numId: 1, ilvl: 1 }, listMarker: "%1.%2." },
+          [schema.text("Nested item")],
+        ),
+      ]),
+    ).at(0);
+
+    expect(paragraph?.attrs?.indent).toEqual({ left: 96, hanging: 24 });
+  });
+
   test("does not paint an empty structural section-break paragraph", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { sectionBreakType: "continuous" }),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1461,8 +1461,11 @@ function convertParagraphAttrs(
   let indentFirstLine =
     typeof pmAttrs.indentFirstLine === "number" ? pmAttrs.indentFirstLine : undefined;
   let hangingIndent = pmAttrs.hangingIndent;
-  if (pmAttrs.numPr?.numId && indentLeft === undefined) {
+  if (pmAttrs.numPr?.numId && indentLeft === undefined && indentFirstLine === undefined) {
     // Fallback: calculate indentation based on level
+    // An authored first-line or hanging position is already a complete list
+    // marker anchor. Adding a synthetic left indent would shift that anchor a
+    // second time, while tab stops still resolve from the paragraph margin.
     // Each level indents 0.5 inch (720 twips) more
     const level = pmAttrs.numPr.ilvl ?? 0;
     // Base indentation: 0.5 inch (720 twips) per level


### PR DESCRIPTION
## Summary

- keep explicit first-line list anchors from receiving a synthetic default left indent
- retain the fallback for lists without authored positioning
- add focused layout-bridge coverage and a patch changeset

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved authored first-line list positioning when converting formatted paragraphs.
  * Prevented extra indentation from being added when a list’s marker position is already defined.
  * Maintained default indentation for nested lists without authored positioning.

* **Tests**
  * Added coverage for authored and fallback list-indentation behavior.

* **Release**
  * Included a patch release for `@stll/folio-core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->