### PR TITLE
fix: stabilize complex field markers

### DIFF
--- a/.changeset/quiet-fields-close.md
+++ b/.changeset/quiet-fields-close.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep complex fields structurally stable across repeated DOCX save and reopen cycles.

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1373,6 +1373,29 @@ function parseParagraphContents(
             complexFieldFormatting = run.formatting;
           }
 
+          // A single physical run may contain both the instruction text and
+          // structural begin/separate/end markers. Preserve only the content
+          // inside the code region: fieldCode owns authored code content, while
+          // the ComplexField serializer owns all structural markers.
+          let inFieldCodeRegion = !hasFieldBegin && !afterSeparator;
+          const fieldCodeContent: Run["content"] = [];
+          for (const content of run.content) {
+            if (content.type === "fieldChar") {
+              inFieldCodeRegion = content.charType === "begin";
+              continue;
+            }
+            if (inFieldCodeRegion) {
+              fieldCodeContent.push(content);
+            }
+          }
+          if (fieldCodeContent.length > 0) {
+            complexFieldCodeRuns.push(
+              fieldCodeContent.length === run.content.length
+                ? run
+                : { ...run, content: fieldCodeContent },
+            );
+          }
+
           if (hasFieldSeparate) {
             afterSeparator = true;
           }
@@ -1382,9 +1405,6 @@ function parseParagraphContents(
             if (!hasFieldSeparate) {
               complexFieldResultRuns.push(run);
             }
-          } else if (!afterSeparator && !hasFieldBegin) {
-            // Add to code runs
-            complexFieldCodeRuns.push(run);
           }
 
           if (hasFieldEnd) {

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -97,11 +97,47 @@ describe("serializeComplexField structural-run formatting round-trip", () => {
       </w:r>
     `);
     const field = fieldOf(original);
+    expect(field.fieldCode).toHaveLength(1);
+    expect(field.fieldCode[0]?.content).toEqual([{ type: "instrText", text: " PAGE " }]);
     expect(field.fieldResult).toHaveLength(0);
     expect(field.formatting).toEqual({ color: { rgb: "595959" }, fontSize: 14 });
 
-    const roundTripped = fieldOf(reparse(serializeParagraph(original)));
-    expect(roundTripped.formatting).toEqual(field.formatting);
+    const roundTripped = reparse(serializeParagraph(original));
+    expect(roundTripped).toEqual(original);
+    expect(reparse(serializeParagraph(roundTripped))).toEqual(roundTripped);
+  });
+
+  test("a field without a separator does not retain its closing marker as field code", () => {
+    const original = parseInner(`
+      <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+      <w:r><w:instrText xml:space="preserve"> INCLUDEPICTURE image.png </w:instrText></w:r>
+      <w:r><w:fldChar w:fldCharType="end"/></w:r>
+    `);
+    const field = fieldOf(original);
+
+    expect(field.fieldCode).toHaveLength(1);
+    expect(field.fieldCode[0]?.content).toEqual([
+      { type: "instrText", text: " INCLUDEPICTURE image.png " },
+    ]);
+
+    const roundTripped = reparse(serializeParagraph(original));
+    expect(roundTripped).toEqual(original);
+    expect(reparse(serializeParagraph(roundTripped))).toEqual(roundTripped);
+  });
+
+  test("an empty field does not gain a synthetic empty code run", () => {
+    const original = parseInner(`
+      <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+      <w:r><w:fldChar w:fldCharType="end"/></w:r>
+    `);
+    const field = fieldOf(original);
+
+    expect(field.instruction).toBe("");
+    expect(field.fieldCode).toHaveLength(0);
+
+    const roundTripped = reparse(serializeParagraph(original));
+    expect(roundTripped).toEqual(original);
+    expect(reparse(serializeParagraph(roundTripped))).toEqual(roundTripped);
   });
 
   test("a field with no run formatting keeps field.formatting undefined (never {})", () => {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -695,7 +695,7 @@ function serializeComplexField(field: ComplexField): string {
   // Field code (instrText)
   if (field.fieldCode.length > 0) {
     parts.push(...field.fieldCode.map((run) => serializeRun(run)));
-  } else {
+  } else if (field.instruction.length > 0) {
     // Fallback: create instrText from instruction
     const needsPreserve =
       field.instruction.startsWith(" ") ||


### PR DESCRIPTION
## Summary

- keep structural begin, separate, and end field markers owned by the complex-field model
- retain only authored code-region content in fieldCode, including mixed-content physical runs
- avoid synthesizing an empty instruction run for empty fields

## Validation

- synthetic and repository fixed-point tests (75 passed)
- exact repeated save/reopen checks
- typecheck, lint, and formatting
- build and clean-room distribution validation
- changeset check
- dependency audit