### PR TITLE
fix: preserve authored gradient fills

### DIFF
--- a/.changeset/new-points-send.md
+++ b/.changeset/new-points-send.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve DrawingML gradient fill details across text boxes and other shared fill consumers.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -934,6 +934,7 @@ export type ShapeContent = {
 // @public
 export type ShapeFill = {
     type: "none" | "solid" | "gradient" | "pattern" | "picture";
+    rawXml?: string;
     color?: ColorValue;
     gradient?: {
         type: "linear" | "radial" | "rectangular" | "path";

--- a/packages/core/src/docx/drawingUtils.test.ts
+++ b/packages/core/src/docx/drawingUtils.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseColorElement } from "./drawingUtils";
+import { parseColorElement, parseFill } from "./drawingUtils";
+import { serializeRun } from "./serializer/runSerializer";
 import type { XmlElement } from "./xmlParser";
+import { parseXmlDocument } from "./xmlParser";
 
 function el(name: string, attributes: Record<string, string> = {}): XmlElement {
   return { name, type: "element", attributes };
@@ -45,5 +47,66 @@ describe("drawingUtils.parseColorElement", () => {
       wrap(el("a:sysClr", { val: "windowText", lastClr: "1f497d" })),
     );
     expect(result).toEqual({ rgb: "1F497D" });
+  });
+});
+
+describe("drawingUtils.parseFill", () => {
+  test("projects gradient details while preserving authored DrawingML", () => {
+    const shapeProperties = parseXmlDocument(`
+      <wps:spPr
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+      >
+        <a:gradFill rotWithShape="0">
+          <a:gsLst>
+            <a:gs pos="0"><a:srgbClr val="FFFFFF"><a:lumMod val="95000"/></a:srgbClr></a:gs>
+            <a:gs pos="100000"><a:srgbClr val="5B9BD5"/></a:gs>
+          </a:gsLst>
+          <a:lin ang="5400000" scaled="0"/>
+          <a:tileRect/>
+        </a:gradFill>
+      </wps:spPr>
+    `);
+    expect(shapeProperties).not.toBeNull();
+    if (!shapeProperties) {
+      return;
+    }
+
+    const fill = parseFill(shapeProperties);
+    expect(fill).toMatchObject({
+      type: "gradient",
+      gradient: {
+        type: "linear",
+        angle: 90,
+        stops: [
+          { position: 0, color: { rgb: "FFFFFF" } },
+          { position: 100_000, color: { rgb: "5B9BD5" } },
+        ],
+      },
+    });
+    expect(fill?.rawXml).toContain('<a:gradFill rotWithShape="0">');
+    expect(fill?.rawXml).toContain('<a:lumMod val="95000"/>');
+    expect(fill?.rawXml).toContain('<a:lin ang="5400000" scaled="0"/>');
+    expect(fill?.rawXml).toContain("<a:tileRect/>");
+    if (!fill?.rawXml) {
+      return;
+    }
+
+    const serialized = serializeRun({
+      type: "run",
+      content: [
+        {
+          type: "shape",
+          shape: {
+            type: "shape",
+            shapeType: "textBox",
+            size: { width: 914_400, height: 457_200 },
+            fill,
+            textBody: { content: [] },
+          },
+        },
+      ],
+    });
+    expect(serialized).toContain(fill.rawXml);
   });
 });

