### PR TITLE
fix: drop orphan comment ranges on export

### DIFF
--- a/.changeset/drop-orphan-comment-ranges.md
+++ b/.changeset/drop-orphan-comment-ranges.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Drop unresolvable comment range and reference markers during export, porting eigenpal #1090.

--- a/packages/core/src/docx/commentRangeIntegrity.test.ts
+++ b/packages/core/src/docx/commentRangeIntegrity.test.ts
@@ -159,6 +159,34 @@ describe("withoutOrphanCommentRanges", () => {
     expect(withoutOrphanCommentRanges(document)).toBe(document);
   });
 
+  test("drops orphan markers inside comment bodies", () => {
+    const document: Document = {
+      package: {
+        document: {
+          comments: [
+            {
+              ...validComment,
+              content: [
+                paragraph([
+                  { type: "commentRangeStart", id: 404 },
+                  run("comment body"),
+                  { type: "commentReference", id: 1 },
+                ]),
+              ],
+            },
+          ],
+          content: [paragraph([run("body")])],
+        },
+      },
+    };
+
+    const result = withoutOrphanCommentRanges(document);
+
+    expect(result).not.toBe(document);
+    const commentParagraph = result.package.document.comments?.at(0)?.content.at(0);
+    expect(commentParagraph?.content.map((item) => item.type)).toEqual(["run", "commentReference"]);
+  });
+
   test("drops orphan commentReference markers", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/docx/commentRangeIntegrity.test.ts
+++ b/packages/core/src/docx/commentRangeIntegrity.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import type { BlockContent, Comment, Document, Paragraph, ParagraphContent } from "../types/document";
+import type {
+  BlockContent,
+  Comment,
+  Document,
+  Paragraph,
+  ParagraphContent,
+} from "../types/document";
 import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 
 const validComment = {
@@ -158,7 +164,9 @@ describe("withoutOrphanCommentRanges", () => {
       package: {
         document: {
           comments: [validComment],
-          content: [paragraph([run("before"), { type: "commentReference", id: 404 }, run("after")])],
+          content: [
+            paragraph([run("before"), { type: "commentReference", id: 404 }, run("after")]),
+          ],
         },
       },
     };

--- a/packages/core/src/docx/commentRangeIntegrity.test.ts
+++ b/packages/core/src/docx/commentRangeIntegrity.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BlockContent, Comment, Document, Paragraph, ParagraphContent } from "../types/document";
+import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
+
+const validComment = {
+  id: 1,
+  author: "Reviewer",
+  content: [{ type: "paragraph", content: [] }],
+} satisfies Comment;
+
+const run = (text: string): ParagraphContent => ({
+  type: "run",
+  content: [{ type: "text", text }],
+});
+
+const paragraph = (content: ParagraphContent[]): Paragraph => ({
+  type: "paragraph",
+  content,
+});
+
+const contentTypes = (block: BlockContent | undefined): string[] => {
+  expect(block?.type).toBe("paragraph");
+  if (block?.type !== "paragraph") {
+    throw new Error("Expected paragraph");
+  }
+  return block.content.map((item) => item.type);
+};
+
+describe("withoutOrphanCommentRanges", () => {
+  test("drops orphans across body, table, header, footnote, and endnote content", () => {
+    const tableCellParagraph = paragraph([
+      { type: "commentRangeEnd", id: 404 },
+      run("table"),
+      { type: "commentReference", id: 1 },
+    ]);
+    const document: Document = {
+      package: {
+        document: {
+          comments: [validComment],
+          content: [
+            paragraph([
+              { type: "commentRangeStart", id: 404 },
+              run("body"),
+              { type: "commentRangeEnd", id: 1 },
+            ]),
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      content: [tableCellParagraph],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        headers: new Map([
+          [
+            "rIdHeader",
+            {
+              type: "header",
+              hdrFtrType: "default",
+              content: [paragraph([{ type: "commentRangeStart", id: 405 }, run("header")])],
+            },
+          ],
+        ]),
+        footnotes: [
+          {
+            type: "footnote",
+            id: 2,
+            content: [paragraph([run("footnote"), { type: "commentRangeEnd", id: 406 }])],
+          },
+        ],
+        endnotes: [
+          {
+            type: "endnote",
+            id: 3,
+            content: [paragraph([{ type: "commentReference", id: 407 }, run("endnote")])],
+          },
+        ],
+      },
+    };
+
+    const result = withoutOrphanCommentRanges(document);
+
+    expect(result).not.toBe(document);
+    expect(contentTypes(result.package.document.content.at(0))).toEqual(["run", "commentRangeEnd"]);
+
+    const table = result.package.document.content.at(1);
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      throw new Error("Expected table");
+    }
+    expect(contentTypes(table.rows.at(0)?.cells.at(0)?.content.at(0))).toEqual([
+      "run",
+      "commentReference",
+    ]);
+
+    expect(contentTypes(result.package.headers?.get("rIdHeader")?.content.at(0))).toEqual(["run"]);
+    expect(contentTypes(result.package.footnotes?.at(0)?.content.at(0))).toEqual(["run"]);
+    expect(contentTypes(result.package.endnotes?.at(0)?.content.at(0))).toEqual(["run"]);
+  });
+
+  test("does not mutate the caller's document model", () => {
+    const originalParagraph = paragraph([
+      { type: "commentRangeStart", id: 404 },
+      run("body"),
+      { type: "commentReference", id: 404 },
+    ]);
+    const document: Document = {
+      package: {
+        document: {
+          comments: [validComment],
+          content: [originalParagraph],
+        },
+      },
+    };
+
+    const result = withoutOrphanCommentRanges(document);
+
+    expect(contentTypes(document.package.document.content.at(0))).toEqual([
+      "commentRangeStart",
+      "run",
+      "commentReference",
+    ]);
+    expect(contentTypes(result.package.document.content.at(0))).toEqual(["run"]);
+    expect(result.package.document.content.at(0)).not.toBe(originalParagraph);
+  });
+
+  test("returns the same document reference when no orphan markers exist", () => {
+    const document: Document = {
+      package: {
+        document: {
+          comments: [validComment],
+          content: [
+            paragraph([
+              { type: "commentRangeStart", id: 1 },
+              run("body"),
+              { type: "commentRangeEnd", id: 1 },
+              { type: "commentReference", id: 1 },
+            ]),
+          ],
+        },
+      },
+    };
+
+    expect(withoutOrphanCommentRanges(document)).toBe(document);
+  });
+
+  test("drops orphan commentReference markers", () => {
+    const document: Document = {
+      package: {
+        document: {
+          comments: [validComment],
+          content: [paragraph([run("before"), { type: "commentReference", id: 404 }, run("after")])],
+        },
+      },
+    };
+
+    const result = withoutOrphanCommentRanges(document);
+
+    expect(contentTypes(result.package.document.content.at(0))).toEqual(["run", "run"]);
+  });
+});

--- a/packages/core/src/docx/commentRangeIntegrity.ts
+++ b/packages/core/src/docx/commentRangeIntegrity.ts
@@ -1,0 +1,244 @@
+import type {
+  BlockContent,
+  Document,
+  DocumentBody,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Paragraph,
+  ParagraphContent,
+  Table,
+  TableCell,
+  TableRow,
+} from "../types/document";
+
+type CommentMarker = Extract<
+  ParagraphContent,
+  { type: "commentRangeStart" } | { type: "commentRangeEnd" } | { type: "commentReference" }
+>;
+type TableCellBlock = TableCell["content"][number];
+
+export const withoutOrphanCommentRanges = (doc: Document): Document => {
+  const validCommentIds = new Set(
+    (doc.package.document.comments ?? []).map((comment) => comment.id),
+  );
+
+  const document = withoutOrphanDocumentBodyMarkers(doc.package.document, validCommentIds);
+  const headers = withoutOrphanHeaderFooterMapMarkers(doc.package.headers, validCommentIds);
+  const footers = withoutOrphanHeaderFooterMapMarkers(doc.package.footers, validCommentIds);
+  const footnotes = withoutOrphanNoteMarkers(doc.package.footnotes, validCommentIds);
+  const endnotes = withoutOrphanNoteMarkers(doc.package.endnotes, validCommentIds);
+
+  if (!document && !headers && !footers && !footnotes && !endnotes) {
+    return doc;
+  }
+
+  return {
+    ...doc,
+    package: {
+      ...doc.package,
+      ...(document ? { document } : {}),
+      ...(headers ? { headers } : {}),
+      ...(footers ? { footers } : {}),
+      ...(footnotes ? { footnotes } : {}),
+      ...(endnotes ? { endnotes } : {}),
+    },
+  };
+};
+
+const withoutOrphanDocumentBodyMarkers = (
+  document: DocumentBody,
+  validCommentIds: ReadonlySet<number>,
+): DocumentBody | null => {
+  const content = withoutOrphanBlockMarkers(document.content, validCommentIds);
+  if (!content) {
+    return null;
+  }
+  return { ...document, content };
+};
+
+const withoutOrphanHeaderFooterMapMarkers = (
+  map: Map<string, HeaderFooter> | undefined,
+  validCommentIds: ReadonlySet<number>,
+): Map<string, HeaderFooter> | null => {
+  if (!map) {
+    return null;
+  }
+
+  let changed = false;
+  const next = new Map<string, HeaderFooter>();
+  for (const [rId, headerFooter] of map) {
+    const content = withoutOrphanBlockMarkers(headerFooter.content, validCommentIds);
+    if (!content) {
+      next.set(rId, headerFooter);
+      continue;
+    }
+    changed = true;
+    next.set(rId, { ...headerFooter, content });
+  }
+
+  return changed ? next : null;
+};
+
+const withoutOrphanNoteMarkers = <TNote extends Footnote | Endnote>(
+  notes: TNote[] | undefined,
+  validCommentIds: ReadonlySet<number>,
+): TNote[] | null => {
+  if (!notes) {
+    return null;
+  }
+
+  let changed = false;
+  const next: TNote[] = [];
+  for (const note of notes) {
+    const content = withoutOrphanBlockMarkers(note.content, validCommentIds);
+    if (!content) {
+      next.push(note);
+      continue;
+    }
+    changed = true;
+    next.push({ ...note, content });
+  }
+
+  return changed ? next : null;
+};
+
+const withoutOrphanBlockMarkers = (
+  blocks: BlockContent[],
+  validCommentIds: ReadonlySet<number>,
+): BlockContent[] | null => {
+  let changed = false;
+  const next: BlockContent[] = [];
+  for (const block of blocks) {
+    const nextBlock = withoutOrphanBlockMarker(block, validCommentIds);
+    if (nextBlock !== block) {
+      changed = true;
+    }
+    next.push(nextBlock);
+  }
+
+  return changed ? next : null;
+};
+
+const withoutOrphanBlockMarker = (
+  block: BlockContent,
+  validCommentIds: ReadonlySet<number>,
+): BlockContent => {
+  if (block.type === "paragraph") {
+    return withoutOrphanParagraphMarkers(block, validCommentIds);
+  }
+
+  if (block.type === "table") {
+    return withoutOrphanTableMarkers(block, validCommentIds);
+  }
+
+  const content = withoutOrphanBlockMarkers(block.content, validCommentIds);
+  if (!content) {
+    return block;
+  }
+  return { ...block, content };
+};
+
+const withoutOrphanTableMarkers = (
+  table: Table,
+  validCommentIds: ReadonlySet<number>,
+): Table => {
+  let changed = false;
+  const rows: TableRow[] = [];
+  for (const row of table.rows) {
+    const nextRow = withoutOrphanTableRowMarkers(row, validCommentIds);
+    if (nextRow !== row) {
+      changed = true;
+    }
+    rows.push(nextRow);
+  }
+
+  if (!changed) {
+    return table;
+  }
+  return { ...table, rows };
+};
+
+const withoutOrphanTableRowMarkers = (
+  row: TableRow,
+  validCommentIds: ReadonlySet<number>,
+): TableRow => {
+  let changed = false;
+  const cells: TableCell[] = [];
+  for (const cell of row.cells) {
+    const nextCell = withoutOrphanTableCellMarkers(cell, validCommentIds);
+    if (nextCell !== cell) {
+      changed = true;
+    }
+    cells.push(nextCell);
+  }
+
+  if (!changed) {
+    return row;
+  }
+  return { ...row, cells };
+};
+
+const withoutOrphanTableCellMarkers = (
+  cell: TableCell,
+  validCommentIds: ReadonlySet<number>,
+): TableCell => {
+  const content = withoutOrphanTableCellBlockMarkers(cell.content, validCommentIds);
+  if (!content) {
+    return cell;
+  }
+  return { ...cell, content };
+};
+
+const withoutOrphanTableCellBlockMarkers = (
+  blocks: TableCellBlock[],
+  validCommentIds: ReadonlySet<number>,
+): TableCellBlock[] | null => {
+  let changed = false;
+  const next: TableCellBlock[] = [];
+  for (const block of blocks) {
+    const nextBlock = withoutOrphanTableCellBlockMarker(block, validCommentIds);
+    if (nextBlock !== block) {
+      changed = true;
+    }
+    next.push(nextBlock);
+  }
+
+  return changed ? next : null;
+};
+
+const withoutOrphanTableCellBlockMarker = (
+  block: TableCellBlock,
+  validCommentIds: ReadonlySet<number>,
+): TableCellBlock => {
+  if (block.type === "paragraph") {
+    return withoutOrphanParagraphMarkers(block, validCommentIds);
+  }
+
+  return withoutOrphanTableMarkers(block, validCommentIds);
+};
+
+const withoutOrphanParagraphMarkers = (
+  paragraph: Paragraph,
+  validCommentIds: ReadonlySet<number>,
+): Paragraph => {
+  let changed = false;
+  const content: ParagraphContent[] = [];
+  for (const item of paragraph.content) {
+    if (isCommentMarker(item) && !validCommentIds.has(item.id)) {
+      changed = true;
+      continue;
+    }
+    content.push(item);
+  }
+
+  if (!changed) {
+    return paragraph;
+  }
+  return { ...paragraph, content };
+};
+
+const isCommentMarker = (content: ParagraphContent): content is CommentMarker =>
+  content.type === "commentRangeStart" ||
+  content.type === "commentRangeEnd" ||
+  content.type === "commentReference";

--- a/packages/core/src/docx/commentRangeIntegrity.ts
+++ b/packages/core/src/docx/commentRangeIntegrity.ts
@@ -1,5 +1,6 @@
 import type {
   BlockContent,
+  Comment,
   Document,
   DocumentBody,
   Endnote,
@@ -51,10 +52,58 @@ const withoutOrphanDocumentBodyMarkers = (
   validCommentIds: ReadonlySet<number>,
 ): DocumentBody | null => {
   const content = withoutOrphanBlockMarkers(document.content, validCommentIds);
-  if (!content) {
+  const comments = withoutOrphanCommentBodyMarkers(document.comments, validCommentIds);
+  if (!content && !comments) {
     return null;
   }
-  return { ...document, content };
+  return {
+    ...document,
+    ...(content ? { content } : {}),
+    ...(comments ? { comments } : {}),
+  };
+};
+
+// Comment bodies are paragraph stories of their own; a dangling
+// commentRangeStart / commentReference inside one round-trips into
+// comments.xml through the paragraph serializer just like body content.
+const withoutOrphanCommentBodyMarkers = (
+  comments: Comment[] | undefined,
+  validCommentIds: ReadonlySet<number>,
+): Comment[] | null => {
+  if (!comments) {
+    return null;
+  }
+
+  let changed = false;
+  const next: Comment[] = [];
+  for (const comment of comments) {
+    const content = withoutOrphanParagraphListMarkers(comment.content, validCommentIds);
+    if (!content) {
+      next.push(comment);
+      continue;
+    }
+    changed = true;
+    next.push({ ...comment, content });
+  }
+
+  return changed ? next : null;
+};
+
+const withoutOrphanParagraphListMarkers = (
+  paragraphs: Paragraph[],
+  validCommentIds: ReadonlySet<number>,
+): Paragraph[] | null => {
+  let changed = false;
+  const next: Paragraph[] = [];
+  for (const paragraph of paragraphs) {
+    const nextParagraph = withoutOrphanParagraphMarkers(paragraph, validCommentIds);
+    if (nextParagraph !== paragraph) {
+      changed = true;
+    }
+    next.push(nextParagraph);
+  }
+
+  return changed ? next : null;
 };
 
 const withoutOrphanHeaderFooterMapMarkers = (

--- a/packages/core/src/docx/commentRangeIntegrity.ts
+++ b/packages/core/src/docx/commentRangeIntegrity.ts
@@ -132,6 +132,10 @@ const withoutOrphanBlockMarker = (
     return withoutOrphanTableMarkers(block, validCommentIds);
   }
 
+  if (!("content" in block) || !block.content) {
+    return block;
+  }
+
   const content = withoutOrphanBlockMarkers(block.content, validCommentIds);
   if (!content) {
     return block;
@@ -139,10 +143,7 @@ const withoutOrphanBlockMarker = (
   return { ...block, content };
 };
 
-const withoutOrphanTableMarkers = (
-  table: Table,
-  validCommentIds: ReadonlySet<number>,
-): Table => {
+const withoutOrphanTableMarkers = (table: Table, validCommentIds: ReadonlySet<number>): Table => {
   let changed = false;
   const rows: TableRow[] = [];
   for (const row of table.rows) {
@@ -215,7 +216,11 @@ const withoutOrphanTableCellBlockMarker = (
     return withoutOrphanParagraphMarkers(block, validCommentIds);
   }
 
-  return withoutOrphanTableMarkers(block, validCommentIds);
+  if (block.type === "table") {
+    return withoutOrphanTableMarkers(block, validCommentIds);
+  }
+
+  return block;
 };
 
 const withoutOrphanParagraphMarkers = (

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import type { Document } from "../types/document";
-import { DocxModelValidationError } from "./modelValidation";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { DocxPackageFidelityError, repackDocx } from "./rezip";
@@ -214,12 +213,13 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
 }
 
 describe("repackDocx", () => {
-  test("rejects an invalid document model before full repack", async () => {
+  test("drops orphan comment references before full repack validation", async () => {
     const originalBuffer = await createHeaderFixture();
     const document: Document = {
       originalBuffer,
       package: {
         document: {
+          finalSectionProperties: {},
           content: [
             {
               type: "paragraph",
@@ -231,15 +231,12 @@ describe("repackDocx", () => {
       },
     };
 
-    try {
-      await repackDocx(document, { updateModifiedDate: false });
-    } catch (error) {
-      expect(error).toBeInstanceOf(DocxModelValidationError);
-      expect(String(error)).toContain("Comment 404 is referenced");
-      return;
-    }
+    const result = await repackDocx(document, { updateModifiedDate: false });
+    const zip = await JSZip.loadAsync(result);
+    const documentXml = await zip.file("word/document.xml")?.async("text");
 
-    throw new Error("Expected repackDocx to reject");
+    expect(documentXml).not.toContain("commentReference");
+    expect(documentXml).not.toContain('w:id="404"');
   });
 
   test("uses parser-repaired package buffers for full repack", async () => {

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -35,6 +35,7 @@ import JSZip from "jszip";
 import type { BlockContent, Comment, HeaderFooter, Image, Hyperlink } from "../types/content";
 import type { Document, Watermark } from "../types/document";
 import { applyReplyThreadMarkers } from "./commentReplyMarkers";
+import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 import { parseEndnotes, parseFootnotes } from "./footnoteParser";
 import { assertValidFolioDocumentModel } from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
@@ -693,7 +694,7 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
   }
 
   const { compressionLevel = 6, updateModifiedDate = true, modifiedBy } = options;
-  const exportDocument = doc;
+  const exportDocument = withoutOrphanCommentRanges(doc);
 
   // Load the original ZIP
   const originalZip = await JSZip.loadAsync(doc.originalBuffer);
@@ -817,7 +818,7 @@ export async function repackDocxFromRaw(
   options: RepackOptions = {},
 ): Promise<ArrayBuffer> {
   const { compressionLevel = 6, updateModifiedDate = true, modifiedBy } = options;
-  const exportDocument = doc;
+  const exportDocument = withoutOrphanCommentRanges(doc);
 
   // Create a new ZIP with all original files
   const newZip = new JSZip();

--- a/packages/core/src/docx/selectiveSave.test.ts
+++ b/packages/core/src/docx/selectiveSave.test.ts
@@ -278,36 +278,28 @@ describe("Selective XML Patch with real DOCX", () => {
 // ============================================================================
 
 describe("attemptSelectiveSave", () => {
-  test("drops orphan comment references before selective-save validation", async () => {
+  test("returns null when orphan comment markers need cleanup", async () => {
     const buffer = await loadFixture("example-with-image.docx");
     const doc = await parseDocx(buffer, { preloadFonts: false });
 
+    // The orphan marker lives in a paragraph outside `changedParaIds`, so the
+    // selective splice could never ship its removal; the save must fall back
+    // to the full repack, which owns orphan cleanup.
     const target = doc.package.document.content.find(
       (block): block is Paragraph => block.type === "paragraph" && block.paraId !== undefined,
     );
     if (!target?.paraId) {
       throw new Error("Expected paragraph with paraId");
     }
-    target.content.push({
-      type: "run",
-      content: [{ type: "text", text: " [ORPHAN_PRUNED]" }],
-    });
     target.content.push({ type: "commentReference", id: 999 });
 
     const result = await attemptSelectiveSave(doc, buffer, {
-      changedParaIds: new Set([target.paraId]),
+      changedParaIds: new Set(),
       structuralChange: false,
       hasUntrackedChanges: false,
     });
 
-    expect(result).not.toBeNull();
-    if (!result) {
-      throw new Error("Expected result");
-    }
-    const resultXml = await getDocumentXml(result);
-    expect(resultXml).toContain("[ORPHAN_PRUNED]");
-    expect(resultXml).not.toContain("commentReference");
-    expect(resultXml).not.toContain('w:id="999"');
+    expect(result).toBeNull();
   });
 
   test("returns null when structural change occurred", async () => {

--- a/packages/core/src/docx/selectiveSave.test.ts
+++ b/packages/core/src/docx/selectiveSave.test.ts
@@ -278,22 +278,36 @@ describe("Selective XML Patch with real DOCX", () => {
 // ============================================================================
 
 describe("attemptSelectiveSave", () => {
-  test("returns null for an invalid document model", async () => {
+  test("drops orphan comment references before selective-save validation", async () => {
     const buffer = await loadFixture("example-with-image.docx");
     const doc = await parseDocx(buffer, { preloadFonts: false });
 
-    doc.package.document.content.unshift({
-      type: "paragraph",
-      content: [{ type: "commentReference", id: 999 }],
+    const target = doc.package.document.content.find(
+      (block): block is Paragraph => block.type === "paragraph" && block.paraId !== undefined,
+    );
+    if (!target?.paraId) {
+      throw new Error("Expected paragraph with paraId");
+    }
+    target.content.push({
+      type: "run",
+      content: [{ type: "text", text: " [ORPHAN_PRUNED]" }],
     });
+    target.content.push({ type: "commentReference", id: 999 });
 
     const result = await attemptSelectiveSave(doc, buffer, {
-      changedParaIds: new Set(),
+      changedParaIds: new Set([target.paraId]),
       structuralChange: false,
       hasUntrackedChanges: false,
     });
 
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("Expected result");
+    }
+    const resultXml = await getDocumentXml(result);
+    expect(resultXml).toContain("[ORPHAN_PRUNED]");
+    expect(resultXml).not.toContain("commentReference");
+    expect(resultXml).not.toContain('w:id="999"');
   });
 
   test("returns null when structural change occurred", async () => {

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -408,20 +408,26 @@ export async function attemptSelectiveSave(
   if (hasModelDrivenPictureWatermark(doc)) {
     return null;
   }
-  const exportDocument = withoutOrphanCommentRanges(doc);
+  // Orphan comment markers can live in paragraphs outside `changedParaIds`,
+  // or in note parts the splice never re-reads, so a cleanup here would not
+  // ship through the selective overlay. Hand off to the full repack, which
+  // sanitizes and re-serializes every part.
+  if (withoutOrphanCommentRanges(doc) !== doc) {
+    return null;
+  }
   // A reply with no anchor of its own must get its parent's commentRange
   // markers, which means editing the parent's paragraph — not necessarily one of
   // `changedParaIds`. The full repack owns that synthesis, so hand off to it.
-  if (hasUnsynthesizedReplyRanges(exportDocument)) {
+  if (hasUnsynthesizedReplyRanges(doc)) {
     return null;
   }
-  if (!validateFolioDocumentModel(exportDocument).valid) {
+  if (!validateFolioDocumentModel(doc).valid) {
     return null;
   }
 
-  const comments = exportDocument.package.document.comments ?? [];
+  const comments = doc.package.document.comments ?? [];
   const hasComments = comments.length > 0;
-  const headerFooterUpdates = collectHeaderFooterUpdates(exportDocument);
+  const headerFooterUpdates = collectHeaderFooterUpdates(doc);
 
   try {
     const JSZip = (await import("jszip")).default;
@@ -467,7 +473,7 @@ export async function attemptSelectiveSave(
       }
 
       if (noteCandidateIds.size > 0) {
-        const unrouted = await patchNoteParts(zip, exportDocument, noteCandidateIds, updates);
+        const unrouted = await patchNoteParts(zip, doc, noteCandidateIds, updates);
         // A splice failure, or a changed id that is neither a body nor a note
         // paragraph, falls back to full repack — matching the prior safety when
         // buildPatchedDocumentXml met a paraId it could not resolve.
@@ -477,7 +483,7 @@ export async function attemptSelectiveSave(
       }
 
       if (bodyChangedIds.size > 0) {
-        const serializedDocXml = serializeDocument(exportDocument);
+        const serializedDocXml = serializeDocument(doc);
         const patchedDocXml = buildPatchedDocumentXml(
           originalDocXml,
           serializedDocXml,
@@ -546,7 +552,7 @@ export async function attemptSelectiveSave(
     // Splice edited numbering definitions into word/numbering.xml. Numbering
     // carries no paraId, so this always runs and self-detects changes (like the
     // comments/header updates above); a no-op when numbering is unchanged.
-    await patchNumberingPart(zip, exportDocument, updates);
+    await patchNumberingPart(zip, doc, updates);
 
     // Serialize modified headers/footers
     for (const [path, xml] of headerFooterUpdates) {

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -12,6 +12,7 @@ import type JSZip from "jszip";
 
 import type { Document, BlockContent, Comment } from "../types/document";
 import { parseCommentsExtended, type CommentExtendedInfo } from "./commentParser";
+import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 import { hasUnsynthesizedReplyRanges } from "./commentReplyMarkers";
 import { validateFolioDocumentModel } from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
@@ -407,19 +408,20 @@ export async function attemptSelectiveSave(
   if (hasModelDrivenPictureWatermark(doc)) {
     return null;
   }
+  const exportDocument = withoutOrphanCommentRanges(doc);
   // A reply with no anchor of its own must get its parent's commentRange
   // markers, which means editing the parent's paragraph — not necessarily one of
   // `changedParaIds`. The full repack owns that synthesis, so hand off to it.
-  if (hasUnsynthesizedReplyRanges(doc)) {
+  if (hasUnsynthesizedReplyRanges(exportDocument)) {
     return null;
   }
-  if (!validateFolioDocumentModel(doc).valid) {
+  if (!validateFolioDocumentModel(exportDocument).valid) {
     return null;
   }
 
-  const comments = doc.package.document.comments ?? [];
+  const comments = exportDocument.package.document.comments ?? [];
   const hasComments = comments.length > 0;
-  const headerFooterUpdates = collectHeaderFooterUpdates(doc);
+  const headerFooterUpdates = collectHeaderFooterUpdates(exportDocument);
 
   try {
     const JSZip = (await import("jszip")).default;
@@ -465,7 +467,7 @@ export async function attemptSelectiveSave(
       }
 
       if (noteCandidateIds.size > 0) {
-        const unrouted = await patchNoteParts(zip, doc, noteCandidateIds, updates);
+        const unrouted = await patchNoteParts(zip, exportDocument, noteCandidateIds, updates);
         // A splice failure, or a changed id that is neither a body nor a note
         // paragraph, falls back to full repack — matching the prior safety when
         // buildPatchedDocumentXml met a paraId it could not resolve.
@@ -475,7 +477,7 @@ export async function attemptSelectiveSave(
       }
 
       if (bodyChangedIds.size > 0) {
-        const serializedDocXml = serializeDocument(doc);
+        const serializedDocXml = serializeDocument(exportDocument);
         const patchedDocXml = buildPatchedDocumentXml(
           originalDocXml,
           serializedDocXml,
@@ -544,7 +546,7 @@ export async function attemptSelectiveSave(
     // Splice edited numbering definitions into word/numbering.xml. Numbering
     // carries no paraId, so this always runs and self-detects changes (like the
     // comments/header updates above); a no-op when numbering is unchanged.
-    await patchNumberingPart(zip, doc, updates);
+    await patchNumberingPart(zip, exportDocument, updates);
 
     // Serialize modified headers/footers
     for (const [path, xml] of headerFooterUpdates) {

--- a/packages/core/src/docx/selectiveSaveGuards.test.ts
+++ b/packages/core/src/docx/selectiveSaveGuards.test.ts
@@ -16,6 +16,7 @@
 import { describe, test, expect } from "bun:test";
 import JSZip from "jszip";
 
+import type { Paragraph } from "../types/document";
 import { parseDocx } from "./parser";
 import { attemptSelectiveSave } from "./selectiveSave";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES, resolveSelectiveSaveFlags } from "./selectiveSaveFlags";
@@ -227,12 +228,12 @@ describe("fallback contract", () => {
     expect(result).toBeNull();
   });
 
-  test("invalid model → null (orphaned commentReference triggers validator)", async () => {
+  test("invalid model → null (missing footnote target triggers validator)", async () => {
     const buffer = await makeFixture();
     const doc = await parseDocx(buffer, { preloadFonts: false });
     doc.package.document.content.unshift({
       type: "paragraph",
-      content: [{ type: "commentReference", id: 9999 }],
+      content: [{ type: "run", content: [{ type: "footnoteRef", id: 9999 }] }],
     });
 
     const result = await attemptSelectiveSave(doc, buffer, {
@@ -242,6 +243,30 @@ describe("fallback contract", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  test("orphaned commentReference is pruned before validation", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const target = doc.package.document.content.find(
+      (block): block is Paragraph => block.type === "paragraph" && block.paraId !== undefined,
+    );
+    if (!target?.paraId) {
+      throw new Error("Expected paragraph with paraId");
+    }
+    target.content.push({
+      type: "run",
+      content: [{ type: "text", text: " [GUARD_ORPHAN_PRUNED]" }],
+    });
+    target.content.push({ type: "commentReference", id: 9999 });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set([target.paraId]),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).not.toBeNull();
   });
 });
 

--- a/packages/core/src/docx/selectiveSaveGuards.test.ts
+++ b/packages/core/src/docx/selectiveSaveGuards.test.ts
@@ -245,7 +245,7 @@ describe("fallback contract", () => {
     expect(result).toBeNull();
   });
 
-  test("orphaned commentReference is pruned before validation", async () => {
+  test("orphaned commentReference → null (cleanup owned by full repack)", async () => {
     const buffer = await makeFixture();
     const doc = await parseDocx(buffer, { preloadFonts: false });
     const target = doc.package.document.content.find(
@@ -254,10 +254,6 @@ describe("fallback contract", () => {
     if (!target?.paraId) {
       throw new Error("Expected paragraph with paraId");
     }
-    target.content.push({
-      type: "run",
-      content: [{ type: "text", text: " [GUARD_ORPHAN_PRUNED]" }],
-    });
     target.content.push({ type: "commentReference", id: 9999 });
 
     const result = await attemptSelectiveSave(doc, buffer, {
@@ -266,7 +262,7 @@ describe("fallback contract", () => {
       hasUntrackedChanges: false,
     });
 
-    expect(result).not.toBeNull();
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Editing can leave comment range markers / `commentReference` nodes that no longer resolve to a `comments.xml` entry (undo-after-delete, cross-document paste, pending composer sentinel). Export previously failed validation on those orphans.

### Changes
- Add copy-on-write `withoutOrphanCommentRanges` that drops unresolved `commentRangeStart`, `commentRangeEnd`, and `commentReference` markers
- Scrub before validation/serialize in `repackDocx`, `repackDocxFromRaw`, and `attemptSelectiveSave`
- Leave the caller's live document untouched; share unchanged leaf nodes by reference

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77b0-30ab-7a50-8ff1-b119fc226b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77b0-30ab-7a50-8ff1-b119fc226b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DOCX exports and selective saves now remove orphaned comment markers and references.
  * Preserves valid document content while preventing invalid comment data from causing export or save failures.
  * Applies consistently across document sections, tables, headers, footers, footnotes, and endnotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->