### PR TITLE
fix: use the standard bold font face

### DIFF
--- a/.changeset/gentle-fonts-fit.md
+++ b/.changeset/gentle-fonts-fit.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Measure and paint ordinary DOCX bold text with the standard 700 font weight.

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
@@ -82,7 +82,7 @@ describe("getListMarkerInlineWidth", () => {
         expect(regular).toBe(20);
         expect(bold).toBe(24);
       },
-      { charWidth: (_char, font) => (font.includes("800") ? 12 : 10) },
+      { charWidth: (_char, font) => (font.includes("700") ? 12 : 10) },
     );
   });
 
@@ -133,7 +133,7 @@ describe("getListMarkerInlineWidth", () => {
         expect(regular).toBe(-20);
         expect(bold).toBe(-24);
       },
-      { charWidth: (_char, font) => (font.includes("800") ? 12 : 10) },
+      { charWidth: (_char, font) => (font.includes("700") ? 12 : 10) },
     );
   });
 

--- a/packages/core/src/layout-engine/measure/measureHelpers.ts
+++ b/packages/core/src/layout-engine/measure/measureHelpers.ts
@@ -94,7 +94,7 @@ function getResolvedFallback(fontFamily: string): string {
  *
  * @example
  * buildFontString({ fontFamily: "Arial", fontSize: 12, bold: true })
- * // Returns: "800 16px Arial, Arimo, Helvetica, sans-serif" (12pt = 16px)
+ * // Returns: "700 16px Arial, Arimo, Helvetica, sans-serif" (12pt = 16px)
  */
 export function buildFontString(style: FontStyle): string {
   const parts: string[] = [];

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -2274,7 +2274,7 @@ describe("all-caps paragraph measurement", () => {
       bold: true,
     });
 
-    expect(font).toContain("800");
+    expect(font).toContain("700");
     expect(font).not.toContain("bold");
   });
 

--- a/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
@@ -82,7 +82,7 @@ class FakeElement {
       font: "",
       measureText(text: string) {
         return {
-          width: text.length * 7 + (this.font.includes("800") ? 10 : 0),
+          width: text.length * 7 + (this.font.includes("700") ? 10 : 0),
         };
       },
     };
@@ -442,7 +442,7 @@ describe("renderLine text styling", () => {
     const lineEl = renderLine(block, line, undefined, fakeDocument);
     const textEl = lineEl.children[0] as HTMLElement | undefined;
 
-    expect(textEl?.style.fontWeight).toBe("800");
+    expect(textEl?.style.fontWeight).toBe("700");
   });
 
   test("keeps automatic text readable on bright DOCX highlights", () => {

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -133,7 +133,7 @@ describe("renderLine box model", () => {
     expect(hyphen?.dataset["discretionaryHyphen"]).toBe("true");
     expect(hyphen?.dataset["pmStart"]).toBeUndefined();
     expect(hyphen?.dataset["pmEnd"]).toBeUndefined();
-    expect(hyphen?.style["fontWeight"]).toBe("800");
+    expect(hyphen?.style["fontWeight"]).toBe("700");
   });
 
   test("paints pair kerning only when the authored threshold is met", () => {

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -154,7 +154,7 @@ describe("Issue #729 — list hanging indent exceeding left indent", () => {
     const bold = renderListItem({ left: 48, hanging: 24 }, undefined, true).marker;
     const regular = renderListItem({ left: 48, hanging: 24 }, undefined, false).marker;
 
-    expect(bold?.style.fontWeight).toBe("800");
+    expect(bold?.style.fontWeight).toBe("700");
     expect(regular?.style.fontWeight).toBe("normal");
   });
 

--- a/packages/core/src/utils/fontWeights.ts
+++ b/packages/core/src/utils/fontWeights.ts
@@ -1,1 +1,3 @@
-export const DOCX_BOLD_FONT_WEIGHT = "800";
+// Word's ordinary bold toggle selects the family's bold face. CSS maps that
+// face to 700; 800 can select a wider extra-bold face and change line breaks.
+export const DOCX_BOLD_FONT_WEIGHT = "700";


### PR DESCRIPTION
## Summary

- map ordinary DOCX bold text to the standard CSS 700 face instead of extra-bold 800
- keep layout measurement, text painting, list markers, discretionary hyphens, and tab sizing on the same shared weight
- update focused regression coverage and add the core patch changeset

Using 800 can select a wider extra-bold face when the requested family is installed, changing otherwise valid Word line breaks.

## Validation

- focused measurement and painter suites: 179/179
- `bun run lint`
- `bun run typecheck`
- exact-document Microsoft Word parity comparison on both source documents, with source files kept out of the repository

CC on behalf of @jan-kubica