### PR TITLE
fix: render inherited positioned footer text

### DIFF
--- a/.changeset/quiet-section-references.md
+++ b/.changeset/quiet-section-references.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Render positioned legacy text boxes and keep inherited section header and footer references active across framework adapters.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -6,6 +6,7 @@
 
 import { ImagePosition } from '@stll/docx-core/model';
 import { ImageWrap } from '@stll/docx-core/model';
+import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
 import { ShapeTextBody } from '@stll/docx-core/model';
@@ -658,6 +659,9 @@ export type ParagraphSpacing = {
     lineUnit?: "px" | "multiplier";
     lineRule?: "auto" | "exact" | "atLeast";
 };
+
+// @public (undocumented)
+export const resolveSectionHeaderFooterRefs: (documentModel: import__stll_docx_core_model.Document | null | undefined) => PageHeaderFooterRefs[] | undefined;
 
 // @public
 export type Run = TextRun | TabRun | ImageRun | LineBreakRun | FieldRun | MathRun;

--- a/packages/core/src/docx/headerFooterParser.test.ts
+++ b/packages/core/src/docx/headerFooterParser.test.ts
@@ -129,4 +129,37 @@ describe("header/footer text boxes", () => {
 
     expect(getShapeTexts(footer)).toEqual(["Footer Box"]);
   });
+
+  test("parses positioned VML text boxes in footers", () => {
+    const footer = parseFooter(`
+      <w:ftr ${NAMESPACES}>
+        <w:p><w:r><w:pict>
+          <v:shape id="footer-box" style="position:absolute;margin-left:72pt;margin-top:720pt;width:216pt;height:18pt;z-index:-1;mso-position-horizontal-relative:page;mso-position-vertical-relative:page" filled="f" stroked="f">
+            <v:textbox inset="0,0,0,0">
+              <w:txbxContent><w:p><w:r><w:t>Positioned footer</w:t></w:r></w:p></w:txbxContent>
+            </v:textbox>
+          </v:shape>
+        </w:pict></w:r></w:p>
+      </w:ftr>`);
+
+    expect(getShapeTexts(footer)).toEqual(["Positioned footer"]);
+    const paragraph = footer.content.at(0);
+    const run = paragraph?.type === "paragraph" ? paragraph.content.at(0) : undefined;
+    const shapeContent = run?.type === "run" ? run.content.at(0) : undefined;
+    if (shapeContent?.type !== "shape") {
+      throw new Error("Expected positioned text box");
+    }
+    expect(shapeContent.shape).toMatchObject({
+      id: "footer-box",
+      shapeType: "textBox",
+      size: { width: 2_743_200, height: 228_600 },
+      position: {
+        horizontal: { relativeTo: "page", posOffset: 914_400 },
+        vertical: { relativeTo: "page", posOffset: 9_144_000 },
+      },
+      wrap: { type: "behind" },
+      fill: { type: "none" },
+      textBody: { margins: { left: 0, top: 0, right: 0, bottom: 0 } },
+    });
+  });
 });

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -136,6 +136,16 @@ const parseVmlInsets = (
 const parseVmlFill = (shapeEl: XmlElement): Shape["fill"] =>
   getAttribute(shapeEl, null, "filled")?.toLowerCase() === "f" ? { type: "none" } : undefined;
 
+const vmlWrapType = (positioned: boolean, zIndex: number): NonNullable<Shape["wrap"]>["type"] => {
+  if (!positioned) {
+    return "inline";
+  }
+  if (Number.isFinite(zIndex) && zIndex < 0) {
+    return "behind";
+  }
+  return "inFront";
+};
+
 export const enrichParagraphTextBoxes = (
   paragraph: Paragraph,
   paraXml: XmlElement,
@@ -344,9 +354,7 @@ const parseVmlTextBoxShape = (
     shapeType: "textBox",
     size: { width: pixelsToEmu(width), height: pixelsToEmu(height) },
     ...(fill === undefined ? {} : { fill }),
-    wrap: {
-      type: !positioned ? "inline" : Number.isFinite(zIndex) && zIndex < 0 ? "behind" : "inFront",
-    },
+    wrap: { type: vmlWrapType(positioned, zIndex) },
     textBody: {
       content: parseTextBoxContent(
         contentEl,

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -1,4 +1,5 @@
 import type {
+  ImagePosition,
   MediaFile,
   Paragraph,
   RelationshipMap,
@@ -7,6 +8,7 @@ import type {
   ShapeContent,
   Theme,
 } from "../types/document";
+import { pixelsToEmu } from "../utils/units";
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
 import type { StyleMap } from "./styleParser";
@@ -16,7 +18,123 @@ import {
   parseTextBox,
   parseTextBoxContent,
 } from "./textBoxParser";
-import { findDeep, getChildElements, getLocalName, type XmlElement } from "./xmlParser";
+import {
+  findDeep,
+  getAttribute,
+  getChildElements,
+  getLocalName,
+  type XmlElement,
+} from "./xmlParser";
+
+const VML_HORIZONTAL_RELATIVES = new Set<ImagePosition["horizontal"]["relativeTo"]>([
+  "character",
+  "column",
+  "insideMargin",
+  "leftMargin",
+  "margin",
+  "outsideMargin",
+  "page",
+  "rightMargin",
+]);
+const VML_VERTICAL_RELATIVES = new Set<ImagePosition["vertical"]["relativeTo"]>([
+  "insideMargin",
+  "line",
+  "margin",
+  "outsideMargin",
+  "page",
+  "paragraph",
+  "topMargin",
+  "bottomMargin",
+]);
+
+const parseVmlStyle = (value: string | null): Record<string, string> => {
+  const declarations: Record<string, string> = {};
+  for (const declaration of value?.split(";") ?? []) {
+    const separator = declaration.indexOf(":");
+    if (separator < 0) {
+      continue;
+    }
+    const key = declaration.slice(0, separator).trim().toLowerCase();
+    if (key) {
+      declarations[key] = declaration.slice(separator + 1).trim();
+    }
+  }
+  return declarations;
+};
+
+const vmlLengthToPixels = (value: string | undefined): number | undefined => {
+  const match = /^(?<amount>-?(?:\d+(?:\.\d+)?|\.\d+))\s*(?<unit>pt|in|px|cm|mm|pc)?$/iu.exec(
+    value?.trim() ?? "",
+  );
+  const amount = Number.parseFloat(match?.groups?.["amount"] ?? "");
+  if (!Number.isFinite(amount)) {
+    return undefined;
+  }
+  switch (match?.groups?.["unit"]?.toLowerCase()) {
+    case "pt":
+      return (amount / 72) * 96;
+    case "in":
+      return amount * 96;
+    case "cm":
+      return (amount / 2.54) * 96;
+    case "mm":
+      return (amount / 25.4) * 96;
+    case "pc":
+      return amount * 16;
+    case "px":
+    case undefined:
+      return amount;
+    default:
+      return undefined;
+  }
+};
+
+const horizontalRelativeTo = (
+  value: string | undefined,
+): ImagePosition["horizontal"]["relativeTo"] => {
+  for (const relative of VML_HORIZONTAL_RELATIVES) {
+    if (relative.toLowerCase() === value?.toLowerCase()) {
+      return relative;
+    }
+  }
+  return "character";
+};
+
+const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"]["relativeTo"] => {
+  for (const relative of VML_VERTICAL_RELATIVES) {
+    if (relative.toLowerCase() === value?.toLowerCase()) {
+      return relative;
+    }
+  }
+  return "paragraph";
+};
+
+const parseVmlInsets = (
+  textBoxEl: XmlElement,
+): { left: number; top: number; right: number; bottom: number } | undefined => {
+  const [left, top, right, bottom, extra] =
+    getAttribute(textBoxEl, null, "inset")
+      ?.split(",")
+      .map((value) => vmlLengthToPixels(value)) ?? [];
+  if (
+    extra !== undefined ||
+    left === undefined ||
+    top === undefined ||
+    right === undefined ||
+    bottom === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    left: pixelsToEmu(left),
+    top: pixelsToEmu(top),
+    right: pixelsToEmu(right),
+    bottom: pixelsToEmu(bottom),
+  };
+};
+
+const parseVmlFill = (shapeEl: XmlElement): Shape["fill"] =>
+  getAttribute(shapeEl, null, "filled")?.toLowerCase() === "f" ? { type: "none" } : undefined;
 
 export const enrichParagraphTextBoxes = (
   paragraph: Paragraph,
@@ -42,7 +160,8 @@ export const enrichParagraphTextBoxes = (
       continue;
     }
 
-    const { textBoxDrawings, hasNonTextBoxContent } = scanRunForTextBoxDrawings(xmlChild);
+    const { textBoxDrawings, vmlTextBoxes, hasNonTextBoxContent } =
+      scanRunForTextBoxDrawings(xmlChild);
 
     const parsedContent = paragraph.content[parsedIndex];
     const parsedRun: Run | undefined = parsedContent?.type === "run" ? parsedContent : undefined;
@@ -101,6 +220,22 @@ export const enrichParagraphTextBoxes = (
       }
     }
 
+    for (const pictEl of vmlTextBoxes) {
+      const shape = parseVmlTextBoxShape(pictEl, styles, theme, numbering, rels, media);
+      if (!shape) {
+        continue;
+      }
+      const shapeContent: ShapeContent = { type: "shape", shape };
+      if (targetRun && hasNonTextBoxContent) {
+        targetRun.content.push(shapeContent);
+      } else {
+        const newRun: Run = { type: "run", content: [shapeContent] };
+        paragraph.content.splice(parsedIndex, 0, newRun);
+        lastConsumedRun = newRun;
+        parsedIndex += 1;
+      }
+    }
+
     if (hasNonTextBoxContent && parsedRun) {
       lastConsumedRun = parsedRun;
       parsedIndex += 1;
@@ -110,11 +245,13 @@ export const enrichParagraphTextBoxes = (
 
 type TextBoxRunScan = {
   textBoxDrawings: XmlElement[];
+  vmlTextBoxes: XmlElement[];
   hasNonTextBoxContent: boolean;
 };
 
 const scanRunForTextBoxDrawings = (xmlRun: XmlElement): TextBoxRunScan => {
   const textBoxDrawings: XmlElement[] = [];
+  const vmlTextBoxes: XmlElement[] = [];
   let hasNonTextBoxContent = false;
 
   const visitDrawing = (drawingEl: XmlElement): void => {
@@ -132,6 +269,14 @@ const scanRunForTextBoxDrawings = (xmlRun: XmlElement): TextBoxRunScan => {
     }
     if (name === "drawing") {
       visitDrawing(el);
+      continue;
+    }
+    if (name === "pict") {
+      if (findDeep(el, "v", "textbox")) {
+        vmlTextBoxes.push(el);
+      } else {
+        hasNonTextBoxContent = true;
+      }
       continue;
     }
     if (name === "AlternateContent") {
@@ -163,5 +308,74 @@ const scanRunForTextBoxDrawings = (xmlRun: XmlElement): TextBoxRunScan => {
     hasNonTextBoxContent = true;
   }
 
-  return { textBoxDrawings, hasNonTextBoxContent };
+  return { textBoxDrawings, vmlTextBoxes, hasNonTextBoxContent };
+};
+
+const parseVmlTextBoxShape = (
+  pictEl: XmlElement,
+  styles: StyleMap | null,
+  theme: Theme | null,
+  numbering: NumberingMap | null,
+  rels: RelationshipMap | null,
+  media: Map<string, MediaFile> | null,
+): Shape | null => {
+  const shapeEl = findDeep(pictEl, "v", "shape");
+  const textBoxEl = shapeEl ? findDeep(shapeEl, "v", "textbox") : null;
+  const contentEl = textBoxEl ? findDeep(textBoxEl, "w", "txbxContent") : null;
+  if (!shapeEl || !contentEl) {
+    return null;
+  }
+
+  const style = parseVmlStyle(getAttribute(shapeEl, null, "style"));
+  const width = vmlLengthToPixels(style["width"]);
+  const height = vmlLengthToPixels(style["height"]);
+  if (width === undefined || height === undefined || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  const left = vmlLengthToPixels(style["margin-left"] ?? style["left"]);
+  const top = vmlLengthToPixels(style["margin-top"] ?? style["top"]);
+  const positioned = style["position"]?.toLowerCase() === "absolute";
+  const zIndex = Number.parseInt(style["z-index"] ?? "", 10);
+  const margins = parseVmlInsets(textBoxEl);
+  const fill = parseVmlFill(shapeEl);
+  const shape: Shape = {
+    type: "shape",
+    shapeType: "textBox",
+    size: { width: pixelsToEmu(width), height: pixelsToEmu(height) },
+    ...(fill === undefined ? {} : { fill }),
+    wrap: {
+      type: !positioned ? "inline" : Number.isFinite(zIndex) && zIndex < 0 ? "behind" : "inFront",
+    },
+    textBody: {
+      content: parseTextBoxContent(
+        contentEl,
+        parseParagraph,
+        null,
+        styles,
+        theme,
+        numbering,
+        rels ?? undefined,
+        media ?? undefined,
+      ),
+      ...(margins === undefined ? {} : { margins }),
+    },
+  };
+  const id = getAttribute(shapeEl, null, "id");
+  if (id) {
+    shape.id = id;
+  }
+  if (positioned) {
+    shape.position = {
+      horizontal: {
+        relativeTo: horizontalRelativeTo(style["mso-position-horizontal-relative"]),
+        ...(left === undefined ? {} : { posOffset: pixelsToEmu(left) }),
+      },
+      vertical: {
+        relativeTo: verticalRelativeTo(style["mso-position-vertical-relative"]),
+        ...(top === undefined ? {} : { posOffset: pixelsToEmu(top) }),
+      },
+    };
+  }
+  return shape;
 };

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -332,7 +332,7 @@ const parseVmlTextBoxShape = (
   const shapeEl = findDeep(pictEl, "v", "shape");
   const textBoxEl = shapeEl ? findDeep(shapeEl, "v", "textbox") : null;
   const contentEl = textBoxEl ? findDeep(textBoxEl, "w", "txbxContent") : null;
-  if (!shapeEl || !contentEl) {
+  if (!shapeEl || !textBoxEl || !contentEl) {
     return null;
   }
 

--- a/packages/core/src/layout-engine/headerFooterRefs.test.ts
+++ b/packages/core/src/layout-engine/headerFooterRefs.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { createEmptyDocument } from "../utils/createDocument";
+import { resolveSectionHeaderFooterRefs } from "./headerFooterRefs";
+
+describe("resolveSectionHeaderFooterRefs", () => {
+  test("inherits omitted slots independently across sections", () => {
+    const document = createEmptyDocument();
+    document.package.document.sections = [
+      {
+        content: [],
+        properties: {
+          headerReferences: [
+            { type: "default", rId: "header-default" },
+            { type: "first", rId: "header-first" },
+          ],
+          footerReferences: [{ type: "default", rId: "footer-default" }],
+        },
+      },
+      {
+        content: [],
+        properties: {
+          titlePg: true,
+          headerReferences: [{ type: "first", rId: "next-header-first" }],
+        },
+      },
+      {
+        content: [],
+        properties: {
+          footerReferences: [{ type: "default", rId: "next-footer-default" }],
+        },
+      },
+    ];
+
+    expect(resolveSectionHeaderFooterRefs(document)).toEqual([
+      {
+        evenAndOddHeaders: false,
+        headerDefault: "header-default",
+        headerFirst: "header-first",
+        footerDefault: "footer-default",
+      },
+      {
+        evenAndOddHeaders: false,
+        titlePg: true,
+        headerDefault: "header-default",
+        headerFirst: "next-header-first",
+        footerDefault: "footer-default",
+      },
+      {
+        evenAndOddHeaders: false,
+        headerDefault: "header-default",
+        headerFirst: "next-header-first",
+        footerDefault: "next-footer-default",
+      },
+    ]);
+  });
+
+  test("applies the document odd-even setting without inheriting title-page mode", () => {
+    const document = createEmptyDocument();
+    document.package.settings = { evenAndOddHeaders: true };
+    document.package.document.sections = [
+      {
+        content: [],
+        properties: {
+          titlePg: true,
+          headerReferences: [{ type: "even", rId: "even-header" }],
+        },
+      },
+      { content: [], properties: {} },
+    ];
+
+    expect(resolveSectionHeaderFooterRefs(document)).toEqual([
+      { evenAndOddHeaders: true, titlePg: true, headerEven: "even-header" },
+      { evenAndOddHeaders: true, headerEven: "even-header" },
+    ]);
+  });
+
+  test("uses final section properties when the section list is absent", () => {
+    const document = createEmptyDocument();
+    document.package.document.finalSectionProperties = {
+      footerReferences: [{ type: "default", rId: "footer" }],
+    };
+
+    expect(resolveSectionHeaderFooterRefs(document)).toEqual([
+      { evenAndOddHeaders: false, footerDefault: "footer" },
+    ]);
+  });
+
+  test("returns no references without a document model", () => {
+    expect(resolveSectionHeaderFooterRefs(null)).toBeUndefined();
+    expect(resolveSectionHeaderFooterRefs(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout-engine/headerFooterRefs.ts
+++ b/packages/core/src/layout-engine/headerFooterRefs.ts
@@ -1,0 +1,75 @@
+import type { Document, SectionProperties } from "../types/document";
+import type { PageHeaderFooterRefs } from "./types";
+
+type InheritedHeaderFooterRefs = Pick<
+  PageHeaderFooterRefs,
+  "headerDefault" | "headerFirst" | "headerEven" | "footerDefault" | "footerFirst" | "footerEven"
+>;
+
+const resolveSectionRefs = (
+  props: SectionProperties,
+  inherited: InheritedHeaderFooterRefs,
+  documentEvenAndOddHeaders: boolean,
+): PageHeaderFooterRefs => {
+  const refs: PageHeaderFooterRefs = {
+    ...inherited,
+    evenAndOddHeaders: props.evenAndOddHeaders ?? documentEvenAndOddHeaders,
+  };
+  if (props.titlePg !== undefined) {
+    refs.titlePg = props.titlePg;
+  }
+  for (const ref of props.headerReferences ?? []) {
+    if (ref.type === "default") {
+      refs.headerDefault = ref.rId;
+    } else if (ref.type === "first") {
+      refs.headerFirst = ref.rId;
+    } else {
+      refs.headerEven = ref.rId;
+    }
+  }
+  for (const ref of props.footerReferences ?? []) {
+    if (ref.type === "default") {
+      refs.footerDefault = ref.rId;
+    } else if (ref.type === "first") {
+      refs.footerFirst = ref.rId;
+    } else {
+      refs.footerEven = ref.rId;
+    }
+  }
+  return refs;
+};
+
+const inheritedRefsFrom = (refs: PageHeaderFooterRefs): InheritedHeaderFooterRefs => ({
+  ...(refs.headerDefault === undefined ? {} : { headerDefault: refs.headerDefault }),
+  ...(refs.headerFirst === undefined ? {} : { headerFirst: refs.headerFirst }),
+  ...(refs.headerEven === undefined ? {} : { headerEven: refs.headerEven }),
+  ...(refs.footerDefault === undefined ? {} : { footerDefault: refs.footerDefault }),
+  ...(refs.footerFirst === undefined ? {} : { footerFirst: refs.footerFirst }),
+  ...(refs.footerEven === undefined ? {} : { footerEven: refs.footerEven }),
+});
+
+export const resolveSectionHeaderFooterRefs = (
+  documentModel: Document | null | undefined,
+): PageHeaderFooterRefs[] | undefined => {
+  const body = documentModel?.package.document;
+  if (!body) {
+    return undefined;
+  }
+  const sections =
+    body.sections && body.sections.length > 0
+      ? body.sections.map(({ properties }) => properties)
+      : body.finalSectionProperties
+        ? [body.finalSectionProperties]
+        : [];
+  if (sections.length === 0) {
+    return undefined;
+  }
+
+  const documentEvenAndOddHeaders = documentModel.package.settings?.evenAndOddHeaders === true;
+  let inherited: InheritedHeaderFooterRefs = {};
+  return sections.map((props) => {
+    const refs = resolveSectionRefs(props, inherited, documentEvenAndOddHeaders);
+    inherited = inheritedRefsFrom(refs);
+    return refs;
+  });
+};

--- a/packages/core/src/layout-engine/headerFooterRefs.ts
+++ b/packages/core/src/layout-engine/headerFooterRefs.ts
@@ -55,12 +55,12 @@ export const resolveSectionHeaderFooterRefs = (
   if (!body) {
     return undefined;
   }
-  const sections =
-    body.sections && body.sections.length > 0
-      ? body.sections.map(({ properties }) => properties)
-      : body.finalSectionProperties
-        ? [body.finalSectionProperties]
-        : [];
+  const sections: SectionProperties[] = [];
+  if (body.sections && body.sections.length > 0) {
+    sections.push(...body.sections.map(({ properties }) => properties));
+  } else if (body.finalSectionProperties) {
+    sections.push(body.finalSectionProperties);
+  }
   if (sections.length === 0) {
     return undefined;
   }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1696,6 +1696,7 @@ export {
   hasPageBreakBefore,
 } from "./keep-together";
 export type { KeepNextChain } from "./keep-together";
+export { resolveSectionHeaderFooterRefs } from "./headerFooterRefs";
 export {
   scheduleSectionBreak,
   applyPendingToActive,

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -90,7 +90,7 @@ import type {
 } from "@stll/folio-core/layout-bridge/engine/selectionRects";
 import type * as SelectionGeometry from "@stll/folio-core/layout-bridge/engine/selectionRects";
 // Layout engine
-import type { ColumnLayout } from "@stll/folio-core/layout-engine";
+import { resolveSectionHeaderFooterRefs, type ColumnLayout } from "@stll/folio-core/layout-engine";
 import { recordLayoutPhase } from "@stll/folio-core/layout-engine/layoutInstrumentation";
 import type { LayoutRunReason } from "@stll/folio-core/layout-engine/layoutInstrumentation";
 import type {
@@ -902,57 +902,6 @@ function renderHeaderFooterContentByRId(
     }
   }
   return rendered.size > 0 ? rendered : undefined;
-}
-
-function getSectionHeaderFooterRefs(
-  documentModel: Document | null | undefined,
-): PageHeaderFooterRefs[] | undefined {
-  const body = documentModel?.package.document;
-  if (!body) {
-    return undefined;
-  }
-  const documentEvenAndOddHeaders = documentModel.package.settings?.evenAndOddHeaders === true;
-  const sections = body.sections;
-  if (sections && sections.length > 0) {
-    return sections.map((section) =>
-      getHeaderFooterRefsFromSectionProperties(section.properties, documentEvenAndOddHeaders),
-    );
-  }
-  const finalProps = body.finalSectionProperties;
-  if (!finalProps) {
-    return undefined;
-  }
-  return [getHeaderFooterRefsFromSectionProperties(finalProps, documentEvenAndOddHeaders)];
-}
-
-function getHeaderFooterRefsFromSectionProperties(
-  props: SectionProperties,
-  documentEvenAndOddHeaders: boolean,
-): PageHeaderFooterRefs {
-  const refs: PageHeaderFooterRefs = {};
-  if (props.titlePg !== undefined) {
-    refs.titlePg = props.titlePg;
-  }
-  refs.evenAndOddHeaders = props.evenAndOddHeaders ?? documentEvenAndOddHeaders;
-  for (const ref of props.headerReferences ?? []) {
-    if (ref.type === "default") {
-      refs.headerDefault = ref.rId;
-    } else if (ref.type === "first") {
-      refs.headerFirst = ref.rId;
-    } else {
-      refs.headerEven = ref.rId;
-    }
-  }
-  for (const ref of props.footerReferences ?? []) {
-    if (ref.type === "default") {
-      refs.footerDefault = ref.rId;
-    } else if (ref.type === "first") {
-      refs.footerFirst = ref.rId;
-    } else {
-      refs.footerEven = ref.rId;
-    }
-  }
-  return refs;
 }
 
 type LayoutInputSignatureOptions = {
@@ -1814,7 +1763,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       documentSettings !== undefined &&
       "mirrorMargins" in documentSettings &&
       documentSettings.mirrorMargins === true;
-    const sectionHeaderFooterRefs = useMemo(() => getSectionHeaderFooterRefs(document), [document]);
+    const sectionHeaderFooterRefs = useMemo(
+      () => resolveSectionHeaderFooterRefs(document),
+      [document],
+    );
     const layoutInputSignature = useMemo(
       () =>
         buildLayoutInputSignature({

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -55,14 +55,13 @@ import {
   convertHeaderFooterPmDocToContent,
   convertHeaderFooterToContent,
 } from "@stll/folio-core/layout-bridge/convert/headerFooterLayout";
-import type { ColumnLayout } from "@stll/folio-core/layout-engine";
+import { resolveSectionHeaderFooterRefs, type ColumnLayout } from "@stll/folio-core/layout-engine";
 import type {
   FlowBlock,
   FootnoteContent,
   HeaderFooterContent,
   Layout,
   Measure,
-  PageHeaderFooterRefs,
 } from "@stll/folio-core/layout-engine/types";
 import { LayoutPainter } from "@stll/folio-core/layout-painter";
 import type { FootnoteRenderItem } from "@stll/folio-core/layout-painter/renderPage";
@@ -143,50 +142,6 @@ function getColumns(sectionProps: SectionProperties | null | undefined): ColumnL
     cols.separator = sectionProps.separator;
   }
   return cols;
-}
-
-function getHeaderFooterRefsFromSectionProperties(props: SectionProperties): PageHeaderFooterRefs {
-  const refs: PageHeaderFooterRefs = {};
-  if (props.titlePg !== undefined) {
-    refs.titlePg = props.titlePg;
-  }
-  for (const hfRef of props.headerReferences ?? []) {
-    if (hfRef.type === "default") {
-      refs.headerDefault = hfRef.rId;
-    } else if (hfRef.type === "first") {
-      refs.headerFirst = hfRef.rId;
-    } else {
-      refs.headerEven = hfRef.rId;
-    }
-  }
-  for (const hfRef of props.footerReferences ?? []) {
-    if (hfRef.type === "default") {
-      refs.footerDefault = hfRef.rId;
-    } else if (hfRef.type === "first") {
-      refs.footerFirst = hfRef.rId;
-    } else {
-      refs.footerEven = hfRef.rId;
-    }
-  }
-  return refs;
-}
-
-function getSectionHeaderFooterRefs(
-  documentModel: Document | null,
-): PageHeaderFooterRefs[] | undefined {
-  const body = documentModel?.package.document;
-  if (!body) {
-    return undefined;
-  }
-  const sections = body.sections;
-  if (sections && sections.length > 0) {
-    return sections.map((section) => getHeaderFooterRefsFromSectionProperties(section.properties));
-  }
-  const finalProps = body.finalSectionProperties;
-  if (!finalProps) {
-    return undefined;
-  }
-  return [getHeaderFooterRefsFromSectionProperties(finalProps)];
 }
 
 /** One resolved header/footer slot: its `HeaderFooter` and relationship id. */
@@ -676,7 +631,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
           footerContentRId: hf.footer.rId,
           firstPageHeaderContentRId: hf.firstHeader.rId,
           firstPageFooterContentRId: hf.firstFooter.rId,
-          sectionHeaderFooterRefs: getSectionHeaderFooterRefs(model),
+          sectionHeaderFooterRefs: resolveSectionHeaderFooterRefs(model),
           theme,
           sectionProperties: sectionProps,
           document: model,


### PR DESCRIPTION
## Summary
- render positioned legacy text boxes through the existing shape pipeline
- inherit omitted header and footer relationship slots across sections
- share section reference resolution between the React and Vue adapters

## Validation
- 47 focused parser and layout tests pass
- strict same-font anonymous replay: 75.7% to 76.7%, 11/11 pages; 14 missing lines removed
- unrelated control unchanged at 95.7%, 1/1 page
- bun audit
- lint, typecheck, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica