### PR TITLE
feat: track inline formatting changes

### DIFF
--- a/.changeset/tracked-range-formatting.md
+++ b/.changeset/tracked-range-formatting.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+"@stll/folio-vue": minor
+---
+
+Support tracked inline formatting operations across document review surfaces.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -337,7 +337,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     readonly additionalProperties: false;
                 }, {
                     readonly type: "object";
-                    readonly description: string;
+                    readonly description: "Apply inline formatting to the text covered by a range handle in direct or tracked mode.";
                     readonly properties: {
                         readonly type: {
                             readonly type: "string";
@@ -1348,7 +1348,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
         readonly additionalProperties: false;
     }, {
         readonly type: "object";
-        readonly description: string;
+        readonly description: "Apply inline formatting to the text covered by a range handle in direct or tracked mode.";
         readonly properties: {
             readonly type: {
                 readonly type: "string";

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -64,7 +64,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly replaceInBlock: readonly ["direct", "tracked-changes"];
     readonly replaceRange: readonly ["direct", "tracked-changes"];
     readonly commentOnRange: readonly ["direct", "tracked-changes"];
-    readonly formatRange: readonly ["direct"];
+    readonly formatRange: readonly ["direct", "tracked-changes"];
     readonly insertAfterBlock: readonly ["direct", "tracked-changes"];
     readonly insertBeforeBlock: readonly ["direct", "tracked-changes"];
     readonly replaceBlock: readonly ["direct", "tracked-changes"];
@@ -570,7 +570,7 @@ export type FolioReviewChange = {
 };
 
 // @public (undocumented)
-export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted" | "cellMerged";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "formatting" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted" | "cellMerged";
 
 // @public (undocumented)
 export type FolioReviewedStory = {

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -432,7 +432,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly replaceInBlock: readonly ["direct", "tracked-changes"];
     readonly replaceRange: readonly ["direct", "tracked-changes"];
     readonly commentOnRange: readonly ["direct", "tracked-changes"];
-    readonly formatRange: readonly ["direct"];
+    readonly formatRange: readonly ["direct", "tracked-changes"];
     readonly insertAfterBlock: readonly ["direct", "tracked-changes"];
     readonly insertBeforeBlock: readonly ["direct", "tracked-changes"];
     readonly replaceBlock: readonly ["direct", "tracked-changes"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -432,7 +432,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly replaceInBlock: readonly ["direct", "tracked-changes"];
     readonly replaceRange: readonly ["direct", "tracked-changes"];
     readonly commentOnRange: readonly ["direct", "tracked-changes"];
-    readonly formatRange: readonly ["direct"];
+    readonly formatRange: readonly ["direct", "tracked-changes"];
     readonly insertAfterBlock: readonly ["direct", "tracked-changes"];
     readonly insertBeforeBlock: readonly ["direct", "tracked-changes"];
     readonly replaceBlock: readonly ["direct", "tracked-changes"];

--- a/api-reports/core/prosemirror-attrs.api.md
+++ b/api-reports/core/prosemirror-attrs.api.md
@@ -62,6 +62,9 @@ export const expectParagraphAttrs: (node: Node_2) => ParagraphAttrs;
 export const expectRunFormattingOverrideMarkAttrs: (mark: Mark) => RunFormattingOverrideAttrs;
 
 // @public (undocumented)
+export const expectRunPropertyChangeMarkAttrs: (mark: Mark) => RunPropertyChangeMarkAttrs;
+
+// @public (undocumented)
 export const expectRunShadingMarkAttrs: (mark: Mark) => RunShadingAttrs;
 
 // @public (undocumented)
@@ -177,6 +180,9 @@ export type ReadProseMirrorAttrsResult<T> = {
 
 // @public (undocumented)
 export const readRunFormattingOverrideMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<RunFormattingOverrideAttrs>;
+
+// @public (undocumented)
+export const readRunPropertyChangeMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<RunPropertyChangeMarkAttrs>;
 
 // @public (undocumented)
 export const readRunShadingMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<RunShadingAttrs>;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -273,6 +273,11 @@ export type RunFormattingOverrideAttrs = { [K in keyof Pick<import__stll_docx_co
 };
 
 // @public
+export type RunPropertyChangeMarkAttrs = {
+    changes: import__stll_docx_core_model.RunPropertyChange[];
+};
+
+// @public
 export type RunShadingAttrs = TextColorAttrs & {
     pattern?: NonNullable<ShadingProperties["pattern"]>;
     patternColor?: string;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -185,7 +185,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly replaceInBlock: readonly ["direct", "tracked-changes"];
     readonly replaceRange: readonly ["direct", "tracked-changes"];
     readonly commentOnRange: readonly ["direct", "tracked-changes"];
-    readonly formatRange: readonly ["direct"];
+    readonly formatRange: readonly ["direct", "tracked-changes"];
     readonly insertAfterBlock: readonly ["direct", "tracked-changes"];
     readonly insertBeforeBlock: readonly ["direct", "tracked-changes"];
     readonly replaceBlock: readonly ["direct", "tracked-changes"];
@@ -789,7 +789,7 @@ export type FolioReviewChangeFilter = {
 };
 
 // @public (undocumented)
-export type FolioReviewChangeKind = "insertion" | "deletion" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted" | "cellMerged";
+export type FolioReviewChangeKind = "insertion" | "deletion" | "formatting" | "rowInserted" | "rowDeleted" | "cellInserted" | "cellDeleted" | "cellMerged";
 
 // @public
 export type FolioReviewComment = {

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -174,8 +174,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
     {
       type: "object",
       description:
-        "Apply inline formatting to the text covered by a range handle. Direct mode only " +
-        "(formatting is not representable as a tracked change).",
+        "Apply inline formatting to the text covered by a range handle in direct or tracked mode.",
       properties: {
         ...operationMetaProperties,
         type: { type: "string", enum: ["formatRange"] },
@@ -451,8 +450,8 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       enum: FOLIO_DOCUMENT_OPERATION_MODES,
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
-        '"direct" applies immediately. `formatRange`, `insertSignatureTable`, ' +
-        "`mergeTableCells` and `splitTableCell` support " +
+        '"direct" applies immediately. `insertSignatureTable`, `mergeTableCells` and ' +
+        "`splitTableCell` support " +
         '"direct" only.',
     },
     atomic: {

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -388,13 +388,13 @@ describe("parseSuggestChangesInput", () => {
         endOffset: 4,
         selectedTextHash: "h123",
       },
+      formatting: { bold: true },
     });
     for (const type of SUGGEST_CHANGES_OPERATION_TYPES) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(type)] });
       expect(result.ok, type).toBe(true);
     }
     for (const excludedType of [
-      "formatRange",
       "commentOnBlock",
       "insertSignatureTable",
       "mergeTableCells",

--- a/packages/agents/src/parse.ts
+++ b/packages/agents/src/parse.ts
@@ -84,12 +84,13 @@ export const parseAddCommentInput = (args: unknown): ParseAddCommentResult => {
 };
 
 const OPERATION_TYPES =
-  "replaceInBlock, replaceRange, commentOnRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn";
+  "replaceInBlock, replaceRange, commentOnRange, formatRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn";
 
 type SuggestedOperationType =
   | "replaceInBlock"
   | "replaceRange"
   | "commentOnRange"
+  | "formatRange"
   | "insertAfterBlock"
   | "insertBeforeBlock"
   | "replaceBlock"
@@ -103,6 +104,7 @@ const isOperationType = (value: unknown): value is SuggestedOperationType =>
   value === "replaceInBlock" ||
   value === "replaceRange" ||
   value === "commentOnRange" ||
+  value === "formatRange" ||
   value === "insertAfterBlock" ||
   value === "insertBeforeBlock" ||
   value === "replaceBlock" ||
@@ -166,7 +168,7 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
   const opId = isNonEmptyString(id) ? id : `op-${index + 1}`;
   const commentField = typeof comment === "string" ? { comment: { text: comment } } : {};
 
-  if (type === "replaceRange" || type === "commentOnRange") {
+  if (type === "replaceRange" || type === "commentOnRange" || type === "formatRange") {
     const range = readTextRange(raw["range"], index);
     if (typeof range === "string") {
       return range;
@@ -176,6 +178,27 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
         return `operations[${index}] (commentOnRange) requires a non-empty string \`comment\`.`;
       }
       return { id: opId, type, range, comment: { text: comment } };
+    }
+    if (type === "formatRange") {
+      const rawFormatting = raw["formatting"];
+      if (!isPlainObject(rawFormatting)) {
+        return `operations[${index}] (formatRange) requires a \`formatting\` object.`;
+      }
+      const formatting: { bold?: boolean; italic?: boolean; underline?: boolean } = {};
+      for (const key of ["bold", "italic", "underline"] as const) {
+        const value = rawFormatting[key];
+        if (value === undefined) {
+          continue;
+        }
+        if (typeof value !== "boolean") {
+          return `operations[${index}].formatting.${key} must be a boolean when provided.`;
+        }
+        formatting[key] = value;
+      }
+      if (Object.keys(formatting).length === 0) {
+        return `operations[${index}] (formatRange) requires at least one formatting property.`;
+      }
+      return { id: opId, type, range, formatting };
     }
     const replace = raw["replace"];
     if (typeof replace !== "string") {

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,7 +52,7 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `formatRange`, `insertSignatureTable`, `mergeTableCells`,
+ * - excluded types: `insertSignatureTable`, `mergeTableCells`,
  *   and `splitTableCell` (direct-only,
  *   not representable as tracked changes for human review)
  *   and `commentOnBlock` (covered by the dedicated `add_comment` tool);
@@ -63,10 +63,9 @@ const scopedHandleSchema = {
  * - the review metadata (`severity`, `area`), `precondition` guard, and the
  *   insert/replace formatting knobs (`inheritFormatting`, `pageBreakBefore`,
  *   `preserveFormatting`, `styleId`, `parties`, `quote`,
- *   `formatting`) are not exposed to the model.
+ *   except `formatting`) are not exposed to the model.
  */
 const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperationType> = new Set([
-  "formatRange",
   "commentOnBlock",
   "insertSignatureTable",
   "mergeTableCells",
@@ -105,7 +104,7 @@ const suggestChangesOperationSchema = {
     range: {
       ...FOLIO_TEXT_RANGE_JSON_SCHEMA,
       description:
-        "Required for `replaceRange` and `commentOnRange`: copy the range object returned by `find_text`.",
+        "Required for `replaceRange`, `commentOnRange`, and `formatRange`: copy the range object returned by `find_text`.",
     },
     find: {
       type: "string",
@@ -134,6 +133,18 @@ const suggestChangesOperationSchema = {
         "For row or column insertion, initial text for new physical cells in source order, up to 100,000 characters per cell.",
       maxItems: 256,
       items: { type: "string" },
+    },
+    formatting: {
+      type: "object",
+      description:
+        "Required for `formatRange`: set one or more inline properties to enable or disable.",
+      properties: {
+        bold: { type: "boolean" },
+        italic: { type: "boolean" },
+        underline: { type: "boolean" },
+      },
+      minProperties: 1,
+      additionalProperties: false,
     },
     comment: {
       type: "string",

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -4,7 +4,12 @@ import { EditorState } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
-import { acceptAIEditRevision, rejectAIEditRevision } from "../prosemirror/commands/comments";
+import {
+  acceptAIEditRevision,
+  acceptAllChanges,
+  rejectAIEditRevision,
+  rejectAllChanges,
+} from "../prosemirror/commands/comments";
 import { applyFolioAIEditOperations } from "./apply";
 import { getTrackedChangesFromDoc } from "./read";
 import { createFolioAIEditSnapshot, createFolioAITextRangeHandle } from "./snapshot";
@@ -69,6 +74,12 @@ const schema = new Schema({
         date: {},
       },
       toDOM: () => ["del", 0],
+    },
+    runPropertyChange: {
+      attrs: {
+        changes: { default: [] },
+      },
+      toDOM: () => ["span", 0],
     },
     comment: {
       attrs: {
@@ -323,8 +334,62 @@ describe("Folio AI edit operations", () => {
     expect(target?.marks.map((mark) => mark.type.name).toSorted()).toEqual(["bold", "comment"]);
   });
 
-  test("reports range formatting as unsupported in tracked-changes mode", () => {
+  test("tracks range formatting and supports accepting or rejecting it", () => {
+    const applyFormatting = () => {
+      const view = makeView(makeState(["target"]));
+      const snapshot = createFolioAIEditSnapshot(view.state.doc);
+      const block = snapshot.blocks.at(0);
+      const range = block
+        ? createFolioAITextRangeHandle({
+            blockId: block.id,
+            text: block.text,
+            startOffset: 0,
+            endOffset: 6,
+          })
+        : null;
+      if (!range) {
+        throw new Error("expected a range");
+      }
+      const result = applyFolioAIEditOperations({
+        view,
+        snapshot,
+        operations: [{ id: "format", type: "formatRange", range, formatting: { italic: true } }],
+        author: "Reviewer",
+      });
+      const revisionId = result.applied.at(0)?.revisionId;
+      if (revisionId === undefined) {
+        throw new Error("expected a formatting revision");
+      }
+      return { view, revisionId };
+    };
+
+    const accepting = applyFormatting();
+    expect(collectMarksByText(accepting.view.state)).toEqual({
+      target: ["runPropertyChange", "italic"],
+    });
+    expect(getTrackedChangesFromDoc(accepting.view.state.doc)).toEqual([
+      expect.objectContaining({
+        id: accepting.revisionId,
+        type: "formatting",
+        author: "Reviewer",
+        text: "target",
+      }),
+    ]);
+    acceptAIEditRevision(accepting.revisionId)(accepting.view.state, accepting.view.dispatch);
+    expect(collectMarksByText(accepting.view.state)).toEqual({ target: ["italic"] });
+
+    const rejecting = applyFormatting();
+    rejectAIEditRevision(rejecting.revisionId)(rejecting.view.state, rejecting.view.dispatch);
+    expect(collectMarksByText(rejecting.view.state)).toEqual({ target: [] });
+  });
+
+  test("does not invent a formatting revision for an unchanged range", () => {
     const view = makeView(makeState(["target"]));
+    const italic = schema.marks["italic"]?.create();
+    if (!italic) {
+      throw new Error("missing italic mark");
+    }
+    view.dispatch(view.state.tr.addMark(1, 7, italic));
     const snapshot = createFolioAIEditSnapshot(view.state.doc);
     const block = snapshot.blocks.at(0);
     const range = block
@@ -343,7 +408,46 @@ describe("Folio AI edit operations", () => {
       snapshot,
       operations: [{ id: "format", type: "formatRange", range, formatting: { italic: true } }],
     });
-    expect(result.skipped).toEqual([{ id: "format", reason: "unsupportedMode" }]);
+    expect(result.skipped).toEqual([{ id: "format", reason: "noopOperation" }]);
+  });
+
+  test("preserves stacked formatting revisions in one batch", () => {
+    const applyFormatting = () => {
+      const view = makeView(makeState(["target"]));
+      const snapshot = createFolioAIEditSnapshot(view.state.doc);
+      const block = snapshot.blocks.at(0);
+      const range = block
+        ? createFolioAITextRangeHandle({
+            blockId: block.id,
+            text: block.text,
+            startOffset: 0,
+            endOffset: 6,
+          })
+        : null;
+      if (!range) {
+        throw new Error("expected a range");
+      }
+      const result = applyFolioAIEditOperations({
+        view,
+        snapshot,
+        operations: [
+          { id: "bold", type: "formatRange", range, formatting: { bold: true } },
+          { id: "italic", type: "formatRange", range, formatting: { italic: true } },
+        ],
+      });
+      expect(result.skipped).toEqual([]);
+      expect(result.applied).toHaveLength(2);
+      expect(getTrackedChangesFromDoc(view.state.doc)).toHaveLength(2);
+      return view;
+    };
+
+    const accepting = applyFormatting();
+    acceptAllChanges()(accepting.state, accepting.dispatch);
+    expect(collectMarksByText(accepting.state)).toEqual({ target: ["bold", "italic"] });
+
+    const rejecting = applyFormatting();
+    rejectAllChanges()(rejecting.state, rejecting.dispatch);
+    expect(collectMarksByText(rejecting.state)).toEqual({ target: [] });
   });
 
   test("rejects a range whose selected text hash is stale", () => {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -10,7 +10,10 @@ import {
 } from "prosemirror-tables";
 
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
+import { expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
+import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
+import type { RunPropertyChange } from "../types/document";
 import { buildCleanBlockText } from "./clean-text";
 import {
   hasInlineEmphasis,
@@ -120,6 +123,111 @@ const applyReplaceBlockStyleId = ({
     ...block.attrs,
     styleId: item.operation.styleId,
   });
+};
+
+type ApplyInlineFormattingOptions = {
+  tr: Transaction;
+  schema: Schema;
+  from: number;
+  to: number;
+  formatting: Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"];
+};
+
+const applyInlineFormatting = ({
+  tr,
+  schema,
+  from,
+  to,
+  formatting,
+}: ApplyInlineFormattingOptions): Transaction => {
+  for (const [name, enabled] of Object.entries(formatting)) {
+    const markType = schema.marks[name];
+    if (!markType) {
+      continue;
+    }
+    if (enabled) {
+      tr.addMark(
+        from,
+        to,
+        name === "underline" ? markType.create({ style: "single" }) : markType.create(),
+      );
+      continue;
+    }
+    tr.removeMark(from, to, markType);
+  }
+  return tr;
+};
+
+const formattingWouldChange = (
+  marks: readonly Mark[],
+  formatting: Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"],
+): boolean =>
+  Object.entries(formatting).some(([name, enabled]) => {
+    const mark = marks.find((candidate) => candidate.type.name === name);
+    if (!enabled) {
+      return mark !== undefined;
+    }
+    if (name === "underline") {
+      return mark?.attrs["style"] !== "single";
+    }
+    return mark === undefined;
+  });
+
+type ApplyTrackedInlineFormattingOptions = ApplyInlineFormattingOptions & {
+  doc: PMNode;
+  revisionId: number;
+  author: string;
+  date: string;
+};
+
+const applyTrackedInlineFormatting = ({
+  tr,
+  schema,
+  doc,
+  from,
+  to,
+  formatting,
+  revisionId,
+  author,
+  date,
+}: ApplyTrackedInlineFormattingOptions): Transaction => {
+  const propertyChangeType = schema.marks["runPropertyChange"];
+  if (!propertyChangeType) {
+    return tr;
+  }
+
+  const segments: { from: number; to: number; changes: RunPropertyChange[] }[] = [];
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (!node.isText || !formattingWouldChange(node.marks, formatting)) {
+      return;
+    }
+    const segmentFrom = Math.max(from, pos);
+    const segmentTo = Math.min(to, pos + node.nodeSize);
+    const previousFormatting = marksToTextFormatting(node.marks);
+    const existingMark = node.marks.find((mark) => mark.type === propertyChangeType);
+    const existingChanges = existingMark
+      ? expectRunPropertyChangeMarkAttrs(existingMark).changes
+      : [];
+    const change: RunPropertyChange = {
+      type: "runPropertyChange",
+      info: { id: revisionId, author, date },
+      ...(Object.keys(previousFormatting).length > 0 ? { previousFormatting } : {}),
+    };
+    segments.push({
+      from: segmentFrom,
+      to: segmentTo,
+      changes: [...existingChanges, change],
+    });
+  });
+
+  if (segments.length === 0) {
+    return tr;
+  }
+  applyInlineFormatting({ tr, schema, from, to, formatting });
+  for (const segment of segments) {
+    tr.addMark(segment.from, segment.to, propertyChangeType.create({ changes: segment.changes }));
+  }
+  return tr;
 };
 
 type LiveBlockEntry = { from: number; to: number; node: PMNode };
@@ -1044,9 +1152,7 @@ const applyFolioAIEditOperationsInternal = ({
   for (const [index, operation] of operations.entries()) {
     if (
       mode === "tracked-changes" &&
-      (operation.type === "formatRange" ||
-        operation.type === "mergeTableCells" ||
-        operation.type === "splitTableCell")
+      (operation.type === "mergeTableCells" || operation.type === "splitTableCell")
     ) {
       skipped.push({ id: operation.id, reason: "unsupportedMode" });
       continue;
@@ -1280,21 +1386,29 @@ const applyFolioAIEditOperationsInternal = ({
         break;
       }
       case "formatRange": {
-        for (const [name, enabled] of Object.entries(item.operation.formatting)) {
-          const markType = view.state.schema.marks[name];
-          if (!markType) {
-            continue;
-          }
-          if (enabled) {
-            tr = tr.addMark(
-              item.from,
-              item.to,
-              name === "underline" ? markType.create({ style: "single" }) : markType.create(),
-            );
-          } else {
-            tr = tr.removeMark(item.from, item.to, markType);
-          }
+        if (mode === "tracked-changes") {
+          const revisionId = revisionSeed++;
+          tr = applyTrackedInlineFormatting({
+            tr,
+            schema: view.state.schema,
+            doc: tr.doc,
+            from: item.from,
+            to: item.to,
+            formatting: item.operation.formatting,
+            revisionId,
+            author,
+            date,
+          });
+          appliedRevisionIds = [revisionId];
+          break;
         }
+        tr = applyInlineFormatting({
+          tr,
+          schema: view.state.schema,
+          from: item.from,
+          to: item.to,
+          formatting: item.operation.formatting,
+        });
         break;
       }
       case "replaceBlock": {

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -11,12 +11,14 @@
 
 import type { Node as PMNode } from "prosemirror-model";
 
+import { expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
 import { getTableCellMergeChange } from "../prosemirror/tableCellMergeRevision";
 import { createFolioAIEditSnapshot } from "./snapshot";
 
 export type FolioReviewChangeKind =
   | "insertion"
   | "deletion"
+  | "formatting"
   | "rowInserted"
   | "rowDeleted"
   | "cellInserted"
@@ -206,6 +208,26 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
     }
     const text = node.text;
     for (const mark of node.marks) {
+      if (mark.type.name === "runPropertyChange") {
+        const { changes } = expectRunPropertyChangeMarkAttrs(mark);
+        for (const change of changes) {
+          const key = `${currentBlockId ?? ""}:formatting:${String(change.info.id)}`;
+          const existing = grouped.get(key);
+          if (existing) {
+            existing.text += text;
+            continue;
+          }
+          grouped.set(key, {
+            id: change.info.id,
+            type: "formatting",
+            author: change.info.author,
+            date: change.info.date ?? null,
+            text,
+            blockId: currentBlockId,
+          });
+        }
+        continue;
+      }
       if (typeof mark.attrs["revisionId"] !== "number") {
         continue;
       }

--- a/packages/core/src/ai-edits/runPropertyFormatting.test.ts
+++ b/packages/core/src/ai-edits/runPropertyFormatting.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "../docx/parser";
+import { createDocx, repackDocx } from "../docx/rezip";
+import { createEmptyDocument } from "../utils/createDocument";
+import { FolioDocxReviewer } from "./headless";
+import { createFolioAITextRangeHandle } from "./snapshot";
+
+const createFormattingBaseline = async (): Promise<ArrayBuffer> => {
+  const document = createEmptyDocument();
+  document.package.document.content = [
+    {
+      type: "paragraph",
+      paraId: "A1000001",
+      content: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "Formatting target" }],
+        },
+      ],
+    },
+  ];
+  return createDocx(document);
+};
+
+const HEADER_RELATIONSHIP_ID = "rIdFormattingHeader";
+
+const createHeaderFormattingBaseline = async (): Promise<ArrayBuffer> => {
+  const seed = await createDocx(createEmptyDocument());
+  const document = await parseDocx(seed, { detectVariables: false, preloadFonts: false });
+  document.package.headers = new Map([
+    [
+      HEADER_RELATIONSHIP_ID,
+      {
+        type: "header" as const,
+        hdrFtrType: "default" as const,
+        content: [
+          {
+            type: "paragraph" as const,
+            paraId: "A1000002",
+            content: [
+              {
+                type: "run" as const,
+                content: [{ type: "text" as const, text: "Header target" }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  ]);
+  document.package.document.finalSectionProperties = {
+    ...document.package.document.finalSectionProperties,
+    headerReferences: [{ type: "default", rId: HEADER_RELATIONSHIP_ID }],
+  };
+  return repackDocx(document, { updateModifiedDate: false });
+};
+
+const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const part = zip.file("word/document.xml");
+  if (!part) {
+    throw new Error("missing word/document.xml");
+  }
+  return part.async("text");
+};
+
+const applyTrackedBold = async (): Promise<ArrayBuffer> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(await createFormattingBaseline(), {
+    author: "Reviewer",
+  });
+  const snapshot = reviewer.snapshot();
+  const block = snapshot.blocks.at(0);
+  const range = block
+    ? createFolioAITextRangeHandle({
+        blockId: block.id,
+        text: block.text,
+        startOffset: 0,
+        endOffset: "Formatting".length,
+      })
+    : null;
+  if (!range) {
+    throw new Error("expected a formatting range");
+  }
+
+  const result = reviewer.applyOperations([
+    { id: "format", type: "formatRange", range, formatting: { bold: true } },
+  ]);
+  expect(result.skipped).toEqual([]);
+  expect(result.applied.at(0)?.revisionId).toBeNumber();
+  return reviewer.toBuffer();
+};
+
+describe("tracked run formatting", () => {
+  test("saves, reopens, accepts, and rejects a formatting revision", async () => {
+    const tracked = await applyTrackedBold();
+    const trackedXml = await documentXml(tracked);
+    expect(trackedXml).toContain("<w:rPrChange ");
+    expect(trackedXml).toContain("<w:b/>");
+
+    const accepting = await FolioDocxReviewer.fromBuffer(tracked);
+    const acceptedChange = accepting.getChanges().find(({ type }) => type === "formatting");
+    if (!acceptedChange) {
+      throw new Error("expected a formatting change after reopen");
+    }
+    expect(accepting.acceptChange(acceptedChange)).toBe(true);
+    const acceptedXml = await documentXml(await accepting.toBuffer());
+    expect(acceptedXml).not.toContain("<w:rPrChange ");
+    expect(acceptedXml).toContain("<w:b/>");
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(tracked);
+    const rejectedChange = rejecting.getChanges().find(({ type }) => type === "formatting");
+    if (!rejectedChange) {
+      throw new Error("expected a formatting change after reopen");
+    }
+    expect(rejecting.rejectChange(rejectedChange)).toBe(true);
+    const rejectedXml = await documentXml(await rejecting.toBuffer());
+    expect(rejectedXml).not.toContain("<w:rPrChange ");
+    expect(rejectedXml).not.toContain("<w:b/>");
+  });
+
+  test("uses the same operation in a secondary document story", async () => {
+    const story = { type: "header" as const, relationshipId: HEADER_RELATIONSHIP_ID };
+    const reviewer = await FolioDocxReviewer.fromBuffer(await createHeaderFormattingBaseline(), {
+      author: "Reviewer",
+    });
+    const snapshot = reviewer.snapshotStory(story);
+    const block = snapshot?.blocks.at(0);
+    const range = block
+      ? createFolioAITextRangeHandle({
+          blockId: block.id,
+          text: block.text,
+          startOffset: 0,
+          endOffset: "Header".length,
+        })
+      : null;
+    if (!snapshot || !range) {
+      throw new Error("expected a header formatting range");
+    }
+
+    const result = reviewer.applyDocumentOperationsToStory({
+      story,
+      batch: {
+        version: 1,
+        mode: "tracked-changes",
+        operations: [
+          { id: "format-header", type: "formatRange", range, formatting: { italic: true } },
+        ],
+      },
+      snapshot,
+    });
+    expect(result.skipped).toEqual([]);
+
+    const reopened = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
+    expect(reopened.readReviewedStory({ story, view: "current-markup" })?.changes).toEqual([
+      expect.objectContaining({ type: "formatting", text: "Header" }),
+    ]);
+  });
+});

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -45,7 +45,7 @@ describe("document operation contract", () => {
         replaceInBlock: ["direct", "tracked-changes"],
         replaceRange: ["direct", "tracked-changes"],
         commentOnRange: ["direct", "tracked-changes"],
-        formatRange: ["direct"],
+        formatRange: ["direct", "tracked-changes"],
         insertAfterBlock: ["direct", "tracked-changes"],
         insertBeforeBlock: ["direct", "tracked-changes"],
         replaceBlock: ["direct", "tracked-changes"],
@@ -66,6 +66,7 @@ describe("document operation contract", () => {
 
   test("reports mode support for each operation type", () => {
     expect(isFolioDocumentOperationModeSupported("replaceInBlock", "tracked-changes")).toBe(true);
+    expect(isFolioDocumentOperationModeSupported("formatRange", "tracked-changes")).toBe(true);
     expect(isFolioDocumentOperationModeSupported("insertSignatureTable", "direct")).toBe(true);
     expect(isFolioDocumentOperationModeSupported("insertSignatureTable", "tracked-changes")).toBe(
       false,

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -71,7 +71,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   replaceInBlock: DIRECT_AND_TRACKED_MODES,
   replaceRange: DIRECT_AND_TRACKED_MODES,
   commentOnRange: DIRECT_AND_TRACKED_MODES,
-  formatRange: DIRECT_ONLY_MODES,
+  formatRange: DIRECT_AND_TRACKED_MODES,
   insertAfterBlock: DIRECT_AND_TRACKED_MODES,
   insertBeforeBlock: DIRECT_AND_TRACKED_MODES,
   replaceBlock: DIRECT_AND_TRACKED_MODES,

--- a/packages/core/src/i18n/messages/ar.json
+++ b/packages/core/src/i18n/messages/ar.json
@@ -491,6 +491,7 @@
       "rowDeleted": "تم حذف الصف",
       "rowInserted": "تم إدراج الصف",
       "rowPropertiesChanged": "تم تغيير تنسيق الصف",
+      "runPropertiesChanged": "تم تغيير تنسيق النص",
       "tableDeleted": "تم حذف الجدول",
       "tableInserted": "تم إدراج الجدول",
       "tablePropertiesChanged": "تم تغيير تنسيق الجدول"

--- a/packages/core/src/i18n/messages/catalogs.gen.ts
+++ b/packages/core/src/i18n/messages/catalogs.gen.ts
@@ -499,6 +499,7 @@ export const CATALOGS = {
         "rowDeleted": "Row deleted",
         "rowInserted": "Row inserted",
         "rowPropertiesChanged": "Row formatting changed",
+        "runPropertiesChanged": "Text formatting changed",
         "tableDeleted": "Table deleted",
         "tableInserted": "Table inserted",
         "tablePropertiesChanged": "Table formatting changed"
@@ -1141,6 +1142,7 @@ export const CATALOGS = {
         "rowDeleted": "Zeile gelöscht",
         "rowInserted": "Zeile eingefügt",
         "rowPropertiesChanged": "Zeilenformatierung geändert",
+        "runPropertiesChanged": "Textformatierung geändert",
         "tableDeleted": "Tabelle gelöscht",
         "tableInserted": "Tabelle eingefügt",
         "tablePropertiesChanged": "Tabellenformatierung geändert"
@@ -1783,6 +1785,7 @@ export const CATALOGS = {
         "rowDeleted": "Ligne supprimée",
         "rowInserted": "Ligne insérée",
         "rowPropertiesChanged": "Mise en forme de ligne modifiée",
+        "runPropertiesChanged": "Mise en forme du texte modifiée",
         "tableDeleted": "Tableau supprimé",
         "tableInserted": "Tableau inséré",
         "tablePropertiesChanged": "Mise en forme de tableau modifiée"
@@ -2425,6 +2428,7 @@ export const CATALOGS = {
         "rowDeleted": "Fila eliminada",
         "rowInserted": "Fila insertada",
         "rowPropertiesChanged": "Formato de fila cambiado",
+        "runPropertiesChanged": "Formato de texto cambiado",
         "tableDeleted": "Tabla eliminada",
         "tableInserted": "Tabla insertada",
         "tablePropertiesChanged": "Formato de tabla cambiado"
@@ -3067,6 +3071,7 @@ export const CATALOGS = {
         "rowDeleted": "Řádek odstraněn",
         "rowInserted": "Řádek vložen",
         "rowPropertiesChanged": "Formátování řádku změněno",
+        "runPropertiesChanged": "Formátování textu změněno",
         "tableDeleted": "Tabulka odstraněna",
         "tableInserted": "Tabulka vložena",
         "tablePropertiesChanged": "Formátování tabulky změněno"
@@ -3709,6 +3714,7 @@ export const CATALOGS = {
         "rowDeleted": "تم حذف الصف",
         "rowInserted": "تم إدراج الصف",
         "rowPropertiesChanged": "تم تغيير تنسيق الصف",
+        "runPropertiesChanged": "تم تغيير تنسيق النص",
         "tableDeleted": "تم حذف الجدول",
         "tableInserted": "تم إدراج الجدول",
         "tablePropertiesChanged": "تم تغيير تنسيق الجدول"
@@ -4351,6 +4357,7 @@ export const CATALOGS = {
         "rowDeleted": "Rida kustutatud",
         "rowInserted": "Rida lisatud",
         "rowPropertiesChanged": "Rea vormingut muudeti",
+        "runPropertiesChanged": "Teksti vormingut muudeti",
         "tableDeleted": "Tabel kustutatud",
         "tableInserted": "Tabel lisatud",
         "tablePropertiesChanged": "Tabeli vormingut muudeti"
@@ -4993,6 +5000,7 @@ export const CATALOGS = {
         "rowDeleted": "השורה נמחקה",
         "rowInserted": "השורה נוספה",
         "rowPropertiesChanged": "עיצוב השורה השתנה",
+        "runPropertiesChanged": "עיצוב הטקסט השתנה",
         "tableDeleted": "הטבלה נמחקה",
         "tableInserted": "הטבלה נוספה",
         "tablePropertiesChanged": "עיצוב הטבלה השתנה"
@@ -5635,6 +5643,7 @@ export const CATALOGS = {
         "rowDeleted": "पंक्ति हटाई गई",
         "rowInserted": "पंक्ति सम्मिलित की गई",
         "rowPropertiesChanged": "पंक्ति प्रारूपण बदला गया",
+        "runPropertiesChanged": "पाठ स्वरूपण बदला गया",
         "tableDeleted": "तालिका हटाई गई",
         "tableInserted": "तालिका सम्मिलित की गई",
         "tablePropertiesChanged": "तालिका प्रारूपण बदला गया"
@@ -6277,6 +6286,7 @@ export const CATALOGS = {
         "rowDeleted": "Sor törölve",
         "rowInserted": "Sor beszúrva",
         "rowPropertiesChanged": "Sorformázás megváltozott",
+        "runPropertiesChanged": "Szövegformázás megváltozott",
         "tableDeleted": "Táblázat törölve",
         "tableInserted": "Táblázat beszúrva",
         "tablePropertiesChanged": "Táblázatformázás megváltozott"
@@ -6919,6 +6929,7 @@ export const CATALOGS = {
         "rowDeleted": "Eilutė panaikinta",
         "rowInserted": "Eilutė įterpta",
         "rowPropertiesChanged": "Eilutės formatavimas pakeistas",
+        "runPropertiesChanged": "Teksto formatavimas pakeistas",
         "tableDeleted": "Lentelė panaikinta",
         "tableInserted": "Lentelė įterpta",
         "tablePropertiesChanged": "Lentelės formatavimas pakeistas"
@@ -7561,6 +7572,7 @@ export const CATALOGS = {
         "rowDeleted": "Rinda izdzēsta",
         "rowInserted": "Rinda ievietota",
         "rowPropertiesChanged": "Rindas formatējums mainīts",
+        "runPropertiesChanged": "Teksta formatējums mainīts",
         "tableDeleted": "Tabula izdzēsta",
         "tableInserted": "Tabula ievietota",
         "tablePropertiesChanged": "Tabulas formatējums mainīts"
@@ -8203,6 +8215,7 @@ export const CATALOGS = {
         "rowDeleted": "Usunięto wiersz",
         "rowInserted": "Wstawiono wiersz",
         "rowPropertiesChanged": "Zmieniono formatowanie wiersza",
+        "runPropertiesChanged": "Zmieniono formatowanie tekstu",
         "tableDeleted": "Usunięto tabelę",
         "tableInserted": "Wstawiono tabelę",
         "tablePropertiesChanged": "Zmieniono formatowanie tabeli"
@@ -8845,6 +8858,7 @@ export const CATALOGS = {
         "rowDeleted": "Linha excluída",
         "rowInserted": "Linha inserida",
         "rowPropertiesChanged": "Formatação da linha alterada",
+        "runPropertiesChanged": "Formatação do texto alterada",
         "tableDeleted": "Tabela excluída",
         "tableInserted": "Tabela inserida",
         "tablePropertiesChanged": "Formatação da tabela alterada"
@@ -9487,6 +9501,7 @@ export const CATALOGS = {
         "rowDeleted": "Riadok odstránený",
         "rowInserted": "Riadok vložený",
         "rowPropertiesChanged": "Formátovanie riadka zmenené",
+        "runPropertiesChanged": "Formátovanie textu zmenené",
         "tableDeleted": "Tabuľka odstránená",
         "tableInserted": "Tabuľka vložená",
         "tablePropertiesChanged": "Formátovanie tabuľky zmenené"
@@ -10129,6 +10144,7 @@ export const CATALOGS = {
         "rowDeleted": "Satır silindi",
         "rowInserted": "Satır eklendi",
         "rowPropertiesChanged": "Satır biçimlendirmesi değiştirildi",
+        "runPropertiesChanged": "Metin biçimlendirmesi değiştirildi",
         "tableDeleted": "Tablo silindi",
         "tableInserted": "Tablo eklendi",
         "tablePropertiesChanged": "Tablo biçimlendirmesi değiştirildi"
@@ -10771,6 +10787,7 @@ export const CATALOGS = {
         "rowDeleted": "已删除行",
         "rowInserted": "已插入行",
         "rowPropertiesChanged": "行格式已更改",
+        "runPropertiesChanged": "文本格式已更改",
         "tableDeleted": "已删除表格",
         "tableInserted": "已插入表格",
         "tablePropertiesChanged": "表格格式已更改"

--- a/packages/core/src/i18n/messages/cs.json
+++ b/packages/core/src/i18n/messages/cs.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Řádek odstraněn",
       "rowInserted": "Řádek vložen",
       "rowPropertiesChanged": "Formátování řádku změněno",
+      "runPropertiesChanged": "Formátování textu změněno",
       "tableDeleted": "Tabulka odstraněna",
       "tableInserted": "Tabulka vložena",
       "tablePropertiesChanged": "Formátování tabulky změněno"

--- a/packages/core/src/i18n/messages/de.json
+++ b/packages/core/src/i18n/messages/de.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Zeile gelöscht",
       "rowInserted": "Zeile eingefügt",
       "rowPropertiesChanged": "Zeilenformatierung geändert",
+      "runPropertiesChanged": "Textformatierung geändert",
       "tableDeleted": "Tabelle gelöscht",
       "tableInserted": "Tabelle eingefügt",
       "tablePropertiesChanged": "Tabellenformatierung geändert"

--- a/packages/core/src/i18n/messages/en.json
+++ b/packages/core/src/i18n/messages/en.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Row deleted",
       "rowInserted": "Row inserted",
       "rowPropertiesChanged": "Row formatting changed",
+      "runPropertiesChanged": "Text formatting changed",
       "tableDeleted": "Table deleted",
       "tableInserted": "Table inserted",
       "tablePropertiesChanged": "Table formatting changed"

--- a/packages/core/src/i18n/messages/es.json
+++ b/packages/core/src/i18n/messages/es.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Fila eliminada",
       "rowInserted": "Fila insertada",
       "rowPropertiesChanged": "Formato de fila cambiado",
+      "runPropertiesChanged": "Formato de texto cambiado",
       "tableDeleted": "Tabla eliminada",
       "tableInserted": "Tabla insertada",
       "tablePropertiesChanged": "Formato de tabla cambiado"

--- a/packages/core/src/i18n/messages/et.json
+++ b/packages/core/src/i18n/messages/et.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Rida kustutatud",
       "rowInserted": "Rida lisatud",
       "rowPropertiesChanged": "Rea vormingut muudeti",
+      "runPropertiesChanged": "Teksti vormingut muudeti",
       "tableDeleted": "Tabel kustutatud",
       "tableInserted": "Tabel lisatud",
       "tablePropertiesChanged": "Tabeli vormingut muudeti"

--- a/packages/core/src/i18n/messages/fr.json
+++ b/packages/core/src/i18n/messages/fr.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Ligne supprimée",
       "rowInserted": "Ligne insérée",
       "rowPropertiesChanged": "Mise en forme de ligne modifiée",
+      "runPropertiesChanged": "Mise en forme du texte modifiée",
       "tableDeleted": "Tableau supprimé",
       "tableInserted": "Tableau inséré",
       "tablePropertiesChanged": "Mise en forme de tableau modifiée"

--- a/packages/core/src/i18n/messages/he.json
+++ b/packages/core/src/i18n/messages/he.json
@@ -491,6 +491,7 @@
       "rowDeleted": "השורה נמחקה",
       "rowInserted": "השורה נוספה",
       "rowPropertiesChanged": "עיצוב השורה השתנה",
+      "runPropertiesChanged": "עיצוב הטקסט השתנה",
       "tableDeleted": "הטבלה נמחקה",
       "tableInserted": "הטבלה נוספה",
       "tablePropertiesChanged": "עיצוב הטבלה השתנה"

--- a/packages/core/src/i18n/messages/hi.json
+++ b/packages/core/src/i18n/messages/hi.json
@@ -491,6 +491,7 @@
       "rowDeleted": "पंक्ति हटाई गई",
       "rowInserted": "पंक्ति सम्मिलित की गई",
       "rowPropertiesChanged": "पंक्ति प्रारूपण बदला गया",
+      "runPropertiesChanged": "पाठ स्वरूपण बदला गया",
       "tableDeleted": "तालिका हटाई गई",
       "tableInserted": "तालिका सम्मिलित की गई",
       "tablePropertiesChanged": "तालिका प्रारूपण बदला गया"

--- a/packages/core/src/i18n/messages/hu.json
+++ b/packages/core/src/i18n/messages/hu.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Sor törölve",
       "rowInserted": "Sor beszúrva",
       "rowPropertiesChanged": "Sorformázás megváltozott",
+      "runPropertiesChanged": "Szövegformázás megváltozott",
       "tableDeleted": "Táblázat törölve",
       "tableInserted": "Táblázat beszúrva",
       "tablePropertiesChanged": "Táblázatformázás megváltozott"

--- a/packages/core/src/i18n/messages/lt.json
+++ b/packages/core/src/i18n/messages/lt.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Eilutė panaikinta",
       "rowInserted": "Eilutė įterpta",
       "rowPropertiesChanged": "Eilutės formatavimas pakeistas",
+      "runPropertiesChanged": "Teksto formatavimas pakeistas",
       "tableDeleted": "Lentelė panaikinta",
       "tableInserted": "Lentelė įterpta",
       "tablePropertiesChanged": "Lentelės formatavimas pakeistas"

--- a/packages/core/src/i18n/messages/lv.json
+++ b/packages/core/src/i18n/messages/lv.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Rinda izdzēsta",
       "rowInserted": "Rinda ievietota",
       "rowPropertiesChanged": "Rindas formatējums mainīts",
+      "runPropertiesChanged": "Teksta formatējums mainīts",
       "tableDeleted": "Tabula izdzēsta",
       "tableInserted": "Tabula ievietota",
       "tablePropertiesChanged": "Tabulas formatējums mainīts"

--- a/packages/core/src/i18n/messages/messages.gen.ts
+++ b/packages/core/src/i18n/messages/messages.gen.ts
@@ -494,6 +494,7 @@ type Messages = {
       "rowDeleted": "Row deleted";
       "rowInserted": "Row inserted";
       "rowPropertiesChanged": "Row formatting changed";
+      "runPropertiesChanged": "Text formatting changed";
       "tableDeleted": "Table deleted";
       "tableInserted": "Table inserted";
       "tablePropertiesChanged": "Table formatting changed";

--- a/packages/core/src/i18n/messages/pl.json
+++ b/packages/core/src/i18n/messages/pl.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Usunięto wiersz",
       "rowInserted": "Wstawiono wiersz",
       "rowPropertiesChanged": "Zmieniono formatowanie wiersza",
+      "runPropertiesChanged": "Zmieniono formatowanie tekstu",
       "tableDeleted": "Usunięto tabelę",
       "tableInserted": "Wstawiono tabelę",
       "tablePropertiesChanged": "Zmieniono formatowanie tabeli"

--- a/packages/core/src/i18n/messages/pt-BR.json
+++ b/packages/core/src/i18n/messages/pt-BR.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Linha excluída",
       "rowInserted": "Linha inserida",
       "rowPropertiesChanged": "Formatação da linha alterada",
+      "runPropertiesChanged": "Formatação do texto alterada",
       "tableDeleted": "Tabela excluída",
       "tableInserted": "Tabela inserida",
       "tablePropertiesChanged": "Formatação da tabela alterada"

--- a/packages/core/src/i18n/messages/sk.json
+++ b/packages/core/src/i18n/messages/sk.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Riadok odstránený",
       "rowInserted": "Riadok vložený",
       "rowPropertiesChanged": "Formátovanie riadka zmenené",
+      "runPropertiesChanged": "Formátovanie textu zmenené",
       "tableDeleted": "Tabuľka odstránená",
       "tableInserted": "Tabuľka vložená",
       "tablePropertiesChanged": "Formátovanie tabuľky zmenené"

--- a/packages/core/src/i18n/messages/tr.json
+++ b/packages/core/src/i18n/messages/tr.json
@@ -491,6 +491,7 @@
       "rowDeleted": "Satır silindi",
       "rowInserted": "Satır eklendi",
       "rowPropertiesChanged": "Satır biçimlendirmesi değiştirildi",
+      "runPropertiesChanged": "Metin biçimlendirmesi değiştirildi",
       "tableDeleted": "Tablo silindi",
       "tableInserted": "Tablo eklendi",
       "tablePropertiesChanged": "Tablo biçimlendirmesi değiştirildi"

--- a/packages/core/src/i18n/messages/zh-CN.json
+++ b/packages/core/src/i18n/messages/zh-CN.json
@@ -491,6 +491,7 @@
       "rowDeleted": "已删除行",
       "rowInserted": "已插入行",
       "rowPropertiesChanged": "行格式已更改",
+      "runPropertiesChanged": "文本格式已更改",
       "tableDeleted": "已删除表格",
       "tableInserted": "已插入表格",
       "tablePropertiesChanged": "表格格式已更改"

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -46,6 +46,7 @@ import type {
   MathAttrs,
   ParagraphAttrs,
   RunFormattingOverrideAttrs,
+  RunPropertyChangeMarkAttrs,
   RunShadingAttrs,
   SdtAttrs,
   ShapeAttrs,
@@ -236,6 +237,7 @@ const textEffectAttrsCache = new WeakMap<Mark, TextEffectAttrs>();
 const footnoteRefAttrsCache = new WeakMap<Mark, FootnoteRefAttrs>();
 const commentAttrsCache = new WeakMap<Mark, CommentAttrs>();
 const trackedChangeAttrsCache = new WeakMap<Mark, TrackedChangeMarkAttrs>();
+const runPropertyChangeAttrsCache = new WeakMap<Mark, RunPropertyChangeMarkAttrs>();
 const runFormattingOverrideAttrsCache = new WeakMap<Mark, RunFormattingOverrideAttrs>();
 const hyperlinkAttrsCache = new WeakMap<Mark, HyperlinkAttrs>();
 
@@ -993,6 +995,27 @@ export const expectTrackedChangeMarkAttrs = (mark: Mark): TrackedChangeMarkAttrs
     trackedChangeAttrsCache,
     readTrackedChangeMarkAttrs,
     "tracked change attrs",
+  );
+
+export const readRunPropertyChangeMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<RunPropertyChangeMarkAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "runPropertyChange", issues);
+  optionalPropertyChanges(attrs, "changes", "runPropertyChange.attrs.changes", issues, [
+    "runPropertyChange",
+  ]);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectRunPropertyChangeMarkAttrs = (mark: Mark): RunPropertyChangeMarkAttrs =>
+  expectCachedMarkAttrs(
+    mark,
+    runPropertyChangeAttrsCache,
+    readRunPropertyChangeMarkAttrs,
+    "run property change attrs",
   );
 
 export const readRunFormattingOverrideMarkAttrs = (

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -9,11 +9,14 @@ import type { Command, EditorState, Transaction } from "prosemirror-state";
 import { removeRow, TableMap } from "prosemirror-tables";
 
 import type {
+  RunPropertyChange,
   SectionProperties,
   TableCellFormatting,
   TableFormatting,
   TableRowFormatting,
 } from "../../types/document";
+import { expectRunPropertyChangeMarkAttrs } from "../attrs";
+import { textFormattingToMarks } from "../conversion/toProseDoc";
 import { markStructuralChange } from "../extensions/features/ParagraphChangeTrackerExtension";
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
 import {
@@ -86,11 +89,12 @@ export function removeCommentMark(commentId: number): Command {
  * Resolve a tracked change: accept or reject.
  * - Accept: keep insertions (remove mark), delete deletions (remove text)
  * - Reject: keep deletions (remove mark), delete insertions (remove text)
+ * - Run formatting: accept the current formatting, or restore the previous formatting
  *
  * Pass `revisionId` to scope the operation to one specific
  * revision — otherwise overlapping marks for other revisions get
  * processed too, silently consuming pending work. Without an id
- * the operation matches every insertion/deletion mark in the
+ * the operation matches every revision mark or property-change entry in the
  * range (the bulk accept-all/reject-all path).
  */
 function resolveChange(
@@ -252,6 +256,21 @@ function resolveChange(
         const rangeFrom = Math.max(from, pos);
         const rangeTo = Math.min(to, nodeEnd);
 
+        const runPropertyChangeMark = node.marks.find(
+          (mark) => mark.type.name === "runPropertyChange",
+        );
+        if (runPropertyChangeMark) {
+          resolveRunPropertyChange({
+            tr,
+            node,
+            from: rangeFrom,
+            to: rangeTo,
+            mark: runPropertyChangeMark,
+            mode,
+            revisionSet,
+          });
+        }
+
         if (removeType && node.marks.some((m) => m.type === removeType && matchesRevision(m))) {
           deleteRanges.push({ from: rangeFrom, to: rangeTo });
         }
@@ -364,6 +383,94 @@ function resolveChange(
     return true;
   };
 }
+
+const RUN_FORMATTING_MARK_NAMES = new Set([
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "textColor",
+  "highlight",
+  "runShading",
+  "fontSize",
+  "fontFamily",
+  "language",
+  "superscript",
+  "subscript",
+  "allCaps",
+  "smallCaps",
+  "characterSpacing",
+  "emboss",
+  "imprint",
+  "hidden",
+  "textShadow",
+  "emphasisMark",
+  "textOutline",
+  "rtl",
+  "textEffect",
+  "runFormattingOverride",
+  "characterStyle",
+]);
+
+type ResolveRunPropertyChangeOptions = {
+  tr: Transaction;
+  node: PMNode;
+  from: number;
+  to: number;
+  mark: Mark;
+  mode: "accept" | "reject";
+  revisionSet: Set<number> | null;
+};
+
+const resolveRunPropertyChange = ({
+  tr,
+  node,
+  from,
+  to,
+  mark,
+  mode,
+  revisionSet,
+}: ResolveRunPropertyChangeOptions): void => {
+  const { changes } = expectRunPropertyChangeMarkAttrs(mark);
+  const matches = changes.filter(
+    (change) => revisionSet === null || revisionSet.has(change.info.id),
+  );
+  if (matches.length === 0) {
+    return;
+  }
+
+  tr.removeMark(from, to, mark);
+  const remaining = changes.filter(
+    (change) => revisionSet !== null && !revisionSet.has(change.info.id),
+  );
+  if (remaining.length > 0) {
+    tr.addMark(from, to, mark.type.create({ changes: remaining }));
+  }
+  if (mode === "accept") {
+    return;
+  }
+
+  const previousFormatting: RunPropertyChange["previousFormatting"] =
+    matches.at(0)?.previousFormatting;
+  for (const currentMark of node.marks) {
+    if (RUN_FORMATTING_MARK_NAMES.has(currentMark.type.name)) {
+      tr.removeMark(from, to, currentMark.type);
+    }
+  }
+  for (const previousMark of textFormattingToMarks(previousFormatting)) {
+    tr.addMark(from, to, previousMark);
+  }
+  if (previousFormatting?.styleId) {
+    const characterStyle = node.type.schema.marks["characterStyle"];
+    if (characterStyle) {
+      tr.addMark(
+        from,
+        to,
+        characterStyle.create({ styleId: previousFormatting.styleId, _styleRPr: null }),
+      );
+    }
+  }
+};
 
 type PPrMarkOp = {
   paragraphPos: number;
@@ -863,12 +970,12 @@ export function rejectAllChanges(): Command {
 }
 
 /**
- * Find the document range covered by all insertion/deletion marks
+ * Find the document range covered by all inline revision marks
  * carrying any of the given AI-edit `revisionIds`. Returns null when
  * none of those marks are present (already accepted/rejected, or
  * never existed). A replace operation typically passes two ids (one
  * for its deletion side, one for its insertion side); inserts and
- * standalone deletions pass a single id.
+ * standalone deletions and formatting changes pass a single id.
  */
 export function findAIEditRevisionRange(
   state: EditorState,
@@ -876,6 +983,7 @@ export function findAIEditRevisionRange(
 ): { from: number; to: number } | null {
   const insertionType = state.schema.marks["insertion"];
   const deletionType = state.schema.marks["deletion"];
+  const runPropertyChangeType = state.schema.marks["runPropertyChange"];
   const idSet = new Set<number>(typeof revisionIds === "number" ? [revisionIds] : revisionIds);
 
   const range = { from: null as number | null, to: null as number | null };
@@ -927,6 +1035,20 @@ export function findAIEditRevisionRange(
     }
     for (const mark of node.marks) {
       if (
+        mark.type === runPropertyChangeType &&
+        expectRunPropertyChangeMarkAttrs(mark).changes.some((change) => idSet.has(change.info.id))
+      ) {
+        const start = pos;
+        const end = pos + node.nodeSize;
+        if (range.from === null || start < range.from) {
+          range.from = start;
+        }
+        if (range.to === null || end > range.to) {
+          range.to = end;
+        }
+        break;
+      }
+      if (
         (mark.type === insertionType || mark.type === deletionType) &&
         typeof mark.attrs["revisionId"] === "number" &&
         idSet.has(mark.attrs["revisionId"])
@@ -953,7 +1075,7 @@ export function findAIEditRevisionRange(
 
 /**
  * Accept the tracked-change marks belonging to an AI-edit operation.
- * Pass a single revisionId for inserts/standalone deletions, or the
+ * Pass a single revisionId for inserts, standalone deletions, or formatting changes; or the
  * full id list for a replace (one id per side). Returns false when
  * none of the ids match anything in the doc.
  */

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1527,7 +1527,7 @@ function restoreRunPropertyChanges(run: Run, marks: readonly Mark[]): void {
   if (changes.length === 0) {
     return;
   }
-  run.propertyChanges = changes.map((change) => ({ ...change }));
+  run.propertyChanges = [...changes];
 }
 
 function getRunFormattingFromMarks(marks: readonly Mark[] | undefined): TextFormatting | undefined {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -82,6 +82,7 @@ import {
   expectMathAttrs,
   expectParagraphAttrs,
   expectRunFormattingOverrideMarkAttrs,
+  expectRunPropertyChangeMarkAttrs,
   expectBlockSdtAttrs,
   expectSdtAttrs,
   expectShapeAttrs,
@@ -1286,11 +1287,13 @@ function createTrackedChangeRun(node: PMNode, marks: readonly Mark[]): Run | nul
   }
   if (node.isText) {
     const formatting = marksToTextFormatting(marks);
-    return {
+    const run: Run = {
       type: "run",
       content: node.text ? [{ type: "text", text: node.text }] : [],
       ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
     };
+    restoreRunPropertyChanges(run, marks);
+    return run;
   }
   if (node.type.name === "hardBreak") {
     return createBreakRun(readHardBreakType(node));
@@ -1511,7 +1514,20 @@ function createRunFromText(text: string, marks: readonly Mark[]): Run {
   if (formatting) {
     run.formatting = formatting;
   }
+  restoreRunPropertyChanges(run, marks);
   return run;
+}
+
+function restoreRunPropertyChanges(run: Run, marks: readonly Mark[]): void {
+  const changeMark = marks.find((mark) => mark.type.name === "runPropertyChange");
+  if (!changeMark) {
+    return;
+  }
+  const { changes } = expectRunPropertyChangeMarkAttrs(changeMark);
+  if (changes.length === 0) {
+    return;
+  }
+  run.propertyChanges = changes.map((change) => ({ ...change }));
 }
 
 function getRunFormattingFromMarks(marks: readonly Mark[] | undefined): TextFormatting | undefined {

--- a/packages/core/src/prosemirror/conversion/propertyChangeRoundtrip.test.ts
+++ b/packages/core/src/prosemirror/conversion/propertyChangeRoundtrip.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import type { Paragraph, ParagraphPropertyChange } from "../../types/content";
+import type {
+  Paragraph,
+  ParagraphPropertyChange,
+  Run,
+  RunPropertyChange,
+} from "../../types/content";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
@@ -92,5 +97,77 @@ describe("paragraph propertyChanges PM round-trip", () => {
     const roundtripped = fromProseDoc(pmDoc).package.document.content[0] as Paragraph | undefined;
     // No phantom propertyChanges should be attached.
     expect(roundtripped?.propertyChanges).toBeUndefined();
+  });
+});
+
+const sampleRunPropertyChange: RunPropertyChange = {
+  type: "runPropertyChange",
+  info: {
+    id: 8,
+    author: "Reviewer",
+    date: "2026-07-17T08:00:00Z",
+  },
+  previousFormatting: { italic: true },
+  currentFormatting: { bold: true },
+};
+
+describe("run propertyChanges PM round-trip", () => {
+  test("preserves run formatting revisions through the editable model", () => {
+    const run: Run = {
+      type: "run",
+      formatting: { bold: true },
+      propertyChanges: [sampleRunPropertyChange],
+      content: [{ type: "text", text: "reviewed" }],
+    };
+    const document = {
+      package: {
+        document: {
+          content: [{ type: "paragraph" as const, content: [run] }],
+          finalSectionProperties: {},
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document as never);
+    const text = pmDoc.firstChild?.firstChild;
+    expect(text?.marks.find((mark) => mark.type.name === "runPropertyChange")?.attrs).toEqual({
+      changes: [sampleRunPropertyChange],
+    });
+
+    const roundtripped = fromProseDoc(pmDoc).package.document.content.at(0);
+    const roundtrippedRun =
+      roundtripped?.type === "paragraph"
+        ? roundtripped.content.find((content) => content.type === "run")
+        : undefined;
+    expect(roundtrippedRun?.propertyChanges).toEqual([sampleRunPropertyChange]);
+  });
+
+  test("does not invent run formatting revisions", () => {
+    const document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph" as const,
+              content: [
+                {
+                  type: "run" as const,
+                  formatting: { bold: true },
+                  content: [{ type: "text" as const, text: "plain" }],
+                },
+              ],
+            },
+          ],
+          finalSectionProperties: {},
+        },
+      },
+    };
+
+    const roundtripped = fromProseDoc(toProseDoc(document as never)).package.document.content.at(0);
+    const run =
+      roundtripped?.type === "paragraph"
+        ? roundtripped.content.find((content) => content.type === "run")
+        : undefined;
+    expect(run?.propertyChanges).toBeUndefined();
   });
 });

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2095,6 +2095,9 @@ function convertRun(
 ): PMNode[] {
   const nodes: PMNode[] = [];
   const { marks, mergedFormatting } = buildRunMarks(run.formatting, styleFormatting, styleResolver);
+  if (run.propertyChanges && run.propertyChanges.length > 0) {
+    marks.push(schema.mark("runPropertyChange", { changes: [...run.propertyChanges] }));
+  }
 
   for (const content of run.content) {
     const contentNodes = convertRunContent(content, marks, mergedFormatting);

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -61,7 +61,11 @@ import {
   EmphasisMarkExtension,
   TextOutlineExtension,
 } from "./marks/TextEffectsExtensions";
-import { InsertionExtension, DeletionExtension } from "./marks/TrackedChangeExtensions";
+import {
+  DeletionExtension,
+  InsertionExtension,
+  RunPropertyChangeExtension,
+} from "./marks/TrackedChangeExtensions";
 import { UnderlineExtension } from "./marks/UnderlineExtension";
 import { BlockSdtExtension } from "./nodes/BlockSdtExtension";
 import { FieldExtension } from "./nodes/FieldExtension";
@@ -151,6 +155,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add("comment", CommentExtension());
   add("insertion", InsertionExtension());
   add("deletion", DeletionExtension());
+  add("runPropertyChange", RunPropertyChangeExtension());
 
   // Nodes
   add("hardBreak", HardBreakExtension());

--- a/packages/core/src/prosemirror/extensions/marks/TrackedChangeExtensions.ts
+++ b/packages/core/src/prosemirror/extensions/marks/TrackedChangeExtensions.ts
@@ -133,3 +133,25 @@ export const DeletionExtension = createMarkExtension({
     },
   },
 });
+
+/**
+ * Run property change — formatting changed while review tracking was active.
+ *
+ * The current formatting remains represented by the normal formatting marks;
+ * this mark carries the previous run properties and revision metadata needed
+ * to serialize, list, accept, and reject the change.
+ */
+export const RunPropertyChangeExtension = createMarkExtension({
+  name: "runPropertyChange",
+  schemaMarkName: "runPropertyChange",
+  markSpec: {
+    attrs: {
+      changes: { default: [] },
+    },
+    inclusive: false,
+    parseDOM: [{ tag: "span.docx-run-property-change" }],
+    toDOM() {
+      return ["span", { class: "docx-run-property-change" }, 0];
+    },
+  },
+});

--- a/packages/core/src/prosemirror/schema/index.ts
+++ b/packages/core/src/prosemirror/schema/index.ts
@@ -41,6 +41,7 @@ export type {
   FootnoteRefAttrs,
   CommentAttrs,
   TrackedChangeMarkAttrs,
+  RunPropertyChangeMarkAttrs,
   RunFormattingOverrideAttrs,
   RunShadingAttrs,
   HyperlinkAttrs,

--- a/packages/core/src/prosemirror/schema/marks.ts
+++ b/packages/core/src/prosemirror/schema/marks.ts
@@ -9,6 +9,7 @@
 import type { ShadingProperties } from "../../types/colors";
 import type {
   EmphasisMark,
+  RunPropertyChange,
   TextEffect,
   TextFormatting,
   ThemeColorSlot,
@@ -116,6 +117,11 @@ export type TrackedChangeMarkAttrs = {
   author: string;
   date?: string;
   moveKind?: "moveTo" | "moveFrom";
+};
+
+/** Run-property revisions carried through the editable model. */
+export type RunPropertyChangeMarkAttrs = {
+  changes: RunPropertyChange[];
 };
 
 export type RunFormattingOverrideAttrs = {

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
@@ -50,6 +50,10 @@ const schema = new Schema({
       attrs: { commentId: { default: 0 } },
       toDOM: () => ["span", 0],
     },
+    runPropertyChange: {
+      attrs: { changes: { default: [] } },
+      toDOM: () => ["span", 0],
+    },
   },
 });
 
@@ -61,6 +65,30 @@ function makeState(doc: ReturnType<typeof schema.node>): EditorState {
 }
 
 describe("extractTrackedChanges: foreign-doc coalescing by (author, date)", () => {
+  test("surfaces adjacent run-formatting revisions as one actionable card", () => {
+    const change = {
+      type: "runPropertyChange" as const,
+      info: { id: 90, author: AUTHOR, date: DATE },
+      previousFormatting: { bold: false },
+      currentFormatting: { bold: true },
+    };
+    const mark = schema.marks.runPropertyChange.create({ changes: [change] });
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, [schema.text("formatted text", [mark])]),
+    ]);
+
+    const { entries } = extractTrackedChanges(makeState(doc));
+
+    expect(entries).toEqual([
+      expect.objectContaining({
+        type: "runPropertiesChanged",
+        text: "formatted text",
+        author: AUTHOR,
+        revisionId: 90,
+      }),
+    ]);
+  });
+
   test("5 insertions with distinct w:ids but same (author, date) collapse to ONE card", () => {
     const ins = (id: number, text: string) =>
       schema.text(text, [

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
@@ -15,6 +15,7 @@ import type { EditorState } from "prosemirror-state";
 
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
 import type { Mark } from "prosemirror-model";
+import { expectRunPropertyChangeMarkAttrs } from "../attrs";
 
 /**
  * One tracked change surfaced by {@link extractTrackedChanges}. Each entry
@@ -51,6 +52,7 @@ export type TrackedChangeEntry = {
     | "insertion"
     | "deletion"
     | "replacement"
+    | "runPropertiesChanged"
     | "paragraphMarkInsertion"
     | "paragraphMarkDeletion"
     | "paragraphPropertiesChanged"
@@ -149,7 +151,8 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
   const insertionType = schema.marks["insertion"];
   const deletionType = schema.marks["deletion"];
   const commentType = schema.marks["comment"];
-  if (!insertionType && !deletionType) return EMPTY_RESULT;
+  const runPropertyChangeType = schema.marks["runPropertyChange"];
+  if (!insertionType && !deletionType && !runPropertyChangeType) return EMPTY_RESULT;
 
   const raw: TrackedChangeEntry[] = [];
   const commentToRevision = new Map<number, number>();
@@ -447,6 +450,20 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
     else inlineText = node.type.name;
     let tcMark: Mark | null = null;
     for (const mark of node.marks) {
+      if (mark.type === runPropertyChangeType) {
+        for (const change of expectRunPropertyChangeMarkAttrs(mark).changes) {
+          raw.push({
+            type: "runPropertiesChanged",
+            text: inlineText,
+            author: change.info.author,
+            date: change.info.date,
+            from: pos,
+            to: pos + node.nodeSize,
+            revisionId: change.info.id,
+          });
+        }
+        continue;
+      }
       if (mark.type === insertionType || mark.type === deletionType) {
         raw.push({
           type: mark.type === insertionType ? "insertion" : "deletion",
@@ -512,6 +529,7 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
     paragraphMarkInsertion: 2,
     paragraphMarkDeletion: 2,
     paragraphPropertiesChanged: 2,
+    runPropertiesChanged: 1,
   };
   const STRUCTURAL_FAMILY_BY_TYPE: Readonly<Record<string, string>> = {
     tableInserted: "insertion",
@@ -526,6 +544,7 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
     rowPropertiesChanged: "properties",
     cellPropertiesChanged: "properties",
     paragraphPropertiesChanged: "properties",
+    runPropertiesChanged: "properties",
     cellMerged: "merge",
   };
   const isStructuralType = (t: TrackedChangeEntry["type"]) => t in STRUCTURAL_PRIORITY;

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -19,6 +19,7 @@ import {
   readBlockSdtAttrs,
   readParagraphAttrs,
   readRunFormattingOverrideMarkAttrs,
+  readRunPropertyChangeMarkAttrs,
   readRunShadingMarkAttrs,
   readSdtAttrs,
   readShapeAttrs,
@@ -274,6 +275,10 @@ const validateMarks = (
       case "insertion":
       case "deletion":
         appendAttrIssues(markPath, readTrackedChangeMarkAttrs(mark), issues);
+        continue;
+
+      case "runPropertyChange":
+        appendAttrIssues(markPath, readRunPropertyChangeMarkAttrs(mark), issues);
         continue;
 
       case "runFormattingOverride":

--- a/packages/vue/src/components/sidebar/TrackedChangeCard.vue
+++ b/packages/vue/src/components/sidebar/TrackedChangeCard.vue
@@ -67,6 +67,15 @@
           ></template
         >
       </template>
+      <template v-else-if="change.type === 'runPropertiesChanged'">
+        {{ t("revisions.runPropertiesChanged")
+        }}<template v-if="change.text"
+          >:
+          <span class="tc-card__changed"
+            >&quot;{{ truncateText(change.text) }}&quot;</span
+          ></template
+        >
+      </template>
       <template v-else-if="change.type === 'rowInserted'">
         <span class="tc-card__inserted">{{ t("revisions.rowInserted") }}</span>
       </template>


### PR DESCRIPTION
## Summary

- preserve run-property revisions through the editable model and DOCX round trips
- support tracked `formatRange` operations with accept, reject, no-op, and stacked-batch behavior
- expose formatting revisions through review APIs, agent tools, localization, and the Vue review UI