### PR TITLE
fix: improve line metrics and cached pagination

### DIFF
--- a/.changeset/quiet-pages-align.md
+++ b/.changeset/quiet-pages-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Improve automatic line metrics and cached page-boundary reconciliation.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -534,6 +534,26 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
     });
 
+    test("rendered page break reconciles small line-metric drift near the page end", () => {
+      const blocks: FlowBlock[] = [
+        makeParagraphBlock(0, "Nearly fills page one", 1),
+        {
+          ...makeParagraphBlock(1, "Cached next page", 23),
+          attrs: { renderedPageBreakBefore: true },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 810)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 16, 90, 20)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
+      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
+    });
+
     test("rendered page break does not reapply leading spacing after snapping", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Nearly fills page one", 1),

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -382,10 +382,8 @@ export function layoutDocument(
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
 
-    const firstLineAdvance =
-      measure.kind === "paragraph" && measure.lines.length > 0
-        ? measuredLineAdvance(measure.lines[0]!)
-        : 0;
+    const firstLine = measure.kind === "paragraph" ? measure.lines.at(0) : undefined;
+    const firstLineAdvance = firstLine ? measuredLineAdvance(firstLine) : 0;
     const renderedBreakNeedsSnap =
       measure.kind === "paragraph" &&
       (!paginator.fits(measure.totalHeight) ||

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -54,6 +54,8 @@ import type {
   SectionBreakBlock,
 } from "./types";
 
+const RENDERED_BREAK_REFLOW_TOLERANCE_LINES = 3;
+
 export type SectionLayoutConfig = {
   pageSize: { w: number; h: number };
   margins: PageMargins;
@@ -380,8 +382,16 @@ export function layoutDocument(
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
 
+    const firstLineAdvance =
+      measure.kind === "paragraph" && measure.lines.length > 0
+        ? measuredLineAdvance(measure.lines[0]!)
+        : 0;
     const renderedBreakNeedsSnap =
-      measure.kind === "paragraph" && !paginator.fits(measure.totalHeight);
+      measure.kind === "paragraph" &&
+      (!paginator.fits(measure.totalHeight) ||
+        (firstLineAdvance > 0 &&
+          paginator.getAvailableHeight() <=
+            firstLineAdvance * RENDERED_BREAK_REFLOW_TOLERANCE_LINES));
     const hasExplicitPageBreak = hasPageBreakBefore(block);
     const breakDecision = reconcileBreakBeforeBlock({
       state: renderedBreakState,

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -213,6 +213,25 @@ describe("font metrics cache", () => {
 });
 
 describe("empty paragraph line-height floor", () => {
+  test("uses mapped font metrics for automatic line-spacing multiples", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "mapped-line-height",
+          runs: [{ kind: "text", text: "Mapped metrics", fontFamily: "Segoe UI", fontSize: 10 }],
+          attrs: { spacing: { line: 1.15, lineUnit: "multiplier", lineRule: "auto" } },
+        },
+        600,
+      );
+
+      expect(measure.lines.at(0)?.lineHeight).toBeCloseTo(
+        10 * PT_TO_PX * ((2210 + 514) / 2048) * 1.15,
+        4,
+      );
+    }, fakeMeasure);
+  });
+
   test("rounds participating lines up to the active document-grid pitch", () => {
     withFakeTextMeasure(() => {
       const measure = measureParagraph(

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -107,6 +107,25 @@ describe("rendered break reconciliation", () => {
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
+  test("a fitting cached marker remains authoritative with leading spacing", () => {
+    const previous = paragraph(1);
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: paragraph(2, {
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+      }),
+      previousBlock: previous,
+      page: page([paragraphFragment(1)]),
+      blocksById: new Map([["1", previous]]),
+      hasExplicitPageBreak: false,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.suppressSpaceBefore).toBe(true);
+  });
+
   test("a fitting cached marker remains authoritative after a table", () => {
     const previous: FlowBlock = { kind: "table", id: 1, rows: [] };
     const decision = reconcileBreakBeforeBlock({

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -69,7 +69,10 @@ export const reconcileBreakBeforeBlock = ({
   // A keep-with-next paragraph carries the marker boundary into its linked
   // content, so its own height is not enough to classify the marker as stale.
   const markerNeedsSnap =
-    renderedBreakNeedsSnap || block.attrs?.keepNext === true || previousBlock?.kind === "table";
+    renderedBreakNeedsSnap ||
+    block.attrs?.keepNext === true ||
+    ((block.attrs?.spacing?.before ?? 0) > 0 && previousBlock?.kind !== "sectionBreak") ||
+    previousBlock?.kind === "table";
   const forcePageBreak =
     markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById);
   const followsAuthoredPageBreak = previousBlock?.kind === "pageBreak";

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -29,6 +29,7 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["georgia", 1.1362],
     ["verdana", 1.2153],
     ["tahoma", 1.207],
+    ["segoe ui", 1.3301],
     ["montserrat", 1.219],
     ["trebuchet ms", 1.1611],
     ["courier new", 1.1328],

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -267,6 +267,18 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
       unitsPerEm: 2048,
     }), // 1.2070 (was hand-transcribed 1.2075 — negligible, now derived)
   },
+  "segoe ui": {
+    googleFont: "Source Sans 3",
+    category: "sans-serif",
+    fallbackStack: ["Segoe UI", "Source Sans 3", "Arial", "Helvetica", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 2210,
+      hheaDescent: -514,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.3301
+  },
   montserrat: {
     googleFont: "Montserrat",
     category: "sans-serif",


### PR DESCRIPTION
## Summary

- derive Segoe UI automatic line spacing from its hhea metrics and retain compatible fallbacks
- reconcile cached page boundaries when small line-metric drift leaves a marker near the page edge
- preserve authoritative boundaries for paragraphs with leading spacing while keeping natural reflow advisory
- add focused measurement, reconciliation, and layout regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page-break handling by using a tolerance-based reflow heuristic when line metrics drift near page boundaries.
  * Strengthened cached rendered page-break behavior so it overrides leading spacing when applying break-before markers.
  * Refined automatic line-height calculations for multiplier-based line spacing with “auto” line rules.
  * Enhanced font resolution for DOCX “Segoe UI” with more accurate metric mapping and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->