### PR TITLE
fix: position vertical image crops by height

### DIFF
--- a/.changeset/bright-dots-crop.md
+++ b/.changeset/bright-dots-crop.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Position vertical OOXML image crops relative to the bitmap height.

--- a/packages/core/src/layout-painter/renderImage-opacity.test.ts
+++ b/packages/core/src/layout-painter/renderImage-opacity.test.ts
@@ -240,9 +240,15 @@ describe("ImageVisualAttrs helpers", () => {
     const img = fakeDocument.createElement("img") as unknown as HTMLImageElement;
     img.style.transform = "scaleX(-1)";
 
-    applyImageVisualAttrs(img, { cropTop: 0.25 });
+    applyImageVisualAttrs(img, {
+      cropTop: 0.25,
+      cropRight: 0.125,
+      cropBottom: 0.125,
+      cropLeft: 0.25,
+    });
 
     expect((img as unknown as FakeElement).style["transform"]).toBe("scaleX(-1) translateY(-25%)");
+    expect((img as unknown as FakeElement).style["transformOrigin"]).toBe("56.25% 56.25%");
     expect((img as unknown as FakeElement).style["marginTop"]).toBeUndefined();
   });
 });

--- a/packages/core/src/layout-painter/renderImage-opacity.test.ts
+++ b/packages/core/src/layout-painter/renderImage-opacity.test.ts
@@ -235,4 +235,14 @@ describe("ImageVisualAttrs helpers", () => {
     applyImageVisualAttrs(img, attrs);
     expect((img as unknown as FakeElement).style["opacity"]).toBeUndefined();
   });
+
+  test("preserves an existing transform when positioning a top crop", () => {
+    const img = fakeDocument.createElement("img") as unknown as HTMLImageElement;
+    img.style.transform = "scaleX(-1)";
+
+    applyImageVisualAttrs(img, { cropTop: 0.25 });
+
+    expect((img as unknown as FakeElement).style["transform"]).toBe("scaleX(-1) translateY(-25%)");
+    expect((img as unknown as FakeElement).style["marginTop"]).toBeUndefined();
+  });
 });

