### PR TITLE
fix: preserve complex script overrides

### DIFF
--- a/.changeset/calm-scripts-rest.md
+++ b/.changeset/calm-scripts-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit complex-script formatting overrides during DOCX serialization.

--- a/packages/core/src/docx/__tests__/runFormatting-cs.test.ts
+++ b/packages/core/src/docx/__tests__/runFormatting-cs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseRunProperties } from "../runParser";
+import { serializeTextFormatting } from "../serializer/runSerializer";
+import { parseXml } from "../xmlParser";
+
+const parseFormatting = (innerXml: string) => {
+  const parsed = parseXml(
+    `<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${innerXml}</w:rPr>`,
+  );
+  const runProperties = parsed.elements.at(0);
+  if (!runProperties || runProperties.type !== "element") {
+    throw new TypeError("Expected run properties element");
+  }
+  return parseRunProperties(runProperties, null);
+};
+
+describe("complex-script run formatting round-trip", () => {
+  test("preserves an explicit false override", () => {
+    const formatting = parseFormatting('<w:cs w:val="0"/>');
+
+    expect(formatting?.cs).toBe(false);
+    expect(serializeTextFormatting(formatting)).toContain('<w:cs w:val="0"/>');
+  });
+
+  test("preserves an enabled override", () => {
+    const formatting = parseFormatting("<w:cs/>");
+
+    expect(formatting?.cs).toBe(true);
+    expect(serializeTextFormatting(formatting)).toContain("<w:cs/>");
+  });
+
+  test("does not materialize an absent override", () => {
+    const formatting = parseFormatting("<w:b/>");
+
+    expect(formatting?.cs).toBeUndefined();
+    expect(serializeTextFormatting(formatting)).not.toContain("<w:cs");
+  });
+});

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -432,8 +432,10 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     parts.push('<w:rtl w:val="0"/>');
   }
 
-  if (formatting.cs) {
+  if (formatting.cs === true) {
     parts.push("<w:cs/>");
+  } else if (formatting.cs === false) {
+    parts.push('<w:cs w:val="0"/>');
   }
 
   if (parts.length === 0) {


### PR DESCRIPTION
## Summary

- serialize an explicit disabled complex-script run override instead of dropping it
- preserve the existing enabled and absent states
- cover all three states with synthetic parser/serializer round-trip tests

## Validation

- `bun run format`
- focused complex-script and RTL formatting tests
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun --filter @stll/folio-core test`
- `bun run build`
- `bun run validate-dist`
- `bun run api:check`
- `bunx changeset status`