### PR TITLE
fix: preserve explicitly empty shape names

### DIFF
--- a/.changeset/lucky-fans-smile.md
+++ b/.changeset/lucky-fans-smile.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicitly authored empty shape names when saving DOCX files.

--- a/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
@@ -193,4 +193,34 @@ describe("shape parse → serialize round-trip", () => {
     const reopenedShape = reopenedDrawing ? parseShapeFromDrawing(reopenedDrawing) : null;
     expect(reopenedShape?.outline?.style).toBe("solid");
   });
+
+  test("preserves an explicitly authored empty shape name", () => {
+    const root = parseXmlDocument(
+      shapeDrawingXml({ prst: "line" }).replaceAll('name="Shape 9"', 'name=""'),
+    );
+    const shape = root ? parseShapeFromDrawing(root) : null;
+    expect(shape?.name).toBe("");
+    if (!shape) {
+      return;
+    }
+
+    const xml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape }],
+    });
+    expect(xml).toContain('<wp:docPr id="9" name=""/>');
+
+    const reopenedRoot = parseXmlDocument(xml);
+    const reopenedDrawing = findDeep(reopenedRoot, "w", "drawing");
+    const reopenedShape = reopenedDrawing ? parseShapeFromDrawing(reopenedDrawing) : null;
+    expect(reopenedShape?.name).toBe("");
+
+    const shapeWithoutName = { ...shape };
+    delete shapeWithoutName.name;
+    const fallbackXml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape: shapeWithoutName }],
+    });
+    expect(fallbackXml).toContain('<wp:docPr id="9" name="Shape 9"/>');
+  });
 });

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -918,7 +918,7 @@ function serializeShapeContent(content: ShapeContent): string {
   const distL = shape.wrap?.distL ?? 0;
   const distR = shape.wrap?.distR ?? 0;
   const docPrId = getUniqueId(shape.id);
-  const docPrName = shape.name || (isTextBox ? `TextBox ${docPrId}` : `Shape ${docPrId}`);
+  const docPrName = shape.name ?? (isTextBox ? `TextBox ${docPrId}` : `Shape ${docPrId}`);
 
   // Build xfrm
   let xfrmAttrs = "";


### PR DESCRIPTION
## Summary

- distinguish an absent shape name from an explicitly empty authored name
- retain the generated fallback only for missing names
- add a focused synthetic round-trip regression

## Validation

- `bun test ./packages/core/src/docx/__tests__/shape-roundtrip.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`
- dependency audit: no vulnerabilities