### PR TITLE
fix: base list wrapping on compressible space width

### DIFF
--- a/.changeset/bright-list-spacing.md
+++ b/.changeset/bright-list-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Base justified list marker wrapping on measured compressible-space width.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -509,7 +509,7 @@ describe("measureParagraph justified shrink tolerance", () => {
   const fractionalWidth = (char: string): number => (char === "b" ? 0.6 : 1);
   const text = `${"a".repeat(99)} bbb`;
 
-  test("allows normal justified prose to use Word-style shrink before wrapping", () => {
+  test("allows normal justified prose to use reference-layout shrink before wrapping", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
@@ -720,6 +720,45 @@ describe("measureParagraph justified shrink tolerance", () => {
         );
 
         expect(measure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("bases default list marker shrink on measured compressible spaces", () => {
+    withFakeTextMeasure(
+      () => {
+        const spaceRichMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-space-budget",
+            runs: [{ kind: "text", text: `${"a ".repeat(15)}bbb` }],
+            attrs: {
+              alignment: "justify",
+              indent: { left: 24, hanging: 24 },
+              listMarker: "1.",
+            },
+          },
+          53,
+        );
+        const spacePoorMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-small-space-budget",
+            runs: [{ kind: "text", text: `${"a".repeat(29)} bbb` }],
+            attrs: {
+              alignment: "justify",
+              indent: { left: 24, hanging: 24 },
+              listMarker: "1.",
+            },
+          },
+          53,
+        );
+
+        expect(spaceRichMeasure.lines).toHaveLength(1);
+        expect(spacePoorMeasure.lines).toHaveLength(2);
       },
       {
         charWidth: fractionalWidth,

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -637,7 +637,7 @@ function justifyShrinkToleranceRatio(
   });
 }
 
-function isDefaultHangingListMarkerLine(block: ParagraphBlock, isFirstLine: boolean): boolean {
+function usesSpaceBasedListMarkerTolerance(block: ParagraphBlock, isFirstLine: boolean): boolean {
   return (
     isFirstLine &&
     block.attrs?.listMarker !== undefined &&
@@ -1448,13 +1448,13 @@ export function measureParagraph(
         const nonBreakingSpaces = measuredWord.split("\u00a0").length - 1;
         const isFirstLine = lines.length === 0;
         const regularSpaceWidth =
-          regularSpaces > 0 && isDefaultHangingListMarkerLine(block, isFirstLine)
+          regularSpaces > 0 && usesSpaceBasedListMarkerTolerance(block, isFirstLine)
             ? regularSpaces * measureTextWidth(" ", style)
             : 0;
         const widthTolerance = isJustifiedParagraph
           ? Math.max(
               WIDTH_TOLERANCE,
-              isDefaultHangingListMarkerLine(block, isFirstLine)
+              usesSpaceBasedListMarkerTolerance(block, isFirstLine)
                 ? (currentLine.regularSpaceWidth + regularSpaceWidth) *
                     JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO
                 : currentLine.availableWidth *
@@ -1504,7 +1504,7 @@ export function measureParagraph(
             currentLine.regularSpaceCount += chunkRegularSpaceCount;
             if (
               chunkRegularSpaceCount > 0 &&
-              isDefaultHangingListMarkerLine(block, lines.length === 0)
+              usesSpaceBasedListMarkerTolerance(block, lines.length === 0)
             ) {
               currentLine.regularSpaceWidth +=
                 chunkRegularSpaceCount * measureTextWidth(" ", style);
@@ -1527,7 +1527,7 @@ export function measureParagraph(
           currentLine.regularSpaceCount += wordRegularSpaceCount;
           if (
             wordRegularSpaceCount > 0 &&
-            isDefaultHangingListMarkerLine(block, lines.length === 0)
+            usesSpaceBasedListMarkerTolerance(block, lines.length === 0)
           ) {
             currentLine.regularSpaceWidth += wordRegularSpaceCount * measureTextWidth(" ", style);
           }
@@ -1580,7 +1580,7 @@ export function measureParagraph(
         currentLine.regularSpaceCount += wordRegularSpaceCount;
         if (
           wordRegularSpaceCount > 0 &&
-          isDefaultHangingListMarkerLine(block, lines.length === 0)
+          usesSpaceBasedListMarkerTolerance(block, lines.length === 0)
         ) {
           currentLine.regularSpaceWidth += wordRegularSpaceCount * measureTextWidth(" ", style);
         }

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -53,6 +53,7 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
+const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
 const JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO = 0.02;
@@ -118,8 +119,10 @@ type LineState = {
   width: number;
   /** Width of collapsible ASCII whitespace at the current line tail. */
   trailingWhitespaceWidth: number;
-  /** Spaces Word may compress while justifying this line. */
+  /** Spaces the layout may compress while justifying this line. */
   regularSpaceCount: number;
+  /** Measured width of the compressible spaces on this line. */
+  regularSpaceWidth: number;
   /** Fixed-width spaces excluded from the line's justification budget. */
   nonBreakingSpaceCount: number;
   maxFontSize: number;
@@ -587,9 +590,8 @@ function justifyShrinkToleranceRatio(
   nonBreakingSpaceCount: number,
 ): number {
   if (block.attrs?.listMarker !== undefined) {
-    // Word keeps a conservative allowance on the marker line. Continuation
-    // lines use prose compression, reduced by fixed non-breaking spaces on the
-    // current line.
+    // Marker lines and continuation lines use separate compression budgets.
+    // Fixed non-breaking spaces reduce the continuation-line allowance.
     const hanging = block.attrs.indent?.hanging ?? 0;
     if (isFirstLine) {
       return hanging <= DEFAULT_LIST_HANGING_INDENT_PX
@@ -633,6 +635,14 @@ function justifyShrinkToleranceRatio(
     regularSpaceCount,
     nonBreakingSpaceCount,
   });
+}
+
+function isDefaultHangingListMarkerLine(block: ParagraphBlock, isFirstLine: boolean): boolean {
+  return (
+    isFirstLine &&
+    block.attrs?.listMarker !== undefined &&
+    (block.attrs.indent?.hanging ?? 0) <= DEFAULT_LIST_HANGING_INDENT_PX
+  );
 }
 
 function trimTrailingSpacesAndTabs(text: string): string {
@@ -958,6 +968,7 @@ export function measureParagraph(
     width: 0,
     trailingWhitespaceWidth: 0,
     regularSpaceCount: 0,
+    regularSpaceWidth: 0,
     nonBreakingSpaceCount: 0,
     maxFontSize: DEFAULT_FONT_SIZE,
     maxFontMetrics: null,
@@ -1111,6 +1122,7 @@ export function measureParagraph(
       width: 0,
       trailingWhitespaceWidth: 0,
       regularSpaceCount: 0,
+      regularSpaceWidth: 0,
       nonBreakingSpaceCount: 0,
       maxFontSize: DEFAULT_FONT_SIZE,
       maxFontMetrics: null,
@@ -1434,16 +1446,24 @@ export function measureParagraph(
         const fullWordWidth = measureTextWidth(word, style);
         const regularSpaces = measuredWord.split(" ").length - 1;
         const nonBreakingSpaces = measuredWord.split("\u00a0").length - 1;
+        const isFirstLine = lines.length === 0;
+        const regularSpaceWidth =
+          regularSpaces > 0 && isDefaultHangingListMarkerLine(block, isFirstLine)
+            ? regularSpaces * measureTextWidth(" ", style)
+            : 0;
         const widthTolerance = isJustifiedParagraph
           ? Math.max(
               WIDTH_TOLERANCE,
-              currentLine.availableWidth *
-                justifyShrinkToleranceRatio(
-                  block,
-                  lines.length === 0,
-                  currentLine.regularSpaceCount + regularSpaces,
-                  currentLine.nonBreakingSpaceCount + nonBreakingSpaces,
-                ),
+              isDefaultHangingListMarkerLine(block, isFirstLine)
+                ? (currentLine.regularSpaceWidth + regularSpaceWidth) *
+                    JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO
+                : currentLine.availableWidth *
+                    justifyShrinkToleranceRatio(
+                      block,
+                      isFirstLine,
+                      currentLine.regularSpaceCount + regularSpaces,
+                      currentLine.nonBreakingSpaceCount + nonBreakingSpaces,
+                    ),
             )
           : WIDTH_TOLERANCE;
 
@@ -1480,7 +1500,15 @@ export function measureParagraph(
             currentLine.width += chunkWidth;
             currentLine.trailingWhitespaceWidth =
               chunkWidth - measureTextWidth(trimTrailingSpacesAndTabs(chunk), style);
-            currentLine.regularSpaceCount += chunk.split(" ").length - 1;
+            const chunkRegularSpaceCount = chunk.split(" ").length - 1;
+            currentLine.regularSpaceCount += chunkRegularSpaceCount;
+            if (
+              chunkRegularSpaceCount > 0 &&
+              isDefaultHangingListMarkerLine(block, lines.length === 0)
+            ) {
+              currentLine.regularSpaceWidth +=
+                chunkRegularSpaceCount * measureTextWidth(" ", style);
+            }
             currentLine.nonBreakingSpaceCount += chunk.split("\u00a0").length - 1;
             currentLine.toRun = runIndex;
             currentLine.toChar = charIndex + chunkEnd;
@@ -1495,7 +1523,14 @@ export function measureParagraph(
           const trailingWhitespaceWidth = fullWordWidth - wordWidth;
           currentLine.width += trailingWhitespaceWidth;
           currentLine.trailingWhitespaceWidth = trailingWhitespaceWidth;
-          currentLine.regularSpaceCount += word.split(" ").length - 1;
+          const wordRegularSpaceCount = word.split(" ").length - 1;
+          currentLine.regularSpaceCount += wordRegularSpaceCount;
+          if (
+            wordRegularSpaceCount > 0 &&
+            isDefaultHangingListMarkerLine(block, lines.length === 0)
+          ) {
+            currentLine.regularSpaceWidth += wordRegularSpaceCount * measureTextWidth(" ", style);
+          }
           currentLine.nonBreakingSpaceCount += word.split("\u00a0").length - 1;
           currentLine.toChar = nextBreak;
 
@@ -1541,7 +1576,14 @@ export function measureParagraph(
           wordWidth === 0
             ? currentLine.trailingWhitespaceWidth + wordTrailingWhitespaceWidth
             : wordTrailingWhitespaceWidth;
-        currentLine.regularSpaceCount += word.split(" ").length - 1;
+        const wordRegularSpaceCount = word.split(" ").length - 1;
+        currentLine.regularSpaceCount += wordRegularSpaceCount;
+        if (
+          wordRegularSpaceCount > 0 &&
+          isDefaultHangingListMarkerLine(block, lines.length === 0)
+        ) {
+          currentLine.regularSpaceWidth += wordRegularSpaceCount * measureTextWidth(" ", style);
+        }
         currentLine.nonBreakingSpaceCount += word.split("\u00a0").length - 1;
         currentLine.toRun = runIndex;
         currentLine.toChar = nextBreak;


### PR DESCRIPTION
## Summary

- calculate justified marker-line shrink from measured compressible whitespace instead of a fixed line-width ratio
- preserve continuation-line and custom-hanging behavior
- add synthetic boundary coverage and a patch changeset

The focused unit suite passes (82 tests). A strict same-font layout comparison removes both targeted marker-line text mismatches while three unrelated controls remain unchanged.