### PR TITLE
fix: normalize anchor position defaults

### DIFF
--- a/.changeset/shy-anchors-rest.md
+++ b/.changeset/shy-anchors-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize omitted floating drawing positions to deterministic zero offsets.

--- a/packages/core/src/docx/drawingUtils.test.ts
+++ b/packages/core/src/docx/drawingUtils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseColorElement, parseFill, parseOutline } from "./drawingUtils";
+import {
+  parseAnchorPosition,
+  parseColorElement,
+  parseFill,
+  parseOutline,
+  parsePositionH,
+  parsePositionV,
+} from "./drawingUtils";
 import { serializeRun } from "./serializer/runSerializer";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
@@ -12,6 +19,71 @@ function el(name: string, attributes: Record<string, string> = {}): XmlElement {
 function wrap(child: XmlElement): XmlElement {
   return { name: "wrapper", type: "element", elements: [child] };
 }
+
+describe("drawingUtils position parsing", () => {
+  test("normalizes omitted anchor positions to serializer defaults", () => {
+    const anchor = parseXmlDocument(`
+      <wp:anchor
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+      />
+    `);
+    expect(anchor).not.toBeNull();
+    if (!anchor) {
+      return;
+    }
+
+    expect(parseAnchorPosition(anchor)).toEqual({
+      horizontal: { relativeTo: "column", posOffset: 0 },
+      vertical: { relativeTo: "paragraph", posOffset: 0 },
+    });
+  });
+
+  test("normalizes position axes that omit both alignment and offset", () => {
+    const positionH = parseXmlDocument(`
+      <wp:positionH
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        relativeFrom="character"
+      />
+    `);
+    const positionV = parseXmlDocument(`
+      <wp:positionV
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        relativeFrom="page"
+      />
+    `);
+
+    expect(parsePositionH(positionH)).toEqual({ relativeTo: "character", posOffset: 0 });
+    expect(parsePositionV(positionV)).toEqual({ relativeTo: "page", posOffset: 0 });
+  });
+
+  test("keeps valid alignments instead of materializing an offset", () => {
+    const positionH = parseXmlDocument(`
+      <wp:positionH
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        relativeFrom="margin"
+      >
+        <wp:align>center</wp:align>
+      </wp:positionH>
+    `);
+    const positionV = parseXmlDocument(`
+      <wp:positionV
+        xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+        relativeFrom="page"
+      >
+        <wp:align>bottom</wp:align>
+      </wp:positionV>
+    `);
+
+    expect(parsePositionH(positionH)).toEqual({
+      relativeTo: "margin",
+      alignment: "center",
+    });
+    expect(parsePositionV(positionV)).toEqual({
+      relativeTo: "page",
+      alignment: "bottom",
+    });
+  });
+});
 
 describe("drawingUtils.parseColorElement", () => {
   test("accepts a well-formed srgbClr value and uppercases it", () => {

--- a/packages/core/src/docx/drawingUtils.ts
+++ b/packages/core/src/docx/drawingUtils.ts
@@ -398,12 +398,10 @@ export function parsePositionH(posH: XmlElement | null): ImagePosition["horizont
   const alignEl = findByFullName(posH, "wp:align");
   if (alignEl) {
     const text = getTextContent(alignEl);
-    const result: ImagePosition["horizontal"] = { relativeTo };
     const alignment = narrowEnum(text, ImageHorizontalAlignmentSchema);
     if (alignment) {
-      result.alignment = alignment;
+      return { relativeTo, alignment };
     }
-    return result;
   }
 
   const posOffsetEl = findByFullName(posH, "wp:posOffset");
@@ -416,7 +414,7 @@ export function parsePositionH(posH: XmlElement | null): ImagePosition["horizont
     };
   }
 
-  return { relativeTo };
+  return { relativeTo, posOffset: 0 };
 }
 
 /**
@@ -434,12 +432,10 @@ export function parsePositionV(posV: XmlElement | null): ImagePosition["vertical
   const alignEl = findByFullName(posV, "wp:align");
   if (alignEl) {
     const text = getTextContent(alignEl);
-    const result: ImagePosition["vertical"] = { relativeTo };
     const alignment = narrowEnum(text, ImageVerticalAlignmentSchema);
     if (alignment) {
-      result.alignment = alignment;
+      return { relativeTo, alignment };
     }
-    return result;
   }
 
   const posOffsetEl = findByFullName(posV, "wp:posOffset");
@@ -452,23 +448,19 @@ export function parsePositionV(posV: XmlElement | null): ImagePosition["vertical
     };
   }
 
-  return { relativeTo };
+  return { relativeTo, posOffset: 0 };
 }
 
 /**
  * Parse position for anchored drawings (combines positionH + positionV).
  */
-export function parseAnchorPosition(anchor: XmlElement): ImagePosition | undefined {
+export function parseAnchorPosition(anchor: XmlElement): ImagePosition {
   const positionH = findByFullName(anchor, "wp:positionH");
   const positionV = findByFullName(anchor, "wp:positionV");
 
-  if (!positionH && !positionV) {
-    return undefined;
-  }
-
   return {
-    horizontal: parsePositionH(positionH) ?? { relativeTo: "column" },
-    vertical: parsePositionV(positionV) ?? { relativeTo: "paragraph" },
+    horizontal: parsePositionH(positionH) ?? { relativeTo: "column", posOffset: 0 },
+    vertical: parsePositionV(positionV) ?? { relativeTo: "paragraph", posOffset: 0 },
   };
 }
 


### PR DESCRIPTION
## Summary

- normalize omitted anchored-drawing position axes to the serializer defaults
- materialize a zero offset when an authored axis omits both alignment and offset
- preserve valid alignments and authored nonzero offsets
- cover the normalization rules with synthetic parser tests

## Validation

- `bun run format`
- focused drawing and shape parser tests
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun --filter @stll/folio-core test`
- `bun run build`
- `bun run validate-dist`
- `bun run api:check`
- `bunx changeset status`