### PR TITLE
fix: use section width for floating text boxes

### DIFF
--- a/.changeset/local-floats-flow.md
+++ b/.changeset/local-floats-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Use each section's content width when measuring positioned text-box exclusion.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -220,6 +220,45 @@ describe("measureBlocks", () => {
     }, fakeMeasure);
   });
 
+  test("uses the anchor section width for positioned text-box exclusion", () => {
+    withFakeTextMeasure(() => {
+      const textBox: TextBoxBlock = {
+        kind: "textBox",
+        id: "outside-narrow-section",
+        width: 140,
+        height: 126,
+        content: [],
+        wrapType: "square",
+        wrapText: "bothSides",
+        position: {
+          horizontal: { relativeTo: "page", posOffset: pixelsToEmu(440) },
+          vertical: { relativeTo: "paragraph", posOffset: 0 },
+        },
+      };
+      const blocks: FlowBlock[] = [
+        para("wide-section", "wide"),
+        textBox,
+        para("narrow-section", "narrow body"),
+      ];
+
+      const measures = measureBlocks(blocks, [720, 160, 160], [40, 40, 40], {
+        pageWidth: [800, 800, 800],
+        pageHeight: [1_000, 1_000, 1_000],
+        marginLeft: [40, 40, 40],
+        marginRight: [40, 600, 600],
+        marginBottom: [40, 40, 40],
+      });
+      const bodyMeasure = measures.at(2);
+      if (bodyMeasure?.kind !== "paragraph") {
+        throw new Error("Expected body paragraph measure");
+      }
+
+      expect(bodyMeasure.lines.at(0)?.floatSkipBefore).toBeUndefined();
+      expect(bodyMeasure.lines.at(0)?.leftOffset).toBeUndefined();
+      expect(bodyMeasure.lines.at(0)?.rightOffset).toBeUndefined();
+    }, fakeMeasure);
+  });
+
   test("keeps an active band across an unspecified continuous section break", () => {
     withFakeTextMeasure(() => {
       const band: TextBoxBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -498,11 +498,12 @@ type BandPageGeometry = {
 
 function extractFloatingZones(
   blocks: FlowBlock[],
-  contentWidth: number,
+  contentWidth: number | number[],
   marginTop: number | number[] = 0,
   pageGeometry?: BandPageGeometry,
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
+  const defaultContentWidth = Array.isArray(contentWidth) ? (contentWidth[0] ?? 0) : contentWidth;
   const textBoxGroupAnchors = new Map<string, number>();
   const paragraphFrameGroupSizes = new Map<string, number>();
   for (const block of blocks) {
@@ -515,13 +516,13 @@ function extractFloatingZones(
     }
   }
   const defaultMarginTop = Array.isArray(marginTop) ? (marginTop[0] ?? 0) : marginTop;
-  const pageWidthInput = pageGeometry?.pageWidth ?? contentWidth;
+  const pageWidthInput = pageGeometry?.pageWidth ?? defaultContentWidth;
   const pageHeightInput = pageGeometry?.pageHeight ?? 0;
   const marginLeftInput = pageGeometry?.marginLeft ?? 0;
   const marginRightInput = pageGeometry?.marginRight ?? 0;
   const marginBottomInput = pageGeometry?.marginBottom ?? 0;
   const defaultPageWidth = Array.isArray(pageWidthInput)
-    ? (pageWidthInput[0] ?? contentWidth)
+    ? (pageWidthInput[0] ?? defaultContentWidth)
     : pageWidthInput;
   const defaultPageHeight = Array.isArray(pageHeightInput)
     ? (pageHeightInput[0] ?? 0)
@@ -589,10 +590,10 @@ function extractFloatingZones(
           rightMargin = imgRun.width + distLeft;
         } else if (h.posOffset !== undefined) {
           const x = emuToPixels(h.posOffset);
-          if (x < contentWidth / 2) {
+          if (x < defaultContentWidth / 2) {
             leftMargin = x + imgRun.width + distRight;
           } else {
-            rightMargin = contentWidth - x + distLeft;
+            rightMargin = defaultContentWidth - x + distLeft;
           }
         }
       } else if (imgRun.cssFloat === "left") {
@@ -630,7 +631,7 @@ function extractFloatingZones(
       continue;
     }
 
-    const tableMeasure = measureTableBlock(tableBlock, contentWidth);
+    const tableMeasure = measureTableBlock(tableBlock, defaultContentWidth);
     const tableWidth = tableMeasure.totalWidth;
     const tableHeight = tableMeasure.totalHeight;
 
@@ -650,20 +651,20 @@ function extractFloatingZones(
       if (floating.tblpXSpec === "left" || floating.tblpXSpec === "inside") {
         x = 0;
       } else if (floating.tblpXSpec === "right" || floating.tblpXSpec === "outside") {
-        x = contentWidth - tableWidth;
+        x = defaultContentWidth - tableWidth;
       } else {
-        x = (contentWidth - tableWidth) / 2;
+        x = (defaultContentWidth - tableWidth) / 2;
       }
     } else if (tableBlock.justification === "center") {
-      x = (contentWidth - tableWidth) / 2;
+      x = (defaultContentWidth - tableWidth) / 2;
     } else if (tableBlock.justification === "right") {
-      x = contentWidth - tableWidth;
+      x = defaultContentWidth - tableWidth;
     }
 
-    if (x < contentWidth / 2) {
+    if (x < defaultContentWidth / 2) {
       leftMargin = x + tableWidth + distRight;
     } else {
-      rightMargin = contentWidth - x + distLeft;
+      rightMargin = defaultContentWidth - x + distLeft;
     }
 
     const topY = floating.tblpY ?? 0;
@@ -698,6 +699,7 @@ function extractFloatingZones(
     const blockMarginLeft = perBlockNumberValue(marginLeftInput, blockIndex, defaultMarginLeft);
     const blockMarginRight = perBlockNumberValue(marginRightInput, blockIndex, defaultMarginRight);
     const blockPageWidth = perBlockNumberValue(pageWidthInput, blockIndex, defaultPageWidth);
+    const blockContentWidth = perBlockNumberValue(contentWidth, blockIndex, defaultContentWidth);
     const vertical = tb.position.vertical;
     const pageFrameRelative = isPageFrameRelativeAnchor(vertical?.relativeTo);
     const topY = pageFrameRelative
@@ -746,10 +748,11 @@ function extractFloatingZones(
       box: tb,
       contentX,
       boxWidth: measure.width,
-      contentWidth,
+      contentWidth: blockContentWidth,
     });
     const leftMargin = wrapSide === "right" ? contentX + measure.width + (tb.distRight ?? 12) : 0;
-    const rightMargin = wrapSide === "left" ? contentWidth - contentX + (tb.distLeft ?? 12) : 0;
+    const rightMargin =
+      wrapSide === "left" ? blockContentWidth - contentX + (tb.distLeft ?? 12) : 0;
     zones.push({
       leftMargin: Math.max(0, leftMargin),
       rightMargin: Math.max(0, rightMargin),
@@ -952,7 +955,7 @@ export function measureBlocks(
   // Pre-extract floating image exclusion zones with anchor block indices
   const floatingZonesWithAnchors = extractFloatingZones(
     blocks,
-    defaultWidth,
+    contentWidth,
     marginTop,
     pageGeometry,
   );


### PR DESCRIPTION
## Summary

- measure positioned text-box exclusion against the anchor block’s section width
- avoid false vertical clearance when a page-positioned box sits outside a narrow continuous section
- add a synthetic unequal-section regression and patch changeset

## Verification

- focused float and text-box suites: 59 passing
- strict shared-font reference-layout comparison: 16.1% to 93.6%, with pagination corrected from 3 pages to 2 and matched lines increasing from 190/218 to 215/218
- stabilized cross-case replay: exact metric match at 91.2%
- dependency audit: no vulnerabilities
- lint and typecheck are delegated to CI

CC on behalf of @jan-kubica