### PR TITLE
fix: preserve absent image wrap distances

### DIFF
--- a/.changeset/fresh-images-rest.md
+++ b/.changeset/fresh-images-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve omitted image wrap distances when saving documents.

--- a/packages/core/src/docx/__tests__/image-effect-extent-opacity-overlap.test.ts
+++ b/packages/core/src/docx/__tests__/image-effect-extent-opacity-overlap.test.ts
@@ -67,8 +67,10 @@ describe("wp:effectExtent stays separate from wp:inline/wp:anchor dist*", () => 
       padding: { top: 100, bottom: 200, left: 300, right: 400 },
     });
     expect(xml).toContain('<wp:effectExtent l="300" t="100" r="400" b="200"/>');
-    // No wrap distances were set, so dist* on wp:inline must be zero.
-    expect(xml).toContain('distT="0" distB="0" distL="0" distR="0"');
+    // An omitted distance is semantically zero but remains absent so an
+    // untouched parse → save → parse is a model fixed point.
+    expect(xml).not.toMatch(/\bdist[TLBR]=/u);
+    expect(reparseSerializedImage(xml)?.wrap).toEqual({ type: "inline" });
   });
 
   test("inline image wrap.dist* serializes to wp:inline dist* attrs", () => {
@@ -97,6 +99,41 @@ describe("wp:effectExtent stays separate from wp:inline/wp:anchor dist*", () => 
     });
     expect(xml).toContain('distT="10" distB="20" distL="30" distR="40"');
     expect(xml).toContain('<wp:effectExtent l="3" t="1" r="4" b="2"/>');
+  });
+
+  test("floating image preserves absent wrap distances", () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "behind" },
+      position: {
+        horizontal: { relativeTo: "column", posOffset: 0 },
+        vertical: { relativeTo: "paragraph", posOffset: 0 },
+      },
+    });
+
+    expect(xml).toContain("<wp:anchor simplePos=");
+    expect(xml).not.toMatch(/\bdist[TLBR]=/u);
+    expect(reparseSerializedImage(xml)?.wrap).toEqual({ type: "behind" });
+  });
+
+  test("explicit zero wrap distances remain explicit", () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "inline", distT: 0, distB: 0, distL: 0, distR: 0 },
+    });
+
+    expect(xml).toContain('distT="0" distB="0" distL="0" distR="0"');
+    expect(reparseSerializedImage(xml)?.wrap).toEqual({
+      type: "inline",
+      distT: 0,
+      distB: 0,
+      distL: 0,
+      distR: 0,
+    });
   });
 
   test("padding survives a full XML round-trip", () => {

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -152,7 +152,7 @@ describe("image EMU attributes are integer-only (issue #417)", () => {
     // wp:inline distT/B/L/R. With padding {top: 0.4, bottom: 0.6},
     // intAttr rounds → t="0" b="1" on the effectExtent element.
     expect(xml).toContain('<wp:effectExtent l="0" t="0" r="0" b="1"/>');
-    expect(xml).toContain('distT="0" distB="0" distL="0" distR="0"');
+    expect(xml).not.toMatch(/\bdist[TLBR]=/u);
   });
 
   test("floating image with float position/extent serializes integer attrs", () => {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -832,6 +832,27 @@ function serializePicGraphic(image: Image, sharedId: string): string {
 }
 
 /**
+ * Serialize only authored wrap-distance attributes. OOXML defaults omitted
+ * values to zero, but preserving absence keeps untouched models stable.
+ */
+function serializeWrapDistanceAttrs(wrap: ImageWrap | undefined): string {
+  const attrs: string[] = [];
+  if (wrap?.distT !== undefined) {
+    attrs.push(`distT="${intAttr(wrap.distT)}"`);
+  }
+  if (wrap?.distB !== undefined) {
+    attrs.push(`distB="${intAttr(wrap.distB)}"`);
+  }
+  if (wrap?.distL !== undefined) {
+    attrs.push(`distL="${intAttr(wrap.distL)}"`);
+  }
+  if (wrap?.distR !== undefined) {
+    attrs.push(`distR="${intAttr(wrap.distR)}"`);
+  }
+  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+}
+
+/**
  * Serialize drawing/image content (w:drawing) to full DrawingML XML
  */
 function serializeDrawingContent(content: DrawingContent): string {
@@ -843,10 +864,7 @@ function serializeDrawingContent(content: DrawingContent): string {
   // distances. Per §20.4.2.5, the visual-effect reservation lives on the
   // separate <wp:effectExtent> element. Don't fold `image.padding`
   // (effectExtent) into wrap dist* — that's the eigenpal #424 fix.
-  const distT = image.wrap.distT ?? 0;
-  const distB = image.wrap.distB ?? 0;
-  const distL = image.wrap.distL ?? 0;
-  const distR = image.wrap.distR ?? 0;
+  const wrapDistanceAttrs = serializeWrapDistanceAttrs(image.wrap);
   const effL = image.padding?.left ?? 0;
   const effT = image.padding?.top ?? 0;
   const effR = image.padding?.right ?? 0;
@@ -872,7 +890,7 @@ function serializeDrawingContent(content: DrawingContent): string {
     // Inline image
     return [
       "<w:drawing>",
-      `<wp:inline distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}">`,
+      `<wp:inline${wrapDistanceAttrs}>`,
       `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
       effectExtentEl,
       inlineDocPr,
@@ -896,7 +914,7 @@ function serializeDrawingContent(content: DrawingContent): string {
 
   return [
     "<w:drawing>",
-    `<wp:anchor distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="${layoutInCellAttr}" allowOverlap="${allowOverlapAttr}">`,
+    `<wp:anchor${wrapDistanceAttrs} simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="${layoutInCellAttr}" allowOverlap="${allowOverlapAttr}">`,
     '<wp:simplePos x="0" y="0"/>',
     position,
     `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
@@ -923,23 +941,6 @@ function serializeShapeTextBody(
     .join("");
 }
 
-function serializeShapeWrapDistances(wrap: ImageWrap | undefined): string {
-  const attrs: string[] = [];
-  if (wrap?.distT !== undefined) {
-    attrs.push(`distT="${intAttr(wrap.distT)}"`);
-  }
-  if (wrap?.distB !== undefined) {
-    attrs.push(`distB="${intAttr(wrap.distB)}"`);
-  }
-  if (wrap?.distL !== undefined) {
-    attrs.push(`distL="${intAttr(wrap.distL)}"`);
-  }
-  if (wrap?.distR !== undefined) {
-    attrs.push(`distR="${intAttr(wrap.distR)}"`);
-  }
-  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
-}
-
 /**
  * Serialize shape content to full DrawingML XML (wps:wsp inside w:drawing)
  */
@@ -949,7 +950,7 @@ function serializeShapeContent(content: ShapeContent): string {
   const cy = shape.size.height;
   const isTextBox = shape.shapeType === "textBox";
   const isFloating = shape.wrap && shape.wrap.type !== "inline";
-  const wrapDistances = serializeShapeWrapDistances(shape.wrap);
+  const wrapDistances = serializeWrapDistanceAttrs(shape.wrap);
   const docPrId = getUniqueId(shape.id);
   const docPrName = shape.name ?? (isTextBox ? `TextBox ${docPrId}` : `Shape ${docPrId}`);
 


### PR DESCRIPTION
## Summary

- serialize image wrap-distance attributes only when they were authored
- preserve the model distinction between omitted distances and explicit zero values
- share the same absence-preserving helper between image and shape serialization

## Validation

- focused image and shape tests (46 passed)
- full core suite (4,375 passed; optional differential tests skipped)
- exact parse/save/reopen checks
- lint, typecheck, and build
- clean-room distribution validation
- changeset check
- dependency audit