### PR TITLE
fix: preserve absent content control selections

### DIFF
--- a/.changeset/tidy-content-controls-rest.md
+++ b/.changeset/tidy-content-controls-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve an absent dropdown selection when saving untouched content controls.

--- a/packages/core/src/docx/serializer/blockSdtSerializer.test.ts
+++ b/packages/core/src/docx/serializer/blockSdtSerializer.test.ts
@@ -149,6 +149,62 @@ describe("serializeBlockSdt — raw sdtPr replay", () => {
     expect(xml).toContain("</w:dropDownList>");
   });
 
+  test.each(["dropDownList", "comboBox"])(
+    "does not infer a %s lastValue for an untouched parsed control",
+    (marker) => {
+      const blocks = parseBlocks(`<w:body ${NS}>
+        <w:sdt>
+          <w:sdtPr>
+            <w:${marker}>
+              <w:listItem w:displayText="Visible label" w:value="stored-value"/>
+            </w:${marker}>
+          </w:sdtPr>
+          <w:sdtContent>
+            <w:p><w:r><w:t>Visible label</w:t></w:r></w:p>
+          </w:sdtContent>
+        </w:sdt>
+      </w:body>`);
+      const first = blocks.at(0);
+      if (!first || first.type !== "blockSdt") {
+        throw new Error(`expected blockSdt, got ${String(first?.type)}`);
+      }
+      const rawPropertiesXml = first.properties.rawPropertiesXml;
+      if (rawPropertiesXml === undefined) {
+        throw new Error("expected captured sdtPr XML");
+      }
+
+      const xml = serializeBlockSdt(first, noChildSerializer);
+
+      expect(xml).toContain(rawPropertiesXml);
+      expect(xml).not.toContain("lastValue");
+
+      const reopened = parseBlocks(`<w:body ${NS}>${xml}</w:body>`).at(0);
+      if (!reopened || reopened.type !== "blockSdt") {
+        throw new Error(`expected reopened blockSdt, got ${String(reopened?.type)}`);
+      }
+      expect(reopened.properties.dropdownLastValue).toBeUndefined();
+      expect(reopened.properties.rawPropertiesXml).toBe(rawPropertiesXml);
+    },
+  );
+
+  test("infers lastValue for a programmatic dropdown without a raw property snapshot", () => {
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "dropdown",
+        listItems: [{ displayText: "Visible label", value: "stored-value" }],
+      },
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "run", content: [{ type: "text", text: "Visible label" }] }],
+        },
+      ],
+    };
+
+    expect(serializeBlockSdt(sdt, noChildSerializer)).toContain('w:lastValue="stored-value"');
+  });
+
   test("dropdownLastValue from the model wins over body-text matching when displayText collides", () => {
     // Two list items share a displayText ("Other"). The body shows the
     // friendly label, but the API set the picked OOXML value to "other-b".

--- a/packages/core/src/docx/serializer/blockSdtSerializer.ts
+++ b/packages/core/src/docx/serializer/blockSdtSerializer.ts
@@ -117,8 +117,8 @@ function extractDropdownLastValue(blockSdt: BlockSdt): string | undefined {
   // and reload-recovered by the parser from the source `w:lastValue`).
   // Recovering it from the body's display text mis-selects the wrong entry
   // when two list items share a displayText, so the body-text fallback
-  // below only kicks in for documents that have neither been updated via
-  // the API nor parsed from a doc that carried a w:lastValue.
+  // below only applies to programmatic controls that have no captured raw
+  // property snapshot.
   const modeled = blockSdt.properties.dropdownLastValue;
   // `""` is a legitimate OOXML lastValue (a producer can author
   // `<w:listItem w:value=""/>` and `setContentControlValue` will pick
@@ -127,6 +127,12 @@ function extractDropdownLastValue(blockSdt: BlockSdt): string | undefined {
   // serialize the wrong sibling when display text collides.
   if (modeled !== undefined) {
     return modeled;
+  }
+  // A parsed raw snapshot is authoritative about whether the producer
+  // authored a selection. Inferring one from visible text would turn an
+  // intentionally absent @lastValue into a persisted selection on save.
+  if (blockSdt.properties.rawPropertiesXml !== undefined) {
+    return undefined;
   }
   const firstBlock = blockSdt.content[0];
   if (!firstBlock || firstBlock.type !== "paragraph") {


### PR DESCRIPTION
## Summary

- treat captured raw content-control properties as authoritative for parsed controls
- preserve an absent dropdown or combo-box selection instead of inferring one from visible text
- retain visible-text inference for programmatic controls without a raw property snapshot

## Validation

- focused and property tests (49 passed)
- core typecheck and lint
- core and monorepo builds
- clean-room distribution validation
- changeset check
- dependency audit