### PR TITLE
fix: save URI-encoded image data URLs

### DIFF
--- a/.changeset/warm-pans-save.md
+++ b/.changeset/warm-pans-save.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Save URI-encoded SVG image data URLs without requiring base64 encoding.

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -12,6 +12,9 @@ const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 const ONE_PIXEL_PNG_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
+const URI_ENCODED_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+
 async function createHeaderFixture(): Promise<ArrayBuffer> {
   const zip = new JSZip();
   zip.file(
@@ -213,6 +216,47 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
 }
 
 describe("repackDocx", () => {
+  test("writes URI-encoded SVG data URLs as image parts", async () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    {
+                      type: "drawing",
+                      image: {
+                        type: "image",
+                        src: `data:image/svg+xml;charset=utf-8,${encodeURIComponent(URI_ENCODED_SVG)}`,
+                        filename: "shape.svg",
+                        alt: "Shape",
+                        size: { width: 95_250, height: 95_250 },
+                        wrap: { type: "inline" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const result = await createDocx(document);
+    const zip = await JSZip.loadAsync(result);
+
+    expect(await zip.file("word/media/image1.svg")?.async("text")).toBe(URI_ENCODED_SVG);
+    expect(await zip.file("word/document.xml")?.async("text")).toContain('r:embed="rId2"');
+    expect(await zip.file("[Content_Types].xml")?.async("text")).toContain(
+      'Extension="svg" ContentType="image/svg+xml"',
+    );
+  });
+
   test("reuses a sanitized source package while preserving later model edits", async () => {
     const sourceZip = await JSZip.loadAsync(await createHeaderFixture());
     sourceZip.file("word/vbaProject.bin", new Uint8Array([1, 2, 3]));

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -491,20 +491,28 @@ function decodeDataUrl(dataUrl: string): {
   data: ArrayBuffer;
   extension: string;
 } {
-  const match = /^data:(?<mime>[^;]+);base64,(?<data>.+)$/u.exec(dataUrl);
+  const match = /^data:(?<mime>[^;,]+)(?<parameters>(?:;[^,]*)?),(?<data>[\s\S]*)$/u.exec(dataUrl);
   if (!match) {
     panic("Invalid data URL");
   }
 
-  // SAFETY: named groups `mime` and `data` always present when regex matches
-  const binary = atob(match.groups!["data"]!);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.codePointAt(i) ?? 0;
+  // SAFETY: named groups are always present when the regex matches.
+  const payload = match.groups!["data"]!;
+  const parameters = match.groups!["parameters"]!;
+  let bytes: Uint8Array;
+  const isBase64 = parameters.split(";").some((parameter) => parameter.toLowerCase() === "base64");
+  if (isBase64) {
+    const binary = atob(payload);
+    bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.codePointAt(i) ?? 0;
+    }
+  } else {
+    bytes = new TextEncoder().encode(decodeURIComponent(payload));
   }
 
   return {
-    data: bytes.buffer,
+    data: bytes.slice().buffer,
     extension: MIME_TO_EXT[match.groups!["mime"]!] ?? "png",
   };
 }


### PR DESCRIPTION
## Summary

- accept URI-encoded image data URLs during DOCX save
- retain the existing base64 decoding path
- add a synthetic SVG package regression test

## Validation

- `bun test packages/core/src/docx/rezip.test.ts`
- `bun --filter @stll/folio-core typecheck`
- focused oxlint and oxfmt checks
- `bun run changeset:check`
- `bun audit`

## Risk

Low. The change is isolated to new image-part decoding; existing base64 data URLs retain their current path.