### PR TITLE
fix: preserve revisions inside inline content controls

### DIFF
--- a/.changeset/steady-controls-review.md
+++ b/.changeset/steady-controls-review.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve tracked insertions and deletions inside inline DOCX content controls.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -467,7 +467,7 @@ export type ImageWrap = {
 export type InlineSdt = {
     type: "inlineSdt"; /** SDT properties */
     properties: SdtProperties; /** Inline content held inside the control */
-    content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | MathEquation)[];
+    content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | Insertion | Deletion | MathEquation)[];
 };
 
 // @public

--- a/packages/core/src/docx/inlineSdtTrackedChanges.test.ts
+++ b/packages/core/src/docx/inlineSdtTrackedChanges.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { Document, InlineSdt, Paragraph } from "../types/document";
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { createEmptyDocument } from "../utils/createDocument";
+import { parseDocx } from "./parser";
+import { createDocx } from "./rezip";
+
+const reviewedDocument = (): Document => {
+  const template = createEmptyDocument();
+  return {
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "inlineSdt",
+                properties: {
+                  sdtType: "richText",
+                  alias: "Reviewed clause",
+                  tag: "reviewed-clause",
+                  id: 42,
+                },
+                content: [
+                  { type: "run", content: [{ type: "text", text: "Clause " }] },
+                  {
+                    type: "deletion",
+                    info: { id: 1, author: "Reviewer", date: "2026-07-14T08:00:00Z" },
+                    content: [{ type: "run", content: [{ type: "text", text: "old" }] }],
+                  },
+                  {
+                    type: "insertion",
+                    info: { id: 2, author: "Reviewer", date: "2026-07-14T08:01:00Z" },
+                    content: [{ type: "run", content: [{ type: "text", text: "new" }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+};
+
+const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const part = zip.file("word/document.xml");
+  if (!part) {
+    throw new Error("missing word/document.xml");
+  }
+  return part.async("text");
+};
+
+const firstInlineSdt = (paragraph: Paragraph): InlineSdt => {
+  const sdt = paragraph.content.find((content) => content.type === "inlineSdt");
+  if (!sdt || sdt.type !== "inlineSdt") {
+    throw new Error("missing inline content control");
+  }
+  return sdt;
+};
+
+const inlineSdtText = (sdt: InlineSdt): string =>
+  sdt.content
+    .flatMap((content) => {
+      if (content.type === "run") {
+        return content.content;
+      }
+      if (content.type === "insertion" || content.type === "deletion") {
+        return content.content.flatMap((run) => (run.type === "run" ? run.content : []));
+      }
+      return [];
+    })
+    .map((content) => (content.type === "text" ? content.text : ""))
+    .join("");
+
+const parsedInlineSdt = async (buffer: ArrayBuffer): Promise<InlineSdt> => {
+  const parsed = await parseDocx(buffer, { detectVariables: false, preloadFonts: false });
+  const paragraph = parsed.package.document.content.at(0);
+  if (paragraph?.type !== "paragraph") {
+    throw new Error("missing paragraph");
+  }
+  return firstInlineSdt(paragraph);
+};
+
+describe("inline content-control tracked changes", () => {
+  test("round-trips wrappers inside w:sdtContent", async () => {
+    const buffer = await createDocx(reviewedDocument());
+    const xml = await documentXml(buffer);
+    const sdtContent = xml.match(/<w:sdtContent>([\s\S]*?)<\/w:sdtContent>/u)?.at(1) ?? "";
+
+    expect(sdtContent).toContain("<w:del ");
+    expect(sdtContent).toContain("<w:ins ");
+
+    const parsed = await parsedInlineSdt(buffer);
+    expect(parsed.content.map((content) => content.type)).toEqual([
+      "run",
+      "deletion",
+      "insertion",
+    ]);
+  });
+
+  test("accept and reject keep the content control with the correct text", async () => {
+    const buffer = await createDocx(reviewedDocument());
+
+    const accepting = await FolioDocxReviewer.fromBuffer(buffer);
+    expect(accepting.getChanges()).toHaveLength(2);
+    expect(accepting.acceptAll()).toBe(2);
+    const accepted = await accepting.toBuffer();
+    const acceptedSdt = await parsedInlineSdt(accepted);
+    expect(inlineSdtText(acceptedSdt)).toBe("Clause new");
+    expect(acceptedSdt.content.every((content) => content.type === "run")).toBe(true);
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(buffer);
+    expect(rejecting.getChanges()).toHaveLength(2);
+    expect(rejecting.rejectAll()).toBe(2);
+    const rejected = await rejecting.toBuffer();
+    const rejectedSdt = await parsedInlineSdt(rejected);
+    expect(inlineSdtText(rejectedSdt)).toBe("Clause old");
+    expect(rejectedSdt.content.every((content) => content.type === "run")).toBe(true);
+  });
+});

--- a/packages/core/src/docx/inlineSdtTrackedChanges.test.ts
+++ b/packages/core/src/docx/inlineSdtTrackedChanges.test.ts
@@ -99,11 +99,7 @@ describe("inline content-control tracked changes", () => {
     expect(sdtContent).toContain("<w:ins ");
 
     const parsed = await parsedInlineSdt(buffer);
-    expect(parsed.content.map((content) => content.type)).toEqual([
-      "run",
-      "deletion",
-      "insertion",
-    ]);
+    expect(parsed.content.map((content) => content.type)).toEqual(["run", "deletion", "insertion"]);
   });
 
   test("accept and reject keep the content control with the correct text", async () => {

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -363,10 +363,7 @@ describe("parseParagraph SDT content preservation", () => {
     if (sdt?.type !== "inlineSdt") {
       return;
     }
-    expect(sdt.content.map((content) => content.type)).toEqual([
-      "insertion",
-      "deletion",
-    ]);
+    expect(sdt.content.map((content) => content.type)).toEqual(["insertion", "deletion"]);
   });
 
   test("keeps a simple field that lives inside an inline SDT", () => {

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -344,6 +344,31 @@ describe("parseParagraph spacing explicit flags", () => {
 // docProps-bound title fields (and similar template content) lost their
 // wrapper on parse.
 describe("parseParagraph SDT content preservation", () => {
+  test("keeps tracked run changes inside an inline SDT", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="reviewed-control"/></w:sdtPr>
+          <w:sdtContent>
+            <w:ins w:id="1" w:author="Reviewer"><w:r><w:t>added</w:t></w:r></w:ins>
+            <w:del w:id="2" w:author="Reviewer"><w:r><w:delText>removed</w:delText></w:r></w:del>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `);
+
+    expect(paragraph.content).toHaveLength(1);
+    const sdt = paragraph.content.at(0);
+    expect(sdt?.type).toBe("inlineSdt");
+    if (sdt?.type !== "inlineSdt") {
+      return;
+    }
+    expect(sdt.content.map((content) => content.type)).toEqual([
+      "insertion",
+      "deletion",
+    ]);
+  });
+
   test("keeps a simple field that lives inside an inline SDT", () => {
     const paragraph = parseParagraphXml(`
       <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1018,10 +1018,11 @@ function isTrackedChangeWrapperChild(content: ParagraphContent): content is Run 
 
 // Mirror of upstream eigenpal/docx-editor PR #482 (commit 29f95751d):
 // OOXML allows runs, hyperlinks, simple/complex fields, nested SDTs,
-// and math equations directly inside `<w:sdtContent>`. Anything else
-// that the paragraph parser produced (bookmarks, comment markers,
-// tracked-change wrappers, ...) is lifted out as a sibling of the SDT
-// so the SDT wrapper itself stays valid for round-trip serialization.
+// tracked insertions/deletions, and math equations directly inside
+// `<w:sdtContent>`. Anything else that the paragraph parser produced
+// (bookmarks, comment markers, tracked-change range markers, ...) is
+// lifted out as a sibling of the SDT so the SDT wrapper itself stays
+// valid for round-trip serialization.
 function isInlineSdtContent(content: ParagraphContent): content is InlineSdt["content"][number] {
   return (
     content.type === "run" ||
@@ -1029,6 +1030,8 @@ function isInlineSdtContent(content: ParagraphContent): content is InlineSdt["co
     content.type === "simpleField" ||
     content.type === "complexField" ||
     content.type === "inlineSdt" ||
+    content.type === "insertion" ||
+    content.type === "deletion" ||
     content.type === "mathEquation"
   );
 }

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -865,6 +865,10 @@ function serializeInlineSdt(sdt: InlineSdt): string {
           return serializeComplexField(item);
         case "inlineSdt":
           return serializeInlineSdt(item);
+        case "insertion":
+          return serializeTrackedChange("ins", item);
+        case "deletion":
+          return serializeTrackedChange("del", item);
         case "mathEquation":
           // Round-trip the raw OMML XML directly
           return item.ommlXml || "";

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -90,6 +90,50 @@ describe("fromProseDoc", () => {
     expect(() => fromProseDoc(pmDoc)).toThrow("sdt.attrs.listItems[0].displayText");
   });
 
+  test("keeps tracked run changes inside inline content controls", () => {
+    const insertion = schema.mark("insertion", {
+      revisionId: 11,
+      author: "Reviewer",
+      date: "2026-07-14T08:00:00Z",
+      moveKind: null,
+    });
+    const deletion = schema.mark("deletion", {
+      revisionId: 12,
+      author: "Reviewer",
+      date: null,
+      moveKind: null,
+    });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("sdt", { sdtType: "richText", tag: "reviewed-control" }, [
+          schema.text("added", [insertion]),
+          schema.text("removed", [deletion]),
+        ]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const paragraph = document.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    const sdt = paragraph.content.at(0);
+    expect(sdt?.type).toBe("inlineSdt");
+    if (sdt?.type !== "inlineSdt") {
+      return;
+    }
+    expect(sdt.content.map((content) => content.type)).toEqual(["insertion", "deletion"]);
+    expect(sdt.content.at(0)).toMatchObject({
+      type: "insertion",
+      info: { id: 11, author: "Reviewer", date: "2026-07-14T08:00:00Z" },
+    });
+    expect(sdt.content.at(1)).toMatchObject({
+      type: "deletion",
+      info: { id: 12, author: "Reviewer" },
+    });
+  });
+
   test("round-trips paragraph automatic-hyphenation suppression through ProseMirror", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1635,10 +1635,10 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   }
 
   // Extract content from the sdt node's children. OOXML allows runs,
-  // hyperlinks, simple/complex fields, nested SDTs, and math here — keep
-  // all of them so docProps-bound fields and similar template content
-  // survive a round-trip through the editor. Keep this filter in sync
-  // with the exhaustive switch in `serializeInlineSdt`.
+  // hyperlinks, simple/complex fields, nested SDTs, tracked changes,
+  // and math here. Keep all of them so docProps-bound fields and reviewed
+  // template content survive a round-trip through the editor. Keep this
+  // filter in sync with the exhaustive switch in `serializeInlineSdt`.
   const sdtContent = extractParagraphContent(node);
   const content = sdtContent.filter(
     (c): c is InlineSdt["content"][number] =>
@@ -1647,6 +1647,8 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
       c.type === "simpleField" ||
       c.type === "complexField" ||
       c.type === "inlineSdt" ||
+      c.type === "insertion" ||
+      c.type === "deletion" ||
       c.type === "mathEquation",
   );
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -1375,6 +1375,53 @@ describe("toProseDoc", () => {
     expect(sdt?.firstChild?.text).toBe("Controlled");
   });
 
+  test("converts tracked run changes inside inline content controls", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "inlineSdt",
+                  properties: { sdtType: "richText" },
+                  content: [
+                    {
+                      type: "insertion",
+                      info: { id: 1, author: "Reviewer" },
+                      content: [{ type: "run", content: [{ type: "text", text: "added" }] }],
+                    },
+                    {
+                      type: "deletion",
+                      info: { id: 2, author: "Reviewer" },
+                      content: [{ type: "run", content: [{ type: "text", text: "removed" }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const sdt = toProseDoc(document).firstChild?.firstChild;
+    expect(sdt?.type.name).toBe("sdt");
+    expect(sdt?.textContent).toBe("addedremoved");
+    expect(
+      Array.from({ length: sdt?.childCount ?? 0 }, (_, index) =>
+        sdt?.child(index).marks.map((mark) => ({
+          type: mark.type.name,
+          moveKind: mark.attrs.moveKind,
+        })),
+      ),
+    ).toEqual([
+      [{ type: "insertion", moveKind: null }],
+      [{ type: "deletion", moveKind: null }],
+    ]);
+  });
+
   test("anchors point comments to nearby text for display", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -1416,10 +1416,7 @@ describe("toProseDoc", () => {
           moveKind: mark.attrs.moveKind,
         })),
       ),
-    ).toEqual([
-      [{ type: "insertion", moveKind: null }],
-      [{ type: "deletion", moveKind: null }],
-    ]);
+    ).toEqual([[{ type: "insertion", moveKind: null }], [{ type: "deletion", moveKind: null }]]);
   });
 
   test("anchors point comments to nearby text for display", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2033,21 +2033,11 @@ function convertInlineSdt(
       }
     } else if (content.type === "insertion") {
       inlineNodes.push(
-        ...convertTrackedChange(
-          content,
-          "insertion",
-          getInheritedRunFormatting,
-          styleResolver,
-        ),
+        ...convertTrackedChange(content, "insertion", getInheritedRunFormatting, styleResolver),
       );
     } else if (content.type === "deletion") {
       inlineNodes.push(
-        ...convertTrackedChange(
-          content,
-          "deletion",
-          getInheritedRunFormatting,
-          styleResolver,
-        ),
+        ...convertTrackedChange(content, "deletion", getInheritedRunFormatting, styleResolver),
       );
     } else {
       // content.type === "mathEquation" — narrowed by exhaustion of the

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2031,6 +2031,24 @@ function convertInlineSdt(
       if (nestedSdt) {
         inlineNodes.push(nestedSdt);
       }
+    } else if (content.type === "insertion") {
+      inlineNodes.push(
+        ...convertTrackedChange(
+          content,
+          "insertion",
+          getInheritedRunFormatting,
+          styleResolver,
+        ),
+      );
+    } else if (content.type === "deletion") {
+      inlineNodes.push(
+        ...convertTrackedChange(
+          content,
+          "deletion",
+          getInheritedRunFormatting,
+          styleResolver,
+        ),
+      );
     } else {
       // content.type === "mathEquation" — narrowed by exhaustion of the
       // InlineSdt['content'] union above.

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1222,16 +1222,25 @@ export type SdtProperties = {
  * Inline SDT (content control within a paragraph).
  *
  * OOXML allows runs, hyperlinks, simple/complex fields, nested SDTs,
- * and math at this level. All of them must survive parse → edit → save
- * so docProps-bound fields and similar template content do not lose
- * their wrapper on round-trip.
+ * tracked insertions/deletions, and math at this level. All of them must survive
+ * parse → edit → save so docProps-bound fields and reviewed template
+ * content do not lose their wrapper on round-trip.
  */
 export type InlineSdt = {
   type: "inlineSdt";
   /** SDT properties */
   properties: SdtProperties;
   /** Inline content held inside the control */
-  content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | MathEquation)[];
+  content: (
+    | Run
+    | Hyperlink
+    | SimpleField
+    | ComplexField
+    | InlineSdt
+    | Insertion
+    | Deletion
+    | MathEquation
+  )[];
 };
 
 /**


### PR DESCRIPTION
## Summary

- preserve tracked insertions and deletions nested inside inline content controls
- round-trip revision metadata through ProseMirror conversion and DOCX serialization
- cover parsing, conversion, serialization, and accept/reject behavior

## Testing

- `bun test packages/core/src/docx/inlineSdtTrackedChanges.test.ts packages/core/src/docx/paragraphParser.test.ts packages/core/src/prosemirror/conversion/toProseDoc.test.ts packages/core/src/prosemirror/conversion/fromProseDoc.test.ts`
- `bun audit`