### PR TITLE
fix: preserve text boxes in inline content controls

### DIFF
--- a/.changeset/calm-controls-hold.md
+++ b/.changeset/calm-controls-hold.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve text boxes nested inside inline DOCX content controls through editing and save.

--- a/.changeset/calm-controls-hold.md
+++ b/.changeset/calm-controls-hold.md
@@ -1,5 +1,6 @@
 ---
+"@stll/docx-core": patch
 "@stll/folio-core": patch
 ---
 
-Preserve text boxes nested inside inline DOCX content controls through editing and save.
+Preserve text boxes nested inside inline DOCX content controls, including tracked moves, through editing and save.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -454,6 +454,8 @@ export type TextBoxAttrs = {
         type: "moveTo";
         info: import__stll_docx_core_model.TrackedChangeInfo;
     };
+    /** Original inline content-control ancestry for save-path reconstruction. */
+    _docxInlineSdts?: SdtAttrs[];
 };
 
 // @public

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -467,7 +467,7 @@ export type ImageWrap = {
 export type InlineSdt = {
     type: "inlineSdt"; /** SDT properties */
     properties: SdtProperties; /** Inline content held inside the control */
-    content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | Insertion | Deletion | MathEquation)[];
+    content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | Insertion | Deletion | MoveFrom | MoveTo | MathEquation)[];
 };
 
 // @public

--- a/packages/core/src/docx/documentParser.test.ts
+++ b/packages/core/src/docx/documentParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { Paragraph } from "../types/document";
+import type { Paragraph, Run } from "../types/document";
 import { parseDocumentBody } from "./documentParser";
 import { parseNumbering } from "./numberingParser";
 
@@ -385,6 +385,50 @@ describe("parseDocumentBody text box enrichment", () => {
     expect(shape.shape.textBody?.content.at(0)).toMatchObject({
       type: "paragraph",
       content: [{ type: "run", content: [{ type: "text", text: "Tracked text box" }] }],
+    });
+  });
+
+  test("enriches text boxes across inline content-control segments", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <w:body>
+    <w:p w14:paraId="TXB00004">
+      <w:sdt>
+        <w:sdtPr><w:alias w:val="Summary"/><w:tag w:val="summary"/><w:richText/></w:sdtPr>
+        <w:sdtContent>
+          <w:r><w:t>Before</w:t></w:r>
+          <w:bookmarkStart w:id="7" w:name="inside-control"/>
+          <w:r>${textBoxDrawingXml("Controlled text box")}</w:r>
+          <w:bookmarkEnd w:id="7"/>
+          <w:r><w:t>After</w:t></w:r>
+        </w:sdtContent>
+      </w:sdt>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const controlledRuns = paragraph.content.flatMap((content) =>
+      content.type === "inlineSdt"
+        ? content.content.filter((item): item is Run => item.type === "run")
+        : [],
+    );
+    const shapes = controlledRuns.flatMap((run) =>
+      run.content.filter((content) => content.type === "shape"),
+    );
+
+    expect(shapes).toHaveLength(1);
+    expect(shapes.at(0)?.shape.textBody?.content.at(0)).toMatchObject({
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text: "Controlled text box" }] }],
     });
   });
 

