### PR TITLE
fix: preserve tracked text box revisions

### DIFF
--- a/.changeset/ripe-needles-grab.md
+++ b/.changeset/ripe-needles-grab.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve tracked-change wrappers around text boxes through editing and save.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -423,7 +423,20 @@ export type TextBoxAttrs = {
     distRight?: number; /** Position for floating/anchored text boxes */
     position?: ImagePositionAttrs; /** Original DOCX placement hint for save-path reconstruction. */
     _docxPlacement?: "standalone" | "inlineWithPrevious"; /** Original DOCX paragraph group for standalone text-box reconstruction. */
-    _docxGroupId?: string;
+    _docxGroupId?: string; /** Original run-level revision wrapper for save-path reconstruction. */
+    _docxTrackedChange?: {
+        type: "insertion";
+        info: import__stll_docx_core_model.TrackedChangeInfo;
+    } | {
+        type: "deletion";
+        info: import__stll_docx_core_model.TrackedChangeInfo;
+    } | {
+        type: "moveFrom";
+        info: import__stll_docx_core_model.TrackedChangeInfo;
+    } | {
+        type: "moveTo";
+        info: import__stll_docx_core_model.TrackedChangeInfo;
+    };
 };
 
 // @public

--- a/packages/core/src/docx/documentParser.test.ts
+++ b/packages/core/src/docx/documentParser.test.ts
@@ -332,6 +332,62 @@ describe("parseDocumentBody text box enrichment", () => {
     expect(middleRun.content.at(0)?.type).toBe("shape");
   });
 
+  test.each([
+    ["ins", "insertion"],
+    ["del", "deletion"],
+    ["moveFrom", "moveFrom"],
+    ["moveTo", "moveTo"],
+  ] as const)("enriches text boxes inside w:%s wrappers", (elementName, contentType) => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <w:body>
+    <w:p w14:paraId="TXB00003">
+      <w:${elementName} w:id="41" w:author="Reviewer" w:date="2026-07-15T12:00:00Z">
+        <w:r>${textBoxDrawingXml("Tracked text box")}</w:r>
+      </w:${elementName}>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const trackedChange = paragraph.content.at(0);
+    expect(trackedChange?.type).toBe(contentType);
+    if (
+      trackedChange?.type !== "insertion" &&
+      trackedChange?.type !== "deletion" &&
+      trackedChange?.type !== "moveFrom" &&
+      trackedChange?.type !== "moveTo"
+    ) {
+      throw new Error("Expected tracked change wrapper");
+    }
+    expect(trackedChange.info).toEqual({
+      id: 41,
+      author: "Reviewer",
+      date: "2026-07-15T12:00:00Z",
+    });
+
+    const run = trackedChange.content.at(0);
+    if (run?.type !== "run") {
+      throw new Error("Expected tracked run");
+    }
+    const shape = run.content.at(0);
+    if (shape?.type !== "shape") {
+      throw new Error("Expected text-box shape");
+    }
+    expect(shape.shape.textBody?.content.at(0)).toMatchObject({
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text: "Tracked text box" }] }],
+    });
+  });
+
   // Regression: Word stores anchored wps:wsp text boxes inside an
   // <mc:AlternateContent> block — Choice Requires="wps" holds the modern
   // shape, Fallback holds a VML rendering. scanRunForTextBoxDrawings only

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -2,11 +2,13 @@ import type {
   ImagePosition,
   MediaFile,
   Paragraph,
+  ParagraphContent,
   RelationshipMap,
   Run,
   Shape,
   ShapeContent,
   Theme,
+  TrackedRunChange,
 } from "../types/document";
 import { pixelsToEmu } from "../utils/units";
 import type { NumberingMap } from "./numberingParser";
