### PR TITLE
fix: stabilize whitespace-sensitive text round trips

### DIFF
--- a/.changeset/calm-runs-preserve.md
+++ b/.changeset/calm-runs-preserve.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep whitespace-sensitive text models stable across save and reopen.

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { getParagraphText, parseParagraph } from "./paragraphParser";
+import { serializeParagraph } from "./serializer/paragraphSerializer";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
 
@@ -255,6 +256,34 @@ describe("parseParagraph tracked-change hardening", () => {
     expect(paragraph.pPrMark).toBeDefined();
     expect(paragraph.pPrMark?.info.id).toBeLessThanOrEqual(2_147_483_647);
     expect(paragraph.pPrMark?.info.id).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("parseParagraph whitespace normalization", () => {
+  test("normalizes whitespace-sensitive text to a save/reopen fixed point", () => {
+    const parsed = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r>
+          <w:t> leading</w:t>
+          <w:t>trailing </w:t>
+          <w:t>two  spaces</w:t>
+        </w:r>
+      </w:p>
+    `);
+
+    const run = parsed.content.at(0);
+    expect(run?.type).toBe("run");
+    if (!run || run.type !== "run") {
+      return;
+    }
+    expect(run.content).toEqual([
+      { type: "text", text: " leading", preserveSpace: true },
+      { type: "text", text: "trailing ", preserveSpace: true },
+      { type: "text", text: "two  spaces", preserveSpace: true },
+    ]);
+
+    const serialized = serializeParagraph(parsed);
+    expect(parseParagraphXml(serialized)).toEqual(parsed);
   });
 });
 

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -58,6 +58,7 @@ import { parseShapeFromDrawing, shouldPreserveRawShapeDrawing } from "./shapePar
 import type { StyleMap } from "./styleParser";
 import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
+import { requiresXmlSpacePreserve } from "./textWhitespace";
 import {
   cloneWithXmlnsDeclarations,
   findAllDeep,
@@ -709,7 +710,8 @@ function parseRunPropertyChanges(
  */
 function parseTextContent(element: XmlElement): TextContent {
   const text = getTextContent(element);
-  const preserveSpace = getAttribute(element, "xml", "space") === "preserve";
+  const preserveSpace =
+    getAttribute(element, "xml", "space") === "preserve" || requiresXmlSpacePreserve(text);
 
   const content: TextContent = { type: "text", text };
   if (preserveSpace) {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -11,6 +11,7 @@
  */
 
 import { panic } from "better-result";
+import { normalizeRevisionId } from "@stll/docx-core/model";
 
 import type {
   Run,
@@ -37,7 +38,7 @@ import type {
   BlockContent,
   RunPropertyChange,
 } from "../../types/document";
-import { normalizeRevisionId } from "@stll/docx-core/model";
+import { requiresXmlSpacePreserve } from "../textWhitespace";
 import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
 import { isValidHexColor } from "../../utils/colorResolver";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: shape textboxes hold paragraphs, paragraphs hold runs
@@ -487,11 +488,7 @@ function serializeRunProperties(
  * Serialize text content (w:t)
  */
 function serializeTextContent(content: TextContent): string {
-  const needsPreserve =
-    content.preserveSpace ||
-    content.text.startsWith(" ") ||
-    content.text.endsWith(" ") ||
-    content.text.includes("  ");
+  const needsPreserve = content.preserveSpace || requiresXmlSpacePreserve(content.text);
 
   const spaceAttr = needsPreserve ? ' xml:space="preserve"' : "";
 

--- a/packages/core/src/docx/textWhitespace.ts
+++ b/packages/core/src/docx/textWhitespace.ts
@@ -1,0 +1,2 @@
+export const requiresXmlSpacePreserve = (text: string): boolean =>
+  text.startsWith(" ") || text.endsWith(" ") || text.includes("  ");


### PR DESCRIPTION
## Summary

- canonicalize whitespace-sensitive `w:t` nodes during parsing
- share the `xml:space="preserve"` predicate between parser and serializer
- add a synthetic save/reopen fixed-point regression test

## Validation

- `bun test packages/core/src/docx/paragraphParser.test.ts`
- `bun --filter @stll/folio-core typecheck`
- focused oxlint and oxfmt checks
- `bun run changeset:check`

## Risk

Low. The parsed model now records the same preservation state that serialization already inferred from leading, trailing, or repeated ASCII spaces.