### PR TITLE
fix: trim split-row continuation spacing

### DIFF
--- a/.changeset/neat-row-continuations.md
+++ b/.changeset/neat-row-continuations.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Consume redundant empty-paragraph spacing when split table rows continue in a fresh flow region.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -24,7 +24,7 @@ import {
   reconcileBreakBeforeBlock,
   recordReflowBoundary,
 } from "./renderedBreakReconciliation";
-import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
+import { buildTableRowBreakInfo, getRowContinuationSkip, snapRowBreak } from "./tableRowBreak";
 import { bandFragmentX, bandTopContentY, isPageFrameRelativeAnchor } from "./textBoxFlow";
 import { floatingTextBoxReservesBand } from "./types";
 import type {
@@ -1005,7 +1005,12 @@ function layoutTable(
           slice = (next ?? splittableRow.height) - consumed;
         }
         const sliceBottom = consumed + slice;
-        const reachesRowEnd = sliceBottom >= splittableRow.height;
+        const continuationSkip =
+          sliceBottom < splittableRow.height
+            ? getRowContinuationSkip(breakInfo, currentRowIndex, sliceBottom)
+            : 0;
+        const nextConsumed = Math.min(splittableRow.height, sliceBottom + continuationSkip);
+        const reachesRowEnd = nextConsumed >= splittableRow.height;
         const moreAfter = !reachesRowEnd || currentRowIndex + 1 < rows.length;
         const fragmentHeight = headerOverhead + slice;
         const sliceFragment: TableFragment = {
@@ -1023,13 +1028,13 @@ function layoutTable(
           ...(moreAfter ? { continuesOnNext: true } : {}),
           ...(repeatHeaderRows ? { headerRowCount } : {}),
           ...(consumed > 0 ? { topClip: consumed } : {}),
-          ...(reachesRowEnd ? {} : { bottomClip: sliceBottom }),
+          ...(sliceBottom >= splittableRow.height ? {} : { bottomClip: sliceBottom }),
           ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
         };
         const sliceResult = paginator.addFragment(sliceFragment, fragmentHeight, 0, 0);
         sliceFragment.y = sliceResult.y;
         sliceFragment.x = computeTableX(sliceResult.state.columnIndex);
-        consumed = sliceBottom;
+        consumed = nextConsumed;
         if (consumed < splittableRow.height) {
           paginator.forceColumnBreak();
         }

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { layoutDocument } from "./index";
 import { clearAllCaches } from "./measure";
 import { resetCanvasContext } from "./measure/measureContainer";
-import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
+import { buildTableRowBreakInfo, getRowContinuationSkip, snapRowBreak } from "./tableRowBreak";
 import type {
   FlowBlock,
   LayoutOptions,
@@ -759,6 +759,128 @@ describe("buildTableRowBreakInfo / snapRowBreak", () => {
     // Not even the first line fits.
     expect(snapRowBreak(info, 0, 0, 15)).toBe(0);
   });
+
+  test("marks leading spacing before an empty continuation paragraph as suppressible", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "t",
+      rows: [
+        {
+          id: "r0",
+          cells: [
+            {
+              id: "c0",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "first",
+                  runs: [{ kind: "text", text: "first" }],
+                },
+                {
+                  kind: "paragraph",
+                  id: "second",
+                  attrs: { spacing: { before: 16, after: 8 }, styleId: "CellText" },
+                  runs: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [220],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [paraMeasure(6), paraMeasure(1)],
+              width: 220,
+              height: 164,
+            },
+          ],
+          height: 164,
+        },
+      ],
+      columnWidths: [220],
+      totalWidth: 220,
+      totalHeight: 164,
+    };
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(snapRowBreak(info, 0, 0, 120)).toBe(120);
+    expect(getRowContinuationSkip(info, 0, 120)).toBe(16);
+  });
+
+  test("does not suppress a shared row band while another cell starts content", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "t",
+      rows: [
+        {
+          id: "r0",
+          cells: [
+            {
+              id: "c0",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "left-first",
+                  runs: [{ kind: "text", text: "first" }],
+                },
+                {
+                  kind: "paragraph",
+                  id: "left-second",
+                  attrs: { spacing: { before: 16 }, styleId: "CellText" },
+                  runs: [],
+                },
+              ],
+            },
+            {
+              id: "c1",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "right-first",
+                  runs: [{ kind: "text", text: "first" }],
+                },
+                {
+                  kind: "paragraph",
+                  id: "right-second",
+                  runs: [{ kind: "text", text: "second" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [110, 110],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            { blocks: [paraMeasure(6), paraMeasure(1)], width: 110, height: 156 },
+            { blocks: [paraMeasure(6), paraMeasure(1)], width: 110, height: 140 },
+          ],
+          height: 156,
+        },
+      ],
+      columnWidths: [110, 110],
+      totalWidth: 220,
+      totalHeight: 156,
+    };
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(getRowContinuationSkip(info, 0, 120)).toBe(0);
+  });
 });
 
 const OPTIONS: LayoutOptions = {
@@ -846,6 +968,57 @@ describe("floating table placement", () => {
 });
 
 describe("oversized table row splits across pages (#570)", () => {
+  test("consumes empty-paragraph leading spacing when a split row resumes", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "t",
+      rows: [
+        {
+          id: "r0",
+          cells: [
+            {
+              id: "c0",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "first",
+                  runs: [{ kind: "text", text: "first" }],
+                },
+                {
+                  kind: "paragraph",
+                  id: "second",
+                  attrs: { spacing: { before: 16, after: 8 }, styleId: "CellText" },
+                  runs: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [220],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [{ blocks: [paraMeasure(6), paraMeasure(1)], width: 220, height: 164 }],
+          height: 164,
+        },
+      ],
+      columnWidths: [220],
+      totalWidth: 220,
+      totalHeight: 164,
+    };
+
+    const fragments = tableFragments(block, measure);
+
+    expect(fragments).toHaveLength(2);
+    expect(fragments[0]).toMatchObject({ height: 120, bottomClip: 120 });
+    expect(fragments[1]).toMatchObject({ height: 28, topClip: 136 });
+    expect(fragments[1]?.bottomClip).toBeUndefined();
+  });
+
   test("a row taller than a page breaks at line boundaries with no content lost", () => {
     // 15 lines = 300px row, page content height = 120px (6 lines).
     const { block, measure } = tallTable(15);

--- a/packages/core/src/layout-engine/tableRowBreak.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.ts
@@ -20,6 +20,7 @@ import {
   getTableCellFloatingImages,
 } from "./measure/tableCellFloating";
 import { createTableCellFlowState, placeTableCellBlock } from "./measure/tableCellFlow";
+import { isEmptyParagraph } from "./paragraphSpacing";
 import type { TableBlock, TableCell, TableCellMeasure, TableMeasure } from "./types";
 
 type UnsafeBreakRange = {
@@ -30,7 +31,10 @@ type UnsafeBreakRange = {
 type CellBreakGeometry = {
   bottoms: number[];
   unsafeRanges: UnsafeBreakRange[];
+  suppressibleLeadingRanges: UnsafeBreakRange[];
 };
+
+const BREAK_OFFSET_EPSILON = 0.01;
 
 const DEFAULT_TABLE_CELL_PADDING_TOP = 1;
 
@@ -63,6 +67,10 @@ function shiftCellGeometry(geometry: CellBreakGeometry, offset: number): CellBre
       top: range.top + offset,
       bottom: range.bottom + offset,
     })),
+    suppressibleLeadingRanges: geometry.suppressibleLeadingRanges.map((range) => ({
+      top: range.top + offset,
+      bottom: range.bottom + offset,
+    })),
   };
 }
 
@@ -75,6 +83,7 @@ function cellBreakGeometry(
   // aligned with both glyph boundaries and inter-paragraph whitespace.
   const bottoms: number[] = [];
   const unsafeRanges: UnsafeBreakRange[] = [];
+  const suppressibleLeadingRanges: UnsafeBreakRange[] = [];
   const cellBlocks = cell?.blocks;
   const blockMeasures = measure.blocks;
   const padTop = cell?.padding?.top ?? DEFAULT_TABLE_CELL_PADDING_TOP;
@@ -99,6 +108,12 @@ function cellBreakGeometry(
         });
       }
       const placement = placeTableCellBlock(flowState, block, blockMeasure);
+      if (placement.leadingSpacing > 0 && isEmptyParagraph(block)) {
+        suppressibleLeadingRanges.push({
+          top: padTop + placement.top,
+          bottom: padTop + placement.contentTop,
+        });
+      }
       // Paragraph lines paint after the resolved leading spacing, matching the
       // paragraph fragment's top padding in the cell painter.
       let y = padTop + placement.contentTop;
@@ -128,8 +143,42 @@ function cellBreakGeometry(
       }
     }
   }
