### PR TITLE
fix: preserve worker kerning mode

### DIFF
--- a/.changeset/clean-worker-kerning.md
+++ b/.changeset/clean-worker-kerning.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored pair kerning in worker measurement requests.

--- a/packages/core/src/layout-engine/measure/measureWorker.test.ts
+++ b/packages/core/src/layout-engine/measure/measureWorker.test.ts
@@ -197,8 +197,28 @@ describe("prefetchMeasurement (flag gating)", () => {
         fontFingerprintWidth: TEST_FONT_FINGERPRINT_WIDTH,
         letterSpacing: 0,
         horizontalScale: 1,
+        fontKerning: "none",
       },
     ]);
+  });
+
+  test("preserves the requested kerning mode at the worker boundary", () => {
+    setFolioMeasurementFlags({ workerFontMetrics: true });
+    const transport = makeFakeTransport();
+    __setMeasureWorkerTransport(() => transport);
+
+    prefetchMeasurement(
+      "hello",
+      "11px Arial",
+      0,
+      1,
+      "11px Arial|kerning:normal|scale:1",
+      TEST_FONT_FINGERPRINT_WIDTH,
+      "normal",
+    );
+    __flushMeasureQueueForTests();
+
+    expect(transport.posted[0]?.entries[0]?.fontKerning).toBe("normal");
   });
 });
 

--- a/packages/core/src/layout-engine/measure/measureWorker.ts
+++ b/packages/core/src/layout-engine/measure/measureWorker.ts
@@ -251,7 +251,7 @@ function flush(current: ProxyState): void {
       fontFingerprintWidth: entry.fontFingerprintWidth,
       letterSpacing: entry.letterSpacing,
       horizontalScale: entry.horizontalScale,
-      fontKerning: entry.fontKerning,
+      ...(entry.fontKerning !== undefined ? { fontKerning: entry.fontKerning } : {}),
     });
   }
   if (entries.length === 0) {

--- a/packages/core/src/layout-engine/measure/measureWorker.ts
+++ b/packages/core/src/layout-engine/measure/measureWorker.ts
@@ -251,6 +251,7 @@ function flush(current: ProxyState): void {
       fontFingerprintWidth: entry.fontFingerprintWidth,
       letterSpacing: entry.letterSpacing,
       horizontalScale: entry.horizontalScale,
+      fontKerning: entry.fontKerning,
     });
   }
   if (entries.length === 0) {


### PR DESCRIPTION
## Summary

- forward the normalized kerning mode through worker batch serialization
- keep worker font fingerprinting aligned with the main-thread request
- cover the proxy boundary with a focused regression

## Validation

- 28 focused worker measurement tests pass
- 15 architecture boundary tests pass
- dependency audit reports no vulnerabilities
- lint and typecheck delegated to CI

CC on behalf of @jan-kubica
