### PR TITLE
fix: reduce document conversion overhead

### DIFF
--- a/.changeset/swift-dolphins-convert.md
+++ b/.changeset/swift-dolphins-convert.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Reduce DOCX parsing and ProseMirror conversion work for large documents.

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -795,67 +795,69 @@ function getLocalName(name: string | undefined): string {
   return colonIndex !== -1 ? name.slice(colonIndex + 1) : name;
 }
 
-function paragraphStartsWithRenderedPageBreak(node: XmlElement): boolean {
-  const inlineWrappers = new Set([
-    "hyperlink",
-    "smartTag",
-    "sdt",
-    "sdtContent",
-    "fldSimple",
-    "customXml",
-    "ins",
-    "del",
-    "moveFrom",
-    "moveTo",
-  ]);
-  const nonContentMarkers = new Set([
-    "pPr",
-    "proofErr",
-    "bookmarkStart",
-    "bookmarkEnd",
-    "commentRangeStart",
-    "commentRangeEnd",
-    "commentReference",
-    "permStart",
-    "permEnd",
-    "rsidR",
-  ]);
-  const visibleRunContent = new Set([
-    "t",
-    "tab",
-    "br",
-    "cr",
-    "sym",
-    "drawing",
-    "pict",
-    "object",
-    "softHyphen",
-    "noBreakHyphen",
-    "fldChar",
-    "instrText",
-    "pgNum",
-    "separator",
-    "continuationSeparator",
-    "footnoteRef",
-    "endnoteRef",
-    "footnoteReference",
-    "endnoteReference",
-    "ptab",
-    "monthShort",
-    "monthLong",
-    "yearShort",
-    "yearLong",
-    "dayShort",
-    "dayLong",
-  ]);
+const RENDERED_BREAK_INLINE_WRAPPERS = new Set([
+  "hyperlink",
+  "smartTag",
+  "sdt",
+  "sdtContent",
+  "fldSimple",
+  "customXml",
+  "ins",
+  "del",
+  "moveFrom",
+  "moveTo",
+]);
 
+const RENDERED_BREAK_NON_CONTENT_MARKERS = new Set([
+  "pPr",
+  "proofErr",
+  "bookmarkStart",
+  "bookmarkEnd",
+  "commentRangeStart",
+  "commentRangeEnd",
+  "commentReference",
+  "permStart",
+  "permEnd",
+  "rsidR",
+]);
+
+const RENDERED_BREAK_VISIBLE_RUN_CONTENT = new Set([
+  "t",
+  "tab",
+  "br",
+  "cr",
+  "sym",
+  "drawing",
+  "pict",
+  "object",
+  "softHyphen",
+  "noBreakHyphen",
+  "fldChar",
+  "instrText",
+  "pgNum",
+  "separator",
+  "continuationSeparator",
+  "footnoteRef",
+  "endnoteRef",
+  "footnoteReference",
+  "endnoteReference",
+  "ptab",
+  "monthShort",
+  "monthLong",
+  "yearShort",
+  "yearLong",
+  "dayShort",
+  "dayLong",
+]);
+
+function paragraphStartsWithRenderedPageBreak(node: XmlElement): boolean {
   type VisitResult = "forced" | "visible" | "continue";
   let sawRenderedPageBreak = false;
 
   const visit = (element: XmlElement): VisitResult => {
     for (const child of getChildElements(element)) {
       const childName = getLocalName(child.name);
-      if (nonContentMarkers.has(childName)) {
+      if (RENDERED_BREAK_NON_CONTENT_MARKERS.has(childName)) {
         continue;
       }
       if (childName === "lastRenderedPageBreak") {
@@ -875,13 +877,13 @@ function paragraphStartsWithRenderedPageBreak(node: XmlElement): boolean {
           if (runChildName === "br" && getAttribute(runChild, "w", "type") === "page") {
             return "forced";
           }
-          if (visibleRunContent.has(runChildName)) {
+          if (RENDERED_BREAK_VISIBLE_RUN_CONTENT.has(runChildName)) {
             return "visible";
           }
         }
         continue;
       }
-      if (inlineWrappers.has(childName)) {
+      if (RENDERED_BREAK_INLINE_WRAPPERS.has(childName)) {
         const result = visit(child);
         if (result !== "continue") {
           return result;

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -1141,7 +1141,11 @@ const attrsResult = <T>(
       }
 
       const presentAttrs: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(attrs)) {
+      for (const key in attrs) {
+        if (!Object.hasOwn(attrs, key)) {
+          continue;
+        }
+        const value = attrs[key];
         if (value !== null) {
           presentAttrs[key] = value;
         }

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -1132,17 +1132,31 @@ const attrsResult = <T>(
     return { ok: false, issues };
   }
 
-  const normalizedAttrs: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(attrs)) {
-    if (value !== null) {
-      normalizedAttrs[key] = value;
-    }
-  }
+  let normalizedAttrs: T | undefined;
+  return {
+    ok: true,
+    get value(): T {
+      if (normalizedAttrs !== undefined) {
+        return normalizedAttrs;
+      }
 
-  // SAFETY: this module is the ProseMirror FFI boundary. The checks above
-  // validate the attrs this code relies on before exposing the typed shape,
-  // and null ProseMirror defaults are normalized to absent optional fields.
-  return { ok: true, value: normalizedAttrs as T };
+      const presentAttrs: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(attrs)) {
+        if (value !== null) {
+          presentAttrs[key] = value;
+        }
+      }
+
+      // SAFETY: this module is the ProseMirror FFI boundary. The checks above
+      // validate the attrs this code relies on before exposing the typed shape,
+      // and null ProseMirror defaults are normalized to absent optional fields.
+      normalizedAttrs = presentAttrs as T;
+      return normalizedAttrs;
+    },
+    set value(value: T) {
+      normalizedAttrs = value;
+    },
+  };
 };
 
 const expectAttrs = <T>(result: ReadProseMirrorAttrsResult<T>, label: string): T => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1000,7 +1000,11 @@ function hasDirectRunFormatting(formatting: TextFormatting | undefined): boolean
     return false;
   }
 
-  for (const [key, value] of Object.entries(formatting)) {
+  for (const key in formatting) {
+    if (!Object.hasOwn(formatting, key)) {
+      continue;
+    }
+    const value = Reflect.get(formatting, key);
     if (key !== "styleId" && value !== undefined) {
       return true;
     }
@@ -3470,14 +3474,44 @@ function paragraphPageBreakPosition(paragraph: Paragraph): "before" | "after" | 
 
 function mayContainPageBreak(paragraph: Paragraph): boolean {
   for (const item of paragraph.content) {
-    if (item.type !== "run") {
+    if (item.type === "run") {
+      for (const content of item.content) {
+        if (content.type === "break" && content.breakType === "page") {
+          return true;
+        }
+      }
+      continue;
+    }
+
+    if (
+      item.type === "hyperlink" ||
+      item.type === "simpleField" ||
+      item.type === "complexField" ||
+      item.type === "inlineSdt" ||
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
       return true;
     }
-    for (const content of item.content) {
-      if (content.type === "break" && content.breakType === "page") {
-        return true;
-      }
+
+    if (
+      item.type === "bookmarkStart" ||
+      item.type === "bookmarkEnd" ||
+      item.type === "commentRangeStart" ||
+      item.type === "commentRangeEnd" ||
+      item.type === "commentReference" ||
+      item.type === "moveFromRangeStart" ||
+      item.type === "moveFromRangeEnd" ||
+      item.type === "moveToRangeStart" ||
+      item.type === "moveToRangeEnd" ||
+      item.type === "mathEquation"
+    ) {
+      continue;
     }
+
+    item satisfies never;
   }
   return false;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -92,6 +92,9 @@ type RunFormattingResolver = (
 
 const TOC_STYLE_ID = /^TOC\d*$/iu;
 
+const isTocStyleId = (styleId: string | undefined): boolean =>
+  styleId !== undefined && TOC_STYLE_ID.test(styleId);
+
 /**
  * Convert a Document to a ProseMirror document
  *
@@ -244,7 +247,7 @@ function convertParagraph(
   textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode {
   const attrs = paragraphFormattingToAttrs(paragraph, styleResolver, tableParagraphOverlay);
-  const isTocParagraph = TOC_STYLE_ID.test(paragraph.formatting?.styleId ?? "");
+  const isTocParagraph = isTocStyleId(paragraph.formatting?.styleId);
   const inlineNodes: PMNode[] = [];
   let inlineOffset = 0;
   let bookmarksArr: { id: number; name: string }[] | undefined;
@@ -722,7 +725,7 @@ function paragraphFormattingToAttrs(
     set(
       "defaultTextFormatting",
       resolveParagraphDefaultTextFormatting(styleId, formatting, styleResolver, {
-        includeParagraphMarkRunProperties: !TOC_STYLE_ID.test(styleId ?? ""),
+        includeParagraphMarkRunProperties: !isTocStyleId(styleId),
       }),
     );
 
@@ -997,8 +1000,12 @@ function hasDirectRunFormatting(formatting: TextFormatting | undefined): boolean
     return false;
   }
 
-  const entries: [string, unknown][] = Object.entries(formatting);
-  return entries.some(([key, value]) => key !== "styleId" && value !== undefined);
+  for (const [key, value] of Object.entries(formatting)) {
+    if (key !== "styleId" && value !== undefined) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function stripParagraphMarkOnlyFormatting(formatting: TextFormatting): TextFormatting | undefined {
@@ -3030,14 +3037,52 @@ type TextBoxExtractionContext = {
 };
 
 type ExtractTextBoxesResult = {
-  textBoxes: ExtractedTextBox[];
+  textBoxes: readonly ExtractedTextBox[];
   textBoxAnchors: ReadonlyMap<Shape, string>;
+};
+
+const NO_EXTRACTED_TEXT_BOXES: ExtractTextBoxesResult = {
+  textBoxes: [],
+  textBoxAnchors: new Map(),
 };
 
 function extractTextBoxesFromParagraph(
   paragraph: Paragraph,
   textBoxGroupId: string,
 ): ExtractTextBoxesResult {
+  if (!mayContainTextBox(paragraph)) {
+    return NO_EXTRACTED_TEXT_BOXES;
+  }
+
+  return extractTextBoxes(paragraph, textBoxGroupId);
+}
+
+function mayContainTextBox(paragraph: Paragraph): boolean {
+  for (const item of paragraph.content) {
+    if (item.type !== "run") {
+      if (
+        item.type === "inlineSdt" ||
+        item.type === "hyperlink" ||
+        item.type === "insertion" ||
+        item.type === "deletion" ||
+        item.type === "moveFrom" ||
+        item.type === "moveTo"
+      ) {
+        return true;
+      }
+      continue;
+    }
+
+    for (const content of item.content) {
+      if (content.type === "shape" && content.shape.textBody) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function extractTextBoxes(paragraph: Paragraph, textBoxGroupId: string): ExtractTextBoxesResult {
   const textBoxes: ExtractedTextBox[] = [];
   const textBoxAnchors = new Map<Shape, string>();
   const visitRun = (run: Run, context: TextBoxExtractionContext): void => {
@@ -3416,6 +3461,28 @@ export function footnoteToProseDoc(content: BlockContent[], options?: ToProseDoc
  *   null     — no page break found.
  */
 function paragraphPageBreakPosition(paragraph: Paragraph): "before" | "after" | null {
+  if (!mayContainPageBreak(paragraph)) {
+    return null;
+  }
+
+  return findParagraphPageBreakPosition(paragraph);
+}
+
+function mayContainPageBreak(paragraph: Paragraph): boolean {
+  for (const item of paragraph.content) {
+    if (item.type !== "run") {
+      return true;
+    }
+    for (const content of item.content) {
+      if (content.type === "break" && content.breakType === "page") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function findParagraphPageBreakPosition(paragraph: Paragraph): "before" | "after" | null {
   // Mutated by visitRun during traversal. oxlint flow analysis can't see
   // closure mutations, so a plain `let` here trips no-unnecessary-condition;
   // wrap in an object to keep the flag genuinely opaque to the linter.

--- a/packages/core/src/utils/fontFamilyMerge.ts
+++ b/packages/core/src/utils/fontFamilyMerge.ts
@@ -2,6 +2,23 @@ import type { TextFormatting } from "../types/document";
 
 type FontFamily = NonNullable<TextFormatting["fontFamily"]>;
 
+const FONT_FAMILY_PAIRS = [
+  ["ascii", "asciiTheme"],
+  ["hAnsi", "hAnsiTheme"],
+  ["eastAsia", "eastAsiaTheme"],
+  ["cs", "csTheme"],
+] as const;
+
+const isFontFamilyPairKey = (key: string): boolean =>
+  key === "ascii" ||
+  key === "asciiTheme" ||
+  key === "hAnsi" ||
+  key === "hAnsiTheme" ||
+  key === "eastAsia" ||
+  key === "eastAsiaTheme" ||
+  key === "cs" ||
+  key === "csTheme";
+
 export function mergeFontFamily(target: FontFamily | undefined, source: FontFamily): FontFamily {
   const result: Record<string, unknown> = {};
   const src = source as Record<string, unknown>;
@@ -24,17 +41,7 @@ export function mergeFontFamily(target: FontFamily | undefined, source: FontFami
     }
   }
 
-  const pairs: [string, string][] = [
-    ["ascii", "asciiTheme"],
-    ["hAnsi", "hAnsiTheme"],
-    ["eastAsia", "eastAsiaTheme"],
-    ["cs", "csTheme"],
-  ];
-  const pairKeys = new Set<string>();
-
-  for (const [explicit, theme] of pairs) {
-    pairKeys.add(explicit);
-    pairKeys.add(theme);
+  for (const [explicit, theme] of FONT_FAMILY_PAIRS) {
     if (src[explicit] === undefined && src[theme] === undefined) {
       continue;
     }
@@ -47,7 +54,7 @@ export function mergeFontFamily(target: FontFamily | undefined, source: FontFami
   }
 
   for (const key of Object.keys(src)) {
-    if (!pairKeys.has(key) && src[key] !== undefined) {
+    if (!isFontFamilyPairKey(key) && src[key] !== undefined) {
       result[key] = src[key];
     }
   }


### PR DESCRIPTION
## Summary

- normalize validated ProseMirror attributes only when a typed value is consumed, avoiding a duplicate materialization during validation
- reject common paragraphs before recursive text-box and page-break scans, and skip TOC matching when no style ID exists
- reuse rendered-break and font-family lookup data instead of allocating it for every paragraph or merge

## Performance

A paired same-process benchmark over 1,500 paragraphs and 100 iterations reduced median ProseMirror conversion from 124.2 ms to 61.4 ms (0.52x). Candidate and control ProseMirror JSON were compared on every run.

The production browser profiler independently measured the conversion phase at 86.3 ms to 46.5 ms cold and 81.8 ms to 45.2 ms warm across three repetitions. The post-download pipeline moved from 409.1 ms to 289.5 ms cold and 407.6 ms to 283.3 ms warm. The host was heavily loaded, so the paired benchmark is the primary evidence and the browser results are directional confirmation.

Validated with the full unit suite, lint, workspace and parity typechecks, build, clean-room distribution validation, changeset check, and dependency audit.