### PR TITLE
fix: preserve explicit no-highlight formatting

### DIFF
--- a/.changeset/quiet-highlights-stay.md
+++ b/.changeset/quiet-highlights-stay.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit no-highlight run formatting when saving DOCX files.

--- a/packages/core/src/docx/__tests__/color-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/color-roundtrip.test.ts
@@ -119,6 +119,7 @@ describe("Named highlight color round-trip", () => {
     "darkGray",
     "black",
     "white",
+    "none",
   ];
 
   for (const hl of highlights) {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -75,7 +75,7 @@ function getUniqueId(id: string | number | undefined): string {
 }
 
 /** Valid OOXML highlight color names (ECMA-376 §17.18.40) */
-const VALID_HIGHLIGHT_COLORS = new Set(HIGHLIGHT_COLOR_VALUES.filter((color) => color !== "none"));
+const VALID_HIGHLIGHT_COLORS = new Set(HIGHLIGHT_COLOR_VALUES);
 
 // ============================================================================
 // COLOR SERIALIZATION
@@ -367,8 +367,9 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
   }
 
   // Highlight — emit valid OOXML named colors via w:highlight,
-  // fall back to w:shd for custom hex colors
-  if (formatting.highlight && formatting.highlight !== "none") {
+  // including `none`, which explicitly cancels an inherited highlight.
+  // Fall back to w:shd for custom hex colors.
+  if (formatting.highlight) {
     if (VALID_HIGHLIGHT_COLORS.has(formatting.highlight)) {
       parts.push(`<w:highlight w:val="${formatting.highlight}"/>`);
     } else if (!formatting.shading) {


### PR DESCRIPTION
## Summary

- preserve explicit OOXML no-highlight overrides during run-property serialization
- cover the complete valid named-highlight set in round-trip tests