### PR TITLE
fix: stabilize captured VML namespaces

### DIFF
--- a/.changeset/curly-cats-smile.md
+++ b/.changeset/curly-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep captured VML run XML stable across repeated document round trips.

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -233,6 +233,18 @@ describe("VML w:pict inline images", () => {
     expect(zip.file("word/media/image1.png")).not.toBeNull();
   });
 
+  test("keeps captured VML XML stable after save and reopen", async () => {
+    const doc = await parseDocx(await pictDocx({ runXml: PICT_WITH_IMAGE }), {
+      preloadFonts: false,
+    });
+    const rawXml = firstDrawing(doc.package.document.content.at(0))?.rawXml;
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const reopened = await parseDocx(out, { preloadFonts: false });
+
+    expect(firstDrawing(reopened.package.document.content.at(0))?.rawXml).toBe(rawXml);
+  });
+
   test("parses an embedded object's VML preview with its authored dimensions", async () => {
     const doc = await parseDocx(await pictDocx({ runXml: OBJECT_WITH_PREVIEW }), {
       preloadFonts: false,

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -979,19 +979,92 @@ export function mergeXmlnsDeclarations(
   return inherited;
 }
 
+const QNAME_VALUE_ATTRIBUTES = new Set([
+  "Ignorable",
+  "PreserveAttributes",
+  "PreserveElements",
+  "ProcessContent",
+  "Requires",
+]);
+
+const addPrefix = (name: string, prefixes: Set<string>): void => {
+  const separatorIndex = name.indexOf(":");
+  if (separatorIndex > 0) {
+    prefixes.add(name.slice(0, separatorIndex));
+  }
+};
+
 /**
- * Return a shallow clone of `element` whose attributes carry every declaration
- * in `xmlnsDecls`. Existing attributes (including any namespace declarations the
- * element already carries) win over the injected ones.
+ * Collect namespace prefixes whose bindings a detached raw subtree needs.
+ *
+ * Element and attribute names use prefixes directly. Markup-compatibility and
+ * QName-valued attributes can also refer to prefixes in their values, so keep
+ * those bindings even when no descendant name uses them.
+ */
+const collectUsedNamespacePrefixes = (
+  element: XmlElement,
+  prefixes = new Set<string>(),
+): Set<string> => {
+  if (element.name) {
+    if (element.name.includes(":")) {
+      addPrefix(element.name, prefixes);
+    } else {
+      prefixes.add("");
+    }
+  }
+
+  if (element.attributes) {
+    for (const [name, value] of Object.entries(element.attributes)) {
+      if (name === "xmlns" || name.startsWith("xmlns:")) {
+        continue;
+      }
+      addPrefix(name, prefixes);
+      const localName = name.slice(name.indexOf(":") + 1);
+      if (name !== "xsi:type" && !QNAME_VALUE_ATTRIBUTES.has(localName)) {
+        continue;
+      }
+      for (const token of String(value).split(/\s+/u)) {
+        const separatorIndex = token.indexOf(":");
+        prefixes.add(separatorIndex > 0 ? token.slice(0, separatorIndex) : token);
+      }
+    }
+  }
+
+  if (element.elements) {
+    for (const child of element.elements) {
+      if (child.type === "element") {
+        collectUsedNamespacePrefixes(child, prefixes);
+      }
+    }
+  }
+  return prefixes;
+};
+
+/**
+ * Return a shallow clone of `element` carrying the inherited namespace
+ * declarations needed by its raw subtree.
+ *
+ * Existing declarations retain their authored order. Only missing, referenced
+ * bindings are appended, which makes repeated detach/replay cycles idempotent
+ * even when the surrounding document declares a different namespace superset.
  */
 export function cloneWithXmlnsDeclarations(
   element: XmlElement,
   xmlnsDecls: Record<string, string>,
 ): XmlElement {
-  for (const _key in xmlnsDecls) {
+  const prefixes = collectUsedNamespacePrefixes(element);
+  const additions: Record<string, string> = {};
+  const attributes = element.attributes ?? {};
+  for (const [name, value] of Object.entries(xmlnsDecls)) {
+    const prefix = name === "xmlns" ? "" : name.slice("xmlns:".length);
+    if (prefixes.has(prefix) && attributes[name] === undefined) {
+      additions[name] = value;
+    }
+  }
+  for (const _key in additions) {
     return {
       ...element,
-      attributes: { ...xmlnsDecls, ...element.attributes },
+      attributes: { ...attributes, ...additions },
     };
   }
   return element;


### PR DESCRIPTION
## Summary

- retain only namespace declarations referenced by detached VML subtrees
- preserve authored declaration order while appending missing inherited bindings
- add a synthetic save/reopen fixed-point regression

## Validation

- `bun test ./packages/core/src/docx/vmlImageParser.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`
- dependency audit: no vulnerabilities