### PR TITLE
fix: render embedded object previews

### DIFF
--- a/.changeset/bright-object-previews.md
+++ b/.changeset/bright-object-previews.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render relationship-backed previews for legacy embedded objects with their authored line height.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -341,7 +341,8 @@ export type ImageRun = {
     distTop?: number;
     distBottom?: number;
     distLeft?: number;
-    distRight?: number;
+    distRight?: number; /** Use the image box as the exact line height for an embedded-object preview. */
+    exactLineHeight?: boolean;
     cropTop?: number;
     cropRight?: number;
     cropBottom?: number;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -146,7 +146,8 @@ export type ImageAttrs = {
     borderStyle?: string; /** Wrap text setting from DOCX (left, right, bothSides, largest) for round-trip */
     wrapText?: NonNullable<import__stll_docx_core_model.ImageWrap["wrapText"]>; /** Hyperlink URL for clickable image */
     hlinkHref?: string; /** Original OOXML for opaque/unsupported DOCX drawings. */
-    _docxRawXml?: string;
+    _docxRawXml?: string; /** Embedded-object previews use their authored box as the exact line height. */
+    _docxObjectPreview?: boolean;
 };
 
 // @public

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -231,7 +231,8 @@ export type ImageAttrs = {
     borderStyle?: string; /** Wrap text setting from DOCX (left, right, bothSides, largest) for round-trip */
     wrapText?: NonNullable<import__stll_docx_core_model.ImageWrap["wrapText"]>; /** Hyperlink URL for clickable image */
     hlinkHref?: string; /** Original OOXML for opaque/unsupported DOCX drawings. */
-    _docxRawXml?: string;
+    _docxRawXml?: string; /** Embedded-object previews use their authored box as the exact line height. */
+    _docxObjectPreview?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -957,9 +957,15 @@ function parseRunContents(
         break;
       }
 
-      case "object":
-        // Legacy OLE objects remain outside the active image path.
+      case "object": {
+        // Embedded objects can carry a relationship-backed VML preview. Route
+        // that preview through the image path while retaining the source XML.
+        const objectPreview = parseVmlImageContent(child, rels, media, rootXmlns);
+        if (objectPreview) {
+          contents.push(objectPreview);
+        }
         break;
+      }
 
       case "rPr":
         // Run properties - already handled separately

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -183,6 +183,7 @@ async function bodyScopedPictDocx(bodyInnerXml: string): Promise<ArrayBuffer> {
 }
 
 const PICT_WITH_IMAGE = `<w:pict><v:shape id="Picture 1" type="#_x0000_t75" style="width:2in;height:1in"><v:imagedata r:id="rIdImg" o:title="logo"/></v:shape></w:pict>`;
+const OBJECT_WITH_PREVIEW = `<w:object><v:shape id="Object 1" type="#_x0000_t75" style="width:20pt;height:18pt"><v:imagedata r:id="rIdImg" o:title="preview"/></v:shape><w:control r:id="rIdControl" w:name="Control 1" w:shapeid="Object 1"/></w:object>`;
 
 // A VML shape/imagedata whose prefixes (`v2`, `r2`) are declared on an ancestor
 // wrapper rather than the document root; used to prove the in-scope xmlns set
@@ -230,6 +231,46 @@ describe("VML w:pict inline images", () => {
     expect(docXml).not.toContain("wp:inline");
     // The referenced media part survives the round-trip.
     expect(zip.file("word/media/image1.png")).not.toBeNull();
+  });
+
+  test("parses an embedded object's VML preview with its authored dimensions", async () => {
+    const doc = await parseDocx(await pictDocx({ runXml: OBJECT_WITH_PREVIEW }), {
+      preloadFonts: false,
+    });
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.rId).toBe("rIdImg");
+    expect(drawing?.image.size).toEqual({ width: 254_000, height: 228_600 });
+    expect(drawing?.image.wrap.type).toBe("inline");
+    expect(drawing?.image.src).toStartWith("data:image/png");
+    expect(drawing?.image.title).toBe("preview");
+    expect(drawing?.rawXml).toContain("<w:object");
+    expect(drawing?.rawXml).toContain("<w:control");
+  });
+
+  test("preserves an embedded object wrapper when saving its preview", async () => {
+    const original = await pictDocx({ runXml: OBJECT_WITH_PREVIEW });
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+
+    expect((await validateDocx(out)).valid).toBe(true);
+    const zip = await JSZip.loadAsync(out);
+    const docXml = await zip.file("word/document.xml")!.async("text");
+    expect(docXml).toContain("<w:object");
+    expect(docXml).toContain("<w:control");
+    expect(docXml).toContain('r:id="rIdImg"');
+    expect(docXml).not.toContain("<w:drawing");
+  });
+
+  test("rejects an embedded-object preview with unsafe authored dimensions", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: OBJECT_WITH_PREVIEW.replace("width:20pt", "width:30000px"),
+      }),
+      { preloadFonts: false },
+    );
+
+    expect(firstDrawing(doc.package.document.content.at(0))).toBeUndefined();
   });
 
   test("renders a positioned solid rectangle without embedded image data", async () => {

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -359,6 +359,14 @@ export function parseVmlImageContent(
     const shapeStyle = parseStyleAttr(getAttribute(shape, null, "style"));
     const widthPx = cssLengthToPx(shapeStyle["width"]);
     const heightPx = cssLengthToPx(shapeStyle["height"]);
+    const isEmbeddedObject = getLocalName(pictElement.name ?? "") === "object";
+    if (
+      isEmbeddedObject &&
+      ((widthPx !== undefined && !validPreviewDimension(widthPx)) ||
+        (heightPx !== undefined && !validPreviewDimension(heightPx)))
+    ) {
+      continue;
+    }
 
     // VML pictures in a run are inline-flow. Absolute-positioned VML is treated
     // as inline here too: rendering the picture in flow is far better than

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1746,4 +1746,27 @@ describe("toFlowBlocks image attribute normalization", () => {
     }
     expect(imageRun.opacity).toBe(0.5);
   });
+
+  test("marks embedded-object previews for exact line-height measurement", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.nodes.image.create({
+          src: "media/preview.png",
+          width: 20,
+          height: 18,
+          _docxObjectPreview: true,
+        }),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+
+    expect(paragraph.runs.at(0)).toMatchObject({
+      kind: "image",
+      exactLineHeight: true,
+    });
+  });
 });

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -874,6 +874,9 @@ function buildImageRun(
   if (attrs.distRight !== undefined) {
     run.distRight = attrs.distRight;
   }
+  if (attrs._docxObjectPreview === true) {
+    run.exactLineHeight = true;
+  }
   // eigenpal #424: pass crop fractions through to the painter so it can
   // emit CSS clip-path. PM defaults are `null`; treat null as "not set".
   if (attrs.cropTop != null) {

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -291,7 +291,9 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);
     } else if (run.kind === "image") {
-      parts.push(`img:${run.width}x${run.height}`);
+      parts.push(
+        `img:${run.width}x${run.height}:${run.exactLineHeight === true ? "exact" : "text"}`,
+      );
     } else if (run.kind === "lineBreak") {
       parts.push("br");
     }

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1135,6 +1135,37 @@ describe("inline image paragraph measurement", () => {
     expect(line?.ascent).toBe(imageHeight + descent);
   });
 
