### PR TITLE
fix: ignore stale cached pagination boundaries

### DIFF
--- a/.changeset/fresh-pagination-markers.md
+++ b/.changeset/fresh-pagination-markers.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Treat stale cached pagination markers as advisory after document reflow.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -382,7 +382,7 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1].fragments[0].blockId).toBe(2);
     });
 
-    test("rendered page break starts a new page after content", () => {
+    test("stale rendered page break remains advisory when the paragraph fits", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Before break", 1),
         {
@@ -397,8 +397,33 @@ describe("Layout Engine - Page Production", () => {
 
       const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
-      expect(layout.pages.length).toBe(2);
-      expect(layout.pages[1].fragments[0].blockId).toBe(1);
+      expect(layout.pages).toHaveLength(1);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0, 1]);
+    });
+
+    test("rendered page break moves a paragraph that would cross the current page", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        {
+          ...makeParagraphBlock(1, "Cached paragraph wraps across four lines", 23),
+          attrs: { renderedPageBreakBefore: true },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 820)]),
+        makeParagraphMeasure([
+          makeLine(0, 0, 0, 10, 100, 20),
+          makeLine(0, 10, 0, 20, 100, 20),
+          makeLine(0, 20, 0, 30, 100, 20),
+          makeLine(0, 30, 0, 40, 100, 20),
+        ]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
     });
 
     test("rendered page break does not add a blank page at a natural overflow", () => {
@@ -554,7 +579,7 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
     });
 
-    test("rendered page break remains authoritative after a whole paragraph moves", () => {
+    test("stale rendered page break remains advisory after a whole paragraph moves", () => {
       const previousItem = {
         ...makeParagraphBlock(1, "Moves intact", 23),
         attrs: { numPr: { numId: 4, ilvl: 1 } },
@@ -579,9 +604,8 @@ describe("Layout Engine - Page Production", () => {
 
       const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
-      expect(layout.pages).toHaveLength(3);
-      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
-      expect(layout.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual([2]);
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
     });
 
     test("rendered page break reuses a page opened within one numbered sequence", () => {
@@ -658,7 +682,7 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
     });
 
-    test("rendered page break remains authoritative when tabbed layouts differ", () => {
+    test("stale rendered page break remains advisory when tabbed layouts reflow", () => {
       const previousRow: FlowBlock = {
         ...makeParagraphBlock(1, "First row", 23),
         runs: [
@@ -699,12 +723,11 @@ describe("Layout Engine - Page Production", () => {
 
       const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
-      expect(layout.pages).toHaveLength(3);
-      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
-      expect(layout.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual([2]);
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
     });
 
-    test("successive rendered page breaks remain authoritative after natural reflow", () => {
+    test("successive stale rendered page breaks remain advisory after natural reflow", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Fill page one", 1),
         makeParagraphBlock(1, "Natural page two", 15),
@@ -730,10 +753,9 @@ describe("Layout Engine - Page Production", () => {
 
       const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
-      expect(layout.pages.length).toBe(4);
-      expect(layout.pages[1].fragments.map((fragment) => fragment.blockId)).toEqual([1]);
-      expect(layout.pages[2].fragments.map((fragment) => fragment.blockId)).toEqual([2, 3, 4]);
-      expect(layout.pages[3].fragments.map((fragment) => fragment.blockId)).toEqual([5]);
+      expect(layout.pages).toHaveLength(3);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2, 3]);
+      expect(layout.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual([4, 5]);
     });
 
     test("explicit pageBreakBefore takes priority over a rendered page break hint", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -504,17 +504,19 @@ export function layoutDocument(
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
 
-    // A cached pagination marker records a break at this paragraph, not an
-    // ordinal page target: the source does not emit markers for every physical
-    // page. Honor the break whenever visible content precedes it on Folio's
-    // current page. A structural/natural break that opened an empty page, or a
-    // page containing only overflowed empty paragraphs, already satisfies it.
+    // A cached pagination marker is advisory after layout inputs change. Snap
+    // to it only when the marked paragraph would cross the current page; if the
+    // paragraph still fits, forcing the stale boundary can create a mostly empty
+    // extra page after reflow. A structural or natural break that already opened
+    // the destination page also satisfies the marker.
     const hasRenderedPageBreak =
       block.kind === "paragraph" && block.attrs?.renderedPageBreakBefore === true;
     if (hasPageBreakBefore(block)) {
       paginator.forcePageBreak();
     } else if (hasRenderedPageBreak) {
       const state = paginator.getCurrentState();
+      const renderedBreakNeedsSnap =
+        measure.kind === "paragraph" && !paginator.fits(measure.totalHeight);
       const previousParagraphAlreadyCrossedMarker = pageStartsWithPreviousParagraphContinuation(
         state.page,
         blocks[i - 1],
@@ -530,6 +532,7 @@ export function layoutDocument(
             continuesTabbedParagraphSequence(blocks[i - 1], block)));
       if (
         !naturalAdvanceAlreadyCrossedMarker &&
+        renderedBreakNeedsSnap &&
         pageHasVisibleBodyContent(state.page, blocksById)
       ) {
         paginator.forcePageBreak();

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -416,7 +416,7 @@ test.describe("image", () => {
 });
 
 test.describe("rendered page-break hints", () => {
-  test("cached hints paginate without duplicating structural breaks", async ({ page }) => {
+  test("cached hints remain advisory without duplicating structural breaks", async ({ page }) => {
     await mountFixture(page, "sample.docx");
 
     const replaceDocument = async (
@@ -450,7 +450,7 @@ test.describe("rendered page-break hints", () => {
     };
 
     await replaceDocument("hintAfterContent");
-    await waitForPages(2);
+    await waitForPages(1);
 
     await replaceDocument("hintAfterBreak");
     await waitForPages(2);


### PR DESCRIPTION
## Summary

- Treat cached pagination markers as advisory after document reflow.
- Snap a marked paragraph only when it would cross the current page.
- Add regression coverage for stale markers, natural reflow, list and tab sequences, and explicit breaks.

## Validation

- `bun test src/layout-engine src/__tests__/layout-pipeline.integration.test.ts` from `packages/core` (410 passed)
- Same-font reference comparison: expected page count restored and score improved from 80.8% to 92.6%
- Separate cached-boundary control: stable score and divergence counts; one redundant page removed
- `bun audit` (no vulnerabilities)
- Lint and typecheck delegated to CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination after document reflow by treating stale page-break markers as advisory.
  * Prevented unnecessary blank pages and forced breaks when content already fits naturally.
  * Preserved correct page breaks when content genuinely crosses a page boundary.

* **Tests**
  * Expanded coverage for reflow scenarios, including moved paragraphs, tabbed layouts, and consecutive page breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->