### PR TITLE
fix: honor table-cell image anchor scope

### DIFF
--- a/.changeset/calm-cell-anchors.md
+++ b/.changeset/calm-cell-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor table-cell positioning scope for anchored images.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -337,7 +337,8 @@ export type ImageRun = {
     alt?: string; /** CSS transform string (rotation, flip) */
     transform?: string;
     opacity?: number; /** Position for floating/anchored images */
-    position?: ImageRunPosition; /** Wrap type from DOCX (inline, square, tight, through, topAndBottom, etc.) */
+    position?: ImageRunPosition; /** Whether a table-cell anchor uses the cell as its positioning scope. Undefined defaults true. */
+    layoutInCell?: boolean; /** Wrap type from DOCX (inline, square, tight, through, topAndBottom, etc.) */
     wrapType?: ImageWrap["type"]; /** Display mode for CSS rendering */
     displayMode?: "inline" | "block" | "float"; /** CSS float direction */
     cssFloat?: "left" | "right" | "none"; /** Wrap distances in pixels */

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -140,7 +140,8 @@ export type ImageAttrs = {
     cropRight?: number;
     cropBottom?: number;
     cropLeft?: number; /** Position for floating images (horizontal and vertical alignment) */
-    position?: ImagePositionAttrs; /** Border width in pixels */
+    position?: ImagePositionAttrs; /** Use the containing table cell as the anchor's positioning scope (the OOXML default). */
+    layoutInCell?: boolean; /** Border width in pixels */
     borderWidth?: number; /** Border color as CSS color string */
     borderColor?: string; /** Border style (CSS border-style value) */
     borderStyle?: string; /** Wrap text setting from DOCX (left, right, bothSides, largest) for round-trip */

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -225,7 +225,8 @@ export type ImageAttrs = {
     cropRight?: number;
     cropBottom?: number;
     cropLeft?: number; /** Position for floating images (horizontal and vertical alignment) */
-    position?: ImagePositionAttrs; /** Border width in pixels */
+    position?: ImagePositionAttrs; /** Use the containing table cell as the anchor's positioning scope (the OOXML default). */
+    layoutInCell?: boolean; /** Border width in pixels */
     borderWidth?: number; /** Border color as CSS color string */
     borderColor?: string; /** Border style (CSS border-style value) */
     borderStyle?: string; /** Wrap text setting from DOCX (left, right, bothSides, largest) for round-trip */

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1895,6 +1895,29 @@ describe("toFlowBlocks image attribute normalization", () => {
     expect(imageRun.opacity).toBe(0.5);
   });
 
+  test("preserves authored table-cell anchor scope on image runs", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.nodes.image.create({
+          src: "media/image.png",
+          width: 100,
+          height: 100,
+          wrapType: "square",
+          displayMode: "float",
+          layoutInCell: false,
+        }),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const imageRun = paragraph.runs.find((run) => run.kind === "image");
+
+    expect(imageRun?.layoutInCell).toBe(false);
+  });
+
   test("marks embedded-object previews for exact line-height measurement", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -916,6 +916,9 @@ function buildImageRun(
   if (attrs.position !== undefined) {
     run.position = attrs.position;
   }
+  if (attrs.layoutInCell !== undefined) {
+    run.layoutInCell = attrs.layoutInCell;
+  }
   if (trackedChange?.isInsertion) {
     run.isInsertion = true;
   }

--- a/packages/core/src/layout-engine/measure/tableCellFloating.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFloating.ts
@@ -35,6 +35,53 @@ export type ResolveTableCellFloatingPosition = (
   paragraphY: number,
 ) => TableCellFloatingPosition;
 
+type ResolveCellScopedPositionOptions = {
+  run: ImageRun;
+  paragraphY: number;
+  contentWidth: number;
+};
+
+const resolveCellScopedPosition = ({
+  run,
+  paragraphY,
+  contentWidth,
+}: ResolveCellScopedPositionOptions): TableCellFloatingPosition => {
+  const position = run.position;
+  let side: "left" | "right" = "left";
+  let x = 0;
+  if (position?.horizontal) {
+    const horizontal = position.horizontal;
+    if (horizontal.align === "right") {
+      side = "right";
+      x = contentWidth - run.width;
+    } else if (horizontal.align === "center") {
+      x = (contentWidth - run.width) / 2;
+    } else if (horizontal.posOffset !== undefined) {
+      x = emuToPixels(horizontal.posOffset);
+      side = x > contentWidth / 2 ? "right" : "left";
+    }
+  } else if (run.cssFloat === "right") {
+    side = "right";
+    x = contentWidth - run.width;
+  }
+
+  let y = paragraphY;
+  if (position?.vertical) {
+    const vertical = position.vertical;
+    if (vertical.posOffset !== undefined) {
+      y = paragraphY + emuToPixels(vertical.posOffset);
+    } else if (vertical.align === "top") {
+      y = 0;
+    }
+  }
+
+  return {
+    side,
+    x,
+    y,
+  };
+};
+
 export function getTableCellContentWidth(
   cell: TableCell | undefined,
   cellMeasure: TableCellMeasure,
@@ -69,48 +116,21 @@ export function getTableCellFloatingImages(
         continue;
       }
 
-      const position = run.position;
       const distTop = run.distTop ?? 0;
       const distBottom = run.distBottom ?? 0;
       const distLeft = run.distLeft ?? 12;
       const distRight = run.distRight ?? 12;
+      const verticalOriginY =
+        run.position?.vertical?.relativeTo === "paragraph" ? placement.top : placement.contentTop;
 
-      let side: "left" | "right";
-      let x: number;
-      let y: number;
-      if (resolvePosition) {
-        ({ side, x, y } = resolvePosition(run, placement.contentTop));
-      } else {
-        side = "left";
-        x = 0;
-        if (position?.horizontal) {
-          const horizontal = position.horizontal;
-          if (horizontal.align === "right") {
-            side = "right";
-            x = contentWidth - run.width;
-          } else if (horizontal.align === "center") {
-            x = (contentWidth - run.width) / 2;
-          } else if (horizontal.posOffset !== undefined) {
-            x = emuToPixels(horizontal.posOffset);
-            side = x > contentWidth / 2 ? "right" : "left";
-          }
-        } else if (run.cssFloat === "right") {
-          side = "right";
-          x = contentWidth - run.width;
-        }
-
-        y = placement.contentTop;
-        if (position?.vertical) {
-          const vertical = position.vertical;
-          if (vertical.posOffset !== undefined) {
-            y = placement.contentTop + emuToPixels(vertical.posOffset);
-          } else if (vertical.align === "top") {
-            y = 0;
-          }
-        }
-
-        x = Math.max(0, Math.min(x, contentWidth - run.width));
-      }
+      const resolved =
+        run.layoutInCell === false && resolvePosition
+          ? resolvePosition(run, verticalOriginY)
+          : resolveCellScopedPosition({
+              run,
+              paragraphY: verticalOriginY,
+              contentWidth,
+            });
 
       let wrapText: "bothSides" | "left" | "right" | "largest" = "bothSides";
       if (run.cssFloat === "left") {
@@ -130,9 +150,9 @@ export function getTableCellFloatingImages(
         ...(run.cropRight != null ? { cropRight: run.cropRight } : {}),
         ...(run.cropBottom != null ? { cropBottom: run.cropBottom } : {}),
         ...(run.cropLeft != null ? { cropLeft: run.cropLeft } : {}),
-        x,
-        y,
-        side,
+        x: resolved.x,
+        y: resolved.y,
+        side: resolved.side,
         distTop,
         distBottom,
         distLeft,

--- a/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
@@ -74,7 +74,7 @@ describe("table cell block flow", () => {
     expect(finishTableCellFlow(state)).toBe(28);
   });
 
-  test("uses collapsed paragraph placement for floating anchors", () => {
+  test("uses the paragraph box before leading spacing as its anchor origin", () => {
     const image: ImageRun = {
       kind: "image",
       src: "floating.png",
@@ -101,15 +101,78 @@ describe("table cell block flow", () => {
       width: 100,
       height: 32,
     };
-    let resolvedAnchor = 0;
+    let pageResolverCalled = false;
 
     const images = getTableCellFloatingImages(cell, cellMeasure, 100, (_run, paragraphY) => {
-      resolvedAnchor = paragraphY;
+      pageResolverCalled = true;
       return { side: "left", x: 0, y: paragraphY };
     });
 
-    expect(resolvedAnchor).toBe(22);
-    expect(images.at(0)?.y).toBe(22);
+    expect(pageResolverCalled).toBe(false);
+    expect(images.at(0)?.y).toBe(10);
+  });
+
+  test("delegates anchors that explicitly escape the table cell", () => {
+    const image: ImageRun = {
+      kind: "image",
+      src: "floating.png",
+      width: 20,
+      height: 20,
+      displayMode: "float",
+      wrapType: "square",
+      layoutInCell: false,
+      position: { vertical: { relativeTo: "paragraph", posOffset: 0 } },
+    };
+    const cell: TableCell = {
+      id: "cell",
+      blocks: [{ kind: "paragraph", id: "anchor", runs: [image] }],
+    };
+    const cellMeasure: TableCellMeasure = {
+      blocks: [measure(10)],
+      width: 100,
+      height: 10,
+    };
+
+    const images = getTableCellFloatingImages(cell, cellMeasure, 100, (_run, paragraphY) => ({
+      side: "right",
+      x: -40,
+      y: paragraphY + 5,
+    }));
+
+    expect(images.at(0)).toMatchObject({ x: -40, y: 5, side: "right" });
+  });
+
+  test("resolves default table-cell anchor offsets from the cell content origin", () => {
+    const image: ImageRun = {
+      kind: "image",
+      src: "floating.png",
+      width: 20,
+      height: 20,
+      displayMode: "float",
+      wrapType: "square",
+      position: {
+        horizontal: { relativeTo: "margin", posOffset: -914_400 },
+        vertical: { relativeTo: "paragraph", posOffset: 0 },
+      },
+    };
+    const cell: TableCell = {
+      id: "cell",
+      blocks: [{ kind: "paragraph", id: "anchor", runs: [image] }],
+    };
+    const cellMeasure: TableCellMeasure = {
+      blocks: [measure(10)],
+      width: 100,
+      height: 10,
+    };
+    let pageResolverCalled = false;
+
+    const images = getTableCellFloatingImages(cell, cellMeasure, 100, () => {
+      pageResolverCalled = true;
+      return { side: "left", x: -96, y: 0 };
+    });
+
+    expect(pageResolverCalled).toBe(false);
+    expect(images.at(0)).toMatchObject({ x: -96, y: 0, side: "left" });
   });
 
   test("keeps consecutive authored empty paragraphs as independent spacers", () => {

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -209,6 +209,8 @@ export type ImageRun = {
   opacity?: number;
   /** Position for floating/anchored images */
   position?: ImageRunPosition;
+  /** Whether a table-cell anchor uses the cell as its positioning scope. Undefined defaults true. */
+  layoutInCell?: boolean;
   /** Wrap type from DOCX (inline, square, tight, through, topAndBottom, etc.) */
   wrapType?: ImageWrap["type"];
   /** Display mode for CSS rendering */

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -894,7 +894,32 @@ describe("renderTableFragment cell floating images", () => {
     return rendered;
   };
 
-  test("resolves negative margin-relative offsets against page geometry", () => {
+  test("resolves cell-escaping offsets against page geometry", () => {
+    const table = renderFloatingImage(
+      {
+        kind: "image",
+        src: "floating.png",
+        width: 80,
+        height: 30,
+        displayMode: "float",
+        wrapType: "inFront",
+        layoutInCell: false,
+        position: {
+          horizontal: { relativeTo: "margin", posOffset: -457_200 },
+          vertical: { relativeTo: "paragraph", posOffset: 0 },
+        },
+      },
+      { pageGeometry },
+    );
+
+    const image = findByClass(table, "layout-cell-floating-image").at(0);
+    // The cell content starts 110px into the content area. The authored
+    // margin-relative offset is -48px, so the cell-local result is -158px.
+    expect(image?.style["left"]).toBe("-158px");
+    expect(image?.style["top"]).toBe("0px");
+  });
+
+  test("resolves default table-cell anchor offsets from the cell origin", () => {
     const table = renderFloatingImage(
       {
         kind: "image",
@@ -912,9 +937,7 @@ describe("renderTableFragment cell floating images", () => {
     );
 
     const image = findByClass(table, "layout-cell-floating-image").at(0);
-    // The cell content starts 110px into the content area. The authored
-    // margin-relative offset is -48px, so the cell-local result is -158px.
-    expect(image?.style["left"]).toBe("-158px");
+    expect(image?.style["left"]).toBe("-48px");
     expect(image?.style["top"]).toBe("0px");
   });
 

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -514,6 +514,7 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
   optionalNumber(attrs, "distLeft", "image.attrs.distLeft", issues);
   optionalNumber(attrs, "distRight", "image.attrs.distRight", issues);
   optionalImagePosition(attrs, "position", "image.attrs.position", issues);
+  optionalBoolean(attrs, "layoutInCell", "image.attrs.layoutInCell", issues);
   optionalNumber(attrs, "borderWidth", "image.attrs.borderWidth", issues);
   optionalString(attrs, "borderColor", "image.attrs.borderColor", issues);
   optionalString(attrs, "borderStyle", "image.attrs.borderStyle", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -10,6 +10,56 @@ import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
 describe("fromProseDoc", () => {
+  test("round-trips authored table-cell anchor scope through the editor model", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    {
+                      type: "drawing",
+                      image: {
+                        type: "image",
+                        rId: "rId1",
+                        size: { width: 914_400, height: 914_400 },
+                        wrap: { type: "square" },
+                        layoutInCell: true,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const imageNode = pmDoc.firstChild?.firstChild;
+    expect(imageNode?.attrs["layoutInCell"]).toBe(true);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const run = paragraph.content.at(0);
+    if (run?.type !== "run") {
+      throw new Error("Expected run");
+    }
+    const drawing = run.content.at(0);
+    if (drawing?.type !== "drawing" || drawing.image?.type !== "image") {
+      throw new Error("Expected image drawing");
+    }
+    expect(drawing.image.layoutInCell).toBe(true);
+  });
+
   test("rejects malformed paragraph attrs at the conversion boundary", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", { paraId: 12 }, [schema.text("invalid")]),

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1737,6 +1737,9 @@ function createImageRun(node: PMNode): Run {
   if (imagePosition) {
     image.position = imagePosition;
   }
+  if (attrs.layoutInCell !== undefined) {
+    image.layoutInCell = attrs.layoutInCell;
+  }
 
   // Round-trip border/outline
   if (attrs.borderWidth && attrs.borderWidth > 0) {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2453,6 +2453,7 @@ function convertImage(image: Image, rawXml?: string): PMNode {
     cropBottom: image.crop?.bottom,
     cropLeft: image.crop?.left,
     position,
+    layoutInCell: image.layoutInCell,
     borderWidth,
     borderColor,
     borderStyle,

--- a/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -35,6 +35,7 @@ export const ImageExtension = createNodeExtension({
       cropBottom: { default: null },
       cropLeft: { default: null },
       position: { default: null },
+      layoutInCell: { default: null },
       borderWidth: { default: null },
       borderColor: { default: null },
       borderStyle: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -306,6 +306,8 @@ export type ImageAttrs = {
   cropLeft?: number;
   /** Position for floating images (horizontal and vertical alignment) */
   position?: ImagePositionAttrs;
+  /** Use the containing table cell as the anchor's positioning scope (the OOXML default). */
+  layoutInCell?: boolean;
   /** Border width in pixels */
   borderWidth?: number;
   /** Border color as CSS color string */


### PR DESCRIPTION
Summary:
- preserve the authored table-cell anchor scope through the editor and layout models
- resolve default cell-scoped offsets from the cell origin while retaining explicit page-relative escape behavior
- use the paragraph box, before leading spacing, as the paragraph-relative anchor origin

Validation:
- 158 focused conversion, layout, and painter tests
- first-page geometry comparison: 1.00
- dependency audit: no vulnerabilities found
- formatting and diff checks

CC on behalf of @jan-kubica