### PR TITLE
feat: add comparison privacy transforms

### DIFF
--- a/.changeset/add-comparison-privacy-transforms.md
+++ b/.changeset/add-comparison-privacy-transforms.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add auditable privacy transforms for version comparison output.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -22,6 +22,9 @@ export type ApplyFolioAIEditsToBufferResult = FolioAIEditApplyResult & {
     buffer: ArrayBuffer;
 };
 
+// @public
+export const applyFolioVersionDiffPrivacy: (diff: FolioVersionDiff, options: FolioVersionDiffPrivacyOptions) => FolioVersionDiff;
+
 // @public (undocumented)
 export const assertSupportedFolioDocumentOperationVersion: (value: unknown) => typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
 
@@ -202,6 +205,9 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replac
 
 // @public (undocumented)
 export const FOLIO_REVIEWED_VIEWS: readonly ["original", "current-markup", "final"];
+
+// @public (undocumented)
+export const FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
 
 // @public
 export const FOLIO_VERSION_COMPARISON_SCOPES: readonly ["text", "formatting", "metadata"];
@@ -415,7 +421,8 @@ export type FolioBlockId = string & {
 
 // @public (undocumented)
 export type FolioCompareDocxVersionsOptions = {
-    include?: readonly FolioVersionComparisonScope[];
+    include?: readonly FolioVersionComparisonScope[]; /** Optional output-only privacy transforms. Source buffers are never mutated. */
+    privacy?: FolioVersionDiffPrivacyOptions;
 };
 
 // @public (undocumented)
@@ -755,14 +762,29 @@ export type FolioVersionBlockHandle = {
 };
 
 // @public (undocumented)
+export type FolioVersionComparisonPrivacyTransform = (typeof FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS)[number];
+
+// @public (undocumented)
 export type FolioVersionComparisonScope = (typeof FOLIO_VERSION_COMPARISON_SCOPES)[number];
 
 // @public
 export type FolioVersionDiff = {
     changes: FolioBlockDiff[]; /** Per-story results in base order followed by stories added in the revised document. */
     stories: FolioStoryDiff[]; /** Changed package metadata fields in stable property order. */
-    metadataChanges: FolioMetadataDiff[]; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
+    metadataChanges: FolioMetadataDiff[]; /** Applied privacy policy and the fields it removed from this result. */
+    privacyReport: FolioVersionDiffPrivacyReport; /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
     summaryCounts: FolioVersionDiffSummaryCounts;
+};
+
+// @public (undocumented)
+export type FolioVersionDiffPrivacyOptions = {
+    transforms: readonly FolioVersionComparisonPrivacyTransform[];
+};
+
+// @public (undocumented)
+export type FolioVersionDiffPrivacyReport = {
+    appliedTransforms: FolioVersionComparisonPrivacyTransform[];
+    removedMetadataProperties: FolioDocumentMetadataProperty[];
 };
 
 // @public
@@ -827,6 +849,9 @@ export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumen
 
 // @public (undocumented)
 export const isFolioReviewedView: (value: unknown) => value is FolioReviewedView;
+
+// @public (undocumented)
+export const isFolioVersionComparisonPrivacyTransform: (value: unknown) => value is FolioVersionComparisonPrivacyTransform;
 
 // @public (undocumented)
 export const isFolioVersionComparisonScope: (value: unknown) => value is FolioVersionComparisonScope;

--- a/packages/agents/src/compare.test.ts
+++ b/packages/agents/src/compare.test.ts
@@ -19,6 +19,7 @@ describe("formatVersionDiffForLLM", () => {
       },
       stories: [],
       metadataChanges: [],
+      privacyReport: { appliedTransforms: [], removedMetadataProperties: [] },
       changes: [
         {
           type: "modified",
@@ -102,12 +103,41 @@ describe("formatVersionDiffForLLM", () => {
         { property: "title", baseValue: "Initial", revisedValue: "Revised" },
         { property: "creator", baseValue: "Author", revisedValue: null },
       ],
+      privacyReport: { appliedTransforms: [], removedMetadataProperties: [] },
     };
 
     expect(formatVersionDiffForLLM(diff).split("\n")).toEqual([
       "Version diff: 0 added, 0 deleted, 0 modified, 0 format-changed, 0 moved, 2 metadata-changed, 1 unchanged",
       '~ metadata.title: "Initial" -> "Revised"',
       '~ metadata.creator: "Author" -> null',
+    ]);
+  });
+
+  test("renders applied privacy transforms and their removal report", () => {
+    const diff: FolioAgentVersionDiff = {
+      summaryCounts: {
+        added: 0,
+        deleted: 0,
+        modified: 0,
+        formatChanged: 0,
+        moved: 0,
+        metadataChanged: 1,
+        unchanged: 1,
+      },
+      stories: [],
+      changes: [],
+      metadataChanges: [{ property: "revision", baseValue: 1, revisedValue: 2 }],
+      privacyReport: {
+        appliedTransforms: ["remove-attribution", "remove-timestamps"],
+        removedMetadataProperties: ["creator", "modified"],
+      },
+    };
+
+    expect(formatVersionDiffForLLM(diff).split("\n")).toEqual([
+      "Version diff: 0 added, 0 deleted, 0 modified, 0 format-changed, 0 moved, 1 metadata-changed, 1 unchanged",
+      "Privacy transforms: remove-attribution, remove-timestamps",
+      "Removed metadata fields: creator, modified",
+      "~ metadata.revision: 1 -> 2",
     ]);
   });
 });

