### PR TITLE
feat: add guarded XML patch proposals

### DIFF
--- a/.changeset/calm-plums-propose.md
+++ b/.changeset/calm-plums-propose.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add guarded XML patch proposal evaluation for server workflows.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -909,19 +909,27 @@ export type FolioDocxReviewerOptions = {
 // @public (undocumented)
 export type FolioDocxXmlPatchProposal = {
     readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
-    readonly replacements: readonly FolioDocxXmlReplacement[];
+    readonly replacements: readonly [FolioDocxXmlReplacement, ...FolioDocxXmlReplacement[]];
 };
 
 // @public (undocumented)
-export type FolioDocxXmlPatchProposalEvaluation = (FolioDocxXmlPatchProposalEvaluationBase & {
+export type FolioDocxXmlPatchProposalEvaluation = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
     readonly status: "accepted";
+    readonly producesOutput: false;
     readonly issues: readonly [];
-    readonly replacements: readonly FolioDocxPreparedXmlReplacement[];
-}) | (FolioDocxXmlPatchProposalEvaluationBase & {
+    readonly replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
+    readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+} | {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
     readonly status: "rejected";
+    readonly producesOutput: false;
     readonly issues: readonly [FolioDocxXmlPatchProposalIssue, ...FolioDocxXmlPatchProposalIssue[]];
     readonly replacements: readonly [];
-});
+    readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+};
 
 // @public (undocumented)
 export type FolioDocxXmlPatchProposalIssue = {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -142,6 +142,18 @@ export type EnsureParaIdsResult = {
     alreadyComplete: boolean;
 };
 
+// @public (undocumented)
+export const evaluateDocxXmlPatchProposal: (input: EvaluateDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchProposalEvaluation>;
+
+// @public (undocumented)
+export type EvaluateDocxXmlPatchProposalArgs = {
+    readonly bytes: ArrayBuffer | Uint8Array;
+    readonly proposal: unknown; /** Exact package paths authorized by the server-side caller. */
+    readonly allowedParts: readonly string[];
+    readonly archive?: DocxArchiveOptions;
+    readonly limits?: FolioDocxXmlPatchProposalLimits;
+};
+
 // @public
 export const extractDocumentStyleSet: (document: import__stll_docx_core_model.Document, options: ExtractDocumentStyleSetOptions) => DocumentStyleSet;
 
@@ -244,6 +256,22 @@ export const FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES: readonly ["invalid-limit
 
 // @public (undocumented)
 export const FOLIO_DOCX_PACKAGE_INSPECTION_VERSION: 1;
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS: Readonly<{
+    readonly maxReplacements: 16;
+    readonly maxPartBytes: number;
+    readonly maxTotalBytes: number;
+}>;
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES: readonly ["invalid-proposal", "unsupported-version", "too-many-replacements", "duplicate-part", "invalid-part-path", "invalid-base-sha256", "part-not-allowed", "part-not-found", "part-not-xml", "replacement-too-large", "replacements-too-large", "xml-doctype-forbidden", "xml-not-well-formed", "xml-encoding-mismatch", "base-hash-mismatch", "package-inspection-failed"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE: "folio-xml-patch-proposal-v1";
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION: 1;
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -830,6 +858,16 @@ export type FolioDocxPackagePart = {
 // @public (undocumented)
 export type FolioDocxPackagePartKind = "xml" | "binary";
 
+// @public (undocumented)
+export type FolioDocxPreparedXmlReplacement = {
+    readonly path: string;
+    readonly baseSha256: string;
+    readonly currentSha256: string;
+    readonly replacementSha256: string;
+    readonly replacementByteLength: number;
+    readonly encoding: "utf-8";
+};
+
 // @public
 export class FolioDocxReviewer {
     acceptAll(): number;
@@ -866,6 +904,48 @@ export class FolioDocxReviewer {
 export type FolioDocxReviewerOptions = {
     author?: string; /** Password for Agile-encrypted .docx files (Office 2010+). */
     password?: string | undefined;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposal = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+    readonly replacements: readonly FolioDocxXmlReplacement[];
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalEvaluation = (FolioDocxXmlPatchProposalEvaluationBase & {
+    readonly status: "accepted";
+    readonly issues: readonly [];
+    readonly replacements: readonly FolioDocxPreparedXmlReplacement[];
+}) | (FolioDocxXmlPatchProposalEvaluationBase & {
+    readonly status: "rejected";
+    readonly issues: readonly [FolioDocxXmlPatchProposalIssue, ...FolioDocxXmlPatchProposalIssue[]];
+    readonly replacements: readonly [];
+});
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalIssue = {
+    readonly code: FolioDocxXmlPatchProposalIssueCode;
+    readonly message: string;
+    readonly proposalPath?: string;
+    readonly part?: string;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalIssueCode = (typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES)[number];
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalLimits = {
+    readonly maxReplacements?: number;
+    readonly maxPartBytes?: number;
+    readonly maxTotalBytes?: number;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlReplacement = {
+    readonly path: string;
+    readonly baseSha256: string;
+    readonly replacementXml: string;
 };
 
 // @public (undocumented)
@@ -1074,6 +1154,12 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
 export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
 
 // @public (undocumented)
+export class InvalidFolioDocxXmlPatchProposalError extends InvalidFolioDocxXmlPatchProposalError_base {}
+
+// @public (undocumented)
+export class InvalidFolioDocxXmlPatchProposalOptionsError extends InvalidFolioDocxXmlPatchProposalOptionsError_base {}
+
+// @public (undocumented)
 export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
 
 // @public (undocumented)
@@ -1108,6 +1194,9 @@ export const isSupportedFolioDocumentOperationVersion: (value: unknown) => value
 
 // @public (undocumented)
 export const parseFolioDocumentOperationBatch: (value: unknown) => FolioDocumentOperationBatch;
+
+// @public (undocumented)
+export const parseFolioDocxXmlPatchProposal: (value: unknown) => FolioDocxXmlPatchProposal;
 
 // @public
 export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: FolioDocumentSectionHandle) => FolioDocumentSectionReadResult;

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.test.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.test.ts
@@ -1,0 +1,309 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { createEmptyDocx } from "../rezip";
+import {
+  evaluateDocxXmlPatchProposal,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+  InvalidFolioDocxXmlPatchProposalError,
+  InvalidFolioDocxXmlPatchProposalOptionsError,
+  parseFolioDocxXmlPatchProposal,
+} from "./evaluateDocxXmlPatchProposal";
+
+const DOCUMENT_PATH = "word/document.xml";
+const REPLACEMENT_XML =
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>';
+
+type PackageFixture = {
+  bytes: Uint8Array;
+  documentSha256: string;
+};
+
+const packageFixture = async (): Promise<PackageFixture> => {
+  const bytes = await createEmptyDocx();
+  const zip = await JSZip.loadAsync(bytes);
+  const documentBytes = await zip.file(DOCUMENT_PATH)?.async("uint8array");
+  if (documentBytes === undefined) {
+    throw new Error("Expected document package part");
+  }
+  return {
+    bytes,
+    documentSha256: createHash("sha256").update(documentBytes).digest("hex"),
+  };
+};
+
+const proposalFor = (baseSha256: string) => ({
+  version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+  replacements: [{ path: DOCUMENT_PATH, baseSha256, replacementXml: REPLACEMENT_XML }],
+});
+
+describe("parseFolioDocxXmlPatchProposal", () => {
+  test("accepts the strict versioned envelope", () => {
+    const proposal = proposalFor("0".repeat(64));
+
+    expect(parseFolioDocxXmlPatchProposal(proposal)).toEqual(proposal);
+  });
+
+  test("rejects unsupported versions and unexpected properties", () => {
+    expect(() =>
+      parseFolioDocxXmlPatchProposal({ ...proposalFor("0".repeat(64)), version: 2 }),
+    ).toThrow(InvalidFolioDocxXmlPatchProposalError);
+    expect(() =>
+      parseFolioDocxXmlPatchProposal({
+        ...proposalFor("0".repeat(64)),
+        outputPath: "modified.docx",
+      }),
+    ).toThrow("unexpected property");
+    expect(() =>
+      parseFolioDocxXmlPatchProposal({
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: Array.from({ length: 17 }),
+      }),
+    ).toThrow("expected at most 16 replacements");
+  });
+});
+
+describe("evaluateDocxXmlPatchProposal", () => {
+  test("accepts an allowed replacement with an exact base hash without producing output", async () => {
+    const { bytes, documentSha256 } = await packageFixture();
+
+    const evaluation = await evaluateDocxXmlPatchProposal({
+      bytes,
+      proposal: proposalFor(documentSha256),
+      allowedParts: [DOCUMENT_PATH],
+    });
+
+    expect(evaluation).toMatchObject({
+      version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+      profile: FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+      status: "accepted",
+      producesOutput: false,
+      issues: [],
+    });
+    expect(evaluation.replacements).toEqual([
+      {
+        path: DOCUMENT_PATH,
+        baseSha256: documentSha256,
+        currentSha256: documentSha256,
+        replacementSha256: createHash("sha256").update(REPLACEMENT_XML).digest("hex"),
+        replacementByteLength: new TextEncoder().encode(REPLACEMENT_XML).byteLength,
+        encoding: "utf-8",
+      },
+    ]);
+    expect(evaluation).not.toHaveProperty("bytes");
+  });
+
+  test("rejects stale base hashes", async () => {
+    const { bytes } = await packageFixture();
+
+    const evaluation = await evaluateDocxXmlPatchProposal({
+      bytes,
+      proposal: proposalFor("0".repeat(64)),
+      allowedParts: [DOCUMENT_PATH],
+    });
+
+    expect(evaluation.status).toBe("rejected");
+    expect(evaluation.replacements).toEqual([]);
+    expect(evaluation.issues).toContainEqual({
+      code: "base-hash-mismatch",
+      message: "The package part changed after the proposal base was inspected.",
+      proposalPath: "$.replacements[0].baseSha256",
+      part: DOCUMENT_PATH,
+    });
+  });
+
+  test("enforces the server-owned allowlist before package inspection", async () => {
+    const evaluation = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: proposalFor("0".repeat(64)),
+      allowedParts: [],
+    });
+
+    expect(evaluation.status).toBe("rejected");
+    expect(evaluation.issues.at(0)).toMatchObject({
+      code: "part-not-allowed",
+      part: DOCUMENT_PATH,
+    });
+  });
+
+  test("rejects duplicate, unsafe-path, and invalid-hash proposals deterministically", async () => {
+    const replacement = {
+      path: "../document.xml",
+      baseSha256: "INVALID",
+      replacementXml: REPLACEMENT_XML,
+    };
+    const evaluation = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [replacement, replacement],
+      },
+      allowedParts: [],
+    });
+
+    expect(evaluation.issues.map(({ code }) => code)).toEqual([
+      "invalid-part-path",
+      "invalid-base-sha256",
+      "duplicate-part",
+      "invalid-part-path",
+      "invalid-base-sha256",
+    ]);
+  });
+
+  test("rejects unsafe XML before inspection", async () => {
+    const doctype = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "custom.xml",
+            baseSha256: "0".repeat(64),
+            replacementXml: "<!DOCTYPE root><root/>",
+          },
+        ],
+      },
+      allowedParts: ["custom.xml"],
+    });
+    const malformed = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "custom.xml",
+            baseSha256: "0".repeat(64),
+            replacementXml: "<root>",
+          },
+        ],
+      },
+      allowedParts: ["custom.xml"],
+    });
+    const encodingMismatch = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "custom.xml",
+            baseSha256: "0".repeat(64),
+            replacementXml: '<?xml version="1.0" encoding="UTF-16"?><root/>',
+          },
+        ],
+      },
+      allowedParts: ["custom.xml"],
+    });
+
+    expect(doctype.issues.map(({ code }) => code)).toEqual(["xml-doctype-forbidden"]);
+    expect(malformed.issues.map(({ code }) => code)).toEqual(["xml-not-well-formed"]);
+    expect(encodingMismatch.issues.map(({ code }) => code)).toEqual(["xml-encoding-mismatch"]);
+  });
+
+  test("rejects replacement byte-limit violations without parsing oversized XML", async () => {
+    const evaluation = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "custom.xml",
+            baseSha256: "0".repeat(64),
+            replacementXml: "<!DOCTYPE root><root/>",
+          },
+        ],
+      },
+      allowedParts: ["custom.xml"],
+      limits: { maxPartBytes: 4, maxTotalBytes: 4 },
+    });
+
+    expect(evaluation.issues.map(({ code }) => code)).toEqual([
+      "replacement-too-large",
+      "replacements-too-large",
+    ]);
+  });
+
+  test("rejects oversized replacement arrays before parsing their entries", async () => {
+    const evaluation = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: Array.from({ length: 17 }),
+      },
+      allowedParts: [],
+    });
+
+    expect(evaluation.issues.at(0)).toMatchObject({
+      code: "too-many-replacements",
+      proposalPath: "$.replacements",
+    });
+  });
+
+  test("maps missing and non-XML package parts to typed rejections", async () => {
+    const { bytes } = await packageFixture();
+    const missing = await evaluateDocxXmlPatchProposal({
+      bytes,
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "missing.xml",
+            baseSha256: "0".repeat(64),
+            replacementXml: "<root/>",
+          },
+        ],
+      },
+      allowedParts: ["missing.xml"],
+    });
+    const zip = await JSZip.loadAsync(bytes);
+    zip.file("word/media/payload.bin", "binary");
+    const withBinary = await zip.generateAsync({ type: "uint8array" });
+    const binary = await evaluateDocxXmlPatchProposal({
+      bytes: withBinary,
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "word/media/payload.bin",
+            baseSha256: "0".repeat(64),
+            replacementXml: "<root/>",
+          },
+        ],
+      },
+      allowedParts: ["word/media/payload.bin"],
+    });
+
+    expect(missing.issues.at(0)).toMatchObject({ code: "part-not-found" });
+    expect(binary.issues.at(0)).toMatchObject({ code: "part-not-xml" });
+  });
+
+  test("rejects unsupported versions as data and invalid policy options as configuration", async () => {
+    const unsupported = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: { version: 2, replacements: [] },
+      allowedParts: [],
+    });
+
+    expect(unsupported.issues.at(0)).toMatchObject({
+      code: "unsupported-version",
+      proposalPath: "$.version",
+    });
+    await expect(
+      evaluateDocxXmlPatchProposal({
+        bytes: new Uint8Array(),
+        proposal: proposalFor("0".repeat(64)),
+        allowedParts: ["../document.xml"],
+      }),
+    ).rejects.toBeInstanceOf(InvalidFolioDocxXmlPatchProposalOptionsError);
+    await expect(
+      evaluateDocxXmlPatchProposal({
+        bytes: new Uint8Array(),
+        proposal: proposalFor("0".repeat(64)),
+        allowedParts: [],
+        limits: { maxReplacements: 17 },
+      }),
+    ).rejects.toBeInstanceOf(InvalidFolioDocxXmlPatchProposalOptionsError);
+  });
+});

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.test.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.test.ts
@@ -223,6 +223,31 @@ describe("evaluateDocxXmlPatchProposal", () => {
       "replacement-too-large",
       "replacements-too-large",
     ]);
