### PR TITLE
fix: reconcile partial visual-row gaps

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -515,6 +515,42 @@ describe("compareGeoms", () => {
     expect(result.score).toBe(1);
   });
 
+  test("reconciles one segmented visual row inside a larger alignment gap", () => {
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "Short", xPt: 72, yPt: 72, widthPt: 30, region: "unknown" }),
+          makeLine({
+            text: "Right segment",
+            xPt: 180,
+            yPt: 72,
+            widthPt: 90,
+            region: "unknown",
+          }),
+          makeLine({
+            text: "Unmatched row",
+            xPt: 72,
+            yPt: 100,
+            widthPt: 80,
+            region: "unknown",
+          }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [makeLine({ text: "Short Right segment", xPt: 72, yPt: 78, widthPt: 198 })],
+      }),
+    ]);
+
+    const result = compareGeoms(reference, folio);
+
+    expect(result.divergences).toEqual([{ kind: "missing-line", page: 1, text: "Unmatched row" }]);
+    expect(result.matchedLines).toBe(2);
+    expect(result.medianYOffsetPt).toBe(6);
+    expect(result.score).toBeCloseTo(2 / 3);
+  });
+
   test("a normalized 1-to-1 gap is treated as a match, not a line-break", () => {
     const word = makeDoc("word", [
       makePage({

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -473,10 +473,8 @@ const resolveOps = (
  * 1-to-N and N-to-1 cases. Otherwise every word line is missing and every
  * folio line is extra.
  *
- * Greedy sub-splitting of large, only-partially-reconcilable regions (e.g.
- * matching prefixes progressively) is spec-optional and not implemented
- * here: a region that doesn't reconcile as a whole falls through entirely to
- * missing/extra rather than being partially salvaged.
+ * If the whole gap does not reconcile, spatially equivalent segmented rows
+ * are recovered independently; unrelated leftovers remain missing/extra.
  */
 type ReconcileGapOptions = {
   wordIdxs: number[];
@@ -512,11 +510,91 @@ const reconcileGap = ({
     if (textSimilarity(wordConcat, folioConcat) >= CONCAT_THRESHOLD) {
       return [{ kind: "line-break", wordIdxs, folioIdxs }];
     }
+
+    const visualRows = reconcileGapByVisualRow({ wordIdxs, folioIdxs, wordFlat, folioFlat });
+    if (visualRows) return visualRows;
   }
   return [
     ...wordIdxs.map((wordIdx): ResolvedItem => ({ kind: "missing", wordIdx })),
     ...folioIdxs.map((folioIdx): ResolvedItem => ({ kind: "extra", folioIdx })),
   ];
+};
+
+/**
+ * A larger alignment gap can contain one equivalent segmented row plus an
+ * unrelated leftover row. Reconcile only the spatially matching row pair and
+ * retain the rest as real missing/extra lines instead of discarding the useful
+ * match because the entire gap does not concatenate to the same text.
+ */
+const reconcileGapByVisualRow = ({
+  wordIdxs,
+  folioIdxs,
+  wordFlat,
+  folioFlat,
+}: ReconcileGapOptions): ResolvedItem[] | null => {
+  const wordRows = groupGapLinesByVisualRow(wordIdxs, wordFlat);
+  const folioRows = groupGapLinesByVisualRow(folioIdxs, folioFlat);
+  const resolved: ResolvedItem[] = [];
+  let wordPosition = 0;
+  let folioPosition = 0;
+  let reconciled = false;
+
+  while (wordPosition < wordRows.length && folioPosition < folioRows.length) {
+    const wordRow = wordRows[wordPosition];
+    const folioRow = folioRows[folioPosition];
+    if (!wordRow || !folioRow) break;
+
+    if (equivalentSegmentedRows(wordRow, folioRow, wordFlat, folioFlat)) {
+      resolved.push({ kind: "line-break", wordIdxs: wordRow, folioIdxs: folioRow });
+      reconciled = true;
+      wordPosition++;
+      folioPosition++;
+      continue;
+    }
+
+    const nextWordRow = wordRows[wordPosition + 1];
+    if (nextWordRow && equivalentSegmentedRows(nextWordRow, folioRow, wordFlat, folioFlat)) {
+      resolved.push(...wordRow.map((wordIdx): ResolvedItem => ({ kind: "missing", wordIdx })));
+      wordPosition++;
+      continue;
+    }
+
+    const nextFolioRow = folioRows[folioPosition + 1];
+    if (nextFolioRow && equivalentSegmentedRows(wordRow, nextFolioRow, wordFlat, folioFlat)) {
+      resolved.push(...folioRow.map((folioIdx): ResolvedItem => ({ kind: "extra", folioIdx })));
+      folioPosition++;
+      continue;
+    }
+    break;
+  }
+
+  if (!reconciled) return null;
+  for (; wordPosition < wordRows.length; wordPosition++) {
+    const row = wordRows[wordPosition] ?? [];
+    resolved.push(...row.map((wordIdx): ResolvedItem => ({ kind: "missing", wordIdx })));
+  }
+  for (; folioPosition < folioRows.length; folioPosition++) {
+    const row = folioRows[folioPosition] ?? [];
+    resolved.push(...row.map((folioIdx): ResolvedItem => ({ kind: "extra", folioIdx })));
+  }
+  return resolved;
+};
+
+const equivalentSegmentedRows = (
+  wordIdxs: number[],
+  folioIdxs: number[],
+  wordFlat: FlatLine[],
+  folioFlat: FlatLine[],
+): boolean => {
+  if (wordIdxs.length === folioIdxs.length) return false;
+  const reference = mergeFlatLines(wordIdxs, wordFlat);
+  const candidate = mergeFlatLines(folioIdxs, folioFlat);
+  return (
+    reference !== null &&
+    candidate !== null &&
+    reference.page === candidate.page &&
+    textSimilarity(reference.line.normText, candidate.line.normText) >= CONCAT_THRESHOLD
+  );
 };
 
 const pageRegionKey = (page: number, region: LineBox["region"]): string =>


### PR DESCRIPTION
## Summary

- reconcile equivalent segmented rows inside larger alignment gaps
- keep unrelated missing and extra rows visible in diagnostics
- cover partial visual-row reconciliation with a deterministic regression

CC on behalf of @jan-kubica