### PR TITLE
feat: add redline privacy reports

### DIFF
--- a/.changeset/redline-privacy-report.md
+++ b/.changeset/redline-privacy-report.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add package-metadata privacy options and reports to redline generation.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -29,6 +29,8 @@ import { FolioDocxReviewer } from '@stll/folio-core/server';
 import { FolioReviewChange } from '@stll/folio-core/ai-edits';
 import { FolioVersionDiff } from '@stll/folio-core/server';
 import { FolioVersionDiffSegment } from '@stll/folio-core/server';
+import { GenerateRedlineDocxOptions } from '@stll/folio-core/server';
+import { GenerateRedlineDocxResult } from '@stll/folio-core/server';
 
 // @public
 export type AnthropicToolDefinition = {
@@ -1665,6 +1667,12 @@ export type FolioAgentEditorRefLike = {
     showInDocument?(target: FolioDocumentNavigationTarget, snapshot?: FolioAIEditSnapshot): boolean;
 };
 
+// @public
+export type FolioAgentGenerateRedlineDocxOptions = GenerateRedlineDocxOptions;
+
+// @public
+export type FolioAgentGenerateRedlineDocxResult = GenerateRedlineDocxResult;
+
 // @public (undocumented)
 export type FolioAgentOutlineEntry = FolioDocumentOutlineEntry & {
     page?: number;
@@ -1745,6 +1753,9 @@ export type FolioToolCallResult = {
 
 // @public
 export const formatVersionDiffForLLM: (diff: FolioAgentVersionDiff) => string;
+
+// @public
+export const generateRedlineDocx: (base: ArrayBuffer, revised: ArrayBuffer, options?: FolioAgentGenerateRedlineDocxOptions) => Promise<FolioAgentGenerateRedlineDocxResult>;
 
 // @public
 export const getFolioToolDefinitions: () => FolioAgentToolDefinition[];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -836,7 +836,8 @@ export const generateRedlineDocx: (base: ArrayBuffer, revised: ArrayBuffer, opti
 export type GenerateRedlineDocxOptions = {
     author?: string; /** Resolved base input state. (default: `"final"`) */
     baseView?: FolioResolvedReviewedView; /** Resolved revised input state. (default: `"final"`) */
-    revisedView?: FolioResolvedReviewedView;
+    revisedView?: FolioResolvedReviewedView; /** Optional output-only package-metadata privacy transforms. */
+    privacy?: FolioDocumentPrivacyOptions;
 };
 
 // @public
@@ -844,7 +845,8 @@ export type GenerateRedlineDocxResult = {
     buffer: ArrayBuffer; /** Operations applied across every matched story. */
     applied: FolioAIEditAppliedOperation[]; /** Block operations that could not be applied. */
     skipped: FolioAIEditSkippedOperation[]; /** Package parts that could not be represented as story-scoped text edits. */
-    unprocessedStories: GenerateRedlineUnprocessedStory[];
+    unprocessedStories: GenerateRedlineUnprocessedStory[]; /** Privacy transforms applied to the generated package. */
+    privacyReport: FolioDocumentPrivacyReport;
 };
 
 // @public (undocumented)

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -181,6 +181,21 @@ The natural shape is a host-side tool keyed by version identifiers instead
 (e.g. a server tool the model calls with two stored version ids, which your
 backend resolves to buffers, diffs, and returns the formatted text for).
 
+To produce a reviewable package from the same pair of buffers, use
+`generateRedlineDocx`. Optional package-metadata privacy transforms are applied
+to the generated output and returned as a structured report:
+
+```ts
+import { generateRedlineDocx } from "@stll/folio-agents";
+
+const result = await generateRedlineDocx(previousVersionBuffer, currentVersionBuffer, {
+  privacy: { transforms: ["remove-attribution", "remove-timestamps"] },
+});
+
+await storeGeneratedPackage(result.buffer);
+console.log(result.privacyReport);
+```
+
 ## TanStack AI
 
 TanStack AI's `toolDefinition` accepts a raw JSON Schema object as

--- a/packages/agents/skills/folio-agents/SKILL.md
+++ b/packages/agents/skills/folio-agents/SKILL.md
@@ -136,6 +136,10 @@ currentBuffer)` + `formatVersionDiffForLLM(diff)`. Both are plain async
   host-side tool keyed by version identifiers instead — the model calls it
   with two version ids, your backend resolves the buffers and returns the
   formatted diff text.
+- **Reviewable output between two saved versions** —
+  `generateRedlineDocx(previousBuffer, currentBuffer, options)` returns the
+  generated package, operation results, unmatched stories, and a structured
+  package-metadata privacy report.
 
 `compareDocxVersions` compares the AS-ACCEPTED view of each buffer: any
 tracked changes already pending in either one count as already applied before

--- a/packages/agents/src/compare.ts
+++ b/packages/agents/src/compare.ts
@@ -3,8 +3,13 @@ import type {
   FolioCompareDocxVersionsOptions,
   FolioVersionDiff,
   FolioVersionDiffSegment,
+  GenerateRedlineDocxOptions,
+  GenerateRedlineDocxResult,
 } from "@stll/folio-core/server";
-import { compareDocxVersions as compareDocxVersionsCore } from "@stll/folio-core/server";
+import {
+  compareDocxVersions as compareDocxVersionsCore,
+  generateRedlineDocx as generateRedlineDocxCore,
+} from "@stll/folio-core/server";
 
 /** Backward-compatible name for a core word-level version-diff segment. */
 export type FolioAgentVersionDiffSegment = FolioVersionDiffSegment;
@@ -18,12 +23,25 @@ export type FolioAgentVersionDiff = FolioVersionDiff;
 /** Backward-compatible name for core comparison options. */
 export type FolioAgentCompareDocxVersionsOptions = FolioCompareDocxVersionsOptions;
 
+/** Agent-facing name for core redline-generation options. */
+export type FolioAgentGenerateRedlineDocxOptions = GenerateRedlineDocxOptions;
+
+/** Agent-facing name for the core redline-generation result. */
+export type FolioAgentGenerateRedlineDocxResult = GenerateRedlineDocxResult;
+
 /** Compare two `.docx` buffers using folio-core's version comparison semantics. */
 export const compareDocxVersions = (
   base: ArrayBuffer,
   revised: ArrayBuffer,
   options: FolioAgentCompareDocxVersionsOptions = {},
 ): Promise<FolioAgentVersionDiff> => compareDocxVersionsCore(base, revised, options);
+
+/** Generate a reviewed package from two `.docx` buffers. */
+export const generateRedlineDocx = (
+  base: ArrayBuffer,
+  revised: ArrayBuffer,
+  options: FolioAgentGenerateRedlineDocxOptions = {},
+): Promise<FolioAgentGenerateRedlineDocxResult> => generateRedlineDocxCore(base, revised, options);
 
 const ELLIPSIS = "…";
 const UNCHANGED_EDGE_CHARS = 30;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -10,10 +10,12 @@ export { createReviewerBridge } from "./bridges/reviewer";
 export type {
   FolioAgentBlockDiff,
   FolioAgentCompareDocxVersionsOptions,
+  FolioAgentGenerateRedlineDocxOptions,
+  FolioAgentGenerateRedlineDocxResult,
   FolioAgentVersionDiff,
   FolioAgentVersionDiffSegment,
 } from "./compare";
-export { compareDocxVersions, formatVersionDiffForLLM } from "./compare";
+export { compareDocxVersions, formatVersionDiffForLLM, generateRedlineDocx } from "./compare";
 export { executeFolioToolCall } from "./execute";
 export {
   FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA,

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -26,6 +26,8 @@ import { createEmptyDocument } from "./utils/createDocument";
 
 type ParagraphSpec = { text: string; paraId?: string };
 
+const CORE_PROPERTIES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cp:coreProperties xmlns:cp="urn:properties" xmlns:dc="urn:descriptive" xmlns:dcterms="urn:terms"><dc:title>Private title</dc:title><dc:creator>Private creator</dc:creator><cp:lastModifiedBy>Private modifier</cp:lastModifiedBy><cp:revision>7</cp:revision><dcterms:created>2026-07-01T10:30:00Z</dcterms:created><dcterms:modified>2026-07-02T11:45:00Z</dcterms:modified></cp:coreProperties>`;
+
 const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuffer> => {
   const template = createEmptyDocument();
   return createDocx({
@@ -46,6 +48,12 @@ const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuf
 
 const blockTexts = (reviewer: FolioDocxReviewer): string[] =>
   reviewer.snapshot().blocks.map((block) => block.text);
+
+const withCoreProperties = async (buffer: ArrayBuffer): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(buffer);
+  zip.file("docProps/core.xml", CORE_PROPERTIES_XML);
+  return zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" });
+};
 
 const storyParagraph = (text: string, paraId: string): Paragraph => ({
   type: "paragraph",
@@ -420,6 +428,30 @@ describe("generateRedlineDocx", () => {
         reason: "missing-base-story",
       },
     ]);
+  });
+
+  test("applies package-metadata privacy transforms and returns their report", async () => {
+    const base = await withCoreProperties(
+      await buildDocxBuffer([{ text: "Base text.", paraId: "00000001" }]),
+    );
+    const revised = await buildDocxBuffer([{ text: "Revised text.", paraId: "00000001" }]);
+
+    const result = await generateRedlineDocx(base, revised, {
+      privacy: { transforms: ["remove-attribution", "remove-timestamps"] },
+    });
+
+    expect(result.privacyReport).toEqual({
+      appliedTransforms: ["remove-attribution", "remove-timestamps"],
+      removedMetadataProperties: ["creator", "lastModifiedBy", "created", "modified"],
+    });
+    const zip = await JSZip.loadAsync(result.buffer);
+    const coreProperties = await zip.file("docProps/core.xml")?.async("text");
+    expect(coreProperties).not.toContain("Private creator");
+    expect(coreProperties).not.toContain("Private modifier");
+    expect(coreProperties).not.toContain("dcterms:created");
+    expect(coreProperties).not.toContain("dcterms:modified");
+    expect(coreProperties).toContain("Private title");
+    expect(coreProperties).toContain("<cp:revision>7</cp:revision>");
   });
 
   test("rejects unresolved markup as an input view", async () => {

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -25,6 +25,12 @@ import type {
 } from "./ai-edits/types";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "./document-operations";
 import { pairFolioDocumentStories } from "./document-stories";
+import {
+  resolveFolioDocumentPrivacyTransforms,
+  rewriteDocxMetadataPrivacy,
+  type FolioDocumentPrivacyOptions,
+  type FolioDocumentPrivacyReport,
+} from "./docx/metadataPrivacy";
 import { alignFolioBlocks, type FolioAlignedBlockEvent } from "./version-comparison";
 
 /** Options for {@link generateRedlineDocx}. */
@@ -35,6 +41,8 @@ export type GenerateRedlineDocxOptions = {
   baseView?: FolioResolvedReviewedView;
   /** Resolved revised input state. (default: `"final"`) */
   revisedView?: FolioResolvedReviewedView;
+  /** Optional output-only package-metadata privacy transforms. */
+  privacy?: FolioDocumentPrivacyOptions;
 };
 
 export class InvalidGenerateRedlineDocxOptionsError extends TaggedError(
@@ -61,6 +69,8 @@ export type GenerateRedlineDocxResult = {
   skipped: FolioAIEditSkippedOperation[];
   /** Package parts that could not be represented as story-scoped text edits. */
   unprocessedStories: GenerateRedlineUnprocessedStory[];
+  /** Privacy transforms applied to the generated package. */
+  privacyReport: FolioDocumentPrivacyReport;
 };
 
 const nextBaseBlockIdByIndex = (events: readonly FolioAlignedBlockEvent[]): (string | null)[] => {
@@ -183,6 +193,9 @@ export const generateRedlineDocx = async (
 ): Promise<GenerateRedlineDocxResult> => {
   const baseView = resolveInputView(options.baseView, "baseView");
   const revisedView = resolveInputView(options.revisedView, "revisedView");
+  const privacyTransforms = resolveFolioDocumentPrivacyTransforms(
+    options.privacy?.transforms ?? [],
+  );
   const [baseReviewer, revisedReviewer] = await Promise.all([
     FolioDocxReviewer.fromBuffer(base, { author: options.author ?? "folio compare" }),
     FolioDocxReviewer.fromBuffer(revised),
@@ -245,10 +258,19 @@ export const generateRedlineDocx = async (
     skipped.push(...result.skipped);
   }
 
+  const redlineBuffer = await baseReviewer.toBuffer();
+  const privacyResult =
+    privacyTransforms.length === 0
+      ? {
+          buffer: redlineBuffer,
+          privacyReport: { appliedTransforms: [], removedMetadataProperties: [] },
+        }
+      : await rewriteDocxMetadataPrivacy(redlineBuffer, { transforms: privacyTransforms });
   return {
-    buffer: await baseReviewer.toBuffer(),
+    buffer: privacyResult.buffer,
     applied,
     skipped,
     unprocessedStories,
+    privacyReport: privacyResult.privacyReport,
   };
 };


### PR DESCRIPTION
Adds package-metadata privacy options and reports to generated redline packages.

Exposes the same result through `@stll/folio-agents`.