### PR TITLE
fix: normalize singleton hyperlink runs

### DIFF
--- a/.changeset/calm-links-settle.md
+++ b/.changeset/calm-links-settle.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize nested hyperlink runs even when the hyperlink is the paragraph's only child.

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -371,6 +371,35 @@ describe("parseParagraph empty-run normalization", () => {
     );
     expect(parseParagraphXml(serialized)).toEqual(paragraph);
   });
+
+  test("normalizes empty runs inside a sole hyperlink", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:hyperlink w:anchor="_Toc1">
+          <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+          <w:r><w:instrText> PAGEREF _Toc1 \\h </w:instrText></w:r>
+          <w:r><w:rPr/></w:r>
+          <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+          <w:r><w:t>7</w:t></w:r>
+          <w:r><w:fldChar w:fldCharType="end"/></w:r>
+        </w:hyperlink>
+      </w:p>
+    `);
+
+    const hyperlink = paragraph.content.at(0);
+    expect(hyperlink?.type).toBe("hyperlink");
+    if (!hyperlink || hyperlink.type !== "hyperlink") {
+      return;
+    }
+
+    expect(hyperlink.children).toHaveLength(5);
+    expect(
+      hyperlink.children.some((child) => child.type === "run" && child.content.length === 0),
+    ).toBe(false);
+
+    const serialized = serializeParagraph(paragraph);
+    expect(parseParagraphXml(serialized)).toEqual(paragraph);
+  });
 });
 
 describe("parseParagraph rendered page break markers", () => {

--- a/packages/core/src/docx/runConsolidator.ts
+++ b/packages/core/src/docx/runConsolidator.ts
@@ -384,10 +384,6 @@ export function consolidateRuns(runs: Run[]): Run[] {
 export function consolidateParagraphContent(content: Hyperlink["children"]): Hyperlink["children"];
 export function consolidateParagraphContent(content: ParagraphContent[]): ParagraphContent[];
 export function consolidateParagraphContent(content: ParagraphContent[]): ParagraphContent[] {
-  if (content.length <= 1) {
-    return content;
-  }
-
   const result: ParagraphContent[] = [];
   const pendingRuns: Run[] = [];
 


### PR DESCRIPTION
## Summary

- apply recursive run normalization when a hyperlink is the paragraph’s only child
- remove empty run artifacts before serialization
- cover complex-field hyperlinks with a synthetic save/reopen regression

## Validation

- `bun run format`
- `bun run lint`
- `bun --filter @stll/folio-core typecheck`
- `bun --filter @stll/folio-core test`
- `bun run build`
- `bun run validate-dist`
- `bun run api:check`
- `bunx changeset status`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed paragraph parsing so hyperlinks containing empty runs are normalised correctly, including when the hyperlink is the paragraph’s only content.
  * Ensured nested hyperlink content is consistently consolidated without introducing empty runs.

* **Tests**
  * Added coverage for sole-hyperlink paragraphs with empty runs.

* **Release**
  * Prepared a patch release for the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->