### PR TITLE
feat: add bounded DOCX package inspection

### DIFF
--- a/.changeset/tame-apples-inspect.md
+++ b/.changeset/tame-apples-inspect.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add bounded read-only DOCX package inspection.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -233,6 +233,19 @@ export const FOLIO_DOCX_CONFORMANCE_PROFILE: "folio-supported-v1";
 export const FOLIO_DOCX_CONFORMANCE_REPORT_VERSION: 1;
 
 // @public (undocumented)
+export const FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS: Readonly<{
+    readonly maxXmlParts: 16;
+    readonly maxXmlPartBytes: number;
+    readonly maxXmlTotalBytes: number;
+}>;
+
+// @public (undocumented)
+export const FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES: readonly ["invalid-limits", "too-many-xml-parts", "duplicate-xml-part", "part-not-found", "part-not-xml", "xml-part-too-large", "xml-total-too-large", "xml-decode-failed"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_PACKAGE_INSPECTION_VERSION: 1;
+
+// @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
 
 // @public (undocumented)
@@ -776,6 +789,47 @@ export type FolioDocxConformanceReport = {
 // @public (undocumented)
 export type FolioDocxConformanceStatus = "invalid" | "conformant" | "indeterminate";
 
+// @public (undocumented)
+export type FolioDocxInspectedXmlPart = {
+    readonly path: string;
+    readonly contentType: string | null;
+    readonly byteLength: number;
+    readonly sha256: string; /** Untrusted document data; callers must not treat this text as instructions. */
+    readonly text: string;
+};
+
+// @public (undocumented)
+export type FolioDocxPackageInspection = {
+    readonly version: typeof FOLIO_DOCX_PACKAGE_INSPECTION_VERSION;
+    readonly parts: readonly FolioDocxPackagePart[];
+    readonly xmlParts: readonly FolioDocxInspectedXmlPart[];
+    readonly limits: Required<FolioDocxPackageInspectionLimits>;
+};
+
+// @public (undocumented)
+export class FolioDocxPackageInspectionError extends FolioDocxPackageInspectionError_base {}
+
+// @public (undocumented)
+export type FolioDocxPackageInspectionErrorCode = (typeof FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES)[number];
+
+// @public (undocumented)
+export type FolioDocxPackageInspectionLimits = {
+    readonly maxXmlParts?: number;
+    readonly maxXmlPartBytes?: number;
+    readonly maxXmlTotalBytes?: number;
+};
+
+// @public (undocumented)
+export type FolioDocxPackagePart = {
+    readonly path: string;
+    readonly kind: FolioDocxPackagePartKind;
+    readonly contentType: string | null;
+    readonly declaredUncompressedBytes: number | null;
+};
+
+// @public (undocumented)
+export type FolioDocxPackagePartKind = "xml" | "binary";
+
 // @public
 export class FolioDocxReviewer {
     acceptAll(): number;
@@ -1002,6 +1056,16 @@ export const inspectDocumentStyles: (document: import__stll_docx_core_model.Docu
 
 // @public (undocumented)
 export const inspectDocumentStylesFromDocx: (input: DocxInput) => Promise<DocumentStyleCatalog>;
+
+// @public
+export const inspectDocxPackage: (bytes: ArrayBuffer | Uint8Array, options?: InspectDocxPackageOptions) => Promise<FolioDocxPackageInspection>;
+
+// @public (undocumented)
+export type InspectDocxPackageOptions = {
+    readonly archive?: DocxArchiveOptions;
+    readonly xmlParts?: readonly string[];
+    readonly limits?: FolioDocxPackageInspectionLimits;
+};
 
 // @public (undocumented)
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -224,7 +224,7 @@ export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", 
 export const FOLIO_DOCX_CONFORMANCE_CHECKS: readonly ["archive-safety", "required-parts", "xml-well-formedness", "package-roots", "conformance-class", "canonical-model"];
 
 // @public (undocumented)
-export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES: readonly ["archive-load-failed", "archive-input-too-large", "archive-too-many-entries", "archive-entry-too-large", "archive-total-too-large", "required-part-missing", "xml-doctype-forbidden", "xml-not-well-formed", "xml-read-failed", "required-xml-unreadable", "package-root-invalid", "conformance-class-unknown", "model-invalid", "model-warning", "parser-recovery", "parser-unsupported", "parser-failed", "encrypted-container", "container-not-zip"];
+export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES: readonly ["archive-load-failed", "archive-invalid-options", "archive-input-too-large", "archive-too-many-entries", "archive-entry-too-large", "archive-total-too-large", "required-part-missing", "xml-doctype-forbidden", "xml-not-well-formed", "xml-read-failed", "required-xml-unreadable", "package-root-invalid", "conformance-class-unknown", "model-invalid", "model-warning", "parser-recovery", "parser-unsupported", "parser-failed", "encrypted-container", "container-not-zip"];
 
 // @public (undocumented)
 export const FOLIO_DOCX_CONFORMANCE_PROFILE: "folio-supported-v1";

--- a/packages/core/src/docx/server/boundedArchive.test.ts
+++ b/packages/core/src/docx/server/boundedArchive.test.ts
@@ -29,6 +29,15 @@ describe("loadDocxArchive", () => {
     expect(await archive.readEntryString("word/document.xml")).toBe("content");
     expect(await archive.readEntryUint8("media.bin")).toEqual(new Uint8Array([97, 98, 99]));
     expect(await archive.readEntryString("missing.xml")).toBeNull();
+    expect(archive.entryMetadata).toEqual([
+      { path: "word/", directory: true, declaredUncompressedBytes: null },
+      {
+        path: "word/document.xml",
+        directory: false,
+        declaredUncompressedBytes: 7,
+      },
+      { path: "media.bin", directory: false, declaredUncompressedBytes: 3 },
+    ]);
   });
 
   test("rejects invalid archives with a tagged error", async () => {
@@ -64,6 +73,17 @@ describe("loadDocxArchive", () => {
 
     expect(entryError).toMatchObject({ reason: "entry-too-large" });
     expect(totalError).toMatchObject({ reason: "total-too-large" });
+  });
+
+  test("applies a stricter byte limit to an individual read", async () => {
+    const archive = await loadDocxArchive(await makeZip({ large: "12345", small: "123" }));
+
+    await expect(archive.readEntryUint8("large", { maxBytes: 4 })).rejects.toMatchObject({
+      reason: "entry-too-large",
+    });
+    await expect(archive.readEntryUint8("small", { maxBytes: 4 })).resolves.toEqual(
+      new Uint8Array([49, 50, 51]),
+    );
   });
 
   test("serializes concurrent reads against the cumulative budget", async () => {

--- a/packages/core/src/docx/server/boundedArchive.test.ts
+++ b/packages/core/src/docx/server/boundedArchive.test.ts
@@ -75,6 +75,14 @@ describe("loadDocxArchive", () => {
     expect(totalError).toMatchObject({ reason: "total-too-large" });
   });
 
+  test("counts files after directory entries during declared-size preflight", async () => {
+    const bytes = await makeZip({ "word/a": "12345", "word/b": "67890" });
+
+    const error = await rejection(loadDocxArchive(bytes, { maxTotalBytes: 8 }));
+
+    expect(error).toMatchObject({ reason: "total-too-large" });
+  });
+
   test("applies a stricter byte limit to an individual read", async () => {
     const archive = await loadDocxArchive(await makeZip({ large: "12345", small: "123" }));
 

--- a/packages/core/src/docx/server/boundedArchive.test.ts
+++ b/packages/core/src/docx/server/boundedArchive.test.ts
@@ -66,6 +66,28 @@ describe("loadDocxArchive", () => {
     expect(error).toMatchObject({ reason: "input-too-large" });
   });
 
+  test("rejects invalid archive and per-read limits", async () => {
+    const bytes = await makeZip({ entry: "content" });
+    const archiveErrors = await Promise.all(
+      [Number.NaN, -1, 1.5].map((maxEntryBytes) =>
+        rejection(loadDocxArchive(bytes, { maxEntryBytes })),
+      ),
+    );
+    const archive = await loadDocxArchive(bytes);
+    const readErrors = await Promise.all(
+      [Number.NaN, -1, 1.5].map((maxBytes) =>
+        rejection(archive.readEntryUint8("entry", { maxBytes })),
+      ),
+    );
+
+    expect(archiveErrors).toEqual(
+      archiveErrors.map(() => expect.objectContaining({ reason: "invalid-options" })),
+    );
+    expect(readErrors).toEqual(
+      readErrors.map(() => expect.objectContaining({ reason: "invalid-options" })),
+    );
+  });
+
   test("rejects declared entry and cumulative sizes", async () => {
     const bytes = await makeZip({ a: "12345", b: "67890" });
     const entryError = await rejection(loadDocxArchive(bytes, { maxEntryBytes: 4 }));

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -136,6 +136,9 @@ export const loadDocxArchive = async (
 
   let declaredTotalBytes = 0;
   for (const entry of archiveEntries) {
+    if (entry.dir) {
+      continue;
+    }
     const declaredBytes = getDeclaredUncompressedBytes(entry);
     if (declaredBytes === null) {
       declaredTotalBytes = Number.NaN;

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -25,10 +25,21 @@ export type DocxArchiveOptions = {
   maxEntries?: number;
 };
 
+export type DocxArchiveEntry = {
+  readonly path: string;
+  readonly directory: boolean;
+  readonly declaredUncompressedBytes: number | null;
+};
+
+export type DocxArchiveReadOptions = {
+  maxBytes?: number;
+};
+
 export type DocxArchive = {
   entries: readonly string[];
+  entryMetadata: readonly DocxArchiveEntry[];
   readEntryString: (path: string) => Promise<string | null>;
-  readEntryUint8: (path: string) => Promise<Uint8Array | null>;
+  readEntryUint8: (path: string, options?: DocxArchiveReadOptions) => Promise<Uint8Array | null>;
 };
 
 type CollectStreamOptions = {
@@ -79,6 +90,15 @@ const collectStream = async ({
     stream.on("error", reject);
   });
 
+const getDeclaredUncompressedBytes = (entry: JSZip.JSZipObject): number | null => {
+  const data = "_data" in entry ? entry._data : undefined;
+  const declaredBytes =
+    typeof data === "object" && data !== null && "uncompressedSize" in data
+      ? data.uncompressedSize
+      : undefined;
+  return typeof declaredBytes === "number" && Number.isFinite(declaredBytes) ? declaredBytes : null;
+};
+
 export const loadDocxArchive = async (
   bytes: ArrayBuffer | Uint8Array,
   options: DocxArchiveOptions = {},
@@ -116,12 +136,8 @@ export const loadDocxArchive = async (
 
   let declaredTotalBytes = 0;
   for (const entry of archiveEntries) {
-    const data = "_data" in entry ? entry._data : undefined;
-    const declaredBytes =
-      typeof data === "object" && data !== null && "uncompressedSize" in data
-        ? data.uncompressedSize
-        : undefined;
-    if (typeof declaredBytes !== "number" || !Number.isFinite(declaredBytes)) {
+    const declaredBytes = getDeclaredUncompressedBytes(entry);
+    if (declaredBytes === null) {
       declaredTotalBytes = Number.NaN;
       break;
     }
@@ -144,7 +160,10 @@ export const loadDocxArchive = async (
   let totalBytesRead = 0;
   let readChain: Promise<unknown> = Promise.resolve();
 
-  const readEntry = async (path: string): Promise<Buffer | null> => {
+  const readEntry = async (
+    path: string,
+    options: DocxArchiveReadOptions = {},
+  ): Promise<Buffer | null> => {
     const work = async (): Promise<Buffer | null> => {
       const entry = zip.file(path);
       if (!entry) {
@@ -152,7 +171,7 @@ export const loadDocxArchive = async (
       }
       const buffer = await collectStream({
         stream: entry.nodeStream("nodebuffer"),
-        maxEntryBytes,
+        maxEntryBytes: Math.min(options.maxBytes ?? maxEntryBytes, maxEntryBytes),
         remainingBytes: maxTotalBytes - totalBytesRead,
         maxTotalBytes,
         path,
@@ -171,12 +190,19 @@ export const loadDocxArchive = async (
 
   return {
     entries: Object.freeze(archiveEntries.map(({ name }) => name)),
+    entryMetadata: Object.freeze(
+      archiveEntries.map((entry) => ({
+        path: entry.name,
+        directory: entry.dir,
+        declaredUncompressedBytes: getDeclaredUncompressedBytes(entry),
+      })),
+    ),
     async readEntryString(path) {
       const buffer = await readEntry(path);
       return buffer === null ? null : buffer.toString("utf-8");
     },
-    async readEntryUint8(path) {
-      const buffer = await readEntry(path);
+    async readEntryUint8(path, options) {
+      const buffer = await readEntry(path, options);
       return buffer === null ? null : new Uint8Array(buffer);
     },
   };

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -14,7 +14,8 @@ export class DocxArchiveError extends TaggedError("DocxArchiveError")<{
     | "input-too-large"
     | "too-many-entries"
     | "entry-too-large"
-    | "total-too-large";
+    | "total-too-large"
+    | "invalid-options";
   cause?: unknown;
 }>() {}
 
@@ -99,14 +100,47 @@ const getDeclaredUncompressedBytes = (entry: JSZip.JSZipObject): number | null =
   return typeof declaredBytes === "number" && Number.isFinite(declaredBytes) ? declaredBytes : null;
 };
 
+type ResolveByteLimitOptions = {
+  value: number | undefined;
+  fallback: number;
+  name: string;
+};
+
+const resolveByteLimit = ({ value, fallback, name }: ResolveByteLimitOptions): number => {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new DocxArchiveError({
+      message: `${name} must be a non-negative safe integer`,
+      reason: "invalid-options",
+    });
+  }
+  return limit;
+};
+
 export const loadDocxArchive = async (
   bytes: ArrayBuffer | Uint8Array,
   options: DocxArchiveOptions = {},
 ): Promise<DocxArchive> => {
-  const maxInputBytes = options.maxInputBytes ?? DOCX_MAX_INPUT_BYTES;
-  const maxEntryBytes = options.maxEntryBytes ?? DOCX_MAX_ENTRY_BYTES;
-  const maxTotalBytes = options.maxTotalBytes ?? DOCX_MAX_TOTAL_BYTES;
-  const maxEntries = options.maxEntries ?? DOCX_MAX_ENTRIES;
+  const maxInputBytes = resolveByteLimit({
+    value: options.maxInputBytes,
+    fallback: DOCX_MAX_INPUT_BYTES,
+    name: "DOCX input byte limit",
+  });
+  const maxEntryBytes = resolveByteLimit({
+    value: options.maxEntryBytes,
+    fallback: DOCX_MAX_ENTRY_BYTES,
+    name: "DOCX entry byte limit",
+  });
+  const maxTotalBytes = resolveByteLimit({
+    value: options.maxTotalBytes,
+    fallback: DOCX_MAX_TOTAL_BYTES,
+    name: "DOCX cumulative byte limit",
+  });
+  const maxEntries = resolveByteLimit({
+    value: options.maxEntries,
+    fallback: DOCX_MAX_ENTRIES,
+    name: "DOCX entry limit",
+  });
 
   if (bytes.byteLength > maxInputBytes) {
     throw new DocxArchiveError({
@@ -167,6 +201,11 @@ export const loadDocxArchive = async (
     path: string,
     readOptions: DocxArchiveReadOptions = {},
   ): Promise<Buffer | null> => {
+    const requestedMaxBytes = resolveByteLimit({
+      value: readOptions.maxBytes,
+      fallback: maxEntryBytes,
+      name: "DOCX entry read byte limit",
+    });
     const work = async (): Promise<Buffer | null> => {
       const entry = zip.file(path);
       if (!entry) {
@@ -174,7 +213,7 @@ export const loadDocxArchive = async (
       }
       const buffer = await collectStream({
         stream: entry.nodeStream("nodebuffer"),
-        maxEntryBytes: Math.min(readOptions.maxBytes ?? maxEntryBytes, maxEntryBytes),
+        maxEntryBytes: Math.min(requestedMaxBytes, maxEntryBytes),
         remainingBytes: maxTotalBytes - totalBytesRead,
         maxTotalBytes,
         path,

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -162,7 +162,7 @@ export const loadDocxArchive = async (
 
   const readEntry = async (
     path: string,
-    options: DocxArchiveReadOptions = {},
+    readOptions: DocxArchiveReadOptions = {},
   ): Promise<Buffer | null> => {
     const work = async (): Promise<Buffer | null> => {
       const entry = zip.file(path);
@@ -171,7 +171,7 @@ export const loadDocxArchive = async (
       }
       const buffer = await collectStream({
         stream: entry.nodeStream("nodebuffer"),
-        maxEntryBytes: Math.min(options.maxBytes ?? maxEntryBytes, maxEntryBytes),
+        maxEntryBytes: Math.min(readOptions.maxBytes ?? maxEntryBytes, maxEntryBytes),
         remainingBytes: maxTotalBytes - totalBytesRead,
         maxTotalBytes,
         path,
@@ -201,8 +201,8 @@ export const loadDocxArchive = async (
       const buffer = await readEntry(path);
       return buffer === null ? null : buffer.toString("utf-8");
     },
-    async readEntryUint8(path, options) {
-      const buffer = await readEntry(path, options);
+    async readEntryUint8(path, readOptions) {
+      const buffer = await readEntry(path, readOptions);
       return buffer === null ? null : new Uint8Array(buffer);
     },
   };

--- a/packages/core/src/docx/server/inspectDocxPackage.test.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.test.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { createEmptyDocx } from "../rezip";
+import {
+  FOLIO_DOCX_PACKAGE_INSPECTION_VERSION,
+  FolioDocxPackageInspectionError,
+  inspectDocxPackage,
+} from "./inspectDocxPackage";
+
+type MutatePackage = (zip: JSZip) => void;
+
+const mutateEmptyPackage = async (mutate: MutatePackage): Promise<Uint8Array> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  mutate(zip);
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+const rejection = async (promise: Promise<unknown>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected promise to reject");
+};
+
+describe("inspectDocxPackage", () => {
+  test("lists deterministic part metadata without returning bodies by default", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("word/media/payload.bin", new Uint8Array(1024));
+    });
+
+    const inspection = await inspectDocxPackage(bytes, {
+      limits: { maxXmlPartBytes: 4 },
+    });
+
+    expect(inspection.version).toBe(FOLIO_DOCX_PACKAGE_INSPECTION_VERSION);
+    expect(inspection.xmlParts).toEqual([]);
+    expect(inspection.parts.map(({ path }) => path)).toEqual(
+      inspection.parts.map(({ path }) => path).toSorted(),
+    );
+    expect(inspection.parts.find(({ path }) => path === "word/document.xml")).toMatchObject({
+      kind: "xml",
+      contentType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+    });
+    expect(inspection.parts.find(({ path }) => path === "word/media/payload.bin")).toMatchObject({
+      kind: "binary",
+      declaredUncompressedBytes: 1024,
+    });
+  });
+
+  test("returns only explicitly requested XML with an exact byte hash", async () => {
+    const zip = await JSZip.loadAsync(await createEmptyDocx());
+    const documentBytes = await zip.file("word/document.xml")?.async("uint8array");
+    if (documentBytes === undefined) {
+      throw new Error("Expected document part");
+    }
+
+    const inspection = await inspectDocxPackage(await zip.generateAsync({ type: "uint8array" }), {
+      xmlParts: ["word/document.xml"],
+    });
+
+    expect(inspection.xmlParts).toHaveLength(1);
+    expect(inspection.xmlParts.at(0)).toMatchObject({
+      path: "word/document.xml",
+      byteLength: documentBytes.byteLength,
+      sha256: createHash("sha256").update(documentBytes).digest("hex"),
+    });
+    expect(inspection.xmlParts.at(0)?.text).toContain("<w:document");
+  });
+
+  test("decodes UTF-16 XML part bodies", async () => {
+    const text = '<?xml version="1.0" encoding="UTF-16"?><root>Žluťoučký</root>';
+    const encoded = Buffer.from(text, "utf16le");
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("custom.xml", Buffer.concat([Buffer.from([0xff, 0xfe]), encoded]));
+    });
+
+    const inspection = await inspectDocxPackage(bytes, { xmlParts: ["custom.xml"] });
+
+    expect(inspection.xmlParts.at(0)?.text).toBe(text);
+  });
+
+  test("rejects missing, binary, and duplicate requested parts", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("word/media/payload.bin", "data");
+    });
+
+    const missing = await rejection(inspectDocxPackage(bytes, { xmlParts: ["missing.xml"] }));
+    const binary = await rejection(
+      inspectDocxPackage(bytes, { xmlParts: ["word/media/payload.bin"] }),
+    );
+    const duplicate = await rejection(
+      inspectDocxPackage(bytes, { xmlParts: ["word/document.xml", "word/document.xml"] }),
+    );
+
+    expect(missing).toMatchObject({ code: "part-not-found" });
+    expect(binary).toMatchObject({ code: "part-not-xml" });
+    expect(duplicate).toMatchObject({ code: "duplicate-xml-part" });
+    expect(missing).toBeInstanceOf(FolioDocxPackageInspectionError);
+  });
+
+  test("enforces requested part count and byte budgets", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("one.xml", "<one/>");
+      zip.file("two.xml", "<two/>");
+    });
+
+    const count = await rejection(
+      inspectDocxPackage(bytes, {
+        xmlParts: ["one.xml", "two.xml"],
+        limits: { maxXmlParts: 1 },
+      }),
+    );
+    const partBytes = await rejection(
+      inspectDocxPackage(bytes, {
+        xmlParts: ["one.xml"],
+        limits: { maxXmlPartBytes: 5 },
+      }),
+    );
+    const totalBytes = await rejection(
+      inspectDocxPackage(bytes, {
+        xmlParts: ["one.xml", "two.xml"],
+        limits: { maxXmlTotalBytes: 11 },
+      }),
+    );
+
+    expect(count).toMatchObject({ code: "too-many-xml-parts" });
+    expect(partBytes).toMatchObject({ code: "xml-part-too-large", part: "one.xml" });
+    expect(totalBytes).toMatchObject({ code: "xml-total-too-large" });
+  });
+
+  test("rejects invalid limit values before loading the archive", async () => {
+    const error = await rejection(
+      inspectDocxPackage(new Uint8Array(), { limits: { maxXmlParts: -1 } }),
+    );
+
+    expect(error).toMatchObject({ code: "invalid-limits" });
+  });
+});

--- a/packages/core/src/docx/server/inspectDocxPackage.test.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.test.ts
@@ -85,6 +85,19 @@ describe("inspectDocxPackage", () => {
     expect(inspection.xmlParts.at(0)?.text).toBe(text);
   });
 
+  test("decodes empty and one-byte XML parts", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("empty.xml", new Uint8Array());
+      zip.file("short.xml", "<");
+    });
+
+    const inspection = await inspectDocxPackage(bytes, {
+      xmlParts: ["empty.xml", "short.xml"],
+    });
+
+    expect(inspection.xmlParts.map(({ text }) => text)).toEqual(["", "<"]);
+  });
+
   test("rejects missing, binary, and duplicate requested parts", async () => {
     const bytes = await mutateEmptyPackage((zip) => {
       zip.file("word/media/payload.bin", "data");

--- a/packages/core/src/docx/server/inspectDocxPackage.test.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.test.ts
@@ -4,10 +4,13 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import { createEmptyDocx } from "../rezip";
+import { DocxArchiveError } from "./boundedArchive";
 import {
   FOLIO_DOCX_PACKAGE_INSPECTION_VERSION,
   FolioDocxPackageInspectionError,
   inspectDocxPackage,
+  readRequestedXmlParts,
+  type FolioDocxPackagePart,
 } from "./inspectDocxPackage";
 
 type MutatePackage = (zip: JSZip) => void;
@@ -145,6 +148,42 @@ describe("inspectDocxPackage", () => {
     expect(count).toMatchObject({ code: "too-many-xml-parts" });
     expect(partBytes).toMatchObject({ code: "xml-part-too-large", part: "one.xml" });
     expect(totalBytes).toMatchObject({ code: "xml-total-too-large" });
+  });
+
+  test("constrains each XML read to the remaining cumulative budget", async () => {
+    const readLimits: number[] = [];
+    const part = {
+      path: "one.xml",
+      kind: "xml",
+      contentType: "application/xml",
+      declaredUncompressedBytes: null,
+    } as const satisfies FolioDocxPackagePart;
+    const partsByPath = new Map([
+      ["one.xml", part],
+      ["two.xml", { ...part, path: "two.xml" }],
+    ]);
+    const error = await rejection(
+      readRequestedXmlParts({
+        paths: ["one.xml", "two.xml"],
+        partsByPath,
+        limits: { maxXmlParts: 2, maxXmlPartBytes: 10, maxXmlTotalBytes: 12 },
+        readEntryUint8: (_path, { maxBytes }) => {
+          readLimits.push(maxBytes);
+          if (readLimits.length === 1) {
+            return Promise.resolve(new Uint8Array(6));
+          }
+          return Promise.reject(
+            new DocxArchiveError({
+              message: "Read exceeded its limit",
+              reason: "entry-too-large",
+            }),
+          );
+        },
+      }),
+    );
+
+    expect(readLimits).toEqual([10, 6]);
+    expect(error).toMatchObject({ code: "xml-total-too-large", part: "two.xml" });
   });
 
   test("rejects invalid limit values before loading the archive", async () => {

--- a/packages/core/src/docx/server/inspectDocxPackage.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.ts
@@ -292,7 +292,7 @@ type ReadRequestedXmlPartsOptions = {
   readEntryUint8: (path: string, options: { maxBytes: number }) => Promise<Uint8Array | null>;
 };
 
-const readRequestedXmlParts = async ({
+export const readRequestedXmlParts = async ({
   paths,
   partsByPath,
   limits,
@@ -301,15 +301,20 @@ const readRequestedXmlParts = async ({
   const selected: FolioDocxInspectedXmlPart[] = [];
   let totalBytes = 0;
   for (const path of paths) {
+    const remainingTotalBytes = limits.maxXmlTotalBytes - totalBytes;
+    const readLimit = Math.min(limits.maxXmlPartBytes, remainingTotalBytes);
     let bytes: Uint8Array | null;
     try {
       // oxlint-disable-next-line no-await-in-loop -- request order defines the result order and cumulative budget
-      bytes = await readEntryUint8(path, { maxBytes: limits.maxXmlPartBytes });
+      bytes = await readEntryUint8(path, { maxBytes: readLimit });
     } catch (cause) {
       if (cause instanceof DocxArchiveError && cause.reason === "entry-too-large") {
+        const cumulativeLimitReached = readLimit < limits.maxXmlPartBytes;
         throw new FolioDocxPackageInspectionError({
-          message: `XML package part "${path}" exceeds the per-part inspection limit`,
-          code: "xml-part-too-large",
+          message: cumulativeLimitReached
+            ? "Requested XML package parts exceed the cumulative inspection limit"
+            : `XML package part "${path}" exceeds the per-part inspection limit`,
+          code: cumulativeLimitReached ? "xml-total-too-large" : "xml-part-too-large",
           part: path,
           cause,
         });

--- a/packages/core/src/docx/server/inspectDocxPackage.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.ts
@@ -92,9 +92,15 @@ type ContentTypeDeclarations = {
 
 const decodeXml = (bytes: Uint8Array, part: string): string => {
   let encoding = "utf-8";
-  if ((bytes[0] === 0xff && bytes[1] === 0xfe) || (bytes[0] === 0x3c && bytes[1] === 0x00)) {
+  if (
+    bytes.length >= 2 &&
+    ((bytes[0] === 0xff && bytes[1] === 0xfe) || (bytes[0] === 0x3c && bytes[1] === 0x00))
+  ) {
     encoding = "utf-16le";
-  } else if ((bytes[0] === 0xfe && bytes[1] === 0xff) || (bytes[0] === 0x00 && bytes[1] === 0x3c)) {
+  } else if (
+    bytes.length >= 2 &&
+    ((bytes[0] === 0xfe && bytes[1] === 0xff) || (bytes[0] === 0x00 && bytes[1] === 0x3c))
+  ) {
     encoding = "utf-16be";
   }
 

--- a/packages/core/src/docx/server/inspectDocxPackage.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.ts
@@ -1,0 +1,375 @@
+import { createHash } from "node:crypto";
+
+import { TaggedError } from "better-result";
+
+import { getAttributeAnyPrefix, getLocalName, parseXmlDocument } from "../xmlParser";
+import type { DocxArchiveEntry, DocxArchiveOptions } from "./boundedArchive";
+import { DocxArchiveError, loadDocxArchive } from "./boundedArchive";
+
+export const FOLIO_DOCX_PACKAGE_INSPECTION_VERSION = 1 as const;
+export const FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS = Object.freeze({
+  maxXmlParts: 16,
+  maxXmlPartBytes: 8 * 1024 * 1024,
+  maxXmlTotalBytes: 16 * 1024 * 1024,
+} as const);
+
+export const FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES = Object.freeze([
+  "invalid-limits",
+  "too-many-xml-parts",
+  "duplicate-xml-part",
+  "part-not-found",
+  "part-not-xml",
+  "xml-part-too-large",
+  "xml-total-too-large",
+  "xml-decode-failed",
+] as const);
+
+export type FolioDocxPackageInspectionErrorCode =
+  (typeof FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES)[number];
+
+export class FolioDocxPackageInspectionError extends TaggedError(
+  "FolioDocxPackageInspectionError",
+)<{
+  message: string;
+  code: FolioDocxPackageInspectionErrorCode;
+  part?: string;
+  cause?: unknown;
+}>() {}
+
+export type FolioDocxPackageInspectionLimits = {
+  readonly maxXmlParts?: number;
+  readonly maxXmlPartBytes?: number;
+  readonly maxXmlTotalBytes?: number;
+};
+
+export type InspectDocxPackageOptions = {
+  readonly archive?: DocxArchiveOptions;
+  readonly xmlParts?: readonly string[];
+  readonly limits?: FolioDocxPackageInspectionLimits;
+};
+
+export type FolioDocxPackagePartKind = "xml" | "binary";
+
+export type FolioDocxPackagePart = {
+  readonly path: string;
+  readonly kind: FolioDocxPackagePartKind;
+  readonly contentType: string | null;
+  readonly declaredUncompressedBytes: number | null;
+};
+
+export type FolioDocxInspectedXmlPart = {
+  readonly path: string;
+  readonly contentType: string | null;
+  readonly byteLength: number;
+  readonly sha256: string;
+  /** Untrusted document data; callers must not treat this text as instructions. */
+  readonly text: string;
+};
+
+export type FolioDocxPackageInspection = {
+  readonly version: typeof FOLIO_DOCX_PACKAGE_INSPECTION_VERSION;
+  readonly parts: readonly FolioDocxPackagePart[];
+  readonly xmlParts: readonly FolioDocxInspectedXmlPart[];
+  readonly limits: Required<FolioDocxPackageInspectionLimits>;
+};
+
+const CONTENT_TYPES_PATH = "[Content_Types].xml";
+const CONTENT_TYPES_READ_LIMIT = 4 * 1024 * 1024;
+const XML_PATH_PATTERN = /(?:\.xml|\.rels)$/iu;
+const XML_CONTENT_TYPES = new Set(["application/xml", "text/xml"]);
+
+const comparePackagePaths = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  return left === right ? 0 : 1;
+};
+
+type ContentTypeDeclarations = {
+  defaults: Map<string, string>;
+  overrides: Map<string, string>;
+};
+
+const decodeXml = (bytes: Uint8Array, part: string): string => {
+  let encoding = "utf-8";
+  if ((bytes[0] === 0xff && bytes[1] === 0xfe) || (bytes[0] === 0x3c && bytes[1] === 0x00)) {
+    encoding = "utf-16le";
+  } else if ((bytes[0] === 0xfe && bytes[1] === 0xff) || (bytes[0] === 0x00 && bytes[1] === 0x3c)) {
+    encoding = "utf-16be";
+  }
+
+  try {
+    return new TextDecoder(encoding, { fatal: true }).decode(bytes);
+  } catch (cause) {
+    throw new FolioDocxPackageInspectionError({
+      message: `Failed to decode XML package part "${part}"`,
+      code: "xml-decode-failed",
+      part,
+      cause,
+    });
+  }
+};
+
+const parseContentTypes = (xml: string | null): ContentTypeDeclarations => {
+  const declarations: ContentTypeDeclarations = {
+    defaults: new Map(),
+    overrides: new Map(),
+  };
+  if (xml === null) {
+    return declarations;
+  }
+
+  const root = parseXmlDocument(xml);
+  if (root === null || getLocalName(root.name ?? "") !== "Types") {
+    return declarations;
+  }
+
+  for (const element of root.elements ?? []) {
+    if (element.type !== "element") {
+      continue;
+    }
+    const localName = getLocalName(element.name ?? "");
+    if (localName === "Default") {
+      const extension = getAttributeAnyPrefix(element, "Extension")?.toLowerCase();
+      const contentType = getAttributeAnyPrefix(element, "ContentType");
+      if (extension !== undefined && contentType !== null) {
+        declarations.defaults.set(extension, contentType);
+      }
+      continue;
+    }
+    if (localName !== "Override") {
+      continue;
+    }
+    const partName = getAttributeAnyPrefix(element, "PartName")?.replace(/^\//u, "");
+    const contentType = getAttributeAnyPrefix(element, "ContentType");
+    if (partName !== undefined && contentType !== null) {
+      declarations.overrides.set(partName, contentType);
+    }
+  }
+
+  return declarations;
+};
+
+const extensionFor = (path: string): string | null => {
+  const filename = path.slice(path.lastIndexOf("/") + 1);
+  const separator = filename.lastIndexOf(".");
+  return separator === -1 ? null : filename.slice(separator + 1).toLowerCase();
+};
+
+const contentTypeFor = (path: string, declarations: ContentTypeDeclarations): string | null => {
+  const override = declarations.overrides.get(path);
+  if (override !== undefined) {
+    return override;
+  }
+  const extension = extensionFor(path);
+  return extension === null ? null : (declarations.defaults.get(extension) ?? null);
+};
+
+const isXmlPart = (path: string, contentType: string | null): boolean => {
+  if (contentType !== null) {
+    return XML_CONTENT_TYPES.has(contentType) || contentType.endsWith("+xml");
+  }
+  return XML_PATH_PATTERN.test(path);
+};
+
+const toPackagePart = (
+  entry: DocxArchiveEntry,
+  declarations: ContentTypeDeclarations,
+): FolioDocxPackagePart => {
+  const contentType = contentTypeFor(entry.path, declarations);
+  return {
+    path: entry.path,
+    kind: isXmlPart(entry.path, contentType) ? "xml" : "binary",
+    contentType,
+    declaredUncompressedBytes: entry.declaredUncompressedBytes,
+  };
+};
+
+const requireNonNegativeInteger = (value: number, name: string): number => {
+  if (Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  throw new FolioDocxPackageInspectionError({
+    message: `${name} must be a non-negative safe integer`,
+    code: "invalid-limits",
+  });
+};
+
+const resolveLimits = (
+  limits: FolioDocxPackageInspectionLimits | undefined,
+): Required<FolioDocxPackageInspectionLimits> => ({
+  maxXmlParts: requireNonNegativeInteger(
+    limits?.maxXmlParts ?? FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS.maxXmlParts,
+    "maxXmlParts",
+  ),
+  maxXmlPartBytes: requireNonNegativeInteger(
+    limits?.maxXmlPartBytes ?? FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS.maxXmlPartBytes,
+    "maxXmlPartBytes",
+  ),
+  maxXmlTotalBytes: requireNonNegativeInteger(
+    limits?.maxXmlTotalBytes ?? FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS.maxXmlTotalBytes,
+    "maxXmlTotalBytes",
+  ),
+});
+
+type ValidateRequestedPartsOptions = {
+  requestedPaths: readonly string[];
+  partsByPath: ReadonlyMap<string, FolioDocxPackagePart>;
+  limits: Required<FolioDocxPackageInspectionLimits>;
+};
+
+const validateRequestedParts = ({
+  requestedPaths,
+  partsByPath,
+  limits,
+}: ValidateRequestedPartsOptions): void => {
+  if (requestedPaths.length > limits.maxXmlParts) {
+    throw new FolioDocxPackageInspectionError({
+      message: `Requested ${requestedPaths.length} XML parts (max ${limits.maxXmlParts})`,
+      code: "too-many-xml-parts",
+    });
+  }
+
+  const seen = new Set<string>();
+  let declaredTotalBytes = 0;
+  for (const path of requestedPaths) {
+    if (seen.has(path)) {
+      throw new FolioDocxPackageInspectionError({
+        message: `XML package part "${path}" was requested more than once`,
+        code: "duplicate-xml-part",
+        part: path,
+      });
+    }
+    seen.add(path);
+
+    const part = partsByPath.get(path);
+    if (part === undefined) {
+      throw new FolioDocxPackageInspectionError({
+        message: `Package part "${path}" does not exist`,
+        code: "part-not-found",
+        part: path,
+      });
+    }
+    if (part.kind !== "xml") {
+      throw new FolioDocxPackageInspectionError({
+        message: `Package part "${path}" is not declared as XML`,
+        code: "part-not-xml",
+        part: path,
+      });
+    }
+
+    const declaredBytes = part.declaredUncompressedBytes;
+    if (declaredBytes === null) {
+      continue;
+    }
+    if (declaredBytes > limits.maxXmlPartBytes) {
+      throw new FolioDocxPackageInspectionError({
+        message: `XML package part "${path}" exceeds the per-part inspection limit`,
+        code: "xml-part-too-large",
+        part: path,
+      });
+    }
+    declaredTotalBytes += declaredBytes;
+    if (declaredTotalBytes > limits.maxXmlTotalBytes) {
+      throw new FolioDocxPackageInspectionError({
+        message: "Requested XML package parts exceed the cumulative inspection limit",
+        code: "xml-total-too-large",
+      });
+    }
+  }
+};
+
+type ReadRequestedXmlPartsOptions = {
+  paths: readonly string[];
+  partsByPath: ReadonlyMap<string, FolioDocxPackagePart>;
+  limits: Required<FolioDocxPackageInspectionLimits>;
+  readEntryUint8: (path: string, options: { maxBytes: number }) => Promise<Uint8Array | null>;
+};
+
+const readRequestedXmlParts = async ({
+  paths,
+  partsByPath,
+  limits,
+  readEntryUint8,
+}: ReadRequestedXmlPartsOptions): Promise<FolioDocxInspectedXmlPart[]> => {
+  const selected: FolioDocxInspectedXmlPart[] = [];
+  let totalBytes = 0;
+  for (const path of paths) {
+    let bytes: Uint8Array | null;
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- request order defines the result order and cumulative budget
+      bytes = await readEntryUint8(path, { maxBytes: limits.maxXmlPartBytes });
+    } catch (cause) {
+      if (cause instanceof DocxArchiveError && cause.reason === "entry-too-large") {
+        throw new FolioDocxPackageInspectionError({
+          message: `XML package part "${path}" exceeds the per-part inspection limit`,
+          code: "xml-part-too-large",
+          part: path,
+          cause,
+        });
+      }
+      throw cause;
+    }
+    if (bytes === null) {
+      throw new FolioDocxPackageInspectionError({
+        message: `Package part "${path}" does not exist`,
+        code: "part-not-found",
+        part: path,
+      });
+    }
+
+    totalBytes += bytes.byteLength;
+    if (totalBytes > limits.maxXmlTotalBytes) {
+      throw new FolioDocxPackageInspectionError({
+        message: "Requested XML package parts exceed the cumulative inspection limit",
+        code: "xml-total-too-large",
+      });
+    }
+    selected.push({
+      path,
+      contentType: partsByPath.get(path)?.contentType ?? null,
+      byteLength: bytes.byteLength,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      text: decodeXml(bytes, path),
+    });
+  }
+  return selected;
+};
+
+/**
+ * Inspect package metadata and only the explicitly requested XML part bodies.
+ * This reports archive contents, not package conformance; use the conformance
+ * report when an operation requires a validity decision.
+ */
+export const inspectDocxPackage = async (
+  bytes: ArrayBuffer | Uint8Array,
+  options: InspectDocxPackageOptions = {},
+): Promise<FolioDocxPackageInspection> => {
+  const limits = resolveLimits(options.limits);
+  const requestedPaths = options.xmlParts ?? [];
+  const archive = await loadDocxArchive(bytes, options.archive);
+  const contentTypesBytes = await archive.readEntryUint8(CONTENT_TYPES_PATH, {
+    maxBytes: CONTENT_TYPES_READ_LIMIT,
+  });
+  const declarations = parseContentTypes(
+    contentTypesBytes === null ? null : decodeXml(contentTypesBytes, CONTENT_TYPES_PATH),
+  );
+  const parts = archive.entryMetadata
+    .filter(({ directory }) => !directory)
+    .map((entry) => toPackagePart(entry, declarations))
+    .toSorted(({ path: left }, { path: right }) => comparePackagePaths(left, right));
+  const partsByPath = new Map(parts.map((part) => [part.path, part] as const));
+  validateRequestedParts({ requestedPaths, partsByPath, limits });
+
+  return {
+    version: FOLIO_DOCX_PACKAGE_INSPECTION_VERSION,
+    parts,
+    xmlParts: await readRequestedXmlParts({
+      paths: requestedPaths,
+      partsByPath,
+      limits,
+      readEntryUint8: archive.readEntryUint8,
+    }),
+    limits,
+  };
+};

--- a/packages/core/src/docx/server/validateDocxConformance.test.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.test.ts
@@ -188,4 +188,14 @@ describe("validateDocxConformance", () => {
     expect(checkStatus(report, "archive-safety")).toBe("failed");
     expect(report.issues.at(0)?.code).toBe("archive-too-many-entries");
   });
+
+  test("fails invalid archive limits before package loading", async () => {
+    const report = await validateDocxConformance(await createEmptyDocx(), {
+      archive: { maxEntries: Number.NaN },
+    });
+
+    expect(report.status).toBe("invalid");
+    expect(checkStatus(report, "archive-safety")).toBe("failed");
+    expect(report.issues.at(0)?.code).toBe("archive-invalid-options");
+  });
 });

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -30,6 +30,7 @@ export const FOLIO_DOCX_CONFORMANCE_CHECKS = Object.freeze([
 
 export const FOLIO_DOCX_CONFORMANCE_ISSUE_CODES = Object.freeze([
   "archive-load-failed",
+  "archive-invalid-options",
   "archive-input-too-large",
   "archive-too-many-entries",
   "archive-entry-too-large",

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -175,6 +175,20 @@ export {
 } from "./docx/server/extractDocxText";
 export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";
 export {
+  FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS,
+  FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES,
+  FOLIO_DOCX_PACKAGE_INSPECTION_VERSION,
+  FolioDocxPackageInspectionError,
+  inspectDocxPackage,
+  type FolioDocxInspectedXmlPart,
+  type FolioDocxPackageInspection,
+  type FolioDocxPackageInspectionErrorCode,
+  type FolioDocxPackageInspectionLimits,
+  type FolioDocxPackagePart,
+  type FolioDocxPackagePartKind,
+  type InspectDocxPackageOptions,
+} from "./docx/server/inspectDocxPackage";
+export {
   FOLIO_DOCX_CONFORMANCE_CHECKS,
   FOLIO_DOCX_CONFORMANCE_ISSUE_CODES,
   FOLIO_DOCX_CONFORMANCE_PROFILE,


### PR DESCRIPTION
## Summary

- add deterministic package part metadata
- read only explicitly requested XML with byte budgets and hashes
- add per-read archive limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded, read-only DOCX package inspection that reports parts (XML vs binary), inferred content types, sizes, and optional XML text extraction.
  - Exposes package-inspection APIs, defaults, error codes, and versioned inspection results, with SHA-256 hashing and UTF decoding for requested XML parts.
- **Bug Fixes**
  - Strengthened archive option validation and size-limit enforcement, including per-entry/read and cumulative XML budgets.
  - Expanded DOCX conformance reporting with the new `archive-invalid-options` issue code for invalid archive settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->