### PR TITLE
fix: drop disabled list positioning

### DIFF
--- a/.changeset/calm-cells-flow.md
+++ b/.changeset/calm-cells-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Drop inherited list positioning when direct formatting disables numbering.

--- a/packages/core/src/docx/serializer/styleNumPrRoundtrip.test.ts
+++ b/packages/core/src/docx/serializer/styleNumPrRoundtrip.test.ts
@@ -51,8 +51,8 @@ describe("serializeParagraphFormatting auto-spacing overrides (#823)", () => {
 });
 
 // toProseDoc load-side: a paragraph that removes the style's numbering
-// (direct numId=0 under a numbered style) drops the style's hanging slot too
-// and keeps only the indent it states itself.
+// (direct numId=0 under a numbered style) drops the style's marker-positioning
+// indents and keeps only the indent it states itself.
 const STYLE_DEFS = {
   styles: [
     {
@@ -95,6 +95,16 @@ describe("style vs direct w:ind merge in toProseDoc (#765)", () => {
       indentLeft: 357,
     });
     expect(attrs["indentLeft"]).toBe(357);
+    expect(attrs["indentFirstLine"] ?? null).toBeNull();
+    expect(attrs["hangingIndent"] ?? false).toBe(false);
+  });
+
+  test("removing style numbering does not retain a style-only left indent", () => {
+    const attrs = pmAttrsFor({
+      styleId: "Numbered",
+      numPr: { numId: 0, ilvl: 0 },
+    });
+    expect(attrs["indentLeft"] ?? null).toBeNull();
     expect(attrs["indentFirstLine"] ?? null).toBeNull();
     expect(attrs["hangingIndent"] ?? false).toBe(false);
   });

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -590,20 +590,20 @@ function paragraphFormattingToAttrs(
     if (spacingFromDocDefaults.before || spacingFromDocDefaults.after) {
       attrs.spacingFromDocDefaults = spacingFromDocDefaults;
     }
-    set("indentLeft", formatting?.indentLeft ?? stylePpr?.indentLeft);
-    set("indentRight", formatting?.indentRight ?? stylePpr?.indentRight);
     // When the paragraph explicitly removes the style's numbering (direct
-    // numId=0 under a numbered style), Word also drops the style's
-    // marker-positioning firstLine/hanging — the paragraph keeps only the
-    // indents it states itself (#765: a direct left=357 renders indented
-    // instead of hanging the first line back to the margin). Outside that
-    // case w:ind merges per attribute: a direct left-only indent keeps the
-    // style's firstLine (Word's own Increase Indent emits exactly that).
+    // numId=0 under a numbered style), the reference layout also drops the
+    // style's marker-positioning indents. The paragraph keeps only the indents
+    // it states itself (#765: a direct left=357 renders indented instead of
+    // hanging the first line back to the margin). Outside that case w:ind
+    // merges per attribute: a direct left-only indent keeps the style's
+    // firstLine.
     const numberingRemoved =
       formatting?.numPr?.numId === 0 && stylePpr?.numPr !== undefined && stylePpr.numPr.numId !== 0;
-    const styleFirstLine = numberingRemoved ? undefined : stylePpr;
-    set("indentFirstLine", formatting?.indentFirstLine ?? styleFirstLine?.indentFirstLine);
-    set("hangingIndent", formatting?.hangingIndent ?? styleFirstLine?.hangingIndent);
+    const numberingStyleIndent = numberingRemoved ? undefined : stylePpr;
+    set("indentLeft", formatting?.indentLeft ?? numberingStyleIndent?.indentLeft);
+    set("indentRight", formatting?.indentRight ?? stylePpr?.indentRight);
+    set("indentFirstLine", formatting?.indentFirstLine ?? numberingStyleIndent?.indentFirstLine);
+    set("hangingIndent", formatting?.hangingIndent ?? numberingStyleIndent?.hangingIndent);
     set("borders", formatting?.borders ?? stylePpr?.borders);
     set("shading", formatting?.shading ?? stylePpr?.shading);
     set("tabs", formatting?.tabs ?? stylePpr?.tabs);


### PR DESCRIPTION
## Summary

- drop an inherited left marker indent when direct paragraph formatting disables style numbering
- preserve explicitly authored paragraph indentation and unrelated right indentation
- add a synthetic regression for a style-only left indent under disabled numbering

## Validation

- 35 focused conversion and serialization tests pass
- strict same-font anonymous replay: 46.1% → 75.6%
- pagination: 23/24 → 23/23 pages
- focused 13-page replay: 71.5% → 76.1%
- unrelated strict replay: unchanged at 91.3%, matching page count
- dependency audit: no vulnerabilities

CI remains authoritative for lint, type checking, build, and the full test matrix.