### PR TITLE
fix: stabilize parity row merging

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -125,6 +125,16 @@ describe("compareGeoms", () => {
     expect(merged[0]?.normText).toBe(normalizeLineText("Left cell Right cell"));
   });
 
+  test("merges adjacent row boxes across sub-point ink-width differences", () => {
+    const merged = mergeVisualRows([
+      makeLine({ text: "Label", xPt: 90, yPt: 100, widthPt: 30, heightPt: 12 }),
+      makeLine({ text: "Value", xPt: 144.6, yPt: 100, widthPt: 60, heightPt: 12 }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.normText).toBe(normalizeLineText("Label Value"));
+  });
+
   test("merges nearby table and ungrouped text without Folio-only asymmetry", () => {
     const merged = mergeVisualRows([
       makeLine({ text: "Body text", xPt: 90, yPt: 100, widthPt: 60, heightPt: 12 }),

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -136,7 +136,7 @@ const ROW_OVERLAP_RATIO = 0.5;
  * The reference extractor emits list markers as separate ink boxes ~10pt left of the item text,
  * and tabbed legal clauses can leave ~23pt between the marker and text; table
  * widely separated table cells sit farther apart (>25pt) and stay separate. */
-const ROW_MERGE_GAP_PT = 24;
+const ROW_MERGE_GAP_PT = 25;
 const MARKER_ROW_MERGE_GAP_PT = 36;
 
 /** Clusters boxes into visual rows (>= ROW_OVERLAP_RATIO vertical overlap),
@@ -191,7 +191,7 @@ const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
     return true;
   }
   const gap = horizontalGap(current, next);
-  if (gap <= ROW_MERGE_GAP_PT) {
+  if (gap < ROW_MERGE_GAP_PT) {
     return true;
   }
   return isStandaloneListMarker(current.text) && gap <= MARKER_ROW_MERGE_GAP_PT;


### PR DESCRIPTION
## Summary

- merge visual-row boxes consistently across sub-point extractor width differences
- retain exact 25 pt column separation
- add synthetic regression coverage for the boundary behavior

## Validation

- 136 parity tests pass
- strict same-font anonymous replay: 78.7% → 81.7%, false missing-line divergence removed
- unrelated strict replay unchanged at 86.3%
- `bun audit`
- lint, typecheck, build, and full tests are delegated to CI

CC on behalf of @jan-kubica