### PR TITLE
fix: stabilize untouched picture watermark headers

### DIFF
--- a/.changeset/fuzzy-trees-wave.md
+++ b/.changeset/fuzzy-trees-wave.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep untouched picture watermark headers byte-stable when documents are saved.

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -43,6 +43,7 @@ import { parseCoreProperties } from "./corePropertiesParser";
 import { parseDocumentBody, extractAllTemplateVariables } from "./documentParser";
 import { parseFootnotes, parseEndnotes } from "./footnoteParser";
 import { parseHeader, parseFooter } from "./headerFooterParser";
+import { assignHeaderFooterVerbatimXml } from "./headerFooterVerbatim";
 import { normalizeHeaderFooterReferences } from "./headerFooterReferenceNormalization";
 import {
   DocxModelValidationError,
@@ -649,6 +650,10 @@ function parseHeadersAndFooters(
               watermark.imageTarget = resolveRelativePath(headerRelsPath, imageRel.target);
             }
           }
+          // parseHeader fingerprints the modeled fields before the package-level
+          // image target can be resolved. Refresh it after adding that derived
+          // target so an untouched header remains eligible for verbatim replay.
+          assignHeaderFooterVerbatimXml(header, headerXml);
         }
         headers.set(rId, header);
       }

--- a/packages/core/src/docx/pictureWatermarkRebind.test.ts
+++ b/packages/core/src/docx/pictureWatermarkRebind.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import { getDocumentWatermark, setDocumentWatermark } from "../watermark";
+import { canReplayHeaderFooterVerbatim, getHeaderFooterVerbatimXml } from "./headerFooterVerbatim";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { createEmptyDocx, repackDocx, validateDocx } from "./rezip";
@@ -100,6 +101,33 @@ const countMediaImages = async (zip: JSZip): Promise<number> =>
   Object.keys(zip.files).filter((p) => /^word\/media\/image/u.test(p)).length;
 
 describe("picture watermark relationship rebinding (eigenpal #684)", () => {
+  test("keeps an untouched picture watermark header byte-stable after save and reopen", async () => {
+    const doc = await parseDocx(await twoHeaderPictureWatermarkDocx(), {
+      preloadFonts: false,
+    });
+    const header = doc.package.headers?.get("rId10");
+    expect(header).toBeDefined();
+    if (!header) {
+      return;
+    }
+    const sourceXml = getHeaderFooterVerbatimXml(header);
+
+    expect(sourceXml).toBeDefined();
+    expect(canReplayHeaderFooterVerbatim(header)).toBe(true);
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const outZip = await JSZip.loadAsync(out);
+    expect(await outZip.file("word/header1.xml")?.async("text")).toBe(sourceXml);
+
+    const reopened = await parseDocx(out, { preloadFonts: false });
+    const reopenedHeader = reopened.package.headers?.get("rId10");
+    expect(reopenedHeader).toBeDefined();
+    if (!reopenedHeader) {
+      return;
+    }
+    expect(reopenedHeader.rawWatermarkXml).toBe(header.rawWatermarkXml);
+    expect(getHeaderFooterVerbatimXml(reopenedHeader)).toBe(sourceXml);
+  });
+
   test("setDocumentWatermark spans multiple headers without throwing and clones per header", async () => {
     const doc = await parseDocx(await twoHeaderPictureWatermarkDocx(), {
       preloadFonts: false,


### PR DESCRIPTION
## Summary

- refresh the untouched-header fingerprint after resolving picture watermark targets
- avoid treating package-level relationship enrichment as a user edit
- add a synthetic byte-stability save regression

## Validation

- `bun test ./packages/core/src/docx/pictureWatermarkRebind.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`
- dependency audit: no vulnerabilities