### PR TITLE
perf: measure paragraph paint geometry on demand

### DIFF
--- a/.changeset/lazy-painter-measure.md
+++ b/.changeset/lazy-painter-measure.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Skip painter text measurement for lines that do not need tab or horizontal-scale geometry.

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -60,6 +60,82 @@ function findTabEls(lineEl: FakeElement): FakeElement[] {
 }
 
 describe("renderLine box model", () => {
+  test("does not create a text measurer for an ordinary unscaled line", () => {
+    let canvasCreations = 0;
+    const countingDocument = {
+      createElement(tagName: string): FakeElement {
+        if (tagName === "canvas") {
+          canvasCreations += 1;
+        }
+        return new FakeElement(tagName);
+      },
+    } as unknown as Document;
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "unscaled-line",
+      runs: [{ kind: "text", text: "No tabs or scaling" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: "No tabs or scaling".length,
+      width: 112,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, countingDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.children.at(0)?.textContent).toBe("No tabs or scaling");
+    expect(canvasCreations).toBe(0);
+  });
+
+  test("measures a horizontally scaled run to reserve its painted advance", () => {
+    let canvasCreations = 0;
+    const countingDocument = {
+      createElement(tagName: string): FakeElement {
+        if (tagName === "canvas") {
+          canvasCreations += 1;
+        }
+        return new FakeElement(tagName);
+      },
+    } as unknown as Document;
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "scaled-line",
+      runs: [{ kind: "text", text: "scaled", horizontalScale: 50 }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: "scaled".length,
+      width: 21,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, countingDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.children.at(0)?.style["width"]).toBe("21px");
+    expect(canvasCreations).toBe(1);
+  });
+
   test("paints no-break hyphens without changing document positions", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1991,11 +1991,16 @@ export function renderLine(
   // Per-line floating margins (leftOffset/rightOffset) are now applied by
   // renderParagraphFragment via MeasuredLine offsets from re-measurement.
 
-  // Build tab context if we have tab runs - also create for text measurement
+  // Build tab context if we have tab runs.
   let tabContext: TabContext | undefined;
 
-  // Always create text measurer for accurate X position tracking
-  const measureText = createTextMeasurer(doc);
+  const hasScaledTextRun = runsForLine.some(
+    (run) =>
+      (isTextRun(run) || isFieldRun(run) || isMathRun(run)) &&
+      run.horizontalScale !== undefined &&
+      run.horizontalScale !== 100,
+  );
+  const measureText = hasTabRuns || hasScaledTextRun ? createTextMeasurer(doc) : undefined;
 
   if (hasTabRuns) {
     // Convert tab stops from layout engine format to tab calculator format
@@ -2042,7 +2047,7 @@ export function renderLine(
   for (let i = 0; i < runsForLine.length; i++) {
     const run = runsForLine[i]!; // SAFETY: i < runsForLine.length
 
-    if (isTabRun(run) && tabContext) {
+    if (isTabRun(run) && tabContext && measureText) {
       // Per-run measurement (not a single-font pass over the joined string)
       // keeps the tab width accurate when trailing runs differ in font/size.
       const followingWidth = measureFollowingContentWidth(
@@ -2212,6 +2217,9 @@ export function renderLine(
       if (isCollapsedLineEdgeSpaceRun(run)) {
         continue;
       }
+      if (!measureText) {
+        continue;
+      }
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
       const measuredWidth = measureText(
@@ -2257,6 +2265,9 @@ export function renderLine(
       // Render field run with context for PAGE/NUMPAGES substitution
       const runEl = renderFieldRun(run, doc, options.context);
       lineEl.append(runEl);
+      if (!measureText) {
+        continue;
+      }
       // Estimate field text width for tab calculations (same value the field
       // painted, so tab math matches).
       const fieldText = resolveFieldText(run, options.context);
@@ -2273,6 +2284,9 @@ export function renderLine(
     } else if (isMathRun(run)) {
       const runEl = renderMathRun(run, doc);
       lineEl.append(runEl);
+      if (!measureText) {
+        continue;
+      }
       const measuredWidth = measureText(
         run.plainText,
         run.fontSize ?? 11,


### PR DESCRIPTION
## Summary

- create the Canvas text measurer only when tab calculations or horizontal scaling consume width geometry
- render ordinary unscaled lines without repeating layout text measurements in the painter
- preserve existing tab and horizontal-scale behavior with focused regression coverage

## Validation

- lint
- monorepo typecheck and parity check
- focused paragraph line, right-tab, and decimal-tab tests (28 passed)
- isolated core, Vue, and script suites
- build and clean-room distribution validation
- changeset check
- dependency audit

## Performance

On the generated long split-table fixture, painter measurement calls fell from 961 to 0 and total Canvas measurement calls fell from 1,405 to 444.