### PR TITLE
fix: respect authored pair kerning

### DIFF
--- a/.changeset/measured-kerning-thresholds.md
+++ b/.changeset/measured-kerning-thresholds.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Respect authored pair-kerning thresholds in layout measurement and rendering.

--- a/api-reports/core/layout-bridge-engine-measuring.api.md
+++ b/api-reports/core/layout-bridge-engine-measuring.api.md
@@ -99,7 +99,8 @@ export type FontStyle = {
     letterSpacing?: number;
     textTransform?: "uppercase";
     fontVariant?: "small-caps";
-    horizontalScale?: number;
+    horizontalScale?: number; /** Enable pair kerning for runs whose authored threshold is met. */
+    kerning?: boolean;
 };
 
 // @public

--- a/packages/core/src/layout-engine/measure/__tests__/fakeTextMeasure.ts
+++ b/packages/core/src/layout-engine/measure/__tests__/fakeTextMeasure.ts
@@ -3,7 +3,7 @@ import { installCanvasMeasureProvider, resetCanvasContext } from "../measureCont
 import { getMeasureProvider, setMeasureProvider } from "../measureProvider";
 
 /** Width contribution of a single character, given the active canvas font. */
-export type FakeCharWidth = (char: string, font: string) => number;
+export type FakeCharWidth = (char: string, font: string, fontKerning?: CanvasFontKerning) => number;
 
 /** Uppercase letters render wider than everything else. */
 export const uppercaseAwareCharWidth: FakeCharWidth = (char) =>
