### PR TITLE
fix: preserve section-specific header clearance

### DIFF
--- a/.changeset/section-header-body-clearance.md
+++ b/.changeset/section-header-body-clearance.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Apply measured header and footer clearance to section-specific body margins.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -19,7 +19,7 @@ import { EditorState } from "prosemirror-state";
 
 import type { LayoutInstrumentation } from "../layout-engine/layoutInstrumentation";
 import { clearAllCaches } from "../layout-engine/measure/cache";
-import type { FootnoteContent } from "../layout-engine/types";
+import type { FootnoteContent, HeaderFooterContent } from "../layout-engine/types";
 import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import { LayoutPainter } from "../layout-painter";
 import { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
@@ -297,6 +297,39 @@ const makeState = (): EditorState =>
       schema.node("paragraph", null, [schema.text("Second paragraph here.")]),
     ]),
   });
+
+const makeSectionedState = (): EditorState =>
+  EditorState.create({
+    doc: schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          sectionBreakType: "continuous",
+          _sectionProperties: {
+            sectionStart: "continuous",
+            marginTop: 1080,
+            marginRight: 1080,
+            marginBottom: 1080,
+            marginLeft: 1080,
+            headerDistance: 540,
+            footerDistance: 540,
+          },
+        },
+        [schema.text("First section")],
+      ),
+      schema.node("paragraph", null, [schema.text("Second section")]),
+    ]),
+  });
+
+const makePreparedHeaderFooter = (height: number): HeaderFooterContent => ({
+  blocks: [],
+  measures: [],
+  height,
+  visualTop: 0,
+  visualBottom: height,
+  marginPushTop: 0,
+  marginPushBottom: height,
+});
 
 type DepsOverrides = Partial<LayoutPipelineDeps<null>>;
 
@@ -591,6 +624,50 @@ describe("runLayoutPipeline", () => {
                 marginPushBottom: 20,
               }
             : undefined,
+      }),
+      state,
+    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.top).toBe(MARGINS.top);
+    expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(MARGINS.top);
+  });
+
+  test("moves a section body between its referenced default header and footer", () => {
+    const state = makeSectionedState();
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        sectionHeaderFooterRefs: [
+          { headerDefault: "first-header", footerDefault: "first-footer" },
+          { headerDefault: "second-header", footerDefault: "second-footer" },
+        ],
+        renderHeaderFooterContentByRId: (_source, _hfPMs, _contentWidth, metrics) => {
+          if (metrics.section === "header") {
+            return new Map([
+              ["first-header", makePreparedHeaderFooter(120)],
+              ["second-header", makePreparedHeaderFooter(20)],
+            ]);
+          }
+          return new Map([
+            ["first-footer", makePreparedHeaderFooter(120)],
+            ["second-footer", makePreparedHeaderFooter(20)],
+          ]);
+        },
+      }),
+      state,
+    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.top).toBe(MARGINS.header + 120);
+    expect(outcome.layout?.pages.at(0)?.margins.bottom).toBe(MARGINS.footer + 120);
+    expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(MARGINS.header + 120);
+  });
+
+  test("keeps a section's authored margin when its referenced header fits above it", () => {
+    const state = makeSectionedState();
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        sectionHeaderFooterRefs: [{ headerDefault: "compact-header" }, {}],
+        renderHeaderFooterContentByRId: () =>
+          new Map([["compact-header", makePreparedHeaderFooter(20)]]),
       }),
       state,
     );

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -175,6 +175,53 @@ function bodyMarginsClearHeaderFooter({
   return { ...authoredMargins, top, bottom };
 }
 
+type SectionHeaderFooterClearanceOptions = {
+  authoredMargins: PageMargins;
+  sectionHeaderFooterRefs: PageHeaderFooterRefs[] | undefined;
+  headerContentByRId: Map<string, HeaderFooterContent> | undefined;
+  footerContentByRId: Map<string, HeaderFooterContent> | undefined;
+};
+
+function bodyBlocksClearSectionHeaderFooter(
+  blocks: FlowBlock[],
+  {
+    authoredMargins,
+    sectionHeaderFooterRefs,
+    headerContentByRId,
+    footerContentByRId,
+  }: SectionHeaderFooterClearanceOptions,
+): FlowBlock[] {
+  if (!sectionHeaderFooterRefs || (!headerContentByRId && !footerContentByRId)) {
+    return blocks;
+  }
+
+  let sectionIndex = 0;
+  let currentAuthoredMargins = authoredMargins;
+  let changed = false;
+  const nextBlocks = blocks.map((block) => {
+    if (block.kind !== "sectionBreak") {
+      return block;
+    }
+
+    currentAuthoredMargins = block.margins ?? currentAuthoredMargins;
+    const refs = sectionHeaderFooterRefs[sectionIndex];
+    sectionIndex += 1;
+    const effectiveMargins = bodyMarginsClearHeaderFooter({
+      authoredMargins: currentAuthoredMargins,
+      preparedHeader: refs?.headerDefault ? headerContentByRId?.get(refs.headerDefault) : undefined,
+      preparedFooter: refs?.footerDefault ? footerContentByRId?.get(refs.footerDefault) : undefined,
+    });
+    if (effectiveMargins === currentAuthoredMargins && block.margins === currentAuthoredMargins) {
+      return block;
+    }
+
+    changed = true;
+    return { ...block, margins: effectiveMargins };
+  });
+
+  return changed ? nextBlocks : blocks;
+}
+
 export function runLayoutPipeline<THfPMs>(
   deps: LayoutPipelineDeps<THfPMs>,
   state: EditorState,
@@ -392,6 +439,14 @@ export function runLayoutPipeline<THfPMs>(
       hfMetricsFooter,
       hfOptions,
     );
+
+    newBlocks = bodyBlocksClearSectionHeaderFooter(newBlocks, {
+      authoredMargins: margins,
+      sectionHeaderFooterRefs,
+      headerContentByRId,
+      footerContentByRId,
+    });
+    outcome.blocks = newBlocks;
 
     const initialBodyMargins = bodyMarginsClearHeaderFooter({
       authoredMargins: margins,


### PR DESCRIPTION
## Summary

- apply measured header and footer clearance to each section layout configuration
- preserve authored body margins when referenced page chrome remains outside them
- cover both overflowing and compact section cases

## Anonymous parity

- targeted strict same-font case: 65.5% → 75.6%
- independent cross-case: 58.9% → 58.9%, with identical page, matched-line, and divergence counts

## Verification

- `bun test packages/core/src/controller/layoutPipeline.test.ts packages/core/src/__tests__/layout-pipeline.integration.test.ts` (69 passed)
- `bun audit` (no vulnerabilities)
- lint and type checks are delegated to CI

CC on behalf of @jan-kubica