### PR TITLE
feat: add automatic DOCX hyphenation

### DIFF
--- a/.changeset/gentle-word-hyphenation.md
+++ b/.changeset/gentle-word-hyphenation.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": minor
+---
+
+Add locale-aware DOCX automatic hyphenation and tighter Word hanging-punctuation layout.

--- a/api-reports/core/layout-bridge-engine-measuring.api.md
+++ b/api-reports/core/layout-bridge-engine-measuring.api.md
@@ -166,13 +166,17 @@ export type LineBreakPolicy = {
     kinsoku?: boolean; /** Document override: characters that may not begin a line. */
     noLineBreaksBefore?: string; /** Document override: characters that may not end a line. */
     noLineBreaksAfter?: string; /** Use the legacy Ethiopic/Amharic compatibility behavior. */
-    useLegacyEthiopicAmharicRules?: boolean;
+    useLegacyEthiopicAmharicRules?: boolean; /** Keep words made entirely of capital letters unhyphenated. */
+    doNotHyphenateCaps?: boolean; /** The run renders with the DOCX all-caps transform. */
+    renderedAllCaps?: boolean;
 };
 
 // @public (undocumented)
 export type LineBreakProvider = {
     findBreaks: (text: string, policy?: LineBreakPolicy) => number[]; /** Grapheme-safe emergency-wrap offsets, in ascending UTF-16 order. */
-    findGraphemeBreaks: (text: string, policy?: LineBreakPolicy) => number[];
+    findGraphemeBreaks: (text: string, policy?: LineBreakPolicy) => number[]; /** Dictionary-based discretionary hyphen offsets, in ascending UTF-16 order. */
+    findHyphenationBreaks?: (text: string, policy?: LineBreakPolicy) => number[]; /** Whether a trailing grapheme may overhang the line edge. */
+    isHangingPunctuation?: (text: string, policy?: LineBreakPolicy) => boolean;
 };
 
 // @public

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -473,7 +473,10 @@ export type MeasuredLine = {
     lineHeight: number; /** Left offset from floating images (pixels from content left edge). */
     leftOffset?: number; /** Right offset from floating images (pixels from content right edge). */
     rightOffset?: number;
-    floatSkipBefore?: number;
+    floatSkipBefore?: number; /** Decorative hyphen inserted at a dictionary break without changing source text. */
+    discretionaryHyphen?: {
+        runIndex: number;
+    };
 };
 
 // @public
