### PR TITLE
fix: honor final section start mode

### DIFF
--- a/.changeset/quiet-sections-flow.md
+++ b/.changeset/quiet-sections-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Use the final section start mode when scheduling terminal OOXML section boundaries.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -321,6 +321,29 @@ const makeSectionedState = (): EditorState =>
     ]),
   });
 
+const makeImplicitSectionBoundaryState = (): EditorState =>
+  EditorState.create({
+    doc: schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _sectionProperties: {},
+        },
+        [schema.text("First section")],
+      ),
+      schema.node("paragraph", null, [schema.text("Second section")]),
+    ]),
+  });
+
+const makeSectionBoundaryDocument = (sectionStart: "continuous" | "nextPage") => {
+  const document = createEmptyDocument();
+  document.package.document.sections = [
+    { properties: {}, content: [] },
+    { properties: { sectionStart }, content: [] },
+  ];
+  return document;
+};
+
 const makePreparedHeaderFooter = (height: number): HeaderFooterContent => ({
   blocks: [],
   measures: [],
@@ -756,6 +779,27 @@ describe("runLayoutPipeline", () => {
     const outcome = runLayoutPipeline(makeDeps(createLayoutSession(), { document }), makeState());
 
     expect(outcome.layout?.pages.at(0)?.size).toEqual({ w: 1124, h: 795 });
+  });
+
+  test("uses the final section start mode for an implicit paragraph boundary", () => {
+    const state = makeImplicitSectionBoundaryState();
+    const continuous = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        document: makeSectionBoundaryDocument("continuous"),
+        sectionProperties: {},
+      }),
+      state,
+    );
+    const nextPage = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        document: makeSectionBoundaryDocument("nextPage"),
+        sectionProperties: {},
+      }),
+      state,
+    );
+
+    expect(continuous.layout?.pages).toHaveLength(1);
+    expect(nextPage.layout?.pages).toHaveLength(2);
   });
 
   test("uses the referenced final-section footer for body clearance", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -539,7 +539,7 @@ export function runLayoutPipeline<THfPMs>(
     // `bodyBreakType` does not model; the adapter narrows it away and passes the
     // value through unchanged at runtime. Preserved verbatim from the adapter.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    const bodyBreakType = sectionProperties?.sectionStart as
+    const bodyBreakType = finalSectionProperties?.sectionStart as
       | "continuous"
       | "nextPage"
       | "evenPage"


### PR DESCRIPTION
## Summary

- schedule section transitions from the final section’s OOXML start mode
- keep continuous implicit boundaries on the current page while preserving explicit next-page behavior
- add controller regression coverage for both start modes

## Verification

- focused section layout tests
- core package build
- dependency audit