### PR TITLE
perf: reuse unchanged DOCX package entries

### DIFF
--- a/.changeset/calm-packages-save.md
+++ b/.changeset/calm-packages-save.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Speed up DOCX serialization by reusing unchanged package entries.

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -20,7 +20,7 @@ import JSZip from "jszip";
 import type { Document } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { repackDocx } from "./rezip";
+import { createDocx, repackDocx } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -225,6 +225,19 @@ describe("numbering-definition write path (selective save)", () => {
 });
 
 describe("numbering-definition write path (full repack)", () => {
+  test("detects an in-place numbering edit after a prior save", async () => {
+    const buffer = await createNumberingFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    await createDocx(doc);
+    editFirstLevelText(doc, EDITED_ABSTRACT_ID, EDITED_LVL_TEXT);
+    const edited = await createDocx(doc);
+
+    expect(levelText(await parseDocx(edited, { preloadFonts: false }), EDITED_ABSTRACT_ID)).toBe(
+      EDITED_LVL_TEXT,
+    );
+  });
+
   test("edited numbering definition persists through repackDocx; untouched parts intact", async () => {
     const buffer = await createNumberingFixture();
 

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import type { Document } from "../types/document";
+import { createEmptyDocument } from "../utils/createDocument";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { createDocx, repackDocx } from "./rezip";
@@ -225,6 +226,49 @@ describe("numbering-definition write path (selective save)", () => {
 });
 
 describe("numbering-definition write path (full repack)", () => {
+  test("a repeated fresh-document save retains newly added numbering definitions", async () => {
+    const doc = createEmptyDocument();
+    doc.package.numbering = {
+      abstractNums: [
+        {
+          abstractNumId: 0,
+          levels: [
+            {
+              ilvl: 0,
+              start: 1,
+              numFmt: "decimal",
+              lvlText: ORIGINAL_LVL_TEXT,
+            },
+          ],
+        },
+      ],
+      nums: [{ numId: 1, abstractNumId: 0 }],
+    };
+
+    await createDocx(doc);
+    editFirstLevelText(doc, 0, EDITED_LVL_TEXT);
+    doc.package.numbering.abstractNums.push({
+      abstractNumId: 1,
+      levels: [
+        {
+          ilvl: 0,
+          start: 1,
+          numFmt: "lowerLetter",
+          lvlText: "%1.",
+        },
+      ],
+    });
+    doc.package.numbering.nums.push({ numId: 2, abstractNumId: 1 });
+
+    const reparsed = await parseDocx(await createDocx(doc), { preloadFonts: false });
+
+    expect(levelText(reparsed, 0)).toBe(EDITED_LVL_TEXT);
+    expect(
+      reparsed.package.numbering?.abstractNums.map(({ abstractNumId }) => abstractNumId),
+    ).toEqual([0, 1]);
+    expect(reparsed.package.numbering?.nums.map(({ numId }) => numId)).toEqual([1, 2]);
+  });
+
   test("detects an in-place numbering edit after a prior save", async () => {
     const buffer = await createNumberingFixture();
     const doc = await parseDocx(buffer, { preloadFonts: false });

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -4,7 +4,7 @@ import JSZip from "jszip";
 import type { Document } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { DocxPackageFidelityError, repackDocx } from "./rezip";
+import { createDocx, DocxPackageFidelityError, repackDocx } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -213,6 +213,39 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
 }
 
 describe("repackDocx", () => {
+  test("reuses a sanitized source package while preserving later model edits", async () => {
+    const sourceZip = await JSZip.loadAsync(await createHeaderFixture());
+    sourceZip.file("word/vbaProject.bin", new Uint8Array([1, 2, 3]));
+    const sourceBuffer = await sourceZip.generateAsync({ type: "arraybuffer" });
+    const document = await parseDocx(sourceBuffer, { preloadFonts: false });
+
+    const firstSave = await createDocx(document);
+    expect((await JSZip.loadAsync(firstSave)).file("word/vbaProject.bin")).toBeNull();
+
+    const body = document.package.document.content.at(0);
+    if (!body || body.type !== "paragraph") {
+      throw new Error("expected a body paragraph");
+    }
+    const run = body.content.at(0);
+    if (!run || run.type !== "run") {
+      throw new Error("expected a body run");
+    }
+    const text = run.content.at(0);
+    if (!text || text.type !== "text") {
+      throw new Error("expected body text");
+    }
+    text.text = "Edited after first save";
+
+    const secondSave = await createDocx(document);
+    const secondZip = await JSZip.loadAsync(secondSave);
+
+    expect(await secondZip.file("word/document.xml")?.async("text")).toContain(
+      "Edited after first save",
+    );
+    expect(secondZip.file("word/vbaProject.bin")).toBeNull();
+    expect((await JSZip.loadAsync(sourceBuffer)).file("word/vbaProject.bin")).not.toBeNull();
+  });
+
   test("drops orphan comment references before full repack validation", async () => {
     const originalBuffer = await createHeaderFixture();
     const document: Document = {

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -692,6 +692,14 @@ type ParsedZipSource = {
 
 const parsedZipSources = new WeakMap<Document, ParsedZipSource>();
 
+const removeNonPreservableEntries = (zip: JSZip): void => {
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && !isPreservableDocxEntry(path)) {
+      zip.remove(path);
+    }
+  }
+};
+
 const loadParsedZipSource = async (
   document: Document,
   buffer: ArrayBuffer,
@@ -702,11 +710,7 @@ const loadParsedZipSource = async (
   }
 
   const zip = await JSZip.loadAsync(buffer);
-  for (const [path, file] of Object.entries(zip.files)) {
-    if (!file.dir && !isPreservableDocxEntry(path)) {
-      zip.remove(path);
-    }
-  }
+  removeNonPreservableEntries(zip);
   const [documentXml, corePropertiesXml] = await Promise.all([
     zip.file("word/document.xml")?.async("text"),
     zip.file("docProps/core.xml")?.async("text"),
@@ -815,31 +819,8 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
     originalZip.file("docProps/core.xml")?.async("text"),
   ]);
 
-  // Create a new ZIP with all original files
-  const newZip = new JSZip();
-
-  // Copy all files from original ZIP
-  for (const [path, file] of Object.entries(originalZip.files)) {
-    // Skip directories
-    if (file.dir) {
-      newZip.folder(path.replace(/\/$/u, ""));
-      continue;
-    }
-
-    if (!isPreservableDocxEntry(path)) {
-      continue;
-    }
-
-    // Get original file content
-    // oxlint-disable-next-line no-await-in-loop -- entries are decoded and written into the shared newZip in original order to keep deterministic output
-    const content = await file.async("arraybuffer");
-
-    // Add to new ZIP (we'll update specific files below)
-    newZip.file(path, content, {
-      compression: "DEFLATE",
-      compressionOptions: { level: compressionLevel },
-    });
-  }
+  removeNonPreservableEntries(originalZip);
+  const newZip = cloneDocxZip(originalZip);
 
   return finishRepack({
     document: exportDocument,
@@ -1818,7 +1799,7 @@ async function serializeNumberingIntoZip(
   if (!file) {
     return;
   }
-  let baseline = numberingBaselines.get(doc);
+  let baseline = doc.originalBuffer ? numberingBaselines.get(doc) : undefined;
   if (!baseline || baseline.originalBuffer !== doc.originalBuffer) {
     const originalXml = await file.async("text");
     baseline = {
@@ -1826,7 +1807,9 @@ async function serializeNumberingIntoZip(
       originalXml,
       serializedXml: serializeNumberingXml(parseNumbering(originalXml).definitions),
     };
-    numberingBaselines.set(doc, baseline);
+    if (doc.originalBuffer) {
+      numberingBaselines.set(doc, baseline);
+    }
   }
   const currentXml = serializeNumberingXml(numbering);
   const changed = collectChangedNumberingDefs(baseline.serializedXml, currentXml);
@@ -2230,7 +2213,7 @@ export async function createDocx(doc: Document): Promise<ArrayBuffer> {
     document: withoutOrphanCommentRanges(doc),
     originalZip: zip,
     outputZip: zip,
-    originalDocumentXml: await zip.file("word/document.xml")?.async("text"),
+    originalDocumentXml: undefined,
     originalCorePropertiesXml: await zip.file("docProps/core.xml")?.async("text"),
     compressionLevel: 6,
     updateModifiedDate: true,

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -676,6 +676,118 @@ export type RepackOptions = {
   modifiedBy?: string;
 };
 
+const generateDocxZip = (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> =>
+  zip.generateAsync({
+    type: "arraybuffer",
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
+
+type ParsedZipSource = {
+  buffer: ArrayBuffer;
+  zip: JSZip;
+  documentXml: string | undefined;
+  corePropertiesXml: string | undefined;
+};
+
+const parsedZipSources = new WeakMap<Document, ParsedZipSource>();
+
+const loadParsedZipSource = async (
+  document: Document,
+  buffer: ArrayBuffer,
+): Promise<ParsedZipSource> => {
+  const cached = parsedZipSources.get(document);
+  if (cached?.buffer === buffer) {
+    return cached;
+  }
+
+  const zip = await JSZip.loadAsync(buffer);
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && !isPreservableDocxEntry(path)) {
+      zip.remove(path);
+    }
+  }
+  const [documentXml, corePropertiesXml] = await Promise.all([
+    zip.file("word/document.xml")?.async("text"),
+    zip.file("docProps/core.xml")?.async("text"),
+  ]);
+  const source = { buffer, zip, documentXml, corePropertiesXml };
+  parsedZipSources.set(document, source);
+  return source;
+};
+
+const cloneDocxZip = (source: JSZip): JSZip => {
+  const clone = new JSZip();
+  clone.files = { ...source.files };
+  return clone;
+};
+
+type FinishRepackOptions = {
+  document: Document;
+  originalZip: JSZip;
+  outputZip: JSZip;
+  originalDocumentXml: string | undefined;
+  originalCorePropertiesXml: string | undefined;
+  compressionLevel: number;
+  updateModifiedDate: boolean;
+  modifiedBy?: string;
+};
+
+const finishRepack = async ({
+  document,
+  originalZip,
+  outputZip,
+  originalDocumentXml,
+  originalCorePropertiesXml,
+  compressionLevel,
+  updateModifiedDate,
+  modifiedBy,
+}: FinishRepackOptions): Promise<ArrayBuffer> => {
+  await materializeNewHeaderFooterParts(document, outputZip, compressionLevel);
+
+  await processNewImages(collectImageParts(document), outputZip, compressionLevel);
+
+  const newHyperlinks = collectHyperlinksWithoutRId(document.package.document.content);
+  await processNewHyperlinks(newHyperlinks, outputZip, compressionLevel);
+
+  assertValidFolioDocumentModel(document, "Cannot repack invalid DOCX document model");
+
+  applyReplyThreadMarkers(document);
+
+  const documentXml = serializeDocument(document);
+  if (originalDocumentXml) {
+    assertDocumentPackageFidelity(originalDocumentXml, documentXml, document);
+  }
+  outputZip.file("word/document.xml", documentXml, {
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
+
+  await rebindWatermarkRelIds(document, outputZip, compressionLevel);
+
+  serializeHeadersFootersToZip(document, outputZip, compressionLevel);
+
+  await serializeNotesToZip(document, originalZip, outputZip, compressionLevel);
+
+  await serializeNumberingIntoZip(document, originalZip, outputZip, compressionLevel);
+
+  await serializeCommentsToZip(document, outputZip, compressionLevel);
+
+  if (updateModifiedDate && originalCorePropertiesXml) {
+    const updatedCoreProperties = updateCoreProperties(originalCorePropertiesXml, {
+      updateModifiedDate,
+      ...(modifiedBy !== undefined ? { modifiedBy } : {}),
+    });
+
+    outputZip.file("docProps/core.xml", updatedCoreProperties, {
+      compression: "DEFLATE",
+      compressionOptions: { level: compressionLevel },
+    });
+  }
+
+  return generateDocxZip(outputZip, compressionLevel);
+};
+
 /**
  * Repack a Document into a valid DOCX file
  *
@@ -698,6 +810,10 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
 
   // Load the original ZIP
   const originalZip = await JSZip.loadAsync(doc.originalBuffer);
+  const [originalDocumentXml, originalCorePropertiesXml] = await Promise.all([
+    originalZip.file("word/document.xml")?.async("text"),
+    originalZip.file("docProps/core.xml")?.async("text"),
+  ]);
 
   // Create a new ZIP with all original files
   const newZip = new JSZip();
@@ -725,83 +841,16 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
     });
   }
 
-  // Promote in-memory header/footer parts to real parts/relationships first, so
-  // collectImageParts sees them and processNewImages can write image relations
-  // into a newly created header/footer's own rels.
-  await materializeNewHeaderFooterParts(exportDocument, newZip, compressionLevel);
-
-  // Process newly inserted images (data URLs → binary media files + relationships).
-  // This mutates image rIds in-place so the serializer outputs correct references.
-  await processNewImages(collectImageParts(exportDocument), newZip, compressionLevel);
-
-  // Process newly created hyperlinks (assign rIds + add relationship entries).
-  // This mutates hyperlink rIds in-place so the serializer outputs correct references.
-  const newHyperlinks = collectHyperlinksWithoutRId(exportDocument.package.document.content);
-  await processNewHyperlinks(newHyperlinks, newZip, compressionLevel);
-
-  assertValidFolioDocumentModel(exportDocument, "Cannot repack invalid DOCX document model");
-
-  // Give every reply comment its parent's anchor before serializing, so the
-  // reply round-trips with matching commentRange markers + reference.
-  applyReplyThreadMarkers(exportDocument);
-
-  // Serialize and update document.xml (after image/hyperlink rIds have been rewritten)
-  const documentXml = serializeDocument(exportDocument);
-  const originalDocumentXml = await originalZip.file("word/document.xml")?.async("text");
-  if (originalDocumentXml) {
-    assertDocumentPackageFidelity(originalDocumentXml, documentXml, exportDocument);
-  }
-  newZip.file("word/document.xml", documentXml, {
-    compression: "DEFLATE",
-    compressionOptions: { level: compressionLevel },
+  return finishRepack({
+    document: exportDocument,
+    originalZip,
+    outputZip: newZip,
+    originalDocumentXml,
+    originalCorePropertiesXml,
+    compressionLevel,
+    updateModifiedDate,
+    ...(modifiedBy !== undefined ? { modifiedBy } : {}),
   });
-
-  // Rebind picture-watermark image rIds so each header references the image in
-  // its own rels (materialization, run before image processing above, gave
-  // coverage-created header parts a relationship target to anchor against).
-  await rebindWatermarkRelIds(exportDocument, newZip, compressionLevel);
-
-  // Serialize and update modified headers/footers
-  serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
-
-  // Splice edited footnote/endnote bodies back into their parts (separators and
-  // unedited notes stay byte-exact).
-  await serializeNotesToZip(exportDocument, originalZip, newZip, compressionLevel);
-
-  // Splice edited numbering definitions back into word/numbering.xml (untouched
-  // definitions and the parts the model omits stay byte-exact).
-  await serializeNumberingIntoZip(exportDocument, originalZip, newZip, compressionLevel);
-
-  // Serialize comments
-  await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
-
-  // Optionally update modification date in docProps/core.xml
-  if (updateModifiedDate) {
-    const corePropsPath = "docProps/core.xml";
-    const corePropsFile = originalZip.file(corePropsPath);
-
-    if (corePropsFile) {
-      const originalCoreProps = await corePropsFile.async("text");
-      const updatedCoreProps = updateCoreProperties(originalCoreProps, {
-        updateModifiedDate,
-        ...(modifiedBy !== undefined ? { modifiedBy } : {}),
-      });
-
-      newZip.file(corePropsPath, updatedCoreProps, {
-        compression: "DEFLATE",
-        compressionOptions: { level: compressionLevel },
-      });
-    }
-  }
-
-  // Generate the new DOCX file
-  const arrayBuffer = await newZip.generateAsync({
-    type: "arraybuffer",
-    compression: "DEFLATE",
-    compressionOptions: { level: compressionLevel },
-  });
-
-  return arrayBuffer;
 }
 
 /**
@@ -1747,6 +1796,14 @@ async function serializeNotesToZip(
  * (lossy) parse+serialize, so an unedited definition matches its baseline and
  * is left byte-exact; only a genuine definition edit differs and is spliced.
  */
+type NumberingBaseline = {
+  originalBuffer: ArrayBuffer | undefined;
+  originalXml: string;
+  serializedXml: string;
+};
+
+const numberingBaselines = new WeakMap<Document, NumberingBaseline>();
+
 async function serializeNumberingIntoZip(
   doc: Document,
   originalZip: JSZip,
@@ -1761,14 +1818,22 @@ async function serializeNumberingIntoZip(
   if (!file) {
     return;
   }
-  const originalXml = await file.async("text");
-  const baselineXml = serializeNumberingXml(parseNumbering(originalXml).definitions);
+  let baseline = numberingBaselines.get(doc);
+  if (!baseline || baseline.originalBuffer !== doc.originalBuffer) {
+    const originalXml = await file.async("text");
+    baseline = {
+      originalBuffer: doc.originalBuffer,
+      originalXml,
+      serializedXml: serializeNumberingXml(parseNumbering(originalXml).definitions),
+    };
+    numberingBaselines.set(doc, baseline);
+  }
   const currentXml = serializeNumberingXml(numbering);
-  const changed = collectChangedNumberingDefs(baselineXml, currentXml);
+  const changed = collectChangedNumberingDefs(baseline.serializedXml, currentXml);
   if (changed.abstractNums.size === 0 && changed.nums.size === 0) {
     return;
   }
-  const patched = buildPatchedNumberingXml(originalXml, currentXml, changed);
+  const patched = buildPatchedNumberingXml(baseline.originalXml, currentXml, changed);
   if (patched === null) {
     return;
   }
@@ -2032,6 +2097,10 @@ export function isDocxBuffer(buffer: ArrayBuffer): boolean {
  * @returns Promise resolving to minimal DOCX as ArrayBuffer
  */
 export function createEmptyDocx(): Promise<ArrayBuffer> {
+  return generateDocxZip(createEmptyDocxZip(), 6);
+}
+
+const createEmptyDocxZip = (): JSZip => {
   const zip = new JSZip();
 
   // Content Types
@@ -2133,12 +2202,8 @@ export function createEmptyDocx(): Promise<ArrayBuffer> {
 </Properties>`,
   );
 
-  return zip.generateAsync({
-    type: "arraybuffer",
-    compression: "DEFLATE",
-    compressionOptions: { level: 6 },
-  });
-}
+  return zip;
+};
 
 /**
  * Create a new DOCX from a Document (without requiring original buffer)
@@ -2147,21 +2212,33 @@ export function createEmptyDocx(): Promise<ArrayBuffer> {
  * @returns Promise resolving to DOCX as ArrayBuffer
  */
 export async function createDocx(doc: Document): Promise<ArrayBuffer> {
-  const emptyBuffer = await createDocumentSeedDocx(doc);
+  if (doc.originalBuffer) {
+    const source = await loadParsedZipSource(doc, doc.originalBuffer);
+    return finishRepack({
+      document: withoutOrphanCommentRanges(doc),
+      originalZip: source.zip,
+      outputZip: cloneDocxZip(source.zip),
+      originalDocumentXml: source.documentXml,
+      originalCorePropertiesXml: source.corePropertiesXml,
+      compressionLevel: 6,
+      updateModifiedDate: true,
+    });
+  }
 
-  // Add document as original buffer
-  const docWithBuffer: Document = {
-    ...doc,
-    originalBuffer: emptyBuffer,
-  };
-
-  // Repack with the document content
-  return repackDocx(docWithBuffer);
+  const zip = await createDocumentSeedZip(doc);
+  return finishRepack({
+    document: withoutOrphanCommentRanges(doc),
+    originalZip: zip,
+    outputZip: zip,
+    originalDocumentXml: await zip.file("word/document.xml")?.async("text"),
+    originalCorePropertiesXml: await zip.file("docProps/core.xml")?.async("text"),
+    compressionLevel: 6,
+    updateModifiedDate: true,
+  });
 }
 
-const createDocumentSeedDocx = async (doc: Document): Promise<ArrayBuffer> => {
-  const buffer = await createEmptyDocx();
-  const zip = await JSZip.loadAsync(buffer);
+const createDocumentSeedZip = async (doc: Document): Promise<JSZip> => {
+  const zip = createEmptyDocxZip();
   const relationships: string[] = [
     '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>',
   ];
@@ -2237,11 +2314,7 @@ const createDocumentSeedDocx = async (doc: Document): Promise<ArrayBuffer> => {
     );
   }
 
-  return zip.generateAsync({
-    type: "arraybuffer",
-    compression: "DEFLATE",
-    compressionOptions: { level: 6 },
-  });
+  return zip;
 };
 
 const relationshipXml = (id: number, type: string, target: string): string =>

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -619,8 +619,29 @@ function extractNumberingElementXml(
   );
 }
 
-function collectNumberingElementIds(xml: string, kind: NumberingElementKind): Map<string, number> {
-  return collectElementIds(xml, NUMBERING_OPEN_LITERAL[kind], NUMBERING_ID_ATTR[kind]);
+type ElementOffsets = { start: number; end: number };
+
+function buildNumberingElementOffsetIndex(
+  xml: string,
+  kind: NumberingElementKind,
+): Map<string, ElementOffsets | null> {
+  const index = new Map<string, ElementOffsets | null>();
+  const openLiteral = NUMBERING_OPEN_LITERAL[kind];
+  const pattern = new RegExp(
+    `${escapeRegExp(openLiteral)}[\\s][^>]*?${escapeRegExp(NUMBERING_ID_ATTR[kind])}="(?<id>[^"]+)"`,
+    "gu",
+  );
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(xml)) !== null) {
+    // SAFETY: named group `id` always exists when this pattern matches.
+    const id = match.groups!["id"]!;
+    if (index.has(id)) {
+      index.set(id, null);
+      continue;
+    }
+    index.set(id, scanElementRange(xml, match.index, openLiteral, NUMBERING_CLOSE_TAG[kind]));
+  }
+  return index;
 }
 
 // Synthetic number formats folio's parser mints from custom / mc:AlternateContent
@@ -646,14 +667,16 @@ export function collectChangedNumberingDefs(
 ): ChangedNumberingDefs {
   const changedForKind = (kind: NumberingElementKind): Set<string> => {
     const changed = new Set<string>();
-    const baselineIds = collectNumberingElementIds(baselineXml, kind);
-    for (const [id, count] of collectNumberingElementIds(currentXml, kind)) {
-      if (count !== 1 || baselineIds.get(id) !== 1) {
+    const baselineIndex = buildNumberingElementOffsetIndex(baselineXml, kind);
+    const currentIndex = buildNumberingElementOffsetIndex(currentXml, kind);
+    for (const [id, afterRange] of currentIndex) {
+      const beforeRange = baselineIndex.get(id);
+      if (!beforeRange || !afterRange) {
         continue;
       }
-      const before = extractNumberingElementXml(baselineXml, kind, id);
-      const after = extractNumberingElementXml(currentXml, kind, id);
-      if (before !== null && after !== null && before !== after) {
+      const before = baselineXml.slice(beforeRange.start, beforeRange.end);
+      const after = currentXml.slice(afterRange.start, afterRange.end);
+      if (before !== after) {
         changed.add(id);
       }
     }

--- a/packages/core/src/docx/serializer/xmlUtils.ts
+++ b/packages/core/src/docx/serializer/xmlUtils.ts
@@ -4,13 +4,28 @@
 
 import { getLocalName, parseXml } from "../xmlParser";
 
+const XML_SPECIAL_CHARACTER_PATTERN = /[&<>"']/u;
+const XML_SPECIAL_CHARACTER_GLOBAL_PATTERN = /[&<>"']/gu;
+
 export function escapeXml(text: string): string {
-  return text
-    .replace(/&/gu, "&amp;")
-    .replace(/</gu, "&lt;")
-    .replace(/>/gu, "&gt;")
-    .replace(/"/gu, "&quot;")
-    .replace(/'/gu, "&apos;");
+  if (!XML_SPECIAL_CHARACTER_PATTERN.test(text)) {
+    return text;
+  }
+  return text.replace(XML_SPECIAL_CHARACTER_GLOBAL_PATTERN, (character) => {
+    if (character === "&") {
+      return "&amp;";
+    }
+    if (character === "<") {
+      return "&lt;";
+    }
+    if (character === ">") {
+      return "&gt;";
+    }
+    if (character === '"') {
+      return "&quot;";
+    }
+    return "&apos;";
+  });
 }
 
 /**


### PR DESCRIPTION
Reuse compressed bytes for unchanged source-package entries during DOCX saves, avoid the intermediate seed archive round trip, and index numbering definitions once per XML input.

Repeated saves still serialize the current model and filter non-preservable entries. Regression coverage verifies repeated body and numbering edits, source-package isolation, and active-content removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved DOCX save performance by reusing unchanged package content.
  * Optimized XML processing during document generation.

* **Bug Fixes**
  * Fixed numbering edits being missed after a document was saved and edited again.
  * Preserved sanitized DOCX output while retaining edits made to document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->