### PR TITLE
fix: retain unclaimed interior table borders

### DIFF
--- a/.changeset/bright-table-edges.md
+++ b/.changeset/bright-table-edges.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve interior table border segments when adjacent cells leave shared edges unclaimed.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -489,6 +489,44 @@ describe("measureTableBlock row height", () => {
     }, fakeMeasure);
   });
 
+  test("counts an interior top border when the cell above leaves the edge open", () => {
+    withFakeTextMeasure(() => {
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [120],
+        rows: [
+          {
+            id: "r0",
+            cells: [
+              {
+                id: "first",
+                blocks: [para("first-p", "One line")],
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              },
+            ],
+          },
+          {
+            id: "r1",
+            cells: [
+              {
+                id: "second",
+                blocks: [para("second-p", "One line")],
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                borders: { top: { width: 2 } },
+              },
+            ],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 120);
+      const contentHeight = measure.rows[1]?.cells[0]?.height ?? 0;
+
+      expect(measure.rows[1]?.height).toBe(contentHeight + 2);
+    }, fakeMeasure);
+  });
+
   test("maxes per-cell content+border, not summed independent maxes", () => {
     withFakeTextMeasure(() => {
       // Cell A: more content (two paragraphs), thin border.

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -173,8 +173,15 @@ export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure
 function getTableCellVerticalBorderHeight(
   cell: TableCell | undefined,
   isFirstRow: boolean,
+  aboveCell?: TableCell,
 ): number {
-  const top = isFirstRow ? (cell?.borders?.top?.width ?? 0) : 0;
+  const aboveBottom = aboveCell?.borders?.bottom;
+  const aboveOwnsEdge =
+    aboveBottom !== undefined &&
+    aboveBottom.width !== 0 &&
+    aboveBottom.style !== "none" &&
+    aboveBottom.style !== "nil";
+  const top = isFirstRow || !aboveOwnsEdge ? (cell?.borders?.top?.width ?? 0) : 0;
   const bottom = cell?.borders?.bottom?.width ?? 0;
   return top + bottom;
 }
@@ -218,6 +225,8 @@ export function measureTableBlock(
   // Build a map of columns occupied by spanning cells from previous rows.
   // Without this, cells in rows with vertical merges get the wrong column width.
   const occupiedColumnsPerRow = new Map<number, Set<number>>();
+  const sourceCellsByPosition = new Map<string, TableCell>();
+  const sourceCellColumns = new WeakMap<TableCell, number>();
   for (let rowIdx = 0; rowIdx < tableBlock.rows.length; rowIdx++) {
     const row = tableBlock.rows[rowIdx];
     if (!row) {
@@ -232,6 +241,14 @@ export function measureTableBlock(
     for (const cell of row.cells) {
       const colSpan = cell.colSpan ?? 1;
       const rowSpan = cell.rowSpan ?? 1;
+      sourceCellColumns.set(cell, colIdx);
+      const rowEnd = Math.min(tableBlock.rows.length, rowIdx + rowSpan);
+      const columnEnd = Math.min(columnWidths.length, colIdx + colSpan);
+      for (let gridRow = rowIdx; gridRow < rowEnd; gridRow++) {
+        for (let gridColumn = colIdx; gridColumn < columnEnd; gridColumn++) {
+          sourceCellsByPosition.set(`${gridRow}:${gridColumn}`, cell);
+        }
+      }
 
       if (rowSpan > 1) {
         for (let r = rowIdx + 1; r < rowIdx + rowSpan; r++) {
@@ -354,7 +371,12 @@ export function measureTableBlock(
       if ((sourceCell?.rowSpan ?? 1) > 1) {
         continue;
       }
-      const borderHeight = getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0);
+      const sourceColumn = sourceCell ? sourceCellColumns.get(sourceCell) : undefined;
+      const aboveCell =
+        sourceColumn === undefined
+          ? undefined
+          : sourceCellsByPosition.get(`${rowIdx - 1}:${sourceColumn}`);
+      const borderHeight = getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0, aboveCell);
       maxCellHeightWithBorders = Math.max(maxCellHeightWithBorders, cell.height + borderHeight);
       maxCellInsets = Math.max(maxCellInsets, padTop + padBottom + borderHeight);
     }
@@ -398,7 +420,12 @@ export function measureTableBlock(
         combinedHeight += rows[spannedRowIdx]?.height ?? 0;
       }
       const requiredHeight =
-        measuredCell.height + getTableCellVerticalBorderHeight(sourceCell, rowIdx === 0);
+        measuredCell.height +
+        getTableCellVerticalBorderHeight(
+          sourceCell,
+          rowIdx === 0,
+          sourceCellsByPosition.get(`${rowIdx - 1}:${sourceCellColumns.get(sourceCell) ?? 0}`),
+        );
       const deficit = requiredHeight - combinedHeight;
       if (deficit <= 0) {
         continue;

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -356,7 +356,7 @@ function renderNestedTable(
 
   // Render all rows
   const columnsPinned = tableColumnsArePinned(block);
-  const cellGrid = buildTableCellGrid(block);
+  const cellGrid = buildTableCellGrid(block, measure.columnWidths.length);
   let y = 0;
   for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
     const row = block.rows[rowIndex];
@@ -565,7 +565,7 @@ type TableCellGrid = Map<string, TableCell>;
 const tableCellGridKey = (rowIndex: number, columnIndex: number): string =>
   `${rowIndex}:${columnIndex}`;
 
-function buildTableCellGrid(block: TableBlock): TableCellGrid {
+function buildTableCellGrid(block: TableBlock, columnCount: number): TableCellGrid {
   const grid: TableCellGrid = new Map();
 
   for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
@@ -581,10 +581,7 @@ function buildTableCellGrid(block: TableBlock): TableCellGrid {
       const colSpan = cell.colSpan ?? 1;
       const rowSpan = cell.rowSpan ?? 1;
       const rowEnd = Math.min(block.rows.length, rowIndex + rowSpan);
-      const columnEnd = Math.min(
-        block.columnWidths?.length ?? columnIndex + colSpan,
-        columnIndex + colSpan,
-      );
+      const columnEnd = Math.min(columnCount, columnIndex + colSpan);
       for (let gridRow = rowIndex; gridRow < rowEnd; gridRow++) {
         for (let gridColumn = columnIndex; gridColumn < columnEnd; gridColumn++) {
           grid.set(tableCellGridKey(gridRow, gridColumn), cell);
@@ -842,7 +839,7 @@ export function renderTableFragment(
   // Track spanning cells across rows
   const spanningCells = new Map<string, SpanningCell>();
   const columnsPinned = tableColumnsArePinned(block);
-  const cellGrid = buildTableCellGrid(block);
+  const cellGrid = buildTableCellGrid(block, measure.columnWidths.length);
 
   // Render repeated header rows for continuation fragments. For a mid-content
   // row break (eigenpal #698), keep repeated headers pinned to the fragment top

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -356,6 +356,7 @@ function renderNestedTable(
 
   // Render all rows
   const columnsPinned = tableColumnsArePinned(block);
+  const cellGrid = buildTableCellGrid(block);
   let y = 0;
   for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
     const row = block.rows[rowIndex];
@@ -383,6 +384,7 @@ function renderNestedTable(
       undefined,
       block.bidi,
       columnsPinned,
+      cellGrid,
     );
     tableEl.append(rowEl);
     y += rowMeasure.height;
@@ -426,9 +428,9 @@ function renderTableCell(
   x: number,
   rowHeight: number,
   borderFlags: {
-    isFirstRow: boolean;
+    drawTop: boolean;
     isLastRow: boolean;
-    isFirstCol: boolean;
+    drawLeft: boolean;
     isLastCol: boolean;
   },
   columnsPinned: boolean,
@@ -459,14 +461,15 @@ function renderTableCell(
     // Strategy: "bottom wins" for rows, "right wins" for columns.
     // Each cell's bottom border represents the shared edge with the row below.
     // Each cell's right border represents the shared edge with the column to its right.
-    // Only the first row draws its top border (table's top edge).
-    // Only the first column draws its left border (table's left edge).
-    if (borderFlags.isFirstRow) {
+    // Top/left edges are retained when the adjacent cell does not already
+    // own the shared edge. This also preserves partial boxes that begin inside
+    // a table instead of limiting those sides to the table perimeter.
+    if (borderFlags.drawTop) {
       applyBorder(cellEl, "top", cell.borders.top);
     }
     applyBorder(cellEl, "right", cell.borders.right);
     applyBorder(cellEl, "bottom", cell.borders.bottom);
-    if (borderFlags.isFirstCol) {
+    if (borderFlags.drawLeft) {
       applyBorder(cellEl, "left", cell.borders.left);
     }
   }
@@ -557,6 +560,46 @@ type SpanningCell = {
   totalHeight: number;
 };
 
+type TableCellGrid = Map<string, TableCell>;
+
+const tableCellGridKey = (rowIndex: number, columnIndex: number): string =>
+  `${rowIndex}:${columnIndex}`;
+
+function buildTableCellGrid(block: TableBlock): TableCellGrid {
+  const grid: TableCellGrid = new Map();
+
+  for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
+    const row = block.rows[rowIndex];
+    if (!row) {
+      continue;
+    }
+    let columnIndex = 0;
+    for (const cell of row.cells) {
+      while (grid.has(tableCellGridKey(rowIndex, columnIndex))) {
+        columnIndex += 1;
+      }
+      const colSpan = cell.colSpan ?? 1;
+      const rowSpan = cell.rowSpan ?? 1;
+      const rowEnd = Math.min(block.rows.length, rowIndex + rowSpan);
+      const columnEnd = Math.min(
+        block.columnWidths?.length ?? columnIndex + colSpan,
+        columnIndex + colSpan,
+      );
+      for (let gridRow = rowIndex; gridRow < rowEnd; gridRow++) {
+        for (let gridColumn = columnIndex; gridColumn < columnEnd; gridColumn++) {
+          grid.set(tableCellGridKey(gridRow, gridColumn), cell);
+        }
+      }
+      columnIndex += colSpan;
+    }
+  }
+
+  return grid;
+}
+
+const hasVisibleBorder = (border: { width?: number; style?: string } | undefined): boolean =>
+  border !== undefined && border.width !== 0 && border.style !== "none" && border.style !== "nil";
+
 /**
  * Render a table row with rowSpan support
  */
@@ -574,6 +617,7 @@ function renderTableRow(
   isFirstRowInFragment?: boolean,
   bidi = false,
   columnsPinned = false,
+  cellGrid?: TableCellGrid,
 ): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
@@ -657,13 +701,18 @@ function renderTableRow(
     const atLogicalEnd = columnIndex + colSpan >= columnWidths.length;
     const isFirstCol = bidi ? atLogicalEnd : atLogicalStart;
     const isLastCol = bidi ? atLogicalStart : atLogicalEnd;
+    const aboveCell = cellGrid?.get(tableCellGridKey(rowIndex - 1, columnIndex));
+    const leftNeighborColumn = bidi ? columnIndex + colSpan : columnIndex - 1;
+    const leftCell = cellGrid?.get(tableCellGridKey(rowIndex, leftNeighborColumn));
+    const drawTop = isFirstRow || !hasVisibleBorder(aboveCell?.borders?.bottom);
+    const drawLeft = isFirstCol || !hasVisibleBorder(leftCell?.borders?.right);
 
     const cellEl = renderTableCell(
       cell,
       cellMeasure,
       cellLeft,
       cellHeight,
-      { isFirstRow, isLastRow, isFirstCol, isLastCol },
+      { drawTop, isLastRow, drawLeft, isLastCol },
       columnsPinned,
       context,
       doc,
@@ -793,6 +842,7 @@ export function renderTableFragment(
   // Track spanning cells across rows
   const spanningCells = new Map<string, SpanningCell>();
   const columnsPinned = tableColumnsArePinned(block);
+  const cellGrid = buildTableCellGrid(block);
 
   // Render repeated header rows for continuation fragments. For a mid-content
   // row break (eigenpal #698), keep repeated headers pinned to the fragment top
@@ -825,6 +875,7 @@ export function renderTableFragment(
         hdrIdx === 0, // first header row draws top border
         block.bidi,
         columnsPinned,
+        cellGrid,
       );
       rowEl.dataset["repeatedHeader"] = "true";
       tableEl.append(rowEl);
@@ -882,6 +933,7 @@ export function renderTableFragment(
       isFirstRowInFragment,
       block.bidi,
       columnsPinned,
+      cellGrid,
     );
 
     contentParent.append(rowEl);

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -278,6 +278,89 @@ describe("renderTableFragment cell paragraph spacing", () => {
   });
 });
 
+describe("renderTableFragment interior border ownership", () => {
+  test("retains top and left edges when adjacent cells leave them unclaimed", () => {
+    const border = { width: 1, style: "solid", color: "#000000" };
+    const paragraph = (id: string) => ({
+      kind: "paragraph" as const,
+      id,
+      runs: [{ kind: "text" as const, text: id }],
+    });
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "top",
+          cells: [
+            {
+              id: "top-left",
+              borders: { right: border, bottom: border },
+              blocks: [paragraph("top-left-p")],
+            },
+            { id: "top-right", blocks: [paragraph("top-right-p")] },
+          ],
+        },
+        {
+          id: "bottom",
+          cells: [
+            {
+              id: "bottom-left",
+              borders: { top: border },
+              blocks: [paragraph("bottom-left-p")],
+            },
+            {
+              id: "bottom-right",
+              borders: { top: border, left: border },
+              blocks: [paragraph("bottom-right-p")],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100, 100],
+    };
+    const measuredCell = () => ({
+      blocks: [{ kind: "paragraph" as const, lines: [], totalHeight: 20 }],
+      width: 100,
+      height: 20,
+    });
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        { cells: [measuredCell(), measuredCell()], height: 20 },
+        { cells: [measuredCell(), measuredCell()], height: 20 },
+      ],
+      columnWidths: [100, 100],
+      totalWidth: 200,
+      totalHeight: 40,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 40,
+      fromRow: 0,
+      toRow: 2,
+    };
+
+    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const rows = findRows(tableEl);
+    const cellAt = (rowIndex: string, columnIndex: string) =>
+      rows
+        .find((row) => row.dataset["rowIndex"] === rowIndex)
+        ?.children.find((candidate) => candidate.dataset["columnIndex"] === columnIndex);
+
+    expect(cellAt("1", "0")?.style["borderTop"]).toBeUndefined();
+    expect(cellAt("1", "1")?.style["borderTop"]).toBe("1px solid #000000");
+    expect(cellAt("0", "1")?.style["borderLeft"]).toBeUndefined();
+    expect(cellAt("1", "1")?.style["borderLeft"]).toBe("1px solid #000000");
+  });
+});
+
 describe("renderTableFragment floating cell content", () => {
   test("paints anchored images and text boxes outside the cell clip", () => {
     const block: TableBlock = {


### PR DESCRIPTION
## Summary

- preserve top and left border segments that start inside a larger table
- resolve shared-edge ownership against adjacent cells to avoid doubled borders
- keep row measurement aligned with the painted border ownership

## Validation

- 47 focused table painter and measurement tests pass
- strict same-font anonymous replay: 91.5% to 97.9%, 1/1 page, three geometry drifts removed
- unrelated control unchanged at 95.7%, 1/1 page
- restored partial border boxes that are outside the text-only score
- bun audit: no vulnerabilities
- lint, typecheck, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica