### PR TITLE
fix: honor authored line-break controls

### DIFF
--- a/.changeset/brave-spaces-wrap.md
+++ b/.changeset/brave-spaces-wrap.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor authored no-break spaces without inventing locale-specific wrapping.

--- a/.changeset/tidy-donkeys-listen.md
+++ b/.changeset/tidy-donkeys-listen.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Refine bounded first-line contraction for justified deep-hanging list markers.

--- a/.changeset/warm-taxis-smile.md
+++ b/.changeset/warm-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Paint OOXML no-break hyphens with the ordinary hyphen glyph.

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -76,7 +76,7 @@ const BREAK_AFTER_CHARACTER = new Set([
   "\u200B", // zero-width space
   "\u00AD", // soft hyphen
 ]);
-const CZECH_ONE_LETTER_PREPOSITIONS = new Set(["k", "o", "s", "u", "v", "z"]);
+const NONBREAKING_SPACES = new Set(["\u00A0", "\u2007", "\u202F"]);
 
 // ECMA-376 kinsoku defaults are language-specific and can be replaced by
 // settings.xml. This conservative common set covers punctuation excluded from
@@ -211,42 +211,6 @@ const isLegacyEthiopicBreakCharacter = (
   return codePoint !== undefined && codePoint >= 0x1361 && codePoint <= 0x1368;
 };
 
-const czechProtectedBreaks = (text: string, policy?: LineBreakPolicy): Set<number> => {
-  const breaks = new Set<number>();
-  if (segmenterLocale(policy?.locale) !== "cs") {
-    return breaks;
-  }
-
-  let tokenStart = 0;
-  let index = 0;
-  while (index < text.length) {
-    const character = firstCodePoint(text, index);
-    if (character === undefined) {
-      break;
-    }
-    if (!/\s/u.test(character)) {
-      index += character.length;
-      continue;
-    }
-
-    const token = text.slice(tokenStart, index);
-    const protectsNextWord =
-      token.length === 1 && CZECH_ONE_LETTER_PREPOSITIONS.has(token.toLocaleLowerCase("cs"));
-    while (index < text.length) {
-      const whitespace = firstCodePoint(text, index);
-      if (whitespace === undefined || !/\s/u.test(whitespace)) {
-        break;
-      }
-      index += whitespace.length;
-      if (protectsNextWord) {
-        breaks.add(index);
-      }
-    }
-    tokenStart = index;
-  }
-  return breaks;
-};
-
 const allowsBreak = (text: string, index: number, policy?: LineBreakPolicy): boolean => {
   const previous = previousCodePoint(text, index);
   const next = firstCodePoint(text, index);
@@ -289,7 +253,7 @@ const findUnicodeBreaks = (text: string, policy?: LineBreakPolicy): number[] => 
     const previous = previousCodePoint(text, index);
     if (
       previous !== undefined &&
-      (/\s/u.test(previous) ||
+      ((/\s/u.test(previous) && !NONBREAKING_SPACES.has(previous)) ||
         BREAK_AFTER_CHARACTER.has(previous) ||
         isLegacyEthiopicBreakCharacter(previous, policy))
     ) {
@@ -321,10 +285,7 @@ const findUnicodeBreaks = (text: string, policy?: LineBreakPolicy): number[] => 
     }
   }
 
-  const protectedBreaks = czechProtectedBreaks(text, policy);
-  return [...new Set(breaks)]
-    .filter((index) => !protectedBreaks.has(index))
-    .sort((left, right) => left - right);
+  return [...new Set(breaks)].sort((left, right) => left - right);
 };
 
 type HyphenateWord = (text: string) => string;

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -40,18 +40,20 @@ describe("findWordBreaks", () => {
     expect(() => findWordBreaks("hello world", { locale: "not_a_locale" })).not.toThrow();
   });
 
