### PR TITLE
fix: stabilize empty run normalization

### DIFF
--- a/.changeset/silly-showers-travel.md
+++ b/.changeset/silly-showers-travel.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize syntactically empty Word runs without hiding unsupported run payloads.

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -311,6 +311,35 @@ describe("parseParagraph tab leader normalization", () => {
   });
 });
 
+describe("parseParagraph empty-run normalization", () => {
+  test("ignores syntactically empty runs before consolidating adjacent text", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r><w:t>A</w:t></w:r>
+        <w:r/>
+        <w:r><w:rPr/></w:r>
+        <w:r><w:t>B</w:t></w:r>
+      </w:p>
+    `);
+
+    expect(paragraph.content).toHaveLength(1);
+    expect(getParagraphText(paragraph)).toBe("AB");
+  });
+
+  test("keeps an unsupported run payload as a consolidation boundary", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r><w:t>A</w:t></w:r>
+        <w:r><w:ptab/></w:r>
+        <w:r><w:t>B</w:t></w:r>
+      </w:p>
+    `);
+
+    expect(paragraph.content).toHaveLength(2);
+    expect(getParagraphText(paragraph)).toBe("AB");
+  });
+});
+
 describe("parseParagraph rendered page break markers", () => {
   test("marks a paragraph when Word rendered-page-break appears before visible text", () => {
     const paragraph = parseParagraphXml(`

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -68,6 +68,7 @@ import {
   getAttribute,
   getChildElements,
   getLocalName,
+  matchesName,
   mergeXmlnsDeclarations,
   parseBooleanElement,
   parseNumberingLevelAttribute,
@@ -1259,6 +1260,10 @@ function parseSimpleField(
   return field;
 }
 
+function hasRunPayloadElement(runElement: XmlElement): boolean {
+  return getChildElements(runElement).some((child) => !matchesName(child, "w", "rPr"));
+}
+
 /**
  * Parse all content within a paragraph
  *
@@ -1466,7 +1471,9 @@ function parseParagraphContents(
           });
         } else {
           // Regular run, not part of a field
-          contents.push(run);
+          if (run.content.length > 0 || hasRunPayloadElement(runElement)) {
+            contents.push(run);
+          }
         }
         break;
       }


### PR DESCRIPTION
Syntactically empty Word runs now normalize away before adjacent runs are consolidated. Runs that contain source payload outside `w:rPr` remain conservative consolidation boundaries, so unsupported content still surfaces as round-trip drift.

Adds focused parser regressions for both cases and a patch changeset.