### PR TITLE
fix: preserve implicit default style spacing

### DIFF
--- a/.changeset/quiet-spaces-rest.md
+++ b/.changeset/quiet-spaces-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve implicit default paragraph style spacing on empty paragraphs.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -192,7 +192,8 @@ export type ParagraphAttrs = {
     lineSpacing?: number;
     lineSpacingRule?: import__stll_docx_core_model.LineSpacingRule;
     spacingExplicit?: SpacingExplicit; /** Layout provenance: document defaults survive on empty paragraphs. */
-    spacingFromDocDefaults?: SpacingExplicit;
+    spacingFromDocDefaults?: SpacingExplicit; /** Layout provenance: implicit default-style spacing survives on empty paragraphs. */
+    spacingFromImplicitDefaultStyle?: SpacingExplicit;
     indentLeft?: number;
     indentRight?: number;
     indentFirstLine?: number;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -294,7 +294,8 @@ export type ParagraphAttrs = {
     lineSpacing?: number;
     lineSpacingRule?: import__stll_docx_core_model.LineSpacingRule;
     spacingExplicit?: SpacingExplicit; /** Layout provenance: document defaults survive on empty paragraphs. */
-    spacingFromDocDefaults?: SpacingExplicit;
+    spacingFromDocDefaults?: SpacingExplicit; /** Layout provenance: implicit default-style spacing survives on empty paragraphs. */
+    spacingFromImplicitDefaultStyle?: SpacingExplicit;
     indentLeft?: number;
     indentRight?: number;
     indentFirstLine?: number;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -664,6 +664,26 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.spacingExplicit?.after).toBe(true);
   });
 
+  test("keeps implicit default-style spacing on an empty paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 120,
+          spaceAfter: 160,
+          spacingFromImplicitDefaultStyle: { before: true, after: true },
+        },
+        [],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.before).toBe(120 / 15);
+    expect(paragraph?.attrs?.spacing?.after).toBe(160 / 15);
+    expect(paragraph?.attrs?.spacingExplicit).toEqual({ before: true, after: true });
+  });
+
   test("suppresses empty hidden list paragraphs and their markers", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1471,12 +1471,10 @@ function convertParagraphAttrs(
         ...(autoAfter ? { after: true } : {}),
       };
     }
-    // Propagate the `spacingExplicit` flag the PM schema carries — empty
-    // paragraphs inherit zero spacing unless the side was set inline (Word
-    // fidelity, eigenpal #402). Auto spacing counts as explicit: an imported
-    // empty paragraph whose only spacing is `w:beforeAutospacing`/
-    // `afterAutospacing` must keep the 14pt gap rather than collapse to zero
-    // (eigenpal/docx-editor#823).
+    // Preserve spacing sides whose source Word renders on an empty paragraph:
+    // direct formatting, document defaults, the implicit default paragraph
+    // style, and automatic spacing. Layout consumes the combined provenance;
+    // the authored PM attributes remain source-specific for serialization.
     const pmSpacingExplicit = pmAttrs.spacingExplicit as
       | { before?: boolean; after?: boolean }
       | null
