### PR TITLE
fix(core): make fromMarkdown numbering self-consistent + add collision-safe document merge

### DIFF
--- a/.changeset/markdown-numbering-namespace.md
+++ b/.changeset/markdown-numbering-namespace.md
@@ -1,0 +1,16 @@
+---
+"@stll/folio-core": minor
+---
+
+`fromMarkdown` now synthesizes `document.package.numbering` for the ordered/bullet
+lists it emits, so `createDocx(fromMarkdown(markdown))` no longer throws
+`DocxModelValidationError: Numbering definition N is missing` and round-trips
+through `docxToMarkdown` unchanged.
+
+Added `mergeDocumentContent(target, source)`, a general helper for appending one
+document's content onto another. It renumbers any `numId`/`abstractNumId` the
+source carries to sit above the target's existing numbering range, so merging
+`fromMarkdown`'s output into a styled preset (e.g.
+`createStellaStyleDocumentPreset()`) can no longer collide with numbering the
+preset already reserves — previously a markdown list could silently render with
+the preset's own clause/definition numbering instead of a plain bullet/number.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -927,6 +927,9 @@ export type MarkdownResult = {
     warnings: string[];
 };
 
+// @public
+export function mergeDocumentContent(target: import__stll_docx_core_model.Document, source: import__stll_docx_core_model.Document): import__stll_docx_core_model.Document;
+
 // @public (undocumented)
 export const normalizeFolioAIBlockText: (text: string) => string;
 

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -927,6 +927,9 @@ export type MarkdownResult = {
     warnings: string[];
 };
 
