### PR TITLE
fix(core): correct @stll/docx-core dependency range to ^0.5.0

### DIFF
--- a/.changeset/folio-core-docx-core-range.md
+++ b/.changeset/folio-core-docx-core-range.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Correct the `@stll/docx-core` dependency range: folio-core imports `normalizeRevisionId`, which only exists in docx-core 0.5.0, but 0.14.0 was published declaring `^0.4.0` (excludes 0.5.0 under 0.x semver). Republish so the range resolves to `^0.5.0`.


### PR DESCRIPTION
folio-core@0.14.0 was published with `@stll/docx-core: ^0.4.0`, but folio-core imports `normalizeRevisionId`, which only exists starting in docx-core 0.5.0. Under 0.x semver, `^0.4.0` excludes 0.5.0, so the published range is incorrect.

docx-core is now at 0.5.0 on main, so a patch release of folio-core will republish with the correct `^0.5.0` range. No source changes.