### PR TITLE
feat: add table row deletion operation

### DIFF
--- a/.changeset/delete-table-rows.md
+++ b/.changeset/delete-table-rows.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add a stable document operation for direct table-row deletion.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -869,6 +869,47 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     };
                     readonly required: readonly ["id", "type", "blockId"];
                     readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Delete the row containing the anchor block. Direct mode only.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["deleteTableRow"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId"];
+                    readonly additionalProperties: false;
                 }];
             };
         };
@@ -1629,6 +1670,47 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                 readonly items: {
                     readonly type: "string";
                 };
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Delete the row containing the anchor block. Direct mode only.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["deleteTableRow"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
             };
             readonly id: {
                 readonly type: "string";

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -72,6 +72,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
+    readonly deleteTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -81,7 +82,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -215,6 +216,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -326,6 +331,11 @@ export type FolioDocumentOperationAffectedTarget = {
 } | {
     type: "comment";
     commentId: number;
+} | {
+    type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
 };
 
 // @public (undocumented)

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -440,6 +440,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
+    readonly deleteTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -449,7 +450,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -577,6 +578,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -650,6 +655,11 @@ export type FolioDocumentOperationAffectedTarget = {
 } | {
     type: "comment";
     commentId: number;
+} | {
+    type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
 };
 
 // @public (undocumented)

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -440,6 +440,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
+    readonly deleteTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -449,7 +450,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -577,6 +578,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -650,6 +655,11 @@ export type FolioDocumentOperationAffectedTarget = {
 } | {
     type: "comment";
     commentId: number;
+} | {
+    type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
 };
 
 // @public (undocumented)

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -193,6 +193,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
+    readonly deleteTableRow: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -202,7 +203,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
@@ -337,6 +338,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for each physical cell in source order; omitted cells stay empty. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -474,6 +479,11 @@ export type FolioDocumentOperationAffectedTarget = {
 } | {
     type: "comment";
     commentId: number;
+} | {
+    type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
 };
 
 // @public (undocumented)

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -401,6 +401,11 @@ const CONTRACT_OPERATION_FIXTURES: Record<FolioDocumentOperationType, Record<str
     position: "before",
     cellTexts: ["First", "Second"],
   },