@@ -564,7 +567,13 @@ export type PaginatorOptions = {
 export type ParagraphAttrs = {
     alignment?: "left" | "center" | "right" | "justify"; /** East Asian first/last-character restrictions (`w:kinsoku`). */
     kinsoku?: boolean; /** Hanging punctuation (`w:overflowPunct`), retained for layout policy. */
-    overflowPunctuation?: boolean; /** Document-wide custom line-edge characters and compatibility behavior. */
+    overflowPunctuation?: boolean; /** Exempt this paragraph from document automatic hyphenation. */
+    suppressAutoHyphens?: boolean; /** Document-wide automatic hyphenation controls retained for line layout. */
+    automaticHyphenation?: {
+        enabled: true;
+        doNotHyphenateCaps?: boolean;
+        consecutiveLineLimit?: number;
+    }; /** Document-wide custom line-edge characters and compatibility behavior. */
     lineBreakRules?: {
         noLineBreaksBefore?: {
             language?: string;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -184,7 +184,8 @@ export type ParagraphAttrs = {
     textId?: string;
     alignment?: import__stll_docx_core_model.ParagraphAlignment; /** Effective East Asian line-edge policy (`w:kinsoku`). */
     kinsoku?: boolean; /** Effective hanging-punctuation policy (`w:overflowPunct`). */
-    overflowPunctuation?: boolean;
+    overflowPunctuation?: boolean; /** Effective paragraph opt-out from document automatic hyphenation. */
+    suppressAutoHyphens?: boolean;
     spaceBefore?: number;
     spaceAfter?: number;
     lineSpacing?: number;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -286,7 +286,8 @@ export type ParagraphAttrs = {
     textId?: string;
     alignment?: import__stll_docx_core_model.ParagraphAlignment; /** Effective East Asian line-edge policy (`w:kinsoku`). */
     kinsoku?: boolean; /** Effective hanging-punctuation policy (`w:overflowPunct`). */
-    overflowPunctuation?: boolean;
+    overflowPunctuation?: boolean; /** Effective paragraph opt-out from document automatic hyphenation. */
+    suppressAutoHyphens?: boolean;
     spaceBefore?: number;
     spaceAfter?: number;
     lineSpacing?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -180,7 +180,11 @@ export type DocumentSettings = {
     themeFontLang?: {
         eastAsia?: string;
         bidi?: string;
-    }; /** Word/OOXML document-wide line-breaking overrides. */
+    }; /** Automatically hyphenate eligible paragraphs (`w:autoHyphenation`). */
+    autoHyphenation?: boolean; /** Keep all-capital words unhyphenated (`w:doNotHyphenateCaps`). */
+    doNotHyphenateCaps?: boolean; /** Maximum consecutive automatically hyphenated lines; zero means unlimited. */
+    consecutiveHyphenLimit?: number; /** Legacy hyphenation zone (`w:hyphenationZone`) in twips; retained for compatibility tooling. */
+    hyphenationZoneTwips?: number; /** Word/OOXML document-wide line-breaking overrides. */
     lineBreakRules?: {
         noLineBreaksBefore?: {
             language?: string;

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "better-result": "2.9.2",
         "csstype": "^3.1.3",
         "fast-xml-parser": "^5.9.3",
+        "hyphen": "1.14.1",
         "jszip": "3.10.1",
         "marked": "^18.0.5",
         "prosemirror-commands": "^1.7.1",
@@ -73,6 +74,9 @@
         "valibot": "1.4.2",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.31",
+      },
+      "devDependencies": {
+        "@types/hyphen": "1.14.0",
       },
     },
     "packages/docx-core": {
@@ -937,6 +941,8 @@
 
     "@types/gensync": ["@types/gensync@1.0.5", "", {}, "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg=="],
 
+    "@types/hyphen": ["@types/hyphen@1.14.0", "", {}, "sha512-Fc/WIwPD0evpA4cFqdek0nqJpJCMeSqKJwwqYGyVI6snpGmf6eISdD2RnQ7+KhEeo5D05CQtAVfV16/FZ+TzLg=="],
+
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
@@ -1456,6 +1462,8 @@
     "human-id": ["human-id@4.2.0", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA=="],
 
     "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "hyphen": ["hyphen@1.14.1", "", {}, "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw=="],
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,7 @@
     "better-result": "2.9.2",
     "csstype": "^3.1.3",
     "fast-xml-parser": "^5.9.3",
+    "hyphen": "1.14.1",
     "jszip": "3.10.1",
     "marked": "^18.0.5",
     "prosemirror-commands": "^1.7.1",
@@ -78,5 +79,8 @@
     "valibot": "1.4.2",
     "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.31"
+  },
+  "devDependencies": {
+    "@types/hyphen": "1.14.0"
   }
 }

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -825,6 +825,25 @@ describe("runLayoutPipeline", () => {
     });
   });
 
+  test("threads document automatic-hyphenation settings into paragraph layout", () => {
+    const document = createEmptyDocument();
+    document.package.settings = {
+      defaultTabStop: 720,
+      autoHyphenation: true,
+      doNotHyphenateCaps: true,
+      consecutiveHyphenLimit: 2,
+    };
+
+    const outcome = runLayoutPipeline(makeDeps(createLayoutSession(), { document }), makeState());
+    const paragraph = outcome.blocks?.find((block) => block.kind === "paragraph");
+
+    expect(paragraph?.attrs?.automaticHyphenation).toEqual({
+      enabled: true,
+      doNotHyphenateCaps: true,
+      consecutiveLineLimit: 2,
+    });
+  });
+
   test("uses the final section start mode for an implicit paragraph boundary", () => {
     const state = makeImplicitSectionBoundaryState();
     const continuous = runLayoutPipeline(

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -303,6 +303,18 @@ export function runLayoutPipeline<THfPMs>(
     if (document?.package.settings?.lineBreakRules) {
       flowOpts.lineBreakRules = document.package.settings.lineBreakRules;
     }
+    const documentSettings = document?.package.settings;
+    if (documentSettings?.autoHyphenation === true) {
+      flowOpts.automaticHyphenation = {
+        enabled: true,
+        ...(documentSettings.doNotHyphenateCaps !== undefined
+          ? { doNotHyphenateCaps: documentSettings.doNotHyphenateCaps }
+          : {}),
+        ...(documentSettings.consecutiveHyphenLimit !== undefined
+          ? { consecutiveLineLimit: documentSettings.consecutiveHyphenLimit }
+          : {}),
+      };
+    }
     let newBlocks = toFlowBlocks(state.doc, flowOpts);
     // Template fill preview: substitute each matched {{marker}} range
     // with its typed value at the flow-block level so the pages lay out
@@ -388,6 +400,10 @@ export function runLayoutPipeline<THfPMs>(
         ...(_theme !== undefined ? { theme: _theme } : {}),
         measureBlocks: hfMeasureBlocks,
         ...(defaultTabStop !== undefined ? { defaultTabStopTwips: defaultTabStop } : {}),
+        ...(flowOpts.lineBreakRules ? { lineBreakRules: flowOpts.lineBreakRules } : {}),
+        ...(flowOpts.automaticHyphenation
+          ? { automaticHyphenation: flowOpts.automaticHyphenation }
+          : {}),
       };
     };
     const hfOptions = buildHfOptions(hfPageCountEstimate);
@@ -623,6 +639,12 @@ export function runLayoutPipeline<THfPMs>(
           }
           if (defaultTabStop !== undefined) {
             footnoteOptions.defaultTabStopTwips = defaultTabStop;
+          }
+          if (flowOpts.lineBreakRules) {
+            footnoteOptions.lineBreakRules = flowOpts.lineBreakRules;
+          }
+          if (flowOpts.automaticHyphenation) {
+            footnoteOptions.automaticHyphenation = flowOpts.automaticHyphenation;
           }
           return footnoteOptions;
         })(),

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -127,3 +127,50 @@ describe("parseSettings — document line-breaking rules", () => {
     ).toBeUndefined();
   });
 });
+
+describe("parseSettings — document automatic hyphenation", () => {
+  test("reads the Word hyphenation controls", () => {
+    expect(
+      parseSettings(
+        wrap(`
+          <w:autoHyphenation/>
+          <w:doNotHyphenateCaps/>
+          <w:consecutiveHyphenLimit w:val="2"/>
+          <w:hyphenationZone w:val="360"/>
+        `),
+      ),
+    ).toMatchObject({
+      autoHyphenation: true,
+      doNotHyphenateCaps: true,
+      consecutiveHyphenLimit: 2,
+      hyphenationZoneTwips: 360,
+    });
+  });
+
+  test("preserves explicit disabled on/off values", () => {
+    expect(
+      parseSettings(
+        wrap(`
+          <w:autoHyphenation w:val="0"/>
+          <w:doNotHyphenateCaps w:val="false"/>
+        `),
+      ),
+    ).toMatchObject({
+      autoHyphenation: false,
+      doNotHyphenateCaps: false,
+    });
+  });
+
+  test("ignores absent, malformed, negative, and out-of-range integer controls", () => {
+    expect(parseSettings(wrap("")).autoHyphenation).toBeUndefined();
+    const settings = parseSettings(
+      wrap(`
+        <w:consecutiveHyphenLimit w:val="-1"/>
+        <w:hyphenationZone w:val="31681"/>
+      `),
+    );
+
+    expect(settings.consecutiveHyphenLimit).toBeUndefined();
+    expect(settings.hyphenationZoneTwips).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -27,6 +27,8 @@ export const DEFAULT_TAB_STOP_TWIPS = 720;
  * we substitute the OOXML default instead.
  */
 const MAX_TAB_STOP_TWIPS = 31_680;
+const MAX_HYPHENATION_ZONE_TWIPS = 31_680;
+const MAX_CONSECUTIVE_HYPHEN_LIMIT = 255;
 
 export function parseSettings(xml: string | null): FolioDocumentSettings {
   const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
@@ -61,6 +63,31 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
     };
   }
 
+  const autoHyphenation = parseOnOffSetting(root, "autoHyphenation");
+  if (autoHyphenation !== undefined) {
+    settings.autoHyphenation = autoHyphenation;
+  }
+  const doNotHyphenateCaps = parseOnOffSetting(root, "doNotHyphenateCaps");
+  if (doNotHyphenateCaps !== undefined) {
+    settings.doNotHyphenateCaps = doNotHyphenateCaps;
+  }
+  const consecutiveHyphenLimit = parseIntegerSetting(
+    root,
+    "consecutiveHyphenLimit",
+    MAX_CONSECUTIVE_HYPHEN_LIMIT,
+  );
+  if (consecutiveHyphenLimit !== undefined) {
+    settings.consecutiveHyphenLimit = consecutiveHyphenLimit;
+  }
+  const hyphenationZoneTwips = parseIntegerSetting(
+    root,
+    "hyphenationZone",
+    MAX_HYPHENATION_ZONE_TWIPS,
+  );
+  if (hyphenationZoneTwips !== undefined) {
+    settings.hyphenationZoneTwips = hyphenationZoneTwips;
+  }
+
   const noLineBreaksBefore = parseKinsokuOverride(root, "noLineBreaksBefore");
   const noLineBreaksAfter = parseKinsokuOverride(root, "noLineBreaksAfter");
   const compat = root ? findChild(root, "w", "compat") : null;
@@ -76,6 +103,35 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
   }
 
   return settings;
+}
+
+type OnOffSettingName = "autoHyphenation" | "doNotHyphenateCaps";
+
+function parseOnOffSetting(root: XmlElement | null, name: OnOffSettingName): boolean | undefined {
+  if (!root) {
+    return undefined;
+  }
+  const element = findChild(root, "w", name);
+  return element ? parseBooleanElement(element) : undefined;
+}
+
+type IntegerSettingName = "consecutiveHyphenLimit" | "hyphenationZone";
+
+function parseIntegerSetting(
+  root: XmlElement | null,
+  name: IntegerSettingName,
+  maximum: number,
+): number | undefined {
+  if (!root) {
+    return undefined;
+  }
+  const element = findChild(root, "w", name);
+  const raw = element ? getAttribute(element, "w", "val") : null;
+  if (raw === null || !/^\d+$/u.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed <= maximum ? parsed : undefined;
 }
 
 function parseKinsokuOverride(

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
@@ -167,6 +167,27 @@ const footnoteWithRowSpanTable: Footnote = {
 };
 
 describe("footnote layout", () => {
+  test("applies document line-breaking policy to footnote paragraphs", () => {
+    const content = convertFootnoteToContent(footnoteWithTable, 3, 400, {
+      measureBlocks: (blocks) =>
+        blocks.map(() => ({ kind: "paragraph" as const, lines: [], totalHeight: 12 })),
+      automaticHyphenation: { enabled: true, doNotHyphenateCaps: true },
+      lineBreakRules: {
+        noLineBreaksBefore: { language: "ja-JP", characters: "※" },
+      },
+    });
+
+    expect(content.blocks.at(0)).toMatchObject({
+      kind: "paragraph",
+      attrs: {
+        automaticHyphenation: { enabled: true, doNotHyphenateCaps: true },
+        lineBreakRules: {
+          noLineBreaksBefore: { language: "ja-JP", characters: "※" },
+        },
+      },
+    });
+  });
+
   test("routes footnotes through the body pipeline so tables survive", () => {
     const content = convertFootnoteToContent(footnoteWithTable, 3, 400, {
       measureBlocks(blocks) {

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -29,6 +29,7 @@ import { footnoteToProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import type { Footnote, StyleDefinitions, Theme } from "../../types/document";
 import { measureParagraph } from "../engine/measuring";
 import { toFlowBlocks } from "./toFlowBlocks";
+import type { ToFlowBlocksOptions } from "./toFlowBlocks";
 
 // Re-exported for back-compat with existing callers that imported the
 // constants from this module before they moved to `layout-engine/types`.
@@ -45,6 +46,8 @@ export type ConvertFootnoteOptions = {
   measureBlocks?: MeasureBlocksFn;
   /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
   defaultTabStopTwips?: number;
+  lineBreakRules?: ToFlowBlocksOptions["lineBreakRules"];
+  automaticHyphenation?: ToFlowBlocksOptions["automaticHyphenation"];
 };
 
 // ============================================================================
@@ -329,6 +332,12 @@ export function convertFootnoteToContent(
   }
   if (options.defaultTabStopTwips !== undefined) {
     flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
+  }
+  if (options.lineBreakRules) {
+    flowOptions.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.automaticHyphenation) {
+    flowOptions.automaticHyphenation = options.automaticHyphenation;
   }
   const blocks = applyFootnotePresentation(toFlowBlocks(pmDoc, flowOptions), displayNumber);
 

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -488,6 +488,30 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
 });
 
 describe("header/footer layout conversion", () => {
+  test("applies document line-breaking policy to header paragraphs", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Header hyphenation")]),
+    ]);
+
+    const result = convertHeaderFooterPmDocToContent(pmDoc, 600, metrics, {
+      measureBlocks,
+      automaticHyphenation: { enabled: true, consecutiveLineLimit: 2 },
+      lineBreakRules: {
+        noLineBreaksBefore: { language: "ja-JP", characters: "※" },
+      },
+    });
+
+    expect(result?.blocks.at(0)).toMatchObject({
+      kind: "paragraph",
+      attrs: {
+        automaticHyphenation: { enabled: true, consecutiveLineLimit: 2 },
+        lineBreakRules: {
+          noLineBreaksBefore: { language: "ja-JP", characters: "※" },
+        },
+      },
+    });
+  });
+
   test("derives flow height before margin push so floating text boxes do not seed the body push", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("Header")]),

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -39,6 +39,7 @@ import type { HeaderFooter, StyleDefinitions, Theme } from "../../types/document
 import { emuToPixels } from "../../utils/units";
 import type { MeasureBlocksFn } from "./footnoteLayout";
 import { toFlowBlocks } from "./toFlowBlocks";
+import type { ToFlowBlocksOptions } from "./toFlowBlocks";
 
 // =============================================================================
 // 1. Page-level metrics passed in by the caller
@@ -650,6 +651,8 @@ export type ConvertHeaderFooterOptions = {
   measureBlocks: MeasureBlocksFn;
   /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
   defaultTabStopTwips?: number;
+  lineBreakRules?: ToFlowBlocksOptions["lineBreakRules"];
+  automaticHyphenation?: ToFlowBlocksOptions["automaticHyphenation"];
   /**
    * Relationship id of the source HF part. Stamped onto the returned
    * `HeaderFooterContent.rId` so the painter can emit `data-rid` on the
@@ -690,15 +693,18 @@ export function convertHeaderFooterToContent(
     proseDocOptions.theme = options.theme;
   }
   const pmDoc = headerFooterToProseDoc(headerFooter.content, proseDocOptions);
-  const flowOptions: {
-    theme?: Theme | null;
-    defaultTabStopTwips?: number;
-  } = {};
+  const flowOptions: ToFlowBlocksOptions = {};
   if (options.theme !== undefined) {
     flowOptions.theme = options.theme;
   }
   if (options.defaultTabStopTwips !== undefined) {
     flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
+  }
+  if (options.lineBreakRules) {
+    flowOptions.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.automaticHyphenation) {
+    flowOptions.automaticHyphenation = options.automaticHyphenation;
   }
   const blocks = toFlowBlocks(pmDoc, flowOptions);
   return finalizeHeaderFooterContent(blocks, contentWidth, metrics, options);
@@ -728,15 +734,18 @@ export function convertHeaderFooterPmDocToContent(
   if (!pmDoc || pmDoc.content.size === 0) {
     return undefined;
   }
-  const flowOptions: {
-    theme?: Theme | null;
-    defaultTabStopTwips?: number;
-  } = {};
+  const flowOptions: ToFlowBlocksOptions = {};
   if (options.theme !== undefined) {
     flowOptions.theme = options.theme;
   }
   if (options.defaultTabStopTwips !== undefined) {
     flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
+  }
+  if (options.lineBreakRules) {
+    flowOptions.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.automaticHyphenation) {
+    flowOptions.automaticHyphenation = options.automaticHyphenation;
   }
   const blocks = toFlowBlocks(pmDoc, flowOptions);
   return finalizeHeaderFooterContent(blocks, contentWidth, metrics, options);

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -6,6 +6,33 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("retains paragraph suppression and stamps the document hyphenation policy", () => {
+    const paragraph = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", { suppressAutoHyphens: true }, [schema.text("Hyphenation")]),
+      ]),
+      {
+        automaticHyphenation: {
+          enabled: true,
+          doNotHyphenateCaps: true,
+          consecutiveLineLimit: 2,
+        },
+      },
+    ).at(0);
+
+    expect(paragraph).toMatchObject({
+      kind: "paragraph",
+      attrs: {
+        suppressAutoHyphens: true,
+        automaticHyphenation: {
+          enabled: true,
+          doNotHyphenateCaps: true,
+          consecutiveLineLimit: 2,
+        },
+      },
+    });
+  });
+
   test("does not add a default list indent to an authored first-line position", () => {
     const paragraph = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -135,6 +135,8 @@ export type ToFlowBlocksOptions = {
     noLineBreaksAfter?: { language?: string; characters: string };
     useLegacyEthiopicAmharicRules?: boolean;
   };
+  /** Document-wide automatic hyphenation policy. */
+  automaticHyphenation?: NonNullable<ParagraphAttrs["automaticHyphenation"]>;
 };
 
 const DEFAULT_FONT = "Calibri";
@@ -1629,6 +1631,9 @@ function convertParagraphAttrs(
   if (pmAttrs.overflowPunctuation !== undefined && pmAttrs.overflowPunctuation !== null) {
     attrs.overflowPunctuation = pmAttrs.overflowPunctuation;
   }
+  if (pmAttrs.suppressAutoHyphens !== undefined && pmAttrs.suppressAutoHyphens !== null) {
+    attrs.suppressAutoHyphens = pmAttrs.suppressAutoHyphens;
+  }
   if (pmAttrs.renderedPageBreakBefore) {
     attrs.renderedPageBreakBefore = true;
   }
@@ -1857,6 +1862,9 @@ function convertParagraph(
   );
   if (options.lineBreakRules) {
     attrs.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.automaticHyphenation) {
+    attrs.automaticHyphenation = options.automaticHyphenation;
   }
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
   if (runs.length === 0) {

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -339,6 +339,15 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     if (attrs.overflowPunctuation !== undefined) {
       parts.push(`overflow-punct:${attrs.overflowPunctuation}`);
     }
+    if (attrs.suppressAutoHyphens !== undefined) {
+      parts.push(`suppress-auto-hyphens:${attrs.suppressAutoHyphens}`);
+    }
+    const automaticHyphenation = attrs.automaticHyphenation;
+    if (automaticHyphenation) {
+      parts.push(
+        `auto-hyphens:${automaticHyphenation.doNotHyphenateCaps}|${automaticHyphenation.consecutiveLineLimit}`,
+      );
+    }
     const lineBreakRules = attrs.lineBreakRules;
     if (lineBreakRules) {
       parts.push(

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -7,6 +7,16 @@
  * OOXML line-edge restrictions that are available in the flow model.
  */
 
+import czechHyphenation from "hyphen/cs";
+import britishEnglishHyphenation from "hyphen/en-gb";
+import americanEnglishHyphenation from "hyphen/en-us";
+import slovakHyphenation from "hyphen/sk";
+
+const { hyphenateSync: hyphenateCzech } = czechHyphenation;
+const { hyphenateSync: hyphenateBritishEnglish } = britishEnglishHyphenation;
+const { hyphenateSync: hyphenateAmericanEnglish } = americanEnglishHyphenation;
+const { hyphenateSync: hyphenateSlovak } = slovakHyphenation;
+
 export type LineBreakPolicy = {
   /** BCP-47 language tag resolved from `w:lang` for this run. */
   locale?: string;
@@ -18,6 +28,10 @@ export type LineBreakPolicy = {
   noLineBreaksAfter?: string;
   /** Use the legacy Ethiopic/Amharic compatibility behavior. */
   useLegacyEthiopicAmharicRules?: boolean;
+  /** Keep words made entirely of capital letters unhyphenated. */
+  doNotHyphenateCaps?: boolean;
+  /** The run renders with the DOCX all-caps transform. */
+  renderedAllCaps?: boolean;
 };
 
 export type LineBreakProvider = {
@@ -25,10 +39,16 @@ export type LineBreakProvider = {
   findBreaks: (text: string, policy?: LineBreakPolicy) => number[];
   /** Grapheme-safe emergency-wrap offsets, in ascending UTF-16 order. */
   findGraphemeBreaks: (text: string, policy?: LineBreakPolicy) => number[];
+  /** Dictionary-based discretionary hyphen offsets, in ascending UTF-16 order. */
+  findHyphenationBreaks?: (text: string, policy?: LineBreakPolicy) => number[];
+  /** Whether a trailing grapheme may overhang the line edge. */
+  isHangingPunctuation?: (text: string, policy?: LineBreakPolicy) => boolean;
 };
 
 const SEGMENTER_CACHE_LIMIT = 16;
 const DEFAULT_SEGMENTER_KEY = "";
+const SOFT_HYPHEN = "\u00AD";
+const MAX_HYPHENATION_WORD_LENGTH = 256;
 
 const wordSegmenters = new Map<string, Intl.Segmenter>();
 const graphemeSegmenters = new Map<string, Intl.Segmenter>();
@@ -298,9 +318,81 @@ const findUnicodeBreaks = (text: string, policy?: LineBreakPolicy): number[] => 
     .sort((left, right) => left - right);
 };
 
+type HyphenateWord = (text: string) => string;
+
+const hyphenatorFor = (locale?: string): HyphenateWord | undefined => {
+  const normalized = locale?.trim().replaceAll("_", "-").toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "en-gb" || normalized.startsWith("en-gb-")) {
+    return hyphenateBritishEnglish;
+  }
+  if (normalized === "en-us" || normalized.startsWith("en-us-")) {
+    return hyphenateAmericanEnglish;
+  }
+  if (normalized === "cs" || normalized.startsWith("cs-")) {
+    return hyphenateCzech;
+  }
+  if (normalized === "sk" || normalized.startsWith("sk-")) {
+    return hyphenateSlovak;
+  }
+  return undefined;
+};
+
+const isAllCapsWord = (text: string, locale?: string): boolean => {
+  const letters = [...text].filter((character) => /\p{Letter}/u.test(character)).join("");
+  if (letters.length === 0) {
+    return false;
+  }
+  const casingLocale = segmenterLocale(locale);
+  return (
+    letters === letters.toLocaleUpperCase(casingLocale) &&
+    letters !== letters.toLocaleLowerCase(casingLocale)
+  );
+};
+
+const findPatternHyphenationBreaks = (text: string, policy?: LineBreakPolicy): number[] => {
+  if (text.length > MAX_HYPHENATION_WORD_LENGTH || text.includes(SOFT_HYPHEN)) {
+    return [];
+  }
+  const hyphenate = hyphenatorFor(policy?.locale);
+  if (!hyphenate) {
+    return [];
+  }
+  if (
+    policy?.doNotHyphenateCaps &&
+    (policy.renderedAllCaps === true || isAllCapsWord(text, policy.locale))
+  ) {
+    return [];
+  }
+
+  const hyphenated = hyphenate(text);
+  const breaks: number[] = [];
+  let sourceOffset = 0;
+  for (const character of hyphenated) {
+    if (character === SOFT_HYPHEN) {
+      breaks.push(sourceOffset);
+      continue;
+    }
+    sourceOffset += character.length;
+  }
+  return sourceOffset === text.length ? breaks : [];
+};
+
+const isDefaultHangingPunctuation = (text: string, policy?: LineBreakPolicy): boolean => {
+  const characters = [...text];
+  return (
+    characters.length > 0 &&
+    characters.every((character) => isProhibitedLineStart(character, policy))
+  );
+};
+
 export const defaultLineBreakProvider: LineBreakProvider = {
   findBreaks: findUnicodeBreaks,
   findGraphemeBreaks: findUnicodeGraphemeBreaks,
+  findHyphenationBreaks: findPatternHyphenationBreaks,
+  isHangingPunctuation: isDefaultHangingPunctuation,
 };
 
 let activeLineBreakProvider = defaultLineBreakProvider;

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -5,7 +5,13 @@ import {
   resetLineBreakProvider,
   setLineBreakProvider,
 } from "./lineBreakProvider";
-import { findGraphemeBreaks, findWordBreaks, isBreakChar } from "./lineBreaks";
+import {
+  findGraphemeBreaks,
+  findHyphenationBreaks,
+  findWordBreaks,
+  isHangingPunctuation,
+  isBreakChar,
+} from "./lineBreaks";
 
 describe("findWordBreaks", () => {
   test("breaks after spaces and hyphens in Latin text", () => {
@@ -61,6 +67,59 @@ describe("findGraphemeBreaks", () => {
   test("never splits an emoji ZWJ sequence or combining character", () => {
     expect(findGraphemeBreaks("👨‍👩‍👧‍👦x")).toEqual([11, 12]);
     expect(findGraphemeBreaks("e\u0301x")).toEqual([2, 3]);
+  });
+});
+
+describe("findHyphenationBreaks", () => {
+  test("uses the dictionary selected by the exact Word language", () => {
+    expect(findHyphenationBreaks("hyphenation", { locale: "en-US" })).toEqual([2, 6]);
+    expect(findHyphenationBreaks("nejneobhospodářovávatelnější", { locale: "cs-CZ" })).toEqual([
+      3, 5, 7, 10, 12, 14, 16, 18, 20, 23, 26,
+    ]);
+  });
+
+  test("fails closed for unsupported or missing locales", () => {
+    expect(findHyphenationBreaks("hyphenation")).toEqual([]);
+    expect(findHyphenationBreaks("hyphenation", { locale: "en" })).toEqual([]);
+    expect(findHyphenationBreaks("hyphenation", { locale: "fr-FR" })).toEqual([]);
+    expect(() =>
+      findHyphenationBreaks("HYPHENATION", {
+        locale: "en-US-%%%",
+        doNotHyphenateCaps: true,
+      }),
+    ).not.toThrow();
+  });
+
+  test("bounds dictionary work for hostile oversized words", () => {
+    expect(findHyphenationBreaks("a".repeat(257), { locale: "en-US" })).toEqual([]);
+  });
+
+  test("honors the document all-caps setting", () => {
+    expect(findHyphenationBreaks("HYPHENATION", { locale: "en-US" })).not.toEqual([]);
+    expect(
+      findHyphenationBreaks("HYPHENATION", {
+        locale: "en-US",
+        doNotHyphenateCaps: true,
+      }),
+    ).toEqual([]);
+    expect(
+      findHyphenationBreaks("hyphenation", {
+        locale: "en-US",
+        doNotHyphenateCaps: true,
+        renderedAllCaps: true,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("isHangingPunctuation", () => {
+  test("allows closing punctuation but not opening punctuation to overhang", () => {
+    expect(isHangingPunctuation("。", { locale: "zh-CN" })).toBe(true);
+    expect(isHangingPunctuation("（", { locale: "zh-CN" })).toBe(false);
+  });
+
+  test("includes document-specific prohibited line-start characters", () => {
+    expect(isHangingPunctuation("※", { noLineBreaksBefore: "※" })).toBe(true);
   });
 });
 

--- a/packages/core/src/layout-engine/measure/lineBreaks.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.ts
@@ -1,4 +1,4 @@
-import { getLineBreakProvider } from "./lineBreakProvider";
+import { defaultLineBreakProvider, getLineBreakProvider } from "./lineBreakProvider";
 import type { LineBreakPolicy } from "./lineBreakProvider";
 import { isCjkCodePoint } from "../../utils/scriptSegments";
 
@@ -12,6 +12,15 @@ export const findWordBreaks = (text: string, policy?: LineBreakPolicy): number[]
 
 export const findGraphemeBreaks = (text: string, policy?: LineBreakPolicy): number[] =>
   getLineBreakProvider().findGraphemeBreaks(text, policy);
+
+export const findHyphenationBreaks = (text: string, policy?: LineBreakPolicy): number[] =>
+  getLineBreakProvider().findHyphenationBreaks?.(text, policy) ?? [];
+
+export const isHangingPunctuation = (text: string, policy?: LineBreakPolicy): boolean => {
+  const provider = getLineBreakProvider();
+  const classify = provider.isHangingPunctuation ?? defaultLineBreakProvider.isHangingPunctuation;
+  return classify?.(text, policy) ?? false;
+};
 
 export function isBreakChar(char: string | undefined): boolean {
   if (char === undefined) {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -119,6 +119,35 @@ describe("font metrics cache", () => {
       }),
     );
   });
+
+  test("keeps automatic hyphenation policy in the paragraph measurement cache key", () => {
+    const paragraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "hyphenation-cache",
+      runs: [{ kind: "text", text: "hyphenation", language: { val: "en-US" } }],
+    };
+
+    expect(hashParagraphBlock(paragraph)).not.toBe(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: { automaticHyphenation: { enabled: true } },
+      }),
+    );
+    expect(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: { automaticHyphenation: { enabled: true } },
+      }),
+    ).not.toBe(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: {
+          automaticHyphenation: { enabled: true },
+          suppressAutoHyphens: true,
+        },
+      }),
+    );
+  });
 });
 
 describe("empty paragraph line-height floor", () => {
@@ -553,6 +582,103 @@ describe("measureParagraph cross-run line breaking", () => {
       expect(leftMeasure.lines).toHaveLength(2);
       expect(justifiedMeasure.lines).toHaveLength(1);
     }, fakeMeasure);
+  });
+});
+
+describe("automatic hyphenation", () => {
+  const paragraph = (attrs?: ParagraphBlock["attrs"]): ParagraphBlock => ({
+    kind: "paragraph",
+    id: "automatic-hyphenation",
+    runs: [{ kind: "text", text: "hyphenation", language: { val: "en-US" } }],
+    attrs,
+  });
+
+  test("uses a dictionary break and accounts for the painted hyphen width", () => {
+    withFakeTextMeasure(
+      () => {
+        const measured = measureParagraph(
+          paragraph({ automaticHyphenation: { enabled: true } }),
+          70,
+        );
+
+        expect(measured.lines).toHaveLength(2);
+        expect(measured.lines[0]).toMatchObject({
+          fromChar: 0,
+          toChar: 6,
+          width: 70,
+          discretionaryHyphen: { runIndex: 0 },
+        });
+        expect(measured.lines[1]).toMatchObject({ fromChar: 6, toChar: 11, width: 50 });
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("leaves the source offsets unchanged when automatic hyphenation is suppressed", () => {
+    withFakeTextMeasure(
+      () => {
+        const measured = measureParagraph(
+          paragraph({
+            automaticHyphenation: { enabled: true },
+            suppressAutoHyphens: true,
+          }),
+          70,
+        );
+
+        expect(measured.lines[0]).toMatchObject({ fromChar: 0, toChar: 7, width: 70 });
+        expect(measured.lines[0]?.discretionaryHyphen).toBeUndefined();
+        expect(measured.lines[1]).toMatchObject({ fromChar: 7, toChar: 11, width: 40 });
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("honors the consecutive-line limit", () => {
+    withFakeTextMeasure(
+      () => {
+        const measured = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "consecutive-hyphen-limit",
+            runs: [{ kind: "text", text: "characteristically", language: { val: "en-US" } }],
+            attrs: {
+              automaticHyphenation: { enabled: true, consecutiveLineLimit: 1 },
+            },
+          },
+          50,
+        );
+
+        expect(measured.lines[0]?.discretionaryHyphen).toEqual({ runIndex: 0 });
+        expect(measured.lines[1]?.discretionaryHyphen).toBeUndefined();
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("treats the DOCX all-caps transform as capitalized text", () => {
+    withFakeTextMeasure(
+      () => {
+        const measured = measureParagraph(
+          {
+            ...paragraph({
+              automaticHyphenation: { enabled: true, doNotHyphenateCaps: true },
+            }),
+            runs: [
+              {
+                kind: "text",
+                text: "hyphenation",
+                language: { val: "en-US" },
+                allCaps: true,
+              },
+            ],
+          },
+          70,
+        );
+
+        expect(measured.lines[0]?.discretionaryHyphen).toBeUndefined();
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
   });
 });
 
@@ -1793,6 +1919,43 @@ describe("CJK line breaking", () => {
         const hanging = measureParagraph(paragraph(true), 20);
         expect(hanging.lines).toHaveLength(1);
         expect(hanging.lines[0]?.width).toBe(30);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("does not hang opening punctuation", () => {
+    withFakeTextMeasure(
+      () => {
+        const paragraph: ParagraphBlock = {
+          kind: "paragraph",
+          id: "cjk-opening-punctuation",
+          runs: [{ kind: "text", text: "中文（", language: { eastAsia: "zh-CN" } }],
+          attrs: { overflowPunctuation: true },
+        };
+
+        expect(measureParagraph(paragraph, 20).lines.length).toBeGreaterThan(1);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("hangs a document-specific prohibited line-start character", () => {
+    withFakeTextMeasure(
+      () => {
+        const paragraph: ParagraphBlock = {
+          kind: "paragraph",
+          id: "custom-hanging-punctuation",
+          runs: [{ kind: "text", text: "中文※", language: { eastAsia: "zh-CN" } }],
+          attrs: {
+            overflowPunctuation: true,
+            lineBreakRules: {
+              noLineBreaksBefore: { language: "zh-CN", characters: "※" },
+            },
+          },
+        };
+
+        expect(measureParagraph(paragraph, 20).lines).toHaveLength(1);
       },
       { charWidth: fixedCharWidth(10) },
     );

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -39,7 +39,13 @@ import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import { buildRunFontStyle, ptToPx } from "./measureHelpers";
 import { getFontMetrics, measureRun, measureTextWidth } from "./measureProvider";
 import type { FontMetrics, FontStyle } from "./measureTypes";
-import { findGraphemeBreaks, findWordBreaks, isBreakChar } from "./lineBreaks";
+import {
+  findGraphemeBreaks,
+  findHyphenationBreaks,
+  findWordBreaks,
+  isHangingPunctuation,
+  isBreakChar,
+} from "./lineBreaks";
 import type { LineBreakPolicy } from "./lineBreakProvider";
 import { countCompressibleSpaces } from "./textMeasurementPolicy";
 
@@ -146,6 +152,7 @@ type LineState = {
   rightOffset: number;
   /** Optional split segment zones from centered floating exclusions */
   segmentZones?: FloatingLineSegmentZone[];
+  discretionaryHyphen?: { runIndex: number };
 };
 
 /**
@@ -192,6 +199,10 @@ function lineBreakPolicy(block: ParagraphBlock, run: TextRun): LineBreakPolicy {
       ? { noLineBreaksAfter: after.characters }
       : {}),
     ...(rules?.useLegacyEthiopicAmharicRules ? { useLegacyEthiopicAmharicRules: true } : {}),
+    ...(block.attrs?.automaticHyphenation?.doNotHyphenateCaps !== undefined
+      ? { doNotHyphenateCaps: block.attrs.automaticHyphenation.doNotHyphenateCaps }
+      : {}),
+    ...(run.allCaps === true ? { renderedAllCaps: true } : {}),
   };
 }
 
@@ -730,7 +741,7 @@ function trailingHangingPunctuationWidth(
   const boundaries = findGraphemeBreaks(text, policy);
   const lastStart = boundaries.at(-2) ?? 0;
   const lastGrapheme = text.slice(lastStart);
-  if (!/^\p{Punctuation}+$/u.test(lastGrapheme)) {
+  if (!isHangingPunctuation(lastGrapheme, policy)) {
     return 0;
   }
   return measureTextWidth(lastGrapheme, style);
@@ -944,6 +955,7 @@ export function measureParagraph(
   );
 
   const lines: MeasuredLine[] = [];
+  let consecutiveHyphenatedLines = 0;
 
   // Handle empty paragraph
   if (runs.length === 0) {
@@ -1158,6 +1170,9 @@ export function measureParagraph(
       toChar: currentLine.toChar,
       width: Math.max(0, currentLine.width - currentLine.trailingWhitespaceWidth),
       ...finalTypography,
+      ...(currentLine.discretionaryHyphen
+        ? { discretionaryHyphen: currentLine.discretionaryHyphen }
+        : {}),
     };
 
     // Only add offsets if they're non-zero (for floating images)
@@ -1176,6 +1191,9 @@ export function measureParagraph(
     }
 
     lines.push(line);
+    consecutiveHyphenatedLines = currentLine.discretionaryHyphen
+      ? consecutiveHyphenatedLines + 1
+      : 0;
 
     // Update cumulative height for next line's floating zone calculation
     cumulativeHeight += finalTypography.lineHeight;
@@ -1517,6 +1535,9 @@ export function measureParagraph(
 
       // Process text word by word
       let charIndex = 0;
+      let activeHyphenationWord:
+        | { start: number; end: number; text: string; breaks: number[] }
+        | undefined;
 
       while (charIndex < text.length) {
         // Find next word boundary
@@ -1566,6 +1587,61 @@ export function measureParagraph(
                       ),
               )
             : WIDTH_TOLERANCE;
+
+        const automaticHyphenation = block.attrs?.automaticHyphenation;
+        const consecutiveLineLimit = automaticHyphenation?.consecutiveLineLimit ?? 0;
+        const mayHyphenateLine =
+          automaticHyphenation?.enabled === true &&
+          block.attrs?.suppressAutoHyphens !== true &&
+          (consecutiveLineLimit === 0 || consecutiveHyphenatedLines < consecutiveLineLimit);
+        if (
+          mayHyphenateLine &&
+          measuredWord.length > 0 &&
+          (activeHyphenationWord === undefined ||
+            charIndex < activeHyphenationWord.start ||
+            charIndex >= activeHyphenationWord.end)
+        ) {
+          const fullWordEnd = charIndex + measuredWord.length;
+          const fullWordText = text.slice(charIndex, fullWordEnd);
+          activeHyphenationWord = {
+            start: charIndex,
+            end: fullWordEnd,
+            text: fullWordText,
+            breaks: findHyphenationBreaks(fullWordText, breakPolicy),
+          };
+        }
+
+        const overflowsCurrentLine =
+          wordWidth > 0 &&
+          currentLine.width + wordWidth > currentLine.availableWidth + widthTolerance;
+        if (mayHyphenateLine && overflowsCurrentLine && activeHyphenationWord) {
+          const consumed = charIndex - activeHyphenationWord.start;
+          const spaceLeft = currentLine.availableWidth - currentLine.width + widthTolerance;
+          const hyphenWidth = measureTextWidth("-", style);
+          let fittingBreak: number | undefined;
+          for (const breakOffset of activeHyphenationWord.breaks) {
+            if (breakOffset <= consumed || breakOffset >= activeHyphenationWord.text.length) {
+              continue;
+            }
+            const prefix = activeHyphenationWord.text.slice(consumed, breakOffset);
+            if (measureTextWidth(prefix, style) + hyphenWidth <= spaceLeft) {
+              fittingBreak = breakOffset;
+            }
+          }
+          if (fittingBreak !== undefined) {
+            const absoluteBreak = activeHyphenationWord.start + fittingBreak;
+            const prefix = text.slice(charIndex, absoluteBreak);
+            currentLine.width += measureTextWidth(prefix, style) + hyphenWidth;
+            currentLine.trailingWhitespaceWidth = 0;
+            currentLine.toRun = runIndex;
+            currentLine.toChar = absoluteBreak;
+            currentLine.discretionaryHyphen = { runIndex };
+            startNewLine(runIndex, absoluteBreak);
+            updateMaxFont(lineHeightStyle);
+            charIndex = absoluteBreak;
+            continue;
+          }
+        }
 
         // If the word itself is longer than a line, hard-break by grapheme.
         // Use substring measurement (not char-by-char accumulation) to preserve

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -379,6 +379,14 @@ export type ParagraphAttrs = {
   kinsoku?: boolean;
   /** Hanging punctuation (`w:overflowPunct`), retained for layout policy. */
   overflowPunctuation?: boolean;
+  /** Exempt this paragraph from document automatic hyphenation. */
+  suppressAutoHyphens?: boolean;
+  /** Document-wide automatic hyphenation controls retained for line layout. */
+  automaticHyphenation?: {
+    enabled: true;
+    doNotHyphenateCaps?: boolean;
+    consecutiveLineLimit?: number;
+  };
   /** Document-wide custom line-edge characters and compatibility behavior. */
   lineBreakRules?: {
     noLineBreaksBefore?: { language?: string; characters: string };
@@ -838,6 +846,8 @@ export type MeasuredLine = {
    * as marginTop on the line element; measurement adds it to totalHeight.
    */
   floatSkipBefore?: number;
+  /** Decorative hyphen inserted at a dictionary break without changing source text. */
+  discretionaryHyphen?: { runIndex: number };
 };
 
 /**

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -60,6 +60,51 @@ function findTabEls(lineEl: FakeElement): FakeElement[] {
 }
 
 describe("renderLine box model", () => {
+  test("paints a discretionary hyphen without assigning it a document position", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "discretionary-hyphen",
+      runs: [
+        {
+          kind: "text",
+          text: "hyphenation",
+          pmStart: 10,
+          pmEnd: 21,
+          bold: true,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 6,
+      width: 49,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+      discretionaryHyphen: { runIndex: 0 },
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 49,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const [text, hyphen] = lineEl.children;
+
+    expect(text?.textContent).toBe("hyphen");
+    expect(text?.dataset["pmStart"]).toBe("10");
+    expect(text?.dataset["pmEnd"]).toBe("16");
+    expect(hyphen?.textContent).toBe("-");
+    expect(hyphen?.dataset["discretionaryHyphen"]).toBe("true");
+    expect(hyphen?.dataset["pmStart"]).toBeUndefined();
+    expect(hyphen?.dataset["pmEnd"]).toBeUndefined();
+    expect(hyphen?.style["fontWeight"]).toBe("800");
+  });
+
   test("paints pair kerning only when the authored threshold is met", () => {
     const line: MeasuredLine = {
       fromRun: 0,

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2213,6 +2213,18 @@ export function renderLine(
     }
   }
 
+  if (line.discretionaryHyphen) {
+    const sourceRun = block.runs[line.discretionaryHyphen.runIndex];
+    if (sourceRun && isTextRun(sourceRun)) {
+      const hyphenRun = { ...sourceRun, text: "-" };
+      Reflect.deleteProperty(hyphenRun, "pmStart");
+      Reflect.deleteProperty(hyphenRun, "pmEnd");
+      const hyphenEl = renderTextRun(hyphenRun, doc);
+      hyphenEl.dataset["discretionaryHyphen"] = "true";
+      lineEl.append(hyphenEl);
+    }
+  }
+
   // A line whose in-flow runs are all line breaks (a blank row from consecutive
   // `<w:br/>`) renders as just a `<br>`, whose PM position the click/caret/
   // visual-line resolvers don't read — they query `span[data-pm-start]`. With no

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -249,6 +249,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   optionalString(attrs, "styleId", "paragraph.attrs.styleId", issues);
   optionalBoolean(attrs, "kinsoku", "paragraph.attrs.kinsoku", issues);
   optionalBoolean(attrs, "overflowPunctuation", "paragraph.attrs.overflowPunctuation", issues);
+  optionalBoolean(attrs, "suppressAutoHyphens", "paragraph.attrs.suppressAutoHyphens", issues);
   optionalNumber(attrs, "spaceBefore", "paragraph.attrs.spaceBefore", issues);
   optionalNumber(attrs, "spaceAfter", "paragraph.attrs.spaceAfter", issues);
   optionalNumber(attrs, "lineSpacing", "paragraph.attrs.lineSpacing", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -90,6 +90,39 @@ describe("fromProseDoc", () => {
     expect(() => fromProseDoc(pmDoc)).toThrow("sdt.attrs.listItems[0].displayText");
   });
 
+  test("round-trips paragraph automatic-hyphenation suppression through ProseMirror", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { suppressAutoHyphens: true },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Keep this paragraph unhyphenated" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const attrs = expectParagraphAttrs(pmDoc.child(0));
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(attrs.suppressAutoHyphens).toBe(true);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.suppressAutoHyphens).toBe(true);
+  });
+
   test("round-trips unedited inherited auto spacing without inlining the style value", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -667,7 +667,12 @@ function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
 // "inherit", dropping the user's decision on save. Branch on `== null` so every
 // toggle routed through here preserves `false`. (Direction is handled
 // separately via the `direction` discriminated union, not this helper.)
-type BooleanToggleKey = "pageBreakBefore" | "widowControl" | "kinsoku" | "overflowPunctuation";
+type BooleanToggleKey =
+  | "pageBreakBefore"
+  | "widowControl"
+  | "kinsoku"
+  | "overflowPunctuation"
+  | "suppressAutoHyphens";
 
 function assignBooleanToggle(
   result: ParagraphFormatting,
@@ -772,6 +777,7 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     assignBooleanToggle(result, attrs, orig, "widowControl");
     assignBooleanToggle(result, attrs, orig, "kinsoku");
     assignBooleanToggle(result, attrs, orig, "overflowPunctuation");
+    assignBooleanToggle(result, attrs, orig, "suppressAutoHyphens");
     if (attrs.spacingExplicit !== orig.spacingExplicit) {
       if (attrs.spacingExplicit) {
         result.spacingExplicit = attrs.spacingExplicit;
@@ -823,7 +829,8 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     attrs.pageBreakBefore != null ||
     attrs.widowControl != null ||
     attrs.kinsoku != null ||
-    attrs.overflowPunctuation != null;
+    attrs.overflowPunctuation != null ||
+    attrs.suppressAutoHyphens != null;
 
   if (!hasFormatting) {
     return undefined;
@@ -903,6 +910,9 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
   }
   if (attrs.overflowPunctuation != null) {
     f.overflowPunctuation = attrs.overflowPunctuation;
+  }
+  if (attrs.suppressAutoHyphens != null) {
+    f.suppressAutoHyphens = attrs.suppressAutoHyphens;
   }
   return f;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -611,6 +611,7 @@ function paragraphFormattingToAttrs(
     set("tabs", formatting?.tabs ?? stylePpr?.tabs);
     set("kinsoku", formatting?.kinsoku ?? stylePpr?.kinsoku);
     set("overflowPunctuation", formatting?.overflowPunctuation ?? stylePpr?.overflowPunctuation);
+    set("suppressAutoHyphens", formatting?.suppressAutoHyphens ?? stylePpr?.suppressAutoHyphens);
 
     // Page break control
     set("pageBreakBefore", formatting?.pageBreakBefore ?? stylePpr?.pageBreakBefore);
@@ -659,6 +660,7 @@ function paragraphFormattingToAttrs(
     set("tabs", formatting?.tabs);
     set("kinsoku", formatting?.kinsoku);
     set("overflowPunctuation", formatting?.overflowPunctuation);
+    set("suppressAutoHyphens", formatting?.suppressAutoHyphens);
 
     // Page break control
     set("pageBreakBefore", formatting?.pageBreakBefore);

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -322,6 +322,7 @@ const paragraphNodeSpec: NodeSpec = {
     alignment: { default: null },
     kinsoku: { default: null },
     overflowPunctuation: { default: null },
+    suppressAutoHyphens: { default: null },
     spaceBefore: { default: null },
     spaceAfter: { default: null },
     lineSpacing: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -61,6 +61,8 @@ export type ParagraphAttrs = {
   kinsoku?: boolean;
   /** Effective hanging-punctuation policy (`w:overflowPunct`). */
   overflowPunctuation?: boolean;
+  /** Effective paragraph opt-out from document automatic hyphenation. */
+  suppressAutoHyphens?: boolean;
 
   // Spacing (in twips)
   spaceBefore?: number;

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -200,6 +200,14 @@ export type DocumentSettings = {
    * `<a:font script="…">` entries. Absent for non-CJK/bidi docs.
    */
   themeFontLang?: { eastAsia?: string; bidi?: string };
+  /** Automatically hyphenate eligible paragraphs (`w:autoHyphenation`). */
+  autoHyphenation?: boolean;
+  /** Keep all-capital words unhyphenated (`w:doNotHyphenateCaps`). */
+  doNotHyphenateCaps?: boolean;
+  /** Maximum consecutive automatically hyphenated lines; zero means unlimited. */
+  consecutiveHyphenLimit?: number;
+  /** Legacy hyphenation zone (`w:hyphenationZone`) in twips; retained for compatibility tooling. */
+  hyphenationZoneTwips?: number;
   /** Word/OOXML document-wide line-breaking overrides. */
   lineBreakRules?: {
     noLineBreaksBefore?: { language?: string; characters: string };


### PR DESCRIPTION
Implement Word-directed automatic hyphenation in the replaceable line-break pipeline.

The document settings parser now carries automatic hyphenation, capital-word suppression, consecutive-line limits, and the legacy zone value. Layout selects bounded en-US, en-GB, Czech, and Slovak dictionaries strictly from `w:lang`; unsupported languages remain unhyphenated. Paragraph suppression survives DOCX, ProseMirror, body, header/footer, table, and footnote conversion.

Discretionary hyphens are measured and painted without mutating source text or ProseMirror positions. Hanging punctuation is limited to Word-style prohibited line-start characters, including document overrides.