### PR TITLE
feat: add Word-aware line breaking

### DIFF
--- a/.changeset/word-aware-line-breaks.md
+++ b/.changeset/word-aware-line-breaks.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": minor
+---
+
+Add replaceable Unicode line breaking with DOCX language, kinsoku, custom line-edge, and compatibility-rule support.

--- a/api-reports/core/layout-bridge-engine-measuring.api.md
+++ b/api-reports/core/layout-bridge-engine-measuring.api.md
@@ -30,6 +30,9 @@ export function clearParagraphMeasureCache(): void;
 // @public
 export function clearTextWidthCache(): void;
 
+// @public (undocumented)
+export const defaultLineBreakProvider: LineBreakProvider;
+
 // @public
 export function findCharacterAtX(x: number, charWidths: number[]): number;
 
@@ -127,6 +130,12 @@ export function getFontCacheSize(): number;
 // @public (undocumented)
 export const getFontMetrics: (style: FontStyle) => FontMetrics;
 
+// @public (undocumented)
+export const getLineBreakProvider: () => LineBreakProvider;
+
+// @public
+export const getLineBreakProviderGeneration: () => number;
+
 // @public
 export function getParagraphCacheSize(): number;
 
@@ -150,6 +159,21 @@ export function hashParagraphBlock(block: ParagraphBlock): string;
 
 // @public
 export function isWorkerFontMetricsEnabled(): boolean;
+
+// @public
+export type LineBreakPolicy = {
+    locale?: string; /** Apply East Asian first/last-character restrictions (`w:kinsoku`). */
+    kinsoku?: boolean; /** Document override: characters that may not begin a line. */
+    noLineBreaksBefore?: string; /** Document override: characters that may not end a line. */
+    noLineBreaksAfter?: string; /** Use the legacy Ethiopic/Amharic compatibility behavior. */
+    useLegacyEthiopicAmharicRules?: boolean;
+};
+
+// @public (undocumented)
+export type LineBreakProvider = {
+    findBreaks: (text: string, policy?: LineBreakPolicy) => number[]; /** Grapheme-safe emergency-wrap offsets, in ascending UTF-16 order. */
+    findGraphemeBreaks: (text: string, policy?: LineBreakPolicy) => number[];
+};
 
 // @public
 export function measureParagraph(block: ParagraphBlock, maxWidth: number, options?: MeasureParagraphOptions): ParagraphMeasure;
