### PR TITLE
chore: add specification source manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "check:parity-contract": "node scripts/check-parity-contract.mjs",
     "check:export-parity": "node scripts/check-export-parity.mjs",
     "check:react-compiler": "bun scripts/react-compiler-bailouts.ts --check",
+    "specifications:check": "bun scripts/specification-sources.ts check",
+    "specifications:fetch": "bun scripts/specification-sources.ts fetch",
     "test:e2e:vue": "bunx playwright test --project=vue",
     "test:e2e:parity": "bunx playwright test --project=parity",
     "build": "bun --filter '@stll/docx-core' build && bun --filter '@stll/folio-core' build && bun --filter '@stll/folio-react' build && bun --filter '@stll/folio-agents' build && bun --filter '@stll/folio-vue' build && bun --filter '@stll/folio-nuxt' build",

--- a/scripts/specification-sources.test.ts
+++ b/scripts/specification-sources.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import sourceManifest from "../specifications/sources.json";
+import { validateSpecificationSourceManifest } from "./specification-sources";
+
+const cloneManifest = (): unknown => structuredClone(sourceManifest);
+
+describe("specification source manifest", () => {
+  test("the committed manifest is valid", () => {
+    expect(validateSpecificationSourceManifest(sourceManifest)).toEqual([]);
+  });
+
+  test("rejects duplicate source ids", () => {
+    const manifest = cloneManifest();
+    if (typeof manifest !== "object" || manifest === null || !("sources" in manifest)) {
+      throw new TypeError("invalid test fixture");
+    }
+    if (!Array.isArray(manifest.sources)) {
+      throw new TypeError("invalid test fixture sources");
+    }
+    manifest.sources.push(structuredClone(manifest.sources.at(0)));
+    expect(validateSpecificationSourceManifest(manifest)).toContain(
+      "manifest.sources: duplicate source ids",
+    );
+  });
+
+  test("rejects source order drift", () => {
+    const manifest = cloneManifest();
+    if (typeof manifest !== "object" || manifest === null || !("sources" in manifest)) {
+      throw new TypeError("invalid test fixture");
+    }
+    if (!Array.isArray(manifest.sources)) {
+      throw new TypeError("invalid test fixture sources");
+    }
+    manifest.sources.reverse();
+    expect(validateSpecificationSourceManifest(manifest)).toContain(
+      "manifest.sources: sources must be sorted by id",
+    );
+  });
+
+  test("rejects an invalid artifact digest", () => {
+    const manifest = cloneManifest();
+    if (typeof manifest !== "object" || manifest === null || !("sources" in manifest)) {
+      throw new TypeError("invalid test fixture");
+    }
+    if (!Array.isArray(manifest.sources)) {
+      throw new TypeError("invalid test fixture sources");
+    }
+    const source = manifest.sources.at(0);
+    if (typeof source !== "object" || source === null) {
+      throw new TypeError("invalid test fixture source");
+    }
+    Object.assign(source, { sha256: "invalid" });
+    expect(validateSpecificationSourceManifest(manifest)).toContain(
+      "sources[0].sha256: expected a lowercase SHA-256 digest",
+    );
+  });
+
+  test("rejects cache paths outside the specification cache", () => {
+    const manifest = cloneManifest();
+    if (typeof manifest !== "object" || manifest === null || !("sources" in manifest)) {
+      throw new TypeError("invalid test fixture");
+    }
+    if (!Array.isArray(manifest.sources)) {
+      throw new TypeError("invalid test fixture sources");
+    }
+    const source = manifest.sources.at(0);
+    if (typeof source !== "object" || source === null) {
+      throw new TypeError("invalid test fixture source");
+    }
+    Object.assign(source, { cachePath: ".cache/specifications/../outside" });
+    expect(validateSpecificationSourceManifest(manifest)).toContain(
+      "sources[0].cachePath: expected a path under .cache/specifications",
+    );
+  });
+});

