### PR TITLE
feat: edit footnote and endnote stories

### DIFF
--- a/.changeset/edit-note-stories.md
+++ b/.changeset/edit-note-stories.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add story-scoped document operations for footnotes and endnotes.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -77,7 +77,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
+export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -380,6 +380,9 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 export type FolioDocumentOperationStory = "main" | {
     type: "header" | "footer";
     relationshipId: string;
+} | {
+    type: "footnote" | "endnote";
+    noteId: number;
 };
 
 // @public (undocumented)
@@ -465,9 +468,7 @@ export type FolioDocumentStoryHandle = {
 export class FolioDocumentStoryNotFoundError extends FolioDocumentStoryNotFoundError_base {}
 
 // @public (undocumented)
-export type FolioEditableDocumentStoryHandle = Exclude<FolioDocumentStoryHandle, {
-    type: "footnote" | "endnote";
-}>;
+export type FolioEditableDocumentStoryHandle = FolioDocumentStoryHandle;
 
 // @public
 export type FolioReviewChange = {

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -378,10 +378,16 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationStory = "main" | {
-    type: "header" | "footer";
+    type: "header";
     relationshipId: string;
 } | {
-    type: "footnote" | "endnote";
+    type: "footer";
+    relationshipId: string;
+} | {
+    type: "footnote";
+    noteId: number;
+} | {
+    type: "endnote";
     noteId: number;
 };
 
@@ -457,10 +463,16 @@ export type FolioDocumentStory = {
 export type FolioDocumentStoryHandle = {
     type: "main";
 } | {
-    type: "header" | "footer";
+    type: "header";
     relationshipId: string;
 } | {
-    type: "footnote" | "endnote";
+    type: "footer";
+    relationshipId: string;
+} | {
+    type: "footnote";
+    noteId: number;
+} | {
+    type: "endnote";
     noteId: number;
 };
 

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -708,10 +708,16 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationStory = "main" | {
-    type: "header" | "footer";
+    type: "header";
     relationshipId: string;
 } | {
-    type: "footnote" | "endnote";
+    type: "footer";
+    relationshipId: string;
+} | {
+    type: "footnote";
+    noteId: number;
+} | {
+    type: "endnote";
     noteId: number;
 };
 

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -710,6 +710,9 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 export type FolioDocumentOperationStory = "main" | {
     type: "header" | "footer";
     relationshipId: string;
+} | {
+    type: "footnote" | "endnote";
+    noteId: number;
 };
 
 // @public (undocumented)

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -445,7 +445,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
+export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -708,10 +708,16 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationStory = "main" | {
-    type: "header" | "footer";
+    type: "header";
     relationshipId: string;
 } | {
-    type: "footnote" | "endnote";
+    type: "footer";
+    relationshipId: string;
+} | {
+    type: "footnote";
+    noteId: number;
+} | {
+    type: "endnote";
     noteId: number;
 };
 

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -710,6 +710,9 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 export type FolioDocumentOperationStory = "main" | {
     type: "header" | "footer";
     relationshipId: string;
+} | {
+    type: "footnote" | "endnote";
+    noteId: number;
 };
 
 // @public (undocumented)

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -445,7 +445,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
+export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -493,6 +493,9 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 export type FolioDocumentOperationStory = "main" | {
     type: "header" | "footer";
     relationshipId: string;
+} | {
+    type: "footnote" | "endnote";
+    noteId: number;
 };
 
 // @public (undocumented)
@@ -613,9 +616,7 @@ export type FolioDocxReviewerOptions = {
 };
 
 // @public (undocumented)
-export type FolioEditableDocumentStoryHandle = Exclude<FolioDocumentStoryHandle, {
-    type: "footnote" | "endnote";
-}>;
+export type FolioEditableDocumentStoryHandle = FolioDocumentStoryHandle;
 
 // @public
 export type FolioFormatProperty = (typeof FORMAT_PROPERTIES)[number];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -491,10 +491,16 @@ export type FolioDocumentOperationStatus = "committed" | "previewed" | "rejected
 
 // @public (undocumented)
 export type FolioDocumentOperationStory = "main" | {
-    type: "header" | "footer";
+    type: "header";
     relationshipId: string;
 } | {
-    type: "footnote" | "endnote";
+    type: "footer";
+    relationshipId: string;
+} | {
+    type: "footnote";
+    noteId: number;
+} | {
+    type: "endnote";
     noteId: number;
 };
 
@@ -570,10 +576,16 @@ export type FolioDocumentStory = {
 export type FolioDocumentStoryHandle = {
     type: "main";
 } | {
-    type: "header" | "footer";
+    type: "header";
     relationshipId: string;
 } | {
-    type: "footnote" | "endnote";
+    type: "footer";
+    relationshipId: string;
+} | {
+    type: "footnote";
+    noteId: number;
+} | {
+    type: "endnote";
     noteId: number;
 };
 

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -192,7 +192,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
 export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main"];
+export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -1145,13 +1145,130 @@ const readNotesFixture = async (): Promise<ArrayBuffer> => {
   const footnotesXml = await footnotesFile.async("text");
   const injected = footnotesXml.replace(
     "</w:footnotes>",
-    '<w:footnote w:id="2"><w:p><w:r><w:t>Injected footnote body text.</w:t></w:r></w:p></w:footnote></w:footnotes>',
+    '<w:footnote w:id="2"><w:p w14:paraId="B2000001"><w:r><w:t>Injected footnote body text.</w:t></w:r></w:p></w:footnote></w:footnotes>',
   );
   zip.file("word/footnotes.xml", injected);
+  zip.file(
+    "word/endnotes.xml",
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="B2000002"><w:r><w:t>Injected endnote body text.</w:t></w:r></w:p></w:endnote></w:endnotes>',
+  );
   return zip.generateAsync({ type: "arraybuffer" });
 };
 
 describe("headless docx review notes read surface", () => {
+  test("edits a footnote through story-scoped document operations", async () => {
+    const baseline = await readNotesFixture();
+    const story = { type: "footnote", noteId: 2 } as const;
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "Reviewer" });
+    const snapshot = reviewer.snapshotStory(story);
+    if (!snapshot) {
+      throw new Error("expected the footnote story");
+    }
+    const target = findBlock(snapshot.blocks, "Injected footnote body text.");
+
+    const result = reviewer.applyDocumentOperationsToStory({
+      story,
+      snapshot,
+      batch: {
+        version: 1,
+        mode: "direct",
+        operations: [
+          {
+            id: "footnote-replace",
+            type: "replaceInBlock",
+            blockId: target.id,
+            find: "Injected footnote",
+            replace: "Updated footnote",
+          },
+        ],
+      },
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.receipts.at(0)?.affected.at(0)).toEqual({
+      type: "block",
+      story,
+      blockId: target.id,
+      effect: "updated",
+    });
+    expect(reviewer.readStory(story)?.text).toBe("Updated footnote body text.");
+    expect(reviewer.getNotesAsText()).toContain("[footnote #2] Updated footnote body text.");
+
+    const saved = await reviewer.toBuffer();
+    expect(await partText(saved, "word/footnotes.xml")).toContain("Updated footnote");
+    expect(await partBytes(saved, "word/document.xml")).toEqual(
+      await partBytes(baseline, "word/document.xml"),
+    );
+    expect(await partBytes(saved, "word/endnotes.xml")).toEqual(
+      await partBytes(baseline, "word/endnotes.xml"),
+    );
+
+    const reopened = await FolioDocxReviewer.fromBuffer(saved);
+    expect(reopened.readStory(story)?.text).toBe("Updated footnote body text.");
+  });
+
+  test("tracks and undoes an endnote operation batch", async () => {
+    const baseline = await readNotesFixture();
+    const story = { type: "endnote", noteId: 3 } as const;
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "Reviewer" });
+    const snapshot = reviewer.snapshotStory(story);
+    if (!snapshot) {
+      throw new Error("expected the endnote story");
+    }
+    const target = findBlock(snapshot.blocks, "Injected endnote body text.");
+
+    const result = reviewer.applyDocumentOperationsToStory({
+      story,
+      snapshot,
+      batch: {
+        version: 1,
+        mode: "tracked-changes",
+        operations: [
+          {
+            id: "endnote-replace",
+            type: "replaceInBlock",
+            blockId: target.id,
+            find: "Injected endnote",
+            replace: "Updated endnote",
+          },
+        ],
+      },
+    });
+
+    expect(result.status).toBe("committed");
+    const saved = await reviewer.toBuffer();
+    const endnotesXml = await partText(saved, "word/endnotes.xml");
+    expect(endnotesXml).toContain("Updated");
+    expect(endnotesXml).toContain("endnote body text.");
+    expect(endnotesXml).toContain("<w:ins ");
+    expect(endnotesXml).toContain("<w:del ");
+    expect(endnotesXml).toContain('w:author="Reviewer"');
+
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.readStory(story)?.text).toBe("Injected endnote body text.");
+    expect(await partBytes(await reviewer.toBuffer(), "word/endnotes.xml")).toEqual(
+      await partBytes(baseline, "word/endnotes.xml"),
+    );
+  });
+
+  test("rejects a missing note story before applying operations", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await readNotesFixture());
+    const story = { type: "footnote", noteId: 999_999 } as const;
+    expect(reviewer.snapshotStory(story)).toBeNull();
+    expect(() =>
+      reviewer.applyDocumentOperationsToStory({
+        story,
+        batch: { version: 1, operations: [] },
+      }),
+    ).toThrow(FolioDocumentStoryNotFoundError);
+  });
+
   test("listStories discovers typed handles that readStory resolves", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(await readNotesFixture());
     const stories = reviewer.listStories();
@@ -1159,6 +1276,9 @@ describe("headless docx review notes read surface", () => {
     const footnote = stories.find(({ handle }) => handle.type === "footnote");
     expect(footnote?.text).toBe("Injected footnote body text.");
     expect(footnote ? reviewer.readStory(footnote.handle) : null).toEqual(footnote);
+    const endnote = stories.find(({ handle }) => handle.type === "endnote");
+    expect(endnote?.text).toBe("Injected endnote body text.");
+    expect(endnote ? reviewer.readStory(endnote.handle) : null).toEqual(endnote);
     expect(reviewer.readStory({ type: "footnote", noteId: 999_999 })).toBeNull();
   });
 
@@ -1171,8 +1291,9 @@ describe("headless docx review notes read surface", () => {
     );
     expect(notes).toContain("[footer default]");
     expect(notes).toContain("[footnote #2] Injected footnote body text.");
+    expect(notes).toContain("[endnote #3] Injected endnote body text.");
     // Body content is not folded into the notes surface.
-    expect(notes).not.toContain("[endnote");
+    expect(notes).not.toContain("Project Goals");
   });
 
   test("getNotesAsText is empty for a document without headers/footers or notes", async () => {

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -15,8 +15,7 @@
  * paragraphs in `document.xml` (leaving every untouched part byte-exact), with
  * a full repack as the fallback for structural edits.
  *
- * Scope: main, header, and footer blocks. Footnote and endnote bodies build on
- * the note serialization path separately.
+ * Scope: main, header, footer, footnote, and endnote blocks.
  */
 
 import { TaggedError } from "better-result";
@@ -43,7 +42,11 @@ import {
   rejectAllChanges,
 } from "../prosemirror/commands/comments";
 import { proseDocToBlocks, updateDocumentContent } from "../prosemirror/conversion/fromProseDoc";
-import { headerFooterToProseDoc, toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import {
+  footnoteToProseDoc,
+  headerFooterToProseDoc,
+  toProseDoc,
+} from "../prosemirror/conversion/toProseDoc";
 import {
   getChangedParagraphIds,
   hasStructuralChanges,
@@ -52,7 +55,7 @@ import {
 } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { schema, singletonManager } from "../prosemirror/schema";
 import type { Comment } from "../types/content";
-import type { Document, HeaderFooter } from "../types/document";
+import type { Document, Endnote, Footnote, HeaderFooter } from "../types/document";
 import { deterministicHexId } from "../utils/hexId";
 import {
   applyFolioDocumentOperations,
@@ -206,10 +209,7 @@ export type FolioDocumentStoryHandle =
   | { type: "header" | "footer"; relationshipId: string }
   | { type: "footnote" | "endnote"; noteId: number };
 
-export type FolioEditableDocumentStoryHandle = Exclude<
-  FolioDocumentStoryHandle,
-  { type: "footnote" | "endnote" }
->;
+export type FolioEditableDocumentStoryHandle = FolioDocumentStoryHandle;
 
 export type FolioDocumentStory = {
   handle: FolioDocumentStoryHandle;
@@ -233,8 +233,15 @@ type FolioHeaderFooterStoryHandle = Extract<
   { type: "header" | "footer" }
 >;
 
-type FolioHeaderFooterStoryState = {
-  handle: FolioHeaderFooterStoryHandle;
+type FolioNoteStoryHandle = Extract<
+  FolioEditableDocumentStoryHandle,
+  { type: "footnote" | "endnote" }
+>;
+
+type FolioSecondaryStoryHandle = Exclude<FolioEditableDocumentStoryHandle, { type: "main" }>;
+
+type FolioSecondaryStoryState = {
+  handle: FolioSecondaryStoryHandle;
   initialState: EditorState;
   state: EditorState;
 };
@@ -250,6 +257,13 @@ const MAIN_STORY = Object.freeze({ type: "main" } as const);
 
 const headerFooterStoryKey = ({ type, relationshipId }: FolioHeaderFooterStoryHandle): string =>
   `${type}:${relationshipId}`;
+
+const noteStoryKey = ({ type, noteId }: FolioNoteStoryHandle): string => `${type}:${noteId}`;
+
+const secondaryStoryKey = (story: FolioSecondaryStoryHandle): string =>
+  story.type === "header" || story.type === "footer"
+    ? headerFooterStoryKey(story)
+    : noteStoryKey(story);
 
 // The change shape and its pure reader now live in `./read` so a live editor
 // can produce the same `FolioReviewChange[]` from its own doc; the reviewer
@@ -369,7 +383,7 @@ export class FolioDocxReviewer {
   private readonly baseDocument: Document;
   private readonly originalBuffer: ArrayBuffer;
   private state: EditorState;
-  private readonly headerFooterStoryStates = new Map<string, FolioHeaderFooterStoryState>();
+  private readonly secondaryStoryStates = new Map<string, FolioSecondaryStoryState>();
   private readonly createdComments: Comment[] = [];
   private readonly documentOperationUndoEntries: FolioDocumentOperationUndoEntry[] = [];
   /**
@@ -480,7 +494,7 @@ export class FolioDocxReviewer {
     });
   }
 
-  /** Apply a versioned operation batch to the main story, a header, or a footer. */
+  /** Apply a versioned operation batch to one editable document story. */
   applyDocumentOperationsToStory({
     story,
     batch,
@@ -615,9 +629,8 @@ export class FolioDocxReviewer {
   /**
    * Header / footer and footnote / endnote text as labeled, LLM-ready lines,
    * one per non-empty part: `[header default] …`, `[footer default] …`,
-   * `[footnote #N] …`, `[endnote #N] …`. Header and footer lines reflect
-   * in-memory edits; note bodies reflect the parsed source. Empty parts and
-   * separator notes are omitted.
+   * `[footnote #N] …`, `[endnote #N] …`. Lines reflect in-memory edits. Empty
+   * parts and separator notes are omitted.
    */
   getNotesAsText(): string {
     const pkg = this.baseDocument.package;
@@ -646,7 +659,8 @@ export class FolioDocxReviewer {
       if (isSeparatorFootnote(footnote)) {
         continue;
       }
-      const text = normalizeFolioAIBlockText(getFootnoteText(footnote));
+      const handle = { type: "footnote", noteId: footnote.id } as const;
+      const text = this.getNoteStoryText(handle, footnote);
       if (text.length > 0) {
         lines.push(`[footnote #${footnote.id}] ${text}`);
       }
@@ -655,7 +669,8 @@ export class FolioDocxReviewer {
       if (isSeparatorEndnote(endnote)) {
         continue;
       }
-      const text = normalizeFolioAIBlockText(getEndnoteText(endnote));
+      const handle = { type: "endnote", noteId: endnote.id } as const;
+      const text = this.getNoteStoryText(handle, endnote);
       if (text.length > 0) {
         lines.push(`[endnote #${endnote.id}] ${text}`);
       }
@@ -686,17 +701,19 @@ export class FolioDocxReviewer {
     }
     for (const footnote of pkg.footnotes ?? []) {
       if (!isSeparatorFootnote(footnote)) {
+        const handle = { type: "footnote", noteId: footnote.id } as const;
         stories.push({
-          handle: { type: "footnote", noteId: footnote.id },
-          text: normalizeFolioAIBlockText(getFootnoteText(footnote)),
+          handle,
+          text: this.getNoteStoryText(handle, footnote),
         });
       }
     }
     for (const endnote of pkg.endnotes ?? []) {
       if (!isSeparatorEndnote(endnote)) {
+        const handle = { type: "endnote", noteId: endnote.id } as const;
         stories.push({
-          handle: { type: "endnote", noteId: endnote.id },
-          text: normalizeFolioAIBlockText(getEndnoteText(endnote)),
+          handle,
+          text: this.getNoteStoryText(handle, endnote),
         });
       }
     }
@@ -899,7 +916,7 @@ export class FolioDocxReviewer {
   /** The current document model with edits merged back in. */
   toDocument(): Document {
     const document = updateDocumentContent(this.baseDocument, this.state.doc);
-    this.mergeEditedHeaderFooterStories(document);
+    this.mergeEditedSecondaryStories(document);
     if (this.createdComments.length > 0 || this.resolvedOverrides.size > 0) {
       document.package.document.comments = this.withResolvedOverrides([
         ...(document.package.document.comments ?? []),
@@ -931,11 +948,24 @@ export class FolioDocxReviewer {
    * is the graceful handling — no separate error surface is needed here.
    */
   private async trySelectiveSave(document: Document): Promise<ArrayBuffer | null> {
+    const changedParaIds = new Set(getChangedParagraphIds(this.state));
+    let structuralChange = hasStructuralChanges(this.state);
+    let untrackedChanges = hasUntrackedChanges(this.state);
+    for (const entry of this.secondaryStoryStates.values()) {
+      if (entry.handle.type !== "footnote" && entry.handle.type !== "endnote") {
+        continue;
+      }
+      for (const paraId of getChangedParagraphIds(entry.state)) {
+        changedParaIds.add(paraId);
+      }
+      structuralChange ||= hasStructuralChanges(entry.state);
+      untrackedChanges ||= hasUntrackedChanges(entry.state);
+    }
     try {
       return await attemptSelectiveSave(document, this.originalBuffer, {
-        changedParaIds: getChangedParagraphIds(this.state),
-        structuralChange: hasStructuralChanges(this.state),
-        hasUntrackedChanges: hasUntrackedChanges(this.state),
+        changedParaIds,
+        structuralChange,
+        hasUntrackedChanges: untrackedChanges,
       });
     } catch {
       return null;
@@ -946,30 +976,37 @@ export class FolioDocxReviewer {
     if (story.type === "main") {
       return this.state;
     }
-    const key = headerFooterStoryKey(story);
-    const existing = this.headerFooterStoryStates.get(key);
+    const key = secondaryStoryKey(story);
+    const existing = this.secondaryStoryStates.get(key);
     if (existing) {
       return existing.state;
     }
-    const source = this.getHeaderFooterStory(story);
+    const source =
+      story.type === "header" || story.type === "footer"
+        ? this.getHeaderFooterStory(story)
+        : this.getNoteStory(story);
     if (!source) {
       return null;
     }
+    const conversionOptions = {
+      ...(this.baseDocument.package.styles !== undefined && {
+        styles: this.baseDocument.package.styles,
+      }),
+      ...(this.baseDocument.package.theme !== undefined && {
+        theme: this.baseDocument.package.theme,
+      }),
+    };
     const state = ensureDeterministicParaIdsInState(
       EditorState.create({
         schema,
-        doc: headerFooterToProseDoc(source.content, {
-          ...(this.baseDocument.package.styles !== undefined && {
-            styles: this.baseDocument.package.styles,
-          }),
-          ...(this.baseDocument.package.theme !== undefined && {
-            theme: this.baseDocument.package.theme,
-          }),
-        }),
+        doc:
+          story.type === "header" || story.type === "footer"
+            ? headerFooterToProseDoc(source.content, conversionOptions)
+            : footnoteToProseDoc(source.content, conversionOptions),
         plugins: singletonManager.getPlugins(),
       }),
     );
-    this.headerFooterStoryStates.set(key, { handle: story, initialState: state, state });
+    this.secondaryStoryStates.set(key, { handle: story, initialState: state, state });
     return state;
   }
 
@@ -989,7 +1026,7 @@ export class FolioDocxReviewer {
       this.state = state;
       return;
     }
-    const entry = this.headerFooterStoryStates.get(headerFooterStoryKey(story));
+    const entry = this.secondaryStoryStates.get(secondaryStoryKey(story));
     if (!entry) {
       throw new FolioDocumentStoryNotFoundError({
         message: `Document story ${JSON.stringify(story)} was not found.`,
@@ -1007,39 +1044,95 @@ export class FolioDocxReviewer {
     return stories?.get(story.relationshipId);
   }
 
+  private getNoteStory(story: FolioNoteStoryHandle): Footnote | Endnote | undefined {
+    if (story.type === "footnote") {
+      return this.baseDocument.package.footnotes?.find(
+        (note) => note.id === story.noteId && !isSeparatorFootnote(note),
+      );
+    }
+    return this.baseDocument.package.endnotes?.find(
+      (note) => note.id === story.noteId && !isSeparatorEndnote(note),
+    );
+  }
+
   private getHeaderFooterStoryText(
     story: FolioHeaderFooterStoryHandle,
     source: HeaderFooter,
   ): string {
-    const state = this.headerFooterStoryStates.get(headerFooterStoryKey(story))?.state;
+    const state = this.secondaryStoryStates.get(headerFooterStoryKey(story))?.state;
     return normalizeFolioAIBlockText(state?.doc.textContent ?? getHeaderFooterText(source));
   }
 
-  private mergeEditedHeaderFooterStories(document: Document): void {
+  private getNoteStoryText(story: FolioNoteStoryHandle, source: Footnote | Endnote): string {
+    const state = this.secondaryStoryStates.get(noteStoryKey(story))?.state;
+    const sourceText =
+      source.type === "footnote" ? getFootnoteText(source) : getEndnoteText(source);
+    return normalizeFolioAIBlockText(state?.doc.textContent ?? sourceText);
+  }
+
+  private mergeEditedSecondaryStories(document: Document): void {
     let headers: Map<string, HeaderFooter> | undefined;
     let footers: Map<string, HeaderFooter> | undefined;
-    for (const entry of this.headerFooterStoryStates.values()) {
+    let footnotes: Footnote[] | undefined;
+    let endnotes: Endnote[] | undefined;
+    for (const entry of this.secondaryStoryStates.values()) {
       if (entry.state === entry.initialState) {
         continue;
       }
-      const source = this.getHeaderFooterStory(entry.handle);
+      if (entry.handle.type === "header" || entry.handle.type === "footer") {
+        const source = this.getHeaderFooterStory(entry.handle);
+        if (!source) {
+          continue;
+        }
+        const edited = { ...source, content: proseDocToBlocks(entry.state.doc) };
+        if (entry.handle.type === "header") {
+          headers ??= new Map(document.package.headers);
+          headers.set(entry.handle.relationshipId, edited);
+          continue;
+        }
+        footers ??= new Map(document.package.footers);
+        footers.set(entry.handle.relationshipId, edited);
+        continue;
+      }
+      if (entry.handle.type === "footnote") {
+        const source = this.baseDocument.package.footnotes?.find(
+          (note) => note.id === entry.handle.noteId && !isSeparatorFootnote(note),
+        );
+        if (!source) {
+          continue;
+        }
+        const edited = { ...source, content: proseDocToBlocks(entry.state.doc) };
+        footnotes ??= [...(document.package.footnotes ?? [])];
+        const index = footnotes.findIndex((note) => note.id === entry.handle.noteId);
+        if (index !== -1) {
+          footnotes[index] = edited;
+        }
+        continue;
+      }
+      const source = this.baseDocument.package.endnotes?.find(
+        (note) => note.id === entry.handle.noteId && !isSeparatorEndnote(note),
+      );
       if (!source) {
         continue;
       }
       const edited = { ...source, content: proseDocToBlocks(entry.state.doc) };
-      if (entry.handle.type === "header") {
-        headers ??= new Map(document.package.headers);
-        headers.set(entry.handle.relationshipId, edited);
-        continue;
+      endnotes ??= [...(document.package.endnotes ?? [])];
+      const index = endnotes.findIndex((note) => note.id === entry.handle.noteId);
+      if (index !== -1) {
+        endnotes[index] = edited;
       }
-      footers ??= new Map(document.package.footers);
-      footers.set(entry.handle.relationshipId, edited);
     }
     if (headers) {
       document.package.headers = headers;
     }
     if (footers) {
       document.package.footers = footers;
+    }
+    if (footnotes) {
+      document.package.footnotes = footnotes;
+    }
+    if (endnotes) {
+      document.package.endnotes = endnotes;
     }
   }
 

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -1097,29 +1097,31 @@ export class FolioDocxReviewer {
         continue;
       }
       if (entry.handle.type === "footnote") {
+        const { noteId } = entry.handle;
         const source = this.baseDocument.package.footnotes?.find(
-          (note) => note.id === entry.handle.noteId && !isSeparatorFootnote(note),
+          (note) => note.id === noteId && !isSeparatorFootnote(note),
         );
         if (!source) {
           continue;
         }
         const edited = { ...source, content: proseDocToBlocks(entry.state.doc) };
         footnotes ??= [...(document.package.footnotes ?? [])];
-        const index = footnotes.findIndex((note) => note.id === entry.handle.noteId);
+        const index = footnotes.findIndex((note) => note.id === noteId);
         if (index !== -1) {
           footnotes[index] = edited;
         }
         continue;
       }
+      const { noteId } = entry.handle;
       const source = this.baseDocument.package.endnotes?.find(
-        (note) => note.id === entry.handle.noteId && !isSeparatorEndnote(note),
+        (note) => note.id === noteId && !isSeparatorEndnote(note),
       );
       if (!source) {
         continue;
       }
       const edited = { ...source, content: proseDocToBlocks(entry.state.doc) };
       endnotes ??= [...(document.package.endnotes ?? [])];
-      const index = endnotes.findIndex((note) => note.id === entry.handle.noteId);
+      const index = endnotes.findIndex((note) => note.id === noteId);
       if (index !== -1) {
         endnotes[index] = edited;
       }

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -206,8 +206,10 @@ export type FolioGetContentAsTextOptions = {
 
 export type FolioDocumentStoryHandle =
   | { type: "main" }
-  | { type: "header" | "footer"; relationshipId: string }
-  | { type: "footnote" | "endnote"; noteId: number };
+  | { type: "header"; relationshipId: string }
+  | { type: "footer"; relationshipId: string }
+  | { type: "footnote"; noteId: number }
+  | { type: "endnote"; noteId: number };
 
 export type FolioEditableDocumentStoryHandle = FolioDocumentStoryHandle;
 

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -48,7 +48,7 @@ describe("document operation contract", () => {
         insertSignatureTable: ["direct"],
       },
       preconditions: ["blockTextHash"],
-      stories: ["main"],
+      stories: ["main", "header", "footer", "footnote", "endnote"],
     });
   });
 

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -609,7 +609,8 @@ export type FolioDocumentOperationIssue = {
 
 export type FolioDocumentOperationStory =
   | "main"
-  | { type: "header" | "footer"; relationshipId: string };
+  | { type: "header" | "footer"; relationshipId: string }
+  | { type: "footnote" | "endnote"; noteId: number };
 
 /** One typed target affected by a successfully applied document operation. */
 export type FolioDocumentOperationAffectedTarget =

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -38,7 +38,13 @@ export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
   "tracked-changes",
 ] as const satisfies readonly FolioAIEditApplyMode[]);
 
-export const FOLIO_DOCUMENT_OPERATION_STORIES = Object.freeze(["main"] as const);
+export const FOLIO_DOCUMENT_OPERATION_STORIES = Object.freeze([
+  "main",
+  "header",
+  "footer",
+  "footnote",
+  "endnote",
+] as const);
 export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS = Object.freeze(["blockTextHash"] as const);
 export const FOLIO_DOCUMENT_OPERATION_BATCH_MODES = Object.freeze([
   "best-effort",

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -615,8 +615,10 @@ export type FolioDocumentOperationIssue = {
 
 export type FolioDocumentOperationStory =
   | "main"
-  | { type: "header" | "footer"; relationshipId: string }
-  | { type: "footnote" | "endnote"; noteId: number };
+  | { type: "header"; relationshipId: string }
+  | { type: "footer"; relationshipId: string }
+  | { type: "footnote"; noteId: number }
+  | { type: "endnote"; noteId: number };
 
 /** One typed target affected by a successfully applied document operation. */
 export type FolioDocumentOperationAffectedTarget =


### PR DESCRIPTION
Adds story-scoped document operations for footnotes and endnotes.

CC on behalf of @jan-kubica