### PR TITLE
fix: use paragraph typography for blank break lines

### DIFF
--- a/.changeset/calm-break-lines.md
+++ b/.changeset/calm-break-lines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Measure blank hard-break lines using paragraph mark typography.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -249,6 +249,32 @@ describe("empty paragraph line-height floor", () => {
     expect(measure.totalHeight).toBe(0);
     expect(measure.lines[0]?.lineHeight).toBe(0);
   });
+
+  test("uses paragraph mark metrics for blank hard-break lines", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "hard-break-default-metrics",
+          runs: [
+            { kind: "text", text: "first", fontSize: 9, fontFamily: "Times New Roman" },
+            { kind: "lineBreak" },
+            { kind: "lineBreak" },
+            { kind: "text", text: "last", fontSize: 9, fontFamily: "Times New Roman" },
+          ],
+          attrs: {
+            defaultFontSize: 9,
+            defaultFontFamily: "Times New Roman",
+            spacing: { line: 1, lineUnit: "multiplier", lineRule: "auto" },
+          },
+        },
+        600,
+      );
+
+      expect(measure.lines).toHaveLength(3);
+      expect(measure.lines[1]?.lineHeight).toBeCloseTo(measure.lines[0]?.lineHeight ?? 0, 5);
+    }, fakeMeasure);
+  });
 });
 
 describe("measureParagraph cross-run line breaking", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -971,10 +971,19 @@ export function measureParagraph(
   };
 
   const calculateLineTypography = (line: LineState): LineTypography => {
-    const typography = calculateTypographyMetrics(line.maxFontSize, spacing, line.maxFontMetrics);
+    const paragraphFontSize = attrs?.defaultFontSize ?? DEFAULT_FONT_SIZE;
+    const paragraphFontFamily = attrs?.defaultFontFamily ?? DEFAULT_FONT_FAMILY;
+    const fontSize = line.maxFontMetrics ? line.maxFontSize : paragraphFontSize;
+    const metrics =
+      line.maxFontMetrics ??
+      getFontMetrics({
+        fontSize: paragraphFontSize,
+        fontFamily: paragraphFontFamily,
+      });
+    const typography = calculateTypographyMetrics(fontSize, spacing, metrics);
 
     // If an inline image or stacked equation is taller than the text-based
-    // line height, the line grows to fit it. Word seats these inline objects
+    // line height, the line grows to fit it. The reference layout seats these inline objects
     // as tall glyphs on the text baseline.
     const finalTypography = { ...typography };
     const inlineObjectHeight = Math.max(line.maxImageHeightPx, line.maxMathHeightPx);


### PR DESCRIPTION
## Summary
- measure break-only lines with the paragraph mark font and size
- keep explicit text-run metrics authoritative for ordinary lines
- add deterministic coverage for consecutive hard breaks

## Validation
- 111 focused layout tests pass
- strict same-font anonymous replay: 86.0% → 93.0%, 1/1 pages, with three vertical divergences removed
- unrelated strict replay unchanged at 91.3%, 1/1 page
- `bun audit`
- lint, typecheck, build, distribution validation, and full tests are delegated to CI

CC on behalf of @jan-kubica