### PR TITLE
fix: correct Garamond line metrics

### DIFF
--- a/.changeset/calm-garamond-lines.md
+++ b/.changeset/calm-garamond-lines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Correct Garamond single-line metrics for stable OOXML pagination.

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -37,6 +37,7 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["impact", 1.2197],
     ["palatino linotype", 1.3491],
     ["book antiqua", 1.2056],
+    ["garamond", 1.1273],
     ["century gothic", 1.2261],
     ["lucida console", 1.0],
   ];
@@ -80,6 +81,7 @@ describe("fontResolver — previously wrong ratios are corrected and reach consu
     ["palatino linotype", 1.3491], // was hand-transcribed 1.0259 — wrong by 31%
     ["arial", 1.1499], // fixed in a prior revision; still exercised here
     ["book antiqua", 1.2056], // was hand-transcribed 1.0259 — wrong by 17%
+    ["garamond", 1.1273], // replaces the unverified 1.068 legacy value
     ["century gothic", 1.2261], // was hand-transcribed 1.1611 — wrong by 6%
     ["trebuchet ms", 1.1611], // was hand-transcribed 1.1431 — wrong
     ["consolas", 1.1709], // was hand-transcribed 1.1626 — wrong
@@ -94,14 +96,9 @@ describe("fontResolver — previously wrong ratios are corrected and reach consu
 });
 
 describe("fontResolver — unverified legacy fonts are left unchanged", () => {
-  // garamond and lucida sans have not been measured against real Word output
-  // (the original fonts aren't available here to read hhea metrics from); their
-  // hand-transcribed ratios must stay exactly as they were before this refactor
-  // introduced the hhea-derived table.
-  const legacyCases: [font: string, unchangedRatio: number][] = [
-    ["garamond", 1.068],
-    ["lucida sans", 1.1655],
-  ];
+  // The original face is not available here to read hhea metrics from, so its
+  // hand-transcribed ratio stays unchanged until a verified source is available.
+  const legacyCases: [font: string, unchangedRatio: number][] = [["lucida sans", 1.1655]];
 
   for (const [font, unchangedRatio] of legacyCases) {
     test(`${font} keeps its legacy ratio`, () => {

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -139,9 +139,9 @@ const APTOS_MEASURED_LINE_HEIGHT: FontLineHeight = {
  * font's `FontLineHeight`, never hand-written. For "hhea" entries the raw
  * `hheaAscent`/`hheaDescent`/`hheaLineGap`/`unitsPerEm` fields below are read
  * directly from the real font files' `hhea` table; the ratio is whatever
- * falls out of the formula in `singleLineRatioOf`. "legacy" entries (e.g.
- * garamond, lucida sans, lucida console) are unverified hand-transcribed
- * ratios carried over unchanged, pending measurement.
+ * falls out of the formula in `singleLineRatioOf`. The remaining "legacy"
+ * entry (lucida sans) is an unverified hand-transcribed ratio carried over
+ * unchanged, pending measurement.
  */
 const FONT_MAPPINGS: Record<string, FontMapping> = {
   // Microsoft Office fonts -> Google equivalents (via Croscore)
@@ -344,9 +344,9 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     category: "serif",
     fallbackStack: ["Garamond", "EB Garamond", "Georgia", "serif"],
     singleLineRatio: singleLineRatioOf({
-      source: "legacy",
-      ratio: 1.068, // 1068/1000
-      note: "Unverified hand-transcribed ratio; not yet measured against real Word output.",
+      source: "measured",
+      ratio: 1.1273,
+      note: "Measured at 11pt against a 12.4pt reference-layout line pitch.",
     }),
   },
   "century gothic": {


### PR DESCRIPTION
## Summary

- replace the legacy Garamond single-line ratio with a measured reference-layout ratio
- keep the corrected metric in the shared resolver path used by paragraph measurement
- lock both direct resolution and downstream cache resolution with focused regression assertions

## Validation

- 101 focused font resolver tests pass
- strict same-font anonymous replay: 58.5% to 72.0%, pages 2/2, pagination divergences 3 to 0, y-drift 12 to 4
- unrelated control unchanged at 95.7%, pages 1/1
- bun audit: no vulnerabilities
- lint, typecheck, build, distribution validation, and full tests delegated to CI

CC on behalf of @jan-kubica