### PR TITLE
fix: keep tracked-change revision ids in signed 32-bit range

### DIFF
--- a/.changeset/revision-id-int32-bounds.md
+++ b/.changeset/revision-id-int32-bounds.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/docx-core": patch
+---
+
+Keep tracked-change revision ids within the range OOXML consumers accept. Suggestion-mode edits seeded their `w:ins`/`w:del` id counter from the clock, producing 13-digit `w:id` values that made exported documents fail to open. Ids now continue from the document's own highest revision id. Port of eigenpal/docx-editor#1093.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -546,6 +546,9 @@ export type MathEquation = {
 };
 
 // @public
+export const MAX_REVISION_ID = 2147483647;
+
+// @public
 export type MediaFile = {
     path: string; /** Original filename */
     filename?: string; /** MIME type */
@@ -599,6 +602,9 @@ export type MoveToRangeStart = {
 export type NoBreakHyphenContent = {
     type: "noBreakHyphen";
 };
+
+// @public
+export function normalizeRevisionId(id: number): number;
 
 // @public
 export type NoteNumberRestart = "continuous" | "eachSect" | "eachPage";

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -223,6 +223,39 @@ describe("parseParagraph tracked-change hardening", () => {
       id: 5,
     });
   });
+
+  test("folds an out-of-range id on an inline w:ins into the int32 range (eigenpal #1093)", () => {
+    const OUT_OF_RANGE = "2147483654"; // MAX_REVISION_ID + 7
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:ins w:id="${OUT_OF_RANGE}" w:author="A">
+          <w:r><w:t>added</w:t></w:r>
+        </w:ins>
+      </w:p>
+    `);
+
+    const insertion = paragraph.content.find((c) => c.type === "insertion");
+    expect(insertion?.type).toBe("insertion");
+    if (!insertion || insertion.type !== "insertion") {
+      return;
+    }
+    expect(insertion.info.id).toBeLessThanOrEqual(2_147_483_647);
+    expect(insertion.info.id).toBeGreaterThanOrEqual(0);
+  });
+
+  test("folds an out-of-range id on a paragraph-mark w:ins (pPrMark)", () => {
+    const OUT_OF_RANGE = "2147483654";
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr><w:rPr><w:ins w:id="${OUT_OF_RANGE}" w:author="A"/></w:rPr></w:pPr>
+        <w:r><w:t>text</w:t></w:r>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark).toBeDefined();
+    expect(paragraph.pPrMark?.info.id).toBeLessThanOrEqual(2_147_483_647);
+    expect(paragraph.pPrMark?.info.id).toBeGreaterThanOrEqual(0);
+  });
 });
 
 describe("parseParagraph rendered page break markers", () => {

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -35,6 +35,7 @@ import type {
   TrackedChangeInfo,
   MathEquation,
 } from "../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { isValidHexId } from "../utils/hexId";
 import {
   parseBookmarkStart as parseBookmarkStartFromModule,
@@ -954,7 +955,9 @@ function parseTrackedChangeInfo(node: XmlElement): TrackedChangeInfo {
   const initials = (getAttribute(node, "w", "initials") ?? "").trim();
 
   const info: TrackedChangeInfo = {
-    id: Number.isInteger(parsedId) && parsedId >= 0 ? parsedId : 0,
+    // `w:id` is attacker-controlled and unbounded in the schema; fold it into
+    // the range consumers accept at the parse boundary (eigenpal #1093).
+    id: normalizeRevisionId(parsedId),
     author: author.length > 0 ? author : "Unknown",
   };
   if (date.length > 0) {

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -41,6 +41,7 @@ import type {
   MediaFile,
   ShapeContent,
 } from "../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { parseGroupDrawing } from "./groupDrawingParser";
 import { parseImage } from "./imageParser";
 import {
@@ -656,7 +657,9 @@ function parsePropertyChangeInfo(changeElement: XmlElement): RunPropertyChange["
   const rsid = (getAttribute(changeElement, "w", "rsid") ?? "").trim();
 
   const info: RunPropertyChange["info"] = {
-    id: Number.isInteger(parsedId) && parsedId >= 0 ? parsedId : 0,
+    // `w:id` is attacker-controlled and unbounded in the schema; fold at the
+    // parse boundary (eigenpal #1093).
+    id: normalizeRevisionId(parsedId),
     author: author.length > 0 ? author : "Unknown",
   };
   if (date.length > 0) {

--- a/packages/core/src/docx/sectionParser.ts
+++ b/packages/core/src/docx/sectionParser.ts
@@ -31,6 +31,7 @@ import type {
   BorderSpec,
   ColorValue,
 } from "../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { parseHeaderReference, parseFooterReference } from "./headerFooterRefParser";
 import { parseFootnoteProperties, parseEndnoteProperties } from "./notePropertiesParser";
 import { BorderStyleSchema, ThemeColorSlotSchema, narrowEnum } from "./parserEnums";
@@ -142,7 +143,9 @@ function parsePropertyChangeInfo(node: XmlElement): SectionPropertyChange["info"
   const rsid = (getAttribute(node, "w", "rsid") ?? "").trim();
 
   const info: SectionPropertyChange["info"] = {
-    id: Number.isInteger(parsedId) && parsedId >= 0 ? parsedId : 0,
+    // `w:id` is attacker-controlled and unbounded in the schema; fold at the
+    // parse boundary (eigenpal #1093).
+    id: normalizeRevisionId(parsedId),
     author: author.length > 0 ? author : "Unknown",
   };
   if (date.length > 0) {

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -176,6 +176,44 @@ describe("serializeParagraph tracked-change hardening", () => {
     expect(xml).toContain('<w:ins w:id="0" w:author="Unknown">');
     expect(xml).not.toContain("w:date=");
   });
+
+  test("folds an out-of-range revision id into the signed 32-bit range (eigenpal #1093)", () => {
+    // A `Date.now()`-derived id (~1.8e12) is a well-formed positive integer, so
+    // the invalid/negative guard used to pass it straight through to `w:id`.
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "insertion",
+          info: { id: 1_784_212_345_678, author: "Reviewer" },
+          content: [{ type: "run", content: [{ type: "text", text: "Added" }] }],
+        },
+      ],
+    };
+
+    const xml = serializeParagraph(paragraph);
+    const id = Number(/<w:ins w:id="(\d+)"/u.exec(xml)?.[1]);
+    expect(id).toBeLessThanOrEqual(2_147_483_647);
+    expect(id).toBeGreaterThanOrEqual(0);
+  });
+
+  test("keeps distinct out-of-range ids distinct so revisions do not merge", () => {
+    const idFor = (id: number): string => {
+      const paragraph: Paragraph = {
+        type: "paragraph",
+        content: [
+          {
+            type: "insertion",
+            info: { id, author: "Reviewer" },
+            content: [{ type: "run", content: [{ type: "text", text: "Added" }] }],
+          },
+        ],
+      };
+      return /<w:ins w:id="(\d+)"/u.exec(serializeParagraph(paragraph))?.[1] ?? "";
+    };
+
+    expect(idFor(1_784_212_345_678)).not.toBe(idFor(1_784_212_345_679));
+  });
 });
 
 describe("serializeParagraph native frame geometry", () => {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -35,6 +35,7 @@ import type {
   TextFormatting,
   TrackedChangeInfo,
 } from "../../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { isValidHexColor } from "../../utils/colorResolver";
 import { numPrEqual } from "../numberingParser";
 import { reconcileRawSdtPr } from "../sdtPropertiesPatch";
@@ -375,7 +376,8 @@ function serializeTrackedChangeAttrs(info: TrackedChangeInfo): string {
   // NOTE: `w:initials` is intentionally NOT emitted — ECMA-376 CT_TrackChange
   // defines only w:id/w:author/w:date. Initials are carried in-model for UI
   // attribution only (w:comment is the sole standards-clean initials target).
-  const parts = [`w:id="${info.id}"`, `w:author="${escapeXml(info.author)}"`];
+  // Bound `w:id` here so an overflowing id cannot reach the XML (eigenpal #1093).
+  const parts = [`w:id="${normalizeRevisionId(info.id)}"`, `w:author="${escapeXml(info.author)}"`];
   if (info.date !== undefined) {
     parts.push(`w:date="${escapeXml(info.date)}"`);
   }
@@ -547,7 +549,7 @@ function extractRPrInner(rPrXml: string): string {
 }
 
 function serializeParagraphPropertyChange(change: ParagraphPropertyChange): string {
-  const normalizedId = Number.isInteger(change.info.id) && change.info.id >= 0 ? change.info.id : 0;
+  const normalizedId = normalizeRevisionId(change.info.id);
   const authorCandidate = typeof change.info.author === "string" ? change.info.author.trim() : "";
   const normalizedAuthor = authorCandidate.length > 0 ? authorCandidate : "Unknown";
   const normalizedDate = typeof change.info.date === "string" ? change.info.date.trim() : undefined;
@@ -950,7 +952,7 @@ function serializeTrackedChange(
   change: Insertion | Deletion | MoveFrom | MoveTo,
 ): string {
   const info = change.info;
-  const normalizedId = Number.isInteger(info.id) && info.id >= 0 ? info.id : 0;
+  const normalizedId = normalizeRevisionId(info.id);
   const authorCandidate = typeof info.author === "string" ? info.author.trim() : "";
   const normalizedAuthor = authorCandidate.length > 0 ? authorCandidate : "Unknown";
   const normalizedDate = typeof info.date === "string" ? info.date.trim() : undefined;

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -37,6 +37,7 @@ import type {
   BlockContent,
   RunPropertyChange,
 } from "../../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
 import { isValidHexColor } from "../../utils/colorResolver";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: shape textboxes hold paragraphs, paragraphs hold runs
@@ -444,7 +445,7 @@ function extractRPrInner(rPrXml: string): string {
 }
 
 function serializeRunPropertyChange(change: RunPropertyChange): string {
-  const normalizedId = Number.isInteger(change.info.id) && change.info.id >= 0 ? change.info.id : 0;
+  const normalizedId = normalizeRevisionId(change.info.id);
   const authorCandidate = typeof change.info.author === "string" ? change.info.author.trim() : "";
   const normalizedAuthor = authorCandidate.length > 0 ? authorCandidate : "Unknown";
   const normalizedDate = typeof change.info.date === "string" ? change.info.date.trim() : undefined;

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -6,6 +6,7 @@ import type {
   SectionPropertyChange,
   SectionProperties,
 } from "../../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { getUnserializedSectionPropertyChildNames } from "../sectionParser";
 import { serializeBorder } from "./borderSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
@@ -303,7 +304,7 @@ function serializeOnOffElement(value: boolean | undefined, name: string): string
 }
 
 function serializeSectionPropertyChange(change: SectionPropertyChange): string {
-  const normalizedId = Number.isInteger(change.info.id) && change.info.id >= 0 ? change.info.id : 0;
+  const normalizedId = normalizeRevisionId(change.info.id);
   const authorCandidate = typeof change.info.author === "string" ? change.info.author.trim() : "";
   const normalizedAuthor = authorCandidate.length > 0 ? authorCandidate : "Unknown";
   const normalizedDate = typeof change.info.date === "string" ? change.info.date.trim() : undefined;

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -36,6 +36,7 @@ import type {
   ShadingProperties,
   Paragraph,
 } from "../../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { isValidHexColor } from "../../utils/colorResolver";
 import { serializeBorder } from "./borderSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
@@ -47,7 +48,7 @@ function normalizeTrackedChangeInfo(info: { id: number; author: string; date?: s
   author: string;
   date?: string;
 } {
-  const normalizedId = Number.isInteger(info.id) && info.id >= 0 ? info.id : 0;
+  const normalizedId = normalizeRevisionId(info.id);
   const authorCandidate = typeof info.author === "string" ? info.author.trim() : "";
   const normalizedAuthor = authorCandidate.length > 0 ? authorCandidate : "Unknown";
   const normalizedDate = typeof info.date === "string" ? info.date.trim() : undefined;

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -49,6 +49,7 @@ import type {
   BookmarkEnd,
   BookmarkStart,
 } from "../types/document";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 import { parseBookmarkEnd, parseBookmarkStart } from "./bookmarkParser";
 import {
   appendBookmarkMarkerToLastParagraphInBlocks,
@@ -133,7 +134,9 @@ function parseTrackedChangeInfo(node: XmlElement): TableStructuralChangeInfo["in
   const initials = (getAttribute(node, "w", "initials") ?? "").trim();
 
   const info: TableStructuralChangeInfo["info"] = {
-    id: Number.isInteger(parsedId) && parsedId >= 0 ? parsedId : 0,
+    // `w:id` is attacker-controlled and unbounded in the schema; fold at the
+    // parse boundary (eigenpal #1093).
+    id: normalizeRevisionId(parsedId),
     author: author.length > 0 ? author : "Unknown",
   };
   if (date.length > 0) {

--- a/packages/core/src/prosemirror/commentIdAllocator.ts
+++ b/packages/core/src/prosemirror/commentIdAllocator.ts
@@ -13,7 +13,11 @@
  */
 
 import type { EditorView } from "prosemirror-view";
+
+import { MAX_REVISION_ID } from "@stll/docx-core/model";
+
 import type { Comment } from "../types/content";
+import { seedRevisionIdsAbove } from "./plugins/revisionIds";
 
 /** Sentinel ID for a comment that hasn't been persisted yet (anchored to selection). */
 export const PENDING_COMMENT_ID = -1;
@@ -37,9 +41,19 @@ export type CommentIdAllocator = {
 export function createCommentIdAllocator(): CommentIdAllocator {
   let nextId = 1;
   return {
-    next: () => nextId++,
+    next: () => {
+      if (nextId > MAX_REVISION_ID) {
+        nextId = 1;
+      }
+      return nextId++;
+    },
     seedAbove(maxId: number) {
-      if (maxId >= nextId) nextId = maxId + 1;
+      if (!Number.isInteger(maxId) || maxId < 0 || maxId >= MAX_REVISION_ID) {
+        return;
+      }
+      if (maxId >= nextId) {
+        nextId = maxId + 1;
+      }
     },
   };
 }
@@ -58,14 +72,28 @@ export function seedCommentAllocator(
   view: EditorView | null,
 ): void {
   let max = 0;
-  for (const comment of comments ?? []) max = Math.max(max, comment.id);
+  for (const comment of comments ?? []) {
+    if (Number.isInteger(comment.id) && comment.id > max && comment.id <= MAX_REVISION_ID) {
+      max = comment.id;
+    }
+  }
   if (view) {
     view.state.doc.descendants((node) => {
       for (const mark of node.marks) {
-        if (mark.attrs["revisionId"] != null)
-          max = Math.max(max, mark.attrs["revisionId"] as number);
+        const revisionId = mark.attrs["revisionId"];
+        if (
+          typeof revisionId === "number" &&
+          Number.isInteger(revisionId) &&
+          revisionId > max &&
+          revisionId <= MAX_REVISION_ID
+        ) {
+          max = revisionId;
+        }
       }
     });
   }
   allocator.seedAbove(max);
+  // Keep the tracked-revision counter in the same shared OOXML id space so
+  // suggestion-mode mints cannot collide with comment ids (eigenpal #1093).
+  seedRevisionIdsAbove(max);
 }

--- a/packages/core/src/prosemirror/plugins/revisionIds.test.ts
+++ b/packages/core/src/prosemirror/plugins/revisionIds.test.ts
@@ -20,7 +20,7 @@ const schema = new Schema({
     paragraph: {
       group: "block",
       content: "inline*",
-      attrs: { pPrIns: { default: null }, cellMarker: { default: null } },
+      attrs: { pPrMark: { default: null }, cellMarker: { default: null } },
       toDOM: () => ["p", 0],
     },
     text: { group: "inline" },
@@ -86,11 +86,13 @@ describe("seedRevisionIdsFromDoc", () => {
     expect(mintRevisionId()).toBeGreaterThan(3_000_000);
   });
 
-  test("seeds above an id carried by a node attr", () => {
+  test("seeds above an id carried by a paragraph-mark attr", () => {
     const doc = schema.node("doc", null, [
-      schema.node("paragraph", { pPrIns: { revisionId: 4_000_000, author: "A", date: null } }, [
-        schema.text("x"),
-      ]),
+      schema.node(
+        "paragraph",
+        { pPrMark: { kind: "ins", info: { id: 4_000_000, author: "A" } } },
+        [schema.text("x")],
+      ),
     ]);
 
     seedRevisionIdsFromDoc(doc);

--- a/packages/core/src/prosemirror/plugins/revisionIds.test.ts
+++ b/packages/core/src/prosemirror/plugins/revisionIds.test.ts
@@ -88,11 +88,9 @@ describe("seedRevisionIdsFromDoc", () => {
 
   test("seeds above an id carried by a paragraph-mark attr", () => {
     const doc = schema.node("doc", null, [
-      schema.node(
-        "paragraph",
-        { pPrMark: { kind: "ins", info: { id: 4_000_000, author: "A" } } },
-        [schema.text("x")],
-      ),
+      schema.node("paragraph", { pPrMark: { kind: "ins", info: { id: 4_000_000, author: "A" } } }, [
+        schema.text("x"),
+      ]),
     ]);
 
     seedRevisionIdsFromDoc(doc);

--- a/packages/core/src/prosemirror/plugins/revisionIds.test.ts
+++ b/packages/core/src/prosemirror/plugins/revisionIds.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Revision-id minting must stay inside the range OOXML consumers accept.
+ *
+ * Regression cover for the counter being seeded from `Date.now()` (~1.8e12),
+ * which serialized straight into `<w:ins w:id="1784…"/>` and made exported
+ * files unreadable. See `MAX_REVISION_ID` for the range rationale.
+ * Port of eigenpal/docx-editor#1093.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+
+import { MAX_REVISION_ID } from "@stll/docx-core/model";
+
+import { mintRevisionId, seedRevisionIdsAbove, seedRevisionIdsFromDoc } from "./revisionIds";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      attrs: { pPrIns: { default: null }, cellMarker: { default: null } },
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+  },
+  marks: {
+    insertion: {
+      attrs: { revisionId: { default: 0 }, author: { default: "" }, date: { default: "" } },
+      toDOM: () => ["ins", 0],
+    },
+  },
+});
+
+describe("mintRevisionId", () => {
+  test("mints ids inside the signed 32-bit range OOXML consumers accept", () => {
+    for (let i = 0; i < 3; i++) {
+      const id = mintRevisionId();
+      expect(id).toBeGreaterThan(0);
+      expect(id).toBeLessThanOrEqual(MAX_REVISION_ID);
+    }
+  });
+
+  test("mints strictly increasing ids", () => {
+    const first = mintRevisionId();
+    const second = mintRevisionId();
+    expect(second).toBeGreaterThan(first);
+  });
+});
+
+describe("seedRevisionIdsAbove", () => {
+  test("resumes numbering just above the document's existing max id", () => {
+    seedRevisionIdsAbove(1_000_000);
+    expect(mintRevisionId()).toBe(1_000_001);
+  });
+
+  test("never lowers the counter", () => {
+    seedRevisionIdsAbove(2_000_000);
+    seedRevisionIdsAbove(5);
+    expect(mintRevisionId()).toBeGreaterThan(2_000_000);
+  });
+
+  test("ignores an out-of-range id from an untrusted file", () => {
+    seedRevisionIdsAbove(9e18);
+    expect(mintRevisionId()).toBeLessThanOrEqual(MAX_REVISION_ID);
+  });
+
+  test("ignores a malformed max id", () => {
+    seedRevisionIdsAbove(Number.NaN);
+    seedRevisionIdsAbove(Number.POSITIVE_INFINITY);
+    expect(mintRevisionId()).toBeLessThanOrEqual(MAX_REVISION_ID);
+  });
+});
+
+describe("seedRevisionIdsFromDoc", () => {
+  test("seeds above an id carried by an inline mark", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("x", [schema.marks["insertion"]!.create({ revisionId: 3_000_000 })]),
+      ]),
+    ]);
+
+    seedRevisionIdsFromDoc(doc);
+
+    expect(mintRevisionId()).toBeGreaterThan(3_000_000);
+  });
+
+  test("seeds above an id carried by a node attr", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { pPrIns: { revisionId: 4_000_000, author: "A", date: null } }, [
+        schema.text("x"),
+      ]),
+    ]);
+
+    seedRevisionIdsFromDoc(doc);
+
+    expect(mintRevisionId()).toBeGreaterThan(4_000_000);
+  });
+
+  test("seeds above an id nested under a cell marker", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        { cellMarker: { kind: "ins", info: { revisionId: 5_000_000, author: "A", date: null } } },
+        [schema.text("x")],
+      ),
+    ]);
+
+    seedRevisionIdsFromDoc(doc);
+
+    expect(mintRevisionId()).toBeGreaterThan(5_000_000);
+  });
+});
+
+// MUST run last in this file: these drive the module counter to the very top of
+// the range, so any later test in this file that expects a specific low value
+// would see a wrapped counter.
+describe("range top boundary", () => {
+  test("seeding at the max id does not push the counter past the range", () => {
+    seedRevisionIdsAbove(MAX_REVISION_ID - 1);
+    seedRevisionIdsAbove(MAX_REVISION_ID);
+    expect(mintRevisionId()).toBe(MAX_REVISION_ID);
+  });
+});

--- a/packages/core/src/prosemirror/plugins/revisionIds.ts
+++ b/packages/core/src/prosemirror/plugins/revisionIds.ts
@@ -52,11 +52,11 @@ export function seedRevisionIdsAbove(maxId: number): void {
   }
 }
 
-/** Node attrs that carry a revision triple directly. */
-const REVISION_ATTR_KEYS = ["pPrIns", "pPrDel", "trIns", "trDel"] as const;
+/** Node attrs that carry a revision id directly (`revisionId` field). */
+const DIRECT_REVISION_ATTR_KEYS = ["trIns", "trDel"] as const;
 
 /**
- * Raise the counter above every `revisionId` already present in `doc`.
+ * Raise the counter above every revision id already present in `doc`.
  * Called from the suggestion-mode plugin's `state.init`.
  */
 export function seedRevisionIdsFromDoc(doc: PmNode): void {
@@ -74,12 +74,20 @@ export function seedRevisionIdsFromDoc(doc: PmNode): void {
     }
 
     const attrs = node.attrs;
-    for (const key of REVISION_ATTR_KEYS) {
+
+    // Paragraph-mark revisions live on `pPrMark` as `{ kind, info: TrackedChangeInfo }`.
+    const pPrMark = attrs["pPrMark"] as { info?: { id?: unknown } } | null | undefined;
+    if (pPrMark?.info) {
+      consider(pPrMark.info.id);
+    }
+
+    for (const key of DIRECT_REVISION_ATTR_KEYS) {
       const value = attrs[key] as { revisionId?: unknown } | null | undefined;
       if (value) {
         consider(value.revisionId);
       }
     }
+
     const cellMarker = attrs["cellMarker"] as
       | { info?: { revisionId?: unknown } }
       | null

--- a/packages/core/src/prosemirror/plugins/revisionIds.ts
+++ b/packages/core/src/prosemirror/plugins/revisionIds.ts
@@ -1,0 +1,93 @@
+/**
+ * Tracked-revision id minting (`w:id` on `<w:ins>` / `<w:del>`).
+ *
+ * Uniqueness comes from `seedRevisionIdsAbove` (called on load with the
+ * document's own max id), NOT from the counter's starting value. A clock seed
+ * bought uniqueness at the cost of ids no consumer could read — see
+ * `MAX_REVISION_ID`. Port of eigenpal/docx-editor#1093.
+ *
+ * Kept free of `suggestionMode` imports so the suggestion plugin can mint
+ * without a load-order cycle.
+ */
+
+import type { Node as PmNode } from "prosemirror-model";
+
+import { MAX_REVISION_ID } from "@stll/docx-core/model";
+
+/**
+ * Next id to hand out. Starts at 1 (0 is the serializer's "unusable metadata"
+ * fallback) and is raised past a loaded document's existing ids by
+ * `seedRevisionIdsAbove`.
+ *
+ * NOT seeded from a clock. `Date.now()` (~1.8e12) overflows the signed 32-bit
+ * int consumers read `w:id` into.
+ */
+let counter = 1;
+
+/**
+ * Mint the next tracked-revision id (`w:id`). Strictly monotonic per realm,
+ * and always inside the range serialized `w:id` may occupy.
+ */
+export function mintRevisionId(): number {
+  // Wrap rather than emit an id no consumer can read.
+  if (counter > MAX_REVISION_ID) {
+    counter = 1;
+  }
+  return counter++;
+}
+
+/**
+ * Raise the counter above `maxId` so freshly minted ids cannot collide with
+ * ids already present in a loaded document. Only ever raises.
+ *
+ * `maxId` is derived from file content, so it is untrusted: a malformed or
+ * out-of-range value is ignored outright rather than folded into range.
+ */
+export function seedRevisionIdsAbove(maxId: number): void {
+  if (!Number.isInteger(maxId) || maxId < 0 || maxId >= MAX_REVISION_ID) {
+    return;
+  }
+  if (maxId >= counter) {
+    counter = maxId + 1;
+  }
+}
+
+/** Node attrs that carry a revision triple directly. */
+const REVISION_ATTR_KEYS = ["pPrIns", "pPrDel", "trIns", "trDel"] as const;
+
+/**
+ * Raise the counter above every `revisionId` already present in `doc`.
+ * Called from the suggestion-mode plugin's `state.init`.
+ */
+export function seedRevisionIdsFromDoc(doc: PmNode): void {
+  let max = 0;
+
+  const consider = (id: unknown): void => {
+    if (typeof id === "number" && Number.isInteger(id) && id > max && id <= MAX_REVISION_ID) {
+      max = id;
+    }
+  };
+
+  doc.descendants((node) => {
+    for (const mark of node.marks) {
+      consider(mark.attrs["revisionId"]);
+    }
+
+    const attrs = node.attrs;
+    for (const key of REVISION_ATTR_KEYS) {
+      const value = attrs[key] as { revisionId?: unknown } | null | undefined;
+      if (value) {
+        consider(value.revisionId);
+      }
+    }
+    const cellMarker = attrs["cellMarker"] as
+      | { info?: { revisionId?: unknown } }
+      | null
+      | undefined;
+    if (cellMarker?.info) {
+      consider(cellMarker.info.revisionId);
+    }
+  });
+
+  seedRevisionIdsAbove(max);
+}

--- a/packages/core/src/prosemirror/plugins/suggestionMode.ts
+++ b/packages/core/src/prosemirror/plugins/suggestionMode.ts
@@ -19,6 +19,7 @@ import type { EditorView } from "prosemirror-view";
 
 import type { TrackedChangeInfo } from "../../types/document";
 import { splitBlockClearBorders } from "../extensions/features/BaseKeymapExtension";
+import { mintRevisionId, seedRevisionIdsFromDoc } from "./revisionIds";
 
 export const suggestionModeKey = new PluginKey<SuggestionModeState>("suggestionMode");
 export const SUGGESTION_META = "suggestionModeApplied";
@@ -35,11 +36,9 @@ type MarkAttrs = {
   date: string;
 };
 
-let nextRevisionId = Date.now();
-
 function makeMarkAttrs(pluginState: SuggestionModeState): MarkAttrs {
   return {
-    revisionId: nextRevisionId++,
+    revisionId: mintRevisionId(),
     author: pluginState.author,
     date: new Date().toISOString(),
   };
@@ -634,7 +633,11 @@ export function createSuggestionModePlugin(initialActive = false, author = "User
     key: suggestionModeKey,
 
     state: {
-      init(): SuggestionModeState {
+      // Seed the revision-id counter from the loaded document on every
+      // EditorState.create so suggesting-mode edits stay inside the signed
+      // 32-bit range OOXML consumers accept (eigenpal/docx-editor#1093).
+      init(_config, instance): SuggestionModeState {
+        seedRevisionIdsFromDoc(instance.doc);
         return { active: initialActive, author };
       },
       apply(tr, state): SuggestionModeState {

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -937,6 +937,36 @@ export type MathEquation = {
 // ============================================================================
 
 /**
+ * Largest value a revision id (`w:id`) may carry: 2^31 - 1.
+ *
+ * `w:id` on `<w:ins>`/`<w:del>` comes from `CT_Markup`, typed
+ * `ST_DecimalNumber` — which ECMA-376 defines as an unbounded integer. The
+ * bound below is an implementation limit: conforming consumers read
+ * `ST_DecimalNumber` into a signed 32-bit int, and a value past this bound
+ * overflows on load and surfaces as an unreadable document. Port of
+ * eigenpal/docx-editor#1093.
+ */
+export const MAX_REVISION_ID = 2_147_483_647;
+
+/**
+ * Coerce any revision id — including one parsed from an untrusted DOCX — into
+ * the range serialized `w:id` attributes may occupy.
+ *
+ * - Malformed (negative, fractional, `NaN`, `Infinity`): collapse to `0`.
+ * - Well-formed but out of range: fold modulo the range (not clamp) so a
+ *   contiguous run of overflowing ids stays distinguishable.
+ */
+export function normalizeRevisionId(id: number): number {
+  if (!Number.isInteger(id) || id < 0) {
+    return 0;
+  }
+  if (id > MAX_REVISION_ID) {
+    return id % (MAX_REVISION_ID + 1);
+  }
+  return id;
+}
+
+/**
  * Tracked change metadata (w:ins, w:del attributes)
  */
 export type TrackedChangeInfo = {

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -62,7 +62,9 @@ export type {
   NumberingDefinitions,
 } from "./lists";
 
-// Content Model
+// Content Model — revision-id bounds (values, not types)
+export { MAX_REVISION_ID, normalizeRevisionId } from "./content";
+
 export type {
   TextContent,
   TabContent,

--- a/packages/docx-core/src/model/trackedChangeIds.test.ts
+++ b/packages/docx-core/src/model/trackedChangeIds.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { MAX_REVISION_ID, normalizeRevisionId } from "./content";
+
+describe("normalizeRevisionId (eigenpal #1093)", () => {
+  test("leaves an in-range id unchanged", () => {
+    expect(normalizeRevisionId(0)).toBe(0);
+    expect(normalizeRevisionId(5)).toBe(5);
+    expect(normalizeRevisionId(MAX_REVISION_ID)).toBe(MAX_REVISION_ID);
+  });
+
+  test("collapses a malformed id to 0", () => {
+    expect(normalizeRevisionId(-3)).toBe(0);
+    expect(normalizeRevisionId(1.5)).toBe(0);
+    expect(normalizeRevisionId(Number.NaN)).toBe(0);
+    expect(normalizeRevisionId(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  test("folds an out-of-range id into the int32 range", () => {
+    expect(normalizeRevisionId(MAX_REVISION_ID + 6)).toBeLessThanOrEqual(MAX_REVISION_ID);
+    expect(normalizeRevisionId(MAX_REVISION_ID + 6)).toBeGreaterThanOrEqual(0);
+  });
+
+  test("an out-of-range id folds to the same value as its in-range residue", () => {
+    // 2^31 === MAX + 1, so 2^31 + 5 folds to 5.
+    expect(normalizeRevisionId(2 ** 31 + 5)).toBe(normalizeRevisionId(5));
+    expect(normalizeRevisionId(2 ** 31 + 5)).toBe(5);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Suggestion mode seeded `w:ins`/`w:del` revision ids from `Date.now()`, producing 13-digit `w:id` values that overflow the signed 32-bit range OOXML consumers read into. Exported documents then failed to open.

### Changes
- Mint revision ids from a document-seeded counter (`revisionIds.ts`), starting at 1
- Seed the counter on `EditorState.create` and from `seedCommentAllocator`
- Fold out-of-range ids at parse and serialize boundaries via `normalizeRevisionId`
- Harden the comment id allocator against out-of-range seeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77b0-30ab-7a50-8ff1-b119fc226b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77b0-30ab-7a50-8ff1-b119fc226b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

