### PR TITLE
fix: security hardening (DoS, injection, content-leak)

### DIFF
--- a/.changeset/security-agent-preconditions.md
+++ b/.changeset/security-agent-preconditions.md
@@ -1,0 +1,11 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-agents": patch
+---
+
+Harden agent operation integrity: `read_document`/`read_section`/`find_text`
+now return a per-block text hash and `suggest_changes`/`add_comment` accept a
+caller-supplied precondition, so a stale edit prepared against content the model
+read earlier is detected instead of being stamped from a fresh apply-time
+snapshot. Operation-mode and block-range lookups use own-property checks so
+prototype keys (`__proto__`, `constructor`) can no longer crash the API.

--- a/.changeset/security-compare-agent-dos.md
+++ b/.changeset/security-compare-agent-dos.md
@@ -1,0 +1,16 @@
+---
+"@stll/folio-core": patch
+"@stll/docx-core": patch
+"@stll/folio-agents": patch
+---
+
+Bound version-comparison, agent, and validation paths against crafted-input
+resource exhaustion: a single aggregate LCS cell budget is now shared across all
+document stories; move detection dequeues in O(1) instead of `Array.shift`;
+`diffWordSegments` caps its DP matrix and falls back to a whole-string diff;
+`ensureParaIds` and `docx-core`'s `validateDocxPackage` enforce entry-count and
+uncompressed-size limits before reading; note-paragraph patching builds a linear
+offset index instead of rescanning per id; agent whole-word search uses a bounded
+boundary window; `suggest_changes` enforces an aggregate operation-text budget;
+and tracked vertical cell split refuses a stored continuation whose `gridSpan`
+exceeds one column.

--- a/.changeset/security-fonts-watermark.md
+++ b/.changeset/security-fonts-watermark.md
@@ -1,0 +1,13 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Prevent untrusted DOCX assets from affecting the host page. Embedded fonts are
+registered under per-document scoped family names (resolved through the font
+resolver) so a document embedding a face named after a host UI family can no
+longer shadow it page-wide, and watermark dialogs validate external image
+targets against an http/https allowlist (with a defensive guard before emitting
+an external relationship) so `file:`/UNC/other-scheme targets cannot be written
+into exported documents.

--- a/.changeset/security-hidden-active-content.md
+++ b/.changeset/security-hidden-active-content.md
@@ -1,0 +1,14 @@
+---
+"@stll/folio-core": patch
+---
+
+Stop hidden and active DOCX content from leaking through save and read paths.
+Selective save now bails to a full repack when the package contains
+non-preservable entries (e.g. `word/vbaProject.bin`, embedded binaries) instead
+of round-tripping them; hidden table-row text and `w:vanish` runs are excluded
+from the AI snapshot; footnotes referenced only from hidden rows are no longer
+painted; metadata-privacy scrubbing matches `docProps/core.xml` case-insensitively;
+server text extraction resolves referenced headers/footers via relationships
+instead of reading orphan parts; bound content-control clicks no longer throw;
+and text-box anchor markers are stripped from pasted HTML and salted with a
+per-load nonce.

--- a/.changeset/security-ooxml-css-injection.md
+++ b/.changeset/security-ooxml-css-injection.md
@@ -1,0 +1,16 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Prevent CSS and OOXML injection from attacker-controlled document/collaboration
+values. Colors are validated to a strict hex/`auto` format at a single
+`colorResolver` choke point (closing themed table-fill and diagonal-border
+`url()` injection and the pasted `data-bgcolor` path); comment `paraId`/`textId`
+are validated to 8-hex at parse and XML-escaped on serialize; run/paragraph/
+table/style color and theme attributes are XML-escaped and hex-validated; inline
+and block SDT raw properties are replayed only when they are a single
+well-formed `w:sdtPr`/`w:sdtEndPr` element (otherwise synthesized); remote
+collaborator colors are validated before use and painted via `backgroundColor`
+(not the `background` shorthand); and controlled comments are sanitized before
+becoming editor state.

--- a/.changeset/security-parse-layout-dos.md
+++ b/.changeset/security-parse-layout-dos.md
@@ -1,0 +1,13 @@
+---
+"@stll/folio-core": patch
+---
+
+Bound DOCX parsing and layout against crafted-input resource exhaustion: clamp
+table `gridSpan`/column counts, section column count, and page dimensions;
+floor the default tab stop; cap kinsoku/line-break rule lists (stored as sets)
+and run language tags; add an iteration cap to cross-run hyphenation; replace
+the conformance root-tag regex with a linear, non-backtracking scanner; cap
+per-element xmlns declarations; enforce an incremental size budget while
+building grouped-drawing SVG previews; make style-numbered list resume O(1) per
+paragraph; and guard encrypted-DOCX parsing with DIFAT cycle detection plus a
+`spinCount` ceiling.

--- a/.changeset/security-review-action-scoping.md
+++ b/.changeset/security-review-action-scoping.md
@@ -1,0 +1,11 @@
+---
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Scope review actions to their intended target. AI `undoDocumentOperations`
+always undoes the body operation instead of whatever story (header/footer)
+currently has focus; sidebar accept/reject applies only the selected revision
+rather than every tracked change in the resolved range (React and Vue); the Vue
+page-setup dialog respects read-only; Vue table properties target the active
+editor view; and Vue AI-authored comments use the requested operation author.

--- a/.changeset/security-url-sanitization.md
+++ b/.changeset/security-url-sanitization.md
@@ -1,0 +1,13 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Sanitize hyperlink and image link URLs so pasted, programmatic, or DOCX-sourced
+`javascript:`/`data:`/`file:` targets can no longer reach the live DOM or be
+opened. Hyperlink marks are sanitized on parse (`parseDOM`), on render
+(`toDOM`), and when set/inserted/edited; image `a:hlinkClick` targets are
+sanitized at parse time; the Vue popup `window.open` path now mirrors React's
+sanitizer; and aux-click on link anchors no longer bypasses the guard. Internal
+bookmark anchors (`#name`) are preserved.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,8 +17,10 @@ jobs:
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest
-    env:
-      CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
+    # Least privilege: default GITHUB_TOKEN perms are read-only; nothing in this
+    # job needs to write.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -28,16 +30,22 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      # Until CodSpeed is connected, just prove the benches still run.
+      # Until CodSpeed is connected, just prove the benches still run. Checked
+      # against `secrets` directly (not job-level env) so CODSPEED_TOKEN is
+      # never exposed to `bun install` or other steps that run arbitrary
+      # lifecycle/bench code.
       - name: Smoke-run benchmarks
-        if: env.CODSPEED_TOKEN == ''
+        if: ${{ secrets.CODSPEED_TOKEN == '' }}
         run: bun run bench
 
       # CodSpeed instruments under Node; tsx runs the TypeScript bench files
       # directly, and the withCodSpeed-wrapped benches report to the action.
+      # CODSPEED_TOKEN is scoped to this step's env only.
       - name: CodSpeed regression report
-        if: env.CODSPEED_TOKEN != ''
+        if: ${{ secrets.CODSPEED_TOKEN != '' }}
         uses: CodSpeedHQ/action@1d13896ef15fbc335e350f1356d4762be9bc1df9 # v3
