### PR TITLE
feat: complete Vue collaboration support

### DIFF
--- a/.changeset/shared-vue-collaboration.md
+++ b/.changeset/shared-vue-collaboration.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-react": patch
+"@stll/folio-vue": minor
+---
+
+Share collaboration module loading and remote-selection painting, and complete the Vue collaboration pipeline.

--- a/api-reports/vue/composables.api.md
+++ b/api-reports/vue/composables.api.md
@@ -21,6 +21,8 @@ import { FlowBlock } from '@stll/folio-core/layout-engine/types';
 import { FolioEditor } from '@stll/folio-core/controller/folioEditor';
 import { FolioSelectiveSaveFlags } from '@stll/folio-core/docx/selectiveSaveFlags';
 import { getSelectionRuns } from '@stll/folio-core/managers/ClipboardManager';
+import { HiddenProseMirrorCollaboration } from '@stll/folio-core/controller/hiddenEditorManager';
+import { HiddenProseMirrorRemoteSelection } from '@stll/folio-core/controller/hiddenEditorManager';
 import { Layout } from '@stll/folio-core/layout-engine/types';
 import { LayoutSelectionGate } from '@stll/folio-core/paged-layout/LayoutSelectionGate';
 import { MaybeRefOrGetter } from 'vue';
@@ -81,6 +83,11 @@ export type UseClipboardReturn = {
 export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorReturn;
 
 // @public (undocumented)
+export type UseDocxEditorCollaboration = HiddenProseMirrorCollaboration & {
+    plugins?: Plugin_2[] | undefined;
+};
+
+// @public (undocumented)
 export type UseDocxEditorOptions = {
     hiddenContainer: Ref<HTMLElement | null>;
     pagesContainer: Ref<HTMLElement | null>;
@@ -91,6 +98,7 @@ export type UseDocxEditorOptions = {
     editorMode?: MaybeRefOrGetter<"editing" | "suggesting" | "viewing">;
     author?: MaybeRefOrGetter<string>;
     externalPlugins?: Plugin_2[];
+    collaboration?: MaybeRefOrGetter<UseDocxEditorCollaboration | undefined>;
     onAnonymizationMatchesChange?: (matches: readonly AnonymizationMatch[]) => void;
     showTemplateDirectives?: MaybeRefOrGetter<boolean | undefined>;
     onSlashMenuChange?: (state: TemplateSlashMenuState) => void;
@@ -109,6 +117,7 @@ export type UseDocxEditorReturn = {
     editor: FolioEditor;
     editorView: Ref<EditorView | null>;
     editorState: Ref<EditorState | null>;
+    remoteSelections: Ref<HiddenProseMirrorRemoteSelection[]>;
     isReady: Ref<boolean>;
     isDirty: Ref<boolean>;
     parseError: Ref<string | null>;

--- a/api-reports/vue/styles.api.md
+++ b/api-reports/vue/styles.api.md
@@ -11,6 +11,7 @@ export const EDITOR_CSS_PATH = "@stll/folio-vue/editor.css";
 export const Z_INDEX: {
     readonly selectionOverlay: 10;
     readonly decorationLayer: 11;
+    readonly remoteSelection: 12;
     readonly imageOverlay: 15;
     readonly hfInlineEditor: 10;
     readonly ruler: 30;

--- a/bun.lock
+++ b/bun.lock
@@ -140,6 +140,9 @@
       "dependencies": {
         "@stll/folio-vue": "workspace:*",
         "vue": "^3.5.39",
+        "y-prosemirror": "^1.3.7",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.31",
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.7",

--- a/packages/core/src/controller/collaborationModules.ts
+++ b/packages/core/src/controller/collaborationModules.ts
@@ -1,0 +1,15 @@
+import type { CollaborationModules } from "./hiddenEditorManager";
+
+let collaborationModulesPromise: Promise<CollaborationModules> | null = null;
+
+/** Lazily load and cache the optional collaboration runtime shared by adapters. */
+export const loadCollaborationModules = (): Promise<CollaborationModules> => {
+  collaborationModulesPromise ??= Promise.all([import("y-prosemirror"), import("yjs")])
+    .then(([yProseMirror, yjs]) => ({ yProseMirror, yjs }))
+    .catch((error: unknown) => {
+      collaborationModulesPromise = null;
+      throw error;
+    });
+
+  return collaborationModulesPromise;
+};

--- a/packages/core/src/render-dom/RemoteSelectionOverlay.test.ts
+++ b/packages/core/src/render-dom/RemoteSelectionOverlay.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RenderedDomContext } from "./RenderedDomContext";
+import { resolveRemoteSelectionOverlayGeometry } from "./RemoteSelectionOverlay";
+
+describe("resolveRemoteSelectionOverlayGeometry", () => {
+  test("normalizes backward ranges while keeping the caret at the remote head", () => {
+    const rangeCalls: Array<[number, number]> = [];
+    const pointCalls: number[] = [];
+    const renderedDomContext: RenderedDomContext = {
+      findElementsForRange: () => [],
+      getContainerOffset: () => ({ x: 0, y: 0 }),
+      getCoordinatesForPosition: (position) => {
+        pointCalls.push(position);
+        return { x: position, y: 4, height: 12 };
+      },
+      getRectsForRange: (from, to) => {
+        rangeCalls.push([from, to]);
+        return [{ x: from, y: 4, width: to - from, height: 12 }];
+      },
+    };
+
+    const geometry = resolveRemoteSelectionOverlayGeometry(renderedDomContext, [
+      { anchor: 14, clientId: 7, color: "#123456", head: 5, name: "Ada" },
+    ]);
+
+    expect(rangeCalls).toEqual([[5, 14]]);
+    expect(pointCalls).toEqual([5]);
+    expect(geometry).toEqual([
+      {
+        caret: { x: 5, y: 4, height: 12 },
+        rects: [{ x: 5, y: 4, width: 9, height: 12 }],
+        selection: { anchor: 14, clientId: 7, color: "#123456", head: 5, name: "Ada" },
+      },
+    ]);
+  });
+});

--- a/packages/core/src/render-dom/RemoteSelectionOverlay.ts
+++ b/packages/core/src/render-dom/RemoteSelectionOverlay.ts
@@ -1,0 +1,115 @@
+import type { HiddenProseMirrorRemoteSelection } from "../controller/hiddenEditorManager";
+import { createRenderedDomContext } from "./RenderedDomContext";
+import type {
+  RenderedDomContext,
+  RenderedDomPoint,
+  RenderedDomRect,
+} from "./RenderedDomContext";
+
+const CARET_CLASS = "folio-remote-selection-caret";
+const LABEL_CLASS = "folio-remote-selection-label";
+const RANGE_CLASS = "folio-remote-selection-rect";
+const OWNED_OVERLAY_SELECTOR = `.${CARET_CLASS}, .${LABEL_CLASS}, .${RANGE_CLASS}`;
+
+export type SyncRemoteSelectionOverlayOptions = {
+  pagesContainer: HTMLElement;
+  selections: readonly HiddenProseMirrorRemoteSelection[];
+  zoom: number;
+  zIndex?: number;
+  renderedDomContext?: RenderedDomContext;
+};
+
+export type RemoteSelectionOverlayGeometry = {
+  caret: RenderedDomPoint | null;
+  rects: RenderedDomRect[];
+  selection: HiddenProseMirrorRemoteSelection;
+};
+
+export const resolveRemoteSelectionOverlayGeometry = (
+  renderedDomContext: RenderedDomContext,
+  selections: readonly HiddenProseMirrorRemoteSelection[],
+): RemoteSelectionOverlayGeometry[] =>
+  selections.map((selection) => ({
+    caret: renderedDomContext.getCoordinatesForPosition(selection.head),
+    rects: renderedDomContext.getRectsForRange(
+      Math.min(selection.anchor, selection.head),
+      Math.max(selection.anchor, selection.head),
+    ),
+    selection,
+  }));
+
+const setBox = (element: HTMLElement, rect: RenderedDomRect): void => {
+  element.style.left = `${rect.x}px`;
+  element.style.top = `${rect.y}px`;
+  element.style.width = `${rect.width}px`;
+  element.style.height = `${rect.height}px`;
+};
+
+const createOverlayElement = (
+  pagesContainer: HTMLElement,
+  className: string,
+  zIndex: number,
+): HTMLDivElement => {
+  const element = pagesContainer.ownerDocument.createElement("div");
+  element.className = className;
+  element.style.position = "absolute";
+  element.style.pointerEvents = "none";
+  element.style.zIndex = String(zIndex);
+  return element;
+};
+
+/** Paint collaborative cursors and selections over the rendered page DOM. */
+export class RemoteSelectionOverlay {
+  clear(pagesContainer: HTMLElement): void {
+    for (const element of pagesContainer.querySelectorAll(OWNED_OVERLAY_SELECTOR)) {
+      element.remove();
+    }
+  }
+
+  sync({
+    pagesContainer,
+    selections,
+    zoom,
+    zIndex = 20,
+    renderedDomContext = createRenderedDomContext(pagesContainer, zoom),
+  }: SyncRemoteSelectionOverlayOptions): void {
+    this.clear(pagesContainer);
+
+    for (const { caret, rects, selection } of resolveRemoteSelectionOverlayGeometry(
+      renderedDomContext,
+      selections,
+    )) {
+      for (const rect of rects) {
+        const element = createOverlayElement(pagesContainer, RANGE_CLASS, zIndex);
+        element.dataset["clientId"] = String(selection.clientId);
+        element.style.background = `color-mix(in srgb, ${selection.color} 24%, transparent)`;
+        setBox(element, rect);
+        pagesContainer.appendChild(element);
+      }
+
+      if (!caret) {
+        continue;
+      }
+
+      const caretElement = createOverlayElement(pagesContainer, CARET_CLASS, zIndex + 1);
+      caretElement.dataset["clientId"] = String(selection.clientId);
+      caretElement.style.background = selection.color;
+      setBox(caretElement, { ...caret, width: 2 });
+      pagesContainer.appendChild(caretElement);
+
+      const label = createOverlayElement(pagesContainer, LABEL_CLASS, zIndex + 2);
+      label.dataset["clientId"] = String(selection.clientId);
+      label.textContent = selection.name;
+      label.style.background = selection.color;
+      label.style.color = "var(--background, #fff)";
+      label.style.fontSize = "10px";
+      label.style.lineHeight = "1";
+      label.style.padding = "2px 4px";
+      label.style.borderRadius = "2px";
+      label.style.left = `${caret.x}px`;
+      label.style.top = `${Math.max(0, caret.y - 18)}px`;
+      label.style.whiteSpace = "nowrap";
+      pagesContainer.appendChild(label);
+    }
+  }
+}

--- a/packages/core/src/render-dom/RemoteSelectionOverlay.ts
+++ b/packages/core/src/render-dom/RemoteSelectionOverlay.ts
@@ -1,10 +1,6 @@
 import type { HiddenProseMirrorRemoteSelection } from "../controller/hiddenEditorManager";
 import { createRenderedDomContext } from "./RenderedDomContext";
-import type {
-  RenderedDomContext,
-  RenderedDomPoint,
-  RenderedDomRect,
-} from "./RenderedDomContext";
+import type { RenderedDomContext, RenderedDomPoint, RenderedDomRect } from "./RenderedDomContext";
 
 const CARET_CLASS = "folio-remote-selection-caret";
 const LABEL_CLASS = "folio-remote-selection-label";

--- a/packages/playground-vue/package.json
+++ b/packages/playground-vue/package.json
@@ -13,7 +13,10 @@
   },
   "dependencies": {
     "@stll/folio-vue": "workspace:*",
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "y-prosemirror": "^1.3.7",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",

--- a/packages/playground-vue/src/App.vue
+++ b/packages/playground-vue/src/App.vue
@@ -17,6 +17,7 @@
         :show-toolbar="true"
         :show-ruler="true"
         :initial-zoom="1"
+        :collaboration="collaboration"
       />
     </main>
     <p v-if="status" class="pg-vue-status">{{ status }}</p>
@@ -25,9 +26,25 @@
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, shallowRef } from "vue";
+import {
+  applyAwarenessUpdate,
+  Awareness,
+  encodeAwarenessUpdate,
+} from "y-protocols/awareness";
+import {
+  initProseMirrorDoc,
+  yCursorPlugin,
+  ySyncPlugin,
+  yUndoPlugin,
+} from "y-prosemirror";
+import * as Y from "yjs";
 
 import { DocxEditor, createEmptyDocument, createStellaStyleDocumentPreset } from "@stll/folio-vue";
-import type { DocxEditorRef, Document as FolioDocument } from "@stll/folio-vue";
+import type {
+  DocxEditorCollaboration,
+  DocxEditorRef,
+  Document as FolioDocument,
+} from "@stll/folio-vue";
 
 import type { FolioParityBridge } from "./parityBridge";
 import { buildParityBridge } from "./parityBridge";
@@ -35,20 +52,105 @@ import { buildParityBridge } from "./parityBridge";
 declare global {
   // eslint-disable-next-line no-var
   var __folioParity: FolioParityBridge | undefined;
+  // eslint-disable-next-line no-var
+  var __folioVueCollaboration:
+    | {
+        getSharedText: () => string;
+        showRemoteSelection: () => boolean;
+        wasSeeded: () => boolean;
+      }
+    | undefined;
 }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
 
 const editorRef = ref<DocxEditorRef | null>(null);
 const documentBuffer = shallowRef<ArrayBuffer | null>(null);
 const currentDocument = shallowRef<FolioDocument | null>(null);
 const status = ref("");
+const collaborationEnabled = new URLSearchParams(window.location.search).has("collaboration");
+const collaborationDocument = collaborationEnabled ? new Y.Doc() : null;
+const collaborationAwareness = collaborationDocument
+  ? new Awareness(collaborationDocument)
+  : null;
+let collaborationWasSeeded = false;
+const remoteCollaborationDocuments: Y.Doc[] = [];
+const remoteCollaborationAwareness: Awareness[] = [];
+const collaboration: DocxEditorCollaboration | undefined =
+  collaborationDocument && collaborationAwareness
+    ? {
+        awareness: collaborationAwareness,
+        onSeeded: () => {
+          collaborationWasSeeded = true;
+        },
+        plugins: [
+          ySyncPlugin(collaborationDocument.getXmlFragment("prosemirror")),
+          yCursorPlugin(collaborationAwareness),
+          yUndoPlugin(),
+        ],
+        shouldSeed: true,
+        yXmlFragment: collaborationDocument.getXmlFragment("prosemirror"),
+      }
+    : undefined;
+
+collaborationAwareness?.setLocalStateField("user", {
+  color: "#2563eb",
+  name: "Vue collaborator",
+});
 
 onMounted(() => {
   void loadFromQuery();
   globalThis.__folioParity = buildParityBridge(() => editorRef.value);
+  if (collaboration) {
+    globalThis.__folioVueCollaboration = {
+      getSharedText: () => {
+        const view = editorRef.value?.getEditor()?.getView();
+        if (!view) {
+          return "";
+        }
+        return initProseMirrorDoc(collaboration.yXmlFragment, view.state.schema).doc.textContent;
+      },
+      showRemoteSelection: () => {
+        if (!globalThis.__folioParity?.selectFirstWord() || !collaborationAwareness) {
+          return false;
+        }
+        const localState = collaborationAwareness.getLocalState();
+        if (!isRecord(localState) || !isRecord(localState["cursor"])) {
+          return false;
+        }
+
+        const remoteDocument = new Y.Doc();
+        const remoteAwareness = new Awareness(remoteDocument);
+        remoteAwareness.setLocalState({
+          cursor: localState["cursor"],
+          user: { color: "#dc2626", name: "Remote collaborator" },
+        });
+        applyAwarenessUpdate(
+          collaborationAwareness,
+          encodeAwarenessUpdate(remoteAwareness, [remoteAwareness.clientID]),
+          "parity-test",
+        );
+        remoteCollaborationDocuments.push(remoteDocument);
+        remoteCollaborationAwareness.push(remoteAwareness);
+        return true;
+      },
+      wasSeeded: () => collaborationWasSeeded,
+    };
+  }
 });
 
 onBeforeUnmount(() => {
   globalThis.__folioParity = undefined;
+  globalThis.__folioVueCollaboration = undefined;
+  collaborationAwareness?.destroy();
+  collaborationDocument?.destroy();
+  for (const awareness of remoteCollaborationAwareness) {
+    awareness.destroy();
+  }
+  for (const document of remoteCollaborationDocuments) {
+    document.destroy();
+  }
 });
 
 async function loadFromQuery(): Promise<void> {

--- a/packages/playground-vue/src/App.vue
+++ b/packages/playground-vue/src/App.vue
@@ -26,17 +26,8 @@
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, shallowRef } from "vue";
-import {
-  applyAwarenessUpdate,
-  Awareness,
-  encodeAwarenessUpdate,
-} from "y-protocols/awareness";
-import {
-  initProseMirrorDoc,
-  yCursorPlugin,
-  ySyncPlugin,
-  yUndoPlugin,
-} from "y-prosemirror";
+import { applyAwarenessUpdate, Awareness, encodeAwarenessUpdate } from "y-protocols/awareness";
+import { initProseMirrorDoc, yCursorPlugin, ySyncPlugin, yUndoPlugin } from "y-prosemirror";
 import * as Y from "yjs";
 
 import { DocxEditor, createEmptyDocument, createStellaStyleDocumentPreset } from "@stll/folio-vue";
@@ -71,9 +62,7 @@ const currentDocument = shallowRef<FolioDocument | null>(null);
 const status = ref("");
 const collaborationEnabled = new URLSearchParams(window.location.search).has("collaboration");
 const collaborationDocument = collaborationEnabled ? new Y.Doc() : null;
-const collaborationAwareness = collaborationDocument
-  ? new Awareness(collaborationDocument)
-  : null;
+const collaborationAwareness = collaborationDocument ? new Awareness(collaborationDocument) : null;
 let collaborationWasSeeded = false;
 const remoteCollaborationDocuments: Y.Doc[] = [];
 const remoteCollaborationAwareness: Awareness[] = [];

--- a/packages/react/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/react/src/paged-editor/HiddenProseMirror.tsx
@@ -33,6 +33,7 @@ import type { EditorView } from "prosemirror-view";
 import {
   collectRemoteSelections,
   createHiddenEditorManager,
+  type CollaborationModules,
   type HiddenEditorManager,
   type HiddenProseMirrorCollaboration,
   type HiddenProseMirrorRemoteSelection,

--- a/packages/react/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/react/src/paged-editor/HiddenProseMirror.tsx
@@ -33,11 +33,11 @@ import type { EditorView } from "prosemirror-view";
 import {
   collectRemoteSelections,
   createHiddenEditorManager,
-  type CollaborationModules,
   type HiddenEditorManager,
   type HiddenProseMirrorCollaboration,
   type HiddenProseMirrorRemoteSelection,
 } from "@stll/folio-core/controller/hiddenEditorManager";
+import { loadCollaborationModules } from "@stll/folio-core/controller/collaborationModules";
 import type { ExtensionManager } from "@stll/folio-core/prosemirror/extensions/ExtensionManager";
 import type { Document, Theme, StyleDefinitions } from "@stll/folio-core/types/document";
 // Import ProseMirror CSS
@@ -52,19 +52,6 @@ export type {
 export { createHiddenEditorState } from "@stll/folio-core/controller/hiddenEditorManager";
 
 const EMPTY_EXTERNAL_PLUGINS: Plugin[] = [];
-
-let collaborationModulesPromise: Promise<CollaborationModules> | null = null;
-
-const loadCollaborationModules = (): Promise<CollaborationModules> => {
-  collaborationModulesPromise ??= Promise.all([import("y-prosemirror"), import("yjs")])
-    .then(([yProseMirror, yjs]) => ({ yProseMirror, yjs }))
-    .catch((error: unknown) => {
-      collaborationModulesPromise = null;
-      throw error;
-    });
-
-  return collaborationModulesPromise;
-};
 
 // ============================================================================
 // TYPES

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -24,18 +24,13 @@
   comment/tracked-change sidebar (`useTrackedChanges` + `useCommentSidebarItems`
   inside `UnifiedSidebar`), and the table context toolbar (`TableToolbar`).
 
-  PORT-BLOCKED (fork has not ported the backing composable/component yet):
-   - externalPlugins / i18n-locale props: not on the fork's `DocxEditorProps`, so
-     `externalPlugins` is `[]` and the locale defaults to `en`.
+  Remaining adapter-specific surfaces:
+   - externalPlugins / i18n-locale props are not on `DocxEditorProps`, so the
+     host plugin list is empty and the locale defaults to `en`.
    - colorMode prop + useColorMode: dark mode is fixed light here.
-   - Comment lifecycle/management (add/reply/resolve): `useCommentManagement` is
-     absent, so the sidebar renders comments/tracked changes but its mutation
-     emits are inert; document comment extraction is not ported either.
-   - Header/footer inline editing, decoration/anonymization overlays, and
-     rulers: not ported, so those chrome affordances stay inert. The title-bar
-     MenuBar is wired (File/Format/Insert/Help), including the insert flow
-     (image/table/page-break/TOC via host props or core view-level helpers);
-     the watermark item stays inert (no watermark dialog ported).
+   - Header/footer inline editing is not available yet. The title-bar MenuBar is
+     wired (File/Format/Insert/Help), including image/table/page-break/TOC.
+     The watermark item remains unavailable until its dialog is implemented.
 -->
 <template>
   <div
@@ -439,6 +434,7 @@ import { useKeyboardShortcuts } from "../composables/useKeyboardShortcuts";
 import { useOutlineSidebar } from "../composables/useOutlineSidebar";
 import { usePageSetupControls } from "../composables/usePageSetupControls";
 import { usePagesPointer } from "../composables/usePagesPointer";
+import { useRemoteSelectionSync } from "../composables/useRemoteSelectionSync";
 import { useSelectionSync } from "../composables/useSelectionSync";
 import { provideDocxPortalClass } from "../composables/usePortalClass";
 import { useTableResize } from "../composables/useTableResize";
@@ -567,8 +563,8 @@ const rulerVisible = computed(() => props.showRuler ?? false);
 const stateTick = ref(0);
 const showFindReplace = ref(false);
 const showHyperlink = ref(false);
-// PORT-BLOCKED: no KeyboardShortcutsDialog component ported yet, so F1 / Ctrl+/
-// toggle inert local state (mirrors the colorMode / externalPlugins stubs above).
+// The keyboard-shortcuts dialog is not available yet, so F1 / Ctrl+/ only
+// preserves the intended open state for the future dialog surface.
 const showKeyboardShortcuts = ref(false);
 const showInsertSymbol = ref(false);
 const showImageProperties = ref(false);
@@ -622,6 +618,7 @@ const {
   editor,
   editorView,
   editorState,
+  remoteSelections,
   isReady,
   isDirty,
   parseError,
@@ -644,8 +641,8 @@ const {
   author: () => props.author,
   password: () => props.password,
   documentKey: () => props.documentKey,
-  // PORT-BLOCKED: no externalPlugins prop on the fork's DocxEditorProps yet.
   externalPlugins: [],
+  collaboration: () => props.collaboration,
   // Anonymization highlights + template directives are driven by the overlay
   // components below; these thread the plugin callbacks and the directive gate.
   onAnonymizationMatchesChange: (matches) => props.onAnonymizationMatchesChange?.(matches),
@@ -761,6 +758,13 @@ const selectionSync = useSelectionSync({
   selectedImage,
   syncCoordinator,
   imageInteracting,
+});
+
+useRemoteSelectionSync({
+  pagesRef,
+  remoteSelections,
+  syncCoordinator,
+  zoom,
 });
 
 const {

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -4,8 +4,7 @@
  * Vue composables mirroring the React `hooks` subpath — history, table
  * selection, find/replace, clipboard, zoom, tracked-changes, visual-line
  * navigation, and the high-level `useDocxEditor` host composable. Only the
- * composables the fork has ported are re-exported (React's `useAutoSave` and
- * `useCommentSidebarItems` have no Vue equivalent yet).
+ * composables the fork has ported are re-exported.
  *
  * @example
  * ```ts

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -33,11 +33,18 @@ import type { EditorView } from "prosemirror-view";
 import { createFolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { FolioEditor } from "@stll/folio-core/controller/folioEditor";
 import { createFolioEditorEmitter } from "@stll/folio-core/controller/folioEditorEvents";
+import { loadCollaborationModules } from "@stll/folio-core/controller/collaborationModules";
 import {
+  collectRemoteSelections,
   createHiddenEditorManager,
   createHiddenEditorState,
 } from "@stll/folio-core/controller/hiddenEditorManager";
-import type { HiddenEditorManager } from "@stll/folio-core/controller/hiddenEditorManager";
+import type {
+  CollaborationModules,
+  HiddenEditorManager,
+  HiddenProseMirrorCollaboration,
+  HiddenProseMirrorRemoteSelection,
+} from "@stll/folio-core/controller/hiddenEditorManager";
 import { runLayoutPipeline as runLayoutPipelineCompute } from "@stll/folio-core/controller/layoutPipeline";
 import type { LayoutOutcome, LayoutRunOptions } from "@stll/folio-core/controller/layoutPipeline";
 import { browserClock, createLayoutScheduler } from "@stll/folio-core/controller/layoutScheduler";
@@ -381,6 +388,8 @@ export type UseDocxEditorOptions = {
   author?: MaybeRefOrGetter<string>;
   /** External ProseMirror plugins supplied by the host app. */
   externalPlugins?: Plugin[];
+  /** Reactive Yjs collaboration owner and the ProseMirror binding plugins. */
+  collaboration?: MaybeRefOrGetter<UseDocxEditorCollaboration | undefined>;
   /**
    * Fires with the anonymization decoration plugin's current match list on
    * mount, term push, and every doc edit. The anonymization plugin is always
@@ -423,6 +432,10 @@ export type UseDocxEditorOptions = {
   onSelectiveSaveTripwire?: ((result: TripwireResult) => void) | undefined;
 };
 
+export type UseDocxEditorCollaboration = HiddenProseMirrorCollaboration & {
+  plugins?: Plugin[] | undefined;
+};
+
 export type UseDocxEditorReturn = {
   /** The headless controller (imperative API + layout access + events). */
   editor: FolioEditor;
@@ -430,6 +443,8 @@ export type UseDocxEditorReturn = {
   editorView: Ref<EditorView | null>;
   /** Latest editor state, updated on each transaction. */
   editorState: Ref<EditorState | null>;
+  /** Remote collaborative cursors decoded into body ProseMirror positions. */
+  remoteSelections: Ref<HiddenProseMirrorRemoteSelection[]>;
   /** True once the hidden view is mounted and a document is loaded. */
   isReady: Ref<boolean>;
   /**
@@ -480,6 +495,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     editorMode,
     author,
     externalPlugins = [],
+    collaboration,
     onAnonymizationMatchesChange,
     showTemplateDirectives,
     onSlashMenuChange,
@@ -499,6 +515,8 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
   const docModel = shallowRef<Document | null>(null);
   const editorView = shallowRef<EditorView | null>(null);
   const editorState = shallowRef<EditorState | null>(null);
+  const collaborationModules = shallowRef<CollaborationModules | null>(null);
+  const remoteSelections = shallowRef<HiddenProseMirrorRemoteSelection[]>([]);
   const layout = shallowRef<Layout | null>(null);
   // Latest flow blocks + measures — the range-projection fallback (off-screen /
   // not-yet-painted ranges) needs them; the primary DOM-rect path does not.
@@ -553,6 +571,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     return [
       suggestionPlugin,
       ...externalPlugins,
+      ...(toValue(collaboration)?.plugins ?? []),
       anonymizationPlugin,
       ...(templatePluginsEnabled() ? [templateDirectivesPlugin, templateSlashMenu] : []),
       templatePreviewPlugin,
@@ -717,8 +736,8 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     getStyles: () => docModel.value?.package.styles ?? null,
     getExtensionManager: () => extensionManager,
     getExternalPlugins: buildExternalPlugins,
-    getCollaboration: () => undefined,
-    getCollaborationModules: () => null,
+    getCollaboration: () => toValue(collaboration),
+    getCollaborationModules: () => collaborationModules.value,
     getPrecomputedInitialState: () => null,
     getReadOnly: () => toValue(readOnly),
     getDocumentKey: () => toValue(documentKey),
@@ -740,10 +759,78 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       isReady.value = false;
       onEditorViewReady?.(null);
     },
-    onRemoteSelectionsChange: () => {
-      // Collaboration remote selections are not wired in the Vue adapter yet.
+    onRemoteSelectionsChange: (selections) => {
+      remoteSelections.value = selections;
     },
   });
+
+  const publishRemoteSelections = (): void => {
+    const awareness = toValue(collaboration)?.awareness;
+    const modules = collaborationModules.value;
+    const view = manager.getView();
+    remoteSelections.value =
+      awareness && modules && view ? collectRemoteSelections(view.state, awareness, modules) : [];
+  };
+
+  watch(
+    () => toValue(collaboration),
+    (activeCollaboration, _previousCollaboration, onCleanup) => {
+      remoteSelections.value = [];
+      if (!activeCollaboration) {
+        collaborationModules.value = null;
+        manager.retryViewCreation();
+        manager.syncExternalDocument();
+        return;
+      }
+
+      let cancelled = false;
+      onCleanup(() => {
+        cancelled = true;
+      });
+      collaborationModules.value = null;
+      void loadCollaborationModules().then(
+        (modules) => {
+          if (cancelled) {
+            return;
+          }
+          collaborationModules.value = modules;
+          manager.retryViewCreation();
+          manager.syncExternalDocument();
+          publishRemoteSelections();
+        },
+        (error: unknown) => {
+          if (cancelled) {
+            return;
+          }
+          collaborationModules.value = null;
+          onError?.(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+    },
+    { immediate: true },
+  );
+
+  watch(
+    () => ({
+      awareness: toValue(collaboration)?.awareness,
+      modules: collaborationModules.value,
+      view: editorView.value,
+    }),
+    ({ awareness, modules, view }, _previous, onCleanup) => {
+      if (!awareness || !modules || !view) {
+        remoteSelections.value = [];
+        return;
+      }
+
+      awareness.on("change", publishRemoteSelections);
+      publishRemoteSelections();
+      onCleanup(() => {
+        awareness.off("change", publishRemoteSelections);
+        remoteSelections.value = [];
+      });
+    },
+    { flush: "post" },
+  );
 
   function handleTransaction(transaction: Transaction, newState: EditorState): void {
     editorState.value = newState;
@@ -876,7 +963,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
    */
   function paintFromPrecomputedState(): void {
     const model = docModel.value;
-    if (!model) {
+    if (!model || toValue(collaboration)) {
       return;
     }
     try {
@@ -1037,6 +1124,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       docChangeTimer = null;
     }
     manager.destroyView();
+    remoteSelections.value = [];
     extensionManager.destroy();
     editorState.value = null;
     layout.value = null;
@@ -1050,6 +1138,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     editor,
     editorView,
     editorState,
+    remoteSelections,
     isReady,
     isDirty,
     parseError,

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -791,19 +791,21 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       void loadCollaborationModules().then(
         (modules) => {
           if (cancelled) {
-            return;
+            return undefined;
           }
           collaborationModules.value = modules;
           manager.retryViewCreation();
           manager.syncExternalDocument();
           publishRemoteSelections();
+          return undefined;
         },
         (error: unknown) => {
           if (cancelled) {
-            return;
+            return undefined;
           }
           collaborationModules.value = null;
           onError?.(error instanceof Error ? error : new Error(String(error)));
+          return undefined;
         },
       );
     },

--- a/packages/vue/src/composables/useRemoteSelectionSync.ts
+++ b/packages/vue/src/composables/useRemoteSelectionSync.ts
@@ -1,0 +1,59 @@
+import { onScopeDispose, watch, type Ref } from "vue";
+
+import type { HiddenProseMirrorRemoteSelection } from "@stll/folio-core/controller/hiddenEditorManager";
+import type { LayoutSelectionGate } from "@stll/folio-core/paged-layout/LayoutSelectionGate";
+import { RemoteSelectionOverlay } from "@stll/folio-core/render-dom/RemoteSelectionOverlay";
+
+import { Z_INDEX } from "../styles/zIndex";
+
+export type UseRemoteSelectionSyncOptions = {
+  pagesRef: Ref<HTMLElement | null>;
+  remoteSelections: Ref<HiddenProseMirrorRemoteSelection[]>;
+  syncCoordinator: LayoutSelectionGate;
+  zoom: Ref<number>;
+};
+
+export const useRemoteSelectionSync = (options: UseRemoteSelectionSyncOptions): void => {
+  const overlay = new RemoteSelectionOverlay();
+  let animationFrame: number | null = null;
+
+  const clear = (): void => {
+    if (animationFrame !== null) {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = null;
+    }
+    const pagesContainer = options.pagesRef.value;
+    if (pagesContainer) {
+      overlay.clear(pagesContainer);
+    }
+  };
+
+  const sync = (): void => {
+    if (animationFrame !== null) {
+      cancelAnimationFrame(animationFrame);
+    }
+    animationFrame = requestAnimationFrame(() => {
+      animationFrame = null;
+      if (!options.syncCoordinator.isSafeToRender()) {
+        return;
+      }
+      const pagesContainer = options.pagesRef.value;
+      if (!pagesContainer) {
+        return;
+      }
+      overlay.sync({
+        pagesContainer,
+        selections: options.remoteSelections.value,
+        zoom: options.zoom.value,
+        zIndex: Z_INDEX.remoteSelection,
+      });
+    });
+  };
+
+  const unsubscribeRender = options.syncCoordinator.onRender(sync);
+  watch([options.pagesRef, options.remoteSelections, options.zoom], sync, { flush: "post" });
+  onScopeDispose(() => {
+    unsubscribeRender();
+    clear();
+  });
+};

--- a/packages/vue/src/styles/zIndex.ts
+++ b/packages/vue/src/styles/zIndex.ts
@@ -10,6 +10,7 @@
 export const Z_INDEX = {
   selectionOverlay: 10,
   decorationLayer: 11,
+  remoteSelection: 12,
   imageOverlay: 15,
   hfInlineEditor: 10,
   ruler: 30,

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -7,6 +7,7 @@
       "author",
       "autoOpenReviewSidebar",
       "className",
+      "collaboration",
       "comments",
       "components",
       "customContextMenuItems",
@@ -68,7 +69,6 @@
       "toolbarExtra"
     ],
     "deferredInVue": {
-      "collaboration": "Yjs collaboration owner is not threaded through the Vue pipeline yet.",
       "showHeaderFooterEditing": "Header/footer inline editing is not ported to Vue."
     },
     "pairedNotes": {

--- a/tests/parity/vue-collaboration.spec.ts
+++ b/tests/parity/vue-collaboration.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+declare global {
+  // eslint-disable-next-line typescript/consistent-type-definitions
+  interface Window {
+    __folioVueCollaboration?: {
+      getSharedText: () => string;
+      showRemoteSelection: () => boolean;
+      wasSeeded: () => boolean;
+    };
+  }
+}
+
+test("Vue collaboration seeds and synchronizes the shared document", async ({ page }) => {
+  await page.goto("http://localhost:4201/?collaboration=1");
+  await expect
+    .poll(() => page.evaluate(() => window.__folioParity?.hasView() ?? false), {
+      timeout: 30_000,
+    })
+    .toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => window.__folioVueCollaboration?.wasSeeded() ?? false))
+    .toBe(true);
+
+  expect(await page.evaluate(() => window.__folioParity?.insertText("shared text"))).toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => window.__folioVueCollaboration?.getSharedText() ?? ""))
+    .toContain("shared text");
+
+  await expect
+    .poll(() => page.evaluate(() => window.__folioVueCollaboration?.showRemoteSelection() ?? false))
+    .toBe(true);
+  await expect
+    .poll(() => page.locator(".folio-remote-selection-rect").count())
+    .toBeGreaterThan(0);
+  await expect(page.locator(".folio-remote-selection-label")).toContainText(
+    "Remote collaborator",
+  );
+});

--- a/tests/parity/vue-collaboration.spec.ts
+++ b/tests/parity/vue-collaboration.spec.ts
@@ -30,10 +30,6 @@ test("Vue collaboration seeds and synchronizes the shared document", async ({ pa
   await expect
     .poll(() => page.evaluate(() => window.__folioVueCollaboration?.showRemoteSelection() ?? false))
     .toBe(true);
-  await expect
-    .poll(() => page.locator(".folio-remote-selection-rect").count())
-    .toBeGreaterThan(0);
-  await expect(page.locator(".folio-remote-selection-label")).toContainText(
-    "Remote collaborator",
-  );
+  await expect.poll(() => page.locator(".folio-remote-selection-rect").count()).toBeGreaterThan(0);
+  await expect(page.locator(".folio-remote-selection-label")).toContainText("Remote collaborator");
 });

--- a/tests/visual/vue-collaboration.interactions.spec.ts
+++ b/tests/visual/vue-collaboration.interactions.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+import { ensureLiveView } from "../parity/parity-fixture";
+
 declare global {
   // eslint-disable-next-line typescript/consistent-type-definitions
   interface Window {
@@ -13,11 +15,7 @@ declare global {
 
 test("Vue collaboration seeds and synchronizes the shared document", async ({ page }) => {
   await page.goto("http://localhost:4201/?collaboration=1");
-  await expect
-    .poll(() => page.evaluate(() => window.__folioParity?.hasView() ?? false), {
-      timeout: 30_000,
-    })
-    .toBe(true);
+  await ensureLiveView(page);
   await expect
     .poll(() => page.evaluate(() => window.__folioVueCollaboration?.wasSeeded() ?? false))
     .toBe(true);


### PR DESCRIPTION
## Summary

- share lazy collaboration module loading and remote-selection painting in the framework-neutral core
- wire Vue collaborative state, binding plugins, awareness updates, and remote cursor overlays end to end
- add a deterministic browser harness for shared-document synchronization and remote selection rendering
- classify the collaboration prop as paired across adapters

## Validation

- focused core collaboration and overlay tests
- adapter parity contract
- dependency audit
- full CI requested for build, type, lint, package, and browser coverage