### PR TITLE
fix: preserve text box paragraph spacing

### DIFF
--- a/.changeset/textbox-paragraph-spacing.md
+++ b/.changeset/textbox-paragraph-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored paragraph spacing inside text boxes.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -16,6 +16,11 @@ import {
 import { measuredLineAdvance } from "./lineFlow";
 import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
 import { getParagraphFragmentPmRange } from "./paragraphFragmentRange";
+import {
+  getParagraphSpacingAfter,
+  getParagraphSpacingBefore,
+  isEmptyParagraph,
+} from "./paragraphSpacing";
 import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
 import { bandFragmentX, bandTopContentY, isPageFrameRelativeAnchor } from "./textBoxFlow";
 import { floatingTextBoxReservesBand } from "./types";
@@ -85,21 +90,6 @@ export function collectSectionConfigs(
   return { configs, breakIndices };
 }
 
-/**
- * Whether a paragraph block has no visible content (no runs, or a single
- * empty text run).
- */
-function isEmptyParagraph(block: ParagraphBlock): boolean {
-  if (block.runs.length === 0) {
-    return true;
-  }
-  if (block.runs.length !== 1) {
-    return false;
-  }
-  const r = block.runs[0];
-  return r?.kind === "text" && r.text === "";
-}
-
 function isPaginationEmptyParagraph(block: ParagraphBlock): boolean {
   return block.runs.every((run) => {
     if (run.kind === "text") {
@@ -155,48 +145,6 @@ function pageStartsWithPreviousParagraphContinuation(
   );
 }
 /**
- * Get spacing before a paragraph block. Empty paragraphs whose
- * `before` came only from the implicit default paragraph style collapse to
- * zero. Reference layout keeps inherited spacing when the empty paragraph itself is
- * authored through direct `w:pPr` formatting or an explicit `w:pStyle`.
- */
-function getSpacingBefore(block: ParagraphBlock): number {
-  const value = block.attrs?.spacing?.before ?? 0;
-  if (value === 0) {
-    return 0;
-  }
-  if (
-    isEmptyParagraph(block) &&
-    !block.attrs?.styleId &&
-    !block.attrs?.hasDirectParagraphFormatting &&
-    !block.attrs?.spacingExplicit?.before
-  ) {
-    return 0;
-  }
-  return value;
-}
-
-/**
- * Get spacing after a paragraph block. Same implicit-default-style collapse
- * rule as `getSpacingBefore`.
- */
-function getSpacingAfter(block: ParagraphBlock): number {
-  const value = block.attrs?.spacing?.after ?? 0;
-  if (value === 0) {
-    return 0;
-  }
-  if (
-    isEmptyParagraph(block) &&
-    !block.attrs?.styleId &&
-    !block.attrs?.hasDirectParagraphFormatting &&
-    !block.attrs?.spacingExplicit?.after
-  ) {
-    return 0;
-  }
-  return value;
-}
-
-/**
  * Estimate the height of a short paragraph-only multi-column section so its
  * final page can use Word-style balanced columns. Sections containing tables,
  * floating blocks, or authored breaks keep the normal bottom-up pagination;
@@ -243,7 +191,7 @@ function balancedParagraphSectionHeight({
       return undefined;
     }
 
-    const leadingSpacing = Math.max(getSpacingBefore(block), trailingSpacing);
+    const leadingSpacing = Math.max(getParagraphSpacingBefore(block), trailingSpacing);
     if (measure.lines.length === 0) {
       if (leadingSpacing > 0) {
         lineUnits.push(leadingSpacing);
@@ -265,7 +213,7 @@ function balancedParagraphSectionHeight({
     if (tallestUnit > availableHeight || totalHeight > availableHeight * columnCount) {
       return undefined;
     }
-    trailingSpacing = getSpacingAfter(block);
+    trailingSpacing = getParagraphSpacingAfter(block);
   }
 
   if (totalHeight <= 0) {
@@ -743,8 +691,8 @@ function layoutParagraph(
   const lines = measure.lines;
   if (lines.length === 0) {
     // Empty paragraph - still takes up space based on spacing
-    const spaceBefore = getSpacingBefore(block);
-    const spaceAfter = getSpacingAfter(block);
+    const spaceBefore = getParagraphSpacingBefore(block);
+    const spaceAfter = getParagraphSpacingAfter(block);
     const state = paginator.getCurrentState();
 
     // Create minimal fragment
@@ -766,8 +714,8 @@ function layoutParagraph(
     return;
   }
 
-  const spaceBefore = getSpacingBefore(block);
-  const spaceAfter = getSpacingAfter(block);
+  const spaceBefore = getParagraphSpacingBefore(block);
+  const spaceAfter = getParagraphSpacingAfter(block);
 
   // Try to fit all lines on current page/column
   let currentLineIndex = 0;

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -24,6 +24,7 @@ import type {
 import { getCachedParagraphMeasure, setCachedParagraphMeasure } from "./cache";
 import { findClearLineY, measureParagraph, MIN_WRAP_SEGMENT_WIDTH } from "./measureParagraph";
 import type { FloatingImageZone } from "./measureParagraph";
+import { layoutTextBoxParagraphs } from "./textBoxParagraphLayout";
 
 /**
  * Pseudo-infinite measurement width (px) used for `w:noWrap` table cells so
@@ -770,7 +771,7 @@ export function measureTextBoxBlock(
   const innerMeasures = tb.content.map((p) =>
     measureParagraph(p, innerWidth, fieldValues ? { fieldValues } : undefined),
   );
-  const contentHeight = innerMeasures.reduce((sum, m) => sum + m.totalHeight, 0);
+  const contentHeight = layoutTextBoxParagraphs(tb.content, innerMeasures).totalHeight;
   const contentBoxHeight = contentHeight + margins.top + margins.bottom;
   const totalHeight =
     tb.autoFit === "shape"

--- a/packages/core/src/layout-engine/measure/textBoxParagraphLayout.test.ts
+++ b/packages/core/src/layout-engine/measure/textBoxParagraphLayout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { layoutTextBoxParagraphs } from "./textBoxParagraphLayout";
+import type { ParagraphBlock, ParagraphMeasure } from "../types";
+
+const paragraph = (
+  id: string,
+  text: string,
+  spacing?: { before?: number; after?: number },
+): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: text === "" ? [] : [{ kind: "text", text }],
+  attrs: {
+    styleId: "authored-style",
+    ...(spacing ? { spacing } : {}),
+  },
+});
+
+const measure = (lineHeight: number): ParagraphMeasure => ({
+  kind: "paragraph",
+  lines: [
+    {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 0,
+      width: 0,
+      ascent: lineHeight * 0.8,
+      descent: lineHeight * 0.2,
+      lineHeight,
+    },
+  ],
+  totalHeight: lineHeight,
+});
+
+describe("text box paragraph flow", () => {
+  test("rejects mismatched paragraph and measure counts", () => {
+    expect(() => layoutTextBoxParagraphs([paragraph("only", "value")], [])).toThrow(
+      "block and measure counts must match",
+    );
+  });
+
+  test("preserves authored spacing around empty paragraphs", () => {
+    const blocks = [
+      paragraph("first", "value"),
+      paragraph("empty", "", { after: 30 }),
+      paragraph("last", "value"),
+    ];
+    const layout = layoutTextBoxParagraphs(blocks, [measure(20), measure(20), measure(20)]);
+
+    expect(layout.placements).toEqual([
+      { leadingSpacing: 0, contentHeight: 20 },
+      { leadingSpacing: 0, contentHeight: 20 },
+      { leadingSpacing: 30, contentHeight: 20 },
+    ]);
+    expect(layout.totalHeight).toBe(90);
+  });
+
+  test("collapses adjacent trailing and leading spacing", () => {
+    const blocks = [
+      paragraph("first", "value", { after: 18 }),
+      paragraph("second", "value", { before: 12, after: 7 }),
+    ];
+    const layout = layoutTextBoxParagraphs(blocks, [measure(20), measure(20)]);
+
+    expect(layout.placements).toEqual([
+      { leadingSpacing: 0, contentHeight: 20 },
+      { leadingSpacing: 18, contentHeight: 20 },
+    ]);
+    expect(layout.totalHeight).toBe(65);
+  });
+});

--- a/packages/core/src/layout-engine/measure/textBoxParagraphLayout.ts
+++ b/packages/core/src/layout-engine/measure/textBoxParagraphLayout.ts
@@ -1,0 +1,45 @@
+import { panic } from "better-result";
+
+import { measuredLineRangeHeight } from "../lineFlow";
+import { getParagraphSpacingAfter, getParagraphSpacingBefore } from "../paragraphSpacing";
+import type { ParagraphBlock, ParagraphMeasure } from "../types";
+
+export type TextBoxParagraphPlacement = {
+  leadingSpacing: number;
+  contentHeight: number;
+};
+
+export type TextBoxParagraphLayout = {
+  placements: TextBoxParagraphPlacement[];
+  totalHeight: number;
+};
+
+/**
+ * Lay out a text box's paragraph story as one unpaginated flow. Adjacent
+ * before/after spacing collapses to the larger value, matching body flow.
+ */
+export function layoutTextBoxParagraphs(
+  blocks: readonly ParagraphBlock[],
+  measures: readonly ParagraphMeasure[],
+): TextBoxParagraphLayout {
+  if (blocks.length !== measures.length) {
+    panic("layoutTextBoxParagraphs: block and measure counts must match");
+  }
+
+  const placements: TextBoxParagraphPlacement[] = [];
+  let totalHeight = 0;
+  let trailingSpacing = 0;
+
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index]!; // SAFETY: index < blocks.length
+    const measure = measures[index]!; // SAFETY: equal lengths checked above
+
+    const leadingSpacing = Math.max(getParagraphSpacingBefore(block), trailingSpacing);
+    const contentHeight = measuredLineRangeHeight(measure.lines, 0, measure.lines.length);
+    placements.push({ leadingSpacing, contentHeight });
+    totalHeight += leadingSpacing + contentHeight;
+    trailingSpacing = getParagraphSpacingAfter(block);
+  }
+
+  return { placements, totalHeight: totalHeight + trailingSpacing };
+}

--- a/packages/core/src/layout-engine/paragraphSpacing.ts
+++ b/packages/core/src/layout-engine/paragraphSpacing.ts
@@ -1,0 +1,53 @@
+import type { ParagraphBlock } from "./types";
+
+/** Whether a paragraph has no visible run content. */
+export function isEmptyParagraph(block: ParagraphBlock): boolean {
+  if (block.runs.length === 0) {
+    return true;
+  }
+  if (block.runs.length !== 1) {
+    return false;
+  }
+  const run = block.runs.at(0);
+  return run?.kind === "text" && run.text === "";
+}
+
+/**
+ * Resolve leading paragraph spacing after applying the empty-paragraph
+ * inherited-spacing collapse rule.
+ */
+export function getParagraphSpacingBefore(block: ParagraphBlock): number {
+  const value = block.attrs?.spacing?.before ?? 0;
+  if (value === 0) {
+    return 0;
+  }
+  if (
+    isEmptyParagraph(block) &&
+    !block.attrs?.styleId &&
+    !block.attrs?.hasDirectParagraphFormatting &&
+    !block.attrs?.spacingExplicit?.before
+  ) {
+    return 0;
+  }
+  return value;
+}
+
+/**
+ * Resolve trailing paragraph spacing after applying the empty-paragraph
+ * inherited-spacing collapse rule.
+ */
+export function getParagraphSpacingAfter(block: ParagraphBlock): number {
+  const value = block.attrs?.spacing?.after ?? 0;
+  if (value === 0) {
+    return 0;
+  }
+  if (
+    isEmptyParagraph(block) &&
+    !block.attrs?.styleId &&
+    !block.attrs?.hasDirectParagraphFormatting &&
+    !block.attrs?.spacingExplicit?.after
+  ) {
+    return 0;
+  }
+  return value;
+}

--- a/packages/core/src/layout-painter/renderTextBox.ts
+++ b/packages/core/src/layout-painter/renderTextBox.ts
@@ -10,6 +10,7 @@
 
 import { DEFAULT_TEXTBOX_MARGINS } from "../layout-engine/types";
 import type { TextBoxFragment, TextBoxBlock, TextBoxMeasure } from "../layout-engine/types";
+import { layoutTextBoxParagraphs } from "../layout-engine/measure/textBoxParagraphLayout";
 import { renderParagraphFragment } from "./renderParagraph";
 import type { RenderContext } from "./renderUtils";
 
@@ -76,12 +77,13 @@ export function renderTextBoxFragment(
 
   // Render inner paragraph content using pre-measured data
   const innerWidth = fragment.width - margins.left - margins.right;
-  let yOffset = 0;
+  const paragraphLayout = layoutTextBoxParagraphs(block.content, measure.innerMeasures);
 
   for (let i = 0; i < block.content.length; i++) {
     const paraBlock = block.content[i];
     const paraMeasure = measure.innerMeasures[i];
-    if (!paraBlock || !paraMeasure) {
+    const placement = paragraphLayout.placements[i];
+    if (!paraBlock || !paraMeasure || !placement) {
       continue;
     }
 
@@ -89,9 +91,9 @@ export function renderTextBoxFragment(
       kind: "paragraph" as const,
       blockId: paraBlock.id,
       x: 0,
-      y: yOffset,
+      y: 0,
       width: innerWidth,
-      height: paraMeasure.totalHeight,
+      height: placement.contentHeight,
       ...(paraBlock.pmStart !== undefined ? { pmStart: paraBlock.pmStart } : {}),
       ...(paraBlock.pmEnd !== undefined ? { pmEnd: paraBlock.pmEnd } : {}),
       fromLine: 0,
@@ -106,9 +108,10 @@ export function renderTextBoxFragment(
     paraEl.style.position = "relative";
     paraEl.style.left = "0";
     paraEl.style.top = "0";
+    paraEl.style.height = `${placement.contentHeight}px`;
+    paraEl.style.marginTop = `${placement.leadingSpacing}px`;
 
     containerEl.append(paraEl);
-    yOffset += paraMeasure.totalHeight;
   }
 
   return containerEl;


### PR DESCRIPTION
## Summary

- share paragraph-spacing resolution between body and text-box stories
- preserve collapsed authored spacing while painting text-box paragraphs
- cover meaningful empty paragraphs and adjacent spacing collapse

CC on behalf of @jan-kubica