### PR TITLE
fix: preserve paragraph style boolean inheritance

### DIFF
--- a/.changeset/steady-style-toggles.md
+++ b/.changeset/steady-style-toggles.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve paragraph-style boolean formatting when paragraph-mark properties differ.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -198,6 +198,45 @@ describe("toFlowBlocks style cascade", () => {
     expect(run.allCaps).toBe(false);
   });
 
+  test("paragraph-mark booleans do not replace inherited paragraph-style booleans", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "EmphasizedClause",
+          type: "paragraph",
+          name: "Emphasized Clause",
+          rPr: { bold: true },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: {
+        styleId: "EmphasizedClause",
+        runProperties: { bold: false },
+      },
+      content: [
+        {
+          type: "run",
+          formatting: { bold: false },
+          content: [{ type: "text", text: "Plain lead" }],
+        },
+        {
+          type: "run",
+          formatting: { fontSize: 22 },
+          content: [{ type: "text", text: "Styled remainder" }],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {});
+    const runs = firstParagraph(blocks).runs.filter((run) => run.kind === "text");
+
+    expect(runs).toHaveLength(2);
+    expect(runs[0]?.bold).toBe(false);
+    expect(runs[1]?.bold).toBe(true);
+  });
+
   test("default character style reaches runs without rStyle", () => {
     const styles: StyleDefinitions = {
       docDefaults: { rPr: { fontSize: 22 } },

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -915,18 +915,18 @@ function suppressParagraphMarkFormatting(
     (paragraphMarkPrecedesStyle
       ? mergeTextFormatting(paragraphMark, base)
       : mergeTextFormatting(base, paragraphMark)) ?? {};
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "bold");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "italic");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "strike");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "doubleStrike");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "allCaps");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "smallCaps");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "hidden");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "emboss");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "imprint");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "shadow");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "outline");
-  suppressBooleanParagraphMark(result, paragraphMark, direct, "rtl");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "bold");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "italic");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "strike");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "doubleStrike");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "allCaps");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "smallCaps");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "hidden");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "emboss");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "imprint");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "shadow");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "outline");
+  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "rtl");
 
   // A direct run suppresses a size stored only on the paragraph mark. Restore
   // the resolved paragraph-style size instead of letting the pilcrow size leak
@@ -962,6 +962,7 @@ function suppressParagraphMarkFormatting(
 
 function suppressBooleanParagraphMark(
   result: TextFormatting,
+  base: TextFormatting | undefined,
   paragraphMark: TextFormatting,
   direct: TextFormatting | undefined,
   key: keyof Pick<
@@ -983,7 +984,7 @@ function suppressBooleanParagraphMark(
   if (paragraphMark[key] === undefined || direct?.[key] !== undefined) {
     return;
   }
-  result[key] = false;
+  result[key] = base?.[key] ?? false;
 }
 
 function resolveTextFormatting(


### PR DESCRIPTION
## Summary

- restore resolved paragraph-style boolean values when paragraph-mark properties differ
- retain explicit run-level overrides and paragraph-mark leakage protection
- cover the cascade boundary with a synthetic layout regression

## Verification

- focused conversion and layout suites: 45 passing
- strict shared-font reference-layout replay: 91.7%, unchanged 3-page pagination; targeted width discrepancy improved by about 7.3 pt
- stabilized cross-case replay: exact metric match at 91.2%
- dependency audit: no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica