### PR TITLE
feat: add table row document operation

### DIFF
--- a/.changeset/insert-table-rows.md
+++ b/.changeset/insert-table-rows.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add a stable document operation for direct table-row insertion.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -816,6 +816,59 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     };
                     readonly required: readonly ["id", "type", "blockId", "parties"];
                     readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Insert a row next to the row containing the anchor block. Direct mode only.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["insertTableRow"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly position: {
+                            readonly type: "string";
+                            readonly enum: readonly ["after", "before"];
+                            readonly description: "Insert after the anchor row (default) or before it. Defaults to \"after\".";
+                        };
+                        readonly cellTexts: {
+                            readonly type: "array";
+                            readonly description: "Initial text for physical cells in source order; omitted cells stay empty.";
+                            readonly items: {
+                                readonly type: "string";
+                            };
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId"];
+                    readonly additionalProperties: false;
                 }];
             };
         };
@@ -1552,6 +1605,59 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
             };
         };
         readonly required: readonly ["id", "type", "blockId", "parties"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Insert a row next to the row containing the anchor block. Direct mode only.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["insertTableRow"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly position: {
+                readonly type: "string";
+                readonly enum: readonly ["after", "before"];
+                readonly description: "Insert after the anchor row (default) or before it. Defaults to \"after\".";
+            };
+            readonly cellTexts: {
+                readonly type: "array";
+                readonly description: "Initial text for physical cells in source order; omitted cells stay empty.";
+                readonly items: {
+                    readonly type: "string";
+                };
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId"];
         readonly additionalProperties: false;
     }];
 };

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -71,6 +71,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -80,7 +81,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -208,6 +209,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     position?: "after" | "before";
     parties: FolioAISignatureParty[];
     comment?: FolioAIComment;