--- a/scripts/specification-sources.ts
+++ b/scripts/specification-sources.ts
@@ -1,0 +1,474 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, rm, stat } from "node:fs/promises";
+import path from "node:path";
+
+import { TaggedError } from "better-result";
+
+type LicenseAuditStatus = "needs-review" | "reviewed";
+type RedistributionPolicy = "cache-only" | "license-compliant" | "reference-only";
+type GeneratedOutputPolicy = "implementation-facts-only" | "license-compliant" | "review-required";
+
+type SourceLicense = {
+  auditStatus: LicenseAuditStatus;
+  notice: string;
+  noticeUrl: string;
+  redistribution: RedistributionPolicy;
+  generatedOutput: GeneratedOutputPolicy;
+};
+
+type SpecificationSourceBase = {
+  id: string;
+  title: string;
+  publisher: string;
+  version: string;
+  profiles: string[];
+  cachePath: string;
+  license: SourceLicense;
+};
+
+type ArtifactSpecificationSource = SpecificationSourceBase & {
+  sourceType: "artifact";
+  url: string;
+  sha256: string;
+  bytes: number;
+};
+
+type GitSpecificationSource = SpecificationSourceBase & {
+  sourceType: "git";
+  repository: string;
+  commit: string;
+  tree: string;
+};
+
+type SpecificationSource = ArtifactSpecificationSource | GitSpecificationSource;
+
+type SpecificationSourceManifest = {
+  schemaVersion: 1;
+  sources: SpecificationSource[];
+};
+
+class SpecificationSourceError extends TaggedError("SpecificationSourceError")<{
+  message: string;
+  cause?: unknown;
+}>() {}
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
+const MANIFEST_PATH = path.join(REPOSITORY_ROOT, "specifications", "sources.json");
+const CACHE_ROOT = path.join(REPOSITORY_ROOT, ".cache", "specifications");
+const SOURCE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const SHA256_RE = /^[a-f0-9]{64}$/u;
+const GIT_OBJECT_ID_RE = /^[a-f0-9]{40}$/u;
+const HTTPS_URL_RE = /^https:\/\//u;
+const CACHE_PATH_RE = /^\.cache\/specifications\/[a-z0-9][a-z0-9./-]*$/u;
+const ARTIFACT_KEYS = new Set([
+  "bytes",
+  "cachePath",
+  "id",
+  "license",
+  "profiles",
+  "publisher",
+  "sha256",
+  "sourceType",
+  "title",
+  "url",
+  "version",
+]);
+const GIT_KEYS = new Set([
+  "cachePath",
+  "commit",
+  "id",
+  "license",
+  "profiles",
+  "publisher",
+  "repository",
+  "sourceType",
+  "title",
+  "tree",
+  "version",
+]);
+const LICENSE_KEYS = new Set([
+  "auditStatus",
+  "generatedOutput",
+  "notice",
+  "noticeUrl",
+  "redistribution",
+]);
+const LICENSE_AUDIT_STATUSES = new Set<unknown>(["needs-review", "reviewed"]);
+const REDISTRIBUTION_POLICIES = new Set<unknown>([
+  "cache-only",
+  "license-compliant",
+  "reference-only",
+]);
+const GENERATED_OUTPUT_POLICIES = new Set<unknown>([
+  "implementation-facts-only",
+  "license-compliant",
+  "review-required",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const compareStrings = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+};
+
+const validateExactKeys = (
+  record: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  location: string,
+  issues: string[],
+): void => {
+  for (const key of Object.keys(record)) {
+    if (!allowedKeys.has(key)) {
+      issues.push(`${location}.${key}: unknown field`);
+    }
+  }
+};
+
+const validateRequiredString = (
+  record: Record<string, unknown>,
+  key: string,
+  location: string,
+  issues: string[],
+): void => {
+  const value = record[key];
+  if (typeof value !== "string" || value.length === 0) {
+    issues.push(`${location}.${key}: expected a non-empty string`);
+  }
+};
+
+const validateProfiles = (value: unknown, location: string, issues: string[]): void => {
+  if (!Array.isArray(value) || value.length === 0) {
+    issues.push(`${location}: expected a non-empty array`);
+    return;
+  }
+  if (!value.every((profile) => typeof profile === "string" && SOURCE_ID_RE.test(profile))) {
+    issues.push(`${location}: expected kebab-case profile names`);
+    return;
+  }
+  const profiles = value.filter((profile): profile is string => typeof profile === "string");
+  if (new Set(profiles).size !== profiles.length) {
+    issues.push(`${location}: duplicate profiles`);
+  }
+  if (profiles.toSorted(compareStrings).some((profile, index) => profile !== profiles[index])) {
+    issues.push(`${location}: profiles must be sorted`);
+  }
+};
+
+const validateLicense = (value: unknown, location: string, issues: string[]): void => {
+  if (!isRecord(value)) {
+    issues.push(`${location}: expected an object`);
+    return;
+  }
+  validateExactKeys(value, LICENSE_KEYS, location, issues);
+  validateRequiredString(value, "notice", location, issues);
+  validateRequiredString(value, "noticeUrl", location, issues);
+  if (!LICENSE_AUDIT_STATUSES.has(value["auditStatus"])) {
+    issues.push(`${location}.auditStatus: unsupported policy`);
+  }
+  if (!REDISTRIBUTION_POLICIES.has(value["redistribution"])) {
+    issues.push(`${location}.redistribution: unsupported policy`);
+  }
+  if (!GENERATED_OUTPUT_POLICIES.has(value["generatedOutput"])) {
+    issues.push(`${location}.generatedOutput: unsupported policy`);
+  }
+  const noticeUrl = value["noticeUrl"];
+  if (typeof noticeUrl === "string" && !HTTPS_URL_RE.test(noticeUrl)) {
+    issues.push(`${location}.noticeUrl: expected an HTTPS URL`);
+  }
+};
+
+const validateSource = (value: unknown, index: number, issues: string[]): void => {
+  const location = `sources[${index}]`;
+  if (!isRecord(value)) {
+    issues.push(`${location}: expected an object`);
+    return;
+  }
+  const sourceType = value["sourceType"];
+  if (sourceType !== "artifact" && sourceType !== "git") {
+    issues.push(`${location}.sourceType: expected artifact or git`);
+    return;
+  }
+  validateExactKeys(value, sourceType === "artifact" ? ARTIFACT_KEYS : GIT_KEYS, location, issues);
+  for (const key of ["cachePath", "id", "publisher", "title", "version"]) {
+    validateRequiredString(value, key, location, issues);
+  }
+  const id = value["id"];
+  if (typeof id === "string" && !SOURCE_ID_RE.test(id)) {
+    issues.push(`${location}.id: expected kebab-case`);
+  }
+  const cachePath = value["cachePath"];
+  if (
+    typeof cachePath === "string" &&
+    (!CACHE_PATH_RE.test(cachePath) || cachePath.split("/").includes(".."))
+  ) {
+    issues.push(`${location}.cachePath: expected a path under .cache/specifications`);
+  }
+  validateProfiles(value["profiles"], `${location}.profiles`, issues);
+  validateLicense(value["license"], `${location}.license`, issues);
+
+  if (sourceType === "artifact") {
+    validateRequiredString(value, "url", location, issues);
+    const url = value["url"];
+    if (typeof url === "string" && !HTTPS_URL_RE.test(url)) {
+      issues.push(`${location}.url: expected an HTTPS URL`);
+    }
+    const sha256 = value["sha256"];
+    if (typeof sha256 !== "string" || !SHA256_RE.test(sha256)) {
+      issues.push(`${location}.sha256: expected a lowercase SHA-256 digest`);
+    }
+    const bytes = value["bytes"];
+    if (typeof bytes !== "number" || !Number.isSafeInteger(bytes) || bytes <= 0) {
+      issues.push(`${location}.bytes: expected a positive safe integer`);
+    }
+    return;
+  }
+
+  validateRequiredString(value, "repository", location, issues);
+  const repository = value["repository"];
+  if (typeof repository === "string" && !repository.startsWith("https://github.com/")) {
+    issues.push(`${location}.repository: expected a GitHub HTTPS URL`);
+  }
+  for (const key of ["commit", "tree"]) {
+    const objectId = value[key];
+    if (typeof objectId !== "string" || !GIT_OBJECT_ID_RE.test(objectId)) {
+      issues.push(`${location}.${key}: expected a lowercase Git object ID`);
+    }
+  }
+};
+
+export const validateSpecificationSourceManifest = (value: unknown): string[] => {
+  const issues: string[] = [];
+  if (!isRecord(value)) {
+    return ["manifest: expected an object"];
+  }
+  validateExactKeys(value, new Set(["schemaVersion", "sources"]), "manifest", issues);
+  if (value["schemaVersion"] !== 1) {
+    issues.push("manifest.schemaVersion: expected 1");
+  }
+  const sources = value["sources"];
+  if (!Array.isArray(sources) || sources.length === 0) {
+    issues.push("manifest.sources: expected a non-empty array");
+    return issues;
+  }
+  for (const [index, source] of sources.entries()) {
+    validateSource(source, index, issues);
+  }
+  const ids = sources.flatMap((source) => {
+    if (!isRecord(source) || typeof source["id"] !== "string") {
+      return [];
+    }
+    return [source["id"]];
+  });
+  if (new Set(ids).size !== ids.length) {
+    issues.push("manifest.sources: duplicate source ids");
+  }
+  if (ids.toSorted(compareStrings).some((id, index) => id !== ids[index])) {
+    issues.push("manifest.sources: sources must be sorted by id");
+  }
+  return issues;
+};
+
+const isSpecificationSourceManifest = (value: unknown): value is SpecificationSourceManifest =>
+  validateSpecificationSourceManifest(value).length === 0;
+
+const loadManifest = async (): Promise<SpecificationSourceManifest> => {
+  const text = await Bun.file(MANIFEST_PATH).text();
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (cause) {
+    throw new SpecificationSourceError({
+      message: "Specification manifest is not valid JSON",
+      cause,
+    });
+  }
+  const issues = validateSpecificationSourceManifest(value);
+  if (issues.length > 0) {
+    throw new SpecificationSourceError({
+      message: `Specification manifest is invalid:\n${issues.map((issue) => `- ${issue}`).join("\n")}`,
+    });
+  }
+  if (!isSpecificationSourceManifest(value)) {
+    throw new SpecificationSourceError({ message: "Specification manifest validation failed" });
+  }
+  return value;
+};
+
+const resolveCachePath = (cachePath: string): string => {
+  const resolved = path.resolve(REPOSITORY_ROOT, cachePath);
+  if (!resolved.startsWith(`${CACHE_ROOT}${path.sep}`)) {
+    throw new SpecificationSourceError({ message: `Cache path escapes cache root: ${cachePath}` });
+  }
+  return resolved;
+};
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+const readBoundedResponse = async (response: Response, maxBytes: number): Promise<Uint8Array> => {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && Number(contentLength) > maxBytes) {
+    throw new SpecificationSourceError({
+      message: `Source response exceeds the ${maxBytes}-byte manifest limit`,
+    });
+  }
+  if (response.body === null) {
+    throw new SpecificationSourceError({ message: "Source response has no body" });
+  }
+  const chunks: Uint8Array[] = [];
+  const reader = response.body.getReader();
+  let totalBytes = 0;
+  while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- each chunk is bounded before the next is read
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    totalBytes += value.length;
+    if (totalBytes > maxBytes) {
+      await reader.cancel();
+      throw new SpecificationSourceError({
+        message: `Source response exceeds the ${maxBytes}-byte manifest limit`,
+      });
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+};
+
+const verifyArtifact = async (
+  source: ArtifactSpecificationSource,
+  fetchMissing: boolean,
+): Promise<"missing" | "verified"> => {
+  const cachePath = resolveCachePath(source.cachePath);
+  if (!existsSync(cachePath) && fetchMissing) {
+    const response = await fetch(source.url);
+    if (!response.ok) {
+      throw new SpecificationSourceError({
+        message: `Failed to fetch ${source.id}: HTTP ${response.status}`,
+      });
+    }
+    const bytes = await readBoundedResponse(response, source.bytes);
+    if (bytes.length !== source.bytes || sha256(bytes) !== source.sha256) {
+      throw new SpecificationSourceError({
+        message: `Fetched artifact does not match manifest: ${source.id}`,
+      });
+    }
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await Bun.write(cachePath, bytes);
+  }
+  if (!existsSync(cachePath)) {
+    return "missing";
+  }
+  const metadata = await stat(cachePath);
+  if (!metadata.isFile() || metadata.size !== source.bytes) {
+    throw new SpecificationSourceError({
+      message: `Cached artifact does not match manifest: ${source.id}`,
+    });
+  }
+  const bytes = new Uint8Array(await Bun.file(cachePath).arrayBuffer());
+  if (bytes.length !== source.bytes || sha256(bytes) !== source.sha256) {
+    throw new SpecificationSourceError({
+      message: `Cached artifact does not match manifest: ${source.id}`,
+    });
+  }
+  return "verified";
+};
+
+const runGit = async (args: string[], cwd = REPOSITORY_ROOT): Promise<string> => {
+  const process = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    throw new SpecificationSourceError({
+      message: `git ${args.at(0) ?? "command"} failed: ${stderr.trim()}`,
+    });
+  }
+  return stdout.trim();
+};
+
+const verifyGitSource = async (
+  source: GitSpecificationSource,
+  fetchMissing: boolean,
+): Promise<"missing" | "verified"> => {
+  const cachePath = resolveCachePath(source.cachePath);
+  const gitDirectory = path.join(cachePath, ".git");
+  if (!existsSync(gitDirectory) && fetchMissing) {
+    await rm(cachePath, { recursive: true, force: true });
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await runGit(["clone", "--filter=blob:none", "--no-checkout", source.repository, cachePath]);
+  }
+  if (!existsSync(gitDirectory)) {
+    return "missing";
+  }
+  if (fetchMissing) {
+    await runGit(["fetch", "--depth=1", "origin", source.commit], cachePath);
+    await runGit(["checkout", "--detach", source.commit], cachePath);
+  }
+  const [origin, commit, tree] = await Promise.all([
+    runGit(["remote", "get-url", "origin"], cachePath),
+    runGit(["rev-parse", "HEAD"], cachePath),
+    runGit(["rev-parse", "HEAD^{tree}"], cachePath),
+  ]);
+  if (origin !== source.repository || commit !== source.commit || tree !== source.tree) {
+    throw new SpecificationSourceError({
+      message: `Cached repository does not match manifest: ${source.id}`,
+    });
+  }
+  return "verified";
+};
+
+const verifySource = async (
+  source: SpecificationSource,
+  fetchMissing: boolean,
+): Promise<"missing" | "verified"> => {
+  if (source.sourceType === "artifact") {
+    return await verifyArtifact(source, fetchMissing);
+  }
+  return await verifyGitSource(source, fetchMissing);
+};
+
+const main = async (args: string[]): Promise<void> => {
+  const command = args.at(0) ?? "check";
+  if (command !== "check" && command !== "fetch") {
+    throw new SpecificationSourceError({
+      message: "Usage: bun scripts/specification-sources.ts [check|fetch]",
+    });
+  }
+  const manifest = await loadManifest();
+  const results = await Promise.all(
+    manifest.sources.map(async (source) => ({
+      id: source.id,
+      status: await verifySource(source, command === "fetch"),
+    })),
+  );
+  const verified = results.filter(({ status }) => status === "verified").length;
+  const missing = results.length - verified;
+  process.stdout.write(
+    `Specification sources: ${manifest.sources.length} valid, ${verified} cached, ${missing} not cached\n`,
+  );
+};
+
+if (import.meta.main) {
+  main(process.argv.slice(2)).catch((cause: unknown) => {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/specification-sources.ts
+++ b/scripts/specification-sources.ts
@@ -56,6 +56,7 @@ class SpecificationSourceError extends TaggedError("SpecificationSourceError")<{
 const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
 const MANIFEST_PATH = path.join(REPOSITORY_ROOT, "specifications", "sources.json");
 const CACHE_ROOT = path.join(REPOSITORY_ROOT, ".cache", "specifications");
+const SOURCE_FETCH_TIMEOUT_MS = 120_000;
 const SOURCE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const SHA256_RE = /^[a-f0-9]{64}$/u;
 const GIT_OBJECT_ID_RE = /^[a-f0-9]{40}$/u;
@@ -355,10 +356,17 @@ const verifyArtifact = async (
 ): Promise<"missing" | "verified"> => {
   const cachePath = resolveCachePath(source.cachePath);
   if (!existsSync(cachePath) && fetchMissing) {
-    const response = await fetch(source.url);
+    const response = await fetch(source.url, {
+      signal: AbortSignal.timeout(SOURCE_FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       throw new SpecificationSourceError({
         message: `Failed to fetch ${source.id}: HTTP ${response.status}`,
+      });
+    }
+    if (!response.url.startsWith("https://")) {
+      throw new SpecificationSourceError({
+        message: `Source redirected outside HTTPS: ${source.id}`,
       });
     }
     const bytes = await readBoundedResponse(response, source.bytes);
@@ -389,7 +397,12 @@ const verifyArtifact = async (
 };
 
 const runGit = async (args: string[], cwd = REPOSITORY_ROOT): Promise<string> => {
-  const process = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const process = Bun.spawn(["git", ...args], {
+    cwd,
+    signal: AbortSignal.timeout(SOURCE_FETCH_TIMEOUT_MS),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const [exitCode, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),

--- a/specifications/README.md
+++ b/specifications/README.md
@@ -1,0 +1,15 @@
+# Specification sources
+
+`sources.json` records the exact external inputs used for specification-aware
+tooling. Source archives and repositories are fetched into
+`.cache/specifications/`; they are not committed.
+
+Run `bun run specifications:check` to validate the manifest and verify any
+cached inputs. Run `bun run specifications:fetch` to populate and verify the
+cache.
+
+The licensing fields are repository policy, not a replacement for the linked
+notices. `implementation-facts-only` permits generated structural facts and
+implementation metadata, but not copied prose or source archives. A
+`needs-review` source remains reference-only until its licensing evidence is
+complete.

--- a/specifications/sources.json
+++ b/specifications/sources.json
@@ -1,0 +1,157 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "id": "ecma-376-part-1",
+      "title": "ECMA-376 Part 1: Fundamentals and Markup Language Reference",
+      "publisher": "Ecma International",
+      "version": "5th edition (December 2016)",
+      "profiles": ["strict"],
+      "sourceType": "artifact",
+      "url": "https://ecma-international.org/wp-content/uploads/ECMA-376-1_5th_edition_december_2016.zip",
+      "sha256": "9d0bcad9cf06054785b03762fcfadbf6bab7e54a5f9d69434e34b7fd464d4129",
+      "bytes": 43501721,
+      "cachePath": ".cache/specifications/ecma-376-part-1.zip",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "Ecma default copyright notice",
+        "noticeUrl": "https://ecma-international.org/policies/by-ipr/ecma-text-copyright-policy/",
+        "redistribution": "cache-only",
+        "generatedOutput": "implementation-facts-only"
+      }
+    },
+    {
+      "id": "ecma-376-part-2-opc",
+      "title": "ECMA-376 Part 2: Open Packaging Conventions",
+      "publisher": "Ecma International",
+      "version": "5th edition (December 2021)",
+      "profiles": ["opc"],
+      "sourceType": "artifact",
+      "url": "https://ecma-international.org/wp-content/uploads/ECMA-376-2_5th_edition_december_2021.zip",
+      "sha256": "1d489dc491168ea1f9e9a59063acc8dd5f02b4ad1d21aa7ec19ba9a58d020c70",
+      "bytes": 1899204,
+      "cachePath": ".cache/specifications/ecma-376-part-2.zip",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "Ecma default copyright notice",
+        "noticeUrl": "https://ecma-international.org/policies/by-ipr/ecma-text-copyright-policy/",
+        "redistribution": "cache-only",
+        "generatedOutput": "implementation-facts-only"
+      }
+    },
+    {
+      "id": "ecma-376-part-3-mce",
+      "title": "ECMA-376 Part 3: Markup Compatibility and Extensibility",
+      "publisher": "Ecma International",
+      "version": "5th edition (December 2015)",
+      "profiles": ["mce"],
+      "sourceType": "artifact",
+      "url": "https://ecma-international.org/wp-content/uploads/ECMA-376-3_5th_edition_december_2015.zip",
+      "sha256": "42294159fbbbe9393ccadac95b859d7729cc68d908898bcbe31034dda059daa8",
+      "bytes": 741741,
+      "cachePath": ".cache/specifications/ecma-376-part-3.zip",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "Ecma default copyright notice",
+        "noticeUrl": "https://ecma-international.org/policies/by-ipr/ecma-text-copyright-policy/",
+        "redistribution": "cache-only",
+        "generatedOutput": "implementation-facts-only"
+      }
+    },
+    {
+      "id": "ecma-376-part-4-transitional",
+      "title": "ECMA-376 Part 4: Transitional Migration Features",
+      "publisher": "Ecma International",
+      "version": "5th edition (December 2016)",
+      "profiles": ["transitional"],
+      "sourceType": "artifact",
+      "url": "https://ecma-international.org/wp-content/uploads/ECMA-376-4_5th_edition_december_2016.zip",
+      "sha256": "bd25da1109f73762356596918bf5ff8b74a1331642dba5f1c1d1dfc6bed34ecd",
+      "bytes": 8471820,
+      "cachePath": ".cache/specifications/ecma-376-part-4.zip",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "Ecma default copyright notice",
+        "noticeUrl": "https://ecma-international.org/policies/by-ipr/ecma-text-copyright-policy/",
+        "redistribution": "cache-only",
+        "generatedOutput": "implementation-facts-only"
+      }
+    },
+    {
+      "id": "ms-docx-extensions",
+      "title": "[MS-DOCX] DOCX extensions",
+      "publisher": "Microsoft Corporation",
+      "version": "2025-11-13",
+      "profiles": ["extensions", "transitional"],
+      "sourceType": "artifact",
+      "url": "https://officeprotocoldoc.z19.web.core.windows.net/files/MS-DOCX/%5BMS-DOCX%5D.pdf",
+      "sha256": "0ca370086064e4c32d821c00220f218df4104a895677e5539dc3e320485861f7",
+      "bytes": 2970201,
+      "cachePath": ".cache/specifications/ms-docx-2025-11-13.pdf",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "Microsoft Open Specifications copyright notice",
+        "noticeUrl": "https://learn.microsoft.com/en-us/openspecs/office_standards/ms-docx/b839fe1f-e1ca-4fa6-8c26-5954d0abbccd#intellectual-property-rights-notice-for-open-specifications-documentation",
+        "redistribution": "cache-only",
+        "generatedOutput": "implementation-facts-only"
+      }
+    },
+    {
+      "id": "ms-oi29500-implementation-notes",
+      "title": "[MS-OI29500] ISO/IEC 29500 implementation information",
+      "publisher": "Microsoft Corporation",
+      "version": "2026-05-19",
+      "profiles": ["implementation-notes", "strict", "transitional"],
+      "sourceType": "artifact",
+      "url": "https://officeprotocoldoc.z19.web.core.windows.net/files/MS-OI29500/%5BMS-OI29500%5D.pdf",
+      "sha256": "e55146bb9568ed6f1e421cf45221f9413a3551b42ff1bda651e29312ab5abf86",
+      "bytes": 17395035,
+      "cachePath": ".cache/specifications/ms-oi29500-2026-05-19.pdf",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "Microsoft Open Specifications copyright notice",
+        "noticeUrl": "https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/1fd4a662-8623-49c0-82f0-18fa91b413b8#intellectual-property-rights-notice-for-open-specifications-documentation",
+        "redistribution": "cache-only",
+        "generatedOutput": "implementation-facts-only"
+      }
+    },
+    {
+      "id": "office-js-api-reference",
+      "title": "Office.js API reference repository",
+      "publisher": "Microsoft Corporation",
+      "version": "2026-07-08",
+      "profiles": ["api"],
+      "sourceType": "git",
+      "repository": "https://github.com/OfficeDev/office-js-docs-reference.git",
+      "commit": "3f63c8ec84be5e671bb51ff8cf72e41a34a4e19a",
+      "tree": "4c902e4949b59dd5deeb573eab15ec1538ea208c",
+      "cachePath": ".cache/specifications/office-js-docs-reference",
+      "license": {
+        "auditStatus": "reviewed",
+        "notice": "MIT",
+        "noticeUrl": "https://github.com/OfficeDev/office-js-docs-reference/blob/3f63c8ec84be5e671bb51ff8cf72e41a34a4e19a/LICENSE",
+        "redistribution": "license-compliant",
+        "generatedOutput": "license-compliant"
+      }
+    },
+    {
+      "id": "ooxml-dev-reference",
+      "title": "ooxml-dev reference repository",
+      "publisher": "superdoc-dev",
+      "version": "2026-05-12",
+      "profiles": ["implementation-notes", "strict", "transitional"],
+      "sourceType": "git",
+      "repository": "https://github.com/superdoc-dev/ooxml-dev.git",
+      "commit": "921aada4a18ed1f59694ffe8dbf4446997f58786",
+      "tree": "3e905c10d7f92acfa6c53098e1e05fb7e142f7a8",
+      "cachePath": ".cache/specifications/ooxml-dev",
+      "license": {
+        "auditStatus": "needs-review",
+        "notice": "MIT asserted in README; no license file at the pinned revision",
+        "noticeUrl": "https://github.com/superdoc-dev/ooxml-dev/blob/921aada4a18ed1f59694ffe8dbf4446997f58786/README.md#license",
+        "redistribution": "reference-only",
+        "generatedOutput": "review-required"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- pin specification sources and licensing metadata
- verify cached sources by digest or revision
- validate manifest structure in tests