### PR TITLE
fix: preserve fractional layout geometry

### DIFF
--- a/.changeset/precise-layout-geometry.md
+++ b/.changeset/precise-layout-geometry.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve fractional section geometry and tighten justified inset-list wrapping.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -23,6 +23,7 @@ import type { FootnoteContent, HeaderFooterContent } from "../layout-engine/type
 import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import { LayoutPainter } from "../layout-painter";
 import { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
+import { twipsToPixels } from "../paged-layout/sectionGeometry";
 import { schema } from "../prosemirror/schema";
 import type { Footnote } from "../types/document";
 import { createEmptyDocument } from "../utils/createDocument";
@@ -818,7 +819,10 @@ describe("runLayoutPipeline", () => {
 
     const outcome = runLayoutPipeline(makeDeps(createLayoutSession(), { document }), makeState());
 
-    expect(outcome.layout?.pages.at(0)?.size).toEqual({ w: 1124, h: 795 });
+    expect(outcome.layout?.pages.at(0)?.size).toEqual({
+      w: twipsToPixels(16_860),
+      h: twipsToPixels(11_920),
+    });
   });
 
   test("uses the final section start mode for an implicit paragraph boundary", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -848,6 +848,35 @@ describe("measureParagraph justified shrink tolerance", () => {
       },
     );
   });
+
+  test("wraps a trailing token beyond the inset-list continuation allowance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-inset-list-boundary",
+            runs: [
+              { kind: "text", text: "x" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${"a".repeat(89)} bbb` },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 20, hanging: 10 },
+            },
+          },
+          110,
+        );
+
+        expect(measure.lines).toHaveLength(3);
+      },
+      {
+        charWidth: (char) => (char === "b" ? 0.465 : 1),
+      },
+    );
+  });
 });
 
 describe("measureParagraph document default tab interval", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -53,6 +53,7 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
+const JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO = 0.025;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
@@ -600,7 +601,7 @@ function justifyShrinkToleranceRatio(
       // A marker that remains inset leaves a narrower continuation body.
       // Keep those lines on the marker-line allowance; full-hanging lists
       // retain the broader prose allowance below.
-      return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+      return JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO;
     }
     return fixedSpaceAdjustedShrinkTolerance({
       tolerance: JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO,

--- a/packages/core/src/paged-layout/sectionGeometry.test.ts
+++ b/packages/core/src/paged-layout/sectionGeometry.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PAGE_WIDTH_PX,
   getMargins,
   getPageSize,
+  twipsToPixels,
   twipsToPxOr,
 } from "./sectionGeometry";
 
@@ -45,5 +46,14 @@ describe("paged editor section geometry", () => {
     expect(twipsToPxOr(0, 96)).toBe(0);
     expect(twipsToPxOr(1440, 96)).toBe(96);
     expect(twipsToPxOr(undefined, 96)).toBe(96);
+  });
+
+  test("preserves fractional units across page and margin geometry", () => {
+    const page = getPageSize({ pageWidth: 1001, pageHeight: 2002 });
+    const margins = getMargins({ marginLeft: 101, marginRight: 202 });
+
+    expect(page.w).toBe(twipsToPixels(1001));
+    expect(margins.left).toBe(twipsToPixels(101));
+    expect(page.w - margins.left - margins.right).toBeCloseTo(twipsToPixels(698), 10);
   });
 });

--- a/packages/core/src/paged-layout/sectionGeometry.ts
+++ b/packages/core/src/paged-layout/sectionGeometry.ts
@@ -13,7 +13,7 @@ const DEFAULT_MARGINS: PageMargins = {
   left: DEFAULT_BODY_MARGIN_PX,
 };
 
-export const twipsToPixels = (twips: number): number => Math.round((twips / 1440) * 96);
+export const twipsToPixels = (twips: number): number => (twips / 1440) * 96;
 
 /**
  * Convert an offset-like twip dimension to px. Explicit 0 is meaningful for


### PR DESCRIPTION
## Summary

- preserve fractional section sizes and margins through layout
- tighten justified inset-list continuation wrapping at the measured boundary
- add synthetic regression coverage for both geometry invariants

## Validation

- focused layout and section-geometry unit suites
- anonymous strict-font parity: 93.0% to 96.1%; matched rows 124/129 to 128/129
- two unrelated strict-font replays retained their scores and divergence counts
- lint and type checking are delegated to CI

CC on behalf of @jan-kubica