### PR TITLE
fix: preserve authored shape outlines

### DIFF
--- a/.changeset/quiet-shapes-flow.md
+++ b/.changeset/quiet-shapes-flow.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve authored DrawingML outline details across shapes and text boxes.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -948,6 +948,7 @@ export type ShapeFill = {
 
 // @public
 export type ShapeOutline = {
+    rawXml?: string;
     width?: number;
     color?: ColorValue;
     style?: "solid" | "dot" | "dash" | "lgDash" | "dashDot" | "lgDashDot" | "lgDashDotDot" | "sysDot" | "sysDash" | "sysDashDot" | "sysDashDotDot";

--- a/packages/core/src/docx/drawingUtils.test.ts
+++ b/packages/core/src/docx/drawingUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseColorElement, parseFill } from "./drawingUtils";
+import { parseColorElement, parseFill, parseOutline } from "./drawingUtils";
 import { serializeRun } from "./serializer/runSerializer";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
@@ -108,5 +108,87 @@ describe("drawingUtils.parseFill", () => {
       ],
     });
     expect(serialized).toContain(fill.rawXml);
+  });
+});
+
+describe("drawingUtils.parseOutline", () => {
+  test("projects outline details while preserving authored DrawingML", () => {
+    const shapeProperties = parseXmlDocument(`
+      <wps:spPr
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+      >
+        <a:ln w="12700" cap="rnd" cmpd="dbl" algn="in">
+          <a:solidFill>
+            <a:schemeClr val="accent1">
+              <a:shade val="50000"/>
+              <a:satMod val="80000"/>
+            </a:schemeClr>
+          </a:solidFill>
+          <a:prstDash val="dash"/>
+          <a:miter lim="800000"/>
+          <a:headEnd type="triangle" w="lg" len="sm"/>
+          <a:tailEnd type="oval"/>
+        </a:ln>
+      </wps:spPr>
+    `);
+    expect(shapeProperties).not.toBeNull();
+    if (!shapeProperties) {
+      return;
+    }
+
+    const outline = parseOutline(shapeProperties);
+    expect(outline).toMatchObject({
+      width: 12_700,
+      cap: "round",
+      color: { themeColor: "accent1", themeShade: "80" },
+      style: "dash",
+      join: "miter",
+      headEnd: { type: "triangle", width: "lg", length: "sm" },
+      tailEnd: { type: "oval" },
+    });
+    expect(outline?.rawXml).toContain('<a:ln w="12700" cap="rnd" cmpd="dbl" algn="in">');
+    expect(outline?.rawXml).toContain('<a:satMod val="80000"/>');
+    expect(outline?.rawXml).toContain('<a:miter lim="800000"/>');
+    if (!outline?.rawXml) {
+      return;
+    }
+
+    const serialized = serializeRun({
+      type: "run",
+      content: [
+        {
+          type: "shape",
+          shape: {
+            type: "shape",
+            shapeType: "textBox",
+            size: { width: 914_400, height: 457_200 },
+            outline,
+            textBody: { content: [] },
+          },
+        },
+      ],
+    });
+    expect(serialized).toContain(outline.rawXml);
+
+    const { rawXml: authoredXml, ...structuredOutline } = outline;
+    expect(authoredXml).toBe(outline.rawXml);
+    const edited = serializeRun({
+      type: "run",
+      content: [
+        {
+          type: "shape",
+          shape: {
+            type: "shape",
+            shapeType: "textBox",
+            size: { width: 914_400, height: 457_200 },
+            outline: { ...structuredOutline, width: 25_400 },
+            textBody: { content: [] },
+          },
+        },
+      ],
+    });
+    expect(edited).toContain('<a:ln w="25400" cap="rnd">');
+    expect(edited).not.toContain('cmpd="dbl"');
   });
 });

