### PR TITLE
fix: preserve explicit portrait orientation

### DIFF
--- a/.changeset/calm-lions-listen.md
+++ b/.changeset/calm-lions-listen.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit portrait section orientation when saving DOCX files.

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -193,4 +193,17 @@ describe("serializeSectionProperties", () => {
       '<w:sectPr><w15:footnoteColumns w:val="2"/></w:sectPr>',
     );
   });
+
+  test("round-trips an explicit portrait orientation", () => {
+    const section = parseSectPr(`
+      <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pgSz w:w="11906" w:h="16838" w:orient="portrait"/>
+      </w:sectPr>
+    `);
+
+    const serialized = serializeSectionProperties(section);
+
+    expect(serialized).toContain('w:orient="portrait"');
+    expect(parseSectPr(serialized).orientation).toBe("portrait");
+  });
 });

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -75,8 +75,8 @@ function serializePageSize(props: SectionProperties): string {
   if (props.pageHeight !== undefined) {
     attrs.push(`w:h="${intAttr(props.pageHeight)}"`);
   }
-  if (props.orientation === "landscape") {
-    attrs.push('w:orient="landscape"');
+  if (props.orientation !== undefined) {
+    attrs.push(`w:orient="${props.orientation}"`);
   }
   return attrs.length > 0 ? `<w:pgSz ${attrs.join(" ")}/>` : "";
 }


### PR DESCRIPTION
## Summary

- serialize an authored portrait section orientation instead of dropping it
- retain existing landscape behavior
- add a synthetic parse/serialize/reparse regression

## Validation

- `bun test packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts`
- `bun --filter @stll/folio-core typecheck`
- focused oxlint and oxfmt checks
- `bun run changeset:check`

## Risk

Low. The change preserves an explicit OOXML value that the parser already models.