+} | {
+    id: string;
+    type: "insertTableRow"; /** Stable paragraph anchor inside the row that receives the new sibling. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -315,7 +322,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable";
+    content: "block" | "signatureTable" | "tableRow";
 } | {
     type: "comment";
     commentId: number;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -439,6 +439,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -448,7 +449,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -570,6 +571,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     position?: "after" | "before";
     parties: FolioAISignatureParty[];
     comment?: FolioAIComment;
+} | {
+    id: string;
+    type: "insertTableRow"; /** Stable paragraph anchor inside the row that receives the new sibling. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -639,7 +646,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable";
+    content: "block" | "signatureTable" | "tableRow";
 } | {
     type: "comment";
     commentId: number;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -439,6 +439,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -448,7 +449,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -570,6 +571,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     position?: "after" | "before";
     parties: FolioAISignatureParty[];
     comment?: FolioAIComment;
+} | {
+    id: string;
+    type: "insertTableRow"; /** Stable paragraph anchor inside the row that receives the new sibling. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -639,7 +646,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable";
+    content: "block" | "signatureTable" | "tableRow";
 } | {
     type: "comment";
     commentId: number;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -192,6 +192,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -201,7 +202,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
@@ -330,6 +331,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     position?: "after" | "before";
     parties: FolioAISignatureParty[];
     comment?: FolioAIComment;
+} | {
+    id: string;
+    type: "insertTableRow"; /** Stable paragraph anchor inside the row that receives the new sibling. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -463,7 +470,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable";
+    content: "block" | "signatureTable" | "tableRow";
 } | {
     type: "comment";
     commentId: number;

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -394,6 +394,13 @@ const CONTRACT_OPERATION_FIXTURES: Record<FolioDocumentOperationType, Record<str
     position: "before",
     parties: [{ name: "Acme s.r.o.", signatory: "Jane Doe", title: "CEO" }],
   },
+  insertTableRow: {
+    id: "op-insert-table-row",
+    type: "insertTableRow",
+    blockId: "0304003A",
+    position: "before",
+    cellTexts: ["First", "Second"],
+  },
 };
 
 const variantTypeOf = (variant: JsonSchemaNode): unknown => variant.properties?.["type"]?.enum?.[0];

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -120,7 +120,7 @@ const blockIdProperty = {
 
 /**
  * JSON Schema (draft-07 compatible) for ONE document operation: the full
- * ten-variant union accepted by `parseFolioDocumentOperationBatch` in
+ * eleven-variant union accepted by `parseFolioDocumentOperationBatch` in
  * `@stll/folio-core`, one `oneOf` variant per entry in
  * `FOLIO_DOCUMENT_OPERATION_TYPES`. Intended for LLM tool definitions and
  * other consumers that need the contract's wire shape without re-declaring
@@ -327,6 +327,27 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
       required: ["id", "type", "blockId", "parties"],
       additionalProperties: false,
     },
+    {
+      type: "object",
+      description: "Insert a row next to the row containing the anchor block. Direct mode only.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["insertTableRow"] },
+        blockId: blockIdProperty,
+        position: {
+          type: "string",
+          enum: ["after", "before"],
+          description: 'Insert after the anchor row (default) or before it. Defaults to "after".',
+        },
+        cellTexts: {
+          type: "array",
+          description: "Initial text for physical cells in source order; omitted cells stay empty.",
+          items: { type: "string" },
+        },
+      },
+      required: ["id", "type", "blockId"],
+      additionalProperties: false,
+    },
   ],
 } as const;
 
@@ -359,8 +380,8 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       enum: FOLIO_DOCUMENT_OPERATION_MODES,
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
-        '"direct" applies immediately. `formatRange` and `insertSignatureTable` support ' +
-        '"direct" only.',
+        '"direct" applies immediately. `formatRange`, `insertSignatureTable`, and ' +
+        '`insertTableRow` support "direct" only.',
     },
     atomic: {
       type: "boolean",

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -289,7 +289,12 @@ describe("parseSuggestChangesInput", () => {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(type)] });
       expect(result.ok, type).toBe(true);
     }
-    for (const excludedType of ["formatRange", "commentOnBlock", "insertSignatureTable"]) {
+    for (const excludedType of [
+      "formatRange",
+      "commentOnBlock",
+      "insertSignatureTable",
+      "insertTableRow",
+    ]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);
     }

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,7 +52,7 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `formatRange` and `insertSignatureTable` (direct-only,
+ * - excluded types: `formatRange`, `insertSignatureTable`, and `insertTableRow` (direct-only,
  *   not representable as tracked changes for human review) and
  *   `commentOnBlock` (covered by the dedicated `add_comment` tool);
  * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
@@ -68,6 +68,7 @@ const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperati
   "formatRange",
   "commentOnBlock",
   "insertSignatureTable",
+  "insertTableRow",
 ]);
 
 /**

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -28,12 +28,20 @@ const schema = new Schema({
     table: {
       content: "tableRow+",
       group: "block",
+      tableRole: "table",
     },
     tableRow: {
       content: "tableCell+",
+      tableRole: "row",
     },
     tableCell: {
-      content: "paragraph+",
+      content: "block+",
+      tableRole: "cell",
+      attrs: {
+        colspan: { default: 1 },
+        rowspan: { default: 1 },
+        colwidth: { default: null },
+      },
     },
   },
   marks: {
@@ -1743,5 +1751,130 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.child(2).type.name).toBe("table");
     expect(view.state.doc.child(2).textContent).toContain("Buyer");
     expect(view.state.doc.child(3).textContent).toBe("After.");
+  });
+
+  test("inserts ordered rows while preserving cells that span the insertion boundary", () => {
+    const spanningCell = schema.node("tableCell", { colspan: 2, rowspan: 2 }, [
+      schema.node("paragraph", { paraId: "cell-a" }, [schema.text("A")]),
+    ]);
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        spanningCell,
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "cell-b" }, [schema.text("B")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "cell-c" }, [schema.text("C")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "insert-first-row",
+          type: "insertTableRow",
+          blockId: "cell-c",
+          position: "before",
+          cellTexts: ["First"],
+        },
+        {
+          id: "insert-second-row",
+          type: "insertTableRow",
+          blockId: "cell-c",
+          position: "before",
+          cellTexts: ["Second"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(result.applied.map(({ id }) => id).toSorted()).toEqual([
+      "insert-first-row",
+      "insert-second-row",
+    ]);
+    const updatedTable = view.state.doc.child(0);
+    expect(updatedTable.childCount).toBe(4);
+    expect(updatedTable.child(0).child(0).attrs["rowspan"]).toBe(4);
+    expect(updatedTable.child(1).childCount).toBe(1);
+    expect(updatedTable.child(1).textContent).toBe("First");
+    expect(updatedTable.child(2).textContent).toBe("Second");
+    expect(updatedTable.child(3).textContent).toBe("C");
+  });
+
+  test("targets the nearest row when the anchor is inside a nested table", () => {
+    const innerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "inner-cell" }, [schema.text("Inner")]),
+        ]),
+      ]),
+    ]);
+    const outerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", null, [schema.text("Outer")]),
+          innerTable,
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [outerTable]) });
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "insert-inner-row",
+          type: "insertTableRow",
+          blockId: "inner-cell",
+          cellTexts: ["New inner"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const updatedOuterTable = view.state.doc.child(0);
+    expect(updatedOuterTable.childCount).toBe(1);
+    const updatedInnerTable = updatedOuterTable.child(0).child(0).child(1);
+    expect(updatedInnerTable.childCount).toBe(2);
+    expect(updatedInnerTable.child(1).textContent).toBe("New inner");
+  });
+
+  test("table-row inserts are skipped in tracked-changes mode", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-cell" }, [schema.text("Cell")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [{ id: "insert-row", type: "insertTableRow", blockId: "tracked-cell" }],
+      mode: "tracked-changes",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "insert-row", reason: "unsupportedMode" }],
+    });
+    expect(view.state.doc.child(0).childCount).toBe(1);
   });
 });

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -289,12 +289,12 @@ const findTableRowInsertion = (
 ): TableRowInsertion | null => {
   const resolved = doc.resolve(blockFrom);
   for (let rowDepth = resolved.depth; rowDepth > 0; rowDepth--) {
-    if (resolved.node(rowDepth).type.spec.tableRole !== "row") {
+    if (resolved.node(rowDepth).type.spec["tableRole"] !== "row") {
       continue;
     }
     const tableDepth = rowDepth - 1;
     const table = resolved.node(tableDepth);
-    if (table.type.spec.tableRole !== "table") {
+    if (table.type.spec["tableRole"] !== "table") {
       return null;
     }
     const map = TableMap.get(table);

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1,5 +1,6 @@
 import type { Mark, Node as PMNode, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
+import { rowIsHeader, TableMap, tableNodeTypes } from "prosemirror-tables";
 
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
@@ -56,6 +57,7 @@ type ResolvedOperation = {
   blockTo: number;
   blockNode: PMNode;
   insertText?: string;
+  tableRowInsertion?: TableRowInsertion;
   commentId?: number;
   /**
    * Position in the input `operations` array, used as a secondary
@@ -211,6 +213,116 @@ const findEnclosingTableBoundary = (doc: PMNode, blockFrom: number): TableBounda
     }
   }
   return null;
+};
+
+type TableRowInsertion = {
+  tableStart: number;
+  rowPosition: number;
+  rowType: PMNode["type"];
+  cells: readonly PMNode[];
+  rowspanUpdates: readonly number[];
+};
+
+const buildTableRowInsertion = (
+  map: TableMap,
+  table: PMNode,
+  tableStart: number,
+  rowIndex: number,
+): TableRowInsertion | null => {
+  const cells: PMNode[] = [];
+  const rowspanUpdates: number[] = [];
+  let referenceRow: number | null = rowIndex > 0 ? -1 : 0;
+  if (rowIsHeader(map, table, rowIndex + referenceRow)) {
+    referenceRow = rowIndex === 0 || rowIndex === map.height ? null : 0;
+  }
+  for (let col = 0, index = map.width * rowIndex; col < map.width; col++, index++) {
+    if (rowIndex > 0 && rowIndex < map.height && map.map[index] === map.map[index - map.width]) {
+      const cellPosition = map.map[index];
+      if (cellPosition === undefined) {
+        return null;
+      }
+      const cell = table.nodeAt(cellPosition);
+      const colspan: unknown = cell?.attrs["colspan"];
+      if (typeof colspan !== "number" || colspan < 1) {
+        return null;
+      }
+      if (!cell) {
+        return null;
+      }
+      rowspanUpdates.push(cellPosition);
+      col += colspan - 1;
+      index += colspan - 1;
+      continue;
+    }
+    const referencePosition =
+      referenceRow === null ? undefined : map.map[index + referenceRow * map.width];
+    const cellType =
+      referencePosition === undefined
+        ? tableNodeTypes(table.type.schema).cell
+        : table.nodeAt(referencePosition)?.type;
+    const cell = cellType?.createAndFill();
+    if (!cell) {
+      return null;
+    }
+    cells.push(cell);
+  }
+  if (cells.length === 0) {
+    return null;
+  }
+  let rowPosition = tableStart;
+  for (let index = 0; index < rowIndex; index++) {
+    rowPosition += table.child(index).nodeSize;
+  }
+  return {
+    tableStart,
+    rowPosition,
+    rowType: tableNodeTypes(table.type.schema).row,
+    cells,
+    rowspanUpdates,
+  };
+};
+
+const findTableRowInsertion = (
+  doc: PMNode,
+  blockFrom: number,
+  position: "after" | "before",
+): TableRowInsertion | null => {
+  const resolved = doc.resolve(blockFrom);
+  for (let rowDepth = resolved.depth; rowDepth > 0; rowDepth--) {
+    if (resolved.node(rowDepth).type.spec.tableRole !== "row") {
+      continue;
+    }
+    const tableDepth = rowDepth - 1;
+    const table = resolved.node(tableDepth);
+    if (table.type.spec.tableRole !== "table") {
+      return null;
+    }
+    const map = TableMap.get(table);
+    const anchorRowIndex = resolved.index(tableDepth);
+    const rowIndex = position === "before" ? anchorRowIndex : anchorRowIndex + 1;
+    const tableStart = resolved.start(tableDepth);
+    return buildTableRowInsertion(map, table, tableStart, rowIndex);
+  }
+  return null;
+};
+
+const populateTableRow = (row: PMNode, cellTexts: readonly string[] | undefined): PMNode => {
+  if (cellTexts === undefined) {
+    return row;
+  }
+  const cells: PMNode[] = [];
+  row.forEach((cell, _offset, index) => {
+    const paragraph = cell.firstChild;
+    if (!paragraph?.isTextblock) {
+      cells.push(cell);
+      return;
+    }
+    const text = cellTexts[index] ?? "";
+    const content = text.length > 0 ? row.type.schema.text(text) : null;
+    const nextParagraph = paragraph.type.create(stripIdentityAttrs(paragraph.attrs), content);
+    cells.push(cell.type.create(cell.attrs, nextParagraph));
+  });
+  return row.type.create(row.attrs, cells);
 };
 
 /**
@@ -391,7 +503,10 @@ const applyFolioAIEditOperationsInternal = ({
   const liveBlocksByParaId = collectLiveBlocksByParaId(view.state.doc);
 
   for (const [index, operation] of operations.entries()) {
-    if (mode === "tracked-changes" && operation.type === "formatRange") {
+    if (
+      mode === "tracked-changes" &&
+      (operation.type === "formatRange" || operation.type === "insertTableRow")
+    ) {
       skipped.push({ id: operation.id, reason: "unsupportedMode" });
       continue;
     }
@@ -655,6 +770,34 @@ const applyFolioAIEditOperationsInternal = ({
         // tracked-changes for new tables is a separate future
         // concern.
         tr = tr.insert(item.from, node);
+        break;
+      }
+      case "insertTableRow": {
+        const insertion = item.tableRowInsertion;
+        if (!insertion) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        for (const updatePosition of insertion.rowspanUpdates) {
+          const cellPosition = insertion.tableStart + updatePosition;
+          const liveCell = tr.doc.nodeAt(cellPosition);
+          if (!liveCell) {
+            continue;
+          }
+          const rowspan: unknown = liveCell.attrs["rowspan"];
+          if (typeof rowspan !== "number") {
+            continue;
+          }
+          tr = tr.setNodeMarkup(cellPosition, undefined, {
+            ...liveCell.attrs,
+            rowspan: rowspan + 1,
+          });
+        }
+        const row = insertion.rowType.create(null, insertion.cells);
+        tr = tr.insert(insertion.rowPosition, populateTableRow(row, item.operation.cellTexts));
         break;
       }
       case "deleteBlock": {
@@ -1106,6 +1249,26 @@ const resolveOperation = ({
         blockFrom,
         blockTo,
         blockNode,
+      },
+    };
+  }
+
+  if (operation.type === "insertTableRow") {
+    const position = operation.position ?? "after";
+    const insertion = findTableRowInsertion(doc, blockFrom, position);
+    if (!insertion || (operation.cellTexts?.length ?? 0) > insertion.cells.length) {
+      return { type: "skip", reason: "unsupportedBlock" };
+    }
+    return {
+      type: "resolved",
+      operation: {
+        operation,
+        from: insertion.rowPosition,
+        to: insertion.rowPosition,
+        blockFrom,
+        blockTo,
+        blockNode,
+        tableRowInsertion: insertion,
       },
     };
   }

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -781,19 +781,33 @@ const applyFolioAIEditOperationsInternal = ({
           });
           continue;
         }
+        const liveRowspanUpdates: { position: number; cell: PMNode; rowspan: number }[] = [];
+        let invalidRowspanUpdate = false;
         for (const updatePosition of insertion.rowspanUpdates) {
           const cellPosition = insertion.tableStart + updatePosition;
           const liveCell = tr.doc.nodeAt(cellPosition);
           if (!liveCell) {
-            continue;
+            invalidRowspanUpdate = true;
+            break;
           }
           const rowspan: unknown = liveCell.attrs["rowspan"];
           if (typeof rowspan !== "number") {
-            continue;
+            invalidRowspanUpdate = true;
+            break;
           }
-          tr = tr.setNodeMarkup(cellPosition, undefined, {
-            ...liveCell.attrs,
-            rowspan: rowspan + 1,
+          liveRowspanUpdates.push({ position: cellPosition, cell: liveCell, rowspan });
+        }
+        if (invalidRowspanUpdate) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        for (const update of liveRowspanUpdates) {
+          tr = tr.setNodeMarkup(update.position, undefined, {
+            ...update.cell.attrs,
+            rowspan: update.rowspan + 1,
           });
         }
         const row = insertion.rowType.create(null, insertion.cells);

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -242,11 +242,11 @@ const buildTableRowInsertion = (
         return null;
       }
       const cell = table.nodeAt(cellPosition);
-      const colspan: unknown = cell?.attrs["colspan"];
-      if (typeof colspan !== "number" || colspan < 1) {
+      if (!cell) {
         return null;
       }
-      if (!cell) {
+      const colspan: unknown = cell.attrs["colspan"];
+      if (typeof colspan !== "number" || colspan < 1) {
         return null;
       }
       rowspanUpdates.push(cellPosition);

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -191,6 +191,93 @@ describe("headless docx review round-trip", () => {
     ).toContain("Updated value");
   });
 
+  test("inserts, persists, and undoes a row inside shape text", async () => {
+    const baseline = await buildTextBoxTableDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const rejected = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      atomic: true,
+      operations: [
+        {
+          id: "insert-row",
+          type: "insertTableRow",
+          blockId: target.id,
+          cellTexts: ["Added value"],
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+
+    expect(rejected.status).toBe("rejected");
+    expect(rejected.applied).toEqual([]);
+    expect(reviewer.getContentAsText()).not.toContain("Added value");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "insert-row",
+          type: "insertTableRow",
+          blockId: target.id,
+          cellTexts: ["Added value"],
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.applied).toEqual([{ id: "insert-row" }]);
+    expect(result.receipts).toEqual([
+      {
+        operationId: "insert-row",
+        operationIndex: 0,
+        affected: [
+          {
+            type: "insertion",
+            story: "main",
+            anchorBlockId: target.id,
+            position: "after",
+            content: "tableRow",
+          },
+        ],
+      },
+    ]);
+
+    const saved = await reviewer.toBuffer();
+    const reparsed = await parseDocx(saved, { detectVariables: false, preloadFonts: false });
+    const table = findTextBoxShape(reparsed).textBody?.content.at(1);
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      throw new Error("expected a nested table");
+    }
+    expect(table.rows).toHaveLength(2);
+    expect(table.rows.at(0)?.cells.at(0)?.content.at(0)?.type).toBe("paragraph");
+    expect(table.rows.at(1)?.cells.at(0)?.content.at(0)?.type).toBe("paragraph");
+    expect((await FolioDocxReviewer.fromBuffer(saved)).getContentAsText()).toContain("Added value");
+
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.getContentAsText()).not.toContain("Added value");
+    const restored = await parseDocx(await reviewer.toBuffer(), {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    const restoredTable = findTextBoxShape(restored).textBody?.content.at(1);
+    expect(restoredTable?.type).toBe("table");
+    if (restoredTable?.type !== "table") {
+      throw new Error("expected a nested table");
+    }
+    expect(restoredTable.rows).toHaveLength(1);
+  });
+
   test("edits a header through story-scoped document operations", async () => {
     const baseline = await makeHeaderFooterBaseline();
     const story = { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const;

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -222,6 +222,15 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         parties: FolioAISignatureParty[];
         comment?: FolioAIComment;
       }
+    | {
+        id: string;
+        type: "insertTableRow";
+        /** Stable paragraph anchor inside the row that receives the new sibling. */
+        blockId: string;
+        position?: "after" | "before";
+        /** Initial text for each physical cell in source order; omitted cells stay empty. */
+        cellTexts?: string[];
+      }
   );
 
 export type FolioAIEditApplyMode = "direct" | "tracked-changes";

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -31,6 +31,7 @@ describe("document operation contract", () => {
         "deleteBlock",
         "commentOnBlock",
         "insertSignatureTable",
+        "insertTableRow",
       ],
       modes: ["direct", "tracked-changes"],
       batchModes: ["best-effort", "atomic"],
@@ -46,6 +47,7 @@ describe("document operation contract", () => {
         deleteBlock: ["direct", "tracked-changes"],
         commentOnBlock: ["direct", "tracked-changes"],
         insertSignatureTable: ["direct"],
+        insertTableRow: ["direct"],
       },
       preconditions: ["blockTextHash"],
       stories: ["main", "header", "footer", "footnote", "endnote"],
@@ -103,6 +105,13 @@ describe("document operation contract", () => {
         blockId: "paragraph-5",
         parties: [{ name: "Party" }],
       },
+      {
+        id: "row",
+        type: "insertTableRow",
+        blockId: "paragraph-6",
+        position: "before",
+        cellTexts: ["A", "B"],
+      },
     ] as const satisfies readonly FolioDocumentOperation[];
 
     expect(
@@ -113,6 +122,7 @@ describe("document operation contract", () => {
         { id: "insert" },
         { id: "comment", commentId: 18 },
         { id: "delete" },
+        { id: "row" },
       ]),
     ).toEqual([
       {
@@ -179,6 +189,19 @@ describe("document operation contract", () => {
           },
         ],
       },
+      {
+        operationId: "row",
+        operationIndex: 6,
+        affected: [
+          {
+            type: "insertion",
+            story: "main",
+            anchorBlockId: "paragraph-6",
+            position: "before",
+            content: "tableRow",
+          },
+        ],
+      },
     ]);
   });
 
