### PR TITLE
fix: preserve simple field structure on save

### DIFF
--- a/.changeset/quiet-fields-rest.md
+++ b/.changeset/quiet-fields-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve the authored simple-field structure when saving DOCX files.

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1240,13 +1240,15 @@ function parseSimpleField(
     field.dirty = true;
   }
 
-  // Parse child runs (the display value)
+  // Parse display content without changing its authored field form.
   const inScopeXmlns = mergeXmlnsDeclarations(rootXmlns, node);
   const children = getChildElements(node);
   for (const child of children) {
     const localName = getLocalName(child.name);
     if (localName === "r") {
       field.content.push(parseRun(child, styles, theme, rels, media, inScopeXmlns));
+    } else if (localName === "hyperlink") {
+      field.content.push(parseHyperlink(child, rels, styles, theme, media, inScopeXmlns));
     }
   }
 

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -122,6 +122,79 @@ describe("serializeComplexField structural-run formatting round-trip", () => {
   });
 });
 
+describe("serializeSimpleField structural round-trip", () => {
+  test("keeps an authored simple field simple", () => {
+    const namespace = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const instruction = ' HYPERLINK "https://example.com/reference?x=1&y=2" ';
+    const source = parseXmlDocument(`
+      <w:p ${namespace}>
+        <w:fldSimple
+          w:instr=" HYPERLINK &quot;https://example.com/reference?x=1&amp;y=2&quot; "
+          w:fldLock="true"
+          w:dirty="true"
+        >
+          <w:r><w:rPr><w:i/></w:rPr><w:t>Reference</w:t></w:r>
+        </w:fldSimple>
+      </w:p>
+    `);
+    if (!source) {
+      throw new Error("failed to parse simple field fixture");
+    }
+    const original = parseParagraph(source, null, null, null, null, null);
+
+    const serialized = serializeParagraph(original);
+    expect(serialized).toContain("<w:fldSimple");
+    expect(serialized).not.toContain("<w:fldChar");
+    expect(serialized).toContain(
+      'w:instr=" HYPERLINK &quot;https://example.com/reference?x=1&amp;y=2&quot; "',
+    );
+
+    const reopenedSource = parseXmlDocument(
+      serialized.replace(/^<w:p(?=[\s>])/u, `<w:p ${namespace}`),
+    );
+    if (!reopenedSource) {
+      throw new Error("failed to reparse simple field fixture");
+    }
+    const reopened = parseParagraph(reopenedSource, null, null, null, null, null);
+    expect(reopened.content.at(0)).toEqual(original.content.at(0));
+    expect(reopened.content.at(0)).toMatchObject({
+      type: "simpleField",
+      instruction,
+      fldLock: true,
+      dirty: true,
+    });
+  });
+
+  test("keeps hyperlink display content inside a simple field", () => {
+    const namespace = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const source = parseXmlDocument(`
+      <w:p ${namespace}>
+        <w:fldSimple w:instr="PAGE">
+          <w:hyperlink w:anchor="_page">
+            <w:r><w:t>1</w:t></w:r>
+          </w:hyperlink>
+        </w:fldSimple>
+      </w:p>
+    `);
+    if (!source) {
+      throw new Error("failed to parse hyperlink field fixture");
+    }
+    const original = parseParagraph(source, null, null, null, null, null);
+
+    const serialized = serializeParagraph(original);
+    const reopenedSource = parseXmlDocument(
+      serialized.replace(/^<w:p(?=[\s>])/u, `<w:p ${namespace}`),
+    );
+    if (!reopenedSource) {
+      throw new Error("failed to reparse hyperlink field fixture");
+    }
+    const reopened = parseParagraph(reopenedSource, null, null, null, null, null);
+    expect(serialized).toContain('<w:fldSimple w:instr="PAGE">');
+    expect(serialized).toContain('<w:hyperlink w:anchor="_page">');
+    expect(reopened.content.at(0)).toEqual(original.content.at(0));
+  });
+});
+
 describe("serializeParagraph tracked-change hardening", () => {
   test("serializes deletion runs using delText and delInstrText", () => {
     const paragraph: Paragraph = {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -649,49 +649,21 @@ function serializeBookmarkEnd(bookmark: BookmarkEnd): string {
   return `<w:bookmarkEnd w:id="${bookmark.id}"/>`;
 }
 
-/**
- * Serialize a simple field as a complex field (fldChar begin/separate/end).
- * Complex field format is more widely supported by OOXML consumers
- * (Google Docs, Apple Pages) than w:fldSimple.
- */
+/** Serialize a simple field without changing its authored OOXML field form. */
 function serializeSimpleField(field: SimpleField): string {
-  const parts: string[] = [];
-
-  // Extract formatting from the first content run
-  const firstRun = field.content.find((c): c is Run => c.type === "run");
-  const rPrXml = firstRun?.formatting ? serializeTextFormatting(firstRun.formatting) : "";
-
-  // Begin field character
-  const beginAttrs: string[] = ['w:fldCharType="begin"'];
+  const attrs = [`w:instr="${escapeXml(field.instruction)}"`];
   if (field.fldLock) {
-    beginAttrs.push('w:fldLock="true"');
+    attrs.push('w:fldLock="true"');
   }
-  parts.push(`<w:r>${rPrXml}<w:fldChar ${beginAttrs.join(" ")}/></w:r>`);
-
-  // Field code (instrText)
-  const needsPreserve =
-    field.instruction.startsWith(" ") ||
-    field.instruction.endsWith(" ") ||
-    field.instruction.includes("  ");
-  const spaceAttr = needsPreserve ? ' xml:space="preserve"' : "";
-  parts.push(
-    `<w:r>${rPrXml}<w:instrText${spaceAttr}>${escapeXml(field.instruction)}</w:instrText></w:r>`,
-  );
-
-  // Separate field character
-  parts.push(`<w:r>${rPrXml}<w:fldChar w:fldCharType="separate"/></w:r>`);
-
-  // Field result (the display runs)
-  for (const item of field.content) {
-    if (item.type === "run") {
-      parts.push(serializeRun(item));
-    }
+  if (field.dirty) {
+    attrs.push('w:dirty="true"');
   }
 
-  // End field character
-  parts.push(`<w:r>${rPrXml}<w:fldChar w:fldCharType="end"/></w:r>`);
+  const contentXml = field.content
+    .map((item) => (item.type === "run" ? serializeRun(item) : serializeHyperlink(item)))
+    .join("");
 
-  return parts.join("");
+  return `<w:fldSimple ${attrs.join(" ")}>${contentXml}</w:fldSimple>`;
 }
 
 /**

--- a/packages/core/src/docx/serializer/sdt-content-roundtrip.test.ts
+++ b/packages/core/src/docx/serializer/sdt-content-roundtrip.test.ts
@@ -50,15 +50,13 @@ describe("inline SDT serialization round-trip", () => {
     const sdt = getInlineSdt(xml);
     expect(sdt.content[0].type).toBe("simpleField");
 
-    // Field lives inside the surviving SDT wrapper. folio's serializer
-    // emits simple fields in their complex-form fldChar equivalent for
-    // broader Word/Pages/Docs compatibility, so assert on the field
-    // instruction and result text rather than the literal element name.
+    // Field lives inside the surviving SDT wrapper and keeps its authored
+    // simple-field representation.
     const serialized = serializeParagraph(parseParagraphXml(xml));
     expect(serialized).toContain("<w:sdt>");
     expect(serialized).toContain("TITLE");
     expect(serialized).toContain("Cached title");
-    expect(serialized).toContain("<w:fldChar");
+    expect(serialized).toContain('<w:fldSimple w:instr="TITLE">');
   });
 
   test("preserves a complex field inside SDT content through parse → serialize", () => {
@@ -201,6 +199,6 @@ describe("inline SDT serialization round-trip", () => {
     const serialized = serializeParagraph(parseParagraphXml(xml));
     expect(serialized).toContain("Page ");
     expect(serialized).toContain("PAGE");
-    expect(serialized).toContain("<w:fldChar");
+    expect(serialized).toContain('<w:fldSimple w:instr="PAGE">');
   });
 });


### PR DESCRIPTION
## Summary

- preserve authored simple fields instead of rewriting them as complex fields
- retain escaped instructions, lock and dirty flags, and display content
- keep hyperlink display content inside simple fields
- add synthetic parse, serialize, and reopen regressions

## Validation

- focused field, serializer, and inline-content suites
- representative fixed-point checks
- full unit suite with isolated timeout reruns
- typecheck and lint
- formatting check
- build and package validation
- changeset check
- dependency audit

CC on behalf of @jan-kubica