+// @public
+export function mergeDocumentContent(target: import__stll_docx_core_model.Document, source: import__stll_docx_core_model.Document): import__stll_docx_core_model.Document;
+
 // @public (undocumented)
 export const normalizeFolioAIBlockText: (text: string) => string;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
 // entry re-exports all of this and adds the React components on top.
 
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
+export { mergeDocumentContent } from "./utils/mergeDocumentContent";
 export {
   extractDocumentStyleSet,
   extractDocumentStyleSetFromDocx,

--- a/packages/core/src/markdown/fromMarkdown.docx.test.ts
+++ b/packages/core/src/markdown/fromMarkdown.docx.test.ts
@@ -1,0 +1,53 @@
+// fromMarkdown must be self-consistent: it mints numId 1, 2, … for the lists
+// it emits (see fromMarkdown.ts's `blocksFromTokens(tokens, { next: 1 })`),
+// so it must also synthesize the `document.package.numbering` those numIds
+// point to. Without that, `createDocx` throws `DocxModelValidationError:
+// Numbering definition N is missing` — this only surfaces once the document
+// is actually serialized to DOCX bytes, not when just walking the in-memory
+// model (see fromMarkdown.test.ts, which never calls createDocx).
+
+import { describe, expect, test } from "bun:test";
+
+import { docxToMarkdown } from "../docx/server/docxToMarkdown";
+import { createDocx } from "../docx/rezip";
+import { fromMarkdown } from "./fromMarkdown";
+
+const CLEAN = {
+  annotations: "strip",
+  trackedChanges: "clean",
+  comments: "strip",
+  hyperlinks: "inline",
+  footnotes: "strip",
+} as const;
+
+describe("fromMarkdown synthesizes self-consistent numbering", () => {
+  test("document.package.numbering is populated for markdown lists", () => {
+    const doc = fromMarkdown("1. a\n2. b\n- x");
+    expect(doc.package.numbering).toBeDefined();
+    expect(doc.package.numbering?.abstractNums.length).toBeGreaterThan(0);
+    expect(doc.package.numbering?.nums.length).toBeGreaterThan(0);
+  });
+
+  test("a document with no lists carries no numbering", () => {
+    const doc = fromMarkdown("Just a paragraph, no lists here.");
+    expect(doc.package.numbering).toBeUndefined();
+  });
+
+  test("createDocx(fromMarkdown(...)) does not throw for ordered + bullet lists", async () => {
+    const doc = fromMarkdown("1. a\n2. b\n- x");
+    await expect(createDocx(doc)).resolves.toBeInstanceOf(ArrayBuffer);
+  });
+
+  test("createDocx(fromMarkdown(...)) round-trips through actual DOCX bytes", async () => {
+    const bytes = await createDocx(fromMarkdown("1. a\n2. b\n- x"));
+    const markdown = await docxToMarkdown(bytes, CLEAN);
+    expect(markdown).toBe("1. a\n2. b\n- x");
+  });
+
+  test("nested lists round-trip through actual DOCX bytes", async () => {
+    const source = "- a\n  1. nested\n- b";
+    const bytes = await createDocx(fromMarkdown(source));
+    const markdown = await docxToMarkdown(bytes, CLEAN);
+    expect(markdown).toBe(source);
+  });
+});

--- a/packages/core/src/markdown/fromMarkdown.ts
+++ b/packages/core/src/markdown/fromMarkdown.ts
@@ -17,12 +17,23 @@
  *   continuous, header/footer-free band (a skill body is a document, not a
  *   Word page). Headers/footers live outside `document.content` and are never
  *   produced here.
+ * - Every markdown list also gets a matching `w:abstractNum`/`w:num` pair in
+ *   `document.package.numbering` (see {@link buildNumbering}), so the result
+ *   is self-consistent and `createDocx` never has to fail with a missing
+ *   numbering definition. Merging this content onto another document that
+ *   has its own numbering (e.g. a styled preset) needs `mergeDocumentContent`
+ *   to renumber the two numbering namespaces apart — appending
+ *   `document.package.document.content` directly can collide.
  */
 import { marked, type Token, type Tokens } from "marked";
 
 import type {
+  AbstractNumbering,
   BlockContent,
   Document,
+  ListLevel,
+  NumberingDefinitions,
+  NumberingInstance,
   ParagraphContent,
   ListRendering,
   Paragraph,
@@ -220,16 +231,55 @@ const tableFromToken = (token: Tokens.Table): Table => ({
   ],
 });
 
+// Twips (720 = 0.5"). Each deeper level indents one more half-inch, matching
+// the step folio's other synthesized numbering (legal-source's checklist
+// profile) uses for a single-column marker + hanging indent.
+const LIST_INDENT_STEP_TWIPS = 720;
+const LIST_HANGING_INDENT_TWIPS = 360;
+
+/**
+ * One `w:abstractNum` level per (numId, ilvl) pair actually used by the
+ * markdown, keyed by ilvl. Built alongside the blocks so {@link fromMarkdown}
+ * can synthesize `document.package.numbering` afterwards — the DOCX
+ * serializer reads numbering defs only from there, never from the
+ * editor-only `listRendering` hint (see `numberingSerializer.ts`).
+ */
+type NumIdLevels = Map<number, ListLevel>;
+
+const buildListLevel = (ilvl: number, isBullet: boolean, start: number): ListLevel => ({
+  ilvl,
+  ...(!isBullet && { start }),
+  numFmt: isBullet ? "bullet" : "decimal",
+  lvlText: isBullet ? "•" : `%${ilvl + 1}.`,
+  suffix: "tab",
+  pPr: {
+    indentLeft: LIST_INDENT_STEP_TWIPS * (ilvl + 1),
+    indentFirstLine: -LIST_HANGING_INDENT_TWIPS,
+    hangingIndent: true,
+  },
+});
+
 // Real list paragraphs with Word-style template markers ("%1." resolves to the
 // live counter at level 0), so inserted/split items renumber instead of
 // repeating a baked-in number. Each top-level markdown list gets its own numId
 // so separate lists restart at 1; nested lists share the parent's numId at a
 // deeper ilvl. toMarkdown resolves the templates back to concrete "N." markers
 // and normalises bullets to "- ", so the markdown round-trips exactly.
-const listBlocks = (list: Tokens.List, level: number, numId: number): BlockContent[] => {
+const listBlocks = (
+  list: Tokens.List,
+  level: number,
+  numId: number,
+  levels: NumIdLevels,
+): BlockContent[] => {
   const out: BlockContent[] = [];
   const start = Number(list.start) || 1;
   const decimalLevels = Array.from({ length: level + 1 }, () => "decimal" as const);
+  // First list to reach this (numId, ilvl) defines the synthesized level —
+  // a nested list that later reuses the same depth under the same numId
+  // shares that counter, matching how `listRendering` already treats it.
+  if (!levels.has(level)) {
+    levels.set(level, buildListLevel(level, !list.ordered, start));
+  }
   for (const item of list.items) {
     const rendering: ListRendering = list.ordered
       ? {
@@ -253,14 +303,18 @@ const listBlocks = (list: Tokens.List, level: number, numId: number): BlockConte
     }
     out.push(listPara(inlineToRuns(inlineTokens, item.text, {}), rendering));
     for (const nested of nestedLists) {
-      out.push(...listBlocks(nested, level + 1, numId));
+      out.push(...listBlocks(nested, level + 1, numId, levels));
     }
   }
   return out;
 };
 
-/** Allocates one numId per markdown list so each list counts independently. */
-type NumIdAllocator = { next: number };
+/**
+ * Allocates one numId per markdown list so each list counts independently,
+ * and collects the level definitions {@link fromMarkdown} needs to
+ * synthesize `document.package.numbering` for every list it mints.
+ */
+type NumIdAllocator = { next: number; levels: Map<number, NumIdLevels> };
 
 const blocksFromTokens = (tokens: Token[] | undefined, numIds: NumIdAllocator): BlockContent[] => {
   const blocks: BlockContent[] = [];
@@ -271,7 +325,10 @@ const blocksFromTokens = (tokens: Token[] | undefined, numIds: NumIdAllocator): 
     } else if (isTokenType(token, "paragraph")) {
       blocks.push(para(inlineToRuns(token.tokens, token.text, {})));
     } else if (isTokenType(token, "list")) {
-      blocks.push(...listBlocks(token, 0, numIds.next++));
+      const numId = numIds.next++;
+      const levels: NumIdLevels = new Map();
+      numIds.levels.set(numId, levels);
+      blocks.push(...listBlocks(token, 0, numId, levels));
     } else if (isTokenType(token, "table")) {
       blocks.push(tableFromToken(token));
     } else if (isTokenType(token, "code")) {
@@ -323,6 +380,29 @@ const applyMarkdownPageGeometry = (document: Document): void => {
   section.footerDistance = 0;
 };
 
+// One `w:abstractNum` per numId (a 1:1 mapping, so `abstractNumId === numId`
+// keeps the synthesis trivial to reason about — callers merging this into a
+// document with its own numbering should not assume the mapping stays 1:1
+// after remapping; see `mergeDocumentContent`, which renumbers both ids
+// independently). Every level actually visited by that markdown list becomes
+// one `w:lvl`, so `createDocx(fromMarkdown(md))` never references a numId
+// with no definition (`DocxModelValidationError: Numbering definition N is
+// missing`) and the DOCX round-trips through `docxToMarkdown` unchanged.
+const buildNumbering = (numIdLevels: Map<number, NumIdLevels>): NumberingDefinitions => {
+  const abstractNums: AbstractNumbering[] = [];
+  const nums: NumberingInstance[] = [];
+  for (const [numId, levels] of numIdLevels) {
+    const sortedLevels = [...levels.entries()].sort(([a], [b]) => a - b).map(([, lvl]) => lvl);
+    abstractNums.push({
+      abstractNumId: numId,
+      multiLevelType: sortedLevels.length > 1 ? "multilevel" : "singleLevel",
+      levels: sortedLevels,
+    });
+    nums.push({ numId, abstractNumId: numId });
+  }
+  return { abstractNums, nums };
+};
+
 /**
  * Convert a markdown string to a parsed `Document`. Synchronous. The result is
  * ready to hand to the editor (`<DocxEditor document={…} />`) and to re-export
@@ -330,9 +410,13 @@ const applyMarkdownPageGeometry = (document: Document): void => {
  */
 export function fromMarkdown(markdown: string): Document {
   const document = createEmptyDocument();
-  const blocks = blocksFromTokens(marked.lexer(markdown), { next: 1 });
+  const numIds: NumIdAllocator = { next: 1, levels: new Map() };
+  const blocks = blocksFromTokens(marked.lexer(markdown), numIds);
   if (blocks.length > 0) {
     document.package.document.content = blocks;
+  }
+  if (numIds.levels.size > 0) {
+    document.package.numbering = buildNumbering(numIds.levels);
   }
   applyMarkdownPageGeometry(document);
   return document;

--- a/packages/core/src/utils/mergeDocumentContent.test.ts
+++ b/packages/core/src/utils/mergeDocumentContent.test.ts
@@ -14,7 +14,7 @@ import { docxToMarkdown } from "../docx/server/docxToMarkdown";
 import { createDocx } from "../docx/rezip";
 import { fromMarkdown } from "../markdown/fromMarkdown";
 import { createStellaStyleDocumentPreset } from "../style-sets/stellaStyle";
-import type { Document, Paragraph } from "../types/document";
+import type { BlockContent, Document, Paragraph, Table, TableCell } from "../types/document";
 import { createEmptyDocument } from "./createDocument";
 import { mergeDocumentContent } from "./mergeDocumentContent";
 
@@ -97,5 +97,119 @@ describe("mergeDocumentContent", () => {
     // (decimal at level 0), not a plain unnumbered paragraph.
     const clauseLine = markdown.split("\n").find((line) => line.includes("Clause text."));
     expect(clauseLine).toMatch(/^1[.)]?\s+Clause text\.$/);
+  });
+
+  test("remaps a colliding numId inside a nested table (table cell containing a table)", () => {
+    const target = stellaTargetWithClause();
+    const listItem = fromMarkdown("1. first").package.document.content[0];
+    if (!listItem || listItem.type !== "paragraph") {
+      throw new Error("expected fromMarkdown to produce a list paragraph");
+    }
+
+    const nestedTable: Table = {
+      type: "table",
+      rows: [{ type: "tableRow", cells: [{ type: "tableCell", content: [listItem] }] }],
+    };
+    const outerTable: Table = {
+      type: "table",
+      rows: [{ type: "tableRow", cells: [{ type: "tableCell", content: [nestedTable] }] }],
+    };
+    const source: Document = {
+      ...fromMarkdown("1. first"),
+      package: {
+        ...fromMarkdown("1. first").package,
+        document: { ...fromMarkdown("1. first").package.document, content: [outerTable] },
+      },
+    };
+
+    const merged = mergeDocumentContent(target, source);
+    const mergedOuterTable = merged.package.document.content.at(-1);
+    if (mergedOuterTable?.type !== "table") {
+      throw new Error("expected the merged content to end with the outer table");
+    }
+    const mergedNestedTable = mergedOuterTable.rows[0]?.cells[0]?.content[0];
+    if (mergedNestedTable?.type !== "table") {
+      throw new Error("expected the outer cell to contain the nested table");
+    }
+    const mergedParagraph = mergedNestedTable.rows[0]?.cells[0]?.content[0];
+
+    expect(mergedParagraph?.type).toBe("paragraph");
+    const remappedNumId =
+      mergedParagraph?.type === "paragraph" ? mergedParagraph.formatting?.numPr?.numId : undefined;
+    // Remapped above the target's reserved numId range (1-5), not left at
+    // the colliding numId 1 fromMarkdown minted.
+    expect(remappedNumId).toBeGreaterThan(5);
+  });
+
+  test("a table cell holding an unexpected (non paragraph/table) block does not crash", () => {
+    // `TableCell.content` is statically typed as `(Paragraph | Table)[]` —
+    // folio's own DOCX parser flattens a `w:sdt` inside a cell into its
+    // children rather than keeping a `blockSdt` wrapper (see
+    // `tableParser.ts`) — but `mergeDocumentContent` is a general helper
+    // that also has to tolerate hand-built `Document` values that don't
+    // honor that invariant. Build one here to lock in the crash fix: passing
+    // a non-table block straight into `remapTable` used to throw on
+    // `table.rows`.
+    const foreignBlock = {
+      type: "blockSdt",
+      properties: { sdtType: "richText" },
+      content: [] as BlockContent[],
+    } satisfies Extract<BlockContent, { type: "blockSdt" }>;
+    // SAFETY: simulating an untrusted/hand-built Document whose cell content
+    // does not conform to `TableCell.content`'s static type — see the test
+    // description above.
+    const cell = { type: "tableCell", content: [foreignBlock] } as unknown as TableCell;
+    const table: Table = { type: "table", rows: [{ type: "tableRow", cells: [cell] }] };
+
+    const target = stellaTargetWithClause();
+    const source: Document = {
+      ...fromMarkdown("1. first"),
+      package: {
+        ...fromMarkdown("1. first").package,
+        document: { ...fromMarkdown("1. first").package.document, content: [table] },
+      },
+    };
+
+    expect(() => mergeDocumentContent(target, source)).not.toThrow();
+
+    const merged = mergeDocumentContent(target, source);
+    const mergedTable = merged.package.document.content.at(-1);
+    if (mergedTable?.type !== "table") {
+      throw new Error("expected the merged content to end with the table");
+    }
+    // The foreign block is preserved unchanged, not dropped or crashed on.
+    expect(mergedTable.rows[0]?.cells[0]?.content[0]).toEqual(foreignBlock);
+  });
+
+  test("recurses into a top-level blockSdt content control", () => {
+    const target = stellaTargetWithClause();
+    const listItem = fromMarkdown("1. first").package.document.content[0];
+    if (!listItem || listItem.type !== "paragraph") {
+      throw new Error("expected fromMarkdown to produce a list paragraph");
+    }
+
+    const sdt: Extract<BlockContent, { type: "blockSdt" }> = {
+      type: "blockSdt",
+      properties: { sdtType: "richText" },
+      content: [listItem],
+    };
+    const source: Document = {
+      ...fromMarkdown("1. first"),
+      package: {
+        ...fromMarkdown("1. first").package,
+        document: { ...fromMarkdown("1. first").package.document, content: [sdt] },
+      },
+    };
+
+    const merged = mergeDocumentContent(target, source);
+    const mergedSdt = merged.package.document.content.at(-1);
+    if (mergedSdt?.type !== "blockSdt") {
+      throw new Error("expected the merged content to end with the blockSdt");
+    }
+    const mergedParagraph = mergedSdt.content[0];
+    expect(mergedParagraph?.type).toBe("paragraph");
+    const remappedNumId =
+      mergedParagraph?.type === "paragraph" ? mergedParagraph.formatting?.numPr?.numId : undefined;
+    expect(remappedNumId).toBeGreaterThan(5);
   });
 });

--- a/packages/core/src/utils/mergeDocumentContent.test.ts
+++ b/packages/core/src/utils/mergeDocumentContent.test.ts
@@ -1,0 +1,101 @@
+// mergeDocumentContent is the general replacement for hand-merging a parsed
+// document's content blocks onto another document (e.g. `fromMarkdown`'s
+// output onto a styled preset): appending `source.package.document.content`
+// directly is unsafe once `source` carries its own numbering, because
+// `fromMarkdown` mints small numIds (1, 2, …) that collide with a preset's
+// reserved numbering (see stellaStyle.ts's `createLegalNumbering`, which
+// reserves numId 1-5 for clause/definitions/recitals/parties/bullet). A
+// colliding markdown list silently renders with the preset's clause/
+// definition marker instead of a plain bullet/number.
+
+import { describe, expect, test } from "bun:test";
+
+import { docxToMarkdown } from "../docx/server/docxToMarkdown";
+import { createDocx } from "../docx/rezip";
+import { fromMarkdown } from "../markdown/fromMarkdown";
+import { createStellaStyleDocumentPreset } from "../style-sets/stellaStyle";
+import type { Document, Paragraph } from "../types/document";
+import { createEmptyDocument } from "./createDocument";
+import { mergeDocumentContent } from "./mergeDocumentContent";
+
+const CLEAN = {
+  annotations: "strip",
+  trackedChanges: "clean",
+  comments: "strip",
+  hyperlinks: "inline",
+  footnotes: "strip",
+} as const;
+
+const clauseParagraph = (text: string): Paragraph => ({
+  type: "paragraph",
+  formatting: { numPr: { numId: 1, ilvl: 0 }, styleId: "ClauseParagraph1" },
+  content: [{ type: "run", formatting: {}, content: [{ type: "text", text }] }],
+});
+
+const stellaTargetWithClause = (): Document => {
+  const target = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+  target.package.document.content = [clauseParagraph("Clause text.")];
+  return target;
+};
+
+describe("mergeDocumentContent", () => {
+  test("appends source content and merges numbering definitions", () => {
+    const target = stellaTargetWithClause();
+    const merged = mergeDocumentContent(target, fromMarkdown("1. first\n2. second"));
+
+    expect(merged.package.document.content).toHaveLength(3);
+    // Target's own reserved numbering (numId 1-5) is untouched.
+    expect(merged.package.numbering?.nums.filter((num) => num.numId <= 5)).toEqual(
+      target.package.numbering?.nums,
+    );
+  });
+
+  test("does not mutate either input document", () => {
+    const target = stellaTargetWithClause();
+    const source = fromMarkdown("1. first\n2. second");
+    const targetContentLength = target.package.document.content.length;
+    const sourceNumIds = source.package.numbering?.nums.map((num) => num.numId);
+
+    mergeDocumentContent(target, source);
+
+    expect(target.package.document.content).toHaveLength(targetContentLength);
+    expect(source.package.numbering?.nums.map((num) => num.numId)).toEqual(sourceNumIds);
+  });
+
+  test("remaps a colliding source numId above the target's existing range", () => {
+    const target = stellaTargetWithClause();
+    const source = fromMarkdown("1. first\n2. second");
+    // fromMarkdown mints numId 1 for its first list — the same id Stella's
+    // preset reserves for clause numbering.
+    expect(source.package.numbering?.nums.map((num) => num.numId)).toEqual([1]);
+
+    const merged = mergeDocumentContent(target, source);
+    const mergedListParagraph = merged.package.document.content.find(
+      (block) => block.type === "paragraph" && block.listRendering,
+    );
+    expect(mergedListParagraph?.type).toBe("paragraph");
+    const remappedNumId =
+      mergedListParagraph?.type === "paragraph"
+        ? mergedListParagraph.formatting?.numPr?.numId
+        : undefined;
+    expect(remappedNumId).toBeGreaterThan(5);
+  });
+
+  test("createDocx(merged) succeeds and round-trips both lists correctly", async () => {
+    const target = stellaTargetWithClause();
+    const merged = mergeDocumentContent(target, fromMarkdown("1. first\n2. second\n\n- bullet"));
+
+    const bytes = await createDocx(merged);
+    const markdown = await docxToMarkdown(bytes, CLEAN);
+
+    // The markdown list keeps its own identity (plain "1."/"- "), not
+    // Stella's clause "(a)"/definitions marker.
+    expect(markdown).toContain("1. first\n2. second");
+    expect(markdown).toContain("- bullet");
+
+    // The preset's clause paragraph still renders with clause numbering
+    // (decimal at level 0), not a plain unnumbered paragraph.
+    const clauseLine = markdown.split("\n").find((line) => line.includes("Clause text."));
+    expect(clauseLine).toMatch(/^1[.)]?\s+Clause text\.$/);
+  });
+});