--- a/packages/core/src/docx/drawingUtils.ts
+++ b/packages/core/src/docx/drawingUtils.ts
@@ -278,25 +278,45 @@ function parseGradientFill(gradientFill: XmlElement): ShapeFill {
  * Parse outline from shape properties (a:ln).
  */
 export function parseOutline(spPr: XmlElement | null): ShapeOutline | undefined {
-  const ln = spPr ? findByFullName(spPr, "a:ln") : null;
+  const ln = spPr ? findChildByLocalName(spPr, "ln") : null;
   if (!ln) {
     return undefined;
   }
 
-  const children = getChildElements(ln);
-
-  if (children.some((el) => el.name === "a:noFill")) {
+  if (findChildByLocalName(ln, "noFill")) {
     return undefined;
   }
 
-  const outline: ShapeOutline = {};
+  const outline: ShapeOutline = {
+    rawXml: elementToXml(ln),
+  };
 
   const w = getAttribute(ln, null, "w");
   if (w) {
-    outline.width = Number.parseInt(w, 10);
+    const parsed = Number.parseInt(w, 10);
+    if (!Number.isNaN(parsed)) {
+      outline.width = parsed;
+    }
   }
 
-  const solidFill = children.find((el) => el.name === "a:solidFill");
+  const cap = getAttribute(ln, null, "cap");
+  if (cap === "flat") {
+    outline.cap = "flat";
+  } else if (cap === "rnd") {
+    outline.cap = "round";
+  } else if (cap === "sq") {
+    outline.cap = "square";
+  }
+
+  if (findChildByLocalName(ln, "bevel")) {
+    outline.join = "bevel";
+  } else if (findChildByLocalName(ln, "round")) {
+    outline.join = "round";
+  } else if (findChildByLocalName(ln, "miter")) {
+    outline.join = "miter";
+  }
+
+  const solidFill = findChildByLocalName(ln, "solidFill");
   if (solidFill) {
     const color = parseColorElement(solidFill);
     if (color !== undefined) {
@@ -304,7 +324,7 @@ export function parseOutline(spPr: XmlElement | null): ShapeOutline | undefined 
     }
   }
 
-  const prstDash = children.find((el) => el.name === "a:prstDash");
+  const prstDash = findChildByLocalName(ln, "prstDash");
   if (prstDash) {
     const val = narrowEnum(getAttribute(prstDash, null, "val"), ShapeOutlineStyleSchema);
     if (val) {
@@ -312,7 +332,51 @@ export function parseOutline(spPr: XmlElement | null): ShapeOutline | undefined 
     }
   }
 
+  const headEnd = findChildByLocalName(ln, "headEnd");
+  if (headEnd) {
+    outline.headEnd = parseLineEnd(headEnd);
+  }
+
+  const tailEnd = findChildByLocalName(ln, "tailEnd");
+  if (tailEnd) {
+    outline.tailEnd = parseLineEnd(tailEnd);
+  }
+
   return outline;
+}
+
+type LineEndType = NonNullable<ShapeOutline["headEnd"]>["type"];
+type LineEndSize = NonNullable<ShapeOutline["headEnd"]>["width"];
+
+const LINE_END_TYPES = [
+  "none",
+  "triangle",
+  "stealth",
+  "diamond",
+  "oval",
+  "arrow",
+] as const satisfies readonly LineEndType[];
+
+function parseLineEnd(element: XmlElement): NonNullable<ShapeOutline["headEnd"]> {
+  const authoredType = getAttribute(element, null, "type");
+  const type = LINE_END_TYPES.find((allowed) => allowed === authoredType) ?? "none";
+
+  const authoredWidth = getAttribute(element, null, "w");
+  const authoredLength = getAttribute(element, null, "len");
+  const width: LineEndSize =
+    authoredWidth === "sm" || authoredWidth === "med" || authoredWidth === "lg"
+      ? authoredWidth
+      : undefined;
+  const length: LineEndSize =
+    authoredLength === "sm" || authoredLength === "med" || authoredLength === "lg"
+      ? authoredLength
+      : undefined;
+
+  return {
+    type,
+    ...(width !== undefined ? { width } : {}),
+    ...(length !== undefined ? { length } : {}),
+  };
 }
 
 // ============================================================================

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -669,6 +669,9 @@ function serializeOutline(outline: ShapeOutline | undefined): string {
   if (!outline) {
     return "";
   }
+  if (outline.rawXml) {
+    return outline.rawXml;
+  }
   const attrs: string[] = [];
   if (typeof outline.width === "number") {
     attrs.push(`w="${outline.width}"`);

--- a/packages/core/src/docx/shapeParser.ts
+++ b/packages/core/src/docx/shapeParser.ts
@@ -26,16 +26,9 @@
  *                     └── wps:bodyPr           (text body properties)
  */
 
-import type {
-  ColorValue,
-  ImageSize,
-  ImageTransform,
-  Shape,
-  ShapeFill,
-  ShapeOutline,
-} from "../types/document";
-import { parseAnchorPosition, parseAnchorWrap, parseColorElement, parseFill } from "./drawingUtils";
-import { narrowEnum, ShapeOutlineStyleSchema, ShapeTypeSchema } from "./parserEnums";
+import type { ColorValue, ImageSize, ImageTransform, Shape, ShapeFill } from "../types/document";
+import { parseAnchorPosition, parseAnchorWrap, parseFill, parseOutline } from "./drawingUtils";
+import { narrowEnum, ShapeTypeSchema } from "./parserEnums";
 import {
   findAllDeep,
   findChildByLocalName,
@@ -59,133 +52,6 @@ function rotToDegrees(rot: string | null | undefined): number | undefined {
  */
 function parseShapeFill(spPr: XmlElement | null): ShapeFill | undefined {
   return parseFill(spPr);
-}
-
-// ---------------------------------------------------------------------------
-// OUTLINE — extends drawingUtils.parseOutline with cap/join/end metadata
-// ---------------------------------------------------------------------------
-
-type LineEndType = NonNullable<ShapeOutline["headEnd"]>["type"];
-type LineEndSize = NonNullable<ShapeOutline["headEnd"]>["width"];
-
-const LINE_END_TYPES = new Set<LineEndType>([
-  "none",
-  "triangle",
-  "stealth",
-  "diamond",
-  "oval",
-  "arrow",
-]);
-
-function narrowLineEndType(value: string | null | undefined): LineEndType {
-  if (value === null || value === undefined) {
-    return "none";
-  }
-  for (const allowed of LINE_END_TYPES) {
-    if (allowed === value) {
-      return allowed;
-    }
-  }
-  return "none";
-}
-
-function narrowLineEndSize(value: string | null | undefined): LineEndSize {
-  if (value === "sm" || value === "med" || value === "lg") {
-    return value;
-  }
-  return undefined;
-}
-
-function parseLineEnd(element: XmlElement): NonNullable<ShapeOutline["headEnd"]> {
-  const type = narrowLineEndType(getAttribute(element, null, "type"));
-  const width = narrowLineEndSize(getAttribute(element, null, "w"));
-  const length = narrowLineEndSize(getAttribute(element, null, "len"));
-  return {
-    type,
-    ...(width !== undefined ? { width } : {}),
-    ...(length !== undefined ? { length } : {}),
-  };
-}
-
-/**
- * Parse a shape outline with cap, join, and arrow end fidelity. Returns
- * `undefined` when the spPr has no `<a:ln>`, an explicit `<a:noFill/>`,
- * or no usable attributes.
- */
-function parseShapeOutline(spPr: XmlElement | null): ShapeOutline | undefined {
-  const ln = findChildByLocalName(spPr, "ln");
-  if (!ln) {
-    return undefined;
-  }
-
-  if (findChildByLocalName(ln, "noFill")) {
-    return undefined;
-  }
-
-  const outline: ShapeOutline = {};
-
-  const w = getAttribute(ln, null, "w");
-  if (w) {
-    const parsed = Number.parseInt(w, 10);
-    if (!Number.isNaN(parsed)) {
-      outline.width = parsed;
-    }
-  }
-
-  const cap = getAttribute(ln, null, "cap");
-  if (cap === "flat") {
-    outline.cap = "flat";
-  } else if (cap === "rnd") {
-    outline.cap = "round";
-  } else if (cap === "sq") {
-    outline.cap = "square";
-  }
-
-  if (findChildByLocalName(ln, "bevel")) {
-    outline.join = "bevel";
-  } else if (findChildByLocalName(ln, "round")) {
-    outline.join = "round";
-  } else if (findChildByLocalName(ln, "miter")) {
-    outline.join = "miter";
-  }
-
-  const solidFill = findChildByLocalName(ln, "solidFill");
-  if (solidFill) {
-    const color = parseColorElement(solidFill);
-    if (color) {
-      outline.color = color;
-    }
-  }
-
-  const prstDash = findChildByLocalName(ln, "prstDash");
-  if (prstDash) {
-    const narrowed = narrowEnum(getAttribute(prstDash, null, "val"), ShapeOutlineStyleSchema);
-    if (narrowed !== undefined) {
-      outline.style = narrowed;
-    }
-  }
-
-  const headEnd = findChildByLocalName(ln, "headEnd");
-  if (headEnd) {
-    outline.headEnd = parseLineEnd(headEnd);
-  }
-  const tailEnd = findChildByLocalName(ln, "tailEnd");
-  if (tailEnd) {
-    outline.tailEnd = parseLineEnd(tailEnd);
-  }
-
-  if (
-    outline.width === undefined &&
-    outline.color === undefined &&
-    outline.cap === undefined &&
-    outline.join === undefined &&
-    outline.style === undefined &&
-    outline.headEnd === undefined &&
-    outline.tailEnd === undefined
-  ) {
-    return undefined;
-  }
-  return outline;
 }
 
 // ---------------------------------------------------------------------------
@@ -316,7 +182,7 @@ export function parseShape(node: XmlElement): Shape {
   const xfrm = findChildByLocalName(spPr, "xfrm");
   const { size, transform } = parseTransform(xfrm);
   const fill = parseShapeFill(spPr);
-  const outline = parseShapeOutline(spPr);
+  const outline = parseOutline(spPr);
 
   const id = cNvPr ? (getAttribute(cNvPr, null, "id") ?? undefined) : undefined;
   const name = cNvPr ? (getAttribute(cNvPr, null, "name") ?? undefined) : undefined;

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -707,6 +707,11 @@ export type ShapeFill = {
  * Shape outline/stroke
  */
 export type ShapeOutline = {
+  /**
+   * Authored DrawingML retained for lossless round-trips. Serializers prefer
+   * this value; callers modifying structured outline fields must omit it.
+   */
+  rawXml?: string;
   /** Line width in EMUs */
   width?: number;
   /** Line color */


### PR DESCRIPTION
## Summary

- centralize DrawingML outline parsing across shapes and text boxes
- preserve authored outline XML when the normalized model cannot represent every detail
- retain structured width, color, dash, cap, join, and arrow-end projections

## Validation

- bun run lint
- bun run typecheck
- bun run test
- bun run build
- bun run api:check
- focused outline parse and serialization regression

## Security

Authored XML is retained only from an already parsed DrawingML outline subtree and re-emitted within the DOCX package; this adds no external input, access, or execution surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preservation of authored shape and text-box outline details when DOCX content is read and written.
  - Retained advanced outline styling, including caps, joins, dash patterns, line ends, colours and widths.
  - Improved handling of outlines with varied DrawingML naming and incomplete styling information.

- **Documentation**
  - Updated shape outline information to reflect preservation of original outline data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->