### PR TITLE
fix: improve Aptos fallback metrics

### DIFF
--- a/.changeset/fresh-bottles-shine.md
+++ b/.changeset/fresh-bottles-shine.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-react": patch
+"@stll/folio-core": patch
+---
+
+Use a closer bundled fallback for Aptos document fonts

--- a/bun.lock
+++ b/bun.lock
@@ -159,6 +159,7 @@
         "@fontsource/caladea": "^5.2.8",
         "@fontsource/carlito": "^5.2.8",
         "@fontsource/cousine": "^5.2.7",
+        "@fontsource/lato": "^5.2.7",
         "@fontsource/noto-sans-arabic": "^5.2.7",
         "@fontsource/source-sans-3": "^5.2.9",
         "@fontsource/tinos": "^5.2.7",
@@ -411,6 +412,8 @@
     "@fontsource/carlito": ["@fontsource/carlito@5.2.8", "", {}, "sha512-EbsNaWvGUWiuSAv/9+n9lHMi2hfPabhw5rY7r+B84XDb0fvkw+3bCksrcEBE3sQDIKgAsIjDzzSbb0+GYJlvEQ=="],
 
     "@fontsource/cousine": ["@fontsource/cousine@5.2.7", "", {}, "sha512-2l6qNHghWeQDGqaR1QmS8iR1YWzhZczcVQpR/MJVNSKE8bELI6v2Rqe+d4pFfG+5PY9QhvZ+aKriqlbKubcR8g=="],
+
+    "@fontsource/lato": ["@fontsource/lato@5.2.7", "", {}, "sha512-k5mum1ADbDW5cTw1Ett1eQVWeoZ6gq0ct6SFBibEhB4LRxhniChJZTBgd6ph5yBxLkN1fcnsnmicBNA4S/3nbw=="],
 
     "@fontsource/noto-sans-arabic": ["@fontsource/noto-sans-arabic@5.2.10", "", {}, "sha512-Hgj3NwQJ0NquIADW3hFboFjsts4UvEOJQ8tOX0bhQZgpNKHsMawjv/1SZnq0QvRbP6efHTZM/A1k7tdy9S6sbA=="],
 

--- a/packages/core/src/controller/fontReadiness.test.ts
+++ b/packages/core/src/controller/fontReadiness.test.ts
@@ -59,6 +59,25 @@ describe("initial layout font loading", () => {
     expect(faces).not.toContain("Cambria|italic|700");
   });
 
