### PR TITLE
fix: normalize missing drawing ids

### DIFF
--- a/.changeset/fair-shapes-rest.md
+++ b/.changeset/fair-shapes-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Assign deterministic, collision-free IDs to parsed drawings that omit them.

--- a/packages/core/src/docx/drawingIdNormalization.test.ts
+++ b/packages/core/src/docx/drawingIdNormalization.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { Document } from "../types/document";
+import { parseDocx } from "./parser";
+import { createEmptyDocx, repackDocx } from "./rezip";
+
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const textBoxDrawing = (text: string, id?: string): string => `
+  <w:drawing>
+    <wp:inline>
+      <wp:extent cx="914400" cy="457200"/>
+      ${id === undefined ? "" : `<wp:docPr id="${id}" name="Text box ${id}"/>`}
+      <a:graphic>
+        <a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+          <wps:wsp>
+            <wps:cNvSpPr txBox="1"/>
+            <wps:spPr>
+              <a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>
+              <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            </wps:spPr>
+            <wps:txbx>
+              <w:txbxContent><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:txbxContent>
+            </wps:txbx>
+            <wps:bodyPr/>
+          </wps:wsp>
+        </a:graphicData>
+      </a:graphic>
+    </wp:inline>
+  </w:drawing>`;
+
+const buildDocx = async (): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+    <w:document
+      xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+      xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+      xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+      xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+      <w:body>
+        <w:p><w:r>${textBoxDrawing("Generated")}</w:r></w:p>
+        <w:p><w:r>${textBoxDrawing("Authored", "100000")}</w:r></w:p>
+        <w:sectPr/>
+      </w:body>
+    </w:document>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const shapeIds = ({ package: { document } }: Document): (string | undefined)[] =>
+  document.content.flatMap((block) => {
+    if (block.type !== "paragraph") {
+      return [];
+    }
+    return block.content.flatMap((content) => {
+      if (content.type !== "run") {
+        return [];
+      }
+      return content.content.flatMap((runContent) =>
+        runContent.type === "shape" ? [runContent.shape.id] : [],
+      );
+    });
+  });
+
+describe("drawing ID normalization", () => {
+  test("assigns missing shape IDs without colliding and remains stable after save", async () => {
+    const parsed = await parseDocx(await buildDocx(), { preloadFonts: false });
+    expect(shapeIds(parsed)).toEqual(["100001", "100000"]);
+
+    const saved = await repackDocx(parsed, { updateModifiedDate: false });
+    const reopened = await parseDocx(saved, { preloadFonts: false });
+    expect(shapeIds(reopened)).toEqual(["100001", "100000"]);
+  });
+});

--- a/packages/core/src/docx/drawingIdNormalization.ts
+++ b/packages/core/src/docx/drawingIdNormalization.ts
@@ -1,0 +1,56 @@
+import type { Image, Shape } from "../types/document";
+import {
+  visitDocxParagraphs,
+  visitParagraphRuns,
+  type DocxParagraphSurfaces,
+} from "./paragraphTraversal";
+
+const GENERATED_DRAWING_ID_START = 100_000;
+
+type DrawingWithId = Image | Shape;
+
+type DrawingIdEntry = {
+  drawing: DrawingWithId;
+  generateWhenMissing: boolean;
+};
+
+const needsGeneratedId = ({ id }: DrawingWithId): boolean =>
+  id === undefined || id === "" || id === "0";
+
+export const normalizeDrawingIds = (surfaces: DocxParagraphSurfaces): void => {
+  const entries: DrawingIdEntry[] = [];
+
+  visitDocxParagraphs(surfaces, (paragraph) => {
+    visitParagraphRuns(paragraph, (run) => {
+      for (const content of run.content) {
+        if (content.type === "shape") {
+          entries.push({ drawing: content.shape, generateWhenMissing: true });
+          continue;
+        }
+        if (content.type === "drawing") {
+          entries.push({
+            drawing: content.image,
+            generateWhenMissing: content.rawXml === undefined,
+          });
+        }
+      }
+    });
+  });
+
+  const usedIds = new Set(
+    entries.flatMap(({ drawing }) => (needsGeneratedId(drawing) ? [] : [drawing.id])),
+  );
+  let nextId = GENERATED_DRAWING_ID_START;
+
+  for (const { drawing, generateWhenMissing } of entries) {
+    if (!generateWhenMissing || !needsGeneratedId(drawing)) {
+      continue;
+    }
+    while (usedIds.has(String(nextId))) {
+      nextId += 1;
+    }
+    drawing.id = String(nextId);
+    usedIds.add(drawing.id);
+    nextId += 1;
+  }
+};

--- a/packages/core/src/docx/headerFooterVerbatim.ts
+++ b/packages/core/src/docx/headerFooterVerbatim.ts
@@ -37,6 +37,14 @@ export const assignHeaderFooterVerbatimXml = (hf: HeaderFooter, xml: string): vo
   ext.verbatimFingerprint = headerFooterSerializationFingerprint(hf);
 };
 
