### PR TITLE
feat: add table column deletion operation

### DIFF
--- a/.changeset/delete-table-columns.md
+++ b/.changeset/delete-table-columns.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add direct table column deletion operations.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -963,6 +963,47 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     };
                     readonly required: readonly ["id", "type", "blockId"];
                     readonly additionalProperties: false;
+                }, {
+                    readonly type: "object";
+                    readonly description: "Delete the column containing the anchor block. Direct mode only.";
+                    readonly properties: {
+                        readonly type: {
+                            readonly type: "string";
+                            readonly enum: readonly ["deleteTableColumn"];
+                        };
+                        readonly blockId: {
+                            readonly type: "string";
+                            readonly description: "Id of the target block, from a prior document read.";
+                        };
+                        readonly id: {
+                            readonly type: "string";
+                            readonly description: string;
+                        };
+                        readonly severity: {
+                            readonly type: "string";
+                            readonly enum: readonly ["low", "medium", "high"];
+                            readonly description: "Optional review severity for structured-review workflows.";
+                        };
+                        readonly area: {
+                            readonly type: "string";
+                            readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+                        };
+                        readonly precondition: {
+                            readonly type: "object";
+                            readonly description: string;
+                            readonly properties: {
+                                readonly blockTextHash: {
+                                    readonly type: "string";
+                                    readonly pattern: "^h[0-9a-z]+$";
+                                    readonly description: "Normalized hash of the target block's text.";
+                                };
+                            };
+                            readonly required: readonly ["blockTextHash"];
+                            readonly additionalProperties: false;
+                        };
+                    };
+                    readonly required: readonly ["id", "type", "blockId"];
+                    readonly additionalProperties: false;
                 }];
             };
         };
@@ -1817,6 +1858,47 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                 readonly items: {
                     readonly type: "string";
                 };
+            };
+            readonly id: {
+                readonly type: "string";
+                readonly description: string;
+            };
+            readonly severity: {
+                readonly type: "string";
+                readonly enum: readonly ["low", "medium", "high"];
+                readonly description: "Optional review severity for structured-review workflows.";
+            };
+            readonly area: {
+                readonly type: "string";
+                readonly description: "Optional review area label (e.g. \"Penalty\") for structured-review workflows.";
+            };
+            readonly precondition: {
+                readonly type: "object";
+                readonly description: string;
+                readonly properties: {
+                    readonly blockTextHash: {
+                        readonly type: "string";
+                        readonly pattern: "^h[0-9a-z]+$";
+                        readonly description: "Normalized hash of the target block's text.";
+                    };
+                };
+                readonly required: readonly ["blockTextHash"];
+                readonly additionalProperties: false;
+            };
+        };
+        readonly required: readonly ["id", "type", "blockId"];
+        readonly additionalProperties: false;
+    }, {
+        readonly type: "object";
+        readonly description: "Delete the column containing the anchor block. Direct mode only.";
+        readonly properties: {
+            readonly type: {
+                readonly type: "string";
+                readonly enum: readonly ["deleteTableColumn"];
+            };
+            readonly blockId: {
+                readonly type: "string";
+                readonly description: "Id of the target block, from a prior document read.";
             };
             readonly id: {
                 readonly type: "string";

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -74,6 +74,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
+    readonly deleteTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -83,7 +84,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn"];
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -227,6 +228,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -340,6 +345,11 @@ export type FolioDocumentOperationAffectedTarget = {
     commentId: number;
 } | {
     type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
+} | {
+    type: "tableColumn";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -442,6 +442,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
+    readonly deleteTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -451,7 +452,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -589,6 +590,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -664,6 +669,11 @@ export type FolioDocumentOperationAffectedTarget = {
     commentId: number;
 } | {
     type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
+} | {
+    type: "tableColumn";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -442,6 +442,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
+    readonly deleteTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -451,7 +452,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn"];
 
 // @public (undocumented)
 export type FolioAIBlock = {
@@ -589,6 +590,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -664,6 +669,11 @@ export type FolioDocumentOperationAffectedTarget = {
     commentId: number;
 } | {
     type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
+} | {
+    type: "tableColumn";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -195,6 +195,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableRow: readonly ["direct"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
+    readonly deleteTableColumn: readonly ["direct"];
 }>;
 
 // @public (undocumented)
@@ -204,7 +205,7 @@ export const FOLIO_DOCUMENT_OPERATION_PRECONDITIONS: readonly ["blockTextHash"];
 export const FOLIO_DOCUMENT_OPERATION_STORIES: readonly ["main", "header", "footer", "footnote", "endnote"];
 
 // @public (undocumented)
-export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn"];
+export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replaceRange", "commentOnRange", "formatRange", "insertAfterBlock", "insertBeforeBlock", "replaceBlock", "deleteBlock", "commentOnBlock", "insertSignatureTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn"];
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
@@ -349,6 +350,10 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     blockId: string;
     position?: "after" | "before"; /** Initial text for newly created physical cells in row order. */
     cellTexts?: string[];
+} | {
+    id: string;
+    type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
+    blockId: string;
 });
 
 // @public (undocumented)
@@ -488,6 +493,11 @@ export type FolioDocumentOperationAffectedTarget = {
     commentId: number;
 } | {
     type: "tableRow";
+    story: FolioDocumentOperationStory;
+    anchorBlockId: string;
+    effect: "deleted";
+} | {
+    type: "tableColumn";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -413,6 +413,11 @@ const CONTRACT_OPERATION_FIXTURES: Record<FolioDocumentOperationType, Record<str
     position: "before",
     cellTexts: ["First", "Second"],
   },
+  deleteTableColumn: {
+    id: "op-delete-table-column",
+    type: "deleteTableColumn",
+    blockId: "0304003A",
+  },
 };
 
 const variantTypeOf = (variant: JsonSchemaNode): unknown => variant.properties?.["type"]?.enum?.[0];

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -382,6 +382,17 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
       required: ["id", "type", "blockId"],
       additionalProperties: false,
     },
+    {
+      type: "object",
+      description: "Delete the column containing the anchor block. Direct mode only.",
+      properties: {
+        ...operationMetaProperties,
+        type: { type: "string", enum: ["deleteTableColumn"] },
+        blockId: blockIdProperty,
+      },
+      required: ["id", "type", "blockId"],
+      additionalProperties: false,
+    },
   ],
 } as const;
 
@@ -415,7 +426,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
         '"direct" applies immediately. `formatRange`, `insertSignatureTable`, `insertTableRow`, ' +
-        '`deleteTableRow`, and `insertTableColumn` support "direct" only.',
+        '`deleteTableRow`, `insertTableColumn`, and `deleteTableColumn` support "direct" only.',
     },
     atomic: {
       type: "boolean",

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -296,6 +296,7 @@ describe("parseSuggestChangesInput", () => {
       "insertTableRow",
       "deleteTableRow",
       "insertTableColumn",
+      "deleteTableColumn",
     ]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -53,7 +53,8 @@ const scopedHandleSchema = {
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
  * - excluded types: `formatRange`, `insertSignatureTable`, `insertTableRow`, `deleteTableRow`,
- *   and `insertTableColumn` (direct-only, not representable as tracked changes for human review)
+ *   `insertTableColumn`, and `deleteTableColumn` (direct-only, not representable as tracked changes
+ *   for human review)
  *   and `commentOnBlock` (covered by the dedicated `add_comment` tool);
  * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
  *   where the contract requires it;
@@ -71,6 +72,7 @@ const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperati
   "insertTableRow",
   "deleteTableRow",
   "insertTableColumn",
+  "deleteTableColumn",
 ]);
 
 /**

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -2314,6 +2314,320 @@ describe("Folio AI edit operations", () => {
     expect(updatedTable.child(2).textContent).toBe("EF");
   });
 
+  test("deletes a column while preserving cells that span it", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", { colspan: 2, colwidth: [100, 200] }, [
+          schema.node("paragraph", { paraId: "delete-column-span" }, [schema.text("A")]),
+        ]),
+        schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text("B")])]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "delete-column-left" }, [schema.text("C")]),
+        ]),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "delete-column-middle" }, [schema.text("D")]),
+        ]),
+        schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text("E")])]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "delete-column",
+          type: "deleteTableColumn",
+          blockId: "delete-column-middle",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result).toEqual({ applied: [{ id: "delete-column" }], skipped: [] });
+    const updatedTable = view.state.doc.child(0);
+    expect(TableMap.get(updatedTable).width).toBe(2);
+    expect(updatedTable.child(0).child(0).attrs["colspan"]).toBe(1);
+    expect(updatedTable.child(0).child(0).attrs["colwidth"]).toEqual([100]);
+    expect(updatedTable.child(0).textContent).toBe("AB");
+    expect(updatedTable.child(1).textContent).toBe("CE");
+  });
+
+  test("targets the nearest column for deletion inside a nested table", () => {
+    const innerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "delete-inner-column" }, [schema.text("Inner A")]),
+        ]),
+        schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text("Inner B")])]),
+      ]),
+    ]);
+    const outerTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", null, [schema.text("Outer")]),
+          innerTable,
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [outerTable]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "delete-inner-column",
+          type: "deleteTableColumn",
+          blockId: "delete-inner-column",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const updatedOuterTable = view.state.doc.child(0);
+    expect(updatedOuterTable.child(0).childCount).toBe(1);
+    const updatedInnerTable = updatedOuterTable.child(0).child(0).child(1);
+    expect(TableMap.get(updatedInnerTable).width).toBe(1);
+    expect(updatedInnerTable.textContent).toBe("Inner B");
+  });
+
+  test("keeps a valid parent when deleting the only table column", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "delete-only-column" }, [schema.text("Cell")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "delete-column",
+          type: "deleteTableColumn",
+          blockId: "delete-only-column",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result).toEqual({ applied: [{ id: "delete-column" }], skipped: [] });
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).type.name).toBe("paragraph");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  test("does not delete an extra column when a batch targets the same column twice", () => {
+    const rows = [
+      ["A", "B"],
+      ["C", "D"],
+    ].map((texts) =>
+      schema.node(
+        "tableRow",
+        null,
+        texts.map((text) =>
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: `duplicate-column-${text}` }, [schema.text(text)]),
+          ]),
+        ),
+      ),
+    );
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+    });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "delete-top", type: "deleteTableColumn", blockId: "duplicate-column-A" },
+        { id: "delete-bottom", type: "deleteTableColumn", blockId: "duplicate-column-C" },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.applied).toEqual([{ id: "delete-top" }]);
+    expect(result.skipped).toEqual([{ id: "delete-bottom", reason: "noopOperation" }]);
+    expect(TableMap.get(view.state.doc.child(0)).width).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("BD");
+  });
+
+  test("recomputes table topology between column deletions in one batch", () => {
+    const rows = [
+      ["A", "B", "C"],
+      ["D", "E", "F"],
+    ].map((texts) =>
+      schema.node(
+        "tableRow",
+        null,
+        texts.map((text) =>
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: `batch-column-${text}` }, [schema.text(text)]),
+          ]),
+        ),
+      ),
+    );
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+    });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "delete-middle", type: "deleteTableColumn", blockId: "batch-column-B" },
+        { id: "delete-right", type: "deleteTableColumn", blockId: "batch-column-C" },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(result.applied.map(({ id }) => id).toSorted()).toEqual([
+      "delete-middle",
+      "delete-right",
+    ]);
+    expect(TableMap.get(view.state.doc.child(0)).width).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("AD");
+  });
+
+  test("keeps insertion and deletion targets stable at the same column boundary", () => {
+    const rows = [
+      ["A", "B"],
+      ["C", "D"],
+    ].map((texts) =>
+      schema.node(
+        "tableRow",
+        null,
+        texts.map((text) =>
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: `mixed-column-${text}` }, [schema.text(text)]),
+          ]),
+        ),
+      ),
+    );
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+    });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "delete-column", type: "deleteTableColumn", blockId: "mixed-column-B" },
+        {
+          id: "insert-column",
+          type: "insertTableColumn",
+          blockId: "mixed-column-B",
+          position: "before",
+          cellTexts: ["New top", "New bottom"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.child(0).child(0).textContent).toBe("ANew top");
+    expect(view.state.doc.child(0).child(1).textContent).toBe("CNew bottom");
+  });
+
+  test("maps column deletion through earlier operations in a mixed batch", () => {
+    const rows = [
+      ["A", "B"],
+      ["C", "D"],
+    ].map((texts) =>
+      schema.node(
+        "tableRow",
+        null,
+        texts.map((text) =>
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: `mapped-column-${text}` }, [schema.text(text)]),
+          ]),
+        ),
+      ),
+    );
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+    });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "delete-column", type: "deleteTableColumn", blockId: "mapped-column-C" },
+        {
+          id: "insert-row",
+          type: "insertTableRow",
+          blockId: "mapped-column-C",
+          cellTexts: ["E", "F"],
+        },
+        {
+          id: "insert-before-table",
+          type: "insertBeforeBlock",
+          blockId: "mapped-column-A",
+          text: "Before table",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.child(0).textContent).toBe("Before table");
+    const updatedTable = view.state.doc.child(1);
+    expect(TableMap.get(updatedTable).width).toBe(1);
+    expect(updatedTable.childCount).toBe(3);
+    expect(updatedTable.textContent).toBe("BDF");
+  });
+
+  test("table-column deletes are skipped in tracked-changes mode", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-delete-column" }, [schema.text("Cell")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "delete-column",
+          type: "deleteTableColumn",
+          blockId: "tracked-delete-column",
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "delete-column", reason: "unsupportedMode" }],
+    });
+    expect(view.state.doc.child(0).child(0).childCount).toBe(1);
+  });
+
   test("table-column inserts are skipped in tracked-changes mode", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -2,6 +2,7 @@ import type { Mark, Node as PMNode, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import {
   columnIsHeader,
+  removeColumn,
   removeRow,
   rowIsHeader,
   TableMap,
@@ -66,6 +67,7 @@ type ResolvedOperation = {
   tableRowInsertion?: TableRowInsertion;
   tableRowDeletion?: TableRowDeletion;
   tableColumnInsertion?: TableColumnInsertion;
+  tableColumnDeletion?: TableColumnDeletion;
   commentId?: number;
   /**
    * Position in the input `operations` array, used as a secondary
@@ -246,6 +248,21 @@ type TableColumnInsertion = {
   columnIndex: number;
 };
 
+type TableColumnDeletion = TableColumnInsertion;
+
+const getTableColumnCoordinateKey = ({
+  tablePosition,
+  columnIndex,
+}: TableColumnInsertion): string => `${tablePosition}:${columnIndex}`;
+
+type TableCellTarget = {
+  tablePosition: number;
+  cellPosition: number;
+  cellEndPosition: number;
+  leftColumnIndex: number;
+  rightColumnIndex: number;
+};
+
 const findEnclosingTableRow = (doc: PMNode, blockFrom: number): TableRowTarget | null => {
   const resolved = doc.resolve(blockFrom);
   for (let rowDepth = resolved.depth; rowDepth > 0; rowDepth--) {
@@ -268,11 +285,7 @@ const findEnclosingTableRow = (doc: PMNode, blockFrom: number): TableRowTarget |
   return null;
 };
 
-const findTableColumnInsertion = (
-  doc: PMNode,
-  blockFrom: number,
-  position: "after" | "before",
-): (TableColumnInsertion & { boundaryPosition: number }) | null => {
+const findEnclosingTableCell = (doc: PMNode, blockFrom: number): TableCellTarget | null => {
   const resolved = doc.resolve(blockFrom);
   for (let cellDepth = resolved.depth; cellDepth > 0; cellDepth--) {
     const cell = resolved.node(cellDepth);
@@ -297,14 +310,32 @@ const findTableColumnInsertion = (
     const cellRect = TableMap.get(table).findCell(cellPosition - tableStart);
     return {
       tablePosition: resolved.before(tableDepth),
-      columnIndex: position === "before" ? cellRect.left : cellRect.right,
-      boundaryPosition: position === "before" ? cellPosition : cellPosition + cell.nodeSize,
+      cellPosition,
+      cellEndPosition: cellPosition + cell.nodeSize,
+      leftColumnIndex: cellRect.left,
+      rightColumnIndex: cellRect.right,
     };
   }
   return null;
 };
 
-const deleteSoleTableRow = (
+const findTableColumnInsertion = (
+  doc: PMNode,
+  blockFrom: number,
+  position: "after" | "before",
+): (TableColumnInsertion & { boundaryPosition: number }) | null => {
+  const target = findEnclosingTableCell(doc, blockFrom);
+  if (!target) {
+    return null;
+  }
+  return {
+    tablePosition: target.tablePosition,
+    columnIndex: position === "before" ? target.leftColumnIndex : target.rightColumnIndex,
+    boundaryPosition: position === "before" ? target.cellPosition : target.cellEndPosition,
+  };
+};
+
+const deleteTableNode = (
   tr: Transaction,
   tablePosition: number,
   table: PMNode,
@@ -707,6 +738,7 @@ const applyFolioAIEditOperationsInternal = ({
   const deletionType = view.state.schema.marks["deletion"];
   const commentType = view.state.schema.marks["comment"];
   const claimedTableRows = new Set<string>();
+  const claimedTableColumns = new Set<string>();
 
   if (mode === "tracked-changes" && (!insertionType || !deletionType)) {
     return {
@@ -731,7 +763,8 @@ const applyFolioAIEditOperationsInternal = ({
       (operation.type === "formatRange" ||
         operation.type === "insertTableRow" ||
         operation.type === "deleteTableRow" ||
-        operation.type === "insertTableColumn")
+        operation.type === "insertTableColumn" ||
+        operation.type === "deleteTableColumn")
     ) {
       skipped.push({ id: operation.id, reason: "unsupportedMode" });
       continue;
@@ -764,6 +797,16 @@ const applyFolioAIEditOperationsInternal = ({
       claimedTableRows.add(rowKey);
     }
 
+    const columnDeletion = resolution.operation.tableColumnDeletion;
+    if (columnDeletion) {
+      const columnKey = getTableColumnCoordinateKey(columnDeletion);
+      if (claimedTableColumns.has(columnKey)) {
+        skipped.push({ id: operation.id, reason: "noopOperation" });
+        continue;
+      }
+      claimedTableColumns.add(columnKey);
+    }
+
     const commentId = commentText !== undefined ? createCommentId?.(commentText) : undefined;
     resolved.push({
       ...resolution.operation,
@@ -779,16 +822,17 @@ const applyFolioAIEditOperationsInternal = ({
   let tr = view.state.tr;
   let revisionSeed = revisionIdSeed ?? nextRevisionSeed(resolved.length);
   const date = new Date().toISOString();
+  const insertedColumnCounts = new Map<string, number>();
 
-  // Sort right-to-left so each tr.insert / tr.delete leaves
-  // earlier positions intact. For ties on `from` we order by
-  // `originalIndex` DESC: applied in reverse, that means the
-  // earlier-listed op lands at the original anchor and the later
-  // one ends up immediately after it, matching the AI's logical
-  // sequence.
+  // Sort right-to-left so each tr.insert / tr.delete leaves earlier
+  // positions intact. Column insertions run before deletions at the
+  // same snapshot coordinate; the deletion path accounts for those
+  // inserted columns so it still removes the original target. Other
+  // ties use reverse input order so repeated insertions retain their
+  // requested sequence.
   for (const item of resolved.toSorted((left, right) => {
-    const leftColumn = left.tableColumnInsertion;
-    const rightColumn = right.tableColumnInsertion;
+    const leftColumn = left.tableColumnInsertion ?? left.tableColumnDeletion;
+    const rightColumn = right.tableColumnInsertion ?? right.tableColumnDeletion;
     if (!leftColumn && rightColumn) {
       return -1;
     }
@@ -801,6 +845,11 @@ const applyFolioAIEditOperationsInternal = ({
       }
       if (leftColumn.columnIndex !== rightColumn.columnIndex) {
         return rightColumn.columnIndex - leftColumn.columnIndex;
+      }
+      const leftIsInsertion = left.tableColumnInsertion !== undefined;
+      const rightIsInsertion = right.tableColumnInsertion !== undefined;
+      if (leftIsInsertion !== rightIsInsertion) {
+        return leftIsInsertion ? -1 : 1;
       }
       return right.originalIndex - left.originalIndex;
     }
@@ -1106,6 +1155,61 @@ const applyFolioAIEditOperationsInternal = ({
           }
           tr = tr.setNodeMarkup(position, undefined, action.attrs);
         }
+        const columnKey = getTableColumnCoordinateKey(insertion);
+        insertedColumnCounts.set(columnKey, (insertedColumnCounts.get(columnKey) ?? 0) + 1);
+        break;
+      }
+      case "deleteTableColumn": {
+        const deletion = item.tableColumnDeletion;
+        const tablePosition = deletion ? tr.mapping.map(deletion.tablePosition, 1) : null;
+        const table = tablePosition === null ? null : tr.doc.nodeAt(tablePosition);
+        if (
+          !deletion ||
+          tablePosition === null ||
+          !table ||
+          table.type.spec["tableRole"] !== "table"
+        ) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        const map = TableMap.get(table);
+        const columnKey = getTableColumnCoordinateKey(deletion);
+        const columnIndex = deletion.columnIndex + (insertedColumnCounts.get(columnKey) ?? 0);
+        if (columnIndex < 0 || columnIndex >= map.width) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
+        if (map.width === 1) {
+          const nextTr = deleteTableNode(tr, tablePosition, table);
+          if (!nextTr) {
+            skipped.push({
+              id: item.operation.id,
+              reason: "unsupportedBlock",
+            });
+            continue;
+          }
+          tr = nextTr;
+          break;
+        }
+        removeColumn(
+          tr,
+          {
+            map,
+            table,
+            tableStart: tablePosition + 1,
+            left: columnIndex,
+            top: 0,
+            right: columnIndex + 1,
+            bottom: map.height,
+          },
+          columnIndex,
+        );
         break;
       }
       case "deleteTableRow": {
@@ -1124,7 +1228,7 @@ const applyFolioAIEditOperationsInternal = ({
           continue;
         }
         if (table.childCount === 1) {
-          const nextTr = deleteSoleTableRow(tr, deletion.tablePosition, table);
+          const nextTr = deleteTableNode(tr, deletion.tablePosition, table);
           if (!nextTr) {
             skipped.push({
               id: item.operation.id,
@@ -1665,6 +1769,28 @@ const resolveOperation = ({
         blockTo,
         blockNode,
         tableColumnInsertion,
+      },
+    };
+  }
+
+  if (operation.type === "deleteTableColumn") {
+    const target = findEnclosingTableCell(doc, blockFrom);
+    if (!target) {
+      return { type: "skip", reason: "unsupportedBlock" };
+    }
+    return {
+      type: "resolved",
+      operation: {
+        operation,
+        from: target.cellPosition,
+        to: target.cellPosition,
+        blockFrom,
+        blockTo,
+        blockNode,
+        tableColumnDeletion: {
+          tablePosition: target.tablePosition,
+          columnIndex: target.leftColumnIndex,
+        },
       },
     };
   }

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -446,6 +446,88 @@ describe("headless docx review round-trip", () => {
     expect(restoredTable.rows.at(0)?.cells).toHaveLength(1);
   });
 
+  test("deletes, persists, and undoes a column inside shape text", async () => {
+    const baseline = await buildTextBoxTableDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const rejected = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      atomic: true,
+      operations: [
+        {
+          id: "delete-column",
+          type: "deleteTableColumn",
+          blockId: target.id,
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+
+    expect(rejected.status).toBe("rejected");
+    expect(rejected.applied).toEqual([]);
+    expect(reviewer.getContentAsText()).toContain("Cell value");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "delete-column",
+          type: "deleteTableColumn",
+          blockId: target.id,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.applied).toEqual([{ id: "delete-column" }]);
+    expect(result.receipts).toEqual([
+      {
+        operationId: "delete-column",
+        operationIndex: 0,
+        affected: [
+          {
+            type: "tableColumn",
+            story: "main",
+            anchorBlockId: target.id,
+            effect: "deleted",
+          },
+        ],
+      },
+    ]);
+
+    const saved = await reviewer.toBuffer();
+    const reparsed = await parseDocx(saved, { detectVariables: false, preloadFonts: false });
+    expect(findTextBoxShape(reparsed).textBody?.content.map(({ type }) => type)).toEqual([
+      "paragraph",
+      "paragraph",
+    ]);
+    expect((await FolioDocxReviewer.fromBuffer(saved)).getContentAsText()).not.toContain(
+      "Cell value",
+    );
+
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle)).toEqual({
+      status: "undone",
+      undoHandle: result.undoHandle,
+    });
+    expect(reviewer.getContentAsText()).toContain("Cell value");
+    const restored = await parseDocx(await reviewer.toBuffer(), {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    const restoredTable = findTextBoxShape(restored).textBody?.content.at(1);
+    expect(restoredTable?.type).toBe("table");
+    if (restoredTable?.type !== "table") {
+      throw new Error("expected a nested table");
+    }
+    expect(restoredTable.rows.at(0)?.cells).toHaveLength(1);
+  });
+
   test("edits a header through story-scoped document operations", async () => {
     const baseline = await makeHeaderFooterBaseline();
     const story = { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const;

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -246,6 +246,12 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         /** Initial text for newly created physical cells in row order. */
         cellTexts?: string[];
       }
