### PR TITLE
feat: load embedded document fonts in Vue

### DIFF
--- a/.changeset/calm-otters-render.md
+++ b/.changeset/calm-otters-render.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-vue": minor
+---
+
+Load document-embedded fonts in the Vue editor and remeasure layout when their faces become ready.

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -468,6 +468,7 @@ import { useDocumentLifecycle } from "../composables/useDocumentLifecycle";
 import { useDocxEditor } from "../composables/useDocxEditor";
 import { useDocxEditorRefApi } from "../composables/useDocxEditorRefApi";
 import { useFormattingActions } from "../composables/useFormattingActions";
+import { useFontLifecycle } from "../composables/useFontLifecycle";
 import { useHyperlinkManagement } from "../composables/useHyperlinkManagement";
 import { useImageActions } from "../composables/useImageActions";
 import { useKeyboardShortcuts } from "../composables/useKeyboardShortcuts";
@@ -481,7 +482,6 @@ import { useTableResize } from "../composables/useTableResize";
 import { useTrackedChanges } from "../composables/useTrackedChanges";
 import { useZoom } from "../composables/useZoom";
 import type { FontOption } from "../utils/fontOptions";
-import { loadHostFontFaces, removeFontFaces } from "../utils/hostFonts";
 import { useTranslation } from "../i18n";
 import { provideFolioUI } from "../ui/folio-ui";
 
@@ -748,12 +748,10 @@ const showLoadingIndicator = computed(
     !(props.preserveDocumentWhileLoading === true && hasRenderedDocumentOnce.value),
 );
 
