### PR TITLE
fix: honor OOXML text box shape fitting

### DIFF
--- a/.changeset/calm-boxes-fit.md
+++ b/.changeset/calm-boxes-fit.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve shape-to-text fitting for imported OOXML text boxes.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -8,6 +8,7 @@ import { ImagePosition } from '@stll/docx-core/model';
 import { ImageWrap } from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
+import { ShapeTextBody } from '@stll/docx-core/model';
 import { TableWidthType } from '@stll/docx-core/model';
 
 // @public
@@ -888,7 +889,8 @@ export type TextBoxBlock = {
     kind: "textBox";
     id: BlockId; /** Width in pixels */
     width: number; /** Height in pixels (may be auto-calculated) */
-    height?: number; /** Fill/background color */
+    height?: number; /** Text fitting behavior */
+    autoFit?: ShapeTextBody["autoFit"]; /** Fill/background color */
     fillColor?: string; /** Border width in pixels */
     outlineWidth?: number; /** Border color */
     outlineColor?: string; /** Outline dash style, or `"none"` for an explicit no-outline. */

--- a/api-reports/core/layout-painter.api.md
+++ b/api-reports/core/layout-painter.api.md
@@ -9,6 +9,7 @@ import { ImageWrap } from '@stll/docx-core/model';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
+import { ShapeTextBody } from '@stll/docx-core/model';
 import { TableWidthType } from '@stll/docx-core/model';
 
 // @public

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -389,7 +389,8 @@ export type TableRowAttrs = {
 // @public
 export type TextBoxAttrs = {
     width?: number; /** Height in pixels */
-    height?: number; /** Unique identifier */
+    height?: number; /** Text fitting behavior */
+    autoFit?: import__stll_docx_core_model.ShapeTextBody["autoFit"]; /** Unique identifier */
     textBoxId?: string; /** Fill color as CSS color */
     fillColor?: string; /** Outline width in pixels */
     outlineWidth?: number; /** Outline color as CSS color */

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -1170,7 +1170,8 @@ export type TextBox = {
     wrap?: ImageWrap; /** Fill */
     fill?: ShapeFill; /** Outline */
     outline?: ShapeOutline; /** Text content */
-    content: Paragraph[]; /** Internal margins */
+    content: Paragraph[]; /** Text fitting behavior */
+    autoFit?: ShapeTextBody["autoFit"]; /** Internal margins */
     margins?: {
         top?: number;
         bottom?: number;

--- a/packages/core/src/docx/documentParser.test.ts
+++ b/packages/core/src/docx/documentParser.test.ts
@@ -51,7 +51,7 @@ const repeatedPlaceholderNumberingXml = `${XML_DECLARATION}
 const numberedParagraphXml = (paraId: string, ilvl: number, text: string, numId = 9) =>
   `<w:p w14:paraId="${paraId}"><w:pPr><w:numPr><w:ilvl w:val="${ilvl}"/><w:numId w:val="${numId}"/></w:numPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
-const textBoxDrawingXml = (text: string) => `
+const textBoxDrawingXml = (text: string, bodyProperties = "<wps:bodyPr/>") => `
   <w:drawing>
     <wp:inline>
       <wp:extent cx="914400" cy="457200"/>
@@ -68,7 +68,7 @@ const textBoxDrawingXml = (text: string) => `
                 <w:p><w:r><w:t>${text}</w:t></w:r></w:p>
               </w:txbxContent>
             </wps:txbx>
-            <wps:bodyPr/>
+            ${bodyProperties}
           </wps:wsp>
         </a:graphicData>
       </a:graphic>
@@ -175,7 +175,10 @@ describe("parseDocumentBody text box enrichment", () => {
   <w:body>
     <w:p w14:paraId="TXB00001">
       <w:r><w:t>Before </w:t></w:r>
-      <w:r><w:t>merged</w:t>${textBoxDrawingXml("Inside text box")}</w:r>
+      <w:r><w:t>merged</w:t>${textBoxDrawingXml(
+        "Inside text box",
+        "<wps:bodyPr><a:spAutoFit/></wps:bodyPr>",
+      )}</w:r>
       <w:bookmarkStart w:id="1" w:name="afterTextbox"/>
       <w:bookmarkEnd w:id="1"/>
       <w:r><w:t>After boundary</w:t></w:r>
@@ -208,6 +211,7 @@ describe("parseDocumentBody text box enrichment", () => {
     }
     expect(shapeContent.shape.shapeType).toBe("textBox");
     expect(shapeContent.shape.textBody?.content.at(0)?.type).toBe("paragraph");
+    expect(shapeContent.shape.textBody?.autoFit).toBe("shape");
 
     const bookmarkStartIndex = paragraph.content.findIndex(
       (content) => content.type === "bookmarkStart",

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -81,6 +81,7 @@ export const enrichParagraphTextBoxes = (
         ...(textBox.outline !== undefined ? { outline: textBox.outline } : {}),
         textBody: {
           content: textBox.content,
+          ...(textBox.autoFit !== undefined ? { autoFit: textBox.autoFit } : {}),
           ...(textBox.margins !== undefined ? { margins: textBox.margins } : {}),
         },
       };

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -206,6 +206,37 @@ describe("shape EMU attributes are integer-only (issue #417)", () => {
   });
 });
 
+describe("text box fitting serialization", () => {
+  test.each([
+    ["shape", "<a:spAutoFit/>", "<a:normAutofit/>", "<a:noAutofit/>"],
+    ["normal", "<a:normAutofit/>", "<a:spAutoFit/>", "<a:noAutofit/>"],
+    ["none", "<a:noAutofit/>", "<a:spAutoFit/>", "<a:normAutofit/>"],
+  ] as const)("writes only the %s fitting element", (autoFit, expected, absentA, absentB) => {
+    const run: Run = {
+      type: "run",
+      content: [
+        {
+          type: "shape",
+          shape: {
+            type: "shape",
+            shapeType: "textBox",
+            size: { width: 914_400, height: 457_200 },
+            textBody: {
+              autoFit,
+              content: [{ type: "paragraph", content: [] }],
+            },
+          },
+        },
+      ],
+    };
+
+    const xml = serializeRun(run);
+    expect(xml).toContain(expected);
+    expect(xml).not.toContain(absentA);
+    expect(xml).not.toContain(absentB);
+  });
+});
+
 describe("run formatting integer attributes (issue #417)", () => {
   test("font size, character spacing, scale, kern, position render as integers", () => {
     const run: Run = {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -947,15 +947,27 @@ function serializeShapeContent(content: ShapeContent): string {
       }
     }
 
+    let autoFitXml = "";
+    if (tb.autoFit === "shape") {
+      autoFitXml = "<a:spAutoFit/>";
+    } else if (tb.autoFit === "normal") {
+      autoFitXml = "<a:normAutofit/>";
+    } else if (tb.autoFit === "none") {
+      autoFitXml = "<a:noAutofit/>";
+    }
+    const bodyPrXml = autoFitXml
+      ? `<wps:bodyPr ${bpAttrs.join(" ")}>${autoFitXml}</wps:bodyPr>`
+      : `<wps:bodyPr ${bpAttrs.join(" ")}/>`;
+
     if (isTextBox) {
       textBody = [
         "<wps:txbx><w:txbxContent>",
         serializeShapeTextBody(tb.content),
         "</w:txbxContent></wps:txbx>",
-        `<wps:bodyPr ${bpAttrs.join(" ")}/>`,
+        bodyPrXml,
       ].join("");
     } else {
-      textBody = [`<wps:bodyPr ${bpAttrs.join(" ")}/>`].join("");
+      textBody = bodyPrXml;
     }
   }
 

--- a/packages/core/src/docx/textBoxParser.test.ts
+++ b/packages/core/src/docx/textBoxParser.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseTextBox } from "./textBoxParser";
+import { parseXmlDocument } from "./xmlParser";
+
+const NAMESPACES = `xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"`;
+
+const drawingWithBodyProperties = (bodyProperties: string): string => `<w:drawing ${NAMESPACES}>
+  <wp:inline>
+    <wp:extent cx="914400" cy="457200"/>
+    <a:graphic>
+      <a:graphicData>
+        <wps:wsp>
+          <wps:spPr/>
+          <wps:txbx><w:txbxContent><w:p/></w:txbxContent></wps:txbx>
+          ${bodyProperties}
+        </wps:wsp>
+      </a:graphicData>
+    </a:graphic>
+  </wp:inline>
+</w:drawing>`;
+
+describe("text box body properties", () => {
+  test.each([
+    ["<wps:bodyPr><a:spAutoFit/></wps:bodyPr>", "shape"],
+    ["<wps:bodyPr><a:normAutofit/></wps:bodyPr>", "normal"],
+    ["<wps:bodyPr><a:noAutofit/></wps:bodyPr>", "none"],
+  ] as const)("parses the %s fitting mode", (bodyProperties, expected) => {
+    const drawing = parseXmlDocument(drawingWithBodyProperties(bodyProperties));
+    expect(drawing).not.toBeNull();
+    if (!drawing) {
+      return;
+    }
+
+    expect(parseTextBox(drawing)?.autoFit).toBe(expected);
+  });
+
+  test("leaves fitting unspecified when no mode is authored", () => {
+    const drawing = parseXmlDocument(drawingWithBodyProperties("<wps:bodyPr/>"));
+    expect(drawing).not.toBeNull();
+    if (!drawing) {
+      return;
+    }
+
+    expect(parseTextBox(drawing)?.autoFit).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/textBoxParser.ts
+++ b/packages/core/src/docx/textBoxParser.ts
@@ -32,6 +32,7 @@ import type {
   ImageSize,
   ImagePosition,
   ImageWrap,
+  ShapeTextBody,
   Theme,
   RelationshipMap,
   MediaFile,
@@ -51,6 +52,7 @@ import {
   getAttribute,
   parseNumericAttribute,
   findByFullName,
+  findChildByLocalName,
   findChildrenByLocalName,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -72,12 +74,24 @@ const DEFAULT_MARGIN_EMU = 91_440;
  */
 function parseBodyProperties(bodyPr: XmlElement | null): {
   margins?: TextBox["margins"];
+  autoFit?: ShapeTextBody["autoFit"];
 } {
   if (!bodyPr) {
     return {};
   }
 
-  const result: { margins?: TextBox["margins"] } = {};
+  const result: {
+    margins?: TextBox["margins"];
+    autoFit?: ShapeTextBody["autoFit"];
+  } = {};
+
+  if (findChildByLocalName(bodyPr, "spAutoFit")) {
+    result.autoFit = "shape";
+  } else if (findChildByLocalName(bodyPr, "normAutofit")) {
+    result.autoFit = "normal";
+  } else if (findChildByLocalName(bodyPr, "noAutofit")) {
+    result.autoFit = "none";
+  }
 
   // Margins (insets) in EMUs
   const lIns = parseNumericAttribute(bodyPr, null, "lIns");
@@ -324,6 +338,9 @@ export function parseTextBox(drawingEl: XmlElement): TextBox | null {
   if (bodyProps.margins) {
     textBox.margins = bodyProps.margins;
   }
+  if (bodyProps.autoFit) {
+    textBox.autoFit = bodyProps.autoFit;
+  }
 
   // Parse position for anchored text boxes
   if (isAnchor) {
@@ -409,6 +426,9 @@ export function parseTextBoxFromShape(
   }
   if (bodyProps.margins) {
     textBox.margins = bodyProps.margins;
+  }
+  if (bodyProps.autoFit) {
+    textBox.autoFit = bodyProps.autoFit;
   }
   if (position) {
     textBox.position = position;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2405,6 +2405,9 @@ function convertTextBoxNode(
   if (attrs.height !== undefined) {
     textBox.height = attrs.height;
   }
+  if (attrs.autoFit !== undefined) {
+    textBox.autoFit = attrs.autoFit;
+  }
   if (attrs.fillColor !== undefined) {
     textBox.fillColor = attrs.fillColor;
   }

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -47,6 +47,64 @@ describe("measureBlock dispatch", () => {
   });
 });
 
+describe("text box fitting", () => {
+  test("shape fitting expands past the authored height without shrinking a larger box", () => {
+    withFakeTextMeasure(() => {
+      const fixed: TextBoxBlock = {
+        kind: "textBox",
+        id: "fixed",
+        width: 200,
+        height: 1,
+        margins: { top: 0, right: 0, bottom: 0, left: 0 },
+        content: [para("inner", "content")],
+      };
+      const fittedMeasure = measureBlock({ ...fixed, id: "fitted", autoFit: "shape" }, 500);
+      const fixedMeasure = measureBlock(fixed, 500);
+      const largeMeasure = measureBlock(
+        { ...fixed, id: "large", height: 1_000, autoFit: "shape" },
+        500,
+      );
+
+      expect(fittedMeasure.kind).toBe("textBox");
+      expect(fixedMeasure.kind).toBe("textBox");
+      expect(largeMeasure.kind).toBe("textBox");
+      if (
+        fittedMeasure.kind !== "textBox" ||
+        fixedMeasure.kind !== "textBox" ||
+        largeMeasure.kind !== "textBox"
+      ) {
+        return;
+      }
+
+      expect(fittedMeasure.height).toBeGreaterThan(fixedMeasure.height);
+      expect(fixedMeasure.height).toBe(1);
+      expect(largeMeasure.height).toBe(1_000);
+    }, fakeMeasure);
+  });
+
+  test.each([undefined, "none", "normal"] as const)(
+    "keeps the authored height for the %s fitting mode",
+    (autoFit) => {
+      withFakeTextMeasure(() => {
+        const textBox: TextBoxBlock = {
+          kind: "textBox",
+          id: "fixed",
+          width: 200,
+          height: 3,
+          ...(autoFit !== undefined ? { autoFit } : {}),
+          content: [para("inner", "content")],
+        };
+
+        const measure = measureBlock(textBox, 500);
+        expect(measure.kind).toBe("textBox");
+        if (measure.kind === "textBox") {
+          expect(measure.height).toBe(3);
+        }
+      }, fakeMeasure);
+    },
+  );
+});
+
 describe("measureBlocks", () => {
   test("returns exactly one measure per input block", () => {
     withFakeTextMeasure(() => {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -771,7 +771,11 @@ export function measureTextBoxBlock(
     measureParagraph(p, innerWidth, fieldValues ? { fieldValues } : undefined),
   );
   const contentHeight = innerMeasures.reduce((sum, m) => sum + m.totalHeight, 0);
-  const totalHeight = tb.height ?? contentHeight + margins.top + margins.bottom;
+  const contentBoxHeight = contentHeight + margins.top + margins.bottom;
+  const totalHeight =
+    tb.autoFit === "shape"
+      ? Math.max(tb.height ?? 0, contentBoxHeight)
+      : (tb.height ?? contentBoxHeight);
   return {
     kind: "textBox",
     width: tb.width,

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -8,6 +8,7 @@
 import type {
   ImagePosition,
   ImageWrap,
+  ShapeTextBody,
   SdtProperties,
   SdtType,
   TableWidthType,
@@ -687,6 +688,8 @@ export type TextBoxBlock = {
   width: number;
   /** Height in pixels (may be auto-calculated) */
   height?: number;
+  /** Text fitting behavior */
+  autoFit?: ShapeTextBody["autoFit"];
   /** Fill/background color */
   fillColor?: string;
   /** Border width in pixels */

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -83,6 +83,12 @@ const IMAGE_CSS_FLOATS = ["left", "right", "none"] as const satisfies readonly N
   ImageAttrs["cssFloat"]
 >[];
 
+const TEXT_BOX_AUTO_FIT_VALUES = [
+  "none",
+  "normal",
+  "shape",
+] as const satisfies readonly NonNullable<TextBoxAttrs["autoFit"]>[];
+
 const FIELD_KINDS = ["simple", "complex"] as const satisfies readonly FieldAttrs["fieldKind"][];
 
 const MATH_DISPLAYS = ["inline", "block"] as const satisfies readonly NonNullable<
@@ -658,6 +664,7 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
 
   optionalNumber(attrs, "width", "textBox.attrs.width", issues);
   optionalNumber(attrs, "height", "textBox.attrs.height", issues);
+  optionalOneOf(attrs, "autoFit", "textBox.attrs.autoFit", issues, TEXT_BOX_AUTO_FIT_VALUES);
   optionalString(attrs, "textBoxId", "textBox.attrs.textBoxId", issues);
   optionalString(attrs, "fillColor", "textBox.attrs.fillColor", issues);
   optionalNumber(attrs, "outlineWidth", "textBox.attrs.outlineWidth", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -1068,7 +1068,7 @@ describe("fromProseDoc", () => {
 
   test("converts textBox nodes back to DOCX text box shapes", () => {
     const pmDoc = schema.node("doc", null, [
-      schema.node("textBox", { width: 120, height: 60 }, [
+      schema.node("textBox", { width: 120, height: 60, autoFit: "shape" }, [
         schema.node("paragraph", null, [schema.text("Inside")]),
       ]),
     ]);
@@ -1090,6 +1090,7 @@ describe("fromProseDoc", () => {
     }
     expect(firstRunContent.shape.shapeType).toBe("textBox");
     expect(firstRunContent.shape.textBody?.content).toHaveLength(1);
+    expect(firstRunContent.shape.textBody?.autoFit).toBe("shape");
   });
 
   test("preserves textBox wrap and position attrs on save", () => {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2798,6 +2798,7 @@ function convertPMTextBox(node: PMNode): Paragraph {
     },
     textBody: {
       content: childParagraphs.length > 0 ? childParagraphs : [{ type: "paragraph", content: [] }],
+      ...(attrs.autoFit !== undefined ? { autoFit: attrs.autoFit } : {}),
       margins: (() => {
         const m: {
           top?: number;

--- a/packages/core/src/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
@@ -25,6 +25,7 @@ function textBoxAttrsFromImport(args: {
   distBEmu?: number;
   distLEmu?: number;
   distREmu?: number;
+  autoFit?: "none" | "normal" | "shape";
 }): TextBoxAttrs {
   const document: Document = {
     package: {
@@ -66,6 +67,7 @@ function textBoxAttrsFromImport(args: {
                         ...(args.distREmu !== undefined ? { distR: args.distREmu } : {}),
                       },
                       textBody: {
+                        ...(args.autoFit !== undefined ? { autoFit: args.autoFit } : {}),
                         content: [
                           {
                             type: "paragraph",
@@ -100,6 +102,12 @@ function textBoxAttrsFromImport(args: {
 }
 
 describe("toProseDoc propagates text-box wrap attributes", () => {
+  test("preserves the text fitting mode", () => {
+    const attrs = textBoxAttrsFromImport({ wrapType: "inline", autoFit: "shape" });
+
+    expect(attrs["autoFit"]).toBe("shape");
+  });
+
   test("wrap='square' + wrapText='right' becomes a left-floating wrap", () => {
     const attrs = textBoxAttrsFromImport({
       wrapType: "square",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2852,6 +2852,9 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): TextBox[] {
             if (shape.textBody.margins) {
               textBox.margins = shape.textBody.margins;
             }
+            if (shape.textBody.autoFit) {
+              textBox.autoFit = shape.textBody.autoFit;
+            }
             textBoxes.push(textBox);
           }
         }
@@ -2987,6 +2990,7 @@ function convertTextBox(
     {
       width: widthPx,
       height: heightPx,
+      autoFit: textBox.autoFit,
       textBoxId: textBox.id,
       fillColor,
       outlineWidth,

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -6,7 +6,7 @@
  * Supports inline and floating positioning.
  */
 
-import type { ImageWrap } from "../../../types/document";
+import type { ImageWrap, ShapeTextBody } from "../../../types/document";
 import { IMAGE_WRAP_TYPE_VALUES, type OutlineStyleAttr } from "../../../types/documentEnumValues";
 import { expectTextBoxAttrs } from "../../attrs";
 import type { ImagePositionAttrs } from "../../schema/nodes";
@@ -17,6 +17,8 @@ export type TextBoxAttrs = {
   width?: number;
   /** Height in pixels */
   height?: number;
+  /** Text fitting behavior */
+  autoFit?: ShapeTextBody["autoFit"];
   /** Unique identifier */
   textBoxId?: string;
   /** Fill color as CSS color */
@@ -85,6 +87,13 @@ function parseTextBoxWrapType(raw: string | undefined): ImageWrap["type"] | unde
   return undefined;
 }
 
+function parseTextBoxAutoFit(raw: string | undefined): TextBoxAttrs["autoFit"] {
+  if (raw === "none" || raw === "normal" || raw === "shape") {
+    return raw;
+  }
+  return undefined;
+}
+
 export const TextBoxExtension = createNodeExtension({
   name: "textBox",
   schemaNodeName: "textBox",
@@ -96,6 +105,7 @@ export const TextBoxExtension = createNodeExtension({
     attrs: {
       width: { default: 200 },
       height: { default: null },
+      autoFit: { default: null },
       textBoxId: { default: null },
       fillColor: { default: null },
       outlineWidth: { default: null },
@@ -129,9 +139,11 @@ export const TextBoxExtension = createNodeExtension({
           const d = el.dataset;
           const position = parseTextBoxPosition(d["position"]);
           const wrapType = parseTextBoxWrapType(d["wrapType"]);
+          const autoFit = parseTextBoxAutoFit(d["autoFit"]);
           return {
             ...(d["width"] ? { width: Number(d["width"]) } : {}),
             ...(d["height"] ? { height: Number(d["height"]) } : {}),
+            ...(autoFit ? { autoFit } : {}),
             ...(d["textboxId"] ? { textBoxId: d["textboxId"] } : {}),
             ...(d["fillColor"] ? { fillColor: d["fillColor"] } : {}),
             ...(d["outlineWidth"] ? { outlineWidth: Number(d["outlineWidth"]) } : {}),
@@ -183,6 +195,9 @@ export const TextBoxExtension = createNodeExtension({
       }
       if (attrs.height) {
         domAttrs["data-height"] = String(attrs.height);
+      }
+      if (attrs.autoFit) {
+        domAttrs["data-auto-fit"] = attrs.autoFit;
       }
       if (attrs.textBoxId) {
         domAttrs["data-textbox-id"] = attrs.textBoxId;

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -34,6 +34,7 @@ import type {
   SectionProperties,
   ShapeFill,
   ShapeOutline,
+  ShapeTextBody,
   SdtProperties,
   SdtType,
 } from "../../types/document";
@@ -484,6 +485,8 @@ export type TextBoxAttrs = {
   width?: number;
   /** Height in pixels */
   height?: number;
+  /** Text fitting behavior */
+  autoFit?: ShapeTextBody["autoFit"];
   /** Unique identifier */
   textBoxId?: string;
   /** Fill color as CSS color */

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -800,6 +800,8 @@ export type TextBox = {
   outline?: ShapeOutline;
   /** Text content */
   content: Paragraph[];
+  /** Text fitting behavior */
+  autoFit?: ShapeTextBody["autoFit"];
   /** Internal margins */
   margins?: {
     top?: number;


### PR DESCRIPTION
## Summary

- preserve authored text fitting modes through import, editing, and serialization
- grow shape-fitted text boxes to measured content while retaining authored dimensions as minimums
- cover shape fitting, fixed modes, conversion, and serialization with targeted regressions

## Validation

- focused unit suites: 111 passed
- strict same-font parity replay: 4 pages, 205 comparable lines
- visual verification confirms shape-fitted content is no longer clipped
- `bun audit`: no vulnerabilities found