### PR TITLE
fix: compare vertical layout by text baseline

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -63,6 +63,7 @@ describe("compareGeoms", () => {
         text: "Left segment",
         xPt: 45,
         yPt: 100,
+        baselinePt: 109,
         widthPt: 90,
         logicalLineGroup: "layout-line:7",
       }),
@@ -70,6 +71,7 @@ describe("compareGeoms", () => {
         text: "Right segment",
         xPt: 350,
         yPt: 100,
+        baselinePt: 111,
         widthPt: 100,
         logicalLineGroup: "layout-line:7",
       }),
@@ -78,6 +80,7 @@ describe("compareGeoms", () => {
     expect(merged).toHaveLength(1);
     expect(merged[0]?.normText).toBe(normalizeLineText("Left segment Right segment"));
     expect(merged[0]?.logicalLineGroup).toBe("layout-line:7");
+    expect(merged[0]?.baselinePt).toBe(110);
   });
 
   test("keeps wide same-row segments from different logical lines separate", () => {
@@ -294,6 +297,66 @@ describe("compareGeoms", () => {
     expect(yDrifts[0]).toMatchObject({ kind: "y-drift", text: "Bravo line" });
     expect(result.medianYOffsetPt).toBe(0);
     expect(result.score).toBeCloseTo(2 / 3);
+  });
+
+  test("matching baselines ignore glyph-dependent ink-top differences", () => {
+    const texts = ["Alpha", "a", "Bravo"];
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({
+            text,
+            yPt: [72, 94, 108][index] ?? 0,
+            baselinePt: 80 + index * 18,
+          }),
+        ),
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({
+            text,
+            yPt: 70 + index * 18,
+            baselinePt: 80 + index * 18,
+          }),
+        ),
+      }),
+    ]);
+
+    const result = compareGeoms(reference, folio);
+
+    expect(result.divergences.filter((item) => item.kind === "y-drift")).toEqual([]);
+    expect(result.medianYOffsetPt).toBe(0);
+    expect(result.score).toBe(1);
+  });
+
+  test("baseline comparison still reports a real one-line vertical excursion", () => {
+    const texts = ["Alpha", "Bravo", "Charlie"];
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({ text, yPt: 72 + index * 18, baselinePt: 80 + index * 18 }),
+        ),
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({
+            text,
+            yPt: 72 + index * 18,
+            baselinePt: 80 + index * 18 + (index === 1 ? 6 : 0),
+          }),
+        ),
+      }),
+    ]);
+
+    const result = compareGeoms(reference, folio);
+
+    expect(result.divergences.filter((item) => item.kind === "y-drift")).toEqual([
+      { kind: "y-drift", page: 1, text: "Bravo", residualPt: 6 },
+    ]);
   });
 
   test("an outlier on the first line is attributed to the first line", () => {

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -179,6 +179,23 @@ describe("toPageGeom", () => {
     expect(page.lines[0]?.heightPt).toBeCloseTo(20 * PX_TO_PT, 5);
   });
 
+  test("converts an extracted baseline to page-relative points", () => {
+    const rawPage = makeRawPage({
+      pageRect: rect(100, 50, 816, 1056),
+      lines: [
+        makeRawLine({
+          text: "Hello",
+          rect: rect(196, 146, 200, 20),
+          baselineTop: 162,
+        }),
+      ],
+    });
+
+    const page = toPageGeom(rawPage);
+
+    expect(page.lines[0]?.baselinePt).toBeCloseTo((162 - 50) * PX_TO_PT, 5);
+  });
+
   test("normalizes coordinates against a CSS-zoomed page (zoomFactor != 1)", () => {
     // Page laid out at 816 layout px, rendered at 50% zoom (visual rect
     // 408px wide). A line whose visual left edge is 48px from the visual

--- a/parity/__tests__/stextParse.test.ts
+++ b/parity/__tests__/stextParse.test.ts
@@ -185,4 +185,26 @@ describe("parseStextXml", () => {
     expect(box?.heightPt).toBe(15);
     expect(box?.region).toBe("unknown");
   });
+
+  test("uses the median non-whitespace character origin as the line baseline", () => {
+    const chars = [
+      charEl("A", "0 10 10 10 0 20 10 20").replace('y="0"', 'y="18"'),
+      charEl(" ", "10 10 20 10 10 20 20 20").replace('y="0"', 'y="99"'),
+      charEl("B", "20 10 30 10 20 20 30 20").replace('y="0"', 'y="20"'),
+      charEl("C", "30 10 40 10 30 20 40 20").replace('y="0"', 'y="22"'),
+    ].join("");
+    const xmlLine = `<line bbox="0 10 40 20" wmode="0" dir="1 0" flags="0"><font name="ArialMT" size="12">${chars}</font></line>`;
+    const pages = parseStextXml(documentEl(pageEl(1, "612", "792", xmlLine)));
+
+    expect(pages[0]?.lines[0]?.baselinePt).toBe(20);
+  });
+
+  test("omits the baseline when character origins are unavailable", () => {
+    const charWithoutOrigin =
+      '<char c="A" quad="0 10 10 10 0 20 10 20" x="0" bidi="0" color="#000000" alpha="#ff" flags="16"/>';
+    const xmlLine = `<line bbox="0 10 10 20" wmode="0" dir="1 0" flags="0"><font name="ArialMT" size="12">${charWithoutOrigin}</font></line>`;
+    const pages = parseStextXml(documentEl(pageEl(1, "612", "792", xmlLine)));
+
+    expect(pages[0]?.lines[0]?.baselinePt).toBeUndefined();
+  });
 });

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -215,6 +215,12 @@ const horizontalGap = (a: LineBox, b: LineBox): number => {
   return Math.max(a.xPt, b.xPt) - Math.min(a.xPt + a.widthPt, b.xPt + b.widthPt);
 };
 
+const mergeBaselines = (a: number | undefined, b: number | undefined): number | undefined => {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return (a + b) / 2;
+};
+
 const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
   const [left, right] = a.xPt <= b.xPt ? [a, b] : [b, a];
   const xPt = Math.min(a.xPt, b.xPt);
@@ -228,6 +234,7 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
     left.logicalLineGroup !== undefined && left.logicalLineGroup === right.logicalLineGroup
       ? left.logicalLineGroup
       : undefined;
+  const baselinePt = mergeBaselines(a.baselinePt, b.baselinePt);
   return {
     text,
     normText: normalizeLineText(text),
@@ -235,6 +242,7 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
     yPt,
     widthPt: Math.max(a.xPt + a.widthPt, b.xPt + b.widthPt) - xPt,
     heightPt: Math.max(a.yPt + a.heightPt, b.yPt + b.heightPt) - yPt,
+    ...(baselinePt !== undefined ? { baselinePt } : {}),
     region: left.region,
     ...(fontName !== undefined ? { fontName } : {}),
     ...(fontSizePt !== undefined ? { fontSizePt } : {}),
@@ -608,6 +616,8 @@ const pageRegionKey = (page: number, region: LineBox["region"]): string =>
 const matchedPageRegionKey = (word: FlatLine, folio: FlatLine): string =>
   pageRegionKey(word.page, folio.line.region);
 
+const verticalAnchorPt = (line: LineBox): number => line.baselinePt ?? line.yPt;
+
 type PageRegionMedianYOffsetsOptions = {
   matches: Extract<ResolvedItem, { kind: "match" }>[];
   wordFlat: FlatLine[];
@@ -636,7 +646,7 @@ const pageRegionMedianYOffsets = ({
     }
     const key = matchedPageRegionKey(w, f);
     const deltas = deltasByPageRegion.get(key) ?? [];
-    deltas.push(f.line.yPt - w.line.yPt);
+    deltas.push(verticalAnchorPt(f.line) - verticalAnchorPt(w.line));
     deltasByPageRegion.set(key, deltas);
   }
   for (const { reference, candidate } of equivalentRows) {
@@ -645,7 +655,7 @@ const pageRegionMedianYOffsets = ({
     }
     const key = matchedPageRegionKey(reference, candidate);
     const deltas = deltasByPageRegion.get(key) ?? [];
-    deltas.push(candidate.line.yPt - reference.line.yPt);
+    deltas.push(verticalAnchorPt(candidate.line) - verticalAnchorPt(reference.line));
     deltasByPageRegion.set(key, deltas);
   }
   return new Map([...deltasByPageRegion].map(([key, deltas]) => [key, median(deltas)]));
@@ -683,20 +693,23 @@ const segmentedYResiduals = (
 ): Map<string, number> => {
   const matchesByPageRegion = new Map<string, StableYMatch[]>();
   for (const match of matches) {
-    const word = wordFlat[match.wordIdx];
-    const folio = folioFlat[match.folioIdx];
+    const reference = wordFlat[match.wordIdx];
+    const candidate = folioFlat[match.folioIdx];
     if (
-      !word ||
-      !folio ||
-      word.page !== folio.page ||
-      !hasStableVerticalInk(word.line) ||
-      !hasStableVerticalInk(folio.line)
+      !reference ||
+      !candidate ||
+      reference.page !== candidate.page ||
+      !hasStableVerticalInk(reference.line) ||
+      !hasStableVerticalInk(candidate.line)
     ) {
       continue;
     }
-    const key = matchedPageRegionKey(word, folio);
+    const key = matchedPageRegionKey(reference, candidate);
     const stableMatches = matchesByPageRegion.get(key) ?? [];
-    stableMatches.push({ match, offsetPt: folio.line.yPt - word.line.yPt });
+    stableMatches.push({
+      match,
+      offsetPt: verticalAnchorPt(candidate.line) - verticalAnchorPt(reference.line),
+    });
     matchesByPageRegion.set(key, stableMatches);
   }
 
@@ -854,7 +867,8 @@ const diffMatches = ({
               medianYOffsetsByPageRegion.get(
                 pageRegionKey(reference.page, candidate.line.region),
               ) ?? 0;
-            const residual = candidate.line.yPt - reference.line.yPt - medianOffset;
+            const residual =
+              verticalAnchorPt(candidate.line) - verticalAnchorPt(reference.line) - medianOffset;
             if (Math.abs(residual) > tolerances.yResidualPt) {
               yDelta = residual;
               orderedDivergences.push({

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -174,6 +174,8 @@ export type RawRect = { left: number; top: number; width: number; height: number
 export type RawLine = {
   text: string;
   rect: RawRect;
+  /** Viewport-relative CSS-pixel position of the originating line's baseline. */
+  baselineTop?: number;
   region: Region;
   /** True when the line's ink box falls fully outside an overflow-clipping ancestor. */
   fullyClipped?: boolean;
@@ -257,6 +259,10 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
     const yPt = (rawLine.rect.top - rawPage.pageRect.top) * zoomFactor * PX_TO_PT;
     const lineWidthPt = rawLine.rect.width * zoomFactor * PX_TO_PT;
     const lineHeightPt = rawLine.rect.height * zoomFactor * PX_TO_PT;
+    const baselinePt =
+      rawLine.baselineTop === undefined
+        ? undefined
+        : (rawLine.baselineTop - rawPage.pageRect.top) * zoomFactor * PX_TO_PT;
 
     const fontName = parseFirstFontFamily(rawLine.fontFamilyRaw);
     const fontSizePt = rawLine.fontSizePx !== undefined ? rawLine.fontSizePx * PX_TO_PT : undefined;
@@ -266,6 +272,7 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
       normText,
       xPt,
       yPt,
+      ...(baselinePt !== undefined ? { baselinePt } : {}),
       widthPt: lineWidthPt,
       heightPt: lineHeightPt,
       region: rawLine.region,
@@ -601,6 +608,19 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
         return fallback;
       };
       const lines = lineEls.flatMap((lineEl, lineIndex) => {
+        const baselineProbe = document.createElement("span");
+        baselineProbe.setAttribute("aria-hidden", "true");
+        baselineProbe.style.display = "inline-block";
+        baselineProbe.style.width = "0";
+        baselineProbe.style.height = "0";
+        baselineProbe.style.margin = "0";
+        baselineProbe.style.padding = "0";
+        baselineProbe.style.border = "0";
+        baselineProbe.style.verticalAlign = "baseline";
+        lineEl.append(baselineProbe);
+        const baselineTop = baselineProbe.getBoundingClientRect().top;
+        baselineProbe.remove();
+
         const segmentInkRect = (segmentEl: HTMLElement): DOMRect | null => {
           if (
             segmentEl.matches("img, svg, canvas, video") ||
@@ -736,6 +756,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
         const toRawLine = (text: string, rect: DOMRect, sourceEl: HTMLElement | null) => ({
           text,
           rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
+          ...(Number.isFinite(baselineTop) ? { baselineTop } : {}),
           region,
           ...(isFullyClipped(sourceEl, rect) ? { fullyClipped: true } : {}),
           ...(visualGroup !== undefined ? { visualGroup } : {}),

--- a/parity/stextParse.ts
+++ b/parity/stextParse.ts
@@ -94,7 +94,7 @@ const extractFirstFont = (lineContent: string): LineFont => {
   };
 };
 
-type ParsedChars = { text: string; inkBbox: Bbox | null };
+type ParsedChars = { text: string; inkBbox: Bbox | null; baselinePt: number | null };
 
 /** Reconstruct line text from `<char c="...">` elements (reading order) and
  * compute the ink bbox as the union of the NON-whitespace chars' quads. The
@@ -105,6 +105,7 @@ type ParsedChars = { text: string; inkBbox: Bbox | null };
 const parseChars = (lineContent: string): ParsedChars => {
   let chars = "";
   let ink: Bbox | null = null;
+  const baselines: number[] = [];
   CHAR_RE.lastIndex = 0;
   let charMatch: RegExpExecArray | null = CHAR_RE.exec(lineContent);
   while (charMatch !== null) {
@@ -114,6 +115,13 @@ const parseChars = (lineContent: string): ParsedChars => {
     if (c === null) continue;
     chars += c;
     if (c.trim() === "") continue;
+    const baselineAttr = extractAttr(charAttrs, "y");
+    if (baselineAttr !== null) {
+      const baseline = Number(baselineAttr);
+      if (Number.isFinite(baseline)) {
+        baselines.push(baseline);
+      }
+    }
     const quad = parseQuad(extractAttr(charAttrs, "quad"));
     if (!quad) continue;
     ink =
@@ -126,7 +134,15 @@ const parseChars = (lineContent: string): ParsedChars => {
             y1: Math.max(ink.y1, quad.y1),
           };
   }
-  return { text: chars, inkBbox: ink };
+  baselines.sort((a, b) => a - b);
+  const middle = Math.floor(baselines.length / 2);
+  let baselinePt: number | null = null;
+  if (baselines.length % 2 === 0 && baselines.length > 0) {
+    baselinePt = ((baselines[middle - 1] ?? 0) + (baselines[middle] ?? 0)) / 2;
+  } else if (baselines.length > 0) {
+    baselinePt = baselines[middle] ?? null;
+  }
+  return { text: chars, inkBbox: ink, baselinePt };
 };
 
 /** A `quad="x0 y0 x1 y1 x2 y2 x3 y3"` attribute (4 corners) reduced to its
@@ -162,7 +178,7 @@ const parseLines = (pageContent: string): LineBox[] => {
     const bboxAttr = extractAttr(lineAttrs, "bbox");
     const lineBbox = bboxAttr === null ? null : parseBbox(bboxAttr);
 
-    const { text: charText, inkBbox } = parseChars(lineContent);
+    const { text: charText, inkBbox, baselinePt } = parseChars(lineContent);
     const font = extractFirstFont(lineContent);
     const extractedText = charText !== "" ? charText : (extractAttr(lineAttrs, "text") ?? "");
     const text = normalizeFontEncodedText(extractedText, font.name);
@@ -177,6 +193,7 @@ const parseLines = (pageContent: string): LineBox[] => {
       normText,
       xPt: bbox.x0,
       yPt: bbox.y0,
+      ...(baselinePt !== null ? { baselinePt } : {}),
       widthPt: bbox.x1 - bbox.x0,
       heightPt: bbox.y1 - bbox.y0,
       ...(font.name !== undefined ? { fontName: font.name } : {}),

--- a/parity/types.ts
+++ b/parity/types.ts
@@ -30,6 +30,9 @@ export type LineBox = {
    * are ink bounds and folio-side boxes are line-height boxes, so absolute
    * yPt is only compared after per-page median-offset correction. */
   yPt: number;
+  /** Text baseline in pt from the page top, when the extractor exposes one.
+   * Vertical comparison prefers this glyph-independent anchor over yPt. */
+  baselinePt?: number;
   widthPt: number;
   heightPt: number;
   /** Primary font of the line (first run), when known. */
@@ -111,7 +114,7 @@ export type ParityResult = {
   folioPages: number;
   totalReferenceLines: number;
   matchedLines: number;
-  /** Systematic per-doc vertical offset (median of per-line y deltas);
+  /** Systematic per-doc vertical offset (median of per-line anchor deltas);
    * informational, already subtracted from y-drift residuals. */
   medianYOffsetPt: number;
   divergences: Divergence[];


### PR DESCRIPTION
## Summary

- capture text baselines from both geometry extractors
- compare vertical placement using baselines when available, retaining the line-top fallback
- add regressions for glyph-dependent ink bounds and true baseline excursions

## Validation

- `bun test parity/__tests__/compare.test.ts parity/__tests__/stextParse.test.ts parity/__tests__/folioExtract.test.ts` (73 passed)
- focused same-font comparison: 95.6% to 100.0%, with all pages and lines matched
- `bun audit` (no vulnerabilities)
- lint and typecheck delegated to CI

CC on behalf of @jan-kubica