### PR TITLE
fix: route commands to the active editor story

### DIFF
--- a/.changeset/calm-stories-route.md
+++ b/.changeset/calm-stories-route.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Route formatting, focus, and history commands to the active document story consistently.

--- a/packages/core/src/controller/activeEditorStory.test.ts
+++ b/packages/core/src/controller/activeEditorStory.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import type { EditorView } from "prosemirror-view";
+
+import { resolveActiveEditorStory } from "./activeEditorStory";
+
+/* oxlint-disable typescript/no-unsafe-type-assertion -- opaque view sentinels */
+const bodyView = { story: "body" } as unknown as EditorView;
+const headerFooterView = { story: "headerFooter" } as unknown as EditorView;
+const noteView = { story: "note" } as unknown as EditorView;
+/* oxlint-enable typescript/no-unsafe-type-assertion */
+
+describe("resolveActiveEditorStory", () => {
+  test("uses note, header/footer, then body precedence", () => {
+    expect(resolveActiveEditorStory({ bodyView, headerFooterView, noteView })).toEqual({
+      type: "note",
+      view: noteView,
+    });
+    expect(resolveActiveEditorStory({ bodyView, headerFooterView, noteView: null })).toEqual({
+      type: "headerFooter",
+      view: headerFooterView,
+    });
+    expect(resolveActiveEditorStory({ bodyView, headerFooterView: null, noteView: null })).toEqual({
+      type: "body",
+      view: bodyView,
+    });
+  });
+
+  test("returns an explicit empty target before any view mounts", () => {
+    expect(
+      resolveActiveEditorStory({ bodyView: null, headerFooterView: null, noteView: null }),
+    ).toEqual({ type: "none", view: null });
+  });
+});

--- a/packages/core/src/controller/activeEditorStory.ts
+++ b/packages/core/src/controller/activeEditorStory.ts
@@ -1,0 +1,42 @@
+/** Framework-neutral arbitration for the editor view that receives commands. */
+
+import type { EditorView } from "prosemirror-view";
+
+export type ActiveEditorStoryTarget =
+  | { type: "note"; view: EditorView }
+  | { type: "headerFooter"; view: EditorView }
+  | { type: "body"; view: EditorView }
+  | { type: "none"; view: null };
+
+export type ActiveEditorStoryCandidates = {
+  bodyView: EditorView | null;
+  headerFooterView: EditorView | null;
+  noteView: EditorView | null;
+};
+
+const NO_ACTIVE_STORY: ActiveEditorStoryTarget = { type: "none", view: null };
+
+/**
+ * Resolve the single command target across editable document stories.
+ *
+ * A visible note panel takes precedence over header/footer mode, which takes
+ * precedence over the body. Keeping this order in core prevents framework
+ * adapters from sending formatting, focus, or history commands to a story
+ * hidden behind another active editor surface during an async UI transition.
+ */
+export const resolveActiveEditorStory = ({
+  bodyView,
+  headerFooterView,
+  noteView,
+}: ActiveEditorStoryCandidates): ActiveEditorStoryTarget => {
+  if (noteView) {
+    return { type: "note", view: noteView };
+  }
+  if (headerFooterView) {
+    return { type: "headerFooter", view: headerFooterView };
+  }
+  if (bodyView) {
+    return { type: "body", view: bodyView };
+  }
+  return NO_ACTIVE_STORY;
+};

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -51,6 +51,8 @@ import {
   type FolioDocumentOperationUndoHandle,
   type FolioDocumentOperationUndoResult,
 } from "@stll/folio-core/ai-edits";
+import { resolveActiveEditorStory } from "@stll/folio-core/controller/activeEditorStory";
+import type { NoteStoryKey } from "@stll/folio-core/controller/noteEditorManager";
 import { normalizeBaseDirection } from "@stll/folio-core/docx/normalizeBaseDirection";
 import { getCachedNumberingMap } from "@stll/folio-core/docx/numberingParser";
 import { updateScrollPageTotal } from "@stll/folio-core/paged-layout/scrollPageInfo";
@@ -951,6 +953,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     canRedo: false,
     canUndo: false,
   });
+  const [activeNoteStory, setActiveNoteStory] = useState<NoteStoryKey | null>(null);
 
   // Measure toolbar height for positioning the outline panel below it
   const toolbarRefCallback = useCallback((el: HTMLDivElement | null) => {
@@ -1024,43 +1027,72 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     // already resolved internally for save / remove.
     getHfView: (rId) => pagedEditorRef.current?.getHfView(rId) ?? null,
   });
+  let activeHfRId = hfEditIsFirstPage ? activeFirstFooterRId : activeFooterRId;
+  if (hfEditPosition === "header") {
+    activeHfRId = hfEditIsFirstPage ? activeFirstHeaderRId : activeHeaderRId;
+  }
 