+  deleteTableRow: {
+    id: "op-delete-table-row",
+    type: "deleteTableRow",
+    blockId: "0304003A",
+  },
 };
 
 const variantTypeOf = (variant: JsonSchemaNode): unknown => variant.properties?.["type"]?.enum?.[0];

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -120,7 +120,7 @@ const blockIdProperty = {
 
 /**
  * JSON Schema (draft-07 compatible) for ONE document operation: the full
- * eleven-variant union accepted by `parseFolioDocumentOperationBatch` in
+ * twelve-variant union accepted by `parseFolioDocumentOperationBatch` in
  * `@stll/folio-core`, one `oneOf` variant per entry in
  * `FOLIO_DOCUMENT_OPERATION_TYPES`. Intended for LLM tool definitions and
  * other consumers that need the contract's wire shape without re-declaring
@@ -348,6 +348,17 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
       required: ["id", "type", "blockId"],
       additionalProperties: false,
     },
+    {
+      type: "object",
+      description: "Delete the row containing the anchor block. Direct mode only.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["deleteTableRow"] },
+        blockId: blockIdProperty,
+      },
+      required: ["id", "type", "blockId"],
+      additionalProperties: false,
+    },
   ],
 } as const;
 
@@ -380,8 +391,8 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       enum: FOLIO_DOCUMENT_OPERATION_MODES,
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
-        '"direct" applies immediately. `formatRange`, `insertSignatureTable`, and ' +
-        '`insertTableRow` support "direct" only.',
+        '"direct" applies immediately. `formatRange`, `insertSignatureTable`, `insertTableRow`, ' +
+        'and `deleteTableRow` support "direct" only.',
     },
     atomic: {
       type: "boolean",

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -294,6 +294,7 @@ describe("parseSuggestChangesInput", () => {
       "commentOnBlock",
       "insertSignatureTable",
       "insertTableRow",
+      "deleteTableRow",
     ]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,8 +52,8 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `formatRange`, `insertSignatureTable`, and `insertTableRow` (direct-only,
- *   not representable as tracked changes for human review) and
+ * - excluded types: `formatRange`, `insertSignatureTable`, `insertTableRow`, and
+ *   `deleteTableRow` (direct-only, not representable as tracked changes for human review) and
  *   `commentOnBlock` (covered by the dedicated `add_comment` tool);
  * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
  *   where the contract requires it;
@@ -69,6 +69,7 @@ const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperati
   "commentOnBlock",
   "insertSignatureTable",
   "insertTableRow",
+  "deleteTableRow",
 ]);
 
 /**

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1852,6 +1852,210 @@ describe("Folio AI edit operations", () => {
     expect(updatedInnerTable.child(1).textContent).toBe("New inner");
   });
 
+  test("deletes rows while preserving cells that span the deletion boundary", () => {
+    const makeMergedTableState = () => {
+      const spanningCell = schema.node("tableCell", { colspan: 2, rowspan: 2 }, [
+        schema.node("paragraph", { paraId: "delete-a" }, [schema.text("A")]),
+      ]);
+      const table = schema.node("table", null, [
+        schema.node("tableRow", null, [
+          spanningCell,
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: "delete-b" }, [schema.text("B")]),
+          ]),
+        ]),
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: "delete-c" }, [schema.text("C")]),
+          ]),
+        ]),
+      ]);
+      return EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    };
+
+    const originState = makeMergedTableState();
+    const originView = makeView(originState);
+    const originResult = applyFolioAIEditOperations({
+      view: originView,
+      snapshot: createFolioAIEditSnapshot(originState.doc),
+      operations: [{ id: "delete-origin", type: "deleteTableRow", blockId: "delete-a" }],
+      mode: "direct",
+    });
+
+    expect(originResult.skipped).toEqual([]);
+    const originTable = originView.state.doc.child(0);
+    expect(originTable.childCount).toBe(1);
+    expect(originTable.child(0).childCount).toBe(2);
+    expect(originTable.child(0).child(0).attrs["colspan"]).toBe(2);
+    expect(originTable.child(0).child(0).attrs["rowspan"]).toBe(1);
+    expect(originTable.textContent).toBe("AC");
+
+    const continuationState = makeMergedTableState();
+    const continuationView = makeView(continuationState);
+    const continuationResult = applyFolioAIEditOperations({
+      view: continuationView,
+      snapshot: createFolioAIEditSnapshot(continuationState.doc),
+      operations: [{ id: "delete-continuation", type: "deleteTableRow", blockId: "delete-c" }],
+      mode: "direct",
+    });
+
+    expect(continuationResult.skipped).toEqual([]);
+    const continuationTable = continuationView.state.doc.child(0);
+    expect(continuationTable.childCount).toBe(1);
+    expect(continuationTable.child(0).childCount).toBe(2);
+    expect(continuationTable.child(0).child(0).attrs["rowspan"]).toBe(1);
+    expect(continuationTable.textContent).toBe("AB");
+  });
+
+  test("deletes only the nearest table when the anchor is nested", () => {
+    const innerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "delete-inner" }, [schema.text("Inner")]),
+        ]),
+      ]),
+    ]);
+    const outerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", null, [schema.text("Before")]),
+          innerTable,
+          schema.node("paragraph", null, [schema.text("After")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [outerTable]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "delete-inner-row", type: "deleteTableRow", blockId: "delete-inner" }],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(1);
+    const updatedOuterCell = view.state.doc.child(0).child(0).child(0);
+    expect(updatedOuterCell.childCount).toBe(2);
+    expect(updatedOuterCell.textContent).toBe("BeforeAfter");
+  });
+
+  test("keeps a valid parent when deleting the only row from the only table", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "delete-only" }, [schema.text("Only")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "delete-only-row", type: "deleteTableRow", blockId: "delete-only" }],
+      mode: "direct",
+    });
+
+    expect(result.applied).toEqual([{ id: "delete-only-row" }]);
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).type.name).toBe("paragraph");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  test("does not delete an extra row when a batch anchors the same row twice", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "same-row-a" }, [schema.text("A")]),
+        ]),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "same-row-b" }, [schema.text("B")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "other-row" }, [schema.text("C")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "delete-row-a", type: "deleteTableRow", blockId: "same-row-a" },
+        { id: "delete-row-b", type: "deleteTableRow", blockId: "same-row-b" },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.applied).toEqual([{ id: "delete-row-a" }]);
+    expect(result.skipped).toEqual([{ id: "delete-row-b", reason: "noopOperation" }]);
+    expect(view.state.doc.child(0).childCount).toBe(1);
+    expect(view.state.doc.textContent).toBe("C");
+  });
+
+  test("recomputes table topology between row deletions in one batch", () => {
+    const rows = ["A", "B", "C"].map((text) =>
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: `batch-${text}` }, [schema.text(text)]),
+        ]),
+      ]),
+    );
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+    });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "delete-middle", type: "deleteTableRow", blockId: "batch-B" },
+        { id: "delete-last", type: "deleteTableRow", blockId: "batch-C" },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(result.applied.map(({ id }) => id).toSorted()).toEqual(["delete-last", "delete-middle"]);
+    expect(view.state.doc.child(0).childCount).toBe(1);
+    expect(view.state.doc.textContent).toBe("A");
+  });
+
+  test("table-row deletes are skipped in tracked-changes mode", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-delete" }, [schema.text("Cell")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "delete-row", type: "deleteTableRow", blockId: "tracked-delete" }],
+      mode: "tracked-changes",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "delete-row", reason: "unsupportedMode" }],
+    });
+    expect(view.state.doc.child(0).childCount).toBe(1);
+  });
+
   test("table-row inserts are skipped in tracked-changes mode", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1,6 +1,6 @@
 import type { Mark, Node as PMNode, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { rowIsHeader, TableMap, tableNodeTypes } from "prosemirror-tables";
+import { removeRow, rowIsHeader, TableMap, tableNodeTypes } from "prosemirror-tables";
 
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
@@ -58,6 +58,7 @@ type ResolvedOperation = {
   blockNode: PMNode;
   insertText?: string;
   tableRowInsertion?: TableRowInsertion;
+  tableRowDeletion?: TableRowDeletion;
   commentId?: number;
   /**
    * Position in the input `operations` array, used as a secondary
@@ -223,6 +224,60 @@ type TableRowInsertion = {
   rowspanUpdates: readonly number[];
 };
 
+type TableRowTarget = {
+  table: PMNode;
+  tableStart: number;
+  tablePosition: number;
+  rowIndex: number;
+  rowPosition: number;
+};
+
+type TableRowDeletion = Omit<TableRowTarget, "table">;
+
+const findEnclosingTableRow = (doc: PMNode, blockFrom: number): TableRowTarget | null => {
+  const resolved = doc.resolve(blockFrom);
+  for (let rowDepth = resolved.depth; rowDepth > 0; rowDepth--) {
+    if (resolved.node(rowDepth).type.spec["tableRole"] !== "row") {
+      continue;
+    }
+    const tableDepth = rowDepth - 1;
+    const table = resolved.node(tableDepth);
+    if (table.type.spec["tableRole"] !== "table") {
+      return null;
+    }
+    return {
+      table,
+      tableStart: resolved.start(tableDepth),
+      tablePosition: resolved.before(tableDepth),
+      rowIndex: resolved.index(tableDepth),
+      rowPosition: resolved.before(rowDepth),
+    };
+  }
+  return null;
+};
+
+const deleteSoleTableRow = (
+  tr: Transaction,
+  tablePosition: number,
+  table: PMNode,
+): Transaction | null => {
+  const tableEnd = tablePosition + table.nodeSize;
+  const resolved = tr.doc.resolve(tablePosition);
+  const parent = resolved.parent;
+  const tableIndex = resolved.index();
+  if (parent.canReplace(tableIndex, tableIndex + 1)) {
+    return tr.delete(tablePosition, tableEnd);
+  }
+  const emptyParagraph = tr.doc.type.schema.nodes["paragraph"]?.createAndFill();
+  if (
+    !emptyParagraph ||
+    !parent.canReplaceWith(tableIndex, tableIndex + 1, emptyParagraph.type, emptyParagraph.marks)
+  ) {
+    return null;
+  }
+  return tr.replaceWith(tablePosition, tableEnd, emptyParagraph);
+};
+
 const buildTableRowInsertion = (
   map: TableMap,
   table: PMNode,
@@ -287,23 +342,13 @@ const findTableRowInsertion = (
   blockFrom: number,
   position: "after" | "before",
 ): TableRowInsertion | null => {
-  const resolved = doc.resolve(blockFrom);
-  for (let rowDepth = resolved.depth; rowDepth > 0; rowDepth--) {
-    if (resolved.node(rowDepth).type.spec["tableRole"] !== "row") {
-      continue;
-    }
-    const tableDepth = rowDepth - 1;
-    const table = resolved.node(tableDepth);
-    if (table.type.spec["tableRole"] !== "table") {
-      return null;
-    }
-    const map = TableMap.get(table);
-    const anchorRowIndex = resolved.index(tableDepth);
-    const rowIndex = position === "before" ? anchorRowIndex : anchorRowIndex + 1;
-    const tableStart = resolved.start(tableDepth);
-    return buildTableRowInsertion(map, table, tableStart, rowIndex);
+  const target = findEnclosingTableRow(doc, blockFrom);
+  if (!target) {
+    return null;
   }
-  return null;
+  const map = TableMap.get(target.table);
+  const rowIndex = position === "before" ? target.rowIndex : target.rowIndex + 1;
+  return buildTableRowInsertion(map, target.table, target.tableStart, rowIndex);
 };
 
 const populateTableRow = (row: PMNode, cellTexts: readonly string[] | undefined): PMNode => {
@@ -484,6 +529,7 @@ const applyFolioAIEditOperationsInternal = ({
   const insertionType = view.state.schema.marks["insertion"];
   const deletionType = view.state.schema.marks["deletion"];
   const commentType = view.state.schema.marks["comment"];
+  const claimedTableRows = new Set<string>();
 
   if (mode === "tracked-changes" && (!insertionType || !deletionType)) {
     return {
@@ -505,7 +551,9 @@ const applyFolioAIEditOperationsInternal = ({
   for (const [index, operation] of operations.entries()) {
     if (
       mode === "tracked-changes" &&
-      (operation.type === "formatRange" || operation.type === "insertTableRow")
+      (operation.type === "formatRange" ||
+        operation.type === "insertTableRow" ||
+        operation.type === "deleteTableRow")
     ) {
       skipped.push({ id: operation.id, reason: "unsupportedMode" });
       continue;
@@ -526,6 +574,16 @@ const applyFolioAIEditOperationsInternal = ({
     if (resolution.type === "skip") {
       skipped.push({ id: operation.id, reason: resolution.reason });
       continue;
+    }
+
+    const deletion = resolution.operation.tableRowDeletion;
+    if (deletion) {
+      const rowKey = `${deletion.tablePosition}:${deletion.rowIndex}`;
+      if (claimedTableRows.has(rowKey)) {
+        skipped.push({ id: operation.id, reason: "noopOperation" });
+        continue;
+      }
+      claimedTableRows.add(rowKey);
     }
 
     const commentId = commentText !== undefined ? createCommentId?.(commentText) : undefined;
@@ -812,6 +870,49 @@ const applyFolioAIEditOperationsInternal = ({
         }
         const row = insertion.rowType.create(null, insertion.cells);
         tr = tr.insert(insertion.rowPosition, populateTableRow(row, item.operation.cellTexts));
+        break;
+      }
+      case "deleteTableRow": {
+        const deletion = item.tableRowDeletion;
+        const table = deletion ? tr.doc.nodeAt(deletion.tablePosition) : null;
+        if (
+          !deletion ||
+          !table ||
+          table.type.spec["tableRole"] !== "table" ||
+          deletion.rowIndex >= table.childCount
+        ) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        if (table.childCount === 1) {
+          const nextTr = deleteSoleTableRow(tr, deletion.tablePosition, table);
+          if (!nextTr) {
+            skipped.push({
+              id: item.operation.id,
+              reason: "unsupportedBlock",
+            });
+            continue;
+          }
+          tr = nextTr;
+          break;
+        }
+        const map = TableMap.get(table);
+        removeRow(
+          tr,
+          {
+            map,
+            table,
+            tableStart: deletion.tableStart,
+            left: 0,
+            top: deletion.rowIndex,
+            right: map.width,
+            bottom: deletion.rowIndex + 1,
+          },
+          deletion.rowIndex,
+        );
         break;
       }
       case "deleteBlock": {
@@ -1283,6 +1384,30 @@ const resolveOperation = ({
         blockTo,
         blockNode,
         tableRowInsertion: insertion,
+      },
+    };
+  }
+
+  if (operation.type === "deleteTableRow") {
+    const target = findEnclosingTableRow(doc, blockFrom);
+    if (!target) {
+      return { type: "skip", reason: "unsupportedBlock" };
+    }
+    return {
+      type: "resolved",
+      operation: {
+        operation,
+        from: target.rowPosition,
+        to: target.rowPosition,
+        blockFrom,
+        blockTo,
+        blockNode,
+        tableRowDeletion: {
+          tableStart: target.tableStart,
+          tablePosition: target.tablePosition,
+          rowIndex: target.rowIndex,
+          rowPosition: target.rowPosition,
+        },
       },
     };
   }

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -278,6 +278,88 @@ describe("headless docx review round-trip", () => {
     expect(restoredTable.rows).toHaveLength(1);
   });
 
+  test("deletes, persists, and undoes a row inside shape text", async () => {
+    const baseline = await buildTextBoxTableDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const rejected = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      atomic: true,
+      operations: [
+        {
+          id: "delete-row",
+          type: "deleteTableRow",
+          blockId: target.id,
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+
+    expect(rejected.status).toBe("rejected");
+    expect(rejected.applied).toEqual([]);
+    expect(reviewer.getContentAsText()).toContain("Cell value");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "delete-row",
+          type: "deleteTableRow",
+          blockId: target.id,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.applied).toEqual([{ id: "delete-row" }]);
+    expect(result.receipts).toEqual([
+      {
+        operationId: "delete-row",
+        operationIndex: 0,
+        affected: [
+          {
+            type: "tableRow",
+            story: "main",
+            anchorBlockId: target.id,
+            effect: "deleted",
+          },
+        ],
+      },
+    ]);
+
+    const saved = await reviewer.toBuffer();
+    const reparsed = await parseDocx(saved, { detectVariables: false, preloadFonts: false });
+    expect(findTextBoxShape(reparsed).textBody?.content.map(({ type }) => type)).toEqual([
+      "paragraph",
+      "paragraph",
+    ]);
+    expect((await FolioDocxReviewer.fromBuffer(saved)).getContentAsText()).not.toContain(
+      "Cell value",
+    );
+
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.getContentAsText()).toContain("Cell value");
+    const restored = await parseDocx(await reviewer.toBuffer(), {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    const restoredTable = findTextBoxShape(restored).textBody?.content.at(1);
+    expect(restoredTable?.type).toBe("table");
+    if (restoredTable?.type !== "table") {
+      throw new Error("expected a nested table");
+    }
+    expect(restoredTable.rows).toHaveLength(1);
+  });
+
   test("edits a header through story-scoped document operations", async () => {
     const baseline = await makeHeaderFooterBaseline();
     const story = { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const;

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -231,6 +231,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         /** Initial text for each physical cell in source order; omitted cells stay empty. */
         cellTexts?: string[];
       }
