### PR TITLE
fix: keep paintless stories out of body clearance

### DIFF
--- a/.changeset/quiet-header-clearance.md
+++ b/.changeset/quiet-header-clearance.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep paintless header and footer stories out of body margin clearance.

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -656,6 +656,44 @@ describe("header/footer layout conversion", () => {
 
     expect(bounds).toEqual({ top: 0, bottom: 24 });
   });
+
+  test("keeps a paintless empty story out of body margin clearance", () => {
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      [emptyParagraph({ id: "empty-story" })],
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 0 });
+  });
+
+  test("keeps a tab-only story out of body margin clearance", () => {
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      [paragraph({ id: "tab-only-story", runs: [{ kind: "tab" }] })],
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 0 });
+  });
+
+  test("keeps authored spacing in empty-story body margin clearance", () => {
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      [
+        emptyParagraph({
+          id: "authored-empty-story",
+          attrs: { spacingExplicit: { before: true } },
+        }),
+      ],
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 12 });
+  });
 });
 
 describe("convertHeaderFooterPmDocToContent", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -215,6 +215,18 @@ function isVisuallyEmptyParagraph(block: FlowBlock): boolean {
   return block.runs.every((run) => run.kind === "text" && run.text.trim().length === 0);
 }
 
+function isPaintlessParagraph(block: FlowBlock): boolean {
+  if (block.kind !== "paragraph") {
+    return false;
+  }
+  return block.runs.every(
+    (run) =>
+      (run.kind === "text" && run.text.trim().length === 0) ||
+      run.kind === "tab" ||
+      run.kind === "lineBreak",
+  );
+}
+
 function normalizeTableBlock(block: TableBlock): TableBlock {
   const blockState = { changed: false };
   const rows = block.rows.map((row) => {
@@ -529,6 +541,13 @@ export function calculateHeaderFooterMarginPushBounds(
   flowHeight: number,
   metrics: HeaderFooterMetrics,
 ): { top: number; bottom: number } {
+  const isPaintlessStory =
+    blocks.length > 0 &&
+    blocks.every((block) => isPaintlessParagraph(block) && !hasAuthoredVisualContent(block));
+  if (isPaintlessStory) {
+    return { top: 0, bottom: 0 };
+  }
+
   let top = 0;
   let bottom = 0;
   let cursorY = 0;


### PR DESCRIPTION
## Summary

- exclude entirely paintless header and footer stories from body margin clearance
- retain their editing and rendering geometry without shifting body pagination
- keep authored spacing and visual formatting authoritative

## Validation

- 45 focused header and layout tests pass
- strict same-font anonymous replay: 88.5% → 92.2%, 5/5 pages, all six pagination divergences removed
- unrelated visible-header replay unchanged at 95.7%, 1/1 page
- `bun audit`
- lint, typecheck, build, distribution validation, and full tests are delegated to CI

CC on behalf of @jan-kubica