+
+    const multibyteXml = "<r>é</r>";
+    const multibyte = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: "custom.xml",
+            baseSha256: "0".repeat(64),
+            replacementXml: multibyteXml,
+          },
+        ],
+      },
+      allowedParts: ["custom.xml"],
+      limits: {
+        maxPartBytes: multibyteXml.length,
+        maxTotalBytes: multibyteXml.length,
+      },
+    });
+
+    expect(multibyte.issues.map(({ code }) => code)).toEqual([
+      "replacement-too-large",
+      "replacements-too-large",
+    ]);
   });
 
   test("rejects oversized replacement arrays before parsing their entries", async () => {
@@ -285,9 +310,18 @@ describe("evaluateDocxXmlPatchProposal", () => {
       proposal: { version: 2, replacements: [] },
       allowedParts: [],
     });
+    const malformed = await evaluateDocxXmlPatchProposal({
+      bytes: new Uint8Array(),
+      proposal: { version: "2", replacements: [] },
+      allowedParts: [],
+    });
 
     expect(unsupported.issues.at(0)).toMatchObject({
       code: "unsupported-version",
+      proposalPath: "$.version",
+    });
+    expect(malformed.issues.at(0)).toMatchObject({
+      code: "invalid-proposal",
       proposalPath: "$.version",
     });
     await expect(

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
@@ -1,0 +1,563 @@
+import { createHash } from "node:crypto";
+
+import { panic, TaggedError } from "better-result";
+
+import { getDocxXmlSafetyIssue } from "../xmlSafety";
+import type { DocxArchiveOptions } from "./boundedArchive";
+import { DocxArchiveError } from "./boundedArchive";
+import { FolioDocxPackageInspectionError, inspectDocxPackage } from "./inspectDocxPackage";
+
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION = 1 as const;
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE = "folio-xml-patch-proposal-v1" as const;
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS = Object.freeze({
+  maxReplacements: 16,
+  maxPartBytes: 8 * 1024 * 1024,
+  maxTotalBytes: 16 * 1024 * 1024,
+} as const);
+
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES = Object.freeze([
+  "invalid-proposal",
+  "unsupported-version",
+  "too-many-replacements",
+  "duplicate-part",
+  "invalid-part-path",
+  "invalid-base-sha256",
+  "part-not-allowed",
+  "part-not-found",
+  "part-not-xml",
+  "replacement-too-large",
+  "replacements-too-large",
+  "xml-doctype-forbidden",
+  "xml-not-well-formed",
+  "xml-encoding-mismatch",
+  "base-hash-mismatch",
+  "package-inspection-failed",
+] as const);
+
+export type FolioDocxXmlPatchProposalIssueCode =
+  (typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES)[number];
+
+export type FolioDocxXmlReplacement = {
+  readonly path: string;
+  readonly baseSha256: string;
+  readonly replacementXml: string;
+};
+
+export type FolioDocxXmlPatchProposal = {
+  readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+  readonly replacements: readonly FolioDocxXmlReplacement[];
+};
+
+export type FolioDocxXmlPatchProposalLimits = {
+  readonly maxReplacements?: number;
+  readonly maxPartBytes?: number;
+  readonly maxTotalBytes?: number;
+};
+
+export type EvaluateDocxXmlPatchProposalArgs = {
+  readonly bytes: ArrayBuffer | Uint8Array;
+  readonly proposal: unknown;
+  /** Exact package paths authorized by the server-side caller. */
+  readonly allowedParts: readonly string[];
+  readonly archive?: DocxArchiveOptions;
+  readonly limits?: FolioDocxXmlPatchProposalLimits;
+};
+
+export type FolioDocxXmlPatchProposalIssue = {
+  readonly code: FolioDocxXmlPatchProposalIssueCode;
+  readonly message: string;
+  readonly proposalPath?: string;
+  readonly part?: string;
+};
+
+export type FolioDocxPreparedXmlReplacement = {
+  readonly path: string;
+  readonly baseSha256: string;
+  readonly currentSha256: string;
+  readonly replacementSha256: string;
+  readonly replacementByteLength: number;
+  readonly encoding: "utf-8";
+};
+
+type FolioDocxXmlPatchProposalEvaluationBase = {
+  readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+  readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
+  readonly producesOutput: false;
+  readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+};
+
+export type FolioDocxXmlPatchProposalEvaluation =
+  | (FolioDocxXmlPatchProposalEvaluationBase & {
+      readonly status: "accepted";
+      readonly issues: readonly [];
+      readonly replacements: readonly FolioDocxPreparedXmlReplacement[];
+    })
+  | (FolioDocxXmlPatchProposalEvaluationBase & {
+      readonly status: "rejected";
+      readonly issues: readonly [
+        FolioDocxXmlPatchProposalIssue,
+        ...FolioDocxXmlPatchProposalIssue[],
+      ];
+      readonly replacements: readonly [];
+    });
+
+export class InvalidFolioDocxXmlPatchProposalError extends TaggedError(
+  "InvalidFolioDocxXmlPatchProposalError",
+)<{
+  message: string;
+  path: string;
+  reason: string;
+}>() {}
+
+export class InvalidFolioDocxXmlPatchProposalOptionsError extends TaggedError(
+  "InvalidFolioDocxXmlPatchProposalOptionsError",
+)<{
+  message: string;
+  path: string;
+}>() {}
+
+const SHA256_PATTERN = /^[\da-f]{64}$/u;
+const XML_DECLARED_ENCODING_PATTERN =
+  /^\uFEFF?<\?xml[^>]*\bencoding\s*=\s*["']([^"']+)["'][^>]*\?>/iu;
+const MAX_PACKAGE_PATH_CODE_UNITS = 1024;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const invalidProposal = (path: string, reason: string): never => {
+  throw new InvalidFolioDocxXmlPatchProposalError({
+    message: `Invalid XML patch proposal at ${path}: ${reason}.`,
+    path,
+    reason,
+  });
+};
+
+const assertAllowedKeys = (
+  value: Record<string, unknown>,
+  path: string,
+  allowedKeys: readonly string[],
+): void => {
+  const allowed = new Set(allowedKeys);
+  const unexpected = Object.keys(value).find((key) => !allowed.has(key));
+  if (unexpected !== undefined) {
+    invalidProposal(`${path}.${unexpected}`, "unexpected property");
+  }
+};
+
+const readString = (value: Record<string, unknown>, key: string, path: string): string => {
+  const result = value[key];
+  if (typeof result !== "string") {
+    return invalidProposal(`${path}.${key}`, "expected a string");
+  }
+  return result;
+};
+
+export const parseFolioDocxXmlPatchProposal = (value: unknown): FolioDocxXmlPatchProposal => {
+  if (!isPlainObject(value)) {
+    return invalidProposal("$", "expected an object");
+  }
+  assertAllowedKeys(value, "$", ["version", "replacements"]);
+  if (value["version"] !== FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION) {
+    return invalidProposal("$.version", "unsupported contract version");
+  }
+  const replacements = value["replacements"];
+  if (!Array.isArray(replacements) || replacements.length === 0) {
+    return invalidProposal("$.replacements", "expected a non-empty array");
+  }
+  if (replacements.length > FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxReplacements) {
+    return invalidProposal(
+      "$.replacements",
+      `expected at most ${FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxReplacements} replacements`,
+    );
+  }
+
+  return {
+    version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+    replacements: replacements.map((replacement, index) => {
+      const path = `$.replacements[${index}]`;
+      if (!isPlainObject(replacement)) {
+        return invalidProposal(path, "expected an object");
+      }
+      assertAllowedKeys(replacement, path, ["path", "baseSha256", "replacementXml"]);
+      return {
+        path: readString(replacement, "path", path),
+        baseSha256: readString(replacement, "baseSha256", path),
+        replacementXml: readString(replacement, "replacementXml", path),
+      };
+    }),
+  };
+};
+
+type ResolveLimitOptions = {
+  value: number | undefined;
+  fallback: number;
+  path: string;
+};
+
+const resolveLimit = ({ value, fallback, path }: ResolveLimitOptions): number => {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new InvalidFolioDocxXmlPatchProposalOptionsError({
+      message: `${path} must be a non-negative safe integer.`,
+      path,
+    });
+  }
+  return limit;
+};
+
+const resolveLimits = (
+  limits: FolioDocxXmlPatchProposalLimits | undefined,
+): Required<FolioDocxXmlPatchProposalLimits> => {
+  const maxReplacements = resolveLimit({
+    value: limits?.maxReplacements,
+    fallback: FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxReplacements,
+    path: "limits.maxReplacements",
+  });
+  if (maxReplacements > FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxReplacements) {
+    throw new InvalidFolioDocxXmlPatchProposalOptionsError({
+      message: `limits.maxReplacements must not exceed ${FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxReplacements}.`,
+      path: "limits.maxReplacements",
+    });
+  }
+  return {
+    maxReplacements,
+    maxPartBytes: resolveLimit({
+      value: limits?.maxPartBytes,
+      fallback: FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxPartBytes,
+      path: "limits.maxPartBytes",
+    }),
+    maxTotalBytes: resolveLimit({
+      value: limits?.maxTotalBytes,
+      fallback: FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS.maxTotalBytes,
+      path: "limits.maxTotalBytes",
+    }),
+  };
+};
+
+const isNormalizedPackagePath = (path: string): boolean =>
+  path.length > 0 &&
+  path.length <= MAX_PACKAGE_PATH_CODE_UNITS &&
+  !path.startsWith("/") &&
+  !path.endsWith("/") &&
+  !path.includes("\\") &&
+  path.split("/").every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+
+const resolveAllowedParts = (allowedParts: readonly unknown[]): ReadonlySet<string> => {
+  const resolved = new Set<string>();
+  for (const [index, path] of allowedParts.entries()) {
+    if (typeof path !== "string" || !isNormalizedPackagePath(path)) {
+      throw new InvalidFolioDocxXmlPatchProposalOptionsError({
+        message: `allowedParts[${index}] must be a normalized package path.`,
+        path: `allowedParts[${index}]`,
+      });
+    }
+    if (resolved.has(path)) {
+      throw new InvalidFolioDocxXmlPatchProposalOptionsError({
+        message: `allowedParts[${index}] must be unique.`,
+        path: `allowedParts[${index}]`,
+      });
+    }
+    resolved.add(path);
+  }
+  return resolved;
+};
+
+type RejectedEvaluationOptions = {
+  issues: readonly [FolioDocxXmlPatchProposalIssue, ...FolioDocxXmlPatchProposalIssue[]];
+  limits: Required<FolioDocxXmlPatchProposalLimits>;
+};
+
+const rejectedEvaluation = ({
+  issues,
+  limits,
+}: RejectedEvaluationOptions): FolioDocxXmlPatchProposalEvaluation => ({
+  version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+  profile: FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+  status: "rejected",
+  producesOutput: false,
+  issues,
+  replacements: [],
+  limits,
+});
+
+type AcceptedEvaluationOptions = {
+  replacements: readonly FolioDocxPreparedXmlReplacement[];
+  limits: Required<FolioDocxXmlPatchProposalLimits>;
+};
+
+const acceptedEvaluation = ({
+  replacements,
+  limits,
+}: AcceptedEvaluationOptions): FolioDocxXmlPatchProposalEvaluation => ({
+  version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+  profile: FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+  status: "accepted",
+  producesOutput: false,
+  issues: [],
+  replacements,
+  limits,
+});
+
+const inspectionIssue = (
+  error: FolioDocxPackageInspectionError,
+): FolioDocxXmlPatchProposalIssue => {
+  if (error.code === "part-not-found" || error.code === "part-not-xml") {
+    return {
+      code: error.code,
+      message: error.message,
+      ...(error.part !== undefined && { part: error.part }),
+    };
+  }
+  return {
+    code: "package-inspection-failed",
+    message: "The package could not be inspected within the configured limits.",
+    ...(error.part !== undefined && { part: error.part }),
+  };
+};
+
+export const evaluateDocxXmlPatchProposal = async ({
+  bytes,
+  proposal: rawProposal,
+  allowedParts,
+  archive,
+  limits: rawLimits,
+}: EvaluateDocxXmlPatchProposalArgs): Promise<FolioDocxXmlPatchProposalEvaluation> => {
+  const limits = resolveLimits(rawLimits);
+  const allowed = resolveAllowedParts(allowedParts);
+  const rawReplacements = isPlainObject(rawProposal) ? rawProposal["replacements"] : undefined;
+  if (
+    isPlainObject(rawProposal) &&
+    rawProposal["version"] === FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION &&
+    Array.isArray(rawReplacements) &&
+    rawReplacements.length > limits.maxReplacements
+  ) {
+    return rejectedEvaluation({
+      issues: [
+        {
+          code: "too-many-replacements",
+          message: `Proposal contains ${rawReplacements.length} replacements (max ${limits.maxReplacements}).`,
+          proposalPath: "$.replacements",
+        },
+      ],
+      limits,
+    });
+  }
+  let proposal: FolioDocxXmlPatchProposal;
+  try {
+    proposal = parseFolioDocxXmlPatchProposal(rawProposal);
+  } catch (error) {
+    if (!(error instanceof InvalidFolioDocxXmlPatchProposalError)) {
+      throw error;
+    }
+    return rejectedEvaluation({
+      issues: [
+        {
+          code: error.path === "$.version" ? "unsupported-version" : "invalid-proposal",
+          message: error.message,
+          proposalPath: error.path,
+        },
+      ],
+      limits,
+    });
+  }
+
+  const issues: FolioDocxXmlPatchProposalIssue[] = [];
+  const seen = new Set<string>();
+  const encodedByPath = new Map<string, Uint8Array>();
+  let encodedTotalBytes = 0;
+  let totalCodeUnits = 0;
+  let totalLimitReported = false;
+  for (const [index, replacement] of proposal.replacements.entries()) {
+    const proposalPath = `$.replacements[${index}]`;
+    if (seen.has(replacement.path)) {
+      issues.push({
+        code: "duplicate-part",
+        message: "Each package part may appear only once in a proposal.",
+        proposalPath: `${proposalPath}.path`,
+        part: replacement.path,
+      });
+    }
+    seen.add(replacement.path);
+    if (!isNormalizedPackagePath(replacement.path)) {
+      issues.push({
+        code: "invalid-part-path",
+        message: "Replacement paths must be normalized package paths.",
+        proposalPath: `${proposalPath}.path`,
+        part: replacement.path,
+      });
+    } else if (!allowed.has(replacement.path)) {
+      issues.push({
+        code: "part-not-allowed",
+        message: "The server-side policy does not allow replacing this package part.",
+        proposalPath: `${proposalPath}.path`,
+        part: replacement.path,
+      });
+    }
+    if (replacement.baseSha256.length !== 64 || !SHA256_PATTERN.test(replacement.baseSha256)) {
+      issues.push({
+        code: "invalid-base-sha256",
+        message: "baseSha256 must be a lowercase hexadecimal SHA-256 digest.",
+        proposalPath: `${proposalPath}.baseSha256`,
+        part: replacement.path,
+      });
+    }
+
+    const replacementCodeUnits = replacement.replacementXml.length;
+    const exceedsPartLowerBound = replacementCodeUnits > limits.maxPartBytes;
+    if (exceedsPartLowerBound) {
+      issues.push({
+        code: "replacement-too-large",
+        message: `Replacement XML exceeds the ${limits.maxPartBytes}-byte per-part limit.`,
+        proposalPath: `${proposalPath}.replacementXml`,
+        part: replacement.path,
+      });
+    }
+    totalCodeUnits += replacementCodeUnits;
+    if (totalCodeUnits > limits.maxTotalBytes && !totalLimitReported) {
+      totalLimitReported = true;
+      issues.push({
+        code: "replacements-too-large",
+        message: `Replacement XML exceeds the ${limits.maxTotalBytes}-byte cumulative limit.`,
+        proposalPath: "$.replacements",
+      });
+    }
+    if (exceedsPartLowerBound || totalLimitReported) {
+      continue;
+    }
+
+    const replacementBytes = new TextEncoder().encode(replacement.replacementXml);
+    if (replacementBytes.byteLength > limits.maxPartBytes) {
+      issues.push({
+        code: "replacement-too-large",
+        message: `Replacement XML exceeds the ${limits.maxPartBytes}-byte per-part limit.`,
+        proposalPath: `${proposalPath}.replacementXml`,
+        part: replacement.path,
+      });
+      continue;
+    }
+    if (encodedTotalBytes + replacementBytes.byteLength > limits.maxTotalBytes) {
+      totalLimitReported = true;
+      issues.push({
+        code: "replacements-too-large",
+        message: `Replacement XML exceeds the ${limits.maxTotalBytes}-byte cumulative limit.`,
+        proposalPath: "$.replacements",
+      });
+      continue;
+    }
+    encodedTotalBytes += replacementBytes.byteLength;
+    encodedByPath.set(replacement.path, replacementBytes);
+
+    const safetyIssue = getDocxXmlSafetyIssue(replacement.replacementXml);
+    if (safetyIssue === "doctype-forbidden") {
+      issues.push({
+        code: "xml-doctype-forbidden",
+        message: "Replacement XML must not declare a document type.",
+        proposalPath: `${proposalPath}.replacementXml`,
+        part: replacement.path,
+      });
+    } else if (safetyIssue === "not-well-formed") {
+      issues.push({
+        code: "xml-not-well-formed",
+        message: "Replacement XML must be well formed.",
+        proposalPath: `${proposalPath}.replacementXml`,
+        part: replacement.path,
+      });
+    } else {
+      const declaredEncoding = replacement.replacementXml
+        .match(XML_DECLARED_ENCODING_PATTERN)
+        ?.at(1);
+      if (
+        declaredEncoding !== undefined &&
+        declaredEncoding.toLowerCase() !== "utf-8" &&
+        declaredEncoding.toLowerCase() !== "utf8"
+      ) {
+        issues.push({
+          code: "xml-encoding-mismatch",
+          message: "Replacement XML declarations must use UTF-8 encoding.",
+          proposalPath: `${proposalPath}.replacementXml`,
+          part: replacement.path,
+        });
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    const firstIssue = issues.at(0);
+    if (firstIssue === undefined) {
+      return panic("Rejected XML patch proposal is missing an issue");
+    }
+    return rejectedEvaluation({ issues: [firstIssue, ...issues.slice(1)], limits });
+  }
+
+  let inspected;
+  try {
+    inspected = await inspectDocxPackage(bytes, {
+      archive,
+      xmlParts: proposal.replacements.map(({ path }) => path),
+      limits: {
+        maxXmlParts: limits.maxReplacements,
+        maxXmlPartBytes: limits.maxPartBytes,
+        maxXmlTotalBytes: limits.maxTotalBytes,
+      },
+    });
+  } catch (error) {
+    if (error instanceof FolioDocxPackageInspectionError) {
+      return rejectedEvaluation({
+        issues: [inspectionIssue(error)],
+        limits,
+      });
+    }
+    if (error instanceof DocxArchiveError) {
+      return rejectedEvaluation({
+        issues: [
+          {
+            code: "package-inspection-failed",
+            message: "The package could not be inspected within the configured limits.",
+          },
+        ],
+        limits,
+      });
+    }
+    throw error;
+  }
+
+  const inspectedByPath = new Map(inspected.xmlParts.map((part) => [part.path, part] as const));
+  for (const [index, replacement] of proposal.replacements.entries()) {
+    const current = inspectedByPath.get(replacement.path);
+    if (current === undefined || current.sha256 === replacement.baseSha256) {
+      continue;
+    }
+    issues.push({
+      code: "base-hash-mismatch",
+      message: "The package part changed after the proposal base was inspected.",
+      proposalPath: `$.replacements[${index}].baseSha256`,
+      part: replacement.path,
+    });
+  }
+  if (issues.length > 0) {
+    const firstIssue = issues.at(0);
+    if (firstIssue === undefined) {
+      return panic("Rejected XML patch proposal is missing an issue");
+    }
+    return rejectedEvaluation({ issues: [firstIssue, ...issues.slice(1)], limits });
+  }
+
+  return acceptedEvaluation({
+    replacements: proposal.replacements.map((replacement) => {
+      const replacementBytes = encodedByPath.get(replacement.path);
+      const current = inspectedByPath.get(replacement.path);
+      if (replacementBytes === undefined || current === undefined) {
+        return panic("Accepted XML replacement is missing prepared package data");
+      }
+      return {
+        path: replacement.path,
+        baseSha256: replacement.baseSha256,
+        currentSha256: current.sha256,
+        replacementSha256: createHash("sha256").update(replacementBytes).digest("hex"),
+        replacementByteLength: replacementBytes.byteLength,
+        encoding: "utf-8",
+      };
+    }),
+    limits,
+  });
+};

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
@@ -204,7 +204,11 @@ export const parseFolioDocxXmlPatchProposal = (value: unknown): FolioDocxXmlPatc
     return invalidProposal("$", "expected an object");
   }
   assertAllowedKeys(value, "$", ["version", "replacements"]);
-  if (value["version"] !== FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION) {
+  const version = value["version"];
+  if (typeof version !== "number" || !Number.isSafeInteger(version)) {
+    return invalidProposal("$.version", "expected an integer contract version");
+  }
+  if (version !== FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION) {
     return invalidProposal("$.version", "unsupported contract version");
   }
   const replacements = value["replacements"];
@@ -397,7 +401,13 @@ export const evaluateDocxXmlPatchProposal = async ({
     return rejectedEvaluation({
       issues: [
         {
-          code: error.path === "$.version" ? "unsupported-version" : "invalid-proposal",
+          code:
+            error.path === "$.version" &&
+            isPlainObject(rawProposal) &&
+            typeof rawProposal["version"] === "number" &&
+            Number.isSafeInteger(rawProposal["version"])
+              ? "unsupported-version"
+              : "invalid-proposal",
           message: error.message,
           proposalPath: error.path,
         },
@@ -471,25 +481,28 @@ export const evaluateDocxXmlPatchProposal = async ({
     }
 
     const replacementBytes = new TextEncoder().encode(replacement.replacementXml);
-    if (replacementBytes.byteLength > limits.maxPartBytes) {
+    const exceedsEncodedPart = replacementBytes.byteLength > limits.maxPartBytes;
+    const nextEncodedTotalBytes = encodedTotalBytes + replacementBytes.byteLength;
+    if (exceedsEncodedPart) {
       issues.push({
         code: "replacement-too-large",
         message: `Replacement XML exceeds the ${limits.maxPartBytes}-byte per-part limit.`,
         proposalPath: `${proposalPath}.replacementXml`,
         part: replacement.path,
       });
-      continue;
     }
-    if (encodedTotalBytes + replacementBytes.byteLength > limits.maxTotalBytes) {
+    if (nextEncodedTotalBytes > limits.maxTotalBytes) {
       totalLimitReported = true;
       issues.push({
         code: "replacements-too-large",
         message: `Replacement XML exceeds the ${limits.maxTotalBytes}-byte cumulative limit.`,
         proposalPath: "$.replacements",
       });
+    }
+    encodedTotalBytes = nextEncodedTotalBytes;
+    if (exceedsEncodedPart || totalLimitReported) {
       continue;
     }
-    encodedTotalBytes += replacementBytes.byteLength;
     encodedByPath.set(replacement.path, replacementBytes);
 
     const safetyIssue = getDocxXmlSafetyIssue(replacement.replacementXml);

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
@@ -5,7 +5,11 @@ import { panic, TaggedError } from "better-result";
 import { getDocxXmlSafetyIssue } from "../xmlSafety";
 import type { DocxArchiveOptions } from "./boundedArchive";
 import { DocxArchiveError } from "./boundedArchive";
-import { FolioDocxPackageInspectionError, inspectDocxPackage } from "./inspectDocxPackage";
+import {
+  FolioDocxPackageInspectionError,
+  inspectDocxPackage,
+  type FolioDocxInspectedXmlPart,
+} from "./inspectDocxPackage";
 
 export const FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION = 1 as const;
 export const FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE = "folio-xml-patch-proposal-v1" as const;
@@ -124,6 +128,32 @@ const SHA256_PATTERN = /^[\da-f]{64}$/u;
 const XML_DECLARED_ENCODING_PATTERN =
   /^\uFEFF?<\?xml[^>]*\bencoding\s*=\s*["']([^"']+)["'][^>]*\?>/iu;
 const MAX_PACKAGE_PATH_CODE_UNITS = 1024;
+
+type PrepareXmlReplacementOptions = {
+  replacement: FolioDocxXmlReplacement;
+  encodedByPath: ReadonlyMap<string, Uint8Array>;
+  inspectedByPath: ReadonlyMap<string, FolioDocxInspectedXmlPart>;
+};
+
+const prepareXmlReplacement = ({
+  replacement,
+  encodedByPath,
+  inspectedByPath,
+}: PrepareXmlReplacementOptions): FolioDocxPreparedXmlReplacement => {
+  const replacementBytes = encodedByPath.get(replacement.path);
+  const current = inspectedByPath.get(replacement.path);
+  if (replacementBytes === undefined || current === undefined) {
+    return panic("Accepted XML replacement is missing prepared package data");
+  }
+  return {
+    path: replacement.path,
+    baseSha256: replacement.baseSha256,
+    currentSha256: current.sha256,
+    replacementSha256: createHash("sha256").update(replacementBytes).digest("hex"),
+    replacementByteLength: replacementBytes.byteLength,
+    encoding: "utf-8",
+  };
+};
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -507,7 +537,7 @@ export const evaluateDocxXmlPatchProposal = async ({
   let inspected;
   try {
     inspected = await inspectDocxPackage(bytes, {
-      archive,
+      ...(archive === undefined ? {} : { archive }),
       xmlParts: proposal.replacements.map(({ path }) => path),
       limits: {
         maxXmlParts: limits.maxReplacements,
@@ -557,21 +587,9 @@ export const evaluateDocxXmlPatchProposal = async ({
     return rejectedEvaluation({ issues: [firstIssue, ...issues.slice(1)], limits });
   }
 
-  const preparedReplacements = proposal.replacements.map((replacement) => {
-    const replacementBytes = encodedByPath.get(replacement.path);
-    const current = inspectedByPath.get(replacement.path);
-    if (replacementBytes === undefined || current === undefined) {
-      return panic("Accepted XML replacement is missing prepared package data");
-    }
-    return {
-      path: replacement.path,
-      baseSha256: replacement.baseSha256,
-      currentSha256: current.sha256,
-      replacementSha256: createHash("sha256").update(replacementBytes).digest("hex"),
-      replacementByteLength: replacementBytes.byteLength,
-      encoding: "utf-8",
-    };
-  });
+  const preparedReplacements = proposal.replacements.map((replacement) =>
+    prepareXmlReplacement({ replacement, encodedByPath, inspectedByPath }),
+  );
   const firstPreparedReplacement = preparedReplacements.at(0);
   if (firstPreparedReplacement === undefined) {
     return panic("Accepted XML patch proposal is missing a prepared replacement");

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
@@ -45,7 +45,7 @@ export type FolioDocxXmlReplacement = {
 
 export type FolioDocxXmlPatchProposal = {
   readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
-  readonly replacements: readonly FolioDocxXmlReplacement[];
+  readonly replacements: readonly [FolioDocxXmlReplacement, ...FolioDocxXmlReplacement[]];
 };
 
 export type FolioDocxXmlPatchProposalLimits = {
@@ -79,27 +79,31 @@ export type FolioDocxPreparedXmlReplacement = {
   readonly encoding: "utf-8";
 };
 
-type FolioDocxXmlPatchProposalEvaluationBase = {
-  readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
-  readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
-  readonly producesOutput: false;
-  readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
-};
-
 export type FolioDocxXmlPatchProposalEvaluation =
-  | (FolioDocxXmlPatchProposalEvaluationBase & {
+  | {
+      readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+      readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
       readonly status: "accepted";
+      readonly producesOutput: false;
       readonly issues: readonly [];
-      readonly replacements: readonly FolioDocxPreparedXmlReplacement[];
-    })
-  | (FolioDocxXmlPatchProposalEvaluationBase & {
+      readonly replacements: readonly [
+        FolioDocxPreparedXmlReplacement,
+        ...FolioDocxPreparedXmlReplacement[],
+      ];
+      readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+    }
+  | {
+      readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+      readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
       readonly status: "rejected";
+      readonly producesOutput: false;
       readonly issues: readonly [
         FolioDocxXmlPatchProposalIssue,
         ...FolioDocxXmlPatchProposalIssue[],
       ];
       readonly replacements: readonly [];
-    });
+      readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+    };
 
 export class InvalidFolioDocxXmlPatchProposalError extends TaggedError(
   "InvalidFolioDocxXmlPatchProposalError",
@@ -152,6 +156,19 @@ const readString = (value: Record<string, unknown>, key: string, path: string): 
   return result;
 };
 
+const parseXmlReplacement = (value: unknown, index: number): FolioDocxXmlReplacement => {
+  const path = `$.replacements[${index}]`;
+  if (!isPlainObject(value)) {
+    return invalidProposal(path, "expected an object");
+  }
+  assertAllowedKeys(value, path, ["path", "baseSha256", "replacementXml"]);
+  return {
+    path: readString(value, "path", path),
+    baseSha256: readString(value, "baseSha256", path),
+    replacementXml: readString(value, "replacementXml", path),
+  };
+};
+
 export const parseFolioDocxXmlPatchProposal = (value: unknown): FolioDocxXmlPatchProposal => {
   if (!isPlainObject(value)) {
     return invalidProposal("$", "expected an object");
@@ -171,20 +188,18 @@ export const parseFolioDocxXmlPatchProposal = (value: unknown): FolioDocxXmlPatc
     );
   }
 
+  const firstReplacement = replacements.at(0);
+  if (firstReplacement === undefined) {
+    return invalidProposal("$.replacements", "expected a non-empty array");
+  }
   return {
     version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
-    replacements: replacements.map((replacement, index) => {
-      const path = `$.replacements[${index}]`;
-      if (!isPlainObject(replacement)) {
-        return invalidProposal(path, "expected an object");
-      }
-      assertAllowedKeys(replacement, path, ["path", "baseSha256", "replacementXml"]);
-      return {
-        path: readString(replacement, "path", path),
-        baseSha256: readString(replacement, "baseSha256", path),
-        replacementXml: readString(replacement, "replacementXml", path),
-      };
-    }),
+    replacements: [
+      parseXmlReplacement(firstReplacement, 0),
+      ...replacements
+        .slice(1)
+        .map((replacement, index) => parseXmlReplacement(replacement, index + 1)),
+    ],
   };
 };
 
@@ -281,7 +296,7 @@ const rejectedEvaluation = ({
 });
 
 type AcceptedEvaluationOptions = {
-  replacements: readonly FolioDocxPreparedXmlReplacement[];
+  replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
   limits: Required<FolioDocxXmlPatchProposalLimits>;
 };
 
@@ -542,22 +557,27 @@ export const evaluateDocxXmlPatchProposal = async ({
     return rejectedEvaluation({ issues: [firstIssue, ...issues.slice(1)], limits });
   }
 
+  const preparedReplacements = proposal.replacements.map((replacement) => {
+    const replacementBytes = encodedByPath.get(replacement.path);
+    const current = inspectedByPath.get(replacement.path);
+    if (replacementBytes === undefined || current === undefined) {
+      return panic("Accepted XML replacement is missing prepared package data");
+    }
+    return {
+      path: replacement.path,
+      baseSha256: replacement.baseSha256,
+      currentSha256: current.sha256,
+      replacementSha256: createHash("sha256").update(replacementBytes).digest("hex"),
+      replacementByteLength: replacementBytes.byteLength,
+      encoding: "utf-8",
+    };
+  });
+  const firstPreparedReplacement = preparedReplacements.at(0);
+  if (firstPreparedReplacement === undefined) {
+    return panic("Accepted XML patch proposal is missing a prepared replacement");
+  }
   return acceptedEvaluation({
-    replacements: proposal.replacements.map((replacement) => {
-      const replacementBytes = encodedByPath.get(replacement.path);
-      const current = inspectedByPath.get(replacement.path);
-      if (replacementBytes === undefined || current === undefined) {
-        return panic("Accepted XML replacement is missing prepared package data");
-      }
-      return {
-        path: replacement.path,
-        baseSha256: replacement.baseSha256,
-        currentSha256: current.sha256,
-        replacementSha256: createHash("sha256").update(replacementBytes).digest("hex"),
-        replacementByteLength: replacementBytes.byteLength,
-        encoding: "utf-8",
-      };
-    }),
+    replacements: [firstPreparedReplacement, ...preparedReplacements.slice(1)],
     limits,
   });
 };

--- a/packages/core/src/docx/server/validateDocxConformance.ts
+++ b/packages/core/src/docx/server/validateDocxConformance.ts
@@ -1,5 +1,4 @@
 import { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
-import { XMLValidator } from "fast-xml-parser";
 
 import type { DocxConformanceClass } from "../../types/document";
 import { detectDocxConformanceClass } from "../conformance";
@@ -13,6 +12,7 @@ import {
   getNamespacePrefix,
   parseXmlDocument,
 } from "../xmlParser";
+import { getDocxXmlSafetyIssue } from "../xmlSafety";
 import type { DocxArchive, DocxArchiveOptions } from "./boundedArchive";
 import { DocxArchiveError, loadDocxArchive } from "./boundedArchive";
 
@@ -99,7 +99,6 @@ const DOCUMENT_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
 const CONTENT_TYPES_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/content-types";
 const RELATIONSHIPS_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/relationships";
-const DOCTYPE_PATTERN = /<!DOCTYPE(?:\s|>)/iu;
 const UNVERIFIED_STANDARDS_DIMENSIONS = Object.freeze([
   "complete-schema-constraints",
   "markup-compatibility-processing",
@@ -192,7 +191,8 @@ const validateXmlParts = async (
     }
     xmlByPath.set(part, xml);
 
-    if (DOCTYPE_PATTERN.test(xml)) {
+    const safetyIssue = getDocxXmlSafetyIssue(xml);
+    if (safetyIssue === "doctype-forbidden") {
       hasInvalidXml = true;
       addIssue(report, {
         check: "xml-well-formedness",
@@ -204,7 +204,7 @@ const validateXmlParts = async (
       continue;
     }
 
-    if (XMLValidator.validate(xml) !== true) {
+    if (safetyIssue === "not-well-formed") {
       hasInvalidXml = true;
       addIssue(report, {
         check: "xml-well-formedness",

--- a/packages/core/src/docx/xmlSafety.ts
+++ b/packages/core/src/docx/xmlSafety.ts
@@ -1,0 +1,12 @@
+import { XMLValidator } from "fast-xml-parser";
+
+const DOCTYPE_PATTERN = /<!DOCTYPE(?:\s|>)/iu;
+
+export type DocxXmlSafetyIssue = "doctype-forbidden" | "not-well-formed";
+
+export const getDocxXmlSafetyIssue = (xml: string): DocxXmlSafetyIssue | null => {
+  if (DOCTYPE_PATTERN.test(xml)) {
+    return "doctype-forbidden";
+  }
+  return XMLValidator.validate(xml) === true ? null : "not-well-formed";
+};

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -189,6 +189,24 @@ export {
   type InspectDocxPackageOptions,
 } from "./docx/server/inspectDocxPackage";
 export {
+  evaluateDocxXmlPatchProposal,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+  InvalidFolioDocxXmlPatchProposalError,
+  InvalidFolioDocxXmlPatchProposalOptionsError,
+  parseFolioDocxXmlPatchProposal,
+  type EvaluateDocxXmlPatchProposalArgs,
+  type FolioDocxPreparedXmlReplacement,
+  type FolioDocxXmlPatchProposal,
+  type FolioDocxXmlPatchProposalEvaluation,
+  type FolioDocxXmlPatchProposalIssue,
+  type FolioDocxXmlPatchProposalIssueCode,
+  type FolioDocxXmlPatchProposalLimits,
+  type FolioDocxXmlReplacement,
+} from "./docx/server/evaluateDocxXmlPatchProposal";
+export {
   FOLIO_DOCX_CONFORMANCE_CHECKS,
   FOLIO_DOCX_CONFORMANCE_ISSUE_CODES,
   FOLIO_DOCX_CONFORMANCE_PROFILE,


### PR DESCRIPTION
## Summary

- add versioned proposal parsing and package-aware evaluation
- enforce exact part policies, byte limits, XML safety, and hash preconditions
- return typed evaluation results without package output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating and evaluating DOCX XML patch proposals.
  * Added checks for supported versions, allowed document parts, file sizes, hashes, safe paths, and XML safety.
  * Added structured acceptance results and detailed rejection issues.
  * Added public configuration and validation options for patch proposals.

* **Bug Fixes**
  * Improved DOCX XML safety validation for forbidden document types and malformed XML.

* **Tests**
  * Added comprehensive coverage for valid, rejected, oversized, stale, malformed, and unsafe proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->