### PR TITLE
fix: stabilize rendered page-break hints

### DIFF
--- a/.changeset/calm-breaks-rest.md
+++ b/.changeset/calm-breaks-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep cached rendered page-break metadata stable when later inline content is omitted.

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -56,6 +56,7 @@ import { parseFontTable } from "./fontTableParser";
 import type { NumberingMap } from "./numberingParser";
 import { normalizeNumberingReferences } from "./numberingReferenceNormalization";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
+import { normalizeRenderedPageBreakHints } from "./renderedPageBreakNormalization";
 import { parseSettings } from "./settingsParser";
 import { parseStylesPackage } from "./styleParser";
 import type { StyleMap } from "./styleParser";
@@ -280,6 +281,13 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
     if (comments.length > 0) {
       documentBody.comments = comments;
     }
+    normalizeRenderedPageBreakHints({
+      documentBody,
+      ...(headers !== undefined ? { headers } : {}),
+      ...(footers !== undefined ? { footers } : {}),
+      ...(footnotes !== undefined ? { footnotes } : {}),
+      ...(endnotes !== undefined ? { endnotes } : {}),
+    });
     const commentReferenceNormalization = normalizeCommentReferences({
       documentBody,
       comments,

--- a/packages/core/src/docx/renderedPageBreakNormalization.test.ts
+++ b/packages/core/src/docx/renderedPageBreakNormalization.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DocumentBody } from "../types/document";
+import { normalizeRenderedPageBreakHints } from "./renderedPageBreakNormalization";
+
+describe("rendered page-break normalization", () => {
+  test("keeps only hints whose leading marker still precedes serializable content", () => {
+    const documentBody = {
+      content: [
+        {
+          type: "paragraph",
+          renderedPageBreakBefore: true,
+          content: [{ type: "run", content: [{ type: "renderedPageBreak" }] }],
+        },
+        {
+          type: "paragraph",
+          renderedPageBreakBefore: true,
+          content: [
+            {
+              type: "run",
+              content: [{ type: "renderedPageBreak" }, { type: "text", text: "retained" }],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          renderedPageBreakBefore: true,
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "before" }, { type: "renderedPageBreak" }],
+            },
+          ],
+        },
+      ],
+    } satisfies DocumentBody;
+
+    normalizeRenderedPageBreakHints({ documentBody });
+
+    expect(
+      documentBody.content.map(({ renderedPageBreakBefore }) => renderedPageBreakBefore),
+    ).toEqual([undefined, true, undefined]);
+  });
+});

