### PR TITLE
fix: honor document hyphenation zones

### DIFF
--- a/.changeset/warm-hyphenation-zone.md
+++ b/.changeset/warm-hyphenation-zone.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor the document hyphenation zone when choosing automatic line breaks.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -573,7 +573,8 @@ export type ParagraphAttrs = {
     automaticHyphenation?: {
         enabled: true;
         doNotHyphenateCaps?: boolean;
-        consecutiveLineLimit?: number;
+        consecutiveLineLimit?: number; /** Maximum tolerated line-end whitespace before hyphenation, in twips. */
+        hyphenationZoneTwips?: number;
     }; /** Document-wide custom line-edge characters and compatibility behavior. */
     lineBreakRules?: {
         noLineBreaksBefore?: {

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -832,6 +832,7 @@ describe("runLayoutPipeline", () => {
       autoHyphenation: true,
       doNotHyphenateCaps: true,
       consecutiveHyphenLimit: 2,
+      hyphenationZoneTwips: 720,
     };
 
     const outcome = runLayoutPipeline(makeDeps(createLayoutSession(), { document }), makeState());
@@ -841,6 +842,7 @@ describe("runLayoutPipeline", () => {
       enabled: true,
       doNotHyphenateCaps: true,
       consecutiveLineLimit: 2,
+      hyphenationZoneTwips: 720,
     });
   });
 

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -313,6 +313,9 @@ export function runLayoutPipeline<THfPMs>(
         ...(documentSettings.consecutiveHyphenLimit !== undefined
           ? { consecutiveLineLimit: documentSettings.consecutiveHyphenLimit }
           : {}),
+        ...(documentSettings.hyphenationZoneTwips !== undefined
+          ? { hyphenationZoneTwips: documentSettings.hyphenationZoneTwips }
+          : {}),
       };
     }
     let newBlocks = toFlowBlocks(state.doc, flowOpts);

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -345,7 +345,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     const automaticHyphenation = attrs.automaticHyphenation;
     if (automaticHyphenation) {
       parts.push(
-        `auto-hyphens:${automaticHyphenation.doNotHyphenateCaps}|${automaticHyphenation.consecutiveLineLimit}`,
+        `auto-hyphens:${automaticHyphenation.doNotHyphenateCaps}|${automaticHyphenation.consecutiveLineLimit}|${automaticHyphenation.hyphenationZoneTwips}`,
       );
     }
     const lineBreakRules = attrs.lineBreakRules;

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -147,6 +147,21 @@ describe("font metrics cache", () => {
         },
       }),
     );
+    expect(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: {
+          automaticHyphenation: { enabled: true, hyphenationZoneTwips: 360 },
+        },
+      }),
+    ).not.toBe(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: {
+          automaticHyphenation: { enabled: true, hyphenationZoneTwips: 720 },
+        },
+      }),
+    );
   });
 });
 
@@ -713,6 +728,48 @@ describe("automatic hyphenation", () => {
         expect(measured.lines[1]).toMatchObject({ fromRun: 1, fromChar: 1 });
       },
       { charWidth: fixedCharWidth(10) },
+    );
+  });
+
+  test("attempts hyphenation only when line-end whitespace exceeds the document zone", () => {
+    const measureWithZone = (hyphenationZoneTwips?: number) =>
+      measureParagraph(
+        {
+          kind: "paragraph",
+          id: "automatic-hyphenation-zone",
+          runs: [
+            {
+              kind: "text",
+              text: "aaaaaaaaaaaaaaaa hyphenation",
+              language: { val: "en-US" },
+            },
+          ],
+          attrs: {
+            automaticHyphenation: {
+              enabled: true,
+              ...(hyphenationZoneTwips !== undefined ? { hyphenationZoneTwips } : {}),
+            },
+          },
+        },
+        100,
+      );
+
+    withFakeTextMeasure(
+      () => {
+        const defaultZone = measureWithZone();
+        const zeroZone = measureWithZone(0);
+
+        expect(defaultZone.lines[0]).toMatchObject({
+          toChar: "aaaaaaaaaaaaaaaa ".length,
+          width: 80,
+        });
+        expect(defaultZone.lines[0]?.discretionaryHyphen).toBeUndefined();
+        expect(zeroZone.lines[0]).toMatchObject({
+          toChar: "aaaaaaaaaaaaaaaa hy".length,
+          discretionaryHyphen: { runIndex: 0 },
+        });
+      },
+      { charWidth: fixedCharWidth(5) },
     );
   });
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -36,7 +36,7 @@ import {
   type FloatingLineSegmentZone,
 } from "./floatingZones";
 import { getListMarkerInlineWidth } from "./listMarkerWidth";
-import { buildRunFontStyle, ptToPx } from "./measureHelpers";
+import { buildRunFontStyle, ptToPx, twipsToPx } from "./measureHelpers";
 import { getFontMetrics, measureRun, measureTextWidth } from "./measureProvider";
 import type { FontMetrics, FontStyle } from "./measureTypes";
 import {
@@ -70,6 +70,7 @@ const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
 const DEFAULT_LIST_HANGING_INDENT_PX = 24;
 const ALL_CAPS_RATIO_THRESHOLD = 0.8;
+const DEFAULT_HYPHENATION_ZONE_TWIPS = 360;
 
 /**
  * Find the longest prefix of `text` that fits within `maxWidth` pixels.
@@ -152,6 +153,16 @@ type LineState = {
   segmentZones?: FloatingLineSegmentZone[];
   discretionaryHyphen?: { runIndex: number };
 };
+
+function exceedsHyphenationZone(line: LineState, zoneTwips: number): boolean {
+  if (line.width <= 0) {
+    return true;
+  }
+
+  const visibleWidth = Math.max(0, line.width - line.trailingWhitespaceWidth);
+  const unusedWidth = Math.max(0, line.availableWidth - visibleWidth);
+  return unusedWidth > twipsToPx(zoneTwips) + WIDTH_TOLERANCE;
+}
 
 /**
  * Extract FontStyle from a run that carries RunFormatting (text, tab, or
@@ -1771,7 +1782,11 @@ export function measureParagraph(
         const mayHyphenateLine =
           automaticHyphenation?.enabled === true &&
           block.attrs?.suppressAutoHyphens !== true &&
-          (consecutiveLineLimit === 0 || consecutiveHyphenatedLines < consecutiveLineLimit);
+          (consecutiveLineLimit === 0 || consecutiveHyphenatedLines < consecutiveLineLimit) &&
+          exceedsHyphenationZone(
+            currentLine,
+            automaticHyphenation.hyphenationZoneTwips ?? DEFAULT_HYPHENATION_ZONE_TWIPS,
+          );
         const isRunTail = nextBreak === text.length;
         const crossRunWord =
           mayHyphenateLine && isRunTail && word.length > 0 && !isBreakChar(word.at(-1))

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -388,6 +388,8 @@ export type ParagraphAttrs = {
     enabled: true;
     doNotHyphenateCaps?: boolean;
     consecutiveLineLimit?: number;
+    /** Maximum tolerated line-end whitespace before hyphenation, in twips. */
+    hyphenationZoneTwips?: number;
   };
   /** Document-wide custom line-edge characters and compatibility behavior. */
   lineBreakRules?: {


### PR DESCRIPTION
## Summary

- thread the parsed document hyphenation zone through body, header, footer, and footnote layout
- compare visible line-end whitespace with the configured zone before inserting a dictionary break
- include the zone in paragraph cache identity and add focused regression coverage