### PR TITLE
feat: add story-aware redline views

### DIFF
--- a/.changeset/story-aware-redlines.md
+++ b/.changeset/story-aware-redlines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Generate tracked changes across matched document stories with selectable resolved input views.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -83,6 +83,9 @@ export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "foot
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
 
 // @public (undocumented)
+export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
+
+// @public (undocumented)
 export const FOLIO_REVIEWED_VIEWS: readonly ["original", "current-markup", "final"];
 
 // @public (undocumented)
@@ -491,6 +494,15 @@ export type FolioReadReviewedStoryOptions = {
     view?: FolioReviewedView;
 };
 
+// @public (undocumented)
+export type FolioResolvedReviewedView = (typeof FOLIO_RESOLVED_REVIEWED_VIEWS)[number];
+
+// @public (undocumented)
+export type FolioResolveReviewedStoryOptions = {
+    story?: FolioEditableDocumentStoryHandle;
+    view: FolioResolvedReviewedView;
+};
+
 // @public
 export type FolioReviewChange = {
     id: number;
@@ -545,6 +557,9 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;
+
+// @public (undocumented)
+export const isFolioResolvedReviewedView: (value: unknown) => value is FolioResolvedReviewedView;
 
 // @public (undocumented)
 export const isFolioReviewedView: (value: unknown) => value is FolioReviewedView;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -204,6 +204,9 @@ export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "foot
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
 
 // @public (undocumented)
+export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
+
+// @public (undocumented)
 export const FOLIO_REVIEWED_VIEWS: readonly ["original", "current-markup", "final"];
 
 // @public (undocumented)
@@ -651,6 +654,7 @@ export class FolioDocxReviewer {
     resolveComment(commentId: string, options?: {
         resolved?: boolean;
     }): boolean;
+    resolveReviewedStory(input: FolioResolveReviewedStoryOptions): boolean;
     snapshot(): FolioAIEditSnapshot;
     snapshotStory(story: FolioEditableDocumentStoryHandle): FolioAIEditSnapshot | null;
     toBuffer(): Promise<ArrayBuffer>;
@@ -681,6 +685,15 @@ export type FolioMetadataDiff = {
 export type FolioReadReviewedStoryOptions = {
     story?: FolioEditableDocumentStoryHandle;
     view?: FolioReviewedView;
+};
+
+// @public (undocumented)
+export type FolioResolvedReviewedView = (typeof FOLIO_RESOLVED_REVIEWED_VIEWS)[number];
+
+// @public (undocumented)
+export type FolioResolveReviewedStoryOptions = {
+    story?: FolioEditableDocumentStoryHandle;
+    view: FolioResolvedReviewedView;
 };
 
 // @public
@@ -806,12 +819,24 @@ export const generateRedlineDocx: (base: ArrayBuffer, revised: ArrayBuffer, opti
 
 // @public
 export type GenerateRedlineDocxOptions = {
-    author?: string;
+    author?: string; /** Resolved base input state. (default: `"final"`) */
+    baseView?: FolioResolvedReviewedView; /** Resolved revised input state. (default: `"final"`) */
+    revisedView?: FolioResolvedReviewedView;
 };
 
 // @public
-export type GenerateRedlineDocxResult = FolioAIEditApplyResult & {
-    buffer: ArrayBuffer;
+export type GenerateRedlineDocxResult = {
+    buffer: ArrayBuffer; /** Operations applied across every matched story. */
+    applied: FolioAIEditAppliedOperation[]; /** Block operations that could not be applied. */
+    skipped: FolioAIEditSkippedOperation[]; /** Package parts that could not be represented as story-scoped text edits. */
+    unprocessedStories: GenerateRedlineUnprocessedStory[];
+};
+
+// @public (undocumented)
+export type GenerateRedlineUnprocessedStory = {
+    baseStory: FolioDocumentStoryHandle | null;
+    revisedStory: FolioDocumentStoryHandle | null;
+    reason: "missing-base-story" | "missing-revised-story";
 };
 
 // @public (undocumented)
@@ -841,11 +866,17 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
 // @public (undocumented)
 export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
 
+// @public (undocumented)
+export class InvalidGenerateRedlineDocxOptionsError extends InvalidGenerateRedlineDocxOptionsError_base {}
+
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;
+
+// @public (undocumented)
+export const isFolioResolvedReviewedView: (value: unknown) => value is FolioResolvedReviewedView;
 
 // @public (undocumented)
 export const isFolioReviewedView: (value: unknown) => value is FolioReviewedView;

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -208,6 +208,10 @@ export const FOLIO_REVIEWED_VIEWS = Object.freeze(["original", "current-markup",
 
 export type FolioReviewedView = (typeof FOLIO_REVIEWED_VIEWS)[number];
 
+export const FOLIO_RESOLVED_REVIEWED_VIEWS = Object.freeze(["original", "final"] as const);
+
+export type FolioResolvedReviewedView = (typeof FOLIO_RESOLVED_REVIEWED_VIEWS)[number];
+
 export type FolioDocumentStoryHandle =
   | { type: "main" }
   | { type: "header"; relationshipId: string }
@@ -225,6 +229,11 @@ export type FolioDocumentStory = {
 export type FolioReadReviewedStoryOptions = {
   story?: FolioEditableDocumentStoryHandle;
   view?: FolioReviewedView;
+};
+
+export type FolioResolveReviewedStoryOptions = {
+  story?: FolioEditableDocumentStoryHandle;
+  view: FolioResolvedReviewedView;
 };
 
 export type FolioReviewedStory = {
@@ -293,6 +302,9 @@ const secondaryStoryKey = (story: FolioSecondaryStoryHandle): string =>
 
 export const isFolioReviewedView = (value: unknown): value is FolioReviewedView =>
   FOLIO_REVIEWED_VIEWS.some((view) => view === value);
+
+export const isFolioResolvedReviewedView = (value: unknown): value is FolioResolvedReviewedView =>
+  FOLIO_RESOLVED_REVIEWED_VIEWS.some((view) => view === value);
 
 const applyCommandToState = (state: EditorState, command: Command): EditorState => {
   let nextState = state;
@@ -556,6 +568,22 @@ export class FolioDocxReviewer {
       text: formatStoryStateForLLM(state, view === "current-markup"),
       changes: getTrackedChangesFromDoc(state.doc),
     };
+  }
+
+  /** Resolve one editable story to its original or final state. */
+  resolveReviewedStory({ story = MAIN_STORY, view }: FolioResolveReviewedStoryOptions): boolean {
+    if (!isFolioResolvedReviewedView(view)) {
+      throw new UnsupportedFolioReviewedViewError({
+        message: "Only original and final views can replace editable story state.",
+        receivedView: view,
+      });
+    }
+    const sourceState = this.getEditableStoryState(story);
+    if (!sourceState) {
+      return false;
+    }
+    this.setEditableStoryState(story, resolveReviewedState(sourceState, view));
+    return true;
   }
 
   /**

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -23,15 +23,19 @@ export { getFolioDocumentOutline, readFolioDocumentSection } from "./scoped-read
 export { getFolioParaIdFromBlockId } from "../types/block-id";
 export { diffWordSegments } from "./word-diff";
 export {
+  FOLIO_RESOLVED_REVIEWED_VIEWS,
   FOLIO_REVIEWED_VIEWS,
   FolioDocumentStoryNotFoundError,
   UnsupportedFolioReviewedViewError,
+  isFolioResolvedReviewedView,
   isFolioReviewedView,
   type FolioApplyDocumentOperationsToStoryOptions,
   type FolioDocumentStory,
   type FolioDocumentStoryHandle,
   type FolioEditableDocumentStoryHandle,
   type FolioReadReviewedStoryOptions,
+  type FolioResolveReviewedStoryOptions,
+  type FolioResolvedReviewedView,
   type FolioReviewedStory,
   type FolioReviewedView,
 } from "./headless";

--- a/packages/core/src/document-stories.ts
+++ b/packages/core/src/document-stories.ts
@@ -1,0 +1,39 @@
+import type { FolioDocumentStoryHandle } from "./ai-edits/headless";
+
+export type FolioDocumentStoryPair = {
+  baseStory: FolioDocumentStoryHandle | null;
+  revisedStory: FolioDocumentStoryHandle | null;
+};
+
+const documentStoryKey = (story: FolioDocumentStoryHandle): string => {
+  if (story.type === "main") {
+    return story.type;
+  }
+  if (story.type === "header" || story.type === "footer") {
+    return `${story.type}:${story.relationshipId}`;
+  }
+  return `${story.type}:${String(story.noteId)}`;
+};
+
+export const pairFolioDocumentStories = (
+  baseStories: readonly FolioDocumentStoryHandle[],
+  revisedStories: readonly FolioDocumentStoryHandle[],
+): FolioDocumentStoryPair[] => {
+  const revisedByKey = new Map(revisedStories.map((story) => [documentStoryKey(story), story]));
+  const pairedKeys = new Set<string>();
+  const pairs: FolioDocumentStoryPair[] = [];
+  for (const baseStory of baseStories) {
+    const key = documentStoryKey(baseStory);
+    const revisedStory = revisedByKey.get(key) ?? null;
+    pairs.push({ baseStory, revisedStory });
+    if (revisedStory) {
+      pairedKeys.add(key);
+    }
+  }
+  for (const revisedStory of revisedStories) {
+    if (!pairedKeys.has(documentStoryKey(revisedStory))) {
+      pairs.push({ baseStory: null, revisedStory });
+    }
+  }
+  return pairs;
+};

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -14,10 +14,14 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
 
 import { FolioDocxReviewer } from "./ai-edits/headless";
+import { parseDocx } from "./docx/parser";
 import { createDocx } from "./docx/rezip";
-import { generateRedlineDocx } from "./redline";
+import { repackDocx } from "./docx/rezip";
+import { generateRedlineDocx, InvalidGenerateRedlineDocxOptionsError } from "./redline";
+import type { HeaderFooter, Paragraph } from "./types/document";
 import { createEmptyDocument } from "./utils/createDocument";
 
 type ParagraphSpec = { text: string; paraId?: string };
@@ -42,6 +46,136 @@ const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuf
 
 const blockTexts = (reviewer: FolioDocxReviewer): string[] =>
   reviewer.snapshot().blocks.map((block) => block.text);
+
+const storyParagraph = (text: string, paraId: string): Paragraph => ({
+  type: "paragraph",
+  paraId,
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+});
+
+const headerFooterStory = (
+  type: "header" | "footer",
+  text: string,
+  paraId: string,
+): HeaderFooter => ({
+  type,
+  hdrFtrType: "default",
+  content: [storyParagraph(text, paraId)],
+});
+
+type StoryDocumentOptions = {
+  bodyText: string;
+  headerText?: string;
+  footerText?: string;
+  footnoteText?: string;
+  endnoteText?: string;
+};
+
+const buildStoryDocument = async ({
+  bodyText,
+  headerText,
+  footerText,
+  footnoteText,
+  endnoteText,
+}: StoryDocumentOptions): Promise<ArrayBuffer> => {
+  const source = await buildDocxBuffer([{ text: bodyText, paraId: "A1000001" }]);
+  const document = await parseDocx(source, { detectVariables: false, preloadFonts: false });
+  if (headerText !== undefined) {
+    document.package.headers = new Map([
+      ["rIdHeader", headerFooterStory("header", headerText, "B1000001")],
+    ]);
+    document.package.document.finalSectionProperties = {
+      ...document.package.document.finalSectionProperties,
+      headerReferences: [{ type: "default", rId: "rIdHeader" }],
+    };
+  }
+  if (footerText !== undefined) {
+    document.package.footers = new Map([
+      ["rIdFooter", headerFooterStory("footer", footerText, "C1000001")],
+    ]);
+    document.package.document.finalSectionProperties = {
+      ...document.package.document.finalSectionProperties,
+      footerReferences: [{ type: "default", rId: "rIdFooter" }],
+    };
+  }
+  const materialized = await repackDocx(document, { updateModifiedDate: false });
+  if (footnoteText === undefined && endnoteText === undefined) {
+    return materialized;
+  }
+
+  const zip = await JSZip.loadAsync(materialized);
+  const contentTypesFile = zip.file("[Content_Types].xml");
+  const relationshipsFile = zip.file("word/_rels/document.xml.rels");
+  if (!contentTypesFile || !relationshipsFile) {
+    throw new Error("expected package metadata parts");
+  }
+  const contentTypes = await contentTypesFile.async("text");
+  const relationships = await relationshipsFile.async("text");
+  const contentTypeOverrides = [
+    footnoteText === undefined
+      ? ""
+      : '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>',
+    endnoteText === undefined
+      ? ""
+      : '<Override PartName="/word/endnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml"/>',
+  ].join("");
+  const noteRelationships = [
+    footnoteText === undefined
+      ? ""
+      : '<Relationship Id="rIdFootnotes" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>',
+    endnoteText === undefined
+      ? ""
+      : '<Relationship Id="rIdEndnotes" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/>',
+  ].join("");
+  zip.file(
+    "[Content_Types].xml",
+    contentTypes.replace("</Types>", `${contentTypeOverrides}</Types>`),
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    relationships.replace("</Relationships>", `${noteRelationships}</Relationships>`),
+  );
+  if (footnoteText !== undefined) {
+    zip.file(
+      "word/footnotes.xml",
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:footnote w:id="2"><w:p w14:paraId="D1000001"><w:r><w:t>${footnoteText}</w:t></w:r></w:p></w:footnote></w:footnotes>`,
+    );
+  }
+  if (endnoteText !== undefined) {
+    zip.file(
+      "word/endnotes.xml",
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="E1000001"><w:r><w:t>${endnoteText}</w:t></w:r></w:p></w:endnote></w:endnotes>`,
+    );
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const storyTextByType = (
+  reviewer: FolioDocxReviewer,
+  view: "original" | "final",
+): Record<string, string> => {
+  const texts: Record<string, string> = {};
+  for (const { handle } of reviewer.listStories()) {
+    const story = reviewer.readReviewedStory({ story: handle, view });
+    if (story) {
+      texts[handle.type] = story.snapshot.blocks.map(({ text }) => text).join("\n");
+    }
+  }
+  return texts;
+};
+
+const withPendingMainChange = async (source: ArrayBuffer, text: string): Promise<ArrayBuffer> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(source, { author: "Source reviewer" });
+  const target = reviewer.snapshot().blocks.at(0);
+  if (!target) {
+    throw new Error("expected a main-story block");
+  }
+  reviewer.applyOperations(
+    [{ id: "source-change", type: "replaceBlock", blockId: target.id, text }],
+    { mode: "tracked-changes" },
+  );
+  return reviewer.toBuffer();
+};
 
 describe("generateRedlineDocx", () => {
   test("accept-all reproduces the revised document; reject-all restores the base", async () => {
@@ -77,6 +211,7 @@ describe("generateRedlineDocx", () => {
     const result = await generateRedlineDocx(base, revised);
 
     expect(result.skipped).toEqual([]);
+    expect(result.unprocessedStories).toEqual([]);
     expect(result.applied.length).toBeGreaterThan(0);
 
     // The redline carries real tracked changes attributed to the default author.
@@ -197,5 +332,105 @@ describe("generateRedlineDocx", () => {
     const view = await FolioDocxReviewer.fromBuffer(result.buffer);
     const authors = new Set(view.getChanges().map((change) => change.author));
     expect(authors).toEqual(new Set(["Jan Kubica"]));
+  });
+
+  test("redlines matched body, header, footer, footnote, and endnote stories", async () => {
+    const base = await buildStoryDocument({
+      bodyText: "Body baseline.",
+      headerText: "Header baseline.",
+      footerText: "Footer baseline.",
+      footnoteText: "Footnote baseline.",
+      endnoteText: "Endnote baseline.",
+    });
+    const revised = await buildStoryDocument({
+      bodyText: "Body revised.",
+      headerText: "Header revised.",
+      footerText: "Footer revised.",
+      footnoteText: "Footnote revised.",
+      endnoteText: "Endnote revised.",
+    });
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.skipped).toEqual([]);
+    expect(result.unprocessedStories).toEqual([]);
+    expect(result.applied).toHaveLength(5);
+    const output = await FolioDocxReviewer.fromBuffer(result.buffer);
+    expect(storyTextByType(output, "original")).toEqual({
+      main: "Body baseline.",
+      header: "Header baseline.",
+      footer: "Footer baseline.",
+      footnote: "Footnote baseline.",
+      endnote: "Endnote baseline.",
+    });
+    expect(storyTextByType(output, "final")).toEqual({
+      main: "Body revised.",
+      header: "Header revised.",
+      footer: "Footer revised.",
+      footnote: "Footnote revised.",
+      endnote: "Endnote revised.",
+    });
+  });
+
+  test("selects original or final input views independently", async () => {
+    const base = await withPendingMainChange(
+      await buildDocxBuffer([{ text: "Base original.", paraId: "00000001" }]),
+      "Base final.",
+    );
+    const revised = await withPendingMainChange(
+      await buildDocxBuffer([{ text: "Revised original.", paraId: "00000001" }]),
+      "Revised final.",
+    );
+
+    const result = await generateRedlineDocx(base, revised, {
+      baseView: "original",
+      revisedView: "original",
+    });
+    const output = await FolioDocxReviewer.fromBuffer(result.buffer);
+
+    expect(output.readReviewedStory({ view: "original" })?.snapshot.blocks.at(0)?.text).toBe(
+      "Base original.",
+    );
+    expect(output.readReviewedStory({ view: "final" })?.snapshot.blocks.at(0)?.text).toBe(
+      "Revised original.",
+    );
+  });
+
+  test("reports package parts that exist on only one side", async () => {
+    const base = await buildStoryDocument({
+      bodyText: "Body text.",
+      headerText: "Removed header.",
+    });
+    const revised = await buildStoryDocument({
+      bodyText: "Body text.",
+      footerText: "Added footer.",
+    });
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.unprocessedStories).toEqual([
+      {
+        baseStory: { type: "header", relationshipId: "rIdHeader" },
+        revisedStory: null,
+        reason: "missing-revised-story",
+      },
+      {
+        baseStory: null,
+        revisedStory: { type: "footer", relationshipId: "rIdFooter" },
+        reason: "missing-base-story",
+      },
+    ]);
+  });
+
+  test("rejects unresolved markup as an input view", async () => {
+    const document = await buildDocxBuffer([{ text: "Body text.", paraId: "00000001" }]);
+
+    await expect(
+      Reflect.apply(generateRedlineDocx, undefined, [
+        document,
+        document,
+        { baseView: "current-markup" },
+      ]),
+    ).rejects.toBeInstanceOf(InvalidGenerateRedlineDocxOptionsError);
   });
 });

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -1,67 +1,74 @@
 /**
- * Redline generator: compare two `.docx` buffers and produce a THIRD `.docx`
- * whose differences are recorded as real Word tracked changes (`w:ins` /
- * `w:del`), ready for review in Word or the folio editor — the
- * document-producing counterpart to {@link compareDocxVersions}'s structured
- * diff.
+ * Compare two `.docx` buffers and produce a third buffer whose text
+ * differences are represented as tracked changes.
  *
- * The pipeline is a composition of existing machinery, not a new engine:
- * the base buffer is opened in a headless {@link FolioDocxReviewer}, the two
- * snapshots are aligned with {@link alignFolioBlocks} (the same three-pass
- * alignment the comparer uses), each alignment event maps onto a
- * tracked-changes {@link FolioAIEditOperation}, and the reviewer's shared
- * apply path records them as redlines. Word-level minimality comes free:
- * the apply engine word-diffs a `replaceBlock` and only marks the divergent
- * tokens.
- *
- * ## Semantics and limitations
- *
- * - **As-accepted inputs.** Pending tracked changes in either input count as
- *   applied before comparison (mirroring {@link compareDocxVersions}): the
- *   base's own pending redlines are accepted in the output, so the tracked
- *   changes it carries are exactly base → revised. This is intentionally
- *   lossy about the inputs' own revision history and authorship.
- * - **Text redlines only.** Format-only changes and relocated blocks are
- *   redlined as plain edits (a move becomes a delete + insert, like Word
- *   compare with move detection off); block-level formatting is carried via
- *   the revised block's `styleId` on inserted blocks.
- * - **Anchoring.** Insertions anchor `before` the next surviving base block
- *   so consecutive additions keep their order; additions past the last base
- *   block anchor `after` it. A base document with no content blocks offers
- *   no anchor at all — such additions surface in `skipped` rather than
- *   silently vanishing.
+ * Each matched editable story is processed independently through the shared
+ * block alignment and document-operation paths. Package parts that exist on
+ * only one side are reported because creating or removing those parts is a
+ * distinct package-level operation.
  */
 
-import { FolioDocxReviewer } from "./ai-edits/headless";
-import type { FolioAIEditApplyResult, FolioAIEditOperation } from "./ai-edits/types";
+import { panic, TaggedError } from "better-result";
+
+import {
+  FolioDocxReviewer,
+  isFolioResolvedReviewedView,
+  type FolioDocumentStoryHandle,
+  type FolioResolvedReviewedView,
+} from "./ai-edits/headless";
+import type {
+  FolioAIBlock,
+  FolioAIEditAppliedOperation,
+  FolioAIEditOperation,
+  FolioAIEditSkippedOperation,
+  FolioAIEditSnapshot,
+} from "./ai-edits/types";
+import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "./document-operations";
+import { pairFolioDocumentStories } from "./document-stories";
 import { alignFolioBlocks, type FolioAlignedBlockEvent } from "./version-comparison";
 
 /** Options for {@link generateRedlineDocx}. */
 export type GenerateRedlineDocxOptions = {
   /** Author recorded on the generated tracked changes. (default: `"folio compare"`) */
   author?: string;
+  /** Resolved base input state. (default: `"final"`) */
+  baseView?: FolioResolvedReviewedView;
+  /** Resolved revised input state. (default: `"final"`) */
+  revisedView?: FolioResolvedReviewedView;
+};
+
+export class InvalidGenerateRedlineDocxOptionsError extends TaggedError(
+  "InvalidGenerateRedlineDocxOptionsError",
+)<{
+  message: string;
+  option: "baseView" | "revisedView";
+  receivedValue: unknown;
+}>() {}
+
+export type GenerateRedlineUnprocessedStory = {
+  baseStory: FolioDocumentStoryHandle | null;
+  revisedStory: FolioDocumentStoryHandle | null;
+  reason: "missing-base-story" | "missing-revised-story";
 };
 
 /** Result of {@link generateRedlineDocx}. */
-export type GenerateRedlineDocxResult = FolioAIEditApplyResult & {
-  /** The redline `.docx`: the base document with base → revised tracked changes. */
+export type GenerateRedlineDocxResult = {
+  /** The base package with generated tracked changes. */
   buffer: ArrayBuffer;
+  /** Operations applied across every matched story. */
+  applied: FolioAIEditAppliedOperation[];
+  /** Block operations that could not be applied. */
+  skipped: FolioAIEditSkippedOperation[];
+  /** Package parts that could not be represented as story-scoped text edits. */
+  unprocessedStories: GenerateRedlineUnprocessedStory[];
 };
 
-/**
- * For each event index, the base block id the next `revisedOnly` event
- * should anchor before: the base side of the nearest later `pair` or
- * `baseOnly` event, or `null` when only additions remain until the end of
- * the document. One backward pass, so a long run of trailing additions
- * (huge revised document vs. a small base) stays linear instead of
- * re-scanning the tail per added block.
- */
 const nextBaseBlockIdByIndex = (events: readonly FolioAlignedBlockEvent[]): (string | null)[] => {
   const nextIds = Array.from<string | null>({ length: events.length });
   let nextId: string | null = null;
-  for (let i = events.length - 1; i >= 0; i--) {
-    nextIds[i] = nextId;
-    const event = events[i];
+  for (let index = events.length - 1; index >= 0; index--) {
+    nextIds[index] = nextId;
+    const event = events[index];
     if (event?.type === "pair") {
       nextId = event.baseBlock.id;
     } else if (event?.type === "baseOnly") {
@@ -71,34 +78,20 @@ const nextBaseBlockIdByIndex = (events: readonly FolioAlignedBlockEvent[]): (str
   return nextIds;
 };
 
-/**
- * Compare `base` and `revised` and return the base document with every
- * difference recorded as a tracked change. See the module doc comment for
- * semantics and limitations; `skipped` reports any block the generator could
- * not redline (e.g. additions with no anchor in an empty base document).
- */
-export const generateRedlineDocx = async (
-  base: ArrayBuffer,
-  revised: ArrayBuffer,
-  options: GenerateRedlineDocxOptions = {},
-): Promise<GenerateRedlineDocxResult> => {
-  const [baseReviewer, revisedReviewer] = await Promise.all([
-    FolioDocxReviewer.fromBuffer(base, { author: options.author ?? "folio compare" }),
-    FolioDocxReviewer.fromBuffer(revised),
-  ]);
-  // As-accepted semantics: resolve the base's own pending redlines first so
-  // the output's tracked changes describe exactly base -> revised.
-  baseReviewer.acceptAll();
-  const baseSnapshot = baseReviewer.snapshot();
-  const revisedBlocks = revisedReviewer.snapshot().blocks;
+type BuildRedlineOperationsOptions = {
+  baseSnapshot: FolioAIEditSnapshot;
+  revisedBlocks: readonly FolioAIBlock[];
+  nextOperationId: () => string;
+};
 
+const buildRedlineOperations = ({
+  baseSnapshot,
+  revisedBlocks,
+  nextOperationId,
+}: BuildRedlineOperationsOptions): FolioAIEditOperation[] => {
   const events = alignFolioBlocks(baseSnapshot.blocks, revisedBlocks);
   const anchorIds = nextBaseBlockIdByIndex(events);
-
   const operations: FolioAIEditOperation[] = [];
-  let operationSeq = 0;
-  const nextOperationId = () => `redline-${++operationSeq}`;
-  /** Additions past the last base block, kept in revised-document order. */
   const trailingAdditions: { text: string; styleId?: string }[] = [];
   const lastBaseBlockId = baseSnapshot.blocks.at(-1)?.id ?? null;
 
@@ -162,10 +155,100 @@ export const generateRedlineDocx = async (
     });
   }
 
-  const { applied, skipped } = baseReviewer.applyOperations(operations, {
-    mode: "tracked-changes",
-    snapshot: baseSnapshot,
-  });
-  const buffer = await baseReviewer.toBuffer();
-  return { buffer, applied, skipped };
+  return operations;
+};
+
+const resolveInputView = (
+  value: unknown,
+  option: "baseView" | "revisedView",
+): FolioResolvedReviewedView => {
+  if (value === undefined) {
+    return "final";
+  }
+  if (!isFolioResolvedReviewedView(value)) {
+    throw new InvalidGenerateRedlineDocxOptionsError({
+      message: `${option} must be original or final.`,
+      option,
+      receivedValue: value,
+    });
+  }
+  return value;
+};
+
+/** Compare two buffers and return tracked changes for every matched editable story. */
+export const generateRedlineDocx = async (
+  base: ArrayBuffer,
+  revised: ArrayBuffer,
+  options: GenerateRedlineDocxOptions = {},
+): Promise<GenerateRedlineDocxResult> => {
+  const baseView = resolveInputView(options.baseView, "baseView");
+  const revisedView = resolveInputView(options.revisedView, "revisedView");
+  const [baseReviewer, revisedReviewer] = await Promise.all([
+    FolioDocxReviewer.fromBuffer(base, { author: options.author ?? "folio compare" }),
+    FolioDocxReviewer.fromBuffer(revised),
+  ]);
+  const baseStories = baseReviewer.listStories().map(({ handle }) => handle);
+  const revisedStories = revisedReviewer.listStories().map(({ handle }) => handle);
+  for (const story of baseStories) {
+    if (!baseReviewer.resolveReviewedStory({ story, view: baseView })) {
+      panic("A listed base story could not be resolved");
+    }
+  }
+
+  const applied: FolioAIEditAppliedOperation[] = [];
+  const skipped: FolioAIEditSkippedOperation[] = [];
+  const unprocessedStories: GenerateRedlineUnprocessedStory[] = [];
+  let operationSequence = 0;
+  const nextOperationId = () => `redline-${++operationSequence}`;
+
+  for (const pair of pairFolioDocumentStories(baseStories, revisedStories)) {
+    if (!pair.baseStory) {
+      unprocessedStories.push({
+        ...pair,
+        reason: "missing-base-story",
+      });
+      continue;
+    }
+    if (!pair.revisedStory) {
+      unprocessedStories.push({
+        ...pair,
+        reason: "missing-revised-story",
+      });
+      continue;
+    }
+    const baseSnapshot = baseReviewer.snapshotStory(pair.baseStory);
+    const revisedSnapshot = revisedReviewer.readReviewedStory({
+      story: pair.revisedStory,
+      view: revisedView,
+    })?.snapshot;
+    if (!baseSnapshot || !revisedSnapshot) {
+      panic("A matched document story could not be read");
+    }
+    const operations = buildRedlineOperations({
+      baseSnapshot,
+      revisedBlocks: revisedSnapshot.blocks,
+      nextOperationId,
+    });
+    if (operations.length === 0) {
+      continue;
+    }
+    const result = baseReviewer.applyDocumentOperationsToStory({
+      story: pair.baseStory,
+      snapshot: baseSnapshot,
+      batch: {
+        version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+        mode: "tracked-changes",
+        operations,
+      },
+    });
+    applied.push(...result.applied);
+    skipped.push(...result.skipped);
+  }
+
+  return {
+    buffer: await baseReviewer.toBuffer(),
+    applied,
+    skipped,
+    unprocessedStories,
+  };
 };

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -64,11 +64,13 @@ export {
   type DocumentStyleSet,
 } from "./style-sets/types";
 export {
+  FOLIO_RESOLVED_REVIEWED_VIEWS,
   FOLIO_REVIEWED_VIEWS,
   FolioDocxReviewer,
   FolioDocumentStoryNotFoundError,
   UnsupportedFolioReviewedViewError,
   applyFolioAIEditsToBuffer,
+  isFolioResolvedReviewedView,
   isFolioReviewedView,
   type ApplyFolioAIEditsToBufferOptions,
   type ApplyFolioAIEditsToBufferResult,
@@ -80,6 +82,8 @@ export {
   type FolioDocumentStoryHandle,
   type FolioEditableDocumentStoryHandle,
   type FolioReadReviewedStoryOptions,
+  type FolioResolveReviewedStoryOptions,
+  type FolioResolvedReviewedView,
   type FolioReviewedStory,
   type FolioReviewedView,
   type FolioReviewChange,
@@ -117,8 +121,10 @@ export {
 } from "./version-comparison";
 export {
   generateRedlineDocx,
+  InvalidGenerateRedlineDocxOptionsError,
   type GenerateRedlineDocxOptions,
   type GenerateRedlineDocxResult,
+  type GenerateRedlineUnprocessedStory,
 } from "./redline";
 export type {
   FolioAIComment,

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -78,6 +78,7 @@ import { panic, TaggedError } from "better-result";
 import { FolioDocxReviewer, type FolioDocumentStoryHandle } from "./ai-edits/headless";
 import type { FolioAIBlock, FolioAIBlockPreviewRun } from "./ai-edits/types";
 import { diffWordSegments, type WordDiffSegment } from "./ai-edits/word-diff";
+import { pairFolioDocumentStories, type FolioDocumentStoryPair } from "./document-stories";
 import { getFolioParaIdFromBlockId } from "./types/block-id";
 
 /** One word-level diff segment within a `modified` block. Mirrors {@link WordDiffSegment}. */
@@ -669,45 +670,7 @@ const addSummaryCounts = (
   target.unchanged += source.unchanged;
 };
 
-const storyKey = (story: FolioDocumentStoryHandle): string => {
-  if (story.type === "main") {
-    return story.type;
-  }
-  if (story.type === "header" || story.type === "footer") {
-    return `${story.type}:${story.relationshipId}`;
-  }
-  return `${story.type}:${String(story.noteId)}`;
-};
-
-type StoryPair = {
-  baseStory: FolioDocumentStoryHandle | null;
-  revisedStory: FolioDocumentStoryHandle | null;
-};
-
-const pairDocumentStories = (
-  baseStories: readonly FolioDocumentStoryHandle[],
-  revisedStories: readonly FolioDocumentStoryHandle[],
-): StoryPair[] => {
-  const revisedByKey = new Map(revisedStories.map((story) => [storyKey(story), story]));
-  const pairedKeys = new Set<string>();
-  const pairs: StoryPair[] = [];
-  for (const baseStory of baseStories) {
-    const key = storyKey(baseStory);
-    const revisedStory = revisedByKey.get(key) ?? null;
-    pairs.push({ baseStory, revisedStory });
-    if (revisedStory) {
-      pairedKeys.add(key);
-    }
-  }
-  for (const revisedStory of revisedStories) {
-    if (!pairedKeys.has(storyKey(revisedStory))) {
-      pairs.push({ baseStory: null, revisedStory });
-    }
-  }
-  return pairs;
-};
-
-type CompareStoryBlocksOptions = StoryPair & {
+type CompareStoryBlocksOptions = FolioDocumentStoryPair & {
   baseBlocks: readonly FolioAIBlock[];
   revisedBlocks: readonly FolioAIBlock[];
   firstMoveGroupId: number;
@@ -942,7 +905,7 @@ export const compareDocxVersions = async (
   const revisedStories = revisedReviewer.listStories().map(({ handle }) => handle);
   let nextMoveGroupId = 1;
 
-  for (const pair of pairDocumentStories(baseStories, revisedStories)) {
+  for (const pair of pairFolioDocumentStories(baseStories, revisedStories)) {
     const baseBlocks = pair.baseStory
       ? (baseReviewer.readReviewedStory({ story: pair.baseStory, view: "final" })?.snapshot
           .blocks ?? [])


### PR DESCRIPTION
Adds resolved input views and story-scoped tracked-change generation.

Reports unmatched package parts explicitly.