+    | {
+        id: string;
+        type: "deleteTableColumn";
+        /** Stable paragraph anchor inside the column to delete. */
+        blockId: string;
+      }
   );
 
 export type FolioAIEditApplyMode = "direct" | "tracked-changes";

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -34,6 +34,7 @@ describe("document operation contract", () => {
         "insertTableRow",
         "deleteTableRow",
         "insertTableColumn",
+        "deleteTableColumn",
       ],
       modes: ["direct", "tracked-changes"],
       batchModes: ["best-effort", "atomic"],
@@ -52,6 +53,7 @@ describe("document operation contract", () => {
         insertTableRow: ["direct"],
         deleteTableRow: ["direct"],
         insertTableColumn: ["direct"],
+        deleteTableColumn: ["direct"],
       },
       preconditions: ["blockTextHash"],
       stories: ["main", "header", "footer", "footnote", "endnote"],
@@ -66,6 +68,7 @@ describe("document operation contract", () => {
     );
     expect(isFolioDocumentOperationModeSupported("deleteTableRow", "tracked-changes")).toBe(false);
     expect(isFolioDocumentOperationModeSupported("insertTableColumn", "direct")).toBe(true);
+    expect(isFolioDocumentOperationModeSupported("deleteTableColumn", "direct")).toBe(true);
     expect(
       Reflect.apply(isFolioDocumentOperationModeSupported, null, ["unknownOperation", "direct"]),
     ).toBe(false);
@@ -125,6 +128,7 @@ describe("document operation contract", () => {
         blockId: "paragraph-8",
         cellTexts: ["A", "B"],
       },
+      { id: "delete-column", type: "deleteTableColumn", blockId: "paragraph-9" },
     ] as const satisfies readonly FolioDocumentOperation[];
 
     expect(
@@ -138,6 +142,7 @@ describe("document operation contract", () => {
         { id: "row" },
         { id: "delete-row" },
         { id: "column" },
+        { id: "delete-column" },
       ]),
     ).toEqual([
       {
@@ -242,6 +247,18 @@ describe("document operation contract", () => {
           },
         ],
       },
+      {
+        operationId: "delete-column",
+        operationIndex: 9,
+        affected: [
+          {
+            type: "tableColumn",
+            story: "main",
+            anchorBlockId: "paragraph-9",
+            effect: "deleted",
+          },
+        ],
+      },
     ]);
   });
 
@@ -314,6 +331,7 @@ describe("document operation contract", () => {
           position: "before",
           cellTexts: ["Top", "Bottom"],
         },
+        { id: "11", type: "deleteTableColumn", blockId: "a" },
       ],
     };
 

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -34,6 +34,7 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES = Object.freeze([
   "insertTableRow",
   "deleteTableRow",
   "insertTableColumn",
+  "deleteTableColumn",
 ] as const satisfies readonly FolioAIEditOperation["type"][]);
 
 export const FOLIO_DOCUMENT_OPERATION_MODES = Object.freeze([
@@ -78,6 +79,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   insertTableRow: DIRECT_ONLY_MODES,
   deleteTableRow: DIRECT_ONLY_MODES,
   insertTableColumn: DIRECT_ONLY_MODES,
+  deleteTableColumn: DIRECT_ONLY_MODES,
 } as const satisfies Readonly<
   Record<FolioDocumentOperationType, readonly FolioDocumentOperationMode[]>
 >);
