### PR TITLE
fix: clear wide tables below floating exclusions

### DIFF
--- a/.changeset/calm-floating-tables.md
+++ b/.changeset/calm-floating-tables.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Place wide in-flow tables below active floating exclusions when they cannot fit beside them.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -258,6 +258,50 @@ describe("measureBlocks", () => {
     }, fakeMeasure);
   });
 
+  test("clears a full-width table below a square-wrapped text box", () => {
+    withFakeTextMeasure(() => {
+      const textBox: TextBoxBlock = {
+        kind: "textBox",
+        id: "square-box",
+        width: 300,
+        height: 100,
+        content: [],
+        wrapType: "square",
+        wrapText: "bothSides",
+        position: {
+          horizontal: { relativeTo: "page", posOffset: pixelsToEmu(96) },
+          vertical: { relativeTo: "page", posOffset: pixelsToEmu(96) },
+        },
+      };
+      const table: TableBlock = {
+        kind: "table",
+        id: "body-table",
+        columnWidths: [600],
+        rows: [
+          {
+            id: "row",
+            height: 40,
+            cells: [{ id: "cell", blocks: [para("cell-content", "content")] }],
+          },
+        ],
+      };
+
+      const measures = measureBlocks([textBox, table], 600, 96, {
+        pageWidth: 792,
+        pageHeight: 1_056,
+        marginLeft: 96,
+        marginRight: 96,
+        marginBottom: 96,
+      });
+      const tableMeasure = measures.at(1);
+      if (tableMeasure?.kind !== "table") {
+        throw new Error("Expected table measure");
+      }
+
+      expect(tableMeasure.bandSkipBefore).toBe(100);
+    }, fakeMeasure);
+  });
+
   test("uses the anchor section width for positioned text-box exclusion", () => {
     withFakeTextMeasure(() => {
       const textBox: TextBoxBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -1085,19 +1085,29 @@ export function measureBlocks(
         : contentWidth;
       const measure = measureBlock(block, blockWidth, zones, cumulativeY, fieldValues);
 
-      // Paragraphs clear a full-width band internally (findClearLineY inside
-      // measureParagraph). An in-flow table or inline image does not, so reserve
-      // a leading skip here that layout applies before the block, pushing it
-      // below the band rather than under it. eigenpal #694.
-      const bandZones = zones?.filter((zone) => zone.fullWidthBlock);
+      // Paragraphs clear floating exclusions internally (findClearLineY inside
+      // measureParagraph). An in-flow table cannot reflow its cells around a
+      // side exclusion, so require room for the whole table. Block images keep
+      // the existing full-width-band behavior.
+      const clearingZones =
+        measure.kind === "table" ? zones : zones?.filter((zone) => zone.fullWidthBlock);
       if (
-        bandZones?.length &&
+        clearingZones?.length &&
         (measure.kind === "image" || (measure.kind === "table" && !(block as TableBlock).floating))
       ) {
         const blockHeight = measure.kind === "image" ? measure.height : measure.totalHeight;
+        const requiredWidth =
+          measure.kind === "table"
+            ? Math.min(blockWidth, measure.totalWidth)
+            : MIN_WRAP_SEGMENT_WIDTH;
         const skip =
-          findClearLineY(cumulativeY, blockHeight, bandZones, blockWidth, MIN_WRAP_SEGMENT_WIDTH) -
-          cumulativeY;
+          findClearLineY(
+            cumulativeY,
+            blockHeight,
+            clearingZones,
+            blockWidth,
+            Math.max(MIN_WRAP_SEGMENT_WIDTH, requiredWidth),
+          ) - cumulativeY;
         if (skip > 0) {
           measure.bandSkipBefore = skip;
           cumulativeY += skip;


### PR DESCRIPTION
## Summary

- require enough horizontal room for an in-flow table while a floating exclusion is active
- place wide tables below positioned square-wrapped text boxes instead of overlapping them
- preserve paragraph wrapping and existing full-width image-band behavior

## Validation

- 51 focused layout tests pass
- strict metric-compatible anonymous replay: 22.6% → 25.8%; one vertical divergence removed
- unrelated control replay unchanged at 95.7%, 1/1 page
- `bun audit`
- lint, typecheck, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica