### PR TITLE
fix: route painted content control interactions

### DIFF
--- a/.changeset/calm-widgets-route.md
+++ b/.changeset/calm-widgets-route.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Route painted content-control clicks through the shared widget controller and render usable pickers in React and Vue.

--- a/packages/core/src/controller/contentControlWidgetController.ts
+++ b/packages/core/src/controller/contentControlWidgetController.ts
@@ -1,10 +1,11 @@
 /**
  * Framework-neutral lifecycle and state owner for typed content-control pickers.
  *
- * The ProseMirror plugin owns click detection and document transactions. This
- * controller binds that plugin's DOM event to a stable, discriminated snapshot
- * that any adapter can render, then routes a selection back through the same
- * transaction helpers. Framework adapters only subscribe and provide chrome.
+ * The ProseMirror plugin owns widget interpretation and document transactions.
+ * This controller binds both the plugin's DOM event and the painted body click
+ * surface to a stable, discriminated snapshot that any adapter can render, then
+ * routes a selection back through the same transaction helpers. Framework
+ * adapters only subscribe, provide the painted root, and render chrome.
  */
 
 import type { EditorView } from "prosemirror-view";
@@ -13,6 +14,7 @@ import {
   CONTENT_CONTROL_WIDGET_EVENT_NAME,
   dispatchDatePick,
   dispatchDropdownPick,
+  handleContentControlWidgetClick,
 } from "../prosemirror/plugins/contentControlWidgets";
 import type { ContentControlWidgetEvent } from "../prosemirror/plugins/contentControlWidgets";
 import { Subscribable } from "../managers/Subscribable";
@@ -122,6 +124,7 @@ export class ContentControlWidgetController extends Subscribable<ContentControlW
   private readonly options: ContentControlWidgetControllerOptions;
   private view: EditorView | null = null;
   private viewDom: HTMLElement | null = null;
+  private eventRoot: HTMLElement | null = null;
   private ownerWindow: Window | null = null;
 
   constructor(options: ContentControlWidgetControllerOptions = {}) {
@@ -129,14 +132,16 @@ export class ContentControlWidgetController extends Subscribable<ContentControlW
     this.options = options;
   }
 
-  bind(view: EditorView | null): void {
-    if (this.view === view) {
+  bind(view: EditorView | null, eventRoot: HTMLElement | null = null): void {
+    if (this.view === view && this.eventRoot === eventRoot) {
       return;
     }
     this.unbindView();
     this.view = view;
     this.viewDom = view?.dom ?? null;
+    this.eventRoot = eventRoot;
     this.viewDom?.addEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, this.onDomEvent);
+    this.eventRoot?.addEventListener("click", this.onPaintedClick);
   }
 
   handleWidgetEvent(event: ContentControlWidgetEvent): void {
@@ -204,6 +209,17 @@ export class ContentControlWidgetController extends Subscribable<ContentControlW
     }
   };
 
+  private readonly onPaintedClick = (event: MouseEvent): void => {
+    if (!this.view || !isPaintedBodyClick(event.target)) {
+      return;
+    }
+    handleContentControlWidgetClick({
+      view: this.view,
+      event,
+      onEvent: (widgetEvent) => this.handleWidgetEvent(widgetEvent),
+    });
+  };
+
   private readonly onKeyDown = (event: KeyboardEvent): void => {
     if (event.key === "Escape") {
       this.close();
@@ -229,6 +245,20 @@ export class ContentControlWidgetController extends Subscribable<ContentControlW
   private unbindView(): void {
     this.close();
     this.viewDom?.removeEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, this.onDomEvent);
+    this.eventRoot?.removeEventListener("click", this.onPaintedClick);
     this.viewDom = null;
+    this.eventRoot = null;
   }
 }
+
+const isPaintedBodyClick = (target: unknown): boolean => {
+  if (
+    typeof target !== "object" ||
+    target === null ||
+    !("closest" in target) ||
+    typeof target.closest !== "function"
+  ) {
+    return false;
+  }
+  return target.closest(".layout-page-content") !== null;
+};

--- a/packages/core/src/prosemirror/plugins/contentControlWidgets.test.ts
+++ b/packages/core/src/prosemirror/plugins/contentControlWidgets.test.ts
@@ -12,7 +12,11 @@ import { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import { schema, singletonManager } from "../schema";
-import { dispatchDatePick, dispatchDropdownPick } from "./contentControlWidgets";
+import {
+  dispatchDatePick,
+  dispatchDropdownPick,
+  handleContentControlWidgetClick,
+} from "./contentControlWidgets";
 
 type StubView = Pick<EditorView, "state" | "dispatch">;
 
@@ -24,6 +28,69 @@ function viewLike(stateRef: { state: EditorState }): StubView {
     },
   };
 }
+
+describe("handleContentControlWidgetClick", () => {
+  test("routes painted descendant clicks through the typed dropdown event", () => {
+    const listItems = JSON.stringify([
+      { value: "ca", displayText: "California" },
+      { value: "ny", displayText: "New York" },
+    ]);
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        tag: "state",
+        listItems,
+      },
+      [schema.node("paragraph", {}, [schema.text("California")])],
+    );
+    const stateRef = {
+      state: EditorState.create({
+        doc: schema.node("doc", null, [sdt]),
+        schema,
+        plugins: [...singletonManager.getPlugins()],
+      }),
+    };
+    const anchor = {
+      dataset: {
+        sdtListItems: listItems,
+        sdtPmPos: "0",
+        sdtTag: "state",
+        sdtType: "dropdown",
+      },
+      getBoundingClientRect: () => ({ bottom: 80, left: 24 }),
+    };
+    const target = {
+      closest: (selector: string) => (selector === "[data-sdt-type]" ? anchor : null),
+    };
+    let prevented = false;
+    const events = [];
+
+    const handled = handleContentControlWidgetClick({
+      view: viewLike(stateRef),
+      event: {
+        target,
+        preventDefault: () => {
+          prevented = true;
+        },
+      },
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(handled).toBe(true);
+    expect(prevented).toBe(true);
+    expect(events).toEqual([
+      {
+        kind: "dropdownOpen",
+        tag: "state",
+        pmPos: 0,
+        sdtType: "dropdown",
+        anchor,
+        listItemsJson: listItems,
+      },
+    ]);
+  });
+});
 
 describe("dispatchDropdownPick", () => {
   test("writes the picked value as the displayText", () => {

--- a/packages/core/src/prosemirror/plugins/contentControlWidgets.test.ts
+++ b/packages/core/src/prosemirror/plugins/contentControlWidgets.test.ts
@@ -11,16 +11,27 @@ import { describe, expect, test } from "bun:test";
 import { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import { ContentControlLockedError, ContentControlTypeError } from "../../content-controls";
 import { schema, singletonManager } from "../schema";
 import {
   dispatchDatePick,
   dispatchDropdownPick,
   handleContentControlWidgetClick,
 } from "./contentControlWidgets";
+import type { ContentControlWidgetEvent } from "./contentControlWidgets";
 
 type StubView = Pick<EditorView, "state" | "dispatch">;
+type StateRef = { state: EditorState };
 
-function viewLike(stateRef: { state: EditorState }): StubView {
+type ClickWidgetOptions = {
+  checked?: boolean;
+  listItems?: string;
+  stateRef: StateRef;
+  tag?: string;
+  type: string;
+};
+
+function viewLike(stateRef: StateRef): StubView {
   return {
     state: stateRef.state,
     dispatch(tr) {
@@ -28,6 +39,42 @@ function viewLike(stateRef: { state: EditorState }): StubView {
     },
   };
 }
+
+const clickWidget = ({
+  checked,
+  listItems,
+  stateRef,
+  tag = "control",
+  type,
+}: ClickWidgetOptions) => {
+  const dataset = {
+    ...(checked === undefined ? {} : { sdtChecked: String(checked) }),
+    ...(listItems === undefined ? {} : { sdtListItems: listItems }),
+    sdtPmPos: "0",
+    sdtTag: tag,
+    sdtType: type,
+  };
+  const anchor = {
+    dataset,
+    getBoundingClientRect: () => ({ bottom: 80, left: 24 }),
+  };
+  const target = {
+    closest: (selector: string) => (selector === "[data-sdt-type]" ? anchor : null),
+  };
+  const events: ContentControlWidgetEvent[] = [];
+  let prevented = false;
+  const handled = handleContentControlWidgetClick({
+    view: viewLike(stateRef),
+    event: {
+      target,
+      preventDefault: () => {
+        prevented = true;
+      },
+    },
+    onEvent: (event) => events.push(event),
+  });
+  return { anchor, events, handled, prevented };
+};
 
 describe("handleContentControlWidgetClick", () => {
   test("routes painted descendant clicks through the typed dropdown event", () => {
@@ -51,30 +98,11 @@ describe("handleContentControlWidgetClick", () => {
         plugins: [...singletonManager.getPlugins()],
       }),
     };
-    const anchor = {
-      dataset: {
-        sdtListItems: listItems,
-        sdtPmPos: "0",
-        sdtTag: "state",
-        sdtType: "dropdown",
-      },
-      getBoundingClientRect: () => ({ bottom: 80, left: 24 }),
-    };
-    const target = {
-      closest: (selector: string) => (selector === "[data-sdt-type]" ? anchor : null),
-    };
-    let prevented = false;
-    const events = [];
-
-    const handled = handleContentControlWidgetClick({
-      view: viewLike(stateRef),
-      event: {
-        target,
-        preventDefault: () => {
-          prevented = true;
-        },
-      },
-      onEvent: (event) => events.push(event),
+    const { anchor, events, handled, prevented } = clickWidget({
+      listItems,
+      stateRef,
+      tag: "state",
+      type: "dropdown",
     });
 
     expect(handled).toBe(true);
@@ -89,6 +117,133 @@ describe("handleContentControlWidgetClick", () => {
         listItemsJson: listItems,
       },
     ]);
+  });
+
+  test("toggles a painted checkbox through a document transaction", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        checked: false,
+        sdtType: "checkbox",
+        tag: "approval",
+      },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const stateRef = {
+      state: EditorState.create({
+        doc: schema.node("doc", null, [sdt]),
+        schema,
+        plugins: [...singletonManager.getPlugins()],
+      }),
+    };
+
+    const { events, handled, prevented } = clickWidget({
+      checked: false,
+      stateRef,
+      tag: "approval",
+      type: "checkbox",
+    });
+
+    expect(handled).toBe(true);
+    expect(prevented).toBe(true);
+    expect(events).toEqual([]);
+    expect(stateRef.state.doc.firstChild?.attrs["checked"]).toBe(true);
+    expect(stateRef.state.doc.firstChild?.firstChild?.textContent).toBe("☒");
+  });
+
+  for (const sdtType of ["dropdown", "date"] as const) {
+    test(`refuses a locked ${sdtType} before opening its picker`, () => {
+      const sdt = schema.node(
+        "blockSdt",
+        {
+          lock: "contentLocked",
+          sdtType,
+          tag: "locked",
+        },
+        [schema.node("paragraph", {}, [])],
+      );
+      const stateRef = {
+        state: EditorState.create({
+          doc: schema.node("doc", null, [sdt]),
+          schema,
+          plugins: [...singletonManager.getPlugins()],
+        }),
+      };
+
+      const { events, handled, prevented } = clickWidget({
+        stateRef,
+        tag: "locked",
+        type: sdtType,
+      });
+
+      expect(handled).toBe(true);
+      expect(prevented).toBe(true);
+      expect(events).toHaveLength(1);
+      expect(events.at(0)?.kind).toBe("refused");
+      expect(events.at(0)?.error).toBeInstanceOf(ContentControlLockedError);
+    });
+  }
+
+  test("surfaces a lock error thrown while toggling a checkbox", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        checked: false,
+        lock: "contentLocked",
+        sdtType: "checkbox",
+        tag: "locked",
+      },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const stateRef = {
+      state: EditorState.create({
+        doc: schema.node("doc", null, [sdt]),
+        schema,
+        plugins: [...singletonManager.getPlugins()],
+      }),
+    };
+
+    const { events, handled } = clickWidget({
+      checked: false,
+      stateRef,
+      tag: "locked",
+      type: "checkbox",
+    });
+
+    expect(handled).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events.at(0)?.kind).toBe("refused");
+    expect(events.at(0)?.error).toBeInstanceOf(ContentControlLockedError);
+  });
+
+  test("surfaces a type error when painted metadata disagrees with the document", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        tag: "state",
+      },
+      [schema.node("paragraph", {}, [schema.text("California")])],
+    );
+    const stateRef = {
+      state: EditorState.create({
+        doc: schema.node("doc", null, [sdt]),
+        schema,
+        plugins: [...singletonManager.getPlugins()],
+      }),
+    };
+
+    const { events, handled } = clickWidget({
+      checked: false,
+      stateRef,
+      tag: "state",
+      type: "checkbox",
+    });
+
+    expect(handled).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events.at(0)?.kind).toBe("refused");
+    expect(events.at(0)?.error).toBeInstanceOf(ContentControlTypeError);
   });
 });
 

