### PR TITLE
fix: normalize zero-height row rules

### DIFF
--- a/.changeset/tidy-rows-rest.md
+++ b/.changeset/tidy-rows-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize no-op zero-height table row rules.

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -149,6 +149,16 @@ describe("table row grid offsets", () => {
   });
 });
 
+describe("table row height", () => {
+  test("omits a height rule when its non-positive height is normalized away", () => {
+    const root = parseXmlDocument(
+      `<w:trPr ${NS}><w:trHeight w:val="0" w:hRule="atLeast"/></w:trPr>`,
+    );
+
+    expect(parseTableRowProperties(root)).toBeUndefined();
+  });
+});
+
 describe("table row conditional formatting", () => {
   test("round-trips conditional table-style flags", () => {
     const root = parseXmlDocument(

--- a/packages/core/src/docx/tableParser.ts
+++ b/packages/core/src/docx/tableParser.ts
@@ -911,11 +911,11 @@ export function parseTableRowProperties(
     const heightVal = parseNumericAttribute(heightElement, "w", "val");
     if (heightVal !== undefined && heightVal > 0) {
       formatting.height = { value: heightVal, type: "dxa" as const };
-    }
 
-    const hRule = getAttribute(heightElement, "w", "hRule");
-    if (hRule === "auto" || hRule === "atLeast" || hRule === "exact") {
-      formatting.heightRule = hRule;
+      const hRule = getAttribute(heightElement, "w", "hRule");
+      if (hRule === "auto" || hRule === "atLeast" || hRule === "exact") {
+        formatting.heightRule = hRule;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- keep a table-row height rule coupled to an accepted positive height
- omit no-op zero-height row formatting instead of creating a serializer-unstable state
- add a focused synthetic regression test for the normalization invariant

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun --filter @stll/folio-core test`
- `bun --filter @stll/folio-core build`
- focused table parser regression test
- `bunx changeset status`

## Security

This changes parse normalization only. It adds no I/O, permissions, dependency, or trust-boundary changes.