+    | {
+        id: string;
+        type: "deleteTableRow";
+        /** Stable paragraph anchor inside the row to delete. */
+        blockId: string;
+      }
   );
 
 export type FolioAIEditApplyMode = "direct" | "tracked-changes";

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -32,6 +32,7 @@ describe("document operation contract", () => {
         "commentOnBlock",
         "insertSignatureTable",
         "insertTableRow",
+        "deleteTableRow",
       ],
       modes: ["direct", "tracked-changes"],
       batchModes: ["best-effort", "atomic"],
@@ -48,6 +49,7 @@ describe("document operation contract", () => {
         commentOnBlock: ["direct", "tracked-changes"],
         insertSignatureTable: ["direct"],
         insertTableRow: ["direct"],
+        deleteTableRow: ["direct"],
       },
       preconditions: ["blockTextHash"],
       stories: ["main", "header", "footer", "footnote", "endnote"],
@@ -60,6 +62,7 @@ describe("document operation contract", () => {
     expect(isFolioDocumentOperationModeSupported("insertSignatureTable", "tracked-changes")).toBe(
       false,
     );
+    expect(isFolioDocumentOperationModeSupported("deleteTableRow", "tracked-changes")).toBe(false);
     expect(
       Reflect.apply(isFolioDocumentOperationModeSupported, null, ["unknownOperation", "direct"]),
     ).toBe(false);
@@ -112,6 +115,7 @@ describe("document operation contract", () => {
         position: "before",
         cellTexts: ["A", "B"],
       },
+      { id: "delete-row", type: "deleteTableRow", blockId: "paragraph-7" },
     ] as const satisfies readonly FolioDocumentOperation[];
 
     expect(
@@ -123,6 +127,7 @@ describe("document operation contract", () => {
         { id: "comment", commentId: 18 },
         { id: "delete" },
         { id: "row" },
+        { id: "delete-row" },
       ]),
     ).toEqual([
       {
@@ -202,6 +207,18 @@ describe("document operation contract", () => {
           },
         ],
       },
+      {
+        operationId: "delete-row",
+        operationIndex: 7,
+        affected: [
+          {
+            type: "tableRow",
+            story: "main",
+            anchorBlockId: "paragraph-7",
+            effect: "deleted",
+          },
+        ],
+      },
     ]);
   });
 
@@ -266,6 +283,7 @@ describe("document operation contract", () => {
           position: "after",
           cellTexts: ["First", "Second"],
         },
+        { id: "9", type: "deleteTableRow", blockId: "a" },
       ],
     };
 

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -32,6 +32,7 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES = Object.freeze([
   "commentOnBlock",
   "insertSignatureTable",
   "insertTableRow",
+  "deleteTableRow",
 ] as const satisfies readonly FolioAIEditOperation["type"][]);
 
 export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
@@ -74,6 +75,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   commentOnBlock: DIRECT_AND_TRACKED_MODES,
   insertSignatureTable: DIRECT_ONLY_MODES,
   insertTableRow: DIRECT_ONLY_MODES,
+  deleteTableRow: DIRECT_ONLY_MODES,
 } as const satisfies Readonly<
   Record<FolioDocumentOperationType, readonly FolioDocumentOperationMode[]>
 >);
