### PR TITLE
fix: render bottom-to-top table text

### DIFF
--- a/.changeset/bright-cells-turn.md
+++ b/.changeset/bright-cells-turn.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render bottom-to-top table cell text in paged layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -10,6 +10,7 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
 import { ShapeTextBody } from '@stll/docx-core/model';
+import { TableCellFormatting } from '@stll/docx-core/model';
 import { TableWidthType } from '@stll/docx-core/model';
 
 // @public
@@ -836,6 +837,7 @@ export type TableCell = {
     rowSpan?: number;
     width?: number;
     verticalAlign?: "top" | "center" | "bottom";
+    textDirection?: NonNullable<TableCellFormatting["textDirection"]>;
     background?: string;
     borders?: CellBorders; /** Per-cell padding in pixels (from w:tcMar or table-level w:tblCellMar) */
     padding?: {

--- a/api-reports/core/layout-painter.api.md
+++ b/api-reports/core/layout-painter.api.md
@@ -10,6 +10,7 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
 import { ShapeTextBody } from '@stll/docx-core/model';
+import { TableCellFormatting } from '@stll/docx-core/model';
 import { TableWidthType } from '@stll/docx-core/model';
 
 // @public

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -979,6 +979,27 @@ describe("toFlowBlocks table cell formatting", () => {
     expect(row.cells.at(1)?.noWrap).toBeUndefined();
   });
 
+  test("threads the cell text direction into the engine TableCell", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", { textDirection: "btLr" }, [
+            schema.node("paragraph", null, [schema.text("Rotated cell")]),
+          ]),
+          schema.node("tableCell", null, [schema.node("paragraph")]),
+        ]),
+      ]),
+    ]);
+
+    const table = toFlowBlocks(doc).at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+
+    expect(table.rows.at(0)?.cells.at(0)?.textDirection).toBe("btLr");
+    expect(table.rows.at(0)?.cells.at(1)?.textDirection).toBeUndefined();
+  });
+
   test("suppresses a trailing empty paragraph after real cell content", () => {
     const doc = schema.node("doc", null, [
       schema.node("table", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2196,6 +2196,9 @@ function convertTableCell(
   if (attrs.verticalAlign) {
     cell.verticalAlign = attrs.verticalAlign;
   }
+  if (attrs.textDirection) {
+    cell.textDirection = attrs.textDirection;
+  }
   if (attrs.backgroundColor) {
     cell.background = `#${attrs.backgroundColor}`;
   }

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -11,6 +11,7 @@ import type {
   ShapeTextBody,
   SdtProperties,
   SdtType,
+  TableCellFormatting,
   TableWidthType,
 } from "@stll/docx-core/model";
 
@@ -535,6 +536,7 @@ export type TableCell = {
   rowSpan?: number;
   width?: number;
   verticalAlign?: "top" | "center" | "bottom";
+  textDirection?: NonNullable<TableCellFormatting["textDirection"]>;
   background?: string;
   borders?: CellBorders;
   /** Per-cell padding in pixels (from w:tcMar or table-level w:tblCellMar) */

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -68,19 +68,28 @@ type RenderedCellContent = {
   floatingLayers: HTMLElement[];
 };
 
-function renderCellContent(
-  cell: TableCell,
-  cellMeasure: TableCellMeasure,
-  context: RenderContext,
-  doc: Document,
-): RenderedCellContent {
+type RenderCellContentOptions = {
+  cell: TableCell;
+  cellMeasure: TableCellMeasure;
+  context: RenderContext;
+  doc: Document;
+  contentWidthOverride?: number;
+};
+
+function renderCellContent({
+  cell,
+  cellMeasure,
+  context,
+  doc,
+  contentWidthOverride,
+}: RenderCellContentOptions): RenderedCellContent {
   const contentEl = doc.createElement("div");
   contentEl.className = TABLE_CLASS_NAMES.cellContent;
   contentEl.style.position = "relative";
   // Content width must account for cell padding since the cell uses border-box sizing.
   // Without this, content is wider than the available area, causing centering and
   // clipping issues (especially for nested tables).
-  const contentWidth = getTableCellContentWidth(cell, cellMeasure);
+  const contentWidth = contentWidthOverride ?? getTableCellContentWidth(cell, cellMeasure);
   contentEl.style.width = `${contentWidth}px`;
 
   // Extract floating images from cell paragraphs
@@ -145,8 +154,8 @@ function renderCellContent(
       const paragraphBlock = block as ParagraphBlock;
       let paragraphMeasure = measure as ParagraphMeasure;
 
-      // Re-measure with floating zones if floating images exist in this cell
-      if (floatingZones.length > 0) {
+      // Re-measure when wrapping width changes or floating exclusions apply.
+      if (floatingZones.length > 0 || contentWidthOverride !== undefined) {
         paragraphMeasure = measureParagraph(paragraphBlock, contentWidth, {
           floatingZones,
           paragraphYOffset: cumulativeY,
@@ -516,7 +525,21 @@ function renderTableCell(
   }
 
   // Render cell content
-  const renderedContent = renderCellContent(cell, cellMeasure, context, doc);
+  const contentWidthOverride =
+    cell.textDirection === "btLr" ? Math.max(1, rowHeight - padTop - padBottom) : undefined;
+  const renderedContent = renderCellContent({
+    cell,
+    cellMeasure,
+    context,
+    doc,
+    ...(contentWidthOverride !== undefined ? { contentWidthOverride } : {}),
+  });
+  if (cell.textDirection === "btLr") {
+    renderedContent.content.style.position = "absolute";
+    renderedContent.content.style.left = "50%";
+    renderedContent.content.style.top = "50%";
+    renderedContent.content.style.transform = "translate(-50%, -50%) rotate(-90deg)";
+  }
   if (renderedContent.floatingLayers.length > 0) {
     renderedContent.content.style.height = "100%";
     renderedContent.content.style.overflow = "hidden";

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { withFakeTextMeasure } from "../layout-engine/measure/__tests__/fakeTextMeasure";
 import type { TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
 import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
 import type { RenderContext } from "./renderUtils";
@@ -275,6 +276,76 @@ describe("renderTableFragment cell paragraph spacing", () => {
     expect(paragraph?.style["height"]).toBe("30px");
     expect(paragraph?.style["paddingTop"]).toBe("6px");
     expect(paragraph?.style["boxSizing"]).toBe("border-box");
+  });
+});
+
+describe("renderTableFragment bottom-to-top cell text", () => {
+  test("rotates and centers content within the cell height", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              textDirection: "btLr",
+              padding: { top: 2, right: 3, bottom: 4, left: 5 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "para",
+                  runs: [{ kind: "text", text: "Rotated cell" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [{ kind: "paragraph", lines: [], totalHeight: 20 }],
+              width: 100,
+              height: 80,
+            },
+          ],
+          height: 80,
+        },
+      ],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 80,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    withFakeTextMeasure(() => {
+      const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+      }) as unknown as FakeElement;
+      const content = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent).at(0);
+
+      expect(content?.style["position"]).toBe("absolute");
+      expect(content?.style["left"]).toBe("50%");
+      expect(content?.style["top"]).toBe("50%");
+      expect(content?.style["width"]).toBe("74px");
+      expect(content?.style["transform"]).toBe("translate(-50%, -50%) rotate(-90deg)");
+    });
   });
 });
 


### PR DESCRIPTION
Carries the validated table-cell text direction through flow conversion. Bottom-to-top cells remeasure against the available cell height, then rotate and center their content.

Adds synthetic bridge and painter regressions plus a patch changeset.

CC on behalf of @jan-kubica