### PR TITLE
feat: expand DOCX capability catalog

### DIFF
--- a/.changeset/bright-catalogs-expand.md
+++ b/.changeset/bright-catalogs-expand.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Expand the DOCX capability catalog with core document and review features.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -406,31 +406,10 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replac
 export const FOLIO_DOCX_CAPABILITY_HOSTS: readonly ["browser", "server"];
 
 // @public (undocumented)
-export const FOLIO_DOCX_CAPABILITY_IDS: readonly ["opaqueDrawing"];
+export const FOLIO_DOCX_CAPABILITY_IDS: readonly ["comments", "opaqueDrawing", "paragraphs", "tables", "trackedChanges"];
 
 // @public (undocumented)
-export const FOLIO_DOCX_CAPABILITY_MANIFEST: Readonly<{
-    version: 1;
-    capabilities: Readonly<{
-        opaqueDrawing: Readonly<{
-            readonly id: "opaqueDrawing";
-            readonly feature: "drawings";
-            readonly hosts: readonly ["browser", "server"];
-            readonly profiles: readonly "transitional"[];
-            readonly support: Readonly<{
-                create: "unsupported";
-                edit: "unsupported";
-                preserve: "supported";
-                read: "supported";
-                render: "partial";
-            }>;
-            readonly evidence: readonly {
-                type: "test";
-                path: string;
-            }[];
-        }>;
-    }>;
-}>;
+export const FOLIO_DOCX_CAPABILITY_MANIFEST: FolioDocxCapabilityManifest;
 
 // @public (undocumented)
 export const FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION: 1;