@@ -597,6 +599,11 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     };
   }
 
+  if (type === "deleteTableRow") {
+    assertAllowedKeys(value, path, COMMON_OPERATION_KEYS);
+    return { ...operationMeta, id, type, blockId };
+  }
+
   return invalidBatch(`${path}.type`, `unsupported operation type "${type}"`);
 };
 
@@ -683,6 +690,12 @@ export type FolioDocumentOperationAffectedTarget =
   | {
       type: "comment";
       commentId: number;
+    }
+  | {
+      type: "tableRow";
+      story: FolioDocumentOperationStory;
+      anchorBlockId: string;
+      effect: "deleted";
     };
 
 /** Input-ordered effect receipt for one successfully applied operation. */
@@ -833,6 +846,13 @@ const getPrimaryAffectedTarget = (
         anchorBlockId: operation.blockId,
         position: operation.position ?? "after",
         content: "tableRow",
+      };
+    case "deleteTableRow":
+      return {
+        type: "tableRow",
+        story,
+        anchorBlockId: operation.blockId,
+        effect: "deleted",
       };
   }
 };


### PR DESCRIPTION
## Summary

- add direct row deletion through the versioned operation contract
- preserve merged-cell topology and nearest nested-table targeting
- cover atomicity, receipts, undo, and persistence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deleting table rows through document operations in direct mode.
  * Deletion results now identify the affected table row in operation receipts.
  * Added handling for nested tables, spanning cells, repeated deletions, and single-row tables.
  * Table-row deletion can be undone and persists correctly through DOCX save and reload.

* **Bug Fixes**
  * Prevented unsupported tracked-changes operations from being applied.
  * Improved validation and atomic handling for invalid deletion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->