@@ -157,16 +159,74 @@ export const enrichParagraphTextBoxes = (
   media: Map<string, MediaFile> | null,
   parseTable: TableParserFn,
 ): void => {
-  const xmlChildren = getChildElements(paraXml);
+  enrichTextBoxRuns({
+    content: paragraph.content,
+    xmlChildren: getChildElements(paraXml),
+    styles,
+    theme,
+    numbering,
+    rels,
+    media,
+    parseTable,
+  });
+};
+
+type EnrichTextBoxRunsParams = {
+  content: ParagraphContent[];
+  xmlChildren: XmlElement[];
+  styles: StyleMap | null;
+  theme: Theme | null;
+  numbering: NumberingMap | null;
+  rels: RelationshipMap | null;
+  media: Map<string, MediaFile> | null;
+  parseTable: TableParserFn;
+};
+
+const trackedChangeTypeFromXml = (localName: string): TrackedRunChange["type"] | undefined => {
+  if (localName === "ins") {
+    return "insertion";
+  }
+  if (localName === "del") {
+    return "deletion";
+  }
+  if (localName === "moveFrom" || localName === "moveTo") {
+    return localName;
+  }
+  return undefined;
+};
+
+const enrichTextBoxRuns = ({
+  content,
+  xmlChildren,
+  styles,
+  theme,
+  numbering,
+  rels,
+  media,
+  parseTable,
+}: EnrichTextBoxRunsParams): void => {
   let parsedIndex = 0;
   let lastConsumedRun: Run | undefined;
 
   for (const xmlChild of xmlChildren) {
-    if (getLocalName(xmlChild.name ?? "") !== "r") {
-      if (
-        parsedIndex < paragraph.content.length &&
-        paragraph.content[parsedIndex]?.type !== "run"
-      ) {
+    const localName = getLocalName(xmlChild.name ?? "");
+    const trackedChangeType = trackedChangeTypeFromXml(localName);
+    const parsedContent = content[parsedIndex];
+    if (trackedChangeType && parsedContent?.type === trackedChangeType) {
+      enrichTextBoxRuns({
+        content: parsedContent.content,
+        xmlChildren: getChildElements(xmlChild),
+        styles,
+        theme,
+        numbering,
+        rels,
+        media,
+        parseTable,
+      });
+    }
+
+    if (localName !== "r") {
+      if (parsedIndex < content.length && parsedContent?.type !== "run") {
         parsedIndex += 1;
       }
       continue;
@@ -175,9 +235,10 @@ export const enrichParagraphTextBoxes = (
     const { textBoxDrawings, vmlTextBoxes, hasNonTextBoxContent } =
       scanRunForTextBoxDrawings(xmlChild);
 
-    const parsedContent = paragraph.content[parsedIndex];
     const parsedRun: Run | undefined = parsedContent?.type === "run" ? parsedContent : undefined;
     const targetRun = parsedRun ?? (hasNonTextBoxContent ? lastConsumedRun : undefined);
+    const targetRunMatchesXml =
+      targetRun !== undefined && (hasNonTextBoxContent || parsedRun?.content.length === 0);
 
     for (const runEl of textBoxDrawings) {
       const textBox = parseTextBox(runEl);
@@ -222,11 +283,11 @@ export const enrichParagraphTextBoxes = (
 
       const shapeContent: ShapeContent = { type: "shape", shape };
 
-      if (targetRun && hasNonTextBoxContent) {
+      if (targetRunMatchesXml) {
         targetRun.content.push(shapeContent);
       } else {
         const newRun: Run = { type: "run", content: [shapeContent] };
-        paragraph.content.splice(parsedIndex, 0, newRun);
+        content.splice(parsedIndex, 0, newRun);
         lastConsumedRun = newRun;
         parsedIndex += 1;
       }
@@ -238,11 +299,11 @@ export const enrichParagraphTextBoxes = (
         continue;
       }
       const shapeContent: ShapeContent = { type: "shape", shape };
-      if (targetRun && hasNonTextBoxContent) {
+      if (targetRunMatchesXml) {
         targetRun.content.push(shapeContent);
       } else {
         const newRun: Run = { type: "run", content: [shapeContent] };
-        paragraph.content.splice(parsedIndex, 0, newRun);
+        content.splice(parsedIndex, 0, newRun);
         lastConsumedRun = newRun;
         parsedIndex += 1;
       }

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -363,6 +363,7 @@ describe("ProseMirror attr readers", () => {
       cssFloat: "center",
       wrapType: "sideways",
       position: { vertical: { relativeTo: "ceiling" } },
+      _docxTrackedChange: { type: "replacement", info: { id: "41", author: 7 } },
     });
 
     const shapeResult = readShapeAttrs(shape);
@@ -389,6 +390,15 @@ describe("ProseMirror attr readers", () => {
       expect(textBoxResult.issues.map((issue) => issue.path)).toContain("textBox.attrs.wrapType");
       expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
         "textBox.attrs.position.vertical.relativeTo",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs._docxTrackedChange.type",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs._docxTrackedChange.info.id",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs._docxTrackedChange.info.author",
       );
     }
   });

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -158,6 +158,13 @@ const TRACKED_CHANGE_MOVE_KINDS = ["moveTo", "moveFrom"] as const satisfies read
   TrackedChangeMarkAttrs["moveKind"]
 >[];
 
+const TEXT_BOX_TRACKED_CHANGE_TYPES = [
+  "insertion",
+  "deletion",
+  "moveFrom",
+  "moveTo",
+] as const satisfies readonly NonNullable<TextBoxAttrs["_docxTrackedChange"]>["type"][];
+
 const HARD_BREAK_TYPES = ["column"] as const satisfies readonly NonNullable<
   HardBreakAttrs["breakType"]
 >[];
@@ -725,6 +732,7 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
     TEXT_BOX_DOCX_PLACEMENTS,
   );
   optionalString(attrs, "_docxGroupId", "textBox.attrs._docxGroupId", issues);
+  optionalTextBoxTrackedChange(attrs, issues);
 
   return attrsResult(attrs, issues);
 };
@@ -1499,6 +1507,39 @@ const optionalRecord = (
   if (value !== undefined && value !== null && !isRecord(value)) {
     issues.push({ path, message: "Expected an object." });
   }
+};
+
+const optionalTextBoxTrackedChange = (
+  attrs: Record<string, unknown>,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs["_docxTrackedChange"];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path: "textBox.attrs._docxTrackedChange", message: "Expected an object." });
+    return;
+  }
+
+  requiredOneOf(
+    value,
+    "type",
+    "textBox.attrs._docxTrackedChange.type",
+    issues,
+    TEXT_BOX_TRACKED_CHANGE_TYPES,
+  );
+  const info = value["info"];
+  if (!isRecord(info)) {
+    issues.push({
+      path: "textBox.attrs._docxTrackedChange.info",
+      message: "Expected an object.",
+    });
+    return;
+  }
+  requiredNumber(info, "id", "textBox.attrs._docxTrackedChange.info.id", issues);
+  requiredString(info, "author", "textBox.attrs._docxTrackedChange.info.author", issues);
+  optionalString(info, "date", "textBox.attrs._docxTrackedChange.info.date", issues);
 };
 
 const optionalAutospacingBase = (

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, test } from "bun:test";
 import type { Node as PMNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 
-import type { Document, Paragraph, Table, TableCell } from "../../types/document";
+import type {
+  Document,
+  Paragraph,
+  Run,
+  Table,
+  TableCell,
+  TrackedChangeInfo,
+  TrackedRunChange,
+} from "../../types/document";
 import { pixelsToEmu } from "../../utils/units";
 import { expectHardBreakAttrs, expectParagraphAttrs } from "../attrs";
 import { schema } from "../schema";
@@ -1416,6 +1424,58 @@ describe("fromProseDoc", () => {
     expect(firstShapeType(block)).toBe("textBox");
   });
 
+  test.each(["insertion", "deletion", "moveFrom", "moveTo"] as const)(
+    "round-trips a text box inside the %s wrapper",
+    (type) => {
+      const document = documentWithTextBoxParagraph({ includeText: false });
+      const paragraph = document.package.document.content.at(0);
+      if (paragraph?.type !== "paragraph") {
+        throw new Error("Expected paragraph");
+      }
+      const run = paragraph.content.at(0);
+      if (run?.type !== "run") {
+        throw new Error("Expected text-box run");
+      }
+      const info = {
+        id: 41,
+        author: "Reviewer",
+        date: "2026-07-15T12:00:00Z",
+      } satisfies TrackedChangeInfo;
+      paragraph.content = [trackedTextBoxWrapper(type, info, run)];
+
+      const pmDoc = toProseDoc(document);
+      const textBoxNode = pmDoc.firstChild;
+      expect(textBoxNode?.type.name).toBe("textBox");
+      expect(textBoxNode?.attrs["_docxTrackedChange"]).toEqual({ type, info });
+
+      const roundTripped = fromProseDoc(pmDoc, document);
+      const block = roundTripped.package.document.content.at(0);
+      if (block?.type !== "paragraph") {
+        throw new Error("Expected round-tripped paragraph");
+      }
+      const trackedChange = block.content.at(0);
+      expect(trackedChange).toMatchObject({ type, info });
+      if (
+        trackedChange?.type !== "insertion" &&
+        trackedChange?.type !== "deletion" &&
+        trackedChange?.type !== "moveFrom" &&
+        trackedChange?.type !== "moveTo"
+      ) {
+        throw new Error("Expected round-tripped tracked change");
+      }
+      const trackedRun = trackedChange.content.at(0);
+      if (trackedRun?.type !== "run") {
+        throw new Error("Expected round-tripped tracked run");
+      }
+      const trackedShape = trackedRun.content.at(0);
+      expect(trackedShape?.type).toBe("shape");
+      if (trackedShape?.type !== "shape") {
+        throw new Error("Expected round-tripped text-box shape");
+      }
+      expect(trackedShape.shape.shapeType).toBe("textBox");
+    },
+  );
+
   test("keeps empty imported text boxes as text boxes", () => {
     const document = documentWithTextBoxParagraph({
       includeText: false,
@@ -2000,6 +2060,23 @@ function documentWithTextBoxParagraph({
       },
     },
   };
+}
+
+function trackedTextBoxWrapper(
+  type: TrackedRunChange["type"],
+  info: TrackedChangeInfo,
+  run: Run,
+): TrackedRunChange {
+  if (type === "insertion") {
+    return { type, info, content: [run] };
+  }
+  if (type === "deletion") {
+    return { type, info, content: [run] };
+  }
+  if (type === "moveFrom") {
+    return { type, info, content: [run] };
+  }
+  return { type, info, content: [run] };
 }
 
 function cellWithText(text: string): TableCell {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2910,10 +2910,13 @@ function convertPMTextBox(node: PMNode): Paragraph {
   // Wrap the shape in a paragraph with a run containing ShapeContent
   const shapeContent: ShapeContent = { type: "shape", shape };
   const run: Run = { type: "run", content: [shapeContent] };
+  const trackedChange = attrs._docxTrackedChange;
 
   return {
     type: "paragraph",
-    content: [run],
+    content: trackedChange
+      ? [{ type: trackedChange.type, info: trackedChange.info, content: [run] }]
+      : [run],
   };
 }
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2827,7 +2827,7 @@ function hasParagraphBoundaryPayload(block: Paragraph, pmParagraph: PMNode): boo
  */
 type ExtractedTextBox = {
   textBox: TextBox;
-  trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>;
+  trackedChange: NonNullable<TextBoxAttrs["_docxTrackedChange"]> | undefined;
 };
 
 function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractedTextBox[] {
@@ -2912,7 +2912,7 @@ function convertTextBox(
     placement?: "standalone" | "inlineWithPrevious";
     groupId?: string;
     context: TableConversionContext;
-    trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>;
+    trackedChange: NonNullable<TextBoxAttrs["_docxTrackedChange"]> | undefined;
   },
 ): PMNode {
   const textBoxData: { size?: Partial<TextBox["size"]> } = textBox;

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -44,6 +44,7 @@ import type {
   MoveFrom,
   MoveTo,
   MathEquation,
+  ShapeTextBody,
   Theme,
 } from "../../types/document";
 import {
@@ -62,6 +63,7 @@ import type {
   TableAttrs,
   TableRowAttrs,
   TableCellAttrs,
+  TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
 import {
@@ -2794,13 +2796,14 @@ function convertParagraphWithTextBoxes(
   if (!isEmptyAfterExtraction || keepWrapperParagraph) {
     nodes.push(pmParagraph);
   }
-  for (const tb of textBoxes) {
+  for (const { textBox, trackedChange } of textBoxes) {
     nodes.push(
-      convertTextBox(tb, styleResolver, {
+      convertTextBox(textBox, styleResolver, {
         placement:
           isEmptyAfterExtraction && !keepWrapperParagraph ? "standalone" : "inlineWithPrevious",
         groupId: textBoxGroupId,
         context,
+        trackedChange,
       }),
     );
   }
@@ -2820,51 +2823,83 @@ function hasParagraphBoundaryPayload(block: Paragraph, pmParagraph: PMNode): boo
 
 /**
  * Extract text boxes from paragraph runs.
- * Text boxes appear as ShapeContent where the shape has textBody,
- * or as DrawingContent that contains a text box instead of an image.
+ * Text boxes appear as ShapeContent where the shape has textBody.
  */
-function extractTextBoxesFromParagraph(paragraph: Paragraph): TextBox[] {
-  const textBoxes: TextBox[] = [];
+type ExtractedTextBox = {
+  textBox: TextBox;
+  trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>;
+};
+
+function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractedTextBox[] {
+  const textBoxes: ExtractedTextBox[] = [];
+  const extractFromRun = (
+    run: Run,
+    trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>,
+  ): void => {
+    for (const runContent of run.content) {
+      if (runContent.type !== "shape" || !runContent.shape.textBody) {
+        continue;
+      }
+      textBoxes.push({
+        textBox: textBoxFromShape(runContent.shape, runContent.shape.textBody),
+        trackedChange,
+      });
+    }
+  };
+
   for (const content of paragraph.content) {
     if (content.type === "run") {
-      for (const rc of content.content) {
-        if (rc.type === "shape") {
-          const shape = rc.shape as Shape;
-          if (shape.textBody) {
-            // Convert shape with text body to TextBox
-            const textBox: TextBox = {
-              type: "textBox",
-              size: shape.size,
-              content: shape.textBody.content,
-            };
-            if (shape.id) {
-              textBox.id = shape.id;
-            }
-            if (shape.position) {
-              textBox.position = shape.position;
-            }
-            if (shape.wrap) {
-              textBox.wrap = shape.wrap;
-            }
-            if (shape.fill) {
-              textBox.fill = shape.fill;
-            }
-            if (shape.outline) {
-              textBox.outline = shape.outline;
-            }
-            if (shape.textBody.margins) {
-              textBox.margins = shape.textBody.margins;
-            }
-            if (shape.textBody.autoFit) {
-              textBox.autoFit = shape.textBody.autoFit;
-            }
-            textBoxes.push(textBox);
-          }
-        }
+      extractFromRun(content);
+      continue;
+    }
+    if (
+      content.type !== "insertion" &&
+      content.type !== "deletion" &&
+      content.type !== "moveFrom" &&
+      content.type !== "moveTo"
+    ) {
+      continue;
+    }
+    const trackedChange = { type: content.type, info: content.info } as const satisfies NonNullable<
+      TextBoxAttrs["_docxTrackedChange"]
+    >;
+    for (const trackedContent of content.content) {
+      if (trackedContent.type === "run") {
+        extractFromRun(trackedContent, trackedChange);
       }
     }
   }
   return textBoxes;
+}
+
+function textBoxFromShape(shape: Shape, textBody: ShapeTextBody): TextBox {
+  const textBox: TextBox = {
+    type: "textBox",
+    size: shape.size,
+    content: textBody.content,
+  };
+  if (shape.id) {
+    textBox.id = shape.id;
+  }
+  if (shape.position) {
+    textBox.position = shape.position;
+  }
+  if (shape.wrap) {
+    textBox.wrap = shape.wrap;
+  }
+  if (shape.fill) {
+    textBox.fill = shape.fill;
+  }
+  if (shape.outline) {
+    textBox.outline = shape.outline;
+  }
+  if (textBody.margins) {
+    textBox.margins = textBody.margins;
+  }
+  if (textBody.autoFit) {
+    textBox.autoFit = textBody.autoFit;
+  }
+  return textBox;
 }
 
 /**
@@ -2877,6 +2912,7 @@ function convertTextBox(
     placement?: "standalone" | "inlineWithPrevious";
     groupId?: string;
     context: TableConversionContext;
+    trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>;
   },
 ): PMNode {
   const textBoxData: { size?: Partial<TextBox["size"]> } = textBox;
@@ -3024,6 +3060,7 @@ function convertTextBox(
       position,
       _docxPlacement: options.placement,
       _docxGroupId: options.groupId,
+      _docxTrackedChange: options.trackedChange,
     },
     contentNodes,
   );

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -9,7 +9,7 @@
 import type { ImageWrap, ShapeTextBody } from "../../../types/document";
 import { IMAGE_WRAP_TYPE_VALUES, type OutlineStyleAttr } from "../../../types/documentEnumValues";
 import { expectTextBoxAttrs } from "../../attrs";
-import type { ImagePositionAttrs } from "../../schema/nodes";
+import type { ImagePositionAttrs, TextBoxAttrs as SchemaTextBoxAttrs } from "../../schema/nodes";
 import { createNodeExtension } from "../create";
 
 export type TextBoxAttrs = {
@@ -61,6 +61,8 @@ export type TextBoxAttrs = {
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */
   _docxGroupId?: string;
+  /** Original run-level revision wrapper for save-path reconstruction. */
+  _docxTrackedChange?: SchemaTextBoxAttrs["_docxTrackedChange"];
 };
 
 function parseTextBoxPosition(raw: string | undefined): ImagePositionAttrs | undefined {
@@ -127,6 +129,7 @@ export const TextBoxExtension = createNodeExtension({
       position: { default: null },
       _docxPlacement: { default: null },
       _docxGroupId: { default: null },
+      _docxTrackedChange: { default: null },
     },
     parseDOM: [
       {

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -38,6 +38,7 @@ import type {
   ShapeTextBody,
   SdtProperties,
   SdtType,
+  TrackedChangeInfo,
 } from "../../types/document";
 import type { OutlineStyleAttr } from "../../types/documentEnumValues";
 import type { SpacingExplicit } from "../../types/formatting";
@@ -548,6 +549,12 @@ export type TextBoxAttrs = {
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */
   _docxGroupId?: string;
+  /** Original run-level revision wrapper for save-path reconstruction. */
+  _docxTrackedChange?:
+    | { type: "insertion"; info: TrackedChangeInfo }
+    | { type: "deletion"; info: TrackedChangeInfo }
+    | { type: "moveFrom"; info: TrackedChangeInfo }
+    | { type: "moveTo"; info: TrackedChangeInfo };
 };
 
 /**


### PR DESCRIPTION
## Summary

- enrich text-box drawings nested inside insertion, deletion, and move wrappers
- carry revision metadata through editor conversion and reconstruct the original wrapper on save
- validate the preservation attribute and cover parser and editor round trips