--- a/packages/agents/src/compare.ts
+++ b/packages/agents/src/compare.ts
@@ -77,5 +77,14 @@ export const formatVersionDiffForLLM = (diff: FolioAgentVersionDiff): string => 
     ({ property, baseValue, revisedValue }) =>
       `~ metadata.${property}: ${JSON.stringify(baseValue)} -> ${JSON.stringify(revisedValue)}`,
   );
-  return [header, ...diff.changes.map(formatChangeLine), ...metadataLines].join("\n");
+  const privacyLines =
+    diff.privacyReport.appliedTransforms.length === 0
+      ? []
+      : [
+          `Privacy transforms: ${diff.privacyReport.appliedTransforms.join(", ")}`,
+          `Removed metadata fields: ${diff.privacyReport.removedMetadataProperties.join(", ") || "none"}`,
+        ];
+  return [header, ...privacyLines, ...diff.changes.map(formatChangeLine), ...metadataLines].join(
+    "\n",
+  );
 };

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -91,11 +91,14 @@ export {
   type FolioReviewReplyInput,
 } from "./ai-edits/headless";
 export {
+  applyFolioVersionDiffPrivacy,
   compareDocxVersions,
   FOLIO_DOCUMENT_METADATA_PROPERTIES,
   FOLIO_VERSION_COMPARISON_SCOPES,
+  FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS,
   InvalidFolioVersionComparisonOptionsError,
   isFolioVersionComparisonScope,
+  isFolioVersionComparisonPrivacyTransform,
   type FolioBlockDiff,
   type FolioCompareDocxVersionsOptions,
   type FolioDocumentMetadataProperty,
@@ -105,7 +108,10 @@ export {
   type FolioStoryDiff,
   type FolioVersionBlockHandle,
   type FolioVersionComparisonScope,
+  type FolioVersionComparisonPrivacyTransform,
   type FolioVersionDiff,
+  type FolioVersionDiffPrivacyOptions,
+  type FolioVersionDiffPrivacyReport,
   type FolioVersionDiffSummaryCounts,
   type FolioVersionDiffSegment,
 } from "./version-comparison";

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -19,7 +19,11 @@ import { createDocx } from "./docx/rezip";
 import { repackDocx } from "./docx/rezip";
 import type { HeaderFooter, Paragraph } from "./types/document";
 import { createEmptyDocument } from "./utils/createDocument";
-import { compareDocxVersions, exceedsLcsBudget } from "./version-comparison";
+import {
+  applyFolioVersionDiffPrivacy,
+  compareDocxVersions,
+  exceedsLcsBudget,
+} from "./version-comparison";
 import { InvalidFolioVersionComparisonOptionsError } from "./version-comparison";
 import type { FolioBlockDiff } from "./version-comparison";
 
@@ -55,9 +59,14 @@ const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuf
 
 type CorePropertiesFixture = {
   title?: string;
+  subject?: string;
   creator?: string;
+  keywords?: string;
+  description?: string;
+  lastModifiedBy?: string;
   revision?: number;
   created?: string;
+  modified?: string;
 };
 
 const escapeXml = (value: string): string =>
@@ -75,13 +84,28 @@ const withCoreProperties = async (
   const zip = await JSZip.loadAsync(buffer);
   const elements = [
     properties.title === undefined ? "" : `<dc:title>${escapeXml(properties.title)}</dc:title>`,
+    properties.subject === undefined
+      ? ""
+      : `<dc:subject>${escapeXml(properties.subject)}</dc:subject>`,
     properties.creator === undefined
       ? ""
       : `<dc:creator>${escapeXml(properties.creator)}</dc:creator>`,
+    properties.keywords === undefined
+      ? ""
+      : `<cp:keywords>${escapeXml(properties.keywords)}</cp:keywords>`,
+    properties.description === undefined
+      ? ""
+      : `<dc:description>${escapeXml(properties.description)}</dc:description>`,
+    properties.lastModifiedBy === undefined
+      ? ""
+      : `<cp:lastModifiedBy>${escapeXml(properties.lastModifiedBy)}</cp:lastModifiedBy>`,
     properties.revision === undefined ? "" : `<cp:revision>${properties.revision}</cp:revision>`,
     properties.created === undefined
       ? ""
       : `<dcterms:created>${escapeXml(properties.created)}</dcterms:created>`,
+    properties.modified === undefined
+      ? ""
+      : `<dcterms:modified>${escapeXml(properties.modified)}</dcterms:modified>`,
   ].join("");
   zip.file(
     "docProps/core.xml",
@@ -436,6 +460,58 @@ describe("compareDocxVersions: selected scopes", () => {
     expect(formattingDiff.summaryCounts.modified).toBe(0);
     expect(formattingDiff.summaryCounts.formatChanged).toBe(1);
     expect(formattingDiff.summaryCounts.unchanged).toBe(1);
+  });
+
+  test("removes selected metadata values and reports each applied transform", async () => {
+    const base = await withCoreProperties(
+      await buildDocxBuffer([{ text: "Stable text.", paraId: "00000001" }]),
+      {
+        title: "Initial title",
+        creator: "Initial author",
+        lastModifiedBy: "Initial reviewer",
+        description: "Initial description",
+        revision: 1,
+        created: "2026-07-01T10:30:00Z",
+        modified: "2026-07-02T10:30:00Z",
+      },
+    );
+    const revised = await withCoreProperties(
+      await buildDocxBuffer([{ text: "Stable text.", paraId: "00000001" }]),
+      {
+        title: "Revised title",
+        creator: "Revised author",
+        lastModifiedBy: "Revised reviewer",
+        description: "Revised description",
+        revision: 2,
+        created: "2026-07-03T10:30:00Z",
+        modified: "2026-07-04T10:30:00Z",
+      },
+    );
+
+    const diff = await compareDocxVersions(base, revised, {
+      include: ["metadata"],
+      privacy: {
+        transforms: ["remove-descriptive-metadata", "remove-timestamps", "remove-attribution"],
+      },
+    });
+
+    expect(diff.metadataChanges).toEqual([{ property: "revision", baseValue: 1, revisedValue: 2 }]);
+    expect(diff.summaryCounts.metadataChanged).toBe(1);
+    expect(diff.privacyReport).toEqual({
+      appliedTransforms: ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"],
+      removedMetadataProperties: [
+        "title",
+        "creator",
+        "description",
+        "lastModifiedBy",
+        "created",
+        "modified",
+      ],
+    });
+
+    expect(
+      applyFolioVersionDiffPrivacy(diff, { transforms: ["remove-attribution"] }).privacyReport,
+    ).toEqual(diff.privacyReport);
   });
 
   test("rejects an empty scope selection", async () => {

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -100,13 +100,16 @@ export const isFolioVersionComparisonScope = (
 export type FolioCompareDocxVersionsOptions = {
   /** Selected scopes; defaults to text and formatting. */
   include?: readonly FolioVersionComparisonScope[];
+  /** Optional output-only privacy transforms. Source buffers are never mutated. */
+  privacy?: FolioVersionDiffPrivacyOptions;
 };
 
 export class InvalidFolioVersionComparisonOptionsError extends TaggedError(
   "InvalidFolioVersionComparisonOptionsError",
 )<{
   message: string;
-  receivedInclude: readonly unknown[];
+  option: "include" | "privacy.transforms";
+  receivedValue: unknown;
 }>() {}
 
 export const FOLIO_DOCUMENT_METADATA_PROPERTIES = Object.freeze([
@@ -128,6 +131,29 @@ export type FolioMetadataDiff = {
   property: FolioDocumentMetadataProperty;
   baseValue: FolioDocumentMetadataValue;
   revisedValue: FolioDocumentMetadataValue;
+};
+
+export const FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS = Object.freeze([
+  "remove-attribution",
+  "remove-timestamps",
+  "remove-descriptive-metadata",
+] as const);
+
+export type FolioVersionComparisonPrivacyTransform =
+  (typeof FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS)[number];
+
+export const isFolioVersionComparisonPrivacyTransform = (
+  value: unknown,
+): value is FolioVersionComparisonPrivacyTransform =>
+  FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS.some((transform) => transform === value);
+
+export type FolioVersionDiffPrivacyOptions = {
+  transforms: readonly FolioVersionComparisonPrivacyTransform[];
+};
+
+export type FolioVersionDiffPrivacyReport = {
+  appliedTransforms: FolioVersionComparisonPrivacyTransform[];
+  removedMetadataProperties: FolioDocumentMetadataProperty[];
 };
 
 /** Run-level formatting properties compared for `formatChanged` detection. */
@@ -226,6 +252,8 @@ export type FolioVersionDiff = {
   stories: FolioStoryDiff[];
   /** Changed package metadata fields in stable property order. */
   metadataChanges: FolioMetadataDiff[];
+  /** Applied privacy policy and the fields it removed from this result. */
+  privacyReport: FolioVersionDiffPrivacyReport;
   /** Counts across every paired/unpaired block, including the unchanged blocks `changes` omits. `moved` counts pairs, not entries. */
   summaryCounts: FolioVersionDiffSummaryCounts;
 };
@@ -791,10 +819,79 @@ const resolveComparisonScopes = (
   if (include.length === 0 || include.some((scope) => !isFolioVersionComparisonScope(scope))) {
     throw new InvalidFolioVersionComparisonOptionsError({
       message: "Version comparison requires at least one recognized scope",
-      receivedInclude: include,
+      option: "include",
+      receivedValue: include,
     });
   }
   return new Set(include);
+};
+
+const PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM = {
+  "remove-attribution": ["creator", "lastModifiedBy"],
+  "remove-timestamps": ["created", "modified"],
+  "remove-descriptive-metadata": ["title", "subject", "keywords", "description"],
+} as const satisfies Record<
+  FolioVersionComparisonPrivacyTransform,
+  readonly FolioDocumentMetadataProperty[]
+>;
+
+const resolvePrivacyTransforms = (
+  transforms: unknown,
+): FolioVersionComparisonPrivacyTransform[] => {
+  if (
+    !Array.isArray(transforms) ||
+    transforms.some((transform) => !isFolioVersionComparisonPrivacyTransform(transform))
+  ) {
+    throw new InvalidFolioVersionComparisonOptionsError({
+      message: "Version comparison received an unrecognized privacy transform",
+      option: "privacy.transforms",
+      receivedValue: transforms,
+    });
+  }
+  const requested = new Set(transforms);
+  return FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS.filter((transform) =>
+    requested.has(transform),
+  );
+};
+
+/** Apply auditable, output-only privacy transforms to a structured version diff. */
+export const applyFolioVersionDiffPrivacy = (
+  diff: FolioVersionDiff,
+  options: FolioVersionDiffPrivacyOptions,
+): FolioVersionDiff => {
+  const requestedTransforms = resolvePrivacyTransforms(options.transforms);
+  const appliedTransformSet = new Set([
+    ...diff.privacyReport.appliedTransforms,
+    ...requestedTransforms,
+  ]);
+  const appliedTransforms = FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS.filter((transform) =>
+    appliedTransformSet.has(transform),
+  );
+  const removedPropertySet = new Set<FolioDocumentMetadataProperty>();
+  for (const transform of appliedTransforms) {
+    for (const property of PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM[transform]) {
+      removedPropertySet.add(property);
+    }
+  }
+  const actuallyRemovedPropertySet = new Set([
+    ...diff.privacyReport.removedMetadataProperties,
+    ...diff.metadataChanges
+      .filter(({ property }) => removedPropertySet.has(property))
+      .map(({ property }) => property),
+  ]);
+  const removedMetadataProperties = FOLIO_DOCUMENT_METADATA_PROPERTIES.filter((property) =>
+    actuallyRemovedPropertySet.has(property),
+  );
+  const metadataChanges = diff.metadataChanges.filter(
+    ({ property }) => !removedPropertySet.has(property),
+  );
+
+  return {
+    ...diff,
+    metadataChanges,
+    privacyReport: { appliedTransforms, removedMetadataProperties },
+    summaryCounts: { ...diff.summaryCounts, metadataChanged: metadataChanges.length },
+  };
 };
 
 type DocumentProperties = ReturnType<FolioDocxReviewer["getDocumentProperties"]>;
@@ -875,5 +972,15 @@ export const compareDocxVersions = async (
     : [];
   counts.metadataChanged = metadataChanges.length;
 
-  return { changes, stories, metadataChanges, summaryCounts: counts };
+  const diff: FolioVersionDiff = {
+    changes,
+    stories,
+    metadataChanges,
+    privacyReport: {
+      appliedTransforms: [],
+      removedMetadataProperties: [],
+    },
+    summaryCounts: counts,
+  };
+  return options.privacy ? applyFolioVersionDiffPrivacy(diff, options.privacy) : diff;
 };


### PR DESCRIPTION
Adds output-only privacy transforms for version comparison metadata, with a structured removal report.

Threads the report through the agent-facing formatter.