### PR TITLE
fix: preserve empty comment authors

### DIFF
--- a/.changeset/tidy-comments-rest.md
+++ b/.changeset/tidy-comments-rest.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve explicitly empty DOCX comment authors during parsing and serialization.

--- a/packages/core/src/docx/commentParser.test.ts
+++ b/packages/core/src/docx/commentParser.test.ts
@@ -105,7 +105,7 @@ describe("commentParser", () => {
       expect(comments[0].date).toBeUndefined();
     });
 
-    test("normalizes missing and empty comment authors", () => {
+    test("preserves explicit empty authors and normalizes unusable authors", () => {
       const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:comment w:id="1" w:author=""><w:p/></w:comment>
@@ -115,7 +115,7 @@ describe("commentParser", () => {
 
       const comments = parseComments(commentsXml, emptyStyles, emptyTheme, emptyRels, emptyMedia);
 
-      expect(comments.map(({ author }) => author)).toEqual(["Unknown", "Unknown", "Unknown"]);
+      expect(comments.map(({ author }) => author)).toEqual(["", "Unknown", "Unknown"]);
     });
   });
 

--- a/packages/core/src/docx/commentParser.ts
+++ b/packages/core/src/docx/commentParser.ts
@@ -167,7 +167,7 @@ export function parseComments(
 
     const id = Number.parseInt(getAttribute(child, "w", "id") ?? "0", 10);
     const rawAuthor = getAttribute(child, "w", "author");
-    const author = rawAuthor?.trim() || "Unknown";
+    const author = parseCommentAuthor(rawAuthor);
     const rawInitials = getAttribute(child, "w", "initials");
     const initials = rawInitials !== null ? String(rawInitials) : undefined;
     const rawDate = getAttribute(child, "w", "date");
@@ -264,3 +264,11 @@ export function parseComments(
 
   return comments;
 }
+
+const parseCommentAuthor = (author: string | null): string => {
+  if (author === "") {
+    return "";
+  }
+
+  return author?.trim() || "Unknown";
+};

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -52,4 +52,10 @@ describe("serializeComments", () => {
     expect(replyIndex).toBeGreaterThan(-1);
     expect(topIndex).toBeLessThan(replyIndex);
   });
+
+  test("preserves an explicitly empty author attribute", () => {
+    const xml = serializeComments([{ ...makeComment(1), author: "" }]);
+
+    expect(xml).toContain('<w:comment w:id="1" w:author=""');
+  });
 });

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -78,10 +78,10 @@ function serializeParagraphWithAnnotationRef(p: Paragraph): string {
 }
 
 function serializeComment(comment: Comment): string {
-  const attrs: string[] = [`w:id="${comment.id}"`];
-  if (comment.author) {
-    attrs.push(`w:author="${escapeXml(comment.author)}"`);
-  }
+  const attrs: string[] = [
+    `w:id="${comment.id}"`,
+    `w:author="${escapeXml(comment.author)}"`,
+  ];
   if (comment.initials) {
     attrs.push(`w:initials="${escapeXml(comment.initials)}"`);
   }

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -78,10 +78,7 @@ function serializeParagraphWithAnnotationRef(p: Paragraph): string {
 }
 
 function serializeComment(comment: Comment): string {
-  const attrs: string[] = [
-    `w:id="${comment.id}"`,
-    `w:author="${escapeXml(comment.author)}"`,
-  ];
+  const attrs: string[] = [`w:id="${comment.id}"`, `w:author="${escapeXml(comment.author)}"`];
   if (comment.initials) {
     attrs.push(`w:initials="${escapeXml(comment.initials)}"`);
   }

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -86,6 +86,17 @@ describe("canonical DOCX document model validation", () => {
     expect(() => assertValidDocumentModel(doc)).not.toThrow();
   });
 
+  test("accepts an explicitly empty comment author", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        comments: [{ id: 1, author: "", content: [paragraph()] }],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
   test("rejects comment anchors without a matching comment", () => {
     const result = validateDocumentModel(
       createDocument({

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -97,6 +97,21 @@ describe("canonical DOCX document model validation", () => {
     expect(result.issues).toEqual([]);
   });
 
+  test("rejects a whitespace-only comment author", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        comments: [{ id: 1, author: "   ", content: [paragraph()] }],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual({
+      path: "package.document.comments[0].author",
+      message: "Comment author cannot be whitespace-only.",
+      severity: "error",
+    });
+  });
+
   test("rejects comment anchors without a matching comment", () => {
     const result = validateDocumentModel(
       createDocument({

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -605,7 +605,7 @@ const validateComments = (comments: readonly Comment[], ctx: ValidationContext):
     seen.add(comment.id);
 
     if (comment.author !== "" && comment.author.trim() === "") {
-      addError(ctx, `${path}.author`, "Comment author is empty.");
+      addError(ctx, `${path}.author`, "Comment author cannot be whitespace-only.");
     }
 
     if (comment.parentId !== undefined && !ctx.commentIds.has(comment.parentId)) {

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -604,7 +604,7 @@ const validateComments = (comments: readonly Comment[], ctx: ValidationContext):
     }
     seen.add(comment.id);
 
-    if (comment.author.trim() === "") {
+    if (comment.author !== "" && comment.author.trim() === "") {
       addError(ctx, `${path}.author`, "Comment author is empty.");
     }
 


### PR DESCRIPTION
Preserve explicitly empty `w:author` values through comment parsing and serialization.

Missing and whitespace-only source authors still normalize to `Unknown`; exact empty values remain distinct and valid in the canonical document model. Focused parser, serializer, and validator regressions cover the boundary.