### PR TITLE
feat: support vertical cell merge revisions

### DIFF
--- a/.changeset/calm-cells-merge.md
+++ b/.changeset/calm-cells-merge.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": minor
+---
+
+Add vertical cell merge revision import, review, resolution, and export support.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -570,7 +570,7 @@ export type FolioReviewChange = {
 };
 
 // @public (undocumented)
-export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted" | "cellMerged";
 
 // @public (undocumented)
 export type FolioReviewedStory = {

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -383,7 +383,7 @@ export type TableCellAttrs = {
         right?: number;
     }; /** Original cell formatting from DOCX for lossless round-trip serialization */
     _originalFormatting?: import__stll_docx_core_model.TableCellFormatting; /** Tracked cell property changes (w:tcPrChange) for round-trip + accept/reject */
-    tcPrChange?: import__stll_docx_core_model.TableCellPropertyChange[]; /** Tracked cell insertion/deletion for round-trip + accept/reject. */
+    tcPrChange?: import__stll_docx_core_model.TableCellPropertyChange[]; /** Tracked cell structural revision for round-trip + accept/reject. */
     cellMarker?: {
         kind: "ins" | "del";
         info: {
@@ -391,6 +391,15 @@ export type TableCellAttrs = {
             author: string;
             date?: string | null;
         };
+    } | {
+        kind: "merge";
+        info: {
+            revisionId: number;
+            author: string;
+            date?: string | null;
+        };
+        verticalMerge?: "continue" | "rest";
+        verticalMergeOriginal?: "continue" | "rest";
     }; /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
     _preserveVMergeRestart?: boolean; /** Original DOCX vMerge continuation cells skipped into this PM rowspan. */
     _docxVMergeContinuationCells?: import__stll_docx_core_model.TableCell[];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -789,7 +789,7 @@ export type FolioReviewChangeFilter = {
 };
 
 // @public (undocumented)
-export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted" | "cellMerged";
 
 // @public
 export type FolioReviewComment = {

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -1189,8 +1189,13 @@ export type TableRowPropertyChange = {
 
 // @public
 export type TableStructuralChangeInfo = {
-    type: "tableRowInsertion" | "tableRowDeletion" | "tableCellInsertion" | "tableCellDeletion" | "tableCellMerge"; /** Tracked change metadata */
+    type: "tableRowInsertion" | "tableRowDeletion" | "tableCellInsertion" | "tableCellDeletion"; /** Tracked change metadata */
     info: TrackedChangeInfo;
+} | {
+    type: "tableCellMerge"; /** Tracked change metadata */
+    info: TrackedChangeInfo; /** Vertical merge state applied by the revision. */
+    verticalMerge?: "continue" | "rest"; /** Vertical merge state that existed before the revision. */
+    verticalMergeOriginal?: "continue" | "rest";
 };
 
 // @public

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -49,6 +49,7 @@ const schema = new Schema({
         rowspan: { default: 1 },
         colwidth: { default: null },
         cellMarker: { default: null },
+        _docxVMergeContinuationCells: { default: null },
       },
     },
   },
@@ -191,6 +192,46 @@ const collectMarksByText = (state: EditorState): Record<string, string[]> => {
 };
 
 describe("Folio AI edit operations", () => {
+  test("reads a vertical merge revision preserved on a collapsed continuation cell", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node(
+            "tableCell",
+            {
+              rowspan: 2,
+              _docxVMergeContinuationCells: [
+                {
+                  type: "tableCell",
+                  formatting: { vMerge: "continue" },
+                  structuralChange: {
+                    type: "tableCellMerge",
+                    info: { id: 90, author: "Reviewer", date: "2026-07-16" },
+                    verticalMerge: "continue",
+                  },
+                  content: [{ type: "paragraph", content: [] }],
+                },
+              ],
+            },
+            [schema.node("paragraph", { paraId: "merge-origin" }, [schema.text("Merged content")])],
+          ),
+        ]),
+        schema.node("tableRow"),
+      ]),
+    ]);
+
+    expect(getTrackedChangesFromDoc(doc)).toEqual([
+      {
+        id: 90,
+        type: "cellMerged",
+        author: "Reviewer",
+        date: "2026-07-16",
+        text: "Merged content",
+        blockId: "merge-origin",
+      },
+    ]);
+  });
+
   test("rejects invalid text range boundaries", () => {
     expect(
       createFolioAITextRangeHandle({

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -199,8 +199,18 @@ describe("Folio AI edit operations", () => {
           schema.node(
             "tableCell",
             {
-              rowspan: 2,
+              rowspan: 3,
               _docxVMergeContinuationCells: [
+                {
+                  type: "tableCell",
+                  formatting: { vMerge: "continue" },
+                  structuralChange: {
+                    type: "tableCellMerge",
+                    info: { id: 90, author: "Reviewer", date: "2026-07-16" },
+                    verticalMerge: "continue",
+                  },
+                  content: [{ type: "paragraph", content: [] }],
+                },
                 {
                   type: "tableCell",
                   formatting: { vMerge: "continue" },
@@ -216,6 +226,7 @@ describe("Folio AI edit operations", () => {
             [schema.node("paragraph", { paraId: "merge-origin" }, [schema.text("Merged content")])],
           ),
         ]),
+        schema.node("tableRow"),
         schema.node("tableRow"),
       ]),
     ]);

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -11,6 +11,7 @@
 
 import type { Node as PMNode } from "prosemirror-model";
 
+import { getTableCellMergeChange } from "../prosemirror/tableCellMergeRevision";
 import { createFolioAIEditSnapshot } from "./snapshot";
 
 export type FolioReviewChangeKind =
@@ -19,7 +20,8 @@ export type FolioReviewChangeKind =
   | "rowInserted"
   | "rowDeleted"
   | "cellInserted"
-  | "cellDeleted";
+  | "cellDeleted"
+  | "cellMerged";
 
 /** A tracked change discovered in the document body. */
 export type FolioReviewChange = {
@@ -129,7 +131,7 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
         typeof marker === "object" &&
         marker !== null &&
         "kind" in marker &&
-        (marker.kind === "ins" || marker.kind === "del") &&
+        (marker.kind === "ins" || marker.kind === "del" || marker.kind === "merge") &&
         "info" in marker &&
         typeof marker.info === "object" &&
         marker.info !== null &&
@@ -139,7 +141,12 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
         const revisionId = marker.info.revisionId;
         const author = "author" in marker.info ? marker.info.author : undefined;
         const date = "date" in marker.info ? marker.info.date : undefined;
-        const kind = marker.kind === "ins" ? "cellInserted" : "cellDeleted";
+        let kind: FolioReviewChangeKind = "cellMerged";
+        if (marker.kind === "ins") {
+          kind = "cellInserted";
+        } else if (marker.kind === "del") {
+          kind = "cellDeleted";
+        }
         const key = `cell:${kind}:${revisionId}`;
         const text = node.textContent;
         const blockId = firstBlockIdWithin({ node, nodePos: pos, blockStarts });
@@ -155,6 +162,30 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
               : existing?.text || text,
           blockId: existing?.blockId ?? blockId,
         });
+      }
+      const continuationCells = node.attrs["_docxVMergeContinuationCells"];
+      if (Array.isArray(continuationCells)) {
+        for (const continuationCell of continuationCells) {
+          const change = getTableCellMergeChange(continuationCell);
+          if (!change) {
+            continue;
+          }
+          const revisionId = change.info.id;
+          const key = `cell:cellMerged:${revisionId}`;
+          const existing = grouped.get(key);
+          const text = node.textContent;
+          grouped.set(key, {
+            id: revisionId,
+            type: "cellMerged",
+            author: change.info.author,
+            date: change.info.date ?? null,
+            text:
+              existing && existing.text.length > 0 && text.length > 0
+                ? `${existing.text}\n${text}`
+                : existing?.text || text,
+            blockId: existing?.blockId ?? firstBlockIdWithin({ node, nodePos: pos, blockStarts }),
+          });
+        }
       }
     }
     if (node.isTextblock) {

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -95,6 +95,7 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
   const deletionType = doc.type.schema.marks["deletion"];
   const blockStarts = blockStartIdsFromDoc(doc);
   const grouped = new Map<string, FolioReviewChange>();
+  const structuralChangeCellPositions = new Map<string, Set<number>>();
   let currentBlockId: string | null = null;
 
   doc.descendants((node, pos) => {
@@ -151,17 +152,21 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
         const text = node.textContent;
         const blockId = firstBlockIdWithin({ node, nodePos: pos, blockStarts });
         const existing = grouped.get(key);
+        const cellPositions = structuralChangeCellPositions.get(key) ?? new Set<number>();
+        const shouldAppendText = existing !== undefined && !cellPositions.has(pos);
         grouped.set(key, {
           id: revisionId,
           type: kind,
           author: typeof author === "string" ? author : "",
           date: typeof date === "string" ? date : null,
           text:
-            existing && existing.text.length > 0 && text.length > 0
+            shouldAppendText && existing.text.length > 0 && text.length > 0
               ? `${existing.text}\n${text}`
               : existing?.text || text,
           blockId: existing?.blockId ?? blockId,
         });
+        cellPositions.add(pos);
+        structuralChangeCellPositions.set(key, cellPositions);
       }
       const continuationCells = node.attrs["_docxVMergeContinuationCells"];
       if (Array.isArray(continuationCells)) {
@@ -174,17 +179,21 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
           const key = `cell:cellMerged:${revisionId}`;
           const existing = grouped.get(key);
           const text = node.textContent;
+          const cellPositions = structuralChangeCellPositions.get(key) ?? new Set<number>();
+          const shouldAppendText = existing !== undefined && !cellPositions.has(pos);
           grouped.set(key, {
             id: revisionId,
             type: "cellMerged",
             author: change.info.author,
             date: change.info.date ?? null,
             text:
-              existing && existing.text.length > 0 && text.length > 0
+              shouldAppendText && existing.text.length > 0 && text.length > 0
                 ? `${existing.text}\n${text}`
                 : existing?.text || text,
             blockId: existing?.blockId ?? firstBlockIdWithin({ node, nodePos: pos, blockStarts }),
           });
+          cellPositions.add(pos);
+          structuralChangeCellPositions.set(key, cellPositions);
         }
       }
     }

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -699,7 +699,16 @@ export function serializeTableCellFormatting(
     } else if (structuralChange.type === "tableCellDeletion") {
       parts.push(`<w:cellDel ${serializeTrackedChangeAttributes(structuralChange.info)}/>`);
     } else if (structuralChange.type === "tableCellMerge") {
-      parts.push(`<w:cellMerge ${serializeTrackedChangeAttributes(structuralChange.info)}/>`);
+      const attrs = [serializeTrackedChangeAttributes(structuralChange.info)];
+      if (structuralChange.verticalMerge) {
+        attrs.push(`w:vMerge="${structuralChange.verticalMerge === "continue" ? "cont" : "rest"}"`);
+      }
+      if (structuralChange.verticalMergeOriginal) {
+        attrs.push(
+          `w:vMergeOrig="${structuralChange.verticalMergeOriginal === "continue" ? "cont" : "rest"}"`,
+        );
+      }
+      parts.push(`<w:cellMerge ${attrs.join(" ")}/>`);
     }
   }
 

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { serializeTableRowFormatting } from "./serializer/tableSerializer";
+import {
+  serializeTableCellFormatting,
+  serializeTableRowFormatting,
+} from "./serializer/tableSerializer";
 import { parseTable, parseTableMeasurement, parseTableRowProperties } from "./tableParser";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
@@ -29,6 +32,54 @@ describe("parseTableMeasurement", () => {
 
   test("keeps canonical pct integers unchanged", () => {
     expect(tblW("5000")).toEqual({ value: 5000, type: "pct" });
+  });
+});
+
+describe("table cell merge revisions", () => {
+  test("preserves original and applied vertical merge states", () => {
+    const table = parseTableXml(`<w:tbl ${NS}>
+      <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+      <w:tr>
+        <w:tc>
+          <w:tcPr>
+            <w:cellMerge w:id="17" w:author="Reviewer" w:vMerge="cont" w:vMergeOrig="rest"/>
+          </w:tcPr>
+          <w:p/>
+        </w:tc>
+      </w:tr>
+    </w:tbl>`);
+
+    const change = table.rows.at(0)?.cells.at(0)?.structuralChange;
+    expect(change).toEqual({
+      type: "tableCellMerge",
+      info: { id: 17, author: "Reviewer" },
+      verticalMerge: "continue",
+      verticalMergeOriginal: "rest",
+    });
+    expect(serializeTableCellFormatting(undefined, undefined, change)).toContain(
+      '<w:cellMerge w:id="17" w:author="Reviewer" w:vMerge="cont" w:vMergeOrig="rest"/>',
+    );
+  });
+
+  test("preserves omitted revision states", () => {
+    const table = parseTableXml(`<w:tbl ${NS}>
+      <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+      <w:tr>
+        <w:tc>
+          <w:tcPr><w:cellMerge w:id="18" w:author="Reviewer"/></w:tcPr>
+          <w:p/>
+        </w:tc>
+      </w:tr>
+    </w:tbl>`);
+
+    const change = table.rows.at(0)?.cells.at(0)?.structuralChange;
+    expect(change).toEqual({
+      type: "tableCellMerge",
+      info: { id: 18, author: "Reviewer" },
+    });
+    expect(serializeTableCellFormatting(undefined, undefined, change)).toContain(
+      '<w:cellMerge w:id="18" w:author="Reviewer"/>',
+    );
   });
 });
 

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -820,12 +820,32 @@ function parseTableCellStructuralChange(
 
   const merge = findChild(tcPrElement, "w", "cellMerge");
   if (merge) {
+    const verticalMerge = parseTableCellVerticalMergeRevisionValue(
+      getAttribute(merge, "w", "vMerge"),
+    );
+    const verticalMergeOriginal = parseTableCellVerticalMergeRevisionValue(
+      getAttribute(merge, "w", "vMergeOrig"),
+    );
     return {
       type: "tableCellMerge",
       info: parseTrackedChangeInfo(merge),
+      ...(verticalMerge !== undefined ? { verticalMerge } : {}),
+      ...(verticalMergeOriginal !== undefined ? { verticalMergeOriginal } : {}),
     };
   }
 
+  return undefined;
+}
+
+function parseTableCellVerticalMergeRevisionValue(
+  value: string | null | undefined,
+): "continue" | "rest" | undefined {
+  if (value === "cont") {
+    return "continue";
+  }
+  if (value === "rest") {
+    return "rest";
+  }
   return undefined;
 }
 

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -1537,7 +1537,7 @@ const optionalTableCellRevision = (
     issues.push({ path, message: "Expected an object." });
     return;
   }
-  requiredOneOf(value, "kind", `${path}.kind`, issues, ["ins", "del"] as const);
+  requiredOneOf(value, "kind", `${path}.kind`, issues, ["ins", "del", "merge"] as const);
   const info = value["info"];
   if (!isRecord(info)) {
     issues.push({ path: `${path}.info`, message: "Expected an object." });
@@ -1546,6 +1546,16 @@ const optionalTableCellRevision = (
   requiredNumber(info, "revisionId", `${path}.info.revisionId`, issues);
   requiredString(info, "author", `${path}.info.author`, issues);
   optionalString(info, "date", `${path}.info.date`, issues);
+  if (value["kind"] === "merge") {
+    optionalOneOf(value, "verticalMerge", `${path}.verticalMerge`, issues, [
+      "continue",
+      "rest",
+    ] as const);
+    optionalOneOf(value, "verticalMergeOriginal", `${path}.verticalMergeOriginal`, issues, [
+      "continue",
+      "rest",
+    ] as const);
+  }
 };
 
 const optionalTextBoxTrackedChange = (

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -67,7 +67,7 @@ const tableSchema = new Schema({
     text: { group: "inline" },
     table: { content: "tableRow+", group: "block", tableRole: "table" },
     tableRow: {
-      content: "tableCell+",
+      content: "tableCell*",
       tableRole: "row",
       attrs: {
         trIns: { default: null },
@@ -85,6 +85,9 @@ const tableSchema = new Schema({
         colwidth: { default: null },
         tcPrChange: { default: null },
         cellMarker: { default: null },
+        _originalFormatting: { default: null },
+        _preserveVMergeRestart: { default: null },
+        _docxVMergeContinuationCells: { default: null },
       },
     },
   },
@@ -462,6 +465,169 @@ describe("table cell structural revision resolution", () => {
     expect(table?.child(0).textContent).toBe("First");
     expect(table?.child(1).textContent).toBe("Second");
     expect(() => view.state.doc.check()).not.toThrow();
+  });
+
+  test("reject restores every cell removed by a pending vertical merge", () => {
+    const continuationCell = {
+      type: "tableCell" as const,
+      formatting: { vMerge: "continue" as const },
+      structuralChange: {
+        type: "tableCellMerge" as const,
+        info: { id: 80, author: "Reviewer" },
+        verticalMerge: "continue" as const,
+      },
+      content: [{ type: "paragraph" as const, content: [] }],
+    };
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            tableSchema.node("tableRow", null, [
+              tableSchema.node(
+                "tableCell",
+                {
+                  rowspan: 3,
+                  _originalFormatting: { vMerge: "restart" },
+                  _docxVMergeContinuationCells: [continuationCell, continuationCell],
+                },
+                [tableSchema.node("paragraph", null, [tableSchema.text("Top")])],
+              ),
+            ]),
+            tableSchema.node("tableRow"),
+            tableSchema.node("tableRow"),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(rejectAIEditRevision(80)(view.state, view.dispatch)).toBe(true);
+    const table = view.state.doc.firstChild;
+    expect(table?.child(0).firstChild?.attrs["rowspan"]).toBe(1);
+    expect(table?.child(1).childCount).toBe(1);
+    expect(table?.child(2).childCount).toBe(1);
+    expect(table?.child(1).firstChild?.attrs["cellMarker"]).toBeNull();
+    expect(table?.child(2).firstChild?.attrs["cellMarker"]).toBeNull();
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
+
+  test("accept keeps a pending vertical merge and clears its revision", () => {
+    const continuationCell = {
+      type: "tableCell" as const,
+      formatting: { vMerge: "continue" as const },
+      structuralChange: {
+        type: "tableCellMerge" as const,
+        info: { id: 81, author: "Reviewer" },
+        verticalMerge: "continue" as const,
+      },
+      content: [{ type: "paragraph" as const, content: [] }],
+    };
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            tableSchema.node("tableRow", null, [
+              tableSchema.node(
+                "tableCell",
+                {
+                  rowspan: 2,
+                  _docxVMergeContinuationCells: [continuationCell],
+                },
+                [tableSchema.node("paragraph", null, [tableSchema.text("Top")])],
+              ),
+            ]),
+            tableSchema.node("tableRow"),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(81)(view.state, view.dispatch)).toBe(true);
+    const mergedCell = view.state.doc.firstChild?.firstChild?.firstChild;
+    expect(mergedCell?.attrs["rowspan"]).toBe(2);
+    expect(mergedCell?.attrs["_docxVMergeContinuationCells"]).toEqual([
+      {
+        type: "tableCell",
+        formatting: { vMerge: "continue" },
+        content: [{ type: "paragraph", content: [] }],
+      },
+    ]);
+  });
+
+  test("reject restores a vertical merge removed by a pending split", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            tableSchema.node("tableRow", null, [
+              tableSchema.node("tableCell", null, [
+                tableSchema.node("paragraph", null, [tableSchema.text("Top")]),
+              ]),
+            ]),
+            tableSchema.node("tableRow", null, [
+              tableSchema.node(
+                "tableCell",
+                {
+                  cellMarker: {
+                    kind: "merge",
+                    info: { revisionId: 82, author: "Reviewer", date: null },
+                    verticalMergeOriginal: "continue",
+                  },
+                },
+                [tableSchema.node("paragraph")],
+              ),
+            ]),
+            tableSchema.node("tableRow", null, [
+              tableSchema.node(
+                "tableCell",
+                {
+                  cellMarker: {
+                    kind: "merge",
+                    info: { revisionId: 82, author: "Reviewer", date: null },
+                    verticalMergeOriginal: "continue",
+                  },
+                },
+                [tableSchema.node("paragraph")],
+              ),
+            ]),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(rejectAIEditRevision(82)(view.state, view.dispatch)).toBe(true);
+    const table = view.state.doc.firstChild;
+    expect(table?.child(0).firstChild?.attrs["rowspan"]).toBe(3);
+    expect(table?.child(1).childCount).toBe(0);
+    expect(table?.child(2).childCount).toBe(0);
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
+
+  test("reject keeps a split revision when no compatible cell exists above", () => {
+    const marker = {
+      kind: "merge",
+      info: { revisionId: 83, author: "Reviewer", date: null },
+      verticalMergeOriginal: "continue",
+    };
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            tableSchema.node("tableRow", null, [
+              tableSchema.node("tableCell", { cellMarker: marker }, [
+                tableSchema.node("paragraph"),
+              ]),
+            ]),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(rejectAIEditRevision(83)(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.firstChild?.firstChild?.firstChild?.attrs["cellMarker"]).toEqual(marker);
   });
 
   test("resolving the only cell preserves a valid document", () => {

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -468,7 +468,34 @@ describe("table cell structural revision resolution", () => {
   });
 
   test("reject restores every cell removed by a pending vertical merge", () => {
-    const continuationCell = {
+    const formattedContinuationCell = {
+      type: "tableCell" as const,
+      formatting: { vMerge: "continue" as const, verticalAlign: "bottom" as const },
+      propertyChanges: [
+        {
+          type: "tableCellPropertyChange" as const,
+          info: { id: 79, author: "Reviewer" },
+          previousFormatting: { verticalAlign: "top" as const },
+        },
+      ],
+      structuralChange: {
+        type: "tableCellMerge" as const,
+        info: { id: 80, author: "Reviewer" },
+        verticalMerge: "continue" as const,
+      },
+      content: [
+        {
+          type: "paragraph" as const,
+          content: [
+            {
+              type: "run" as const,
+              content: [{ type: "text" as const, text: "Restored" }],
+            },
+          ],
+        },
+      ],
+    };
+    const emptyContinuationCell = {
       type: "tableCell" as const,
       formatting: { vMerge: "continue" as const },
       structuralChange: {
@@ -489,7 +516,7 @@ describe("table cell structural revision resolution", () => {
                 {
                   rowspan: 3,
                   _originalFormatting: { vMerge: "restart" },
-                  _docxVMergeContinuationCells: [continuationCell, continuationCell],
+                  _docxVMergeContinuationCells: [formattedContinuationCell, emptyContinuationCell],
                 },
                 [tableSchema.node("paragraph", null, [tableSchema.text("Top")])],
               ),
@@ -508,6 +535,17 @@ describe("table cell structural revision resolution", () => {
     expect(table?.child(2).childCount).toBe(1);
     expect(table?.child(1).firstChild?.attrs["cellMarker"]).toBeNull();
     expect(table?.child(2).firstChild?.attrs["cellMarker"]).toBeNull();
+    expect(table?.child(1).firstChild?.textContent).toBe("Restored");
+    expect(table?.child(1).firstChild?.attrs["_originalFormatting"]).toEqual({
+      verticalAlign: "bottom",
+    });
+    expect(table?.child(1).firstChild?.attrs["tcPrChange"]).toEqual([
+      {
+        type: "tableCellPropertyChange",
+        info: { id: 79, author: "Reviewer" },
+        previousFormatting: { verticalAlign: "top" },
+      },
+    ]);
     expect(() => view.state.doc.check()).not.toThrow();
   });
 
@@ -605,6 +643,40 @@ describe("table cell structural revision resolution", () => {
     expect(() => view.state.doc.check()).not.toThrow();
   });
 
+  test("reject replaces an empty origin paragraph with restored split content", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node("table", null, [
+            tableSchema.node("tableRow", null, [
+              tableSchema.node("tableCell", null, [tableSchema.node("paragraph")]),
+            ]),
+            tableSchema.node("tableRow", null, [
+              tableSchema.node(
+                "tableCell",
+                {
+                  cellMarker: {
+                    kind: "merge",
+                    info: { revisionId: 83, author: "Reviewer", date: null },
+                    verticalMergeOriginal: "continue",
+                  },
+                },
+                [tableSchema.node("paragraph", null, [tableSchema.text("Restored")])],
+              ),
+            ]),
+          ]),
+        ]),
+      }),
+    );
+
+    expect(rejectAIEditRevision(83)(view.state, view.dispatch)).toBe(true);
+    const mergedCell = view.state.doc.firstChild?.firstChild?.firstChild;
+    expect(mergedCell?.childCount).toBe(1);
+    expect(mergedCell?.textContent).toBe("Restored");
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
+
   test("reject keeps a split revision when no compatible cell exists above", () => {
     const marker = {
       kind: "merge",
@@ -626,8 +698,34 @@ describe("table cell structural revision resolution", () => {
       }),
     );
 
-    expect(rejectAIEditRevision(83)(view.state, view.dispatch)).toBe(true);
+    expect(rejectAIEditRevision(83)(view.state, view.dispatch)).toBe(false);
     expect(view.state.doc.firstChild?.firstChild?.firstChild?.attrs["cellMarker"]).toEqual(marker);
+  });
+
+  test("failed split resolution does not apply compatible cells from the same revision", () => {
+    const marker = {
+      kind: "merge",
+      info: { revisionId: 84, author: "Reviewer", date: null },
+      verticalMergeOriginal: "continue",
+    };
+    const doc = tableSchema.node("doc", null, [
+      tableSchema.node("table", null, [
+        tableSchema.node("tableRow", null, [
+          tableSchema.node("tableCell", { cellMarker: marker }, [tableSchema.node("paragraph")]),
+          cell("Top", undefined),
+        ]),
+        tableSchema.node("tableRow", null, [
+          cell("Left", undefined),
+          tableSchema.node("tableCell", { cellMarker: marker }, [
+            tableSchema.node("paragraph", null, [tableSchema.text("Bottom")]),
+          ]),
+        ]),
+      ]),
+    ]);
+    const view = dispatcher(EditorState.create({ schema: tableSchema, doc }));
+
+    expect(rejectAIEditRevision(84)(view.state, view.dispatch)).toBe(false);
+    expect(view.state.doc.eq(doc)).toBe(true);
   });
 
   test("resolving the only cell preserves a valid document", () => {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -323,6 +323,7 @@ function resolveChange(
 
       tableCellStructuralOps.sort((left, right) => right.cellPos - left.cellPos);
       let resolvedTableCellStructure = false;
+      let failedTableCellMergeResolution = false;
       for (const op of tableCellStructuralOps) {
         const mappedPos = tr.mapping.map(op.cellPos);
         const cell = tr.doc.nodeAt(mappedPos);
@@ -334,6 +335,10 @@ function resolveChange(
             op.source === "collapsed"
               ? resolveCollapsedTableCellMerge(tr, mappedPos, op.mode, op.revisionSet)
               : resolveVisibleTableCellMerge(tr, mappedPos, op.mode);
+          if (!resolved) {
+            failedTableCellMergeResolution = true;
+            break;
+          }
           resolvedTableCellStructure ||= resolved;
           continue;
         }
@@ -344,6 +349,9 @@ function resolveChange(
         }
         deleteTableCellAt(tr, mappedPos);
         resolvedTableCellStructure = true;
+      }
+      if (failedTableCellMergeResolution) {
+        return false;
       }
       if (resolvedTableCellStructure) {
         markStructuralChange(tr);

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -15,6 +15,12 @@ import type {
   TableRowFormatting,
 } from "../../types/document";
 import { markStructuralChange } from "../extensions/features/ParagraphChangeTrackerExtension";
+import { getTableCellMergeChange } from "../tableCellMergeRevision";
+import {
+  hasMatchingCollapsedTableCellMerge,
+  resolveCollapsedTableCellMerge,
+  resolveVisibleTableCellMerge,
+} from "./tableCellMergeResolution";
 import {
   paragraphRejectAttrPatch,
   paragraphRejectOriginalFormatting,
@@ -214,10 +220,9 @@ function resolveChange(
           (node.type.name === "tableCell" || node.type.name === "tableHeader") &&
           rangeCoversNode(from, to, pos, node)
         ) {
-          const op = collectTableCellStructuralOp(node, pos, mode, revisionSet);
-          if (op) {
-            tableCellStructuralOps.push(op);
-          }
+          tableCellStructuralOps.push(
+            ...collectTableCellStructuralOps(node, pos, mode, revisionSet),
+          );
         }
 
         // Table property changes (w:tblPrChange / w:trPrChange / w:tcPrChange)
@@ -324,6 +329,14 @@ function resolveChange(
         if (!cell || (cell.type.name !== "tableCell" && cell.type.name !== "tableHeader")) {
           continue;
         }
+        if (op.type === "merge") {
+          const resolved =
+            op.source === "collapsed"
+              ? resolveCollapsedTableCellMerge(tr, mappedPos, op.mode, op.revisionSet)
+              : resolveVisibleTableCellMerge(tr, mappedPos, op.mode);
+          resolvedTableCellStructure ||= resolved;
+          continue;
+        }
         if (op.action === "clear") {
           tr.setNodeAttribute(mappedPos, "cellMarker", null);
           resolvedTableCellStructure = true;
@@ -359,17 +372,35 @@ type TableRowRevisionAttr = {
   revisionId: number;
 };
 
-type TableCellStructuralOp = {
-  cellPos: number;
-  action: "clear" | "remove";
-};
+type TableCellStructuralOp =
+  | {
+      type: "membership";
+      cellPos: number;
+      action: "clear" | "remove";
+    }
+  | {
+      type: "merge";
+      cellPos: number;
+      source: "visible" | "collapsed";
+      mode: "accept" | "reject";
+      revisionSet: Set<number> | null;
+    };
 
-type TableCellRevisionAttr = {
-  kind: "ins" | "del";
-  info: {
-    revisionId: number;
-  };
-};
+type TableCellRevisionAttr =
+  | {
+      kind: "ins" | "del";
+      info: {
+        revisionId: number;
+      };
+    }
+  | {
+      kind: "merge";
+      info: {
+        revisionId: number;
+      };
+      verticalMerge?: "continue" | "rest";
+      verticalMergeOriginal?: "continue" | "rest";
+    };
 
 function collectTableRowStructuralOp(
   node: PMNode,
@@ -404,31 +435,52 @@ function isTableRowRevisionAttr(value: unknown): value is TableRowRevisionAttr {
   );
 }
 
-function collectTableCellStructuralOp(
+function collectTableCellStructuralOps(
   node: PMNode,
   cellPos: number,
   mode: "accept" | "reject",
   revisionSet: Set<number> | null,
-): TableCellStructuralOp | null {
+): TableCellStructuralOp[] {
+  const operations: TableCellStructuralOp[] = [];
   const marker = node.attrs["cellMarker"];
-  if (!isTableCellRevisionAttr(marker)) {
-    return null;
+  if (
+    isTableCellRevisionAttr(marker) &&
+    (revisionSet === null || revisionSet.has(marker.info.revisionId))
+  ) {
+    if (marker.kind === "merge") {
+      operations.push({
+        type: "merge",
+        cellPos,
+        source: "visible",
+        mode,
+        revisionSet,
+      });
+    } else {
+      const keepsCell = (marker.kind === "ins") === (mode === "accept");
+      operations.push({
+        type: "membership",
+        cellPos,
+        action: keepsCell ? "clear" : "remove",
+      });
+    }
   }
-  if (revisionSet !== null && !revisionSet.has(marker.info.revisionId)) {
-    return null;
+  if (hasMatchingCollapsedTableCellMerge(node, revisionSet)) {
+    operations.push({
+      type: "merge",
+      cellPos,
+      source: "collapsed",
+      mode,
+      revisionSet,
+    });
   }
-  const keepsCell = (marker.kind === "ins") === (mode === "accept");
-  return {
-    cellPos,
-    action: keepsCell ? "clear" : "remove",
-  };
+  return operations;
 }
 
 function isTableCellRevisionAttr(value: unknown): value is TableCellRevisionAttr {
   if (typeof value !== "object" || value === null || !("kind" in value) || !("info" in value)) {
     return false;
   }
-  if (value.kind !== "ins" && value.kind !== "del") {
+  if (value.kind !== "ins" && value.kind !== "del" && value.kind !== "merge") {
     return false;
   }
   const info = value.info;
@@ -839,7 +891,16 @@ export function findAIEditRevisionRange(
     }
     if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
       const marker = node.attrs["cellMarker"];
-      if (isTableCellRevisionAttr(marker) && idSet.has(marker.info.revisionId)) {
+      const hasDirectRevision =
+        isTableCellRevisionAttr(marker) && idSet.has(marker.info.revisionId);
+      const continuationCells = node.attrs["_docxVMergeContinuationCells"];
+      const hasCollapsedRevision =
+        Array.isArray(continuationCells) &&
+        continuationCells.some((cell) => {
+          const change = getTableCellMergeChange(cell);
+          return change !== null && idSet.has(change.info.id);
+        });
+      if (hasDirectRevision || hasCollapsedRevision) {
         const start = pos;
         const end = pos + node.nodeSize;
         if (range.from === null || start < range.from) {

--- a/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
+++ b/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
@@ -1,8 +1,10 @@
+import { Result } from "better-result";
 import type { Node as PMNode } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
 import type { TableCell, TableCellFormatting } from "../../types/document";
+import { standaloneTableCellToProseMirror } from "../conversion/toProseDoc";
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
 
 export const hasMatchingCollapsedTableCellMerge = (
@@ -152,6 +154,10 @@ const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean 
     cell.childCount === 1 &&
     cell.firstChild?.isTextblock === true &&
     cell.firstChild.childCount === 0;
+  const aboveCellWasEmpty =
+    aboveCell.childCount === 1 &&
+    aboveCell.firstChild?.isTextblock === true &&
+    aboveCell.firstChild.childCount === 0;
   tr.delete(cellPos, cellPos + cell.nodeSize);
   tr.setNodeMarkup(abovePos, undefined, {
     ...aboveCell.attrs,
@@ -159,6 +165,10 @@ const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean 
     _docxVMergeContinuationCells: continuationCells,
   });
   if (!cellWasEmpty) {
+    if (aboveCellWasEmpty) {
+      tr.replaceWith(abovePos + 1, abovePos + 1 + aboveCell.content.size, cell.content);
+      return true;
+    }
     const contentEnd = abovePos + 1 + aboveCell.content.size;
     tr.insert(contentEnd, cell.content);
   }
@@ -297,19 +307,19 @@ export const resolveCollapsedTableCellMerge = (
 };
 
 const createRestoredTableCell = (origin: PMNode, source: TableCell): PMNode | null => {
-  const originalFormatting = source.formatting ? { ...source.formatting } : undefined;
-  if (originalFormatting) {
-    delete originalFormatting.vMerge;
+  const formatting = source.formatting ? { ...source.formatting } : undefined;
+  if (formatting) {
+    delete formatting.vMerge;
   }
-  const attrs = {
-    ...origin.attrs,
-    colspan: source.formatting?.gridSpan ?? origin.attrs["colspan"],
-    rowspan: 1,
-    cellMarker: null,
-    _preserveVMergeRestart: null,
-    _docxVMergeContinuationCells: null,
-    _originalFormatting: originalFormatting ?? null,
-    tcPrChange: source.propertyChanges ?? null,
+  const restoredSource: TableCell = {
+    type: "tableCell",
+    ...(formatting ? { formatting } : {}),
+    ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
+    content: source.content,
   };
-  return origin.type.createAndFill(attrs);
+  const restored = standaloneTableCellToProseMirror(
+    restoredSource,
+    origin.type.name === "tableHeader" ? "tableHeader" : "tableCell",
+  );
+  return Result.try(() => origin.type.schema.nodeFromJSON(restored.toJSON())).unwrapOr(null);
 };

--- a/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
+++ b/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
@@ -1,0 +1,315 @@
+import type { Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+import { TableMap } from "prosemirror-tables";
+
+import type { TableCell, TableCellFormatting } from "../../types/document";
+import { getTableCellMergeChange } from "../tableCellMergeRevision";
+
+export const hasMatchingCollapsedTableCellMerge = (
+  node: PMNode,
+  revisionSet: Set<number> | null,
+): boolean => {
+  const continuationCells = node.attrs["_docxVMergeContinuationCells"];
+  if (!Array.isArray(continuationCells)) {
+    return false;
+  }
+  return continuationCells.some((cell) => {
+    const change = getTableCellMergeChange(cell);
+    return change !== null && (revisionSet === null || revisionSet.has(change.info.id));
+  });
+};
+
+type TableCellRevisionAttr = {
+  kind: "merge";
+  info: {
+    revisionId: number;
+  };
+  verticalMerge?: "continue" | "rest";
+  verticalMergeOriginal?: "continue" | "rest";
+};
+
+const isTableCellMergeRevisionAttr = (value: unknown): value is TableCellRevisionAttr => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("kind" in value) ||
+    value.kind !== "merge" ||
+    !("info" in value)
+  ) {
+    return false;
+  }
+  const info = value.info;
+  return (
+    typeof info === "object" &&
+    info !== null &&
+    "revisionId" in info &&
+    typeof info.revisionId === "number"
+  );
+};
+
+type TableCellContext = {
+  table: PMNode;
+  tableStart: number;
+  relativeCellPos: number;
+};
+
+const tableCellContext = (doc: PMNode, cellPos: number): TableCellContext | null => {
+  const resolved = doc.resolve(cellPos);
+  for (let depth = resolved.depth; depth > 0; depth -= 1) {
+    const node = resolved.node(depth);
+    if (node.type.spec["tableRole"] !== "table") {
+      continue;
+    }
+    const tablePos = resolved.before(depth);
+    return {
+      table: node,
+      tableStart: tablePos + 1,
+      relativeCellPos: cellPos - tablePos - 1,
+    };
+  }
+  return null;
+};
+
+export const resolveVisibleTableCellMerge = (
+  tr: Transaction,
+  cellPos: number,
+  mode: "accept" | "reject",
+): boolean => {
+  const cell = tr.doc.nodeAt(cellPos);
+  const marker = cell?.attrs["cellMarker"];
+  if (!cell || !isTableCellMergeRevisionAttr(marker)) {
+    return false;
+  }
+  if (mode === "accept") {
+    tr.setNodeAttribute(cellPos, "cellMarker", null);
+    return true;
+  }
+
+  const originalState = marker.verticalMergeOriginal ?? "rest";
+  if (originalState === "continue") {
+    return mergeTableCellWithCellAbove(tr, cellPos);
+  }
+
+  const originalFormatting = cell.attrs["_originalFormatting"];
+  let nextOriginalFormatting = originalFormatting;
+  if (typeof originalFormatting === "object" && originalFormatting !== null) {
+    nextOriginalFormatting = { ...originalFormatting };
+    delete nextOriginalFormatting.vMerge;
+  }
+  tr.setNodeMarkup(cellPos, undefined, {
+    ...cell.attrs,
+    cellMarker: null,
+    _originalFormatting: nextOriginalFormatting,
+  });
+  return true;
+};
+
+const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean => {
+  const context = tableCellContext(tr.doc, cellPos);
+  const cell = tr.doc.nodeAt(cellPos);
+  if (!context || !cell) {
+    return false;
+  }
+  const map = TableMap.get(context.table);
+  const rectangle = map.findCell(context.relativeCellPos);
+  if (rectangle.top === 0) {
+    return false;
+  }
+  const aboveRelativePos = map.map[(rectangle.top - 1) * map.width + rectangle.left];
+  if (aboveRelativePos === undefined || aboveRelativePos === context.relativeCellPos) {
+    return false;
+  }
+  const aboveRectangle = map.findCell(aboveRelativePos);
+  if (
+    aboveRectangle.left !== rectangle.left ||
+    aboveRectangle.right !== rectangle.right ||
+    aboveRectangle.bottom !== rectangle.top
+  ) {
+    return false;
+  }
+  const abovePos = context.tableStart + aboveRelativePos;
+  const aboveCell = tr.doc.nodeAt(abovePos);
+  const aboveRowspan = aboveCell?.attrs["rowspan"];
+  const cellRowspan = cell.attrs["rowspan"];
+  if (
+    !aboveCell ||
+    typeof aboveRowspan !== "number" ||
+    typeof cellRowspan !== "number" ||
+    aboveRowspan < 1 ||
+    cellRowspan < 1
+  ) {
+    return false;
+  }
+
+  const continuationCells = tableCellContinuationCells(aboveCell, aboveRowspan);
+  continuationCells.push(tableCellContinuationFromNode(cell));
+  const nestedContinuations = cell.attrs["_docxVMergeContinuationCells"];
+  if (Array.isArray(nestedContinuations)) {
+    continuationCells.push(...nestedContinuations);
+  }
+
+  const cellWasEmpty =
+    cell.childCount === 1 &&
+    cell.firstChild?.isTextblock === true &&
+    cell.firstChild.childCount === 0;
+  tr.delete(cellPos, cellPos + cell.nodeSize);
+  tr.setNodeMarkup(abovePos, undefined, {
+    ...aboveCell.attrs,
+    rowspan: aboveRowspan + cellRowspan,
+    _docxVMergeContinuationCells: continuationCells,
+  });
+  if (!cellWasEmpty) {
+    const contentEnd = abovePos + 1 + aboveCell.content.size;
+    tr.insert(contentEnd, cell.content);
+  }
+  return true;
+};
+
+const tableCellContinuationCells = (cell: PMNode, rowspan: number): TableCell[] => {
+  const stored = cell.attrs["_docxVMergeContinuationCells"];
+  const cells: TableCell[] = Array.isArray(stored) ? [...stored] : [];
+  while (cells.length < rowspan - 1) {
+    cells.push(emptyVerticalMergeContinuation());
+  }
+  return cells;
+};
+
+const tableCellContinuationFromNode = (cell: PMNode): TableCell => {
+  const originalFormatting = cell.attrs["_originalFormatting"];
+  const formatting: TableCellFormatting =
+    typeof originalFormatting === "object" && originalFormatting !== null
+      ? { ...originalFormatting, vMerge: "continue" }
+      : { vMerge: "continue" };
+  const colspan = cell.attrs["colspan"];
+  if (typeof colspan === "number" && colspan > 1) {
+    formatting.gridSpan = colspan;
+  }
+  const continuation: TableCell = {
+    type: "tableCell",
+    formatting,
+    content: [{ type: "paragraph", content: [] }],
+  };
+  const propertyChanges = cell.attrs["tcPrChange"];
+  if (Array.isArray(propertyChanges) && propertyChanges.length > 0) {
+    continuation.propertyChanges = [...propertyChanges];
+  }
+  return continuation;
+};
+
+const emptyVerticalMergeContinuation = (): TableCell => ({
+  type: "tableCell",
+  formatting: { vMerge: "continue" },
+  content: [{ type: "paragraph", content: [] }],
+});
+
+export const resolveCollapsedTableCellMerge = (
+  tr: Transaction,
+  cellPos: number,
+  mode: "accept" | "reject",
+  revisionSet: Set<number> | null,
+): boolean => {
+  const cell = tr.doc.nodeAt(cellPos);
+  const stored = cell?.attrs["_docxVMergeContinuationCells"];
+  if (!cell || !Array.isArray(stored)) {
+    return false;
+  }
+
+  const matchingIndices: number[] = [];
+  const nextCells = stored.map((continuationCell, index) => {
+    const change = getTableCellMergeChange(continuationCell);
+    if (!change || (revisionSet !== null && !revisionSet.has(change.info.id))) {
+      return continuationCell;
+    }
+    matchingIndices.push(index);
+    const nextCell = { ...continuationCell };
+    delete nextCell.structuralChange;
+    return nextCell;
+  });
+  if (matchingIndices.length === 0) {
+    return false;
+  }
+  if (mode === "accept") {
+    tr.setNodeAttribute(cellPos, "_docxVMergeContinuationCells", nextCells);
+    return true;
+  }
+
+  const splitIndices = matchingIndices.filter((index) => {
+    const change = getTableCellMergeChange(stored[index]);
+    return (
+      change?.verticalMerge === "continue" && (change.verticalMergeOriginal ?? "rest") === "rest"
+    );
+  });
+  if (splitIndices.length === 0) {
+    tr.setNodeAttribute(cellPos, "_docxVMergeContinuationCells", nextCells);
+    return true;
+  }
+  const firstSplitIndex = splitIndices.at(0);
+  if (
+    firstSplitIndex === undefined ||
+    splitIndices.length !== stored.length - firstSplitIndex ||
+    splitIndices.some((index, offset) => index !== firstSplitIndex + offset)
+  ) {
+    return false;
+  }
+
+  const context = tableCellContext(tr.doc, cellPos);
+  if (!context) {
+    return false;
+  }
+  const map = TableMap.get(context.table);
+  const rectangle = map.findCell(context.relativeCellPos);
+  const rowspan = cell.attrs["rowspan"];
+  if (
+    typeof rowspan !== "number" ||
+    rowspan !== stored.length + 1 ||
+    rectangle.bottom - rectangle.top !== rowspan
+  ) {
+    return false;
+  }
+
+  const restorations: { index: number; cell: PMNode }[] = [];
+  for (const index of splitIndices) {
+    const source = nextCells[index];
+    if (!source) {
+      return false;
+    }
+    const restoredCell = createRestoredTableCell(cell, source);
+    if (!restoredCell) {
+      return false;
+    }
+    restorations.push({ index, cell: restoredCell });
+  }
+
+  const mapFrom = tr.mapping.maps.length;
+  for (const restoration of restorations) {
+    const row = rectangle.top + restoration.index + 1;
+    const insertionPos = context.tableStart + map.positionAt(row, rectangle.left, context.table);
+    tr.insert(tr.mapping.slice(mapFrom).map(insertionPos, 1), restoration.cell);
+  }
+
+  const remainingCells = nextCells.slice(0, firstSplitIndex);
+  tr.setNodeMarkup(cellPos, undefined, {
+    ...cell.attrs,
+    rowspan: firstSplitIndex + 1,
+    _docxVMergeContinuationCells: remainingCells.length > 0 ? remainingCells : null,
+  });
+  return true;
+};
+
+const createRestoredTableCell = (origin: PMNode, source: TableCell): PMNode | null => {
+  const originalFormatting = source.formatting ? { ...source.formatting } : undefined;
+  if (originalFormatting) {
+    delete originalFormatting.vMerge;
+  }
+  const attrs = {
+    ...origin.attrs,
+    colspan: source.formatting?.gridSpan ?? origin.attrs["colspan"],
+    rowspan: 1,
+    cellMarker: null,
+    _preserveVMergeRestart: null,
+    _docxVMergeContinuationCells: null,
+    _originalFormatting: originalFormatting ?? null,
+    tcPrChange: source.propertyChanges ?? null,
+  };
+  return origin.type.createAndFill(attrs);
+};

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -176,6 +176,119 @@ describe("fromProseDoc", () => {
     ]);
   });
 
+  test("round-trips vertical cell merge revision states through visible cells", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      structuralChange: {
+                        type: "tableCellMerge",
+                        info: { id: 83, author: "Reviewer" },
+                        verticalMergeOriginal: "continue",
+                      },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(pmDoc.firstChild?.firstChild?.firstChild?.attrs["cellMarker"]).toEqual({
+      kind: "merge",
+      info: { revisionId: 83, author: "Reviewer", date: null },
+      verticalMergeOriginal: "continue",
+    });
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+    if (table?.type !== "table") {
+      throw new Error("Expected table");
+    }
+    expect(table.rows.at(0)?.cells.at(0)?.structuralChange).toEqual({
+      type: "tableCellMerge",
+      info: { id: 83, author: "Reviewer" },
+      verticalMergeOriginal: "continue",
+    });
+  });
+
+  test("preserves merge revisions on collapsed vertical continuation cells", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "restart" },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                    {
+                      type: "tableCell",
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "continue" },
+                      structuralChange: {
+                        type: "tableCellMerge",
+                        info: { id: 84, author: "Reviewer" },
+                        verticalMerge: "continue",
+                      },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                    {
+                      type: "tableCell",
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const mergedCell = pmDoc.firstChild?.firstChild?.firstChild;
+    expect(mergedCell?.attrs["rowspan"]).toBe(2);
+    expect(mergedCell?.attrs["_docxVMergeContinuationCells"]).toHaveLength(1);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+    if (table?.type !== "table") {
+      throw new Error("Expected table");
+    }
+    expect(table.rows.at(1)?.cells.at(0)?.structuralChange).toEqual({
+      type: "tableCellMerge",
+      info: { id: 84, author: "Reviewer" },
+      verticalMerge: "continue",
+    });
+  });
+
   test("round-trips authored table-cell anchor scope through the editor model", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2740,14 +2740,28 @@ function convertPMTableCell(node: PMNode, documentCounts?: TrackedChangeCounts):
     cell.propertyChanges = [...attrs.tcPrChange];
   }
   if (attrs.cellMarker) {
-    cell.structuralChange = {
-      type: attrs.cellMarker.kind === "ins" ? "tableCellInsertion" : "tableCellDeletion",
-      info: {
-        id: attrs.cellMarker.info.revisionId,
-        author: attrs.cellMarker.info.author,
-        ...(attrs.cellMarker.info.date != null && { date: attrs.cellMarker.info.date }),
-      },
+    const info = {
+      id: attrs.cellMarker.info.revisionId,
+      author: attrs.cellMarker.info.author,
+      ...(attrs.cellMarker.info.date != null && { date: attrs.cellMarker.info.date }),
     };
+    if (attrs.cellMarker.kind === "merge") {
+      cell.structuralChange = {
+        type: "tableCellMerge",
+        info,
+        ...(attrs.cellMarker.verticalMerge !== undefined
+          ? { verticalMerge: attrs.cellMarker.verticalMerge }
+          : {}),
+        ...(attrs.cellMarker.verticalMergeOriginal !== undefined
+          ? { verticalMergeOriginal: attrs.cellMarker.verticalMergeOriginal }
+          : {}),
+      };
+    } else {
+      cell.structuralChange = {
+        type: attrs.cellMarker.kind === "ins" ? "tableCellInsertion" : "tableCellDeletion",
+        info,
+      };
+    }
   }
   return cell;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1902,6 +1902,28 @@ function convertTableCell({
   return schema.node(nodeType, attrs, contentNodes);
 }
 
+export function standaloneTableCellToProseMirror(
+  cell: TableCell,
+  nodeType: "tableCell" | "tableHeader",
+): PMNode {
+  let textBoxGroupIndex = 0;
+  const nextTextBoxGroupId = (): string => String(textBoxGroupIndex++);
+  return convertTableCell({
+    cell,
+    styleResolver: null,
+    context: { theme: null, nextTextBoxGroupId },
+    isHeader: nodeType === "tableHeader",
+    gridWidthPercent: undefined,
+    conditionalStyle: undefined,
+    tableBorders: undefined,
+    position: {},
+    calculatedRowSpan: 1,
+    preserveVMergeRestart: undefined,
+    vMergeContinuationCells: undefined,
+    defaultCellMargins: undefined,
+  });
+}
+
 /**
  * Convert a SimpleField or ComplexField to a ProseMirror field node.
  * Preserves run formatting (bold, fontSize, color, etc.) as PM marks.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1847,6 +1847,21 @@ function convertTableCell({
         date: cell.structuralChange.info.date ?? null,
       },
     };
+  } else if (cell.structuralChange?.type === "tableCellMerge") {
+    attrs.cellMarker = {
+      kind: "merge",
+      info: {
+        revisionId: cell.structuralChange.info.id,
+        author: cell.structuralChange.info.author,
+        date: cell.structuralChange.info.date ?? null,
+      },
+      ...(cell.structuralChange.verticalMerge !== undefined
+        ? { verticalMerge: cell.structuralChange.verticalMerge }
+        : {}),
+      ...(cell.structuralChange.verticalMergeOriginal !== undefined
+        ? { verticalMergeOriginal: cell.structuralChange.verticalMergeOriginal }
+        : {}),
+    };
   }
   if (preserveVMergeRestart) {
     attrs._preserveVMergeRestart = true;

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -667,15 +667,26 @@ export type TableCellAttrs = {
   _originalFormatting?: TableCellFormatting;
   /** Tracked cell property changes (w:tcPrChange) for round-trip + accept/reject */
   tcPrChange?: TableCellPropertyChange[];
-  /** Tracked cell insertion/deletion for round-trip + accept/reject. */
-  cellMarker?: {
-    kind: "ins" | "del";
-    info: {
-      revisionId: number;
-      author: string;
-      date?: string | null;
-    };
-  };
+  /** Tracked cell structural revision for round-trip + accept/reject. */
+  cellMarker?:
+    | {
+        kind: "ins" | "del";
+        info: {
+          revisionId: number;
+          author: string;
+          date?: string | null;
+        };
+      }
+    | {
+        kind: "merge";
+        info: {
+          revisionId: number;
+          author: string;
+          date?: string | null;
+        };
+        verticalMerge?: "continue" | "rest";
+        verticalMergeOriginal?: "continue" | "rest";
+      };
   /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
   _preserveVMergeRestart?: boolean;
   /** Original DOCX vMerge continuation cells skipped into this PM rowspan. */

--- a/packages/core/src/prosemirror/tableCellMergeRevision.ts
+++ b/packages/core/src/prosemirror/tableCellMergeRevision.ts
@@ -1,0 +1,43 @@
+import type { TableCell } from "../types/document";
+
+export type TableCellMergeChange = Extract<
+  NonNullable<TableCell["structuralChange"]>,
+  { type: "tableCellMerge" }
+>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isVerticalMergeRevisionValue = (
+  value: unknown,
+): value is NonNullable<TableCellMergeChange["verticalMerge"]> =>
+  value === "continue" || value === "rest";
+
+export const getTableCellMergeChange = (value: unknown): TableCellMergeChange | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const change = value["structuralChange"];
+  if (!isRecord(change) || change["type"] !== "tableCellMerge") {
+    return null;
+  }
+  const info = change["info"];
+  if (!isRecord(info) || typeof info["id"] !== "number" || typeof info["author"] !== "string") {
+    return null;
+  }
+
+  return {
+    type: "tableCellMerge",
+    info: {
+      id: info["id"],
+      author: info["author"],
+      ...(typeof info["date"] === "string" ? { date: info["date"] } : {}),
+    },
+    ...(isVerticalMergeRevisionValue(change["verticalMerge"])
+      ? { verticalMerge: change["verticalMerge"] }
+      : {}),
+    ...(isVerticalMergeRevisionValue(change["verticalMergeOriginal"])
+      ? { verticalMergeOriginal: change["verticalMergeOriginal"] }
+      : {}),
+  };
+};

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
@@ -28,7 +28,10 @@ const schema = new Schema({
     },
     tableCell: {
       content: "paragraph+",
-      attrs: { cellMarker: { default: null } },
+      attrs: {
+        cellMarker: { default: null },
+        _docxVMergeContinuationCells: { default: null },
+      },
       toDOM: () => ["td", 0],
     },
     table: { content: "tableRow+", group: "block", toDOM: () => ["table", 0] },
@@ -136,6 +139,49 @@ describe("extractTrackedChanges: foreign-doc coalescing by (author, date)", () =
     expect(entries.map(({ type, revisionId, text }) => ({ type, revisionId, text }))).toEqual([
       { type: "cellInserted", revisionId: 101, text: "Inserted" },
       { type: "cellDeleted", revisionId: 102, text: "Deleted" },
+    ]);
+  });
+
+  test("visible and collapsed vertical merge revisions surface as structural changes", () => {
+    const visible = schema.nodes.tableCell.create(
+      {
+        cellMarker: {
+          kind: "merge",
+          info: { revisionId: 103, author: AUTHOR, date: DATE },
+          verticalMergeOriginal: "continue",
+        },
+      },
+      [schema.nodes.paragraph.create({}, [schema.text("Visible")])],
+    );
+    const collapsed = schema.nodes.tableCell.create(
+      {
+        _docxVMergeContinuationCells: [
+          {
+            type: "tableCell",
+            formatting: { vMerge: "continue" },
+            structuralChange: {
+              type: "tableCellMerge",
+              info: { id: 104, author: AUTHOR, date: "2026-05-29T20:28:35.944Z" },
+              verticalMerge: "continue",
+            },
+            content: [{ type: "paragraph", content: [] }],
+          },
+        ],
+      },
+      [schema.nodes.paragraph.create({}, [schema.text("Collapsed")])],
+    );
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.table.create({}, [
+        schema.nodes.tableRow.create({}, [visible]),
+        schema.nodes.tableRow.create({}, [collapsed]),
+      ]),
+    ]);
+
+    const { entries } = extractTrackedChanges(makeState(doc));
+
+    expect(entries.map(({ type, revisionId }) => ({ type, revisionId }))).toEqual([
+      { type: "cellMerged", revisionId: 103 },
+      { type: "cellMerged", revisionId: 104 },
     ]);
   });
 

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
@@ -12,6 +12,8 @@
  * @public
  */
 import type { EditorState } from "prosemirror-state";
+
+import { getTableCellMergeChange } from "../tableCellMergeRevision";
 import type { Mark } from "prosemirror-model";
 
 /**
@@ -288,6 +290,24 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
             from: pos,
             to: pos + node.nodeSize,
             revisionId: cellMarker.info.revisionId,
+          });
+        }
+      }
+      const continuationCells = node.attrs["_docxVMergeContinuationCells"];
+      if (Array.isArray(continuationCells)) {
+        for (const continuationCell of continuationCells) {
+          const change = getTableCellMergeChange(continuationCell);
+          if (!change) {
+            continue;
+          }
+          raw.push({
+            type: "cellMerged",
+            text: node.textContent || "",
+            author: change.info.author,
+            date: change.info.date,
+            from: pos,
+            to: pos + node.nodeSize,
+            revisionId: change.info.id,
           });
         }
       }

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1116,16 +1116,21 @@ export type SectionPropertyChange = {
 /**
  * Table structural tracked change metadata (row/cell insert/delete/merge)
  */
-export type TableStructuralChangeInfo = {
-  type:
-    | "tableRowInsertion"
-    | "tableRowDeletion"
-    | "tableCellInsertion"
-    | "tableCellDeletion"
-    | "tableCellMerge";
-  /** Tracked change metadata */
-  info: TrackedChangeInfo;
-};
+export type TableStructuralChangeInfo =
+  | {
+      type: "tableRowInsertion" | "tableRowDeletion" | "tableCellInsertion" | "tableCellDeletion";
+      /** Tracked change metadata */
+      info: TrackedChangeInfo;
+    }
+  | {
+      type: "tableCellMerge";
+      /** Tracked change metadata */
+      info: TrackedChangeInfo;
+      /** Vertical merge state applied by the revision. */
+      verticalMerge?: "continue" | "rest";
+      /** Vertical merge state that existed before the revision. */
+      verticalMergeOriginal?: "continue" | "rest";
+    };
 
 // ============================================================================
 // STRUCTURED DOCUMENT TAGS (SDT / Content Controls)


### PR DESCRIPTION
## Summary

- preserve vertical merge revision states during import and export
- expose collapsed revisions through review APIs
- resolve merge and split revisions while preserving table geometry

## Validation

- focused table revision tests
- full test suite
- package builds and publish-shape checks
- API report and changeset checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking vertical table-cell merge revisions.
  * Vertical merge changes can now be imported, reviewed, accepted or rejected, and exported while preserving merge states.
  * Added support for detecting merges in both visible and collapsed continuation cells.
* **Bug Fixes**
  * Improved restoration of merged table structures when rejecting revisions.
* **Tests**
  * Added coverage for parsing, serialization, conversion, extraction, and merge resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->