### PR TITLE
feat: add guarded XML patch application

### DIFF
--- a/.changeset/strong-rivers-apply.md
+++ b/.changeset/strong-rivers-apply.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add guarded XML patch application with complete output validation.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -8,6 +8,19 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { TaggedErrorClass } from 'better-result';
 
 // @public
+export const applyDocxXmlPatchProposal: (input: ApplyDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchApplication>;
+
+// @public (undocumented)
+export type ApplyDocxXmlPatchProposalArgs = {
+    readonly bytes: ArrayBuffer | Uint8Array;
+    readonly proposal: unknown; /** Exact package paths authorized by the server-side caller. */
+    readonly allowedParts: readonly string[];
+    readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+    readonly archive?: DocxArchiveOptions;
+    readonly limits?: FolioDocxXmlPatchProposalLimits;
+};
+
+// @public
 export const applyFolioAIEditsToBuffer: (buffer: ArrayBuffer, operations: FolioAIEditOperation[], options?: ApplyFolioAIEditsToBufferOptions) => Promise<ApplyFolioAIEditsToBufferResult>;
 
 // @public
@@ -256,6 +269,12 @@ export const FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES: readonly ["invalid-limit
 
 // @public (undocumented)
 export const FOLIO_DOCX_PACKAGE_INSPECTION_VERSION: 1;
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE: "folio-xml-patch-application-v1";
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION: 1;
 
 // @public (undocumented)
 export const FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS: Readonly<{
@@ -907,6 +926,62 @@ export type FolioDocxReviewerOptions = {
 };
 
 // @public (undocumented)
+export type FolioDocxXmlPatchApplication = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly status: "proposal-rejected";
+    readonly producesOutput: false;
+    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
+        status: "rejected";
+    }>;
+    readonly conformance: null;
+    readonly receipt: null;
+} | {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly status: "output-rejected";
+    readonly producesOutput: false;
+    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
+        status: "accepted";
+    }>;
+    readonly conformance: FolioDocxConformanceReport;
+    readonly receipt: null;
+} | {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly status: "applied";
+    readonly producesOutput: true;
+    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
+        status: "accepted";
+    }>;
+    readonly conformance: FolioDocxConformanceReport & {
+        readonly status: "conformant";
+    };
+    readonly receipt: FolioDocxXmlPatchApplicationReceipt;
+    readonly bytes: Uint8Array;
+};
+
+// @public (undocumented)
+export class FolioDocxXmlPatchApplicationError extends FolioDocxXmlPatchApplicationError_base {}
+
+// @public (undocumented)
+export type FolioDocxXmlPatchApplicationReceipt = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly proposalProfile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
+    readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+    readonly input: {
+        readonly sha256: string;
+        readonly byteLength: number;
+    };
+    readonly output: {
+        readonly sha256: string;
+        readonly byteLength: number;
+    };
+    readonly replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
+};
+
+// @public (undocumented)
 export type FolioDocxXmlPatchProposal = {
     readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
     readonly replacements: readonly [FolioDocxXmlReplacement, ...FolioDocxXmlReplacement[]];
@@ -1226,6 +1301,9 @@ export const STELLA_STYLE_SET_NAME = "Stella Style";
 
 // @public (undocumented)
 export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
+
+// @public (undocumented)
+export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends UnsupportedFolioDocxXmlPatchApplicationProfileError_base {}
 
 // @public (undocumented)
 export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base {}

--- a/packages/core/src/docx/server/applyDocxXmlPatchProposal.test.ts
+++ b/packages/core/src/docx/server/applyDocxXmlPatchProposal.test.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { createEmptyDocx } from "../rezip";
+import {
+  applyDocxXmlPatchProposal,
+  FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+  FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+  UnsupportedFolioDocxXmlPatchApplicationProfileError,
+} from "./applyDocxXmlPatchProposal";
+import { FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION } from "./evaluateDocxXmlPatchProposal";
+import { FOLIO_DOCX_CONFORMANCE_PROFILE } from "./validateDocxConformance";
+
+const DOCUMENT_PATH = "word/document.xml";
+const STYLES_PATH = "word/styles.xml";
+const REPLACEMENT_XML =
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Updated</w:t></w:r></w:p></w:body></w:document>';
+
+const sha256 = (bytes: Uint8Array | string): string =>
+  createHash("sha256").update(bytes).digest("hex");
+
+type PackageFixture = {
+  bytes: Uint8Array;
+  documentXml: string;
+  documentSha256: string;
+  stylesXml: string;
+  stylesSha256: string;
+};
+
+const packageFixture = async (): Promise<PackageFixture> => {
+  const bytes = new Uint8Array(await createEmptyDocx());
+  const zip = await JSZip.loadAsync(bytes);
+  const document = zip.file(DOCUMENT_PATH);
+  const styles = zip.file(STYLES_PATH);
+  if (document === null || styles === null) {
+    throw new Error("Expected document and styles package parts");
+  }
+  const documentBytes = await document.async("uint8array");
+  const stylesBytes = await styles.async("uint8array");
+  return {
+    bytes,
+    documentXml: new TextDecoder().decode(documentBytes),
+    documentSha256: sha256(documentBytes),
+    stylesXml: new TextDecoder().decode(stylesBytes),
+    stylesSha256: sha256(stylesBytes),
+  };
+};
+
+const proposalFor = (baseSha256: string, replacementXml = REPLACEMENT_XML) => ({
+  version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+  replacements: [{ path: DOCUMENT_PATH, baseSha256, replacementXml }],
+});
+
+describe("applyDocxXmlPatchProposal", () => {
+  test("applies all replacements and returns a content-addressed receipt", async () => {
+    const fixture = await packageFixture();
+    const replacementStylesXml = `${fixture.stylesXml}\n`;
+
+    const result = await applyDocxXmlPatchProposal({
+      bytes: fixture.bytes,
+      proposal: {
+        version: FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION,
+        replacements: [
+          {
+            path: DOCUMENT_PATH,
+            baseSha256: fixture.documentSha256,
+            replacementXml: REPLACEMENT_XML,
+          },
+          {
+            path: STYLES_PATH,
+            baseSha256: fixture.stylesSha256,
+            replacementXml: replacementStylesXml,
+          },
+        ],
+      },
+      allowedParts: [DOCUMENT_PATH, STYLES_PATH],
+      validationProfile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+    });
+
+    expect(result).toMatchObject({
+      version: FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+      profile: FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+      status: "applied",
+      producesOutput: true,
+      conformance: {
+        profile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+        status: "conformant",
+      },
+    });
+    if (result.status !== "applied") {
+      throw new Error("Expected applied XML patch result");
+    }
+    expect(result.receipt).toMatchObject({
+      input: {
+        sha256: sha256(fixture.bytes),
+        byteLength: fixture.bytes.byteLength,
+      },
+      output: {
+        sha256: sha256(result.bytes),
+        byteLength: result.bytes.byteLength,
+      },
+      replacements: [
+        {
+          path: DOCUMENT_PATH,
+          baseSha256: fixture.documentSha256,
+          replacementSha256: sha256(REPLACEMENT_XML),
+        },
+        {
+          path: STYLES_PATH,
+          baseSha256: fixture.stylesSha256,
+          replacementSha256: sha256(replacementStylesXml),
+        },
+      ],
+    });
+
+    const outputZip = await JSZip.loadAsync(result.bytes);
+    expect(await outputZip.file(DOCUMENT_PATH)?.async("text")).toBe(REPLACEMENT_XML);
+    expect(await outputZip.file(STYLES_PATH)?.async("text")).toBe(replacementStylesXml);
+    const inputZip = await JSZip.loadAsync(fixture.bytes);
+    expect(await inputZip.file(DOCUMENT_PATH)?.async("text")).toBe(fixture.documentXml);
+  });
+
+  test("returns no output when proposal preconditions fail", async () => {
+    const fixture = await packageFixture();
+
+    const result = await applyDocxXmlPatchProposal({
+      bytes: fixture.bytes,
+      proposal: proposalFor("0".repeat(64)),
+      allowedParts: [DOCUMENT_PATH],
+      validationProfile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+    });
+
+    expect(result.status).toBe("proposal-rejected");
+    expect(result.producesOutput).toBe(false);
+    expect(result.receipt).toBeNull();
+    expect(result).not.toHaveProperty("bytes");
+  });
+
+  test("withholds output that fails the complete validation profile", async () => {
+    const fixture = await packageFixture();
+    const invalidDocument =
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:notBody/></w:document>';
+
+    const result = await applyDocxXmlPatchProposal({
+      bytes: fixture.bytes,
+      proposal: proposalFor(fixture.documentSha256, invalidDocument),
+      allowedParts: [DOCUMENT_PATH],
+      validationProfile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+    });
+
+    expect(result.status).toBe("output-rejected");
+    expect(result.producesOutput).toBe(false);
+    expect(result.conformance?.status).toBe("invalid");
+    expect(result.receipt).toBeNull();
+    expect(result).not.toHaveProperty("bytes");
+  });
+
+  test("rejects validation profiles that are not implemented", async () => {
+    const fixture = await packageFixture();
+
+    await expect(
+      Reflect.apply(applyDocxXmlPatchProposal, undefined, [
+        {
+          bytes: fixture.bytes,
+          proposal: proposalFor(fixture.documentSha256),
+          allowedParts: [DOCUMENT_PATH],
+          validationProfile: "unavailable-profile",
+        },
+      ]),
+    ).rejects.toBeInstanceOf(UnsupportedFolioDocxXmlPatchApplicationProfileError);
+  });
+});

--- a/packages/core/src/docx/server/applyDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/applyDocxXmlPatchProposal.ts
@@ -1,0 +1,398 @@
+import { createHash } from "node:crypto";
+
+import { panic, TaggedError } from "better-result";
+import JSZip from "jszip";
+
+import type { DocxArchiveOptions } from "./boundedArchive";
+import { loadDocxArchive } from "./boundedArchive";
+import {
+  evaluateDocxXmlPatchProposal,
+  FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+  InvalidFolioDocxXmlPatchProposalError,
+  parseFolioDocxXmlPatchProposal,
+  type FolioDocxPreparedXmlReplacement,
+  type FolioDocxXmlPatchProposal,
+  type FolioDocxXmlPatchProposalEvaluation,
+  type FolioDocxXmlPatchProposalLimits,
+} from "./evaluateDocxXmlPatchProposal";
+import {
+  FOLIO_DOCX_CONFORMANCE_PROFILE,
+  validateDocxConformance,
+  type FolioDocxConformanceReport,
+} from "./validateDocxConformance";
+
+export const FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION = 1 as const;
+export const FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE = "folio-xml-patch-application-v1" as const;
+
+export type ApplyDocxXmlPatchProposalArgs = {
+  readonly bytes: ArrayBuffer | Uint8Array;
+  readonly proposal: unknown;
+  /** Exact package paths authorized by the server-side caller. */
+  readonly allowedParts: readonly string[];
+  readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+  readonly archive?: DocxArchiveOptions;
+  readonly limits?: FolioDocxXmlPatchProposalLimits;
+};
+
+export type FolioDocxXmlPatchApplicationReceipt = {
+  readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+  readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+  readonly proposalProfile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
+  readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+  readonly input: {
+    readonly sha256: string;
+    readonly byteLength: number;
+  };
+  readonly output: {
+    readonly sha256: string;
+    readonly byteLength: number;
+  };
+  readonly replacements: readonly [
+    FolioDocxPreparedXmlReplacement,
+    ...FolioDocxPreparedXmlReplacement[],
+  ];
+};
+
+type AcceptedProposalEvaluation = Extract<
+  FolioDocxXmlPatchProposalEvaluation,
+  { status: "accepted" }
+>;
+type RejectedProposalEvaluation = Extract<
+  FolioDocxXmlPatchProposalEvaluation,
+  { status: "rejected" }
+>;
+type ConformantReport = FolioDocxConformanceReport & { readonly status: "conformant" };
+
+export type FolioDocxXmlPatchApplication =
+  | {
+      readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+      readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+      readonly status: "proposal-rejected";
+      readonly producesOutput: false;
+      readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, { status: "rejected" }>;
+      readonly conformance: null;
+      readonly receipt: null;
+    }
+  | {
+      readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+      readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+      readonly status: "output-rejected";
+      readonly producesOutput: false;
+      readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, { status: "accepted" }>;
+      readonly conformance: FolioDocxConformanceReport;
+      readonly receipt: null;
+    }
+  | {
+      readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+      readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+      readonly status: "applied";
+      readonly producesOutput: true;
+      readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, { status: "accepted" }>;
+      readonly conformance: FolioDocxConformanceReport & { readonly status: "conformant" };
+      readonly receipt: FolioDocxXmlPatchApplicationReceipt;
+      readonly bytes: Uint8Array;
+    };
+
+export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends TaggedError(
+  "UnsupportedFolioDocxXmlPatchApplicationProfileError",
+)<{
+  message: string;
+  profile: unknown;
+}>() {}
+
+export class FolioDocxXmlPatchApplicationError extends TaggedError(
+  "FolioDocxXmlPatchApplicationError",
+)<{
+  message: string;
+  stage: "verify" | "load" | "replace" | "generate";
+  part?: string;
+  cause?: unknown;
+}>() {}
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+const snapshotInput = (bytes: ArrayBuffer | Uint8Array): Uint8Array =>
+  Uint8Array.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes));
+
+const snapshotArchiveOptions = (
+  archive: DocxArchiveOptions | undefined,
+): DocxArchiveOptions | undefined => {
+  if (archive === undefined) {
+    return undefined;
+  }
+  return {
+    ...(archive.maxInputBytes === undefined ? {} : { maxInputBytes: archive.maxInputBytes }),
+    ...(archive.maxEntryBytes === undefined ? {} : { maxEntryBytes: archive.maxEntryBytes }),
+    ...(archive.maxTotalBytes === undefined ? {} : { maxTotalBytes: archive.maxTotalBytes }),
+    ...(archive.maxEntries === undefined ? {} : { maxEntries: archive.maxEntries }),
+  };
+};
+
+const snapshotProposalLimits = (
+  limits: FolioDocxXmlPatchProposalLimits | undefined,
+): FolioDocxXmlPatchProposalLimits | undefined => {
+  if (limits === undefined) {
+    return undefined;
+  }
+  return {
+    ...(limits.maxReplacements === undefined ? {} : { maxReplacements: limits.maxReplacements }),
+    ...(limits.maxPartBytes === undefined ? {} : { maxPartBytes: limits.maxPartBytes }),
+    ...(limits.maxTotalBytes === undefined ? {} : { maxTotalBytes: limits.maxTotalBytes }),
+  };
+};
+
+type EvaluateProposalOptions = {
+  bytes: Uint8Array;
+  proposal: unknown;
+  allowedParts: readonly string[];
+  archive: DocxArchiveOptions | undefined;
+  limits: FolioDocxXmlPatchProposalLimits | undefined;
+};
+
+const evaluateProposal = async ({
+  bytes,
+  proposal,
+  allowedParts,
+  archive,
+  limits,
+}: EvaluateProposalOptions): Promise<FolioDocxXmlPatchProposalEvaluation> =>
+  await evaluateDocxXmlPatchProposal({
+    bytes,
+    proposal,
+    allowedParts,
+    ...(archive === undefined ? {} : { archive }),
+    ...(limits === undefined ? {} : { limits }),
+  });
+
+type ProposalRejectedOptions = {
+  evaluation: RejectedProposalEvaluation;
+};
+
+const proposalRejected = ({
+  evaluation,
+}: ProposalRejectedOptions): FolioDocxXmlPatchApplication => ({
+  version: FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+  profile: FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+  status: "proposal-rejected",
+  producesOutput: false,
+  evaluation,
+  conformance: null,
+  receipt: null,
+});
+
+const verifyArchiveContents = async (
+  bytes: Uint8Array,
+  options: DocxArchiveOptions | undefined,
+): Promise<void> => {
+  let archive;
+  try {
+    archive = await loadDocxArchive(bytes, options);
+  } catch (cause) {
+    throw new FolioDocxXmlPatchApplicationError({
+      message: "The evaluated package could not be verified within the archive limits.",
+      stage: "verify",
+      cause,
+    });
+  }
+
+  for (const entry of archive.entryMetadata.toSorted(({ path: left }, { path: right }) =>
+    left < right ? -1 : Number(left > right),
+  )) {
+    if (entry.directory) {
+      continue;
+    }
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- serialized reads enforce the archive budget
+      const content = await archive.readEntryUint8(entry.path);
+      if (content === null) {
+        throw new FolioDocxXmlPatchApplicationError({
+          message: "An archive entry disappeared during verification.",
+          stage: "verify",
+          part: entry.path,
+        });
+      }
+    } catch (cause) {
+      if (cause instanceof FolioDocxXmlPatchApplicationError) {
+        throw cause;
+      }
+      throw new FolioDocxXmlPatchApplicationError({
+        message: "An archive entry could not be verified within the configured limits.",
+        stage: "verify",
+        part: entry.path,
+        cause,
+      });
+    }
+  }
+};
+
+type ApplyReplacementsOptions = {
+  bytes: Uint8Array;
+  proposal: FolioDocxXmlPatchProposal;
+};
+
+const applyReplacements = async ({
+  bytes,
+  proposal,
+}: ApplyReplacementsOptions): Promise<Uint8Array> => {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(bytes);
+  } catch (cause) {
+    throw new FolioDocxXmlPatchApplicationError({
+      message: "The evaluated package could not be loaded for replacement.",
+      stage: "load",
+      cause,
+    });
+  }
+
+  for (const replacement of proposal.replacements) {
+    const current = zip.file(replacement.path);
+    if (current === null) {
+      throw new FolioDocxXmlPatchApplicationError({
+        message: "An evaluated package part was unavailable during replacement.",
+        stage: "replace",
+      });
+    }
+    zip.file(replacement.path, new TextEncoder().encode(replacement.replacementXml), {
+      binary: true,
+      date: current.date,
+      comment: current.comment,
+      createFolders: false,
+      unixPermissions: current.unixPermissions,
+      dosPermissions: current.dosPermissions,
+      compression: "DEFLATE",
+      compressionOptions: { level: 6 },
+    });
+  }
+
+  try {
+    return await zip.generateAsync({
+      type: "uint8array",
+      compression: "DEFLATE",
+      compressionOptions: { level: 6 },
+    });
+  } catch (cause) {
+    throw new FolioDocxXmlPatchApplicationError({
+      message: "The replacement package could not be generated.",
+      stage: "generate",
+      cause,
+    });
+  }
+};
+
+type OutputRejectedOptions = {
+  evaluation: AcceptedProposalEvaluation;
+  conformance: FolioDocxConformanceReport;
+};
+
+const outputRejected = ({
+  evaluation,
+  conformance,
+}: OutputRejectedOptions): FolioDocxXmlPatchApplication => ({
+  version: FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+  profile: FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+  status: "output-rejected",
+  producesOutput: false,
+  evaluation,
+  conformance,
+  receipt: null,
+});
+
+type AppliedOptions = {
+  input: Uint8Array;
+  output: Uint8Array;
+  evaluation: AcceptedProposalEvaluation;
+  conformance: ConformantReport;
+};
+
+const applied = ({
+  input,
+  output,
+  evaluation,
+  conformance,
+}: AppliedOptions): FolioDocxXmlPatchApplication => ({
+  version: FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+  profile: FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+  status: "applied",
+  producesOutput: true,
+  evaluation,
+  conformance,
+  receipt: {
+    version: FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+    profile: FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+    proposalProfile: FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE,
+    validationProfile: FOLIO_DOCX_CONFORMANCE_PROFILE,
+    input: {
+      sha256: sha256(input),
+      byteLength: input.byteLength,
+    },
+    output: {
+      sha256: sha256(output),
+      byteLength: output.byteLength,
+    },
+    replacements: evaluation.replacements,
+  },
+  bytes: output,
+});
+
+/** Apply a guarded XML proposal and return output only after full profile validation. */
+export const applyDocxXmlPatchProposal = async ({
+  bytes,
+  proposal: rawProposal,
+  allowedParts,
+  validationProfile,
+  archive,
+  limits,
+}: ApplyDocxXmlPatchProposalArgs): Promise<FolioDocxXmlPatchApplication> => {
+  if (validationProfile !== FOLIO_DOCX_CONFORMANCE_PROFILE) {
+    throw new UnsupportedFolioDocxXmlPatchApplicationProfileError({
+      message: "The requested package validation profile is not supported.",
+      profile: validationProfile,
+    });
+  }
+
+  const input = snapshotInput(bytes);
+  const policyAllowedParts = [...allowedParts];
+  const policyArchive = snapshotArchiveOptions(archive);
+  const policyLimits = snapshotProposalLimits(limits);
+  let proposal: FolioDocxXmlPatchProposal;
+  try {
+    proposal = parseFolioDocxXmlPatchProposal(rawProposal);
+  } catch (error) {
+    if (!(error instanceof InvalidFolioDocxXmlPatchProposalError)) {
+      throw error;
+    }
+    const evaluation = await evaluateProposal({
+      bytes: input,
+      proposal: rawProposal,
+      allowedParts: policyAllowedParts,
+      archive: policyArchive,
+      limits: policyLimits,
+    });
+    if (evaluation.status !== "rejected") {
+      return panic("An invalid XML proposal produced an accepted evaluation");
+    }
+    return proposalRejected({ evaluation });
+  }
+
+  const evaluation = await evaluateProposal({
+    bytes: input,
+    proposal,
+    allowedParts: policyAllowedParts,
+    archive: policyArchive,
+    limits: policyLimits,
+  });
+  if (evaluation.status === "rejected") {
+    return proposalRejected({ evaluation });
+  }
+
+  await verifyArchiveContents(input, policyArchive);
+  const output = await applyReplacements({ bytes: input, proposal });
+  const conformance = await validateDocxConformance(output, {
+    ...(policyArchive === undefined ? {} : { archive: policyArchive }),
+  });
+  if (conformance.status !== "conformant") {
+    return outputRejected({ evaluation, conformance });
+  }
+  return applied({ input, output, evaluation, conformance });
+};

