### PR TITLE
fix: keep body clear of page footers

### DIFF
--- a/.changeset/footer-body-clearance.md
+++ b/.changeset/footer-body-clearance.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep body content above the in-flow extent of page footers.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -501,13 +501,13 @@ describe("runLayoutPipeline", () => {
     expect(layoutErrors).toHaveLength(0);
   });
 
-  test("keeps authored body margins when footer content extends beyond them", () => {
+  test("moves body content above an overflowing default footer", () => {
     const state = makeState();
-    const baseline = runLayoutPipeline(makeDeps(createLayoutSession()), state);
-    const withTallFooter = runLayoutPipeline(
+    const outcome = runLayoutPipeline(
       makeDeps(createLayoutSession(), {
-        renderHfFromContentOrPm: (_hf, _rId, _hfPMs, _contentWidth, metrics) =>
-          metrics.section === "footer"
+        footerContent: { type: "footer", hdrFtrType: "default", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "footer"
             ? {
                 blocks: [],
                 measures: [],
@@ -522,12 +522,31 @@ describe("runLayoutPipeline", () => {
       state,
     );
 
-    expect(withTallFooter.layout?.pages.map((page) => page.margins)).toEqual(
-      baseline.layout?.pages.map((page) => page.margins),
+    expect(outcome.layout?.pages.at(0)?.margins.bottom).toBe(MARGINS.footer + 120);
+  });
+
+  test("keeps authored body margin when a default footer stays below it", () => {
+    const state = makeState();
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        footerContent: { type: "footer", hdrFtrType: "default", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "footer"
+            ? {
+                blocks: [],
+                measures: [],
+                height: 20,
+                visualTop: 0,
+                visualBottom: 20,
+                marginPushTop: 0,
+                marginPushBottom: 20,
+              }
+            : undefined,
+      }),
+      state,
     );
-    expect(withTallFooter.layout?.pages.map((page) => page.fragments.map(({ y }) => y))).toEqual(
-      baseline.layout?.pages.map((page) => page.fragments.map(({ y }) => y)),
-    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.bottom).toBe(MARGINS.bottom);
   });
 
   test("moves body content below an overflowing default header", () => {
@@ -611,6 +630,35 @@ describe("runLayoutPipeline", () => {
     );
   });
 
+  test("moves only the title-page body above an overflowing first-page footer", () => {
+    const state = makeState();
+    const baseline = runLayoutPipeline(makeDeps(createLayoutSession()), state);
+    const withTallFirstFooter = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        sectionProperties: { titlePg: true },
+        firstPageFooterContent: { type: "footer", hdrFtrType: "first", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "footer"
+            ? {
+                blocks: [],
+                measures: [],
+                height: 120,
+                visualTop: 0,
+                visualBottom: 120,
+                marginPushTop: 0,
+                marginPushBottom: 120,
+              }
+            : undefined,
+      }),
+      state,
+    );
+
+    const baselineFirstPage = baseline.layout?.pages.at(0);
+    const pushedFirstPage = withTallFirstFooter.layout?.pages.at(0);
+    expect(pushedFirstPage?.margins.bottom).toBe(MARGINS.footer + 120);
+    expect(pushedFirstPage?.margins.bottom).toBeGreaterThan(baselineFirstPage?.margins.bottom ?? 0);
+  });
+
   test("threads the final section geometry into layout", () => {
     const document = createEmptyDocument();
     document.package.document.sections = [
@@ -631,6 +679,51 @@ describe("runLayoutPipeline", () => {
     const outcome = runLayoutPipeline(makeDeps(createLayoutSession(), { document }), makeState());
 
     expect(outcome.layout?.pages.at(0)?.size).toEqual({ w: 1124, h: 795 });
+  });
+
+  test("uses the referenced final-section footer for body clearance", () => {
+    const document = createEmptyDocument();
+    document.package.document.sections = [
+      {
+        properties: {
+          pageWidth: 12_240,
+          pageHeight: 15_840,
+          marginTop: 1_080,
+          marginRight: 1_080,
+          marginBottom: 1_440,
+          marginLeft: 1_080,
+          footerDistance: 720,
+        },
+        content: [],
+      },
+    ];
+
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        document,
+        sectionHeaderFooterRefs: [{ footerDefault: "final-footer" }],
+        renderHeaderFooterContentByRId: (_source, _hfPMs, _contentWidth, metrics) =>
+          metrics.section === "footer"
+            ? new Map([
+                [
+                  "final-footer",
+                  {
+                    blocks: [],
+                    measures: [],
+                    height: 120,
+                    visualTop: 0,
+                    visualBottom: 120,
+                    marginPushTop: 0,
+                    marginPushBottom: 120,
+                  },
+                ],
+              ])
+            : undefined,
+      }),
+      makeState(),
+    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.bottom).toBe(168);
   });
 
   test("discards the outcome and leaves the session unmutated when the paint phase throws", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -150,19 +150,29 @@ export type LayoutPipelineDeps<THfPMs> = {
   emptyTemplatePreviewEntries: readonly TemplatePreviewEntry[];
 };
 
-function bodyMarginsBelowHeader(
-  authoredMargins: PageMargins,
-  preparedHeader: HeaderFooterContent | undefined,
-): PageMargins {
-  if (!preparedHeader) {
+type BodyMarginClearanceOptions = {
+  authoredMargins: PageMargins;
+  preparedHeader: HeaderFooterContent | undefined;
+  preparedFooter: HeaderFooterContent | undefined;
+};
+
+function bodyMarginsClearHeaderFooter({
+  authoredMargins,
+  preparedHeader,
+  preparedFooter,
+}: BodyMarginClearanceOptions): PageMargins {
+  const headerBottom = preparedHeader
+    ? (authoredMargins.header ?? 0) + (preparedHeader.marginPushBottom ?? preparedHeader.height)
+    : authoredMargins.top;
+  const footerClearance = preparedFooter
+    ? (authoredMargins.footer ?? 0) + (preparedFooter.marginPushBottom ?? preparedFooter.height)
+    : authoredMargins.bottom;
+  const top = Math.max(authoredMargins.top, headerBottom);
+  const bottom = Math.max(authoredMargins.bottom, footerClearance);
+  if (top === authoredMargins.top && bottom === authoredMargins.bottom) {
     return authoredMargins;
   }
-  const headerBottom =
-    (authoredMargins.header ?? 0) + (preparedHeader.marginPushBottom ?? preparedHeader.height);
-  if (headerBottom <= authoredMargins.top) {
-    return authoredMargins;
-  }
-  return { ...authoredMargins, top: headerBottom };
+  return { ...authoredMargins, top, bottom };
 }
 
 export function runLayoutPipeline<THfPMs>(
@@ -383,12 +393,16 @@ export function runLayoutPipeline<THfPMs>(
       hfOptions,
     );
 
-    const initialBodyMargins = bodyMarginsBelowHeader(margins, headerContentForRender);
+    const initialBodyMargins = bodyMarginsClearHeaderFooter({
+      authoredMargins: margins,
+      preparedHeader: headerContentForRender,
+      preparedFooter: footerContentForRender,
+    });
 
     recordPhaseDuration("header-footer", phaseStartedAt);
 
     // Compute per-block widths and band geometry from the effective body
-    // margins after normal in-flow header content has been accounted for.
+    // margins after normal in-flow header/footer content has been accounted for.
     phaseStartedAt = performance.now();
     const bodyLayoutConfig: SectionLayoutConfig = {
       pageSize,
@@ -405,10 +419,21 @@ export function runLayoutPipeline<THfPMs>(
     } else if (sectionHeaderFooterRefs !== undefined) {
       finalHeaderForLayout = undefined;
     }
+    const finalFooterRId = sectionHeaderFooterRefs?.at(-1)?.footerDefault;
+    let finalFooterForLayout = footerContentForRender;
+    if (finalFooterRId) {
+      finalFooterForLayout = footerContentByRId?.get(finalFooterRId);
+    } else if (sectionHeaderFooterRefs !== undefined) {
+      finalFooterForLayout = undefined;
+    }
     const finalLayoutConfig: SectionLayoutConfig = finalSectionProperties
       ? {
           pageSize: getPageSize(finalSectionProperties),
-          margins: bodyMarginsBelowHeader(getMargins(finalSectionProperties), finalHeaderForLayout),
+          margins: bodyMarginsClearHeaderFooter({
+            authoredMargins: getMargins(finalSectionProperties),
+            preparedHeader: finalHeaderForLayout,
+            preparedFooter: finalFooterForLayout,
+          }),
         }
       : bodyLayoutConfig;
     const finalColumns = getColumns(finalSectionProperties);
@@ -473,7 +498,11 @@ export function runLayoutPipeline<THfPMs>(
         mirrorMargins,
       };
       if (hasTitlePg) {
-        nextLayoutOpts.firstPageMargins = bodyMarginsBelowHeader(margins, firstPageHeaderForRender);
+        nextLayoutOpts.firstPageMargins = bodyMarginsClearHeaderFooter({
+          authoredMargins: margins,
+          preparedHeader: firstPageHeaderForRender,
+          preparedFooter: firstPageFooterForRender,
+        });
       }
       if (finalSectionProperties) {
         nextLayoutOpts.finalPageSize = finalLayoutConfig.pageSize;


### PR DESCRIPTION
Reserve body clearance for normal-flow footer content only when it extends above the authored bottom margin. The same rule now covers default, title-page, and referenced final-section footers while leaving floating artwork independent.

An anonymous strict same-font replay improved from 89.4% to 90.1% with the expected nine-page count preserved. A separate replay remained unchanged at 90.3%. Targeted layout-pipeline regressions pass, and the dependency audit reports no vulnerabilities.

CC on behalf of @jan-kubica