### PR TITLE
feat: edit footnote and endnote stories

### DIFF
--- a/.changeset/bright-notes-edit.md
+++ b/.changeset/bright-notes-edit.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-react": minor
+"@stll/folio-vue": minor
+---
+
+Add shared editable footnote and endnote stories with matching React and Vue surfaces.

--- a/api-reports/vue/composables.api.md
+++ b/api-reports/vue/composables.api.md
@@ -30,6 +30,7 @@ import { Layout } from '@stll/folio-core/layout-engine/types';
 import { LayoutSelectionGate } from '@stll/folio-core/paged-layout/LayoutSelectionGate';
 import { MaybeRefOrGetter } from 'vue';
 import { Measure } from '@stll/folio-core/layout-engine/types';
+import { NoteStoryKey } from '@stll/folio-core/controller/noteEditorManager';
 import { ParsedClipboardContent } from '@stll/folio-core/utils/clipboard';
 import { Plugin as Plugin_2 } from 'prosemirror-state';
 import { ProseMirrorFindMatch } from '@stll/folio-core/prosemirror/findReplaceSelection';
@@ -121,6 +122,7 @@ export type UseDocxEditorCollaboration = HiddenProseMirrorCollaboration & {
 export type UseDocxEditorOptions = {
     hiddenContainer: Ref<HTMLElement | null>;
     hiddenHeaderFooterContainer?: Ref<HTMLElement | null>;
+    noteEditorContainer?: Ref<HTMLElement | null>;
     pagesContainer: Ref<HTMLElement | null>;
     readOnly?: MaybeRefOrGetter<boolean>;
     pageGap?: number;
@@ -155,6 +157,7 @@ export type UseDocxEditorReturn = {
     editorState: Ref<EditorState | null>;
     remoteSelections: Ref<HiddenProseMirrorRemoteSelection[]>;
     headerFooterSelection: Ref<HeaderFooterSelectionState | null>;
+    activeNoteStory: Ref<NoteStoryKey | null>;
     isReady: Ref<boolean>;
     isDirty: Ref<boolean>;
     parseError: Ref<string | null>;
@@ -171,6 +174,9 @@ export type UseDocxEditorReturn = {
     setDocument: (doc: Document_2) => void;
     getHeaderFooterView: (rId: string) => EditorView | null;
     syncHeaderFooterViews: () => void;
+    openNoteStory: (story: NoteStoryKey) => void;
+    closeNoteStory: () => void;
+    getActiveNoteView: () => EditorView | null;
     getCommands: () => CommandMap;
     focus: () => void;
     reLayout: () => void;

--- a/packages/core/src/controller/noteEditorManager.test.ts
+++ b/packages/core/src/controller/noteEditorManager.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document } from "../types/document";
+import { enumerateDocumentNoteStories } from "./noteEditorManager";
+
+describe("note editor story identity", () => {
+  test("keeps footnote and endnote ids in separate namespaces", () => {
+    const document: Document = {
+      package: {
+        document: { content: [] },
+        footnotes: [{ type: "footnote", id: 4, content: [] }],
+        endnotes: [{ type: "endnote", id: 4, content: [] }],
+      },
+    };
+
+    expect(enumerateDocumentNoteStories(document)).toEqual([
+      { kind: "footnote", noteId: 4 },
+      { kind: "endnote", noteId: 4 },
+    ]);
+  });
+
+  test("does not expose separator stories as editable note bodies", () => {
+    const document: Document = {
+      package: {
+        document: { content: [] },
+        footnotes: [
+          { type: "footnote", id: -1, noteType: "separator", content: [] },
+          { type: "footnote", id: 2, noteType: "normal", content: [] },
+        ],
+        endnotes: [
+          { type: "endnote", id: 0, noteType: "continuationSeparator", content: [] },
+          { type: "endnote", id: 3, content: [] },
+        ],
+      },
+    };
+
+    expect(enumerateDocumentNoteStories(document)).toEqual([
+      { kind: "footnote", noteId: 2 },
+      { kind: "endnote", noteId: 3 },
+    ]);
+  });
+});

--- a/packages/core/src/controller/noteEditorManager.ts
+++ b/packages/core/src/controller/noteEditorManager.ts
@@ -3,6 +3,7 @@
 import { EditorState } from "prosemirror-state";
 import type { EditorState as EditorStateT } from "prosemirror-state";
 import type { Plugin } from "prosemirror-state";
+import type { Node as PMNode } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
 
 import { isSeparatorEndnote, isSeparatorFootnote } from "../docx/footnoteParser";
@@ -62,6 +63,7 @@ type MountedView = {
   appliedContent: BlockContent[];
   appliedNote: NoteStory;
   appliedPlugins: Plugin[];
+  appliedProseDocument: PMNode;
   appliedStyles: StyleDefinitions | null | undefined;
   appliedTheme: Theme | null | undefined;
   dirty: boolean;
@@ -91,20 +93,27 @@ const resolveNote = (document: Document | null, story: NoteStoryKey): NoteStory 
   return notes?.find(({ id }) => id === story.noteId) ?? null;
 };
 
-const buildInitialState = (
+const noteToProseDocument = (
   note: NoteStory,
   styles: StyleDefinitions | null | undefined,
   theme: Theme | null | undefined,
-  manager: ExtensionManager,
-  externalPlugins: Plugin[],
-): EditorStateT => {
+) => {
   const options: { styles?: StyleDefinitions; theme?: Theme | null } = {};
   if (styles) options.styles = styles;
   if (theme !== undefined) options.theme = theme;
+  return footnoteToProseDoc(note.content, options);
+};
+
+const buildInitialState = (
+  document: PMNode,
+  styles: StyleDefinitions | null | undefined,
+  manager: ExtensionManager,
+  externalPlugins: Plugin[],
+): EditorStateT => {
   return ensureBaseDirectionInState(
     ensureParaIdsInState(
       EditorState.create({
-        doc: footnoteToProseDoc(note.content, options),
+        doc: document,
         schema,
         plugins: [...manager.getPlugins(), ...externalPlugins, createDocumentStylesPlugin(styles)],
       }),
@@ -160,21 +169,30 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
       const existing = mounted.get(key);
       if (existing) {
         if (existing.mountNode.parentElement !== host) host.append(existing.mountNode);
-        const contentIsCurrent =
-          existing.appliedNote === note && existing.appliedContent === note.content;
+        const nextProseDocument = noteToProseDocument(note, styles, theme);
         const contextIsCurrent =
           existing.appliedStyles === styles &&
           existing.appliedTheme === theme &&
           existing.appliedPlugins === externalPlugins;
-        if (contentIsCurrent && contextIsCurrent) continue;
+        const referencesAreCurrent =
+          existing.appliedNote === note && existing.appliedContent === note.content;
+        const contentIsCurrent =
+          referencesAreCurrent || existing.appliedProseDocument.eq(nextProseDocument);
+        if (contentIsCurrent && contextIsCurrent) {
+          existing.appliedNote = note;
+          existing.appliedContent = note.content;
+          existing.appliedProseDocument = nextProseDocument;
+          continue;
+        }
         existing.view.updateState(
-          buildInitialState(note, styles, theme, existing.manager, externalPlugins),
+          buildInitialState(nextProseDocument, styles, existing.manager, externalPlugins),
         );
         existing.appliedNote = note;
         existing.appliedContent = note.content;
         existing.appliedStyles = styles;
         existing.appliedTheme = theme;
         existing.appliedPlugins = externalPlugins;
+        existing.appliedProseDocument = nextProseDocument;
         existing.dirty = false;
         continue;
       }
@@ -186,8 +204,9 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
       mountNode.dataset["noteKind"] = storyKey.kind;
       mountNode.dataset["noteId"] = String(storyKey.noteId);
       host.append(mountNode);
+      const proseDocument = noteToProseDocument(note, styles, theme);
       const view = new EditorView(mountNode, {
-        state: buildInitialState(note, styles, theme, manager, externalPlugins),
+        state: buildInitialState(proseDocument, styles, manager, externalPlugins),
         dispatchTransaction(transaction) {
           view.updateState(view.state.apply(transaction));
           const mountedStory = mounted.get(key);
@@ -204,6 +223,7 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
         appliedContent: note.content,
         appliedNote: note,
         appliedPlugins: externalPlugins,
+        appliedProseDocument: proseDocument,
         appliedStyles: styles,
         appliedTheme: theme,
         dirty: false,
@@ -251,6 +271,11 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
           footnotes[index] = updated;
           story.appliedNote = updated;
           story.appliedContent = updated.content;
+          story.appliedProseDocument = noteToProseDocument(
+            updated,
+            story.appliedStyles,
+            story.appliedTheme,
+          );
           continue;
         }
         const index = endnotes?.findIndex(({ id }) => id === story.note.noteId) ?? -1;
@@ -264,6 +289,11 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
         endnotes[index] = updated;
         story.appliedNote = updated;
         story.appliedContent = updated.content;
+        story.appliedProseDocument = noteToProseDocument(
+          updated,
+          story.appliedStyles,
+          story.appliedTheme,
+        );
       }
       if (!footnotesChanged && !endnotesChanged) return document;
       return {

--- a/packages/core/src/controller/noteEditorManager.ts
+++ b/packages/core/src/controller/noteEditorManager.ts
@@ -262,9 +262,10 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
         if (story.note.kind === "footnote") {
           const index = footnotes?.findIndex(({ id }) => id === story.note.noteId) ?? -1;
           const current = index === -1 ? null : footnotes?.at(index);
-          if (!current) continue;
+          if (!current || !footnotes) continue;
           if (!footnotesChanged) {
-            footnotes = [...(footnotes ?? [])];
+            const copiedFootnotes = [...footnotes];
+            footnotes = copiedFootnotes;
             footnotesChanged = true;
           }
           const updated: Footnote = { ...current, content: proseDocToBlocks(story.view.state.doc) };
@@ -280,9 +281,10 @@ export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditor
         }
         const index = endnotes?.findIndex(({ id }) => id === story.note.noteId) ?? -1;
         const current = index === -1 ? null : endnotes?.at(index);
-        if (!current) continue;
+        if (!current || !endnotes) continue;
         if (!endnotesChanged) {
-          endnotes = [...(endnotes ?? [])];
+          const copiedEndnotes = [...endnotes];
+          endnotes = copiedEndnotes;
           endnotesChanged = true;
         }
         const updated: Endnote = { ...current, content: proseDocToBlocks(story.view.state.doc) };

--- a/packages/core/src/controller/noteEditorManager.ts
+++ b/packages/core/src/controller/noteEditorManager.ts
@@ -1,0 +1,280 @@
+/** Framework-neutral lifecycle owner for editable footnote and endnote stories. */
+
+import { EditorState } from "prosemirror-state";
+import type { EditorState as EditorStateT } from "prosemirror-state";
+import type { Plugin } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+
+import { isSeparatorEndnote, isSeparatorFootnote } from "../docx/footnoteParser";
+import { proseDocToBlocks } from "../prosemirror/conversion/fromProseDoc";
+import { footnoteToProseDoc } from "../prosemirror/conversion/toProseDoc";
+import { ExtensionManager } from "../prosemirror/extensions/ExtensionManager";
+import { ensureBaseDirectionInState } from "../prosemirror/extensions/features/AutoBidiDetectionExtension";
+import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
+import { createStarterKit } from "../prosemirror/extensions/StarterKit";
+import { createDocumentStylesPlugin } from "../prosemirror/plugins/documentStyles";
+import { schema } from "../prosemirror/schema";
+import type {
+  BlockContent,
+  Document,
+  Endnote,
+  Footnote,
+  StyleDefinitions,
+  Theme,
+} from "../types/document";
+
+export type NoteStoryKind = "footnote" | "endnote";
+
+export type NoteStoryKey = {
+  kind: NoteStoryKind;
+  noteId: number;
+};
+
+export type NoteEditorTransaction = NoteStoryKey & {
+  docChanged: boolean;
+  selectionChanged: boolean;
+  view: EditorView;
+};
+
+export type NoteEditorManagerDeps = {
+  getDocument: () => Document | null;
+  getHost: () => HTMLElement | null;
+  getPlugins?: (() => Plugin[]) | undefined;
+  getStyles: () => StyleDefinitions | null | undefined;
+  getTheme: () => Theme | null | undefined;
+  onTransaction?: ((transaction: NoteEditorTransaction) => void) | undefined;
+};
+
+export type NoteEditorManager = {
+  activate: (story: NoteStoryKey | null) => EditorView | null;
+  destroy: () => void;
+  getActive: () => NoteStoryKey | null;
+  getView: (story: NoteStoryKey) => EditorView | null;
+  listStories: () => NoteStoryKey[];
+  snapshotDocument: (document: Document) => Document;
+  sync: () => void;
+};
+
+type NoteStory = Footnote | Endnote;
+const EMPTY_PLUGINS: Plugin[] = [];
+
+type MountedView = {
+  appliedContent: BlockContent[];
+  appliedNote: NoteStory;
+  appliedPlugins: Plugin[];
+  appliedStyles: StyleDefinitions | null | undefined;
+  appliedTheme: Theme | null | undefined;
+  dirty: boolean;
+  manager: ExtensionManager;
+  mountNode: HTMLElement;
+  note: NoteStoryKey;
+  view: EditorView;
+};
+
+const storyMapKey = ({ kind, noteId }: NoteStoryKey): string => `${kind}:${String(noteId)}`;
+
+const isNormalFootnote = (note: Footnote): boolean => !isSeparatorFootnote(note);
+const isNormalEndnote = (note: Endnote): boolean => !isSeparatorEndnote(note);
+
+export const enumerateDocumentNoteStories = (document: Document | null): NoteStoryKey[] => [
+  ...(document?.package.footnotes ?? [])
+    .filter(isNormalFootnote)
+    .map(({ id }) => ({ kind: "footnote" as const, noteId: id })),
+  ...(document?.package.endnotes ?? [])
+    .filter(isNormalEndnote)
+    .map(({ id }) => ({ kind: "endnote" as const, noteId: id })),
+];
+
+const resolveNote = (document: Document | null, story: NoteStoryKey): NoteStory | null => {
+  const notes =
+    story.kind === "footnote" ? document?.package.footnotes : document?.package.endnotes;
+  return notes?.find(({ id }) => id === story.noteId) ?? null;
+};
+
+const buildInitialState = (
+  note: NoteStory,
+  styles: StyleDefinitions | null | undefined,
+  theme: Theme | null | undefined,
+  manager: ExtensionManager,
+  externalPlugins: Plugin[],
+): EditorStateT => {
+  const options: { styles?: StyleDefinitions; theme?: Theme | null } = {};
+  if (styles) options.styles = styles;
+  if (theme !== undefined) options.theme = theme;
+  return ensureBaseDirectionInState(
+    ensureParaIdsInState(
+      EditorState.create({
+        doc: footnoteToProseDoc(note.content, options),
+        schema,
+        plugins: [...manager.getPlugins(), ...externalPlugins, createDocumentStylesPlugin(styles)],
+      }),
+    ),
+  );
+};
+
+export const createNoteEditorManager = (deps: NoteEditorManagerDeps): NoteEditorManager => {
+  const mounted = new Map<string, MountedView>();
+  let active: NoteStoryKey | null = null;
+
+  const updateVisibility = (): void => {
+    const activeKey = active ? storyMapKey(active) : null;
+    for (const [key, story] of mounted) {
+      story.mountNode.hidden = key !== activeKey;
+    }
+  };
+
+  const destroyMounted = (story: MountedView): void => {
+    story.view.destroy();
+    story.manager.destroy();
+    story.mountNode.remove();
+  };
+
+  const destroy = (): void => {
+    for (const story of mounted.values()) destroyMounted(story);
+    mounted.clear();
+    active = null;
+  };
+
+  const sync = (): void => {
+    const host = deps.getHost();
+    if (!host) return;
+    const document = deps.getDocument();
+    const styles = deps.getStyles();
+    const theme = deps.getTheme();
+    const externalPlugins = deps.getPlugins?.() ?? EMPTY_PLUGINS;
+    const wanted = new Map(
+      enumerateDocumentNoteStories(document).map((story) => [storyMapKey(story), story] as const),
+    );
+    const activeKey = active ? storyMapKey(active) : null;
+
+    for (const [key, story] of mounted) {
+      if (wanted.has(key)) continue;
+      destroyMounted(story);
+      mounted.delete(key);
+    }
+
+    for (const [key, storyKey] of wanted) {
+      if (!mounted.has(key) && key !== activeKey) continue;
+      const note = resolveNote(document, storyKey);
+      if (!note) continue;
+      const existing = mounted.get(key);
+      if (existing) {
+        if (existing.mountNode.parentElement !== host) host.append(existing.mountNode);
+        const contentIsCurrent =
+          existing.appliedNote === note && existing.appliedContent === note.content;
+        const contextIsCurrent =
+          existing.appliedStyles === styles &&
+          existing.appliedTheme === theme &&
+          existing.appliedPlugins === externalPlugins;
+        if (contentIsCurrent && contextIsCurrent) continue;
+        existing.view.updateState(
+          buildInitialState(note, styles, theme, existing.manager, externalPlugins),
+        );
+        existing.appliedNote = note;
+        existing.appliedContent = note.content;
+        existing.appliedStyles = styles;
+        existing.appliedTheme = theme;
+        existing.appliedPlugins = externalPlugins;
+        existing.dirty = false;
+        continue;
+      }
+
+      const manager = new ExtensionManager(createStarterKit());
+      manager.buildSchema();
+      manager.initializeRuntime();
+      const mountNode = host.ownerDocument.createElement("div");
+      mountNode.dataset["noteKind"] = storyKey.kind;
+      mountNode.dataset["noteId"] = String(storyKey.noteId);
+      host.append(mountNode);
+      const view = new EditorView(mountNode, {
+        state: buildInitialState(note, styles, theme, manager, externalPlugins),
+        dispatchTransaction(transaction) {
+          view.updateState(view.state.apply(transaction));
+          const mountedStory = mounted.get(key);
+          if (mountedStory && transaction.docChanged) mountedStory.dirty = true;
+          deps.onTransaction?.({
+            ...storyKey,
+            docChanged: transaction.docChanged,
+            selectionChanged: transaction.selectionSet,
+            view,
+          });
+        },
+      });
+      mounted.set(key, {
+        appliedContent: note.content,
+        appliedNote: note,
+        appliedPlugins: externalPlugins,
+        appliedStyles: styles,
+        appliedTheme: theme,
+        dirty: false,
+        manager,
+        mountNode,
+        note: storyKey,
+        view,
+      });
+    }
+    if (active && !wanted.has(storyMapKey(active))) active = null;
+    updateVisibility();
+  };
+
+  return {
+    activate: (story) => {
+      active = story;
+      sync();
+      if (!story) return null;
+      const view = mounted.get(storyMapKey(story))?.view ?? null;
+      if (view) return view;
+      active = null;
+      updateVisibility();
+      return null;
+    },
+    destroy,
+    getActive: () => active,
+    getView: (story) => mounted.get(storyMapKey(story))?.view ?? null,
+    listStories: () => enumerateDocumentNoteStories(deps.getDocument()),
+    snapshotDocument: (document) => {
+      let footnotes = document.package.footnotes;
+      let endnotes = document.package.endnotes;
+      let footnotesChanged = false;
+      let endnotesChanged = false;
+      for (const story of mounted.values()) {
+        if (!story.dirty) continue;
+        if (story.note.kind === "footnote") {
+          const index = footnotes?.findIndex(({ id }) => id === story.note.noteId) ?? -1;
+          const current = index === -1 ? null : footnotes?.at(index);
+          if (!current) continue;
+          if (!footnotesChanged) {
+            footnotes = [...(footnotes ?? [])];
+            footnotesChanged = true;
+          }
+          const updated: Footnote = { ...current, content: proseDocToBlocks(story.view.state.doc) };
+          footnotes[index] = updated;
+          story.appliedNote = updated;
+          story.appliedContent = updated.content;
+          continue;
+        }
+        const index = endnotes?.findIndex(({ id }) => id === story.note.noteId) ?? -1;
+        const current = index === -1 ? null : endnotes?.at(index);
+        if (!current) continue;
+        if (!endnotesChanged) {
+          endnotes = [...(endnotes ?? [])];
+          endnotesChanged = true;
+        }
+        const updated: Endnote = { ...current, content: proseDocToBlocks(story.view.state.doc) };
+        endnotes[index] = updated;
+        story.appliedNote = updated;
+        story.appliedContent = updated.content;
+      }
+      if (!footnotesChanged && !endnotesChanged) return document;
+      return {
+        ...document,
+        package: {
+          ...document.package,
+          ...(footnotesChanged && footnotes ? { footnotes } : {}),
+          ...(endnotesChanged && endnotes ? { endnotes } : {}),
+        },
+      };
+    },
+    sync,
+  };
+};

--- a/packages/core/src/layout-bridge/dom/noteStoryDom.test.ts
+++ b/packages/core/src/layout-bridge/dom/noteStoryDom.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { findNoteStoryForTarget } from "./noteStoryDom";
+
+const target = (dataset: Record<string, string>) => ({
+  closest: () => ({ dataset }),
+});
+
+describe("painted note story identity", () => {
+  test("resolves both note namespaces from a reference or body ancestor", () => {
+    expect(findNoteStoryForTarget(target({ noteKind: "footnote", noteId: "12" }))).toEqual({
+      kind: "footnote",
+      noteId: 12,
+    });
+    expect(findNoteStoryForTarget(target({ noteKind: "endnote", noteId: "12" }))).toEqual({
+      kind: "endnote",
+      noteId: 12,
+    });
+  });
+
+  test("rejects incomplete and malformed story markers", () => {
+    expect(findNoteStoryForTarget(target({ noteKind: "footnote" }))).toBeNull();
+    expect(findNoteStoryForTarget(target({ noteKind: "comment", noteId: "2" }))).toBeNull();
+    expect(findNoteStoryForTarget(target({ noteKind: "footnote", noteId: "2x" }))).toBeNull();
+    expect(findNoteStoryForTarget(null)).toBeNull();
+  });
+});

--- a/packages/core/src/layout-bridge/dom/noteStoryDom.ts
+++ b/packages/core/src/layout-bridge/dom/noteStoryDom.ts
@@ -1,0 +1,28 @@
+/** Shared painted-DOM identity resolver for editable note stories. */
+
+import type { NoteStoryKey } from "../../controller/noteEditorManager";
+
+type NoteTarget = {
+  dataset: DOMStringMap;
+};
+
+type ClosestNoteTarget = {
+  closest: (selector: string) => NoteTarget | null;
+};
+
+const isClosestNoteTarget = (value: unknown): value is ClosestNoteTarget =>
+  typeof value === "object" &&
+  value !== null &&
+  "closest" in value &&
+  typeof value.closest === "function";
+
+export const findNoteStoryForTarget = (target: unknown): NoteStoryKey | null => {
+  if (!isClosestNoteTarget(target)) return null;
+  const noteTarget = target.closest("[data-note-kind][data-note-id]");
+  const kind = noteTarget?.dataset["noteKind"];
+  const rawNoteId = noteTarget?.dataset["noteId"] ?? "";
+  if (!/^-?\d+$/u.test(rawNoteId)) return null;
+  const noteId = Number(rawNoteId);
+  if ((kind !== "footnote" && kind !== "endnote") || !Number.isSafeInteger(noteId)) return null;
+  return { kind, noteId };
+};

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -1057,6 +1057,7 @@ describe("footnote rendering", () => {
       [
         {
           displayNumber: "1",
+          noteId: 7,
           content: {
             blocks: [tableBlock],
             measures: [tableMeasure],
@@ -1069,6 +1070,10 @@ describe("footnote rendering", () => {
     );
 
     expect(footnoteArea.textContent).toContain("Cell");
+    expect((footnoteArea as unknown as FakeElement).children.at(1)?.dataset).toMatchObject({
+      noteId: "7",
+      noteKind: "footnote",
+    });
     expect(collectPmAnchors(footnoteArea as unknown as FakeElement)).toEqual([]);
   });
 });

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -166,6 +166,8 @@ export type { HeaderFooterContent } from "../layout-engine/types";
  * A single footnote item ready for rendering at page bottom.
  */
 export type FootnoteRenderItem = {
+  /** Stable story id used by editable-note surfaces. */
+  noteId?: number;
   /** Display number (e.g. "1", "2") */
   displayNumber: string;
   /** Plain text content */
@@ -1338,6 +1340,10 @@ export function renderFootnoteArea(
   // Render each footnote
   for (const fn of footnotes) {
     const fnEl = doc.createElement("div");
+    if (fn.noteId !== undefined) {
+      fnEl.dataset["noteKind"] = "footnote";
+      fnEl.dataset["noteId"] = String(fn.noteId);
+    }
     fnEl.style.marginBottom = `${FOOTNOTE_ENTRY_MARGIN_BOTTOM}px`;
     fnEl.style.color = "var(--doc-canvas-text, #000)";
 

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -502,12 +502,18 @@ describe("renderLine box model", () => {
           superscript: true,
           underline: { style: "single" },
         },
+        {
+          kind: "text",
+          text: "4",
+          endnoteRefId: 4,
+          superscript: true,
+        },
       ],
     };
     const line: MeasuredLine = {
       fromRun: 0,
       fromChar: 0,
-      toRun: 0,
+      toRun: 1,
       toChar: 1,
       width: 10,
       ascent: 12,
@@ -530,6 +536,9 @@ describe("renderLine box model", () => {
     expect(noteMarker?.style["position"]).toBe("relative");
     expect(noteMarker?.style["top"]).toBe("-0.4em");
     expect(noteMarker?.style["textDecorationLine"]).toBeUndefined();
+    expect(noteMarker?.dataset["noteKind"]).toBe("footnote");
+    expect(noteMarker?.dataset["noteId"]).toBe("9");
+    expect(lineEl.children.at(1)?.dataset).toMatchObject({ noteKind: "endnote", noteId: "4" });
   });
 
   test("sizes superscript markers from the run font instead of the parent line", () => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -497,6 +497,14 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
   const span = doc.createElement("span");
   span.className = `${PARAGRAPH_CLASS_NAMES.run} ${PARAGRAPH_CLASS_NAMES.text}`;
 
+  if (run.footnoteRefId !== undefined) {
+    span.dataset["noteKind"] = "footnote";
+    span.dataset["noteId"] = String(run.footnoteRefId);
+  } else if (run.endnoteRefId !== undefined) {
+    span.dataset["noteKind"] = "endnote";
+    span.dataset["noteId"] = String(run.endnoteRefId);
+  }
+
   // Template fill preview substitution: the run's text is the typed value
   // already laid out in place of its {{marker}}, so only a class is needed —
   // `highlighted` paints the accent chip without altering the flowed width.

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -1030,7 +1030,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     if (hfEditPosition && hfEditorRef.current) {
       return hfEditorRef.current.getView();
     }
-    return pagedEditorRef.current?.getView();
+    return pagedEditorRef.current?.getActiveView();
   }, [hfEditPosition]);
 
   // Helper to focus the active editor
@@ -1272,6 +1272,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     const pmDoc = pagedEditorRef.current?.getDocument();
     if (pmDoc) {
       doc.package.document.content = pmDoc.package.document.content;
+      if (pmDoc.package.footnotes !== undefined) {
+        doc.package.footnotes = pmDoc.package.footnotes;
+      }
+      if (pmDoc.package.endnotes !== undefined) {
+        doc.package.endnotes = pmDoc.package.endnotes;
+      }
     } else {
       // The editor view was never instantiated, so getDocument() returned null
       // and the PM-layer auto-bidi normalization never reached this clone.
@@ -4164,6 +4170,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                         readOnly={readOnly}
                         onDocumentChange={handleDocumentChange}
                         extensionManager={extensionManager}
+                        suggestionModeActive={editingMode === "suggesting"}
+                        suggestionAuthor={author}
                         {...(onCopy !== undefined ? { onCopy } : {})}
                         {...(onCut !== undefined ? { onCut } : {})}
                         {...(onPaste !== undefined ? { onPaste } : {})}

--- a/packages/react/src/components/NoteStoryEditor.tsx
+++ b/packages/react/src/components/NoteStoryEditor.tsx
@@ -1,0 +1,211 @@
+/** Thin React surface over core's persistent note-story editor manager. */
+
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import { useTranslations } from "use-intl";
+
+import type { EditorView } from "prosemirror-view";
+import type { Plugin } from "prosemirror-state";
+
+import {
+  createNoteEditorManager,
+  type NoteEditorManager,
+  type NoteStoryKey,
+} from "@stll/folio-core/controller/noteEditorManager";
+import { setSuggestionMode } from "@stll/folio-core/prosemirror/plugins/suggestionMode";
+import type { Document, StyleDefinitions, Theme } from "@stll/folio-core/types/document";
+
+import "prosemirror-view/style/prosemirror.css";
+
+export type NoteStoryEditorRef = {
+  close: () => void;
+  getActiveView: () => EditorView | null;
+  open: (story: NoteStoryKey) => void;
+  snapshotDocument: (document: Document) => Document;
+};
+
+export type NoteStoryEditorProps = {
+  document: Document | null;
+  onActiveChange: (active: boolean) => void;
+  onDocumentChange: (document: Document) => void;
+  onStoryChange: (view: EditorView, docChanged: boolean, selectionChanged: boolean) => void;
+  plugins?: Plugin[];
+  suggestionAuthor?: string;
+  suggestionModeActive?: boolean;
+  styles?: StyleDefinitions | null;
+  theme?: Theme | null;
+};
+
+const panelStyle: CSSProperties = {
+  position: "absolute",
+  right: 24,
+  bottom: 24,
+  width: "min(560px, calc(100% - 48px))",
+  maxHeight: "45%",
+  overflow: "auto",
+  zIndex: 30,
+  background: "var(--doc-canvas, #fff)",
+  color: "var(--doc-canvas-text, #000)",
+  border: "1px solid var(--doc-border, rgba(0, 0, 0, 0.18))",
+  borderRadius: 6,
+  boxShadow: "0 8px 28px rgba(0, 0, 0, 0.18)",
+};
+
+const headerStyle: CSSProperties = {
+  position: "sticky",
+  top: 0,
+  zIndex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "8px 12px",
+  background: "var(--doc-canvas, #fff)",
+  borderBottom: "1px solid var(--doc-border, rgba(0, 0, 0, 0.12))",
+  fontSize: 12,
+  fontWeight: 600,
+};
+
+const hostStyle: CSSProperties = { padding: "12px 16px", minHeight: 72 };
+const EMPTY_PLUGINS: Plugin[] = [];
+
+/* eslint-disable prefer-arrow-callback -- preserve the component name in React DevTools. */
+export const NoteStoryEditor = forwardRef<NoteStoryEditorRef, NoteStoryEditorProps>(
+  function NoteStoryEditor(
+    {
+      document,
+      onActiveChange,
+      onDocumentChange,
+      onStoryChange,
+      plugins = EMPTY_PLUGINS,
+      styles,
+      suggestionAuthor,
+      suggestionModeActive = false,
+      theme,
+    },
+    ref,
+  ) {
+    const t = useTranslations("folio");
+    const hostRef = useRef<HTMLDivElement>(null);
+    const documentRef = useRef(document);
+    const stylesRef = useRef(styles);
+    const themeRef = useRef(theme);
+    const pluginsRef = useRef(plugins);
+    const onDocumentChangeRef = useRef(onDocumentChange);
+    const onActiveChangeRef = useRef(onActiveChange);
+    const onStoryChangeRef = useRef(onStoryChange);
+    const [active, setActive] = useState<NoteStoryKey | null>(null);
+    documentRef.current = document;
+    stylesRef.current = styles;
+    themeRef.current = theme;
+    pluginsRef.current = plugins;
+    onDocumentChangeRef.current = onDocumentChange;
+    onActiveChangeRef.current = onActiveChange;
+    onStoryChangeRef.current = onStoryChange;
+
+    const managerRef = useRef<NoteEditorManager | null>(null);
+    managerRef.current ??= createNoteEditorManager({
+      getDocument: () => documentRef.current,
+      getHost: () => hostRef.current,
+      getPlugins: () => pluginsRef.current,
+      getStyles: () => stylesRef.current,
+      getTheme: () => themeRef.current,
+      onTransaction: ({ docChanged, selectionChanged, view }) => {
+        if (docChanged) {
+          const current = documentRef.current;
+          if (current) {
+            onDocumentChangeRef.current(managerRef.current?.snapshotDocument(current) ?? current);
+          }
+        }
+        onStoryChangeRef.current(view, docChanged, selectionChanged);
+      },
+    });
+
+    const footnotes = document?.package.footnotes;
+    const endnotes = document?.package.endnotes;
+    useEffect(() => {
+      const manager = managerRef.current;
+      manager?.sync();
+      if (active && !manager?.getActive()) {
+        setActive(null);
+        onActiveChangeRef.current(false);
+      }
+    }, [active, footnotes, endnotes, plugins, styles, theme]);
+
+    useEffect(() => {
+      const manager = managerRef.current;
+      if (!manager) return;
+      for (const story of manager.listStories()) {
+        const view = manager.getView(story);
+        if (view)
+          setSuggestionMode(suggestionModeActive, view.state, view.dispatch, suggestionAuthor);
+      }
+    }, [suggestionAuthor, suggestionModeActive]);
+
+    useEffect(
+      () => () => {
+        managerRef.current?.destroy();
+      },
+      [],
+    );
+
+    const closeEditor = (): void => {
+      managerRef.current?.activate(null);
+      setActive(null);
+      onActiveChangeRef.current(false);
+    };
+
+    useImperativeHandle(ref, () => ({
+      close: closeEditor,
+      getActiveView: () => {
+        const story = managerRef.current?.getActive();
+        return story ? (managerRef.current?.getView(story) ?? null) : null;
+      },
+      open: (story) => {
+        const view = managerRef.current?.activate(story);
+        if (!view) return;
+        setSuggestionMode(suggestionModeActive, view.state, view.dispatch, suggestionAuthor);
+        setActive(story);
+        onActiveChangeRef.current(true);
+        requestAnimationFrame(() => view.focus());
+      },
+      snapshotDocument: (current) => managerRef.current?.snapshotDocument(current) ?? current,
+    }));
+
+    const title = active
+      ? t(
+          active.kind === "footnote"
+            ? "dialogs.footnoteProperties.footnotes"
+            : "dialogs.footnoteProperties.endnotes",
+        )
+      : "";
+
+    return (
+      <aside
+        style={{ ...panelStyle, display: active ? "block" : "none" }}
+        aria-label={title}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+          event.preventDefault();
+          event.stopPropagation();
+          closeEditor();
+        }}
+      >
+        <div style={headerStyle}>
+          <span>{title}</span>
+          <button
+            type="button"
+            aria-label={t("common.closeDialog")}
+            onClick={closeEditor}
+            style={{ border: 0, background: "transparent", color: "inherit", cursor: "pointer" }}
+          >
+            ×
+          </button>
+        </div>
+        <div ref={hostRef} style={hostStyle} />
+      </aside>
+    );
+  },
+);
+/* eslint-enable prefer-arrow-callback */
+
+NoteStoryEditor.displayName = "NoteStoryEditor";

--- a/packages/react/src/components/NoteStoryEditor.tsx
+++ b/packages/react/src/components/NoteStoryEditor.tsx
@@ -76,70 +76,87 @@ export const NoteStoryEditor = forwardRef<NoteStoryEditorRef, NoteStoryEditorPro
       onActiveChange,
       onDocumentChange,
       onStoryChange,
-      plugins = EMPTY_PLUGINS,
+      plugins,
       styles,
       suggestionAuthor,
-      suggestionModeActive = false,
+      suggestionModeActive,
       theme,
     },
     ref,
   ) {
     const t = useTranslations("folio");
+    const resolvedPlugins = plugins ?? EMPTY_PLUGINS;
+    const isSuggestionModeActive = suggestionModeActive ?? false;
     const hostRef = useRef<HTMLDivElement>(null);
     const documentRef = useRef(document);
     const stylesRef = useRef(styles);
     const themeRef = useRef(theme);
-    const pluginsRef = useRef(plugins);
+    const pluginsRef = useRef(resolvedPlugins);
     const onDocumentChangeRef = useRef(onDocumentChange);
     const onActiveChangeRef = useRef(onActiveChange);
     const onStoryChangeRef = useRef(onStoryChange);
     const [active, setActive] = useState<NoteStoryKey | null>(null);
-    documentRef.current = document;
-    stylesRef.current = styles;
-    themeRef.current = theme;
-    pluginsRef.current = plugins;
-    onDocumentChangeRef.current = onDocumentChange;
-    onActiveChangeRef.current = onActiveChange;
-    onStoryChangeRef.current = onStoryChange;
-
     const managerRef = useRef<NoteEditorManager | null>(null);
-    managerRef.current ??= createNoteEditorManager({
-      getDocument: () => documentRef.current,
-      getHost: () => hostRef.current,
-      getPlugins: () => pluginsRef.current,
-      getStyles: () => stylesRef.current,
-      getTheme: () => themeRef.current,
-      onTransaction: ({ docChanged, selectionChanged, view }) => {
-        if (docChanged) {
-          const current = documentRef.current;
-          if (current) {
-            onDocumentChangeRef.current(managerRef.current?.snapshotDocument(current) ?? current);
-          }
-        }
-        onStoryChangeRef.current(view, docChanged, selectionChanged);
-      },
-    });
 
     const footnotes = document?.package.footnotes;
     const endnotes = document?.package.endnotes;
     useEffect(() => {
+      documentRef.current = document;
+      stylesRef.current = styles;
+      themeRef.current = theme;
+      pluginsRef.current = resolvedPlugins;
+      onDocumentChangeRef.current = onDocumentChange;
+      onActiveChangeRef.current = onActiveChange;
+      onStoryChangeRef.current = onStoryChange;
+      if (managerRef.current === null) {
+        managerRef.current = createNoteEditorManager({
+          getDocument: () => documentRef.current,
+          getHost: () => hostRef.current,
+          getPlugins: () => pluginsRef.current,
+          getStyles: () => stylesRef.current,
+          getTheme: () => themeRef.current,
+          onTransaction: ({ docChanged, selectionChanged, view }) => {
+            if (docChanged) {
+              const current = documentRef.current;
+              if (current) {
+                onDocumentChangeRef.current(
+                  managerRef.current?.snapshotDocument(current) ?? current,
+                );
+              }
+            }
+            onStoryChangeRef.current(view, docChanged, selectionChanged);
+          },
+        });
+      }
       const manager = managerRef.current;
-      manager?.sync();
+      manager.sync();
       if (active && !manager?.getActive()) {
         setActive(null);
         onActiveChangeRef.current(false);
       }
-    }, [active, footnotes, endnotes, plugins, styles, theme]);
+    }, [
+      active,
+      document,
+      endnotes,
+      footnotes,
+      onActiveChange,
+      onDocumentChange,
+      onStoryChange,
+      resolvedPlugins,
+      styles,
+      theme,
+    ]);
 
     useEffect(() => {
       const manager = managerRef.current;
       if (!manager) return;
       for (const story of manager.listStories()) {
         const view = manager.getView(story);
-        if (view)
-          setSuggestionMode(suggestionModeActive, view.state, view.dispatch, suggestionAuthor);
+        if (view) {
+          setSuggestionMode(isSuggestionModeActive, view.state, view.dispatch, suggestionAuthor);
+        }
       }
-    }, [suggestionAuthor, suggestionModeActive]);
+    }, [isSuggestionModeActive, suggestionAuthor]);
 
     useEffect(
       () => () => {
@@ -163,7 +180,7 @@ export const NoteStoryEditor = forwardRef<NoteStoryEditorRef, NoteStoryEditorPro
       open: (story) => {
         const view = managerRef.current?.activate(story);
         if (!view) return;
-        setSuggestionMode(suggestionModeActive, view.state, view.dispatch, suggestionAuthor);
+        setSuggestionMode(isSuggestionModeActive, view.state, view.dispatch, suggestionAuthor);
         setActive(story);
         onActiveChangeRef.current(true);
         requestAnimationFrame(() => view.focus());

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -3029,6 +3029,11 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       [scheduleLayout],
     );
 
+    const handleNoteDocumentChange = useCallback((updated: Document) => {
+      onDocumentChangeRef.current?.(updated);
+      folioEmitterRef.current.emit("docChange", updated);
+    }, []);
+
     // Clear HF caret state + cross-surface drag state on any hfEditMode
     // transition. Without this, dragAnchorRef leftover from the previous
     // surface lets a Shift-click resolve an anchor in the wrong PM
@@ -5816,7 +5821,6 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         <HiddenHeaderFooterPMs
           ref={hfPMsRef}
           document={document}
-          onActiveChange={setNoteStoryActive}
           onTransaction={handleHfPmTransaction}
           {...(styles !== undefined ? { styles } : {})}
           {...(_theme !== undefined ? { theme: _theme } : {})}
@@ -5825,10 +5829,8 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         <NoteStoryEditor
           ref={noteEditorRef}
           document={document}
-          onDocumentChange={(updated) => {
-            onDocumentChangeRef.current?.(updated);
-            folioEmitterRef.current.emit("docChange", updated);
-          }}
+          onActiveChange={setNoteStoryActive}
+          onDocumentChange={handleNoteDocumentChange}
           onStoryChange={handleNoteStoryTransaction}
           plugins={noteStoryPlugins}
           suggestionModeActive={suggestionModeActive}

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -30,15 +30,19 @@ import { createPortal } from "react-dom";
 import type { Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction, Plugin } from "prosemirror-state";
+import { redo as historyRedo, undo as historyUndo } from "prosemirror-history";
 import { CellSelection } from "prosemirror-tables";
 import type { EditorView } from "prosemirror-view";
 
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
+import { NoteStoryEditor } from "../components/NoteStoryEditor";
+import type { NoteStoryEditorRef } from "../components/NoteStoryEditor";
 import type { AISuggestion } from "@stll/folio-core/ai-suggestions/types";
 import { createFolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { FolioEditor } from "@stll/folio-core/controller/folioEditor";
 import { createFolioEditorEmitter } from "@stll/folio-core/controller/folioEditorEvents";
+import { suggestionModeKey } from "@stll/folio-core/prosemirror/plugins/suggestionMode";
 import { createLatestRequestGate } from "@stll/folio-core/controller/latestRequestGate";
 import { runLayoutPipeline as runLayoutPipelineCompute } from "@stll/folio-core/controller/layoutPipeline";
 import {
@@ -75,6 +79,7 @@ import {
   findHfSlotForTarget,
   findHfSlotKindForTarget,
 } from "@stll/folio-core/layout-bridge/dom/findHfPmSpans";
+import { findNoteStoryForTarget } from "@stll/folio-core/layout-bridge/dom/noteStoryDom";
 import { clickToPosition } from "@stll/folio-core/layout-bridge/engine/clickToPosition";
 import {
   hitTestFragment,
@@ -296,6 +301,10 @@ export type PagedEditorProps = {
   collaboration?: HiddenProseMirrorCollaboration | undefined;
   /** Extension manager for plugins/schema/commands (optional — falls back to default) */
   extensionManager?: ExtensionManager;
+  /** Current tracked-editing state for secondary note stories. */
+  suggestionModeActive?: boolean;
+  /** Author attached to tracked edits made inside note stories. */
+  suggestionAuthor?: string;
   /** Callback when header or footer is double-clicked for editing. Pass
    * `undefined` to disable header/footer editing entirely. */
   onHeaderFooterDoubleClick?:
@@ -356,6 +365,8 @@ export type PagedEditorRef = {
   getState: () => EditorState | null;
   /** Get the ProseMirror EditorView. */
   getView: () => EditorView | null;
+  /** Get the currently focused body or note-story view. */
+  getActiveView: () => EditorView | null;
   /**
    * Look up the persistent hidden HF EditorView by `rId`. Returns null when
    * the slot isn't mounted (e.g. document has no HF for that rId, or the
@@ -1328,6 +1339,7 @@ function buildFootnoteRenderItems(
 
       items.push({
         displayNumber: String(displayNum),
+        noteId: fnId,
         text,
         ...(content
           ? {
@@ -1391,6 +1403,8 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       showTemplateDirectives = true,
       collaboration,
       extensionManager,
+      suggestionModeActive = false,
+      suggestionAuthor,
       onHeaderFooterDoubleClick,
       hfEditMode,
       onBodyClick,
@@ -1425,7 +1439,17 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     const folioEmitterRef = useRef(createFolioEditorEmitter());
     const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
     const hfPMsRef = useRef<HiddenHeaderFooterPMsRef>(null);
+    const noteEditorRef = useRef<NoteStoryEditorRef>(null);
+    const [noteStoryActive, setNoteStoryActive] = useState(false);
     const painterRef = useRef<LayoutPainter | null>(null);
+    const noteStoryPlugins = useMemo(
+      () => externalPlugins.filter(({ key }) => key === suggestionModeKey.key),
+      [externalPlugins],
+    );
+
+    useEffect(() => {
+      if (readOnly) noteEditorRef.current?.close();
+    }, [readOnly]);
 
     // Visual line navigation (ArrowUp/ArrowDown with sticky X)
     const { handlePMKeyDown } = useVisualLineNavigation({ pagesContainerRef });
@@ -2990,6 +3014,21 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       [scheduleLayout, ensureHiddenEditorView],
     );
 
+    const handleNoteStoryTransaction = useCallback(
+      (view: EditorView, docChanged: boolean, selectionChanged: boolean) => {
+        if (docChanged) {
+          const bodyState = hiddenPMRef.current?.getState();
+          if (bodyState) scheduleLayout(bodyState, null);
+        }
+        if (docChanged || selectionChanged) {
+          const { from, to } = view.state.selection;
+          onSelectionChangeRef.current?.(from, to);
+          folioEmitterRef.current.emit("selectionChange", { from, to });
+        }
+      },
+      [scheduleLayout],
+    );
+
     // Clear HF caret state + cross-surface drag state on any hfEditMode
     // transition. Without this, dragAnchorRef leftover from the previous
     // surface lets a Shift-click resolve an anchor in the wrong PM
@@ -3203,7 +3242,6 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         if (!target) {
           return;
         }
-
         if (target.type === "position") {
           scrollToPositionImpl(target.pmPos);
           return;
@@ -3366,6 +3404,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         if (!target) {
           return;
         }
+        noteEditorRef.current?.close();
 
         // Portaled descendants (Dialog, Combobox) are filtered upstream by
         // `containedHandler(pagesContainerRef, …)` at the JSX site.
@@ -4386,6 +4425,15 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         if (!target) {
           return;
         }
+        if (!readOnly && e.detail === 2) {
+          const story = findNoteStoryForTarget(target);
+          if (story) {
+            e.preventDefault();
+            e.stopPropagation();
+            noteEditorRef.current?.open(story);
+            return;
+          }
+        }
         // Portaled descendants (Dialog, Combobox) are filtered upstream by
         // `containedHandler(pagesContainerRef, …)` at the JSX site.
         // Handle hyperlink clicks (single-click only, not drag-to-select)
@@ -4739,7 +4787,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         // HF host marks each view's mount node with `data-hf-r-id`; once
         // an HF view holds focus, the body PM redirect would immediately
         // bounce keystrokes off it (Codex #487 P1).
-        if (e.target instanceof HTMLElement && e.target.closest("[data-hf-r-id]")) {
+        if (
+          e.target instanceof HTMLElement &&
+          e.target.closest("[data-hf-r-id], [data-note-kind][data-note-id]")
+        ) {
           return;
         }
         // Portaled descendants (Dialog, Combobox) are filtered upstream
@@ -4955,7 +5006,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         // landing under the cursor in the document instead of the active
         // HF). Mirrors the focus / mousedown guards in handleContainerFocus
         // and handleContainerMouseDown (Codex #487 P1: 21:12 review).
-        if (e.target instanceof HTMLElement && e.target.closest("[data-hf-r-id]")) {
+        if (
+          e.target instanceof HTMLElement &&
+          e.target.closest("[data-hf-r-id], [data-note-kind][data-note-id]")
+        ) {
           return;
         }
 
@@ -5058,7 +5112,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         }
         // Don't steal focus from the persistent hidden HF EditorView host
         // — see handleContainerFocus for the same guard rationale.
-        if (e.target instanceof HTMLElement && e.target.closest("[data-hf-r-id]")) {
+        if (
+          e.target instanceof HTMLElement &&
+          e.target.closest("[data-hf-r-id], [data-note-kind][data-note-id]")
+        ) {
           return;
         }
         // Focus hidden PM if clicking outside pages area. Wrapped via
@@ -5531,13 +5588,17 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           return folioEditor;
         },
         getDocument() {
-          return folioEditor.getDocument();
+          const current = folioEditor.getDocument();
+          return current ? (noteEditorRef.current?.snapshotDocument(current) ?? current) : null;
         },
         getState() {
           return folioEditor.getState();
         },
         getView() {
           return folioEditor.getView();
+        },
+        getActiveView() {
+          return noteEditorRef.current?.getActiveView() ?? folioEditor.getView();
         },
         getHfView(rId: string) {
           return hfPMsRef.current?.getView(rId) ?? null;
@@ -5552,7 +5613,9 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           ensureHiddenEditorView(options);
         },
         focus() {
-          folioEditor.focus();
+          const noteView = noteEditorRef.current?.getActiveView();
+          if (noteView) noteView.focus();
+          else folioEditor.focus();
           setIsFocused(true);
         },
         blur() {
@@ -5566,16 +5629,20 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           folioEditor.dispatch(tr);
         },
         undo() {
-          return folioEditor.undo();
+          const noteView = noteEditorRef.current?.getActiveView();
+          return noteView ? historyUndo(noteView.state, noteView.dispatch) : folioEditor.undo();
         },
         redo() {
-          return folioEditor.redo();
+          const noteView = noteEditorRef.current?.getActiveView();
+          return noteView ? historyRedo(noteView.state, noteView.dispatch) : folioEditor.redo();
         },
         canUndo() {
-          return folioEditor.canUndo();
+          const noteView = noteEditorRef.current?.getActiveView();
+          return noteView ? historyUndo(noteView.state) : folioEditor.canUndo();
         },
         canRedo() {
-          return folioEditor.canRedo();
+          const noteView = noteEditorRef.current?.getActiveView();
+          return noteView ? historyRedo(noteView.state) : folioEditor.canRedo();
         },
         setSelection(anchor: number, head?: number) {
           folioEditor.setSelection(anchor, head);
@@ -5749,7 +5816,23 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         <HiddenHeaderFooterPMs
           ref={hfPMsRef}
           document={document}
+          onActiveChange={setNoteStoryActive}
           onTransaction={handleHfPmTransaction}
+          {...(styles !== undefined ? { styles } : {})}
+          {...(_theme !== undefined ? { theme: _theme } : {})}
+        />
+
+        <NoteStoryEditor
+          ref={noteEditorRef}
+          document={document}
+          onDocumentChange={(updated) => {
+            onDocumentChangeRef.current?.(updated);
+            folioEmitterRef.current.emit("docChange", updated);
+          }}
+          onStoryChange={handleNoteStoryTransaction}
+          plugins={noteStoryPlugins}
+          suggestionModeActive={suggestionModeActive}
+          {...(suggestionAuthor !== undefined ? { suggestionAuthor } : {})}
           {...(styles !== undefined ? { styles } : {})}
           {...(_theme !== undefined ? { theme: _theme } : {})}
         />
@@ -5843,8 +5926,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
               HfCaretOverlay below owns the caret while a header/footer is
               being edited. */}
             <SelectionOverlay
-              selectionRects={hfEditMode ? EMPTY_SELECTION_RECTS : selectionRects}
-              caretPosition={hfEditMode ? null : caretPosition}
+              selectionRects={
+                hfEditMode || noteStoryActive ? EMPTY_SELECTION_RECTS : selectionRects
+              }
+              caretPosition={hfEditMode || noteStoryActive ? null : caretPosition}
               isFocused={isFocused}
               pageGap={pageGap}
               markCaretRect

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -1443,7 +1443,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     const [noteStoryActive, setNoteStoryActive] = useState(false);
     const painterRef = useRef<LayoutPainter | null>(null);
     const noteStoryPlugins = useMemo(
-      () => externalPlugins.filter(({ key }) => key === suggestionModeKey.key),
+      () => externalPlugins.filter(({ spec }) => spec.key === suggestionModeKey),
       [externalPlugins],
     );
 

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -270,6 +270,21 @@
             @remove="handleHfRemove"
           />
 
+          <aside
+            v-show="activeNoteStory"
+            class="docx-editor-vue__note-editor"
+            :aria-label="activeNoteStoryLabel"
+            @keydown.esc.stop.prevent="closeNoteStory"
+          >
+            <header class="docx-editor-vue__note-editor-header">
+              <span>{{ activeNoteStoryLabel }}</span>
+              <button type="button" :aria-label="t('common.closeDialog')" @click="closeNoteStory">
+                ×
+              </button>
+            </header>
+            <div ref="notePmRef" class="docx-editor-vue__note-editor-host" />
+          </aside>
+
           <ImageSelectionOverlay
             :image-info="selectedImage"
             :zoom="zoom"
@@ -620,6 +635,7 @@ const showOutline = ref(props.showOutline);
 const showSidebar = ref(false);
 const activeSidebarItem = ref<string | null>(null);
 const activeHeaderFooterRId = ref<string | null>(null);
+const notePmRef = ref<HTMLElement | null>(null);
 const bookmarks = shallowRef<{ name: string; label?: string }[]>([]);
 
 // Populated by `useOutlineSidebar` — collected lazily on outline open and
@@ -664,6 +680,7 @@ const {
   editorState,
   remoteSelections,
   headerFooterSelection,
+  activeNoteStory,
   isReady,
   isDirty,
   parseError,
@@ -678,12 +695,16 @@ const {
   setDocument,
   getHeaderFooterView,
   syncHeaderFooterViews,
+  openNoteStory,
+  closeNoteStory,
+  getActiveNoteView,
   getCommands,
   focus,
   reLayout,
 } = useDocxEditor({
   hiddenContainer: hiddenPmRef,
   hiddenHeaderFooterContainer: hiddenHfPmRef,
+  noteEditorContainer: notePmRef,
   pagesContainer: pagesRef,
   readOnly,
   editorMode,
@@ -735,9 +756,21 @@ const {
 
 const activeEditorView = computed(
   () =>
+    getActiveNoteView() ??
     (activeHeaderFooterRId.value ? getHeaderFooterView(activeHeaderFooterRId.value) : null) ??
     editorView.value,
 );
+
+const activeNoteStoryLabel = computed(() => {
+  const story = activeNoteStory.value;
+  if (!story) return "";
+  const label = t(
+    story.kind === "footnote"
+      ? "dialogs.footnoteProperties.footnotes"
+      : "dialogs.footnoteProperties.endnotes",
+  );
+  return label;
+});
 
 // Show the loading interstitial while a document is loading, EXCEPT when the host
 // opted into `preserveDocumentWhileLoading` and a prior document is already
@@ -841,6 +874,12 @@ const {
   getHfPmView: getHeaderFooterView,
   syncHfPMs: syncHeaderFooterViews,
   setDocument,
+  openNoteStory: (story) => {
+    openNoteStory(story);
+    selectionSync.clearOverlay();
+  },
+  closeNoteStory,
+  getActiveNoteView,
   reLayout,
   onDocumentChange: notifyDocumentChange,
   clearOverlay: selectionSync.clearOverlay,
@@ -1494,6 +1533,43 @@ defineExpose(exposed);
 .docx-editor-vue__table-insert-btn:hover {
   background: var(--doc-primary, #1a73e8);
   color: var(--doc-on-primary, #fff);
+}
+.docx-editor-vue__note-editor {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  z-index: 30;
+  width: min(560px, calc(100% - 48px));
+  max-height: 45%;
+  overflow: auto;
+  border: 1px solid var(--doc-border, rgb(0 0 0 / 18%));
+  border-radius: 6px;
+  background: var(--doc-canvas, #fff);
+  color: var(--doc-canvas-text, #000);
+  box-shadow: 0 8px 28px rgb(0 0 0 / 18%);
+}
+.docx-editor-vue__note-editor-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--doc-border, rgb(0 0 0 / 12%));
+  background: var(--doc-canvas, #fff);
+  font-size: 12px;
+  font-weight: 600;
+}
+.docx-editor-vue__note-editor-header button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.docx-editor-vue__note-editor-host {
+  min-height: 72px;
+  padding: 12px 16px;
 }
 .docx-editor-vue__add-comment-btn {
   position: absolute;

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -40,6 +40,11 @@ import type {
   HeaderFooterPartKind,
 } from "@stll/folio-core/controller/headerFooterEditorManager";
 import {
+  createNoteEditorManager,
+  type NoteEditorManager,
+  type NoteStoryKey,
+} from "@stll/folio-core/controller/noteEditorManager";
+import {
   collectRemoteSelections,
   createHiddenEditorManager,
   createHiddenEditorState,
@@ -227,6 +232,7 @@ function buildFootnoteRenderItems(
       const displayNum = content?.displayNumber ?? 0;
       items.push({
         displayNumber: String(displayNum),
+        noteId: fnId,
         text: getFootnoteText(fn),
         ...(content
           ? {
@@ -304,6 +310,8 @@ export type UseDocxEditorOptions = {
   hiddenContainer: Ref<HTMLElement | null>;
   /** Optional separate host for persistent header/footer ProseMirror views. */
   hiddenHeaderFooterContainer?: Ref<HTMLElement | null>;
+  /** Visible host for the active footnote or endnote ProseMirror story. */
+  noteEditorContainer?: Ref<HTMLElement | null>;
   /** Container element the paginated pages are painted into. */
   pagesContainer: Ref<HTMLElement | null>;
   /** Whether the editor is read-only. Reactive. */
@@ -403,6 +411,8 @@ export type UseDocxEditorReturn = {
   remoteSelections: Ref<HiddenProseMirrorRemoteSelection[]>;
   /** Selection in the currently active persistent header/footer view. */
   headerFooterSelection: Ref<HeaderFooterSelectionState | null>;
+  /** The note story currently open in the visible note editor. */
+  activeNoteStory: Ref<NoteStoryKey | null>;
   /** True once the hidden view is mounted and a document is loaded. */
   isReady: Ref<boolean>;
   /**
@@ -436,6 +446,12 @@ export type UseDocxEditorReturn = {
   getHeaderFooterView: (rId: string) => EditorView | null;
   /** Synchronize persistent header/footer views after a document-model change. */
   syncHeaderFooterViews: () => void;
+  /** Open an existing footnote or endnote story. */
+  openNoteStory: (story: NoteStoryKey) => void;
+  /** Close the visible note-story editor. */
+  closeNoteStory: () => void;
+  /** Resolve the active note-story view. */
+  getActiveNoteView: () => EditorView | null;
   /** Access the extension command map for invoking marks / nodes / features. */
   getCommands: () => CommandMap;
   /** Focus the hidden ProseMirror view. */
@@ -450,6 +466,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
   const {
     hiddenContainer,
     hiddenHeaderFooterContainer,
+    noteEditorContainer,
     pagesContainer,
     readOnly = false,
     pageGap = DEFAULT_PAGE_GAP,
@@ -487,6 +504,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
   const collaborationModules = shallowRef<CollaborationModules | null>(null);
   const remoteSelections = shallowRef<HiddenProseMirrorRemoteSelection[]>([]);
   const headerFooterSelection = shallowRef<HeaderFooterSelectionState | null>(null);
+  const activeNoteStory = shallowRef<NoteStoryKey | null>(null);
   const layout = shallowRef<Layout | null>(null);
   // Latest flow blocks + measures — the range-projection fallback (off-screen /
   // not-yet-painted ranges) needs them; the primary DOM-rect path does not.
@@ -514,6 +532,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
   // definitions). Prepended to the host's external plugins so the hidden-editor
   // manager installs it on every (re)created state.
   const suggestionPlugin = createSuggestionModePlugin(false);
+  const notePlugins = [suggestionPlugin];
   // Inline autocomplete is always installed and inert until a host dispatches
   // start/token/finish metadata. Keep its keymap ahead of extension keymaps so
   // Tab, Mod+ArrowRight, and Escape consume an active suggestion first.
@@ -579,6 +598,34 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       syncCoordinator.requestRender();
     },
   });
+  const noteEditorManagerHolder: { current: NoteEditorManager | null } = { current: null };
+  const noteEditorManager = createNoteEditorManager({
+    getHost: () => noteEditorContainer?.value ?? null,
+    getPlugins: () => notePlugins,
+    getDocument: () => docModel.value,
+    getStyles: () => docModel.value?.package.styles ?? null,
+    getTheme: () => docModel.value?.package.theme ?? null,
+    onTransaction: ({ docChanged, selectionChanged, view }) => {
+      if (docChanged) {
+        isDirty.value = true;
+        const current = docModel.value;
+        if (current) {
+          const updated = noteEditorManagerHolder.current?.snapshotDocument(current) ?? current;
+          docModel.value = updated;
+          onChange?.(updated);
+          emitter.emit("docChange", updated);
+        }
+        const bodyView = editorView.value;
+        if (bodyView) scheduler.schedule(bodyView.state, null);
+      }
+      if (docChanged || selectionChanged) {
+        onSelectionUpdate?.(view.state);
+        const { from, to } = view.state.selection;
+        emitter.emit("selectionChange", { from, to });
+      }
+    },
+  });
+  noteEditorManagerHolder.current = noteEditorManager;
 
   // ---- Layout pipeline ----------------------------------------------------
 
@@ -707,6 +754,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
       const updated = fromProseDoc(view.state.doc, base);
       docModel.value = updated;
       headerFooterManager.sync();
+      noteEditorManager.sync();
       onChange?.(updated);
       emitter.emit("docChange", updated);
     } catch (err) {
@@ -894,12 +942,19 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     if (view) {
       syncSuggestionMode(view);
     }
+    for (const story of noteEditorManager.listStories()) {
+      const noteView = noteEditorManager.getView(story);
+      if (noteView) syncSuggestionMode(noteView);
+    }
   });
 
   // Keep the hidden view's editable() ARIA state in sync with readOnly.
   watch(
     () => toValue(readOnly),
-    () => manager.syncEditable(),
+    (isReadOnly) => {
+      manager.syncEditable();
+      if (isReadOnly) closeNoteStory();
+    },
   );
 
   // Live-toggle the template directive/slash-menu pair without tearing the view
@@ -952,9 +1007,12 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     // clearing its dirty signals on document reset).
     isDirty.value = false;
     headerFooterSelection.value = null;
+    activeNoteStory.value = null;
+    noteEditorManager.activate(null);
     scheduler.dispose();
     manager.destroyView();
     headerFooterManager.sync();
+    noteEditorManager.sync();
     manager.ensureView();
     if (!manager.getView()) {
       // Host not mounted yet: paint from a precomputed state so the pages show
@@ -991,12 +1049,18 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
 
   // Recreate / repaint whenever the host mounts or the document identity flips.
   watch(
-    [hiddenContainer, pagesContainer, headerFooterHost],
+    [
+      hiddenContainer,
+      pagesContainer,
+      headerFooterHost,
+      ...(noteEditorContainer ? [noteEditorContainer] : []),
+    ],
     () => {
       if (hiddenContainer.value && docModel.value && !manager.getView()) {
         mountView();
       }
       headerFooterManager.sync();
+      noteEditorManager.sync();
     },
     { flush: "post" },
   );
@@ -1031,7 +1095,9 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     if (!view || !currentDocument) {
       return null;
     }
-    const base = headerFooterManager.snapshotDocument(currentDocument);
+    const base = noteEditorManager.snapshotDocument(
+      headerFooterManager.snapshotDocument(currentDocument),
+    );
 
     // Snapshot the editor state once, before any awaited dynamic imports, so
     // the document we serialize and the selective-save change signals are all
@@ -1098,6 +1164,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     // API's save wrapper, the single public save entry point.
     docModel.value = updatedDoc;
     headerFooterManager.sync();
+    noteEditorManager.sync();
     isDirty.value = false;
 
     return new Blob([buffer], {
@@ -1107,12 +1174,18 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
 
   function getDocument(): Document | null {
     const document = docModel.value;
-    return document ? headerFooterManager.snapshotDocument(document) : null;
+    return document
+      ? noteEditorManager.snapshotDocument(headerFooterManager.snapshotDocument(document))
+      : null;
   }
 
   function setDocument(doc: Document): void {
     docModel.value = doc;
     headerFooterManager.sync();
+    noteEditorManager.sync();
+    if (activeNoteStory.value && !noteEditorManager.getView(activeNoteStory.value)) {
+      activeNoteStory.value = null;
+    }
   }
 
   function getHeaderFooterView(rId: string): EditorView | null {
@@ -1123,12 +1196,32 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     headerFooterManager.sync();
   }
 
+  function openNoteStory(story: NoteStoryKey): void {
+    const view = noteEditorManager.activate(story);
+    if (!view) return;
+    syncSuggestionMode(view);
+    activeNoteStory.value = story;
+    requestAnimationFrame(() => view.focus());
+  }
+
+  function closeNoteStory(): void {
+    noteEditorManager.activate(null);
+    activeNoteStory.value = null;
+  }
+
+  function getActiveNoteView(): EditorView | null {
+    const story = activeNoteStory.value;
+    return story ? noteEditorManager.getView(story) : null;
+  }
+
   function getCommands(): CommandMap {
     return extensionManager.getCommands();
   }
 
   function focus(): void {
-    editorView.value?.focus();
+    const noteView = getActiveNoteView();
+    if (noteView) noteView.focus();
+    else editorView.value?.focus();
   }
 
   function reLayout(): void {
@@ -1149,6 +1242,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     manager.destroyView();
     remoteSelections.value = [];
     headerFooterManager.destroy();
+    noteEditorManager.destroy();
     extensionManager.destroy();
     editorState.value = null;
     layout.value = null;
@@ -1164,6 +1258,7 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     editorState,
     remoteSelections,
     headerFooterSelection,
+    activeNoteStory,
     isReady,
     isDirty,
     parseError,
@@ -1178,6 +1273,9 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     setDocument,
     getHeaderFooterView,
     syncHeaderFooterViews,
+    openNoteStory,
+    closeNoteStory,
+    getActiveNoteView,
     getCommands,
     focus,
     reLayout,

--- a/packages/vue/src/composables/usePagesPointer.ts
+++ b/packages/vue/src/composables/usePagesPointer.ts
@@ -14,9 +14,11 @@ import { onBeforeUnmount, onMounted, ref, shallowRef, type Ref, type ShallowRef 
 import { TextSelection, NodeSelection, type Command } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import type { Document } from "@stll/folio-core/types/document";
+import type { NoteStoryKey } from "@stll/folio-core/controller/noteEditorManager";
 import type { Layout } from "@stll/folio-core/layout-engine";
 import { findImageElement } from "@stll/folio-core/layout-painter/imageLayout";
 import { clickToPositionInHfSlot } from "@stll/folio-core/layout-bridge/dom/findHfPmSpans";
+import { findNoteStoryForTarget } from "@stll/folio-core/layout-bridge/dom/noteStoryDom";
 import { proseDocToBlocks } from "@stll/folio-core/prosemirror/conversion/fromProseDoc";
 import {
   detectTableInsertHover,
@@ -99,6 +101,10 @@ export type UsePagesPointerOptions = {
    * callers fall back to in-place mutation + `syncHfPMs()`.
    */
   setDocument: (doc: Document) => void;
+  /** Open a footnote or endnote story from a painted reference/body. */
+  openNoteStory: (story: NoteStoryKey) => void;
+  closeNoteStory: () => void;
+  getActiveNoteView: () => EditorView | null;
 };
 
 const MULTI_CLICK_DELAY = 500;
@@ -260,6 +266,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     const viewportEl = opts.pagesViewportRef.value;
     if (!viewportEl) return;
     if (!(event.target instanceof HTMLElement)) return;
+    if (event.target.closest(".docx-editor-vue__note-editor")) return;
 
     const hit = detectTableInsertHover({
       mouseX: event.clientX,
@@ -323,6 +330,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
    */
   function handlePagesClick(event: MouseEvent) {
     const el = event.target;
+    if (el instanceof HTMLElement && el.closest(".docx-editor-vue__note-editor")) return;
     const anchor = el instanceof HTMLElement ? el.closest<HTMLAnchorElement>("a[href]") : null;
     if (!anchor) return;
     event.preventDefault();
@@ -358,10 +366,18 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
   }
 
   function handlePagesDoubleClick(event: MouseEvent) {
-    if (opts.readOnly.value || !opts.showHeaderFooterEditing.value) return;
-    if (hfEdit.value) return;
+    if (opts.readOnly.value) return;
     if (!(event.target instanceof HTMLElement)) return;
     const target = event.target;
+    if (target.closest(".docx-editor-vue__note-editor")) return;
+    const noteStory = findNoteStoryForTarget(target);
+    if (noteStory) {
+      event.preventDefault();
+      event.stopPropagation();
+      opts.openNoteStory(noteStory);
+      return;
+    }
+    if (!opts.showHeaderFooterEditing.value || hfEdit.value) return;
     const headerEl = target.closest<HTMLElement>(".layout-page-header");
     const footerEl = target.closest<HTMLElement>(".layout-page-footer");
     const hfEl = headerEl ?? footerEl;
@@ -483,6 +499,12 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
     const target = event.target;
     const targetEl = target instanceof HTMLElement ? target : null;
+
+    if (targetEl?.closest(".docx-editor-vue__note-editor")) return;
+
+    if (opts.getActiveNoteView()) {
+      opts.closeNoteStory();
+    }
 
     // HF mode: clicks OUTSIDE the painted HF area close edit mode and refocus
     // the body PM. The body-PM-selection branch below also falls through, so


### PR DESCRIPTION
## Summary

- add a framework-neutral, lazy note-story editor manager
- open existing footnotes and endnotes from painted references and page-bottom bodies
- keep React and Vue save, undo/redo, suggestion-mode, and read-only behavior aligned
- persist edited note stories through full and selective save paths