@@ -235,6 +258,13 @@ describe("document operation contract", () => {
           parties: [{ name: "Party", signatory: "Signer", title: "Director" }],
           severity: "high",
           area: "Execution",
+        },
+        {
+          id: "8",
+          type: "insertTableRow",
+          blockId: "a",
+          position: "after",
+          cellTexts: ["First", "Second"],
         },
       ],
     };
@@ -335,6 +365,21 @@ describe("document operation contract", () => {
         ],
       },
       "$.operations[0].parties[0].name",
+      "expected a string",
+    ],
+    [
+      {
+        version: 1,
+        operations: [
+          {
+            id: "1",
+            type: "insertTableRow",
+            blockId: "a",
+            cellTexts: ["valid", 42],
+          },
+        ],
+      },
+      "$.operations[0].cellTexts[1]",
       "expected a string",
     ],
   ] as const;

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -31,6 +31,7 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES = Object.freeze([
   "deleteBlock",
   "commentOnBlock",
   "insertSignatureTable",
+  "insertTableRow",
 ] as const satisfies readonly FolioAIEditOperation["type"][]);
 
 export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
@@ -72,6 +73,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   deleteBlock: DIRECT_AND_TRACKED_MODES,
   commentOnBlock: DIRECT_AND_TRACKED_MODES,
   insertSignatureTable: DIRECT_ONLY_MODES,
