### PR TITLE
fix: honor rendered breaks at table row starts

### DIFF
--- a/.changeset/calm-rows-snap.md
+++ b/.changeset/calm-rows-snap.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor cached rendered page boundaries at table-row starts when a row would otherwise split.

--- a/packages/core/src/docx/saveEquivalence.property.test.ts
+++ b/packages/core/src/docx/saveEquivalence.property.test.ts
@@ -291,42 +291,32 @@ const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => {
 // ============================================================================
 
 describe("invariant 1: no-op save fidelity", () => {
-  test(
-    "selective save of an unedited doc reproduces the parsed model exactly",
-    async () => {
-      await fc.assert(
-        fc.asyncProperty(fc.constantFrom(...FIXTURES), async (name) => {
-          const buffer = readFixture(name);
-          const doc = await parse(buffer);
-          const saved = await attemptSelectiveSave(doc, buffer, {
-            changedParaIds: new Set(),
-            structuralChange: false,
-            hasUntrackedChanges: false,
-          });
-          expect(saved).not.toBeNull();
-          if (!saved) {
-            return;
-          }
-          expect(normalizedPackage(await parse(saved))).toEqual(normalizedPackage(doc));
-        }),
-        propertyConfig({ numRuns: 9, seed: SEED }),
-      );
+  test.each(FIXTURES)(
+    "selective save of an unedited doc reproduces the parsed model exactly (%s)",
+    async (name) => {
+      const buffer = readFixture(name);
+      const doc = await parse(buffer);
+      const saved = await attemptSelectiveSave(doc, buffer, {
+        changedParaIds: new Set(),
+        structuralChange: false,
+        hasUntrackedChanges: false,
+      });
+      expect(saved).not.toBeNull();
+      if (!saved) {
+        return;
+      }
+      expect(normalizedPackage(await parse(saved))).toEqual(normalizedPackage(doc));
     },
     propertyTestTimeout(20_000),
   );
 
-  test(
-    "full repack of an unedited doc preserves all visible text",
-    async () => {
-      await fc.assert(
-        fc.asyncProperty(fc.constantFrom(...FIXTURES), async (name) => {
-          const buffer = readFixture(name);
-          const doc = await parse(buffer);
-          const repacked = await fullRepack(doc, buffer);
-          expect(allBodyText(await parse(repacked))).toBe(allBodyText(doc));
-        }),
-        propertyConfig({ numRuns: 9, seed: SEED }),
-      );
+  test.each(FIXTURES)(
+    "full repack of an unedited doc preserves all visible text (%s)",
+    async (name) => {
+      const buffer = readFixture(name);
+      const doc = await parse(buffer);
+      const repacked = await fullRepack(doc, buffer);
+      expect(allBodyText(await parse(repacked))).toBe(allBodyText(doc));
     },
     propertyTestTimeout(20_000),
   );
@@ -336,18 +326,13 @@ describe("invariant 1: no-op save fidelity", () => {
   // gaps used to break this (a duplicated <w:commentReference>, and a
   // complex-field run losing its fontFamily); both are fixed in the paragraph
   // serializer, so this now holds across the rich fixtures too.
-  test(
-    "full repack of an unedited doc is a lossless model fixed point",
-    async () => {
-      await fc.assert(
-        fc.asyncProperty(fc.constantFrom(...FIXTURES), async (name) => {
-          const buffer = readFixture(name);
-          const doc = await parse(buffer);
-          const repacked = await fullRepack(doc, buffer);
-          expect(normalizedPackage(await parse(repacked))).toEqual(normalizedPackage(doc));
-        }),
-        propertyConfig({ numRuns: 9, seed: SEED }),
-      );
+  test.each(FIXTURES)(
+    "full repack of an unedited doc is a lossless model fixed point (%s)",
+    async (name) => {
+      const buffer = readFixture(name);
+      const doc = await parse(buffer);
+      const repacked = await fullRepack(doc, buffer);
+      expect(normalizedPackage(await parse(repacked))).toEqual(normalizedPackage(doc));
     },
     propertyTestTimeout(20_000),
   );
@@ -512,6 +497,6 @@ describe("invariant 4: selective save keeps untouched bytes identical", () => {
         propertyConfig({ numRuns: 12, seed: SEED }),
       );
     },
-    propertyTestTimeout(30_000),
+    propertyTestTimeout(60_000),
   );
 });

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -862,6 +862,12 @@ export function getHeaderRowsHeight(measure: TableMeasure, headerRowCount: numbe
   return height;
 }
 
+const tableRowStartsWithRenderedPageBreak = (block: TableBlock, rowIndex: number): boolean =>
+  block.rows[rowIndex]?.cells.some((cell) => {
+    const firstBlock = cell.blocks.at(0);
+    return firstBlock?.kind === "paragraph" && firstBlock.attrs?.renderedPageBreakBefore === true;
+  }) ?? false;
+
 /**
  * Layout a table block onto pages.
  */
@@ -960,6 +966,29 @@ function layoutTable(
   };
 
   while (currentRowIndex < rows.length) {
+    const rowState = paginator.getCurrentState();
+    const rowHeaderOverhead = shouldRepeatHeaderRows(currentRowIndex, 0, rowState)
+      ? headerRowsHeight
+      : 0;
+    const rowAvailableHeight =
+      paginator.getAvailableHeight() - rowHeaderOverhead - rowState.trailingSpacing;
+    const rowStartsFreshPage =
+      rowState.cursorY === rowState.topMargin && rowState.page.fragments.length === 0;
+
+    // A leading w:lastRenderedPageBreak is Word's cached boundary for this
+    // row. Keep the hint advisory while the row fits, but when Folio would
+    // otherwise split it in the remaining page space, snap the row to the
+    // cached page boundary. Oversized rows still split after reaching the
+    // fresh page, so the hint cannot create a retry loop.
+    if (
+      !rowStartsFreshPage &&
+      tableRowStartsWithRenderedPageBreak(block, currentRowIndex) &&
+      rows[currentRowIndex]!.height > rowAvailableHeight
+    ) {
+      paginator.forcePageBreak();
+      continue;
+    }
+
     // Break permitted rows between whole text lines when they exceed the current
     // flow region; rows taller than a full region use the same path repeatedly.
     const splittableRow = rows[currentRowIndex]!; // SAFETY: currentRowIndex < rows.length

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -120,6 +120,14 @@ function tallTable(n: number): { block: TableBlock; measure: TableMeasure } {
   return { block, measure };
 }
 
+function markFirstTableParagraphWithRenderedBreak(block: TableBlock): void {
+  const firstBlock = block.rows.at(0)?.cells.at(0)?.blocks.at(0);
+  if (firstBlock?.kind !== "paragraph") {
+    throw new Error("test table must start with a paragraph");
+  }
+  firstBlock.attrs = { renderedPageBreakBefore: true };
+}
+
 function tableWithHeaderAndTallBody(bodyLines: number): {
   block: TableBlock;
   measure: TableMeasure;
@@ -1101,11 +1109,7 @@ describe("oversized table row splits across pages (#570)", () => {
     };
     const spacerMeasure = paraMeasureWithLineHeight(1, 70);
     const { block, measure } = tallTable(5);
-    const layout = layoutDocument(
-      [spacer, block as FlowBlock],
-      [spacerMeasure as Measure, measure as Measure],
-      OPTIONS,
-    );
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
     const frags = layout.pages
       .flatMap((page) => page.fragments)
       .filter((f): f is TableFragment => f.kind === "table");
@@ -1115,6 +1119,72 @@ describe("oversized table row splits across pages (#570)", () => {
     expect(frags[0]?.topClip).toBeUndefined();
     expect(frags[1]).toMatchObject({ height: 60, topClip: 40 });
     expect(frags[1]?.bottomClip).toBeUndefined();
+  });
+
+  test("moves a non-fitting row to its cached rendered page boundary", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 70);
+    const { block, measure } = tallTable(5);
+    markFirstTableParagraphWithRenderedBreak(block);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const frags = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(frags).toHaveLength(1);
+    expect(frags[0]).toMatchObject({
+      y: OPTIONS.margins.top,
+      height: 5 * LINE,
+      fromRow: 0,
+      toRow: 1,
+    });
+    expect(frags[0]?.topClip).toBeUndefined();
+    expect(frags[0]?.bottomClip).toBeUndefined();
+  });
+
+  test("keeps a stale rendered row boundary advisory when the row fits", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 20);
+    const { block, measure } = tallTable(3);
+    markFirstTableParagraphWithRenderedBreak(block);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const fragment = layout.pages
+      .flatMap((page) => page.fragments)
+      .find((candidate): candidate is TableFragment => candidate.kind === "table");
+
+    expect(layout.pages).toHaveLength(1);
+    expect(fragment).toMatchObject({ y: OPTIONS.margins.top + 20, height: 3 * LINE });
+  });
+
+  test("still splits an oversized cached-boundary row on the fresh page", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 20);
+    const { block, measure } = tallTable(15);
+    markFirstTableParagraphWithRenderedBreak(block);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const frags = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(layout.pages[0]?.fragments.every((fragment) => fragment.kind !== "table")).toBe(true);
+    expect(frags.length).toBeGreaterThan(1);
+    expect(frags[0]).toMatchObject({ y: OPTIONS.margins.top, bottomClip: 6 * LINE });
+    expect(frags.at(-1)?.bottomClip).toBeUndefined();
   });
 
   test("splits a break-permitted row after adjacent table rows", () => {

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { layoutDocument } from "./index";
 import { clearAllCaches } from "./measure";
-import { resetCanvasContext } from "./measure/measureContainer";
+import { installCanvasMeasureProvider, resetCanvasContext } from "./measure/measureContainer";
 import { buildTableRowBreakInfo, getRowContinuationSkip, snapRowBreak } from "./tableRowBreak";
 import type {
   FlowBlock,
@@ -26,6 +26,7 @@ const LINE = 20;
 const originalDocument = globalThis.document;
 
 beforeEach(() => {
+  installCanvasMeasureProvider();
   Object.defineProperty(globalThis, "document", {
     configurable: true,
     value: {


### PR DESCRIPTION
## Summary

- honor a leading `w:lastRenderedPageBreak` when a table row would otherwise split in the remaining page space
- keep stale rendered boundaries advisory when the row still fits, and preserve progress for rows taller than a fresh page
- make finite save-fidelity fixtures deterministic and stabilize the expensive randomized byte-integrity invariant
- make the table row-break regression suite install its own measurement provider for isolated runs

The cached-boundary behavior follows Microsoft’s documented `lastRenderedPageBreak` semantics: https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/e0d0fc07-96bb-4248-a832-dd0e8e42f001

## Validation

- `bun run test`
- `bun run build`
- `bun run validate-dist`
- `bun run lint`
- `bun run typecheck`
- `bun test packages/core/src/layout-engine/tableRowBreak.test.ts` (37/37)
- exact-document Microsoft Word parity comparison, with source documents kept out of the repository

CC on behalf of @jan-kubica