### PR TITLE
fix: preserve comment content formatting

### DIFF
--- a/.changeset/quiet-comments-format.md
+++ b/.changeset/quiet-comments-format.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve paragraph and run formatting when serializing comment content.

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Comment } from "../../types/content";
+import { parseComments } from "../commentParser";
 import { serializeComments, serializeCommentsExtended } from "./commentSerializer";
 
 function makeComment(id: number, parentId?: number): Comment {
@@ -73,6 +74,30 @@ describe("serializeComments", () => {
     expect(xml).toContain("w14:paraId=");
     expect(xml).toContain("&lt;script&gt;");
     expect(xml).toContain("&quot;");
+  });
+
+  test("round-trips supported paragraph and run formatting in comment content", () => {
+    const comment = makeComment(1);
+    const paragraph = comment.content[0]!;
+    paragraph.formatting = {
+      alignment: "center",
+      spaceAfter: 120,
+    };
+    const run = paragraph.content[0]!;
+    if (run.type !== "run") {
+      throw new Error("Expected synthetic comment content to contain a run");
+    }
+    run.formatting = {
+      fontSize: 24,
+      underline: { style: "single" },
+    };
+
+    const reparsed = parseComments(serializeComments([comment]), null, null, new Map(), new Map());
+    const reparsedParagraph = reparsed[0]?.content[0];
+    const reparsedRun = reparsedParagraph?.content.find((item) => item.type === "run");
+
+    expect(reparsedParagraph?.formatting).toMatchObject(paragraph.formatting);
+    expect(reparsedRun?.formatting).toMatchObject(run.formatting);
   });
 });
 

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -5,76 +5,27 @@
  */
 
 import { deterministicHexId } from "../../utils/hexId";
-import type { Comment, Paragraph, Run } from "../../types/content";
+import type { Comment, Paragraph } from "../../types/content";
+import { serializeParagraph } from "./paragraphSerializer";
 import { escapeXml } from "./xmlUtils";
 
-function serializeRunContent(run: Run): string {
-  let xml = "<w:r>";
-  // Run properties (minimal — just preserve formatting basics)
-  const rPr: string[] = [];
-  if (run.formatting?.bold) {
-    rPr.push("<w:b/>");
-  }
-  if (run.formatting?.italic) {
-    rPr.push("<w:i/>");
-  }
-  if (rPr.length > 0) {
-    xml += `<w:rPr>${rPr.join("")}</w:rPr>`;
-  }
-
-  for (const c of run.content) {
-    if (c.type === "text") {
-      const preserveSpace = c.text !== c.text.trim() || c.text.includes("  ");
-      xml += preserveSpace
-        ? `<w:t xml:space="preserve">${escapeXml(c.text)}</w:t>`
-        : `<w:t>${escapeXml(c.text)}</w:t>`;
-    } else if (c.type === "break") {
-      xml += "<w:br/>";
-    }
-  }
-  xml += "</w:r>";
-  return xml;
-}
-
-/**
- * `w14:paraId` / `w14:textId` open tag for a comment paragraph. Word keys
- * commentsExtended.xml (reply threading) and commentsExtensible.xml (UTC
- * dates) on the paraId of a comment's LAST paragraph, so the id must survive
- * serialization; the parser stores it on `Paragraph.paraId`.
- */
-function commentParagraphOpenTag(p: Paragraph): string {
-  const attrs: string[] = [];
-  if (p.paraId) {
-    attrs.push(`w14:paraId="${escapeXml(p.paraId)}"`);
-  }
-  if (p.textId) {
-    attrs.push(`w14:textId="${escapeXml(p.textId)}"`);
-  }
-  return attrs.length > 0 ? `<w:p ${attrs.join(" ")}>` : "<w:p>";
-}
-
-function serializeParagraph(p: Paragraph): string {
-  let xml = commentParagraphOpenTag(p);
-  for (const item of p.content) {
-    if (item.type === "run") {
-      xml += serializeRunContent(item);
-    }
-  }
-  xml += "</w:p>";
-  return xml;
-}
+const ANNOTATION_REFERENCE_XML =
+  '<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:annotationRef/></w:r>';
+const PARAGRAPH_PROPERTIES_END = "</w:pPr>";
 
 /** Serialize a paragraph, prepending an annotationRef run (required by Word in first paragraph of a comment) */
-function serializeParagraphWithAnnotationRef(p: Paragraph): string {
-  let xml = commentParagraphOpenTag(p);
-  xml += '<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:annotationRef/></w:r>';
-  for (const item of p.content) {
-    if (item.type === "run") {
-      xml += serializeRunContent(item);
-    }
+function serializeParagraphWithAnnotationRef(paragraph: Paragraph): string {
+  const xml = serializeParagraph(paragraph);
+  const propertiesEnd = xml.indexOf(PARAGRAPH_PROPERTIES_END);
+  if (propertiesEnd !== -1) {
+    const contentStart = propertiesEnd + PARAGRAPH_PROPERTIES_END.length;
+    return `${xml.slice(0, contentStart)}${ANNOTATION_REFERENCE_XML}${xml.slice(contentStart)}`;
   }
-  xml += "</w:p>";
-  return xml;
+
+  return xml.replace(
+    /^<w:p(?=[\s>])[^>]*>/u,
+    (openingTag) => `${openingTag}${ANNOTATION_REFERENCE_XML}`,
+  );
 }
 
 function serializeComment(comment: Comment): string {


### PR DESCRIPTION
## Summary

- serialize comment paragraphs through the canonical paragraph writer
- preserve supported paragraph and run properties in comment bodies
- insert the required annotation-reference run after paragraph properties
- remove the partial comment-only writer that handled only bold and italic

## Validation

- focused comment and thread suites (19 passed)
- full core suite with isolated stress-test reruns
- lint and core typecheck
- focused post-rebase regression test
- changeset check