### PR TITLE
fix: preserve explicit single-column sections

### DIFF
--- a/.changeset/tidy-coins-hear.md
+++ b/.changeset/tidy-coins-hear.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit single-column section counts when saving DOCX files.

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -206,4 +206,17 @@ describe("serializeSectionProperties", () => {
     expect(serialized).toContain('w:orient="portrait"');
     expect(parseSectPr(serialized).orientation).toBe("portrait");
   });
+
+  test("round-trips an explicit single-column count", () => {
+    const section = parseSectPr(`
+      <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:cols w:num="1"/>
+      </w:sectPr>
+    `);
+
+    const serialized = serializeSectionProperties(section);
+
+    expect(serialized).toContain('w:num="1"');
+    expect(parseSectPr(serialized).columnCount).toBe(1);
+  });
 });

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -122,12 +122,16 @@ function serializeColumns(props: SectionProperties): string {
   // A single-column section still carries its gutter as `<w:cols w:space=".."/>`,
   // so bail only when there is genuinely nothing to emit (no count, no explicit
   // columns, and no space) — otherwise the column spacing is dropped on save.
-  if (!props.columnCount && !props.columns?.length && props.columnSpace === undefined) {
+  if (
+    props.columnCount === undefined &&
+    !props.columns?.length &&
+    props.columnSpace === undefined
+  ) {
     return "";
   }
 
   const attrs: string[] = [];
-  if (props.columnCount !== undefined && props.columnCount > 1) {
+  if (props.columnCount !== undefined && props.columnCount >= 1) {
     attrs.push(`w:num="${intAttr(props.columnCount)}"`);
   }
   if (props.columnSpace !== undefined) {


### PR DESCRIPTION
## Summary

- serialize an authored single-column count instead of collapsing it to an implicit default
- retain current handling for absent and invalid counts
- add a synthetic parse/serialize/reparse regression

## Validation

- `bun test packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts`
- `bun --filter @stll/folio-core typecheck`
- focused oxlint and oxfmt checks
- `bun run changeset:check`

## Risk

Low. The serializer now preserves a positive OOXML count already represented by the parsed model.