### PR TITLE
fix: distinguish explicit section-leading spacing

### DIFF
--- a/.changeset/tidy-section-leading-spacing.md
+++ b/.changeset/tidy-section-leading-spacing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Suppress inherited leading spacing when a cached page boundary follows a section break.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -413,6 +413,31 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments[0]?.y).toBe(DEFAULT_MARGINS.top + 24);
     });
 
+    test("rendered page break consumes inherited spacing after a section boundary", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before section", 1),
+        { kind: "sectionBreak", id: 1, type: "nextPage" },
+        {
+          ...makeParagraphBlock(2, "First paragraph in section", 17),
+          attrs: {
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+          },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 14, 100, 24)]),
+        { kind: "sectionBreak" },
+        makeParagraphMeasure([makeLine(0, 0, 0, 26, 120, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments[0]?.blockId).toBe(2);
+      expect(layout.pages[1]?.fragments[0]?.y).toBe(DEFAULT_MARGINS.top);
+    });
+
     test("stale rendered page break remains advisory when the paragraph fits", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Before break", 1),

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -123,9 +123,13 @@ describe("rendered break reconciliation", () => {
     expect(decision.suppressSpaceBefore).toBe(true);
   });
 
-  test("a section boundary does not consume authored paragraph spacing", () => {
+  test("a section boundary preserves explicit paragraph spacing", () => {
     const previous: FlowBlock = { kind: "sectionBreak", id: 1, type: "nextPage" };
-    const marker = paragraph(2, { renderedPageBreakBefore: true });
+    const marker = paragraph(2, {
+      renderedPageBreakBefore: true,
+      spacing: { before: 24 },
+      spacingExplicit: { before: true },
+    });
     const decision = reconcileBreakBeforeBlock({
       state: INITIAL_RENDERED_BREAK_STATE,
       block: marker,
@@ -140,12 +144,35 @@ describe("rendered break reconciliation", () => {
     expect(decision.suppressSpaceBefore).toBe(false);
   });
 
+  test("a section boundary consumes inherited paragraph spacing", () => {
+    const previous: FlowBlock = { kind: "sectionBreak", id: 1, type: "nextPage" };
+    const marker = paragraph(2, {
+      renderedPageBreakBefore: true,
+      spacing: { before: 24 },
+    });
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: marker,
+      previousBlock: previous,
+      page: page(),
+      blocksById: new Map(),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.suppressSpaceBefore).toBe(true);
+  });
+
   test("a continuous section boundary preserves spacing when the marker snaps", () => {
     const prior = paragraph(1);
     const previous: FlowBlock = { kind: "sectionBreak", id: 2, type: "continuous" };
     const decision = reconcileBreakBeforeBlock({
       state: INITIAL_RENDERED_BREAK_STATE,
-      block: paragraph(3, { renderedPageBreakBefore: true }),
+      block: paragraph(3, {
+        renderedPageBreakBefore: true,
+        spacingExplicit: { before: true },
+      }),
       previousBlock: previous,
       page: page([paragraphFragment(1)]),
       blocksById: new Map([["1", prior]]),

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -184,6 +184,26 @@ describe("rendered break reconciliation", () => {
     expect(decision.suppressSpaceBefore).toBe(false);
   });
 
+  test("a continuous section boundary preserves inherited spacing without a page advance", () => {
+    const prior = paragraph(1);
+    const previous: FlowBlock = { kind: "sectionBreak", id: 2, type: "continuous" };
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: paragraph(3, {
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+      }),
+      previousBlock: previous,
+      page: page([paragraphFragment(1)]),
+      blocksById: new Map([["1", prior]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.suppressSpaceBefore).toBe(false);
+  });
+
   test("a reflow boundary satisfies the next cached marker", () => {
     const previous = paragraph(1);
     const decision = reconcileBreakBeforeBlock({

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -68,10 +68,14 @@ export const reconcileBreakBeforeBlock = ({
     markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById);
   const followsAuthoredPageBreak = previousBlock?.kind === "pageBreak";
   const followsSectionBreak = previousBlock?.kind === "sectionBreak";
+  const followsPageBreakingSection = followsSectionBreak && previousBlock.type !== "continuous";
   const preserveSectionLeadingSpacing =
     followsSectionBreak && block.attrs?.spacingExplicit?.before === true;
   const markerAccountsForBoundary =
-    forcePageBreak || markerAlreadySatisfied || followsAuthoredPageBreak || followsSectionBreak;
+    forcePageBreak ||
+    markerAlreadySatisfied ||
+    followsAuthoredPageBreak ||
+    followsPageBreakingSection;
 
   return {
     forcePageBreak,

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -68,16 +68,16 @@ export const reconcileBreakBeforeBlock = ({
     markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById);
   const followsAuthoredPageBreak = previousBlock?.kind === "pageBreak";
   const followsSectionBreak = previousBlock?.kind === "sectionBreak";
+  const preserveSectionLeadingSpacing =
+    followsSectionBreak && block.attrs?.spacingExplicit?.before === true;
+  const markerAccountsForBoundary =
+    forcePageBreak || markerAlreadySatisfied || followsAuthoredPageBreak || followsSectionBreak;
 
   return {
     forcePageBreak,
-    // Suppress spacing only when this cached marker accounts for the current
-    // page boundary. A section boundary can also leave the cursor at the page
-    // top, but it does not make the following paragraph's authored spacing
-    // redundant.
-    suppressSpaceBefore:
-      !followsSectionBreak &&
-      (forcePageBreak || markerAlreadySatisfied || followsAuthoredPageBreak),
+    // The boundary consumes inherited/default leading spacing. Preserve only
+    // spacing authored directly on the first paragraph of a section.
+    suppressSpaceBefore: markerAccountsForBoundary && !preserveSectionLeadingSpacing,
     state: INITIAL_RENDERED_BREAK_STATE,
   };
 };


### PR DESCRIPTION
Distinguishes explicit section-leading paragraph spacing from inherited/default spacing while reconciling cached page boundaries. Adds focused unit and integration regressions for both cases.

CC on behalf of @jan-kubica