### PR TITLE
fix: resolve paragraph indent inheritance

### DIFF
--- a/.changeset/calm-indent-cascade.md
+++ b/.changeset/calm-indent-cascade.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve explicit first-line paragraph indents ahead of inherited hanging indents.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -136,6 +136,37 @@ describe("toProseDoc", () => {
     expect(doc.firstChild?.attrs.spacingExplicit).toBeNull();
   });
 
+  test("direct first-line indent clears a hanging indent inherited from the paragraph style", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "Heading", indentFirstLine: 720 },
+              content: [],
+            },
+          ],
+        },
+        styles: {
+          styles: [
+            {
+              styleId: "Heading",
+              type: "paragraph",
+              pPr: { indentLeft: 360, indentFirstLine: -180, hangingIndent: true },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+
+    expect(doc.firstChild?.attrs.indentLeft).toBe(360);
+    expect(doc.firstChild?.attrs.indentFirstLine).toBe(720);
+    expect(doc.firstChild?.attrs.hangingIndent).toBe(false);
+  });
+
   test("applies paragraph-mark defaults to otherwise unformatted visible text", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -600,10 +600,11 @@ function paragraphFormattingToAttrs(
     const numberingRemoved =
       formatting?.numPr?.numId === 0 && stylePpr?.numPr !== undefined && stylePpr.numPr.numId !== 0;
     const numberingStyleIndent = numberingRemoved ? undefined : stylePpr;
-    set("indentLeft", formatting?.indentLeft ?? numberingStyleIndent?.indentLeft);
+    const effectiveIndent = mergeParagraphFormatting(numberingStyleIndent, formatting);
+    set("indentLeft", effectiveIndent?.indentLeft);
     set("indentRight", formatting?.indentRight ?? stylePpr?.indentRight);
-    set("indentFirstLine", formatting?.indentFirstLine ?? numberingStyleIndent?.indentFirstLine);
-    set("hangingIndent", formatting?.hangingIndent ?? numberingStyleIndent?.hangingIndent);
+    set("indentFirstLine", effectiveIndent?.indentFirstLine);
+    set("hangingIndent", effectiveIndent?.hangingIndent);
     set("borders", formatting?.borders ?? stylePpr?.borders);
     set("shading", formatting?.shading ?? stylePpr?.shading);
     set("tabs", formatting?.tabs ?? stylePpr?.tabs);

--- a/packages/core/src/utils/paragraphFormattingMerge.test.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.test.ts
@@ -40,6 +40,16 @@ describe("mergeParagraphFormatting", () => {
     expect(result?.numPr).toEqual({ numId: 4, ilvl: 2 });
   });
 
+  test("explicit first-line indent clears an inherited hanging indent", () => {
+    const result = mergeParagraphFormatting(
+      { indentFirstLine: -360, hangingIndent: true },
+      { indentFirstLine: 720 },
+    );
+
+    expect(result?.indentFirstLine).toBe(720);
+    expect(result?.hangingIndent).toBe(false);
+  });
+
   test("replaces tab collections and merges paragraph mark run properties", () => {
     const sourceTabs: NonNullable<ParagraphFormatting["tabs"]> = [
       { position: 720, alignment: "left" },

--- a/packages/core/src/utils/paragraphFormattingMerge.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.ts
@@ -70,6 +70,10 @@ export function mergeParagraphFormatting(
     copyDefinedParagraphProperty(result, source, key);
   }
 
+  if (source.indentFirstLine !== undefined) {
+    result.hangingIndent = source.hangingIndent === true;
+  }
+
   const mergedRunProperties = mergeTextFormatting(result.runProperties, source.runProperties);
   if (mergedRunProperties) {
     result.runProperties = mergedRunProperties;


### PR DESCRIPTION
## Summary

- clear inherited hanging-indent semantics when direct formatting sets a first-line position
- share paragraph-format merge behavior with the document conversion path
- add synthetic coverage for style-chain and direct-format precedence

CC on behalf of @jan-kubica