+  insertTableRow: DIRECT_ONLY_MODES,
 } as const satisfies Readonly<
   Record<FolioDocumentOperationType, readonly FolioDocumentOperationMode[]>
 >);
@@ -215,6 +217,26 @@ const readOptionalBoolean = (
     return candidate;
   }
   return invalidBatch(`${path}.${key}`, "expected a boolean when provided");
+};
+
+const readOptionalStringArray = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] | undefined => {
+  const candidate = value[key];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(candidate)) {
+    return invalidBatch(`${path}.${key}`, "expected an array when provided");
+  }
+  return candidate.map((item, index) => {
+    if (typeof item === "string") {
+      return item;
+    }
+    return invalidBatch(`${path}.${key}[${index}]`, "expected a string");
+  });
 };
 
 const readNonNegativeInteger = (
@@ -558,6 +580,23 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     };
   }
 
+  if (type === "insertTableRow") {
+    assertAllowedKeys(value, path, [...COMMON_OPERATION_KEYS, "position", "cellTexts"]);
+    const position = value["position"];
+    if (position !== undefined && position !== "after" && position !== "before") {
+      return invalidBatch(`${path}.position`, 'expected "after" or "before" when provided');
+    }
+    const cellTexts = readOptionalStringArray(value, "cellTexts", path);
+    return {
+      ...operationMeta,
+      id,
+      type,
+      blockId,
+      ...(position !== undefined && { position }),
+      ...(cellTexts !== undefined && { cellTexts }),
+    };
+  }
+
   return invalidBatch(`${path}.type`, `unsupported operation type "${type}"`);
 };
 
@@ -639,7 +678,7 @@ export type FolioDocumentOperationAffectedTarget =
       story: FolioDocumentOperationStory;
       anchorBlockId: string;
       position: "before" | "after";
-      content: "block" | "signatureTable";
+      content: "block" | "signatureTable" | "tableRow";
     }
   | {
       type: "comment";
@@ -786,6 +825,14 @@ const getPrimaryAffectedTarget = (
         anchorBlockId: operation.blockId,
         position: operation.position ?? "after",
         content: "signatureTable",
+      };
+    case "insertTableRow":
+      return {
+        type: "insertion",
+        story,
+        anchorBlockId: operation.blockId,
+        position: operation.position ?? "after",
+        content: "tableRow",
       };
   }
 };


### PR DESCRIPTION
## Summary

- add direct row insertion through the versioned operation contract
- preserve merged-cell topology and nearest nested-table targeting
- cover parsing, receipts, atomicity, undo, and save/reopen behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inserting table rows directly before or after an existing row.
  * New rows can include initial cell text and preserve table formatting, including merged cells.
  * Added operation receipts, validation, serialization, and undo support for table-row insertions.

* **Limitations**
  * Table-row insertion is available only in direct mode and is excluded from suggested changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->