### PR TITLE
feat(core): server docxToMarkdown + fix table-cell content-control extraction

### DIFF
--- a/.changeset/docx-to-markdown-server.md
+++ b/.changeset/docx-to-markdown-server.md
@@ -1,0 +1,10 @@
+---
+"@stll/folio-core": minor
+---
+
+Add `docxToMarkdown(bytes)` to the `/server` entry: a one-call, server-safe DOCX
+bytes → markdown converter that composes `parseDocx` (font preloading disabled)
+and `toMarkdown`, so non-browser callers get full DOCX fidelity without deep
+imports or a hand-rolled OOXML walker. Also fixes the DOCX table-cell parser to
+descend into block-level content controls (`w:tc > w:sdt > w:sdtContent`), so
+controlled field text inside table cells is no longer dropped.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -137,6 +137,9 @@ export type DocxArchiveOptions = {
 export type DocxParagraphSource = "header" | "body" | "footer";
 
 // @public
+export function docxToMarkdown(input: ArrayBuffer | Uint8Array, opts?: MarkdownOptions): Promise<string>;
+
+// @public
 export const ensureParaIds: (docx: Uint8Array | ArrayBuffer, options?: EnsureParaIdsOptions) => Promise<EnsureParaIdsResult>;
 
 // @public

--- a/packages/core/src/docx/server/__snapshots__/docxToMarkdown.corpus.test.ts.snap
+++ b/packages/core/src/docx/server/__snapshots__/docxToMarkdown.corpus.test.ts.snap
@@ -1,0 +1,106 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`docxToMarkdown corpus snapshots extracts alt-prefix-sdt.docx 1`] = `"Due date: 31 December 2026"`;
+
+exports[`docxToMarkdown corpus snapshots extracts authored-empty-paragraph.docx 1`] = `
+"Heading paragraph.
+
+Trailing paragraph."
+`;
+
+exports[`docxToMarkdown corpus snapshots extracts block-sdt-richtext.docx 1`] = `
+"Heads of Terms — **Project Acorn**
+
+Trailing paragraph."
+`;
+
+exports[`docxToMarkdown corpus snapshots extracts checkbox-val-false.docx 1`] = `"☐ Boolean false form."`;
+
+exports[`docxToMarkdown corpus snapshots extracts checkbox-val-true.docx 1`] = `"☒ Boolean true form."`;
+
+exports[`docxToMarkdown corpus snapshots extracts datahash-sdt.docx 1`] = `"Hashed content."`;
+
+exports[`docxToMarkdown corpus snapshots extracts date-fractional-seconds.docx 1`] = `"2026-06-02"`;
+
+exports[`docxToMarkdown corpus snapshots extracts dropdown-empty-value.docx 1`] = `"Choose: (none)"`;
+
+exports[`docxToMarkdown corpus snapshots extracts empty-sdt-content.docx 1`] = `"Before:  :after"`;
+
+exports[`docxToMarkdown corpus snapshots extracts extraspec-bookmark-sibling.docx 1`] = `
+"Inside bookmarked sdt.
+
+After."
+`;
+
+exports[`docxToMarkdown corpus snapshots extracts extraspec-commentrange-sibling.docx 1`] = `
+"Inside commented sdt.
+
+After."
+`;
+
+exports[`docxToMarkdown corpus snapshots extracts inline-sdt-checkbox.docx 1`] = `"☒ I accept the NDA."`;
+
+exports[`docxToMarkdown corpus snapshots extracts inline-sdt-dropdown.docx 1`] = `"Governing law: England and Wales."`;
+
+exports[`docxToMarkdown corpus snapshots extracts inline-sdt-mixed-rpr.docx 1`] = `"**Buyer:** *ACME, s.r.o.*"`;
+
+exports[`docxToMarkdown corpus snapshots extracts lock-content-locked.docx 1`] = `"Content is locked."`;
+
+exports[`docxToMarkdown corpus snapshots extracts lock-sdt-content-locked.docx 1`] = `"Both are locked."`;
+
+exports[`docxToMarkdown corpus snapshots extracts lock-sdt-locked.docx 1`] = `"Wrapper is locked."`;
+
+exports[`docxToMarkdown corpus snapshots extracts nested-block-sdt.docx 1`] = `"Nested content paragraph."`;
+
+exports[`docxToMarkdown corpus snapshots extracts opendope-encoded-ampersand-tag.docx 1`] = `"OpenDoPE slot."`;
+
+exports[`docxToMarkdown corpus snapshots extracts placeholder-docpart.docx 1`] = `"(placeholder)"`;
+
+exports[`docxToMarkdown corpus snapshots extracts placeholder-without-docpart.docx 1`] = `"No docPart inside placeholder."`;
+
+exports[`docxToMarkdown corpus snapshots extracts repeating-section.docx 1`] = `"One row of the repeating section."`;
+
+exports[`docxToMarkdown corpus snapshots extracts sdt-rpr-placeholder.docx 1`] = `"**Placeholder text.**"`;
+
+exports[`docxToMarkdown corpus snapshots extracts sdt-self-closing.docx 1`] = `"After empty sdt."`;
+
+exports[`docxToMarkdown corpus snapshots extracts sdt-without-sdtpr.docx 1`] = `"hi"`;
+
+exports[`docxToMarkdown corpus snapshots extracts upstream-complex-styles.docx 1`] = `
+"# Heading 1
+
+This is a paragraph under heading 1. It contains normal text.
+
+## Heading 2
+
+Another paragraph with Times New Roman font and Arial font.
+
+Red text. Blue text. Green text.
+
+Highlighted text and normal text."
+`;
+
+exports[`docxToMarkdown corpus snapshots extracts upstream-empty.docx 1`] = `""`;
+
+exports[`docxToMarkdown corpus snapshots extracts upstream-styled-content.docx 1`] = `
+"Normal text. **Bold text.** *Italic text.* Underlined text.
+
+***Bold and italic text.*** ~~Strikethrough text.~~
+
+Large text (18pt). Small text (8pt).
+
+Centered paragraph.
+
+Right-aligned paragraph."
+`;
+
+exports[`docxToMarkdown corpus snapshots extracts upstream-with-tables.docx 1`] = `
+"Document with tables:
+
+| A1 | B1 | C1 |
+| --- | --- | --- |
+| A2 | B2 | C2 |
+| A3 | B3 | C3 |
+
+End of document."
+`;

