### PR TITLE
fix: improve Word list and table pagination parity

### DIFF
--- a/.changeset/calm-lists-align.md
+++ b/.changeset/calm-lists-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Match Word's final-line paragraph-mark spacing for visible lists.

--- a/.changeset/fresh-tables-flow.md
+++ b/.changeset/fresh-tables-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Ignore cached table page boundaries when tracked row content can change pagination.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -626,6 +626,7 @@ export type ParagraphAttrs = {
     listMarkerHidden?: boolean;
     listMarkerFontFamily?: string;
     listMarkerFontSize?: number;
+    listParagraphMarkFontSize?: number;
     listMarkerBold?: boolean; /** Horizontal alignment of the marker around the paragraph's list anchor. */
     listMarkerAlignment?: "left" | "center" | "right";
     listMarkerSuffix?: "tab" | "space" | "nothing";

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -8,6 +8,19 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { TaggedErrorClass } from 'better-result';
 
 // @public
+export const applyDocxXmlPatchProposal: (input: ApplyDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchApplication>;
+
+// @public (undocumented)
+export type ApplyDocxXmlPatchProposalArgs = {
+    readonly bytes: ArrayBuffer | Uint8Array;
+    readonly proposal: unknown; /** Exact package paths authorized by the server-side caller. */
+    readonly allowedParts: readonly string[];
+    readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+    readonly archive?: DocxArchiveOptions;
+    readonly limits?: FolioDocxXmlPatchProposalLimits;
+};
+
+// @public
 export const applyFolioAIEditsToBuffer: (buffer: ArrayBuffer, operations: FolioAIEditOperation[], options?: ApplyFolioAIEditsToBufferOptions) => Promise<ApplyFolioAIEditsToBufferResult>;
 
 // @public
@@ -142,6 +155,18 @@ export type EnsureParaIdsResult = {
     alreadyComplete: boolean;
 };
 
+// @public (undocumented)
+export const evaluateDocxXmlPatchProposal: (input: EvaluateDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchProposalEvaluation>;
+
+// @public (undocumented)
+export type EvaluateDocxXmlPatchProposalArgs = {
+    readonly bytes: ArrayBuffer | Uint8Array;
+    readonly proposal: unknown; /** Exact package paths authorized by the server-side caller. */
+    readonly allowedParts: readonly string[];
+    readonly archive?: DocxArchiveOptions;
+    readonly limits?: FolioDocxXmlPatchProposalLimits;
+};
+
 // @public
 export const extractDocumentStyleSet: (document: import__stll_docx_core_model.Document, options: ExtractDocumentStyleSetOptions) => DocumentStyleSet;
 
@@ -244,6 +269,28 @@ export const FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES: readonly ["invalid-limit
 
 // @public (undocumented)
 export const FOLIO_DOCX_PACKAGE_INSPECTION_VERSION: 1;
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE: "folio-xml-patch-application-v1";
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION: 1;
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS: Readonly<{
+    readonly maxReplacements: 16;
+    readonly maxPartBytes: number;
+    readonly maxTotalBytes: number;
+}>;
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES: readonly ["invalid-proposal", "unsupported-version", "too-many-replacements", "duplicate-part", "invalid-part-path", "invalid-base-sha256", "part-not-allowed", "part-not-found", "part-not-xml", "replacement-too-large", "replacements-too-large", "xml-doctype-forbidden", "xml-not-well-formed", "xml-encoding-mismatch", "base-hash-mismatch", "package-inspection-failed"];
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE: "folio-xml-patch-proposal-v1";
+
+// @public (undocumented)
+export const FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION: 1;
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -830,6 +877,16 @@ export type FolioDocxPackagePart = {
 // @public (undocumented)
 export type FolioDocxPackagePartKind = "xml" | "binary";
 
+// @public (undocumented)
+export type FolioDocxPreparedXmlReplacement = {
+    readonly path: string;
+    readonly baseSha256: string;
+    readonly currentSha256: string;
+    readonly replacementSha256: string;
+    readonly replacementByteLength: number;
+    readonly encoding: "utf-8";
+};
+
 // @public
 export class FolioDocxReviewer {
     acceptAll(): number;
@@ -866,6 +923,112 @@ export class FolioDocxReviewer {
 export type FolioDocxReviewerOptions = {
     author?: string; /** Password for Agile-encrypted .docx files (Office 2010+). */
     password?: string | undefined;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchApplication = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly status: "proposal-rejected";
+    readonly producesOutput: false;
+    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
+        status: "rejected";
+    }>;
+    readonly conformance: null;
+    readonly receipt: null;
+} | {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly status: "output-rejected";
+    readonly producesOutput: false;
+    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
+        status: "accepted";
+    }>;
+    readonly conformance: FolioDocxConformanceReport;
+    readonly receipt: null;
+} | {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly status: "applied";
+    readonly producesOutput: true;
+    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
+        status: "accepted";
+    }>;
+    readonly conformance: FolioDocxConformanceReport & {
+        readonly status: "conformant";
+    };
+    readonly receipt: FolioDocxXmlPatchApplicationReceipt;
+    readonly bytes: Uint8Array;
+};
+
+// @public (undocumented)
+export class FolioDocxXmlPatchApplicationError extends FolioDocxXmlPatchApplicationError_base {}
+
+// @public (undocumented)
+export type FolioDocxXmlPatchApplicationReceipt = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
+    readonly proposalProfile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
+    readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
+    readonly input: {
+        readonly sha256: string;
+        readonly byteLength: number;
+    };
+    readonly output: {
+        readonly sha256: string;
+        readonly byteLength: number;
+    };
+    readonly replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposal = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+    readonly replacements: readonly [FolioDocxXmlReplacement, ...FolioDocxXmlReplacement[]];
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalEvaluation = {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
+    readonly status: "accepted";
+    readonly producesOutput: false;
+    readonly issues: readonly [];
+    readonly replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
+    readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+} | {
+    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
+    readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
+    readonly status: "rejected";
+    readonly producesOutput: false;
+    readonly issues: readonly [FolioDocxXmlPatchProposalIssue, ...FolioDocxXmlPatchProposalIssue[]];
+    readonly replacements: readonly [];
+    readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalIssue = {
+    readonly code: FolioDocxXmlPatchProposalIssueCode;
+    readonly message: string;
+    readonly proposalPath?: string;
+    readonly part?: string;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalIssueCode = (typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES)[number];
+
+// @public (undocumented)
+export type FolioDocxXmlPatchProposalLimits = {
+    readonly maxReplacements?: number;
+    readonly maxPartBytes?: number;
+    readonly maxTotalBytes?: number;
+};
+
+// @public (undocumented)
+export type FolioDocxXmlReplacement = {
+    readonly path: string;
+    readonly baseSha256: string;
+    readonly replacementXml: string;
 };
 
 // @public (undocumented)
@@ -1074,6 +1237,12 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
 export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
 
 // @public (undocumented)
+export class InvalidFolioDocxXmlPatchProposalError extends InvalidFolioDocxXmlPatchProposalError_base {}
+
+// @public (undocumented)
+export class InvalidFolioDocxXmlPatchProposalOptionsError extends InvalidFolioDocxXmlPatchProposalOptionsError_base {}
+
+// @public (undocumented)
 export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
 
 // @public (undocumented)
@@ -1109,6 +1278,9 @@ export const isSupportedFolioDocumentOperationVersion: (value: unknown) => value
 // @public (undocumented)
 export const parseFolioDocumentOperationBatch: (value: unknown) => FolioDocumentOperationBatch;
 
+// @public (undocumented)
+export const parseFolioDocxXmlPatchProposal: (value: unknown) => FolioDocxXmlPatchProposal;
+
 // @public
 export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: FolioDocumentSectionHandle) => FolioDocumentSectionReadResult;
 
@@ -1129,6 +1301,9 @@ export const STELLA_STYLE_SET_NAME = "Stella Style";
 
 // @public (undocumented)
 export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
+
+// @public (undocumented)
+export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends UnsupportedFolioDocxXmlPatchApplicationProfileError_base {}
 
 // @public (undocumented)
 export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base {}

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -8,19 +8,6 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { TaggedErrorClass } from 'better-result';
 
 // @public
-export const applyDocxXmlPatchProposal: (input: ApplyDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchApplication>;
-
-// @public (undocumented)
-export type ApplyDocxXmlPatchProposalArgs = {
-    readonly bytes: ArrayBuffer | Uint8Array;
-    readonly proposal: unknown; /** Exact package paths authorized by the server-side caller. */
-    readonly allowedParts: readonly string[];
-    readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
-    readonly archive?: DocxArchiveOptions;
-    readonly limits?: FolioDocxXmlPatchProposalLimits;
-};
-
-// @public
 export const applyFolioAIEditsToBuffer: (buffer: ArrayBuffer, operations: FolioAIEditOperation[], options?: ApplyFolioAIEditsToBufferOptions) => Promise<ApplyFolioAIEditsToBufferResult>;
 
 // @public
@@ -155,18 +142,6 @@ export type EnsureParaIdsResult = {
     alreadyComplete: boolean;
 };
 
-// @public (undocumented)
-export const evaluateDocxXmlPatchProposal: (input: EvaluateDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchProposalEvaluation>;
-
-// @public (undocumented)
-export type EvaluateDocxXmlPatchProposalArgs = {
-    readonly bytes: ArrayBuffer | Uint8Array;
-    readonly proposal: unknown; /** Exact package paths authorized by the server-side caller. */
-    readonly allowedParts: readonly string[];
-    readonly archive?: DocxArchiveOptions;
-    readonly limits?: FolioDocxXmlPatchProposalLimits;
-};
-
 // @public
 export const extractDocumentStyleSet: (document: import__stll_docx_core_model.Document, options: ExtractDocumentStyleSetOptions) => DocumentStyleSet;
 
@@ -269,28 +244,6 @@ export const FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES: readonly ["invalid-limit
 
 // @public (undocumented)
 export const FOLIO_DOCX_PACKAGE_INSPECTION_VERSION: 1;
-
-// @public (undocumented)
-export const FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE: "folio-xml-patch-application-v1";
-
-// @public (undocumented)
-export const FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION: 1;
-
-// @public (undocumented)
-export const FOLIO_DOCX_XML_PATCH_PROPOSAL_DEFAULTS: Readonly<{
-    readonly maxReplacements: 16;
-    readonly maxPartBytes: number;
-    readonly maxTotalBytes: number;
-}>;
-
-// @public (undocumented)
-export const FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES: readonly ["invalid-proposal", "unsupported-version", "too-many-replacements", "duplicate-part", "invalid-part-path", "invalid-base-sha256", "part-not-allowed", "part-not-found", "part-not-xml", "replacement-too-large", "replacements-too-large", "xml-doctype-forbidden", "xml-not-well-formed", "xml-encoding-mismatch", "base-hash-mismatch", "package-inspection-failed"];
-
-// @public (undocumented)
-export const FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE: "folio-xml-patch-proposal-v1";
-
-// @public (undocumented)
-export const FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION: 1;
 
 // @public (undocumented)
 export const FOLIO_RESOLVED_REVIEWED_VIEWS: readonly ["original", "final"];
@@ -877,16 +830,6 @@ export type FolioDocxPackagePart = {
 // @public (undocumented)
 export type FolioDocxPackagePartKind = "xml" | "binary";
 
-// @public (undocumented)
-export type FolioDocxPreparedXmlReplacement = {
-    readonly path: string;
-    readonly baseSha256: string;
-    readonly currentSha256: string;
-    readonly replacementSha256: string;
-    readonly replacementByteLength: number;
-    readonly encoding: "utf-8";
-};
-
 // @public
 export class FolioDocxReviewer {
     acceptAll(): number;
@@ -923,112 +866,6 @@ export class FolioDocxReviewer {
 export type FolioDocxReviewerOptions = {
     author?: string; /** Password for Agile-encrypted .docx files (Office 2010+). */
     password?: string | undefined;
-};
-
-// @public (undocumented)
-export type FolioDocxXmlPatchApplication = {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
-    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
-    readonly status: "proposal-rejected";
-    readonly producesOutput: false;
-    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
-        status: "rejected";
-    }>;
-    readonly conformance: null;
-    readonly receipt: null;
-} | {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
-    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
-    readonly status: "output-rejected";
-    readonly producesOutput: false;
-    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
-        status: "accepted";
-    }>;
-    readonly conformance: FolioDocxConformanceReport;
-    readonly receipt: null;
-} | {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
-    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
-    readonly status: "applied";
-    readonly producesOutput: true;
-    readonly evaluation: Extract<FolioDocxXmlPatchProposalEvaluation, {
-        status: "accepted";
-    }>;
-    readonly conformance: FolioDocxConformanceReport & {
-        readonly status: "conformant";
-    };
-    readonly receipt: FolioDocxXmlPatchApplicationReceipt;
-    readonly bytes: Uint8Array;
-};
-
-// @public (undocumented)
-export class FolioDocxXmlPatchApplicationError extends FolioDocxXmlPatchApplicationError_base {}
-
-// @public (undocumented)
-export type FolioDocxXmlPatchApplicationReceipt = {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_VERSION;
-    readonly profile: typeof FOLIO_DOCX_XML_PATCH_APPLICATION_PROFILE;
-    readonly proposalProfile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
-    readonly validationProfile: typeof FOLIO_DOCX_CONFORMANCE_PROFILE;
-    readonly input: {
-        readonly sha256: string;
-        readonly byteLength: number;
-    };
-    readonly output: {
-        readonly sha256: string;
-        readonly byteLength: number;
-    };
-    readonly replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
-};
-
-// @public (undocumented)
-export type FolioDocxXmlPatchProposal = {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
-    readonly replacements: readonly [FolioDocxXmlReplacement, ...FolioDocxXmlReplacement[]];
-};
-
-// @public (undocumented)
-export type FolioDocxXmlPatchProposalEvaluation = {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
-    readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
-    readonly status: "accepted";
-    readonly producesOutput: false;
-    readonly issues: readonly [];
-    readonly replacements: readonly [FolioDocxPreparedXmlReplacement, ...FolioDocxPreparedXmlReplacement[]];
-    readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
-} | {
-    readonly version: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_VERSION;
-    readonly profile: typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_PROFILE;
-    readonly status: "rejected";
-    readonly producesOutput: false;
-    readonly issues: readonly [FolioDocxXmlPatchProposalIssue, ...FolioDocxXmlPatchProposalIssue[]];
-    readonly replacements: readonly [];
-    readonly limits: Required<FolioDocxXmlPatchProposalLimits>;
-};
-
-// @public (undocumented)
-export type FolioDocxXmlPatchProposalIssue = {
-    readonly code: FolioDocxXmlPatchProposalIssueCode;
-    readonly message: string;
-    readonly proposalPath?: string;
-    readonly part?: string;
-};
-
-// @public (undocumented)
-export type FolioDocxXmlPatchProposalIssueCode = (typeof FOLIO_DOCX_XML_PATCH_PROPOSAL_ISSUE_CODES)[number];
-
-// @public (undocumented)
-export type FolioDocxXmlPatchProposalLimits = {
-    readonly maxReplacements?: number;
-    readonly maxPartBytes?: number;
-    readonly maxTotalBytes?: number;
-};
-
-// @public (undocumented)
-export type FolioDocxXmlReplacement = {
-    readonly path: string;
-    readonly baseSha256: string;
-    readonly replacementXml: string;
 };
 
 // @public (undocumented)
@@ -1237,12 +1074,6 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
 export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
 
 // @public (undocumented)
-export class InvalidFolioDocxXmlPatchProposalError extends InvalidFolioDocxXmlPatchProposalError_base {}
-
-// @public (undocumented)
-export class InvalidFolioDocxXmlPatchProposalOptionsError extends InvalidFolioDocxXmlPatchProposalOptionsError_base {}
-
-// @public (undocumented)
 export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
 
 // @public (undocumented)
@@ -1278,9 +1109,6 @@ export const isSupportedFolioDocumentOperationVersion: (value: unknown) => value
 // @public (undocumented)
 export const parseFolioDocumentOperationBatch: (value: unknown) => FolioDocumentOperationBatch;
 
-// @public (undocumented)
-export const parseFolioDocxXmlPatchProposal: (value: unknown) => FolioDocxXmlPatchProposal;
-
 // @public
 export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: FolioDocumentSectionHandle) => FolioDocumentSectionReadResult;
 
@@ -1301,9 +1129,6 @@ export const STELLA_STYLE_SET_NAME = "Stella Style";
 
 // @public (undocumented)
 export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
-
-// @public (undocumented)
-export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends UnsupportedFolioDocxXmlPatchApplicationProfileError_base {}
 
 // @public (undocumented)
 export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base {}

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -412,6 +412,30 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.defaultFontFamily).toBe("Arial Narrow");
   });
 
+  test("preserves a larger complex-script paragraph-mark size for visible lists", () => {
+    const listParagraph = schema.node(
+      "paragraph",
+      {
+        defaultTextFormatting: { fontSize: 21, fontSizeCs: 22 },
+        listIsBullet: true,
+        listMarker: "\u2022",
+        numPr: { numId: 1, ilvl: 0 },
+      },
+      [schema.text("List item")],
+    );
+    const ordinaryParagraph = schema.node(
+      "paragraph",
+      { defaultTextFormatting: { fontSize: 21, fontSizeCs: 22 } },
+      [schema.text("Ordinary paragraph")],
+    );
+
+    const blocks = toFlowBlocks(schema.node("doc", null, [listParagraph, ordinaryParagraph]));
+
+    expect(blocks.at(0)?.attrs?.defaultFontSize).toBe(10.5);
+    expect(blocks.at(0)?.attrs?.listParagraphMarkFontSize).toBe(11);
+    expect(blocks.at(1)?.attrs?.listParagraphMarkFontSize).toBeUndefined();
+  });
+
   test("does not reserve extra outline height away from the start of the story", () => {
     const blocks = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1884,6 +1884,14 @@ function convertParagraphAttrs(
       // fontSize in TextFormatting is in half-points, convert to points
       attrs.defaultFontSize = dtf.fontSize / 2;
     }
+    if (
+      attrs.listMarker !== undefined &&
+      !attrs.listMarkerHidden &&
+      dtf.fontSizeCs !== undefined &&
+      (dtf.fontSize === undefined || dtf.fontSizeCs > dtf.fontSize)
+    ) {
+      attrs.listParagraphMarkFontSize = dtf.fontSizeCs / 2;
+    }
     if (dtf.fontFamily) {
       const resolvedFamily = resolveWesternThemeFont(dtf.fontFamily, theme);
       if (resolvedFamily) {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -893,6 +893,29 @@ const tableRowStartsWithRenderedPageBreak = (block: TableBlock, rowIndex: number
     return firstBlock?.kind === "paragraph" && firstBlock.attrs?.renderedPageBreakBefore === true;
   }) ?? false;
 
+const flowBlockHasTrackedChanges = (block: FlowBlock): boolean => {
+  if (block.kind === "paragraph") {
+    return block.runs.some((run) => {
+      if (run.kind === "lineBreak") {
+        return false;
+      }
+      return run.isInsertion || run.isDeletion;
+    });
+  }
+  if (block.kind === "table") {
+    return block.rows.some((row) =>
+      row.cells.some((cell) => cell.blocks.some(flowBlockHasTrackedChanges)),
+    );
+  }
+  if (block.kind === "textBox") {
+    return block.content.some(flowBlockHasTrackedChanges);
+  }
+  return false;
+};
+
+const tableRowHasTrackedChanges = (block: TableBlock, rowIndex: number): boolean =>
+  block.rows[rowIndex]?.cells.some((cell) => cell.blocks.some(flowBlockHasTrackedChanges)) ?? false;
+
 /**
  * Layout a table block onto pages.
  */
@@ -920,7 +943,6 @@ function layoutTable(
   const hasVerticalMerges = block.rows.some((row) =>
     row.cells.some((cell) => (cell.rowSpan ?? 1) > 1),
   );
-
   // X position from justification / indent, recomputed per fragment because the
   // active column can change across section breaks.
   const computeTableX = (columnIndex: number): number => {
@@ -1008,6 +1030,7 @@ function layoutTable(
     if (
       !rowStartsFreshPage &&
       tableRowStartsWithRenderedPageBreak(block, currentRowIndex) &&
+      !tableRowHasTrackedChanges(block, currentRowIndex) &&
       rows[currentRowIndex]!.height > rowAvailableHeight
     ) {
       paginator.forcePageBreak();

--- a/packages/core/src/layout-engine/measure/measureParagraph-list-marker.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-list-marker.test.ts
@@ -10,6 +10,30 @@ const DEFAULT_TAB_STOP_PX = (DEFAULT_TAB_STOP_TWIPS / 1440) * 96;
 const fakeMeasure = { charWidth: fixedCharWidth(10) };
 
 describe("measureParagraph reserves the marker's tab-stop footprint", () => {
+  test("a larger list paragraph mark raises only the final line box", () => {
+    withFakeTextMeasure(() => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: "p",
+        runs: [{ kind: "text", text: "aaaa aaaa", fontFamily: "Aptos", fontSize: 10.5 }],
+        attrs: {
+          defaultFontSize: 10.5,
+          defaultFontFamily: "Aptos",
+          listMarker: "\u2022",
+          listMarkerSuffix: "nothing",
+          listParagraphMarkFontSize: 11,
+          spacing: { line: 1.15, lineRule: "auto", lineUnit: "multiplier" },
+        },
+      };
+
+      const measure = measureParagraph(block, 60);
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines.at(0)?.lineHeight).toBeCloseTo(10.5 * (96 / 72) * 1.2207 * 1.15, 3);
+      expect(measure.lines.at(1)?.lineHeight).toBeCloseTo(11 * (96 / 72) * 1.2207 * 1.15, 3);
+    }, fakeMeasure);
+  });
+
   // Regression for upstream #600: with the previous "+12 px gap" logic the
   // first line had `bodyWidth - markerWidth - 12` of text room. Long markers
   // like "1.1.1." therefore had too much budget — the painter pushed text

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -2057,6 +2057,18 @@ export function measureParagraph(
     }
   }
 
+  const listParagraphMarkFontSize = attrs?.listParagraphMarkFontSize;
+  if (
+    listParagraphMarkFontSize !== undefined &&
+    listParagraphMarkFontSize > currentLine.maxFontSize
+  ) {
+    const fontFamily = currentLine.maxFontMetrics?.fontFamily ?? attrs?.defaultFontFamily;
+    updateMaxFont({
+      fontSize: listParagraphMarkFontSize,
+      ...(fontFamily === undefined ? {} : { fontFamily }),
+    });
+  }
+
   // Finalize the last line
   finalizeLine();
 

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1122,6 +1122,34 @@ describe("oversized table row splits across pages (#570)", () => {
     expect(frags[1]?.bottomClip).toBeUndefined();
   });
 
+  test("ignores a stale rendered row boundary when tracked content changes flow", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 70);
+    const { block, measure } = tallTable(5);
+    markFirstTableParagraphWithRenderedBreak(block);
+    const firstRun = block.rows.at(0)?.cells.at(0)?.blocks.at(0);
+    if (firstRun?.kind !== "paragraph" || firstRun.runs.at(0)?.kind !== "text") {
+      throw new Error("test table must start with a text run");
+    }
+    firstRun.runs[0]!.isInsertion = true;
+
+    const layout = layoutDocument(
+      [spacer, block as FlowBlock],
+      [spacerMeasure as Measure, measure as Measure],
+      OPTIONS,
+    );
+    const frags = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(frags.at(0)).toMatchObject({ fromRow: 0, toRow: 1, height: 40, bottomClip: 40 });
+    expect(frags.at(1)).toMatchObject({ fromRow: 0, toRow: 1, height: 60, topClip: 40 });
+  });
+
   test("moves a non-fitting row to its cached rendered page boundary", () => {
     const spacer: FlowBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -471,6 +471,12 @@ export type ParagraphAttrs = {
   listMarkerHidden?: boolean; // w:vanish on numbering level rPr
   listMarkerFontFamily?: string; // from numbering level rPr (w:rFonts)
   listMarkerFontSize?: number; // from numbering level rPr, in points
+  /**
+   * Effective paragraph-mark size used only to measure a visible list
+   * paragraph's final line. Word lets the inherited complex-script size raise
+   * that line box without enlarging the marker or Western text glyphs.
+   */
+  listParagraphMarkFontSize?: number;
   listMarkerBold?: boolean; // from numbering level rPr (w:b)
   /** Horizontal alignment of the marker around the paragraph's list anchor. */
   listMarkerAlignment?: "left" | "center" | "right";


### PR DESCRIPTION
## Summary

- measure the final visible list line with its effective paragraph-mark size
- treat cached table row page boundaries as stale when tracked content changes row flow
- add focused synthetic regressions for both layout invariants
- refresh the pre-existing stale server API report in a separate commit

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run validate-dist`
- `bun run api:check`
- Microsoft Word differential parity on the affected document pair