### PR TITLE
fix: preserve cached keep-next boundaries

### DIFF
--- a/.changeset/steady-kept-boundaries.md
+++ b/.changeset/steady-kept-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve cached page boundaries on keep-with-next paragraphs.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -401,6 +401,28 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0, 1]);
     });
 
+    test("rendered page break preserves a fitting keep-next heading boundary", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before heading", 1),
+        {
+          ...makeParagraphBlock(1, "Kept heading", 16, { keepNext: true }),
+          attrs: { keepNext: true, renderedPageBreakBefore: true },
+        },
+        makeParagraphBlock(2, "Kept body", 29),
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 14, 100, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 9, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
+    });
+
     test("rendered page break moves a paragraph that would cross the current page", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Nearly fills page one", 1),

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -88,6 +88,22 @@ describe("rendered break reconciliation", () => {
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
+  test("a fitting cached marker remains authoritative on a keep-next paragraph", () => {
+    const previous = paragraph(1);
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: paragraph(2, { keepNext: true, renderedPageBreakBefore: true }),
+      previousBlock: previous,
+      page: page([paragraphFragment(1)]),
+      blocksById: new Map([["1", previous]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
   test("paragraph continuation satisfies a cached marker", () => {
     const previous = paragraph(1);
     const decision = reconcileBreakBeforeBlock({

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -56,12 +56,13 @@ export const reconcileBreakBeforeBlock = ({
     (state.type === "pageAdvance" &&
       (continuesNumberedSequence(previousBlock, block) ||
         continuesTabbedParagraphSequence(previousBlock, block)));
+  // A keep-with-next paragraph carries the marker boundary into its linked
+  // content, so its own height is not enough to classify the marker as stale.
+  const markerNeedsSnap = renderedBreakNeedsSnap || block.attrs?.keepNext === true;
 
   return {
     forcePageBreak:
-      renderedBreakNeedsSnap &&
-      !markerAlreadySatisfied &&
-      pageHasVisibleBodyContent(page, blocksById),
+      markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById),
     state: INITIAL_RENDERED_BREAK_STATE,
   };
 };


### PR DESCRIPTION
## Summary

- preserve cached page boundaries on fitting keep-with-next paragraphs
- keep ordinary fitting cached markers advisory after reflow
- add state-machine and end-to-end layout regressions

## Validation

- `bun test src/layout-engine src/__tests__/layout-pipeline.integration.test.ts` from `packages/core` (432 passed)
- same-font reference comparison: 86.6% to 89.0%, with all pagination divergences removed
- advisory-marker control: unchanged at 92.6%
- `bun audit` (no vulnerabilities)
- lint and typecheck delegated to CI

CC on behalf of @jan-kubica
