### PR TITLE
fix: preserve inline cached page boundaries

### DIFF
--- a/.changeset/calm-breaks-flow.md
+++ b/.changeset/calm-breaks-flow.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve cached OOXML page boundaries inside paragraphs during editing and layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -477,7 +477,8 @@ export type MeasuredLine = {
     floatSkipBefore?: number; /** Decorative hyphen inserted at a dictionary break without changing source text. */
     discretionaryHyphen?: {
         runIndex: number;
-    };
+    }; /** A cached pagination boundary occurs immediately before this line. */
+    renderedPageBreakBefore?: boolean;
 };
 
 // @public
@@ -608,7 +609,7 @@ export type ParagraphAttrs = {
     keepNext?: boolean;
     keepLines?: boolean;
     widowControl?: boolean;
-    pageBreakBefore?: boolean; /** Word's cached pagination hint (`w:lastRenderedPageBreak`). */
+    pageBreakBefore?: boolean; /** Cached OOXML pagination hint (`w:lastRenderedPageBreak`). */
     renderedPageBreakBefore?: boolean;
     styleId?: string;
     contextualSpacing?: boolean;
@@ -697,11 +698,18 @@ export type ParagraphSpacing = {
     lineRule?: "auto" | "exact" | "atLeast";
 };
 
+// @public
+export type RenderedPageBreakRun = RunFormatting & {
+    kind: "renderedPageBreak";
+    pmStart?: number;
+    pmEnd?: number;
+};
+
 // @public (undocumented)
 export const resolveSectionHeaderFooterRefs: (documentModel: import__stll_docx_core_model.Document | null | undefined) => PageHeaderFooterRefs[] | undefined;
 
 // @public
-export type Run = TextRun | TabRun | ImageRun | LineBreakRun | FieldRun | MathRun;
+export type Run = TextRun | TabRun | ImageRun | LineBreakRun | RenderedPageBreakRun | FieldRun | MathRun;
 
 // @public
 export type RunFormatting = {

--- a/api-reports/docx-core/index.api.md
+++ b/api-reports/docx-core/index.api.md
@@ -202,7 +202,7 @@ export type Run = {
 };
 
 // @public
-export type RunContent = TextContent | TabContent | BreakContent | SymbolContent | NoteReferenceContent | FieldCharContent | InstrTextContent | SoftHyphenContent | NoBreakHyphenContent | DrawingContent | ShapeContent;
+export type RunContent = TextContent | TabContent | BreakContent | SymbolContent | NoteReferenceContent | FieldCharContent | InstrTextContent | SoftHyphenContent | NoBreakHyphenContent | RenderedPageBreakContent | DrawingContent | ShapeContent;
 
 // @public (undocumented)
 export type SectionProperties = {

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -770,7 +770,7 @@ export type Run = {
 };
 
 // @public
-export type RunContent = TextContent | TabContent | BreakContent | SymbolContent | NoteReferenceContent | FieldCharContent | InstrTextContent | SoftHyphenContent | NoBreakHyphenContent | DrawingContent | ShapeContent;
+export type RunContent = TextContent | TabContent | BreakContent | SymbolContent | NoteReferenceContent | FieldCharContent | InstrTextContent | SoftHyphenContent | NoBreakHyphenContent | RenderedPageBreakContent | DrawingContent | ShapeContent;
 
 // @public
 export type RunPropertyChange = {

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -554,6 +554,44 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1]);
     });
 
