### PR TITLE
feat: add package metadata privacy rewriting

### DIFF
--- a/.changeset/private-metadata-rewrite.md
+++ b/.changeset/private-metadata-rewrite.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add auditable package-metadata privacy rewriting that persists through later saves.

--- a/api-reports/core/docx.api.md
+++ b/api-reports/core/docx.api.md
@@ -36,13 +36,54 @@ export class DocxEncryptionError extends DocxEncryptionError_base {}
 export type DocxEncryptionErrorCode = (typeof DOCX_ENCRYPTION_ERROR_CODES)[keyof typeof DOCX_ENCRYPTION_ERROR_CODES];
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_METADATA_PROPERTIES: readonly ["title", "subject", "creator", "keywords", "description", "lastModifiedBy", "revision", "created", "modified"];
+
+// @public (undocumented)
+export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
+
+// @public (undocumented)
+export type FolioDocumentMetadataProperty = (typeof FOLIO_DOCUMENT_METADATA_PROPERTIES)[number];
+
+// @public (undocumented)
+export class FolioDocumentPrivacyArchiveError extends FolioDocumentPrivacyArchiveError_base {}
+
+// @public (undocumented)
+export type FolioDocumentPrivacyOptions = {
+    transforms: readonly FolioDocumentPrivacyTransform[];
+};
+
+// @public (undocumented)
+export type FolioDocumentPrivacyReport = {
+    appliedTransforms: FolioDocumentPrivacyTransform[];
+    removedMetadataProperties: FolioDocumentMetadataProperty[];
+};
+
+// @public (undocumented)
+export type FolioDocumentPrivacyTransform = (typeof FOLIO_DOCUMENT_PRIVACY_TRANSFORMS)[number];
+
+// @public (undocumented)
 export function getCachedNumberingMap(definitions: import__stll_docx_core_model.NumberingDefinitions): NumberingMap;
+
+// @public (undocumented)
+export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
 
 // @public (undocumented)
 export const isDocxEncryptionError: (error: unknown) => error is DocxEncryptionError;
 
+// @public (undocumented)
+export const isFolioDocumentPrivacyTransform: (value: unknown) => value is FolioDocumentPrivacyTransform;
+
 // @public
 export const openDocxBuffer: (data: ArrayBuffer | Uint8Array, options?: DecryptDocxOptions) => Promise<ArrayBuffer>;