-  // Helper to get the active editor's view — returns HF editor view when in HF editing mode
-  const getActiveEditorView = useCallback(() => {
-    if (hfEditPosition && hfEditorRef.current) {
-      return hfEditorRef.current.getView();
-    }
-    return pagedEditorRef.current?.getActiveView();
-  }, [hfEditPosition]);
+  const getActiveEditorStory = useCallback(() => {
+    const bodyView = pagedEditorRef.current?.getView() ?? null;
+    return resolveActiveEditorStory({
+      bodyView,
+      headerFooterView:
+        hfEditPosition && hfEditorRef.current ? hfEditorRef.current.getView() : null,
+      noteView: activeNoteStory ? (pagedEditorRef.current?.getActiveView() ?? null) : null,
+    });
+  }, [activeNoteStory, hfEditPosition]);
+
+  const getActiveEditorView = useCallback(
+    () => getActiveEditorStory().view,
+    [getActiveEditorStory],
+  );
 
   // Helper to focus the active editor
   const focusActiveEditor = useCallback(() => {
-    if (hfEditPosition && hfEditorRef.current) {
+    if (getActiveEditorStory().type === "headerFooter" && hfEditorRef.current) {
       hfEditorRef.current.focus();
     } else {
       pagedEditorRef.current?.focus();
     }
-  }, [hfEditPosition]);
+  }, [getActiveEditorStory]);
 
   // Helper to undo in the active editor
   const undoActiveEditor = useCallback(() => {
-    if (hfEditPosition && hfEditorRef.current) {
+    if (getActiveEditorStory().type === "headerFooter" && hfEditorRef.current) {
       hfEditorRef.current.undo();
     } else {
       pagedEditorRef.current?.undo();
       requestAnimationFrame(refreshBodyHistoryAvailability);
     }
-  }, [hfEditPosition, refreshBodyHistoryAvailability]);
+  }, [getActiveEditorStory, refreshBodyHistoryAvailability]);
 
   // Helper to redo in the active editor
   const redoActiveEditor = useCallback(() => {
-    if (hfEditPosition && hfEditorRef.current) {
+    if (getActiveEditorStory().type === "headerFooter" && hfEditorRef.current) {
       hfEditorRef.current.redo();
     } else {
       pagedEditorRef.current?.redo();
       requestAnimationFrame(refreshBodyHistoryAvailability);
     }
-  }, [hfEditPosition, refreshBodyHistoryAvailability]);
+  }, [getActiveEditorStory, refreshBodyHistoryAvailability]);
+
+  const handleActiveNoteStoryChange = useCallback(
+    (story: NoteStoryKey | null) => {
+      setActiveNoteStory(story);
+      if (story && hfEditPosition) {
+        handleBodyClick();
+      }
+    },
+    [handleBodyClick, hfEditPosition],
+  );
+
+  const handleHeaderFooterStoryOpen = useCallback(
+    (position: "header" | "footer", pageNumber?: number) => {
+      pagedEditorRef.current?.closeNoteStory();
+      handleHeaderFooterDoubleClick(position, pageNumber);
+    },
+    [handleHeaderFooterDoubleClick],
+  );
 
   // Find/Replace hook
   const findReplace = useFindReplaceState();
@@ -3002,9 +3034,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       // header/footer editor when one is being edited, otherwise the body.
       // Mirrors `undoActiveEditor`/`redoActiveEditor` but returns the
       // prosemirror-history result so a host can tell whether anything was
-      // reversed. Ports upstream docx-editor ff971a7b.
+      // reversed. Notes take precedence during the brief transition that
+      // saves and closes an active header/footer. Ports upstream docx-editor
+      // ff971a7b.
       undo: () => {
-        if (hfEditPosition && hfEditorRef.current) {
+        if (getActiveEditorStory().type === "headerFooter" && hfEditorRef.current) {
           return hfEditorRef.current.undo();
         }
         const undone = pagedEditorRef.current?.undo() ?? false;
@@ -3012,7 +3046,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         return undone;
       },
       redo: () => {
-        if (hfEditPosition && hfEditorRef.current) {
+        if (getActiveEditorStory().type === "headerFooter" && hfEditorRef.current) {
           return hfEditorRef.current.redo();
         }
         const redone = pagedEditorRef.current?.redo() ?? false;
@@ -3216,7 +3250,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       replaceComments,
       commentsRef,
       commentsDirtyRef,
-      hfEditPosition,
+      getActiveEditorStory,
       refreshBodyHistoryAvailability,
     ],
   );
@@ -3240,6 +3274,18 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     () => DISPLAY_MODES.map((mode) => ({ value: mode, label: t(DISPLAY_MODE_LABEL_KEYS[mode]) })),
     [t],
   );
