### PR TITLE
feat(react): add DocxEditor initialZoom="fit-width"

### DIFF
--- a/.changeset/docx-editor-fit-width.md
+++ b/.changeset/docx-editor-fit-width.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": minor
+---
+
+Add `initialZoom="fit-width"` to `DocxEditor`. It sizes the page to the editor's width and keeps it fit as the editor resizes (never enlarging past 100%), so a document embedded in a container narrower than its page no longer overflows and clips on the right. A manual zoom (toolbar or `ref.setZoom`) afterwards overrides the fit. The fit is computed from the laid-out page geometry, so the scaled page never has to be measured in the DOM.

--- a/api-reports/react/index.api.md
+++ b/api-reports/react/index.api.md
@@ -383,7 +383,7 @@ export type DocxEditorProps = {
     marginGuideColor?: string;
     showRuler?: boolean;
     rulerUnit?: "inch" | "cm";
-    initialZoom?: number;
+    initialZoom?: number | "fit-width";
     enableWheelZoom?: boolean;
     readOnly?: boolean;
     autoOpenReviewSidebar?: boolean;

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -160,8 +160,12 @@ export type DocxEditorProps = {
   showRuler?: boolean;
   /** Measurement unit shown on the rulers (default: 'inch'). */
   rulerUnit?: "inch" | "cm";
-  /** Initial zoom level (default: 1.0) */
-  initialZoom?: number;
+  /**
+   * Initial zoom level as a number (default: 1.0 = 100%), or `"fit-width"` to
+   * size the page to the editor's width and keep it fit as the editor resizes.
+   * A manual zoom (toolbar or `ref.setZoom`) afterwards overrides the fit.
+   */
+  initialZoom?: number | "fit-width";
   /** Whether Ctrl/Cmd+wheel and trackpad-pinch zoom are enabled (default: true) */
   enableWheelZoom?: boolean;
   /** Whether the editor is read-only. When true, hides toolbar and rulers */

--- a/packages/react/src/components/hooks/useZoomAndPageInfo.ts
+++ b/packages/react/src/components/hooks/useZoomAndPageInfo.ts
@@ -13,11 +13,23 @@ import type { PagedEditorRef } from "../../paged-editor/PagedEditor";
 
 const PAGE_INFO_FADE_MS = 600;
 
+// Breathing room kept between the fitted page and the scroll container edges so
+// the page does not sit flush against them (matched to the viewport padding).
+const FIT_TO_WIDTH_PADDING_PX = 16;
+const FIT_TO_WIDTH_MIN_ZOOM = 0.1;
+// A page never grows past 100% in fit-width: a container wider than the page
+// leaves the page at natural size, centred, rather than magnified.
+const FIT_TO_WIDTH_MAX_ZOOM = 1;
+
 export type UseZoomAndPageInfoArgs = {
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   pagedEditorRef: RefObject<PagedEditorRef | null>;
-  /** Initial zoom on mount. Subsequent changes do not apply. */
-  initialZoom: number;
+  /**
+   * Initial zoom on mount as a number (1 = 100%), or `"fit-width"` to size the
+   * page to the scroll container's width and keep it fit as the container
+   * resizes. A later imperative `setZoom`/toolbar change overrides the fit.
+   */
+  initialZoom: number | "fit-width";
 };
 
 export type UseZoomAndPageInfoReturn = {
@@ -43,7 +55,8 @@ export function useZoomAndPageInfo({
   pagedEditorRef,
   initialZoom,
 }: UseZoomAndPageInfoArgs): UseZoomAndPageInfoReturn {
-  const [zoom, setZoom] = useState(initialZoom);
+  const fitToWidth = initialZoom === "fit-width";
+  const [zoom, setZoom] = useState(typeof initialZoom === "number" ? initialZoom : 1);
   const zoomRef = useRef(zoom);
   const pendingZoomAnchorRef = useRef<ViewportCenterZoomAnchor | null>(null);
 
@@ -160,6 +173,49 @@ export function useZoomAndPageInfo({
       }
     };
   }, [scrollContainerEl, scheduleScrollPageInfoFade, updateScrollPageInfo]);
+
+  // fit-width: scale the page so its width fills the scroll container, and keep
+  // it fit as the container resizes. The page's natural width comes from the
+  // laid-out geometry (`layout.pages[0].size.w`), so the scaled page never has
+  // to be measured in the DOM; a rAF retry covers the window before the first
+  // layout completes. A manual zoom afterwards wins (this only re-fires on a
+  // container resize), matching the documented "override the fit" behaviour.
+  useEffect(() => {
+    if (!fitToWidth || !scrollContainerEl) {
+      return undefined;
+    }
+    let rafId = 0;
+    const applyFit = () => {
+      const pageWidth = pagedEditorRef.current?.getLayout()?.pages[0]?.size.w ?? 0;
+      if (pageWidth <= 0) {
+        rafId = requestAnimationFrame(applyFit); // layout not ready yet
+        return;
+      }
+      const available = scrollContainerEl.clientWidth - FIT_TO_WIDTH_PADDING_PX;
+      if (available <= 0) {
+        return;
+      }
+      const target = Math.min(
+        FIT_TO_WIDTH_MAX_ZOOM,
+        Math.max(FIT_TO_WIDTH_MIN_ZOOM, Math.round((available / pageWidth) * 100) / 100),
+      );
+      // Guard against a redundant zoom set (which would re-anchor the scroll)
+      // and sub-percent jitter.
+      if (Math.abs(target - zoomRef.current) > 0.005) {
+        setZoomWithViewportAnchor(target);
+      }
+    };
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(applyFit);
+    });
+    observer.observe(scrollContainerEl);
+    applyFit();
+    return () => {
+      cancelAnimationFrame(rafId);
+      observer.disconnect();
+    };
+  }, [fitToWidth, scrollContainerEl, pagedEditorRef, setZoomWithViewportAnchor]);
 
   return {
     zoom,


### PR DESCRIPTION
## What

Add `initialZoom="fit-width"` to `DocxEditor` (previously `initialZoom?: number` only, now `number | "fit-width"`). It sizes the page so its width fills the editor and keeps it fit as the editor resizes — never enlarging past 100%, so a container wider than the page just centres it.

## Why

A `.docx` renders its page at a fixed pixel width. When `DocxEditor` is embedded in a container narrower than that page (a preview pane, a compact hero, a split view), the page overflows and the right edge clips. Today every embedder reimplements a fit-to-width loop on top of the numeric `initialZoom` + `ref.setZoom` (apps/web has `useDocxFitZoom`; a landing DOCX-editor page needed the same). This makes it a first-class option.

## How

In `useZoomAndPageInfo`, when `initialZoom === "fit-width"`, a `ResizeObserver` on the scroll container computes `zoom = (containerWidth − padding) / pageWidth` and applies it via the existing viewport-anchored `setZoom`. The page width comes from the laid-out geometry (`layout.pages[0].size.w`), so the *scaled* page never has to be measured in the DOM; a `requestAnimationFrame` retry covers the window before the first layout completes. Clamped to [0.1, 1]. A manual zoom afterwards wins (the effect only re-fires on a container resize), matching the documented "override the fit" behaviour.

## Notes

- Purely additive: `initialZoom` defaults to `1` and existing numeric callers are unchanged.
- Follow-up worth considering: re-fit on a document *change* that alters page width without a container resize (today handled by remounting the editor per document, which the common embedders already do).

Typecheck passes on the react package.