### PR TITLE
fix: preserve authored blank paragraph spacing

### DIFF
--- a/.changeset/authored-paragraph-mark-spacing.md
+++ b/.changeset/authored-paragraph-mark-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve inherited spacing on blank paragraphs with directly formatted paragraph marks.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -565,7 +565,8 @@ export type ParagraphAttrs = {
         before?: boolean;
         after?: boolean;
     };
-    hasDirectParagraphFormatting?: boolean;
+    hasDirectParagraphFormatting?: boolean; /** Whether an empty paragraph carries direct formatting on its paragraph mark. */
+    hasDirectParagraphMarkFormatting?: boolean;
     indent?: ParagraphIndent;
     keepNext?: boolean;
     keepLines?: boolean;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -232,7 +232,7 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.hasDirectParagraphFormatting).toBeUndefined();
   });
 
-  test("does not treat paragraph-mark character styling as paragraph formatting", () => {
+  test("tracks paragraph-mark character styling separately from paragraph formatting", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", {
         _originalFormatting: { runProperties: { fontSize: 24 } },
@@ -243,6 +243,18 @@ describe("toFlowBlocks paragraph formatting", () => {
 
     expect(paragraph?.kind).toBe("paragraph");
     expect(paragraph?.attrs?.hasDirectParagraphFormatting).toBeUndefined();
+    expect(paragraph?.attrs?.hasDirectParagraphMarkFormatting).toBe(true);
+  });
+
+  test("does not mark an empty paragraph-mark property bag as directly formatted", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { _originalFormatting: { runProperties: {} } }),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.hasDirectParagraphMarkFormatting).toBeUndefined();
   });
 
   test("preserves Word rendered-page-break hints for layout", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1838,6 +1838,12 @@ function convertParagraph(
       attrs.hasDirectParagraphFormatting = true;
     }
     const paragraphMarkFormatting = pmAttrs._originalFormatting?.runProperties;
+    if (
+      paragraphMarkFormatting &&
+      Object.values(paragraphMarkFormatting).some((value) => value !== undefined && value !== null)
+    ) {
+      attrs.hasDirectParagraphMarkFormatting = true;
+    }
     if (paragraphMarkFormatting?.fontSize !== undefined) {
       attrs.defaultFontSize = paragraphMarkFormatting.fontSize / 2;
     }

--- a/packages/core/src/layout-engine/emptyParagraphSpacing.test.ts
+++ b/packages/core/src/layout-engine/emptyParagraphSpacing.test.ts
@@ -137,6 +137,24 @@ describe("empty-paragraph spacing collapse (issue #402)", () => {
     expect(fragments[2]!.y).toBe(112);
   });
 
+  test("inherited spacing on an empty paragraph with direct paragraph-mark formatting is honored", () => {
+    const blocks: FlowBlock[] = [
+      makePara(0, "Heading", { spacing: { after: 0 } }),
+      makePara(1, "", {
+        spacing: { before: 0, after: 80 },
+        hasDirectParagraphMarkFormatting: true,
+      }),
+      makePara(2, "Body", { spacing: { before: 0 } }),
+    ];
+    const measures: Measure[] = [makeMeasure(16), makeMeasure(16), makeMeasure(16)];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    const fragments = layout.pages[0]!.fragments;
+
+    expect(fragments[1]!.y).toBe(16);
+    expect(fragments[2]!.y).toBe(112);
+  });
+
   test("non-empty paragraphs always carry their inherited spacing", () => {
     // Sanity: the collapse only applies to empty paragraphs.
     const blocks: FlowBlock[] = [

--- a/packages/core/src/layout-engine/paragraphSpacing.ts
+++ b/packages/core/src/layout-engine/paragraphSpacing.ts
@@ -25,6 +25,7 @@ export function getParagraphSpacingBefore(block: ParagraphBlock): number {
     isEmptyParagraph(block) &&
     !block.attrs?.styleId &&
     !block.attrs?.hasDirectParagraphFormatting &&
+    !block.attrs?.hasDirectParagraphMarkFormatting &&
     !block.attrs?.spacingExplicit?.before
   ) {
     return 0;
@@ -45,6 +46,7 @@ export function getParagraphSpacingAfter(block: ParagraphBlock): number {
     isEmptyParagraph(block) &&
     !block.attrs?.styleId &&
     !block.attrs?.hasDirectParagraphFormatting &&
+    !block.attrs?.hasDirectParagraphMarkFormatting &&
     !block.attrs?.spacingExplicit?.after
   ) {
     return 0;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -390,6 +390,8 @@ export type ParagraphAttrs = {
    * inherited spacing; a bare empty paragraph still collapses that spacing.
    */
   hasDirectParagraphFormatting?: boolean;
+  /** Whether an empty paragraph carries direct formatting on its paragraph mark. */
+  hasDirectParagraphMarkFormatting?: boolean;
   indent?: ParagraphIndent;
   keepNext?: boolean;
   keepLines?: boolean;


### PR DESCRIPTION
## Summary

- track direct paragraph-mark formatting independently from direct paragraph formatting
- preserve inherited spacing on authored blank paragraphs while keeping bare blanks collapsed
- cover the provenance boundary with synthetic conversion and layout regressions

## Fidelity

- anonymous strict same-font case: 85.3% to 94.7%
- page count remained 2/2
- removed four targeted vertical divergences
- independent anonymous replay: 70.8% unchanged, 1/1 page

## Validation

- 78 focused tests passed
- package build and public API snapshot check passed
- dependency audit found no vulnerabilities

CC on behalf of @jan-kubica