@@ -623,6 +625,11 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
     };
   }
 
+  if (type === "deleteTableColumn") {
+    assertAllowedKeys(value, path, COMMON_OPERATION_KEYS);
+    return { ...operationMeta, id, type, blockId };
+  }
+
   return invalidBatch(`${path}.type`, `unsupported operation type "${type}"`);
 };
 
@@ -712,6 +719,12 @@ export type FolioDocumentOperationAffectedTarget =
     }
   | {
       type: "tableRow";
+      story: FolioDocumentOperationStory;
+      anchorBlockId: string;
+      effect: "deleted";
+    }
+  | {
+      type: "tableColumn";
       story: FolioDocumentOperationStory;
       anchorBlockId: string;
       effect: "deleted";
@@ -880,6 +893,13 @@ const getPrimaryAffectedTarget = (
         anchorBlockId: operation.blockId,
         position: operation.position ?? "after",
         content: "tableColumn",
+      };
+    case "deleteTableColumn":
+      return {
+        type: "tableColumn",
+        story,
+        anchorBlockId: operation.blockId,
+        effect: "deleted",
       };
   }
 };


### PR DESCRIPTION
Adds direct table column deletion through the versioned contract.

Preserves merged-cell topology and nested targeting.

Covers batching, receipts, persistence, and undo.