### PR TITLE
feat: add profile-aware DOCX diagnostics

### DIFF
--- a/.changeset/smooth-dolls-pull.md
+++ b/.changeset/smooth-dolls-pull.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add profile-aware DOCX compatibility diagnostics.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -299,9 +299,47 @@ export { Document_2 as Document }
 
 // @public (undocumented)
 export type DocxCompatibility = {
+    schemaVersion: 1;
+    context: DocxCompatibilityContext;
     canSafelyEdit: boolean;
+    issues: DocxCompatibilityIssue[];
     reasons: DocxCompatibilityReason[];
     unsupportedContentCount: number;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityContext = {
+    host: FolioDocxCompatibilityHost;
+    profile: FolioDocxCompatibilityProfile;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityIssue = {
+    code: DocxCompatibilityReason;
+    capability: FolioDocxFeatureCapability;
+    coverage: {
+        host: "covered" | "unknown" | "unverified";
+        profile: "covered" | "unknown" | "unverified";
+    };
+    location: DocxCompatibilityLocation;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityLocation = {
+    part: DocxCompatibilityPart;
+    path: string;
+    blockId?: string;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityPart = {
+    type: "document";
+} | {
+    type: "header" | "footer";
+    relationshipId: string;
+} | {
+    type: "footnote" | "endnote";
+    id: number;
 };
 
 // @public
@@ -357,6 +395,54 @@ export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_HOSTS: readonly ["browser", "server"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_IDS: readonly ["opaqueDrawing"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_MANIFEST: Readonly<{
+    version: 1;
+    capabilities: Readonly<{
+        opaqueDrawing: Readonly<{
+            readonly id: "opaqueDrawing";
+            readonly feature: "drawings";
+            readonly hosts: readonly ["browser", "server"];
+            readonly profiles: readonly "transitional"[];
+            readonly support: Readonly<{
+                create: "unsupported";
+                edit: "unsupported";
+                preserve: "supported";
+                read: "supported";
+                render: "partial";
+            }>;
+            readonly evidence: readonly {
+                type: "test";
+                path: string;
+            }[];
+        }>;
+    }>;
+}>;
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION: 1;
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_OPERATIONS: readonly ["create", "edit", "preserve", "read", "render"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_COMPATIBILITY_HOSTS: readonly ["browser", "server", "unknown"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_COMPATIBILITY_PROFILES: readonly ["strict", "transitional", "unknown"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_PROFILES: readonly ["strict", "transitional"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_SUPPORT_STATES: readonly ["supported", "partial", "unsupported"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -634,6 +720,40 @@ export type FolioDocumentOperationUndoResult = {
     reason: FolioDocumentOperationUndoFailureReason;
 };
 
+// @public (undocumented)
+export type FolioDocxCapabilityHost = (typeof FOLIO_DOCX_CAPABILITY_HOSTS)[number];
+
+// @public (undocumented)
+export type FolioDocxCapabilityId = (typeof FOLIO_DOCX_CAPABILITY_IDS)[number];
+
+// @public (undocumented)
+export type FolioDocxCapabilityOperation = (typeof FOLIO_DOCX_CAPABILITY_OPERATIONS)[number];
+
+// @public (undocumented)
+export type FolioDocxCompatibilityHost = (typeof FOLIO_DOCX_COMPATIBILITY_HOSTS)[number];
+
+// @public (undocumented)
+export type FolioDocxCompatibilityProfile = (typeof FOLIO_DOCX_COMPATIBILITY_PROFILES)[number];
+
+// @public (undocumented)
+export type FolioDocxFeatureCapability = {
+    readonly id: FolioDocxCapabilityId;
+    readonly feature: "drawings";
+    readonly hosts: readonly FolioDocxCapabilityHost[];
+    readonly profiles: readonly FolioDocxProfile[];
+    readonly support: Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>;
+    readonly evidence: readonly {
+        readonly type: "test";
+        readonly path: string;
+    }[];
+};
+
+// @public (undocumented)
+export type FolioDocxProfile = (typeof FOLIO_DOCX_PROFILES)[number];
+
+// @public (undocumented)
+export type FolioDocxSupportState = (typeof FOLIO_DOCX_SUPPORT_STATES)[number];
+
 // @public
 export function fromMarkdown(markdown: string): import__stll_docx_core_model.Document;
 
@@ -657,6 +777,9 @@ export const getFolioDocumentOperationIssues: (operations: readonly FolioDocumen
 
 // @public
 export const getFolioDocumentOperationReceipts: (operations: readonly FolioDocumentOperation[], applied: readonly FolioAIEditAppliedOperation[]) => FolioDocumentOperationReceipt[];
+
+// @public (undocumented)
+export const getFolioDocxCapability: (id: unknown) => FolioDocxFeatureCapability;
 
 // @public
 export const getFolioParaIdFromBlockId: (id: string) => string | null;
@@ -694,13 +817,25 @@ export type ImageRef = {
 } & ImageMeta;
 
 // @public (undocumented)
+export const inspectDocxCompatibility: (doc: import__stll_docx_core_model.Document, options?: InspectDocxCompatibilityOptions) => DocxCompatibility;
+
+// @public (undocumented)
+export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
+
+// @public (undocumented)
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
+
+// @public (undocumented)
+export class InvalidFolioDocxCapabilityIdError extends InvalidFolioDocxCapabilityIdError_base {}
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;
+
+// @public (undocumented)
+export const isFolioDocxCapabilityId: (value: unknown) => value is FolioDocxCapabilityId;
 
 // @public (undocumented)
 export const isSequentialFolioBlockId: (id: string) => boolean;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -299,9 +299,47 @@ export { Document_2 as Document }
 
 // @public (undocumented)
 export type DocxCompatibility = {
+    schemaVersion: 1;
+    context: DocxCompatibilityContext;
     canSafelyEdit: boolean;
+    issues: DocxCompatibilityIssue[];
     reasons: DocxCompatibilityReason[];
     unsupportedContentCount: number;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityContext = {
+    host: FolioDocxCompatibilityHost;
+    profile: FolioDocxCompatibilityProfile;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityIssue = {
+    code: DocxCompatibilityReason;
+    capability: FolioDocxFeatureCapability;
+    coverage: {
+        host: "covered" | "unknown" | "unverified";
+        profile: "covered" | "unknown" | "unverified";
+    };
+    location: DocxCompatibilityLocation;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityLocation = {
+    part: DocxCompatibilityPart;
+    path: string;
+    blockId?: string;
+};
+
+// @public (undocumented)
+export type DocxCompatibilityPart = {
+    type: "document";
+} | {
+    type: "header" | "footer";
+    relationshipId: string;
+} | {
+    type: "footnote" | "endnote";
+    id: number;
 };
 
 // @public
@@ -357,6 +395,54 @@ export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_HOSTS: readonly ["browser", "server"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_IDS: readonly ["opaqueDrawing"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_MANIFEST: Readonly<{
+    version: 1;
+    capabilities: Readonly<{
+        opaqueDrawing: Readonly<{
+            readonly id: "opaqueDrawing";
+            readonly feature: "drawings";
+            readonly hosts: readonly ["browser", "server"];
+            readonly profiles: readonly "transitional"[];
+            readonly support: Readonly<{
+                create: "unsupported";
+                edit: "unsupported";
+                preserve: "supported";
+                read: "supported";
+                render: "partial";
+            }>;
+            readonly evidence: readonly {
+                type: "test";
+                path: string;
+            }[];
+        }>;
+    }>;
+}>;
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION: 1;
+
+// @public (undocumented)
+export const FOLIO_DOCX_CAPABILITY_OPERATIONS: readonly ["create", "edit", "preserve", "read", "render"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_COMPATIBILITY_HOSTS: readonly ["browser", "server", "unknown"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_COMPATIBILITY_PROFILES: readonly ["strict", "transitional", "unknown"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_PROFILES: readonly ["strict", "transitional"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_SUPPORT_STATES: readonly ["supported", "partial", "unsupported"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -634,6 +720,40 @@ export type FolioDocumentOperationUndoResult = {
     reason: FolioDocumentOperationUndoFailureReason;
 };
 
+// @public (undocumented)
+export type FolioDocxCapabilityHost = (typeof FOLIO_DOCX_CAPABILITY_HOSTS)[number];
+
+// @public (undocumented)
+export type FolioDocxCapabilityId = (typeof FOLIO_DOCX_CAPABILITY_IDS)[number];
+
+// @public (undocumented)
+export type FolioDocxCapabilityOperation = (typeof FOLIO_DOCX_CAPABILITY_OPERATIONS)[number];
+
+// @public (undocumented)
+export type FolioDocxCompatibilityHost = (typeof FOLIO_DOCX_COMPATIBILITY_HOSTS)[number];
+
+// @public (undocumented)
+export type FolioDocxCompatibilityProfile = (typeof FOLIO_DOCX_COMPATIBILITY_PROFILES)[number];
+
+// @public (undocumented)
+export type FolioDocxFeatureCapability = {
+    readonly id: FolioDocxCapabilityId;
+    readonly feature: "drawings";
+    readonly hosts: readonly FolioDocxCapabilityHost[];
+    readonly profiles: readonly FolioDocxProfile[];
+    readonly support: Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>;
+    readonly evidence: readonly {
+        readonly type: "test";
+        readonly path: string;
+    }[];
+};
+
+// @public (undocumented)
+export type FolioDocxProfile = (typeof FOLIO_DOCX_PROFILES)[number];
+
+// @public (undocumented)
+export type FolioDocxSupportState = (typeof FOLIO_DOCX_SUPPORT_STATES)[number];
+
 // @public
 export function fromMarkdown(markdown: string): import__stll_docx_core_model.Document;
 
@@ -657,6 +777,9 @@ export const getFolioDocumentOperationIssues: (operations: readonly FolioDocumen
 
 // @public
 export const getFolioDocumentOperationReceipts: (operations: readonly FolioDocumentOperation[], applied: readonly FolioAIEditAppliedOperation[]) => FolioDocumentOperationReceipt[];
+
+// @public (undocumented)
+export const getFolioDocxCapability: (id: unknown) => FolioDocxFeatureCapability;
 
 // @public
 export const getFolioParaIdFromBlockId: (id: string) => string | null;
@@ -694,13 +817,25 @@ export type ImageRef = {
 } & ImageMeta;
 
 // @public (undocumented)
+export const inspectDocxCompatibility: (doc: import__stll_docx_core_model.Document, options?: InspectDocxCompatibilityOptions) => DocxCompatibility;
+
+// @public (undocumented)
+export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
+
+// @public (undocumented)
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
+
+// @public (undocumented)
+export class InvalidFolioDocxCapabilityIdError extends InvalidFolioDocxCapabilityIdError_base {}
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;
+
+// @public (undocumented)
+export const isFolioDocxCapabilityId: (value: unknown) => value is FolioDocxCapabilityId;
 
 // @public (undocumented)
 export const isSequentialFolioBlockId: (id: string) => boolean;

--- a/packages/core/src/docx/capabilities.ts
+++ b/packages/core/src/docx/capabilities.ts
@@ -1,0 +1,97 @@
+export const FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION = 1 as const;
+
+export const FOLIO_DOCX_CAPABILITY_HOSTS = Object.freeze(["browser", "server"] as const);
+export const FOLIO_DOCX_COMPATIBILITY_HOSTS = Object.freeze([
+  ...FOLIO_DOCX_CAPABILITY_HOSTS,
+  "unknown",
+] as const);
+export const FOLIO_DOCX_PROFILES = Object.freeze(["strict", "transitional"] as const);
+export const FOLIO_DOCX_COMPATIBILITY_PROFILES = Object.freeze([
+  ...FOLIO_DOCX_PROFILES,
+  "unknown",
+] as const);
+export const FOLIO_DOCX_CAPABILITY_OPERATIONS = Object.freeze([
+  "create",
+  "edit",
+  "preserve",
+  "read",
+  "render",
+] as const);
+export const FOLIO_DOCX_SUPPORT_STATES = Object.freeze([
+  "supported",
+  "partial",
+  "unsupported",
+] as const);
+export const FOLIO_DOCX_CAPABILITY_IDS = Object.freeze(["opaqueDrawing"] as const);
+
+export type FolioDocxCapabilityHost = (typeof FOLIO_DOCX_CAPABILITY_HOSTS)[number];
+export type FolioDocxCompatibilityHost = (typeof FOLIO_DOCX_COMPATIBILITY_HOSTS)[number];
+export type FolioDocxProfile = (typeof FOLIO_DOCX_PROFILES)[number];
+export type FolioDocxCompatibilityProfile = (typeof FOLIO_DOCX_COMPATIBILITY_PROFILES)[number];
+export type FolioDocxCapabilityOperation = (typeof FOLIO_DOCX_CAPABILITY_OPERATIONS)[number];
+export type FolioDocxSupportState = (typeof FOLIO_DOCX_SUPPORT_STATES)[number];
+export type FolioDocxCapabilityId = (typeof FOLIO_DOCX_CAPABILITY_IDS)[number];
+
+export type FolioDocxFeatureCapability = {
+  readonly id: FolioDocxCapabilityId;
+  readonly feature: "drawings";
+  readonly hosts: readonly FolioDocxCapabilityHost[];
+  readonly profiles: readonly FolioDocxProfile[];
+  readonly support: Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>;
+  readonly evidence: readonly {
+    readonly type: "test";
+    readonly path: string;
+  }[];
+};
+
+const OPAQUE_DRAWING_CAPABILITY = Object.freeze({
+  id: "opaqueDrawing",
+  feature: "drawings",
+  hosts: FOLIO_DOCX_CAPABILITY_HOSTS,
+  profiles: Object.freeze(["transitional"]),
+  support: Object.freeze({
+    create: "unsupported",
+    edit: "unsupported",
+    preserve: "supported",
+    read: "supported",
+    render: "partial",
+  }),
+  evidence: Object.freeze([
+    {
+      type: "test",
+      path: "packages/core/src/docx/compatibility.test.ts",
+    },
+    {
+      type: "test",
+      path: "packages/core/src/docx/rezip.test.ts",
+    },
+  ]),
+} as const satisfies FolioDocxFeatureCapability);
+
+export const FOLIO_DOCX_CAPABILITY_MANIFEST = Object.freeze({
+  version: FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION,
+  capabilities: Object.freeze({
+    opaqueDrawing: OPAQUE_DRAWING_CAPABILITY,
+  }),
+});
+
+export class InvalidFolioDocxCapabilityIdError extends TaggedError(
+  "InvalidFolioDocxCapabilityIdError",
+)<{
+  message: string;
+  receivedId: unknown;
+}>() {}
+
+export const isFolioDocxCapabilityId = (value: unknown): value is FolioDocxCapabilityId =>
+  value === "opaqueDrawing";
+
+export const getFolioDocxCapability = (id: unknown): FolioDocxFeatureCapability => {
+  if (!isFolioDocxCapabilityId(id)) {
+    throw new InvalidFolioDocxCapabilityIdError({
+      message: "Invalid DOCX capability id.",
+      receivedId: id,
+    });
+  }
+  return FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities[id];
+};
+import { TaggedError } from "better-result";

--- a/packages/core/src/docx/compatibility.test.ts
+++ b/packages/core/src/docx/compatibility.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
 
 import type { Document } from "../types/document";
+import {
+  FOLIO_DOCX_CAPABILITY_MANIFEST,
+  FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION,
+  getFolioDocxCapability,
+  InvalidFolioDocxCapabilityIdError,
+} from "./capabilities";
 import { inspectDocxCompatibility } from "./compatibility";
 
-const createDocument = (rawXml?: string): Document => ({
+const createDocument = (rawXml?: string, paraId?: string): Document => ({
   package: {
     document: {
       content: [
         {
           type: "paragraph",
+          ...(paraId === undefined ? {} : { paraId }),
           content: [
             {
               type: "run",
@@ -36,17 +44,115 @@ const createDocument = (rawXml?: string): Document => ({
 describe("DOCX compatibility inspection", () => {
   test("allows editing ordinary parsed content", () => {
     expect(inspectDocxCompatibility(createDocument())).toEqual({
+      schemaVersion: 1,
+      context: { host: "unknown", profile: "unknown" },
       canSafelyEdit: true,
+      issues: [],
       reasons: [],
       unsupportedContentCount: 0,
     });
   });
 
   test("blocks editing when the document contains opaque drawing XML", () => {
-    expect(inspectDocxCompatibility(createDocument("<w:drawing/>"))).toEqual({
+    expect(inspectDocxCompatibility(createDocument("<w:drawing/>", "A1B2C3D4"))).toEqual({
+      schemaVersion: 1,
+      context: { host: "unknown", profile: "unknown" },
       canSafelyEdit: false,
+      issues: [
+        {
+          code: "opaqueDrawing",
+          capability: getFolioDocxCapability("opaqueDrawing"),
+          coverage: { host: "unknown", profile: "unknown" },
+          location: {
+            blockId: "A1B2C3D4",
+            part: { type: "document" },
+            path: "package.document.content[0].content[0].content[1]",
+          },
+        },
+      ],
       reasons: ["opaqueDrawing"],
       unsupportedContentCount: 1,
     });
+  });
+
+  test("reports the requested profile, host, and non-body part", () => {
+    const document = createDocument("<w:drawing/>", "A1B2C3D4");
+    const content = document.package.document.content;
+    document.package.document.content = [];
+    document.package.headers = new Map([
+      [
+        "rId7",
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content,
+        },
+      ],
+    ]);
+
+    const compatibility = inspectDocxCompatibility(document, {
+      host: "browser",
+      profile: "transitional",
+    });
+
+    expect(compatibility.context).toEqual({ host: "browser", profile: "transitional" });
+    expect(compatibility.issues.at(0)?.coverage).toEqual({
+      host: "covered",
+      profile: "covered",
+    });
+    expect(compatibility.issues.at(0)?.location).toEqual({
+      blockId: "A1B2C3D4",
+      part: { type: "header", relationshipId: "rId7" },
+      path: 'package.headers.get("rId7").content[0].content[0].content[1]',
+    });
+  });
+
+  test("marks profiles outside an issue's evidence scope as unverified", () => {
+    const compatibility = inspectDocxCompatibility(createDocument("<w:drawing/>"), {
+      host: "server",
+      profile: "strict",
+    });
+
+    expect(compatibility.issues.at(0)?.coverage).toEqual({
+      host: "covered",
+      profile: "unverified",
+    });
+  });
+});
+
+describe("DOCX capability manifest", () => {
+  test("describes operation support for structured compatibility issues", async () => {
+    expect(FOLIO_DOCX_CAPABILITY_MANIFEST.version).toBe(FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION);
+    expect(getFolioDocxCapability("opaqueDrawing")).toEqual({
+      id: "opaqueDrawing",
+      feature: "drawings",
+      hosts: ["browser", "server"],
+      profiles: ["transitional"],
+      support: {
+        create: "unsupported",
+        edit: "unsupported",
+        preserve: "supported",
+        read: "supported",
+        render: "partial",
+      },
+      evidence: [
+        {
+          type: "test",
+          path: "packages/core/src/docx/compatibility.test.ts",
+        },
+        {
+          type: "test",
+          path: "packages/core/src/docx/rezip.test.ts",
+        },
+      ],
+    });
+    const repositoryRoot = path.resolve(import.meta.dir, "../../../..");
+    for (const evidence of getFolioDocxCapability("opaqueDrawing").evidence) {
+      expect(await Bun.file(path.join(repositoryRoot, evidence.path)).exists()).toBe(true);
+    }
+  });
+
+  test("rejects unknown ids at the public lookup boundary", () => {
+    expect(() => getFolioDocxCapability("__proto__")).toThrow(InvalidFolioDocxCapabilityIdError);
   });
 });

--- a/packages/core/src/docx/compatibility.ts
+++ b/packages/core/src/docx/compatibility.ts
@@ -6,102 +6,212 @@ import type {
   ParagraphContent,
   Run,
 } from "../types/document";
+import {
+  getFolioDocxCapability,
+  type FolioDocxCompatibilityHost,
+  type FolioDocxCompatibilityProfile,
+  type FolioDocxFeatureCapability,
+} from "./capabilities";
 
 export type DocxCompatibilityReason = "opaqueDrawing";
 
+export type DocxCompatibilityContext = {
+  host: FolioDocxCompatibilityHost;
+  profile: FolioDocxCompatibilityProfile;
+};
+
+export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
+
+export type DocxCompatibilityPart =
+  | { type: "document" }
+  | { type: "header" | "footer"; relationshipId: string }
+  | { type: "footnote" | "endnote"; id: number };
+
+export type DocxCompatibilityLocation = {
+  part: DocxCompatibilityPart;
+  path: string;
+  blockId?: string;
+};
+
+export type DocxCompatibilityIssue = {
+  code: DocxCompatibilityReason;
+  capability: FolioDocxFeatureCapability;
+  coverage: {
+    host: "covered" | "unknown" | "unverified";
+    profile: "covered" | "unknown" | "unverified";
+  };
+  location: DocxCompatibilityLocation;
+};
+
 export type DocxCompatibility = {
+  schemaVersion: 1;
+  context: DocxCompatibilityContext;
   canSafelyEdit: boolean;
+  issues: DocxCompatibilityIssue[];
   reasons: DocxCompatibilityReason[];
   unsupportedContentCount: number;
 };
 
-const COMPATIBLE_DOCX: DocxCompatibility = {
-  canSafelyEdit: true,
-  reasons: [],
-  unsupportedContentCount: 0,
+type InspectionLocationContext = {
+  blockId?: string;
+  part: DocxCompatibilityPart;
+  path: string;
 };
 
-export function inspectDocxCompatibility(doc: Document): DocxCompatibility {
-  const reasons = new Set<DocxCompatibilityReason>();
-  let unsupportedContentCount = 0;
+type RecordIssue = (location: DocxCompatibilityLocation) => void;
 
-  const record = (reason: DocxCompatibilityReason) => {
-    reasons.add(reason);
-    unsupportedContentCount += 1;
+const resolveCompatibilityContext = (
+  options: InspectDocxCompatibilityOptions,
+): DocxCompatibilityContext => ({
+  host: options.host ?? "unknown",
+  profile: options.profile ?? "unknown",
+});
+
+const getCoverageState = (
+  value: string,
+  coveredValues: readonly string[],
+): "covered" | "unknown" | "unverified" => {
+  if (value === "unknown") {
+    return "unknown";
+  }
+  return coveredValues.includes(value) ? "covered" : "unverified";
+};
+
+export const inspectDocxCompatibility = (
+  doc: Document,
+  options: InspectDocxCompatibilityOptions = {},
+): DocxCompatibility => {
+  const context = resolveCompatibilityContext(options);
+  const reasons = new Set<DocxCompatibilityReason>();
+  const issues: DocxCompatibilityIssue[] = [];
+
+  const record: RecordIssue = (location) => {
+    const code = "opaqueDrawing";
+    const capability = getFolioDocxCapability(code);
+    reasons.add(code);
+    issues.push({
+      code,
+      capability,
+      coverage: {
+        host: getCoverageState(context.host, capability.hosts),
+        profile: getCoverageState(context.profile, capability.profiles),
+      },
+      location,
+    });
   };
 
-  inspectBlocks(doc.package.document.content, record);
-  for (const header of doc.package.headers?.values() ?? []) {
-    inspectHeaderFooter(header, record);
+  inspectBlocks(doc.package.document.content, {
+    part: { type: "document" },
+    path: "package.document.content",
+    record,
+  });
+  for (const [relationshipId, header] of doc.package.headers?.entries() ?? []) {
+    inspectHeaderFooter(header, {
+      part: { type: "header", relationshipId },
+      path: `package.headers.get(${JSON.stringify(relationshipId)}).content`,
+      record,
+    });
   }
-  for (const footer of doc.package.footers?.values() ?? []) {
-    inspectHeaderFooter(footer, record);
+  for (const [relationshipId, footer] of doc.package.footers?.entries() ?? []) {
+    inspectHeaderFooter(footer, {
+      part: { type: "footer", relationshipId },
+      path: `package.footers.get(${JSON.stringify(relationshipId)}).content`,
+      record,
+    });
   }
   for (const footnote of doc.package.footnotes ?? []) {
-    inspectBlocks(footnote.content, record);
+    inspectBlocks(footnote.content, {
+      part: { type: "footnote", id: footnote.id },
+      path: `package.footnotes[id=${footnote.id}].content`,
+      record,
+    });
   }
   for (const endnote of doc.package.endnotes ?? []) {
-    inspectBlocks(endnote.content, record);
-  }
-
-  if (unsupportedContentCount === 0) {
-    return COMPATIBLE_DOCX;
+    inspectBlocks(endnote.content, {
+      part: { type: "endnote", id: endnote.id },
+      path: `package.endnotes[id=${endnote.id}].content`,
+      record,
+    });
   }
 
   return {
-    canSafelyEdit: false,
+    schemaVersion: 1,
+    context,
+    canSafelyEdit: issues.length === 0,
+    issues,
     reasons: Array.from(reasons),
-    unsupportedContentCount,
+    unsupportedContentCount: issues.length,
   };
-}
+};
 
 function inspectBlocks(
   blocks: BlockContent[],
-  record: (reason: DocxCompatibilityReason) => void,
+  context: InspectionLocationContext & { record: RecordIssue },
 ): void {
-  for (const block of blocks) {
+  for (const [blockIndex, block] of blocks.entries()) {
+    const blockPath = `${context.path}[${blockIndex}]`;
     if (block.type === "paragraph") {
-      inspectParagraphContent(block.content, record);
+      inspectParagraphContent(block.content, {
+        ...(block.paraId === undefined ? {} : { blockId: block.paraId }),
+        part: context.part,
+        path: `${blockPath}.content`,
+        record: context.record,
+      });
       continue;
     }
 
     if (block.type === "table") {
-      for (const row of block.rows) {
-        for (const cell of row.cells) {
-          inspectBlocks(cell.content, record);
+      for (const [rowIndex, row] of block.rows.entries()) {
+        for (const [cellIndex, cell] of row.cells.entries()) {
+          inspectBlocks(cell.content, {
+            part: context.part,
+            path: `${blockPath}.rows[${rowIndex}].cells[${cellIndex}].content`,
+            record: context.record,
+          });
         }
       }
       continue;
     }
 
-    inspectBlocks(block.content, record);
+    inspectBlocks(block.content, {
+      part: context.part,
+      path: `${blockPath}.content`,
+      record: context.record,
+    });
   }
 }
 
 function inspectHeaderFooter(
   headerFooter: HeaderFooter,
-  record: (reason: DocxCompatibilityReason) => void,
+  context: InspectionLocationContext & { record: RecordIssue },
 ): void {
-  inspectBlocks(headerFooter.content, record);
+  inspectBlocks(headerFooter.content, context);
 }
 
 function inspectParagraphContent(
   content: ParagraphContent[],
-  record: (reason: DocxCompatibilityReason) => void,
+  context: InspectionLocationContext & { record: RecordIssue },
 ): void {
-  for (const item of content) {
+  for (const [itemIndex, item] of content.entries()) {
+    const itemContext = {
+      ...context,
+      path: `${context.path}[${itemIndex}]`,
+    };
     if (item.type === "run") {
-      inspectRun(item, record);
+      inspectRun(item, itemContext);
       continue;
     }
 
     if (item.type === "hyperlink") {
-      inspectHyperlink(item, record);
+      inspectHyperlink(item, itemContext);
       continue;
     }
 
     if (item.type === "inlineSdt") {
-      inspectParagraphContent(item.content, record);
+      inspectParagraphContent(item.content, {
+        ...itemContext,
+        path: `${itemContext.path}.content`,
+      });
       continue;
     }
 
@@ -111,21 +221,33 @@ function inspectParagraphContent(
       item.type === "moveFrom" ||
       item.type === "moveTo"
     ) {
-      inspectParagraphContent(item.content, record);
+      inspectParagraphContent(item.content, {
+        ...itemContext,
+        path: `${itemContext.path}.content`,
+      });
       continue;
     }
 
     if (item.type === "simpleField") {
-      inspectParagraphContent(item.content, record);
+      inspectParagraphContent(item.content, {
+        ...itemContext,
+        path: `${itemContext.path}.content`,
+      });
       continue;
     }
 
     if (item.type === "complexField") {
-      for (const run of item.fieldCode) {
-        inspectRun(run, record);
+      for (const [runIndex, run] of item.fieldCode.entries()) {
+        inspectRun(run, {
+          ...itemContext,
+          path: `${itemContext.path}.fieldCode[${runIndex}]`,
+        });
       }
-      for (const run of item.fieldResult) {
-        inspectRun(run, record);
+      for (const [runIndex, run] of item.fieldResult.entries()) {
+        inspectRun(run, {
+          ...itemContext,
+          path: `${itemContext.path}.fieldResult[${runIndex}]`,
+        });
       }
     }
   }
@@ -133,19 +255,26 @@ function inspectParagraphContent(
 
 function inspectHyperlink(
   hyperlink: Hyperlink,
-  record: (reason: DocxCompatibilityReason) => void,
+  context: InspectionLocationContext & { record: RecordIssue },
 ): void {
-  for (const child of hyperlink.children) {
+  for (const [childIndex, child] of hyperlink.children.entries()) {
     if (child.type === "run") {
-      inspectRun(child, record);
+      inspectRun(child, {
+        ...context,
+        path: `${context.path}.children[${childIndex}]`,
+      });
     }
   }
 }
 
-function inspectRun(run: Run, record: (reason: DocxCompatibilityReason) => void): void {
-  for (const content of run.content) {
+function inspectRun(run: Run, context: InspectionLocationContext & { record: RecordIssue }): void {
+  for (const [contentIndex, content] of run.content.entries()) {
     if (content.type === "drawing" && content.rawXml) {
-      record("opaqueDrawing");
+      context.record({
+        ...(context.blockId === undefined ? {} : { blockId: context.blockId }),
+        part: context.part,
+        path: `${context.path}.content[${contentIndex}]`,
+      });
     }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,37 @@
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
 export { createDocx } from "./docx/rezip";
 export type { Document } from "./types/document";
-export type { DocxCompatibility } from "./docx/compatibility";
+export {
+  inspectDocxCompatibility,
+  type DocxCompatibility,
+  type DocxCompatibilityContext,
+  type DocxCompatibilityIssue,
+  type DocxCompatibilityLocation,
+  type DocxCompatibilityPart,
+  type InspectDocxCompatibilityOptions,
+} from "./docx/compatibility";
+export {
+  FOLIO_DOCX_CAPABILITY_HOSTS,
+  FOLIO_DOCX_CAPABILITY_IDS,
+  FOLIO_DOCX_CAPABILITY_MANIFEST,
+  FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION,
+  FOLIO_DOCX_CAPABILITY_OPERATIONS,
+  FOLIO_DOCX_COMPATIBILITY_HOSTS,
+  FOLIO_DOCX_COMPATIBILITY_PROFILES,
+  FOLIO_DOCX_PROFILES,
+  FOLIO_DOCX_SUPPORT_STATES,
+  getFolioDocxCapability,
+  InvalidFolioDocxCapabilityIdError,
+  isFolioDocxCapabilityId,
+  type FolioDocxCapabilityHost,
+  type FolioDocxCapabilityId,
+  type FolioDocxCapabilityOperation,
+  type FolioDocxCompatibilityHost,
+  type FolioDocxCompatibilityProfile,
+  type FolioDocxFeatureCapability,
+  type FolioDocxProfile,
+  type FolioDocxSupportState,
+} from "./docx/capabilities";
 export {
   deriveBlockId,
   getFolioParaIdFromBlockId,


### PR DESCRIPTION
## Summary

- add a versioned DOCX capability manifest
- report profile and host coverage for compatibility issues
- include structured part and block locations