### PR TITLE
fix: preserve table row conditional formatting

### DIFF
--- a/.changeset/soft-rows-style.md
+++ b/.changeset/soft-rows-style.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve conditional table-row formatting across DOCX save and reopen.

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -484,6 +484,11 @@ export function serializeTableRowFormatting(
   const parts: string[] = [];
 
   if (formatting) {
+    const cnfStyleXml = serializeConditionalFormatStyle(formatting.conditionalFormat);
+    if (cnfStyleXml) {
+      parts.push(cnfStyleXml);
+    }
+
     if (formatting.gridBefore) {
       parts.push(`<w:gridBefore w:val="${intAttr(formatting.gridBefore)}"/>`);
     }

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -130,6 +130,25 @@ describe("table row grid offsets", () => {
   });
 });
 
+describe("table row conditional formatting", () => {
+  test("round-trips conditional table-style flags", () => {
+    const root = parseXmlDocument(
+      `<w:trPr ${NS}><w:cnfStyle w:val="100000100000"/></w:trPr>`,
+    ) as XmlElement;
+    const formatting = parseTableRowProperties(root);
+
+    expect(formatting).toEqual({
+      conditionalFormat: {
+        firstRow: true,
+        oddHBand: true,
+      },
+    });
+
+    const serialized = serializeTableRowFormatting(formatting);
+    expect(parseTableRowProperties(parseXmlDocument(serialized))).toEqual(formatting);
+  });
+});
+
 describe("inferImplicitSingleCellRowSpans", () => {
   test("does not expand a vMerge continuation single-cell row", () => {
     const table = parseTableXml(`<w:tbl ${NS}>


### PR DESCRIPTION
## Summary

- serialize table-row conditional style flags through the existing canonical bitmask helper
- preserve row formatting when conditional flags are the only authored row property
- add a synthetic parse/serialize/reparse regression

## Validation

- `bun test ./packages/core/src/docx/tableParser.test.ts`
- `bun run test`
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run format`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`
- dependency audit: no vulnerabilities