### PR TITLE
fix: preserve floating table image geometry

### DIFF
--- a/.changeset/tidy-floating-raster.md
+++ b/.changeset/tidy-floating-raster.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve page-relative positioning and crop geometry for floating images inside tables.

--- a/packages/core/src/layout-engine/measure/tableCellFloating.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFloating.ts
@@ -1,5 +1,5 @@
 import { emuToPixels } from "../../utils/units";
-import type { TableCell, TableCellMeasure } from "../types";
+import type { ImageRun, TableCell, TableCellMeasure } from "../types";
 import { isFloatingImageRun } from "../types";
 import { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
 import type { FloatingImageZone } from "./floatingZones";
@@ -10,6 +10,11 @@ export type TableCellFloatingImage = {
   height: number;
   alt?: string;
   transform?: string;
+  opacity?: number;
+  cropTop?: number;
+  cropRight?: number;
+  cropBottom?: number;
+  cropLeft?: number;
   x: number;
   y: number;
   side: "left" | "right";
@@ -21,6 +26,13 @@ export type TableCellFloatingImage = {
   pmStart?: number;
   pmEnd?: number;
 };
+
+type TableCellFloatingPosition = Pick<TableCellFloatingImage, "x" | "y" | "side">;
+
+export type ResolveTableCellFloatingPosition = (
+  run: ImageRun,
+  paragraphY: number,
+) => TableCellFloatingPosition;
 
 export function getTableCellContentWidth(
   cell: TableCell | undefined,
@@ -35,6 +47,7 @@ export function getTableCellFloatingImages(
   cell: TableCell,
   cellMeasure: TableCellMeasure,
   contentWidth: number,
+  resolvePosition?: ResolveTableCellFloatingPosition,
 ): TableCellFloatingImage[] {
   const result: TableCellFloatingImage[] = [];
   let paragraphY = 0;
@@ -60,37 +73,42 @@ export function getTableCellFloatingImages(
       const distLeft = run.distLeft ?? 12;
       const distRight = run.distRight ?? 12;
 
-      let side: "left" | "right" = "left";
-      let x = 0;
-      if (position?.horizontal) {
-        const horizontal = position.horizontal;
-        if (horizontal.align === "right") {
+      let side: "left" | "right";
+      let x: number;
+      let y: number;
+      if (resolvePosition) {
+        ({ side, x, y } = resolvePosition(run, paragraphY));
+      } else {
+        side = "left";
+        x = 0;
+        if (position?.horizontal) {
+          const horizontal = position.horizontal;
+          if (horizontal.align === "right") {
+            side = "right";
+            x = contentWidth - run.width;
+          } else if (horizontal.align === "center") {
+            x = (contentWidth - run.width) / 2;
+          } else if (horizontal.posOffset !== undefined) {
+            x = emuToPixels(horizontal.posOffset);
+            side = x > contentWidth / 2 ? "right" : "left";
+          }
+        } else if (run.cssFloat === "right") {
           side = "right";
           x = contentWidth - run.width;
-        } else if (horizontal.align === "left") {
-          x = 0;
-        } else if (horizontal.align === "center") {
-          x = (contentWidth - run.width) / 2;
-        } else if (horizontal.posOffset !== undefined) {
-          x = emuToPixels(horizontal.posOffset);
-          side = x > contentWidth / 2 ? "right" : "left";
         }
-      } else if (run.cssFloat === "right") {
-        side = "right";
-        x = contentWidth - run.width;
-      }
 
-      let y = paragraphY;
-      if (position?.vertical) {
-        const vertical = position.vertical;
-        if (vertical.posOffset !== undefined) {
-          y = paragraphY + emuToPixels(vertical.posOffset);
-        } else if (vertical.align === "top") {
-          y = 0;
+        y = paragraphY;
+        if (position?.vertical) {
+          const vertical = position.vertical;
+          if (vertical.posOffset !== undefined) {
+            y = paragraphY + emuToPixels(vertical.posOffset);
+          } else if (vertical.align === "top") {
+            y = 0;
+          }
         }
-      }
 
-      x = Math.max(0, Math.min(x, contentWidth - run.width));
+        x = Math.max(0, Math.min(x, contentWidth - run.width));
+      }
 
       let wrapText: "bothSides" | "left" | "right" | "largest" = "bothSides";
       if (run.cssFloat === "left") {
@@ -105,6 +123,11 @@ export function getTableCellFloatingImages(
         height: run.height,
         ...(run.alt !== undefined ? { alt: run.alt } : {}),
         ...(run.transform !== undefined ? { transform: run.transform } : {}),
+        ...(run.opacity != null ? { opacity: run.opacity } : {}),
+        ...(run.cropTop != null ? { cropTop: run.cropTop } : {}),
+        ...(run.cropRight != null ? { cropRight: run.cropRight } : {}),
+        ...(run.cropBottom != null ? { cropBottom: run.cropBottom } : {}),
+        ...(run.cropLeft != null ? { cropLeft: run.cropLeft } : {}),
         x,
         y,
         side,

--- a/packages/core/src/layout-painter/anchoredImagePosition.ts
+++ b/packages/core/src/layout-painter/anchoredImagePosition.ts
@@ -1,0 +1,119 @@
+import type { ImageRun } from "../layout-engine/types";
+import { emuToPixels } from "./renderUtils";
+
+export type PageGeometry = {
+  pageWidth: number;
+  pageHeight: number;
+  marginLeft: number;
+  marginTop: number;
+  marginRight: number;
+  marginBottom: number;
+  contentWidth: number;
+  contentHeight: number;
+};
+
+/** Coordinates relative to the page content area's top-left corner. */
+export type AnchoredImagePosition = {
+  x: number;
+  y: number;
+  side: "left" | "right";
+};
+
+function resolveHorizontalBand(
+  relativeTo: string | undefined,
+  geometry: PageGeometry,
+): { baseX: number; bandWidth: number } {
+  switch (relativeTo) {
+    case "page":
+      return { baseX: -geometry.marginLeft, bandWidth: geometry.pageWidth };
+    case "leftMargin":
+    case "insideMargin":
+      return { baseX: -geometry.marginLeft, bandWidth: geometry.marginLeft };
+    case "rightMargin":
+    case "outsideMargin":
+      return { baseX: geometry.contentWidth, bandWidth: geometry.marginRight };
+    case "character":
+      return { baseX: 0, bandWidth: 0 };
+    default:
+      return { baseX: 0, bandWidth: geometry.contentWidth };
+  }
+}
+
+function resolveVerticalBand(
+  relativeTo: string | undefined,
+  fragmentY: number,
+  geometry: PageGeometry,
+): { baseY: number; bandHeight: number } {
+  switch (relativeTo) {
+    case "page":
+      return { baseY: -geometry.marginTop, bandHeight: geometry.pageHeight };
+    case "topMargin":
+      return { baseY: -geometry.marginTop, bandHeight: geometry.marginTop };
+    case "bottomMargin":
+      return { baseY: geometry.contentHeight, bandHeight: geometry.marginBottom };
+    case "paragraph":
+    case "line":
+      return { baseY: fragmentY, bandHeight: 0 };
+    default:
+      return { baseY: 0, bandHeight: geometry.contentHeight };
+  }
+}
+
+/** Resolve an anchored image into page-content-relative coordinates. */
+export function resolveAnchoredImagePosition(
+  imgRun: ImageRun,
+  fragmentY: number,
+  geometry: PageGeometry,
+): AnchoredImagePosition {
+  const position = imgRun.position;
+  const contentWidth = geometry.contentWidth;
+
+  let side: "left" | "right" = "left";
+  let x = 0;
+
+  if (position?.horizontal) {
+    const h = position.horizontal;
+    const { baseX, bandWidth } = resolveHorizontalBand(h.relativeTo, geometry);
+    const horizontalHasBand = h.relativeTo !== "character";
+
+    if (h.align === "right" || h.align === "outside") {
+      side = "right";
+      x = horizontalHasBand ? baseX + bandWidth - imgRun.width : 0;
+    } else if (h.align === "left" || h.align === "inside") {
+      x = baseX;
+    } else if (h.align === "center") {
+      x = horizontalHasBand ? baseX + (bandWidth - imgRun.width) / 2 : 0;
+    } else if (h.posOffset !== undefined) {
+      x = baseX + emuToPixels(h.posOffset);
+      side = x > contentWidth / 2 ? "right" : "left";
+    } else {
+      x = baseX;
+    }
+  } else if (imgRun.cssFloat === "right") {
+    side = "right";
+    x = contentWidth - imgRun.width;
+  }
+
+  let y: number;
+  if (position?.vertical) {
+    const v = position.vertical;
+    const { baseY, bandHeight } = resolveVerticalBand(v.relativeTo, fragmentY, geometry);
+    const verticalHasBand = v.relativeTo !== "paragraph" && v.relativeTo !== "line";
+
+    if (v.align === "top" || v.align === "inside") {
+      y = baseY;
+    } else if (v.align === "center") {
+      y = verticalHasBand ? baseY + (bandHeight - imgRun.height) / 2 : fragmentY;
+    } else if (v.align === "bottom" || v.align === "outside") {
+      y = verticalHasBand ? baseY + bandHeight - imgRun.height : fragmentY;
+    } else if (v.posOffset !== undefined) {
+      y = baseY + emuToPixels(v.posOffset);
+    } else {
+      y = verticalHasBand ? baseY : fragmentY;
+    }
+  } else {
+    y = fragmentY;
+  }
+
+  return { x, y, side };
+}

--- a/packages/core/src/layout-painter/renderImage-opacity.test.ts
+++ b/packages/core/src/layout-painter/renderImage-opacity.test.ts
@@ -111,6 +111,18 @@ const findImageDescendant = (el: FakeElement): FakeElement | undefined => {
   return undefined;
 };
 
+describe("applyImageVisualAttrs crop sizing", () => {
+  test("lets a horizontally cropped bitmap expand beyond its frame", () => {
+    const image = fakeDocument.createElement("img");
+
+    applyImageVisualAttrs(image, { cropLeft: 0.2, cropRight: 0.3 });
+
+    expect(Number.parseFloat(image.style.width)).toBeCloseTo(200, 6);
+    expect(image.style.maxWidth).toBe("none");
+    expect(image.style.maxHeight).toBe("none");
+  });
+});
+
 describe("renderImageFragment opacity (floating block path)", () => {
   test("emits CSS opacity for a floating image with opacity 0.5", () => {
     const block = baseImageBlock({ opacity: 0.5 });

--- a/packages/core/src/layout-painter/renderImage.ts
+++ b/packages/core/src/layout-painter/renderImage.ts
@@ -96,6 +96,10 @@ export function applyImageVisualAttrs(img: HTMLImageElement, v: ImageVisualAttrs
   const fh = 1 / remainingH;
   img.style.width = `${fw * 100}%`;
   img.style.height = `${fh * 100}%`;
+  // Cropping deliberately enlarges the bitmap beyond its visible frame.
+  // Opt out of host image resets that cap replaced elements to their parent.
+  img.style.maxWidth = "none";
+  img.style.maxHeight = "none";
   img.style.marginLeft = `${-left * fw * 100}%`;
   const existingTransform = img.style.transform;
   if (existingTransform) {

--- a/packages/core/src/layout-painter/renderImage.ts
+++ b/packages/core/src/layout-painter/renderImage.ts
@@ -51,6 +51,10 @@ export function hasImageVisualAttrs(v: ImageVisualAttrs): boolean {
   if (v.opacity != null && v.opacity < 1) {
     return true;
   }
+  return hasImageCrop(v);
+}
+
+export function hasImageCrop(v: ImageVisualAttrs): boolean {
   return Boolean(v.cropTop || v.cropRight || v.cropBottom || v.cropLeft);
 }
 

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -47,6 +47,11 @@ import type { BorderSpec, Theme, Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { borderToStyle } from "../utils/formatToStyle";
 import { eighthsToPixels, pointsToPixels } from "../utils/units";
+import {
+  resolveAnchoredImagePosition as resolveAnchoredImagePositionShared,
+  type AnchoredImagePosition,
+  type PageGeometry,
+} from "./anchoredImagePosition";
 import type { BlockLookup } from "./index";
 import { renderFragment } from "./renderFragment";
 import { applyImageVisualAttrs, hasImageVisualAttrs, renderImageFragment } from "./renderImage";
@@ -757,88 +762,8 @@ export { emuToPixels, isFloatingImageRun } from "./renderUtils";
  * (eigenpal docx-editor) `PageGeometry` shape introduced in #424 so the
  * anchor math stays identical across the two codebases.
  */
-export type PageGeometry = {
-  pageWidth: number;
-  pageHeight: number;
-  marginLeft: number;
-  marginTop: number;
-  marginRight: number;
-  marginBottom: number;
-  contentWidth: number;
-  contentHeight: number;
-};
-
-/**
- * Resolved on-page coordinates for an anchored floating image.
- * `x` / `y` are in content-area-relative pixels (content origin = (0, 0)).
- * `side` feeds the text-wrap exclusion zone helper.
- */
-export type AnchoredImagePosition = {
-  x: number;
-  y: number;
-  side: "left" | "right";
-};
-
-// eigenpal #424 (positionV/H align): ECMA-376 §20.4.3.2 (ST_RelFromH).
-// Maps the OOXML relativeFrom enum onto the painter's content-relative band.
-// `baseX` is the band origin; `bandWidth` is the band's extent — both feed
-// the align="left|center|right" / posOffset arithmetic below. We render
-// single-sided, so `insideMargin` is treated as `leftMargin` (recto inside)
-// and `outsideMargin` as `rightMargin` (recto outside).
-function resolveHorizontalBand(
-  relativeTo: string | undefined,
-  geometry: PageGeometry,
-): { baseX: number; bandWidth: number } {
-  switch (relativeTo) {
-    case "page":
-      return { baseX: -geometry.marginLeft, bandWidth: geometry.pageWidth };
-    case "leftMargin":
-    case "insideMargin":
-      return { baseX: -geometry.marginLeft, bandWidth: geometry.marginLeft };
-    case "rightMargin":
-    case "outsideMargin":
-      return { baseX: geometry.contentWidth, bandWidth: geometry.marginRight };
-    case "character":
-      // `character` would need the originating run's x-position; we don't
-      // thread that through the bridge yet. Anchor at the content origin.
-      return { baseX: 0, bandWidth: 0 };
-    default:
-      // `column`, `margin`, and unknown values resolve to the content band.
-      return { baseX: 0, bandWidth: geometry.contentWidth };
-  }
-}
-
-// eigenpal #424 (positionV/H align): ECMA-376 §20.4.3.1 (ST_RelFromV).
-// Symmetric with the horizontal helper. `topMargin` is the strip above
-// the content area; `bottomMargin` is below it; `paragraph` / `line` fall
-// back to the running paragraph anchor (no band). The resolver above
-// uses `relativeTo` (not `bandHeight`) to detect the no-band case so a
-// legitimately zero-sized margin still aligns correctly.
-function resolveVerticalBand(
-  relativeTo: string | undefined,
-  fragmentY: number,
-  geometry: PageGeometry,
-): { baseY: number; bandHeight: number } {
-  switch (relativeTo) {
-    case "page":
-      return { baseY: -geometry.marginTop, bandHeight: geometry.pageHeight };
-    case "topMargin":
-      return { baseY: -geometry.marginTop, bandHeight: geometry.marginTop };
-    case "bottomMargin":
-      return {
-        baseY: geometry.contentHeight,
-        bandHeight: geometry.marginBottom,
-      };
-    case "paragraph":
-    case "line":
-      return { baseY: fragmentY, bandHeight: 0 };
-    default:
-      // `margin`, `insideMargin`, `outsideMargin`, and unknown values all
-      // resolve to the content band; vertical `*Margin` variants degenerate
-      // to `margin` in a single-sided render.
-      return { baseY: 0, bandHeight: geometry.contentHeight };
-  }
-}
+export type { PageGeometry } from "./anchoredImagePosition";
+export type { AnchoredImagePosition } from "./anchoredImagePosition";
 
 /**
  * Resolve the on-page coordinates of an anchored floating image.
@@ -859,77 +784,7 @@ export function resolveAnchoredImagePosition(
   fragmentY: number,
   geometry: PageGeometry,
 ): AnchoredImagePosition {
-  const position = imgRun.position;
-  const contentWidth = geometry.contentWidth;
-
-  let side: "left" | "right" = "left";
-  let x = 0;
-
-  if (position?.horizontal) {
-    const h = position.horizontal;
-    const { baseX, bandWidth } = resolveHorizontalBand(h.relativeTo, geometry);
-    // `character` is the only horizontal anchor that intentionally carries
-    // no band (we don't yet thread the originating run's x); for every
-    // other relativeFrom variant the band is real and `bandWidth === 0`
-    // means the page legitimately has a zero-width strip (e.g. mirrored
-    // margins on a no-margin layout), which should still be honoured.
-    const horizontalHasBand = h.relativeTo !== "character";
-
-    if (h.align === "right" || h.align === "outside") {
-      // `outside` is the facing-page mirror of `right`. Without facing-page
-      // context we treat it as the right edge of the band, matching Word's
-      // single-sided render.
-      side = "right";
-      x = horizontalHasBand ? baseX + bandWidth - imgRun.width : 0;
-    } else if (h.align === "left" || h.align === "inside") {
-      side = "left";
-      x = baseX;
-    } else if (h.align === "center") {
-      side = "left";
-      x = horizontalHasBand ? baseX + (bandWidth - imgRun.width) / 2 : 0;
-    } else if (h.posOffset !== undefined) {
-      x = baseX + emuToPixels(h.posOffset);
-      side = x > contentWidth / 2 ? "right" : "left";
-    } else {
-      // Bare positionH (no align, no offset) — anchor at the band origin.
-      x = baseX;
-    }
-  } else if (imgRun.cssFloat === "right") {
-    side = "right";
-    x = contentWidth - imgRun.width;
-  }
-
-  let y: number;
-
-  if (position?.vertical) {
-    const v = position.vertical;
-    const { baseY, bandHeight } = resolveVerticalBand(v.relativeTo, fragmentY, geometry);
-    // paragraph/line are the only vertical anchors without a band — they
-    // ride the running paragraph's y, so align/center against a non-existent
-    // band must defer to `fragmentY`. Every other relativeFrom variant has
-    // a real band, so `bandHeight === 0` (e.g. zero top/bottom margin)
-    // should still resolve via the band-relative math instead of falling
-    // back to `fragmentY`.
-    const verticalHasBand = v.relativeTo !== "paragraph" && v.relativeTo !== "line";
-
-    if (v.align === "top" || v.align === "inside") {
-      y = baseY;
-    } else if (v.align === "center") {
-      y = verticalHasBand ? baseY + (bandHeight - imgRun.height) / 2 : fragmentY;
-    } else if (v.align === "bottom" || v.align === "outside") {
-      y = verticalHasBand ? baseY + bandHeight - imgRun.height : fragmentY;
-    } else if (v.posOffset !== undefined) {
-      y = baseY + emuToPixels(v.posOffset);
-    } else {
-      // Bare positionV — for paragraph/line bands the image stays in flow;
-      // for any other band, the spec means "anchor at the band origin".
-      y = verticalHasBand ? baseY : fragmentY;
-    }
-  } else {
-    y = fragmentY;
-  }
-
-  return { x, y, side };
+  return resolveAnchoredImagePositionShared(imgRun, fragmentY, geometry);
 }
 
 /**
@@ -2031,7 +1886,7 @@ export function renderPage(
           blockData.block as TableBlock,
           blockData.measure as TableMeasure,
           fragmentContext,
-          { document: doc },
+          { document: doc, pageGeometry },
         );
         prevParagraphBorders = undefined;
       } else if (

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -35,7 +35,9 @@ import {
   tableColumnsArePinned,
 } from "../layout-engine/types";
 import { emuToPixels } from "../utils/units";
+import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
 import { getAutomaticTextColorForBackground } from "./documentColors";
+import { applyImageVisualAttrs, hasImageVisualAttrs } from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTextBoxFragment } from "./renderTextBox";
 import type { RenderContext } from "./renderUtils";
@@ -61,6 +63,13 @@ const CELL_DIAGONAL_BORDER_CLASS = "layout-table-cell-diagonal-border";
  */
 export type RenderTableFragmentOptions = {
   document?: Document;
+  pageGeometry?: PageGeometry;
+};
+
+type PageContentPosition = {
+  geometry: PageGeometry;
+  x: number;
+  y: number;
 };
 
 /**
@@ -77,6 +86,7 @@ type RenderCellContentOptions = {
   context: RenderContext;
   doc: Document;
   contentWidthOverride?: number;
+  pageContentPosition?: PageContentPosition;
 };
 
 type CellContentClip = {
@@ -90,6 +100,7 @@ function renderCellContent({
   context,
   doc,
   contentWidthOverride,
+  pageContentPosition,
 }: RenderCellContentOptions): RenderedCellContent {
   const contentEl = doc.createElement("div");
   contentEl.className = TABLE_CLASS_NAMES.cellContent;
@@ -101,7 +112,25 @@ function renderCellContent({
   contentEl.style.width = `${contentWidth}px`;
 
   // Extract floating images from cell paragraphs
-  const cellFloatingImages = getTableCellFloatingImages(cell, cellMeasure, contentWidth);
+  const cellFloatingImages = getTableCellFloatingImages(
+    cell,
+    cellMeasure,
+    contentWidth,
+    pageContentPosition
+      ? (run, paragraphY) => {
+          const position = resolveAnchoredImagePosition(
+            run,
+            pageContentPosition.y + paragraphY,
+            pageContentPosition.geometry,
+          );
+          return {
+            x: position.x - pageContentPosition.x,
+            y: position.y - pageContentPosition.y,
+            side: position.side,
+          };
+        }
+      : undefined,
+  );
 
   // Build floating zones for measurement and render floating layer
   const floatingZones = buildTableCellFloatingZones(cellFloatingImages, contentWidth);
@@ -138,11 +167,19 @@ function renderCellContent({
       imgEl.style.width = `${img.width}px`;
       imgEl.style.height = `${img.height}px`;
       imgEl.style.display = "block";
+      imgEl.style.maxWidth = "none";
+      imgEl.style.maxHeight = "none";
       if (img.alt) {
         imgEl.alt = img.alt;
       }
       if (img.transform) {
         imgEl.style.transform = img.transform;
+      }
+      if (hasImageVisualAttrs(img)) {
+        imgContainer.style.width = `${img.width}px`;
+        imgContainer.style.height = `${img.height}px`;
+        imgContainer.style.overflow = "hidden";
+        applyImageVisualAttrs(imgEl, img);
       }
       imgContainer.append(imgEl);
       floatingLayer.append(imgContainer);
@@ -514,6 +551,7 @@ type RenderTableCellOptions = {
   context: RenderContext;
   doc: Document;
   contentClip?: CellContentClip;
+  pageContentPosition?: PageContentPosition;
 };
 
 function renderTableCell({
@@ -526,6 +564,7 @@ function renderTableCell({
   context,
   doc,
   contentClip,
+  pageContentPosition,
 }: RenderTableCellOptions): HTMLElement {
   const cellEl = doc.createElement("div");
   cellEl.className = TABLE_CLASS_NAMES.cell;
@@ -614,6 +653,15 @@ function renderTableCell({
     context,
     doc,
     ...(contentWidthOverride !== undefined ? { contentWidthOverride } : {}),
+    ...(pageContentPosition
+      ? {
+          pageContentPosition: {
+            geometry: pageContentPosition.geometry,
+            x: pageContentPosition.x + padLeft,
+            y: pageContentPosition.y + padTop,
+          },
+        }
+      : {}),
   });
   if (cell.textDirection === "btLr") {
     renderedContent.content.style.position = "absolute";
@@ -748,6 +796,7 @@ type RenderTableRowOptions = {
   columnsPinned?: boolean;
   cellGrid?: TableCellGrid;
   contentClip?: CellContentClip;
+  pageContentPosition?: PageContentPosition;
 };
 
 function renderTableRow({
@@ -766,6 +815,7 @@ function renderTableRow({
   columnsPinned = false,
   cellGrid,
   contentClip,
+  pageContentPosition,
 }: RenderTableRowOptions): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
@@ -865,6 +915,15 @@ function renderTableRow({
       context,
       doc,
       ...(contentClip ? { contentClip } : {}),
+      ...(pageContentPosition
+        ? {
+            pageContentPosition: {
+              geometry: pageContentPosition.geometry,
+              x: pageContentPosition.x + cellLeft,
+              y: pageContentPosition.y,
+            },
+          }
+        : {}),
     });
     cellEl.dataset["cellIndex"] = String(cellIndex);
     cellEl.dataset["columnIndex"] = String(columnIndex);
@@ -925,6 +984,13 @@ export function renderTableFragment(
   options: RenderTableFragmentOptions = {},
 ): HTMLElement {
   const doc = options.document ?? document;
+  const tablePageContentPosition = options.pageGeometry
+    ? {
+        geometry: options.pageGeometry,
+        x: fragment.x - options.pageGeometry.marginLeft,
+        y: fragment.y - options.pageGeometry.marginTop,
+      }
+    : undefined;
 
   const tableEl = doc.createElement("div");
   tableEl.className = TABLE_CLASS_NAMES.table;
@@ -1025,6 +1091,14 @@ export function renderTableFragment(
         bidi: block.bidi === true,
         columnsPinned,
         cellGrid,
+        ...(tablePageContentPosition
+          ? {
+              pageContentPosition: {
+                ...tablePageContentPosition,
+                y: tablePageContentPosition.y + y,
+              },
+            }
+          : {}),
       });
       rowEl.dataset["repeatedHeader"] = "true";
       tableEl.append(rowEl);
@@ -1093,6 +1167,14 @@ export function renderTableFragment(
       columnsPinned,
       cellGrid,
       ...(contentClip ? { contentClip } : {}),
+      ...(tablePageContentPosition
+        ? {
+            pageContentPosition: {
+              ...tablePageContentPosition,
+              y: tablePageContentPosition.y + y,
+            },
+          }
+        : {}),
     });
 
     contentParent.append(rowEl);

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -37,7 +37,7 @@ import {
 import { emuToPixels } from "../utils/units";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
 import { getAutomaticTextColorForBackground } from "./documentColors";
-import { applyImageVisualAttrs, hasImageVisualAttrs } from "./renderImage";
+import { applyImageVisualAttrs, hasImageCrop, hasImageVisualAttrs } from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTextBoxFragment } from "./renderTextBox";
 import type { RenderContext } from "./renderUtils";
@@ -176,9 +176,11 @@ function renderCellContent({
         imgEl.style.transform = img.transform;
       }
       if (hasImageVisualAttrs(img)) {
-        imgContainer.style.width = `${img.width}px`;
-        imgContainer.style.height = `${img.height}px`;
-        imgContainer.style.overflow = "hidden";
+        if (hasImageCrop(img)) {
+          imgContainer.style.width = `${img.width}px`;
+          imgContainer.style.height = `${img.height}px`;
+          imgContainer.style.overflow = "hidden";
+        }
         applyImageVisualAttrs(imgEl, img);
       }
       imgContainer.append(imgEl);

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -927,4 +927,23 @@ describe("renderTableFragment cell floating images", () => {
     expect(image?.style["opacity"]).toBe("0.6");
     expect(image?.style["objectFit"]).toBe("fill");
   });
+
+  test("does not clip an uncropped image that only has opacity", () => {
+    const table = renderFloatingImage({
+      kind: "image",
+      src: "transparent.png",
+      width: 120,
+      height: 40,
+      displayMode: "float",
+      wrapType: "inFront",
+      opacity: 0.6,
+      transform: "rotate(10deg)",
+    });
+
+    const container = findByClass(table, "layout-cell-floating-image").at(0);
+    const image = container?.children.at(0);
+    expect(container?.style["overflow"]).toBeUndefined();
+    expect(container?.style["width"]).toBeUndefined();
+    expect(image?.style["opacity"]).toBe("0.6");
+  });
 });

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { withFakeTextMeasure } from "../layout-engine/measure/__tests__/fakeTextMeasure";
-import type { TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
+import type { ImageRun, TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
+import type { PageGeometry } from "./anchoredImagePosition";
 import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
 import type { RenderContext } from "./renderUtils";
 
@@ -59,6 +60,17 @@ const renderContext: RenderContext = {
   pageNumber: 1,
   totalPages: 1,
   section: "body",
+};
+
+const pageGeometry: PageGeometry = {
+  pageWidth: 816,
+  pageHeight: 1056,
+  marginLeft: 96,
+  marginTop: 96,
+  marginRight: 96,
+  marginBottom: 96,
+  contentWidth: 624,
+  contentHeight: 864,
 };
 
 function findRows(element: FakeElement): FakeElement[] {
@@ -805,5 +817,114 @@ describe("renderTableFragment floating cell content", () => {
     expect(textBoxLayer?.style["top"]).toBe("2px");
     expect(textBox?.style["left"]).toBe("20px");
     expect(Number.parseFloat(textBox?.style["top"] ?? "0")).toBeGreaterThan(50);
+  });
+});
+
+describe("renderTableFragment cell floating images", () => {
+  const renderFloatingImage = (
+    image: ImageRun,
+    options: { pageGeometry?: PageGeometry } = {},
+  ): FakeElement => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              padding: { top: 10, right: 10, bottom: 10, left: 10 },
+              blocks: [{ kind: "paragraph", id: "anchor", runs: [image] }],
+            },
+          ],
+        },
+      ],
+      columnWidths: [220],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [{ kind: "paragraph", lines: [], totalHeight: 40 }],
+              width: 220,
+              height: 80,
+            },
+          ],
+          height: 80,
+        },
+      ],
+      columnWidths: [220],
+      totalWidth: 220,
+      totalHeight: 80,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "table",
+      x: 196,
+      y: 196,
+      width: 220,
+      height: 80,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    let rendered = new FakeElement("div");
+    withFakeTextMeasure(() => {
+      rendered = renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+        ...options,
+      }) as unknown as FakeElement;
+    });
+    return rendered;
+  };
+
+  test("resolves negative margin-relative offsets against page geometry", () => {
+    const table = renderFloatingImage(
+      {
+        kind: "image",
+        src: "floating.png",
+        width: 80,
+        height: 30,
+        displayMode: "float",
+        wrapType: "inFront",
+        position: {
+          horizontal: { relativeTo: "margin", posOffset: -457_200 },
+          vertical: { relativeTo: "paragraph", posOffset: 0 },
+        },
+      },
+      { pageGeometry },
+    );
+
+    const image = findByClass(table, "layout-cell-floating-image").at(0);
+    // The cell content starts 110px into the content area. The authored
+    // margin-relative offset is -48px, so the cell-local result is -158px.
+    expect(image?.style["left"]).toBe("-158px");
+    expect(image?.style["top"]).toBe("0px");
+  });
+
+  test("applies crop and opacity attributes in the cell floating layer", () => {
+    const table = renderFloatingImage({
+      kind: "image",
+      src: "cropped.png",
+      width: 120,
+      height: 40,
+      displayMode: "float",
+      wrapType: "inFront",
+      cropLeft: 0.2,
+      cropRight: 0.1,
+      opacity: 0.6,
+    });
+
+    const container = findByClass(table, "layout-cell-floating-image").at(0);
+    const image = container?.children.at(0);
+    expect(container?.style["width"]).toBe("120px");
+    expect(container?.style["height"]).toBe("40px");
+    expect(container?.style["overflow"]).toBe("hidden");
+    expect(Number.parseFloat(image?.style["width"] ?? "")).toBeCloseTo((1 / 0.7) * 100, 6);
+    expect(image?.style["opacity"]).toBe("0.6");
+    expect(image?.style["objectFit"]).toBe("fill");
   });
 });


### PR DESCRIPTION
## Summary

- share anchored-image position geometry with table-cell floating images
- preserve crop, opacity, and explicit bitmap sizing in the table floating layer
- cover negative page-relative offsets and cropped-image scaling with focused regressions

CC on behalf of @jan-kubica