### PR TITLE
feat: add tracked vertical cell merging

### DIFF
--- a/.changeset/tracked-vertical-cell-merging.md
+++ b/.changeset/tracked-vertical-cell-merging.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-agents": minor
+---
+
+Add tracked vertical table cell merge operations with row-count targeting and reversible native revisions.

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -1007,7 +1007,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                     readonly additionalProperties: false;
                 }, {
                     readonly type: "object";
-                    readonly description: "Merge the rectangular table region bounded by two cell anchors. Direct mode only.";
+                    readonly description: "Merge a region targeted by an opposite-cell anchor or a downward row count. Tracked mode supports vertical-only regions with empty continuation cells.";
                     readonly properties: {
                         readonly type: {
                             readonly type: "string";
@@ -1019,7 +1019,13 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                         };
                         readonly endBlockId: {
                             readonly type: "string";
+                            readonly minLength: 1;
                             readonly description: "Stable paragraph anchor inside the opposite corner cell.";
+                        };
+                        readonly rowCount: {
+                            readonly type: "integer";
+                            readonly minimum: 2;
+                            readonly description: "Number of grid rows to merge downward from the anchored cell.";
                         };
                         readonly id: {
                             readonly type: "string";
@@ -1048,7 +1054,12 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                             readonly additionalProperties: false;
                         };
                     };
-                    readonly required: readonly ["id", "type", "blockId", "endBlockId"];
+                    readonly required: readonly ["id", "type", "blockId"];
+                    readonly oneOf: readonly [{
+                        readonly required: readonly ["endBlockId"];
+                    }, {
+                        readonly required: readonly ["rowCount"];
+                    }];
                     readonly additionalProperties: false;
                 }, {
                     readonly type: "object";
@@ -2018,7 +2029,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
         readonly additionalProperties: false;
     }, {
         readonly type: "object";
-        readonly description: "Merge the rectangular table region bounded by two cell anchors. Direct mode only.";
+        readonly description: "Merge a region targeted by an opposite-cell anchor or a downward row count. Tracked mode supports vertical-only regions with empty continuation cells.";
         readonly properties: {
             readonly type: {
                 readonly type: "string";
@@ -2030,7 +2041,13 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
             };
             readonly endBlockId: {
                 readonly type: "string";
+                readonly minLength: 1;
                 readonly description: "Stable paragraph anchor inside the opposite corner cell.";
+            };
+            readonly rowCount: {
+                readonly type: "integer";
+                readonly minimum: 2;
+                readonly description: "Number of grid rows to merge downward from the anchored cell.";
             };
             readonly id: {
                 readonly type: "string";
@@ -2059,7 +2076,12 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                 readonly additionalProperties: false;
             };
         };
-        readonly required: readonly ["id", "type", "blockId", "endBlockId"];
+        readonly required: readonly ["id", "type", "blockId"];
+        readonly oneOf: readonly [{
+            readonly required: readonly ["endBlockId"];
+        }, {
+            readonly required: readonly ["rowCount"];
+        }];
         readonly additionalProperties: false;
     }, {
         readonly type: "object";

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -239,11 +239,9 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
     blockId: string;
 } & ({
-    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
     rowCount?: never;
 } | {
-    /** Number of grid rows to merge downward from the anchored cell. */
     rowCount: number;
     endBlockId?: never;
 })) | {

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -75,7 +75,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteTableRow: readonly ["direct", "tracked-changes"];
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
-    readonly mergeTableCells: readonly ["direct"];
+    readonly mergeTableCells: readonly ["direct", "tracked-changes"];
     readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
@@ -234,12 +234,19 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
     blockId: string;
-} | {
+} | ({
     id: string;
-    type: "mergeTableCells"; /** Stable paragraph anchor inside one corner cell. */
-    blockId: string; /** Stable paragraph anchor inside the opposite corner cell. */
+    type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
+    blockId: string;
+} & ({
+    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
+    rowCount?: never;
 } | {
+    /** Number of grid rows to merge downward from the anchored cell. */
+    rowCount: number;
+    endBlockId?: never;
+})) | {
     id: string;
     type: "splitTableCell"; /** Stable paragraph anchor inside the cell to split. */
     blockId: string;
@@ -364,13 +371,18 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";
-} | {
+} | ({
     type: "tableCells";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
-    endAnchorBlockId: string;
     effect: "merged";
+} & ({
+    endAnchorBlockId: string;
+    rowCount?: never;
 } | {
+    rowCount: number;
+    endAnchorBlockId?: never;
+})) | {
     type: "tableCell";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -443,7 +443,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteTableRow: readonly ["direct", "tracked-changes"];
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
-    readonly mergeTableCells: readonly ["direct"];
+    readonly mergeTableCells: readonly ["direct", "tracked-changes"];
     readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
@@ -596,12 +596,19 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
     blockId: string;
-} | {
+} | ({
     id: string;
-    type: "mergeTableCells"; /** Stable paragraph anchor inside one corner cell. */
-    blockId: string; /** Stable paragraph anchor inside the opposite corner cell. */
+    type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
+    blockId: string;
+} & ({
+    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
+    rowCount?: never;
 } | {
+    /** Number of grid rows to merge downward from the anchored cell. */
+    rowCount: number;
+    endBlockId?: never;
+})) | {
     id: string;
     type: "splitTableCell"; /** Stable paragraph anchor inside the cell to split. */
     blockId: string;
@@ -688,13 +695,18 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";
-} | {
+} | ({
     type: "tableCells";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
-    endAnchorBlockId: string;
     effect: "merged";
+} & ({
+    endAnchorBlockId: string;
+    rowCount?: never;
 } | {
+    rowCount: number;
+    endAnchorBlockId?: never;
+})) | {
     type: "tableCell";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -601,11 +601,9 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
     blockId: string;
 } & ({
-    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
     rowCount?: never;
 } | {
-    /** Number of grid rows to merge downward from the anchored cell. */
     rowCount: number;
     endBlockId?: never;
 })) | {

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -443,7 +443,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteTableRow: readonly ["direct", "tracked-changes"];
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
-    readonly mergeTableCells: readonly ["direct"];
+    readonly mergeTableCells: readonly ["direct", "tracked-changes"];
     readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
@@ -596,12 +596,19 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
     blockId: string;
-} | {
+} | ({
     id: string;
-    type: "mergeTableCells"; /** Stable paragraph anchor inside one corner cell. */
-    blockId: string; /** Stable paragraph anchor inside the opposite corner cell. */
+    type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
+    blockId: string;
+} & ({
+    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
+    rowCount?: never;
 } | {
+    /** Number of grid rows to merge downward from the anchored cell. */
+    rowCount: number;
+    endBlockId?: never;
+})) | {
     id: string;
     type: "splitTableCell"; /** Stable paragraph anchor inside the cell to split. */
     blockId: string;
@@ -688,13 +695,18 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";
-} | {
+} | ({
     type: "tableCells";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
-    endAnchorBlockId: string;
     effect: "merged";
+} & ({
+    endAnchorBlockId: string;
+    rowCount?: never;
 } | {
+    rowCount: number;
+    endAnchorBlockId?: never;
+})) | {
     type: "tableCell";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -601,11 +601,9 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
     blockId: string;
 } & ({
-    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
     rowCount?: never;
 } | {
-    /** Number of grid rows to merge downward from the anchored cell. */
     rowCount: number;
     endBlockId?: never;
 })) | {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -361,11 +361,9 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
     blockId: string;
 } & ({
-    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
     rowCount?: never;
 } | {
-    /** Number of grid rows to merge downward from the anchored cell. */
     rowCount: number;
     endBlockId?: never;
 })) | {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -196,7 +196,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE: Readonly<{
     readonly deleteTableRow: readonly ["direct", "tracked-changes"];
     readonly insertTableColumn: readonly ["direct", "tracked-changes"];
     readonly deleteTableColumn: readonly ["direct", "tracked-changes"];
-    readonly mergeTableCells: readonly ["direct"];
+    readonly mergeTableCells: readonly ["direct", "tracked-changes"];
     readonly splitTableCell: readonly ["direct", "tracked-changes"];
 }>;
 
@@ -356,12 +356,19 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     id: string;
     type: "deleteTableColumn"; /** Stable paragraph anchor inside the column to delete. */
     blockId: string;
-} | {
+} | ({
     id: string;
-    type: "mergeTableCells"; /** Stable paragraph anchor inside one corner cell. */
-    blockId: string; /** Stable paragraph anchor inside the opposite corner cell. */
+    type: "mergeTableCells"; /** Stable paragraph anchor inside the first cell. */
+    blockId: string;
+} & ({
+    /** Stable paragraph anchor inside the opposite corner cell. */
     endBlockId: string;
+    rowCount?: never;
 } | {
+    /** Number of grid rows to merge downward from the anchored cell. */
+    rowCount: number;
+    endBlockId?: never;
+})) | {
     id: string;
     type: "splitTableCell"; /** Stable paragraph anchor inside the cell to split. */
     blockId: string;
@@ -512,13 +519,18 @@ export type FolioDocumentOperationAffectedTarget = {
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
     effect: "deleted";
-} | {
+} | ({
     type: "tableCells";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;
-    endAnchorBlockId: string;
     effect: "merged";
+} & ({
+    endAnchorBlockId: string;
+    rowCount?: never;
 } | {
+    rowCount: number;
+    endAnchorBlockId?: never;
+})) | {
     type: "tableCell";
     story: FolioDocumentOperationStory;
     anchorBlockId: string;

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -269,7 +269,10 @@ const admits = (schema: JsonSchemaNode, value: unknown): boolean => {
   if (schema.oneOf !== undefined) {
     // oneOf semantics: exactly one variant must admit the value, so the union
     // stays a real discriminated union.
-    return schema.oneOf.filter((variant) => admits(variant, value)).length === 1;
+    const { oneOf, ...baseSchema } = schema;
+    return (
+      admits(baseSchema, value) && oneOf.filter((variant) => admits(variant, value)).length === 1
+    );
   }
   if (schema.enum !== undefined && !schema.enum.includes(value)) {
     return false;
@@ -299,7 +302,9 @@ const admits = (schema: JsonSchemaNode, value: unknown): boolean => {
     case "object":
       return admitsObject(schema, value);
     default:
-      return true;
+      return schema.required === undefined && schema.properties === undefined
+        ? true
+        : admitsObject(schema, value);
   }
 };
 
@@ -462,6 +467,30 @@ describe("document operation contract JSON schema conformance", () => {
       expect(admits(OPERATION_SCHEMA, operation), type).toBe(true);
       expect(admits(BATCH_SCHEMA, batch), type).toBe(true);
     }
+  });
+
+  test("cell merge targeting admits exactly one endpoint form", () => {
+    const anchored = CONTRACT_OPERATION_FIXTURES.mergeTableCells;
+    const counted = {
+      id: "op-merge-table-cells-down",
+      type: "mergeTableCells",
+      blockId: "0304003A",
+      rowCount: 3,
+    };
+    expect(admits(OPERATION_SCHEMA, counted)).toBe(true);
+    expect(
+      admits(OPERATION_SCHEMA, {
+        ...anchored,
+        rowCount: 3,
+      }),
+    ).toBe(false);
+    expect(
+      admits(OPERATION_SCHEMA, {
+        id: "op-merge-table-cells-missing-target",
+        type: "mergeTableCells",
+        blockId: "0304003A",
+      }),
+    ).toBe(false);
   });
 
   test("rejects a wrong contract version in both the parser and the schema", () => {

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -394,17 +394,24 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA = {
     {
       type: "object",
       description:
-        "Merge the rectangular table region bounded by two cell anchors. Direct mode only.",
+        "Merge a region targeted by an opposite-cell anchor or a downward row count. Tracked mode supports vertical-only regions with empty continuation cells.",
       properties: {
         ...operationMetaProperties,
         type: { type: "string", enum: ["mergeTableCells"] },
         blockId: blockIdProperty,
         endBlockId: {
           type: "string",
+          minLength: 1,
           description: "Stable paragraph anchor inside the opposite corner cell.",
         },
+        rowCount: {
+          type: "integer",
+          minimum: 2,
+          description: "Number of grid rows to merge downward from the anchored cell.",
+        },
       },
-      required: ["id", "type", "blockId", "endBlockId"],
+      required: ["id", "type", "blockId"],
+      oneOf: [{ required: ["endBlockId"] }, { required: ["rowCount"] }],
       additionalProperties: false,
     },
     {
@@ -451,9 +458,8 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA = {
       enum: FOLIO_DOCUMENT_OPERATION_MODES,
       description:
         'How edits land: "tracked-changes" (default) proposes revisions for human review, ' +
-        '"direct" applies immediately. `insertSignatureTable` and `mergeTableCells` support ' +
-        '"direct" only. Tracked `splitTableCell` operations ' +
-        "support vertical-only spans.",
+        '"direct" applies immediately. `insertSignatureTable` supports "direct" only. ' +
+        "Tracked cell merge and split operations support unambiguous vertical-only topology.",
     },
     atomic: {
       type: "boolean",

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -376,6 +376,7 @@ describe("parseSuggestChangesInput", () => {
     const supersetOperation = (type: string) => ({
       type,
       blockId: "b1",
+      endBlockId: "b2",
       find: "old",
       replace: "new",
       text: "inserted",
@@ -394,9 +395,33 @@ describe("parseSuggestChangesInput", () => {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(type)] });
       expect(result.ok, type).toBe(true);
     }
-    for (const excludedType of ["commentOnBlock", "insertSignatureTable", "mergeTableCells"]) {
+    for (const excludedType of ["commentOnBlock", "insertSignatureTable"]) {
       const result = parseSuggestChangesInput({ operations: [supersetOperation(excludedType)] });
       expect(result.ok, excludedType).toBe(false);
     }
+  });
+
+  test("accepts a row-count target for vertical cell merging", () => {
+    expect(
+      parseSuggestChangesInput({
+        operations: [
+          {
+            type: "mergeTableCells",
+            blockId: "b1",
+            rowCount: 3,
+          },
+        ],
+      }),
+    ).toEqual({
+      ok: true,
+      operations: [
+        {
+          id: "op-1",
+          type: "mergeTableCells",
+          blockId: "b1",
+          rowCount: 3,
+        },
+      ],
+    });
   });
 });

--- a/packages/agents/src/parse.ts
+++ b/packages/agents/src/parse.ts
@@ -84,7 +84,7 @@ export const parseAddCommentInput = (args: unknown): ParseAddCommentResult => {
 };
 
 const OPERATION_TYPES =
-  "replaceInBlock, replaceRange, commentOnRange, formatRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn, splitTableCell";
+  "replaceInBlock, replaceRange, commentOnRange, formatRange, insertAfterBlock, insertBeforeBlock, replaceBlock, deleteBlock, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn, mergeTableCells, splitTableCell";
 
 type SuggestedOperationType =
   | "replaceInBlock"
@@ -99,6 +99,7 @@ type SuggestedOperationType =
   | "deleteTableRow"
   | "insertTableColumn"
   | "deleteTableColumn"
+  | "mergeTableCells"
   | "splitTableCell";
 
 const isOperationType = (value: unknown): value is SuggestedOperationType =>
@@ -114,6 +115,7 @@ const isOperationType = (value: unknown): value is SuggestedOperationType =>
   value === "deleteTableRow" ||
   value === "insertTableColumn" ||
   value === "deleteTableColumn" ||
+  value === "mergeTableCells" ||
   value === "splitTableCell";
 
 const readTextRange = (value: unknown, index: number): FolioAITextRangeHandle | string => {
@@ -252,6 +254,23 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
 
   if (type === "deleteTableRow" || type === "deleteTableColumn" || type === "splitTableCell") {
     return { id: opId, type, blockId };
+  }
+
+  if (type === "mergeTableCells") {
+    const endBlockId = raw["endBlockId"];
+    const rowCount = raw["rowCount"];
+    if (isNonEmptyString(endBlockId) && rowCount === undefined) {
+      return { id: opId, type, blockId, endBlockId };
+    }
+    if (
+      endBlockId === undefined &&
+      typeof rowCount === "number" &&
+      Number.isInteger(rowCount) &&
+      rowCount >= 2
+    ) {
+      return { id: opId, type, blockId, rowCount };
+    }
+    return `operations[${index}] (mergeTableCells) requires exactly one non-empty \`endBlockId\` or integer \`rowCount\` of at least 2.`;
   }
 
   if (type === "replaceInBlock") {

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -52,9 +52,8 @@ const scopedHandleSchema = {
 /**
  * `suggest_changes` deliberately narrows the full document-operation contract
  * (see `FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA` in `operation-schema.ts`):
- * - excluded types: `insertSignatureTable` and `mergeTableCells` (direct-only,
- *   not representable as tracked changes for human review), plus
- *   `commentOnBlock` (covered by the dedicated `add_comment` tool);
+ * - excluded types: `insertSignatureTable` (direct-only) and `commentOnBlock`
+ *   (covered by the dedicated `add_comment` tool);
  * - `id` is optional here (auto-generated `op-1`, `op-2`, … by `parse.ts`)
  *   where the contract requires it;
  * - `comment` is a plain string here; `parse.ts` wraps it into the contract's
@@ -67,7 +66,6 @@ const scopedHandleSchema = {
 const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperationType> = new Set([
   "commentOnBlock",
   "insertSignatureTable",
-  "mergeTableCells",
 ]);
 
 /**
@@ -98,6 +96,16 @@ const suggestChangesOperationSchema = {
     blockId: {
       type: "string",
       description: "The block to edit, from `read_document` or `find_text`.",
+    },
+    endBlockId: {
+      type: "string",
+      minLength: 1,
+      description: "For cell merging, a block in the opposite corner cell.",
+    },
+    rowCount: {
+      type: "integer",
+      minimum: 2,
+      description: "For vertical cell merging, the number of grid rows to merge downward.",
     },
     range: {
       ...FOLIO_TEXT_RANGE_JSON_SCHEMA,

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -3313,7 +3313,226 @@ describe("Folio AI edit operations", () => {
     expect(TableMap.get(view.state.doc.child(0)).width).toBe(3);
   });
 
-  test("treats a same-cell merge as a no-op and rejects tracked mode", () => {
+  test("tracks an empty vertical merge as one reversible cell revision", () => {
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-merge-start" }, [schema.text("A")]),
+        ]),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-merge-side-a" }, [schema.text("X")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node(
+          "tableCell",
+          { verticalAlign: "bottom", _originalFormatting: { verticalAlign: "bottom" } },
+          [schema.node("paragraph", { paraId: "tracked-merge-empty-b" })],
+        ),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-merge-side-b" }, [schema.text("Y")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [
+        schema.node(
+          "tableCell",
+          { verticalAlign: "center", _originalFormatting: { verticalAlign: "center" } },
+          [schema.node("paragraph", { paraId: "tracked-merge-empty-c" })],
+        ),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "tracked-merge-side-c" }, [schema.text("Z")]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "tracked-merge",
+          type: "mergeTableCells",
+          blockId: "tracked-merge-start",
+          rowCount: 3,
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const revisionId = result.applied.at(0)?.revisionId;
+    expect(typeof revisionId).toBe("number");
+    expect(result.applied.at(0)?.revisionIds).toEqual([revisionId]);
+    const mergedCell = view.state.doc.child(0).child(0).child(0);
+    expect(mergedCell.attrs["rowspan"]).toBe(3);
+    expect(view.state.doc.child(0).child(1).childCount).toBe(1);
+    expect(view.state.doc.child(0).child(2).childCount).toBe(1);
+    expect(mergedCell.attrs["_docxVMergeContinuationCells"]).toEqual([
+      expect.objectContaining({
+        formatting: expect.objectContaining({ vMerge: "continue", verticalAlign: "bottom" }),
+        structuralChange: {
+          type: "tableCellMerge",
+          info: { id: revisionId, author: "AI", date: expect.any(String) },
+          verticalMerge: "continue",
+          verticalMergeOriginal: "rest",
+        },
+      }),
+      expect.objectContaining({
+        formatting: expect.objectContaining({ vMerge: "continue", verticalAlign: "center" }),
+        structuralChange: expect.objectContaining({
+          type: "tableCellMerge",
+          info: expect.objectContaining({ id: revisionId }),
+        }),
+      }),
+    ]);
+
+    if (revisionId === undefined) {
+      throw new Error("expected a vertical merge revision");
+    }
+    expect(acceptAIEditRevision(revisionId)(view.state, view.dispatch)).toBe(true);
+    const acceptedContinuations = view.state.doc.child(0).child(0).child(0).attrs[
+      "_docxVMergeContinuationCells"
+    ];
+    expect(acceptedContinuations).toEqual([
+      expect.not.objectContaining({ structuralChange: expect.anything() }),
+      expect.not.objectContaining({ structuralChange: expect.anything() }),
+    ]);
+
+    const rejectingView = makeView(state);
+    const rejectingResult = applyFolioAIEditOperations({
+      view: rejectingView,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "tracked-merge",
+          type: "mergeTableCells",
+          blockId: "tracked-merge-start",
+          rowCount: 3,
+        },
+      ],
+      mode: "tracked-changes",
+    });
+    const rejectingRevisionId = rejectingResult.applied.at(0)?.revisionId;
+    if (rejectingRevisionId === undefined) {
+      throw new Error("expected a vertical merge revision");
+    }
+    expect(
+      rejectAIEditRevision(rejectingRevisionId)(rejectingView.state, rejectingView.dispatch),
+    ).toBe(true);
+    const rejectedTable = rejectingView.state.doc.child(0);
+    expect(rejectedTable.child(0).child(0).attrs["rowspan"]).toBe(1);
+    expect(rejectedTable.child(1).child(0).attrs).toMatchObject({
+      cellMarker: null,
+      _originalFormatting: { verticalAlign: "bottom" },
+    });
+    expect(rejectedTable.child(2).child(0).attrs).toMatchObject({
+      cellMarker: null,
+      _originalFormatting: { verticalAlign: "center" },
+    });
+  });
+
+  test("tracked merging rejects ambiguous topology without mutation", () => {
+    const cases = [
+      {
+        name: "horizontal",
+        table: schema.node("table", null, [
+          schema.node("tableRow", null, [
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: "tracked-merge-horizontal-a" }, [
+                schema.text("A"),
+              ]),
+            ]),
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: "tracked-merge-horizontal-b" }, [
+                schema.text("B"),
+              ]),
+            ]),
+          ]),
+        ]),
+        operation: {
+          id: "tracked-merge-horizontal",
+          type: "mergeTableCells" as const,
+          blockId: "tracked-merge-horizontal-a",
+          endBlockId: "tracked-merge-horizontal-b",
+        },
+      },
+      {
+        name: "content-bearing continuation",
+        table: schema.node("table", null, [
+          schema.node("tableRow", null, [
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: "tracked-merge-content-a" }, [schema.text("A")]),
+            ]),
+          ]),
+          schema.node("tableRow", null, [
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: "tracked-merge-content-b" }, [schema.text("B")]),
+            ]),
+          ]),
+        ]),
+        operation: {
+          id: "tracked-merge-content",
+          type: "mergeTableCells" as const,
+          blockId: "tracked-merge-content-a",
+          endBlockId: "tracked-merge-content-b",
+        },
+      },
+      {
+        name: "marked continuation",
+        table: schema.node("table", null, [
+          schema.node("tableRow", null, [
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: "tracked-merge-marked-a" }, [schema.text("A")]),
+            ]),
+          ]),
+          schema.node("tableRow", null, [
+            schema.node(
+              "tableCell",
+              {
+                cellMarker: {
+                  kind: "ins",
+                  info: {
+                    revisionId: 7,
+                    author: "Existing",
+                    date: "2026-07-17T00:00:00.000Z",
+                  },
+                },
+              },
+              [schema.node("paragraph", { paraId: "tracked-merge-marked-b" })],
+            ),
+          ]),
+        ]),
+        operation: {
+          id: "tracked-merge-marked",
+          type: "mergeTableCells" as const,
+          blockId: "tracked-merge-marked-a",
+          rowCount: 2,
+        },
+      },
+    ];
+
+    for (const { name, table, operation } of cases) {
+      const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+      const view = makeView(state);
+      expect(
+        applyFolioAIEditOperations({
+          view,
+          snapshot: createFolioAIEditSnapshot(state.doc),
+          operations: [operation],
+          mode: "tracked-changes",
+        }),
+        name,
+      ).toEqual({
+        applied: [],
+        skipped: [{ id: operation.id, reason: "unsupportedBlock" }],
+      });
+      expect(view.state.doc.eq(state.doc), name).toBe(true);
+    }
+  });
+
+  test("treats a same-cell merge as a no-op in either mode", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [
         schema.node("tableCell", null, [
@@ -3360,7 +3579,7 @@ describe("Folio AI edit operations", () => {
       }),
     ).toEqual({
       applied: [],
-      skipped: [{ id: "tracked-merge", reason: "unsupportedMode" }],
+      skipped: [{ id: "tracked-merge", reason: "noopOperation" }],
     });
   });
 

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -11,7 +11,10 @@ import {
 } from "prosemirror-tables";
 
 import { expectRunPropertyChangeMarkAttrs, expectTableCellAttrs } from "../prosemirror/attrs";
-import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
+import {
+  marksToTextFormatting,
+  standaloneTableCellFromProseMirror,
+} from "../prosemirror/conversion/fromProseDoc";
 import { standaloneTableCellToProseMirror } from "../prosemirror/conversion/toProseDoc";
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
@@ -578,6 +581,110 @@ const mergeTableRectangle = (
     tr = tr.replaceWith(contentStart, contentEnd, appendedContent);
   }
   return tr;
+};
+
+type MergeTrackedVerticalTableCellsOptions = {
+  tr: Transaction;
+  tablePosition: number;
+  table: PMNode;
+  rectangle: TableRectangle;
+  revisionId: number;
+  author: string;
+  date: string;
+};
+
+const mergeTrackedVerticalTableCells = ({
+  tr,
+  tablePosition,
+  table,
+  rectangle,
+  revisionId,
+  author,
+  date,
+}: MergeTrackedVerticalTableCellsOptions): Transaction | null => {
+  const map = TableMap.get(table);
+  if (
+    rectangle.right - rectangle.left !== 1 ||
+    rectangle.bottom - rectangle.top < 2 ||
+    rectangle.left < 0 ||
+    rectangle.top < 0 ||
+    rectangle.right > map.width ||
+    rectangle.bottom > map.height ||
+    tableRectangleCutsMergedCell(map, rectangle)
+  ) {
+    return null;
+  }
+
+  const cells: { position: number; cell: PMNode }[] = [];
+  for (let row = rectangle.top; row < rectangle.bottom; row++) {
+    const position = map.map[row * map.width + rectangle.left];
+    if (position === undefined) {
+      return null;
+    }
+    const cell = table.nodeAt(position);
+    if (
+      !cell ||
+      !tableRectanglesEqual(map.findCell(position), {
+        left: rectangle.left,
+        top: row,
+        right: rectangle.right,
+        bottom: row + 1,
+      })
+    ) {
+      return null;
+    }
+    const attrs = expectTableCellAttrs(cell);
+    if (
+      attrs.colspan !== 1 ||
+      attrs.rowspan !== 1 ||
+      attrs.cellMarker !== undefined ||
+      attrs._docxVMergeContinuationCells !== undefined ||
+      attrs._preserveVMergeRestart === true ||
+      attrs._originalFormatting?.vMerge !== undefined
+    ) {
+      return null;
+    }
+    cells.push({ position, cell });
+  }
+
+  const origin = cells.at(0);
+  if (
+    !origin ||
+    cells.length !== rectangle.bottom - rectangle.top ||
+    cells.some(({ cell }) => cell.type !== origin.cell.type) ||
+    cells.slice(1).some(({ cell }) => !isEmptyTableCell(cell))
+  ) {
+    return null;
+  }
+
+  const continuationCells = cells.slice(1).map(({ cell }) => {
+    const continuation = standaloneTableCellFromProseMirror(cell);
+    return {
+      ...continuation,
+      formatting: {
+        ...continuation.formatting,
+        vMerge: "continue" as const,
+      },
+      structuralChange: {
+        type: "tableCellMerge" as const,
+        info: { id: revisionId, author, date },
+        verticalMerge: "continue" as const,
+        verticalMergeOriginal: "rest" as const,
+      },
+    };
+  });
+
+  const nextTr = mergeTableRectangle(tr, tablePosition, table, rectangle);
+  if (!nextTr) {
+    return null;
+  }
+  nextTr.setNodeAttribute(
+    tablePosition + 1 + origin.position,
+    "_docxVMergeContinuationCells",
+    continuationCells,
+  );
+  markStructuralChange(nextTr);
+  return nextTr;
 };
 
 const splitTableRectangle = (
@@ -1310,10 +1417,6 @@ const applyFolioAIEditOperationsInternal = ({
   const liveBlocksByParaId = collectLiveBlocksByParaId(view.state.doc);
 
   for (const [index, operation] of operations.entries()) {
-    if (mode === "tracked-changes" && operation.type === "mergeTableCells") {
-      skipped.push({ id: operation.id, reason: "unsupportedMode" });
-      continue;
-    }
     const commentText = getOperationCommentText(operation);
     if (commentText !== undefined && (!commentType || createCommentId === undefined)) {
       skipped.push({ id: operation.id, reason: "unsupportedBlock" });
@@ -1950,7 +2053,19 @@ const applyFolioAIEditOperationsInternal = ({
           });
           continue;
         }
-        const nextTr = mergeTableRectangle(tr, tablePosition, table, merge.rectangle);
+        const revisionId = mode === "tracked-changes" ? revisionSeed : null;
+        const nextTr =
+          revisionId === null
+            ? mergeTableRectangle(tr, tablePosition, table, merge.rectangle)
+            : mergeTrackedVerticalTableCells({
+                tr,
+                tablePosition,
+                table,
+                rectangle: merge.rectangle,
+                revisionId,
+                author,
+                date,
+              });
         if (!nextTr) {
           skipped.push({
             id: item.operation.id,
@@ -1959,6 +2074,10 @@ const applyFolioAIEditOperationsInternal = ({
           continue;
         }
         tr = nextTr;
+        if (revisionId !== null) {
+          revisionSeed++;
+          appliedRevisionIds = [revisionId];
+        }
         break;
       }
       case "splitTableCell": {
@@ -2645,31 +2764,62 @@ const resolveOperation = ({
   }
 
   if (operation.type === "mergeTableCells") {
-    const endTarget = resolveStableBlock({
-      snapshot,
-      blockId: operation.endBlockId,
-      liveBlocks,
-      liveBlocksByParaId,
-    });
-    if (endTarget.type === "skip") {
-      return endTarget;
-    }
     const startCell = findEnclosingTableCell(doc, blockFrom);
-    const endCell = findEnclosingTableCell(doc, endTarget.blockFrom);
-    if (!startCell || !endCell || startCell.tablePosition !== endCell.tablePosition) {
+    if (!startCell) {
       return { type: "skip", reason: "unsupportedBlock" };
     }
-    const rectangle = {
-      left: Math.min(startCell.leftColumnIndex, endCell.leftColumnIndex),
-      top: Math.min(startCell.topRowIndex, endCell.topRowIndex),
-      right: Math.max(startCell.rightColumnIndex, endCell.rightColumnIndex),
-      bottom: Math.max(startCell.bottomRowIndex, endCell.bottomRowIndex),
-    };
     const table = doc.nodeAt(startCell.tablePosition);
     if (!table || table.type.spec["tableRole"] !== "table") {
       return { type: "skip", reason: "unsupportedBlock" };
     }
     const map = TableMap.get(table);
+    let rectangle: TableRectangle;
+    let endCellPosition: number;
+    let endCellEndPosition: number;
+    if (operation.rowCount !== undefined) {
+      rectangle = {
+        left: startCell.leftColumnIndex,
+        top: startCell.topRowIndex,
+        right: startCell.rightColumnIndex,
+        bottom: startCell.topRowIndex + operation.rowCount,
+      };
+      if (
+        rectangle.right - rectangle.left !== 1 ||
+        rectangle.bottom > map.height ||
+        operation.rowCount < 2
+      ) {
+        return { type: "skip", reason: "unsupportedBlock" };
+      }
+      const endRelativePosition = map.map[(rectangle.bottom - 1) * map.width + rectangle.left];
+      const endCell = endRelativePosition === undefined ? null : table.nodeAt(endRelativePosition);
+      if (!endCell || endRelativePosition === undefined) {
+        return { type: "skip", reason: "unsupportedBlock" };
+      }
+      endCellPosition = startCell.tablePosition + 1 + endRelativePosition;
+      endCellEndPosition = endCellPosition + endCell.nodeSize;
+    } else {
+      const endTarget = resolveStableBlock({
+        snapshot,
+        blockId: operation.endBlockId,
+        liveBlocks,
+        liveBlocksByParaId,
+      });
+      if (endTarget.type === "skip") {
+        return endTarget;
+      }
+      const endCell = findEnclosingTableCell(doc, endTarget.blockFrom);
+      if (!endCell || startCell.tablePosition !== endCell.tablePosition) {
+        return { type: "skip", reason: "unsupportedBlock" };
+      }
+      rectangle = {
+        left: Math.min(startCell.leftColumnIndex, endCell.leftColumnIndex),
+        top: Math.min(startCell.topRowIndex, endCell.topRowIndex),
+        right: Math.max(startCell.rightColumnIndex, endCell.rightColumnIndex),
+        bottom: Math.max(startCell.bottomRowIndex, endCell.bottomRowIndex),
+      };
+      endCellPosition = endCell.cellPosition;
+      endCellEndPosition = endCell.cellEndPosition;
+    }
     if (
       (rectangle.right - rectangle.left === 1 && rectangle.bottom - rectangle.top === 1) ||
       tableRectangleCutsMergedCell(map, rectangle)
@@ -2686,8 +2836,8 @@ const resolveOperation = ({
       type: "resolved",
       operation: {
         operation,
-        from: Math.min(startCell.cellPosition, endCell.cellPosition),
-        to: Math.max(startCell.cellEndPosition, endCell.cellEndPosition),
+        from: Math.min(startCell.cellPosition, endCellPosition),
+        to: Math.max(startCell.cellEndPosition, endCellEndPosition),
         blockFrom,
         blockTo,
         blockNode,

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -657,22 +657,21 @@ const mergeTrackedVerticalTableCells = ({
     return null;
   }
 
-  const continuationCells = cells.slice(1).map(({ cell }) => {
+  const continuationCells: TableCell[] = [];
+  for (const { cell } of cells.slice(1)) {
     const continuation = standaloneTableCellFromProseMirror(cell);
-    return {
-      ...continuation,
-      formatting: {
-        ...continuation.formatting,
-        vMerge: "continue" as const,
-      },
-      structuralChange: {
-        type: "tableCellMerge" as const,
-        info: { id: revisionId, author, date },
-        verticalMerge: "continue" as const,
-        verticalMergeOriginal: "rest" as const,
-      },
+    continuation.formatting = {
+      ...continuation.formatting,
+      vMerge: "continue",
     };
-  });
+    continuation.structuralChange = {
+      type: "tableCellMerge",
+      info: { id: revisionId, author, date },
+      verticalMerge: "continue",
+      verticalMergeOriginal: "rest",
+    };
+    continuationCells.push(continuation);
+  }
 
   const nextTr = mergeTableRectangle(tr, tablePosition, table, rectangle);
   if (!nextTr) {

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -173,6 +173,48 @@ const buildTextBoxVerticalMergeDocument = async (): Promise<ArrayBuffer> => {
   return repackDocx(document, { updateModifiedDate: false });
 };
 
+const buildTextBoxVerticalMergeCandidateDocument = async (): Promise<ArrayBuffer> => {
+  const baseline = await buildTextBoxTableDocument();
+  const document = await parseDocx(baseline, { detectVariables: false, preloadFonts: false });
+  const table = findTextBoxShape(document).textBody?.content.find(({ type }) => type === "table");
+  if (table?.type !== "table") {
+    throw new Error("expected a text-box table");
+  }
+  const firstRow = table.rows.at(0);
+  if (!firstRow?.cells.at(0)) {
+    throw new Error("expected a text-box table cell");
+  }
+  firstRow.cells.push({
+    type: "tableCell",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "run", content: [{ type: "text", text: "Peer top" }] }],
+      },
+    ],
+  });
+  table.rows.push({
+    type: "tableRow",
+    cells: [
+      {
+        type: "tableCell",
+        formatting: { verticalAlign: "bottom" },
+        content: [{ type: "paragraph", content: [] }],
+      },
+      {
+        type: "tableCell",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "run", content: [{ type: "text", text: "Peer bottom" }] }],
+          },
+        ],
+      },
+    ],
+  });
+  return repackDocx(document, { updateModifiedDate: false });
+};
+
 /** Extract the `<w:p …>…</w:p>` element that contains `needle`. */
 const paragraphContaining = (documentXml: string, needle: string): string => {
   const at = documentXml.indexOf(needle);
@@ -638,6 +680,140 @@ describe("headless docx review round-trip", () => {
     const rejected = await rejecting.toBuffer();
     expect(await partText(rejected, "word/document.xml")).not.toContain("<w:cellDel ");
     expect(rejecting.getContentAsText()).toContain("Cell value");
+  });
+
+  test("tracks, persists, accepts, and rejects an empty vertical cell merge", async () => {
+    const baseline = await buildTextBoxVerticalMergeCandidateDocument();
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "Reviewer" });
+    const target = findBlock(reviewer.snapshot().blocks, "Cell value");
+
+    const rejectedBatch = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "tracked-changes",
+      atomic: true,
+      operations: [
+        {
+          id: "merge-cells",
+          type: "mergeTableCells",
+          blockId: target.id,
+          rowCount: 2,
+        },
+        { id: "missing", type: "deleteBlock", blockId: "para-missing" },
+      ],
+    });
+    expect(rejectedBatch.status).toBe("rejected");
+    expect(rejectedBatch.applied).toEqual([]);
+    expect(reviewer.getChanges()).toEqual([]);
+
+    const result = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "tracked-changes",
+      operations: [
+        {
+          id: "merge-cells",
+          type: "mergeTableCells",
+          blockId: target.id,
+          rowCount: 2,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("committed");
+    expect(result.skipped).toEqual([]);
+    expect(result.applied).toHaveLength(1);
+    expect(typeof result.applied.at(0)?.revisionId).toBe("number");
+    expect(result.receipts).toEqual([
+      {
+        operationId: "merge-cells",
+        operationIndex: 0,
+        affected: [
+          {
+            type: "tableCells",
+            story: "main",
+            anchorBlockId: target.id,
+            rowCount: 2,
+            effect: "merged",
+          },
+        ],
+      },
+    ]);
+    const pendingChange = reviewer.getChanges().find(({ type }) => type === "cellMerged");
+    if (!pendingChange) {
+      throw new Error("expected a pending vertical merge");
+    }
+    expect(pendingChange.author).toBe("Reviewer");
+
+    const pending = await reviewer.toBuffer();
+    const pendingXml = await partText(pending, "word/document.xml");
+    expect(pendingXml).toContain("<w:cellMerge ");
+    expect(pendingXml).toContain('w:vMerge="cont"');
+    expect(pendingXml).toContain('w:vMergeOrig="rest"');
+    const pendingTable = findTextBoxShape(
+      await parseDocx(pending, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(pendingTable?.type).toBe("table");
+    if (pendingTable?.type !== "table") {
+      throw new Error("expected a pending table");
+    }
+    expect(pendingTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBe("restart");
+    const pendingContinuation = pendingTable.rows.at(1)?.cells.at(0);
+    expect(pendingContinuation?.formatting).toMatchObject({
+      vMerge: "continue",
+      verticalAlign: "bottom",
+    });
+    expect(pendingContinuation?.structuralChange).toMatchObject({
+      type: "tableCellMerge",
+      verticalMerge: "continue",
+      verticalMergeOriginal: "rest",
+    });
+
+    const accepting = await FolioDocxReviewer.fromBuffer(pending);
+    const acceptChange = accepting.getChanges().find(({ type }) => type === "cellMerged");
+    if (!acceptChange) {
+      throw new Error("expected the vertical merge after reopen");
+    }
+    expect(accepting.acceptChange(acceptChange)).toBe(true);
+    const accepted = await accepting.toBuffer();
+    expect(await partText(accepted, "word/document.xml")).not.toContain("<w:cellMerge ");
+    const acceptedTable = findTextBoxShape(
+      await parseDocx(accepted, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(acceptedTable?.type).toBe("table");
+    if (acceptedTable?.type !== "table") {
+      throw new Error("expected an accepted table");
+    }
+    expect(acceptedTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBe("restart");
+    const acceptedContinuation = acceptedTable.rows.at(1)?.cells.at(0);
+    expect(acceptedContinuation?.formatting).toMatchObject({
+      vMerge: "continue",
+      verticalAlign: "bottom",
+    });
+    expect(acceptedContinuation?.structuralChange).toBeUndefined();
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(pending);
+    const rejectChange = rejecting.getChanges().find(({ type }) => type === "cellMerged");
+    if (!rejectChange) {
+      throw new Error("expected the vertical merge before rejection");
+    }
+    expect(rejecting.rejectChange(rejectChange)).toBe(true);
+    const rejected = await rejecting.toBuffer();
+    expect(await partText(rejected, "word/document.xml")).not.toContain("<w:cellMerge ");
+    const rejectedTable = findTextBoxShape(
+      await parseDocx(rejected, { detectVariables: false, preloadFonts: false }),
+    ).textBody?.content.at(1);
+    expect(rejectedTable?.type).toBe("table");
+    if (rejectedTable?.type !== "table") {
+      throw new Error("expected a rejected table");
+    }
+    expect(rejectedTable.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBeUndefined();
+    const rejectedContinuation = rejectedTable.rows.at(1)?.cells.at(0);
+    expect(rejectedContinuation?.formatting?.verticalAlign).toBe("bottom");
+    expect(rejectedContinuation?.formatting?.vMerge).toBeUndefined();
+
+    if (!result.undoHandle) {
+      throw new Error("expected an undo handle");
+    }
+    expect(reviewer.undoDocumentOperations(result.undoHandle).status).toBe("undone");
   });
 
   test("tracks, persists, accepts, and rejects a vertical cell split", async () => {

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -252,14 +252,23 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         /** Stable paragraph anchor inside the column to delete. */
         blockId: string;
       }
-    | {
+    | ({
         id: string;
         type: "mergeTableCells";
-        /** Stable paragraph anchor inside one corner cell. */
+        /** Stable paragraph anchor inside the first cell. */
         blockId: string;
-        /** Stable paragraph anchor inside the opposite corner cell. */
-        endBlockId: string;
-      }
+      } & (
+        | {
+            /** Stable paragraph anchor inside the opposite corner cell. */
+            endBlockId: string;
+            rowCount?: never;
+          }
+        | {
+            /** Number of grid rows to merge downward from the anchored cell. */
+            rowCount: number;
+            endBlockId?: never;
+          }
+      ))
     | {
         id: string;
         type: "splitTableCell";

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -56,7 +56,7 @@ describe("document operation contract", () => {
         deleteTableRow: ["direct", "tracked-changes"],
         insertTableColumn: ["direct", "tracked-changes"],
         deleteTableColumn: ["direct", "tracked-changes"],
-        mergeTableCells: ["direct"],
+        mergeTableCells: ["direct", "tracked-changes"],
         splitTableCell: ["direct", "tracked-changes"],
       },
       preconditions: ["blockTextHash"],
@@ -81,6 +81,7 @@ describe("document operation contract", () => {
       true,
     );
     expect(isFolioDocumentOperationModeSupported("mergeTableCells", "direct")).toBe(true);
+    expect(isFolioDocumentOperationModeSupported("mergeTableCells", "tracked-changes")).toBe(true);
     expect(isFolioDocumentOperationModeSupported("splitTableCell", "direct")).toBe(true);
     expect(isFolioDocumentOperationModeSupported("splitTableCell", "tracked-changes")).toBe(true);
     expect(
@@ -310,6 +311,38 @@ describe("document operation contract", () => {
     ]);
   });
 
+  test("parses and receipts a row-count cell merge target", () => {
+    const batch = {
+      version: 1,
+      mode: "tracked-changes",
+      operations: [
+        {
+          id: "merge-down",
+          type: "mergeTableCells",
+          blockId: "paragraph-10",
+          rowCount: 3,
+        },
+      ],
+    } as const;
+
+    expect(parseFolioDocumentOperationBatch(batch)).toEqual(batch);
+    expect(getFolioDocumentOperationReceipts(batch.operations, [{ id: "merge-down" }])).toEqual([
+      {
+        operationId: "merge-down",
+        operationIndex: 0,
+        affected: [
+          {
+            type: "tableCells",
+            story: "main",
+            anchorBlockId: "paragraph-10",
+            rowCount: 3,
+            effect: "merged",
+          },
+        ],
+      },
+    ]);
+  });
+
   test("rejects an unsupported serialized contract version", () => {
     expect(() => assertSupportedFolioDocumentOperationVersion(2)).toThrow(
       UnsupportedFolioDocumentOperationVersionError,
@@ -502,6 +535,38 @@ describe("document operation contract", () => {
       },
       "$.operations[0].cellTexts[1]",
       "expected a string",
+    ],
+    [
+      {
+        version: 1,
+        operations: [{ id: "1", type: "mergeTableCells", blockId: "a" }],
+      },
+      "$.operations[0]",
+      "expected exactly one of endBlockId or rowCount",
+    ],
+    [
+      {
+        version: 1,
+        operations: [
+          {
+            id: "1",
+            type: "mergeTableCells",
+            blockId: "a",
+            endBlockId: "b",
+            rowCount: 2,
+          },
+        ],
+      },
+      "$.operations[0]",
+      "expected exactly one of endBlockId or rowCount",
+    ],
+    [
+      {
+        version: 1,
+        operations: [{ id: "1", type: "mergeTableCells", blockId: "a", rowCount: 1 }],
+      },
+      "$.operations[0].rowCount",
+      "greater than or equal to 2",
     ],
   ] as const;
 

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -82,7 +82,7 @@ export const FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE = Object.freeze({
   deleteTableRow: DIRECT_AND_TRACKED_MODES,
   insertTableColumn: DIRECT_AND_TRACKED_MODES,
   deleteTableColumn: DIRECT_AND_TRACKED_MODES,
-  mergeTableCells: DIRECT_ONLY_MODES,
+  mergeTableCells: DIRECT_AND_TRACKED_MODES,
   splitTableCell: DIRECT_AND_TRACKED_MODES,
 } as const satisfies Readonly<
   Record<FolioDocumentOperationType, readonly FolioDocumentOperationMode[]>
@@ -635,14 +635,23 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
   }
 
   if (type === "mergeTableCells") {
-    assertAllowedKeys(value, path, [...COMMON_OPERATION_KEYS, "endBlockId"]);
-    return {
-      ...operationMeta,
-      id,
-      type,
-      blockId,
-      endBlockId: readString(value, "endBlockId", path),
-    };
+    assertAllowedKeys(value, path, [...COMMON_OPERATION_KEYS, "endBlockId", "rowCount"]);
+    const endBlockId = readOptionalString(value, "endBlockId", path);
+    const rawRowCount = value["rowCount"];
+    if ((endBlockId === undefined) === (rawRowCount === undefined)) {
+      return invalidBatch(path, "expected exactly one of endBlockId or rowCount");
+    }
+    if (endBlockId !== undefined) {
+      if (endBlockId.length === 0) {
+        return invalidBatch(`${path}.endBlockId`, "expected a non-empty string");
+      }
+      return { ...operationMeta, id, type, blockId, endBlockId };
+    }
+    const rowCount = readNonNegativeInteger(value, "rowCount", path);
+    if (rowCount < 2) {
+      return invalidBatch(`${path}.rowCount`, "expected an integer greater than or equal to 2");
+    }
+    return { ...operationMeta, id, type, blockId, rowCount };
   }
 
   if (type === "splitTableCell") {
@@ -749,13 +758,15 @@ export type FolioDocumentOperationAffectedTarget =
       anchorBlockId: string;
       effect: "deleted";
     }
-  | {
+  | ({
       type: "tableCells";
       story: FolioDocumentOperationStory;
       anchorBlockId: string;
-      endAnchorBlockId: string;
       effect: "merged";
-    }
+    } & (
+      | { endAnchorBlockId: string; rowCount?: never }
+      | { rowCount: number; endAnchorBlockId?: never }
+    ))
   | {
       type: "tableCell";
       story: FolioDocumentOperationStory;
@@ -935,13 +946,21 @@ const getPrimaryAffectedTarget = (
         effect: "deleted",
       };
     case "mergeTableCells":
-      return {
-        type: "tableCells",
-        story,
-        anchorBlockId: operation.blockId,
-        endAnchorBlockId: operation.endBlockId,
-        effect: "merged",
-      };
+      return operation.rowCount !== undefined
+        ? {
+            type: "tableCells",
+            story,
+            anchorBlockId: operation.blockId,
+            rowCount: operation.rowCount,
+            effect: "merged",
+          }
+        : {
+            type: "tableCells",
+            story,
+            anchorBlockId: operation.blockId,
+            endAnchorBlockId: operation.endBlockId,
+            effect: "merged",
+          };
     case "splitTableCell":
       return {
         type: "tableCell",


### PR DESCRIPTION
## Summary

- add reversible tracked vertical cell merges for empty continuation cells
- add row-count targeting and agent contract support
- cover atomic batches, receipts, undo, and save/reopen resolution

## Validation

- focused core and agent tests
- focused save/reopen test