### PR TITLE
fix: preserve subpixel border strokes

### DIFF
--- a/.changeset/quiet-authored-rule-strokes.md
+++ b/.changeset/quiet-authored-rule-strokes.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored subpixel border weight and paragraph rule extents.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-borderWidth.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-borderWidth.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+import { convertBorderSpecToLayout } from "./toFlowBlocks";
+
+describe("border width conversion", () => {
+  test("keeps eighth-point widths fractional in layout coordinates", () => {
+    expect(convertBorderSpecToLayout({ style: "single", size: 2 })?.width).toBeCloseTo(1 / 3);
+    expect(convertBorderSpecToLayout({ style: "single", size: 4 })?.width).toBeCloseTo(2 / 3);
+  });
+
+  test("uses a visible hairline when width is omitted", () => {
+    expect(convertBorderSpecToLayout({ style: "single" })?.width).toBe(1);
+  });
+});

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2041,9 +2041,7 @@ function reserveLeadingEmptyOutlineHeight(blocks: FlowBlock[]): void {
  * OOXML stores border widths in eighths of a point.
  */
 function borderWidthToPixels(eighthsOfPoint: number): number {
-  // 1 point = 1.333 pixels at 96 DPI
-  // eighths of a point: divide by 8 first
-  return Math.max(1, Math.round((eighthsOfPoint / 8) * 1.333));
+  return pointsToPixels(eighthsOfPoint / 8);
 }
 
 // OOXML border style → CSS border-style mapping
@@ -2088,7 +2086,7 @@ export function convertBorderSpecToLayout(
   }
   const result: BorderStyle = {
     style: OOXML_TO_CSS_BORDER[border.style] || "solid",
-    width: borderWidthToPixels(border.size ?? 0),
+    width: border.size === undefined ? 1 : borderWidthToPixels(border.size),
     color: border.color
       ? resolveColor(border.color as Parameters<typeof resolveColor>[0], theme)
       : "#000000",

--- a/packages/core/src/layout-painter/borderStroke.test.ts
+++ b/packages/core/src/layout-painter/borderStroke.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  borderStrokeToCss,
+  resolveCssBorderStroke,
+  resolveParagraphBorderHorizontalOutsets,
+} from "./borderStroke";
+
+describe("border stroke painting", () => {
+  test("projects authored subpixel width into optical coverage", () => {
+    expect(borderStrokeToCss({ width: 1 / 3, style: "solid", color: "#123456" })).toBe(
+      "1px solid color-mix(in srgb, #123456 33.3333%, transparent)",
+    );
+  });
+
+  test("keeps full-pixel and explicit hairline strokes opaque", () => {
+    expect(resolveCssBorderStroke({ width: 2, style: "dashed", color: "#123456" })).toEqual({
+      width: 2,
+      style: "dashed",
+      color: "#123456",
+    });
+    expect(resolveCssBorderStroke({ width: 0, style: "solid" })).toEqual({
+      width: 1,
+      style: "solid",
+      color: "#000000",
+    });
+  });
+
+  test("extends horizontal paragraph rules beyond text when side borders are absent", () => {
+    expect(resolveParagraphBorderHorizontalOutsets({ bottom: { width: 1 } }, true)).toEqual({
+      left: 2,
+      right: 2,
+    });
+    expect(
+      resolveParagraphBorderHorizontalOutsets(
+        { left: { width: 2, space: 3 }, bottom: { width: 1 } },
+        true,
+      ),
+    ).toEqual({ left: 5, right: 2 });
+  });
+});

--- a/packages/core/src/layout-painter/borderStroke.ts
+++ b/packages/core/src/layout-painter/borderStroke.ts
@@ -1,0 +1,63 @@
+import type { BorderStyle, ParagraphBorders } from "../layout-engine/types";
+import { pointsToPixels } from "../utils/units";
+
+type CssBorderStroke = {
+  color: string;
+  style: string;
+  width: number;
+};
+
+const DEFAULT_BORDER_COLOR = "#000000";
+const DEFAULT_BORDER_STYLE = "solid";
+const CSS_HAIRLINE_WIDTH = 1;
+const PARAGRAPH_RULE_ENDPOINT_OUTSET = pointsToPixels(1.5);
+
+/**
+ * Preserve the optical weight of authored subpixel borders. CSS quantizes a
+ * fractional border width to one device pixel, so its color carries the
+ * fractional coverage while layout keeps the authored width.
+ */
+export const resolveCssBorderStroke = (
+  border: Pick<BorderStyle, "color" | "style" | "width">,
+): CssBorderStroke => {
+  const authoredWidth = border.width ?? CSS_HAIRLINE_WIDTH;
+  if (authoredWidth <= 0 || authoredWidth >= CSS_HAIRLINE_WIDTH) {
+    return {
+      color: border.color ?? DEFAULT_BORDER_COLOR,
+      style: border.style ?? DEFAULT_BORDER_STYLE,
+      width: Math.max(CSS_HAIRLINE_WIDTH, authoredWidth),
+    };
+  }
+
+  const coveragePercent = Number((authoredWidth * 100).toFixed(4));
+  const color = border.color ?? DEFAULT_BORDER_COLOR;
+  return {
+    color: `color-mix(in srgb, ${color} ${coveragePercent}%, transparent)`,
+    style: border.style ?? DEFAULT_BORDER_STYLE,
+    width: CSS_HAIRLINE_WIDTH,
+  };
+};
+
+export const borderStrokeToCss = (
+  border: Pick<BorderStyle, "color" | "style" | "width">,
+): string => {
+  const stroke = resolveCssBorderStroke(border);
+  return `${stroke.width}px ${stroke.style} ${stroke.color}`;
+};
+
+type ParagraphBorderHorizontalOutsets = {
+  left: number;
+  right: number;
+};
+
+/** Resolve the outer horizontal edges of a paragraph border box. */
+export const resolveParagraphBorderHorizontalOutsets = (
+  borders: ParagraphBorders,
+  hasHorizontalRule: boolean,
+): ParagraphBorderHorizontalOutsets => {
+  const ruleOutset = hasHorizontalRule ? PARAGRAPH_RULE_ENDPOINT_OUTSET : 0;
+  return {
+    left: borders.left ? (borders.left.space ?? 0) + (borders.left.width ?? 0) : ruleOutset,
+    right: borders.right ? (borders.right.space ?? 0) + (borders.right.width ?? 0) : ruleOutset,
+  };
+};

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -569,6 +569,35 @@ describe("header and footer rendering", () => {
     ).toBeUndefined();
   });
 
