### PR TITLE
fix: preserve header and footer colors

### DIFF
--- a/.changeset/calm-header-footer-colors.md
+++ b/.changeset/calm-header-footer-colors.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Preserve authored header and footer colors at full opacity.

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -554,7 +554,7 @@ describe("floating text box render zones", () => {
 });
 
 describe("header and footer rendering", () => {
-  test("dims header and footer chrome while editing body content", () => {
+  test("preserves authored header and footer colors", () => {
     const pageElement = renderPage(
       { ...page, fragments: [] },
       { pageNumber: 1, totalPages: 1, section: "body" },
@@ -563,10 +563,10 @@ describe("header and footer rendering", () => {
 
     expect(
       findByClass(pageElement as unknown as FakeElement, "layout-page-header")?.style.opacity,
-    ).toBe("0.62");
+    ).toBeUndefined();
     expect(
       findByClass(pageElement as unknown as FakeElement, "layout-page-footer")?.style.opacity,
-    ).toBe("0.62");
+    ).toBeUndefined();
   });
 
   test("ignores even footers unless odd/even headers are enabled", () => {

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -2170,7 +2170,6 @@ export function renderPage(
     headerEl.style.width = `${headerContentWidth}px`;
     headerEl.style.height = `${interactiveHeaderHeight}px`;
     headerEl.style.minHeight = `${interactiveHeaderHeight}px`;
-    headerEl.style.opacity = "0.62";
 
     let shouldClipHeader = !headerOverflows && headerContentFitsBox;
     if (options.headerContent && options.headerContent.blocks.length > 0) {
@@ -2243,7 +2242,6 @@ export function renderPage(
     footerEl.style.width = `${footerContentWidth}px`;
     footerEl.style.height = `${interactiveFooterHeight}px`;
     footerEl.style.minHeight = `${interactiveFooterHeight}px`;
-    footerEl.style.opacity = "0.62";
 
     // As with the header, only clip when the content fits the shrunk box; a
     // floating object extending past the flow band must stay visible

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -673,17 +673,6 @@
   border-top: 1px dotted var(--doc-primary);
 }
 
-/* The painter dims every header/footer to 0.62 opacity (inline style in
-   renderPage). While editing a region, restore full opacity for the edited kind
-   so the typed text reads as black; `!important` beats the inline opacity.
-   Kept in sync with prosemirror-layer.css. */
-.paged-editor--editing-header .layout-page-header {
-  opacity: 1 !important;
-}
-.paged-editor--editing-footer .layout-page-footer {
-  opacity: 1 !important;
-}
-
 .paged-editor--hf-editing .layout-page-header:hover,
 .paged-editor--hf-editing .layout-page-footer:hover {
   background-color: transparent;

--- a/packages/react/src/styles/prosemirror-layer.css
+++ b/packages/react/src/styles/prosemirror-layer.css
@@ -767,18 +767,6 @@
   border-top: 1px dotted var(--doc-primary);
 }
 
-/* The painter dims every header/footer to 0.62 opacity so it reads as secondary
-   chrome in normal mode (set as an INLINE style in renderPage). While the user
-   is editing a region, the text they are typing must read as full-opacity black,
-   so restore opacity 1 for the edited kind. `!important` is required to beat the
-   inline opacity; scoping to the edited kind leaves the other region dimmed. */
-.paged-editor--editing-header .layout-page-header {
-  opacity: 1 !important;
-}
-.paged-editor--editing-footer .layout-page-footer {
-  opacity: 1 !important;
-}
-
 /* Post-eigenpal#611 the painter is the sole visible HF renderer in edit mode
    too (the inline overlay no longer mounts its own PM), so the old
    `.paged-editor--editing-{header,footer} > * { visibility: hidden }` patch that


### PR DESCRIPTION
Remove container-level opacity from painted header and footer regions so authored colors render without global compositing. The editing styles no longer need opacity overrides.

CC on behalf of @jan-kubica