### PR TITLE
fix: preserve list marker alignment

### DIFF
--- a/.changeset/level-marker-alignment.md
+++ b/.changeset/level-marker-alignment.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve numbering-level marker alignment through parsing and layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -584,7 +584,8 @@ export type ParagraphAttrs = {
     listIsBullet?: boolean;
     listMarkerHidden?: boolean;
     listMarkerFontFamily?: string;
-    listMarkerFontSize?: number;
+    listMarkerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing";
     listMarkerRevision?: {
         kind: "ins" | "del";

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -199,7 +199,8 @@ export type ParagraphAttrs = {
     listMarker?: string; /** Whether the list marker is hidden (w:vanish on numbering level rPr) */
     listMarkerHidden?: boolean; /** Marker font family from numbering level rPr */
     listMarkerFontFamily?: string; /** Marker font size from numbering level rPr, in points */
-    listMarkerFontSize?: number;
+    listMarkerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing"; /** `w:caps` on the numbering level rPr — render marker in upper case. */
     listMarkerAllCaps?: boolean;
     listImplicitChildLevelAdvances?: number;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -308,7 +308,8 @@ export type ParagraphAttrs = {
     listMarker?: string; /** Whether the list marker is hidden (w:vanish on numbering level rPr) */
     listMarkerHidden?: boolean; /** Marker font family from numbering level rPr */
     listMarkerFontFamily?: string; /** Marker font size from numbering level rPr, in points */
-    listMarkerFontSize?: number;
+    listMarkerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing"; /** `w:caps` on the numbering level rPr — render marker in upper case. */
     listMarkerAllCaps?: boolean;
     listImplicitChildLevelAdvances?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -497,7 +497,8 @@ export type ListRendering = {
     numFmt?: NumberFormat; /** Whether the list marker is hidden (w:vanish on level rPr) */
     markerHidden?: boolean; /** Marker font family from numbering level rPr (ascii name) */
     markerFontFamily?: string; /** Marker font size from numbering level rPr, in points */
-    markerFontSize?: number;
+    markerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    markerAlignment?: "left" | "center" | "right";
     markerAllCaps?: boolean;
     markerSuffix?: LevelSuffix; /** Number format for each level from 0 through this paragraph's level. */
     levelNumFmts?: NumberFormat[]; /** Abstract numbering definition shared by one or more numIds. */

--- a/packages/core/src/docx/numberingParser.ts
+++ b/packages/core/src/docx/numberingParser.ts
@@ -969,6 +969,9 @@ export function computeListRendering(
   if (level.rPr?.allCaps) {
     rendering.markerAllCaps = true;
   }
+  if (level.lvlJc) {
+    rendering.markerAlignment = level.lvlJc;
+  }
   if (level.suffix) {
     rendering.markerSuffix = level.suffix;
   }

--- a/packages/core/src/docx/paragraphParser-numbering-suffix.test.ts
+++ b/packages/core/src/docx/paragraphParser-numbering-suffix.test.ts
@@ -12,6 +12,7 @@ const NUMBERING_WITH_SUFFIXES = `<?xml version="1.0" encoding="UTF-8" standalone
       <w:start w:val="1"/>
       <w:numFmt w:val="decimal"/>
       <w:lvlText w:val="%1."/>
+      <w:lvlJc w:val="right"/>
       <w:suff w:val="space"/>
     </w:lvl>
   </w:abstractNum>
@@ -57,6 +58,7 @@ describe("paragraphParser propagates w:suff to listRendering", () => {
     );
 
     expect(paragraph.listRendering?.markerSuffix).toBe("space");
+    expect(paragraph.listRendering?.markerAlignment).toBe("right");
   });
 
   test('w:suff="nothing" reaches listRendering.markerSuffix', () => {

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1790,6 +1790,9 @@ export function parseParagraph(
         if (level.rPr?.allCaps) {
           listRendering.markerAllCaps = true;
         }
+        if (level.lvlJc) {
+          listRendering.markerAlignment = level.lvlJc;
+        }
         if (level.suffix) {
           listRendering.markerSuffix = level.suffix;
         }

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -896,6 +896,7 @@ function serializeParagraphAttrs(attrs: Record<string, unknown> | undefined): st
     "listMarker",
     "listIsBullet",
     "listMarkerHidden",
+    "listMarkerAlignment",
     "listMarkerSuffix",
     "tabs",
   ];

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1200,6 +1200,15 @@ function readListMarkerSuffix(value: unknown): PMParagraphAttrs["listMarkerSuffi
   return undefined;
 }
 
+function readListMarkerAlignment(
+  value: unknown,
+): PMParagraphAttrs["listMarkerAlignment"] | undefined {
+  if (value === "left" || value === "center" || value === "right") {
+    return value;
+  }
+  return undefined;
+}
+
 function toPreviousListAttrs(previousFormatting: Record<string, unknown>): PMParagraphAttrs {
   const attrs: PMParagraphAttrs = {};
   const numPr = previousFormatting["numPr"];
@@ -1263,6 +1272,11 @@ function toPreviousListAttrs(previousFormatting: Record<string, unknown>): PMPar
   const listMarkerFontSize = previousFormatting["listMarkerFontSize"];
   if (typeof listMarkerFontSize === "number") {
     attrs.listMarkerFontSize = listMarkerFontSize;
+  }
+
+  const listMarkerAlignment = readListMarkerAlignment(previousFormatting["listMarkerAlignment"]);
+  if (listMarkerAlignment) {
+    attrs.listMarkerAlignment = listMarkerAlignment;
   }
 
   const listMarkerSuffix = readListMarkerSuffix(previousFormatting["listMarkerSuffix"]);
@@ -1341,6 +1355,9 @@ function applyDeletedListMarkerAttrs(
   }
   if (previousListAttrs.listMarkerFontSize) {
     attrs.listMarkerFontSize = previousListAttrs.listMarkerFontSize;
+  }
+  if (previousListAttrs.listMarkerAlignment) {
+    attrs.listMarkerAlignment = previousListAttrs.listMarkerAlignment;
   }
   if (previousListAttrs.listMarkerSuffix) {
     attrs.listMarkerSuffix = previousListAttrs.listMarkerSuffix;
@@ -1712,6 +1729,9 @@ function convertParagraphAttrs(
   }
   if (pmAttrs.listMarkerFontSize) {
     attrs.listMarkerFontSize = pmAttrs.listMarkerFontSize;
+  }
+  if (pmAttrs.listMarkerAlignment) {
+    attrs.listMarkerAlignment = pmAttrs.listMarkerAlignment;
   }
   if (pmAttrs.listMarkerSuffix) {
     attrs.listMarkerSuffix = pmAttrs.listMarkerSuffix;

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import type { ParagraphBlock } from "../types";
 import { fixedCharWidth, withFakeTextMeasure } from "./__tests__/fakeTextMeasure";
-import { DEFAULT_TAB_STOP_TWIPS, getListMarkerInlineWidth } from "./listMarkerWidth";
+import {
+  DEFAULT_TAB_STOP_TWIPS,
+  getListMarkerInlineWidth,
+  getListMarkerVisualOffset,
+} from "./listMarkerWidth";
 
 const DEFAULT_TAB_STOP_PX = (DEFAULT_TAB_STOP_TWIPS / 1440) * 96;
 
@@ -67,6 +71,45 @@ describe("getListMarkerInlineWidth", () => {
       );
       // 2 chars + 1 space char = 30.
       expect(width).toBe(30);
+    }, fakeMeasure);
+  });
+
+  test("right-aligned marker ends at its anchor without consuming body width", () => {
+    withFakeTextMeasure(() => {
+      const block = listBlock({
+        listMarker: "1.",
+        listMarkerAlignment: "right",
+        listMarkerSuffix: "nothing",
+      });
+
+      expect(getListMarkerInlineWidth(block)).toBe(0);
+      expect(getListMarkerVisualOffset(block)).toBe(-20);
+    }, fakeMeasure);
+  });
+
+  test("center-aligned marker straddles its anchor", () => {
+    withFakeTextMeasure(() => {
+      const block = listBlock({
+        listMarker: "1.",
+        listMarkerAlignment: "center",
+        listMarkerSuffix: "space",
+      });
+
+      expect(getListMarkerInlineWidth(block)).toBe(20);
+      expect(getListMarkerVisualOffset(block)).toBe(-10);
+    }, fakeMeasure);
+  });
+
+  test("right-aligned tab marker preserves the hanging body anchor", () => {
+    withFakeTextMeasure(() => {
+      const block = listBlock({
+        listMarker: "1.",
+        listMarkerAlignment: "right",
+        indent: { left: 60, hanging: 36 },
+      });
+
+      expect(getListMarkerInlineWidth(block)).toBe(36);
+      expect(getListMarkerVisualOffset(block)).toBe(-20);
     }, fakeMeasure);
   });
 

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.ts
@@ -10,7 +10,7 @@
  * Both the painter (`renderParagraph.ts`) and the measurer (`measureParagraph`)
  * call into this so they agree on the marker's footprint — otherwise long
  * markers overflow the right edge of the first line. The painter applies the
- * returned width as `min-width`; the measurer subtracts the same value from
+ * returned value as a fixed inline width; the measurer subtracts the same value from
  * the first line's available width.
  */
 import type { ParagraphBlock, TextRun } from "../types";
@@ -82,14 +82,15 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
   const { fontFamily, fontSize } = resolveListMarkerFont(block);
   const style: FontStyle = { fontFamily, fontSize };
   const naturalWidth = measureTextWidth(attrs.listMarker, style);
+  const markerEndOffset = getMarkerEndOffset(naturalWidth, attrs.listMarkerAlignment);
 
   // §17.9.25 — `w:suff` controls what follows the marker before body text.
   const suffix = attrs.listMarkerSuffix ?? "tab";
   if (suffix === "nothing") {
-    return naturalWidth;
+    return markerEndOffset;
   }
   if (suffix === "space") {
-    return naturalWidth + measureTextWidth(" ", style);
+    return markerEndOffset + measureTextWidth(" ", style);
   }
 
   // Default suffix is `tab`. Body text aligns at the next stop past
@@ -101,7 +102,7 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
   const firstLine = indent?.firstLine ?? 0;
   const hanging = indent?.hanging ?? 0;
   const markerStartPx = hanging > 0 ? indentLeft - hanging : indentLeft + firstLine;
-  const minBodyStart = markerStartPx + naturalWidth;
+  const minBodyStart = markerStartPx + markerEndOffset;
 
   // Build tab-stop candidates. For hanging lists, the right edge of the
   // hanging slot (= indentLeft) is the implicit first tab stop after the
@@ -147,3 +148,34 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
   }
   return bodyStart - markerStartPx;
 }
+
+/** Paint-only offset that places the marker around its authored list anchor. */
+export function getListMarkerVisualOffset(block: ParagraphBlock): number {
+  const attrs = block.attrs;
+  if (!attrs?.listMarker || attrs.listMarkerHidden) {
+    return 0;
+  }
+
+  const { fontFamily, fontSize } = resolveListMarkerFont(block);
+  const naturalWidth = measureTextWidth(attrs.listMarker, { fontFamily, fontSize });
+  if (attrs.listMarkerAlignment === "right") {
+    return -naturalWidth;
+  }
+  if (attrs.listMarkerAlignment === "center") {
+    return -naturalWidth / 2;
+  }
+  return 0;
+}
+
+const getMarkerEndOffset = (
+  naturalWidth: number,
+  alignment: ParagraphBlock["attrs"]["listMarkerAlignment"],
+): number => {
+  if (alignment === "right") {
+    return 0;
+  }
+  if (alignment === "center") {
+    return naturalWidth / 2;
+  }
+  return naturalWidth;
+};

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.ts
@@ -169,7 +169,7 @@ export function getListMarkerVisualOffset(block: ParagraphBlock): number {
 
 const getMarkerEndOffset = (
   naturalWidth: number,
-  alignment: ParagraphBlock["attrs"]["listMarkerAlignment"],
+  alignment: NonNullable<ParagraphBlock["attrs"]>["listMarkerAlignment"],
 ): number => {
   if (alignment === "right") {
     return 0;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -422,6 +422,8 @@ export type ParagraphAttrs = {
   listMarkerHidden?: boolean; // w:vanish on numbering level rPr
   listMarkerFontFamily?: string; // from numbering level rPr (w:rFonts)
   listMarkerFontSize?: number; // from numbering level rPr, in points
+  /** Horizontal alignment of the marker around the paragraph's list anchor. */
+  listMarkerAlignment?: "left" | "center" | "right";
   /**
    * `w:suff` (§17.9.25) — what follows the marker before body text.
    * `tab` (default) grows the marker to the next tab stop; `space` adds

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -80,7 +80,10 @@ const fakeDocument = {
   },
 } as unknown as Document;
 
-function renderListItem(indent: { left: number; hanging: number }): {
+function renderListItem(
+  indent: { left: number; hanging: number },
+  listMarkerAlignment?: "left" | "center" | "right",
+): {
   line: HTMLElement;
   marker: HTMLElement | undefined;
 } {
@@ -88,7 +91,7 @@ function renderListItem(indent: { left: number; hanging: number }): {
     kind: "paragraph",
     id: "p1",
     runs: [{ kind: "text", text: "TEST1" }],
-    attrs: { listMarker: "1.", indent },
+    attrs: { listMarker: "1.", indent, listMarkerAlignment },
   };
   const measure: ParagraphMeasure = {
     kind: "paragraph",
@@ -146,6 +149,13 @@ function renderListItem(indent: { left: number; hanging: number }): {
 }
 
 describe("Issue #729 — list hanging indent exceeding left indent", () => {
+  test("right-aligned marker paints before its anchor without moving body text", () => {
+    const { marker } = renderListItem({ left: 48, hanging: 24 }, "right");
+
+    expect(marker?.style.width).toBe("24px");
+    expect(Number.parseFloat(marker?.style.transform?.slice(11) ?? "")).toBeCloseTo(-14, 1);
+  });
+
   test("hanging > left: marker hangs into the margin via negative margin-left", () => {
     // 15px left, 38px hanging — marker should start at 15 - 38 = -23px.
     const { line, marker } = renderListItem({ left: 15, hanging: 38 });

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -9,7 +9,10 @@ import { ommlToMathml } from "../docx/mathToMathml";
 import { parseXmlDocument } from "../docx/xmlParser";
 import { evaluateFieldInstruction } from "../fields/evaluateField";
 import type { FieldContext } from "../fields/fieldContext";
-import { getListMarkerInlineWidth } from "../layout-engine/measure/listMarkerWidth";
+import {
+  getListMarkerInlineWidth,
+  getListMarkerVisualOffset,
+} from "../layout-engine/measure/listMarkerWidth";
 import type {
   ParagraphBlock,
   ParagraphMeasure,
@@ -2737,6 +2740,7 @@ export function renderParagraphFragment(
       const marker = renderListMarker(
         block.attrs.listMarker,
         getListMarkerInlineWidth(block),
+        getListMarkerVisualOffset(block),
         doc,
         markerFontFamily,
         markerFontSize,
@@ -2769,7 +2773,7 @@ export function renderParagraphFragment(
 
 /**
  * Render a list marker element as an inline-block at the start of the first
- * body line. `minWidth` (from `getListMarkerInlineWidth`) sizes the marker
+ * body line. `inlineWidth` (from `getListMarkerInlineWidth`) sizes the marker
  * so the body text aligns at the next tab stop per ECMA-376 §17.9.25 —
  * this honours `w:suff` (`tab` / `space` / `nothing`) and the document's
  * tab grid. Long markers like "1.1.1." therefore grow to the next stop
@@ -2777,7 +2781,8 @@ export function renderParagraphFragment(
  */
 function renderListMarker(
   marker: string,
-  minWidth: number,
+  inlineWidth: number,
+  visualOffset: number,
   doc: Document,
   fontFamily?: string,
   fontSize?: number,
@@ -2805,8 +2810,9 @@ function renderListMarker(
   span.style.textAlign = "left";
   span.style.textAlignLast = "left";
   span.style.boxSizing = "border-box";
-  if (minWidth > 0) {
-    span.style.minWidth = `${minWidth}px`;
+  span.style.width = `${inlineWidth}px`;
+  if (visualOffset !== 0) {
+    span.style.transform = `translateX(${visualOffset}px)`;
   }
 
   if (revision) {

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -267,6 +267,11 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   optionalBoolean(attrs, "listMarkerHidden", "paragraph.attrs.listMarkerHidden", issues);
   optionalString(attrs, "listMarkerFontFamily", "paragraph.attrs.listMarkerFontFamily", issues);
   optionalNumber(attrs, "listMarkerFontSize", "paragraph.attrs.listMarkerFontSize", issues);
+  optionalOneOf(attrs, "listMarkerAlignment", "paragraph.attrs.listMarkerAlignment", issues, [
+    "left",
+    "center",
+    "right",
+  ]);
   optionalString(attrs, "listMarkerSuffix", "paragraph.attrs.listMarkerSuffix", issues);
   optionalBoolean(attrs, "listMarkerAllCaps", "paragraph.attrs.listMarkerAllCaps", issues);
   optionalNumber(

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -519,6 +519,9 @@ function listRenderingFromAttrs(attrs: ParagraphAttrs): Paragraph["listRendering
     ...(attrs.listMarkerFontSize != null && {
       markerFontSize: attrs.listMarkerFontSize,
     }),
+    ...(attrs.listMarkerAlignment != null && {
+      markerAlignment: attrs.listMarkerAlignment,
+    }),
     ...(attrs.listMarkerSuffix != null && {
       markerSuffix: attrs.listMarkerSuffix,
     }),

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -493,6 +493,9 @@ function paragraphFormattingToAttrs(
   if (paragraph.listRendering?.markerFontSize) {
     attrs.listMarkerFontSize = paragraph.listRendering.markerFontSize;
   }
+  if (paragraph.listRendering?.markerAlignment) {
+    attrs.listMarkerAlignment = paragraph.listRendering.markerAlignment;
+  }
   if (paragraph.listRendering?.markerSuffix) {
     attrs.listMarkerSuffix = paragraph.listRendering.markerSuffix;
   }

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -339,6 +339,7 @@ const paragraphNodeSpec: NodeSpec = {
     listMarkerHidden: { default: null },
     listMarkerFontFamily: { default: null },
     listMarkerFontSize: { default: null },
+    listMarkerAlignment: { default: null },
     listMarkerSuffix: { default: null },
     listMarkerAllCaps: { default: null },
     listImplicitChildLevelAdvances: { default: null },

--- a/packages/core/src/prosemirror/extensions/features/ListExtension-suggestion.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension-suggestion.test.ts
@@ -82,6 +82,7 @@ describe("ListExtension suggestion mode integration", () => {
       listMarkerHidden: null,
       listMarkerFontFamily: null,
       listMarkerFontSize: null,
+      listMarkerAlignment: null,
       listMarkerSuffix: null,
       listLevelNumFmts: null,
       listLevelStarts: null,

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -63,6 +63,7 @@ const LIST_FORMATTING_ATTRS = [
   "listMarkerHidden",
   "listMarkerFontFamily",
   "listMarkerFontSize",
+  "listMarkerAlignment",
   "listMarkerSuffix",
   "listLevelNumFmts",
   "listLevelStarts",

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -103,6 +103,8 @@ export type ParagraphAttrs = {
   listMarkerFontFamily?: string;
   /** Marker font size from numbering level rPr, in points */
   listMarkerFontSize?: number;
+  /** Horizontal alignment of the marker around the paragraph's list anchor. */
+  listMarkerAlignment?: "left" | "center" | "right";
   /**
    * `w:suff` (§17.9.25) — what follows the marker before body text.
    * `tab` (default) grows the marker to the next tab stop; `space` adds one

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -110,6 +110,7 @@ export function listAttrsFromResolvedStyle(
     listMarkerHidden: rendering?.markerHidden ?? null,
     listMarkerFontFamily: rendering?.markerFontFamily ?? null,
     listMarkerFontSize: rendering?.markerFontSize ?? null,
+    listMarkerAlignment: rendering?.markerAlignment ?? null,
     listMarkerSuffix: rendering?.markerSuffix ?? null,
     listMarkerAllCaps: rendering?.markerAllCaps ?? null,
     listImplicitChildLevelAdvances: null,

--- a/packages/docx-core/src/model/lists.ts
+++ b/packages/docx-core/src/model/lists.ts
@@ -176,6 +176,8 @@ export type ListRendering = {
   markerFontFamily?: string;
   /** Marker font size from numbering level rPr, in points */
   markerFontSize?: number;
+  /** Horizontal alignment of the marker around the paragraph's list anchor. */
+  markerAlignment?: "left" | "center" | "right";
   /**
    * `w:caps` on the numbering level rPr — the marker text renders in upper
    * case (e.g. "SCHEDULE 1" instead of "Schedule 1"). Apply at substitution


### PR DESCRIPTION
## Summary

- carry numbering-level marker alignment through the document, editor, and layout models
- compute marker footprint from the aligned edge while painting the glyph around its authored anchor
- cover parsing, measurement, painting, tracked list formatting, and header/footer conversion

## Fidelity

- anonymous strict same-font case: 57.2% to 71.5%, with 18/18 pages preserved
- independent anonymous cross-case: 100% unchanged

## Validation

- 98 focused unit tests passed
- dependency audit found no vulnerabilities

CC on behalf of @jan-kubica