### PR TITLE
fix: preserve absent shape wrap distances

### DIFF
--- a/.changeset/honest-shapes-wrap.md
+++ b/.changeset/honest-shapes-wrap.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve absent shape wrap distances when saving DrawingML.

--- a/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
@@ -11,14 +11,18 @@ function shapeDrawingXml({
   anchor,
   fill,
   outline,
+  distances = "explicit-zero",
 }: {
   prst: string;
   anchor?: boolean;
   fill?: string;
   outline?: string;
+  distances?: "absent" | "explicit-zero";
 }): string {
+  const distanceAttrs =
+    distances === "explicit-zero" ? ' distT="0" distB="0" distL="0" distR="0"' : "";
   const container = anchor
-    ? `<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" relativeHeight="251658240" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">
+    ? `<wp:anchor${distanceAttrs} simplePos="0" relativeHeight="251658240" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">
         <wp:simplePos x="0" y="0"/>
         <wp:positionH relativeFrom="column"><wp:posOffset>100000</wp:posOffset></wp:positionH>
         <wp:positionV relativeFrom="paragraph"><wp:posOffset>200000</wp:posOffset></wp:positionV>
@@ -202,6 +206,43 @@ describe("shape parse → serialize round-trip", () => {
     });
     expect(xml).toContain("<wp:wrapSquare");
     expect(xml).toContain("<wp:anchor");
+  });
+
+  test("distinguishes absent wrap distances from explicit zero", () => {
+    const absentRoot = parseXmlDocument(
+      shapeDrawingXml({ prst: "rect", anchor: true, distances: "absent" }),
+    );
+    const absentShape = absentRoot ? parseShapeFromDrawing(absentRoot) : null;
+    expect(absentShape?.wrap).toEqual({ type: "square", wrapText: "bothSides" });
+    if (!absentShape) {
+      return;
+    }
+
+    const absentXml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape: absentShape }],
+    });
+    expect(absentXml).not.toContain("distT=");
+    expect(absentXml).not.toContain("distB=");
+    expect(absentXml).not.toContain("distL=");
+    expect(absentXml).not.toContain("distR=");
+
+    const reopenedRoot = parseXmlDocument(absentXml);
+    const reopenedDrawing = findDeep(reopenedRoot, "w", "drawing");
+    const reopenedShape = reopenedDrawing ? parseShapeFromDrawing(reopenedDrawing) : null;
+    expect(reopenedShape?.wrap).toEqual({ type: "square", wrapText: "bothSides" });
+
+    const zeroRoot = parseXmlDocument(shapeDrawingXml({ prst: "rect", anchor: true }));
+    const zeroShape = zeroRoot ? parseShapeFromDrawing(zeroRoot) : null;
+    expect(zeroShape?.wrap).toMatchObject({ distT: 0, distB: 0, distL: 0, distR: 0 });
+    if (!zeroShape) {
+      return;
+    }
+    const zeroXml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape: zeroShape }],
+    });
+    expect(zeroXml).toContain('distT="0" distB="0" distL="0" distR="0"');
   });
 
   test("serializes normalized line cap values as OOXML tokens", () => {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -918,6 +918,23 @@ function serializeShapeTextBody(
     .join("");
 }
 
+function serializeShapeWrapDistances(wrap: ImageWrap | undefined): string {
+  const attrs: string[] = [];
+  if (wrap?.distT !== undefined) {
+    attrs.push(`distT="${intAttr(wrap.distT)}"`);
+  }
+  if (wrap?.distB !== undefined) {
+    attrs.push(`distB="${intAttr(wrap.distB)}"`);
+  }
+  if (wrap?.distL !== undefined) {
+    attrs.push(`distL="${intAttr(wrap.distL)}"`);
+  }
+  if (wrap?.distR !== undefined) {
+    attrs.push(`distR="${intAttr(wrap.distR)}"`);
+  }
+  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+}
+
 /**
  * Serialize shape content to full DrawingML XML (wps:wsp inside w:drawing)
  */
@@ -927,10 +944,7 @@ function serializeShapeContent(content: ShapeContent): string {
   const cy = shape.size.height;
   const isTextBox = shape.shapeType === "textBox";
   const isFloating = shape.wrap && shape.wrap.type !== "inline";
-  const distT = shape.wrap?.distT ?? 0;
-  const distB = shape.wrap?.distB ?? 0;
-  const distL = shape.wrap?.distL ?? 0;
-  const distR = shape.wrap?.distR ?? 0;
+  const wrapDistances = serializeShapeWrapDistances(shape.wrap);
   const docPrId = getUniqueId(shape.id);
   const docPrName = shape.name ?? (isTextBox ? `TextBox ${docPrId}` : `Shape ${docPrId}`);
 
@@ -1030,7 +1044,7 @@ function serializeShapeContent(content: ShapeContent): string {
   if (!isFloating) {
     return [
       "<w:drawing>",
-      `<wp:inline distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}">`,
+      `<wp:inline${wrapDistances}>`,
       `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
       '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
       `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"/>`,
@@ -1053,7 +1067,7 @@ function serializeShapeContent(content: ShapeContent): string {
 
   return [
     "<w:drawing>",
-    `<wp:anchor distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
+    `<wp:anchor${wrapDistances} simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
     '<wp:simplePos x="0" y="0"/>',
     position,
     `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,


### PR DESCRIPTION
## Summary

- preserve the distinction between absent and explicitly zero shape wrap distances
- emit only modeled shape distance attributes for inline and anchored shapes
- add a synthetic parse, serialize, and reopen regression for both states

## Validation

- representative fixed-point checks
- focused shape round-trip suite
- full unit suite with isolated timeout rerun
- typecheck and lint
- formatting and diff checks
- build and package validation
- changeset check
- dependency audit

CC on behalf of @jan-kubica