### PR TITLE
fix: continue compatible numbering handoffs

### DIFF
--- a/.changeset/neat-lists-continue.md
+++ b/.changeset/neat-lists-continue.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Continue adjacent compatible list instances after an explicit numbering restart.

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -112,23 +112,48 @@ const formatNumber = (value: number, numFmt: string): string => {
   }
 };
 
+type PreviousListState = {
+  abstractNumId: number | null;
+  fromStyle: boolean;
+  numId: number | null;
+};
+
+type ComputeListMarkerOptions = {
+  numbering: NumberingMap | null;
+  listCounters: Map<number, number[]>;
+  abstractCounters: Map<number, number[]>;
+  restartedNumIds: Set<number>;
+  previousList: PreviousListState;
+};
+
 const computeListMarker = (
   paragraph: Paragraph,
-  numbering: NumberingMap | null,
-  listCounters: Map<number, number[]>,
-  abstractCounters: Map<number, number[]>,
+  {
+    numbering,
+    listCounters,
+    abstractCounters,
+    restartedNumIds,
+    previousList,
+  }: ComputeListMarkerOptions,
 ): void => {
   const listRendering = paragraph.listRendering;
   if (!listRendering || !numbering) {
+    previousList.abstractNumId = null;
+    previousList.fromStyle = false;
+    previousList.numId = null;
     return;
   }
 
   const { numId, level } = listRendering;
   if (numId === 0) {
+    previousList.abstractNumId = null;
+    previousList.fromStyle = false;
+    previousList.numId = null;
     return;
   }
 
-  if (!listCounters.has(numId)) {
+  const firstEncounter = !listCounters.has(numId);
+  if (firstEncounter) {
     listCounters.set(numId, Array.from<number>({ length: 9 }).fill(Number.NaN));
   }
 
@@ -140,7 +165,25 @@ const computeListMarker = (
   const abstractNumId = numbering.getAbstractNumId(numId);
   const styleNumbering = paragraph.formatting?.numPrFromStyle;
   let resumedAbstractCounters: number[] | undefined;
-  if (abstractNumId !== null && styleNumbering) {
+  const resumesRestartedInstance =
+    firstEncounter &&
+    listRendering.startOverride === undefined &&
+    abstractNumId !== null &&
+    previousList.abstractNumId === abstractNumId &&
+    previousList.numId !== null &&
+    previousList.numId !== numId &&
+    restartedNumIds.has(previousList.numId);
+  const resumesStyleInstance =
+    firstEncounter &&
+    !styleNumbering &&
+    listRendering.startOverride === undefined &&
+    abstractNumId !== null &&
+    previousList.abstractNumId === abstractNumId &&
+    previousList.fromStyle === true;
+  if (
+    abstractNumId !== null &&
+    (styleNumbering || resumesRestartedInstance || resumesStyleInstance)
+  ) {
     const latestAbstractCounters = abstractCounters.get(abstractNumId);
     if (latestAbstractCounters) {
       // A paragraph whose numbering comes only from its style resumes the
@@ -153,6 +196,13 @@ const computeListMarker = (
       }
       resumedAbstractCounters = latestAbstractCounters;
     }
+  }
+  if (
+    listRendering.startOverride !== undefined ||
+    resumesRestartedInstance ||
+    (previousList.numId === numId && restartedNumIds.has(numId))
+  ) {
+    restartedNumIds.add(numId);
   }
   if (abstractNumId !== null && level > 0) {
     const latestAbstractCounters = abstractCounters.get(abstractNumId);
@@ -206,11 +256,17 @@ const computeListMarker = (
     }
     abstractCounters.set(abstractNumId, [...counters]);
   }
+  previousList.abstractNumId = abstractNumId;
+  previousList.fromStyle = Boolean(styleNumbering);
+  previousList.numId = numId;
 
   const pattern = listRendering.marker;
 
   if (listRendering.isBullet) {
     listRendering.marker = convertBulletToUnicode(pattern || "");
+    previousList.abstractNumId = null;
+    previousList.fromStyle = false;
+    previousList.numId = null;
     return;
   }
 
@@ -237,6 +293,8 @@ const computeListMarker = (
 type ParseBlockContentState = {
   listCounters: Map<number, number[]>;
   abstractCounters: Map<number, number[]>;
+  restartedNumIds: Set<number>;
+  previousList: PreviousListState;
   options: ParseBlockContentOptions | undefined;
 };
 
@@ -252,6 +310,8 @@ export const parseBlockContent = (
   parseBlockContentWithState(parent, styles, theme, numbering, rels, media, {
     listCounters: new Map(),
     abstractCounters: new Map(),
+    restartedNumIds: new Set(),
+    previousList: { abstractNumId: null, fromStyle: false, numId: null },
     // Accumulate the container's own xmlns onto the inherited in-scope set so a
     // captured VML `w:pict` replay resolves prefixes scoped on this level too.
     options: {
@@ -281,7 +341,13 @@ const parseBlockContentWithState = (
       const paragraph = parseParagraph(child, styles, theme, numbering, rels, media, state.options);
       prependPendingBookmarkMarkers(paragraph, pendingBookmarkMarkers);
       enrichParagraphTextBoxes(paragraph, child, styles, theme, numbering, rels, media);
-      computeListMarker(paragraph, numbering, state.listCounters, state.abstractCounters);
+      computeListMarker(paragraph, {
+        numbering,
+        listCounters: state.listCounters,
+        abstractCounters: state.abstractCounters,
+        restartedNumIds: state.restartedNumIds,
+        previousList: state.previousList,
+      });
       content.push(paragraph);
       continue;
     }

--- a/packages/core/src/docx/numbering-shared-abstract.test.ts
+++ b/packages/core/src/docx/numbering-shared-abstract.test.ts
@@ -177,6 +177,85 @@ test("style numbering resumes the latest compatible restarted instance", () => {
   ).toEqual(["(1)", "(1)", "(2)", "(3)"]);
 });
 
+test("an adjacent base instance continues an explicit restart instance", () => {
+  const numbering = parseNumbering(NUMBERING_SHARED);
+  const root = parseXmlDocument(
+    `<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:p><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Second</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Third</w:t></w:r></w:p>
+    </w:body>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse body XML");
+  }
+
+  const paragraphs = parseBlockContent(root, null, null, numbering, null, null);
+
+  expect(
+    paragraphs.map((paragraph) =>
+      paragraph.type === "paragraph" ? paragraph.listRendering?.marker : undefined,
+    ),
+  ).toEqual(["(1)", "(2)", "(3)"]);
+});
+
+test("a non-list paragraph ends an explicit restart handoff", () => {
+  const numbering = parseNumbering(NUMBERING_SHARED);
+  const root = parseXmlDocument(
+    `<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:p><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:r><w:t>Interruption</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Separate</w:t></w:r></w:p>
+    </w:body>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse body XML");
+  }
+
+  const paragraphs = parseBlockContent(root, null, null, numbering, null, null);
+
+  expect(
+    paragraphs.map((paragraph) =>
+      paragraph.type === "paragraph" ? paragraph.listRendering?.marker : undefined,
+    ),
+  ).toEqual(["(1)", undefined, "(1)"]);
+});
+
+test("a direct instance continues an adjacent style-derived sequence", () => {
+  const numbering = parseNumbering(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:abstractNum w:abstractNumId="4">
+        <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="(%1)"/></w:lvl>
+      </w:abstractNum>
+      <w:num w:numId="1"><w:abstractNumId w:val="4"/></w:num>
+      <w:num w:numId="2"><w:abstractNumId w:val="4"/></w:num>
+    </w:numbering>`);
+  const styles = parseStyles(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:style w:type="paragraph" w:styleId="Clause">
+        <w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr>
+      </w:style>
+    </w:styles>`);
+  const root = parseXmlDocument(
+    `<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:p><w:pPr><w:pStyle w:val="Clause"/></w:pPr><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:pPr><w:pStyle w:val="Clause"/></w:pPr><w:r><w:t>Second</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t>Third</w:t></w:r></w:p>
+    </w:body>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse body XML");
+  }
+
+  const paragraphs = parseBlockContent(root, styles, null, numbering, null, null);
+
+  expect(
+    paragraphs.map((paragraph) =>
+      paragraph.type === "paragraph" ? paragraph.listRendering?.marker : undefined,
+    ),
+  ).toEqual(["(1)", "(2)", "(3)"]);
+});
+
 test("a style-numbered bridge advances the concrete stream it resumes", () => {
   const numbering = parseNumbering(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">


### PR DESCRIPTION
## Summary

- continue adjacent compatible numbering when an explicit restart instance hands off to its base instance
- continue an adjacent direct instance from a style-derived sequence
- preserve independent numbering after a non-list interruption
- add a patch changeset for `@stll/folio-core`

## Validation

- focused numbering and layout regressions: 16 passed
- public API snapshots are current
- dependency audit found no vulnerabilities
- anonymous strict same-font comparison: 12/12 pages, score stable at 78.6%, text mismatches reduced from 47 to 40
- unrelated one-page control unchanged at 70.8%
- lint, typecheck, build, and full tests are delegated to CI

CC on behalf of @jan-kubica