+  test("keeps horizontal paragraph rule endpoints visible outside the text band", () => {
+    const content: HeaderFooterContent = {
+      blocks: [
+        {
+          kind: "paragraph",
+          id: "header-rule",
+          attrs: { borders: { bottom: { width: 1 / 3, style: "solid", color: "#000000" } } },
+          runs: [{ kind: "text", text: "Header" }],
+        },
+      ],
+      measures: [{ kind: "paragraph", lines: [], totalHeight: 16 }],
+      height: 16,
+      visualTop: 0,
+      visualBottom: 16,
+    };
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument, headerContent: content },
+    ) as unknown as FakeElement;
+    const header = findByClass(pageElement, "layout-page-header");
+    const rule = findByClass(pageElement, "layout-paragraph-border");
+
+    expect(header?.style.overflow).toBe("clip");
+    expect(header?.style.overflowClipMargin).toBe("2px");
+    expect(rule?.style.left).toBe("-2px");
+    expect(rule?.style.right).toBe("-2px");
+  });
+
   test("ignores even footers unless odd/even headers are enabled", () => {
     const pageOptions = {};
     const applied = applySectionHeaderFooterOptions(

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -149,6 +149,8 @@ export const PAGE_CLASS_NAMES = {
   footer: "layout-page-footer",
 };
 
+const HEADER_FOOTER_RULE_CLIP_MARGIN = pointsToPixels(1.5);
+
 // RenderContext is re-exported from renderUtils
 export type { RenderContext } from "./renderUtils";
 
@@ -2051,7 +2053,8 @@ export function renderPage(
     }
     if (shouldClipHeader) {
       headerEl.style.maxHeight = `${availableHeaderHeight}px`;
-      headerEl.style.overflow = "hidden";
+      headerEl.style.overflow = "clip";
+      headerEl.style.overflowClipMargin = `${HEADER_FOOTER_RULE_CLIP_MARGIN}px`;
     }
     pageEl.append(headerEl);
 
@@ -2129,7 +2132,8 @@ export function renderPage(
     }
     if (shouldClipFooter) {
       footerEl.style.maxHeight = `${availableFooterHeight}px`;
-      footerEl.style.overflow = "hidden";
+      footerEl.style.overflow = "clip";
+      footerEl.style.overflowClipMargin = `${HEADER_FOOTER_RULE_CLIP_MARGIN}px`;
     }
     pageEl.append(footerEl);
     moveBehindHeaderFooterElementsToPage(footerEl, pageEl, footerNaturalTop, page.margins.left);

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -49,6 +49,7 @@ import {
   rotatedBoundingBox,
 } from "../utils/rotationBoundingBox";
 import { hasCjk, segmentByScript } from "../utils/scriptSegments";
+import { borderStrokeToCss, resolveParagraphBorderHorizontalOutsets } from "./borderStroke";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import { applyImageVisualAttrs, hasImageVisualAttrs, wrapImageWithCrop } from "./renderImage";
 import { isFloatingImageRun, resolveImageLineAlign } from "./renderUtils";
@@ -2478,7 +2479,8 @@ export function renderParagraphFragment(
     // Ensure box-sizing is set for proper border calculations
     fragmentEl.style.boxSizing = "border-box";
 
-    const borderToCss = (b: BorderStyle) => `${b.width}px ${borderStyleToCss(b.style)} ${b.color}`;
+    const borderToCss = (border: BorderStyle) =>
+      borderStrokeToCss({ ...border, style: borderStyleToCss(border.style) });
 
     // Word-style border grouping (ECMA-376 §17.3.1.24):
     // Adjacent paragraphs with identical pBdr form a group.
@@ -2503,12 +2505,12 @@ export function renderParagraphFragment(
     // With box-sizing: border-box, the border paints inside the box, so each
     // side's outer edge must shift outward by both `space` (text↔border gap
     // in OOXML §17.3.1.24) and the border width to keep the visible gap.
-    borderBox.style.left = `${
-      indentLeft - (borders.left?.space ?? 0) - (borders.left?.width ?? 0)
-    }px`;
-    borderBox.style.right = `${
-      indentRight - (borders.right?.space ?? 0) - (borders.right?.width ?? 0)
-    }px`;
+    const horizontalOutsets = resolveParagraphBorderHorizontalOutsets(
+      borders,
+      renderedTopBorder !== undefined || renderedBottomBorder !== undefined,
+    );
+    borderBox.style.left = `${indentLeft - horizontalOutsets.left}px`;
+    borderBox.style.right = `${indentRight - horizontalOutsets.right}px`;
     borderBox.style.top = `${-(renderedTopBorder?.space ?? 0) - (renderedTopBorder?.width ?? 0)}px`;
     borderBox.style.bottom = `${
       -(renderedBottomBorder?.space ?? 0) - (renderedBottomBorder?.width ?? 0)

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -41,6 +41,7 @@ import {
 } from "../layout-engine/types";
 import { emuToPixels } from "../utils/units";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
+import { borderStrokeToCss, resolveCssBorderStroke } from "./borderStroke";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import { applyImageVisualAttrs, hasImageCrop, hasImageVisualAttrs } from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
@@ -484,10 +485,7 @@ function applyBorder(
   if (!border || border.style === "none" || border.style === "nil") {
     el.style[styleProp] = "none";
   } else {
-    const width = Math.max(1, border.width ?? 1);
-    const color = border.color ?? "#000000";
-    const style = border.style ?? "solid";
-    el.style[styleProp] = `${width}px ${style} ${color}`;
+    el.style[styleProp] = borderStrokeToCss(border);
   }
 }
 
@@ -513,8 +511,9 @@ function renderCellDiagonalBorder({
   }
 
   const line = doc.createElement("div");
-  const strokeWidth = Math.max(1, border?.width ?? 1);
-  const color = border?.color ?? "#000000";
+  const stroke = resolveCssBorderStroke(border ?? {});
+  const strokeWidth = stroke.width;
+  const color = stroke.color;
   const length = Math.hypot(cellWidth, cellHeight);
   const angle = Math.atan2(cellHeight, cellWidth);
 


### PR DESCRIPTION
## Summary

- retain fractional authored border widths through layout
- preserve optical weight when CSS quantizes subpixel strokes
- keep horizontal paragraph-rule endpoints visible at page-furniture boundaries

## Validation

- 37 focused border, table, paragraph, and page-renderer tests
- formatting and diff checks
- dependency security audit

CC on behalf of @jan-kubica