### PR TITLE
fix: preserve inline text box wrapping

### DIFF
--- a/.changeset/quiet-boxes-wrap.md
+++ b/.changeset/quiet-boxes-wrap.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve inline text box wrapping across document saves.

--- a/packages/core/src/docx/textBoxDrawingOwnership.test.ts
+++ b/packages/core/src/docx/textBoxDrawingOwnership.test.ts
@@ -77,6 +77,26 @@ const bodyDrawingTypes = ({ package: { document } }: ParsedDocx): string[] =>
       : [],
   );
 
+const bodyShapeWrapTypes = ({ package: { document } }: ParsedDocx): string[] => {
+  const wrapTypes: string[] = [];
+  for (const block of document.content) {
+    if (block.type !== "paragraph") {
+      continue;
+    }
+    for (const content of block.content) {
+      if (content.type !== "run") {
+        continue;
+      }
+      for (const item of content.content) {
+        if (item.type === "shape" && item.shape.wrap) {
+          wrapTypes.push(item.shape.wrap.type);
+        }
+      }
+    }
+  }
+  return wrapTypes;
+};
+
 const savedDocumentXml = async (buffer: ArrayBuffer): Promise<string> => {
   const zip = await JSZip.loadAsync(buffer);
   return zip.file("word/document.xml")!.async("text");
@@ -125,5 +145,23 @@ describe("text-box drawing ownership", () => {
     const savedXml = await savedDocumentXml(saved);
     expect(savedXml.match(/<w:pict(?:\s|>)/gu)).toHaveLength(1);
     expect(savedXml).not.toContain("<w:drawing");
+  });
+
+  test("inline VML text boxes keep their wrap state after DrawingML normalization", async () => {
+    const source = await buildDocx(`
+      <w:pict>
+        <v:shape style="width:2in;height:1in">
+          <v:textbox>
+            <w:txbxContent><w:p><w:r><w:t>Legacy text</w:t></w:r></w:p></w:txbxContent>
+          </v:textbox>
+        </v:shape>
+      </w:pict>`);
+    const parsed = await parseDocx(source, { preloadFonts: false });
+
+    expect(bodyShapeWrapTypes(parsed)).toEqual(["inline"]);
+
+    const saved = await repackDocx(parsed, { updateModifiedDate: false });
+    const reopened = await parseDocx(saved, { preloadFonts: false });
+    expect(bodyShapeWrapTypes(reopened)).toEqual(["inline"]);
   });
 });

--- a/packages/core/src/docx/textBoxParser.ts
+++ b/packages/core/src/docx/textBoxParser.ts
@@ -356,6 +356,8 @@ export function parseTextBox(drawingEl: XmlElement): TextBox | null {
     if (wrap) {
       textBox.wrap = wrap;
     }
+  } else {
+    textBox.wrap = { type: "inline" };
   }
 
   return textBox;


### PR DESCRIPTION
## Summary

- model `wp:inline` text boxes with the same explicit inline wrap state used by other shapes
- keep VML-to-DrawingML text-box normalization stable across save and reopen
- add a synthetic end-to-end regression covering the normalization path

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun --filter @stll/folio-core test`
- `bun --filter @stll/folio-core build`
- focused text-box ownership regression test
- `bunx changeset status`

## Security

This changes parser normalization only. It adds no I/O, permissions, dependency, or trust-boundary changes.