### PR TITLE
feat: add table column insertion operation

### DIFF
--- a/.changeset/insert-table-columns.md
+++ b/.changeset/insert-table-columns.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add a stable document operation for direct table-column insertion.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -910,6 +910,59 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     };
                     readonly required: readonly ["id", "type", "blockId"];
                     readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Insert a column next to the column containing the anchor block. Direct mode only.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["insertTableColumn"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly position: {
+                            readonly type: "string";
+                            readonly enum: readonly ["after", "before"];
+                            readonly description: "Insert after the anchor column (default) or before it. Defaults to \"after\".";
+                        };
+                        readonly cellTexts: {
+                            readonly type: "array";
+                            readonly description: "Initial text for newly created physical cells in row order.";
+                            readonly items: {
+                                readonly type: "string";
+                            };
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId"];
+                    readonly additionalProperties: false;
                 }];
             };
         };
@@ -1711,6 +1764,59 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
             readonly blockId: {
                 readonly type: "string";
                 readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Insert a column next to the column containing the anchor block. Direct mode only.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["insertTableColumn"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
+            };
+            readonly position: {
+                readonly type: "string";
+                readonly enum: readonly ["after", "before"];
+                readonly description: "Insert after the anchor column (default) or before it. Defaults to \"after\".";
+            };
+            readonly cellTexts: {
+                readonly type: "array";
+                readonly description: "Initial text for newly created physical cells in row order.";
+                readonly items: {
+                    readonly type: "string";
+                };
             };
             readonly id: {
                 readonly type: "string";

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -73,6 +73,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
+    readonly insertTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -82,7 +83,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -220,6 +221,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
     blockId: string;
+} | {
+    id: string;
+    type: "insertTableColumn"; /** Stable paragraph anchor inside the cell that receives the new sibling column. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -327,7 +334,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable" | "tableRow";
+    content: "block" | "signatureTable" | "tableRow" | "tableColumn";
 } | {
     type: "comment";
     commentId: number;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -441,6 +441,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
+    readonly insertTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -450,7 +451,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -582,6 +583,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
     blockId: string;
+} | {
+    id: string;
+    type: "insertTableColumn"; /** Stable paragraph anchor inside the cell that receives the new sibling column. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -651,7 +658,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable" | "tableRow";
+    content: "block" | "signatureTable" | "tableRow" | "tableColumn";
 } | {
     type: "comment";
     commentId: number;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -441,6 +441,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
+    readonly insertTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -450,7 +451,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -582,6 +583,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
     blockId: string;
+} | {
+    id: string;
+    type: "insertTableColumn"; /** Stable paragraph anchor inside the cell that receives the new sibling column. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -651,7 +658,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable" | "tableRow";
+    content: "block" | "signatureTable" | "tableRow" | "tableColumn";
 } | {
     type: "comment";
     commentId: number;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -194,6 +194,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertSignatureTable: readonly ["direct"];
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
+    readonly insertTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -203,7 +204,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
@@ -342,6 +343,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableRow"; /** Stable paragraph anchor inside the row to delete. */
     blockId: string;
+} | {
+    id: string;
+    type: "insertTableColumn"; /** Stable paragraph anchor inside the cell that receives the new sibling column. */
+    blockId: string;
+    position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
+    cellTexts?: string[];
 });
 
 // @public (undocumented)
@@ -475,7 +482,7 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     position: "before" | "after";
-    content: "block" | "signatureTable" | "tableRow";
+    content: "block" | "signatureTable" | "tableRow" | "tableColumn";
 } | {
     type: "comment";
     commentId: number;

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -406,6 +406,13 @@ const CONTRACT_OPERATION_FIXTURES: Record<FolioDocumentOperationType, Record<str
     type: "deleteTableRow",
     blockId: "0304003A",
   },
