### PR TITLE
fix: honor Vue host locale and color mode

### DIFF
--- a/.changeset/vue-host-configuration.md
+++ b/.changeset/vue-host-configuration.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-vue": minor
+"@stll/folio-nuxt": patch
+---
+
+Honor inherited locales and add reactive light, dark, and system color-mode providers.

--- a/api-reports/vue/composables.api.md
+++ b/api-reports/vue/composables.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AnonymizationMatch } from '@stll/folio-core/prosemirror/plugins/anonymizationDecorations';
+import { App } from 'vue';
 import { CellCoordinates } from '@stll/folio-core/managers/types';
 import { ClipboardSelection } from '@stll/folio-core/managers/ClipboardManager';
 import { CommandMap } from '@stll/folio-core/prosemirror/extensions/types';
@@ -43,7 +44,18 @@ import { TripwireResult } from '@stll/folio-core/docx/selectiveSaveTripwire';
 
 export { ClipboardSelection }
 
+// @public
+export type ColorMode = "light" | "dark" | "system";
+
+// @public
+export const colorModePlugin: {
+    install(app: App, colorMode?: MaybeRefOrGetter<ColorMode>): void;
+};
+
 export { createSelectionFromDOM }
+
+// @public
+export const defaultColorMode: ColorMode;
 
 // @public (undocumented)
 export type DragAutoScrollOptions = {
@@ -62,6 +74,9 @@ export type HeaderFooterSelectionState = {
     rId: string;
     to: number;
 };
+
+// @public
+export const provideColorMode: (colorMode?: MaybeRefOrGetter<ColorMode>) => void;
 
 export { runsToClipboardContent }
 
@@ -90,6 +105,9 @@ export type UseClipboardReturn = {
     isProcessing: Ref<boolean>;
     lastPastedContent: Ref<ParsedClipboardContent | null>;
 };
+
+// @public
+export function useColorMode(): ComputedRef<boolean>;
 
 // @public (undocumented)
 export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorReturn;

--- a/api-reports/vue/index.api.md
+++ b/api-reports/vue/index.api.md
@@ -241,6 +241,14 @@ export { clearAutocompleteSuggestion }
 export { clearTemplateSlashMenu }
 
 // @public
+export type ColorMode = "light" | "dark" | "system";
+
+// @public
+export const colorModePlugin: {
+    install(app: App, colorMode?: MaybeRefOrGetter<ColorMode>): void;
+};
+
+// @public
 export type ColorPreset = {
     label: string;
     value: string;
@@ -266,6 +274,9 @@ export { createStellaStyleSet }
 export { DEFAULT_AI_SUGGESTION_PRESETS }
 
 export { DEFAULT_AUTOCOMPLETE_DEAD_ZONE_NODES }
+
+// @public
+export const defaultColorMode: ColorMode;
 
 // @public
 export const defaultLocale = "en";
@@ -686,6 +697,9 @@ export { PictureWatermark }
 export { PositionalText }
 
 // @public
+export const provideColorMode: (colorMode?: MaybeRefOrGetter<ColorMode>) => void;
+
+// @public
 export const provideLocale: (locale?: MaybeRefOrGetter<string>) => void;
 
 // @public
@@ -694,6 +708,7 @@ export const renderAsync: (input: DocxInput, container: HTMLElement, options?: R
 // @public
 export type RenderAsyncOptions = Omit<DocxEditorProps, "documentBuffer" | "document"> & {
     locale?: string;
+    colorMode?: ColorMode;
 };
 
 export { resetTemplateSlashQuery }
@@ -751,6 +766,9 @@ export { TextWatermark }
 export { toMarkdown }
 
 export { toMarkdownResult }
+
+// @public
+export function useColorMode(): ComputedRef<boolean>;
 
 // @public
 export const useTranslation: () => {

--- a/api-reports/vue/index.api.md
+++ b/api-reports/vue/index.api.md
@@ -708,7 +708,7 @@ export const renderAsync: (input: DocxInput, container: HTMLElement, options?: R
 // @public
 export type RenderAsyncOptions = Omit<DocxEditorProps, "documentBuffer" | "document"> & {
     locale?: string;
-    colorMode?: ColorMode;
+    colorMode?: MaybeRefOrGetter<ColorMode>;
 };
 
 export { resetTemplateSlashQuery }

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -26,6 +26,7 @@ const STYLES_SUBPATH = "@stll/folio-vue/editor.css";
 // `packages/vue/src/composables/index.ts`.
 const VUE_COMPOSABLES = [
   "useClipboard",
+  "useColorMode",
   "useDocxEditor",
   "useDragAutoScroll",
   "useFixedDropdown",

--- a/packages/playground-vue/src/main.ts
+++ b/packages/playground-vue/src/main.ts
@@ -1,8 +1,20 @@
 import { createApp } from "vue";
+import { colorModePlugin, i18nPlugin, type ColorMode } from "@stll/folio-vue";
 
 import App from "./App.vue";
 
+const COLOR_MODES = ["light", "dark", "system"] as const satisfies readonly ColorMode[];
+
+function isColorMode(value: string | null): value is ColorMode {
+  return COLOR_MODES.some((mode) => mode === value);
+}
+
 const container = document.querySelector("#app");
 if (container) {
-  createApp(App).mount(container);
+  const search = new URLSearchParams(window.location.search);
+  const requestedColorMode = search.get("colorMode");
+  const app = createApp(App);
+  app.use(i18nPlugin, search.get("locale") ?? "en");
+  app.use(colorModePlugin, isColorMode(requestedColorMode) ? requestedColorMode : "light");
+  app.mount(container);
 }

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -449,6 +449,7 @@ import UnifiedSidebar from "./UnifiedSidebar.vue";
 
 import { useCommentLifecycle } from "../composables/useCommentLifecycle";
 import { useCommentManagement } from "../composables/useCommentManagement";
+import { useColorMode } from "../composables/useColorMode";
 import { useContextMenus } from "../composables/useContextMenus";
 import { useDocumentLifecycle } from "../composables/useDocumentLifecycle";
 import { useDocxEditor } from "../composables/useDocxEditor";
@@ -465,7 +466,6 @@ import { useSelectionSync } from "../composables/useSelectionSync";
 import { provideDocxPortalClass } from "../composables/usePortalClass";
 import { useTableResize } from "../composables/useTableResize";
 import { useTrackedChanges } from "../composables/useTrackedChanges";
-import { useColorMode } from "../composables/useColorMode";
 import { useZoom } from "../composables/useZoom";
 import type { FontOption } from "../utils/fontOptions";
 import { loadHostFontFaces, removeFontFaces } from "../utils/hostFonts";

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -24,9 +24,7 @@
   inside `UnifiedSidebar`), and the table context toolbar (`TableToolbar`).
 
   Remaining adapter-specific surfaces:
-   - externalPlugins / i18n-locale props are not on `DocxEditorProps`, so the
-     host plugin list is empty and the locale defaults to `en`.
-   - colorMode prop + useColorMode: dark mode is fixed light here.
+   - externalPlugins are not on `DocxEditorProps`, so the host plugin list is empty.
    - The title-bar MenuBar is wired (File/Format/Insert/Help), including the insert flow
      (image/table/page-break/TOC via host props or core view-level helpers);
      the watermark item stays inert (no watermark dialog ported).
@@ -37,7 +35,7 @@
       'docx-editor-vue ep-root paged-editor',
       className,
       displayModeClass,
-      { 'paged-editor--readonly': readOnly },
+      { dark: isDark, 'paged-editor--readonly': readOnly },
     ]"
     :style="style"
   >
@@ -467,10 +465,11 @@ import { useSelectionSync } from "../composables/useSelectionSync";
 import { provideDocxPortalClass } from "../composables/usePortalClass";
 import { useTableResize } from "../composables/useTableResize";
 import { useTrackedChanges } from "../composables/useTrackedChanges";
+import { useColorMode } from "../composables/useColorMode";
 import { useZoom } from "../composables/useZoom";
 import type { FontOption } from "../utils/fontOptions";
 import { loadHostFontFaces, removeFontFaces } from "../utils/hostFonts";
-import { provideLocale, useTranslation } from "../i18n";
+import { useTranslation } from "../i18n";
 import { provideFolioUI } from "../ui/folio-ui";
 
 const props = withDefaults(defineProps<DocxEditorProps>(), {
@@ -500,15 +499,15 @@ const emit = defineEmits<{
   (e: "comments-change", comments: Comment[]): void;
 }>();
 
-// PORT-BLOCKED: no i18n/locale prop on the fork's DocxEditorProps yet — default to `en`.
-provideLocale();
 // Provide the consumer's UI-injection overrides (or the built-in defaults) to
 // the chrome subtree. Descendant chrome (Toolbar, FormattingBar) resolves the
 // injected primitives via `useFolioUI`, so `components.ColorPicker` etc. take
 // effect. Provided once at setup; the prop is not expected to change identity.
 provideFolioUI(props.components);
-// PORT-BLOCKED: no colorMode prop; share a fixed-light token scope with teleported chrome.
-const isDark = ref(false);
+// Inherit the host's reactive light/dark/system setting. With no provider the
+// composable preserves the editor's existing light default. Teleported chrome
+// receives the same resolved mode through the portal-class provider.
+const isDark = useColorMode();
 provideDocxPortalClass(isDark);
 
 const editorMode = ref<EditorMode>(props.mode);

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -16,6 +16,7 @@
  */
 
 export * from "./useClipboard";
+export * from "./useColorMode";
 export * from "./useDocxEditor";
 export * from "./useDragAutoScroll";
 export * from "./useFindReplace";

--- a/packages/vue/src/composables/useColorMode.ts
+++ b/packages/vue/src/composables/useColorMode.ts
@@ -1,4 +1,15 @@
-import { ref, computed, watchEffect, type ComputedRef } from "vue";
+import {
+  computed,
+  inject,
+  provide,
+  ref,
+  toValue,
+  watchEffect,
+  type App,
+  type ComputedRef,
+  type InjectionKey,
+  type MaybeRefOrGetter,
+} from "vue";
 import {
   prefersColorSchemeDark,
   resolveIsDark,
@@ -6,20 +17,55 @@ import {
   type ColorMode,
 } from "../utils/colorMode";
 
+/** Color mode used when a host does not provide one. */
+export const defaultColorMode: ColorMode = "light";
+
+const COLOR_MODE_KEY: InjectionKey<ComputedRef<ColorMode>> = Symbol("folioColorMode");
+
 /**
- * Resolve the effective dark flag from a reactive `colorMode`. `'system'`
- * follows the OS via `subscribeSystemDark` (SSR-safe; re-syncs on entry).
- * Mirrors the React adapter's inline colorMode logic via the shared core helpers.
+ * Provide a reactive color mode to descendant folio components.
+ *
+ * Call this from a parent component's setup function. For app-wide setup, use
+ * {@link colorModePlugin} instead.
  */
-export function useColorMode(colorMode: () => ColorMode): ComputedRef<boolean> {
+export const provideColorMode = (
+  colorMode: MaybeRefOrGetter<ColorMode> = defaultColorMode,
+): void => {
+  provide(
+    COLOR_MODE_KEY,
+    computed(() => toValue(colorMode)),
+  );
+};
+
+/** Vue plugin form: `app.use(colorModePlugin, "system")`. */
+export const colorModePlugin = {
+  install(app: App, colorMode: MaybeRefOrGetter<ColorMode> = defaultColorMode): void {
+    app.provide(
+      COLOR_MODE_KEY,
+      computed(() => toValue(colorMode)),
+    );
+  },
+};
+
+/**
+ * Resolve the effective dark flag from the inherited color mode. `'system'`
+ * follows the OS via `subscribeSystemDark` (SSR-safe; re-syncs on entry).
+ */
+export function useColorMode(): ComputedRef<boolean> {
+  const colorMode = inject(
+    COLOR_MODE_KEY,
+    computed(() => defaultColorMode),
+  );
   const systemDark = ref(prefersColorSchemeDark());
   watchEffect((onCleanup) => {
-    if (colorMode() !== "system") return;
+    if (colorMode.value !== "system") return;
     onCleanup(
       subscribeSystemDark((dark) => {
         systemDark.value = dark;
       }),
     );
   });
-  return computed(() => resolveIsDark(colorMode(), systemDark.value));
+  return computed(() => resolveIsDark(colorMode.value, systemDark.value));
 }
+
+export type { ColorMode } from "../utils/colorMode";

--- a/packages/vue/src/composables/useColorMode.ts
+++ b/packages/vue/src/composables/useColorMode.ts
@@ -1,6 +1,7 @@
 import {
   computed,
   inject,
+  onMounted,
   provide,
   ref,
   toValue,
@@ -10,12 +11,7 @@ import {
   type InjectionKey,
   type MaybeRefOrGetter,
 } from "vue";
-import {
-  prefersColorSchemeDark,
-  resolveIsDark,
-  subscribeSystemDark,
-  type ColorMode,
-} from "../utils/colorMode";
+import { resolveIsDark, subscribeSystemDark, type ColorMode } from "../utils/colorMode";
 
 /** Color mode used when a host does not provide one. */
 export const defaultColorMode: ColorMode = "light";
@@ -56,16 +52,20 @@ export function useColorMode(): ComputedRef<boolean> {
     COLOR_MODE_KEY,
     computed(() => defaultColorMode),
   );
-  const systemDark = ref(prefersColorSchemeDark());
+  const isMounted = ref(false);
+  const systemDark = ref(false);
+  onMounted(() => {
+    isMounted.value = true;
+  });
   watchEffect((onCleanup) => {
-    if (colorMode.value !== "system") return;
+    if (!isMounted.value || colorMode.value !== "system") return;
     onCleanup(
       subscribeSystemDark((dark) => {
         systemDark.value = dark;
       }),
     );
   });
-  return computed(() => resolveIsDark(colorMode.value, systemDark.value));
+  return computed(() => resolveIsDark(colorMode.value, isMounted.value && systemDark.value));
 }
 
 export type { ColorMode } from "../utils/colorMode";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -65,6 +65,13 @@ export type { ColorPreset, FolioButtonProps, FolioUIComponents, OutlineItem } fr
 // i18n runtime (Vue-specific — React consumes `use-intl` directly). Locale-string
 // types live in the shared catalog; import them from `@stll/folio-core` if needed.
 export { defaultLocale, i18nPlugin, provideLocale, useTranslation } from "./i18n";
+export {
+  colorModePlugin,
+  defaultColorMode,
+  provideColorMode,
+  useColorMode,
+  type ColorMode,
+} from "./composables/useColorMode";
 
 // Wheel/keyboard zoom composable (Vue equivalent of React's `useWheelZoom` hook).
 export { useWheelZoom } from "./composables/useWheelZoom";

--- a/packages/vue/src/renderAsync.ts
+++ b/packages/vue/src/renderAsync.ts
@@ -27,6 +27,7 @@ import type { DocxInput } from "@stll/folio-core/utils/docxInput";
 
 import DocxEditor from "./components/DocxEditor.vue";
 import type { DocxEditorProps, DocxEditorRef } from "./components/DocxEditor/types";
+import { colorModePlugin, defaultColorMode, type ColorMode } from "./composables/useColorMode";
 import { i18nPlugin } from "./i18n";
 
 /** Framework-agnostic handle for an imperatively mounted editor instance. */
@@ -55,6 +56,8 @@ export type DocxEditorHandle = EditorHandle & {
 export type RenderAsyncOptions = Omit<DocxEditorProps, "documentBuffer" | "document"> & {
   /** BCP-47 locale for bundled folio UI strings (default: `en`). */
   locale?: string;
+  /** Editor chrome color mode (default: `light`). */
+  colorMode?: ColorMode;
 };
 
 /**
@@ -68,7 +71,7 @@ export const renderAsync = (
   container: HTMLElement,
   options: RenderAsyncOptions = {},
 ): Promise<DocxEditorHandle> => {
-  const { locale = "en", ...editorOptions } = options;
+  const { colorMode = defaultColorMode, locale = "en", ...editorOptions } = options;
 
   return new Promise<DocxEditorHandle>((resolve, reject) => {
     const editorRef = ref<DocxEditorRef | null>(null);
@@ -135,6 +138,7 @@ export const renderAsync = (
     });
 
     app.use(i18nPlugin, locale);
+    app.use(colorModePlugin, colorMode);
     app.mount(container);
   });
 };

--- a/packages/vue/src/renderAsync.ts
+++ b/packages/vue/src/renderAsync.ts
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { createApp, h, ref, type App } from "vue";
+import { createApp, h, ref, type App, type MaybeRefOrGetter } from "vue";
 
 import type { Document } from "@stll/folio-core/types/document";
 import type { DocxInput } from "@stll/folio-core/utils/docxInput";
@@ -57,7 +57,7 @@ export type RenderAsyncOptions = Omit<DocxEditorProps, "documentBuffer" | "docum
   /** BCP-47 locale for bundled folio UI strings (default: `en`). */
   locale?: string;
   /** Editor chrome color mode (default: `light`). */
-  colorMode?: ColorMode;
+  colorMode?: MaybeRefOrGetter<ColorMode>;
 };
 
 /**

--- a/packages/vue/src/utils/colorMode.ts
+++ b/packages/vue/src/utils/colorMode.ts
@@ -1,8 +1,7 @@
 /**
- * Color-mode resolution shared by every adapter so the light/dark/auto logic
- * (and its SSR + prefers-color-scheme handling) can't drift between hosts. The
- * adapters keep only their framework binding (useState/useEffect vs
- * ref/watchEffect); the rules live here.
+ * Color-mode resolution for the Vue host binding. Pure resolution stays
+ * separate from Vue's provide/inject layer so browser capability checks and
+ * system-preference subscriptions remain independently testable.
  *
  * @packageDocumentation
  */

--- a/scripts/parity/export-divergence.md
+++ b/scripts/parity/export-divergence.md
@@ -41,6 +41,14 @@ Vue-native runtime (no React equivalent — React consumes `use-intl` directly):
 - `provideLocale` — Vue i18n provide helper.
 - `useTranslation` — Vue i18n composable.
 
+Vue-native host color-mode runtime (React inherits its host's CSS token scope):
+
+- `ColorMode` — Vue color-mode setting type.
+- `colorModePlugin` — Vue app-level color-mode provider.
+- `defaultColorMode` — Vue standalone fallback.
+- `provideColorMode` — Vue component-level color-mode provider.
+- `useColorMode` — Vue reactive color-mode binding.
+
 Per-dialog prop/data type aliases (framework-idiom difference, not a port gap):
 React's dialogs are `.tsx` components that export a named props/data type alias
 per dialog from root, so React hosts can type their dialog usage. Vue's dialogs

--- a/tests/parity/vue-host-configuration.spec.ts
+++ b/tests/parity/vue-host-configuration.spec.ts
@@ -1,0 +1,22 @@
+import { test } from "@playwright/test";
+
+import { expect } from "./parity-fixture";
+
+const VUE_PLAYGROUND = "http://localhost:4201";
+
+test("Vue inherits locale and reactive system color mode from the host", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`${VUE_PLAYGROUND}/?file=sample.docx&locale=de&colorMode=system`);
+
+  const editor = page.locator(".docx-editor-vue");
+  await expect(editor).toHaveClass(/\bdark\b/u);
+  await expect(page.getByRole("button", { name: "Datei", exact: true })).toBeVisible();
+
+  const pageContent = page.locator(".layout-page-content").first();
+  await expect(pageContent).toBeVisible();
+  await pageContent.click({ button: "right", position: { x: 40, y: 40 } });
+  await expect(page.locator(".ctx-menu")).toHaveClass(/\bdark\b/u);
+
+  await page.emulateMedia({ colorScheme: "light" });
+  await expect(editor).not.toHaveClass(/\bdark\b/u);
+});


### PR DESCRIPTION
## Summary

- inherit the host locale instead of shadowing it with an editor-local English provider
- add reactive light, dark, and system color-mode providers for the editor root, teleported chrome, and `renderAsync`
- auto-import the color-mode composable in Nuxt and cover provider inheritance in the Vue playground