@@ -1485,11 +1483,25 @@ function convertParagraphAttrs(
       | { before?: boolean; after?: boolean }
       | null
       | undefined;
+    const spacingFromImplicitDefaultStyle = pmAttrs.spacingFromImplicitDefaultStyle as
+      | { before?: boolean; after?: boolean }
+      | null
+      | undefined;
     const explicit: { before?: boolean; after?: boolean } = {};
-    if (autoBefore || pmSpacingExplicit?.before || spacingFromDocDefaults?.before) {
+    if (
+      autoBefore ||
+      pmSpacingExplicit?.before ||
+      spacingFromDocDefaults?.before ||
+      spacingFromImplicitDefaultStyle?.before
+    ) {
       explicit.before = true;
     }
-    if (autoAfter || pmSpacingExplicit?.after || spacingFromDocDefaults?.after) {
+    if (
+      autoAfter ||
+      pmSpacingExplicit?.after ||
+      spacingFromDocDefaults?.after ||
+      spacingFromImplicitDefaultStyle?.after
+    ) {
       explicit.after = true;
     }
     if (explicit.before !== undefined || explicit.after !== undefined) {

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -39,6 +39,7 @@ describe("ProseMirror attr readers", () => {
       numPr: { numId: 4, ilvl: 1 },
       bookmarks: [{ id: 7, name: "_Ref7" }],
       _autospacingBase: { before: 200, after: null },
+      spacingFromImplicitDefaultStyle: { after: true },
       _sectionProperties: { sectionStart: "nextPage" },
       _propertyChanges: [],
     });
@@ -53,6 +54,7 @@ describe("ProseMirror attr readers", () => {
     expect(result.value.bookmarks?.at(0)?.name).toBe("_Ref7");
     expect(result.value._autospacingBase?.before).toBe(200);
     expect(result.value._autospacingBase?.after).toBeNull();
+    expect(result.value.spacingFromImplicitDefaultStyle?.after).toBe(true);
     expect(expectParagraphAttrs(node).paraId).toBe("para-1");
   });
 

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -333,6 +333,12 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   optionalTabStops(attrs, "tabs", "paragraph.attrs.tabs", issues);
   optionalRecord(attrs, "spacingExplicit", "paragraph.attrs.spacingExplicit", issues);
   optionalRecord(attrs, "spacingFromDocDefaults", "paragraph.attrs.spacingFromDocDefaults", issues);
+  optionalRecord(
+    attrs,
+    "spacingFromImplicitDefaultStyle",
+    "paragraph.attrs.spacingFromImplicitDefaultStyle",
+    issues,
+  );
   optionalTextFormatting(
     attrs,
     "defaultTextFormatting",

--- a/packages/core/src/prosemirror/commands/propertyChangeScope.ts
+++ b/packages/core/src/prosemirror/commands/propertyChangeScope.ts
@@ -56,7 +56,7 @@ type AttrPatch = Record<string, unknown>;
  *   `runInWithNext` (`w:specVanish` lives in that rPr)
  * - load-time style/numbering bookkeeping the command layer cannot recompute
  *   without a style resolver: `numPrFromStyle`, the `list*` rendering attrs,
- *   `spacingFromDocDefaults`
+ *   `spacingFromDocDefaults`, `spacingFromImplicitDefaultStyle`
  */
 export const PPR_CHANGE_SCOPED_ATTR_KEYS = [
   "styleId",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -136,6 +136,36 @@ describe("toProseDoc", () => {
     expect(doc.firstChild?.attrs.spacingExplicit).toBeNull();
   });
 
+  test("tracks implicit default-style spacing so empty paragraphs retain it during layout", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [{ type: "paragraph", content: [] }],
+        },
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              pPr: { spaceBefore: 120, spaceAfter: 160 },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+
+    expect(doc.firstChild?.attrs.spaceBefore).toBe(120);
+    expect(doc.firstChild?.attrs.spaceAfter).toBe(160);
+    expect(doc.firstChild?.attrs.spacingFromImplicitDefaultStyle).toEqual({
+      before: true,
+      after: true,
+    });
+    expect(doc.firstChild?.attrs.spacingExplicit).toBeNull();
+  });
+
   test("direct first-line indent clears a hanging indent inherited from the paragraph style", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -596,6 +596,26 @@ function paragraphFormattingToAttrs(
       ? (styleResolver.getStyle(styleId) ?? styleResolver.getDefaultParagraphStyle())
       : styleResolver.getDefaultParagraphStyle();
     const docDefaultSpacing = styleResolver.getDocDefaults()?.pPr;
+    const spacingFromImplicitDefaultStyle: NonNullable<
+      ParagraphAttrs["spacingFromImplicitDefaultStyle"]
+    > = {};
+    if (
+      !styleId &&
+      formatting?.spaceBefore === undefined &&
+      paragraphStyle?.pPr?.spaceBefore !== undefined
+    ) {
+      spacingFromImplicitDefaultStyle.before = true;
+    }
+    if (
+      !styleId &&
+      formatting?.spaceAfter === undefined &&
+      paragraphStyle?.pPr?.spaceAfter !== undefined
+    ) {
+      spacingFromImplicitDefaultStyle.after = true;
+    }
+    if (spacingFromImplicitDefaultStyle.before || spacingFromImplicitDefaultStyle.after) {
+      attrs.spacingFromImplicitDefaultStyle = spacingFromImplicitDefaultStyle;
+    }
     const spacingFromDocDefaults: NonNullable<ParagraphAttrs["spacingFromDocDefaults"]> = {};
     if (
       formatting?.spaceBefore === undefined &&

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -329,6 +329,7 @@ const paragraphNodeSpec: NodeSpec = {
     lineSpacingRule: { default: null },
     spacingExplicit: { default: null },
     spacingFromDocDefaults: { default: null },
+    spacingFromImplicitDefaultStyle: { default: null },
     indentLeft: { default: null },
     indentRight: { default: null },
     indentFirstLine: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -72,6 +72,8 @@ export type ParagraphAttrs = {
   spacingExplicit?: SpacingExplicit;
   /** Layout provenance: document defaults survive on empty paragraphs. */
   spacingFromDocDefaults?: SpacingExplicit;
+  /** Layout provenance: implicit default-style spacing survives on empty paragraphs. */
+  spacingFromImplicitDefaultStyle?: SpacingExplicit;
 
   // Indentation (in twips)
   indentLeft?: number;


### PR DESCRIPTION
## Summary

- track spacing inherited from the implicit default paragraph style
- retain that spacing on empty paragraphs without materializing direct formatting
- cover the conversion and layout boundaries with focused regressions