### PR TITLE
fix: preserve authored table cell paragraph layout

### DIFF
--- a/.changeset/calm-cell-paragraphs.md
+++ b/.changeset/calm-cell-paragraphs.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored table-cell paragraphs and keep paragraph-mark fonts off existing body text.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1063,7 +1063,7 @@ describe("toFlowBlocks table cell formatting", () => {
     expect(table.rows.at(0)?.cells.at(1)?.textDirection).toBeUndefined();
   });
 
-  test("suppresses a trailing empty paragraph after real cell content", () => {
+  test("keeps an authored trailing empty paragraph after prose cell content", () => {
     const doc = schema.node("doc", null, [
       schema.node("table", null, [
         schema.node("tableRow", null, [
@@ -1082,8 +1082,32 @@ describe("toFlowBlocks table cell formatting", () => {
     }
 
     const cells = table.rows.at(0)?.cells;
-    expect(cells?.at(0)?.blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBe(true);
+    expect(cells?.at(0)?.blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
     expect(cells?.at(1)?.blocks.at(0)?.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+  });
+
+  test("suppresses the required trailing paragraph after a nested table", () => {
+    const nestedTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text("nested")])]),
+      ]),
+    ]);
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [nestedTable, schema.node("paragraph")]),
+        ]),
+      ]),
+    ]);
+
+    const table = toFlowBlocks(doc).at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+
+    expect(table.rows.at(0)?.cells.at(0)?.blocks.at(-1)?.attrs?.suppressEmptyParagraphHeight).toBe(
+      true,
+    );
   });
 
   test("suppresses a terminal run of empty body paragraphs after a final table", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2182,13 +2182,14 @@ function convertTableCell(
     offset += child.nodeSize;
   });
 
-  // A structurally empty paragraph appended after real cell content is the
-  // cell-end marker in Word's layout model, not another visible blank line.
-  // Keep the paragraph as a zero-height anchor for editing/positions. A cell
-  // whose only paragraph is empty still needs Word's normal empty-line floor.
+  // A table cell whose final block is a nested table needs a trailing paragraph
+  // as its editable cell-end marker. Keep that marker as a zero-height anchor.
+  // Empty paragraphs after ordinary prose are authored content and retain their
+  // normal line height.
   const trailingBlock = blocks.at(-1);
+  const precedingBlock = blocks.at(-2);
   if (
-    blocks.length > 1 &&
+    precedingBlock?.kind === "table" &&
     trailingBlock?.kind === "paragraph" &&
     trailingBlock.runs.every((run) => run.kind === "text" && run.text.length === 0)
   ) {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -242,7 +242,7 @@ describe("toProseDoc", () => {
     expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(true);
     expect(text?.marks.some((mark) => mark.type.name === "italic")).toBe(false);
     expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(21);
-    expect(text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe("Arial");
+    expect(text?.marks.some((mark) => mark.type.name === "fontFamily")).toBe(false);
   });
 
   test("keeps direct run formatting ahead of paragraph-mark defaults", () => {
@@ -409,6 +409,78 @@ describe("toProseDoc", () => {
 
     expect(paragraph?.attrs.defaultTextFormatting.fontSize).toBe(52);
     expect(text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size).toBe(24);
+  });
+
+  test("does not leak a paragraph-mark font into directly formatted body text", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: { boldCs: true },
+                  content: [{ type: "text", text: "Body text" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          docDefaults: {
+            rPr: { fontFamily: { ascii: "Arial", hAnsi: "Arial" } },
+          },
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe("Arial");
+  });
+
+  test("keeps the default style font on an unformatted body run", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {},
+                  content: [{ type: "text", text: "Body text" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          docDefaults: {
+            rPr: { fontFamily: { ascii: "Arial", hAnsi: "Arial" } },
+          },
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe("Arial");
   });
 
   test("keeps named paragraph style fonts ahead of paragraph-mark formatting", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -266,7 +266,8 @@ function convertParagraph(
   // paragraph glyph alone. Strip them from the body-run inheritance path.
   let inheritableParagraphRunFormatting: TextFormatting | undefined;
   if (paragraphRunFormatting && !isTocParagraph) {
-    inheritableParagraphRunFormatting = stripParagraphMarkOnlyFormatting(paragraphRunFormatting);
+    inheritableParagraphRunFormatting =
+      stripParagraphMarkFormattingForBodyRuns(paragraphRunFormatting);
   }
   const baseRunFormatting = mergeTextFormatting(styleRunFormatting, extraRunFormatting);
   // With a named paragraph style, w:pPr/w:rPr formats the paragraph mark and
@@ -941,6 +942,18 @@ function stripParagraphMarkOnlyFormatting(formatting: TextFormatting): TextForma
   return Object.keys(rest).length > 0 ? rest : undefined;
 }
 
+function stripParagraphMarkFormattingForBodyRuns(
+  formatting: TextFormatting,
+): TextFormatting | undefined {
+  const paragraphMarkFormatting = stripParagraphMarkOnlyFormatting(formatting);
+  if (!paragraphMarkFormatting) {
+    return undefined;
+  }
+
+  const { fontFamily: _fontFamily, ...bodyRunFormatting } = paragraphMarkFormatting;
+  return Object.keys(bodyRunFormatting).length > 0 ? bodyRunFormatting : undefined;
+}
+
 function suppressParagraphMarkFormatting(
   base: TextFormatting | undefined,
   paragraphMark: TextFormatting | undefined,
@@ -985,7 +998,6 @@ function suppressParagraphMarkFormatting(
   ) {
     result.fontSizeCs = base.fontSizeCs;
   }
-
   if (paragraphMark.underline !== undefined && direct?.underline === undefined) {
     result.underline = { style: "none" };
   }


### PR DESCRIPTION
## Summary

- keep paragraph-mark font metadata from overriding existing body text
- preserve authored trailing empty paragraphs in table cells
- suppress only the required editable paragraph after a nested table

## Validation

- focused conversion and layout-bridge tests (113 passing)
- formatting verification
- dependency audit
- lint, typecheck, build, and full suites run in CI

CC on behalf of @jan-kubica