### PR TITLE
fix: trigger publishing only for version releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,14 @@ on:
   push:
     branches: [main]
     paths:
-      - packages/docx-core/package.json
-      - packages/core/package.json
-      - packages/react/package.json
-      - packages/agents/package.json
-      - packages/vue/package.json
-      - packages/nuxt/package.json
+      # Changesets owns these files, so ordinary manifest maintenance cannot
+      # accidentally start a release transaction.
+      - packages/docx-core/CHANGELOG.md
+      - packages/core/CHANGELOG.md
+      - packages/react/CHANGELOG.md
+      - packages/agents/CHANGELOG.md
+      - packages/vue/CHANGELOG.md
+      - packages/nuxt/CHANGELOG.md
   workflow_dispatch:
     inputs:
       publish:


### PR DESCRIPTION
## Summary

- trigger automatic publishing from Changesets-owned package changelogs
- keep manual build and publish dispatch unchanged
- prevent dependency or tooling-only manifest edits from starting a release transaction

## Validation

- `git diff --check`
- actionlint 1.7.12
- zizmor 1.28.0

CC on behalf of @jan-kubica