### PR TITLE
fix: honor grouped shape outline colours

### DIFF
--- a/.changeset/soft-grouped-lines.md
+++ b/.changeset/soft-grouped-lines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render grouped shape outline colours supplied by OOXML style references.

--- a/packages/core/src/docx/groupDrawingParser.test.ts
+++ b/packages/core/src/docx/groupDrawingParser.test.ts
@@ -53,6 +53,45 @@ describe("parseGroupDrawing", () => {
     expect(svg).not.toContain('<rect width="2000000" height="1000000" fill="#FFFFFF"');
   });
 
+  test("uses grouped shape style outline colour when geometry omits a direct colour", () => {
+    const drawing = parseXmlDocument(`
+      <w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+        xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+        <wp:anchor>
+          <wp:extent cx="2000000" cy="100000"/>
+          <wp:wrapTopAndBottom/>
+          <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup">
+            <wpg:wgp><wps:wsp>
+              <wps:spPr>
+                <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="100000"/></a:xfrm>
+                <a:custGeom><a:pathLst><a:path w="2000000" h="100000">
+                  <a:moveTo><a:pt x="0" y="50000"/></a:moveTo>
+                  <a:lnTo><a:pt x="2000000" y="50000"/></a:lnTo>
+                </a:path></a:pathLst></a:custGeom>
+                <a:ln w="20000"/>
+              </wps:spPr>
+              <wps:style>
+                <a:lnRef idx="1"><a:srgbClr val="123456"/></a:lnRef>
+                <a:fillRef idx="0"><a:srgbClr val="ABCDEF"/></a:fillRef>
+              </wps:style>
+            </wps:wsp></wpg:wgp>
+          </a:graphicData></a:graphic>
+        </wp:anchor>
+      </w:drawing>
+    `);
+
+    if (!drawing) {
+      throw new Error("Expected drawing fixture");
+    }
+    const image = parseGroupDrawing(drawing);
+    const svg = decodeURIComponent(image?.src?.split(",").at(1) ?? "");
+
+    expect(svg).toContain('fill="none" stroke="#123456" stroke-width="20000"');
+  });
+
   test("composes grouped pictures within the authored group extent", () => {
     const drawing = parseXmlDocument(`
       <w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"

--- a/packages/core/src/docx/groupDrawingParser.ts
+++ b/packages/core/src/docx/groupDrawingParser.ts
@@ -67,9 +67,13 @@ const colorFrom = (parent: XmlElement | null, fallback?: string): string | undef
       return value.toUpperCase();
     }
   }
+  if (findChildByLocalName(parent, "noFill")) {
+    return "none";
+  }
   const solidFill = findChildByLocalName(parent, "solidFill");
   const srgb = findChildByLocalName(solidFill, "srgbClr");
-  const value = getAttribute(srgb, null, "val");
+  const referencedSrgb = findChildByLocalName(parent, "srgbClr");
+  const value = getAttribute(srgb ?? referencedSrgb, null, "val");
   if (value && HEX_COLOR.test(value)) {
     return value.toUpperCase();
   }
@@ -139,9 +143,11 @@ const renderGeometry = (wsp: XmlElement): string => {
     return "";
   }
   const spPr = findChildByLocalName(wsp, "spPr");
+  const style = findChildByLocalName(wsp, "style");
+  const styleStroke = colorFrom(findChildByLocalName(style, "lnRef"), "none");
   const fill = colorFrom(spPr, "none");
   const line = findChildByLocalName(spPr, "ln");
-  const stroke = colorFrom(line, "none");
+  const stroke = colorFrom(line, styleStroke);
   const strokeWidth = line ? (parseNumericAttribute(line, null, "w") ?? DEFAULT_LINE_WIDTH_EMU) : 0;
   const paths = findAllDeep(findChildByLocalName(spPr, "custGeom"), "a", "path");
   if (paths.length === 0) {


### PR DESCRIPTION
## Summary

- resolve explicit RGB fallbacks from grouped shape outline style references
- preserve direct no-fill semantics over referenced outline colours
- add a synthetic regression for style-backed grouped geometry

## Validation

- 48 focused parser, drawing, and anchored-layout tests pass
- strict-font parity replay restores the omitted positioned artwork at its authored extent
- text-geometry score remains 83.3% because the score excludes non-text artwork
- `bun audit` reports no vulnerabilities
- lint and typecheck are delegated to CI as requested

CC on behalf of @jan-kubica