### PR TITLE
fix: preserve positional tabs

### DIFF
--- a/.changeset/bright-tabs-align.md
+++ b/.changeset/bright-tabs-align.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve Word positional tabs across parsing, editing, and serialization.

--- a/api-reports/core/prosemirror-attrs.api.md
+++ b/api-reports/core/prosemirror-attrs.api.md
@@ -77,6 +77,9 @@ export const expectShapeAttrs: (node: Node_2) => ShapeAttrs;
 export const expectStrikeMarkAttrs: (mark: Mark) => StrikeAttrs;
 
 // @public (undocumented)
+export const expectTabAttrs: (node: Node_2) => TabAttrs;
+
+// @public (undocumented)
 export const expectTableAttrs: (node: Node_2) => TableAttrs;
 
 // @public (undocumented)
@@ -195,6 +198,9 @@ export const readShapeAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<ShapeA
 
 // @public (undocumented)
 export const readStrikeMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<StrikeAttrs>;
+
+// @public (undocumented)
+export const readTabAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<TabAttrs>;
 
 // @public (undocumented)
 export const readTableAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<TableAttrs>;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -357,6 +357,11 @@ export type StrikeAttrs = {
     double?: boolean;
 };
 
+// @public (undocumented)
+export type TabAttrs = {
+    positional?: import__stll_docx_core_model.PositionalTab;
+};
+
 // @public
 export type TableAttrs = {
     styleId?: string;

--- a/api-reports/docx-core/index.api.md
+++ b/api-reports/docx-core/index.api.md
@@ -194,6 +194,13 @@ export const parseLegalSource: (source: string, options?: {
 }) => LegalSourceParseResult;
 
 // @public
+export type PositionalTab = {
+    relativeTo?: "margin" | "indent";
+    alignment?: "left" | "center" | "right";
+    leader?: "none" | "dot" | "hyphen" | "underscore" | "middleDot";
+};
+
+// @public
 export type Run = {
     type: "run";
     formatting?: TextFormatting;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -751,6 +751,13 @@ export type PictureWatermark = {
 };
 
 // @public
+export type PositionalTab = {
+    relativeTo?: "margin" | "indent";
+    alignment?: "left" | "center" | "right";
+    leader?: "none" | "dot" | "hyphen" | "underscore" | "middleDot";
+};
+
+// @public
 export type PropertyChangeInfo = {
     rsid?: string;
 } & TrackedChangeInfo;
@@ -1060,9 +1067,10 @@ export type SymbolContent = {
     char: string;
 };
 
-// @public
+// @public (undocumented)
 export type TabContent = {
     type: "tab";
+    positional?: PositionalTab;
 };
 
 // @public

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -330,13 +330,46 @@ describe("parseParagraph empty-run normalization", () => {
     const paragraph = parseParagraphXml(`
       <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
         <w:r><w:t>A</w:t></w:r>
-        <w:r><w:ptab/></w:r>
+        <w:r><w:yearLong/></w:r>
         <w:r><w:t>B</w:t></w:r>
       </w:p>
     `);
 
     expect(paragraph.content).toHaveLength(2);
     expect(getParagraphText(paragraph)).toBe("AB");
+  });
+
+  test("preserves positional tab semantics across XML serialization", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r><w:t>Section</w:t></w:r>
+        <w:r>
+          <w:ptab w:relativeTo="margin" w:alignment="right" w:leader="dot"/>
+        </w:r>
+        <w:r><w:t>A.1</w:t></w:r>
+      </w:p>
+    `);
+
+    expect(paragraph.content).toHaveLength(3);
+    expect(paragraph.content.at(1)).toEqual({
+      type: "run",
+      content: [
+        {
+          type: "tab",
+          positional: {
+            relativeTo: "margin",
+            alignment: "right",
+            leader: "dot",
+          },
+        },
+      ],
+    });
+
+    const serialized = serializeParagraph(paragraph);
+    expect(serialized).toContain(
+      '<w:ptab w:relativeTo="margin" w:alignment="right" w:leader="dot"/>',
+    );
+    expect(parseParagraphXml(serialized)).toEqual(paragraph);
   });
 });
 

--- a/packages/core/src/docx/parserEnums.ts
+++ b/packages/core/src/docx/parserEnums.ts
@@ -44,6 +44,9 @@ import {
   LINE_SPACING_RULE_VALUES,
   NUMBER_FORMAT_VALUES,
   PARAGRAPH_ALIGNMENT_VALUES,
+  POSITIONAL_TAB_ALIGNMENT_VALUES,
+  POSITIONAL_TAB_LEADER_VALUES,
+  POSITIONAL_TAB_RELATIVE_TO_VALUES,
   SDT_LOCK_VALUES,
   SHADING_PATTERN_VALUES,
   SHAPE_OUTLINE_STYLE_VALUES,
@@ -111,6 +114,12 @@ export const LineSpacingRuleSchema = v.picklist(LINE_SPACING_RULE_VALUES);
 export const TabStopAlignmentSchema = v.picklist(TAB_STOP_ALIGNMENT_VALUES);
 
 export const TabLeaderSchema = v.picklist(TAB_LEADER_VALUES);
+
+export const PositionalTabRelativeToSchema = v.picklist(POSITIONAL_TAB_RELATIVE_TO_VALUES);
+
+export const PositionalTabAlignmentSchema = v.picklist(POSITIONAL_TAB_ALIGNMENT_VALUES);
+
+export const PositionalTabLeaderSchema = v.picklist(POSITIONAL_TAB_LEADER_VALUES);
 
 export const FrameXAlignSchema = v.picklist(FRAME_X_ALIGN_VALUES);
 

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -49,6 +49,9 @@ import {
   FontHintSchema,
   FontThemeSchema,
   HighlightColorSchema,
+  PositionalTabAlignmentSchema,
+  PositionalTabLeaderSchema,
+  PositionalTabRelativeToSchema,
   ShadingPatternSchema,
   TextEffectSchema,
   ThemeColorSlotSchema,
@@ -733,6 +736,29 @@ function parseTabContent(): TabContent {
   return { type: "tab" };
 }
 
+function parsePositionalTabContent(element: XmlElement): TabContent {
+  const positional: NonNullable<TabContent["positional"]> = {};
+  const relativeTo = narrowEnum(
+    getAttribute(element, "w", "relativeTo"),
+    PositionalTabRelativeToSchema,
+  );
+  const alignment = narrowEnum(
+    getAttribute(element, "w", "alignment"),
+    PositionalTabAlignmentSchema,
+  );
+  const leader = narrowEnum(getAttribute(element, "w", "leader"), PositionalTabLeaderSchema);
+  if (relativeTo !== undefined) {
+    positional.relativeTo = relativeTo;
+  }
+  if (alignment !== undefined) {
+    positional.alignment = alignment;
+  }
+  if (leader !== undefined) {
+    positional.leader = leader;
+  }
+  return { type: "tab", positional };
+}
+
 /**
  * Parse break element (w:br)
  */
@@ -922,6 +948,10 @@ function parseRunContents(
       case "tab":
         // Tab character
         contents.push(parseTabContent());
+        break;
+
+      case "ptab":
+        contents.push(parsePositionalTabContent(child));
         break;
 
       case "br":

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -503,8 +503,18 @@ function serializeTextContent(content: TextContent): string {
 /**
  * Serialize tab content (w:tab)
  */
-function serializeTabContent(_content: TabContent): string {
-  return "<w:tab/>";
+function serializeTabContent(content: TabContent): string {
+  if (!content.positional) {
+    return "<w:tab/>";
+  }
+  const attrs = [
+    content.positional.relativeTo
+      ? ` w:relativeTo="${escapeXml(content.positional.relativeTo)}"`
+      : "",
+    content.positional.alignment ? ` w:alignment="${escapeXml(content.positional.alignment)}"` : "",
+    content.positional.leader ? ` w:leader="${escapeXml(content.positional.leader)}"` : "",
+  ].join("");
+  return `<w:ptab${attrs}/>`;
 }
 
 /**

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -13,6 +13,9 @@ import {
   LINE_SPACING_RULE_VALUES,
   OUTLINE_STYLE_ATTR_VALUES,
   PARAGRAPH_ALIGNMENT_VALUES,
+  POSITIONAL_TAB_ALIGNMENT_VALUES,
+  POSITIONAL_TAB_LEADER_VALUES,
+  POSITIONAL_TAB_RELATIVE_TO_VALUES,
   SDT_LOCK_VALUES,
   SDT_TYPE_VALUES,
   SHADING_PATTERN_VALUES,
@@ -42,6 +45,7 @@ import type {
   HighlightAttrs,
   HyperlinkAttrs,
   HardBreakAttrs,
+  TabAttrs,
   ImageAttrs,
   MathAttrs,
   ParagraphAttrs,
@@ -213,6 +217,7 @@ const SECTION_VERTICAL_ALIGNMENTS = ["top", "center", "both", "bottom"] as const
 
 const paragraphAttrsCache = new WeakMap<PMNode, ParagraphAttrs>();
 const hardBreakAttrsCache = new WeakMap<PMNode, HardBreakAttrs>();
+const tabAttrsCache = new WeakMap<PMNode, TabAttrs>();
 const tableAttrsCache = new WeakMap<PMNode, TableAttrs>();
 const tableRowAttrsCache = new WeakMap<PMNode, TableRowAttrs>();
 const tableCellAttrsCache = new WeakMap<PMNode, TableCellAttrs>();
@@ -390,6 +395,43 @@ export const readHardBreakAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Har
 
 export const expectHardBreakAttrs = (node: PMNode): HardBreakAttrs =>
   expectCachedNodeAttrs(node, hardBreakAttrsCache, readHardBreakAttrs, "hard break attrs");
+
+export const readTabAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TabAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "tab", issues);
+
+  optionalRecord(attrs, "positional", "tab.attrs.positional", issues);
+  const positional = attrs["positional"];
+  if (isRecord(positional)) {
+    optionalOneOf(
+      positional,
+      "relativeTo",
+      "tab.attrs.positional.relativeTo",
+      issues,
+      POSITIONAL_TAB_RELATIVE_TO_VALUES,
+    );
+    optionalOneOf(
+      positional,
+      "alignment",
+      "tab.attrs.positional.alignment",
+      issues,
+      POSITIONAL_TAB_ALIGNMENT_VALUES,
+    );
+    optionalOneOf(
+      positional,
+      "leader",
+      "tab.attrs.positional.leader",
+      issues,
+      POSITIONAL_TAB_LEADER_VALUES,
+    );
+  }
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTabAttrs = (node: PMNode): TabAttrs =>
+  expectCachedNodeAttrs(node, tabAttrsCache, readTabAttrs, "tab attrs");
 
 export const readTableAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TableAttrs> => {
   const attrs = attrsRecord(node.attrs);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -88,6 +88,7 @@ import {
   expectSdtAttrs,
   expectShapeAttrs,
   expectStrikeMarkAttrs,
+  expectTabAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
@@ -1602,7 +1603,7 @@ function extractParagraphContent(
     } else if (node.type.name === "tab") {
       // Tab ends current run
       flushCurrentInline();
-      content.push(createTabRun());
+      content.push(createTabRun(node));
     } else if (node.type.name === "renderedPageBreak") {
       flushCurrentInline();
       content.push(createRenderedPageBreakRun());
@@ -1691,7 +1692,7 @@ function createTrackedChangeRun(node: PMNode, marks: readonly Mark[]): Run | nul
     return createShapeRun(node);
   }
   if (node.type.name === "tab") {
-    return createTabRun();
+    return createTabRun(node);
   }
   if (node.type.name === "renderedPageBreak") {
     return createRenderedPageBreakRun();
@@ -1839,7 +1840,7 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
   }
 
   if (node.type.name === "tab") {
-    hyperlink.children.push(createTabRun(nonLinkMarks));
+    hyperlink.children.push(createTabRun(node, nonLinkMarks));
     return;
   }
 
@@ -1982,9 +1983,11 @@ function readHardBreakType(node: PMNode): BreakContent["breakType"] {
 /**
  * Create a Run containing a tab
  */
-function createTabRun(marks?: readonly Mark[]): Run {
+function createTabRun(node: PMNode, marks?: readonly Mark[]): Run {
+  const { positional } = expectTabAttrs(node);
   const tabContent: TabContent = {
     type: "tab",
+    ...(positional ? { positional } : {}),
   };
 
   const run: Run = {

--- a/packages/core/src/prosemirror/conversion/semanticRoundtrip.test.ts
+++ b/packages/core/src/prosemirror/conversion/semanticRoundtrip.test.ts
@@ -322,4 +322,59 @@ describe("semantic ProseMirror round-trip fixture", () => {
     });
     expect(textBoxShape.outline).toBeUndefined();
   });
+
+  test("preserves positional tabs through the editor model", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                runText("Section"),
+                {
+                  type: "run",
+                  content: [
+                    {
+                      type: "tab",
+                      positional: {
+                        relativeTo: "margin",
+                        alignment: "right",
+                        leader: "dot",
+                      },
+                    },
+                  ],
+                },
+                runText("A.1"),
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const tab = pmDoc.firstChild?.child(1);
+    expect(tab?.type.name).toBe("tab");
+    expect(tab?.attrs["positional"]).toEqual({
+      relativeTo: "margin",
+      alignment: "right",
+      leader: "dot",
+    });
+
+    const roundtripped = fromProseDoc(pmDoc, document);
+    expect(firstParagraph(roundtripped).content.at(1)).toEqual({
+      type: "run",
+      content: [
+        {
+          type: "tab",
+          positional: {
+            relativeTo: "margin",
+            alignment: "right",
+            leader: "dot",
+          },
+        },
+      ],
+    });
+  });
 });

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2332,7 +2332,11 @@ function convertRunContent(
     case "tab":
       // Convert to tab node for proper rendering. Keep the run marks because
       // Word commonly represents signature blanks as underlined tab runs.
-      return [schema.node("tab").mark(marks)];
+      return [
+        schema
+          .node("tab", content.positional ? { positional: content.positional } : undefined)
+          .mark(marks),
+      ];
 
     case "drawing":
       return [withHyperlinkBoundaryMarks(convertImage(content.image, content.rawXml), marks)];

--- a/packages/core/src/prosemirror/extensions/nodes/TabExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TabExtension.ts
@@ -2,6 +2,8 @@
  * Tab Extension — inline tab character node
  */
 
+import type { PositionalTab } from "../../../types/document";
+import { expectTabAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
 
 export const TabExtension = createNodeExtension({
@@ -10,21 +12,64 @@ export const TabExtension = createNodeExtension({
   nodeSpec: {
     inline: true,
     group: "inline",
+    attrs: {
+      positional: { default: null },
+    },
     selectable: false,
     parseDOM: [
       {
         tag: "span.docx-tab",
+        getAttrs(node) {
+          if (!(node instanceof HTMLElement) || !node.dataset["docxPositionalTab"]) {
+            return null;
+          }
+
+          return {
+            positional: parsePositionalTab(node),
+          };
+        },
       },
     ],
-    toDOM() {
-      return [
-        "span",
-        {
-          class: "docx-tab",
-          style: "display: inline-block; min-width: 16px; white-space: pre;",
-        },
-        "\t",
-      ];
+    toDOM(node) {
+      const { positional } = expectTabAttrs(node);
+      const attrs: Record<string, string> = {
+        class: "docx-tab",
+        style: "display: inline-block; min-width: 16px; white-space: pre;",
+      };
+      if (positional) {
+        attrs["data-docx-positional-tab"] = "true";
+        if (positional.relativeTo) {
+          attrs["data-docx-tab-relative-to"] = positional.relativeTo;
+        }
+        if (positional.alignment) {
+          attrs["data-docx-tab-alignment"] = positional.alignment;
+        }
+        if (positional.leader) {
+          attrs["data-docx-tab-leader"] = positional.leader;
+        }
+      }
+
+      return ["span", attrs, "\t"];
     },
   },
 });
+
+const parsePositionalTab = (element: HTMLElement): PositionalTab => {
+  const relativeTo = element.dataset["docxTabRelativeTo"];
+  const alignment = element.dataset["docxTabAlignment"];
+  const leader = element.dataset["docxTabLeader"];
+
+  return {
+    ...(relativeTo === "margin" || relativeTo === "indent" ? { relativeTo } : {}),
+    ...(alignment === "left" || alignment === "center" || alignment === "right"
+      ? { alignment }
+      : {}),
+    ...(leader === "none" ||
+    leader === "dot" ||
+    leader === "hyphen" ||
+    leader === "underscore" ||
+    leader === "middleDot"
+      ? { leader }
+      : {}),
+  };
+};

--- a/packages/core/src/prosemirror/schema/index.ts
+++ b/packages/core/src/prosemirror/schema/index.ts
@@ -13,6 +13,7 @@ import { createStarterKit } from "../extensions/StarterKit";
 // Re-export type interfaces (used by toProseDoc, fromProseDoc, and other modules)
 export type {
   HardBreakAttrs,
+  TabAttrs,
   ParagraphAttrs,
   FieldAttrs,
   ImageAttrs,

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -12,6 +12,7 @@ import type {
   ParagraphFormatting,
   ParagraphMarkChange,
   ParagraphPropertyChange,
+  PositionalTab,
   FieldType,
   Hyperlink,
   LineSpacingRule,
@@ -47,6 +48,10 @@ import type { TrackedChangeProvenance } from "./marks";
 
 export type HardBreakAttrs = {
   breakType?: "column";
+};
+
+export type TabAttrs = {
+  positional?: PositionalTab;
 };
 
 /**

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -24,6 +24,7 @@ import {
   readSdtAttrs,
   readShapeAttrs,
   readStrikeMarkAttrs,
+  readTabAttrs,
   readTableAttrs,
   readTableCellAttrs,
   readTableRowAttrs,
@@ -130,7 +131,10 @@ const validateNodeAttrs = (
     case "horizontalRule":
     case "pageBreak":
     case "renderedPageBreak":
+      return;
+
     case "tab":
+      appendAttrIssues(path, readTabAttrs(node), issues);
       return;
 
     case "hardBreak":

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -70,6 +70,7 @@ export type {
   SdtType,
   SoftHyphenContent,
   SymbolContent,
+  PositionalTab,
   TabContent,
   Table,
   TableCell,

--- a/packages/core/src/types/documentEnumValues.ts
+++ b/packages/core/src/types/documentEnumValues.ts
@@ -9,6 +9,7 @@ import type {
   NumberFormat,
   ParagraphAlignment,
   ParagraphFormatting,
+  PositionalTab,
   SdtProperties,
   SdtType,
   ShadingProperties,
@@ -188,6 +189,25 @@ export const TAB_LEADER_VALUES = [
   "heavy",
   "middleDot",
 ] as const satisfies readonly TabLeader[];
+
+export const POSITIONAL_TAB_RELATIVE_TO_VALUES = [
+  "margin",
+  "indent",
+] as const satisfies readonly NonNullable<PositionalTab["relativeTo"]>[];
+
+export const POSITIONAL_TAB_ALIGNMENT_VALUES = [
+  "left",
+  "center",
+  "right",
+] as const satisfies readonly NonNullable<PositionalTab["alignment"]>[];
+
+export const POSITIONAL_TAB_LEADER_VALUES = [
+  "none",
+  "dot",
+  "hyphen",
+  "underscore",
+  "middleDot",
+] as const satisfies readonly NonNullable<PositionalTab["leader"]>[];
 
 type Frame = NonNullable<ParagraphFormatting["frame"]>;
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -39,6 +39,7 @@ export type {
 
   // Run Content
   TextContent,
+  PositionalTab,
   TabContent,
   BreakContent,
   SymbolContent,

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -7,6 +7,7 @@ export type {
   DocxPackage,
   Paragraph,
   ParagraphContent,
+  PositionalTab,
   Run,
   RunContent,
   SectionProperties,

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -37,8 +37,16 @@ export type TextContent = {
 /**
  * Tab character
  */
+export type PositionalTab = {
+  relativeTo?: "margin" | "indent";
+  alignment?: "left" | "center" | "right";
+  leader?: "none" | "dot" | "hyphen" | "underscore" | "middleDot";
+};
+
 export type TabContent = {
   type: "tab";
+  /** Word positional-tab properties (`w:ptab`); absent for a regular `w:tab`. */
+  positional?: PositionalTab;
 };
 
 /**

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -67,6 +67,7 @@ export { MAX_REVISION_ID, normalizeRevisionId } from "./content";
 
 export type {
   TextContent,
+  PositionalTab,
   TabContent,
   BreakContent,
   SymbolContent,

--- a/packages/docx-core/src/serialize/docx.test.ts
+++ b/packages/docx-core/src/serialize/docx.test.ts
@@ -78,3 +78,37 @@ describe("DOCX border serialization escapes attribute values", () => {
     expect(xml).toContain('w:color="CCCCCC"');
   });
 });
+
+describe("DOCX positional tab serialization", () => {
+  test("writes positional tab attributes", async () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    {
+                      type: "tab",
+                      positional: {
+                        relativeTo: "margin",
+                        alignment: "right",
+                        leader: "dot",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const xml = await readDocumentXml(await serializeDocumentToDocx(document));
+    expect(xml).toContain('<w:ptab w:relativeTo="margin" w:alignment="right" w:leader="dot"/>');
+  });
+});

--- a/packages/docx-core/src/serialize/docx.ts
+++ b/packages/docx-core/src/serialize/docx.ts
@@ -333,7 +333,13 @@ const serializeRunContent = (content: RunContent): string => {
         content.preserveSpace ? ' xml:space="preserve"' : ""
       }>${escapeXml(content.text)}</w:t>`;
     case "tab":
-      return "<w:tab/>";
+      if (!content.positional) {
+        return "<w:tab/>";
+      }
+      return `<w:ptab${attr("w:relativeTo", content.positional.relativeTo)}${attr(
+        "w:alignment",
+        content.positional.alignment,
+      )}${attr("w:leader", content.positional.leader)}/>`;
     case "break":
       return `<w:br${attr("w:type", content.breakType)}/>`;
     case "renderedPageBreak":


### PR DESCRIPTION
## Summary

- model Word positional tabs separately from regular tab characters
- preserve positional-tab alignment, reference frame, and leader values through parsing, ProseMirror editing, and serialization
- add synthetic XML, editor-model, and package serialization regressions

## Validation

- `bun run lint`
- `bun --filter @stll/docx-core typecheck`
- `bun --filter @stll/folio-core typecheck`
- `bun --filter @stll/docx-core test`
- `bun --filter @stll/folio-core test`
- `bun run build`
- `bun run validate-dist`
- `bunx changeset status`