### PR TITLE
fix: trace table rows in parity diagnostics

### DIFF
--- a/parity/__tests__/sourceTraceFlow.test.ts
+++ b/parity/__tests__/sourceTraceFlow.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FlowBlock } from "../../packages/core/src/layout-engine/types";
+import { traceFlowBlocks } from "../sourceTraceFlow";
+
+const TABLE_BLOCKS = [
+  {
+    kind: "table",
+    id: "table-1",
+    rows: [
+      {
+        id: "row-1",
+        cells: [
+          {
+            id: "cell-1",
+            blocks: [
+              {
+                kind: "paragraph",
+                id: "paragraph-1",
+                runs: [{ kind: "text", text: "Alpha", fontFamily: "Aptos" }],
+              },
+            ],
+          },
+          {
+            id: "cell-2",
+            blocks: [
+              {
+                kind: "paragraph",
+                id: "paragraph-2",
+                attrs: { alignment: "center" },
+                runs: [{ kind: "text", text: "Beta" }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+] as const satisfies FlowBlock[];
+
+describe("flow source tracing", () => {
+  test("matches text spanning multiple table cells and reports cell context", () => {
+    const matches = traceFlowBlocks({ blocks: TABLE_BLOCKS, query: "alpha beta", limit: 8 });
+
+    expect(matches).toHaveLength(1);
+    expect(matches.at(0)).toMatchObject({
+      type: "tableRow",
+      path: ["blocks", 0, "rows", 0],
+      tableId: "table-1",
+      rowId: "row-1",
+      rowIndex: 0,
+      cells: [
+        {
+          cellIndex: 0,
+          cellId: "cell-1",
+          text: "Alpha",
+          blocks: [{ type: "paragraph", id: "paragraph-1", text: "Alpha" }],
+        },
+        {
+          cellIndex: 1,
+          cellId: "cell-2",
+          text: "Beta",
+          blocks: [
+            {
+              type: "paragraph",
+              id: "paragraph-2",
+              text: "Beta",
+              attrs: { alignment: "center" },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("reports a paragraph inside a table alongside its row context", () => {
+    const matches = traceFlowBlocks({ blocks: TABLE_BLOCKS, query: "beta", limit: 8 });
+
+    expect(matches.map(({ type }) => type)).toEqual(["tableRow", "paragraph"]);
+    expect(matches.at(1)).toMatchObject({
+      type: "paragraph",
+      path: ["blocks", 0, "rows", 0, "cells", 1, "blocks", 0],
+      id: "paragraph-2",
+      attrs: { alignment: "center" },
+    });
+  });
+
+  test("enforces the match limit across nested blocks", () => {
+    expect(traceFlowBlocks({ blocks: TABLE_BLOCKS, query: "beta", limit: 1 })).toHaveLength(1);
+  });
+
+  test("searches complete cell text beyond the diagnostic preview", () => {
+    const longPrefix = "x".repeat(300);
+    const blocks = [
+      {
+        kind: "table",
+        id: "long-table",
+        rows: [
+          {
+            id: "long-row",
+            cells: [
+              {
+                id: "long-cell",
+                blocks: [
+                  {
+                    kind: "paragraph",
+                    id: "long-paragraph",
+                    runs: [{ kind: "text", text: `${longPrefix} needle` }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] satisfies FlowBlock[];
+
+    expect(traceFlowBlocks({ blocks, query: "needle", limit: 8 }).at(0)).toMatchObject({
+      type: "tableRow",
+      tableId: "long-table",
+    });
+  });
+});

--- a/parity/sourceTrace.ts
+++ b/parity/sourceTrace.ts
@@ -10,8 +10,8 @@ import path from "node:path";
 
 import { parseDocx } from "../packages/core/src/docx/parser";
 import { toFlowBlocks } from "../packages/core/src/layout-bridge/convert/toFlowBlocks";
-import type { FlowBlock, Run } from "../packages/core/src/layout-engine/types";
 import { toProseDoc } from "../packages/core/src/prosemirror/conversion/toProseDoc";
+import { traceFlowBlocks } from "./sourceTraceFlow";
 import { normalizeLineText } from "./textNorm";
 
 type Flags = {
@@ -169,65 +169,6 @@ const summarizePmChild = (node: PMNode, pos: number): unknown => ({
   marks: pmMarks(node),
 });
 
-const summarizeRun = (run: Run): unknown => {
-  const base = {
-    kind: run.kind,
-    pmStart: run.pmStart,
-    pmEnd: run.pmEnd,
-    fontFamily: "fontFamily" in run ? run.fontFamily : undefined,
-    fontSize: "fontSize" in run ? run.fontSize : undefined,
-    bold: "bold" in run ? run.bold : undefined,
-    allCaps: "allCaps" in run ? run.allCaps : undefined,
-    smallCaps: "smallCaps" in run ? run.smallCaps : undefined,
-  };
-  if (run.kind === "text") {
-    return { ...base, text: truncate(run.text) };
-  }
-  if (run.kind === "field") {
-    return {
-      ...base,
-      fieldType: run.fieldType,
-      instruction: run.instruction,
-      fallback: run.fallback,
-      fldLock: run.fldLock,
-    };
-  }
-  if (run.kind === "tab") {
-    return base;
-  }
-  if (run.kind === "lineBreak") {
-    return base;
-  }
-  if (run.kind === "image") {
-    return { ...base, width: run.width, height: run.height, wrapType: run.wrapType };
-  }
-  if (run.kind === "math") {
-    return { ...base, plainText: run.plainText };
-  }
-  return base;
-};
-
-const blockText = (block: FlowBlock): string => {
-  if (block.kind === "paragraph") {
-    return block.runs
-      .map((run) => {
-        if (run.kind === "text") return run.text;
-        if (run.kind === "field") return run.fallback ?? "";
-        if (run.kind === "tab") return "\t";
-        return "";
-      })
-      .join("");
-  }
-  if (block.kind === "table") {
-    return block.rows
-      .flatMap((row) => row.cells)
-      .flatMap((cell) => cell.blocks)
-      .map(blockText)
-      .join(" ");
-  }
-  return "";
-};
-
 const normalizedSearchText = (value: string): string =>
   normalizeLineText(value).toLocaleLowerCase();
 
@@ -289,18 +230,11 @@ const main = async (): Promise<void> => {
     return undefined;
   });
 
-  const flowMatches = flowBlocks
-    .map((block, index) => ({ block, index, text: blockText(block) }))
-    .filter(({ text }) => normalizedSearchText(text).includes(needle))
-    .slice(0, flags.limit)
-    .map(({ block, index, text }) => ({
-      index,
-      id: "id" in block ? block.id : undefined,
-      kind: block.kind,
-      text: truncate(text),
-      attrs: block.kind === "paragraph" ? block.attrs : undefined,
-      runs: block.kind === "paragraph" ? block.runs.map(summarizeRun) : undefined,
-    }));
+  const flowMatches = traceFlowBlocks({
+    blocks: flowBlocks,
+    query: flags.text!,
+    limit: flags.limit,
+  });
 
   console.log(
     JSON.stringify(

--- a/parity/sourceTraceFlow.ts
+++ b/parity/sourceTraceFlow.ts
@@ -56,6 +56,8 @@ type TableRowFlowMatch = {
 
 export type FlowMatch = ParagraphFlowMatch | TableRowFlowMatch;
 
+type BlockTextReader = (block: FlowBlock) => string;
+
 const truncate = (value: string, max = 240): string =>
   value.length <= max ? value : `${value.slice(0, max - 1)}…`;
 
@@ -104,29 +106,38 @@ const paragraphText = (block: ParagraphBlock): string =>
     })
     .join("");
 
-const blockText = (block: FlowBlock): string => {
-  if (block.kind === "paragraph") {
-    return paragraphText(block);
-  }
-  if (block.kind === "table") {
-    return block.rows
-      .flatMap((row) => row.cells)
-      .flatMap((cell) => cell.blocks)
-      .map(blockText)
-      .join(" ");
-  }
-  if (block.kind === "textBox") {
-    return block.content.map(blockText).join(" ");
-  }
-  return "";
+const createBlockTextReader = (): BlockTextReader => {
+  const cache = new WeakMap<FlowBlock, string>();
+  const blockText: BlockTextReader = (block) => {
+    const cached = cache.get(block);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let text = "";
+    if (block.kind === "paragraph") {
+      text = paragraphText(block);
+    } else if (block.kind === "table") {
+      text = block.rows
+        .flatMap((row) => row.cells)
+        .flatMap((cell) => cell.blocks)
+        .map(blockText)
+        .join(" ");
+    } else if (block.kind === "textBox") {
+      text = block.content.map(blockText).join(" ");
+    }
+    cache.set(block, text);
+    return text;
+  };
+  return blockText;
 };
 
-const summarizeBlock = (block: FlowBlock): FlowBlockSummary => {
+const summarizeBlock = (block: FlowBlock, blockText: BlockTextReader): FlowBlockSummary => {
   if (block.kind === "paragraph") {
     return {
       type: "paragraph",
       id: block.id,
-      text: truncate(paragraphText(block)),
+      text: truncate(blockText(block)),
       attrs: block.attrs,
       runs: block.runs.map(summarizeRun),
     };
@@ -137,36 +148,47 @@ const summarizeBlock = (block: FlowBlock): FlowBlockSummary => {
   return { type: "block", id: block.id, kind: block.kind };
 };
 
-const summarizeCell = (cell: TableCell, cellIndex: number): TableCellSummary => ({
+type SummarizeCellOptions = {
+  cell: TableCell;
+  cellIndex: number;
+  blockText: BlockTextReader;
+};
+
+const summarizeCell = ({ cell, cellIndex, blockText }: SummarizeCellOptions): TableCellSummary => ({
   cellIndex,
   cellId: cell.id,
   text: truncate(cell.blocks.map(blockText).join(" ")),
-  blocks: cell.blocks.map(summarizeBlock),
+  blocks: cell.blocks.map((block) => summarizeBlock(block, blockText)),
 });
+
+type TraceContext = {
+  needle: string;
+  limit: number;
+  matches: FlowMatch[];
+  blockText: BlockTextReader;
+};
 
 type VisitBlocksOptions = {
   blocks: FlowBlock[];
   path: TracePathSegment[];
-  needle: string;
-  limit: number;
-  matches: FlowMatch[];
+  context: TraceContext;
 };
 
 type VisitTableOptions = Omit<VisitBlocksOptions, "blocks"> & {
   table: TableBlock;
 };
 
-const visitBlocks = ({ blocks, path, needle, limit, matches }: VisitBlocksOptions): void => {
+const visitBlocks = ({ blocks, path, context }: VisitBlocksOptions): void => {
   for (const [blockIndex, block] of blocks.entries()) {
-    if (matches.length >= limit) {
+    if (context.matches.length >= context.limit) {
       return;
     }
 
     const blockPath = [...path, blockIndex];
     if (block.kind === "paragraph") {
-      const text = paragraphText(block);
-      if (normalizedSearchText(text).includes(needle)) {
-        matches.push({
+      const text = context.blockText(block);
+      if (normalizedSearchText(text).includes(context.needle)) {
+        context.matches.push({
           type: "paragraph",
           path: blockPath,
           id: block.id,
@@ -179,7 +201,7 @@ const visitBlocks = ({ blocks, path, needle, limit, matches }: VisitBlocksOption
     }
 
     if (block.kind === "table") {
-      visitTable({ table: block, path: blockPath, needle, limit, matches });
+      visitTable({ table: block, path: blockPath, context });
       continue;
     }
 
@@ -187,30 +209,30 @@ const visitBlocks = ({ blocks, path, needle, limit, matches }: VisitBlocksOption
       visitBlocks({
         blocks: block.content,
         path: [...blockPath, "content"],
-        needle,
-        limit,
-        matches,
+        context,
       });
     }
   }
 };
 
-const visitTable = ({ table, path, needle, limit, matches }: VisitTableOptions): void => {
+const visitTable = ({ table, path, context }: VisitTableOptions): void => {
   for (const [rowIndex, row] of table.rows.entries()) {
-    if (matches.length >= limit) {
+    if (context.matches.length >= context.limit) {
       return;
     }
 
-    const text = row.cells.map((cell) => cell.blocks.map(blockText).join(" ")).join(" ");
-    if (normalizedSearchText(text).includes(needle)) {
-      matches.push({
+    const text = row.cells.map((cell) => cell.blocks.map(context.blockText).join(" ")).join(" ");
+    if (normalizedSearchText(text).includes(context.needle)) {
+      context.matches.push({
         type: "tableRow",
         path: [...path, "rows", rowIndex],
         tableId: table.id,
         rowId: row.id,
         rowIndex,
         text: truncate(text),
-        cells: row.cells.map(summarizeCell),
+        cells: row.cells.map((cell, cellIndex) =>
+          summarizeCell({ cell, cellIndex, blockText: context.blockText }),
+        ),
       });
     }
 
@@ -218,9 +240,7 @@ const visitTable = ({ table, path, needle, limit, matches }: VisitTableOptions):
       visitBlocks({
         blocks: cell.blocks,
         path: [...path, "rows", rowIndex, "cells", cellIndex, "blocks"],
-        needle,
-        limit,
-        matches,
+        context,
       });
     }
   }
@@ -237,9 +257,12 @@ export const traceFlowBlocks = ({ blocks, query, limit }: TraceFlowBlocksOptions
   visitBlocks({
     blocks,
     path: ["blocks"],
-    needle: normalizedSearchText(query),
-    limit,
-    matches,
+    context: {
+      needle: normalizedSearchText(query),
+      limit,
+      matches,
+      blockText: createBlockTextReader(),
+    },
   });
   return matches;
 };

--- a/parity/sourceTraceFlow.ts
+++ b/parity/sourceTraceFlow.ts
@@ -1,0 +1,245 @@
+import type {
+  FlowBlock,
+  ParagraphBlock,
+  Run,
+  TableBlock,
+  TableCell,
+} from "../packages/core/src/layout-engine/types";
+import { normalizeLineText } from "./textNorm";
+
+type TracePathSegment = number | "blocks" | "cells" | "content" | "rows";
+
+type FlowBlockSummary =
+  | {
+      type: "paragraph";
+      id: ParagraphBlock["id"];
+      text: string;
+      attrs: ParagraphBlock["attrs"];
+      runs: unknown[];
+    }
+  | {
+      type: "table";
+      id: TableBlock["id"];
+      rowCount: number;
+    }
+  | {
+      type: "block";
+      id: FlowBlock["id"];
+      kind: Exclude<FlowBlock["kind"], "paragraph" | "table">;
+    };
+
+type TableCellSummary = {
+  cellIndex: number;
+  cellId: TableCell["id"];
+  text: string;
+  blocks: FlowBlockSummary[];
+};
+
+type ParagraphFlowMatch = {
+  type: "paragraph";
+  path: TracePathSegment[];
+  id: ParagraphBlock["id"];
+  text: string;
+  attrs: ParagraphBlock["attrs"];
+  runs: unknown[];
+};
+
+type TableRowFlowMatch = {
+  type: "tableRow";
+  path: TracePathSegment[];
+  tableId: TableBlock["id"];
+  rowId: TableBlock["rows"][number]["id"];
+  rowIndex: number;
+  text: string;
+  cells: TableCellSummary[];
+};
+
+export type FlowMatch = ParagraphFlowMatch | TableRowFlowMatch;
+
+const truncate = (value: string, max = 240): string =>
+  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+
+const normalizedSearchText = (value: string): string =>
+  normalizeLineText(value).toLocaleLowerCase();
+
+const summarizeRun = (run: Run): unknown => {
+  const base = {
+    kind: run.kind,
+    pmStart: run.pmStart,
+    pmEnd: run.pmEnd,
+    fontFamily: "fontFamily" in run ? run.fontFamily : undefined,
+    fontSize: "fontSize" in run ? run.fontSize : undefined,
+    bold: "bold" in run ? run.bold : undefined,
+    allCaps: "allCaps" in run ? run.allCaps : undefined,
+    smallCaps: "smallCaps" in run ? run.smallCaps : undefined,
+  };
+  if (run.kind === "text") {
+    return { ...base, text: truncate(run.text) };
+  }
+  if (run.kind === "field") {
+    return {
+      ...base,
+      fieldType: run.fieldType,
+      instruction: run.instruction,
+      fallback: run.fallback,
+      fldLock: run.fldLock,
+    };
+  }
+  if (run.kind === "image") {
+    return { ...base, width: run.width, height: run.height, wrapType: run.wrapType };
+  }
+  if (run.kind === "math") {
+    return { ...base, plainText: run.plainText };
+  }
+  return base;
+};
+
+const paragraphText = (block: ParagraphBlock): string =>
+  block.runs
+    .map((run) => {
+      if (run.kind === "text") return run.text;
+      if (run.kind === "field") return run.fallback ?? "";
+      if (run.kind === "tab") return "\t";
+      return "";
+    })
+    .join("");
+
+const blockText = (block: FlowBlock): string => {
+  if (block.kind === "paragraph") {
+    return paragraphText(block);
+  }
+  if (block.kind === "table") {
+    return block.rows
+      .flatMap((row) => row.cells)
+      .flatMap((cell) => cell.blocks)
+      .map(blockText)
+      .join(" ");
+  }
+  if (block.kind === "textBox") {
+    return block.content.map(blockText).join(" ");
+  }
+  return "";
+};
+
+const summarizeBlock = (block: FlowBlock): FlowBlockSummary => {
+  if (block.kind === "paragraph") {
+    return {
+      type: "paragraph",
+      id: block.id,
+      text: truncate(paragraphText(block)),
+      attrs: block.attrs,
+      runs: block.runs.map(summarizeRun),
+    };
+  }
+  if (block.kind === "table") {
+    return { type: "table", id: block.id, rowCount: block.rows.length };
+  }
+  return { type: "block", id: block.id, kind: block.kind };
+};
+
+const summarizeCell = (cell: TableCell, cellIndex: number): TableCellSummary => ({
+  cellIndex,
+  cellId: cell.id,
+  text: truncate(cell.blocks.map(blockText).join(" ")),
+  blocks: cell.blocks.map(summarizeBlock),
+});
+
+type VisitBlocksOptions = {
+  blocks: FlowBlock[];
+  path: TracePathSegment[];
+  needle: string;
+  limit: number;
+  matches: FlowMatch[];
+};
+
+type VisitTableOptions = Omit<VisitBlocksOptions, "blocks"> & {
+  table: TableBlock;
+};
+
+const visitBlocks = ({ blocks, path, needle, limit, matches }: VisitBlocksOptions): void => {
+  for (const [blockIndex, block] of blocks.entries()) {
+    if (matches.length >= limit) {
+      return;
+    }
+
+    const blockPath = [...path, blockIndex];
+    if (block.kind === "paragraph") {
+      const text = paragraphText(block);
+      if (normalizedSearchText(text).includes(needle)) {
+        matches.push({
+          type: "paragraph",
+          path: blockPath,
+          id: block.id,
+          text: truncate(text),
+          attrs: block.attrs,
+          runs: block.runs.map(summarizeRun),
+        });
+      }
+      continue;
+    }
+
+    if (block.kind === "table") {
+      visitTable({ table: block, path: blockPath, needle, limit, matches });
+      continue;
+    }
+
+    if (block.kind === "textBox") {
+      visitBlocks({
+        blocks: block.content,
+        path: [...blockPath, "content"],
+        needle,
+        limit,
+        matches,
+      });
+    }
+  }
+};
+
+const visitTable = ({ table, path, needle, limit, matches }: VisitTableOptions): void => {
+  for (const [rowIndex, row] of table.rows.entries()) {
+    if (matches.length >= limit) {
+      return;
+    }
+
+    const text = row.cells.map((cell) => cell.blocks.map(blockText).join(" ")).join(" ");
+    if (normalizedSearchText(text).includes(needle)) {
+      matches.push({
+        type: "tableRow",
+        path: [...path, "rows", rowIndex],
+        tableId: table.id,
+        rowId: row.id,
+        rowIndex,
+        text: truncate(text),
+        cells: row.cells.map(summarizeCell),
+      });
+    }
+
+    for (const [cellIndex, cell] of row.cells.entries()) {
+      visitBlocks({
+        blocks: cell.blocks,
+        path: [...path, "rows", rowIndex, "cells", cellIndex, "blocks"],
+        needle,
+        limit,
+        matches,
+      });
+    }
+  }
+};
+
+type TraceFlowBlocksOptions = {
+  blocks: FlowBlock[];
+  query: string;
+  limit: number;
+};
+
+export const traceFlowBlocks = ({ blocks, query, limit }: TraceFlowBlocksOptions): FlowMatch[] => {
+  const matches: FlowMatch[] = [];
+  visitBlocks({
+    blocks,
+    path: ["blocks"],
+    needle: normalizedSearchText(query),
+    limit,
+    matches,
+  });
+  return matches;
+};


### PR DESCRIPTION
## Summary

- trace flow blocks recursively through tables and text boxes
- report table-row and per-cell context when a query spans cell boundaries
- preserve paragraph formatting and run details in nested trace results

## Validation

- `bun test parity/__tests__`
- `bun run typecheck`
- `bun run lint`
- `bun --bun oxfmt --check .`
- `bun audit`
- `bun run changeset:check`
- `bun test packages/core/src/layout-engine/performance.test.ts packages/core/src/docx/unzip.test.ts`