### PR TITLE
chore: adopt central release policy v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Enforce release intent
         # The repository owner publishes this versioned shared contract.
-        uses: stella/.github/.github/actions/changeset-policy@v1.0.0 # zizmor: ignore[unpinned-uses]
+        uses: stella/.github/.github/actions/changeset-policy@c47bb87cc82047b5fdc2540983148d4e3efa9a37 # v1.3.0
         with:
           release-paths: |
             packages/docx-core/src/**

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@v1.0.0 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@c47bb87cc82047b5fdc2540983148d4e3efa9a37 # v1.3.0
     with:
       artifact-pattern: npm-tarball-*
       package-files: |

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/changeset-release-pr.yml@v1.0.0 # zizmor: ignore[unpinned-uses]
+    uses: stella/.github/.github/workflows/changeset-release-pr.yml@c47bb87cc82047b5fdc2540983148d4e3efa9a37 # v1.3.0
     with:
       bun-version-file: package.json
     secrets:


### PR DESCRIPTION
## Summary

- pin the shared Changesets policy and release-PR workflow to immutable v1.3.0
- pin independent npm publishing to the same audited central release
- remove obsolete unpinned-use suppressions

## Validation

- `git diff --check`
- central v1.3 changeset-version policy validation
- verified all three shared entry points exist at the v1.3.0 release commit

CC on behalf of @jan-kubica