--- a/packages/core/src/docx/inlineSdtTextBoxes.test.ts
+++ b/packages/core/src/docx/inlineSdtTextBoxes.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import type { InlineSdt, Paragraph, Run } from "../types/document";
+import { parseDocx } from "./parser";
+import { createEmptyDocx, repackDocx } from "./rezip";
+
+const textBoxDrawingXml = `
+  <w:drawing>
+    <wp:inline>
+      <wp:extent cx="1828800" cy="914400"/>
+      <wp:docPr id="11" name="Text Box 11"/>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+          <wps:wsp>
+            <wps:spPr>
+              <a:xfrm><a:off x="0" y="0"/><a:ext cx="1828800" cy="914400"/></a:xfrm>
+              <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            </wps:spPr>
+            <wps:txbx>
+              <w:txbxContent>
+                <w:p><w:r><w:t>Controlled text box</w:t></w:r></w:p>
+              </w:txbxContent>
+            </wps:txbx>
+            <wps:bodyPr/>
+          </wps:wsp>
+        </a:graphicData>
+      </a:graphic>
+    </wp:inline>
+  </w:drawing>`;
+
+const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <w:body>
+    <w:p>
+      <w:sdt>
+        <w:sdtPr><w:alias w:val="Outer"/><w:richText/></w:sdtPr>
+        <w:sdtContent>
+          <w:r><w:t>Before </w:t></w:r>
+          <w:sdt>
+            <w:sdtPr><w:alias w:val="Inner"/><w:tag w:val="inner"/><w:richText/></w:sdtPr>
+            <w:sdtContent><w:r>${textBoxDrawingXml}</w:r></w:sdtContent>
+          </w:sdt>
+          <w:r><w:t> after</w:t></w:r>
+        </w:sdtContent>
+      </w:sdt>
+    </w:p>
+    <w:sectPr/>
+  </w:body>
+</w:document>`;
+
+const createSource = async (): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  zip.file("word/document.xml", documentXml);
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const firstParagraph = (document: Awaited<ReturnType<typeof parseDocx>>): Paragraph => {
+  const paragraph = document.package.document.content.at(0);
+  if (paragraph?.type !== "paragraph") {
+    throw new Error("Expected paragraph");
+  }
+  return paragraph;
+};
+
+const firstInlineSdt = (content: Paragraph["content"] | InlineSdt["content"]): InlineSdt => {
+  const sdt = content.find((item) => item.type === "inlineSdt");
+  if (sdt?.type !== "inlineSdt") {
+    throw new Error("Expected inline content control");
+  }
+  return sdt;
+};
+
+const textBoxRuns = (sdt: InlineSdt): Run[] =>
+  sdt.content.filter(
+    (item): item is Run =>
+      item.type === "run" &&
+      item.content.some((content) => content.type === "shape" && content.shape.textBody),
+  );
+
+describe("inline content-control text boxes", () => {
+  test("preserves nested controls and drawings through the editor save path", async () => {
+    const source = await createSource();
+    const parsed = await parseDocx(source, { detectVariables: false, preloadFonts: false });
+    const outer = firstInlineSdt(firstParagraph(parsed).content);
+    const inner = firstInlineSdt(outer.content);
+
+    expect(textBoxRuns(inner)).toHaveLength(1);
+
+    const pmDocument = toProseDoc(parsed);
+    expect(pmDocument.childCount).toBe(2);
+    expect(pmDocument.child(1).type.name).toBe("textBox");
+    expect(pmDocument.child(1).attrs["_docxInlineSdts"]).toMatchObject([
+      { sdtType: "richText", alias: "Outer" },
+      { sdtType: "richText", alias: "Inner", tag: "inner" },
+    ]);
+
+    const saved = await repackDocx(fromProseDoc(pmDocument, parsed), {
+      updateModifiedDate: false,
+    });
+    const savedZip = await JSZip.loadAsync(saved);
+    const savedXml = await savedZip.file("word/document.xml")?.async("text");
+    expect(savedXml?.match(/<w:sdt>/gu)).toHaveLength(2);
+    expect(savedXml).toContain("<wps:txbx>");
+
+    const reparsed = await parseDocx(saved, {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    const reparsedOuter = firstInlineSdt(firstParagraph(reparsed).content);
+    const reparsedInner = firstInlineSdt(reparsedOuter.content);
+    expect(textBoxRuns(reparsedInner)).toHaveLength(1);
+  });
+});

--- a/packages/core/src/docx/inlineSdtTrackedChanges.test.ts
+++ b/packages/core/src/docx/inlineSdtTrackedChanges.test.ts
@@ -49,6 +49,45 @@ const reviewedDocument = (): Document => {
   };
 };
 
+const movedDocument = (): Document => {
+  const template = createEmptyDocument();
+  return {
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "inlineSdt",
+                properties: {
+                  sdtType: "richText",
+                  alias: "Moved clause",
+                },
+                content: [
+                  {
+                    type: "moveFrom",
+                    info: { id: 3, author: "Reviewer", date: "2026-07-16T08:00:00Z" },
+                    content: [{ type: "run", content: [{ type: "text", text: "old" }] }],
+                  },
+                  {
+                    type: "moveTo",
+                    info: { id: 4, author: "Reviewer", date: "2026-07-16T08:01:00Z" },
+                    content: [{ type: "run", content: [{ type: "text", text: "new" }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+};
+
 const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
   const zip = await JSZip.loadAsync(buffer);
   const part = zip.file("word/document.xml");
@@ -100,6 +139,18 @@ describe("inline content-control tracked changes", () => {
 
     const parsed = await parsedInlineSdt(buffer);
     expect(parsed.content.map((content) => content.type)).toEqual(["run", "deletion", "insertion"]);
+  });
+
+  test("round-trips move wrappers inside w:sdtContent", async () => {
+    const buffer = await createDocx(movedDocument());
+    const xml = await documentXml(buffer);
+    const sdtContent = xml.match(/<w:sdtContent>([\s\S]*?)<\/w:sdtContent>/u)?.at(1) ?? "";
+
+    expect(sdtContent).toContain("<w:moveFrom ");
+    expect(sdtContent).toContain("<w:moveTo ");
+
+    const parsed = await parsedInlineSdt(buffer);
+    expect(parsed.content.map((content) => content.type)).toEqual(["moveFrom", "moveTo"]);
   });
 
   test("accept and reject keep the content control with the correct text", async () => {

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1018,7 +1018,7 @@ function isTrackedChangeWrapperChild(content: ParagraphContent): content is Run 
 
 // Mirror of upstream eigenpal/docx-editor PR #482 (commit 29f95751d):
 // OOXML allows runs, hyperlinks, simple/complex fields, nested SDTs,
-// tracked insertions/deletions, and math equations directly inside
+// tracked insertions/deletions/moves, and math equations directly inside
 // `<w:sdtContent>`. Anything else that the paragraph parser produced
 // (bookmarks, comment markers, tracked-change range markers, ...) is
 // lifted out as a sibling of the SDT so the SDT wrapper itself stays
@@ -1032,6 +1032,8 @@ function isInlineSdtContent(content: ParagraphContent): content is InlineSdt["co
     content.type === "inlineSdt" ||
     content.type === "insertion" ||
     content.type === "deletion" ||
+    content.type === "moveFrom" ||
+    content.type === "moveTo" ||
     content.type === "mathEquation"
   );
 }

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -1,5 +1,6 @@
 import type {
   ImagePosition,
+  InlineSdt,
   MediaFile,
   Paragraph,
   ParagraphContent,
@@ -210,6 +211,9 @@ const enrichTextBoxRuns = ({
 
   for (const xmlChild of xmlChildren) {
     const localName = getLocalName(xmlChild.name ?? "");
+    if (localName === "pPr") {
+      continue;
+    }
     const trackedChangeType = trackedChangeTypeFromXml(localName);
     const parsedContent = content[parsedIndex];
     if (trackedChangeType && parsedContent?.type === trackedChangeType) {
@@ -223,6 +227,39 @@ const enrichTextBoxRuns = ({
         media,
         parseTable,
       });
+    }
+
+    if (localName === "sdt" && parsedContent?.type === "inlineSdt") {
+      const properties = parsedContent.properties;
+      const nestedContent: InlineSdt["content"] = [];
+      let lastSegmentIndex = parsedIndex;
+
+      for (let index = parsedIndex; index < content.length; index += 1) {
+        const candidate = content[index];
+        if (candidate?.type !== "inlineSdt" || candidate.properties !== properties) {
+          continue;
+        }
+        nestedContent.push(...candidate.content);
+        lastSegmentIndex = index;
+      }
+
+      const sdtContent = getChildElements(xmlChild).find(
+        (child) => getLocalName(child.name ?? "") === "sdtContent",
+      );
+      if (sdtContent) {
+        enrichTextBoxRuns({
+          content: nestedContent,
+          xmlChildren: getChildElements(sdtContent),
+          styles,
+          theme,
+          numbering,
+          rels,
+          media,
+          parseTable,
+        });
+      }
+      parsedIndex = lastSegmentIndex + 1;
+      continue;
     }
 
     if (localName !== "r") {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -869,6 +869,10 @@ function serializeInlineSdt(sdt: InlineSdt): string {
           return serializeTrackedChange("ins", item);
         case "deletion":
           return serializeTrackedChange("del", item);
+        case "moveFrom":
+          return serializeTrackedChange("moveFrom", item);
+        case "moveTo":
+          return serializeTrackedChange("moveTo", item);
         case "mathEquation":
           // Round-trip the raw OMML XML directly
           return item.ommlXml || "";

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -364,6 +364,7 @@ describe("ProseMirror attr readers", () => {
       wrapType: "sideways",
       position: { vertical: { relativeTo: "ceiling" } },
       _docxTrackedChange: { type: "replacement", info: { id: "41", author: 7 } },
+      _docxInlineSdts: [{ sdtType: "custom", id: "forty-two" }],
     });
 
     const shapeResult = readShapeAttrs(shape);
@@ -399,6 +400,12 @@ describe("ProseMirror attr readers", () => {
       );
       expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
         "textBox.attrs._docxTrackedChange.info.author",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs._docxInlineSdts[0].sdtType",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs._docxInlineSdts[0].id",
       );
     }
   });

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -587,21 +587,7 @@ export const readSdtAttrs = (node: PMNode): ReadProseMirrorAttrsResult<SdtAttrs>
   const attrs = attrsRecord(node.attrs);
   const issues: ProseMirrorAttrIssue[] = [];
   expectNodeType(node, "sdt", issues);
-
-  requiredOneOf(attrs, "sdtType", "sdt.attrs.sdtType", issues, SDT_TYPE_VALUES);
-  optionalString(attrs, "alias", "sdt.attrs.alias", issues);
-  optionalString(attrs, "tag", "sdt.attrs.tag", issues);
-  optionalNumber(attrs, "id", "sdt.attrs.id", issues);
-  optionalOneOf(attrs, "lock", "sdt.attrs.lock", issues, SDT_LOCK_VALUES);
-  optionalString(attrs, "placeholder", "sdt.attrs.placeholder", issues);
-  optionalBoolean(attrs, "showingPlaceholder", "sdt.attrs.showingPlaceholder", issues);
-  optionalString(attrs, "dateFormat", "sdt.attrs.dateFormat", issues);
-  optionalString(attrs, "dateValueISO", "sdt.attrs.dateValueISO", issues);
-  optionalSdtListItems(attrs, "listItems", "sdt.attrs.listItems", issues);
-  optionalString(attrs, "dropdownLastValue", "sdt.attrs.dropdownLastValue", issues);
-  optionalBoolean(attrs, "checked", "sdt.attrs.checked", issues);
-  optionalString(attrs, "rawPropertiesXml", "sdt.attrs.rawPropertiesXml", issues);
-  optionalString(attrs, "rawEndPropertiesXml", "sdt.attrs.rawEndPropertiesXml", issues);
+  validateSdtAttrsRecord(attrs, "sdt.attrs", issues);
 
   return attrsResult(attrs, issues);
 };
@@ -741,6 +727,7 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
   );
   optionalString(attrs, "_docxGroupId", "textBox.attrs._docxGroupId", issues);
   optionalTextBoxTrackedChange(attrs, issues);
+  optionalTextBoxInlineSdts(attrs, issues);
 
   return attrsResult(attrs, issues);
 };
@@ -1567,6 +1554,49 @@ const optionalTextBoxTrackedChange = (
   requiredNumber(info, "id", "textBox.attrs._docxTrackedChange.info.id", issues);
   requiredString(info, "author", "textBox.attrs._docxTrackedChange.info.author", issues);
   optionalString(info, "date", "textBox.attrs._docxTrackedChange.info.date", issues);
+};
+
+const optionalTextBoxInlineSdts = (
+  attrs: Record<string, unknown>,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs["_docxInlineSdts"];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    issues.push({ path: "textBox.attrs._docxInlineSdts", message: "Expected an array." });
+    return;
+  }
+  for (const [index, item] of value.entries()) {
+    const path = `textBox.attrs._docxInlineSdts[${index}]`;
+    if (!isRecord(item)) {
+      issues.push({ path, message: "Expected an object." });
+      continue;
+    }
+    validateSdtAttrsRecord(item, path, issues);
+  }
+};
+
+const validateSdtAttrsRecord = (
+  attrs: Record<string, unknown>,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  requiredOneOf(attrs, "sdtType", `${path}.sdtType`, issues, SDT_TYPE_VALUES);
+  optionalString(attrs, "alias", `${path}.alias`, issues);
+  optionalString(attrs, "tag", `${path}.tag`, issues);
+  optionalNumber(attrs, "id", `${path}.id`, issues);
+  optionalOneOf(attrs, "lock", `${path}.lock`, issues, SDT_LOCK_VALUES);
+  optionalString(attrs, "placeholder", `${path}.placeholder`, issues);
+  optionalBoolean(attrs, "showingPlaceholder", `${path}.showingPlaceholder`, issues);
+  optionalString(attrs, "dateFormat", `${path}.dateFormat`, issues);
+  optionalString(attrs, "dateValueISO", `${path}.dateValueISO`, issues);
+  optionalSdtListItems(attrs, "listItems", `${path}.listItems`, issues);
+  optionalString(attrs, "dropdownLastValue", `${path}.dropdownLastValue`, issues);
+  optionalBoolean(attrs, "checked", `${path}.checked`, issues);
+  optionalString(attrs, "rawPropertiesXml", `${path}.rawPropertiesXml`, issues);
+  optionalString(attrs, "rawEndPropertiesXml", `${path}.rawEndPropertiesXml`, issues);
 };
 
 const optionalAutospacingBase = (

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -1595,6 +1595,113 @@ describe("fromProseDoc", () => {
     },
   );
 
+  test("round-trips text boxes through nested inline content controls", () => {
+    const document = documentWithTextBoxParagraph({ includeText: false });
+    const paragraph = document.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const textBoxRun = paragraph.content.at(0);
+    if (textBoxRun?.type !== "run") {
+      throw new Error("Expected text-box run");
+    }
+    paragraph.content = [
+      {
+        type: "inlineSdt",
+        properties: {
+          sdtType: "richText",
+          alias: "Outer",
+          rawPropertiesXml: '<w:sdtPr><w:alias w:val="Outer"/><w:richText/></w:sdtPr>',
+        },
+        content: [
+          { type: "run", content: [{ type: "text", text: "Before " }] },
+          {
+            type: "inlineSdt",
+            properties: { sdtType: "plainText", alias: "Inner", tag: "inner" },
+            content: [
+              { type: "run", content: [{ type: "text", text: "inside " }] },
+              textBoxRun,
+              { type: "run", content: [{ type: "text", text: " after" }] },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const pmDoc = toProseDoc(document);
+    const textBoxNode = pmDoc.child(1);
+    expect(pmDoc.childCount).toBe(2);
+    expect(pmDoc.child(0).type.name).toBe("paragraph");
+    expect(textBoxNode.type.name).toBe("textBox");
+    expect(textBoxNode.attrs["_docxInlineSdts"]).toMatchObject([
+      { sdtType: "richText", alias: "Outer" },
+      { sdtType: "plainText", alias: "Inner", tag: "inner" },
+    ]);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+    const outer = block.content.at(0);
+    if (outer?.type !== "inlineSdt") {
+      throw new Error("Expected outer content control");
+    }
+    const inner = outer.content.find((content) => content.type === "inlineSdt");
+    if (inner?.type !== "inlineSdt") {
+      throw new Error("Expected inner content control");
+    }
+    const shapes = inner.content.flatMap((content) =>
+      content.type === "run"
+        ? content.content.filter((runContent) => runContent.type === "shape")
+        : [],
+    );
+
+    expect(block.content).toHaveLength(1);
+    expect(outer.properties.rawPropertiesXml).toContain('w:val="Outer"');
+    expect(inner.properties).toMatchObject({ sdtType: "plainText", alias: "Inner", tag: "inner" });
+    expect(shapes).toHaveLength(1);
+    expect(shapes.at(0)?.shape.shapeType).toBe("textBox");
+  });
+
+  test("keeps multiple standalone text boxes in one inline content control", () => {
+    const document = documentWithTextBoxParagraph({
+      includeText: false,
+      textBoxCount: 2,
+    });
+    const paragraph = document.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    paragraph.content = [
+      {
+        type: "inlineSdt",
+        properties: { sdtType: "richText", alias: "Cards" },
+        content: paragraph.content.filter((content): content is Run => content.type === "run"),
+      },
+    ];
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+    const sdt = block.content.at(0);
+    if (sdt?.type !== "inlineSdt") {
+      throw new Error("Expected content control");
+    }
+    const shapes = sdt.content.flatMap((content) =>
+      content.type === "run"
+        ? content.content.filter((runContent) => runContent.type === "shape")
+        : [],
+    );
+
+    expect(pmDoc.childCount).toBe(2);
+    expect(block.content).toHaveLength(1);
+    expect(shapes).toHaveLength(2);
+  });
+
   test("keeps empty imported text boxes as text boxes", () => {
     const document = documentWithTextBoxParagraph({
       includeText: false,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -1664,6 +1664,66 @@ describe("fromProseDoc", () => {
     expect(shapes.at(0)?.shape.shapeType).toBe("textBox");
   });
 
+  test.each(["moveFrom", "moveTo"] as const)(
+    "round-trips a text box inside an inline content control and %s wrapper",
+    (type) => {
+      const document = documentWithTextBoxParagraph({ includeText: false });
+      const paragraph = document.package.document.content.at(0);
+      if (paragraph?.type !== "paragraph") {
+        throw new Error("Expected paragraph");
+      }
+      const textBoxRun = paragraph.content.at(0);
+      if (textBoxRun?.type !== "run") {
+        throw new Error("Expected text-box run");
+      }
+      const info = {
+        id: 42,
+        author: "Reviewer",
+        date: "2026-07-16T12:00:00Z",
+      } satisfies TrackedChangeInfo;
+      paragraph.content = [
+        {
+          type: "inlineSdt",
+          properties: { sdtType: "richText", alias: "Tracked shape" },
+          content: [trackedTextBoxWrapper(type, info, textBoxRun)],
+        },
+      ];
+
+      const pmDoc = toProseDoc(document);
+      const textBoxNode = pmDoc.firstChild;
+      expect(textBoxNode?.type.name).toBe("textBox");
+      expect(textBoxNode?.attrs["_docxTrackedChange"]).toEqual({ type, info });
+      expect(textBoxNode?.attrs["_docxInlineSdts"]).toMatchObject([
+        { sdtType: "richText", alias: "Tracked shape" },
+      ]);
+
+      const roundTripped = fromProseDoc(pmDoc, document);
+      const block = roundTripped.package.document.content.at(0);
+      if (block?.type !== "paragraph") {
+        throw new Error("Expected round-tripped paragraph");
+      }
+      const sdt = block.content.at(0);
+      if (sdt?.type !== "inlineSdt") {
+        throw new Error("Expected content control");
+      }
+      const trackedChange = sdt.content.at(0);
+      expect(trackedChange).toMatchObject({ type, info });
+      if (trackedChange?.type !== type) {
+        throw new Error("Expected round-tripped move wrapper");
+      }
+      const trackedRun = trackedChange.content.at(0);
+      if (trackedRun?.type !== "run") {
+        throw new Error("Expected round-tripped tracked run");
+      }
+      const trackedShape = trackedRun.content.at(0);
+      expect(trackedShape?.type).toBe("shape");
+      if (trackedShape?.type !== "shape") {
+        throw new Error("Expected round-tripped text-box shape");
+      }
+      expect(trackedShape.shape.shapeType).toBe("textBox");
+    },
+  );
+
   test("keeps multiple standalone text boxes in one inline content control", () => {
     const document = documentWithTextBoxParagraph({
       includeText: false,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2949,10 +2949,9 @@ function convertPMTextBox(node: PMNode): Paragraph {
   const trackedChange = attrs._docxTrackedChange;
   const inlineSdts = attrs._docxInlineSdts ?? [];
   if (inlineSdts.length > 0) {
-    let wrapped: InlineSdt["content"][number] =
-      trackedChange?.type === "insertion" || trackedChange?.type === "deletion"
-        ? { type: trackedChange.type, info: trackedChange.info, content: [run] }
-        : run;
+    let wrapped: InlineSdt["content"][number] = trackedChange
+      ? { type: trackedChange.type, info: trackedChange.info, content: [run] }
+      : run;
     for (let index = inlineSdts.length - 1; index >= 0; index -= 1) {
       const sdtAttrs = inlineSdts[index];
       if (!sdtAttrs) {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1682,6 +1682,8 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
       c.type === "inlineSdt" ||
       c.type === "insertion" ||
       c.type === "deletion" ||
+      c.type === "moveFrom" ||
+      c.type === "moveTo" ||
       c.type === "mathEquation",
   );
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -514,10 +514,14 @@ function mergeTextBoxIntoTrailingInlineSdts(
   if (!outerAttrs || incomingSdt?.type !== "inlineSdt") {
     return false;
   }
-  const targetSdt = target.content.findLast(
-    (content) =>
-      content.type === "inlineSdt" && sdtPropertiesMatchAttrs(content.properties, outerAttrs),
-  );
+  let targetSdt: InlineSdt | undefined;
+  for (let index = target.content.length - 1; index >= 0; index -= 1) {
+    const content = target.content[index];
+    if (content?.type === "inlineSdt" && sdtPropertiesMatchAttrs(content.properties, outerAttrs)) {
+      targetSdt = content;
+      break;
+    }
+  }
   if (!targetSdt) {
     return false;
   }
@@ -547,10 +551,14 @@ function mergeInlineSdtNodes(
   if (!nestedAttrs || incomingNested?.type !== "inlineSdt") {
     return false;
   }
-  const targetNested = target.content.findLast(
-    (content) =>
-      content.type === "inlineSdt" && sdtPropertiesMatchAttrs(content.properties, nestedAttrs),
-  );
+  let targetNested: InlineSdt | undefined;
+  for (let nestedIndex = target.content.length - 1; nestedIndex >= 0; nestedIndex -= 1) {
+    const content = target.content[nestedIndex];
+    if (content?.type === "inlineSdt" && sdtPropertiesMatchAttrs(content.properties, nestedAttrs)) {
+      targetNested = content;
+      break;
+    }
+  }
   if (!targetNested) {
     target.content.push(incomingNested);
     return true;

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -107,6 +107,7 @@ import type {
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
 import { runShadingAttrsToShading } from "./runShadingMark";
+import { sdtPropertiesFromAttrs, sdtPropertiesMatchAttrs } from "./sdtAttrs";
 
 function normalizeShapeOutlineStyle(style: string | undefined): ShapeOutline["style"] | undefined {
   if (!style) {
@@ -468,7 +469,11 @@ function appendTextBoxBlock(
   const previousBlock = blocks.at(-1);
   if (attrs._docxPlacement === "inlineWithPrevious" && previousBlock?.type === "paragraph") {
     appendPageBreaks(previousBlock, options.pendingPageBreaks);
-    previousBlock.content.push(...paragraph.content);
+    if (
+      !mergeTextBoxIntoTrailingInlineSdts(previousBlock, paragraph, attrs._docxInlineSdts ?? [])
+    ) {
+      previousBlock.content.push(...paragraph.content);
+    }
     return null;
   }
 
@@ -477,7 +482,15 @@ function appendTextBoxBlock(
     attrs._docxGroupId &&
     options.previousStandaloneTextBox?.groupId === attrs._docxGroupId
   ) {
-    options.previousStandaloneTextBox.paragraph.content.push(...paragraph.content);
+    if (
+      !mergeTextBoxIntoTrailingInlineSdts(
+        options.previousStandaloneTextBox.paragraph,
+        paragraph,
+        attrs._docxInlineSdts ?? [],
+      )
+    ) {
+      options.previousStandaloneTextBox.paragraph.content.push(...paragraph.content);
+    }
     return options.previousStandaloneTextBox;
   }
 
@@ -486,6 +499,63 @@ function appendTextBoxBlock(
   return attrs._docxPlacement === "standalone" && attrs._docxGroupId
     ? { paragraph, groupId: attrs._docxGroupId }
     : null;
+}
+
+function mergeTextBoxIntoTrailingInlineSdts(
+  target: Paragraph,
+  incoming: Paragraph,
+  inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>,
+): boolean {
+  if (inlineSdts.length === 0 || incoming.content.length !== 1) {
+    return false;
+  }
+  const incomingSdt = incoming.content.at(0);
+  const outerAttrs = inlineSdts.at(0);
+  if (!outerAttrs || incomingSdt?.type !== "inlineSdt") {
+    return false;
+  }
+  const targetSdt = target.content.findLast(
+    (content) =>
+      content.type === "inlineSdt" && sdtPropertiesMatchAttrs(content.properties, outerAttrs),
+  );
+  if (!targetSdt) {
+    return false;
+  }
+  return mergeInlineSdtNodes(targetSdt, incomingSdt, inlineSdts, 0);
+}
+
+function mergeInlineSdtNodes(
+  target: InlineSdt,
+  incoming: InlineSdt,
+  inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>,
+  index: number,
+): boolean {
+  const attrs = inlineSdts[index];
+  if (
+    !attrs ||
+    !sdtPropertiesMatchAttrs(target.properties, attrs) ||
+    !sdtPropertiesMatchAttrs(incoming.properties, attrs)
+  ) {
+    return false;
+  }
+  if (index === inlineSdts.length - 1) {
+    target.content.push(...incoming.content);
+    return true;
+  }
+  const incomingNested = incoming.content.at(0);
+  const nestedAttrs = inlineSdts[index + 1];
+  if (!nestedAttrs || incomingNested?.type !== "inlineSdt") {
+    return false;
+  }
+  const targetNested = target.content.findLast(
+    (content) =>
+      content.type === "inlineSdt" && sdtPropertiesMatchAttrs(content.properties, nestedAttrs),
+  );
+  if (!targetNested) {
+    target.content.push(incomingNested);
+    return true;
+  }
+  return mergeInlineSdtNodes(targetNested, incomingNested, inlineSdts, index + 1);
 }
 
 /**
@@ -1587,52 +1657,7 @@ function createMathFromNode(node: PMNode): MathEquation {
  */
 function createInlineSdtFromNode(node: PMNode): InlineSdt {
   const attrs = expectSdtAttrs(node);
-
-  const properties: SdtProperties = {
-    sdtType: attrs.sdtType,
-  };
-  if (attrs.alias) {
-    properties.alias = attrs.alias;
-  }
-  if (attrs.tag) {
-    properties.tag = attrs.tag;
-  }
-  // `typeof` guards (not `!== undefined`) so a ProseMirror null default can
-  // never enter the `number` / `string` / `boolean`-typed model property,
-  // matching the block-SDT reader (`convertPMBlockSdt`).
-  if (typeof attrs.id === "number") {
-    properties.id = attrs.id;
-  }
-  if (attrs.lock) {
-    properties.lock = attrs.lock;
-  }
-  if (attrs.placeholder) {
-    properties.placeholder = attrs.placeholder;
-  }
-  if (attrs.showingPlaceholder !== undefined) {
-    properties.showingPlaceholder = attrs.showingPlaceholder;
-  }
-  if (attrs.dateFormat) {
-    properties.dateFormat = attrs.dateFormat;
-  }
-  if (attrs.dateValueISO) {
-    properties.dateValueISO = attrs.dateValueISO;
-  }
-  if (attrs.listItems) {
-    properties.listItems = parseSdtListItems(attrs.listItems);
-  }
-  if (typeof attrs.dropdownLastValue === "string") {
-    properties.dropdownLastValue = attrs.dropdownLastValue;
-  }
-  if (typeof attrs.checked === "boolean") {
-    properties.checked = attrs.checked;
-  }
-  if (attrs.rawPropertiesXml) {
-    properties.rawPropertiesXml = attrs.rawPropertiesXml;
-  }
-  if (attrs.rawEndPropertiesXml) {
-    properties.rawEndPropertiesXml = attrs.rawEndPropertiesXml;
-  }
+  const properties = sdtPropertiesFromAttrs(attrs);
 
   // Extract content from the sdt node's children. OOXML allows runs,
   // hyperlinks, simple/complex fields, nested SDTs, tracked changes,
@@ -1657,24 +1682,6 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
     properties,
     content,
   };
-}
-
-function parseSdtListItems(rawItems: string): NonNullable<SdtProperties["listItems"]> {
-  const parsed = JSON.parse(rawItems) as unknown;
-  if (!Array.isArray(parsed)) {
-    throw new TypeError("Invalid ProseMirror sdt attrs: listItems is not an array");
-  }
-
-  return parsed.map((item): NonNullable<SdtProperties["listItems"]>[number] => {
-    if (!item || typeof item !== "object" || Array.isArray(item)) {
-      throw new TypeError("Invalid ProseMirror sdt attrs: listItems contains an invalid item");
-    }
-    const itemAttrs = item as { displayText?: unknown; value?: unknown };
-    if (typeof itemAttrs.displayText !== "string" || typeof itemAttrs.value !== "string") {
-      throw new TypeError("Invalid ProseMirror sdt attrs: listItems contains an invalid item");
-    }
-    return { displayText: itemAttrs.displayText, value: itemAttrs.value };
-  });
 }
 
 /**
@@ -2932,6 +2939,28 @@ function convertPMTextBox(node: PMNode): Paragraph {
   const shapeContent: ShapeContent = { type: "shape", shape };
   const run: Run = { type: "run", content: [shapeContent] };
   const trackedChange = attrs._docxTrackedChange;
+  const inlineSdts = attrs._docxInlineSdts ?? [];
+  if (inlineSdts.length > 0) {
+    let wrapped: InlineSdt["content"][number] =
+      trackedChange?.type === "insertion" || trackedChange?.type === "deletion"
+        ? { type: trackedChange.type, info: trackedChange.info, content: [run] }
+        : run;
+    for (let index = inlineSdts.length - 1; index >= 0; index -= 1) {
+      const sdtAttrs = inlineSdts[index];
+      if (!sdtAttrs) {
+        continue;
+      }
+      wrapped = {
+        type: "inlineSdt",
+        properties: sdtPropertiesFromAttrs(sdtAttrs),
+        content: [wrapped],
+      };
+    }
+    return {
+      type: "paragraph",
+      content: [wrapped],
+    };
+  }
 
   return {
     type: "paragraph",

--- a/packages/core/src/prosemirror/conversion/sdtAttrs.ts
+++ b/packages/core/src/prosemirror/conversion/sdtAttrs.ts
@@ -1,0 +1,97 @@
+import type { SdtProperties } from "../../types/document";
+import type { SdtAttrs } from "../schema/nodes";
+
+export const sdtAttrsFromProperties = (properties: SdtProperties): SdtAttrs => ({
+  sdtType: properties.sdtType,
+  ...(properties.alias !== undefined ? { alias: properties.alias } : {}),
+  ...(properties.tag !== undefined ? { tag: properties.tag } : {}),
+  ...(properties.id !== undefined ? { id: properties.id } : {}),
+  ...(properties.lock !== undefined ? { lock: properties.lock } : {}),
+  ...(properties.placeholder !== undefined ? { placeholder: properties.placeholder } : {}),
+  showingPlaceholder: properties.showingPlaceholder ?? false,
+  ...(properties.dateFormat !== undefined ? { dateFormat: properties.dateFormat } : {}),
+  ...(properties.dateValueISO !== undefined ? { dateValueISO: properties.dateValueISO } : {}),
+  ...(properties.listItems !== undefined
+    ? { listItems: JSON.stringify(properties.listItems) }
+    : {}),
+  ...(properties.dropdownLastValue !== undefined
+    ? { dropdownLastValue: properties.dropdownLastValue }
+    : {}),
+  ...(properties.checked !== undefined ? { checked: properties.checked } : {}),
+  ...(properties.rawPropertiesXml !== undefined
+    ? { rawPropertiesXml: properties.rawPropertiesXml }
+    : {}),
+  ...(properties.rawEndPropertiesXml !== undefined
+    ? { rawEndPropertiesXml: properties.rawEndPropertiesXml }
+    : {}),
+});
+
+export const sdtPropertiesFromAttrs = (attrs: SdtAttrs): SdtProperties => {
+  const properties: SdtProperties = { sdtType: attrs.sdtType };
+  if (attrs.alias) {
+    properties.alias = attrs.alias;
+  }
+  if (attrs.tag) {
+    properties.tag = attrs.tag;
+  }
+  if (typeof attrs.id === "number") {
+    properties.id = attrs.id;
+  }
+  if (attrs.lock) {
+    properties.lock = attrs.lock;
+  }
+  if (attrs.placeholder) {
+    properties.placeholder = attrs.placeholder;
+  }
+  if (attrs.showingPlaceholder !== undefined) {
+    properties.showingPlaceholder = attrs.showingPlaceholder;
+  }
+  if (attrs.dateFormat) {
+    properties.dateFormat = attrs.dateFormat;
+  }
+  if (attrs.dateValueISO) {
+    properties.dateValueISO = attrs.dateValueISO;
+  }
+  if (attrs.listItems) {
+    properties.listItems = parseSdtListItems(attrs.listItems);
+  }
+  if (typeof attrs.dropdownLastValue === "string") {
+    properties.dropdownLastValue = attrs.dropdownLastValue;
+  }
+  if (typeof attrs.checked === "boolean") {
+    properties.checked = attrs.checked;
+  }
+  if (attrs.rawPropertiesXml) {
+    properties.rawPropertiesXml = attrs.rawPropertiesXml;
+  }
+  if (attrs.rawEndPropertiesXml) {
+    properties.rawEndPropertiesXml = attrs.rawEndPropertiesXml;
+  }
+  return properties;
+};
+
+export const sdtPropertiesMatchAttrs = (properties: SdtProperties, attrs: SdtAttrs): boolean =>
+  JSON.stringify(sdtAttrsFromProperties(properties)) ===
+  JSON.stringify(sdtAttrsFromProperties(sdtPropertiesFromAttrs(attrs)));
+
+const parseSdtListItems = (rawItems: string): NonNullable<SdtProperties["listItems"]> => {
+  const parsed = JSON.parse(rawItems) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new TypeError("Invalid ProseMirror sdt attrs: listItems is not an array");
+  }
+
+  return parsed.map((item): NonNullable<SdtProperties["listItems"]>[number] => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new TypeError("Invalid ProseMirror sdt attrs: listItems contains an invalid item");
+    }
+    if (
+      !("displayText" in item) ||
+      typeof item.displayText !== "string" ||
+      !("value" in item) ||
+      typeof item.value !== "string"
+    ) {
+      throw new TypeError("Invalid ProseMirror sdt attrs: listItems contains an invalid item");
+    }
+    return { displayText: item.displayText, value: item.value };
+  });
+};

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2963,7 +2963,7 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesRe
       content.push(item);
     }
 
-    return content.length > 0 ? { ...sdt, content } : undefined;
+    return content.length > 0 || sdt.content.length === 0 ? { ...sdt, content } : undefined;
   };
 
   const content: ParagraphContent[] = [];

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -21,6 +21,7 @@ import type {
   BlockSdt,
   Document,
   Paragraph,
+  ParagraphContent,
   ParagraphFormatting,
   Run,
   TextFormatting,
@@ -73,6 +74,7 @@ import {
 } from "./effectiveTableCellFormatting";
 import { marksToTextFormatting } from "./fromProseDoc";
 import { shadingToRunShadingAttrs } from "./runShadingMark";
+import { sdtAttrsFromProperties } from "./sdtAttrs";
 
 /**
  * Options for document conversion
@@ -1999,25 +2001,7 @@ function convertInlineSdt(
 
   return schema.node(
     "sdt",
-    {
-      sdtType: props.sdtType,
-      alias: props.alias ?? null,
-      tag: props.tag ?? null,
-      id: props.id ?? null,
-      lock: props.lock ?? null,
-      placeholder: props.placeholder ?? null,
-      showingPlaceholder: props.showingPlaceholder ?? false,
-      dateFormat: props.dateFormat ?? null,
-      dateValueISO: props.dateValueISO ?? null,
-      listItems: props.listItems ? JSON.stringify(props.listItems) : null,
-      dropdownLastValue: props.dropdownLastValue ?? null,
-      checked: props.checked ?? null,
-      // Pass the captured `w:sdtPr` / `w:sdtEndPr` through as attrs so the
-      // serializer replays them verbatim after a save, keeping unmodeled
-      // OOXML features lossless — the same contract as `convertBlockSdt`.
-      rawPropertiesXml: props.rawPropertiesXml ?? null,
-      rawEndPropertiesXml: props.rawEndPropertiesXml ?? null,
-    },
+    sdtAttrsFromProperties(props),
     inlineNodes.length > 0 ? inlineNodes : undefined,
   );
 }
@@ -2801,9 +2785,9 @@ function convertParagraphWithTextBoxes(
     tableParagraphOverlay,
   }: ConvertParagraphWithTextBoxesOptions,
 ): PMNode[] {
-  const textBoxes = extractTextBoxesFromParagraph(block);
+  const { paragraph, textBoxes } = extractTextBoxesFromParagraph(block);
   const pmParagraph = convertParagraph(
-    block,
+    paragraph,
     styleResolver,
     undefined,
     extraRunFormatting,
@@ -2816,7 +2800,7 @@ function convertParagraphWithTextBoxes(
   if (!isEmptyAfterExtraction || keepWrapperParagraph) {
     nodes.push(pmParagraph);
   }
-  for (const { textBox, trackedChange } of textBoxes) {
+  for (const { textBox, trackedChange, inlineSdts } of textBoxes) {
     nodes.push(
       convertTextBox(textBox, styleResolver, {
         placement:
@@ -2824,6 +2808,7 @@ function convertParagraphWithTextBoxes(
         groupId: textBoxGroupId,
         context,
         trackedChange,
+        inlineSdts,
       }),
     );
   }
@@ -2848,48 +2833,146 @@ function hasParagraphBoundaryPayload(block: Paragraph, pmParagraph: PMNode): boo
 type ExtractedTextBox = {
   textBox: TextBox;
   trackedChange: NonNullable<TextBoxAttrs["_docxTrackedChange"]> | undefined;
+  inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>;
 };
 
-function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractedTextBox[] {
+type TextBoxExtractionContext = {
+  trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>;
+  inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>;
+};
+
+type ExtractTextBoxesResult = {
+  paragraph: Paragraph;
+  textBoxes: ExtractedTextBox[];
+};
+
+function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesResult {
   const textBoxes: ExtractedTextBox[] = [];
-  const extractFromRun = (
-    run: Run,
-    trackedChange?: NonNullable<TextBoxAttrs["_docxTrackedChange"]>,
-  ): void => {
+  const stripRun = (run: Run, context: TextBoxExtractionContext): Run | undefined => {
+    const content: Run["content"] = [];
+    let removedTextBox = false;
     for (const runContent of run.content) {
       if (runContent.type !== "shape" || !runContent.shape.textBody) {
+        content.push(runContent);
         continue;
       }
+      removedTextBox = true;
       textBoxes.push({
         textBox: textBoxFromShape(runContent.shape, runContent.shape.textBody),
-        trackedChange,
+        trackedChange: context.trackedChange,
+        inlineSdts: context.inlineSdts,
       });
     }
+    if (!removedTextBox) {
+      return run;
+    }
+    if (content.length === 0) {
+      return undefined;
+    }
+    return { ...run, content };
   };
 
-  for (const content of paragraph.content) {
-    if (content.type === "run") {
-      extractFromRun(content);
+  const stripTrackedChange = (
+    change: Insertion | Deletion | MoveFrom | MoveTo,
+    context: TextBoxExtractionContext,
+  ): Insertion | Deletion | MoveFrom | MoveTo | undefined => {
+    const trackedChange = { type: change.type, info: change.info } as const satisfies NonNullable<
+      TextBoxAttrs["_docxTrackedChange"]
+    >;
+    const content = change.content.flatMap((item) => {
+      if (item.type !== "run") {
+        return [item];
+      }
+      const run = stripRun(item, { ...context, trackedChange });
+      return run ? [run] : [];
+    });
+    if (content.length === 0) {
+      return undefined;
+    }
+    if (change.type === "insertion") {
+      return { ...change, content };
+    }
+    if (change.type === "deletion") {
+      return { ...change, content };
+    }
+    if (change.type === "moveFrom") {
+      return { ...change, content };
+    }
+    return { ...change, content };
+  };
+
+  const stripInlineSdt = (
+    sdt: InlineSdt,
+    context: TextBoxExtractionContext,
+  ): InlineSdt | undefined => {
+    const inlineSdts = [...context.inlineSdts, sdtAttrsFromProperties(sdt.properties)];
+    const nestedContext = { ...context, inlineSdts };
+    const content: InlineSdt["content"] = [];
+
+    for (const item of sdt.content) {
+      if (item.type === "run") {
+        const run = stripRun(item, nestedContext);
+        if (run) {
+          content.push(run);
+        }
+        continue;
+      }
+      if (item.type === "inlineSdt") {
+        const nestedSdt = stripInlineSdt(item, nestedContext);
+        if (nestedSdt) {
+          content.push(nestedSdt);
+        }
+        continue;
+      }
+      if (item.type === "insertion" || item.type === "deletion") {
+        const change = stripTrackedChange(item, nestedContext);
+        if (change?.type === "insertion" || change?.type === "deletion") {
+          content.push(change);
+        }
+        continue;
+      }
+      content.push(item);
+    }
+
+    return content.length > 0 ? { ...sdt, content } : undefined;
+  };
+
+  const content: ParagraphContent[] = [];
+  const rootContext: TextBoxExtractionContext = { inlineSdts: [] };
+  for (const item of paragraph.content) {
+    if (item.type === "run") {
+      const run = stripRun(item, rootContext);
+      if (run) {
+        content.push(run);
+      }
+      continue;
+    }
+    if (item.type === "inlineSdt") {
+      const sdt = stripInlineSdt(item, rootContext);
+      if (sdt) {
+        content.push(sdt);
+      }
       continue;
     }
     if (
-      content.type !== "insertion" &&
-      content.type !== "deletion" &&
-      content.type !== "moveFrom" &&
-      content.type !== "moveTo"
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
     ) {
+      const change = stripTrackedChange(item, rootContext);
+      if (change) {
+        content.push(change);
+      }
       continue;
     }
-    const trackedChange = { type: content.type, info: content.info } as const satisfies NonNullable<
-      TextBoxAttrs["_docxTrackedChange"]
-    >;
-    for (const trackedContent of content.content) {
-      if (trackedContent.type === "run") {
-        extractFromRun(trackedContent, trackedChange);
-      }
-    }
+    content.push(item);
   }
-  return textBoxes;
+
+  return {
+    paragraph: { ...paragraph, content },
+    textBoxes,
+  };
 }
 
 function textBoxFromShape(shape: Shape, textBody: ShapeTextBody): TextBox {
@@ -2933,6 +3016,7 @@ function convertTextBox(
     groupId?: string;
     context: TableConversionContext;
     trackedChange: NonNullable<TextBoxAttrs["_docxTrackedChange"]> | undefined;
+    inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>;
   },
 ): PMNode {
   const textBoxData: { size?: Partial<TextBox["size"]> } = textBox;
@@ -3081,6 +3165,7 @@ function convertTextBox(
       _docxPlacement: options.placement,
       _docxGroupId: options.groupId,
       _docxTrackedChange: options.trackedChange,
+      _docxInlineSdts: options.inlineSdts.length > 0 ? options.inlineSdts : undefined,
     },
     contentNodes,
   );

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2928,9 +2928,14 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesRe
         }
         continue;
       }
-      if (item.type === "insertion" || item.type === "deletion") {
+      if (
+        item.type === "insertion" ||
+        item.type === "deletion" ||
+        item.type === "moveFrom" ||
+        item.type === "moveTo"
+      ) {
         const change = stripTrackedChange(item, nestedContext);
-        if (change?.type === "insertion" || change?.type === "deletion") {
+        if (change) {
           content.push(change);
         }
         continue;

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2879,13 +2879,17 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesRe
     const trackedChange = { type: change.type, info: change.info } as const satisfies NonNullable<
       TextBoxAttrs["_docxTrackedChange"]
     >;
-    const content = change.content.flatMap((item) => {
+    const content: (Run | Hyperlink)[] = [];
+    for (const item of change.content) {
       if (item.type !== "run") {
-        return [item];
+        content.push(item);
+        continue;
       }
       const run = stripRun(item, { ...context, trackedChange });
-      return run ? [run] : [];
-    });
+      if (run) {
+        content.push(run);
+      }
+    }
     if (content.length === 0) {
       return undefined;
     }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1989,6 +1989,26 @@ function convertInlineSdt(
       inlineNodes.push(
         ...convertTrackedChange(content, "deletion", getInheritedRunFormatting, styleResolver),
       );
+    } else if (content.type === "moveTo") {
+      inlineNodes.push(
+        ...convertTrackedChange(
+          content,
+          "insertion",
+          getInheritedRunFormatting,
+          styleResolver,
+          "moveTo",
+        ),
+      );
+    } else if (content.type === "moveFrom") {
+      inlineNodes.push(
+        ...convertTrackedChange(
+          content,
+          "deletion",
+          getInheritedRunFormatting,
+          styleResolver,
+          "moveFrom",
+        ),
+      );
     } else {
       // content.type === "mathEquation" — narrowed by exhaustion of the
       // InlineSdt['content'] union above.

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -63,6 +63,8 @@ export type TextBoxAttrs = {
   _docxGroupId?: string;
   /** Original run-level revision wrapper for save-path reconstruction. */
   _docxTrackedChange?: SchemaTextBoxAttrs["_docxTrackedChange"];
+  /** Original inline content-control ancestry for save-path reconstruction. */
+  _docxInlineSdts?: SchemaTextBoxAttrs["_docxInlineSdts"];
 };
 
 function parseTextBoxPosition(raw: string | undefined): ImagePositionAttrs | undefined {
@@ -130,6 +132,7 @@ export const TextBoxExtension = createNodeExtension({
       _docxPlacement: { default: null },
       _docxGroupId: { default: null },
       _docxTrackedChange: { default: null },
+      _docxInlineSdts: { default: null },
     },
     parseDOM: [
       {

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -555,6 +555,8 @@ export type TextBoxAttrs = {
     | { type: "deletion"; info: TrackedChangeInfo }
     | { type: "moveFrom"; info: TrackedChangeInfo }
     | { type: "moveTo"; info: TrackedChangeInfo };
+  /** Original inline content-control ancestry for save-path reconstruction. */
+  _docxInlineSdts?: SdtAttrs[];
 };
 
 /**

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1222,7 +1222,7 @@ export type SdtProperties = {
  * Inline SDT (content control within a paragraph).
  *
  * OOXML allows runs, hyperlinks, simple/complex fields, nested SDTs,
- * tracked insertions/deletions, and math at this level. All of them must survive
+ * tracked insertions/deletions/moves, and math at this level. All of them must survive
  * parse → edit → save so docProps-bound fields and reviewed template
  * content do not lose their wrapper on round-trip.
  */
@@ -1239,6 +1239,8 @@ export type InlineSdt = {
     | InlineSdt
     | Insertion
     | Deletion
+    | MoveFrom
+    | MoveTo
     | MathEquation
   )[];
 };


### PR DESCRIPTION
Preserves text-box drawings nested in inline content controls across parsing and editor save reconstruction. Carries nested control metadata through the ProseMirror boundary, validates the preservation attrs, and adds synthetic parse/save coverage.