+    test("rendered page break reconciles a cached boundary inside a paragraph", () => {
+      const paragraph: ParagraphBlock = {
+        kind: "paragraph",
+        id: 1,
+        runs: [
+          { kind: "text", text: "before", pmStart: 2, pmEnd: 8 },
+          { kind: "renderedPageBreak", pmStart: 8, pmEnd: 9 },
+          { kind: "text", text: "after", pmStart: 9, pmEnd: 14 },
+        ],
+        pmStart: 1,
+        pmEnd: 15,
+      };
+      const markerLine = {
+        ...makeLine(2, 0, 2, 5, 50, 20),
+        renderedPageBreakBefore: true,
+      };
+      const blocks: FlowBlock[] = [makeParagraphBlock(0, "Nearly fills page one", 16), paragraph];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 20, 500, 790)]),
+        makeParagraphMeasure([makeLine(0, 0, 0, 6, 60, 20), markerLine]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages).toHaveLength(2);
+      expect(layout.pages[0]?.fragments.at(-1)).toMatchObject({
+        blockId: 1,
+        fromLine: 0,
+        toLine: 1,
+      });
+      expect(layout.pages[1]?.fragments.at(0)).toMatchObject({
+        blockId: 1,
+        fromLine: 1,
+        toLine: 2,
+        continuesFromPrev: true,
+      });
+    });
+
     test("rendered page break does not reapply leading spacing after snapping", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Nearly fills page one", 1),

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -290,6 +290,10 @@ describe("parseParagraph rendered page break markers", () => {
     `);
 
     expect(paragraph.renderedPageBreakBefore).toBeUndefined();
+    expect(paragraph.content.at(0)).toMatchObject({
+      type: "run",
+      content: [{ type: "text", text: "Previous page text" }, { type: "renderedPageBreak" }],
+    });
   });
 
   test("lastRenderedPageBreak inside a hyperlink wrapper is honored", () => {

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -990,7 +990,7 @@ function parseRunContents(
         break;
 
       case "lastRenderedPageBreak":
-        // Marker for last rendered page break - informational only
+        contents.push({ type: "renderedPageBreak" });
         break;
 
       case "cr": {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -1118,8 +1118,18 @@ export function serializeParagraph(paragraph: Paragraph): string {
 
 function injectRenderedPageBreakIntoFirstRun(xml: string): string | null {
   const runOpeningTag = /<w:r(?=[\s>/])[^>]*>/u;
-  if (!runOpeningTag.test(xml)) {
+  const openingTag = runOpeningTag.exec(xml);
+  if (!openingTag) {
     return null;
+  }
+  const runEnd = xml.indexOf("</w:r>", openingTag.index + openingTag[0].length);
+  if (
+    runEnd !== -1 &&
+    xml
+      .slice(openingTag.index + openingTag[0].length, runEnd)
+      .includes("<w:lastRenderedPageBreak/>")
+  ) {
+    return xml;
   }
   return xml.replace(runOpeningTag, (match) => `${match}<w:lastRenderedPageBreak/>`);
 }

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -1078,6 +1078,8 @@ function serializeRunContent(content: RunContent): string {
       return serializeSoftHyphen(content);
     case "noBreakHyphen":
       return serializeNoBreakHyphen(content);
+    case "renderedPageBreak":
+      return "<w:lastRenderedPageBreak/>";
     case "drawing":
       if (content.rawXml) {
         return content.rawXml;

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -873,6 +873,8 @@ function blockSig(b: FlowBlock): string {
         text += `\\t|${serializeRunFmt(r)};`;
       } else if (r.kind === "lineBreak") {
         text += "\\n;";
+      } else if (r.kind === "renderedPageBreak") {
+        text += "R;";
       } else if (r.kind === "image") {
         // Include src + transform + wrapType so swapping the painted
         // image (different logo at the same dims) invalidates the

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -492,6 +492,42 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.renderedPageBreakBefore).toBe(true);
   });
 
+  test("preserves a cached page boundary inside a paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("First page"),
+        schema.node("renderedPageBreak"),
+        schema.text("Second page"),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      return;
+    }
+    expect(paragraph.runs.map((run) => run.kind)).toEqual(["text", "renderedPageBreak", "text"]);
+  });
+
+  test("does not duplicate a leading cached page boundary in flow runs", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { renderedPageBreakBefore: true }, [
+        schema.node("renderedPageBreak"),
+        schema.text("Next page"),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      return;
+    }
+    expect(paragraph.attrs?.renderedPageBreakBefore).toBe(true);
+    expect(paragraph.runs.map((run) => run.kind)).toEqual(["text"]);
+  });
+
   test("assigns stable block ids for repeated conversions of the same document", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First paragraph")]),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1013,6 +1013,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
   const paragraphStyleId = pmAttrs.styleId;
   const inTocParagraph =
     typeof paragraphStyleId === "string" && TOC_STYLE_ID.test(paragraphStyleId);
+  let leadingRenderedPageBreakPending = pmAttrs.renderedPageBreakBefore === true;
 
   // Single dispatcher for one inline PM child. Recurses on `sdt` so nested
   // content controls keep contributing runs at the right pmStart/pmEnd.
@@ -1021,6 +1022,21 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
   // tab/image and silently dropped fields, math, and nested SDTs even
   // when the parser preserved them (see eigenpal #482).
   function pushRunsForChild(child: PMNode, childPos: number): void {
+    if (child.type.name === "renderedPageBreak") {
+      if (leadingRenderedPageBreakPending) {
+        leadingRenderedPageBreakPending = false;
+        return;
+      }
+      runs.push({
+        kind: "renderedPageBreak",
+        pmStart: childPos,
+        pmEnd: childPos + child.nodeSize,
+      });
+      return;
+    }
+    if (child.type.name !== "sdt") {
+      leadingRenderedPageBreakPending = false;
+    }
     if (child.isText && child.text) {
       const formatting = extractRunFormatting(child.marks, theme);
       if (inTocParagraph) {

--- a/packages/core/src/layout-bridge/engine/clickToPosition.ts
+++ b/packages/core/src/layout-bridge/engine/clickToPosition.ts
@@ -147,7 +147,11 @@ function computeLinePmRange(
       // Before the line - count all characters
       if (run.kind === "text") {
         charOffset += run.text.length;
-      } else if (run.kind === "tab" || run.kind === "lineBreak") {
+      } else if (
+        run.kind === "tab" ||
+        run.kind === "lineBreak" ||
+        run.kind === "renderedPageBreak"
+      ) {
         charOffset += 1;
       } else if (run.kind === "image") {
         charOffset += 1;
@@ -182,7 +186,11 @@ function computeLinePmRange(
         const start = runIndex === line.fromRun ? line.fromChar : 0;
         const end = runIndex === line.toRun ? line.toChar : text.length;
         lineLength += end - start;
-      } else if (run.kind === "tab" || run.kind === "lineBreak") {
+      } else if (
+        run.kind === "tab" ||
+        run.kind === "lineBreak" ||
+        run.kind === "renderedPageBreak"
+      ) {
         lineLength += 1;
       } else if (run.kind === "image") {
         lineLength += 1;

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -636,6 +636,19 @@ function layoutParagraph({
   while (currentLineIndex < lines.length) {
     const state = paginator.getCurrentState();
     const availableHeight = paginator.getAvailableHeight();
+    const currentLine = lines.at(currentLineIndex);
+    const markerAlreadySatisfied =
+      state.columnIndex === 0 &&
+      state.cursorY === state.topMargin &&
+      state.page.fragments.length === 0;
+    if (
+      currentLine?.renderedPageBreakBefore === true &&
+      !markerAlreadySatisfied &&
+      availableHeight <= measuredLineAdvance(currentLine) * RENDERED_BREAK_REFLOW_TOLERANCE_LINES
+    ) {
+      paginator.forcePageBreak();
+      continue;
+    }
 
     // If the paragraph cannot begin on this page solely because its leading
     // spacing collapses with the previous block's trailing spacing — spacing
@@ -678,6 +691,7 @@ function layoutParagraph({
     let linesFnHeight = 0;
     const linesFnIds: number[] = [];
     let fittingLines = 0;
+    let forcePageBreakAfterFragment = false;
 
     // The first fragment of a paragraph eats `spaceBefore` from the
     // available height for *every* line check, not only the first one.
@@ -701,6 +715,15 @@ function layoutParagraph({
     for (let j = currentLineIndex; j < lines.length; j++) {
       const line = lines[j]!; // SAFETY: j < lines.length
       const lineAdvance = measuredLineAdvance(line);
+      if (
+        j > currentLineIndex &&
+        line.renderedPageBreakBefore === true &&
+        availableHeight - (linesHeight + firstFragmentSpaceBefore + linesFnHeight) <=
+          lineAdvance * RENDERED_BREAK_REFLOW_TOLERANCE_LINES
+      ) {
+        forcePageBreakAfterFragment = true;
+        break;
+      }
       const lineRefs = getLineFootnoteRefs(block, line.fromRun, line.toRun, footnoteHeightById);
       const totalWithLine = linesHeight + lineAdvance;
       const withSpacing =
@@ -826,7 +849,9 @@ function layoutParagraph({
 
     // If more lines remain, advance to next column/page
     if (currentLineIndex < lines.length) {
-      if (forceBreakAfterFragment) {
+      if (forcePageBreakAfterFragment) {
+        paginator.forcePageBreak();
+      } else if (forceBreakAfterFragment) {
         paginator.forceColumnBreak();
       } else {
         paginator.ensureFits(measuredLineAdvance(lines[currentLineIndex]!)); // SAFETY: guarded by length check

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -505,6 +505,33 @@ describe("empty paragraph line-height floor", () => {
   });
 });
 
+describe("inline rendered page boundaries", () => {
+  test("starts a measured line at a cached mid-paragraph boundary", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "inline-rendered-boundary",
+          runs: [
+            { kind: "text", text: "before" },
+            { kind: "renderedPageBreak" },
+            { kind: "text", text: "after" },
+          ],
+        },
+        600,
+      );
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines.at(0)).toMatchObject({ fromRun: 0, toRun: 0 });
+      expect(measure.lines.at(1)).toMatchObject({
+        fromRun: 2,
+        toRun: 2,
+        renderedPageBreakBefore: true,
+      });
+    }, fakeMeasure);
+  });
+});
+
 describe("measureParagraph cross-run line breaking", () => {
   const style = { fontFamily: "Calibri", fontSize: 11 };
   const width = (text: string): number => measureTextWidth(text, style);

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -160,6 +160,7 @@ type LineState = {
   /** Optional split segment zones from centered floating exclusions */
   segmentZones?: FloatingLineSegmentZone[];
   discretionaryHyphen?: { runIndex: number };
+  renderedPageBreakBefore?: boolean;
 };
 
 function exceedsHyphenationZone(line: LineState, zoneTwips: number): boolean {
@@ -1398,6 +1399,7 @@ export function measureParagraph(
       ...(currentLine.discretionaryHyphen
         ? { discretionaryHyphen: currentLine.discretionaryHyphen }
         : {}),
+      ...(currentLine.renderedPageBreakBefore ? { renderedPageBreakBefore: true } : {}),
     };
 
     // Only add offsets if they're non-zero (for floating images)
@@ -1502,6 +1504,31 @@ export function measureParagraph(
     }
     // SAFETY: runIndex is bounded by runs.length
     const run = runs[runIndex]!;
+
+    if (run.kind === "renderedPageBreak") {
+      const hasFollowingContent = runs
+        .slice(runIndex + 1)
+        .some((followingRun) => followingRun.kind !== "renderedPageBreak");
+      if (!hasFollowingContent) {
+        currentLine.toRun = runIndex;
+        currentLine.toChar = 0;
+        continue;
+      }
+      const lineHasContent =
+        currentLine.width > 0 ||
+        currentLine.maxImageHeightPx > 0 ||
+        currentLine.maxMathHeightPx > 0;
+      if (lineHasContent) {
+        startNewLine(runIndex + 1, 0);
+      } else {
+        currentLine.fromRun = runIndex + 1;
+        currentLine.toRun = runIndex + 1;
+        currentLine.fromChar = 0;
+        currentLine.toChar = 0;
+      }
+      currentLine.renderedPageBreakBefore = true;
+      continue;
+    }
 
     if (isLineBreakRun(run)) {
       // Force line break

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -255,6 +255,13 @@ export type LineBreakRun = {
   pmEnd?: number;
 };
 
+/** Zero-width cached page boundary inside a paragraph. */
+export type RenderedPageBreakRun = RunFormatting & {
+  kind: "renderedPageBreak";
+  pmStart?: number;
+  pmEnd?: number;
+};
+
 /**
  * A field run (PAGE, NUMPAGES, etc.) that gets substituted at render time.
  */
@@ -297,7 +304,14 @@ export type MathRun = RunFormatting & {
 /**
  * Union of all run types.
  */
-export type Run = TextRun | TabRun | ImageRun | LineBreakRun | FieldRun | MathRun;
+export type Run =
+  | TextRun
+  | TabRun
+  | ImageRun
+  | LineBreakRun
+  | RenderedPageBreakRun
+  | FieldRun
+  | MathRun;
 
 /**
  * Paragraph spacing configuration.
@@ -430,7 +444,7 @@ export type ParagraphAttrs = {
   keepLines?: boolean;
   widowControl?: boolean;
   pageBreakBefore?: boolean;
-  /** Word's cached pagination hint (`w:lastRenderedPageBreak`). */
+  /** Cached OOXML pagination hint (`w:lastRenderedPageBreak`). */
   renderedPageBreakBefore?: boolean;
   styleId?: string;
   contextualSpacing?: boolean;
@@ -861,6 +875,8 @@ export type MeasuredLine = {
   floatSkipBefore?: number;
   /** Decorative hyphen inserted at a dictionary break without changing source text. */
   discretionaryHyphen?: { runIndex: number };
+  /** A cached pagination boundary occurs immediately before this line. */
+  renderedPageBreakBefore?: boolean;
 };
 
 /**

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -2629,6 +2629,9 @@ function runContentKey(run: Run): string {
   if (run.kind === "lineBreak") {
     return "lb";
   }
+  if (run.kind === "renderedPageBreak") {
+    return "rpb";
+  }
   if (run.kind === "image") {
     return `img:${run.src}|${run.width}x${run.height}${run.transform ? `|tr:${run.transform}` : ""}`;
   }

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1171,6 +1171,14 @@ function renderRun(run: Run, doc: Document, context?: RenderContext): HTMLElemen
   if (isMathRun(run)) {
     return renderMathRun(run, doc);
   }
+  if (run.kind === "renderedPageBreak") {
+    const span = doc.createElement("span");
+    span.className = PARAGRAPH_CLASS_NAMES.run;
+    span.style.display = "none";
+    span.dataset["docxRenderedPageBreak"] = "true";
+    applyPmPositions(span, run.pmStart, run.pmEnd);
+    return span;
+  }
 
   // Fallback for unknown run types
   const span = doc.createElement("span");

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -822,6 +822,7 @@ function convertPMParagraph(
     documentCounts,
     attrs._emptyHyperlinks ?? undefined,
     textBoxAnchorMarkers,
+    attrs.renderedPageBreakBefore === true,
   );
 
   // Emit BookmarkStart/End from bookmarks attr (for TOC anchors, cross-references)
@@ -1177,12 +1178,14 @@ function extractParagraphContent(
   _documentCounts?: TrackedChangeCounts,
   emptyHyperlinks?: NonNullable<ParagraphAttrs["_emptyHyperlinks"]>,
   textBoxAnchorMarkers?: Map<string, Run>,
+  skipLeadingRenderedPageBreak = false,
 ): ParagraphContent[] {
   const content: ParagraphContent[] = [];
   const sortedEmptyHyperlinks = (emptyHyperlinks ?? [])
     .map((attrs, order) => ({ attrs, order }))
     .toSorted((left, right) => left.attrs.offset - right.attrs.offset || left.order - right.order);
   let nextEmptyHyperlink = 0;
+  let leadingRenderedPageBreakPending = skipLeadingRenderedPageBreak;
 
   // Track current run being built
   let currentRun: Run | null = null;
@@ -1269,6 +1272,11 @@ function extractParagraphContent(
   };
 
   const processInlineNode = (node: PMNode, offset: number): void => {
+    if (node.type.name === "renderedPageBreak" && leadingRenderedPageBreakPending) {
+      leadingRenderedPageBreakPending = false;
+      return;
+    }
+    leadingRenderedPageBreakPending = false;
     syncCommentRanges(node, offset);
     const linkMark = node.marks.find((m) => m.type.name === "hyperlink");
 
@@ -1427,6 +1435,9 @@ function extractParagraphContent(
       // Tab ends current run
       flushCurrentInline();
       content.push(createTabRun());
+    } else if (node.type.name === "renderedPageBreak") {
+      flushCurrentInline();
+      content.push(createRenderedPageBreakRun());
     } else if (node.type.name === "field") {
       // Field ends current run and emits a field content item
       flushCurrentInline();
@@ -1513,6 +1524,9 @@ function createTrackedChangeRun(node: PMNode, marks: readonly Mark[]): Run | nul
   }
   if (node.type.name === "tab") {
     return createTabRun();
+  }
+  if (node.type.name === "renderedPageBreak") {
+    return createRenderedPageBreakRun();
   }
   return null;
 }
@@ -1661,6 +1675,11 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
     return;
   }
 
+  if (node.type.name === "renderedPageBreak") {
+    hyperlink.children.push(createRenderedPageBreakRun());
+    return;
+  }
+
   if (node.type.name === "image") {
     hyperlink.children.push(createImageRun(node));
     return;
@@ -1779,6 +1798,13 @@ function createBreakRun(
     run.formatting = formatting;
   }
   return run;
+}
+
+function createRenderedPageBreakRun(): Run {
+  return {
+    type: "run",
+    content: [{ type: "renderedPageBreak" }],
+  };
 }
 
 function readHardBreakType(node: PMNode): BreakContent["breakType"] {

--- a/packages/core/src/prosemirror/conversion/renderedPageBreakRoundtrip.test.ts
+++ b/packages/core/src/prosemirror/conversion/renderedPageBreakRoundtrip.test.ts
@@ -20,6 +20,29 @@ describe("renderedPageBreakBefore round-trip", () => {
     const xml = serializeParagraph(parsed as never);
     expect(xml).toMatch(/<w:lastRenderedPageBreak\/>/u);
     expect(xml).toMatch(/<w:r[^>]*><w:lastRenderedPageBreak\/>/u);
+    expect(xml.match(/<w:lastRenderedPageBreak\/>/gu)).toHaveLength(1);
+  });
+
+  test("preserves an inline cached boundary at its editable position", () => {
+    const paragraph = schema.node("paragraph", null, [
+      schema.text("Previous page"),
+      schema.node("renderedPageBreak"),
+      schema.text("Next page"),
+    ]);
+    const document = fromProseDoc(schema.node("doc", null, [paragraph]));
+    const parsed = document.package.document.content.at(0);
+
+    expect(parsed).toMatchObject({
+      type: "paragraph",
+      content: [
+        { type: "run", content: [{ type: "text", text: "Previous page" }] },
+        { type: "run", content: [{ type: "renderedPageBreak" }] },
+        { type: "run", content: [{ type: "text", text: "Next page" }] },
+      ],
+    });
+    expect(serializeParagraph(parsed as never).match(/<w:lastRenderedPageBreak\/>/gu)).toHaveLength(
+      1,
+    );
   });
 
   test("serializer injects marker into the first run inside a hyperlink wrapper", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2306,6 +2306,9 @@ function convertRunContent(
       // Page breaks are represented as block separators by paragraphPageBreakPosition.
       return [];
 
+    case "renderedPageBreak":
+      return [schema.node("renderedPageBreak").mark(marks)];
+
     case "tab":
       // Convert to tab node for proper rendering. Keep the run marks because
       // Word commonly represents signature blanks as underlined tab runs.

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -75,6 +75,7 @@ import { HorizontalRuleExtension } from "./nodes/HorizontalRuleExtension";
 import { ImageExtension } from "./nodes/ImageExtension";
 import { MathExtension } from "./nodes/MathExtension";
 import { PageBreakExtension } from "./nodes/PageBreakExtension";
+import { RenderedPageBreakExtension } from "./nodes/RenderedPageBreakExtension";
 import { SdtExtension } from "./nodes/SdtExtension";
 import { ShapeExtension } from "./nodes/ShapeExtension";
 import { TabExtension } from "./nodes/TabExtension";
@@ -171,6 +172,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add("gapCursor", GapCursorExtension());
   add("horizontalRule", HorizontalRuleExtension());
   add("pageBreak", PageBreakExtension());
+  add("renderedPageBreak", RenderedPageBreakExtension());
   add("field", FieldExtension());
   add("sdt", SdtExtension());
   add("blockSdt", BlockSdtExtension());

--- a/packages/core/src/prosemirror/extensions/nodes/RenderedPageBreakExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/RenderedPageBreakExtension.ts
@@ -1,0 +1,24 @@
+/** Zero-width cached pagination boundary preserved from DOCX. */
+
+import { createNodeExtension } from "../create";
+
+export const RenderedPageBreakExtension = createNodeExtension({
+  name: "renderedPageBreak",
+  schemaNodeName: "renderedPageBreak",
+  nodeSpec: {
+    inline: true,
+    group: "inline",
+    atom: true,
+    selectable: false,
+    parseDOM: [{ tag: "span[data-docx-rendered-page-break]" }],
+    toDOM() {
+      return [
+        "span",
+        {
+          "data-docx-rendered-page-break": "true",
+          style: "display: none;",
+        },
+      ];
+    },
+  },
+});

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -129,6 +129,7 @@ const validateNodeAttrs = (
     case "text":
     case "horizontalRule":
     case "pageBreak":
+    case "renderedPageBreak":
     case "tab":
       return;
 

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -116,6 +116,11 @@ export type NoBreakHyphenContent = {
   type: "noBreakHyphen";
 };
 
+/** Cached pagination boundary emitted by a previous layout pass. */
+export type RenderedPageBreakContent = {
+  type: "renderedPageBreak";
+};
+
 /**
  * Drawing/image reference
  */
@@ -149,6 +154,7 @@ export type RunContent =
   | InstrTextContent
   | SoftHyphenContent
   | NoBreakHyphenContent
+  | RenderedPageBreakContent
   | DrawingContent
   | ShapeContent;
 

--- a/packages/docx-core/src/serialize/docx.ts
+++ b/packages/docx-core/src/serialize/docx.ts
@@ -336,6 +336,8 @@ const serializeRunContent = (content: RunContent): string => {
       return "<w:tab/>";
     case "break":
       return `<w:br${attr("w:type", content.breakType)}/>`;
+    case "renderedPageBreak":
+      return "<w:lastRenderedPageBreak/>";
     case "symbol":
       return `<w:sym w:font="${escapeXml(content.font)}" w:char="${escapeXml(content.char)}"/>`;
     case "footnoteRef":


### PR DESCRIPTION
## Summary

- preserve `w:lastRenderedPageBreak` at its inline position through parsing, editing, and serialization
- reconcile cached boundaries near page edges while leaving stale hints advisory
- keep layout painting, position mapping, and selective/full-save fixed points stable

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun --filter @stll/folio-core test`
- `bun test scripts`
- `bun run build`
- `bun run validate-dist`

CC on behalf of @jan-kubica