### PR TITLE
fix: align Word font parity and cascades

### DIFF
--- a/.changeset/calm-falcons-resolve.md
+++ b/.changeset/calm-falcons-resolve.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve theme fonts during layout and preserve paragraph style fonts inside table styles.

--- a/.changeset/curvy-ravens-dress.md
+++ b/.changeset/curvy-ravens-dress.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": patch
+---
+
+Register host-provided italic font faces with their authored style.

--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -596,7 +596,8 @@ export function FolioUIProvider(input: {
 export type FontDefinition = {
     family: string; /** URL to the font file (woff2, woff, ttf, or otf). */
     src: string; /** CSS `font-weight` for this face (a number like `700`, or a keyword). Defaults to `normal`. */
-    weight?: number | string;
+    weight?: number | string; /** CSS `font-style` for this face (for example `italic`). Defaults to `normal`. */
+    style?: string;
 };
 
 // @public

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
@@ -55,6 +55,16 @@ const schema = new Schema({
         bidi: { default: null },
       },
     },
+    fontFamily: {
+      attrs: {
+        ascii: { default: null },
+        hAnsi: { default: null },
+        eastAsia: { default: null },
+        asciiTheme: { default: null },
+        hAnsiTheme: { default: null },
+        eastAsiaTheme: { default: null },
+      },
+    },
     textEffect: {
       attrs: { effect: {} },
     },
@@ -100,6 +110,25 @@ function firstRun(blocks: unknown[]): TextRun {
 }
 
 describe("toFlowBlocks run-level OOXML marks", () => {
+  test("resolves a theme font before its legacy fallback name", () => {
+    const doc = buildSingleRunDoc("text", "fontFamily", {
+      ascii: "Calibri",
+      hAnsi: "Calibri",
+      asciiTheme: "majorHAnsi",
+      hAnsiTheme: "majorHAnsi",
+    });
+
+    const themedRun = firstRun(
+      toFlowBlocks(doc, {
+        theme: { fontScheme: { majorFont: { latin: "Aptos" } } },
+      }),
+    );
+    const fallbackRun = firstRun(toFlowBlocks(doc, {}));
+
+    expect(themedRun.fontFamily).toBe("Aptos");
+    expect(fallbackRun.fontFamily).toBe("Calibri");
+  });
+
   test("propagates caps and text effect marks to run formatting", () => {
     for (const markName of [
       "allCaps",

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -83,6 +83,7 @@ import type {
 } from "../../types/document";
 import { NUMBER_FORMAT_VALUES } from "../../types/documentEnumValues";
 import { resolveColor, resolveHighlightToCss } from "../../utils/colorResolver";
+import { resolveThemeFont } from "../../utils/fontResolver";
 import { resolveShadingFill } from "../../utils/formatToStyle";
 import {
   AUTO_PARAGRAPH_SPACING_PX,
@@ -513,12 +514,13 @@ function extractRunFormatting(marks: readonly Mark[], theme?: Theme | null): Run
 
       case "fontFamily": {
         const attrs = expectFontFamilyMarkAttrs(mark);
-        const font = attrs.ascii || attrs.hAnsi;
+        const font = resolveWesternThemeFont(attrs, theme);
         if (font) {
           formatting.fontFamily = font;
         }
-        if (attrs.eastAsia) {
-          formatting.eastAsiaFontFamily = attrs.eastAsia;
+        const eastAsiaFont = resolveEastAsiaThemeFont(attrs, theme);
+        if (eastAsiaFont) {
+          formatting.eastAsiaFontFamily = eastAsiaFont;
         }
         break;
       }
@@ -678,6 +680,34 @@ function extractRunFormatting(marks: readonly Mark[], theme?: Theme | null): Run
   return formatting;
 }
 
+type ThemeFontAttributes = {
+  ascii?: string | null;
+  hAnsi?: string | null;
+  eastAsia?: string | null;
+  asciiTheme?: string | null;
+  hAnsiTheme?: string | null;
+  eastAsiaTheme?: string | null;
+};
+
+const resolveWesternThemeFont = (
+  fontFamily: ThemeFontAttributes,
+  theme?: Theme | null,
+): string | undefined => {
+  const themeRef = fontFamily.asciiTheme ?? fontFamily.hAnsiTheme;
+  const themedFont = themeRef ? resolveThemeFont(themeRef, theme?.fontScheme) : null;
+  return themedFont ?? fontFamily.ascii ?? fontFamily.hAnsi ?? undefined;
+};
+
+const resolveEastAsiaThemeFont = (
+  fontFamily: ThemeFontAttributes,
+  theme?: Theme | null,
+): string | undefined => {
+  const themedFont = fontFamily.eastAsiaTheme
+    ? resolveThemeFont(fontFamily.eastAsiaTheme, theme?.fontScheme)
+    : null;
+  return themedFont ?? fontFamily.eastAsia ?? undefined;
+};
+
 function isAutomaticTextColorValue(color: ColorValue): boolean {
   const rgb = color.rgb?.trim().toLowerCase();
   return color.auto === true || rgb === "auto" || (!rgb && !color.themeColor);
@@ -760,16 +790,20 @@ function paragraphRunDefaults(pmAttrs: PMParagraphAttrs, theme?: Theme | null): 
   }
 
   const result: RunFormatting = {};
-  const fontFamily =
-    defaultTextFormatting.fontFamily?.ascii ?? defaultTextFormatting.fontFamily?.hAnsi;
+  const fontFamily = defaultTextFormatting.fontFamily
+    ? resolveWesternThemeFont(defaultTextFormatting.fontFamily, theme)
+    : undefined;
   if (fontFamily) {
     result.fontFamily = fontFamily;
   }
   // East-Asian font inherited from the paragraph style / docDefaults, so CJK
   // runs without a direct `w:eastAsia` still get per-character EA selection. A
   // run's own fontFamily mark overrides this via mergeRunFormatting.
-  if (defaultTextFormatting.fontFamily?.eastAsia) {
-    result.eastAsiaFontFamily = defaultTextFormatting.fontFamily.eastAsia;
+  const eastAsiaFontFamily = defaultTextFormatting.fontFamily
+    ? resolveEastAsiaThemeFont(defaultTextFormatting.fontFamily, theme)
+    : undefined;
+  if (eastAsiaFontFamily) {
+    result.eastAsiaFontFamily = eastAsiaFontFamily;
   }
   if (defaultTextFormatting.language) {
     result.language = { ...defaultTextFormatting.language };
@@ -1828,16 +1862,14 @@ function convertParagraphAttrs(
     attrs.defaultTabStopTwips = defaultTabStopTwips;
   }
   // Default font for empty paragraph measurement (from style's rPr / pPr/rPr)
-  const dtf = pmAttrs.defaultTextFormatting as
-    | { fontSize?: number; fontFamily?: { ascii?: string; hAnsi?: string } }
-    | undefined;
+  const dtf = pmAttrs.defaultTextFormatting as TextFormatting | undefined;
   if (dtf) {
     if (dtf.fontSize !== undefined) {
       // fontSize in TextFormatting is in half-points, convert to points
       attrs.defaultFontSize = dtf.fontSize / 2;
     }
     if (dtf.fontFamily) {
-      const resolvedFamily = dtf.fontFamily.ascii || dtf.fontFamily.hAnsi;
+      const resolvedFamily = resolveWesternThemeFont(dtf.fontFamily, theme);
       if (resolvedFamily) {
         attrs.defaultFontFamily = resolvedFamily;
       }
@@ -1932,8 +1964,9 @@ function convertParagraph(
     if (paragraphMarkFormatting?.fontSize !== undefined) {
       attrs.defaultFontSize = paragraphMarkFormatting.fontSize / 2;
     }
-    const paragraphMarkFontFamily =
-      paragraphMarkFormatting?.fontFamily?.ascii ?? paragraphMarkFormatting?.fontFamily?.hAnsi;
+    const paragraphMarkFontFamily = paragraphMarkFormatting?.fontFamily
+      ? resolveWesternThemeFont(paragraphMarkFormatting.fontFamily, options.theme)
+      : undefined;
     if (paragraphMarkFontFamily) {
       attrs.defaultFontFamily = paragraphMarkFontFamily;
     }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -974,7 +974,15 @@ describe("toProseDoc", () => {
             {
               styleId: "ShadedTable",
               type: "table",
-              rPr: { color: { rgb: "365F91" } },
+              rPr: {
+                color: { rgb: "365F91" },
+                fontFamily: {
+                  asciiTheme: "majorHAnsi",
+                  ascii: "Calibri",
+                  hAnsiTheme: "majorHAnsi",
+                  hAnsi: "Calibri",
+                },
+              },
               tblStylePr: [{ type: "firstRow", rPr: { bold: true } }],
             },
           ],

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -953,7 +953,7 @@ describe("toProseDoc", () => {
     );
   });
 
-  test("table style run properties do not import docDefault fonts over Normal", () => {
+  test("table style run properties do not override inherited paragraph style fonts", () => {
     const document: Document = {
       package: {
         styles: {
@@ -970,6 +970,11 @@ describe("toProseDoc", () => {
               rPr: {
                 fontFamily: { ascii: "Aptos", hAnsi: "Aptos" },
               },
+            },
+            {
+              styleId: "Body",
+              type: "paragraph",
+              basedOn: "Normal",
             },
             {
               styleId: "ShadedTable",
@@ -999,6 +1004,7 @@ describe("toProseDoc", () => {
                       content: [
                         {
                           type: "paragraph",
+                          formatting: { styleId: "Body" },
                           content: [
                             {
                               type: "run",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -272,18 +272,14 @@ function convertParagraph(
 
   // Get style-based text formatting (font size, bold, color, etc.)
   let styleRunFormatting: TextFormatting | undefined;
-  let paragraphStyleRunFormatting: TextFormatting | undefined;
+  let paragraphStyleFontFamily: TextFormatting["fontFamily"] | undefined;
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(paragraph.formatting?.styleId);
     styleRunFormatting = resolved.runFormatting;
-    // Parsed style definitions already contain their cycle-safe `basedOn`
-    // cascade, so this rPr includes inherited named-style font slots too.
-    const paragraphStyle = paragraph.formatting?.styleId
-      ? styleResolver.getStyle(paragraph.formatting.styleId)
-      : styleResolver.getDefaultParagraphStyle();
-    if (paragraphStyle?.type === "paragraph") {
-      paragraphStyleRunFormatting = paragraphStyle.rPr;
-    }
+    paragraphStyleFontFamily = resolveParagraphStyleFontFamily(
+      paragraph.formatting?.styleId,
+      styleResolver,
+    );
   }
 
   const paragraphRunFormatting = resolveRunFormattingWithoutDefaults(
@@ -303,9 +299,9 @@ function convertParagraph(
   // case while still applying the table style's color, emphasis, and size.
   // Preserve the paragraph-style font slots over the table contribution;
   // direct run formatting still wins later in getInheritedRunFormatting.
-  if (paragraphStyleRunFormatting?.fontFamily) {
+  if (paragraphStyleFontFamily) {
     baseRunFormatting = mergeTextFormatting(baseRunFormatting, {
-      fontFamily: paragraphStyleRunFormatting.fontFamily,
+      fontFamily: paragraphStyleFontFamily,
     });
   }
   // With a named paragraph style, w:pPr/w:rPr formats the paragraph mark and
@@ -421,6 +417,22 @@ function convertParagraph(
 
   return schema.node("paragraph", attrs, inlineNodes);
 }
+
+const resolveParagraphStyleFontFamily = (
+  styleId: string | undefined,
+  styleResolver: StyleEngine,
+): TextFormatting["fontFamily"] | undefined => {
+  let style = styleId ? styleResolver.getStyle(styleId) : styleResolver.getDefaultParagraphStyle();
+  const visited = new Set<string>();
+  while (style?.type === "paragraph" && !visited.has(style.styleId)) {
+    visited.add(style.styleId);
+    if (style.rPr?.fontFamily) {
+      return style.rPr.fontFamily;
+    }
+    style = style.basedOn ? styleResolver.getStyle(style.basedOn) : undefined;
+  }
+  return undefined;
+};
 
 /**
  * Apply comment marks to PM nodes within a comment range.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -276,6 +276,8 @@ function convertParagraph(
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(paragraph.formatting?.styleId);
     styleRunFormatting = resolved.runFormatting;
+    // Parsed style definitions already contain their cycle-safe `basedOn`
+    // cascade, so this rPr includes inherited named-style font slots too.
     const paragraphStyle = paragraph.formatting?.styleId
       ? styleResolver.getStyle(paragraph.formatting.styleId)
       : styleResolver.getDefaultParagraphStyle();

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -272,9 +272,16 @@ function convertParagraph(
 
   // Get style-based text formatting (font size, bold, color, etc.)
   let styleRunFormatting: TextFormatting | undefined;
+  let paragraphStyleRunFormatting: TextFormatting | undefined;
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(paragraph.formatting?.styleId);
     styleRunFormatting = resolved.runFormatting;
+    const paragraphStyle = paragraph.formatting?.styleId
+      ? styleResolver.getStyle(paragraph.formatting.styleId)
+      : styleResolver.getDefaultParagraphStyle();
+    if (paragraphStyle?.type === "paragraph") {
+      paragraphStyleRunFormatting = paragraphStyle.rPr;
+    }
   }
 
   const paragraphRunFormatting = resolveRunFormattingWithoutDefaults(
@@ -288,7 +295,17 @@ function convertParagraph(
     inheritableParagraphRunFormatting =
       stripParagraphMarkFormattingForBodyRuns(paragraphRunFormatting);
   }
-  const baseRunFormatting = mergeTextFormatting(styleRunFormatting, extraRunFormatting);
+  let baseRunFormatting = mergeTextFormatting(styleRunFormatting, extraRunFormatting);
+  // A table style can carry legacy theme/fallback fonts from the template
+  // that created it. Word keeps the paragraph style's authored font in that
+  // case while still applying the table style's color, emphasis, and size.
+  // Preserve the paragraph-style font slots over the table contribution;
+  // direct run formatting still wins later in getInheritedRunFormatting.
+  if (paragraphStyleRunFormatting?.fontFamily) {
+    baseRunFormatting = mergeTextFormatting(baseRunFormatting, {
+      fontFamily: paragraphStyleRunFormatting.fontFamily,
+    });
+  }
   // With a named paragraph style, w:pPr/w:rPr formats the paragraph mark and
   // only fills gaps in the style's body-run defaults. Style-less generated
   // documents use the paragraph mark as their highest-precedence run default.

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -17,7 +17,12 @@ import {
   setAnonymizationTermsMeta,
   startAutocompleteSuggestion,
 } from "@stll/folio-react";
-import type { Document as FolioDocument, DocxEditorRef, EditorMode } from "@stll/folio-react";
+import type {
+  Document as FolioDocument,
+  DocxEditorRef,
+  EditorMode,
+  FontDefinition,
+} from "@stll/folio-react";
 import { FOLIO_LOCALES, getFolioMessages } from "@stll/folio-react/messages";
 
 import { CollaborationApp } from "./CollaborationApp";
@@ -48,6 +53,9 @@ declare global {
         getEditorRef: () => DocxEditorRef | null;
       }
     | undefined;
+  // Parity harness hook: locally installed reference-renderer fonts are
+  // supplied before React mounts so Folio measures with the same font files.
+  var __folioParityFonts: ReadonlyArray<FontDefinition> | undefined;
   // Cross-adapter E2E bridge: identical surface in the React and Vue
   // playgrounds so the `tests/parity` specs drive both editors through one API.
   var __folioParity: FolioParityBridge | undefined;
@@ -533,6 +541,7 @@ export function App() {
   const [editorMode, setEditorMode] = useState<EditorMode>("editing");
   const [locale, setLocale] = useState<string>(DEFAULT_LOCALE);
   const query = new URLSearchParams(window.location.search);
+  const parityFonts = globalThis.__folioParityFonts;
   const showMarginGuides = query.has("marginGuides");
   const marginGuideColor = query.get("marginGuideColor") ?? undefined;
 
@@ -710,6 +719,7 @@ export function App() {
             document={documentBuffer ? null : currentDocument}
             documentBuffer={documentBuffer}
             author="Folio User"
+            {...(parityFonts !== undefined ? { fonts: parityFonts } : {})}
             onError={handleError}
             showToolbar={true}
             showRuler={true}

--- a/packages/react/src/paged-editor/hostFonts.test.ts
+++ b/packages/react/src/paged-editor/hostFonts.test.ts
@@ -31,6 +31,13 @@ describe("toFontFaceInputs", () => {
     expect(input?.descriptors).not.toHaveProperty("weight");
   });
 
+  test("preserves an italic style descriptor", () => {
+    const [input] = toFontFaceInputs([
+      { family: "Brand Sans", src: "/italic.woff2", style: "  italic  " },
+    ]);
+    expect(input?.descriptors.style).toBe("italic");
+  });
+
   test("trims surrounding whitespace on family and src", () => {
     const [input] = toFontFaceInputs([{ family: "  Brand Sans  ", src: "  /a.woff2  " }]);
     expect(input?.family).toBe("Brand Sans");
@@ -79,5 +86,15 @@ describe("toFontFaceInputs", () => {
     const [input] = toFontFaceInputs(withSymbolWeight);
     expect(input?.family).toBe("Sym");
     expect(input?.descriptors).not.toHaveProperty("weight");
+  });
+
+  test("drops a blank or non-string style instead of throwing", () => {
+    const malformed = [
+      { family: "Blank", src: "/blank.woff2", style: "  " },
+      { family: "Symbol", src: "/symbol.woff2", style: Symbol("italic") },
+    ] as unknown as ReadonlyArray<FontDefinition>;
+    const inputs = toFontFaceInputs(malformed);
+    expect(inputs[0]?.descriptors).not.toHaveProperty("style");
+    expect(inputs[1]?.descriptors).not.toHaveProperty("style");
   });
 });

--- a/packages/react/src/paged-editor/hostFonts.ts
+++ b/packages/react/src/paged-editor/hostFonts.ts
@@ -24,6 +24,8 @@ export type FontDefinition = {
   src: string;
   /** CSS `font-weight` for this face (a number like `700`, or a keyword). Defaults to `normal`. */
   weight?: number | string;
+  /** CSS `font-style` for this face (for example `italic`). Defaults to `normal`. */
+  style?: string;
 };
 
 /** `FontFace` constructor inputs derived from a {@link FontDefinition}. */
@@ -73,6 +75,9 @@ export function toFontFaceInputs(
     // would even make `String()` throw) is dropped to the default.
     if (typeof font.weight === "number" || typeof font.weight === "string") {
       descriptors.weight = String(font.weight);
+    }
+    if (isNonEmptyString(font.style)) {
+      descriptors.style = font.style.trim();
     }
     inputs.push({
       family: font.family.trim(),

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -617,6 +617,27 @@ describe("assessFontEnvironment", () => {
     });
   });
 
+  test("pairs repeated text by font family before source order", () => {
+    const assessment = assessFontEnvironment(
+      ["Arial", "Calibri"],
+      fontGeom("word", [
+        ["Repeated label", "ArialMT"],
+        ["Repeated label", "Calibri-Bold"],
+      ]),
+      fontGeom("folio", [
+        ["Repeated label", "Calibri"],
+        ["Repeated label", "Arial"],
+      ]),
+    );
+
+    expect(assessment).toEqual({
+      status: "native",
+      tags: [],
+      comparedLines: 2,
+      matchingLines: 2,
+    });
+  });
+
   test("rejects matching family names with persistently different metrics", () => {
     const lines = Array.from({ length: 8 }, (_, index): [string, string] => [
       `Line ${index}`,

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -8,6 +8,8 @@ import {
   formatServerStartFailure,
   isFullyClippedByAncestors,
   isPlausibleBaseline,
+  localFontContentType,
+  localFontRouteUrl,
   meaningfulTextRange,
   parseCssFontFamilies,
   parseFirstFontFamily,
@@ -22,6 +24,21 @@ const rect = (left: number, top: number, width: number, height: number) => ({
   top,
   width,
   height,
+});
+
+describe("local font routes", () => {
+  test("uses a private browser route without exposing the local path", () => {
+    const source = localFontRouteUrl(3, "/private/fonts/Example.ttf");
+    expect(source).toBe("http://localhost:4393/__folio-parity-font/3.ttf");
+    expect(source).not.toContain("/private/fonts");
+    expect(localFontContentType("Example.ttf")).toBe("font/ttf");
+  });
+
+  test("rejects unsupported files before launching the browser", () => {
+    expect(() => localFontContentType("/private/fonts/Example.bin")).toThrow(
+      "unsupported local font format: .bin",
+    );
+  });
 });
 
 describe("clean screenshot style", () => {

--- a/parity/__tests__/wordFonts.test.ts
+++ b/parity/__tests__/wordFonts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { wordFontDefinitions } from "../wordFonts";
+
+describe("wordFontDefinitions", () => {
+  test("maps Aptos regular, bold, and italic faces to explicit CSS descriptors", () => {
+    const fonts = wordFontDefinitions("/word-fonts");
+
+    expect(fonts).toContainEqual({
+      family: "Aptos",
+      filePath: "/word-fonts/Aptos.ttf",
+      weight: 400,
+    });
+    expect(fonts).toContainEqual({
+      family: "Aptos",
+      filePath: "/word-fonts/Aptos-Bold-Italic.ttf",
+      weight: 700,
+      style: "italic",
+    });
+    expect(fonts).toContainEqual({
+      family: "Aptos Narrow",
+      filePath: "/word-fonts/Aptos-Narrow.ttf",
+      weight: 400,
+    });
+  });
+
+  test("uses one unique source file for each declared face", () => {
+    const paths = wordFontDefinitions("/word-fonts").map(({ filePath }) => filePath);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -36,6 +36,7 @@ import { compareGeoms } from "./compare";
 import { getReferenceRenderer, isReferenceRendererId } from "./referenceRenderer";
 import type { ReferenceRenderer } from "./referenceRenderer";
 import { writeHtmlReport } from "./report";
+import { getAvailableWordFonts } from "./wordFonts";
 import type { DocAssets } from "./report";
 import type {
   CorpusReport,
@@ -232,6 +233,7 @@ const runPipeline = async (
   const failures: DocFailure[] = [];
 
   let extractor: FolioExtractor | undefined;
+  const localFonts = flags.referenceId === "word" ? await getAvailableWordFonts() : [];
 
   try {
     for (let i = 0; i < docs.length; i++) {
@@ -253,6 +255,7 @@ const runPipeline = async (
           extractor = await createFolioExtractor({
             headless: !flags.headed,
             reuseServer: flags.reuseServer,
+            localFonts,
           });
         }
 

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -439,13 +439,33 @@ const collectFontPairs = (referenceGeom: DocGeom, folioGeom: DocGeom): FontPair[
     }
   }
 
-  for (const lines of folioLinesByText.values()) lines.reverse();
-
   const pairs: FontPair[] = [];
   for (const page of referenceGeom.pages) {
     for (const line of page.lines) {
       if (line.fontName === undefined) continue;
-      const folioLine = folioLinesByText.get(line.normText)?.pop();
+      const candidates = folioLinesByText.get(line.normText);
+      if (!candidates || candidates.length === 0) continue;
+
+      // Repeated labels, list markers, and running header/footer text can move
+      // across pages independently. Pair a same-family occurrence first;
+      // source-order-only pairing otherwise invents a renderer mismatch when
+      // the same text is authored in more than one font. The closest width is
+      // the least ambiguous match for subsequent metric comparison.
+      let matchingIndex = -1;
+      let closestWidthDelta = Number.POSITIVE_INFINITY;
+      for (let index = 0; index < candidates.length; index += 1) {
+        const candidate = candidates[index];
+        if (!candidate?.fontName || !fontFamiliesMatch(line.fontName, candidate.fontName)) {
+          continue;
+        }
+        const widthDelta = Math.abs(line.widthPt - candidate.widthPt);
+        if (widthDelta < closestWidthDelta) {
+          matchingIndex = index;
+          closestWidthDelta = widthDelta;
+        }
+      }
+      const folioLine =
+        matchingIndex >= 0 ? candidates.splice(matchingIndex, 1).at(0) : candidates.shift();
       if (folioLine?.fontName !== undefined) {
         pairs.push({
           referenceFont: line.fontName,

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -91,6 +91,35 @@ export type FolioExtractOptions = {
   maxPages?: number;
 };
 
+/** A font installed alongside a local reference renderer. The harness reads
+ * the file in Node and passes it to Chromium as a data URL; local paths are
+ * never exposed to the playground server. */
+export type LocalFontDefinition = {
+  family: string;
+  filePath: string;
+  weight?: number | string;
+  style?: string;
+};
+
+type BrowserFontDefinition = {
+  family: string;
+  src: string;
+  weight?: number | string;
+  style?: string;
+};
+
+type RoutedBrowserFont = {
+  definition: BrowserFontDefinition;
+  body: Buffer;
+  contentType: string;
+};
+
+export type CreateFolioExtractorOptions = {
+  headless?: boolean;
+  reuseServer?: boolean;
+  localFonts?: ReadonlyArray<LocalFontDefinition>;
+};
+
 export type FolioExtractor = {
   extract: (docxPath: string, options?: FolioExtractOptions) => Promise<FolioExtraction>;
   inspectPage: (docxPath: string, pageNumber: number) => Promise<FolioPageInspection>;
@@ -103,14 +132,18 @@ const PAGE_SELECTOR = ".layout-page";
 const VIEWPORT = { width: 1400, height: 1000 };
 const SCREENSHOT_VIEWPORT_VERTICAL_CHROME_PX = 200;
 
-const SERVER_PROBE_TIMEOUT_MS = 2000;
+// A cold Vite source transform can occupy the server before its first HTTP
+// response. Short probes repeatedly abort that same warm-up work and can report
+// a false startup failure even after Vite is listening.
+const SERVER_PROBE_TIMEOUT_MS = 30_000;
+const SERVER_OUTPUT_DRAIN_TIMEOUT_MS = 2000;
 const SERVER_REUSE_PROBE_TIMEOUT_MS = 15_000;
-const SERVER_START_TIMEOUT_MS = 90_000;
+const SERVER_START_TIMEOUT_MS = 180_000;
 const SERVER_POLL_INTERVAL_MS = 500;
 const SERVER_LOG_TAIL_CHARS = 4000;
 
-const PLAYGROUND_NAVIGATION_TIMEOUT_MS = 120_000;
-const EDITOR_RENDER_TIMEOUT_MS = 20_000;
+const PLAYGROUND_NAVIGATION_TIMEOUT_MS = 300_000;
+const EDITOR_RENDER_TIMEOUT_MS = 90_000;
 const STABILITY_POLL_INTERVAL_MS = 250;
 const STABILITY_MAX_MS = 15_000;
 const STABILITY_SETTLE_MS = 250;
@@ -118,6 +151,48 @@ const STABILITY_SETTLE_MS = 250;
 const CHROMIUM_MISSING_MARKER = "Executable doesn't exist";
 const CHROMIUM_MISSING_MESSAGE =
   "Playwright chromium missing; run: bunx playwright install chromium";
+
+const FONT_MIME_BY_EXTENSION = {
+  ".otf": "font/otf",
+  ".ttf": "font/ttf",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+} as const;
+
+export const localFontContentType = (filePath: string): string => {
+  const extension = path.extname(filePath).toLowerCase();
+  const mime = FONT_MIME_BY_EXTENSION[extension as keyof typeof FONT_MIME_BY_EXTENSION];
+  if (!mime) {
+    throw new FolioExtractError(`unsupported local font format: ${extension || "(none)"}`);
+  }
+  return mime;
+};
+
+export const localFontRouteUrl = (index: number, filePath: string): string =>
+  `${PLAYGROUND_URL}/__folio-parity-font/${index}${path.extname(filePath).toLowerCase()}`;
+
+const loadBrowserFonts = async (
+  fonts: ReadonlyArray<LocalFontDefinition> | undefined,
+): Promise<RoutedBrowserFont[]> =>
+  await Promise.all(
+    (fonts ?? []).map(async ({ family, filePath, weight, style }, index) => {
+      const definition: BrowserFontDefinition = {
+        family,
+        src: localFontRouteUrl(index, filePath),
+      };
+      if (weight !== undefined) {
+        definition.weight = weight;
+      }
+      if (style !== undefined) {
+        definition.style = style;
+      }
+      return {
+        definition,
+        body: await fs.readFile(filePath),
+        contentType: localFontContentType(filePath),
+      };
+    }),
+  );
 
 type OutputTail = { read: () => string; done: Promise<void> };
 
@@ -1131,7 +1206,7 @@ const stagedFixtureName = (sha256: string): string =>
   `${TMP_FIXTURE_PREFIX}${sha256.slice(0, 12)}.docx`;
 
 export const createFolioExtractor = async (
-  opts: { headless?: boolean; reuseServer?: boolean } = {},
+  opts: CreateFolioExtractorOptions = {},
 ): Promise<FolioExtractor> => {
   const headless = opts.headless ?? true;
   // Default to a FRESH server so the feedback loop always reflects this
@@ -1181,7 +1256,7 @@ export const createFolioExtractor = async (
       await killByPort(PLAYGROUND_PORT);
       await Promise.race([
         Promise.all([serverStdoutTail.done, serverStderrTail.done]),
-        Bun.sleep(SERVER_PROBE_TIMEOUT_MS),
+        Bun.sleep(SERVER_OUTPUT_DRAIN_TIMEOUT_MS),
       ]);
       throw new FolioExtractError(
         formatServerStartFailure(
@@ -1215,6 +1290,21 @@ export const createFolioExtractor = async (
     colorScheme: "light",
   });
   const page = await context.newPage();
+  const routedFonts = await loadBrowserFonts(opts.localFonts);
+  if (routedFonts.length > 0) {
+    for (const { definition, body, contentType } of routedFonts) {
+      // oxlint-disable-next-line no-await-in-loop -- routes must be installed before the first navigation
+      await page.route(definition.src, async (route) => {
+        await route.fulfill({ body, contentType });
+      });
+    }
+    await page.addInitScript(
+      (fonts) => {
+        Reflect.set(globalThis, "__folioParityFonts", fonts);
+      },
+      routedFonts.map(({ definition }) => definition),
+    );
+  }
 
   const navigateToDocument = async (stagedName: string): Promise<void> => {
     const documentUrl = `${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`;
@@ -1295,6 +1385,7 @@ export const createFolioExtractor = async (
           stagedName,
           zoomFactor: String(zoomFactor),
           pxToPt: String(PX_TO_PT),
+          localFontFaces: String(routedFonts.length),
         },
       };
 

--- a/parity/wordFonts.ts
+++ b/parity/wordFonts.ts
@@ -51,12 +51,10 @@ export const wordFontDefinitions = (fontDirectory: string): LocalFontDefinition[
 /** Fonts bundled with Word but not normally visible to Chromium. Missing
  * faces are skipped so an older Word installation remains usable. */
 export const getAvailableWordFonts = async (): Promise<LocalFontDefinition[]> => {
-  const available: LocalFontDefinition[] = [];
-  for (const font of wordFontDefinitions(WORD_FONT_DIR)) {
-    // oxlint-disable-next-line no-await-in-loop -- preserve manifest order for deterministic face registration
-    if (await Bun.file(font.filePath).exists()) {
-      available.push(font);
-    }
-  }
-  return available;
+  const available = await Promise.all(
+    wordFontDefinitions(WORD_FONT_DIR).map(async (font) =>
+      (await Bun.file(font.filePath).exists()) ? [font] : [],
+    ),
+  );
+  return available.flat();
 };

--- a/parity/wordFonts.ts
+++ b/parity/wordFonts.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+
+import type { LocalFontDefinition } from "./folioExtract";
+
+const WORD_FONT_DIR = "/Applications/Microsoft Word.app/Contents/Resources/DFonts";
+
+type WordFontFace = Omit<LocalFontDefinition, "filePath"> & { fileName: string };
+
+const APTOS_FACES = [
+  { fileName: "Aptos-Light.ttf", family: "Aptos", weight: 300 },
+  { fileName: "Aptos-Light-Italic.ttf", family: "Aptos", weight: 300, style: "italic" },
+  { fileName: "Aptos.ttf", family: "Aptos", weight: 400 },
+  { fileName: "Aptos-Italic.ttf", family: "Aptos", weight: 400, style: "italic" },
+  { fileName: "Aptos-SemiBold.ttf", family: "Aptos", weight: 600 },
+  { fileName: "Aptos-SemiBold-Italic.ttf", family: "Aptos", weight: 600, style: "italic" },
+  { fileName: "Aptos-Bold.ttf", family: "Aptos", weight: 700 },
+  { fileName: "Aptos-Bold-Italic.ttf", family: "Aptos", weight: 700, style: "italic" },
+  { fileName: "Aptos-ExtraBold.ttf", family: "Aptos", weight: 800 },
+  { fileName: "Aptos-ExtraBold-Italic.ttf", family: "Aptos", weight: 800, style: "italic" },
+  { fileName: "Aptos-Black.ttf", family: "Aptos", weight: 900 },
+  { fileName: "Aptos-Black-Italic.ttf", family: "Aptos", weight: 900, style: "italic" },
+  { fileName: "Aptos-Narrow.ttf", family: "Aptos Narrow", weight: 400 },
+  {
+    fileName: "Aptos-Narrow-Italic.ttf",
+    family: "Aptos Narrow",
+    weight: 400,
+    style: "italic",
+  },
+  { fileName: "Aptos-Narrow-Bold.ttf", family: "Aptos Narrow", weight: 700 },
+  {
+    fileName: "Aptos-Narrow-Bold-Italic.ttf",
+    family: "Aptos Narrow",
+    weight: 700,
+    style: "italic",
+  },
+] as const satisfies ReadonlyArray<WordFontFace>;
+
+export const wordFontDefinitions = (fontDirectory: string): LocalFontDefinition[] =>
+  APTOS_FACES.map((face) => {
+    const font: LocalFontDefinition = {
+      family: face.family,
+      filePath: path.join(fontDirectory, face.fileName),
+      weight: face.weight,
+    };
+    if ("style" in face) {
+      font.style = face.style;
+    }
+    return font;
+  });
+
+/** Fonts bundled with Word but not normally visible to Chromium. Missing
+ * faces are skipped so an older Word installation remains usable. */
+export const getAvailableWordFonts = async (): Promise<LocalFontDefinition[]> => {
+  const available: LocalFontDefinition[] = [];
+  for (const font of wordFontDefinitions(WORD_FONT_DIR)) {
+    // oxlint-disable-next-line no-await-in-loop -- preserve manifest order for deterministic face registration
+    if (await Bun.file(font.filePath).exists()) {
+      available.push(font);
+    }
+  }
+  return available;
+};


### PR DESCRIPTION
## Summary
- preserve host font face styles and load the local Word Aptos family in parity runs
- resolve theme fonts throughout layout and preserve paragraph-style fonts inside styled tables
- harden parity startup, font detection, and same-family line matching

## Validation
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- `bun run validate-dist`
- `bun run changeset:check`
- full unit suite; load-sensitive timeouts rerun alone: 37/37 passed
- interaction failures from parallel cold-start rerun single-worker: 12/12 passed
- exact local Word parity: native fonts on every comparable line; page counts 11/11 and 9/9
- differential harness invoked; optional Python and .NET adapters unavailable locally

No source documents, document text, font binaries, or local font paths are included.