### PR TITLE
fix: resolve inherited tab stops by position

### DIFF
--- a/.changeset/calm-tab-stops.md
+++ b/.changeset/calm-tab-stops.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve inherited and hanging-indent tab stops by their authored positions.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -167,6 +167,48 @@ describe("toProseDoc", () => {
     expect(doc.firstChild?.attrs.hangingIndent).toBe(false);
   });
 
+  test("direct tab clear retains inherited stops at other positions", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                styleId: "Footer",
+                tabs: [{ position: 4536, alignment: "clear" }],
+              },
+              content: [],
+            },
+          ],
+        },
+        styles: {
+          styles: [
+            {
+              styleId: "Footer",
+              type: "paragraph",
+              pPr: {
+                tabs: [
+                  { position: 1701, alignment: "left" },
+                  { position: 4536, alignment: "center" },
+                  { position: 9072, alignment: "right" },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+
+    expect(doc.firstChild?.attrs.tabs).toEqual([
+      { position: 1701, alignment: "left" },
+      { position: 4536, alignment: "clear" },
+      { position: 9072, alignment: "right" },
+    ]);
+  });
+
   test("applies paragraph-mark defaults to otherwise unformatted visible text", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -48,7 +48,10 @@ import type {
   Theme,
 } from "../../types/document";
 import { resolveColor } from "../../utils/colorResolver";
-import { mergeParagraphFormatting } from "../../utils/paragraphFormattingMerge";
+import {
+  mergeParagraphFormatting,
+  mergeParagraphTabStops,
+} from "../../utils/paragraphFormattingMerge";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
 import { setAutospacingBaseValue } from "../autospacingBase";
@@ -625,7 +628,7 @@ function paragraphFormattingToAttrs(
     set("hangingIndent", effectiveIndent?.hangingIndent);
     set("borders", formatting?.borders ?? stylePpr?.borders);
     set("shading", formatting?.shading ?? stylePpr?.shading);
-    set("tabs", formatting?.tabs ?? stylePpr?.tabs);
+    set("tabs", mergeParagraphTabStops(stylePpr?.tabs, formatting?.tabs));
     set("kinsoku", formatting?.kinsoku ?? stylePpr?.kinsoku);
     set("overflowPunctuation", formatting?.overflowPunctuation ?? stylePpr?.overflowPunctuation);
     set("suppressAutoHyphens", formatting?.suppressAutoHyphens ?? stylePpr?.suppressAutoHyphens);

--- a/packages/core/src/prosemirror/utils/tabCalculator.test.ts
+++ b/packages/core/src/prosemirror/utils/tabCalculator.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  type TabContext,
   twipsToPixels,
   pixelsToTwips,
   computeTabStops,
@@ -77,7 +78,7 @@ describe("computeTabStops", () => {
     expect(stops[0].pos).not.toBe(720);
   });
 
-  it("filters stops before left indent", () => {
+  it("keeps explicit stops before a hanging indent", () => {
     const stops = computeTabStops({
       explicitStops: [
         { val: "start", pos: 100 }, // Before indent
@@ -86,9 +87,10 @@ describe("computeTabStops", () => {
       leftIndent: 500,
     });
 
-    // The stop at 100 should be filtered out
+    // A hanging first line may start before the paragraph's left indent and
+    // must still be able to advance through this authored stop.
     const stop100 = stops.find((s) => s.pos === 100);
-    expect(stop100).toBeUndefined();
+    expect(stop100).toBeDefined();
 
     // The stop at 1000 should remain
     const stop1000 = stops.find((s) => s.pos === 1000);
@@ -101,18 +103,28 @@ describe("computeTabStops", () => {
       leftIndent: 1134,
     });
 
-    expect(
-      stops
-        .filter((stop) => stop.pos >= 1134)
-        .slice(0, 3)
-        .map((stop) => stop.pos),
-    ).toEqual([1134, 1440, 2160]);
+    expect(stops.slice(0, 3).map((stop) => stop.pos)).toEqual([567, 1440, 2160]);
     expect(
       calculateTabWidth(twipsToPixels(1573), {
         explicitStops: [{ val: "start", pos: 567 }],
         leftIndent: 1134,
       }).width,
     ).toBeCloseTo(twipsToPixels(2160 - 1573), 5);
+  });
+
+  it("advances consecutive hanging-line tabs through a pre-indent stop", () => {
+    const context = {
+      explicitStops: [{ val: "start", pos: 1701 }],
+      defaultTabInterval: 709,
+      leftIndent: 2124,
+    } satisfies TabContext;
+    const firstCursor = twipsToPixels(600);
+    const first = calculateTabWidth(firstCursor, context);
+    const secondCursor = firstCursor + first.width;
+    const second = calculateTabWidth(secondCursor, context);
+
+    expect(pixelsToTwips(secondCursor)).toBeCloseTo(1701, 5);
+    expect(pixelsToTwips(secondCursor + second.width)).toBeCloseTo(2127, 5);
   });
 
   it("returns stops sorted by position", () => {

--- a/packages/core/src/prosemirror/utils/tabCalculator.ts
+++ b/packages/core/src/prosemirror/utils/tabCalculator.ts
@@ -91,7 +91,9 @@ export function pixelsToTwips(pixels: number): number {
  * Compute the list of effective tab stops for a paragraph
  *
  * Merges explicit stops with default stops at regular intervals.
- * Filters out stops that fall before the left indent.
+ * Explicit stops before the left indent remain available to a hanging first
+ * line. Continuation lines naturally skip them because their cursor already
+ * starts at the left indent.
  *
  * @param context - Tab context with explicit stops and settings
  * @returns Sorted array of tab stops in twips
@@ -103,10 +105,9 @@ export function computeTabStops(context: TabContext): TabStop[] {
     leftIndent = 0,
   } = context;
 
-  // Filter out clear stops and those before left indent
-  const validExplicitStops = explicitStops
-    .filter((stop) => stop.val !== "clear")
-    .filter((stop) => stop.pos >= leftIndent);
+  // Clear stops suppress matching inherited/default positions but are not
+  // themselves destinations.
+  const validExplicitStops = explicitStops.filter((stop) => stop.val !== "clear");
 
   // Track cleared positions
   const clearPositions = explicitStops
@@ -125,22 +126,24 @@ export function computeTabStops(context: TabContext): TabStop[] {
   // For hanging indent paragraphs (where leftIndent > 0 and no explicit stops before it),
   // add the leftIndent position as an implicit tab stop.
   // This is standard Word behavior: tabs jump to the left margin for alignment.
-  if (leftIndent > 0 && !validExplicitStops.some((s) => s.pos <= leftIndent)) {
-    const hasLeftIndentClear = clearPositions.some((p) => Math.abs(p - leftIndent) < 20);
-    if (!hasLeftIndentClear) {
-      stops.push({
-        val: "start",
-        pos: leftIndent,
-        leader: "none",
-      });
-    }
+  const hasLeftIndentClear = clearPositions.some((p) => Math.abs(p - leftIndent) < 20);
+  const addsImplicitLeftIndent =
+    leftIndent > 0 &&
+    !hasLeftIndentClear &&
+    !validExplicitStops.some((stop) => stop.pos <= leftIndent);
+  if (addsImplicitLeftIndent) {
+    stops.push({
+      val: "start",
+      pos: leftIndent,
+      leader: "none",
+    });
   }
 
   // Generate default stops on the document-wide grid measured from the text
-  // area's left edge. An indent filters earlier stops, but must not shift the
-  // grid itself: a 1,134-twip indent still advances through 1,440, 2,160, ...,
-  // not 1,854, 2,574, ... . Start at the grid line at or before the rightmost
-  // explicit stop / indent; the loop advances to the first candidate after it.
+  // area's left edge. An indent must not shift the grid itself: a 1,134-twip
+  // indent still advances through 1,440, 2,160, ..., not 1,854, 2,574, ... .
+  // Start at the grid line at or before the rightmost explicit stop / indent;
+  // the loop advances to the next grid position.
   const searchStart = Math.max(maxExplicit, leftIndent);
   let pos = Math.floor(searchStart / defaultTabInterval) * defaultTabInterval;
   const limitPos = leftIndent + 14_400; // 14400 twips = 10 inches
@@ -164,8 +167,8 @@ export function computeTabStops(context: TabContext): TabStop[] {
         break;
       }
     }
-    // Skip if at leftIndent (already added above)
-    const isAtLeftIndent = leftIndent > 0 && Math.abs(pos - leftIndent) < 20;
+    // Skip if at leftIndent only when the implicit stop was added above.
+    const isAtLeftIndent = addsImplicitLeftIndent && Math.abs(pos - leftIndent) < 20;
 
     if (!hasExplicitStop && !hasClearStop && !isAtLeftIndent) {
       stops.push({

--- a/packages/core/src/utils/paragraphFormattingMerge.test.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.test.ts
@@ -50,7 +50,7 @@ describe("mergeParagraphFormatting", () => {
     expect(result?.hangingIndent).toBe(false);
   });
 
-  test("replaces tab collections and merges paragraph mark run properties", () => {
+  test("merges tab stops by position and merges paragraph mark run properties", () => {
     const sourceTabs: NonNullable<ParagraphFormatting["tabs"]> = [
       { position: 720, alignment: "left" },
     ];
@@ -68,11 +68,36 @@ describe("mergeParagraphFormatting", () => {
       },
     );
 
-    expect(result?.tabs).toEqual(sourceTabs);
+    expect(result?.tabs).toEqual([
+      { position: 360, alignment: "center" },
+      { position: 720, alignment: "left" },
+    ]);
     expect(result?.tabs).not.toBe(sourceTabs);
     expect(result?.runProperties?.underline).toEqual({
       style: "double",
       color: { rgb: "FF0000" },
     });
+  });
+
+  test("retains inherited stops while direct clear removes one position", () => {
+    const inherited = mergeParagraphFormatting(
+      { tabs: [{ position: 1701, alignment: "left" }] },
+      {
+        tabs: [
+          { position: 4536, alignment: "center" },
+          { position: 9072, alignment: "right" },
+        ],
+      },
+    );
+
+    const resolved = mergeParagraphFormatting(inherited, {
+      tabs: [{ position: 4536, alignment: "clear" }],
+    });
+
+    expect(resolved?.tabs).toEqual([
+      { position: 1701, alignment: "left" },
+      { position: 4536, alignment: "clear" },
+      { position: 9072, alignment: "right" },
+    ]);
   });
 });

--- a/packages/core/src/utils/paragraphFormattingMerge.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.ts
@@ -54,6 +54,14 @@ const copyDefinedParagraphProperty = <K extends ParagraphReplaceKey>(
  */
 export function mergeParagraphTabStops(
   inherited: TabStop[] | undefined,
+  direct: TabStop[],
+): TabStop[];
+export function mergeParagraphTabStops(
+  inherited: TabStop[] | undefined,
+  direct: TabStop[] | undefined,
+): TabStop[] | undefined;
+export function mergeParagraphTabStops(
+  inherited: TabStop[] | undefined,
   direct: TabStop[] | undefined,
 ): TabStop[] | undefined {
   if (direct === undefined) {

--- a/packages/core/src/utils/paragraphFormattingMerge.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.ts
@@ -1,4 +1,4 @@
-import type { ParagraphFormatting } from "../types/document";
+import type { ParagraphFormatting, TabStop } from "../types/document";
 import { mergeTextFormatting } from "./textFormattingMerge";
 
 const PARAGRAPH_REPLACE_KEYS = [
@@ -44,12 +44,40 @@ const copyDefinedParagraphProperty = <K extends ParagraphReplaceKey>(
 };
 
 /**
+ * Merge custom tab stops across OOXML paragraph-property layers.
+ *
+ * Tabs cascade by position rather than replacing the inherited collection:
+ * a higher-priority stop supersedes the stop at the same position, while a
+ * `clear` stop removes that inherited position during layout. Keeping the
+ * clear entry also lets the tab calculator suppress an automatic stop at the
+ * same position.
+ */
+export function mergeParagraphTabStops(
+  inherited: TabStop[] | undefined,
+  direct: TabStop[] | undefined,
+): TabStop[] | undefined {
+  if (direct === undefined) {
+    return inherited === undefined ? undefined : [...inherited];
+  }
+
+  const stopsByPosition = new Map<number, TabStop>();
+  for (const stop of inherited ?? []) {
+    stopsByPosition.set(stop.position, stop);
+  }
+  for (const stop of direct) {
+    stopsByPosition.set(stop.position, stop);
+  }
+
+  return [...stopsByPosition.values()].toSorted((a, b) => a.position - b.position);
+}
+
+/**
  * Merge paragraph properties for OOXML style cascade resolution.
  *
  * The source is the higher-priority layer. Most `w:pPr` properties replace an
  * inherited value when present; nested child containers merge by child field;
- * tabs replace as a complete ordered collection; paragraph mark `w:rPr` uses
- * the run-formatting merge rules.
+ * tabs merge by position; paragraph mark `w:rPr` uses the run-formatting
+ * merge rules.
  */
 export function mergeParagraphFormatting(
   target: ParagraphFormatting | undefined,
@@ -91,7 +119,7 @@ export function mergeParagraphFormatting(
     result.frame = { ...result.frame, ...source.frame };
   }
   if (source.tabs !== undefined) {
-    result.tabs = [...source.tabs];
+    result.tabs = mergeParagraphTabStops(result.tabs, source.tabs);
   }
 
   return result;


### PR DESCRIPTION
Merge custom paragraph tab stops by their authored positions, including direct clear entries, and keep pre-indent stops reachable from hanging first lines. This preserves inherited stops that remain active while aligning consecutive tabs with the document-wide grid.

CC on behalf of @jan-kubica