### PR TITLE
feat: add tracked table row insertion

### DIFF
--- a/.changeset/tracked-table-row-insertion.md
+++ b/.changeset/tracked-table-row-insertion.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add tracked table row insertion with review resolution and agent-tool support.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -818,7 +818,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     readonly additionalProperties: false;
                 }, {
                     readonly type: "object";
-                    readonly description: "Insert a row next to the row containing the anchor block. Direct mode only.";
+                    readonly description: "Insert a row next to the row containing the anchor block.";
                     readonly properties: {
                         readonly type: {
                             readonly type: "string";
@@ -1829,7 +1829,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
         readonly additionalProperties: false;
     }, {
         readonly type: "object";
-        readonly description: "Insert a row next to the row containing the anchor block. Direct mode only.";
+        readonly description: "Insert a row next to the row containing the anchor block.";
         readonly properties: {
             readonly type: {
                 readonly type: "string";
@@ -2150,7 +2150,7 @@ export type FolioAgentBridge = {
 // @public
 export type FolioAgentChange = {
     id: string;
-    type: "insertion" | "deletion";
+    type: "insertion" | "deletion" | "rowInserted" | "rowDeleted";
     author: string;
     text: string;
     blockId: string | null;

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -71,7 +71,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
-    readonly insertTableRow: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct", "tracked-changes"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
     readonly deleteTableColumn: readonly ["direct"];
@@ -564,13 +564,13 @@ export type FolioReviewChange = {
     id: number;
     type: FolioReviewChangeKind;
     author: string; /** ISO date the change was authored, or `null` when the source omitted it. */
-    date: string | null; /** Inserted text for insertions, removed text for deletions. */
+    date: string | null; /** Affected text, including the row content for structural revisions. */
     text: string;
     blockId: string | null;
 };
 
 // @public (undocumented)
-export type FolioReviewChangeKind = "insertion" | "deletion";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted";
 
 // @public (undocumented)
 export type FolioReviewedStory = {

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -439,7 +439,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
-    readonly insertTableRow: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct", "tracked-changes"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
     readonly deleteTableColumn: readonly ["direct"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -439,7 +439,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
-    readonly insertTableRow: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct", "tracked-changes"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
     readonly deleteTableColumn: readonly ["direct"];

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -396,7 +396,24 @@ export type TableRowAttrs = {
     hidden?: boolean; /** Original row formatting from DOCX for lossless round-trip serialization */
     _originalFormatting?: import__stll_docx_core_model.TableRowFormatting; /** Tracked row property changes (w:trPrChange) for round-trip + accept/reject */
     trPrChange?: import__stll_docx_core_model.TableRowPropertyChange[];
-};
+} & ({
+    trIns: {
+        revisionId: number;
+        author: string;
+        date?: string | null;
+    };
+    trDel?: never;
+} | {
+    trIns?: never; /** Tracked structural row deletion (w:trPr/w:del). */
+    trDel: {
+        revisionId: number;
+        author: string;
+        date?: string | null;
+    };
+} | {
+    trIns?: never;
+    trDel?: never;
+});
 
 // @public
 export type TextBoxAttrs = {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -192,7 +192,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteBlock: readonly ["direct", "tracked-changes"];
     readonly commentOnBlock: readonly ["direct", "tracked-changes"];
     readonly insertSignatureTable: readonly ["direct"];
-    readonly insertTableRow: readonly ["direct"];
+    readonly insertTableRow: readonly ["direct", "tracked-changes"];
     readonly deleteTableRow: readonly ["direct"];
     readonly insertTableColumn: readonly ["direct"];
     readonly deleteTableColumn: readonly ["direct"];
@@ -777,7 +777,7 @@ export type FolioReviewChange = {
     id: number;
     type: FolioReviewChangeKind;
     author: string; /** ISO date the change was authored, or `null` when the source omitted it. */
-    date: string | null; /** Inserted text for insertions, removed text for deletions. */
+    date: string | null; /** Affected text, including the row content for structural revisions. */
     text: string;
     blockId: string | null;
 };
@@ -789,7 +789,7 @@ export type FolioReviewChangeFilter = {
 };
 
 // @public (undocumented)
-export type FolioReviewChangeKind = "insertion" | "deletion";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted";
 
 // @public
 export type FolioReviewComment = {

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -329,7 +329,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
     },
     {
       type: "object",
-      description: "Insert a row next to the row containing the anchor block. Direct mode only.",
+      description: "Insert a row next to the row containing the anchor block.",
       properties: {
         ...operationMetaProperties,
         type: { type: "string", enum: ["insertTableRow"] },
@@ -452,8 +452,8 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       enum: FOLIO_DOCUMENT_OPERATION_MODES,
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
-        '"direct" applies immediately. `formatRange`, `insertSignatureTable`, `insertTableRow`, ' +
-        "`deleteTableRow`, `insertTableColumn`, `deleteTableColumn`, `mergeTableCells`, and " +
+        '"direct" applies immediately. `formatRange`, `insertSignatureTable`, `deleteTableRow`, ' +
+        "`insertTableColumn`, `deleteTableColumn`, `mergeTableCells`, and " +
         '`splitTableCell` support "direct" only.',
     },
     atomic: {

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -157,6 +157,65 @@ describe("parseSuggestChangesInput", () => {
     expect(result.operations[0]?.id).toBe("custom-1");
   });
 
+  test("a tracked table-row insertion accepts position and initial cell text", () => {
+    const result = parseSuggestChangesInput({
+      operations: [
+        {
+          type: "insertTableRow",
+          blockId: "cell-1",
+          position: "before",
+          cellTexts: ["First", "Second"],
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: true,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertTableRow",
+          blockId: "cell-1",
+          position: "before",
+          cellTexts: ["First", "Second"],
+        },
+      ],
+    });
+  });
+
+  test("a tracked table-row insertion rejects invalid cell text", () => {
+    const result = parseSuggestChangesInput({
+      operations: [
+        {
+          type: "insertTableRow",
+          blockId: "cell-1",
+          cellTexts: ["First", 2],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ok:false");
+    }
+    expect(result.error).toContain("cellTexts[1]");
+  });
+
+  test("a tracked table-row insertion rejects an oversized cell list", () => {
+    const result = parseSuggestChangesInput({
+      operations: [
+        {
+          type: "insertTableRow",
+          blockId: "cell-1",
+          cellTexts: Array.from({ length: 257 }, () => ""),
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ok:false");
+    }
+    expect(result.error).toContain("256-cell limit");
+  });
+
   test("an optional comment attaches a review comment to the operation", () => {
     const result = parseSuggestChangesInput({
       operations: [{ type: "deleteBlock", blockId: "b1", comment: "why this edit" }],
@@ -293,7 +352,6 @@ describe("parseSuggestChangesInput", () => {
       "formatRange",
       "commentOnBlock",
       "insertSignatureTable",
-      "insertTableRow",
       "deleteTableRow",
       "insertTableColumn",
       "deleteTableColumn",

--- a/packages/agents/src/parse.ts
+++ b/packages/agents/src/parse.ts
@@ -33,6 +33,7 @@ const isNonEmptyString = (value: unknown): value is string =>
  */
 export const MAX_OPERATIONS_PER_CALL = 50;
 export const MAX_OPERATION_TEXT_LENGTH = 100_000;
+const MAX_TABLE_ROW_CELL_TEXTS = 256;
 
 /** Plain-language error for a string argument over {@link MAX_OPERATION_TEXT_LENGTH}. */
 export const explainTextTooLong = (label: string, length: number): string =>
@@ -83,7 +84,7 @@ export const parseAddCommentInput = (args: unknown): ParseAddCommentResult => {
 };
 
 const OPERATION_TYPES =
-  "replaceInBlock, replaceRange, commentOnRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock";
+  "replaceInBlock, replaceRange, commentOnRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow";
 
 type SuggestedOperationType =
   | "replaceInBlock"
@@ -92,7 +93,8 @@ type SuggestedOperationType =
   | "insertAfterBlock"
   | "insertBeforeBlock"
   | "replaceBlock"
-  | "deleteBlock";
+  | "deleteBlock"
+  | "insertTableRow";
 
 const isOperationType = (value: unknown): value is SuggestedOperationType =>
   value === "replaceInBlock" ||
@@ -101,7 +103,8 @@ const isOperationType = (value: unknown): value is SuggestedOperationType =>
   value === "insertAfterBlock" ||
   value === "insertBeforeBlock" ||
   value === "replaceBlock" ||
-  value === "deleteBlock";
+  value === "deleteBlock" ||
+  value === "insertTableRow";
 
 const readTextRange = (value: unknown, index: number): FolioAITextRangeHandle | string => {
   const path = `operations[${index}].range`;
@@ -180,6 +183,40 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
 
   if (!isNonEmptyString(blockId)) {
     return `operations[${index}].blockId must be a non-empty string.`;
+  }
+
+  if (type === "insertTableRow") {
+    const position = raw["position"];
+    if (position !== undefined && position !== "after" && position !== "before") {
+      return `operations[${index}] (insertTableRow) \`position\` must be "after" or "before" when provided.`;
+    }
+    const rawCellTexts = raw["cellTexts"];
+    if (rawCellTexts !== undefined && !Array.isArray(rawCellTexts)) {
+      return `operations[${index}] (insertTableRow) \`cellTexts\` must be an array of strings when provided.`;
+    }
+    if (rawCellTexts !== undefined && rawCellTexts.length > MAX_TABLE_ROW_CELL_TEXTS) {
+      return `operations[${index}] (insertTableRow) \`cellTexts\` has ${rawCellTexts.length.toLocaleString()} entries, over the ${MAX_TABLE_ROW_CELL_TEXTS.toLocaleString()}-cell limit.`;
+    }
+    const cellTexts: string[] = [];
+    for (const [cellIndex, cellText] of (rawCellTexts ?? []).entries()) {
+      if (typeof cellText !== "string") {
+        return `operations[${index}] (insertTableRow) \`cellTexts[${cellIndex}]\` must be a string.`;
+      }
+      if (cellText.length > MAX_OPERATION_TEXT_LENGTH) {
+        return explainTextTooLong(
+          `operations[${index}] (insertTableRow) \`cellTexts[${cellIndex}]\``,
+          cellText.length,
+        );
+      }
+      cellTexts.push(cellText);
+    }
+    return {
+      id: opId,
+      type,
+      blockId,
+      ...(position !== undefined && { position }),
+      ...(rawCellTexts !== undefined && { cellTexts }),
+    };
   }
 
   if (type === "replaceInBlock") {

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,7 +52,7 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `formatRange`, `insertSignatureTable`, `insertTableRow`, `deleteTableRow`,
+ * - excluded types: `formatRange`, `insertSignatureTable`, `deleteTableRow`,
  *   `insertTableColumn`, `deleteTableColumn`, `mergeTableCells`, and `splitTableCell` (direct-only,
  *   not representable as tracked changes for human review)
  *   and `commentOnBlock` (covered by the dedicated `add_comment` tool);
@@ -62,14 +62,13 @@ const scopedHandleSchema = {
  *   `{ text }` object;
  * - the review metadata (`severity`, `area`), `precondition` guard, and the
  *   insert/replace formatting knobs (`inheritFormatting`, `pageBreakBefore`,
- *   `preserveFormatting`, `styleId`, `position`, `parties`, `quote`,
+ *   `preserveFormatting`, `styleId`, `parties`, `quote`,
  *   `formatting`) are not exposed to the model.
  */
 const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperationType> = new Set([
   "formatRange",
   "commentOnBlock",
   "insertSignatureTable",
-  "insertTableRow",
   "deleteTableRow",
   "insertTableColumn",
   "deleteTableColumn",
@@ -125,6 +124,17 @@ const suggestChangesOperationSchema = {
       type: "string",
       description:
         "Required for `insertAfterBlock` / `insertBeforeBlock` / `replaceBlock`: the text to insert or replace the block with, up to 100,000 characters.",
+    },
+    position: {
+      type: "string",
+      enum: ["after", "before"],
+      description: "For row insertion, place the new row after the anchor row or before it.",
+    },
+    cellTexts: {
+      type: "array",
+      description: "For row insertion, initial text for physical cells in source order.",
+      maxItems: 256,
+      items: { type: "string" },
     },
     comment: {
       type: "string",
@@ -283,7 +293,7 @@ export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[] = [
   {
     name: FOLIO_AGENT_TOOL_NAMES.readChanges,
     description:
-      "Read pending tracked changes (insertions and deletions) awaiting human review. Use this to see the effect " +
+      "Read pending tracked changes awaiting human review. Use this to see the effect " +
       "of edits already suggested via `suggest_changes` before proposing more.",
     inputSchema: {
       type: "object",

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -132,7 +132,8 @@ const suggestChangesOperationSchema = {
     },
     cellTexts: {
       type: "array",
-      description: "For row insertion, initial text for physical cells in source order.",
+      description:
+        "For row insertion, initial text for physical cells in source order, up to 100,000 characters per cell.",
       maxItems: 256,
       items: { type: "string" },
     },

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -155,10 +155,10 @@ export type FolioAgentComment = {
   replies: FolioAgentCommentReply[];
 };
 
-/** A pending tracked change (insertion or deletion), shaped to match {@link FolioDocxReviewer.getChanges}. */
+/** A pending tracked change, shaped to match {@link FolioDocxReviewer.getChanges}. */
 export type FolioAgentChange = {
   id: string;
-  type: "insertion" | "deletion";
+  type: "insertion" | "deletion" | "rowInserted" | "rowDeleted";
   author: string;
   text: string;
   blockId: string | null;

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -34,6 +34,10 @@ const schema = new Schema({
     tableRow: {
       content: "tableCell*",
       tableRole: "row",
+      attrs: {
+        trIns: { default: null },
+        trDel: { default: null },
+      },
     },
     tableCell: {
       content: "block+",
@@ -3217,7 +3221,7 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.child(0).childCount).toBe(1);
   });
 
-  test("table-row inserts are skipped in tracked-changes mode", () => {
+  test("table-row inserts create one structural revision in tracked-changes mode", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [
         schema.node("tableCell", null, [
@@ -3236,10 +3240,43 @@ describe("Folio AI edit operations", () => {
       mode: "tracked-changes",
     });
 
+    expect(result.skipped).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    const revisionId = result.applied.at(0)?.revisionId;
+    expect(typeof revisionId).toBe("number");
+    expect(result.applied.at(0)?.revisionIds).toEqual([revisionId]);
+    const liveTable = view.state.doc.child(0);
+    expect(liveTable.childCount).toBe(2);
+    expect(liveTable.child(1).attrs["trIns"]).toEqual({
+      revisionId,
+      author: "AI",
+      date: expect.any(String),
+    });
+  });
+
+  test("tracked row insertion rejects a boundary crossed by a vertical span", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", { rowspan: 2 }, [
+          schema.node("paragraph", { paraId: "spanned-cell" }, [schema.text("Cell")]),
+        ]),
+      ]),
+      schema.node("tableRow"),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "insert-row", type: "insertTableRow", blockId: "spanned-cell" }],
+      mode: "tracked-changes",
+    });
+
     expect(result).toEqual({
       applied: [],
-      skipped: [{ id: "insert-row", reason: "unsupportedMode" }],
+      skipped: [{ id: "insert-row", reason: "unsupportedBlock" }],
     });
-    expect(view.state.doc.child(0).childCount).toBe(1);
+    expect(view.state.doc).toEqual(state.doc);
   });
 });

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1002,7 +1002,6 @@ const applyFolioAIEditOperationsInternal = ({
     if (
       mode === "tracked-changes" &&
       (operation.type === "formatRange" ||
-        operation.type === "insertTableRow" ||
         operation.type === "deleteTableRow" ||
         operation.type === "insertTableColumn" ||
         operation.type === "deleteTableColumn" ||
@@ -1424,6 +1423,13 @@ const applyFolioAIEditOperationsInternal = ({
           });
           continue;
         }
+        if (mode === "tracked-changes" && insertion.rowspanUpdates.length > 0) {
+          skipped.push({
+            id: item.operation.id,
+            reason: "unsupportedBlock",
+          });
+          continue;
+        }
         const liveRowspanUpdates: { position: number; cell: PMNode; rowspan: number }[] = [];
         let invalidRowspanUpdate = false;
         for (const updatePosition of insertion.rowspanUpdates) {
@@ -1453,7 +1459,19 @@ const applyFolioAIEditOperationsInternal = ({
             rowspan: update.rowspan + 1,
           });
         }
-        const row = insertion.rowType.create(null, insertion.cells);
+        let rowAttrs: Record<string, unknown> | null = null;
+        if (mode === "tracked-changes") {
+          const revisionId = revisionSeed++;
+          rowAttrs = {
+            trIns: {
+              revisionId,
+              author,
+              date,
+            },
+          };
+          appliedRevisionIds = [revisionId];
+        }
+        const row = insertion.rowType.create(rowAttrs, insertion.cells);
         tr = tr.insert(insertion.rowPosition, populateTableRow(row, item.operation.cellTexts));
         break;
       }

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -278,6 +278,76 @@ describe("headless docx review round-trip", () => {
     expect(restoredTable.rows).toHaveLength(1);
   });
 
+  test("tracks, persists, accepts, and rejects a row insertion", async () => {
+    const baseline = await buildTextBoxTableDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "tracked-changes",
+      operations: [
+        {
+          id: "insert-row",
+          type: "insertTableRow",
+          blockId: target.id,
+          cellTexts: ["Added value"],
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.applied).toHaveLength(1);
+    expect(typeof result.applied.at(0)?.revisionId).toBe("number");
+    const pendingChange = reviewer.getChanges().find(({ type }) => type === "rowInserted");
+    if (!pendingChange) {
+      throw new Error("expected a pending row insertion");
+    }
+    expect(pendingChange.author).toBe("Reviewer");
+
+    const pending = await reviewer.toBuffer();
+    const pendingXml = await partText(pending, "word/document.xml");
+    expect(pendingXml).toContain("<w:ins ");
+    expect(pendingXml).toContain("Added value");
+
+    const reopened = await FolioDocxReviewer.fromBuffer(pending);
+    const reopenedChange = reopened.getChanges().find(({ type }) => type === "rowInserted");
+    if (!reopenedChange) {
+      throw new Error("expected the row insertion after reopen");
+    }
+
+    expect(reopened.acceptChange(reopenedChange)).toBe(true);
+    const accepted = await reopened.toBuffer();
+    expect(await partText(accepted, "word/document.xml")).not.toContain("<w:ins ");
+    expect(reopened.getContentAsText()).toContain("Added value");
+    const acceptedTable = findTextBoxShape(
+      await parseDocx(accepted, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(acceptedTable?.type).toBe("table");
+    if (acceptedTable?.type !== "table") {
+      throw new Error("expected an accepted table");
+    }
+    expect(acceptedTable.rows).toHaveLength(2);
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(pending);
+    const rejectChange = rejecting.getChanges().find(({ type }) => type === "rowInserted");
+    if (!rejectChange) {
+      throw new Error("expected the row insertion before rejection");
+    }
+    expect(rejecting.rejectChange(rejectChange)).toBe(true);
+    const rejected = await rejecting.toBuffer();
+    expect(await partText(rejected, "word/document.xml")).not.toContain("<w:ins ");
+    expect(rejecting.getContentAsText()).not.toContain("Added value");
+    const rejectedTable = findTextBoxShape(
+      await parseDocx(rejected, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(rejectedTable?.type).toBe("table");
+    if (rejectedTable?.type !== "table") {
+      throw new Error("expected a rejected table");
+    }
+    expect(rejectedTable.rows).toHaveLength(1);
+  });
+
   test("deletes, persists, and undoes a row inside shape text", async () => {
     const baseline = await buildTextBoxTableDocument();
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline);

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -862,10 +862,10 @@ export class FolioDocxReviewer {
   }
 
   /**
-   * The tracked changes (insertions and deletions) present in the body, read
-   * from the same `insertion` / `deletion` marks the editor renders. Each
-   * carries the revision id {@link acceptChange} / {@link rejectChange} resolve
-   * against. Runs of one revision within a block fold into a single entry.
+   * The tracked changes present in the body, including inline and structural
+   * revisions. Each carries the revision id {@link acceptChange} /
+   * {@link rejectChange} resolve against. Related revision sites fold into one
+   * entry where the document model identifies them as one authored change.
    */
   getChanges(filter?: FolioReviewChangeFilter): FolioReviewChange[] {
     const changes = getTrackedChangesFromDoc(this.state.doc);

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -55,11 +55,17 @@ const blockStartIdsFromDoc = (doc: PMNode): Map<number, string> => {
   return starts;
 };
 
-const firstBlockIdWithin = (
-  node: PMNode,
-  nodePos: number,
-  blockStarts: ReadonlyMap<number, string>,
-): string | null => {
+type FirstBlockIdWithinParams = {
+  node: PMNode;
+  nodePos: number;
+  blockStarts: ReadonlyMap<number, string>;
+};
+
+const firstBlockIdWithin = ({
+  node,
+  nodePos,
+  blockStarts,
+}: FirstBlockIdWithinParams): string | null => {
   let blockId: string | null = null;
   node.descendants((child, relativePos) => {
     if (blockId !== null || !child.isTextblock) {
@@ -93,20 +99,21 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
         if (
           typeof marker !== "object" ||
           marker === null ||
-          typeof (marker as { revisionId?: unknown }).revisionId !== "number"
+          !("revisionId" in marker) ||
+          typeof marker.revisionId !== "number"
         ) {
           continue;
         }
-        const revisionId = (marker as { revisionId: number }).revisionId;
-        const author = (marker as { author?: unknown }).author;
-        const date = (marker as { date?: unknown }).date;
+        const revisionId = marker.revisionId;
+        const author = "author" in marker ? marker.author : undefined;
+        const date = "date" in marker ? marker.date : undefined;
         grouped.set(`row:${kind}:${revisionId}:${String(pos)}`, {
           id: revisionId,
           type: kind,
           author: typeof author === "string" ? author : "",
           date: typeof date === "string" ? date : null,
           text: node.textContent,
-          blockId: firstBlockIdWithin(node, pos, blockStarts),
+          blockId: firstBlockIdWithin({ node, nodePos: pos, blockStarts }),
         });
       }
     }

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -13,13 +13,13 @@ import type { Node as PMNode } from "prosemirror-model";
 
 import { createFolioAIEditSnapshot } from "./snapshot";
 
-export type FolioReviewChangeKind = "insertion" | "deletion";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted";
 
-/** A tracked change (insertion or deletion) discovered in the document body. */
+/** A tracked change discovered in the document body. */
 export type FolioReviewChange = {
   /**
    * The tracked-change revision id — the OOXML `w:id` carried on the
-   * insertion / deletion mark. A replace produces two changes (a deletion side
+   * revision marker. A text replacement produces two changes (a deletion side
    * and an insertion side) with distinct ids.
    */
   id: number;
@@ -27,7 +27,7 @@ export type FolioReviewChange = {
   author: string;
   /** ISO date the change was authored, or `null` when the source omitted it. */
   date: string | null;
-  /** Inserted text for insertions, removed text for deletions. */
+  /** Affected text, including the row content for structural revisions. */
   text: string;
   /**
    * Stable id of the containing body block (Word `w14:paraId` or `seq-NNNN`).
@@ -55,10 +55,26 @@ const blockStartIdsFromDoc = (doc: PMNode): Map<number, string> => {
   return starts;
 };
 
+const firstBlockIdWithin = (
+  node: PMNode,
+  nodePos: number,
+  blockStarts: ReadonlyMap<number, string>,
+): string | null => {
+  let blockId: string | null = null;
+  node.descendants((child, relativePos) => {
+    if (blockId !== null || !child.isTextblock) {
+      return blockId === null;
+    }
+    blockId = blockStarts.get(nodePos + 1 + relativePos) ?? null;
+    return false;
+  });
+  return blockId;
+};
+
 /**
- * The tracked changes (insertions and deletions) present in the body, read from
- * the `insertion` / `deletion` marks the editor renders. Runs of one revision
- * within a block fold into a single entry.
+ * The tracked changes present in the body, read from inline marks and
+ * structural node attributes. Runs of one inline revision within a block fold
+ * into a single entry.
  */
 export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
   const insertionType = doc.type.schema.marks["insertion"];
@@ -68,6 +84,32 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
   let currentBlockId: string | null = null;
 
   doc.descendants((node, pos) => {
+    if (node.type.name === "tableRow") {
+      for (const [attrName, kind] of [
+        ["trIns", "rowInserted"],
+        ["trDel", "rowDeleted"],
+      ] as const) {
+        const marker = node.attrs[attrName];
+        if (
+          typeof marker !== "object" ||
+          marker === null ||
+          typeof (marker as { revisionId?: unknown }).revisionId !== "number"
+        ) {
+          continue;
+        }
+        const revisionId = (marker as { revisionId: number }).revisionId;
+        const author = (marker as { author?: unknown }).author;
+        const date = (marker as { date?: unknown }).date;
+        grouped.set(`row:${kind}:${revisionId}:${String(pos)}`, {
+          id: revisionId,
+          type: kind,
+          author: typeof author === "string" ? author : "",
+          date: typeof date === "string" ? date : null,
+          text: node.textContent,
+          blockId: firstBlockIdWithin(node, pos, blockStarts),
+        });
+      }
+    }
     if (node.isTextblock) {
       currentBlockId = blockStarts.get(pos) ?? null;
       return true;

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -52,7 +52,7 @@ describe("document operation contract", () => {
         deleteBlock: ["direct", "tracked-changes"],
         commentOnBlock: ["direct", "tracked-changes"],
         insertSignatureTable: ["direct"],
-        insertTableRow: ["direct"],
+        insertTableRow: ["direct", "tracked-changes"],
         deleteTableRow: ["direct"],
         insertTableColumn: ["direct"],
         deleteTableColumn: ["direct"],

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -78,7 +78,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   deleteBlock: DIRECT_AND_TRACKED_MODES,
   commentOnBlock: DIRECT_AND_TRACKED_MODES,
   insertSignatureTable: DIRECT_ONLY_MODES,
-  insertTableRow: DIRECT_ONLY_MODES,
+  insertTableRow: DIRECT_AND_TRACKED_MODES,
   deleteTableRow: DIRECT_ONLY_MODES,
   insertTableColumn: DIRECT_ONLY_MODES,
   deleteTableColumn: DIRECT_ONLY_MODES,

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -437,6 +437,14 @@ export const readTableRowAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Tabl
   optionalBoolean(attrs, "isHeader", "tableRow.attrs.isHeader", issues);
   optionalBoolean(attrs, "hidden", "tableRow.attrs.hidden", issues);
   optionalRecord(attrs, "_originalFormatting", "tableRow.attrs._originalFormatting", issues);
+  optionalTableRowRevision(attrs, "trIns", issues);
+  optionalTableRowRevision(attrs, "trDel", issues);
+  if (attrs["trIns"] != null && attrs["trDel"] != null) {
+    issues.push({
+      path: "tableRow.attrs",
+      message: "Expected at most one structural revision marker.",
+    });
+  }
 
   return attrsResult(attrs, issues);
 };
@@ -1507,6 +1515,25 @@ const optionalRecord = (
   if (value !== undefined && value !== null && !isRecord(value)) {
     issues.push({ path, message: "Expected an object." });
   }
+};
+
+const optionalTableRowRevision = (
+  attrs: Record<string, unknown>,
+  key: "trIns" | "trDel",
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  const path = `tableRow.attrs.${key}`;
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+  requiredNumber(value, "revisionId", `${path}.revisionId`, issues);
+  requiredString(value, "author", `${path}.author`, issues);
+  optionalString(value, "date", `${path}.date`, issues);
 };
 
 const optionalTextBoxTrackedChange = (

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -7,11 +7,13 @@ import type { Command, Transaction } from "prosemirror-state";
 
 import {
   acceptChange,
+  acceptAllChanges,
   acceptAIEditRevision,
   findChangeAtPosition,
   findNextChange,
   findPreviousChange,
   rejectAIEditRevision,
+  rejectAllChanges,
   rejectChange,
 } from "./comments";
 
@@ -252,6 +254,20 @@ describe("table row structural revision resolution", () => {
     expect(rejectAIEditRevision(41)(rejecting.state, rejecting.dispatch)).toBe(true);
     expect(rejecting.state.doc.firstChild?.textContent).toBe("OriginalChanged");
     expect(rejecting.state.doc.firstChild?.child(1).attrs["trDel"]).toBeNull();
+  });
+
+  test("bulk accept and reject resolve inserted rows", () => {
+    const marker = {
+      trIns: { revisionId: 51, author: "Reviewer", date: "2026-07-16" },
+    };
+    const accepting = dispatcher(stateWithRows(marker));
+    expect(acceptAllChanges()(accepting.state, accepting.dispatch)).toBe(true);
+    expect(accepting.state.doc.firstChild?.childCount).toBe(2);
+    expect(accepting.state.doc.firstChild?.child(1).attrs["trIns"]).toBeNull();
+
+    const rejecting = dispatcher(stateWithRows(marker));
+    expect(rejectAllChanges()(rejecting.state, rejecting.dispatch)).toBe(true);
+    expect(rejecting.state.doc.firstChild?.textContent).toBe("Original");
   });
 });
 

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -269,6 +269,44 @@ describe("table row structural revision resolution", () => {
     expect(rejectAllChanges()(rejecting.state, rejecting.dispatch)).toBe(true);
     expect(rejecting.state.doc.firstChild?.textContent).toBe("Original");
   });
+
+  test("rejecting the only inserted row preserves a valid document", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            row("Changed", {
+              trIns: { revisionId: 61, author: "Reviewer", date: "2026-07-16" },
+            }),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(rejectAIEditRevision(61)(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
+
+  test("accepting the only deleted row preserves a valid document", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            row("Changed", {
+              trDel: { revisionId: 62, author: "Reviewer", date: "2026-07-16" },
+            }),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(62)(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
 });
 
 describe("findChangeAtPosition", () => {

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -58,6 +58,45 @@ const schema = new Schema({
   },
 });
 
+const tableSchema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { content: "text*", group: "block" },
+    text: { group: "inline" },
+    table: { content: "tableRow+", group: "block", tableRole: "table" },
+    tableRow: {
+      content: "tableCell+",
+      tableRole: "row",
+      attrs: {
+        trIns: { default: null },
+        trDel: { default: null },
+        trPrChange: { default: null },
+      },
+    },
+    tableCell: {
+      content: "block+",
+      tableRole: "cell",
+      isolating: true,
+      attrs: {
+        colspan: { default: 1 },
+        rowspan: { default: 1 },
+        colwidth: { default: null },
+        tcPrChange: { default: null },
+      },
+    },
+  },
+  marks: {
+    insertion: {
+      attrs: { revisionId: {}, author: {}, date: {} },
+      excludes: "",
+    },
+    deletion: {
+      attrs: { revisionId: {}, author: {}, date: {} },
+      excludes: "",
+    },
+  },
+});
+
 const REV_A_ATTRS = { revisionId: 1, author: "AI", date: "2026-01-01" };
 const REV_B_ATTRS = { revisionId: 2, author: "AI", date: "2026-01-02" };
 
@@ -130,6 +169,89 @@ describe("AI revision accept/reject scoping", () => {
     // remaining insertion mark belongs to revision B alone.
     expect(view.state.doc.textContent).toBe(" middle beta");
     expect(insertionRevisionsAt(view.state)).toEqual([2]);
+  });
+});
+
+describe("table row structural revision resolution", () => {
+  const row = (
+    text: string,
+    marker:
+      | { trIns: { revisionId: number; author: string; date: string } }
+      | { trDel: { revisionId: number; author: string; date: string } }
+      | undefined,
+  ) =>
+    tableSchema.node("tableRow", marker, [
+      tableSchema.node("tableCell", null, [
+        tableSchema.node("paragraph", null, [tableSchema.text(text)]),
+      ]),
+    ]);
+
+  const stateWithRows = (
+    marker:
+      | { trIns: { revisionId: number; author: string; date: string } }
+      | { trDel: { revisionId: number; author: string; date: string } },
+  ) =>
+    EditorState.create({
+      schema: tableSchema,
+      doc: tableSchema.node("doc", null, [
+        tableSchema.node("table", null, [row("Original", undefined), row("Changed", marker)]),
+      ]),
+    });
+
+  test("accept keeps an inserted row and clears its marker", () => {
+    const view = dispatcher(
+      stateWithRows({
+        trIns: { revisionId: 31, author: "Reviewer", date: "2026-07-16" },
+      }),
+    );
+
+    expect(acceptAIEditRevision(31)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.firstChild;
+    expect(table?.childCount).toBe(2);
+    expect(table?.child(1).attrs["trIns"]).toBeNull();
+  });
+
+  test("reject removes an inserted row without consuming another row revision", () => {
+    const inserted = row("Changed", {
+      trIns: { revisionId: 31, author: "Reviewer", date: "2026-07-16" },
+    });
+    const pending = row("Pending", {
+      trIns: { revisionId: 32, author: "Reviewer", date: "2026-07-16" },
+    });
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [row("Original", undefined), inserted, pending]),
+        ]),
+      }),
+    );
+
+    expect(rejectAIEditRevision(31)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.firstChild;
+    expect(table?.childCount).toBe(2);
+    expect(table?.textContent).toBe("OriginalPending");
+    expect(table?.child(1).attrs["trIns"]).toEqual({
+      revisionId: 32,
+      author: "Reviewer",
+      date: "2026-07-16",
+    });
+  });
+
+  test("accept removes a deleted row and reject restores it", () => {
+    const marker = {
+      trDel: { revisionId: 41, author: "Reviewer", date: "2026-07-16" },
+    };
+    const accepting = dispatcher(stateWithRows(marker));
+    expect(acceptAIEditRevision(41)(accepting.state, accepting.dispatch)).toBe(true);
+    expect(accepting.state.doc.firstChild?.textContent).toBe("Original");
+
+    const rejecting = dispatcher(stateWithRows(marker));
+    expect(rejectAIEditRevision(41)(rejecting.state, rejecting.dispatch)).toBe(true);
+    expect(rejecting.state.doc.firstChild?.textContent).toBe("OriginalChanged");
+    expect(rejecting.state.doc.firstChild?.child(1).attrs["trDel"]).toBeNull();
   });
 });
 

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -357,7 +357,8 @@ function isTableRowRevisionAttr(value: unknown): value is TableRowRevisionAttr {
   return (
     typeof value === "object" &&
     value !== null &&
-    typeof (value as { revisionId?: unknown }).revisionId === "number"
+    "revisionId" in value &&
+    typeof value.revisionId === "number"
   );
 }
 
@@ -737,6 +738,7 @@ export function findAIEditRevisionRange(
           if (range.to === null || end > range.to) {
             range.to = end;
           }
+          return false;
         }
       }
     }

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -14,6 +14,7 @@ import type {
   TableFormatting,
   TableRowFormatting,
 } from "../../types/document";
+import { markStructuralChange } from "../extensions/features/ParagraphChangeTrackerExtension";
 import {
   paragraphRejectAttrPatch,
   paragraphRejectOriginalFormatting,
@@ -286,6 +287,7 @@ function resolveChange(
       }
 
       tableRowStructuralOps.sort((left, right) => right.rowPos - left.rowPos);
+      let resolvedTableRowStructure = false;
       for (const op of tableRowStructuralOps) {
         const mappedPos = tr.mapping.map(op.rowPos);
         const row = tr.doc.nodeAt(mappedPos);
@@ -294,9 +296,14 @@ function resolveChange(
         }
         if (op.action === "clear") {
           tr.setNodeAttribute(mappedPos, op.attrName, null);
+          resolvedTableRowStructure = true;
           continue;
         }
         deleteTableRowAt(tr, mappedPos);
+        resolvedTableRowStructure = true;
+      }
+      if (resolvedTableRowStructure) {
+        markStructuralChange(tr);
       }
 
       if (tr.steps.length > 0) {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -5,7 +5,8 @@
  */
 
 import type { Mark, Node as PMNode } from "prosemirror-model";
-import type { Command, EditorState } from "prosemirror-state";
+import type { Command, EditorState, Transaction } from "prosemirror-state";
+import { removeRow, TableMap } from "prosemirror-tables";
 
 import type {
   SectionProperties,
@@ -94,9 +95,6 @@ function resolveChange(
   return (state, dispatch) => {
     const insertionType = state.schema.marks["insertion"];
     const deletionType = state.schema.marks["deletion"];
-    if (!insertionType && !deletionType) {
-      return false;
-    }
 
     const keepType = mode === "accept" ? insertionType : deletionType;
     const removeType = mode === "accept" ? deletionType : insertionType;
@@ -109,6 +107,7 @@ function resolveChange(
       const tr = state.tr;
       const deleteRanges: { from: number; to: number }[] = [];
       const pPrMarkOps: PPrMarkOp[] = [];
+      const tableRowStructuralOps: TableRowStructuralOp[] = [];
 
       state.doc.nodesBetween(from, to, (node, pos): boolean => {
         if (node.type.name === "paragraph") {
@@ -203,6 +202,13 @@ function resolveChange(
           return true;
         }
 
+        if (node.type.name === "tableRow" && rangeCoversNode(from, to, pos, node)) {
+          const op = collectTableRowStructuralOp(node, pos, mode, revisionSet);
+          if (op) {
+            tableRowStructuralOps.push(op);
+          }
+        }
+
         // Table property changes (w:tblPrChange / w:trPrChange / w:tcPrChange)
         // carried on the table / row / cell node attrs.
         const tableChangeAttrName = TABLE_PROPERTY_CHANGE_ATTR_BY_NODE[node.type.name];
@@ -279,6 +285,20 @@ function resolveChange(
         }
       }
 
+      tableRowStructuralOps.sort((left, right) => right.rowPos - left.rowPos);
+      for (const op of tableRowStructuralOps) {
+        const mappedPos = tr.mapping.map(op.rowPos);
+        const row = tr.doc.nodeAt(mappedPos);
+        if (!row || row.type.name !== "tableRow") {
+          continue;
+        }
+        if (op.action === "clear") {
+          tr.setNodeAttribute(mappedPos, op.attrName, null);
+          continue;
+        }
+        deleteTableRowAt(tr, mappedPos);
+      }
+
       if (tr.steps.length > 0) {
         dispatch(tr);
       }
@@ -291,6 +311,91 @@ type PPrMarkOp = {
   paragraphPos: number;
   action: "clear" | "join";
 };
+
+type TableRowStructuralOp = {
+  rowPos: number;
+  attrName: "trIns" | "trDel";
+  action: "clear" | "remove";
+};
+
+type TableRowRevisionAttr = {
+  revisionId: number;
+};
+
+function collectTableRowStructuralOp(
+  node: PMNode,
+  rowPos: number,
+  mode: "accept" | "reject",
+  revisionSet: Set<number> | null,
+): TableRowStructuralOp | null {
+  for (const attrName of ["trIns", "trDel"] as const) {
+    const marker = node.attrs[attrName];
+    if (!isTableRowRevisionAttr(marker)) {
+      continue;
+    }
+    if (revisionSet !== null && !revisionSet.has(marker.revisionId)) {
+      continue;
+    }
+    const keepsRow = (attrName === "trIns") === (mode === "accept");
+    return {
+      rowPos,
+      attrName,
+      action: keepsRow ? "clear" : "remove",
+    };
+  }
+  return null;
+}
+
+function isTableRowRevisionAttr(value: unknown): value is TableRowRevisionAttr {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { revisionId?: unknown }).revisionId === "number"
+  );
+}
+
+function deleteTableRowAt(tr: Transaction, rowPos: number): void {
+  const resolved = tr.doc.resolve(rowPos);
+  const table = resolved.parent;
+  if (table.type.spec["tableRole"] !== "table") {
+    return;
+  }
+  const rowIndex = resolved.index();
+  if (table.childCount > 1) {
+    const map = TableMap.get(table);
+    removeRow(
+      tr,
+      {
+        map,
+        table,
+        tableStart: resolved.start(),
+        left: 0,
+        top: rowIndex,
+        right: map.width,
+        bottom: rowIndex + 1,
+      },
+      rowIndex,
+    );
+    return;
+  }
+
+  const tablePosition = resolved.start() - 1;
+  const tableEnd = tablePosition + table.nodeSize;
+  const outerResolved = tr.doc.resolve(tablePosition);
+  const parent = outerResolved.parent;
+  const tableIndex = outerResolved.index();
+  if (parent.canReplace(tableIndex, tableIndex + 1)) {
+    tr.delete(tablePosition, tableEnd);
+    return;
+  }
+  const emptyParagraph = tr.doc.type.schema.nodes["paragraph"]?.createAndFill();
+  if (
+    emptyParagraph &&
+    parent.canReplaceWith(tableIndex, tableIndex + 1, emptyParagraph.type, emptyParagraph.marks)
+  ) {
+    tr.replaceWith(tablePosition, tableEnd, emptyParagraph);
+  }
+}
 
 export type ParagraphBoundaryChange = {
   from: number;
@@ -608,14 +713,26 @@ export function findAIEditRevisionRange(
 ): { from: number; to: number } | null {
   const insertionType = state.schema.marks["insertion"];
   const deletionType = state.schema.marks["deletion"];
-  if (!insertionType && !deletionType) {
-    return null;
-  }
   const idSet = new Set<number>(typeof revisionIds === "number" ? [revisionIds] : revisionIds);
 
   const range = { from: null as number | null, to: null as number | null };
 
   state.doc.descendants((node, pos) => {
+    if (node.type.name === "tableRow") {
+      for (const attrName of ["trIns", "trDel"] as const) {
+        const marker = node.attrs[attrName];
+        if (isTableRowRevisionAttr(marker) && idSet.has(marker.revisionId)) {
+          const start = pos;
+          const end = pos + node.nodeSize;
+          if (range.from === null || start < range.from) {
+            range.from = start;
+          }
+          if (range.to === null || end > range.to) {
+            range.to = end;
+          }
+        }
+      }
+    }
     // Widen from `isText` to `isInline` so an AI-edit revision on an inline
     // atom (image, shape) shows up in the matched range. eigenpal #641.
     if (!node.isInline) {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -18,6 +18,84 @@ import { fromProseDoc, proseDocToBlocks } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
 describe("fromProseDoc", () => {
+  test("round-trips table row structural revision markers through the editor model", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  structuralChange: {
+                    type: "tableRowInsertion",
+                    info: {
+                      id: 71,
+                      author: "Reviewer",
+                      date: "2026-07-16T08:00:00.000Z",
+                    },
+                  },
+                  cells: [
+                    {
+                      type: "tableCell",
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+                {
+                  type: "tableRow",
+                  structuralChange: {
+                    type: "tableRowDeletion",
+                    info: { id: 72, author: "Reviewer" },
+                  },
+                  cells: [
+                    {
+                      type: "tableCell",
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(pmDoc.firstChild?.child(0).attrs["trIns"]).toEqual({
+      revisionId: 71,
+      author: "Reviewer",
+      date: "2026-07-16T08:00:00.000Z",
+    });
+    expect(pmDoc.firstChild?.child(1).attrs["trDel"]).toEqual({
+      revisionId: 72,
+      author: "Reviewer",
+      date: null,
+    });
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+    if (table?.type !== "table") {
+      throw new Error("Expected table");
+    }
+    expect(table.rows.map(({ structuralChange }) => structuralChange)).toEqual([
+      {
+        type: "tableRowInsertion",
+        info: {
+          id: 71,
+          author: "Reviewer",
+          date: "2026-07-16T08:00:00.000Z",
+        },
+      },
+      {
+        type: "tableRowDeletion",
+        info: { id: 72, author: "Reviewer" },
+      },
+    ]);
+  });
+
   test("round-trips authored table-cell anchor scope through the editor model", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -154,6 +154,47 @@ describe("fromProseDoc", () => {
     expect(() => fromProseDoc(pmDoc)).toThrow("paragraph.attrs.paraId");
   });
 
+  test("rejects malformed table row revision attrs at the conversion boundary", () => {
+    const invalidRevisionDoc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node(
+          "tableRow",
+          {
+            trIns: {
+              revisionId: "71",
+              author: "Reviewer",
+            },
+          },
+          [schema.node("tableCell", null, [schema.node("paragraph")])],
+        ),
+      ]),
+    ]);
+
+    const conflictingRevisionDoc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node(
+          "tableRow",
+          {
+            trIns: {
+              revisionId: 71,
+              author: "Reviewer",
+            },
+            trDel: {
+              revisionId: 72,
+              author: "Reviewer",
+            },
+          },
+          [schema.node("tableCell", null, [schema.node("paragraph")])],
+        ),
+      ]),
+    ]);
+
+    expect(() => fromProseDoc(invalidRevisionDoc)).toThrow("tableRow.attrs.trIns.revisionId");
+    expect(() => fromProseDoc(conflictingRevisionDoc)).toThrow(
+      "Expected at most one structural revision marker.",
+    );
+  });
+
   test("rejects malformed hyperlink attrs at the conversion boundary", () => {
     const hyperlinkMark = schema.mark("hyperlink", { href: 123 });
     const pmDoc = schema.node("doc", null, [

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2586,6 +2586,25 @@ function convertPMTableRow(
   if (Array.isArray(attrs.trPrChange) && attrs.trPrChange.length > 0) {
     row.propertyChanges = [...attrs.trPrChange];
   }
+  if (attrs.trIns) {
+    row.structuralChange = {
+      type: "tableRowInsertion",
+      info: {
+        id: attrs.trIns.revisionId,
+        author: attrs.trIns.author,
+        ...(attrs.trIns.date && { date: attrs.trIns.date }),
+      },
+    };
+  } else if (attrs.trDel) {
+    row.structuralChange = {
+      type: "tableRowDeletion",
+      info: {
+        id: attrs.trDel.revisionId,
+        author: attrs.trDel.author,
+        ...(attrs.trDel.date && { date: attrs.trDel.date }),
+      },
+    };
+  }
   return row;
 }
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2592,7 +2592,7 @@ function convertPMTableRow(
       info: {
         id: attrs.trIns.revisionId,
         author: attrs.trIns.author,
-        ...(attrs.trIns.date && { date: attrs.trIns.date }),
+        ...(attrs.trIns.date != null && { date: attrs.trIns.date }),
       },
     };
   } else if (attrs.trDel) {
@@ -2601,7 +2601,7 @@ function convertPMTableRow(
       info: {
         id: attrs.trDel.revisionId,
         author: attrs.trDel.author,
-        ...(attrs.trDel.date && { date: attrs.trDel.date }),
+        ...(attrs.trDel.date != null && { date: attrs.trDel.date }),
       },
     };
   }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1532,6 +1532,19 @@ function convertTableRow(
   if (row.propertyChanges && row.propertyChanges.length > 0) {
     attrs.trPrChange = [...row.propertyChanges];
   }
+  if (row.structuralChange?.type === "tableRowInsertion") {
+    attrs.trIns = {
+      revisionId: row.structuralChange.info.id,
+      author: row.structuralChange.info.author,
+      date: row.structuralChange.info.date ?? null,
+    };
+  } else if (row.structuralChange?.type === "tableRowDeletion") {
+    attrs.trDel = {
+      revisionId: row.structuralChange.info.id,
+      author: row.structuralChange.info.author,
+      date: row.structuralChange.info.date ?? null,
+    };
+  }
 
   const numCells = row.cells.length;
   const isFirstRow = rowIndex === 0;

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1510,39 +1510,46 @@ function convertTableRow(
   rowSpanMap?: Map<string, RowSpanInfo>,
   defaultCellMargins?: TableCellMarginsAttrs,
 ): PMNode {
-  const attrs: TableRowAttrs = {
+  const attrsWithoutStructuralChange: Omit<TableRowAttrs, "trIns" | "trDel"> = {
     // isHeader controls header row REPETITION on page breaks.
     // Only w:tblHeader (row.formatting.header) should trigger this — NOT tblLook/firstRow
     // which is purely a conditional formatting flag (ECMA-376 §17.7.6.1).
     isHeader: !!row.formatting?.header,
   };
   if (row.formatting?.height?.value !== undefined) {
-    attrs.height = row.formatting.height.value;
+    attrsWithoutStructuralChange.height = row.formatting.height.value;
   }
   if (row.formatting?.heightRule) {
-    attrs.heightRule = row.formatting.heightRule;
+    attrsWithoutStructuralChange.heightRule = row.formatting.heightRule;
   }
   if (row.formatting?.hidden) {
-    attrs.hidden = true;
+    attrsWithoutStructuralChange.hidden = true;
   }
   if (row.formatting) {
-    attrs._originalFormatting = row.formatting;
+    attrsWithoutStructuralChange._originalFormatting = row.formatting;
   }
   // Carry `w:trPrChange` opaquely through PM for round-trip + accept/reject.
   if (row.propertyChanges && row.propertyChanges.length > 0) {
-    attrs.trPrChange = [...row.propertyChanges];
+    attrsWithoutStructuralChange.trPrChange = [...row.propertyChanges];
   }
+  let attrs: TableRowAttrs = attrsWithoutStructuralChange;
   if (row.structuralChange?.type === "tableRowInsertion") {
-    attrs.trIns = {
-      revisionId: row.structuralChange.info.id,
-      author: row.structuralChange.info.author,
-      date: row.structuralChange.info.date ?? null,
+    attrs = {
+      ...attrsWithoutStructuralChange,
+      trIns: {
+        revisionId: row.structuralChange.info.id,
+        author: row.structuralChange.info.author,
+        date: row.structuralChange.info.date ?? null,
+      },
     };
   } else if (row.structuralChange?.type === "tableRowDeletion") {
-    attrs.trDel = {
-      revisionId: row.structuralChange.info.id,
-      author: row.structuralChange.info.author,
-      date: row.structuralChange.info.date ?? null,
+    attrs = {
+      ...attrsWithoutStructuralChange,
+      trDel: {
+        revisionId: row.structuralChange.info.id,
+        author: row.structuralChange.info.author,
+        date: row.structuralChange.info.date ?? null,
+      },
     };
   }
 

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -25,6 +25,7 @@ export const paragraphChangeTrackerKey = new PluginKey<ParagraphChangeTrackerSta
 
 const CLEAR_META = "clear";
 const IGNORE_META = "ignore";
+const STRUCTURAL_META = "structural";
 
 export type ParagraphChangeTrackerState = {
   /** Set of paraIds that were modified since last clear */
@@ -160,7 +161,7 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
         // Clone previous state
         const newState: ParagraphChangeTrackerState = {
           changedParaIds: new Set(prevState.changedParaIds),
-          structuralChange: prevState.structuralChange,
+          structuralChange: prevState.structuralChange || meta === STRUCTURAL_META,
           hasUntrackedChanges: prevState.hasUntrackedChanges,
           paragraphCount: newCount,
         };
@@ -274,6 +275,10 @@ export function clearTrackedChanges(state: EditorState): Transaction {
 
 export function ignoreTrackedChanges(tr: Transaction): Transaction {
   return tr.setMeta(paragraphChangeTrackerKey, IGNORE_META);
+}
+
+export function markStructuralChange(tr: Transaction): Transaction {
+  return tr.setMeta(paragraphChangeTrackerKey, STRUCTURAL_META);
 }
 
 export const ParagraphChangeTrackerExtension = createExtension({

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -337,6 +337,8 @@ const tableRowSpec: NodeSpec = {
     hidden: { default: false },
     _originalFormatting: { default: null },
     trPrChange: { default: null },
+    trIns: { default: null },
+    trDel: { default: null },
   },
   parseDOM: [{ tag: "tr" }],
   toDOM(node) {

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -608,6 +608,16 @@ export type TableRowAttrs = {
   _originalFormatting?: TableRowFormatting;
   /** Tracked row property changes (w:trPrChange) for round-trip + accept/reject */
   trPrChange?: TableRowPropertyChange[];
+  /** Tracked structural row insertion (w:trPr/w:ins). */
+  trIns?: TableRowRevisionAttrs;
+  /** Tracked structural row deletion (w:trPr/w:del). */
+  trDel?: TableRowRevisionAttrs;
+};
+
+export type TableRowRevisionAttrs = {
+  revisionId: number;
+  author: string;
+  date?: string | null;
 };
 
 /**

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -608,17 +608,30 @@ export type TableRowAttrs = {
   _originalFormatting?: TableRowFormatting;
   /** Tracked row property changes (w:trPrChange) for round-trip + accept/reject */
   trPrChange?: TableRowPropertyChange[];
-  /** Tracked structural row insertion (w:trPr/w:ins). */
-  trIns?: TableRowRevisionAttrs;
-  /** Tracked structural row deletion (w:trPr/w:del). */
-  trDel?: TableRowRevisionAttrs;
-};
-
-export type TableRowRevisionAttrs = {
-  revisionId: number;
-  author: string;
-  date?: string | null;
-};
+} & (
+  | {
+      /** Tracked structural row insertion (w:trPr/w:ins). */
+      trIns: {
+        revisionId: number;
+        author: string;
+        date?: string | null;
+      };
+      trDel?: never;
+    }
+  | {
+      trIns?: never;
+      /** Tracked structural row deletion (w:trPr/w:del). */
+      trDel: {
+        revisionId: number;
+        author: string;
+        date?: string | null;
+      };
+    }
+  | {
+      trIns?: never;
+      trDel?: never;
+    }
+);
 
 /**
  * Table cell attributes


### PR DESCRIPTION
Adds tracked table row insertion with accept/reject resolution, persistence, and agent-tool support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inserting table rows with tracked changes.
  * Added review tracking for inserted and deleted table rows.
  * Added agent-tool support for table-row insertion, including placement and cell content validation.
  * Table-row changes can now be accepted or rejected individually or in bulk.

* **Bug Fixes**
  * Improved validation and document round-tripping for structural table-row changes.
  * Prevented unsupported table-row operations involving incompatible row-span updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->