### PR TITLE
feat: support diagonal table cell borders

### DIFF
--- a/.changeset/calm-diagonal-cell-borders.md
+++ b/.changeset/calm-diagonal-cell-borders.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": minor
+---
+
+Preserve and render both OOXML table-cell diagonal border directions.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -49,6 +49,8 @@ export type CellBorders = {
     bottom?: CellBorderSpec;
     left?: CellBorderSpec;
     right?: CellBorderSpec;
+    topLeftToBottomRight?: CellBorderSpec;
+    topRightToBottomLeft?: CellBorderSpec;
 };
 
 // @public

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -369,12 +369,7 @@ export type TableCellAttrs = {
     backgroundColor?: string; /** OOXML text direction (e.g. 'tbRl', 'btLr') */
     textDirection?: NonNullable<import__stll_docx_core_model.TableCellFormatting["textDirection"]>; /** No text wrapping in cell */
     noWrap?: boolean; /** Cell borders — full BorderSpec per side (style, color, size) */
-    borders?: {
-        top?: import__stll_docx_core_model.BorderSpec;
-        bottom?: import__stll_docx_core_model.BorderSpec;
-        left?: import__stll_docx_core_model.BorderSpec;
-        right?: import__stll_docx_core_model.BorderSpec;
-    }; /** Cell margins/padding in twips per side */
+    borders?: import__stll_docx_core_model.TableCellBorders; /** Cell margins/padding in twips per side */
     margins?: {
         top?: number;
         bottom?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -1079,9 +1079,15 @@ export type TableCell = {
 };
 
 // @public
+export type TableCellBorders = TableBorders & {
+    topLeftToBottomRight?: BorderSpec;
+    topRightToBottomLeft?: BorderSpec;
+};
+
+// @public
 export type TableCellFormatting = {
     width?: TableMeasurement; /** Cell borders */
-    borders?: TableBorders; /** Cell margins (override table default) */
+    borders?: TableCellBorders; /** Cell margins (override table default) */
     margins?: CellMargins; /** Cell shading/background */
     shading?: ShadingProperties; /** Vertical alignment */
     verticalAlign?: "top" | "center" | "bottom"; /** Text direction */

--- a/packages/core/src/docx/__tests__/diagonal-cell-borders.test.ts
+++ b/packages/core/src/docx/__tests__/diagonal-cell-borders.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { serializeTableCellFormatting } from "../serializer/tableSerializer";
+import { parseStyles } from "../styleParser";
+import { parseTableCellProperties } from "../tableParser";
+import type { XmlElement } from "../xmlParser";
+import { parseXmlDocument } from "../xmlParser";
+
+const W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+describe("diagonal table cell borders", () => {
+  test("parses and serializes both cell diagonal directions", () => {
+    const tcPr = parseXmlDocument(
+      `<w:tcPr ${W_NS}><w:tcBorders><w:tl2br w:val="dashed" w:sz="12" w:color="123456"/><w:tr2bl w:val="double" w:sz="18" w:color="654321"/></w:tcBorders></w:tcPr>`,
+    ) as XmlElement | null;
+
+    const formatting = parseTableCellProperties(tcPr);
+
+    expect(formatting?.borders?.topLeftToBottomRight).toMatchObject({
+      color: { rgb: "123456" },
+      size: 12,
+      style: "dashed",
+    });
+    expect(formatting?.borders?.topRightToBottomLeft).toMatchObject({
+      color: { rgb: "654321" },
+      size: 18,
+      style: "double",
+    });
+
+    const serialized = serializeTableCellFormatting(formatting);
+    expect(serialized).toContain('<w:tl2br w:val="dashed" w:sz="12" w:color="123456"/>');
+    expect(serialized).toContain('<w:tr2bl w:val="double" w:sz="18" w:color="654321"/>');
+  });
+
+  test("preserves diagonals declared by a table style cell property", () => {
+    const styles = parseStyles(
+      `<w:styles ${W_NS}>
+        <w:style w:type="table" w:styleId="DiagonalCells">
+          <w:name w:val="Diagonal cells"/>
+          <w:tcPr>
+            <w:tcBorders><w:tl2br w:val="single" w:sz="8"/></w:tcBorders>
+          </w:tcPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+
+    expect(styles.get("DiagonalCells")?.tcPr?.borders?.topLeftToBottomRight).toMatchObject({
+      size: 8,
+      style: "single",
+    });
+  });
+});

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -27,6 +27,8 @@ import type {
   TableStructuralChangeInfo,
   TableMeasurement,
   TableBorders,
+  TableCellBorders,
+  BorderSpec,
   TableLook,
   CellMargins,
   FloatingTableProperties,
@@ -97,60 +99,56 @@ function serializeMeasurement(
 /**
  * Serialize table borders (w:tblBorders or w:tcBorders)
  */
+function serializeTableBorderParts(borders: TableBorders): string[] {
+  const parts: string[] = [];
+
+  const appendBorder = (border: BorderSpec | undefined, name: string): void => {
+    const xml = serializeBorder(border, name);
+    if (xml) {
+      parts.push(xml);
+    }
+  };
+
+  appendBorder(borders.top, "top");
+  appendBorder(borders.left, "left");
+  appendBorder(borders.bottom, "bottom");
+  appendBorder(borders.right, "right");
+  appendBorder(borders.insideH, "insideH");
+  appendBorder(borders.insideV, "insideV");
+
+  return parts;
+}
+
 function serializeTableBorders(borders: TableBorders | undefined, elementName: string): string {
   if (!borders) {
     return "";
   }
 
-  const parts: string[] = [];
-
-  if (borders.top) {
-    const topXml = serializeBorder(borders.top, "top");
-    if (topXml) {
-      parts.push(topXml);
-    }
-  }
-
-  if (borders.left) {
-    const leftXml = serializeBorder(borders.left, "left");
-    if (leftXml) {
-      parts.push(leftXml);
-    }
-  }
-
-  if (borders.bottom) {
-    const bottomXml = serializeBorder(borders.bottom, "bottom");
-    if (bottomXml) {
-      parts.push(bottomXml);
-    }
-  }
-
-  if (borders.right) {
-    const rightXml = serializeBorder(borders.right, "right");
-    if (rightXml) {
-      parts.push(rightXml);
-    }
-  }
-
-  if (borders.insideH) {
-    const insideHXml = serializeBorder(borders.insideH, "insideH");
-    if (insideHXml) {
-      parts.push(insideHXml);
-    }
-  }
-
-  if (borders.insideV) {
-    const insideVXml = serializeBorder(borders.insideV, "insideV");
-    if (insideVXml) {
-      parts.push(insideVXml);
-    }
-  }
+  const parts = serializeTableBorderParts(borders);
 
   if (parts.length === 0) {
     return "";
   }
 
   return `<w:${elementName}>${parts.join("")}</w:${elementName}>`;
+}
+
+function serializeTableCellBorders(borders: TableCellBorders | undefined): string {
+  if (!borders) {
+    return "";
+  }
+
+  const parts = serializeTableBorderParts(borders);
+  const topLeftToBottomRight = serializeBorder(borders.topLeftToBottomRight, "tl2br");
+  if (topLeftToBottomRight) {
+    parts.push(topLeftToBottomRight);
+  }
+  const topRightToBottomLeft = serializeBorder(borders.topRightToBottomLeft, "tr2bl");
+  if (topRightToBottomLeft) {
+    parts.push(topRightToBottomLeft);
+  }
+
+  return parts.length > 0 ? `<w:tcBorders>${parts.join("")}</w:tcBorders>` : "";
 }
 
 // ============================================================================
@@ -651,7 +649,7 @@ export function serializeTableCellFormatting(
     }
 
     // Cell borders
-    const bordersXml = serializeTableBorders(formatting.borders, "tcBorders");
+    const bordersXml = serializeTableCellBorders(formatting.borders);
     if (bordersXml) {
       parts.push(bordersXml);
     }

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -31,6 +31,7 @@ import type {
   ShadingProperties,
   TabStop,
   TableBorders,
+  TableCellBorders,
   CellMargins,
   TableLook,
   TableMeasurement,
@@ -870,6 +871,26 @@ function parseTableBorders(tblBorders: XmlElement | null): TableBorders | undefi
   return Object.keys(borders).length > 0 ? borders : undefined;
 }
 
+/** Parse cell-only diagonal borders in addition to the shared table sides. */
+function parseTableCellBorders(tcBorders: XmlElement | null): TableCellBorders | undefined {
+  if (!tcBorders) {
+    return undefined;
+  }
+
+  const borders: TableCellBorders = { ...parseTableBorders(tcBorders) };
+  const topLeftToBottomRight = parseBorderSpec(findChild(tcBorders, "w", "tl2br"));
+  if (topLeftToBottomRight) {
+    borders.topLeftToBottomRight = topLeftToBottomRight;
+  }
+
+  const topRightToBottomLeft = parseBorderSpec(findChild(tcBorders, "w", "tr2bl"));
+  if (topRightToBottomLeft) {
+    borders.topRightToBottomLeft = topRightToBottomLeft;
+  }
+
+  return Object.keys(borders).length > 0 ? borders : undefined;
+}
+
 /**
  * Parse cell margins
  */
@@ -1158,7 +1179,7 @@ function parseTableCellProperties(
   // Cell borders
   const tcBorders = findChild(tcPr, "w", "tcBorders");
   if (tcBorders) {
-    const bordersResult = parseTableBorders(tcBorders);
+    const bordersResult = parseTableCellBorders(tcBorders);
     if (bordersResult) {
       formatting.borders = bordersResult;
     }

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -34,6 +34,7 @@ import type {
   TableMeasurement,
   TableWidthType,
   TableBorders,
+  TableCellBorders,
   TableLook,
   CellMargins,
   FloatingTableProperties,
@@ -265,6 +266,26 @@ export function parseTableBorders(bordersElement: XmlElement | null): TableBorde
   }
 
   return borders;
+}
+
+/** Parse cell-only diagonal borders in addition to the shared table sides. */
+function parseTableCellBorders(bordersElement: XmlElement | null): TableCellBorders | undefined {
+  if (!bordersElement) {
+    return undefined;
+  }
+
+  const borders: TableCellBorders = { ...parseTableBorders(bordersElement) };
+  const topLeftToBottomRight = parseBorderSpec(findChild(bordersElement, "w", "tl2br"));
+  if (topLeftToBottomRight) {
+    borders.topLeftToBottomRight = topLeftToBottomRight;
+  }
+
+  const topRightToBottomLeft = parseBorderSpec(findChild(bordersElement, "w", "tr2bl"));
+  if (topRightToBottomLeft) {
+    borders.topRightToBottomLeft = topRightToBottomLeft;
+  }
+
+  return Object.keys(borders).length > 0 ? borders : undefined;
 }
 
 // ============================================================================
@@ -1055,7 +1076,7 @@ export function parseTableCellProperties(
   }
 
   // Cell borders (w:tcBorders)
-  const borders = parseTableBorders(findChild(tcPrElement, "w", "tcBorders"));
+  const borders = parseTableCellBorders(findChild(tcPrElement, "w", "tcBorders"));
   if (borders) {
     formatting.borders = borders;
   }

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-diagonal-cell-borders.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-diagonal-cell-borders.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../prosemirror/schema";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+describe("table cell diagonal border conversion", () => {
+  test("carries visible diagonals into the layout model", () => {
+    const cell = schema.node(
+      "tableCell",
+      {
+        borders: {
+          topLeftToBottomRight: {
+            color: { rgb: "123456" },
+            size: 12,
+            style: "dashed",
+          },
+          topRightToBottomLeft: { style: "nil" },
+        },
+      },
+      [schema.node("paragraph", null, [schema.text("Cell")])],
+    );
+    const doc = schema.node("doc", null, [
+      schema.node("table", { columnWidths: [1200] }, [schema.node("tableRow", null, [cell])]),
+    ]);
+
+    const table = toFlowBlocks(doc).find((block) => block.kind === "table");
+    expect(table?.kind).toBe("table");
+    if (!table || table.kind !== "table") {
+      return;
+    }
+
+    expect(table.rows.at(0)?.cells.at(0)?.borders?.topLeftToBottomRight).toEqual({
+      color: "#123456",
+      style: "dashed",
+      width: 2,
+    });
+    expect(table.rows.at(0)?.cells.at(0)?.borders?.topRightToBottomLeft).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2109,6 +2109,15 @@ function extractCellBorders(
     result[side] = border?.size === 0 ? { ...converted, width: 0 } : converted;
   }
 
+  const diagonalSides = ["topLeftToBottomRight", "topRightToBottomLeft"] as const;
+  for (const side of diagonalSides) {
+    const border = borders[side];
+    const converted = border ? convertBorderSpecToLayout(border, theme) : undefined;
+    if (converted) {
+      result[side] = converted;
+    }
+  }
+
   return Object.keys(result).length > 0 ? result : undefined;
 }
 

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -524,6 +524,8 @@ export type CellBorders = {
   bottom?: CellBorderSpec;
   left?: CellBorderSpec;
   right?: CellBorderSpec;
+  topLeftToBottomRight?: CellBorderSpec;
+  topRightToBottomLeft?: CellBorderSpec;
 };
 
 /**

--- a/packages/core/src/layout-painter/renderTable-diagonal-cell-borders.test.ts
+++ b/packages/core/src/layout-painter/renderTable-diagonal-cell-borders.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
+import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
+import type { RenderContext } from "./renderUtils";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): null {
+    return null;
+  }
+
+  querySelectorAll(): FakeElement[] {
+    return [];
+  }
+}
+
+const fakeDocument = {
+  createElement(): FakeElement {
+    return new FakeElement();
+  },
+  createTextNode(): FakeElement {
+    return new FakeElement();
+  },
+} as unknown as Document;
+
+const renderContext: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+const findByClass = (element: FakeElement, className: string): FakeElement[] => {
+  const matches = element.className.split(" ").includes(className) ? [element] : [];
+  for (const child of element.children) {
+    matches.push(...findByClass(child, className));
+  }
+  return matches;
+};
+
+describe("table cell diagonal border painting", () => {
+  test("paints both directions across the measured cell box", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "table",
+      columnWidths: [100],
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              blocks: [{ kind: "paragraph", id: "paragraph", runs: [] }],
+              borders: {
+                topLeftToBottomRight: { color: "#123456", style: "dashed", width: 2 },
+                topRightToBottomLeft: { color: "#654321", style: "double", width: 3 },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [{ kind: "paragraph", lines: [], totalHeight: 40 }],
+              height: 40,
+              width: 100,
+            },
+          ],
+          height: 40,
+        },
+      ],
+      columnWidths: [100],
+      totalHeight: 40,
+      totalWidth: 100,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "table",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    const rendered = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const diagonals = findByClass(rendered, TABLE_CLASS_NAMES.cellDiagonalBorder);
+
+    expect(diagonals).toHaveLength(2);
+    expect(diagonals.at(0)?.dataset["direction"]).toBe("top-left-to-bottom-right");
+    expect(diagonals.at(0)?.style["width"]).toBe(`${Math.hypot(100, 40)}px`);
+    expect(diagonals.at(0)?.style["backgroundImage"]).toContain("repeating-linear-gradient");
+    expect(diagonals.at(1)?.dataset["direction"]).toBe("top-right-to-bottom-left");
+    expect(diagonals.at(1)?.style["top"]).toBe("38.5px");
+    expect(diagonals.at(1)?.style["backgroundImage"]).toContain("linear-gradient");
+  });
+});

--- a/packages/core/src/layout-painter/renderTable-diagonal-cell-borders.test.ts
+++ b/packages/core/src/layout-painter/renderTable-diagonal-cell-borders.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
-import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
+import { renderTableFragment } from "./renderTable";
 import type { RenderContext } from "./renderUtils";
 
 class FakeElement {
@@ -105,7 +105,7 @@ describe("table cell diagonal border painting", () => {
     const rendered = renderTableFragment(fragment, block, measure, renderContext, {
       document: fakeDocument,
     }) as unknown as FakeElement;
-    const diagonals = findByClass(rendered, TABLE_CLASS_NAMES.cellDiagonalBorder);
+    const diagonals = findByClass(rendered, "layout-table-cell-diagonal-border");
 
     expect(diagonals).toHaveLength(2);
     expect(diagonals.at(0)?.dataset["direction"]).toBe("top-left-to-bottom-right");

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -52,8 +52,9 @@ export const TABLE_CLASS_NAMES = {
   rowResizeHandle: "layout-table-row-resize-handle",
   tableEdgeHandleBottom: "layout-table-edge-handle-bottom",
   tableEdgeHandleRight: "layout-table-edge-handle-right",
-  cellDiagonalBorder: "layout-table-cell-diagonal-border",
 };
+
+const CELL_DIAGONAL_BORDER_CLASS = "layout-table-cell-diagonal-border";
 
 /**
  * Options for rendering a table fragment
@@ -449,7 +450,7 @@ function renderCellDiagonalBorder(
   const length = Math.hypot(cellWidth, cellHeight);
   const angle = Math.atan2(cellHeight, cellWidth);
 
-  line.className = TABLE_CLASS_NAMES.cellDiagonalBorder;
+  line.className = CELL_DIAGONAL_BORDER_CLASS;
   line.dataset["direction"] = direction;
   line.style.position = "absolute";
   line.style.left = "0";

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -19,6 +19,7 @@ import type {
   TableBlock,
   TableMeasure,
   TableCell,
+  CellBorderSpec,
   TableCellMeasure,
   ParagraphBlock,
   ParagraphMeasure,
@@ -51,6 +52,7 @@ export const TABLE_CLASS_NAMES = {
   rowResizeHandle: "layout-table-row-resize-handle",
   tableEdgeHandleBottom: "layout-table-edge-handle-bottom",
   tableEdgeHandleRight: "layout-table-edge-handle-right",
+  cellDiagonalBorder: "layout-table-cell-diagonal-border",
 };
 
 /**
@@ -428,6 +430,59 @@ function applyBorder(
   }
 }
 
+type CellDiagonalDirection = "top-left-to-bottom-right" | "top-right-to-bottom-left";
+
+function renderCellDiagonalBorder(
+  border: CellBorderSpec | undefined,
+  direction: CellDiagonalDirection,
+  cellWidth: number,
+  cellHeight: number,
+  doc: Document,
+): HTMLElement | null {
+  if (!hasVisibleBorder(border)) {
+    return null;
+  }
+
+  const line = doc.createElement("div");
+  const strokeWidth = Math.max(1, border?.width ?? 1);
+  const color = border?.color ?? "#000000";
+  const length = Math.hypot(cellWidth, cellHeight);
+  const angle = Math.atan2(cellHeight, cellWidth);
+
+  line.className = TABLE_CLASS_NAMES.cellDiagonalBorder;
+  line.dataset["direction"] = direction;
+  line.style.position = "absolute";
+  line.style.left = "0";
+  line.style.top =
+    direction === "top-left-to-bottom-right"
+      ? `${-strokeWidth / 2}px`
+      : `${cellHeight - strokeWidth / 2}px`;
+  line.style.width = `${length}px`;
+  line.style.height = `${strokeWidth}px`;
+  line.style.transformOrigin = "0 50%";
+  line.style.transform = `rotate(${direction === "top-left-to-bottom-right" ? angle : -angle}rad)`;
+  line.style.pointerEvents = "none";
+  line.style.zIndex = "1";
+
+  switch (border?.style) {
+    case "dashed":
+      line.style.backgroundImage = `repeating-linear-gradient(to right, ${color} 0, ${color} ${strokeWidth * 3}px, transparent ${strokeWidth * 3}px, transparent ${strokeWidth * 5}px)`;
+      break;
+    case "dotted":
+      line.style.backgroundImage = `radial-gradient(circle at ${strokeWidth / 2}px 50%, ${color} ${strokeWidth / 2}px, transparent ${strokeWidth / 2}px)`;
+      line.style.backgroundSize = `${strokeWidth * 2}px ${strokeWidth}px`;
+      break;
+    case "double":
+      line.style.backgroundImage = `linear-gradient(to bottom, ${color} 0, ${color} 33%, transparent 33%, transparent 67%, ${color} 67%, ${color} 100%)`;
+      break;
+    default:
+      line.style.backgroundColor = color;
+      break;
+  }
+
+  return line;
+}
+
 /**
  * Render a single table cell
  */
@@ -546,6 +601,26 @@ function renderTableCell(
     cellEl.style.overflow = "visible";
   }
   cellEl.append(renderedContent.content);
+  const topLeftToBottomRight = renderCellDiagonalBorder(
+    cell.borders?.topLeftToBottomRight,
+    "top-left-to-bottom-right",
+    cellMeasure.width,
+    rowHeight,
+    doc,
+  );
+  if (topLeftToBottomRight) {
+    cellEl.append(topLeftToBottomRight);
+  }
+  const topRightToBottomLeft = renderCellDiagonalBorder(
+    cell.borders?.topRightToBottomLeft,
+    "top-right-to-bottom-left",
+    cellMeasure.width,
+    rowHeight,
+    doc,
+  );
+  if (topRightToBottomLeft) {
+    cellEl.append(topRightToBottomLeft);
+  }
   for (const floatingLayer of renderedContent.floatingLayers) {
     floatingLayer.style.left = `${padLeft}px`;
     floatingLayer.style.top = `${padTop}px`;

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -433,13 +433,21 @@ function applyBorder(
 
 type CellDiagonalDirection = "top-left-to-bottom-right" | "top-right-to-bottom-left";
 
-function renderCellDiagonalBorder(
-  border: CellBorderSpec | undefined,
-  direction: CellDiagonalDirection,
-  cellWidth: number,
-  cellHeight: number,
-  doc: Document,
-): HTMLElement | null {
+type RenderCellDiagonalBorderOptions = {
+  border: CellBorderSpec | undefined;
+  direction: CellDiagonalDirection;
+  cellWidth: number;
+  cellHeight: number;
+  doc: Document;
+};
+
+function renderCellDiagonalBorder({
+  border,
+  direction,
+  cellWidth,
+  cellHeight,
+  doc,
+}: RenderCellDiagonalBorderOptions): HTMLElement | null {
   if (!hasVisibleBorder(border)) {
     return null;
   }
@@ -602,23 +610,23 @@ function renderTableCell(
     cellEl.style.overflow = "visible";
   }
   cellEl.append(renderedContent.content);
-  const topLeftToBottomRight = renderCellDiagonalBorder(
-    cell.borders?.topLeftToBottomRight,
-    "top-left-to-bottom-right",
-    cellMeasure.width,
-    rowHeight,
+  const topLeftToBottomRight = renderCellDiagonalBorder({
+    border: cell.borders?.topLeftToBottomRight,
+    direction: "top-left-to-bottom-right",
+    cellWidth: cellMeasure.width,
+    cellHeight: rowHeight,
     doc,
-  );
+  });
   if (topLeftToBottomRight) {
     cellEl.append(topLeftToBottomRight);
   }
-  const topRightToBottomLeft = renderCellDiagonalBorder(
-    cell.borders?.topRightToBottomLeft,
-    "top-right-to-bottom-left",
-    cellMeasure.width,
-    rowHeight,
+  const topRightToBottomLeft = renderCellDiagonalBorder({
+    border: cell.borders?.topRightToBottomLeft,
+    direction: "top-right-to-bottom-left",
+    cellWidth: cellMeasure.width,
+    cellHeight: rowHeight,
     doc,
-  );
+  });
   if (topRightToBottomLeft) {
     cellEl.append(topRightToBottomLeft);
   }

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -462,6 +462,8 @@ export const readTableCellAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Tab
     "bottom",
     "left",
     "right",
+    "topLeftToBottomRight",
+    "topRightToBottomLeft",
   ]);
   optionalInsetMap(attrs, "margins", "tableCell.attrs.margins", issues);
   optionalRecord(attrs, "_originalFormatting", "tableCell.attrs._originalFormatting", issues);

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -35,6 +35,7 @@ import type {
   TableCell,
   TableCellFormatting,
   TableBorders,
+  TableCellBorders,
   TableLook,
   SimpleField,
   ComplexField,
@@ -1679,17 +1680,19 @@ const TABLE_BORDER_SIDES = [
   "right",
   "insideH",
   "insideV",
-] as const satisfies readonly (keyof TableBorders)[];
+  "topLeftToBottomRight",
+  "topRightToBottomLeft",
+] as const satisfies readonly (keyof TableCellBorders)[];
 
 function resolveThemedBorderColors(
-  borders: TableBorders | undefined,
+  borders: TableCellBorders | undefined,
   theme: Theme | null | undefined,
-): TableBorders | undefined {
+): TableCellBorders | undefined {
   if (!borders || !theme?.colorScheme) {
     return borders;
   }
 
-  let resolved: TableBorders | undefined;
+  let resolved: TableCellBorders | undefined;
   for (const side of TABLE_BORDER_SIDES) {
     const border = borders[side];
     if (!border?.color?.themeColor || border.color.auto) {

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -41,7 +41,7 @@ import { createNodeExtension, createExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime, AnyExtension } from "../types";
 
 type TableCellBorders = NonNullable<TableCellAttrs["borders"]>;
-type TableCellBorderSide = keyof TableCellBorders;
+type TableCellBorderSide = "top" | "bottom" | "left" | "right";
 
 // ============================================================================
 // CSS PASTE HELPERS — Extract formatting from inline styles (Google Docs, etc.)

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -23,6 +23,7 @@ import type {
   TextFormatting,
   NumberFormat,
   TableBorders,
+  TableCellBorders,
   TableFormatting,
   TablePropertyChange,
   TableRowFormatting,
@@ -615,12 +616,7 @@ export type TableCellAttrs = {
   /** No text wrapping in cell */
   noWrap?: boolean;
   /** Cell borders — full BorderSpec per side (style, color, size) */
-  borders?: {
-    top?: BorderSpec;
-    bottom?: BorderSpec;
-    left?: BorderSpec;
-    right?: BorderSpec;
-  };
+  borders?: TableCellBorders;
   /** Cell margins/padding in twips per side */
   margins?: { top?: number; bottom?: number; left?: number; right?: number };
   /** Original cell formatting from DOCX for lossless round-trip serialization */

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -41,6 +41,7 @@ export type {
   TableWidthType,
   TableMeasurement,
   TableBorders,
+  TableCellBorders,
   CellMargins,
   TableLook,
   FloatingTableProperties,

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -397,6 +397,16 @@ export type TableBorders = {
 };
 
 /**
+ * Table cell borders, including the two diagonals permitted by w:tcBorders.
+ */
+export type TableCellBorders = TableBorders & {
+  /** Border from the top-left corner to the bottom-right corner (w:tl2br) */
+  topLeftToBottomRight?: BorderSpec;
+  /** Border from the top-right corner to the bottom-left corner (w:tr2bl) */
+  topRightToBottomLeft?: BorderSpec;
+};
+
+/**
  * Cell margins
  */
 export type CellMargins = {
@@ -536,7 +546,7 @@ export type TableCellFormatting = {
   /** Cell width */
   width?: TableMeasurement;
   /** Cell borders */
-  borders?: TableBorders;
+  borders?: TableCellBorders;
   /** Cell margins (override table default) */
   margins?: CellMargins;
   /** Cell shading/background */

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -397,12 +397,11 @@ export type TableBorders = {
 };
 
 /**
- * Table cell borders, including the two diagonals permitted by w:tcBorders.
+ * Table cell borders, including w:tl2br (top-left to bottom-right) and
+ * w:tr2bl (top-right to bottom-left).
  */
 export type TableCellBorders = TableBorders & {
-  /** Border from the top-left corner to the bottom-right corner (w:tl2br) */
   topLeftToBottomRight?: BorderSpec;
-  /** Border from the top-right corner to the bottom-left corner (w:tr2bl) */
   topRightToBottomLeft?: BorderSpec;
 };
 


### PR DESCRIPTION
## Summary

- add typed OOXML cell diagonal borders across parsing, style resolution, and round-trip serialization
- carry both diagonal directions through editor attributes and layout conversion
- paint diagonal styles without changing cell measurement, with synthetic regression coverage

CC on behalf of @jan-kubica