### PR TITLE
fix: constrain shallow list continuation wrapping

### DIFF
--- a/.changeset/gentle-list-continuations.md
+++ b/.changeset/gentle-list-continuations.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep shallow full-hanging justified list continuations within their measured line width.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -916,6 +916,35 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
+  test("keeps shallow full-hanging list continuations on rounding tolerance", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-shallow-list-continuation",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 18, hanging: 18 },
+            },
+          },
+          118,
+        );
+
+        expect(measure.lines).toHaveLength(3);
+      },
+      {
+        charWidth: fractionalWidth,
+      },
+    );
+  });
+
   test("keeps inset list continuation lines on the conservative tolerance", () => {
     withFakeTextMeasure(
       () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -1484,20 +1484,20 @@ export function measureParagraph(
             : 0;
         const widthTolerance =
           isJustifiedParagraph && !isShallowFullHangingListContinuation(block, isFirstLine)
-          ? Math.max(
-              WIDTH_TOLERANCE,
-              usesMarkerSpaceTolerance
-                ? (currentLine.regularSpaceWidth + regularSpaceWidth) *
-                    JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO
-                : currentLine.availableWidth *
-                    justifyShrinkToleranceRatio(
-                      block,
-                      isFirstLine,
-                      currentLine.regularSpaceCount + regularSpaces,
-                      currentLine.nonBreakingSpaceCount + nonBreakingSpaces,
-                    ),
-            )
-          : WIDTH_TOLERANCE;
+            ? Math.max(
+                WIDTH_TOLERANCE,
+                usesMarkerSpaceTolerance
+                  ? (currentLine.regularSpaceWidth + regularSpaceWidth) *
+                      JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO
+                  : currentLine.availableWidth *
+                      justifyShrinkToleranceRatio(
+                        block,
+                        isFirstLine,
+                        currentLine.regularSpaceCount + regularSpaces,
+                        currentLine.nonBreakingSpaceCount + nonBreakingSpaces,
+                      ),
+              )
+            : WIDTH_TOLERANCE;
 
         // If the word itself is longer than a line, hard-break by characters.
         // Use substring measurement (not char-by-char accumulation) to preserve

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -648,6 +648,22 @@ function usesSpaceBasedListMarkerTolerance(block: ParagraphBlock, isFirstLine: b
   );
 }
 
+function isShallowFullHangingListContinuation(
+  block: ParagraphBlock,
+  isFirstLine: boolean,
+): boolean {
+  if (isFirstLine || block.attrs?.listMarker === undefined) {
+    return false;
+  }
+  const hanging = block.attrs.indent?.hanging ?? 0;
+  const left = block.attrs.indent?.left ?? 0;
+  return (
+    hanging > 0 &&
+    hanging < DEFAULT_LIST_HANGING_INDENT_PX &&
+    Math.abs(left - hanging) <= WIDTH_TOLERANCE
+  );
+}
+
 function trimTrailingSpacesAndTabs(text: string): string {
   let end = text.length;
   while (end > 0) {
@@ -1461,14 +1477,16 @@ export function measureParagraph(
         const regularSpaces = countCompressibleSpaces(measuredWord);
         const nonBreakingSpaces = measuredWord.split("\u00a0").length - 1;
         const isFirstLine = lines.length === 0;
+        const usesMarkerSpaceTolerance = usesSpaceBasedListMarkerTolerance(block, isFirstLine);
         const regularSpaceWidth =
-          regularSpaces > 0 && usesSpaceBasedListMarkerTolerance(block, isFirstLine)
+          regularSpaces > 0 && usesMarkerSpaceTolerance
             ? regularSpaces * measureTextWidth(" ", style)
             : 0;
-        const widthTolerance = isJustifiedParagraph
+        const widthTolerance =
+          isJustifiedParagraph && !isShallowFullHangingListContinuation(block, isFirstLine)
           ? Math.max(
               WIDTH_TOLERANCE,
-              usesSpaceBasedListMarkerTolerance(block, isFirstLine)
+              usesMarkerSpaceTolerance
                 ? (currentLine.regularSpaceWidth + regularSpaceWidth) *
                     JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO
                 : currentLine.availableWidth *


### PR DESCRIPTION
## Summary

- keep shallow full-hanging justified list continuations within measured line width
- preserve standard-indent and inset-list wrapping behavior
- add focused regression coverage and a patch changeset

CC on behalf of @jan-kubica