--- a/packages/core/src/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/core/src/prosemirror/plugins/contentControlWidgets.ts
@@ -86,6 +86,21 @@ export const contentControlWidgetsPluginKey = new PluginKey<unknown>("contentCon
  */
 export const CONTENT_CONTROL_WIDGET_EVENT_NAME = "folio:content-control-widget";
 
+const SDT_DATASET_KEY = {
+  checked: "sdtChecked",
+  listItems: "sdtListItems",
+  pmPos: "sdtPmPos",
+  tag: "sdtTag",
+  type: "sdtType",
+} as const;
+const SDT_TYPE = {
+  checkbox: "checkbox",
+  comboBox: "comboBox",
+  date: "date",
+  dropdown: "dropdown",
+} as const;
+const SDT_TYPE_SELECTOR = "[data-sdt-type]";
+
 const findClosest = (target: unknown, selector: string): unknown => {
   if (
     typeof target !== "object" ||
@@ -114,7 +129,7 @@ const isContentControlWidgetElement = (value: unknown): value is ContentControlW
 };
 
 const findSdtAncestor = (target: unknown): ContentControlWidgetElement | null => {
-  const candidate = findClosest(target, "[data-sdt-type]");
+  const candidate = findClosest(target, SDT_TYPE_SELECTOR);
   return isContentControlWidgetElement(candidate) ? candidate : null;
 };
 
@@ -132,12 +147,12 @@ export const handleContentControlWidgetClick = ({
   if (!anchor) {
     return false;
   }
-  const tag = anchor.dataset["sdtTag"] ?? "";
-  const sdtType = anchor.dataset["sdtType"];
+  const tag = anchor.dataset[SDT_DATASET_KEY.tag] ?? "";
+  const sdtType = anchor.dataset[SDT_DATASET_KEY.type];
   // pmPos is what addresses the clicked instance unambiguously. The
   // painter stamps it from the SdtGroup; tag is kept on the event
   // for telemetry but is no longer the addressing key.
-  const pmPosRaw = anchor.dataset["sdtPmPos"];
+  const pmPosRaw = anchor.dataset[SDT_DATASET_KEY.pmPos];
   const pmPos = pmPosRaw ? Number.parseInt(pmPosRaw, 10) : Number.NaN;
   if (!sdtType || Number.isNaN(pmPos)) {
     return false;
@@ -146,13 +161,13 @@ export const handleContentControlWidgetClick = ({
   // surface the click intent. Errors thrown by the helper are
   // caught here so the editor stays interactive even on refusal.
   try {
-    if (sdtType === "checkbox") {
-      const current = anchor.dataset["sdtChecked"] === "true";
+    if (sdtType === SDT_TYPE.checkbox) {
+      const current = anchor.dataset[SDT_DATASET_KEY.checked] === "true";
       const tr = setContentControlValueTr(
         view.state,
         { pmPos },
         {
-          kind: "checkbox",
+          kind: SDT_TYPE.checkbox,
           checked: !current,
         },
       );
@@ -161,7 +176,7 @@ export const handleContentControlWidgetClick = ({
         event.preventDefault();
         return true;
       }
-    } else if (sdtType === "dropdown" || sdtType === "comboBox") {
+    } else if (sdtType === SDT_TYPE.dropdown || sdtType === SDT_TYPE.comboBox) {
       const refusal = lockRefusalFor(view, pmPos);
       if (refusal) {
         onEvent({
@@ -181,11 +196,11 @@ export const handleContentControlWidgetClick = ({
         pmPos,
         sdtType,
         anchor,
-        listItemsJson: anchor.dataset["sdtListItems"],
+        listItemsJson: anchor.dataset[SDT_DATASET_KEY.listItems],
       });
       event.preventDefault();
       return true;
-    } else if (sdtType === "date") {
+    } else if (sdtType === SDT_TYPE.date) {
       const refusal = lockRefusalFor(view, pmPos);
       if (refusal) {
         onEvent({

--- a/packages/core/src/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/core/src/prosemirror/plugins/contentControlWidgets.ts
@@ -56,6 +56,23 @@ export type ContentControlWidgetEvent =
 
 export type ContentControlWidgetCallback = (event: ContentControlWidgetEvent) => void;
 
+type ContentControlWidgetClickEvent = {
+  preventDefault: () => void;
+  target: unknown;
+};
+
+type ContentControlWidgetView = Pick<EditorView, "dispatch" | "state">;
+
+type HandleContentControlWidgetClickOptions = {
+  event: ContentControlWidgetClickEvent;
+  onEvent: ContentControlWidgetCallback;
+  view: ContentControlWidgetView;
+};
+
+type ContentControlWidgetElement = ContentControlWidgetAnchor & {
+  dataset: DOMStringMap;
+};
+
 export const contentControlWidgetsPluginKey = new PluginKey<unknown>("contentControlWidgets");
 
 /**
@@ -69,12 +86,147 @@ export const contentControlWidgetsPluginKey = new PluginKey<unknown>("contentCon
  */
 export const CONTENT_CONTROL_WIDGET_EVENT_NAME = "folio:content-control-widget";
 
-function findSdtAncestor(target: EventTarget | null): HTMLElement | null {
-  if (!(target instanceof Element)) {
+const findClosest = (target: unknown, selector: string): unknown => {
+  if (
+    typeof target !== "object" ||
+    target === null ||
+    !("closest" in target) ||
+    typeof target.closest !== "function"
+  ) {
     return null;
   }
-  return target.closest<HTMLElement>("[data-sdt-type]");
-}
+  return target.closest(selector);
+};
+
+const isContentControlWidgetElement = (value: unknown): value is ContentControlWidgetElement => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("dataset" in value) ||
+    typeof value.dataset !== "object" ||
+    value.dataset === null ||
+    !("getBoundingClientRect" in value) ||
+    typeof value.getBoundingClientRect !== "function"
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const findSdtAncestor = (target: unknown): ContentControlWidgetElement | null => {
+  const candidate = findClosest(target, "[data-sdt-type]");
+  return isContentControlWidgetElement(candidate) ? candidate : null;
+};
+
+/**
+ * Interpret one click from either the live ProseMirror DOM or the painted page
+ * tree. Both surfaces carry the same `data-sdt-*` projection, so adapters only
+ * need to forward the click and render the resulting typed event.
+ */
+export const handleContentControlWidgetClick = ({
+  event,
+  onEvent,
+  view,
+}: HandleContentControlWidgetClickOptions): boolean => {
+  const anchor = findSdtAncestor(event.target);
+  if (!anchor) {
+    return false;
+  }
+  const tag = anchor.dataset["sdtTag"] ?? "";
+  const sdtType = anchor.dataset["sdtType"];
+  // pmPos is what addresses the clicked instance unambiguously. The
+  // painter stamps it from the SdtGroup; tag is kept on the event
+  // for telemetry but is no longer the addressing key.
+  const pmPosRaw = anchor.dataset["sdtPmPos"];
+  const pmPos = pmPosRaw ? Number.parseInt(pmPosRaw, 10) : Number.NaN;
+  if (!sdtType || Number.isNaN(pmPos)) {
+    return false;
+  }
+  // The lock check happens inside the transaction helper; we just
+  // surface the click intent. Errors thrown by the helper are
+  // caught here so the editor stays interactive even on refusal.
+  try {
+    if (sdtType === "checkbox") {
+      const current = anchor.dataset["sdtChecked"] === "true";
+      const tr = setContentControlValueTr(
+        view.state,
+        { pmPos },
+        {
+          kind: "checkbox",
+          checked: !current,
+        },
+      );
+      if (tr) {
+        view.dispatch(tr);
+        event.preventDefault();
+        return true;
+      }
+    } else if (sdtType === "dropdown" || sdtType === "comboBox") {
+      const refusal = lockRefusalFor(view, pmPos);
+      if (refusal) {
+        onEvent({
+          kind: "refused",
+          tag,
+          pmPos,
+          sdtType,
+          anchor,
+          error: refusal,
+        });
+        event.preventDefault();
+        return true;
+      }
+      onEvent({
+        kind: "dropdownOpen",
+        tag,
+        pmPos,
+        sdtType,
+        anchor,
+        listItemsJson: anchor.dataset["sdtListItems"],
+      });
+      event.preventDefault();
+      return true;
+    } else if (sdtType === "date") {
+      const refusal = lockRefusalFor(view, pmPos);
+      if (refusal) {
+        onEvent({
+          kind: "refused",
+          tag,
+          pmPos,
+          sdtType,
+          anchor,
+          error: refusal,
+        });
+        event.preventDefault();
+        return true;
+      }
+      onEvent({
+        kind: "datePick",
+        tag,
+        pmPos,
+        anchor,
+        currentValue: findBlockSdtMatch(view.state.doc, { pmPos })?.node.textContent,
+      });
+      event.preventDefault();
+      return true;
+    }
+  } catch (error) {
+    if (error instanceof ContentControlLockedError || error instanceof ContentControlTypeError) {
+      // Refusal is expected: emit it through the typed callback and let
+      // the editor shell decide how to surface it.
+      onEvent({
+        kind: "refused",
+        tag,
+        pmPos,
+        sdtType,
+        anchor,
+        error,
+      });
+      return true;
+    }
+    throw error;
+  }
+  return false;
+};
 
 export function createContentControlWidgetsPlugin(
   onEvent: ContentControlWidgetCallback = () => undefined,
@@ -93,109 +245,11 @@ export function createContentControlWidgetsPlugin(
     props: {
       handleDOMEvents: {
         click(view, event) {
-          const anchor = findSdtAncestor(event.target);
-          if (!anchor) {
-            return false;
-          }
-          const tag = anchor.dataset["sdtTag"] ?? "";
-          const sdtType = anchor.dataset["sdtType"];
-          // pmPos is what addresses the clicked instance unambiguously. The
-          // painter stamps it from the SdtGroup; tag is kept on the event
-          // for telemetry but is no longer the addressing key.
-          const pmPosRaw = anchor.dataset["sdtPmPos"];
-          const pmPos = pmPosRaw ? Number.parseInt(pmPosRaw, 10) : Number.NaN;
-          if (!sdtType || Number.isNaN(pmPos)) {
-            return false;
-          }
-          // The lock check happens inside the transaction helper; we just
-          // surface the click intent. Errors thrown by the helper are
-          // caught here so the editor stays interactive even on refusal.
-          try {
-            if (sdtType === "checkbox") {
-              const current = anchor.dataset["sdtChecked"] === "true";
-              const tr = setContentControlValueTr(
-                view.state,
-                { pmPos },
-                {
-                  kind: "checkbox",
-                  checked: !current,
-                },
-              );
-              if (tr) {
-                view.dispatch(tr);
-                event.preventDefault();
-                return true;
-              }
-            } else if (sdtType === "dropdown" || sdtType === "comboBox") {
-              const refusal = lockRefusalFor(view, pmPos);
-              if (refusal) {
-                emit(view, {
-                  kind: "refused",
-                  tag,
-                  pmPos,
-                  sdtType,
-                  anchor,
-                  error: refusal,
-                });
-                event.preventDefault();
-                return true;
-              }
-              emit(view, {
-                kind: "dropdownOpen",
-                tag,
-                pmPos,
-                sdtType,
-                anchor,
-                listItemsJson: anchor.dataset["sdtListItems"],
-              });
-              event.preventDefault();
-              return true;
-            } else if (sdtType === "date") {
-              const refusal = lockRefusalFor(view, pmPos);
-              if (refusal) {
-                emit(view, {
-                  kind: "refused",
-                  tag,
-                  pmPos,
-                  sdtType,
-                  anchor,
-                  error: refusal,
-                });
-                event.preventDefault();
-                return true;
-              }
-              emit(view, {
-                kind: "datePick",
-                tag,
-                pmPos,
-                anchor,
-                currentValue: findBlockSdtMatch(view.state.doc, { pmPos })?.node.textContent,
-              });
-              event.preventDefault();
-              return true;
-            }
-          } catch (error) {
-            if (
-              error instanceof ContentControlLockedError ||
-              error instanceof ContentControlTypeError
-            ) {
-              // Refusal is expected — emit it through the typed callback
-              // and let the editor shell decide what to do (toast,
-              // analytics, no-op). The plugin itself stays silent so
-              // refusals never end up as ad-hoc console noise.
-              emit(view, {
-                kind: "refused",
-                tag,
-                pmPos,
-                sdtType,
-                anchor,
-                error,
-              });
-              return true;
-            }
-            throw error;
-          }
-          return false;
+          return handleContentControlWidgetClick({
+            view,
+            event,
+            onEvent: (payload) => emit(view, payload),
+          });
         },
       },
     },
@@ -276,7 +330,10 @@ export function dispatchDatePick(view: EditorView, pmPos: number, date: string):
  * picker." Preflight at click time so locked dropdowns / date pickers
  * don't flash open just to close again when the user makes a selection.
  */
-function lockRefusalFor(view: EditorView, pmPos: number): ContentControlLockedError | null {
+function lockRefusalFor(
+  view: Pick<EditorView, "state">,
+  pmPos: number,
+): ContentControlLockedError | null {
   const match = findBlockSdtMatch(view.state.doc, { pmPos });
   if (!match) {
     return null;

--- a/packages/react/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/react/src/components/ContentControlWidgetsOverlay.tsx
@@ -13,12 +13,16 @@ import { useFolioUI } from "../ui/folio-ui";
 type FolioMenuItem = ReturnType<typeof useFolioUI>["Menu"]["Item"];
 
 type ContentControlWidgetsOverlayProps = {
+  getEventRoot: () => HTMLElement | null;
   getEditorView: () => EditorView | null;
 };
 
-export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWidgetsOverlayProps) {
+export function ContentControlWidgetsOverlay({
+  getEventRoot,
+  getEditorView,
+}: ContentControlWidgetsOverlayProps) {
   const folioUI = useFolioUI();
-  const { Item: MenuItem } = folioUI.Menu;
+  const { Root: Menu, Item: MenuItem } = folioUI.Menu;
   const DatePickerPopover = folioUI.DatePickerPopover;
   const t = useTranslations("folio");
   const controller = useMemo(() => new ContentControlWidgetController(), []);
@@ -30,9 +34,9 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
   const view = getEditorView();
 
   useEffect(() => {
-    controller.bind(view);
+    controller.bind(view, getEventRoot());
     return () => controller.destroy();
-  }, [controller, view]);
+  }, [controller, getEventRoot, view]);
 
   const onDropdownPick = useCallback(
     (value: string) => controller.pickDropdown(value),
@@ -67,22 +71,24 @@ export function ContentControlWidgetsOverlay({ getEditorView }: ContentControlWi
         className="bg-popover text-popover-foreground min-w-[10rem] rounded-md border p-1 shadow-md"
       >
         {snapshot.status === "dropdown" && (
-          <div role="menu" className="flex flex-col">
-            {snapshot.items.length === 0 ? (
-              <div className="text-muted-foreground px-2 py-1 text-sm">
-                {t("contentControlDropdownNoOptions")}
-              </div>
-            ) : (
-              snapshot.items.map((item) => (
-                <ContentControlDropdownItem
-                  key={`${item.value}::${item.displayText}`}
-                  item={item}
-                  MenuItem={MenuItem}
-                  onPick={onDropdownPick}
-                />
-              ))
-            )}
-          </div>
+          <Menu>
+            <div role="menu" className="flex flex-col">
+              {snapshot.items.length === 0 ? (
+                <div className="text-muted-foreground px-2 py-1 text-sm">
+                  {t("contentControlDropdownNoOptions")}
+                </div>
+              ) : (
+                snapshot.items.map((item) => (
+                  <ContentControlDropdownItem
+                    key={`${item.value}::${item.displayText}`}
+                    item={item}
+                    MenuItem={MenuItem}
+                    onPick={onDropdownPick}
+                  />
+                ))
+              )}
+            </div>
+          </Menu>
         )}
         {snapshot.status === "date" && (
           <DatePickerPopover

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3766,6 +3766,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [handleContextMenuAction],
   );
   const getBodyEditorView = useCallback(() => pagedEditorRef.current?.getView() ?? null, []);
+  const getContentControlEventRoot = useCallback(() => {
+    if (readOnly) {
+      return null;
+    }
+    const root = containerRef.current?.querySelector(".paged-editor__pages");
+    return root instanceof HTMLElement ? root : null;
+  }, [readOnly]);
 
   const closeTableProperties = useCallback(() => setTablePropsOpen(false), []);
   const applyTableProperties = useCallback(
@@ -4398,7 +4405,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             )}
 
             {/* Dropdown / date pickers for content controls */}
-            <ContentControlWidgetsOverlay getEditorView={getBodyEditorView} />
+            <ContentControlWidgetsOverlay
+              getEventRoot={getContentControlEventRoot}
+              getEditorView={getBodyEditorView}
+            />
 
             {/* Toast notifications */}
             {/* Toast notifications provided by host app */}

--- a/packages/vue/src/components/ContentControlWidgetsOverlay.vue
+++ b/packages/vue/src/components/ContentControlWidgetsOverlay.vue
@@ -52,7 +52,10 @@ import { useDocxPortalClass } from "../composables/usePortalClass";
 import { useTranslation } from "../i18n";
 import { useFolioUI } from "../ui/folio-ui";
 
-const props = defineProps<{ view: EditorView | null }>();
+const props = defineProps<{
+  eventRoot: HTMLElement | null;
+  view: EditorView | null;
+}>();
 
 const { t } = useTranslation();
 const { Button: FolioButton, DatePickerPopover } = useFolioUI();
@@ -64,8 +67,8 @@ const unsubscribe = controller.subscribe(() => {
 });
 
 watch(
-  () => props.view,
-  (view) => controller.bind(view),
+  [() => props.view, () => props.eventRoot],
+  ([view, eventRoot]) => controller.bind(view, eventRoot),
   { immediate: true },
 );
 

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -389,7 +389,7 @@
       @close-image-context-menu="imageContextMenu = null"
       @open-image-properties="showImageProperties = true"
     />
-    <ContentControlWidgetsOverlay :view="editorView" />
+    <ContentControlWidgetsOverlay :event-root="readOnly ? null : pagesRef" :view="editorView" />
   </div>
 </template>
 

--- a/tests/parity/content-control-widgets.spec.ts
+++ b/tests/parity/content-control-widgets.spec.ts
@@ -7,13 +7,13 @@ forEachAdapter("edits dropdown and date content controls", async (adapter, { pag
     true,
   );
 
-  const dropdown = page.locator('[data-sdt-type="dropdown"]').first();
+  const dropdown = page.locator('.paged-editor__pages [data-sdt-type="dropdown"]').first();
   await expect(dropdown).toBeVisible();
   await dropdown.click();
   await page.getByRole("menuitem", { name: "New York" }).click();
   await expect(dropdown).toContainText("New York");
 
-  const date = page.locator('[data-sdt-type="date"]').first();
+  const date = page.locator('.paged-editor__pages [data-sdt-type="date"]').first();
   await expect(date).toBeVisible();
   await date.click();
   await page.locator('input[type="date"]').fill("2026-06-02");

--- a/tests/parity/vue-table-properties.spec.ts
+++ b/tests/parity/vue-table-properties.spec.ts
@@ -12,8 +12,14 @@ test("Vue applies table properties from the table options menu", async ({ page }
   await ensureLiveView(page);
   expect(await page.evaluate(() => window.__folioParity?.insertTable(2, 2) ?? false)).toBe(true);
 
-  await page.getByTitle("Table options").click();
-  await page.getByRole("button", { name: "Table properties" }).click();
+  const tableOptions = page.getByTitle("Table options");
+  await tableOptions.scrollIntoViewIfNeeded();
+  await tableOptions.click();
+
+  const tableProperties = page.getByRole("button", { name: "Table properties" });
+  await expect(tableProperties).toBeVisible();
+  await tableProperties.scrollIntoViewIfNeeded();
+  await tableProperties.click();
 
   const dialog = page.getByRole("dialog", { name: "Table Properties" });
   await expect(dialog).toBeVisible();


### PR DESCRIPTION
Routes painted document-body content-control interactions through the shared core handler in both React and Vue, while preserving read-only and header/footer isolation.

Also restores the injected React menu root required by dropdown controls and stabilizes the affected browser parity coverage. Includes the required patch changeset for core, React, and Vue.

Validated with focused parity tests, full core/react/vue unit suites, typecheck, lint, build, clean-room distribution validation, and a clean security/dependency audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content-control clicks on rendered editor pages are now supported.
  * React and Vue editors now provide functional dropdown and date pickers.
  * Interactions with locked or unsupported controls are handled gracefully.

* **Bug Fixes**
  * Improved dropdown and date control interactions in paged editors.
  * Updated table properties navigation for more reliable access.

* **Tests**
  * Expanded coverage for rendered content-control interactions and picker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->