### PR TITLE
fix: resume style-bridged list counters

### DIFF
--- a/.changeset/quiet-lists-align.md
+++ b/.changeset/quiet-lists-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep style-bridged numbering streams in sequence.

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -139,6 +139,7 @@ const computeListMarker = (
 
   const abstractNumId = numbering.getAbstractNumId(numId);
   const styleNumbering = paragraph.formatting?.numPrFromStyle;
+  let resumedAbstractCounters: number[] | undefined;
   if (abstractNumId !== null && styleNumbering) {
     const latestAbstractCounters = abstractCounters.get(abstractNumId);
     if (latestAbstractCounters) {
@@ -150,6 +151,7 @@ const computeListMarker = (
       for (let i = 0; i < counters.length; i += 1) {
         counters[i] = latestAbstractCounters[i] ?? Number.NaN;
       }
+      resumedAbstractCounters = latestAbstractCounters;
     }
   }
   if (abstractNumId !== null && level > 0) {
@@ -188,6 +190,20 @@ const computeListMarker = (
   }
 
   if (abstractNumId !== null) {
+    if (resumedAbstractCounters) {
+      for (const [otherNumId, otherCounters] of listCounters) {
+        if (
+          otherNumId === numId ||
+          numbering.getAbstractNumId(otherNumId) !== abstractNumId ||
+          !otherCounters.every((value, index) => Object.is(value, resumedAbstractCounters[index]))
+        ) {
+          continue;
+        }
+        for (let i = 0; i < otherCounters.length; i += 1) {
+          otherCounters[i] = counters[i] ?? Number.NaN;
+        }
+      }
+    }
     abstractCounters.set(abstractNumId, [...counters]);
   }
 

--- a/packages/core/src/docx/numbering-shared-abstract.test.ts
+++ b/packages/core/src/docx/numbering-shared-abstract.test.ts
@@ -176,3 +176,42 @@ test("style numbering resumes the latest compatible restarted instance", () => {
     ),
   ).toEqual(["(1)", "(1)", "(2)", "(3)"]);
 });
+
+test("a style-numbered bridge advances the concrete stream it resumes", () => {
+  const numbering = parseNumbering(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:abstractNum w:abstractNumId="4">
+        <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="upperRoman"/><w:lvlText w:val="%1."/></w:lvl>
+        <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2"/></w:lvl>
+      </w:abstractNum>
+      <w:num w:numId="1"><w:abstractNumId w:val="4"/></w:num>
+      <w:num w:numId="2"><w:abstractNumId w:val="4"/></w:num>
+    </w:numbering>`);
+  const styles = parseStyles(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:style w:type="paragraph" w:styleId="Clause">
+        <w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="2"/></w:numPr></w:pPr>
+      </w:style>
+    </w:styles>`);
+  const root = parseXmlDocument(
+    `<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Section one</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>First clause</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Section two</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Second section, first clause</w:t></w:r></w:p>
+      <w:p><w:pPr><w:pStyle w:val="Clause"/></w:pPr><w:r><w:t>Style bridge</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Concrete continuation</w:t></w:r></w:p>
+    </w:body>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse body XML");
+  }
+
+  const paragraphs = parseBlockContent(root, styles, null, numbering, null, null);
+
+  expect(
+    paragraphs.map((paragraph) =>
+      paragraph.type === "paragraph" ? paragraph.listRendering?.marker : undefined,
+    ),
+  ).toEqual(["I.", "I.1", "II.", "II.1", "II.2", "II.3"]);
+});


### PR DESCRIPTION
## Summary

- synchronize a concrete numbering stream when a style-attached item resumes it through a compatible abstract definition
- preserve independence for unrelated numbering instances
- add a synthetic regression for switching from direct numbering through a style bridge and back

## Validation

- 23 focused numbering and conversion tests pass
- strict same-font anonymous replay: 45.9% → 46.2%, removing 82 text mismatches; pagination remains the next independent gap
- focused four-page replay: 89.4%, matching page count
- unrelated strict replay: unchanged at 91.3%, matching page count
- dependency audit: no vulnerabilities

CI remains authoritative for lint, type checking, build, and the full test matrix.