### PR TITLE
fix: ignore negative list levels while parsing

### DIFF
--- a/.changeset/quiet-lists-parse.md
+++ b/.changeset/quiet-lists-parse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Ignore negative OOXML list levels instead of rejecting the document model.

--- a/packages/core/src/docx/numberingReferenceNormalization.test.ts
+++ b/packages/core/src/docx/numberingReferenceNormalization.test.ts
@@ -67,8 +67,20 @@ describe("normalizeNumberingReferences", () => {
     expect(documentBody.comments?.at(0)?.content.at(0)?.formatting?.numPr).toBeUndefined();
   });
 
+  test("ignores negative list levels when numbering is explicitly disabled", async () => {
+    const buffer = await createNumberingReferenceFixture({ ilvl: -1, numId: 0 });
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const block = doc.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(block.formatting?.numPr).toEqual({ numId: 0 });
+  });
+
   test("parses and saves documents that reference a missing numbering part", async () => {
-    const buffer = await createMissingNumberingReferenceFixture();
+    const buffer = await createNumberingReferenceFixture({ ilvl: 0, numId: 2 });
     const doc = await parseDocx(buffer, { preloadFonts: false });
     const block = doc.package.document.content.at(0);
 
@@ -98,7 +110,15 @@ describe("normalizeNumberingReferences", () => {
   });
 });
 
-const createMissingNumberingReferenceFixture = async (): Promise<ArrayBuffer> => {
+type NumberingReferenceFixtureOptions = {
+  ilvl: number;
+  numId: number;
+};
+
+const createNumberingReferenceFixture = async ({
+  ilvl,
+  numId,
+}: NumberingReferenceFixtureOptions): Promise<ArrayBuffer> => {
   const zip = new JSZip();
   zip.file(
     "[Content_Types].xml",
@@ -129,8 +149,8 @@ const createMissingNumberingReferenceFixture = async (): Promise<ArrayBuffer> =>
     <w:p>
       <w:pPr>
         <w:numPr>
-          <w:ilvl w:val="0"/>
-          <w:numId w:val="2"/>
+          <w:ilvl w:val="${ilvl}"/>
+          <w:numId w:val="${numId}"/>
         </w:numPr>
       </w:pPr>
       <w:r><w:t>Body</w:t></w:r>

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -70,6 +70,7 @@ import {
   getLocalName,
   mergeXmlnsDeclarations,
   parseBooleanElement,
+  parseNumberingLevelAttribute,
   parseNumericAttribute,
   elementToXml,
 } from "./xmlParser";
@@ -715,7 +716,7 @@ export function parseParagraphProperties(
       }
 
       if (ilvlEl) {
-        const val = parseNumericAttribute(ilvlEl, "w", "val");
+        const val = parseNumberingLevelAttribute(ilvlEl);
         if (val !== undefined) {
           formatting.numPr.ilvl = val;
         }

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -66,6 +66,7 @@ import {
   getAttribute,
   getLocalName,
   parseBooleanElement,
+  parseNumberingLevelAttribute,
   parseNumericAttribute,
   parseTableMeasurementValue,
 } from "./xmlParser";
@@ -750,7 +751,7 @@ function parseParagraphProperties(
         }
       }
       if (ilvl) {
-        const val = parseNumericAttribute(ilvl, "w", "val");
+        const val = parseNumberingLevelAttribute(ilvl);
         if (val !== undefined) {
           formatting.numPr.ilvl = val;
         }

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -744,6 +744,20 @@ export function parseNumericAttribute(
 }
 
 /**
+ * Parse a zero-based numbering level reference.
+ *
+ * OOXML numbering levels cannot be negative. Some producers emit negative
+ * sentinel values alongside `w:numId="0"` to disable numbering; treat those
+ * as an omitted level instead of leaking an invalid value into the model.
+ */
+export function parseNumberingLevelAttribute(
+  element: XmlElement | null | undefined,
+): number | undefined {
+  const level = parseNumericAttribute(element, "w", "val");
+  return level !== undefined && level >= 0 ? level : undefined;
+}
+
+/**
  * Parse `w:w` on a table width/height element. For `w:type="pct"`, producers
  * sometimes emit human-readable percentages (`100%`) instead of 50ths-of-percent
  * (`5000`); normalize those to the ECMA-376 unit the layout engine expects.


### PR DESCRIPTION
## Summary

- treat negative OOXML numbering levels as omitted values
- apply the normalization consistently to paragraph and style parsing
- add a synthetic parse regression for an explicit numbering-disabled sentinel

## Validation

- `bun test ./packages/core/src/docx/numberingReferenceNormalization.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX list parsing by safely ignoring negative list levels when numbering is disabled.
  * Prevented invalid negative numbering values from affecting document structure.

* **Tests**
  * Added coverage for documents containing negative list levels and varied numbering values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->