### PR TITLE
fix: preserve image drawing metadata

### DIFF
--- a/.changeset/calm-images-smile.md
+++ b/.changeset/calm-images-smile.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve distinct image names, descriptions, and titles when saving DOCX files.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -123,6 +123,7 @@ export type HyperlinkAttrs = {
 // @public
 export type ImageAttrs = {
     src: string;
+    docPrName?: string;
     alt?: string;
     title?: string;
     width?: number;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -208,6 +208,7 @@ export type HyperlinkAttrs = {
 // @public
 export type ImageAttrs = {
     src: string;
+    docPrName?: string;
     alt?: string;
     title?: string;
     width?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -388,6 +388,7 @@ type Image_2 = {
     src?: string;
     mimeType?: string;
     filename?: string;
+    docPrName?: string;
     alt?: string;
     title?: string;
     size: ImageSize;

--- a/packages/core/src/docx/__tests__/image-doc-properties-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/image-doc-properties-roundtrip.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document, Image, Run } from "../../types/document";
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { parseDrawing } from "../imageParser";
+import { serializeRun } from "../serializer/runSerializer";
+import { parseXml, type XmlElement } from "../xmlParser";
+
+const NS = [
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"',
+  'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"',
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"',
+  'xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"',
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"',
+].join(" ");
+
+type DrawingKind = "anchor" | "inline";
+
+const drawingXml = (kind: DrawingKind, docPrAttrs: string): string => {
+  const open =
+    kind === "inline"
+      ? "<wp:inline>"
+      : '<wp:anchor simplePos="0" relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">';
+  const position =
+    kind === "anchor"
+      ? '<wp:simplePos x="0" y="0"/><wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH><wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>'
+      : "";
+  const wrap = kind === "anchor" ? '<wp:wrapSquare wrapText="bothSides"/>' : "";
+
+  return `<w:drawing ${NS}>
+    ${open}
+      ${position}
+      <wp:extent cx="914400" cy="457200"/>
+      ${wrap}
+      <wp:docPr id="7" ${docPrAttrs}/>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="7" name="media.png"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="914400" cy="457200"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData>
+      </a:graphic>
+    </wp:${kind}>
+  </w:drawing>`;
+};
+
+const parseDrawingXml = (xml: string): Image | null => {
+  const parsed = parseXml(xml);
+  const drawing = (parsed.elements as XmlElement[]).at(0);
+  return drawing ? parseDrawing(drawing, undefined, undefined) : null;
+};
+
+const serializeImage = (image: Image): string => {
+  const run: Run = { type: "run", content: [{ type: "drawing", image }] };
+  return serializeRun(run);
+};
+
+const reparseSerializedImage = (xml: string): Image | null => {
+  const parsed = parseXml(`<root ${NS}>${xml}</root>`);
+  const root = (parsed.elements as XmlElement[]).at(0);
+  const run = (root?.elements as XmlElement[] | undefined)?.at(0);
+  const drawing = (run?.elements as XmlElement[] | undefined)?.at(0);
+  return drawing ? parseDrawing(drawing, undefined, undefined) : null;
+};
+
+const documentWithImage = (image: Image): Document => ({
+  package: {
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "run", content: [{ type: "drawing", image }] }],
+        },
+      ],
+    },
+  },
+});
+
+const firstImage = (document: Document): Image | null => {
+  const paragraph = document.package.document.content.at(0);
+  if (paragraph?.type !== "paragraph") {
+    return null;
+  }
+  const run = paragraph.content.at(0);
+  if (run?.type !== "run") {
+    return null;
+  }
+  const drawing = run.content.at(0);
+  return drawing?.type === "drawing" ? drawing.image : null;
+};
+
+describe("wp:docPr image metadata round-trip", () => {
+  test.each(["inline", "anchor"] as const)(
+    "keeps authored name, description, and title distinct for %s images",
+    (kind) => {
+      const image = parseDrawingXml(
+        drawingXml(
+          kind,
+          'name="Authored name" descr="Accessibility description" title="Display title"',
+        ),
+      );
+      expect(image).toMatchObject({
+        docPrName: "Authored name",
+        alt: "Accessibility description",
+        title: "Display title",
+      });
+      if (!image) {
+        return;
+      }
+
+      const serialized = serializeImage(image);
+      expect(serialized).toContain(
+        'name="Authored name" descr="Accessibility description" title="Display title"',
+      );
+      expect(reparseSerializedImage(serialized)).toMatchObject({
+        docPrName: "Authored name",
+        alt: "Accessibility description",
+        title: "Display title",
+      });
+
+      const editorRoundTrip = fromProseDoc(
+        toProseDoc(documentWithImage(image)),
+        documentWithImage(image),
+      );
+      expect(firstImage(editorRoundTrip)).toMatchObject({
+        docPrName: "Authored name",
+        alt: "Accessibility description",
+        title: "Display title",
+      });
+    },
+  );
+
+  test("does not synthesize title from name or description", () => {
+    const image = parseDrawingXml(
+      drawingXml("inline", 'name="Authored name" descr="Accessibility description"'),
+    );
+    expect(image?.title).toBeUndefined();
+    if (!image) {
+      return;
+    }
+
+    const serialized = serializeImage(image);
+    expect(serialized).toContain('name="Authored name" descr="Accessibility description"');
+    expect(serialized).not.toContain(" title=");
+    expect(reparseSerializedImage(serialized)?.title).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/imageParser.ts
+++ b/packages/core/src/docx/imageParser.ts
@@ -620,10 +620,13 @@ function parseInline(
   if (props.id) {
     image.id = props.id;
   }
-  if (props.alt) {
+  if (props.name !== undefined) {
+    image.docPrName = props.name;
+  }
+  if (props.alt !== undefined) {
     image.alt = props.alt;
   }
-  if (props.title) {
+  if (props.title !== undefined) {
     image.title = props.title;
   }
   if (props.decorative) {
@@ -760,10 +763,13 @@ function parseAnchor(
   if (props.id) {
     image.id = props.id;
   }
-  if (props.alt) {
+  if (props.name !== undefined) {
+    image.docPrName = props.name;
+  }
+  if (props.alt !== undefined) {
     image.alt = props.alt;
   }
-  if (props.title) {
+  if (props.title !== undefined) {
     image.title = props.title;
   }
   if (props.decorative) {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -853,13 +853,15 @@ function serializeDrawingContent(content: DrawingContent): string {
   const effB = image.padding?.bottom ?? 0;
   const effectExtentEl = `<wp:effectExtent l="${intAttr(effL)}" t="${intAttr(effT)}" r="${intAttr(effR)}" b="${intAttr(effB)}"/>`;
   const docPrId = getUniqueId(image.id);
-  const docPrName = image.title || image.filename || `Picture ${docPrId}`;
+  const docPrName = image.docPrName ?? image.filename ?? `Picture ${docPrId}`;
+  const docPrDescription = image.alt !== undefined ? ` descr="${escapeXml(image.alt)}"` : "";
+  const docPrTitle = image.title !== undefined ? ` title="${escapeXml(image.title)}"` : "";
   const hlinkClick = image.hlinkRId ? `<a:hlinkClick r:id="${escapeXml(image.hlinkRId)}"/>` : "";
-  const inlineDocPrAttrs = `id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}${image.decorative ? ' hidden="1"' : ""}`;
+  const inlineDocPrAttrs = `id="${docPrId}" name="${escapeXml(docPrName)}"${docPrDescription}${docPrTitle}${image.decorative ? ' hidden="1"' : ""}`;
   const inlineDocPr = hlinkClick
     ? `<wp:docPr ${inlineDocPrAttrs}>${hlinkClick}</wp:docPr>`
     : `<wp:docPr ${inlineDocPrAttrs}/>`;
-  const anchorDocPrAttrs = `id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}`;
+  const anchorDocPrAttrs = `id="${docPrId}" name="${escapeXml(docPrName)}"${docPrDescription}${docPrTitle}`;
   const anchorDocPr = hlinkClick
     ? `<wp:docPr ${anchorDocPrAttrs}>${hlinkClick}</wp:docPr>`
     : `<wp:docPr ${anchorDocPrAttrs}/>`;

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -528,6 +528,7 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
   expectNodeType(node, "image", issues);
 
   requiredString(attrs, "src", "image.attrs.src", issues);
+  optionalString(attrs, "docPrName", "image.attrs.docPrName", issues);
   optionalString(attrs, "alt", "image.attrs.alt", issues);
   optionalString(attrs, "title", "image.attrs.title", issues);
   optionalString(attrs, "rId", "image.attrs.rId", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2149,10 +2149,13 @@ function createImageRun(node: PMNode): Run {
     },
     wrap,
   };
-  if (attrs.alt) {
+  if (attrs.docPrName != null) {
+    image.docPrName = attrs.docPrName;
+  }
+  if (attrs.alt != null) {
     image.alt = attrs.alt;
   }
-  if (attrs.title) {
+  if (attrs.title != null) {
     image.title = attrs.title;
   }
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2580,6 +2580,7 @@ function convertImage(image: Image, rawXml?: string): PMNode {
 
   return schema.node("image", {
     src: image.src || "",
+    docPrName: image.docPrName,
     alt: image.alt,
     title: image.title,
     width: widthPx,

--- a/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -16,6 +16,7 @@ export const ImageExtension = createNodeExtension({
     draggable: true,
     attrs: {
       src: {},
+      docPrName: { default: null },
       alt: { default: null },
       title: { default: null },
       width: { default: null },

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -280,6 +280,7 @@ export type ImagePositionAttrs = {
  */
 export type ImageAttrs = {
   src: string;
+  docPrName?: string;
   alt?: string;
   title?: string;
   /** Width in pixels (already converted from EMU) */

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -443,9 +443,11 @@ export type Image = {
   mimeType?: string;
   /** Original filename */
   filename?: string;
+  /** Authored non-visual drawing name (`wp:docPr@name`) */
+  docPrName?: string;
   /** Alt text for accessibility */
   alt?: string;
-  /** Title/description */
+  /** Authored non-visual drawing title (`wp:docPr@title`) */
   title?: string;
   /** Image size */
   size: ImageSize;


### PR DESCRIPTION
Preserve authored drawing names, accessibility descriptions, and titles as independent image metadata across DOCX parsing, editor conversion, and serialization. Adds focused inline and anchored drawing round-trip coverage and updates the public API snapshots.