### PR TITLE
feat: add Word line endpoint validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "bench": "bun benchmarks/index.ts",
     "bench:cross-language": "bun benchmarks/cross-language/run.ts",
     "parity": "bun parity/cli.ts",
+    "parity:line-endpoints": "bun parity/lineEndpointsCli.ts",
     "test:visual": "bunx playwright test",
     "test:interactions": "bunx playwright test --project=interactions",
     "test:differential": "cd packages/core && bun test src/docx/__tests__/differential.test.ts",

--- a/parity/README.md
+++ b/parity/README.md
@@ -38,6 +38,37 @@ The HTML report lands in `parity/report/index.html` and identifies the selected
 renderer and its version. Reports describe the renderer as a **reference**, not
 as a specification oracle.
 
+## Word line-endpoint regression manifests
+
+The focused line-endpoint validator separates Word capture from Folio
+validation. Capture requires the local Word adapter, but validation reads a
+versioned JSON manifest and does not launch or require Word. This makes a
+reviewed reference capture reusable on machines and CI runners where Word is
+not installed.
+
+```sh
+# On a licensed Mac with Microsoft Word and mutool
+bun run parity:line-endpoints capture path/to/fixture.docx \
+  --output path/to/fixture.word-lines.json
+
+# Anywhere Folio's playground can run; Word is not opened
+bun run parity:line-endpoints validate path/to/fixture.docx \
+  --manifest path/to/fixture.word-lines.json
+```
+
+The manifest records the exact DOCX SHA-256, Word and extraction versions, and
+the normalized text occupying each visual line. Validation fails fast if the
+DOCX hash differs, then reports only page placement and line-ending
+differences; x/y/width geometry is intentionally excluded. Because normalized
+line text can still contain sensitive document content, do not commit manifests
+captured from confidential or personal documents. Use synthetic or explicitly
+public fixtures for repository baselines.
+
+This is a clean-room interoperability check: Word runs only as an external
+reference renderer during capture. No Word code, APIs, or runtime dependency
+ships in Folio. A captured result is evidence about one documented Word version
+and font environment, not proof of OOXML conformance.
+
 For repeated runs in one worktree, start a current-source playground once and
 explicitly reuse it:
 

--- a/parity/__tests__/lineEndpoints.test.ts
+++ b/parity/__tests__/lineEndpoints.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  LINE_ENDPOINT_MANIFEST_SCHEMA,
+  LINE_ENDPOINT_MANIFEST_VERSION,
+  compareLineEndpoints,
+  createWordLineEndpointManifest,
+  parseLineEndpointManifest,
+} from "../lineEndpoints";
+import { normalizeLineText } from "../textNorm";
+import type { DocGeom, LineBox, PageGeom, Region } from "../types";
+
+const SOURCE_SHA256 = "a".repeat(64);
+
+describe("Word line-endpoint manifests", () => {
+  test("captures normalized visual lines without local source paths", () => {
+    const reference = makeGeom("word", [
+      makePage(1, [
+        makeLine("Clause", { xPt: 10, yPt: 20 }),
+        makeLine("one", { xPt: 50, yPt: 20 }),
+        makeLine("  second   line  ", { yPt: 40 }),
+      ]),
+    ]);
+
+    const manifest = createWordLineEndpointManifest({
+      reference,
+      sourceFileName: "fixture.docx",
+      sourceSha256: SOURCE_SHA256,
+      capturedAt: "2026-07-14T00:00:00.000Z",
+    });
+
+    expect(manifest.schema).toBe(LINE_ENDPOINT_MANIFEST_SCHEMA);
+    expect(manifest.version).toBe(LINE_ENDPOINT_MANIFEST_VERSION);
+    expect(manifest.source).toEqual({ fileName: "fixture.docx", sha256: SOURCE_SHA256 });
+    expect(manifest.pages).toEqual([
+      {
+        number: 1,
+        lines: [
+          { text: "Clause one", region: "body" },
+          { text: "second line", region: "body" },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(manifest)).not.toContain(reference.file);
+  });
+
+  test("accepts matching endpoints while ignoring geometry", () => {
+    const manifest = makeManifest([
+      makePage(1, [makeLine("First line"), makeLine("Second line", { yPt: 30 })]),
+    ]);
+    const folio = makeGeom("folio", [
+      makePage(1, [
+        makeLine("First line", { xPt: 120, yPt: 90, widthPt: 300 }),
+        makeLine("Second line", { xPt: 90, yPt: 140, widthPt: 250 }),
+      ]),
+    ]);
+
+    expect(compareLineEndpoints(manifest, folio)).toEqual({
+      matches: true,
+      referenceLines: 2,
+      folioLines: 2,
+      divergences: [],
+    });
+  });
+
+  test("reports a changed line endpoint", () => {
+    const manifest = makeManifest([
+      makePage(1, [makeLine("Alpha beta"), makeLine("gamma delta", { yPt: 30 })]),
+    ]);
+    const folio = makeGeom("folio", [
+      makePage(1, [makeLine("Alpha beta gamma"), makeLine("delta", { yPt: 30 })]),
+    ]);
+
+    const result = compareLineEndpoints(manifest, folio);
+
+    expect(result.matches).toBe(false);
+    expect(result.divergences).toEqual([
+      {
+        kind: "line-break",
+        page: 1,
+        referenceTexts: ["Alpha beta", "gamma delta"],
+        folioTexts: ["Alpha beta gamma", "delta"],
+      },
+    ]);
+  });
+
+  test("reports text that moved to another page", () => {
+    const manifest = makeManifest([makePage(1, [makeLine("Page edge")]), makePage(2, [])]);
+    const folio = makeGeom("folio", [makePage(1, []), makePage(2, [makeLine("Page edge")])]);
+
+    const result = compareLineEndpoints(manifest, folio);
+
+    expect(result.matches).toBe(false);
+    expect(result.divergences).toContainEqual({
+      kind: "pagination",
+      text: "Page edge",
+      referencePage: 1,
+      folioPage: 2,
+    });
+  });
+
+  test("rejects unknown manifest versions and malformed hashes", () => {
+    const valid = makeManifest([makePage(1, [makeLine("Text")])]);
+
+    expect(() => parseLineEndpointManifest({ ...valid, version: 2 })).toThrow(
+      "Unsupported line-endpoint manifest version: 2",
+    );
+    expect(() =>
+      parseLineEndpointManifest({ ...valid, source: { ...valid.source, sha256: "not-a-hash" } }),
+    ).toThrow("source.sha256 must be 64 lowercase hex characters");
+    expect(() =>
+      parseLineEndpointManifest({
+        ...valid,
+        source: { ...valid.source, fileName: "/private/fixture.docx" },
+      }),
+    ).toThrow("source.fileName must be a basename");
+  });
+});
+
+const makeManifest = (pages: PageGeom[]) =>
+  createWordLineEndpointManifest({
+    reference: makeGeom("word", pages),
+    sourceFileName: "fixture.docx",
+    sourceSha256: SOURCE_SHA256,
+    capturedAt: "2026-07-14T00:00:00.000Z",
+  });
+
+const makeGeom = (source: "word" | "folio", pages: PageGeom[]): DocGeom => ({
+  source,
+  file: source === "word" ? "/private/reference/fixture.docx" : "/workspace/fixture.docx",
+  pages,
+  meta:
+    source === "word" ? { wordVersion: "16.99", mutool: "mutool 1.0", sha256: SOURCE_SHA256 } : {},
+});
+
+const makePage = (number: number, lines: LineBox[]): PageGeom => ({
+  number,
+  widthPt: 612,
+  heightPt: 792,
+  lines,
+});
+
+type MakeLineOptions = {
+  xPt?: number;
+  yPt?: number;
+  widthPt?: number;
+  region?: Region;
+};
+
+const makeLine = (
+  text: string,
+  { xPt = 10, yPt = 10, widthPt = 80, region = "body" }: MakeLineOptions = {},
+): LineBox => ({
+  text,
+  normText: normalizeLineText(text),
+  xPt,
+  yPt,
+  baselinePt: yPt + 9,
+  widthPt,
+  heightPt: 10,
+  region,
+});

--- a/parity/__tests__/lineEndpoints.test.ts
+++ b/parity/__tests__/lineEndpoints.test.ts
@@ -114,6 +114,12 @@ describe("Word line-endpoint manifests", () => {
         source: { ...valid.source, fileName: "/private/fixture.docx" },
       }),
     ).toThrow("source.fileName must be a basename");
+    expect(() =>
+      parseLineEndpointManifest({
+        ...valid,
+        reference: { ...valid.reference, wordVersion: null },
+      }),
+    ).toThrow("reference.wordVersion must be a non-empty string");
   });
 });
 

--- a/parity/__tests__/lineEndpointsCli.test.ts
+++ b/parity/__tests__/lineEndpointsCli.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseLineEndpointCliArgs } from "../lineEndpointsCli";
+
+describe("Word line-endpoint CLI", () => {
+  test("parses capture with an explicit output", () => {
+    expect(
+      parseLineEndpointCliArgs([
+        "capture",
+        "fixture.docx",
+        "--output",
+        "fixture.word-lines.json",
+        "--refresh-word",
+      ]),
+    ).toEqual({
+      type: "capture",
+      docxPath: "fixture.docx",
+      outputPath: "fixture.word-lines.json",
+      refreshWord: true,
+    });
+  });
+
+  test("parses offline validation options", () => {
+    expect(
+      parseLineEndpointCliArgs([
+        "validate",
+        "fixture.docx",
+        "--manifest",
+        "fixture.word-lines.json",
+        "--headed",
+        "--reuse-server",
+      ]),
+    ).toEqual({
+      type: "validate",
+      docxPath: "fixture.docx",
+      manifestPath: "fixture.word-lines.json",
+      headed: true,
+      reuseServer: true,
+    });
+  });
+
+  test("requires explicit manifest paths", () => {
+    expect(() => parseLineEndpointCliArgs(["capture", "fixture.docx"])).toThrow(
+      "capture requires --output",
+    );
+    expect(() => parseLineEndpointCliArgs(["validate", "fixture.docx"])).toThrow(
+      "validate requires --manifest",
+    );
+  });
+
+  test("rejects unknown options", () => {
+    expect(() =>
+      parseLineEndpointCliArgs(["validate", "fixture.docx", "--manifest", "lines.json", "--ci"]),
+    ).toThrow("Unknown validate option: --ci");
+  });
+});

--- a/parity/lineEndpoints.ts
+++ b/parity/lineEndpoints.ts
@@ -154,16 +154,19 @@ const endpointPageToGeom = (page: LineEndpointPage): PageGeom => ({
   lines: page.lines.map(endpointToLineBox),
 });
 
-const endpointToLineBox = ({ text, region }: LineEndpoint, index: number): LineBox => ({
-  text,
-  normText: normalizeLineText(text),
-  xPt: 0,
-  yPt: index * 12,
-  baselinePt: index * 12 + 9,
-  widthPt: normalizeLineText(text).length,
-  heightPt: 10,
-  region,
-});
+const endpointToLineBox = ({ text, region }: LineEndpoint, index: number): LineBox => {
+  const normText = normalizeLineText(text);
+  return {
+    text,
+    normText,
+    xPt: 0,
+    yPt: index * 12,
+    baselinePt: index * 12 + 9,
+    widthPt: normText.length,
+    heightPt: 10,
+    region,
+  };
+};
 
 const isLineEndpointDivergence = (divergence: Divergence): divergence is LineEndpointDivergence => {
   switch (divergence.kind) {

--- a/parity/lineEndpoints.ts
+++ b/parity/lineEndpoints.ts
@@ -1,0 +1,312 @@
+import { compareGeoms, mergeVisualRows } from "./compare";
+import { normalizeLineText } from "./textNorm";
+import type { Divergence, DocGeom, LineBox, PageGeom, Region } from "./types";
+
+export const LINE_ENDPOINT_MANIFEST_SCHEMA = "folio.word-line-endpoints";
+export const LINE_ENDPOINT_MANIFEST_VERSION = 1;
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+
+export type LineEndpoint = {
+  /** Normalized text occupying one visual line. Its final token is the endpoint under test. */
+  text: string;
+  region: Region;
+};
+
+export type LineEndpointPage = {
+  number: number;
+  lines: LineEndpoint[];
+};
+
+export type WordLineEndpointManifest = {
+  schema: typeof LINE_ENDPOINT_MANIFEST_SCHEMA;
+  version: typeof LINE_ENDPOINT_MANIFEST_VERSION;
+  source: {
+    /** Basename only: manifests must not disclose a local absolute path. */
+    fileName: string;
+    sha256: string;
+  };
+  reference: {
+    renderer: "word";
+    capturedAt: string;
+    wordVersion?: string;
+    mutoolVersion?: string;
+  };
+  pages: LineEndpointPage[];
+};
+
+export type LineEndpointDivergence = Extract<
+  Divergence,
+  {
+    kind:
+      | "page-count"
+      | "pagination"
+      | "line-break"
+      | "missing-line"
+      | "extra-line"
+      | "text-mismatch";
+  }
+>;
+
+export type LineEndpointValidationResult = {
+  matches: boolean;
+  referenceLines: number;
+  folioLines: number;
+  divergences: LineEndpointDivergence[];
+};
+
+export class LineEndpointManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LineEndpointManifestError";
+  }
+}
+
+type CreateManifestOptions = {
+  reference: DocGeom;
+  sourceFileName: string;
+  sourceSha256: string;
+  capturedAt?: string;
+};
+
+export const createWordLineEndpointManifest = ({
+  reference,
+  sourceFileName,
+  sourceSha256,
+  capturedAt = new Date().toISOString(),
+}: CreateManifestOptions): WordLineEndpointManifest => {
+  if (reference.source !== "word") {
+    throw new LineEndpointManifestError("Line-endpoint manifests must be captured from Word.");
+  }
+  if (!SHA256_PATTERN.test(sourceSha256)) {
+    throw new LineEndpointManifestError("The source SHA-256 must be 64 lowercase hex characters.");
+  }
+  const fileName = requireSourceFileName(sourceFileName);
+
+  const wordVersion = nonEmpty(reference.meta["wordVersion"]);
+  const mutoolVersion = nonEmpty(reference.meta["mutool"]);
+
+  return {
+    schema: LINE_ENDPOINT_MANIFEST_SCHEMA,
+    version: LINE_ENDPOINT_MANIFEST_VERSION,
+    source: { fileName, sha256: sourceSha256 },
+    reference: {
+      renderer: "word",
+      capturedAt,
+      ...(wordVersion === undefined ? {} : { wordVersion }),
+      ...(mutoolVersion === undefined ? {} : { mutoolVersion }),
+    },
+    pages: extractLineEndpointPages(reference),
+  };
+};
+
+export const extractLineEndpointPages = (geom: DocGeom): LineEndpointPage[] =>
+  geom.pages.map((page) => ({
+    number: page.number,
+    lines: mergeVisualRows(page.lines)
+      .map((line) => ({ text: normalizeLineText(line.text), region: line.region }))
+      .filter(({ text }) => text.length > 0),
+  }));
+
+export const compareLineEndpoints = (
+  manifest: WordLineEndpointManifest,
+  folio: DocGeom,
+): LineEndpointValidationResult => {
+  const referenceGeom = endpointPagesToGeom({
+    pages: manifest.pages,
+    source: "word",
+    file: manifest.source.fileName,
+  });
+  const folioPages = extractLineEndpointPages(folio);
+  const folioGeom = endpointPagesToGeom({ pages: folioPages, source: "folio", file: folio.file });
+
+  // The shared comparison engine owns sequence alignment, pagination matching,
+  // and one-to-many line-break reconciliation. Canonical geometry deliberately
+  // removes x/y/width differences so this validator reports endpoints only.
+  const result = compareGeoms(referenceGeom, folioGeom);
+  const divergences = result.divergences.filter(isLineEndpointDivergence);
+
+  return {
+    matches: divergences.length === 0,
+    referenceLines: countLines(manifest.pages),
+    folioLines: countLines(folioPages),
+    divergences,
+  };
+};
+
+type EndpointPagesToGeomOptions = {
+  pages: LineEndpointPage[];
+  source: "word" | "folio";
+  file: string;
+};
+
+const endpointPagesToGeom = ({ pages, source, file }: EndpointPagesToGeomOptions): DocGeom => ({
+  source,
+  file,
+  meta: { canonicalizedFor: "line-endpoints" },
+  pages: pages.map(endpointPageToGeom),
+});
+
+const endpointPageToGeom = (page: LineEndpointPage): PageGeom => ({
+  number: page.number,
+  widthPt: 612,
+  heightPt: 792,
+  lines: page.lines.map(endpointToLineBox),
+});
+
+const endpointToLineBox = ({ text, region }: LineEndpoint, index: number): LineBox => ({
+  text,
+  normText: normalizeLineText(text),
+  xPt: 0,
+  yPt: index * 12,
+  baselinePt: index * 12 + 9,
+  widthPt: normalizeLineText(text).length,
+  heightPt: 10,
+  region,
+});
+
+const isLineEndpointDivergence = (divergence: Divergence): divergence is LineEndpointDivergence => {
+  switch (divergence.kind) {
+    case "page-count":
+    case "pagination":
+    case "line-break":
+    case "missing-line":
+    case "extra-line":
+    case "text-mismatch":
+      return true;
+    case "x-drift":
+    case "y-drift":
+    case "width-drift":
+      return false;
+  }
+};
+
+const countLines = (pages: LineEndpointPage[]): number =>
+  pages.reduce((total, page) => total + page.lines.length, 0);
+
+const nonEmpty = (value: string | undefined): string | undefined =>
+  value === undefined || value.length === 0 ? undefined : value;
+
+export const parseLineEndpointManifest = (value: unknown): WordLineEndpointManifest => {
+  const root = requireRecord(value, "manifest");
+  if (root["schema"] !== LINE_ENDPOINT_MANIFEST_SCHEMA) {
+    throw new LineEndpointManifestError("Unsupported line-endpoint manifest schema.");
+  }
+  if (root["version"] !== LINE_ENDPOINT_MANIFEST_VERSION) {
+    throw new LineEndpointManifestError(
+      `Unsupported line-endpoint manifest version: ${String(root["version"])}.`,
+    );
+  }
+
+  const source = requireRecord(root["source"], "source");
+  const fileName = requireSourceFileName(requireString(source["fileName"], "source.fileName"));
+  const sha256 = requireString(source["sha256"], "source.sha256");
+  if (!SHA256_PATTERN.test(sha256)) {
+    throw new LineEndpointManifestError("source.sha256 must be 64 lowercase hex characters.");
+  }
+
+  const reference = requireRecord(root["reference"], "reference");
+  if (reference["renderer"] !== "word") {
+    throw new LineEndpointManifestError("reference.renderer must be word.");
+  }
+  const capturedAt = requireString(reference["capturedAt"], "reference.capturedAt");
+  if (Number.isNaN(Date.parse(capturedAt))) {
+    throw new LineEndpointManifestError("reference.capturedAt must be an ISO timestamp.");
+  }
+  const wordVersion = optionalString(reference["wordVersion"], "reference.wordVersion");
+  const mutoolVersion = optionalString(reference["mutoolVersion"], "reference.mutoolVersion");
+
+  if (!Array.isArray(root["pages"])) {
+    throw new LineEndpointManifestError("pages must be an array.");
+  }
+  const pages = root["pages"].map(parsePage);
+  for (let index = 1; index < pages.length; index += 1) {
+    const previous = pages[index - 1];
+    const current = pages[index];
+    if (previous !== undefined && current !== undefined && current.number <= previous.number) {
+      throw new LineEndpointManifestError("Page numbers must be strictly increasing.");
+    }
+  }
+
+  return {
+    schema: LINE_ENDPOINT_MANIFEST_SCHEMA,
+    version: LINE_ENDPOINT_MANIFEST_VERSION,
+    source: { fileName, sha256 },
+    reference: {
+      renderer: "word",
+      capturedAt,
+      ...(wordVersion === undefined ? {} : { wordVersion }),
+      ...(mutoolVersion === undefined ? {} : { mutoolVersion }),
+    },
+    pages,
+  };
+};
+
+const parsePage = (value: unknown, pageIndex: number): LineEndpointPage => {
+  const page = requireRecord(value, `pages[${pageIndex}]`);
+  const number = page["number"];
+  if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
+    throw new LineEndpointManifestError(`pages[${pageIndex}].number must be a positive integer.`);
+  }
+  if (!Array.isArray(page["lines"])) {
+    throw new LineEndpointManifestError(`pages[${pageIndex}].lines must be an array.`);
+  }
+  return { number, lines: page["lines"].map((line, index) => parseLine(line, pageIndex, index)) };
+};
+
+const parseLine = (value: unknown, pageIndex: number, lineIndex: number): LineEndpoint => {
+  const prefix = `pages[${pageIndex}].lines[${lineIndex}]`;
+  const line = requireRecord(value, prefix);
+  const text = requireString(line["text"], `${prefix}.text`);
+  const region = line["region"];
+  if (typeof region !== "string" || !isRegion(region)) {
+    throw new LineEndpointManifestError(`${prefix}.region is invalid.`);
+  }
+  return { text, region };
+};
+
+const isRegion = (value: string): value is Region =>
+  value === "body" ||
+  value === "header" ||
+  value === "footer" ||
+  value === "footnote" ||
+  value === "unknown";
+
+const requireRecord = (value: unknown, field: string): Record<string, unknown> => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new LineEndpointManifestError(`${field} must be an object.`);
+  }
+  return Object.fromEntries(Object.entries(value));
+};
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new LineEndpointManifestError(`${field} must be a non-empty string.`);
+  }
+  return value;
+};
+
+const optionalString = (value: unknown, field: string): string | undefined => {
+  if (value === undefined) return undefined;
+  return requireString(value, field);
+};
+
+const requireSourceFileName = (value: string): string => {
+  if (value.length === 0 || value.includes("/") || value.includes("\\")) {
+    throw new LineEndpointManifestError("source.fileName must be a basename without directories.");
+  }
+  return value;
+};
+
+export const readLineEndpointManifest = async (
+  manifestPath: string,
+): Promise<WordLineEndpointManifest> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await Bun.file(manifestPath).text());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new LineEndpointManifestError(`Cannot read line-endpoint manifest: ${message}`);
+  }
+  return parseLineEndpointManifest(parsed);
+};

--- a/parity/lineEndpointsCli.ts
+++ b/parity/lineEndpointsCli.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env bun
+/**
+ * Capture Microsoft Word line endpoints into a portable manifest, or validate
+ * Folio against a previously captured manifest without launching Word.
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { createFolioExtractor } from "./folioExtract";
+import {
+  LineEndpointManifestError,
+  compareLineEndpoints,
+  createWordLineEndpointManifest,
+  readLineEndpointManifest,
+} from "./lineEndpoints";
+import { sha256OfFile } from "./pdfReference";
+import type { LineEndpointDivergence } from "./lineEndpoints";
+import { getWordTruth } from "./wordTruth";
+
+const EXIT_OK = 0;
+const EXIT_DIVERGENT = 1;
+const EXIT_INFRA_FAILURE = 2;
+
+export type LineEndpointCliCommand =
+  | { type: "help" }
+  | { type: "capture"; docxPath: string; outputPath: string; refreshWord: boolean }
+  | {
+      type: "validate";
+      docxPath: string;
+      manifestPath: string;
+      headed: boolean;
+      reuseServer: boolean;
+    };
+
+export const parseLineEndpointCliArgs = (argv: string[]): LineEndpointCliCommand => {
+  const command = argv.at(0);
+  if (command === undefined || command === "--help" || command === "-h") {
+    return { type: "help" };
+  }
+  if (command !== "capture" && command !== "validate") {
+    throw new LineEndpointManifestError(`Unknown command: ${command}`);
+  }
+
+  const docxPath = argv.at(1);
+  if (docxPath === undefined || docxPath.startsWith("--")) {
+    throw new LineEndpointManifestError(`${command} requires a DOCX path.`);
+  }
+
+  if (command === "capture") {
+    let outputPath: string | undefined;
+    let refreshWord = false;
+    for (let index = 2; index < argv.length; index += 1) {
+      const arg = argv[index];
+      if (arg === "--refresh-word") {
+        refreshWord = true;
+        continue;
+      }
+      if (arg === "--output") {
+        outputPath = requireFlagValue({ argv, index, flag: arg });
+        index += 1;
+        continue;
+      }
+      throw new LineEndpointManifestError(`Unknown capture option: ${String(arg)}`);
+    }
+    if (outputPath === undefined) {
+      throw new LineEndpointManifestError("capture requires --output <manifest.json>.");
+    }
+    return { type: "capture", docxPath, outputPath, refreshWord };
+  }
+
+  let manifestPath: string | undefined;
+  let headed = false;
+  let reuseServer = false;
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--headed") {
+      headed = true;
+      continue;
+    }
+    if (arg === "--reuse-server") {
+      reuseServer = true;
+      continue;
+    }
+    if (arg === "--manifest") {
+      manifestPath = requireFlagValue({ argv, index, flag: arg });
+      index += 1;
+      continue;
+    }
+    throw new LineEndpointManifestError(`Unknown validate option: ${String(arg)}`);
+  }
+  if (manifestPath === undefined) {
+    throw new LineEndpointManifestError("validate requires --manifest <manifest.json>.");
+  }
+  return { type: "validate", docxPath, manifestPath, headed, reuseServer };
+};
+
+type RequireFlagValueOptions = {
+  argv: string[];
+  index: number;
+  flag: string;
+};
+
+const requireFlagValue = ({ argv, index, flag }: RequireFlagValueOptions): string => {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new LineEndpointManifestError(`${flag} requires a path.`);
+  }
+  return value;
+};
+
+const HELP_TEXT = `Microsoft Word line-endpoint validator
+
+Usage:
+  bun parity/lineEndpointsCli.ts capture <file.docx> --output <manifest.json> [--refresh-word]
+  bun parity/lineEndpointsCli.ts validate <file.docx> --manifest <manifest.json> [--headed] [--reuse-server]
+
+Capture requires Microsoft Word for Mac and mutool. Validate uses only the
+captured manifest and Folio, so it can run without Word. Manifests contain
+normalized document line text; do not commit captures from confidential files.
+`;
+
+const assertFileExists = async (filePath: string, label: string): Promise<void> => {
+  if (!(await Bun.file(filePath).exists())) {
+    throw new LineEndpointManifestError(`${label} does not exist: ${filePath}`);
+  }
+};
+
+const capture = async (
+  command: Extract<LineEndpointCliCommand, { type: "capture" }>,
+): Promise<number> => {
+  const docxPath = path.resolve(command.docxPath);
+  const outputPath = path.resolve(command.outputPath);
+  await assertFileExists(docxPath, "DOCX");
+
+  const [reference, sourceSha256] = await Promise.all([
+    getWordTruth(docxPath, { refresh: command.refreshWord }),
+    sha256OfFile(docxPath),
+  ]);
+  const manifest = createWordLineEndpointManifest({
+    reference,
+    sourceFileName: path.basename(docxPath),
+    sourceSha256,
+  });
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await Bun.write(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  const lineCount = manifest.pages.reduce((total, page) => total + page.lines.length, 0);
+  console.log(
+    `Captured ${lineCount} Word line endpoint${lineCount === 1 ? "" : "s"} across ${manifest.pages.length} page${manifest.pages.length === 1 ? "" : "s"}: ${outputPath}`,
+  );
+  return EXIT_OK;
+};
+
+const validate = async (
+  command: Extract<LineEndpointCliCommand, { type: "validate" }>,
+): Promise<number> => {
+  const docxPath = path.resolve(command.docxPath);
+  const manifestPath = path.resolve(command.manifestPath);
+  await Promise.all([
+    assertFileExists(docxPath, "DOCX"),
+    assertFileExists(manifestPath, "Manifest"),
+  ]);
+
+  const [manifest, sourceSha256] = await Promise.all([
+    readLineEndpointManifest(manifestPath),
+    sha256OfFile(docxPath),
+  ]);
+  if (manifest.source.sha256 !== sourceSha256) {
+    throw new LineEndpointManifestError(
+      `Manifest source hash does not match ${path.basename(docxPath)}. Capture a new manifest for this exact DOCX.`,
+    );
+  }
+
+  const extractor = await createFolioExtractor({
+    headless: !command.headed,
+    reuseServer: command.reuseServer,
+  });
+  try {
+    const folio = await extractor.extract(docxPath);
+    const result = compareLineEndpoints(manifest, folio.geom);
+    if (result.matches) {
+      console.log(
+        `PASS: ${result.folioLines} Folio line endpoints match Word ${manifest.reference.wordVersion ?? "unknown version"}.`,
+      );
+      return EXIT_OK;
+    }
+
+    console.error(
+      `FAIL: ${result.divergences.length} line-endpoint divergence${result.divergences.length === 1 ? "" : "s"} (${result.referenceLines} Word lines, ${result.folioLines} Folio lines).`,
+    );
+    for (const divergence of result.divergences) {
+      console.error(`  ${formatDivergence(divergence)}`);
+    }
+    return EXIT_DIVERGENT;
+  } finally {
+    await extractor.close();
+  }
+};
+
+const formatDivergence = (divergence: LineEndpointDivergence): string => {
+  switch (divergence.kind) {
+    case "page-count":
+      return `page count: Word ${divergence.reference}, Folio ${divergence.folio}`;
+    case "pagination":
+      return `pagination: “${divergence.text}” on Word page ${divergence.referencePage}, Folio page ${divergence.folioPage}`;
+    case "line-break":
+      return `page ${divergence.page}: Word [${divergence.referenceTexts.join(" | ")}], Folio [${divergence.folioTexts.join(" | ")}]`;
+    case "missing-line":
+      return `page ${divergence.page}: missing Folio line “${divergence.text}”`;
+    case "extra-line":
+      return `page ${divergence.page}: extra Folio line “${divergence.text}”`;
+    case "text-mismatch":
+      return `page ${divergence.page}: Word “${divergence.referenceText}”, Folio “${divergence.folioText}”`;
+  }
+};
+
+export const runLineEndpointCli = async (argv: string[]): Promise<number> => {
+  const command = parseLineEndpointCliArgs(argv);
+  if (command.type === "help") {
+    console.log(HELP_TEXT);
+    return EXIT_OK;
+  }
+  if (command.type === "capture") return await capture(command);
+  return await validate(command);
+};
+
+if (import.meta.main) {
+  try {
+    process.exitCode = await runLineEndpointCli(process.argv.slice(2));
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error(`Word line-endpoint validator failed: ${err.name}: ${err.message}`);
+    process.exitCode = EXIT_INFRA_FAILURE;
+  }
+}


### PR DESCRIPTION
Adds a versioned manifest for capturing Microsoft Word visual line endpoints and an offline validator for comparing Folio without launching Word. Manifests bind to an exact DOCX SHA-256 and deliberately omit geometry and local source paths. Documents the clean-room limitations and sensitive-text handling.