+  insertTableColumn: {
+    id: "op-insert-table-column",
+    type: "insertTableColumn",
+    blockId: "0304003A",
+    position: "before",
+    cellTexts: ["First", "Second"],
+  },
 };
 
 const variantTypeOf = (variant: JsonSchemaNode): unknown => variant.properties?.["type"]?.enum?.[0];

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -120,7 +120,7 @@ const blockIdProperty = {
 
 /**
  * JSON Schema (draft-07 compatible) for ONE document operation: the full
- * twelve-variant union accepted by `parseFolioDocumentOperationBatch` in
+ * thirteen-variant union accepted by `parseFolioDocumentOperationBatch` in
  * `@stll/folio-core`, one `oneOf` variant per entry in
  * `FOLIO_DOCUMENT_OPERATION_TYPES`. Intended for LLM tool definitions and
  * other consumers that need the contract's wire shape without re-declaring
@@ -359,6 +359,29 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
       required: ["id", "type", "blockId"],
       additionalProperties: false,
     },
+    {
+      type: "object",
+      description:
+        "Insert a column next to the column containing the anchor block. Direct mode only.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["insertTableColumn"] },
+        blockId: blockIdProperty,
+        position: {
+          type: "string",
+          enum: ["after", "before"],
+          description:
+            'Insert after the anchor column (default) or before it. Defaults to "after".',
+        },
+        cellTexts: {
+          type: "array",
+          description: "Initial text for newly created physical cells in row order.",
+          items: { type: "string" },
+        },
+      },
+      required: ["id", "type", "blockId"],
+      additionalProperties: false,
+    },
   ],
 } as const;
 
@@ -392,7 +415,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
         '"direct" applies immediately. `formatRange`, `insertSignatureTable`, `insertTableRow`, ' +
-        'and `deleteTableRow` support "direct" only.',
+        '`deleteTableRow`, and `insertTableColumn` support "direct" only.',
     },
     atomic: {
       type: "boolean",

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -295,6 +295,7 @@ describe("parseSuggestChangesInput", () => {
       "insertSignatureTable",
       "insertTableRow",
       "deleteTableRow",
+      "insertTableColumn",
     ]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,9 +52,9 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `formatRange`, `insertSignatureTable`, `insertTableRow`, and
- *   `deleteTableRow` (direct-only, not representable as tracked changes for human review) and
- *   `commentOnBlock` (covered by the dedicated `add_comment` tool);
+ * - excluded types: `formatRange`, `insertSignatureTable`, `insertTableRow`, `deleteTableRow`,
+ *   and `insertTableColumn` (direct-only, not representable as tracked changes for human review)
+ *   and `commentOnBlock` (covered by the dedicated `add_comment` tool);
  * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
  *   where the contract requires it;
  * - `comment` is a plain string here; `parse.ts` wraps it into the contract's
@@ -70,6 +70,7 @@ const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperati
   "insertSignatureTable",
   "insertTableRow",
   "deleteTableRow",
+  "insertTableColumn",
 ]);
 
 /**

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -2152,6 +2152,34 @@ describe("Folio AI edit operations", () => {
     expect(updatedInnerTable.textContent).toBe("InnerNew inner");
   });
 
+  test("skips column insertion when a cell has no table ancestors", () => {
+    const shallowCell = schema.nodes.tableCell.create(null, [
+      schema.node("paragraph", { paraId: "shallow-column" }, [schema.text("Cell")]),
+    ]);
+    const malformedDoc = schema.nodes.doc.create(null, [shallowCell]);
+    const state = EditorState.create({ schema, doc: malformedDoc });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: "shallow-column",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "insert-column", reason: "unsupportedBlock" }],
+    });
+    expect(view.state.doc).toEqual(malformedDoc);
+  });
+
   test("orders same-boundary and distinct column inserts against the original table", () => {
     const makeTableState = () => {
       const rows = [

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
+import { TableMap } from "prosemirror-tables";
 
 import { applyFolioAIEditOperations } from "./apply";
 import { createFolioAIEditSnapshot, createFolioAITextRangeHandle } from "./snapshot";
@@ -2029,6 +2030,285 @@ describe("Folio AI edit operations", () => {
     expect(result.applied.map(({ id }) => id).toSorted()).toEqual(["delete-last", "delete-middle"]);
     expect(view.state.doc.child(0).childCount).toBe(1);
     expect(view.state.doc.textContent).toBe("A");
+  });
+
+  test("inserts a column while preserving cells that span its boundary", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", { colspan: 2 }, [
+          schema.node("paragraph", { paraId: "column-span" }, [schema.text("A")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "column-left" }, [schema.text("B")]),
+        ]),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "column-right" }, [schema.text("C")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: "column-left",
+          cellTexts: ["New"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.applied).toEqual([{ id: "insert-column" }]);
+    expect(result.skipped).toEqual([]);
+    const updatedTable = view.state.doc.child(0);
+    expect(TableMap.get(updatedTable).width).toBe(3);
+    expect(updatedTable.child(0).childCount).toBe(1);
+    expect(updatedTable.child(0).child(0).attrs["colspan"]).toBe(3);
+    expect(updatedTable.child(1).childCount).toBe(3);
+    expect(updatedTable.child(1).textContent).toBe("BNewC");
+  });
+
+  test("rejects excess column cell text without mutating the table", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", { colspan: 2 }, [
+          schema.node("paragraph", { paraId: "column-span-top" }, [schema.text("A")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "column-anchor" }, [schema.text("B")]),
+        ]),
+        schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text("C")])]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: "column-anchor",
+          cellTexts: ["One", "Two"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.applied).toEqual([]);
+    expect(result.skipped).toEqual([{ id: "insert-column", reason: "unsupportedBlock" }]);
+    expect(view.state.doc).toEqual(state.doc);
+  });
+
+  test("targets the nearest column when the anchor is inside a nested table", () => {
+    const innerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "inner-column" }, [schema.text("Inner")]),
+        ]),
+      ]),
+    ]);
+    const outerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", null, [schema.text("Outer")]),
+          innerTable,
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [outerTable]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "insert-inner-column",
+          type: "insertTableColumn",
+          blockId: "inner-column",
+          cellTexts: ["New inner"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const updatedOuterTable = view.state.doc.child(0);
+    expect(updatedOuterTable.child(0).childCount).toBe(1);
+    const updatedInnerTable = updatedOuterTable.child(0).child(0).child(1);
+    expect(updatedInnerTable.child(0).childCount).toBe(2);
+    expect(updatedInnerTable.textContent).toBe("InnerNew inner");
+  });
+
+  test("orders same-boundary and distinct column inserts against the original table", () => {
+    const makeTableState = () => {
+      const rows = [
+        ["A", "B"],
+        ["C", "D"],
+      ].map((texts) =>
+        schema.node(
+          "tableRow",
+          null,
+          texts.map((text) =>
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: `column-${text}` }, [schema.text(text)]),
+            ]),
+          ),
+        ),
+      );
+      return EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+      });
+    };
+
+    const sameBoundaryState = makeTableState();
+    const sameBoundaryView = makeView(sameBoundaryState);
+    const sameBoundaryResult = applyFolioAIEditOperations({
+      view: sameBoundaryView,
+      snapshot: createFolioAIEditSnapshot(sameBoundaryState.doc),
+      operations: [
+        {
+          id: "first-column",
+          type: "insertTableColumn",
+          blockId: "column-A",
+          cellTexts: ["First top", "First bottom"],
+        },
+        {
+          id: "second-column",
+          type: "insertTableColumn",
+          blockId: "column-C",
+          cellTexts: ["Second top", "Second bottom"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(sameBoundaryResult.skipped).toEqual([]);
+    expect(sameBoundaryView.state.doc.child(0).child(0).textContent).toBe("AFirst topSecond topB");
+    expect(sameBoundaryView.state.doc.child(0).child(1).textContent).toBe(
+      "CFirst bottomSecond bottomD",
+    );
+
+    const distinctState = makeTableState();
+    const distinctView = makeView(distinctState);
+    const distinctResult = applyFolioAIEditOperations({
+      view: distinctView,
+      snapshot: createFolioAIEditSnapshot(distinctState.doc),
+      operations: [
+        {
+          id: "left-column",
+          type: "insertTableColumn",
+          blockId: "column-C",
+          cellTexts: ["Left top", "Left bottom"],
+        },
+        {
+          id: "right-column",
+          type: "insertTableColumn",
+          blockId: "column-B",
+          cellTexts: ["Right top", "Right bottom"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(distinctResult.skipped).toEqual([]);
+    expect(distinctView.state.doc.child(0).child(0).textContent).toBe("ALeft topBRight top");
+    expect(distinctView.state.doc.child(0).child(1).textContent).toBe("CLeft bottomDRight bottom");
+  });
+
+  test("maps column insertion through earlier operations in a mixed batch", () => {
+    const rows = [
+      ["A", "B"],
+      ["C", "D"],
+    ].map((texts) =>
+      schema.node(
+        "tableRow",
+        null,
+        texts.map((text) =>
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: `mixed-${text}` }, [schema.text(text)]),
+          ]),
+        ),
+      ),
+    );
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+    });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: "mixed-C",
+          cellTexts: ["New top", "New bottom"],
+        },
+        {
+          id: "insert-row",
+          type: "insertTableRow",
+          blockId: "mixed-C",
+          cellTexts: ["E", "F"],
+        },
+        {
+          id: "insert-before-table",
+          type: "insertBeforeBlock",
+          blockId: "mixed-A",
+          text: "Before table",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.child(0).textContent).toBe("Before table");
+    const updatedTable = view.state.doc.child(1);
+    expect(updatedTable.childCount).toBe(3);
+    expect(updatedTable.child(0).textContent).toBe("ANew topB");
+    expect(updatedTable.child(1).textContent).toBe("CNew bottomD");
+    expect(updatedTable.child(2).childCount).toBe(3);
+    expect(updatedTable.child(2).textContent).toBe("EF");
+  });
+
+  test("table-column inserts are skipped in tracked-changes mode", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-column" }, [schema.text("Cell")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "insert-column", type: "insertTableColumn", blockId: "tracked-column" }],
+      mode: "tracked-changes",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "insert-column", reason: "unsupportedMode" }],
+    });
+    expect(view.state.doc.child(0).child(0).childCount).toBe(1);
   });
 
   test("table-row deletes are skipped in tracked-changes mode", () => {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -282,6 +282,9 @@ const findTableColumnInsertion = (
     }
     const rowDepth = cellDepth - 1;
     const tableDepth = rowDepth - 1;
+    if (tableDepth < 0) {
+      return null;
+    }
     if (
       resolved.node(rowDepth).type.spec["tableRole"] !== "row" ||
       resolved.node(tableDepth).type.spec["tableRole"] !== "table"

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1,6 +1,13 @@
 import type { Mark, Node as PMNode, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { removeRow, rowIsHeader, TableMap, tableNodeTypes } from "prosemirror-tables";
+import {
+  addColSpan,
+  columnIsHeader,
+  removeRow,
+  rowIsHeader,
+  TableMap,
+  tableNodeTypes,
+} from "prosemirror-tables";
 
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
@@ -59,6 +66,7 @@ type ResolvedOperation = {
   insertText?: string;
   tableRowInsertion?: TableRowInsertion;
   tableRowDeletion?: TableRowDeletion;
+  tableColumnInsertion?: TableColumnInsertion;
   commentId?: number;
   /**
    * Position in the input `operations` array, used as a secondary
@@ -234,6 +242,11 @@ type TableRowTarget = {
 
 type TableRowDeletion = Omit<TableRowTarget, "table">;
 
+type TableColumnInsertion = {
+  tablePosition: number;
+  columnIndex: number;
+};
+
 const findEnclosingTableRow = (doc: PMNode, blockFrom: number): TableRowTarget | null => {
   const resolved = doc.resolve(blockFrom);
   for (let rowDepth = resolved.depth; rowDepth > 0; rowDepth--) {
@@ -251,6 +264,39 @@ const findEnclosingTableRow = (doc: PMNode, blockFrom: number): TableRowTarget |
       tablePosition: resolved.before(tableDepth),
       rowIndex: resolved.index(tableDepth),
       rowPosition: resolved.before(rowDepth),
+    };
+  }
+  return null;
+};
+
+const findTableColumnInsertion = (
+  doc: PMNode,
+  blockFrom: number,
+  position: "after" | "before",
+): (TableColumnInsertion & { boundaryPosition: number }) | null => {
+  const resolved = doc.resolve(blockFrom);
+  for (let cellDepth = resolved.depth; cellDepth > 0; cellDepth--) {
+    const cell = resolved.node(cellDepth);
+    const tableRole = cell.type.spec["tableRole"];
+    if (tableRole !== "cell" && tableRole !== "header_cell") {
+      continue;
+    }
+    const rowDepth = cellDepth - 1;
+    const tableDepth = rowDepth - 1;
+    if (
+      resolved.node(rowDepth).type.spec["tableRole"] !== "row" ||
+      resolved.node(tableDepth).type.spec["tableRole"] !== "table"
+    ) {
+      return null;
+    }
+    const table = resolved.node(tableDepth);
+    const tableStart = resolved.start(tableDepth);
+    const cellPosition = resolved.before(cellDepth);
+    const cellRect = TableMap.get(table).findCell(cellPosition - tableStart);
+    return {
+      tablePosition: resolved.before(tableDepth),
+      columnIndex: position === "before" ? cellRect.left : cellRect.right,
+      boundaryPosition: position === "before" ? cellPosition : cellPosition + cell.nodeSize,
     };
   }
   return null;
@@ -368,6 +414,96 @@ const populateTableRow = (row: PMNode, cellTexts: readonly string[] | undefined)
     cells.push(cell.type.create(cell.attrs, nextParagraph));
   });
   return row.type.create(row.attrs, cells);
+};
+
+const getInsertedPhysicalColumnRows = (map: TableMap, columnIndex: number): number[] => {
+  const rows: number[] = [];
+  for (let row = 0; row < map.height; row++) {
+    const index = row * map.width + columnIndex;
+    const crossesColspan =
+      columnIndex > 0 && columnIndex < map.width && map.map[index - 1] === map.map[index];
+    if (!crossesColspan) {
+      rows.push(row);
+    }
+  }
+  return rows;
+};
+
+type TableColumnInsertionAction =
+  | { type: "insertCell"; position: number; cell: PMNode }
+  | { type: "setColspan"; position: number; cell: PMNode; colspanOffset: number };
+
+const populateTableCell = (cell: PMNode, text: string): PMNode | null => {
+  const paragraph = cell.firstChild;
+  if (!paragraph?.isTextblock) {
+    return null;
+  }
+  const content = text.length > 0 ? cell.type.schema.text(text) : null;
+  const nextParagraph = paragraph.type.create(stripIdentityAttrs(paragraph.attrs), content);
+  return cell.type.create(cell.attrs, nextParagraph);
+};
+
+const buildTableColumnInsertionActions = (
+  map: TableMap,
+  table: PMNode,
+  columnIndex: number,
+  cellTexts: readonly string[] | undefined,
+): TableColumnInsertionAction[] | null => {
+  if (columnIndex < 0 || columnIndex > map.width) {
+    return null;
+  }
+  const physicalRows = getInsertedPhysicalColumnRows(map, columnIndex);
+  if ((cellTexts?.length ?? 0) > physicalRows.length) {
+    return null;
+  }
+  let referenceColumn: number | null = columnIndex > 0 ? -1 : 0;
+  if (columnIsHeader(map, table, columnIndex + referenceColumn)) {
+    referenceColumn = columnIndex === 0 || columnIndex === map.width ? null : 0;
+  }
+  const actions: TableColumnInsertionAction[] = [];
+  let physicalCellIndex = 0;
+  for (let row = 0; row < map.height; row++) {
+    const index = row * map.width + columnIndex;
+    if (columnIndex > 0 && columnIndex < map.width && map.map[index - 1] === map.map[index]) {
+      const position = map.map[index];
+      if (position === undefined) {
+        return null;
+      }
+      const cell = table.nodeAt(position);
+      if (!cell) {
+        return null;
+      }
+      actions.push({
+        type: "setColspan",
+        position,
+        cell,
+        colspanOffset: columnIndex - map.colCount(position),
+      });
+      row += Number(cell.attrs["rowspan"] ?? 1) - 1;
+      continue;
+    }
+    const referencePosition =
+      referenceColumn === null ? undefined : map.map[index + referenceColumn];
+    const cellType =
+      referencePosition === undefined
+        ? tableNodeTypes(table.type.schema).cell
+        : table.nodeAt(referencePosition)?.type;
+    const cell = cellType?.createAndFill();
+    if (!cell) {
+      return null;
+    }
+    const populatedCell = populateTableCell(cell, cellTexts?.[physicalCellIndex] ?? "");
+    if (!populatedCell) {
+      return null;
+    }
+    actions.push({
+      type: "insertCell",
+      position: map.positionAt(row, columnIndex, table),
+      cell: populatedCell,
+    });
+    physicalCellIndex++;
+  }
+  return actions;
 };
 
 /**
@@ -553,7 +689,8 @@ const applyFolioAIEditOperationsInternal = ({
       mode === "tracked-changes" &&
       (operation.type === "formatRange" ||
         operation.type === "insertTableRow" ||
-        operation.type === "deleteTableRow")
+        operation.type === "deleteTableRow" ||
+        operation.type === "insertTableColumn")
     ) {
       skipped.push({ id: operation.id, reason: "unsupportedMode" });
       continue;
@@ -609,6 +746,23 @@ const applyFolioAIEditOperationsInternal = ({
   // one ends up immediately after it, matching the AI's logical
   // sequence.
   for (const item of resolved.toSorted((left, right) => {
+    const leftColumn = left.tableColumnInsertion;
+    const rightColumn = right.tableColumnInsertion;
+    if (!leftColumn && rightColumn) {
+      return -1;
+    }
+    if (leftColumn && !rightColumn) {
+      return 1;
+    }
+    if (leftColumn && rightColumn) {
+      if (leftColumn.tablePosition !== rightColumn.tablePosition) {
+        return rightColumn.tablePosition - leftColumn.tablePosition;
+      }
+      if (leftColumn.columnIndex !== rightColumn.columnIndex) {
+        return rightColumn.columnIndex - leftColumn.columnIndex;
+      }
+      return right.originalIndex - left.originalIndex;
+    }
     if (left.from !== right.from) {
       return right.from - left.from;
     }
@@ -870,6 +1024,51 @@ const applyFolioAIEditOperationsInternal = ({
         }
         const row = insertion.rowType.create(null, insertion.cells);
         tr = tr.insert(insertion.rowPosition, populateTableRow(row, item.operation.cellTexts));
+        break;
+      }
+      case "insertTableColumn": {
+        const insertion = item.tableColumnInsertion;
+        const tablePosition = insertion ? tr.mapping.map(insertion.tablePosition, 1) : null;
+        const table = tablePosition === null ? null : tr.doc.nodeAt(tablePosition);
+        if (
+          !insertion ||
+          tablePosition === null ||
+          !table ||
+          table.type.spec["tableRole"] !== "table"
+        ) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        const map = TableMap.get(table);
+        const actions = buildTableColumnInsertionActions(
+          map,
+          table,
+          insertion.columnIndex,
+          item.operation.cellTexts,
+        );
+        if (!actions) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        const mapFrom = tr.mapping.maps.length;
+        for (const action of actions) {
+          const position = tr.mapping.slice(mapFrom).map(tablePosition + 1 + action.position);
+          if (action.type === "insertCell") {
+            tr = tr.insert(position, action.cell);
+            continue;
+          }
+          tr = tr.setNodeMarkup(
+            position,
+            undefined,
+            addColSpan(action.cell.attrs, action.colspanOffset),
+          );
+        }
         break;
       }
       case "deleteTableRow": {
@@ -1408,6 +1607,27 @@ const resolveOperation = ({
           rowIndex: target.rowIndex,
           rowPosition: target.rowPosition,
         },
+      },
+    };
+  }
+
+  if (operation.type === "insertTableColumn") {
+    const position = operation.position ?? "after";
+    const insertion = findTableColumnInsertion(doc, blockFrom, position);
+    if (!insertion) {
+      return { type: "skip", reason: "unsupportedBlock" };
+    }
+    const { boundaryPosition, ...tableColumnInsertion } = insertion;
+    return {
+      type: "resolved",
+      operation: {
+        operation,
+        from: boundaryPosition,
+        to: boundaryPosition,
+        blockFrom,
+        blockTo,
+        blockNode,
+        tableColumnInsertion,
       },
     };
   }

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1,7 +1,6 @@
 import type { Mark, Node as PMNode, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import {
-  addColSpan,
   columnIsHeader,
   removeRow,
   rowIsHeader,
@@ -431,7 +430,42 @@ const getInsertedPhysicalColumnRows = (map: TableMap, columnIndex: number): numb
 
 type TableColumnInsertionAction =
   | { type: "insertCell"; position: number; cell: PMNode }
-  | { type: "setColspan"; position: number; cell: PMNode; colspanOffset: number };
+  | { type: "setColspan"; position: number; attrs: Record<string, unknown> };
+
+const expandTableCellColspan = (
+  cell: PMNode,
+  colspanOffset: number,
+): Record<string, unknown> | null => {
+  const colspan: unknown = cell.attrs["colspan"];
+  const rowspan: unknown = cell.attrs["rowspan"];
+  const colwidth: unknown = cell.attrs["colwidth"];
+  if (
+    typeof colspan !== "number" ||
+    !Number.isInteger(colspan) ||
+    colspan < 1 ||
+    typeof rowspan !== "number" ||
+    !Number.isInteger(rowspan) ||
+    rowspan < 1 ||
+    !Number.isInteger(colspanOffset) ||
+    colspanOffset < 0 ||
+    colspanOffset > colspan
+  ) {
+    return null;
+  }
+  if (colwidth !== null && !Array.isArray(colwidth)) {
+    return null;
+  }
+  if (Array.isArray(colwidth) && !colwidth.every((width) => typeof width === "number")) {
+    return null;
+  }
+  const nextColwidth = Array.isArray(colwidth) ? [...colwidth] : null;
+  nextColwidth?.splice(colspanOffset, 0, 0);
+  return {
+    ...cell.attrs,
+    colspan: colspan + 1,
+    colwidth: nextColwidth,
+  };
+};
 
 const populateTableCell = (cell: PMNode, text: string): PMNode | null => {
   const paragraph = cell.firstChild;
@@ -473,13 +507,17 @@ const buildTableColumnInsertionActions = (
       if (!cell) {
         return null;
       }
+      const colspanOffset = columnIndex - map.colCount(position);
+      const attrs = expandTableCellColspan(cell, colspanOffset);
+      if (!attrs) {
+        return null;
+      }
       actions.push({
         type: "setColspan",
         position,
-        cell,
-        colspanOffset: columnIndex - map.colCount(position),
+        attrs,
       });
-      row += Number(cell.attrs["rowspan"] ?? 1) - 1;
+      row += Number(cell.attrs["rowspan"]) - 1;
       continue;
     }
     const referencePosition =
@@ -1063,11 +1101,7 @@ const applyFolioAIEditOperationsInternal = ({
             tr = tr.insert(position, action.cell);
             continue;
           }
-          tr = tr.setNodeMarkup(
-            position,
-            undefined,
-            addColSpan(action.cell.attrs, action.colspanOffset),
-          );
+          tr = tr.setNodeMarkup(position, undefined, action.attrs);
         }
         break;
       }

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -360,6 +360,92 @@ describe("headless docx review round-trip", () => {
     expect(restoredTable.rows).toHaveLength(1);
   });
 
+  test("inserts, persists, and undoes a column inside shape text", async () => {
+    const baseline = await buildTextBoxTableDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const rejected = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      atomic: true,
+      operations: [
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: target.id,
+          cellTexts: ["Added value"],
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+
+    expect(rejected.status).toBe("rejected");
+    expect(rejected.applied).toEqual([]);
+    expect(reviewer.getContentAsText()).not.toContain("Added value");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: target.id,
+          cellTexts: ["Added value"],
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.applied).toEqual([{ id: "insert-column" }]);
+    expect(result.receipts).toEqual([
+      {
+        operationId: "insert-column",
+        operationIndex: 0,
+        affected: [
+          {
+            type: "insertion",
+            story: "main",
+            anchorBlockId: target.id,
+            position: "after",
+            content: "tableColumn",
+          },
+        ],
+      },
+    ]);
+
+    const saved = await reviewer.toBuffer();
+    const reparsed = await parseDocx(saved, { detectVariables: false, preloadFonts: false });
+    const table = findTextBoxShape(reparsed).textBody?.content.at(1);
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      throw new Error("expected a nested table");
+    }
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows.at(0)?.cells).toHaveLength(2);
+    expect((await FolioDocxReviewer.fromBuffer(saved)).getContentAsText()).toContain("Added value");
+
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.getContentAsText()).not.toContain("Added value");
+    const restored = await parseDocx(await reviewer.toBuffer(), {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    const restoredTable = findTextBoxShape(restored).textBody?.content.at(1);
+    expect(restoredTable?.type).toBe("table");
+    if (restoredTable?.type !== "table") {
+      throw new Error("expected a nested table");
+    }
+    expect(restoredTable.rows.at(0)?.cells).toHaveLength(1);
+  });
+
   test("edits a header through story-scoped document operations", async () => {
     const baseline = await makeHeaderFooterBaseline();
     const story = { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const;

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -237,6 +237,15 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         /** Stable paragraph anchor inside the row to delete. */
         blockId: string;
       }