--- a/packages/core/src/docx/server/docxToMarkdown.completeness.test.ts
+++ b/packages/core/src/docx/server/docxToMarkdown.completeness.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { docxToMarkdown } from "./docxToMarkdown";
+
+// ── DOCX building blocks ────────────────────────────────────────────────────
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+const para = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+/** Wrap content in a block-level content control (structured document tag). */
+const sdt = (inner: string) => `<w:sdt><w:sdtContent>${inner}</w:sdtContent></w:sdt>`;
+const cell = (inner: string) => `<w:tc>${inner}</w:tc>`;
+const row = (cells: string) => `<w:tr>${cells}</w:tr>`;
+const table = (rows: string) => `<w:tbl>${rows}</w:tbl>`;
+
+const makeDocx = async (body: string): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${body}</w:body></w:document>`,
+  );
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+/**
+ * Assert that every one of `tokens` survives the DOCX -> markdown round-trip.
+ * Content is dropped silently when a container type is not descended into, so
+ * "every placed token appears in the output" is the invariant that catches the
+ * whole class. On failure, reports exactly which tokens vanished.
+ */
+const expectAllExtracted = async (body: string, tokens: readonly string[]): Promise<void> => {
+  const markdown = await docxToMarkdown(await makeDocx(body));
+  const missing = tokens.filter((t) => !markdown.includes(t));
+  expect(missing).toEqual([]);
+};
+
+// ── Fixtures: one per content-control position ──────────────────────────────
+
+describe("docxToMarkdown content completeness — fixtures", () => {
+  const fixtures: { name: string; body: string; tokens: string[] }[] = [
+    {
+      name: "plain body paragraph",
+      body: para("PLAIN"),
+      tokens: ["PLAIN"],
+    },
+    {
+      name: "block-level content control",
+      body: sdt(para("BLOCK_SDT")),
+      tokens: ["BLOCK_SDT"],
+    },
+    {
+      name: "nested content controls",
+      body: sdt(sdt(para("NESTED_SDT"))),
+      tokens: ["NESTED_SDT"],
+    },
+    {
+      name: "content control inside a table cell",
+      body: table(row(cell(para("CELL_PLAIN")) + cell(sdt(para("CELL_SDT"))))),
+      tokens: ["CELL_PLAIN", "CELL_SDT"],
+    },
+    {
+      name: "content control wrapping a whole cell (row level)",
+      body: table(row(cell(para("ROW_A")) + sdt(cell(para("ROW_SDT_CELL"))))),
+      tokens: ["ROW_A", "ROW_SDT_CELL"],
+    },
+    {
+      name: "content control wrapping a whole row (table level)",
+      body: table(sdt(row(cell(para("TBL_SDT_ROW")))) + row(cell(para("TBL_B")))),
+      tokens: ["TBL_SDT_ROW", "TBL_B"],
+    },
+    {
+      name: "content control wrapping a whole table (block level)",
+      body: sdt(table(row(cell(para("SDT_TABLE"))))),
+      tokens: ["SDT_TABLE"],
+    },
+    {
+      name: "deeply nested control in a cell",
+      body: table(row(cell(sdt(sdt(para("DEEP_CELL_SDT")))))),
+      tokens: ["DEEP_CELL_SDT"],
+    },
+  ];
+
+  test.each(fixtures)("preserves text in: $name", async ({ body, tokens }) => {
+    await expectAllExtracted(body, tokens);
+  });
+});
+
+// ── Fuzz: random container nestings, every token must survive ────────────────
+
+/** Small deterministic PRNG so failures are reproducible via the seed. */
+const makeRng = (seed: number) => {
+  let state = (seed ^ 0x9e3779b9) >>> 0;
+  return () => {
+    // xorshift32
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state / 0xffffffff;
+  };
+};
+
+describe("docxToMarkdown content completeness — fuzz", () => {
+  const ITERATIONS = 250;
+  const MAX_DEPTH = 4;
+
+  for (let seed = 1; seed <= ITERATIONS; seed++) {
+    test(`no content dropped for random nesting (seed ${seed})`, async () => {
+      const rng = makeRng(seed);
+      const tokens: string[] = [];
+      const nextToken = () => {
+        const t = `T${seed}x${tokens.length}z`;
+        tokens.push(t);
+        return t;
+      };
+      const pick = <T>(arr: readonly T[]): T => arr[Math.floor(rng() * arr.length)] as T;
+      const times = (max: number) => 1 + Math.floor(rng() * max);
+
+      // Paragraph content possibly wrapped in 0..2 content controls — markdown
+      // treats content controls as transparent, so the text must always emerge.
+      const leafParagraph = (): string => {
+        let block = para(nextToken());
+        for (let w = Math.floor(rng() * 3); w > 0; w--) {
+          block = sdt(block);
+        }
+        return block;
+      };
+
+      // Cell content: paragraphs, each optionally control-wrapped. No nested
+      // tables inside cells (markdown cannot represent those), which keeps the
+      // invariant about *content controls* clean.
+      const cellContent = (): string => {
+        let inner = "";
+        for (let n = times(2); n > 0; n--) {
+          inner += leafParagraph();
+        }
+        return inner;
+      };
+
+      const buildTable = (): string => {
+        const cols = times(3);
+        let rows = "";
+        for (let r = times(2); r > 0; r--) {
+          let cells = "";
+          for (let c = 0; c < cols; c++) {
+            // A cell, its content, or the whole cell may be control-wrapped —
+            // exercising cell-level, and (rarely) row-level sdt descent.
+            cells += rng() < 0.3 ? sdt(cell(cellContent())) : cell(cellContent());
+          }
+          // Occasionally wrap the entire row in a content control (table level).
+          rows += rng() < 0.25 ? sdt(row(cells)) : row(cells);
+        }
+        return table(rows);
+      };
+
+      const buildBlock = (depth: number): string => {
+        if (depth <= 0 || rng() < 0.4) {
+          return leafParagraph();
+        }
+        return pick([
+          () => sdt(buildBlock(depth - 1)),
+          () => buildTable(),
+          () => buildBlock(depth - 1) + buildBlock(depth - 1),
+        ])();
+      };
+
+      let body = "";
+      for (let n = times(4); n > 0; n--) {
+        body += buildBlock(MAX_DEPTH);
+      }
+
+      const markdown = await docxToMarkdown(await makeDocx(body));
+      const missing = tokens.filter((t) => !markdown.includes(t));
+      expect(missing).toEqual([]);
+    });
+  }
+});

--- a/packages/core/src/docx/server/docxToMarkdown.corpus.test.ts
+++ b/packages/core/src/docx/server/docxToMarkdown.corpus.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { docxToMarkdown } from "./docxToMarkdown";
+
+// Real-world DOCX corpus (content controls, tables, dropdowns, repeating
+// sections, upstream-authored docs). Snapshotting the markdown extraction gives
+// a reviewable diff whenever parsing or serialization changes what text or
+// structure survives — a silent content drop shows up as a snapshot change.
+const CORPUS_DIR = join(import.meta.dir, "../__tests__/__fixtures__/corpus");
+
+const fixtures = readdirSync(CORPUS_DIR)
+  .filter((name) => name.endsWith(".docx"))
+  .sort();
+
+describe("docxToMarkdown corpus snapshots", () => {
+  test.each(fixtures)("extracts %s", async (name) => {
+    const bytes = new Uint8Array(readFileSync(join(CORPUS_DIR, name)));
+    const markdown = await docxToMarkdown(bytes);
+    expect(markdown).toMatchSnapshot();
+  });
+});

--- a/packages/core/src/docx/server/docxToMarkdown.test.ts
+++ b/packages/core/src/docx/server/docxToMarkdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { docxToMarkdown } from "./docxToMarkdown";
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+const p = (text: string, style?: string) =>
+  `<w:p>${style ? `<w:pPr><w:pStyle w:val="${style}"/></w:pPr>` : ""}<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+const makeDocx = async (body: string): Promise<Uint8Array> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${body}</w:body></w:document>`,
+  );
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+describe("docxToMarkdown", () => {
+  test("composes parseDocx + toMarkdown and keeps content-control text at every position", async () => {
+    // Heading + a block-level content control + a table whose second cell wraps
+    // its value in a content control. The hand-rolled OOXML walker this
+    // replaces dropped the table-cell control; folio's parser must not.
+    const bytes = await makeDocx(
+      p("Agreement", "Heading1") +
+        `<w:sdt><w:sdtContent>${p("Controlled clause text.")}</w:sdtContent></w:sdt>` +
+        `<w:tbl><w:tr>` +
+        `<w:tc>${p("Party")}</w:tc>` +
+        `<w:tc><w:sdt><w:sdtContent>${p("Acme Corp")}</w:sdtContent></w:sdt></w:tc>` +
+        `</w:tr></w:tbl>`,
+    );
+
+    const markdown = await docxToMarkdown(bytes);
+
+    expect(markdown).toContain("Agreement");
+    expect(markdown).toContain("Controlled clause text.");
+    expect(markdown).toContain("Party");
+    expect(markdown).toContain("Acme Corp");
+  });
+});

--- a/packages/core/src/docx/server/docxToMarkdown.ts
+++ b/packages/core/src/docx/server/docxToMarkdown.ts
@@ -1,0 +1,20 @@
+import { toMarkdown } from "../../markdown";
+import type { MarkdownOptions } from "../../markdown/types";
+import { parseDocx } from "../parser";
+
+/**
+ * Convert a DOCX file to markdown in a single server-safe call.
+ *
+ * Composes {@link parseDocx} (bytes -> Document, with font preloading disabled
+ * so it never touches the DOM) and {@link toMarkdown} (Document -> markdown).
+ * This gives non-browser callers folio's full DOCX fidelity — headings,
+ * tables, lists, and content controls (`w:sdt`) at every position — without
+ * deep-importing internal subpaths or re-implementing an OOXML walker.
+ */
+export async function docxToMarkdown(
+  input: ArrayBuffer | Uint8Array,
+  opts?: MarkdownOptions,
+): Promise<string> {
+  const doc = await parseDocx(input, { preloadFonts: false });
+  return toMarkdown(doc, opts);
+}

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -1242,9 +1242,9 @@ function parseCellContent(
   // Get all child elements
   const elements = getChildElements(tcElement);
 
-  for (const child of elements) {
+  const parseCellChild = (child: XmlElement): void => {
     if (!child.name) {
-      continue;
+      return;
     }
 
     const localName = getLocalName(child.name);
@@ -1255,20 +1255,44 @@ function parseCellContent(
       enrichParagraphTextBoxes(para, child, styles, theme, numbering, rels, media, parseTable);
       prependPendingBookmarkMarkers(para, pendingBookmarkMarkers);
       content.push(para);
-    } else if (localName === "tbl") {
+      return;
+    }
+
+    if (localName === "tbl") {
       // Parse nested table (recursive)
       const table = parseTable(child, styles, theme, numbering, rels, media, options);
       if (prependBookmarkMarkersToFirstParagraphInBlocks([table], pendingBookmarkMarkers)) {
         pendingBookmarkMarkers.length = 0;
       }
       content.push(table);
-    } else if (localName === "bookmarkStart" || localName === "bookmarkEnd") {
+      return;
+    }
+
+    if (localName === "sdt") {
+      // Block-level content control inside a cell: its content lives in
+      // `w:sdtContent`, so descend so controlled paragraphs/tables (common for
+      // bound fields in legal tables) are not dropped.
+      const sdtContent = findChildByLocalName(child, "sdtContent");
+      if (!sdtContent) {
+        return;
+      }
+      for (const sdtChild of getChildElements(sdtContent)) {
+        parseCellChild(sdtChild);
+      }
+      return;
+    }
+
+    if (localName === "bookmarkStart" || localName === "bookmarkEnd") {
       const marker = parseBookmarkMarker(child, localName);
       if (!appendBookmarkMarkerToLastParagraphInBlocks(content, marker)) {
         pendingBookmarkMarkers.push(marker);
       }
     }
     // Other content types in cells are rare but could be added
+  };
+
+  for (const child of elements) {
+    parseCellChild(child);
   }
 
   // Ensure at least one empty paragraph (Word requires this)

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -177,6 +177,7 @@ export {
   type ExtractedDocxParagraph,
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";
+export { docxToMarkdown } from "./docx/server/docxToMarkdown";
 export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";
 export {
   applyDocxXmlPatchProposal,


### PR DESCRIPTION
## What

Adds a server-reachable **`docxToMarkdown(bytes)`** to `@stll/folio-core/server` and fixes a content-control drop in the DOCX table parser.

### `docxToMarkdown(input, opts?)`
A one-call, server-safe DOCX bytes → markdown converter that composes `parseDocx` (font preloading disabled, so it never touches the DOM) and `toMarkdown`. Today the only server export is `extractDocxText` (plaintext) and `toMarkdown` lives on the browser/`./markdown` entry taking an already-parsed `Document`, so non-browser callers had to deep-import internals or hand-roll an OOXML walker. This gives them folio's full fidelity (headings, tables, lists, content controls) in one supported call.

### Fix: table-cell content controls
`parseCellContent` (`tableParser.ts`) handled `w:p` and `w:tbl` cell children but not `w:sdt`, so field text bound inside a table cell (`w:tc > w:sdt > w:sdtContent > w:p`) was silently dropped — even though row-level (`w:tr > w:sdt`) and table-level (`w:tbl > w:sdt`) content controls were already handled. Descends into `sdtContent` with the same recursive pattern. Common in legal templates (table-bound fields).

## Tests — catching the class, not just the case

- **Fixtures** (`docxToMarkdown.completeness.test.ts`): one per content-control position — block, nested, in-cell, cell-wrapping, row-wrapping, table-wrapping, deeply-nested — asserting all text survives.
- **Seeded fuzz** (same file): 250 deterministic iterations building random nestings of paragraphs / content controls / tables, asserting **every placed token survives extraction**. This reproduces and would have auto-caught the table-cell drop; failures print the seed + missing tokens.
- **Corpus snapshots** (`docxToMarkdown.corpus.test.ts`): markdown snapshots over the 29 real-world `__fixtures__/corpus` DOCX files (content controls, dropdowns, repeating sections, tables, upstream-authored docs), so any change to what text/structure survives shows up as a reviewable diff.

Full `packages/core/src/docx` suite passes (1332), api-report + changeset (minor) included.