-  test("keeps Czech one-letter prepositions with the following word", () => {
+  test("keeps ordinary spaces breakable regardless of locale", () => {
     const text = "text v  text";
 
-    expect(findWordBreaks(text, { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks(text, { locale: "cs-CZ" })).toEqual([5, 7, 8]);
     expect(findWordBreaks(text, { locale: "en-US" })).toEqual([5, 7, 8]);
     expect(findWordBreaks("textov text", { locale: "cs-CZ" })).toEqual([7]);
-    expect(findWordBreaks("text o text", { locale: "cs-CZ" })).toEqual([5]);
-    expect(findWordBreaks("text u text", { locale: "cs-CZ" })).toEqual([5]);
-    expect(findWordBreaks("text O text", { locale: "cs-CZ" })).toEqual([5]);
-    expect(findWordBreaks("text U text", { locale: "cs-CZ" })).toEqual([5]);
+    expect(findWordBreaks("text o text", { locale: "cs-CZ" })).toEqual([5, 7]);
     expect(findWordBreaks("text a text", { locale: "cs-CZ" })).toEqual([5, 7]);
-    expect(findWordBreaks("text i text", { locale: "cs-CZ" })).toEqual([5, 7]);
+  });
+
+  test("does not break at glue-class spaces", () => {
+    expect(findWordBreaks("one\u00A0two")).toEqual([]);
+    expect(findWordBreaks("one\u2007two")).toEqual([]);
+    expect(findWordBreaks("one\u202Ftwo")).toEqual([]);
   });
 
   test("keeps prohibited CJK punctuation off the next line", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -389,71 +389,23 @@ describe("measureParagraph cross-run line breaking", () => {
     }, fakeMeasure);
   });
 
-  test("keeps a Czech one-letter preposition with a following formatted run", () => {
+  test("uses authored no-break spaces across formatted runs", () => {
     withFakeTextMeasure(() => {
-      const sameRunWhitespace: Run[] = [
+      const ordinaryWhitespace: Run[] = [
         { kind: "text", text: "alpha o ", language: { val: "cs-CZ" } },
         { kind: "text", text: "beta", bold: true, language: { val: "cs-CZ" } },
       ];
-      const sameRunMeasure = measureParagraph(paragraph(sameRunWhitespace), width("alpha o"));
-
-      expect(lineStartsAt(sameRunMeasure.lines, 0, "alpha ".length)).toBe(true);
-      expect(lineStartsAtRun(sameRunMeasure.lines, 1)).toBe(false);
-
-      const splitCases: { runs: Run[]; followingRun: number }[] = [
-        {
-          runs: [
-            { kind: "text", text: "alpha " },
-            { kind: "text", text: "o", language: { val: "cs-CZ" } },
-            { kind: "text", text: " beta", bold: true },
-          ],
-          followingRun: 2,
-        },
-        {
-          runs: [
-            { kind: "text", text: "alpha " },
-            { kind: "text", text: "o", language: { val: "cs-CZ" } },
-            { kind: "text", text: " " },
-            { kind: "text", text: "beta", bold: true },
-          ],
-          followingRun: 3,
-        },
-        {
-          runs: [
-            { kind: "text", text: "alpha " },
-            { kind: "text", text: "o ", language: { val: "cs-CZ" } },
-            { kind: "text", text: "" },
-            { kind: "text", text: "beta", bold: true },
-          ],
-          followingRun: 3,
-        },
+      const noBreakWhitespace: Run[] = [
+        { kind: "text", text: "alpha o\u00A0", language: { val: "cs-CZ" } },
+        { kind: "text", text: "beta", bold: true, language: { val: "cs-CZ" } },
       ];
+      const ordinaryMeasure = measureParagraph(paragraph(ordinaryWhitespace), width("alpha o"));
+      const noBreakMeasure = measureParagraph(paragraph(noBreakWhitespace), width("alpha o"));
 
-      for (const splitCase of splitCases) {
-        const { lines } = measureParagraph(paragraph(splitCase.runs), width("alpha o"));
-
-        expect(lineStartsAtRun(lines, 1)).toBe(true);
-        expect(lineStartsAtRun(lines, splitCase.followingRun)).toBe(false);
-      }
+      expect(lineStartsAtRun(ordinaryMeasure.lines, 1)).toBe(true);
+      expect(lineStartsAt(noBreakMeasure.lines, 0, "alpha ".length)).toBe(true);
+      expect(lineStartsAtRun(noBreakMeasure.lines, 1)).toBe(false);
     }, fakeMeasure);
-  });
-
-  test("bounds protected-break scanning for fragmented Czech runs", () => {
-    withFakeTextMeasure(
-      () => {
-        const runs: Run[] = Array.from({ length: 500 }, () => ({
-          kind: "text",
-          text: "o",
-          language: { val: "cs-CZ" },
-        }));
-        const startedAt = performance.now();
-
-        measureParagraph(paragraph(runs), 10_000);
-
-        expect(performance.now() - startedAt).toBeLessThan(1_500);
-      },
-      { charWidth: fixedCharWidth(1) },
-    );
   });
 
   test("allows a normal wrap when whitespace precedes the footnote marker", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1139,6 +1139,47 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
+  test("allows the bounded first-line tolerance for deep hanging list markers", () => {
+    const firstLineText = `${"a".repeat(98)} bbb`;
+
+    withFakeTextMeasure(
+      () => {
+        const fittingMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-deep-hanging-list-marker",
+            runs: [{ kind: "text", text: firstLineText }],
+            attrs: {
+              alignment: "justify",
+              indent: { left: 36, hanging: 36 },
+              listMarker: "1.1.1",
+            },
+          },
+          136,
+        );
+        const overflowingMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-deep-hanging-list-marker-boundary",
+            runs: [{ kind: "text", text: firstLineText }],
+            attrs: {
+              alignment: "justify",
+              indent: { left: 36, hanging: 36 },
+              listMarker: "1.1.1",
+            },
+          },
+          135.9,
+        );
+
+        expect(fittingMeasure.lines).toHaveLength(1);
+        expect(overflowingMeasure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: (char) => (char === "b" ? 1.05 : 1),
+      },
+    );
+  });
+
   test("bases full-hanging list continuation shrink on measured spaces", () => {
     withFakeTextMeasure(
       () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -65,6 +65,7 @@ const WIDTH_TOLERANCE = 0.5;
 const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 const JUSTIFY_SPACE_CONTRACTION_RATIO = 0.075;
 const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
+const JUSTIFY_DEEP_HANGING_LIST_MARKER_SHRINK_TOLERANCE_RATIO = 0.022;
 // Full-hanging continuations allow stronger space contraction with bounded total shrink.
 const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.32;
 const JUSTIFY_LIST_CONTINUATION_MAX_SHRINK_TOLERANCE_RATIO = 0.015;
@@ -613,7 +614,10 @@ function resolveJustifyFitStrategy(
     if (isFirstLine) {
       return hanging <= DEFAULT_LIST_HANGING_INDENT_PX
         ? { type: "space", ratio: JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO }
-        : { type: "width", ratio: JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO };
+        : {
+            type: "width",
+            ratio: JUSTIFY_DEEP_HANGING_LIST_MARKER_SHRINK_TOLERANCE_RATIO,
+          };
     }
     const left = block.attrs.indent?.left ?? 0;
     if (hanging > 0 && left > hanging) {

--- a/packages/core/src/layout-engine/measure/measureProvider.ts
+++ b/packages/core/src/layout-engine/measure/measureProvider.ts
@@ -12,6 +12,7 @@
 import { panic } from "better-result";
 
 import type { FontMetrics, FontStyle, RunMeasurement, TextMeasurement } from "./measureTypes";
+import { toPaintedText } from "./textMeasurementPolicy";
 
 /**
  * Swappable text-measurement backend. A canvas implementation is installed at
@@ -55,10 +56,10 @@ export const getFontMetrics = (style: FontStyle): FontMetrics =>
   activeMeasureProvider.getFontMetrics(style);
 
 export const measureTextWidth = (text: string, style: FontStyle): number =>
-  activeMeasureProvider.measureTextWidth(text, style);
+  activeMeasureProvider.measureTextWidth(toPaintedText(text), style);
 
 export const measureText = (text: string, style: FontStyle): TextMeasurement =>
-  activeMeasureProvider.measureText(text, style);
+  activeMeasureProvider.measureText(toPaintedText(text), style);
 
 export const measureRun = (text: string, style: FontStyle): RunMeasurement =>
-  activeMeasureProvider.measureRun(text, style);
+  activeMeasureProvider.measureRun(toPaintedText(text), style);

--- a/packages/core/src/layout-engine/measure/textMeasurementPolicy.test.ts
+++ b/packages/core/src/layout-engine/measure/textMeasurementPolicy.test.ts
@@ -5,6 +5,7 @@ import {
   countCompressibleSpaces,
   getFontKerningMode,
   getRunFontKerningMode,
+  toPaintedText,
 } from "./textMeasurementPolicy";
 
 describe("text measurement policy", () => {
@@ -38,5 +39,9 @@ describe("text measurement policy", () => {
   test("counts only spaces that justification may compress", () => {
     expect(countCompressibleSpaces("one two  three")).toBe(3);
     expect(countCompressibleSpaces("one\u00a0two\tthree\u2003four")).toBe(0);
+  });
+
+  test("paints no-break hyphens with the ordinary hyphen glyph", () => {
+    expect(toPaintedText("non\u2011breaking hyphen")).toBe("non-breaking hyphen");
   });
 });

--- a/packages/core/src/layout-engine/measure/textMeasurementPolicy.ts
+++ b/packages/core/src/layout-engine/measure/textMeasurementPolicy.ts
@@ -15,6 +15,9 @@ export const FONT_KERNING_MODE = {
 
 export type FontKerningMode = (typeof FONT_KERNING_MODE)[keyof typeof FONT_KERNING_MODE];
 
+const NO_BREAK_HYPHEN = "\u2011";
+const PAINTED_HYPHEN = "-";
+
 type RunKerningInput = Pick<RunFormatting, "fontSize" | "kerningMinPt">;
 
 /** Resolve an authored kerning threshold against the effective run size. */
@@ -44,4 +47,9 @@ export function countCompressibleSpaces(text: string): number {
     }
   }
   return count;
+}
+
+/** Paint OOXML no-break hyphens with the ordinary hyphen glyph. */
+export function toPaintedText(text: string): string {
+  return text.replaceAll(NO_BREAK_HYPHEN, PAINTED_HYPHEN);
 }

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -60,6 +60,37 @@ function findTabEls(lineEl: FakeElement): FakeElement[] {
 }
 
 describe("renderLine box model", () => {
+  test("paints no-break hyphens without changing document positions", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "no-break-hyphen",
+      runs: [{ kind: "text", text: "non\u2011breaking", pmStart: 10, pmEnd: 22 }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: "non\u2011breaking".length,
+      width: 84,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 84,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const text = lineEl.children.at(0);
+
+    expect(text?.textContent).toBe("non-breaking");
+    expect(text?.dataset["pmStart"]).toBe("10");
+    expect(text?.dataset["pmEnd"]).toBe("22");
+  });
+
   test("paints a discretionary hyphen without assigning it a document position", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -19,6 +19,7 @@ import {
   countCompressibleSpaces,
   getFontKerningMode,
   getRunFontKerningMode,
+  toPaintedText,
 } from "../layout-engine/measure/textMeasurementPolicy";
 import type {
   ParagraphBlock,
@@ -508,6 +509,7 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
 
   applyRunStyles(span, run);
   applyPmPositions(span, run.pmStart, run.pmEnd);
+  const paintedText = toPaintedText(run.text);
 
   // Handle hyperlinks
   if (run.hyperlink) {
@@ -522,7 +524,7 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
     if (run.hyperlink.tooltip) {
       anchor.title = run.hyperlink.tooltip;
     }
-    anchor.textContent = run.text;
+    anchor.textContent = paintedText;
     // TOC entries opt out of the Hyperlink character style — Word renders
     // them in the paragraph's own colour, no underline. The bridge sets
     // `noDefaultStyle: true` and strips resolved colour/underline; here we
@@ -544,7 +546,7 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
     span.append(anchor);
   } else {
     // Set text content
-    span.textContent = run.text;
+    span.textContent = paintedText;
   }
   applyWhitespaceUnderline(span, run);
 


### PR DESCRIPTION
Honor authored glue spaces and no-break hyphens during measurement and painting, and refine bounded fitting for deep-hanging justified list markers.

Adds synthetic boundary coverage and patch changesets for `@stll/folio-core`.