### PR TITLE
fix: split break-permitted table rows

### DIFF
--- a/.changeset/calm-splitting-rows.md
+++ b/.changeset/calm-splitting-rows.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Split break-permitted table rows across flow regions at safe line boundaries.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -873,7 +873,8 @@ export type TableRow = {
     gridAfter?: number;
     height?: number;
     heightRule?: "auto" | "atLeast" | "exact";
-    isHeader?: boolean;
+    isHeader?: boolean; /** `w:cantSplit`: keep this row in one flow region. */
+    cantSplit?: boolean;
     hidden?: boolean;
 };
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -908,6 +908,25 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
 });
 
 describe("toFlowBlocks table cell formatting", () => {
+  test("carries cantSplit row formatting into layout blocks", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node(
+          "tableRow",
+          { _originalFormatting: { cantSplit: true } },
+          [schema.node("tableCell", null, [schema.node("paragraph")])],
+        ),
+      ]),
+    ]);
+
+    const table = toFlowBlocks(doc).at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+
+    expect(table.rows.at(0)?.cantSplit).toBe(true);
+  });
+
   // Regression eigenpal #424 gap 14: the parser captured w:noWrap and the PM
   // schema carried it, but convertTableCell dropped the field, so cells like
   // case numbers / citations wrapped where Word kept them on one line.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -911,11 +911,9 @@ describe("toFlowBlocks table cell formatting", () => {
   test("carries cantSplit row formatting into layout blocks", () => {
     const doc = schema.node("doc", null, [
       schema.node("table", null, [
-        schema.node(
-          "tableRow",
-          { _originalFormatting: { cantSplit: true } },
-          [schema.node("tableCell", null, [schema.node("paragraph")])],
-        ),
+        schema.node("tableRow", { _originalFormatting: { cantSplit: true } }, [
+          schema.node("tableCell", null, [schema.node("paragraph")]),
+        ]),
       ]),
     ]);
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2221,6 +2221,9 @@ function convertTableRow(
   if (attrs.isHeader) {
     row.isHeader = attrs.isHeader;
   }
+  if (attrs._originalFormatting?.cantSplit) {
+    row.cantSplit = true;
+  }
   if (attrs.hidden) {
     row.hidden = attrs.hidden;
   }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -886,6 +886,9 @@ function layoutTable(
   let currentRowIndex = 0;
 
   const breakInfo = buildTableRowBreakInfo(block, measure);
+  const hasVerticalMerges = block.rows.some((row) =>
+    row.cells.some((cell) => (cell.rowSpan ?? 1) > 1),
+  );
 
   // X position from justification / indent, recomputed per fragment because the
   // active column can change across section breaks.
@@ -935,7 +938,8 @@ function layoutTable(
 
   const canSplitRow = (rowIndex: number, state = paginator.getCurrentState()): boolean => {
     const row = rows[rowIndex];
-    if (!row) {
+    const sourceRow = block.rows[rowIndex];
+    if (!row || !sourceRow || sourceRow.cantSplit || sourceRow.isHeader || hasVerticalMerges) {
       return false;
     }
     if ((breakInfo.breakOffsets[rowIndex]?.length ?? 0) <= 1) {
@@ -944,17 +948,29 @@ function layoutTable(
     const freshHeaderOverhead =
       headerRowCount > 0 && rowIndex >= headerRowCount ? headerRowsHeight : 0;
     const requiredHeight = row.height + freshHeaderOverhead;
-    return requiredHeight > getCurrentRowCapacity(state);
+    const oversized = requiredHeight > getCurrentRowCapacity(state);
+    if (
+      !oversized &&
+      (state.footnoteHeight > 0 || (rowFootnoteIds[rowIndex]?.length ?? 0) > 0)
+    ) {
+      return false;
+    }
+
+    const currentHeaderOverhead = shouldRepeatHeaderRows(rowIndex, 0, state)
+      ? headerRowsHeight
+      : 0;
+    const currentAvailableHeight =
+      paginator.getAvailableHeight() - currentHeaderOverhead - state.trailingSpacing;
+    return oversized || row.height > currentAvailableHeight;
   };
 
   while (currentRowIndex < rows.length) {
-    // A row taller than a whole page can't fit anywhere; break it between whole
-    // text lines across pages instead of overflowing the page and clipping the
-    // content. eigenpal/docx-editor#698 (fixes their #570).
-    const oversizedRow = rows[currentRowIndex]!; // SAFETY: currentRowIndex < rows.length
+    // Break permitted rows between whole text lines when they exceed the current
+    // flow region; rows taller than a full region use the same path repeatedly.
+    const splittableRow = rows[currentRowIndex]!; // SAFETY: currentRowIndex < rows.length
     if (canSplitRow(currentRowIndex)) {
       let consumed = 0;
-      while (consumed < oversizedRow.height) {
+      while (consumed < splittableRow.height) {
         const sliceState = paginator.getCurrentState();
         const repeatHeaderRows = shouldRepeatHeaderRows(currentRowIndex, consumed, sliceState);
         const headerOverhead = repeatHeaderRows ? headerRowsHeight : 0;
@@ -976,10 +992,10 @@ function layoutTable(
           // the next whole line anyway so the loop always makes progress.
           const from = consumed;
           const next = breakInfo.breakOffsets[currentRowIndex]?.find((o) => o > from);
-          slice = (next ?? oversizedRow.height) - consumed;
+          slice = (next ?? splittableRow.height) - consumed;
         }
         const sliceBottom = consumed + slice;
-        const reachesRowEnd = sliceBottom >= oversizedRow.height;
+        const reachesRowEnd = sliceBottom >= splittableRow.height;
         const moreAfter = !reachesRowEnd || currentRowIndex + 1 < rows.length;
         const fragmentHeight = headerOverhead + slice;
         const sliceFragment: TableFragment = {
@@ -1004,7 +1020,7 @@ function layoutTable(
         sliceFragment.y = sliceResult.y;
         sliceFragment.x = computeTableX(sliceResult.state.columnIndex);
         consumed = sliceBottom;
-        if (consumed < oversizedRow.height) {
+        if (consumed < splittableRow.height) {
           paginator.forceColumnBreak();
         }
       }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -949,16 +949,11 @@ function layoutTable(
       headerRowCount > 0 && rowIndex >= headerRowCount ? headerRowsHeight : 0;
     const requiredHeight = row.height + freshHeaderOverhead;
     const oversized = requiredHeight > getCurrentRowCapacity(state);
-    if (
-      !oversized &&
-      (state.footnoteHeight > 0 || (rowFootnoteIds[rowIndex]?.length ?? 0) > 0)
-    ) {
+    if (!oversized && (state.footnoteHeight > 0 || (rowFootnoteIds[rowIndex]?.length ?? 0) > 0)) {
       return false;
     }
 
-    const currentHeaderOverhead = shouldRepeatHeaderRows(rowIndex, 0, state)
-      ? headerRowsHeight
-      : 0;
+    const currentHeaderOverhead = shouldRepeatHeaderRows(rowIndex, 0, state) ? headerRowsHeight : 0;
     const currentAvailableHeight =
       paginator.getAvailableHeight() - currentHeaderOverhead - state.trailingSpacing;
     return oversized || row.height > currentAvailableHeight;

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1,8 +1,8 @@
 /**
- * Table row-break geometry + mid-content row splitting. A table row taller than
- * a whole page must break between whole text lines across pages instead of
- * overflowing and clipping content. Regression for eigenpal/docx-editor#698
- * (their #570).
+ * Table row-break geometry + mid-content row splitting. Break-permitted rows
+ * must split between whole text lines when they exceed the current flow region,
+ * including rows taller than a full page. Regression for
+ * eigenpal/docx-editor#698 (their #570).
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -920,7 +920,7 @@ describe("oversized table row splits across pages (#570)", () => {
     expect(frags[1]?.bottomClip).toBeUndefined();
   });
 
-  test("keeps page-fitting rows whole when only remaining space is short", () => {
+  test("splits a break-permitted first row when only remaining space is short", () => {
     const spacer: FlowBlock = {
       kind: "paragraph",
       id: "spacer",
@@ -937,14 +937,14 @@ describe("oversized table row splits across pages (#570)", () => {
       .flatMap((page) => page.fragments)
       .filter((f): f is TableFragment => f.kind === "table");
 
-    expect(frags.length).toBe(1);
+    expect(frags).toHaveLength(2);
+    expect(frags[0]).toMatchObject({ height: 40, bottomClip: 40 });
     expect(frags[0]?.topClip).toBeUndefined();
-    expect(frags[0]?.bottomClip).toBeUndefined();
-    expect(frags[0]?.height).toBe(100);
-    expect(frags[0]?.y).toBe(OPTIONS.margins.top);
+    expect(frags[1]).toMatchObject({ height: 60, topClip: 40 });
+    expect(frags[1]?.bottomClip).toBeUndefined();
   });
 
-  test("moves a page-fitting row intact after adjacent table rows", () => {
+  test("splits a break-permitted row after adjacent table rows", () => {
     const { block, measure } = tableWithHeaderTallBodyAndShortRow(4);
     measure.rows[2] = {
       cells: [{ blocks: [paraMeasure(3)], width: 220, height: 3 * LINE }],
@@ -958,17 +958,48 @@ describe("oversized table row splits across pages (#570)", () => {
     const secondPageTables =
       layout.pages[1]?.fragments.filter((f): f is TableFragment => f.kind === "table") ?? [];
 
-    expect(firstPageTables).toHaveLength(1);
+    expect(firstPageTables).toHaveLength(2);
     expect(firstPageTables[0]).toMatchObject({ fromRow: 0, toRow: 2 });
     expect(firstPageTables[0]?.bottomClip).toBeUndefined();
+    expect(firstPageTables[1]).toMatchObject({
+      fromRow: 2,
+      toRow: 3,
+      bottomClip: LINE,
+    });
     expect(secondPageTables).toHaveLength(1);
     expect(secondPageTables[0]).toMatchObject({
       fromRow: 2,
       toRow: 3,
       headerRowCount: 1,
+      topClip: LINE,
     });
-    expect(secondPageTables[0]?.topClip).toBeUndefined();
     expect(secondPageTables[0]?.bottomClip).toBeUndefined();
+  });
+
+  test("keeps a cantSplit row whole when only remaining space is short", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 70);
+    const { block, measure } = tallTable(5);
+    block.rows[0]!.cantSplit = true;
+
+    const layout = layoutDocument(
+      [spacer, block as FlowBlock],
+      [spacerMeasure as Measure, measure as Measure],
+      OPTIONS,
+    );
+    const frags = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((f): f is TableFragment => f.kind === "table");
+
+    expect(frags).toHaveLength(1);
+    expect(frags[0]?.topClip).toBeUndefined();
+    expect(frags[0]?.bottomClip).toBeUndefined();
+    expect(frags[0]?.height).toBe(100);
+    expect(frags[0]?.y).toBe(OPTIONS.margins.top);
   });
 
   test("keeps page-fitting rows whole after footnote reservations", () => {

--- a/packages/core/src/layout-engine/tableRowBreak.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.ts
@@ -1,12 +1,11 @@
 /**
  * Table row-break geometry. Ported from eigenpal/docx-editor#698 (folio subset).
  *
- * Word lets a table row break across a page boundary ("allow row to break
- * across pages", on by default). When a row is taller than a whole page it
- * cannot fit anywhere, so the portion that fits stays and the rest continues on
- * the next page — broken between whole text lines, never through a glyph.
- * Without this folio forced the oversized row onto one page and the overflow
- * was clipped (content lost; upstream #570).
+ * Table rows may break across flow regions unless `cantSplit` is set. When a
+ * permitted row exceeds the current region, the portion that fits stays and
+ * the rest continues in the next region, broken between whole text lines and
+ * never through a glyph. This also prevents oversized rows from overflowing
+ * one page and clipping content (upstream #570).
  *
  * This computes, per row, the safe break offsets (the y of every line bottom in
  * the row's cells) so the paginator can snap a break to the deepest whole line

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -546,6 +546,8 @@ export type TableRow = {
   height?: number;
   heightRule?: "auto" | "atLeast" | "exact";
   isHeader?: boolean;
+  /** `w:cantSplit`: keep this row in one flow region. */
+  cantSplit?: boolean;
   hidden?: boolean;
 };
 


### PR DESCRIPTION
## Summary

- split break-permitted table rows at safe line boundaries when they exceed the current flow region
- preserve explicit `cantSplit` formatting through the layout bridge
- keep conservative guards for headers, vertical merges, and footnote reservations

CC on behalf of @jan-kubica