### PR TITLE
fix: omit rowless placeholder tables

### DIFF
--- a/.changeset/kind-tables-rest.md
+++ b/.changeset/kind-tables-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Allow DOCX parsing to omit rowless placeholder tables.

--- a/packages/core/src/docx/blockContentParser.ts
+++ b/packages/core/src/docx/blockContentParser.ts
@@ -374,6 +374,9 @@ const parseBlockContentWithState = (
 
     if (localName === "tbl") {
       const table = parseTable(child, styles, theme, numbering, rels, media, state.options);
+      if (!table) {
+        continue;
+      }
       if (prependBookmarkMarkersToFirstParagraphInBlocks([table], pendingBookmarkMarkers)) {
         pendingBookmarkMarkers.length = 0;
       }

--- a/packages/core/src/docx/footnoteParser.ts
+++ b/packages/core/src/docx/footnoteParser.ts
@@ -160,7 +160,10 @@ function parseNoteBlockContent(
     if (localName === "p") {
       blocks.push(parseParagraph(child, styles, theme, numbering, rels));
     } else if (localName === "tbl") {
-      blocks.push(parseTable(child, styles, theme, numbering, rels, media));
+      const table = parseTable(child, styles, theme, numbering, rels, media);
+      if (table) {
+        blocks.push(table);
+      }
     } else if (localName === "sdt") {
       // Recurse into sdtContent so SDT children inside notes are
       // recognized; otherwise the note body silently drops citation

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -4,6 +4,7 @@ import {
   serializeTableCellFormatting,
   serializeTableRowFormatting,
 } from "./serializer/tableSerializer";
+import { parseBlockContent } from "./blockContentParser";
 import {
   parseTable,
   parseTableCellProperties,
@@ -18,7 +19,11 @@ function parseTableXml(xml: string) {
   if (!root) {
     throw new Error("Failed to parse table XML");
   }
-  return parseTable(root, null, null, null, null, new Map());
+  const table = parseTable(root, null, null, null, null, new Map());
+  if (!table) {
+    throw new Error("Expected a table with at least one row");
+  }
+  return table;
 }
 
 const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
@@ -37,6 +42,20 @@ describe("parseTableMeasurement", () => {
 
   test("keeps canonical pct integers unchanged", () => {
     expect(tblW("5000")).toEqual({ value: 5000, type: "pct" });
+  });
+});
+
+describe("rowless tables", () => {
+  test("omits a placeholder table instead of creating an invalid model", () => {
+    const root = parseXmlDocument(`<w:body ${NS}>
+      <w:p><w:r><w:t>before</w:t></w:r></w:p>
+      <w:tbl><w:tblPr/></w:tbl>
+      <w:p><w:r><w:t>after</w:t></w:r></w:p>
+    </w:body>`) as XmlElement;
+
+    expect(
+      parseBlockContent(root, null, null, null, null, new Map()).map(({ type }) => type),
+    ).toEqual(["paragraph", "paragraph"]);
   });
 });
 

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -1265,6 +1265,9 @@ function parseCellContent(
     if (localName === "tbl") {
       // Parse nested table (recursive)
       const table = parseTable(child, styles, theme, numbering, rels, media, options);
+      if (!table) {
+        return;
+      }
       if (prependBookmarkMarkersToFirstParagraphInBlocks([table], pendingBookmarkMarkers)) {
         pendingBookmarkMarkers.length = 0;
       }
@@ -1632,7 +1635,7 @@ export function parseTable(
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
   options?: { inHeaderFooter?: boolean; rootXmlns?: Record<string, string> },
-): Table {
+): Table | undefined {
   const table: Table = {
     type: "table",
     rows: [],
@@ -1685,6 +1688,14 @@ export function parseTable(
 
   for (const child of getChildElements(tblElement)) {
     parseTableChild(child);
+  }
+
+  // OOXML encountered in the wild can contain placeholder w:tbl elements
+  // without rows. They have no visible content, while the canonical model
+  // intentionally requires every table to contain a row. Omit the placeholder
+  // instead of inventing a visible row or rejecting the entire document.
+  if (table.rows.length === 0) {
+    return undefined;
   }
 
   inferImplicitSingleCellRowSpans(table, rowsWithGridOffsets);

--- a/packages/core/src/docx/textBoxParser.ts
+++ b/packages/core/src/docx/textBoxParser.ts
@@ -156,7 +156,7 @@ export type TableParserFn = (
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
-) => Table;
+) => Table | undefined;
 
 /**
  * Parse text box content with provided parser functions
@@ -189,7 +189,10 @@ export function parseTextBoxContent(
       const paragraph = parseParagraph(child, styles, theme, numbering, rels, media);
       blocks.push(paragraph);
     } else if (localName === "tbl" && parseTable) {
-      blocks.push(parseTable(child, styles, theme, numbering, rels, media));
+      const table = parseTable(child, styles, theme, numbering, rels, media);
+      if (table) {
+        blocks.push(table);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- omit rowless OOXML table placeholders instead of constructing an invalid canonical table
- apply the invariant consistently in body, nested-cell, text-box, and note parsing
- preserve surrounding block content and pending bookmark markers
- add a synthetic parser regression for a rowless table between paragraphs

## Validation

- focused table parser suites
- representative parse, save, and reopen checks
- typecheck and lint
- formatting and diff checks
- full build
- changeset check
- dependency audit

CC on behalf of @jan-kubica