+    | {
+        id: string;
+        type: "insertTableColumn";
+        /** Stable paragraph anchor inside the cell that receives the new sibling column. */
+        blockId: string;
+        position?: "after" | "before";
+        /** Initial text for newly created physical cells in row order. */
+        cellTexts?: string[];
+      }
   );
 
 export type FolioAIEditApplyMode = "direct" | "tracked-changes";

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -33,6 +33,7 @@ describe("document operation contract", () => {
         "insertSignatureTable",
         "insertTableRow",
         "deleteTableRow",
+        "insertTableColumn",
       ],
       modes: ["direct", "tracked-changes"],
       batchModes: ["best-effort", "atomic"],
@@ -50,6 +51,7 @@ describe("document operation contract", () => {
         insertSignatureTable: ["direct"],
         insertTableRow: ["direct"],
         deleteTableRow: ["direct"],
+        insertTableColumn: ["direct"],
       },
       preconditions: ["blockTextHash"],
       stories: ["main", "header", "footer", "footnote", "endnote"],
@@ -63,6 +65,7 @@ describe("document operation contract", () => {
       false,
     );
     expect(isFolioDocumentOperationModeSupported("deleteTableRow", "tracked-changes")).toBe(false);
+    expect(isFolioDocumentOperationModeSupported("insertTableColumn", "direct")).toBe(true);
     expect(
       Reflect.apply(isFolioDocumentOperationModeSupported, null, ["unknownOperation", "direct"]),
     ).toBe(false);
@@ -116,6 +119,12 @@ describe("document operation contract", () => {
         cellTexts: ["A", "B"],
       },
       { id: "delete-row", type: "deleteTableRow", blockId: "paragraph-7" },
+      {
+        id: "column",
+        type: "insertTableColumn",
+        blockId: "paragraph-8",
+        cellTexts: ["A", "B"],
+      },
     ] as const satisfies readonly FolioDocumentOperation[];
 
     expect(
@@ -128,6 +137,7 @@ describe("document operation contract", () => {
         { id: "delete" },
         { id: "row" },
         { id: "delete-row" },
+        { id: "column" },
       ]),
     ).toEqual([
       {
@@ -219,6 +229,19 @@ describe("document operation contract", () => {
           },
         ],
       },
+      {
+        operationId: "column",
+        operationIndex: 8,
+        affected: [
+          {
+            type: "insertion",
+            story: "main",
+            anchorBlockId: "paragraph-8",
+            position: "after",
+            content: "tableColumn",
+          },
+        ],
+      },
     ]);
   });
 
@@ -284,6 +307,13 @@ describe("document operation contract", () => {
           cellTexts: ["First", "Second"],
         },
         { id: "9", type: "deleteTableRow", blockId: "a" },
+        {
+          id: "10",
+          type: "insertTableColumn",
+          blockId: "a",
+          position: "before",
+          cellTexts: ["Top", "Bottom"],
+        },
       ],
     };
 

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -33,6 +33,7 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES = Object.freeze([
   "insertSignatureTable",
   "insertTableRow",
   "deleteTableRow",
+  "insertTableColumn",
 ] as const satisfies readonly FolioAIEditOperation["type"][]);
 
 export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
