### PR TITLE
feat: connect Vue table properties action

### DIFF
--- a/.changeset/vue-table-properties-action.md
+++ b/.changeset/vue-table-properties-action.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-vue": minor
+---
+
+Connect the Vue table options menu to the existing table properties dialog and command.

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -28,6 +28,12 @@ export type FolioParityBridge = {
   setupContentControls: () => boolean;
   /** Dispatch a clipboard DOM event and return the matching host callback count. */
   dispatchClipboardEvent: (kind: "copy" | "cut" | "paste") => number;
+  /** Table properties at the live selection, or null outside a table. */
+  getCurrentTableProperties: () => {
+    width: number | null;
+    widthType: string | null;
+    justification: string | null;
+  } | null;
   /** Insert a rows×cols table at the selection (core helper). Returns success. */
   insertTable: (rows: number, cols: number) => boolean;
   /** Count `table` nodes in the live document (0 with no live view). */
@@ -173,6 +179,28 @@ export function buildParityBridge(
       }
       view.dom.dispatchEvent(new ClipboardEvent(kind, { bubbles: true, cancelable: true }));
       return getClipboardCallbackCount(kind);
+    },
+    getCurrentTableProperties: () => {
+      const view = liveView();
+      if (!view) {
+        return null;
+      }
+      const { $from } = view.state.selection;
+      for (let depth = $from.depth; depth >= 0; depth--) {
+        const node = $from.node(depth);
+        if (node.type.name !== "table") {
+          continue;
+        }
+        const width = node.attrs["width"];
+        const widthType = node.attrs["widthType"];
+        const justification = node.attrs["justification"];
+        return {
+          width: typeof width === "number" ? width : null,
+          widthType: typeof widthType === "string" ? widthType : null,
+          justification: typeof justification === "string" ? justification : null,
+        };
+      }
+      return null;
     },
     insertTable: (rows, cols) => {
       const view = liveView();

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -75,6 +75,12 @@ export type FolioParityBridge = {
   setupContentControls: () => boolean;
   /** Dispatch a clipboard DOM event and return the matching host callback count. */
   dispatchClipboardEvent: (kind: "copy" | "cut" | "paste") => number;
+  /** Table properties at the live selection, or null outside a table. */
+  getCurrentTableProperties: () => {
+    width: number | null;
+    widthType: string | null;
+    justification: string | null;
+  } | null;
   /** Insert a rows×cols table at the selection (core helper). Returns success. */
   insertTable: (rows: number, cols: number) => boolean;
   /** Count `table` nodes in the live document (0 with no live view). */
@@ -220,6 +226,28 @@ function buildParityBridge(
       }
       view.dom.dispatchEvent(new ClipboardEvent(kind, { bubbles: true, cancelable: true }));
       return getClipboardCallbackCount(kind);
+    },
+    getCurrentTableProperties: () => {
+      const view = liveView();
+      if (!view) {
+        return null;
+      }
+      const { $from } = view.state.selection;
+      for (let depth = $from.depth; depth >= 0; depth--) {
+        const node = $from.node(depth);
+        if (node.type.name !== "table") {
+          continue;
+        }
+        const width = node.attrs["width"];
+        const widthType = node.attrs["widthType"];
+        const justification = node.attrs["justification"];
+        return {
+          width: typeof width === "number" ? width : null,
+          widthType: typeof widthType === "string" ? widthType : null,
+          justification: typeof justification === "string" ? justification : null,
+        };
+      }
+      return null;
     },
     insertTable: (rows, cols) => {
       const view = liveView();

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -95,6 +95,7 @@
             :get-commands="getCommands"
             :state-tick="stateTick"
             :theme="theme ?? null"
+            @open-table-properties="showTableProperties = true"
           />
         </template>
         <template v-if="$slots['toolbar-extra'] || toolbarExtra" #toolbar-extra>
@@ -111,15 +112,18 @@
       v-model:show-insert-symbol="showInsertSymbol"
       v-model:show-image-properties="showImageProperties"
       v-model:show-page-setup="showPageSetup"
+      v-model:show-table-properties="showTableProperties"
       :view="activeEditorView"
       :scroll-visible-position-into-view="scrollVisiblePositionIntoView"
       :bookmarks="bookmarks"
       :selected-image-pm-pos="selectedImage?.pmPos ?? null"
       :section-properties="currentSectionProps"
+      :table-properties="currentTableProperties"
       @insert-symbol="handleInsertSymbol"
       @hyperlink-submit="handleHyperlinkSubmit"
       @hyperlink-remove="handleHyperlinkRemove"
       @page-setup-apply="handlePageSetupApply"
+      @table-properties-apply="handleTablePropertiesApply"
     />
 
     <div v-if="parseError" class="docx-editor-vue__error">{{ parseError }}</div>
@@ -403,6 +407,7 @@ import {
   insertTableInView,
   insertTableOfContentsInView,
 } from "@stll/folio-core/prosemirror";
+import { getTableContext } from "@stll/folio-core/prosemirror/extensions/nodes/TableExtension";
 import { extractSelectionContext } from "@stll/folio-core/prosemirror/plugins/selectionTracker";
 import { inspectDocxCompatibility } from "@stll/folio-core/docx/compatibility";
 import {
@@ -594,6 +599,7 @@ const showKeyboardShortcuts = ref(false);
 const showInsertSymbol = ref(false);
 const showImageProperties = ref(false);
 const showPageSetup = ref(false);
+const showTableProperties = ref(false);
 const showOutline = ref(props.showOutline);
 const showSidebar = ref(false);
 const activeSidebarItem = ref<string | null>(null);
@@ -977,6 +983,32 @@ const currentSectionProps = computed<SectionProperties | null>(() => {
   return body.finalSectionProperties ?? body.sections?.[0]?.properties ?? null;
 });
 
+const currentTableProperties = computed(() => {
+  void stateTick.value;
+  const view = editorView.value;
+  if (!view) {
+    return {};
+  }
+  const table = getTableContext(view.state).table;
+  if (!table) {
+    return {};
+  }
+  const current: { width?: number; widthType?: string; justification?: string } = {};
+  const width = table.attrs["width"];
+  const widthType = table.attrs["widthType"];
+  const justification = table.attrs["justification"];
+  if (typeof width === "number") {
+    current.width = width;
+  }
+  if (typeof widthType === "string") {
+    current.widthType = widthType;
+  }
+  if (typeof justification === "string") {
+    current.justification = justification;
+  }
+  return current;
+});
+
 // Optional Toolbar props that must be OMITTED (not passed as `undefined`) under
 // exactOptionalPropertyTypes: bind via `v-bind` so an absent value drops the key.
 const toolbarDynamicProps = computed(() => {
@@ -1193,6 +1225,23 @@ function handleMenuAction(action: string): void {
 // it honors the host `onInsertTable` prop or falls back to the core helper.
 function handleMenuTableInsert(rows: number, cols: number): void {
   handleInsertTableAction(rows, cols);
+}
+
+type TablePropertiesUpdate = {
+  width?: number | null;
+  widthType?: string | null;
+  justification?: "left" | "center" | "right" | null;
+};
+
+function handleTablePropertiesApply(properties: TablePropertiesUpdate): void {
+  const view = editorView.value;
+  const factory = getCommands()["setTableProperties"];
+  if (!view || !factory) {
+    return;
+  }
+  const command = factory(properties);
+  command(view.state, (transaction) => view.dispatch(transaction), view);
+  view.focus();
 }
 
 // ---- Loading + lifecycle -------------------------------------------------

--- a/packages/vue/src/components/DocxEditor/DocxEditorDialogs.vue
+++ b/packages/vue/src/components/DocxEditor/DocxEditorDialogs.vue
@@ -1,14 +1,15 @@
 <!--
   Modal-dialog cluster for DocxEditor — collects the dialogs the editor surfaces
-  (find/replace, hyperlink, insert symbol, image properties, page setup) so the
-  host template does not carry the dialog markup just to wire show-flags and
-  close handlers. (Image insertion has no dialog — Insert > Image opens the OS
-  file picker directly.)
+  (find/replace, hyperlink, insert symbol, image properties, page setup, table
+  properties) so the host template does not carry the dialog markup just to
+  wire show-flags and close handlers. (Image insertion has no dialog — Insert >
+  Image opens the OS file picker directly.)
 
   Visibility is passed via `v-model:show-*` so the host owns the boolean refs and
   dialogs close themselves through the standard `update:` emit pattern. Action
-  emits (`insert-symbol`, `hyperlink-submit`, `page-setup-apply`) bubble up so the
-  host's feature composables keep ownership of the document mutations.
+  emits (`insert-symbol`, `hyperlink-submit`, `page-setup-apply`,
+  `table-properties-apply`) bubble up so the host's feature composables keep
+  ownership of the document mutations.
 
   Fork note: the Watermark and Keyboard-Shortcuts dialogs are PORT-BLOCKED (not
   ported to the fork's `dialogs/` set yet) and are omitted here.
@@ -49,6 +50,13 @@
     @close="emit('update:showPageSetup', false)"
     @apply="(props) => emit('page-setup-apply', props)"
   />
+
+  <TablePropertiesDialog
+    :is-open="showTableProperties"
+    :current-props="tableProperties"
+    @close="emit('update:showTableProperties', false)"
+    @apply="(props) => emit('table-properties-apply', props)"
+  />
 </template>
 
 <script setup lang="ts">
@@ -61,6 +69,7 @@ import HyperlinkDialog from "../dialogs/HyperlinkDialog.vue";
 import ImagePropertiesDialog from "../dialogs/ImagePropertiesDialog.vue";
 import InsertSymbolDialog from "../dialogs/InsertSymbolDialog.vue";
 import PageSetupDialog from "../dialogs/PageSetupDialog.vue";
+import TablePropertiesDialog from "../dialogs/TablePropertiesDialog.vue";
 
 type BookmarkOption = {
   name: string;
@@ -74,6 +83,18 @@ type HyperlinkSubmitPayload = {
   tooltip: string;
 };
 
+type TableProperties = {
+  width?: number | null;
+  widthType?: string | null;
+  justification?: "left" | "center" | "right" | null;
+};
+
+type CurrentTableProperties = {
+  width?: number;
+  widthType?: string;
+  justification?: string;
+};
+
 defineProps<{
   view: EditorView | null;
   bookmarks: BookmarkOption[];
@@ -85,6 +106,8 @@ defineProps<{
   showInsertSymbol: boolean;
   showImageProperties: boolean;
   showPageSetup: boolean;
+  showTableProperties: boolean;
+  tableProperties: CurrentTableProperties;
 }>();
 
 const emit = defineEmits<{
@@ -93,9 +116,11 @@ const emit = defineEmits<{
   (e: "update:showInsertSymbol", value: boolean): void;
   (e: "update:showImageProperties", value: boolean): void;
   (e: "update:showPageSetup", value: boolean): void;
+  (e: "update:showTableProperties", value: boolean): void;
   (e: "insert-symbol", symbol: string): void;
   (e: "hyperlink-submit", data: HyperlinkSubmitPayload): void;
   (e: "hyperlink-remove"): void;
   (e: "page-setup-apply", props: Partial<SectionProperties>): void;
+  (e: "table-properties-apply", props: TableProperties): void;
 }>();
 </script>

--- a/packages/vue/src/components/ui/TableToolbar.vue
+++ b/packages/vue/src/components/ui/TableToolbar.vue
@@ -84,6 +84,10 @@ const props = defineProps<{
   theme?: Theme | null;
 }>();
 
+const emit = defineEmits<{
+  (event: "open-table-properties"): void;
+}>();
+
 // Single source of truth for the table-context state the toolbar reads —
 // recomputed on every editor transaction. `isInTable` and the "more"
 // dropdown's gating/active state all derive from this one walk.
@@ -238,9 +242,10 @@ const moreActionMap: Partial<Record<TableAction, [string, ...unknown[]]>> = {
 };
 
 function onMoreAction(action: TableAction) {
-  // Dialog action is a v1.x followup — explicit no-op so the menu
-  // closes cleanly without dispatching a phantom command.
-  if (action === "tableProperties") return;
+  if (action === "tableProperties") {
+    emit("open-table-properties");
+    return;
+  }
   const mapped = moreActionMap[action];
   if (mapped) exec(...mapped);
   else exec(action);

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -24,6 +24,11 @@ type FolioParityBridge = {
   countSelectionRects: () => number;
   setupContentControls: () => boolean;
   dispatchClipboardEvent: (kind: "copy" | "cut" | "paste") => number;
+  getCurrentTableProperties: () => {
+    width: number | null;
+    widthType: string | null;
+    justification: string | null;
+  } | null;
   insertTable: (rows: number, cols: number) => boolean;
   countTables: () => number;
   commentFirstWord: () => boolean;

--- a/tests/parity/vue-table-properties.spec.ts
+++ b/tests/parity/vue-table-properties.spec.ts
@@ -1,0 +1,29 @@
+import { test } from "@playwright/test";
+
+import { ensureLiveView, expect, openEditor, type AdapterFixture } from "./parity-fixture";
+
+const VUE_ADAPTER = {
+  name: "vue",
+  baseUrl: "http://localhost:4201",
+} as const satisfies AdapterFixture;
+
+test("Vue applies table properties from the table options menu", async ({ page }) => {
+  await openEditor(page, VUE_ADAPTER);
+  await ensureLiveView(page);
+  expect(await page.evaluate(() => window.__folioParity?.insertTable(2, 2) ?? false)).toBe(true);
+
+  await page.getByTitle("Table options").click();
+  await page.getByRole("button", { name: "Table properties" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Table Properties" });
+  await expect(dialog).toBeVisible();
+  await dialog.locator("select").nth(0).selectOption("pct");
+  await dialog.locator('input[type="number"]').fill("2500");
+  await dialog.locator("select").nth(1).selectOption("center");
+  await dialog.getByRole("button", { name: "Apply" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect
+    .poll(() => page.evaluate(() => window.__folioParity?.getCurrentTableProperties() ?? null))
+    .toEqual({ width: 2500, widthType: "pct", justification: "center" });
+});


### PR DESCRIPTION
## Summary

- route the Vue table options action into the existing table properties dialog
- initialize the dialog from the selected table and apply changes through the shared table command
- restore editor focus after applying and add an interaction regression for width and alignment

## Validation

- adapter parity contract (65 props, 38 ref members, zero deferments)
- changeset check
- dependency audit
- full checks and the new browser interaction delegated to CI