@@ -194,6 +218,9 @@ export function rectsToFloatingZones(rects: FloatingExclusionRect[], contentWidt
 // @public
 export function resetCanvasContext(): void;
 
+// @public (undocumented)
+export const resetLineBreakProvider: () => void;
+
 // @public
 export type RunMeasurement = {
     width: number;
@@ -215,6 +242,9 @@ export function setFolioMeasurementFlags(flags: FolioMeasurementFeatureFlags | u
 
 // @public
 export function setFontCacheSize(size: number): void;
+
+// @public (undocumented)
+export const setLineBreakProvider: (provider: LineBreakProvider) => void;
 
 // @public
 export function setParagraphCacheSize(size: number): void;

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -559,7 +559,20 @@ export type PaginatorOptions = {
 
 // @public
 export type ParagraphAttrs = {
-    alignment?: "left" | "center" | "right" | "justify"; /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
+    alignment?: "left" | "center" | "right" | "justify"; /** East Asian first/last-character restrictions (`w:kinsoku`). */
+    kinsoku?: boolean; /** Hanging punctuation (`w:overflowPunct`), retained for layout policy. */
+    overflowPunctuation?: boolean; /** Document-wide custom line-edge characters and compatibility behavior. */
+    lineBreakRules?: {
+        noLineBreaksBefore?: {
+            language?: string;
+            characters: string;
+        };
+        noLineBreaksAfter?: {
+            language?: string;
+            characters: string;
+        };
+        useLegacyEthiopicAmharicRules?: boolean;
+    }; /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
     outlineLevel?: number;
     spacing?: ParagraphSpacing; /** Spacing sides resolved from OOXML automatic paragraph spacing. */
     automaticSpacing?: {
@@ -684,7 +697,12 @@ export type RunFormatting = {
     highlight?: string;
     shading?: string;
     fontFamily?: string;
-    eastAsiaFontFamily?: string;
+    eastAsiaFontFamily?: string; /** Run language metadata resolved from `w:lang`. */
+    language?: {
+        val?: string;
+        eastAsia?: string;
+        bidi?: string;
+    };
     fontSize?: number;
     letterSpacing?: number;
     superscript?: boolean;

--- a/api-reports/core/prosemirror-attrs.api.md
+++ b/api-reports/core/prosemirror-attrs.api.md
@@ -50,6 +50,9 @@ export const expectHyperlinkMarkAttrs: (mark: Mark) => HyperlinkAttrs;
 export const expectImageAttrs: (node: Node_2) => ImageAttrs;
 
 // @public (undocumented)
+export const expectLanguageMarkAttrs: (mark: Mark) => LanguageAttrs;
+
+// @public (undocumented)
 export const expectMathAttrs: (node: Node_2) => MathAttrs;
 
 // @public (undocumented)
@@ -153,6 +156,9 @@ export const readHyperlinkMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<
 
 // @public (undocumented)
 export const readImageAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<ImageAttrs>;
+
+// @public (undocumented)
+export const readLanguageMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<LanguageAttrs>;
 
 // @public (undocumented)
 export const readMathAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<MathAttrs>;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -164,6 +164,13 @@ export type ImagePositionAttrs = {
     };
 };
 
+// @public (undocumented)
+export type LanguageAttrs = {
+    val?: string;
+    eastAsia?: string;
+    bidi?: string;
+};
+
 // @public
 export type MathAttrs = {
     display?: "inline" | "block"; /** Raw OMML XML for round-trip preservation */
@@ -175,7 +182,9 @@ export type MathAttrs = {
 export type ParagraphAttrs = {
     paraId?: string;
     textId?: string;
-    alignment?: import__stll_docx_core_model.ParagraphAlignment;
+    alignment?: import__stll_docx_core_model.ParagraphAlignment; /** Effective East Asian line-edge policy (`w:kinsoku`). */
+    kinsoku?: boolean; /** Effective hanging-punctuation policy (`w:overflowPunct`). */
+    overflowPunctuation?: boolean;
     spaceBefore?: number;
     spaceAfter?: number;
     lineSpacing?: number;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -284,7 +284,9 @@ export const PAINTABLE_MARK_NAMES: ReadonlySet<string>;
 export type ParagraphAttrs = {
     paraId?: string;
     textId?: string;
-    alignment?: import__stll_docx_core_model.ParagraphAlignment;
+    alignment?: import__stll_docx_core_model.ParagraphAlignment; /** Effective East Asian line-edge policy (`w:kinsoku`). */
+    kinsoku?: boolean; /** Effective hanging-punctuation policy (`w:overflowPunct`). */
+    overflowPunctuation?: boolean;
     spaceBefore?: number;
     spaceAfter?: number;
     lineSpacing?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -180,6 +180,17 @@ export type DocumentSettings = {
     themeFontLang?: {
         eastAsia?: string;
         bidi?: string;
+    }; /** Word/OOXML document-wide line-breaking overrides. */
+    lineBreakRules?: {
+        noLineBreaksBefore?: {
+            language?: string;
+            characters: string;
+        };
+        noLineBreaksAfter?: {
+            language?: string;
+            characters: string;
+        };
+        useLegacyEthiopicAmharicRules?: boolean;
     };
 };
 
@@ -637,7 +648,9 @@ export type ParagraphContent = Run | Hyperlink | BookmarkStart | BookmarkEnd | S
 // @public (undocumented)
 export type ParagraphFormatting = {
     alignment?: ParagraphAlignment; /** Text direction (w:bidi) */
-    bidi?: boolean; /** Spacing before in twips (w:spacing/@w:before) */
+    bidi?: boolean; /** Apply East Asian first/last-character line-breaking rules (w:kinsoku). */
+    kinsoku?: boolean; /** Allow punctuation to hang beyond the text margin (w:overflowPunct). */
+    overflowPunctuation?: boolean; /** Spacing before in twips (w:spacing/@w:before) */
     spaceBefore?: number; /** Spacing after in twips (w:spacing/@w:after) */
     spaceAfter?: number; /** Line spacing value (w:spacing/@w:line) */
     lineSpacing?: number; /** Line spacing rule (w:spacing/@w:lineRule) */
@@ -1240,6 +1253,11 @@ export type TextFormatting = {
         hAnsiTheme?: string;
         eastAsiaTheme?: string;
         csTheme?: string;
+    }; /** Run language metadata (`w:lang`) used by spelling and line breaking. */
+    language?: {
+        val?: string;
+        eastAsia?: string;
+        bidi?: string;
     }; /** Character spacing in twips (w:spacing) */
     spacing?: number; /** Raised/lowered text position in half-points (w:position) */
     position?: number; /** Horizontal text scale percentage (w:w) */

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -300,6 +300,9 @@ export function runLayoutPipeline<THfPMs>(
     if (defaultTabStop !== undefined) {
       flowOpts.defaultTabStopTwips = defaultTabStop;
     }
+    if (document?.package.settings?.lineBreakRules) {
+      flowOpts.lineBreakRules = document.package.settings.lineBreakRules;
+    }
     let newBlocks = toFlowBlocks(state.doc, flowOpts);
     // Template fill preview: substitute each matched {{marker}} range
     // with its typed value at the flow-block level so the pages lay out

--- a/packages/core/src/docx/__tests__/runFormatting-rtl-effect.test.ts
+++ b/packages/core/src/docx/__tests__/runFormatting-rtl-effect.test.ts
@@ -63,6 +63,27 @@ describe("w:rtl run direction round-trip (eigenpal #424 gap 10)", () => {
   });
 });
 
+describe("w:lang run language round-trip", () => {
+  test("preserves primary, East Asian, and bidi language tags", () => {
+    const { formatting, serialized } = roundTrip(
+      '<w:lang w:val="en-GB" w:eastAsia="ja-JP" w:bidi="ar-SA"/>',
+    );
+
+    expect(formatting?.language).toEqual({
+      val: "en-GB",
+      eastAsia: "ja-JP",
+      bidi: "ar-SA",
+    });
+    expect(serialized).toContain('<w:lang w:val="en-GB" w:eastAsia="ja-JP" w:bidi="ar-SA"/>');
+  });
+
+  test("omits an empty language element", () => {
+    const { formatting, serialized } = roundTrip("<w:lang/>");
+    expect(formatting?.language).toBeUndefined();
+    expect(serialized).not.toContain("<w:lang");
+  });
+});
+
 describe("w:effect text animation round-trip (eigenpal #424 gap 11)", () => {
   // Upstream eigenpal #424 enumerates six active animations plus the explicit
   // "none" sentinel; mirror that union verbatim so host CSS keys (and class

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -371,8 +371,10 @@ type ParagraphPropertyChildren = {
   jc?: XmlElement;
   keepLines?: XmlElement;
   keepNext?: XmlElement;
+  kinsoku?: XmlElement;
   numPr?: XmlElement;
   outlineLvl?: XmlElement;
+  overflowPunct?: XmlElement;
   pageBreakBefore?: XmlElement;
   pBdr?: XmlElement;
   pStyle?: XmlElement;
@@ -415,11 +417,17 @@ function collectFirstParagraphPropertyChildren(pPr: XmlElement): ParagraphProper
       case "keepNext":
         children.keepNext ??= child;
         break;
+      case "kinsoku":
+        children.kinsoku ??= child;
+        break;
       case "numPr":
         children.numPr ??= child;
         break;
       case "outlineLvl":
         children.outlineLvl ??= child;
+        break;
+      case "overflowPunct":
+        children.overflowPunct ??= child;
         break;
       case "pageBreakBefore":
         children.pageBreakBefore ??= child;
@@ -486,6 +494,16 @@ export function parseParagraphProperties(
 
   const formatting: ParagraphFormatting = {};
   const propertyChildren = collectFirstParagraphPropertyChildren(pPr);
+
+  const kinsoku = propertyChildren.kinsoku;
+  if (kinsoku) {
+    formatting.kinsoku = parseBooleanElement(kinsoku);
+  }
+
+  const overflowPunct = propertyChildren.overflowPunct;
+  if (overflowPunct) {
+    formatting.overflowPunctuation = parseBooleanElement(overflowPunct);
+  }
 
   // === Alignment ===
   const jc = propertyChildren.jc;

--- a/packages/core/src/docx/runConsolidator.ts
+++ b/packages/core/src/docx/runConsolidator.ts
@@ -152,13 +152,7 @@ export function formattingEquals(
 }
 
 function languageEquals(a: TextFormatting["language"], b: TextFormatting["language"]): boolean {
-  if (!a && !b) {
-    return true;
-  }
-  if (!a || !b) {
-    return false;
-  }
-  return a.val === b.val && a.eastAsia === b.eastAsia && a.bidi === b.bidi;
+  return a?.val === b?.val && a?.eastAsia === b?.eastAsia && a?.bidi === b?.bidi;
 }
 
 /**

--- a/packages/core/src/docx/runConsolidator.ts
+++ b/packages/core/src/docx/runConsolidator.ts
@@ -144,8 +144,21 @@ export function formattingEquals(
   if (!fontFamilyEquals(a.fontFamily, b.fontFamily)) {
     return false;
   }
+  if (!languageEquals(a.language, b.language)) {
+    return false;
+  }
 
   return true;
+}
+
+function languageEquals(a: TextFormatting["language"], b: TextFormatting["language"]): boolean {
+  if (!a && !b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return a.val === b.val && a.eastAsia === b.eastAsia && a.bidi === b.bidi;
 }
 
 /**

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -167,6 +167,7 @@ type RunPropertyChildren = {
   iCs?: XmlElement;
   imprint?: XmlElement;
   kern?: XmlElement;
+  lang?: XmlElement;
   outline?: XmlElement;
   position?: XmlElement;
   rFonts?: XmlElement;
@@ -235,6 +236,9 @@ function collectFirstRunPropertyChildren(rPr: XmlElement): RunPropertyChildren {
         break;
       case "kern":
         children.kern ??= child;
+        break;
+      case "lang":
+        children.lang ??= child;
         break;
       case "outline":
         children.outline ??= child;
@@ -515,6 +519,20 @@ export function parseRunProperties(
     }
 
     formatting.fontFamily = fontFamily;
+  }
+
+  const lang = propertyChildren.lang;
+  if (lang) {
+    const val = getAttribute(lang, "w", "val") || undefined;
+    const eastAsia = getAttribute(lang, "w", "eastAsia") || undefined;
+    const bidi = getAttribute(lang, "w", "bidi") || undefined;
+    if (val || eastAsia || bidi) {
+      formatting.language = {
+        ...(val ? { val } : {}),
+        ...(eastAsia ? { eastAsia } : {}),
+        ...(bidi ? { bidi } : {}),
+      };
+    }
   }
 
   // Character spacing in twips (w:spacing)

--- a/packages/core/src/docx/serializer/paragraphSerializer-toggleOverrides.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer-toggleOverrides.test.ts
@@ -24,6 +24,8 @@ const BOOLEAN_TOGGLES = [
   "pageBreakBefore",
   "suppressLineNumbers",
   "suppressAutoHyphens",
+  "kinsoku",
+  "overflowPunctuation",
   "bidi",
 ] as const satisfies readonly (keyof ParagraphFormatting)[];
 
@@ -36,6 +38,8 @@ const TAG: Record<BooleanToggle, string> = {
   pageBreakBefore: "w:pageBreakBefore",
   suppressLineNumbers: "w:suppressLineNumbers",
   suppressAutoHyphens: "w:suppressAutoHyphens",
+  kinsoku: "w:kinsoku",
+  overflowPunctuation: "w:overflowPunct",
   bidi: "w:bidi",
 };
 
@@ -85,6 +89,8 @@ describe("serializeParagraph — explicit-false paragraph toggles (eigenpal #687
           <w:pageBreakBefore w:val="0"/>
           <w:suppressLineNumbers w:val="0"/>
           <w:suppressAutoHyphens w:val="0"/>
+          <w:kinsoku w:val="0"/>
+          <w:overflowPunct w:val="0"/>
           <w:bidi w:val="0"/>
           <w:contextualSpacing w:val="0"/>
         </w:pPr>

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -456,6 +456,8 @@ export function serializeParagraphFormatting(
     // Suppress line numbers / auto hyphens
     pushToggle("suppressLineNumbers", formatting.suppressLineNumbers);
     pushToggle("suppressAutoHyphens", formatting.suppressAutoHyphens);
+    pushToggle("kinsoku", formatting.kinsoku);
+    pushToggle("overflowPunct", formatting.overflowPunctuation);
 
     // Spacing
     const spacingXml = serializeSpacing(formatting);

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -220,6 +220,22 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     }
   }
 
+  if (formatting.language) {
+    const languageAttrs: string[] = [];
+    if (formatting.language.val) {
+      languageAttrs.push(`w:val="${escapeXml(formatting.language.val)}"`);
+    }
+    if (formatting.language.eastAsia) {
+      languageAttrs.push(`w:eastAsia="${escapeXml(formatting.language.eastAsia)}"`);
+    }
+    if (formatting.language.bidi) {
+      languageAttrs.push(`w:bidi="${escapeXml(formatting.language.bidi)}"`);
+    }
+    if (languageAttrs.length > 0) {
+      parts.push(`<w:lang ${languageAttrs.join(" ")}/>`);
+    }
+  }
+
   // Bold
   if (formatting.bold === true) {
     parts.push("<w:b/>");

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -94,3 +94,36 @@ describe("parseSettings — w:themeFontLang (§17.15.1.88)", () => {
     expect(parseSettings(null).themeFontLang).toBeUndefined();
   });
 });
+
+describe("parseSettings — document line-breaking rules", () => {
+  test("reads language-scoped prohibited line-start and line-end characters", () => {
+    const settings = parseSettings(
+      wrap(`
+        <w:noLineBreaksBefore w:lang="ja-JP" w:val="、。"/>
+        <w:noLineBreaksAfter w:lang="ja-JP" w:val="（［"/>
+      `),
+    );
+
+    expect(settings.lineBreakRules).toEqual({
+      noLineBreaksBefore: { language: "ja-JP", characters: "、。" },
+      noLineBreaksAfter: { language: "ja-JP", characters: "（［" },
+    });
+  });
+
+  test("reads the legacy Ethiopic and Amharic breaking compatibility flag", () => {
+    expect(
+      parseSettings(wrap(`<w:compat><w:applyBreakingRules/></w:compat>`)).lineBreakRules,
+    ).toEqual({ useLegacyEthiopicAmharicRules: true });
+  });
+
+  test("ignores disabled and incomplete line-breaking controls", () => {
+    expect(
+      parseSettings(
+        wrap(`
+          <w:noLineBreaksBefore w:lang="ja-JP"/>
+          <w:compat><w:applyBreakingRules w:val="0"/></w:compat>
+        `),
+      ).lineBreakRules,
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -3,9 +3,8 @@
  *
  * Extracts document-wide settings the layout pipeline consumes at render
  * time. We deliberately read only the handful of settings that affect
- * layout; the rest of settings.xml (compatibility flags, view state,
- * autoformat options) is preserved opaquely by the rezip step and ignored
- * here.
+ * layout, including the line-breaking compatibility controls Folio supports;
+ * the rest of settings.xml is preserved opaquely by the rezip step.
  *
  * See ECMA-376 §17.15 for the full settings part.
  */
@@ -62,7 +61,40 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
     };
   }
 
+  const noLineBreaksBefore = parseKinsokuOverride(root, "noLineBreaksBefore");
+  const noLineBreaksAfter = parseKinsokuOverride(root, "noLineBreaksAfter");
+  const compat = root ? findChild(root, "w", "compat") : null;
+  const applyBreakingRules = compat ? findChild(compat, "w", "applyBreakingRules") : null;
+  const useLegacyEthiopicAmharicRules =
+    applyBreakingRules !== null && parseBooleanElement(applyBreakingRules);
+  if (noLineBreaksBefore || noLineBreaksAfter || useLegacyEthiopicAmharicRules) {
+    settings.lineBreakRules = {
+      ...(noLineBreaksBefore ? { noLineBreaksBefore } : {}),
+      ...(noLineBreaksAfter ? { noLineBreaksAfter } : {}),
+      ...(useLegacyEthiopicAmharicRules ? { useLegacyEthiopicAmharicRules: true } : {}),
+    };
+  }
+
   return settings;
+}
+
+function parseKinsokuOverride(
+  root: XmlElement | null,
+  name: "noLineBreaksBefore" | "noLineBreaksAfter",
+): { language?: string; characters: string } | undefined {
+  if (!root) {
+    return undefined;
+  }
+  const element = findChild(root, "w", name);
+  const characters = element ? getAttribute(element, "w", "val") : null;
+  if (!characters) {
+    return undefined;
+  }
+  const language = getAttribute(element, "w", "lang") || undefined;
+  return {
+    characters,
+    ...(language ? { language } : {}),
+  };
 }
 
 function parseDefaultTabStop(root: XmlElement | null): number {

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -768,6 +768,16 @@ function parseParagraphProperties(
     formatting.suppressAutoHyphens = parseBooleanElement(suppressAutoHyphens);
   }
 
+  const kinsoku = findChild(pPr, "w", "kinsoku");
+  if (kinsoku) {
+    formatting.kinsoku = parseBooleanElement(kinsoku);
+  }
+
+  const overflowPunct = findChild(pPr, "w", "overflowPunct");
+  if (overflowPunct) {
+    formatting.overflowPunctuation = parseBooleanElement(overflowPunct);
+  }
+
   // Run properties for this paragraph (default run formatting)
   const rPr = findChild(pPr, "w", "rPr");
   if (rPr) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
@@ -48,6 +48,13 @@ const schema = new Schema({
       attrs: { color: {} },
     },
     rtl: {},
+    language: {
+      attrs: {
+        val: { default: null },
+        eastAsia: { default: null },
+        bidi: { default: null },
+      },
+    },
     textEffect: {
       attrs: { effect: {} },
     },
@@ -171,6 +178,23 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     // ProseMirror round-trip but mixed RTL runs would still paint LTR.
     const blocks = toFlowBlocks(buildSingleRunDoc("שלום", "rtl"), {});
     expect(firstRun(blocks).rtl).toBe(true);
+  });
+
+  test("propagates Word language metadata to line layout", () => {
+    const blocks = toFlowBlocks(
+      buildSingleRunDoc("日本語", "language", {
+        val: "en-GB",
+        eastAsia: "ja-JP",
+        bidi: "ar-SA",
+      }),
+      {},
+    );
+
+    expect(firstRun(blocks).language).toEqual({
+      val: "en-GB",
+      eastAsia: "ja-JP",
+      bidi: "ar-SA",
+    });
   });
 
   test("propagates textEffect mark to run formatting", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -44,6 +44,7 @@ import {
   expectEmphasisMarkAttrs,
   expectFieldAttrs,
   expectFontFamilyMarkAttrs,
+  expectLanguageMarkAttrs,
   expectFontSizeMarkAttrs,
   expectFootnoteRefMarkAttrs,
   expectHardBreakAttrs,
@@ -128,6 +129,12 @@ export type ToFlowBlocksOptions = {
    * Defaults to the OOXML 720-twip value when absent.
    */
   defaultTabStopTwips?: number;
+  /** Document-wide custom Word line-breaking settings. */
+  lineBreakRules?: {
+    noLineBreaksBefore?: { language?: string; characters: string };
+    noLineBreaksAfter?: { language?: string; characters: string };
+    useLegacyEthiopicAmharicRules?: boolean;
+  };
 };
 
 const DEFAULT_FONT = "Calibri";
@@ -509,6 +516,16 @@ function extractRunFormatting(marks: readonly Mark[], theme?: Theme | null): Run
         break;
       }
 
+      case "language": {
+        const attrs = expectLanguageMarkAttrs(mark);
+        formatting.language = {
+          ...(attrs.val ? { val: attrs.val } : {}),
+          ...(attrs.eastAsia ? { eastAsia: attrs.eastAsia } : {}),
+          ...(attrs.bidi ? { bidi: attrs.bidi } : {}),
+        };
+        break;
+      }
+
       case "characterSpacing": {
         const attrs = expectCharacterSpacingMarkAttrs(mark);
         if (attrs.spacing !== undefined) {
@@ -746,6 +763,9 @@ function paragraphRunDefaults(pmAttrs: PMParagraphAttrs, theme?: Theme | null): 
   // run's own fontFamily mark overrides this via mergeRunFormatting.
   if (defaultTextFormatting.fontFamily?.eastAsia) {
     result.eastAsiaFontFamily = defaultTextFormatting.fontFamily.eastAsia;
+  }
+  if (defaultTextFormatting.language) {
+    result.language = { ...defaultTextFormatting.language };
   }
   if (defaultTextFormatting.fontSize !== undefined) {
     result.fontSize = defaultTextFormatting.fontSize / 2;
@@ -1603,6 +1623,12 @@ function convertParagraphAttrs(
   if (pmAttrs.pageBreakBefore) {
     attrs.pageBreakBefore = true;
   }
+  if (pmAttrs.kinsoku !== undefined && pmAttrs.kinsoku !== null) {
+    attrs.kinsoku = pmAttrs.kinsoku;
+  }
+  if (pmAttrs.overflowPunctuation !== undefined && pmAttrs.overflowPunctuation !== null) {
+    attrs.overflowPunctuation = pmAttrs.overflowPunctuation;
+  }
   if (pmAttrs.renderedPageBreakBefore) {
     attrs.renderedPageBreakBefore = true;
   }
@@ -1762,7 +1788,6 @@ function convertParagraphAttrs(
   if (defaultTabStopTwips !== undefined) {
     attrs.defaultTabStopTwips = defaultTabStopTwips;
   }
-
   // Default font for empty paragraph measurement (from style's rPr / pPr/rPr)
   const dtf = pmAttrs.defaultTextFormatting as
     | { fontSize?: number; fontFamily?: { ascii?: string; hAnsi?: string } }
@@ -1830,6 +1855,9 @@ function convertParagraph(
     options.originalListAbstractCounters,
     options.originalListSeenNumIds,
   );
+  if (options.lineBreakRules) {
+    attrs.lineBreakRules = options.lineBreakRules;
+  }
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
   if (runs.length === 0) {
     const hasDirectParagraphFormatting =

--- a/packages/core/src/layout-bridge/engine/measuring/index.ts
+++ b/packages/core/src/layout-bridge/engine/measuring/index.ts
@@ -43,6 +43,16 @@ export type {
 } from "../../../layout-engine/measure/measureTypes";
 
 export {
+  defaultLineBreakProvider,
+  getLineBreakProvider,
+  getLineBreakProviderGeneration,
+  setLineBreakProvider,
+  resetLineBreakProvider,
+  type LineBreakPolicy,
+  type LineBreakProvider,
+} from "../../../layout-engine/measure/lineBreakProvider";
+
+export {
   measureParagraph,
   measureParagraphs,
   getRunCharWidths,

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ParagraphBlock, ParagraphMeasure } from "../types";
+import { getLineBreakProviderGeneration } from "./lineBreakProvider";
 
 // =============================================================================
 // TEXT WIDTH CACHE
@@ -281,12 +282,12 @@ const paragraphMeasureCache = new Map<string, ParagraphMeasureEntry>();
  */
 export function hashParagraphBlock(block: ParagraphBlock): string {
   // Simple hash based on runs content
-  const parts: string[] = [];
+  const parts: string[] = [`lbp:${getLineBreakProviderGeneration()}`];
 
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.eastAsiaFontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}`,
+        `t:${run.text}|${run.fontFamily}|${run.eastAsiaFontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}|${run.language?.val}|${run.language?.eastAsia}|${run.language?.bidi}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);
@@ -331,6 +332,18 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     }
     if (attrs.reserveEmptyOutlineHeight) {
       parts.push("outline-empty-reserve");
+    }
+    if (attrs.kinsoku !== undefined) {
+      parts.push(`kinsoku:${attrs.kinsoku}`);
+    }
+    if (attrs.overflowPunctuation !== undefined) {
+      parts.push(`overflow-punct:${attrs.overflowPunctuation}`);
+    }
+    const lineBreakRules = attrs.lineBreakRules;
+    if (lineBreakRules) {
+      parts.push(
+        `line-break-rules:${lineBreakRules.noLineBreaksBefore?.language}|${lineBreakRules.noLineBreaksBefore?.characters}|${lineBreakRules.noLineBreaksAfter?.language}|${lineBreakRules.noLineBreaksAfter?.characters}|${lineBreakRules.useLegacyEthiopicAmharicRules}`,
+      );
     }
     const borders = attrs.borders;
     if (borders) {

--- a/packages/core/src/layout-engine/measure/index.ts
+++ b/packages/core/src/layout-engine/measure/index.ts
@@ -34,6 +34,16 @@ export {
 export type { FontStyle, FontMetrics, TextMeasurement, RunMeasurement } from "./measureTypes";
 
 export {
+  defaultLineBreakProvider,
+  getLineBreakProvider,
+  getLineBreakProviderGeneration,
+  setLineBreakProvider,
+  resetLineBreakProvider,
+  type LineBreakPolicy,
+  type LineBreakProvider,
+} from "./lineBreakProvider";
+
+export {
   measureParagraph,
   measureParagraphs,
   getRunCharWidths,

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -1,0 +1,281 @@
+/**
+ * Replaceable line-break policy for the layout engine.
+ *
+ * Providers return UTF-16 offsets so their output composes directly with the
+ * run and ProseMirror positions used by the rest of the layout pipeline. The
+ * default provider uses the platform's Unicode segmenter, then applies the
+ * Word/OOXML line-edge restrictions that are available in the flow model.
+ */
+
+export type LineBreakPolicy = {
+  /** BCP-47 language tag resolved from `w:lang` for this run. */
+  locale?: string;
+  /** Apply East Asian first/last-character restrictions (`w:kinsoku`). */
+  kinsoku?: boolean;
+  /** Document override: characters that may not begin a line. */
+  noLineBreaksBefore?: string;
+  /** Document override: characters that may not end a line. */
+  noLineBreaksAfter?: string;
+  /** Use the legacy Ethiopic/Amharic compatibility behavior. */
+  useLegacyEthiopicAmharicRules?: boolean;
+};
+
+export type LineBreakProvider = {
+  /** Legal soft-wrap offsets, in ascending UTF-16 order. */
+  findBreaks: (text: string, policy?: LineBreakPolicy) => number[];
+  /** Grapheme-safe emergency-wrap offsets, in ascending UTF-16 order. */
+  findGraphemeBreaks: (text: string, policy?: LineBreakPolicy) => number[];
+};
+
+const SEGMENTER_CACHE_LIMIT = 16;
+const DEFAULT_SEGMENTER_KEY = "";
+
+const wordSegmenters = new Map<string, Intl.Segmenter>();
+const graphemeSegmenters = new Map<string, Intl.Segmenter>();
+
+const segmenterLocale = (locale?: string): string | undefined => {
+  const language = locale?.trim().replaceAll("_", "-").split("-").at(0);
+  return language && /^[a-z]{2,3}$/iu.test(language) ? language.toLowerCase() : undefined;
+};
+
+const DICTIONARY_BREAK_SCRIPT =
+  /[\p{Script=Thai}\p{Script=Lao}\p{Script=Khmer}\p{Script=Myanmar}]/u;
+const CJK_SCRIPT = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+const BREAK_AFTER_CHARACTER = new Set([
+  "-",
+  "\u058A", // Armenian hyphen
+  "\u05BE", // Hebrew maqaf
+  "\u1400", // Canadian syllabics hyphen
+  "\u1806", // Mongolian todo soft hyphen
+  "\u2010", // hyphen
+  "\u2E17", // double oblique hyphen
+  "\u2E40", // double hyphen
+  "\u30A0", // katakana-hiragana double hyphen
+  "\uFE63", // small hyphen-minus
+  "\uFF0D", // fullwidth hyphen-minus
+  "\u200B", // zero-width space
+  "\u00AD", // soft hyphen
+]);
+
+// ECMA-376 kinsoku defaults are language-specific and can be overridden by
+// settings.xml. This conservative common set covers the punctuation Word does
+// not place at a line edge across Japanese and Chinese documents; document
+// overrides are layered on top below.
+const DEFAULT_PROHIBITED_LINE_START = new Set([
+  "!",
+  "%",
+  ")",
+  ",",
+  ".",
+  ":",
+  ";",
+  "?",
+  "]",
+  "}",
+  "、",
+  "。",
+  "〉",
+  "》",
+  "」",
+  "』",
+  "】",
+  "〕",
+  "）",
+  "］",
+  "｝",
+  "，",
+  "．",
+  "：",
+  "；",
+  "！",
+  "？",
+  "…",
+  "’",
+  "”",
+]);
+
+const DEFAULT_PROHIBITED_LINE_END = new Set([
+  "$",
+  "(",
+  "[",
+  "{",
+  "£",
+  "¥",
+  "〈",
+  "《",
+  "「",
+  "『",
+  "【",
+  "〔",
+  "（",
+  "［",
+  "｛",
+  "‘",
+  "“",
+]);
+
+const getSegmenter = (
+  cache: Map<string, Intl.Segmenter>,
+  granularity: "word" | "grapheme",
+  locale?: string,
+): Intl.Segmenter => {
+  const normalizedLocale = segmenterLocale(locale);
+  const key = normalizedLocale ?? DEFAULT_SEGMENTER_KEY;
+  const cached = cache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const segmenter = new Intl.Segmenter(normalizedLocale, { granularity });
+  if (cache.size >= SEGMENTER_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (typeof oldestKey === "string") {
+      cache.delete(oldestKey);
+    }
+  }
+  cache.set(key, segmenter);
+  return segmenter;
+};
+
+const firstCodePoint = (text: string, index: number): string | undefined => {
+  if (index >= text.length) {
+    return undefined;
+  }
+  return String.fromCodePoint(text.codePointAt(index) ?? 0);
+};
+
+const previousCodePoint = (text: string, index: number): string | undefined => {
+  if (index <= 0) {
+    return undefined;
+  }
+  const trailing = text.charCodeAt(index - 1);
+  if (trailing >= 0xdc00 && trailing <= 0xdfff && index >= 2) {
+    return text.slice(index - 2, index);
+  }
+  return text[index - 1];
+};
+
+const isProhibitedLineStart = (character: string | undefined, policy?: LineBreakPolicy): boolean =>
+  character !== undefined &&
+  (policy?.noLineBreaksBefore?.includes(character) === true ||
+    (policy?.kinsoku !== false && DEFAULT_PROHIBITED_LINE_START.has(character)));
+
+const isProhibitedLineEnd = (character: string | undefined, policy?: LineBreakPolicy): boolean =>
+  character !== undefined &&
+  (policy?.noLineBreaksAfter?.includes(character) === true ||
+    (policy?.kinsoku !== false && DEFAULT_PROHIBITED_LINE_END.has(character)));
+
+const isLegacyEthiopicBreakCharacter = (
+  character: string | undefined,
+  policy?: LineBreakPolicy,
+): boolean => {
+  if (!policy?.useLegacyEthiopicAmharicRules || character === undefined) {
+    return false;
+  }
+  const codePoint = character.codePointAt(0);
+  return codePoint !== undefined && codePoint >= 0x1361 && codePoint <= 0x1368;
+};
+
+const allowsBreak = (text: string, index: number, policy?: LineBreakPolicy): boolean => {
+  const previous = previousCodePoint(text, index);
+  const next = firstCodePoint(text, index);
+  return !isProhibitedLineEnd(previous, policy) && !isProhibitedLineStart(next, policy);
+};
+
+const pushBreak = (
+  breaks: number[],
+  text: string,
+  index: number,
+  policy?: LineBreakPolicy,
+): void => {
+  if (index <= 0 || index > text.length || breaks.at(-1) === index) {
+    return;
+  }
+  if (allowsBreak(text, index, policy)) {
+    breaks.push(index);
+  }
+};
+
+const findUnicodeGraphemeBreaks = (text: string, policy?: LineBreakPolicy): number[] => {
+  const breaks: number[] = [];
+  for (const segment of getSegmenter(graphemeSegmenters, "grapheme", policy?.locale).segment(
+    text,
+  )) {
+    const end = segment.index + segment.segment.length;
+    breaks.push(end);
+  }
+  return breaks;
+};
+
+const findUnicodeBreaks = (text: string, policy?: LineBreakPolicy): number[] => {
+  if (text.length === 0) {
+    return [];
+  }
+
+  const breaks: number[] = [];
+  const graphemeBreaks = findUnicodeGraphemeBreaks(text, policy);
+  for (const index of graphemeBreaks) {
+    const previous = previousCodePoint(text, index);
+    if (
+      previous !== undefined &&
+      (/\s/u.test(previous) ||
+        BREAK_AFTER_CHARACTER.has(previous) ||
+        isLegacyEthiopicBreakCharacter(previous, policy))
+    ) {
+      pushBreak(breaks, text, index, policy);
+    }
+  }
+
+  const wordSegments = [...getSegmenter(wordSegmenters, "word", policy?.locale).segment(text)];
+
+  for (const [segmentIndex, segment] of wordSegments.entries()) {
+    const end = segment.index + segment.segment.length;
+    const nextSegment = wordSegments[segmentIndex + 1];
+
+    if (
+      segment.isWordLike &&
+      nextSegment?.isWordLike === true &&
+      DICTIONARY_BREAK_SCRIPT.test(segment.segment + nextSegment.segment)
+    ) {
+      pushBreak(breaks, text, end, policy);
+    }
+  }
+
+  if (CJK_SCRIPT.test(text)) {
+    for (const index of graphemeBreaks) {
+      const previous = previousCodePoint(text, index);
+      const next = firstCodePoint(text, index);
+      if (
+        (previous !== undefined && CJK_SCRIPT.test(previous)) ||
+        (isProhibitedLineStart(previous, policy) && next !== undefined && CJK_SCRIPT.test(next))
+      ) {
+        pushBreak(breaks, text, index, policy);
+      }
+    }
+  }
+
+  return [...new Set(breaks)].sort((left, right) => left - right);
+};
+
+export const defaultLineBreakProvider: LineBreakProvider = {
+  findBreaks: findUnicodeBreaks,
+  findGraphemeBreaks: findUnicodeGraphemeBreaks,
+};
+
+let activeLineBreakProvider = defaultLineBreakProvider;
+let lineBreakProviderGeneration = 0;
+
+export const getLineBreakProvider = (): LineBreakProvider => activeLineBreakProvider;
+
+/** Changes whenever the active provider changes, so layout caches cannot go stale. */
+export const getLineBreakProviderGeneration = (): number => lineBreakProviderGeneration;
+
+export const setLineBreakProvider = (provider: LineBreakProvider): void => {
+  activeLineBreakProvider = provider;
+  lineBreakProviderGeneration += 1;
+};
+
+export const resetLineBreakProvider = (): void => {
+  activeLineBreakProvider = defaultLineBreakProvider;
+  lineBreakProviderGeneration += 1;
+};

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { findWordBreaks, isBreakChar } from "./lineBreaks";
+import {
+  getLineBreakProvider,
+  resetLineBreakProvider,
+  setLineBreakProvider,
+} from "./lineBreakProvider";
+import { findGraphemeBreaks, findWordBreaks, isBreakChar } from "./lineBreaks";
 
 describe("findWordBreaks", () => {
   test("breaks after spaces and hyphens in Latin text", () => {
     expect(findWordBreaks("hello world")).toEqual([6]);
     expect(findWordBreaks("well-known")).toEqual([5]);
+    expect(findWordBreaks("a  b")).toEqual([2, 3]);
+    expect(findWordBreaks("hy\u00ADphen")).toEqual([3]);
   });
 
   test("adds a break after every CJK code point", () => {
@@ -17,6 +24,51 @@ describe("findWordBreaks", () => {
     const text = "𠀀文";
     const breaks = findWordBreaks(text);
     expect(breaks).toEqual([2, 3]);
+  });
+
+  test("uses dictionary boundaries for scripts without spaces", () => {
+    expect(findWordBreaks("ภาษาไทยภาษาไทย", { locale: "th" })).toEqual([4, 7, 11]);
+  });
+
+  test("falls back safely for malformed DOCX language tags", () => {
+    expect(() => findWordBreaks("hello world", { locale: "not_a_locale" })).not.toThrow();
+  });
+
+  test("keeps prohibited CJK punctuation off the next line", () => {
+    expect(findWordBreaks("中文。测试", { locale: "zh-CN" })).toEqual([1, 3, 4, 5]);
+  });
+
+  test("applies document-specific kinsoku overrides", () => {
+    expect(findWordBreaks("中文測", { noLineBreaksBefore: "測" })).toEqual([1, 3]);
+  });
+
+  test("applies Word's legacy Ethiopic and Amharic break opportunities", () => {
+    const text = "ሀ፡ለ";
+    expect(findWordBreaks(text)).toEqual([]);
+    expect(findWordBreaks(text, { useLegacyEthiopicAmharicRules: true })).toEqual([2]);
+  });
+});
+
+describe("findGraphemeBreaks", () => {
+  test("never splits an emoji ZWJ sequence or combining character", () => {
+    expect(findGraphemeBreaks("👨‍👩‍👧‍👦x")).toEqual([11, 12]);
+    expect(findGraphemeBreaks("e\u0301x")).toEqual([2, 3]);
+  });
+});
+
+describe("line-break provider", () => {
+  test("is replaceable and resettable", () => {
+    const original = getLineBreakProvider();
+    try {
+      setLineBreakProvider({
+        findBreaks: () => [1],
+        findGraphemeBreaks: () => [1],
+      });
+      expect(findWordBreaks("abc")).toEqual([1]);
+    } finally {
+      resetLineBreakProvider();
+    }
+    expect(getLineBreakProvider()).toBe(original);
   });
 });
 

--- a/packages/core/src/layout-engine/measure/lineBreaks.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.ts
@@ -1,3 +1,5 @@
+import { getLineBreakProvider } from "./lineBreakProvider";
+import type { LineBreakPolicy } from "./lineBreakProvider";
 import { isCjkCodePoint } from "../../utils/scriptSegments";
 
 /**
@@ -5,44 +7,22 @@ import { isCjkCodePoint } from "../../utils/scriptSegments";
  * whitespace or hyphen; CJK text can break after every ideograph so a
  * partial line is filled instead of pushing the whole run to the next line.
  */
-export function findWordBreaks(text: string): number[] {
-  const breaks: number[] = [];
+export const findWordBreaks = (text: string, policy?: LineBreakPolicy): number[] =>
+  getLineBreakProvider().findBreaks(text, policy);
 
-  for (let index = 0; index < text.length;) {
-    const codePoint = text.codePointAt(index);
-    if (codePoint === undefined) {
-      break;
-    }
-    const charLength = codePoint > 0xffff ? 2 : 1;
-    const char = text[index];
-
-    if (char === " " || char === "-" || char === "\t") {
-      breaks.push(index + charLength);
-    } else if (isCjkCodePoint(codePoint)) {
-      breaks.push(index + charLength);
-    }
-
-    index += charLength;
-  }
-
-  return breaks;
-}
+export const findGraphemeBreaks = (text: string, policy?: LineBreakPolicy): number[] =>
+  getLineBreakProvider().findGraphemeBreaks(text, policy);
 
 export function isBreakChar(char: string | undefined): boolean {
   if (char === undefined) {
     return false;
   }
-  if (char === " " || char === "-" || char === "\t") {
+  if (/\s/u.test(char) || char === "-" || char === "\u00AD" || char === "\u200B") {
     return true;
   }
-  const codePoint = char.codePointAt(0);
-  if (codePoint === undefined) {
-    return false;
-  }
-  // Astral CJK ends on a low surrogate; treat it as a break so run glue does
-  // not span ideograph boundaries.
   if (char >= "\uDC00" && char <= "\uDFFF") {
     return true;
   }
-  return isCjkCodePoint(codePoint);
+  const codePoint = char.codePointAt(0);
+  return codePoint !== undefined && isCjkCodePoint(codePoint);
 }

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -395,6 +395,21 @@ describe("measureParagraph cross-run line breaking", () => {
     }, fakeMeasure);
   });
 
+  test("hard-breaks long words only at grapheme boundaries", () => {
+    withFakeTextMeasure(
+      () => {
+        const family = "👨‍👩‍👧‍👦";
+        const text = `${family}x`;
+        const { lines } = measureParagraph(paragraph([{ kind: "text", text }]), 10);
+
+        expect(lines).toHaveLength(2);
+        expect(lines[0]?.toChar).toBe(family.length);
+        expect(lines[1]).toMatchObject({ fromChar: family.length, toChar: text.length });
+      },
+      { charWidth: fixedCharWidth(5) },
+    );
+  });
+
   test("does not soft-wrap overflowed preserved spaces onto their own lines", () => {
     withFakeTextMeasure(() => {
       const spaces = " ".repeat(12);
@@ -1759,6 +1774,25 @@ describe("CJK line breaking", () => {
         expect(measure.lines[0]?.toChar).toBe(4);
         expect(measure.lines[1]?.fromRun).toBe(1);
         expect(measure.lines[1]?.fromChar).toBe(0);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("allows trailing punctuation to hang when w:overflowPunct is enabled", () => {
+    withFakeTextMeasure(
+      () => {
+        const paragraph = (overflowPunctuation: boolean): ParagraphBlock => ({
+          kind: "paragraph",
+          id: `cjk-overflow-punctuation-${overflowPunctuation}`,
+          runs: [{ kind: "text", text: "中文。", language: { eastAsia: "zh-CN" } }],
+          attrs: { overflowPunctuation },
+        });
+
+        expect(measureParagraph(paragraph(false), 20).lines).toHaveLength(2);
+        const hanging = measureParagraph(paragraph(true), 20);
+        expect(hanging.lines).toHaveLength(1);
+        expect(hanging.lines[0]?.width).toBe(30);
       },
       { charWidth: fixedCharWidth(10) },
     );

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -39,7 +39,8 @@ import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import { buildRunFontStyle, ptToPx } from "./measureHelpers";
 import { getFontMetrics, measureRun, measureTextWidth } from "./measureProvider";
 import type { FontMetrics, FontStyle } from "./measureTypes";
-import { findWordBreaks, isBreakChar } from "./lineBreaks";
+import { findGraphemeBreaks, findWordBreaks, isBreakChar } from "./lineBreaks";
+import type { LineBreakPolicy } from "./lineBreakProvider";
 import { countCompressibleSpaces } from "./textMeasurementPolicy";
 
 export { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
@@ -71,20 +72,24 @@ function findMaxFittingLength(
   style: FontStyle,
   maxWidth: number,
   forceMin: boolean = false,
+  policy?: LineBreakPolicy,
 ): number {
-  let lo = 1;
-  let hi = text.length;
+  const boundaries = findGraphemeBreaks(text, policy);
+  let lo = 0;
+  let hi = boundaries.length - 1;
   let best = 0;
   while (lo <= hi) {
     const mid = Math.floor((lo + hi) / 2);
-    if (measureTextWidth(text.slice(0, mid), style) <= maxWidth) {
-      best = mid;
+    // SAFETY: lo/hi are bounded by boundaries.length.
+    const boundary = boundaries[mid]!;
+    if (measureTextWidth(text.slice(0, boundary), style) <= maxWidth) {
+      best = boundary;
       lo = mid + 1;
     } else {
       hi = mid - 1;
     }
   }
-  return forceMin && best === 0 ? 1 : best;
+  return forceMin && best === 0 ? (boundaries.at(0) ?? 0) : best;
 }
 
 /**
@@ -151,6 +156,43 @@ type LineState = {
  */
 function runToFontStyle(run: TextRun | TabRun | FieldRun | MathRun): FontStyle {
   return buildRunFontStyle(run, DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE);
+}
+
+function languageMatches(ruleLanguage: string | undefined, locale: string | undefined): boolean {
+  if (!ruleLanguage) {
+    return true;
+  }
+  if (!locale) {
+    return false;
+  }
+  const rule = ruleLanguage.toLowerCase();
+  const active = locale.toLowerCase();
+  return active === rule || active.startsWith(`${rule}-`) || rule.startsWith(`${active}-`);
+}
+
+function lineBreakPolicy(block: ParagraphBlock, run: TextRun): LineBreakPolicy {
+  const language = run.language;
+  let locale = language?.val;
+  if (hasCjk(run.text)) {
+    locale = language?.eastAsia ?? language?.val;
+  } else if (run.rtl) {
+    locale = language?.bidi ?? language?.val;
+  }
+  const rules = block.attrs?.lineBreakRules;
+  const before = rules?.noLineBreaksBefore;
+  const after = rules?.noLineBreaksAfter;
+
+  return {
+    ...(locale ? { locale } : {}),
+    ...(block.attrs?.kinsoku !== undefined ? { kinsoku: block.attrs.kinsoku } : {}),
+    ...(before && languageMatches(before.language, locale)
+      ? { noLineBreaksBefore: before.characters }
+      : {}),
+    ...(after && languageMatches(after.language, locale)
+      ? { noLineBreaksAfter: after.characters }
+      : {}),
+    ...(rules?.useLegacyEthiopicAmharicRules ? { useLegacyEthiopicAmharicRules: true } : {}),
+  };
 }
 
 /**
@@ -676,12 +718,31 @@ function trimTrailingSpacesAndTabs(text: string): string {
   return text.slice(0, end);
 }
 
+function trailingHangingPunctuationWidth(
+  text: string,
+  style: FontStyle,
+  policy: LineBreakPolicy,
+  enabled: boolean | undefined,
+): number {
+  if (!enabled || text.length === 0) {
+    return 0;
+  }
+  const boundaries = findGraphemeBreaks(text, policy);
+  const lastStart = boundaries.at(-2) ?? 0;
+  const lastGrapheme = text.slice(lastStart);
+  if (!/^\p{Punctuation}+$/u.test(lastGrapheme)) {
+    return 0;
+  }
+  return measureTextWidth(lastGrapheme, style);
+}
+
 /**
  * Width of the unbreakable text glued to the end of each run.
  * A run boundary is not itself a wrap opportunity: adjacent note markers and
  * format-only word splits must wrap as one cluster.
  */
-function computeTrailingGlueWidths(runs: Run[]): number[] {
+function computeTrailingGlueWidths(block: ParagraphBlock): number[] {
+  const runs = block.runs;
   const widths = Array.from({ length: runs.length }, () => 0);
   for (let index = runs.length - 1; index >= 0; index--) {
     const nextRun = runs[index + 1];
@@ -699,7 +760,7 @@ function computeTrailingGlueWidths(runs: Run[]): number[] {
     }
 
     const style = runToFontStyle(nextRun);
-    const breaks = findWordBreaks(text);
+    const breaks = findWordBreaks(text, lineBreakPolicy(block, nextRun));
     if (breaks.length === 0) {
       widths[index] = measureTextWidth(text, style) + (widths[index + 1] ?? 0);
       continue;
@@ -976,7 +1037,7 @@ export function measureParagraph(
     };
   }
 
-  const trailingGlueWidths = computeTrailingGlueWidths(runs);
+  const trailingGlueWidths = computeTrailingGlueWidths(block);
 
   // Initialize line state
   let currentLine: LineState = {
@@ -1437,6 +1498,7 @@ export function measureParagraph(
       const textRun = run as TextRun;
       const text = textRun.text;
       const style = runToFontStyle(textRun);
+      const breakPolicy = lineBreakPolicy(block, textRun);
       // Line height comes from the CJK-aware style; width measurement below
       // keeps `style` so wrapping is unchanged.
       const lineHeightStyle = cjkLineHeightStyle(textRun, style);
@@ -1451,7 +1513,7 @@ export function measureParagraph(
       }
 
       // Find word break points for wrapping
-      const wordBreaks = findWordBreaks(text);
+      const wordBreaks = findWordBreaks(text, breakPolicy);
 
       // Process text word by word
       let charIndex = 0;
@@ -1474,6 +1536,12 @@ export function measureParagraph(
         const measuredWord = trimTrailingSpacesAndTabs(word);
         const wordWidth = measureTextWidth(measuredWord, style);
         const fullWordWidth = measureTextWidth(word, style);
+        const hangingPunctuationWidth = trailingHangingPunctuationWidth(
+          measuredWord,
+          style,
+          breakPolicy,
+          block.attrs?.overflowPunctuation,
+        );
         const regularSpaces = countCompressibleSpaces(measuredWord);
         const nonBreakingSpaces = measuredWord.split("\u00a0").length - 1;
         const isFirstLine = lines.length === 0;
@@ -1499,11 +1567,11 @@ export function measureParagraph(
               )
             : WIDTH_TOLERANCE;
 
-        // If the word itself is longer than a line, hard-break by characters.
+        // If the word itself is longer than a line, hard-break by grapheme.
         // Use substring measurement (not char-by-char accumulation) to preserve
         // kerning accuracy. Char-by-char accumulation overestimates width by
         // ~1-2px per line due to lost kerning, causing extra wraps in narrow cells.
-        if (wordWidth > currentLine.availableWidth + widthTolerance) {
+        if (wordWidth - hangingPunctuationWidth > currentLine.availableWidth + widthTolerance) {
           // Long word that needs hard-breaking. DON'T start a new line first —
           // fill the remaining space on the current line with as many characters
           // as possible. This prevents wasting a full line when a small run
@@ -1513,16 +1581,21 @@ export function measureParagraph(
           while (chunkStart < measuredWord.length) {
             const spaceLeft = currentLine.availableWidth - currentLine.width + WIDTH_TOLERANCE;
             const remaining = measuredWord.slice(chunkStart);
-            let bestEnd = findMaxFittingLength(remaining, style, spaceLeft);
+            let bestEnd = findMaxFittingLength(
+              remaining,
+              style,
+              spaceLeft,
+              currentLine.width === 0,
+              breakPolicy,
+            );
 
-            // Nothing fits → start a new line and retry (or force 1 char on empty line)
+            // Nothing fits beside existing content: start a new line and retry.
+            // On an empty line findMaxFittingLength forces one whole grapheme,
+            // even if that grapheme itself is wider than the line.
             if (bestEnd === 0) {
-              if (currentLine.width > 0) {
-                startNewLine(runIndex, charIndex + chunkStart);
-                updateMaxFont(lineHeightStyle);
-                continue;
-              }
-              bestEnd = 1;
+              startNewLine(runIndex, charIndex + chunkStart);
+              updateMaxFont(lineHeightStyle);
+              continue;
             }
 
             const chunkEnd = chunkStart + bestEnd;
@@ -1585,13 +1658,15 @@ export function measureParagraph(
           wordWidth + rawGlueWidth <= getPostWrapAvailableWidth() + widthTolerance
             ? rawGlueWidth
             : 0;
+        const hangingAllowance = glueWidth === 0 ? hangingPunctuationWidth : 0;
         // Let collapsible whitespace remain at the previous line's tail until
         // visible content decides whether to wrap. Starting a line from an
         // overflowed space creates whitespace-only soft-wrap lines.
         if (
           wordWidth > 0 &&
           currentLine.width > 0 &&
-          currentLine.width + wordWidth + glueWidth > currentLine.availableWidth + widthTolerance
+          currentLine.width + wordWidth + glueWidth >
+            currentLine.availableWidth + widthTolerance + hangingAllowance
         ) {
           // Word doesn't fit, start new line
           startNewLine(runIndex, charIndex);

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -58,6 +58,8 @@ export type RunFormatting = {
    * to `fontFamily`.
    */
   eastAsiaFontFamily?: string;
+  /** Run language metadata resolved from `w:lang`. */
+  language?: { val?: string; eastAsia?: string; bidi?: string };
   fontSize?: number;
   letterSpacing?: number;
   superscript?: boolean;
@@ -372,6 +374,16 @@ export type ListNumPr = {
  */
 export type ParagraphAttrs = {
   alignment?: "left" | "center" | "right" | "justify";
+  /** East Asian first/last-character restrictions (`w:kinsoku`). */
+  kinsoku?: boolean;
+  /** Hanging punctuation (`w:overflowPunct`), retained for layout policy. */
+  overflowPunctuation?: boolean;
+  /** Document-wide custom line-edge characters and compatibility behavior. */
+  lineBreakRules?: {
+    noLineBreaksBefore?: { language?: string; characters: string };
+    noLineBreaksAfter?: { language?: string; characters: string };
+    useLegacyEthiopicAmharicRules?: boolean;
+  };
   /** OOXML outline level (`w:outlineLvl`), where zero is the top level. */
   outlineLevel?: number;
   spacing?: ParagraphSpacing;

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -36,6 +36,7 @@ import type {
   EmphasisMarkAttrs,
   FieldAttrs,
   FontFamilyAttrs,
+  LanguageAttrs,
   FontSizeAttrs,
   FootnoteRefAttrs,
   HighlightAttrs,
@@ -220,6 +221,7 @@ const highlightAttrsCache = new WeakMap<Mark, HighlightAttrs>();
 const runShadingAttrsCache = new WeakMap<Mark, RunShadingAttrs>();
 const fontSizeAttrsCache = new WeakMap<Mark, FontSizeAttrs>();
 const fontFamilyAttrsCache = new WeakMap<Mark, FontFamilyAttrs>();
+const languageAttrsCache = new WeakMap<Mark, LanguageAttrs>();
 const characterSpacingAttrsCache = new WeakMap<Mark, CharacterSpacingAttrs>();
 const characterStyleAttrsCache = new WeakMap<Mark, CharacterStyleAttrs>();
 const emphasisMarkAttrsCache = new WeakMap<Mark, EmphasisMarkAttrs>();
@@ -245,6 +247,8 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
     PARAGRAPH_ALIGNMENT_VALUES,
   );
   optionalString(attrs, "styleId", "paragraph.attrs.styleId", issues);
+  optionalBoolean(attrs, "kinsoku", "paragraph.attrs.kinsoku", issues);
+  optionalBoolean(attrs, "overflowPunctuation", "paragraph.attrs.overflowPunctuation", issues);
   optionalNumber(attrs, "spaceBefore", "paragraph.attrs.spaceBefore", issues);
   optionalNumber(attrs, "spaceAfter", "paragraph.attrs.spaceAfter", issues);
   optionalNumber(attrs, "lineSpacing", "paragraph.attrs.lineSpacing", issues);
@@ -837,6 +841,21 @@ export const readFontFamilyMarkAttrs = (
 
 export const expectFontFamilyMarkAttrs = (mark: Mark): FontFamilyAttrs =>
   expectCachedMarkAttrs(mark, fontFamilyAttrsCache, readFontFamilyMarkAttrs, "font family attrs");
+
+export const readLanguageMarkAttrs = (mark: Mark): ReadProseMirrorAttrsResult<LanguageAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "language", issues);
+
+  optionalString(attrs, "val", "language.attrs.val", issues);
+  optionalString(attrs, "eastAsia", "language.attrs.eastAsia", issues);
+  optionalString(attrs, "bidi", "language.attrs.bidi", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectLanguageMarkAttrs = (mark: Mark): LanguageAttrs =>
+  expectCachedMarkAttrs(mark, languageAttrsCache, readLanguageMarkAttrs, "language attrs");
 
 export const readCharacterSpacingMarkAttrs = (
   mark: Mark,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -71,6 +71,7 @@ import {
   expectTextEffectMarkAttrs,
   expectFieldAttrs,
   expectFontFamilyMarkAttrs,
+  expectLanguageMarkAttrs,
   expectFontSizeMarkAttrs,
   expectFootnoteRefMarkAttrs,
   expectHardBreakAttrs,
@@ -666,7 +667,7 @@ function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
 // "inherit", dropping the user's decision on save. Branch on `== null` so every
 // toggle routed through here preserves `false`. (Direction is handled
 // separately via the `direction` discriminated union, not this helper.)
-type BooleanToggleKey = "pageBreakBefore" | "widowControl";
+type BooleanToggleKey = "pageBreakBefore" | "widowControl" | "kinsoku" | "overflowPunctuation";
 
 function assignBooleanToggle(
   result: ParagraphFormatting,
@@ -769,6 +770,8 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     }
     assignBooleanToggle(result, attrs, orig, "pageBreakBefore");
     assignBooleanToggle(result, attrs, orig, "widowControl");
+    assignBooleanToggle(result, attrs, orig, "kinsoku");
+    assignBooleanToggle(result, attrs, orig, "overflowPunctuation");
     if (attrs.spacingExplicit !== orig.spacingExplicit) {
       if (attrs.spacingExplicit) {
         result.spacingExplicit = attrs.spacingExplicit;
@@ -818,7 +821,9 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     // keep the paragraph from short-circuiting to "no formatting".
     bidi != null ||
     attrs.pageBreakBefore != null ||
-    attrs.widowControl != null;
+    attrs.widowControl != null ||
+    attrs.kinsoku != null ||
+    attrs.overflowPunctuation != null;
 
   if (!hasFormatting) {
     return undefined;
@@ -892,6 +897,12 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
   }
   if (attrs.widowControl != null) {
     f.widowControl = attrs.widowControl;
+  }
+  if (attrs.kinsoku != null) {
+    f.kinsoku = attrs.kinsoku;
+  }
+  if (attrs.overflowPunctuation != null) {
+    f.overflowPunctuation = attrs.overflowPunctuation;
   }
   return f;
 }
@@ -2011,6 +2022,16 @@ export function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
           ff.csTheme = attrs.csTheme;
         }
         formatting.fontFamily = ff;
+        break;
+      }
+
+      case "language": {
+        const attrs = expectLanguageMarkAttrs(mark);
+        formatting.language = {
+          ...(attrs.val ? { val: attrs.val } : {}),
+          ...(attrs.eastAsia ? { eastAsia: attrs.eastAsia } : {}),
+          ...(attrs.bidi ? { bidi: attrs.bidi } : {}),
+        };
         break;
       }
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -608,6 +608,8 @@ function paragraphFormattingToAttrs(
     set("borders", formatting?.borders ?? stylePpr?.borders);
     set("shading", formatting?.shading ?? stylePpr?.shading);
     set("tabs", formatting?.tabs ?? stylePpr?.tabs);
+    set("kinsoku", formatting?.kinsoku ?? stylePpr?.kinsoku);
+    set("overflowPunctuation", formatting?.overflowPunctuation ?? stylePpr?.overflowPunctuation);
 
     // Page break control
     set("pageBreakBefore", formatting?.pageBreakBefore ?? stylePpr?.pageBreakBefore);
@@ -654,6 +656,8 @@ function paragraphFormattingToAttrs(
     set("borders", formatting?.borders);
     set("shading", formatting?.shading);
     set("tabs", formatting?.tabs);
+    set("kinsoku", formatting?.kinsoku);
+    set("overflowPunctuation", formatting?.overflowPunctuation);
 
     // Page break control
     set("pageBreakBefore", formatting?.pageBreakBefore);
@@ -2559,6 +2563,10 @@ export function textFormattingToMarks(
         csTheme: formatting.fontFamily.csTheme,
       }),
     );
+  }
+
+  if (formatting.language) {
+    marks.push(schema.mark("language", formatting.language));
   }
 
   // Superscript/Subscript

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -44,6 +44,7 @@ import { HiddenTextExtension } from "./marks/HiddenTextExtension";
 import { HighlightExtension } from "./marks/HighlightExtension";
 import { HyperlinkExtension } from "./marks/HyperlinkExtension";
 import { ItalicExtension } from "./marks/ItalicExtension";
+import { LanguageExtension } from "./marks/LanguageExtension";
 import { RtlExtension } from "./marks/RtlExtension";
 import { RunFormattingOverrideExtension } from "./marks/RunFormattingOverrideExtension";
 import { RunShadingExtension } from "./marks/RunShadingExtension";
@@ -129,6 +130,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add("highlight", HighlightExtension());
   add("fontSize", FontSizeExtension());
   add("fontFamily", FontFamilyExtension());
+  add("language", LanguageExtension());
   add("superscript", SuperscriptExtension());
   add("subscript", SubscriptExtension());
   add("hyperlink", HyperlinkExtension());

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -320,6 +320,8 @@ const paragraphNodeSpec: NodeSpec = {
     paraId: { default: null },
     textId: { default: null },
     alignment: { default: null },
+    kinsoku: { default: null },
+    overflowPunctuation: { default: null },
     spaceBefore: { default: null },
     spaceAfter: { default: null },
     lineSpacing: { default: null },

--- a/packages/core/src/prosemirror/extensions/marks/LanguageExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/LanguageExtension.ts
@@ -1,0 +1,27 @@
+import { expectLanguageMarkAttrs } from "../../attrs";
+import { createMarkExtension } from "../create";
+
+/** Preserve OOXML `w:lang` and expose its primary language to the editing DOM. */
+export const LanguageExtension = createMarkExtension({
+  name: "language",
+  schemaMarkName: "language",
+  markSpec: {
+    attrs: {
+      val: { default: null },
+      eastAsia: { default: null },
+      bidi: { default: null },
+    },
+    parseDOM: [
+      {
+        tag: "span[lang]",
+        getAttrs: (dom) =>
+          typeof dom === "string" ? false : { val: dom.getAttribute("lang") ?? undefined },
+      },
+    ],
+    toDOM(mark) {
+      const { val, eastAsia, bidi } = expectLanguageMarkAttrs(mark);
+      const language = val ?? eastAsia ?? bidi;
+      return language ? ["span", { lang: language }, 0] : ["span", 0];
+    },
+  },
+});

--- a/packages/core/src/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/core/src/prosemirror/extensions/marks/markUtils.ts
@@ -94,6 +94,17 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         };
         break;
       }
+      case "language": {
+        const val = mark.attrs["val"];
+        const eastAsia = mark.attrs["eastAsia"];
+        const bidi = mark.attrs["bidi"];
+        formatting.language = {
+          ...(typeof val === "string" ? { val } : {}),
+          ...(typeof eastAsia === "string" ? { eastAsia } : {}),
+          ...(typeof bidi === "string" ? { bidi } : {}),
+        };
+        break;
+      }
       case "superscript":
         formatting.vertAlign = "superscript";
         break;
@@ -341,6 +352,9 @@ export function textFormattingToMarks(formatting: TextFormatting, schema: Schema
         asciiTheme: formatting.fontFamily.asciiTheme,
       }),
     );
+  }
+  if (formatting.language && schema.marks["language"]) {
+    marks.push(schema.marks["language"].create(formatting.language));
   }
   if (formatting.vertAlign === "superscript" && schema.marks["superscript"]) {
     marks.push(schema.marks["superscript"].create());

--- a/packages/core/src/prosemirror/schema/index.ts
+++ b/packages/core/src/prosemirror/schema/index.ts
@@ -33,6 +33,7 @@ export type {
   StrikeAttrs,
   FontSizeAttrs,
   FontFamilyAttrs,
+  LanguageAttrs,
   HighlightAttrs,
   CharacterSpacingAttrs,
   EmphasisMarkAttrs,

--- a/packages/core/src/prosemirror/schema/marks.ts
+++ b/packages/core/src/prosemirror/schema/marks.ts
@@ -58,6 +58,12 @@ export type FontFamilyAttrs = {
   csTheme?: string;
 };
 
+export type LanguageAttrs = {
+  val?: string;
+  eastAsia?: string;
+  bidi?: string;
+};
+
 export type HighlightAttrs = {
   color: NonNullable<TextFormatting["highlight"]>;
 };

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -56,6 +56,10 @@ export type ParagraphAttrs = {
 
   // Alignment
   alignment?: ParagraphAlignment;
+  /** Effective East Asian line-edge policy (`w:kinsoku`). */
+  kinsoku?: boolean;
+  /** Effective hanging-punctuation policy (`w:overflowPunct`). */
+  overflowPunctuation?: boolean;
 
   // Spacing (in twips)
   spaceBefore?: number;

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -14,6 +14,7 @@ import {
   readHighlightMarkAttrs,
   readHyperlinkMarkAttrs,
   readImageAttrs,
+  readLanguageMarkAttrs,
   readMathAttrs,
   readBlockSdtAttrs,
   readParagraphAttrs,
@@ -244,6 +245,10 @@ const validateMarks = (
 
       case "fontFamily":
         appendAttrIssues(markPath, readFontFamilyMarkAttrs(mark), issues);
+        continue;
+
+      case "language":
+        appendAttrIssues(markPath, readLanguageMarkAttrs(mark), issues);
         continue;
 
       case "characterSpacing":

--- a/packages/core/src/utils/paragraphFormattingMerge.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.ts
@@ -4,6 +4,8 @@ import { mergeTextFormatting } from "./textFormattingMerge";
 const PARAGRAPH_REPLACE_KEYS = [
   "alignment",
   "bidi",
+  "kinsoku",
+  "overflowPunctuation",
   "spaceBefore",
   "spaceAfter",
   "lineSpacing",

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -199,6 +199,12 @@ export type DocumentSettings = {
    * `<a:font script="…">` entries. Absent for non-CJK/bidi docs.
    */
   themeFontLang?: { eastAsia?: string; bidi?: string };
+  /** Word/OOXML document-wide line-breaking overrides. */
+  lineBreakRules?: {
+    noLineBreaksBefore?: { language?: string; characters: string };
+    noLineBreaksAfter?: { language?: string; characters: string };
+    useLegacyEthiopicAmharicRules?: boolean;
+  };
 };
 
 /** DOCX package conformance classes. */

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -140,6 +140,12 @@ export type TextFormatting = {
     eastAsiaTheme?: string;
     csTheme?: string;
   };
+  /** Run language metadata (`w:lang`) used by spelling and line breaking. */
+  language?: {
+    val?: string;
+    eastAsia?: string;
+    bidi?: string;
+  };
 
   // Spacing and position
   /** Character spacing in twips (w:spacing) */
@@ -232,6 +238,10 @@ export type ParagraphFormatting = {
   alignment?: ParagraphAlignment;
   /** Text direction (w:bidi) */
   bidi?: boolean;
+  /** Apply East Asian first/last-character line-breaking rules (w:kinsoku). */
+  kinsoku?: boolean;
+  /** Allow punctuation to hang beyond the text margin (w:overflowPunct). */
+  overflowPunctuation?: boolean;
 
   // Spacing
   /** Spacing before in twips (w:spacing/@w:before) */


### PR DESCRIPTION
## Summary

- replace the fixed line-break helper with an `Intl.Segmenter`-based, replaceable provider
- preserve and apply DOCX language metadata, kinsoku rules, custom prohibited edge characters, hanging punctuation, and the Ethiopic compatibility flag
- keep emergency wrapping grapheme-safe and invalidate paragraph measurements when providers change
- add DOCX round-trip, layout, Unicode, and provider replacement coverage

Soft hyphens remain supported; automatic dictionary hyphenation is not added by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved Unicode-aware line breaking, including grapheme-safe wrapping and support for languages without spaces.
  * Added CJK kinsoku rules, hanging punctuation, custom line-edge overrides, and legacy Ethiopic/Amharic compatibility rules.
  * Preserved Word language metadata across DOCX and editor conversions.
  * Added support for paragraph settings controlling kinsoku and overflow punctuation.
* **Bug Fixes**
  * Prevented line breaks within grapheme clusters such as emoji sequences.
  * Improved handling of soft hyphens, zero-width spaces, and malformed language tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->