--- a/packages/core/src/docx/drawingUtils.ts
+++ b/packages/core/src/docx/drawingUtils.ts
@@ -27,6 +27,9 @@ import {
   getTextContent,
   parseNumericAttribute,
   findByFullName,
+  findChildByLocalName,
+  findChildrenByLocalName,
+  elementToXml,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
@@ -201,23 +204,74 @@ export function parseFill(spPr: XmlElement | null): ShapeFill | undefined {
     return undefined;
   }
 
-  const children = getChildElements(spPr);
-
-  if (children.some((el) => el.name === "a:noFill")) {
+  if (findChildByLocalName(spPr, "noFill")) {
     return { type: "none" };
   }
 
-  const solidFill = children.find((el) => el.name === "a:solidFill");
+  const solidFill = findChildByLocalName(spPr, "solidFill");
   if (solidFill) {
     const color = parseColorElement(solidFill);
     return color !== undefined ? { type: "solid", color } : { type: "solid" };
   }
 
-  if (children.some((el) => el.name === "a:gradFill")) {
-    return { type: "gradient" };
+  const gradientFill = findChildByLocalName(spPr, "gradFill");
+  if (gradientFill) {
+    return parseGradientFill(gradientFill);
   }
 
   return undefined;
+}
+
+function parseGradientFill(gradientFill: XmlElement): ShapeFill {
+  let type: "linear" | "radial" | "rectangular" | "path" = "linear";
+  let angle: number | undefined;
+
+  const linear = findChildByLocalName(gradientFill, "lin");
+  if (linear) {
+    const authoredAngle = getAttribute(linear, null, "ang");
+    if (authoredAngle) {
+      const parsedAngle = Number.parseInt(authoredAngle, 10);
+      angle = Number.isNaN(parsedAngle) ? undefined : parsedAngle / 60_000;
+    }
+  }
+
+  const path = findChildByLocalName(gradientFill, "path");
+  if (path) {
+    const pathType = getAttribute(path, null, "path");
+    if (pathType === "circle") {
+      type = "radial";
+    } else if (pathType === "rect") {
+      type = "rectangular";
+    } else {
+      type = "path";
+    }
+  }
+
+  const stops: NonNullable<ShapeFill["gradient"]>["stops"] = [];
+  const stopList = findChildByLocalName(gradientFill, "gsLst");
+  if (stopList) {
+    for (const stop of findChildrenByLocalName(stopList, "gs")) {
+      const authoredPosition = getAttribute(stop, null, "pos");
+      const parsedPosition = authoredPosition ? Number.parseInt(authoredPosition, 10) : 0;
+      const color = parseColorElement(stop);
+      if (color) {
+        stops.push({
+          position: Number.isNaN(parsedPosition) ? 0 : parsedPosition,
+          color,
+        });
+      }
+    }
+  }
+
+  return {
+    type: "gradient",
+    rawXml: elementToXml(gradientFill),
+    gradient: {
+      type,
+      ...(angle !== undefined ? { angle } : {}),
+      stops,
+    },
+  };
 }
 
 /**

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -623,6 +623,9 @@ function serializeFill(fill: ShapeFill | undefined): string {
   if (!fill) {
     return "";
   }
+  if (fill.rawXml) {
+    return fill.rawXml;
+  }
   if (fill.type === "none") {
     return "<a:noFill/>";
   }

--- a/packages/core/src/docx/shapeParser.ts
+++ b/packages/core/src/docx/shapeParser.ts
@@ -34,17 +34,11 @@ import type {
   ShapeFill,
   ShapeOutline,
 } from "../types/document";
-import {
-  parseAnchorPosition,
-  parseAnchorWrap,
-  parseColorElement,
-  parseFill as parseSpPrFill,
-} from "./drawingUtils";
+import { parseAnchorPosition, parseAnchorWrap, parseColorElement, parseFill } from "./drawingUtils";
 import { narrowEnum, ShapeOutlineStyleSchema, ShapeTypeSchema } from "./parserEnums";
 import {
   findAllDeep,
   findChildByLocalName,
-  findChildrenByLocalName,
   getAttribute,
   parseNumericAttribute,
 } from "./xmlParser";
@@ -59,78 +53,12 @@ function rotToDegrees(rot: string | null | undefined): number | undefined {
   return Number.isNaN(val) ? undefined : val / 60_000;
 }
 
-// ---------------------------------------------------------------------------
-// FILL — extends drawingUtils.parseFill with gradient stop fidelity
-// ---------------------------------------------------------------------------
-
 /**
  * Parse a fill with full gradient stop capture (eigenpal #21).
  * Falls through to `drawingUtils.parseFill` for solid / none cases.
  */
 function parseShapeFill(spPr: XmlElement | null): ShapeFill | undefined {
-  const base = parseSpPrFill(spPr);
-  if (base?.type !== "gradient" || !spPr) {
-    return base;
-  }
-  // Re-parse gradients locally for stop-level detail.
-  const gradFill = findChildByLocalName(spPr, "gradFill");
-  if (!gradFill) {
-    return base;
-  }
-  return parseGradientFill(gradFill);
-}
-
-function parseGradientFill(gradFill: XmlElement): ShapeFill {
-  let gradientType: "linear" | "radial" | "rectangular" | "path" = "linear";
-  let angle: number | undefined;
-
-  const lin = findChildByLocalName(gradFill, "lin");
-  if (lin) {
-    gradientType = "linear";
-    const ang = getAttribute(lin, null, "ang");
-    if (ang) {
-      // Word stores `ang` in 60000ths of a degree, same as rotation.
-      const parsed = Number.parseInt(ang, 10);
-      angle = Number.isNaN(parsed) ? undefined : parsed / 60_000;
-    }
-  }
-
-  const path = findChildByLocalName(gradFill, "path");
-  if (path) {
-    const pathType = getAttribute(path, null, "path");
-    if (pathType === "circle") {
-      gradientType = "radial";
-    } else if (pathType === "rect") {
-      gradientType = "rectangular";
-    } else {
-      gradientType = "path";
-    }
-  }
-
-  const stops: { position: number; color: ColorValue }[] = [];
-  const gsLst = findChildByLocalName(gradFill, "gsLst");
-  if (gsLst) {
-    for (const gs of findChildrenByLocalName(gsLst, "gs")) {
-      const pos = getAttribute(gs, null, "pos");
-      const position = pos ? Number.parseInt(pos, 10) : 0;
-      const color = parseColorElement(gs);
-      if (color) {
-        stops.push({
-          position: Number.isNaN(position) ? 0 : position,
-          color,
-        });
-      }
-    }
-  }
-
-  return {
-    type: "gradient",
-    gradient: {
-      type: gradientType,
-      ...(angle !== undefined ? { angle } : {}),
-      stops,
-    },
-  };
+  return parseFill(spPr);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -685,6 +685,11 @@ export type ShapeType =
  */
 export type ShapeFill = {
   type: "none" | "solid" | "gradient" | "pattern" | "picture";
+  /**
+   * Authored DrawingML retained when the normalized projection is incomplete.
+   * Serializers prefer this value; omit it when modifying the fill.
+   */
+  rawXml?: string;
   /** Solid fill color */
   color?: ColorValue;
   /** Gradient stops for gradient fill */


### PR DESCRIPTION
Centralizes DrawingML gradient parsing so shapes and text boxes share the same normalized projection. Authored gradient XML is retained for lossless round-trips of modifiers and geometry that the normalized model does not represent yet; programmatic fills without authored XML continue through structured serialization.

Adds a focused regression covering stops, direction, color transforms, scaling, and tile geometry, plus patch changesets for both affected packages.