### PR TITLE
fix: preserve positioned paragraph frames

### DIFF
--- a/.changeset/calm-frames-flow.md
+++ b/.changeset/calm-frames-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve positioned paragraph frames during layout and pagination.

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -517,7 +517,10 @@ export function runLayoutPipeline<THfPMs>(
     let newMeasures =
       incrementalResult?.measures ??
       measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
+        pageWidth: blockMeasureInputs.pageWidths,
         pageHeight: blockMeasureInputs.pageHeights,
+        marginLeft: blockMeasureInputs.marginLefts,
+        marginRight: blockMeasureInputs.marginRights,
         marginBottom: blockMeasureInputs.marginBottoms,
       });
     pendingArtifacts = {
@@ -703,7 +706,10 @@ export function runLayoutPipeline<THfPMs>(
           blockWidths,
           blockMeasureInputs.marginTops,
           {
+            pageWidth: blockMeasureInputs.pageWidths,
             pageHeight: blockMeasureInputs.pageHeights,
+            marginLeft: blockMeasureInputs.marginLefts,
+            marginRight: blockMeasureInputs.marginRights,
             marginBottom: blockMeasureInputs.marginBottoms,
           },
           values,

--- a/packages/core/src/layout-bridge/convert/paragraphFrames.ts
+++ b/packages/core/src/layout-bridge/convert/paragraphFrames.ts
@@ -1,0 +1,197 @@
+import { getParagraphFrame, markParagraphFrameTextBox } from "../../layout-engine/paragraphFrame";
+import type { ParagraphFrame } from "../../layout-engine/paragraphFrame";
+import { setTextBoxGroupId } from "../../layout-engine/textBoxGroup";
+import type {
+  BlockId,
+  FlowBlock,
+  ImageRunPosition,
+  ParagraphBlock,
+  TextBoxBlock,
+} from "../../layout-engine/types";
+import { pixelsToEmu } from "../../utils/units";
+
+type BlockIdFactory = () => BlockId;
+
+const FRAME_PROPERTIES = [
+  "width",
+  "height",
+  "hAnchor",
+  "vAnchor",
+  "x",
+  "y",
+  "xAlign",
+  "yAlign",
+  "wrap",
+] as const satisfies readonly (keyof ParagraphFrame)[];
+
+function framesEqual(left: ParagraphFrame, right: ParagraphFrame): boolean {
+  return FRAME_PROPERTIES.every((property) => left[property] === right[property]);
+}
+
+function horizontalRelativeTo(
+  anchor: ParagraphFrame["hAnchor"],
+): NonNullable<NonNullable<ImageRunPosition["horizontal"]>["relativeTo"]> {
+  if (anchor === "page" || anchor === "margin") {
+    return anchor;
+  }
+  return "column";
+}
+
+function verticalRelativeTo(
+  anchor: ParagraphFrame["vAnchor"],
+): NonNullable<NonNullable<ImageRunPosition["vertical"]>["relativeTo"]> {
+  if (anchor === "page" || anchor === "margin") {
+    return anchor;
+  }
+  return "paragraph";
+}
+
+function framePosition(frame: ParagraphFrame): ImageRunPosition | undefined {
+  const horizontal =
+    frame.x !== undefined || frame.xAlign !== undefined || frame.hAnchor !== undefined
+      ? {
+          relativeTo: horizontalRelativeTo(frame.hAnchor),
+          ...(frame.x !== undefined ? { posOffset: pixelsToEmu(frame.x) } : {}),
+          ...(frame.xAlign !== undefined ? { align: frame.xAlign } : {}),
+        }
+      : undefined;
+  const verticalAlign = frame.yAlign === "inline" ? undefined : frame.yAlign;
+  const vertical =
+    frame.y !== undefined || verticalAlign !== undefined || frame.vAnchor !== undefined
+      ? {
+          relativeTo: verticalRelativeTo(frame.vAnchor),
+          ...(frame.y !== undefined ? { posOffset: pixelsToEmu(frame.y) } : {}),
+          ...(verticalAlign !== undefined ? { align: verticalAlign } : {}),
+        }
+      : undefined;
+
+  if (horizontal === undefined && vertical === undefined) {
+    return undefined;
+  }
+  return {
+    ...(horizontal !== undefined ? { horizontal } : {}),
+    ...(vertical !== undefined ? { vertical } : {}),
+  };
+}
+
+function frameWrapType(frame: ParagraphFrame): NonNullable<TextBoxBlock["wrapType"]> {
+  switch (frame.wrap) {
+    case "notBeside":
+      return "topAndBottom";
+    case "none":
+      return "inFront";
+    case "through":
+      return "through";
+    case "tight":
+      return "tight";
+    case "around":
+    case "auto":
+    case undefined:
+      return "square";
+    default:
+      frame.wrap satisfies never;
+      return "square";
+  }
+}
+
+function toFrameTextBox(
+  content: ParagraphBlock[],
+  frame: ParagraphFrame,
+  nextBlockId: BlockIdFactory,
+): TextBoxBlock {
+  const first = content.at(0);
+  const last = content.at(-1);
+  const textBox: TextBoxBlock = {
+    kind: "textBox",
+    id: nextBlockId(),
+    width: frame.width ?? 200,
+    margins: { top: 0, right: 0, bottom: 0, left: 0 },
+    content,
+    displayMode: "float",
+    wrapType: frameWrapType(frame),
+    wrapText: "bothSides",
+    ...(first?.pmStart !== undefined ? { pmStart: first.pmStart } : {}),
+    ...(last?.pmEnd !== undefined ? { pmEnd: last.pmEnd } : {}),
+  };
+  if (frame.height !== undefined) {
+    textBox.height = frame.height;
+  }
+  const position = framePosition(frame);
+  if (position !== undefined) {
+    textBox.position = position;
+  }
+  markParagraphFrameTextBox(textBox);
+  return textBox;
+}
+
+export function groupParagraphFrames(
+  blocks: FlowBlock[],
+  nextBlockId: BlockIdFactory,
+): FlowBlock[] {
+  const grouped: FlowBlock[] = [];
+  let index = 0;
+  let activeFrameSetId: string | undefined;
+
+  while (index < blocks.length) {
+    const block = blocks[index];
+    if (block?.kind !== "paragraph") {
+      if (block) {
+        grouped.push(block);
+      }
+      activeFrameSetId = undefined;
+      index += 1;
+      continue;
+    }
+
+    const frame = getParagraphFrame(block);
+    if (frame === undefined) {
+      grouped.push(block);
+      if (
+        block.runs.length > 0 ||
+        activeFrameSetId === undefined ||
+        !hasFollowingParagraphFrame(blocks, index + 1)
+      ) {
+        activeFrameSetId = undefined;
+      }
+      index += 1;
+      continue;
+    }
+
+    activeFrameSetId ??= `paragraph-frame-${block.pmStart ?? block.id}`;
+    const content: ParagraphBlock[] = [];
+    while (index < blocks.length) {
+      const paragraph = blocks[index];
+      if (paragraph?.kind !== "paragraph") {
+        break;
+      }
+      const paragraphFrame = getParagraphFrame(paragraph);
+      if (paragraphFrame === undefined || !framesEqual(frame, paragraphFrame)) {
+        break;
+      }
+      content.push(paragraph);
+      index += 1;
+    }
+
+    const textBox = toFrameTextBox(content, frame, nextBlockId);
+    setTextBoxGroupId(textBox, activeFrameSetId);
+    grouped.push(textBox);
+  }
+
+  return grouped;
+}
+
+function hasFollowingParagraphFrame(blocks: FlowBlock[], startIndex: number): boolean {
+  for (let index = startIndex; index < blocks.length; index++) {
+    const block = blocks[index];
+    if (block?.kind !== "paragraph") {
+      return false;
+    }
+    if (getParagraphFrame(block) !== undefined) {
+      return true;
+    }
+    if (block.runs.length > 0) {
+      return false;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { getTextBoxGroupId } from "../../layout-engine/textBoxGroup";
 import { schema } from "../../prosemirror/schema";
 import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
@@ -217,6 +218,82 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(para?.kind).toBe("paragraph");
     if (para?.kind === "paragraph") {
       expect(para.paraId).toBe("1A2B3C4D");
+    }
+  });
+
+  test("groups consecutive page-anchored frame paragraphs into one positioned container", () => {
+    const frame = {
+      width: 1440,
+      height: 720,
+      hAnchor: "page" as const,
+      vAnchor: "page" as const,
+      x: 720,
+      y: 1440,
+      wrap: "around" as const,
+    };
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { _originalFormatting: { frame } }, [schema.text("first")]),
+      schema.node("paragraph", { _originalFormatting: { frame } }, [schema.text("second")]),
+      schema.node("paragraph", null, [schema.text("body")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual(["textBox", "paragraph"]);
+    const framed = blocks.at(0);
+    if (framed?.kind !== "textBox") {
+      throw new Error("Expected grouped paragraph frame");
+    }
+    expect(framed).toMatchObject({
+      width: 96,
+      height: 48,
+      margins: { top: 0, right: 0, bottom: 0, left: 0 },
+      displayMode: "float",
+      wrapType: "square",
+      position: {
+        horizontal: { relativeTo: "page", posOffset: 457_200 },
+        vertical: { relativeTo: "page", posOffset: 914_400 },
+      },
+    });
+    expect(framed.content.map((paragraph) => paragraph.runs.at(0))).toMatchObject([
+      { kind: "text", text: "first" },
+      { kind: "text", text: "second" },
+    ]);
+  });
+
+  test("keeps page-anchored frames in one wrap set across an empty anchor paragraph", () => {
+    const frame = {
+      width: 1440,
+      height: 720,
+      hAnchor: "page" as const,
+      vAnchor: "page" as const,
+      x: 720,
+      y: 1440,
+      wrap: "around" as const,
+    };
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { _originalFormatting: { frame } }, [schema.text("left")]),
+      schema.node("paragraph", { paragraphStyle: "Anchor" }),
+      schema.node("paragraph", { _originalFormatting: { frame: { ...frame, x: 2880 } } }, [
+        schema.text("right"),
+      ]),
+      schema.node("paragraph", null, [schema.text("body")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const left = blocks.at(0);
+    const right = blocks.at(2);
+
+    expect(blocks.map((block) => block.kind)).toEqual([
+      "textBox",
+      "paragraph",
+      "textBox",
+      "paragraph",
+    ]);
+    expect(left?.kind).toBe("textBox");
+    expect(right?.kind).toBe("textBox");
+    if (left?.kind === "textBox" && right?.kind === "textBox") {
+      expect(getTextBoxGroupId(right)).toBe(getTextBoxGroupId(left));
     }
   });
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -34,6 +34,7 @@ import type {
   FloatingTablePosition,
 } from "../../layout-engine/types";
 import { setTextBoxGroupId } from "../../layout-engine/textBoxGroup";
+import { setParagraphFrame } from "../../layout-engine/paragraphFrame";
 import { DEFAULT_TEXTBOX_MARGINS, DEFAULT_TEXTBOX_WIDTH } from "../../layout-engine/types";
 import { getColumns } from "../sectionColumns";
 import {
@@ -87,6 +88,7 @@ import {
   halfPointsToPixels,
   halfPointsToPoints,
 } from "../../utils/units";
+import { groupParagraphFrames } from "./paragraphFrames";
 
 /**
  * Options for the conversion.
@@ -1854,7 +1856,7 @@ function convertParagraph(
 
   const bookmarkNames = pmAttrs.bookmarks?.map((b) => b.name);
 
-  return {
+  const block: ParagraphBlock = {
     kind: "paragraph",
     id: nextBlockId(),
     runs,
@@ -1864,6 +1866,21 @@ function convertParagraph(
     pmStart: startPos,
     pmEnd: startPos + node.nodeSize,
   };
+  const frame = pmAttrs._originalFormatting?.frame;
+  if (frame !== undefined) {
+    setParagraphFrame(block, {
+      ...(frame.width !== undefined ? { width: twipsToPixels(frame.width) } : {}),
+      ...(frame.height !== undefined ? { height: twipsToPixels(frame.height) } : {}),
+      ...(frame.hAnchor !== undefined ? { hAnchor: frame.hAnchor } : {}),
+      ...(frame.vAnchor !== undefined ? { vAnchor: frame.vAnchor } : {}),
+      ...(frame.x !== undefined ? { x: twipsToPixels(frame.x) } : {}),
+      ...(frame.y !== undefined ? { y: twipsToPixels(frame.y) } : {}),
+      ...(frame.xAlign !== undefined ? { xAlign: frame.xAlign } : {}),
+      ...(frame.yAlign !== undefined ? { yAlign: frame.yAlign } : {}),
+      ...(frame.wrap !== undefined ? { wrap: frame.wrap } : {}),
+    });
+  }
+  return block;
 }
 
 /**
@@ -2104,7 +2121,7 @@ function convertTableCell(
 
   const cell: TableCell = {
     id: nextBlockId(),
-    blocks,
+    blocks: groupParagraphFrames(blocks, nextBlockId),
     colSpan: attrs.colspan,
     rowSpan: attrs.rowspan,
     padding,
@@ -2770,7 +2787,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
 
   reserveLeadingEmptyOutlineHeight(blocks);
   suppressTerminalEmptyParagraphsAfterTable(blocks);
-  return mergeRunInParagraphs(blocks);
+  return groupParagraphFrames(mergeRunInParagraphs(blocks), nextBlockId);
 }
 
 /**

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import type { FlowBlock, ImageBlock, ParagraphBlock, TableBlock, TextBoxBlock } from "../types";
+import { markParagraphFrameTextBox } from "../paragraphFrame";
 import { setTextBoxGroupId } from "../textBoxGroup";
+import { pixelsToEmu } from "../../utils/units";
 import { fixedCharWidth, withFakeTextMeasure } from "./__tests__/fakeTextMeasure";
 import { measureBlock, measureBlocks, measureTableBlock } from "./measureBlocks";
 
@@ -141,6 +143,45 @@ describe("measureBlocks", () => {
       }
 
       expect(paragraphMeasure.lines.at(0)?.floatSkipBefore).toBeCloseTo(60, 5);
+    }, fakeMeasure);
+  });
+
+  test("reserves a paragraph frame set before measuring body text", () => {
+    withFakeTextMeasure(() => {
+      const frame = (id: string, x: number): TextBoxBlock => ({
+        kind: "textBox",
+        id,
+        width: 300,
+        height: 100,
+        content: [],
+        displayMode: "float",
+        wrapType: "square",
+        wrapText: "bothSides",
+        position: {
+          horizontal: { relativeTo: "page", posOffset: pixelsToEmu(x) },
+          vertical: { relativeTo: "page", posOffset: pixelsToEmu(136) },
+        },
+      });
+      const left = frame("left-frame", 96);
+      const right = frame("right-frame", 396);
+      markParagraphFrameTextBox(left);
+      markParagraphFrameTextBox(right);
+      setTextBoxGroupId(left, "frame-set");
+      setTextBoxGroupId(right, "frame-set");
+
+      const measures = measureBlocks([left, right, para("body", "body")], 600, 96, {
+        pageWidth: 792,
+        pageHeight: 1_056,
+        marginLeft: 96,
+        marginRight: 96,
+        marginBottom: 96,
+      });
+      const bodyMeasure = measures.at(2);
+      if (bodyMeasure?.kind !== "paragraph") {
+        throw new Error("Expected body paragraph measure");
+      }
+
+      expect(bodyMeasure.lines.at(0)?.floatSkipBefore).toBeCloseTo(140, 5);
     }, fakeMeasure);
   });
 

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -1,9 +1,11 @@
 import { recordMeasureBlock, recordMeasureBlockError } from "../layoutInstrumentation";
-import { bandTopContentY, isPageFrameRelativeAnchor } from "../textBoxFlow";
+import { isParagraphFrameTextBox } from "../paragraphFrame";
+import { bandFragmentX, bandTopContentY, isPageFrameRelativeAnchor } from "../textBoxFlow";
 import { getTextBoxGroupId } from "../textBoxGroup";
 import {
   DEFAULT_TEXTBOX_MARGINS,
   floatingTextBoxReservesBand,
+  floatingTextBoxWrapsText,
   isFloatingTextBoxBlock,
   tableColumnsArePinned,
 } from "../types";
@@ -455,11 +457,42 @@ function perBlockNumberValue(
   return value;
 }
 
+type TextBoxWrapSideOptions = {
+  box: TextBoxBlock;
+  contentX: number;
+  boxWidth: number;
+  contentWidth: number;
+};
+
+function textBoxWrapSide({
+  box,
+  contentX,
+  boxWidth,
+  contentWidth,
+}: TextBoxWrapSideOptions): "left" | "right" {
+  if (box.wrapText === "left") {
+    return "left";
+  }
+  if (box.wrapText === "right") {
+    return "right";
+  }
+
+  const leftSpace = contentX;
+  const rightSpace = contentWidth - contentX - boxWidth;
+  if (box.wrapText === "largest") {
+    return leftSpace >= rightSpace ? "left" : "right";
+  }
+  return contentX + boxWidth / 2 < contentWidth / 2 ? "right" : "left";
+}
+
 // Page geometry the band extraction needs to resolve page/margin-pinned
 // topAndBottom anchors (bottom-strip frames, centered/bottom align). Per-block
 // because sections can vary page size and margins. eigenpal #694.
 type BandPageGeometry = {
+  pageWidth?: number | number[];
   pageHeight: number | number[];
+  marginLeft?: number | number[];
+  marginRight?: number | number[];
   marginBottom: number | number[];
 };
 
@@ -472,11 +505,23 @@ function extractFloatingZones(
   const zones: FloatingZoneWithAnchor[] = [];
   const textBoxGroupAnchors = new Map<string, number>();
   const defaultMarginTop = Array.isArray(marginTop) ? (marginTop[0] ?? 0) : marginTop;
+  const pageWidthInput = pageGeometry?.pageWidth ?? contentWidth;
   const pageHeightInput = pageGeometry?.pageHeight ?? 0;
+  const marginLeftInput = pageGeometry?.marginLeft ?? 0;
+  const marginRightInput = pageGeometry?.marginRight ?? 0;
   const marginBottomInput = pageGeometry?.marginBottom ?? 0;
+  const defaultPageWidth = Array.isArray(pageWidthInput)
+    ? (pageWidthInput[0] ?? contentWidth)
+    : pageWidthInput;
   const defaultPageHeight = Array.isArray(pageHeightInput)
     ? (pageHeightInput[0] ?? 0)
     : pageHeightInput;
+  const defaultMarginLeft = Array.isArray(marginLeftInput)
+    ? (marginLeftInput[0] ?? 0)
+    : marginLeftInput;
+  const defaultMarginRight = Array.isArray(marginRightInput)
+    ? (marginRightInput[0] ?? 0)
+    : marginRightInput;
   const defaultMarginBottom = Array.isArray(marginBottomInput)
     ? (marginBottomInput[0] ?? 0)
     : marginBottomInput;
@@ -620,6 +665,84 @@ function extractFloatingZones(
       topY: topY - distTop,
       bottomY: bottomY + distBottom,
       anchorBlockIndex: blockIndex,
+    });
+  }
+
+  // Positioned side-wrapped text boxes carve the same horizontal exclusion
+  // during pagination that the painter applies during its final re-measure.
+  // Without this pre-scan, paragraphs paint around the box but retain their
+  // original page assignment, so a page-anchored frame can overlap later body
+  // content or create a false extra page.
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+    const block = blocks[blockIndex]!; // SAFETY: blockIndex < blocks.length
+    if (block.kind !== "textBox") {
+      continue;
+    }
+    const tb = block as TextBoxBlock;
+    if (!floatingTextBoxWrapsText(tb) || tb.position === undefined) {
+      continue;
+    }
+
+    const measure = measureTextBoxBlock(tb);
+    const blockMarginTop = perBlockNumberValue(marginTop, blockIndex, defaultMarginTop);
+    const blockMarginLeft = perBlockNumberValue(marginLeftInput, blockIndex, defaultMarginLeft);
+    const blockMarginRight = perBlockNumberValue(marginRightInput, blockIndex, defaultMarginRight);
+    const blockPageWidth = perBlockNumberValue(pageWidthInput, blockIndex, defaultPageWidth);
+    const vertical = tb.position.vertical;
+    const pageFrameRelative = isPageFrameRelativeAnchor(vertical?.relativeTo);
+    const topY = pageFrameRelative
+      ? bandTopContentY(vertical, {
+          pageHeight: perBlockNumberValue(pageHeightInput, blockIndex, defaultPageHeight),
+          marginTop: blockMarginTop,
+          marginBottom: perBlockNumberValue(marginBottomInput, blockIndex, defaultMarginBottom),
+          boxHeight: measure.height,
+        })
+      : emuToPixels(vertical?.posOffset ?? 0);
+    const groupId = getTextBoxGroupId(tb);
+    const anchorBlockIndex = groupId
+      ? (textBoxGroupAnchors.get(groupId) ?? blockIndex)
+      : blockIndex;
+    if (groupId && !textBoxGroupAnchors.has(groupId)) {
+      textBoxGroupAnchors.set(groupId, blockIndex);
+    }
+    if (isParagraphFrameTextBox(tb)) {
+      zones.push({
+        leftMargin: 0,
+        rightMargin: 0,
+        topY: 0,
+        bottomY: topY + measure.height + (tb.distBottom ?? 0),
+        anchorBlockIndex,
+        ...(pageFrameRelative ? { isMarginRelative: true } : {}),
+        fullWidthBlock: true,
+      });
+      continue;
+    }
+
+    const horizontal = tb.position.horizontal;
+    const pageX = horizontal
+      ? bandFragmentX(horizontal, {
+          pageWidth: blockPageWidth,
+          marginLeft: blockMarginLeft,
+          marginRight: blockMarginRight,
+          boxWidth: measure.width,
+        })
+      : blockMarginLeft;
+    const contentX = pageX - blockMarginLeft;
+    const wrapSide = textBoxWrapSide({
+      box: tb,
+      contentX,
+      boxWidth: measure.width,
+      contentWidth,
+    });
+    const leftMargin = wrapSide === "right" ? contentX + measure.width + (tb.distRight ?? 12) : 0;
+    const rightMargin = wrapSide === "left" ? contentWidth - contentX + (tb.distLeft ?? 12) : 0;
+    zones.push({
+      leftMargin: Math.max(0, leftMargin),
+      rightMargin: Math.max(0, rightMargin),
+      topY: topY - (tb.distTop ?? 0),
+      bottomY: topY + measure.height + (tb.distBottom ?? 0),
+      anchorBlockIndex,
+      ...(pageFrameRelative ? { isMarginRelative: true } : {}),
     });
   }
 

--- a/packages/core/src/layout-engine/paragraphFrame.ts
+++ b/packages/core/src/layout-engine/paragraphFrame.ts
@@ -1,0 +1,32 @@
+import type { ParagraphBlock, TextBoxBlock } from "./types";
+
+export type ParagraphFrame = {
+  width?: number;
+  height?: number;
+  hAnchor?: "text" | "margin" | "page";
+  vAnchor?: "text" | "margin" | "page";
+  x?: number;
+  y?: number;
+  xAlign?: "left" | "center" | "right" | "inside" | "outside";
+  yAlign?: "top" | "center" | "bottom" | "inside" | "outside" | "inline";
+  wrap?: "around" | "auto" | "none" | "notBeside" | "through" | "tight";
+};
+
+const paragraphFrames = new WeakMap<ParagraphBlock, ParagraphFrame>();
+const paragraphFrameTextBoxes = new WeakSet<TextBoxBlock>();
+
+export function setParagraphFrame(block: ParagraphBlock, frame: ParagraphFrame): void {
+  paragraphFrames.set(block, frame);
+}
+
+export function getParagraphFrame(block: ParagraphBlock): ParagraphFrame | undefined {
+  return paragraphFrames.get(block);
+}
+
+export function markParagraphFrameTextBox(block: TextBoxBlock): void {
+  paragraphFrameTextBoxes.add(block);
+}
+
+export function isParagraphFrameTextBox(block: TextBoxBlock): boolean {
+  return paragraphFrameTextBoxes.has(block);
+}

--- a/packages/core/src/layout-painter/renderTextBox.ts
+++ b/packages/core/src/layout-painter/renderTextBox.ts
@@ -100,8 +100,12 @@ export function renderTextBoxFragment(
       toLine: paraMeasure.lines.length,
     };
 
+    const prevBorders = block.content[i - 1]?.attrs?.borders;
+    const nextBorders = block.content[i + 1]?.attrs?.borders;
     const paraEl = renderParagraphFragment(paraFragment, paraBlock, paraMeasure, context, {
       document: doc,
+      ...(prevBorders !== undefined ? { prevBorders } : {}),
+      ...(nextBorders !== undefined ? { nextBorders } : {}),
     });
 
     // Override absolute positioning to use relative flow within the text box

--- a/packages/core/src/paged-layout/sectionBlockWidths.test.ts
+++ b/packages/core/src/paged-layout/sectionBlockWidths.test.ts
@@ -58,6 +58,9 @@ describe("section block measurement inputs", () => {
     });
 
     expect(inputs.marginTops).toEqual([64, 64, BODY_CONFIG.margins.top]);
+    expect(inputs.pageWidths).toEqual([600, 600, BODY_CONFIG.pageSize.w]);
+    expect(inputs.marginLefts).toEqual([50, 50, BODY_CONFIG.margins.left]);
+    expect(inputs.marginRights).toEqual([50, 50, BODY_CONFIG.margins.right]);
   });
 
   test("uses the authored width after a forced break in unequal columns", () => {

--- a/packages/core/src/paged-layout/sectionBlockWidths.ts
+++ b/packages/core/src/paged-layout/sectionBlockWidths.ts
@@ -15,6 +15,9 @@ type PerBlockMeasureInputs = {
   // bands (`bandTopContentY`) in the measure pass. Sections can vary page size
   // and margins, so these are per-block like `widths`/`marginTops`.
   pageHeights: number[];
+  pageWidths: number[];
+  marginLefts: number[];
+  marginRights: number[];
   marginBottoms: number[];
 };
 
@@ -71,6 +74,9 @@ export function computePerBlockMeasureInputs({
   const widths: number[] = [];
   const marginTops: number[] = [];
   const pageHeights: number[] = [];
+  const pageWidths: number[] = [];
+  const marginLefts: number[] = [];
+  const marginRights: number[] = [];
   const marginBottoms: number[] = [];
 
   for (let i = 0; i < blocks.length; i++) {
@@ -79,6 +85,9 @@ export function computePerBlockMeasureInputs({
     widths.push(colWidth(contentWidth(config), columns, columnIndex));
     marginTops.push(config.margins.top);
     pageHeights.push(config.pageSize.h);
+    pageWidths.push(config.pageSize.w);
+    marginLefts.push(config.margins.left);
+    marginRights.push(config.margins.right);
     marginBottoms.push(config.margins.bottom);
 
     if (sectionIdx < breakIndices.length && i === breakIndices[sectionIdx]) {
@@ -91,5 +100,13 @@ export function computePerBlockMeasureInputs({
     }
   }
 
-  return { widths, marginTops, pageHeights, marginBottoms };
+  return {
+    widths,
+    marginTops,
+    pageHeights,
+    pageWidths,
+    marginLefts,
+    marginRights,
+    marginBottoms,
+  };
 }


### PR DESCRIPTION
## Summary

- project paragraph frame formatting into positioned layout containers
- keep related frame groups active as one pagination region, including empty anchor separators
- thread per-section page geometry into measurement and preserve adjacent frame borders

## Validation

- focused layout suites: 201 passed
- strict shared-font parity: 25.4% to 84.1%; page count corrected from 3 to 2
- independent positioned-object replay: unchanged at 91.2% with identical page and divergence metrics
- `bun audit`: no vulnerabilities found
- lint, typecheck, build, and full repository gates: delegated to CI

CC on behalf of @jan-kubica