### PR TITLE
fix: align Word parity font environments

### DIFF
--- a/parity/__tests__/wordFonts.test.ts
+++ b/parity/__tests__/wordFonts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { wordFontDefinitions } from "../wordFonts";
+import { getReferenceLocalFonts, wordFontDefinitions } from "../wordFonts";
 
 describe("wordFontDefinitions", () => {
   test("maps Aptos regular, bold, and italic faces to explicit CSS descriptors", () => {
@@ -27,5 +27,21 @@ describe("wordFontDefinitions", () => {
   test("uses one unique source file for each declared face", () => {
     const paths = wordFontDefinitions("/word-fonts").map(({ filePath }) => filePath);
     expect(new Set(paths).size).toBe(paths.length);
+  });
+});
+
+describe("getReferenceLocalFonts", () => {
+  test("loads Word's app-bundled faces only for the Word reference", async () => {
+    const wordFonts = [{ family: "Aptos", filePath: "/word-fonts/Aptos.ttf", weight: 400 }];
+    let calls = 0;
+    const loadWordFonts = async () => {
+      calls += 1;
+      return wordFonts;
+    };
+
+    expect(await getReferenceLocalFonts("libreoffice", loadWordFonts)).toEqual([]);
+    expect(calls).toBe(0);
+    expect(await getReferenceLocalFonts("word", loadWordFonts)).toEqual(wordFonts);
+    expect(calls).toBe(1);
   });
 });

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -36,7 +36,7 @@ import { compareGeoms } from "./compare";
 import { getReferenceRenderer, isReferenceRendererId } from "./referenceRenderer";
 import type { ReferenceRenderer } from "./referenceRenderer";
 import { writeHtmlReport } from "./report";
-import { getAvailableWordFonts } from "./wordFonts";
+import { getReferenceLocalFonts } from "./wordFonts";
 import type { DocAssets } from "./report";
 import type {
   CorpusReport,
@@ -233,7 +233,7 @@ const runPipeline = async (
   const failures: DocFailure[] = [];
 
   let extractor: FolioExtractor | undefined;
-  const localFonts = flags.referenceId === "word" ? await getAvailableWordFonts() : [];
+  const localFonts = await getReferenceLocalFonts(flags.referenceId);
 
   try {
     for (let i = 0; i < docs.length; i++) {

--- a/parity/inspect.ts
+++ b/parity/inspect.ts
@@ -13,6 +13,7 @@ import { createFolioExtractor } from "./folioExtract";
 import { getReferenceRenderer, isReferenceRendererId } from "./referenceRenderer";
 import { normalizeLineText, textSimilarity } from "./textNorm";
 import type { DocGeom, LineBox, PageGeom, ReferenceRendererId } from "./types";
+import { getReferenceLocalFonts } from "./wordFonts";
 
 type InspectFlags = {
   doc?: string | undefined;
@@ -184,9 +185,10 @@ const main = async (): Promise<void> => {
   const doc = path.resolve(flags.doc!);
   const maxPages = flags.maxPages ?? Math.max(flags.page, 1);
   const referenceRenderer = getReferenceRenderer(flags.referenceId);
+  const localFonts = await getReferenceLocalFonts(flags.referenceId);
 
   const referenceGeom = await referenceRenderer.getGeometry(doc, {});
-  const extractor = await createFolioExtractor();
+  const extractor = await createFolioExtractor({ localFonts });
   let folio: FolioExtractResult;
   try {
     folio = await extractor.extract(doc, { maxPages });

--- a/parity/wordFonts.ts
+++ b/parity/wordFonts.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import type { LocalFontDefinition } from "./folioExtract";
+import type { ReferenceRendererId } from "./types";
 
 const WORD_FONT_DIR = "/Applications/Microsoft Word.app/Contents/Resources/DFonts";
 
@@ -58,3 +59,13 @@ export const getAvailableWordFonts = async (): Promise<LocalFontDefinition[]> =>
   );
   return available.flat();
 };
+
+type LoadWordFonts = () => Promise<LocalFontDefinition[]>;
+
+/** Keep every parity entry point in the same font environment as its chosen
+ * reference. Word's app-bundled fonts are not normally visible to Chromium. */
+export const getReferenceLocalFonts = (
+  referenceId: ReferenceRendererId,
+  loadWordFonts: LoadWordFonts = getAvailableWordFonts,
+): Promise<LocalFontDefinition[]> =>
+  referenceId === "word" ? loadWordFonts() : Promise.resolve([]);


### PR DESCRIPTION
## Summary

- share reference-specific local font selection between the aggregate parity CLI and the single-page inspector
- load Microsoft Word app-bundled fonts in Chromium only when Word is the selected reference
- cover lazy reference-specific font loading with a focused regression test

## Validation

- `bun test parity/__tests__`
- `bun run typecheck:parity`
- `bun run lint`
- `bun run test`

CC on behalf of @jan-kubica