### PR TITLE
fix: position top-and-bottom image artwork

### DIFF
--- a/.changeset/quiet-artwork-floats.md
+++ b/.changeset/quiet-artwork-floats.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Position top-and-bottom image artwork using its authored page anchors.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -146,6 +146,44 @@ describe("measureBlocks", () => {
     }, fakeMeasure);
   });
 
+  test("reserves positioned top-and-bottom image bands without inline image height", () => {
+    withFakeTextMeasure(() => {
+      const anchor: ParagraphBlock = {
+        kind: "paragraph",
+        id: "image-band-anchor",
+        attrs: { suppressEmptyParagraph: true },
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 300,
+            height: 60,
+            displayMode: "block",
+            wrapType: "topAndBottom",
+            position: {
+              vertical: { relativeTo: "page", posOffset: pixelsToEmu(120) },
+            },
+          },
+        ],
+      };
+
+      const measures = measureBlocks([anchor, para("after", "after")], 600, 96, {
+        pageWidth: 792,
+        pageHeight: 1_056,
+        marginLeft: 96,
+        marginRight: 96,
+        marginBottom: 96,
+      });
+      const anchorMeasure = measures.at(0);
+      const afterMeasure = measures.at(1);
+      if (anchorMeasure?.kind !== "paragraph" || afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measures");
+      }
+      expect(anchorMeasure.totalHeight).toBeLessThan(60);
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore).toBeGreaterThan(0);
+    }, fakeMeasure);
+  });
+
   test("reserves a paragraph frame set before measuring body text", () => {
     withFakeTextMeasure(() => {
       const frame = (id: string, x: number): TextBoxBlock => ({

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -49,7 +49,7 @@ const NO_WRAP_MEASURE_WIDTH = 1_000_000;
  * around a background letterhead or a foreground overlay (Codex
  * PR #258 review).
  */
-function isFloatingImageRun(run: ImageRun): boolean {
+function isSideWrappingImageRun(run: ImageRun): boolean {
   const wrapType = run.wrapType;
   const displayMode = run.displayMode;
 
@@ -551,7 +551,8 @@ function extractFloatingZones(
       }
       const imgRun = run as ImageRun;
 
-      if (!isFloatingImageRun(imgRun)) {
+      const positionedBand = imgRun.wrapType === "topAndBottom" && imgRun.position !== undefined;
+      if (!isSideWrappingImageRun(imgRun) && !positionedBand) {
         continue;
       }
 
@@ -562,6 +563,33 @@ function extractFloatingZones(
       const distBottom = imgRun.distBottom ?? 0;
       const distLeft = imgRun.distLeft ?? 12;
       const distRight = imgRun.distRight ?? 12;
+
+      if (positionedBand && position !== undefined) {
+        const vertical = position.vertical;
+        const blockMarginTop = perBlockNumberValue(marginTop, blockIndex, defaultMarginTop);
+        const pageFrameRelative = isPageFrameRelativeAnchor(vertical?.relativeTo);
+        const rawTop = pageFrameRelative
+          ? bandTopContentY(vertical, {
+              pageHeight: perBlockNumberValue(pageHeightInput, blockIndex, defaultPageHeight),
+              marginTop: blockMarginTop,
+              marginBottom: perBlockNumberValue(marginBottomInput, blockIndex, defaultMarginBottom),
+              boxHeight: imgRun.height,
+            })
+          : emuToPixels(vertical?.posOffset ?? 0);
+        const bottomY = rawTop + imgRun.height + distBottom;
+        if (bottomY > 0) {
+          zones.push({
+            leftMargin: 0,
+            rightMargin: 0,
+            topY: Math.max(0, rawTop - distTop),
+            bottomY,
+            anchorBlockIndex: blockIndex,
+            ...(pageFrameRelative ? { isMarginRelative: true } : {}),
+            fullWidthBlock: true,
+          });
+        }
+        continue;
+      }
 
       if (position?.vertical) {
         const v = position.vertical;

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1335,6 +1335,36 @@ describe("block image rotation measurement", () => {
     expect(measure.lines[0]?.lineHeight).toBeGreaterThanOrEqual(60 + 12);
     expect(measure.lines[0]?.lineHeight).toBeLessThan(120);
   });
+
+  test("positioned top-and-bottom artwork stays out of paragraph flow", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "positioned-band",
+          runs: [
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 600,
+              height: 95,
+              displayMode: "block",
+              wrapType: "topAndBottom",
+              position: {
+                horizontal: { relativeTo: "page", posOffset: 0 },
+                vertical: { relativeTo: "page", posOffset: 0 },
+              },
+            },
+            { kind: "text", text: "Body text" },
+          ],
+        },
+        600,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines.at(0)?.lineHeight).toBeLessThan(95);
+    }, fakeMeasure);
+  });
 });
 
 describe("paragraph indentation measurement", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -420,6 +420,9 @@ function isEmptyTextRun(run: TextRun): boolean {
  * preceding a floating image.
  */
 function isBlockLayoutImageRun(run: ImageRun): boolean {
+  if (isFloatingImageRun(run)) {
+    return false;
+  }
   return run.wrapType === "topAndBottom" || run.displayMode === "block";
 }
 
@@ -1233,25 +1236,10 @@ export function measureParagraph(
 
     if (isImageRun(run)) {
       const wrapType = run.wrapType;
-      // Match the painter's `isFloatingImageRun` classification —
-      // including `behind` / `inFront` (wrapNone). These images are
-      // anchored at absolute coordinates and the painter lifts them
-      // out of the paragraph flow, so the measurer must also skip
-      // them: otherwise the line reserves the image's inline width
-      // and height while the painter renders it as an overlay,
-      // leaving phantom gaps in the body text (Codex PR #258 review).
-      // Drop the `run.position` precondition too — wrapNone images
-      // can be authored without an explicit `<wp:positionH>` and
-      // still shouldn't contribute to inline metrics.
-      const isFloating =
-        run.displayMode === "float" ||
-        wrapType === "square" ||
-        wrapType === "tight" ||
-        wrapType === "through" ||
-        wrapType === "behind" ||
-        wrapType === "inFront";
-
-      if (isFloating) {
+      // Keep measurement aligned with the shared anchored-image predicate.
+      // These images paint in a page layer and must not reserve inline width
+      // or height at their host run.
+      if (isFloatingImageRun(run)) {
         currentLine.toRun = runIndex;
         currentLine.toChar = 1;
         continue;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1302,7 +1302,8 @@ export type HeaderFooterContent = {
 /**
  * `true` when the image run is anchored at page-level coordinates instead of
  * participating in inline flow. Covers the OOXML floating wrap types
- * (`square`, `tight`, `through`, `behind`, `inFront`) and the legacy
+ * (`square`, `tight`, `through`, `behind`, `inFront`), explicitly positioned
+ * `topAndBottom` artwork, and the legacy
  * `displayMode === "float"` escape hatch used by ProseMirror nodes that
  * pre-date the wrap-type round-trip.
  *
@@ -1311,6 +1312,9 @@ export type HeaderFooterContent = {
  */
 export const isFloatingImageRun = (run: ImageRun): boolean => {
   const wrapType = run.wrapType;
+  if (wrapType === "topAndBottom" && run.position !== undefined) {
+    return true;
+  }
   if (
     wrapType === "square" ||
     wrapType === "tight" ||

--- a/packages/core/src/layout-painter/floatingImageClassification.test.ts
+++ b/packages/core/src/layout-painter/floatingImageClassification.test.ts
@@ -40,8 +40,18 @@ describe("isFloatingImageRun (issue #418)", () => {
     expect(isFloatingImageRun(baseImage("inline"))).toBe(false);
   });
 
-  test("topAndBottom is not floating (it's a block image)", () => {
+  test("unpositioned topAndBottom artwork remains in flow", () => {
     expect(isFloatingImageRun(baseImage("topAndBottom"))).toBe(false);
+  });
+
+  test("positioned topAndBottom artwork is floating", () => {
+    expect(
+      isFloatingImageRun(
+        baseImage("topAndBottom", {
+          position: { vertical: { relativeTo: "page", posOffset: 0 } },
+        }),
+      ),
+    ).toBe(true);
   });
 
   test("explicit displayMode='float' overrides missing wrapType", () => {


### PR DESCRIPTION
## Summary

- classify explicitly positioned top-and-bottom images as anchored artwork
- paint them in the page layer instead of reserving their height inline
- preserve full-width exclusion bands when an anchored image overlaps body flow

## Validation

- 125 focused tests pass
- strict native-font anonymous replay: 74.1% → 75.9%, with all 9 pagination divergences removed and page artwork restored to authored coordinates
- unrelated strict replay unchanged at 91.3%
- `bun audit`
- lint, typecheck, build, distribution validation, and full tests are delegated to CI

CC on behalf of @jan-kubica