### PR TITLE
fix: bound justified list contraction

### DIFF
--- a/.changeset/flat-wombats-own.md
+++ b/.changeset/flat-wombats-own.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Match Word's bounded space contraction for justified hanging list continuations.

--- a/.changeset/flat-wombats-own.md
+++ b/.changeset/flat-wombats-own.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Match Word's bounded space contraction for justified hanging list continuations.
+Improve bounded space contraction for justified hanging list continuations.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1157,7 +1157,7 @@ describe("measureParagraph justified shrink tolerance", () => {
               indent: { left: 36, hanging: 36 },
             },
           },
-          136,
+          136.4,
         );
         const spacePoorMeasure = measureParagraph(
           {
@@ -1174,7 +1174,7 @@ describe("measureParagraph justified shrink tolerance", () => {
               indent: { left: 36, hanging: 36 },
             },
           },
-          136,
+          136.4,
         );
 
         expect(spaceRichMeasure.lines).toHaveLength(2);
@@ -1182,6 +1182,59 @@ describe("measureParagraph justified shrink tolerance", () => {
       },
       {
         charWidth: fractionalWidth,
+      },
+    );
+  });
+
+  test("allows Word-compatible space contraction on full-hanging list continuations", () => {
+    const continuationText = `${"a ".repeat(10)}bbb`;
+
+    withFakeTextMeasure(
+      () => {
+        const fittingMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-continuation-contraction",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: continuationText },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 36 },
+            },
+          },
+          136,
+        );
+        const overflowingMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-continuation-contraction-boundary",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: continuationText },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 36 },
+            },
+          },
+          135.8,
+        );
+
+        expect(fittingMeasure.lines).toHaveLength(2);
+        expect(overflowingMeasure.lines).toHaveLength(3);
+      },
+      {
+        charWidth: (char) => {
+          if (char === "b") return 5.3;
+          if (char === " ") return 0.55;
+          return 8;
+        },
       },
     );
   });
@@ -1260,7 +1313,7 @@ describe("measureParagraph justified shrink tolerance", () => {
               indent: { left: 24, hanging: 24 },
             },
           },
-          124,
+          124.4,
         );
 
         expect(measure.lines).toHaveLength(2);

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1186,7 +1186,7 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("allows Word-compatible space contraction on full-hanging list continuations", () => {
+  test("allows bounded space contraction on full-hanging list continuations", () => {
     const continuationText = `${"a ".repeat(10)}bbb`;
 
     withFakeTextMeasure(

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -65,7 +65,9 @@ const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 const JUSTIFY_SPACE_CONTRACTION_RATIO = 0.075;
 const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
-const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.23;
+// Word contracts continuation spaces aggressively, but caps the total line shrink.
+const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.32;
+const JUSTIFY_LIST_CONTINUATION_MAX_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
@@ -589,7 +591,7 @@ function uppercaseLetterRatio(text: string): number {
 
 type JustifyFitStrategy =
   | { type: "rounding" }
-  | { type: "space"; ratio: number }
+  | { type: "space"; ratio: number; maxWidthRatio?: number }
   | { type: "width"; ratio: number };
 
 type JustificationProfile = {
@@ -617,7 +619,11 @@ function resolveJustifyFitStrategy(
     if (hanging > 0 && left > hanging) {
       return { type: "width", ratio: JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO };
     }
-    return { type: "space", ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO };
+    return {
+      type: "space",
+      ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO,
+      maxWidthRatio: JUSTIFY_LIST_CONTINUATION_MAX_SHRINK_TOLERANCE_RATIO,
+    };
   }
 
   const hasTabStops = (block.attrs?.tabs?.length ?? 0) > 0;
@@ -658,7 +664,12 @@ function justifyFitTolerance(
   if (strategy.type === "width") {
     return Math.max(WIDTH_TOLERANCE, line.availableWidth * strategy.ratio);
   }
-  return Math.max(WIDTH_TOLERANCE, (line.regularSpaceWidth + candidateSpaceWidth) * strategy.ratio);
+  const spaceTolerance = (line.regularSpaceWidth + candidateSpaceWidth) * strategy.ratio;
+  const boundedTolerance =
+    strategy.maxWidthRatio === undefined
+      ? spaceTolerance
+      : Math.min(spaceTolerance, line.availableWidth * strategy.maxWidthRatio);
+  return Math.max(WIDTH_TOLERANCE, boundedTolerance);
 }
 
 function isShallowFullHangingListContinuation(

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -65,7 +65,7 @@ const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 const JUSTIFY_SPACE_CONTRACTION_RATIO = 0.075;
 const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
-// Word contracts continuation spaces aggressively, but caps the total line shrink.
+// Full-hanging continuations allow stronger space contraction with bounded total shrink.
 const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.32;
 const JUSTIFY_LIST_CONTINUATION_MAX_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO = 0.015;


### PR DESCRIPTION
Allow full-hanging justified list continuations to use a larger measured-space contraction while capping total line shrink. This improves document interoperability without overcompressing later continuation lines.

Adds a synthetic boundary regression and a patch changeset for `@stll/folio-core`.