### PR TITLE
fix: skip raw drawing previews during image packaging

### DIFF
--- a/.changeset/calm-donkeys-smile.md
+++ b/.changeset/calm-donkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Avoid creating unused image parts for raw OOXML drawing previews.

--- a/packages/core/src/docx/newImage.ts
+++ b/packages/core/src/docx/newImage.ts
@@ -1,0 +1,15 @@
+import type { DrawingContent, RunContent } from "../types/content";
+
+const SYNTHETIC_IMAGE_RID_PREFIX = "rId_img_";
+
+/**
+ * A drawing needs a new package image part only when it is model-driven.
+ *
+ * Raw OOXML drawings can carry data-URL previews for browser rendering, but
+ * save replays their raw XML instead of serializing the preview image.
+ */
+export const isNewDataUrlDrawing = (content: RunContent): content is DrawingContent =>
+  content.type === "drawing" &&
+  !content.rawXml &&
+  content.image.src?.startsWith("data:") === true &&
+  (!content.image.rId || content.image.rId.startsWith(SYNTHETIC_IMAGE_RID_PREFIX));

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -32,12 +32,13 @@
 import { panic } from "better-result";
 import JSZip from "jszip";
 
-import type { BlockContent, Comment, HeaderFooter, Image, Hyperlink } from "../types/content";
+import type { BlockContent, Comment, HeaderFooter, Image, Hyperlink, Run } from "../types/content";
 import type { Document, Watermark } from "../types/document";
 import { applyReplyThreadMarkers } from "./commentReplyMarkers";
 import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 import { parseEndnotes, parseFootnotes } from "./footnoteParser";
 import { assertValidFolioDocumentModel } from "./modelValidation";
+import { isNewDataUrlDrawing } from "./newImage";
 import { parseNumbering } from "./numberingParser";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import {
@@ -417,24 +418,12 @@ async function registerImageExtensions(
   });
 }
 
-/**
- * Collect all newly inserted images with data-URL src from the document content.
- * Existing DOCX images may also have a resolved data URL for preview; those must
- * continue to reference their original media part. Editor-created images use a
- * synthetic rId until they are assigned a real DOCX relationship here.
- */
-const SYNTHETIC_IMAGE_RID_PREFIX = "rId_img_";
-
-const isNewDataUrlImage = (image: Image) =>
-  image.src?.startsWith("data:") &&
-  (!image.rId || image.rId.startsWith(SYNTHETIC_IMAGE_RID_PREFIX));
-
 function collectNewImages(blocks: BlockContent[]): Image[] {
   const images: Image[] = [];
 
-  const collectFromRun = (run: { content: { type: string; image?: Image }[] }): void => {
+  const collectFromRun = (run: Run): void => {
     for (const c of run.content) {
-      if (c.type === "drawing" && c.image && isNewDataUrlImage(c.image)) {
+      if (isNewDataUrlDrawing(c)) {
         images.push(c.image);
       }
     }

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -10,11 +10,13 @@
 
 import type JSZip from "jszip";
 
+import type { Run } from "../types/content";
 import type { Document, BlockContent, Comment } from "../types/document";
 import { parseCommentsExtended, type CommentExtendedInfo } from "./commentParser";
 import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 import { hasUnsynthesizedReplyRanges } from "./commentReplyMarkers";
 import { validateFolioDocumentModel } from "./modelValidation";
+import { isNewDataUrlDrawing } from "./newImage";
 import { parseNumbering } from "./numberingParser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { isPreservableDocxEntry } from "./unzip";
@@ -48,23 +50,13 @@ import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
 import { serializeNumberingXml } from "./serializer/numberingSerializer";
 
-const SYNTHETIC_IMAGE_RID_PREFIX = "rId_img_";
-
 /**
  * Check if document content has new images (data: URL without rId) or
  * new hyperlinks (href without rId). Combined into a single traversal
  * to avoid walking the block tree twice.
  */
 function hasNewImagesOrHyperlinks(blocks: BlockContent[]): boolean {
-  const runHasNewImage = (run: {
-    content: { type: string; image?: { src?: string; rId?: string } }[];
-  }): boolean =>
-    run.content.some(
-      (c) =>
-        c.type === "drawing" &&
-        c.image?.src?.startsWith("data:") === true &&
-        (!c.image.rId || c.image.rId.startsWith(SYNTHETIC_IMAGE_RID_PREFIX)),
-    );
+  const runHasNewImage = (run: Run): boolean => run.content.some(isNewDataUrlDrawing);
 
   for (const block of blocks) {
     if (block.type === "paragraph") {

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -307,6 +307,32 @@ describe("VML w:pict inline images", () => {
     expect(drawing?.rawXml).toContain("<w:pict");
   });
 
+  test("does not package a raw VML preview as a new image", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:rect style="width:1in;height:.5in" fillcolor="black"/></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    const rawXml = drawing?.rawXml;
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect(drawing?.image.rId).toBe("");
+
+    const zip = await JSZip.loadAsync(out);
+    const rels = await zip.file("word/_rels/document.xml.rels")?.async("text");
+    expect(rels).not.toContain(`Type="${RELATIONSHIP_TYPES.image}"`);
+    expect(Object.keys(zip.files).some((path) => path.startsWith("word/media/"))).toBe(false);
+
+    const reopened = await parseDocx(out, { preloadFonts: false });
+    const reopenedDrawing = firstDrawing(reopened.package.document.content.at(0));
+    expect(reopenedDrawing?.image.rId).toBe("");
+    expect(reopenedDrawing?.rawXml).toBe(rawXml);
+  });
+
   test("renders bounded rectangle and line children from a positioned VML group", async () => {
     const doc = await parseDocx(
       await pictDocx({


### PR DESCRIPTION
## Summary

- package data-URL drawings only when they are model-driven
- keep raw OOXML previews from creating unused media parts and relationships
- share the new-image predicate between selective save and full repack
- add a synthetic save/reopen regression for a raw VML preview

## Validation

- focused VML regression and related DOCX suites
- full unit suite
- typecheck and lint
- formatting check
- build and package validation
- changeset check
- dependency audit

CC on behalf of @jan-kubica