### PR TITLE
fix: honor blank even-page furniture

### DIFF
--- a/.changeset/even-page-furniture.md
+++ b/.changeset/even-page-furniture.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor blank even-page header and footer slots when separate odd/even page furniture is enabled.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -405,7 +405,8 @@ export type LayoutOptions = {
         h: number;
     }; /** Initial page margins. */
     margins: PageMargins;
-    firstPageMargins?: PageMargins; /** Body-level final section page size. */
+    firstPageMargins?: PageMargins; /** Per-section body margins used on even section pages. */
+    sectionEvenPageMargins?: (PageMargins | undefined)[]; /** Body-level final section page size. */
     finalPageSize?: {
         w: number;
         h: number;
@@ -543,7 +544,8 @@ export type PaginatorOptions = {
     }; /** Page margins. */
     margins: PageMargins; /** Swap left/right margins on even physical pages. */
     mirrorMargins?: boolean;
-    firstPageMargins?: PageMargins; /** Column configuration (optional). */
+    firstPageMargins?: PageMargins; /** Per-section body margins used on even section pages. */
+    sectionEvenPageMargins?: (PageMargins | undefined)[]; /** Column configuration (optional). */
     columns?: ColumnLayout; /** Per-page footnote reserved heights (pageNumber → height in pixels). */
     footnoteReservedHeights?: Map<number, number>; /** Header/footer refs by section index. */
     sectionHeaderFooterRefs?: PageHeaderFooterRefs[]; /** Callback when a new page is created. */

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -298,6 +298,15 @@ const makeState = (): EditorState =>
     ]),
   });
 
