### PR TITLE
fix: preserve absent shape fills

### DIFF
--- a/.changeset/wise-shirts-juggle.md
+++ b/.changeset/wise-shirts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve the distinction between absent and explicitly disabled shape fills.

--- a/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
@@ -130,6 +130,38 @@ describe("shape parse → serialize round-trip", () => {
     expect(xml).toContain('<a:path path="circle"/>');
   });
 
+  test("distinguishes an absent fill from an explicit no-fill", () => {
+    const root = parseXmlDocument(shapeDrawingXml({ prst: "rect" }));
+    const shape = root ? parseShapeFromDrawing(root) : null;
+    expect(shape?.fill).toBeUndefined();
+    if (!shape) {
+      return;
+    }
+
+    const xml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape }],
+    });
+    expect(xml).not.toContain("<a:noFill/>");
+
+    const reopenedRoot = parseXmlDocument(xml);
+    const reopenedDrawing = findDeep(reopenedRoot, "w", "drawing");
+    const reopenedShape = reopenedDrawing ? parseShapeFromDrawing(reopenedDrawing) : null;
+    expect(reopenedShape?.fill).toBeUndefined();
+
+    const noFillRoot = parseXmlDocument(shapeDrawingXml({ prst: "rect", fill: "<a:noFill/>" }));
+    const noFillShape = noFillRoot ? parseShapeFromDrawing(noFillRoot) : null;
+    expect(noFillShape?.fill).toEqual({ type: "none" });
+    if (!noFillShape) {
+      return;
+    }
+    const noFillXml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape: noFillShape }],
+    });
+    expect(noFillXml).toContain("<a:noFill/>");
+  });
+
   test("preserves anchored wrap type", () => {
     const root = parseXmlDocument(shapeDrawingXml({ prst: "rightArrow", anchor: true }));
     const shape = root ? parseShapeFromDrawing(root) : null;

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -614,7 +614,10 @@ function serializeDrawingColor(color: ColorValue | undefined): string {
 
 /** Serialize shape fill to DrawingML */
 function serializeFill(fill: ShapeFill | undefined): string {
-  if (!fill || fill.type === "none") {
+  if (!fill) {
+    return "";
+  }
+  if (fill.type === "none") {
     return "<a:noFill/>";
   }
   if (fill.type === "solid" && fill.color) {


### PR DESCRIPTION
## Summary

- preserve the distinction between an absent DrawingML shape fill and an explicit no-fill
- avoid emitting a:noFill when the source shape inherits its fill
- add a synthetic parse/serialize/reparse regression for both states

## Validation

- focused shape round-trip tests
- full unit suite
- typecheck and lint
- formatting check
- build and package validation
- changeset check
- dependency audit

CC on behalf of @jan-kubica