### PR TITLE
feat: add multi-renderer interoperability references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Browser editor and framework-neutral engine for Word <code>.docx</code> files.</strong>
+  <strong>Browser editor and framework-neutral engine for OOXML <code>.docx</code> documents.</strong>
 </p>
 
 <p align="center">
@@ -23,7 +23,7 @@
 # folio
 
 Browser editor and framework-neutral engine for `.docx` files. It opens, edits,
-and writes Word documents while preserving pagination, tables, headers and
+and writes OOXML documents while preserving pagination, tables, headers and
 footers, tracked changes, and footnotes.
 
 The core package is framework-neutral. React, Vue, Nuxt, and document-review
@@ -34,6 +34,18 @@ Part of [stella](https://github.com/stella/stella), an open-source legal workspa
 See [DOCX platform boundary](./docs/docx-platform.md) for what belongs in folio
 and how editors, headless tools, agents, and hosts share one document model and
 operation contract.
+
+## Standards-first interoperability
+
+Folio targets interoperable OOXML behavior through published standards,
+differential parsing, round-trip and interaction tests, and reproducible layout
+comparisons across independent implementations.
+
+Comparison reports record the reference implementation, version, and relevant
+rendering environment so results remain explicit and reproducible.
+
+See [Interoperability references](./docs/interoperability.md) for the complete
+testing methodology and reference matrix.
 
 ## Packages
 

--- a/docs/docx-platform.md
+++ b/docs/docx-platform.md
@@ -106,8 +106,10 @@ through these capability levels:
 Compatibility claims should identify the evidence behind them:
 
 - the applicable ECMA-376 or ISO/IEC 29500 rule;
-- Microsoft extension documentation where Word adds behavior;
-- observed behavior from a reproducible Word interoperability fixture.
+- published implementation notes where a producer adds behavior;
+- structural agreement with independent OOXML parsers;
+- observed behavior from reproducible, versioned LibreOffice, Word, or other
+  renderer interoperability fixtures.
 
 Tests and public APIs should also name the intended profile: OOXML
 Transitional, OOXML Strict, or Word-compatible behavior. International text,

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -51,6 +51,8 @@ release and re-check its licence before adding it to CI or a hosted service.
   opt-in and identified by name and version in every report.
 - Comparisons use synthetic, public, or explicitly authorized fixtures. Do not
   upload customer or legal documents to third-party services.
+- Treat documents as untrusted parser input. Keep reference applications
+  patched, and use a disposable environment for corpora from unknown sources.
 - Record renderer version, conversion path, fonts, and document hash. A result
   without provenance is not reproducible evidence.
 - Treat font substitutions and platform-specific metrics as environment data,

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -1,0 +1,65 @@
+# Interoperability references
+
+Folio is standards-first and implementation-tested. OOXML specifications and
+published implementation notes define the intended document semantics;
+independent libraries and renderers expose interoperability gaps that a single
+implementation cannot.
+
+No external application is a conformance oracle. Matching a renderer proves
+agreement with that version, font environment, and export path. It does not
+prove that either implementation satisfies every applicable OOXML requirement.
+
+## Evidence layers
+
+| Layer                         | References                                                                                                                                     | What it tells us                                                        |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Normative format              | [ECMA-376](https://ecma-international.org/publications-and-standards/standards/ecma-376/), ISO/IEC 29500                                       | Package, schema, and document-semantics requirements                    |
+| Published extensions          | [Microsoft implementation notes](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/bd9e8289-844a-42e2-9809-66c7005bd9e2) | Documented producer-specific behavior and deviations                    |
+| Structural differential tests | [python-docx](https://github.com/python-openxml/python-docx), [Open XML SDK](https://github.com/dotnet/Open-XML-SDK)                           | Whether independent parsers project the same document structure         |
+| Rendering comparisons         | [LibreOffice](https://www.libreoffice.org/), optionally Microsoft Word                                                                         | Pagination, line breaking, geometry, and font-environment differences   |
+| Round-trip and behavior tests | Folio's unit, property, differential, and Playwright suites                                                                                    | Whether editing preserves document invariants and user-visible behavior |
+
+## Projects evaluated
+
+The licensing notes below concern the narrow testing architecture described
+here: Folio invokes a separately installed executable or service and consumes
+its output. Copying source, linking a library into a distributed package,
+modifying an external project, or redistributing its binaries requires a
+separate compliance review.
+
+| Project                                                                   | Licence                                                              | Technically useful for                                                        | Decision                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [LibreOffice](https://www.libreoffice.org/licenses/)                      | MPL-2.0, with components under other compatible open-source licences | Independent DOCX-to-PDF layout rendering                                      | **Integrated and default.** Invoke the user-installed `soffice` executable; do not bundle it with Folio. LibreOffice explicitly permits business use.                                                                   |
+| [ONLYOFFICE Docs Community](https://github.com/ONLYOFFICE/DocumentServer) | AGPL-3.0                                                             | Independent DOCX-to-PDF conversion through its self-hosted Conversion Service | **Usable with deployment constraints; adapter pending.** Keep it an external, pinned service. Do not bundle or modify it without satisfying AGPL source, licence, and network-use obligations for the deployed version. |
+| Microsoft Word                                                            | Proprietary, agreement-specific                                      | Widely deployed DOCX behavior and implementation-specific compatibility       | **Optional adapter.** Never describe it as ground truth. The operator must confirm that automated compatibility use is allowed by the licence covering the installed copy.                                              |
+| [Apache OpenOffice](https://www.openoffice.org/license.html)              | Apache-2.0                                                           | Headless DOCX-to-PDF rendering                                                | **Permitted but lower priority.** Its shared ancestry with LibreOffice provides less independent evidence than ONLYOFFICE.                                                                                              |
+| [python-docx](https://github.com/python-openxml/python-docx)              | MIT                                                                  | Structural parsing and round-trip projections                                 | **Integrated in differential CI.** It does not paginate or provide a layout oracle.                                                                                                                                     |
+| [Open XML SDK](https://github.com/dotnet/Open-XML-SDK)                    | MIT                                                                  | Structural parsing, package/schema validation, and projections                | **Integrated in differential CI.** It does not render pages.                                                                                                                                                            |
+| [docx4j](https://github.com/plutext/docx4j)                               | Apache-2.0                                                           | Structural checks, transformations, and optional PDF export                   | **Permitted, not currently needed.** Its Java/PDF pipeline could provide another projection, but it should not be presented as a full-fidelity office renderer.                                                         |
+| [Apache POI XWPF](https://poi.apache.org/components/document/index.html)  | Apache-2.0                                                           | Text extraction and partial DOCX structure checks                             | **Permitted, weak fit for layout.** Apache describes XWPF as moderately functional and support varies by feature.                                                                                                       |
+| [Mammoth](https://github.com/mwilliamson/mammoth.js)                      | BSD-2-Clause                                                         | Semantic DOCX-to-HTML conversion                                              | **Permitted, unsuitable for layout parity.** Mammoth intentionally ignores many visual details.                                                                                                                         |
+| [Pandoc](https://pandoc.org/)                                             | GPL-2.0-or-later                                                     | Semantic format conversion through an external executable                     | **Permitted as a separate tool, unsuitable for layout parity.** PDF output depends on another typesetting backend rather than a DOCX page-layout engine.                                                                |
+
+Using an unmodified copyleft executable as a separate local process does not by
+itself make Folio a derivative of that executable. Distribution, linking,
+modification, or network deployment can change the obligations; pin the exact
+release and re-check its licence before adding it to CI or a hosted service.
+
+## Harness rules
+
+- LibreOffice is the default rendering reference. Proprietary references are
+  opt-in and identified by name and version in every report.
+- Comparisons use synthetic, public, or explicitly authorized fixtures. Do not
+  upload customer or legal documents to third-party services.
+- Record renderer version, conversion path, fonts, and document hash. A result
+  without provenance is not reproducible evidence.
+- Treat font substitutions and platform-specific metrics as environment data,
+  not automatically as Folio defects.
+- Resolve disagreements from specifications and documented extensions first.
+  Multi-renderer agreement is supporting evidence, not a vote that changes the
+  standard.
+- Use project names factually for interoperability identification; do not use
+  logos or imply endorsement.
+
+The local rendering harness and its report format are documented in
+[`parity/README.md`](../parity/README.md).

--- a/parity/README.md
+++ b/parity/README.md
@@ -1,23 +1,42 @@
-# Word rendering parity engine
+# DOCX rendering interoperability harness
 
-Answers one question for any `.docx`: does folio lay it out the way real
-Microsoft Word does, and if not, where and why?
+Answers one question for any `.docx`: how does folio's layout compare with an
+independent DOCX renderer, and where do the implementations diverge?
 
-Like `benchmarks/cross-language/`, this is an on-demand local tool, not a CI
-gate: the ground truth requires Microsoft Word for Mac (driven via
-AppleScript) plus `mutool` (`brew install mupdf-tools`). The tool skips with a
-clear message when either is missing.
+No renderer is labelled “ground truth.” The default reference is open-source
+[LibreOffice Writer](https://www.libreoffice.org/). Microsoft Word is an
+explicit, optional reference. Agreement with either implementation is useful
+interoperability evidence, but it does not by itself prove OOXML conformance.
+
+This is an on-demand local tool, not a CI gate. It uses `mutool`
+(`brew install mupdf-tools`) to normalize each exported PDF into the same line
+geometry.
 
 ## Usage
 
 ```sh
-bun parity/cli.ts                          # full default corpus, HTML report
-bun parity/cli.ts path/to/file.docx        # one document
-bun parity/cli.ts some/dir --json          # machine-readable output
-bun parity/cli.ts --refresh-truth          # ignore cached Word exports
+# LibreOffice is the default reference renderer
+bun parity/cli.ts
+bun parity/cli.ts path/to/file.docx --reference libreoffice
+
+# Word is available only when selected explicitly
+bun parity/cli.ts path/to/file.docx --reference word
+
+bun parity/cli.ts some/dir --json
+bun parity/cli.ts --refresh-reference
 ```
 
-The HTML report lands in `parity/report/index.html`.
+Requirements:
+
+- `libreoffice`: a local LibreOffice installation plus `mutool`; the adapter
+  runs Writer headlessly with an isolated temporary profile.
+- `word`: Microsoft Word for Mac plus `mutool`; the adapter drives a locally
+  installed copy through AppleScript. Check the licence terms covering that
+  installation before using automated outputs for compatibility development.
+
+The HTML report lands in `parity/report/index.html` and identifies the selected
+renderer and its version. Reports describe the renderer as a **reference**, not
+as a specification oracle.
 
 For repeated runs in one worktree, start a current-source playground once and
 explicitly reuse it:
@@ -33,37 +52,47 @@ where the caller owns the server and knows it reflects the current worktree.
 
 ## How it works
 
-1. **Ground truth** (`wordTruth.ts`): the docx is exported to PDF by scripting
-   the locally installed Word, then `mutool draw -F stext` extracts per-line
-   text + geometry (points, page-relative). Artifacts are cached in
-   `parity/.cache/<sha256>/` so re-runs never reopen Word.
-2. **Folio extraction** (`folioExtract.ts`): the same docx is loaded in the
-   playground (Playwright + the existing `?file=` fixture route) and the
-   painted DOM (`.layout-page` / `.layout-line`) is walked into the same
-   normalized geometry, converting CSS px to pt and normalising against the
-   page element width so playground zoom cannot skew coordinates. Per-page
+1. **Reference rendering**: the selected adapter exports the DOCX to PDF.
+   LibreOffice uses a headless isolated process; Word uses its macOS scripting
+   interface. `mutool draw -F stext` extracts per-line text and geometry.
+   Artifacts are cached by document hash and renderer, so repeat runs do not
+   reopen the application.
+2. **Folio extraction** (`folioExtract.ts`): the same DOCX is loaded in the
+   playground and the painted DOM is walked into normalized geometry. Page
    screenshots are captured for the report.
-3. **Comparison** (`compare.ts`): lines are sequence-aligned by text, which
-   surfaces pagination shifts, line-break differences, and missing/extra
-   content; matched lines are then diffed geometrically with a per-page
-   median-offset correction (Word boxes are ink bounds, folio boxes are
-   line-height boxes, so only residual drift is a divergence).
-4. **Feature attribution + clustering** (`features.ts`): each paragraph in the
-   OOXML is tagged with the layout features it exercises (tables, tabs,
-   numbering, anchored drawings, spacing rules, justification, fields, CJK,
-   ...); each divergence inherits the tags of its paragraph. Across the corpus,
-   (divergence kind x feature) clusters are ranked by lift, so a single root
-   cause (e.g. "atLeast line spacing") shows up as one ranked cluster instead
-   of dozens of scattered diffs.
-5. **Report** (`report.ts`): per-doc fidelity scores, the cluster ranking, and
-   per-page Word-vs-folio renderings with both sets of line boxes overlaid.
+3. **Comparison** (`compare.ts`): lines are sequence-aligned by text, exposing
+   pagination shifts, line-break differences, and missing or extra content.
+   Matched lines are then compared geometrically.
+4. **Feature attribution and clustering** (`features.ts`): each divergence is
+   associated with the active OOXML features. Cross-corpus clusters expose a
+   likely shared cause instead of presenting dozens of isolated diffs.
+5. **Report** (`report.ts`): per-document scores, cluster rankings, and
+   side-by-side reference/Folio renderings with line-box overlays.
 
-Font preflight compares the family Word embedded in its PDF with Chromium's
-resolved CSS family on matching text lines. A requested font may be substituted
-without invalidating the run when both renderers use the same fallback
-(`font-shared:*`). `font-renderer-mismatch` means geometry may primarily reflect
-different font metrics and the document should not drive a layout fix.
-Chromium families are canvas-probed in CSS-stack order; the computed stack alone
-cannot reveal which fallback supplied the glyphs.
+Font preflight compares the family embedded in the reference PDF with
+Chromium's resolved CSS family. A requested font may be substituted without
+invalidating the run when both renderers use the same fallback. A
+`font-renderer-mismatch` means geometry may primarily reflect different font
+metrics and should not drive a layout change by itself.
+
+## Interpreting disagreements
+
+The engineering source order is:
+
+1. [ECMA-376](https://ecma-international.org/publications-and-standards/standards/ecma-376/)
+   and ISO/IEC 29500 normative requirements;
+2. published implementation notes and documented extensions;
+3. structural differential checks against python-docx and Open XML SDK;
+4. reproducible behavior across independent renderers.
+
+When LibreOffice, Word, and folio disagree, the harness records the divergence;
+it does not automatically crown the majority. Page layout contains
+underspecified and implementation-specific behavior, and different engines may
+also substitute different fonts. A fix should be tied to a specification rule,
+documented extension, or an explicit interoperability choice.
+
+See [Interoperability references](../docs/interoperability.md) for the projects
+we can legally and technically use, what each one can measure, and why some
+DOCX libraries are not layout references.
 
 Shared data contract: `types.ts`. Tolerances and paths: `config.ts`.

--- a/parity/__tests__/cli.test.ts
+++ b/parity/__tests__/cli.test.ts
@@ -27,6 +27,25 @@ describe("parity CLI args", () => {
     expect(flags.reuseServer).toBe(true);
   });
 
+  test("defaults to LibreOffice and accepts Word as an explicit reference", () => {
+    expect(parseArgs(["fixture.docx"]).referenceId).toBe("libreoffice");
+    expect(parseArgs(["fixture.docx", "--reference", "word"]).referenceId).toBe("word");
+  });
+
+  test("validates the reference renderer", () => {
+    expect(() => parseArgs(["fixture.docx", "--reference"])).toThrow(
+      "--reference requires libreoffice or word",
+    );
+    expect(() => parseArgs(["fixture.docx", "--reference", "pages"])).toThrow(
+      "Unknown reference renderer: pages",
+    );
+  });
+
+  test("keeps the old refresh flag as an alias", () => {
+    expect(parseArgs(["--refresh-reference"]).refreshReference).toBe(true);
+    expect(parseArgs(["--refresh-truth"]).refreshReference).toBe(true);
+  });
+
   test("requires a path after --output", () => {
     expect(() => parseArgs(["fixture.docx", "--output"])).toThrow("--output requires a file path");
     expect(() => parseArgs(["fixture.docx", "--output", "--json"])).toThrow(

--- a/parity/__tests__/cli.test.ts
+++ b/parity/__tests__/cli.test.ts
@@ -52,4 +52,12 @@ describe("parity CLI args", () => {
       "--output requires a file path",
     );
   });
+
+  test("rejects fractional and partially numeric page limits", () => {
+    for (const value of ["1.5", "2pages"]) {
+      expect(() => parseArgs(["fixture.docx", "--max-pages", value])).toThrow(
+        "--max-pages requires a positive integer",
+      );
+    }
+  });
 });

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -228,7 +228,7 @@ describe("compareGeoms", () => {
     expect(result.score).toBe(1);
     expect(result.divergences).toEqual([]);
     expect(result.medianYOffsetPt).toBe(0);
-    expect(result.totalWordLines).toBe(2);
+    expect(result.totalReferenceLines).toBe(2);
     expect(result.matchedLines).toBe(2);
   });
 
@@ -479,7 +479,7 @@ describe("compareGeoms", () => {
     expect(result.divergences).toHaveLength(1);
     expect(result.divergences[0]).toMatchObject({
       kind: "line-break",
-      wordTexts: ["The quick brown fox jumps"],
+      referenceTexts: ["The quick brown fox jumps"],
       folioTexts: ["The quick brown", "fox jumps"],
     });
     expect(
@@ -586,12 +586,12 @@ describe("compareGeoms", () => {
 
     const result = compareGeoms(word, folio);
 
-    expect(result.divergences[0]).toEqual({ kind: "page-count", word: 1, folio: 2 });
+    expect(result.divergences[0]).toEqual({ kind: "page-count", reference: 1, folio: 2 });
     const pagination = result.divergences.find((d) => d.kind === "pagination");
     expect(pagination).toMatchObject({
       kind: "pagination",
       text: "Line two",
-      wordPage: 1,
+      referencePage: 1,
       folioPage: 2,
     });
   });
@@ -717,7 +717,7 @@ describe("compareGeoms", () => {
     expect(result.divergences).toContainEqual({
       kind: "text-mismatch",
       page: 1,
-      wordText: "The quick brown fox",
+      referenceText: "The quick brown fox",
       folioText: "The quick brown fox.",
     });
   });
@@ -729,7 +729,7 @@ describe("compareGeoms", () => {
 
     expect(emptyResult.score).toBe(1);
     expect(emptyResult.divergences).toEqual([]);
-    expect(emptyResult.totalWordLines).toBe(0);
+    expect(emptyResult.totalReferenceLines).toBe(0);
 
     const folioOnly = makeDoc("folio", [
       makePage({

--- a/parity/__tests__/divergences.test.ts
+++ b/parity/__tests__/divergences.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const DIVERGENCES_SCRIPT = path.resolve(import.meta.dir, "../divergences.ts");
+
+const VALID_REPORT = {
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  reference: {
+    id: "libreoffice",
+    displayName: "LibreOffice Writer",
+  },
+  results: [],
+  clusters: [],
+};
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runDivergences = async (report: unknown): Promise<RunResult> => {
+  const dir = await mkdtemp(path.join(tmpdir(), "folio-divergences-test-"));
+  const reportPath = path.join(dir, "report.json");
+  await Bun.write(reportPath, JSON.stringify(report));
+
+  try {
+    const proc = Bun.spawn([process.execPath, DIVERGENCES_SCRIPT, "--report", reportPath], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+describe("parity divergence report validation", () => {
+  test("accepts explicit valid reference metadata", async () => {
+    const result = await runDivergences(VALID_REPORT);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).reference).toEqual(VALID_REPORT.reference);
+  });
+
+  test("rejects reports without reference metadata", async () => {
+    const { reference: _, ...report } = VALID_REPORT;
+    const result = await runDivergences(report);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("predates explicit reference-renderer metadata");
+  });
+
+  test("rejects unknown reference renderer ids", async () => {
+    const result = await runDivergences({
+      ...VALID_REPORT,
+      reference: { id: "unknown", displayName: "Unknown" },
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("predates explicit reference-renderer metadata");
+  });
+});

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -238,9 +238,9 @@ describe("attributeDivergences", () => {
   const baseResult = (divergences: Divergence[]): ParityResult => ({
     file: "/docs/sample.docx",
     score: 0.9,
-    wordPages: 1,
+    referencePages: 1,
     folioPages: 1,
-    totalWordLines: 10,
+    totalReferenceLines: 10,
     matchedLines: 9,
     medianYOffsetPt: 0,
     divergences,
@@ -314,7 +314,7 @@ describe("attributeDivergences", () => {
       paragraphs: [paragraph("Whatever", ["table"])],
       docFeatures: ["multi-section"],
     };
-    const result = baseResult([{ kind: "page-count", word: 3, folio: 4 }]);
+    const result = baseResult([{ kind: "page-count", reference: 3, folio: 4 }]);
     const attributed = attributeDivergences(result, doc);
     expect(attributed.attributed[0]?.features).toEqual(["doc:multi-section"]);
   });
@@ -335,7 +335,7 @@ describe("attributeDivergences", () => {
 
   test("copies ParityResult fields through and attaches docFeatures", () => {
     const doc: DocFeatures = { paragraphs: [], docFeatures: ["landscape"] };
-    const result = baseResult([{ kind: "page-count", word: 1, folio: 1 }]);
+    const result = baseResult([{ kind: "page-count", reference: 1, folio: 1 }]);
     const attributed = attributeDivergences(result, doc);
     expect(attributed.file).toBe(result.file);
     expect(attributed.score).toBe(result.score);
@@ -356,9 +356,9 @@ describe("clusterCorpus", () => {
   ): FeatureAttributedResult => ({
     file,
     score: 0.9,
-    wordPages: 1,
+    referencePages: 1,
     folioPages: 1,
-    totalWordLines: 10,
+    totalReferenceLines: 10,
     matchedLines: 9,
     medianYOffsetPt: 0,
     divergences: attributed.map((a) => a.divergence),
@@ -468,8 +468,14 @@ describe("clusterCorpus", () => {
         "/a.docx",
         ["landscape"],
         [
-          { divergence: { kind: "page-count", word: 1, folio: 2 }, features: ["doc:landscape"] },
-          { divergence: { kind: "page-count", word: 1, folio: 2 }, features: ["doc:landscape"] },
+          {
+            divergence: { kind: "page-count", reference: 1, folio: 2 },
+            features: ["doc:landscape"],
+          },
+          {
+            divergence: { kind: "page-count", reference: 1, folio: 2 },
+            features: ["doc:landscape"],
+          },
         ],
       ),
       makeResult("/b.docx", [], []),

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -572,7 +572,7 @@ describe("assessFontEnvironment", () => {
     });
   });
 
-  test("rejects a renderer mismatch even when Word used the requested font", () => {
+  test("rejects a renderer mismatch even when the reference used the requested font", () => {
     const assessment = assessFontEnvironment(
       ["Arial"],
       fontGeom("word", [["Same text", "ArialMT"]]),

--- a/parity/__tests__/libreOfficeReference.test.ts
+++ b/parity/__tests__/libreOfficeReference.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { buildLibreOfficeExportArgs } from "../libreOfficeTruth";
+import { buildLibreOfficeExportArgs } from "../libreOfficeReference";
 
 describe("LibreOffice reference renderer", () => {
   test("uses headless PDF export with an isolated user profile", () => {

--- a/parity/__tests__/libreOfficeTruth.test.ts
+++ b/parity/__tests__/libreOfficeTruth.test.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { buildLibreOfficeExportArgs } from "../libreOfficeTruth";
+
+describe("LibreOffice reference renderer", () => {
+  test("uses headless PDF export with an isolated user profile", () => {
+    const args = buildLibreOfficeExportArgs({
+      binary: "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+      inputPath: "/tmp/folio/input.docx",
+      outputDir: "/tmp/folio/output",
+      profileDir: "/tmp/folio/profile with spaces",
+    });
+
+    expect(args).toContain("--headless");
+    expect(args).toContain("pdf:writer_pdf_Export");
+    expect(args).toContain("/tmp/folio/input.docx");
+    expect(args).toContain("/tmp/folio/output");
+
+    const profileArg = args.find((arg) => arg.startsWith("-env:UserInstallation="));
+    expect(profileArg).toBeDefined();
+    expect(profileArg).toContain("file://");
+    expect(profileArg).toContain("profile%20with%20spaces");
+  });
+
+  test("passes paths as separate process arguments", () => {
+    const inputPath = path.join("/tmp", "folio fixtures", "contract.docx");
+    const args = buildLibreOfficeExportArgs({
+      binary: "soffice",
+      inputPath,
+      outputDir: "/tmp/output with spaces",
+      profileDir: "/tmp/profile",
+    });
+
+    expect(args.at(-1)).toBe(inputPath);
+    expect(args.at(-2)).toBe("/tmp/output with spaces");
+  });
+});

--- a/parity/__tests__/pdfReference.test.ts
+++ b/parity/__tests__/pdfReference.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { canReusePagePngCache } from "../pdfReference";
+
+describe("PDF reference page cache", () => {
+  test("does not treat a bounded render as a complete unbounded cache", () => {
+    expect(
+      canReusePagePngCache({
+        existing: ["/cache/p1.png"],
+        completePageCount: null,
+      }),
+    ).toBe(false);
+  });
+
+  test("reuses bounded and explicitly complete sequential page caches", () => {
+    const existing = ["/cache/p1.png", "/cache/p2.png"];
+
+    expect(canReusePagePngCache({ existing, completePageCount: null, maxPages: 2 })).toBe(true);
+    expect(canReusePagePngCache({ existing, completePageCount: 2 })).toBe(true);
+  });
+
+  test("rejects incomplete or non-sequential caches", () => {
+    expect(
+      canReusePagePngCache({
+        existing: ["/cache/p1.png"],
+        completePageCount: 2,
+      }),
+    ).toBe(false);
+    expect(
+      canReusePagePngCache({
+        existing: ["/cache/p1.png", "/cache/p3.png"],
+        completePageCount: 2,
+      }),
+    ).toBe(false);
+  });
+});

--- a/parity/__tests__/report.test.ts
+++ b/parity/__tests__/report.test.ts
@@ -24,7 +24,7 @@ const writeFixturePng = async (name: string): Promise<string> => {
   return filePath;
 };
 
-const makeGeom = (source: "word" | "folio", file: string): DocGeom => ({
+const makeGeom = (source: DocGeom["source"], file: string): DocGeom => ({
   source,
   file,
   pages: [
@@ -72,9 +72,9 @@ describe("writeHtmlReport", () => {
     const resultA: FeatureAttributedResult = {
       file: docAFile,
       score: 1,
-      wordPages: 1,
+      referencePages: 1,
       folioPages: 1,
-      totalWordLines: 1,
+      totalReferenceLines: 1,
       matchedLines: 1,
       medianYOffsetPt: 0.5,
       divergences: [],
@@ -85,13 +85,13 @@ describe("writeHtmlReport", () => {
     const resultB: FeatureAttributedResult = {
       file: docBFile,
       score: 0.5,
-      wordPages: 1,
+      referencePages: 1,
       folioPages: 1,
-      totalWordLines: 2,
+      totalReferenceLines: 2,
       matchedLines: 1,
       medianYOffsetPt: 1.25,
       divergences: [
-        { kind: "page-count", word: 2, folio: 1 },
+        { kind: "page-count", reference: 2, folio: 1 },
         {
           kind: "missing-line",
           page: 1,
@@ -106,7 +106,7 @@ describe("writeHtmlReport", () => {
         {
           kind: "text-mismatch",
           page: 1,
-          wordText: "Hello world",
+          referenceText: "Hello world",
           folioText: "Hell0 world",
         },
       ],
@@ -121,7 +121,11 @@ describe("writeHtmlReport", () => {
 
     const report: CorpusReport = {
       generatedAt: "2026-07-04T00:00:00.000Z",
-      wordVersion: "16.112",
+      reference: {
+        id: "libreoffice",
+        displayName: "LibreOffice Writer",
+        version: "LibreOffice 26.2.4.2",
+      },
       results: [resultA, resultB],
       clusters: [
         {
@@ -153,18 +157,18 @@ describe("writeHtmlReport", () => {
       [
         docAFile,
         {
-          wordPagePngs: [wordPngA],
+          referencePagePngs: [wordPngA],
           folioPagePngs: [folioPngA],
-          wordGeom: makeGeom("word", docAFile),
+          referenceGeom: makeGeom("libreoffice", docAFile),
           folioGeom: makeGeom("folio", docAFile),
         },
       ],
       [
         docBFile,
         {
-          wordPagePngs: [wordPngB],
+          referencePagePngs: [wordPngB],
           folioPagePngs: [folioPngB],
-          wordGeom: makeGeom("word", docBFile),
+          referenceGeom: makeGeom("libreoffice", docBFile),
           folioGeom: makeGeom("folio", docBFile),
         },
       ],
@@ -221,8 +225,10 @@ describe("writeHtmlReport", () => {
     expect(yDriftIdx).toBeGreaterThan(textMismatchIdx);
 
     // PNGs were copied into REPORT_DIR/assets/<slug>/.
-    const copiedWordA = await readFile(path.join(REPORT_DIR, "assets", "sample-one", "word-1.png"));
-    expect(copiedWordA.equals(ONE_PIXEL_PNG)).toBe(true);
+    const copiedReferenceA = await readFile(
+      path.join(REPORT_DIR, "assets", "sample-one", "reference-1.png"),
+    );
+    expect(copiedReferenceA.equals(ONE_PIXEL_PNG)).toBe(true);
   });
 
   test("de-duplicates slugs that sanitize to the same basename", async () => {
@@ -232,9 +238,9 @@ describe("writeHtmlReport", () => {
     const baseResult = (file: string): FeatureAttributedResult => ({
       file,
       score: 1,
-      wordPages: 0,
+      referencePages: 0,
       folioPages: 0,
-      totalWordLines: 0,
+      totalReferenceLines: 0,
       matchedLines: 0,
       medianYOffsetPt: 0,
       divergences: [],
@@ -244,6 +250,7 @@ describe("writeHtmlReport", () => {
 
     const report: CorpusReport = {
       generatedAt: "2026-07-04T00:00:00.000Z",
+      reference: { id: "libreoffice", displayName: "LibreOffice Writer" },
       results: [baseResult(fileOne), baseResult(fileTwo)],
       clusters: [],
     };
@@ -262,9 +269,10 @@ describe("writeHtmlReport", () => {
     );
   });
 
-  test("handles missing wordVersion, empty corpus, and missing PNG source gracefully", async () => {
+  test("handles missing reference version, empty corpus, and missing PNG source gracefully", async () => {
     const report: CorpusReport = {
       generatedAt: "2026-07-04T00:00:00.000Z",
+      reference: { id: "libreoffice", displayName: "LibreOffice Writer" },
       results: [],
       clusters: [],
     };

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -116,7 +116,7 @@ export const parseArgs = (argv: string[]): CliFlags => {
       i += 1;
     } else if (arg === "--max-pages") {
       const value = argv[i + 1];
-      const maxPages = value === undefined ? Number.NaN : Number.parseInt(value, 10);
+      const maxPages = value === undefined ? Number.NaN : Number(value);
       if (!Number.isInteger(maxPages) || maxPages <= 0) {
         throw new Error("--max-pages requires a positive integer");
       }

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Word rendering parity engine: CLI entry point.
+ * Multi-engine DOCX rendering comparison: CLI entry point.
  *
  * Usage:
  *   bun parity/cli.ts                          # full default corpus, HTML report
@@ -8,14 +8,16 @@
  *   bun parity/cli.ts --help                   # print usage
  *   bun parity/cli.ts some/dir --json          # machine-readable output
  *   bun parity/cli.ts path/to/file.docx --output parity.json
- *   bun parity/cli.ts --refresh-truth          # ignore cached Word exports
+ *   bun parity/cli.ts --reference libreoffice  # open-source reference (default)
+ *   bun parity/cli.ts --reference word         # optional proprietary reference
+ *   bun parity/cli.ts --refresh-reference      # ignore cached reference exports
  *   bun parity/cli.ts --headed                 # show the folio browser window
  *   bun parity/cli.ts --no-report              # skip writing the HTML report
  *   bun parity/cli.ts path/to/file.docx --max-pages 20
  *
- * Ground truth requires Microsoft Word for Mac plus `mutool`
- * (`brew install mupdf-tools`); the CLI exits 2 with a clear message when
- * either is missing, mirroring the differential-test skip ergonomics.
+ * Every renderer is an explicit comparison reference, never “ground truth.”
+ * LibreOffice is the default. All references require `mutool`
+ * (`brew install mupdf-tools`) for normalized PDF geometry extraction.
  */
 import { mkdir, stat } from "node:fs/promises";
 import path from "node:path";
@@ -31,15 +33,17 @@ import type { ParagraphFeatures } from "./features";
 import { createFolioExtractor } from "./folioExtract";
 import type { FolioExtractor } from "./folioExtract";
 import { compareGeoms } from "./compare";
+import { getReferenceRenderer, isReferenceRendererId } from "./referenceRenderer";
+import type { ReferenceRenderer } from "./referenceRenderer";
 import { writeHtmlReport } from "./report";
 import type { DocAssets } from "./report";
-import { getWordPagePngs, getWordTruth, getWordVersion, isWordAvailable } from "./wordTruth";
 import type {
   CorpusReport,
   Divergence,
   DivergenceKind,
   DocGeom,
   FeatureAttributedResult,
+  ReferenceRendererId,
 } from "./types";
 
 const EXIT_OK = 0;
@@ -48,6 +52,7 @@ const EXIT_INFRA_FAILURE = 2;
 
 const TOP_CLUSTER_LIMIT = 10;
 const PERFECT_SCORE = 1;
+const DEFAULT_REFERENCE_RENDERER: ReferenceRendererId = "libreoffice";
 
 /** Word lock files ("~$name.docx") and dotfiles are never real documents. */
 const DOCX_GLOB = "**/*.docx";
@@ -56,7 +61,8 @@ const isRealDocxName = (name: string): boolean => !name.startsWith("~$") && !nam
 type CliFlags = {
   help: boolean;
   json: boolean;
-  refreshTruth: boolean;
+  refreshReference: boolean;
+  referenceId: ReferenceRendererId;
   headed: boolean;
   reuseServer: boolean;
   noReport: boolean;
@@ -69,7 +75,8 @@ export const parseArgs = (argv: string[]): CliFlags => {
   const flags: CliFlags = {
     help: false,
     json: false,
-    refreshTruth: false,
+    refreshReference: false,
+    referenceId: DEFAULT_REFERENCE_RENDERER,
     headed: false,
     reuseServer: false,
     noReport: false,
@@ -77,12 +84,23 @@ export const parseArgs = (argv: string[]): CliFlags => {
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
+    if (arg === undefined) continue;
     if (arg === "--help" || arg === "-h") {
       flags.help = true;
     } else if (arg === "--json") {
       flags.json = true;
-    } else if (arg === "--refresh-truth") {
-      flags.refreshTruth = true;
+    } else if (arg === "--refresh-reference" || arg === "--refresh-truth") {
+      flags.refreshReference = true;
+    } else if (arg === "--reference") {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error("--reference requires libreoffice or word");
+      }
+      if (!isReferenceRendererId(value)) {
+        throw new Error(`Unknown reference renderer: ${value}`);
+      }
+      flags.referenceId = value;
+      i += 1;
     } else if (arg === "--headed") {
       flags.headed = true;
     } else if (arg === "--reuse-server") {
@@ -111,7 +129,7 @@ export const parseArgs = (argv: string[]): CliFlags => {
   return flags;
 };
 
-const HELP_TEXT = `Word rendering parity engine
+const HELP_TEXT = `DOCX rendering interoperability comparison
 
 Usage:
   bun parity/cli.ts [doc-or-dir ...] [options]
@@ -121,13 +139,15 @@ Options:
   --json               Print the machine-readable report to stdout.
   --output <path>      Write the JSON report to a file.
   --max-pages <n>      Compare only the first n pages.
-  --refresh-truth      Re-render Word ground truth instead of using cache.
+  --reference <id>     Reference renderer: libreoffice (default) or word.
+  --refresh-reference  Re-render the reference instead of using cache.
   --headed             Show the Folio browser window.
   --reuse-server       Reuse a healthy current-worktree playground server.
   --no-report          Skip writing the HTML report.
 
 Examples:
-  bun parity/cli.ts path/to/file.docx --max-pages 20
+  bun parity/cli.ts path/to/file.docx --reference libreoffice --max-pages 20
+  bun parity/cli.ts path/to/file.docx --reference word
   bun parity/cli.ts some/dir --json --output /tmp/parity.json
 `;
 
@@ -183,7 +203,7 @@ const resolveCorpus = async (inputPaths: string[]): Promise<string[]> => {
   return Array.from(files).toSorted((a, b) => a.localeCompare(b));
 };
 
-/** Per-doc pipeline failure: any throw during word-truth/folio/compare/features. */
+/** Per-doc pipeline failure: any throw during reference/folio/compare/features. */
 type DocFailure = { file: string; error: Error };
 
 /** Result of running the full per-doc pipeline over the corpus. */
@@ -195,13 +215,16 @@ type PipelineOutcome = {
 };
 
 /**
- * Runs word-truth -> folio-extract -> compare -> feature-attribution for
- * every doc in `docs`, sequentially: Word is a single-instance app and the
- * folio extractor shares one browser page, so docs cannot be processed
- * concurrently. A single `FolioExtractor` is created lazily before the first
- * folio extraction and closed in `finally` regardless of how the loop ends.
+ * Runs reference-render -> folio-extract -> compare -> feature-attribution
+ * for every document sequentially. Some external renderers are single-instance
+ * applications and the folio extractor shares one browser page, so documents
+ * cannot be processed concurrently.
  */
-const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOutcome> => {
+const runPipeline = async (
+  docs: string[],
+  flags: CliFlags,
+  referenceRenderer: ReferenceRenderer,
+): Promise<PipelineOutcome> => {
   const results: FeatureAttributedResult[] = [];
   const paragraphsByDoc: ParagraphFeatures[][] = [];
   const assets = new Map<string, DocAssets>();
@@ -215,12 +238,12 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
       if (!doc) continue;
 
       const label = `[${i + 1}/${docs.length}] ${path.basename(doc)}`;
-      process.stderr.write(`${label}: word truth… `);
+      process.stderr.write(`${label}: ${referenceRenderer.displayName}… `);
 
       try {
-        // oxlint-disable-next-line no-await-in-loop -- Word is a single-instance app; docs are exported one at a time
-        const wordGeom = limitGeomPages(
-          await getWordTruth(doc, { refresh: flags.refreshTruth }),
+        // oxlint-disable-next-line no-await-in-loop -- references are rendered sequentially for deterministic app automation
+        const referenceGeom = limitGeomPages(
+          await referenceRenderer.getTruth(doc, { refresh: flags.refreshReference }),
           flags.maxPages,
         );
 
@@ -234,13 +257,14 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
 
         process.stderr.write("folio… ");
         // oxlint-disable-next-line no-await-in-loop -- the extractor shares one browser page across docs
-        const folio = await extractor.extract(doc, { maxPages: flags.maxPages });
+        const pageLimit = flags.maxPages === undefined ? {} : { maxPages: flags.maxPages };
+        const folio = await extractor.extract(doc, pageLimit);
 
-        const result = compareGeoms(wordGeom, folio.geom);
+        const result = compareGeoms(referenceGeom, folio.geom);
 
         // oxlint-disable-next-line no-await-in-loop -- sequential per-doc pipeline
         const docFeatures = await extractDocFeatures(doc);
-        const fontEnvironment = detectFontEnvironment(doc, wordGeom, folio.geom);
+        const fontEnvironment = detectFontEnvironment(doc, referenceGeom, folio.geom);
         if (fontEnvironment.tags.length > 0) {
           docFeatures.docFeatures.push(...fontEnvironment.tags);
         }
@@ -251,30 +275,30 @@ const runPipeline = async (docs: string[], flags: CliFlags): Promise<PipelineOut
         } else if (fontEnvironment.status === "mismatch") {
           if (fontEnvironment.tags.includes("font-renderer-metric-mismatch")) {
             process.stderr.write(
-              `(Word/Folio font metric mismatch despite ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} matching family names) `,
+              `(${referenceRenderer.displayName}/Folio font metric mismatch despite ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} matching family names) `,
             );
           } else {
             process.stderr.write(
-              `(Word/Folio font mismatch: ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} lines match) `,
+              `(${referenceRenderer.displayName}/Folio font mismatch: ${fontEnvironment.matchingLines}/${fontEnvironment.comparedLines} lines match) `,
             );
           }
         } else if (fontEnvironment.status === "unverified") {
-          process.stderr.write("(Word/Folio font parity unverified) ");
+          process.stderr.write(`(${referenceRenderer.displayName}/Folio font parity unverified) `);
         }
         const attributed = attributeDivergences(result, docFeatures);
 
         // oxlint-disable-next-line no-await-in-loop -- sequential per-doc pipeline
-        const wordPagePngs = limitPaths(
-          await getWordPagePngs(doc, { maxPages: flags.maxPages }),
+        const referencePagePngs = limitPaths(
+          await referenceRenderer.getPagePngs(doc, pageLimit),
           flags.maxPages,
         );
 
         results.push(attributed);
         paragraphsByDoc.push(docFeatures.paragraphs);
         assets.set(doc, {
-          wordPagePngs,
+          referencePagePngs,
           folioPagePngs: folio.screenshotPaths,
-          wordGeom,
+          referenceGeom,
           folioGeom: folio.geom,
         });
 
@@ -319,13 +343,14 @@ const compactDivergenceCounts = (divergences: Divergence[]): string => {
 
 const printHumanSummary = (report: CorpusReport, failures: DocFailure[]): void => {
   const docCount = report.results.length;
+  const version = report.reference.version ?? "unknown version";
   console.log(
-    `\nWord rendering parity report — ${docCount} document${docCount === 1 ? "" : "s"}, Word ${report.wordVersion ?? "unknown"}\n`,
+    `\nDOCX interoperability report — ${docCount} document${docCount === 1 ? "" : "s"}, Folio vs ${report.reference.displayName} ${version}\n`,
   );
 
   for (const result of report.results) {
     const pct = `${(result.score * 100).toFixed(1)}%`;
-    const pages = `pages ${result.wordPages}/${result.folioPages}`;
+    const pages = `pages ${result.referencePages}/${result.folioPages}`;
     const counts = compactDivergenceCounts(result.divergences) || "no divergences";
     console.log(
       `  ${path.basename(result.file).padEnd(40)} ${pct.padStart(6)}  ${pages}  ${counts}`,
@@ -375,12 +400,13 @@ const main = async (argv: string[]): Promise<number> => {
     return EXIT_OK;
   }
 
-  if (!(await isWordAvailable())) {
+  const referenceRenderer = getReferenceRenderer(flags.referenceId);
+  if (!(await referenceRenderer.isAvailable())) {
     console.error(
-      "Word rendering parity engine requires Microsoft Word for Mac and `mutool`.\n" +
-        "  - Install Word: https://www.microsoft.com/microsoft-365/word\n" +
+      `${referenceRenderer.displayName} comparison requires the renderer and \`mutool\`.\n` +
+        `  - ${referenceRenderer.installHint}\n` +
         "  - Install mutool: brew install mupdf-tools\n" +
-        "This tool is a local, on-demand comparison; it is not a CI gate.",
+        "This is a local, on-demand interoperability comparison; no renderer is treated as specification ground truth.",
     );
     return EXIT_INFRA_FAILURE;
   }
@@ -391,13 +417,21 @@ const main = async (argv: string[]): Promise<number> => {
     return EXIT_OK;
   }
 
-  const { results, paragraphsByDoc, assets, failures } = await runPipeline(docs, flags);
+  const { results, paragraphsByDoc, assets, failures } = await runPipeline(
+    docs,
+    flags,
+    referenceRenderer,
+  );
   const clusters = clusterCorpus(results, paragraphsByDoc);
-  const wordVersion = (await getWordVersion()) ?? undefined;
+  const referenceVersion = (await referenceRenderer.getVersion()) ?? undefined;
 
   const report: CorpusReport = {
     generatedAt: new Date().toISOString(),
-    ...(wordVersion !== undefined ? { wordVersion } : {}),
+    reference: {
+      id: referenceRenderer.id,
+      displayName: referenceRenderer.displayName,
+      ...(referenceVersion !== undefined ? { version: referenceVersion } : {}),
+    },
     results,
     clusters,
   };
@@ -430,7 +464,7 @@ if (import.meta.main) {
     process.exitCode = await main(process.argv.slice(2));
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
-    console.error(`Word rendering parity engine failed: ${err.name}: ${err.message}`);
+    console.error(`DOCX interoperability comparison failed: ${err.name}: ${err.message}`);
     process.exitCode = EXIT_INFRA_FAILURE;
   }
 }

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -243,7 +243,7 @@ const runPipeline = async (
       try {
         // oxlint-disable-next-line no-await-in-loop -- references are rendered sequentially for deterministic app automation
         const referenceGeom = limitGeomPages(
-          await referenceRenderer.getTruth(doc, { refresh: flags.refreshReference }),
+          await referenceRenderer.getGeometry(doc, { refresh: flags.refreshReference }),
           flags.maxPages,
         );
 

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -1,12 +1,12 @@
 /**
- * Rendering parity engine: pure comparison of two `DocGeom` values into
- * a `ParityResult`. No I/O, no browser: this module only manipulates the
+ * Multi-engine rendering comparison: pure comparison of two `DocGeom` values
+ * into a `ParityResult`. No I/O, no browser: this module only manipulates the
  * already-extracted geometry, which keeps it fully unit-testable.
  *
  * The core problem is a sequence-alignment problem: match lines by text
- * across two documents (word = ground truth, folio = candidate), then diff
- * the matched pairs geometrically. See the module-level comments below for
- * the alignment algorithm and the gap-reconciliation (line-break) heuristic.
+ * across two documents (external reference first, folio second), then diff
+ * the matched pairs geometrically. See the module-level comments below for the
+ * alignment algorithm and the gap-reconciliation (line-break) heuristic.
  */
 
 import { DEFAULT_TOLERANCES } from "./config";
@@ -57,7 +57,11 @@ export const compareGeoms = (
 
   const divergences: Divergence[] = [];
   if (word.pages.length !== folio.pages.length) {
-    divergences.push({ kind: "page-count", word: word.pages.length, folio: folio.pages.length });
+    divergences.push({
+      kind: "page-count",
+      reference: word.pages.length,
+      folio: folio.pages.length,
+    });
   }
 
   const cellCount = wordFlat.length * folioFlat.length;
@@ -92,18 +96,18 @@ export const compareGeoms = (
   });
   divergences.push(...orderedDivergences);
 
-  const totalWordLines = wordFlat.length;
+  const totalReferenceLines = wordFlat.length;
   const score =
-    totalWordLines === 0
-      ? scoreForEmptyWordDoc(folioFlat.length)
-      : matchedGeomPass / totalWordLines;
+    totalReferenceLines === 0
+      ? scoreForEmptyReferenceDoc(folioFlat.length)
+      : matchedGeomPass / totalReferenceLines;
 
   return {
     file: word.file,
     score,
-    wordPages: word.pages.length,
+    referencePages: word.pages.length,
     folioPages: folio.pages.length,
-    totalWordLines,
+    totalReferenceLines,
     matchedLines: matchedLineCount,
     medianYOffsetPt,
     divergences,
@@ -112,12 +116,13 @@ export const compareGeoms = (
 
 /** Score when the reference side has no lines at all: 1 if folio is also empty
  * (nothing to diverge on), 0 otherwise (every folio line is unaccounted for). */
-const scoreForEmptyWordDoc = (folioLineCount: number): number => (folioLineCount === 0 ? 1 : 0);
+const scoreForEmptyReferenceDoc = (folioLineCount: number): number =>
+  folioLineCount === 0 ? 1 : 0;
 
 const stripSpaces = (text: string): string => text.replaceAll(" ", "");
 
 /**
- * Reference PDF extraction reports glyph-ink bounds while Folio reports the line
+ * PDF extraction reports glyph-ink bounds while Folio reports the line
  * box. Punctuation-only rows (signature rules, ellipses, separators) have no
  * stable cap-height edge, so their top coordinates cannot establish or verify
  * a baseline offset. Horizontal geometry remains comparable.
@@ -773,7 +778,7 @@ const diffMatches = ({
         orderedDivergences.push({
           kind: "text-mismatch",
           page: w.page,
-          wordText: w.line.normText,
+          referenceText: w.line.normText,
           folioText: f.line.normText,
         });
       }
@@ -781,7 +786,7 @@ const diffMatches = ({
         orderedDivergences.push({
           kind: "pagination",
           text: w.line.normText,
-          wordPage: w.page,
+          referencePage: w.page,
           folioPage: f.page,
         });
       }
@@ -874,7 +879,7 @@ const diffMatches = ({
         orderedDivergences.push({
           kind: "line-break",
           page,
-          wordTexts: item.wordIdxs.map((idx) => wordFlat[idx]?.line.normText ?? ""),
+          referenceTexts: item.wordIdxs.map((idx) => wordFlat[idx]?.line.normText ?? ""),
           folioTexts: item.folioIdxs.map((idx) => folioFlat[idx]?.line.normText ?? ""),
         });
       }

--- a/parity/diffReport.ts
+++ b/parity/diffReport.ts
@@ -4,6 +4,7 @@
  */
 import path from "node:path";
 
+import { isReferenceRendererId } from "./referenceRenderer";
 import type { CorpusReport, DivergenceKind, FeatureAttributedResult } from "./types";
 
 type DiffFlags = {
@@ -66,6 +67,9 @@ const readReport = async (file: string): Promise<CorpusReport> => {
   if (!Array.isArray(report.results)) {
     throw new Error(`${file} is not a parity JSON report`);
   }
+  if (!report.reference || !isReferenceRendererId(report.reference.id)) {
+    throw new Error(`${file} predates explicit reference-renderer metadata; regenerate it`);
+  }
   return report;
 };
 
@@ -97,6 +101,11 @@ const formatScoreDelta = (after: number, before: number): string => {
 const main = async (): Promise<void> => {
   const flags = parseArgs(process.argv.slice(2));
   const [before, after] = await Promise.all([readReport(flags.before!), readReport(flags.after!)]);
+  if (before.reference.id !== after.reference.id) {
+    throw new Error(
+      `cannot diff reports from different references (${before.reference.id} vs ${after.reference.id})`,
+    );
+  }
   const beforeByFile = new Map(before.results.map((result) => [result.file, summarize(result)]));
   const afterByFile = new Map(after.results.map((result) => [result.file, summarize(result)]));
   const files = Array.from(new Set([...beforeByFile.keys(), ...afterByFile.keys()])).toSorted();
@@ -132,6 +141,7 @@ const main = async (): Promise<void> => {
       {
         before: path.resolve(flags.before!),
         after: path.resolve(flags.after!),
+        reference: after.reference,
         docs,
       },
       null,

--- a/parity/divergences.ts
+++ b/parity/divergences.ts
@@ -4,10 +4,12 @@
  *
  * Reads an existing `parity/cli.ts --json` report and prints a deterministic,
  * filterable list of divergences plus ready-to-run follow-up commands. This
- * avoids re-running Word/Folio when the next step is just choosing a target.
+ * avoids re-running the reference renderer and Folio when the next step is
+ * just choosing a target.
  */
 import path from "node:path";
 
+import { isReferenceRendererId } from "./referenceRenderer";
 import { normalizeLineText } from "./textNorm";
 import type { CorpusReport, Divergence, DivergenceKind } from "./types";
 
@@ -93,6 +95,9 @@ const readReport = async (file: string): Promise<CorpusReport> => {
   if (!Array.isArray(report.results)) {
     throw new Error(`${file} is not a parity JSON report`);
   }
+  if (!report.reference || !isReferenceRendererId(report.reference.id)) {
+    throw new Error(`${file} predates explicit reference-renderer metadata; regenerate it`);
+  }
   return report;
 };
 
@@ -101,7 +106,7 @@ const divergencePage = (divergence: Divergence): number | undefined => {
     case "page-count":
       return undefined;
     case "pagination":
-      return divergence.wordPage;
+      return divergence.referencePage;
     case "line-break":
     case "missing-line":
     case "extra-line":
@@ -116,7 +121,7 @@ const divergencePage = (divergence: Divergence): number | undefined => {
 const divergenceText = (divergence: Divergence): string => {
   switch (divergence.kind) {
     case "page-count":
-      return `word=${divergence.word} folio=${divergence.folio}`;
+      return `reference=${divergence.reference} folio=${divergence.folio}`;
     case "pagination":
     case "missing-line":
     case "extra-line":
@@ -125,9 +130,9 @@ const divergenceText = (divergence: Divergence): string => {
     case "width-drift":
       return divergence.text;
     case "line-break":
-      return `${divergence.wordTexts.join(" ")} | ${divergence.folioTexts.join(" ")}`;
+      return `${divergence.referenceTexts.join(" ")} | ${divergence.folioTexts.join(" ")}`;
     case "text-mismatch":
-      return `${divergence.wordText} -> ${divergence.folioText}`;
+      return `${divergence.referenceText} -> ${divergence.folioText}`;
   }
 };
 
@@ -143,9 +148,9 @@ const divergenceQueryText = (divergence: Divergence): string => {
     case "width-drift":
       return divergence.text;
     case "line-break":
-      return divergence.wordTexts.join(" ");
+      return divergence.referenceTexts.join(" ");
     case "text-mismatch":
-      return divergence.wordText;
+      return divergence.referenceText;
   }
 };
 
@@ -213,6 +218,7 @@ const main = async (): Promise<void> => {
     JSON.stringify(
       {
         report: reportPath,
+        reference: report.reference,
         total: rows.length,
         counts,
         rows: selected.map((row) =>
@@ -220,7 +226,7 @@ const main = async (): Promise<void> => {
             inspectCommand:
               row.page === undefined
                 ? undefined
-                : `bun parity/inspect.ts --doc ${shellQuote(row.doc)} --page ${row.page} --text ${shellQuote(row.queryText)} --max-pages ${row.page}`,
+                : `bun parity/inspect.ts --doc ${shellQuote(row.doc)} --reference ${report.reference.id} --page ${row.page} --text ${shellQuote(row.queryText)} --max-pages ${row.page}`,
             sourceTraceCommand: `bun parity/sourceTrace.ts --doc ${shellQuote(row.doc)} --text ${shellQuote(row.queryText)}`,
           }),
         ),

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -583,8 +583,10 @@ export const detectFontEnvironment = (
  * no associated text (it is a whole-document divergence). */
 const divergenceSearchText = (divergence: Divergence): string | undefined => {
   if (divergence.kind === "page-count") return undefined;
-  if (divergence.kind === "line-break") return divergence.wordTexts[0] ?? divergence.folioTexts[0];
-  if (divergence.kind === "text-mismatch") return divergence.wordText;
+  if (divergence.kind === "line-break") {
+    return divergence.referenceTexts[0] ?? divergence.folioTexts[0];
+  }
+  if (divergence.kind === "text-mismatch") return divergence.referenceText;
   return divergence.text;
 };
 

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -333,13 +333,13 @@ export const extractDocFeatures = (docxPath: string): Promise<DocFeatures> => {
 };
 
 // ---------------------------------------------------------------------------
-// ground-truth font substitution detection
+// reference-renderer font substitution detection
 // ---------------------------------------------------------------------------
 
 /** PostScript-name decorations a PDF may append to a faithfully-rendered
  * font, normalized to lowercase alphanumerics ("ArialMT" satisfies "Arial",
  * "Calibri-BoldItalic" satisfies "Calibri"). Anything else after the
- * requested family name means Word rendered a DIFFERENT family (e.g. a
+ * requested family name means the reference renderer used a DIFFERENT family (e.g. a
  * request for "Inter" answered by "Interstate-Bold": remainder "state-bold"
  * is no style suffix, so it counts as a substitution). */
 const PDF_FONT_STYLE_SUFFIXES = new Set([
@@ -414,9 +414,9 @@ export const fontFamiliesMatch = (leftRaw: string, rightRaw: string): boolean =>
 };
 
 type FontPair = {
-  wordFont: string;
+  referenceFont: string;
   folioFont: string;
-  wordWidthPt: number;
+  referenceWidthPt: number;
   folioWidthPt: number;
 };
 
@@ -430,7 +430,7 @@ const FONT_METRIC_RELATIVE_TOLERANCE = 0.05;
 // measured width stays stable even when their glyph metrics do not.
 const MIN_FONT_METRIC_OUTLIER_SHARE = 0.25;
 
-const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): FontPair[] => {
+const collectFontPairs = (referenceGeom: DocGeom, folioGeom: DocGeom): FontPair[] => {
   const folioLinesByText = new Map<string, LineBox[]>();
   for (const page of folioGeom.pages) {
     for (const line of page.lines) {
@@ -447,15 +447,15 @@ const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): FontPair[] => 
   for (const lines of folioLinesByText.values()) lines.reverse();
 
   const pairs: FontPair[] = [];
-  for (const page of wordGeom.pages) {
+  for (const page of referenceGeom.pages) {
     for (const line of page.lines) {
       if (line.fontName === undefined) continue;
       const folioLine = folioLinesByText.get(line.normText)?.pop();
       if (folioLine?.fontName !== undefined) {
         pairs.push({
-          wordFont: line.fontName,
+          referenceFont: line.fontName,
           folioFont: folioLine.fontName,
-          wordWidthPt: line.widthPt,
+          referenceWidthPt: line.widthPt,
           folioWidthPt: folioLine.widthPt,
         });
       }
@@ -467,14 +467,14 @@ const collectFontPairs = (wordGeom: DocGeom, folioGeom: DocGeom): FontPair[] => 
 const hasFontMetricMismatch = (pairs: FontPair[]): boolean => {
   const ratios = pairs
     .filter(
-      ({ wordFont, folioFont, wordWidthPt, folioWidthPt }) =>
-        fontFamiliesMatch(wordFont, folioFont) &&
-        wordWidthPt >= MIN_FONT_METRIC_WIDTH_PT &&
+      ({ referenceFont, folioFont, referenceWidthPt, folioWidthPt }) =>
+        fontFamiliesMatch(referenceFont, folioFont) &&
+        referenceWidthPt >= MIN_FONT_METRIC_WIDTH_PT &&
         folioWidthPt >= MIN_FONT_METRIC_WIDTH_PT &&
-        wordWidthPt <= MAX_FONT_METRIC_WIDTH_PT &&
+        referenceWidthPt <= MAX_FONT_METRIC_WIDTH_PT &&
         folioWidthPt <= MAX_FONT_METRIC_WIDTH_PT,
     )
-    .map(({ wordWidthPt, folioWidthPt }) => folioWidthPt / wordWidthPt)
+    .map(({ referenceWidthPt, folioWidthPt }) => folioWidthPt / referenceWidthPt)
     .toSorted((a, b) => a - b);
   if (ratios.length < MIN_FONT_METRIC_SAMPLES) return false;
 
@@ -490,21 +490,21 @@ const hasFontMetricMismatch = (pairs: FontPair[]): boolean => {
   return Math.max(wider, narrower) / ratios.length >= MIN_FONT_METRIC_OUTLIER_SHARE;
 };
 
-/** Classify the actual fonts resolved by Word and Chromium. Requested-font
+/** Classify the actual fonts resolved by the reference renderer and Chromium. Requested-font
  * substitution is harmless for geometric parity when both renderers resolve
  * every comparable line to the same family. */
 export const assessFontEnvironment = (
   requestedFonts: string[],
-  wordGeom: DocGeom,
+  referenceGeom: DocGeom,
   folioGeom: DocGeom,
 ): FontEnvironmentAssessment => {
-  const observedWordFonts = wordGeom.pages.flatMap((page) =>
+  const observedReferenceFonts = referenceGeom.pages.flatMap((page) =>
     page.lines.flatMap((line) => (line.fontName === undefined ? [] : [line.fontName])),
   );
-  const substitutionTags = computeFontSubstitutionTags(requestedFonts, observedWordFonts);
-  const pairs = collectFontPairs(wordGeom, folioGeom);
-  const matchingLines = pairs.filter(({ wordFont, folioFont }) =>
-    fontFamiliesMatch(wordFont, folioFont),
+  const substitutionTags = computeFontSubstitutionTags(requestedFonts, observedReferenceFonts);
+  const pairs = collectFontPairs(referenceGeom, folioGeom);
+  const matchingLines = pairs.filter(({ referenceFont, folioFont }) =>
+    fontFamiliesMatch(referenceFont, folioFont),
   ).length;
   const metricMismatch = hasFontMetricMismatch(pairs);
 
@@ -561,8 +561,8 @@ const collectRequestedFonts = (docxPath: string): string[] => {
 };
 
 /**
- * Detects when the Word ground truth itself was rendered with substituted
- * fonts (the machine driving Word lacks a font the document requests, e.g. a
+ * Detects when the reference renderer used substituted fonts (the rendering
+ * environment lacks a font the document requests, e.g. a
  * web font like "Inter"). Divergences in such documents may reflect font
  * availability rather than folio layout bugs, so the report must carry the
  * warning. Returned tags (e.g. "font-substituted:inter") are meant to be
@@ -570,10 +570,10 @@ const collectRequestedFonts = (docxPath: string): string[] => {
  */
 export const detectFontEnvironment = (
   docxPath: string,
-  wordGeom: DocGeom,
+  referenceGeom: DocGeom,
   folioGeom: DocGeom,
 ): FontEnvironmentAssessment =>
-  assessFontEnvironment(collectRequestedFonts(docxPath), wordGeom, folioGeom);
+  assessFontEnvironment(collectRequestedFonts(docxPath), referenceGeom, folioGeom);
 
 // ---------------------------------------------------------------------------
 // divergence -> paragraph attribution

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -2,7 +2,7 @@
  * Folio-side geometry extraction: loads a .docx in the playground (Playwright
  * + the existing `?file=` fixture route), walks the painted layout DOM
  * (`.layout-page` / `.layout-line`), and normalizes it into the same
- * `DocGeom` shape the reference extractor produces. Also captures a per-page
+ * `DocGeom` shape produced by external reference renderers. Also captures a per-page
  * PNG screenshot for the HTML report.
  *
  * DOM-only concerns (getBoundingClientRect, closest, getComputedStyle,
@@ -832,7 +832,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
 
         // The `.layout-line` box spans the full column width regardless of where
         // the text ink actually sits (centered/right-aligned lines, table cells),
-        // while the reference extractor reports glyph-ink bounds. Use the union
+        // while PDF-based reference extractors report glyph-ink bounds. Use the union
         // of the line's run and list-marker boxes as the ink rect so both sides
         // measure the same thing; fall back to the line box for lines without
         // segment children.

--- a/parity/folioInspect.ts
+++ b/parity/folioInspect.ts
@@ -2,10 +2,10 @@
 /**
  * Folio DOM/page inspector for visual parity debugging.
  *
- * This complements `parity/inspect.ts`: the parity inspector compares Word vs
- * Folio line boxes, while this command dumps Folio's source-linked painted
- * lines and spans so an agent can trace a visual line back to PM positions and
- * computed CSS without manually reading browser DevTools.
+ * This complements `parity/inspect.ts`: the parity inspector compares an
+ * external reference with Folio line boxes, while this command dumps Folio's
+ * source-linked painted lines and spans so an agent can trace a visual line
+ * back to PM positions and computed CSS without manually reading DevTools.
  */
 import path from "node:path";
 

--- a/parity/inspect.ts
+++ b/parity/inspect.ts
@@ -10,9 +10,9 @@ import path from "node:path";
 
 import { compareGeoms, mergeVisualRows } from "./compare";
 import { createFolioExtractor } from "./folioExtract";
-import { getWordPagePngs, getWordTruth } from "./wordTruth";
+import { getReferenceRenderer, isReferenceRendererId } from "./referenceRenderer";
 import { normalizeLineText, textSimilarity } from "./textNorm";
-import type { DocGeom, LineBox, PageGeom } from "./types";
+import type { DocGeom, LineBox, PageGeom, ReferenceRendererId } from "./types";
 
 type InspectFlags = {
   doc?: string;
@@ -21,6 +21,7 @@ type InspectFlags = {
   maxPages?: number;
   ledger: boolean;
   limit: number;
+  referenceId: ReferenceRendererId;
 };
 
 type Candidate = {
@@ -32,16 +33,16 @@ type Candidate = {
 
 type LedgerRow = {
   index: number;
-  wordText?: string;
+  referenceText?: string;
   folioText?: string;
   similarity?: number;
-  wordY?: number;
+  referenceY?: number;
   folioY?: number;
   deltaY?: number;
-  wordX?: number;
+  referenceX?: number;
   folioX?: number;
   deltaX?: number;
-  wordWidth?: number;
+  referenceWidth?: number;
   folioWidth?: number;
   deltaWidth?: number;
 };
@@ -53,11 +54,12 @@ type FolioExtractResult = Awaited<
 const usage = (): string =>
   [
     "Usage:",
-    "  bun parity/inspect.ts --doc file.docx --page 1 --text 'Definitions'",
-    "  bun parity/inspect.ts --doc file.docx --page 1 --ledger --max-pages 3",
+    "  bun parity/inspect.ts --doc file.docx --reference libreoffice --page 1 --text 'Definitions'",
+    "  bun parity/inspect.ts --doc file.docx --reference word --page 1 --ledger --max-pages 3",
     "",
     "Options:",
     "  --doc <path>        DOCX to inspect",
+    "  --reference <id>    libreoffice (default) or word",
     "  --page <n>          1-based page number (default: 1)",
     "  --text <text>       line text to search for",
     "  --max-pages <n>     cap Folio extraction",
@@ -66,11 +68,22 @@ const usage = (): string =>
   ].join("\n");
 
 const parseArgs = (argv: string[]): InspectFlags => {
-  const flags: InspectFlags = { page: 1, ledger: false, limit: 5 };
+  const flags: InspectFlags = {
+    page: 1,
+    ledger: false,
+    limit: 5,
+    referenceId: "libreoffice",
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--doc") {
       flags.doc = argv[++i];
+    } else if (arg === "--reference") {
+      const value = argv[++i];
+      if (!value || !isReferenceRendererId(value)) {
+        throw new Error("--reference requires libreoffice or word");
+      }
+      flags.referenceId = value;
     } else if (arg === "--page") {
       flags.page = Number.parseInt(argv[++i] ?? "", 10);
     } else if (arg === "--text") {
@@ -129,20 +142,20 @@ const candidatesFor = (lines: LineBox[], text: string, limit: number): Candidate
 const round = (value: number | undefined): number | undefined =>
   value === undefined ? undefined : Number(value.toFixed(3));
 
-const ledgerFor = (wordLines: LineBox[], folioLines: LineBox[]): LedgerRow[] => {
-  const max = Math.max(wordLines.length, folioLines.length);
+const ledgerFor = (referenceLines: LineBox[], folioLines: LineBox[]): LedgerRow[] => {
+  const max = Math.max(referenceLines.length, folioLines.length);
   const rows: LedgerRow[] = [];
   for (let i = 0; i < max; i++) {
-    const word = wordLines[i];
+    const reference = referenceLines[i];
     const folio = folioLines[i];
     rows.push({
       index: i + 1,
-      ...(word
+      ...(reference
         ? {
-            wordText: word.text,
-            wordY: round(word.yPt),
-            wordX: round(word.xPt),
-            wordWidth: round(word.widthPt),
+            referenceText: reference.text,
+            referenceY: round(reference.yPt),
+            referenceX: round(reference.xPt),
+            referenceWidth: round(reference.widthPt),
           }
         : {}),
       ...(folio
@@ -153,12 +166,12 @@ const ledgerFor = (wordLines: LineBox[], folioLines: LineBox[]): LedgerRow[] => 
             folioWidth: round(folio.widthPt),
           }
         : {}),
-      ...(word && folio
+      ...(reference && folio
         ? {
-            similarity: round(textSimilarity(word.normText, folio.normText)),
-            deltaY: round(folio.yPt - word.yPt),
-            deltaX: round(folio.xPt - word.xPt),
-            deltaWidth: round(folio.widthPt - word.widthPt),
+            similarity: round(textSimilarity(reference.normText, folio.normText)),
+            deltaY: round(folio.yPt - reference.yPt),
+            deltaX: round(folio.xPt - reference.xPt),
+            deltaWidth: round(folio.widthPt - reference.widthPt),
           }
         : {}),
     });
@@ -170,8 +183,9 @@ const main = async (): Promise<void> => {
   const flags = parseArgs(process.argv.slice(2));
   const doc = path.resolve(flags.doc!);
   const maxPages = flags.maxPages ?? Math.max(flags.page, 1);
+  const referenceRenderer = getReferenceRenderer(flags.referenceId);
 
-  const wordGeom = await getWordTruth(doc, {});
+  const referenceGeom = await referenceRenderer.getTruth(doc, {});
   const extractor = await createFolioExtractor();
   let folio: FolioExtractResult;
   try {
@@ -180,13 +194,16 @@ const main = async (): Promise<void> => {
     await extractor.close();
   }
 
-  const limitedWordGeom = { ...wordGeom, pages: wordGeom.pages.slice(0, maxPages) };
-  const comparison = compareGeoms(limitedWordGeom, folio.geom);
-  const wordLines = pageLines(wordGeom, flags.page);
+  const limitedReferenceGeom = {
+    ...referenceGeom,
+    pages: referenceGeom.pages.slice(0, maxPages),
+  };
+  const comparison = compareGeoms(limitedReferenceGeom, folio.geom);
+  const referenceLines = pageLines(referenceGeom, flags.page);
   const folioLines = pageLines(folio.geom, flags.page);
-  const wordPage = pageInfo(wordGeom, flags.page);
+  const referencePage = pageInfo(referenceGeom, flags.page);
   const folioPage = pageInfo(folio.geom, flags.page);
-  const wordPngs = await getWordPagePngs(doc, { maxPages });
+  const referencePngs = await referenceRenderer.getPagePngs(doc, { maxPages });
   const counts: Record<string, number> = {};
   for (const divergence of comparison.divergences) {
     counts[divergence.kind] = (counts[divergence.kind] ?? 0) + 1;
@@ -197,11 +214,15 @@ const main = async (): Promise<void> => {
     page: flags.page,
     score: comparison.score,
     counts,
+    referenceRenderer: {
+      id: referenceRenderer.id,
+      displayName: referenceRenderer.displayName,
+    },
     pages: {
-      word: wordPage && {
-        widthPt: wordPage.widthPt,
-        heightPt: wordPage.heightPt,
-        lines: wordLines.length,
+      reference: referencePage && {
+        widthPt: referencePage.widthPt,
+        heightPt: referencePage.heightPt,
+        lines: referenceLines.length,
       },
       folio: folioPage && {
         widthPt: folioPage.widthPt,
@@ -210,17 +231,17 @@ const main = async (): Promise<void> => {
       },
     },
     assets: {
-      wordPng: wordPngs[flags.page - 1],
+      referencePng: referencePngs[flags.page - 1],
       folioPng: folio.screenshotPaths[flags.page - 1],
     },
     ...(flags.text
       ? {
           query: flags.text,
-          wordCandidates: candidatesFor(wordLines, flags.text, flags.limit),
+          referenceCandidates: candidatesFor(referenceLines, flags.text, flags.limit),
           folioCandidates: candidatesFor(folioLines, flags.text, flags.limit),
         }
       : {}),
-    ...(flags.ledger ? { ledger: ledgerFor(wordLines, folioLines) } : {}),
+    ...(flags.ledger ? { ledger: ledgerFor(referenceLines, folioLines) } : {}),
   };
 
   console.log(JSON.stringify(result, null, 2));

--- a/parity/inspect.ts
+++ b/parity/inspect.ts
@@ -185,7 +185,7 @@ const main = async (): Promise<void> => {
   const maxPages = flags.maxPages ?? Math.max(flags.page, 1);
   const referenceRenderer = getReferenceRenderer(flags.referenceId);
 
-  const referenceGeom = await referenceRenderer.getTruth(doc, {});
+  const referenceGeom = await referenceRenderer.getGeometry(doc, {});
   const extractor = await createFolioExtractor();
   let folio: FolioExtractResult;
   try {

--- a/parity/libreOfficeReference.ts
+++ b/parity/libreOfficeReference.ts
@@ -26,14 +26,14 @@ const STEXT_XML_FILENAME = "libreoffice-stext.xml";
 const GEOM_JSON_FILENAME = "libreoffice-geom.json";
 const PAGES_DIRNAME = "libreoffice-pages";
 
-export type LibreOfficeTruthStage = "availability" | "export" | "extract";
+export type LibreOfficeReferenceStage = "availability" | "export" | "extract";
 
-export class LibreOfficeTruthError extends Error {
-  readonly stage: LibreOfficeTruthStage;
+export class LibreOfficeReferenceError extends Error {
+  readonly stage: LibreOfficeReferenceStage;
 
-  constructor(message: string, stage: LibreOfficeTruthStage) {
+  constructor(message: string, stage: LibreOfficeReferenceStage) {
     super(message);
-    this.name = "LibreOfficeTruthError";
+    this.name = "LibreOfficeReferenceError";
     this.stage = stage;
   }
 }
@@ -60,7 +60,7 @@ export const getLibreOfficeVersion = async (): Promise<string | null> => {
 
   const proc = Bun.spawn([binary, "--headless", "--version"], {
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "ignore",
   });
   const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
   const version = stdout.trim().replace(/^LibreOffice\s+/u, "");
@@ -98,7 +98,7 @@ export const buildLibreOfficeExportArgs = ({
 const exportViaLibreOffice = async (docxPath: string, destPdfPath: string): Promise<void> => {
   const binary = await getLibreOfficeBinary();
   if (binary === null) {
-    throw new LibreOfficeTruthError(
+    throw new LibreOfficeReferenceError(
       "LibreOffice is not available on this machine.",
       "availability",
     );
@@ -134,13 +134,13 @@ const exportViaLibreOffice = async (docxPath: string, destPdfPath: string): Prom
     clearTimeout(timeout);
 
     if (timedOut) {
-      throw new LibreOfficeTruthError(
+      throw new LibreOfficeReferenceError(
         `LibreOffice export timed out after ${EXPORT_TIMEOUT_MS}ms for ${docxPath}`,
         "export",
       );
     }
     if (exitCode !== 0) {
-      throw new LibreOfficeTruthError(
+      throw new LibreOfficeReferenceError(
         `LibreOffice export failed for ${docxPath} (exit ${exitCode})`,
         "export",
       );
@@ -148,7 +148,7 @@ const exportViaLibreOffice = async (docxPath: string, destPdfPath: string): Prom
 
     const output = Bun.file(outputPath);
     if (!(await output.exists()) || output.size === 0) {
-      throw new LibreOfficeTruthError(
+      throw new LibreOfficeReferenceError(
         `LibreOffice export produced no PDF for ${docxPath}`,
         "export",
       );
@@ -159,7 +159,7 @@ const exportViaLibreOffice = async (docxPath: string, destPdfPath: string): Prom
   }
 };
 
-export const getLibreOfficeTruth = async (
+export const getLibreOfficeGeometry = async (
   docxPath: string,
   options: { refresh?: boolean } = {},
 ): Promise<DocGeom> => {
@@ -175,7 +175,7 @@ export const getLibreOfficeTruth = async (
   }
 
   if (!(await isLibreOfficeAvailable())) {
-    throw new LibreOfficeTruthError(
+    throw new LibreOfficeReferenceError(
       "LibreOffice and/or mutool are not available on this machine.",
       "availability",
     );
@@ -190,8 +190,10 @@ export const getLibreOfficeTruth = async (
     pages = await extractPdfGeometry(pdfPath, xmlPath);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new LibreOfficeTruthError(message, "extract");
+    throw new LibreOfficeReferenceError(message, "extract");
   }
+
+  await rm(path.join(dir, PAGES_DIRNAME), { recursive: true, force: true });
 
   const [libreOfficeVersion, mutoolVersion] = await Promise.all([
     getLibreOfficeVersion(),
@@ -223,14 +225,19 @@ export const getLibreOfficePagePngs = async (
   const pdfPath = path.join(dir, PDF_FILENAME);
 
   if (!(await Bun.file(pdfPath).exists())) {
-    await getLibreOfficeTruth(absDocxPath);
+    await getLibreOfficeGeometry(absDocxPath, { refresh: true });
   }
 
   const pagesDir = path.join(dir, PAGES_DIRNAME);
   await mkdir(pagesDir, { recursive: true });
-  return await getPdfPagePngs({
-    pdfPath,
-    pagesDir,
-    ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
-  });
+  try {
+    return await getPdfPagePngs({
+      pdfPath,
+      pagesDir,
+      ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new LibreOfficeReferenceError(message, "extract");
+  }
 };

--- a/parity/libreOfficeReference.ts
+++ b/parity/libreOfficeReference.ts
@@ -170,7 +170,7 @@ export const getLibreOfficeGeometry = async (
 
   const geomPath = path.join(dir, GEOM_JSON_FILENAME);
   if (!(options.refresh ?? false)) {
-    const cached = await readCachedGeom(geomPath, absDocxPath);
+    const cached = await readCachedGeom({ geomPath, absDocxPath });
     if (cached) return cached;
   }
 
@@ -187,7 +187,7 @@ export const getLibreOfficeGeometry = async (
   const xmlPath = path.join(dir, STEXT_XML_FILENAME);
   let pages;
   try {
-    pages = await extractPdfGeometry(pdfPath, xmlPath);
+    pages = await extractPdfGeometry({ pdfPath, xmlPath });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new LibreOfficeReferenceError(message, "extract");

--- a/parity/libreOfficeTruth.ts
+++ b/parity/libreOfficeTruth.ts
@@ -1,0 +1,236 @@
+/**
+ * LibreOffice reference renderer: convert DOCX to PDF with an isolated,
+ * headless Writer process, then extract the shared comparison geometry.
+ */
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  cacheDirFor,
+  extractPdfGeometry,
+  getMutoolVersion,
+  getPdfPagePngs,
+  readCachedGeom,
+  sha256OfFile,
+} from "./pdfReference";
+import type { DocGeom } from "./types";
+
+const LIBREOFFICE_APP_BINARY = "/Applications/LibreOffice.app/Contents/MacOS/soffice";
+const EXPORT_TIMEOUT_MS = 180_000;
+
+const PDF_FILENAME = "libreoffice.pdf";
+const STEXT_XML_FILENAME = "libreoffice-stext.xml";
+const GEOM_JSON_FILENAME = "libreoffice-geom.json";
+const PAGES_DIRNAME = "libreoffice-pages";
+
+export type LibreOfficeTruthStage = "availability" | "export" | "extract";
+
+export class LibreOfficeTruthError extends Error {
+  readonly stage: LibreOfficeTruthStage;
+
+  constructor(message: string, stage: LibreOfficeTruthStage) {
+    super(message);
+    this.name = "LibreOfficeTruthError";
+    this.stage = stage;
+  }
+}
+
+const getLibreOfficeBinary = async (): Promise<string | null> => {
+  const fromPath = Bun.which("soffice") ?? Bun.which("libreoffice");
+  if (fromPath !== null) return fromPath;
+  return (await Bun.file(LIBREOFFICE_APP_BINARY).exists()) ? LIBREOFFICE_APP_BINARY : null;
+};
+
+export const isLibreOfficeAvailable = async (): Promise<boolean> =>
+  (await getLibreOfficeBinary()) !== null && Bun.which("mutool") !== null;
+
+let cachedLibreOfficeVersion: string | null | undefined;
+
+export const getLibreOfficeVersion = async (): Promise<string | null> => {
+  if (cachedLibreOfficeVersion !== undefined) return cachedLibreOfficeVersion;
+
+  const binary = await getLibreOfficeBinary();
+  if (binary === null) {
+    cachedLibreOfficeVersion = null;
+    return cachedLibreOfficeVersion;
+  }
+
+  const proc = Bun.spawn([binary, "--headless", "--version"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+  const version = stdout.trim().replace(/^LibreOffice\s+/u, "");
+  cachedLibreOfficeVersion = exitCode === 0 && version !== "" ? version : null;
+  return cachedLibreOfficeVersion;
+};
+
+type BuildLibreOfficeExportArgsOptions = {
+  binary: string;
+  inputPath: string;
+  outputDir: string;
+  profileDir: string;
+};
+
+export const buildLibreOfficeExportArgs = ({
+  binary,
+  inputPath,
+  outputDir,
+  profileDir,
+}: BuildLibreOfficeExportArgsOptions): string[] => [
+  binary,
+  "--headless",
+  "--nologo",
+  "--nodefault",
+  "--nofirststartwizard",
+  "--norestore",
+  `-env:UserInstallation=${pathToFileURL(profileDir).href}`,
+  "--convert-to",
+  "pdf:writer_pdf_Export",
+  "--outdir",
+  outputDir,
+  inputPath,
+];
+
+const exportViaLibreOffice = async (docxPath: string, destPdfPath: string): Promise<void> => {
+  const binary = await getLibreOfficeBinary();
+  if (binary === null) {
+    throw new LibreOfficeTruthError(
+      "LibreOffice is not available on this machine.",
+      "availability",
+    );
+  }
+
+  const workDir = await mkdtemp(path.join(tmpdir(), "folio-libreoffice-"));
+  const inputPath = path.join(workDir, "input.docx");
+  const outputPath = path.join(workDir, "input.pdf");
+  const profileDir = path.join(workDir, "profile");
+  await mkdir(profileDir, { recursive: true });
+  await Bun.write(inputPath, Bun.file(docxPath));
+
+  try {
+    const proc = Bun.spawn(
+      buildLibreOfficeExportArgs({
+        binary,
+        inputPath,
+        outputDir: workDir,
+        profileDir,
+      }),
+      // LibreOffice may hand conversion to a child process that keeps inherited
+      // pipe descriptors open after the launcher exits. Ignoring output avoids
+      // waiting forever for EOF after a successful conversion.
+      { stdout: "ignore", stderr: "ignore" },
+    );
+
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, EXPORT_TIMEOUT_MS);
+    const exitCode = await proc.exited;
+    clearTimeout(timeout);
+
+    if (timedOut) {
+      throw new LibreOfficeTruthError(
+        `LibreOffice export timed out after ${EXPORT_TIMEOUT_MS}ms for ${docxPath}`,
+        "export",
+      );
+    }
+    if (exitCode !== 0) {
+      throw new LibreOfficeTruthError(
+        `LibreOffice export failed for ${docxPath} (exit ${exitCode})`,
+        "export",
+      );
+    }
+
+    const output = Bun.file(outputPath);
+    if (!(await output.exists()) || output.size === 0) {
+      throw new LibreOfficeTruthError(
+        `LibreOffice export produced no PDF for ${docxPath}`,
+        "export",
+      );
+    }
+    await Bun.write(destPdfPath, output);
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+};
+
+export const getLibreOfficeTruth = async (
+  docxPath: string,
+  options: { refresh?: boolean } = {},
+): Promise<DocGeom> => {
+  const absDocxPath = path.resolve(docxPath);
+  const sha256 = await sha256OfFile(absDocxPath);
+  const dir = cacheDirFor(sha256);
+  await mkdir(dir, { recursive: true });
+
+  const geomPath = path.join(dir, GEOM_JSON_FILENAME);
+  if (!(options.refresh ?? false)) {
+    const cached = await readCachedGeom(geomPath, absDocxPath);
+    if (cached) return cached;
+  }
+
+  if (!(await isLibreOfficeAvailable())) {
+    throw new LibreOfficeTruthError(
+      "LibreOffice and/or mutool are not available on this machine.",
+      "availability",
+    );
+  }
+
+  const pdfPath = path.join(dir, PDF_FILENAME);
+  await exportViaLibreOffice(absDocxPath, pdfPath);
+
+  const xmlPath = path.join(dir, STEXT_XML_FILENAME);
+  let pages;
+  try {
+    pages = await extractPdfGeometry(pdfPath, xmlPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new LibreOfficeTruthError(message, "extract");
+  }
+
+  const [libreOfficeVersion, mutoolVersion] = await Promise.all([
+    getLibreOfficeVersion(),
+    getMutoolVersion(),
+  ]);
+  const geom: DocGeom = {
+    source: "libreoffice",
+    file: absDocxPath,
+    pages,
+    meta: {
+      libreOfficeVersion: libreOfficeVersion ?? "",
+      mutool: mutoolVersion,
+      cachedAt: new Date().toISOString(),
+      sha256,
+    },
+  };
+
+  await Bun.write(geomPath, JSON.stringify(geom, null, 2));
+  return geom;
+};
+
+export const getLibreOfficePagePngs = async (
+  docxPath: string,
+  options: { maxPages?: number } = {},
+): Promise<string[]> => {
+  const absDocxPath = path.resolve(docxPath);
+  const sha256 = await sha256OfFile(absDocxPath);
+  const dir = cacheDirFor(sha256);
+  const pdfPath = path.join(dir, PDF_FILENAME);
+
+  if (!(await Bun.file(pdfPath).exists())) {
+    await getLibreOfficeTruth(absDocxPath);
+  }
+
+  const pagesDir = path.join(dir, PAGES_DIRNAME);
+  await mkdir(pagesDir, { recursive: true });
+  return await getPdfPagePngs({
+    pdfPath,
+    pagesDir,
+    ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
+  });
+};

--- a/parity/pdfReference.ts
+++ b/parity/pdfReference.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared PDF extraction for external DOCX reference renderers.
+ *
+ * A renderer adapter is responsible only for producing a PDF. This module
+ * turns that PDF into the normalized line geometry and page images consumed
+ * by the comparison/reporting pipeline.
+ */
+
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { CACHE_DIR } from "./config";
+import { parseStextXml } from "./stextParse";
+import { normalizeLineText } from "./textNorm";
+import type { DocGeom, PageGeom } from "./types";
+
+const PNG_DPI = 96;
+const PAGE_PNG_RE = /^p(\d+)\.png$/;
+
+export const sha256OfFile = async (filePath: string): Promise<string> => {
+  const data = await Bun.file(filePath).arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(data);
+  return hasher.digest("hex");
+};
+
+export const cacheDirFor = (sha256: string): string => path.join(CACHE_DIR, sha256);
+
+/** `mutool -v` prints its version to stderr, not stdout. */
+export const getMutoolVersion = async (): Promise<string> => {
+  const proc = Bun.spawn(["mutool", "-v"], { stdout: "ignore", stderr: "pipe" });
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+  return stderr.trim();
+};
+
+export const readCachedGeom = async (
+  geomPath: string,
+  absDocxPath: string,
+): Promise<DocGeom | null> => {
+  const file = Bun.file(geomPath);
+  if (!(await file.exists())) return null;
+  const geom = (await file.json()) as DocGeom;
+  return Object.assign({}, geom, {
+    file: absDocxPath,
+    pages: geom.pages.map((page) =>
+      Object.assign({}, page, {
+        lines: page.lines.map((line) =>
+          Object.assign({}, line, { normText: normalizeLineText(line.text) }),
+        ),
+      }),
+    ),
+  });
+};
+
+export const extractPdfGeometry = async (pdfPath: string, xmlPath: string): Promise<PageGeom[]> => {
+  const proc = Bun.spawn(["mutool", "draw", "-F", "stext", "-o", xmlPath, pdfPath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `mutool stext extraction failed for ${pdfPath} (exit ${exitCode}): ${stderr.trim()}`,
+    );
+  }
+
+  return parseStextXml(await Bun.file(xmlPath).text());
+};
+
+const listPagePngs = async (pagesDir: string): Promise<string[]> => {
+  let entries: string[];
+  try {
+    entries = await readdir(pagesDir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => PAGE_PNG_RE.test(name))
+    .sort((a, b) => pageNumberOfPngName(a) - pageNumberOfPngName(b))
+    .map((name) => path.join(pagesDir, name));
+};
+
+const pageNumberOfPngName = (filename: string): number => {
+  const match = PAGE_PNG_RE.exec(filename);
+  return match?.[1] === undefined ? 0 : Number(match[1]);
+};
+
+const renderPagePngs = async (
+  pdfPath: string,
+  pagesDir: string,
+  options: { maxPages?: number },
+): Promise<void> => {
+  const pageRange = options.maxPages === undefined ? [] : [`1-${options.maxPages}`];
+  const proc = Bun.spawn(
+    [
+      "mutool",
+      "draw",
+      "-r",
+      String(PNG_DPI),
+      "-o",
+      path.join(pagesDir, "p%d.png"),
+      pdfPath,
+      ...pageRange,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `mutool PNG rendering failed for ${pdfPath} (exit ${exitCode}): ${stderr.trim()}`,
+    );
+  }
+};
+
+type GetPdfPagePngsOptions = {
+  pdfPath: string;
+  pagesDir: string;
+  maxPages?: number;
+};
+
+export const getPdfPagePngs = async ({
+  pdfPath,
+  pagesDir,
+  maxPages,
+}: GetPdfPagePngsOptions): Promise<string[]> => {
+  const existing = await listPagePngs(pagesDir);
+  if (maxPages !== undefined && existing.length >= maxPages) {
+    return existing.slice(0, maxPages);
+  }
+  if (maxPages === undefined && existing.length > 0) return existing;
+
+  await renderPagePngs(pdfPath, pagesDir, maxPages === undefined ? {} : { maxPages });
+  const rendered = await listPagePngs(pagesDir);
+  return maxPages === undefined ? rendered : rendered.slice(0, maxPages);
+};

--- a/parity/pdfReference.ts
+++ b/parity/pdfReference.ts
@@ -55,7 +55,7 @@ export const readCachedGeom = async (
 
 export const extractPdfGeometry = async (pdfPath: string, xmlPath: string): Promise<PageGeom[]> => {
   const proc = Bun.spawn(["mutool", "draw", "-F", "stext", "-o", xmlPath, pdfPath], {
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
   const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
@@ -103,7 +103,7 @@ const renderPagePngs = async (
       pdfPath,
       ...pageRange,
     ],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "ignore", stderr: "pipe" },
   );
   const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
   if (exitCode !== 0) {

--- a/parity/pdfReference.ts
+++ b/parity/pdfReference.ts
@@ -35,10 +35,15 @@ export const getMutoolVersion = async (): Promise<string> => {
   return stderr.trim();
 };
 
-export const readCachedGeom = async (
-  geomPath: string,
-  absDocxPath: string,
-): Promise<DocGeom | null> => {
+type ReadCachedGeomOptions = {
+  geomPath: string;
+  absDocxPath: string;
+};
+
+export const readCachedGeom = async ({
+  geomPath,
+  absDocxPath,
+}: ReadCachedGeomOptions): Promise<DocGeom | null> => {
   const file = Bun.file(geomPath);
   if (!(await file.exists())) return null;
   const geom = (await file.json()) as DocGeom;
@@ -54,7 +59,15 @@ export const readCachedGeom = async (
   });
 };
 
-export const extractPdfGeometry = async (pdfPath: string, xmlPath: string): Promise<PageGeom[]> => {
+type ExtractPdfGeometryOptions = {
+  pdfPath: string;
+  xmlPath: string;
+};
+
+export const extractPdfGeometry = async ({
+  pdfPath,
+  xmlPath,
+}: ExtractPdfGeometryOptions): Promise<PageGeom[]> => {
   const proc = Bun.spawn(["mutool", "draw", "-F", "stext", "-o", xmlPath, pdfPath], {
     stdout: "ignore",
     stderr: "pipe",

--- a/parity/pdfReference.ts
+++ b/parity/pdfReference.ts
@@ -16,6 +16,7 @@ import type { DocGeom, PageGeom } from "./types";
 
 const PNG_DPI = 96;
 const PAGE_PNG_RE = /^p(\d+)\.png$/;
+const COMPLETE_PAGE_COUNT_FILENAME = ".complete-page-count";
 
 export const sha256OfFile = async (filePath: string): Promise<string> => {
   const data = await Bun.file(filePath).arrayBuffer();
@@ -86,6 +87,37 @@ const pageNumberOfPngName = (filename: string): number => {
   return match?.[1] === undefined ? 0 : Number(match[1]);
 };
 
+const readCompletePageCount = async (pagesDir: string): Promise<number | null> => {
+  const marker = Bun.file(path.join(pagesDir, COMPLETE_PAGE_COUNT_FILENAME));
+  if (!(await marker.exists())) return null;
+
+  const value = (await marker.text()).trim();
+  if (!/^\d+$/u.test(value)) return null;
+
+  const count = Number(value);
+  return Number.isSafeInteger(count) ? count : null;
+};
+
+type CanReusePagePngCacheOptions = {
+  existing: string[];
+  completePageCount: number | null;
+  maxPages?: number;
+};
+
+export const canReusePagePngCache = ({
+  existing,
+  completePageCount,
+  maxPages,
+}: CanReusePagePngCacheOptions): boolean => {
+  const hasSequentialPages = existing.every(
+    (filename, index) => pageNumberOfPngName(path.basename(filename)) === index + 1,
+  );
+  if (!hasSequentialPages) return false;
+
+  if (completePageCount !== null && existing.length === completePageCount) return true;
+  return maxPages !== undefined && existing.length >= maxPages;
+};
+
 const renderPagePngs = async (
   pdfPath: string,
   pagesDir: string,
@@ -125,12 +157,21 @@ export const getPdfPagePngs = async ({
   maxPages,
 }: GetPdfPagePngsOptions): Promise<string[]> => {
   const existing = await listPagePngs(pagesDir);
-  if (maxPages !== undefined && existing.length >= maxPages) {
-    return existing.slice(0, maxPages);
+  const completePageCount = await readCompletePageCount(pagesDir);
+  if (
+    canReusePagePngCache({
+      existing,
+      completePageCount,
+      ...(maxPages === undefined ? {} : { maxPages }),
+    })
+  ) {
+    return maxPages === undefined ? existing : existing.slice(0, maxPages);
   }
-  if (maxPages === undefined && existing.length > 0) return existing;
 
   await renderPagePngs(pdfPath, pagesDir, maxPages === undefined ? {} : { maxPages });
   const rendered = await listPagePngs(pagesDir);
+  if (maxPages === undefined) {
+    await Bun.write(path.join(pagesDir, COMPLETE_PAGE_COUNT_FILENAME), `${rendered.length}\n`);
+  }
   return maxPages === undefined ? rendered : rendered.slice(0, maxPages);
 };

--- a/parity/referenceRenderer.ts
+++ b/parity/referenceRenderer.ts
@@ -2,10 +2,10 @@
 
 import {
   getLibreOfficePagePngs,
-  getLibreOfficeTruth,
+  getLibreOfficeGeometry,
   getLibreOfficeVersion,
   isLibreOfficeAvailable,
-} from "./libreOfficeTruth";
+} from "./libreOfficeReference";
 import type { DocGeom, ReferenceRendererId } from "./types";
 import { getWordPagePngs, getWordTruth, getWordVersion, isWordAvailable } from "./wordTruth";
 
@@ -15,7 +15,7 @@ export type ReferenceRenderer = {
   installHint: string;
   isAvailable: () => Promise<boolean>;
   getVersion: () => Promise<string | null>;
-  getTruth: (docxPath: string, options?: { refresh?: boolean }) => Promise<DocGeom>;
+  getGeometry: (docxPath: string, options?: { refresh?: boolean }) => Promise<DocGeom>;
   getPagePngs: (docxPath: string, options?: { maxPages?: number }) => Promise<string[]>;
 };
 
@@ -25,7 +25,7 @@ const LIBREOFFICE_RENDERER: ReferenceRenderer = {
   installHint: "Install LibreOffice from https://www.libreoffice.org/download/",
   isAvailable: isLibreOfficeAvailable,
   getVersion: getLibreOfficeVersion,
-  getTruth: getLibreOfficeTruth,
+  getGeometry: getLibreOfficeGeometry,
   getPagePngs: getLibreOfficePagePngs,
 };
 
@@ -35,7 +35,7 @@ const WORD_RENDERER: ReferenceRenderer = {
   installHint: "Install Word for Mac from https://www.microsoft.com/microsoft-365/word",
   isAvailable: isWordAvailable,
   getVersion: getWordVersion,
-  getTruth: getWordTruth,
+  getGeometry: getWordTruth,
   getPagePngs: getWordPagePngs,
 };
 
@@ -43,6 +43,10 @@ export const isReferenceRendererId = (value: string): value is ReferenceRenderer
   value === "libreoffice" || value === "word";
 
 export const getReferenceRenderer = (id: ReferenceRendererId): ReferenceRenderer => {
-  if (id === "libreoffice") return LIBREOFFICE_RENDERER;
-  return WORD_RENDERER;
+  switch (id) {
+    case "libreoffice":
+      return LIBREOFFICE_RENDERER;
+    case "word":
+      return WORD_RENDERER;
+  }
 };

--- a/parity/referenceRenderer.ts
+++ b/parity/referenceRenderer.ts
@@ -1,0 +1,48 @@
+/** External DOCX renderers that can serve as explicit comparison references. */
+
+import {
+  getLibreOfficePagePngs,
+  getLibreOfficeTruth,
+  getLibreOfficeVersion,
+  isLibreOfficeAvailable,
+} from "./libreOfficeTruth";
+import type { DocGeom, ReferenceRendererId } from "./types";
+import { getWordPagePngs, getWordTruth, getWordVersion, isWordAvailable } from "./wordTruth";
+
+export type ReferenceRenderer = {
+  id: ReferenceRendererId;
+  displayName: string;
+  installHint: string;
+  isAvailable: () => Promise<boolean>;
+  getVersion: () => Promise<string | null>;
+  getTruth: (docxPath: string, options?: { refresh?: boolean }) => Promise<DocGeom>;
+  getPagePngs: (docxPath: string, options?: { maxPages?: number }) => Promise<string[]>;
+};
+
+const LIBREOFFICE_RENDERER: ReferenceRenderer = {
+  id: "libreoffice",
+  displayName: "LibreOffice Writer",
+  installHint: "Install LibreOffice from https://www.libreoffice.org/download/",
+  isAvailable: isLibreOfficeAvailable,
+  getVersion: getLibreOfficeVersion,
+  getTruth: getLibreOfficeTruth,
+  getPagePngs: getLibreOfficePagePngs,
+};
+
+const WORD_RENDERER: ReferenceRenderer = {
+  id: "word",
+  displayName: "Microsoft Word",
+  installHint: "Install Word for Mac from https://www.microsoft.com/microsoft-365/word",
+  isAvailable: isWordAvailable,
+  getVersion: getWordVersion,
+  getTruth: getWordTruth,
+  getPagePngs: getWordPagePngs,
+};
+
+export const isReferenceRendererId = (value: string): value is ReferenceRendererId =>
+  value === "libreoffice" || value === "word";
+
+export const getReferenceRenderer = (id: ReferenceRendererId): ReferenceRenderer => {
+  if (id === "libreoffice") return LIBREOFFICE_RENDERER;
+  return WORD_RENDERER;
+};

--- a/parity/report.ts
+++ b/parity/report.ts
@@ -1,14 +1,14 @@
 /**
- * Word rendering parity engine: static HTML report writer.
+ * Multi-engine DOCX comparison: static HTML report writer.
  *
  * Renders a `CorpusReport` (see `types.ts`) plus per-doc rendered assets into
  * a self-contained static site under `REPORT_DIR` (`config.ts`): an
  * `index.html` overview (per-doc scores, cross-corpus clusters) and one
- * `doc-<slug>.html` detail page per document (side-by-side Word/folio page
- * renderings with line-box overlays, plus the grouped divergence list).
+ * `doc-<slug>.html` detail page per document (side-by-side reference/folio
+ * page renderings with line-box overlays, plus the grouped divergence list).
  *
  * Deliberately imports only `./types` (and `./config` for the output path):
- * this module must stay testable standalone, without the Word/folio/compare
+ * this module must stay testable standalone, without the renderer/folio/compare
  * extractors that produce its input.
  */
 import { copyFile, mkdir, rm } from "node:fs/promises";
@@ -27,9 +27,9 @@ import type {
 } from "./types";
 
 export type DocAssets = {
-  wordPagePngs: string[];
+  referencePagePngs: string[];
   folioPagePngs: string[];
-  wordGeom: DocGeom;
+  referenceGeom: DocGeom;
   folioGeom: DocGeom;
 };
 
@@ -56,7 +56,7 @@ const DIVERGENCE_KIND_ORDER: DivergenceKind[] = [
 
 /** Per-doc page assets after copying into REPORT_DIR, relative-path or null (missing). */
 type CopiedPageAssets = {
-  wordPngs: (string | null)[];
+  referencePngs: (string | null)[];
   folioPngs: (string | null)[];
 };
 
@@ -77,9 +77,9 @@ export const writeHtmlReport = async (
     const docAssets = assets.get(result.file);
     const copied = docAssets
       ? await copyDocAssets(slug, docAssets)
-      : { wordPngs: [], folioPngs: [] };
+      : { referencePngs: [], folioPngs: [] };
 
-    const html = renderDocPage(result, docAssets, copied);
+    const html = renderDocPage(result, docAssets, copied, report.reference.displayName);
     await Bun.write(path.join(REPORT_DIR, `doc-${slug}.html`), html);
   }
 
@@ -131,14 +131,14 @@ const copyDocAssets = async (slug: string, docAssets: DocAssets): Promise<Copied
     }
   };
 
-  const wordPngs = await Promise.all(
-    docAssets.wordPagePngs.map((src, i) => copyOne(src, `word-${i + 1}.png`)),
+  const referencePngs = await Promise.all(
+    docAssets.referencePagePngs.map((src, i) => copyOne(src, `reference-${i + 1}.png`)),
   );
   const folioPngs = await Promise.all(
     docAssets.folioPagePngs.map((src, i) => copyOne(src, `folio-${i + 1}.png`)),
   );
 
-  return { wordPngs, folioPngs };
+  return { referencePngs, folioPngs };
 };
 
 // --- shared helpers ---
@@ -172,11 +172,11 @@ const scoreColor = (score: number): string => {
 const divergenceText = (divergence: Divergence): string => {
   switch (divergence.kind) {
     case "page-count":
-      return `page count: word=${divergence.word}, folio=${divergence.folio}`;
+      return `page count: reference=${divergence.reference}, folio=${divergence.folio}`;
     case "pagination":
       return divergence.text;
     case "line-break":
-      return `${divergence.wordTexts.join(" ")} | ${divergence.folioTexts.join(" ")}`;
+      return `${divergence.referenceTexts.join(" ")} | ${divergence.folioTexts.join(" ")}`;
     case "missing-line":
     case "extra-line":
     case "x-drift":
@@ -184,7 +184,7 @@ const divergenceText = (divergence: Divergence): string => {
     case "width-drift":
       return divergence.text;
     case "text-mismatch":
-      return `${divergence.wordText} → ${divergence.folioText}`;
+      return `${divergence.referenceText} → ${divergence.folioText}`;
     default: {
       const exhaustive: never = divergence;
       return exhaustive;
@@ -198,7 +198,7 @@ const divergencePage = (divergence: Divergence): string => {
     case "page-count":
       return "—";
     case "pagination":
-      return `${divergence.wordPage} → ${divergence.folioPage}`;
+      return `${divergence.referencePage} → ${divergence.folioPage}`;
     default:
       return String(divergence.page);
   }
@@ -233,24 +233,26 @@ const renderIndex = (report: CorpusReport, slugs: Map<string, string>): string =
   const rows = report.results.map((result) => renderIndexRow(result, slugs)).join("\n");
   const clusterRows = report.clusters.map(renderClusterRow).join("\n");
   const docCount = report.results.length;
+  const referenceVersion = report.reference.version ?? "unknown version";
 
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>folio vs Word parity report</title>
+<title>folio DOCX interoperability report</title>
 <style>${STYLE}</style>
 </head>
 <body>
 <header>
-<h1>Word rendering parity report</h1>
-<p>Generated ${escapeHtml(report.generatedAt)} &middot; Word ${escapeHtml(report.wordVersion ?? "unknown")} &middot; ${docCount} document${docCount === 1 ? "" : "s"}</p>
+<h1>DOCX rendering interoperability report</h1>
+<p>Folio compared with ${escapeHtml(report.reference.displayName)} ${escapeHtml(referenceVersion)} &middot; generated ${escapeHtml(report.generatedAt)} &middot; ${docCount} document${docCount === 1 ? "" : "s"}</p>
+<p class="method-note">The external renderer is a comparison reference, not a specification oracle. Agreement is interoperability evidence; OOXML conformance is assessed separately against the standard and structural validators.</p>
 </header>
 <main>
 <section>
 <h2>Documents</h2>
 <table>
-<thead><tr><th>Document</th><th>Score</th><th>Pages (word / folio)</th><th>Lines matched</th><th>Median Y offset (pt)</th><th>Divergences</th></tr></thead>
+<thead><tr><th>Document</th><th>Score</th><th>Pages (reference / folio)</th><th>Lines matched</th><th>Median Y offset (pt)</th><th>Divergences</th></tr></thead>
 <tbody>
 ${rows.length > 0 ? rows : `<tr><td colspan="6">No documents.</td></tr>`}
 </tbody>
@@ -280,8 +282,8 @@ const renderIndexRow = (result: FeatureAttributedResult, slugs: Map<string, stri
   return `<tr>
 <td><a href="doc-${escapeHtml(slug)}.html">${escapeHtml(name)}</a></td>
 <td><span class="score" style="color:${scoreColor(result.score)}">${pct}%</span></td>
-<td>${result.wordPages} / ${result.folioPages}</td>
-<td>${result.matchedLines} / ${result.totalWordLines}</td>
+<td>${result.referencePages} / ${result.folioPages}</td>
+<td>${result.matchedLines} / ${result.totalReferenceLines}</td>
 <td>${result.medianYOffsetPt.toFixed(2)}</td>
 <td>${counts.length > 0 ? escapeHtml(counts) : "—"}</td>
 </tr>`;
@@ -305,20 +307,21 @@ const renderClusterRow = (cluster: Cluster): string => {
 
 // --- doc-<slug>.html ---
 
-type PanelSide = "word" | "folio";
+type PanelSide = "reference" | "folio";
 
 const renderDocPage = (
   result: FeatureAttributedResult,
   docAssets: DocAssets | undefined,
   copied: CopiedPageAssets,
+  referenceDisplayName: string,
 ): string => {
   const name = path.basename(result.file);
   const pageCount = docAssets
-    ? Math.max(docAssets.wordGeom.pages.length, docAssets.folioGeom.pages.length)
+    ? Math.max(docAssets.referenceGeom.pages.length, docAssets.folioGeom.pages.length)
     : 0;
 
   const pagePairs = Array.from({ length: pageCount }, (_, i) =>
-    renderPagePair(i, docAssets, copied),
+    renderPagePair(i, docAssets, copied, referenceDisplayName),
   ).join("\n");
 
   const banner =
@@ -337,7 +340,7 @@ const renderDocPage = (
 <header>
 <p><a href="index.html">&larr; back to summary</a></p>
 <h1>${escapeHtml(name)}</h1>
-<p>Score ${(result.score * 100).toFixed(1)}% &middot; ${result.matchedLines}/${result.totalWordLines} lines matched &middot; median Y offset ${result.medianYOffsetPt.toFixed(2)}pt</p>
+<p>Folio compared with ${escapeHtml(referenceDisplayName)} &middot; score ${(result.score * 100).toFixed(1)}% &middot; ${result.matchedLines}/${result.totalReferenceLines} lines matched &middot; median Y offset ${result.medianYOffsetPt.toFixed(2)}pt</p>
 </header>
 <main>
 ${banner}
@@ -367,33 +370,34 @@ const renderPagePair = (
   pageIndex: number,
   docAssets: DocAssets | undefined,
   copied: CopiedPageAssets,
+  referenceDisplayName: string,
 ): string => {
-  const wordPage = docAssets?.wordGeom.pages[pageIndex];
+  const referencePage = docAssets?.referenceGeom.pages[pageIndex];
   const folioPage = docAssets?.folioGeom.pages[pageIndex];
-  const wordImg = copied.wordPngs[pageIndex] ?? null;
+  const referenceImg = copied.referencePngs[pageIndex] ?? null;
   const folioImg = copied.folioPngs[pageIndex] ?? null;
 
-  const wordPanel = renderPanel({
-    side: "word",
+  const referencePanel = renderPanel({
+    side: "reference",
     pageIndex,
-    page: wordPage,
+    page: referencePage,
     otherPage: folioPage,
-    imgPath: wordImg,
-    label: `Word — page ${pageIndex + 1}`,
+    imgPath: referenceImg,
+    label: `${referenceDisplayName} — page ${pageIndex + 1}`,
   });
   const folioPanel = renderPanel({
     side: "folio",
     pageIndex,
     page: folioPage,
-    otherPage: wordPage,
+    otherPage: referencePage,
     imgPath: folioImg,
     label: `folio — page ${pageIndex + 1}`,
   });
 
-  return `<div class="page-pair">${wordPanel}${folioPanel}</div>`;
+  return `<div class="page-pair">${referencePanel}${folioPanel}</div>`;
 };
 
-/** Parameters for rendering one Word/folio page panel; kept local to renderPanel. */
+/** Parameters for rendering one reference/folio page panel. */
 type RenderPanelOptions = {
   side: PanelSide;
   pageIndex: number;
@@ -412,7 +416,7 @@ const renderPanel = ({
   label,
 }: RenderPanelOptions): string => {
   if (!page) {
-    const missingSide = side === "word" ? "Word" : "folio";
+    const missingSide = side === "reference" ? "reference" : "folio";
     return `<div class="page-panel placeholder-panel">
 <h3>${escapeHtml(label)}</h3>
 <div class="placeholder">No corresponding ${missingSide} page</div>
@@ -421,9 +425,9 @@ const renderPanel = ({
 
   const pageNum = pageIndex + 1;
   const crossId = `${side}-cross-${pageNum}`;
-  const otherLabel = side === "word" ? "folio" : "Word";
-  const primaryClass = side === "word" ? "word-boxes" : "folio-boxes";
-  const crossClass = side === "word" ? "folio-boxes" : "word-boxes";
+  const otherLabel = side === "reference" ? "folio" : "reference";
+  const primaryClass = side === "reference" ? "reference-boxes" : "folio-boxes";
+  const crossClass = side === "reference" ? "folio-boxes" : "reference-boxes";
 
   const primaryBoxes = renderBoxesSvgGroup(page.lines, primaryClass);
   const crossBoxes = otherPage
@@ -508,6 +512,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Ar
 header { padding: 24px 32px; background: #ffffff; border-bottom: 1px solid #d0d7de; }
 header h1 { margin: 0 0 4px; font-size: 1.5rem; }
 header p { margin: 0; color: #57606a; }
+.method-note { margin-top: 8px; max-width: 90ch; }
 main { padding: 24px 32px; }
 section { margin-bottom: 32px; }
 h2 { font-size: 1.15rem; border-bottom: 1px solid #d0d7de; padding-bottom: 6px; }
@@ -525,7 +530,7 @@ a:hover { text-decoration: underline; }
 .page-image-wrap { position: relative; width: 100%; background: #eaeef2; line-height: 0; }
 .page-image-wrap img { display: block; width: 100%; height: auto; }
 .page-image-wrap svg { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
-.word-boxes rect { stroke: #0969da; fill: none; stroke-width: 1; vector-effect: non-scaling-stroke; }
+.reference-boxes rect { stroke: #0969da; fill: none; stroke-width: 1; vector-effect: non-scaling-stroke; }
 .folio-boxes rect { stroke: #cf222e; fill: none; stroke-width: 1; vector-effect: non-scaling-stroke; }
 .placeholder { display: flex; align-items: center; justify-content: center; background: #eaeef2; color: #57606a; border: 1px dashed #9198a1; min-height: 160px; font-size: 0.85rem; }
 .placeholder-panel { flex: 1 1 0; }

--- a/parity/report.ts
+++ b/parity/report.ts
@@ -79,7 +79,12 @@ export const writeHtmlReport = async (
       ? await copyDocAssets(slug, docAssets)
       : { referencePngs: [], folioPngs: [] };
 
-    const html = renderDocPage(result, docAssets, copied, report.reference.displayName);
+    const html = renderDocPage({
+      result,
+      docAssets,
+      copied,
+      referenceDisplayName: report.reference.displayName,
+    });
     await Bun.write(path.join(REPORT_DIR, `doc-${slug}.html`), html);
   }
 
@@ -309,19 +314,26 @@ const renderClusterRow = (cluster: Cluster): string => {
 
 type PanelSide = "reference" | "folio";
 
-const renderDocPage = (
-  result: FeatureAttributedResult,
-  docAssets: DocAssets | undefined,
-  copied: CopiedPageAssets,
-  referenceDisplayName: string,
-): string => {
+type RenderDocPageOptions = {
+  result: FeatureAttributedResult;
+  docAssets: DocAssets | undefined;
+  copied: CopiedPageAssets;
+  referenceDisplayName: string;
+};
+
+const renderDocPage = ({
+  result,
+  docAssets,
+  copied,
+  referenceDisplayName,
+}: RenderDocPageOptions): string => {
   const name = path.basename(result.file);
   const pageCount = docAssets
     ? Math.max(docAssets.referenceGeom.pages.length, docAssets.folioGeom.pages.length)
     : 0;
 
-  const pagePairs = Array.from({ length: pageCount }, (_, i) =>
-    renderPagePair(i, docAssets, copied, referenceDisplayName),
+  const pagePairs = Array.from({ length: pageCount }, (_, pageIndex) =>
+    renderPagePair({ pageIndex, docAssets, copied, referenceDisplayName }),
   ).join("\n");
 
   const banner =
@@ -366,12 +378,19 @@ document.querySelectorAll(".cross-toggle").forEach((el) => {
 `;
 };
 
-const renderPagePair = (
-  pageIndex: number,
-  docAssets: DocAssets | undefined,
-  copied: CopiedPageAssets,
-  referenceDisplayName: string,
-): string => {
+type RenderPagePairOptions = {
+  pageIndex: number;
+  docAssets: DocAssets | undefined;
+  copied: CopiedPageAssets;
+  referenceDisplayName: string;
+};
+
+const renderPagePair = ({
+  pageIndex,
+  docAssets,
+  copied,
+  referenceDisplayName,
+}: RenderPagePairOptions): string => {
   const referencePage = docAssets?.referenceGeom.pages[pageIndex];
   const folioPage = docAssets?.folioGeom.pages[pageIndex];
   const referenceImg = copied.referencePngs[pageIndex] ?? null;

--- a/parity/types.ts
+++ b/parity/types.ts
@@ -1,13 +1,21 @@
 /**
- * Rendering parity engine: shared data contract.
+ * Multi-engine DOCX rendering comparison: shared data contract.
  *
  * All geometry is expressed in PDF points (1pt = 1/72in), page-relative with
- * the origin at the page's top-left corner. Reference geometry comes from
- * `mutool draw -F stext` over the exported PDF; folio-side geometry comes from
- * the painted playground DOM (CSS px at 96dpi, converted with the px-to-pt
+ * the origin at the page's top-left corner. Reference-renderer geometry comes
+ * from `mutool draw -F stext` over an exported PDF; folio-side geometry comes
+ * from the painted playground DOM (CSS px at 96dpi, converted with the px-to-pt
  * factor 72/96 after normalising against the page element width so playground
  * zoom cannot skew coordinates).
  */
+
+export type ReferenceRendererId = "libreoffice" | "word";
+
+export type ReferenceRendererInfo = {
+  id: ReferenceRendererId;
+  displayName: string;
+  version?: string;
+};
 
 export type Region = "body" | "header" | "footer" | "footnote" | "unknown";
 
@@ -18,9 +26,9 @@ export type LineBox = {
   normText: string;
   /** Left edge of the line's ink/text start, in pt from the page left. */
   xPt: number;
-  /** Top edge of the line box, in pt from the page top. Reference boxes are
-   * ink bounds and folio-side boxes are line-height boxes, so absolute yPt is
-   * only compared after per-page median-offset correction. */
+  /** Top edge of the line box, in pt from the page top. PDF-extracted boxes
+   * are ink bounds and folio-side boxes are line-height boxes, so absolute
+   * yPt is only compared after per-page median-offset correction. */
   yPt: number;
   widthPt: number;
   heightPt: number;
@@ -44,21 +52,21 @@ export type PageGeom = {
 };
 
 export type DocGeom = {
-  source: "word" | "folio";
+  source: ReferenceRendererId | "folio";
   /** Absolute path of the source .docx. */
   file: string;
   pages: PageGeom[];
-  /** Extractor provenance: word version, mutool version, playground URL, px-to-pt scale, ... */
+  /** Extractor provenance: renderer version, mutool version, playground URL, px-to-pt scale, ... */
   meta: Record<string, string>;
 };
 
-/** A divergence between the reference rendering and folio's rendering. */
+/** A divergence between an external reference renderer and folio. */
 export type Divergence =
-  | { kind: "page-count"; word: number; folio: number }
+  | { kind: "page-count"; reference: number; folio: number }
   /** Same line of text landed on different pages. */
-  | { kind: "pagination"; text: string; wordPage: number; folioPage: number }
+  | { kind: "pagination"; text: string; referencePage: number; folioPage: number }
   /** One reference line corresponds to 2+ folio lines, or vice versa. */
-  | { kind: "line-break"; page: number; wordTexts: string[]; folioTexts: string[] }
+  | { kind: "line-break"; page: number; referenceTexts: string[]; folioTexts: string[] }
   /** Line present in reference output but never matched in folio. */
   | { kind: "missing-line"; page: number; text: string }
   /** Line present in folio output but never matched in the reference. */
@@ -70,7 +78,7 @@ export type Divergence =
   /** Matched line's ink width differs (font metric / measurement divergence). */
   | { kind: "width-drift"; page: number; text: string; deltaPt: number }
   /** Lines aligned positionally but their text content differs. */
-  | { kind: "text-mismatch"; page: number; wordText: string; folioText: string };
+  | { kind: "text-mismatch"; page: number; referenceText: string; folioText: string };
 
 export type DivergenceKind = Divergence["kind"];
 
@@ -90,7 +98,7 @@ export type ComparisonTolerances = {
   yResidualPt: number;
   /** Max |width delta| in pt before width-drift. */
   widthPt: number;
-  /** Widths may also pass on relative terms: |delta| <= widthRelative * wordWidth. */
+  /** Widths may also pass on relative terms: |delta| <= widthRelative * referenceWidth. */
   widthRelative: number;
 };
 
@@ -99,9 +107,9 @@ export type ParityResult = {
   /** 0..1: fraction of reference lines matched to a folio line on the same page
    * with all geometric deltas within tolerance. */
   score: number;
-  wordPages: number;
+  referencePages: number;
   folioPages: number;
-  totalWordLines: number;
+  totalReferenceLines: number;
   matchedLines: number;
   /** Systematic per-doc vertical offset (median of per-line y deltas);
    * informational, already subtracted from y-drift residuals. */
@@ -133,7 +141,7 @@ export type Cluster = {
 
 export type CorpusReport = {
   generatedAt: string;
-  wordVersion?: string;
+  reference: ReferenceRendererInfo;
   results: FeatureAttributedResult[];
   clusters: Cluster[];
 };

--- a/parity/wordTruth.ts
+++ b/parity/wordTruth.ts
@@ -1,5 +1,5 @@
 /**
- * Word ground truth: export a .docx via the locally installed Microsoft Word
+ * Microsoft Word reference renderer: export a DOCX via the locally installed app
  * for Mac (scripted headlessly through AppleScript), extract per-line
  * geometry with `mutool draw -F stext`, and render per-page PNGs for the
  * visual report. Everything is cached under `CACHE_DIR/<sha256 of the docx
@@ -7,12 +7,17 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
-import { CACHE_DIR } from "./config";
-import { parseStextXml } from "./stextParse";
-import { normalizeLineText } from "./textNorm";
+import {
+  cacheDirFor,
+  extractPdfGeometry,
+  getMutoolVersion,
+  getPdfPagePngs,
+  readCachedGeom,
+  sha256OfFile,
+} from "./pdfReference";
 import type { DocGeom } from "./types";
 
 const WORD_APP_PATH = "/Applications/Microsoft Word.app";
@@ -20,13 +25,10 @@ const EXPORT_TIMEOUT_MS = 180_000;
 const CLOSE_TIMEOUT_MS = 30_000;
 const EXPORT_ATTEMPTS = 2;
 const CLOSE_ATTEMPTS = 2;
-const PNG_DPI = 96;
-
 const PDF_FILENAME = "word.pdf";
 const STEXT_XML_FILENAME = "word-stext.xml";
 const GEOM_JSON_FILENAME = "word-geom.json";
 const PAGES_DIRNAME = "word-pages";
-const PAGE_PNG_RE = /^p(\d+)\.png$/;
 
 const GET_WORD_VERSION_SCRIPT = 'tell application "Microsoft Word" to get version';
 
@@ -73,25 +75,6 @@ export const getWordVersion = async (): Promise<string | null> => {
   cachedWordVersion = stdout === "" ? null : stdout;
   return cachedWordVersion;
 };
-
-/** `mutool -v` prints its version to stderr, not stdout. */
-const getMutoolVersion = async (): Promise<string> => {
-  // `mutool -v` only writes to stderr; ignore stdout so its pipe fd is not
-  // left open and leaked.
-  const proc = Bun.spawn(["mutool", "-v"], { stdout: "ignore", stderr: "pipe" });
-  const stderr = await new Response(proc.stderr).text();
-  await proc.exited;
-  return stderr.trim();
-};
-
-const sha256OfFile = async (filePath: string): Promise<string> => {
-  const data = await Bun.file(filePath).arrayBuffer();
-  const hasher = new Bun.CryptoHasher("sha256");
-  hasher.update(data);
-  return hasher.digest("hex");
-};
-
-const cacheDirFor = (sha256: string): string => path.join(CACHE_DIR, sha256);
 
 /** Escape a path for interpolation into a double-quoted AppleScript string
  * literal: backslashes first, then double quotes. */
@@ -298,37 +281,7 @@ const runWordExportScript = async (args: RunWordExportArgs): Promise<void> => {
   }
 };
 
-const runMutoolStext = async (pdfPath: string, xmlPath: string): Promise<void> => {
-  const proc = Bun.spawn(["mutool", "draw", "-F", "stext", "-o", xmlPath, pdfPath], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
-  if (exitCode !== 0) {
-    throw new WordTruthError(
-      `mutool stext extraction failed for ${pdfPath} (exit ${exitCode}): ${stderr.trim()}`,
-      "extract",
-    );
-  }
-};
-
-const readCachedGeom = async (geomPath: string, absDocxPath: string): Promise<DocGeom | null> => {
-  const file = Bun.file(geomPath);
-  if (!(await file.exists())) return null;
-  const geom = (await file.json()) as DocGeom;
-  return Object.assign({}, geom, {
-    file: absDocxPath,
-    pages: geom.pages.map((page) =>
-      Object.assign({}, page, {
-        lines: page.lines.map((line) =>
-          Object.assign({}, line, { normText: normalizeLineText(line.text) }),
-        ),
-      }),
-    ),
-  });
-};
-
-/** Word ground truth for `docxPath`: exports via Word, extracts geometry via
+/** Word reference geometry for `docxPath`: exports via Word, extracts via
  * mutool, and caches the result under `CACHE_DIR/<sha256>/word-geom.json`.
  * Returns the cached geometry (with `file` rewritten to the requested
  * absolute path) unless `opts.refresh` is set. */
@@ -358,10 +311,7 @@ export const getWordTruth = async (
   await exportViaWord(absDocxPath, pdfPath);
 
   const xmlPath = path.join(dir, STEXT_XML_FILENAME);
-  await runMutoolStext(pdfPath, xmlPath);
-
-  const xml = await Bun.file(xmlPath).text();
-  const pages = parseStextXml(xml);
+  const pages = await extractPdfGeometry(pdfPath, xmlPath);
 
   const [wordVersion, mutoolVersion] = await Promise.all([getWordVersion(), getMutoolVersion()]);
   const geom: DocGeom = {
@@ -378,52 +328,6 @@ export const getWordTruth = async (
 
   await Bun.write(geomPath, JSON.stringify(geom, null, 2));
   return geom;
-};
-
-const listPagePngs = async (pagesDir: string): Promise<string[]> => {
-  let entries: string[];
-  try {
-    entries = await readdir(pagesDir);
-  } catch {
-    return [];
-  }
-  return entries
-    .filter((name) => PAGE_PNG_RE.test(name))
-    .sort((a, b) => pageNumberOfPngName(a) - pageNumberOfPngName(b))
-    .map((name) => path.join(pagesDir, name));
-};
-
-const pageNumberOfPngName = (filename: string): number => {
-  const match = PAGE_PNG_RE.exec(filename);
-  return match?.[1] === undefined ? 0 : Number(match[1]);
-};
-
-const renderPagePngs = async (
-  pdfPath: string,
-  pagesDir: string,
-  options: { maxPages?: number } = {},
-): Promise<void> => {
-  const pageRange = options.maxPages === undefined ? [] : [`1-${options.maxPages}`];
-  const proc = Bun.spawn(
-    [
-      "mutool",
-      "draw",
-      "-r",
-      String(PNG_DPI),
-      "-o",
-      path.join(pagesDir, "p%d.png"),
-      pdfPath,
-      ...pageRange,
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
-  if (exitCode !== 0) {
-    throw new WordTruthError(
-      `mutool PNG rendering failed for ${pdfPath} (exit ${exitCode}): ${stderr.trim()}`,
-      "extract",
-    );
-  }
 };
 
 /** Absolute paths of the cached per-page PNGs for `docxPath`, in page order,
@@ -444,14 +348,9 @@ export const getWordPagePngs = async (
 
   const pagesDir = path.join(dir, PAGES_DIRNAME);
   await mkdir(pagesDir, { recursive: true });
-
-  const existing = await listPagePngs(pagesDir);
-  if (options.maxPages !== undefined && existing.length >= options.maxPages) {
-    return existing.slice(0, options.maxPages);
-  }
-  if (options.maxPages === undefined && existing.length > 0) return existing;
-
-  await renderPagePngs(pdfPath, pagesDir, options);
-  const rendered = await listPagePngs(pagesDir);
-  return options.maxPages === undefined ? rendered : rendered.slice(0, options.maxPages);
+  return await getPdfPagePngs({
+    pdfPath,
+    pagesDir,
+    ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
+  });
 };

--- a/parity/wordTruth.ts
+++ b/parity/wordTruth.ts
@@ -311,7 +311,15 @@ export const getWordTruth = async (
   await exportViaWord(absDocxPath, pdfPath);
 
   const xmlPath = path.join(dir, STEXT_XML_FILENAME);
-  const pages = await extractPdfGeometry(pdfPath, xmlPath);
+  let pages;
+  try {
+    pages = await extractPdfGeometry(pdfPath, xmlPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new WordTruthError(message, "extract");
+  }
+
+  await rm(path.join(dir, PAGES_DIRNAME), { recursive: true, force: true });
 
   const [wordVersion, mutoolVersion] = await Promise.all([getWordVersion(), getMutoolVersion()]);
   const geom: DocGeom = {
@@ -343,14 +351,19 @@ export const getWordPagePngs = async (
   const pdfPath = path.join(dir, PDF_FILENAME);
 
   if (!(await Bun.file(pdfPath).exists())) {
-    await getWordTruth(absDocxPath);
+    await getWordTruth(absDocxPath, { refresh: true });
   }
 
   const pagesDir = path.join(dir, PAGES_DIRNAME);
   await mkdir(pagesDir, { recursive: true });
-  return await getPdfPagePngs({
-    pdfPath,
-    pagesDir,
-    ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
-  });
+  try {
+    return await getPdfPagePngs({
+      pdfPath,
+      pagesDir,
+      ...(options.maxPages === undefined ? {} : { maxPages: options.maxPages }),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new WordTruthError(message, "extract");
+  }
 };

--- a/parity/wordTruth.ts
+++ b/parity/wordTruth.ts
@@ -296,7 +296,7 @@ export const getWordTruth = async (
 
   const geomPath = path.join(dir, GEOM_JSON_FILENAME);
   if (!(opts?.refresh ?? false)) {
-    const cached = await readCachedGeom(geomPath, absDocxPath);
+    const cached = await readCachedGeom({ geomPath, absDocxPath });
     if (cached) return cached;
   }
 
@@ -313,7 +313,7 @@ export const getWordTruth = async (
   const xmlPath = path.join(dir, STEXT_XML_FILENAME);
   let pages;
   try {
-    pages = await extractPdfGeometry(pdfPath, xmlPath);
+    pages = await extractPdfGeometry({ pdfPath, xmlPath });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new WordTruthError(message, "extract");


### PR DESCRIPTION
Adds a renderer-neutral DOCX interoperability harness with LibreOffice as the default reference and Microsoft Word as an explicit opt-in.

The comparison pipeline now records renderer provenance, shares PDF geometry extraction across adapters, and uses reference-neutral JSON and HTML report fields. The accompanying documentation describes the standards-first methodology and the role of structural and rendering references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LibreOffice as the default reference renderer for DOCX interoperability comparisons, with optional Word rendering.
  * Added `--reference` and `--refresh-reference` options, improved validation, and reference-specific inspection and reporting.
  * Reports now identify the selected renderer and display reference-versus-Folio comparisons more clearly.
* **Documentation**
  * Added interoperability guidance covering standards, rendering comparisons, round-trip testing, and reproducible evidence.
  * Updated terminology and parity harness instructions to focus on OOXML and multi-renderer compatibility.
* **Tests**
  * Expanded coverage for renderer selection, caching, validation, and LibreOffice PDF rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->