### PR TITLE
fix: preserve DrawingML theme aliases

### DIFF
--- a/.changeset/shiny-colors-rest.md
+++ b/.changeset/shiny-colors-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve DrawingML background and text theme colors when saving shapes.

--- a/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
@@ -104,6 +104,31 @@ describe("shape parse → serialize round-trip", () => {
     expect(xml).toContain('<a:srgbClr val="5B9BD5"');
   });
 
+  test("preserves DrawingML background theme aliases through round-trip", () => {
+    const root = parseXmlDocument(
+      shapeDrawingXml({
+        prst: "rect",
+        fill: `<a:solidFill><a:schemeClr val="bg1"/></a:solidFill>`,
+      }),
+    );
+    const shape = root ? parseShapeFromDrawing(root) : null;
+    expect(shape?.fill?.color?.themeColor).toBe("background1");
+    if (!shape) {
+      return;
+    }
+
+    const xml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape }],
+    });
+    expect(xml).toContain('<a:schemeClr val="bg1"/>');
+
+    const reopenedRoot = parseXmlDocument(xml);
+    const reopenedDrawing = findDeep(reopenedRoot, "w", "drawing");
+    const reopenedShape = reopenedDrawing ? parseShapeFromDrawing(reopenedDrawing) : null;
+    expect(reopenedShape?.fill?.color?.themeColor).toBe("background1");
+  });
+
   test("preserves radial gradient path through round-trip", () => {
     const root = parseXmlDocument(
       shapeDrawingXml({

--- a/packages/core/src/docx/drawingUtils.ts
+++ b/packages/core/src/docx/drawingUtils.ts
@@ -58,6 +58,29 @@ const SCHEME_TO_THEME_COLOR: Record<string, ColorValue["themeColor"]> = {
 };
 
 /**
+ * Map normalized theme color slots back to DrawingML scheme color names.
+ * DrawingML uses bg1/bg2/tx1/tx2 where the document model uses descriptive names.
+ */
+export const THEME_COLOR_TO_DRAWING_SCHEME = {
+  dk1: "dk1",
+  lt1: "lt1",
+  dk2: "dk2",
+  lt2: "lt2",
+  accent1: "accent1",
+  accent2: "accent2",
+  accent3: "accent3",
+  accent4: "accent4",
+  accent5: "accent5",
+  accent6: "accent6",
+  hlink: "hlink",
+  folHlink: "folHlink",
+  background1: "bg1",
+  text1: "tx1",
+  background2: "bg2",
+  text2: "tx2",
+} as const satisfies Record<NonNullable<ColorValue["themeColor"]>, string>;
+
+/**
  * sRGB hex per OOXML (ST_HexColorRGB): exactly six hex digits, case-insensitive.
  * Anything else is rejected so untrusted DOCX input cannot smuggle markup through
  * downstream renderers that interpolate the value into HTML/SVG.

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -41,6 +41,7 @@ import type {
 import { requiresXmlSpacePreserve } from "../textWhitespace";
 import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
 import { isValidHexColor } from "../../utils/colorResolver";
+import { THEME_COLOR_TO_DRAWING_SCHEME } from "../drawingUtils";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: shape textboxes hold paragraphs, paragraphs hold runs
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTable } from "./tableSerializer";
@@ -599,7 +600,8 @@ function serializeDrawingColor(color: ColorValue | undefined): string {
     return `<a:srgbClr val="${escapeXml(color.rgb.replace("#", ""))}"/>`;
   }
   if (color.themeColor) {
-    let clr = `<a:schemeClr val="${escapeXml(color.themeColor)}"`;
+    const schemeColor = THEME_COLOR_TO_DRAWING_SCHEME[color.themeColor];
+    let clr = `<a:schemeClr val="${schemeColor}"`;
     if (color.themeTint) {
       clr += `><a:tint val="${escapeXml(color.themeTint)}"/></a:schemeClr>`;
     } else if (color.themeShade) {


### PR DESCRIPTION
## Summary

- map normalized theme-color slots back to their DrawingML scheme aliases
- preserve background and text theme colors through shape save and reopen
- use a complete typed inverse mapping for every supported theme slot
- add a synthetic shape round-trip regression

## Validation

- focused shape round-trip suite
- representative fixed-point checks
- typecheck and lint
- formatting and diff checks
- build and package validation
- changeset check
- dependency audit

CC on behalf of @jan-kubica