### PR TITLE
feat: add DOCX conformance reports

### DIFF
--- a/.changeset/calm-donkeys-report.md
+++ b/.changeset/calm-donkeys-report.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add a versioned DOCX conformance report to the server API.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -112,6 +112,14 @@ export type DocumentStyleSet = {
 // @public
 export class DocxArchiveError extends DocxArchiveError_base {}
 
+// @public (undocumented)
+export type DocxArchiveOptions = {
+    maxInputBytes?: number;
+    maxEntryBytes?: number;
+    maxTotalBytes?: number;
+    maxEntries?: number;
+};
+
 // @public
 export type DocxParagraphSource = "header" | "body" | "footer";
 
@@ -211,6 +219,18 @@ export const FOLIO_DOCUMENT_OPERATION_TYPES: readonly ["replaceInBlock", "replac
 
 // @public (undocumented)
 export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CONFORMANCE_CHECKS: readonly ["archive-safety", "required-parts", "xml-well-formedness", "package-roots", "conformance-class", "canonical-model"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES: readonly ["archive-load-failed", "archive-input-too-large", "archive-too-many-entries", "archive-entry-too-large", "archive-total-too-large", "required-part-missing", "xml-doctype-forbidden", "xml-not-well-formed", "xml-read-failed", "required-xml-unreadable", "package-root-invalid", "conformance-class-unknown", "model-invalid", "model-warning", "parser-recovery", "parser-unsupported", "parser-failed", "encrypted-container", "container-not-zip"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_CONFORMANCE_PROFILE: "folio-supported-v1";
+
+// @public (undocumented)
+export const FOLIO_DOCX_CONFORMANCE_REPORT_VERSION: 1;
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -716,6 +736,46 @@ export type FolioDocumentStoryHandle = {
 // @public (undocumented)
 export class FolioDocumentStoryNotFoundError extends FolioDocumentStoryNotFoundError_base {}
 
+// @public (undocumented)
+export type FolioDocxConformanceCheck = {
+    readonly id: FolioDocxConformanceCheckId;
+    readonly status: FolioDocxConformanceCheckStatus;
+};
+
+// @public (undocumented)
+export type FolioDocxConformanceCheckId = (typeof FOLIO_DOCX_CONFORMANCE_CHECKS)[number];
+
+// @public (undocumented)
+export type FolioDocxConformanceCheckStatus = "passed" | "failed" | "indeterminate" | "not-run";
+
+// @public (undocumented)
+export type FolioDocxConformanceIssue = {
+    readonly check: FolioDocxConformanceCheckId;
+    readonly code: FolioDocxConformanceIssueCode;
+    readonly message: string;
+    readonly severity: "error" | "warning";
+    readonly part?: string;
+    readonly modelPath?: string;
+    readonly count?: number;
+};
+
+// @public (undocumented)
+export type FolioDocxConformanceIssueCode = (typeof FOLIO_DOCX_CONFORMANCE_ISSUE_CODES)[number];
+
+// @public (undocumented)
+export type FolioDocxConformanceReport = {
+    readonly version: typeof FOLIO_DOCX_CONFORMANCE_REPORT_VERSION;
+    readonly profile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+    readonly status: FolioDocxConformanceStatus;
+    readonly conformanceClass: import__stll_docx_core_model.DocxConformanceClass;
+    readonly checks: readonly FolioDocxConformanceCheck[];
+    readonly issues: readonly FolioDocxConformanceIssue[];
+    readonly unverifiedStandardsDimensions: readonly ["complete-schema-constraints", "markup-compatibility-processing", "consumer-specific-rendering"];
+};
+
+// @public (undocumented)
+export type FolioDocxConformanceStatus = "invalid" | "conformant" | "indeterminate";
+
 // @public
 export class FolioDocxReviewer {
     acceptAll(): number;
@@ -1008,6 +1068,14 @@ export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFo
 
 // @public (undocumented)
 export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base {}
+
+// @public
+export const validateDocxConformance: (bytes: ArrayBuffer | Uint8Array, options?: ValidateDocxConformanceOptions) => Promise<FolioDocxConformanceReport>;
+
+// @public (undocumented)
+export type ValidateDocxConformanceOptions = {
+    readonly archive?: DocxArchiveOptions;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/src/docx/server/boundedArchive.test.ts
+++ b/packages/core/src/docx/server/boundedArchive.test.ts
@@ -51,6 +51,12 @@ describe("loadDocxArchive", () => {
     expect(error).toMatchObject({ reason: "too-many-entries" });
   });
 
+  test("rejects excessive input size before archive parsing", async () => {
+    const error = await rejection(loadDocxArchive(new Uint8Array(5), { maxInputBytes: 4 }));
+
+    expect(error).toMatchObject({ reason: "input-too-large" });
+  });
+
   test("rejects declared entry and cumulative sizes", async () => {
     const bytes = await makeZip({ a: "12345", b: "67890" });
     const entryError = await rejection(loadDocxArchive(bytes, { maxEntryBytes: 4 }));

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -4,15 +4,22 @@ import JSZip from "jszip";
 export const DOCX_MAX_ENTRY_BYTES = 128 * 1024 * 1024;
 export const DOCX_MAX_TOTAL_BYTES = 256 * 1024 * 1024;
 export const DOCX_MAX_ENTRIES = 4096;
+export const DOCX_MAX_INPUT_BYTES = 50 * 1024 * 1024;
 
 /** Error raised when a DOCX archive cannot be loaded within configured limits. */
 export class DocxArchiveError extends TaggedError("DocxArchiveError")<{
   message: string;
-  reason: "load-failed" | "too-many-entries" | "entry-too-large" | "total-too-large";
+  reason:
+    | "load-failed"
+    | "input-too-large"
+    | "too-many-entries"
+    | "entry-too-large"
+    | "total-too-large";
   cause?: unknown;
 }>() {}
 
 export type DocxArchiveOptions = {
+  maxInputBytes?: number;
   maxEntryBytes?: number;
   maxTotalBytes?: number;
   maxEntries?: number;
@@ -76,9 +83,17 @@ export const loadDocxArchive = async (
   bytes: ArrayBuffer | Uint8Array,
   options: DocxArchiveOptions = {},
 ): Promise<DocxArchive> => {
+  const maxInputBytes = options.maxInputBytes ?? DOCX_MAX_INPUT_BYTES;
   const maxEntryBytes = options.maxEntryBytes ?? DOCX_MAX_ENTRY_BYTES;
   const maxTotalBytes = options.maxTotalBytes ?? DOCX_MAX_TOTAL_BYTES;
   const maxEntries = options.maxEntries ?? DOCX_MAX_ENTRIES;
+
+  if (bytes.byteLength > maxInputBytes) {
+    throw new DocxArchiveError({
+      message: `DOCX input contains ${bytes.byteLength} bytes (max ${maxInputBytes})`,
+      reason: "input-too-large",
+    });
+  }
 
   let zip: JSZip;
   try {

--- a/packages/core/src/docx/server/validateDocxConformance.test.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.test.ts
@@ -131,6 +131,22 @@ describe("validateDocxConformance", () => {
     expect(checkStatus(report, "package-roots")).toBe("passed");
   });
 
+  test("accepts a package-root-relative main document target", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file(
+        "_rels/.rels",
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="/word/document.xml"/>
+        </Relationships>`,
+      );
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("conformant");
+    expect(checkStatus(report, "package-roots")).toBe("passed");
+  });
+
   test("reports an unknown main document namespace as indeterminate", async () => {
     const bytes = await mutateEmptyPackage((zip) => {
       zip.file(

--- a/packages/core/src/docx/server/validateDocxConformance.test.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { createEmptyDocx } from "../rezip";
+import type {
+  FolioDocxConformanceCheckId,
+  FolioDocxConformanceReport,
+} from "./validateDocxConformance";
+import {
+  FOLIO_DOCX_CONFORMANCE_PROFILE,
+  FOLIO_DOCX_CONFORMANCE_REPORT_VERSION,
+  validateDocxConformance,
+} from "./validateDocxConformance";
+
+const checkStatus = (report: FolioDocxConformanceReport, id: FolioDocxConformanceCheckId) =>
+  report.checks.find((check) => check.id === id)?.status;
+
+type MutatePackage = (zip: JSZip) => void;
+
+const mutateEmptyPackage = async (mutate: MutatePackage): Promise<Uint8Array> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  mutate(zip);
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+describe("validateDocxConformance", () => {
+  test("reports the exact profile and unverified dimensions for a supported package", async () => {
+    const report = await validateDocxConformance(await createEmptyDocx());
+
+    expect(report).toMatchObject({
+      version: FOLIO_DOCX_CONFORMANCE_REPORT_VERSION,
+      profile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+      status: "conformant",
+      conformanceClass: "transitional",
+      issues: [],
+    });
+    expect(report.checks.every(({ status }) => status === "passed")).toBe(true);
+    expect(report.unverifiedStandardsDimensions).toEqual([
+      "complete-schema-constraints",
+      "markup-compatibility-processing",
+      "consumer-specific-rendering",
+    ]);
+  });
+
+  test("fails a malformed XML part and does not run semantic checks", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("word/document.xml", "<w:document>");
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("invalid");
+    expect(checkStatus(report, "xml-well-formedness")).toBe("failed");
+    expect(checkStatus(report, "package-roots")).toBe("not-run");
+    expect(report.issues).toContainEqual({
+      check: "xml-well-formedness",
+      code: "xml-not-well-formed",
+      message: "An XML package part is not well formed.",
+      severity: "error",
+      part: "word/document.xml",
+    });
+  });
+
+  test("rejects document type declarations in XML package parts", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("custom.xml", "<!DOCTYPE root [<!ELEMENT root EMPTY>]><root/>");
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("invalid");
+    expect(report.issues.at(0)).toMatchObject({
+      check: "xml-well-formedness",
+      code: "xml-doctype-forbidden",
+      part: "custom.xml",
+    });
+  });
+
+  test("fails missing required parts with their package paths", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.remove("_rels/.rels");
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("invalid");
+    expect(checkStatus(report, "required-parts")).toBe("failed");
+    expect(report.issues).toContainEqual({
+      check: "required-parts",
+      code: "required-part-missing",
+      message: "A required package part is missing.",
+      severity: "error",
+      part: "_rels/.rels",
+    });
+  });
+
+  test("fails an invalid main document package binding", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file(
+        "_rels/.rels",
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>',
+      );
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("invalid");
+    expect(checkStatus(report, "package-roots")).toBe("failed");
+    expect(report.issues.some(({ part }) => part === "_rels/.rels")).toBe(true);
+  });
+
+  test("accepts prefixed package vocabulary roots", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file(
+        "[Content_Types].xml",
+        `<ct:Types xmlns:ct="http://schemas.openxmlformats.org/package/2006/content-types">
+          <ct:Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+        </ct:Types>`,
+      );
+      zip.file(
+        "_rels/.rels",
+        `<r:Relationships xmlns:r="http://schemas.openxmlformats.org/package/2006/relationships">
+          <r:Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+        </r:Relationships>`,
+      );
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("conformant");
+    expect(checkStatus(report, "package-roots")).toBe("passed");
+  });
+
+  test("reports an unknown main document namespace as indeterminate", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file(
+        "word/document.xml",
+        '<x:document xmlns:x="urn:example"><x:body><x:p/></x:body></x:document>',
+      );
+    });
+
+    const report = await validateDocxConformance(bytes);
+
+    expect(report.status).toBe("indeterminate");
+    expect(report.conformanceClass).toBe("unknown");
+    expect(checkStatus(report, "conformance-class")).toBe("indeterminate");
+    expect(report.issues).toContainEqual({
+      check: "conformance-class",
+      code: "conformance-class-unknown",
+      message: "The main document namespace does not identify a supported conformance class.",
+      severity: "warning",
+      part: "word/document.xml",
+    });
+  });
+
+  test("reports encrypted containers as indeterminate before archive loading", async () => {
+    const report = await validateDocxConformance(
+      new Uint8Array([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
+    );
+
+    expect(report.status).toBe("indeterminate");
+    expect(checkStatus(report, "archive-safety")).toBe("indeterminate");
+    expect(checkStatus(report, "required-parts")).toBe("not-run");
+  });
+
+  test("fails packages that exceed configured archive limits", async () => {
+    const report = await validateDocxConformance(await createEmptyDocx(), {
+      archive: { maxEntries: 1 },
+    });
+
+    expect(report.status).toBe("invalid");
+    expect(checkStatus(report, "archive-safety")).toBe("failed");
+    expect(report.issues.at(0)?.code).toBe("archive-too-many-entries");
+  });
+});

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -1,0 +1,508 @@
+import { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
+import { XMLValidator } from "fast-xml-parser";
+
+import type { DocxConformanceClass } from "../../types/document";
+import { detectDocxConformanceClass } from "../conformance";
+import { DOCX_CONTAINER_TYPES, detectDocxContainerType } from "../encryption/containerFormat";
+import { DocxModelValidationError, validateFolioDocumentModel } from "../modelValidation";
+import { DocxParseError, parseDocx } from "../parser";
+import {
+  findChildByLocalName,
+  getAttributeAnyPrefix,
+  getLocalName,
+  getNamespacePrefix,
+  parseXmlDocument,
+} from "../xmlParser";
+import type { DocxArchive, DocxArchiveOptions } from "./boundedArchive";
+import { DocxArchiveError, loadDocxArchive } from "./boundedArchive";
+
+export const FOLIO_DOCX_CONFORMANCE_REPORT_VERSION = 1 as const;
+export const FOLIO_DOCX_CONFORMANCE_PROFILE = "folio-supported-v1" as const;
+
+export const FOLIO_DOCX_CONFORMANCE_CHECKS = Object.freeze([
+  "archive-safety",
+  "required-parts",
+  "xml-well-formedness",
+  "package-roots",
+  "conformance-class",
+  "canonical-model",
+] as const);
+
+export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES = Object.freeze([
+  "archive-load-failed",
+  "archive-too-many-entries",
+  "archive-entry-too-large",
+  "archive-total-too-large",
+  "required-part-missing",
+  "xml-doctype-forbidden",
+  "xml-not-well-formed",
+  "required-xml-unreadable",
+  "package-root-invalid",
+  "conformance-class-unknown",
+  "model-invalid",
+  "model-warning",
+  "parser-recovery",
+  "parser-unsupported",
+  "parser-failed",
+  "encrypted-container",
+  "container-not-zip",
+] as const);
+
+export type FolioDocxConformanceCheckId = (typeof FOLIO_DOCX_CONFORMANCE_CHECKS)[number];
+export type FolioDocxConformanceIssueCode = (typeof FOLIO_DOCX_CONFORMANCE_ISSUE_CODES)[number];
+export type FolioDocxConformanceCheckStatus = "passed" | "failed" | "indeterminate" | "not-run";
+export type FolioDocxConformanceStatus = "invalid" | "conformant" | "indeterminate";
+
+export type FolioDocxConformanceIssue = {
+  readonly check: FolioDocxConformanceCheckId;
+  readonly code: FolioDocxConformanceIssueCode;
+  readonly message: string;
+  readonly severity: "error" | "warning";
+  readonly part?: string;
+  readonly modelPath?: string;
+  readonly count?: number;
+};
+
+export type FolioDocxConformanceCheck = {
+  readonly id: FolioDocxConformanceCheckId;
+  readonly status: FolioDocxConformanceCheckStatus;
+};
+
+export type FolioDocxConformanceReport = {
+  readonly version: typeof FOLIO_DOCX_CONFORMANCE_REPORT_VERSION;
+  readonly profile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+  readonly status: FolioDocxConformanceStatus;
+  readonly conformanceClass: DocxConformanceClass;
+  readonly checks: readonly FolioDocxConformanceCheck[];
+  readonly issues: readonly FolioDocxConformanceIssue[];
+  readonly unverifiedStandardsDimensions: readonly [
+    "complete-schema-constraints",
+    "markup-compatibility-processing",
+    "consumer-specific-rendering",
+  ];
+};
+
+export type ValidateDocxConformanceOptions = {
+  readonly archive?: DocxArchiveOptions;
+};
+
+const REQUIRED_PARTS = Object.freeze([
+  "[Content_Types].xml",
+  "_rels/.rels",
+  "word/document.xml",
+] as const);
+const XML_PART_PATTERN = /(?:\.xml|\.rels)$/u;
+const DOCUMENT_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+const CONTENT_TYPES_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/content-types";
+const RELATIONSHIPS_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/relationships";
+const DOCTYPE_PATTERN = /<!DOCTYPE(?:\s|>)/iu;
+const UNVERIFIED_STANDARDS_DIMENSIONS = Object.freeze([
+  "complete-schema-constraints",
+  "markup-compatibility-processing",
+  "consumer-specific-rendering",
+] as const);
+
+type MutableReport = {
+  conformanceClass: DocxConformanceClass;
+  checks: Map<FolioDocxConformanceCheckId, FolioDocxConformanceCheckStatus>;
+  issues: FolioDocxConformanceIssue[];
+};
+
+const createMutableReport = (): MutableReport => ({
+  conformanceClass: DOCX_CONFORMANCE_CLASSES.UNKNOWN,
+  checks: new Map(FOLIO_DOCX_CONFORMANCE_CHECKS.map((id) => [id, "not-run"])),
+  issues: [],
+});
+
+const addIssue = (report: MutableReport, issue: FolioDocxConformanceIssue): void => {
+  report.issues.push(issue);
+};
+
+const finishReport = (report: MutableReport): FolioDocxConformanceReport => {
+  const checks = FOLIO_DOCX_CONFORMANCE_CHECKS.map((id) => ({
+    id,
+    status: report.checks.get(id) ?? "not-run",
+  }));
+  const hasFailedCheck = checks.some(({ status }) => status === "failed");
+  const hasIndeterminateCheck = checks.some(({ status }) => status === "indeterminate");
+  let status: FolioDocxConformanceStatus = "conformant";
+  if (hasFailedCheck) {
+    status = "invalid";
+  } else if (
+    hasIndeterminateCheck ||
+    checks.some(({ status: checkStatus }) => checkStatus === "not-run")
+  ) {
+    status = "indeterminate";
+  }
+
+  return {
+    version: FOLIO_DOCX_CONFORMANCE_REPORT_VERSION,
+    profile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+    status,
+    conformanceClass: report.conformanceClass,
+    checks,
+    issues: report.issues,
+    unverifiedStandardsDimensions: UNVERIFIED_STANDARDS_DIMENSIONS,
+  };
+};
+
+const validateRequiredParts = (archive: DocxArchive, report: MutableReport): boolean => {
+  const entries = new Set(archive.entries);
+  const missingParts = REQUIRED_PARTS.filter((path) => !entries.has(path));
+  if (missingParts.length === 0) {
+    report.checks.set("required-parts", "passed");
+    return true;
+  }
+
+  report.checks.set("required-parts", "failed");
+  for (const part of missingParts) {
+    addIssue(report, {
+      check: "required-parts",
+      code: "required-part-missing",
+      message: "A required package part is missing.",
+      severity: "error",
+      part,
+    });
+  }
+  return false;
+};
+
+type XmlPartsResult = {
+  documentXml: string;
+  packageRelationshipsXml: string;
+  contentTypesXml: string;
+};
+
+const validateXmlParts = async (
+  archive: DocxArchive,
+  report: MutableReport,
+): Promise<XmlPartsResult | null> => {
+  const xmlByPath = new Map<string, string>();
+  let hasInvalidXml = false;
+
+  for (const part of archive.entries.filter((path) => XML_PART_PATTERN.test(path)).toSorted()) {
+    // oxlint-disable-next-line no-await-in-loop -- serialized reads enforce the archive byte budget
+    const xml = await archive.readEntryString(part);
+    if (xml === null) {
+      continue;
+    }
+    xmlByPath.set(part, xml);
+
+    if (DOCTYPE_PATTERN.test(xml)) {
+      hasInvalidXml = true;
+      addIssue(report, {
+        check: "xml-well-formedness",
+        code: "xml-doctype-forbidden",
+        message: "XML package parts must not declare a document type.",
+        severity: "error",
+        part,
+      });
+      continue;
+    }
+
+    if (XMLValidator.validate(xml) !== true) {
+      hasInvalidXml = true;
+      addIssue(report, {
+        check: "xml-well-formedness",
+        code: "xml-not-well-formed",
+        message: "An XML package part is not well formed.",
+        severity: "error",
+        part,
+      });
+    }
+  }
+
+  if (hasInvalidXml) {
+    report.checks.set("xml-well-formedness", "failed");
+    return null;
+  }
+  report.checks.set("xml-well-formedness", "passed");
+
+  const contentTypesXml = xmlByPath.get("[Content_Types].xml");
+  const packageRelationshipsXml = xmlByPath.get("_rels/.rels");
+  const documentXml = xmlByPath.get("word/document.xml");
+  if (
+    contentTypesXml === undefined ||
+    packageRelationshipsXml === undefined ||
+    documentXml === undefined
+  ) {
+    report.checks.set("xml-well-formedness", "indeterminate");
+    addIssue(report, {
+      check: "xml-well-formedness",
+      code: "required-xml-unreadable",
+      message: "A required XML package part could not be read.",
+      severity: "error",
+    });
+    return null;
+  }
+
+  return { contentTypesXml, packageRelationshipsXml, documentXml };
+};
+
+type HasRootNamespaceOptions = {
+  name: string;
+  attributes: Record<string, unknown> | undefined;
+  expected: string;
+};
+
+const hasRootNamespace = ({ name, attributes, expected }: HasRootNamespaceOptions): boolean => {
+  const prefix = getNamespacePrefix(name);
+  const attribute = prefix === null ? "xmlns" : `xmlns:${prefix}`;
+  return attributes?.[attribute] === expected;
+};
+
+const hasDocumentContentType = (contentTypesXml: string): boolean => {
+  const root = parseXmlDocument(contentTypesXml);
+  if (
+    root === null ||
+    getLocalName(root.name ?? "") !== "Types" ||
+    !hasRootNamespace({
+      name: root.name ?? "",
+      attributes: root.attributes,
+      expected: CONTENT_TYPES_NAMESPACE,
+    })
+  ) {
+    return false;
+  }
+
+  return (
+    root.elements?.some(
+      (element) =>
+        element.type === "element" &&
+        getLocalName(element.name ?? "") === "Override" &&
+        getAttributeAnyPrefix(element, "PartName") === "/word/document.xml" &&
+        getAttributeAnyPrefix(element, "ContentType") === DOCUMENT_CONTENT_TYPE,
+    ) ?? false
+  );
+};
+
+const hasMainDocumentRelationship = (packageRelationshipsXml: string): boolean => {
+  const root = parseXmlDocument(packageRelationshipsXml);
+  if (
+    root === null ||
+    getLocalName(root.name ?? "") !== "Relationships" ||
+    !hasRootNamespace({
+      name: root.name ?? "",
+      attributes: root.attributes,
+      expected: RELATIONSHIPS_NAMESPACE,
+    })
+  ) {
+    return false;
+  }
+
+  return (
+    root.elements?.some((element) => {
+      if (element.type !== "element" || getLocalName(element.name ?? "") !== "Relationship") {
+        return false;
+      }
+      const type = getAttributeAnyPrefix(element, "Type");
+      return (
+        type?.endsWith("/officeDocument") === true &&
+        getAttributeAnyPrefix(element, "Target") === "word/document.xml" &&
+        getAttributeAnyPrefix(element, "TargetMode") !== "External"
+      );
+    }) ?? false
+  );
+};
+
+const hasDocumentRoot = (documentXml: string): boolean => {
+  const root = parseXmlDocument(documentXml);
+  return (
+    root !== null &&
+    getLocalName(root.name ?? "") === "document" &&
+    findChildByLocalName(root, "body") !== null
+  );
+};
+
+const validatePackageRoots = (xml: XmlPartsResult, report: MutableReport): boolean => {
+  const invalidParts: string[] = [];
+  if (!hasDocumentContentType(xml.contentTypesXml)) {
+    invalidParts.push("[Content_Types].xml");
+  }
+  if (!hasMainDocumentRelationship(xml.packageRelationshipsXml)) {
+    invalidParts.push("_rels/.rels");
+  }
+  if (!hasDocumentRoot(xml.documentXml)) {
+    invalidParts.push("word/document.xml");
+  }
+
+  if (invalidParts.length === 0) {
+    report.checks.set("package-roots", "passed");
+    return true;
+  }
+
+  report.checks.set("package-roots", "failed");
+  for (const part of invalidParts) {
+    addIssue(report, {
+      check: "package-roots",
+      code: "package-root-invalid",
+      message:
+        "A required package part does not declare the expected root or main document binding.",
+      severity: "error",
+      part,
+    });
+  }
+  return false;
+};
+
+const validateConformanceClass = (documentXml: string, report: MutableReport): void => {
+  report.conformanceClass = detectDocxConformanceClass(documentXml);
+  if (report.conformanceClass !== DOCX_CONFORMANCE_CLASSES.UNKNOWN) {
+    report.checks.set("conformance-class", "passed");
+    return;
+  }
+
+  report.checks.set("conformance-class", "indeterminate");
+  addIssue(report, {
+    check: "conformance-class",
+    code: "conformance-class-unknown",
+    message: "The main document namespace does not identify a supported conformance class.",
+    severity: "warning",
+    part: "word/document.xml",
+  });
+};
+
+const findModelValidationError = (error: unknown): DocxModelValidationError | null => {
+  let current = error;
+  while (current instanceof Error) {
+    if (current instanceof DocxModelValidationError) {
+      return current;
+    }
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return null;
+};
+
+const validateCanonicalModel = async (
+  bytes: ArrayBuffer | Uint8Array,
+  report: MutableReport,
+): Promise<void> => {
+  try {
+    const document = await parseDocx(bytes, {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+    const validation = validateFolioDocumentModel(document);
+    if (!validation.valid) {
+      report.checks.set("canonical-model", "failed");
+    } else if ((document.warnings?.length ?? 0) > 0) {
+      report.checks.set("canonical-model", "indeterminate");
+      addIssue(report, {
+        check: "canonical-model",
+        code: "parser-recovery",
+        message: "The canonical parser reported recovery or preservation warnings.",
+        severity: "warning",
+        count: document.warnings?.length,
+      });
+    } else {
+      report.checks.set("canonical-model", "passed");
+    }
+
+    for (const issue of validation.issues) {
+      addIssue(report, {
+        check: "canonical-model",
+        code: issue.severity === "error" ? "model-invalid" : "model-warning",
+        message: issue.message,
+        severity: issue.severity,
+        modelPath: issue.path,
+      });
+    }
+  } catch (error) {
+    const modelError = findModelValidationError(error);
+    if (modelError !== null) {
+      report.checks.set("canonical-model", "failed");
+      for (const issue of modelError.issues) {
+        addIssue(report, {
+          check: "canonical-model",
+          code: issue.severity === "error" ? "model-invalid" : "model-warning",
+          message: issue.message,
+          severity: issue.severity,
+          modelPath: issue.path,
+        });
+      }
+      return;
+    }
+
+    report.checks.set("canonical-model", "indeterminate");
+    addIssue(report, {
+      check: "canonical-model",
+      code: error instanceof DocxParseError ? "parser-unsupported" : "parser-failed",
+      message: "The canonical document model could not be assessed.",
+      severity: "warning",
+    });
+  }
+};
+
+/** Assess a DOCX package against Folio's named, versioned support profile. */
+export const validateDocxConformance = async (
+  bytes: ArrayBuffer | Uint8Array,
+  options: ValidateDocxConformanceOptions = {},
+): Promise<FolioDocxConformanceReport> => {
+  const report = createMutableReport();
+  const containerType = detectDocxContainerType(bytes);
+  if (containerType === DOCX_CONTAINER_TYPES.CFB) {
+    report.checks.set("archive-safety", "indeterminate");
+    addIssue(report, {
+      check: "archive-safety",
+      code: "encrypted-container",
+      message: "Encrypted containers require decryption before this profile can assess them.",
+      severity: "warning",
+    });
+    return finishReport(report);
+  }
+  if (containerType !== DOCX_CONTAINER_TYPES.ZIP) {
+    report.checks.set("archive-safety", "failed");
+    addIssue(report, {
+      check: "archive-safety",
+      code: "container-not-zip",
+      message: "The input is not a supported DOCX package container.",
+      severity: "error",
+    });
+    return finishReport(report);
+  }
+
+  let archive: DocxArchive;
+  try {
+    archive = await loadDocxArchive(bytes, options.archive);
+    report.checks.set("archive-safety", "passed");
+  } catch (error) {
+    report.checks.set("archive-safety", "failed");
+    addIssue(report, {
+      check: "archive-safety",
+      code: error instanceof DocxArchiveError ? `archive-${error.reason}` : "archive-load-failed",
+      message: "The DOCX package could not be loaded within the configured safety limits.",
+      severity: "error",
+    });
+    return finishReport(report);
+  }
+
+  if (!validateRequiredParts(archive, report)) {
+    return finishReport(report);
+  }
+
+  let xml: XmlPartsResult | null;
+  try {
+    xml = await validateXmlParts(archive, report);
+  } catch (error) {
+    report.checks.set("xml-well-formedness", "indeterminate");
+    addIssue(report, {
+      check: "xml-well-formedness",
+      code: error instanceof DocxArchiveError ? `archive-${error.reason}` : "xml-read-failed",
+      message: "The XML package parts could not be read within the configured safety limits.",
+      severity: "warning",
+    });
+    return finishReport(report);
+  }
+  if (xml === null) {
+    return finishReport(report);
+  }
+
+  if (!validatePackageRoots(xml, report)) {
+    return finishReport(report);
+  }
+
+  validateConformanceClass(xml.documentXml, report);
+  await validateCanonicalModel(bytes, report);
+  return finishReport(report);
+};

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -37,6 +37,7 @@ export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES = Object.freeze([
   "required-part-missing",
   "xml-doctype-forbidden",
   "xml-not-well-formed",
+  "xml-read-failed",
   "required-xml-unreadable",
   "package-root-invalid",
   "conformance-class-unknown",
@@ -386,16 +387,17 @@ const validateCanonicalModel = async (
       preloadFonts: false,
     });
     const validation = validateFolioDocumentModel(document);
+    const warningCount = document.warnings?.length ?? 0;
     if (!validation.valid) {
       report.checks.set("canonical-model", "failed");
-    } else if ((document.warnings?.length ?? 0) > 0) {
+    } else if (warningCount > 0) {
       report.checks.set("canonical-model", "indeterminate");
       addIssue(report, {
         check: "canonical-model",
         code: "parser-recovery",
         message: "The canonical parser reported recovery or preservation warnings.",
         severity: "warning",
-        count: document.warnings?.length,
+        count: warningCount,
       });
     } else {
       report.checks.set("canonical-model", "passed");

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -299,7 +299,7 @@ const hasMainDocumentRelationship = (packageRelationshipsXml: string): boolean =
         return false;
       }
       const type = getAttributeAnyPrefix(element, "Type");
-      const target = getAttributeAnyPrefix(element, "Target")?.replace(/^\.\//u, "");
+      const target = getAttributeAnyPrefix(element, "Target")?.replace(/^\.?\//u, "");
       return (
         type?.endsWith("/officeDocument") === true &&
         target === "word/document.xml" &&

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -112,7 +112,7 @@ type MutableReport = {
 
 const createMutableReport = (): MutableReport => ({
   conformanceClass: DOCX_CONFORMANCE_CLASSES.UNKNOWN,
-  checks: new Map(FOLIO_DOCX_CONFORMANCE_CHECKS.map((id) => [id, "not-run"])),
+  checks: new Map(FOLIO_DOCX_CONFORMANCE_CHECKS.map((id) => [id, "not-run"] as const)),
   issues: [],
 });
 
@@ -298,9 +298,10 @@ const hasMainDocumentRelationship = (packageRelationshipsXml: string): boolean =
         return false;
       }
       const type = getAttributeAnyPrefix(element, "Type");
+      const target = getAttributeAnyPrefix(element, "Target")?.replace(/^\.\//u, "");
       return (
         type?.endsWith("/officeDocument") === true &&
-        getAttributeAnyPrefix(element, "Target") === "word/document.xml" &&
+        target === "word/document.xml" &&
         getAttributeAnyPrefix(element, "TargetMode") !== "External"
       );
     }) ?? false

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -30,6 +30,7 @@ export const FOLIO_DOCX_CONFORMANCE_CHECKS = Object.freeze([
 
 export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES = Object.freeze([
   "archive-load-failed",
+  "archive-input-too-large",
   "archive-too-many-entries",
   "archive-entry-too-large",
   "archive-total-too-large",

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -175,6 +175,21 @@ export {
 } from "./docx/server/extractDocxText";
 export { DocxArchiveError } from "./docx/server/boundedArchive";
 export {
+  FOLIO_DOCX_CONFORMANCE_CHECKS,
+  FOLIO_DOCX_CONFORMANCE_ISSUE_CODES,
+  FOLIO_DOCX_CONFORMANCE_PROFILE,
+  FOLIO_DOCX_CONFORMANCE_REPORT_VERSION,
+  validateDocxConformance,
+  type FolioDocxConformanceCheck,
+  type FolioDocxConformanceCheckId,
+  type FolioDocxConformanceCheckStatus,
+  type FolioDocxConformanceIssue,
+  type FolioDocxConformanceIssueCode,
+  type FolioDocxConformanceReport,
+  type FolioDocxConformanceStatus,
+  type ValidateDocxConformanceOptions,
+} from "./docx/server/validateDocxConformance";
+export {
   FOLIO_DOCUMENT_PRIVACY_TRANSFORMS,
   FolioDocumentPrivacyArchiveError,
   InvalidFolioDocumentPrivacyOptionsError,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -173,7 +173,7 @@ export {
   type ExtractedDocxParagraph,
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";
-export { DocxArchiveError } from "./docx/server/boundedArchive";
+export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";
 export {
   FOLIO_DOCX_CONFORMANCE_CHECKS,
   FOLIO_DOCX_CONFORMANCE_ISSUE_CODES,


### PR DESCRIPTION
## Summary

- add a versioned package conformance report
- report bounded archive, XML, package binding, and canonical model checks
- bound archive input size before parsing