### PR TITLE
fix: reconcile segmented comparison rows

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -616,6 +616,40 @@ describe("compareGeoms", () => {
     expect(result.score).toBe(1);
   });
 
+  test("reconciles a matched prefix with a trailing segment on the same visual row", () => {
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "Primary registration 123 VAT:",
+            xPt: 72,
+            yPt: 72,
+            widthPt: 180,
+          }),
+        ],
+      }),
+    ]);
+    const candidate = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "Primary registration 123",
+            xPt: 72,
+            yPt: 72,
+            widthPt: 120,
+          }),
+          makeLine({ text: "VAT:", xPt: 222, yPt: 72, widthPt: 30 }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(reference, candidate);
+
+    expect(result.divergences).toEqual([]);
+    expect(result.matchedLines).toBe(1);
+    expect(result.score).toBe(1);
+  });
+
   test("reconciles one segmented visual row inside a larger alignment gap", () => {
     const reference = makeDoc("folio", [
       makePage({

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -475,7 +475,76 @@ const resolveOps = (
     }
   }
   flushGap();
-  return resolved;
+  return reconcileMatchedRowSegments(resolved, wordFlat, folioFlat);
+};
+
+/**
+ * A high-similarity prefix can be selected as a direct match before alignment
+ * sees that the next segment completes the same visual row. Fold that trailing
+ * segment back into a one-to-many row so geometry is compared over the full
+ * row instead of reporting a text mismatch plus an extra line.
+ */
+const reconcileMatchedRowSegments = (
+  resolved: ResolvedItem[],
+  referenceFlat: FlatLine[],
+  candidateFlat: FlatLine[],
+): ResolvedItem[] => {
+  const reconciled: ResolvedItem[] = [];
+
+  for (let index = 0; index < resolved.length; index += 1) {
+    const item = resolved[index];
+    if (!item || item.kind !== "match") {
+      if (item) reconciled.push(item);
+      continue;
+    }
+
+    const next = resolved[index + 1];
+    const trailingKind = next?.kind === "missing" || next?.kind === "extra" ? next.kind : null;
+    if (!trailingKind) {
+      reconciled.push(item);
+      continue;
+    }
+
+    const referenceIdxs = [item.wordIdx];
+    const candidateIdxs = [item.folioIdx];
+    const anchor =
+      trailingKind === "missing" ? referenceFlat[item.wordIdx] : candidateFlat[item.folioIdx];
+    if (!anchor) {
+      reconciled.push(item);
+      continue;
+    }
+
+    let cursor = index + 1;
+    while (cursor < resolved.length) {
+      const trailing = resolved[cursor];
+      if (!trailing || trailing.kind !== trailingKind) break;
+      const flatLine =
+        trailing.kind === "missing"
+          ? referenceFlat[trailing.wordIdx]
+          : candidateFlat[trailing.folioIdx];
+      if (
+        !flatLine ||
+        flatLine.page !== anchor.page ||
+        flatLine.line.region !== anchor.line.region ||
+        !isSameVisualRow(anchor.line, flatLine.line)
+      ) {
+        break;
+      }
+      if (trailing.kind === "missing") referenceIdxs.push(trailing.wordIdx);
+      else candidateIdxs.push(trailing.folioIdx);
+      cursor += 1;
+    }
+
+    if (!equivalentSegmentedRows(referenceIdxs, candidateIdxs, referenceFlat, candidateFlat)) {
+      reconciled.push(item);
+      continue;
+    }
+
+    reconciled.push({ kind: "line-break", wordIdxs: referenceIdxs, folioIdxs: candidateIdxs });
+    index = cursor - 1;
+  }
+
+  return reconciled;
 };
 
 /**


### PR DESCRIPTION
Reconciles a direct text match with trailing segments only when they share a page, semantic region, visual row, and existing concatenation threshold. This keeps full-row geometry checks while avoiding duplicate text and extra-line findings.

Adds a synthetic regression for a widely separated trailing segment.

CC on behalf of @jan-kubica