@@ -733,6 +712,12 @@ export type FolioDocxCapabilityHost = (typeof FOLIO_DOCX_CAPABILITY_HOSTS)[numbe
 export type FolioDocxCapabilityId = (typeof FOLIO_DOCX_CAPABILITY_IDS)[number];
 
 // @public (undocumented)
+export type FolioDocxCapabilityManifest = {
+    readonly version: typeof FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION;
+    readonly capabilities: Readonly<Record<FolioDocxCapabilityId, FolioDocxFeatureCapability>>;
+};
+
+// @public (undocumented)
 export type FolioDocxCapabilityOperation = (typeof FOLIO_DOCX_CAPABILITY_OPERATIONS)[number];
 
 // @public (undocumented)
@@ -744,7 +729,7 @@ export type FolioDocxCompatibilityProfile = (typeof FOLIO_DOCX_COMPATIBILITY_PRO
 // @public (undocumented)
 export type FolioDocxFeatureCapability = {
     readonly id: FolioDocxCapabilityId;
-    readonly feature: "drawings";
+    readonly feature: "comments" | "drawings" | "paragraphs" | "revisions" | "tables";
     readonly hosts: readonly FolioDocxCapabilityHost[];
     readonly profiles: readonly FolioDocxProfile[];
     readonly support: Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -406,31 +406,10 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replac
 export const FOLIO_DOCX_CAPABILITY_HOSTS: readonly ["browser", "server"];
 
 // @public (undocumented)
-export const FOLIO_DOCX_CAPABILITY_IDS: readonly ["opaqueDrawing"];
+export const FOLIO_DOCX_CAPABILITY_IDS: readonly ["comments", "opaqueDrawing", "paragraphs", "tables", "trackedChanges"];
 
 // @public (undocumented)
-export const FOLIO_DOCX_CAPABILITY_MANIFEST: Readonly<{
-    version: 1;
-    capabilities: Readonly<{
-        opaqueDrawing: Readonly<{
-            readonly id: "opaqueDrawing";
-            readonly feature: "drawings";
-            readonly hosts: readonly ["browser", "server"];
-            readonly profiles: readonly "transitional"[];
-            readonly support: Readonly<{
-                create: "unsupported";
-                edit: "unsupported";
-                preserve: "supported";
-                read: "supported";
-                render: "partial";
-            }>;
-            readonly evidence: readonly {
-                type: "test";
-                path: string;
-            }[];
-        }>;
-    }>;
-}>;
+export const FOLIO_DOCX_CAPABILITY_MANIFEST: FolioDocxCapabilityManifest;
 
 // @public (undocumented)
 export const FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION: 1;
@@ -733,6 +712,12 @@ export type FolioDocxCapabilityHost = (typeof FOLIO_DOCX_CAPABILITY_HOSTS)[numbe
 export type FolioDocxCapabilityId = (typeof FOLIO_DOCX_CAPABILITY_IDS)[number];
 
 // @public (undocumented)
+export type FolioDocxCapabilityManifest = {
+    readonly version: typeof FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION;
+    readonly capabilities: Readonly<Record<FolioDocxCapabilityId, FolioDocxFeatureCapability>>;
+};
+
+// @public (undocumented)
 export type FolioDocxCapabilityOperation = (typeof FOLIO_DOCX_CAPABILITY_OPERATIONS)[number];
 
 // @public (undocumented)
@@ -744,7 +729,7 @@ export type FolioDocxCompatibilityProfile = (typeof FOLIO_DOCX_COMPATIBILITY_PRO
 // @public (undocumented)
 export type FolioDocxFeatureCapability = {
     readonly id: FolioDocxCapabilityId;
-    readonly feature: "drawings";
+    readonly feature: "comments" | "drawings" | "paragraphs" | "revisions" | "tables";
     readonly hosts: readonly FolioDocxCapabilityHost[];
     readonly profiles: readonly FolioDocxProfile[];
     readonly support: Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>;

--- a/packages/core/src/docx/capabilities.ts
+++ b/packages/core/src/docx/capabilities.ts
@@ -1,3 +1,5 @@
+import { TaggedError } from "better-result";
+
 export const FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION = 1 as const;
 
 export const FOLIO_DOCX_CAPABILITY_HOSTS = Object.freeze(["browser", "server"] as const);
@@ -22,7 +24,13 @@ export const FOLIO_DOCX_SUPPORT_STATES = Object.freeze([
   "partial",
   "unsupported",
 ] as const);
-export const FOLIO_DOCX_CAPABILITY_IDS = Object.freeze(["opaqueDrawing"] as const);
+export const FOLIO_DOCX_CAPABILITY_IDS = Object.freeze([
+  "comments",
+  "opaqueDrawing",
+  "paragraphs",
+  "tables",
+  "trackedChanges",
+] as const);
 
 export type FolioDocxCapabilityHost = (typeof FOLIO_DOCX_CAPABILITY_HOSTS)[number];
 export type FolioDocxCompatibilityHost = (typeof FOLIO_DOCX_COMPATIBILITY_HOSTS)[number];
@@ -34,7 +42,7 @@ export type FolioDocxCapabilityId = (typeof FOLIO_DOCX_CAPABILITY_IDS)[number];
 
 export type FolioDocxFeatureCapability = {
   readonly id: FolioDocxCapabilityId;
-  readonly feature: "drawings";
+  readonly feature: "comments" | "drawings" | "paragraphs" | "revisions" | "tables";
   readonly hosts: readonly FolioDocxCapabilityHost[];
   readonly profiles: readonly FolioDocxProfile[];
   readonly support: Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>;
@@ -44,11 +52,43 @@ export type FolioDocxFeatureCapability = {
   }[];
 };
 
+export type FolioDocxCapabilityManifest = {
+  readonly version: typeof FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION;
+  readonly capabilities: Readonly<Record<FolioDocxCapabilityId, FolioDocxFeatureCapability>>;
+};
+
+const TRANSITIONAL_PROFILE_COVERAGE = Object.freeze(["transitional"] as const);
+const STRUCTURED_FEATURE_SUPPORT = Object.freeze({
+  create: "supported",
+  edit: "supported",
+  preserve: "supported",
+  read: "supported",
+  render: "partial",
+} as const satisfies Readonly<Record<FolioDocxCapabilityOperation, FolioDocxSupportState>>);
+
+const COMMENTS_CAPABILITY = Object.freeze({
+  id: "comments",
+  feature: "comments",
+  hosts: FOLIO_DOCX_CAPABILITY_HOSTS,
+  profiles: TRANSITIONAL_PROFILE_COVERAGE,
+  support: STRUCTURED_FEATURE_SUPPORT,
+  evidence: Object.freeze([
+    {
+      type: "test",
+      path: "packages/core/src/docx/commentReplyThreads.test.ts",
+    },
+    {
+      type: "test",
+      path: "packages/core/src/prosemirror/commands/comments.test.ts",
+    },
+  ]),
+} as const satisfies FolioDocxFeatureCapability);
+
 const OPAQUE_DRAWING_CAPABILITY = Object.freeze({
   id: "opaqueDrawing",
   feature: "drawings",
   hosts: FOLIO_DOCX_CAPABILITY_HOSTS,
-  profiles: Object.freeze(["transitional"]),
+  profiles: TRANSITIONAL_PROFILE_COVERAGE,
   support: Object.freeze({
     create: "unsupported",
     edit: "unsupported",
@@ -68,12 +108,72 @@ const OPAQUE_DRAWING_CAPABILITY = Object.freeze({
   ]),
 } as const satisfies FolioDocxFeatureCapability);
 
-export const FOLIO_DOCX_CAPABILITY_MANIFEST = Object.freeze({
+const PARAGRAPHS_CAPABILITY = Object.freeze({
+  id: "paragraphs",
+  feature: "paragraphs",
+  hosts: FOLIO_DOCX_CAPABILITY_HOSTS,
+  profiles: TRANSITIONAL_PROFILE_COVERAGE,
+  support: STRUCTURED_FEATURE_SUPPORT,
+  evidence: Object.freeze([
+    {
+      type: "test",
+      path: "packages/core/src/docx/paragraphParser.test.ts",
+    },
+    {
+      type: "test",
+      path: "packages/core/src/docx/serializer/paragraphSerializer.test.ts",
+    },
+  ]),
+} as const satisfies FolioDocxFeatureCapability);
+
+const TABLES_CAPABILITY = Object.freeze({
+  id: "tables",
+  feature: "tables",
+  hosts: FOLIO_DOCX_CAPABILITY_HOSTS,
+  profiles: TRANSITIONAL_PROFILE_COVERAGE,
+  support: STRUCTURED_FEATURE_SUPPORT,
+  evidence: Object.freeze([
+    {
+      type: "test",
+      path: "packages/core/src/docx/tableParser.test.ts",
+    },
+    {
+      type: "test",
+      path: "packages/core/src/prosemirror/conversion/tableBordersRoundtrip.test.ts",
+    },
+  ]),
+} as const satisfies FolioDocxFeatureCapability);
+
+const TRACKED_CHANGES_CAPABILITY = Object.freeze({
+  id: "trackedChanges",
+  feature: "revisions",
+  hosts: FOLIO_DOCX_CAPABILITY_HOSTS,
+  profiles: TRANSITIONAL_PROFILE_COVERAGE,
+  support: STRUCTURED_FEATURE_SUPPORT,
+  evidence: Object.freeze([
+    {
+      type: "test",
+      path: "packages/core/src/redline.test.ts",
+    },
+    {
+      type: "test",
+      path: "packages/core/src/prosemirror/plugins/suggestionMode.test.ts",
+    },
+  ]),
+} as const satisfies FolioDocxFeatureCapability);
+
+const CAPABILITY_MANIFEST = Object.freeze({
   version: FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION,
   capabilities: Object.freeze({
+    comments: COMMENTS_CAPABILITY,
     opaqueDrawing: OPAQUE_DRAWING_CAPABILITY,
+    paragraphs: PARAGRAPHS_CAPABILITY,
+    tables: TABLES_CAPABILITY,
+    trackedChanges: TRACKED_CHANGES_CAPABILITY,
   }),
-});
+} as const satisfies FolioDocxCapabilityManifest);
+
+export const FOLIO_DOCX_CAPABILITY_MANIFEST: FolioDocxCapabilityManifest = CAPABILITY_MANIFEST;
 
 export class InvalidFolioDocxCapabilityIdError extends TaggedError(
   "InvalidFolioDocxCapabilityIdError",
@@ -83,7 +183,7 @@ export class InvalidFolioDocxCapabilityIdError extends TaggedError(
 }>() {}
 
 export const isFolioDocxCapabilityId = (value: unknown): value is FolioDocxCapabilityId =>
-  value === "opaqueDrawing";
+  FOLIO_DOCX_CAPABILITY_IDS.some((id) => id === value);
 
 export const getFolioDocxCapability = (id: unknown): FolioDocxFeatureCapability => {
   if (!isFolioDocxCapabilityId(id)) {
@@ -94,4 +194,3 @@ export const getFolioDocxCapability = (id: unknown): FolioDocxFeatureCapability 
   }
   return FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities[id];
 };
-import { TaggedError } from "better-result";

--- a/packages/core/src/docx/compatibility.test.ts
+++ b/packages/core/src/docx/compatibility.test.ts
@@ -4,6 +4,7 @@ import { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
 
 import type { Document } from "../types/document";
 import {
+  FOLIO_DOCX_CAPABILITY_IDS,
   FOLIO_DOCX_CAPABILITY_MANIFEST,
   FOLIO_DOCX_CAPABILITY_MANIFEST_VERSION,
   getFolioDocxCapability,
@@ -161,10 +162,32 @@ describe("DOCX capability manifest", () => {
         },
       ],
     });
+  });
+
+  test("covers core document and review features with repository evidence", async () => {
+    expect(FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities.paragraphs.support).toEqual({
+      create: "supported",
+      edit: "supported",
+      preserve: "supported",
+      read: "supported",
+      render: "partial",
+    });
+    expect(FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities.tables.feature).toBe("tables");
+    expect(FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities.comments.feature).toBe("comments");
+    expect(FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities.trackedChanges.feature).toBe("revisions");
+
     const repositoryRoot = path.resolve(import.meta.dir, "../../../..");
-    for (const evidence of getFolioDocxCapability("opaqueDrawing").evidence) {
-      expect(await Bun.file(path.join(repositoryRoot, evidence.path)).exists()).toBe(true);
+    for (const capability of Object.values(FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities)) {
+      for (const evidence of capability.evidence) {
+        expect(await Bun.file(path.join(repositoryRoot, evidence.path)).exists()).toBe(true);
+      }
     }
+  });
+
+  test("keeps the public id list aligned with manifest keys", () => {
+    expect(Object.keys(FOLIO_DOCX_CAPABILITY_MANIFEST.capabilities)).toEqual(
+      FOLIO_DOCX_CAPABILITY_IDS,
+    );
   });
 
   test("rejects unknown ids at the public lookup boundary", () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export {
   isFolioDocxCapabilityId,
   type FolioDocxCapabilityHost,
   type FolioDocxCapabilityId,
+  type FolioDocxCapabilityManifest,
   type FolioDocxCapabilityOperation,
   type FolioDocxCompatibilityHost,
   type FolioDocxCompatibilityProfile,


### PR DESCRIPTION
## Summary

- add evidence-backed entries for core document and review features
- keep profile coverage and render support conservative
- expose a stable typed manifest shape