### PR TITLE
fix: avoid body-empty trailing pages

### DIFF
--- a/.changeset/terminal-empty-markers.md
+++ b/.changeset/terminal-empty-markers.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Prevent repeated terminal empty markers from creating a body-empty page.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1000,6 +1000,24 @@ describe("toFlowBlocks table cell formatting", () => {
     expect(blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
   });
 
+  test("keeps one line before the final marker in a repeated terminal empty run", () => {
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("content")]),
+        schema.node("paragraph"),
+        schema.node("paragraph"),
+      ]),
+    );
+
+    expect(
+      blocks
+        .slice(-2)
+        .map((block) =>
+          block.kind === "paragraph" ? block.attrs?.suppressEmptyParagraphHeight : undefined,
+        ),
+    ).toEqual([undefined, true]);
+  });
+
   test("keeps terminal empty paragraph height when the document contains only empty paragraphs", () => {
     const blocks = toFlowBlocks(
       schema.node("doc", null, [schema.node("paragraph"), schema.node("paragraph")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1941,6 +1941,26 @@ function suppressTerminalEmptyParagraphsAfterTable(blocks: FlowBlock[]): void {
   }
 }
 
+function suppressFinalParagraphInRepeatedEmptySuffix(blocks: FlowBlock[]): void {
+  let suffixStart = blocks.length;
+  while (suffixStart > 0 && isPaintlessTerminalParagraph(blocks[suffixStart - 1])) {
+    suffixStart -= 1;
+  }
+
+  if (
+    suffixStart === 0 ||
+    blocks.length - suffixStart < 2 ||
+    blocks[suffixStart - 1]?.kind === "table"
+  ) {
+    return;
+  }
+
+  const finalBlock = blocks.at(-1);
+  if (isPaintlessTerminalParagraph(finalBlock)) {
+    finalBlock.attrs = { ...finalBlock.attrs, suppressEmptyParagraphHeight: true };
+  }
+}
+
 function reserveLeadingEmptyOutlineHeight(blocks: FlowBlock[]): void {
   const firstBlock = blocks.at(0);
   if (
@@ -2795,6 +2815,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
 
   reserveLeadingEmptyOutlineHeight(blocks);
   suppressTerminalEmptyParagraphsAfterTable(blocks);
+  suppressFinalParagraphInRepeatedEmptySuffix(blocks);
   return groupParagraphFrames(mergeRunInParagraphs(blocks), nextBlockId);
 }
 


### PR DESCRIPTION
## Summary

- preserve one visible empty line in repeated terminal paragraph runs
- keep the final paintless marker as a zero-height editing anchor
- add synthetic regression coverage for single, repeated, and empty-only documents