### PR TITLE
fix: preserve lockfile graph during versioning

### DIFF
--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -41,6 +41,10 @@ the browser, built on ProseMirror. Two published packages plus a dev playground:
   differential parity gate — extend them when you change parsing, layout, or
   editor interactions.
 - Return minimal data from public APIs; do not export types that have no consumer.
+- **Never delete or regenerate `bun.lock` to apply package version bumps.** Run
+  `bun scripts/check-lockfile-workspace-versions.ts --write`, then
+  `bun install --frozen-lockfile`. The synchronizer is the sole owner of cached
+  workspace self-versions; dependency-graph changes belong in an explicit install.
 
 ### Fidelity Consolidation
 

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -28,7 +28,9 @@ without one of the above.
 1. PRs merge to `main`, each carrying its changeset(s).
 2. `release-pr.yml` maintains a **"Version Packages"** PR that applies the
    pending changesets: it bumps the affected `package.json` versions, updates the
-   changelogs, and re-syncs `bun.lock`.
+   changelogs, and surgically synchronizes workspace self-versions in `bun.lock`
+   before a frozen install. The resolved dependency graph is never regenerated
+   as a side effect of versioning.
 3. Merging that PR lands the version bumps on `main`. `publish.yml` builds and
    packs all six public packages without a publishing credential, then delegates
    registry state, dependency ordering, OIDC publishing, and per-package GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,8 @@ jobs:
       # `--frozen-lockfile` above only checks that the dependency graph still
       # satisfies bun.lock; it does not notice a workspace's cached "version"
       # field drifting behind its package.json (a plain `bun install` doesn't
-      # rewrite that field either — only a full lockfile regenerate does). See
-      # scripts/check-lockfile-workspace-versions.ts for the incident this
-      # guards against.
+      # rewrite that field either. The release path uses the same script in
+      # byte-preserving --write mode; CI keeps it in check-only mode.
       - name: Lockfile workspace-version check
         run: bun run check:lockfile-versions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,10 @@ the browser, built on ProseMirror. Two published packages plus a dev playground:
   differential parity gate — extend them when you change parsing, layout, or
   editor interactions.
 - Return minimal data from public APIs; do not export types that have no consumer.
+- **Never delete or regenerate `bun.lock` to apply package version bumps.** Run
+  `bun scripts/check-lockfile-workspace-versions.ts --write`, then
+  `bun install --frozen-lockfile`. The synchronizer is the sole owner of cached
+  workspace self-versions; dependency-graph changes belong in an explicit install.
 
 ### Fidelity Consolidation
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "validate-dist:vue": "bun scripts/validate-dist.ts vue",
     "api:update": "bun scripts/api-reports.ts --update",
     "api:check": "bun scripts/api-reports.ts",
-    "changeset:version": "changeset version && rm -f bun.lock && bun install",
+    "changeset:version": "changeset version && bun scripts/check-lockfile-workspace-versions.ts --write && bun install --frozen-lockfile",
     "bench": "bun benchmarks/index.ts",
     "bench:cross-language": "bun benchmarks/cross-language/run.ts",
     "parity": "bun parity/cli.ts",

