### PR TITLE
perf: reduce DOCX parsing overhead

### DIFF
--- a/.changeset/fast-docx-parsing.md
+++ b/.changeset/fast-docx-parsing.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Speed up DOCX parsing with batched package extraction and lower-allocation XML lookups.

--- a/packages/core/src/docx/encryption/cryptoBytes.ts
+++ b/packages/core/src/docx/encryption/cryptoBytes.ts
@@ -44,8 +44,17 @@ export const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
   return mismatch === 0;
 };
 
-export const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
-  bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+export const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer => {
+  if (
+    bytes.buffer instanceof ArrayBuffer &&
+    bytes.byteOffset === 0 &&
+    bytes.byteLength === bytes.buffer.byteLength
+  ) {
+    return bytes.buffer;
+  }
+
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+};
 
 export const decodeBase64 = (encoded: string): Uint8Array => {
   if (typeof atob === "function") {

--- a/packages/core/src/docx/hyperlinkParser.ts
+++ b/packages/core/src/docx/hyperlinkParser.ts
@@ -30,6 +30,7 @@ import type { StyleMap } from "./styleParser";
 import {
   getAttribute,
   getChildElements,
+  getLocalName,
   mergeXmlnsDeclarations,
   parseNumericAttribute,
 } from "./xmlParser";
@@ -38,17 +39,6 @@ import type { XmlElement } from "./xmlParser";
 // ============================================================================
 // HYPERLINK PARSER
 // ============================================================================
-
-/**
- * Get the local name of an element (without namespace prefix)
- */
-function getLocalName(name: string | undefined): string {
-  if (!name) {
-    return "";
-  }
-  const colonIndex = name.indexOf(":");
-  return colonIndex !== -1 ? name.slice(colonIndex + 1) : name;
-}
 
 /**
  * Parse bookmark start (w:bookmarkStart)

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -67,6 +67,7 @@ import {
   findChildren,
   getAttribute,
   getChildElements,
+  getLocalName,
   mergeXmlnsDeclarations,
   parseBooleanElement,
   parseNumericAttribute,
@@ -785,17 +786,6 @@ export function parseParagraphProperties(
 // ============================================================================
 // PARAGRAPH CONTENT PARSERS
 // ============================================================================
-
-/**
- * Get the local name of an element (without namespace prefix)
- */
-function getLocalName(name: string | undefined): string {
-  if (!name) {
-    return "";
-  }
-  const colonIndex = name.indexOf(":");
-  return colonIndex !== -1 ? name.slice(colonIndex + 1) : name;
-}
 
 const RENDERED_BREAK_INLINE_WRAPPERS = new Set([
   "hyperlink",

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -144,7 +144,7 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
     // ========================================================================
     onProgress("Extracting DOCX...", 0);
     const raw = await timeStageAsync("unzip", () =>
-      unzipDocx(buffer, { ...unzipLimits, password }),
+      unzipDocx(buffer, { ...unzipLimits, password, extractAllXml: false }),
     );
     if (raw.wasEncrypted) {
       warnings.push(

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -65,6 +65,7 @@ import {
   findChildren,
   getAttribute,
   getChildElements,
+  getLocalName,
   getTextContent,
   mergeXmlnsDeclarations,
   parseBooleanElement,
@@ -887,17 +888,6 @@ function parseDrawingContent(
     drawing.rawXml = elementToXml(element);
   }
   return drawing;
-}
-
-/**
- * Get the local name of an element (without namespace prefix)
- */
-function getLocalName(name: string | undefined): string {
-  if (!name) {
-    return "";
-  }
-  const colonIndex = name.indexOf(":");
-  return colonIndex !== -1 ? name.slice(colonIndex + 1) : name;
 }
 
 /**

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -77,6 +77,7 @@ import {
   findChildren,
   getAttribute,
   getChildElements,
+  getLocalName,
   mergeXmlnsDeclarations,
   parseNumericAttribute,
   parseTableMeasurementValue,
@@ -1458,14 +1459,6 @@ export function parseTableRow(
   }
 
   return row;
-}
-
-function getLocalName(name: string | undefined): string {
-  if (!name) {
-    return "";
-  }
-  const colonIndex = name.indexOf(":");
-  return colonIndex === -1 ? name : name.slice(colonIndex + 1);
 }
 
 function parseBookmarkMarker(

--- a/packages/core/src/docx/unzip.test.ts
+++ b/packages/core/src/docx/unzip.test.ts
@@ -115,6 +115,22 @@ describe("unzipDocx security limits", () => {
     expect(content.media.has("word/media/image1.png")).toBe(true);
   });
 
+  test("can keep unused XML in the source package without decompressing it", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("customXml/item1.xml", "<data />");
+
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+    const fullContent = await unzipDocx(buffer);
+    const content = await unzipDocx(buffer, { extractAllXml: false });
+
+    expect(fullContent.allXml.get("customXml/item1.xml")).toBe("<data />");
+    expect(content.originalBuffer).toBe(buffer);
+    expect(content.allXml.has("customXml/item1.xml")).toBe(false);
+    expect(content.originalZip.file("customXml/item1.xml")).not.toBeNull();
+  });
+
   test("skips oversized raster media instead of rejecting the document", async () => {
     const zip = new JSZip();
     zip.file("[Content_Types].xml", "<Types />");

--- a/packages/core/src/docx/unzip.ts
+++ b/packages/core/src/docx/unzip.ts
@@ -79,8 +79,34 @@ const DEFAULT_UNZIP_LIMITS: DocxUnzipLimits = {
   allowedMediaMimeTypes: DEFAULT_ALLOWED_MEDIA_MIME_TYPES,
 };
 
+const PARSED_XML_PARTS = new Set([
+  "[content_types].xml",
+  "_rels/.rels",
+  "docprops/app.xml",
+  "docprops/core.xml",
+  "docprops/custom.xml",
+  "word/_rels/document.xml.rels",
+  "word/_rels/fonttable.xml.rels",
+  "word/comments.xml",
+  "word/commentsextended.xml",
+  "word/commentsextensible.xml",
+  "word/document.xml",
+  "word/endnotes.xml",
+  "word/fonttable.xml",
+  "word/footnotes.xml",
+  "word/numbering.xml",
+  "word/settings.xml",
+  "word/styles.xml",
+  "word/theme/theme1.xml",
+]);
+
+const shouldExtractXmlPart = (path: string): boolean =>
+  PARSED_XML_PARTS.has(path) || path.startsWith("word/");
+
 export type DocxUnzipOptions = Partial<Omit<DocxUnzipLimits, "allowedMediaMimeTypes">> & {
   allowedMediaMimeTypes?: Iterable<string>;
+  /** Extract every XML part into allXml instead of only parts used by the parser. */
+  extractAllXml?: boolean;
   /** Password for Agile-encrypted .docx files (Office 2010+). */
   password?: string | undefined;
 };
@@ -103,6 +129,25 @@ type CentralDirectoryInfo = {
   offset: number;
   size: number;
 };
+
+type ExtractedEntry =
+  | {
+      type: "xml";
+      path: string;
+      lowerPath: string;
+      content: string;
+    }
+  | {
+      type: "media";
+      path: string;
+      mimeType: string;
+      content: ArrayBuffer;
+    }
+  | {
+      type: "font";
+      path: string;
+      content: ArrayBuffer;
+    };
 
 const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06_05_4b_50;
 const ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE = 0x02_01_4b_50;
@@ -194,12 +239,16 @@ export async function unzipDocx(
     throw new DocxSecurityError("DOCX file exceeds the maximum allowed size");
   }
 
-  const zipBuffer = await openDocxBuffer(buffer, { password: options.password });
+  const containerType = detectDocxContainerType(buffer);
+  const zipBuffer =
+    containerType === DOCX_CONTAINER_TYPES.ZIP
+      ? buffer
+      : await openDocxBuffer(buffer, { password: options.password });
   if (zipBuffer.byteLength > limits.maxInputBytes) {
     throw new DocxSecurityError("DOCX file exceeds the maximum allowed size");
   }
 
-  const wasEncrypted = detectDocxContainerType(buffer) === DOCX_CONTAINER_TYPES.CFB;
+  const wasEncrypted = containerType === DOCX_CONTAINER_TYPES.CFB;
   const loaded = await loadDocxZip(zipBuffer, limits.maxFiles);
   if (loaded.buffer.byteLength > limits.maxInputBytes) {
     throw new DocxSecurityError("DOCX file exceeds the maximum allowed size");
@@ -243,8 +292,11 @@ export async function unzipDocx(
   };
 
   let totalUncompressedBytes = 0;
+  const extractionTasks: Promise<ExtractedEntry | null>[] = [];
 
-  // Process each file in the ZIP
+  // Validate the complete package before decompressing accepted entries. The
+  // extraction promises are awaited together so independent ZIP parts do not
+  // pay JSZip's scheduling overhead one at a time.
   for (const [path, file] of entries) {
     if (!isSafeDocxPath(path)) {
       throw new DocxSecurityError("DOCX file contains an unsafe entry path");
@@ -267,55 +319,15 @@ export async function unzipDocx(
     // Determine file type and extract
     if (lowerPath.endsWith(".xml") || lowerPath.endsWith(".rels")) {
       assertEntrySize(path, declaredSize, limits.maxXmlBytes);
-      // oxlint-disable-next-line no-await-in-loop -- entries share a running totalUncompressedBytes budget and write into ordered content maps
-      const xmlContent = await file.async("text");
-      assertExtractedSize(path, xmlContent.length, limits.maxXmlBytes);
-      content.allXml.set(path, xmlContent);
-
-      // Categorize known XML files
-      if (lowerPath === "word/document.xml") {
-        content.documentXml = xmlContent;
-      } else if (lowerPath === "word/styles.xml") {
-        content.stylesXml = xmlContent;
-      } else if (lowerPath === "word/theme/theme1.xml") {
-        content.themeXml = xmlContent;
-      } else if (lowerPath === "word/numbering.xml") {
-        content.numberingXml = xmlContent;
-      } else if (lowerPath === "word/fonttable.xml") {
-        content.fontTableXml = xmlContent;
-      } else if (lowerPath === "word/settings.xml") {
-        content.settingsXml = xmlContent;
-      } else if (lowerPath === "word/websettings.xml") {
-        content.webSettingsXml = xmlContent;
-      } else if (lowerPath === "word/footnotes.xml") {
-        content.footnotesXml = xmlContent;
-      } else if (lowerPath === "word/endnotes.xml") {
-        content.endnotesXml = xmlContent;
-      } else if (lowerPath === "word/comments.xml") {
-        content.commentsXml = xmlContent;
-      } else if (lowerPath === "word/commentsextensible.xml") {
-        content.commentsExtensibleXml = xmlContent;
-      } else if (lowerPath === "word/commentsextended.xml") {
-        content.commentsExtendedXml = xmlContent;
-      } else if (lowerPath === "word/_rels/document.xml.rels") {
-        content.documentRels = xmlContent;
-      } else if (lowerPath === "_rels/.rels") {
-        content.packageRels = xmlContent;
-      } else if (lowerPath === "[content_types].xml") {
-        content.contentTypesXml = xmlContent;
-      } else if (lowerPath === "docprops/core.xml") {
-        content.corePropsXml = xmlContent;
-      } else if (lowerPath === "docprops/app.xml") {
-        content.appPropsXml = xmlContent;
-      } else if (lowerPath === "docprops/custom.xml") {
-        content.customPropsXml = xmlContent;
-      } else if (/^word\/header[^/]*\.xml$/u.test(lowerPath)) {
-        const filename = path.split("/").pop() || path;
-        content.headers.set(filename, xmlContent);
-      } else if (/^word\/footer[^/]*\.xml$/u.test(lowerPath)) {
-        const filename = path.split("/").pop() || path;
-        content.footers.set(filename, xmlContent);
+      if (options.extractAllXml === false && !shouldExtractXmlPart(lowerPath)) {
+        continue;
       }
+      extractionTasks.push(
+        file.async("text").then((xmlContent) => {
+          assertExtractedSize(path, xmlContent.length, limits.maxXmlBytes);
+          return { type: "xml", path, lowerPath, content: xmlContent };
+        }),
+      );
     } else if (lowerPath.startsWith("word/media/")) {
       // Media files (images, etc.)
       const mimeType = getMediaMimeType(path);
@@ -328,34 +340,104 @@ export async function unzipDocx(
         );
         continue;
       }
-      // oxlint-disable-next-line no-await-in-loop -- entries share a running totalUncompressedBytes budget and write into ordered content maps
-      const binaryContent = await file.async("arraybuffer");
-      if (binaryContent.byteLength > limits.maxMediaBytes) {
-        content.warnings.push(
-          `Skipped oversized media file: ${path}; original entry preserved for round-trip.`,
-        );
-        continue;
-      }
-      if (!isMediaContentAllowed(binaryContent, mimeType)) {
-        continue;
-      }
-      content.media.set(path, binaryContent);
+      extractionTasks.push(
+        file.async("arraybuffer").then((binaryContent) => {
+          if (binaryContent.byteLength > limits.maxMediaBytes) {
+            content.warnings.push(
+              `Skipped oversized media file: ${path}; original entry preserved for round-trip.`,
+            );
+            return null;
+          }
+          if (!isMediaContentAllowed(binaryContent, mimeType)) {
+            return null;
+          }
+          return { type: "media", path, mimeType, content: binaryContent };
+        }),
+      );
     } else if (lowerPath.startsWith("word/fonts/")) {
       // Embedded fonts are optional for editing and original ZIP preservation.
       // Skip oversized fonts instead of rejecting otherwise readable documents.
       if (isEntryTooLarge(declaredSize, limits.maxFontBytes)) {
         continue;
       }
-      // oxlint-disable-next-line no-await-in-loop -- entries share a running totalUncompressedBytes budget and write into ordered content maps
-      const binaryContent = await file.async("arraybuffer");
-      if (binaryContent.byteLength > limits.maxFontBytes) {
-        continue;
-      }
-      content.fonts.set(path, binaryContent);
+      extractionTasks.push(
+        file.async("arraybuffer").then((binaryContent) => {
+          if (binaryContent.byteLength > limits.maxFontBytes) {
+            return null;
+          }
+          return { type: "font", path, content: binaryContent };
+        }),
+      );
     }
   }
 
+  for (const extracted of await Promise.all(extractionTasks)) {
+    if (!extracted) {
+      continue;
+    }
+    if (extracted.type === "xml") {
+      assignXmlContent(content, extracted);
+      continue;
+    }
+    if (extracted.type === "media") {
+      content.media.set(extracted.path, extracted.content);
+      continue;
+    }
+    content.fonts.set(extracted.path, extracted.content);
+  }
+
   return content;
+}
+
+function assignXmlContent(
+  content: RawDocxContent,
+  { path, lowerPath, content: xmlContent }: Extract<ExtractedEntry, { type: "xml" }>,
+): void {
+  content.allXml.set(path, xmlContent);
+
+  if (lowerPath === "word/document.xml") {
+    content.documentXml = xmlContent;
+  } else if (lowerPath === "word/styles.xml") {
+    content.stylesXml = xmlContent;
+  } else if (lowerPath === "word/theme/theme1.xml") {
+    content.themeXml = xmlContent;
+  } else if (lowerPath === "word/numbering.xml") {
+    content.numberingXml = xmlContent;
+  } else if (lowerPath === "word/fonttable.xml") {
+    content.fontTableXml = xmlContent;
+  } else if (lowerPath === "word/settings.xml") {
+    content.settingsXml = xmlContent;
+  } else if (lowerPath === "word/websettings.xml") {
+    content.webSettingsXml = xmlContent;
+  } else if (lowerPath === "word/footnotes.xml") {
+    content.footnotesXml = xmlContent;
+  } else if (lowerPath === "word/endnotes.xml") {
+    content.endnotesXml = xmlContent;
+  } else if (lowerPath === "word/comments.xml") {
+    content.commentsXml = xmlContent;
+  } else if (lowerPath === "word/commentsextensible.xml") {
+    content.commentsExtensibleXml = xmlContent;
+  } else if (lowerPath === "word/commentsextended.xml") {
+    content.commentsExtendedXml = xmlContent;
+  } else if (lowerPath === "word/_rels/document.xml.rels") {
+    content.documentRels = xmlContent;
+  } else if (lowerPath === "_rels/.rels") {
+    content.packageRels = xmlContent;
+  } else if (lowerPath === "[content_types].xml") {
+    content.contentTypesXml = xmlContent;
+  } else if (lowerPath === "docprops/core.xml") {
+    content.corePropsXml = xmlContent;
+  } else if (lowerPath === "docprops/app.xml") {
+    content.appPropsXml = xmlContent;
+  } else if (lowerPath === "docprops/custom.xml") {
+    content.customPropsXml = xmlContent;
+  } else if (/^word\/header[^/]*\.xml$/u.test(lowerPath)) {
+    const filename = path.split("/").pop() || path;
+    content.headers.set(filename, xmlContent);
+  } else if (/^word\/footer[^/]*\.xml$/u.test(lowerPath)) {
+    const filename = path.split("/").pop() || path;
+    content.footers.set(filename, xmlContent);
+  }
 }
 
 async function loadDocxZip(buffer: ArrayBuffer, maxFiles: number): Promise<LoadedZip> {

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -97,6 +97,8 @@ const TEXT_KEY = "#text";
 /** Attribute group key used by fast-xml-parser in preserveOrder mode. */
 const ATTR_KEY = ":@";
 
+type MutableFxpNode = XmlElement & Record<string, unknown>;
+
 /**
  * Convert a fast-xml-parser preserveOrder node into an XmlElement.
  *
@@ -104,7 +106,7 @@ const ATTR_KEY = ":@";
  * (the tag name or `#text`) whose value is the children array, plus an
  * optional `:@` key holding the attributes object.
  */
-function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
+function fxpNodeToElement(node: Record<string, unknown>): MutableFxpNode {
   // Text node: { "#text": "some text" }
   if (TEXT_KEY in node) {
     return { type: "text", text: node[TEXT_KEY] as string };
@@ -120,8 +122,8 @@ function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
       continue;
     }
 
-    const children = node[key] as Record<string, unknown>[];
-    const element: XmlElement = { type: "element", name: key };
+    const children = node[key] as MutableFxpNode[];
+    const element: MutableFxpNode = { type: "element", name: key };
 
     // fast-xml-parser only emits the attribute group when it contains an
     // attribute, so a second Object.keys allocation is unnecessary.
@@ -130,11 +132,10 @@ function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
     }
 
     if (children.length > 0) {
-      const elements: XmlElement[] = [];
-      for (const child of children) {
-        elements.push(fxpNodeToElement(child));
+      for (let index = 0; index < children.length; index += 1) {
+        children[index] = fxpNodeToElement(children[index]!);
       }
-      element.elements = elements;
+      element.elements = children;
     }
 
     return element;
@@ -149,14 +150,13 @@ function fxpNodeToElement(node: Record<string, unknown>): XmlElement {
  * XmlElement that matches xml-js's non-compact root structure:
  * `{ elements: [...] }`.
  */
-function fxpToRootElement(nodes: Record<string, unknown>[]): XmlElement {
-  const elements: XmlElement[] = [];
-  for (const node of nodes) {
-    elements.push(fxpNodeToElement(node));
+function fxpToRootElement(nodes: MutableFxpNode[]): XmlElement {
+  for (let index = 0; index < nodes.length; index += 1) {
+    nodes[index] = fxpNodeToElement(nodes[index]!);
   }
 
   return {
-    elements,
+    elements: nodes,
   };
 }
 
@@ -201,7 +201,7 @@ export function parseXml(xml: string): XmlElement {
   // <w:t xml:space="preserve"> </w:t> are preserved — matching the old
   // xml-js captureSpacesBetweenElements behaviour.
   const parser = xml.includes("binData") ? fxpParserWithStopNodes : fxpParser;
-  const nodes = parser.parse(xml) as Record<string, unknown>[];
+  const nodes = parser.parse(xml) as MutableFxpNode[];
   return fxpToRootElement(nodes);
 }
 
@@ -236,7 +236,13 @@ export function parseXmlDocument(xml: string): XmlElement | null {
  * Get local name from a prefixed element name
  * e.g., "w:p" -> "p", "a:graphic" -> "graphic"
  */
-export function getLocalName(name: string): string {
+export function getLocalName(name: string | undefined): string {
+  if (!name) {
+    return "";
+  }
+  if (name[1] === ":") {
+    return name.slice(2);
+  }
   const colonIndex = name.indexOf(":");
   return colonIndex !== -1 ? name.slice(colonIndex + 1) : name;
 }
@@ -246,8 +252,22 @@ export function getLocalName(name: string): string {
  * e.g., "w:p" -> "w", "a:graphic" -> "a"
  */
 export function getNamespacePrefix(name: string): string | null {
+  if (name[1] === ":") {
+    return name[0] ?? null;
+  }
   const colonIndex = name.indexOf(":");
   return colonIndex !== -1 ? name.slice(0, colonIndex) : null;
+}
+
+function hasLocalName(name: string | undefined, localName: string): boolean {
+  if (!name) {
+    return false;
+  }
+  if (name === localName) {
+    return true;
+  }
+  const localNameOffset = name.length - localName.length;
+  return localNameOffset > 0 && name[localNameOffset - 1] === ":" && name.endsWith(localName);
 }
 
 /**
@@ -268,7 +288,7 @@ export function matchesName(element: XmlElement, namespace: string, localName: s
   }
 
   // Also check just the local name if no namespace prefix in element
-  if (getLocalName(element.name) === localName) {
+  if (hasLocalName(element.name, localName)) {
     return true;
   }
 
@@ -304,7 +324,7 @@ export function findChild(
     }
 
     // Check local name match
-    if (getLocalName(child.name || "") === localName) {
+    if (hasLocalName(child.name, localName)) {
       return child;
     }
   }
@@ -337,7 +357,7 @@ export function findChildren(
       continue;
     }
 
-    if (child.name === fullName || getLocalName(child.name || "") === localName) {
+    if (child.name === fullName || hasLocalName(child.name, localName)) {
       results.push(child);
     }
   }
@@ -365,7 +385,7 @@ export function findChildByLocalName(
       continue;
     }
 
-    if (getLocalName(child.name || "") === localName) {
+    if (hasLocalName(child.name, localName)) {
       return child;
     }
   }
@@ -389,7 +409,7 @@ export function findChildrenByLocalName(
   }
 
   return parent.elements.filter(
-    (child) => child.type === "element" && getLocalName(child.name || "") === localName,
+    (child) => child.type === "element" && hasLocalName(child.name, localName),
   );
 }
 
@@ -465,15 +485,16 @@ export function getAttribute(
 
   // Try with namespace prefix first
   if (namespace) {
-    const prefixedName = `${namespace}:${name}`;
-    if (prefixedName in attrs) {
-      return attrs[prefixedName] ?? null;
+    const prefixedValue = attrs[`${namespace}:${name}`];
+    if (prefixedValue !== undefined) {
+      return prefixedValue;
     }
   }
 
   // Try without namespace
-  if (name in attrs) {
-    return attrs[name] ?? null;
+  const unprefixedValue = attrs[name];
+  if (unprefixedValue !== undefined) {
+    return unprefixedValue;
   }
 
   // Fall back to any-prefix local-name match so alt-prefix producers keep
@@ -481,9 +502,8 @@ export function getAttribute(
   // namespaced attribute; if `namespace` is null the caller explicitly
   // wanted an unprefixed attribute.
   if (namespace) {
-    const suffix = `:${name}`;
-    for (const key of Object.keys(attrs)) {
-      if (key.endsWith(suffix)) {
+    for (const key in attrs) {
+      if (hasLocalName(key, name)) {
         return attrs[key] ?? null;
       }
     }
@@ -908,12 +928,15 @@ export function collectXmlnsDeclarations(element: XmlElement): Record<string, st
   if (!attrs) {
     return out;
   }
-  for (const [key, value] of Object.entries(attrs)) {
-    if (Object.keys(out).length >= MAX_XMLNS_DECLARATIONS_PER_ELEMENT) {
+  let declarationCount = 0;
+  for (const key in attrs) {
+    if (declarationCount >= MAX_XMLNS_DECLARATIONS_PER_ELEMENT) {
       break;
     }
+    const value = attrs[key];
     if ((key === "xmlns" || key.startsWith("xmlns:")) && value !== undefined) {
       out[key] = String(value);
+      declarationCount += 1;
     }
   }
   return out;
@@ -932,10 +955,10 @@ export function mergeXmlnsDeclarations(
   element: XmlElement,
 ): Record<string, string> {
   const own = collectXmlnsDeclarations(element);
-  if (Object.keys(own).length === 0) {
-    return inherited;
+  for (const _key in own) {
+    return { ...inherited, ...own };
   }
-  return { ...inherited, ...own };
+  return inherited;
 }
 
 /**
@@ -947,11 +970,11 @@ export function cloneWithXmlnsDeclarations(
   element: XmlElement,
   xmlnsDecls: Record<string, string>,
 ): XmlElement {
-  if (Object.keys(xmlnsDecls).length === 0) {
-    return element;
+  for (const _key in xmlnsDecls) {
+    return {
+      ...element,
+      attributes: { ...xmlnsDecls, ...element.attributes },
+    };
   }
-  return {
-    ...element,
-    attributes: { ...xmlnsDecls, ...element.attributes },
-  };
+  return element;
 }

--- a/packages/core/src/utils/docxInput.test.ts
+++ b/packages/core/src/utils/docxInput.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { toArrayBuffer } from "./docxInput";
+
+describe("toArrayBuffer", () => {
+  test("reuses an exact Uint8Array backing buffer", async () => {
+    const buffer = new ArrayBuffer(4);
+    const input = new Uint8Array(buffer);
+
+    const result = await toArrayBuffer(input);
+
+    expect(result).toBe(buffer);
+  });
+
+  test("copies only the bytes in a partial Uint8Array view", async () => {
+    const buffer = Uint8Array.from([1, 2, 3, 4]).buffer;
+    const input = new Uint8Array(buffer, 1, 2);
+
+    const result = await toArrayBuffer(input);
+
+    expect(result).not.toBe(buffer);
+    expect([...new Uint8Array(result)]).toEqual([2, 3]);
+  });
+
+  test("copies a Uint8Array backed by shared memory", async () => {
+    const buffer = new SharedArrayBuffer(3);
+    const input = new Uint8Array(buffer);
+    input.set([1, 2, 3]);
+
+    const result = await toArrayBuffer(input);
+
+    expect(result).toBeInstanceOf(ArrayBuffer);
+    expect([...new Uint8Array(result)]).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/src/utils/docxInput.ts
+++ b/packages/core/src/utils/docxInput.ts
@@ -23,7 +23,15 @@ export function toArrayBuffer(input: DocxInput): Promise<ArrayBuffer> {
     return Promise.resolve(input);
   }
   if (input instanceof Uint8Array) {
-    // Copy into a fresh ArrayBuffer (input may be a view over a larger or shared buffer)
+    if (
+      input.buffer instanceof ArrayBuffer &&
+      input.byteOffset === 0 &&
+      input.byteLength === input.buffer.byteLength
+    ) {
+      return Promise.resolve(input.buffer);
+    }
+
+    // Copy views over larger or shared buffers into an exact-size ArrayBuffer.
     const copy = new ArrayBuffer(input.byteLength);
     new Uint8Array(copy).set(input);
     return Promise.resolve(copy);


### PR DESCRIPTION
Batch independent DOCX entry extraction after validating the complete package, and avoid decompressing XML outside the parser-relevant package tree during the standard parse path while preserving the full-extraction API default.

Reuse exact input buffers, reduce namespace and local-name lookup allocations, and share the optimized lookup helper across content parsers. Regression coverage verifies bounded extraction behavior, arbitrary relationship-targeted headers and footers, exact-buffer reuse, partial/shared-buffer copies, and corpus round-trip fidelity.