--- a/packages/core/src/utils/mergeDocumentContent.ts
+++ b/packages/core/src/utils/mergeDocumentContent.ts
@@ -1,0 +1,194 @@
+/**
+ * Merge Document Content Utility
+ *
+ * Composes two documents by appending one document's body content onto
+ * another's, renumbering any list numbering the source carries so it can
+ * never collide with numbering the target already defines.
+ */
+
+import type {
+  AbstractNumbering,
+  BlockContent,
+  Document,
+  ListRendering,
+  NumberingDefinitions,
+  NumberingInstance,
+  Paragraph,
+  Table,
+} from "../types/document";
+
+/**
+ * Append `source`'s body content onto `target`'s. Both documents keep their
+ * own identity — this returns a new `Document`; neither argument is mutated.
+ *
+ * `target` wins on everything except content and numbering: its style set,
+ * theme, font table, settings, and section/page geometry are unchanged, so
+ * merging markdown (or any other document) into a styled preset keeps that
+ * preset's look. Only `source`'s numbering — the `w:abstractNum`/`w:num`
+ * definitions its content's `numPr` references — travels with it, and every
+ * `abstractNumId`/`numId` it carries is renumbered to sit strictly above
+ * whatever `target` already uses. This is unconditional (not just on a
+ * detected collision): it is simpler to reason about, and makes repeated
+ * merges into the same target safe too (merging two sources that each mint
+ * `numId` 1 does not collide with each other either).
+ *
+ * A typical caller composes `fromMarkdown` with a styled preset:
+ *
+ * ```ts
+ * const target = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+ * const merged = mergeDocumentContent(target, fromMarkdown(markdown));
+ * const bytes = await createDocx(merged);
+ * ```
+ */
+export function mergeDocumentContent(target: Document, source: Document): Document {
+  const targetNumbering = target.package.numbering;
+  const sourceNumbering = source.package.numbering;
+
+  if (
+    sourceNumbering === undefined ||
+    (sourceNumbering.abstractNums.length === 0 && sourceNumbering.nums.length === 0)
+  ) {
+    return {
+      ...target,
+      package: {
+        ...target.package,
+        document: {
+          ...target.package.document,
+          content: [...target.package.document.content, ...source.package.document.content],
+        },
+      },
+    };
+  }
+
+  const remappedSource = remapContentNumbering(source.package.document.content, sourceNumbering);
+
+  return {
+    ...target,
+    package: {
+      ...target.package,
+      document: {
+        ...target.package.document,
+        content: [...target.package.document.content, ...remappedSource.content],
+      },
+      numbering: {
+        abstractNums: [
+          ...(targetNumbering?.abstractNums ?? []),
+          ...remappedSource.numbering.abstractNums,
+        ],
+        nums: [...(targetNumbering?.nums ?? []), ...remappedSource.numbering.nums],
+      },
+    },
+  };
+
+  function remapContentNumbering(
+    content: BlockContent[],
+    numbering: NumberingDefinitions,
+  ): { content: BlockContent[]; numbering: NumberingDefinitions } {
+    const abstractNumIdBase = Math.max(
+      0,
+      ...(targetNumbering?.abstractNums ?? []).map((abstractNum) => abstractNum.abstractNumId),
+    );
+    const numIdBase = Math.max(0, ...(targetNumbering?.nums ?? []).map((num) => num.numId));
+
+    const abstractNumIdRemap = new Map<number, number>();
+    const remappedAbstractNums: AbstractNumbering[] = numbering.abstractNums.map(
+      (abstractNum, index) => {
+        const remappedAbstractNumId = abstractNumIdBase + index + 1;
+        abstractNumIdRemap.set(abstractNum.abstractNumId, remappedAbstractNumId);
+        return { ...abstractNum, abstractNumId: remappedAbstractNumId };
+      },
+    );
+
+    const numIdRemap = new Map<number, number>();
+    const remappedNums: NumberingInstance[] = numbering.nums.map((num, index) => {
+      const remappedNumId = numIdBase + index + 1;
+      numIdRemap.set(num.numId, remappedNumId);
+      return {
+        ...num,
+        numId: remappedNumId,
+        abstractNumId: abstractNumIdRemap.get(num.abstractNumId) ?? num.abstractNumId,
+      };
+    });
+
+    return {
+      content: content.map((block) => remapBlock(block, numIdRemap, abstractNumIdRemap)),
+      numbering: { abstractNums: remappedAbstractNums, nums: remappedNums },
+    };
+  }
+}
+
+function remapBlock(
+  block: BlockContent,
+  numIdRemap: Map<number, number>,
+  abstractNumIdRemap: Map<number, number>,
+): BlockContent {
+  if (block.type === "paragraph") {
+    return remapParagraph(block, numIdRemap, abstractNumIdRemap);
+  }
+  if (block.type === "table") {
+    return remapTable(block, numIdRemap, abstractNumIdRemap);
+  }
+  // blockSdt — content controls can nest paragraphs/tables/other controls.
+  return {
+    ...block,
+    content: block.content.map((child) => remapBlock(child, numIdRemap, abstractNumIdRemap)),
+  };
+}
+
+function remapTable(
+  table: Table,
+  numIdRemap: Map<number, number>,
+  abstractNumIdRemap: Map<number, number>,
+): Table {
+  return {
+    ...table,
+    rows: table.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) => ({
+        ...cell,
+        content: cell.content.map((item) =>
+          item.type === "paragraph"
+            ? remapParagraph(item, numIdRemap, abstractNumIdRemap)
+            : remapTable(item, numIdRemap, abstractNumIdRemap),
+        ),
+      })),
+    })),
+  };
+}
+
+function remapParagraph(
+  paragraph: Paragraph,
+  numIdRemap: Map<number, number>,
+  abstractNumIdRemap: Map<number, number>,
+): Paragraph {
+  const numId = paragraph.formatting?.numPr?.numId;
+  const remappedNumId = numId === undefined ? undefined : numIdRemap.get(numId);
+  if (remappedNumId === undefined) {
+    return paragraph;
+  }
+
+  return {
+    ...paragraph,
+    formatting: {
+      ...paragraph.formatting,
+      numPr: { ...paragraph.formatting?.numPr, numId: remappedNumId },
+    },
+    ...(paragraph.listRendering && {
+      listRendering: remapListRendering(paragraph.listRendering, remappedNumId, abstractNumIdRemap),
+    }),
+  };
+}
+
+function remapListRendering(
+  rendering: ListRendering,
+  remappedNumId: number,
+  abstractNumIdRemap: Map<number, number>,
+): ListRendering {
+  return {
+    ...rendering,
+    numId: remappedNumId,
+    ...(rendering.abstractNumId !== undefined && {
+      abstractNumId: abstractNumIdRemap.get(rendering.abstractNumId) ?? rendering.abstractNumId,
+    }),
+  };
+}