+export const refreshHeaderFooterVerbatimFingerprint = (hf: HeaderFooter): void => {
+  const ext = hf as HeaderFooterWithVerbatim;
+  if (!ext.verbatimXml) {
+    return;
+  }
+  ext.verbatimFingerprint = headerFooterSerializationFingerprint(hf);
+};
+
 export const clearHeaderFooterVerbatimXml = (hf: HeaderFooter): void => {
   const ext = hf as HeaderFooterWithVerbatim;
   delete ext.verbatimXml;

--- a/packages/core/src/docx/paragraphTraversal.ts
+++ b/packages/core/src/docx/paragraphTraversal.ts
@@ -11,7 +11,7 @@ import type {
   Table,
 } from "../types/document";
 
-type VisitDocxParagraphsInput = {
+export type DocxParagraphSurfaces = {
   documentBody: DocumentBody;
   headers?: Map<string, HeaderFooter> | undefined;
   footers?: Map<string, HeaderFooter> | undefined;
@@ -19,33 +19,10 @@ type VisitDocxParagraphsInput = {
   endnotes?: readonly Endnote[] | undefined;
 };
 
-export const visitDocxParagraphs = (
-  { documentBody, headers, footers, footnotes, endnotes }: VisitDocxParagraphsInput,
-  visit: (paragraph: Paragraph) => void,
-): void => {
-  const seenParagraphs = new WeakSet<Paragraph>();
-
-  const visitParagraph = (paragraph: Paragraph): void => {
-    if (seenParagraphs.has(paragraph)) {
-      return;
-    }
-    seenParagraphs.add(paragraph);
-
-    visit(paragraph);
-    for (const content of paragraph.content) {
-      visitParagraphContent(content);
-    }
-  };
-
+/** Visit every run directly owned by a paragraph's inline-content tree. */
+export const visitParagraphRuns = (paragraph: Paragraph, visit: (run: Run) => void): void => {
   const visitRun = (run: Run): void => {
-    for (const content of run.content) {
-      if (content.type !== "shape" || !content.shape.textBody) {
-        continue;
-      }
-      for (const block of content.shape.textBody.content) {
-        visitBlock(block);
-      }
-    }
+    visit(run);
   };
 
   const visitHyperlink = (hyperlink: Hyperlink): void => {
@@ -86,10 +63,6 @@ export const visitDocxParagraphs = (
       return;
     }
     if (content.type === "inlineSdt") {
-      // Inline SDT children include simple/complex fields, nested SDTs,
-      // and math equations alongside runs/hyperlinks. Recurse through
-      // the regular paragraph-content visitor so each child is dispatched
-      // to its existing handler instead of being narrowed to Run|Hyperlink.
       for (const child of content.content) {
         visitParagraphContent(child);
       }
@@ -101,6 +74,38 @@ export const visitDocxParagraphs = (
       }
       for (const run of content.fieldResult) {
         visitRun(run);
+      }
+    }
+  };
+
+  for (const content of paragraph.content) {
+    visitParagraphContent(content);
+  }
+};
+
+export const visitDocxParagraphs = (
+  { documentBody, headers, footers, footnotes, endnotes }: DocxParagraphSurfaces,
+  visit: (paragraph: Paragraph) => void,
+): void => {
+  const seenParagraphs = new WeakSet<Paragraph>();
+
+  const visitParagraph = (paragraph: Paragraph): void => {
+    if (seenParagraphs.has(paragraph)) {
+      return;
+    }
+    seenParagraphs.add(paragraph);
+
+    visit(paragraph);
+    visitParagraphRuns(paragraph, visitRun);
+  };
+
+  const visitRun = (run: Run): void => {
+    for (const content of run.content) {
+      if (content.type !== "shape" || !content.shape.textBody) {
+        continue;
+      }
+      for (const block of content.shape.textBody.content) {
+        visitBlock(block);
       }
     }
   };

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -41,9 +41,13 @@ import { normalizeCommentReferences } from "./commentReferenceNormalization";
 import { detectDocxConformanceClass } from "./conformance";
 import { parseCoreProperties } from "./corePropertiesParser";
 import { parseDocumentBody, extractAllTemplateVariables } from "./documentParser";
+import { normalizeDrawingIds } from "./drawingIdNormalization";
 import { parseFootnotes, parseEndnotes } from "./footnoteParser";
 import { parseHeader, parseFooter } from "./headerFooterParser";
-import { assignHeaderFooterVerbatimXml } from "./headerFooterVerbatim";
+import {
+  assignHeaderFooterVerbatimXml,
+  refreshHeaderFooterVerbatimFingerprint,
+} from "./headerFooterVerbatim";
 import { normalizeHeaderFooterReferences } from "./headerFooterReferenceNormalization";
 import {
   DocxModelValidationError,
@@ -280,6 +284,22 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
     );
     if (comments.length > 0) {
       documentBody.comments = comments;
+    }
+    normalizeDrawingIds({
+      documentBody,
+      ...(headers !== undefined ? { headers } : {}),
+      ...(footers !== undefined ? { footers } : {}),
+      ...(footnotes !== undefined ? { footnotes } : {}),
+      ...(endnotes !== undefined ? { endnotes } : {}),
+    });
+    // Header/footer fingerprints are captured by their part parsers. Refresh
+    // them after package-level ID normalization so untouched raw parts remain
+    // replayable; subsequent normalizers will still invalidate changed parts.
+    for (const header of headers?.values() ?? []) {
+      refreshHeaderFooterVerbatimFingerprint(header);
+    }
+    for (const footer of footers?.values() ?? []) {
+      refreshHeaderFooterVerbatimFingerprint(footer);
     }
     normalizeRenderedPageBreakHints({
       documentBody,


### PR DESCRIPTION
## Summary

- assign deterministic IDs to parsed drawings that omit required non-visual IDs
- reserve authored IDs across all document stories to avoid generated collisions
- preserve untouched header/footer XML replay after package-level normalization
- cover collision avoidance and save/reopen stability with a synthetic regression

## Validation

- `bun run format`
- `bun run lint`
- `bun --filter @stll/folio-core typecheck`
- `bun --filter @stll/folio-core test`
- `bun run build`
- `bun run validate-dist`
- `bun run api:check`
- `bunx changeset status`
- `bun run bench`