+  test("loads the metric-compatible fallback for Aptos before layout", () => {
+    const fontFamily = schema.marks["fontFamily"]?.create({
+      ascii: "Aptos",
+      hAnsi: "Aptos",
+    });
+    if (!fontFamily) {
+      throw new Error("Expected fontFamily mark in schema");
+    }
+
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Aptos text", [fontFamily])]),
+    ]);
+
+    const faces = collectInitialLayoutFontFaces(null, pmDoc).map(fontFaceKey);
+
+    expect(faces).toContain("Aptos|normal|400");
+    expect(faces).toContain("Lato|normal|400");
+  });
+
   test("combines inherited text formatting with explicit marks", () => {
     const bold = schema.marks["bold"]?.create();
     if (!bold) {

--- a/packages/core/src/controller/fontReadiness.ts
+++ b/packages/core/src/controller/fontReadiness.ts
@@ -30,6 +30,8 @@ export function documentFontsAreLoaded(): boolean {
 const INITIAL_LAYOUT_FONT_TIMEOUT_MS = 2000;
 const DEFAULT_LAYOUT_FONT_FAMILY = "Calibri";
 const OFFICE_FONT_FAMILY_MAP: Record<string, string> = {
+  Aptos: "Lato",
+  "Aptos Display": "Lato",
   Arial: "Arimo",
   Calibri: "Carlito",
   Cambria: "Caladea",

--- a/packages/core/src/utils/fontLoader.ts
+++ b/packages/core/src/utils/fontLoader.ts
@@ -25,8 +25,8 @@ let isLoadingAny = false;
  * this map is used for font availability checks and preloading.
  */
 export const FONT_MAPPING: Record<string, string> = {
-  Aptos: "Source Sans 3",
-  "Aptos Display": "Source Sans 3",
+  Aptos: "Lato",
+  "Aptos Display": "Lato",
   Calibri: "Carlito",
   Cambria: "Caladea",
   Arial: "Arimo",
@@ -50,6 +50,7 @@ const BUNDLED_FONTS = new Set([
   "Arimo",
   "Tinos",
   "Cousine",
+  "Lato",
   "Source Sans 3",
   // Also register the Microsoft names since @font-face aliases exist
   "Calibri",

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -50,12 +50,12 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
   }
 });
 
-describe("fontResolver — Aptos falls back to bundled Source Sans 3", () => {
+describe("fontResolver — Aptos falls back to bundled Lato", () => {
   test.each(["Aptos", "Aptos Display"])("%s keeps an Office-compatible fallback", (font) => {
     const resolved = resolveFontFamily(font);
 
-    expect(resolved.googleFont).toBe("Source Sans 3");
-    expect(resolved.cssFallback).toContain("Source Sans 3");
+    expect(resolved.googleFont).toBe("Lato");
+    expect(resolved.cssFallback).toContain("Lato");
     expect(resolved.hasGoogleEquivalent).toBe(true);
   });
 });

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -144,17 +144,17 @@ const APTOS_MEASURED_LINE_HEIGHT: FontLineHeight = {
  * unchanged, pending measurement.
  */
 const FONT_MAPPINGS: Record<string, FontMapping> = {
-  // Microsoft Office fonts -> Google equivalents (via Croscore)
+  // Microsoft Office fonts -> bundled open-source equivalents
   aptos: {
-    googleFont: "Source Sans 3",
+    googleFont: "Lato",
     category: "sans-serif",
-    fallbackStack: ["Aptos", "Source Sans 3", "Arial", "Helvetica", "sans-serif"],
+    fallbackStack: ["Aptos", "Lato", "Arial", "Helvetica", "sans-serif"],
     singleLineRatio: singleLineRatioOf(APTOS_MEASURED_LINE_HEIGHT),
   },
   "aptos display": {
-    googleFont: "Source Sans 3",
+    googleFont: "Lato",
     category: "sans-serif",
-    fallbackStack: ["Aptos Display", "Source Sans 3", "Arial", "Helvetica", "sans-serif"],
+    fallbackStack: ["Aptos Display", "Lato", "Arial", "Helvetica", "sans-serif"],
     singleLineRatio: singleLineRatioOf(APTOS_MEASURED_LINE_HEIGHT),
   },
   calibri: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,7 @@
     "@fontsource/caladea": "^5.2.8",
     "@fontsource/carlito": "^5.2.8",
     "@fontsource/cousine": "^5.2.7",
+    "@fontsource/lato": "^5.2.7",
     "@fontsource/noto-sans-arabic": "^5.2.7",
     "@fontsource/source-sans-3": "^5.2.9",
     "@fontsource/tinos": "^5.2.7",

--- a/packages/react/src/styles/fonts.css
+++ b/packages/react/src/styles/fonts.css
@@ -14,7 +14,13 @@
 @import "@fontsource/carlito/700.css";
 @import "@fontsource/carlito/700-italic.css";
 
-/* Source Sans 3 → Aptos (default Word font since 2023) */
+/* Lato → Aptos (default Word font since 2023) */
+@import "@fontsource/lato/400.css";
+@import "@fontsource/lato/400-italic.css";
+@import "@fontsource/lato/700.css";
+@import "@fontsource/lato/700-italic.css";
+
+/* Source Sans 3 → Segoe UI and other humanist sans-serif faces */
 @import "@fontsource/source-sans-3/400.css";
 @import "@fontsource/source-sans-3/400-italic.css";
 @import "@fontsource/source-sans-3/700.css";


### PR DESCRIPTION
## Summary

- use bundled Lato as the open-source fallback for Aptos and Aptos Display
- preload the mapped face before the initial layout pass
- cover resolver and font-readiness behavior with focused regressions

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run validate-dist`
- `bun run changeset:check`

CC on behalf of @jan-kubica