### PR TITLE
fix: harden clipboard, image sources, and VML style parsing

### DIFF
--- a/.changeset/security-untrusted-input-hardening.md
+++ b/.changeset/security-untrusted-input-hardening.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Harden untrusted clipboard HTML, image sources, and VML style parsing against XSS, remote fetch, ReDoS, and prototype pollution.

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@stll/template-conditions": "^0.1.0",
         "better-result": "2.9.2",
         "csstype": "^3.1.3",
+        "dompurify": "^3.4.12",
         "fast-xml-parser": "^5.9.3",
         "hyphen": "1.14.1",
         "jszip": "3.10.1",
@@ -1281,7 +1282,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -2272,6 +2273,8 @@
     "@babel/traverse/@babel/parser": ["@babel/parser@8.0.4", "", { "dependencies": { "@babel/types": "^8.0.4" }, "bin": "./bin/babel-parser.js" }, "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g=="],
 
     "@babel/traverse/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@eigenpal/docx-editor-core/dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
     "@stll/template-conditions": "^0.1.0",
     "better-result": "2.9.2",
     "csstype": "^3.1.3",
+    "dompurify": "^3.4.12",
     "fast-xml-parser": "^5.9.3",
     "hyphen": "1.14.1",
     "jszip": "3.10.1",