--- a/packages/core/src/docx/server/applyDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/applyDocxXmlPatchProposal.ts
@@ -63,6 +63,9 @@ type RejectedProposalEvaluation = Extract<
 >;
 type ConformantReport = FolioDocxConformanceReport & { readonly status: "conformant" };
 
+const isConformantReport = (report: FolioDocxConformanceReport): report is ConformantReport =>
+  report.status === "conformant";
+
 export type FolioDocxXmlPatchApplication =
   | {
       readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
@@ -391,7 +394,7 @@ export const applyDocxXmlPatchProposal = async ({
   const conformance = await validateDocxConformance(output, {
     ...(policyArchive === undefined ? {} : { archive: policyArchive }),
   });
-  if (conformance.status !== "conformant") {
+  if (!isConformantReport(conformance)) {
     return outputRejected({ evaluation, conformance });
   }
   return applied({ input, output, evaluation, conformance });

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -175,6 +175,16 @@ export {
 } from "./docx/server/extractDocxText";
 export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";
 export {
+  applyDocxXmlPatchProposal,
+  FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE,
+  FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION,
+  FolioDocxXmlPatchApplicationError,
+  UnsupportedFolioDocxXmlPatchApplicationProfileError,
+  type ApplyDocxXmlPatchProposalArgs,
+  type FolioDocxXmlPatchApplication,
+  type FolioDocxXmlPatchApplicationReceipt,
+} from "./docx/server/applyDocxXmlPatchProposal";
+export {
   FOLIO_DOCX_PACKAGE_INSPECTION_DEFAULTS,
   FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES,
   FOLIO_DOCX_PACKAGE_INSPECTION_VERSION,


### PR DESCRIPTION
## Summary

- apply accepted XML patch proposals as one package update
- validate generated packages before returning bytes
- return content-addressed receipts for applied batches