### PR TITLE
fix: honor authored layout compatibility

### DIFF
--- a/.changeset/calm-otters-align.md
+++ b/.changeset/calm-otters-align.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Honor legacy OOXML compatibility modes when fitting justified lines.

--- a/.changeset/tidy-mice-rest.md
+++ b/.changeset/tidy-mice-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Use paragraph-mark metrics for whitespace-only paragraphs.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -566,7 +566,10 @@ export type PaginatorOptions = {
 
 // @public
 export type ParagraphAttrs = {
-    alignment?: "left" | "center" | "right" | "justify"; /** East Asian first/last-character restrictions (`w:kinsoku`). */
+    alignment?: "left" | "center" | "right" | "justify"; /** Document-generation policy for justified line fitting. */
+    justificationCompatibility?: {
+        type: "legacy";
+    }; /** East Asian first/last-character restrictions (`w:kinsoku`). */
     kinsoku?: boolean; /** Hanging punctuation (`w:overflowPunct`); defaults to enabled when omitted. */
     overflowPunctuation?: boolean; /** Exempt this paragraph from document automatic hyphenation. */
     suppressAutoHyphens?: boolean; /** Document-wide automatic hyphenation controls retained for line layout. */

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -175,6 +175,7 @@ export type DocumentBody = {
 
 // @public
 export type DocumentSettings = {
+    compatibilityMode?: number;
     defaultTabStop: number;
     evenAndOddHeaders?: boolean;
     themeFontLang?: {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -29,6 +29,7 @@ import type { ToFlowBlocksOptions } from "../layout-bridge/convert/toFlowBlocks"
 import { getColumns } from "../layout-bridge/sectionColumns";
 import { layoutDocument } from "../layout-engine";
 import type { ColumnLayout, SectionLayoutConfig } from "../layout-engine";
+import { resolveJustificationCompatibility } from "../layout-engine/justificationCompatibility";
 import {
   recordLayoutComplete,
   recordLayoutError,
@@ -305,6 +306,12 @@ export function runLayoutPipeline<THfPMs>(
       flowOpts.lineBreakRules = document.package.settings.lineBreakRules;
     }
     const documentSettings = document?.package.settings;
+    const justificationCompatibility = resolveJustificationCompatibility(
+      documentSettings?.compatibilityMode,
+    );
+    if (justificationCompatibility) {
+      flowOpts.justificationCompatibility = justificationCompatibility;
+    }
     if (documentSettings?.autoHyphenation === true) {
       flowOpts.automaticHyphenation = {
         enabled: true,
@@ -405,6 +412,9 @@ export function runLayoutPipeline<THfPMs>(
         measureBlocks: hfMeasureBlocks,
         ...(defaultTabStop !== undefined ? { defaultTabStopTwips: defaultTabStop } : {}),
         ...(flowOpts.lineBreakRules ? { lineBreakRules: flowOpts.lineBreakRules } : {}),
+        ...(flowOpts.justificationCompatibility
+          ? { justificationCompatibility: flowOpts.justificationCompatibility }
+          : {}),
         ...(flowOpts.automaticHyphenation
           ? { automaticHyphenation: flowOpts.automaticHyphenation }
           : {}),
@@ -651,6 +661,9 @@ export function runLayoutPipeline<THfPMs>(
           }
           if (flowOpts.lineBreakRules) {
             footnoteOptions.lineBreakRules = flowOpts.lineBreakRules;
+          }
+          if (flowOpts.justificationCompatibility) {
+            footnoteOptions.justificationCompatibility = flowOpts.justificationCompatibility;
           }
           if (flowOpts.automaticHyphenation) {
             footnoteOptions.automaticHyphenation = flowOpts.automaticHyphenation;

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -128,6 +128,28 @@ describe("parseSettings — document line-breaking rules", () => {
   });
 });
 
+describe("parseSettings — application compatibility generation", () => {
+  test("parses the named compatibilityMode setting", () => {
+    expect(
+      parseSettings(
+        wrap(
+          `<w:compat><w:compatSetting w:name="compatibilityMode" w:uri="http://schemas.microsoft.com/office/word" w:val="14"/></w:compat>`,
+        ),
+      ).compatibilityMode,
+    ).toBe(14);
+  });
+
+  test("ignores unrelated and malformed compatibility settings", () => {
+    expect(
+      parseSettings(
+        wrap(
+          `<w:compat><w:compatSetting w:name="other" w:val="14"/><w:compatSetting w:name="compatibilityMode" w:val="invalid"/></w:compat>`,
+        ),
+      ).compatibilityMode,
+    ).toBeUndefined();
+  });
+});
+
 describe("parseSettings — document automatic hyphenation", () => {
   test("reads the Word hyphenation controls", () => {
     expect(

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -10,7 +10,13 @@
  */
 
 import type { DocumentSettings } from "../types/document";
-import { findChild, getAttribute, parseBooleanElement, parseXmlDocument } from "./xmlParser";
+import {
+  findChild,
+  findChildren,
+  getAttribute,
+  parseBooleanElement,
+  parseXmlDocument,
+} from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 export type FolioDocumentSettings = DocumentSettings & {
@@ -91,6 +97,10 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
   const noLineBreaksBefore = parseKinsokuOverride(root, "noLineBreaksBefore");
   const noLineBreaksAfter = parseKinsokuOverride(root, "noLineBreaksAfter");
   const compat = root ? findChild(root, "w", "compat") : null;
+  const compatibilityMode = parseCompatibilityMode(compat);
+  if (compatibilityMode !== undefined) {
+    settings.compatibilityMode = compatibilityMode;
+  }
   const splitPageBreakAndParagraphMark = compat
     ? findChild(compat, "w", "splitPgBreakAndParaMark")
     : null;
@@ -109,6 +119,21 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
   }
 
   return settings;
+}
+
+function parseCompatibilityMode(compat: XmlElement | null): number | undefined {
+  if (!compat) {
+    return undefined;
+  }
+  const setting = findChildren(compat, "w", "compatSetting").find(
+    (candidate) => getAttribute(candidate, "w", "name") === "compatibilityMode",
+  );
+  const raw = setting ? getAttribute(setting, "w", "val") : null;
+  if (raw === null || !/^\d+$/u.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 type OnOffSettingName = "autoHyphenation" | "doNotHyphenateCaps";

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -48,6 +48,7 @@ export type ConvertFootnoteOptions = {
   /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
   defaultTabStopTwips?: number;
   lineBreakRules?: ToFlowBlocksOptions["lineBreakRules"];
+  justificationCompatibility?: ToFlowBlocksOptions["justificationCompatibility"];
   automaticHyphenation?: ToFlowBlocksOptions["automaticHyphenation"];
 };
 
@@ -342,6 +343,9 @@ export function convertFootnoteToContent(
   }
   if (options.lineBreakRules) {
     flowOptions.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.justificationCompatibility) {
+    flowOptions.justificationCompatibility = options.justificationCompatibility;
   }
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -652,6 +652,7 @@ export type ConvertHeaderFooterOptions = {
   /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
   defaultTabStopTwips?: number;
   lineBreakRules?: ToFlowBlocksOptions["lineBreakRules"];
+  justificationCompatibility?: ToFlowBlocksOptions["justificationCompatibility"];
   automaticHyphenation?: ToFlowBlocksOptions["automaticHyphenation"];
   /**
    * Relationship id of the source HF part. Stamped onto the returned
@@ -703,6 +704,9 @@ export function convertHeaderFooterToContent(
   if (options.lineBreakRules) {
     flowOptions.lineBreakRules = options.lineBreakRules;
   }
+  if (options.justificationCompatibility) {
+    flowOptions.justificationCompatibility = options.justificationCompatibility;
+  }
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;
   }
@@ -743,6 +747,9 @@ export function convertHeaderFooterPmDocToContent(
   }
   if (options.lineBreakRules) {
     flowOptions.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.justificationCompatibility) {
+    flowOptions.justificationCompatibility = options.justificationCompatibility;
   }
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -281,6 +281,27 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.reserveEmptyOutlineHeight).toBe(true);
   });
 
+  test("whitespace-only paragraph measurement uses direct paragraph-mark font metrics", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: { fontSize: 22, fontFamily: { ascii: "Calibri" } },
+          _originalFormatting: {
+            runProperties: { fontSize: 16, fontFamily: { ascii: "Arial Narrow" } },
+          },
+        },
+        [schema.text(" ")],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.defaultFontSize).toBe(8);
+    expect(paragraph?.attrs?.defaultFontFamily).toBe("Arial Narrow");
+  });
+
   test("does not reserve extra outline height away from the start of the story", () => {
     const blocks = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -33,6 +33,7 @@ describe("toFlowBlocks paragraph formatting", () => {
         schema.node("paragraph", { suppressAutoHyphens: true }, [schema.text("Hyphenation")]),
       ]),
       {
+        justificationCompatibility: { type: "legacy" },
         automaticHyphenation: {
           enabled: true,
           doNotHyphenateCaps: true,
@@ -45,6 +46,7 @@ describe("toFlowBlocks paragraph formatting", () => {
       kind: "paragraph",
       attrs: {
         suppressAutoHyphens: true,
+        justificationCompatibility: { type: "legacy" },
         automaticHyphenation: {
           enabled: true,
           doNotHyphenateCaps: true,

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -135,6 +135,8 @@ export type ToFlowBlocksOptions = {
     noLineBreaksAfter?: { language?: string; characters: string };
     useLegacyEthiopicAmharicRules?: boolean;
   };
+  /** Document-generation policy for justified line fitting. */
+  justificationCompatibility?: NonNullable<ParagraphAttrs["justificationCompatibility"]>;
   /** Document-wide automatic hyphenation policy. */
   automaticHyphenation?: NonNullable<ParagraphAttrs["automaticHyphenation"]>;
 };
@@ -1888,6 +1890,9 @@ function convertParagraph(
   );
   if (options.lineBreakRules) {
     attrs.lineBreakRules = options.lineBreakRules;
+  }
+  if (options.justificationCompatibility) {
+    attrs.justificationCompatibility = options.justificationCompatibility;
   }
   if (options.automaticHyphenation) {
     attrs.automaticHyphenation = options.automaticHyphenation;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1870,6 +1870,15 @@ function mapTabAlignment(
 /**
  * Convert a paragraph node to a ParagraphBlock.
  */
+function hasOnlyVisuallyEmptyTextRuns(runs: Run[]): boolean {
+  return (
+    runs.length > 0 &&
+    runs.every(
+      (run) => run.kind === "text" && run.text.replace(/\u00a0/gu, " ").trim().length === 0,
+    )
+  );
+}
+
 function convertParagraph(
   node: PMNode,
   startPos: number,
@@ -1898,7 +1907,7 @@ function convertParagraph(
     attrs.automaticHyphenation = options.automaticHyphenation;
   }
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
-  if (runs.length === 0) {
+  if (runs.length === 0 || hasOnlyVisuallyEmptyTextRuns(runs)) {
     const hasDirectParagraphFormatting =
       pmAttrs._originalFormatting &&
       Object.entries(pmAttrs._originalFormatting).some(

--- a/packages/core/src/layout-engine/justificationCompatibility.test.ts
+++ b/packages/core/src/layout-engine/justificationCompatibility.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveJustificationCompatibility } from "./justificationCompatibility";
+
+describe("resolveJustificationCompatibility", () => {
+  test("uses strict justified fitting through compatibility mode 14", () => {
+    expect(resolveJustificationCompatibility(14)).toEqual({ type: "legacy" });
+  });
+
+  test("keeps modern and unspecified documents on current fitting", () => {
+    expect(resolveJustificationCompatibility(15)).toBeUndefined();
+    expect(resolveJustificationCompatibility(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout-engine/justificationCompatibility.ts
+++ b/packages/core/src/layout-engine/justificationCompatibility.ts
@@ -1,0 +1,15 @@
+import type { ParagraphAttrs } from "./types";
+
+const LEGACY_JUSTIFICATION_MAX_COMPATIBILITY_MODE = 14;
+
+export function resolveJustificationCompatibility(
+  compatibilityMode: number | undefined,
+): NonNullable<ParagraphAttrs["justificationCompatibility"]> | undefined {
+  if (
+    compatibilityMode === undefined ||
+    compatibilityMode > LEGACY_JUSTIFICATION_MAX_COMPATIBILITY_MODE
+  ) {
+    return undefined;
+  }
+  return { type: "legacy" };
+}

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -334,6 +334,9 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     if (attrs.reserveEmptyOutlineHeight) {
       parts.push("outline-empty-reserve");
     }
+    if (attrs.justificationCompatibility) {
+      parts.push(`justify-compat:${attrs.justificationCompatibility.type}`);
+    }
     parts.push(...lineBreakPolicyCacheParts(attrs));
     const borders = attrs.borders;
     if (borders) {

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -163,6 +163,25 @@ describe("font metrics cache", () => {
       }),
     );
   });
+
+  test("keeps justification compatibility in the paragraph measurement cache key", () => {
+    const paragraph = {
+      kind: "paragraph",
+      id: "compatibility-cache-key",
+      runs: [{ kind: "text", text: "Text" }],
+      attrs: { alignment: "justify" },
+    } as const satisfies ParagraphBlock;
+
+    expect(hashParagraphBlock(paragraph)).not.toBe(
+      hashParagraphBlock({
+        ...paragraph,
+        attrs: {
+          ...paragraph.attrs,
+          justificationCompatibility: { type: "legacy" },
+        },
+      }),
+    );
+  });
 });
 
 describe("empty paragraph line-height floor", () => {
@@ -823,6 +842,30 @@ describe("measureParagraph justified shrink tolerance", () => {
 
         expect(spaceRichMeasure.lines).toHaveLength(1);
         expect(spacePoorMeasure.lines).toHaveLength(2);
+      },
+      {
+        charWidth: ordinarySpaceRichWidth,
+      },
+    );
+  });
+
+  test("does not contract justified lines in legacy compatibility mode", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "legacy-justified-line-fit",
+            runs: [{ kind: "text", text: spaceRichText }],
+            attrs: {
+              alignment: "justify",
+              justificationCompatibility: { type: "legacy" },
+            },
+          },
+          100,
+        );
+
+        expect(measure.lines).toHaveLength(2);
       },
       {
         charWidth: ordinarySpaceRichWidth,

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -328,6 +328,44 @@ describe("empty paragraph line-height floor", () => {
     });
   }
 
+  test("visually empty text uses paragraph-mark metrics", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "empty-run-paragraph-mark-metrics",
+        pmStart: 0,
+        pmEnd: 1,
+        runs: [{ kind: "text", text: " ", fontSize: 18, fontFamily: "Arial" }],
+        attrs: {
+          defaultFontSize: 8,
+          defaultFontFamily: "Arial Narrow",
+        },
+      },
+      600,
+    );
+
+    expect(measure.lines[0]?.lineHeight).toBeCloseTo(8 * PT_TO_PX * 1.15, 1);
+  });
+
+  test("format-split visually empty text uses paragraph-mark metrics", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "split-empty-run-paragraph-mark-metrics",
+        pmStart: 0,
+        pmEnd: 2,
+        runs: [
+          { kind: "text", text: " ", fontSize: 18 },
+          { kind: "text", text: "\u00a0", fontSize: 20 },
+        ],
+        attrs: { defaultFontSize: 8, defaultFontFamily: "Arial Narrow" },
+      },
+      600,
+    );
+
+    expect(measure.lines[0]?.lineHeight).toBeCloseTo(8 * PT_TO_PX * 1.15, 1);
+  });
+
   test("suppressed empty paragraph keeps a zero-height anchor", () => {
     const measure = measureParagraph(
       {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -591,6 +591,7 @@ function uppercaseLetterRatio(text: string): number {
 }
 
 type JustifyFitStrategy =
+  | { type: "strict" }
   | { type: "rounding" }
   | { type: "space"; ratio: number; maxWidthRatio?: number }
   | { type: "width"; ratio: number };
@@ -605,6 +606,9 @@ function resolveJustifyFitStrategy(
   isFirstLine: boolean,
   profile: JustificationProfile,
 ): JustifyFitStrategy {
+  if (block.attrs?.justificationCompatibility?.type === "legacy") {
+    return { type: "strict" };
+  }
   if (isShallowFullHangingListContinuation(block, isFirstLine)) {
     return { type: "rounding" };
   }
@@ -662,6 +666,9 @@ function justifyFitTolerance(
   strategy: JustifyFitStrategy,
   candidateSpaceWidth: number,
 ): number {
+  if (strategy.type === "strict") {
+    return 0;
+  }
   if (strategy.type === "rounding") {
     return WIDTH_TOLERANCE;
   }

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -1194,16 +1194,11 @@ export function measureParagraph(
     };
   }
 
-  // Check for empty text run only
-  if (
-    runs.length === 1 &&
-    // SAFETY: length === 1 guarantees index 0 exists
-    isTextRun(runs[0]!) &&
-    isEmptyTextRun(runs[0] as TextRun)
-  ) {
-    const run = runs[0] as TextRun;
-    const fontSize = run.fontSize ?? attrs?.defaultFontSize ?? DEFAULT_FONT_SIZE;
-    const fontFamily = run.fontFamily ?? attrs?.defaultFontFamily ?? DEFAULT_FONT_FAMILY;
+  // Whitespace-only text is layout-empty: use the paragraph-mark formatting
+  // carried by attrs rather than formatting from an otherwise invisible run.
+  if (runs.length > 0 && runs.every((run) => isTextRun(run) && isEmptyTextRun(run))) {
+    const fontSize = attrs?.defaultFontSize ?? DEFAULT_FONT_SIZE;
+    const fontFamily = attrs?.defaultFontFamily ?? DEFAULT_FONT_FAMILY;
     const emptyMetrics = calculateEmptyParagraphMetrics(fontSize, spacing, fontFamily);
 
     lines.push({

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -377,6 +377,8 @@ export type ListNumPr = {
  */
 export type ParagraphAttrs = {
   alignment?: "left" | "center" | "right" | "justify";
+  /** Document-generation policy for justified line fitting. */
+  justificationCompatibility?: { type: "legacy" };
   /** East Asian first/last-character restrictions (`w:kinsoku`). */
   kinsoku?: boolean;
   /** Hanging punctuation (`w:overflowPunct`); defaults to enabled when omitted. */

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -183,6 +183,11 @@ export type {
  */
 export type DocumentSettings = {
   /**
+   * Application compatibility generation from
+   * `w:compat/w:compatSetting[@w:name="compatibilityMode"]`.
+   */
+  compatibilityMode?: number;
+  /**
    * `w:defaultTabStop` (§17.6.13) — interval in twips between default
    * tab stops applied when a paragraph has no custom `w:tabs`. Word
    * defaults to 720 twips (½ inch) when absent.


### PR DESCRIPTION
## Summary

- apply legacy OOXML compatibility generation when fitting justified lines across document stories
- measure whitespace-only paragraphs using their paragraph-mark formatting
- cover parser, propagation, cache identity, and measurement behavior with focused invariant tests

Validated with the full unit suite, typecheck, lint, build, package-shape validation, interaction tests, and changeset checks.