### PR TITLE
feat: add tracked vertical cell splitting

### DIFF
--- a/.changeset/calm-tables-split.md
+++ b/.changeset/calm-tables-split.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add tracked vertical table cell split operations with reversible native revisions and agent-tool support.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -1052,7 +1052,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     readonly additionalProperties: false;
                 }, {
                     readonly type: "object";
-                    readonly description: "Split one spanned table cell into individual cells. Direct mode only.";
+                    readonly description: "Split one spanned table cell into individual cells. Tracked mode supports vertical-only spans.";
                     readonly properties: {
                         readonly type: {
                             readonly type: "string";
@@ -2063,7 +2063,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
         readonly additionalProperties: false;
     }, {
         readonly type: "object";
-        readonly description: "Split one spanned table cell into individual cells. Direct mode only.";
+        readonly description: "Split one spanned table cell into individual cells. Tracked mode supports vertical-only spans.";
         readonly properties: {
             readonly type: {
                 readonly type: "string";

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -76,7 +76,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
     readonly mergeTableCells: readonly ["direct"];
-    readonly splitTableCell: readonly ["direct"];
+    readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
 // @public (undocumented)

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -444,7 +444,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
     readonly mergeTableCells: readonly ["direct"];
-    readonly splitTableCell: readonly ["direct"];
+    readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
 // @public (undocumented)

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -444,7 +444,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
     readonly mergeTableCells: readonly ["direct"];
-    readonly splitTableCell: readonly ["direct"];
+    readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
 // @public (undocumented)

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -197,7 +197,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
     readonly mergeTableCells: readonly ["direct"];
-    readonly splitTableCell: readonly ["direct"];
+    readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
 // @public (undocumented)

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -409,7 +409,8 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
     },
     {
       type: "object",
-      description: "Split one spanned table cell into individual cells. Direct mode only.",
+      description:
+        "Split one spanned table cell into individual cells. Tracked mode supports vertical-only spans.",
       properties: {
         ...operationMetaProperties,
         type: { type: "string", enum: ["splitTableCell"] },
@@ -450,9 +451,9 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       enum: FOLIO_DOCUMENT_OPERATION_MODES,
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
-        '"direct" applies immediately. `insertSignatureTable`, `mergeTableCells` and ' +
-        "`splitTableCell` support " +
-        '"direct" only.',
+        '"direct" applies immediately. `insertSignatureTable` and `mergeTableCells` support ' +
+        '"direct" only. Tracked `splitTableCell` operations ' +
+        "support vertical-only spans.",
     },
     atomic: {
       type: "boolean",

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -394,11 +394,7 @@ describe("parseSuggestChangesInput", () => {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(type)] });
       expect(result.ok, type).toBe(true);
     }
-    for (const excludedType of [
-      "commentOnBlock",
-      "insertSignatureTable",
-      "mergeTableCells",
-    ]) {
+    for (const excludedType of ["commentOnBlock", "insertSignatureTable", "mergeTableCells"]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);
     }

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -398,7 +398,6 @@ describe("parseSuggestChangesInput", () => {
       "commentOnBlock",
       "insertSignatureTable",
       "mergeTableCells",
-      "splitTableCell",
     ]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);

--- a/packages/agents/src/parse.ts
+++ b/packages/agents/src/parse.ts
@@ -84,7 +84,7 @@ export const parseAddCommentInput = (args: unknown): ParseAddCommentResult => {
 };
 
 const OPERATION_TYPES =
-  "replaceInBlock, replaceRange, commentOnRange, formatRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn";
+  "replaceInBlock, replaceRange, commentOnRange, formatRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn, splitTableCell";
 
 type SuggestedOperationType =
   | "replaceInBlock"
@@ -98,7 +98,8 @@ type SuggestedOperationType =
   | "insertTableRow"
   | "deleteTableRow"
   | "insertTableColumn"
-  | "deleteTableColumn";
+  | "deleteTableColumn"
+  | "splitTableCell";
 
 const isOperationType = (value: unknown): value is SuggestedOperationType =>
   value === "replaceInBlock" ||
@@ -112,7 +113,8 @@ const isOperationType = (value: unknown): value is SuggestedOperationType =>
   value === "insertTableRow" ||
   value === "deleteTableRow" ||
   value === "insertTableColumn" ||
-  value === "deleteTableColumn";
+  value === "deleteTableColumn" ||
+  value === "splitTableCell";
 
 const readTextRange = (value: unknown, index: number): FolioAITextRangeHandle | string => {
   const path = `operations[${index}].range`;
@@ -248,7 +250,7 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
     };
   }
 
-  if (type === "deleteTableRow" || type === "deleteTableColumn") {
+  if (type === "deleteTableRow" || type === "deleteTableColumn" || type === "splitTableCell") {
     return { id: opId, type, blockId };
   }
 

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,10 +52,9 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `insertSignatureTable`, `mergeTableCells`,
- *   and `splitTableCell` (direct-only,
- *   not representable as tracked changes for human review)
- *   and `commentOnBlock` (covered by the dedicated `add_comment` tool);
+ * - excluded types: `insertSignatureTable` and `mergeTableCells` (direct-only,
+ *   not representable as tracked changes for human review), plus
+ *   `commentOnBlock` (covered by the dedicated `add_comment` tool);
  * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
  *   where the contract requires it;
  * - `comment` is a plain string here; `parse.ts` wraps it into the contract's
@@ -69,7 +68,6 @@ const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperati
   "commentOnBlock",
   "insertSignatureTable",
   "mergeTableCells",
-  "splitTableCell",
 ]);
 
 /**

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -53,7 +53,10 @@ const schema = new Schema({
         colspan: { default: 1 },
         rowspan: { default: 1 },
         colwidth: { default: null },
+        tcPrChange: { default: null },
         cellMarker: { default: null },
+        _originalFormatting: { default: null },
+        _preserveVMergeRestart: { default: null },
         _docxVMergeContinuationCells: { default: null },
       },
     },
@@ -3397,6 +3400,120 @@ describe("Folio AI edit operations", () => {
     expect(updatedTable.child(1).child(1).attrs["colwidth"]).toEqual([200]);
   });
 
+  test("tracks a vertical split as one reversible cell merge revision", () => {
+    const continuationCell = {
+      type: "tableCell" as const,
+      formatting: {
+        vMerge: "continue" as const,
+        verticalAlign: "bottom" as const,
+      },
+      content: [{ type: "paragraph" as const, content: [] }],
+    };
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node(
+          "tableCell",
+          {
+            rowspan: 2,
+            _originalFormatting: { vMerge: "restart" },
+            _docxVMergeContinuationCells: [continuationCell],
+          },
+          [schema.node("paragraph", { paraId: "tracked-split" }, [schema.text("Content")])],
+        ),
+      ]),
+      schema.node("tableRow"),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "split-cell", type: "splitTableCell", blockId: "tracked-split" }],
+      mode: "tracked-changes",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const revisionId = result.applied.at(0)?.revisionId;
+    expect(typeof revisionId).toBe("number");
+    expect(result.applied.at(0)?.revisionIds).toEqual([revisionId]);
+    const splitTable = view.state.doc.child(0);
+    expect(splitTable.child(0).child(0).attrs["rowspan"]).toBe(1);
+    expect(splitTable.child(1).childCount).toBe(1);
+    expect(splitTable.child(1).child(0).attrs).toMatchObject({
+      cellMarker: {
+        kind: "merge",
+        info: {
+          revisionId,
+          author: "AI",
+          date: expect.any(String),
+        },
+        verticalMergeOriginal: "continue",
+      },
+      _originalFormatting: { verticalAlign: "bottom" },
+    });
+
+    if (revisionId === undefined) {
+      throw new Error("expected a vertical split revision");
+    }
+    expect(acceptAIEditRevision(revisionId)(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.child(0).child(1).child(0).attrs["cellMarker"]).toBeNull();
+
+    const rejectingView = makeView(state);
+    const rejectingResult = applyFolioAIEditOperations({
+      view: rejectingView,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "split-cell", type: "splitTableCell", blockId: "tracked-split" }],
+      mode: "tracked-changes",
+    });
+    const rejectingRevisionId = rejectingResult.applied.at(0)?.revisionId;
+    if (rejectingRevisionId === undefined) {
+      throw new Error("expected a vertical split revision");
+    }
+    expect(
+      rejectAIEditRevision(rejectingRevisionId)(rejectingView.state, rejectingView.dispatch),
+    ).toBe(true);
+    const restoredTable = rejectingView.state.doc.child(0);
+    expect(restoredTable.child(0).child(0).attrs["rowspan"]).toBe(2);
+    expect(restoredTable.child(1).childCount).toBe(0);
+    expect(restoredTable.child(0).child(0).attrs["_docxVMergeContinuationCells"]).toEqual([
+      continuationCell,
+    ]);
+  });
+
+  test("tracked splitting rejects a horizontal span without mutation", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", { colspan: 2 }, [
+          schema.node("paragraph", { paraId: "tracked-horizontal-split" }, [
+            schema.text("Content"),
+          ]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "split-cell",
+          type: "splitTableCell",
+          blockId: "tracked-horizontal-split",
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    expect(result).toEqual({
+      applied: [],
+      skipped: [{ id: "split-cell", reason: "unsupportedBlock" }],
+    });
+    expect(view.state.doc.eq(state.doc)).toBe(true);
+  });
+
   test("applies cell text edits before splitting and maps through an earlier insertion", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [
@@ -3540,7 +3657,7 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc).toEqual(state.doc);
   });
 
-  test("treats an unspanned split as a no-op and rejects tracked mode", () => {
+  test("treats an unspanned split as a no-op in both modes", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [
         schema.node("tableCell", null, [
@@ -3573,7 +3690,7 @@ describe("Folio AI edit operations", () => {
       }),
     ).toEqual({
       applied: [],
-      skipped: [{ id: "tracked", reason: "unsupportedMode" }],
+      skipped: [{ id: "tracked", reason: "noopOperation" }],
     });
   });
 

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -53,6 +53,7 @@ const schema = new Schema({
         colspan: { default: 1 },
         rowspan: { default: 1 },
         colwidth: { default: null },
+        verticalAlign: { default: null },
         tcPrChange: { default: null },
         cellMarker: { default: null },
         _originalFormatting: { default: null },
@@ -3401,26 +3402,57 @@ describe("Folio AI edit operations", () => {
   });
 
   test("tracks a vertical split as one reversible cell merge revision", () => {
-    const continuationCell = {
-      type: "tableCell" as const,
-      formatting: {
-        vMerge: "continue" as const,
-        verticalAlign: "bottom" as const,
+    const continuationCells = [
+      {
+        type: "tableCell" as const,
+        formatting: {
+          vMerge: "continue" as const,
+          verticalAlign: "bottom" as const,
+        },
+        content: [
+          {
+            type: "paragraph" as const,
+            content: [
+              {
+                type: "run" as const,
+                content: [{ type: "text" as const, text: "Second" }],
+              },
+            ],
+          },
+        ],
       },
-      content: [{ type: "paragraph" as const, content: [] }],
-    };
+      {
+        type: "tableCell" as const,
+        formatting: {
+          vMerge: "continue" as const,
+          verticalAlign: "center" as const,
+        },
+        content: [
+          {
+            type: "paragraph" as const,
+            content: [
+              {
+                type: "run" as const,
+                content: [{ type: "text" as const, text: "Third" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [
         schema.node(
           "tableCell",
           {
-            rowspan: 2,
+            rowspan: 3,
             _originalFormatting: { vMerge: "restart" },
-            _docxVMergeContinuationCells: [continuationCell],
+            _docxVMergeContinuationCells: continuationCells,
           },
           [schema.node("paragraph", { paraId: "tracked-split" }, [schema.text("Content")])],
         ),
       ]),
+      schema.node("tableRow"),
       schema.node("tableRow"),
     ]);
     const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
@@ -3440,6 +3472,9 @@ describe("Folio AI edit operations", () => {
     const splitTable = view.state.doc.child(0);
     expect(splitTable.child(0).child(0).attrs["rowspan"]).toBe(1);
     expect(splitTable.child(1).childCount).toBe(1);
+    expect(splitTable.child(2).childCount).toBe(1);
+    expect(splitTable.child(1).child(0).textContent).toBe("Second");
+    expect(splitTable.child(2).child(0).textContent).toBe("Third");
     expect(splitTable.child(1).child(0).attrs).toMatchObject({
       cellMarker: {
         kind: "merge",
@@ -3452,12 +3487,23 @@ describe("Folio AI edit operations", () => {
       },
       _originalFormatting: { verticalAlign: "bottom" },
     });
+    expect(splitTable.child(2).child(0).attrs).toMatchObject({
+      cellMarker: {
+        kind: "merge",
+        info: { revisionId },
+        verticalMergeOriginal: "continue",
+      },
+      _originalFormatting: { verticalAlign: "center" },
+    });
 
     if (revisionId === undefined) {
       throw new Error("expected a vertical split revision");
     }
     expect(acceptAIEditRevision(revisionId)(view.state, view.dispatch)).toBe(true);
     expect(view.state.doc.child(0).child(1).child(0).attrs["cellMarker"]).toBeNull();
+    expect(view.state.doc.child(0).child(2).child(0).attrs["cellMarker"]).toBeNull();
+    expect(view.state.doc.child(0).child(1).child(0).textContent).toBe("Second");
+    expect(view.state.doc.child(0).child(2).child(0).textContent).toBe("Third");
 
     const rejectingView = makeView(state);
     const rejectingResult = applyFolioAIEditOperations({
@@ -3474,11 +3520,12 @@ describe("Folio AI edit operations", () => {
       rejectAIEditRevision(rejectingRevisionId)(rejectingView.state, rejectingView.dispatch),
     ).toBe(true);
     const restoredTable = rejectingView.state.doc.child(0);
-    expect(restoredTable.child(0).child(0).attrs["rowspan"]).toBe(2);
+    expect(restoredTable.child(0).child(0).attrs["rowspan"]).toBe(3);
     expect(restoredTable.child(1).childCount).toBe(0);
-    expect(restoredTable.child(0).child(0).attrs["_docxVMergeContinuationCells"]).toEqual([
-      continuationCell,
-    ]);
+    expect(restoredTable.child(2).childCount).toBe(0);
+    expect(restoredTable.child(0).child(0).attrs["_docxVMergeContinuationCells"]).toEqual(
+      continuationCells,
+    );
   });
 
   test("tracked splitting rejects a horizontal span without mutation", () => {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { Fragment, type Mark, type Node as PMNode, type Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import {
@@ -9,11 +10,12 @@ import {
   tableNodeTypes,
 } from "prosemirror-tables";
 
-import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
-import { expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
+import { expectRunPropertyChangeMarkAttrs, expectTableCellAttrs } from "../prosemirror/attrs";
 import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
+import { standaloneTableCellToProseMirror } from "../prosemirror/conversion/toProseDoc";
+import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
-import type { RunPropertyChange } from "../types/document";
+import type { RunPropertyChange, TableCell, TableCellFormatting } from "../types/document";
 import { buildCleanBlockText } from "./clean-text";
 import {
   hasInlineEmphasis,
@@ -669,6 +671,163 @@ const splitTableRectangle = (
   return tr.setNodeMarkup(tableStart + cellPosition, undefined, attrsByColumn.at(0));
 };
 
+type SplitTrackedVerticalTableCellOptions = {
+  tr: Transaction;
+  tablePosition: number;
+  table: PMNode;
+  rectangle: TableRectangle;
+  revisionId: number;
+  author: string;
+  date: string;
+};
+
+const splitTrackedVerticalTableCell = ({
+  tr,
+  tablePosition,
+  table,
+  rectangle,
+  revisionId,
+  author,
+  date,
+}: SplitTrackedVerticalTableCellOptions): Transaction | null => {
+  const map = TableMap.get(table);
+  if (
+    rectangle.right - rectangle.left !== 1 ||
+    rectangle.bottom - rectangle.top < 2 ||
+    rectangle.left < 0 ||
+    rectangle.top < 0 ||
+    rectangle.right > map.width ||
+    rectangle.bottom > map.height
+  ) {
+    return null;
+  }
+  const relativeCellPosition = map.map[rectangle.top * map.width + rectangle.left];
+  if (relativeCellPosition === undefined) {
+    return null;
+  }
+  const cellRectangle = map.findCell(relativeCellPosition);
+  if (!tableRectanglesEqual(cellRectangle, rectangle)) {
+    return null;
+  }
+  const cell = table.nodeAt(relativeCellPosition);
+  if (!cell) {
+    return null;
+  }
+  const attrs = expectTableCellAttrs(cell);
+  if (
+    attrs.colspan !== 1 ||
+    attrs.rowspan !== rectangle.bottom - rectangle.top ||
+    attrs.cellMarker !== undefined
+  ) {
+    return null;
+  }
+  const continuationCells = attrs._docxVMergeContinuationCells;
+  if (
+    continuationCells !== undefined &&
+    continuationCells.length !== rectangle.bottom - rectangle.top - 1
+  ) {
+    return null;
+  }
+
+  const marker = {
+    kind: "merge" as const,
+    info: { revisionId, author, date },
+    verticalMergeOriginal: "continue" as const,
+  };
+  const insertedCells: PMNode[] = [];
+  for (let index = 0; index < rectangle.bottom - rectangle.top - 1; index++) {
+    const source = continuationCells?.[index];
+    if (source?.structuralChange !== undefined) {
+      return null;
+    }
+    const insertedCell = source
+      ? trackedSplitCellFromStoredSource(cell, source, marker)
+      : cell.type.createAndFill({
+          ...cell.attrs,
+          rowspan: 1,
+          cellMarker: marker,
+          _originalFormatting: formattingWithoutVerticalMerge(attrs._originalFormatting),
+          _preserveVMergeRestart: null,
+          _docxVMergeContinuationCells: null,
+        });
+    if (!insertedCell) {
+      return null;
+    }
+    insertedCells.push(insertedCell);
+  }
+
+  const tableStart = tablePosition + 1;
+  const mapFrom = tr.mapping.maps.length;
+  for (const [index, insertedCell] of insertedCells.entries()) {
+    const row = rectangle.top + index + 1;
+    const position = tableStart + map.positionAt(row, rectangle.left, table);
+    tr = tr.insert(tr.mapping.slice(mapFrom).map(position, 1), insertedCell);
+  }
+  tr = tr.setNodeMarkup(tableStart + relativeCellPosition, undefined, {
+    ...cell.attrs,
+    rowspan: 1,
+    _originalFormatting: formattingWithoutVerticalMerge(attrs._originalFormatting),
+    _preserveVMergeRestart: null,
+    _docxVMergeContinuationCells: null,
+  });
+  markStructuralChange(tr);
+  return tr;
+};
+
+type TrackedSplitCellMarker = {
+  kind: "merge";
+  info: {
+    revisionId: number;
+    author: string;
+    date: string;
+  };
+  verticalMergeOriginal: "continue";
+};
+
+const trackedSplitCellFromStoredSource = (
+  origin: PMNode,
+  source: TableCell,
+  marker: TrackedSplitCellMarker,
+): PMNode | null => {
+  const restoredSource: TableCell = {
+    type: "tableCell",
+    ...(source.formatting ? { formatting: formattingWithoutVerticalMerge(source.formatting) } : {}),
+    ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
+    content: source.content,
+  };
+  const converted = standaloneTableCellToProseMirror(
+    restoredSource,
+    origin.type.name === "tableHeader" ? "tableHeader" : "tableCell",
+  );
+  const compatible = Result.try(() => origin.type.schema.nodeFromJSON(converted.toJSON())).unwrapOr(
+    null,
+  );
+  if (!compatible) {
+    return null;
+  }
+  return compatible.type.create(
+    {
+      ...compatible.attrs,
+      rowspan: 1,
+      cellMarker: marker,
+      _preserveVMergeRestart: null,
+      _docxVMergeContinuationCells: null,
+    },
+    compatible.content,
+  );
+};
+
+const formattingWithoutVerticalMerge = (
+  formatting: TableCellFormatting | undefined,
+): TableCellFormatting | undefined => {
+  if (!formatting) {
+    return undefined;
+  }
+  const next = { ...formatting };
+  delete next.vMerge;
+  return next;
+};
+
 const findTableColumnInsertion = (
   doc: PMNode,
   blockFrom: number,
@@ -1150,10 +1309,7 @@ const applyFolioAIEditOperationsInternal = ({
   const liveBlocksByParaId = collectLiveBlocksByParaId(view.state.doc);
 
   for (const [index, operation] of operations.entries()) {
-    if (
-      mode === "tracked-changes" &&
-      (operation.type === "mergeTableCells" || operation.type === "splitTableCell")
-    ) {
+    if (mode === "tracked-changes" && operation.type === "mergeTableCells") {
       skipped.push({ id: operation.id, reason: "unsupportedMode" });
       continue;
     }
@@ -1820,7 +1976,19 @@ const applyFolioAIEditOperationsInternal = ({
           });
           continue;
         }
-        const nextTr = splitTableRectangle(tr, tablePosition, table, split.rectangle);
+        const revisionId = mode === "tracked-changes" ? revisionSeed : null;
+        const nextTr =
+          revisionId === null
+            ? splitTableRectangle(tr, tablePosition, table, split.rectangle)
+            : splitTrackedVerticalTableCell({
+                tr,
+                tablePosition,
+                table,
+                rectangle: split.rectangle,
+                revisionId,
+                author,
+                date,
+              });
         if (!nextTr) {
           skipped.push({
             id: item.operation.id,
@@ -1829,6 +1997,10 @@ const applyFolioAIEditOperationsInternal = ({
           continue;
         }
         tr = nextTr;
+        if (revisionId !== null) {
+          revisionSeed++;
+          appliedRevisionIds = [revisionId];
+        }
         break;
       }
       case "deleteTableRow": {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -789,9 +789,10 @@ const trackedSplitCellFromStoredSource = (
   source: TableCell,
   marker: TrackedSplitCellMarker,
 ): PMNode | null => {
+  const formatting = formattingWithoutVerticalMerge(source.formatting);
   const restoredSource: TableCell = {
     type: "tableCell",
-    ...(source.formatting ? { formatting: formattingWithoutVerticalMerge(source.formatting) } : {}),
+    ...(formatting ? { formatting } : {}),
     ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
     content: source.content,
   };

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -129,6 +129,50 @@ const buildTextBoxCellRevisionDocument = async (
   return repackDocx(document, { updateModifiedDate: false });
 };
 
+const buildTextBoxVerticalMergeDocument = async (): Promise<ArrayBuffer> => {
+  const baseline = await buildTextBoxTableDocument();
+  const document = await parseDocx(baseline, { detectVariables: false, preloadFonts: false });
+  const table = findTextBoxShape(document).textBody?.content.find(({ type }) => type === "table");
+  if (table?.type !== "table") {
+    throw new Error("expected a text-box table");
+  }
+  const firstRow = table.rows.at(0);
+  const origin = firstRow?.cells.at(0);
+  if (!origin) {
+    throw new Error("expected a text-box table cell");
+  }
+  origin.formatting = { ...origin.formatting, vMerge: "restart" };
+  firstRow.cells.push({
+    type: "tableCell",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "run", content: [{ type: "text", text: "Peer top" }] }],
+      },
+    ],
+  });
+  table.rows.push({
+    type: "tableRow",
+    cells: [
+      {
+        type: "tableCell",
+        formatting: { vMerge: "continue", verticalAlign: "bottom" },
+        content: [{ type: "paragraph", content: [] }],
+      },
+      {
+        type: "tableCell",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "run", content: [{ type: "text", text: "Peer bottom" }] }],
+          },
+        ],
+      },
+    ],
+  });
+  return repackDocx(document, { updateModifiedDate: false });
+};
+
 /** Extract the `<w:p …>…</w:p>` element that contains `needle`. */
 const paragraphContaining = (documentXml: string, needle: string): string => {
   const at = documentXml.indexOf(needle);
@@ -594,6 +638,81 @@ describe("headless docx review round-trip", () => {
     const rejected = await rejecting.toBuffer();
     expect(await partText(rejected, "word/document.xml")).not.toContain("<w:cellDel ");
     expect(rejecting.getContentAsText()).toContain("Cell value");
+  });
+
+  test("tracks, persists, accepts, and rejects a vertical cell split", async () => {
+    const baseline = await buildTextBoxVerticalMergeDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "tracked-changes",
+      operations: [{ id: "split-cell", type: "splitTableCell", blockId: target.id }],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.skipped).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    expect(typeof result.applied.at(0)?.revisionId).toBe("number");
+    const pendingChange = reviewer.getChanges().find(({ type }) => type === "cellMerged");
+    if (!pendingChange) {
+      throw new Error("expected a pending vertical split");
+    }
+    expect(pendingChange.author).toBe("Reviewer");
+
+    const pending = await reviewer.toBuffer();
+    const pendingXml = await partText(pending, "word/document.xml");
+    expect(pendingXml).toContain("<w:cellMerge ");
+    expect(pendingXml).toContain('w:vMergeOrig="cont"');
+    const pendingTable = findTextBoxShape(
+      await parseDocx(pending, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(pendingTable?.type).toBe("table");
+    if (pendingTable?.type !== "table") {
+      throw new Error("expected a pending table");
+    }
+    expect(pendingTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
+    expect(pendingTable.rows.at(1)?.cells.at(0)?.structuralChange).toMatchObject({
+      type: "tableCellMerge",
+      verticalMergeOriginal: "continue",
+    });
+
+    const accepting = await FolioDocxReviewer.fromBuffer(pending);
+    const acceptChange = accepting.getChanges().find(({ type }) => type === "cellMerged");
+    if (!acceptChange) {
+      throw new Error("expected the vertical split after reopen");
+    }
+    expect(accepting.acceptChange(acceptChange)).toBe(true);
+    const accepted = await accepting.toBuffer();
+    expect(await partText(accepted, "word/document.xml")).not.toContain("<w:cellMerge ");
+    const acceptedTable = findTextBoxShape(
+      await parseDocx(accepted, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(acceptedTable?.type).toBe("table");
+    if (acceptedTable?.type !== "table") {
+      throw new Error("expected an accepted table");
+    }
+    expect(acceptedTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
+    expect(acceptedTable.rows.at(1)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(pending);
+    const rejectChange = rejecting.getChanges().find(({ type }) => type === "cellMerged");
+    if (!rejectChange) {
+      throw new Error("expected the vertical split before rejection");
+    }
+    expect(rejecting.rejectChange(rejectChange)).toBe(true);
+    const rejected = await rejecting.toBuffer();
+    expect(await partText(rejected, "word/document.xml")).not.toContain("<w:cellMerge ");
+    const rejectedTable = findTextBoxShape(
+      await parseDocx(rejected, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(rejectedTable?.type).toBe("table");
+    if (rejectedTable?.type !== "table") {
+      throw new Error("expected a rejected table");
+    }
+    expect(rejectedTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBe("restart");
+    expect(rejectedTable.rows.at(1)?.cells.at(0)?.formatting?.vMerge).toBe("continue");
   });
 
   test("tracks, persists, accepts, and rejects a column insertion", async () => {

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -673,7 +673,9 @@ describe("headless docx review round-trip", () => {
       throw new Error("expected a pending table");
     }
     expect(pendingTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
-    expect(pendingTable.rows.at(1)?.cells.at(0)?.structuralChange).toMatchObject({
+    const pendingContinuation = pendingTable.rows.at(1)?.cells.at(0);
+    expect(pendingContinuation?.formatting?.verticalAlign).toBe("bottom");
+    expect(pendingContinuation?.structuralChange).toMatchObject({
       type: "tableCellMerge",
       verticalMergeOriginal: "continue",
     });
@@ -694,7 +696,9 @@ describe("headless docx review round-trip", () => {
       throw new Error("expected an accepted table");
     }
     expect(acceptedTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
-    expect(acceptedTable.rows.at(1)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
+    const acceptedContinuation = acceptedTable.rows.at(1)?.cells.at(0);
+    expect(acceptedContinuation?.formatting?.verticalAlign).toBe("bottom");
+    expect(acceptedContinuation?.formatting?.vMerge).toBeUndefined();
 
     const rejecting = await FolioDocxReviewer.fromBuffer(pending);
     const rejectChange = rejecting.getChanges().find(({ type }) => type === "cellMerged");
@@ -712,7 +716,9 @@ describe("headless docx review round-trip", () => {
       throw new Error("expected a rejected table");
     }
     expect(rejectedTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBe("restart");
-    expect(rejectedTable.rows.at(1)?.cells.at(0)?.formatting?.vMerge).toBe("continue");
+    const rejectedContinuation = rejectedTable.rows.at(1)?.cells.at(0);
+    expect(rejectedContinuation?.formatting?.verticalAlign).toBe("bottom");
+    expect(rejectedContinuation?.formatting?.vMerge).toBe("continue");
   });
 
   test("tracks, persists, accepts, and rejects a column insertion", async () => {

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -57,7 +57,7 @@ describe("document operation contract", () => {
         insertTableColumn: ["direct", "tracked-changes"],
         deleteTableColumn: ["direct", "tracked-changes"],
         mergeTableCells: ["direct"],
-        splitTableCell: ["direct"],
+        splitTableCell: ["direct", "tracked-changes"],
       },
       preconditions: ["blockTextHash"],
       stories: ["main", "header", "footer", "footnote", "endnote"],
@@ -82,6 +82,7 @@ describe("document operation contract", () => {
     );
     expect(isFolioDocumentOperationModeSupported("mergeTableCells", "direct")).toBe(true);
     expect(isFolioDocumentOperationModeSupported("splitTableCell", "direct")).toBe(true);
+    expect(isFolioDocumentOperationModeSupported("splitTableCell", "tracked-changes")).toBe(true);
     expect(
       Reflect.apply(isFolioDocumentOperationModeSupported, null, ["unknownOperation", "direct"]),
     ).toBe(false);

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -83,7 +83,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   insertTableColumn: DIRECT_AND_TRACKED_MODES,
   deleteTableColumn: DIRECT_AND_TRACKED_MODES,
   mergeTableCells: DIRECT_ONLY_MODES,
-  splitTableCell: DIRECT_ONLY_MODES,
+  splitTableCell: DIRECT_AND_TRACKED_MODES,
 } as const satisfies Readonly<
   Record<FolioDocumentOperationType, readonly FolioDocumentOperationMode[]>
 >);

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -643,7 +643,7 @@ describe("table cell structural revision resolution", () => {
     expect(() => view.state.doc.check()).not.toThrow();
   });
 
-  test("reject replaces an empty origin paragraph with restored split content", () => {
+  test("reject preserves restored split content in its continuation cell", () => {
     const view = dispatcher(
       EditorState.create({
         schema: tableSchema,
@@ -673,7 +673,24 @@ describe("table cell structural revision resolution", () => {
     expect(rejectAIEditRevision(83)(view.state, view.dispatch)).toBe(true);
     const mergedCell = view.state.doc.firstChild?.firstChild?.firstChild;
     expect(mergedCell?.childCount).toBe(1);
-    expect(mergedCell?.textContent).toBe("Restored");
+    expect(mergedCell?.textContent).toBe("");
+    expect(mergedCell?.attrs["_docxVMergeContinuationCells"]).toEqual([
+      {
+        type: "tableCell",
+        formatting: { vMerge: "continue" },
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "run",
+                content: [{ type: "text", text: "Restored" }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
     expect(() => view.state.doc.check()).not.toThrow();
   });
 

--- a/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
+++ b/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
@@ -4,6 +4,7 @@ import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
 import type { TableCell, TableCellFormatting } from "../../types/document";
+import { standaloneTableCellFromProseMirror } from "../conversion/fromProseDoc";
 import { standaloneTableCellToProseMirror } from "../conversion/toProseDoc";
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
 
@@ -150,28 +151,12 @@ const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean 
     continuationCells.push(...nestedContinuations);
   }
 
-  const cellWasEmpty =
-    cell.childCount === 1 &&
-    cell.firstChild?.isTextblock === true &&
-    cell.firstChild.childCount === 0;
-  const aboveCellWasEmpty =
-    aboveCell.childCount === 1 &&
-    aboveCell.firstChild?.isTextblock === true &&
-    aboveCell.firstChild.childCount === 0;
   tr.delete(cellPos, cellPos + cell.nodeSize);
   tr.setNodeMarkup(abovePos, undefined, {
     ...aboveCell.attrs,
     rowspan: aboveRowspan + cellRowspan,
     _docxVMergeContinuationCells: continuationCells,
   });
-  if (!cellWasEmpty) {
-    if (aboveCellWasEmpty) {
-      tr.replaceWith(abovePos + 1, abovePos + 1 + aboveCell.content.size, cell.content);
-      return true;
-    }
-    const contentEnd = abovePos + 1 + aboveCell.content.size;
-    tr.insert(contentEnd, cell.content);
-  }
   return true;
 };
 
@@ -185,24 +170,17 @@ const tableCellContinuationCells = (cell: PMNode, rowspan: number): TableCell[] 
 };
 
 const tableCellContinuationFromNode = (cell: PMNode): TableCell => {
-  const originalFormatting = cell.attrs["_originalFormatting"];
-  const formatting: TableCellFormatting =
-    typeof originalFormatting === "object" && originalFormatting !== null
-      ? { ...originalFormatting, vMerge: "continue" }
-      : { vMerge: "continue" };
+  const continuation = standaloneTableCellFromProseMirror(cell);
+  const formatting: TableCellFormatting = {
+    ...continuation.formatting,
+    vMerge: "continue",
+  };
   const colspan = cell.attrs["colspan"];
   if (typeof colspan === "number" && colspan > 1) {
     formatting.gridSpan = colspan;
   }
-  const continuation: TableCell = {
-    type: "tableCell",
-    formatting,
-    content: [{ type: "paragraph", content: [] }],
-  };
-  const propertyChanges = cell.attrs["tcPrChange"];
-  if (Array.isArray(propertyChanges) && propertyChanges.length > 0) {
-    continuation.propertyChanges = [...propertyChanges];
-  }
+  continuation.formatting = formatting;
+  delete continuation.structuralChange;
   return continuation;
 };
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2987,6 +2987,9 @@ function convertPMTableCell(node: PMNode, documentCounts?: TrackedChangeCounts):
   return cell;
 }
 
+export const standaloneTableCellFromProseMirror = (node: PMNode): TableCell =>
+  convertPMTableCell(node);
+
 /**
  * Convert ProseMirror table cell attrs to TableCellFormatting
  * Borders are stored as full BorderSpec objects — no conversion needed.


### PR DESCRIPTION
## Summary

- enable tracked vertical cell splitting
- preserve continuation content and formatting through review resolution
- expose the operation through agent tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tracked-change support for splitting vertically merged table cells, including reversible behavior and agent-tool enablement.
  - Clarified that `splitTableCell` tracked mode supports vertical-only spans.
  - Updated suggestion/operation handling so `splitTableCell` can be generated and validated in tracked-change workflows.

- **Bug Fixes**
  - Unspanned cell splits are treated as no-ops in both supported modes.

- **Documentation**
  - Updated public schema descriptions to reflect tracked-mode capabilities for `splitTableCell`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->