### PR TITLE
fix: reuse natural pages for tabbed sequences

### DIFF
--- a/.changeset/quiet-tabbed-pagination.md
+++ b/.changeset/quiet-tabbed-pagination.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep cached pagination markers within naturally reflowed tabbed paragraph sequences.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -613,6 +613,97 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
     });
 
+    test("rendered page break reuses a page opened within one tabbed style sequence", () => {
+      const previousRow: FlowBlock = {
+        ...makeParagraphBlock(1, "First row", 23),
+        runs: [
+          { kind: "text", text: "First", pmStart: 23, pmEnd: 28 },
+          { kind: "tab", pmStart: 28, pmEnd: 29 },
+          { kind: "text", text: "row", pmStart: 29, pmEnd: 32 },
+        ],
+        attrs: {
+          styleId: "TabularLine",
+          indent: { left: 42 },
+          tabs: [{ val: "start", pos: 720 }],
+        },
+      };
+      const marker: FlowBlock = {
+        ...makeParagraphBlock(2, "Second row", 33),
+        runs: [
+          { kind: "text", text: "Second", pmStart: 33, pmEnd: 39 },
+          { kind: "tab", pmStart: 39, pmEnd: 40 },
+          { kind: "text", text: "row", pmStart: 40, pmEnd: 43 },
+        ],
+        attrs: {
+          styleId: "TabularLine",
+          indent: { left: 42 },
+          tabs: [{ val: "start", pos: 720 }],
+          renderedPageBreakBefore: true,
+        },
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        previousRow,
+        marker,
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 840)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 9, 100, 40)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 10, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
+    });
+
+    test("rendered page break remains authoritative when tabbed layouts differ", () => {
+      const previousRow: FlowBlock = {
+        ...makeParagraphBlock(1, "First row", 23),
+        runs: [
+          { kind: "text", text: "First", pmStart: 23, pmEnd: 28 },
+          { kind: "tab", pmStart: 28, pmEnd: 29 },
+          { kind: "text", text: "row", pmStart: 29, pmEnd: 32 },
+        ],
+        attrs: {
+          styleId: "TabularLine",
+          indent: { left: 42 },
+          tabs: [{ val: "start", pos: 720 }],
+        },
+      };
+      const marker: FlowBlock = {
+        ...makeParagraphBlock(2, "Different row", 33),
+        runs: [
+          { kind: "text", text: "Different", pmStart: 33, pmEnd: 42 },
+          { kind: "tab", pmStart: 42, pmEnd: 43 },
+          { kind: "text", text: "row", pmStart: 43, pmEnd: 46 },
+        ],
+        attrs: {
+          styleId: "TabularLine",
+          indent: { left: 42 },
+          tabs: [{ val: "start", pos: 1440 }],
+          renderedPageBreakBefore: true,
+        },
+      };
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        previousRow,
+        marker,
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 840)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 9, 100, 40)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 13, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(3);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
+      expect(layout.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual([2]);
+    });
+
     test("successive rendered page breaks remain authoritative after natural reflow", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Fill page one", 1),

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -127,6 +127,48 @@ function continuesNumberedSequence(previous: FlowBlock | undefined, current: Flo
   return previousNumPr.numId === currentNumPr.numId && previousNumPr.ilvl === currentNumPr.ilvl;
 }
 
+function continuesTabbedParagraphSequence(
+  previous: FlowBlock | undefined,
+  current: FlowBlock,
+): boolean {
+  if (previous?.kind !== "paragraph" || current.kind !== "paragraph") {
+    return false;
+  }
+  if (!previous.attrs?.styleId || previous.attrs.styleId !== current.attrs?.styleId) {
+    return false;
+  }
+  if (
+    !previous.runs.some((run) => run.kind === "tab") ||
+    !current.runs.some((run) => run.kind === "tab")
+  ) {
+    return false;
+  }
+  const previousIndent = previous.attrs.indent;
+  const currentIndent = current.attrs.indent;
+  if (
+    previousIndent?.left !== currentIndent?.left ||
+    previousIndent?.right !== currentIndent?.right ||
+    previousIndent?.firstLine !== currentIndent?.firstLine ||
+    previousIndent?.hanging !== currentIndent?.hanging
+  ) {
+    return false;
+  }
+  const previousTabs = previous.attrs.tabs ?? [];
+  const currentTabs = current.attrs.tabs ?? [];
+  return (
+    previousTabs.length === currentTabs.length &&
+    previousTabs.every((tab, index) => {
+      const currentTab = currentTabs[index];
+      if (!currentTab) {
+        return false;
+      }
+      return (
+        tab.val === currentTab.val && tab.pos === currentTab.pos && tab.leader === currentTab.leader
+      );
+    })
+  );
+}
+
 type NaturalPageAdvance = "none" | "ordinary" | "reflowBoundary";
 
 function pageStartsWithPreviousParagraphContinuation(
@@ -484,7 +526,8 @@ export function layoutDocument(
           isPaginationEmptyParagraph(block) &&
           naturalPageAdvanceSinceRenderedBreak !== "none") ||
         (naturalPageAdvanceSinceRenderedBreak !== "none" &&
-          continuesNumberedSequence(blocks[i - 1], block));
+          (continuesNumberedSequence(blocks[i - 1], block) ||
+            continuesTabbedParagraphSequence(blocks[i - 1], block)));
       if (
         !naturalAdvanceAlreadyCrossedMarker &&
         pageHasVisibleBodyContent(state.page, blocksById)


### PR DESCRIPTION
## Summary
- treat a natural page advance as satisfying an adjacent cached pagination marker when tabbed rows share the same style, indentation, and tab-stop geometry
- retain the cached marker when the neighboring tabbed layouts differ
- cover both paths with focused pagination regressions

## Validation
- 56 focused layout tests pass
- strict same-font anonymous replay: 62.0% → 90.1%, pages 2/3 → 2/2, all twelve pagination divergences removed
- unrelated one-page control: 95.7%, 1/1 page
- `bun audit`: no vulnerabilities
- lint, type checking, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica