### PR TITLE
fix: preserve bold automatic list marker formatting

### DIFF
--- a/.changeset/calm-markers-emphasize.md
+++ b/.changeset/calm-markers-emphasize.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve explicit bold formatting on automatic list markers through parsing, layout, and painting.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -617,7 +617,8 @@ export type ParagraphAttrs = {
     listIsBullet?: boolean;
     listMarkerHidden?: boolean;
     listMarkerFontFamily?: string;
-    listMarkerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    listMarkerFontSize?: number;
+    listMarkerBold?: boolean; /** Horizontal alignment of the marker around the paragraph's list anchor. */
     listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing";
     listMarkerRevision?: {

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -210,7 +210,8 @@ export type ParagraphAttrs = {
     listMarker?: string; /** Whether the list marker is hidden (w:vanish on numbering level rPr) */
     listMarkerHidden?: boolean; /** Marker font family from numbering level rPr */
     listMarkerFontFamily?: string; /** Marker font size from numbering level rPr, in points */
-    listMarkerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    listMarkerFontSize?: number; /** Marker bold state from numbering level rPr */
+    listMarkerBold?: boolean; /** Horizontal alignment of the marker around the paragraph's list anchor. */
     listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing"; /** `w:caps` on the numbering level rPr — render marker in upper case. */
     listMarkerAllCaps?: boolean;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -312,7 +312,8 @@ export type ParagraphAttrs = {
     listMarker?: string; /** Whether the list marker is hidden (w:vanish on numbering level rPr) */
     listMarkerHidden?: boolean; /** Marker font family from numbering level rPr */
     listMarkerFontFamily?: string; /** Marker font size from numbering level rPr, in points */
-    listMarkerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    listMarkerFontSize?: number; /** Marker bold state from numbering level rPr */
+    listMarkerBold?: boolean; /** Horizontal alignment of the marker around the paragraph's list anchor. */
     listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing"; /** `w:caps` on the numbering level rPr — render marker in upper case. */
     listMarkerAllCaps?: boolean;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -523,7 +523,8 @@ export type ListRendering = {
     numFmt?: NumberFormat; /** Whether the list marker is hidden (w:vanish on level rPr) */
     markerHidden?: boolean; /** Marker font family from numbering level rPr (ascii name) */
     markerFontFamily?: string; /** Marker font size from numbering level rPr, in points */
-    markerFontSize?: number; /** Horizontal alignment of the marker around the paragraph's list anchor. */
+    markerFontSize?: number; /** Marker bold state from numbering level rPr */
+    markerBold?: boolean; /** Horizontal alignment of the marker around the paragraph's list anchor. */
     markerAlignment?: "left" | "center" | "right";
     markerAllCaps?: boolean;
     markerSuffix?: LevelSuffix; /** Number format for each level from 0 through this paragraph's level. */

--- a/packages/core/src/docx/numberingParser-custom-format.test.ts
+++ b/packages/core/src/docx/numberingParser-custom-format.test.ts
@@ -122,3 +122,22 @@ test("computeListRendering carries parent and current level starts", () => {
 
   expect(computeListRendering({ numId: 3, ilvl: 1 }, numbering)?.levelStarts).toEqual([3, 3]);
 });
+
+test("computeListRendering preserves explicit marker bold states", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W}>
+  <w:abstractNum w:abstractNumId="9">
+    <w:lvl w:ilvl="0">
+      <w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/><w:rPr><w:b/></w:rPr>
+    </w:lvl>
+    <w:lvl w:ilvl="1">
+      <w:numFmt w:val="lowerLetter"/><w:lvlText w:val="%2."/><w:rPr><w:b w:val="0"/></w:rPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="4"><w:abstractNumId w:val="9"/></w:num>
+</w:numbering>`;
+  const numbering = parseNumbering(xml);
+
+  expect(computeListRendering({ numId: 4, ilvl: 0 }, numbering)?.markerBold).toBe(true);
+  expect(computeListRendering({ numId: 4, ilvl: 1 }, numbering)?.markerBold).toBe(false);
+});

--- a/packages/core/src/docx/numberingParser.ts
+++ b/packages/core/src/docx/numberingParser.ts
@@ -966,6 +966,9 @@ export function computeListRendering(
   if (level.rPr?.fontSize) {
     rendering.markerFontSize = level.rPr.fontSize / 2;
   }
+  if (level.rPr?.bold !== undefined) {
+    rendering.markerBold = level.rPr.bold;
+  }
   if (level.rPr?.allCaps) {
     rendering.markerAllCaps = true;
   }

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1825,6 +1825,9 @@ export function parseParagraph(
         if (level.rPr?.fontSize) {
           listRendering.markerFontSize = level.rPr.fontSize / 2;
         }
+        if (level.rPr?.bold !== undefined) {
+          listRendering.markerBold = level.rPr.bold;
+        }
         if (level.rPr?.allCaps) {
           listRendering.markerAllCaps = true;
         }

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -938,6 +938,7 @@ function serializeParagraphAttrs(attrs: Record<string, unknown> | undefined): st
     "listMarker",
     "listIsBullet",
     "listMarkerHidden",
+    "listMarkerBold",
     "listMarkerAlignment",
     "listMarkerSuffix",
     "tabs",

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -64,6 +64,20 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.indent).toEqual({ left: 96, hanging: 24 });
   });
 
+  test("keeps an explicit list-marker bold override", () => {
+    const paragraph = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          { numPr: { numId: 1, ilvl: 0 }, listMarker: "%1.", listMarkerBold: false },
+          [schema.text("List item")],
+        ),
+      ]),
+    ).at(0);
+
+    expect(paragraph?.attrs?.listMarkerBold).toBe(false);
+  });
+
   test("preserves native frame wrap spacing on the positioned container", () => {
     const frame = {
       width: 3600,

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1301,6 +1301,11 @@ function toPreviousListAttrs(previousFormatting: Record<string, unknown>): PMPar
     attrs.listMarkerFontSize = listMarkerFontSize;
   }
 
+  const listMarkerBold = previousFormatting["listMarkerBold"];
+  if (typeof listMarkerBold === "boolean") {
+    attrs.listMarkerBold = listMarkerBold;
+  }
+
   const listMarkerAlignment = readListMarkerAlignment(previousFormatting["listMarkerAlignment"]);
   if (listMarkerAlignment) {
     attrs.listMarkerAlignment = listMarkerAlignment;
@@ -1382,6 +1387,9 @@ function applyDeletedListMarkerAttrs(
   }
   if (previousListAttrs.listMarkerFontSize) {
     attrs.listMarkerFontSize = previousListAttrs.listMarkerFontSize;
+  }
+  if (previousListAttrs.listMarkerBold !== undefined) {
+    attrs.listMarkerBold = previousListAttrs.listMarkerBold;
   }
   if (previousListAttrs.listMarkerAlignment) {
     attrs.listMarkerAlignment = previousListAttrs.listMarkerAlignment;
@@ -1765,6 +1773,9 @@ function convertParagraphAttrs(
   }
   if (pmAttrs.listMarkerFontSize) {
     attrs.listMarkerFontSize = pmAttrs.listMarkerFontSize;
+  }
+  if (pmAttrs.listMarkerBold !== null && pmAttrs.listMarkerBold !== undefined) {
+    attrs.listMarkerBold = pmAttrs.listMarkerBold;
   }
   if (pmAttrs.listMarkerAlignment) {
     attrs.listMarkerAlignment = pmAttrs.listMarkerAlignment;

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
@@ -112,6 +112,31 @@ describe("getListMarkerInlineWidth", () => {
     }, fakeMeasure);
   });
 
+  test("uses marker bold state for right-aligned visual offset", () => {
+    withFakeTextMeasure(
+      () => {
+        const regular = getListMarkerVisualOffset(
+          listBlock({
+            listMarker: "1.",
+            listMarkerAlignment: "right",
+            listMarkerBold: false,
+          }),
+        );
+        const bold = getListMarkerVisualOffset(
+          listBlock({
+            listMarker: "1.",
+            listMarkerAlignment: "right",
+            listMarkerBold: true,
+          }),
+        );
+
+        expect(regular).toBe(-20);
+        expect(bold).toBe(-24);
+      },
+      { charWidth: (_char, font) => (font.includes("800") ? 12 : 10) },
+    );
+  });
+
   test("center-aligned marker straddles its anchor", () => {
     withFakeTextMeasure(() => {
       const block = listBlock({

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
@@ -61,6 +61,31 @@ describe("getListMarkerInlineWidth", () => {
     }, fakeMeasure);
   });
 
+  test("uses marker bold state for natural-width measurement", () => {
+    withFakeTextMeasure(
+      () => {
+        const regular = getListMarkerInlineWidth(
+          listBlock({
+            listMarker: "1.",
+            listMarkerBold: false,
+            listMarkerSuffix: "nothing",
+          }),
+        );
+        const bold = getListMarkerInlineWidth(
+          listBlock({
+            listMarker: "1.",
+            listMarkerBold: true,
+            listMarkerSuffix: "nothing",
+          }),
+        );
+
+        expect(regular).toBe(20);
+        expect(bold).toBe(24);
+      },
+      { charWidth: (_char, font) => (font.includes("800") ? 12 : 10) },
+    );
+  });
+
   test('w:suff="space" → natural + one space glyph', () => {
     withFakeTextMeasure(() => {
       const width = getListMarkerInlineWidth(

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.ts
@@ -158,8 +158,12 @@ export function getListMarkerVisualOffset(block: ParagraphBlock): number {
     return 0;
   }
 
-  const { fontFamily, fontSize } = resolveListMarkerFont(block);
-  const naturalWidth = measureTextWidth(attrs.listMarker, { fontFamily, fontSize });
+  const { fontFamily, fontSize, bold } = resolveListMarkerFont(block);
+  const naturalWidth = measureTextWidth(attrs.listMarker, {
+    fontFamily,
+    fontSize,
+    ...(bold !== undefined ? { bold } : {}),
+  });
   if (attrs.listMarkerAlignment === "right") {
     return -naturalWidth;
   }

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.ts
@@ -39,6 +39,7 @@ const TWIPS_TO_PX = 96 / 1440;
 export function resolveListMarkerFont(block: ParagraphBlock): {
   fontFamily: string;
   fontSize: number;
+  bold?: boolean;
 } {
   const attrs = block.attrs;
   const firstTextRun = block.runs.find((r): r is TextRun => r.kind === "text");
@@ -52,7 +53,8 @@ export function resolveListMarkerFont(block: ParagraphBlock): {
     firstTextRun?.fontSize ??
     attrs?.defaultFontSize ??
     DEFAULT_FONT_SIZE;
-  return { fontFamily, fontSize };
+  const bold = attrs?.listMarkerBold ?? firstTextRun?.bold;
+  return { fontFamily, fontSize, ...(bold !== undefined ? { bold } : {}) };
 }
 
 /**
@@ -79,8 +81,8 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
     return 0;
   }
 
-  const { fontFamily, fontSize } = resolveListMarkerFont(block);
-  const style: FontStyle = { fontFamily, fontSize };
+  const { fontFamily, fontSize, bold } = resolveListMarkerFont(block);
+  const style: FontStyle = { fontFamily, fontSize, ...(bold !== undefined ? { bold } : {}) };
   const naturalWidth = measureTextWidth(attrs.listMarker, style);
   const markerEndOffset = getMarkerEndOffset(naturalWidth, attrs.listMarkerAlignment);
 

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -447,6 +447,7 @@ export type ParagraphAttrs = {
   listMarkerHidden?: boolean; // w:vanish on numbering level rPr
   listMarkerFontFamily?: string; // from numbering level rPr (w:rFonts)
   listMarkerFontSize?: number; // from numbering level rPr, in points
+  listMarkerBold?: boolean; // from numbering level rPr (w:b)
   /** Horizontal alignment of the marker around the paragraph's list anchor. */
   listMarkerAlignment?: "left" | "center" | "right";
   /**

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -83,6 +83,7 @@ const fakeDocument = {
 function renderListItem(
   indent: { left: number; hanging: number },
   listMarkerAlignment?: "left" | "center" | "right",
+  listMarkerBold?: boolean,
 ): {
   line: HTMLElement;
   marker: HTMLElement | undefined;
@@ -91,7 +92,7 @@ function renderListItem(
     kind: "paragraph",
     id: "p1",
     runs: [{ kind: "text", text: "TEST1" }],
-    attrs: { listMarker: "1.", indent, listMarkerAlignment },
+    attrs: { listMarker: "1.", indent, listMarkerAlignment, listMarkerBold },
   };
   const measure: ParagraphMeasure = {
     kind: "paragraph",
@@ -149,6 +150,14 @@ function renderListItem(
 }
 
 describe("Issue #729 — list hanging indent exceeding left indent", () => {
+  test("marker bold state reaches the painted element", () => {
+    const bold = renderListItem({ left: 48, hanging: 24 }, undefined, true).marker;
+    const regular = renderListItem({ left: 48, hanging: 24 }, undefined, false).marker;
+
+    expect(bold?.style.fontWeight).toBe("800");
+    expect(regular?.style.fontWeight).toBe("normal");
+  });
+
   test("right-aligned marker paints before its anchor without moving body text", () => {
     const { marker } = renderListItem({ left: 48, hanging: 24 }, "right");
 

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2732,7 +2732,11 @@ export function renderParagraphFragment(
       // 2. First text run's font (paragraph content)
       // 3. Paragraph default font (from style)
       let firstTextRun: TextRun | undefined;
-      if (!block.attrs.listMarkerFontFamily || !block.attrs.listMarkerFontSize) {
+      if (
+        !block.attrs.listMarkerFontFamily ||
+        !block.attrs.listMarkerFontSize ||
+        block.attrs.listMarkerBold === undefined
+      ) {
         for (let ri = line.fromRun; ri <= line.toRun; ri++) {
           const r = block.runs[ri];
           if (r && r.kind === "text") {
@@ -2747,6 +2751,7 @@ export function renderParagraphFragment(
         block.attrs.defaultFontFamily;
       const markerFontSize =
         block.attrs.listMarkerFontSize ?? firstTextRun?.fontSize ?? block.attrs.defaultFontSize;
+      const markerBold = block.attrs.listMarkerBold ?? firstTextRun?.bold;
 
       const marker = renderListMarker(
         block.attrs.listMarker,
@@ -2755,6 +2760,7 @@ export function renderParagraphFragment(
         doc,
         markerFontFamily,
         markerFontSize,
+        markerBold,
         block.attrs.listMarkerRevision,
         block.attrs.listMarkerSecondSlotOffsetTwips,
       );
@@ -2797,6 +2803,7 @@ function renderListMarker(
   doc: Document,
   fontFamily?: string,
   fontSize?: number,
+  bold?: boolean,
   revision?: ParagraphAttrs["listMarkerRevision"],
   secondSlotOffsetTwips?: number,
 ): HTMLElement {
@@ -2812,6 +2819,9 @@ function renderListMarker(
   if (fontSize) {
     // 1pt = 96/72 px
     span.style.fontSize = `${(fontSize * 96) / 72}px`;
+  }
+  if (bold !== undefined) {
+    span.style.fontWeight = bold ? DOCX_BOLD_FONT_WEIGHT : "normal";
   }
 
   // `text-align-last` inherits, so a justified paragraph would distribute the

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -272,6 +272,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   optionalBoolean(attrs, "listMarkerHidden", "paragraph.attrs.listMarkerHidden", issues);
   optionalString(attrs, "listMarkerFontFamily", "paragraph.attrs.listMarkerFontFamily", issues);
   optionalNumber(attrs, "listMarkerFontSize", "paragraph.attrs.listMarkerFontSize", issues);
+  optionalBoolean(attrs, "listMarkerBold", "paragraph.attrs.listMarkerBold", issues);
   optionalOneOf(attrs, "listMarkerAlignment", "paragraph.attrs.listMarkerAlignment", issues, [
     "left",
     "center",

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -520,6 +520,9 @@ function listRenderingFromAttrs(attrs: ParagraphAttrs): Paragraph["listRendering
     ...(attrs.listMarkerFontSize != null && {
       markerFontSize: attrs.listMarkerFontSize,
     }),
+    ...(attrs.listMarkerBold != null && {
+      markerBold: attrs.listMarkerBold,
+    }),
     ...(attrs.listMarkerAlignment != null && {
       markerAlignment: attrs.listMarkerAlignment,
     }),

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -494,6 +494,9 @@ function paragraphFormattingToAttrs(
   if (paragraph.listRendering?.markerFontSize) {
     attrs.listMarkerFontSize = paragraph.listRendering.markerFontSize;
   }
+  if (paragraph.listRendering?.markerBold !== undefined) {
+    attrs.listMarkerBold = paragraph.listRendering.markerBold;
+  }
   if (paragraph.listRendering?.markerAlignment) {
     attrs.listMarkerAlignment = paragraph.listRendering.markerAlignment;
   }

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -342,6 +342,7 @@ const paragraphNodeSpec: NodeSpec = {
     listMarkerHidden: { default: null },
     listMarkerFontFamily: { default: null },
     listMarkerFontSize: { default: null },
+    listMarkerBold: { default: null },
     listMarkerAlignment: { default: null },
     listMarkerSuffix: { default: null },
     listMarkerAllCaps: { default: null },

--- a/packages/core/src/prosemirror/extensions/features/ListExtension-suggestion.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension-suggestion.test.ts
@@ -82,6 +82,7 @@ describe("ListExtension suggestion mode integration", () => {
       listMarkerHidden: null,
       listMarkerFontFamily: null,
       listMarkerFontSize: null,
+      listMarkerBold: null,
       listMarkerAlignment: null,
       listMarkerSuffix: null,
       listLevelNumFmts: null,

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -63,6 +63,7 @@ const LIST_FORMATTING_ATTRS = [
   "listMarkerHidden",
   "listMarkerFontFamily",
   "listMarkerFontSize",
+  "listMarkerBold",
   "listMarkerAlignment",
   "listMarkerSuffix",
   "listLevelNumFmts",

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -110,6 +110,8 @@ export type ParagraphAttrs = {
   listMarkerFontFamily?: string;
   /** Marker font size from numbering level rPr, in points */
   listMarkerFontSize?: number;
+  /** Marker bold state from numbering level rPr */
+  listMarkerBold?: boolean;
   /** Horizontal alignment of the marker around the paragraph's list anchor. */
   listMarkerAlignment?: "left" | "center" | "right";
   /**

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -110,6 +110,7 @@ export function listAttrsFromResolvedStyle(
     listMarkerHidden: rendering?.markerHidden ?? null,
     listMarkerFontFamily: rendering?.markerFontFamily ?? null,
     listMarkerFontSize: rendering?.markerFontSize ?? null,
+    listMarkerBold: rendering?.markerBold ?? null,
     listMarkerAlignment: rendering?.markerAlignment ?? null,
     listMarkerSuffix: rendering?.markerSuffix ?? null,
     listMarkerAllCaps: rendering?.markerAllCaps ?? null,

--- a/packages/docx-core/src/model/lists.ts
+++ b/packages/docx-core/src/model/lists.ts
@@ -176,6 +176,8 @@ export type ListRendering = {
   markerFontFamily?: string;
   /** Marker font size from numbering level rPr, in points */
   markerFontSize?: number;
+  /** Marker bold state from numbering level rPr */
+  markerBold?: boolean;
   /** Horizontal alignment of the marker around the paragraph's list anchor. */
   markerAlignment?: "left" | "center" | "right";
   /**


### PR DESCRIPTION
Preserves explicit bold and regular states from numbering-level run properties across the document model, editor attributes, layout, and painting.

Uses the same marker weight for deterministic width measurement and visual output, including explicit regular overrides.

CC on behalf of @jan-kubica
