### PR TITLE
fix: scope hanging punctuation to East Asian runs

### DIFF
--- a/.changeset/tidy-commas-stay.md
+++ b/.changeset/tidy-commas-stay.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Limit hanging punctuation to East Asian language runs so Latin punctuation stays within line bounds.

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -61,6 +61,11 @@ const segmenterLocale = (locale?: string): string | undefined => {
 const DICTIONARY_BREAK_SCRIPT =
   /[\p{Script=Thai}\p{Script=Lao}\p{Script=Khmer}\p{Script=Myanmar}]/u;
 const CJK_SCRIPT = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+// Word limits overflow punctuation to runs whose language is Chinese,
+// Japanese, Korean, or Yi (treated as Simplified Chinese). Applying the
+// East-Asian punctuation set to Latin runs lets ordinary commas and periods
+// exceed a margin, changing otherwise unrelated line and page breaks.
+const WORD_HANGING_PUNCTUATION_LANGUAGES = new Set(["ii", "ja", "ko", "zh"]);
 const SIMPLE_BREAK_TEXT =
   /^[\p{Script=Latin}\p{Script=Cyrillic}\p{Script=Greek}\p{Number}\p{Punctuation}\p{White_Space}]*$/u;
 const BREAK_AFTER_CHARACTER = new Set([
@@ -426,6 +431,10 @@ const findPatternHyphenationBreaks = (text: string, policy?: LineBreakPolicy): n
 };
 
 const isDefaultHangingPunctuation = (text: string, policy?: LineBreakPolicy): boolean => {
+  const language = segmenterLocale(policy?.locale);
+  if (!language || !WORD_HANGING_PUNCTUATION_LANGUAGES.has(language)) {
+    return false;
+  }
   const characters = [...text];
   return (
     characters.length > 0 &&

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -166,10 +166,16 @@ describe("isHangingPunctuation", () => {
     expect(isHangingPunctuation("（", { locale: "zh-CN" })).toBe(false);
   });
 
+  test("does not apply East-Asian hanging punctuation to Latin runs", () => {
+    expect(isHangingPunctuation(",", { locale: "en-US" })).toBe(false);
+    expect(isHangingPunctuation(",", { locale: "ja-JP" })).toBe(true);
+  });
+
   test("includes document-specific prohibited line-start characters", () => {
-    expect(isHangingPunctuation("※", { noLineBreaksBefore: "※" })).toBe(true);
+    expect(isHangingPunctuation("※", { locale: "ja-JP", noLineBreaksBefore: "※" })).toBe(true);
     expect(
       isHangingPunctuation("※", {
+        locale: "ja-JP",
         kinsoku: false,
         noLineBreaksBefore: "※",
       }),

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -2422,6 +2422,25 @@ describe("CJK line breaking", () => {
     );
   });
 
+  test("keeps Latin punctuation inside the line extent", () => {
+    withFakeTextMeasure(
+      () => {
+        const paragraph: ParagraphBlock = {
+          kind: "paragraph",
+          id: "latin-overflow-punctuation",
+          runs: [{ kind: "text", text: "AB,", language: { val: "en-US" } }],
+          attrs: { overflowPunctuation: true },
+        };
+
+        const measure = measureParagraph(paragraph, 20);
+
+        expect(measure.lines).toHaveLength(2);
+        expect(measure.lines[0]?.toChar).toBe(2);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
+
   test("does not hang opening punctuation", () => {
     withFakeTextMeasure(
       () => {

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -66,6 +66,10 @@ export type FolioSpanInspection = {
   fontSizePx?: number;
   fontWeight?: string;
   fontStyle?: string;
+  fontKerning?: string;
+  letterSpacing?: string;
+  canvasAdvanceWidthPx?: number;
+  fontLoaded?: boolean;
   textTransform?: string;
 };
 
@@ -1146,6 +1150,7 @@ const inspectSinglePage = (page: Page, domIndex: number): Promise<FolioPageInspe
       Number.isFinite(pageRect.width) && pageRect.width > 0 ? el.offsetWidth / pageRect.width : 1;
 
     const lineEls = Array.from(el.querySelectorAll(".layout-line")) as HTMLElement[];
+    const canvasContext = document.createElement("canvas").getContext("2d");
     const lines = lineEls.map((lineEl, lineIndex) => {
       const region: Region = (() => {
         if (lineEl.closest(".layout-page-header")) {
@@ -1165,6 +1170,24 @@ const inspectSinglePage = (page: Page, domIndex: number): Promise<FolioPageInspe
         const pmStart = Number(spanEl.dataset["pmStart"]);
         const pmEnd = Number(spanEl.dataset["pmEnd"]);
         const fontSizePx = Number.parseFloat(computed.fontSize);
+        const font = [
+          computed.fontStyle,
+          computed.fontWeight,
+          computed.fontSize,
+          computed.fontFamily,
+        ].join(" ");
+        let canvasAdvanceWidthPx: number | undefined;
+        if (canvasContext) {
+          canvasContext.font = font;
+          if (
+            computed.fontKerning === "auto" ||
+            computed.fontKerning === "normal" ||
+            computed.fontKerning === "none"
+          ) {
+            canvasContext.fontKerning = computed.fontKerning;
+          }
+          canvasAdvanceWidthPx = canvasContext.measureText(spanEl.textContent ?? "").width;
+        }
         return {
           text: spanEl.textContent ?? "",
           className: spanEl.className,
@@ -1175,6 +1198,17 @@ const inspectSinglePage = (page: Page, domIndex: number): Promise<FolioPageInspe
           ...(Number.isFinite(fontSizePx) ? { fontSizePx } : {}),
           fontWeight: computed.fontWeight,
           fontStyle: computed.fontStyle,
+          fontKerning: computed.fontKerning,
+          letterSpacing: computed.letterSpacing,
+          ...(canvasAdvanceWidthPx !== undefined ? { canvasAdvanceWidthPx } : {}),
+          fontLoaded: document.fonts.check(
+            [
+              computed.fontStyle,
+              computed.fontWeight,
+              computed.fontSize,
+              computed.fontFamily.split(",")[0],
+            ].join(" "),
+          ),
           textTransform: computed.textTransform,
         };
       });

--- a/parity/folioInspect.ts
+++ b/parity/folioInspect.ts
@@ -100,6 +100,11 @@ const main = async (): Promise<void> => {
           fontSizePx: span.fontSizePx === undefined ? undefined : round(span.fontSizePx),
           fontWeight: span.fontWeight,
           fontStyle: span.fontStyle,
+          fontKerning: span.fontKerning,
+          letterSpacing: span.letterSpacing,
+          canvasAdvanceWidthPx:
+            span.canvasAdvanceWidthPx === undefined ? undefined : round(span.canvasAdvanceWidthPx),
+          fontLoaded: span.fontLoaded,
           textTransform: span.textTransform,
         })),
         omittedSpans: Math.max(0, line.spans.length - flags.maxSpans),


### PR DESCRIPTION
## Summary

- limit default overflow punctuation to Chinese, Japanese, Korean, and Yi language runs
- keep Latin commas and periods inside the measured line extent
- expose font kerning, spacing, canvas advance, and load state in parity inspections

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run validate-dist`
- `bun run changeset:check`
- 76/76 committed Word 16.112 line endpoints match

## Reference

Microsoft documents `w:overflowPunct` as language-scoped compatibility behavior: https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/d6898d5b-80e4-4d1a-98b3-63f0aed1e52d

CC on behalf of @jan-kubica