--- a/scripts/bun-lock-workspace-versions.test.ts
+++ b/scripts/bun-lock-workspace-versions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import packageJson from "../package.json";
+import { syncWorkspaceVersions } from "./lib/bun-lock-workspace-versions";
+
+const fixture = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "packages/core": {
+      "name": "@stll/core",
+      "version": "1.0.0",
+      "dependencies": { "version": "do-not-touch" },
+    },
+    "packages/escaped\\u002dname": { "version": "2.0.0" },
+  },
+  "packages": [{ "version": "also-do-not-touch" }],
+}\n`;
+
+describe("bun.lock workspace self-version synchronization", () => {
+  test("changes only the exact workspace version string spans", () => {
+    const result = syncWorkspaceVersions(
+      fixture,
+      new Map([
+        ["packages/core", "1.1.0"],
+        ["packages/escaped-name", "2.1.0"],
+      ]),
+    );
+
+    expect(result.mismatches).toHaveLength(2);
+    expect(result.text).toBe(
+      fixture
+        .replace('"version": "1.0.0"', '"version": "1.1.0"')
+        .replace('"version": "2.0.0"', '"version": "2.1.0"'),
+    );
+    expect(result.text).toContain('"version": "do-not-touch"');
+    expect(result.text).toContain('"version": "also-do-not-touch"');
+  });
+
+  test("version-up/version-down is byte-identical", () => {
+    const up = syncWorkspaceVersions(fixture, new Map([["packages/core", "1.1.0"]])).text;
+    const down = syncWorkspaceVersions(up, new Map([["packages/core", "1.0.0"]])).text;
+
+    expect(down).toBe(fixture);
+  });
+
+  test("refuses to invent missing workspace structure", () => {
+    const result = syncWorkspaceVersions(fixture, new Map([["packages/missing", "1.0.0"]]));
+
+    expect(result.text).toBe(fixture);
+    expect(result.mismatches).toEqual([
+      { workspace: "packages/missing", expected: "1.0.0", actual: null },
+    ]);
+  });
+
+  test("release versioning cannot delete or regenerate bun.lock", () => {
+    const command = packageJson.scripts["changeset:version"];
+
+    expect(command).not.toMatch(/\brm\b/);
+    expect(command).toContain("check-lockfile-workspace-versions.ts --write");
+    expect(command).toEndWith("bun install --frozen-lockfile");
+  });
+});

--- a/scripts/check-lockfile-workspace-versions.ts
+++ b/scripts/check-lockfile-workspace-versions.ts
@@ -14,14 +14,13 @@
 // dependency range (see the @stll/docx-core ^0.4.0-vs-0.5.0 incident this
 // script was added to prevent).
 //
-// The only fix once it drifts is `rm bun.lock && bun install` (a full
-// regenerate). This script cross-checks each packages/*/package.json
-// `version` against the version bun.lock has cached for that workspace, so
-// the drift itself gets caught in CI instead of silently persisting.
+// This script is the single owner of workspace self-version synchronization:
+// check-only by default for CI, or byte-preserving repair with `--write`.
 
 import { panic } from "better-result";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
+import { syncWorkspaceVersions } from "./lib/bun-lock-workspace-versions";
 
 const ROOT = join(import.meta.dirname, "..");
 
@@ -37,31 +36,13 @@ const workspaceDirs = entries
 
 const lockText = await Bun.file(join(ROOT, "bun.lock")).text();
 
-// bun.lock is JSON-with-trailing-commas ("JSONC"-flavored), not strict JSON,
-// so a plain JSON.parse fails on it as-is. Trailing commas only ever appear
-// directly before a closing `}`/`]`, and that exact sequence cannot occur
-// inside any of bun.lock's own string values (workspace paths, package
-// names/versions/specifiers, or the base64 `sha512-...` integrity hashes),
-// so stripping them is a safe, structure-preserving normalize. Parsing the
-// whole file once and reading `workspaces[dir].version` from the resulting
-// object is immune to bun's key ordering or nested-object shape — unlike a
-// per-block regex, there is no block to mis-extract.
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const parsedLock: unknown = JSON.parse(lockText.replace(/,(\s*[}\]])/g, "$1"));
-if (!isRecord(parsedLock) || !isRecord(parsedLock.workspaces)) {
-  panic("bun.lock did not parse into the expected { workspaces: {...} } shape");
+const args = process.argv.slice(2);
+if (args.some((arg) => arg !== "--write") || args.filter((arg) => arg === "--write").length > 1) {
+  panic("Usage: bun scripts/check-lockfile-workspace-versions.ts [--write]");
 }
-const { workspaces: lockWorkspaces } = parsedLock;
-
-const versionForWorkspace = (workspacePath: string): string | null => {
-  const entry = lockWorkspaces[workspacePath];
-  if (!isRecord(entry) || typeof entry.version !== "string") return null;
-  return entry.version;
-};
-
-const mismatches: string[] = [];
+const write = args[0] === "--write";
+const expectedVersions = new Map<string, string>();
+const packageNames = new Map<string, string>();
 
 for (const workspaceDir of workspaceDirs) {
   // A directory under packages/ is not necessarily a real workspace: skip
@@ -73,17 +54,24 @@ for (const workspaceDir of workspaceDirs) {
   const version = pkg.version;
   if (typeof name !== "string" || typeof version !== "string") continue;
 
-  const lockedVersion = versionForWorkspace(workspaceDir);
-  if (lockedVersion === null) {
-    mismatches.push(`${name} (${workspaceDir}): no bun.lock entry found`);
-    continue;
-  }
-  if (lockedVersion !== version) {
-    mismatches.push(
-      `${name} (${workspaceDir}): package.json is ${version}, bun.lock has ${lockedVersion}`,
-    );
-  }
+  expectedVersions.set(workspaceDir, version);
+  packageNames.set(workspaceDir, name);
 }
+
+const result = syncWorkspaceVersions(lockText, expectedVersions);
+const unrepairable = result.mismatches.filter(({ actual }) => actual === null);
+
+if (write && unrepairable.length === 0 && result.text !== lockText) {
+  await Bun.write(join(ROOT, "bun.lock"), result.text);
+  console.log(`bun.lock workspace-version sync: updated ${result.mismatches.length} workspace(s).`);
+  process.exit(0);
+}
+
+const mismatches = result.mismatches.map(({ workspace, expected, actual }) =>
+  actual === null
+    ? `${packageNames.get(workspace)} (${workspace}): no writable bun.lock version entry found`
+    : `${packageNames.get(workspace)} (${workspace}): package.json is ${expected}, bun.lock has ${actual}`,
+);
 
 if (mismatches.length > 0) {
   console.error(
@@ -92,11 +80,12 @@ if (mismatches.length > 0) {
       "",
       ...mismatches.map((line) => `  - ${line}`),
       "",
-      "A plain `bun install` will not fix this (it doesn't rewrite cached",
-      "workspace versions for entries that already exist). Regenerate the",
-      "lockfile instead:",
+      write
+        ? "The lockfile shape is incomplete; workspace entries must exist before they can be synchronized."
+        : "A plain `bun install` will not fix cached workspace self-versions. Synchronize them with:",
       "",
-      "    rm bun.lock && bun install",
+      "    bun scripts/check-lockfile-workspace-versions.ts --write",
+      "    bun install --frozen-lockfile",
       "",
       "Then commit the refreshed bun.lock.",
     ].join("\n"),
@@ -104,4 +93,8 @@ if (mismatches.length > 0) {
   process.exit(1);
 }
 
-console.log("bun.lock workspace-version check: all workspace versions match. OK.");
+console.log(
+  write
+    ? "bun.lock workspace-version sync: already current. OK."
+    : "bun.lock workspace-version check: all workspace versions match. OK.",
+);

--- a/scripts/lib/bun-lock-workspace-versions.ts
+++ b/scripts/lib/bun-lock-workspace-versions.ts
@@ -1,0 +1,167 @@
+type JsonNode =
+  | { kind: "object"; properties: Map<string, JsonNode> }
+  | { kind: "string"; start: number; end: number; value: string }
+  | { kind: "other" };
+
+export type WorkspaceVersionMismatch = {
+  workspace: string;
+  expected: string;
+  actual: string | null;
+};
+
+export type WorkspaceVersionSyncResult = {
+  text: string;
+  mismatches: WorkspaceVersionMismatch[];
+};
+
+/**
+ * Synchronize only workspace self-version string values in a Bun lockfile.
+ *
+ * Bun does not refresh these cached values when package.json versions change.
+ * Re-generating the lockfile fixes them, but also needlessly rewrites the
+ * resolved dependency graph. This parser finds the exact JSON string spans and
+ * changes nothing else, making version-up/version-down operations reversible.
+ */
+export const syncWorkspaceVersions = (
+  source: string,
+  expectedVersions: ReadonlyMap<string, string>,
+): WorkspaceVersionSyncResult => {
+  let cursor = 0;
+
+  const fail = (message: string): never => {
+    throw new Error(`Invalid bun.lock at byte ${cursor}: ${message}`);
+  };
+
+  const skipTrivia = (): void => {
+    while (cursor < source.length) {
+      if (/\s/.test(source[cursor] ?? "")) {
+        cursor += 1;
+        continue;
+      }
+      if (source.startsWith("//", cursor)) {
+        const newline = source.indexOf("\n", cursor + 2);
+        cursor = newline === -1 ? source.length : newline + 1;
+        continue;
+      }
+      if (source.startsWith("/*", cursor)) {
+        const end = source.indexOf("*/", cursor + 2);
+        if (end === -1) fail("unterminated block comment");
+        cursor = end + 2;
+        continue;
+      }
+      break;
+    }
+  };
+
+  const parseString = (): Extract<JsonNode, { kind: "string" }> => {
+    skipTrivia();
+    const start = cursor;
+    if (source[cursor] !== '"') fail("expected a string");
+    cursor += 1;
+    while (cursor < source.length) {
+      const char = source[cursor];
+      if (char === "\\") {
+        cursor += 2;
+        continue;
+      }
+      cursor += 1;
+      if (char === '"') {
+        const raw = source.slice(start, cursor);
+        return {
+          kind: "string",
+          start,
+          end: cursor,
+          value: JSON.parse(raw) as string,
+        };
+      }
+    }
+    fail("unterminated string");
+  };
+
+  const parseValue = (): JsonNode => {
+    skipTrivia();
+    if (source[cursor] === '"') return parseString();
+    if (source[cursor] === "{") return parseObject();
+    if (source[cursor] === "[") {
+      cursor += 1;
+      skipTrivia();
+      while (source[cursor] !== "]") {
+        parseValue();
+        skipTrivia();
+        if (source[cursor] === ",") {
+          cursor += 1;
+          skipTrivia();
+          if (source[cursor] === "]") break;
+        } else if (source[cursor] !== "]") {
+          fail("expected ',' or ']' in array");
+        }
+      }
+      if (source[cursor] !== "]") fail("unterminated array");
+      cursor += 1;
+      return { kind: "other" };
+    }
+
+    const start = cursor;
+    while (cursor < source.length && !/[\s,}\]]/.test(source[cursor] ?? "")) cursor += 1;
+    if (cursor === start) fail("expected a value");
+    return { kind: "other" };
+  };
+
+  const parseObject = (): Extract<JsonNode, { kind: "object" }> => {
+    skipTrivia();
+    if (source[cursor] !== "{") fail("expected an object");
+    cursor += 1;
+    const properties = new Map<string, JsonNode>();
+    skipTrivia();
+    while (source[cursor] !== "}") {
+      const key = parseString().value;
+      skipTrivia();
+      if (source[cursor] !== ":") fail("expected ':' after object key");
+      cursor += 1;
+      properties.set(key, parseValue());
+      skipTrivia();
+      if (source[cursor] === ",") {
+        cursor += 1;
+        skipTrivia();
+        if (source[cursor] === "}") break;
+      } else if (source[cursor] !== "}") {
+        fail("expected ',' or '}' in object");
+      }
+    }
+    if (source[cursor] !== "}") fail("unterminated object");
+    cursor += 1;
+    return { kind: "object", properties };
+  };
+
+  const root = parseValue();
+  skipTrivia();
+  if (cursor !== source.length) fail("unexpected content after root value");
+  if (root.kind !== "object") throw new Error("Invalid bun.lock: root must be an object");
+  const workspaces = root.properties.get("workspaces");
+  if (workspaces?.kind !== "object") {
+    throw new Error("Invalid bun.lock: root workspaces property must be an object");
+  }
+
+  const mismatches: WorkspaceVersionMismatch[] = [];
+  const replacements: Array<{ start: number; end: number; value: string }> = [];
+  for (const [workspace, expected] of expectedVersions) {
+    const entry = workspaces.properties.get(workspace);
+    const version = entry?.kind === "object" ? entry.properties.get("version") : undefined;
+    const actual = version?.kind === "string" ? version.value : null;
+    if (actual === expected) continue;
+    mismatches.push({ workspace, expected, actual });
+    if (version?.kind === "string") {
+      replacements.push({
+        start: version.start,
+        end: version.end,
+        value: JSON.stringify(expected),
+      });
+    }
+  }
+
+  let text = source;
+  for (const replacement of replacements.sort((a, b) => b.start - a.start)) {
+    text = text.slice(0, replacement.start) + replacement.value + text.slice(replacement.end);
+  }
+  return { text, mismatches };
+};


### PR DESCRIPTION
## Summary

- synchronize cached Bun workspace self-versions without regenerating the resolved dependency graph
- make Changesets versioning use the synchronizer followed by a frozen install
- add executable invariants for exact-field updates, missing structure, and byte-identical version round trips
- document the required lockfile workflow in generated repository guidance

## Validation

- real `@stll/folio-core` 0.15.1 → 0.15.2 → 0.15.1 round trip; both frozen installs passed and `bun.lock` returned byte-identical (SHA-256 `523dcb8ba872729516775b007343a9975c613deb9ee60db29f0ec410b12ed414`)
- `bun run lint`
- `bun run format:check`
- `bun run check:i18n`
- parity/export/compiler guards
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run api:check`
- `bun run validate-dist`

CC on behalf of @jan-kubica