### PR TITLE
feat: add stable Vue document navigation

### DIFF
--- a/.changeset/vue-stable-navigation.md
+++ b/.changeset/vue-stable-navigation.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-vue": minor
+---
+
+Resolve and reveal stable document navigation targets through the Vue editor ref.

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -34,6 +34,8 @@ export type FolioParityBridge = {
   countCommentAnchors: () => number;
   /** Block count of the AI-edit snapshot over the live doc (0 with no live view). */
   aiSnapshotBlockCount: () => number;
+  /** Reveal the first stable snapshot block and report target/current pages. */
+  navigateToFirstBlock: () => { shown: boolean; targetPage: number; currentPage: number };
   /** Apply and undo one direct document-operation batch; true only when content restores. */
   applyAndUndoDocumentOperation: () => boolean;
   /** Push an anonymization term matching the first word. Returns whether one was pushed. */
@@ -187,6 +189,18 @@ export function buildParityBridge(getRef: () => DocxEditorRef | null): FolioPari
     countCommentAnchors: () =>
       document.querySelectorAll(".paged-editor__pages [data-comment-id]").length,
     aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
+    navigateToFirstBlock: () => {
+      const ref = getRef();
+      const snapshot = ref?.createAIEditSnapshot();
+      const firstBlock = snapshot?.blocks.at(0);
+      if (!ref || !snapshot || !firstBlock) {
+        return { shown: false, targetPage: 0, currentPage: 0 };
+      }
+      const target = { type: "block", story: "main", blockId: firstBlock.id } as const;
+      const targetPage = ref.getTargetPage(target, snapshot) ?? 0;
+      const shown = ref.showInDocument(target, snapshot);
+      return { shown, targetPage, currentPage: ref.getCurrentPage() };
+    },
     applyAndUndoDocumentOperation: () => {
       const ref = getRef();
       const firstSnapshot = ref?.createAIEditSnapshot();

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -81,6 +81,8 @@ export type FolioParityBridge = {
   countCommentAnchors: () => number;
   /** Block count of the AI-edit snapshot over the live doc (0 with no live view). */
   aiSnapshotBlockCount: () => number;
+  /** Reveal the first stable snapshot block and report target/current pages. */
+  navigateToFirstBlock: () => { shown: boolean; targetPage: number; currentPage: number };
   /** Apply and undo one direct document-operation batch; true only when content restores. */
   applyAndUndoDocumentOperation: () => boolean;
   /** Push an anonymization term matching the first word. Returns whether one was pushed. */
@@ -234,6 +236,18 @@ function buildParityBridge(getRef: () => DocxEditorRef | null): FolioParityBridg
     countCommentAnchors: () =>
       document.querySelectorAll(".paged-editor__pages [data-comment-id]").length,
     aiSnapshotBlockCount: () => getRef()?.createAIEditSnapshot()?.blocks.length ?? 0,
+    navigateToFirstBlock: () => {
+      const ref = getRef();
+      const snapshot = ref?.createAIEditSnapshot();
+      const firstBlock = snapshot?.blocks.at(0);
+      if (!ref || !snapshot || !firstBlock) {
+        return { shown: false, targetPage: 0, currentPage: 0 };
+      }
+      const target = { type: "block", story: "main", blockId: firstBlock.id } as const;
+      const targetPage = ref.getTargetPage(target, snapshot) ?? 0;
+      const shown = ref.showInDocument(target, snapshot);
+      return { shown, targetPage, currentPage: ref.getCurrentPage() };
+    },
     applyAndUndoDocumentOperation: () => {
       const ref = getRef();
       const firstSnapshot = ref?.createAIEditSnapshot();

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -77,6 +77,7 @@ import type { PagedEditorRef } from "../components/DocxEditor/pagedEditorRef";
 import {
   clampRangeToDocSize,
   resolveFolioAIBlockRange,
+  resolveFolioAITextRange,
 } from "@stll/folio-core/ai-edits/blockRange";
 import { getPageTextFromLayout } from "@stll/folio-core/paged-layout/pageText";
 
@@ -488,10 +489,29 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
       requestAnimationFrame(() => opts.scrollVisiblePositionIntoView(from));
       return true;
     },
-    // PORT-BLOCKED: Vue does not yet expose stable document-target navigation.
-    // Keep the imperative ref surface aligned with React while returning a
-    // deterministic failure until the backing Vue navigation bridge lands.
-    showInDocument: () => false,
+    showInDocument: (target, snapshot) => {
+      const view = opts.editorView.value;
+      if (!view) {
+        return false;
+      }
+      const range =
+        target.type === "textRange"
+          ? resolveFolioAITextRange({ range: target, doc: view.state.doc, snapshot })
+          : resolveFolioAIBlockRange({
+              blockId: target.blockId,
+              doc: view.state.doc,
+              snapshot,
+            });
+      if (range === null) {
+        return false;
+      }
+      const { from, to } = range;
+      const $from = view.state.doc.resolve(from);
+      const $to = view.state.doc.resolve(to);
+      view.dispatch(view.state.tr.setSelection(TextSelection.between($from, $to)));
+      requestAnimationFrame(() => opts.scrollVisiblePositionIntoView(from));
+      return true;
+    },
     getTrackedChanges: () => {
       const view = opts.editorView.value;
       return view ? getTrackedChangesFromDoc(view.state.doc) : [];
@@ -511,9 +531,26 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
       }
       return getPageTextFromLayout(opts.layout.value, view.state.doc, page);
     },
-    // PORT-BLOCKED: target-to-page resolution depends on the same stable
-    // document-target bridge as showInDocument. Return null until it lands.
-    getTargetPage: () => null,
+    getTargetPage: (target, snapshot) => {
+      const view = opts.editorView.value;
+      const currentLayout = opts.layout.value;
+      if (!view || !currentLayout) {
+        return null;
+      }
+      const range =
+        target.type === "textRange"
+          ? resolveFolioAITextRange({ range: target, doc: view.state.doc, snapshot })
+          : resolveFolioAIBlockRange({
+              blockId: target.blockId,
+              doc: view.state.doc,
+              snapshot,
+            });
+      if (range === null) {
+        return null;
+      }
+      const pageIndex = findPageIndexContainingPmPos(currentLayout, range.from);
+      return pageIndex == null ? null : pageIndex + 1;
+    },
     getContentControls: (filter = {}) => {
       const view = opts.editorView.value;
       if (!view) {

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -104,6 +104,7 @@
       "getEditorRef",
       "getPageText",
       "getSelectionText",
+      "getTargetPage",
       "getTotalPages",
       "getTrackedChanges",
       "getZoom",
@@ -121,6 +122,7 @@
       "scrollToContentControl",
       "scrollToPage",
       "scrollToParaId",
+      "showInDocument",
       "setContentControlContent",
       "setContentControlValue",
       "setZoom",
@@ -132,9 +134,6 @@
       "hasPendingChanges": "Both wired, same set/clear points, different-idiom implementation. React derives it live each call from the ParagraphChangeTracker plugin (getChangedParagraphIds/hasStructuralChanges/hasUntrackedChanges) OR-ed with commentsDirtyRef, and clears the tracker after each successful save. Vue cannot read the tracker for this because it deliberately leaves the tracker uncleared across saves (the tracker is the selective-save baseline; see the featureFlags props note) and re-editing an already-tracked paragraph would not grow the set, so a tracker read could never go false after save. Instead Vue tracks two boolean flags with the same set/clear points as React's underlying signals: `isDirty` in useDocxEditor (set on every doc-changing transaction — the same signal that drives the writeback/onChange; cleared on a successful save() and on document load/swap) and `commentsDirty` in useCommentManagement (set on every user comment mutation add/reply/resolve/unresolve/delete; cleared on document load via seedFromDocument and on a successful save via the ref API's save wrapper). useDocxEditorRefApi returns `isDirty || commentsDirty` (false before the view mounts, matching React's no-view guard). Net semantics match: pending after typing or a comment edit, clean after save or load. Housekeeping transactions (paraId allocation, auto-bidi) only run as appendTransactions to a real user edit or imperatively at initial-state build (never through the runtime transaction handler on a plain load), so they never set isDirty spuriously.",
       "getEditorRef": "Both wired, real handle in both, one sub-method genuinely no-op in both. Vue has no ported PagedEditor component to source a ref from, so useDocxEditorRefApi.ts synthesizes the identical PagedEditorRef shape from primitives it already holds: getEditor/getDocument/getState/getView/ensureView/focus/blur/isFocused/dispatch/undo/redo/canUndo/canRedo/setSelection/getLayout/relayout delegate straight to the headless FolioEditor controller (core/controller/folioEditor.ts), which already implements the hidden-editor imperative API 1:1 with React's PagedEditorRef surface; scrollToPosition delegates to the same scrollVisiblePositionIntoView used by the AI-edit scroll methods; scrollToPage/scrollToParaId reuse this file's own DocxEditorRef-level implementations verbatim (same pagesRef/pagesViewportRef-based DOM math as React's PagedEditor); getPageNumberForPmPos uses findPageIndexContainingPmPos against the reactive layout, the same helper getCurrentPage already uses, so it is null before first layout and 1-indexed like React's version. getHfView is a documented no-op returning null in Vue (paired with React's real hfPMsRef-backed lookup only in the sense that both exist and typecheck): useDocxEditor's layout pipeline always calls runLayoutPipelineCompute with hfPMs: null (see the HfPmsHandle type there), so Vue has no persistent hidden header/footer EditorView to look up by rId yet, unlike React's inline HF editing. ensureView ignores its {focus} option like the top-level ensureEditorView (PORT-BLOCKED, ProseMirror-core ensureView() takes no argument yet)."
     },
-    "deferredInVue": {
-      "getTargetPage": "Vue does not yet resolve stable document targets to rendered pages.",
-      "showInDocument": "Vue does not yet reveal and select stable document targets."
-    }
+    "deferredInVue": {}
   }
 }

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -27,6 +27,7 @@ type FolioParityBridge = {
   commentFirstWord: () => boolean;
   countCommentAnchors: () => number;
   aiSnapshotBlockCount: () => number;
+  navigateToFirstBlock: () => { shown: boolean; targetPage: number; currentPage: number };
   applyAndUndoDocumentOperation: () => boolean;
   anonymizeFirstWord: () => boolean;
   countAnonymizationRects: () => number;

--- a/tests/parity/stable-navigation.spec.ts
+++ b/tests/parity/stable-navigation.spec.ts
@@ -1,0 +1,15 @@
+import { ensureLiveView, expect, forEachAdapter, openEditor } from "./parity-fixture";
+
+forEachAdapter(
+  "navigation: stable block targets reveal on the resolved page",
+  async (adapter, { page }) => {
+    await openEditor(page, adapter);
+    await ensureLiveView(page);
+
+    const result = await page.evaluate(() => window.__folioParity?.navigateToFirstBlock());
+
+    expect(result?.shown).toBe(true);
+    expect(result?.targetPage).toBeGreaterThan(0);
+    expect(result?.currentPage).toBe(result?.targetPage);
+  },
+);


### PR DESCRIPTION
Adds stable document-target navigation to the Vue editor ref.

Both block targets and validated text-range targets now resolve through the shared core range helpers, select the live editor range, reveal it, and report the rendered page. The parity contract now classifies all imperative ref members as paired.

Adds a cross-adapter browser assertion for target resolution and reveal behavior.