### PR TITLE
fix: preserve clickable image hyperlinks

### DIFF
--- a/.changeset/fuzzy-images-link.md
+++ b/.changeset/fuzzy-images-link.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve clickable image hyperlinks across DOCX save and reopen.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -147,6 +147,7 @@ export type ImageAttrs = {
     borderStyle?: string;
     wrapText?: NonNullable<import__stll_docx_core_model.ImageWrap["wrapText"]>;
     hlinkHref?: string;
+    hlinkRId?: string;
     _docxRawXml?: string;
     _docxObjectPreview?: boolean;
 };

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -232,6 +232,7 @@ export type ImageAttrs = {
     borderStyle?: string;
     wrapText?: NonNullable<import__stll_docx_core_model.ImageWrap["wrapText"]>;
     hlinkHref?: string;
+    hlinkRId?: string;
     _docxRawXml?: string;
     _docxObjectPreview?: boolean;
 };

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -402,6 +402,7 @@ type Image_2 = {
     allowOverlap?: boolean;
     decorative?: boolean;
     hlinkHref?: string;
+    hlinkRId?: string;
     outline?: ShapeOutline;
     effects?: {
         brightness?: number;

--- a/packages/core/src/docx/imageParser.ts
+++ b/packages/core/src/docx/imageParser.ts
@@ -660,6 +660,7 @@ function parseInline(
     const safeHref = sanitizeExternalUrl(href);
     if (safeHref) {
       image.hlinkHref = safeHref;
+      image.hlinkRId = props.hlinkRId;
     }
   }
 
@@ -808,6 +809,7 @@ function parseAnchor(
     const safeHref = sanitizeExternalUrl(href);
     if (safeHref) {
       image.hlinkHref = safeHref;
+      image.hlinkRId = props.hlinkRId;
     }
   }
 

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
-import type { Document } from "../types/document";
+import type { Document, Image } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { createDocx, DocxPackageFidelityError, repackDocx } from "./rezip";
@@ -142,6 +142,80 @@ async function createAlternateContentImageFixture(): Promise<ArrayBuffer> {
   return zip.generateAsync({ type: "arraybuffer" });
 }
 
+async function createHyperlinkedImageFixture(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId5" Type="${RELATIONSHIP_TYPES.image}" Target="media/image1.png"/>
+  <Relationship Id="rId6" Type="${RELATIONSHIP_TYPES.hyperlink}" Target="https://example.test/guide" TargetMode="External"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:drawing>
+          <wp:inline>
+            <wp:extent cx="9525" cy="9525"/>
+            <wp:docPr id="7" name="image1.png"><a:hlinkClick r:id="rId6"/></wp:docPr>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic>
+                  <pic:nvPicPr><pic:cNvPr id="7" name="image1.png"/><pic:cNvPicPr/></pic:nvPicPr>
+                  <pic:blipFill><a:blip r:embed="rId5"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>
+                  <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="9525" cy="9525"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  zip.file("word/media/image1.png", new Uint8Array([1, 2, 3, 4]));
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+function getFirstImage(document: Document): Image {
+  const paragraph = document.package.document.content.at(0);
+  if (!paragraph || paragraph.type !== "paragraph") {
+    throw new Error("expected a paragraph");
+  }
+  const run = paragraph.content.at(0);
+  if (!run || run.type !== "run") {
+    throw new Error("expected a run");
+  }
+  const drawing = run.content.at(0);
+  if (!drawing || drawing.type !== "drawing") {
+    throw new Error("expected a drawing");
+  }
+  return drawing.image;
+}
+
 async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer> {
   const zip = new JSZip();
   zip.file(
@@ -216,6 +290,29 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
 }
 
 describe("repackDocx", () => {
+  test("preserves clickable image hyperlinks across full save and reopen", async () => {
+    const parsed = await parseDocx(await createHyperlinkedImageFixture(), {
+      preloadFonts: false,
+    });
+    expect(getFirstImage(parsed)).toMatchObject({
+      hlinkHref: "https://example.test/guide",
+      hlinkRId: "rId6",
+    });
+
+    const saved = await repackDocx(parsed, { updateModifiedDate: false });
+    const savedZip = await JSZip.loadAsync(saved);
+    expect(await savedZip.file("word/document.xml")?.async("text")).toContain(
+      '<a:hlinkClick r:id="rId6"/>',
+    );
+
+    const reopened = await parseDocx(saved, { preloadFonts: false });
+    expect(getFirstImage(reopened)).toMatchObject({
+      hlinkHref: "https://example.test/guide",
+      hlinkRId: "rId6",
+    });
+    expect(reopened.package.document.content).toEqual(parsed.package.document.content);
+  });
+
   test("writes URI-encoded SVG data URLs as image parts", async () => {
     const document: Document = {
       package: {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -846,6 +846,15 @@ function serializeDrawingContent(content: DrawingContent): string {
   const effectExtentEl = `<wp:effectExtent l="${intAttr(effL)}" t="${intAttr(effT)}" r="${intAttr(effR)}" b="${intAttr(effB)}"/>`;
   const docPrId = getUniqueId(image.id);
   const docPrName = image.title || image.filename || `Picture ${docPrId}`;
+  const hlinkClick = image.hlinkRId ? `<a:hlinkClick r:id="${escapeXml(image.hlinkRId)}"/>` : "";
+  const inlineDocPrAttrs = `id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}${image.decorative ? ' hidden="1"' : ""}`;
+  const inlineDocPr = hlinkClick
+    ? `<wp:docPr ${inlineDocPrAttrs}>${hlinkClick}</wp:docPr>`
+    : `<wp:docPr ${inlineDocPrAttrs}/>`;
+  const anchorDocPrAttrs = `id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}`;
+  const anchorDocPr = hlinkClick
+    ? `<wp:docPr ${anchorDocPrAttrs}>${hlinkClick}</wp:docPr>`
+    : `<wp:docPr ${anchorDocPrAttrs}/>`;
 
   const graphic = serializePicGraphic(image, docPrId);
 
@@ -856,7 +865,7 @@ function serializeDrawingContent(content: DrawingContent): string {
       `<wp:inline distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}">`,
       `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
       effectExtentEl,
-      `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}${image.decorative ? ' hidden="1"' : ""}/>`,
+      inlineDocPr,
       '<wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/></wp:cNvGraphicFramePr>',
       graphic,
       "</wp:inline>",
@@ -883,7 +892,7 @@ function serializeDrawingContent(content: DrawingContent): string {
     `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
     effectExtentEl,
     wrap,
-    `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}/>`,
+    anchorDocPr,
     '<wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/></wp:cNvGraphicFramePr>',
     graphic,
     "</wp:anchor>",

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -548,6 +548,7 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
   optionalString(attrs, "borderStyle", "image.attrs.borderStyle", issues);
   optionalOneOf(attrs, "wrapText", "image.attrs.wrapText", issues, IMAGE_WRAP_TEXT_VALUES);
   optionalString(attrs, "hlinkHref", "image.attrs.hlinkHref", issues);
+  optionalString(attrs, "hlinkRId", "image.attrs.hlinkRId", issues);
   optionalString(attrs, "_docxRawXml", "image.attrs._docxRawXml", issues);
   optionalBoolean(attrs, "_docxObjectPreview", "image.attrs._docxObjectPreview", issues);
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2203,6 +2203,9 @@ function createImageRun(node: PMNode): Run {
   if (attrs.hlinkHref) {
     image.hlinkHref = attrs.hlinkHref;
   }
+  if (attrs.hlinkRId) {
+    image.hlinkRId = attrs.hlinkRId;
+  }
 
   // eigenpal #424: fold crop fractions back into Image.crop. PM defaults are
   // `null`, so `!= null` catches both null and undefined; zero sides are

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2609,6 +2609,7 @@ function convertImage(image: Image, rawXml?: string): PMNode {
     borderStyle,
     wrapText,
     hlinkHref: image.hlinkHref,
+    hlinkRId: image.hlinkRId,
     _docxRawXml: rawXml,
     _docxObjectPreview:
       rawXml !== undefined && /<(?:[A-Za-z_][\w.-]*:)?object(?:\s|>)/u.test(rawXml),

--- a/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -41,6 +41,7 @@ export const ImageExtension = createNodeExtension({
       borderStyle: { default: null },
       wrapText: { default: null },
       hlinkHref: { default: null },
+      hlinkRId: { default: null },
       _docxRawXml: { default: null },
       _docxObjectPreview: { default: null },
     },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -331,6 +331,8 @@ export type ImageAttrs = {
   wrapText?: NonNullable<ImageWrap["wrapText"]>;
   /** Hyperlink URL for clickable image */
   hlinkHref?: string;
+  /** DOCX relationship ID for the clickable image hyperlink */
+  hlinkRId?: string;
   /** Original OOXML for opaque/unsupported DOCX drawings. */
   _docxRawXml?: string;
   /** Embedded-object previews use their authored box as the exact line height. */

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -484,6 +484,8 @@ export type Image = {
   decorative?: boolean;
   /** Hyperlink URL for clickable image */
   hlinkHref?: string;
+  /** Relationship ID for the clickable image hyperlink */
+  hlinkRId?: string;
   /** Image outline/border */
   outline?: ShapeOutline;
   /** Image effects */


### PR DESCRIPTION
## Summary

- retain a sanitized image hyperlink relationship ID during parsing
- carry the relationship through ProseMirror conversion
- serialize clickable-image metadata for inline and anchored images
- add a synthetic full-save/reopen fixed-point regression

## Validation

- `bun test ./packages/core/src/docx/rezip.test.ts`
- `bun run build`
- `bun run api:check`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`
- dependency audit: no vulnerabilities