### PR TITLE
fix: preserve cell insets around row minimums

### DIFF
--- a/.changeset/tall-row-insets.md
+++ b/.changeset/tall-row-insets.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep vertical cell insets outside minimum table-row content heights.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -538,15 +538,14 @@ describe("measureTableBlock row height", () => {
     }, fakeMeasure);
   });
 
-  test("adds horizontal cell borders on top of an atLeast/auto minimum height", () => {
+  test("adds cell padding and borders on top of an atLeast/auto minimum height", () => {
     withFakeTextMeasure(() => {
       // A short single-line cell whose content is well under an explicit
-      // (atLeast) row height, but which carries a horizontal border. Word treats
-      // the explicit height as the minimum of the cell content+padding region;
-      // the border sits on the grid line and adds on top. So the row must be
-      // taller than the explicit height by the border thickness — the border
-      // must not be absorbed by `max(content + border, explicit)`.
+      // (atLeast) row height, but which carries vertical padding and horizontal
+      // borders. The explicit value is the content floor; cell insets add to it.
       const border = 6;
+      const paddingTop = 7;
+      const paddingBottom = 9;
       const tallMinHeight = 400;
       const build = (rule: "atLeast" | undefined): TableBlock => ({
         kind: "table",
@@ -561,7 +560,7 @@ describe("measureTableBlock row height", () => {
               {
                 id: "a",
                 blocks: [para("a1", "One line")],
-                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                padding: { top: paddingTop, right: 0, bottom: paddingBottom, left: 0 },
                 // First row: top+bottom both collapse in, so 2 * border.
                 borders: { top: { width: border }, bottom: { width: border } },
               },
@@ -574,8 +573,9 @@ describe("measureTableBlock row height", () => {
         const measure = measureTableBlock(build(rule), 120);
         const contentHeight = measure.rows[0]?.cells[0]?.height ?? 0;
         expect(contentHeight).toBeLessThan(tallMinHeight); // content is the shorter term
-        // Border (2 * 6 on the first row) added on top of the minimum height.
-        expect(measure.rows[0]?.height).toBe(tallMinHeight + 2 * border);
+        expect(measure.rows[0]?.height).toBe(
+          tallMinHeight + paddingTop + paddingBottom + 2 * border,
+        );
         expect(measure.rows[0]?.height).toBeGreaterThan(tallMinHeight);
       }
     }, fakeMeasure);

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -335,7 +335,7 @@ export function measureTableBlock(
     // stays content + padding (the painter lays cell content out within it); the
     // border only contributes to the row total here.
     let maxCellHeightWithBorders = 0;
-    let maxBorderHeight = 0;
+    let maxCellInsets = 0;
     for (let cellIdx = 0; cellIdx < row.cells.length; cellIdx++) {
       const cell = row.cells[cellIdx]!; // SAFETY: cellIdx < row.cells.length
       const sourceCell = sourceRowCells?.[cellIdx];
@@ -356,7 +356,7 @@ export function measureTableBlock(
       }
       const borderHeight = getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0);
       maxCellHeightWithBorders = Math.max(maxCellHeightWithBorders, cell.height + borderHeight);
-      maxBorderHeight = Math.max(maxBorderHeight, borderHeight);
+      maxCellInsets = Math.max(maxCellInsets, padTop + padBottom + borderHeight);
     }
 
     // Apply heightRule from the source row
@@ -366,13 +366,9 @@ export function measureTableBlock(
     if (explicitHeight && heightRule === "exact") {
       row.height = explicitHeight;
     } else if (explicitHeight) {
-      // Both 'atLeast' and 'auto' (OOXML default) treat the value as a minimum.
-      // ECMA-376 §17.4.81: when hRule is absent or "auto", val is the minimum row
-      // height. In Word that minimum governs the cell content+padding region only;
-      // horizontal cell borders sit on the grid lines and add on top of it. So when
-      // the explicit height wins over content, the border must still be added rather
-      // than absorbed (`Math.max(content + border, explicit)` would swallow it).
-      row.height = Math.max(maxCellHeightWithBorders, explicitHeight + maxBorderHeight);
+      // Compatibility layouts treat both 'atLeast' and auto-with-val as a
+      // content floor; cell padding and horizontal borders remain outside it.
+      row.height = Math.max(maxCellHeightWithBorders, explicitHeight + maxCellInsets);
     } else {
       // No explicit height — use content height directly.
       row.height = maxCellHeightWithBorders;


### PR DESCRIPTION
## Summary
- keep vertical cell padding and collapsed borders outside at-least and compatibility-auto row minimums
- preserve exact-height rows as fixed outer geometry
- cover the inset calculation with a focused synthetic regression

## Validation
- 51 focused layout and style-cascade tests pass
- strict shared-font anonymous replay: 86.0% → 98.0%, 1/1 page, six of seven vertical divergences removed
- unrelated control replay unchanged at 95.7%, 1/1 page
- `bun audit`
- lint, typecheck, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica