### PR TITLE
fix: preserve Czech line-break rules

### DIFF
--- a/.changeset/calm-czech-wrapping.md
+++ b/.changeset/calm-czech-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve inherited language metadata and Czech one-letter preposition wrapping.

--- a/packages/core/src/docx/styleParser.test.ts
+++ b/packages/core/src/docx/styleParser.test.ts
@@ -22,6 +22,25 @@ describe("docDefaults presence (#909)", () => {
     const defs = parseStyleDefinitions(`<w:styles ${STYLES_NS}></w:styles>`, null);
     expect(defs.docDefaults).toBeUndefined();
   });
+
+  test("preserves document-default language metadata", () => {
+    const defs = parseStyleDefinitions(
+      `<w:styles ${STYLES_NS}>
+        <w:docDefaults>
+          <w:rPrDefault>
+            <w:rPr><w:lang w:val="cs-CZ" w:eastAsia="ja-JP" w:bidi="ar-SA"/></w:rPr>
+          </w:rPrDefault>
+        </w:docDefaults>
+      </w:styles>`,
+      null,
+    );
+
+    expect(defs.docDefaults?.rPr?.language).toEqual({
+      val: "cs-CZ",
+      eastAsia: "ja-JP",
+      bidi: "ar-SA",
+    });
+  });
 });
 
 describe("style table measurements", () => {

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -285,6 +285,20 @@ function parseRunProperties(
     formatting.fontFamily = fontFamily;
   }
 
+  const lang = findChild(rPr, "w", "lang");
+  if (lang) {
+    const val = getAttribute(lang, "w", "val") || undefined;
+    const eastAsia = getAttribute(lang, "w", "eastAsia") || undefined;
+    const bidi = getAttribute(lang, "w", "bidi") || undefined;
+    if (val || eastAsia || bidi) {
+      formatting.language = {
+        ...(val ? { val } : {}),
+        ...(eastAsia ? { eastAsia } : {}),
+        ...(bidi ? { bidi } : {}),
+      };
+    }
+  }
+
   // Character spacing (in twips)
   const spacing = findChild(rPr, "w", "spacing");
   if (spacing) {

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -4,7 +4,7 @@
  * Providers return UTF-16 offsets so their output composes directly with the
  * run and ProseMirror positions used by the rest of the layout pipeline. The
  * default provider uses the platform's Unicode segmenter, then applies the
- * Word/OOXML line-edge restrictions that are available in the flow model.
+ * OOXML line-edge restrictions that are available in the flow model.
  */
 
 export type LineBreakPolicy = {
@@ -56,11 +56,12 @@ const BREAK_AFTER_CHARACTER = new Set([
   "\u200B", // zero-width space
   "\u00AD", // soft hyphen
 ]);
+const CZECH_NONSYLLABIC_ONE_LETTER_PREPOSITIONS = new Set(["k", "s", "v", "z"]);
 
 // ECMA-376 kinsoku defaults are language-specific and can be overridden by
-// settings.xml. This conservative common set covers the punctuation Word does
-// not place at a line edge across Japanese and Chinese documents; document
-// overrides are layered on top below.
+// settings.xml. This conservative common set covers punctuation excluded from
+// line edges across Japanese and Chinese documents; document overrides are
+// layered on top below.
 const DEFAULT_PROHIBITED_LINE_START = new Set([
   "!",
   "%",
@@ -176,6 +177,43 @@ const isLegacyEthiopicBreakCharacter = (
   return codePoint !== undefined && codePoint >= 0x1361 && codePoint <= 0x1368;
 };
 
+const czechProtectedBreaks = (text: string, policy?: LineBreakPolicy): Set<number> => {
+  const breaks = new Set<number>();
+  if (segmenterLocale(policy?.locale) !== "cs") {
+    return breaks;
+  }
+
+  let tokenStart = 0;
+  let index = 0;
+  while (index < text.length) {
+    const character = firstCodePoint(text, index);
+    if (character === undefined) {
+      break;
+    }
+    if (!/\s/u.test(character)) {
+      index += character.length;
+      continue;
+    }
+
+    const token = text.slice(tokenStart, index);
+    const protectsNextWord =
+      [...token].length === 1 &&
+      CZECH_NONSYLLABIC_ONE_LETTER_PREPOSITIONS.has(token.toLocaleLowerCase("cs"));
+    while (index < text.length) {
+      const whitespace = firstCodePoint(text, index);
+      if (whitespace === undefined || !/\s/u.test(whitespace)) {
+        break;
+      }
+      index += whitespace.length;
+      if (protectsNextWord) {
+        breaks.add(index);
+      }
+    }
+    tokenStart = index;
+  }
+  return breaks;
+};
+
 const allowsBreak = (text: string, index: number, policy?: LineBreakPolicy): boolean => {
   const previous = previousCodePoint(text, index);
   const next = firstCodePoint(text, index);
@@ -254,7 +292,10 @@ const findUnicodeBreaks = (text: string, policy?: LineBreakPolicy): number[] => 
     }
   }
 
-  return [...new Set(breaks)].sort((left, right) => left - right);
+  const protectedBreaks = czechProtectedBreaks(text, policy);
+  return [...new Set(breaks)]
+    .filter((index) => !protectedBreaks.has(index))
+    .sort((left, right) => left - right);
 };
 
 export const defaultLineBreakProvider: LineBreakProvider = {

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -34,6 +34,14 @@ describe("findWordBreaks", () => {
     expect(() => findWordBreaks("hello world", { locale: "not_a_locale" })).not.toThrow();
   });
 
+  test("keeps Czech nonsyllabic one-letter prepositions with the following word", () => {
+    const text = "text v  text";
+
+    expect(findWordBreaks(text, { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks(text, { locale: "en-US" })).toEqual([5, 7, 8]);
+    expect(findWordBreaks("textov text", { locale: "cs-CZ" })).toEqual([7]);
+  });
+
   test("keeps prohibited CJK punctuation off the next line", () => {
     expect(findWordBreaks("中文。测试", { locale: "zh-CN" })).toEqual([1, 3, 4, 5]);
   });
@@ -42,7 +50,7 @@ describe("findWordBreaks", () => {
     expect(findWordBreaks("中文測", { noLineBreaksBefore: "測" })).toEqual([1, 3]);
   });
 
-  test("applies Word's legacy Ethiopic and Amharic break opportunities", () => {
+  test("applies legacy Ethiopic and Amharic break opportunities", () => {
     const text = "ሀ፡ለ";
     expect(findWordBreaks(text)).toEqual([]);
     expect(findWordBreaks(text, { useLegacyEthiopicAmharicRules: true })).toEqual([2]);


### PR DESCRIPTION
## Summary

- preserve inherited language metadata from document defaults and styles
- keep Czech nonsyllabic one-letter prepositions with the following word
- add focused parser and line-break regression coverage plus a patch changeset

CC on behalf of @jan-kubica