### PR TITLE
fix: preserve inline text box source order

### DIFF
--- a/.changeset/steady-textbox-anchors.md
+++ b/.changeset/steady-textbox-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve inline text box source order across document edits.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -462,7 +462,8 @@ export type TextBoxAttrs = {
     distRight?: number; /** Position for floating/anchored text boxes */
     position?: ImagePositionAttrs; /** Original DOCX placement hint for save-path reconstruction. */
     _docxPlacement?: "standalone" | "inlineWithPrevious"; /** Original DOCX paragraph group for standalone text-box reconstruction. */
-    _docxGroupId?: string; /** Original run-level revision wrapper for save-path reconstruction. */
+    _docxGroupId?: string; /** Inline anchor linking this block node to its source run position. */
+    _docxAnchorId?: string; /** Original run-level revision wrapper for save-path reconstruction. */
     _docxTrackedChange?: {
         type: "insertion";
         info: import__stll_docx_core_model.TrackedChangeInfo;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -6,6 +6,27 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("keeps text-box anchors out of paragraph layout", () => {
+    const paragraph = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("Before"),
+          schema.node("textBoxAnchor", { anchorId: "paragraph:0" }),
+          schema.text("After"),
+        ]),
+      ]),
+    ).at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+
+    expect(paragraph.runs).toHaveLength(2);
+    expect(paragraph.runs.flatMap((run) => (run.kind === "text" ? [run.text] : []))).toEqual([
+      "Before",
+      "After",
+    ]);
+  });
+
   test("retains paragraph suppression and stamps the document hyphenation policy", () => {
     const paragraph = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -15,7 +15,6 @@ import {
   readSdtAttrs,
   readShapeAttrs,
   readTextBoxAttrs,
-  readTextBoxAnchorAttrs,
   readTextColorMarkAttrs,
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
@@ -24,6 +23,7 @@ import {
   readTableRowAttrs,
 } from ".";
 import { schema } from "../schema";
+import { readTextBoxAnchorAttrs } from "../textBoxAnchorAttrs";
 
 const issueMessages = (result: ReturnType<typeof readParagraphAttrs>) => {
   if (result.ok) {

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -15,6 +15,7 @@ import {
   readSdtAttrs,
   readShapeAttrs,
   readTextBoxAttrs,
+  readTextBoxAnchorAttrs,
   readTextColorMarkAttrs,
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
@@ -407,6 +408,16 @@ describe("ProseMirror attr readers", () => {
       expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
         "textBox.attrs._docxInlineSdts[0].id",
       );
+    }
+  });
+
+  test("rejects malformed text-box anchor attrs", () => {
+    const anchor = schema.nodes.textBoxAnchor.create({ anchorId: 7 });
+    const result = readTextBoxAnchorAttrs(anchor);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.map((issue) => issue.path)).toContain("textBoxAnchor.attrs.anchorId");
     }
   });
 

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -60,7 +60,6 @@ import type {
   TrackedChangeMarkAttrs,
   UnderlineAttrs,
 } from "../schema";
-import type { TextBoxAnchorAttrs } from "../schema/nodes";
 
 export type ProseMirrorAttrIssue = {
   path: string;
@@ -222,7 +221,6 @@ const mathAttrsCache = new WeakMap<PMNode, MathAttrs>();
 const sdtAttrsCache = new WeakMap<PMNode, SdtAttrs>();
 const shapeAttrsCache = new WeakMap<PMNode, ShapeAttrs>();
 const textBoxAttrsCache = new WeakMap<PMNode, TextBoxAttrs>();
-const textBoxAnchorAttrsCache = new WeakMap<PMNode, TextBoxAnchorAttrs>();
 
 const underlineAttrsCache = new WeakMap<Mark, UnderlineAttrs>();
 const strikeAttrsCache = new WeakMap<Mark, StrikeAttrs>();
@@ -740,30 +738,6 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
 
 export const expectTextBoxAttrs = (node: PMNode): TextBoxAttrs =>
   expectCachedNodeAttrs(node, textBoxAttrsCache, readTextBoxAttrs, "text box attrs");
-
-export const readTextBoxAnchorAttrs = (
-  node: PMNode,
-): ReadProseMirrorAttrsResult<TextBoxAnchorAttrs> => {
-  const attrs = attrsRecord(node.attrs);
-  const issues: ProseMirrorAttrIssue[] = [];
-  expectNodeType(node, "textBoxAnchor", issues);
-  optionalString(attrs, "anchorId", "textBoxAnchor.attrs.anchorId", issues);
-  if (typeof attrs["anchorId"] !== "string" || attrs["anchorId"].length === 0) {
-    issues.push({
-      path: "textBoxAnchor.attrs.anchorId",
-      message: "Expected a non-empty string.",
-    });
-  }
-  return attrsResult(attrs, issues);
-};
-
-export const expectTextBoxAnchorAttrs = (node: PMNode): TextBoxAnchorAttrs =>
-  expectCachedNodeAttrs(
-    node,
-    textBoxAnchorAttrsCache,
-    readTextBoxAnchorAttrs,
-    "text box anchor attrs",
-  );
 
 export const readUnderlineMarkAttrs = (mark: Mark): ReadProseMirrorAttrsResult<UnderlineAttrs> => {
   const attrs = attrsRecord(mark.attrs);

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -55,12 +55,12 @@ import type {
   TableCellAttrs,
   TableRowAttrs,
   TextBoxAttrs,
-  TextBoxAnchorAttrs,
   TextColorAttrs,
   TextEffectAttrs,
   TrackedChangeMarkAttrs,
   UnderlineAttrs,
 } from "../schema";
+import type { TextBoxAnchorAttrs } from "../schema/nodes";
 
 export type ProseMirrorAttrIssue = {
   path: string;

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -55,6 +55,7 @@ import type {
   TableCellAttrs,
   TableRowAttrs,
   TextBoxAttrs,
+  TextBoxAnchorAttrs,
   TextColorAttrs,
   TextEffectAttrs,
   TrackedChangeMarkAttrs,
@@ -221,6 +222,7 @@ const mathAttrsCache = new WeakMap<PMNode, MathAttrs>();
 const sdtAttrsCache = new WeakMap<PMNode, SdtAttrs>();
 const shapeAttrsCache = new WeakMap<PMNode, ShapeAttrs>();
 const textBoxAttrsCache = new WeakMap<PMNode, TextBoxAttrs>();
+const textBoxAnchorAttrsCache = new WeakMap<PMNode, TextBoxAnchorAttrs>();
 
 const underlineAttrsCache = new WeakMap<Mark, UnderlineAttrs>();
 const strikeAttrsCache = new WeakMap<Mark, StrikeAttrs>();
@@ -729,6 +731,7 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
     TEXT_BOX_DOCX_PLACEMENTS,
   );
   optionalString(attrs, "_docxGroupId", "textBox.attrs._docxGroupId", issues);
+  optionalString(attrs, "_docxAnchorId", "textBox.attrs._docxAnchorId", issues);
   optionalTextBoxTrackedChange(attrs, issues);
   optionalTextBoxInlineSdts(attrs, issues);
 
@@ -737,6 +740,30 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
 
 export const expectTextBoxAttrs = (node: PMNode): TextBoxAttrs =>
   expectCachedNodeAttrs(node, textBoxAttrsCache, readTextBoxAttrs, "text box attrs");
+
+export const readTextBoxAnchorAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<TextBoxAnchorAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "textBoxAnchor", issues);
+  optionalString(attrs, "anchorId", "textBoxAnchor.attrs.anchorId", issues);
+  if (typeof attrs["anchorId"] !== "string" || attrs["anchorId"].length === 0) {
+    issues.push({
+      path: "textBoxAnchor.attrs.anchorId",
+      message: "Expected a non-empty string.",
+    });
+  }
+  return attrsResult(attrs, issues);
+};
+
+export const expectTextBoxAnchorAttrs = (node: PMNode): TextBoxAnchorAttrs =>
+  expectCachedNodeAttrs(
+    node,
+    textBoxAnchorAttrsCache,
+    readTextBoxAnchorAttrs,
+    "text box anchor attrs",
+  );
 
 export const readUnderlineMarkAttrs = (mark: Mark): ReadProseMirrorAttrsResult<UnderlineAttrs> => {
   const attrs = attrsRecord(mark.attrs);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -1959,6 +1959,53 @@ describe("fromProseDoc", () => {
     },
   );
 
+  test("preserves text-box order inside a hyperlink nested in a tracked change", () => {
+    const document = documentWithTextBoxParagraph({ includeText: false });
+    const paragraph = document.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const textBoxRun = paragraph.content.at(0);
+    if (textBoxRun?.type !== "run") {
+      throw new Error("Expected text-box run");
+    }
+    paragraph.content = [
+      {
+        type: "insertion",
+        info: { id: 42, author: "Reviewer" },
+        content: [
+          {
+            type: "hyperlink",
+            href: "https://example.com",
+            children: [
+              { type: "run", content: [{ type: "text", text: "Before" }] },
+              textBoxRun,
+              { type: "run", content: [{ type: "text", text: "After" }] },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const block = roundTripped.package.document.content.at(0);
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+    expect(block.content).toHaveLength(3);
+    expect(
+      block.content.every(
+        (content) =>
+          content.type === "insertion" &&
+          content.content.every(
+            (trackedContent) =>
+              trackedContent.type === "hyperlink" && trackedContent.href === "https://example.com",
+          ),
+      ),
+    ).toBe(true);
+    expect(paragraphInlineOrder(block)).toEqual(["Before", "textBox", "After"]);
+  });
+
   test("round-trips text boxes through nested inline content controls", () => {
     const document = documentWithTextBoxParagraph({ includeText: false });
     const paragraph = document.package.document.content.at(0);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -5,6 +5,7 @@ import { EditorState } from "prosemirror-state";
 import type {
   Document,
   Paragraph,
+  ParagraphContent,
   Run,
   Table,
   TableCell,
@@ -1743,6 +1744,152 @@ describe("fromProseDoc", () => {
     expect(firstShapeType(block)).toBe("textBox");
   });
 
+  test("preserves an inline text box between surrounding text", () => {
+    const document = documentWithTextBoxParagraph({ includeText: true });
+    const sourceParagraph = document.package.document.content.at(0);
+    if (sourceParagraph?.type !== "paragraph") {
+      throw new Error("Expected source paragraph");
+    }
+    sourceParagraph.content.push({
+      type: "run",
+      content: [{ type: "text", text: "After" }],
+    });
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+
+    expect(paragraphInlineOrder(paragraph)).toEqual(["Before", "textBox", "After"]);
+  });
+
+  test("preserves the source order of multiple inline text boxes", () => {
+    const document = documentWithTextBoxParagraph({ includeText: true, textBoxCount: 2 });
+    const sourceParagraph = document.package.document.content.at(0);
+    if (sourceParagraph?.type !== "paragraph") {
+      throw new Error("Expected source paragraph");
+    }
+    const secondTextBox = sourceParagraph.content.pop();
+    if (secondTextBox?.type !== "run") {
+      throw new Error("Expected second text box run");
+    }
+    sourceParagraph.content.push(
+      { type: "run", content: [{ type: "text", text: "Middle" }] },
+      secondTextBox,
+      { type: "run", content: [{ type: "text", text: "After" }] },
+    );
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+
+    expect(paragraphInlineOrder(paragraph)).toEqual([
+      "Before",
+      "textBox",
+      "Middle",
+      "textBox",
+      "After",
+    ]);
+  });
+
+  test("keeps an inline text-box anchor stable across surrounding text edits", () => {
+    const document = documentWithTextBoxParagraph({ includeText: true });
+    const sourceParagraph = document.package.document.content.at(0);
+    if (sourceParagraph?.type !== "paragraph") {
+      throw new Error("Expected source paragraph");
+    }
+    sourceParagraph.content.push({
+      type: "run",
+      content: [{ type: "text", text: "After" }],
+    });
+    let state = EditorState.create({ doc: toProseDoc(document) });
+    const firstAnchorPosition = findNodePosition(state.doc, "textBoxAnchor");
+    if (firstAnchorPosition === undefined) {
+      throw new Error("Expected text-box anchor");
+    }
+    state = state.apply(state.tr.insertText(" edited-before", firstAnchorPosition));
+    const editedAnchorPosition = findNodePosition(state.doc, "textBoxAnchor");
+    if (editedAnchorPosition === undefined) {
+      throw new Error("Expected mapped text-box anchor");
+    }
+    state = state.apply(state.tr.insertText("edited-after ", editedAnchorPosition + 1));
+
+    const roundTripped = fromProseDoc(state.doc, document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+
+    expect(paragraphInlineOrder(paragraph)).toEqual([
+      "Before edited-before",
+      "textBox",
+      "edited-after After",
+    ]);
+  });
+
+  test("removes an orphaned inline anchor when its text box is deleted", () => {
+    const document = documentWithTextBoxParagraph({ includeText: true });
+    const sourceParagraph = document.package.document.content.at(0);
+    if (sourceParagraph?.type !== "paragraph") {
+      throw new Error("Expected source paragraph");
+    }
+    sourceParagraph.content.push({
+      type: "run",
+      content: [{ type: "text", text: "After" }],
+    });
+    const pmDoc = toProseDoc(document);
+    const editedDoc = schema.node("doc", null, [pmDoc.child(0)]);
+
+    const roundTripped = fromProseDoc(editedDoc, document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+
+    expect(paragraphText(paragraph)).toBe("BeforeAfter");
+    expect(
+      paragraph.content.some((content) => content.type === "run" && content.content.length === 0),
+    ).toBe(false);
+  });
+
+  test("preserves inline text-box order inside a table cell", () => {
+    const document = documentWithTextBoxParagraph({ includeText: true });
+    const sourceParagraph = document.package.document.content.at(0);
+    if (sourceParagraph?.type !== "paragraph") {
+      throw new Error("Expected source paragraph");
+    }
+    sourceParagraph.content.push({
+      type: "run",
+      content: [{ type: "text", text: "After" }],
+    });
+    document.package.document.content = [
+      {
+        type: "table",
+        rows: [
+          {
+            type: "tableRow",
+            cells: [{ type: "tableCell", content: [sourceParagraph] }],
+          },
+        ],
+      },
+    ];
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const table = roundTripped.package.document.content.at(0);
+    if (table?.type !== "table") {
+      throw new Error("Expected round-tripped table");
+    }
+    const paragraph = table.rows.at(0)?.cells.at(0)?.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected table-cell paragraph");
+    }
+
+    expect(paragraphInlineOrder(paragraph)).toEqual(["Before", "textBox", "After"]);
+  });
+
   test("keeps imported text-box-only paragraphs as standalone wrappers", () => {
     const document = documentWithTextBoxParagraph({ includeText: false });
     const pmDoc = toProseDoc(document);
@@ -1879,6 +2026,44 @@ describe("fromProseDoc", () => {
     expect(inner.properties).toMatchObject({ sdtType: "plainText", alias: "Inner", tag: "inner" });
     expect(shapes).toHaveLength(1);
     expect(shapes.at(0)?.shape.shapeType).toBe("textBox");
+    expect(paragraphInlineOrder(block)).toEqual(["Before ", "inside ", "textBox", " after"]);
+  });
+
+  test("preserves a tracked text box between tracked text runs", () => {
+    const document = documentWithTextBoxParagraph({ includeText: false });
+    const paragraph = document.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const textBoxRun = paragraph.content.at(0);
+    if (textBoxRun?.type !== "run") {
+      throw new Error("Expected text-box run");
+    }
+    const info = { id: 43, author: "Reviewer" } satisfies TrackedChangeInfo;
+    paragraph.content = [
+      {
+        type: "insertion",
+        info,
+        content: [
+          { type: "run", content: [{ type: "text", text: "Before" }] },
+          textBoxRun,
+          { type: "run", content: [{ type: "text", text: "After" }] },
+        ],
+      },
+    ];
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const result = roundTripped.package.document.content.at(0);
+    if (result?.type !== "paragraph") {
+      throw new Error("Expected round-tripped paragraph");
+    }
+
+    expect(paragraphInlineOrder(result)).toEqual(["Before", "textBox", "After"]);
+    expect(
+      result.content.map((content) =>
+        content.type === "insertion" ? `${content.type}:${content.info.id}` : content.type,
+      ),
+    ).toEqual(["insertion:43", "insertion:43", "insertion:43"]);
   });
 
   test.each(["moveFrom", "moveTo"] as const)(
@@ -2497,6 +2682,53 @@ function paragraphText(block: Paragraph | Table | undefined): string {
         : [],
     )
     .join("");
+}
+
+function paragraphInlineOrder(paragraph: Paragraph): string[] {
+  return inlineContentOrder(paragraph.content);
+}
+
+function inlineContentOrder(content: readonly ParagraphContent[]): string[] {
+  return content.flatMap((item) => {
+    if (item.type === "inlineSdt") {
+      return inlineContentOrder(item.content);
+    }
+    if (
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
+      return inlineContentOrder(item.content);
+    }
+    if (item.type === "hyperlink") {
+      return inlineContentOrder(item.children);
+    }
+    if (item.type !== "run") {
+      return [];
+    }
+    return item.content.flatMap((runContent) => {
+      if (runContent.type === "text") {
+        return [runContent.text];
+      }
+      if (runContent.type === "shape" && runContent.shape.shapeType === "textBox") {
+        return ["textBox"];
+      }
+      return [];
+    });
+  });
+}
+
+function findNodePosition(doc: PMNode, nodeType: string): number | undefined {
+  let position: number | undefined;
+  doc.descendants((node, nodePosition) => {
+    if (node.type.name !== nodeType) {
+      return true;
+    }
+    position = nodePosition;
+    return false;
+  });
+  return position;
 }
 
 function documentWithTextBoxParagraph({

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -655,30 +655,25 @@ function editTextBoxAnchorInContent(
       content.splice(index, 1, ...(replacement ? [replacement] : []));
       return true;
     }
-    if (item?.type === "inlineSdt") {
-      const hadContent = item.content.length > 0;
-      if (editTextBoxAnchorInContent(item.content, marker, replacement)) {
-        if (!replacement && hadContent && item.content.length === 0) {
-          content.splice(index, 1);
-        }
-        return true;
-      }
+    const nestedContent =
+      item?.type === "hyperlink"
+        ? item.children
+        : item?.type === "inlineSdt" ||
+            item?.type === "insertion" ||
+            item?.type === "deletion" ||
+            item?.type === "moveFrom" ||
+            item?.type === "moveTo"
+          ? item.content
+          : undefined;
+    if (!nestedContent) {
       continue;
     }
-    if (
-      item?.type === "insertion" ||
-      item?.type === "deletion" ||
-      item?.type === "moveFrom" ||
-      item?.type === "moveTo"
-    ) {
-      const markerIndex = item.content.findIndex((child) => child === marker);
-      if (markerIndex >= 0) {
-        item.content.splice(markerIndex, 1, ...(replacement ? [replacement] : []));
-        if (!replacement && item.content.length === 0) {
-          content.splice(index, 1);
-        }
-        return true;
+    const hadContent = nestedContent.length > 0;
+    if (editTextBoxAnchorInContent(nestedContent, marker, replacement)) {
+      if (!replacement && hadContent && nestedContent.length === 0) {
+        content.splice(index, 1);
       }
+      return true;
     }
   }
   return false;
@@ -1283,9 +1278,12 @@ function extractParagraphContent(
         return;
       }
       textBoxAnchorMarkers.set(anchorId, marker);
+      const anchoredContent: Run | Hyperlink = linkMark
+        ? { ...createHyperlink(linkMark), children: [marker] }
+        : marker;
       const changeMark = insertionMark ?? deletionMark;
       if (!changeMark) {
-        content.push(marker);
+        content.push(anchoredContent);
         return;
       }
       const changeAttrs = expectTrackedChangeMarkAttrs(changeMark);
@@ -1298,13 +1296,13 @@ function extractParagraphContent(
         content.push({
           type: changeAttrs.moveKind === "moveTo" ? "moveTo" : "insertion",
           info,
-          content: [marker],
+          content: [anchoredContent],
         });
       } else {
         content.push({
           type: changeAttrs.moveKind === "moveFrom" ? "moveFrom" : "deletion",
           info,
-          content: [marker],
+          content: [anchoredContent],
         });
       }
       return;
@@ -1326,6 +1324,9 @@ function extractParagraphContent(
       if (!run) {
         return;
       }
+      const trackedContent: Run | Hyperlink = linkMark
+        ? { ...createHyperlink(linkMark), children: [run] }
+        : run;
 
       const info: TrackedChangeInfo = {
         id: changeAttrs.revisionId,
@@ -1344,14 +1345,14 @@ function extractParagraphContent(
       // fuse into a phantom move pair.
       if (insertionMark) {
         if (changeAttrs.moveKind === "moveTo") {
-          content.push({ type: "moveTo", info, content: [run] });
+          content.push({ type: "moveTo", info, content: [trackedContent] });
         } else {
-          content.push({ type: "insertion", info, content: [run] });
+          content.push({ type: "insertion", info, content: [trackedContent] });
         }
       } else if (changeAttrs.moveKind === "moveFrom") {
-        content.push({ type: "moveFrom", info, content: [run] });
+        content.push({ type: "moveFrom", info, content: [trackedContent] });
       } else {
-        content.push({ type: "deletion", info, content: [run] });
+        content.push({ type: "deletion", info, content: [trackedContent] });
       }
       return;
     }

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -91,7 +91,6 @@ import {
   expectTableCellAttrs,
   expectTableRowAttrs,
   expectTextBoxAttrs,
-  expectTextBoxAnchorAttrs,
   expectTextColorMarkAttrs,
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
@@ -108,6 +107,7 @@ import type {
   TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
+import { expectTextBoxAnchorAttrs } from "../textBoxAnchorAttrs";
 import { runShadingAttrsToShading } from "./runShadingMark";
 import { sdtPropertiesFromAttrs, sdtPropertiesMatchAttrs } from "./sdtAttrs";
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -655,16 +655,18 @@ function editTextBoxAnchorInContent(
       content.splice(index, 1, ...(replacement ? [replacement] : []));
       return true;
     }
-    const nestedContent =
-      item?.type === "hyperlink"
-        ? item.children
-        : item?.type === "inlineSdt" ||
-            item?.type === "insertion" ||
-            item?.type === "deletion" ||
-            item?.type === "moveFrom" ||
-            item?.type === "moveTo"
-          ? item.content
-          : undefined;
+    let nestedContent: ParagraphContent[] | undefined;
+    if (item?.type === "hyperlink") {
+      nestedContent = item.children;
+    } else if (
+      item?.type === "inlineSdt" ||
+      item?.type === "insertion" ||
+      item?.type === "deletion" ||
+      item?.type === "moveFrom" ||
+      item?.type === "moveTo"
+    ) {
+      nestedContent = item.content;
+    }
     if (!nestedContent) {
       continue;
     }

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -480,6 +480,7 @@ function appendTextBoxBlock(
     const anchorMarker = anchorId ? options.textBoxAnchorMarkers.get(anchorId) : undefined;
     const textBoxRun = findTextBoxShapeRun(paragraph.content);
     if (
+      anchorId &&
       anchorMarker &&
       textBoxRun &&
       replaceTextBoxAnchorInBlocks(blocks, anchorMarker, textBoxRun)

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -91,6 +91,7 @@ import {
   expectTableCellAttrs,
   expectTableRowAttrs,
   expectTextBoxAttrs,
+  expectTextBoxAnchorAttrs,
   expectTextColorMarkAttrs,
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
@@ -257,6 +258,7 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
  */
 function extractBlocks(pmDoc: PMNode): BlockContent[] {
   const blocks: BlockContent[] = [];
+  const textBoxAnchorMarkers = new Map<string, Run>();
   const documentCounts = buildDocumentTrackedChangeCounts(pmDoc);
   let pendingPageBreaks = 0;
   let previousStandaloneTextBox: PreviousStandaloneTextBox | null = null;
@@ -286,7 +288,7 @@ function extractBlocks(pmDoc: PMNode): BlockContent[] {
     }
 
     if (node.type.name === "paragraph") {
-      const paragraph = convertPMParagraph(node, documentCounts);
+      const paragraph = convertPMParagraph(node, documentCounts, textBoxAnchorMarkers);
       prependPageBreaks(paragraph, pendingPageBreaks);
       pendingPageBreaks = 0;
       blocks.push(paragraph);
@@ -301,6 +303,7 @@ function extractBlocks(pmDoc: PMNode): BlockContent[] {
       previousStandaloneTextBox = appendTextBoxBlock(blocks, node, {
         pendingPageBreaks,
         previousStandaloneTextBox,
+        textBoxAnchorMarkers,
       });
       pendingPageBreaks = 0;
     } else if (node.type.name === "blockSdt") {
@@ -316,12 +319,15 @@ function extractBlocks(pmDoc: PMNode): BlockContent[] {
     flushPendingPageBreaks();
   }
 
+  removeUnresolvedTextBoxAnchors(blocks, textBoxAnchorMarkers);
+
   return blocks;
 }
 
 type AppendTextBoxBlockOptions = {
   pendingPageBreaks: number;
   previousStandaloneTextBox: PreviousStandaloneTextBox | null;
+  textBoxAnchorMarkers: Map<string, Run>;
 };
 
 type PreviousStandaloneTextBox = {
@@ -470,6 +476,17 @@ function appendTextBoxBlock(
   const previousBlock = blocks.at(-1);
   if (attrs._docxPlacement === "inlineWithPrevious" && previousBlock?.type === "paragraph") {
     appendPageBreaks(previousBlock, options.pendingPageBreaks);
+    const anchorId = attrs._docxAnchorId;
+    const anchorMarker = anchorId ? options.textBoxAnchorMarkers.get(anchorId) : undefined;
+    const textBoxRun = findTextBoxShapeRun(paragraph.content);
+    if (
+      anchorMarker &&
+      textBoxRun &&
+      replaceTextBoxAnchorInBlocks(blocks, anchorMarker, textBoxRun)
+    ) {
+      options.textBoxAnchorMarkers.delete(anchorId);
+      return null;
+    }
     if (
       !mergeTextBoxIntoTrailingInlineSdts(previousBlock, paragraph, attrs._docxInlineSdts ?? [])
     ) {
@@ -565,6 +582,139 @@ function mergeInlineSdtNodes(
     return true;
   }
   return mergeInlineSdtNodes(targetNested, incomingNested, inlineSdts, index + 1);
+}
+
+function findTextBoxShapeRun(content: readonly ParagraphContent[]): Run | undefined {
+  for (const item of content) {
+    if (item.type === "run") {
+      if (
+        item.content.some(
+          (runContent) => runContent.type === "shape" && runContent.shape.shapeType === "textBox",
+        )
+      ) {
+        return item;
+      }
+      continue;
+    }
+    if (
+      item.type === "inlineSdt" ||
+      item.type === "hyperlink" ||
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
+      const nestedContent = item.type === "hyperlink" ? item.children : item.content;
+      const run = findTextBoxShapeRun(nestedContent);
+      if (run) {
+        return run;
+      }
+    }
+  }
+  return undefined;
+}
+
+function replaceTextBoxAnchorInBlocks(
+  blocks: BlockContent[],
+  marker: Run,
+  textBoxRun: Run,
+): boolean {
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      if (editTextBoxAnchorInContent(block.content, marker, textBoxRun)) {
+        return true;
+      }
+      continue;
+    }
+    if (block.type === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          if (replaceTextBoxAnchorInBlocks(cell.content, marker, textBoxRun)) {
+            return true;
+          }
+        }
+      }
+      continue;
+    }
+    if (replaceTextBoxAnchorInBlocks(block.content, marker, textBoxRun)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function editTextBoxAnchorInContent(
+  content: ParagraphContent[],
+  marker: Run,
+  replacement?: Run,
+): boolean {
+  for (let index = 0; index < content.length; index += 1) {
+    const item = content[index];
+    if (item === marker) {
+      content.splice(index, 1, ...(replacement ? [replacement] : []));
+      return true;
+    }
+    if (item?.type === "inlineSdt") {
+      const hadContent = item.content.length > 0;
+      if (editTextBoxAnchorInContent(item.content, marker, replacement)) {
+        if (!replacement && hadContent && item.content.length === 0) {
+          content.splice(index, 1);
+        }
+        return true;
+      }
+      continue;
+    }
+    if (
+      item?.type === "insertion" ||
+      item?.type === "deletion" ||
+      item?.type === "moveFrom" ||
+      item?.type === "moveTo"
+    ) {
+      const markerIndex = item.content.findIndex((child) => child === marker);
+      if (markerIndex >= 0) {
+        item.content.splice(markerIndex, 1, ...(replacement ? [replacement] : []));
+        if (!replacement && item.content.length === 0) {
+          content.splice(index, 1);
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function removeUnresolvedTextBoxAnchors(
+  blocks: BlockContent[],
+  markers: ReadonlyMap<string, Run>,
+): void {
+  for (const marker of markers.values()) {
+    removeTextBoxAnchorFromBlocks(blocks, marker);
+  }
+}
+
+function removeTextBoxAnchorFromBlocks(blocks: BlockContent[], marker: Run): boolean {
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      if (editTextBoxAnchorInContent(block.content, marker)) {
+        return true;
+      }
+      continue;
+    }
+    if (block.type === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          if (removeTextBoxAnchorFromBlocks(cell.content, marker)) {
+            return true;
+          }
+        }
+      }
+      continue;
+    }
+    if (removeTextBoxAnchorFromBlocks(block.content, marker)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -663,9 +813,18 @@ function appendPageBreaks(paragraph: Paragraph, count: number): void {
 /**
  * Convert a ProseMirror paragraph node to our Paragraph type
  */
-function convertPMParagraph(node: PMNode, documentCounts?: TrackedChangeCounts): Paragraph {
+function convertPMParagraph(
+  node: PMNode,
+  documentCounts?: TrackedChangeCounts,
+  textBoxAnchorMarkers?: Map<string, Run>,
+): Paragraph {
   const attrs = expectParagraphAttrs(node);
-  let content = extractParagraphContent(node, documentCounts, attrs._emptyHyperlinks ?? undefined);
+  let content = extractParagraphContent(
+    node,
+    documentCounts,
+    attrs._emptyHyperlinks ?? undefined,
+    textBoxAnchorMarkers,
+  );
 
   // Emit BookmarkStart/End from bookmarks attr (for TOC anchors, cross-references)
   const bookmarks = attrs.bookmarks as { id: number; name: string }[] | undefined;
@@ -1013,6 +1172,7 @@ function extractParagraphContent(
   // `moveKind` mark attribute set by `toProseDoc`.
   _documentCounts?: TrackedChangeCounts,
   emptyHyperlinks?: NonNullable<ParagraphAttrs["_emptyHyperlinks"]>,
+  textBoxAnchorMarkers?: Map<string, Run>,
 ): ParagraphContent[] {
   const content: ParagraphContent[] = [];
   const sortedEmptyHyperlinks = (emptyHyperlinks ?? [])
@@ -1111,6 +1271,43 @@ function extractParagraphContent(
     const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
     const insertionMark = node.marks.find((m) => m.type.name === "insertion");
     const deletionMark = node.marks.find((m) => m.type.name === "deletion");
+    if (node.type.name === "textBoxAnchor") {
+      flushCurrentInline();
+      if (!textBoxAnchorMarkers) {
+        return;
+      }
+      const { anchorId } = expectTextBoxAnchorAttrs(node);
+      const marker: Run = { type: "run", content: [] };
+      if (textBoxAnchorMarkers.has(anchorId)) {
+        return;
+      }
+      textBoxAnchorMarkers.set(anchorId, marker);
+      const changeMark = insertionMark ?? deletionMark;
+      if (!changeMark) {
+        content.push(marker);
+        return;
+      }
+      const changeAttrs = expectTrackedChangeMarkAttrs(changeMark);
+      const info: TrackedChangeInfo = {
+        id: changeAttrs.revisionId,
+        author: changeAttrs.author || "Unknown",
+        ...(changeAttrs.date ? { date: changeAttrs.date } : {}),
+      };
+      if (insertionMark) {
+        content.push({
+          type: changeAttrs.moveKind === "moveTo" ? "moveTo" : "insertion",
+          info,
+          content: [marker],
+        });
+      } else {
+        content.push({
+          type: changeAttrs.moveKind === "moveFrom" ? "moveFrom" : "deletion",
+          info,
+          content: [marker],
+        });
+      }
+      return;
+    }
     if (insertionMark || deletionMark) {
       // Finish any current content
       flushCurrentInline();
@@ -1227,7 +1424,7 @@ function extractParagraphContent(
     } else if (node.type.name === "sdt") {
       // SDT ends current run and emits an InlineSdt content item
       flushCurrentInline();
-      content.push(createInlineSdtFromNode(node));
+      content.push(createInlineSdtFromNode(node, textBoxAnchorMarkers));
     } else if (node.type.name === "math") {
       // Math ends current run and emits a MathEquation content item
       flushCurrentInline();
@@ -1679,7 +1876,7 @@ function createMathFromNode(node: PMNode): MathEquation {
 /**
  * Create an InlineSdt from a PM sdt node
  */
-function createInlineSdtFromNode(node: PMNode): InlineSdt {
+function createInlineSdtFromNode(node: PMNode, textBoxAnchorMarkers?: Map<string, Run>): InlineSdt {
   const attrs = expectSdtAttrs(node);
   const properties = sdtPropertiesFromAttrs(attrs);
 
@@ -1688,7 +1885,7 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   // and math here. Keep all of them so docProps-bound fields and reviewed
   // template content survive a round-trip through the editor. Keep this
   // filter in sync with the exhaustive switch in `serializeInlineSdt`.
-  const sdtContent = extractParagraphContent(node);
+  const sdtContent = extractParagraphContent(node, undefined, undefined, textBoxAnchorMarkers);
   const content = sdtContent.filter(
     (c): c is InlineSdt["content"][number] =>
       c.type === "run" ||
@@ -2726,13 +2923,14 @@ function tableRowAttrsToFormatting(attrs: TableRowAttrs): TableRowFormatting | u
 function convertPMTableCell(node: PMNode, documentCounts?: TrackedChangeCounts): TableCell {
   const attrs = expectTableCellAttrs(node);
   const content: (Paragraph | Table)[] = [];
+  const textBoxAnchorMarkers = new Map<string, Run>();
   let previousStandaloneTextBox: PreviousStandaloneTextBox | null = null;
 
   // Extract cell content (paragraphs and nested tables)
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((contentNode) => {
     if (contentNode.type.name === "paragraph") {
-      content.push(convertPMParagraph(contentNode, documentCounts));
+      content.push(convertPMParagraph(contentNode, documentCounts, textBoxAnchorMarkers));
       previousStandaloneTextBox = null;
     } else if (contentNode.type.name === "table") {
       content.push(convertPMTable(contentNode, documentCounts));
@@ -2741,9 +2939,12 @@ function convertPMTableCell(node: PMNode, documentCounts?: TrackedChangeCounts):
       previousStandaloneTextBox = appendTextBoxBlock(content, contentNode, {
         pendingPageBreaks: 0,
         previousStandaloneTextBox,
+        textBoxAnchorMarkers,
       });
     }
   });
+
+  removeUnresolvedTextBoxAnchors(content, textBoxAnchorMarkers);
 
   const cell: TableCell = { type: "tableCell", content };
   const cellFormatting = tableCellAttrsToFormatting(attrs);

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2534,9 +2534,9 @@ function convertImage(image: Image, rawXml?: string): PMNode {
  */
 type ConvertHyperlinkOptions = {
   getInheritedRunFormatting: RunFormattingResolver;
-  styleResolver?: StyleEngine | null;
-  hyperlinkIndex?: number;
-  textBoxAnchors?: ReadonlyMap<Shape, string>;
+  styleResolver: StyleEngine | null | undefined;
+  hyperlinkIndex: number;
+  textBoxAnchors: ReadonlyMap<Shape, string> | undefined;
 };
 
 function convertHyperlink(

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -231,6 +231,7 @@ function convertParagraph(
   activeCommentIds?: Set<number>,
   extraRunFormatting?: TextFormatting,
   tableParagraphOverlay?: TableCellParagraphSpacingOverlay,
+  textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode {
   const attrs = paragraphFormattingToAttrs(paragraph, styleResolver, tableParagraphOverlay);
   const isTocParagraph = TOC_STYLE_ID.test(paragraph.formatting?.styleId ?? "");
@@ -312,7 +313,14 @@ function convertParagraph(
     moveKind: "moveFrom" | "moveTo" | null,
   ): void => {
     emitInlineNodes(
-      convertTrackedChange(change, markType, getInheritedRunFormatting, styleResolver, moveKind),
+      convertTrackedChange(
+        change,
+        markType,
+        getInheritedRunFormatting,
+        styleResolver,
+        moveKind,
+        textBoxAnchors,
+      ),
     );
   };
 
@@ -325,7 +333,12 @@ function convertParagraph(
       anchorPointComment(inlineNodes, content.id);
     } else if (content.type === "run") {
       emitInlineNodes(
-        convertRun(content, getInheritedRunFormatting(content.formatting), styleResolver),
+        convertRun(
+          content,
+          getInheritedRunFormatting(content.formatting),
+          styleResolver,
+          textBoxAnchors,
+        ),
       );
     } else if (content.type === "hyperlink") {
       const currentHyperlinkIndex = hyperlinkIndex;
@@ -351,7 +364,9 @@ function convertParagraph(
     } else if (content.type === "simpleField" || content.type === "complexField") {
       emitInlineNode(convertField(content, getInheritedRunFormatting, styleResolver));
     } else if (content.type === "inlineSdt") {
-      emitInlineNode(convertInlineSdt(content, getInheritedRunFormatting, styleResolver));
+      emitInlineNode(
+        convertInlineSdt(content, getInheritedRunFormatting, styleResolver, textBoxAnchors),
+      );
     } else if (content.type === "insertion" || content.type === "moveTo") {
       emitTrackedChange(content, "insertion", content.type === "moveTo" ? "moveTo" : null);
     } else if (content.type === "deletion" || content.type === "moveFrom") {
@@ -423,12 +438,20 @@ function convertTrackedChange(
   getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleEngine | null,
   moveKind: "moveFrom" | "moveTo" | null = null,
+  textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode[] {
   const nodes: PMNode[] = [];
   let hyperlinkIndex = 0;
   for (const item of change.content) {
     if (item.type === "run") {
-      nodes.push(...convertRun(item, getInheritedRunFormatting(item.formatting), styleResolver));
+      nodes.push(
+        ...convertRun(
+          item,
+          getInheritedRunFormatting(item.formatting),
+          styleResolver,
+          textBoxAnchors,
+        ),
+      );
     } else {
       const currentHyperlinkIndex = hyperlinkIndex;
       hyperlinkIndex += 1;
@@ -462,7 +485,8 @@ function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
       (node.type.name === "image" ||
         node.type.name === "shape" ||
         node.type.name === "hardBreak" ||
-        node.type.name === "tab"))
+        node.type.name === "tab" ||
+        node.type.name === "textBoxAnchor"))
   );
 }
 
@@ -2004,6 +2028,7 @@ function convertInlineSdt(
   sdt: InlineSdt,
   getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleEngine | null,
+  textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode | null {
   const props = sdt.properties;
   const inlineNodes: PMNode[] = [];
@@ -2015,6 +2040,7 @@ function convertInlineSdt(
         content,
         getInheritedRunFormatting(content.formatting),
         styleResolver,
+        textBoxAnchors,
       );
       inlineNodes.push(...runNodes);
     } else if (content.type === "hyperlink") {
@@ -2033,17 +2059,36 @@ function convertInlineSdt(
         inlineNodes.push(fieldNode);
       }
     } else if (content.type === "inlineSdt") {
-      const nestedSdt = convertInlineSdt(content, getInheritedRunFormatting, styleResolver);
+      const nestedSdt = convertInlineSdt(
+        content,
+        getInheritedRunFormatting,
+        styleResolver,
+        textBoxAnchors,
+      );
       if (nestedSdt) {
         inlineNodes.push(nestedSdt);
       }
     } else if (content.type === "insertion") {
       inlineNodes.push(
-        ...convertTrackedChange(content, "insertion", getInheritedRunFormatting, styleResolver),
+        ...convertTrackedChange(
+          content,
+          "insertion",
+          getInheritedRunFormatting,
+          styleResolver,
+          null,
+          textBoxAnchors,
+        ),
       );
     } else if (content.type === "deletion") {
       inlineNodes.push(
-        ...convertTrackedChange(content, "deletion", getInheritedRunFormatting, styleResolver),
+        ...convertTrackedChange(
+          content,
+          "deletion",
+          getInheritedRunFormatting,
+          styleResolver,
+          null,
+          textBoxAnchors,
+        ),
       );
     } else if (content.type === "moveTo") {
       inlineNodes.push(
@@ -2053,6 +2098,7 @@ function convertInlineSdt(
           getInheritedRunFormatting,
           styleResolver,
           "moveTo",
+          textBoxAnchors,
         ),
       );
     } else if (content.type === "moveFrom") {
@@ -2063,6 +2109,7 @@ function convertInlineSdt(
           getInheritedRunFormatting,
           styleResolver,
           "moveFrom",
+          textBoxAnchors,
         ),
       );
     } else {
@@ -2092,6 +2139,7 @@ function convertRun(
   run: Run,
   styleFormatting?: TextFormatting,
   styleResolver?: StyleEngine | null,
+  textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode[] {
   const nodes: PMNode[] = [];
   const { marks, mergedFormatting } = buildRunMarks(run.formatting, styleFormatting, styleResolver);
@@ -2100,7 +2148,7 @@ function convertRun(
   }
 
   for (const content of run.content) {
-    const contentNodes = convertRunContent(content, marks, mergedFormatting);
+    const contentNodes = convertRunContent(content, marks, mergedFormatting, textBoxAnchors);
     nodes.push(...contentNodes);
   }
 
@@ -2167,6 +2215,7 @@ function convertRunContent(
   content: RunContent,
   marks: ReturnType<typeof schema.mark>[],
   formatting?: TextFormatting,
+  textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode[] {
   switch (content.type) {
     case "text":
@@ -2200,8 +2249,8 @@ function convertRunContent(
       // Other shapes render as inline SVG
       const shp = content.shape;
       if (shp.textBody) {
-        // Skip - handled by extractTextBoxesFromParagraph
-        return [];
+        const anchorId = textBoxAnchors?.get(shp);
+        return anchorId ? [schema.node("textBoxAnchor", { anchorId }).mark(marks)] : [];
       }
       return [withHyperlinkBoundaryMarks(convertShape(shp), marks)];
     }
@@ -2864,27 +2913,30 @@ function convertParagraphWithTextBoxes(
     tableParagraphOverlay,
   }: ConvertParagraphWithTextBoxesOptions,
 ): PMNode[] {
-  const { paragraph, textBoxes } = extractTextBoxesFromParagraph(block);
+  const { textBoxes, textBoxAnchors } = extractTextBoxesFromParagraph(block, textBoxGroupId);
   const pmParagraph = convertParagraph(
-    paragraph,
+    block,
     styleResolver,
     undefined,
     extraRunFormatting,
     tableParagraphOverlay,
+    textBoxAnchors,
   );
   const nodes: PMNode[] = [];
-  const isEmptyAfterExtraction = textBoxes.length > 0 && pmParagraph.content.size === 0;
+  const isEmptyAfterExtraction =
+    textBoxes.length > 0 && !hasContentBesidesTextBoxAnchors(pmParagraph);
   const keepWrapperParagraph =
     isEmptyAfterExtraction && hasParagraphBoundaryPayload(block, pmParagraph);
   if (!isEmptyAfterExtraction || keepWrapperParagraph) {
     nodes.push(pmParagraph);
   }
-  for (const { textBox, trackedChange, inlineSdts } of textBoxes) {
+  for (const { textBox, anchorId, trackedChange, inlineSdts } of textBoxes) {
     nodes.push(
       convertTextBox(textBox, styleResolver, {
         placement:
           isEmptyAfterExtraction && !keepWrapperParagraph ? "standalone" : "inlineWithPrevious",
         groupId: textBoxGroupId,
+        anchorId,
         context,
         trackedChange,
         inlineSdts,
@@ -2892,6 +2944,24 @@ function convertParagraphWithTextBoxes(
     );
   }
   return nodes;
+}
+
+function hasContentBesidesTextBoxAnchors(paragraph: PMNode): boolean {
+  let hasContent = false;
+  paragraph.descendants((node) => {
+    if (node.type.name === "textBoxAnchor") {
+      return false;
+    }
+    if (node.type.name === "sdt") {
+      if (node.childCount === 0) {
+        hasContent = true;
+      }
+      return !hasContent;
+    }
+    hasContent = true;
+    return false;
+  });
+  return hasContent;
 }
 
 function hasParagraphBoundaryPayload(block: Paragraph, pmParagraph: PMNode): boolean {
@@ -2911,6 +2981,7 @@ function hasParagraphBoundaryPayload(block: Paragraph, pmParagraph: PMNode): boo
  */
 type ExtractedTextBox = {
   textBox: TextBox;
+  anchorId: string;
   trackedChange: NonNullable<TextBoxAttrs["_docxTrackedChange"]> | undefined;
   inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>;
 };
@@ -2921,90 +2992,57 @@ type TextBoxExtractionContext = {
 };
 
 type ExtractTextBoxesResult = {
-  paragraph: Paragraph;
   textBoxes: ExtractedTextBox[];
+  textBoxAnchors: ReadonlyMap<Shape, string>;
 };
 
-function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesResult {
+function extractTextBoxesFromParagraph(
+  paragraph: Paragraph,
+  textBoxGroupId: string,
+): ExtractTextBoxesResult {
   const textBoxes: ExtractedTextBox[] = [];
-  const stripRun = (run: Run, context: TextBoxExtractionContext): Run | undefined => {
-    const content: Run["content"] = [];
-    let removedTextBox = false;
+  const textBoxAnchors = new Map<Shape, string>();
+  const visitRun = (run: Run, context: TextBoxExtractionContext): void => {
     for (const runContent of run.content) {
       if (runContent.type !== "shape" || !runContent.shape.textBody) {
-        content.push(runContent);
         continue;
       }
-      removedTextBox = true;
+      const anchorId = `${textBoxGroupId}:${textBoxes.length}`;
+      textBoxAnchors.set(runContent.shape, anchorId);
       textBoxes.push({
         textBox: textBoxFromShape(runContent.shape, runContent.shape.textBody),
+        anchorId,
         trackedChange: context.trackedChange,
         inlineSdts: context.inlineSdts,
       });
     }
-    if (!removedTextBox) {
-      return run;
-    }
-    if (content.length === 0) {
-      return undefined;
-    }
-    return { ...run, content };
   };
 
-  const stripTrackedChange = (
+  const visitTrackedChange = (
     change: Insertion | Deletion | MoveFrom | MoveTo,
     context: TextBoxExtractionContext,
-  ): Insertion | Deletion | MoveFrom | MoveTo | undefined => {
+  ): void => {
     const trackedChange = { type: change.type, info: change.info } as const satisfies NonNullable<
       TextBoxAttrs["_docxTrackedChange"]
     >;
-    const content: (Run | Hyperlink)[] = [];
     for (const item of change.content) {
-      if (item.type !== "run") {
-        content.push(item);
-        continue;
-      }
-      const run = stripRun(item, { ...context, trackedChange });
-      if (run) {
-        content.push(run);
+      if (item.type === "run") {
+        visitRun(item, { ...context, trackedChange });
       }
     }
-    if (content.length === 0) {
-      return undefined;
-    }
-    if (change.type === "insertion") {
-      return { ...change, content };
-    }
-    if (change.type === "deletion") {
-      return { ...change, content };
-    }
-    if (change.type === "moveFrom") {
-      return { ...change, content };
-    }
-    return { ...change, content };
   };
 
-  const stripInlineSdt = (
-    sdt: InlineSdt,
-    context: TextBoxExtractionContext,
-  ): InlineSdt | undefined => {
+  const visitInlineSdt = (sdt: InlineSdt, context: TextBoxExtractionContext): void => {
     const inlineSdts = [...context.inlineSdts, sdtAttrsFromProperties(sdt.properties)];
     const nestedContext = { ...context, inlineSdts };
-    const content: InlineSdt["content"] = [];
 
     for (const item of sdt.content) {
       if (item.type === "run") {
-        const run = stripRun(item, nestedContext);
-        if (run) {
-          content.push(run);
-        }
+        visitRun(item, nestedContext);
         continue;
       }
       if (item.type === "inlineSdt") {
-        const nestedSdt = stripInlineSdt(item, nestedContext);
-        if (nestedSdt) {
-          content.push(nestedSdt);
-        }
+        visitInlineSdt(item, nestedContext);
         continue;
       }
       if (
@@ -3013,33 +3051,19 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesRe
         item.type === "moveFrom" ||
         item.type === "moveTo"
       ) {
-        const change = stripTrackedChange(item, nestedContext);
-        if (change) {
-          content.push(change);
-        }
-        continue;
+        visitTrackedChange(item, nestedContext);
       }
-      content.push(item);
     }
-
-    return content.length > 0 || sdt.content.length === 0 ? { ...sdt, content } : undefined;
   };
 
-  const content: ParagraphContent[] = [];
   const rootContext: TextBoxExtractionContext = { inlineSdts: [] };
   for (const item of paragraph.content) {
     if (item.type === "run") {
-      const run = stripRun(item, rootContext);
-      if (run) {
-        content.push(run);
-      }
+      visitRun(item, rootContext);
       continue;
     }
     if (item.type === "inlineSdt") {
-      const sdt = stripInlineSdt(item, rootContext);
-      if (sdt) {
-        content.push(sdt);
-      }
+      visitInlineSdt(item, rootContext);
       continue;
     }
     if (
@@ -3048,18 +3072,13 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): ExtractTextBoxesRe
       item.type === "moveFrom" ||
       item.type === "moveTo"
     ) {
-      const change = stripTrackedChange(item, rootContext);
-      if (change) {
-        content.push(change);
-      }
-      continue;
+      visitTrackedChange(item, rootContext);
     }
-    content.push(item);
   }
 
   return {
-    paragraph: { ...paragraph, content },
     textBoxes,
+    textBoxAnchors,
   };
 }
 
@@ -3102,6 +3121,7 @@ function convertTextBox(
   options: {
     placement?: "standalone" | "inlineWithPrevious";
     groupId?: string;
+    anchorId: string;
     context: TableConversionContext;
     trackedChange: NonNullable<TextBoxAttrs["_docxTrackedChange"]> | undefined;
     inlineSdts: NonNullable<TextBoxAttrs["_docxInlineSdts"]>;
@@ -3252,6 +3272,7 @@ function convertTextBox(
       position,
       _docxPlacement: options.placement,
       _docxGroupId: options.groupId,
+      _docxAnchorId: options.anchorId,
       _docxTrackedChange: options.trackedChange,
       _docxInlineSdts: options.inlineSdts.length > 0 ? options.inlineSdts : undefined,
     },

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -21,7 +21,6 @@ import type {
   BlockSdt,
   Document,
   Paragraph,
-  ParagraphContent,
   ParagraphFormatting,
   Run,
   TextFormatting,

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -342,12 +342,12 @@ function convertParagraph(
     } else if (content.type === "hyperlink") {
       const currentHyperlinkIndex = hyperlinkIndex;
       hyperlinkIndex += 1;
-      const linkNodes = convertHyperlink(
-        content,
+      const linkNodes = convertHyperlink(content, {
         getInheritedRunFormatting,
         styleResolver,
-        currentHyperlinkIndex,
-      );
+        hyperlinkIndex: currentHyperlinkIndex,
+        textBoxAnchors,
+      });
       if (linkNodes.length === 0) {
         emptyHyperlinks ??= [];
         emptyHyperlinks.push({
@@ -455,7 +455,12 @@ function convertTrackedChange(
       const currentHyperlinkIndex = hyperlinkIndex;
       hyperlinkIndex += 1;
       nodes.push(
-        ...convertHyperlink(item, getInheritedRunFormatting, styleResolver, currentHyperlinkIndex),
+        ...convertHyperlink(item, {
+          getInheritedRunFormatting,
+          styleResolver,
+          hyperlinkIndex: currentHyperlinkIndex,
+          textBoxAnchors,
+        }),
       );
     }
   }
@@ -2045,12 +2050,12 @@ function convertInlineSdt(
     } else if (content.type === "hyperlink") {
       const currentHyperlinkIndex = hyperlinkIndex;
       hyperlinkIndex += 1;
-      const linkNodes = convertHyperlink(
-        content,
+      const linkNodes = convertHyperlink(content, {
         getInheritedRunFormatting,
         styleResolver,
-        currentHyperlinkIndex,
-      );
+        hyperlinkIndex: currentHyperlinkIndex,
+        textBoxAnchors,
+      });
       inlineNodes.push(...linkNodes);
     } else if (content.type === "simpleField" || content.type === "complexField") {
       const fieldNode = convertField(content, getInheritedRunFormatting, styleResolver);
@@ -2525,13 +2530,23 @@ function convertImage(image: Image, rawXml?: string): PMNode {
  * Convert a Hyperlink to ProseMirror nodes with link mark
  *
  * @param hyperlink - The hyperlink to convert
- * @param getInheritedRunFormatting - Formatting inherited by each child run
+ * @param options - Formatting, source identity, and extracted text-box anchors
  */
+type ConvertHyperlinkOptions = {
+  getInheritedRunFormatting: RunFormattingResolver;
+  styleResolver?: StyleEngine | null;
+  hyperlinkIndex?: number;
+  textBoxAnchors?: ReadonlyMap<Shape, string>;
+};
+
 function convertHyperlink(
   hyperlink: Hyperlink,
-  getInheritedRunFormatting: RunFormattingResolver,
-  styleResolver?: StyleEngine | null,
-  hyperlinkIndex?: number,
+  {
+    getInheritedRunFormatting,
+    styleResolver,
+    hyperlinkIndex,
+    textBoxAnchors,
+  }: ConvertHyperlinkOptions,
 ): PMNode[] {
   const nodes: PMNode[] = [];
 
@@ -2561,7 +2576,7 @@ function convertHyperlink(
       // silently dropped TOC entries' tab between title and page number,
       // collapsing the right-aligned page number flush against the title.
       for (const content of child.content) {
-        nodes.push(...convertRunContent(content, allMarks, mergedFormatting));
+        nodes.push(...convertRunContent(content, allMarks, mergedFormatting, textBoxAnchors));
       }
     }
   }
@@ -3017,6 +3032,14 @@ function extractTextBoxesFromParagraph(
     }
   };
 
+  const visitHyperlink = (hyperlink: Hyperlink, context: TextBoxExtractionContext): void => {
+    for (const child of hyperlink.children) {
+      if (child.type === "run") {
+        visitRun(child, context);
+      }
+    }
+  };
+
   const visitTrackedChange = (
     change: Insertion | Deletion | MoveFrom | MoveTo,
     context: TextBoxExtractionContext,
@@ -3027,7 +3050,9 @@ function extractTextBoxesFromParagraph(
     for (const item of change.content) {
       if (item.type === "run") {
         visitRun(item, { ...context, trackedChange });
+        continue;
       }
+      visitHyperlink(item, { ...context, trackedChange });
     }
   };
 
@@ -3042,6 +3067,10 @@ function extractTextBoxesFromParagraph(
       }
       if (item.type === "inlineSdt") {
         visitInlineSdt(item, nestedContext);
+        continue;
+      }
+      if (item.type === "hyperlink") {
+        visitHyperlink(item, nestedContext);
         continue;
       }
       if (
@@ -3063,6 +3092,10 @@ function extractTextBoxesFromParagraph(
     }
     if (item.type === "inlineSdt") {
       visitInlineSdt(item, rootContext);
+      continue;
+    }
+    if (item.type === "hyperlink") {
+      visitHyperlink(item, rootContext);
       continue;
     }
     if (

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -80,6 +80,7 @@ import { ShapeExtension } from "./nodes/ShapeExtension";
 import { TabExtension } from "./nodes/TabExtension";
 import { createTableExtensions } from "./nodes/TableExtension";
 import { TextBoxExtension } from "./nodes/TextBoxExtension";
+import { TextBoxAnchorExtension } from "./nodes/TextBoxAnchorExtension";
 import type { AnyExtension } from "./types";
 
 export type StarterKitOptions = {
@@ -162,6 +163,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add("tab", TabExtension());
   add("image", ImageExtension());
   add("textBox", TextBoxExtension());
+  add("textBoxAnchor", TextBoxAnchorExtension());
   add("shape", ShapeExtension());
   add("imageDrag", ImageDragExtension());
   add("imagePaste", ImagePasteExtension());

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
@@ -1,0 +1,50 @@
+/**
+ * Zero-width inline anchor for a text box extracted to a sibling PM block.
+ *
+ * Keeping the anchor in the paragraph lets ordinary ProseMirror transactions
+ * map its position as surrounding text is edited. The save conversion consumes
+ * it when the sibling text box is restored to the DOCX run stream.
+ */
+
+import { expectTextBoxAnchorAttrs } from "../../attrs";
+import { createNodeExtension } from "../create";
+
+export const TextBoxAnchorExtension = createNodeExtension({
+  name: "textBoxAnchor",
+  schemaNodeName: "textBoxAnchor",
+  nodeSpec: {
+    inline: true,
+    group: "inline",
+    marks: "_",
+    atom: true,
+    selectable: false,
+    attrs: {
+      anchorId: {},
+    },
+    parseDOM: [
+      {
+        tag: "span[data-docx-textbox-anchor]",
+        getAttrs(dom): { anchorId: string } | false {
+          if (!(dom instanceof HTMLElement)) {
+            return false;
+          }
+          const anchorId = dom.dataset["docxTextboxAnchor"];
+          return anchorId ? { anchorId } : false;
+        },
+      },
+    ],
+    toDOM(node) {
+      const { anchorId } = expectTextBoxAnchorAttrs(node);
+      return [
+        "span",
+        {
+          "data-docx-textbox-anchor": anchorId,
+          "aria-hidden": "true",
+          contenteditable: "false",
+          style:
+            "display: inline-block; width: 0; height: 0; overflow: hidden; pointer-events: none;",
+        },
+      ];
+    },
+  },
+});

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
@@ -6,7 +6,7 @@
  * it when the sibling text box is restored to the DOCX run stream.
  */
 
-import { expectTextBoxAnchorAttrs } from "../../attrs";
+import { expectTextBoxAnchorAttrs } from "../../textBoxAnchorAttrs";
 import { createNodeExtension } from "../create";
 
 export const TextBoxAnchorExtension = createNodeExtension({

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -61,6 +61,8 @@ export type TextBoxAttrs = {
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */
   _docxGroupId?: string;
+  /** Inline anchor linking this block node to its source run position. */
+  _docxAnchorId?: string;
   /** Original run-level revision wrapper for save-path reconstruction. */
   _docxTrackedChange?: SchemaTextBoxAttrs["_docxTrackedChange"];
   /** Original inline content-control ancestry for save-path reconstruction. */
@@ -131,6 +133,7 @@ export const TextBoxExtension = createNodeExtension({
       position: { default: null },
       _docxPlacement: { default: null },
       _docxGroupId: { default: null },
+      _docxAnchorId: { default: null },
       _docxTrackedChange: { default: null },
       _docxInlineSdts: { default: null },
     },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -549,6 +549,8 @@ export type TextBoxAttrs = {
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */
   _docxGroupId?: string;
+  /** Inline anchor linking this block node to its source run position. */
+  _docxAnchorId?: string;
   /** Original run-level revision wrapper for save-path reconstruction. */
   _docxTrackedChange?:
     | { type: "insertion"; info: TrackedChangeInfo }
@@ -557,6 +559,11 @@ export type TextBoxAttrs = {
     | { type: "moveTo"; info: TrackedChangeInfo };
   /** Original inline content-control ancestry for save-path reconstruction. */
   _docxInlineSdts?: SdtAttrs[];
+};
+
+/** Internal inline position marker for an extracted text box block. */
+export type TextBoxAnchorAttrs = {
+  anchorId: string;
 };
 
 /**

--- a/packages/core/src/prosemirror/textBoxAnchorAttrs.ts
+++ b/packages/core/src/prosemirror/textBoxAnchorAttrs.ts
@@ -1,0 +1,44 @@
+import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type { ProseMirrorAttrIssue, ReadProseMirrorAttrsResult } from "./attrs";
+import type { TextBoxAnchorAttrs } from "./schema/nodes";
+
+const attrsCache = new WeakMap<PMNode, TextBoxAnchorAttrs>();
+
+export const readTextBoxAnchorAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<TextBoxAnchorAttrs> => {
+  const issues: ProseMirrorAttrIssue[] = [];
+  if (node.type.name !== "textBoxAnchor") {
+    issues.push({
+      path: "textBoxAnchor.type.name",
+      message: `Expected textBoxAnchor, got ${node.type.name}.`,
+    });
+  }
+  const anchorId = node.attrs["anchorId"];
+  if (typeof anchorId !== "string" || anchorId.length === 0) {
+    issues.push({
+      path: "textBoxAnchor.attrs.anchorId",
+      message: "Expected a non-empty string.",
+    });
+  }
+  if (issues.length > 0 || typeof anchorId !== "string") {
+    return { ok: false, issues };
+  }
+  return { ok: true, value: { anchorId } };
+};
+
+export const expectTextBoxAnchorAttrs = (node: PMNode): TextBoxAnchorAttrs => {
+  const cached = attrsCache.get(node);
+  if (cached) {
+    return cached;
+  }
+  const result = readTextBoxAnchorAttrs(node);
+  if (!result.ok) {
+    const details = result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("\n");
+    panic(`Invalid ProseMirror text box anchor attrs:\n${details}`);
+  }
+  attrsCache.set(node, result.value);
+  return result.value;
+};

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -28,12 +28,12 @@ import {
   readTableCellAttrs,
   readTableRowAttrs,
   readTextBoxAttrs,
-  readTextBoxAnchorAttrs,
   readTextColorMarkAttrs,
   readTextEffectMarkAttrs,
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
 } from "./attrs";
+import { readTextBoxAnchorAttrs } from "./textBoxAnchorAttrs";
 
 export type ProseMirrorDocumentValidationIssue = {
   path: string;

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -28,6 +28,7 @@ import {
   readTableCellAttrs,
   readTableRowAttrs,
   readTextBoxAttrs,
+  readTextBoxAnchorAttrs,
   readTextColorMarkAttrs,
   readTextEffectMarkAttrs,
   readTrackedChangeMarkAttrs,
@@ -184,6 +185,10 @@ const validateNodeAttrs = (
 
     case "textBox":
       appendAttrIssues(path, readTextBoxAttrs(node), issues);
+      return;
+
+    case "textBoxAnchor":
+      appendAttrIssues(path, readTextBoxAnchorAttrs(node), issues);
       return;
 
     default:


### PR DESCRIPTION
## Summary

- preserve each extracted inline text box at its original run-stream position
- keep edit-stable zero-width anchors out of paragraph layout and consume them during save reconstruction
- retain source order through nested content controls, tracked changes, and table cells; remove orphan anchors when a text box is deleted

## Testing

- `bun test packages/core/src/prosemirror/conversion/fromProseDoc.test.ts packages/core/src/prosemirror/conversion/toProseDoc.test.ts`
- `bun test packages/core/src/prosemirror/attrs/index.test.ts --test-name-pattern "text-box anchor"`
- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts --test-name-pattern "text-box anchors out"`
- `bun run changeset:check`
- `bun audit`

Full typecheck and lint are left to CI.