### PR TITLE
feat: compare document stories

### DIFF
--- a/.changeset/add-story-aware-comparison.md
+++ b/.changeset/add-story-aware-comparison.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Compare document stories with source-specific block handles.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -736,6 +736,9 @@ export type FolioVersionDiff = {
     summaryCounts: FolioVersionDiffSummaryCounts;
 };
 
+// @public
+export type FolioVersionDiffSegment = WordDiffSegment;
+
 // @public (undocumented)
 export type FolioVersionDiffSummaryCounts = {
     added: number;
@@ -745,9 +748,6 @@ export type FolioVersionDiffSummaryCounts = {
     moved: number;
     unchanged: number;
 };
-
-// @public
-export type FolioVersionDiffSegment = WordDiffSegment;
 
 // @public
 export const generateRedlineDocx: (base: ArrayBuffer, revised: ArrayBuffer, options?: GenerateRedlineDocxOptions) => Promise<GenerateRedlineDocxResult>;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -364,34 +364,42 @@ export type FolioBlockDiff = {
     blockId: string;
     kind: string;
     text: string;
+    revisedHandle: FolioVersionBlockHandle;
 } | {
     type: "deleted";
     blockId: string;
     kind: string;
     text: string;
+    baseHandle: FolioVersionBlockHandle;
 } | {
     type: "modified";
     blockId: string;
     kind: string;
     segments: FolioVersionDiffSegment[];
+    baseHandle: FolioVersionBlockHandle;
+    revisedHandle: FolioVersionBlockHandle;
 } | {
     type: "formatChanged";
     blockId: string;
     kind: string;
     text: string;
     changedProperties: FolioFormatProperty[];
+    baseHandle: FolioVersionBlockHandle;
+    revisedHandle: FolioVersionBlockHandle;
 } | {
     type: "movedFrom";
     blockId: string;
     kind: string;
     text: string;
     moveGroupId: number;
+    baseHandle: FolioVersionBlockHandle;
 } | {
     type: "movedTo";
     blockId: string;
     kind: string;
     text: string;
     moveGroupId: number;
+    revisedHandle: FolioVersionBlockHandle;
 };
 
 // @public
@@ -708,16 +716,34 @@ export type FolioReviewReplyInput = {
 };
 
 // @public
+export type FolioStoryDiff = {
+    baseStory: FolioDocumentStoryHandle | null;
+    revisedStory: FolioDocumentStoryHandle | null;
+    changes: FolioBlockDiff[];
+    summaryCounts: FolioVersionDiffSummaryCounts;
+};
+
+// @public
+export type FolioVersionBlockHandle = {
+    story: FolioDocumentStoryHandle;
+    blockId: string;
+};
+
+// @public
 export type FolioVersionDiff = {
-    changes: FolioBlockDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
-    summaryCounts: {
-        added: number;
-        deleted: number;
-        modified: number;
-        formatChanged: number;
-        moved: number;
-        unchanged: number;
-    };
+    changes: FolioBlockDiff[]; /** Per-story results in base order followed by stories added in the revised document. */
+    stories: FolioStoryDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
+    summaryCounts: FolioVersionDiffSummaryCounts;
+};
+
+// @public (undocumented)
+export type FolioVersionDiffSummaryCounts = {
+    added: number;
+    deleted: number;
+    modified: number;
+    formatChanged: number;
+    moved: number;
+    unchanged: number;
 };
 
 // @public

--- a/packages/agents/src/compare.test.ts
+++ b/packages/agents/src/compare.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import type { FolioAgentVersionDiff } from "./compare";
 import { formatVersionDiffForLLM } from "./compare";
 
+const mainHandle = (blockId: string) => ({ story: { type: "main" } as const, blockId });
+
 describe("formatVersionDiffForLLM", () => {
   test("renders summary counts and word-diff markers", () => {
     const diff: FolioAgentVersionDiff = {
@@ -14,6 +16,7 @@ describe("formatVersionDiffForLLM", () => {
         moved: 1,
         unchanged: 2,
       },
+      stories: [],
       changes: [
         {
           type: "modified",
@@ -24,18 +27,22 @@ describe("formatVersionDiffForLLM", () => {
             { type: "del", text: "paragraph." },
             { type: "ins", text: "clause." },
           ],
+          baseHandle: mainHandle("00000002"),
+          revisedHandle: mainHandle("00000002"),
         },
         {
           type: "deleted",
           blockId: "00000003",
           kind: "paragraph",
           text: "Gamma paragraph.",
+          baseHandle: mainHandle("00000003"),
         },
         {
           type: "added",
           blockId: "00000006",
           kind: "paragraph",
           text: "Epsilon paragraph.",
+          revisedHandle: mainHandle("00000006"),
         },
         {
           type: "formatChanged",
@@ -43,6 +50,8 @@ describe("formatVersionDiffForLLM", () => {
           kind: "paragraph",
           text: "Delta paragraph.",
           changedProperties: ["bold", "color"],
+          baseHandle: mainHandle("00000007"),
+          revisedHandle: mainHandle("00000007"),
         },
         {
           type: "movedFrom",
@@ -50,6 +59,7 @@ describe("formatVersionDiffForLLM", () => {
           kind: "paragraph",
           text: "Zeta paragraph moved somewhere else.",
           moveGroupId: 1,
+          baseHandle: mainHandle("00000008"),
         },
         {
           type: "movedTo",
@@ -57,6 +67,7 @@ describe("formatVersionDiffForLLM", () => {
           kind: "paragraph",
           text: "Zeta paragraph moved somewhere else.",
           moveGroupId: 1,
+          revisedHandle: mainHandle("00000008"),
         },
       ],
     };

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -94,7 +94,10 @@ export {
   compareDocxVersions,
   type FolioBlockDiff,
   type FolioFormatProperty,
+  type FolioStoryDiff,
+  type FolioVersionBlockHandle,
   type FolioVersionDiff,
+  type FolioVersionDiffSummaryCounts,
   type FolioVersionDiffSegment,
 } from "./version-comparison";
 export {

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -11,9 +11,13 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
 
 import { FolioDocxReviewer } from "./ai-edits/headless";
+import { parseDocx } from "./docx/parser";
 import { createDocx } from "./docx/rezip";
+import { repackDocx } from "./docx/rezip";
+import type { HeaderFooter, Paragraph } from "./types/document";
 import { createEmptyDocument } from "./utils/createDocument";
 import { compareDocxVersions, exceedsLcsBudget } from "./version-comparison";
 import type { FolioBlockDiff } from "./version-comparison";
@@ -46,6 +50,82 @@ const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuf
       },
     },
   });
+};
+
+const storyParagraph = (text: string, paraId: string): Paragraph => ({
+  type: "paragraph",
+  paraId,
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+});
+
+const headerFooterStory = (
+  type: "header" | "footer",
+  text: string,
+  paraId: string,
+): HeaderFooter => ({
+  type,
+  hdrFtrType: "default",
+  content: [storyParagraph(text, paraId)],
+});
+
+type StoryDocumentOptions = {
+  bodyText: string;
+  headerText: string;
+  footnoteText: string;
+  footerText?: string;
+};
+
+const buildStoryDocument = async ({
+  bodyText,
+  headerText,
+  footnoteText,
+  footerText,
+}: StoryDocumentOptions): Promise<ArrayBuffer> => {
+  const source = await buildDocxBuffer([{ text: bodyText, paraId: "A1000001" }]);
+  const document = await parseDocx(source, { detectVariables: false, preloadFonts: false });
+  document.package.headers = new Map([
+    ["rIdHeader", headerFooterStory("header", headerText, "B1000001")],
+  ]);
+  document.package.document.finalSectionProperties = {
+    ...document.package.document.finalSectionProperties,
+    headerReferences: [{ type: "default", rId: "rIdHeader" }],
+  };
+  if (footerText !== undefined) {
+    document.package.footers = new Map([
+      ["rIdFooter", headerFooterStory("footer", footerText, "D1000001")],
+    ]);
+    document.package.document.finalSectionProperties.footerReferences = [
+      { type: "default", rId: "rIdFooter" },
+    ];
+  }
+  const materialized = await repackDocx(document, { updateModifiedDate: false });
+  const zip = await JSZip.loadAsync(materialized);
+  const contentTypesFile = zip.file("[Content_Types].xml");
+  const relationshipsFile = zip.file("word/_rels/document.xml.rels");
+  if (!contentTypesFile || !relationshipsFile) {
+    throw new Error("expected package metadata parts");
+  }
+  const contentTypes = await contentTypesFile.async("text");
+  const relationships = await relationshipsFile.async("text");
+  zip.file(
+    "[Content_Types].xml",
+    contentTypes.replace(
+      "</Types>",
+      '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/></Types>',
+    ),
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    relationships.replace(
+      "</Relationships>",
+      '<Relationship Id="rIdFootnotes" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/></Relationships>',
+    ),
+  );
+  zip.file(
+    "word/footnotes.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:footnote w:id="2"><w:p w14:paraId="C1000001"><w:r><w:t>${footnoteText}</w:t></w:r></w:p></w:footnote></w:footnotes>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
 };
 
 const findChange = (changes: readonly FolioBlockDiff[], blockId: string): FolioBlockDiff => {
@@ -102,6 +182,7 @@ describe("compareDocxVersions: real w14:paraId alignment", () => {
       blockId: "00000003",
       kind: "paragraph",
       text: "Gamma paragraph.",
+      baseHandle: { story: { type: "main" }, blockId: "00000003" },
     });
 
     const added = findChange(diff.changes, "00000006");
@@ -110,6 +191,63 @@ describe("compareDocxVersions: real w14:paraId alignment", () => {
       blockId: "00000006",
       kind: "paragraph",
       text: "Epsilon paragraph.",
+      revisedHandle: { story: { type: "main" }, blockId: "00000006" },
+    });
+  });
+});
+
+describe("compareDocxVersions: document stories", () => {
+  test("reports per-story changes with source-specific navigation handles", async () => {
+    const base = await buildStoryDocument({
+      bodyText: "Body text.",
+      headerText: "Header baseline.",
+      footnoteText: "Stable note.",
+    });
+    const revised = await buildStoryDocument({
+      bodyText: "Body text.",
+      headerText: "Header revised.",
+      footnoteText: "Stable note.",
+      footerText: "Added footer.",
+    });
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({
+      added: 1,
+      deleted: 0,
+      modified: 1,
+      formatChanged: 0,
+      moved: 0,
+      unchanged: 2,
+    });
+    expect(diff.stories).toHaveLength(4);
+
+    const header = diff.stories.find(({ revisedStory }) => revisedStory?.type === "header");
+    expect(header?.baseStory).toEqual({ type: "header", relationshipId: "rIdHeader" });
+    expect(header?.revisedStory).toEqual({ type: "header", relationshipId: "rIdHeader" });
+    const headerChange = header?.changes.at(0);
+    if (!headerChange || headerChange.type !== "modified") {
+      throw new Error("expected a modified header block");
+    }
+    expect(headerChange.baseHandle).toEqual({
+      story: { type: "header", relationshipId: "rIdHeader" },
+      blockId: "B1000001",
+    });
+    expect(headerChange.revisedHandle).toEqual({
+      story: { type: "header", relationshipId: "rIdHeader" },
+      blockId: "B1000001",
+    });
+
+    const footer = diff.stories.find(({ revisedStory }) => revisedStory?.type === "footer");
+    expect(footer?.baseStory).toBeNull();
+    expect(footer?.summaryCounts.added).toBe(1);
+    const footerChange = footer?.changes.at(0);
+    if (!footerChange || footerChange.type !== "added") {
+      throw new Error("expected an added footer block");
+    }
+    expect(footerChange.revisedHandle).toEqual({
+      story: { type: "footer", relationshipId: "rIdFooter" },
+      blockId: "D1000001",
     });
   });
 });

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -73,7 +73,9 @@
  * `unchanged` rather than misattribute properties.
  */
 
-import { FolioDocxReviewer } from "./ai-edits/headless";
+import { panic } from "better-result";
+
+import { FolioDocxReviewer, type FolioDocumentStoryHandle } from "./ai-edits/headless";
 import type { FolioAIBlock, FolioAIBlockPreviewRun } from "./ai-edits/types";
 import { diffWordSegments, type WordDiffSegment } from "./ai-edits/word-diff";
 import { getFolioParaIdFromBlockId } from "./types/block-id";
@@ -95,34 +97,87 @@ const FORMAT_PROPERTIES = [
 /** A run-level formatting property that can differ in a `formatChanged` block. */
 export type FolioFormatProperty = (typeof FORMAT_PROPERTIES)[number];
 
+/** Stable location of one compared block within its source document. */
+export type FolioVersionBlockHandle = {
+  story: FolioDocumentStoryHandle;
+  blockId: string;
+};
+
 /** One block-level change between two document versions, in revised-side document order. */
 export type FolioBlockDiff =
-  | { type: "added"; blockId: string; kind: string; text: string }
-  | { type: "deleted"; blockId: string; kind: string; text: string }
-  | { type: "modified"; blockId: string; kind: string; segments: FolioVersionDiffSegment[] }
+  | {
+      type: "added";
+      blockId: string;
+      kind: string;
+      text: string;
+      revisedHandle: FolioVersionBlockHandle;
+    }
+  | {
+      type: "deleted";
+      blockId: string;
+      kind: string;
+      text: string;
+      baseHandle: FolioVersionBlockHandle;
+    }
+  | {
+      type: "modified";
+      blockId: string;
+      kind: string;
+      segments: FolioVersionDiffSegment[];
+      baseHandle: FolioVersionBlockHandle;
+      revisedHandle: FolioVersionBlockHandle;
+    }
   | {
       type: "formatChanged";
       blockId: string;
       kind: string;
       text: string;
       changedProperties: FolioFormatProperty[];
+      baseHandle: FolioVersionBlockHandle;
+      revisedHandle: FolioVersionBlockHandle;
     }
-  | { type: "movedFrom"; blockId: string; kind: string; text: string; moveGroupId: number }
-  | { type: "movedTo"; blockId: string; kind: string; text: string; moveGroupId: number };
+  | {
+      type: "movedFrom";
+      blockId: string;
+      kind: string;
+      text: string;
+      moveGroupId: number;
+      baseHandle: FolioVersionBlockHandle;
+    }
+  | {
+      type: "movedTo";
+      blockId: string;
+      kind: string;
+      text: string;
+      moveGroupId: number;
+      revisedHandle: FolioVersionBlockHandle;
+    };
+
+export type FolioVersionDiffSummaryCounts = {
+  added: number;
+  deleted: number;
+  modified: number;
+  formatChanged: number;
+  moved: number;
+  unchanged: number;
+};
+
+/** Changes within one matched, added, or deleted document story. */
+export type FolioStoryDiff = {
+  baseStory: FolioDocumentStoryHandle | null;
+  revisedStory: FolioDocumentStoryHandle | null;
+  changes: FolioBlockDiff[];
+  summaryCounts: FolioVersionDiffSummaryCounts;
+};
 
 /** Result of {@link compareDocxVersions}. */
 export type FolioVersionDiff = {
   /** Every changed block, in revised-side document order (deletions and move sources slotted where they sat). */
   changes: FolioBlockDiff[];
+  /** Per-story results in base order followed by stories added in the revised document. */
+  stories: FolioStoryDiff[];
   /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
-  summaryCounts: {
-    added: number;
-    deleted: number;
-    modified: number;
-    formatChanged: number;
-    moved: number;
-    unchanged: number;
-  };
+  summaryCounts: FolioVersionDiffSummaryCounts;
 };
 
 type BlockPair = { baseIndex: number; revisedIndex: number };
@@ -462,7 +517,8 @@ const meetsMoveWordCount = (text: string): boolean => {
  */
 const detectMoves = (
   changes: FolioBlockDiff[],
-  counts: FolioVersionDiff["summaryCounts"],
+  counts: FolioVersionDiffSummaryCounts,
+  firstMoveGroupId: number,
 ): void => {
   const deletedIndexesByText = new Map<string, number[]>();
   changes.forEach((change, index) => {
@@ -476,7 +532,7 @@ const detectMoves = (
     return;
   }
 
-  let moveGroupId = 0;
+  let moveGroupId = firstMoveGroupId - 1;
   changes.forEach((change, index) => {
     if (change.type !== "added") {
       return;
@@ -496,6 +552,7 @@ const detectMoves = (
       kind: deleted.kind,
       text: deleted.text,
       moveGroupId,
+      baseHandle: deleted.baseHandle,
     };
     changes[index] = {
       type: "movedTo",
@@ -503,11 +560,155 @@ const detectMoves = (
       kind: change.kind,
       text: change.text,
       moveGroupId,
+      revisedHandle: change.revisedHandle,
     };
     counts.deleted--;
     counts.added--;
     counts.moved++;
   });
+};
+
+const createSummaryCounts = (): FolioVersionDiffSummaryCounts => ({
+  added: 0,
+  deleted: 0,
+  modified: 0,
+  formatChanged: 0,
+  moved: 0,
+  unchanged: 0,
+});
+
+const addSummaryCounts = (
+  target: FolioVersionDiffSummaryCounts,
+  source: FolioVersionDiffSummaryCounts,
+): void => {
+  target.added += source.added;
+  target.deleted += source.deleted;
+  target.modified += source.modified;
+  target.formatChanged += source.formatChanged;
+  target.moved += source.moved;
+  target.unchanged += source.unchanged;
+};
+
+const storyKey = (story: FolioDocumentStoryHandle): string => {
+  if (story.type === "main") {
+    return story.type;
+  }
+  if (story.type === "header" || story.type === "footer") {
+    return `${story.type}:${story.relationshipId}`;
+  }
+  return `${story.type}:${String(story.noteId)}`;
+};
+
+type StoryPair = {
+  baseStory: FolioDocumentStoryHandle | null;
+  revisedStory: FolioDocumentStoryHandle | null;
+};
+
+const pairDocumentStories = (
+  baseStories: readonly FolioDocumentStoryHandle[],
+  revisedStories: readonly FolioDocumentStoryHandle[],
+): StoryPair[] => {
+  const revisedByKey = new Map(revisedStories.map((story) => [storyKey(story), story]));
+  const pairedKeys = new Set<string>();
+  const pairs: StoryPair[] = [];
+  for (const baseStory of baseStories) {
+    const key = storyKey(baseStory);
+    const revisedStory = revisedByKey.get(key) ?? null;
+    pairs.push({ baseStory, revisedStory });
+    if (revisedStory) {
+      pairedKeys.add(key);
+    }
+  }
+  for (const revisedStory of revisedStories) {
+    if (!pairedKeys.has(storyKey(revisedStory))) {
+      pairs.push({ baseStory: null, revisedStory });
+    }
+  }
+  return pairs;
+};
+
+type CompareStoryBlocksOptions = StoryPair & {
+  baseBlocks: readonly FolioAIBlock[];
+  revisedBlocks: readonly FolioAIBlock[];
+  firstMoveGroupId: number;
+};
+
+const compareStoryBlocks = ({
+  baseStory,
+  revisedStory,
+  baseBlocks,
+  revisedBlocks,
+  firstMoveGroupId,
+}: CompareStoryBlocksOptions): FolioStoryDiff => {
+  const changes: FolioBlockDiff[] = [];
+  const counts = createSummaryCounts();
+
+  for (const event of alignFolioBlocks(baseBlocks, revisedBlocks)) {
+    if (event.type === "pair") {
+      if (!baseStory || !revisedStory) {
+        panic("A paired comparison event requires both story handles");
+      }
+      const { baseBlock, revisedBlock } = event;
+      const baseHandle = { story: baseStory, blockId: baseBlock.id };
+      const revisedHandle = { story: revisedStory, blockId: revisedBlock.id };
+      if (baseBlock.text !== revisedBlock.text) {
+        counts.modified++;
+        changes.push({
+          type: "modified",
+          blockId: revisedBlock.id,
+          kind: revisedBlock.kind,
+          segments: diffWordSegments(baseBlock.text, revisedBlock.text),
+          baseHandle,
+          revisedHandle,
+        });
+        continue;
+      }
+      const changedProperties = diffPreviewRunFormatting(baseBlock, revisedBlock);
+      if (changedProperties.length > 0) {
+        counts.formatChanged++;
+        changes.push({
+          type: "formatChanged",
+          blockId: revisedBlock.id,
+          kind: revisedBlock.kind,
+          text: revisedBlock.text,
+          changedProperties,
+          baseHandle,
+          revisedHandle,
+        });
+        continue;
+      }
+      counts.unchanged++;
+      continue;
+    }
+    if (event.type === "baseOnly") {
+      if (!baseStory) {
+        panic("A base-only comparison event requires a base story handle");
+      }
+      counts.deleted++;
+      changes.push({
+        type: "deleted",
+        blockId: event.block.id,
+        kind: event.block.kind,
+        text: event.block.text,
+        baseHandle: { story: baseStory, blockId: event.block.id },
+      });
+      continue;
+    }
+    if (!revisedStory) {
+      panic("A revised-only comparison event requires a revised story handle");
+    }
+    counts.added++;
+    changes.push({
+      type: "added",
+      blockId: event.block.id,
+      kind: event.block.kind,
+      text: event.block.text,
+      revisedHandle: { story: revisedStory, blockId: event.block.id },
+    });
+  }
+
+  detectMoves(changes, counts, firstMoveGroupId);
+  return { baseStory, revisedStory, changes, summaryCounts: counts };
 };
 
 /**
@@ -524,67 +725,35 @@ export const compareDocxVersions = async (
     FolioDocxReviewer.fromBuffer(base),
     FolioDocxReviewer.fromBuffer(revised),
   ]);
-  const baseBlocks = baseReviewer.snapshot().blocks;
-  const revisedBlocks = revisedReviewer.snapshot().blocks;
-
   const changes: FolioBlockDiff[] = [];
-  const counts: FolioVersionDiff["summaryCounts"] = {
-    added: 0,
-    deleted: 0,
-    modified: 0,
-    formatChanged: 0,
-    moved: 0,
-    unchanged: 0,
-  };
+  const stories: FolioStoryDiff[] = [];
+  const counts = createSummaryCounts();
+  const baseStories = baseReviewer.listStories().map(({ handle }) => handle);
+  const revisedStories = revisedReviewer.listStories().map(({ handle }) => handle);
+  let nextMoveGroupId = 1;
 
-  for (const event of alignFolioBlocks(baseBlocks, revisedBlocks)) {
-    if (event.type === "pair") {
-      const { baseBlock, revisedBlock } = event;
-      if (baseBlock.text !== revisedBlock.text) {
-        counts.modified++;
-        changes.push({
-          type: "modified",
-          blockId: revisedBlock.id,
-          kind: revisedBlock.kind,
-          segments: diffWordSegments(baseBlock.text, revisedBlock.text),
-        });
-        continue;
-      }
-      const changedProperties = diffPreviewRunFormatting(baseBlock, revisedBlock);
-      if (changedProperties.length > 0) {
-        counts.formatChanged++;
-        changes.push({
-          type: "formatChanged",
-          blockId: revisedBlock.id,
-          kind: revisedBlock.kind,
-          text: revisedBlock.text,
-          changedProperties,
-        });
-        continue;
-      }
-      counts.unchanged++;
-      continue;
-    }
-    if (event.type === "baseOnly") {
-      counts.deleted++;
-      changes.push({
-        type: "deleted",
-        blockId: event.block.id,
-        kind: event.block.kind,
-        text: event.block.text,
-      });
-      continue;
-    }
-    counts.added++;
-    changes.push({
-      type: "added",
-      blockId: event.block.id,
-      kind: event.block.kind,
-      text: event.block.text,
+  for (const pair of pairDocumentStories(baseStories, revisedStories)) {
+    const baseBlocks = pair.baseStory
+      ? (baseReviewer.readReviewedStory({ story: pair.baseStory, view: "final" })?.snapshot
+          .blocks ?? [])
+      : [];
+    const revisedBlocks = pair.revisedStory
+      ? (revisedReviewer.readReviewedStory({ story: pair.revisedStory, view: "final" })?.snapshot
+          .blocks ?? [])
+      : [];
+    const storyDiff = compareStoryBlocks({
+      ...pair,
+      baseBlocks,
+      revisedBlocks,
+      firstMoveGroupId: nextMoveGroupId,
     });
+    stories.push(storyDiff);
+    for (const change of storyDiff.changes) {
+      changes.push(change);
+    }
+    addSummaryCounts(counts, storyDiff.summaryCounts);
+    nextMoveGroupId += storyDiff.summaryCounts.moved;
   }
 
-  detectMoves(changes, counts);
-
-  return { changes, summaryCounts: counts };
+  return { changes, stories, summaryCounts: counts };
 };


### PR DESCRIPTION
Adds per-story version comparison with source-specific block handles.

CC on behalf of @jan-kubica