### PR TITLE
fix: honor omitted section start defaults

### DIFF
--- a/.changeset/gentle-section-defaults.md
+++ b/.changeset/gentle-section-defaults.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor the default next-page behavior for omitted section start types.

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -4,6 +4,7 @@ import { layoutDocument } from "./index";
 import type {
   ColumnBreakBlock,
   FlowBlock,
+  Measure,
   ParagraphBlock,
   ParagraphMeasure,
   SectionBreakBlock,
@@ -143,6 +144,48 @@ describe("continuous section break geometry", () => {
     );
     expect(secondColumnFragment?.x).toBe(350);
     expect(secondColumnFragment?.width).toBe(300);
+  });
+
+  test("an omitted next section type defaults to a new page", () => {
+    const first = paragraph("first", 100);
+    const firstBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "first-break",
+      type: "continuous",
+    };
+    const second = paragraph("second", 100);
+    const omittedTypeBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "omitted-type-break",
+    };
+    const third = paragraph("third", 100);
+    const blocks: FlowBlock[] = [
+      first.block,
+      firstBreak,
+      second.block,
+      omittedTypeBreak,
+      third.block,
+    ];
+    const measures = [
+      first.measure,
+      { kind: "sectionBreak" },
+      second.measure,
+      { kind: "sectionBreak" },
+      third.measure,
+    ] satisfies Measure[];
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      bodyBreakType: "continuous",
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0]?.fragments.map((fragment) => fragment.blockId)).toEqual(["first"]);
+    expect(result.pages[1]?.fragments.map((fragment) => fragment.blockId)).toEqual([
+      "second",
+      "third",
+    ]);
   });
 
   test("content after a continuous column section resumes below its tallest column", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -56,6 +56,7 @@ export type SectionLayoutConfig = {
 };
 
 const DEFAULT_COLUMNS: ColumnLayout = { count: 1, gap: 0 };
+const DEFAULT_SECTION_BREAK_TYPE = "nextPage";
 
 export function collectSectionConfigs(
   blocks: FlowBlock[],
@@ -356,10 +357,7 @@ export function layoutDocument(
     bodyConfig,
     finalConfig,
   );
-  const sectionBreakTypes = [
-    ...breakIndices.map((index) => (blocks[index] as SectionBreakBlock).type),
-    options.bodyBreakType,
-  ];
+  const sectionBreakTypes = breakIndices.map((index) => (blocks[index] as SectionBreakBlock).type);
   const initialConfig = sectionConfigs.at(0) ?? bodyConfig;
 
   // Create paginator with first section's columns
@@ -486,10 +484,15 @@ export function layoutDocument(
         break;
 
       case "sectionBreak": {
-        // Use the NEXT section's columns; for break type, prefer next section's
-        // type but fall back to current break's type (preserves explicit 'continuous')
+        // A concrete following section with no authored type uses the format
+        // default. Only the final body retains the current type as a fallback
+        // when direct engine callers cannot supply its section properties.
         const nextSectionConfig = sectionConfigs[sectionIdx + 1] ?? initialConfig;
-        const nextType = sectionBreakTypes[sectionIdx + 1] ?? sectionBreakTypes[sectionIdx];
+        let nextType =
+          options.bodyBreakType ?? sectionBreakTypes[sectionIdx] ?? DEFAULT_SECTION_BREAK_TYPE;
+        if (sectionIdx + 1 < sectionBreakTypes.length) {
+          nextType = sectionBreakTypes[sectionIdx + 1] ?? DEFAULT_SECTION_BREAK_TYPE;
+        }
         handleSectionBreak(
           block as SectionBreakBlock,
           paginator,


### PR DESCRIPTION
## Summary

- treat an omitted type on a concrete following section as the next-page default
- preserve the final-body fallback for direct layout callers
- add a synthetic multi-section regression

## Validation

- `bun test packages/core/src/layout-engine/continuousSectionGeometry.test.ts` (9 passed)
- focused same-font comparison: 75.8% to 82.3%; three pagination divergences removed
- `bun run changeset:check`
- `bun audit` (no vulnerabilities)
- lint and typecheck delegated to CI

CC on behalf of @jan-kubica