--- a/packages/core/src/layout-painter/renderImage.ts
+++ b/packages/core/src/layout-painter/renderImage.ts
@@ -97,6 +97,15 @@ export function applyImageVisualAttrs(img: HTMLImageElement, v: ImageVisualAttrs
   img.style.width = `${fw * 100}%`;
   img.style.height = `${fh * 100}%`;
   img.style.marginLeft = `${-left * fw * 100}%`;
+  const existingTransform = img.style.transform;
+  if (existingTransform) {
+    // The enlarged bitmap's center differs from the visible crop frame's
+    // center when opposite crop amounts are asymmetric. Rotate or flip around
+    // the visible center so the cropped region stays aligned with its frame.
+    const visibleCenterX = (left + 1 - right) * 50;
+    const visibleCenterY = (top + 1 - bottom) * 50;
+    img.style.transformOrigin = `${visibleCenterX}% ${visibleCenterY}%`;
+  }
   if (top !== 0) {
     // Vertical percentage margins resolve against the containing block's
     // width, so they over-shift wide, shallow images. A percentage translate
@@ -104,8 +113,8 @@ export function applyImageVisualAttrs(img: HTMLImageElement, v: ImageVisualAttrs
     // exact source offset that must move above the clipped frame. Append the
     // translation so source cropping occurs before any image flip or rotation.
     const cropTransform = `translateY(${-top * 100}%)`;
-    img.style.transform = img.style.transform
-      ? `${img.style.transform} ${cropTransform}`
+    img.style.transform = existingTransform
+      ? `${existingTransform} ${cropTransform}`
       : cropTransform;
   }
   // Object-fit on the upscaled `<img>` would re-letterbox inside the

--- a/packages/core/src/layout-painter/renderImage.ts
+++ b/packages/core/src/layout-painter/renderImage.ts
@@ -25,7 +25,7 @@ export const IMAGE_CLASS_NAMES = {
 // (opacity render pipeline).
 
 /**
- * Structural shape required to apply Word's per-image visual attributes:
+ * Structural shape required to apply OOXML per-image visual attributes:
  * `wp:srcRect` crop fractions and `a:alphaModFix` opacity. `ImageRun` and
  * `ImageBlock` both satisfy this, so callers don't need an adapter.
  */
@@ -55,9 +55,9 @@ export function hasImageVisualAttrs(v: ImageVisualAttrs): boolean {
 }
 
 /**
- * Apply Word's `<a:srcRect>` crop to an `<img>` whose parent already has
+ * Apply an OOXML `<a:srcRect>` crop to an `<img>` whose parent already has
  * `overflow: hidden` and is sized to the *visible* (cropped) dimensions
- * (this matches `wp:extent` semantics: in Word the extent is the cropped
+ * (this matches `wp:extent` semantics: the extent is the cropped
  * frame, with `<a:stretch><a:fillRect/>` stretching the cropped source to
  * fill it).
  *
@@ -97,9 +97,19 @@ export function applyImageVisualAttrs(img: HTMLImageElement, v: ImageVisualAttrs
   img.style.width = `${fw * 100}%`;
   img.style.height = `${fh * 100}%`;
   img.style.marginLeft = `${-left * fw * 100}%`;
-  img.style.marginTop = `${-top * fh * 100}%`;
+  if (top !== 0) {
+    // Vertical percentage margins resolve against the containing block's
+    // width, so they over-shift wide, shallow images. A percentage translate
+    // resolves against the enlarged bitmap itself: `top * fullHeight` is the
+    // exact source offset that must move above the clipped frame. Append the
+    // translation so source cropping occurs before any image flip or rotation.
+    const cropTransform = `translateY(${-top * 100}%)`;
+    img.style.transform = img.style.transform
+      ? `${img.style.transform} ${cropTransform}`
+      : cropTransform;
+  }
   // Object-fit on the upscaled `<img>` would re-letterbox inside the
-  // enlarged box; force fill so the bitmap stretches to fw×fh as Word does.
+  // enlarged box; force fill so the bitmap stretches to fw×fh.
   img.style.objectFit = "fill";
 }
 

--- a/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
@@ -151,7 +151,6 @@ describe("renderLine inline image handling", () => {
   // extent size, so the wrong region shows surrounded by blank bands. The
   // painter wraps the `<img>` in an overflow-hidden inline-block sized to
   // the visible extent and upscales the inner `<img>` by 1/(1-l-r) × 1/(1-t-b).
-  // Regression: gemini-code-assist + chatgpt-codex review on PR #510.
   test("wraps a cropped inline image and scales the inner <img>", () => {
     const imageRun: ImageRun = {
       kind: "image",
@@ -199,8 +198,9 @@ describe("renderLine inline image handling", () => {
     const imgEl = wrapperEl?.children[0] as FakeElement | undefined;
     expect(imgEl?.tagName).toBe("img");
     // The inner <img> is enlarged so the cropped region exactly covers the
-    // wrapper, with negative margins shifting the bitmap so the cropped
-    // top-left lands at the wrapper's origin. `object-fit: fill` keeps the
+    // wrapper, with a horizontal margin and bitmap-relative vertical
+    // translation shifting the cropped top-left to the wrapper's origin.
+    // `object-fit: fill` keeps the
     // bitmap stretched (no contain letterboxing) inside the enlarged box.
     // FP precision: the painter computes 1/(1-l-r) where l+r is FP-noisy, so
     // assert with a numeric tolerance on the parsed percent rather than the
@@ -208,15 +208,55 @@ describe("renderLine inline image handling", () => {
     const widthPct = Number.parseFloat(imgEl?.style.width ?? "");
     const heightPct = Number.parseFloat(imgEl?.style.height ?? "");
     const marginLeftPct = Number.parseFloat(imgEl?.style.marginLeft ?? "");
-    const marginTopPct = Number.parseFloat(imgEl?.style.marginTop ?? "");
     expect(widthPct).toBeCloseTo((1 / 0.65) * 100, 6);
     expect(heightPct).toBeCloseTo((1 / 0.85) * 100, 6);
     expect(marginLeftPct).toBeCloseTo((-0.15 / 0.65) * 100, 6);
-    expect(marginTopPct).toBeCloseTo((-0.1 / 0.85) * 100, 6);
+    expect(imgEl?.style.transform).toBe("translateY(-10%)");
+    expect(imgEl?.style.marginTop).toBeFalsy();
     expect(imgEl?.style.objectFit).toBe("fill");
     // The legacy clip-path approach must not be used.
     expect(imgEl?.style.clipPath).toBeFalsy();
     expect(wrapperEl?.style.clipPath).toBeFalsy();
+  });
+
+  test("positions a top crop from the bitmap height for a wide, shallow image", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 480,
+      height: 48,
+      cropTop: 0.2,
+      cropBottom: 0.1,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-wide-crop",
+      runs: [imageRun],
+      pmStart: 0,
+      pmEnd: 3,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 480,
+      ascent: 48,
+      descent: 0,
+      lineHeight: 48,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const wrapperEl = lineEl.children[0] as FakeElement | undefined;
+    const imgEl = wrapperEl?.children[0] as FakeElement | undefined;
+
+    expect(wrapperEl?.style.width).toBe("480px");
+    expect(wrapperEl?.style.height).toBe("48px");
+    expect(Number.parseFloat(imgEl?.style.height ?? "")).toBeCloseTo((1 / 0.7) * 100, 6);
+    expect(imgEl?.style.transform).toBe("translateY(-20%)");
+    expect(imgEl?.style.marginTop).toBeFalsy();
   });
 
   // Pathological crops (e.g. cropLeft + cropRight ≥ 1) would otherwise divide
@@ -299,8 +339,8 @@ describe("renderLine inline image handling", () => {
     expect(imageEl?.style.clipPath).toBeFalsy();
   });
 
-  // Regression chatgpt-codex on #410: the image+text flex branch fired on
-  // `runsForLine.some(isImageRun)`, which also matched FLOATING images. Those
+  // The image+text flex branch must not treat a floating image as inline.
+  // `runsForLine.some(isImageRun)` also matches floating images, but those
   // render in a page-level layer and `continue` in the main loop, so a line
   // that wraps around a floating image (text-only inline content) was being
   // forced into flex/baseline layout — changing alignment + indent + line


### PR DESCRIPTION
Positions vertical OOXML source-rectangle crops relative to the enlarged bitmap height instead of the containing block width.

Preserves existing flip and rotation transforms while keeping horizontal crop positioning unchanged.

CC on behalf of @jan-kubica