### PR TITLE
fix: preserve paragraph fonts in table styles

### DIFF
--- a/.changeset/wicked-emus-pick.md
+++ b/.changeset/wicked-emus-pick.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve paragraph fonts when table styles add run formatting.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -953,6 +953,70 @@ describe("toProseDoc", () => {
     );
   });
 
+  test("table style run properties do not import docDefault fonts over Normal", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          docDefaults: {
+            rPr: {
+              fontFamily: { ascii: "Cambria", hAnsi: "Cambria" },
+            },
+          },
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: {
+                fontFamily: { ascii: "Aptos", hAnsi: "Aptos" },
+              },
+            },
+            {
+              styleId: "ShadedTable",
+              type: "table",
+              rPr: { color: { rgb: "365F91" } },
+              tblStylePr: [{ type: "firstRow", rPr: { bold: true } }],
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "table",
+              formatting: { styleId: "ShadedTable", look: { firstRow: true } },
+              rows: [
+                {
+                  cells: [
+                    {
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [{ type: "text", text: "Styled cell" }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const text = doc.firstChild?.firstChild?.firstChild?.firstChild?.firstChild;
+
+    expect(text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii).toBe("Aptos");
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(true);
+    expect(text?.marks.find((mark) => mark.type.name === "textColor")?.attrs.rgb).toBe("365F91");
+  });
+
   test("resolves themed table-cell fills while preserving their OOXML metadata", () => {
     const shading = {
       pattern: "clear",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -266,7 +266,7 @@ function convertParagraph(
     styleRunFormatting = resolved.runFormatting;
   }
 
-  const paragraphRunFormatting = resolveParagraphMarkRunFormatting(
+  const paragraphRunFormatting = resolveRunFormattingWithoutDefaults(
     paragraph.formatting?.runProperties,
     styleResolver,
   );
@@ -859,10 +859,10 @@ function resolveTableStyleConditional(
   }
 
   const runPropsFromPpr = conditional.pPr?.runProperties
-    ? resolveTextFormatting(conditional.pPr.runProperties, styleResolver)
+    ? resolveRunFormattingWithoutDefaults(conditional.pPr.runProperties, styleResolver)
     : undefined;
   const resolvedRpr = conditional.rPr
-    ? resolveTextFormatting(conditional.rPr, styleResolver)
+    ? resolveRunFormattingWithoutDefaults(conditional.rPr, styleResolver)
     : undefined;
   const mergedRunProps = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
   const paragraphSpacingOverlay = extractTableParagraphSpacingOverlay(conditional.pPr);
@@ -894,9 +894,11 @@ function resolveTableBaseStyle(
   }
 
   const runPropsFromPpr = style.pPr?.runProperties
-    ? resolveTextFormatting(style.pPr.runProperties, styleResolver)
+    ? resolveRunFormattingWithoutDefaults(style.pPr.runProperties, styleResolver)
     : undefined;
-  const resolvedRpr = style.rPr ? resolveTextFormatting(style.rPr, styleResolver) : undefined;
+  const resolvedRpr = style.rPr
+    ? resolveRunFormattingWithoutDefaults(style.rPr, styleResolver)
+    : undefined;
   const mergedRunProps = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
   const paragraphSpacingOverlay = extractTableParagraphSpacingOverlay(style.pPr);
 
@@ -1110,7 +1112,12 @@ function resolveTextFormatting(
   return mergeTextFormatting(styleFormatting, formatting);
 }
 
-function resolveParagraphMarkRunFormatting(
+/**
+ * Resolve an embedded character-style reference without importing
+ * `docDefaults`. The caller already has the paragraph cascade, including
+ * document defaults, and will layer these own properties over it.
+ */
+function resolveRunFormattingWithoutDefaults(
   formatting: TextFormatting | undefined,
   styleResolver: StyleEngine | null,
 ): TextFormatting | undefined {
@@ -1144,7 +1151,7 @@ function resolveParagraphDefaultTextFormatting(
     options.includeParagraphMarkRunProperties === false ? undefined : formatting?.runProperties;
   const paragraphRunProperties = rawParagraphMarkRpr
     ? stripParagraphMarkOnlyFormatting(
-        resolveParagraphMarkRunFormatting(rawParagraphMarkRpr, styleResolver) ?? {},
+        resolveRunFormattingWithoutDefaults(rawParagraphMarkRpr, styleResolver) ?? {},
       )
     : undefined;
 


### PR DESCRIPTION
Resolve embedded run properties from table styles without importing document defaults over the already-resolved paragraph cascade. Add synthetic coverage for base and conditional table run properties, plus the required patch changeset.