### PR TITLE
fix: stabilize preserved OOXML fragments

### DIFF
--- a/.changeset/calm-xml-stays.md
+++ b/.changeset/calm-xml-stays.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep preserved OOXML fragments stable across save and reopen.

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -183,6 +183,7 @@ async function bodyScopedPictDocx(bodyInnerXml: string): Promise<ArrayBuffer> {
 }
 
 const PICT_WITH_IMAGE = `<w:pict><v:shape id="Picture 1" type="#_x0000_t75" style="width:2in;height:1in"><v:imagedata r:id="rIdImg" o:title="logo"/></v:shape></w:pict>`;
+const PICT_WITH_CHARACTER_REFERENCED_LINE_ENDINGS = `<w:pict><v:shape id="Picture 1" type="#_x0000_t75" style="width:2in;height:1in">&#xD;&#xA;<v:imagedata r:id="rIdImg" o:title="logo"/>&#xD;&#xA;</v:shape></w:pict>`;
 const OBJECT_WITH_PREVIEW = `<w:object><v:shape id="Object 1" type="#_x0000_t75" style="width:20pt;height:18pt"><v:imagedata r:id="rIdImg" o:title="preview"/></v:shape><w:control r:id="rIdControl" w:name="Control 1" w:shapeid="Object 1"/></w:object>`;
 
 // A VML shape/imagedata whose prefixes (`v2`, `r2`) are declared on an ancestor
@@ -237,6 +238,32 @@ describe("VML w:pict inline images", () => {
     const doc = await parseDocx(await pictDocx({ runXml: PICT_WITH_IMAGE }), {
       preloadFonts: false,
     });
+    const rawXml = firstDrawing(doc.package.document.content.at(0))?.rawXml;
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const reopened = await parseDocx(out, { preloadFonts: false });
+
+    expect(firstDrawing(reopened.package.document.content.at(0))?.rawXml).toBe(rawXml);
+  });
+
+  test("keeps character-referenced VML line endings stable after save and reopen", async () => {
+    const doc = await parseDocx(
+      await pictDocx({ runXml: PICT_WITH_CHARACTER_REFERENCED_LINE_ENDINGS }),
+      { preloadFonts: false },
+    );
+    const rawXml = firstDrawing(doc.package.document.content.at(0))?.rawXml;
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const reopened = await parseDocx(out, { preloadFonts: false });
+
+    expect(firstDrawing(reopened.package.document.content.at(0))?.rawXml).toBe(rawXml);
+  });
+
+  test("stabilizes VML that omits standard namespace declarations", async () => {
+    const doc = await parseDocx(
+      await bodyScopedPictDocx(`<w:p><w:r>${PICT_WITH_IMAGE}</w:r></w:p>`),
+      { preloadFonts: false },
+    );
     const rawXml = firstDrawing(doc.package.document.content.at(0))?.rawXml;
 
     const out = await repackDocx(doc, { updateModifiedDate: false });

--- a/packages/core/src/docx/xmlParser.test.ts
+++ b/packages/core/src/docx/xmlParser.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { collectXmlnsDeclarations, elementToXml, parseXmlDocument } from "./xmlParser";
+import {
+  cloneWithXmlnsDeclarations,
+  collectXmlnsDeclarations,
+  elementToXml,
+  NAMESPACES,
+  parseXmlDocument,
+} from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 describe("OOXML parsing", () => {
@@ -53,6 +59,27 @@ describe("OOXML parsing", () => {
     expect(document ? elementToXml(document) : "").toContain(
       '<w:binData w:name="image1">QUJDRA==</w:binData>',
     );
+  });
+
+  test("keeps character-referenced carriage returns stable when serialized", () => {
+    const document = parseXmlDocument("<v:shape>&#xD;&#xA;<v:path/></v:shape>");
+    const serialized = document ? elementToXml(document) : "";
+    const reopened = parseXmlDocument(serialized);
+
+    expect(serialized).not.toContain("\r");
+    expect(reopened ? elementToXml(reopened) : "").toBe(serialized);
+  });
+
+  test("supplies canonical bindings for known unbound OOXML prefixes", () => {
+    const document = parseXmlDocument(
+      '<w:pict><v:shape><v:imagedata r:id="image"/></v:shape></w:pict>',
+    );
+    const selfContained = document ? cloneWithXmlnsDeclarations(document, {}) : null;
+    const serialized = selfContained ? elementToXml(selfContained) : "";
+
+    expect(serialized).toContain(`xmlns:w="${NAMESPACES.w}"`);
+    expect(serialized).toContain(`xmlns:v="${NAMESPACES.v}"`);
+    expect(serialized).toContain(`xmlns:r="${NAMESPACES.r}"`);
   });
 });
 

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -96,6 +96,8 @@ const fxpBuilder = new XMLBuilder(fxpBuilderOptions);
 const TEXT_KEY = "#text";
 /** Attribute group key used by fast-xml-parser in preserveOrder mode. */
 const ATTR_KEY = ":@";
+/** Character reference required to keep carriage returns through XML end-of-line normalization. */
+const XML_CARRIAGE_RETURN_REFERENCE = "&#13;";
 
 type MutableFxpNode = XmlElement & Record<string, unknown>;
 
@@ -210,7 +212,8 @@ export function parseXml(xml: string): XmlElement {
  */
 export function elementToXml(element: XmlElement): string {
   const fxpNode = elementToFxpNode(element);
-  return fxpBuilder.build([fxpNode]) as string;
+  const xml = fxpBuilder.build([fxpNode]) as string;
+  return xml.replaceAll("\r", XML_CARRIAGE_RETURN_REFERENCE);
 }
 
 /**
@@ -1040,6 +1043,9 @@ const collectUsedNamespacePrefixes = (
   return prefixes;
 };
 
+const isCanonicalNamespacePrefix = (prefix: string): prefix is keyof typeof NAMESPACES =>
+  Object.hasOwn(NAMESPACES, prefix);
+
 /**
  * Return a shallow clone of `element` carrying the inherited namespace
  * declarations needed by its raw subtree.
@@ -1047,6 +1053,8 @@ const collectUsedNamespacePrefixes = (
  * Existing declarations retain their authored order. Only missing, referenced
  * bindings are appended, which makes repeated detach/replay cycles idempotent
  * even when the surrounding document declares a different namespace superset.
+ * If a producer omitted a binding for a standard OOXML prefix, use its
+ * canonical binding so the detached subtree is valid on its first replay.
  */
 export function cloneWithXmlnsDeclarations(
   element: XmlElement,
@@ -1060,6 +1068,18 @@ export function cloneWithXmlnsDeclarations(
     if (prefixes.has(prefix) && attributes[name] === undefined) {
       additions[name] = value;
     }
+  }
+  for (const prefix of prefixes) {
+    const name = `xmlns:${prefix}`;
+    if (
+      !prefix ||
+      attributes[name] !== undefined ||
+      additions[name] !== undefined ||
+      !isCanonicalNamespacePrefix(prefix)
+    ) {
+      continue;
+    }
+    additions[name] = NAMESPACES[prefix];
   }
   for (const _key in additions) {
     return {


### PR DESCRIPTION
## Summary

- serialize carriage returns as XML character references so end-of-line normalization cannot silently change preserved fragments
- supply canonical namespace declarations for referenced standard OOXML prefixes when malformed producer XML omitted them
- keep detached VML and other preserved XML fragments stable across save and reopen

## Validation

- focused XML and VML regression tests (29 passed)
- core suite (4,367 passed; optional differential tests skipped)
- typecheck, lint, and formatting
- build and clean-room distribution validation
- changeset check
- dependency audit