### PR TITLE
fix: default hanging punctuation to enabled

### DIFF
--- a/.changeset/calm-hanging-punctuation.md
+++ b/.changeset/calm-hanging-punctuation.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Default omitted paragraph hanging-punctuation settings to enabled during line layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -567,7 +567,7 @@ export type PaginatorOptions = {
 // @public
 export type ParagraphAttrs = {
     alignment?: "left" | "center" | "right" | "justify"; /** East Asian first/last-character restrictions (`w:kinsoku`). */
-    kinsoku?: boolean; /** Hanging punctuation (`w:overflowPunct`), retained for layout policy. */
+    kinsoku?: boolean; /** Hanging punctuation (`w:overflowPunct`); defaults to enabled when omitted. */
     overflowPunctuation?: boolean; /** Exempt this paragraph from document automatic hyphenation. */
     suppressAutoHyphens?: boolean; /** Document-wide automatic hyphenation controls retained for line layout. */
     automaticHyphenation?: {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -2181,20 +2181,24 @@ describe("CJK line breaking", () => {
     );
   });
 
-  test("allows trailing punctuation to hang when w:overflowPunct is enabled", () => {
+  test("defaults to hanging punctuation unless w:overflowPunct is disabled", () => {
     withFakeTextMeasure(
       () => {
-        const paragraph = (overflowPunctuation: boolean): ParagraphBlock => ({
+        const paragraph = (overflowPunctuation?: boolean): ParagraphBlock => ({
           kind: "paragraph",
-          id: `cjk-overflow-punctuation-${overflowPunctuation}`,
+          id: `cjk-overflow-punctuation-${String(overflowPunctuation)}`,
           runs: [{ kind: "text", text: "中文。", language: { eastAsia: "zh-CN" } }],
-          attrs: { overflowPunctuation },
+          ...(overflowPunctuation === undefined ? {} : { attrs: { overflowPunctuation } }),
         });
 
         expect(measureParagraph(paragraph(false), 20).lines).toHaveLength(2);
-        const hanging = measureParagraph(paragraph(true), 20);
-        expect(hanging.lines).toHaveLength(1);
-        expect(hanging.lines[0]?.width).toBe(30);
+        for (const hanging of [
+          measureParagraph(paragraph(), 20),
+          measureParagraph(paragraph(true), 20),
+        ]) {
+          expect(hanging.lines).toHaveLength(1);
+          expect(hanging.lines[0]?.width).toBe(30);
+        }
       },
       { charWidth: fixedCharWidth(10) },
     );

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -736,7 +736,7 @@ function trailingHangingPunctuationWidth(
   policy: LineBreakPolicy,
   enabled: boolean | undefined,
 ): number {
-  if (!enabled || text.length === 0) {
+  if (enabled === false || text.length === 0) {
     return 0;
   }
   const boundaries = findGraphemeBreaks(text, policy);

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -379,7 +379,7 @@ export type ParagraphAttrs = {
   alignment?: "left" | "center" | "right" | "justify";
   /** East Asian first/last-character restrictions (`w:kinsoku`). */
   kinsoku?: boolean;
-  /** Hanging punctuation (`w:overflowPunct`), retained for layout policy. */
+  /** Hanging punctuation (`w:overflowPunct`); defaults to enabled when omitted. */
   overflowPunctuation?: boolean;
   /** Exempt this paragraph from document automatic hyphenation. */
   suppressAutoHyphens?: boolean;


### PR DESCRIPTION
## Summary

- honor the OOXML default when `w:overflowPunct` is omitted
- preserve explicit paragraph opt-out behavior
- cover omitted, enabled, and disabled line fitting states