--- a/packages/core/src/docx/renderedPageBreakNormalization.ts
+++ b/packages/core/src/docx/renderedPageBreakNormalization.ts
@@ -1,0 +1,125 @@
+import type {
+  DocumentBody,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Hyperlink,
+  ParagraphContent,
+  Run,
+} from "../types/document";
+import { visitDocxParagraphs } from "./paragraphTraversal";
+
+type NormalizeRenderedPageBreakHintsInput = {
+  documentBody: DocumentBody;
+  headers?: Map<string, HeaderFooter>;
+  footers?: Map<string, HeaderFooter>;
+  footnotes?: readonly Footnote[];
+  endnotes?: readonly Endnote[];
+};
+
+export const normalizeRenderedPageBreakHints = ({
+  documentBody,
+  headers,
+  footers,
+  footnotes,
+  endnotes,
+}: NormalizeRenderedPageBreakHintsInput): void => {
+  visitDocxParagraphs({ documentBody, headers, footers, footnotes, endnotes }, (paragraph) => {
+    if (
+      paragraph.renderedPageBreakBefore === true &&
+      !retainsLeadingRenderedPageBreak(paragraph.content)
+    ) {
+      delete paragraph.renderedPageBreakBefore;
+    }
+  });
+};
+
+const retainsLeadingRenderedPageBreak = (content: readonly ParagraphContent[]): boolean => {
+  const scan = { sawRenderedPageBreak: false };
+  for (const item of content) {
+    const result = scanParagraphContent(item, scan);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return false;
+};
+
+type RenderedPageBreakScan = {
+  sawRenderedPageBreak: boolean;
+};
+
+const scanRun = (run: Run, scan: RenderedPageBreakScan): boolean | undefined => {
+  for (const content of run.content) {
+    if (content.type === "renderedPageBreak") {
+      scan.sawRenderedPageBreak = true;
+      continue;
+    }
+    return scan.sawRenderedPageBreak;
+  }
+  return undefined;
+};
+
+const scanHyperlink = (hyperlink: Hyperlink, scan: RenderedPageBreakScan): boolean | undefined => {
+  for (const child of hyperlink.children) {
+    if (child.type !== "run") {
+      continue;
+    }
+    const result = scanRun(child, scan);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
+};
+
+const scanInlineContent = (
+  content: readonly (Run | Hyperlink)[],
+  scan: RenderedPageBreakScan,
+): boolean | undefined => {
+  for (const child of content) {
+    const result = child.type === "run" ? scanRun(child, scan) : scanHyperlink(child, scan);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
+};
+
+const scanParagraphContent = (
+  content: ParagraphContent,
+  scan: RenderedPageBreakScan,
+): boolean | undefined => {
+  if (content.type === "run") {
+    return scanRun(content, scan);
+  }
+  if (content.type === "hyperlink") {
+    return scanHyperlink(content, scan);
+  }
+  if (content.type === "simpleField") {
+    return scanInlineContent(content.content, scan);
+  }
+  if (
+    content.type === "insertion" ||
+    content.type === "deletion" ||
+    content.type === "moveFrom" ||
+    content.type === "moveTo"
+  ) {
+    return scanInlineContent(content.content, scan);
+  }
+  if (content.type === "inlineSdt") {
+    for (const child of content.content) {
+      const result = scanParagraphContent(child, scan);
+      if (result !== undefined) {
+        return result;
+      }
+    }
+    return undefined;
+  }
+  if (content.type === "complexField") {
+    // The serializer always emits a leading w:fldChar for a complex field.
+    return scan.sawRenderedPageBreak;
+  }
+  // Range markers and math are not visible to the raw leading-break detector.
+  return undefined;
+};

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -312,6 +312,46 @@ describe("VML w:pict inline images", () => {
     expect(firstDrawing(doc.package.document.content.at(0))).toBeUndefined();
   });
 
+  test("stabilizes a cached page-break hint when later inline content is omitted", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:lastRenderedPageBreak/><w:pict><v:rect/></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+    const paragraph = doc.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected a paragraph");
+    }
+    expect(paragraph.renderedPageBreakBefore).toBeUndefined();
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const reopened = await parseDocx(out, { preloadFonts: false });
+
+    expect(reopened.package.document.content.at(0)).toEqual(paragraph);
+  });
+
+  test("keeps a cached page-break hint when the following VML content is retained", async () => {
+    const doc = await parseDocx(
+      await pictDocx({ runXml: `<w:lastRenderedPageBreak/>${PICT_WITH_IMAGE}` }),
+      { preloadFonts: false },
+    );
+    const paragraph = doc.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected a paragraph");
+    }
+    expect(paragraph.renderedPageBreakBefore).toBe(true);
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const reopened = await parseDocx(out, { preloadFonts: false });
+
+    expect(reopened.package.document.content.at(0)).toEqual(paragraph);
+  });
+
   test("renders a positioned solid rectangle without embedded image data", async () => {
     const doc = await parseDocx(
       await pictDocx({


### PR DESCRIPTION
## Summary

- normalize cached rendered-page-break hints after parsing all document stories
- retain a hint only when the surviving model can serialize it before meaningful inline content
- preserve hints when supported VML content survives while dropping stale hints left by omitted unsupported content

## Validation

- focused parser and save/reopen tests (59 passed)
- full core suite (4,379 passed; optional differential tests skipped)
- core typecheck and lint
- build and clean-room distribution validation
- changeset check