### PR TITLE
fix: clip split table-cell content

### DIFF
--- a/.changeset/split-table-cell-continuations.md
+++ b/.changeset/split-table-cell-continuations.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Clip ordinary table-cell content to the visible row slice across page continuations.

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -79,6 +79,11 @@ type RenderCellContentOptions = {
   contentWidthOverride?: number;
 };
 
+type CellContentClip = {
+  top: number;
+  bottom: number;
+};
+
 function renderCellContent({
   cell,
   cellMeasure,
@@ -382,22 +387,21 @@ function renderNestedTable(
       continue;
     }
 
-    const rowEl = renderTableRow(
+    const rowEl = renderTableRow({
       row,
       rowMeasure,
       rowIndex,
       y,
-      measure.columnWidths,
-      block.rows.length,
+      columnWidths: measure.columnWidths,
+      totalRows: block.rows.length,
       context,
       doc,
       spanningCells,
       rowYPositions,
-      undefined,
-      block.bidi,
+      bidi: block.bidi,
       columnsPinned,
       cellGrid,
-    );
+    });
     tableEl.append(rowEl);
     y += rowMeasure.height;
   }
@@ -495,21 +499,34 @@ function renderCellDiagonalBorder({
 /**
  * Render a single table cell
  */
-function renderTableCell(
-  cell: TableCell,
-  cellMeasure: TableCellMeasure,
-  x: number,
-  rowHeight: number,
+type RenderTableCellOptions = {
+  cell: TableCell;
+  cellMeasure: TableCellMeasure;
+  x: number;
+  rowHeight: number;
   borderFlags: {
     drawTop: boolean;
     isLastRow: boolean;
     drawLeft: boolean;
     isLastCol: boolean;
-  },
-  columnsPinned: boolean,
-  context: RenderContext,
-  doc: Document,
-): HTMLElement {
+  };
+  columnsPinned: boolean;
+  context: RenderContext;
+  doc: Document;
+  contentClip?: CellContentClip;
+};
+
+function renderTableCell({
+  cell,
+  cellMeasure,
+  x,
+  rowHeight,
+  borderFlags,
+  columnsPinned,
+  context,
+  doc,
+  contentClip,
+}: RenderTableCellOptions): HTMLElement {
   const cellEl = doc.createElement("div");
   cellEl.className = TABLE_CLASS_NAMES.cell;
 
@@ -609,6 +626,14 @@ function renderTableCell(
     renderedContent.content.style.overflow = "hidden";
     cellEl.style.overflow = "visible";
   }
+  if (contentClip) {
+    const contentHeight = Math.max(0, rowHeight - padTop - padBottom);
+    const clipTop = Math.min(contentHeight, Math.max(0, contentClip.top - padTop));
+    const clipBottom = Math.min(contentHeight, Math.max(clipTop, contentClip.bottom - padTop));
+    renderedContent.content.style.height = `${contentHeight}px`;
+    renderedContent.content.style.overflow = "hidden";
+    renderedContent.content.style.clipPath = `inset(${clipTop}px 0 ${contentHeight - clipBottom}px 0)`;
+  }
   cellEl.append(renderedContent.content);
   const topLeftToBottomRight = renderCellDiagonalBorder({
     border: cell.borders?.topLeftToBottomRight,
@@ -707,22 +732,41 @@ const hasVisibleBorder = (border: { width?: number; style?: string } | undefined
 /**
  * Render a table row with rowSpan support
  */
-function renderTableRow(
-  row: TableBlock["rows"][number],
-  rowMeasure: TableMeasure["rows"][number],
-  rowIndex: number,
-  y: number,
-  columnWidths: number[],
-  totalRows: number,
-  context: RenderContext,
-  doc: Document,
-  spanningCells?: Map<string, SpanningCell>,
-  rowYPositions?: number[],
-  isFirstRowInFragment?: boolean,
+type RenderTableRowOptions = {
+  row: TableBlock["rows"][number];
+  rowMeasure: TableMeasure["rows"][number];
+  rowIndex: number;
+  y: number;
+  columnWidths: number[];
+  totalRows: number;
+  context: RenderContext;
+  doc: Document;
+  spanningCells?: Map<string, SpanningCell>;
+  rowYPositions?: number[];
+  isFirstRowInFragment?: boolean;
+  bidi?: boolean;
+  columnsPinned?: boolean;
+  cellGrid?: TableCellGrid;
+  contentClip?: CellContentClip;
+};
+
+function renderTableRow({
+  row,
+  rowMeasure,
+  rowIndex,
+  y,
+  columnWidths,
+  totalRows,
+  context,
+  doc,
+  spanningCells,
+  rowYPositions,
+  isFirstRowInFragment,
   bidi = false,
   columnsPinned = false,
-  cellGrid?: TableCellGrid,
-): HTMLElement {
+  cellGrid,
+  contentClip,
+}: RenderTableRowOptions): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
 
@@ -811,16 +855,17 @@ function renderTableRow(
     const drawTop = isFirstRow || !hasVisibleBorder(aboveCell?.borders?.bottom);
     const drawLeft = isFirstCol || !hasVisibleBorder(leftCell?.borders?.right);
 
-    const cellEl = renderTableCell(
+    const cellEl = renderTableCell({
       cell,
       cellMeasure,
-      cellLeft,
-      cellHeight,
-      { drawTop, isLastRow, drawLeft, isLastCol },
+      x: cellLeft,
+      rowHeight: cellHeight,
+      borderFlags: { drawTop, isLastRow, drawLeft, isLastCol },
       columnsPinned,
       context,
       doc,
-    );
+      contentClip,
+    });
     cellEl.dataset["cellIndex"] = String(cellIndex);
     cellEl.dataset["columnIndex"] = String(columnIndex);
 
@@ -965,22 +1010,22 @@ export function renderTableFragment(
         continue;
       }
 
-      const rowEl = renderTableRow(
-        hdrRow,
-        hdrRowMeasure,
-        hdrIdx,
+      const rowEl = renderTableRow({
+        row: hdrRow,
+        rowMeasure: hdrRowMeasure,
+        rowIndex: hdrIdx,
         y,
-        measure.columnWidths,
-        block.rows.length,
+        columnWidths: measure.columnWidths,
+        totalRows: block.rows.length,
         context,
         doc,
         spanningCells,
         rowYPositions,
-        hdrIdx === 0, // first header row draws top border
-        block.bidi,
+        isFirstRowInFragment: hdrIdx === 0,
+        bidi: block.bidi,
         columnsPinned,
         cellGrid,
-      );
+      });
       rowEl.dataset["repeatedHeader"] = "true";
       tableEl.append(rowEl);
       y += hdrRowMeasure.height;
@@ -1022,23 +1067,32 @@ export function renderTableFragment(
       headerRowCount > 0 && fragment.continuesFromPrev
         ? false // header rows already drawn, content rows are not "first"
         : fragment.continuesFromPrev && rowIndex === fragment.fromRow;
+    const contentClip =
+      rowIndex === fragment.fromRow &&
+      (fragment.topClip !== undefined || fragment.bottomClip !== undefined)
+        ? {
+            top: fragment.topClip ?? 0,
+            bottom: fragment.bottomClip ?? rowMeasure.height,
+          }
+        : undefined;
 
-    const rowEl = renderTableRow(
+    const rowEl = renderTableRow({
       row,
       rowMeasure,
       rowIndex,
       y,
-      measure.columnWidths,
-      block.rows.length,
+      columnWidths: measure.columnWidths,
+      totalRows: block.rows.length,
       context,
       doc,
       spanningCells,
       rowYPositions,
       isFirstRowInFragment,
-      block.bidi,
+      bidi: block.bidi,
       columnsPinned,
       cellGrid,
-    );
+      contentClip,
+    });
 
     contentParent.append(rowEl);
     y += rowMeasure.height;

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -398,7 +398,7 @@ function renderNestedTable(
       doc,
       spanningCells,
       rowYPositions,
-      bidi: block.bidi,
+      bidi: block.bidi === true,
       columnsPinned,
       cellGrid,
     });
@@ -864,7 +864,7 @@ function renderTableRow({
       columnsPinned,
       context,
       doc,
-      contentClip,
+      ...(contentClip ? { contentClip } : {}),
     });
     cellEl.dataset["cellIndex"] = String(cellIndex);
     cellEl.dataset["columnIndex"] = String(columnIndex);
@@ -1022,7 +1022,7 @@ export function renderTableFragment(
         spanningCells,
         rowYPositions,
         isFirstRowInFragment: hdrIdx === 0,
-        bidi: block.bidi,
+        bidi: block.bidi === true,
         columnsPinned,
         cellGrid,
       });
@@ -1066,7 +1066,7 @@ export function renderTableFragment(
     const isFirstRowInFragment =
       headerRowCount > 0 && fragment.continuesFromPrev
         ? false // header rows already drawn, content rows are not "first"
-        : fragment.continuesFromPrev && rowIndex === fragment.fromRow;
+        : fragment.continuesFromPrev === true && rowIndex === fragment.fromRow;
     const contentClip =
       rowIndex === fragment.fromRow &&
       (fragment.topClip !== undefined || fragment.bottomClip !== undefined)
@@ -1088,10 +1088,10 @@ export function renderTableFragment(
       spanningCells,
       rowYPositions,
       isFirstRowInFragment,
-      bidi: block.bidi,
+      bidi: block.bidi === true,
       columnsPinned,
       cellGrid,
-      contentClip,
+      ...(contentClip ? { contentClip } : {}),
     });
 
     contentParent.append(rowEl);

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -1067,12 +1067,13 @@ export function renderTableFragment(
       headerRowCount > 0 && fragment.continuesFromPrev
         ? false // header rows already drawn, content rows are not "first"
         : fragment.continuesFromPrev === true && rowIndex === fragment.fromRow;
+    const rowTopClip = rowIndex === fragment.fromRow ? fragment.topClip : undefined;
+    const rowBottomClip = rowIndex === fragment.toRow - 1 ? fragment.bottomClip : undefined;
     const contentClip =
-      rowIndex === fragment.fromRow &&
-      (fragment.topClip !== undefined || fragment.bottomClip !== undefined)
+      rowTopClip !== undefined || rowBottomClip !== undefined
         ? {
-            top: fragment.topClip ?? 0,
-            bottom: fragment.bottomClip ?? rowMeasure.height,
+            top: rowTopClip ?? 0,
+            bottom: rowBottomClip ?? rowMeasure.height,
           }
         : undefined;
 

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -207,6 +207,133 @@ describe("renderTableFragment clipped header continuations", () => {
   });
 });
 
+describe("renderTableFragment split-row cell content", () => {
+  test("clips ordinary cell content to each intersecting row slice", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "content",
+                  runs: [{ kind: "text", text: "Tall cell content" }],
+                },
+                {
+                  kind: "paragraph",
+                  id: "floating-anchor",
+                  runs: [
+                    {
+                      kind: "image",
+                      src: "floating.png",
+                      width: 20,
+                      height: 20,
+                      displayMode: "float",
+                      wrapType: "inFront",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                { kind: "paragraph", lines: [], totalHeight: 100 },
+                { kind: "paragraph", lines: [], totalHeight: 0 },
+              ],
+              width: 100,
+              height: 100,
+            },
+          ],
+          height: 100,
+        },
+      ],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 100,
+    };
+    const fragments: TableFragment[] = [
+      {
+        kind: "table",
+        blockId: "tbl",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 30,
+        fromRow: 0,
+        toRow: 1,
+        bottomClip: 30,
+        continuesOnNext: true,
+      },
+      {
+        kind: "table",
+        blockId: "tbl",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 40,
+        fromRow: 0,
+        toRow: 1,
+        topClip: 30,
+        bottomClip: 70,
+        continuesFromPrev: true,
+        continuesOnNext: true,
+      },
+      {
+        kind: "table",
+        blockId: "tbl",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 30,
+        fromRow: 0,
+        toRow: 1,
+        topClip: 70,
+        continuesFromPrev: true,
+      },
+    ];
+
+    let clipPaths: (string | undefined)[] = [];
+    withFakeTextMeasure(() => {
+      clipPaths = fragments.map((fragment) => {
+        const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+          document: fakeDocument,
+        }) as unknown as FakeElement;
+        const content = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent).at(0);
+        const floatingLayer = findByClass(tableEl, "layout-cell-floating-images-layer").at(0);
+
+        expect(tableEl.style["overflow"]).toBe("visible");
+        expect(content?.style["height"]).toBe("100px");
+        expect(content?.style["overflow"]).toBe("hidden");
+        expect(floatingLayer?.style["clipPath"]).toBeUndefined();
+
+        return content?.style["clipPath"];
+      });
+    });
+
+    expect(clipPaths).toEqual([
+      "inset(0px 0 70px 0)",
+      "inset(30px 0 30px 0)",
+      "inset(70px 0 0px 0)",
+    ]);
+  });
+});
+
 describe("renderTableFragment cell paragraph spacing", () => {
   test("reserves measured paragraph spacing inside table cells", () => {
     const block: TableBlock = {

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -332,6 +332,90 @@ describe("renderTableFragment split-row cell content", () => {
       "inset(70px 0 0px 0)",
     ]);
   });
+
+  test("applies a bottom slice only to the final row of a multi-row fragment", () => {
+    const paragraph = (id: string) => ({
+      kind: "paragraph" as const,
+      id,
+      runs: [
+        { kind: "text" as const, text: "Cell content" },
+        {
+          kind: "image" as const,
+          src: "floating.png",
+          width: 20,
+          height: 20,
+          displayMode: "float" as const,
+          wrapType: "inFront" as const,
+        },
+      ],
+    });
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row-1",
+          cells: [
+            {
+              id: "cell-1",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [paragraph("paragraph-1")],
+            },
+          ],
+        },
+        {
+          id: "row-2",
+          cells: [
+            {
+              id: "cell-2",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [paragraph("paragraph-2")],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const measuredRow = {
+      cells: [
+        {
+          blocks: [{ kind: "paragraph" as const, lines: [], totalHeight: 100 }],
+          width: 100,
+          height: 100,
+        },
+      ],
+      height: 100,
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [measuredRow, measuredRow],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 200,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 130,
+      fromRow: 0,
+      toRow: 2,
+      bottomClip: 30,
+      continuesOnNext: true,
+    };
+
+    withFakeTextMeasure(() => {
+      const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+      }) as unknown as FakeElement;
+      const contents = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent);
+
+      expect(contents.at(0)?.style["clipPath"]).toBeUndefined();
+      expect(contents.at(1)?.style["clipPath"]).toBe("inset(0px 0 70px 0)");
+    });
+  });
 });
 
 describe("renderTableFragment cell paragraph spacing", () => {


### PR DESCRIPTION
## Summary

- constrain ordinary table-cell content to the visible row slice on page continuations
- preserve overflow behavior for anchored cell objects
- cover first, middle, and final row slices with synthetic regressions

CC on behalf of @jan-kubica