### PR TITLE
fix: preserve font script hints

### DIFF
--- a/.changeset/calm-fonts-hint.md
+++ b/.changeset/calm-fonts-hint.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve Word font script hints across document edits and saves.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -83,6 +83,7 @@ export type FontFamilyAttrs = {
     hAnsi?: string;
     eastAsia?: string;
     cs?: string;
+    hint?: NonNullable<NonNullable<import__stll_docx_core_model.TextFormatting["fontFamily"]>["hint"]>;
     asciiTheme?: string;
     hAnsiTheme?: string;
     eastAsiaTheme?: string;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -140,6 +140,7 @@ export type FontFamilyAttrs = {
     hAnsi?: string;
     eastAsia?: string;
     cs?: string;
+    hint?: NonNullable<NonNullable<import__stll_docx_core_model.TextFormatting["fontFamily"]>["hint"]>;
     asciiTheme?: string;
     hAnsiTheme?: string;
     eastAsiaTheme?: string;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -1275,6 +1275,7 @@ export type TextFormatting = {
         hAnsi?: string;
         eastAsia?: string;
         cs?: string;
+        hint?: "default" | "eastAsia" | "cs";
         asciiTheme?: "majorAscii" | "majorHAnsi" | "majorEastAsia" | "majorBidi" | "minorAscii" | "minorHAnsi" | "minorEastAsia" | "minorBidi";
         hAnsiTheme?: string;
         eastAsiaTheme?: string;

--- a/packages/core/src/docx/__tests__/fontHintRoundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/fontHintRoundtrip.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document } from "../../types/document";
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { parseRunProperties } from "../runParser";
+import { serializeTextFormatting } from "../serializer/runSerializer";
+import { parseXml } from "../xmlParser";
+import type { XmlElement } from "../xmlParser";
+
+const parseRPr = (xml: string): XmlElement => {
+  const parsed = parseXml(
+    `<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${xml}</w:rPr>`,
+  );
+  const rPr = parsed.elements.at(0);
+  if (!rPr || rPr.type !== "element") {
+    throw new Error("Expected run properties element");
+  }
+  return rPr;
+};
+
+describe("run font hint round-trip", () => {
+  for (const hint of ["default", "eastAsia", "cs"] as const) {
+    test(`preserves a hint-only ${hint} font declaration`, () => {
+      const formatting = parseRunProperties(parseRPr(`<w:rFonts w:hint="${hint}"/>`), null);
+
+      expect(formatting?.fontFamily).toEqual({ hint });
+      expect(serializeTextFormatting(formatting)).toContain(`<w:rFonts w:hint="${hint}"/>`);
+    });
+  }
+
+  test("does not retain an unknown font hint", () => {
+    const formatting = parseRunProperties(parseRPr('<w:rFonts w:hint="unsupported"/>'), null);
+
+    expect(formatting?.fontFamily).toEqual({});
+    expect(serializeTextFormatting(formatting)).not.toContain("<w:rFonts");
+  });
+
+  test("preserves the hint through the editor model", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  formatting: { fontFamily: { hint: "eastAsia" } },
+                  content: [{ type: "text", text: "text" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const roundtripped = fromProseDoc(toProseDoc(document), document);
+    const paragraph = roundtripped.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const run = paragraph.content.at(0);
+    expect(run?.type).toBe("run");
+    if (run?.type !== "run") {
+      throw new Error("Expected run");
+    }
+    expect(run.formatting?.fontFamily?.hint).toBe("eastAsia");
+  });
+});

--- a/packages/core/src/docx/numberingParser.ts
+++ b/packages/core/src/docx/numberingParser.ts
@@ -21,7 +21,7 @@ import type {
   ParagraphFormatting,
   TextFormatting,
 } from "../types/document";
-import { LevelSuffixSchema, ThemeColorSlotSchema, narrowEnum } from "./parserEnums";
+import { FontHintSchema, LevelSuffixSchema, ThemeColorSlotSchema, narrowEnum } from "./parserEnums";
 import {
   parseXmlDocument,
   findChild,
@@ -748,11 +748,13 @@ function parseLevelRunProps(rPr: XmlElement): TextFormatting {
     const hAnsi = getAttribute(rFontsEl, "w", "hAnsi");
     const eastAsia = getAttribute(rFontsEl, "w", "eastAsia");
     const cs = getAttribute(rFontsEl, "w", "cs");
+    const hint = narrowEnum(getAttribute(rFontsEl, "w", "hint"), FontHintSchema);
     formatting.fontFamily = {
       ...(ascii != null ? { ascii } : {}),
       ...(hAnsi != null ? { hAnsi } : {}),
       ...(eastAsia != null ? { eastAsia } : {}),
       ...(cs != null ? { cs } : {}),
+      ...(hint !== undefined ? { hint } : {}),
     };
   }
 

--- a/packages/core/src/docx/parserEnums.ts
+++ b/packages/core/src/docx/parserEnums.ts
@@ -29,6 +29,7 @@ import {
   FIELD_TYPE_VALUES,
   FLOATING_TABLE_X_SPEC_VALUES,
   FLOATING_TABLE_Y_SPEC_VALUES,
+  FONT_HINT_VALUES,
   FONT_THEME_VALUES,
   FRAME_WRAP_VALUES,
   FRAME_X_ALIGN_VALUES,
@@ -96,6 +97,8 @@ export const TextEffectSchema = v.picklist(TEXT_EFFECT_VALUES);
 export const EmphasisMarkSchema = v.picklist(EMPHASIS_MARK_VALUES);
 
 export const FontThemeSchema = v.picklist(FONT_THEME_VALUES);
+
+export const FontHintSchema = v.picklist(FONT_HINT_VALUES);
 
 // ---------------------------------------------------------------------------
 // Paragraph formatting enums

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -46,6 +46,7 @@ import { parseGroupDrawing } from "./groupDrawingParser";
 import { parseImage } from "./imageParser";
 import {
   EmphasisMarkSchema,
+  FontHintSchema,
   FontThemeSchema,
   HighlightColorSchema,
   ShadingPatternSchema,
@@ -483,6 +484,10 @@ export function parseRunProperties(
     const csFont = getAttribute(rFonts, "w", "cs");
     if (csFont) {
       fontFamily.cs = csFont;
+    }
+    const hint = narrowEnum(getAttribute(rFonts, "w", "hint"), FontHintSchema);
+    if (hint) {
+      fontFamily.hint = hint;
     }
 
     // Theme font references

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -205,6 +205,9 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     if (formatting.fontFamily.cs) {
       fontAttrs.push(`w:cs="${escapeXml(formatting.fontFamily.cs)}"`);
     }
+    if (formatting.fontFamily.hint) {
+      fontAttrs.push(`w:hint="${escapeXml(formatting.fontFamily.hint)}"`);
+    }
     if (formatting.fontFamily.asciiTheme) {
       fontAttrs.push(`w:asciiTheme="${formatting.fontFamily.asciiTheme}"`);
     }

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -42,6 +42,7 @@ import {
   BorderStyleSchema,
   ConditionalStyleTypeSchema,
   EmphasisMarkSchema,
+  FontHintSchema,
   FontThemeSchema,
   HighlightColorSchema,
   LineSpacingRuleSchema,
@@ -238,6 +239,10 @@ function parseRunProperties(
     const csFont = getAttribute(rFonts, "w", "cs");
     if (csFont) {
       fontFamily.cs = csFont;
+    }
+    const hint = narrowEnum(getAttribute(rFonts, "w", "hint"), FontHintSchema);
+    if (hint) {
+      fontFamily.hint = hint;
     }
 
     // Theme font references - resolve to actual font names

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -862,6 +862,7 @@ export const readFontFamilyMarkAttrs = (
   optionalString(attrs, "hAnsi", "fontFamily.attrs.hAnsi", issues);
   optionalString(attrs, "eastAsia", "fontFamily.attrs.eastAsia", issues);
   optionalString(attrs, "cs", "fontFamily.attrs.cs", issues);
+  optionalString(attrs, "hint", "fontFamily.attrs.hint", issues);
   optionalString(attrs, "asciiTheme", "fontFamily.attrs.asciiTheme", issues);
   optionalString(attrs, "hAnsiTheme", "fontFamily.attrs.hAnsiTheme", issues);
   optionalString(attrs, "eastAsiaTheme", "fontFamily.attrs.eastAsiaTheme", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2461,6 +2461,9 @@ export function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         if (attrs.eastAsia) {
           ff.eastAsia = attrs.eastAsia;
         }
+        if (attrs.hint) {
+          ff.hint = attrs.hint;
+        }
         // Use stored cs value, falling back to ascii for Complex Script compatibility
         const csVal = attrs.cs || attrs.ascii;
         if (csVal) {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2767,6 +2767,7 @@ export function textFormattingToMarks(
         hAnsi: formatting.fontFamily.hAnsi,
         eastAsia: formatting.fontFamily.eastAsia,
         cs: formatting.fontFamily.cs,
+        hint: formatting.fontFamily.hint,
         asciiTheme: formatting.fontFamily.asciiTheme,
         hAnsiTheme: formatting.fontFamily.hAnsiTheme,
         eastAsiaTheme: formatting.fontFamily.eastAsiaTheme,

--- a/packages/core/src/prosemirror/extensions/marks/FontFamilyExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/FontFamilyExtension.ts
@@ -18,6 +18,7 @@ export const FontFamilyExtension = createMarkExtension({
       hAnsi: { default: null },
       eastAsia: { default: null },
       cs: { default: null },
+      hint: { default: null },
       asciiTheme: { default: null },
       hAnsiTheme: { default: null },
       eastAsiaTheme: { default: null },

--- a/packages/core/src/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/core/src/prosemirror/extensions/marks/markUtils.ts
@@ -88,9 +88,11 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
           mark.attrs["hAnsi"] !== null && mark.attrs["hAnsi"] !== undefined
             ? String(mark.attrs["hAnsi"])
             : undefined;
+        const hint = mark.attrs["hint"];
         formatting.fontFamily = {
           ...(ascii !== undefined ? { ascii } : {}),
           ...(hAnsi !== undefined ? { hAnsi } : {}),
+          ...(hint === "default" || hint === "eastAsia" || hint === "cs" ? { hint } : {}),
         };
         break;
       }
@@ -349,6 +351,7 @@ export function textFormattingToMarks(formatting: TextFormatting, schema: Schema
       schema.marks["fontFamily"].create({
         ascii: formatting.fontFamily.ascii,
         hAnsi: formatting.fontFamily.hAnsi,
+        hint: formatting.fontFamily.hint,
         asciiTheme: formatting.fontFamily.asciiTheme,
       }),
     );

--- a/packages/core/src/prosemirror/schema/marks.ts
+++ b/packages/core/src/prosemirror/schema/marks.ts
@@ -53,6 +53,7 @@ export type FontFamilyAttrs = {
   hAnsi?: string;
   eastAsia?: string;
   cs?: string;
+  hint?: NonNullable<NonNullable<TextFormatting["fontFamily"]>["hint"]>;
   asciiTheme?: string;
   hAnsiTheme?: string;
   eastAsiaTheme?: string;

--- a/packages/core/src/types/documentEnumValues.ts
+++ b/packages/core/src/types/documentEnumValues.ts
@@ -133,6 +133,7 @@ export const EMPHASIS_MARK_VALUES = [
 ] as const satisfies readonly EmphasisMark[];
 
 type FontTheme = NonNullable<NonNullable<TextFormatting["fontFamily"]>["asciiTheme"]>;
+type FontHint = NonNullable<NonNullable<TextFormatting["fontFamily"]>["hint"]>;
 
 export const FONT_THEME_VALUES = [
   "majorAscii",
@@ -144,6 +145,12 @@ export const FONT_THEME_VALUES = [
   "minorEastAsia",
   "minorBidi",
 ] as const satisfies readonly FontTheme[];
+
+export const FONT_HINT_VALUES = [
+  "default",
+  "eastAsia",
+  "cs",
+] as const satisfies readonly FontHint[];
 
 export const PARAGRAPH_ALIGNMENT_VALUES = [
   "left",

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -126,6 +126,8 @@ export type TextFormatting = {
     hAnsi?: string;
     eastAsia?: string;
     cs?: string;
+    /** Script slot Word should prefer when selecting a glyph font (w:hint). */
+    hint?: "default" | "eastAsia" | "cs";
     /** Theme font reference */
     asciiTheme?:
       | "majorAscii"


### PR DESCRIPTION
## Summary

- preserve valid OOXML font script hints across run, style, and numbering parsing
- serialize font hints with the rest of the typed font-family model
- retain font hints through editor-model conversions and marks
- reject unsupported hint values through the existing enum-narrowing boundary
- add synthetic parser, serializer, and editor round-trip regressions

## Validation

- focused font-hint and affected suites
- representative fixed-point checks
- full unit suite
- typecheck and lint
- formatting and diff checks
- build and package validation
- changeset check
- dependency audit

CC on behalf of @jan-kubica