### PR TITLE
fix: preserve section-leading paragraph spacing

### DIFF
--- a/.changeset/neat-section-spacing.md
+++ b/.changeset/neat-section-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored paragraph spacing after section boundaries with cached pagination hints.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -387,6 +387,32 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1].fragments[0].y).toBe(DEFAULT_MARGINS.top);
     });
 
+    test("rendered page break preserves leading spacing after a section boundary", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before section", 1),
+        { kind: "sectionBreak", id: 1, type: "nextPage" },
+        {
+          ...makeParagraphBlock(2, "First paragraph in section", 17),
+          attrs: {
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+            spacingExplicit: { before: true },
+          },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 14, 100, 24)]),
+        { kind: "sectionBreak" },
+        makeParagraphMeasure([makeLine(0, 0, 0, 26, 120, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments[0]?.blockId).toBe(2);
+      expect(layout.pages[1]?.fragments[0]?.y).toBe(DEFAULT_MARGINS.top + 24);
+    });
+
     test("stale rendered page break remains advisory when the paragraph fits", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Before break", 1),

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -447,11 +447,7 @@ export function layoutDocument(
           paginator,
           contentWidth: paginator.columnWidth,
           footnoteHeightById: options.footnoteHeightById,
-          suppressSpaceBefore:
-            block.attrs?.renderedPageBreakBefore === true &&
-            !hasExplicitPageBreak &&
-            (breakDecision.forcePageBreak ||
-              paginator.getCurrentState().cursorY === paginator.getCurrentState().topMargin),
+          suppressSpaceBefore: breakDecision.suppressSpaceBefore,
         });
         break;
 

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -51,6 +51,7 @@ describe("rendered break reconciliation", () => {
 
     expect(decision).toEqual({
       forcePageBreak: true,
+      suppressSpaceBefore: false,
       state: INITIAL_RENDERED_BREAK_STATE,
     });
   });
@@ -69,6 +70,7 @@ describe("rendered break reconciliation", () => {
     });
 
     expect(decision.forcePageBreak).toBe(true);
+    expect(decision.suppressSpaceBefore).toBe(true);
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
@@ -85,6 +87,7 @@ describe("rendered break reconciliation", () => {
     });
 
     expect(decision.forcePageBreak).toBe(false);
+    expect(decision.suppressSpaceBefore).toBe(false);
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
@@ -117,6 +120,41 @@ describe("rendered break reconciliation", () => {
     });
 
     expect(decision.forcePageBreak).toBe(false);
+    expect(decision.suppressSpaceBefore).toBe(true);
+  });
+
+  test("a section boundary does not consume authored paragraph spacing", () => {
+    const previous: FlowBlock = { kind: "sectionBreak", id: 1, type: "nextPage" };
+    const marker = paragraph(2, { renderedPageBreakBefore: true });
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: marker,
+      previousBlock: previous,
+      page: page(),
+      blocksById: new Map(),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.suppressSpaceBefore).toBe(false);
+  });
+
+  test("a continuous section boundary preserves spacing when the marker snaps", () => {
+    const prior = paragraph(1);
+    const previous: FlowBlock = { kind: "sectionBreak", id: 2, type: "continuous" };
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: paragraph(3, { renderedPageBreakBefore: true }),
+      previousBlock: previous,
+      page: page([paragraphFragment(1)]),
+      blocksById: new Map([["1", prior]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: true,
+    });
+
+    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.suppressSpaceBefore).toBe(false);
   });
 
   test("a reflow boundary satisfies the next cached marker", () => {

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -22,6 +22,7 @@ type ReconcileBeforeBlockOptions = {
 
 type BreakDecision = {
   forcePageBreak: boolean;
+  suppressSpaceBefore: boolean;
   state: RenderedBreakState;
 };
 
@@ -43,10 +44,14 @@ export const reconcileBreakBeforeBlock = ({
   renderedBreakNeedsSnap,
 }: ReconcileBeforeBlockOptions): BreakDecision => {
   if (hasExplicitPageBreak) {
-    return { forcePageBreak: true, state: INITIAL_RENDERED_BREAK_STATE };
+    return {
+      forcePageBreak: true,
+      suppressSpaceBefore: false,
+      state: INITIAL_RENDERED_BREAK_STATE,
+    };
   }
   if (block.kind !== "paragraph" || block.attrs?.renderedPageBreakBefore !== true) {
-    return { forcePageBreak: false, state };
+    return { forcePageBreak: false, suppressSpaceBefore: false, state };
   }
 
   const markerAlreadySatisfied =
@@ -59,10 +64,20 @@ export const reconcileBreakBeforeBlock = ({
   // A keep-with-next paragraph carries the marker boundary into its linked
   // content, so its own height is not enough to classify the marker as stale.
   const markerNeedsSnap = renderedBreakNeedsSnap || block.attrs?.keepNext === true;
+  const forcePageBreak =
+    markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById);
+  const followsAuthoredPageBreak = previousBlock?.kind === "pageBreak";
+  const followsSectionBreak = previousBlock?.kind === "sectionBreak";
 
   return {
-    forcePageBreak:
-      markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById),
+    forcePageBreak,
+    // Suppress spacing only when this cached marker accounts for the current
+    // page boundary. A section boundary can also leave the cursor at the page
+    // top, but it does not make the following paragraph's authored spacing
+    // redundant.
+    suppressSpaceBefore:
+      !followsSectionBreak &&
+      (forcePageBreak || markerAlreadySatisfied || followsAuthoredPageBreak),
     state: INITIAL_RENDERED_BREAK_STATE,
   };
 };


### PR DESCRIPTION
## Summary

- distinguish cached pagination boundaries from section boundaries when applying leading paragraph spacing
- preserve authored section-leading spacing while retaining cached-break suppression for actual pagination
- cover the decision and end-to-end page placement with regressions

CC on behalf of @jan-kubica