### PR TITLE
fix: preserve explicit section bidi

### DIFF
--- a/.changeset/good-keys-refuse.md
+++ b/.changeset/good-keys-refuse.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit left-to-right section bidi settings across DOCX save and reopen.

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -4,7 +4,7 @@ import JSZip from "jszip";
 import type { Document, Image } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { createDocx, DocxPackageFidelityError, repackDocx } from "./rezip";
+import { createDocx, createEmptyDocx, DocxPackageFidelityError, repackDocx } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -290,6 +290,29 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
 }
 
 describe("repackDocx", () => {
+  test("preserves an explicit false final-section bidi setting across save and reopen", async () => {
+    const sourceZip = await JSZip.loadAsync(await createEmptyDocx());
+    const documentFile = sourceZip.file("word/document.xml");
+    if (!documentFile) {
+      throw new Error("expected word/document.xml");
+    }
+    const documentXml = await documentFile.async("text");
+    const explicitLtrXml = documentXml.replace("</w:sectPr>", '<w:bidi w:val="0"/></w:sectPr>');
+    expect(explicitLtrXml).not.toBe(documentXml);
+    sourceZip.file("word/document.xml", explicitLtrXml);
+
+    const parsed = await parseDocx(await sourceZip.generateAsync({ type: "arraybuffer" }), {
+      preloadFonts: false,
+    });
+    expect(parsed.package.document.finalSectionProperties?.bidi).toBe(false);
+
+    const saved = await repackDocx(parsed, { updateModifiedDate: false });
+    const reopened = await parseDocx(saved, { preloadFonts: false });
+
+    expect(reopened.package.document.finalSectionProperties?.bidi).toBe(false);
+    expect(reopened.package.document.sections?.at(-1)?.properties.bidi).toBe(false);
+  });
+
   test("preserves clickable image hyperlinks across full save and reopen", async () => {
     const parsed = await parseDocx(await createHyperlinkedImageFixture(), {
       preloadFonts: false,

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -382,8 +382,9 @@ export function serializeSectionProperties(props: SectionProperties | undefined)
   if (props.titlePg) {
     parts.push("<w:titlePg/>");
   }
-  if (props.bidi) {
-    parts.push("<w:bidi/>");
+  const bidiXml = serializeOnOffElement(props.bidi, "bidi");
+  if (bidiXml) {
+    parts.push(bidiXml);
   }
   for (const xml of [
     serializeOnOffElement(props.formProtection, "formProt"),


### PR DESCRIPTION
## Summary

- preserve the full undefined, true, and false state of section bidi settings
- emit an explicit false OOXML on/off value instead of dropping it
- cover parse, full save, reopen, and derived-section behavior with a synthetic regression

## Validation

- representative fixed-point checks
- focused DOCX integration suite
- full unit suite
- typecheck and lint
- formatting and diff checks
- build
- changeset check
- dependency audit

CC on behalf of @jan-kubica