### PR TITLE
fix: base justified fitting on compressible spaces

### DIFF
--- a/.changeset/tidy-justified-lines.md
+++ b/.changeset/tidy-justified-lines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Base justified line fitting on measured compressible spaces and preserve Czech one-letter prepositions across formatted runs.

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -76,7 +76,7 @@ const BREAK_AFTER_CHARACTER = new Set([
   "\u200B", // zero-width space
   "\u00AD", // soft hyphen
 ]);
-const CZECH_NONSYLLABIC_ONE_LETTER_PREPOSITIONS = new Set(["k", "s", "v", "z"]);
+const CZECH_ONE_LETTER_PREPOSITIONS = new Set(["k", "o", "s", "u", "v", "z"]);
 
 // ECMA-376 kinsoku defaults are language-specific and can be overridden by
 // settings.xml. This conservative common set covers punctuation excluded from
@@ -217,8 +217,7 @@ const czechProtectedBreaks = (text: string, policy?: LineBreakPolicy): Set<numbe
 
     const token = text.slice(tokenStart, index);
     const protectsNextWord =
-      [...token].length === 1 &&
-      CZECH_NONSYLLABIC_ONE_LETTER_PREPOSITIONS.has(token.toLocaleLowerCase("cs"));
+      token.length === 1 && CZECH_ONE_LETTER_PREPOSITIONS.has(token.toLocaleLowerCase("cs"));
     while (index < text.length) {
       const whitespace = firstCodePoint(text, index);
       if (whitespace === undefined || !/\s/u.test(whitespace)) {

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -40,12 +40,18 @@ describe("findWordBreaks", () => {
     expect(() => findWordBreaks("hello world", { locale: "not_a_locale" })).not.toThrow();
   });
 
-  test("keeps Czech nonsyllabic one-letter prepositions with the following word", () => {
+  test("keeps Czech one-letter prepositions with the following word", () => {
     const text = "text v  text";
 
     expect(findWordBreaks(text, { locale: "cs-CZ" })).toEqual([5]);
     expect(findWordBreaks(text, { locale: "en-US" })).toEqual([5, 7, 8]);
     expect(findWordBreaks("textov text", { locale: "cs-CZ" })).toEqual([7]);
+    expect(findWordBreaks("text o text", { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks("text u text", { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks("text O text", { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks("text U text", { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks("text a text", { locale: "cs-CZ" })).toEqual([5, 7]);
+    expect(findWordBreaks("text i text", { locale: "cs-CZ" })).toEqual([5, 7]);
   });
 
   test("keeps prohibited CJK punctuation off the next line", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -374,6 +374,73 @@ describe("measureParagraph cross-run line breaking", () => {
     }, fakeMeasure);
   });
 
+  test("keeps a Czech one-letter preposition with a following formatted run", () => {
+    withFakeTextMeasure(() => {
+      const sameRunWhitespace: Run[] = [
+        { kind: "text", text: "alpha o ", language: { val: "cs-CZ" } },
+        { kind: "text", text: "beta", bold: true, language: { val: "cs-CZ" } },
+      ];
+      const sameRunMeasure = measureParagraph(paragraph(sameRunWhitespace), width("alpha o"));
+
+      expect(lineStartsAt(sameRunMeasure.lines, 0, "alpha ".length)).toBe(true);
+      expect(lineStartsAtRun(sameRunMeasure.lines, 1)).toBe(false);
+
+      const splitCases: { runs: Run[]; followingRun: number }[] = [
+        {
+          runs: [
+            { kind: "text", text: "alpha " },
+            { kind: "text", text: "o", language: { val: "cs-CZ" } },
+            { kind: "text", text: " beta", bold: true },
+          ],
+          followingRun: 2,
+        },
+        {
+          runs: [
+            { kind: "text", text: "alpha " },
+            { kind: "text", text: "o", language: { val: "cs-CZ" } },
+            { kind: "text", text: " " },
+            { kind: "text", text: "beta", bold: true },
+          ],
+          followingRun: 3,
+        },
+        {
+          runs: [
+            { kind: "text", text: "alpha " },
+            { kind: "text", text: "o ", language: { val: "cs-CZ" } },
+            { kind: "text", text: "" },
+            { kind: "text", text: "beta", bold: true },
+          ],
+          followingRun: 3,
+        },
+      ];
+
+      for (const splitCase of splitCases) {
+        const { lines } = measureParagraph(paragraph(splitCase.runs), width("alpha o"));
+
+        expect(lineStartsAtRun(lines, 1)).toBe(true);
+        expect(lineStartsAtRun(lines, splitCase.followingRun)).toBe(false);
+      }
+    }, fakeMeasure);
+  });
+
+  test("bounds protected-break scanning for fragmented Czech runs", () => {
+    withFakeTextMeasure(
+      () => {
+        const runs: Run[] = Array.from({ length: 500 }, () => ({
+          kind: "text",
+          text: "o",
+          language: { val: "cs-CZ" },
+        }));
+        const startedAt = performance.now();
+
+        measureParagraph(paragraph(runs), 10_000);
+
+        expect(performance.now() - startedAt).toBeLessThan(1_500);
+      },
+      { charWidth: fixedCharWidth(1) },
+    );
+  });
+
   test("allows a normal wrap when whitespace precedes the footnote marker", () => {
     withFakeTextMeasure(() => {
       const runs: Run[] = [
@@ -720,21 +787,32 @@ describe("automatic hyphenation", () => {
 describe("measureParagraph justified shrink tolerance", () => {
   const fractionalWidth = (char: string): number => (char === "b" ? 0.6 : 1);
   const text = `${"a".repeat(99)} bbb`;
+  const spaceRichText = `${"a ".repeat(20)}${"a".repeat(60)}bbb`;
 
-  test("allows normal justified prose to use reference-layout shrink before wrapping", () => {
+  test("bases ordinary justified shrink on measured compressible spaces", () => {
     withFakeTextMeasure(
       () => {
-        const measure = measureParagraph(
+        const spaceRichMeasure = measureParagraph(
           {
             kind: "paragraph",
             id: "justified-prose-shrink",
+            runs: [{ kind: "text", text: spaceRichText }],
+            attrs: { alignment: "justify" },
+          },
+          100,
+        );
+        const spacePoorMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-prose-small-space-budget",
             runs: [{ kind: "text", text }],
             attrs: { alignment: "justify" },
           },
           100,
         );
 
-        expect(measure.lines).toHaveLength(1);
+        expect(spaceRichMeasure.lines).toHaveLength(1);
+        expect(spacePoorMeasure.lines).toHaveLength(2);
       },
       {
         charWidth: fractionalWidth,
@@ -766,7 +844,7 @@ describe("measureParagraph justified shrink tolerance", () => {
   });
 
   test("keeps regular spaces available for justified shrink beside a fixed space", () => {
-    const mixedSpaceText = `${"a".repeat(97)}  \u00a0bbb`;
+    const mixedSpaceText = `${"a ".repeat(15)}${"a".repeat(68)}\u00a0bbb`;
 
     withFakeTextMeasure(
       () => {
@@ -816,7 +894,7 @@ describe("measureParagraph justified shrink tolerance", () => {
           {
             kind: "paragraph",
             id: "justified-unused-tab-stop",
-            runs: [{ kind: "text", text }],
+            runs: [{ kind: "text", text: spaceRichText }],
             attrs: {
               alignment: "justify",
               indent: { firstLine: 48 },
@@ -858,14 +936,14 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("allows hanging tabbed justified prose a small additional shrink", () => {
+  test("uses measured spaces with configured but unused tab stops", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
           {
             kind: "paragraph",
             id: "justified-hanging-tab",
-            runs: [{ kind: "text", text }],
+            runs: [{ kind: "text", text: spaceRichText }],
             attrs: {
               alignment: "justify",
               indent: { firstLine: 0 },
@@ -978,13 +1056,30 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("uses prose shrink tolerance for justified list continuation lines", () => {
+  test("bases full-hanging list continuation shrink on measured spaces", () => {
     withFakeTextMeasure(
       () => {
-        const measure = measureParagraph(
+        const spaceRichMeasure = measureParagraph(
           {
             kind: "paragraph",
             id: "justified-list-continuation",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: spaceRichText },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 36 },
+            },
+          },
+          136,
+        );
+        const spacePoorMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-small-continuation-budget",
             runs: [
               { kind: "text", text: "first line" },
               { kind: "lineBreak" },
@@ -999,7 +1094,8 @@ describe("measureParagraph justified shrink tolerance", () => {
           136,
         );
 
-        expect(measure.lines).toHaveLength(2);
+        expect(spaceRichMeasure.lines).toHaveLength(2);
+        expect(spacePoorMeasure.lines).toHaveLength(3);
       },
       {
         charWidth: fractionalWidth,
@@ -1063,7 +1159,7 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("keeps full-hanging list continuation lines on the prose tolerance", () => {
+  test("uses the measured-space budget for full-hanging list continuations", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
@@ -1073,7 +1169,7 @@ describe("measureParagraph justified shrink tolerance", () => {
             runs: [
               { kind: "text", text: "first line" },
               { kind: "lineBreak" },
-              { kind: "text", text },
+              { kind: "text", text: spaceRichText },
             ],
             attrs: {
               alignment: "justify",
@@ -1089,6 +1185,68 @@ describe("measureParagraph justified shrink tolerance", () => {
       {
         charWidth: fractionalWidth,
       },
+    );
+  });
+
+  test("counts spaces inside opaque field runs but not native math", () => {
+    const opaqueSpaceRichText = `${"a ".repeat(10)}b`;
+    const opaqueSpacePoorText = `${"a".repeat(19)} b`;
+    const measureOpaqueRun = (run: Run) =>
+      measureParagraph(
+        {
+          kind: "paragraph",
+          id: "justified-opaque-run-space-budget",
+          runs: [{ kind: "text", text: "x" }, run],
+          attrs: { alignment: "justify" },
+        },
+        21,
+      );
+    const measureResolvedField = () =>
+      measureParagraph(
+        {
+          kind: "paragraph",
+          id: "justified-resolved-field-space-budget",
+          runs: [
+            { kind: "text", text: "x" },
+            {
+              kind: "field",
+              fieldType: "OTHER",
+              fallback: opaqueSpacePoorText,
+              pmStart: 1,
+            },
+          ],
+          attrs: { alignment: "justify" },
+        },
+        21,
+        { fieldValues: new Map([[1, opaqueSpaceRichText]]) },
+      );
+
+    withFakeTextMeasure(
+      () => {
+        const fieldRich = measureOpaqueRun({
+          kind: "field",
+          fieldType: "OTHER",
+          fallback: opaqueSpaceRichText,
+        });
+        const fieldPoor = measureOpaqueRun({
+          kind: "field",
+          fieldType: "OTHER",
+          fallback: opaqueSpacePoorText,
+        });
+        const mathRich = measureOpaqueRun({
+          kind: "math",
+          display: "inline",
+          ommlXml:
+            '<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"><m:r><m:t>a b</m:t></m:r></m:oMath>',
+          plainText: opaqueSpaceRichText,
+        });
+
+        expect(fieldRich.lines).toHaveLength(1);
+        expect(fieldPoor.lines).toHaveLength(2);
+        expect(measureResolvedField().lines).toHaveLength(1);
+        expect(mathRich.lines).toHaveLength(2);
+      },
+      { charWidth: fixedCharWidth(1) },
     );
   });
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -62,10 +62,11 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
+const JUSTIFY_SPACE_CONTRACTION_RATIO = 0.1;
 const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
+const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.23;
 const JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
-const JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO = 0.02;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
 const DEFAULT_LIST_HANGING_INDENT_PX = 24;
 const ALL_CAPS_RATIO_THRESHOLD = 0.8;
@@ -133,11 +134,7 @@ type LineState = {
   /** Width of collapsible ASCII whitespace at the current line tail. */
   trailingWhitespaceWidth: number;
   /** Spaces the layout may compress while justifying this line. */
-  regularSpaceCount: number;
-  /** Measured width of the compressible spaces on this line. */
   regularSpaceWidth: number;
-  /** Fixed-width spaces excluded from the line's justification budget. */
-  nonBreakingSpaceCount: number;
   maxFontSize: number;
   maxFontMetrics: FontMetrics | null;
   /** Maximum inline image height in pixels (already in px, not points) */
@@ -620,86 +617,78 @@ function uppercaseLetterRatio(text: string): number {
   return letters === 0 ? 0 : uppercase / letters;
 }
 
-type FixedSpaceAdjustedShrinkToleranceOptions = {
-  tolerance: number;
-  regularSpaceCount: number;
-  nonBreakingSpaceCount: number;
+type JustifyFitStrategy =
+  | { type: "rounding" }
+  | { type: "space"; ratio: number }
+  | { type: "width"; ratio: number };
+
+type JustificationProfile = {
+  hasTabRuns: boolean;
+  uppercaseRatio: number;
 };
 
-function fixedSpaceAdjustedShrinkTolerance({
-  tolerance,
-  regularSpaceCount,
-  nonBreakingSpaceCount,
-}: FixedSpaceAdjustedShrinkToleranceOptions): number {
-  const totalSpaces = regularSpaceCount + nonBreakingSpaceCount;
-  if (totalSpaces === 0) {
-    return tolerance;
-  }
-  // The reference layout contracts ordinary spaces during justification, but
-  // keeps NBSPs fixed. Scale the allowance to the share that can shrink.
-  return Math.max(JUSTIFY_SHRINK_TOLERANCE_RATIO, tolerance * (regularSpaceCount / totalSpaces));
-}
-
-function justifyShrinkToleranceRatio(
+function resolveJustifyFitStrategy(
   block: ParagraphBlock,
   isFirstLine: boolean,
-  regularSpaceCount: number,
-  nonBreakingSpaceCount: number,
-): number {
+  profile: JustificationProfile,
+): JustifyFitStrategy {
+  if (isShallowFullHangingListContinuation(block, isFirstLine)) {
+    return { type: "rounding" };
+  }
+
   if (block.attrs?.listMarker !== undefined) {
-    // Marker lines and continuation lines use separate compression budgets.
-    // Fixed non-breaking spaces reduce the continuation-line allowance.
     const hanging = block.attrs.indent?.hanging ?? 0;
     if (isFirstLine) {
       return hanging <= DEFAULT_LIST_HANGING_INDENT_PX
-        ? JUSTIFY_SHRINK_TOLERANCE_RATIO
-        : JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO;
+        ? { type: "space", ratio: JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO }
+        : { type: "width", ratio: JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO };
     }
     const left = block.attrs.indent?.left ?? 0;
     if (hanging > 0 && left > hanging) {
-      // A marker that remains inset leaves a narrower continuation body.
-      // Keep those lines on the marker-line allowance; full-hanging lists
-      // retain the broader prose allowance below.
-      return JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO;
+      return { type: "width", ratio: JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO };
     }
-    return fixedSpaceAdjustedShrinkTolerance({
-      tolerance: JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO,
-      regularSpaceCount,
-      nonBreakingSpaceCount,
-    });
+    return { type: "space", ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO };
   }
+
   const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
-  const hasTabRuns = block.runs.some(isTabRun);
-  if (isFirstLine && hasTabRuns && (block.attrs?.indent?.hanging ?? 0) > 0) {
-    return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  if (isFirstLine && profile.hasTabRuns && (block.attrs?.indent?.hanging ?? 0) > 0) {
+    return { type: "width", ratio: JUSTIFY_SHRINK_TOLERANCE_RATIO };
   }
-  if (!isFirstLine && hasTabRuns && !hasTabStops) {
-    return JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO;
+  if (!isFirstLine && profile.hasTabRuns && !hasTabStops) {
+    return { type: "width", ratio: JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO };
   }
-  if (hasTabRuns && (isFirstLine || hasTabStops)) {
-    return (block.attrs?.indent?.firstLine ?? 0) === 0
-      ? JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO
-      : JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  if (profile.hasTabRuns && (isFirstLine || hasTabStops)) {
+    return {
+      type: "width",
+      ratio:
+        (block.attrs?.indent?.firstLine ?? 0) === 0
+          ? JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO
+          : JUSTIFY_SHRINK_TOLERANCE_RATIO,
+    };
   }
-
-  const text = block.runs.map((run) => (isTextRun(run) ? (run.text ?? "") : "")).join("");
-  if (uppercaseLetterRatio(text) > ALL_CAPS_RATIO_THRESHOLD) {
-    return JUSTIFY_SHRINK_TOLERANCE_RATIO;
+  if (profile.uppercaseRatio > ALL_CAPS_RATIO_THRESHOLD) {
+    return { type: "width", ratio: JUSTIFY_SHRINK_TOLERANCE_RATIO };
   }
-
-  return fixedSpaceAdjustedShrinkTolerance({
-    tolerance: JUSTIFY_PROSE_SHRINK_TOLERANCE_RATIO,
-    regularSpaceCount,
-    nonBreakingSpaceCount,
-  });
+  return { type: "space", ratio: JUSTIFY_SPACE_CONTRACTION_RATIO };
 }
 
-function usesSpaceBasedListMarkerTolerance(block: ParagraphBlock, isFirstLine: boolean): boolean {
-  return (
-    isFirstLine &&
-    block.attrs?.listMarker !== undefined &&
-    (block.attrs.indent?.hanging ?? 0) <= DEFAULT_LIST_HANGING_INDENT_PX
-  );
+function compressibleSpaceWidth(text: string, style: FontStyle): number {
+  const count = countCompressibleSpaces(text);
+  return count === 0 ? 0 : count * measureTextWidth(" ", style);
+}
+
+function justifyFitTolerance(
+  line: LineState,
+  strategy: JustifyFitStrategy,
+  candidateSpaceWidth: number,
+): number {
+  if (strategy.type === "rounding") {
+    return WIDTH_TOLERANCE;
+  }
+  if (strategy.type === "width") {
+    return Math.max(WIDTH_TOLERANCE, line.availableWidth * strategy.ratio);
+  }
+  return Math.max(WIDTH_TOLERANCE, (line.regularSpaceWidth + candidateSpaceWidth) * strategy.ratio);
 }
 
 function isShallowFullHangingListContinuation(
@@ -767,23 +756,82 @@ function computeTrailingGlueWidths(block: ParagraphBlock): number[] {
       widths[index] = widths[index + 1] ?? 0;
       continue;
     }
-    if (isSpaceOrTab(text[0])) {
+    if (isSpaceOrTab(text.at(0))) {
       continue;
     }
 
     const style = runToFontStyle(nextRun);
     const breaks = findWordBreaks(text, lineBreakPolicy(block, nextRun));
-    if (breaks.length === 0) {
-      widths[index] = measureTextWidth(text, style) + (widths[index + 1] ?? 0);
+    const firstBreak = breaks.at(0);
+    const leading =
+      firstBreak === undefined ? text : trimTrailingSpacesAndTabs(text.slice(0, firstBreak));
+    widths[index] =
+      measureTextWidth(leading, style) + (firstBreak === undefined ? (widths[index + 1] ?? 0) : 0);
+  }
+  return widths;
+}
+
+function computeProtectedCrossRunGlueWidths(block: ParagraphBlock): number[] {
+  const widths = Array.from({ length: block.runs.length }, () => 0);
+  for (let index = 0; index < block.runs.length; index++) {
+    const run = block.runs[index];
+    if (!run || !isTextRun(run)) {
+      continue;
+    }
+    const trailing = /(\S+)(\s*)$/u.exec(run.text ?? "");
+    const token = trailing?.[1];
+    const policy = lineBreakPolicy(block, run);
+    if (!token || token.length !== 1 || !policy.locale?.toLocaleLowerCase().startsWith("cs")) {
       continue;
     }
 
-    const firstBreak = breaks[0];
-    if (firstBreak === undefined) {
+    let separator = trailing[2] ?? "";
+    let glueWidth = separator.length > 0 ? measureTextWidth(separator, runToFontStyle(run)) : 0;
+    let followingWord = "";
+    let unseparatedFollowingText = false;
+    for (let nextIndex = index + 1; nextIndex < block.runs.length; nextIndex++) {
+      const nextRun = block.runs[nextIndex];
+      if (!nextRun || !isTextRun(nextRun)) {
+        break;
+      }
+      const text = nextRun.text ?? "";
+      let consumed = "";
+      for (const char of text) {
+        const isWhitespace = /\s/u.test(char);
+        if (followingWord.length > 0 && isWhitespace) {
+          break;
+        }
+        if (separator.length === 0 && !isWhitespace) {
+          unseparatedFollowingText = true;
+          break;
+        }
+        consumed += char;
+        if (isWhitespace) {
+          separator += char;
+        } else {
+          followingWord += char;
+        }
+      }
+      if (consumed.length > 0) {
+        glueWidth += measureTextWidth(consumed, runToFontStyle(nextRun));
+      }
+      if (unseparatedFollowingText) {
+        break;
+      }
+      if (followingWord.length > 0 && consumed.length < text.length) {
+        break;
+      }
+    }
+    if (unseparatedFollowingText || separator.length === 0 || followingWord.length === 0) {
       continue;
     }
-    const leading = trimTrailingSpacesAndTabs(text.slice(0, firstBreak));
-    widths[index] = measureTextWidth(leading, style);
+
+    const boundary = token.length + separator.length;
+    const probe = token + separator + followingWord;
+    const breaks = findWordBreaks(probe, policy);
+    if (!breaks.includes(boundary)) {
+      widths[index] = glueWidth;
+    }
   }
   return widths;
 }
@@ -985,6 +1033,18 @@ export function measureParagraph(
   const attrs = block.attrs;
   const spacing = attrs?.spacing;
   const isJustifiedParagraph = attrs?.alignment === "justify";
+  const justificationProfile: JustificationProfile = {
+    hasTabRuns: isJustifiedParagraph && runs.some(isTabRun),
+    uppercaseRatio: isJustifiedParagraph
+      ? uppercaseLetterRatio(runs.map((run) => (isTextRun(run) ? (run.text ?? "") : "")).join(""))
+      : 0,
+  };
+  const firstLineJustifyFitStrategy = resolveJustifyFitStrategy(block, true, justificationProfile);
+  const continuationJustifyFitStrategy = resolveJustifyFitStrategy(
+    block,
+    false,
+    justificationProfile,
+  );
 
   // Floating image support
   const floatingZones = options?.floatingZones;
@@ -1170,6 +1230,7 @@ export function measureParagraph(
   }
 
   const trailingGlueWidths = computeTrailingGlueWidths(block);
+  const protectedCrossRunGlueWidths = computeProtectedCrossRunGlueWidths(block);
 
   // Initialize line state
   let currentLine: LineState = {
@@ -1179,9 +1240,7 @@ export function measureParagraph(
     toChar: 0,
     width: 0,
     trailingWhitespaceWidth: 0,
-    regularSpaceCount: 0,
     regularSpaceWidth: 0,
-    nonBreakingSpaceCount: 0,
     maxFontSize: DEFAULT_FONT_SIZE,
     maxFontMetrics: null,
     maxImageHeightPx: 0,
@@ -1344,9 +1403,7 @@ export function measureParagraph(
       toChar: charIndex,
       width: 0,
       trailingWhitespaceWidth: 0,
-      regularSpaceCount: 0,
       regularSpaceWidth: 0,
-      nonBreakingSpaceCount: 0,
       maxFontSize: DEFAULT_FONT_SIZE,
       maxFontMetrics: null,
       maxImageHeightPx: 0,
@@ -1587,15 +1644,24 @@ export function measureParagraph(
       updateMaxFont(style);
 
       const fieldWidth = measureTextWidth(fallback, style);
+      const fieldSpaceWidth = compressibleSpaceWidth(fallback, style);
+      const fieldTolerance = isJustifiedParagraph
+        ? justifyFitTolerance(
+            currentLine,
+            lines.length === 0 ? firstLineJustifyFitStrategy : continuationJustifyFitStrategy,
+            fieldSpaceWidth,
+          )
+        : WIDTH_TOLERANCE;
       if (
         currentLine.width > 0 &&
-        currentLine.width + fieldWidth > currentLine.availableWidth + WIDTH_TOLERANCE
+        currentLine.width + fieldWidth > currentLine.availableWidth + fieldTolerance
       ) {
         startNewLine(runIndex, 0);
         updateMaxFont(style);
       }
 
       currentLine.width += fieldWidth;
+      currentLine.regularSpaceWidth += fieldSpaceWidth;
       currentLine.trailingWhitespaceWidth = 0;
       currentLine.toRun = runIndex;
       currentLine.toChar = 1;
@@ -1616,7 +1682,8 @@ export function measureParagraph(
         ...(run.italic !== undefined ? { italic: run.italic } : {}),
       };
       updateMaxFont(style);
-      const mathWidth = measureTextWidth(run.plainText || "[equation]", style);
+      const mathText = run.plainText || "[equation]";
+      const mathWidth = measureTextWidth(mathText, style);
       const mathFootprintPx = estimateMathFootprintPx(run);
       if (
         currentLine.width > 0 &&
@@ -1689,30 +1756,15 @@ export function measureParagraph(
           breakPolicy,
           block.attrs?.overflowPunctuation,
         );
-        const regularSpaces = countCompressibleSpaces(measuredWord);
-        const nonBreakingSpaces = measuredWord.split("\u00a0").length - 1;
         const isFirstLine = lines.length === 0;
-        const usesMarkerSpaceTolerance = usesSpaceBasedListMarkerTolerance(block, isFirstLine);
-        const regularSpaceWidth =
-          regularSpaces > 0 && usesMarkerSpaceTolerance
-            ? regularSpaces * measureTextWidth(" ", style)
-            : 0;
-        const widthTolerance =
-          isJustifiedParagraph && !isShallowFullHangingListContinuation(block, isFirstLine)
-            ? Math.max(
-                WIDTH_TOLERANCE,
-                usesMarkerSpaceTolerance
-                  ? (currentLine.regularSpaceWidth + regularSpaceWidth) *
-                      JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO
-                  : currentLine.availableWidth *
-                      justifyShrinkToleranceRatio(
-                        block,
-                        isFirstLine,
-                        currentLine.regularSpaceCount + regularSpaces,
-                        currentLine.nonBreakingSpaceCount + nonBreakingSpaces,
-                      ),
-              )
-            : WIDTH_TOLERANCE;
+        const regularSpaceWidth = compressibleSpaceWidth(measuredWord, style);
+        const widthTolerance = isJustifiedParagraph
+          ? justifyFitTolerance(
+              currentLine,
+              isFirstLine ? firstLineJustifyFitStrategy : continuationJustifyFitStrategy,
+              regularSpaceWidth,
+            )
+          : WIDTH_TOLERANCE;
 
         const automaticHyphenation = block.attrs?.automaticHyphenation;
         const consecutiveLineLimit = automaticHyphenation?.consecutiveLineLimit ?? 0;
@@ -1858,16 +1910,7 @@ export function measureParagraph(
             currentLine.width += chunkWidth;
             currentLine.trailingWhitespaceWidth =
               chunkWidth - measureTextWidth(trimTrailingSpacesAndTabs(chunk), style);
-            const chunkRegularSpaceCount = countCompressibleSpaces(chunk);
-            currentLine.regularSpaceCount += chunkRegularSpaceCount;
-            if (
-              chunkRegularSpaceCount > 0 &&
-              usesSpaceBasedListMarkerTolerance(block, lines.length === 0)
-            ) {
-              currentLine.regularSpaceWidth +=
-                chunkRegularSpaceCount * measureTextWidth(" ", style);
-            }
-            currentLine.nonBreakingSpaceCount += chunk.split("\u00a0").length - 1;
+            currentLine.regularSpaceWidth += compressibleSpaceWidth(chunk, style);
             currentLine.toRun = runIndex;
             currentLine.toChar = charIndex + chunkEnd;
 
@@ -1881,15 +1924,7 @@ export function measureParagraph(
           const trailingWhitespaceWidth = fullWordWidth - wordWidth;
           currentLine.width += trailingWhitespaceWidth;
           currentLine.trailingWhitespaceWidth = trailingWhitespaceWidth;
-          const wordRegularSpaceCount = countCompressibleSpaces(word);
-          currentLine.regularSpaceCount += wordRegularSpaceCount;
-          if (
-            wordRegularSpaceCount > 0 &&
-            usesSpaceBasedListMarkerTolerance(block, lines.length === 0)
-          ) {
-            currentLine.regularSpaceWidth += wordRegularSpaceCount * measureTextWidth(" ", style);
-          }
-          currentLine.nonBreakingSpaceCount += word.split("\u00a0").length - 1;
+          currentLine.regularSpaceWidth += compressibleSpaceWidth(word, style);
           currentLine.toChar = nextBreak;
 
           charIndex = nextBreak;
@@ -1900,10 +1935,11 @@ export function measureParagraph(
         // run and the next run starts without whitespace, include that glued
         // width in the wrap decision so a note marker or format-only word
         // split is not stranded on the next line (eigenpal/docx-editor#991).
+        const wordTail = word.at(-1);
+        const protectedGlueWidth = protectedCrossRunGlueWidths[runIndex] ?? 0;
         const rawGlueWidth =
-          // eslint-disable-next-line unicorn/prefer-at -- hot path: direct index avoids .at() overhead.
-          isRunTail && word.length > 0 && !isBreakChar(word[word.length - 1])
-            ? (trailingGlueWidths[runIndex] ?? 0)
+          isRunTail && wordTail !== undefined && (!isBreakChar(wordTail) || protectedGlueWidth > 0)
+            ? Math.max(trailingGlueWidths[runIndex] ?? 0, protectedGlueWidth)
             : 0;
         const glueWidth =
           rawGlueWidth > 0 &&
@@ -1935,15 +1971,7 @@ export function measureParagraph(
           wordWidth === 0
             ? currentLine.trailingWhitespaceWidth + wordTrailingWhitespaceWidth
             : wordTrailingWhitespaceWidth;
-        const wordRegularSpaceCount = countCompressibleSpaces(word);
-        currentLine.regularSpaceCount += wordRegularSpaceCount;
-        if (
-          wordRegularSpaceCount > 0 &&
-          usesSpaceBasedListMarkerTolerance(block, lines.length === 0)
-        ) {
-          currentLine.regularSpaceWidth += wordRegularSpaceCount * measureTextWidth(" ", style);
-        }
-        currentLine.nonBreakingSpaceCount += word.split("\u00a0").length - 1;
+        currentLine.regularSpaceWidth += compressibleSpaceWidth(word, style);
         currentLine.toRun = runIndex;
         currentLine.toChar = nextBreak;
 

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -185,6 +185,84 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(lineEl.style.wordSpacing).toBe("-5px");
   });
 
+  test("counts resolved field text when compressing an overfull line", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-resolved-field-spaces",
+      runs: [
+        {
+          kind: "field",
+          fieldType: "OTHER",
+          instruction: "REF target",
+          fallback: "fallback",
+          pmStart: 1,
+        },
+      ],
+      attrs: { alignment: "justify" },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 110,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      context: {
+        pageNumber: 1,
+        totalPages: 1,
+        section: "body",
+        bookmarkText: new Map([["target", "alpha beta gamma"]]),
+      },
+    });
+
+    expect(lineEl.style.wordSpacing).toBe("-5px");
+  });
+
+  test("does not treat native math spaces as compressible line spaces", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-native-math-spaces",
+      runs: [
+        {
+          kind: "math",
+          display: "inline",
+          ommlXml:
+            '<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"><m:r><m:t>a b</m:t></m:r></m:oMath>',
+          plainText: "a b",
+        },
+      ],
+      attrs: { alignment: "justify" },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 110,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+    });
+
+    expect(lineEl.style.wordSpacing).toBeUndefined();
+  });
+
   test("underfull justified tab lines distribute their remaining width explicitly", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1425,15 +1425,13 @@ type RenderLineOptions = {
  */
 const RIGHT_EDGE_EPSILON_PX = 0.5;
 
-function countShrinkableSpaces(runs: Run[]): number {
+function countShrinkableSpaces(runs: Run[], context: RenderContext | undefined): number {
   let count = 0;
   for (const run of runs) {
     if (isTextRun(run)) {
       count += countCompressibleSpaces(run.text ?? "");
     } else if (isFieldRun(run)) {
-      count += countCompressibleSpaces(run.fallback ?? "");
-    } else if (isMathRun(run)) {
-      count += countCompressibleSpaces(run.plainText ?? "");
+      count += countCompressibleSpaces(resolveFieldText(run, context));
     }
   }
   return count;
@@ -1879,6 +1877,7 @@ export function renderLine(
       const overfullPx = line.width - justifyCapacityPx;
       const shrinkableSpaces = countShrinkableSpaces(
         runsForLine.filter((run) => !isTextRun(run) || !isCollapsedLineEdgeSpaceRun(run)),
+        options.context,
       );
       if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
         lineEl.style.textAlign = "left";


### PR DESCRIPTION
## Summary

- resolve justified-line fit through explicit space- and width-based strategies
- base prose and full-hanging list allowances on measured compressible-space widths
- keep protected Czech one-letter prepositions with following text across formatting runs
- align resolved-field compression between measurement and painting

## Validation

- focused paragraph measurement, painting, and line-break tests (125 passing)
- fragmented-run performance regression
- formatting verification
- dependency audit
- lint, typecheck, build, and full suites run in CI

CC on behalf of @jan-kubica