### PR TITLE
fix: carry rendered breaks across empty paragraphs

### DIFF
--- a/.changeset/calm-rendered-break-carriers.md
+++ b/.changeset/calm-rendered-break-carriers.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve cached page-boundary reconciliation across empty carrier paragraphs.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -387,6 +387,36 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1].fragments[0].y).toBe(DEFAULT_MARGINS.top);
     });
 
+    test("rendered page break reuses an authored boundary across an empty carrier", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Before break", 1),
+        { kind: "pageBreak", id: 1, pmStart: 15, pmEnd: 16 },
+        {
+          ...makeParagraphBlock(2, "", 17),
+          runs: [],
+        },
+        {
+          ...makeParagraphBlock(3, "Cached next page", 18),
+          attrs: {
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+          },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+        { kind: "pageBreak" },
+        makeParagraphMeasure([]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[1]?.fragments.at(-1)?.blockId).toBe(3);
+      expect(layout.pages[1]?.fragments.at(-1)?.y).toBe(DEFAULT_MARGINS.top);
+    });
+
     test("rendered page break preserves leading spacing after a section boundary", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Before section", 1),

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -204,6 +204,159 @@ describe("rendered break reconciliation", () => {
     expect(decision.suppressSpaceBefore).toBe(false);
   });
 
+  test("an authored page boundary remains satisfied across an empty carrier", () => {
+    const empty = paragraph(2, {}, []);
+    const boundaryState = reconcileAfterBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: { kind: "pageBreak", id: 1 },
+      pageNumberBefore: 1,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const carriedState = reconcileAfterBlock({
+      state: boundaryState,
+      block: empty,
+      pageNumberBefore: 2,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const decision = reconcileBreakBeforeBlock({
+      state: carriedState,
+      block: paragraph(3, {
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+      }),
+      previousBlock: empty,
+      page: page([paragraphFragment(2)]),
+      blocksById: new Map([["2", empty]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.suppressSpaceBefore).toBe(true);
+    expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
+  test("an authored section boundary preserves explicit spacing across an empty carrier", () => {
+    const empty = paragraph(2, {}, []);
+    const boundaryState = reconcileAfterBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: { kind: "sectionBreak", id: 1, type: "nextPage" },
+      pageNumberBefore: 1,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const decision = reconcileBreakBeforeBlock({
+      state: reconcileAfterBlock({
+        state: boundaryState,
+        block: empty,
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+      block: paragraph(3, {
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+        spacingExplicit: { before: true },
+      }),
+      previousBlock: empty,
+      page: page([paragraphFragment(2)]),
+      blocksById: new Map([["2", empty]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.suppressSpaceBefore).toBe(false);
+  });
+
+  test("a coalesced section boundary upgrades carried section-spacing semantics", () => {
+    const empty = paragraph(2, {}, []);
+    const pageBreakState = reconcileAfterBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: { kind: "pageBreak", id: 1 },
+      pageNumberBefore: 1,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const sectionState = reconcileAfterBlock({
+      state: pageBreakState,
+      block: { kind: "sectionBreak", id: 2, type: "continuous" },
+      pageNumberBefore: 2,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const decision = reconcileBreakBeforeBlock({
+      state: reconcileAfterBlock({
+        state: sectionState,
+        block: empty,
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+      block: paragraph(3, {
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+        spacingExplicit: { before: true },
+      }),
+      previousBlock: empty,
+      page: page([paragraphFragment(2)]),
+      blocksById: new Map([["2", empty]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(sectionState).toEqual({
+      type: "pageAdvance",
+      reason: "authoredBoundary",
+      boundary: "sectionBreak",
+    });
+    expect(decision.suppressSpaceBefore).toBe(false);
+  });
+
+  test("a same-page column boundary preserves carried hard-break semantics", () => {
+    const empty = paragraph(3, {}, []);
+    const pageBreakState = reconcileAfterBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: { kind: "pageBreak", id: 1 },
+      pageNumberBefore: 1,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const columnState = reconcileAfterBlock({
+      state: pageBreakState,
+      block: { kind: "columnBreak", id: 2 },
+      pageNumberBefore: 2,
+      pageNumberAfter: 2,
+      previousPage: page(),
+    });
+    const decision = reconcileBreakBeforeBlock({
+      state: reconcileAfterBlock({
+        state: columnState,
+        block: empty,
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+      block: paragraph(4, {
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+      }),
+      previousBlock: empty,
+      page: page([paragraphFragment(3)]),
+      blocksById: new Map([["3", empty]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(columnState).toEqual({
+      type: "pageAdvance",
+      reason: "authoredBoundary",
+      boundary: "hardBreak",
+    });
+    expect(decision.suppressSpaceBefore).toBe(true);
+  });
+
   test("a reflow boundary satisfies the next cached marker", () => {
     const previous = paragraph(1);
     const decision = reconcileBreakBeforeBlock({
@@ -309,7 +462,7 @@ describe("rendered break state transitions", () => {
     ).toEqual({ type: "pageAdvance", reason: "reflowBoundary" });
   });
 
-  test("structural breaks clear accumulated movement", () => {
+  test("page-breaking structural blocks record an authored boundary", () => {
     const block: FlowBlock = { kind: "pageBreak", id: 2 };
     expect(
       reconcileAfterBlock({
@@ -317,6 +470,90 @@ describe("rendered break state transitions", () => {
         block,
         pageNumberBefore: 1,
         pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+    ).toEqual({
+      type: "pageAdvance",
+      reason: "authoredBoundary",
+      boundary: "hardBreak",
+    });
+  });
+
+  test("a visible block consumes an authored boundary before a later marker", () => {
+    expect(
+      reconcileAfterBlock({
+        state: {
+          type: "pageAdvance",
+          reason: "authoredBoundary",
+          boundary: "hardBreak",
+        },
+        block: paragraph(2),
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+    ).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
+  test("a visible list marker consumes an authored boundary on a run-empty paragraph", () => {
+    expect(
+      reconcileAfterBlock({
+        state: {
+          type: "pageAdvance",
+          reason: "authoredBoundary",
+          boundary: "hardBreak",
+        },
+        block: paragraph(2, { listMarker: "1." }, []),
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+    ).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
+  test("visible shading consumes an authored boundary on a run-empty paragraph", () => {
+    expect(
+      reconcileAfterBlock({
+        state: {
+          type: "pageAdvance",
+          reason: "authoredBoundary",
+          boundary: "hardBreak",
+        },
+        block: paragraph(2, { shading: "#FFFF00" }, []),
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+    ).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
+  test("a visible border consumes an authored boundary on a run-empty paragraph", () => {
+    expect(
+      reconcileAfterBlock({
+        state: {
+          type: "pageAdvance",
+          reason: "authoredBoundary",
+          boundary: "hardBreak",
+        },
+        block: paragraph(
+          2,
+          { borders: { bottom: { style: "solid", width: 1, color: "#000000" } } },
+          [],
+        ),
+        pageNumberBefore: 2,
+        pageNumberAfter: 2,
+        previousPage: page(),
+      }),
+    ).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
+  test("a non-page-breaking structural block clears accumulated movement", () => {
+    expect(
+      reconcileAfterBlock({
+        state: { type: "pageAdvance", reason: "ordinary" },
+        block: { kind: "sectionBreak", id: 2, type: "continuous" },
+        pageNumberBefore: 1,
+        pageNumberAfter: 1,
         previousPage: page(),
       }),
     ).toEqual(INITIAL_RENDERED_BREAK_STATE);

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -1,10 +1,14 @@
-import { isEmptyParagraph } from "./paragraphSpacing";
 import { continuesNumberedSequence, continuesTabbedParagraphSequence } from "./paragraphSequence";
 import type { FlowBlock, Page, ParagraphBlock } from "./types";
 
 export type RenderedBreakState =
   | { type: "noPageAdvance" }
-  | { type: "pageAdvance"; reason: "ordinary" | "reflowBoundary" };
+  | { type: "pageAdvance"; reason: "ordinary" | "reflowBoundary" }
+  | {
+      type: "pageAdvance";
+      reason: "authoredBoundary";
+      boundary: "hardBreak" | "sectionBreak";
+    };
 
 export const INITIAL_RENDERED_BREAK_STATE: RenderedBreakState = {
   type: "noPageAdvance",
@@ -56,6 +60,7 @@ export const reconcileBreakBeforeBlock = ({
 
   const markerAlreadySatisfied =
     pageStartsWithPreviousParagraphContinuation(page, previousBlock) ||
+    (state.type === "pageAdvance" && state.reason === "authoredBoundary") ||
     (state.type === "pageAdvance" && state.reason === "reflowBoundary") ||
     (state.type === "pageAdvance" && isPaginationEmptyParagraph(block)) ||
     (state.type === "pageAdvance" &&
@@ -69,8 +74,13 @@ export const reconcileBreakBeforeBlock = ({
   const followsAuthoredPageBreak = previousBlock?.kind === "pageBreak";
   const followsSectionBreak = previousBlock?.kind === "sectionBreak";
   const followsPageBreakingSection = followsSectionBreak && previousBlock.type !== "continuous";
+  const followsCarriedSectionBoundary =
+    state.type === "pageAdvance" &&
+    state.reason === "authoredBoundary" &&
+    state.boundary === "sectionBreak";
   const preserveSectionLeadingSpacing =
-    followsSectionBreak && block.attrs?.spacingExplicit?.before === true;
+    (followsSectionBreak || followsCarriedSectionBoundary) &&
+    block.attrs?.spacingExplicit?.before === true;
   const markerAccountsForBoundary =
     forcePageBreak ||
     markerAlreadySatisfied ||
@@ -100,7 +110,7 @@ type ReconcileAfterBlockOptions = {
   previousPage: Page | undefined;
 };
 
-/** Record page movement caused by laying out a block, or reset at a structural break. */
+/** Record page movement and carry authored boundaries across pagination-empty paragraphs. */
 export const reconcileAfterBlock = ({
   state,
   block,
@@ -109,10 +119,25 @@ export const reconcileAfterBlock = ({
   previousPage,
 }: ReconcileAfterBlockOptions): RenderedBreakState => {
   if (isStructuralBreak(block)) {
-    return INITIAL_RENDERED_BREAK_STATE;
+    if (pageNumberAfter <= pageNumberBefore) {
+      if (state.type === "pageAdvance" && state.reason === "authoredBoundary") {
+        return block.kind === "sectionBreak" ? { ...state, boundary: "sectionBreak" } : state;
+      }
+      return INITIAL_RENDERED_BREAK_STATE;
+    }
+    return {
+      type: "pageAdvance",
+      reason: "authoredBoundary",
+      boundary: block.kind === "sectionBreak" ? "sectionBreak" : "hardBreak",
+    };
   }
-  if (!isVisibleBodyBlock(block) || pageNumberAfter <= pageNumberBefore) {
+  if (block.kind === "paragraph" && isPaginationEmptyParagraph(block)) {
     return state;
+  }
+  if (pageNumberAfter <= pageNumberBefore) {
+    return state.type === "pageAdvance" && state.reason === "authoredBoundary"
+      ? INITIAL_RENDERED_BREAK_STATE
+      : state;
   }
 
   const blockContinuedAcrossBoundary = previousPage?.fragments.some(
@@ -125,12 +150,33 @@ export const reconcileAfterBlock = ({
 };
 
 const isPaginationEmptyParagraph = (block: ParagraphBlock): boolean =>
+  !hasVisibleEmptyParagraphDecoration(block) &&
   block.runs.every((run) => {
     if (run.kind === "text") {
       return run.text.trim().length === 0;
     }
     return run.kind === "tab" || run.kind === "lineBreak";
   });
+
+const hasVisibleEmptyParagraphDecoration = (block: ParagraphBlock): boolean => {
+  if (
+    block.attrs?.listMarker !== undefined &&
+    block.attrs.listMarker.length > 0 &&
+    block.attrs.listMarkerHidden !== true
+  ) {
+    return true;
+  }
+  if (block.attrs?.shading) {
+    return true;
+  }
+  return Object.values(block.attrs?.borders ?? {}).some(
+    (border) =>
+      border !== undefined &&
+      border.style !== "none" &&
+      border.style !== "nil" &&
+      border.width !== 0,
+  );
+};
 
 const pageHasVisibleBodyContent = (
   page: Page,
@@ -166,10 +212,3 @@ const pageStartsWithPreviousParagraphContinuation = (
 
 const isStructuralBreak = (block: FlowBlock): boolean =>
   block.kind === "pageBreak" || block.kind === "columnBreak" || block.kind === "sectionBreak";
-
-const isVisibleBodyBlock = (block: FlowBlock): boolean => {
-  if (block.kind === "paragraph") {
-    return !isEmptyParagraph(block);
-  }
-  return !isStructuralBreak(block);
-};


### PR DESCRIPTION
Carries authored page-boundary state across pagination-empty carrier paragraphs so cached break markers reconcile against the boundary that opened the page. The state is consumed by the marker or first visible block, while explicit section-leading spacing remains preserved. Adds focused state-transition and layout regressions.

CC on behalf of @jan-kubica