+        env:
+          CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
         with:
           run: npx tsx benchmarks/index.ts
           token: ${{ env.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,19 +30,32 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      # Until CodSpeed is connected, just prove the benches still run. Checked
-      # against `secrets` directly (not job-level env) so CODSPEED_TOKEN is
-      # never exposed to `bun install` or other steps that run arbitrary
-      # lifecycle/bench code.
+      # Detect the secret's presence without exposing it: the `secrets` context
+      # is not available in `if:`, and job-level env would leak the token into
+      # `bun install`/bench steps. This tiny step runs no project code and only
+      # emits a boolean, after `bun install`, so the token never reaches steps
+      # that run arbitrary lifecycle/bench code.
+      - name: Detect CodSpeed token
+        id: codspeed
+        env:
+          CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
+        run: |
+          if [ -n "$CODSPEED_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Until CodSpeed is connected, just prove the benches still run.
       - name: Smoke-run benchmarks
-        if: ${{ secrets.CODSPEED_TOKEN == '' }}
+        if: steps.codspeed.outputs.present == 'false'
         run: bun run bench
 
       # CodSpeed instruments under Node; tsx runs the TypeScript bench files
       # directly, and the withCodSpeed-wrapped benches report to the action.
       # CODSPEED_TOKEN is scoped to this step's env only.
       - name: CodSpeed regression report
-        if: ${{ secrets.CODSPEED_TOKEN != '' }}
+        if: steps.codspeed.outputs.present == 'true'
         uses: CodSpeedHQ/action@1d13896ef15fbc335e350f1356d4762be9bc1df9 # v3
         env:
           CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,12 +39,16 @@ name: Publish
 # already on the registry, so bumping only one package republishes only it.
 # Manual dispatch with `publish` unchecked builds + packs only (a dry run).
 #
-# Each successful publish also cuts a GitHub Release (tag `<name>@<version>`)
-# with the exact tarball that went to npm attached as an asset. That tarball is
-# the content-addressed link between the public GitHub reference and the npm
-# artifact: downstream users can verify byte-for-byte that what they install
-# matches this release. Release creation is idempotent — it skips if the tag
-# already exists, mirroring the hardened action's version-level idempotency.
+# Each run also cuts a GitHub Release (tag `<name>@<version>`) with this run's
+# tarball attached as an asset. When the publish step actually shipped the
+# version (not a no-op), that tarball is the content-addressed link between the
+# public GitHub reference and the npm artifact: downstream users can verify
+# byte-for-byte that what they install matches this release. When the version
+# was already on the registry before this run (idempotent publish skip), the
+# release notes say so instead of asserting byte-identity, since this run's
+# rebuild was never the artifact npm actually accepted. Release creation is
+# idempotent — it skips if the tag already exists, mirroring the hardened
+# action's version-level idempotency.
 
 env:
   NODE_VERSION: "22"
@@ -189,6 +193,26 @@ jobs:
             echo "tag=${name}@${version}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Check whether this version already exists on npm
+        id: registry-check
+        shell: bash
+        env:
+          NAME: ${{ steps.tarball.outputs.name }}
+          VERSION: ${{ steps.tarball.outputs.version }}
+        run: |
+          set -euo pipefail
+          # The hardened publish action is idempotent: it no-ops if NAME@VERSION
+          # is already on the registry. Capture that pre-publish state here (an
+          # independent check, not a claimed output of the action) so the
+          # release step below can tell "this run actually published" from "this
+          # run skipped because it was already there" and avoid asserting
+          # byte-identity for a tarball npm never accepted this run.
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "already-published=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "already-published=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Publish to npm
         uses: stella/.github/.github/actions/npm-publish-hardened@96b8912e0786548c4e62046ce3965769991dd0e0
         with:
@@ -199,10 +223,12 @@ jobs:
           tag: latest
 
       - name: Create GitHub Release
-        # Attach the exact tarball published to npm so the GitHub Release is the
-        # content-addressed public reference for the artifact. Idempotent: on a
-        # re-run (or when the sibling package was not bumped and npm publish was
-        # skipped), the tag already exists and we skip.
+        # Attach this run's tarball so the GitHub Release is a content-addressed
+        # public reference for the artifact. Idempotent: on a re-run (or when the
+        # sibling package was not bumped), the tag already exists and we skip.
+        # The release notes below only claim byte-identity with the npm artifact
+        # when `registry-check` observed no pre-existing publish (i.e. this run's
+        # `npm publish` was not a no-op); see ALREADY_PUBLISHED handling below.
         env:
           GH_TOKEN: ${{ github.token }}
           # The job does not check out the repository, so gh cannot infer the
@@ -213,6 +239,7 @@ jobs:
           NAME: ${{ steps.tarball.outputs.name }}
           VERSION: ${{ steps.tarball.outputs.version }}
           TARBALL: ${{ steps.tarball.outputs.path }}
+          ALREADY_PUBLISHED: ${{ steps.registry-check.outputs.already-published }}
         shell: bash
         run: |
           set -euo pipefail
@@ -228,10 +255,17 @@ jobs:
           CHANGELOG_PATH="${changelog}" NOTES_PATH="${notes}" node -e '
           const fs = require("node:fs");
 
-          const { CHANGELOG_PATH: changelogPath, NAME: name, NOTES_PATH: notesPath, VERSION: version } = process.env;
-          if (!changelogPath || !name || !notesPath || !version) {
+          const {
+            ALREADY_PUBLISHED: alreadyPublishedRaw,
+            CHANGELOG_PATH: changelogPath,
+            NAME: name,
+            NOTES_PATH: notesPath,
+            VERSION: version,
+          } = process.env;
+          if (!alreadyPublishedRaw || !changelogPath || !name || !notesPath || !version) {
             throw new Error("Missing release note generation environment variables");
           }
+          const alreadyPublished = alreadyPublishedRaw === "true";
 
           const lines = fs.readFileSync(changelogPath, "utf8").split(/\r?\n/);
           const heading = `## ${version}`;
@@ -251,7 +285,13 @@ jobs:
             throw new Error(`Empty ${heading} section in ${changelogPath}`);
           }
 
-          const provenance = `\`${name}@${version}\` published to npm via OIDC trusted publishing with SLSA provenance. The attached tarball is the exact artifact published to the registry.`;
+          // "already-published" means NAME@VERSION was already on the registry
+          // before the publish step ran in this workflow run, so the hardened
+          // action was a no-op: the tarball built in this run was never
+          // accepted by npm and must not be claimed as the registry artifact.
+          const provenance = alreadyPublished
+            ? `\`${name}@${version}\` was already published to npm before this workflow run (this run'"'"'s publish step was a no-op). The attached tarball is a local rebuild of the same source and is not guaranteed to be byte-identical to the artifact on the registry.`
+            : `\`${name}@${version}\` published to npm via OIDC trusted publishing with SLSA provenance. The attached tarball is the exact artifact published to the registry.`;
           fs.writeFileSync(notesPath, `${section}\n\n---\n\n${provenance}\n`);
           '
           gh release create "${TAG}" "${TARBALL}" \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -42,9 +42,13 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Persist the app token so the changesets branch push authenticates as
-          # the app (not the unusable default GITHUB_TOKEN).
           token: ${{ steps.app-token.outputs.token }}
+          # changesets/action authenticates its own branch push and PR creation
+          # via the GITHUB_TOKEN env var passed to that step below; it does not
+          # rely on git's persisted credential helper. Do not let checkout also
+          # write the app token into .git/config, where the later `bun install`
+          # step (untrusted lifecycle scripts) could read it.
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/api-reports/agents/index.api.md
+++ b/api-reports/agents/index.api.md
@@ -156,7 +156,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -243,7 +243,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -326,7 +326,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -414,7 +414,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -483,7 +483,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -552,7 +552,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -617,7 +617,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -670,7 +670,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -727,7 +727,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -808,7 +808,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -861,7 +861,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -902,7 +902,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -955,7 +955,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -996,7 +996,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -1047,7 +1047,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -1093,7 +1093,7 @@ export const FOLIO_DOCUMENT_OPERATION_BATCH_JSON_SCHEMA: {
                                 readonly blockTextHash: {
                                     readonly type: "string";
                                     readonly pattern: "^h[0-9a-z]+$";
-                                    readonly description: "Normalized hash of the target block's text.";
+                                    readonly description: "Normalized hash of the target block's text, from a prior document read.";
                                 };
                             };
                             readonly required: readonly ["blockTextHash"];
@@ -1178,7 +1178,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1265,7 +1265,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1348,7 +1348,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1436,7 +1436,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1505,7 +1505,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1574,7 +1574,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1639,7 +1639,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1692,7 +1692,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1749,7 +1749,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1830,7 +1830,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1883,7 +1883,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1924,7 +1924,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -1977,7 +1977,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -2018,7 +2018,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -2069,7 +2069,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -2115,7 +2115,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: {
                     readonly blockTextHash: {
                         readonly type: "string";
                         readonly pattern: "^h[0-9a-z]+$";
-                        readonly description: "Normalized hash of the target block's text.";
+                        readonly description: "Normalized hash of the target block's text, from a prior document read.";
                     };
                 };
                 readonly required: readonly ["blockTextHash"];
@@ -2146,6 +2146,7 @@ export type FolioAgentBlock = {
     blockId: string;
     kind: string;
     text: string;
+    blockTextHash: string;
 };
 
 // @public
@@ -2287,7 +2288,8 @@ export type FolioAgentTextMatch = {
     story?: {
         type: "main";
     };
-    blockId: string; /** Stable handle that can be passed directly to `show_in_document` or a range operation. */
+    blockId: string; /** Normalized-text hash of the whole containing block; see {@link FolioAgentBlock.blockTextHash}. */
+    blockTextHash: string; /** Stable handle that can be passed directly to `show_in_document` or a range operation. */
     range: FolioAITextRangeHandle; /** 0-based index of this occurrence within its block. */
     occurrenceInBlock: number; /** Real rendered page when a live paginated surface supplies it. */
     page?: number;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -225,6 +225,9 @@ export type AutocompleteTriggerOptions = {
 export type AutocompleteTriggerSkipReason = "selection-non-empty" | "midword" | "deadzone" | "empty-doc";
 
 // @public
+export function buildEmbeddedFontFamilyMap(faces: readonly EmbeddedFont[]): Map<string, string>;
+
+// @public
 export function buildPositionalText(doc: Node_2, from?: number, to?: number): PositionalText;
 
 // @public (undocumented)
@@ -385,7 +388,8 @@ export type DocxConformanceClass = import__stll_docx_core_model.DocxConformanceC
 
 // @public
 export type EmbeddedFont = {
-    family: string; /** CSS `font-style` the face maps to (`embed*Italic` → `italic`). */
+    family: string; /** Original Word font name (`w:font w:name`), before scoping. */
+    originalFamily: string; /** CSS `font-style` the face maps to (`embed*Italic` → `italic`). */
     style: "normal" | "italic"; /** CSS `font-weight` the face maps to (`embedBold*` → `700`). */
     weight: 400 | 700; /** De-obfuscated OpenType/TrueType bytes (backed by a fresh, non-shared buffer). */
     bytes: Uint8Array<ArrayBuffer>; /** Whether the source face was subsetted (`w:subsetted`). */
@@ -413,7 +417,7 @@ export type ExtractDocumentStyleSetOptions = {
 };
 
 // @public
-export function extractEmbeddedFonts(buffer: ArrayBuffer): Promise<EmbeddedFont[]>;
+export function extractEmbeddedFonts(buffer: ArrayBuffer, docNonce?: string): Promise<EmbeddedFont[]>;
 
 // @public (undocumented)
 export const finishAutocompleteSuggestion: (tr: Transaction, requestId: string) => Transaction;
@@ -827,7 +831,7 @@ export const getAnonymizationMatches: (state: EditorState) => readonly Anonymiza
 export const getAutocompleteSuggestion: (state: EditorState) => AutocompleteSuggestionState;
 
 // @public
-export function getEmbeddedFontFaces(parts: EmbeddedFontParts): EmbeddedFont[];
+export function getEmbeddedFontFaces(parts: EmbeddedFontParts, docNonce?: string): EmbeddedFont[];
 
 // @public
 export const getFolioCaretViewportRect: (view: EditorView) => DOMRect | null;
@@ -951,6 +955,9 @@ export function resolveSuggestionAnchor(doc: Node_2, suggestion: AISuggestion): 
 export const scanDirectives: (doc: Node_2) => DirectiveRange[];
 
 // @public
+export function scopeEmbeddedFontFamily(docNonce: string, originalFamily: string): string;
+
+// @public
 export const scrollFolioPositionIntoView: (view: EditorView, pmPos: number) => boolean;
 
 // @public (undocumented)
@@ -988,6 +995,9 @@ export const setAnonymizationTermsMeta: (terms: readonly AnonymizationTerm[]) =>
         terms: readonly AnonymizationTerm[];
     };
 };
+
+// @public (undocumented)
+export const setEmbeddedFontFamilyMap: (map: ReadonlyMap<string, string> | null) => void;
 
 // @public (undocumented)
 export function setFocusedSuggestionMeta(focusedId: string | null): {

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -225,6 +225,9 @@ export type AutocompleteTriggerOptions = {
 export type AutocompleteTriggerSkipReason = "selection-non-empty" | "midword" | "deadzone" | "empty-doc";
 
 // @public
+export function buildEmbeddedFontFamilyMap(faces: readonly EmbeddedFont[]): Map<string, string>;
+
+// @public
 export function buildPositionalText(doc: Node_2, from?: number, to?: number): PositionalText;
 
 // @public (undocumented)
@@ -385,7 +388,8 @@ export type DocxConformanceClass = import__stll_docx_core_model.DocxConformanceC
 
 // @public
 export type EmbeddedFont = {
-    family: string; /** CSS `font-style` the face maps to (`embed*Italic` → `italic`). */
+    family: string; /** Original Word font name (`w:font w:name`), before scoping. */
+    originalFamily: string; /** CSS `font-style` the face maps to (`embed*Italic` → `italic`). */
     style: "normal" | "italic"; /** CSS `font-weight` the face maps to (`embedBold*` → `700`). */
     weight: 400 | 700; /** De-obfuscated OpenType/TrueType bytes (backed by a fresh, non-shared buffer). */
     bytes: Uint8Array<ArrayBuffer>; /** Whether the source face was subsetted (`w:subsetted`). */
@@ -413,7 +417,7 @@ export type ExtractDocumentStyleSetOptions = {
 };
 
 // @public
-export function extractEmbeddedFonts(buffer: ArrayBuffer): Promise<EmbeddedFont[]>;
+export function extractEmbeddedFonts(buffer: ArrayBuffer, docNonce?: string): Promise<EmbeddedFont[]>;
 
 // @public (undocumented)
 export const finishAutocompleteSuggestion: (tr: Transaction, requestId: string) => Transaction;
@@ -827,7 +831,7 @@ export const getAnonymizationMatches: (state: EditorState) => readonly Anonymiza
 export const getAutocompleteSuggestion: (state: EditorState) => AutocompleteSuggestionState;
 
 // @public
-export function getEmbeddedFontFaces(parts: EmbeddedFontParts): EmbeddedFont[];
+export function getEmbeddedFontFaces(parts: EmbeddedFontParts, docNonce?: string): EmbeddedFont[];
 
 // @public
 export const getFolioCaretViewportRect: (view: EditorView) => DOMRect | null;
@@ -951,6 +955,9 @@ export function resolveSuggestionAnchor(doc: Node_2, suggestion: AISuggestion): 
 export const scanDirectives: (doc: Node_2) => DirectiveRange[];
 
 // @public
+export function scopeEmbeddedFontFamily(docNonce: string, originalFamily: string): string;
+
+// @public
 export const scrollFolioPositionIntoView: (view: EditorView, pmPos: number) => boolean;
 
 // @public (undocumented)
@@ -988,6 +995,9 @@ export const setAnonymizationTermsMeta: (terms: readonly AnonymizationTerm[]) =>
         terms: readonly AnonymizationTerm[];
     };
 };
+
+// @public (undocumented)
+export const setEmbeddedFontFamilyMap: (map: ReadonlyMap<string, string> | null) => void;
 
 // @public (undocumented)
 export function setFocusedSuggestionMeta(focusedId: string | null): {

--- a/api-reports/core/layout-bridge-engine-measuring.api.md
+++ b/api-reports/core/layout-bridge-engine-measuring.api.md
@@ -164,8 +164,8 @@ export function isWorkerFontMetricsEnabled(): boolean;
 export type LineBreakPolicy = {
     locale?: string; /** Apply East Asian first/last-character restrictions (`w:kinsoku`). */
     kinsoku?: boolean; /** Document replacement list: characters that may not begin a line. */
-    noLineBreaksBefore?: string; /** Document replacement list: characters that may not end a line. */
-    noLineBreaksAfter?: string; /** Use the legacy Ethiopic/Amharic compatibility behavior. */
+    noLineBreaksBefore?: ReadonlySet<string>; /** Document replacement list: characters that may not end a line. */
+    noLineBreaksAfter?: ReadonlySet<string>; /** Use the legacy Ethiopic/Amharic compatibility behavior. */
     useLegacyEthiopicAmharicRules?: boolean; /** Keep words made entirely of capital letters unhyphenated. */
     doNotHyphenateCaps?: boolean; /** The run renders with the DOCX all-caps transform. */
     renderedAllCaps?: boolean;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -1216,6 +1216,9 @@ export const getFolioDocumentOutline: (snapshot: FolioAIEditSnapshot) => FolioDo
 export const getFolioParaIdFromBlockId: (id: string) => string | null;
 
 // @public (undocumented)
+export const hashFolioAIBlockText: (text: string) => string;
+
+// @public (undocumented)
 export const inspectDocumentStyles: (document: import__stll_docx_core_model.Document) => DocumentStyleCatalog;
 
 // @public (undocumented)
@@ -1275,6 +1278,9 @@ export const isSequentialFolioBlockId: (id: string) => boolean;
 
 // @public (undocumented)
 export const isSupportedFolioDocumentOperationVersion: (value: unknown) => value is typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+
+// @public (undocumented)
+export const normalizeFolioAIBlockText: (text: string) => string;
 
 // @public (undocumented)
 export const parseFolioDocumentOperationBatch: (value: unknown) => FolioDocumentOperationBatch;

--- a/api-reports/core/watermark.api.md
+++ b/api-reports/core/watermark.api.md
@@ -12,6 +12,9 @@ export function ensureWatermarkHeaderCoverage(doc: import__stll_docx_core_model.
 // @public
 export function getDocumentWatermark(doc: import__stll_docx_core_model.Document): import__stll_docx_core_model.Watermark | undefined;
 
+// @public
+export function isAllowedExternalWatermarkImageUrl(target: string): boolean;
+
 // @public (undocumented)
 export type PictureWatermark = import__stll_docx_core_model.PictureWatermark;
 

--- a/packages/agents/src/execute.test.ts
+++ b/packages/agents/src/execute.test.ts
@@ -626,6 +626,38 @@ describe("find_text edge cases", () => {
     expect(result.totalMatches).toBe(2);
   });
 
+  test("whole-word matching stays correct for a match far into a very large block", async () => {
+    // Regression guard for bounding find_text's whole-word boundary check to
+    // a small fixed window instead of slicing the whole block on either side
+    // of every match (previously O(block.text.length) per match). Both
+    // occurrences sit tens of thousands of characters into the block;
+    // "prefixedTARGET" directly abuts a word character on its left, so the
+    // exclusion must still trigger from a window that only looks a few
+    // characters either side of the match.
+    const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
+    const bridge = createReviewerBridge(reviewer);
+    const target = reviewer.snapshot().blocks.at(0);
+    if (target === undefined) {
+      throw new Error("expected at least one block");
+    }
+    const filler = "x".repeat(20_000);
+    const text = `${filler} TARGET ${filler} prefixedTARGET ${filler}`;
+    reviewer.applyOperations(
+      [{ id: "large-block", type: "replaceBlock", blockId: target.id, text }],
+      { mode: "direct" },
+    );
+
+    const result = expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.findText,
+        { query: "TARGET", wholeWord: true },
+        bridge,
+      ),
+    ) as FolioAgentFindTextResult;
+
+    expect(result.totalMatches).toBe(1);
+  });
+
   test("limits main-story search to real page mappings and exposes the page on matches", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
     const base = createReviewerBridge(reviewer);

--- a/packages/agents/src/execute.test.ts
+++ b/packages/agents/src/execute.test.ts
@@ -361,6 +361,93 @@ describe("executeFolioToolCall: happy path against a real FolioDocxReviewer", ()
     expect(result.receipts).toEqual([]);
   });
 
+  test("suggest_changes honors a caller-supplied precondition, catching staleness a fresh same-call snapshot cannot", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
+    const bridge = createReviewerBridge(reviewer);
+
+    const blocks = expectOk(
+      executeFolioToolCall(FOLIO_AGENT_TOOL_NAMES.readDocument, {}, bridge),
+    ) as FolioAgentBlock[];
+    const heading = blocks.find((block) => block.text.includes("Heading"));
+    if (!heading) {
+      throw new Error("expected a block containing 'Heading'");
+    }
+    expect(heading.blockTextHash).toMatch(/^h[0-9a-z]+$/);
+    const staleBlockTextHash = heading.blockTextHash;
+
+    // Someone else edits the block between the read above and the apply
+    // below — exactly the gap a precondition stamped fresh at apply time
+    // (from a snapshot taken in THIS call) can never observe.
+    expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.suggestChanges,
+        {
+          operations: [
+            {
+              type: "replaceInBlock",
+              blockId: heading.blockId,
+              find: "Heading",
+              replace: "Renamed",
+            },
+          ],
+        },
+        bridge,
+      ),
+    );
+
+    // Echoing the now-stale hash from the ORIGINAL read must be skipped,
+    // not silently applied against the block's new content.
+    const staleResult = expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.suggestChanges,
+        {
+          operations: [
+            {
+              type: "replaceInBlock",
+              blockId: heading.blockId,
+              find: "Renamed",
+              replace: "Changed again",
+              precondition: { blockTextHash: staleBlockTextHash },
+            },
+          ],
+        },
+        bridge,
+      ),
+    ) as FolioAgentApplyOperationsSummary;
+    expect(staleResult.applied).toEqual([]);
+    expect(staleResult.skipped).toHaveLength(1);
+    expect(staleResult.skipped[0]?.reason).toContain("re-read the document");
+
+    // Echoing the CURRENT hash (from a fresh read) applies normally.
+    const freshBlocks = expectOk(
+      executeFolioToolCall(FOLIO_AGENT_TOOL_NAMES.readDocument, {}, bridge),
+    ) as FolioAgentBlock[];
+    const freshHeading = freshBlocks.find((block) => block.blockId === heading.blockId);
+    if (!freshHeading) {
+      throw new Error("expected the block to still exist");
+    }
+    expect(freshHeading.blockTextHash).not.toBe(staleBlockTextHash);
+    const freshResult = expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.suggestChanges,
+        {
+          operations: [
+            {
+              type: "replaceInBlock",
+              blockId: freshHeading.blockId,
+              find: "Renamed",
+              replace: "Changed again",
+              precondition: { blockTextHash: freshHeading.blockTextHash },
+            },
+          ],
+        },
+        bridge,
+      ),
+    ) as FolioAgentApplyOperationsSummary;
+    expect(freshResult.applied).toHaveLength(1);
+    expect(freshResult.skipped).toEqual([]);
+  });
+
   test("suggest_changes explains an unsupported mutation mode", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
     const reviewerBridge = createReviewerBridge(reviewer);

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -2,6 +2,8 @@ import {
   createFolioAITextRangeHandle,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
   getFolioDocumentOutline,
+  hashFolioAIBlockText,
+  normalizeFolioAIBlockText,
   readFolioDocumentSection,
   type FolioAIBlock,
   type FolioAITextRangeHandle,
@@ -38,6 +40,17 @@ const ok = (result: unknown): FolioToolCallResult => ({ ok: true, result });
 const fail = (error: string): FolioToolCallResult => ({ ok: false, error });
 
 const VALID_TOOL_NAMES: readonly string[] = Object.values(FOLIO_AGENT_TOOL_NAMES);
+
+/**
+ * The same normalized-text hash the core snapshot/apply machinery uses for
+ * `precondition.blockTextHash` (see `hashFolioAIBlockText` /
+ * `normalizeFolioAIBlockText`). Computed straight from a block's `text`
+ * rather than looked up from `snapshot.anchors` so every read path (main
+ * document, a section, a find_text match) can attach it without threading
+ * the anchors map around — it is defined to produce the exact same value.
+ */
+const blockTextHashOf = (text: string): string =>
+  hashFolioAIBlockText(normalizeFolioAIBlockText(text));
 
 /** `find_text` requires a short `query` and caps how much of a large match set it returns in one call. */
 const MAX_QUERY_LENGTH = 1_000;
@@ -128,7 +141,14 @@ const dispatch = (name: string, args: unknown, bridge: FolioAgentBridge): FolioT
 
 const readDocument = (bridge: FolioAgentBridge): FolioToolCallResult => {
   const { blocks } = bridge.snapshot();
-  return ok(blocks.map((block) => ({ blockId: block.id, kind: block.kind, text: block.text })));
+  return ok(
+    blocks.map((block) => ({
+      blockId: block.id,
+      kind: block.kind,
+      text: block.text,
+      blockTextHash: blockTextHashOf(block.text),
+    })),
+  );
 };
 
 const parseSectionHandle = (value: unknown): FolioDocumentSectionHandle | null => {
@@ -231,7 +251,12 @@ const readSection = (args: unknown, bridge: FolioAgentBridge): FolioToolCallResu
   return ok({
     handle,
     heading: resolved.section.heading,
-    blocks: selected.map(({ id, kind, text }) => ({ blockId: id, kind, text })),
+    blocks: selected.map(({ id, kind, text }) => ({
+      blockId: id,
+      kind,
+      text,
+      blockTextHash: blockTextHashOf(text),
+    })),
     totalBlocks: resolved.section.blocks.length,
     truncated: hasMore,
     ...(hasMore && lastBlockId !== undefined && { nextAfterBlockId: lastBlockId }),
@@ -310,6 +335,7 @@ const findTextMatches = (
   const expression = new RegExp(escapedQuery, matchCase ? "gu" : "giu");
   for (const block of blocks) {
     let occurrence = 0;
+    let blockTextHash: string | undefined;
     for (const match of block.text.matchAll(expression)) {
       const at = match.index;
       const matchedText = match[0];
@@ -341,10 +367,12 @@ const findTextMatches = (
       if (matches.length < MAX_FIND_MATCHES) {
         const contextStart = Math.max(0, at - CONTEXT_RADIUS);
         const contextEnd = Math.min(block.text.length, at + matchedText.length + CONTEXT_RADIUS);
+        blockTextHash ??= blockTextHashOf(block.text);
         matches.push({
           type: "main",
           story: { type: "main" },
           blockId: block.id,
+          blockTextHash,
           range,
           occurrenceInBlock: occurrence,
           context: block.text.slice(contextStart, contextEnd),
@@ -572,6 +600,23 @@ const summarizeApplyResult = (result: {
   receipts: result.receipts ?? [],
 });
 
+/**
+ * Attach a `precondition.blockTextHash` guard to every operation before
+ * handing the batch to the bridge.
+ *
+ * When the caller (the model) already echoed a `precondition` on the
+ * operation — sourced from a `blockTextHash` returned by an earlier
+ * `read_document` / `read_section` / `find_text` call — that is honored
+ * as-is: it is the only signal that can catch a document edit made
+ * BETWEEN that read and this apply call.
+ *
+ * When no precondition was supplied, fall back to stamping one from this
+ * call's own fresh `bridge.snapshot()`, matching the previous behavior.
+ * This fallback cannot detect cross-call staleness — the snapshot it reads
+ * from is taken right before applying, so it always matches the current
+ * live document — but it still guards a later operation in the SAME batch
+ * against an earlier operation in that batch touching the same block.
+ */
 const applyOperations = (
   bridge: FolioAgentBridge,
   operations: FolioDocumentOperation[],
@@ -579,6 +624,10 @@ const applyOperations = (
   const snapshot = bridge.snapshot();
   const guardedOperations: FolioDocumentOperation[] = [];
   for (const operation of operations) {
+    if (operation.precondition !== undefined) {
+      guardedOperations.push(operation);
+      continue;
+    }
     const blockId =
       operation.type === "replaceRange" ||
       operation.type === "commentOnRange" ||

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -279,6 +279,16 @@ const readStory = (args: unknown, bridge: FolioAgentBridge): FolioToolCallResult
 const CONTEXT_RADIUS = 40;
 const WORD_CHARACTER_AT_END = /[\p{L}\p{M}\p{N}_]$/u;
 const WORD_CHARACTER_AT_START = /^[\p{L}\p{M}\p{N}_]/u;
+/**
+ * Window (UTF-16 code units) sliced on each side of a match for the
+ * whole-word boundary check. The regexes above only ever test the single
+ * grapheme adjacent to the match, but a surrogate pair or a base character
+ * with stacked combining marks can span a few code units — this window is
+ * generous enough to cover that while staying a constant, not
+ * `block.text.length`. Without a bound, `.slice(0, at)` / `.slice(at + len)`
+ * on every match makes a whole-word search O(n^2) in the block's length.
+ */
+const WORD_BOUNDARY_WINDOW = 8;
 
 /** All matches for `query`, capped at {@link MAX_FIND_MATCHES}; `totalMatches` still counts every occurrence. */
 type FindTextMatches<TMatch = FolioAgentTextMatch> = {
@@ -305,8 +315,12 @@ const findTextMatches = (
       const matchedText = match[0];
       if (
         wholeWord &&
-        (WORD_CHARACTER_AT_END.test(block.text.slice(0, at)) ||
-          WORD_CHARACTER_AT_START.test(block.text.slice(at + matchedText.length)))
+        (WORD_CHARACTER_AT_END.test(
+          block.text.slice(Math.max(0, at - WORD_BOUNDARY_WINDOW), at),
+        ) ||
+          WORD_CHARACTER_AT_START.test(
+            block.text.slice(at + matchedText.length, at + matchedText.length + WORD_BOUNDARY_WINDOW),
+          ))
       ) {
         continue;
       }
@@ -359,8 +373,10 @@ const findStoryTextMatches = (
     const matchedText = match[0];
     if (
       wholeWord &&
-      (WORD_CHARACTER_AT_END.test(text.slice(0, at)) ||
-        WORD_CHARACTER_AT_START.test(text.slice(at + matchedText.length)))
+      (WORD_CHARACTER_AT_END.test(text.slice(Math.max(0, at - WORD_BOUNDARY_WINDOW), at)) ||
+        WORD_CHARACTER_AT_START.test(
+          text.slice(at + matchedText.length, at + matchedText.length + WORD_BOUNDARY_WINDOW),
+        ))
     ) {
       continue;
     }

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -341,11 +341,12 @@ const findTextMatches = (
       const matchedText = match[0];
       if (
         wholeWord &&
-        (WORD_CHARACTER_AT_END.test(
-          block.text.slice(Math.max(0, at - WORD_BOUNDARY_WINDOW), at),
-        ) ||
+        (WORD_CHARACTER_AT_END.test(block.text.slice(Math.max(0, at - WORD_BOUNDARY_WINDOW), at)) ||
           WORD_CHARACTER_AT_START.test(
-            block.text.slice(at + matchedText.length, at + matchedText.length + WORD_BOUNDARY_WINDOW),
+            block.text.slice(
+              at + matchedText.length,
+              at + matchedText.length + WORD_BOUNDARY_WINDOW,
+            ),
           ))
       ) {
         continue;

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -64,16 +64,24 @@ export const FOLIO_TEXT_RANGE_JSON_SCHEMA = {
   additionalProperties: false,
 } as const;
 
-const preconditionJsonSchema = {
+/**
+ * JSON Schema for the contract's optional `precondition` guard: `{
+ * blockTextHash }`, echoed from a `blockTextHash` returned by a document
+ * read (`read_document`, `read_section`, `find_text`). Exported so
+ * `tools.ts` can attach the same shape to `suggest_changes` and
+ * `add_comment` without redeclaring it.
+ */
+export const FOLIO_PRECONDITION_JSON_SCHEMA = {
   type: "object",
   description:
-    "Optional guard: the operation is skipped (reason `preconditionFailed`) unless the target " +
-    "block's normalized text hash still matches.",
+    "Optional guard against editing a block that changed since you read it: echo the `blockTextHash` " +
+    "returned by read_document / read_section / find_text for this block. The operation is skipped " +
+    "(reason `preconditionFailed`) unless the target block's current normalized text hash still matches.",
   properties: {
     blockTextHash: {
       type: "string",
       pattern: NORMALIZED_TEXT_HASH_PATTERN,
-      description: "Normalized hash of the target block's text.",
+      description: "Normalized hash of the target block's text, from a prior document read.",
     },
   },
   required: ["blockTextHash"],
@@ -110,7 +118,7 @@ const operationMetaProperties = {
     type: "string",
     description: 'Optional review area label (e.g. "Penalty") for structured-review workflows.',
   },
-  precondition: preconditionJsonSchema,
+  precondition: FOLIO_PRECONDITION_JSON_SCHEMA,
 } as const;
 
 const blockIdProperty = {

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -41,6 +41,32 @@ describe("parseAddCommentInput", () => {
     expect(result.operation).toMatchObject({ quote: "the quoted text" });
   });
 
+  test("valid input with a precondition includes it on the operation", () => {
+    const result = parseAddCommentInput({
+      blockId: "b1",
+      text: "note",
+      precondition: { blockTextHash: "h1a2b3" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected ok:true");
+    }
+    expect(result.operation).toMatchObject({ precondition: { blockTextHash: "h1a2b3" } });
+  });
+
+  test("rejects a malformed precondition", () => {
+    const result = parseAddCommentInput({
+      blockId: "b1",
+      text: "note",
+      precondition: { blockTextHash: "not-a-hash" },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ok:false");
+    }
+    expect(result.error).toContain("precondition.blockTextHash");
+  });
+
   test("rejects non-object args", () => {
     const result = parseAddCommentInput("not an object");
     expect(result.ok).toBe(false);
@@ -148,6 +174,44 @@ describe("parseSuggestChangesInput", () => {
     expect(result.operations).toEqual([
       { id: "op-1", type: "replaceInBlock", blockId: "b1", find: "Heading", replace: "Intro" },
     ]);
+  });
+
+  test("a caller-supplied precondition is attached to the operation", () => {
+    const result = parseSuggestChangesInput({
+      operations: [
+        {
+          type: "replaceInBlock",
+          blockId: "b1",
+          find: "Heading",
+          replace: "Intro",
+          precondition: { blockTextHash: "h1a2b3" },
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected ok:true");
+    }
+    expect(result.operations[0]?.precondition).toEqual({ blockTextHash: "h1a2b3" });
+  });
+
+  test("rejects a precondition with a malformed blockTextHash", () => {
+    const result = parseSuggestChangesInput({
+      operations: [
+        {
+          type: "replaceInBlock",
+          blockId: "b1",
+          find: "Heading",
+          replace: "Intro",
+          precondition: { blockTextHash: "not-a-hash" },
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ok:false");
+    }
+    expect(result.error).toContain("precondition.blockTextHash");
   });
 
   test("a caller-supplied id is preserved instead of the auto-generated one", () => {

--- a/packages/agents/src/parse.test.ts
+++ b/packages/agents/src/parse.test.ts
@@ -10,7 +10,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parseAddCommentInput, parseSuggestChangesInput } from "./parse";
+import {
+  MAX_TOTAL_OPERATION_TEXT_LENGTH,
+  parseAddCommentInput,
+  parseSuggestChangesInput,
+} from "./parse";
 import { SUGGEST_CHANGES_OPERATION_TYPES } from "./tools";
 
 describe("parseAddCommentInput", () => {
@@ -303,6 +307,44 @@ describe("parseSuggestChangesInput", () => {
       throw new Error("expected ok:false");
     }
     expect(result.error).toContain("50-operation limit");
+  });
+
+  test("rejects a batch whose combined text exceeds the aggregate budget even though every field is within its own per-field cap", () => {
+    // Regression guard for the aggregate text budget: each `text` field alone
+    // is under MAX_OPERATION_TEXT_LENGTH (100,000) and the batch is under the
+    // 50-operation cap, but the SUM (21 * 100,000 = 2,100,000) exceeds
+    // MAX_TOTAL_OPERATION_TEXT_LENGTH. Without this aggregate check a batch
+    // shaped like this (or a much larger one using cellTexts arrays) could
+    // still push an unbounded total into the tracked-changes engine in one
+    // suggest_changes call.
+    const nearCapText = "x".repeat(100_000);
+    const operations = Array.from({ length: 21 }, (_, i) => ({
+      type: "replaceBlock",
+      blockId: `block-${i}`,
+      text: nearCapText,
+    }));
+
+    const result = parseSuggestChangesInput({ operations });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ok:false");
+    }
+    expect(result.error).toContain("aggregate limit");
+  });
+
+  test("accepts a batch whose combined text stays within the aggregate budget", () => {
+    const okText = "x".repeat(50_000);
+    const operations = Array.from({ length: 10 }, (_, i) => ({
+      type: "replaceBlock",
+      blockId: `block-${i}`,
+      text: okText,
+    }));
+    expect(10 * 50_000).toBeLessThan(MAX_TOTAL_OPERATION_TEXT_LENGTH);
+
+    const result = parseSuggestChangesInput({ operations });
+
+    expect(result.ok).toBe(true);
   });
 
   test("rejects an unknown operation type", () => {

--- a/packages/agents/src/parse.ts
+++ b/packages/agents/src/parse.ts
@@ -57,6 +57,37 @@ export const explainTextTooLong = (label: string, length: number): string =>
 const explainAggregateTextTooLong = (index: number): string =>
   `operations[${index}] pushes suggest_changes' combined text over the ${MAX_TOTAL_OPERATION_TEXT_LENGTH.toLocaleString()}-character aggregate limit across all operations; split the edit across multiple suggest_changes calls.`;
 
+/** Normalized text hashes (`hashFolioAIBlockText`) look like `h` followed by base-36 digits. */
+const NORMALIZED_TEXT_HASH_PATTERN = /^h[0-9a-z]+$/;
+
+/**
+ * Parse an optional `precondition: { blockTextHash }` field, present on
+ * `add_comment` / `suggest_changes` operation arguments when the caller
+ * echoes a `blockTextHash` returned by an earlier `read_document` /
+ * `read_section` / `find_text` call. Guards the eventual apply against a
+ * document edit made between that read and this call — `execute.ts`
+ * otherwise has no way to distinguish "the model never read this block" from
+ * "the model read it and it has since changed".
+ *
+ * Returns `undefined` when omitted, the parsed precondition when valid, or a
+ * plain-language error string otherwise.
+ */
+const readOperationPrecondition = (
+  value: unknown,
+): { blockTextHash: string } | undefined | string => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(value)) {
+    return "`precondition` must be an object when provided.";
+  }
+  const blockTextHash = value["blockTextHash"];
+  if (!isNonEmptyString(blockTextHash) || !NORMALIZED_TEXT_HASH_PATTERN.test(blockTextHash)) {
+    return "`precondition.blockTextHash` must be a normalized block text hash, echoed from read_document / read_section / find_text.";
+  }
+  return { blockTextHash };
+};
+
 /** Mutable running budget threaded through {@link buildSuggestedOperation} for one `suggest_changes` call. */
 type TextBudget = { remaining: number };
 
@@ -98,6 +129,10 @@ export const parseAddCommentInput = (args: unknown): ParseAddCommentResult => {
   if (typeof quote === "string" && quote.length > MAX_OPERATION_TEXT_LENGTH) {
     return { ok: false, error: explainTextTooLong("add_comment's `quote`", quote.length) };
   }
+  const precondition = readOperationPrecondition(args["precondition"]);
+  if (typeof precondition === "string") {
+    return { ok: false, error: `add_comment's ${precondition}` };
+  }
 
   const comment: FolioAIComment = { text };
   const operation: FolioAIEditOperation = {
@@ -106,6 +141,7 @@ export const parseAddCommentInput = (args: unknown): ParseAddCommentResult => {
     blockId,
     comment,
     ...(quote !== undefined ? { quote } : {}),
+    ...(precondition !== undefined ? { precondition } : {}),
   };
   return { ok: true, operation };
 };
@@ -168,13 +204,19 @@ const readTextRange = (value: unknown, index: number): FolioAITextRangeHandle | 
   if (typeof endOffset !== "number" || !Number.isInteger(endOffset) || endOffset <= startOffset) {
     return `${path}.endOffset must be an integer greater than startOffset.`;
   }
-  if (!isNonEmptyString(selectedTextHash) || !/^h[0-9a-z]+$/.test(selectedTextHash)) {
+  if (!isNonEmptyString(selectedTextHash) || !NORMALIZED_TEXT_HASH_PATTERN.test(selectedTextHash)) {
     return `${path}.selectedTextHash must be a normalized text hash.`;
   }
   return { type, story, blockId, startOffset, endOffset, selectedTextHash };
 };
 
-/** Validate + map one `suggest_changes` operation, or return a plain-language error string. */
+/**
+ * Validate + map one `suggest_changes` operation, or return a plain-language
+ * error string. Parses the shared `precondition` field itself (every
+ * operation variant accepts it, so it does not belong to any one type's
+ * branch below) and merges it onto whatever {@link buildSuggestedOperationCore}
+ * builds.
+ */
 const buildSuggestedOperation = (
   raw: unknown,
   index: number,
@@ -183,6 +225,23 @@ const buildSuggestedOperation = (
   if (!isPlainObject(raw)) {
     return `operations[${index}] must be an object.`;
   }
+  const precondition = readOperationPrecondition(raw["precondition"]);
+  if (typeof precondition === "string") {
+    return `operations[${index}] ${precondition}`;
+  }
+  const built = buildSuggestedOperationCore(raw, index, budget);
+  if (typeof built === "string") {
+    return built;
+  }
+  return precondition === undefined ? built : { ...built, precondition };
+};
+
+/** Type-and-shape-specific half of {@link buildSuggestedOperation}. */
+const buildSuggestedOperationCore = (
+  raw: Record<string, unknown>,
+  index: number,
+  budget: TextBudget,
+): FolioAIEditOperation | string => {
   const type = raw["type"];
   const blockId = raw["blockId"];
   const id = raw["id"];

--- a/packages/agents/src/parse.ts
+++ b/packages/agents/src/parse.ts
@@ -35,9 +35,36 @@ export const MAX_OPERATIONS_PER_CALL = 50;
 export const MAX_OPERATION_TEXT_LENGTH = 100_000;
 const MAX_TABLE_INSERTION_CELL_TEXTS = 256;
 
+/**
+ * Aggregate cap on the SUM of every text-bearing field's length across one
+ * `suggest_changes` call. Each field alone is bounded by
+ * {@link MAX_OPERATION_TEXT_LENGTH} and each call by
+ * {@link MAX_OPERATIONS_PER_CALL} operations, but an operation can carry
+ * several capped fields (e.g. `comment` plus `text`), and a table-insertion
+ * operation can carry up to {@link MAX_TABLE_INSERTION_CELL_TEXTS} capped
+ * cell texts — so a maximally-shaped batch could still push roughly
+ * 50 * 256 * 100,000 ~= 1.28B characters into the tracked-changes engine in
+ * one call even though every per-field cap was respected. This budget bounds
+ * the running total instead.
+ */
+export const MAX_TOTAL_OPERATION_TEXT_LENGTH = 2_000_000;
+
 /** Plain-language error for a string argument over {@link MAX_OPERATION_TEXT_LENGTH}. */
 export const explainTextTooLong = (label: string, length: number): string =>
   `${label} is ${length.toLocaleString()} characters, over the ${MAX_OPERATION_TEXT_LENGTH.toLocaleString()}-character limit; shorten it or split it into multiple operations.`;
+
+/** Plain-language error when the running total across all operations exceeds {@link MAX_TOTAL_OPERATION_TEXT_LENGTH}. */
+const explainAggregateTextTooLong = (index: number): string =>
+  `operations[${index}] pushes suggest_changes' combined text over the ${MAX_TOTAL_OPERATION_TEXT_LENGTH.toLocaleString()}-character aggregate limit across all operations; split the edit across multiple suggest_changes calls.`;
+
+/** Mutable running budget threaded through {@link buildSuggestedOperation} for one `suggest_changes` call. */
+type TextBudget = { remaining: number };
+
+/** Decrement the shared budget by `length`; returns true once the aggregate cap is exceeded. */
+const consumeTextBudget = (budget: TextBudget, length: number): boolean => {
+  budget.remaining -= length;
+  return budget.remaining < 0;
+};
 
 /** Result of {@link parseAddCommentInput}. */
 export type ParseAddCommentResult =
@@ -148,7 +175,11 @@ const readTextRange = (value: unknown, index: number): FolioAITextRangeHandle | 
 };
 
 /** Validate + map one `suggest_changes` operation, or return a plain-language error string. */
-const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperation | string => {
+const buildSuggestedOperation = (
+  raw: unknown,
+  index: number,
+  budget: TextBudget,
+): FolioAIEditOperation | string => {
   if (!isPlainObject(raw)) {
     return `operations[${index}] must be an object.`;
   }
@@ -166,8 +197,13 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
   if (comment !== undefined && typeof comment !== "string") {
     return `operations[${index}].comment must be a string when provided.`;
   }
-  if (typeof comment === "string" && comment.length > MAX_OPERATION_TEXT_LENGTH) {
-    return explainTextTooLong(`operations[${index}].comment`, comment.length);
+  if (typeof comment === "string") {
+    if (comment.length > MAX_OPERATION_TEXT_LENGTH) {
+      return explainTextTooLong(`operations[${index}].comment`, comment.length);
+    }
+    if (consumeTextBudget(budget, comment.length)) {
+      return explainAggregateTextTooLong(index);
+    }
   }
   const opId = isNonEmptyString(id) ? id : `op-${index + 1}`;
   const commentField = typeof comment === "string" ? { comment: { text: comment } } : {};
@@ -211,6 +247,9 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
     if (replace.length > MAX_OPERATION_TEXT_LENGTH) {
       return explainTextTooLong(`operations[${index}] (replaceRange) \`replace\``, replace.length);
     }
+    if (consumeTextBudget(budget, replace.length)) {
+      return explainAggregateTextTooLong(index);
+    }
     return { id: opId, type, range, replace, ...commentField };
   }
 
@@ -240,6 +279,9 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
           `operations[${index}] (${type}) \`cellTexts[${cellIndex}]\``,
           cellText.length,
         );
+      }
+      if (consumeTextBudget(budget, cellText.length)) {
+        return explainAggregateTextTooLong(index);
       }
       cellTexts.push(cellText);
     }
@@ -282,6 +324,9 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
     if (find.length > MAX_OPERATION_TEXT_LENGTH) {
       return explainTextTooLong(`operations[${index}] (replaceInBlock) \`find\``, find.length);
     }
+    if (consumeTextBudget(budget, find.length)) {
+      return explainAggregateTextTooLong(index);
+    }
     if (typeof replace !== "string") {
       return `operations[${index}] (replaceInBlock) requires a string \`replace\`.`;
     }
@@ -290,6 +335,9 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
         `operations[${index}] (replaceInBlock) \`replace\``,
         replace.length,
       );
+    }
+    if (consumeTextBudget(budget, replace.length)) {
+      return explainAggregateTextTooLong(index);
     }
     return { id: opId, type, blockId, find, replace, ...commentField };
   }
@@ -301,6 +349,9 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
     if (text.length > MAX_OPERATION_TEXT_LENGTH) {
       return explainTextTooLong(`operations[${index}] (${type}) \`text\``, text.length);
     }
+    if (consumeTextBudget(budget, text.length)) {
+      return explainAggregateTextTooLong(index);
+    }
     return { id: opId, type, blockId, text, ...commentField };
   }
   if (type === "replaceBlock") {
@@ -310,6 +361,9 @@ const buildSuggestedOperation = (raw: unknown, index: number): FolioAIEditOperat
     }
     if (text.length > MAX_OPERATION_TEXT_LENGTH) {
       return explainTextTooLong(`operations[${index}] (replaceBlock) \`text\``, text.length);
+    }
+    if (consumeTextBudget(budget, text.length)) {
+      return explainAggregateTextTooLong(index);
     }
     return { id: opId, type, blockId, text, ...commentField };
   }
@@ -343,8 +397,9 @@ export const parseSuggestChangesInput = (args: unknown): ParseSuggestChangesResu
   }
 
   const operations: FolioAIEditOperation[] = [];
+  const budget: TextBudget = { remaining: MAX_TOTAL_OPERATION_TEXT_LENGTH };
   for (const [index, raw] of rawOperations.entries()) {
-    const built = buildSuggestedOperation(raw, index);
+    const built = buildSuggestedOperation(raw, index, budget);
     if (typeof built === "string") {
       return { ok: false, error: built };
     }

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -3,7 +3,7 @@ import {
   type FolioDocumentOperationType,
 } from "@stll/folio-core/server";
 
-import { FOLIO_TEXT_RANGE_JSON_SCHEMA } from "./operation-schema";
+import { FOLIO_PRECONDITION_JSON_SCHEMA, FOLIO_TEXT_RANGE_JSON_SCHEMA } from "./operation-schema";
 import { FOLIO_AGENT_TOOL_NAMES } from "./types";
 import type { FolioAgentToolDefinition } from "./types";
 
@@ -58,10 +58,12 @@ const scopedHandleSchema = {
  *   where the contract requires it;
  * - `comment` is a plain string here; `parse.ts` wraps it into the contract's
  *   `{ text }` object;
- * - the review metadata (`severity`, `area`), `precondition` guard, and the
- *   insert/replace formatting knobs (`inheritFormatting`, `pageBreakBefore`,
- *   `preserveFormatting`, `styleId`, `parties`, `quote`,
- *   except `formatting`) are not exposed to the model.
+ * - the review metadata (`severity`, `area`) and the insert/replace
+ *   formatting knobs (`inheritFormatting`, `pageBreakBefore`,
+ *   `preserveFormatting`, `styleId`, `parties`, `quote`, except `formatting`)
+ *   are not exposed to the model. `precondition` IS exposed (see
+ *   `FOLIO_PRECONDITION_JSON_SCHEMA`) so the model can guard an edit against
+ *   staleness introduced between an earlier read and this call.
  */
 const SUGGEST_CHANGES_EXCLUDED_OPERATION_TYPES: ReadonlySet<FolioDocumentOperationType> = new Set([
   "commentOnBlock",
@@ -157,6 +159,7 @@ const suggestChangesOperationSchema = {
       description:
         "Optional comment explaining this edit, attached to the affected text, up to 100,000 characters.",
     },
+    precondition: FOLIO_PRECONDITION_JSON_SCHEMA,
   },
   required: ["type"],
   additionalProperties: false,
@@ -175,7 +178,9 @@ export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[] = [
     name: FOLIO_AGENT_TOOL_NAMES.readDocument,
     description:
       "Read the full document body as a list of blocks (paragraphs, headings, list items). Call this first, " +
-      "or whenever you need fresh block ids after a mutation — block ids from a stale read may no longer resolve.",
+      "or whenever you need fresh block ids after a mutation — block ids from a stale read may no longer " +
+      "resolve. Each block includes a `blockTextHash`; echo it as `precondition.blockTextHash` on a " +
+      "suggest_changes / add_comment operation to guard against the block changing before that call runs.",
     inputSchema: {
       type: "object",
       properties: {},
@@ -206,7 +211,8 @@ export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[] = [
     name: FOLIO_AGENT_TOOL_NAMES.readSection,
     description:
       "Read one logical heading section using a handle from get_document_outline. Content is block-bounded " +
-      "and paginated with an afterBlockId cursor, avoiding a full-document read.",
+      "and paginated with an afterBlockId cursor, avoiding a full-document read. Each block includes a " +
+      "`blockTextHash`; echo it as `precondition.blockTextHash` on a suggest_changes / add_comment operation.",
     inputSchema: {
       type: "object",
       properties: {
@@ -252,8 +258,9 @@ export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[] = [
     name: FOLIO_AGENT_TOOL_NAMES.findText,
     description:
       "Search a document, section, rendered page, or story and return `{ matches, truncated, totalMatches }`. " +
-      "Main-story matches include a stable block and exact range; other stories return story-relative offsets. " +
-      "Every match includes surrounding context. `matches` is " +
+      "Main-story matches include a stable block, exact range, and `blockTextHash` (echo it as " +
+      "`precondition.blockTextHash` on a later suggest_changes / add_comment operation); other stories return " +
+      "story-relative offsets. Every match includes surrounding context. `matches` is " +
       "capped at 200 entries; `truncated` is true and `totalMatches` reports the real count when there were " +
       "more — narrow the query or scope instead of assuming you saw every hit.",
     inputSchema: {
@@ -337,6 +344,7 @@ export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[] = [
             "Optional exact text within the block this comment is about, up to 100,000 characters.",
         },
         text: { type: "string", description: "The comment body, up to 100,000 characters." },
+        precondition: FOLIO_PRECONDITION_JSON_SCHEMA,
       },
       required: ["blockId", "text"],
       additionalProperties: false,
@@ -347,7 +355,9 @@ export const FOLIO_AGENT_TOOLS: FolioAgentToolDefinition[] = [
     description:
       "Propose one or more edits as tracked changes for a human to accept or reject — nothing is applied " +
       "directly to the visible text. Each operation needs a blockId from `read_document` or `find_text`; if the " +
-      "document changed since that read, re-read it and retry with fresh ids (a skip reason will say so). At " +
+      "document changed since that read, re-read it and retry with fresh ids (a skip reason will say so). Pass " +
+      "the `blockTextHash` from that read as `precondition.blockTextHash` to guard against the document " +
+      "changing between the read and this call. At " +
       "most 50 operations per call — batch larger edits across multiple calls. Each `find` / `replace` / " +
       "`text` / `comment` string is capped at 100,000 characters.",
     inputSchema: {

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -66,6 +66,15 @@ export type FolioAgentBlock = {
   blockId: string;
   kind: string;
   text: string;
+  /**
+   * Normalized-text hash of this block at read time. Echo it back as
+   * `precondition.blockTextHash` on a `suggest_changes` / `add_comment`
+   * operation targeting this block so the apply call is guarded against
+   * edits made to the document between this read and that apply — without
+   * it, only same-call staleness within one `suggest_changes` batch is
+   * caught.
+   */
+  blockTextHash: string;
 };
 
 /** One main-story `find_text` match. Existing consumers can keep using its block and range directly. */
@@ -74,6 +83,8 @@ export type FolioAgentTextMatch = {
   type?: "main";
   story?: { type: "main" };
   blockId: string;
+  /** Normalized-text hash of the whole containing block; see {@link FolioAgentBlock.blockTextHash}. */
+  blockTextHash: string;
   /** Stable handle that can be passed directly to `show_in_document` or a range operation. */
   range: FolioAITextRangeHandle;
   /** 0-based index of this occurrence within its block. */

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -3805,7 +3805,11 @@ describe("Folio AI edit operations", () => {
             _originalFormatting: { vMerge: "restart" },
             _docxVMergeContinuationCells: continuationCells,
           },
-          [schema.node("paragraph", { paraId: "wide-continuation-split" }, [schema.text("Content")])],
+          [
+            schema.node("paragraph", { paraId: "wide-continuation-split" }, [
+              schema.text("Content"),
+            ]),
+          ],
         ),
       ]),
       schema.node("tableRow"),

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -44,6 +44,7 @@ const schema = new Schema({
       attrs: {
         trIns: { default: null },
         trDel: { default: null },
+        hidden: { default: false },
       },
     },
     tableCell: {
@@ -531,6 +532,31 @@ describe("Folio AI edit operations", () => {
     expect(snapshot.blocks).toEqual([]);
     expect(snapshot.emptyDocumentAnchorId).toBeUndefined();
     expect(snapshot.anchors).toEqual({});
+  });
+
+  test("hides text inside a hidden table row from the AI-facing snapshot", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", { hidden: true }, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("Hidden secret")]),
+          ]),
+        ]),
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("Visible")]),
+          ]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc });
+
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+
+    expect(snapshot.blocks.map((block) => block.text)).toEqual(["Visible"]);
+    expect(
+      Object.values(snapshot.anchors).some((anchor) => anchor.text.includes("Hidden secret")),
+    ).toBe(false);
   });
 
   test("snapshot uses sequential fallback ids for duplicate paraIds", () => {

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -3747,6 +3747,62 @@ describe("Folio AI edit operations", () => {
     );
   });
 
+  test("tracked splitting refuses to restore a stored continuation cell with gridSpan > 1", () => {
+    // Regression guard: splitTrackedVerticalTableCell only ever restores a
+    // single-column rectangle (the caller enforces
+    // `rectangle.right - rectangle.left === 1`), so a restored continuation
+    // cell must be colspan 1. `_docxVMergeContinuationCells` entries are
+    // captured from a prior (possibly attacker-crafted) parse; a stored
+    // gridSpan > 1 must be refused instead of silently widening the
+    // restored cell across multiple columns.
+    const continuationCells = [
+      {
+        type: "tableCell" as const,
+        formatting: {
+          vMerge: "continue" as const,
+          gridSpan: 5,
+        },
+        content: [
+          {
+            type: "paragraph" as const,
+            content: [{ type: "run" as const, content: [{ type: "text" as const, text: "Wide" }] }],
+          },
+        ],
+      },
+    ];
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node(
+          "tableCell",
+          {
+            rowspan: 2,
+            _originalFormatting: { vMerge: "restart" },
+            _docxVMergeContinuationCells: continuationCells,
+          },
+          [schema.node("paragraph", { paraId: "wide-continuation-split" }, [schema.text("Content")])],
+        ),
+      ]),
+      schema.node("tableRow"),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        { id: "split-cell", type: "splitTableCell", blockId: "wide-continuation-split" },
+      ],
+      mode: "tracked-changes",
+    });
+
+    expect(result.applied).toEqual([]);
+    expect(result.skipped).toEqual([{ id: "split-cell", reason: "unsupportedBlock" }]);
+    const untouchedTable = view.state.doc.child(0);
+    expect(untouchedTable.child(0).child(0).attrs["rowspan"]).toBe(2);
+    expect(untouchedTable.child(1).childCount).toBe(0);
+  });
+
   test("tracked splitting rejects a horizontal span without mutation", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [

--- a/packages/core/src/ai-edits/blockRange.test.ts
+++ b/packages/core/src/ai-edits/blockRange.test.ts
@@ -158,6 +158,16 @@ describe("resolveFolioAIBlockRange", () => {
 
     expect(resolveFolioAIBlockRange({ blockId: "seq-0009", doc: liveDoc })).toBeNull();
   });
+
+  test("returns null instead of resolving Object.prototype for a __proto__ block id", () => {
+    // A plain `anchors[blockId]` lookup resolves "__proto__" to
+    // Object.prototype instead of undefined, which then has no `from`/`to`
+    // and yields NaN positions further down. An untrusted blockId (e.g.
+    // from an agent tool call) must fail cleanly instead.
+    const liveDoc = makeDoc([{ paraId: "0A0A0A0A", text: "Only" }]);
+
+    expect(resolveFolioAIBlockRange({ blockId: "__proto__", doc: liveDoc })).toBeNull();
+  });
 });
 
 describe("resolveFolioAITextRange", () => {

--- a/packages/core/src/ai-edits/blockRange.ts
+++ b/packages/core/src/ai-edits/blockRange.ts
@@ -38,8 +38,13 @@ export const resolveFolioAIBlockRange = ({
   }
 
   const resolvedSnapshot = snapshot ?? createFolioAIEditSnapshot(doc);
-  const anchor =
-    resolvedSnapshot.anchors[blockId] ?? resolveSequentialBlockAnchor(blockId, resolvedSnapshot);
+  // A plain indexed lookup resolves "__proto__" to Object.prototype instead
+  // of undefined, which then passes the `!anchor` check below with no
+  // `from`/`to` fields and yields NaN positions. Require an own property
+  // before trusting the lookup.
+  const anchor = Object.hasOwn(resolvedSnapshot.anchors, blockId)
+    ? resolvedSnapshot.anchors[blockId]
+    : resolveSequentialBlockAnchor(blockId, resolvedSnapshot);
   if (!anchor) {
     return null;
   }

--- a/packages/core/src/ai-edits/clean-text.ts
+++ b/packages/core/src/ai-edits/clean-text.ts
@@ -37,9 +37,7 @@ export const buildCleanBlockText = (blockNode: PMNode, blockFrom: number): Clean
       return true;
     }
     if (
-      node.marks.some(
-        (mark) => mark.type.name === DELETION_MARK || mark.type.name === HIDDEN_MARK,
-      )
+      node.marks.some((mark) => mark.type.name === DELETION_MARK || mark.type.name === HIDDEN_MARK)
     ) {
       // Skip the run entirely (deleted, or OOXML w:vanish hidden text).
       // Don't update lastEnd — if the next surviving char sits right

--- a/packages/core/src/ai-edits/clean-text.ts
+++ b/packages/core/src/ai-edits/clean-text.ts
@@ -26,6 +26,7 @@ export type CleanBlockText = {
 const DELETION_MARK = "deletion";
 const INSERTION_MARK = "insertion";
 const COMMENT_MARK = "comment";
+const HIDDEN_MARK = "hidden";
 
 export const buildCleanBlockText = (blockNode: PMNode, blockFrom: number): CleanBlockText => {
   let text = "";
@@ -35,11 +36,15 @@ export const buildCleanBlockText = (blockNode: PMNode, blockFrom: number): Clean
     if (!node.isText || node.text === undefined) {
       return true;
     }
-    if (node.marks.some((mark) => mark.type.name === DELETION_MARK)) {
-      // Skip the run entirely. Don't update lastEnd — if the next
-      // surviving char sits right after the deletion in the live
-      // doc, we still want offsets to anchor at the live position
-      // (which sits past the skipped run).
+    if (
+      node.marks.some(
+        (mark) => mark.type.name === DELETION_MARK || mark.type.name === HIDDEN_MARK,
+      )
+    ) {
+      // Skip the run entirely (deleted, or OOXML w:vanish hidden text).
+      // Don't update lastEnd — if the next surviving char sits right
+      // after the skipped run in the live doc, we still want offsets to
+      // anchor at the live position (which sits past the skipped run).
       return false;
     }
     const startPos = blockFrom + 1 + pos;

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -55,6 +55,26 @@ export const createFolioAITextRangeHandle = ({
   };
 };
 
+const TABLE_ROW_NODE_NAME = "tableRow";
+
+/**
+ * True when `pos`'s nearest `tableRow` ancestor is marked `hidden` (OOXML
+ * `w:trPr/w:hidden` — Word never renders the row). A textblock inside such a
+ * row must not surface its text to the AI/agent snapshot: an attacker DOCX
+ * could otherwise smuggle prompt-injection instructions into a row that no
+ * human ever sees.
+ */
+const isInHiddenTableRow = (doc: PMNode, pos: number): boolean => {
+  const $pos = doc.resolve(pos);
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const ancestor = $pos.node(depth);
+    if (ancestor.type.name === TABLE_ROW_NODE_NAME) {
+      return ancestor.attrs["hidden"] === true;
+    }
+  }
+  return false;
+};
+
 export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   const draftBlocks: {
     block: FolioAIBlock;
@@ -70,7 +90,13 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   let blockIndex = 0;
   doc.descendants((node, pos, parent) => {
     if (!node.isTextblock) {
-      return;
+      return true;
+    }
+
+    if (isInHiddenTableRow(doc, pos)) {
+      // Don't descend into a hidden row's content — nothing inside it
+      // should reach the AI-facing snapshot.
+      return false;
     }
 
     // Snapshot the AI-facing text in its post-tracked-changes
@@ -84,7 +110,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     const normalizedText = normalizeFolioAIBlockText(text);
     if (normalizedText.length === 0) {
       if (parent?.type !== doc.type) {
-        return;
+        return true;
       }
       emptyAnchorState.textblockCount++;
       if (emptyAnchorState.candidate === null) {
@@ -95,7 +121,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
           paraId: typeof paraIdAttr === "string" && paraIdAttr.length > 0 ? paraIdAttr : null,
         };
       }
-      return;
+      return true;
     }
 
     const textHash = hashFolioAIBlockText(normalizedText);
@@ -145,6 +171,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
         textHash,
       },
     });
+    return true;
   });
 
   const blocks: FolioAIBlock[] = [];

--- a/packages/core/src/ai-edits/table-cell-mutations.ts
+++ b/packages/core/src/ai-edits/table-cell-mutations.ts
@@ -416,6 +416,16 @@ const trackedSplitCellFromStoredSource = ({
   source,
   marker,
 }: TrackedSplitCellFromStoredSourceOptions): PMNode | null => {
+  // splitTrackedVerticalTableCell only ever calls this to restore a single
+  // COLUMN-wide continuation cell (the caller already enforces
+  // `rectangle.right - rectangle.left === 1`), so the restored cell must be
+  // colspan 1. `source` is a stored vMerge-continuation cell captured from a
+  // prior (possibly attacker-supplied) parse; trusting its `gridSpan`
+  // wholesale would let a crafted document restore a cell spanning many
+  // columns here. Reject rather than silently widening the cell.
+  if (source.formatting?.gridSpan !== undefined && source.formatting.gridSpan > 1) {
+    return null;
+  }
   const formatting = formattingWithoutVerticalMerge(source.formatting);
   const restoredSource: TableCell = {
     type: "tableCell",

--- a/packages/core/src/ai-edits/word-diff.test.ts
+++ b/packages/core/src/ai-edits/word-diff.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for diffWordSegments: correctness of the normal O(n*m) LCS path,
+ * plus a regression guard for the MAX_WORD_DIFF_CELLS bounded fallback.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { diffWordSegments } from "./word-diff";
+
+describe("diffWordSegments", () => {
+  test("reconstructs both strings from equal/del/ins segments for a small replacement", () => {
+    const before = "The quick fox jumps.";
+    const after = "The slow fox jumps.";
+
+    const segments = diffWordSegments(before, after);
+
+    const reconstructedBefore = segments
+      .filter((s) => s.type !== "ins")
+      .map((s) => s.text)
+      .join("");
+    const reconstructedAfter = segments
+      .filter((s) => s.type !== "del")
+      .map((s) => s.text)
+      .join("");
+    expect(reconstructedBefore).toBe(before);
+    expect(reconstructedAfter).toBe(after);
+    // "quick" -> "slow" is the only divergence; everything else is shared.
+    expect(segments.some((s) => s.type === "del" && s.text.includes("quick"))).toBe(true);
+    expect(segments.some((s) => s.type === "ins" && s.text.includes("slow"))).toBe(true);
+  });
+
+  test("returns empty segments for two empty strings", () => {
+    expect(diffWordSegments("", "")).toEqual([]);
+  });
+
+  test("falls back to a single whole-string del+ins pair once the token-count product exceeds MAX_WORD_DIFF_CELLS", () => {
+    // Regression guard for the word-diff DoS fix: diffWordSegments used to
+    // allocate an unbounded (m+1)*(n+1) DP table for two attacker-controlled
+    // strings inside one `modified` block pair. 2,001 distinct words each
+    // tokenize (tokenize() also emits the whitespace runs as their own
+    // tokens) to 4,001 tokens; 4,001 * 4,001 = 16,008,001 cells, well over
+    // the 4,000,000-cell budget, so the DP must be skipped entirely.
+    const before = Array.from({ length: 2001 }, (_, i) => `before${i}`).join(" ");
+    const after = Array.from({ length: 2001 }, (_, i) => `after${i}`).join(" ");
+
+    const segments = diffWordSegments(before, after);
+
+    expect(segments).toEqual([
+      { type: "del", text: before },
+      { type: "ins", text: after },
+    ]);
+  });
+});

--- a/packages/core/src/ai-edits/word-diff.ts
+++ b/packages/core/src/ai-edits/word-diff.ts
@@ -17,6 +17,16 @@ export type WordDiffSegment = {
 
 const tokenize = (s: string): string[] => s.match(/\s+|\S+/gu) ?? [];
 
+/**
+ * Cell budget for the O(n*m) word-diff DP table below, mirroring
+ * `MAX_LCS_CELLS` in `version-comparison.ts`. `before`/`after` come from
+ * attacker-controlled document text (a `modified` block pair), so an
+ * unbounded pair of large strings would otherwise force a quadratic-sized
+ * allocation. Past this budget, skip the DP and fall back to a single
+ * whole-string `del` + `ins` pair — a coarser diff, but O(1) memory.
+ */
+const MAX_WORD_DIFF_CELLS = 4_000_000;
+
 export const diffWordSegments = (before: string, after: string): WordDiffSegment[] => {
   const a = tokenize(before);
   const b = tokenize(after);
@@ -25,6 +35,16 @@ export const diffWordSegments = (before: string, after: string): WordDiffSegment
   }
   const m = a.length;
   const n = b.length;
+  if (m * n > MAX_WORD_DIFF_CELLS) {
+    const segments: WordDiffSegment[] = [];
+    if (before.length > 0) {
+      segments.push({ type: "del", text: before });
+    }
+    if (after.length > 0) {
+      segments.push({ type: "ins", text: after });
+    }
+    return segments;
+  }
   const dp: number[][] = Array.from({ length: m + 1 }, () =>
     Array.from({ length: n + 1 }, () => 0),
   );

--- a/packages/core/src/controller/hiddenEditorManager.ts
+++ b/packages/core/src/controller/hiddenEditorManager.ts
@@ -98,6 +98,17 @@ type AwarenessUser = {
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+/**
+ * A remote collaborator's awareness `user.color` is read from another
+ * peer's Yjs awareness state — effectively untrusted network input — and
+ * gets fed straight into `element.style.background`/`backgroundColor` (see
+ * `RemoteSelectionOverlay`). Restrict it to a plain 6-digit hex color before
+ * accepting it so a crafted value (e.g. a CSS `url(...)` payload) can't ride
+ * along as a CSS-injection / beacon vector; anything else falls back to the
+ * default selection color below.
+ */
+const AWARENESS_HEX_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/u;
+
 const isYSyncState = (value: unknown, yjs: YjsModule): value is YSyncState => {
   if (!isObjectRecord(value)) {
     return false;
@@ -136,8 +147,13 @@ const readAwarenessUser = (state: unknown, clientId: number): AwarenessUser => {
   }
 
   const user = state["user"];
+  const rawColor = user["color"];
+  const color =
+    typeof rawColor === "string" && AWARENESS_HEX_COLOR_PATTERN.test(rawColor)
+      ? rawColor
+      : "var(--doc-image-selection)";
   return {
-    color: typeof user["color"] === "string" ? user["color"] : "var(--doc-image-selection)",
+    color,
     name: typeof user["name"] === "string" ? user["name"] : `User ${clientId}`,
   };
 };

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -103,6 +103,26 @@ describe("document operation contract", () => {
     expect(FOLIO_DOCUMENT_OPERATION_BATCH_MODES).toEqual(["best-effort", "atomic"]);
   });
 
+  test("rejects prototype-key operation types instead of resolving inherited members", () => {
+    // A plain indexed lookup on FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE
+    // resolves "__proto__" / "constructor" / "toString" to an inherited
+    // Object.prototype member instead of undefined, which would otherwise
+    // reach `.includes` on a non-array value and throw. Untrusted input
+    // (e.g. a document-operation batch parsed from an agent tool call) must
+    // be rejected cleanly instead.
+    for (const operationType of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
+      expect(
+        Reflect.apply(isFolioDocumentOperationModeSupported, null, [operationType, "direct"]),
+      ).toBe(false);
+      expect(
+        Reflect.apply(isFolioDocumentOperationModeSupported, null, [
+          operationType,
+          "tracked-changes",
+        ]),
+      ).toBe(false);
+    }
+  });
+
   test("checks untyped contract versions at a serialization boundary", () => {
     expect(isSupportedFolioDocumentOperationVersion(1)).toBe(true);
     expect(isSupportedFolioDocumentOperationVersion("1")).toBe(false);

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -133,10 +133,14 @@ export const isFolioDocumentOperationModeSupported = (
   operationType: FolioDocumentOperationType,
   mode: FolioDocumentOperationMode,
 ): boolean => {
-  const supportedModes = FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE[operationType];
-  if (supportedModes === undefined) {
+  // A plain indexed lookup resolves "__proto__" / "constructor" / "toString"
+  // to an inherited Object.prototype member instead of undefined — an
+  // untrusted `operationType` string must be checked as an own property
+  // first, or the `.includes` call below throws on that non-array value.
+  if (!Object.hasOwn(FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE, operationType)) {
     return false;
   }
+  const supportedModes = FOLIO_DOCUMENT_OPERATION_MODES_BY_TYPE[operationType];
   return includesDocumentOperationMode(supportedModes, mode);
 };
 

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -124,6 +124,12 @@ type ComputeListMarkerOptions = {
   abstractCounters: Map<number, number[]>;
   restartedNumIds: Set<number>;
   previousList: PreviousListState;
+  /**
+   * `numId`s sharing each `abstractNumId`, populated as each `numId` is
+   * first seen. Lets resume-propagation below look up sibling instances
+   * directly instead of scanning every `numId` ever seen in the document.
+   */
+  siblingNumIdsByAbstractNumId: Map<number, Set<number>>;
 };
 
 const computeListMarker = (
@@ -134,6 +140,7 @@ const computeListMarker = (
     abstractCounters,
     restartedNumIds,
     previousList,
+    siblingNumIdsByAbstractNumId,
   }: ComputeListMarkerOptions,
 ): void => {
   const listRendering = paragraph.listRendering;
@@ -163,6 +170,14 @@ const computeListMarker = (
   }
 
   const abstractNumId = numbering.getAbstractNumId(numId);
+  if (firstEncounter && abstractNumId !== null) {
+    let siblingNumIds = siblingNumIdsByAbstractNumId.get(abstractNumId);
+    if (!siblingNumIds) {
+      siblingNumIds = new Set();
+      siblingNumIdsByAbstractNumId.set(abstractNumId, siblingNumIds);
+    }
+    siblingNumIds.add(numId);
+  }
   const styleNumbering = paragraph.formatting?.numPrFromStyle;
   let resumedAbstractCounters: number[] | undefined;
   const resumesRestartedInstance =
@@ -241,10 +256,12 @@ const computeListMarker = (
 
   if (abstractNumId !== null) {
     if (resumedAbstractCounters) {
-      for (const [otherNumId, otherCounters] of listCounters) {
+      const siblingNumIds = siblingNumIdsByAbstractNumId.get(abstractNumId);
+      for (const otherNumId of siblingNumIds ?? []) {
+        const otherCounters = listCounters.get(otherNumId);
         if (
           otherNumId === numId ||
-          numbering.getAbstractNumId(otherNumId) !== abstractNumId ||
+          !otherCounters ||
           !otherCounters.every((value, index) => Object.is(value, resumedAbstractCounters[index]))
         ) {
           continue;
@@ -295,6 +312,7 @@ type ParseBlockContentState = {
   abstractCounters: Map<number, number[]>;
   restartedNumIds: Set<number>;
   previousList: PreviousListState;
+  siblingNumIdsByAbstractNumId: Map<number, Set<number>>;
   options: ParseBlockContentOptions | undefined;
 };
 
@@ -312,6 +330,7 @@ export const parseBlockContent = (
     abstractCounters: new Map(),
     restartedNumIds: new Set(),
     previousList: { abstractNumId: null, fromStyle: false, numId: null },
+    siblingNumIdsByAbstractNumId: new Map(),
     // Accumulate the container's own xmlns onto the inherited in-scope set so a
     // captured VML `w:pict` replay resolves prefixes scoped on this level too.
     options: {
@@ -347,6 +366,7 @@ const parseBlockContentWithState = (
         abstractCounters: state.abstractCounters,
         restartedNumIds: state.restartedNumIds,
         previousList: state.previousList,
+        siblingNumIdsByAbstractNumId: state.siblingNumIdsByAbstractNumId,
       });
       content.push(paragraph);
       continue;

--- a/packages/core/src/docx/conformance.test.ts
+++ b/packages/core/src/docx/conformance.test.ts
@@ -83,4 +83,15 @@ describe("DOCX conformance detection", () => {
       DOCX_CONFORMANCE_CLASSES.TRANSITIONAL,
     );
   });
+
+  test("scans a large quote-heavy tag prefix with no closing '>' in linear time", () => {
+    // A regex-based scanner with `(?:[^>"']|"[^"]*"|'[^']*')*` here is
+    // susceptible to catastrophic backtracking once no terminating `>`
+    // exists; the hand-rolled scanner must resolve this in one linear pass.
+    const hostile = `<x:document ${'"'.repeat(65_000)}`;
+    const start = performance.now();
+
+    expect(detectDocxConformanceClass(hostile)).toBe(DOCX_CONFORMANCE_CLASSES.UNKNOWN);
+    expect(performance.now() - start).toBeLessThan(1000);
+  });
 });

--- a/packages/core/src/docx/conformance.ts
+++ b/packages/core/src/docx/conformance.ts
@@ -7,8 +7,93 @@ import { getLocalName, getNamespacePrefix, parseXmlDocument } from "./xmlParser"
 const STRICT_MAIN_NAMESPACE = "http://purl.oclc.org/ooxml/wordprocessingml/main";
 const TRANSITIONAL_MAIN_NAMESPACE = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 const ROOT_START_TAG_SCAN_LIMIT = 64 * 1024;
-const ROOT_START_TAG_PATTERN =
-  /^(?:\uFEFF|\s|<\?[\s\S]*?\?>|<!--[\s\S]*?-->)*(?<tag><[^\s/>]+(?:[^>"']|"[^"]*"|'[^']*')*>)/u;
+const XML_WHITESPACE = /\s/u;
+
+/**
+ * Find the root start tag within a bounded prefix of `document.xml`,
+ * without backtracking.
+ *
+ * Equivalent in captured-tag semantics to the previous
+ * `/^(?:\uFEFF|\s|<\?[\s\S]*?\?>|<!--[\s\S]*?-->)*(?<tag><[^\s/>]+(?:[^>"']|"[^"]*"|'[^']*')*>)/u`
+ * pattern, but as a linear hand-rolled scanner: the original alternation of
+ * greedy/lazy `[\s\S]*?` spans over an attacker-controlled prefix was
+ * susceptible to catastrophic backtracking on crafted input. This walks
+ * `scanTarget` once, tracking in-quote state, and returns `undefined` in
+ * every case the regex would have failed to match (unterminated PI/comment,
+ * no tag found before the scan limit, malformed tag open).
+ */
+function scanRootStartTag(scanTarget: string): string | undefined {
+  const length = scanTarget.length;
+  let index = 0;
+
+  // Skip a BOM / whitespace / processing-instruction / comment prefix, in
+  // any order and any number of times.
+  for (;;) {
+    if (index >= length) {
+      return undefined;
+    }
+    const character = scanTarget[index];
+    if (character === "\uFEFF" || XML_WHITESPACE.test(character ?? "")) {
+      index += 1;
+      continue;
+    }
+    if (scanTarget.startsWith("<?", index)) {
+      const closeIndex = scanTarget.indexOf("?>", index + 2);
+      if (closeIndex === -1) {
+        return undefined;
+      }
+      index = closeIndex + 2;
+      continue;
+    }
+    if (scanTarget.startsWith("<!--", index)) {
+      const closeIndex = scanTarget.indexOf("-->", index + 4);
+      if (closeIndex === -1) {
+        return undefined;
+      }
+      index = closeIndex + 3;
+      continue;
+    }
+    break;
+  }
+
+  // The root start tag must open here: `<` followed by at least one
+  // character that is not whitespace, `/`, or `>`.
+  if (scanTarget[index] !== "<") {
+    return undefined;
+  }
+  const nameStart = index + 1;
+  const firstNameChar = scanTarget[nameStart];
+  if (
+    firstNameChar === undefined ||
+    firstNameChar === "/" ||
+    firstNameChar === ">" ||
+    XML_WHITESPACE.test(firstNameChar)
+  ) {
+    return undefined;
+  }
+
+  // Scan to the first unquoted `>`, honoring single- and double-quoted
+  // attribute values so a `>` inside an attribute (e.g. `data-x="1 > 0"`)
+  // does not end the tag early.
+  let quote: '"' | "'" | undefined;
+  for (let cursor = nameStart; cursor < length; cursor++) {
+    const character = scanTarget[cursor];
+    if (quote) {
+      if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === ">") {
+      return scanTarget.slice(index, cursor + 1);
+    }
+  }
+  return undefined;
+}
 
 export const detectDocxConformanceClass = (documentXml: string | null): DocxConformanceClass => {
   if (documentXml === null) {
@@ -19,7 +104,7 @@ export const detectDocxConformanceClass = (documentXml: string | null): DocxConf
     documentXml.length <= ROOT_START_TAG_SCAN_LIMIT
       ? documentXml
       : documentXml.slice(0, ROOT_START_TAG_SCAN_LIMIT);
-  const rootStartTag = ROOT_START_TAG_PATTERN.exec(scanTarget)?.groups?.["tag"];
+  const rootStartTag = scanRootStartTag(scanTarget);
   const fastRoot =
     rootStartTag === undefined
       ? null

--- a/packages/core/src/docx/documentParser.test.ts
+++ b/packages/core/src/docx/documentParser.test.ts
@@ -169,13 +169,13 @@ describe("parseDocumentBody list numbering", () => {
 describe("parseDocumentBody text box enrichment", () => {
   test("keeps tables in text boxes in source order", () => {
     const textBoxContent = `
-      <w:p w14:paraId="TXBI0001"><w:r><w:t>Before table</w:t></w:r></w:p>
+      <w:p w14:paraId="7B810001"><w:r><w:t>Before table</w:t></w:r></w:p>
       <w:tbl>
         <w:tblPr/>
         <w:tblGrid><w:gridCol w:w="2400"/></w:tblGrid>
-        <w:tr><w:tc><w:tcPr/><w:p w14:paraId="TXBI0002"><w:r><w:t>Cell text</w:t></w:r></w:p></w:tc></w:tr>
+        <w:tr><w:tc><w:tcPr/><w:p w14:paraId="7B810002"><w:r><w:t>Cell text</w:t></w:r></w:p></w:tc></w:tr>
       </w:tbl>
-      <w:p w14:paraId="TXBI0003"><w:r><w:t>After table</w:t></w:r></w:p>`;
+      <w:p w14:paraId="7B810003"><w:r><w:t>After table</w:t></w:r></w:p>`;
     const body = parseDocumentBody(`${XML_DECLARATION}
 <w:document
   xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -206,7 +206,7 @@ describe("parseDocumentBody text box enrichment", () => {
     }
     expect(table.rows.at(0)?.cells.at(0)?.content.at(0)).toMatchObject({
       type: "paragraph",
-      paraId: "TXBI0002",
+      paraId: "7B810002",
     });
   });
 

--- a/packages/core/src/docx/encryption/agileDecryption.ts
+++ b/packages/core/src/docx/encryption/agileDecryption.ts
@@ -15,6 +15,7 @@ import {
   writeUint32Le,
 } from "./cryptoBytes";
 import { DOCX_ENCRYPTION_ERROR_CODES, DocxEncryptionError } from "./errors";
+import { MAX_SPIN_COUNT } from "./encryptionInfo";
 import type { AgileKeyMaterial } from "./encryptionInfo";
 
 /** [MS-OFFCRYPTO] 2.3.4.15 — block keys used during password verification. */
@@ -105,7 +106,15 @@ const decryptAesCbc = async (
   return new Uint8Array(decrypted).subarray(0, ciphertext.length);
 };
 
-/** [MS-OFFCRYPTO] 2.3.4.9 — iterated hash of password + salt. */
+/**
+ * [MS-OFFCRYPTO] 2.3.4.9 — iterated hash of password + salt.
+ *
+ * `iterations` is expected to already be validated by
+ * `encryptionInfo.ts`'s `spinCount` parsing, but this loop drives real
+ * WebCrypto work per iteration, so it is clamped again here as well —
+ * this function must stay safe to call with an untrusted iteration count
+ * regardless of caller.
+ */
 const hashPassword = async (
   password: string,
   salt: Uint8Array,
@@ -113,8 +122,9 @@ const hashPassword = async (
   hashName: string,
 ): Promise<Uint8Array> => {
   const algorithm = webHashName(hashName);
+  const boundedIterations = Math.min(Math.max(iterations, 0), MAX_SPIN_COUNT);
   let state = await digest(algorithm, joinBytes([salt, passwordToUtf16Le(password)]));
-  for (let i = 0; i < iterations; i++) {
+  for (let i = 0; i < boundedIterations; i++) {
     state = await digest(algorithm, joinBytes([writeUint32Le(i), state]));
   }
   return state;

--- a/packages/core/src/docx/encryption/compoundFile.ts
+++ b/packages/core/src/docx/encryption/compoundFile.ts
@@ -132,11 +132,24 @@ const loadSector = (file: Uint8Array, header: CompoundHeader, sectorId: number):
 
 const loadFatSectorIds = (file: Uint8Array, header: CompoundHeader): number[] => {
   const ids = [...header.headerDifat];
+  // A hostile `difatSectorCount` (up to 2^32-1) would otherwise force this
+  // loop to run far more times than the file could possibly contain DIFAT
+  // sectors; a chain that revisits a sector could spin for its full
+  // declared length even at a capped count. Bound the loop by the sectors
+  // the file can actually hold and guard against a cycle, mirroring
+  // `followSectorChain`.
+  const maxDifatSectors = Math.ceil(file.length / header.sectorBytes);
+  const stepLimit = Math.min(header.difatSectorCount, maxDifatSectors);
+  const seen = new Set<number>();
   let chain = header.difatStart;
-  for (let step = 0; step < header.difatSectorCount; step++) {
+  for (let step = 0; step < stepLimit; step++) {
     if (chain === SECTOR_END || chain === SECTOR_FREE) {
       break;
     }
+    if (seen.has(chain)) {
+      throw new Error(`DIFAT chain loop at sector ${chain}`);
+    }
+    seen.add(chain);
     const sector = loadSector(file, header, chain);
     const view = viewOf(sector);
     const slotsPerSector = header.sectorBytes / 4 - 1;

--- a/packages/core/src/docx/encryption/encryptionInfo.ts
+++ b/packages/core/src/docx/encryption/encryptionInfo.ts
@@ -130,6 +130,26 @@ const requireInt = (attrs: Record<string, string>, name: string, element: string
 const requireBase64 = (attrs: Record<string, string>, name: string, element: string): Uint8Array =>
   decodeBase64(requireAttr(attrs, name, element));
 
+/**
+ * Cap on `encryptedKey/@spinCount`. MS-OFFCRYPTO's documented default is
+ * 100,000; a hostile/corrupt value here would drive `hashPassword`'s
+ * per-iteration WebCrypto digest loop (agileDecryption.ts) an
+ * attacker-chosen number of times, so reject anything past a generous
+ * multiple of that default instead of trusting the file.
+ */
+export const MAX_SPIN_COUNT = 200_000;
+
+const requireSpinCount = (attrs: Record<string, string>, element: string): number => {
+  const spinCount = requireInt(attrs, "spinCount", element);
+  if (spinCount < 0 || spinCount > MAX_SPIN_COUNT) {
+    throw new DocxEncryptionError({
+      code: DOCX_ENCRYPTION_ERROR_CODES.DECRYPTION_FAILED,
+      message: `EncryptionInfo <${element}> attribute "spinCount" out of range: ${spinCount}`,
+    });
+  }
+  return spinCount;
+};
+
 const parseAgileXml = (xmlBytes: Uint8Array): AgileKeyMaterial => {
   const xml = new TextDecoder("utf-8").decode(xmlBytes);
   const keyDataTag = findElement(xml, "keyData");
@@ -154,7 +174,7 @@ const parseAgileXml = (xmlBytes: Uint8Array): AgileKeyMaterial => {
     cipherBlockBytes: requireInt(keyData, "blockSize", "keyData"),
     cipherName: requireAttr(keyData, "cipherAlgorithm", "keyData"),
     cipherMode: requireAttr(keyData, "cipherChaining", "keyData"),
-    passwordIterations: requireInt(encryptedKey, "spinCount", "encryptedKey"),
+    passwordIterations: requireSpinCount(encryptedKey, "encryptedKey"),
     passwordSalt: requireBase64(encryptedKey, "saltValue", "encryptedKey"),
     passwordHash: requireAttr(encryptedKey, "hashAlgorithm", "encryptedKey"),
     passwordKeyBits: requireInt(encryptedKey, "keyBits", "encryptedKey"),

--- a/packages/core/src/docx/ensureParaIds.test.ts
+++ b/packages/core/src/docx/ensureParaIds.test.ts
@@ -14,6 +14,7 @@ import { isSequentialFolioBlockId } from "../types/block-id";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import { ensureParaIds, EnsureParaIdsError } from "./ensureParaIds";
 import { parseDocx } from "./parser";
+import { DOCX_MAX_ENTRIES } from "./server/boundedArchive";
 
 const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`;
@@ -368,6 +369,24 @@ describe("ensureParaIds", () => {
     const notDocx = await zip.generateAsync({ type: "uint8array" });
 
     await expect(ensureParaIds(notDocx)).rejects.toThrow(EnsureParaIdsError);
+  });
+
+  test("rejects an untrusted archive over the bounded-load entry-count cap before reading any XML", async () => {
+    // Regression guard for routing ensureParaIds through the bounded archive
+    // loader (loadDocxArchive): an attacker-supplied ingest buffer with an
+    // excessive entry count must fail fast instead of materializing every
+    // part's XML with no cap.
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", CONTENT_TYPES);
+    zip.file("_rels/.rels", ROOT_RELS);
+    zip.file("word/_rels/document.xml.rels", DOCUMENT_RELS);
+    zip.file("word/document.xml", documentXml(PARA("Body")));
+    for (let i = 0; i < DOCX_MAX_ENTRIES + 5; i++) {
+      zip.file(`word/media/filler${i}.bin`, "x");
+    }
+    const input = await zip.generateAsync({ type: "uint8array" });
+
+    await expect(ensureParaIds(input)).rejects.toThrow(EnsureParaIdsError);
   });
 
   test("wraps malformed ZIP input in EnsureParaIdsError", async () => {

--- a/packages/core/src/docx/ensureParaIds.ts
+++ b/packages/core/src/docx/ensureParaIds.ts
@@ -53,6 +53,7 @@ import JSZip from "jszip";
 
 import { deterministicHexId } from "../utils/hexId";
 import { isXmlNameBoundary } from "./selectiveXmlPatch";
+import { loadDocxArchive } from "./server/boundedArchive";
 
 /** A malformed or unsupported package prevented paragraph-ID normalization. */
 export class EnsureParaIdsError extends TaggedError("EnsureParaIdsError")<{
@@ -478,14 +479,16 @@ const ensureParaIdsInternal = async (
   docx: Uint8Array | ArrayBuffer,
   options: EnsureParaIdsOptions,
 ): Promise<EnsureParaIdsResult> => {
-  const zip = await JSZip.loadAsync(docx);
+  // Bounded read: entry count, per-entry size, and cumulative uncompressed
+  // size are all capped before any part's XML is materialized as a string.
+  // `docx` here is untrusted ingest input (see the module doc comment), so
+  // an attacker-crafted archive with thousands of parts or a decompression-
+  // bomb entry must fail fast instead of exhausting memory.
+  const archive = await loadDocxArchive(docx);
 
-  const xmlPartNames: string[] = [];
-  zip.forEach((relativePath, entry) => {
+  const xmlPartNames = archive.entries.filter((relativePath) => {
     const lower = relativePath.toLowerCase();
-    if (!entry.dir && lower.startsWith("word/") && lower.endsWith(".xml")) {
-      xmlPartNames.push(relativePath);
-    }
+    return lower.startsWith("word/") && lower.endsWith(".xml");
   });
   const documentPartName = xmlPartNames.find((name) => name.toLowerCase() === DOCUMENT_PART);
   if (documentPartName === undefined) {
@@ -494,9 +497,10 @@ const ensureParaIdsInternal = async (
 
   const partTexts = new Map<string, string>();
   for (const name of xmlPartNames) {
-    const entry = zip.file(name);
-    if (entry) {
-      partTexts.set(name, await entry.async("text"));
+    // oxlint-disable-next-line no-await-in-loop -- archive.readEntryString serializes reads to enforce a shared cumulative byte budget across parts
+    const text = await archive.readEntryString(name);
+    if (text !== null) {
+      partTexts.set(name, text);
     }
   }
 
@@ -552,6 +556,12 @@ const ensureParaIdsInternal = async (
   if (updates.size === 0) {
     return { docx: toUint8Array(docx), assigned: 0, deduplicated: 0, alreadyComplete: true };
   }
+
+  // Only the write-back path needs a raw JSZip (signature detection, writing
+  // new part bytes, and repackaging). `docx` was already validated against
+  // the entry-count/size caps above, so this second parse runs on a
+  // buffer whose shape is already bounded.
+  const zip = await JSZip.loadAsync(docx);
 
   if (hasDigitalSignatureParts(zip) && options.allowSignedPackageMutation !== true) {
     throw createEnsureParaIdsError(

--- a/packages/core/src/docx/groupDrawingParser.test.ts
+++ b/packages/core/src/docx/groupDrawingParser.test.ts
@@ -170,4 +170,34 @@ describe("parseGroupDrawing", () => {
     expect(svg).toContain('href="data:image/png;base64,c2Vjb25k"');
     expect(svg).toContain('<clipPath id="group-picture-1">');
   });
+
+  test("bounds a group of large text boxes instead of embedding every shape unbounded", () => {
+    const bigText = "x".repeat(20_000);
+    const shapes = Array.from(
+      { length: 256 },
+      () =>
+        `<wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm></wps:spPr><wps:txbx><w:txbxContent><w:p><w:r><w:t>${bigText}</w:t></w:r></w:p></w:txbxContent></wps:txbx></wps:wsp>`,
+    ).join("");
+    const drawing = parseXmlDocument(`
+      <w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+        xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+        <wp:anchor>
+          <wp:extent cx="2000000" cy="1000000"/>
+          <wp:wrapTopAndBottom/>
+          <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup">
+            <wpg:wgp>${shapes}</wpg:wgp>
+          </a:graphicData></a:graphic>
+        </wp:anchor>
+      </w:drawing>
+    `);
+
+    if (!drawing) {
+      throw new Error("Expected drawing fixture");
+    }
+
+    expect(parseGroupDrawing(drawing)).toBeNull();
+  });
 });

--- a/packages/core/src/docx/groupDrawingParser.ts
+++ b/packages/core/src/docx/groupDrawingParser.ts
@@ -263,18 +263,27 @@ const createSvg = (
   media: Map<string, MediaFile> | undefined,
 ): string | null => {
   const children = getChildElements(group).slice(0, MAX_GROUP_SHAPES);
-  const content = children
-    .map((child, index) => {
-      const localName = getLocalName(child.name ?? "");
-      if (localName === "pic") {
-        return renderPicture(child, index, rels, media);
-      }
-      if (localName !== "wsp") {
-        return "";
-      }
-      return findChildByLocalName(child, "txbx") ? renderTextBox(child) : renderGeometry(child);
-    })
-    .join("");
+  // Accumulate incrementally and bail as soon as the budget is exceeded,
+  // rather than joining every child's markup (each of which can embed a
+  // large media data URL) and checking the total afterward — that would let
+  // a hostile group of otherwise-individually-bounded shapes build a
+  // multi-GB transient string before ever being rejected.
+  let content = "";
+  for (const [index, child] of children.entries()) {
+    const localName = getLocalName(child.name ?? "");
+    let piece: string;
+    if (localName === "pic") {
+      piece = renderPicture(child, index, rels, media);
+    } else if (localName === "wsp") {
+      piece = findChildByLocalName(child, "txbx") ? renderTextBox(child) : renderGeometry(child);
+    } else {
+      continue;
+    }
+    content += piece;
+    if (content.length > MAX_SVG_CHARACTERS) {
+      return null;
+    }
+  }
   if (!content) {
     return null;
   }

--- a/packages/core/src/docx/imageParser.ts
+++ b/packages/core/src/docx/imageParser.ts
@@ -38,6 +38,7 @@ import type {
   MediaFile,
 } from "../types/document";
 import { emuToPixels } from "../utils/units";
+import { sanitizeExternalUrl } from "../utils/urlSecurity";
 import {
   parsePositionH,
   parsePositionV,
@@ -649,11 +650,14 @@ function parseInline(
     image.opacity = opacity;
   }
 
-  // Resolve image hyperlink (a:hlinkClick)
+  // Resolve image hyperlink (a:hlinkClick). Mirrors hyperlinkParser.ts:
+  // an unsafe/unresolved target leaves hlinkHref unset rather than storing
+  // a raw javascript:/data:/file: href.
   if (props.hlinkRId && rels) {
     const href = resolveTarget(rels, props.hlinkRId);
-    if (href) {
-      image.hlinkHref = href;
+    const safeHref = sanitizeExternalUrl(href);
+    if (safeHref) {
+      image.hlinkHref = safeHref;
     }
   }
 
@@ -793,11 +797,14 @@ function parseAnchor(
     image.allowOverlap = allowOverlap;
   }
 
-  // Resolve image hyperlink (a:hlinkClick)
+  // Resolve image hyperlink (a:hlinkClick). Mirrors hyperlinkParser.ts:
+  // an unsafe/unresolved target leaves hlinkHref unset rather than storing
+  // a raw javascript:/data:/file: href.
   if (props.hlinkRId && rels) {
     const href = resolveTarget(rels, props.hlinkRId);
-    if (href) {
-      image.hlinkHref = href;
+    const safeHref = sanitizeExternalUrl(href);
+    if (safeHref) {
+      image.hlinkHref = safeHref;
     }
   }
 

--- a/packages/core/src/docx/metadataPrivacy.test.ts
+++ b/packages/core/src/docx/metadataPrivacy.test.ts
@@ -89,6 +89,60 @@ describe("rewriteDocxMetadataPrivacy", () => {
     });
   });
 
+  test("scrubs core properties written under a differently-cased part name", async () => {
+    // OPC part names are case-insensitive; a producer that wrote
+    // "docProps/Core.xml" instead of the conventional lowercase path is
+    // still valid and must not be missed by the privacy rewrite.
+    const template = createEmptyDocument();
+    const buffer = await createDocx({
+      ...template,
+      package: {
+        ...template.package,
+        document: {
+          ...template.package.document,
+          content: [
+            {
+              type: "paragraph",
+              paraId: "00000001",
+              content: [{ type: "run", content: [{ type: "text", text: "Body text." }] }],
+            },
+          ],
+        },
+      },
+    });
+    const zip = await JSZip.loadAsync(buffer);
+    zip.remove("docProps/core.xml");
+    zip.file("docProps/Core.xml", CORE_PROPERTIES_XML);
+    const casedBuffer = await zip.generateAsync({ type: "arraybuffer" });
+
+    const result = await rewriteDocxMetadataPrivacy(casedBuffer, {
+      transforms: ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"],
+    });
+
+    expect(result.privacyReport.removedMetadataProperties).toEqual([
+      "title",
+      "subject",
+      "creator",
+      "keywords",
+      "description",
+      "lastModifiedBy",
+      "created",
+      "modified",
+    ]);
+
+    const rewrittenZip = await JSZip.loadAsync(result.buffer);
+    // Written back under the original casing, not a new lowercase entry.
+    expect(rewrittenZip.file("docProps/core.xml")).toBeNull();
+    const rewrittenFile = rewrittenZip.file("docProps/Core.xml");
+    if (!rewrittenFile) {
+      throw new Error("expected the cased core properties part to survive the rewrite");
+    }
+    const xml = await rewrittenFile.async("text");
+    expect(xml).not.toContain("<dc:creator>");
+    expect(xml).not.toContain("<cp:lastModifiedBy>");
+    expect(xml).toContain("<cp:revision>7</cp:revision>");
+  });
+
   test("keeps removed timestamps absent through selective and structural saves", async () => {
     const rewritten = await rewriteDocxMetadataPrivacy(await buildDocument(), {
       transforms: ["remove-attribution", "remove-timestamps", "remove-descriptive-metadata"],

--- a/packages/core/src/docx/metadataPrivacy.ts
+++ b/packages/core/src/docx/metadataPrivacy.ts
@@ -91,6 +91,27 @@ const XML_DECLARATION_PATTERN = /^\s*<\?xml[^?]*\?>/u;
 const MAX_INPUT_BYTES = 50 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 5000;
 const MAX_CORE_PROPERTIES_BYTES = 1024 * 1024;
+const CORE_PROPERTIES_PATH_LOWER = "docprops/core.xml";
+
+/**
+ * Look up a package part by its conventional lowercase path, falling back to
+ * a case-insensitive scan. OPC part names are case-insensitive, so a
+ * producer that wrote `docProps/Core.xml` (or another casing) must still be
+ * found — otherwise the privacy rewrite silently no-ops and the unscrubbed
+ * buffer round-trips untouched.
+ */
+const findZipEntryCaseInsensitive = (zip: JSZip, lowerPath: string): JSZip.JSZipObject | null => {
+  const direct = zip.file(lowerPath);
+  if (direct) {
+    return direct;
+  }
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && path.toLowerCase() === lowerPath) {
+      return file;
+    }
+  }
+  return null;
+};
 
 const loadPrivacyArchive = async (buffer: ArrayBuffer): Promise<JSZip> => {
   if (buffer.byteLength > MAX_INPUT_BYTES) {
@@ -116,7 +137,7 @@ const loadPrivacyArchive = async (buffer: ArrayBuffer): Promise<JSZip> => {
       reason: "too-many-entries",
     });
   }
-  const coreProperties = zip.file("docProps/core.xml");
+  const coreProperties = findZipEntryCaseInsensitive(zip, CORE_PROPERTIES_PATH_LOWER);
   if (!coreProperties) {
     return zip;
   }
@@ -184,7 +205,7 @@ export const rewriteDocxMetadataPrivacy = async (
 ): Promise<RewriteDocxMetadataPrivacyResult> => {
   const appliedTransforms = resolveFolioDocumentPrivacyTransforms(transforms);
   const zip = await loadPrivacyArchive(buffer);
-  const coreProperties = zip.file("docProps/core.xml");
+  const coreProperties = findZipEntryCaseInsensitive(zip, CORE_PROPERTIES_PATH_LOWER);
   if (!coreProperties) {
     return {
       buffer,
@@ -201,7 +222,9 @@ export const rewriteDocxMetadataPrivacy = async (
       privacyReport: { appliedTransforms, removedMetadataProperties: [] },
     };
   }
-  zip.file("docProps/core.xml", rewritten.xml);
+  // Write back under the entry's original name/casing so a non-conventional
+  // producer doesn't end up with two core-properties-shaped parts.
+  zip.file(coreProperties.name, rewritten.xml);
   return {
     buffer: await zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" }),
     privacyReport: {

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -35,6 +35,7 @@ import type {
   TrackedChangeInfo,
   MathEquation,
 } from "../types/document";
+import { isValidHexId } from "../utils/hexId";
 import {
   parseBookmarkStart as parseBookmarkStartFromModule,
   parseBookmarkEnd as parseBookmarkEndFromModule,
@@ -1720,14 +1721,19 @@ export function parseParagraph(
     content: [],
   };
 
-  // Get paragraph ID attributes (Word 2010+ uses these for collaboration)
+  // Get paragraph ID attributes (Word 2010+ uses these for collaboration).
+  // OOXML types these as ST_LongHexNumber (exactly 8 hex digits); a value
+  // that doesn't match is not a real Word id and downstream code (paraId
+  // threading, XML serialization) must not trust it as one. Drop it rather
+  // than store a malformed value — comment threading already re-derives a
+  // fresh id when one is missing (see ensureThreadedCommentParaIds).
   const paraId = getAttribute(node, "w14", "paraId") ?? getAttribute(node, "w", "paraId");
-  if (paraId) {
+  if (paraId && isValidHexId(paraId)) {
     paragraph.paraId = paraId;
   }
 
   const textId = getAttribute(node, "w14", "textId") ?? getAttribute(node, "w", "textId");
-  if (textId) {
+  if (textId && isValidHexId(textId)) {
     paragraph.textId = textId;
   }
 

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -40,11 +40,11 @@ import { assertValidFolioDocumentModel } from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import {
+  buildParagraphOffsetIndex,
   buildPatchedNoteXml,
   buildPatchedNumberingXml,
   collectChangedNumberingDefs,
   collectParaIds,
-  extractParagraphXml,
 } from "./selectiveXmlPatch";
 import {
   ensureThreadedCommentParaIds,
@@ -1799,17 +1799,29 @@ async function patchNotePartIntoZip(
  * (re-parsed original) serialization — i.e. the ones actually edited. A
  * paragraph is only considered when its `paraId` resolves uniquely in both,
  * so it can be spliced safely.
+ *
+ * Builds one {@link buildParagraphOffsetIndex} per side (a single linear scan
+ * each) instead of calling `extractParagraphXml` per candidate id, which
+ * re-scanned the whole XML per id — O(note count * XML size) for a document
+ * with many footnotes/endnotes. The index turns each lookup below into O(1).
  */
 function collectChangedNoteParaIds(baselineXml: string, currentXml: string): Set<string> {
   const changed = new Set<string>();
   const baselineIds = collectParaIds(baselineXml);
+  const baselineOffsets = buildParagraphOffsetIndex(baselineXml);
+  const currentOffsets = buildParagraphOffsetIndex(currentXml);
   for (const [id, count] of collectParaIds(currentXml)) {
     if (count !== 1 || baselineIds.get(id) !== 1) {
       continue;
     }
-    const before = extractParagraphXml(baselineXml, id);
-    const after = extractParagraphXml(currentXml, id);
-    if (before !== null && after !== null && before !== after) {
+    const beforeRange = baselineOffsets.get(id);
+    const afterRange = currentOffsets.get(id);
+    if (!beforeRange || !afterRange) {
+      continue;
+    }
+    const before = baselineXml.slice(beforeRange.start, beforeRange.end);
+    const after = currentXml.slice(afterRange.start, afterRange.end);
+    if (before !== after) {
       changed.add(id);
     }
   }

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -62,6 +62,7 @@ import { serializeThemeXml } from "./serializer/themeSerializer";
 import { escapeXml } from "./serializer/xmlUtils";
 import { isPreservableDocxEntry } from "./unzip";
 import type { RawDocxContent } from "./unzip";
+import { isAllowedExternalWatermarkImageUrl } from "../watermark";
 
 export class DocxPackageFidelityError extends Error {
   constructor(message: string) {
@@ -1578,9 +1579,20 @@ async function rebindWatermarkRelIds(
     // a scan only for watermarks built without a parsed source.
     let canonical: CanonicalImage | undefined;
     if (watermark.imageTarget !== undefined) {
-      canonical = watermark.imageTargetExternal
-        ? { mode: "external", url: watermark.imageTarget }
-        : { mode: "internal", absolute: watermark.imageTarget };
+      if (watermark.imageTargetExternal) {
+        // Defense in depth: the watermark dialogs validate the scheme before
+        // calling onApply, but a `Watermark` can also arrive from a
+        // programmatically-built document (API/import). Never emit an
+        // external relationship for a non-http(s) target — that would let a
+        // `file:` URL or UNC path into the exported package's relationships.
+        // Fall back to whatever the rId already resolves to (or drop it,
+        // same as an orphaned rId) rather than trusting the raw string.
+        canonical = isAllowedExternalWatermarkImageUrl(watermark.imageTarget)
+          ? { mode: "external", url: watermark.imageTarget }
+          : resolveCanonical(watermark.imageRId);
+      } else {
+        canonical = { mode: "internal", absolute: watermark.imageTarget };
+      }
     } else {
       canonical = resolveCanonical(watermark.imageRId);
     }

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -73,6 +73,17 @@ import {
 import type { XmlElement } from "./xmlParser";
 
 /**
+ * Sanity cap on `w:lang` `@w:val`/`@w:eastAsia`/`@w:bidi` tag length. BCP-47
+ * tags top out well under this; a hostile/corrupt tag here would drive the
+ * hyphenation dictionary lookup and segmenter cache keying with an
+ * attacker-sized string per run.
+ */
+const MAX_LANGUAGE_TAG_LENGTH = 35;
+
+const truncateLanguageTag = (value: string | undefined): string | undefined =>
+  value === undefined ? undefined : value.slice(0, MAX_LANGUAGE_TAG_LENGTH);
+
+/**
  * Parse color value from attributes
  */
 function parseColorValue(
@@ -523,9 +534,9 @@ export function parseRunProperties(
 
   const lang = propertyChildren.lang;
   if (lang) {
-    const val = getAttribute(lang, "w", "val") || undefined;
-    const eastAsia = getAttribute(lang, "w", "eastAsia") || undefined;
-    const bidi = getAttribute(lang, "w", "bidi") || undefined;
+    const val = truncateLanguageTag(getAttribute(lang, "w", "val") || undefined);
+    const eastAsia = truncateLanguageTag(getAttribute(lang, "w", "eastAsia") || undefined);
+    const bidi = truncateLanguageTag(getAttribute(lang, "w", "bidi") || undefined);
     if (val || eastAsia || bidi) {
       formatting.language = {
         ...(val ? { val } : {}),

--- a/packages/core/src/docx/sectionParser.ts
+++ b/packages/core/src/docx/sectionParser.ts
@@ -45,6 +45,20 @@ import {
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
+/**
+ * Sanity cap on `w:cols/@w:num`. Word's column picker tops out well below
+ * this; a hostile/corrupt value here would force the layout engine to
+ * generate a proportional band per column.
+ */
+const MAX_SECTION_COLUMNS = 45;
+
+/**
+ * Sanity cap on `w:pgSz` `@w:w`/`@w:h`, in twips (~22in). Matches the
+ * existing `w:defaultTabStop` cap (`settingsParser.ts`) and bounds the
+ * ruler tick generators, which are sized off the page dimensions.
+ */
+const MAX_PAGE_DIMENSION_TWIPS = 31_680;
+
 const serializedSectionPropertyChildNames = new Set([
   "headerReference",
   "footerReference",
@@ -337,13 +351,13 @@ export function parseSectionProperties(sectPr: XmlElement | null): SectionProper
     // Width in twips
     const w = parseNumericAttribute(pgSz, "w", "w");
     if (w !== undefined) {
-      props.pageWidth = w;
+      props.pageWidth = Math.min(w, MAX_PAGE_DIMENSION_TWIPS);
     }
 
     // Height in twips
     const h = parseNumericAttribute(pgSz, "w", "h");
     if (h !== undefined) {
-      props.pageHeight = h;
+      props.pageHeight = Math.min(h, MAX_PAGE_DIMENSION_TWIPS);
     }
 
     // Orientation
@@ -410,7 +424,7 @@ export function parseSectionProperties(sectPr: XmlElement | null): SectionProper
     // Number of columns
     const num = parseNumericAttribute(cols, "w", "num");
     if (num !== undefined) {
-      props.columnCount = num;
+      props.columnCount = Math.min(num, MAX_SECTION_COLUMNS);
     }
 
     // Space between columns in twips

--- a/packages/core/src/docx/selectiveSave.test.ts
+++ b/packages/core/src/docx/selectiveSave.test.ts
@@ -114,7 +114,7 @@ const corePropertiesXml = `${XML_DECLARATION}
 </cp:coreProperties>`;
 
 const imageParagraphXml = (rId: string): string =>
-  `<w:p w14:paraId="I0000001"><w:r><w:drawing><wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"><wp:extent cx="9525" cy="9525"/><wp:docPr id="1" name="Test image" descr="Generated fixture image"/><a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="1" name="image1.png"/><pic:cNvPicPr/></pic:nvPicPr><pic:blipFill><a:blip r:embed="${rId}"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill><pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="9525" cy="9525"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>`;
+  `<w:p w14:paraId="50000001"><w:r><w:drawing><wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"><wp:extent cx="9525" cy="9525"/><wp:docPr id="1" name="Test image" descr="Generated fixture image"/><a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="1" name="image1.png"/><pic:cNvPicPr/></pic:nvPicPr><pic:blipFill><a:blip r:embed="${rId}"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill><pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="9525" cy="9525"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>`;
 
 const documentXml = ({
   paragraphCount = 4,
@@ -125,7 +125,7 @@ const documentXml = ({
 }: FixtureOptions): string => {
   const paragraphs: string[] = [];
   for (let index = 1; index <= paragraphCount; index++) {
-    const id = `P${String(index).padStart(7, "0")}`;
+    const id = `1${String(index).padStart(7, "0")}`;
     paragraphs.push(
       paragraphXml(
         id,
@@ -137,7 +137,7 @@ const documentXml = ({
 
   if (includeTable) {
     paragraphs.push(
-      `<w:tbl><w:tr><w:tc>${paragraphXml("T0000001", "Table cell text")}</w:tc></w:tr></w:tbl>`,
+      `<w:tbl><w:tr><w:tc>${paragraphXml("20000001", "Table cell text")}</w:tc></w:tr></w:tbl>`,
     );
   }
 
@@ -160,12 +160,12 @@ const documentXml = ({
 
 const headerXml = `${XML_DECLARATION}
 <w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
-  ${paragraphXml("H0000001", "Header text")}
+  ${paragraphXml("30000001", "Header text")}
 </w:hdr>`;
 
 const footerXml = `${XML_DECLARATION}
 <w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
-  ${paragraphXml("F0000001", "Footer text")}
+  ${paragraphXml("40000001", "Footer text")}
 </w:ftr>`;
 
 async function createFixtureDocx(options: FixtureOptions): Promise<ArrayBuffer> {

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -16,6 +16,7 @@ import { hasUnsynthesizedReplyRanges } from "./commentReplyMarkers";
 import { validateFolioDocumentModel } from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
+import { isPreservableDocxEntry } from "./unzip";
 import {
   applyUpdatesToZip,
   findMaxRId,
@@ -423,6 +424,21 @@ export async function attemptSelectiveSave(
   try {
     const JSZip = (await import("jszip")).default;
     const zip = await JSZip.loadAsync(originalBuffer);
+
+    // The selective path only ever overlays a handful of known-safe parts
+    // (document.xml, comments, headers/footers, numbering, core props) on
+    // top of the ORIGINAL zip and re-emits everything else verbatim —
+    // unlike the full repack (`repackDocx`), which drops every entry that
+    // fails `isPreservableDocxEntry` (macros, OLE embeddings, disallowed
+    // media). An untrusted DOCX carrying one of those would otherwise
+    // round-trip its active content unfiltered through a selective save.
+    // Bail to the full repack, which owns that filtering.
+    for (const [path, file] of Object.entries(zip.files)) {
+      if (!file.dir && !isPreservableDocxEntry(path)) {
+        return null;
+      }
+    }
+
     const updates = new Map<string, string>();
 
     // Patch document.xml and the note parts (footnotes.xml / endnotes.xml). A

--- a/packages/core/src/docx/selectiveSaveGuards.test.ts
+++ b/packages/core/src/docx/selectiveSaveGuards.test.ts
@@ -53,9 +53,10 @@ async function makeFixture(extraPaddingBytes = 0): Promise<ArrayBuffer> {
   zip.file("word/styles.xml", STYLES);
   zip.file("docProps/core.xml", CORE_PROPS);
   if (extraPaddingBytes > 0) {
-    // Synthetic large binary so we can drive the memory-threshold guard
+    // Synthetic large media entry (a preservable type, so it does not trip
+    // the non-preservable-entry guard) to drive the memory-threshold guard
     // without inflating the test runner with multi-MB fixtures.
-    zip.file("word/media/padding.bin", new Uint8Array(extraPaddingBytes), {
+    zip.file("word/media/padding.png", new Uint8Array(extraPaddingBytes), {
       compression: "STORE",
     });
   }
@@ -241,6 +242,74 @@ describe("fallback contract", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe("non-preservable entry guard", () => {
+  test("bails to full repack when the original zip carries a vbaProject.bin macro part", async () => {
+    // attemptSelectiveSave loads the ORIGINAL buffer into JSZip and overlays
+    // only a handful of known-safe part updates — unlike repackDocx, which
+    // drops every entry failing isPreservableDocxEntry (macros, OLE
+    // embeddings, disallowed media). Without this guard, an attacker DOCX
+    // carrying an active-content part would round-trip it unfiltered
+    // through the selective path.
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", CONTENT_TYPES);
+    zip.file("_rels/.rels", PACKAGE_RELS);
+    zip.file("word/_rels/document.xml.rels", DOC_RELS);
+    zip.file("word/document.xml", DOCUMENT_XML);
+    zip.file("word/styles.xml", STYLES);
+    zip.file("docProps/core.xml", CORE_PROPS);
+    zip.file("word/vbaProject.bin", new Uint8Array([0, 1, 2, 3]));
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(["60000001"]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("does not bail on the Word package preview thumbnail", async () => {
+    // `docProps/thumbnail.jpeg` is plain preview media Word writes into
+    // nearly every authored file; if the guard treated it as active
+    // content, the selective path would be dead code for real documents.
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", CONTENT_TYPES);
+    zip.file("_rels/.rels", PACKAGE_RELS);
+    zip.file("word/_rels/document.xml.rels", DOC_RELS);
+    zip.file("word/document.xml", DOCUMENT_XML);
+    zip.file("word/styles.xml", STYLES);
+    zip.file("docProps/core.xml", CORE_PROPS);
+    zip.file("docProps/thumbnail.jpeg", new Uint8Array([0xff, 0xd8, 0xff, 0xd9]));
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
+  });
+
+  test("still takes the selective path when every entry is preservable", async () => {
+    // Control case: the same fixture shape without the macro part must
+    // still take the selective path, so the new guard is not overly broad.
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
   });
 });
 

--- a/packages/core/src/docx/selectiveSaveGuards.test.ts
+++ b/packages/core/src/docx/selectiveSaveGuards.test.ts
@@ -28,8 +28,8 @@ const PARAGRAPH = (id: string, text: string): string =>
 const DOCUMENT_XML = `${XML_DECL}
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <w:body>
-    ${PARAGRAPH("P0000001", "Hello world")}
-    ${PARAGRAPH("P0000002", "Second paragraph")}
+    ${PARAGRAPH("60000001", "Hello world")}
+    ${PARAGRAPH("60000002", "Second paragraph")}
     <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
   </w:body>
 </w:document>`;
@@ -150,7 +150,7 @@ describe("fallback contract", () => {
     const doc = await parseDocx(buffer, { preloadFonts: false });
 
     const result = await attemptSelectiveSave(doc, buffer, {
-      changedParaIds: new Set(["P0000001"]),
+      changedParaIds: new Set(["60000001"]),
       structuralChange: true,
       hasUntrackedChanges: false,
     });
@@ -163,7 +163,7 @@ describe("fallback contract", () => {
     const doc = await parseDocx(buffer, { preloadFonts: false });
 
     const result = await attemptSelectiveSave(doc, buffer, {
-      changedParaIds: new Set(["P0000001"]),
+      changedParaIds: new Set(["60000001"]),
       structuralChange: false,
       hasUntrackedChanges: true,
     });

--- a/packages/core/src/docx/selectiveXmlPatch.test.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.test.ts
@@ -7,6 +7,7 @@ import { describe, test, expect } from "bun:test";
 import {
   findParagraphOffsets,
   extractParagraphXml,
+  buildParagraphOffsetIndex,
   validatePatchSafety,
   buildPatchedDocumentXml,
   countParagraphElements,
@@ -158,6 +159,45 @@ describe("extractParagraphXml", () => {
 
   test("returns null for missing paraId", () => {
     expect(extractParagraphXml(SIMPLE_DOC, "NOPE")).toBeNull();
+  });
+});
+
+// ============================================================================
+// buildParagraphOffsetIndex
+// ============================================================================
+
+describe("buildParagraphOffsetIndex", () => {
+  test("indexes every unique paraId in one pass, matching per-id findParagraphOffsets results", () => {
+    // Regression guard: rezip.ts's collectChangedNoteParaIds used to call
+    // extractParagraphXml (a full regex-scan-plus-depth-walk) once per note
+    // paraId, which is O(note count * XML size). The index below is built
+    // once per XML and every lookup afterward is O(1); this test asserts the
+    // index agrees with the original per-id function it replaces.
+    const index = buildParagraphOffsetIndex(SIMPLE_DOC);
+    for (const id of ["AAA111", "BBB222", "CCC333"]) {
+      const expected = findParagraphOffsets(SIMPLE_DOC, id);
+      expect(index.get(id)).toEqual(expected);
+    }
+    expect(index.size).toBe(3);
+  });
+
+  test("indexes nested <w:p> inside mc:AlternateContent alongside the outer paragraph", () => {
+    const index = buildParagraphOffsetIndex(DOC_WITH_MC);
+    for (const id of ["OUTER1", "INNER1", "INNER2", "NORMAL1"]) {
+      const expected = findParagraphOffsets(DOC_WITH_MC, id);
+      expect(index.get(id)).toEqual(expected);
+    }
+  });
+
+  test("omits a paraId that appears on more than one element, mirroring the ambiguous-null case", () => {
+    const index = buildParagraphOffsetIndex(DOC_WITH_DUPLICATE_ID);
+    expect(index.has("DUP001")).toBe(false);
+    expect(findParagraphOffsets(DOC_WITH_DUPLICATE_ID, "DUP001")).toBeNull();
+  });
+
+  test("returns an empty index for a missing paraId lookup", () => {
+    const index = buildParagraphOffsetIndex(SIMPLE_DOC);
+    expect(index.get("MISSING")).toBeUndefined();
   });
 });
 

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -120,6 +120,88 @@ export function extractParagraphXml(serializedXml: string, paraId: string): stri
   return serializedXml.slice(offsets.start, offsets.end);
 }
 
+export type ParagraphOffsets = { start: number; end: number };
+
+/**
+ * Single linear-scan index of every `<w:p>` element's start/end offsets,
+ * keyed by `w14:paraId`. Generalizes {@link findParagraphOffsets} (one
+ * regex-scan-plus-depth-walk per lookup) to build every paragraph's offsets
+ * in a single pass, so a caller that needs many paragraphs from the same XML
+ * (e.g. `collectChangedNoteParaIds` in rezip.ts, walking every note paraId)
+ * does O(1) map lookups afterward instead of re-scanning the whole XML once
+ * per id — O(ids * XML length) collapses to O(XML length).
+ *
+ * A `<w:p>` nested inside another (e.g. inside `mc:AlternateContent`) is
+ * indexed too via a depth stack, matching every element `findParagraphOffsets`
+ * can resolve. A paraId that appears on more than one element is ambiguous —
+ * mirroring {@link findParagraphOffsets}'s single-match requirement — and is
+ * omitted from the index, so a lookup misses exactly where the per-id
+ * function would return null.
+ */
+export function buildParagraphOffsetIndex(xml: string): Map<string, ParagraphOffsets> {
+  const seenCount = new Map<string, number>();
+  const ranges = new Map<string, ParagraphOffsets>();
+  const stack: { start: number; paraId: string | undefined }[] = [];
+  let pos = 0;
+
+  const noteOpen = (paraId: string | undefined): void => {
+    if (paraId) {
+      seenCount.set(paraId, (seenCount.get(paraId) ?? 0) + 1);
+    }
+  };
+  const noteRange = (paraId: string | undefined, start: number, end: number): void => {
+    if (paraId) {
+      ranges.set(paraId, { start, end });
+    }
+  };
+
+  while (pos < xml.length) {
+    const tagStart = xml.indexOf("<", pos);
+    if (tagStart === -1) {
+      break;
+    }
+
+    if (xml.startsWith("</w:p>", tagStart)) {
+      const frame = stack.pop();
+      const end = tagStart + "</w:p>".length;
+      if (frame) {
+        noteRange(frame.paraId, frame.start, end);
+      }
+      pos = end;
+      continue;
+    }
+
+    if (!xml.startsWith("<w:p", tagStart) || !isXmlNameBoundary(xml[tagStart + 4])) {
+      pos = tagStart + 1;
+      continue;
+    }
+
+    const tagEnd = xml.indexOf(">", tagStart);
+    if (tagEnd === -1) {
+      break;
+    }
+    const openTag = xml.slice(tagStart, tagEnd + 1);
+    const paraId = /\bw14:paraId="(?<id>[^"]*)"/u.exec(openTag)?.groups?.["id"];
+    noteOpen(paraId);
+
+    if (xml[tagEnd - 1] === "/") {
+      // Self-closing <w:p ... /> — resolved immediately, never pushed.
+      noteRange(paraId, tagStart, tagEnd + 1);
+    } else {
+      stack.push({ start: tagStart, paraId });
+    }
+    pos = tagEnd + 1;
+  }
+
+  const index = new Map<string, ParagraphOffsets>();
+  for (const [id, range] of ranges) {
+    if (seenCount.get(id) === 1) {
+      index.set(id, range);
+    }
+  }
+  return index;
+}
+
 /**
  * Count <w:p> elements in an XML string (top-level paragraph count).
  * Counts opening <w:p tags that are NOT self-closing.

--- a/packages/core/src/docx/serializer/blockSdtSerializer.ts
+++ b/packages/core/src/docx/serializer/blockSdtSerializer.ts
@@ -18,6 +18,7 @@
 
 import type { BlockContent, BlockSdt, SdtProperties } from "../../types/document";
 import { reconcileRawSdtPr } from "../sdtPropertiesPatch";
+import { isSingleWellFormedElement } from "./xmlUtils";
 
 function escapeXmlAttr(value: string): string {
   return value
@@ -174,7 +175,15 @@ export function serializeBlockSdt(
   serializeChild: (block: BlockContent) => string,
 ): string {
   const props = blockSdt.properties;
-  const baseSdtPr = props.rawPropertiesXml ?? serializeFallbackSdtPr(props);
+  // Replay the captured snapshot only when it is structurally a single
+  // `<w:sdtPr>` element — a malformed or attacker-supplied string (e.g. one
+  // that closes `<w:sdt>` early or injects sibling markup) falls back to a
+  // synthesized properties block instead of being spliced into the document
+  // verbatim.
+  const baseSdtPr =
+    props.rawPropertiesXml && isSingleWellFormedElement(props.rawPropertiesXml, "sdtPr")
+      ? props.rawPropertiesXml
+      : serializeFallbackSdtPr(props);
   // Reconcile any modeled property mutations the editor may have made into
   // the raw XML before replay so checkbox / dropdown / date interactions
   // survive the round-trip. Unmodeled markers (dataBinding,
@@ -185,7 +194,10 @@ export function serializeBlockSdt(
     ...(dateFullDate !== undefined ? { dateFullDate } : {}),
     ...(dropdownLastValue !== undefined ? { dropdownLastValue } : {}),
   });
-  const sdtEndPrXml = props.rawEndPropertiesXml ?? "";
+  const sdtEndPrXml =
+    props.rawEndPropertiesXml && isSingleWellFormedElement(props.rawEndPropertiesXml, "sdtEndPr")
+      ? props.rawEndPropertiesXml
+      : "";
   const contentXml = blockSdt.content.map(serializeChild).join("");
   // Replay any direct sdt children that lived OUTSIDE sdtContent at parse
   // time (range markers per MS-OE376 §2.5.2.30: bookmark / comment /

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Comment } from "../../types/content";
-import { serializeComments } from "./commentSerializer";
+import { serializeComments, serializeCommentsExtended } from "./commentSerializer";
 
 function makeComment(id: number, parentId?: number): Comment {
   return {
@@ -57,5 +57,37 @@ describe("serializeComments", () => {
     const xml = serializeComments([{ ...makeComment(1), author: "" }]);
 
     expect(xml).toContain('<w:comment w:id="1" w:author=""');
+  });
+
+  test("escapes a paragraph paraId that carries markup instead of a real Word id", () => {
+    // A malformed/attacker-supplied `paraId` (e.g. relayed through a
+    // collaboration payload) must not be able to break out of the
+    // `w14:paraId="..."` attribute and inject sibling XML.
+    const malicious = '12345678"/><script>alert(1)</script><w:p w14:paraId="';
+    const comment = makeComment(1);
+    comment.content[0]!.paraId = malicious;
+
+    const xml = serializeComments([comment]);
+
+    expect(xml).not.toContain("<script>");
+    expect(xml).toContain("w14:paraId=");
+    expect(xml).toContain("&lt;script&gt;");
+    expect(xml).toContain("&quot;");
+  });
+});
+
+describe("serializeCommentsExtended", () => {
+  test("escapes paraId/paraIdParent that carry markup instead of a real Word id", () => {
+    const malicious = '12345678" w15:done="1"><script>alert(1)</script';
+    const parent = makeComment(1);
+    parent.content[0]!.paraId = malicious;
+    parent.done = true;
+
+    const xml = serializeCommentsExtended([parent]);
+
+    expect(xml).not.toBeNull();
+    expect(xml).not.toContain("<script>");
+    expect(xml).toContain("&quot;");
+    expect(xml).toContain("&lt;script&gt;");
   });
 });

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -45,10 +45,10 @@ function serializeRunContent(run: Run): string {
 function commentParagraphOpenTag(p: Paragraph): string {
   const attrs: string[] = [];
   if (p.paraId) {
-    attrs.push(`w14:paraId="${p.paraId}"`);
+    attrs.push(`w14:paraId="${escapeXml(p.paraId)}"`);
   }
   if (p.textId) {
-    attrs.push(`w14:textId="${p.textId}"`);
+    attrs.push(`w14:textId="${escapeXml(p.textId)}"`);
   }
   return attrs.length > 0 ? `<w:p ${attrs.join(" ")}>` : "<w:p>";
 }
@@ -317,8 +317,10 @@ export function serializeCommentsExtended(comments: readonly Comment[]): string 
   let xml = COMMENTS_EXTENDED_HEADER;
   for (const entry of entries) {
     const parentAttr =
-      entry.paraIdParent !== undefined ? ` w15:paraIdParent="${entry.paraIdParent}"` : "";
-    xml += `<w15:commentEx w15:paraId="${entry.paraId}"${parentAttr} w15:done="${entry.done ? "1" : "0"}"/>`;
+      entry.paraIdParent !== undefined
+        ? ` w15:paraIdParent="${escapeXml(entry.paraIdParent)}"`
+        : "";
+    xml += `<w15:commentEx w15:paraId="${escapeXml(entry.paraId)}"${parentAttr} w15:done="${entry.done ? "1" : "0"}"/>`;
   }
   xml += "</w15:commentsEx>";
   return xml;

--- a/packages/core/src/docx/serializer/paragraphSerializer-inlineSdtRawPr.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer-inlineSdtRawPr.test.ts
@@ -141,6 +141,83 @@ describe("inline SDT raw-property round-trip", () => {
   });
 });
 
+describe("inline SDT raw-property structural validation", () => {
+  test("falls back to synthesized sdtPr when rawPropertiesXml closes the SDT early", () => {
+    // `rawPropertiesXml` is normally a verbatim `<w:sdtPr>` snapshot captured
+    // by our own parser, but it can also arrive from an untrusted surface
+    // (a programmatically constructed node, a collaboration payload). A
+    // value like this one closes `<w:sdtContent>`/`<w:sdt>` early and
+    // splices in sibling markup — it must never be spliced into the
+    // serialized document verbatim.
+    const malicious =
+      '<w:sdtPr><w:tag w:val="x"/></w:sdtPr></w:sdtContent></w:sdt>' +
+      "<w:p><w:r><w:t>INJECTED</w:t></w:r></w:p>" +
+      "<w:sdt><w:sdtPr>";
+
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "inlineSdt",
+          properties: { sdtType: "richText", alias: "clause", rawPropertiesXml: malicious },
+          content: [{ type: "run", content: [{ type: "text", text: "value" }] }],
+        },
+      ],
+    };
+
+    const serialized = serializeParagraph(paragraph);
+
+    expect(serialized).not.toContain("INJECTED");
+    expect(serialized).not.toContain(malicious);
+    // Falls back to a single well-formed synthesized <w:sdtPr>, still
+    // carrying the modeled alias.
+    expect(serialized).toContain('<w:sdtPr><w:alias w:val="clause"/></w:sdtPr>');
+  });
+
+  test("falls back to no end-properties when rawEndPropertiesXml isn't a single well-formed <w:sdtEndPr>", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "inlineSdt",
+          properties: {
+            sdtType: "richText",
+            rawEndPropertiesXml: "<w:sdtEndPr/><w:p><w:r><w:t>INJECTED</w:t></w:r></w:p>",
+          },
+          content: [{ type: "run", content: [{ type: "text", text: "value" }] }],
+        },
+      ],
+    };
+
+    const serialized = serializeParagraph(paragraph);
+
+    expect(serialized).not.toContain("INJECTED");
+    expect(serialized).not.toContain("<w:sdtEndPr");
+  });
+
+  test("still replays a well-formed rawPropertiesXml/rawEndPropertiesXml verbatim", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "inlineSdt",
+          properties: {
+            sdtType: "richText",
+            rawPropertiesXml: '<w:sdtPr><w:tag w:val="ok"/></w:sdtPr>',
+            rawEndPropertiesXml: "<w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>",
+          },
+          content: [{ type: "run", content: [{ type: "text", text: "value" }] }],
+        },
+      ],
+    };
+
+    const serialized = serializeParagraph(paragraph);
+
+    expect(serialized).toContain('<w:sdtPr><w:tag w:val="ok"/></w:sdtPr>');
+    expect(serialized).toContain("<w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>");
+  });
+});
+
 describe("inline SDT null-default normalization", () => {
   test("PM null-default attrs never enter the model or the serialized XML", () => {
     // A control with no id / dropdownLastValue / checked: `toProseDoc`

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -35,13 +35,14 @@ import type {
   TextFormatting,
   TrackedChangeInfo,
 } from "../../types/document";
+import { isValidHexColor } from "../../utils/colorResolver";
 import { numPrEqual } from "../numberingParser";
 import { reconcileRawSdtPr } from "../sdtPropertiesPatch";
 import { serializeBorder } from "./borderSerializer";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: paragraphs hold runs, shape-textbox runs hold paragraphs
 import { serializeRun, serializeTextFormatting } from "./runSerializer";
 import { serializeSectionProperties } from "./sectionPropertiesSerializer";
-import { escapeXml, intAttr } from "./xmlUtils";
+import { escapeXml, intAttr, isSingleWellFormedElement } from "./xmlUtils";
 
 // ============================================================================
 // BORDER SERIALIZATION
@@ -122,36 +123,36 @@ function serializeShading(shading: ShadingProperties | undefined): string {
 
   // Pattern/val
   if (shading.pattern) {
-    attrs.push(`w:val="${shading.pattern}"`);
+    attrs.push(`w:val="${escapeXml(shading.pattern)}"`);
   } else {
     attrs.push('w:val="clear"');
   }
 
   // Color (pattern color)
-  if (shading.color?.rgb) {
-    attrs.push(`w:color="${shading.color.rgb}"`);
+  if (shading.color?.rgb && isValidHexColor(shading.color.rgb)) {
+    attrs.push(`w:color="${escapeXml(shading.color.rgb)}"`);
   } else if (shading.color?.auto) {
     attrs.push('w:color="auto"');
   }
 
   // Fill (background color)
-  if (shading.fill?.rgb) {
-    attrs.push(`w:fill="${shading.fill.rgb}"`);
+  if (shading.fill?.rgb && isValidHexColor(shading.fill.rgb)) {
+    attrs.push(`w:fill="${escapeXml(shading.fill.rgb)}"`);
   } else if (shading.fill?.auto) {
     attrs.push('w:fill="auto"');
   }
 
   // Theme fill
   if (shading.fill?.themeColor) {
-    attrs.push(`w:themeFill="${shading.fill.themeColor}"`);
+    attrs.push(`w:themeFill="${escapeXml(shading.fill.themeColor)}"`);
   }
 
   if (shading.fill?.themeTint) {
-    attrs.push(`w:themeFillTint="${shading.fill.themeTint}"`);
+    attrs.push(`w:themeFillTint="${escapeXml(shading.fill.themeTint)}"`);
   }
 
   if (shading.fill?.themeShade) {
-    attrs.push(`w:themeFillShade="${shading.fill.themeShade}"`);
+    attrs.push(`w:themeFillShade="${escapeXml(shading.fill.themeShade)}"`);
   }
 
   if (attrs.length === 0) {
@@ -897,7 +898,15 @@ function serializeInlineSdt(sdt: InlineSdt): string {
   // dropdown selection) into the raw properties before replay so it is not
   // discarded, exactly as the block-SDT serializer does. Unmodeled markers
   // inside the raw string are left untouched.
-  const baseSdtPr = props.rawPropertiesXml ?? synthesizeInlineSdtPr(props);
+  // Replay the captured snapshot only when it is structurally a single
+  // `<w:sdtPr>`/`<w:sdtEndPr>` element — a malformed or attacker-supplied
+  // string (e.g. one that closes `<w:sdt>` early or injects sibling markup)
+  // falls back to a synthesized properties block instead of being spliced
+  // into the document verbatim.
+  const baseSdtPr =
+    props.rawPropertiesXml && isSingleWellFormedElement(props.rawPropertiesXml, "sdtPr")
+      ? props.rawPropertiesXml
+      : synthesizeInlineSdtPr(props);
   const dateFullDate =
     props.sdtType === "date" && props.dateValueISO ? props.dateValueISO : undefined;
   const dropdownLastValue =
@@ -909,7 +918,10 @@ function serializeInlineSdt(sdt: InlineSdt): string {
     ...(dateFullDate !== undefined ? { dateFullDate } : {}),
     ...(dropdownLastValue !== undefined ? { dropdownLastValue } : {}),
   });
-  const sdtEndPrXml = props.rawEndPropertiesXml ?? "";
+  const sdtEndPrXml =
+    props.rawEndPropertiesXml && isSingleWellFormedElement(props.rawEndPropertiesXml, "sdtEndPr")
+      ? props.rawEndPropertiesXml
+      : "";
 
   return `<w:sdt>${sdtPrXml}${sdtEndPrXml}<w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
 }
@@ -1073,10 +1085,10 @@ export function serializeParagraph(paragraph: Paragraph): string {
   // Paragraph ID attributes
   const attrs: string[] = [];
   if (paragraph.paraId) {
-    attrs.push(`w14:paraId="${paragraph.paraId}"`);
+    attrs.push(`w14:paraId="${escapeXml(paragraph.paraId)}"`);
   }
   if (paragraph.textId) {
-    attrs.push(`w14:textId="${paragraph.textId}"`);
+    attrs.push(`w14:textId="${escapeXml(paragraph.textId)}"`);
   }
   const attrsStr = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
 

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -38,6 +38,7 @@ import type {
   RunPropertyChange,
 } from "../../types/document";
 import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
+import { isValidHexColor } from "../../utils/colorResolver";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: shape textboxes hold paragraphs, paragraphs hold runs
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTable } from "./tableSerializer";
@@ -89,20 +90,20 @@ function serializeColorElement(color: ColorValue | undefined): string {
 
   if (color.auto) {
     attrs.push('w:val="auto"');
-  } else if (color.rgb) {
-    attrs.push(`w:val="${color.rgb}"`);
+  } else if (color.rgb && isValidHexColor(color.rgb)) {
+    attrs.push(`w:val="${escapeXml(color.rgb)}"`);
   }
 
   if (color.themeColor) {
-    attrs.push(`w:themeColor="${color.themeColor}"`);
+    attrs.push(`w:themeColor="${escapeXml(color.themeColor)}"`);
   }
 
   if (color.themeTint) {
-    attrs.push(`w:themeTint="${color.themeTint}"`);
+    attrs.push(`w:themeTint="${escapeXml(color.themeTint)}"`);
   }
 
   if (color.themeShade) {
-    attrs.push(`w:themeShade="${color.themeShade}"`);
+    attrs.push(`w:themeShade="${escapeXml(color.themeShade)}"`);
   }
 
   if (attrs.length === 0) {
@@ -128,36 +129,36 @@ function serializeShading(shading: ShadingProperties | undefined): string {
 
   // Pattern/val
   if (shading.pattern) {
-    attrs.push(`w:val="${shading.pattern}"`);
+    attrs.push(`w:val="${escapeXml(shading.pattern)}"`);
   } else {
     attrs.push('w:val="clear"');
   }
 
   // Color (pattern color)
-  if (shading.color?.rgb) {
-    attrs.push(`w:color="${shading.color.rgb}"`);
+  if (shading.color?.rgb && isValidHexColor(shading.color.rgb)) {
+    attrs.push(`w:color="${escapeXml(shading.color.rgb)}"`);
   } else if (shading.color?.auto) {
     attrs.push('w:color="auto"');
   }
 
   // Fill (background color)
-  if (shading.fill?.rgb) {
-    attrs.push(`w:fill="${shading.fill.rgb}"`);
+  if (shading.fill?.rgb && isValidHexColor(shading.fill.rgb)) {
+    attrs.push(`w:fill="${escapeXml(shading.fill.rgb)}"`);
   } else if (shading.fill?.auto) {
     attrs.push('w:fill="auto"');
   }
 
   // Theme fill
   if (shading.fill?.themeColor) {
-    attrs.push(`w:themeFill="${shading.fill.themeColor}"`);
+    attrs.push(`w:themeFill="${escapeXml(shading.fill.themeColor)}"`);
   }
 
   if (shading.fill?.themeTint) {
-    attrs.push(`w:themeFillTint="${shading.fill.themeTint}"`);
+    attrs.push(`w:themeFillTint="${escapeXml(shading.fill.themeTint)}"`);
   }
 
   if (shading.fill?.themeShade) {
-    attrs.push(`w:themeFillShade="${shading.fill.themeShade}"`);
+    attrs.push(`w:themeFillShade="${escapeXml(shading.fill.themeShade)}"`);
   }
 
   if (attrs.length === 0) {
@@ -378,17 +379,17 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
   if (formatting.underline) {
     const uAttrs: string[] = [`w:val="${formatting.underline.style}"`];
     if (formatting.underline.color) {
-      if (formatting.underline.color.rgb) {
-        uAttrs.push(`w:color="${formatting.underline.color.rgb}"`);
+      if (formatting.underline.color.rgb && isValidHexColor(formatting.underline.color.rgb)) {
+        uAttrs.push(`w:color="${escapeXml(formatting.underline.color.rgb)}"`);
       }
       if (formatting.underline.color.themeColor) {
-        uAttrs.push(`w:themeColor="${formatting.underline.color.themeColor}"`);
+        uAttrs.push(`w:themeColor="${escapeXml(formatting.underline.color.themeColor)}"`);
       }
       if (formatting.underline.color.themeTint) {
-        uAttrs.push(`w:themeTint="${formatting.underline.color.themeTint}"`);
+        uAttrs.push(`w:themeTint="${escapeXml(formatting.underline.color.themeTint)}"`);
       }
       if (formatting.underline.color.themeShade) {
-        uAttrs.push(`w:themeShade="${formatting.underline.color.themeShade}"`);
+        uAttrs.push(`w:themeShade="${escapeXml(formatting.underline.color.themeShade)}"`);
       }
     }
     parts.push(`<w:u ${uAttrs.join(" ")}/>`);
@@ -596,15 +597,15 @@ function serializeDrawingColor(color: ColorValue | undefined): string {
   if (!color) {
     return "";
   }
-  if (color.rgb) {
-    return `<a:srgbClr val="${color.rgb.replace("#", "")}"/>`;
+  if (color.rgb && isValidHexColor(color.rgb)) {
+    return `<a:srgbClr val="${escapeXml(color.rgb.replace("#", ""))}"/>`;
   }
   if (color.themeColor) {
-    let clr = `<a:schemeClr val="${color.themeColor}"`;
+    let clr = `<a:schemeClr val="${escapeXml(color.themeColor)}"`;
     if (color.themeTint) {
-      clr += `><a:tint val="${color.themeTint}"/></a:schemeClr>`;
+      clr += `><a:tint val="${escapeXml(color.themeTint)}"/></a:schemeClr>`;
     } else if (color.themeShade) {
-      clr += `><a:shade val="${color.themeShade}"/></a:schemeClr>`;
+      clr += `><a:shade val="${escapeXml(color.themeShade)}"/></a:schemeClr>`;
     } else {
       clr += `/>`;
     }

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -13,6 +13,21 @@ const parseSectPr = (xml: string) => {
   return parseSectionProperties(node);
 };
 
+describe("parseSectionProperties", () => {
+  test("clamps a hostile column count and page size to sane maximums", () => {
+    const section = parseSectPr(`
+      <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pgSz w:w="2000000000" w:h="2000000000"/>
+        <w:cols w:num="2000000000"/>
+      </w:sectPr>
+    `);
+
+    expect(section.pageWidth).toBe(31_680);
+    expect(section.pageHeight).toBe(31_680);
+    expect(section.columnCount).toBe(45);
+  });
+});
+
 describe("serializeSectionProperties", () => {
   test("keeps titlePg before bidi in sectPr order", () => {
     const xml = serializeSectionProperties({

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -36,6 +36,7 @@ import type {
   ShadingProperties,
   Paragraph,
 } from "../../types/document";
+import { isValidHexColor } from "../../utils/colorResolver";
 import { serializeBorder } from "./borderSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
 
@@ -206,36 +207,36 @@ function serializeShading(shading: ShadingProperties | undefined): string {
 
   // Pattern/val
   if (shading.pattern) {
-    attrs.push(`w:val="${shading.pattern}"`);
+    attrs.push(`w:val="${escapeXml(shading.pattern)}"`);
   } else {
     attrs.push('w:val="clear"');
   }
 
   // Color (pattern color)
-  if (shading.color?.rgb) {
-    attrs.push(`w:color="${shading.color.rgb}"`);
+  if (shading.color?.rgb && isValidHexColor(shading.color.rgb)) {
+    attrs.push(`w:color="${escapeXml(shading.color.rgb)}"`);
   } else if (shading.color?.auto) {
     attrs.push('w:color="auto"');
   }
 
   // Fill (background color)
-  if (shading.fill?.rgb) {
-    attrs.push(`w:fill="${shading.fill.rgb}"`);
+  if (shading.fill?.rgb && isValidHexColor(shading.fill.rgb)) {
+    attrs.push(`w:fill="${escapeXml(shading.fill.rgb)}"`);
   } else if (shading.fill?.auto) {
     attrs.push('w:fill="auto"');
   }
 
   // Theme fill
   if (shading.fill?.themeColor) {
-    attrs.push(`w:themeFill="${shading.fill.themeColor}"`);
+    attrs.push(`w:themeFill="${escapeXml(shading.fill.themeColor)}"`);
   }
 
   if (shading.fill?.themeTint) {
-    attrs.push(`w:themeFillTint="${shading.fill.themeTint}"`);
+    attrs.push(`w:themeFillTint="${escapeXml(shading.fill.themeTint)}"`);
   }
 
   if (shading.fill?.themeShade) {
-    attrs.push(`w:themeFillShade="${shading.fill.themeShade}"`);
+    attrs.push(`w:themeFillShade="${escapeXml(shading.fill.themeShade)}"`);
   }
 
   if (attrs.length === 0) {

--- a/packages/core/src/docx/serializer/xmlUtils.ts
+++ b/packages/core/src/docx/serializer/xmlUtils.ts
@@ -2,6 +2,8 @@
  * Shared XML utility functions for serializers.
  */
 
+import { getLocalName, parseXml } from "../xmlParser";
+
 export function escapeXml(text: string): string {
   return text
     .replace(/&/gu, "&amp;")
@@ -28,4 +30,37 @@ export function intAttr(value: number | undefined | null): string {
     return "0";
   }
   return String(Math.round(value));
+}
+
+/**
+ * Verify that `xml` parses to exactly one root element named `expectedLocalName`
+ * (namespace prefix ignored). Used to gate raw XML snapshots — e.g. an SDT's
+ * `rawPropertiesXml`/`rawEndPropertiesXml` — before splicing them verbatim
+ * into a serialized document. Those snapshots are normally produced by our
+ * own parser, but they can also arrive from an untrusted surface (a
+ * programmatically constructed node, a collaboration payload); a value that
+ * is not a single well-formed `<w:sdtPr>`/`<w:sdtEndPr>` element could inject
+ * sibling markup or close the enclosing `<w:sdt>` early. Callers should fall
+ * back to a synthesized properties block when this returns `false`.
+ */
+export function isSingleWellFormedElement(xml: string, expectedLocalName: string): boolean {
+  const trimmed = xml.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  let parsed: ReturnType<typeof parseXml>;
+  try {
+    parsed = parseXml(trimmed);
+  } catch {
+    return false;
+  }
+
+  const roots = (parsed.elements ?? []).filter((element) => element.type === "element");
+  if (roots.length !== 1) {
+    return false;
+  }
+
+  const root = roots[0];
+  return root?.name !== undefined && getLocalName(root.name) === expectedLocalName;
 }

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -1,31 +1,80 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
+import { RELATIONSHIP_TYPES } from "../relsParser";
 import { extractDocxText } from "./extractDocxText";
 
 const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+const PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships";
 
 type MakeDocxOptions = {
   body: string;
   headers?: Record<string, string>;
   footers?: Record<string, string>;
+  /**
+   * Header/footer part paths present in the archive but deliberately left
+   * out of `word/_rels/document.xml.rels` + every section's
+   * `w:headerReference` / `w:footerReference` — an orphan part no section
+   * actually wires up, the way a stale or planted part would look.
+   */
+  orphanParts?: Record<string, "header" | "footer">;
 };
 
+/**
+ * Build a minimal DOCX. When `headers`/`footers` are given, also wires them
+ * up the way a real Word document does — a relationship in
+ * `word/_rels/document.xml.rels` plus a matching `w:headerReference` /
+ * `w:footerReference` on the body's `w:sectPr` — since `extractDocxText`
+ * resolves referenced parts through that wiring rather than by filename.
+ */
 const makeDocx = async ({
   body,
   headers = {},
   footers = {},
+  orphanParts = {},
 }: MakeDocxOptions): Promise<Uint8Array> => {
   const zip = new JSZip();
+  const relationships: string[] = [];
+  const sectionReferences: string[] = [];
+  let nextRId = 1;
+
+  const wireParts = (
+    parts: Record<string, string>,
+    kind: "header" | "footer",
+    relationshipType: string,
+  ): void => {
+    const rootName = kind === "header" ? "hdr" : "ftr";
+    for (const [path, content] of Object.entries(parts)) {
+      zip.file(path, `<w:${rootName} xmlns:w="${W_NS}">${content}</w:${rootName}>`);
+      const rId = `rId${nextRId++}`;
+      const target = path.replace(/^word\//, "");
+      relationships.push(`<Relationship Id="${rId}" Type="${relationshipType}" Target="${target}"/>`);
+      sectionReferences.push(`<w:${kind}Reference w:type="default" r:id="${rId}"/>`);
+    }
+  };
+
+  wireParts(headers, "header", RELATIONSHIP_TYPES.header);
+  wireParts(footers, "footer", RELATIONSHIP_TYPES.footer);
+
+  for (const [path, kind] of Object.entries(orphanParts)) {
+    const rootName = kind === "header" ? "hdr" : "ftr";
+    zip.file(path, `<w:${rootName} xmlns:w="${W_NS}">${paragraph("Orphan")}</w:${rootName}>`);
+    // Deliberately no Relationship entry and no section reference — this
+    // part exists in the archive but nothing wires it up.
+  }
+
+  const sectPr = sectionReferences.length > 0 ? `<w:sectPr>${sectionReferences.join("")}</w:sectPr>` : "";
   zip.file(
     "word/document.xml",
-    `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
+    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${body}${sectPr}</w:body></w:document>`,
   );
-  for (const [path, content] of Object.entries(headers)) {
-    zip.file(path, `<w:hdr xmlns:w="${W_NS}">${content}</w:hdr>`);
-  }
-  for (const [path, content] of Object.entries(footers)) {
-    zip.file(path, `<w:ftr xmlns:w="${W_NS}">${content}</w:ftr>`);
+  if (relationships.length > 0) {
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}">${relationships.join("")}</Relationships>`,
+    );
   }
   return await zip.generateAsync({ type: "uint8array" });
 };
@@ -68,6 +117,30 @@ describe("extractDocxText", () => {
     ]);
     expect(result.charCount).toBe("Header 1Header 2BeforeCellControlAfterFooter".length);
     expect(result.view).toBe("accepted");
+  });
+
+  test("excludes an orphaned header/footer part no section references", async () => {
+    const bytes = await makeDocx({
+      body: paragraph("Before"),
+      headers: {
+        "word/header1.xml": paragraph("Referenced header"),
+      },
+      orphanParts: {
+        // Present in the archive, and filename-shaped like a real header,
+        // but wired into neither the rels nor any section — stale content
+        // (or a planted prompt-injection payload) that Word itself never
+        // renders must not be surfaced here either.
+        "word/header2.xml": "header",
+        "word/footer1.xml": "footer",
+      },
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text, source }) => ({ text, source }))).toEqual([
+      { text: "Referenced header", source: "header" },
+      { text: "Before", source: "body" },
+    ]);
   });
 
   test("preserves explicit whitespace and applies the accepted revision view", async () => {

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -49,7 +49,9 @@ const makeDocx = async ({
       zip.file(path, `<w:${rootName} xmlns:w="${W_NS}">${content}</w:${rootName}>`);
       const rId = `rId${nextRId++}`;
       const target = path.replace(/^word\//, "");
-      relationships.push(`<Relationship Id="${rId}" Type="${relationshipType}" Target="${target}"/>`);
+      relationships.push(
+        `<Relationship Id="${rId}" Type="${relationshipType}" Target="${target}"/>`,
+      );
       sectionReferences.push(`<w:${kind}Reference w:type="default" r:id="${rId}"/>`);
     }
   };
@@ -64,7 +66,8 @@ const makeDocx = async ({
     // part exists in the archive but nothing wires it up.
   }
 
-  const sectPr = sectionReferences.length > 0 ? `<w:sectPr>${sectionReferences.join("")}</w:sectPr>` : "";
+  const sectPr =
+    sectionReferences.length > 0 ? `<w:sectPr>${sectionReferences.join("")}</w:sectPr>` : "";
   zip.file(
     "word/document.xml",
     `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${body}${sectPr}</w:body></w:document>`,

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -1,9 +1,11 @@
 import type { DocxArchive } from "./boundedArchive";
 import { loadDocxArchive } from "./boundedArchive";
+import { parseRelationships, RELATIONSHIP_TYPES } from "../relsParser";
 import {
   findAllDeep,
   findChild,
   findDeep,
+  getAttribute,
   getAttributeAnyPrefix,
   getLocalName,
   getTextContent,
@@ -11,7 +13,7 @@ import {
   type XmlElement,
 } from "../xmlParser";
 
-const HEADER_FOOTER_PATH = /^word\/(?:header|footer)\d+\.xml$/u;
+const DOCUMENT_RELS_PATH = "word/_rels/document.xml.rels";
 
 /** Document part containing an extracted paragraph. */
 export type DocxParagraphSource = "header" | "body" | "footer";
@@ -195,6 +197,8 @@ type ExtractPartsOptions = {
   source: "header" | "footer";
   rootName: "hdr" | "ftr";
   startIndex: number;
+  /** Part paths to read, in extraction order — see {@link resolveReferencedHeaderFooterParts}. */
+  paths: readonly string[];
 };
 
 const extractParts = async ({
@@ -202,14 +206,11 @@ const extractParts = async ({
   source,
   rootName,
   startIndex,
+  paths,
 }: ExtractPartsOptions): Promise<ExtractContainerResult> => {
   const paragraphs: ExtractedDocxParagraph[] = [];
   let charCount = 0;
   let nextIndex = startIndex;
-  const prefix = `word/${source}`;
-  const paths = archive.entries
-    .filter((path) => HEADER_FOOTER_PATH.test(path) && path.startsWith(prefix))
-    .toSorted();
 
   for (const path of paths) {
     // oxlint-disable-next-line no-await-in-loop -- part order defines stable paragraph indices
@@ -235,6 +236,73 @@ const extractParts = async ({
   return { paragraphs, charCount };
 };
 
+/** A `word/_rels/document.xml.rels` `Target` is relative to `word/`; resolve it to a full archive-entry path. */
+const resolveWordPartPath = (target: string): string =>
+  target.startsWith("/") ? target.slice(1) : `word/${target}`;
+
+type ReferencedHeaderFooterParts = {
+  headers: string[];
+  footers: string[];
+};
+
+/**
+ * Resolve the header/footer parts actually wired into the document via
+ * `word/_rels/document.xml.rels` + each section's `w:headerReference` /
+ * `w:footerReference`, instead of extracting every `word/header*.xml` /
+ * `word/footer*.xml` entry by filename. A DOCX can carry an orphaned
+ * header/footer part (stale, or planted by an attacker) that no section
+ * references — reading it unconditionally would surface prompt-injection or
+ * stale content that Word itself never renders.
+ */
+const resolveReferencedHeaderFooterParts = async (
+  archive: DocxArchive,
+  documentRoot: XmlElement,
+): Promise<ReferencedHeaderFooterParts> => {
+  const relsXml = await archive.readEntryString(DOCUMENT_RELS_PATH);
+  if (relsXml === null) {
+    return { headers: [], footers: [] };
+  }
+  const relationships = parseRelationships(relsXml);
+
+  const headerRIds = new Set<string>();
+  const footerRIds = new Set<string>();
+  for (const sectPr of findAllDeep(documentRoot, "w", "sectPr")) {
+    for (const ref of findAllDeep(sectPr, "w", "headerReference")) {
+      const rId = getAttribute(ref, "r", "id");
+      if (rId !== null) {
+        headerRIds.add(rId);
+      }
+    }
+    for (const ref of findAllDeep(sectPr, "w", "footerReference")) {
+      const rId = getAttribute(ref, "r", "id");
+      if (rId !== null) {
+        footerRIds.add(rId);
+      }
+    }
+  }
+
+  const resolvePaths = (rIds: Set<string>, relationshipType: string): string[] => {
+    const paths = new Set<string>();
+    for (const rId of rIds) {
+      const relationship = relationships.get(rId);
+      if (
+        !relationship ||
+        relationship.type !== relationshipType ||
+        relationship.targetMode === "External"
+      ) {
+        continue;
+      }
+      paths.add(resolveWordPartPath(relationship.target));
+    }
+    return [...paths].toSorted();
+  };
+
+  return {
+    headers: resolvePaths(headerRIds, RELATIONSHIP_TYPES.header),
+    footers: resolvePaths(footerRIds, RELATIONSHIP_TYPES.footer),
+  };
+};
+
 const createEmptyResult = (): ExtractedDocxText => ({
   paragraphs: [],
   charCount: 0,
@@ -257,11 +325,14 @@ export const extractDocxText = async (
     return createEmptyResult();
   }
 
+  const referencedParts = await resolveReferencedHeaderFooterParts(archive, root);
+
   const headers = await extractParts({
     archive,
     source: "header",
     rootName: "hdr",
     startIndex: 0,
+    paths: referencedParts.headers,
   });
   const bodyResult = extractContainer({
     container: body,
@@ -273,6 +344,7 @@ export const extractDocxText = async (
     source: "footer",
     rootName: "ftr",
     startIndex: headers.paragraphs.length + bodyResult.paragraphs.length,
+    paths: referencedParts.footers,
   });
 
   return {

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -32,6 +32,12 @@ describe("parseSettings — w:defaultTabStop (§17.6.13)", () => {
     );
   });
 
+  test("floors near-zero values that would force thousands of tab stops per line", () => {
+    expect(parseSettings(wrap(`<w:defaultTabStop w:val="1"/>`)).defaultTabStop).toBe(
+      DEFAULT_TAB_STOP_TWIPS,
+    );
+  });
+
   test("ignores non-numeric values", () => {
     expect(parseSettings(wrap(`<w:defaultTabStop w:val="banana"/>`)).defaultTabStop).toBe(
       DEFAULT_TAB_STOP_TWIPS,
@@ -125,6 +131,15 @@ describe("parseSettings — document line-breaking rules", () => {
         `),
       ).lineBreakRules,
     ).toBeUndefined();
+  });
+
+  test("caps a hostile prohibited-character list instead of carrying it in full", () => {
+    const hostileCharacters = "、".repeat(10_000);
+    const settings = parseSettings(
+      wrap(`<w:noLineBreaksBefore w:lang="ja-JP" w:val="${hostileCharacters}"/>`),
+    );
+
+    expect(settings.lineBreakRules?.noLineBreaksBefore?.characters).toHaveLength(128);
   });
 });
 

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -36,6 +36,21 @@ const MAX_TAB_STOP_TWIPS = 31_680;
 const MAX_HYPHENATION_ZONE_TWIPS = 31_680;
 const MAX_CONSECUTIVE_HYPHEN_LIMIT = 255;
 
+/**
+ * Floor on `w:defaultTabStop`, in twips (1/12 inch). A near-zero value would
+ * force the layout engine to generate thousands of tab stops across a
+ * single line; below this floor we substitute the OOXML default instead.
+ */
+const MIN_TAB_STOP_TWIPS = 120;
+
+/**
+ * Sanity cap on parsed `w:noLineBreaksBefore`/`w:noLineBreaksAfter`
+ * character lists. Typical kinsoku overrides list a handful of prohibited
+ * characters; anything past this is corruption or a hostile input crafted
+ * to inflate the per-character membership set built at measure time.
+ */
+const MAX_KINSOKU_CHARACTERS_LENGTH = 128;
+
 export function parseSettings(xml: string | null): FolioDocumentSettings {
   const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
   const settings: FolioDocumentSettings = {
@@ -179,7 +194,9 @@ function parseKinsokuOverride(
   }
   const language = getAttribute(element, "w", "lang") || undefined;
   return {
-    characters,
+    // Code-point safe truncation: slicing the raw string could split a
+    // surrogate pair in half.
+    characters: Array.from(characters).slice(0, MAX_KINSOKU_CHARACTERS_LENGTH).join(""),
     ...(language ? { language } : {}),
   };
 }
@@ -197,7 +214,7 @@ function parseDefaultTabStop(root: XmlElement | null): number {
     return DEFAULT_TAB_STOP_TWIPS;
   }
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TAB_STOP_TWIPS) {
+  if (!Number.isFinite(parsed) || parsed < MIN_TAB_STOP_TWIPS || parsed > MAX_TAB_STOP_TWIPS) {
     return DEFAULT_TAB_STOP_TWIPS;
   }
   return parsed;

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -50,6 +50,15 @@ describe("table cell marker visibility", () => {
   });
 });
 
+describe("table cell grid span cap", () => {
+  test("clamps a hostile gridSpan to the practical column cap", () => {
+    const root = parseXmlDocument(`<w:tcPr ${NS}><w:gridSpan w:val="2000000000"/></w:tcPr>`);
+    const formatting = parseTableCellProperties(root);
+
+    expect(formatting?.gridSpan).toBe(63);
+  });
+});
+
 describe("table cell merge revisions", () => {
   test("preserves original and applied vertical merge states", () => {
     const table = parseTableXml(`<w:tbl ${NS}>

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -83,6 +83,14 @@ import {
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
+/**
+ * Sanity cap on `w:gridSpan` (and the derived table column count). Word's
+ * practical column limit is 63; a hostile/corrupt value here would blow up
+ * every downstream structure sized by column count (TableMap, border grids,
+ * cell-grid arrays).
+ */
+export const MAX_TABLE_COLUMNS = 63;
+
 // ============================================================================
 // TABLE MEASUREMENT PARSING
 // ============================================================================
@@ -1143,7 +1151,7 @@ export function parseTableCellProperties(
   if (gridSpanElement) {
     const gridSpan = parseNumericAttribute(gridSpanElement, "w", "val");
     if (gridSpan !== undefined && gridSpan > 1) {
-      formatting.gridSpan = gridSpan;
+      formatting.gridSpan = Math.min(gridSpan, MAX_TABLE_COLUMNS);
     }
   }
 

--- a/packages/core/src/docx/unzip.ts
+++ b/packages/core/src/docx/unzip.ts
@@ -528,6 +528,14 @@ export function isPreservableDocxEntry(path: string): boolean {
     return PRESERVABLE_MEDIA_MIME_TYPES.has(getMediaMimeType(path));
   }
 
+  // Word writes an optional package preview image (`docProps/thumbnail.jpeg`,
+  // `.wmf`, or `.emf`) into nearly every authored file. It is plain media,
+  // not active content; treat it like `word/media/` so neither the repack
+  // nor the selective-save non-preservable-entry guard drops it.
+  if (lowerPath.startsWith("docprops/thumbnail.")) {
+    return PRESERVABLE_MEDIA_MIME_TYPES.has(getMediaMimeType(path));
+  }
+
   if (lowerPath.startsWith("word/fonts/")) {
     return true;
   }

--- a/packages/core/src/docx/xmlParser.test.ts
+++ b/packages/core/src/docx/xmlParser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { elementToXml, parseXmlDocument } from "./xmlParser";
+import { collectXmlnsDeclarations, elementToXml, parseXmlDocument } from "./xmlParser";
+import type { XmlElement } from "./xmlParser";
 
 describe("OOXML parsing", () => {
   test("preserves ordered nested elements and attributes", () => {
@@ -52,5 +53,17 @@ describe("OOXML parsing", () => {
     expect(document ? elementToXml(document) : "").toContain(
       '<w:binData w:name="image1">QUJDRA==</w:binData>',
     );
+  });
+});
+
+describe("collectXmlnsDeclarations", () => {
+  test("caps a hostile number of distinct xmlns declarations on one element", () => {
+    const attributes: Record<string, string> = {};
+    for (let i = 0; i < 10_000; i++) {
+      attributes[`xmlns:ns${i}`] = `urn:example:${i}`;
+    }
+    const element: XmlElement = { type: "element", name: "w:pict", attributes };
+
+    expect(Object.keys(collectXmlnsDeclarations(element))).toHaveLength(64);
   });
 });

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -886,6 +886,14 @@ export function findAllDeep(
 }
 
 /**
+ * Sanity cap on distinct `xmlns:*` declarations collected per element. Real
+ * documents declare a handful; a hostile element with thousands of unique
+ * prefixes would otherwise get replayed onto every captured `w:pict` rawXml
+ * subtree that inherits from it.
+ */
+const MAX_XMLNS_DECLARATIONS_PER_ELEMENT = 64;
+
+/**
  * Collect every `xmlns` / `xmlns:*` declaration from an element's attributes.
  *
  * The serializer's hard-coded root namespaces only cover canonical prefixes
@@ -901,6 +909,9 @@ export function collectXmlnsDeclarations(element: XmlElement): Record<string, st
     return out;
   }
   for (const [key, value] of Object.entries(attrs)) {
+    if (Object.keys(out).length >= MAX_XMLNS_DECLARATIONS_PER_ELEMENT) {
+      break;
+    }
     if ((key === "xmlns" || key.startsWith("xmlns:")) && value !== undefined) {
       out[key] = String(value);
     }

--- a/packages/core/src/fonts/embeddedFonts.test.ts
+++ b/packages/core/src/fonts/embeddedFonts.test.ts
@@ -3,7 +3,12 @@ import JSZip from "jszip";
 
 import { parseDocx } from "../docx/parser";
 import { repackDocx } from "../docx/rezip";
-import { extractEmbeddedFonts, getEmbeddedFontFaces } from "./embeddedFonts";
+import {
+  extractEmbeddedFonts,
+  getEmbeddedFontFaces,
+  scopeEmbeddedFontFamily,
+  buildEmbeddedFontFamilyMap,
+} from "./embeddedFonts";
 import { parseEmbeddedFontTable } from "./embeddedFontTable";
 import { deobfuscateFont, isValidFontKey } from "./fontDeobfuscation";
 
@@ -153,21 +158,42 @@ describe("getEmbeddedFontFaces", () => {
       ["word/fonts/font1.odttf", obfuscated.buffer],
       ["word/fonts/font2.odttf", obfuscated.buffer],
     ]);
-    const faces = getEmbeddedFontFaces({
-      fontTableXml: FONT_TABLE_XML,
-      fontTableRelsXml: FONT_TABLE_RELS,
-      fonts,
-    });
+    const faces = getEmbeddedFontFaces(
+      {
+        fontTableXml: FONT_TABLE_XML,
+        fontTableRelsXml: FONT_TABLE_RELS,
+        fonts,
+      },
+      "nonce",
+    );
 
     expect(faces).toHaveLength(2);
     const regular = faces.find((f) => f.weight === 400 && f.style === "normal");
     const bold = faces.find((f) => f.weight === 700 && f.style === "normal");
-    expect(regular?.family).toBe("My Brand Sans");
+    // `family` is the per-document SCOPED name — never the raw DOCX name, so
+    // an embedded face cannot shadow a same-named host/system font (e.g. an
+    // embedded "Arial") via the global `document.fonts`.
+    expect(regular?.family).toBe(scopeEmbeddedFontFamily("nonce", "My Brand Sans"));
+    expect(regular?.originalFamily).toBe("My Brand Sans");
     expect(regular?.subsetted).toBe(true);
     expect(bold?.subsetted).toBe(false);
     // The de-obfuscated bytes are a valid SFNT font, byte-identical to the input.
     expect(hasSfntSignature(regular?.bytes ?? new Uint8Array())).toBe(true);
     expect(Array.from(regular?.bytes ?? new Uint8Array())).toEqual(Array.from(font));
+  });
+
+  test("two different docNonces never collide on the same original family", () => {
+    const fonts = new Map<string, ArrayBuffer>([["word/fonts/font1.odttf", obfuscated.buffer]]);
+    const facesA = getEmbeddedFontFaces(
+      { fontTableXml: FONT_TABLE_XML, fontTableRelsXml: FONT_TABLE_RELS, fonts },
+      "doc-a",
+    );
+    const facesB = getEmbeddedFontFaces(
+      { fontTableXml: FONT_TABLE_XML, fontTableRelsXml: FONT_TABLE_RELS, fonts },
+      "doc-b",
+    );
+    expect(facesA[0]?.family).not.toBe(facesB[0]?.family);
+    expect(facesA[0]?.originalFamily).toBe(facesB[0]?.originalFamily);
   });
 
   test("skips a face whose binary is missing, keeps the resolvable one", () => {
@@ -199,13 +225,17 @@ describe("getEmbeddedFontFaces", () => {
     // (`word/`) and must resolve to `word/fonts/font1.odttf`, matched even when
     // the ZIP entry carries a leading slash.
     const fonts = new Map<string, ArrayBuffer>([["/word/fonts/font1.odttf", obfuscated.buffer]]);
-    const faces = getEmbeddedFontFaces({
-      fontTableXml: FONT_TABLE_XML,
-      fontTableRelsXml: FONT_TABLE_RELS,
-      fonts,
-    });
+    const faces = getEmbeddedFontFaces(
+      {
+        fontTableXml: FONT_TABLE_XML,
+        fontTableRelsXml: FONT_TABLE_RELS,
+        fonts,
+      },
+      "nonce",
+    );
     expect(faces.map((f) => f.weight)).toEqual([400]);
-    expect(faces[0]?.family).toBe("My Brand Sans");
+    expect(faces[0]?.family).toBe(scopeEmbeddedFontFamily("nonce", "My Brand Sans"));
+    expect(faces[0]?.originalFamily).toBe("My Brand Sans");
   });
 
   test("resolves a leading-slash absolute rel target", () => {
@@ -239,15 +269,16 @@ describe("getEmbeddedFontFaces", () => {
 });
 
 describe("extractEmbeddedFonts (buffer)", () => {
-  test("end-to-end: unzips, resolves rels, de-obfuscates to a valid font", async () => {
+  test("end-to-end: unzips, resolves rels, de-obfuscates to a valid font, scopes the family", async () => {
     const font = makeFont();
     const obfuscated = deobfuscateFont(font, GUID);
     const buffer = await buildDocx({ regular: obfuscated, bold: obfuscated });
 
-    const faces = await extractEmbeddedFonts(buffer);
+    const faces = await extractEmbeddedFonts(buffer, "nonce");
     expect(faces).toHaveLength(2);
     const regular = faces.find((f) => f.weight === 400 && f.style === "normal");
-    expect(regular?.family).toBe("My Brand Sans");
+    expect(regular?.family).toBe(scopeEmbeddedFontFamily("nonce", "My Brand Sans"));
+    expect(regular?.originalFamily).toBe("My Brand Sans");
     expect(hasSfntSignature(regular?.bytes ?? new Uint8Array())).toBe(true);
     expect(Array.from(regular?.bytes ?? new Uint8Array())).toEqual(Array.from(font));
   });
@@ -259,6 +290,43 @@ describe("extractEmbeddedFonts (buffer)", () => {
     zip.file("word/document.xml", DOCUMENT_XML);
     const buffer = await zip.generateAsync({ type: "arraybuffer" });
     expect(await extractEmbeddedFonts(buffer)).toEqual([]);
+  });
+
+  test("two loads of the same buffer with no explicit docNonce never collide", async () => {
+    // Each call mints its own random nonce (see `getEmbeddedFontFaces`), so
+    // even reloading the identical document twice yields distinct scoped
+    // families — no stale registration can carry over.
+    const font = makeFont();
+    const obfuscated = deobfuscateFont(font, GUID);
+    const buffer = await buildDocx({ regular: obfuscated });
+
+    const [first, second] = await Promise.all([
+      extractEmbeddedFonts(buffer),
+      extractEmbeddedFonts(buffer),
+    ]);
+    expect(first[0]?.family).not.toBe(second[0]?.family);
+    expect(first[0]?.originalFamily).toBe(second[0]?.originalFamily);
+  });
+});
+
+describe("scopeEmbeddedFontFamily / buildEmbeddedFontFamilyMap", () => {
+  test("scoped family embeds both the nonce and the original name", () => {
+    expect(scopeEmbeddedFontFamily("abc123", "Arial")).toBe("folio-embedded-abc123-Arial");
+  });
+
+  test("buildEmbeddedFontFamilyMap maps every face's original name to its scoped family", () => {
+    const fonts = new Map<string, ArrayBuffer>([
+      ["word/fonts/font1.odttf", deobfuscateFont(makeFont(), GUID).buffer],
+      ["word/fonts/font2.odttf", deobfuscateFont(makeFont(), GUID).buffer],
+    ]);
+    const faces = getEmbeddedFontFaces(
+      { fontTableXml: FONT_TABLE_XML, fontTableRelsXml: FONT_TABLE_RELS, fonts },
+      "nonce",
+    );
+    const map = buildEmbeddedFontFamilyMap(faces);
+    expect(map.get("My Brand Sans")).toBe(scopeEmbeddedFontFamily("nonce", "My Brand Sans"));
+    // Never the raw name.
+    expect([...map.values()]).not.toContain("My Brand Sans");
   });
 });
 

--- a/packages/core/src/fonts/embeddedFonts.ts
+++ b/packages/core/src/fonts/embeddedFonts.ts
@@ -205,9 +205,7 @@ export function getEmbeddedFontFaces(
  * runs — which still carry the original name — keep resolving to the scoped
  * face that was actually registered on `document.fonts`.
  */
-export function buildEmbeddedFontFamilyMap(
-  faces: readonly EmbeddedFont[],
-): Map<string, string> {
+export function buildEmbeddedFontFamilyMap(faces: readonly EmbeddedFont[]): Map<string, string> {
   const map = new Map<string, string>();
   for (const face of faces) {
     map.set(face.originalFamily, face.family);

--- a/packages/core/src/fonts/embeddedFonts.ts
+++ b/packages/core/src/fonts/embeddedFonts.ts
@@ -18,13 +18,44 @@
 import { parseRelationships, resolveRelativePath } from "../docx/relsParser";
 import { unzipDocx } from "../docx/unzip";
 import type { RelationshipMap } from "../types";
+import { generateHexId } from "../utils/hexId";
 import { deobfuscateFont, isValidFontKey } from "./fontDeobfuscation";
 import { parseEmbeddedFontTable, type EmbeddedFontFaceRef } from "./embeddedFontTable";
 
+// A DOCX author controls both the embedded font bytes AND the `w:font
+// w:name` it's declared under — including names that collide with a real
+// installed/host font (e.g. "Arial", "Inter"). Registering an embedded face
+// under its raw name on the page-global `document.fonts` would let one
+// document's embedded bytes shadow that family for the WHOLE host page,
+// including host-page chrome that never opted into the DOCX's fonts. Every
+// face is therefore registered under a per-document SCOPED name instead —
+// see `scopeEmbeddedFontFamily` — and the raw name is never registered
+// anywhere; `buildEmbeddedFontFamilyMap` gives callers the original→scoped
+// mapping so the editor's own rendering can still resolve runs to it.
+const SCOPED_FAMILY_PREFIX = "folio-embedded";
+
+/**
+ * Build the per-document scoped family name an embedded face registers
+ * under. `docNonce` is fresh per document load (see {@link getEmbeddedFontFaces}),
+ * so the same original name in two different documents (or two loads of the
+ * same document) never collides.
+ */
+export function scopeEmbeddedFontFamily(docNonce: string, originalFamily: string): string {
+  return `${SCOPED_FAMILY_PREFIX}-${docNonce}-${originalFamily}`;
+}
+
 /** A single de-obfuscated embedded font face, ready to register as `@font-face`. */
 export type EmbeddedFont = {
-  /** Word font name to register the face under (`w:font w:name`). */
+  /**
+   * Family name to register the face under (`@font-face`/`FontFace`).
+   * Always a per-document SCOPED name (see {@link scopeEmbeddedFontFamily}) —
+   * never the raw `w:font w:name` from the DOCX. Use `originalFamily` (and
+   * {@link buildEmbeddedFontFamilyMap}) to resolve document runs, which
+   * still reference the font by its original DOCX name, to this family.
+   */
   family: string;
+  /** Original Word font name (`w:font w:name`), before scoping. */
+  originalFamily: string;
   /** CSS `font-style` the face maps to (`embed*Italic` → `italic`). */
   style: "normal" | "italic";
   /** CSS `font-weight` the face maps to (`embedBold*` → `700`). */
@@ -90,11 +121,12 @@ function lookupFontData(
 }
 
 function resolveFace(
-  family: string,
+  originalFamily: string,
   ref: EmbeddedFontFaceRef,
   kind: EmbedKind,
   fonts: ReadonlyMap<string, ArrayBuffer>,
   rels: RelationshipMap,
+  docNonce: string,
 ): EmbeddedFont | null {
   const target = rels.get(ref.relId)?.target;
   if (!target) {
@@ -118,7 +150,8 @@ function resolveFace(
         bytes;
 
   return {
-    family,
+    family: scopeEmbeddedFontFamily(docNonce, originalFamily),
+    originalFamily,
     style: kind.style,
     weight: kind.weight,
     bytes: data,
@@ -130,8 +163,16 @@ function resolveFace(
  * Resolve and de-obfuscate every embedded font face declared in a font table.
  * Pure and DOM-free. Faces whose relationship or binary is missing are skipped,
  * so the result only contains faces that produced usable bytes.
+ *
+ * `docNonce` scopes every face's registered family to one document load (see
+ * {@link scopeEmbeddedFontFamily}); defaults to a fresh random id so callers
+ * that don't care about a specific value still get per-call isolation. Pass
+ * an explicit value for deterministic tests.
  */
-export function getEmbeddedFontFaces(parts: EmbeddedFontParts): EmbeddedFont[] {
+export function getEmbeddedFontFaces(
+  parts: EmbeddedFontParts,
+  docNonce: string = generateHexId(),
+): EmbeddedFont[] {
   const entries = parseEmbeddedFontTable(parts.fontTableXml);
   if (entries.length === 0) {
     return [];
@@ -148,13 +189,30 @@ export function getEmbeddedFontFaces(parts: EmbeddedFontParts): EmbeddedFont[] {
       if (!ref) {
         continue;
       }
-      const face = resolveFace(entry.name, ref, kind, parts.fonts, rels);
+      const face = resolveFace(entry.name, ref, kind, parts.fonts, rels, docNonce);
       if (face) {
         faces.push(face);
       }
     }
   }
   return faces;
+}
+
+/**
+ * Build the original DOCX font name → scoped registered family map for a set
+ * of resolved embedded faces. Callers thread this into font resolution (see
+ * `utils/fontResolver.ts`'s `setEmbeddedFontFamilyMap`) so the document's own
+ * runs — which still carry the original name — keep resolving to the scoped
+ * face that was actually registered on `document.fonts`.
+ */
+export function buildEmbeddedFontFamilyMap(
+  faces: readonly EmbeddedFont[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const face of faces) {
+    map.set(face.originalFamily, face.family);
+  }
+  return map;
 }
 
 function findFontTableRels(allXml: ReadonlyMap<string, string>): string | undefined {
@@ -170,13 +228,19 @@ function findFontTableRels(allXml: ReadonlyMap<string, string>): string | undefi
  * Extract every embedded font face from a raw `.docx` buffer. Unzips the
  * package, then resolves + de-obfuscates the faces via
  * {@link getEmbeddedFontFaces}. Returns an empty list for documents with no
- * embedded fonts.
+ * embedded fonts. See {@link getEmbeddedFontFaces} for `docNonce`.
  */
-export async function extractEmbeddedFonts(buffer: ArrayBuffer): Promise<EmbeddedFont[]> {
+export async function extractEmbeddedFonts(
+  buffer: ArrayBuffer,
+  docNonce: string = generateHexId(),
+): Promise<EmbeddedFont[]> {
   const raw = await unzipDocx(buffer);
-  return getEmbeddedFontFaces({
-    fontTableXml: raw.fontTableXml,
-    fontTableRelsXml: findFontTableRels(raw.allXml),
-    fonts: raw.fonts,
-  });
+  return getEmbeddedFontFaces(
+    {
+      fontTableXml: raw.fontTableXml,
+      fontTableRelsXml: findFontTableRels(raw.allXml),
+      fonts: raw.fonts,
+    },
+    docNonce,
+  );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -212,7 +212,13 @@ export {
 export {
   extractEmbeddedFonts,
   getEmbeddedFontFaces,
+  buildEmbeddedFontFamilyMap,
+  scopeEmbeddedFontFamily,
   type EmbeddedFont,
   type EmbeddedFontParts,
 } from "./fonts/embeddedFonts";
-export { getGoogleFontsEnabled, setGoogleFontsEnabled } from "./utils/fontResolver";
+export {
+  getGoogleFontsEnabled,
+  setGoogleFontsEnabled,
+  setEmbeddedFontFamilyMap,
+} from "./utils/fontResolver";

--- a/packages/core/src/layout-engine/footnoteLineReservation.test.ts
+++ b/packages/core/src/layout-engine/footnoteLineReservation.test.ts
@@ -99,6 +99,36 @@ describe("footnote line-level reservation", () => {
     expect(layout.pages[0]!.footnoteReservedHeight).toBeGreaterThanOrEqual(30);
   });
 
+  test("does not reserve or record a footnote referenced only from a hidden table row", () => {
+    const paragraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "cell-paragraph",
+      runs: [textRun(1, "cell"), textRun(5, "1", 9)],
+    };
+    const table: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [{ id: "row", hidden: true, cells: [{ id: "cell", blocks: [paragraph] }] }],
+    };
+    const tableMeasure: TableMeasure = {
+      kind: "table",
+      rows: [{ cells: [{ blocks: [], width: 100, height: 20 }], height: 20 }],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 20,
+    };
+
+    const layout = layoutDocument([table], [tableMeasure], {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[9, 30]]),
+    });
+
+    expect(layout.pages[0]!.footnoteIds ?? []).toEqual([]);
+    expect(layout.pages[0]!.footnoteReservedHeight ?? 0).toBe(0);
+  });
+
   test("moves a footnote-bearing table row with its footnote reservation", () => {
     const { block: paragraph, measure: paragraphMeasure } = makePara(
       1,

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1245,7 +1245,10 @@ function collectTableRowFootnoteIds(
   row: TableBlock["rows"][number] | undefined,
   footnoteHeightById: Map<number, number> | undefined,
 ): number[] {
-  if (!row || !footnoteHeightById) {
+  // A footnote referenced only from a hidden row must not reserve or paint
+  // its body — Word never renders a hidden row, so its footnote reference
+  // never becomes visible either.
+  if (!row || !footnoteHeightById || row.hidden) {
     return [];
   }
 
@@ -1267,6 +1270,9 @@ function collectTableRowFootnoteIds(
       }
       if (block.kind === "table") {
         for (const nestedRow of block.rows) {
+          if (nestedRow.hidden) {
+            continue;
+          }
           for (const cell of nestedRow.cells) {
             walk(cell.blocks);
           }

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -8,6 +8,7 @@
 import type { ParagraphBlock, ParagraphMeasure } from "../types";
 import { lineBreakPolicyCacheParts } from "./effectiveLineBreakPolicy";
 import { getLineBreakProviderGeneration } from "./lineBreakProvider";
+import { clearFontResolvedCache } from "./measureHelpers";
 
 // =============================================================================
 // TEXT WIDTH CACHE
@@ -449,6 +450,7 @@ export function clearAllCaches(): void {
   clearTextWidthCache();
   clearFontMetricsCache();
   clearParagraphMeasureCache();
+  clearFontResolvedCache();
 }
 
 /**

--- a/packages/core/src/layout-engine/measure/effectiveLineBreakPolicy.test.ts
+++ b/packages/core/src/layout-engine/measure/effectiveLineBreakPolicy.test.ts
@@ -53,7 +53,7 @@ describe("resolveEffectiveLineBreakPolicy", () => {
     ).toEqual({
       locale: "ja-JP",
       kinsoku: true,
-      noLineBreaksBefore: "。",
+      noLineBreaksBefore: new Set(["。"]),
       useLegacyEthiopicAmharicRules: true,
     });
   });

--- a/packages/core/src/layout-engine/measure/effectiveLineBreakPolicy.ts
+++ b/packages/core/src/layout-engine/measure/effectiveLineBreakPolicy.ts
@@ -41,10 +41,10 @@ export const resolveEffectiveLineBreakPolicy = ({
     ...(locale ? { locale } : {}),
     ...(attrs?.kinsoku !== undefined ? { kinsoku: attrs.kinsoku } : {}),
     ...(before && languageMatches(before.language, locale)
-      ? { noLineBreaksBefore: before.characters }
+      ? { noLineBreaksBefore: toCodePointSet(before.characters) }
       : {}),
     ...(after && languageMatches(after.language, locale)
-      ? { noLineBreaksAfter: after.characters }
+      ? { noLineBreaksAfter: toCodePointSet(after.characters) }
       : {}),
     ...(rules?.useLegacyEthiopicAmharicRules ? { useLegacyEthiopicAmharicRules: true } : {}),
     ...(automaticHyphenation?.doNotHyphenateCaps !== undefined
@@ -126,3 +126,10 @@ const languageMatches = (ruleLanguage: string | undefined, locale: string | unde
   const active = locale.toLowerCase();
   return active === rule || active.startsWith(`${rule}-`) || rule.startsWith(`${active}-`);
 };
+
+/**
+ * Split an already length-capped kinsoku character list (settingsParser.ts)
+ * into a code-point Set so line-edge membership checks are O(1) instead of
+ * an O(n) `String.includes` scan per character measured.
+ */
+const toCodePointSet = (characters: string): ReadonlySet<string> => new Set(Array.from(characters));

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -23,9 +23,9 @@ export type LineBreakPolicy = {
   /** Apply East Asian first/last-character restrictions (`w:kinsoku`). */
   kinsoku?: boolean;
   /** Document replacement list: characters that may not begin a line. */
-  noLineBreaksBefore?: string;
+  noLineBreaksBefore?: ReadonlySet<string>;
   /** Document replacement list: characters that may not end a line. */
-  noLineBreaksAfter?: string;
+  noLineBreaksAfter?: ReadonlySet<string>;
   /** Use the legacy Ethiopic/Amharic compatibility behavior. */
   useLegacyEthiopicAmharicRules?: boolean;
   /** Keep words made entirely of capital letters unhyphenated. */
@@ -186,14 +186,14 @@ const isProhibitedLineStart = (character: string | undefined, policy?: LineBreak
   character !== undefined &&
   policy?.kinsoku !== false &&
   (policy?.noLineBreaksBefore !== undefined
-    ? policy.noLineBreaksBefore.includes(character)
+    ? policy.noLineBreaksBefore.has(character)
     : DEFAULT_PROHIBITED_LINE_START.has(character));
 
 const isProhibitedLineEnd = (character: string | undefined, policy?: LineBreakPolicy): boolean =>
   character !== undefined &&
   policy?.kinsoku !== false &&
   (policy?.noLineBreaksAfter !== undefined
-    ? policy.noLineBreaksAfter.includes(character)
+    ? policy.noLineBreaksAfter.has(character)
     : DEFAULT_PROHIBITED_LINE_END.has(character));
 
 const isCjkLineBreakParticipant = (
@@ -201,11 +201,15 @@ const isCjkLineBreakParticipant = (
   policy?: LineBreakPolicy,
 ): boolean =>
   character !== undefined &&
+  // Basic CJK character-by-character breaking applies regardless of the
+  // kinsoku setting; only the prohibited-edge participant checks below are
+  // kinsoku-gated, matching `isProhibitedLineStart`/`isProhibitedLineEnd`.
   (CJK_SCRIPT.test(character) ||
-    DEFAULT_PROHIBITED_LINE_START.has(character) ||
-    DEFAULT_PROHIBITED_LINE_END.has(character) ||
-    policy?.noLineBreaksBefore?.includes(character) === true ||
-    policy?.noLineBreaksAfter?.includes(character) === true);
+    (policy?.kinsoku !== false &&
+      (DEFAULT_PROHIBITED_LINE_START.has(character) ||
+        DEFAULT_PROHIBITED_LINE_END.has(character) ||
+        policy?.noLineBreaksBefore?.has(character) === true ||
+        policy?.noLineBreaksAfter?.has(character) === true)));
 
 const isLegacyEthiopicBreakCharacter = (
   character: string | undefined,

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -172,9 +172,9 @@ describe("isHangingPunctuation", () => {
   });
 
   test("includes document-specific prohibited line-start characters", () => {
-    expect(
-      isHangingPunctuation("※", { locale: "ja-JP", noLineBreaksBefore: new Set(["※"]) }),
-    ).toBe(true);
+    expect(isHangingPunctuation("※", { locale: "ja-JP", noLineBreaksBefore: new Set(["※"]) })).toBe(
+      true,
+    );
     expect(
       isHangingPunctuation("※", {
         locale: "ja-JP",

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -71,14 +71,14 @@ describe("findWordBreaks", () => {
   });
 
   test("applies document-specific kinsoku overrides", () => {
-    expect(findWordBreaks("中文測", { noLineBreaksBefore: "測" })).toEqual([1, 3]);
+    expect(findWordBreaks("中文測", { noLineBreaksBefore: new Set(["測"]) })).toEqual([1, 3]);
   });
 
   test("ignores custom kinsoku lists when kinsoku is disabled", () => {
     expect(
       findWordBreaks("中文測", {
         kinsoku: false,
-        noLineBreaksBefore: "測",
+        noLineBreaksBefore: new Set(["測"]),
       }),
     ).toEqual([1, 2, 3]);
   });
@@ -88,14 +88,14 @@ describe("findWordBreaks", () => {
       findWordBreaks("中文。」測", {
         locale: "ja-JP",
         kinsoku: true,
-        noLineBreaksBefore: "。",
+        noLineBreaksBefore: new Set(["。"]),
       }),
     ).toEqual([1, 3, 4, 5]);
     expect(
       findWordBreaks("中（文", {
         locale: "ja-JP",
         kinsoku: true,
-        noLineBreaksAfter: "測",
+        noLineBreaksAfter: new Set(["測"]),
       }),
     ).toEqual([1, 2, 3]);
   });
@@ -172,12 +172,14 @@ describe("isHangingPunctuation", () => {
   });
 
   test("includes document-specific prohibited line-start characters", () => {
-    expect(isHangingPunctuation("※", { locale: "ja-JP", noLineBreaksBefore: "※" })).toBe(true);
+    expect(
+      isHangingPunctuation("※", { locale: "ja-JP", noLineBreaksBefore: new Set(["※"]) }),
+    ).toBe(true);
     expect(
       isHangingPunctuation("※", {
         locale: "ja-JP",
         kinsoku: false,
-        noLineBreaksBefore: "※",
+        noLineBreaksBefore: new Set(["※"]),
       }),
     ).toBe(false);
   });
@@ -187,7 +189,7 @@ describe("isHangingPunctuation", () => {
       isHangingPunctuation("」", {
         locale: "ja-JP",
         kinsoku: true,
-        noLineBreaksBefore: "。",
+        noLineBreaksBefore: new Set(["。"]),
       }),
     ).toBe(false);
   });

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -45,6 +45,15 @@ import { layoutTextBoxContent } from "./textBoxParagraphLayout";
 const NO_WRAP_MEASURE_WIDTH = 1_000_000;
 
 /**
+ * Sanity cap on the table column count derived from summed cell colSpans
+ * when a table has no `tblGrid`/explicit column widths. Mirrors the
+ * `MAX_TABLE_COLUMNS` clamp applied to `w:gridSpan` at parse time
+ * (`docx/tableParser.ts`); enforced again here since a hostile colSpan sum
+ * would otherwise size the fallback column array and cell grid unbounded.
+ */
+const MAX_TABLE_COLUMNS = 63;
+
+/**
  * Check if an image run is a *text-wrapping* floating image — it
  * occupies an exclusion zone the body text should flow around.
  *
@@ -123,10 +132,13 @@ export function measureTableBlock(
 
   if (columnWidths.length === 0 && tableBlock.rows.length > 0) {
     // Determine total columns from first row's colSpans
-    const colCount = tableBlock.rows[0]!.cells.reduce(
-      // SAFETY: rows.length > 0
-      (sum, cell) => sum + (cell.colSpan ?? 1),
-      0,
+    const colCount = Math.min(
+      tableBlock.rows[0]!.cells.reduce(
+        // SAFETY: rows.length > 0
+        (sum, cell) => sum + (cell.colSpan ?? 1),
+        0,
+      ),
+      MAX_TABLE_COLUMNS,
     );
     const totalWidth = explicitWidthPx ?? contentWidth;
     const equalWidth = totalWidth / Math.max(1, colCount);

--- a/packages/core/src/layout-engine/measure/measureHelpers.ts
+++ b/packages/core/src/layout-engine/measure/measureHelpers.ts
@@ -83,6 +83,18 @@ function getResolvedFallback(fontFamily: string): string {
 }
 
 /**
+ * Clear the resolved-font-family cache. `resolveFontFamily`'s output for a
+ * given key can change even when the raw font names don't — e.g. when the
+ * active document's embedded-font family map changes (see
+ * `utils/fontResolver.ts`'s `setEmbeddedFontFamilyMap`) — so this must be
+ * cleared whenever that happens, not just on font-name changes. Folded into
+ * `clearAllCaches` (`./cache.ts`) so callers get it for free.
+ */
+export function clearFontResolvedCache(): void {
+  fontResolvedCache.clear();
+}
+
+/**
  * Build a CSS font string from styling properties
  *
  * Font sizes are in points and need to be converted to pixels for canvas.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -792,6 +792,23 @@ describe("measureParagraph cross-run line breaking", () => {
       expect(justifiedMeasure.lines).toHaveLength(1);
     }, fakeMeasure);
   });
+
+  test("bounds cross-run word collection for a word split across many tiny runs", () => {
+    withFakeTextMeasure(
+      () => {
+        // 100 single-character runs, well past MAX_CROSS_RUN_SEGMENTS (64),
+        // forming one word with no line-break opportunity.
+        const runs: Run[] = Array.from({ length: 100 }, (_, index) => ({
+          kind: "text",
+          text: String.fromCharCode(97 + (index % 26)),
+        }));
+        const { lines } = measureParagraph(paragraph(runs), 2000);
+
+        expect(lines).toHaveLength(1);
+      },
+      { charWidth: fixedCharWidth(10) },
+    );
+  });
 });
 
 describe("automatic hyphenation", () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -900,6 +900,14 @@ type CollectCrossRunWordOptions = {
   startChar: number;
 };
 
+/**
+ * Cap on the number of runs `collectCrossRunWord` traverses per call. A
+ * paragraph split into many tiny (including empty) runs would otherwise let
+ * the search walk the full run list for every word-start position it is
+ * invoked from, without the per-word text-length budget ever kicking in.
+ */
+const MAX_CROSS_RUN_SEGMENTS = 64;
+
 /** Collect one lexical word continued through adjacent formatting runs. */
 function collectCrossRunWord({
   block,
@@ -911,6 +919,9 @@ function collectCrossRunWord({
   let width = 0;
 
   for (let runIndex = startRunIndex; runIndex < block.runs.length; runIndex++) {
+    if (runIndex - startRunIndex >= MAX_CROSS_RUN_SEGMENTS) {
+      return undefined;
+    }
     const run = block.runs[runIndex];
     if (!run || !isTextRun(run)) {
       break;

--- a/packages/core/src/prosemirror/commands/hyperlink.ts
+++ b/packages/core/src/prosemirror/commands/hyperlink.ts
@@ -15,10 +15,27 @@ import type { Mark, MarkType, Node as PMNode } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 
 import { expectHyperlinkMarkAttrs } from "../attrs";
+import { normalizeUserUrl } from "../../utils/urlSecurity";
 
 type HyperlinkRange = { start: number; end: number };
 
 const hyperlinkHref = (mark: Mark): string => expectHyperlinkMarkAttrs(mark).href;
+
+/**
+ * Normalize/sanitize a URL typed by a user (hyperlink popup edit) before it
+ * is written into a mark. Internal bookmark anchors (`#name`) bypass
+ * `normalizeUserUrl` (which parses via the `URL` constructor and would
+ * reject a bare fragment); protocol-less input (e.g. "example.com") is
+ * accepted and normalized to https; anything resolving to a disallowed
+ * scheme (javascript:, data:, file:, ...) is dropped to an empty href.
+ */
+const normalizeHyperlinkInput = (rawHref: string): string => {
+  const trimmed = rawHref.trim();
+  if (trimmed.startsWith("#")) {
+    return trimmed;
+  }
+  return normalizeUserUrl(trimmed);
+};
 
 /**
  * Contiguous ranges of text nodes in `parent` (starting at `parentStart`) that
@@ -101,7 +118,7 @@ export const editHyperlinkAtCursor = (
   }
 
   const { tooltip } = expectHyperlinkMarkAttrs(linkMark);
-  const newMark = hlType.create({ href, tooltip });
+  const newMark = hlType.create({ href: normalizeHyperlinkInput(href), tooltip });
   const textNode = view.state.schema.text(displayText, [
     ...$from.marks().filter((m) => m.type !== hlType),
     newMark,

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -100,6 +100,22 @@ const isTocStyleId = (styleId: string | undefined): boolean =>
   styleId !== undefined && TOC_STYLE_ID.test(styleId);
 
 /**
+ * Build a `nextTextBoxGroupId()` generator salted with a random per-load
+ * nonce, so minted text-box anchor ids (`<salt>:<group>:<index>`) are unique
+ * across separate conversions instead of purely sequential ("0:0", "0:1",
+ * ...) starting fresh every load. `TextBoxAnchorExtension` parses
+ * `data-docx-textbox-anchor` straight off pasted DOM and `fromProseDoc`
+ * registers anchors first-seen-wins — without the salt, a pasted external
+ * span carrying a guessed/copied id could collide with and hijack a real
+ * text box anchored in a completely different document.
+ */
+const createTextBoxGroupIdFactory = (): (() => string) => {
+  const salt = Math.random().toString(36).slice(2, 10);
+  let index = 0;
+  return () => `${salt}:${index++}`;
+};
+
+/**
  * Convert a Document to a ProseMirror document
  *
  * @param document - The Document to convert
@@ -116,8 +132,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
   // (eigenpal/docx-editor#833).
   const styleResolver = createStyleEngine(options?.styles ?? document.package.styles);
   const theme = options?.theme ?? document.package.theme ?? null;
-  let textBoxGroupIndex = 0;
-  const nextTextBoxGroupId = (): string => String(textBoxGroupIndex++);
+  const nextTextBoxGroupId = createTextBoxGroupIdFactory();
 
   const convertBodyBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
@@ -2005,8 +2020,7 @@ export function standaloneTableCellToProseMirror(
   cell: TableCell,
   nodeType: "tableCell" | "tableHeader",
 ): PMNode {
-  let textBoxGroupIndex = 0;
-  const nextTextBoxGroupId = (): string => String(textBoxGroupIndex++);
+  const nextTextBoxGroupId = createTextBoxGroupIdFactory();
   return convertTableCell({
     cell,
     styleResolver: null,
@@ -3439,8 +3453,7 @@ export function headerFooterToProseDoc(
   const nodes: PMNode[] = [];
   const styleResolver = options?.styles ? createStyleEngine(options.styles) : null;
   const theme = options?.theme ?? null;
-  let textBoxGroupIndex = 0;
-  const nextTextBoxGroupId = (): string => String(textBoxGroupIndex++);
+  const nextTextBoxGroupId = createTextBoxGroupIdFactory();
 
   const convertBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -181,3 +181,36 @@ describe("cleanPastedHtml — safety and robustness", () => {
     expect(out).toBe("");
   });
 });
+
+describe("cleanPastedHtml — text-box anchor hijack via paste", () => {
+  test("strips a data-docx-textbox-anchor marker from external HTML", () => {
+    // A page outside folio could plant this marker with an id chosen to
+    // collide with a real anchor elsewhere in the document; stripping it
+    // makes the pasted span parse as an inert, unrecognized span instead of
+    // a textBoxAnchor node.
+    const html = '<p><span data-docx-textbox-anchor="0:0">​</span>Hijack</p>';
+    const out = cleanPastedHtml(html);
+    expect(out).not.toContain("data-docx-textbox-anchor");
+    expect(out).toContain("Hijack");
+  });
+
+  test("keeps a data-docx-textbox-anchor marker inside a ProseMirror clipboard slice", () => {
+    // Internal copy/paste of a real text box serializes through
+    // prosemirror-view's clipboard wrapper, which stamps `data-pm-slice` on
+    // the outer element. That must not be treated as external DOM.
+    const html =
+      '<div data-pm-slice="0 0 []"><p><span data-docx-textbox-anchor="0:0">​</span>Real box</p></div>';
+    const out = cleanPastedHtml(html);
+    expect(out).toContain("data-docx-textbox-anchor");
+    expect(out).toContain("Real box");
+  });
+
+  test("strips a single- or double-quoted anchor attribute value", () => {
+    expect(cleanPastedHtml("<span data-docx-textbox-anchor='0:0'>x</span>")).not.toContain(
+      "data-docx-textbox-anchor",
+    );
+    expect(cleanPastedHtml('<span data-docx-textbox-anchor="0:0">x</span>')).not.toContain(
+      "data-docx-textbox-anchor",
+    );
+  });
+});

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -164,6 +164,38 @@ const NOISE_TAG = new RegExp(`<\\/?(?:font|meta|link)${TAG_TAIL}>`, "gi");
 const EMPTY_SPAN = new RegExp(`<span(?:\\s${TAG_TAIL})?><\\/span>`, "gi");
 const MAX_EMPTY_SPAN_PASSES = 5;
 
+// ProseMirror's own clipboard serializer wraps a copied slice's top element
+// with `data-pm-slice="<openStart> <openEnd> <context>"` (see
+// prosemirror-view's `serializeForClipboard`). Its presence is the only
+// signal available at this string-transform layer that the incoming HTML
+// came from a ProseMirror editor's own copy rather than an arbitrary
+// external DOM (another app, a browser page, a hand-crafted paste).
+const PM_SLICE_MARKER = /\bdata-pm-slice\s*=/i;
+
+// `data-docx-textbox-anchor` is an internal reconstruction marker
+// (`TextBoxAnchorExtension`) that `fromProseDoc` uses to relocate a
+// paragraph's sibling text box on save, registering the first anchor it
+// sees for a given id. It should never originate from outside a
+// ProseMirror-serialized folio slice: an external page could plant a span
+// carrying an id that collides with — and hijacks — a real text box's
+// anchor (relocating it, or wrapping it in an attacker-controlled
+// hyperlink). Strip the attribute so a matching span parses as an inert,
+// zero-width `<span>` instead of a `textBoxAnchor` node.
+const TEXTBOX_ANCHOR_ATTR = /\s+data-docx-textbox-anchor(?:="[^"]*"|='[^']*')?/gi;
+
+/**
+ * Remove the `data-docx-textbox-anchor` marker from HTML that did not come
+ * from a ProseMirror clipboard slice (see {@link PM_SLICE_MARKER}). Internal
+ * copy/paste of a real text box carries the marker HTML unmodified so it
+ * keeps working; anything else has the marker stripped defensively.
+ */
+function stripForeignTextBoxAnchors(html: string, originalHtml: string): string {
+  if (PM_SLICE_MARKER.test(originalHtml)) {
+    return html;
+  }
+  return html.replace(TEXTBOX_ANCHOR_ATTR, "");
+}
+
 /**
  * Remove empty spans left behind after stripping `mso-*` styles. Only truly
  * empty spans are removed (whitespace-only spans are kept so word-separating
@@ -203,6 +235,7 @@ export function cleanPastedHtml(html: string): string {
     cleaned = cleaned.replace(NOISE_TAG, "");
     cleaned = stripMsoStyles(cleaned);
     cleaned = stripEmptySpans(cleaned);
+    cleaned = stripForeignTextBoxAnchors(cleaned, html);
     return cleaned.trim();
   } catch {
     return html;

--- a/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.test.ts
@@ -1,0 +1,74 @@
+// Security regression: `parseDOM`/`toDOM` must strip javascript:/data:/file:
+// hrefs so pasted or programmatically-authored anchors never reach the live
+// DOM as a navigable link, while internal bookmark anchors (`#name`) keep
+// working unchanged.
+
+import { describe, expect, test } from "bun:test";
+
+import { HyperlinkExtension } from "./HyperlinkExtension";
+
+// Minimal getAttribute-only stand-in — `getAttrs` only calls
+// `dom.getAttribute`, so a full HTMLElement isn't needed to exercise it.
+const fakeAnchorDom = (attrs: Record<string, string>): HTMLElement =>
+  ({
+    getAttribute: (name: string) => attrs[name] ?? null,
+  }) as unknown as HTMLElement;
+
+const getParseDomAttrs = (dom: HTMLElement) => {
+  const rule = HyperlinkExtension().config.markSpec.parseDOM?.[0];
+  if (!rule?.getAttrs) {
+    throw new Error("HyperlinkExtension must define parseDOM[0].getAttrs");
+  }
+  return rule.getAttrs(dom) as { href: string } | false | null;
+};
+
+describe("HyperlinkExtension parseDOM — href sanitization", () => {
+  test("strips javascript: hrefs to an empty href", () => {
+    const executableHref = ["java", "script:alert(1)"].join("");
+    const attrs = getParseDomAttrs(fakeAnchorDom({ href: executableHref }));
+    expect(attrs).not.toBe(false);
+    expect((attrs as { href: string }).href).toBe("");
+  });
+
+  test("strips data: hrefs to an empty href", () => {
+    const attrs = getParseDomAttrs(fakeAnchorDom({ href: "data:text/html,<script></script>" }));
+    expect((attrs as { href: string }).href).toBe("");
+  });
+
+  test("strips file: hrefs to an empty href", () => {
+    const attrs = getParseDomAttrs(fakeAnchorDom({ href: "file:///etc/passwd" }));
+    expect((attrs as { href: string }).href).toBe("");
+  });
+
+  test("keeps allow-listed https hrefs", () => {
+    const attrs = getParseDomAttrs(fakeAnchorDom({ href: "https://example.com/doc" }));
+    expect((attrs as { href: string }).href).toBe("https://example.com/doc");
+  });
+
+  test("keeps internal bookmark anchors", () => {
+    const attrs = getParseDomAttrs(fakeAnchorDom({ href: "#bookmark1" }));
+    expect((attrs as { href: string }).href).toBe("#bookmark1");
+  });
+});
+
+describe("HyperlinkExtension toDOM — defense-in-depth href sanitization", () => {
+  test("re-sanitizes an unsafe href already stored on the mark", () => {
+    const spec = HyperlinkExtension().config.markSpec;
+    if (!spec.toDOM) {
+      throw new Error("HyperlinkExtension must define toDOM");
+    }
+
+    const executableHref = ["java", "script:alert(1)"].join("");
+    const fakeMark = {
+      type: { name: "hyperlink" },
+      attrs: { href: executableHref, tooltip: null, rId: null, _docxHyperlinkIndex: null },
+    } as Parameters<typeof spec.toDOM>[0];
+
+    const output = spec.toDOM(fakeMark, true);
+    if (!Array.isArray(output)) {
+      throw new TypeError("Expected DOMOutputSpec to be an array");
+    }
+    const domAttrs = output[1] as Record<string, string> | undefined;
+    expect(domAttrs?.["href"]).toBe("");
+  });
+});

--- a/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.ts
@@ -6,9 +6,53 @@ import { panic } from "better-result";
 import type { Command, EditorState } from "prosemirror-state";
 
 import { expectHyperlinkMarkAttrs } from "../../attrs";
+import { normalizeUserUrl, sanitizeExternalUrl } from "../../../utils/urlSecurity";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 import { isMarkActive } from "./markUtils";
+
+// ============================================================================
+// HREF SANITIZATION HELPERS
+// ============================================================================
+
+// Internal bookmark anchors (`#name`) are not absolute URLs, so they never
+// reach `sanitizeExternalUrl`/`normalizeUserUrl` (which parse via the `URL`
+// constructor and would reject them). Adapters resolve `#name` hrefs to
+// bookmark navigation directly off the DOM attribute, so they must survive
+// both the DOM round-trip and dialog/programmatic writes unchanged.
+
+/**
+ * Sanitize an href arriving from (or being emitted to) the DOM: pasted HTML,
+ * clipboard content, or a mark attr already stored on the document. Only
+ * allow-listed absolute URLs (http/https/mailto/tel) and internal bookmark
+ * anchors survive; everything else (javascript:, data:, file:, ...) becomes
+ * an empty href, matching how the codebase already signals "no link" for an
+ * unresolved hyperlink (see `toProseDoc.ts`'s `hyperlink.href || ""`).
+ */
+function sanitizeStoredHref(rawHref: string | undefined): string {
+  if (!rawHref) {
+    return "";
+  }
+  const trimmed = rawHref.trim();
+  if (trimmed.startsWith("#")) {
+    return trimmed;
+  }
+  return sanitizeExternalUrl(trimmed) ?? "";
+}
+
+/**
+ * Normalize/sanitize a URL typed by a user (hyperlink dialog/popup) before it
+ * is written into a mark. Protocol-less input (e.g. "example.com") is
+ * accepted and normalized to https; anything resolving to a disallowed
+ * scheme is dropped.
+ */
+function normalizeHyperlinkInput(rawHref: string): string {
+  const trimmed = rawHref.trim();
+  if (trimmed.startsWith("#")) {
+    return trimmed;
+  }
+  return normalizeUserUrl(trimmed);
+}
 
 // ============================================================================
 // HYPERLINK QUERY HELPERS (exported for toolbar)
@@ -84,8 +128,10 @@ export const HyperlinkExtension = createMarkExtension({
       {
         tag: "a[href]",
         getAttrs: (dom) => ({
-          // HTMLElement.getAttribute is available on all element types
-          href: dom.getAttribute("href") ?? "",
+          // HTMLElement.getAttribute is available on all element types.
+          // Sanitize on the way in so pasted/programmatic anchors carrying
+          // javascript:/data:/file: hrefs never make it into the mark.
+          href: sanitizeStoredHref(dom.getAttribute("href") ?? undefined),
           tooltip: dom.getAttribute("title") ?? undefined,
         }),
       },
@@ -93,7 +139,9 @@ export const HyperlinkExtension = createMarkExtension({
     toDOM(mark) {
       const { href, tooltip } = expectHyperlinkMarkAttrs(mark);
       const domAttrs: Record<string, string> = {
-        href,
+        // Defense in depth: re-sanitize the stored href before it reaches the
+        // live DOM, in case a mark was created by another path.
+        href: sanitizeStoredHref(href),
         target: "_blank",
         rel: "noopener noreferrer",
       };
@@ -119,7 +167,10 @@ export const HyperlinkExtension = createMarkExtension({
         }
 
         if (dispatch) {
-          const mark = hlType.create({ href, tooltip: tooltip || null });
+          const mark = hlType.create({
+            href: normalizeHyperlinkInput(href),
+            tooltip: tooltip || null,
+          });
           let tr = state.tr.addMark(from, to, mark);
           // Remove any explicit text color so the default hyperlink blue (#0563c1)
           // shows through, matching MS Word behavior
@@ -182,7 +233,10 @@ export const HyperlinkExtension = createMarkExtension({
       (text: string, href: string, tooltip?: string): Command =>
       (state, dispatch) => {
         if (dispatch) {
-          const mark = hlType.create({ href, tooltip: tooltip || null });
+          const mark = hlType.create({
+            href: normalizeHyperlinkInput(href),
+            tooltip: tooltip || null,
+          });
           const textNode = state.schema.text(text, [mark]);
           dispatch(state.tr.replaceSelectionWith(textNode, false).scrollIntoView());
         }

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.test.ts
@@ -411,3 +411,65 @@ describe("addColumn position mapping (collapsed caret)", () => {
     expect(rowCellCounts(state.doc)).toEqual([4, 4, 4]);
   });
 });
+
+// Pasted table cells carry their background color as `data-bgcolor` (our own
+// round-trip marker, written by tableCellSpec.toDOM) so it survives a
+// paste that goes through the browser's clipboard HTML rather than our own
+// serializer. Unlike `element.style.backgroundColor`, which the CSSOM
+// already normalizes to a real color, `dataset` is read back as opaque
+// text — a crafted clipboard payload can put anything there, including a
+// CSS `url(...)` fragment. `parseCellAttrsFromDOM` must reject a value
+// that isn't a real hex color rather than trusting it into
+// `background-color: #${backgroundColor}` at render time.
+describe("table cell paste — dataset.bgcolor validation", () => {
+  const fakeCellElement = (bgcolor: string) =>
+    ({
+      style: {
+        borderTopStyle: "",
+        borderTopColor: "",
+        borderTopWidth: "",
+        borderBottomStyle: "",
+        borderBottomColor: "",
+        borderBottomWidth: "",
+        borderLeftStyle: "",
+        borderLeftColor: "",
+        borderLeftWidth: "",
+        borderRightStyle: "",
+        borderRightColor: "",
+        borderRightWidth: "",
+        paddingTop: "",
+        paddingRight: "",
+        paddingBottom: "",
+        paddingLeft: "",
+        verticalAlign: "",
+        backgroundColor: "",
+      },
+      dataset: { bgcolor },
+      getAttribute: () => null,
+    }) as unknown as HTMLElement;
+
+  const getCellAttrs = (bgcolor: string): Record<string, unknown> => {
+    const rule = schema.nodes["tableCell"]?.spec.parseDOM?.[0];
+    // `rule.tag` is the ParseRule union's discriminant (TagParseRule.tag is a
+    // required string; StyleParseRule.tag is always undefined) — narrowing
+    // on it is what lets TS accept an HTMLElement argument to `getAttrs`.
+    if (!rule?.tag || !rule.getAttrs) {
+      throw new Error("Expected tableCell parseDOM tag rule with getAttrs");
+    }
+    const attrs = rule.getAttrs(fakeCellElement(bgcolor));
+    if (!attrs) {
+      throw new Error("Expected getAttrs to return an attrs object");
+    }
+    return attrs as Record<string, unknown>;
+  };
+
+  test("rejects a dataset.bgcolor carrying a CSS url() payload", () => {
+    const attrs = getCellAttrs("FFFFFF 0,red 1px),url(//x)");
+    expect(attrs["backgroundColor"]).toBeUndefined();
+  });
+
+  test("accepts a valid 6-digit hex dataset.bgcolor", () => {
+    const attrs = getCellAttrs("336699");
+    expect(attrs["backgroundColor"]).toBe("336699");
+  });
+});

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -27,7 +27,7 @@ import {
   TABLE_WIDTH_TYPE_VALUES,
 } from "../../../types/documentEnumValues";
 import type { TableBorders } from "../../../types/formatting";
-import { resolveColor } from "../../../utils/colorResolver";
+import { isValidHexColor, resolveColor } from "../../../utils/colorResolver";
 import {
   expectTableAttrs,
   expectTableCellAttrs,
@@ -238,8 +238,17 @@ function parseCellAttrsFromDOM(element: HTMLElement): TableCellAttrs {
   const valignFromData: TableCellAttrs["verticalAlign"] =
     rawValign === "top" || rawValign === "center" || rawValign === "bottom" ? rawValign : undefined;
   const verticalAlign = valignFromData ?? mapCssVerticalAlign(style.verticalAlign) ?? undefined;
+  // `dataset["bgcolor"]` is our own round-trip marker (see toDOM below), but
+  // it is read back from arbitrary pasted HTML — unlike `style.backgroundColor`,
+  // which the browser's CSSOM already normalizes to a real color, a raw
+  // dataset value could carry a crafted CSS payload (e.g. `url(...)`).
+  // Validate it as a hex color before trusting it; `toDOM` builds
+  // `background-color: #${backgroundColor}` directly from this attr.
+  const rawBgColor = element.dataset["bgcolor"];
   const backgroundColor =
-    element.dataset["bgcolor"] || parseCssColorToHex(style.backgroundColor) || undefined;
+    (isValidHexColor(rawBgColor) ? rawBgColor : undefined) ||
+    parseCssColorToHex(style.backgroundColor) ||
+    undefined;
   // getAttribute returns string|null; colSpan/rowSpan default to 1 per HTML spec
   const colspan = Number(element.getAttribute("colspan") ?? "1") || 1;
   const rowspan = Number(element.getAttribute("rowspan") ?? "1") || 1;

--- a/packages/core/src/prosemirror/plugins/contentControlWidgets.test.ts
+++ b/packages/core/src/prosemirror/plugins/contentControlWidgets.test.ts
@@ -11,7 +11,14 @@ import { describe, expect, test } from "bun:test";
 import { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
-import { ContentControlLockedError, ContentControlTypeError } from "../../content-controls";
+import {
+  ContentControlBoundError,
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "../../content-controls";
+
+/** A minimal `<w:sdtPr>` carrying a `<w:dataBinding>` — marks the control bound. */
+const BOUND_RAW_PROPERTIES_XML = '<w:sdtPr><w:dataBinding w:xpath="/root/field"/></w:sdtPr>';
 import { schema, singletonManager } from "../schema";
 import {
   dispatchDatePick,
@@ -216,6 +223,43 @@ describe("handleContentControlWidgetClick", () => {
     expect(events.at(0)?.error).toBeInstanceOf(ContentControlLockedError);
   });
 
+  test("refuses instead of throwing when toggling a bound (data-bound) checkbox", () => {
+    // An attacker DOCX can bind any typed control to XML data; the click
+    // handler must surface ContentControlBoundError as a refusal, the same
+    // as a lock or type mismatch, not let it escape as an uncaught error.
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        checked: false,
+        sdtType: "checkbox",
+        tag: "bound",
+        rawPropertiesXml: BOUND_RAW_PROPERTIES_XML,
+      },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const stateRef = {
+      state: EditorState.create({
+        doc: schema.node("doc", null, [sdt]),
+        schema,
+        plugins: [...singletonManager.getPlugins()],
+      }),
+    };
+
+    const { events, handled } = clickWidget({
+      checked: false,
+      stateRef,
+      tag: "bound",
+      type: "checkbox",
+    });
+
+    expect(handled).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events.at(0)?.kind).toBe("refused");
+    expect(events.at(0)?.error).toBeInstanceOf(ContentControlBoundError);
+    // Nothing was applied — the control's state is untouched.
+    expect(stateRef.state.doc.firstChild?.attrs["checked"]).toBe(false);
+  });
+
   test("surfaces a type error when painted metadata disagrees with the document", () => {
     const sdt = schema.node(
       "blockSdt",
@@ -303,6 +347,29 @@ describe("dispatchDropdownPick — lock handling", () => {
   });
 });
 
+describe("dispatchDropdownPick — bound handling", () => {
+  test("returns false instead of throwing when the picked control is bound", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        tag: "state",
+        rawPropertiesXml: BOUND_RAW_PROPERTIES_XML,
+        listItems: JSON.stringify([{ value: "ca", displayText: "California" }]),
+      },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const initial = EditorState.create({
+      doc: schema.node("doc", null, [sdt]),
+      schema,
+      plugins: [...singletonManager.getPlugins()],
+    });
+    const ref = { state: initial };
+    expect(() => dispatchDropdownPick(viewLike(ref) as EditorView, 0, "ca")).not.toThrow();
+    expect(dispatchDropdownPick(viewLike(ref) as EditorView, 0, "ca")).toBe(false);
+  });
+});
+
 describe("dispatchDatePick", () => {
   test("returns false instead of throwing when the picked control is locked", () => {
     const sdt = schema.node(
@@ -311,6 +378,26 @@ describe("dispatchDatePick", () => {
         sdtType: "date",
         tag: "effective",
         lock: "sdtContentLocked",
+      },
+      [schema.node("paragraph", {}, [])],
+    );
+    const initial = EditorState.create({
+      doc: schema.node("doc", null, [sdt]),
+      schema,
+      plugins: [...singletonManager.getPlugins()],
+    });
+    const ref = { state: initial };
+    expect(() => dispatchDatePick(viewLike(ref) as EditorView, 0, "2026-06-02")).not.toThrow();
+    expect(dispatchDatePick(viewLike(ref) as EditorView, 0, "2026-06-02")).toBe(false);
+  });
+
+  test("returns false instead of throwing when the picked control is bound", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "date",
+        tag: "effective",
+        rawPropertiesXml: BOUND_RAW_PROPERTIES_XML,
       },
       [schema.node("paragraph", {}, [])],
     );

--- a/packages/core/src/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/core/src/prosemirror/plugins/contentControlWidgets.ts
@@ -16,7 +16,11 @@
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
-import { ContentControlLockedError, ContentControlTypeError } from "../../content-controls";
+import {
+  ContentControlBoundError,
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "../../content-controls";
 import { findBlockSdtMatch, setContentControlValueTr } from "../commands/contentControls";
 
 export type ContentControlWidgetAnchor = {
@@ -51,7 +55,7 @@ export type ContentControlWidgetEvent =
       pmPos: number;
       sdtType: string;
       anchor: ContentControlWidgetAnchor;
-      error: ContentControlLockedError | ContentControlTypeError;
+      error: ContentControlLockedError | ContentControlTypeError | ContentControlBoundError;
     };
 
 export type ContentControlWidgetCallback = (event: ContentControlWidgetEvent) => void;
@@ -225,9 +229,17 @@ export const handleContentControlWidgetClick = ({
       return true;
     }
   } catch (error) {
-    if (error instanceof ContentControlLockedError || error instanceof ContentControlTypeError) {
+    if (
+      error instanceof ContentControlLockedError ||
+      error instanceof ContentControlTypeError ||
+      error instanceof ContentControlBoundError
+    ) {
       // Refusal is expected: emit it through the typed callback and let
-      // the editor shell decide how to surface it.
+      // the editor shell decide how to surface it. A bound (data-bound)
+      // control throws ContentControlBoundError from
+      // setContentControlValueTr — an attacker DOCX can bind any typed
+      // control, so this must be a refusal like the other two, not an
+      // uncaught UI exception.
       onEvent({
         kind: "refused",
         tag,
@@ -305,10 +317,14 @@ export function dispatchDropdownPick(view: EditorView, pmPos: number, value: str
     return true;
   } catch (error) {
     // The click-time preflight should have caught lock refusals, but the
-    // doc could have changed mid-picker. Swallow the typed refusal so the
-    // adapter UI does not crash; return false so the caller knows the
-    // change was rejected.
-    if (error instanceof ContentControlLockedError || error instanceof ContentControlTypeError) {
+    // doc could have changed mid-picker (or the control turned out to be
+    // data-bound). Swallow the typed refusal so the adapter UI does not
+    // crash; return false so the caller knows the change was rejected.
+    if (
+      error instanceof ContentControlLockedError ||
+      error instanceof ContentControlTypeError ||
+      error instanceof ContentControlBoundError
+    ) {
       return false;
     }
     throw error;
@@ -331,7 +347,11 @@ export function dispatchDatePick(view: EditorView, pmPos: number, date: string):
     view.dispatch(tr);
     return true;
   } catch (error) {
-    if (error instanceof ContentControlLockedError || error instanceof ContentControlTypeError) {
+    if (
+      error instanceof ContentControlLockedError ||
+      error instanceof ContentControlTypeError ||
+      error instanceof ContentControlBoundError
+    ) {
       return false;
     }
     throw error;

--- a/packages/core/src/render-dom/RemoteSelectionOverlay.ts
+++ b/packages/core/src/render-dom/RemoteSelectionOverlay.ts
@@ -89,14 +89,17 @@ export class RemoteSelectionOverlay {
 
       const caretElement = createOverlayElement(pagesContainer, CARET_CLASS, zIndex + 1);
       caretElement.dataset["clientId"] = String(selection.clientId);
-      caretElement.style.background = selection.color;
+      // `backgroundColor` (unlike the `background` shorthand) only accepts a
+      // <color> value, so a collaborator color that somehow carries a CSS
+      // `url(...)` payload can't be turned into a background-image beacon.
+      caretElement.style.backgroundColor = selection.color;
       setBox(caretElement, { ...caret, width: 2 });
       pagesContainer.appendChild(caretElement);
 
       const label = createOverlayElement(pagesContainer, LABEL_CLASS, zIndex + 2);
       label.dataset["clientId"] = String(selection.clientId);
       label.textContent = selection.name;
-      label.style.background = selection.color;
+      label.style.backgroundColor = selection.color;
       label.style.color = "var(--background, #fff)";
       label.style.fontSize = "10px";
       label.style.lineHeight = "1";

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -24,7 +24,11 @@ export type {
   FolioDocumentSectionHandle,
   FolioDocumentSectionReadResult,
 } from "./ai-edits/types";
-export { createFolioAITextRangeHandle } from "./ai-edits/snapshot";
+export {
+  createFolioAITextRangeHandle,
+  hashFolioAIBlockText,
+  normalizeFolioAIBlockText,
+} from "./ai-edits/snapshot";
 export { getFolioDocumentOutline, readFolioDocumentSection } from "./ai-edits/scoped-reading";
 export {
   deriveBlockId,

--- a/packages/core/src/utils/colorResolver.test.ts
+++ b/packages/core/src/utils/colorResolver.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { isValidHexColor, resolveColor, resolveColorToHex } from "./colorResolver";
+
+// A crafted `w:val`/`w:fill` (or a themeN.xml color-scheme swatch) that
+// smuggles a CSS `url()` payload instead of a real color — this is the
+// shape a themed table-fill / diagonal-border CSS-injection finding takes.
+const MALICIOUS_COLOR = "FFFFFF 0,red 1px),url(//x)";
+
+describe("isValidHexColor", () => {
+  test("accepts 3/6/8-digit hex, with or without a leading #", () => {
+    expect(isValidHexColor("FF0000")).toBe(true);
+    expect(isValidHexColor("#FF0000")).toBe(true);
+    expect(isValidHexColor("F00")).toBe(true);
+    expect(isValidHexColor("FF0000AA")).toBe(true);
+  });
+
+  test("rejects a value carrying a CSS url() payload", () => {
+    expect(isValidHexColor(MALICIOUS_COLOR)).toBe(false);
+  });
+
+  test("rejects empty/undefined/null", () => {
+    expect(isValidHexColor("")).toBe(false);
+    expect(isValidHexColor(undefined)).toBe(false);
+    expect(isValidHexColor(null)).toBe(false);
+  });
+});
+
+describe("resolveColor", () => {
+  test("resolves a valid rgb color", () => {
+    expect(resolveColor({ rgb: "ff0000" }, null)).toBe("#FF0000");
+  });
+
+  test("falls back to the safe default when rgb carries a CSS injection payload", () => {
+    expect(resolveColor({ rgb: MALICIOUS_COLOR }, null)).toBe("#000000");
+    expect(resolveColor({ rgb: MALICIOUS_COLOR }, null, "FF0000")).toBe("#FF0000");
+  });
+
+  test("falls back to the safe default when a theme-resolved swatch is malformed", () => {
+    const maliciousTheme = {
+      colorScheme: {
+        dk1: "000000",
+        lt1: "FFFFFF",
+        dk2: "44546A",
+        lt2: "E7E6E6",
+        accent1: MALICIOUS_COLOR,
+        accent2: "ED7D31",
+        accent3: "A5A5A5",
+        accent4: "FFC000",
+        accent5: "5B9BD5",
+        accent6: "70AD47",
+        hlink: "0563C1",
+        folHlink: "954F72",
+      },
+    };
+    expect(resolveColor({ themeColor: "accent1" }, maliciousTheme)).toBe("#000000");
+  });
+
+  test("auto and undefined color both resolve to the default", () => {
+    expect(resolveColor({ auto: true }, null)).toBe("#000000");
+    expect(resolveColor(undefined, null)).toBe("#000000");
+  });
+});
+
+describe("resolveColorToHex", () => {
+  test("returns the normalized hex for a valid rgb color", () => {
+    expect(resolveColorToHex({ rgb: "ff0000" }, null)).toBe("FF0000");
+  });
+
+  test("returns undefined (safe fallback / no-color) for a CSS injection payload", () => {
+    expect(resolveColorToHex({ rgb: MALICIOUS_COLOR }, null)).toBeUndefined();
+  });
+
+  test("returns undefined for auto/absent colors", () => {
+    expect(resolveColorToHex({ auto: true }, null)).toBeUndefined();
+    expect(resolveColorToHex(undefined, null)).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/colorResolver.ts
+++ b/packages/core/src/utils/colorResolver.ts
@@ -22,6 +22,40 @@
 import type { ColorValue, Theme, ThemeColorSlot, ThemeColorScheme } from "../types/document";
 
 /**
+ * Strict hex-color validator shared by every OOXML → CSS color path in this
+ * module. OOXML readers are lenient about `w:val`/`w:fill` attribute content
+ * and theme swatch text, so a crafted `<w:color>`, table shading, or
+ * `themeN.xml` color-scheme entry can carry arbitrary text — including a CSS
+ * `url(...)` payload — instead of a real color. Accepts a 3, 6, or 8 digit
+ * hex string with an optional leading `#`; anything else (including the
+ * literal `"auto"`, which callers handle separately) is rejected.
+ */
+const HEX_COLOR_PATTERN = /^#?[0-9A-Fa-f]{3}(?:[0-9A-Fa-f]{3})?(?:[0-9A-Fa-f]{2})?$/u;
+
+/**
+ * Normalize a raw color string to a bare uppercase hex value (no `#`), or
+ * `undefined` when it is not a valid 3/6/8-digit hex color. This is the
+ * single choke point every resolved color passes through before becoming a
+ * CSS string — see {@link resolveColor} and {@link resolveColorToHex}.
+ */
+function normalizeHexColor(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return HEX_COLOR_PATTERN.test(value) ? value.replace(/^#/u, "").toUpperCase() : undefined;
+}
+
+/**
+ * Public form of the same hex-color check, for callers that read a color
+ * value from an untrusted surface (e.g. a pasted DOM node's `dataset`,
+ * which bypasses the CSSOM's own value validation) and must reject it
+ * before storing it as editor state.
+ */
+export function isValidHexColor(value: string | undefined | null): boolean {
+  return typeof value === "string" && normalizeHexColor(value) !== undefined;
+}
+
+/**
  * Default theme colors (Office 2016 default theme)
  */
 const DEFAULT_THEME_COLORS: ThemeColorScheme = {
@@ -274,14 +308,18 @@ export function resolveColor(
   theme: Theme | null | undefined,
   defaultColor: string = "000000",
 ): string {
+  // `defaultColor` is normally a hardcoded literal, but validate it too
+  // (defense in depth) so a bad caller-supplied fallback can't leak through.
+  const safeDefault = normalizeHexColor(defaultColor) ?? "000000";
+
   if (!color) {
-    return `#${defaultColor}`;
+    return `#${safeDefault}`;
   }
 
   // Handle "auto" color
   if (color.auto) {
     // Auto typically means black for text, but can be context-dependent
-    return `#${defaultColor}`;
+    return `#${safeDefault}`;
   }
 
   let hexColor: string;
@@ -312,8 +350,9 @@ export function resolveColor(
     hexColor = defaultColor;
   }
 
-  // Ensure proper format
-  return `#${hexColor.toUpperCase().replace(/^#/u, "")}`;
+  // Ensure proper format — falls back to the (already validated) default
+  // when the resolved value isn't a real hex color (see HEX_COLOR_PATTERN).
+  return `#${normalizeHexColor(hexColor) ?? safeDefault}`;
 }
 
 /**
@@ -340,7 +379,7 @@ export function resolveColorToHex(
   }
 
   if (color.rgb && color.rgb !== "auto") {
-    return color.rgb.toUpperCase().replace(/^#/, "");
+    return normalizeHexColor(color.rgb);
   }
 
   return undefined;

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -9,6 +9,7 @@ import {
   hasGoogleFontEquivalent,
   isCjkFont,
   resolveFontFamily,
+  setEmbeddedFontFamilyMap,
   setGoogleFontsEnabled,
 } from "./fontResolver";
 
@@ -244,6 +245,49 @@ describe("fontResolver — Google Fonts compatibility toggle", () => {
     } finally {
       setGoogleFontsEnabled(before);
     }
+  });
+});
+
+describe("fontResolver — embedded-font family scoping", () => {
+  // `quoteFontName` only wraps names with spaces/special chars, so
+  // "Calibri" (mapped branch) stays unquoted while "My Brand Sans"
+  // (unmapped/category branch) gets quoted — this exercises both forms.
+  test("an active map substitutes the scoped family and drops the raw name, for both mapped and unmapped fonts", () => {
+    try {
+      setEmbeddedFontFamilyMap(
+        new Map([
+          ["Calibri", "folio-embedded-doc1-Calibri"],
+          ["My Brand Sans", "folio-embedded-doc1-My Brand Sans"],
+        ]),
+      );
+
+      const calibri = resolveFontFamily("Calibri");
+      expect(calibri.cssFallback.startsWith("folio-embedded-doc1-Calibri,")).toBe(true);
+      expect(calibri.cssFallback).not.toMatch(/(^|,\s*)Calibri(,|$)/u);
+
+      const brand = resolveFontFamily("My Brand Sans");
+      expect(brand.cssFallback.startsWith('"folio-embedded-doc1-My Brand Sans",')).toBe(true);
+      expect(brand.cssFallback).not.toContain('"My Brand Sans"');
+    } finally {
+      setEmbeddedFontFamilyMap(null);
+    }
+  });
+
+  test("a font absent from the map resolves unscoped as usual", () => {
+    try {
+      setEmbeddedFontFamilyMap(new Map([["My Brand Sans", "folio-embedded-doc1-My Brand Sans"]]));
+      const resolved = resolveFontFamily("Calibri");
+      expect(resolved.cssFallback).not.toContain("folio-embedded");
+      expect(resolved.cssFallback.startsWith("Calibri,")).toBe(true);
+    } finally {
+      setEmbeddedFontFamilyMap(null);
+    }
+  });
+
+  test("clearing the map (null) falls back to the raw name", () => {
+    setEmbeddedFontFamilyMap(new Map([["Calibri", "folio-embedded-doc1-Calibri"]]));
+    setEmbeddedFontFamilyMap(null);
+    expect(resolveFontFamily("Calibri").cssFallback.startsWith("Calibri,")).toBe(true);
   });
 });
 

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -739,8 +739,32 @@ export const setGoogleFontsEnabled = (enabled: boolean): void => {
 
 export const getGoogleFontsEnabled = (): boolean => googleFontsEnabled;
 
+// The active document's embedded-font original→scoped family map (see
+// `fonts/embeddedFonts.ts`). Embedded faces are never registered under their
+// raw DOCX name (that would let an embedded "Arial" shadow the host page's
+// own Arial via the global `document.fonts`); they register under a scoped
+// `folio-embedded-{docNonce}-{name}` family instead. `resolveFontFamily`
+// substitutes that scoped family in place of the raw name so the document's
+// own runs still resolve to their embedded face.
+//
+// Module-level like `googleFontsEnabled` above: the React/Vue font-lifecycle
+// effects call `setEmbeddedFontFamilyMap` once per loaded document, in the
+// same breath as their resolved-font cache invalidation (`clearAllCaches`,
+// which clears `fontResolvedCache` — see measure/measureHelpers.ts). A known
+// gap of this module-singleton approach: two editor instances with embedded
+// fonts mounted at the same time share one active map, so one instance's
+// layout pass could transiently resolve using the other's map. That is a
+// correctness edge case scoped to folio's own rendering, not a security one —
+// `document.fonts` itself never carries a raw/unscoped name either way.
+let embeddedFontFamilyMap: ReadonlyMap<string, string> | null = null;
+
+export const setEmbeddedFontFamilyMap = (map: ReadonlyMap<string, string> | null): void => {
+  embeddedFontFamilyMap = map;
+};
+
 export function resolveFontFamily(docxFontName: string): ResolvedFont {
   const normalizedName = docxFontName.trim().toLowerCase();
+  const scopedFamily = embeddedFontFamilyMap?.get(docxFontName) ?? null;
 
   // Direct mapping, or a romanized CJK spelling aliased to its native entry.
   const aliasTarget = CJK_FONT_ALIASES[normalizedName];
@@ -754,9 +778,15 @@ export function resolveFontFamily(docxFontName: string): ResolvedFont {
       aliasTarget && !mapping.fallbackStack.some((f) => f.toLowerCase() === normalizedName)
         ? [docxFontName, ...mapping.fallbackStack]
         : mapping.fallbackStack;
+    // An embedded face for this name takes priority over both the authored
+    // name and the mapped stack — it leads the list; the raw name is dropped
+    // entirely rather than also listed, since it was never registered.
+    const primaryStack = scopedFamily
+      ? [scopedFamily, ...fallbackStack.filter((f) => f.toLowerCase() !== normalizedName)]
+      : fallbackStack;
     return {
       googleFont: googleFontsEnabled ? mapping.googleFont : null,
-      cssFallback: withArabicFallback(fallbackStack.map(quoteFontName).join(", ")),
+      cssFallback: withArabicFallback(primaryStack.map(quoteFontName).join(", ")),
       originalFont: docxFontName,
       hasGoogleEquivalent: googleFontsEnabled,
       singleLineRatio: mapping.singleLineRatio,
@@ -766,10 +796,11 @@ export function resolveFontFamily(docxFontName: string): ResolvedFont {
   // No mapping - detect category and create fallback
   const category = detectFontCategory(docxFontName);
   const defaultFallback = DEFAULT_FALLBACKS[category];
+  const primaryName = scopedFamily ?? docxFontName;
 
   return {
     googleFont: null,
-    cssFallback: withArabicFallback(`${quoteFontName(docxFontName)}, ${defaultFallback}`),
+    cssFallback: withArabicFallback(`${quoteFontName(primaryName)}, ${defaultFallback}`),
     originalFont: docxFontName,
     hasGoogleEquivalent: false,
     singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,

--- a/packages/core/src/utils/hexId.test.ts
+++ b/packages/core/src/utils/hexId.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
 
-import { deterministicHexId, generateHexId, MAX_HEX_ID_EXCLUSIVE } from "./hexId";
+import { deterministicHexId, generateHexId, isValidHexId, MAX_HEX_ID_EXCLUSIVE } from "./hexId";
 
 describe("generateHexId", () => {
   test("returns an 8-character uppercase hex string", () => {
@@ -53,5 +53,21 @@ describe("deterministicHexId", () => {
       expect(id).not.toBe("00000000");
       expect(Number.parseInt(id, 16)).toBeLessThan(MAX_HEX_ID_EXCLUSIVE);
     }
+  });
+});
+
+describe("isValidHexId", () => {
+  test("accepts exactly 8 hex digits", () => {
+    expect(isValidHexId("00ABCDEF")).toBe(true);
+    expect(isValidHexId(generateHexId())).toBe(true);
+  });
+
+  test("rejects malformed ids instead of only escaping them — comment/paragraph paraId must not carry markup", () => {
+    expect(isValidHexId('12345678" ><script>alert(1)</script>')).toBe(false);
+    expect(isValidHexId("1234567")).toBe(false); // too short
+    expect(isValidHexId("123456789")).toBe(false); // too long
+    expect(isValidHexId("")).toBe(false);
+    expect(isValidHexId(undefined)).toBe(false);
+    expect(isValidHexId(null)).toBe(false);
   });
 });

--- a/packages/core/src/utils/hexId.ts
+++ b/packages/core/src/utils/hexId.ts
@@ -18,6 +18,19 @@
 export const MAX_HEX_ID_EXCLUSIVE = 0x7fffffff;
 
 /**
+ * OOXML `ST_LongHexNumber` shape: exactly 8 hex digits (`xsd:hexBinary`,
+ * length 4 bytes). `w14:paraId` / `w14:textId` / comment `paraId` /
+ * `w15:paraIdParent` are all typed this way. A value that doesn't match this
+ * is not a real Word id — it must not be trusted as one (e.g. echoed
+ * unescaped into serialized XML attributes).
+ */
+export const HEX_ID_PATTERN = /^[0-9A-Fa-f]{8}$/u;
+
+/** Whether `value` is a well-formed 8-hex-digit OOXML long-hex id. */
+export const isValidHexId = (value: string | undefined | null): boolean =>
+  typeof value === "string" && HEX_ID_PATTERN.test(value);
+
+/**
  * Random 8-char uppercase hex id, matching Microsoft's `w14:paraId`
  * extension format (also reused for comment `paraId` / `durableId`).
  *

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -655,10 +655,7 @@ describe("compareDocxVersions: move detection", () => {
       .map((c) => c.text)
       .toSorted();
     expect(movedTexts).toEqual(
-      [
-        "Confidentiality survives termination.",
-        "Notices must be delivered in writing.",
-      ].toSorted(),
+      ["Confidentiality survives termination.", "Notices must be delivered in writing."].toSorted(),
     );
     // Each movedFrom must share its moveGroupId with the matching movedTo of
     // the SAME text, not the other relocated block's.

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -15,12 +15,14 @@ import JSZip from "jszip";
 
 import { buildTextBoxTableDocument } from "./__tests__/textBoxTableDocument";
 import { FolioDocxReviewer } from "./ai-edits/headless";
+import type { FolioAIBlock } from "./ai-edits/types";
 import { parseDocx } from "./docx/parser";
 import { createDocx } from "./docx/rezip";
 import { repackDocx } from "./docx/rezip";
 import type { HeaderFooter, Paragraph } from "./types/document";
 import { createEmptyDocument } from "./utils/createDocument";
 import {
+  alignFolioBlocks,
   applyFolioVersionDiffPrivacy,
   compareDocxVersions,
   exceedsLcsBudget,
@@ -614,6 +616,62 @@ describe("compareDocxVersions: move detection", () => {
     });
     expect(diff.changes.map((c) => c.type).toSorted()).toEqual(["added", "deleted"]);
   });
+
+  test("two simultaneous relocations pair independently, exercising the per-text FIFO queue for two keys", async () => {
+    // Regression guard for detectMoves' O(k)-per-shift() -> O(1) head-cursor
+    // refactor (a plain array `.shift()` per matched `added` block became a
+    // `{ items, head }` queue keyed by text). Both "Notices" and
+    // "Confidentiality" are relocated ahead of "Governing"/"Payment" (which
+    // stay a valid monotonic stable-id pair and count as unchanged); this
+    // exercises `deletedIndexesByText` with two live keys at once so the
+    // Map-based rewrite resolves each text's own queue independently instead
+    // of cross-contaminating.
+    const base = await buildDocxBuffer([
+      { text: "Governing law shall be Czech law.", paraId: "00000001" },
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+      { text: "Notices must be delivered in writing.", paraId: "00000003" },
+      { text: "Confidentiality survives termination.", paraId: "00000004" },
+    ]);
+    const revised = await buildDocxBuffer([
+      { text: "Confidentiality survives termination.", paraId: "00000004" },
+      { text: "Notices must be delivered in writing.", paraId: "00000003" },
+      { text: "Governing law shall be Czech law.", paraId: "00000001" },
+      { text: "Payment is due within thirty days.", paraId: "00000002" },
+    ]);
+
+    const diff = await compareDocxVersions(base, revised);
+
+    expect(diff.summaryCounts).toEqual({
+      added: 0,
+      deleted: 0,
+      modified: 0,
+      formatChanged: 0,
+      moved: 2,
+      metadataChanged: 0,
+      unchanged: 2,
+    });
+    const movedTexts = diff.changes
+      .filter((c) => c.type === "movedFrom")
+      .map((c) => c.text)
+      .toSorted();
+    expect(movedTexts).toEqual(
+      [
+        "Confidentiality survives termination.",
+        "Notices must be delivered in writing.",
+      ].toSorted(),
+    );
+    // Each movedFrom must share its moveGroupId with the matching movedTo of
+    // the SAME text, not the other relocated block's.
+    for (const from of diff.changes.filter((c) => c.type === "movedFrom")) {
+      const to = diff.changes.find(
+        (c) => c.type === "movedTo" && c.moveGroupId === from.moveGroupId,
+      );
+      if (!to || to.type !== "movedTo" || from.type !== "movedFrom") {
+        throw new Error("expected a matching movedTo for every movedFrom");
+      }
+      expect(to.text).toBe(from.text);
+    }
+  });
 });
 
 describe("compareDocxVersions: format-only changes", () => {
@@ -666,6 +724,69 @@ describe("exceedsLcsBudget: pass 2's LCS cell-budget guard", () => {
     // fixture, which would make this test slow for no extra coverage.
     expect(exceedsLcsBudget(2000, 2000)).toBe(false); // exactly at budget: 4,000,000 cells
     expect(exceedsLcsBudget(2001, 2001)).toBe(true); // just over budget: 4,004,001 cells
+  });
+});
+
+describe("alignFolioBlocks: shared LCS budget across pass 2 calls", () => {
+  // Neither side carries a stable (non-`seq-NNNN`) block id, so pass 1
+  // cannot pair anything; only pass 2 (exact-text LCS) can recover the
+  // position-shifted "Gamma paragraph." match. compareDocxVersions threads
+  // ONE budget object across every story pair (see
+  // FolioVersionComparisonLcsBudget); this exercises that same threading
+  // point directly by passing a pre-exhausted budget to alignFolioBlocks
+  // (the function compareStoryBlocks calls per story) instead of the
+  // default fresh one, which is what a story pair sees once an earlier
+  // story in the same compareDocxVersions call has used up the budget.
+  const base: FolioAIBlock[] = [
+    { id: "seq-0001", kind: "paragraph", text: "Alpha paragraph." },
+    { id: "seq-0002", kind: "paragraph", text: "Gamma paragraph." },
+  ];
+  const revised: FolioAIBlock[] = [
+    { id: "seq-0003", kind: "paragraph", text: "Alpha paragraph." },
+    { id: "seq-0004", kind: "paragraph", text: "Epsilon paragraph." },
+    { id: "seq-0005", kind: "paragraph", text: "Gamma paragraph." },
+  ];
+
+  test("a fresh budget lets pass 2 recover the position-shifted match", () => {
+    const events = alignFolioBlocks(base, revised);
+    expect(events.map((e) => e.type)).toEqual(["pair", "revisedOnly", "pair"]);
+    const [alphaPair, insertion, gammaPair] = events;
+    if (
+      !alphaPair ||
+      alphaPair.type !== "pair" ||
+      !gammaPair ||
+      gammaPair.type !== "pair" ||
+      !insertion ||
+      insertion.type !== "revisedOnly"
+    ) {
+      throw new Error("expected pair/revisedOnly/pair");
+    }
+    expect(gammaPair.baseBlock.text).toBe("Gamma paragraph.");
+    expect(gammaPair.revisedBlock.text).toBe("Gamma paragraph.");
+    expect(insertion.block.text).toBe("Epsilon paragraph.");
+  });
+
+  test("an exhausted budget refuses pass 2, falling back to pass 3's positional zip", () => {
+    const events = alignFolioBlocks(base, revised, { remainingCells: 0 });
+    expect(events.map((e) => e.type)).toEqual(["pair", "pair", "revisedOnly"]);
+    const [alphaPair, mismatchedPair, insertion] = events;
+    if (
+      !alphaPair ||
+      alphaPair.type !== "pair" ||
+      !mismatchedPair ||
+      mismatchedPair.type !== "pair" ||
+      !insertion ||
+      insertion.type !== "revisedOnly"
+    ) {
+      throw new Error("expected pair/pair/revisedOnly");
+    }
+    // Without pass 2, position 1 on each side is just zipped together
+    // regardless of text: base's "Gamma paragraph." lands against revised's
+    // "Epsilon paragraph." instead of being recovered as unchanged, and
+    // revised's actual "Gamma paragraph." falls out as a bare insertion.
+    expect(mismatchedPair.baseBlock.text).toBe("Gamma paragraph.");
+    expect(mismatchedPair.revisedBlock.text).toBe("Epsilon paragraph.");
+    expect(insertion.block.text).toBe("Gamma paragraph.");
   });
 });
 

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -337,19 +337,36 @@ export const exceedsLcsBudget = (
   unpairedRevisedCount: number,
 ): boolean => unpairedBaseCount * unpairedRevisedCount > MAX_LCS_CELLS;
 
+/**
+ * Mutable cell budget SHARED across every story pair one {@link compareDocxVersions}
+ * call compares. {@link exceedsLcsBudget} alone only bounds a single pass 2
+ * call's own table; without an aggregate budget, a document with many
+ * attacker-controlled stories (footnotes/endnotes) could still force a fresh
+ * near-{@link MAX_LCS_CELLS}-sized allocation for EVERY story pair. Each
+ * `pairByExactText` call that actually runs pass 2 decrements
+ * `remainingCells` by its own `m * n`; once exhausted, every subsequent
+ * story's pass 2 is refused regardless of that story's own size, falling
+ * through to pass 3's linear positional zip.
+ */
+export type FolioVersionComparisonLcsBudget = { remainingCells: number };
+
+const createLcsBudget = (): FolioVersionComparisonLcsBudget => ({ remainingCells: MAX_LCS_CELLS });
+
 /** Pass 2: order-preserving LCS by exact text equality over the blocks pass 1 left unpaired. */
 const pairByExactText = (
   base: readonly IndexedBlock[],
   revised: readonly IndexedBlock[],
+  lcsBudget: FolioVersionComparisonLcsBudget,
 ): BlockPair[] => {
   const m = base.length;
   const n = revised.length;
   if (m === 0 || n === 0) {
     return [];
   }
-  if (exceedsLcsBudget(m, n)) {
+  if (exceedsLcsBudget(m, n) || lcsBudget.remainingCells <= 0) {
     return [];
   }
+  lcsBudget.remainingCells -= m * n;
   const baseTexts = base.map(({ block }) => block.text);
   const revisedTexts = revised.map(({ block }) => block.text);
   // A single flat Int32Array (indexed `i * (n + 1) + j`) instead of `m + 1`
@@ -412,10 +429,17 @@ export type FolioAlignedBlockEvent =
  * snapshots and flatten it into an ordered event stream. Shared by
  * {@link compareDocxVersions} and the redline generator so both interpret
  * one document walk instead of re-deriving it.
+ *
+ * `lcsBudget` defaults to a fresh, single-call budget so a caller comparing
+ * one block pair in isolation (the redline generator) behaves exactly as
+ * before. {@link compareDocxVersions} passes one budget object shared across
+ * every story pair instead, so pass 2's cell allowance is aggregate across
+ * the whole comparison rather than reset per story.
  */
 export const alignFolioBlocks = (
   baseBlocks: readonly FolioAIBlock[],
   revisedBlocks: readonly FolioAIBlock[],
+  lcsBudget: FolioVersionComparisonLcsBudget = createLcsBudget(),
 ): FolioAlignedBlockEvent[] => {
   const stableIdAnchors = pairByStableId(baseBlocks, revisedBlocks);
   const usedBaseIndexes = new Set(stableIdAnchors.map((anchor) => anchor.baseIndex));
@@ -433,7 +457,7 @@ export const alignFolioBlocks = (
       revisedRemaining.push({ block, index: blockIndex });
     }
   });
-  const exactTextAnchors = pairByExactText(baseRemaining, revisedRemaining);
+  const exactTextAnchors = pairByExactText(baseRemaining, revisedRemaining, lcsBudget);
 
   const anchors = longestIncreasingByRevisedIndex(
     [...stableIdAnchors, ...exactTextAnchors].toSorted((a, b) => a.baseIndex - b.baseIndex),
@@ -576,6 +600,32 @@ const meetsMoveWordCount = (text: string): boolean => {
 };
 
 /**
+ * Cap on how many same-text `deleted` candidates {@link detectMoves} queues
+ * per distinct text. Duplicated boilerplate at or above the word floor
+ * (e.g. a repeated long clause) could otherwise grow one text's candidate
+ * list without bound; past this cap, further same-text deletions are simply
+ * left as `deleted` (never matched to a move) instead of queued.
+ */
+const MAX_MOVE_CANDIDATES_PER_TEXT = 10_000;
+
+/**
+ * FIFO queue of `changes` indexes for one deleted text. `shift()` on a plain
+ * array is O(k); a head cursor makes dequeue O(1) so `detectMoves` stays
+ * linear in the number of added/deleted blocks instead of quadratic when a
+ * document repeats the same text many times.
+ */
+type DeletedIndexQueue = { items: number[]; head: number };
+
+const dequeueDeletedIndex = (queue: DeletedIndexQueue | undefined): number | undefined => {
+  if (!queue || queue.head >= queue.items.length) {
+    return undefined;
+  }
+  const index = queue.items[queue.head];
+  queue.head += 1;
+  return index;
+};
+
+/**
  * Re-classify `deleted` + `added` pairs with identical text as
  * `movedFrom` / `movedTo` entries sharing a `moveGroupId`, in place, so each
  * side keeps its slot in the revised-side document order. Matching is FIFO
@@ -587,12 +637,21 @@ const detectMoves = (
   counts: FolioVersionDiffSummaryCounts,
   firstMoveGroupId: number,
 ): void => {
-  const deletedIndexesByText = new Map<string, number[]>();
+  const deletedIndexesByText = new Map<string, DeletedIndexQueue>();
   changes.forEach((change, index) => {
-    if (change.type === "deleted" && meetsMoveWordCount(change.text)) {
-      const queue = deletedIndexesByText.get(change.text) ?? [];
-      queue.push(index);
-      deletedIndexesByText.set(change.text, queue);
+    if (change.type !== "deleted" || !meetsMoveWordCount(change.text)) {
+      return;
+    }
+    const queue = deletedIndexesByText.get(change.text);
+    if (!queue) {
+      deletedIndexesByText.set(change.text, { items: [index], head: 0 });
+      return;
+    }
+    // This build pass runs to completion before any dequeue below, so `head`
+    // is always 0 here; comparing against the cap directly is equivalent to
+    // (and simpler than) tracking the unconsumed remainder.
+    if (queue.items.length < MAX_MOVE_CANDIDATES_PER_TEXT) {
+      queue.items.push(index);
     }
   });
   if (deletedIndexesByText.size === 0) {
@@ -604,7 +663,7 @@ const detectMoves = (
     if (change.type !== "added") {
       return;
     }
-    const deletedIndex = deletedIndexesByText.get(change.text)?.shift();
+    const deletedIndex = dequeueDeletedIndex(deletedIndexesByText.get(change.text));
     if (deletedIndex === undefined) {
       return;
     }
@@ -664,6 +723,7 @@ type CompareStoryBlocksOptions = FolioDocumentStoryPair & {
   firstMoveGroupId: number;
   includeText: boolean;
   includeFormatting: boolean;
+  lcsBudget: FolioVersionComparisonLcsBudget;
 };
 
 const compareStoryBlocks = ({
@@ -674,11 +734,12 @@ const compareStoryBlocks = ({
   firstMoveGroupId,
   includeText,
   includeFormatting,
+  lcsBudget,
 }: CompareStoryBlocksOptions): FolioStoryDiff => {
   const changes: FolioBlockDiff[] = [];
   const counts = createSummaryCounts();
 
-  for (const event of alignFolioBlocks(baseBlocks, revisedBlocks)) {
+  for (const event of alignFolioBlocks(baseBlocks, revisedBlocks, lcsBudget)) {
     if (event.type === "pair") {
       if (!baseStory || !revisedStory) {
         panic("A paired comparison event requires both story handles");
@@ -883,6 +944,11 @@ export const compareDocxVersions = async (
   const baseStories = baseReviewer.listStories().map(({ handle }) => handle);
   const revisedStories = revisedReviewer.listStories().map(({ handle }) => handle);
   let nextMoveGroupId = 1;
+  // Shared across every story pair below (not one per story) so an
+  // attacker-controlled story count (many footnotes/endnotes) can't force a
+  // fresh near-MAX_LCS_CELLS allocation per story. See
+  // FolioVersionComparisonLcsBudget's doc comment.
+  const lcsBudget = createLcsBudget();
 
   for (const pair of pairFolioDocumentStories(baseStories, revisedStories)) {
     const baseBlocks = pair.baseStory
@@ -900,6 +966,7 @@ export const compareDocxVersions = async (
       firstMoveGroupId: nextMoveGroupId,
       includeText: scopes.has("text"),
       includeFormatting: scopes.has("formatting"),
+      lcsBudget,
     });
     stories.push(storyDiff);
     for (const change of storyDiff.changes) {

--- a/packages/core/src/watermark/index.test.ts
+++ b/packages/core/src/watermark/index.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import { RELATIONSHIP_TYPES } from "../docx/relsParser";
 import type { Document, HeaderFooter, Watermark } from "../types/document";
-import { ensureWatermarkHeaderCoverage, getDocumentWatermark, setDocumentWatermark } from "./index";
+import {
+  ensureWatermarkHeaderCoverage,
+  getDocumentWatermark,
+  isAllowedExternalWatermarkImageUrl,
+  setDocumentWatermark,
+} from "./index";
 
 function makeDoc(headers: Record<string, HeaderFooter>): Document {
   return {
@@ -16,6 +21,32 @@ function makeDoc(headers: Record<string, HeaderFooter>): Document {
 function emptyHeader(): HeaderFooter {
   return { type: "header", hdrFtrType: "default", content: [] };
 }
+
+describe("isAllowedExternalWatermarkImageUrl", () => {
+  test("allows http/https URLs", () => {
+    expect(isAllowedExternalWatermarkImageUrl("https://example.com/watermark.png")).toBe(true);
+    expect(isAllowedExternalWatermarkImageUrl("http://example.com/watermark.png")).toBe(true);
+  });
+
+  test("rejects a file: URL", () => {
+    expect(isAllowedExternalWatermarkImageUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  test("rejects a UNC path", () => {
+    expect(isAllowedExternalWatermarkImageUrl("\\\\attacker\\share\\payload.png")).toBe(false);
+  });
+
+  test("rejects an unparseable string", () => {
+    expect(isAllowedExternalWatermarkImageUrl("not a url")).toBe(false);
+    expect(isAllowedExternalWatermarkImageUrl("")).toBe(false);
+  });
+
+  test("rejects other schemes (javascript:, data:, ftp:)", () => {
+    expect(isAllowedExternalWatermarkImageUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedExternalWatermarkImageUrl("data:text/plain;base64,aGk=")).toBe(false);
+    expect(isAllowedExternalWatermarkImageUrl("ftp://example.com/watermark.png")).toBe(false);
+  });
+});
 
 describe("getDocumentWatermark", () => {
   test("returns the first header's watermark", () => {

--- a/packages/core/src/watermark/index.ts
+++ b/packages/core/src/watermark/index.ts
@@ -19,6 +19,29 @@ import type {
 export type { Watermark, TextWatermark, PictureWatermark } from "../types/document";
 
 /**
+ * Schemes allowed for a picture watermark's external image target
+ * (`TargetMode="External"` in the saved package's relationships).
+ */
+const ALLOWED_EXTERNAL_IMAGE_SCHEMES = new Set(["http:", "https:"]);
+
+/**
+ * Whether `target` is safe to save as a watermark picture's external image
+ * relationship. A watermark dialog lets an author type an arbitrary string
+ * for this field; without a scheme check it becomes a `TargetMode="External"`
+ * relationship verbatim (see `docx/rezip.ts`), which would let a `file:` URL
+ * or UNC path (`\\host\share\...`) into the exported `.docx` — a resource
+ * whatever later opens the file (e.g. Word) would try to resolve. Only
+ * `http:`/`https:` targets are allowed.
+ */
+export function isAllowedExternalWatermarkImageUrl(target: string): boolean {
+  try {
+    return ALLOWED_EXTERNAL_IMAGE_SCHEMES.has(new URL(target).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read the document's watermark. Walks every header part and returns
  * the first watermark encountered (header insertion order). Returns
  * `undefined` when no header carries one.

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -34,11 +34,67 @@ export type ValidateDocumentModelResult = {
   issues: ValidateDocumentModelIssue[];
 };
 
+/**
+ * Local bounds on the ZIP archive `validateDocxPackage` inflates parts from.
+ * `docx-core` has no dependency on `@stll/folio-core`, so these mirror the
+ * shape of `packages/core/src/docx/server/boundedArchive.ts` rather than
+ * importing it: an untrusted or generator-produced buffer must be rejected
+ * for entry count and declared uncompressed size before `document.xml` /
+ * `document.xml.rels` are inflated, so a decompression-bomb entry or an
+ * archive with an excessive part count can't force an unbounded allocation.
+ */
+const VALIDATE_DOCX_MAX_ENTRIES = 4096;
+const VALIDATE_DOCX_MAX_ENTRY_BYTES = 128 * 1024 * 1024;
+const VALIDATE_DOCX_MAX_TOTAL_BYTES = 256 * 1024 * 1024;
+
+type ZipEntryWithMetadata = { _data?: { uncompressedSize?: number } };
+
+const getDeclaredUncompressedSize = (file: JSZip.JSZipObject): number | null => {
+  const metadata = (file as JSZip.JSZipObject & ZipEntryWithMetadata)._data;
+  return typeof metadata?.uncompressedSize === "number" ? metadata.uncompressedSize : null;
+};
+
+/**
+ * Reject an archive whose entry count or declared uncompressed size (total
+ * or per-entry) exceeds the local bounds above, before any part is inflated.
+ * A declared size JSZip could not determine is skipped rather than treated
+ * as unbounded — the per-entry cap below still bounds what an inflate call
+ * can actually produce once it runs.
+ */
+const checkDocxArchiveBounds = (zip: JSZip): string | null => {
+  const entries = Object.values(zip.files);
+  if (entries.length > VALIDATE_DOCX_MAX_ENTRIES) {
+    return `Generated DOCX declares ${entries.length} archive entries, over the ${VALIDATE_DOCX_MAX_ENTRIES}-entry limit.`;
+  }
+
+  let totalUncompressedBytes = 0;
+  for (const entry of entries) {
+    const declaredBytes = getDeclaredUncompressedSize(entry);
+    if (declaredBytes === null) {
+      continue;
+    }
+    if (declaredBytes > VALIDATE_DOCX_MAX_ENTRY_BYTES) {
+      return `Generated DOCX entry "${entry.name}" declares ${declaredBytes} uncompressed bytes, over the ${VALIDATE_DOCX_MAX_ENTRY_BYTES}-byte limit.`;
+    }
+    totalUncompressedBytes += declaredBytes;
+    if (totalUncompressedBytes > VALIDATE_DOCX_MAX_TOTAL_BYTES) {
+      return `Generated DOCX declares more than ${VALIDATE_DOCX_MAX_TOTAL_BYTES} cumulative uncompressed bytes.`;
+    }
+  }
+  return null;
+};
+
 export const validateDocxPackage = async (
   buffer: ArrayBuffer | Uint8Array,
 ): Promise<ValidateDocxPackageResult> => {
   try {
     const zip = await JSZip.loadAsync(buffer);
+
+    const boundsError = checkDocxArchiveBounds(zip);
+    if (boundsError) {
+      return { valid: false, error: boundsError };
+    }
+
     for (const requiredPath of [
       "[Content_Types].xml",
       "_rels/.rels",

--- a/packages/react/src/components/CommentsSidebar.tsx
+++ b/packages/react/src/components/CommentsSidebar.tsx
@@ -310,7 +310,11 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
     // layout-computed map is the fallback for virtualized/non-rendered pages.
     for (const comment of visibleComments) {
       const cardId = `comment-${comment.id}`;
-      const el = pagesEl.querySelector(`[data-comment-id="${comment.id}"]`);
+      // `comment.id` is typed as a number, but a controlled `comments` prop
+      // supplied by the host app isn't runtime-checked — escape it before
+      // splicing into the selector so it can't break out of the attribute
+      // value (e.g. `1"] , img[src=x onerror=...`).
+      const el = pagesEl.querySelector(`[data-comment-id="${CSS.escape(String(comment.id))}"]`);
       if (el) {
         const rect = el.getBoundingClientRect();
         pushPosition(

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -36,7 +36,7 @@ import {
 // Paginated editor
 import type { Mark } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
-import { closeHistory } from "prosemirror-history";
+import { closeHistory, undo as historyUndo } from "prosemirror-history";
 import { useTranslations } from "use-intl";
 
 import {
@@ -564,6 +564,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const [outlineHeadings, setHeadingInfos] = useState<HeadingInfo[]>([]);
 
   const [, setTrackedChanges] = useState<TrackedChangeEntry[]>([]);
+  // Mirrors the tracked-change entries so the sidebar accept/reject handlers
+  // can resolve a specific `revisionId` from a (from, to) range without
+  // subscribing to the state value (avoids extra re-renders / dep churn).
+  const trackedChangesRef = useRef<TrackedChangeEntry[]>([]);
   const [anchorPositions, setAnchorPositions] =
     useState<Map<string, number>>(EMPTY_ANCHOR_POSITIONS);
 
@@ -633,6 +637,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         merged.push({ ...entry });
       }
     }
+    trackedChangesRef.current = merged;
     setTrackedChanges(merged);
   }, []);
 
@@ -2972,7 +2977,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         ) {
           return { status: "rejected", undoHandle, reason: "documentChanged" };
         }
-        if (!(pagedEditorRef.current?.undo() ?? false)) {
+        // Undo directly against the body view we just validated, rather than
+        // `pagedEditorRef.current.undo()`, which routes to whatever story
+        // (header/footer/note) currently has editor focus. Dispatching on
+        // `view` here is equivalent to what the routed undo would do when the
+        // body is active, but it can never accidentally undo an edit in a
+        // different story while reporting this AI operation as undone.
+        if (!historyUndo(view.state, view.dispatch)) {
           return { status: "rejected", undoHandle, reason: "documentChanged" };
         }
 
@@ -3815,16 +3826,32 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     setCommentSelectionRange(null);
     setAddCommentYPosition(null);
   }, [commentSelectionRange, setAddCommentYPosition, setCommentSelectionRange, setIsAddingComment]);
+  // Resolve the specific tracked-change `revisionId` for a (from, to) range
+  // reported by the sidebar. The 2-arg acceptChange/rejectChange commands
+  // treat a missing revisionId as "match every mark in range", which would
+  // also resolve an unrelated collaborator's tracked change sharing the same
+  // paragraph/row span — so callers below always resolve a revisionId first
+  // and go through the revision-scoped command instead.
+  const resolveSidebarChangeRevisionId = useCallback((from: number, to: number) => {
+    const entry = trackedChangesRef.current.find((candidate) => {
+      return candidate.from === from && candidate.to === to;
+    });
+    return entry?.revisionId ?? null;
+  }, []);
   const handleSidebarAcceptChange = useCallback(
     (from: number, to: number) => {
       const view = pagedEditorRef.current?.getView();
       if (!view) {
         return;
       }
-      acceptChange(from, to)(view.state, view.dispatch);
+      const revisionId = resolveSidebarChangeRevisionId(from, to);
+      if (revisionId === null) {
+        return;
+      }
+      acceptAIEditRevision(revisionId)(view.state, view.dispatch);
       extractTrackedChanges();
     },
-    [extractTrackedChanges],
+    [extractTrackedChanges, resolveSidebarChangeRevisionId],
   );
   const handleSidebarRejectChange = useCallback(
     (from: number, to: number) => {
@@ -3832,10 +3859,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       if (!view) {
         return;
       }
-      rejectChange(from, to)(view.state, view.dispatch);
+      const revisionId = resolveSidebarChangeRevisionId(from, to);
+      if (revisionId === null) {
+        return;
+      }
+      rejectAIEditRevision(revisionId)(view.state, view.dispatch);
       extractTrackedChanges();
     },
-    [extractTrackedChanges],
+    [extractTrackedChanges, resolveSidebarChangeRevisionId],
   );
   const commentsPageWidth = history.state?.package.document.finalSectionProperties?.pageWidth;
   const commentsSidebarOverlay = useMemo(() => {

--- a/packages/react/src/components/dialogs/WatermarkDialog.tsx
+++ b/packages/react/src/components/dialogs/WatermarkDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useState } from "react";
 import { useTranslations } from "use-intl";
 
-import type { Watermark } from "@stll/folio-core/watermark";
+import { isAllowedExternalWatermarkImageUrl, type Watermark } from "@stll/folio-core/watermark";
 import { useFolioUI } from "../../ui/folio-ui";
 import {
   DIALOG_BACKDROP_CLASS,
@@ -104,10 +104,18 @@ export function WatermarkDialog({
     washout: `${id}-watermark-washout`,
   };
 
+  // An external target becomes a `TargetMode="External"` relationship in the
+  // saved package verbatim (see `docx/rezip.ts`); restrict it to http(s) so a
+  // `file:` URL or UNC path can't ride along in the exported `.docx`.
+  const imageTargetError =
+    mode === "picture" && imageTargetExternal && imageTarget.trim().length > 0
+      ? getExternalImageTargetError(imageTarget.trim())
+      : "";
+
   const canApply =
     mode === "none" ||
     (mode === "text" && text.trim().length > 0) ||
-    (mode === "picture" && imageRId.trim().length > 0);
+    (mode === "picture" && imageRId.trim().length > 0 && imageTargetError.length === 0);
 
   const handleApply = () => {
     if (!canApply) {
@@ -234,12 +242,16 @@ export function WatermarkDialog({
                 <label className="col-span-2 flex flex-col gap-1" htmlFor={fieldIds.imageTarget}>
                   <span className={DIALOG_LABEL_CLASS}>{t("dialogs.watermark.imageTarget")}</span>
                   <input
+                    aria-invalid={imageTargetError.length > 0}
                     className={DIALOG_INPUT_CLASS}
                     id={fieldIds.imageTarget}
                     onChange={(e) => setImageTarget(e.target.value)}
                     placeholder="word/media/image1.png"
                     value={imageTarget}
                   />
+                  {imageTargetError.length > 0 && (
+                    <span className="text-destructive text-xs">{imageTargetError}</span>
+                  )}
                 </label>
                 <label className="flex flex-col gap-1" htmlFor={fieldIds.scale}>
                   <span className={DIALOG_LABEL_CLASS}>{t("dialogs.watermark.scale")}</span>
@@ -316,6 +328,13 @@ function clampScalePercent(value: number): number {
 
 function stripHash(value: string): string {
   return value.startsWith("#") ? value.slice(1) : value;
+}
+
+/** Mirrors `HyperlinkDialog.tsx`'s `getUrlError` — a plain-English, untranslated
+ * field-level validation message (existing convention for this kind of inline
+ * error in this dialog family). */
+function getExternalImageTargetError(value: string): string {
+  return isAllowedExternalWatermarkImageUrl(value) ? "" : "Use a web address (http/https).";
 }
 
 function toColorInputValue(value: string | undefined): string {

--- a/packages/react/src/components/useFolioComments.ts
+++ b/packages/react/src/components/useFolioComments.ts
@@ -16,9 +16,54 @@ import {
   useState,
 } from "react";
 
-import type { Comment } from "@stll/folio-core/types/content";
+import type { Comment, Paragraph } from "@stll/folio-core/types/content";
 import type { Document } from "@stll/folio-core/types/document";
+import { isValidHexId } from "@stll/folio-core/utils/hexId";
 import { PENDING_COMMENT_ID, getCommentAuthorKey, getCommentParentId } from "./commentsHelpers";
+
+/**
+ * Sanitize a `paraId`/`textId`-bearing paragraph: drop either field when it
+ * isn't a well-formed OOXML long-hex id (see `isValidHexId`), leaving
+ * everything else untouched. Comment paragraphs from a controlled
+ * `commentsProp` come from the host app rather than our own parser/
+ * serializer, so they aren't guaranteed to satisfy the id shape those trust.
+ */
+function sanitizeCommentParagraph(paragraph: Paragraph): Paragraph {
+  const paraIdValid = paragraph.paraId === undefined || isValidHexId(paragraph.paraId);
+  const textIdValid = paragraph.textId === undefined || isValidHexId(paragraph.textId);
+  if (paraIdValid && textIdValid) {
+    return paragraph;
+  }
+  const { paraId, textId, ...rest } = paragraph;
+  return {
+    ...rest,
+    ...(paraIdValid && paraId !== undefined ? { paraId } : {}),
+    ...(textIdValid && textId !== undefined ? { textId } : {}),
+  };
+}
+
+/**
+ * Validate a controlled `commentsProp` at the boundary before it becomes
+ * editor state. A host app (or a collaboration payload relayed through it)
+ * can hand back arbitrary JSON, so `id` isn't guaranteed numeric and
+ * paragraph `paraId`/`textId` aren't guaranteed to be real Word ids — both
+ * eventually reach XML/CSS-adjacent serialization (comment threading,
+ * `[data-comment-id]` selectors). Comments with a non-finite `id` are
+ * dropped entirely; malformed paraId/textId are stripped in place.
+ */
+function sanitizeControlledComments(comments: Comment[]): Comment[] {
+  const sanitized: Comment[] = [];
+  for (const comment of comments) {
+    if (!Number.isFinite(comment.id)) {
+      continue;
+    }
+    sanitized.push({
+      ...comment,
+      content: comment.content.map(sanitizeCommentParagraph),
+    });
+  }
+  return sanitized;
+}
 
 type UseFolioCommentsOptions = {
   /** Current document (history head); seeds comments on first load. */
@@ -50,8 +95,12 @@ export function useFolioComments({
   const [visibleCommentAuthors, setVisibleCommentAuthors] = useState<Set<string> | null>(null);
   const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
   const [internalComments, setInternalComments] = useState<Comment[]>([]);
-  const isControlledComments = commentsProp !== undefined;
-  const comments = isControlledComments ? commentsProp : internalComments;
+  const sanitizedCommentsProp = useMemo(
+    () => (commentsProp !== undefined ? sanitizeControlledComments(commentsProp) : undefined),
+    [commentsProp],
+  );
+  const isControlledComments = sanitizedCommentsProp !== undefined;
+  const comments = isControlledComments ? sanitizedCommentsProp : internalComments;
 
   const commentsDirtyRef = useRef(false);
   const commentsRef = useRef(comments);

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -97,6 +97,7 @@ import type {
   CaretPosition,
 } from "@stll/folio-core/layout-bridge/engine/selectionRects";
 import type * as SelectionGeometry from "@stll/folio-core/layout-bridge/engine/selectionRects";
+import { setEmbeddedFontFamilyMap } from "@stll/folio-core/utils/fontResolver";
 // Layout engine
 import { resolveSectionHeaderFooterRefs, type ColumnLayout } from "@stll/folio-core/layout-engine";
 import { recordLayoutPhase } from "@stll/folio-core/layout-engine/layoutInstrumentation";
@@ -5571,15 +5572,21 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       }
       let cancelled = false;
       let registered: FontFace[] = [];
-      void loadEmbeddedFontFaces(embeddedFontBuffer).then((faces) => {
+      void loadEmbeddedFontFaces(embeddedFontBuffer).then(({ faces, familyMap }) => {
         if (cancelled) {
           removeFontFaces(faces);
           return undefined;
         }
         registered = faces;
-        if (faces.length === 0) {
+        if (faces.length === 0 && familyMap.size === 0) {
           return undefined;
         }
+        // Activate this document's original→scoped embedded-font family map
+        // before invalidating the resolved-font cache, so every run that
+        // resolves after this point (measurement + paint) picks up the
+        // scoped family instead of the raw DOCX name — which is never
+        // registered on `document.fonts` (see `fonts/embeddedFonts.ts`).
+        setEmbeddedFontFamilyMap(familyMap.size > 0 ? familyMap : null);
         const view = hiddenPMRef.current?.getView();
         if (!view) {
           return undefined;
@@ -5593,6 +5600,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       return () => {
         cancelled = true;
         removeFontFaces(registered);
+        setEmbeddedFontFamilyMap(null);
       };
     }, [embeddedFontBuffer]);
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -3495,6 +3495,15 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         }
 
         if (e.button !== 0) {
+          // Non-left buttons (e.g. middle-click) can trigger a native
+          // auxclick navigation on an <a> before any click-time sanitization
+          // runs. Block navigation for those, matching the left-click
+          // preventDefault below; everything else in this handler is
+          // left-click only.
+          const auxTarget = e.target instanceof HTMLElement ? e.target : null;
+          if (auxTarget?.closest("a[href]") instanceof HTMLAnchorElement) {
+            e.preventDefault();
+          }
           return;
         } // Only handle left click
 

--- a/packages/react/src/paged-editor/embeddedFonts.test.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.test.ts
@@ -13,7 +13,8 @@ const { loadEmbeddedFontFaces } = await import("./embeddedFonts");
 
 function fakeFont(): EmbeddedFont {
   return {
-    family: "My Brand Sans",
+    family: "folio-embedded-test-nonce-My Brand Sans",
+    originalFamily: "My Brand Sans",
     style: "normal",
     weight: 400,
     bytes: new Uint8Array([0x00, 0x01, 0x00, 0x00]),
@@ -101,33 +102,44 @@ afterEach(() => {
 
 describe("loadEmbeddedFontFaces (best-effort)", () => {
   test("registers and returns the loaded faces on success", async () => {
-    const faces = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    const { faces, familyMap } = await loadEmbeddedFontFaces(new ArrayBuffer(8));
     expect(faces).toHaveLength(1);
     expect(addedFaces).toHaveLength(1);
     expect(deletedFaces).toHaveLength(0);
+    // The face is registered under its scoped name, mapped from the original.
+    expect(addedFaces[0]).toMatchObject({ family: "folio-embedded-test-nonce-My Brand Sans" });
+    expect(familyMap.get("My Brand Sans")).toBe("folio-embedded-test-nonce-My Brand Sans");
   });
 
-  test("does not throw and returns [] when extraction throws", async () => {
+  test("does not throw and returns empty when extraction throws", async () => {
     extractImpl = () => Promise.reject(new Error("corrupt zip"));
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual({
+      faces: [],
+      familyMap: new Map(),
+    });
     expect(addedFaces).toHaveLength(0);
   });
 
   test("does not throw and skips a face when FontFace construction throws", async () => {
     fontFaceMode = "ctor-throw";
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    const { faces } = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    expect(faces).toEqual([]);
     expect(addedFaces).toHaveLength(0);
   });
 
   test("drops a face whose load() rejects", async () => {
     fontFaceMode = "load-reject";
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    const { faces } = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    expect(faces).toEqual([]);
     expect(addedFaces).toHaveLength(1);
     expect(deletedFaces).toHaveLength(1);
   });
 
-  test("returns [] outside a DOM (no document.fonts)", async () => {
+  test("returns empty outside a DOM (no document.fonts)", async () => {
     stubGlobal("document", undefined);
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual({
+      faces: [],
+      familyMap: new Map(),
+    });
   });
 });

--- a/packages/react/src/paged-editor/embeddedFonts.ts
+++ b/packages/react/src/paged-editor/embeddedFonts.ts
@@ -8,7 +8,27 @@
  * preventing one document's embedded family from bleeding into the next.
  */
 
-import { extractEmbeddedFonts, type EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
+import {
+  extractEmbeddedFonts,
+  buildEmbeddedFontFamilyMap,
+  type EmbeddedFont,
+} from "@stll/folio-core/fonts/embeddedFonts";
+
+/** Result of registering a document's embedded fonts with the browser. */
+export type LoadedEmbeddedFonts = {
+  /** The `FontFace` handles that loaded successfully, for later cleanup. */
+  faces: FontFace[];
+  /**
+   * Original DOCX font name (`w:font w:name`) → the per-document scoped
+   * family it was registered under (never the raw name — see
+   * `@stll/folio-core/fonts/embeddedFonts`). Callers activate this with
+   * `setEmbeddedFontFamilyMap` (`@stll/folio-core/utils/fontResolver`) so the
+   * document's own runs keep resolving to their embedded face.
+   */
+  familyMap: ReadonlyMap<string, string>;
+};
+
+const EMPTY_LOADED_EMBEDDED_FONTS: LoadedEmbeddedFonts = { faces: [], familyMap: new Map() };
 
 export function getDocumentFontSet(): FontFaceSet | null {
   if (typeof document === "undefined" || !("fonts" in document)) {
@@ -57,10 +77,10 @@ export async function registerFontFace(
  * faces the browser rejects (malformed/subsetted binaries) are dropped so the
  * run falls back to the CSS font stack.
  */
-export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFace[]> {
+export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<LoadedEmbeddedFonts> {
   const fontSet = getDocumentFontSet();
   if (!fontSet) {
-    return [];
+    return EMPTY_LOADED_EMBEDDED_FONTS;
   }
 
   // Embedded fonts are best-effort: a corrupt/oversized package makes unzip
@@ -69,15 +89,17 @@ export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFa
   try {
     fonts = await extractEmbeddedFonts(buffer);
   } catch {
-    return [];
+    return EMPTY_LOADED_EMBEDDED_FONTS;
   }
   if (fonts.length === 0) {
-    return [];
+    return EMPTY_LOADED_EMBEDDED_FONTS;
   }
 
   const loaded: FontFace[] = [];
   await Promise.all(
     fonts.map(async (font) => {
+      // `font.family` is already the per-document scoped name, never the raw
+      // DOCX name (see `@stll/folio-core/fonts/embeddedFonts`).
       const face = await registerFontFace(fontSet, font.family, font.bytes, {
         weight: String(font.weight),
         style: font.style,
@@ -87,7 +109,11 @@ export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFa
       }
     }),
   );
-  return loaded;
+  // Built from every declared face, not just the ones that loaded — a face
+  // whose FontFace failed to load still reserves its scoped name; resolving
+  // a run to that (now-missing) scoped family just falls through the rest of
+  // the CSS fallback stack, same as any other unavailable custom font.
+  return { faces: loaded, familyMap: buildEmbeddedFontFamilyMap(fonts) };
 }
 
 /** Remove previously registered faces from the document font set. */

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -1043,7 +1043,7 @@ const currentWatermark = computed<Watermark | undefined>(() => {
 
 const currentTableProperties = computed(() => {
   void stateTick.value;
-  const view = editorView.value;
+  const view = activeEditorView.value;
   if (!view) {
     return {};
   }
@@ -1309,7 +1309,7 @@ type TablePropertiesUpdate = {
 };
 
 function handleTablePropertiesApply(properties: TablePropertiesUpdate): void {
-  const view = editorView.value;
+  const view = activeEditorView.value;
   const factory = getCommands()["setTableProperties"];
   if (!view || !factory) {
     return;
@@ -1466,9 +1466,13 @@ const { exposed } = useDocxEditorRefApi({
   author: () => props.author,
   // Mirror React's applyAIEditOperations comment closure: mint the comment,
   // append it to the thread list, and hand back its id for the tracked-change
-  // mark that references it.
-  createAIEditComment: (text) => {
-    const comment = commentManagement.createComment(text);
+  // mark that references it. `author` is the resolved per-call operation
+  // author (useDocxEditorRefApi's `operationAuthor`, defaulting to
+  // `props.author`) — without threading it through, every AI-edit comment
+  // would always be attributed to `props.author`, ignoring a caller-supplied
+  // override.
+  createAIEditComment: (text, author) => {
+    const comment = commentManagement.createComment(text, undefined, author);
     commentManagement.pushComment(comment);
     return comment.id;
   },

--- a/packages/vue/src/components/dialogs/WatermarkDialog.vue
+++ b/packages/vue/src/components/dialogs/WatermarkDialog.vue
@@ -52,7 +52,15 @@
         </label>
         <label class="field field--wide">
           <span class="field__label">Image target</span>
-          <input v-model="imageTarget" class="field__input" placeholder="word/media/image1.png" />
+          <input
+            v-model="imageTarget"
+            :aria-invalid="imageTargetError.length > 0"
+            class="field__input"
+            placeholder="word/media/image1.png"
+          />
+          <span v-if="imageTargetError.length > 0" class="field__error">{{
+            imageTargetError
+          }}</span>
         </label>
         <label class="field">
           <span class="field__label">Scale</span>
@@ -85,7 +93,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import type { Watermark } from "@stll/folio-core/watermark";
+import { isAllowedExternalWatermarkImageUrl, type Watermark } from "@stll/folio-core/watermark";
 import { useFolioUI } from "../../ui/folio-ui";
 
 const { Dialog: FolioDialog } = useFolioUI();
@@ -116,11 +124,22 @@ const imageTargetExternal = ref(false);
 const scalePercent = ref(100);
 const washout = ref(true);
 
+// An external target becomes a `TargetMode="External"` relationship in the
+// saved package verbatim (see `docx/rezip.ts`); restrict it to http(s) so a
+// `file:` URL or UNC path can't ride along in the exported `.docx`.
+const imageTargetError = computed(() =>
+  mode.value === "picture" && imageTargetExternal.value && imageTarget.value.trim().length > 0
+    ? getExternalImageTargetError(imageTarget.value.trim())
+    : "",
+);
+
 const canApply = computed(
   () =>
     mode.value === "none" ||
     (mode.value === "text" && text.value.trim().length > 0) ||
-    (mode.value === "picture" && imageRId.value.trim().length > 0),
+    (mode.value === "picture" &&
+      imageRId.value.trim().length > 0 &&
+      imageTargetError.value.length === 0),
 );
 
 watch(
@@ -201,6 +220,10 @@ function stripHash(value: string): string {
   return value.startsWith("#") ? value.slice(1) : value;
 }
 
+function getExternalImageTargetError(value: string): string {
+  return isAllowedExternalWatermarkImageUrl(value) ? "" : "Use a web address (http/https).";
+}
+
 function toColorInputValue(value: string | undefined): string {
   if (!value || value === "auto") return DEFAULT_TEXT_COLOR;
   return value.startsWith("#") ? value : `#${value}`;
@@ -259,6 +282,10 @@ function toColorInputValue(value: string | undefined): string {
 .field__input--color {
   min-height: 34px;
   padding: 2px;
+}
+.field__error {
+  font-size: 12px;
+  color: var(--doc-error);
 }
 .check {
   display: flex;

--- a/packages/vue/src/composables/useCommentManagement.ts
+++ b/packages/vue/src/composables/useCommentManagement.ts
@@ -5,8 +5,9 @@
  * to our core primitives:
  *   - id allocation:      commentIdAllocator (createCommentIdAllocator, seed)
  *   - comment factory:    commentOps.createComment(allocator, ...)
- *   - accept / reject:    range-based acceptChange / rejectChange, located by
- *                         revisionId through queries.findChangeRange
+ *   - accept / reject:    revision-scoped acceptAIEditRevision / rejectAIEditRevision
+ *                         (by-id path) or range-based acceptChange / rejectChange
+ *                         (raw selection path)
  *
  * Controlled (`comments` prop set) vs uncontrolled: when controlled, the thread
  * list is read from the prop and every mutation only routes through
@@ -23,8 +24,12 @@ import {
   seedCommentAllocator,
 } from "@stll/folio-core/prosemirror/commentIdAllocator";
 import { createComment as coreCreateComment } from "@stll/folio-core/prosemirror/commentOps";
-import { findChangeRange } from "@stll/folio-core/prosemirror/queries";
-import { acceptChange, rejectChange } from "@stll/folio-core/prosemirror/commands/comments";
+import {
+  acceptChange,
+  rejectChange,
+  acceptAIEditRevision,
+  rejectAIEditRevision,
+} from "@stll/folio-core/prosemirror/commands/comments";
 
 export type UseCommentManagementOptions = {
   editorView: Ref<EditorView | null>;
@@ -51,8 +56,14 @@ export type UseCommentManagementReturn = {
   commentsDirty: ComputedRef<boolean>;
   /** Clear {@link commentsDirty} after a successful save. */
   clearCommentsDirty: () => void;
-  /** Build a comment with a freshly-allocated, collision-seeded id. */
-  createComment: (text: string, parentId?: number) => Comment;
+  /**
+   * Build a comment with a freshly-allocated, collision-seeded id.
+   * `authorOverride` lets a caller (AI-edit operations) mint a comment
+   * attributed to the resolved operation author instead of the editor's
+   * default `options.author()` — mirrors React's `applyAIEditOperations`
+   * closure, which creates each comment with the per-call `operationAuthor`.
+   */
+  createComment: (text: string, parentId?: number, authorOverride?: string) => Comment;
   /** Append a comment and emit the change. */
   pushComment: (comment: Comment) => void;
   /** Replace the whole list and emit the change (uncontrolled also stores it). */
@@ -104,11 +115,11 @@ export function useCommentManagement(
     setComments([...comments.value, comment]);
   }
 
-  function createComment(text: string, parentId?: number): Comment {
+  function createComment(text: string, parentId?: number, authorOverride?: string): Comment {
     // Raise the allocator above every id currently live in the model + doc so a
     // reply/new comment can never re-mint an existing comment or revision id.
     seedCommentAllocator(allocator, comments.value, options.editorView.value);
-    return coreCreateComment(allocator, text, options.author(), parentId);
+    return coreCreateComment(allocator, text, authorOverride ?? options.author(), parentId);
   }
 
   function seedFromDocument(): void {
@@ -155,10 +166,15 @@ export function useCommentManagement(
   function resolveChangeById(revisionId: number, accept: boolean): void {
     const view = options.editorView.value;
     if (!view) return;
-    const range = findChangeRange(view, revisionId);
-    if (!range) return;
-    const command = accept ? acceptChange : rejectChange;
-    command(range.from, range.to)(view.state, view.dispatch);
+    // Revision-scoped: acceptAIEditRevision/rejectAIEditRevision both locate
+    // the range for this specific revisionId AND thread it through as the
+    // match set, so only marks/structural changes carrying this id resolve.
+    // A plain range-based acceptChange(from, to)/rejectChange(from, to) here
+    // would treat the missing revisionId as "match everything in range,"
+    // which can also resolve an unrelated collaborator's tracked change
+    // sharing the same paragraph/row span.
+    const command = accept ? acceptAIEditRevision : rejectAIEditRevision;
+    command(revisionId)(view.state, view.dispatch);
   }
 
   function handleAcceptChangeById(revisionId: number): void {

--- a/packages/vue/src/composables/useDocxEditorRefApi.ts
+++ b/packages/vue/src/composables/useDocxEditorRefApi.ts
@@ -143,9 +143,12 @@ export type UseDocxEditorRefApiOptions = {
   /**
    * Mint a comment for an AI-edit operation that carries comment text, append
    * it to the thread list, and return its id (mirrors React's `createCommentId`
-   * closure over the comment manager). Wired from useCommentManagement.
+   * closure over the comment manager). Wired from useCommentManagement. The
+   * optional `author` lets each call site attribute the comment to the
+   * resolved per-call `operationAuthor` rather than always the editor's
+   * default author.
    */
-  createAIEditComment: (text: string) => number;
+  createAIEditComment: (text: string, author?: string) => number;
   /** Read and replace the current comment array for transactional undo. */
   getComments: () => Comment[];
   setComments: (comments: Comment[]) => void;
@@ -403,7 +406,7 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
         snapshot,
         batch,
         author: operationAuthor,
-        createCommentId: opts.createAIEditComment,
+        createCommentId: (text) => opts.createAIEditComment(text, operationAuthor),
         createUndoHandle: () => ({
           type: "documentOperationUndo",
           id: `vue-${String(documentOperationUndoHandleCursor++)}`,
@@ -469,7 +472,7 @@ export function useDocxEditorRefApi(opts: UseDocxEditorRefApiOptions): {
         operations,
         mode,
         author: operationAuthor,
-        createCommentId: opts.createAIEditComment,
+        createCommentId: (text) => opts.createAIEditComment(text, operationAuthor),
       });
     },
     acceptAIEditOperation: (revisionIds) => {

--- a/packages/vue/src/composables/useFontLifecycle.test.ts
+++ b/packages/vue/src/composables/useFontLifecycle.test.ts
@@ -23,7 +23,12 @@ describe("useFontLifecycle", () => {
 
     try {
       const face = createFontFace();
-      const loadEmbedded = mock((_buffer: ArrayBuffer) => Promise.resolve([face]));
+      const loadEmbedded = mock((_buffer: ArrayBuffer) =>
+        Promise.resolve({
+          faces: [face],
+          familyMap: new Map([["Document Sans", "folio-embedded-test-nonce-Document Sans"]]),
+        }),
+      );
       const remove = mock((_faces: readonly FontFace[]) => {});
       const remeasure = mock(() => {});
       const ready = ref(false);
@@ -81,7 +86,7 @@ describe("useFontLifecycle", () => {
 
     try {
       const face = createFontFace();
-      const pending = deferred<FontFace[]>();
+      const pending = deferred<{ faces: FontFace[]; familyMap: ReadonlyMap<string, string> }>();
       const remove = mock((_faces: readonly FontFace[]) => {});
       const remeasure = mock(() => {});
       const ready = ref(false);
@@ -107,7 +112,7 @@ describe("useFontLifecycle", () => {
       await nextTick();
       ready.value = false;
       await nextTick();
-      pending.resolve([face]);
+      pending.resolve({ faces: [face], familyMap: new Map() });
       await Promise.resolve();
 
       expect(remove).toHaveBeenCalledWith([face]);
@@ -151,7 +156,7 @@ describe("useFontLifecycle", () => {
             remeasure,
           },
           {
-            loadEmbedded: () => Promise.resolve([]),
+            loadEmbedded: () => Promise.resolve({ faces: [], familyMap: new Map() }),
             loadHost,
             remove,
           },

--- a/packages/vue/src/composables/useFontLifecycle.ts
+++ b/packages/vue/src/composables/useFontLifecycle.ts
@@ -1,9 +1,10 @@
 /** Owns browser font registration for one Vue editor instance. */
 
 import { watch, type Ref } from "vue";
+import { setEmbeddedFontFamilyMap } from "@stll/folio-core/utils/fontResolver";
 
 import type { FontDefinition } from "../components/DocxEditor/types";
-import { loadEmbeddedFontFaces } from "../utils/embeddedFonts";
+import { loadEmbeddedFontFaces, type LoadedEmbeddedFonts } from "../utils/embeddedFonts";
 import { removeFontFaces } from "../utils/fontFaces";
 import { loadHostFontFaces } from "../utils/hostFonts";
 
@@ -15,7 +16,7 @@ export type UseFontLifecycleOptions = {
 };
 
 export type FontLifecycleDependencies = {
-  loadEmbedded: (buffer: ArrayBuffer) => Promise<FontFace[]>;
+  loadEmbedded: (buffer: ArrayBuffer) => Promise<LoadedEmbeddedFonts>;
   loadHost: (fonts: ReadonlyArray<FontDefinition> | undefined) => Promise<FontFace[]>;
   remove: (faces: readonly FontFace[]) => void;
 };
@@ -44,21 +45,29 @@ export function useFontLifecycle(
 
       let cancelled = false;
       let registered: FontFace[] = [];
-      void dependencies.loadEmbedded(buffer).then((faces) => {
+      void dependencies.loadEmbedded(buffer).then(({ faces, familyMap }) => {
         if (cancelled) {
           dependencies.remove(faces);
           return undefined;
         }
         registered = faces;
-        if (faces.length > 0) {
-          options.remeasure();
+        if (faces.length === 0 && familyMap.size === 0) {
+          return undefined;
         }
+        // Activate this document's original→scoped embedded-font family map
+        // before `options.remeasure()` invalidates the resolved-font cache,
+        // so every run that resolves after this point picks up the scoped
+        // family instead of the raw DOCX name — which is never registered on
+        // `document.fonts` (see `@stll/folio-core/fonts/embeddedFonts`).
+        setEmbeddedFontFamilyMap(familyMap.size > 0 ? familyMap : null);
+        options.remeasure();
         return undefined;
       });
 
       onCleanup(() => {
         cancelled = true;
         dependencies.remove(registered);
+        setEmbeddedFontFamilyMap(null);
       });
     },
     { immediate: true },

--- a/packages/vue/src/composables/useHyperlinkManagement.ts
+++ b/packages/vue/src/composables/useHyperlinkManagement.ts
@@ -17,6 +17,7 @@ import {
   editHyperlinkAtCursor,
   removeHyperlinkAtCursor,
 } from "@stll/folio-core/prosemirror/commands/hyperlink";
+import { sanitizeExternalUrl } from "@stll/folio-core/utils/urlSecurity";
 import type { HyperlinkPopupData } from "../components/ui/hyperlinkPopupTypes";
 
 export type { HyperlinkPopupData };
@@ -75,7 +76,9 @@ export function useHyperlinkManagement(opts: UseHyperlinkManagementOptions) {
   }
 
   function handleHyperlinkPopupNavigate(href: string) {
-    window.open(href, "_blank", "noopener,noreferrer");
+    const safeHref = sanitizeExternalUrl(href);
+    if (!safeHref) return;
+    window.open(safeHref, "_blank", "noopener,noreferrer");
     hyperlinkPopupData.value = null;
   }
 

--- a/packages/vue/src/composables/usePageSetupControls.test.ts
+++ b/packages/vue/src/composables/usePageSetupControls.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect, mock } from "bun:test";
+import { ref } from "vue";
+import type { Document } from "@stll/folio-core/types/document";
+import { usePageSetupControls } from "./usePageSetupControls";
+
+function makeDoc(): Document {
+  return {
+    package: {
+      document: { content: [], finalSectionProperties: { marginLeft: 1440 } },
+    },
+  };
+}
+
+describe("usePageSetupControls.handlePageSetupApply — readOnly guard", () => {
+  test("is a no-op when readOnly is true (mirrors React's DocxEditor.tsx guard)", () => {
+    const doc = makeDoc();
+    const onChange = mock((_doc: Document) => {});
+    const reLayout = mock(() => {});
+    const stateTick = ref(0);
+    const { handlePageSetupApply } = usePageSetupControls({
+      editorView: ref(null),
+      getDocument: () => doc,
+      readOnly: ref(true),
+      stateTick,
+      reLayout,
+      onChange,
+    });
+
+    handlePageSetupApply({ marginLeft: 720 });
+
+    expect(doc.package.document.finalSectionProperties?.marginLeft).toBe(1440);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(reLayout).not.toHaveBeenCalled();
+    expect(stateTick.value).toBe(0);
+  });
+
+  test("applies the change when not readOnly", () => {
+    const doc = makeDoc();
+    const onChange = mock((_doc: Document) => {});
+    const reLayout = mock(() => {});
+    const stateTick = ref(0);
+    const { handlePageSetupApply } = usePageSetupControls({
+      editorView: ref(null),
+      getDocument: () => doc,
+      readOnly: ref(false),
+      stateTick,
+      reLayout,
+      onChange,
+    });
+
+    handlePageSetupApply({ marginLeft: 720 });
+
+    expect(doc.package.document.finalSectionProperties?.marginLeft).toBe(720);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(reLayout).toHaveBeenCalledTimes(1);
+    expect(stateTick.value).toBe(1);
+  });
+});

--- a/packages/vue/src/composables/usePageSetupControls.ts
+++ b/packages/vue/src/composables/usePageSetupControls.ts
@@ -36,6 +36,7 @@ type MarginProperty = "marginLeft" | "marginRight" | "marginTop" | "marginBottom
 
 export function usePageSetupControls(opts: UsePageSetupControlsOptions) {
   function handlePageSetupApply(sp: Partial<SectionProperties>) {
+    if (opts.readOnly.value) return;
     const doc = opts.getDocument();
     if (!doc?.package?.document) return;
     const existing = doc.package.document.finalSectionProperties ?? {};

--- a/packages/vue/src/composables/usePagesPointer.ts
+++ b/packages/vue/src/composables/usePagesPointer.ts
@@ -493,7 +493,17 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
   }
 
   function handlePagesMouseDown(event: MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0) {
+      // Non-left buttons (e.g. middle-click) can trigger a native auxclick
+      // navigation on an <a> before any click-time sanitization runs. Block
+      // navigation for those; everything else in this handler is left-click
+      // only.
+      const auxTarget = event.target instanceof HTMLElement ? event.target : null;
+      if (auxTarget?.closest<HTMLAnchorElement>("a[href]")) {
+        event.preventDefault();
+      }
+      return;
+    }
     if (opts.imageInteracting.value) return;
     const body = opts.editorView.value;
     if (!body) return;

--- a/packages/vue/src/utils/embeddedFonts.test.ts
+++ b/packages/vue/src/utils/embeddedFonts.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
 
+// The mock replaces the module registry entry for every later importer in the
+// test process, so it must keep the real exports and only stub extraction.
+const actualEmbeddedFonts = await import("@stll/folio-core/fonts/embeddedFonts");
+
 let extractImpl: (buffer: ArrayBuffer) => Promise<EmbeddedFont[]>;
 void mock.module("@stll/folio-core/fonts/embeddedFonts", () => ({
+  ...actualEmbeddedFonts,
   extractEmbeddedFonts: (buffer: ArrayBuffer) => extractImpl(buffer),
 }));
 

--- a/packages/vue/src/utils/embeddedFonts.test.ts
+++ b/packages/vue/src/utils/embeddedFonts.test.ts
@@ -11,7 +11,8 @@ const { loadEmbeddedFontFaces } = await import("./embeddedFonts");
 
 function fakeFont(): EmbeddedFont {
   return {
-    family: "Document Sans",
+    family: "folio-embedded-test-nonce-Document Sans",
+    originalFamily: "Document Sans",
     style: "normal",
     weight: 400,
     bytes: new Uint8Array([0x00, 0x01, 0x00, 0x00]),
@@ -92,33 +93,42 @@ afterEach(() => {
 
 describe("loadEmbeddedFontFaces", () => {
   test("registers faces extracted from the document", async () => {
-    const faces = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    const { faces, familyMap } = await loadEmbeddedFontFaces(new ArrayBuffer(8));
     expect(faces).toHaveLength(1);
     expect(addedFaces).toHaveLength(1);
     expect(deletedFaces).toHaveLength(0);
+    expect(familyMap.get("Document Sans")).toBe("folio-embedded-test-nonce-Document Sans");
   });
 
   test("falls back when extraction fails", async () => {
     extractImpl = () => Promise.reject(new Error("corrupt package"));
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual({
+      faces: [],
+      familyMap: new Map(),
+    });
     expect(addedFaces).toHaveLength(0);
   });
 
   test("skips a face rejected by the browser", async () => {
     fontFaceMode = "load-reject";
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    const { faces } = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    expect(faces).toEqual([]);
     expect(addedFaces).toHaveLength(1);
     expect(deletedFaces).toHaveLength(1);
   });
 
   test("skips invalid face descriptors", async () => {
     fontFaceMode = "ctor-throw";
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    const { faces } = await loadEmbeddedFontFaces(new ArrayBuffer(8));
+    expect(faces).toEqual([]);
     expect(addedFaces).toHaveLength(0);
   });
 
   test("is a no-op outside a browser document", async () => {
     stubGlobal("document", undefined);
-    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual([]);
+    expect(await loadEmbeddedFontFaces(new ArrayBuffer(8))).toEqual({
+      faces: [],
+      familyMap: new Map(),
+    });
   });
 });

--- a/packages/vue/src/utils/embeddedFonts.ts
+++ b/packages/vue/src/utils/embeddedFonts.ts
@@ -1,34 +1,59 @@
 /** Register fonts embedded in a document with the browser font set. */
 
-import { extractEmbeddedFonts, type EmbeddedFont } from "@stll/folio-core/fonts/embeddedFonts";
+import {
+  extractEmbeddedFonts,
+  buildEmbeddedFontFamilyMap,
+  type EmbeddedFont,
+} from "@stll/folio-core/fonts/embeddedFonts";
 
 import { getDocumentFontSet, registerFontFace } from "./fontFaces";
+
+/** Result of registering a document's embedded fonts with the browser. */
+export type LoadedEmbeddedFonts = {
+  /** The `FontFace` handles that loaded successfully, for later cleanup. */
+  faces: FontFace[];
+  /**
+   * Original DOCX font name (`w:font w:name`) → the per-document scoped
+   * family it was registered under (never the raw name — see
+   * `@stll/folio-core/fonts/embeddedFonts`). Callers activate this with
+   * `setEmbeddedFontFamilyMap` (`@stll/folio-core/utils/fontResolver`) so the
+   * document's own runs keep resolving to their embedded face.
+   */
+  familyMap: ReadonlyMap<string, string>;
+};
+
+const EMPTY_LOADED_EMBEDDED_FONTS: LoadedEmbeddedFonts = { faces: [], familyMap: new Map() };
 
 /**
  * Extract and register embedded faces from a raw document buffer. Extraction
  * and individual face failures are best-effort: rendering falls back to the
  * normal CSS font stack instead of failing the document load.
  */
-export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<FontFace[]> {
+export async function loadEmbeddedFontFaces(buffer: ArrayBuffer): Promise<LoadedEmbeddedFonts> {
   const fontSet = getDocumentFontSet();
   if (!fontSet) {
-    return [];
+    return EMPTY_LOADED_EMBEDDED_FONTS;
   }
 
   let fonts: EmbeddedFont[];
   try {
     fonts = await extractEmbeddedFonts(buffer);
   } catch {
-    return [];
+    return EMPTY_LOADED_EMBEDDED_FONTS;
   }
 
   const faces = await Promise.all(
     fonts.map((font) =>
+      // `font.family` is already the per-document scoped name, never the raw
+      // DOCX name (see `@stll/folio-core/fonts/embeddedFonts`).
       registerFontFace(fontSet, font.family, font.bytes, {
         weight: String(font.weight),
         style: font.style,
       }),
     ),
   );
-  return faces.filter((face): face is FontFace => face !== null);
+  return {
+    faces: faces.filter((face): face is FontFace => face !== null),
+    familyMap: buildEmbeddedFontFamilyMap(fonts),
+  };
 }


### PR DESCRIPTION
## Security hardening: DoS, injection, and content-leak fixes

Addresses a batch of security-review findings. Each finding was verified against the
current tree before fixing; already-fixed, false-positive, and non-security
("informational") items were excluded. Nothing was run locally — CI validates
typecheck/lint/tests. Changesets are included; behaviour is guarded by new synthetic
regression tests plus the existing interaction/parity suites.

### Parse & layout DoS (crafted DOCX within existing ZIP/XML limits)
Bounds on unbounded parser/layout inputs: table `gridSpan`/column counts, section
columns and page dimensions, kinsoku/line-break lists (now sets), run language tags,
cross-run hyphenation iterations, default tab-stop floor, per-element xmlns count,
grouped-drawing SVG size (incremental budget), style-numbered list resume (O(1)), and
encrypted-DOCX DIFAT cycle detection + `spinCount` ceiling. The conformance root-tag
regex (catastrophic backtracking) is replaced with a linear scanner.

### Compare / agent / validation DoS
Aggregate LCS budget shared across all document stories; O(1) move dequeue; word-diff
matrix cap with fallback; `ensureParaIds` and `@stll/docx-core`'s `validateDocxPackage`
enforce entry/size limits before reading; linear note-paraId index; bounded agent
whole-word search; aggregate `suggest_changes` text budget; tracked-split colspan guard.

### Injection (XSS / OOXML / CSS)
Hyperlink and image hrefs are sanitized at parse/render/command time (core, React, Vue,
including image `hlinkClick` and paste); colours are validated to strict hex at a single
`colorResolver` choke point (closing themed-fill and diagonal-border `url()` injection);
comment `paraId`/`textId`, run/paragraph/table/style colours, and SDT raw properties are
escaped/validated on serialize; collaborator colours and controlled comments are
validated before use.

### Hidden / active content leaks
Selective save bails to full repack when non-preservable entries (macros, embedded
binaries) are present; hidden table-row text/`w:vanish` runs are excluded from the AI
snapshot; hidden-row footnotes are no longer painted; metadata-privacy scrubbing is
case-insensitive; server text extraction resolves referenced (not orphan) header/footer
parts; text-box anchor markers are stripped from pasted HTML and nonce-salted.

### Integrity & robustness
AI undo is body-scoped; sidebar accept/reject is revision-scoped (React + Vue); agent
preconditions expose a read-time block hash and honour caller-supplied preconditions;
prototype-key lookups use own-property checks; bound content-control clicks no longer
throw; Vue read-only page-setup, table-properties view, and AI-comment author are fixed.

### Untrusted assets & CI
Embedded fonts are registered under per-document scoped family names so they can't
shadow host-page UI families; watermark dialogs validate external image targets;
`release-pr`/`benchmarks` CI tokens are scoped and `publish` release notes no longer
misrepresent a skipped-publish artifact.

### Notes for reviewers
- **Font scoping** uses a module-level original→scoped map; two editor instances mounted
  simultaneously share it (correctness edge case, not a leak) — flagged in code.
- `getPreviewRuns` in `snapshot.ts` still skips only `deletion`, not `hidden` runs
  (same class as the fixed clean-text path) — left as a follow-up.
- `sectionPropertiesSerializer.ts` has the same unescaped-colour pattern (page
  background) as the serializers fixed here — follow-up.
- Draft: opened for CI. Please review the behaviour-changing items above before merge.

CC on behalf of @jan-kubica
