### PR TITLE
fix: preserve structural page geometry

### DIFF
--- a/.changeset/calm-page-flow.md
+++ b/.changeset/calm-page-flow.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Honor break-only paragraph placement and exact image-only line footprints during pagination.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -233,7 +233,8 @@ export type ParagraphAttrs = {
     shading?: import__stll_docx_core_model.ShadingProperties;
     tabs?: import__stll_docx_core_model.TabStop[];
     pageBreakBefore?: boolean; /** Word's cached rendered-page-break marker; preserved for round-trip only. */
-    renderedPageBreakBefore?: boolean;
+    renderedPageBreakBefore?: boolean; /** Internal import marker for a paragraph whose only run content is a hard page break. */
+    _pageBreakCarrier?: boolean;
     keepNext?: boolean;
     keepLines?: boolean;
     widowControl?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -335,7 +335,8 @@ export type ParagraphAttrs = {
     shading?: import__stll_docx_core_model.ShadingProperties;
     tabs?: import__stll_docx_core_model.TabStop[];
     pageBreakBefore?: boolean; /** Word's cached rendered-page-break marker; preserved for round-trip only. */
-    renderedPageBreakBefore?: boolean;
+    renderedPageBreakBefore?: boolean; /** Internal import marker for a paragraph whose only run content is a hard page break. */
+    _pageBreakCarrier?: boolean;
     keepNext?: boolean;
     keepLines?: boolean;
     widowControl?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -195,7 +195,8 @@ export type DocumentSettings = {
             characters: string;
         };
         useLegacyEthiopicAmharicRules?: boolean;
-    };
+    }; /** Move a break-only paragraph mark onto the page after its hard page break. */
+    splitPageBreakAndParagraphMark?: boolean;
 };
 
 // @public

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -367,7 +367,11 @@ describe("Layout Engine - Page Production", () => {
         { kind: "pageBreak", id: 1, pmStart: 15, pmEnd: 16 },
         {
           ...makeParagraphBlock(2, "Cached next page", 17),
-          attrs: { renderedPageBreakBefore: true },
+          attrs: {
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+            spacingExplicit: { before: true },
+          },
         },
       ];
       const measures: Measure[] = [
@@ -380,6 +384,7 @@ describe("Layout Engine - Page Production", () => {
 
       expect(layout.pages.length).toBe(2);
       expect(layout.pages[1].fragments[0].blockId).toBe(2);
+      expect(layout.pages[1].fragments[0].y).toBe(DEFAULT_MARGINS.top);
     });
 
     test("stale rendered page break remains advisory when the paragraph fits", () => {
@@ -446,6 +451,53 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages).toHaveLength(2);
       expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
+    });
+
+    test("rendered page break does not reapply leading spacing after snapping", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        {
+          ...makeParagraphBlock(1, "Cached next page", 23),
+          attrs: {
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+            spacingExplicit: { before: true },
+          },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 820)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 80)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments[0]?.y).toBe(DEFAULT_MARGINS.top);
+    });
+
+    test("authored pageBreakBefore keeps leading spacing", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before break", 1),
+        {
+          ...makeParagraphBlock(1, "Authored next page", 14),
+          attrs: {
+            pageBreakBefore: true,
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+            spacingExplicit: { before: true },
+          },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 18, 90, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments[0]?.y).toBe(DEFAULT_MARGINS.top + 24);
     });
 
     test("rendered page break does not add a blank page at a natural overflow", () => {

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -174,3 +174,17 @@ describe("parseSettings — document automatic hyphenation", () => {
     expect(settings.hyphenationZoneTwips).toBeUndefined();
   });
 });