+  const activeHistoryAvailability = (() => {
+    if (activeNoteStory) {
+      return {
+        canRedo: pagedEditorRef.current?.canRedo() ?? false,
+        canUndo: pagedEditorRef.current?.canUndo() ?? false,
+      };
+    }
+    if (hfEditPosition) {
+      return { canRedo: history.canRedo, canUndo: history.canUndo };
+    }
+    return bodyHistoryAvailability;
+  })();
 
   const toolbarChildren = toolbarExtra ?? null;
   const visibleCommentAuthorCount = commentAuthors.filter((commentAuthor) =>
@@ -3733,10 +3779,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     showCommentsSidebar,
     visibleComments,
   ]);
-  let activeHfRId = hfEditIsFirstPage ? activeFirstFooterRId : activeFooterRId;
-  if (hfEditPosition === "header") {
-    activeHfRId = hfEditIsFirstPage ? activeFirstHeaderRId : activeHeaderRId;
-  }
   const getActiveHfView = useCallback(
     () => (activeHfRId ? (pagedEditorRef.current?.getHfView(activeHfRId) ?? null) : null),
     [activeHfRId],
@@ -4001,8 +4043,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                       onFormat={handleFormat}
                       onUndo={undoActiveEditor}
                       onRedo={redoActiveEditor}
-                      canUndo={hfEditPosition ? history.canUndo : bodyHistoryAvailability.canUndo}
-                      canRedo={hfEditPosition ? history.canRedo : bodyHistoryAvailability.canRedo}
+                      canUndo={activeHistoryAvailability.canUndo}
+                      canRedo={activeHistoryAvailability.canRedo}
                       disabled={readOnly}
                       theme={history.state.package.theme || theme || null}
                       fontFamilies={fontFamilies}
@@ -4160,10 +4202,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                           ? { styles: history.state.package.styles }
                           : {})}
                         onHeaderFooterDoubleClick={
-                          showHeaderFooterEditing ? handleHeaderFooterDoubleClick : undefined
+                          showHeaderFooterEditing ? handleHeaderFooterStoryOpen : undefined
                         }
                         hfEditMode={hfEditPosition}
+                        activeHeaderFooterRId={activeHfRId}
                         onBodyClick={handleBodyClick}
+                        onActiveNoteStoryChange={handleActiveNoteStoryChange}
                         zoom={zoom}
                         showMarginGuides={showMarginGuides}
                         {...(marginGuideColor !== undefined ? { marginGuideColor } : {})}

