### PR TITLE
fix: preserve document layout invariants

### DIFF
--- a/.changeset/document-grid-types.md
+++ b/.changeset/document-grid-types.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Honor document grid types and preserve section marks after trailing page breaks.
+Honor document grid types, preserve section marks after trailing page breaks, and reconcile cached page boundaries after tables.

--- a/.changeset/document-grid-types.md
+++ b/.changeset/document-grid-types.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor document grid types when applying section line pitches.

--- a/.changeset/document-grid-types.md
+++ b/.changeset/document-grid-types.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Honor document grid types when applying section line pitches.
+Honor document grid types and preserve section marks after trailing page breaks.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -237,7 +237,8 @@ export type ParagraphAttrs = {
     tabs?: import__stll_docx_core_model.TabStop[];
     pageBreakBefore?: boolean; /** Word's cached rendered-page-break marker; preserved for round-trip only. */
     renderedPageBreakBefore?: boolean; /** Internal import marker for a paragraph whose only run content is a hard page break. */
-    _pageBreakCarrier?: boolean;
+    _pageBreakCarrier?: boolean; /** Internal import marker for a hard page break after this paragraph's text. */
+    _trailingPageBreak?: boolean;
     keepNext?: boolean;
     keepLines?: boolean;
     widowControl?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -339,7 +339,8 @@ export type ParagraphAttrs = {
     tabs?: import__stll_docx_core_model.TabStop[];
     pageBreakBefore?: boolean; /** Word's cached rendered-page-break marker; preserved for round-trip only. */
     renderedPageBreakBefore?: boolean; /** Internal import marker for a paragraph whose only run content is a hard page break. */
-    _pageBreakCarrier?: boolean;
+    _pageBreakCarrier?: boolean; /** Internal import marker for a hard page break after this paragraph's text. */
+    _trailingPageBreak?: boolean;
     keepNext?: boolean;
     keepLines?: boolean;
     widowControl?: boolean; /** Contextual spacing — suppress space between same-style paragraphs */

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -1,5 +1,6 @@
 import type { EditorState } from "prosemirror-state";
 
+import { resolveDocumentGridLinePitch } from "../docx/documentGrid";
 import { buildBookmarkPageMap } from "../fields/bookmarkPages";
 import { buildBookmarkText } from "../fields/bookmarkText";
 import {
@@ -330,12 +331,10 @@ export function runLayoutPipeline<THfPMs>(
           : {}),
       };
     }
-    const finalSectionDocumentGridLinePitchTwips =
-      document?.package.document.sections?.at(-1)?.properties.docGrid?.linePitch;
-    if (
-      finalSectionDocumentGridLinePitchTwips !== undefined &&
-      finalSectionDocumentGridLinePitchTwips > 0
-    ) {
+    const finalSectionDocumentGridLinePitchTwips = resolveDocumentGridLinePitch(
+      document?.package.document.sections?.at(-1)?.properties.docGrid,
+    );
+    if (finalSectionDocumentGridLinePitchTwips !== undefined) {
       flowOpts.finalSectionDocumentGridLinePitchTwips = finalSectionDocumentGridLinePitchTwips;
     }
     let newBlocks = toFlowBlocks(state.doc, flowOpts);

--- a/packages/core/src/docx/documentGrid.test.ts
+++ b/packages/core/src/docx/documentGrid.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveDocumentGridLinePitch } from "./documentGrid";
+
+describe("resolveDocumentGridLinePitch", () => {
+  test.each(["lines", "linesAndChars", "snapToChars"] as const)(
+    "activates a positive pitch for the %s grid type",
+    (type) => {
+      expect(resolveDocumentGridLinePitch({ type, linePitch: 360 })).toBe(360);
+    },
+  );
+
+  test("keeps omitted and default grid types inactive", () => {
+    expect(resolveDocumentGridLinePitch({ linePitch: 360 })).toBeUndefined();
+    expect(resolveDocumentGridLinePitch({ type: "default", linePitch: 360 })).toBeUndefined();
+  });
+
+  test("rejects absent and non-positive pitches", () => {
+    expect(resolveDocumentGridLinePitch({ type: "lines" })).toBeUndefined();
+    expect(resolveDocumentGridLinePitch({ type: "lines", linePitch: 0 })).toBeUndefined();
+    expect(resolveDocumentGridLinePitch({ type: "lines", linePitch: -1 })).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/documentGrid.ts
+++ b/packages/core/src/docx/documentGrid.ts
@@ -1,0 +1,14 @@
+type DocumentGrid = {
+  type?: "default" | "lines" | "linesAndChars" | "snapToChars";
+  linePitch?: number;
+};
+
+export function resolveDocumentGridLinePitch(grid: DocumentGrid | undefined): number | undefined {
+  if (grid?.type === undefined || grid.type === "default") {
+    return undefined;
+  }
+  if (grid.linePitch === undefined || grid.linePitch <= 0) {
+    return undefined;
+  }
+  return grid.linePitch;
+}

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -8,7 +8,7 @@ import { toFlowBlocks } from "./toFlowBlocks";
 describe("toFlowBlocks paragraph formatting", () => {
   test("stamps each top-level paragraph with its section line pitch", () => {
     const doc = schema.node("doc", null, [
-      schema.node("paragraph", { _sectionProperties: { docGrid: { linePitch: 360 } } }, [
+      schema.node("paragraph", { _sectionProperties: { docGrid: { type: "lines", linePitch: 360 } } }, [
         schema.text("First section"),
       ]),
       schema.node("paragraph", null, [schema.text("Final section")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -8,9 +8,11 @@ import { toFlowBlocks } from "./toFlowBlocks";
 describe("toFlowBlocks paragraph formatting", () => {
   test("stamps each top-level paragraph with its section line pitch", () => {
     const doc = schema.node("doc", null, [
-      schema.node("paragraph", { _sectionProperties: { docGrid: { type: "lines", linePitch: 360 } } }, [
-        schema.text("First section"),
-      ]),
+      schema.node(
+        "paragraph",
+        { _sectionProperties: { docGrid: { type: "lines", linePitch: 360 } } },
+        [schema.text("First section")],
+      ),
       schema.node("paragraph", null, [schema.text("Final section")]),
     ]);
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -57,6 +57,12 @@ describe("toFlowBlocks paragraph formatting", () => {
           lineSpacing: 1_000,
           lineSpacingRule: "exact",
           _trailingPageBreak: true,
+          paraId: "A1B2C3D4",
+          bookmarks: [{ id: 7, name: "section-cover" }],
+          borders: { bottom: { style: "single", size: 8, color: { rgb: "000000" } } },
+          shading: { fill: { rgb: "FFFF00" } },
+          pageBreakBefore: true,
+          renderedPageBreakBefore: true,
         },
         [schema.text("Section cover")],
       ),
@@ -79,9 +85,15 @@ describe("toFlowBlocks paragraph formatting", () => {
       return;
     }
     expect(carrier.runs).toEqual([]);
+    expect(carrier.paraId).toBeUndefined();
+    expect(carrier.bookmarks).toBeUndefined();
     expect(carrier.attrs?.spacing?.after).toBeCloseTo(40 / 15);
     expect(carrier.attrs?.spacing?.line).toBeCloseTo(1_000 / 15);
     expect(carrier.attrs?.spacing?.before).toBeUndefined();
+    expect(carrier.attrs?.borders).toBeUndefined();
+    expect(carrier.attrs?.shading).toBeUndefined();
+    expect(carrier.attrs?.pageBreakBefore).toBeUndefined();
+    expect(carrier.attrs?.renderedPageBreakBefore).toBeUndefined();
   });
 
   test("does not retain an imported trailing break after the break node is removed", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -44,6 +44,64 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(cellParagraph.attrs?.documentGridLinePitch).toBeUndefined();
   });
 
+  test("lays out a trailing page-break section mark on the following page", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _sectionProperties: { sectionStart: "continuous" },
+          spaceBefore: 300,
+          spaceAfter: 40,
+          lineSpacing: 1_000,
+          lineSpacingRule: "exact",
+          _trailingPageBreak: true,
+        },
+        [schema.text("Section cover")],
+      ),
+      schema.node("pageBreak"),
+      schema.node("paragraph", null, [schema.text("Next page")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.kind)).toEqual([
+      "paragraph",
+      "pageBreak",
+      "paragraph",
+      "sectionBreak",
+      "paragraph",
+    ]);
+    const carrier = blocks.at(2);
+    expect(carrier?.kind).toBe("paragraph");
+    if (carrier?.kind !== "paragraph") {
+      return;
+    }
+    expect(carrier.runs).toEqual([]);
+    expect(carrier.attrs?.spacing?.after).toBeCloseTo(40 / 15);
+    expect(carrier.attrs?.spacing?.line).toBeCloseTo(1_000 / 15);
+    expect(carrier.attrs?.spacing?.before).toBeUndefined();
+  });
+
+  test("does not retain an imported trailing break after the break node is removed", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _sectionProperties: { sectionStart: "continuous" },
+          _trailingPageBreak: true,
+        },
+        [schema.text("Section cover")],
+      ),
+      schema.node("paragraph", null, [schema.text("Next paragraph")]),
+    ]);
+
+    expect(toFlowBlocks(doc).map((block) => block.kind)).toEqual([
+      "paragraph",
+      "sectionBreak",
+      "paragraph",
+    ]);
+  });
+
   test("keeps text-box anchors out of paragraph layout", () => {
     const paragraph = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2706,6 +2706,32 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     blocks.push(block);
   };
 
+  const trailingPageBreakSectionPositions = new Set<number>();
+  const consumedPageBreakPositions = new Set<number>();
+  const collectTrailingPageBreakSections = (parent: PMNode, contentStart: number): void => {
+    let childStart = contentStart;
+    for (let index = 0; index < parent.childCount; index += 1) {
+      const child = parent.child(index);
+      const next = index + 1 < parent.childCount ? parent.child(index + 1) : undefined;
+      const paragraphAttrs =
+        child.type.name === "paragraph" ? expectParagraphAttrs(child) : undefined;
+      if (
+        paragraphAttrs &&
+        next?.type.name === "pageBreak" &&
+        paragraphAttrs._trailingPageBreak === true &&
+        (paragraphAttrs._sectionProperties || paragraphAttrs.sectionBreakType)
+      ) {
+        trailingPageBreakSectionPositions.add(childStart);
+        consumedPageBreakPositions.add(childStart + child.nodeSize);
+      }
+      if (child.type.name === "blockSdt") {
+        collectTrailingPageBreakSections(child, childStart + 1);
+      }
+      childStart += child.nodeSize;
+    }
+  };
+  collectTrailingPageBreakSections(doc, offset);
+
   // Refactored visit-style traversal so blockSdt can recurse into its
   // children without duplicating the per-block conversion code.
   const visit = (node: PMNode, pos: number): void => {
@@ -2854,6 +2880,34 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
 
         // Emit section break block if this paragraph ends a section
         if (hasSectionBreak) {
+          if (trailingPageBreakSectionPositions.has(pos)) {
+            const sourceParagraph = blocks.at(-1);
+            if (sourceParagraph?.kind === "paragraph" && sourceParagraph.pmStart === pos) {
+              const pageBreak: PageBreakBlock = {
+                kind: "pageBreak",
+                id: nextBlockId(),
+                pmStart: pos + node.nodeSize,
+                pmEnd: pos + node.nodeSize + 1,
+              };
+              trackedPush(pageBreak);
+              const carrierAttrs = { ...sourceParagraph.attrs };
+              if (carrierAttrs.spacing) {
+                carrierAttrs.spacing = { ...carrierAttrs.spacing };
+                delete carrierAttrs.spacing.before;
+              }
+              delete carrierAttrs.listMarker;
+              delete carrierAttrs.suppressEmptyParagraphHeight;
+              const carrier: ParagraphBlock = {
+                ...sourceParagraph,
+                id: nextBlockId(),
+                runs: [],
+                attrs: carrierAttrs,
+                pmStart: pos + node.nodeSize,
+                pmEnd: pos + node.nodeSize,
+              };
+              trackedPush(carrier);
+            }
+          }
           const sectionBreak: SectionBreakBlock = {
             kind: "sectionBreak",
             id: nextBlockId(),
@@ -2928,6 +2982,9 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
 
       case "horizontalRule":
       case "pageBreak": {
+        if (consumedPageBreakPositions.has(pos)) {
+          break;
+        }
         const pb: PageBreakBlock = {
           kind: "pageBreak",
           id: nextBlockId(),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -8,6 +8,7 @@
 import type { Node as PMNode, Mark } from "prosemirror-model";
 
 import { convertBulletToUnicode } from "../../docx/bulletMarkers";
+import { resolveDocumentGridLinePitch } from "../../docx/documentGrid";
 import { padDecimal } from "../../docx/numberingParser";
 import type {
   FlowBlock,
@@ -2863,8 +2864,9 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
           }
 
           if (secProps) {
-            if (secProps.docGrid?.linePitch !== undefined && secProps.docGrid.linePitch > 0) {
-              sectionBreak.documentGridLinePitchTwips = secProps.docGrid.linePitch;
+            const documentGridLinePitchTwips = resolveDocumentGridLinePitch(secProps.docGrid);
+            if (documentGridLinePitchTwips !== undefined) {
+              sectionBreak.documentGridLinePitchTwips = documentGridLinePitchTwips;
             }
             // Populate page size
             if (secProps.pageWidth || secProps.pageHeight) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2890,15 +2890,40 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
                 pmEnd: pos + node.nodeSize + 1,
               };
               trackedPush(pageBreak);
-              const carrierAttrs = { ...sourceParagraph.attrs };
-              if (carrierAttrs.spacing) {
-                carrierAttrs.spacing = { ...carrierAttrs.spacing };
-                delete carrierAttrs.spacing.before;
+              const sourceAttrs = sourceParagraph.attrs;
+              const carrierSpacing = sourceAttrs?.spacing ? { ...sourceAttrs.spacing } : undefined;
+              if (carrierSpacing) {
+                delete carrierSpacing.before;
               }
-              delete carrierAttrs.listMarker;
-              delete carrierAttrs.suppressEmptyParagraphHeight;
+              const carrierAttrs: ParagraphAttrs = {
+                ...(carrierSpacing ? { spacing: carrierSpacing } : {}),
+                ...(sourceAttrs?.automaticSpacing?.after === true
+                  ? { automaticSpacing: { after: true } }
+                  : {}),
+                ...(sourceAttrs?.spacingExplicit?.after === true
+                  ? { spacingExplicit: { after: true } }
+                  : {}),
+                ...(sourceAttrs?.hasDirectParagraphFormatting === true
+                  ? { hasDirectParagraphFormatting: true }
+                  : {}),
+                ...(sourceAttrs?.hasDirectParagraphMarkFormatting === true
+                  ? { hasDirectParagraphMarkFormatting: true }
+                  : {}),
+                ...(sourceAttrs?.snapToGrid !== undefined
+                  ? { snapToGrid: sourceAttrs.snapToGrid }
+                  : {}),
+                ...(sourceAttrs?.documentGridLinePitch !== undefined
+                  ? { documentGridLinePitch: sourceAttrs.documentGridLinePitch }
+                  : {}),
+                ...(sourceAttrs?.defaultFontSize !== undefined
+                  ? { defaultFontSize: sourceAttrs.defaultFontSize }
+                  : {}),
+                ...(sourceAttrs?.defaultFontFamily !== undefined
+                  ? { defaultFontFamily: sourceAttrs.defaultFontFamily }
+                  : {}),
+              };
               const carrier: ParagraphBlock = {
-                ...sourceParagraph,
+                kind: "paragraph",
                 id: nextBlockId(),
                 runs: [],
                 attrs: carrierAttrs,

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -107,6 +107,23 @@ describe("rendered break reconciliation", () => {
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
+  test("a fitting cached marker remains authoritative after a table", () => {
+    const previous: FlowBlock = { kind: "table", id: 1, rows: [] };
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: paragraph(2, { renderedPageBreakBefore: true }),
+      previousBlock: previous,
+      page: page([paragraphFragment(1)]),
+      blocksById: new Map([["1", previous]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.suppressSpaceBefore).toBe(true);
+    expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
+  });
+
   test("paragraph continuation satisfies a cached marker", () => {
     const previous = paragraph(1);
     const decision = reconcileBreakBeforeBlock({

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -68,7 +68,8 @@ export const reconcileBreakBeforeBlock = ({
         continuesTabbedParagraphSequence(previousBlock, block)));
   // A keep-with-next paragraph carries the marker boundary into its linked
   // content, so its own height is not enough to classify the marker as stale.
-  const markerNeedsSnap = renderedBreakNeedsSnap || block.attrs?.keepNext === true;
+  const markerNeedsSnap =
+    renderedBreakNeedsSnap || block.attrs?.keepNext === true || previousBlock?.kind === "table";
   const forcePageBreak =
     markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById);
   const followsAuthoredPageBreak = previousBlock?.kind === "pageBreak";

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -310,6 +310,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
     "paragraph.attrs.renderedPageBreakBefore",
     issues,
   );
+  optionalBoolean(attrs, "_trailingPageBreak", "paragraph.attrs._trailingPageBreak", issues);
   optionalBoolean(attrs, "runInWithNext", "paragraph.attrs.runInWithNext", issues);
   optionalBoolean(attrs, "keepNext", "paragraph.attrs.keepNext", issues);
   optionalBoolean(attrs, "keepLines", "paragraph.attrs.keepLines", issues);

--- a/packages/core/src/prosemirror/conversion/toProseDoc-pagebreak.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc-pagebreak.test.ts
@@ -145,6 +145,7 @@ describe('toProseDoc — hard page break (`<w:br w:type="page"/>`)', () => {
 
     const pmDoc = toProseDoc(document);
     expect(childTypeNames(pmDoc)).toEqual(["paragraph", "pageBreak", "paragraph"]);
+    expect(pmDoc.child(0).attrs["_trailingPageBreak"]).toBe(true);
   });
 
   test("emits pageBreak when the break sits inside a hyperlink wrapper", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -139,6 +139,17 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
             paragraph.marks,
           );
         }
+        if (pbPos === "after") {
+          const paragraphIndex = converted.findIndex((node) => node.type.name === "paragraph");
+          const trailingParagraph = paragraphIndex >= 0 ? converted.at(paragraphIndex) : undefined;
+          if (trailingParagraph) {
+            converted[paragraphIndex] = trailingParagraph.type.create(
+              { ...trailingParagraph.attrs, _trailingPageBreak: true },
+              trailingParagraph.content,
+              trailingParagraph.marks,
+            );
+          }
+        }
         out.push(...converted);
         if (pbPos === "after") {
           out.push(schema.node("pageBreak"));

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -361,6 +361,7 @@ const paragraphNodeSpec: NodeSpec = {
     pageBreakBefore: { default: null },
     renderedPageBreakBefore: { default: null },
     _pageBreakCarrier: { default: null },
+    _trailingPageBreak: { default: null },
     keepNext: { default: null },
     keepLines: { default: null },
     widowControl: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -172,6 +172,8 @@ export type ParagraphAttrs = {
   renderedPageBreakBefore?: boolean;
   /** Internal import marker for a paragraph whose only run content is a hard page break. */
   _pageBreakCarrier?: boolean;
+  /** Internal import marker for a hard page break after this paragraph's text. */
+  _trailingPageBreak?: boolean;
   keepNext?: boolean;
   keepLines?: boolean;
   widowControl?: boolean;

--- a/parity/__tests__/textNorm.test.ts
+++ b/parity/__tests__/textNorm.test.ts
@@ -14,6 +14,10 @@ describe("normalizeLineText", () => {
     expect(normalizeLineText("\uf0e3 Loan Market Association")).toBe("ã Loan Market Association");
   });
 
+  test("normalizes legacy Symbol-font bullets", () => {
+    expect(normalizeLineText("\uf0b7 First item")).toBe("• First item");
+  });
+
   test("folds CJK radical aliases emitted by PDF font maps", () => {
     expect(normalizeLineText("⺟甲⼄丙丁")).toBe("母甲乙丙丁");
   });

--- a/parity/textNorm.ts
+++ b/parity/textNorm.ts
@@ -14,6 +14,7 @@ export const normalizeLineText = (text: string): string =>
     // line endpoint are unchanged, so canonicalize only those radical blocks.
     .replace(/[⺀-⿕]/gu, (character) => character.normalize("NFKC"))
     .replace(/[­​-‍﻿]/gu, "")
+    .replace(/\uf0b7/gu, "•")
     .replace(/\uf0e3/gu, "ã")
     .replace(/\s*\.{3,}\s*/gu, " … ")
     .replace(/\s+/gu, " ")


### PR DESCRIPTION
## Summary

- honor active OOXML document grid types when deriving line pitch
- preserve section-mark layout after trailing hard page breaks
- reconcile cached rendered boundaries after tables
- normalize legacy Symbol-font bullets in comparison output

Includes focused synthetic regressions for each invariant.