### PR TITLE
fix: reduce parity comparison false positives

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -650,6 +650,109 @@ describe("compareGeoms", () => {
     expect(result.score).toBe(1);
   });
 
+  test("reconciles a leading candidate segment before a matched suffix", () => {
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "ID: Primary registration 123",
+            xPt: 72,
+            yPt: 72,
+            widthPt: 188,
+          }),
+        ],
+      }),
+    ]);
+    const candidate = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "ID:", xPt: 72, yPt: 72, widthPt: 15 }),
+          makeLine({
+            text: "Primary registration 123",
+            xPt: 140,
+            yPt: 72,
+            widthPt: 120,
+          }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(reference, candidate);
+
+    expect(result.divergences).toEqual([]);
+    expect(result.matchedLines).toBe(1);
+    expect(result.score).toBe(1);
+  });
+
+  test("reconciles a leading reference segment before a matched suffix", () => {
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "ID:", xPt: 72, yPt: 72, widthPt: 15 }),
+          makeLine({
+            text: "Primary registration 123",
+            xPt: 140,
+            yPt: 72,
+            widthPt: 120,
+          }),
+        ],
+      }),
+    ]);
+    const candidate = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "ID: Primary registration 123",
+            xPt: 72,
+            yPt: 72,
+            widthPt: 188,
+          }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(reference, candidate);
+
+    expect(result.divergences).toEqual([]);
+    expect(result.matchedLines).toBe(2);
+    expect(result.score).toBe(1);
+  });
+
+  test("leaves an unrelated preceding row outside leading-segment reconciliation", () => {
+    const reference = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({ text: "Unrelated row", xPt: 72, yPt: 48, widthPt: 80 }),
+          makeLine({ text: "ID:", xPt: 72, yPt: 72, widthPt: 15 }),
+          makeLine({
+            text: "Primary registration 123",
+            xPt: 140,
+            yPt: 72,
+            widthPt: 120,
+          }),
+        ],
+      }),
+    ]);
+    const candidate = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "ID: Primary registration 123",
+            xPt: 72,
+            yPt: 72,
+            widthPt: 188,
+          }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(reference, candidate);
+
+    expect(result.divergences).toEqual([{ kind: "missing-line", page: 1, text: "Unrelated row" }]);
+    expect(result.matchedLines).toBe(2);
+    expect(result.score).toBeCloseTo(2 / 3);
+  });
+
   test("reconciles one segmented visual row inside a larger alignment gap", () => {
     const reference = makeDoc("folio", [
       makePage({

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -6,10 +6,12 @@ import {
   computeZoomFactor,
   formatNavigationFailure,
   formatServerStartFailure,
+  isFullyClippedByAncestors,
   isPlausibleBaseline,
   meaningfulTextRange,
   parseCssFontFamilies,
   parseFirstFontFamily,
+  parseInsetClipPath,
   screenshotViewportHeight,
   toPageGeom,
 } from "../folioExtract";
@@ -153,6 +155,32 @@ describe("isPlausibleBaseline", () => {
   });
 });
 
+describe("CSS clipping geometry", () => {
+  test("parses computed inset shorthand in pixels and percentages", () => {
+    expect(parseInsetClipPath("inset(10px 5% 20px)", 200, 100)).toEqual({
+      top: 10,
+      right: 10,
+      bottom: 20,
+      left: 10,
+    });
+    expect(parseInsetClipPath("circle(50%)", 200, 100)).toBeNull();
+  });
+
+  test("scales inset clips from layout pixels to transformed visual pixels", () => {
+    const ancestor = {
+      rect: rect(0, 0, 100, 100),
+      offsetWidth: 200,
+      offsetHeight: 200,
+      clipsX: false,
+      clipsY: false,
+      clipPath: "inset(80px 0 40px)",
+    };
+
+    expect(isFullyClippedByAncestors(rect(10, 10, 50, 10), [ancestor])).toBe(true);
+    expect(isFullyClippedByAncestors(rect(10, 45, 50, 10), [ancestor])).toBe(false);
+  });
+});
+
 describe("parseFirstFontFamily", () => {
   test("takes the first family and strips double quotes", () => {
     expect(parseFirstFontFamily('"Calibri", "Arial", sans-serif')).toBe("Calibri");
@@ -271,6 +299,33 @@ describe("toPageGeom", () => {
     const page = toPageGeom(rawPage);
 
     expect(page.lines.map((line) => line.text)).toEqual(["Visible"]);
+  });
+
+  test("drops lines fully excluded by a CSS inset clip path", () => {
+    const clippingAncestor = {
+      rect: rect(0, 0, 100, 100),
+      offsetWidth: 100,
+      offsetHeight: 100,
+      clipsX: false,
+      clipsY: true,
+      clipPath: "inset(60px 0 0)",
+    };
+    const rawPage = makeRawPage({
+      lines: [
+        makeRawLine({
+          text: "Clipped",
+          rect: rect(0, 20, 100, 10),
+          clippingAncestors: [clippingAncestor],
+        }),
+        makeRawLine({
+          text: "Visible",
+          rect: rect(0, 70, 100, 10),
+          clippingAncestors: [clippingAncestor],
+        }),
+      ],
+    });
+
+    expect(toPageGeom(rawPage).lines.map((line) => line.text)).toEqual(["Visible"]);
   });
 
   test("drops lines whose normalized text is empty (whitespace-only / soft hyphen only)", () => {

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -479,29 +479,29 @@ const resolveOps = (
 };
 
 /**
- * A high-similarity prefix can be selected as a direct match before alignment
- * sees that the next segment completes the same visual row. Fold that trailing
- * segment back into a one-to-many row so geometry is compared over the full
- * row instead of reporting a text mismatch plus an extra line.
+ * A high-similarity prefix or suffix can be selected as a direct match before
+ * alignment sees that an adjacent segment completes the same visual row. Fold
+ * those segments back into a one-to-many row so geometry is compared over the
+ * full row instead of reporting a text mismatch plus a missing/extra line.
  */
 const reconcileMatchedRowSegments = (
   resolved: ResolvedItem[],
   referenceFlat: FlatLine[],
   candidateFlat: FlatLine[],
 ): ResolvedItem[] => {
-  const reconciled: ResolvedItem[] = [];
+  const trailingReconciled: ResolvedItem[] = [];
 
   for (let index = 0; index < resolved.length; index += 1) {
     const item = resolved[index];
     if (!item || item.kind !== "match") {
-      if (item) reconciled.push(item);
+      if (item) trailingReconciled.push(item);
       continue;
     }
 
     const next = resolved[index + 1];
     const trailingKind = next?.kind === "missing" || next?.kind === "extra" ? next.kind : null;
     if (!trailingKind) {
-      reconciled.push(item);
+      trailingReconciled.push(item);
       continue;
     }
 
@@ -510,7 +510,7 @@ const reconcileMatchedRowSegments = (
     const anchor =
       trailingKind === "missing" ? referenceFlat[item.wordIdx] : candidateFlat[item.folioIdx];
     if (!anchor) {
-      reconciled.push(item);
+      trailingReconciled.push(item);
       continue;
     }
 
@@ -536,12 +536,79 @@ const reconcileMatchedRowSegments = (
     }
 
     if (!equivalentSegmentedRows(referenceIdxs, candidateIdxs, referenceFlat, candidateFlat)) {
+      trailingReconciled.push(item);
+      continue;
+    }
+
+    trailingReconciled.push({
+      kind: "line-break",
+      wordIdxs: referenceIdxs,
+      folioIdxs: candidateIdxs,
+    });
+    index = cursor - 1;
+  }
+
+  const reconciled: ResolvedItem[] = [];
+  for (const item of trailingReconciled) {
+    if (item.kind !== "match") {
       reconciled.push(item);
       continue;
     }
 
+    const previous = reconciled.at(-1);
+    const leadingKind =
+      previous?.kind === "missing" || previous?.kind === "extra" ? previous.kind : null;
+    if (!leadingKind) {
+      reconciled.push(item);
+      continue;
+    }
+
+    const anchor =
+      leadingKind === "missing" ? referenceFlat[item.wordIdx] : candidateFlat[item.folioIdx];
+    if (!anchor) {
+      reconciled.push(item);
+      continue;
+    }
+
+    let leadingStart = reconciled.length;
+    while (leadingStart > 0) {
+      const leading = reconciled[leadingStart - 1];
+      if (!leading || leading.kind !== leadingKind) break;
+      const flatLine =
+        leading.kind === "missing"
+          ? referenceFlat[leading.wordIdx]
+          : candidateFlat[leading.folioIdx];
+      if (
+        !flatLine ||
+        flatLine.page !== anchor.page ||
+        flatLine.line.region !== anchor.line.region ||
+        !isSameVisualRow(anchor.line, flatLine.line)
+      ) {
+        break;
+      }
+      leadingStart -= 1;
+    }
+
+    const leadingItems = reconciled.slice(leadingStart);
+    const leadingReferenceIdxs: number[] = [];
+    const leadingCandidateIdxs: number[] = [];
+    for (const leading of leadingItems) {
+      if (leading.kind === "missing") {
+        leadingReferenceIdxs.push(leading.wordIdx);
+      } else if (leading.kind === "extra") {
+        leadingCandidateIdxs.push(leading.folioIdx);
+      }
+    }
+    const referenceIdxs = [...leadingReferenceIdxs, item.wordIdx];
+    const candidateIdxs = [...leadingCandidateIdxs, item.folioIdx];
+
+    if (!equivalentSegmentedRows(referenceIdxs, candidateIdxs, referenceFlat, candidateFlat)) {
+      reconciled.push(item);
+      continue;
+    }
+
+    reconciled.splice(leadingStart);
     reconciled.push({ kind: "line-break", wordIdxs: referenceIdxs, folioIdxs: candidateIdxs });
-    index = cursor - 1;
   }
 
   return reconciled;

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -179,6 +179,8 @@ export type RawLine = {
   region: Region;
   /** True when the line's ink box falls fully outside an overflow-clipping ancestor. */
   fullyClipped?: boolean;
+  /** CSS clipping ancestors, captured in visual pixels for visibility filtering. */
+  clippingAncestors?: RawClippingAncestor[];
   /** First actually available family from the computed CSS stack of the first
    * `.layout-run`; falls back to the computed stack when canvas probing is unavailable. */
   fontFamilyRaw?: string;
@@ -188,6 +190,15 @@ export type RawLine = {
   visualGroup?: string;
   /** Stable page-local identity of the originating `.layout-line`. */
   logicalLineGroup?: string;
+};
+
+export type RawClippingAncestor = {
+  rect: RawRect;
+  offsetWidth: number;
+  offsetHeight: number;
+  clipsX: boolean;
+  clipsY: boolean;
+  clipPath?: string;
 };
 
 /** One `.layout-page` element and its lines, extracted with DOM-only reads. */
@@ -230,6 +241,88 @@ export const isPlausibleBaseline = (baselineTop: number, rect: RawRect): boolean
   return offsetRatio >= MIN_BASELINE_OFFSET_RATIO && offsetRatio <= MAX_BASELINE_OFFSET_RATIO;
 };
 
+type InsetClip = { top: number; right: number; bottom: number; left: number };
+
+const cssInsetLength = (token: string, dimension: number): number | null => {
+  if (token === "0") return 0;
+  if (token.endsWith("px")) {
+    const value = Number.parseFloat(token);
+    return Number.isFinite(value) ? value : null;
+  }
+  if (token.endsWith("%")) {
+    const value = Number.parseFloat(token);
+    return Number.isFinite(value) ? (value / 100) * dimension : null;
+  }
+  return null;
+};
+
+/** Parse the computed form of a CSS `inset()` clip path. Unsupported units
+ * return null so the visibility filter remains conservative. */
+export const parseInsetClipPath = (
+  clipPath: string | undefined,
+  width: number,
+  height: number,
+): InsetClip | null => {
+  const match = clipPath?.match(/^inset\(([^)]*)\)$/u);
+  const value = match?.[1]?.split(/\s+round\s+/u)[0]?.trim();
+  if (!value) return null;
+
+  const tokens = value.split(/\s+/u);
+  if (tokens.length < 1 || tokens.length > 4) return null;
+  const [topToken, rightToken = topToken, bottomToken = topToken, leftToken = rightToken] = tokens;
+  if (!topToken || !rightToken || !bottomToken || !leftToken) return null;
+
+  const top = cssInsetLength(topToken, height);
+  const right = cssInsetLength(rightToken, width);
+  const bottom = cssInsetLength(bottomToken, height);
+  const left = cssInsetLength(leftToken, width);
+  if (top === null || right === null || bottom === null || left === null) return null;
+  return { top, right, bottom, left };
+};
+
+/** Whether a visual rect has no remaining area after all supported CSS clips
+ * are intersected. Clip-path lengths are layout pixels, so they are scaled to
+ * the post-transform visual rect before comparison. */
+export const isFullyClippedByAncestors = (
+  rect: RawRect,
+  ancestors: RawClippingAncestor[] | undefined,
+): boolean => {
+  let left = rect.left;
+  let top = rect.top;
+  let right = rect.left + rect.width;
+  let bottom = rect.top + rect.height;
+
+  for (const ancestor of ancestors ?? []) {
+    const ancestorRight = ancestor.rect.left + ancestor.rect.width;
+    const ancestorBottom = ancestor.rect.top + ancestor.rect.height;
+    if (ancestor.clipsX) {
+      left = Math.max(left, ancestor.rect.left);
+      right = Math.min(right, ancestorRight);
+    }
+    if (ancestor.clipsY) {
+      top = Math.max(top, ancestor.rect.top);
+      bottom = Math.min(bottom, ancestorBottom);
+    }
+
+    const inset = parseInsetClipPath(
+      ancestor.clipPath,
+      ancestor.offsetWidth,
+      ancestor.offsetHeight,
+    );
+    if (inset) {
+      const scaleX = ancestor.offsetWidth > 0 ? ancestor.rect.width / ancestor.offsetWidth : 1;
+      const scaleY = ancestor.offsetHeight > 0 ? ancestor.rect.height / ancestor.offsetHeight : 1;
+      left = Math.max(left, ancestor.rect.left + inset.left * scaleX);
+      right = Math.min(right, ancestorRight - inset.right * scaleX);
+      top = Math.max(top, ancestor.rect.top + inset.top * scaleY);
+      bottom = Math.min(bottom, ancestorBottom - inset.bottom * scaleY);
+    }
+
+    if (right <= left || bottom <= top) return true;
+  }
+  return false;
+};
+
 /** First font-family in a CSS `font-family` list, with surrounding quotes stripped. */
 export const parseFirstFontFamily = (fontFamilyRaw: string | undefined): string | undefined => {
   if (!fontFamilyRaw) {
@@ -264,7 +357,12 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
 
   const lines: LineBox[] = [];
   for (const rawLine of rawPage.lines) {
-    if (rawLine.fullyClipped || rawLine.rect.width <= 0 || rawLine.rect.height <= 0) {
+    if (
+      rawLine.fullyClipped ||
+      isFullyClippedByAncestors(rawLine.rect, rawLine.clippingAncestors) ||
+      rawLine.rect.width <= 0 ||
+      rawLine.rect.height <= 0
+    ) {
       continue;
     }
     const normText = normalizeLineText(rawLine.text);
@@ -576,7 +674,14 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
       const clippingValues = new Set(["auto", "clip", "hidden", "scroll"]);
       const ancestorClipCache = new Map<
         HTMLElement,
-        { clipsX: boolean; clipsY: boolean; rect?: DOMRect }
+        {
+          clipsX: boolean;
+          clipsY: boolean;
+          clipPath?: string;
+          rect?: DOMRect;
+          offsetWidth: number;
+          offsetHeight: number;
+        }
       >();
       const canvasContext = document.createElement("canvas").getContext("2d");
       const fontProbeText = "mmmmmmmmmmlliWW0123456789";
@@ -735,39 +840,60 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
           return text;
         };
 
-        const isFullyClipped = (sourceEl: HTMLElement | null, rect: DOMRect): boolean => {
-          let ancestor = (sourceEl ?? lineEl).parentElement;
+        const clippingAncestorsFor = (sourceEl: HTMLElement | null) => {
+          const clippingAncestors = [];
+          let ancestor: HTMLElement | null = sourceEl ?? lineEl;
           while (ancestor && el.contains(ancestor)) {
             let clipInfo = ancestorClipCache.get(ancestor);
             if (!clipInfo) {
               const computed = getComputedStyle(ancestor);
               const clipsX = clippingValues.has(computed.overflowX);
               const clipsY = clippingValues.has(computed.overflowY);
+              const clipPath = computed.clipPath === "none" ? undefined : computed.clipPath;
               clipInfo = {
                 clipsX,
                 clipsY,
-                ...(clipsX || clipsY ? { rect: ancestor.getBoundingClientRect() } : {}),
+                ...(clipPath !== undefined ? { clipPath } : {}),
+                ...(clipsX || clipsY || clipPath !== undefined
+                  ? { rect: ancestor.getBoundingClientRect() }
+                  : {}),
+                offsetWidth: ancestor.offsetWidth,
+                offsetHeight: ancestor.offsetHeight,
               };
               ancestorClipCache.set(ancestor, clipInfo);
             }
-            const { clipsX, clipsY, rect: ancestorRect } = clipInfo;
-            if (clipsX || clipsY) {
+            const {
+              clipsX,
+              clipsY,
+              clipPath,
+              rect: ancestorRect,
+              offsetWidth,
+              offsetHeight,
+            } = clipInfo;
+            if (clipsX || clipsY || clipPath !== undefined) {
               if (!ancestorRect) {
                 throw new Error("clipping ancestor is missing cached geometry");
               }
-              if (
-                (clipsX && (rect.right <= ancestorRect.left || rect.left >= ancestorRect.right)) ||
-                (clipsY && (rect.bottom <= ancestorRect.top || rect.top >= ancestorRect.bottom))
-              ) {
-                return true;
-              }
+              clippingAncestors.push({
+                rect: {
+                  left: ancestorRect.left,
+                  top: ancestorRect.top,
+                  width: ancestorRect.width,
+                  height: ancestorRect.height,
+                },
+                clipsX,
+                clipsY,
+                ...(clipPath !== undefined ? { clipPath } : {}),
+                offsetWidth,
+                offsetHeight,
+              });
             }
             if (ancestor === el) {
               break;
             }
             ancestor = ancestor.parentElement;
           }
-          return false;
+          return clippingAncestors;
         };
 
         const toRawLine = (text: string, rect: DOMRect, sourceEl: HTMLElement | null) => ({
@@ -775,7 +901,7 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
           rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
           ...(Number.isFinite(baselineTop) ? { baselineTop } : {}),
           region,
-          ...(isFullyClipped(sourceEl, rect) ? { fullyClipped: true } : {}),
+          clippingAncestors: clippingAncestorsFor(sourceEl),
           ...(visualGroup !== undefined ? { visualGroup } : {}),
           logicalLineGroup,
           ...fontFrom(sourceEl),


### PR DESCRIPTION
## Summary

- exclude fully clipped DOM text from extracted comparison geometry, including transformed `inset()` clips
- reconcile equivalent leading and trailing visual-row segments around direct text matches
- cover zoom scaling, symmetric segmentation, and unrelated-row isolation with synthetic regressions

CC on behalf of @jan-kubica