-  return { bottoms, unsafeRanges };
+  return { bottoms, unsafeRanges, suppressibleLeadingRanges };
 }
+
+const continuationSkipForCell = (
+  geometry: CellBreakGeometry,
+  offset: number,
+): number | undefined => {
+  const hasRemainingContent = geometry.unsafeRanges.some(
+    ({ bottom }) => bottom > offset + BREAK_OFFSET_EPSILON,
+  );
+  if (!hasRemainingContent) {
+    return undefined;
+  }
+
+  const leadingRange = geometry.suppressibleLeadingRanges.find(
+    ({ top, bottom }) =>
+      top <= offset + BREAK_OFFSET_EPSILON && bottom > offset + BREAK_OFFSET_EPSILON,
+  );
+  return leadingRange ? leadingRange.bottom - offset : 0;
+};
+
+/**
+ * Leading spacing before an empty paragraph is consumed when a split row
+ * resumes at the top of a fresh flow region. Only a whitespace band shared by
+ * every cell with remaining content is suppressible; non-empty paragraphs,
+ * line boxes, cell padding, and explicit row height retain authored space.
+ */
+const continuationSkipAfter = (geometries: CellBreakGeometry[], offset: number): number => {
+  const skips = geometries
+    .map((geometry) => continuationSkipForCell(geometry, offset))
+    .filter((skip): skip is number => skip !== undefined);
+  if (skips.length === 0 || skips.some((skip) => skip <= BREAK_OFFSET_EPSILON)) {
+    return 0;
+  }
+  return Math.min(...skips);
+};
 
 /** Precomputed break geometry for a table. */
 export type TableRowBreakInfo = {
@@ -141,6 +190,8 @@ export type TableRowBreakInfo = {
    * final boundary.
    */
   breakOffsets: number[][];
+  /** Suppressible leading paragraph whitespace after each matching break offset. */
+  continuationSkips: number[][];
 };
 
 /** Build break geometry for a table from its block + measure. */
@@ -158,6 +209,7 @@ export function buildTableRowBreakInfo(
   rowTops.push(acc);
 
   const breakOffsets: number[][] = [];
+  const continuationSkips: number[][] = [];
   for (let r = 0; r < rowCount; r++) {
     const rowHeight = measure.rows[r]?.height ?? 0;
     const offsets = new Set<number>();
@@ -189,10 +241,31 @@ export function buildTableRowBreakInfo(
           geometry.unsafeRanges.every((range) => !isInsideRange(offset, range)),
         ),
     );
-    breakOffsets.push(safeOffsets.sort((a, b) => a - b));
+    const sortedOffsets = safeOffsets.sort((a, b) => a - b);
+    breakOffsets.push(sortedOffsets);
+    continuationSkips.push(
+      sortedOffsets.map((offset) => continuationSkipAfter(cellGeometries, offset)),
+    );
   }
 
-  return { rowTops, breakOffsets };
+  return { rowTops, breakOffsets, continuationSkips };
+}
+
+/** Leading empty-paragraph whitespace to consume when a row resumes after `offset`. */
+export function getRowContinuationSkip(
+  info: TableRowBreakInfo,
+  rowIndex: number,
+  offset: number,
+): number {
+  const offsets = info.breakOffsets[rowIndex];
+  const skips = info.continuationSkips[rowIndex];
+  const index = offsets?.findIndex(
+    (candidate) => Math.abs(candidate - offset) <= BREAK_OFFSET_EPSILON,
+  );
+  if (index === undefined || index < 0) {
+    return 0;
+  }
+  return skips?.[index] ?? 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
- consume redundant leading space before an empty paragraph when a split table row resumes in a fresh flow region
- require the suppressible whitespace band to be shared by every cell with remaining content
- keep line boxes, non-empty paragraphs, cell padding, and explicit row height unchanged

## Validation
- 45 focused table pagination and painting tests
- formatter and diff verification
- dependency security audit
- private interoperability render: page count preserved; systematic continuation offset removed
- lint and typecheck delegated to CI

CC on behalf of @jan-kubica