--- a/packages/core/src/docx/imageParser.ts
+++ b/packages/core/src/docx/imageParser.ts
@@ -39,6 +39,7 @@ import type {
 } from "../types/document";
 import { emuToPixels } from "../utils/units";
 import { sanitizeExternalUrl } from "../utils/urlSecurity";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import {
   parsePositionH,
   parsePositionV,
@@ -628,8 +629,9 @@ function parseInline(
   if (props.decorative) {
     image.decorative = true;
   }
-  if (imageData.src) {
-    image.src = imageData.src;
+  const safeSrc = sanitizeImageSrc(imageData.src);
+  if (safeSrc) {
+    image.src = safeSrc;
   }
   if (imageData.mimeType) {
     image.mimeType = imageData.mimeType;
@@ -766,8 +768,9 @@ function parseAnchor(
   if (props.decorative) {
     image.decorative = true;
   }
-  if (imageData.src) {
-    image.src = imageData.src;
+  const safeSrc = sanitizeImageSrc(imageData.src);
+  if (safeSrc) {
+    image.src = safeSrc;
   }
   if (imageData.mimeType) {
     image.mimeType = imageData.mimeType;

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -799,3 +799,21 @@ describe("VML w:pict inline images", () => {
     expect(reDrawing?.image.src?.startsWith("data:image/png")).toBe(true);
   });
 });
+
+describe("VML style attribute hardening", () => {
+  test("ignores prototype-polluting style keys without breaking width parse", async () => {
+    const marker = "__folio_vml_style_pollution__";
+    expect(Object.hasOwn(Object.prototype, marker)).toBe(false);
+
+    const original = await pictDocx({
+      runXml: `<w:pict><v:shape style="width:120pt;height:40pt;__proto__:${marker};constructor:x;prototype:y"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+    });
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.src?.startsWith("data:image/png")).toBe(true);
+    expect(drawing?.image.size.width).toBeGreaterThan(0);
+
+    expect(Object.hasOwn(Object.prototype, marker)).toBe(false);
+    expect(({} as Record<string, unknown>)[marker]).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -29,6 +29,7 @@
  */
 
 import type { DrawingContent, Image, MediaFile, RelationshipMap } from "../types/document";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import { pixelsToEmu } from "../utils/units";
 import { resolveImageData } from "./imageParser";
 import { isWatermarkShape } from "./watermarkParser";
@@ -106,6 +107,8 @@ function cssLengthToPx(raw: string | undefined): number | undefined {
   }
 }
 
+const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 /** Read a `style="k1:v1;k2:v2"` attribute into a lowercased key/value record. */
 function parseStyleAttr(style: string | null): Record<string, string> {
   const out: Record<string, string> = {};
@@ -119,9 +122,12 @@ function parseStyleAttr(style: string | null): Record<string, string> {
     }
     const key = decl.slice(0, colon).trim().toLowerCase();
     const value = decl.slice(colon + 1).trim();
-    if (key) {
-      out[key] = value;
+    // Skip keys that would pollute Object.prototype — the style string is
+    // attacker-controlled when the DOCX is untrusted.
+    if (!key || PROTOTYPE_POLLUTION_KEYS.has(key)) {
+      continue;
     }
+    out[key] = value;
   }
   return out;
 }
@@ -380,8 +386,9 @@ export function parseVmlImageContent(
       },
       wrap: { type: "inline" },
     };
-    if (src) {
-      image.src = src;
+    const safeSrc = sanitizeImageSrc(src);
+    if (safeSrc) {
+      image.src = safeSrc;
     }
     if (mimeType) {
       image.mimeType = mimeType;

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -111,7 +111,9 @@ const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype
 
 /** Read a `style="k1:v1;k2:v2"` attribute into a lowercased key/value record. */
 function parseStyleAttr(style: string | null): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Null prototype: the style string is attacker-controlled when the DOCX is
+  // untrusted, so the record must not inherit from (or shadow) Object.prototype.
+  const out: Record<string, string> = Object.create(null);
   if (!style) {
     return out;
   }

--- a/packages/core/src/layout-painter/renderImage.ts
+++ b/packages/core/src/layout-painter/renderImage.ts
@@ -8,6 +8,8 @@
  */
 
 import type { ImageFragment, ImageBlock, ImageMeasure } from "../layout-engine/types";
+import { sanitizeExternalUrl } from "../utils/urlSecurity";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import type { RenderContext } from "./renderUtils";
 
 /**
@@ -223,9 +225,10 @@ export function renderImageFragment(
     containerEl.dataset["pmEnd"] = String(fragment.pmEnd);
   }
 
-  // Create the actual image element
+  // Create the actual image element. Only local data:/blob: sources are
+  // painted — remote or executable schemes are dropped.
   const imgEl = doc.createElement("img");
-  imgEl.src = block.src;
+  imgEl.src = sanitizeImageSrc(block.src) ?? "";
   imgEl.alt = block.alt ?? "";
 
   // Image sizing
@@ -239,9 +242,9 @@ export function renderImageFragment(
     imgEl.style.transform = block.transform;
   }
 
-  // eigenpal #424: scale/shift `<img>` so the cropped slice fills the
-  // overflow-hidden container (already sized to the visible extent above),
-  // plus emit `opacity` when set via `<a:alphaModFix>` (PR #517 follow-up).
+  // Scale/shift `<img>` so the cropped slice fills the overflow-hidden
+  // container (already sized to the visible extent above), plus emit
+  // `opacity` when set via `<a:alphaModFix>`.
   if (hasImageVisualAttrs(block)) {
     applyImageVisualAttrs(imgEl, block);
   }
@@ -250,9 +253,10 @@ export function renderImageFragment(
   imgEl.draggable = false;
 
   // Wrap in hyperlink if image has a link
-  if (block.hlinkHref) {
+  const hlinkHref = sanitizeExternalUrl(block.hlinkHref);
+  if (hlinkHref) {
     const linkEl = doc.createElement("a");
-    linkEl.href = block.hlinkHref;
+    linkEl.href = hlinkHref;
     linkEl.target = "_blank";
     linkEl.rel = "noopener noreferrer";
     linkEl.style.display = "block";

--- a/packages/core/src/layout-painter/renderImage.ts
+++ b/packages/core/src/layout-painter/renderImage.ts
@@ -9,7 +9,7 @@
 
 import type { ImageFragment, ImageBlock, ImageMeasure } from "../layout-engine/types";
 import { sanitizeExternalUrl } from "../utils/urlSecurity";
-import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
+import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import type { RenderContext } from "./renderUtils";
 
 /**
@@ -226,9 +226,9 @@ export function renderImageFragment(
   }
 
   // Create the actual image element. Only local data:/blob: sources are
-  // painted — remote or executable schemes are dropped.
+  // painted — remote or executable schemes are dropped (src left unset).
   const imgEl = doc.createElement("img");
-  imgEl.src = sanitizeImageSrc(block.src) ?? "";
+  applySanitizedImageSrc(imgEl, block.src);
   imgEl.alt = block.alt ?? "";
 
   // Image sizing

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -46,6 +46,7 @@ import type {
 import type { BorderSpec, Theme, Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { borderToStyle } from "../utils/formatToStyle";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import { eighthsToPixels, pointsToPixels } from "../utils/units";
 import {
   resolveAnchoredImagePosition as resolveAnchoredImagePositionShared,
@@ -950,7 +951,7 @@ export function renderFloatingImagesLayer(
     }
 
     const img = doc.createElement("img");
-    img.src = floatImg.src;
+    img.src = sanitizeImageSrc(floatImg.src) ?? "";
     img.style.width = `${floatImg.width}px`;
     img.style.height = `${floatImg.height}px`;
     img.style.display = "block";
@@ -1238,7 +1239,7 @@ function renderHeaderFooterContent(
   // Render floating images with absolute positioning
   for (const floatImg of floatingImages) {
     const img = doc.createElement("img");
-    img.src = floatImg.src;
+    img.src = sanitizeImageSrc(floatImg.src) ?? "";
     img.width = floatImg.width;
     img.height = floatImg.height;
     if (floatImg.alt) {

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -46,7 +46,7 @@ import type {
 import type { BorderSpec, Theme, Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { borderToStyle } from "../utils/formatToStyle";
-import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
+import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { eighthsToPixels, pointsToPixels } from "../utils/units";
 import {
   resolveAnchoredImagePosition as resolveAnchoredImagePositionShared,
@@ -951,7 +951,7 @@ export function renderFloatingImagesLayer(
     }
 
     const img = doc.createElement("img");
-    img.src = sanitizeImageSrc(floatImg.src) ?? "";
+    applySanitizedImageSrc(img, floatImg.src);
     img.style.width = `${floatImg.width}px`;
     img.style.height = `${floatImg.height}px`;
     img.style.display = "block";
@@ -1239,7 +1239,7 @@ function renderHeaderFooterContent(
   // Render floating images with absolute positioning
   for (const floatImg of floatingImages) {
     const img = doc.createElement("img");
-    img.src = sanitizeImageSrc(floatImg.src) ?? "";
+    applySanitizedImageSrc(img, floatImg.src);
     img.width = floatImg.width;
     img.height = floatImg.height;
     if (floatImg.alt) {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -44,7 +44,7 @@ import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
 import { detectBaseDirection } from "../utils/baseDirection";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
-import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
+import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import {
   inlineImageBoundingBox,
   parseRotationDegrees,
@@ -727,7 +727,7 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   const img = doc.createElement("img");
   img.className = `${PARAGRAPH_CLASS_NAMES.run} ${PARAGRAPH_CLASS_NAMES.image}`;
 
-  img.src = sanitizeImageSrc(run.src) ?? "";
+  applySanitizedImageSrc(img, run.src);
   img.width = run.width;
   img.height = run.height;
   img.style.width = `${run.width}px`;
@@ -847,7 +847,7 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   container.style.marginBottom = `${run.distBottom ?? 6}px`;
 
   const img = doc.createElement("img");
-  img.src = sanitizeImageSrc(run.src) ?? "";
+  applySanitizedImageSrc(img, run.src);
   img.width = run.width;
   img.height = run.height;
   if (run.alt) {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -44,6 +44,7 @@ import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
 import { detectBaseDirection } from "../utils/baseDirection";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import {
   inlineImageBoundingBox,
   parseRotationDegrees,
@@ -726,7 +727,7 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   const img = doc.createElement("img");
   img.className = `${PARAGRAPH_CLASS_NAMES.run} ${PARAGRAPH_CLASS_NAMES.image}`;
 
-  img.src = run.src;
+  img.src = sanitizeImageSrc(run.src) ?? "";
   img.width = run.width;
   img.height = run.height;
   img.style.width = `${run.width}px`;
@@ -846,7 +847,7 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   container.style.marginBottom = `${run.distBottom ?? 6}px`;
 
   const img = doc.createElement("img");
-  img.src = run.src;
+  img.src = sanitizeImageSrc(run.src) ?? "";
   img.width = run.width;
   img.height = run.height;
   if (run.alt) {

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -40,6 +40,7 @@ import {
   tableColumnsArePinned,
 } from "../layout-engine/types";
 import { emuToPixels } from "../utils/units";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
 import { borderStrokeToCss, resolveCssBorderStroke } from "./borderStroke";
 import { getAutomaticTextColorForBackground } from "./documentColors";
@@ -169,7 +170,7 @@ function renderCellContent({
       }
 
       const imgEl = doc.createElement("img");
-      imgEl.src = img.src;
+      imgEl.src = sanitizeImageSrc(img.src) ?? "";
       imgEl.style.width = `${img.width}px`;
       imgEl.style.height = `${img.height}px`;
       imgEl.style.display = "block";

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -40,7 +40,7 @@ import {
   tableColumnsArePinned,
 } from "../layout-engine/types";
 import { emuToPixels } from "../utils/units";
-import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
+import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
 import { borderStrokeToCss, resolveCssBorderStroke } from "./borderStroke";
 import { getAutomaticTextColorForBackground } from "./documentColors";
@@ -170,7 +170,7 @@ function renderCellContent({
       }
 
       const imgEl = doc.createElement("img");
-      imgEl.src = sanitizeImageSrc(img.src) ?? "";
+      applySanitizedImageSrc(imgEl, img.src);
       imgEl.style.width = `${img.width}px`;
       imgEl.style.height = `${img.height}px`;
       imgEl.style.display = "block";

--- a/packages/core/src/layout-painter/renderWatermark.ts
+++ b/packages/core/src/layout-painter/renderWatermark.ts
@@ -12,7 +12,7 @@
 import type { Page } from "../layout-engine/types";
 import type { Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
-import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
+import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 
 const WATERMARK_CLASS = "layout-page-watermark";
 
@@ -104,7 +104,7 @@ function renderPictureWatermark(
   doc: Document,
 ): HTMLElement {
   const img = doc.createElement("img");
-  img.src = sanitizeImageSrc(imageSrc) ?? "";
+  applySanitizedImageSrc(img, imageSrc);
   img.alt = "";
   // Decorative — never announced.
   img.setAttribute("aria-hidden", "true");

--- a/packages/core/src/layout-painter/renderWatermark.ts
+++ b/packages/core/src/layout-painter/renderWatermark.ts
@@ -12,11 +12,12 @@
 import type { Page } from "../layout-engine/types";
 import type { Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 
 const WATERMARK_CLASS = "layout-page-watermark";
 
 export type RenderWatermarkOptions = {
-  /** Resolved image src for picture watermarks (data URL or http URL). */
+  /** Resolved image src for picture watermarks (`data:` / `blob:` only). */
   imageSrc?: string;
 };
 
@@ -103,7 +104,7 @@ function renderPictureWatermark(
   doc: Document,
 ): HTMLElement {
   const img = doc.createElement("img");
-  img.src = imageSrc;
+  img.src = sanitizeImageSrc(imageSrc) ?? "";
   img.alt = "";
   // Decorative — never announced.
   img.setAttribute("aria-hidden", "true");

--- a/packages/core/src/prosemirror/commands/image.ts
+++ b/packages/core/src/prosemirror/commands/image.ts
@@ -20,6 +20,7 @@ import {
   IMAGE_VERTICAL_RELATIVE_TO_VALUES,
 } from "../../types/documentEnumValues";
 import { isSafeImageFile } from "../../utils/imageValidation";
+import { sanitizeImageSrc } from "../../utils/sanitizeImageSrc";
 import { expectImageAttrs, mergeImageAttrs } from "../attrs";
 import type { ImageAttrs, ImagePositionAttrs } from "../schema/nodes";
 
@@ -349,6 +350,11 @@ function readFileAsDataUrl(file: File): Promise<string> {
 
 function loadImageDimensions(src: string): Promise<{ width: number; height: number }> {
   return new Promise((resolve, reject) => {
+    const safeSrc = sanitizeImageSrc(src);
+    if (!safeSrc) {
+      reject(new Error("Rejected unsafe image source"));
+      return;
+    }
     const img = new Image();
     img.addEventListener("load", () => {
       resolve({
@@ -359,6 +365,6 @@ function loadImageDimensions(src: string): Promise<{ width: number; height: numb
     img.addEventListener("error", () => {
       reject(new Error("Failed to load image"));
     });
-    img.src = src;
+    img.src = safeSrc;
   });
 }

--- a/packages/core/src/prosemirror/extensions/features/ImagePasteExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ImagePasteExtension.ts
@@ -10,6 +10,7 @@ import type { EditorView } from "prosemirror-view";
 
 import { getClipboardImageFiles } from "../../../utils/clipboard";
 import { isSafeImageFile } from "../../../utils/imageValidation";
+import { sanitizeImageSrc } from "../../../utils/sanitizeImageSrc";
 import { createExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
@@ -29,12 +30,17 @@ async function readFileAsDataUrl(file: File): Promise<string> {
 
 async function loadImageSize(src: string): Promise<{ width: number; height: number }> {
   return await new Promise((resolve, reject) => {
+    const safeSrc = sanitizeImageSrc(src);
+    if (!safeSrc) {
+      reject(new Error("Rejected unsafe image source"));
+      return;
+    }
     const img = new Image();
     img.addEventListener("load", () =>
       resolve({ width: img.naturalWidth || 1, height: img.naturalHeight || 1 }),
     );
     img.addEventListener("error", () => reject(new Error("Failed to load pasted image")));
-    img.src = src;
+    img.src = safeSrc;
   });
 }
 
@@ -55,7 +61,12 @@ async function insertImageFiles(view: EditorView, files: File[]): Promise<void> 
     let dataUrl: string;
     try {
       // oxlint-disable-next-line no-await-in-loop -- images insert sequentially at the moving insertPos cursor; ordering must be preserved
-      dataUrl = await readFileAsDataUrl(file);
+      const rawDataUrl = await readFileAsDataUrl(file);
+      const safeSrc = sanitizeImageSrc(rawDataUrl);
+      if (!safeSrc) {
+        continue;
+      }
+      dataUrl = safeSrc;
     } catch {
       continue;
     }

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -18,6 +18,8 @@
  * audience).
  */
 
+import { stripXmlDeclarations } from "../../../utils/stripXmlDeclarations";
+
 /**
  * Remove every HTML comment, including downlevel conditional comments
  * (`<!--[if gte mso 9]> ... <![endif]-->`) that carry the Office `<xml>` island,
@@ -158,7 +160,6 @@ const TAG_TAIL = `(?:"[^"]*"|'[^']*'|[^>"'])*`;
 // `<v:shape>`, `<m:oMath>`, `<st1:place>`). Tag-only removal keeps any inner
 // text so wrapped user content is never deleted.
 const NAMESPACED_TAG = new RegExp(`<\\/?(?:[owvm]|st\\d+):${TAG_TAIL}>`, "gi");
-const XML_PROCESSING_INSTRUCTION = new RegExp(`<\\?xml${TAG_TAIL}>`, "gi");
 const STRAY_XML_TAG = new RegExp(`<\\/?xml${TAG_TAIL}>`, "gi");
 const NOISE_TAG = new RegExp(`<\\/?(?:font|meta|link)${TAG_TAIL}>`, "gi");
 const EMPTY_SPAN = new RegExp(`<span(?:\\s${TAG_TAIL})?><\\/span>`, "gi");
@@ -229,7 +230,7 @@ export function cleanPastedHtml(html: string): string {
 
   try {
     let cleaned = stripHtmlComments(html);
-    cleaned = cleaned.replace(XML_PROCESSING_INSTRUCTION, "");
+    cleaned = stripXmlDeclarations(cleaned);
     cleaned = cleaned.replace(NAMESPACED_TAG, "");
     cleaned = cleaned.replace(STRAY_XML_TAG, "");
     cleaned = cleaned.replace(NOISE_TAG, "");

--- a/packages/core/src/utils/__tests__/clipboard.test.ts
+++ b/packages/core/src/utils/__tests__/clipboard.test.ts
@@ -293,6 +293,16 @@ describe("cleanWordHtml", () => {
     });
   });
 
+  test("strips xml declarations without regex backtracking", () => {
+    withDomParserStub(() => {
+      expect(cleanWordHtml('a<?xml version="1.0"?>b')).toBe("ab");
+      const evil = "<?xml".repeat(20_000);
+      const start = performance.now();
+      expect(cleanWordHtml(evil)).toBe(evil);
+      expect(performance.now() - start).toBeLessThan(2000);
+    });
+  });
+
   test("strips many unterminated Office namespace openers in linear time", () => {
     withDomParserStub(() => {
       const evil = "<o:p>".repeat(100_000);

--- a/packages/core/src/utils/clipboard.ts
+++ b/packages/core/src/utils/clipboard.ts
@@ -8,7 +8,15 @@
  * - Ctrl+C, Ctrl+V, Ctrl+X keyboard shortcuts
  */
 
+import createDOMPurify from "dompurify";
+
 import type { Run, TextFormatting, Paragraph } from "../types/document";
+import { stripXmlDeclarations } from "./stripXmlDeclarations";
+
+// DOMPurify's default export only binds `sanitize` when a `window` exists.
+let domPurify: ReturnType<typeof createDOMPurify> | undefined;
+const getDomPurify = (): ReturnType<typeof createDOMPurify> =>
+  (domPurify ??= createDOMPurify(window));
 
 // ============================================================================
 // TYPES
@@ -545,16 +553,27 @@ function stripPairedNamespaceTags(html: string, prefix: string): string {
 }
 
 /**
+ * Sanitize inbound clipboard HTML at the paste trust boundary.
+ *
+ * Comments and XML declarations are stripped with linear scanners. When a
+ * browser `window` is available, DOMPurify removes scripts, event handlers,
+ * and dangerous URLs before any DOM walk. Without a window (unit stubs / SSR)
+ * the linear cleaners still run; the live editor path always has `window`.
+ */
+export function sanitizeInboundClipboardHtml(html: string): string {
+  let cleaned = stripHtmlComments(html);
+  cleaned = stripXmlDeclarations(cleaned);
+  if (typeof globalThis.window === "undefined") {
+    return cleaned;
+  }
+  return getDomPurify().sanitize(cleaned);
+}
+
+/**
  * Clean Microsoft Word HTML
  */
 export function cleanWordHtml(html: string): string {
-  let cleaned = html;
-
-  // Remove Word-specific comments and any other HTML comments.
-  cleaned = stripHtmlComments(cleaned);
-
-  // Remove XML declarations
-  cleaned = cleaned.replace(/<\?xml[^>]*>/gi, "");
+  let cleaned = sanitizeInboundClipboardHtml(html);
 
   // Remove o: (Office) namespace tags.
   cleaned = stripPairedNamespaceTags(cleaned, "o:");
@@ -579,7 +598,8 @@ export function cleanWordHtml(html: string): string {
 }
 
 function cleanWordAttributes(html: string): string {
-  const container = new DOMParser().parseFromString(html, "text/html").body;
+  const sanitized = sanitizeInboundClipboardHtml(html);
+  const container = new DOMParser().parseFromString(sanitized, "text/html").body;
 
   for (const element of Array.from(container.querySelectorAll<HTMLElement>("*"))) {
     const filteredClasses = Array.from(element.classList).filter(
@@ -621,7 +641,8 @@ export function htmlToRuns(html: string, plainTextFallback: string): Run[] {
     return plainTextFallback ? [createTextRun(plainTextFallback)] : [];
   }
 
-  const container = new DOMParser().parseFromString(html, "text/html").body;
+  const sanitized = sanitizeInboundClipboardHtml(html);
+  const container = new DOMParser().parseFromString(sanitized, "text/html").body;
 
   const runs: Run[] = [];
   processNode(container, runs, {});

--- a/packages/core/src/utils/sanitizeImageSrc.test.ts
+++ b/packages/core/src/utils/sanitizeImageSrc.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { sanitizeImageSrc } from "./sanitizeImageSrc";
+
+describe("sanitizeImageSrc", () => {
+  test("allows data:image and blob URLs", () => {
+    expect(sanitizeImageSrc("data:image/png;base64,abc")).toBe("data:image/png;base64,abc");
+    expect(sanitizeImageSrc("data:image/svg+xml;charset=utf-8,%3Csvg/%3E")).toContain(
+      "data:image/svg+xml",
+    );
+    expect(sanitizeImageSrc("blob:https://example.com/uuid")).toBe("blob:https://example.com/uuid");
+  });
+
+  test("rejects remote and executable schemes", () => {
+    expect(sanitizeImageSrc("https://evil.example/a.png")).toBeUndefined();
+    expect(sanitizeImageSrc("http://evil.example/a.png")).toBeUndefined();
+    expect(sanitizeImageSrc("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeImageSrc("data:text/html,<script>alert(1)</script>")).toBeUndefined();
+    expect(sanitizeImageSrc("file:///etc/passwd")).toBeUndefined();
+  });
+
+  test("rejects empty and non-string input", () => {
+    expect(sanitizeImageSrc("")).toBeUndefined();
+    expect(sanitizeImageSrc("   ")).toBeUndefined();
+    expect(sanitizeImageSrc(null)).toBeUndefined();
+    expect(sanitizeImageSrc(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/sanitizeImageSrc.test.ts
+++ b/packages/core/src/utils/sanitizeImageSrc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { sanitizeImageSrc } from "./sanitizeImageSrc";
+import { applySanitizedImageSrc, sanitizeImageSrc } from "./sanitizeImageSrc";
 
 describe("sanitizeImageSrc", () => {
   test("allows data:image and blob URLs", () => {
@@ -24,5 +24,21 @@ describe("sanitizeImageSrc", () => {
     expect(sanitizeImageSrc("   ")).toBeUndefined();
     expect(sanitizeImageSrc(null)).toBeUndefined();
     expect(sanitizeImageSrc(undefined)).toBeUndefined();
+  });
+});
+
+describe("applySanitizedImageSrc", () => {
+  test("assigns accepted sources", () => {
+    const img = { src: "" };
+    applySanitizedImageSrc(img, "blob:https://example.com/uuid");
+    expect(img.src).toBe("blob:https://example.com/uuid");
+  });
+
+  test("leaves src untouched for rejected sources", () => {
+    const img = { src: "" };
+    applySanitizedImageSrc(img, "https://evil.example/a.png");
+    expect(img.src).toBe("");
+    applySanitizedImageSrc(img, undefined);
+    expect(img.src).toBe("");
   });
 });

--- a/packages/core/src/utils/sanitizeImageSrc.ts
+++ b/packages/core/src/utils/sanitizeImageSrc.ts
@@ -1,0 +1,26 @@
+/**
+ * Keep painted image sources local to bytes the host already owns.
+ *
+ * Document media and pasted files enter the editor as `data:image/*` or
+ * `blob:` URLs. Network and executable schemes are rejected so opening or
+ * pasting an untrusted document cannot trigger an external request or run a
+ * script scheme through `<img src>`.
+ */
+export function sanitizeImageSrc(src: string | null | undefined): string | undefined {
+  if (typeof src !== "string") {
+    return undefined;
+  }
+  const value = src.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  if (/^blob:/iu.test(value)) {
+    return value;
+  }
+  if (/^data:image\/[a-z0-9.+-]+(?:;[^,]*)?,/iu.test(value)) {
+    return value;
+  }
+
+  return undefined;
+}

--- a/packages/core/src/utils/sanitizeImageSrc.ts
+++ b/packages/core/src/utils/sanitizeImageSrc.ts
@@ -24,3 +24,21 @@ export function sanitizeImageSrc(src: string | null | undefined): string | undef
 
   return undefined;
 }
+
+/**
+ * Assign a sanitized source to an `<img>` element. When the source is rejected
+ * the `src` attribute is left unset: assigning `""` makes some browsers resolve
+ * it against the page URL and fire a spurious request for the current page.
+ *
+ * Structural parameter type so painter unit tests (which fake the DOM) can
+ * exercise it without an `HTMLImageElement`.
+ */
+export function applySanitizedImageSrc(
+  imgEl: Pick<HTMLImageElement, "src">,
+  src: string | null | undefined,
+): void {
+  const safeSrc = sanitizeImageSrc(src);
+  if (safeSrc !== undefined) {
+    imgEl.src = safeSrc;
+  }
+}

--- a/packages/core/src/utils/stripXmlDeclarations.test.ts
+++ b/packages/core/src/utils/stripXmlDeclarations.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { stripXmlDeclarations } from "./stripXmlDeclarations";
+
+describe("stripXmlDeclarations", () => {
+  test("removes complete xml declarations case-insensitively", () => {
+    expect(stripXmlDeclarations('a<?xml version="1.0"?>b')).toBe("ab");
+    expect(stripXmlDeclarations("a<?XML encoding='utf-8'?>b")).toBe("ab");
+  });
+
+  test("preserves unterminated openers", () => {
+    expect(stripXmlDeclarations("keep<?xml dangling")).toBe("keep<?xml dangling");
+  });
+
+  test("strips many unterminated openers in linear time", () => {
+    const evil = "<?xml".repeat(50_000);
+    const start = performance.now();
+    const out = stripXmlDeclarations(evil);
+    expect(performance.now() - start).toBeLessThan(2000);
+    expect(out).toBe(evil);
+  });
+});

--- a/packages/core/src/utils/stripXmlDeclarations.ts
+++ b/packages/core/src/utils/stripXmlDeclarations.ts
@@ -1,0 +1,42 @@
+/**
+ * Remove complete `<?xml ...?>` declarations from attacker-controlled clipboard HTML.
+ *
+ * Linear scan instead of `/<\?xml[^>]*>/gi`: that pattern backtracks polynomially
+ * when many `<?xml` openers appear with no closing `>`. An unterminated opener
+ * is preserved verbatim (same as the regex, which never matched it).
+ */
+export function stripXmlDeclarations(html: string): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  let searchFrom = 0;
+
+  while (true) {
+    const start = html.indexOf("<", searchFrom);
+    if (start === -1) {
+      chunks.push(html.slice(cursor));
+      break;
+    }
+
+    const isXmlDeclaration =
+      html.charCodeAt(start + 1) === 63 &&
+      (html.charCodeAt(start + 2) === 88 || html.charCodeAt(start + 2) === 120) &&
+      (html.charCodeAt(start + 3) === 77 || html.charCodeAt(start + 3) === 109) &&
+      (html.charCodeAt(start + 4) === 76 || html.charCodeAt(start + 4) === 108);
+    if (!isXmlDeclaration) {
+      searchFrom = start + 1;
+      continue;
+    }
+
+    const end = html.indexOf(">", start + 5);
+    if (end === -1) {
+      chunks.push(html.slice(cursor));
+      break;
+    }
+
+    chunks.push(html.slice(cursor, start));
+    cursor = end + 1;
+    searchFrom = cursor;
+  }
+
+  return chunks.join("");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens untrusted-document and paste trust boundaries in `@stll/folio-core`:

- **Clipboard HTML:** sanitize inbound paste with DOMPurify before any DOM walk; strip `<?xml …?>` with a linear scanner (avoids polynomial ReDoS).
- **Image sources:** allow only `data:image/*` and `blob:` at parse and paint (`sanitizeImageSrc`); drop remote/`javascript:`/`file:` schemes so opening a crafted DOCX cannot trigger network fetches or script URLs through `<img>`.
- **VML styles:** ignore `__proto__` / `constructor` / `prototype` keys when parsing attacker-controlled `style` attributes.

## Test plan

- [x] `bun test packages/core/src/utils/sanitizeImageSrc.test.ts packages/core/src/utils/stripXmlDeclarations.test.ts packages/core/src/utils/__tests__/clipboard.test.ts packages/core/src/docx/vmlImageParser.test.ts packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts`
- [ ] Spot-check paste from Word and a document with embedded images in the playground

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3ee20ba-d3c8-421a-a44b-99f2b9abcc24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3ee20ba-d3c8-421a-a44b-99f2b9abcc24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

