### PR TITLE
perf: parse document XML in one pass

### DIFF
--- a/.changeset/quick-documents-parse.md
+++ b/.changeset/quick-documents-parse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Parse document XML with a faster single-pass path and compatibility fallback.

--- a/packages/core/src/docx/documentParser.ts
+++ b/packages/core/src/docx/documentParser.ts
@@ -26,6 +26,7 @@ import { parseBlockContent } from "./blockContentParser";
 import type { NumberingMap } from "./numberingParser";
 import { getParagraphText } from "./paragraphParser";
 import { parseSectionProperties, getDefaultSectionProperties } from "./sectionParser";
+import { parseStreamingXml } from "./streamingXmlParser";
 import type { StyleMap } from "./styleParser";
 import { parseXml, findChild, collectXmlnsDeclarations } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -209,7 +210,8 @@ export function parseDocumentBody(
   }
 
   // Parse XML
-  const doc = parseXml(xml);
+  const streamed = parseStreamingXml(xml);
+  const doc = streamed.status === "parsed" ? streamed.value : parseXml(xml);
 
   // Find root document element (w:document)
   const documentEl = (doc.elements ?? []).find(

--- a/packages/core/src/docx/streamingXmlParser.test.ts
+++ b/packages/core/src/docx/streamingXmlParser.test.ts
@@ -24,7 +24,7 @@ const XML_CASES = [
     </w:p>
   </w:body>
 </w:document>`,
-  "<document>\r\n  <body><p><![CDATA[raw <xml> & text]]></p></body>\r</document>",
+  "<document>\r\n  <body><p><![CDATA[raw <xml>\r\n&\rtext]]></p></body>\r</document>",
   "<document><text><![CDATA[first]]><!-- ignored -->second</text></document>",
   "<x:document><x:body><x:p/><x:tbl><x:tr><x:tc/></x:tr></x:tbl></x:body></x:document>",
 ] as const;

--- a/packages/core/src/docx/streamingXmlParser.test.ts
+++ b/packages/core/src/docx/streamingXmlParser.test.ts
@@ -38,10 +38,13 @@ describe("parseStreamingXml", () => {
   });
 
   test("falls back for declarations and malformed nesting outside its contract", () => {
+    const deeplyNested = `<document>${"<x>".repeat(101)}value${"</x>".repeat(101)}</document>`;
+
     expect(parseStreamingXml("<!DOCTYPE document><document/>").status).toBe("unsupported");
     expect(parseStreamingXml("<document><body></document>").status).toBe("unsupported");
     expect(parseStreamingXml("<document>&custom;</document>").status).toBe("unsupported");
     expect(parseStreamingXml('<document __proto__="unsafe"/>').status).toBe("unsupported");
+    expect(parseStreamingXml(deeplyNested).status).toBe("unsupported");
   });
 
   test("matches entity and line-ending behavior for generated values", () => {

--- a/packages/core/src/docx/streamingXmlParser.test.ts
+++ b/packages/core/src/docx/streamingXmlParser.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import JSZip from "jszip";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { parseStreamingXml } from "./streamingXmlParser";
+import { parseXml } from "./xmlParser";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../../..");
+const DOCUMENT_FIXTURE_GLOBS = [
+  "tests/visual/fixtures/*.docx",
+  "packages/core/src/docx/__fixtures__/*.docx",
+  "packages/core/src/docx/__tests__/__fixtures__/**/*.docx",
+] as const;
+
+const XML_CASES = [
+  `<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="urn:w">
+  <!-- ignored -->
+  <w:body>
+    <w:p data-one="&quot;&amp;&#65;&#x42;" data-two='apostrophe'>
+      <w:r><w:t xml:space="preserve"> text &lt; value </w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  "<document>\r\n  <body><p><![CDATA[raw <xml> & text]]></p></body>\r</document>",
+  "<document><text><![CDATA[first]]><!-- ignored -->second</text></document>",
+  "<x:document><x:body><x:p/><x:tbl><x:tr><x:tc/></x:tr></x:tbl></x:body></x:document>",
+] as const;
+
+describe("parseStreamingXml", () => {
+  test.each(XML_CASES)("matches the compatibility parser", (xml) => {
+    expect(parseStreamingXml(xml)).toEqual({
+      status: "parsed",
+      value: parseXml(xml),
+    });
+  });
+
+  test("falls back for declarations and malformed nesting outside its contract", () => {
+    expect(parseStreamingXml("<!DOCTYPE document><document/>").status).toBe("unsupported");
+    expect(parseStreamingXml("<document><body></document>").status).toBe("unsupported");
+    expect(parseStreamingXml("<document>&custom;</document>").status).toBe("unsupported");
+    expect(parseStreamingXml('<document __proto__="unsafe"/>').status).toBe("unsupported");
+  });
+
+  test("matches entity and line-ending behavior for generated values", () => {
+    const encodedToken = fc.constantFrom(
+      "text",
+      " ",
+      "\t",
+      "\r",
+      "\r\n",
+      "žluťoučký",
+      "日本語",
+      "&amp;",
+      "&apos;",
+      "&gt;",
+      "&lt;",
+      "&quot;",
+      "&#65;",
+      "&#x1F642;",
+    );
+
+    fc.assert(
+      fc.property(
+        fc.array(encodedToken, { maxLength: 40 }),
+        fc.array(encodedToken, { maxLength: 20 }),
+        (textTokens, attributeTokens) => {
+          const xml = `<document value="${attributeTokens.join("")}"><text>${textTokens.join(
+            "",
+          )}</text><empty/></document>`;
+          expect(parseStreamingXml(xml)).toEqual({
+            status: "parsed",
+            value: parseXml(xml),
+          });
+        },
+      ),
+      { numRuns: 250 },
+    );
+  });
+
+  test("matches the compatibility parser for every repository document body", async () => {
+    const paths: string[] = [];
+    for (const pattern of DOCUMENT_FIXTURE_GLOBS) {
+      paths.push(...new Bun.Glob(pattern).scanSync({ cwd: REPO_ROOT }));
+    }
+    expect(paths.length).toBeGreaterThan(30);
+
+    for (const path of paths) {
+      const zip = await JSZip.loadAsync(readFileSync(resolve(REPO_ROOT, path)));
+      const documentFile = zip.file("word/document.xml");
+      if (!documentFile) {
+        throw new Error(`Missing word/document.xml in ${path}`);
+      }
+      const xml = await documentFile.async("string");
+      expect(parseStreamingXml(xml), path).toEqual({
+        status: "parsed",
+        value: parseXml(xml),
+      });
+    }
+  });
+});

--- a/packages/core/src/docx/streamingXmlParser.ts
+++ b/packages/core/src/docx/streamingXmlParser.ts
@@ -1,0 +1,376 @@
+import type { XmlElement } from "./xmlParser";
+
+type ParseXmlResult = { status: "parsed"; value: XmlElement } | { status: "unsupported" };
+
+type ElementFrame = {
+  element: XmlElement;
+  name: string;
+};
+
+const BUILT_IN_ENTITIES = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"',
+} as const;
+
+/**
+ * Parse ordinary OOXML into Folio's existing element representation in one
+ * pass. Unsupported or malformed constructs return a sentinel so callers can
+ * retain the general-purpose parser as a compatibility fallback.
+ */
+export const parseStreamingXml = (xml: string): ParseXmlResult => {
+  const root: XmlElement = { elements: [] };
+  const stack: ElementFrame[] = [];
+  let cursor = 0;
+  let mergeAdjacentText = false;
+
+  while (cursor < xml.length) {
+    const open = xml.indexOf("<", cursor);
+    if (open === -1) {
+      if (!appendText(xml.slice(cursor), stack, mergeAdjacentText)) {
+        return { status: "unsupported" };
+      }
+      break;
+    }
+
+    if (open > cursor && !appendText(xml.slice(cursor, open), stack, mergeAdjacentText)) {
+      return { status: "unsupported" };
+    }
+    if (open > cursor) {
+      mergeAdjacentText = true;
+    }
+
+    if (xml.startsWith("<!--", open)) {
+      const close = xml.indexOf("-->", open + 4);
+      if (close === -1) {
+        return { status: "unsupported" };
+      }
+      cursor = close + 3;
+      continue;
+    }
+
+    if (xml.startsWith("<![CDATA[", open)) {
+      const close = xml.indexOf("]]>", open + 9);
+      if (close === -1 || !appendRawText(xml.slice(open + 9, close), stack)) {
+        return { status: "unsupported" };
+      }
+      cursor = close + 3;
+      mergeAdjacentText = false;
+      continue;
+    }
+
+    if (xml.startsWith("<?", open)) {
+      const close = xml.indexOf("?>", open + 2);
+      if (close === -1) {
+        return { status: "unsupported" };
+      }
+      cursor = close + 2;
+      continue;
+    }
+
+    if (xml.startsWith("<!", open)) {
+      return { status: "unsupported" };
+    }
+
+    const close = findTagClose(xml, open + 1);
+    if (close === -1) {
+      return { status: "unsupported" };
+    }
+
+    if (xml.charCodeAt(open + 1) === 47) {
+      const name = xml.slice(open + 2, close).trim();
+      const frame = stack.pop();
+      if (!frame || frame.name !== name) {
+        return { status: "unsupported" };
+      }
+      cursor = close + 1;
+      mergeAdjacentText = false;
+      continue;
+    }
+
+    const parsedTag = parseOpenTag(xml, open + 1, close);
+    if (parsedTag.status === "unsupported") {
+      return parsedTag;
+    }
+
+    const parent = stack.at(-1)?.element ?? root;
+    appendElement(parent, parsedTag.element);
+    if (!parsedTag.selfClosing) {
+      if (stack.length >= 100) {
+        return { status: "unsupported" };
+      }
+      stack.push({ element: parsedTag.element, name: parsedTag.name });
+    }
+    cursor = close + 1;
+    mergeAdjacentText = false;
+  }
+
+  if (stack.length > 0) {
+    return { status: "unsupported" };
+  }
+  return { status: "parsed", value: root };
+};
+
+type ParsedOpenTag =
+  | {
+      status: "parsed";
+      element: XmlElement;
+      name: string;
+      selfClosing: boolean;
+    }
+  | { status: "unsupported" };
+
+const parseOpenTag = (xml: string, start: number, close: number): ParsedOpenTag => {
+  let cursor = skipWhitespace(xml, start, close);
+  const nameStart = cursor;
+  cursor = scanName(xml, cursor, close);
+  if (cursor === nameStart) {
+    return { status: "unsupported" };
+  }
+
+  const name = xml.slice(nameStart, cursor);
+  if (isUnsafePropertyName(name)) {
+    return { status: "unsupported" };
+  }
+  let attributes: Record<string, string> | undefined;
+  let selfClosing = false;
+
+  while (cursor < close) {
+    cursor = skipWhitespace(xml, cursor, close);
+    if (cursor >= close) {
+      break;
+    }
+    if (xml.charCodeAt(cursor) === 47) {
+      selfClosing = true;
+      cursor = skipWhitespace(xml, cursor + 1, close);
+      if (cursor !== close) {
+        return { status: "unsupported" };
+      }
+      break;
+    }
+
+    const attributeNameStart = cursor;
+    cursor = scanName(xml, cursor, close);
+    if (cursor === attributeNameStart) {
+      return { status: "unsupported" };
+    }
+    const attributeName = xml.slice(attributeNameStart, cursor);
+    if (isUnsafePropertyName(attributeName)) {
+      return { status: "unsupported" };
+    }
+    cursor = skipWhitespace(xml, cursor, close);
+    if (xml.charCodeAt(cursor) !== 61) {
+      return { status: "unsupported" };
+    }
+    cursor = skipWhitespace(xml, cursor + 1, close);
+
+    const quote = xml.charCodeAt(cursor);
+    if (quote !== 34 && quote !== 39) {
+      return { status: "unsupported" };
+    }
+    const valueStart = cursor + 1;
+    cursor = xml.indexOf(quote === 34 ? '"' : "'", valueStart);
+    if (cursor === -1 || cursor > close) {
+      return { status: "unsupported" };
+    }
+    const decoded = decodeXmlEntities(normalizeLineEndings(xml.slice(valueStart, cursor)));
+    if (decoded === null) {
+      return { status: "unsupported" };
+    }
+    attributes ??= {};
+    attributes[attributeName] = decoded;
+    cursor += 1;
+  }
+
+  const element: XmlElement = { type: "element", name };
+  if (attributes) {
+    element.attributes = attributes;
+  }
+  return { status: "parsed", element, name, selfClosing };
+};
+
+const appendElement = (parent: XmlElement, child: XmlElement): void => {
+  parent.elements ??= [];
+  parent.elements.push(child);
+};
+
+const appendText = (text: string, stack: ElementFrame[], mergeAdjacentText: boolean): boolean => {
+  if (text.length === 0) {
+    return true;
+  }
+  const decoded = decodeXmlEntities(normalizeLineEndings(text));
+  if (decoded === null) {
+    return false;
+  }
+  const parent = stack.at(-1)?.element;
+  const previous = mergeAdjacentText ? parent?.elements?.at(-1) : undefined;
+  if (previous?.type === "text" && typeof previous.text === "string") {
+    previous.text += decoded;
+    return true;
+  }
+  return appendRawText(decoded, stack);
+};
+
+const appendRawText = (text: string, stack: ElementFrame[]): boolean => {
+  const parent = stack.at(-1)?.element;
+  if (!parent) {
+    return text.trim().length === 0;
+  }
+  appendElement(parent, { type: "text", text });
+  return true;
+};
+
+const findTagClose = (xml: string, start: number): number => {
+  let quote = 0;
+  for (let cursor = start; cursor < xml.length; cursor += 1) {
+    const code = xml.charCodeAt(cursor);
+    if (quote !== 0) {
+      if (code === quote) {
+        quote = 0;
+      }
+      continue;
+    }
+    if (code === 34 || code === 39) {
+      quote = code;
+      continue;
+    }
+    if (code === 62) {
+      return cursor;
+    }
+  }
+  return -1;
+};
+
+const skipWhitespace = (xml: string, start: number, limit: number): number => {
+  let cursor = start;
+  while (cursor < limit) {
+    const code = xml.charCodeAt(cursor);
+    if (code !== 9 && code !== 10 && code !== 13 && code !== 32) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+};
+
+const scanName = (xml: string, start: number, limit: number): number => {
+  let cursor = start;
+  while (cursor < limit) {
+    const code = xml.charCodeAt(cursor);
+    if (
+      code === 9 ||
+      code === 10 ||
+      code === 13 ||
+      code === 32 ||
+      code === 47 ||
+      code === 61 ||
+      code === 62
+    ) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+};
+
+const decodeXmlEntities = (value: string): string | null => {
+  const firstEntity = value.indexOf("&");
+  if (firstEntity === -1) {
+    return value;
+  }
+
+  const parts: string[] = [];
+  let cursor = 0;
+  let entityStart = firstEntity;
+  while (entityStart !== -1) {
+    parts.push(value.slice(cursor, entityStart));
+    const entityEnd = value.indexOf(";", entityStart + 1);
+    if (entityEnd === -1) {
+      return null;
+    }
+    const entity = value.slice(entityStart + 1, entityEnd);
+    const decoded = decodeXmlEntity(entity);
+    if (decoded === null) {
+      return null;
+    }
+    parts.push(decoded);
+    cursor = entityEnd + 1;
+    entityStart = value.indexOf("&", cursor);
+  }
+  parts.push(value.slice(cursor));
+  return parts.join("");
+};
+
+const normalizeLineEndings = (value: string): string => {
+  if (!value.includes("\r")) {
+    return value;
+  }
+  return value.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+};
+
+const decodeXmlEntity = (entity: string): string | null => {
+  switch (entity) {
+    case "amp":
+      return BUILT_IN_ENTITIES.amp;
+    case "apos":
+      return BUILT_IN_ENTITIES.apos;
+    case "gt":
+      return BUILT_IN_ENTITIES.gt;
+    case "lt":
+      return BUILT_IN_ENTITIES.lt;
+    case "quot":
+      return BUILT_IN_ENTITIES.quot;
+  }
+  if (entity.charCodeAt(0) !== 35) {
+    return null;
+  }
+
+  const hexadecimal = entity.charCodeAt(1) === 120 || entity.charCodeAt(1) === 88;
+  const digits = entity.slice(hexadecimal ? 2 : 1);
+  if (digits.length === 0 || !hasOnlyDigits(digits, hexadecimal)) {
+    return null;
+  }
+  const codePoint = Number.parseInt(digits, hexadecimal ? 16 : 10);
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint <= 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
+    return null;
+  }
+  return String.fromCodePoint(codePoint);
+};
+
+const hasOnlyDigits = (value: string, hexadecimal: boolean): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    const decimal = code >= 48 && code <= 57;
+    const lowerHex = hexadecimal && code >= 97 && code <= 102;
+    const upperHex = hexadecimal && code >= 65 && code <= 70;
+    if (!decimal && !lowerHex && !upperHex) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const isUnsafePropertyName = (name: string): boolean => {
+  switch (name) {
+    case "__defineGetter__":
+    case "__defineSetter__":
+    case "__lookupGetter__":
+    case "__lookupSetter__":
+    case "__proto__":
+    case "constructor":
+    case "hasOwnProperty":
+    case "prototype":
+    case "toString":
+    case "valueOf":
+      return true;
+    default:
+      return false;
+  }
+};

--- a/packages/core/src/docx/streamingXmlParser.ts
+++ b/packages/core/src/docx/streamingXmlParser.ts
@@ -53,7 +53,7 @@ export const parseStreamingXml = (xml: string): ParseXmlResult => {
 
     if (xml.startsWith("<![CDATA[", open)) {
       const close = xml.indexOf("]]>", open + 9);
-      if (close === -1 || !appendRawText(xml.slice(open + 9, close), stack)) {
+      if (close === -1 || !appendRawText(normalizeLineEndings(xml.slice(open + 9, close)), stack)) {
         return { status: "unsupported" };
       }
       cursor = close + 3;


### PR DESCRIPTION
## Summary

- parse ordinary document XML directly into Folio’s existing element model in one pass
- retain the general-purpose parser as a compatibility fallback for unsupported XML constructs
- verify exact tree parity across repository document fixtures and generated XML cases

## Validation

- formatting, lint, typecheck, unit tests, build, and packaged-consumer validation
- changeset and security audit
- document parser parity across the repository corpus
- interaction suite (22 passed, 2 expected skips; one unrelated Vue startup test passed on isolated rerun)