+
+// @public
+export const rewriteDocxMetadataPrivacy: (buffer: ArrayBuffer, options: FolioDocumentPrivacyOptions) => Promise<RewriteDocxMetadataPrivacyResult>;
+
+// @public (undocumented)
+export type RewriteDocxMetadataPrivacyResult = {
+    buffer: ArrayBuffer;
+    privacyReport: FolioDocumentPrivacyReport;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-reports/core/docx.api.md
+++ b/api-reports/core/docx.api.md
@@ -77,7 +77,7 @@ export const isFolioDocumentPrivacyTransform: (value: unknown) => value is Folio
 export const openDocxBuffer: (data: ArrayBuffer | Uint8Array, options?: DecryptDocxOptions) => Promise<ArrayBuffer>;
 
 // @public
-export const rewriteDocxMetadataPrivacy: (buffer: ArrayBuffer, options: FolioDocumentPrivacyOptions) => Promise<RewriteDocxMetadataPrivacyResult>;
+export const rewriteDocxMetadataPrivacy: (buffer: ArrayBuffer, input: FolioDocumentPrivacyOptions) => Promise<RewriteDocxMetadataPrivacyResult>;
 
 // @public (undocumented)
 export type RewriteDocxMetadataPrivacyResult = {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -204,6 +204,9 @@ export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "foot
 export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
 
 // @public (undocumented)
+export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
+
+// @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
 
 // @public (undocumented)
@@ -579,6 +582,23 @@ export type FolioDocumentOutlineEntry = {
 };
 
 // @public (undocumented)
+export class FolioDocumentPrivacyArchiveError extends FolioDocumentPrivacyArchiveError_base {}
+
+// @public (undocumented)
+export type FolioDocumentPrivacyOptions = {
+    transforms: readonly FolioDocumentPrivacyTransform[];
+};
+
+// @public (undocumented)
+export type FolioDocumentPrivacyReport = {
+    appliedTransforms: FolioDocumentPrivacyTransform[];
+    removedMetadataProperties: FolioDocumentMetadataProperty[];
+};
+
+// @public (undocumented)
+export type FolioDocumentPrivacyTransform = (typeof FOLIO_DOCUMENT_PRIVACY_TRANSFORMS)[number];
+
+// @public (undocumented)
 export type FolioDocumentSection = {
     handle: FolioDocumentSectionHandle;
     heading: FolioDocumentOutlineEntry; /** Heading block followed by every block in its logical section. */
@@ -775,7 +795,7 @@ export type FolioVersionBlockHandle = {
 };
 
 // @public (undocumented)
-export type FolioVersionComparisonPrivacyTransform = (typeof FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS)[number];
+export type FolioVersionComparisonPrivacyTransform = FolioDocumentPrivacyTransform;
 
 // @public (undocumented)
 export type FolioVersionComparisonScope = (typeof FOLIO_VERSION_COMPARISON_SCOPES)[number];
@@ -790,15 +810,10 @@ export type FolioVersionDiff = {
 };
 
 // @public (undocumented)
-export type FolioVersionDiffPrivacyOptions = {
-    transforms: readonly FolioVersionComparisonPrivacyTransform[];
-};
+export type FolioVersionDiffPrivacyOptions = FolioDocumentPrivacyOptions;
 
 // @public (undocumented)
-export type FolioVersionDiffPrivacyReport = {
-    appliedTransforms: FolioVersionComparisonPrivacyTransform[];
-    removedMetadataProperties: FolioDocumentMetadataProperty[];
-};
+export type FolioVersionDiffPrivacyReport = FolioDocumentPrivacyReport;
 
 // @public
 export type FolioVersionDiffSegment = WordDiffSegment;
@@ -864,6 +879,9 @@ export const inspectDocumentStylesFromDocx: (input: DocxInput) => Promise<Docume
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
 
 // @public (undocumented)
+export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
+
+// @public (undocumented)
 export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
 
 // @public (undocumented)
@@ -874,6 +892,9 @@ export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;
+
+// @public (undocumented)
+export const isFolioDocumentPrivacyTransform: (value: unknown) => value is FolioDocumentPrivacyTransform;
 
 // @public (undocumented)
 export const isFolioResolvedReviewedView: (value: unknown) => value is FolioResolvedReviewedView;
@@ -901,6 +922,15 @@ export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: F
 
 // @public
 export const replyToComment: (doc: import__stll_docx_core_model.Document, parentCommentId: number, input: CreateCommentReplyInput) => import__stll_docx_core_model.Comment | null;
+
+// @public
+export const rewriteDocxMetadataPrivacy: (buffer: ArrayBuffer, options: FolioDocumentPrivacyOptions) => Promise<RewriteDocxMetadataPrivacyResult>;
+
+// @public (undocumented)
+export type RewriteDocxMetadataPrivacyResult = {
+    buffer: ArrayBuffer;
+    privacyReport: FolioDocumentPrivacyReport;
+};
 
 // @public (undocumented)
 export const STELLA_STYLE_SET_NAME = "Stella Style";

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -924,7 +924,7 @@ export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: F
 export const replyToComment: (doc: import__stll_docx_core_model.Document, parentCommentId: number, input: CreateCommentReplyInput) => import__stll_docx_core_model.Comment | null;
 
 // @public
-export const rewriteDocxMetadataPrivacy: (buffer: ArrayBuffer, options: FolioDocumentPrivacyOptions) => Promise<RewriteDocxMetadataPrivacyResult>;
+export const rewriteDocxMetadataPrivacy: (buffer: ArrayBuffer, input: FolioDocumentPrivacyOptions) => Promise<RewriteDocxMetadataPrivacyResult>;
 
 // @public (undocumented)
 export type RewriteDocxMetadataPrivacyResult = {

--- a/packages/core/src/docx/index.ts
+++ b/packages/core/src/docx/index.ts
@@ -3,6 +3,19 @@
 // reachable at their explicit subpaths via the core `"./*"` export wildcard.
 export { getCachedNumberingMap } from "./numberingParser";
 export {
+  FOLIO_DOCUMENT_METADATA_PROPERTIES,
+  FOLIO_DOCUMENT_PRIVACY_TRANSFORMS,
+  FolioDocumentPrivacyArchiveError,
+  InvalidFolioDocumentPrivacyOptionsError,
+  isFolioDocumentPrivacyTransform,
+  rewriteDocxMetadataPrivacy,
+  type FolioDocumentMetadataProperty,
+  type FolioDocumentPrivacyOptions,
+  type FolioDocumentPrivacyReport,
+  type FolioDocumentPrivacyTransform,
+  type RewriteDocxMetadataPrivacyResult,
+} from "./metadataPrivacy";
+export {
   DOCX_ENCRYPTION_ERROR_CODES,
   DocxEncryptionError,
   decryptDocxIfNeeded,

--- a/packages/core/src/docx/metadataPrivacy.test.ts
+++ b/packages/core/src/docx/metadataPrivacy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { createEmptyDocument } from "../utils/createDocument";
+import { parseCoreProperties } from "./corePropertiesParser";
+import {
+  FolioDocumentPrivacyArchiveError,
+  InvalidFolioDocumentPrivacyOptionsError,
+  rewriteDocxMetadataPrivacy,
+} from "./metadataPrivacy";
+import { createDocx } from "./rezip";
+
+const CORE_PROPERTIES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cp:coreProperties xmlns:cp="urn:properties" xmlns:dc="urn:descriptive" xmlns:dcterms="urn:terms" xmlns:custom="urn:custom"><dc:title>Title</dc:title><dc:subject>Subject</dc:subject><dc:creator>Creator</dc:creator><cp:keywords>keywords</cp:keywords><dc:description>Description</dc:description><cp:lastModifiedBy>Modifier</cp:lastModifiedBy><cp:revision>7</cp:revision><dcterms:created>2026-07-01T10:30:00Z</dcterms:created><dcterms:modified>2026-07-02T11:45:00Z</dcterms:modified><custom:retained>keep me</custom:retained></cp:coreProperties>`;
+
+const buildDocument = async (): Promise<ArrayBuffer> => {
+  const template = createEmptyDocument();
+  const buffer = await createDocx({
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: [
+          {
+            type: "paragraph",
+            paraId: "00000001",
+            content: [{ type: "run", content: [{ type: "text", text: "Body text." }] }],
+          },
+        ],
+      },
+    },
+  });
+  const zip = await JSZip.loadAsync(buffer);
+  zip.file("docProps/core.xml", CORE_PROPERTIES_XML);
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const readCorePropertiesXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file("docProps/core.xml");
+  if (!file) {
+    throw new Error("expected core properties");
+  }
+  return file.async("text");
+};
+
+const expectPrivateMetadataAbsent = async (buffer: ArrayBuffer): Promise<void> => {
+  const xml = await readCorePropertiesXml(buffer);
+  for (const property of [
+    "title",
+    "subject",
+    "creator",
+    "keywords",
+    "description",
+    "lastModifiedBy",
+    "created",
+    "modified",
+  ]) {
+    expect(xml).not.toContain(`<${property}>`);
+    expect(xml).not.toContain(`:${property}>`);
+  }
+  expect(xml).toContain("<cp:revision>7</cp:revision>");
+  expect(xml).toContain("<custom:retained>keep me</custom:retained>");
+};
+
+describe("rewriteDocxMetadataPrivacy", () => {
+  test("removes selected metadata and reports fields that existed", async () => {
+    const result = await rewriteDocxMetadataPrivacy(await buildDocument(), {
+      transforms: ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"],
+    });
+
+    expect(result.privacyReport).toEqual({
+      appliedTransforms: ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"],
+      removedMetadataProperties: [
+        "title",
+        "subject",
+        "creator",
+        "keywords",
+        "description",
+        "lastModifiedBy",
+        "created",
+        "modified",
+      ],
+    });
+    await expectPrivateMetadataAbsent(result.buffer);
+    expect(parseCoreProperties(await readCorePropertiesXml(result.buffer))).toEqual({
+      revision: 7,
+    });
+  });
+
+  test("keeps removed timestamps absent through selective and structural saves", async () => {
+    const rewritten = await rewriteDocxMetadataPrivacy(await buildDocument(), {
+      transforms: ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"],
+    });
+    const selectiveReviewer = await FolioDocxReviewer.fromBuffer(rewritten.buffer);
+    const target = selectiveReviewer.snapshot().blocks.at(0);
+    if (!target) {
+      throw new Error("expected a body block");
+    }
+    selectiveReviewer.applyOperations(
+      [{ id: "replace", type: "replaceBlock", blockId: target.id, text: "Updated body." }],
+      { mode: "direct" },
+    );
+    const selectivelySaved = await selectiveReviewer.toBuffer();
+    await expectPrivateMetadataAbsent(selectivelySaved);
+
+    const structuralReviewer = await FolioDocxReviewer.fromBuffer(selectivelySaved);
+    const structuralTarget = structuralReviewer.snapshot().blocks.at(0);
+    if (!structuralTarget) {
+      throw new Error("expected a body block");
+    }
+    structuralReviewer.applyOperations(
+      [
+        {
+          id: "insert",
+          type: "insertAfterBlock",
+          blockId: structuralTarget.id,
+          text: "Additional body.",
+        },
+      ],
+      { mode: "direct" },
+    );
+    await expectPrivateMetadataAbsent(await structuralReviewer.toBuffer());
+  });
+
+  test("rejects unknown transforms at the public boundary", async () => {
+    const buffer = await buildDocument();
+
+    await expect(
+      Reflect.apply(rewriteDocxMetadataPrivacy, undefined, [buffer, { transforms: ["unknown"] }]),
+    ).rejects.toBeInstanceOf(InvalidFolioDocumentPrivacyOptionsError);
+  });
+
+  test("rejects an unreadable package with a tagged error", async () => {
+    await expect(
+      rewriteDocxMetadataPrivacy(new TextEncoder().encode("not a package").buffer, {
+        transforms: ["remove-attribution"],
+      }),
+    ).rejects.toBeInstanceOf(FolioDocumentPrivacyArchiveError);
+  });
+});

--- a/packages/core/src/docx/metadataPrivacy.ts
+++ b/packages/core/src/docx/metadataPrivacy.ts
@@ -180,9 +180,9 @@ const rewriteCorePropertiesPrivacy = (
 /** Rewrite selected package metadata fields without changing other package parts. */
 export const rewriteDocxMetadataPrivacy = async (
   buffer: ArrayBuffer,
-  options: FolioDocumentPrivacyOptions,
+  { transforms }: FolioDocumentPrivacyOptions,
 ): Promise<RewriteDocxMetadataPrivacyResult> => {
-  const appliedTransforms = resolveFolioDocumentPrivacyTransforms(options.transforms);
+  const appliedTransforms = resolveFolioDocumentPrivacyTransforms(transforms);
   const zip = await loadPrivacyArchive(buffer);
   const coreProperties = zip.file("docProps/core.xml");
   if (!coreProperties) {
@@ -203,7 +203,7 @@ export const rewriteDocxMetadataPrivacy = async (
   }
   zip.file("docProps/core.xml", rewritten.xml);
   return {
-    buffer: await zip.generateAsync({ type: "arraybuffer" }),
+    buffer: await zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" }),
     privacyReport: {
       appliedTransforms,
       removedMetadataProperties: rewritten.removedMetadataProperties,

--- a/packages/core/src/docx/metadataPrivacy.ts
+++ b/packages/core/src/docx/metadataPrivacy.ts
@@ -17,6 +17,9 @@ export const FOLIO_DOCUMENT_METADATA_PROPERTIES = Object.freeze([
 
 export type FolioDocumentMetadataProperty = (typeof FOLIO_DOCUMENT_METADATA_PROPERTIES)[number];
 
+const isFolioDocumentMetadataProperty = (value: string): value is FolioDocumentMetadataProperty =>
+  FOLIO_DOCUMENT_METADATA_PROPERTIES.some((property) => property === value);
+
 export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS = Object.freeze([
   "remove-attribution",
   "remove-timestamps",
@@ -156,7 +159,7 @@ const rewriteCorePropertiesPrivacy = (
       return true;
     }
     const property = getLocalName(element.name ?? "");
-    if (!FOLIO_DOCUMENT_METADATA_PROPERTIES.some((candidate) => candidate === property)) {
+    if (!isFolioDocumentMetadataProperty(property)) {
       return true;
     }
     if (!propertiesToRemove.has(property)) {

--- a/packages/core/src/docx/metadataPrivacy.ts
+++ b/packages/core/src/docx/metadataPrivacy.ts
@@ -1,0 +1,209 @@
+import { TaggedError } from "better-result";
+import JSZip from "jszip";
+
+import { elementToXml, getLocalName, parseXmlDocument } from "./xmlParser";
+
+export const FOLIO_DOCUMENT_METADATA_PROPERTIES = Object.freeze([
+  "title",
+  "subject",
+  "creator",
+  "keywords",
+  "description",
+  "lastModifiedBy",
+  "revision",
+  "created",
+  "modified",
+] as const);
+
+export type FolioDocumentMetadataProperty = (typeof FOLIO_DOCUMENT_METADATA_PROPERTIES)[number];
+
+export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS = Object.freeze([
+  "remove-attribution",
+  "remove-timestamps",
+  "remove-descriptive-metadata",
+] as const);
+
+export type FolioDocumentPrivacyTransform = (typeof FOLIO_DOCUMENT_PRIVACY_TRANSFORMS)[number];
+
+export const isFolioDocumentPrivacyTransform = (
+  value: unknown,
+): value is FolioDocumentPrivacyTransform =>
+  FOLIO_DOCUMENT_PRIVACY_TRANSFORMS.some((transform) => transform === value);
+
+export type FolioDocumentPrivacyOptions = {
+  transforms: readonly FolioDocumentPrivacyTransform[];
+};
+
+export type FolioDocumentPrivacyReport = {
+  appliedTransforms: FolioDocumentPrivacyTransform[];
+  removedMetadataProperties: FolioDocumentMetadataProperty[];
+};
+
+export type RewriteDocxMetadataPrivacyResult = {
+  buffer: ArrayBuffer;
+  privacyReport: FolioDocumentPrivacyReport;
+};
+
+export class InvalidFolioDocumentPrivacyOptionsError extends TaggedError(
+  "InvalidFolioDocumentPrivacyOptionsError",
+)<{
+  message: string;
+  receivedValue: unknown;
+}>() {}
+
+export class FolioDocumentPrivacyArchiveError extends TaggedError(
+  "FolioDocumentPrivacyArchiveError",
+)<{
+  message: string;
+  reason: "input-too-large" | "load-failed" | "too-many-entries" | "core-properties-too-large";
+  cause?: unknown;
+}>() {}
+
+export const PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM = {
+  "remove-attribution": ["creator", "lastModifiedBy"],
+  "remove-timestamps": ["created", "modified"],
+  "remove-descriptive-metadata": ["title", "subject", "keywords", "description"],
+} as const satisfies Record<
+  FolioDocumentPrivacyTransform,
+  readonly FolioDocumentMetadataProperty[]
+>;
+
+export const resolveFolioDocumentPrivacyTransforms = (
+  transforms: unknown,
+): FolioDocumentPrivacyTransform[] => {
+  if (
+    !Array.isArray(transforms) ||
+    transforms.some((transform) => !isFolioDocumentPrivacyTransform(transform))
+  ) {
+    throw new InvalidFolioDocumentPrivacyOptionsError({
+      message: "Document privacy received an unrecognized transform",
+      receivedValue: transforms,
+    });
+  }
+  const requested = new Set(transforms);
+  return FOLIO_DOCUMENT_PRIVACY_TRANSFORMS.filter((transform) => requested.has(transform));
+};
+
+const XML_DECLARATION_PATTERN = /^\s*<\?xml[^?]*\?>/u;
+const MAX_INPUT_BYTES = 50 * 1024 * 1024;
+const MAX_ARCHIVE_ENTRIES = 5000;
+const MAX_CORE_PROPERTIES_BYTES = 1024 * 1024;
+
+const loadPrivacyArchive = async (buffer: ArrayBuffer): Promise<JSZip> => {
+  if (buffer.byteLength > MAX_INPUT_BYTES) {
+    throw new FolioDocumentPrivacyArchiveError({
+      message: "Document privacy input exceeded the compressed-size limit",
+      reason: "input-too-large",
+    });
+  }
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(buffer);
+  } catch (cause) {
+    throw new FolioDocumentPrivacyArchiveError({
+      message: "Document privacy input is not a readable package",
+      reason: "load-failed",
+      cause,
+    });
+  }
+  const entries = Object.values(zip.files);
+  if (entries.length > MAX_ARCHIVE_ENTRIES) {
+    throw new FolioDocumentPrivacyArchiveError({
+      message: "Document privacy input exceeded the package-entry limit",
+      reason: "too-many-entries",
+    });
+  }
+  const coreProperties = zip.file("docProps/core.xml");
+  if (!coreProperties) {
+    return zip;
+  }
+  const data = "_data" in coreProperties ? coreProperties._data : undefined;
+  const declaredBytes =
+    typeof data === "object" && data !== null && "uncompressedSize" in data
+      ? data.uncompressedSize
+      : undefined;
+  if (typeof declaredBytes !== "number" || declaredBytes > MAX_CORE_PROPERTIES_BYTES) {
+    throw new FolioDocumentPrivacyArchiveError({
+      message: "Document privacy core properties exceeded the part-size limit",
+      reason: "core-properties-too-large",
+    });
+  }
+  return zip;
+};
+
+type RewriteCorePropertiesPrivacyResult = {
+  xml: string;
+  removedMetadataProperties: FolioDocumentMetadataProperty[];
+};
+
+const rewriteCorePropertiesPrivacy = (
+  xml: string,
+  transforms: readonly FolioDocumentPrivacyTransform[],
+): RewriteCorePropertiesPrivacyResult => {
+  const root = parseXmlDocument(xml);
+  if (!root?.elements) {
+    return { xml, removedMetadataProperties: [] };
+  }
+  const propertiesToRemove = new Set<FolioDocumentMetadataProperty>();
+  for (const transform of transforms) {
+    for (const property of PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM[transform]) {
+      propertiesToRemove.add(property);
+    }
+  }
+  const removedPropertySet = new Set<FolioDocumentMetadataProperty>();
+  root.elements = root.elements.filter((element) => {
+    if (element.type !== "element") {
+      return true;
+    }
+    const property = getLocalName(element.name ?? "");
+    if (!FOLIO_DOCUMENT_METADATA_PROPERTIES.some((candidate) => candidate === property)) {
+      return true;
+    }
+    if (!propertiesToRemove.has(property)) {
+      return true;
+    }
+    removedPropertySet.add(property);
+    return false;
+  });
+  const declaration = xml.match(XML_DECLARATION_PATTERN)?.at(0) ?? "";
+  return {
+    xml: `${declaration}${elementToXml(root)}`,
+    removedMetadataProperties: FOLIO_DOCUMENT_METADATA_PROPERTIES.filter((property) =>
+      removedPropertySet.has(property),
+    ),
+  };
+};
+
+/** Rewrite selected package metadata fields without changing other package parts. */
+export const rewriteDocxMetadataPrivacy = async (
+  buffer: ArrayBuffer,
+  options: FolioDocumentPrivacyOptions,
+): Promise<RewriteDocxMetadataPrivacyResult> => {
+  const appliedTransforms = resolveFolioDocumentPrivacyTransforms(options.transforms);
+  const zip = await loadPrivacyArchive(buffer);
+  const coreProperties = zip.file("docProps/core.xml");
+  if (!coreProperties) {
+    return {
+      buffer,
+      privacyReport: { appliedTransforms, removedMetadataProperties: [] },
+    };
+  }
+  const rewritten = rewriteCorePropertiesPrivacy(
+    await coreProperties.async("text"),
+    appliedTransforms,
+  );
+  if (rewritten.removedMetadataProperties.length === 0) {
+    return {
+      buffer,
+      privacyReport: { appliedTransforms, removedMetadataProperties: [] },
+    };
+  }
+  zip.file("docProps/core.xml", rewritten.xml);
+  return {
+    buffer: await zip.generateAsync({ type: "arraybuffer" }),
+    privacyReport: {
+      appliedTransforms,
+      removedMetadataProperties: rewritten.removedMetadataProperties,
+    },
+  };
+};

--- a/packages/core/src/docx/rezip-coreprops-redos.test.ts
+++ b/packages/core/src/docx/rezip-coreprops-redos.test.ts
@@ -12,6 +12,12 @@ describe("updateCoreProperties dcterms:modified", () => {
     expect(out).toContain("<dcterms:modified");
   });
 
+  test("does not synthesize a missing modified date", () => {
+    const xml = "<cp:coreProperties><cp:revision>7</cp:revision></cp:coreProperties>";
+
+    expect(updateCoreProperties(xml, { updateModifiedDate: true })).toBe(xml);
+  });
+
   test("stays linear on malformed core.xml", () => {
     const evil = "<dcterms:modified".repeat(100_000);
     const start = performance.now();

--- a/packages/core/src/docx/rezip-coreprops-redos.test.ts
+++ b/packages/core/src/docx/rezip-coreprops-redos.test.ts
@@ -18,6 +18,12 @@ describe("updateCoreProperties dcterms:modified", () => {
     expect(updateCoreProperties(xml, { updateModifiedDate: true })).toBe(xml);
   });
 
+  test("does not synthesize a missing modifier", () => {
+    const xml = "<cp:coreProperties><cp:revision>7</cp:revision></cp:coreProperties>";
+
+    expect(updateCoreProperties(xml, { modifiedBy: "Reviewer" })).toBe(xml);
+  });
+
   test("stays linear on malformed core.xml", () => {
     const evil = "<dcterms:modified".repeat(100_000);
     const start = performance.now();

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -1837,9 +1837,7 @@ function findNotePartEntry(zip: JSZip, conventionalLowerPath: string): JSZip.JSZ
 // UTILITY FUNCTIONS
 // ============================================================================
 
-/**
- * Update core properties XML with new modification date
- */
+/** Update existing core-property values without synthesizing absent metadata. */
 export function updateCoreProperties(
   corePropsXml: string,
   options: { updateModifiedDate?: boolean; modifiedBy?: string },
@@ -1854,12 +1852,6 @@ export function updateCoreProperties(
       result = result.replace(
         /<dcterms:modified[^<>]*>[^<]*<\/dcterms:modified>/u,
         `<dcterms:modified xsi:type="dcterms:W3CDTF">${now}</dcterms:modified>`,
-      );
-    } else {
-      // Add modified date if not present
-      result = result.replace(
-        "</cp:coreProperties>",
-        `<dcterms:modified xsi:type="dcterms:W3CDTF">${now}</dcterms:modified></cp:coreProperties>`,
       );
     }
   }

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -1840,11 +1840,11 @@ function findNotePartEntry(zip: JSZip, conventionalLowerPath: string): JSZip.JSZ
 /** Update existing core-property values without synthesizing absent metadata. */
 export function updateCoreProperties(
   corePropsXml: string,
-  options: { updateModifiedDate?: boolean; modifiedBy?: string },
+  { updateModifiedDate, modifiedBy }: { updateModifiedDate?: boolean; modifiedBy?: string },
 ): string {
   let result = corePropsXml;
 
-  if (options.updateModifiedDate) {
+  if (updateModifiedDate) {
     const now = new Date().toISOString();
 
     // Update dcterms:modified
@@ -1856,18 +1856,12 @@ export function updateCoreProperties(
     }
   }
 
-  if (options.modifiedBy) {
+  if (modifiedBy) {
     // Update cp:lastModifiedBy
     if (result.includes("<cp:lastModifiedBy")) {
       result = result.replace(
         /<cp:lastModifiedBy>[^<]*<\/cp:lastModifiedBy>/u,
-        `<cp:lastModifiedBy>${escapeXml(options.modifiedBy)}</cp:lastModifiedBy>`,
-      );
-    } else {
-      // Add lastModifiedBy if not present
-      result = result.replace(
-        "</cp:coreProperties>",
-        `<cp:lastModifiedBy>${escapeXml(options.modifiedBy)}</cp:lastModifiedBy></cp:coreProperties>`,
+        `<cp:lastModifiedBy>${escapeXml(modifiedBy)}</cp:lastModifiedBy>`,
       );
     }
   }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -174,3 +174,14 @@ export {
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";
 export { DocxArchiveError } from "./docx/server/boundedArchive";
+export {
+  FOLIO_DOCUMENT_PRIVACY_TRANSFORMS,
+  FolioDocumentPrivacyArchiveError,
+  InvalidFolioDocumentPrivacyOptionsError,
+  isFolioDocumentPrivacyTransform,
+  rewriteDocxMetadataPrivacy,
+  type FolioDocumentPrivacyOptions,
+  type FolioDocumentPrivacyReport,
+  type FolioDocumentPrivacyTransform,
+  type RewriteDocxMetadataPrivacyResult,
+} from "./docx/metadataPrivacy";

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -79,6 +79,16 @@ import { FolioDocxReviewer, type FolioDocumentStoryHandle } from "./ai-edits/hea
 import type { FolioAIBlock, FolioAIBlockPreviewRun } from "./ai-edits/types";
 import { diffWordSegments, type WordDiffSegment } from "./ai-edits/word-diff";
 import { pairFolioDocumentStories, type FolioDocumentStoryPair } from "./document-stories";
+import {
+  FOLIO_DOCUMENT_METADATA_PROPERTIES,
+  FOLIO_DOCUMENT_PRIVACY_TRANSFORMS,
+  isFolioDocumentPrivacyTransform,
+  PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM,
+  type FolioDocumentMetadataProperty,
+  type FolioDocumentPrivacyOptions,
+  type FolioDocumentPrivacyReport,
+  type FolioDocumentPrivacyTransform,
+} from "./docx/metadataPrivacy";
 import { getFolioParaIdFromBlockId } from "./types/block-id";
 
 /** One word-level diff segment within a `modified` block. Mirrors {@link WordDiffSegment}. */
@@ -113,19 +123,8 @@ export class InvalidFolioVersionComparisonOptionsError extends TaggedError(
   receivedValue: unknown;
 }>() {}
 
-export const FOLIO_DOCUMENT_METADATA_PROPERTIES = Object.freeze([
-  "title",
-  "subject",
-  "creator",
-  "keywords",
-  "description",
-  "lastModifiedBy",
-  "revision",
-  "created",
-  "modified",
-] as const);
-
-export type FolioDocumentMetadataProperty = (typeof FOLIO_DOCUMENT_METADATA_PROPERTIES)[number];
+export { FOLIO_DOCUMENT_METADATA_PROPERTIES };
+export type { FolioDocumentMetadataProperty };
 export type FolioDocumentMetadataValue = string | number | null;
 
 export type FolioMetadataDiff = {
@@ -134,28 +133,17 @@ export type FolioMetadataDiff = {
   revisedValue: FolioDocumentMetadataValue;
 };
 
-export const FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS = Object.freeze([
-  "remove-attribution",
-  "remove-timestamps",
-  "remove-descriptive-metadata",
-] as const);
+export const FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS = FOLIO_DOCUMENT_PRIVACY_TRANSFORMS;
 
-export type FolioVersionComparisonPrivacyTransform =
-  (typeof FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS)[number];
+export type FolioVersionComparisonPrivacyTransform = FolioDocumentPrivacyTransform;
 
 export const isFolioVersionComparisonPrivacyTransform = (
   value: unknown,
-): value is FolioVersionComparisonPrivacyTransform =>
-  FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS.some((transform) => transform === value);
+): value is FolioVersionComparisonPrivacyTransform => isFolioDocumentPrivacyTransform(value);
 
-export type FolioVersionDiffPrivacyOptions = {
-  transforms: readonly FolioVersionComparisonPrivacyTransform[];
-};
+export type FolioVersionDiffPrivacyOptions = FolioDocumentPrivacyOptions;
 
-export type FolioVersionDiffPrivacyReport = {
-  appliedTransforms: FolioVersionComparisonPrivacyTransform[];
-  removedMetadataProperties: FolioDocumentMetadataProperty[];
-};
+export type FolioVersionDiffPrivacyReport = FolioDocumentPrivacyReport;
 
 /** Run-level formatting properties compared for `formatChanged` detection. */
 const FORMAT_PROPERTIES = [
@@ -788,15 +776,6 @@ const resolveComparisonScopes = (
   }
   return new Set(include);
 };
-
-const PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM = {
-  "remove-attribution": ["creator", "lastModifiedBy"],
-  "remove-timestamps": ["created", "modified"],
-  "remove-descriptive-metadata": ["title", "subject", "keywords", "description"],
-} as const satisfies Record<
-  FolioVersionComparisonPrivacyTransform,
-  readonly FolioDocumentMetadataProperty[]
->;
 
 const resolvePrivacyTransforms = (
   transforms: unknown,


### PR DESCRIPTION
Adds typed package-metadata privacy transforms with structured reports.

Preserves removed fields across subsequent save paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DOCX privacy rewriting to remove attribution, timestamps, and descriptive metadata.
  * Reports which privacy transformations were applied and which metadata fields were removed.
  * Added validation and clear errors for unsupported options or unreadable documents.
  * Privacy rewriting remains effective after subsequent document saves.
  * Version comparison privacy controls now use the same document privacy options.

* **Bug Fixes**
  * Existing modification dates are updated only when present; missing dates are no longer added automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->