### PR TITLE
fix: normalize default tab leaders

### DIFF
--- a/.changeset/quiet-tabs-rest.md
+++ b/.changeset/quiet-tabs-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize the default paragraph tab leader during DOCX parsing.

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -287,6 +287,30 @@ describe("parseParagraph whitespace normalization", () => {
   });
 });
 
+describe("parseParagraph tab leader normalization", () => {
+  test("normalizes the default leader to a save/reopen fixed point", () => {
+    const parsed = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:tabs>
+            <w:tab w:val="left" w:pos="720" w:leader="none"/>
+            <w:tab w:val="right" w:pos="1440" w:leader="dot"/>
+          </w:tabs>
+        </w:pPr>
+        <w:r><w:t>text</w:t></w:r>
+      </w:p>
+    `);
+
+    expect(parsed.formatting.tabs).toEqual([
+      { position: 720, alignment: "left" },
+      { position: 1440, alignment: "right", leader: "dot" },
+    ]);
+
+    const serialized = serializeParagraph(parsed);
+    expect(parseParagraphXml(serialized)).toEqual(parsed);
+  });
+});
+
 describe("parseParagraph rendered page break markers", () => {
   test("marks a paragraph when Word rendered-page-break appears before visible text", () => {
     const paragraph = parseParagraphXml(`

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -272,7 +272,7 @@ function parseTabStops(tabs: XmlElement | null): TabStop[] | undefined {
       };
 
       const leader = narrowEnum(getAttribute(tab, "w", "leader"), TabLeaderSchema);
-      if (leader) {
+      if (leader && leader !== "none") {
         tabStop.leader = leader;
       }
 

--- a/packages/core/src/docx/styleParser.test.ts
+++ b/packages/core/src/docx/styleParser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { serializeStylesXml } from "./serializer/stylesSerializer";
 import { parseStyleDefinitions, parseStyles } from "./styleParser";
 
 const STYLES_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
@@ -40,6 +41,33 @@ describe("docDefaults presence (#909)", () => {
       eastAsia: "ja-JP",
       bidi: "ar-SA",
     });
+  });
+});
+
+describe("style tab leader normalization", () => {
+  test("normalizes the default leader to a save/reopen fixed point", () => {
+    const parsed = parseStyleDefinitions(
+      `<w:styles ${STYLES_NS}>
+        <w:docDefaults><w:pPrDefault><w:pPr/></w:pPrDefault></w:docDefaults>
+        <w:style w:type="paragraph" w:styleId="BodyText">
+          <w:name w:val="Body Text"/>
+          <w:pPr>
+            <w:tabs>
+              <w:tab w:val="left" w:pos="720" w:leader="none"/>
+              <w:tab w:val="right" w:pos="1440" w:leader="dot"/>
+            </w:tabs>
+          </w:pPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+
+    expect(parsed.styles.at(0)?.pPr?.tabs).toEqual([
+      { position: 720, alignment: "left" },
+      { position: 1440, alignment: "right", leader: "dot" },
+    ]);
+
+    expect(parseStyleDefinitions(serializeStylesXml(parsed), null)).toEqual(parsed);
   });
 });
 

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -555,7 +555,7 @@ function parseTabStops(tabs: XmlElement | null): TabStop[] | undefined {
       };
 
       const leader = narrowEnum(getAttribute(tab, "w", "leader"), TabLeaderSchema);
-      if (leader) {
+      if (leader && leader !== "none") {
         tabStop.leader = leader;
       }
 


### PR DESCRIPTION
## Summary

- normalize explicit default tab leaders to the canonical omitted state
- apply the same invariant to direct paragraph formatting and styles
- add synthetic save/reopen fixed-point regressions

## Validation

- `bun test ./packages/core/src/docx/paragraphParser.test.ts ./packages/core/src/docx/styleParser.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`
- dependency audit: no vulnerabilities