--- a/packages/react/src/components/NoteStoryEditor.tsx
+++ b/packages/react/src/components/NoteStoryEditor.tsx
@@ -26,7 +26,7 @@ export type NoteStoryEditorRef = {
 
 export type NoteStoryEditorProps = {
   document: Document | null;
-  onActiveChange: (active: boolean) => void;
+  onActiveChange: (story: NoteStoryKey | null) => void;
   onDocumentChange: (document: Document) => void;
   onStoryChange: (view: EditorView, docChanged: boolean, selectionChanged: boolean) => void;
   plugins?: Plugin[];
@@ -132,7 +132,7 @@ export const NoteStoryEditor = forwardRef<NoteStoryEditorRef, NoteStoryEditorPro
       manager.sync();
       if (active && !manager?.getActive()) {
         setActive(null);
-        onActiveChangeRef.current(false);
+        onActiveChangeRef.current(null);
       }
     }, [
       active,
@@ -168,7 +168,7 @@ export const NoteStoryEditor = forwardRef<NoteStoryEditorRef, NoteStoryEditorPro
     const closeEditor = (): void => {
       managerRef.current?.activate(null);
       setActive(null);
-      onActiveChangeRef.current(false);
+      onActiveChangeRef.current(null);
     };
 
     useImperativeHandle(ref, () => ({
@@ -182,7 +182,7 @@ export const NoteStoryEditor = forwardRef<NoteStoryEditorRef, NoteStoryEditorPro
         if (!view) return;
         setSuggestionMode(isSuggestionModeActive, view.state, view.dispatch, suggestionAuthor);
         setActive(story);
-        onActiveChangeRef.current(true);
+        onActiveChangeRef.current(story);
         requestAnimationFrame(() => view.focus());
       },
       snapshotDocument: (current) => managerRef.current?.snapshotDocument(current) ?? current,

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -42,6 +42,7 @@ import type { AISuggestion } from "@stll/folio-core/ai-suggestions/types";
 import { createFolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { FolioEditor } from "@stll/folio-core/controller/folioEditor";
 import { createFolioEditorEmitter } from "@stll/folio-core/controller/folioEditorEvents";
+import { resolveActiveEditorStory } from "@stll/folio-core/controller/activeEditorStory";
 import { suggestionModeKey } from "@stll/folio-core/prosemirror/plugins/suggestionMode";
 import { createLatestRequestGate } from "@stll/folio-core/controller/latestRequestGate";
 import { runLayoutPipeline as runLayoutPipelineCompute } from "@stll/folio-core/controller/layoutPipeline";
@@ -80,6 +81,7 @@ import {
   findHfSlotKindForTarget,
 } from "@stll/folio-core/layout-bridge/dom/findHfPmSpans";
 import { findNoteStoryForTarget } from "@stll/folio-core/layout-bridge/dom/noteStoryDom";
+import type { NoteStoryKey } from "@stll/folio-core/controller/noteEditorManager";
 import { clickToPosition } from "@stll/folio-core/layout-bridge/engine/clickToPosition";
 import {
   hitTestFragment,
@@ -305,6 +307,8 @@ export type PagedEditorProps = {
   suggestionModeActive?: boolean;
   /** Author attached to tracked edits made inside note stories. */
   suggestionAuthor?: string;
+  /** Reports the visible note story so outer chrome can target its commands. */
+  onActiveNoteStoryChange?: ((story: NoteStoryKey | null) => void) | undefined;
   /** Callback when header or footer is double-clicked for editing. Pass
    * `undefined` to disable header/footer editing entirely. */
   onHeaderFooterDoubleClick?:
@@ -312,6 +316,8 @@ export type PagedEditorProps = {
     | undefined;
   /** Active header/footer editing mode (dims body, intercepts body clicks). */
   hfEditMode?: "header" | "footer" | null;
+  /** Relationship id of the active header/footer story. */
+  activeHeaderFooterRId?: string | null;
   /** Called when user clicks the body area while in HF editing mode. */
   onBodyClick?: () => void;
   /** Custom class name. */
@@ -365,8 +371,10 @@ export type PagedEditorRef = {
   getState: () => EditorState | null;
   /** Get the ProseMirror EditorView. */
   getView: () => EditorView | null;
-  /** Get the currently focused body or note-story view. */
+  /** Get the active body, header/footer, or note-story view. */
   getActiveView: () => EditorView | null;
+  /** Close the visible note story, if one is active. */
+  closeNoteStory: () => void;
   /**
    * Look up the persistent hidden HF EditorView by `rId`. Returns null when
    * the slot isn't mounted (e.g. document has no HF for that rId, or the
@@ -1405,8 +1413,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       extensionManager,
       suggestionModeActive = false,
       suggestionAuthor,
+      onActiveNoteStoryChange,
       onHeaderFooterDoubleClick,
       hfEditMode,
+      activeHeaderFooterRId,
       onBodyClick,
       className,
       style,
@@ -1445,6 +1455,13 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
     const noteStoryPlugins = useMemo(
       () => externalPlugins.filter(({ spec }) => spec.key === suggestionModeKey),
       [externalPlugins],
+    );
+    const handleActiveNoteStoryChange = useCallback(
+      (story: NoteStoryKey | null) => {
+        setNoteStoryActive(story !== null);
+        onActiveNoteStoryChange?.(story);
+      },
+      [onActiveNoteStoryChange],
     );
 
     useEffect(() => {
@@ -1994,6 +2011,18 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       });
     }
     const folioEditor = folioEditorRef.current;
+    const getActiveEditorStory = useCallback(
+      () =>
+        resolveActiveEditorStory({
+          bodyView: folioEditor.getView(),
+          headerFooterView:
+            hfEditMode && activeHeaderFooterRId
+              ? (hfPMsRef.current?.getView(activeHeaderFooterRId) ?? null)
+              : null,
+          noteView: noteEditorRef.current?.getActiveView() ?? null,
+        }),
+      [activeHeaderFooterRId, folioEditor, hfEditMode],
+    );
 
     const marginGuideSettingsInitializedRef = useRef(false);
     useEffect(() => {
@@ -5603,7 +5632,10 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           return folioEditor.getView();
         },
         getActiveView() {
-          return noteEditorRef.current?.getActiveView() ?? folioEditor.getView();
+          return getActiveEditorStory().view;
+        },
+        closeNoteStory() {
+          noteEditorRef.current?.close();
         },
         getHfView(rId: string) {
           return hfPMsRef.current?.getView(rId) ?? null;
@@ -5618,36 +5650,37 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           ensureHiddenEditorView(options);
         },
         focus() {
-          const noteView = noteEditorRef.current?.getActiveView();
-          if (noteView) noteView.focus();
-          else folioEditor.focus();
+          getActiveEditorStory().view?.focus();
           setIsFocused(true);
         },
         blur() {
-          folioEditor.blur();
+          const view = getActiveEditorStory().view;
+          if (view?.hasFocus() && view.dom instanceof HTMLElement) view.dom.blur();
           setIsFocused(false);
         },
         isFocused() {
-          return folioEditor.isFocused();
+          return getActiveEditorStory().view?.hasFocus() ?? false;
         },
         dispatch(tr: Transaction) {
           folioEditor.dispatch(tr);
         },
         undo() {
-          const noteView = noteEditorRef.current?.getActiveView();
-          return noteView ? historyUndo(noteView.state, noteView.dispatch) : folioEditor.undo();
+          const target = getActiveEditorStory();
+          if (target.type === "none") return false;
+          return historyUndo(target.view.state, target.view.dispatch);
         },
         redo() {
-          const noteView = noteEditorRef.current?.getActiveView();
-          return noteView ? historyRedo(noteView.state, noteView.dispatch) : folioEditor.redo();
+          const target = getActiveEditorStory();
+          if (target.type === "none") return false;
+          return historyRedo(target.view.state, target.view.dispatch);
         },
         canUndo() {
-          const noteView = noteEditorRef.current?.getActiveView();
-          return noteView ? historyUndo(noteView.state) : folioEditor.canUndo();
+          const target = getActiveEditorStory();
+          return target.type === "none" ? false : historyUndo(target.view.state);
         },
         canRedo() {
-          const noteView = noteEditorRef.current?.getActiveView();
-          return noteView ? historyRedo(noteView.state) : folioEditor.canRedo();
+          const target = getActiveEditorStory();
+          return target.type === "none" ? false : historyRedo(target.view.state);
         },
         setSelection(anchor: number, head?: number) {
           folioEditor.setSelection(anchor, head);
@@ -5722,6 +5755,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       [
         ensureHiddenEditorView,
         folioEditor,
+        getActiveEditorStory,
         scrollToPageImpl,
         scrollToParaIdImpl,
         scrollToPositionImpl,
@@ -5829,7 +5863,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         <NoteStoryEditor
           ref={noteEditorRef}
           document={document}
-          onActiveChange={setNoteStoryActive}
+          onActiveChange={handleActiveNoteStoryChange}
           onDocumentChange={handleNoteDocumentChange}
           onStoryChange={handleNoteStoryTransaction}
           plugins={noteStoryPlugins}

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -430,6 +430,7 @@ import {
 import { getTableContext } from "@stll/folio-core/prosemirror/extensions/nodes/TableExtension";
 import { extractSelectionContext } from "@stll/folio-core/prosemirror/plugins/selectionTracker";
 import { inspectDocxCompatibility } from "@stll/folio-core/docx/compatibility";
+import { resolveActiveEditorStory } from "@stll/folio-core/controller/activeEditorStory";
 import {
   clearAllCaches,
   resetCanvasContext,
@@ -699,7 +700,6 @@ const {
   closeNoteStory,
   getActiveNoteView,
   getCommands,
-  focus,
   reLayout,
 } = useDocxEditor({
   hiddenContainer: hiddenPmRef,
@@ -756,9 +756,13 @@ const {
 
 const activeEditorView = computed(
   () =>
-    getActiveNoteView() ??
-    (activeHeaderFooterRId.value ? getHeaderFooterView(activeHeaderFooterRId.value) : null) ??
-    editorView.value,
+    resolveActiveEditorStory({
+      bodyView: editorView.value,
+      headerFooterView: activeHeaderFooterRId.value
+        ? getHeaderFooterView(activeHeaderFooterRId.value)
+        : null,
+      noteView: getActiveNoteView(),
+    }).view,
 );
 
 const activeNoteStoryLabel = computed(() => {
@@ -1437,8 +1441,10 @@ const { exposed } = useDocxEditorRefApi({
   },
   getComments: () => commentManagement.comments.value,
   setComments: commentManagement.setComments,
-  focus,
+  focus: () => activeEditorView.value?.focus(),
   getDocument,
+  getActiveView: () => activeEditorView.value,
+  closeNoteStory,
   getHeaderFooterView,
   setZoom,
   save,

--- a/packages/vue/src/components/DocxEditor/pagedEditorRef.ts
+++ b/packages/vue/src/components/DocxEditor/pagedEditorRef.ts
@@ -29,6 +29,10 @@ export type PagedEditorRef = {
   getState: () => EditorState | null;
   /** Get the ProseMirror EditorView. */
   getView: () => EditorView | null;
+  /** Get the currently active body, header/footer, or note-story view. */
+  getActiveView: () => EditorView | null;
+  /** Close the visible note story, if one is active. */
+  closeNoteStory: () => void;
   /**
    * Look up the persistent hidden HF EditorView by `rId`. Returns null when the
    * slot isn't mounted (no HF for that rId, or the hidden host hasn't mounted).

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -28,7 +28,7 @@ import type { Ref } from "vue";
 import { TextSelection } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
-import { closeHistory } from "prosemirror-history";
+import { closeHistory, redo as historyRedo, undo as historyUndo } from "prosemirror-history";
 
 import {
   applyFolioAIEditOperations,
@@ -138,6 +138,8 @@ export type UseDocxEditorRefApiOptions = {
   // Action handles from useDocxEditor.
   focus: () => void;
   getDocument: () => Document | null;
+  getActiveView: () => EditorView | null;
+  closeNoteStory: () => void;
   getHeaderFooterView: (rId: string) => EditorView | null;
   setZoom: (zoom: number) => void;
   /** useDocxEditor.save returns a Blob; the ref surface exposes an ArrayBuffer. */
@@ -204,25 +206,54 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
   // which every method below already guards against).
   let pagedEditorRef: PagedEditorRef | null = null;
 
+  function undoActiveView(): boolean {
+    const view = opts.getActiveView();
+    return view ? historyUndo(view.state, view.dispatch) : false;
+  }
+
+  function redoActiveView(): boolean {
+    const view = opts.getActiveView();
+    return view ? historyRedo(view.state, view.dispatch) : false;
+  }
+
+  function canUndoActiveView(): boolean {
+    const view = opts.getActiveView();
+    return view ? historyUndo(view.state) : false;
+  }
+
+  function canRedoActiveView(): boolean {
+    const view = opts.getActiveView();
+    return view ? historyRedo(view.state) : false;
+  }
+
+  function blurActiveView(): void {
+    const view = opts.getActiveView();
+    if (view?.hasFocus() && view.dom instanceof HTMLElement) {
+      view.dom.blur();
+    }
+  }
+
   function getEditorRef(): PagedEditorRef {
     pagedEditorRef ??= {
       getEditor: () => opts.editor,
       getDocument: () => opts.editor.getDocument(),
       getState: () => opts.editor.getState(),
       getView: () => opts.editor.getView(),
+      getActiveView: opts.getActiveView,
+      closeNoteStory: opts.closeNoteStory,
       getHfView: (rId) => opts.getHeaderFooterView(rId),
       // The fork's controller ensureView() takes no focus argument yet; the
       // { focus } option is accepted for React parity but ignored, matching
       // ensureEditorView above (PORT-BLOCKED).
       ensureView: () => opts.editor.ensureView(),
-      focus: () => opts.editor.focus(),
-      blur: () => opts.editor.blur(),
-      isFocused: () => opts.editor.isFocused(),
+      focus: opts.focus,
+      blur: blurActiveView,
+      isFocused: () => opts.getActiveView()?.hasFocus() ?? false,
       dispatch: (tr: Transaction) => opts.editor.dispatch(tr),
-      undo: () => opts.editor.undo(),
-      redo: () => opts.editor.redo(),
-      canUndo: () => opts.editor.canUndo(),
-      canRedo: () => opts.editor.canRedo(),
+      undo: undoActiveView,
+      redo: redoActiveView,
+      canUndo: canUndoActiveView,
+      canRedo: canRedoActiveView,
       setSelection: (anchor: number, head?: number) => opts.editor.setSelection(anchor, head),
       getLayout: () => opts.editor.getLayout(),
       relayout: () => opts.editor.relayout(),
@@ -440,8 +471,8 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
       }
       return rejectAIEditRevision(revisionIds)(view.state, view.dispatch);
     },
-    undo: () => opts.editor.undo(),
-    redo: () => opts.editor.redo(),
+    undo: undoActiveView,
+    redo: redoActiveView,
     scrollToAIEditOperation: (revisionIds) => {
       const view = opts.editorView.value;
       if (!view) {

--- a/packages/vue/src/composables/usePagesPointer.ts
+++ b/packages/vue/src/composables/usePagesPointer.ts
@@ -374,6 +374,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     if (noteStory) {
       event.preventDefault();
       event.stopPropagation();
+      if (hfEdit.value) handleHfSave();
       opts.openNoteStory(noteStory);
       return;
     }

--- a/scripts/check-parity-contract.mjs
+++ b/scripts/check-parity-contract.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 // Cross-adapter parity check between @stll/folio-react and @stll/folio-vue.
 //
-// Reads the `DocxEditorProps` and `DocxEditorRef` member names directly from
-// each adapter's TypeScript source and applies `scripts/parity/parity.contract.json`.
+// Reads the `DocxEditorProps`, `DocxEditorRef`, and nested `PagedEditorRef`
+// member names directly from each adapter's TypeScript source and applies
+// `scripts/parity/parity.contract.json`.
 // (Upstream reads committed API-Extractor snapshots; the folio fork has no Vue
 // api-report yet, so we parse the source type declarations instead.)
 //
@@ -28,6 +29,11 @@ const repoRoot = path.resolve(__dirname, "..");
 
 const REACT_PROPS_SRC = path.join(repoRoot, "packages/react/src/components/DocxEditor.props.ts");
 const VUE_TYPES_SRC = path.join(repoRoot, "packages/vue/src/components/DocxEditor/types.ts");
+const REACT_PAGED_REF_SRC = path.join(repoRoot, "packages/react/src/paged-editor/PagedEditor.tsx");
+const VUE_PAGED_REF_SRC = path.join(
+  repoRoot,
+  "packages/vue/src/components/DocxEditor/pagedEditorRef.ts",
+);
 const CONTRACT_PATH = path.join(repoRoot, "scripts/parity/parity.contract.json");
 
 /**
@@ -99,6 +105,7 @@ function readJson(p) {
 const SECTION_SCHEMA = {
   props: { paired: "array", deferredInVue: "object" },
   ref: { paired: "array", deferredInVue: "object" },
+  pagedRef: { paired: "array", deferredInVue: "object" },
 };
 
 function validateContractShape(contract) {
@@ -167,7 +174,13 @@ function checkSection(kind, section, reactMembers, vueMembers, issues) {
 }
 
 function main() {
-  for (const f of [REACT_PROPS_SRC, VUE_TYPES_SRC, CONTRACT_PATH]) {
+  for (const f of [
+    REACT_PROPS_SRC,
+    VUE_TYPES_SRC,
+    REACT_PAGED_REF_SRC,
+    VUE_PAGED_REF_SRC,
+    CONTRACT_PATH,
+  ]) {
     if (!fs.existsSync(f)) {
       console.error(`Missing required file: ${f}`);
       process.exit(1);
@@ -176,6 +189,8 @@ function main() {
 
   const reactSrc = fs.readFileSync(REACT_PROPS_SRC, "utf8");
   const vueSrc = fs.readFileSync(VUE_TYPES_SRC, "utf8");
+  const reactPagedRefSrc = fs.readFileSync(REACT_PAGED_REF_SRC, "utf8");
+  const vuePagedRefSrc = fs.readFileSync(VUE_PAGED_REF_SRC, "utf8");
   const contract = readJson(CONTRACT_PATH);
 
   const shapeErrors = validateContractShape(contract);
@@ -190,6 +205,8 @@ function main() {
     ["Vue DocxEditorProps", vueSrc, "DocxEditorProps"],
     ["React DocxEditorRef", reactSrc, "DocxEditorRef"],
     ["Vue DocxEditorRef", vueSrc, "DocxEditorRef"],
+    ["React PagedEditorRef", reactPagedRefSrc, "PagedEditorRef"],
+    ["Vue PagedEditorRef", vuePagedRefSrc, "PagedEditorRef"],
   ];
   const parsed = {};
   for (const [label, src, typeName] of sources) {
@@ -216,16 +233,27 @@ function main() {
     parsed["Vue DocxEditorRef"],
     issues,
   );
+  checkSection(
+    "PAGED REF",
+    contract.pagedRef,
+    parsed["React PagedEditorRef"],
+    parsed["Vue PagedEditorRef"],
+    issues,
+  );
 
   console.log(`Parity contract: scripts/parity/parity.contract.json (v${contract.version})`);
   console.log(`  React DocxEditorProps: ${parsed["React DocxEditorProps"].size} fields`);
   console.log(`  Vue   DocxEditorProps: ${parsed["Vue DocxEditorProps"].size} fields`);
   console.log(`  React DocxEditorRef:   ${parsed["React DocxEditorRef"].size} members`);
   console.log(`  Vue   DocxEditorRef:   ${parsed["Vue DocxEditorRef"].size} members`);
+  console.log(`  React PagedEditorRef:  ${parsed["React PagedEditorRef"].size} members`);
+  console.log(`  Vue   PagedEditorRef:  ${parsed["Vue PagedEditorRef"].size} members`);
   console.log(`  Paired props:          ${contract.props.paired.length}`);
   console.log(`  Deferred-in-Vue props: ${Object.keys(contract.props.deferredInVue).length}`);
   console.log(`  Paired ref members:    ${contract.ref.paired.length}`);
   console.log(`  Deferred-in-Vue refs:  ${Object.keys(contract.ref.deferredInVue).length}`);
+  console.log(`  Paired paged refs:     ${contract.pagedRef.paired.length}`);
+  console.log(`  Deferred paged refs:  ${Object.keys(contract.pagedRef.deferredInVue).length}`);
 
   if (issues.length > 0) {
     console.error(`\nParity drift: ${issues.length} issue${issues.length === 1 ? "" : "s"}`);

--- a/scripts/parity/parity.contract.json
+++ b/scripts/parity/parity.contract.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "comment": "Cross-adapter parity contract between @stll/folio-react and @stll/folio-vue. Drives `bun run check:parity-contract`, which parses each adapter's `DocxEditorProps` / `DocxEditorRef` from source and applies this contract, failing on any undocumented drift. `paired` = behavior matches between adapters: either both wire the prop functionally, or both intentionally no-op it identically (a prop React declares but never consumes, so Vue declaring + not consuming is the same behavior — see `pairedNotes` for the source-verified justification of each such entry). `deferredInVue` = declared in the Vue `DocxEditorProps` / `DocxEditorRef` type (so the type surface stays parity-complete and `satisfies DocxEditorRef` holds), but the Vue implementation does not match React yet — DocxEditor.vue ignores a prop React DOES consume, or useDocxEditorRefApi.ts stubs the method to a constant. Each deferred entry has a one-line reason. `pairedNotes` (optional, props only) records the source-verified reason a prop is paired when the pairing is a no-op-in-both or a different-idiom match rather than an obvious functional pairing. Adding a prop/method to either adapter without classifying it here fails the gate.",
+  "comment": "Cross-adapter parity contract between @stll/folio-react and @stll/folio-vue. Drives `bun run check:parity-contract`, which parses each adapter's `DocxEditorProps`, `DocxEditorRef`, and nested `PagedEditorRef` from source and applies this contract, failing on any undocumented drift. `paired` = behavior matches between adapters: either both wire the field functionally, or both intentionally no-op it identically. `deferredInVue` = declared in Vue's type surface but not implemented with matching behavior yet. Each deferred entry has a one-line reason. `pairedNotes` records source-verified reasons for non-obvious pairings. Adding a prop or method to either adapter without classifying it here fails the gate.",
   "props": {
     "paired": [
       "anonymizationSelectionSeq",
@@ -132,8 +132,37 @@
     "pairedNotes": {
       "applyDocumentOperations": "Both wired against the shared core `applyFolioDocumentOperations`, mirroring the adjacent (already-paired) `applyAIEditOperations`. Both assert the batch version (`assertSupportedFolioDocumentOperationVersion`), return an all-skipped `unsupportedBlock` result at the contract version when no view is mounted, and otherwise delegate to core with the same snapshot/batch/author. Comment-creation idiom differs like the AI-edit method: React's `createCommentId` closure calls `createComment` and folds the results in via `updateComments`, while Vue passes `opts.createAIEditComment`, which mints the comment and appends it to the thread list internally (from useCommentManagement) — same observable effect.",
       "hasPendingChanges": "Both wired, same set/clear points, different-idiom implementation. React derives it live each call from the ParagraphChangeTracker plugin (getChangedParagraphIds/hasStructuralChanges/hasUntrackedChanges) OR-ed with commentsDirtyRef, and clears the tracker after each successful save. Vue cannot read the tracker for this because it deliberately leaves the tracker uncleared across saves (the tracker is the selective-save baseline; see the featureFlags props note) and re-editing an already-tracked paragraph would not grow the set, so a tracker read could never go false after save. Instead Vue tracks two boolean flags with the same set/clear points as React's underlying signals: `isDirty` in useDocxEditor (set on every doc-changing transaction — the same signal that drives the writeback/onChange; cleared on a successful save() and on document load/swap) and `commentsDirty` in useCommentManagement (set on every user comment mutation add/reply/resolve/unresolve/delete; cleared on document load via seedFromDocument and on a successful save via the ref API's save wrapper). useDocxEditorRefApi returns `isDirty || commentsDirty` (false before the view mounts, matching React's no-view guard). Net semantics match: pending after typing or a comment edit, clean after save or load. Housekeeping transactions (paraId allocation, auto-bidi) only run as appendTransactions to a real user edit or imperatively at initial-state build (never through the runtime transaction handler on a plain load), so they never set isDirty spuriously.",
-      "getEditorRef": "Both wired with live handles. Vue synthesizes the PagedEditorRef shape from the shared controller and viewport primitives; getHfView delegates to the same relationship-id-keyed persistent header/footer manager that supplies the Vue layout pipeline, matching React's manager-backed lookup. Scroll, page, selection, history, dispatch, layout, and view methods remain direct controller bindings. ensureView accepts the parity {focus} option while the shared controller currently treats creation and focus as separate operations."
+      "getEditorRef": "Both wired with live handles. Vue synthesizes the PagedEditorRef shape from the shared controller and viewport primitives; getHfView delegates to the same relationship-id-keyed persistent header/footer manager that supplies the Vue layout pipeline, matching React's manager-backed lookup. Focus and history resolve the live active story; body selection, dispatch, layout, scroll, and page methods remain direct controller bindings. ensureView accepts the parity {focus} option while the shared controller currently treats creation and focus as separate operations."
     },
+    "deferredInVue": {}
+  },
+  "pagedRef": {
+    "comment": "Nested PagedEditorRef parity. Both adapters expose this handle through DocxEditorRef.getEditorRef(); every paired method must be implemented on both sides.",
+    "paired": [
+      "blur",
+      "canRedo",
+      "canUndo",
+      "closeNoteStory",
+      "dispatch",
+      "ensureView",
+      "focus",
+      "getActiveView",
+      "getDocument",
+      "getEditor",
+      "getHfView",
+      "getLayout",
+      "getPageNumberForPmPos",
+      "getState",
+      "getView",
+      "isFocused",
+      "redo",
+      "relayout",
+      "scrollToPage",
+      "scrollToParaId",
+      "scrollToPosition",
+      "setSelection",
+      "undo"
+    ],
     "deferredInVue": {}
   }
 }


### PR DESCRIPTION
## Summary

- centralize body, header/footer, and note command-target resolution in core
- make story transitions exclusive and route focus and history consistently in React and Vue
- extend the parity gate to the nested editor handle