### PR TITLE
fix: align table cell paragraph flow

### DIFF
--- a/.changeset/tidy-cell-flow.md
+++ b/.changeset/tidy-cell-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align table cell measurement, painting, and row splitting around one paragraph-spacing flow.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -740,6 +740,44 @@ describe("measureTableBlock row height", () => {
     }, fakeMeasure);
   });
 
+  test("collapses adjacent paragraph spacing within a cell", () => {
+    withFakeTextMeasure(() => {
+      const first = para("first", "First");
+      first.attrs = { spacing: { after: 8 } };
+      const second = para("second", "Second");
+      second.attrs = { spacing: { before: 8 } };
+      const table: TableBlock = {
+        kind: "table",
+        id: "t",
+        columnWidths: [240],
+        rows: [
+          {
+            id: "row",
+            cells: [
+              {
+                id: "cell",
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                blocks: [first, second],
+              },
+            ],
+          },
+        ],
+      };
+
+      const measure = measureTableBlock(table, 240);
+      const cell = measure.rows.at(0)?.cells.at(0);
+      const firstMeasure = cell?.blocks.at(0);
+      const secondMeasure = cell?.blocks.at(1);
+      if (firstMeasure?.kind !== "paragraph" || secondMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measures");
+      }
+      const summedParagraphHeights = firstMeasure.totalHeight + secondMeasure.totalHeight;
+
+      expect(cell?.height).toBe(summedParagraphHeights - 8);
+      expect(measure.rows.at(0)?.height).toBe(cell?.height);
+    }, fakeMeasure);
+  });
+
   test("image-only table cell paragraphs use the image visual height", () => {
     withFakeTextMeasure(() => {
       const table: TableBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -1,12 +1,16 @@
 import { recordMeasureBlock, recordMeasureBlockError } from "../layoutInstrumentation";
 import { isParagraphFrameTextBox } from "../paragraphFrame";
+import {
+  createTableCellFlowState,
+  finishTableCellFlow,
+  placeTableCellBlock,
+} from "./tableCellFlow";
 import { bandFragmentX, bandTopContentY, isPageFrameRelativeAnchor } from "../textBoxFlow";
 import { getTextBoxGroupId } from "../textBoxGroup";
 import {
   DEFAULT_TEXTBOX_MARGINS,
   floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
-  isFloatingTextBoxBlock,
   tableColumnsArePinned,
 } from "../types";
 import type {
@@ -103,75 +107,6 @@ function resolveTableWidthPx(
     return Math.round((width / 20) * 1.333);
   }
   return undefined;
-}
-
-function isInlineFlowImageRun(run: ImageRun): boolean {
-  if (run.displayMode === "float") {
-    return false;
-  }
-
-  if (
-    run.wrapType === "square" ||
-    run.wrapType === "tight" ||
-    run.wrapType === "through" ||
-    run.wrapType === "behind" ||
-    run.wrapType === "inFront"
-  ) {
-    return false;
-  }
-
-  if (run.displayMode === "block" || run.wrapType === "topAndBottom") {
-    return false;
-  }
-
-  return true;
-}
-
-export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure: Measure): number {
-  if (block.kind === "textBox" && isFloatingTextBoxBlock(block)) {
-    return 0;
-  }
-
-  if (block.kind !== "paragraph" || blockMeasure.kind !== "paragraph") {
-    if ("totalHeight" in blockMeasure) {
-      return blockMeasure.totalHeight;
-    }
-    if ("height" in blockMeasure) {
-      return blockMeasure.height;
-    }
-    return 0;
-  }
-
-  const paragraphBlock = block;
-  const paragraphMeasure = blockMeasure;
-  const nonEmptyRuns = paragraphBlock.runs.filter(
-    (run) => run.kind !== "text" || run.text.replace(/\u00a0/gu, " ").trim().length > 0,
-  );
-  if (paragraphMeasure.lines.length !== 1 || nonEmptyRuns.length === 0) {
-    return paragraphMeasure.totalHeight;
-  }
-
-  const inlineImageRuns: ImageRun[] = [];
-  for (const run of nonEmptyRuns) {
-    if (run.kind !== "image" || !isInlineFlowImageRun(run)) {
-      return paragraphMeasure.totalHeight;
-    }
-    inlineImageRuns.push(run);
-  }
-
-  let maxImageHeight = 0;
-  for (const run of inlineImageRuns) {
-    maxImageHeight = Math.max(maxImageHeight, run.height);
-  }
-  if (inlineImageRuns.length === 1) {
-    const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
-    const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
-    return spacingBefore + maxImageHeight + spacingAfter;
-  }
-  const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
-  const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
-
-  return spacingBefore + maxImageHeight + spacingAfter;
 }
 
 export function measureTableBlock(
@@ -293,14 +228,16 @@ export function measureTableBlock(
       const cell = row.cells[cellIdx]!; // SAFETY: cellIdx < row.cells.length
       const sourceCell = sourceRowCells?.[cellIdx];
       cell.height = 0;
+      const flowState = createTableCellFlowState();
       for (let blockIdx = 0; blockIdx < cell.blocks.length; blockIdx++) {
         const sourceBlock = sourceCell?.blocks[blockIdx];
         const blockMeasure = cell.blocks[blockIdx];
         if (!sourceBlock || !blockMeasure) {
           continue;
         }
-        cell.height += measureTableCellBlockVisualHeight(sourceBlock, blockMeasure);
+        placeTableCellBlock(flowState, sourceBlock, blockMeasure);
       }
+      cell.height = finishTableCellFlow(flowState);
       const padTop = sourceCell?.padding?.top ?? DEFAULT_CELL_PADDING_Y;
       const padBottom = sourceCell?.padding?.bottom ?? DEFAULT_CELL_PADDING_Y;
       cell.height += padTop + padBottom;

--- a/packages/core/src/layout-engine/measure/tableCellFloating.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFloating.ts
@@ -1,4 +1,5 @@
 import { emuToPixels } from "../../utils/units";
+import { createTableCellFlowState, placeTableCellBlock } from "./tableCellFlow";
 import type { ImageRun, TableCell, TableCellMeasure } from "../types";
 import { isFloatingImageRun } from "../types";
 import { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
@@ -50,15 +51,16 @@ export function getTableCellFloatingImages(
   resolvePosition?: ResolveTableCellFloatingPosition,
 ): TableCellFloatingImage[] {
   const result: TableCellFloatingImage[] = [];
-  let paragraphY = 0;
+  const flowState = createTableCellFlowState();
 
   for (let blockIndex = 0; blockIndex < cell.blocks.length; blockIndex++) {
     const block = cell.blocks[blockIndex];
-    if (block?.kind !== "paragraph") {
-      const blockMeasure = cellMeasure.blocks[blockIndex];
-      if (blockMeasure?.kind === "table") {
-        paragraphY += blockMeasure.totalHeight;
-      }
+    const blockMeasure = cellMeasure.blocks[blockIndex];
+    if (!block || !blockMeasure) {
+      continue;
+    }
+    const placement = placeTableCellBlock(flowState, block, blockMeasure);
+    if (block.kind !== "paragraph") {
       continue;
     }
 
@@ -77,7 +79,7 @@ export function getTableCellFloatingImages(
       let x: number;
       let y: number;
       if (resolvePosition) {
-        ({ side, x, y } = resolvePosition(run, paragraphY));
+        ({ side, x, y } = resolvePosition(run, placement.contentTop));
       } else {
         side = "left";
         x = 0;
@@ -97,11 +99,11 @@ export function getTableCellFloatingImages(
           x = contentWidth - run.width;
         }
 
-        y = paragraphY;
+        y = placement.contentTop;
         if (position?.vertical) {
           const vertical = position.vertical;
           if (vertical.posOffset !== undefined) {
-            y = paragraphY + emuToPixels(vertical.posOffset);
+            y = placement.contentTop + emuToPixels(vertical.posOffset);
           } else if (vertical.align === "top") {
             y = 0;
           }
@@ -139,11 +141,6 @@ export function getTableCellFloatingImages(
         ...(run.pmStart !== undefined ? { pmStart: run.pmStart } : {}),
         ...(run.pmEnd !== undefined ? { pmEnd: run.pmEnd } : {}),
       });
-    }
-
-    const blockMeasure = cellMeasure.blocks[blockIndex];
-    if (blockMeasure?.kind === "paragraph") {
-      paragraphY += blockMeasure.totalHeight;
     }
   }
 

--- a/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+
+import { getTableCellFloatingImages } from "./tableCellFloating";
+import type {
+  ImageRun,
+  ParagraphBlock,
+  ParagraphMeasure,
+  TableCell,
+  TableCellMeasure,
+} from "../types";
+import {
+  createTableCellFlowState,
+  finishTableCellFlow,
+  placeTableCellBlock,
+} from "./tableCellFlow";
+
+const paragraph = (
+  id: string,
+  text: string,
+  spacing: { before?: number; after?: number } = {},
+): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: text.length > 0 ? [{ kind: "text", text }] : [],
+  attrs: { spacing, styleId: "CellText" },
+});
+
+const measure = (contentHeight: number, spacing = 0): ParagraphMeasure => ({
+  kind: "paragraph",
+  lines: [
+    {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 10,
+      ascent: contentHeight * 0.8,
+      descent: contentHeight * 0.2,
+      lineHeight: contentHeight,
+    },
+  ],
+  totalHeight: contentHeight + spacing,
+});
+
+const suppressedMeasure: ParagraphMeasure = {
+  kind: "paragraph",
+  lines: [
+    {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 0,
+      width: 0,
+      ascent: 0,
+      descent: 0,
+      lineHeight: 0,
+    },
+  ],
+  totalHeight: 0,
+};
+
+describe("table cell block flow", () => {
+  test("collapses adjacent paragraph spacing to the larger side", () => {
+    const state = createTableCellFlowState();
+    placeTableCellBlock(state, paragraph("first", "first", { after: 8 }), measure(10, 8));
+    const second = placeTableCellBlock(
+      state,
+      paragraph("second", "second", { before: 8 }),
+      measure(10, 8),
+    );
+
+    expect(second.top).toBe(10);
+    expect(second.leadingSpacing).toBe(8);
+    expect(finishTableCellFlow(state)).toBe(28);
+  });
+
+  test("uses collapsed paragraph placement for floating anchors", () => {
+    const image: ImageRun = {
+      kind: "image",
+      src: "floating.png",
+      width: 20,
+      height: 20,
+      displayMode: "float",
+      wrapType: "square",
+      position: { vertical: { relativeTo: "paragraph", posOffset: 0 } },
+    };
+    const cell: TableCell = {
+      id: "cell",
+      blocks: [
+        paragraph("first", "first", { after: 8 }),
+        {
+          kind: "paragraph",
+          id: "anchor",
+          runs: [image],
+          attrs: { spacing: { before: 12 } },
+        },
+      ],
+    };
+    const cellMeasure: TableCellMeasure = {
+      blocks: [measure(10, 8), measure(10, 12)],
+      width: 100,
+      height: 32,
+    };
+    let resolvedAnchor = 0;
+
+    const images = getTableCellFloatingImages(cell, cellMeasure, 100, (_run, paragraphY) => {
+      resolvedAnchor = paragraphY;
+      return { side: "left", x: 0, y: paragraphY };
+    });
+
+    expect(resolvedAnchor).toBe(22);
+    expect(images.at(0)?.y).toBe(22);
+  });
+
+  test("keeps consecutive authored empty paragraphs as independent spacers", () => {
+    const state = createTableCellFlowState();
+    placeTableCellBlock(state, paragraph("body", "body", { after: 8 }), measure(10, 8));
+    placeTableCellBlock(state, paragraph("blank-1", "", { before: 8, after: 8 }), measure(10, 16));
+    const secondBlank = placeTableCellBlock(
+      state,
+      paragraph("blank-2", "", { before: 8, after: 8 }),
+      measure(10, 16),
+    );
+
+    expect(secondBlank.leadingSpacing).toBe(16);
+    expect(finishTableCellFlow(state)).toBe(62);
+  });
+
+  test("includes final authored paragraph spacing in the cell height", () => {
+    const state = createTableCellFlowState();
+    placeTableCellBlock(state, paragraph("body", "body", { after: 8 }), measure(10, 8));
+
+    expect(state.height).toBe(10);
+    expect(finishTableCellFlow(state)).toBe(18);
+  });
+
+  test("keeps a suppressed empty paragraph at zero height", () => {
+    const state = createTableCellFlowState();
+    const block = paragraph("marker", "", { before: 8, after: 8 });
+    block.attrs = { ...block.attrs, suppressEmptyParagraphHeight: true };
+
+    expect(placeTableCellBlock(state, block, suppressedMeasure).leadingSpacing).toBe(0);
+    expect(finishTableCellFlow(state)).toBe(0);
+  });
+
+  test("collapses surrounding spacing across a suppressed empty paragraph", () => {
+    const state = createTableCellFlowState();
+    placeTableCellBlock(state, paragraph("first", "first", { after: 8 }), measure(10, 8));
+    const marker = paragraph("marker", "", { before: 8, after: 8 });
+    marker.attrs = { ...marker.attrs, suppressEmptyParagraphHeight: true };
+    const markerPlacement = placeTableCellBlock(state, marker, suppressedMeasure);
+    const third = placeTableCellBlock(
+      state,
+      paragraph("third", "third", { before: 8 }),
+      measure(10, 8),
+    );
+
+    expect(markerPlacement).toEqual({
+      top: 10,
+      contentTop: 10,
+      contentHeight: 0,
+      leadingSpacing: 0,
+    });
+    expect(third.leadingSpacing).toBe(8);
+    expect(finishTableCellFlow(state)).toBe(28);
+  });
+});

--- a/packages/core/src/layout-engine/measure/tableCellFlow.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.ts
@@ -1,0 +1,105 @@
+import { measuredLineRangeHeight } from "../lineFlow";
+import {
+  getParagraphSpacingAfter,
+  getParagraphSpacingBefore,
+  isEmptyParagraph,
+} from "../paragraphSpacing";
+import type { FlowBlock, Measure, ParagraphBlock, ParagraphMeasure } from "../types";
+import { isFloatingTextBoxBlock } from "../types";
+
+export type TableCellBlockPlacement = {
+  top: number;
+  contentTop: number;
+  contentHeight: number;
+  leadingSpacing: number;
+};
+
+export type TableCellFlowState = {
+  height: number;
+  previousParagraphWasEmpty: boolean;
+  trailingSpacing: number;
+};
+
+export const createTableCellFlowState = (): TableCellFlowState => ({
+  height: 0,
+  previousParagraphWasEmpty: false,
+  trailingSpacing: 0,
+});
+
+export const finishTableCellFlow = (state: TableCellFlowState): number =>
+  state.height + state.trailingSpacing;
+
+const isSuppressedParagraphMeasure = (measure: ParagraphMeasure): boolean =>
+  measure.totalHeight === 0 && measure.lines.every(({ lineHeight }) => lineHeight === 0);
+
+const paragraphSpacing = (
+  block: ParagraphBlock,
+  measure: ParagraphMeasure,
+): { before: number; after: number } => {
+  if (isSuppressedParagraphMeasure(measure)) {
+    return { before: 0, after: 0 };
+  }
+  return {
+    before: getParagraphSpacingBefore(block),
+    after: getParagraphSpacingAfter(block),
+  };
+};
+
+export const getTableCellBlockContentHeight = (block: FlowBlock, measure: Measure): number => {
+  if (block.kind === "textBox" && isFloatingTextBoxBlock(block)) {
+    return 0;
+  }
+  if (block.kind === "paragraph" && measure.kind === "paragraph") {
+    return measuredLineRangeHeight(measure.lines, 0, measure.lines.length);
+  }
+  if ("totalHeight" in measure) {
+    return measure.totalHeight;
+  }
+  if ("height" in measure) {
+    return measure.height;
+  }
+  return 0;
+};
+
+/**
+ * Place one block in an unpaginated table-cell story.
+ *
+ * Adjacent paragraph spacing collapses to the larger side. Consecutive
+ * authored empty paragraphs remain independent vertical spacers, including
+ * at the end of the cell.
+ */
+export const placeTableCellBlock = (
+  state: TableCellFlowState,
+  block: FlowBlock,
+  measure: Measure,
+): TableCellBlockPlacement => {
+  const top = state.height;
+  const contentHeight = getTableCellBlockContentHeight(block, measure);
+  if (
+    block.kind === "paragraph" &&
+    measure.kind === "paragraph" &&
+    isSuppressedParagraphMeasure(measure)
+  ) {
+    return { top, contentTop: top, contentHeight: 0, leadingSpacing: 0 };
+  }
+  if (block.kind !== "paragraph" || measure.kind !== "paragraph") {
+    const leadingSpacing = state.trailingSpacing;
+    const contentTop = top + leadingSpacing;
+    state.height = contentTop + contentHeight;
+    state.previousParagraphWasEmpty = false;
+    state.trailingSpacing = 0;
+    return { top, contentTop, contentHeight, leadingSpacing };
+  }
+
+  const spacing = paragraphSpacing(block, measure);
+  const empty = isEmptyParagraph(block);
+  const leadingSpacing =
+    empty && state.previousParagraphWasEmpty
+      ? spacing.before + state.trailingSpacing
+      : Math.max(spacing.before, state.trailingSpacing);
+  const contentTop = top + leadingSpacing;
+  state.height = contentTop + contentHeight;
+  state.previousParagraphWasEmpty = empty;
+  state.trailingSpacing = spacing.after;
+  return { top, contentTop, contentHeight, leadingSpacing };
+};

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -292,7 +292,7 @@ describe("buildTableRowBreakInfo / snapRowBreak", () => {
 
     const info = buildTableRowBreakInfo(block, measure);
 
-    expect(info.breakOffsets[0]).toEqual([20, 40, 60, 80, 96]);
+    expect(info.breakOffsets[0]).toEqual([28, 48, 68, 88, 96]);
   });
 
   test("treats height-based cell blocks as atomic break offsets", () => {

--- a/packages/core/src/layout-engine/tableRowBreak.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.ts
@@ -19,8 +19,8 @@ import {
   getTableCellContentWidth,
   getTableCellFloatingImages,
 } from "./measure/tableCellFloating";
-import type { Measure, TableBlock, TableCell, TableCellMeasure, TableMeasure } from "./types";
-import { isFloatingTextBoxBlock } from "./types";
+import { createTableCellFlowState, placeTableCellBlock } from "./measure/tableCellFlow";
+import type { TableBlock, TableCell, TableCellMeasure, TableMeasure } from "./types";
 
 type UnsafeBreakRange = {
   top: number;
@@ -33,16 +33,6 @@ type CellBreakGeometry = {
 };
 
 const DEFAULT_TABLE_CELL_PADDING_TOP = 1;
-
-function getAtomicBlockHeight(measure: Measure): number {
-  if ("totalHeight" in measure) {
-    return measure.totalHeight;
-  }
-  if ("height" in measure) {
-    return measure.height;
-  }
-  return 0;
-}
 
 function isInsideRange(offset: number, range: UnsafeBreakRange): boolean {
   return offset > range.top && offset < range.bottom;
@@ -81,11 +71,8 @@ function cellBreakGeometry(
   cell: TableCell | undefined,
   measure: TableCellMeasure,
 ): CellBreakGeometry {
-  // Mirror the PAINTER's cell-content stacking (renderCellContent), not just the
-  // cell-height model: each block advances by its `totalHeight` (which bundles
-  // space-before/after), but its lines paint from the block top with no leading
-  // space-before. Seating line bottoms this way keeps them on the painted line
-  // boundaries so an oversized-row break never cuts through a glyph row.
+  // Mirror the painter's shared cell-flow placement so clean row breaks stay
+  // aligned with both glyph boundaries and inter-paragraph whitespace.
   const bottoms: number[] = [];
   const unsafeRanges: UnsafeBreakRange[] = [];
   const cellBlocks = cell?.blocks;
@@ -95,27 +82,26 @@ function cellBreakGeometry(
   const floatingImages =
     cell !== undefined ? getTableCellFloatingImages(cell, measure, contentWidth) : [];
   const floatingZones = buildTableCellFloatingZones(floatingImages, contentWidth);
-  let y = padTop;
-  let paragraphY = 0;
+  const flowState = createTableCellFlowState();
   for (let i = 0; i < blockMeasures.length; i++) {
     let blockMeasure = blockMeasures[i];
     if (blockMeasure?.kind === "paragraph") {
       const block = cellBlocks?.[i];
-      if (block?.kind === "paragraph" && floatingZones.length > 0) {
+      if (block?.kind !== "paragraph") {
+        continue;
+      }
+      if (floatingZones.length > 0) {
+        const previewState = { ...flowState };
+        const preview = placeTableCellBlock(previewState, block, blockMeasure);
         blockMeasure = measureParagraph(block, contentWidth, {
           floatingZones,
-          paragraphYOffset: paragraphY,
+          paragraphYOffset: preview.contentTop,
         });
       }
-      // The painter (renderCellContent) stacks each cell paragraph by its full
-      // measured height (`totalHeight`, which bundles space-before/after) yet
-      // paints the lines from the fragment top with NO leading space-before; the
-      // before/after surface as trailing space. Mirror that exactly: seat line
-      // bottoms from the block top and advance by `totalHeight`. Offsetting the
-      // lines by `spacing.before` (as the cell-height model does) shifted every
-      // break offset off the painted line boundary, so an oversized row split
-      // through the middle of a glyph row across the page break.
-      const blockTop = y;
+      const placement = placeTableCellBlock(flowState, block, blockMeasure);
+      // Paragraph lines paint after the resolved leading spacing, matching the
+      // paragraph fragment's top padding in the cell painter.
+      let y = padTop + placement.contentTop;
       for (const line of blockMeasure.lines) {
         y += line.floatSkipBefore ?? 0;
         const top = y;
@@ -123,19 +109,20 @@ function cellBreakGeometry(
         unsafeRanges.push({ top, bottom: y });
         bottoms.push(y);
       }
-      y = blockTop + blockMeasure.totalHeight;
-      paragraphY += blockMeasure.totalHeight;
+      // Inter-paragraph spacing is also a safe break band. Recording the box
+      // boundary lets pagination use available whitespace instead of backing
+      // up to the preceding glyph line.
+      bottoms.push(padTop + flowState.height);
     } else if (blockMeasure) {
       const block = cellBlocks?.[i];
-      if (block?.kind === "textBox" && isFloatingTextBoxBlock(block)) {
+      if (!block) {
         continue;
       }
-      // Nested table / non-paragraph: one atomic block (break only at its bottom).
-      const blockHeight = getAtomicBlockHeight(blockMeasure);
+      const placement = placeTableCellBlock(flowState, block, blockMeasure);
+      const blockHeight = placement.contentHeight;
       if (blockHeight > 0) {
-        const top = y;
-        y += blockHeight;
-        paragraphY += blockHeight;
+        const top = padTop + placement.contentTop;
+        const y = top + blockHeight;
         unsafeRanges.push({ top, bottom: y });
         bottoms.push(y);
       }

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -14,6 +14,11 @@ import {
   getTableCellContentWidth,
   getTableCellFloatingImages,
 } from "../layout-engine/measure/tableCellFloating";
+import {
+  createTableCellFlowState,
+  finishTableCellFlow,
+  placeTableCellBlock,
+} from "../layout-engine/measure/tableCellFlow";
 import type {
   TableFragment,
   TableBlock,
@@ -190,7 +195,7 @@ function renderCellContent({
     floatingLayers.push(floatingLayer);
   }
 
-  let cumulativeY = 0;
+  const flowState = createTableCellFlowState();
   let anchorParagraphY = 0;
   let floatingTextBoxesLayer: HTMLElement | undefined;
   for (let i = 0; i < cell.blocks.length; i++) {
@@ -203,11 +208,14 @@ function renderCellContent({
 
       // Re-measure when wrapping width changes or floating exclusions apply.
       if (floatingZones.length > 0 || contentWidthOverride !== undefined) {
+        const previewState = { ...flowState };
+        const preview = placeTableCellBlock(previewState, paragraphBlock, paragraphMeasure);
         paragraphMeasure = measureParagraph(paragraphBlock, contentWidth, {
           floatingZones,
-          paragraphYOffset: cumulativeY,
+          paragraphYOffset: preview.contentTop,
         });
       }
+      const placement = placeTableCellBlock(flowState, paragraphBlock, paragraphMeasure);
 
       // Create synthetic fragment for the paragraph
       const syntheticFragment: ParagraphFragment = {
@@ -216,7 +224,7 @@ function renderCellContent({
         x: 0,
         y: 0,
         width: contentWidth,
-        height: paragraphMeasure.totalHeight,
+        height: placement.contentHeight,
         fromLine: 0,
         toLine: paragraphMeasure.lines.length,
         ...(paragraphBlock.pmStart !== undefined ? { pmStart: paragraphBlock.pmStart } : {}),
@@ -234,14 +242,12 @@ function renderCellContent({
 
       fragEl.style.position = "relative";
       fragEl.style.boxSizing = "border-box";
-      fragEl.style.height = `${paragraphMeasure.totalHeight}px`;
-      const spaceBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
-      if (spaceBefore > 0) {
-        fragEl.style.paddingTop = `${spaceBefore}px`;
+      fragEl.style.height = `${placement.leadingSpacing + placement.contentHeight}px`;
+      if (placement.leadingSpacing > 0) {
+        fragEl.style.paddingTop = `${placement.leadingSpacing}px`;
       }
       contentEl.append(fragEl);
-      anchorParagraphY = cumulativeY;
-      cumulativeY += paragraphMeasure.totalHeight;
+      anchorParagraphY = placement.contentTop;
     } else if (block?.kind === "table" && measure?.kind === "table") {
       // Nested table - render in normal document flow.
       // Avoid cumulative marginTop offsets here: cell content already flows vertically,
@@ -251,13 +257,18 @@ function renderCellContent({
 
       const nestedTableEl = renderNestedTable(tableBlock, tableMeasure, context, doc);
       nestedTableEl.style.position = "relative";
+      const placement = placeTableCellBlock(flowState, tableBlock, tableMeasure);
+      if (placement.leadingSpacing > 0) {
+        const spacer = doc.createElement("div");
+        spacer.style.height = `${placement.leadingSpacing}px`;
+        contentEl.append(spacer);
+      }
       contentEl.append(nestedTableEl);
-      cumulativeY += (measure as TableMeasure).totalHeight;
       // A standalone anchored shape after a nested table belongs to a
       // shape-only host paragraph at the current flow position. That host is
       // omitted from the ProseMirror cell, so the nested table's bottom is the
       // anchor Y for the following floating text box.
-      anchorParagraphY = cumulativeY;
+      anchorParagraphY = flowState.height;
     } else if (block?.kind === "textBox" && measure?.kind === "textBox") {
       const textBoxBlock = block as TextBoxBlock;
       const textBoxMeasure = measure as TextBoxMeasure;
@@ -288,14 +299,20 @@ function renderCellContent({
         continue;
       }
 
+      const placement = placeTableCellBlock(flowState, textBoxBlock, textBoxMeasure);
+      if (placement.leadingSpacing > 0) {
+        const spacer = doc.createElement("div");
+        spacer.style.height = `${placement.leadingSpacing}px`;
+        contentEl.append(spacer);
+      }
       textBoxEl.style.position = "relative";
       textBoxEl.style.left = "0";
       textBoxEl.style.top = "0";
       contentEl.append(textBoxEl);
-      cumulativeY += textBoxMeasure.height;
-      anchorParagraphY = cumulativeY;
+      anchorParagraphY = flowState.height;
     }
   }
+  contentEl.style.height = `${finishTableCellFlow(flowState)}px`;
 
   if (floatingTextBoxesLayer) {
     floatingLayers.push(floatingTextBoxesLayer);

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -431,7 +431,7 @@ describe("renderTableFragment split-row cell content", () => {
 });
 
 describe("renderTableFragment cell paragraph spacing", () => {
-  test("reserves measured paragraph spacing inside table cells", () => {
+  test("keeps trailing spacing in the cell flow instead of the paragraph box", () => {
     const block: TableBlock = {
       kind: "table",
       id: "tbl",
@@ -464,7 +464,18 @@ describe("renderTableFragment cell paragraph spacing", () => {
               blocks: [
                 {
                   kind: "paragraph",
-                  lines: [],
+                  lines: [
+                    {
+                      fromRun: 0,
+                      fromChar: 0,
+                      toRun: 0,
+                      toChar: 9,
+                      width: 50,
+                      ascent: 9,
+                      descent: 3,
+                      lineHeight: 12,
+                    },
+                  ],
                   totalHeight: 30,
                 },
               ],
@@ -495,10 +506,12 @@ describe("renderTableFragment cell paragraph spacing", () => {
     }) as unknown as FakeElement;
 
     const paragraph = findByClass(tableEl, "layout-paragraph").at(0);
+    const cellContent = findByClass(tableEl, "layout-table-cell-content").at(0);
 
-    expect(paragraph?.style["height"]).toBe("30px");
+    expect(paragraph?.style["height"]).toBe("18px");
     expect(paragraph?.style["paddingTop"]).toBe("6px");
     expect(paragraph?.style["boxSizing"]).toBe("border-box");
+    expect(cellContent?.style["height"]).toBe("30px");
   });
 });
 

--- a/packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -7,14 +7,11 @@ import {
 import {
   measureBlocks,
   measureTableBlock,
-  measureTableCellBlockVisualHeight,
 } from "@stll/folio-core/layout-engine/measure/measureBlocks";
 import type {
   FlowBlock,
   ImageBlock,
-  Measure,
   ParagraphBlock,
-  ParagraphMeasure,
   TableBlock,
   TextBoxBlock,
 } from "@stll/folio-core/layout-engine/types";
@@ -39,140 +36,6 @@ const imageOnlyParagraph: ParagraphBlock = {
     },
   },
 };
-
-const imageParagraphMeasure: ParagraphMeasure = {
-  kind: "paragraph",
-  lines: [
-    {
-      fromRun: 0,
-      fromChar: 0,
-      toRun: 0,
-      toChar: 0,
-      width: 186,
-      ascent: 30.921875,
-      descent: 6.078125,
-      lineHeight: 37,
-    },
-  ],
-  totalHeight: 42,
-};
-
-describe("measureTableCellBlockVisualHeight", () => {
-  test("uses actual image height for image-only table-cell paragraphs", () => {
-    expect(measureTableCellBlockVisualHeight(imageOnlyParagraph, imageParagraphMeasure)).toBe(34);
-  });
-
-  test("ignores visually empty text around image-only table-cell paragraphs", () => {
-    const paragraph: ParagraphBlock = {
-      ...imageOnlyParagraph,
-      runs: [
-        { kind: "text", text: " " },
-        ...imageOnlyParagraph.runs,
-        { kind: "text", text: "\u00a0" },
-      ],
-    };
-
-    expect(measureTableCellBlockVisualHeight(paragraph, imageParagraphMeasure)).toBe(34);
-  });
-
-  test("keeps measured paragraph height for mixed-content paragraphs", () => {
-    const mixedParagraph: ParagraphBlock = {
-      ...imageOnlyParagraph,
-      runs: [{ kind: "text", text: "Caption" }, ...imageOnlyParagraph.runs],
-    };
-
-    expect(measureTableCellBlockVisualHeight(mixedParagraph, imageParagraphMeasure)).toBe(42);
-  });
-
-  test("keeps measured paragraph height for floating image-only paragraphs", () => {
-    const floatingImageParagraph: ParagraphBlock = {
-      ...imageOnlyParagraph,
-      runs: [
-        {
-          kind: "image",
-          src: "data:image/png;base64,",
-          width: 186,
-          height: 90,
-          displayMode: "float",
-          wrapType: "square",
-        },
-      ],
-    };
-    const floatingParagraphMeasure: ParagraphMeasure = {
-      kind: "paragraph",
-      lines: [
-        {
-          fromRun: 0,
-          fromChar: 0,
-          toRun: 0,
-          toChar: 1,
-          width: 0,
-          ascent: 10,
-          descent: 2,
-          lineHeight: 12,
-        },
-      ],
-      totalHeight: 12,
-    };
-
-    expect(
-      measureTableCellBlockVisualHeight(floatingImageParagraph, floatingParagraphMeasure),
-    ).toBe(12);
-  });
-
-  test("keeps measured paragraph height for block image-only paragraphs", () => {
-    const blockImageParagraph: ParagraphBlock = {
-      ...imageOnlyParagraph,
-      runs: [
-        {
-          kind: "image",
-          src: "data:image/png;base64,",
-          width: 186,
-          height: 90,
-          displayMode: "block",
-          wrapType: "topAndBottom",
-          distTop: 8,
-          distBottom: 6,
-        },
-      ],
-    };
-    const blockParagraphMeasure: ParagraphMeasure = {
-      kind: "paragraph",
-      lines: [
-        {
-          fromRun: 0,
-          fromChar: 0,
-          toRun: 0,
-          toChar: 1,
-          width: 186,
-          ascent: 96,
-          descent: 8,
-          lineHeight: 104,
-        },
-      ],
-      totalHeight: 104,
-    };
-
-    expect(measureTableCellBlockVisualHeight(blockImageParagraph, blockParagraphMeasure)).toBe(104);
-  });
-
-  test("uses totalHeight for non-paragraph block measures", () => {
-    const block: FlowBlock = {
-      kind: "table",
-      id: "nested",
-      rows: [],
-    };
-    const measure: Measure = {
-      kind: "table",
-      rows: [],
-      columnWidths: [],
-      totalWidth: 10,
-      totalHeight: 22,
-    };
-
-    expect(measureTableCellBlockVisualHeight(block, measure)).toBe(22);
-  });
-});
 
 describe("measureBlocks floating text-box bands", () => {
   test("activates a margin-pinned band at its real text-box anchor", () => {


### PR DESCRIPTION
## Summary

- collapse adjacent table-cell paragraph spacing through one shared vertical-flow model
- reuse the same block placements for measurement, painting, floating anchors, and row-break geometry
- retain terminal and consecutive authored blank-paragraph spacing without creating avoidable overflow fragments

## Validation

- focused table measurement, painting, pagination, selection, and architecture tests (140 passing)
- formatting verification
- dependency audit
- lint, typecheck, build, and full suites run in CI

CC on behalf of @jan-kubica