-// Host custom font faces (the `fonts` prop). Register on mount + whenever the
-// prop identity changes, then re-measure so metrics reflect the new faces — a
-// face registered after the first layout would otherwise keep its fallback
-// metrics until the next edit. The cleanup unregisters the faces and re-measures
-// their absence. Mirrors React PagedEditor's hostFonts effect (same best-effort
-// FontFace path + font-ready re-layout).
+// Font faces affect line measurement, so both embedded document fonts and
+// host-provided faces must trigger a fresh layout once the browser accepts
+// them. The lifecycle also unregisters faces when their document/prop source
+// changes, preventing one editor load from leaking into the next.
 function remeasureForFontChange(): void {
   const view = editorView.value;
   if (!view) {
@@ -764,37 +762,12 @@ function remeasureForFontChange(): void {
   reLayout();
 }
 
-watch(
-  () => props.fonts,
-  (fonts, _prev, onCleanup) => {
-    if (!fonts || fonts.length === 0) {
-      return;
-    }
-    let cancelled = false;
-    let registered: FontFace[] = [];
-    void loadHostFontFaces(fonts).then((faces) => {
-      if (cancelled) {
-        removeFontFaces(faces);
-        return undefined;
-      }
-      registered = faces;
-      if (faces.length === 0) {
-        return undefined;
-      }
-      remeasureForFontChange();
-      return undefined;
-    });
-    onCleanup(() => {
-      cancelled = true;
-      if (registered.length === 0) {
-        return;
-      }
-      removeFontFaces(registered);
-      remeasureForFontChange();
-    });
-  },
-  { immediate: true },
-);
+useFontLifecycle({
+  isReady,
+  getDocument,
+  fonts: () => props.fonts,
+  remeasure: remeasureForFontChange,
+});
 
 // ---- Feature composables (order: image → hyperlink → pointer → context) --
 const {

--- a/packages/vue/src/composables/useFontLifecycle.test.ts
+++ b/packages/vue/src/composables/useFontLifecycle.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, mock, test } from "bun:test";
+import { effectScope, nextTick, ref } from "vue";
+
+import { useFontLifecycle, type FontLifecycleDependencies } from "./useFontLifecycle";
+
+function deferred<T>() {
+  return Promise.withResolvers<T>();
+}
+
+function createFontFace(): FontFace {
+  return new FontFace("Document Sans", new ArrayBuffer(1));
+}
+
+describe("useFontLifecycle", () => {
+  test("remeasures after embedded fonts load and removes them on document cleanup", async () => {
+    const originalFontFace = Reflect.get(globalThis, "FontFace");
+    const hadFontFace = "FontFace" in globalThis;
+    Object.defineProperty(globalThis, "FontFace", {
+      value: class {},
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const face = createFontFace();
+      const loadEmbedded = mock((_buffer: ArrayBuffer) => Promise.resolve([face]));
+      const remove = mock((_faces: readonly FontFace[]) => {});
+      const remeasure = mock(() => {});
+      const ready = ref(false);
+      const buffer = new ArrayBuffer(8);
+      const document = { originalBuffer: buffer };
+      const dependencies: FontLifecycleDependencies = {
+        loadEmbedded,
+        loadHost: () => Promise.resolve([]),
+        remove,
+      };
+      const scope = effectScope();
+      scope.run(() => {
+        useFontLifecycle(
+          {
+            isReady: ready,
+            getDocument: () => document,
+            fonts: () => undefined,
+            remeasure,
+          },
+          dependencies,
+        );
+      });
+
+      ready.value = true;
+      await nextTick();
+      await Promise.resolve();
+      expect(loadEmbedded).toHaveBeenCalledWith(buffer);
+      expect(remeasure).toHaveBeenCalledTimes(1);
+
+      ready.value = false;
+      await nextTick();
+      expect(remove).toHaveBeenCalledWith([face]);
+      scope.stop();
+    } finally {
+      if (hadFontFace) {
+        Object.defineProperty(globalThis, "FontFace", {
+          value: originalFontFace,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, "FontFace");
+      }
+    }
+  });
+
+  test("removes a stale async result without remeasuring the replacement document", async () => {
+    const originalFontFace = Reflect.get(globalThis, "FontFace");
+    const hadFontFace = "FontFace" in globalThis;
+    Object.defineProperty(globalThis, "FontFace", {
+      value: class {},
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const face = createFontFace();
+      const pending = deferred<FontFace[]>();
+      const remove = mock((_faces: readonly FontFace[]) => {});
+      const remeasure = mock(() => {});
+      const ready = ref(false);
+      const document = { originalBuffer: new ArrayBuffer(8) };
+      const scope = effectScope();
+      scope.run(() => {
+        useFontLifecycle(
+          {
+            isReady: ready,
+            getDocument: () => document,
+            fonts: () => undefined,
+            remeasure,
+          },
+          {
+            loadEmbedded: () => pending.promise,
+            loadHost: () => Promise.resolve([]),
+            remove,
+          },
+        );
+      });
+
+      ready.value = true;
+      await nextTick();
+      ready.value = false;
+      await nextTick();
+      pending.resolve([face]);
+      await Promise.resolve();
+
+      expect(remove).toHaveBeenCalledWith([face]);
+      expect(remeasure).not.toHaveBeenCalled();
+      scope.stop();
+    } finally {
+      if (hadFontFace) {
+        Object.defineProperty(globalThis, "FontFace", {
+          value: originalFontFace,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, "FontFace");
+      }
+    }
+  });
+
+  test("remeasures when host faces are added and removed", async () => {
+    const originalFontFace = Reflect.get(globalThis, "FontFace");
+    const hadFontFace = "FontFace" in globalThis;
+    Object.defineProperty(globalThis, "FontFace", {
+      value: class {},
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const face = createFontFace();
+      const fonts = ref([{ family: "Host Sans", src: "/host-sans.woff2" }]);
+      const loadHost = mock(() => Promise.resolve([face]));
+      const remove = mock((_faces: readonly FontFace[]) => {});
+      const remeasure = mock(() => {});
+      const scope = effectScope();
+      scope.run(() => {
+        useFontLifecycle(
+          {
+            isReady: ref(false),
+            getDocument: () => null,
+            fonts: () => fonts.value,
+            remeasure,
+          },
+          {
+            loadEmbedded: () => Promise.resolve([]),
+            loadHost,
+            remove,
+          },
+        );
+      });
+
+      await Promise.resolve();
+      expect(loadHost).toHaveBeenCalledWith(fonts.value);
+      expect(remeasure).toHaveBeenCalledTimes(1);
+
+      fonts.value = [];
+      await nextTick();
+      expect(remove).toHaveBeenCalledWith([face]);
+      expect(remeasure).toHaveBeenCalledTimes(2);
+      scope.stop();
+    } finally {
+      if (hadFontFace) {
+        Object.defineProperty(globalThis, "FontFace", {
+          value: originalFontFace,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, "FontFace");
+      }
+    }
+  });
+});

--- a/packages/vue/src/composables/useFontLifecycle.ts
+++ b/packages/vue/src/composables/useFontLifecycle.ts
@@ -47,12 +47,13 @@ export function useFontLifecycle(
       void dependencies.loadEmbedded(buffer).then((faces) => {
         if (cancelled) {
           dependencies.remove(faces);
-          return;
+          return undefined;
         }
         registered = faces;
         if (faces.length > 0) {
           options.remeasure();
         }
+        return undefined;
       });
 
       onCleanup(() => {
@@ -75,12 +76,13 @@ export function useFontLifecycle(
       void dependencies.loadHost(fonts).then((faces) => {
         if (cancelled) {
           dependencies.remove(faces);
-          return;
+          return undefined;
         }
         registered = faces;
         if (faces.length > 0) {
           options.remeasure();
         }
+        return undefined;
       });
 
       onCleanup(() => {

--- a/packages/vue/src/composables/useFontLifecycle.ts
+++ b/packages/vue/src/composables/useFontLifecycle.ts
@@ -1,0 +1,97 @@
+/** Owns browser font registration for one Vue editor instance. */
+
+import { watch, type Ref } from "vue";
+
+import type { FontDefinition } from "../components/DocxEditor/types";
+import { loadEmbeddedFontFaces } from "../utils/embeddedFonts";
+import { removeFontFaces } from "../utils/fontFaces";
+import { loadHostFontFaces } from "../utils/hostFonts";
+
+export type UseFontLifecycleOptions = {
+  isReady: Ref<boolean>;
+  getDocument: () => { originalBuffer?: ArrayBuffer | null } | null;
+  fonts: () => ReadonlyArray<FontDefinition> | undefined;
+  remeasure: () => void;
+};
+
+export type FontLifecycleDependencies = {
+  loadEmbedded: (buffer: ArrayBuffer) => Promise<FontFace[]>;
+  loadHost: (fonts: ReadonlyArray<FontDefinition> | undefined) => Promise<FontFace[]>;
+  remove: (faces: readonly FontFace[]) => void;
+};
+
+const DEFAULT_DEPENDENCIES: FontLifecycleDependencies = {
+  loadEmbedded: loadEmbeddedFontFaces,
+  loadHost: loadHostFontFaces,
+  remove: removeFontFaces,
+};
+
+/**
+ * Register document-embedded and host-provided fonts for the lifetime of their
+ * sources. Async results from a stale document or prop value are immediately
+ * removed, preventing one editor load from leaking faces into the next.
+ */
+export function useFontLifecycle(
+  options: UseFontLifecycleOptions,
+  dependencies: FontLifecycleDependencies = DEFAULT_DEPENDENCIES,
+): void {
+  watch(
+    () => (options.isReady.value ? (options.getDocument()?.originalBuffer ?? null) : null),
+    (buffer, _previous, onCleanup) => {
+      if (!buffer) {
+        return;
+      }
+
+      let cancelled = false;
+      let registered: FontFace[] = [];
+      void dependencies.loadEmbedded(buffer).then((faces) => {
+        if (cancelled) {
+          dependencies.remove(faces);
+          return;
+        }
+        registered = faces;
+        if (faces.length > 0) {
+          options.remeasure();
+        }
+      });
+
+      onCleanup(() => {
+        cancelled = true;
+        dependencies.remove(registered);
+      });
+    },
+    { immediate: true },
+  );
+
+  watch(
+    options.fonts,
+    (fonts, _previous, onCleanup) => {
+      if (!fonts || fonts.length === 0) {
+        return;
+      }
+
+      let cancelled = false;
+      let registered: FontFace[] = [];
+      void dependencies.loadHost(fonts).then((faces) => {
+        if (cancelled) {
+          dependencies.remove(faces);
+          return;
+        }
+        registered = faces;
+        if (faces.length > 0) {
+          options.remeasure();
+        }
+      });
+
+      onCleanup(() => {
+        cancelled = true;
+        if (registered.length === 0) {
+          return;
+        }
+        dependencies.remove(registered);
+        options.remeasure();
+      });
+    },
+    { immediate: true },
+  );
+}

--- a/packages/vue/src/utils/embeddedFonts.test.ts
+++ b/packages/vue/src/utils/embeddedFonts.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
+
+let extractImpl: (buffer: ArrayBuffer) => Promise<EmbeddedFont[]>;
+void mock.module("@stll/folio-core/fonts/embeddedFonts", () => ({
+  extractEmbeddedFonts: (buffer: ArrayBuffer) => extractImpl(buffer),
+}));
+
+const { loadEmbeddedFontFaces } = await import("./embeddedFonts");
+
+function fakeFont(): EmbeddedFont {
+  return {
+    family: "Document Sans",
+    style: "normal",
+    weight: 400,
+    bytes: new Uint8Array([0x00, 0x01, 0x00, 0x00]),
+    subsetted: false,
+  };
+}
+
+type FontFaceMode = "load-ok" | "load-reject" | "ctor-throw";
+type StubbedGlobal = "document" | "FontFace";
+
+let fontFaceMode: FontFaceMode;
+let addedFaces: unknown[];
+let deletedFaces: unknown[];
+
+class FakeFontFace {
+  constructor(_family: string, _source: unknown, _descriptors: unknown) {
+    if (fontFaceMode === "ctor-throw") {
+      throw new SyntaxError("invalid font family");
+    }
+  }
+
+  load(): Promise<FakeFontFace> {
+    if (fontFaceMode === "load-reject") {
+      return Promise.reject(new Error("load failed"));
+    }
+    return Promise.resolve(this);
+  }
+}
+
+function stubGlobal(prop: StubbedGlobal, value: unknown): void {
+  Object.defineProperty(globalThis, prop, { value, configurable: true, writable: true });
+}
+
+function restoreGlobal(prop: StubbedGlobal, had: boolean, original: unknown): void {
+  if (had) {
+    Object.defineProperty(globalThis, prop, {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+    return;
+  }
+  Reflect.deleteProperty(globalThis, prop);
+}
+
+let hadDocument: boolean;
+let originalDocument: unknown;
+let hadFontFace: boolean;
+let originalFontFace: unknown;
+
+beforeEach(() => {
+  fontFaceMode = "load-ok";
+  addedFaces = [];
+  deletedFaces = [];
+  extractImpl = () => Promise.resolve([fakeFont()]);
+
+  hadDocument = "document" in globalThis;
+  originalDocument = Reflect.get(globalThis, "document");
+  hadFontFace = "FontFace" in globalThis;
+  originalFontFace = Reflect.get(globalThis, "FontFace");
+
+  stubGlobal("document", {
+    fonts: {
+      add: (face: unknown) => addedFaces.push(face),
+      delete: (face: unknown) => {
+        deletedFaces.push(face);
+        return true;
+      },
+    },
+  });
+  stubGlobal("FontFace", FakeFontFace);
+});
+
+afterEach(() => {
+  restoreGlobal("document", hadDocument, originalDocument);
+  restoreGlobal("FontFace", hadFontFace, originalFontFace);
+});
+
+describe("loadEmbeddedFontFaces", () => {
+  test("registers faces extracted from the document", async () => {
+    const faces = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    expect(faces).toHaveLength(1);
+    expect(addedFaces).toHaveLength(1);
+    expect(deletedFaces).toHaveLength(0);
+  });
+
+  test("falls back when extraction fails", async () => {
+    extractImpl = () => Promise.reject(new Error("corrupt package"));
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(addedFaces).toHaveLength(0);
+  });
+
+  test("skips a face rejected by the browser", async () => {
+    fontFaceMode = "load-reject";
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(addedFaces).toHaveLength(1);
+    expect(deletedFaces).toHaveLength(1);
+  });
+
+  test("skips invalid face descriptors", async () => {
+    fontFaceMode = "ctor-throw";
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(addedFaces).toHaveLength(0);
+  });
+
+  test("is a no-op outside a browser document", async () => {
+    stubGlobal("document", undefined);
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+  });
+});

--- a/packages/vue/src/utils/embeddedFonts.ts
+++ b/packages/vue/src/utils/embeddedFonts.ts
@@ -22,17 +22,13 @@ export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFa
     return [];
   }
 
-  const loaded: FontFace[] = [];
-  await Promise.all(
-    fonts.map(async (font) => {
-      const face = await registerFontFace(fontSet, font.family, font.bytes, {
+  const faces = await Promise.all(
+    fonts.map((font) =>
+      registerFontFace(fontSet, font.family, font.bytes, {
         weight: String(font.weight),
         style: font.style,
-      });
-      if (face) {
-        loaded.push(face);
-      }
-    }),
+      }),
+    ),
   );
-  return loaded;
+  return faces.filter((face): face is FontFace => face !== null);
 }

--- a/packages/vue/src/utils/embeddedFonts.ts
+++ b/packages/vue/src/utils/embeddedFonts.ts
@@ -1,0 +1,38 @@
+/** Register fonts embedded in a document with the browser font set. */
+
+import { extractEmbeddedFonts, type EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
+
+import { getDocumentFontSet, registerFontFace } from "./fontFaces";
+
+/**
+ * Extract and register embedded faces from a raw document buffer. Extraction
+ * and individual face failures are best-effort: rendering falls back to the
+ * normal CSS font stack instead of failing the document load.
+ */
+export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFace[]> {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return [];
+  }
+
+  let fonts: EmbeddedFont[];
+  try {
+    fonts = await extractEmbeddedFonts(buffer);
+  } catch {
+    return [];
+  }
+
+  const loaded: FontFace[] = [];
+  await Promise.all(
+    fonts.map(async (font) => {
+      const face = await registerFontFace(fontSet, font.family, font.bytes, {
+        weight: String(font.weight),
+        style: font.style,
+      });
+      if (face) {
+        loaded.push(face);
+      }
+    }),
+  );
+  return loaded;
+}

--- a/packages/vue/src/utils/fontFaces.ts
+++ b/packages/vue/src/utils/fontFaces.ts
@@ -1,0 +1,50 @@
+/** Browser-only `FontFace` registration shared by Vue's font sources. */
+
+/** The document's `FontFaceSet`, or `null` outside a DOM. */
+export function getDocumentFontSet(): FontFaceSet | null {
+  if (typeof document === "undefined" || !("fonts" in document)) {
+    return null;
+  }
+  return document.fonts;
+}
+
+/**
+ * Register one font face best-effort. Invalid descriptors and rejected font
+ * binaries are skipped so one bad face cannot prevent the document rendering.
+ */
+export async function registerFontFace(
+  fontSet: FontFaceSet,
+  family: string,
+  source: string | BufferSource,
+  descriptors: FontFaceDescriptors,
+): Promise<FontFace | null> {
+  let face: FontFace;
+  try {
+    face = new FontFace(family, source, descriptors);
+    fontSet.add(face);
+  } catch {
+    return null;
+  }
+
+  const loaded = await face.load().then(
+    () => true,
+    () => false,
+  );
+  if (loaded) {
+    return face;
+  }
+
+  fontSet.delete(face);
+  return null;
+}
+
+/** Remove previously registered faces from the document font set. */
+export function removeFontFaces(faces: readonly FontFace[]): void {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return;
+  }
+  for (const face of faces) {
+    fontSet.delete(face);
+  }
+}

--- a/packages/vue/src/utils/hostFonts.ts
+++ b/packages/vue/src/utils/hostFonts.ts
@@ -1,12 +1,11 @@
 /**
  * Host-app custom fonts — the `fonts` prop on the Vue `DocxEditor`.
  *
- * Vue port of `packages/react/src/paged-editor/hostFonts.ts` (plus the DOM-only
- * `FontFace` helpers it shares with `embeddedFonts.ts`). The host passes its own
- * brand/web font faces; each registers with the browser through a best-effort
- * `FontFace` path, so a bad entry is skipped rather than throwing. Once
- * registered, the family name is available for rendering and can be listed in
- * the font-family picker via the `fontFamilies` prop.
+ * Vue port of `packages/react/src/paged-editor/hostFonts.ts`. The host passes
+ * its own brand/web font faces; each registers with the browser through a
+ * best-effort `FontFace` path, so a bad entry is skipped rather than throwing.
+ * Once registered, the family name is available for rendering and can be
+ * listed in the font-family picker via the `fontFamilies` prop.
  *
  * Framework-neutral: DOM `FontFace` APIs only, no Vue or React. The prop
  * normalizer ({@link toFontFaceInputs}) is pure (no DOM), so it is unit-testable
@@ -14,6 +13,7 @@
  */
 
 import type { FontDefinition } from "../components/DocxEditor/types";
+import { getDocumentFontSet, registerFontFace } from "./fontFaces";
 
 /** `FontFace` constructor inputs derived from a {@link FontDefinition}. */
 export type FontFaceInput = {
@@ -72,50 +72,11 @@ export function toFontFaceInputs(
   return inputs;
 }
 
-/** The document's `FontFaceSet`, or `null` outside a DOM. */
-export function getDocumentFontSet(): FontFaceSet | null {
-  if (typeof document === "undefined" || !("fonts" in document)) {
-    return null;
-  }
-  return document.fonts;
-}
-
-/**
- * Register one font face on the document font set, best-effort. Returns the
- * loaded `FontFace`, or `null` when construction throws (invalid family or
- * descriptor) or the binary/URL fails to load (malformed / subsetted).
- */
-async function registerFontFace(
-  fontSet: FontFaceSet,
-  family: string,
-  source: string,
-  descriptors: FontFaceDescriptors,
-): Promise<FontFace | null> {
-  let face: FontFace;
-  try {
-    // `new FontFace` throws synchronously (SyntaxError) on an invalid family or
-    // descriptor; `fontSet.add` can reject a face too. Skip on failure.
-    face = new FontFace(family, source, descriptors);
-    fontSet.add(face);
-  } catch {
-    return null;
-  }
-  const ready = await face.load().then(
-    () => true,
-    () => false,
-  );
-  if (ready) {
-    return face;
-  }
-  fontSet.delete(face);
-  return null;
-}
-
 /**
  * Register the host's custom font faces with the browser via the `FontFace` API.
  * No-op (returns `[]`) outside a DOM or when no valid fonts are given. Returns
  * the faces that loaded successfully; each bad entry is skipped, never thrown.
- * Pair with {@link removeFontFaces} to unregister on change/unmount.
+ * The font lifecycle unregisters returned faces on change/unmount.
  */
 export async function loadHostFontFaces(
   fonts: ReadonlyArray<FontDefinition> | undefined,
@@ -138,15 +99,4 @@ export async function loadHostFontFaces(
     }),
   );
   return loaded;
-}
-
-/** Remove previously registered faces from the document font set. */
-export function removeFontFaces(faces: readonly FontFace[]): void {
-  const fontSet = getDocumentFontSet();
-  if (!fontSet) {
-    return;
-  }
-  for (const face of faces) {
-    fontSet.delete(face);
-  }
 }

--- a/packages/vue/src/utils/hostFonts.ts
+++ b/packages/vue/src/utils/hostFonts.ts
@@ -89,14 +89,10 @@ export async function loadHostFontFaces(
   if (inputs.length === 0) {
     return [];
   }
-  const loaded: FontFace[] = [];
-  await Promise.all(
-    inputs.map(async ({ family, source, descriptors }) => {
-      const face = await registerFontFace(fontSet, family, source, descriptors);
-      if (face) {
-        loaded.push(face);
-      }
-    }),
+  const faces = await Promise.all(
+    inputs.map(({ family, source, descriptors }) =>
+      registerFontFace(fontSet, family, source, descriptors),
+    ),
   );
-  return loaded;
+  return faces.filter((face): face is FontFace => face !== null);
 }

--- a/packages/vue/src/utils/index.ts
+++ b/packages/vue/src/utils/index.ts
@@ -18,6 +18,3 @@ export {
   findVerticalScrollParent,
   findVerticalScrollParentOrRoot,
 } from "@stll/folio-core/utils/findVerticalScrollParent";
-// TODO(vue): fontLoader (getRenderableDocumentFonts / loadFontDefinitions /
-// FontDefinition …) is reconciled against core's embedded-font surface when the
-// useFontLifecycle composable lands, to avoid duplicating core's font handling.


### PR DESCRIPTION
## Summary

- register document-embedded font faces in the Vue editor
- centralize embedded and host font cleanup under a race-safe lifecycle
- remeasure layout after accepted faces become ready