### PR TITLE
feat: add structured DOCX text extraction

### DIFF
--- a/.changeset/calm-tables-extract.md
+++ b/.changeset/calm-tables-extract.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add structured DOCX text extraction to the server API.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -67,6 +67,33 @@ export type DeriveBlockIdInput = {
     taken: ReadonlySet<string>;
 };
 
+// @public
+export class DocxArchiveError extends DocxArchiveError_base {}
+
+// @public
+export type DocxParagraphSource = "header" | "body" | "footer";
+
+// @public
+export const extractDocxText: (bytes: ArrayBuffer | Uint8Array) => Promise<ExtractedDocxText>;
+
+// @public
+export type ExtractedDocxParagraph = {
+    index: number;
+    text: string;
+    source: DocxParagraphSource;
+    style?: string;
+    bold?: boolean;
+    fontSize?: number;
+    alignment?: "left" | "center" | "right" | "both";
+};
+
+// @public
+export type ExtractedDocxText = {
+    paragraphs: ExtractedDocxParagraph[];
+    charCount: number;
+    view: "accepted";
+};
+
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES: readonly ["best-effort", "atomic"];
 

--- a/packages/core/src/docx/server/boundedArchive.test.ts
+++ b/packages/core/src/docx/server/boundedArchive.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { DocxArchiveError, loadDocxArchive } from "./boundedArchive";
+
+const makeZip = async (entries: Record<string, string>): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  for (const [path, content] of Object.entries(entries)) {
+    zip.file(path, content);
+  }
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+const rejection = async (promise: Promise<unknown>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected promise to reject");
+};
+
+describe("loadDocxArchive", () => {
+  test("reads text and bytes and reports missing entries", async () => {
+    const archive = await loadDocxArchive(
+      await makeZip({ "word/document.xml": "content", "media.bin": "abc" }),
+    );
+
+    expect(await archive.readEntryString("word/document.xml")).toBe("content");
+    expect(await archive.readEntryUint8("media.bin")).toEqual(new Uint8Array([97, 98, 99]));
+    expect(await archive.readEntryString("missing.xml")).toBeNull();
+  });
+
+  test("rejects invalid archives with a tagged error", async () => {
+    const error = await rejection(loadDocxArchive(new TextEncoder().encode("not a zip")));
+
+    expect(error).toBeInstanceOf(DocxArchiveError);
+    expect(error).toMatchObject({
+      _tag: "DocxArchiveError",
+      reason: "load-failed",
+    });
+  });
+
+  test("rejects excessive entry counts before reading", async () => {
+    const error = await rejection(
+      loadDocxArchive(await makeZip({ a: "1", b: "2" }), {
+        maxEntries: 1,
+      }),
+    );
+
+    expect(error).toMatchObject({ reason: "too-many-entries" });
+  });
+
+  test("rejects declared entry and cumulative sizes", async () => {
+    const bytes = await makeZip({ a: "12345", b: "67890" });
+    const entryError = await rejection(loadDocxArchive(bytes, { maxEntryBytes: 4 }));
+    const totalError = await rejection(loadDocxArchive(bytes, { maxTotalBytes: 8 }));
+
+    expect(entryError).toMatchObject({ reason: "entry-too-large" });
+    expect(totalError).toMatchObject({ reason: "total-too-large" });
+  });
+
+  test("serializes concurrent reads against the cumulative budget", async () => {
+    const archive = await loadDocxArchive(await makeZip({ a: "12345", b: "67890" }), {
+      maxEntryBytes: 5,
+      maxTotalBytes: 10,
+    });
+
+    const results = await Promise.allSettled([
+      archive.readEntryString("a"),
+      archive.readEntryString("b"),
+      archive.readEntryString("a"),
+    ]);
+
+    expect(results.map(({ status }) => status)).toEqual(["fulfilled", "fulfilled", "rejected"]);
+    expect(results.at(2)).toMatchObject({
+      reason: { reason: "total-too-large" },
+    });
+  });
+});

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -1,0 +1,168 @@
+import { TaggedError } from "better-result";
+import JSZip from "jszip";
+
+export const DOCX_MAX_ENTRY_BYTES = 128 * 1024 * 1024;
+export const DOCX_MAX_TOTAL_BYTES = 256 * 1024 * 1024;
+export const DOCX_MAX_ENTRIES = 4096;
+
+/** Error raised when a DOCX archive cannot be loaded within configured limits. */
+export class DocxArchiveError extends TaggedError("DocxArchiveError")<{
+  message: string;
+  reason: "load-failed" | "too-many-entries" | "entry-too-large" | "total-too-large";
+  cause?: unknown;
+}>() {}
+
+export type DocxArchiveOptions = {
+  maxEntryBytes?: number;
+  maxTotalBytes?: number;
+  maxEntries?: number;
+};
+
+export type DocxArchive = {
+  entries: readonly string[];
+  readEntryString: (path: string) => Promise<string | null>;
+  readEntryUint8: (path: string) => Promise<Uint8Array | null>;
+};
+
+type CollectStreamOptions = {
+  stream: NodeJS.ReadableStream;
+  maxEntryBytes: number;
+  remainingBytes: number;
+  maxTotalBytes: number;
+  path: string;
+};
+
+const collectStream = async ({
+  stream,
+  maxEntryBytes,
+  remainingBytes,
+  maxTotalBytes,
+  path,
+}: CollectStreamOptions): Promise<Buffer> =>
+  await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let entryBytes = 0;
+
+    const fail = (reason: "entry-too-large" | "total-too-large", message: string) => {
+      const destroy: unknown = Reflect.get(stream, "destroy");
+      if (typeof destroy === "function") {
+        Reflect.apply(destroy, stream, []);
+      }
+      reject(new DocxArchiveError({ message, reason }));
+    };
+
+    stream.on("data", (chunk: Buffer | string) => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      entryBytes += bytes.length;
+
+      if (entryBytes > maxEntryBytes) {
+        fail("entry-too-large", `DOCX entry "${path}" exceeded the ${maxEntryBytes}-byte limit`);
+        return;
+      }
+      if (entryBytes > remainingBytes) {
+        fail(
+          "total-too-large",
+          `DOCX archive exceeded the ${maxTotalBytes}-byte cumulative limit while reading "${path}"`,
+        );
+        return;
+      }
+      chunks.push(bytes);
+    });
+    stream.on("end", () => resolve(Buffer.concat(chunks)));
+    stream.on("error", reject);
+  });
+
+export const loadDocxArchive = async (
+  bytes: ArrayBuffer | Uint8Array,
+  options: DocxArchiveOptions = {},
+): Promise<DocxArchive> => {
+  const maxEntryBytes = options.maxEntryBytes ?? DOCX_MAX_ENTRY_BYTES;
+  const maxTotalBytes = options.maxTotalBytes ?? DOCX_MAX_TOTAL_BYTES;
+  const maxEntries = options.maxEntries ?? DOCX_MAX_ENTRIES;
+
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(bytes);
+  } catch (cause) {
+    throw new DocxArchiveError({
+      message: "Failed to parse DOCX archive",
+      reason: "load-failed",
+      cause,
+    });
+  }
+
+  const archiveEntries = Object.values(zip.files);
+  if (archiveEntries.length > maxEntries) {
+    throw new DocxArchiveError({
+      message: `DOCX archive declares ${archiveEntries.length} entries (max ${maxEntries})`,
+      reason: "too-many-entries",
+    });
+  }
+
+  let declaredTotalBytes = 0;
+  for (const entry of archiveEntries) {
+    const data = "_data" in entry ? entry._data : undefined;
+    const declaredBytes =
+      typeof data === "object" && data !== null && "uncompressedSize" in data
+        ? data.uncompressedSize
+        : undefined;
+    if (typeof declaredBytes !== "number" || !Number.isFinite(declaredBytes)) {
+      declaredTotalBytes = Number.NaN;
+      break;
+    }
+    if (declaredBytes > maxEntryBytes) {
+      throw new DocxArchiveError({
+        message: `DOCX entry "${entry.name}" declares ${declaredBytes} bytes (max ${maxEntryBytes})`,
+        reason: "entry-too-large",
+      });
+    }
+    declaredTotalBytes += declaredBytes;
+  }
+
+  if (Number.isFinite(declaredTotalBytes) && declaredTotalBytes > maxTotalBytes) {
+    throw new DocxArchiveError({
+      message: `DOCX archive declares ${declaredTotalBytes} cumulative bytes (max ${maxTotalBytes})`,
+      reason: "total-too-large",
+    });
+  }
+
+  let totalBytesRead = 0;
+  let readChain: Promise<unknown> = Promise.resolve();
+
+  const readEntry = async (path: string): Promise<Buffer | null> => {
+    const work = async (): Promise<Buffer | null> => {
+      const entry = zip.file(path);
+      if (!entry) {
+        return null;
+      }
+      const buffer = await collectStream({
+        stream: entry.nodeStream("nodebuffer"),
+        maxEntryBytes,
+        remainingBytes: maxTotalBytes - totalBytesRead,
+        maxTotalBytes,
+        path,
+      });
+      totalBytesRead += buffer.length;
+      return buffer;
+    };
+
+    const next = readChain.then(work, work);
+    readChain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await next;
+  };
+
+  return {
+    entries: Object.freeze(archiveEntries.map(({ name }) => name)),
+    async readEntryString(path) {
+      const buffer = await readEntry(path);
+      return buffer === null ? null : buffer.toString("utf-8");
+    },
+    async readEntryUint8(path) {
+      const buffer = await readEntry(path);
+      return buffer === null ? null : new Uint8Array(buffer);
+    },
+  };
+};

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { extractDocxText } from "./extractDocxText";
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+type MakeDocxOptions = {
+  body: string;
+  headers?: Record<string, string>;
+  footers?: Record<string, string>;
+};
+
+const makeDocx = async ({
+  body,
+  headers = {},
+  footers = {},
+}: MakeDocxOptions): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
+  );
+  for (const [path, content] of Object.entries(headers)) {
+    zip.file(path, `<w:hdr xmlns:w="${W_NS}">${content}</w:hdr>`);
+  }
+  for (const [path, content] of Object.entries(footers)) {
+    zip.file(path, `<w:ftr xmlns:w="${W_NS}">${content}</w:ftr>`);
+  }
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+describe("extractDocxText", () => {
+  test("returns deterministic paragraphs across document parts", async () => {
+    const bytes = await makeDocx({
+      body:
+        paragraph("Before") +
+        `<w:tbl><w:tr><w:tc>${paragraph("Cell")}</w:tc></w:tr></w:tbl>` +
+        `<w:sdt><w:sdtContent>${paragraph("Control")}</w:sdtContent></w:sdt>` +
+        paragraph("After"),
+      headers: {
+        "word/header2.xml": paragraph("Header 2"),
+        "word/header1.xml": paragraph("Header 1"),
+      },
+      footers: {
+        "word/footer1.xml": paragraph("Footer"),
+      },
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(
+      result.paragraphs.map(({ index, text, source }) => ({
+        index,
+        text,
+        source,
+      })),
+    ).toEqual([
+      { index: 0, text: "Header 1", source: "header" },
+      { index: 1, text: "Header 2", source: "header" },
+      { index: 2, text: "Before", source: "body" },
+      { index: 3, text: "Cell", source: "body" },
+      { index: 4, text: "Control", source: "body" },
+      { index: 5, text: "After", source: "body" },
+      { index: 6, text: "Footer", source: "footer" },
+    ]);
+    expect(result.charCount).toBe("Header 1Header 2BeforeCellControlAfterFooter".length);
+    expect(result.view).toBe("accepted");
+  });
+
+  test("preserves explicit whitespace and applies the accepted revision view", async () => {
+    const bytes = await makeDocx({
+      body: `<w:p>
+        <w:r><w:t>Keep</w:t><w:br/><w:t>Line</w:t><w:tab/><w:t>Tab</w:t></w:r>
+        <w:del><w:r><w:delText>Deleted</w:delText></w:r></w:del>
+        <w:moveFrom><w:r><w:t>Moved away</w:t></w:r></w:moveFrom>
+        <w:ins><w:r><w:t>Inserted</w:t></w:r></w:ins>
+      </w:p>`,
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.at(0)?.text).toBe("Keep\nLine\tTabInserted");
+  });
+
+  test("extracts paragraph and majority-run formatting metadata", async () => {
+    const bytes = await makeDocx({
+      body: `<w:p>
+        <w:pPr><w:pStyle w:val="Heading1"/><w:jc w:val="center"/></w:pPr>
+        <w:r><w:rPr><w:b/><w:sz w:val="28"/></w:rPr><w:t>Majority</w:t></w:r>
+        <w:r><w:t>x</w:t></w:r>
+      </w:p>
+      <w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Left</w:t></w:r></w:p>`,
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.at(0)).toEqual({
+      index: 0,
+      text: "Majorityx",
+      source: "body",
+      style: "Heading1",
+      alignment: "center",
+      bold: true,
+      fontSize: 28,
+    });
+    expect(result.paragraphs.at(1)?.alignment).toBe("left");
+  });
+
+  test("supports alternate prefixes for the main OOXML namespace", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `<x:document xmlns:x="${W_NS}"><x:body><x:p><x:pPr><x:pStyle x:val="Title"/></x:pPr><x:r><x:t>Alternate</x:t></x:r></x:p></x:body></x:document>`,
+    );
+    const bytes = await zip.generateAsync({ type: "uint8array" });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.at(0)?.text).toBe("Alternate");
+    expect(result.paragraphs.at(0)?.style).toBe("Title");
+  });
+
+  test("returns an empty result when the main document part is absent", async () => {
+    const zip = new JSZip();
+    zip.file("other.xml", "<root/>");
+    const bytes = await zip.generateAsync({ type: "uint8array" });
+
+    expect(await extractDocxText(bytes)).toEqual({
+      paragraphs: [],
+      charCount: 0,
+      view: "accepted",
+    });
+  });
+});

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -1,0 +1,283 @@
+import type { DocxArchive } from "./boundedArchive";
+import { loadDocxArchive } from "./boundedArchive";
+import {
+  findAllDeep,
+  findChild,
+  findDeep,
+  getAttributeAnyPrefix,
+  getLocalName,
+  getTextContent,
+  parseXml,
+  type XmlElement,
+} from "../xmlParser";
+
+const HEADER_FOOTER_PATH = /^word\/(?:header|footer)\d+\.xml$/u;
+
+/** Document part containing an extracted paragraph. */
+export type DocxParagraphSource = "header" | "body" | "footer";
+
+/** Paragraph text and lightweight formatting metadata from a DOCX archive. */
+export type ExtractedDocxParagraph = {
+  index: number;
+  text: string;
+  source: DocxParagraphSource;
+  style?: string;
+  bold?: boolean;
+  fontSize?: number;
+  alignment?: "left" | "center" | "right" | "both";
+};
+
+/** Accepted-revision paragraph text extracted in deterministic part order. */
+export type ExtractedDocxText = {
+  paragraphs: ExtractedDocxParagraph[];
+  charCount: number;
+  view: "accepted";
+};
+
+type ParagraphProperties = Pick<ExtractedDocxParagraph, "style" | "alignment">;
+
+type RunMetrics = {
+  bold: boolean;
+  fontSize?: number;
+  chars: number;
+};
+
+const childElements = (element: XmlElement): XmlElement[] =>
+  element.elements?.filter((child) => child.type === "element") ?? [];
+
+const collectText = (element: XmlElement): string => {
+  let text = "";
+
+  const walk = (node: XmlElement) => {
+    const localName = getLocalName(node.name ?? "");
+    if (localName === "t") {
+      text += getTextContent(node);
+      return;
+    }
+    if (localName === "br") {
+      text += "\n";
+      return;
+    }
+    if (localName === "tab") {
+      text += "\t";
+      return;
+    }
+    if (localName === "del" || localName === "delText" || localName === "moveFrom") {
+      return;
+    }
+    for (const child of childElements(node)) {
+      walk(child);
+    }
+  };
+
+  walk(element);
+  return text;
+};
+
+const readParagraphProperties = (paragraph: XmlElement): ParagraphProperties => {
+  const properties = findChild(paragraph, "w", "pPr");
+  if (!properties) {
+    return {};
+  }
+
+  const result: ParagraphProperties = {};
+  const style = findChild(properties, "w", "pStyle");
+  const styleValue = getAttributeAnyPrefix(style, "val");
+  if (styleValue !== null) {
+    result.style = styleValue;
+  }
+
+  const justification = findChild(properties, "w", "jc");
+  const alignment = getAttributeAnyPrefix(justification, "val");
+  if (
+    alignment === "left" ||
+    alignment === "center" ||
+    alignment === "right" ||
+    alignment === "both"
+  ) {
+    result.alignment = alignment;
+  }
+  return result;
+};
+
+const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
+  const metrics: RunMetrics[] = [];
+
+  for (const run of childElements(paragraph)) {
+    if (getLocalName(run.name ?? "") !== "r") {
+      continue;
+    }
+
+    const properties = findChild(run, "w", "rPr");
+    const boldProperty = findChild(properties, "w", "b");
+    const boldValue = getAttributeAnyPrefix(boldProperty, "val");
+    const bold = boldProperty !== null && boldValue !== "0" && boldValue !== "false";
+
+    const sizeProperty = findChild(properties, "w", "sz");
+    const sizeValue = getAttributeAnyPrefix(sizeProperty, "val");
+    const parsedSize = sizeValue === null ? Number.NaN : Number.parseInt(sizeValue, 10);
+    const fontSize = Number.isFinite(parsedSize) && parsedSize > 0 ? parsedSize : undefined;
+
+    let chars = 0;
+    for (const textNode of findAllDeep(run, "w", "t")) {
+      chars += getTextContent(textNode).length;
+    }
+    if (chars === 0) {
+      continue;
+    }
+
+    const entry: RunMetrics = { bold, chars };
+    if (fontSize !== undefined) {
+      entry.fontSize = fontSize;
+    }
+    metrics.push(entry);
+  }
+
+  return metrics;
+};
+
+type ExtractContainerOptions = {
+  container: XmlElement;
+  source: DocxParagraphSource;
+  startIndex: number;
+};
+
+type ExtractContainerResult = {
+  paragraphs: ExtractedDocxParagraph[];
+  charCount: number;
+};
+
+const extractContainer = ({
+  container,
+  source,
+  startIndex,
+}: ExtractContainerOptions): ExtractContainerResult => {
+  const paragraphs: ExtractedDocxParagraph[] = [];
+  let charCount = 0;
+
+  for (const [offset, paragraph] of findAllDeep(container, "w", "p").entries()) {
+    const text = collectText(paragraph);
+    const entry: ExtractedDocxParagraph = {
+      index: startIndex + offset,
+      text,
+      source,
+    };
+    const { style, alignment } = readParagraphProperties(paragraph);
+    if (style !== undefined) {
+      entry.style = style;
+    }
+    if (alignment !== undefined) {
+      entry.alignment = alignment;
+    }
+
+    const runs = readRunMetrics(paragraph);
+    if (runs.length > 0) {
+      const totalChars = runs.reduce((sum, run) => sum + run.chars, 0);
+      const boldChars = runs.reduce((sum, run) => sum + (run.bold ? run.chars : 0), 0);
+      if (boldChars > totalChars / 2) {
+        entry.bold = true;
+      }
+      const firstFontSize = runs.find((run) => run.fontSize !== undefined)?.fontSize;
+      if (firstFontSize !== undefined) {
+        entry.fontSize = firstFontSize;
+      }
+    }
+
+    paragraphs.push(entry);
+    charCount += text.length;
+  }
+
+  return { paragraphs, charCount };
+};
+
+type ExtractPartsOptions = {
+  archive: DocxArchive;
+  source: "header" | "footer";
+  rootName: "hdr" | "ftr";
+  startIndex: number;
+};
+
+const extractParts = async ({
+  archive,
+  source,
+  rootName,
+  startIndex,
+}: ExtractPartsOptions): Promise<ExtractContainerResult> => {
+  const paragraphs: ExtractedDocxParagraph[] = [];
+  let charCount = 0;
+  let nextIndex = startIndex;
+  const prefix = `word/${source}`;
+  const paths = archive.entries
+    .filter((path) => HEADER_FOOTER_PATH.test(path) && path.startsWith(prefix))
+    .toSorted();
+
+  for (const path of paths) {
+    // oxlint-disable-next-line no-await-in-loop -- part order defines stable paragraph indices
+    const xml = await archive.readEntryString(path);
+    if (xml === null) {
+      continue;
+    }
+    const root = parseXml(xml);
+    const container = findDeep(root, "w", rootName);
+    if (!container) {
+      continue;
+    }
+    const result = extractContainer({
+      container,
+      source,
+      startIndex: nextIndex,
+    });
+    paragraphs.push(...result.paragraphs);
+    charCount += result.charCount;
+    nextIndex += result.paragraphs.length;
+  }
+
+  return { paragraphs, charCount };
+};
+
+const createEmptyResult = (): ExtractedDocxText => ({
+  paragraphs: [],
+  charCount: 0,
+  view: "accepted",
+});
+
+/** Extract paragraph text and formatting metadata from a DOCX archive. */
+export const extractDocxText = async (
+  bytes: ArrayBuffer | Uint8Array,
+): Promise<ExtractedDocxText> => {
+  const archive = await loadDocxArchive(bytes);
+  const documentXml = await archive.readEntryString("word/document.xml");
+  if (documentXml === null) {
+    return createEmptyResult();
+  }
+
+  const root = parseXml(documentXml);
+  const body = findDeep(root, "w", "body");
+  if (!body) {
+    return createEmptyResult();
+  }
+
+  const headers = await extractParts({
+    archive,
+    source: "header",
+    rootName: "hdr",
+    startIndex: 0,
+  });
+  const bodyResult = extractContainer({
+    container: body,
+    source: "body",
+    startIndex: headers.paragraphs.length,
+  });
+  const footers = await extractParts({
+    archive,
+    source: "footer",
+    rootName: "ftr",
+    startIndex: headers.paragraphs.length + bodyResult.paragraphs.length,
+  });
+
+  return {
+    paragraphs: [...headers.paragraphs, ...bodyResult.paragraphs, ...footers.paragraphs],
+    charCount: headers.charCount + bodyResult.charCount + footers.charCount,
+    view: "accepted",
+  };
+};

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -100,3 +100,10 @@ export {
   type FolioDocumentOperationUndoHandle,
   type FolioDocumentOperationUndoResult,
 } from "./document-operations";
+export {
+  extractDocxText,
+  type DocxParagraphSource,
+  type ExtractedDocxParagraph,
+  type ExtractedDocxText,
+} from "./docx/server/extractDocxText";
+export { DocxArchiveError } from "./docx/server/boundedArchive";


### PR DESCRIPTION
## Summary

- add bounded server-side archive reads
- expose structured DOCX paragraph extraction
- cover deterministic part ordering, revisions, and formatting metadata