@@ -76,6 +77,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   insertSignatureTable: DIRECT_ONLY_MODES,
   insertTableRow: DIRECT_ONLY_MODES,
   deleteTableRow: DIRECT_ONLY_MODES,
+  insertTableColumn: DIRECT_ONLY_MODES,
 } as const satisfies Readonly<
   Record<FolioDocumentOperationType, readonly FolioDocumentOperationMode[]>
 >);
@@ -604,6 +606,23 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     return { ...operationMeta, id, type, blockId };
   }
 
+  if (type === "insertTableColumn") {
+    assertAllowedKeys(value, path, [...COMMON_OPERATION_KEYS, "position", "cellTexts"]);
+    const position = value["position"];
+    if (position !== undefined && position !== "after" && position !== "before") {
+      return invalidBatch(`${path}.position`, 'expected "after" or "before" when provided');
+    }
+    const cellTexts = readOptionalStringArray(value, "cellTexts", path);
+    return {
+      ...operationMeta,
+      id,
+      type,
+      blockId,
+      ...(position !== undefined && { position }),
+      ...(cellTexts !== undefined && { cellTexts }),
+    };
+  }
+
   return invalidBatch(`${path}.type`, `unsupported operation type "${type}"`);
 };
 
@@ -685,7 +704,7 @@ export type FolioDocumentOperationAffectedTarget =
       story: FolioDocumentOperationStory;
       anchorBlockId: string;
       position: "before" | "after";
-      content: "block" | "signatureTable" | "tableRow";
+      content: "block" | "signatureTable" | "tableRow" | "tableColumn";
     }
   | {
       type: "comment";
@@ -853,6 +872,14 @@ const getPrimaryAffectedTarget = (
         story,
         anchorBlockId: operation.blockId,
         effect: "deleted",
+      };
+    case "insertTableColumn":
+      return {
+        type: "insertion",
+        story,
+        anchorBlockId: operation.blockId,
+        position: operation.position ?? "after",
+        content: "tableColumn",
       };
   }
 };


### PR DESCRIPTION
## Summary

- add direct column insertion through the versioned operation contract
- preserve merged-cell topology and nested-table targeting
- cover mixed batches, receipts, undo, and persistence