### PR TITLE
fix: avoid duplicate document XML parse

### DIFF
--- a/.changeset/quick-dingos-parse.md
+++ b/.changeset/quick-dingos-parse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Avoid reparsing the complete document XML when detecting DOCX conformance.

--- a/packages/core/src/docx/conformance.test.ts
+++ b/packages/core/src/docx/conformance.test.ts
@@ -33,6 +33,37 @@ describe("DOCX conformance detection", () => {
     expect(detectDocxConformanceClass(null)).toBe(DOCX_CONFORMANCE_CLASSES.UNKNOWN);
   });
 
+  test("reads only the actual root start tag", () => {
+    expect(
+      detectDocxConformanceClass(
+        `<?xml version="1.0"?>
+        <!-- <x:document xmlns:x="${STRICT_MAIN_NAMESPACE}"/> -->
+        <x:document data-comparison="1 > 0" xmlns:x = '${TRANSITIONAL_MAIN_NAMESPACE}'>
+          <x:body xmlns:x="${STRICT_MAIN_NAMESPACE}"/>
+        </x:document>`,
+      ),
+    ).toBe(DOCX_CONFORMANCE_CLASSES.TRANSITIONAL);
+  });
+
+  test("falls back to full parsing for uncommon content before the root", () => {
+    expect(
+      detectDocxConformanceClass(`not XML <x:document xmlns:x="${STRICT_MAIN_NAMESPACE}"/>`),
+    ).toBe(DOCX_CONFORMANCE_CLASSES.STRICT);
+    expect(
+      detectDocxConformanceClass(
+        `<!DOCTYPE x:document [<!ELEMENT x:document EMPTY>]><x:document xmlns:x="${STRICT_MAIN_NAMESPACE}"/>`,
+      ),
+    ).toBe(DOCX_CONFORMANCE_CLASSES.STRICT);
+  });
+
+  test("bounds the root scan without changing full-parser fallback behavior", () => {
+    expect(
+      detectDocxConformanceClass(
+        `<!-- ${"padding".repeat(10_000)} --><x:document xmlns:x="${STRICT_MAIN_NAMESPACE}"/>`,
+      ),
+    ).toBe(DOCX_CONFORMANCE_CLASSES.STRICT);
+  });
+
   test("stores the detected class on parsed package metadata", async () => {
     const zip = new JSZip();
     zip.file(

--- a/packages/core/src/docx/conformance.ts
+++ b/packages/core/src/docx/conformance.ts
@@ -1,17 +1,35 @@
 import { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
 
 import type { DocxConformanceClass } from "../types/document";
+import type { XmlElement } from "./xmlParser";
 import { getLocalName, getNamespacePrefix, parseXmlDocument } from "./xmlParser";
 
 const STRICT_MAIN_NAMESPACE = "http://purl.oclc.org/ooxml/wordprocessingml/main";
 const TRANSITIONAL_MAIN_NAMESPACE = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const ROOT_START_TAG_SCAN_LIMIT = 64 * 1024;
+const ROOT_START_TAG_PATTERN =
+  /^(?:\uFEFF|\s|<\?[\s\S]*?\?>|<!--[\s\S]*?-->)*(?<tag><[^\s/>]+(?:[^>"']|"[^"]*"|'[^']*')*>)/u;
 
 export const detectDocxConformanceClass = (documentXml: string | null): DocxConformanceClass => {
   if (documentXml === null) {
     return DOCX_CONFORMANCE_CLASSES.UNKNOWN;
   }
 
-  const root = parseXmlDocument(documentXml);
+  const rootStartTag = ROOT_START_TAG_PATTERN.exec(documentXml.slice(0, ROOT_START_TAG_SCAN_LIMIT))
+    ?.groups?.["tag"];
+  const fastRoot =
+    rootStartTag === undefined
+      ? null
+      : parseXmlDocument(
+          rootStartTag.endsWith("/>") ? rootStartTag : `${rootStartTag.slice(0, -1)}/>`,
+        );
+  // Preserve the full parser's behavior for uncommon XML prologs that the
+  // bounded fast path intentionally does not recognize (for example a DTD).
+  const root = fastRoot ?? parseXmlDocument(documentXml);
+  return detectDocxConformanceClassFromRoot(root);
+};
+
+const detectDocxConformanceClassFromRoot = (root: XmlElement | null): DocxConformanceClass => {
   if (root === null || getLocalName(root.name ?? "") !== "document") {
     return DOCX_CONFORMANCE_CLASSES.UNKNOWN;
   }

--- a/packages/core/src/docx/conformance.ts
+++ b/packages/core/src/docx/conformance.ts
@@ -15,8 +15,11 @@ export const detectDocxConformanceClass = (documentXml: string | null): DocxConf
     return DOCX_CONFORMANCE_CLASSES.UNKNOWN;
   }
 
-  const rootStartTag = ROOT_START_TAG_PATTERN.exec(documentXml.slice(0, ROOT_START_TAG_SCAN_LIMIT))
-    ?.groups?.["tag"];
+  const scanTarget =
+    documentXml.length <= ROOT_START_TAG_SCAN_LIMIT
+      ? documentXml
+      : documentXml.slice(0, ROOT_START_TAG_SCAN_LIMIT);
+  const rootStartTag = ROOT_START_TAG_PATTERN.exec(scanTarget)?.groups?.["tag"];
   const fastRoot =
     rootStartTag === undefined
       ? null


### PR DESCRIPTION
## Summary

- detect Strict/Transitional conformance from a bounded root start-tag parse
- retain the complete XML parser as a fallback for uncommon prologs
- cover comments, quoted delimiters, alternate prefixes, DTD fallback, and the scan bound

## Performance

This removes the second full parse of `word/document.xml`. In the production startup benchmark, the DOCX parse phase fell by 36–39% for the generated 1,500-paragraph fixture and 34–37% for the larger fixture.