--- a/packages/core/src/utils/mergeDocumentContent.ts
+++ b/packages/core/src/utils/mergeDocumentContent.ts
@@ -129,10 +129,19 @@ function remapBlock(
     return remapTable(block, numIdRemap, abstractNumIdRemap);
   }
   // blockSdt — content controls can nest paragraphs/tables/other controls.
-  return {
-    ...block,
-    content: block.content.map((child) => remapBlock(child, numIdRemap, abstractNumIdRemap)),
-  };
+  // `BlockContent` is meant to be exhaustive here, but this helper also runs
+  // on content from hand-built `Document` inputs (not necessarily produced by
+  // `parseDocx`), so guard the shape at runtime rather than trusting the
+  // static type: a block whose `type` matches neither "paragraph" nor
+  // "table" but that also carries no `content` array passes through
+  // unchanged instead of throwing.
+  if ("content" in block && Array.isArray(block.content)) {
+    return {
+      ...block,
+      content: block.content.map((child) => remapBlock(child, numIdRemap, abstractNumIdRemap)),
+    };
+  }
+  return block;
 }
 
 function remapTable(
@@ -146,14 +155,31 @@ function remapTable(
       ...row,
       cells: row.cells.map((cell) => ({
         ...cell,
-        content: cell.content.map((item) =>
-          item.type === "paragraph"
-            ? remapParagraph(item, numIdRemap, abstractNumIdRemap)
-            : remapTable(item, numIdRemap, abstractNumIdRemap),
-        ),
+        content: cell.content.map((item) => remapCellItem(item, numIdRemap, abstractNumIdRemap)),
       })),
     })),
   };
+}
+
+/**
+ * `TableCell.content` is typed as `(Paragraph | Table)[]` — narrower than
+ * `BlockContent` — because folio's own DOCX parser flattens a `w:sdt` inside
+ * a cell into its `sdtContent` children (see `tableParser.ts`) rather than
+ * keeping a `blockSdt` wrapper. A hand-built `Document` is not bound by that
+ * invariant, so delegate to `remapBlock` (which fully handles paragraph,
+ * table, and container blocks, including nested tables) and only accept its
+ * result back into the cell when it is still a `Paragraph | Table` — an
+ * anomalous `blockSdt` (or any other shape `remapBlock` had to pass through
+ * unchanged) is left as-is rather than smuggled into a field the type system
+ * says can't hold it.
+ */
+function remapCellItem(
+  item: Paragraph | Table,
+  numIdRemap: Map<number, number>,
+  abstractNumIdRemap: Map<number, number>,
+): Paragraph | Table {
+  const remapped = remapBlock(item, numIdRemap, abstractNumIdRemap);
+  return remapped.type === "blockSdt" ? item : remapped;
 }
 
 function remapParagraph(


### PR DESCRIPTION
## Summary

- `fromMarkdown` mints list `numId`s (1, 2, …) via `blocksFromTokens(tokens, { next: 1 })` but never populated `document.package.numbering` — the DOCX serializer only reads numbering defs from there, never from the editor-only `listRendering` hint. As a result `createDocx(fromMarkdown(md))` threw `DocxModelValidationError: Numbering definition N is missing` whenever the markdown had a list. `fromMarkdown` now synthesizes matching `w:abstractNum`/`w:num` definitions for every list it emits, so the result is self-consistent on its own and round-trips through `docxToMarkdown` unchanged.
- That doesn't help a caller merging `fromMarkdown`'s content onto a document that already carries numbering (e.g. a styled preset that reserves low `numId`s for its own lists) — the markdown's `numId` 1, 2, … silently collides and renders with the preset's numbering instead of a plain bullet/number. Added `mergeDocumentContent(target, source)`, a general helper (not markdown-specific) that appends one document's content onto another and renumbers any `numId`/`abstractNumId` the source carries to sit strictly above the target's existing numbering range.

## Test plan

- [x] `bun run typecheck` (whole repo)
- [x] `bun run lint`
- [x] `bun test src` in `packages/core` (4349 pass)
- [x] `bun run build`
- [x] `bun run api:update` then `bun run api:check` — diff limited to the new `mergeDocumentContent` export
- [x] New tests: `packages/core/src/markdown/fromMarkdown.docx.test.ts` (createDocx(fromMarkdown(...)) succeeds + round-trips ordered/bullet/nested lists through actual DOCX bytes), `packages/core/src/utils/mergeDocumentContent.test.ts` (merges content + numbering, remaps colliding numId above a styled preset's reserved range, no mutation, round-trips both the markdown list and the preset's own numbered list correctly)
- [x] Changeset added (`@stll/folio-core`: minor)