### PR TITLE
fix: stabilize parity baseline comparison

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -331,6 +331,34 @@ describe("compareGeoms", () => {
     expect(result.score).toBe(1);
   });
 
+  test("uses ink tops for both lines when only one baseline is available", () => {
+    const texts = ["Alpha", "Bravo", "Charlie"];
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({ text, yPt: 72 + index * 18, baselinePt: 80 + index * 18 }),
+        ),
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: texts.map((text, index) =>
+          makeLine({
+            text,
+            yPt: 72 + index * 18,
+            ...(index === 0 ? {} : { baselinePt: 80 + index * 18 }),
+          }),
+        ),
+      }),
+    ]);
+
+    const result = compareGeoms(reference, folio);
+
+    expect(result.divergences.filter((item) => item.kind === "y-drift")).toEqual([]);
+    expect(result.medianYOffsetPt).toBe(0);
+    expect(result.score).toBe(1);
+  });
+
   test("baseline comparison still reports a real one-line vertical excursion", () => {
     const texts = ["Alpha", "Bravo", "Charlie"];
     const reference = makeDoc("folio", [

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -6,6 +6,7 @@ import {
   computeZoomFactor,
   formatNavigationFailure,
   formatServerStartFailure,
+  isPlausibleBaseline,
   meaningfulTextRange,
   parseCssFontFamilies,
   parseFirstFontFamily,
@@ -142,6 +143,16 @@ describe("computeZoomFactor", () => {
   });
 });
 
+describe("isPlausibleBaseline", () => {
+  test("rejects a zero-width probe that wrapped below the extracted ink row", () => {
+    expect(isPlausibleBaseline(190, rect(0, 146, 200, 20))).toBe(false);
+  });
+
+  test("keeps a baseline near the extracted ink row", () => {
+    expect(isPlausibleBaseline(174, rect(0, 146, 200, 20))).toBe(true);
+  });
+});
+
 describe("parseFirstFontFamily", () => {
   test("takes the first family and strips double quotes", () => {
     expect(parseFirstFontFamily('"Calibri", "Arial", sans-serif')).toBe("Calibri");
@@ -194,6 +205,23 @@ describe("toPageGeom", () => {
     const page = toPageGeom(rawPage);
 
     expect(page.lines[0]?.baselinePt).toBeCloseTo((162 - 50) * PX_TO_PT, 5);
+  });
+
+  test("omits a baseline probe that wrapped onto the following visual row", () => {
+    const rawPage = makeRawPage({
+      pageRect: rect(100, 50, 816, 1056),
+      lines: [
+        makeRawLine({
+          text: "Full line",
+          rect: rect(196, 146, 200, 20),
+          baselineTop: 190,
+        }),
+      ],
+    });
+
+    const page = toPageGeom(rawPage);
+
+    expect(page.lines[0]?.baselinePt).toBeUndefined();
   });
 
   test("normalizes coordinates against a CSS-zoomed page (zoomFactor != 1)", () => {

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -616,7 +616,17 @@ const pageRegionKey = (page: number, region: LineBox["region"]): string =>
 const matchedPageRegionKey = (word: FlatLine, folio: FlatLine): string =>
   pageRegionKey(word.page, folio.line.region);
 
-const verticalAnchorPt = (line: LineBox): number => line.baselinePt ?? line.yPt;
+type VerticalOffsetOptions = {
+  reference: LineBox;
+  candidate: LineBox;
+};
+
+const verticalOffsetPt = ({ reference, candidate }: VerticalOffsetOptions): number => {
+  if (reference.baselinePt !== undefined && candidate.baselinePt !== undefined) {
+    return candidate.baselinePt - reference.baselinePt;
+  }
+  return candidate.yPt - reference.yPt;
+};
 
 type PageRegionMedianYOffsetsOptions = {
   matches: Extract<ResolvedItem, { kind: "match" }>[];
@@ -646,7 +656,7 @@ const pageRegionMedianYOffsets = ({
     }
     const key = matchedPageRegionKey(w, f);
     const deltas = deltasByPageRegion.get(key) ?? [];
-    deltas.push(verticalAnchorPt(f.line) - verticalAnchorPt(w.line));
+    deltas.push(verticalOffsetPt({ reference: w.line, candidate: f.line }));
     deltasByPageRegion.set(key, deltas);
   }
   for (const { reference, candidate } of equivalentRows) {
@@ -655,7 +665,7 @@ const pageRegionMedianYOffsets = ({
     }
     const key = matchedPageRegionKey(reference, candidate);
     const deltas = deltasByPageRegion.get(key) ?? [];
-    deltas.push(verticalAnchorPt(candidate.line) - verticalAnchorPt(reference.line));
+    deltas.push(verticalOffsetPt({ reference: reference.line, candidate: candidate.line }));
     deltasByPageRegion.set(key, deltas);
   }
   return new Map([...deltasByPageRegion].map(([key, deltas]) => [key, median(deltas)]));
@@ -708,7 +718,7 @@ const segmentedYResiduals = (
     const stableMatches = matchesByPageRegion.get(key) ?? [];
     stableMatches.push({
       match,
-      offsetPt: verticalAnchorPt(candidate.line) - verticalAnchorPt(reference.line),
+      offsetPt: verticalOffsetPt({ reference: reference.line, candidate: candidate.line }),
     });
     matchesByPageRegion.set(key, stableMatches);
   }
@@ -868,7 +878,8 @@ const diffMatches = ({
                 pageRegionKey(reference.page, candidate.line.region),
               ) ?? 0;
             const residual =
-              verticalAnchorPt(candidate.line) - verticalAnchorPt(reference.line) - medianOffset;
+              verticalOffsetPt({ reference: reference.line, candidate: candidate.line }) -
+              medianOffset;
             if (Math.abs(residual) > tolerances.yResidualPt) {
               yDelta = residual;
               orderedDivergences.push({

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -213,6 +213,23 @@ export const computeZoomFactor = (offsetWidth: number, pageRectWidth: number): n
   return offsetWidth / pageRectWidth;
 };
 
+const MIN_BASELINE_OFFSET_RATIO = -0.5;
+const MAX_BASELINE_OFFSET_RATIO = 1.5;
+
+/**
+ * Baseline probes are zero-width inline boxes. On a visually full line, a
+ * browser can wrap the probe onto the next row even though the document text
+ * itself did not wrap. Keep only probe positions near the extracted ink box;
+ * the comparator can fall back to ink-top geometry for rejected probes.
+ */
+export const isPlausibleBaseline = (baselineTop: number, rect: RawRect): boolean => {
+  if (!Number.isFinite(baselineTop) || rect.height <= 0) {
+    return false;
+  }
+  const offsetRatio = (baselineTop - rect.top) / rect.height;
+  return offsetRatio >= MIN_BASELINE_OFFSET_RATIO && offsetRatio <= MAX_BASELINE_OFFSET_RATIO;
+};
+
 /** First font-family in a CSS `font-family` list, with surrounding quotes stripped. */
 export const parseFirstFontFamily = (fontFamilyRaw: string | undefined): string | undefined => {
   if (!fontFamilyRaw) {
@@ -260,7 +277,7 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
     const lineWidthPt = rawLine.rect.width * zoomFactor * PX_TO_PT;
     const lineHeightPt = rawLine.rect.height * zoomFactor * PX_TO_PT;
     const baselinePt =
-      rawLine.baselineTop === undefined
+      rawLine.baselineTop === undefined || !isPlausibleBaseline(rawLine.baselineTop, rawLine.rect)
         ? undefined
         : (rawLine.baselineTop - rawPage.pageRect.top) * zoomFactor * PX_TO_PT;
 


### PR DESCRIPTION
## Summary

- Reject baseline probes that wrapped outside the extracted ink row.
- Compare baselines only when both matched lines provide one; otherwise compare both ink tops.
- Add targeted regression coverage for probe validation and paired vertical anchors.

## Verification

- Parity unit suite: 145 passed, 0 failed.
- Dependency audit: no vulnerabilities found.
- Strict-font comparison score: 0.923 to 1.000.
- Local lint and typecheck intentionally deferred to CI; CI runs both commands.

CC on behalf of @jan-kubica