@@ -53,11 +53,12 @@ export function withFakeTextMeasure(
         getContext() {
           return {
             font: "",
-            measureText(this: { font: string }, text: string) {
+            fontKerning: "auto" as CanvasFontKerning,
+            measureText(this: { font: string; fontKerning: CanvasFontKerning }, text: string) {
               measureCount += 1;
               let width = 0;
               for (const char of text) {
-                width += charWidth(char, this.font);
+                width += charWidth(char, this.font, this.fontKerning);
               }
               return {
                 width,

--- a/packages/core/src/layout-engine/measure/font-metrics.worker.test.ts
+++ b/packages/core/src/layout-engine/measure/font-metrics.worker.test.ts
@@ -21,6 +21,7 @@ import {
 
 type CanvasStub = {
   font: string;
+  fontKerning: "normal" | "none";
   measureText: (text: string) => { width: number };
 };
 
@@ -31,8 +32,9 @@ class FakeOffscreenCanvas {
     }
     return {
       font: "",
-      measureText(text: string) {
-        return { width: text.length * 6 };
+      fontKerning: "none",
+      measureText(this: CanvasStub, text: string) {
+        return { width: text.length * 6 - (this.fontKerning === "normal" ? 1 : 0) };
       },
     };
   }
@@ -62,6 +64,7 @@ function entry(overrides: Partial<MeasureRequestEntry>): MeasureRequestEntry {
     fontFingerprintWidth: overrides.fontFingerprintWidth ?? WORKER_FONT_FINGERPRINT_TEXT.length * 6,
     letterSpacing: overrides.letterSpacing ?? 0,
     horizontalScale,
+    ...(overrides.fontKerning !== undefined ? { fontKerning: overrides.fontKerning } : {}),
   };
 }
 
@@ -86,6 +89,21 @@ describe("handleMeasureRequest", () => {
       expect(reply.entries[0]?.fontCacheKey).toBe("11px Arial|scale:1");
       expect(reply.entries[0]?.letterSpacing).toBe(0);
     }
+  });
+
+  test("applies the requested kerning mode", () => {
+    const reply = handleMeasureRequest(
+      req([
+        entry({
+          text: "AVAV",
+          fontCacheKey: "11px Arial|kerning:normal|scale:1",
+          fontFingerprintWidth: WORKER_FONT_FINGERPRINT_TEXT.length * 6 - 1,
+          fontKerning: "normal",
+        }),
+      ]),
+    );
+
+    expect(reply.ok && reply.entries[0]?.width).toBe("AVAV".length * 6 - 1);
   });
 
   test("applies letterSpacing for multi-char text", () => {

--- a/packages/core/src/layout-engine/measure/font-metrics.worker.ts
+++ b/packages/core/src/layout-engine/measure/font-metrics.worker.ts
@@ -32,6 +32,7 @@ class WorkerInitError extends TaggedError("WorkerInitError")<{
 
 type WorkerCanvasContext = {
   font: string;
+  fontKerning?: "normal" | "none";
   measureText: (text: string) => { width: number };
 };
 
@@ -73,6 +74,7 @@ function isFontFingerprintMatch(context: WorkerCanvasContext, expectedWidth: num
 function measureEntry(entry: MeasureRequestEntry): MeasureResponseEntry | null {
   const context = getCtx();
   context.font = entry.font;
+  context.fontKerning = entry.fontKerning ?? "none";
   if (!isFontFingerprintMatch(context, entry.fontFingerprintWidth)) {
     return null;
   }

--- a/packages/core/src/layout-engine/measure/measureContainer.ts
+++ b/packages/core/src/layout-engine/measure/measureContainer.ts
@@ -77,16 +77,22 @@ export function resetCanvasContext(): void {
   canvasContext = null;
 }
 
-function getWorkerFontFingerprintWidth(ctx: CanvasRenderingContext2D, font: string): number {
+function getWorkerFontFingerprintWidth(
+  ctx: CanvasRenderingContext2D,
+  font: string,
+  fontCacheKey: string,
+  fontKerning: CanvasFontKerning,
+): number {
   const generation = getTextWidthCacheGeneration();
-  const cached = workerFontFingerprintCache.get(font);
+  const cached = workerFontFingerprintCache.get(fontCacheKey);
   if (cached?.generation === generation) {
     return cached.width;
   }
 
   ctx.font = font;
+  ctx.fontKerning = fontKerning;
   const width = ctx.measureText(WORKER_FONT_FINGERPRINT_TEXT).width;
-  workerFontFingerprintCache.set(font, { generation, width });
+  workerFontFingerprintCache.set(fontCacheKey, { generation, width });
   return width;
 }
 
@@ -126,6 +132,7 @@ function canvasGetFontMetrics(style: FontStyle): FontMetrics {
   try {
     const ctx = getCanvasContext();
     ctx.font = buildFontString(style);
+    ctx.fontKerning = style.kerning ? "normal" : "none";
 
     // Measure a standard character to get metrics
     const metrics = ctx.measureText("Hg");
@@ -192,13 +199,17 @@ function canvasMeasureTextWidth(text: string, style: FontStyle): number {
   const font = buildFontString(style);
   const letterSpacing = style.letterSpacing ?? 0;
   const horizontalScale = getHorizontalScaleFactor(style);
-  const fontCacheKey = `${font}|scale:${horizontalScale}`;
+  const fontKerning: CanvasFontKerning = style.kerning ? "normal" : "none";
+  const fontCacheKey = style.kerning
+    ? `${font}|kerning:normal|scale:${horizontalScale}`
+    : `${font}|scale:${horizontalScale}`;
   const cached = getCachedTextWidth(measuredText, fontCacheKey, letterSpacing);
   if (cached !== undefined) {
     return cached;
   }
 
   ctx.font = font;
+  ctx.fontKerning = fontKerning;
 
   const metrics = ctx.measureText(measuredText);
 
@@ -221,7 +232,7 @@ function canvasMeasureTextWidth(text: string, style: FontStyle): number {
     return scaledWidth;
   }
 
-  const fontFingerprintWidth = getWorkerFontFingerprintWidth(ctx, font);
+  const fontFingerprintWidth = getWorkerFontFingerprintWidth(ctx, font, fontCacheKey, fontKerning);
   // Cache miss just cost a main-thread `measureText`. Ask the worker to
   // pre-warm:
   //   1) this exact entry (helps future re-layouts after font-ready,
@@ -240,6 +251,7 @@ function canvasMeasureTextWidth(text: string, style: FontStyle): number {
     horizontalScale,
     fontCacheKey,
     fontFingerprintWidth,
+    fontKerning,
   );
   prefetchBinarySearchProbes(
     measuredText,
@@ -248,6 +260,7 @@ function canvasMeasureTextWidth(text: string, style: FontStyle): number {
     fontFingerprintWidth,
     letterSpacing,
     horizontalScale,
+    fontKerning,
   );
   return scaledWidth;
 }
@@ -274,6 +287,9 @@ function glyphAdvanceStyle(style: FontStyle, fontFamily: string | undefined): Fo
   }
   if (style.fontVariant !== undefined) {
     result.fontVariant = style.fontVariant;
+  }
+  if (style.kerning !== undefined) {
+    result.kerning = style.kerning;
   }
   return result;
 }
@@ -324,6 +340,7 @@ function prefetchBinarySearchProbes(
   fontFingerprintWidth: number,
   letterSpacing: number,
   horizontalScale: number,
+  fontKerning: CanvasFontKerning,
 ): void {
   if (text.length < 4) {
     return;
@@ -342,6 +359,7 @@ function prefetchBinarySearchProbes(
       horizontalScale,
       fontCacheKey,
       fontFingerprintWidth,
+      fontKerning,
     );
   }
 }
@@ -382,6 +400,7 @@ function canvasMeasureRun(text: string, style: FontStyle): RunMeasurement {
   const ctx = getCanvasContext();
   const baseFont = buildFontString(style);
   ctx.font = baseFont;
+  ctx.fontKerning = style.kerning ? "normal" : "none";
   // CJK code points measure with the EA font (matching the painter); the rest
   // keep the base font. Only built when an EA font is present and the run has no
   // letter spacing (which the painter leaves to a single base-font span), so the

--- a/packages/core/src/layout-engine/measure/measureContainer.ts
+++ b/packages/core/src/layout-engine/measure/measureContainer.ts
@@ -81,7 +81,7 @@ function getWorkerFontFingerprintWidth(
   ctx: CanvasRenderingContext2D,
   font: string,
   fontCacheKey: string,
-  fontKerning: CanvasFontKerning,
+  fontKerning: "normal" | "none",
 ): number {
   const generation = getTextWidthCacheGeneration();
   const cached = workerFontFingerprintCache.get(fontCacheKey);
@@ -199,7 +199,7 @@ function canvasMeasureTextWidth(text: string, style: FontStyle): number {
   const font = buildFontString(style);
   const letterSpacing = style.letterSpacing ?? 0;
   const horizontalScale = getHorizontalScaleFactor(style);
-  const fontKerning: CanvasFontKerning = style.kerning ? "normal" : "none";
+  const fontKerning: "normal" | "none" = style.kerning ? "normal" : "none";
   const fontCacheKey = style.kerning
     ? `${font}|kerning:normal|scale:${horizontalScale}`
     : `${font}|scale:${horizontalScale}`;
@@ -340,7 +340,7 @@ function prefetchBinarySearchProbes(
   fontFingerprintWidth: number,
   letterSpacing: number,
   horizontalScale: number,
-  fontKerning: CanvasFontKerning,
+  fontKerning: "normal" | "none",
 ): void {
   if (text.length < 4) {
     return;

--- a/packages/core/src/layout-engine/measure/measureHelpers.ts
+++ b/packages/core/src/layout-engine/measure/measureHelpers.ts
@@ -34,16 +34,18 @@ export function buildRunFontStyle(
   fallbackFontFamily: string,
   fallbackFontSize: number,
 ): FontStyle {
+  const fontSize = run.fontSize ?? fallbackFontSize;
   return {
     fontFamily: run.fontFamily ?? fallbackFontFamily,
     ...(run.eastAsiaFontFamily !== undefined ? { eastAsiaFontFamily: run.eastAsiaFontFamily } : {}),
-    fontSize: run.fontSize ?? fallbackFontSize,
+    fontSize,
     ...(run.bold !== undefined ? { bold: run.bold } : {}),
     ...(run.italic !== undefined ? { italic: run.italic } : {}),
     ...(run.letterSpacing !== undefined ? { letterSpacing: run.letterSpacing } : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
     ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
     ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+    kerning: run.kerningMinPt !== undefined && fontSize >= run.kerningMinPt,
   };
 }
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -44,6 +44,42 @@ describe("text measurement cache", () => {
       expect(getMeasureCount()).toBe(2);
     }, fakeMeasure);
   });
+
+  test("keeps enabled kerning in the text width cache key", () => {
+    withFakeTextMeasure((getMeasureCount) => {
+      const text = "AVAV";
+      measureTextWidth(text, { fontFamily: "Arial", fontSize: 11, kerning: false });
+      measureTextWidth(text, { fontFamily: "Arial", fontSize: 11, kerning: true });
+
+      expect(getMeasureCount()).toBe(2);
+    }, fakeMeasure);
+  });
+});
+
+describe("run kerning threshold", () => {
+  test("disables pair kerning unless the authored threshold is met", () => {
+    withFakeTextMeasure(
+      () => {
+        const runs = [{ kind: "text" as const, text: "AVAV", fontSize: 11 }];
+        const charWidth = 4;
+        const availableWidth = runs[0]!.text.length * charWidth;
+        const base = { kind: "paragraph" as const, id: "kerning", runs };
+
+        expect(measureParagraph(base, availableWidth).lines).toHaveLength(2);
+        expect(
+          measureParagraph({ ...base, runs: [{ ...runs[0]!, kerningMinPt: 10 }] }, availableWidth)
+            .lines,
+        ).toHaveLength(1);
+        expect(
+          measureParagraph({ ...base, runs: [{ ...runs[0]!, kerningMinPt: 12 }] }, availableWidth)
+            .lines,
+        ).toHaveLength(2);
+      },
+      {
+        charWidth: (_char, _font, fontKerning) => (fontKerning === "normal" ? 4 : 5),
+      },
+    );
+  });
 });
 
 describe("font metrics cache", () => {

--- a/packages/core/src/layout-engine/measure/measureTypes.ts
+++ b/packages/core/src/layout-engine/measure/measureTypes.ts
@@ -26,6 +26,8 @@ export type FontStyle = {
   textTransform?: "uppercase";
   fontVariant?: "small-caps";
   horizontalScale?: number;
+  /** Enable pair kerning for runs whose authored threshold is met. */
+  kerning?: boolean;
 };
 
 /**

--- a/packages/core/src/layout-engine/measure/measureWorker.ts
+++ b/packages/core/src/layout-engine/measure/measureWorker.ts
@@ -322,6 +322,7 @@ export function prefetchMeasurement(
   horizontalScale: number,
   fontCacheKey: string,
   fontFingerprintWidth: number,
+  fontKerning: "normal" | "none" = "none",
 ): void {
   if (!isWorkerFontMetricsEnabled()) {
     return;
@@ -344,6 +345,7 @@ export function prefetchMeasurement(
     fontFingerprintWidth,
     letterSpacing,
     horizontalScale,
+    fontKerning,
     cacheGeneration: getTextWidthCacheGeneration(),
   });
   scheduleFlush(current);

--- a/packages/core/src/layout-engine/measure/measureWorkerProtocol.ts
+++ b/packages/core/src/layout-engine/measure/measureWorkerProtocol.ts
@@ -40,6 +40,7 @@ export type MeasureRequestEntry = {
   fontFingerprintWidth: number;
   letterSpacing: number;
   horizontalScale: number;
+  fontKerning?: "normal" | "none";
 };
 
 export const WORKER_FONT_FINGERPRINT_TEXT = "HAMBURGEFONTS ivwqy 0123456789";

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -60,6 +60,48 @@ function findTabEls(lineEl: FakeElement): FakeElement[] {
 }
 
 describe("renderLine box model", () => {
+  test("paints pair kerning only when the authored threshold is met", () => {
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 4,
+      width: 28,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+    const render = (kerningMinPt?: number) =>
+      renderLine(
+        {
+          kind: "paragraph",
+          id: "kerning",
+          runs: [
+            {
+              kind: "text",
+              text: "AVAV",
+              fontSize: 11,
+              ...(kerningMinPt !== undefined ? { kerningMinPt } : {}),
+            },
+          ],
+        },
+        line,
+        undefined,
+        fakeDocument,
+        {
+          availableWidth: 360,
+          isLastLine: true,
+          isFirstLine: true,
+          paragraphEndsWithLineBreak: false,
+          leftIndentPx: 0,
+        },
+      ) as unknown as FakeElement;
+
+    expect(render().children.at(0)?.style["fontKerning"]).toBe("none");
+    expect(render(12).children.at(0)?.style["fontKerning"]).toBe("none");
+    expect(render(10).children.at(0)?.style["fontKerning"]).toBe("normal");
+  });
+
   test("uses content-box and visible overflow so highlighted text is not clipped", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -246,12 +246,9 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     element.style.transform = `scaleX(${run.horizontalScale / 100})`;
     element.style.transformOrigin = "left center";
   }
-  if (run.kerningMinPt && run.kerningMinPt > 0) {
-    const fontSizePt = run.fontSize ?? 11;
-    if (fontSizePt >= run.kerningMinPt) {
-      element.style.fontKerning = "normal";
-    }
-  }
+  const fontSizePt = run.fontSize ?? 11;
+  element.style.fontKerning =
+    run.kerningMinPt !== undefined && fontSizePt >= run.kerningMinPt ? "normal" : "none";
   if (run.emboss) {
     element.style.textShadow = "1px 1px 1px rgba(255,255,255,0.5), -1px -1px 1px rgba(0,0,0,0.3)";
   }
@@ -1447,12 +1444,14 @@ function countShrinkableSpaces(runs: Run[]): number {
  * Build a TextMeasureStyle from a TextRun or FieldRun's relevant fields.
  */
 function runMeasureStyle(run: TextRun | FieldRun | MathRun): TextMeasureStyle {
+  const fontSize = run.fontSize ?? 11;
   return {
     ...(run.bold !== undefined ? { bold: run.bold } : {}),
     ...(run.italic !== undefined ? { italic: run.italic } : {}),
     ...(run.letterSpacing !== undefined ? { letterSpacing: run.letterSpacing } : {}),
     ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
     ...(run.eastAsiaFontFamily !== undefined ? { eastAsiaFontFamily: run.eastAsiaFontFamily } : {}),
+    kerning: run.kerningMinPt !== undefined && fontSize >= run.kerningMinPt,
   };
 }
 
@@ -1645,6 +1644,7 @@ type TextMeasureStyle = {
   /** EA font for CJK code points; segments the measured text by script when set
    * (and the run has no letter spacing), mirroring measureContainer. */
   eastAsiaFontFamily?: string;
+  kerning?: boolean;
 };
 
 function applyLetterSpacingToMeasuredWidth(
@@ -1669,6 +1669,7 @@ function createTextMeasurer(
     if (!ctx) {
       return applyLetterSpacingToMeasuredWidth(text.length * 7, text, style.letterSpacing);
     } // Fallback estimate
+    ctx.fontKerning = style.kerning ? "normal" : "none";
     // Use font resolver for category-appropriate fallback stacks,
     // matching measureContainer.ts
     const cssFallback = resolveFontFamily(fontFamily).cssFallback;


### PR DESCRIPTION
## Summary

- disable pair kerning by default during measurement and painting
- enable pair kerning only when the authored OOXML threshold is met
- keep main-thread, worker, cache-key, and painted-run behavior aligned

## Validation

- focused core tests: 142 passed
- anonymous layout parity score: 74.1% → 74.7%
- dependency audit: no vulnerabilities found
- lint and typecheck: delegated to CI

CC on behalf of @jan-kubica