### PR TITLE
fix: isolate paragraph-mark formatting from styled runs

### DIFF
--- a/.changeset/quiet-character-boundaries.md
+++ b/.changeset/quiet-character-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Prevent paragraph-mark emphasis from leaking through character-style references.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -616,7 +616,7 @@ describe("toProseDoc", () => {
     );
   });
 
-  test("does not leak paragraph-mark bold through a character-style reference", () => {
+  test("does not leak paragraph-mark emphasis through a character-style reference", () => {
     const document: Document = {
       package: {
         document: {
@@ -626,6 +626,7 @@ describe("toProseDoc", () => {
               formatting: {
                 runProperties: {
                   bold: true,
+                  italic: true,
                 },
               },
               content: [
@@ -656,11 +657,19 @@ describe("toProseDoc", () => {
     const paragraph = doc.firstChild;
     const text = paragraph?.firstChild;
 
-    expect(paragraph?.attrs._originalFormatting.runProperties.bold).toBe(true);
-    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(false);
-    expect(text?.marks.find((mark) => mark.type.name === "runFormattingOverride")?.attrs.bold).toBe(
-      false,
+    const emphasisMarks = ["bold", "italic"] as const;
+    const formattingOverride = text?.marks.find(
+      (mark) => mark.type.name === "runFormattingOverride",
     );
+
+    expect(paragraph?.attrs._originalFormatting.runProperties).toMatchObject({
+      bold: true,
+      italic: true,
+    });
+    for (const markName of emphasisMarks) {
+      expect(text?.marks.some((mark) => mark.type.name === markName)).toBe(false);
+      expect(formattingOverride?.attrs[markName]).toBe(false);
+    }
     expect(text?.marks.find((mark) => mark.type.name === "characterStyle")?.attrs.styleId).toBe(
       "BodyCharacter",
     );
@@ -670,7 +679,10 @@ describe("toProseDoc", () => {
     const rebuiltRun =
       rebuiltParagraph?.type === "paragraph" ? rebuiltParagraph.content.at(0) : null;
 
-    expect(rebuiltParagraph?.formatting?.runProperties.bold).toBe(true);
+    expect(rebuiltParagraph?.formatting?.runProperties).toMatchObject({
+      bold: true,
+      italic: true,
+    });
     expect(rebuiltRun?.type === "run" ? rebuiltRun.formatting?.styleId : null).toBe(
       "BodyCharacter",
     );

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -136,7 +136,7 @@ describe("toProseDoc", () => {
     expect(doc.firstChild?.attrs.spacingExplicit).toBeNull();
   });
 
-  test("applies oneNDA paragraph mark defaults to unformatted visible text like Word", () => {
+  test("applies paragraph-mark defaults to otherwise unformatted visible text", () => {
     const document: Document = {
       package: {
         document: {
@@ -172,7 +172,7 @@ describe("toProseDoc", () => {
     expect(text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe("Arial");
   });
 
-  test("keeps oneNDA heading direct run formatting ahead of paragraph mark defaults", () => {
+  test("keeps direct run formatting ahead of paragraph-mark defaults", () => {
     const document: Document = {
       package: {
         document: {
@@ -613,6 +613,66 @@ describe("toProseDoc", () => {
     expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(false);
     expect(text?.marks.find((mark) => mark.type.name === "runFormattingOverride")?.attrs.bold).toBe(
       false,
+    );
+  });
+
+  test("does not leak paragraph-mark bold through a character-style reference", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  bold: true,
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    styleId: "BodyCharacter",
+                  },
+                  content: [{ type: "text", text: "Visible body text" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          styles: [
+            {
+              styleId: "BodyCharacter",
+              type: "character",
+              rPr: {},
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = doc.firstChild;
+    const text = paragraph?.firstChild;
+
+    expect(paragraph?.attrs._originalFormatting.runProperties.bold).toBe(true);
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(false);
+    expect(text?.marks.find((mark) => mark.type.name === "runFormattingOverride")?.attrs.bold).toBe(
+      false,
+    );
+    expect(text?.marks.find((mark) => mark.type.name === "characterStyle")?.attrs.styleId).toBe(
+      "BodyCharacter",
+    );
+
+    const rebuilt = fromProseDoc(doc, document);
+    const rebuiltParagraph = rebuilt.package.document.content.at(0);
+    const rebuiltRun =
+      rebuiltParagraph?.type === "paragraph" ? rebuiltParagraph.content.at(0) : null;
+
+    expect(rebuiltParagraph?.formatting?.runProperties.bold).toBe(true);
+    expect(rebuiltRun?.type === "run" ? rebuiltRun.formatting?.styleId : null).toBe(
+      "BodyCharacter",
     );
   });
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -244,10 +244,8 @@ function convertParagraph(
     paragraph.formatting?.runProperties,
     styleResolver,
   );
-  // Word does not propagate paragraph-mark-only visual decorations
-  // (highlight, shading) to body runs — they paint the pilcrow alone. Strip
-  // them off the inheritance path so a `<w:pPr><w:rPr><w:highlight/></w:rPr>`
-  // used to mark just the paragraph glyph doesn't bleed onto every run.
+  // Paragraph-mark-only visual decorations (highlight, shading) paint the
+  // paragraph glyph alone. Strip them from the body-run inheritance path.
   let inheritableParagraphRunFormatting: TextFormatting | undefined;
   if (paragraphRunFormatting && !isTocParagraph) {
     inheritableParagraphRunFormatting = stripParagraphMarkOnlyFormatting(paragraphRunFormatting);
@@ -269,7 +267,9 @@ function convertParagraph(
         ? suppressParagraphMarkFormatting(baseRunFormatting, undefined, formatting)
         : baseRunFormatting;
     }
-    if (!hasDirectRunFormatting(formatting)) {
+    const hasExplicitRunFormatting =
+      hasDirectRunFormatting(formatting) || formatting?.styleId !== undefined;
+    if (!hasExplicitRunFormatting) {
       return defaultRunFormatting;
     }
     return suppressParagraphMarkFormatting(


### PR DESCRIPTION
## Summary

- Treat character-style references as explicit body-run formatting boundaries.
- Preserve paragraph-mark metadata and character-style references across round trips.
- Add a synthetic regression for paragraph-mark emphasis isolation.

## Verification

- `bun test packages/core/src/prosemirror/conversion/toProseDoc.test.ts` (30 passed)
- Layout comparison score: 0.8977 to 0.9318
- Aligned lines: 85/88 to 88/88; line-break and text mismatches: 1 each to 0
- `bun audit` (no vulnerabilities found)
- Local lint and typecheck intentionally deferred to CI; CI runs both commands.

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed paragraph-level bold formatting incorrectly carrying over to text using a character-style reference.
  * Preserved character-style references and explicit run-formatting overrides when converting and rebuilding documents.
  * Improved handling of paragraph-only visual formatting. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->