### PR TITLE
fix: preserve native OOXML frame spacing and side wrapping

### DIFF
--- a/.changeset/calm-native-frames.md
+++ b/.changeset/calm-native-frames.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve OOXML paragraph-frame spacing, keep drop caps in normal flow, and retain side wrapping for single frames.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -664,8 +664,12 @@ export type ParagraphFormatting = {
     outlineLevel?: number; /** Paragraph style ID (w:pStyle) */
     styleId?: string; /** Text frame properties (w:framePr) */
     frame?: {
+        dropCap?: "none" | "drop" | "margin";
+        lines?: number;
         width?: number;
         height?: number;
+        hSpace?: number;
+        vSpace?: number;
         hAnchor?: "text" | "margin" | "page";
         vAnchor?: "text" | "margin" | "page";
         x?: number;

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -495,3 +495,31 @@ describe("parseParagraph smartTag wrapper", () => {
     expect(text).toContain(", STATE");
   });
 });
+
+describe("parseParagraph native frame geometry", () => {
+  test("captures frame size, offsets, anchors, and wrap spacing", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:framePr w:dropCap="none" w:lines="2" w:w="3600" w:h="1440" w:hSpace="144" w:vSpace="72"
+            w:hAnchor="page" w:vAnchor="text" w:x="720" w:y="144" w:wrap="around"/>
+        </w:pPr>
+        <w:r><w:t>Framed text</w:t></w:r>
+      </w:p>
+    `);
+
+    expect(paragraph.formatting?.frame).toEqual({
+      dropCap: "none",
+      lines: 2,
+      width: 3600,
+      height: 1440,
+      hSpace: 144,
+      vSpace: 72,
+      hAnchor: "page",
+      vAnchor: "text",
+      x: 720,
+      y: 144,
+      wrap: "around",
+    });
+  });
+});

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -291,6 +291,16 @@ function parseFrameProperties(
 
   const frame: ParagraphFormatting["frame"] = {};
 
+  const dropCap = getAttribute(framePr, "w", "dropCap");
+  if (dropCap === "none" || dropCap === "drop" || dropCap === "margin") {
+    frame.dropCap = dropCap;
+  }
+
+  const lines = parseNumericAttribute(framePr, "w", "lines");
+  if (lines !== undefined) {
+    frame.lines = lines;
+  }
+
   const w = parseNumericAttribute(framePr, "w", "w");
   if (w !== undefined) {
     frame.width = w;
@@ -299,6 +309,16 @@ function parseFrameProperties(
   const h = parseNumericAttribute(framePr, "w", "h");
   if (h !== undefined) {
     frame.height = h;
+  }
+
+  const hSpace = parseNumericAttribute(framePr, "w", "hSpace");
+  if (hSpace !== undefined) {
+    frame.hSpace = hSpace;
+  }
+
+  const vSpace = parseNumericAttribute(framePr, "w", "vSpace");
+  if (vSpace !== undefined) {
+    frame.vSpace = vSpace;
   }
 
   const hAnchor = getAttribute(framePr, "w", "hAnchor");

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -177,3 +177,33 @@ describe("serializeParagraph tracked-change hardening", () => {
     expect(xml).not.toContain("w:date=");
   });
 });
+
+describe("serializeParagraph native frame geometry", () => {
+  test("writes frame wrap spacing alongside its size and anchors", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: {
+        frame: {
+          dropCap: "none",
+          lines: 2,
+          width: 3600,
+          height: 1440,
+          hSpace: 144,
+          vSpace: 72,
+          hAnchor: "page",
+          vAnchor: "text",
+          x: 720,
+          y: 144,
+          wrap: "around",
+        },
+      },
+      content: [{ type: "run", content: [{ type: "text", text: "Framed text" }] }],
+    };
+
+    const xml = serializeParagraph(paragraph);
+
+    expect(xml).toContain(
+      '<w:framePr w:dropCap="none" w:lines="2" w:w="3600" w:h="1440" w:hSpace="144" w:vSpace="72" w:hAnchor="page" w:vAnchor="text" w:x="720" w:y="144" w:wrap="around"/>',
+    );
+  });
+});

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -304,12 +304,28 @@ function serializeFrameProperties(frame: ParagraphFormatting["frame"]): string {
 
   const attrs: string[] = [];
 
+  if (frame.dropCap) {
+    attrs.push(`w:dropCap="${frame.dropCap}"`);
+  }
+
+  if (frame.lines !== undefined) {
+    attrs.push(`w:lines="${intAttr(frame.lines)}"`);
+  }
+
   if (frame.width !== undefined) {
     attrs.push(`w:w="${intAttr(frame.width)}"`);
   }
 
   if (frame.height !== undefined) {
     attrs.push(`w:h="${intAttr(frame.height)}"`);
+  }
+
+  if (frame.hSpace !== undefined) {
+    attrs.push(`w:hSpace="${intAttr(frame.hSpace)}"`);
+  }
+
+  if (frame.vSpace !== undefined) {
+    attrs.push(`w:vSpace="${intAttr(frame.vSpace)}"`);
   }
 
   if (frame.hAnchor) {

--- a/packages/core/src/layout-bridge/convert/paragraphFrames.ts
+++ b/packages/core/src/layout-bridge/convert/paragraphFrames.ts
@@ -15,6 +15,8 @@ type BlockIdFactory = () => BlockId;
 const FRAME_PROPERTIES = [
   "width",
   "height",
+  "hSpace",
+  "vSpace",
   "hAnchor",
   "vAnchor",
   "x",
@@ -110,6 +112,10 @@ function toFrameTextBox(
     displayMode: "float",
     wrapType: frameWrapType(frame),
     wrapText: "bothSides",
+    distTop: frame.vSpace ?? 0,
+    distBottom: frame.vSpace ?? 0,
+    distLeft: frame.hSpace ?? 0,
+    distRight: frame.hSpace ?? 0,
     ...(first?.pmStart !== undefined ? { pmStart: first.pmStart } : {}),
     ...(last?.pmEnd !== undefined ? { pmEnd: last.pmEnd } : {}),
   };

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -37,6 +37,64 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.indent).toEqual({ left: 96, hanging: 24 });
   });
 
+  test("preserves native frame wrap spacing on the positioned container", () => {
+    const frame = {
+      width: 3600,
+      height: 1440,
+      hSpace: 144,
+      vSpace: 72,
+      hAnchor: "page" as const,
+      vAnchor: "text" as const,
+      x: 720,
+      y: 144,
+      wrap: "around" as const,
+    };
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", { _originalFormatting: { frame } }, [schema.text("First")]),
+        schema.node("paragraph", { _originalFormatting: { frame } }, [schema.text("Second")]),
+        schema.node("paragraph", null, [schema.text("Body")]),
+      ]),
+    );
+
+    expect(blocks.map((block) => block.kind)).toEqual(["textBox", "paragraph"]);
+    expect(blocks.at(0)).toMatchObject({
+      kind: "textBox",
+      width: 240,
+      height: 96,
+      displayMode: "float",
+      wrapType: "square",
+      position: {
+        horizontal: { relativeTo: "page", posOffset: 457200 },
+        vertical: { relativeTo: "paragraph", posOffset: 91440 },
+      },
+      content: [{ kind: "paragraph" }, { kind: "paragraph" }],
+    });
+    const textBox = blocks.at(0);
+    expect(textBox?.kind).toBe("textBox");
+    if (textBox?.kind !== "textBox") {
+      return;
+    }
+    expect(textBox.distTop).toBeCloseTo(4.8);
+    expect(textBox.distBottom).toBeCloseTo(4.8);
+    expect(textBox.distLeft).toBeCloseTo(9.6);
+    expect(textBox.distRight).toBeCloseTo(9.6);
+  });
+
+  test("keeps drop-cap frames in normal paragraph flow", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          { _originalFormatting: { frame: { dropCap: "drop", lines: 3 } } },
+          [schema.text("Opening paragraph")],
+        ),
+      ]),
+    );
+
+    expect(blocks.map((block) => block.kind)).toEqual(["paragraph"]);
+  });
+
   test("does not paint an empty structural section-break paragraph", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { sectionBreakType: "continuous" }),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1867,10 +1867,12 @@ function convertParagraph(
     pmEnd: startPos + node.nodeSize,
   };
   const frame = pmAttrs._originalFormatting?.frame;
-  if (frame !== undefined) {
+  if (frame !== undefined && frame.dropCap !== "drop" && frame.dropCap !== "margin") {
     setParagraphFrame(block, {
       ...(frame.width !== undefined ? { width: twipsToPixels(frame.width) } : {}),
       ...(frame.height !== undefined ? { height: twipsToPixels(frame.height) } : {}),
+      ...(frame.hSpace !== undefined ? { hSpace: twipsToPixels(frame.hSpace) } : {}),
+      ...(frame.vSpace !== undefined ? { vSpace: twipsToPixels(frame.vSpace) } : {}),
       ...(frame.hAnchor !== undefined ? { hAnchor: frame.hAnchor } : {}),
       ...(frame.vAnchor !== undefined ? { vAnchor: frame.vAnchor } : {}),
       ...(frame.x !== undefined ? { x: twipsToPixels(frame.x) } : {}),

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -185,6 +185,41 @@ describe("measureBlocks", () => {
     }, fakeMeasure);
   });
 
+  test("wraps beside a single paragraph frame", () => {
+    withFakeTextMeasure(() => {
+      const frame: TextBoxBlock = {
+        kind: "textBox",
+        id: "single-frame",
+        width: 300,
+        height: 100,
+        content: [],
+        displayMode: "float",
+        wrapType: "square",
+        wrapText: "bothSides",
+        position: {
+          horizontal: { relativeTo: "page", posOffset: pixelsToEmu(96) },
+          vertical: { relativeTo: "page", posOffset: pixelsToEmu(136) },
+        },
+      };
+      markParagraphFrameTextBox(frame);
+      setTextBoxGroupId(frame, "single-frame-set");
+
+      const measures = measureBlocks([frame, para("body", "body")], 600, 96, {
+        pageWidth: 792,
+        pageHeight: 1_056,
+        marginLeft: 96,
+        marginRight: 96,
+        marginBottom: 96,
+      });
+      const bodyMeasure = measures.at(1);
+      if (bodyMeasure?.kind !== "paragraph") {
+        throw new Error("Expected body paragraph measure");
+      }
+
+      expect(bodyMeasure.lines.at(0)?.floatSkipBefore).toBeUndefined();
+    }, fakeMeasure);
+  });
+
   test("keeps an active band across an unspecified continuous section break", () => {
     withFakeTextMeasure(() => {
       const band: TextBoxBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -504,6 +504,16 @@ function extractFloatingZones(
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
   const textBoxGroupAnchors = new Map<string, number>();
+  const paragraphFrameGroupSizes = new Map<string, number>();
+  for (const block of blocks) {
+    if (block.kind !== "textBox" || !isParagraphFrameTextBox(block)) {
+      continue;
+    }
+    const groupId = getTextBoxGroupId(block);
+    if (groupId !== undefined) {
+      paragraphFrameGroupSizes.set(groupId, (paragraphFrameGroupSizes.get(groupId) ?? 0) + 1);
+    }
+  }
   const defaultMarginTop = Array.isArray(marginTop) ? (marginTop[0] ?? 0) : marginTop;
   const pageWidthInput = pageGeometry?.pageWidth ?? contentWidth;
   const pageHeightInput = pageGeometry?.pageHeight ?? 0;
@@ -705,7 +715,11 @@ function extractFloatingZones(
     if (groupId && !textBoxGroupAnchors.has(groupId)) {
       textBoxGroupAnchors.set(groupId, blockIndex);
     }
-    if (isParagraphFrameTextBox(tb)) {
+    if (
+      isParagraphFrameTextBox(tb) &&
+      groupId !== undefined &&
+      (paragraphFrameGroupSizes.get(groupId) ?? 0) > 1
+    ) {
       zones.push({
         leftMargin: 0,
         rightMargin: 0,

--- a/packages/core/src/layout-engine/paragraphFrame.ts
+++ b/packages/core/src/layout-engine/paragraphFrame.ts
@@ -3,6 +3,8 @@ import type { ParagraphBlock, TextBoxBlock } from "./types";
 export type ParagraphFrame = {
   width?: number;
   height?: number;
+  hSpace?: number;
+  vSpace?: number;
   hAnchor?: "text" | "margin" | "page";
   vAnchor?: "text" | "margin" | "page";
   x?: number;

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -323,8 +323,12 @@ export type ParagraphFormatting = {
   // Frame properties
   /** Text frame properties (w:framePr) */
   frame?: {
+    dropCap?: "none" | "drop" | "margin";
+    lines?: number;
     width?: number;
     height?: number;
+    hSpace?: number;
+    vSpace?: number;
     hAnchor?: "text" | "margin" | "page";
     vAnchor?: "text" | "margin" | "page";
     x?: number;


### PR DESCRIPTION
## Summary

- preserve OOXML paragraph-frame drop-cap, line-count, and wrap-spacing attributes through parse and save paths
- carry authored horizontal and vertical spacing into positioned frame containers
- retain side wrapping for a single frame while preserving full-width behavior for multi-frame sets

## Verification

- 174 focused parser, serializer, conversion, measurement, and text-box layout tests
- affected package builds and generated API reports
- strict same-font reference-layout replay: selected case improved from 56.7% to 80.0%; unrelated case remained unchanged at 89.5%
- dependency audit: no vulnerabilities found
- lint and typechecking delegated to CI

CC on behalf of @jan-kubica