+const makeTwoPageState = (): EditorState =>
+  EditorState.create({
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Odd page")]),
+      schema.node("pageBreak"),
+      schema.node("paragraph", null, [schema.text("Even page")]),
+    ]),
+  });
+
 const makeSectionedState = (): EditorState =>
   EditorState.create({
     doc: schema.node("doc", null, [
@@ -653,6 +662,37 @@ describe("runLayoutPipeline", () => {
 
     expect(outcome.layout?.pages.at(0)?.margins.top).toBe(MARGINS.top);
     expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(MARGINS.top);
+  });
+
+  test("uses authored margins for a blank even-page header and footer", () => {
+    const content = { type: "header", hdrFtrType: "default", content: [] } as const;
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        headerContent: content,
+        footerContent: { ...content, type: "footer" },
+        sectionHeaderFooterRefs: [
+          {
+            evenAndOddHeaders: true,
+            headerDefault: "odd-header",
+            footerDefault: "odd-footer",
+          },
+        ],
+        renderHfFromContentOrPm: (hf) => (hf ? makePreparedHeaderFooter(120) : undefined),
+        renderHeaderFooterContentByRId: (_source, _hfPMs, _width, metrics) =>
+          new Map([
+            [
+              metrics.section === "header" ? "odd-header" : "odd-footer",
+              makePreparedHeaderFooter(120),
+            ],
+          ]),
+      }),
+      makeTwoPageState(),
+    );
+
+    expect(outcome.layout?.pages).toHaveLength(2);
+    expect(outcome.layout?.pages[0]?.margins.top).toBe(MARGINS.header + 120);
+    expect(outcome.layout?.pages[0]?.margins.bottom).toBe(MARGINS.footer + 120);
+    expect(outcome.layout?.pages[1]?.margins).toEqual(MARGINS);
   });
 
   test("moves a section body between its referenced default header and footer", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -439,6 +439,21 @@ export function runLayoutPipeline<THfPMs>(
       hfMetricsFooter,
       hfOptions,
     );
+    const sectionPropertiesForMargins =
+      document?.package.document.sections?.map((section) => section.properties) ??
+      (sectionProperties ? [sectionProperties] : []);
+    const sectionEvenPageMargins = sectionHeaderFooterRefs?.map((refs, index) => {
+      if (refs.evenAndOddHeaders !== true) {
+        return undefined;
+      }
+      const properties = sectionPropertiesForMargins[index];
+      const authoredMargins = properties ? getMargins(properties) : margins;
+      return bodyMarginsClearHeaderFooter({
+        authoredMargins,
+        preparedHeader: refs.headerEven ? headerContentByRId?.get(refs.headerEven) : undefined,
+        preparedFooter: refs.footerEven ? footerContentByRId?.get(refs.footerEven) : undefined,
+      });
+    });
 
     newBlocks = bodyBlocksClearSectionHeaderFooter(newBlocks, {
       authoredMargins: margins,
@@ -575,6 +590,9 @@ export function runLayoutPipeline<THfPMs>(
       }
       if (sectionHeaderFooterRefs !== undefined) {
         nextLayoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
+      }
+      if (sectionEvenPageMargins !== undefined) {
+        nextLayoutOpts.sectionEvenPageMargins = sectionEvenPageMargins;
       }
       return nextLayoutOpts;
     };

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -422,6 +422,9 @@ export function layoutDocument(
     ...(options.firstPageMargins !== undefined
       ? { firstPageMargins: options.firstPageMargins }
       : {}),
+    ...(options.sectionEvenPageMargins !== undefined
+      ? { sectionEvenPageMargins: options.sectionEvenPageMargins }
+      : {}),
     columns: initialConfig.columns ?? DEFAULT_COLUMNS,
     ...(options.footnoteReservedHeights !== undefined
       ? { footnoteReservedHeights: options.footnoteReservedHeights }

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -24,6 +24,21 @@ describe("paginator mirrored margins", () => {
   });
 });
 
+describe("paginator even-page margins", () => {
+  test("uses the section-specific clearance on even section pages", () => {
+    const evenMargins = { ...MARGINS, top: 30, bottom: 35 };
+    const paginator = createPaginator({
+      pageSize: SIZE,
+      margins: MARGINS,
+      sectionEvenPageMargins: [evenMargins],
+    });
+
+    expect(paginator.getCurrentState().page.margins).toEqual(MARGINS);
+    expect(paginator.forcePageBreak().page.margins).toEqual(evenMargins);
+    expect(paginator.forcePageBreak().page.margins).toEqual(MARGINS);
+  });
+});
+
 describe("paginator forcePageBreak", () => {
   test("two consecutive forcePageBreak calls preserve an explicit blank page", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -62,6 +62,8 @@ export type PaginatorOptions = {
    * first-page header) vs. its body pages. Pages 2+ use `margins`.
    */
   firstPageMargins?: PageMargins;
+  /** Per-section body margins used on even section pages. */
+  sectionEvenPageMargins?: (PageMargins | undefined)[];
   /** Column configuration (optional). */
   columns?: ColumnLayout;
   /** Per-page footnote reserved heights (pageNumber → height in pixels). */
@@ -149,7 +151,10 @@ export function createPaginator(options: PaginatorOptions) {
     }
     return (
       arePageSizesEqual(state.page.size, pageSize) &&
-      areMarginsEqual(state.page.margins, getPageMargins(state.page.number))
+      areMarginsEqual(
+        state.page.margins,
+        getPageMargins(state.page.number, state.page.sectionPageNumber ?? currentSectionPageNumber),
+      )
     );
   }
 
@@ -178,11 +183,15 @@ export function createPaginator(options: PaginatorOptions) {
     recalculateColumnWidths();
   }
 
-  function getPageMargins(pageNumber: number): PageMargins {
+  function getPageMargins(pageNumber: number, sectionPageNumber: number): PageMargins {
+    const evenMargins =
+      sectionPageNumber % 2 === 0
+        ? options.sectionEvenPageMargins?.[currentSectionIndex]
+        : undefined;
     const pageMargins =
       pageNumber === 1 && options.firstPageMargins
         ? { ...options.firstPageMargins }
-        : { ...margins };
+        : { ...(evenMargins ?? margins) };
     if (options.mirrorMargins === true && pageNumber % 2 === 0) {
       return { ...pageMargins, left: pageMargins.right, right: pageMargins.left };
     }
@@ -200,7 +209,7 @@ export function createPaginator(options: PaginatorOptions) {
    * Get X position for a given column index.
    */
   function getColumnX(columnIndex: number): number {
-    const activeLeftMargin = states.at(-1)?.page.margins.left ?? getPageMargins(1).left;
+    const activeLeftMargin = states.at(-1)?.page.margins.left ?? getPageMargins(1, 1).left;
     let x = activeLeftMargin;
     for (let index = 0; index < columnIndex; index++) {
       x += (columnWidths[index] ?? columnWidths[0] ?? 0) + gapAfterColumn(columns, index);
@@ -224,7 +233,7 @@ export function createPaginator(options: PaginatorOptions) {
     // every page in the section would inherit page 1's title-page top
     // margin, leaving large empty space at the top of pages 2+ on
     // first-page-header docs (NVCA-style templates).
-    const pageMargins = getPageMargins(pageNumber);
+    const pageMargins = getPageMargins(pageNumber, currentSectionPageNumber);
     const topMargin = pageMargins.top;
     const contentBottom = pageSize.h - pageMargins.bottom;
 
@@ -462,7 +471,7 @@ export function createPaginator(options: PaginatorOptions) {
       applyPendingLayout();
     }
 
-    const pageMargins = getPageMargins(current.page.number);
+    const pageMargins = getPageMargins(current.page.number, 1);
     const topMargin = pageMargins.top;
     const rawContentBottom = pageSize.h - pageMargins.bottom;
     const footnoteHeight = options.footnoteReservedHeights?.get(current.page.number) ?? 0;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1151,6 +1151,8 @@ export type LayoutOptions = {
    * same extension.
    */
   firstPageMargins?: PageMargins;
+  /** Per-section body margins used on even section pages. */
+  sectionEvenPageMargins?: (PageMargins | undefined)[];
   /** Body-level final section page size. */
   finalPageSize?: { w: number; h: number };
   /** Body-level final section margins. */

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -626,6 +626,34 @@ describe("header and footer rendering", () => {
     });
   });
 
+  test("leaves enabled even-page slots blank when no even part exists", () => {
+    const pageOptions = {
+      headerContent: headerFooterTextContent("Odd header"),
+      footerContent: headerFooterTextContent("Odd footer"),
+    };
+    const applied = applySectionHeaderFooterOptions(
+      {
+        ...page,
+        number: 2,
+        sectionPageNumber: 2,
+        headerFooterRefs: {
+          evenAndOddHeaders: true,
+          headerDefault: "default-header",
+          footerDefault: "default-footer",
+        },
+        fragments: [],
+      },
+      pageOptions,
+      {
+        headerContentByRId: new Map([["default-header", headerFooterTextContent("Odd header")]]),
+        footerContentByRId: new Map([["default-footer", headerFooterTextContent("Odd footer")]]),
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(pageOptions).toEqual({});
+  });
+
   test("keeps top-and-bottom text boxes in header flow", () => {
     const textBoxBlock: TextBoxBlock = {
       kind: "textBox",

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -2355,7 +2355,7 @@ export function applySectionHeaderFooterOptions(
     if (useFirst) {
       return refs.headerFirst;
     }
-    if (useEven && refs.headerEven) {
+    if (useEven) {
       return refs.headerEven;
     }
     return refs.headerDefault;
@@ -2364,7 +2364,7 @@ export function applySectionHeaderFooterOptions(
     if (useFirst) {
       return refs.footerFirst;
     }
-    if (useEven && refs.footerEven) {
+    if (useEven) {
       return refs.footerEven;
     }
     return refs.footerDefault;


### PR DESCRIPTION
## Summary

- leave enabled even-page header and footer slots blank when no even part is authored
- paginate each section page with clearance from the page-furniture variant it renders
- preserve first-page and mirrored-margin behavior

## Fidelity

- anonymous strict same-font case: 88.5% to 91.0%
- page count: 2/3 to 2/2
- removed one page-count, eight duplicate page-furniture, and two pagination divergences
- independent anonymous cross-case: 70.8% unchanged, 1/1 page

## Validation

- 47 focused tests passed
- core build and public API snapshot check passed
- dependency audit found no vulnerabilities

CC on behalf of @jan-kubica