+  test("embedded-object preview uses its authored box as the exact line height", () => {
+    const imageHeight = 40;
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "object-preview",
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 80,
+            height: imageHeight,
+            exactLineHeight: true,
+          },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+        },
+      },
+      600,
+    );
+
+    expect(measure.lines[0]).toMatchObject({
+      lineHeight: imageHeight,
+      ascent: imageHeight,
+      descent: 0,
+    });
+    expect(measure.totalHeight).toBe(imageHeight);
+  });
+
   test("inline image footprint includes its wp:inline distT/distB", () => {
     withFakeTextMeasure(() => {
       // distTop/distBottom = 8 each = 16px of extra footprint; the line

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -129,6 +129,8 @@ type LineState = {
   maxFontMetrics: FontMetrics | null;
   /** Maximum inline image height in pixels (already in px, not points) */
   maxImageHeightPx: number;
+  /** Maximum exact-height embedded-object preview on the line. */
+  maxExactImageHeightPx: number;
   /** Maximum inline math height in pixels (already in px, not points) */
   maxMathHeightPx: number;
   availableWidth: number;
@@ -973,6 +975,7 @@ export function measureParagraph(
     maxFontSize: DEFAULT_FONT_SIZE,
     maxFontMetrics: null,
     maxImageHeightPx: 0,
+    maxExactImageHeightPx: 0,
     maxMathHeightPx: 0,
     availableWidth: firstLineWidth,
     leftOffset: firstLineFloatingMargins.leftMargin,
@@ -1008,6 +1011,12 @@ export function measureParagraph(
       // test in renderLine — the two pick paired line-height + alignment
       // strategies and disagreeing reintroduces the floating-label bug.
       if (line.fromRun === line.toRun) {
+        if (line.maxExactImageHeightPx >= objectHeight) {
+          finalTypography.lineHeight = objectHeight;
+          finalTypography.ascent = objectHeight;
+          finalTypography.descent = 0;
+          return finalTypography;
+        }
         // Object alone on the line: grow to the object height plus the
         // parent font's descent on BOTH sides so the row has visible
         // breathing room above and below it.
@@ -1127,6 +1136,7 @@ export function measureParagraph(
       maxFontSize: DEFAULT_FONT_SIZE,
       maxFontMetrics: null,
       maxImageHeightPx: 0,
+      maxExactImageHeightPx: 0,
       maxMathHeightPx: 0,
       availableWidth: adjustedWidth,
       leftOffset: floatingMargins.leftMargin,
@@ -1335,6 +1345,9 @@ export function measureParagraph(
       const imageFootprintPx = imageHeight + (run.distTop ?? 0) + (run.distBottom ?? 0);
       if (imageFootprintPx > currentLine.maxImageHeightPx) {
         currentLine.maxImageHeightPx = imageFootprintPx;
+      }
+      if (run.exactLineHeight === true && imageFootprintPx > currentLine.maxExactImageHeightPx) {
+        currentLine.maxExactImageHeightPx = imageFootprintPx;
       }
 
       currentLine.width += imageWidth;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -217,6 +217,8 @@ export type ImageRun = {
   distBottom?: number;
   distLeft?: number;
   distRight?: number;
+  /** Use the image box as the exact line height for an embedded-object preview. */
+  exactLineHeight?: boolean;
   /**
    * wp:srcRect crop fractions in [0, 1]; emit as CSS `clip-path: inset(...)`
    * to match Word's visible region. eigenpal #424 (image-crop subset).

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -506,6 +506,7 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
   optionalOneOf(attrs, "wrapText", "image.attrs.wrapText", issues, IMAGE_WRAP_TEXT_VALUES);
   optionalString(attrs, "hlinkHref", "image.attrs.hlinkHref", issues);
   optionalString(attrs, "_docxRawXml", "image.attrs._docxRawXml", issues);
+  optionalBoolean(attrs, "_docxObjectPreview", "image.attrs._docxObjectPreview", issues);
 
   return attrsResult(attrs, issues);
 };

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2406,6 +2406,8 @@ function convertImage(image: Image, rawXml?: string): PMNode {
     wrapText,
     hlinkHref: image.hlinkHref,
     _docxRawXml: rawXml,
+    _docxObjectPreview:
+      rawXml !== undefined && /<(?:[A-Za-z_][\w.-]*:)?object(?:\s|>)/u.test(rawXml),
   });
 }
 

--- a/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -41,6 +41,7 @@ export const ImageExtension = createNodeExtension({
       wrapText: { default: null },
       hlinkHref: { default: null },
       _docxRawXml: { default: null },
+      _docxObjectPreview: { default: null },
     },
     parseDOM: [
       {

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -307,6 +307,8 @@ export type ImageAttrs = {
   hlinkHref?: string;
   /** Original OOXML for opaque/unsupported DOCX drawings. */
   _docxRawXml?: string;
+  /** Embedded-object previews use their authored box as the exact line height. */
+  _docxObjectPreview?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

- render relationship-backed previews carried by legacy embedded objects
- preserve source object XML during save
- reserve the authored preview box as the exact inline line height
- reject unsafe explicit preview dimensions at the parser boundary

## Validation

- focused parser and layout tests pass after rebase
- strict same-font anonymous replay: 90.6% to 93.8%, 2/2 pages, one vertical divergence removed
- unrelated control replay unchanged at 95.7%, 1/1 page
- dependency audit reports no vulnerabilities
- lint, typecheck, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering previews of legacy embedded objects.
  * Preserved embedded-object structure and authored preview metadata when saving documents.
  * Improved preview sizing by using the authored image box as the exact line height.
* **Bug Fixes**
  * Rejects embedded previews with unsafe or invalid dimensions without throwing errors.
  * Prevents incorrect layout measurement caching for previews with exact line heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->