### PR TITLE
fix: keep page-fitting table rows intact

### DIFF
--- a/.changeset/calm-table-rows.md
+++ b/.changeset/calm-table-rows.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Move page-fitting table rows intact to the next flow region.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -995,9 +995,6 @@ function layoutTable(
   const getCurrentRowCapacity = (state = paginator.getCurrentState()): number =>
     state.rawContentBottom - state.topMargin;
 
-  const getCurrentAvailableHeight = (state = paginator.getCurrentState()): number =>
-    state.contentBottom - state.cursorY;
-
   const hasAdjacentPriorTableRows = (
     rowIndex: number,
     state = paginator.getCurrentState(),
@@ -1026,20 +1023,13 @@ function layoutTable(
     if (!row) {
       return false;
     }
-    const repeatedHeaderOverhead = shouldRepeatHeaderRows(rowIndex, 0, state)
-      ? headerRowsHeight
-      : 0;
     if ((breakInfo.breakOffsets[rowIndex]?.length ?? 0) <= 1) {
       return false;
     }
-    const requiredHeight = row.height + repeatedHeaderOverhead;
-    if (requiredHeight > getCurrentRowCapacity(state)) {
-      return true;
-    }
-    return (
-      hasAdjacentPriorTableRows(rowIndex, state) &&
-      requiredHeight > getCurrentAvailableHeight(state) - state.trailingSpacing
-    );
+    const freshHeaderOverhead =
+      headerRowCount > 0 && rowIndex >= headerRowCount ? headerRowsHeight : 0;
+    const requiredHeight = row.height + freshHeaderOverhead;
+    return requiredHeight > getCurrentRowCapacity(state);
   };
 
   while (currentRowIndex < rows.length) {

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -944,6 +944,33 @@ describe("oversized table row splits across pages (#570)", () => {
     expect(frags[0]?.y).toBe(OPTIONS.margins.top);
   });
 
+  test("moves a page-fitting row intact after adjacent table rows", () => {
+    const { block, measure } = tableWithHeaderTallBodyAndShortRow(4);
+    measure.rows[2] = {
+      cells: [{ blocks: [paraMeasure(3)], width: 220, height: 3 * LINE }],
+      height: 3 * LINE,
+    };
+    measure.totalHeight = 8 * LINE;
+
+    const layout = layoutDocument([block as FlowBlock], [measure as Measure], OPTIONS);
+    const firstPageTables =
+      layout.pages[0]?.fragments.filter((f): f is TableFragment => f.kind === "table") ?? [];
+    const secondPageTables =
+      layout.pages[1]?.fragments.filter((f): f is TableFragment => f.kind === "table") ?? [];
+
+    expect(firstPageTables).toHaveLength(1);
+    expect(firstPageTables[0]).toMatchObject({ fromRow: 0, toRow: 2 });
+    expect(firstPageTables[0]?.bottomClip).toBeUndefined();
+    expect(secondPageTables).toHaveLength(1);
+    expect(secondPageTables[0]).toMatchObject({
+      fromRow: 2,
+      toRow: 3,
+      headerRowCount: 1,
+    });
+    expect(secondPageTables[0]?.topClip).toBeUndefined();
+    expect(secondPageTables[0]?.bottomClip).toBeUndefined();
+  });
+
   test("keeps page-fitting rows whole after footnote reservations", () => {
     const spacer: FlowBlock = {
       kind: "paragraph",


### PR DESCRIPTION
## Summary
- move page-fitting body rows intact to the next flow region instead of slicing into residual space
- include repeated header height when deciding whether a row is genuinely oversized
- add a synthetic regression for adjacent table rows and repeated headers

## Validation
- 33 focused table and layout tests pass
- anonymous same-font replay: 59.0% → 67.8%, 3/3 pages, all 16 pagination divergences removed
- unrelated control unchanged at 95.7%, 1/1 page
- dependency audit reports no vulnerabilities
- lint, typecheck, build, distribution validation, and full tests are delegated to CI

CC on behalf of @jan-kubica