### PR TITLE
fix: preserve zero first-line paragraph indents

### DIFF
--- a/.changeset/calm-pens-indent.md
+++ b/.changeset/calm-pens-indent.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit zero first-line paragraph indents during DOCX saves.

--- a/packages/core/src/docx/serializer/paragraphSerializer-indentRoundtrip.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer-indentRoundtrip.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "../parser";
+import { createEmptyDocx, repackDocx } from "../rezip";
+
+const DOCUMENT_XML_PATH = "word/document.xml";
+
+describe("paragraph indentation round-trip", () => {
+  test("preserves an explicit zero first-line indent through a full save", async () => {
+    const zip = await JSZip.loadAsync(await createEmptyDocx());
+    zip.file(
+      DOCUMENT_XML_PATH,
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:ind w:firstLine="0"/></w:pPr>
+      <w:r><w:t>Paragraph</w:t></w:r>
+    </w:p>
+    <w:sectPr/>
+  </w:body>
+</w:document>`,
+    );
+    const originalBuffer = await zip.generateAsync({ type: "arraybuffer" });
+    const document = await parseDocx(originalBuffer, { preloadFonts: false });
+
+    expect(document.package.document.content.at(0)?.formatting?.indentFirstLine).toBe(0);
+
+    const saved = await repackDocx({ ...document, originalBuffer });
+    const reparsed = await parseDocx(saved, { preloadFonts: false });
+
+    expect(reparsed.package.document.content.at(0)?.formatting?.indentFirstLine).toBe(0);
+  });
+});

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -251,7 +251,7 @@ function serializeIndentation(formatting: ParagraphFormatting): string {
     if (formatting.hangingIndent) {
       // Hanging indent is stored as positive value but uses w:hanging attribute
       attrs.push(`w:hanging="${intAttr(Math.abs(formatting.indentFirstLine))}"`);
-    } else if (formatting.indentFirstLine !== 0) {
+    } else {
       attrs.push(`w:firstLine="${intAttr(formatting.indentFirstLine)}"`);
     }
   }


### PR DESCRIPTION
## Summary

- serialize an authored zero first-line indent instead of collapsing it to absence
- keep hanging-indent handling unchanged
- add a synthetic full-save round-trip regression

## Validation

- focused paragraph serializer and numbering tests
- `bun --filter @stll/folio-core typecheck`
- focused oxlint and oxfmt checks
- `bun run changeset:check`

## Risk

Low. The serializer now distinguishes an explicit zero value from an omitted first-line indent, matching the parser model.