+
+describe("parseSettings — break-only paragraph placement", () => {
+  test("records only an enabled splitPgBreakAndParaMark compatibility flag", () => {
+    expect(
+      parseSettings(wrap(`<w:compat><w:splitPgBreakAndParaMark/></w:compat>`))
+        .splitPageBreakAndParagraphMark,
+    ).toBe(true);
+    expect(
+      parseSettings(wrap(`<w:compat><w:splitPgBreakAndParaMark w:val="0"/></w:compat>`))
+        .splitPageBreakAndParagraphMark,
+    ).toBeUndefined();
+    expect(parseSettings(wrap("")).splitPageBreakAndParagraphMark).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -91,6 +91,12 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
   const noLineBreaksBefore = parseKinsokuOverride(root, "noLineBreaksBefore");
   const noLineBreaksAfter = parseKinsokuOverride(root, "noLineBreaksAfter");
   const compat = root ? findChild(root, "w", "compat") : null;
+  const splitPageBreakAndParagraphMark = compat
+    ? findChild(compat, "w", "splitPgBreakAndParaMark")
+    : null;
+  if (splitPageBreakAndParagraphMark && parseBooleanElement(splitPageBreakAndParagraphMark)) {
+    settings.splitPageBreakAndParagraphMark = true;
+  }
   const applyBreakingRules = compat ? findChild(compat, "w", "applyBreakingRules") : null;
   const useLegacyEthiopicAmharicRules =
     applyBreakingRules !== null && parseBooleanElement(applyBreakingRules);

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -650,6 +650,28 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.listMarkerHidden).toBe(true);
   });
 
+  test("suppresses a paintless imported page-break carrier", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { _pageBreakCarrier: true, spaceBefore: 360 }),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.suppressEmptyParagraphHeight).toBe(true);
+  });
+
+  test("keeps authored empty paragraphs and visible break-carrier markers", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { spaceBefore: 360 }),
+      schema.node("paragraph", { _pageBreakCarrier: true, listMarker: "1." }),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.at(0)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+    expect(blocks.at(1)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
+
   test("preserves explicit automatic line spacing", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { lineSpacing: 240, lineSpacingRule: "auto" }, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1909,6 +1909,18 @@ function convertParagraph(
       attrs.listMarkerHidden = true;
     }
   }
+  const hasVisibleParagraphPayload =
+    (attrs.listMarker !== undefined && !attrs.listMarkerHidden) ||
+    attrs.borders?.top !== undefined ||
+    attrs.borders?.bottom !== undefined ||
+    attrs.borders?.left !== undefined ||
+    attrs.borders?.right !== undefined ||
+    attrs.borders?.between !== undefined ||
+    attrs.borders?.bar !== undefined ||
+    attrs.shading !== undefined;
+  if (runs.length === 0 && pmAttrs._pageBreakCarrier === true && !hasVisibleParagraphPayload) {
+    attrs.suppressEmptyParagraphHeight = true;
+  }
 
   const bookmarkNames = pmAttrs.bookmarks?.map((b) => b.name);
 

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -410,13 +410,14 @@ export function layoutDocument(
 
     const renderedBreakNeedsSnap =
       measure.kind === "paragraph" && !paginator.fits(measure.totalHeight);
+    const hasExplicitPageBreak = hasPageBreakBefore(block);
     const breakDecision = reconcileBreakBeforeBlock({
       state: renderedBreakState,
       block,
       previousBlock: blocks[i - 1],
       page: paginator.getCurrentState().page,
       blocksById,
-      hasExplicitPageBreak: hasPageBreakBefore(block),
+      hasExplicitPageBreak,
       renderedBreakNeedsSnap,
     });
     if (breakDecision.forcePageBreak) {
@@ -440,13 +441,18 @@ export function layoutDocument(
     const pageBeforeBlockLayout = paginator.getCurrentState().page.number;
     switch (block.kind) {
       case "paragraph":
-        layoutParagraph(
+        layoutParagraph({
           block,
-          measure as ParagraphMeasure,
+          measure: measure as ParagraphMeasure,
           paginator,
-          paginator.columnWidth,
-          options.footnoteHeightById,
-        );
+          contentWidth: paginator.columnWidth,
+          footnoteHeightById: options.footnoteHeightById,
+          suppressSpaceBefore:
+            block.attrs?.renderedPageBreakBefore === true &&
+            !hasExplicitPageBreak &&
+            (breakDecision.forcePageBreak ||
+              paginator.getCurrentState().cursorY === paginator.getCurrentState().topMargin),
+        });
         break;
 
       case "table":
@@ -602,17 +608,27 @@ function getLineFootnoteRefs(
  * lacks room for both — preventing footnote overflow without the
  * static-reservation iteration loop.
  */
-function layoutParagraph(
-  block: ParagraphBlock,
-  measure: ParagraphMeasure,
-  paginator: ReturnType<typeof createPaginator>,
-  contentWidth: number,
-  footnoteHeightById?: Map<number, number>,
-): void {
+type LayoutParagraphOptions = {
+  block: ParagraphBlock;
+  measure: ParagraphMeasure;
+  paginator: ReturnType<typeof createPaginator>;
+  contentWidth: number;
+  footnoteHeightById: Map<number, number> | undefined;
+  suppressSpaceBefore: boolean;
+};
+
+function layoutParagraph({
+  block,
+  measure,
+  paginator,
+  contentWidth,
+  footnoteHeightById,
+  suppressSpaceBefore,
+}: LayoutParagraphOptions): void {
   const lines = measure.lines;
   if (lines.length === 0) {
     // Empty paragraph - still takes up space based on spacing
-    const spaceBefore = getParagraphSpacingBefore(block);
+    const spaceBefore = suppressSpaceBefore ? 0 : getParagraphSpacingBefore(block);
     const spaceAfter = getParagraphSpacingAfter(block);
     const state = paginator.getCurrentState();
 
@@ -635,7 +651,7 @@ function layoutParagraph(
     return;
   }
 
-  const spaceBefore = getParagraphSpacingBefore(block);
+  const spaceBefore = suppressSpaceBefore ? 0 : getParagraphSpacingBefore(block);
   const spaceAfter = getParagraphSpacingAfter(block);
 
   // Try to fit all lines on current page/column

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -786,9 +786,9 @@ describe("measureTableBlock row height", () => {
       if (paragraph?.kind !== "paragraph") {
         throw new Error("Expected paragraph measure");
       }
-      expect(paragraph.totalHeight).toBeGreaterThan(40);
+      expect(paragraph.totalHeight).toBe(40);
       expect(cell?.height).toBe(40);
-      expect(cell?.height).toBeLessThan(paragraph.totalHeight);
+      expect(cell?.height).toBe(paragraph.totalHeight);
       expect(row?.height).toBe(cell?.height);
     }, fakeMeasure);
   });

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1173,7 +1173,7 @@ describe("measureParagraph document default tab interval", () => {
 });
 
 describe("inline image paragraph measurement", () => {
-  test("image-only line reserves descender room above and below image", () => {
+  test("image-only line uses the authored image footprint", () => {
     const imageHeight = 29;
     const measure = measureParagraph(
       {
@@ -1199,9 +1199,9 @@ describe("inline image paragraph measurement", () => {
       600,
     );
 
-    expect(measure.lines[0]?.lineHeight).toBeGreaterThan(imageHeight);
-    expect(measure.lines[0]?.ascent).toBeGreaterThan(imageHeight);
-    expect(measure.lines[0]?.descent).toBeGreaterThan(0);
+    expect(measure.lines[0]?.lineHeight).toBe(imageHeight);
+    expect(measure.lines[0]?.ascent).toBe(imageHeight);
+    expect(measure.lines[0]?.descent).toBe(0);
   });
 
   test("advances floating-zone y offsets by image-inflated line height", () => {
@@ -1276,7 +1276,7 @@ describe("inline image paragraph measurement", () => {
     }, fakeMeasure);
   });
 
-  test("image-only line keeps imageH + descent*2 breathing-room band", () => {
+  test("image-only line does not add text descent", () => {
     const imageHeight = 40;
     const measure = measureParagraph(
       {
@@ -1300,9 +1300,9 @@ describe("inline image paragraph measurement", () => {
 
     const line = measure.lines.at(0);
     expect(line).toBeDefined();
-    const descent = line?.descent ?? 0;
-    expect(line?.lineHeight).toBe(imageHeight + descent * 2);
-    expect(line?.ascent).toBe(imageHeight + descent);
+    expect(line?.lineHeight).toBe(imageHeight);
+    expect(line?.ascent).toBe(imageHeight);
+    expect(line?.descent).toBe(0);
   });
 
   test("embedded-object preview uses its authored box as the exact line height", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -1095,23 +1095,21 @@ export function measureParagraph(
     if (inlineObjectHeight > finalTypography.lineHeight) {
       const objectHeight = inlineObjectHeight;
       const buffer = finalTypography.descent;
-      // `fromRun === toRun` with a tall inline object present means the line
-      // holds exactly that one object (no flowing text/tabs). Must stay paired
-      // with the painter's image-only `runsForLine.length === 1 && isImageRun(...)`
-      // test in renderLine — the two pick paired line-height + alignment
-      // strategies and disagreeing reintroduces the floating-label bug.
-      if (line.fromRun === line.toRun) {
-        if (line.maxExactImageHeightPx >= objectHeight) {
-          finalTypography.lineHeight = objectHeight;
-          finalTypography.ascent = objectHeight;
-          finalTypography.descent = 0;
-          return finalTypography;
-        }
-        // Object alone on the line: grow to the object height plus the
-        // parent font's descent on BOTH sides so the row has visible
-        // breathing room above and below it.
-        finalTypography.lineHeight = objectHeight + buffer * 2;
-        finalTypography.ascent = objectHeight + buffer;
+      // An image-only line uses the authored image footprint directly. There
+      // is no text baseline that needs font descent above or below the image;
+      // adding one silently grows large diagrams and can change pagination.
+      // Keep this paired with the painter's image-only flex alignment.
+      const soleRun = line.fromRun === line.toRun ? runs[line.fromRun] : undefined;
+      if (line.maxExactImageHeightPx >= objectHeight) {
+        finalTypography.lineHeight = objectHeight;
+        finalTypography.ascent = objectHeight;
+        finalTypography.descent = 0;
+        return finalTypography;
+      }
+      if (soleRun && isImageRun(soleRun)) {
+        finalTypography.lineHeight = objectHeight;
+        finalTypography.ascent = objectHeight;
+        finalTypography.descent = 0;
       } else {
         // Object flowing with text/tabs (e.g. a logo + label header line):
         // the full object height sits above the baseline and only the text

--- a/packages/core/src/prosemirror/conversion/toProseDoc-pagebreak.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc-pagebreak.test.ts
@@ -51,7 +51,65 @@ describe('toProseDoc — hard page break (`<w:br w:type="page"/>`)', () => {
     };
 
     const pmDoc = toProseDoc(document);
-    expect(childTypeNames(pmDoc)).toContain("pageBreak");
+    expect(childTypeNames(pmDoc)).toEqual(["paragraph", "pageBreak", "paragraph", "paragraph"]);
+    expect(pmDoc.child(2).attrs["_pageBreakCarrier"]).toBe(true);
+  });
+
+  test("keeps an enabled split break-only paragraph as authored page content", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "break", breakType: "page" }],
+                },
+              ],
+            },
+            { type: "paragraph", content: [] },
+          ],
+        },
+        settings: {
+          defaultTabStop: 720,
+          splitPageBreakAndParagraphMark: true,
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+
+    expect(childTypeNames(pmDoc)).toEqual(["pageBreak", "paragraph", "paragraph"]);
+    expect(pmDoc.child(1).attrs["_pageBreakCarrier"]).toBeNull();
+    expect(pmDoc.child(2).attrs["_pageBreakCarrier"]).toBeNull();
+  });
+
+  test("does not classify a separate authored empty paragraph as a break carrier", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "break", breakType: "page" }],
+                },
+              ],
+            },
+            { type: "paragraph", content: [] },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+
+    expect(pmDoc.child(1).attrs["_pageBreakCarrier"]).toBe(true);
+    expect(pmDoc.child(2).attrs["_pageBreakCarrier"]).toBeNull();
   });
 
   test("emits pageBreak after text for a paragraph with text followed by a break", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -111,11 +111,25 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
         if (pbPos === "before") {
           out.push(schema.node("pageBreak"));
         }
-        out.push(
-          ...convertParagraphWithTextBoxes(block, styleResolver, {
-            textBoxGroupId: nextTextBoxGroupId(),
-          }),
-        );
+        const converted = convertParagraphWithTextBoxes(block, styleResolver, {
+          textBoxGroupId: nextTextBoxGroupId(),
+        });
+        const firstConverted = converted.at(0);
+        if (
+          pbPos === "before" &&
+          converted.length === 1 &&
+          firstConverted?.type.name === "paragraph" &&
+          firstConverted.content.size === 0 &&
+          document.package.settings?.splitPageBreakAndParagraphMark !== true
+        ) {
+          const paragraph = firstConverted;
+          converted[0] = paragraph.type.create(
+            { ...paragraph.attrs, _pageBreakCarrier: true },
+            paragraph.content,
+            paragraph.marks,
+          );
+        }
+        out.push(...converted);
         if (pbPos === "after") {
           out.push(schema.node("pageBreak"));
         }

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -358,6 +358,7 @@ const paragraphNodeSpec: NodeSpec = {
     tabs: { default: null },
     pageBreakBefore: { default: null },
     renderedPageBreakBefore: { default: null },
+    _pageBreakCarrier: { default: null },
     keepNext: { default: null },
     keepLines: { default: null },
     widowControl: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -166,6 +166,8 @@ export type ParagraphAttrs = {
   pageBreakBefore?: boolean;
   /** Word's cached rendered-page-break marker; preserved for round-trip only. */
   renderedPageBreakBefore?: boolean;
+  /** Internal import marker for a paragraph whose only run content is a hard page break. */
+  _pageBreakCarrier?: boolean;
   keepNext?: boolean;
   keepLines?: boolean;
   widowControl?: boolean;

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -214,6 +214,8 @@ export type DocumentSettings = {
     noLineBreaksAfter?: { language?: string; characters: string };
     useLegacyEthiopicAmharicRules?: boolean;
   };
+  /** Move a break-only paragraph mark onto the page after its hard page break. */
+  splitPageBreakAndParagraphMark?: boolean;
 };
 
 /** DOCX package conformance classes. */


### PR DESCRIPTION
Honor OOXML break-only paragraph placement and cached page boundaries during pagination. Image-only lines now use their authored footprint so text-line descent does not alter surrounding page flow.

CC on behalf of @jan-kubica