### PR TITLE
fix: preserve comment reference formatting

### DIFF
--- a/.changeset/calm-comments-smile.md
+++ b/.changeset/calm-comments-smile.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve localized comment annotation-reference formatting across DOCX serialization.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -91,6 +91,7 @@ type Comment_2 = {
     initials?: string;
     date?: string;
     content: Paragraph[];
+    annotationReferenceFormatting?: TextFormatting;
     parentId?: number;
     done?: boolean;
 };

--- a/packages/core/src/docx/commentParser.ts
+++ b/packages/core/src/docx/commentParser.ts
@@ -17,10 +17,76 @@
  * - Comment content: child w:p elements
  */
 
-import type { Comment, Paragraph, Theme, RelationshipMap, MediaFile } from "../types/document";
+import type {
+  Comment,
+  Paragraph,
+  Theme,
+  RelationshipMap,
+  MediaFile,
+  TextFormatting,
+} from "../types/document";
 import { parseParagraph } from "./paragraphParser";
+import { parseRunProperties } from "./runParser";
 import type { StyleMap } from "./styleParser";
-import { parseXml, findChild, getChildElements, getAttribute } from "./xmlParser";
+import {
+  parseXml,
+  findChild,
+  getChildElements,
+  getAttribute,
+  getLocalName,
+  type XmlElement,
+} from "./xmlParser";
+
+type ParsedFirstCommentParagraph = {
+  paragraph: Paragraph;
+  annotationReferenceFormatting?: TextFormatting;
+};
+
+const DEFAULT_ANNOTATION_REFERENCE_STYLE_ID = "CommentReference";
+
+const normalizeAnnotationReferenceFormatting = (
+  formatting: TextFormatting | undefined,
+): TextFormatting | undefined => {
+  if (
+    formatting?.styleId === DEFAULT_ANNOTATION_REFERENCE_STYLE_ID &&
+    Object.keys(formatting).length === 1
+  ) {
+    return undefined;
+  }
+  return formatting;
+};
+
+const normalizeFirstCommentParagraph = (
+  paragraphElement: XmlElement,
+  paragraph: Paragraph,
+  theme: Theme | null,
+): ParsedFirstCommentParagraph => {
+  const firstContentElement = getChildElements(paragraphElement).find(
+    (element) => getLocalName(element.name) !== "pPr",
+  );
+  if (
+    !firstContentElement ||
+    getLocalName(firstContentElement.name) !== "r" ||
+    !findChild(firstContentElement, "w", "annotationRef")
+  ) {
+    return { paragraph };
+  }
+
+  const runProperties = findChild(firstContentElement, "w", "rPr");
+  const annotationReferenceFormatting = normalizeAnnotationReferenceFormatting(
+    runProperties ? parseRunProperties(runProperties, theme) : undefined,
+  );
+  const firstParsedContent = paragraph.content.at(0);
+  const normalizedParagraph =
+    firstParsedContent?.type === "run" && firstParsedContent.content.length === 0
+      ? { ...paragraph, content: paragraph.content.slice(1) }
+      : paragraph;
+
+  return {
+    paragraph: normalizedParagraph,
+    ...(annotationReferenceFormatting !== undefined ? { annotationReferenceFormatting } : {}),
+  };
+};
 
 /**
  * Build a lookup from paraId → dateUtc from commentsExtensible.xml
@@ -215,11 +281,18 @@ export function parseComments(
 
     // Parse comment content (paragraphs)
     const paragraphs: Paragraph[] = [];
+    let annotationReferenceFormatting: TextFormatting | undefined;
     for (const contentChild of getChildElements(child)) {
       const contentName = contentChild.name?.replace(/^.*:/u, "") ?? "";
       if (contentName === "p") {
         const paragraph = parseParagraph(contentChild, styles, theme, null, rels, media);
-        paragraphs.push(paragraph);
+        if (paragraphs.length > 0) {
+          paragraphs.push(paragraph);
+          continue;
+        }
+        const normalized = normalizeFirstCommentParagraph(contentChild, paragraph, theme);
+        annotationReferenceFormatting = normalized.annotationReferenceFormatting;
+        paragraphs.push(normalized.paragraph);
       }
     }
 
@@ -235,6 +308,7 @@ export function parseComments(
       ...(initials !== undefined ? { initials } : {}),
       ...(date !== undefined ? { date } : {}),
       ...(done !== undefined ? { done } : {}),
+      ...(annotationReferenceFormatting !== undefined ? { annotationReferenceFormatting } : {}),
       content: paragraphs,
     });
   }

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -96,8 +96,35 @@ describe("serializeComments", () => {
     const reparsedParagraph = reparsed[0]?.content[0];
     const reparsedRun = reparsedParagraph?.content.find((item) => item.type === "run");
 
+    expect(reparsed[0]?.annotationReferenceFormatting).toBeUndefined();
     expect(reparsedParagraph?.formatting).toMatchObject(paragraph.formatting);
     expect(reparsedRun?.formatting).toMatchObject(run.formatting);
+  });
+
+  test("preserves localized annotation-reference formatting outside editable content", () => {
+    const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:comment w:id="1" w:author="Tester">
+          <w:p>
+            <w:r>
+              <w:rPr><w:rStyle w:val="LocalizedCommentReference"/></w:rPr>
+              <w:annotationRef/>
+            </w:r>
+            <w:bookmarkStart w:id="0" w:name="marker"/>
+            <w:r><w:t>body</w:t></w:r>
+            <w:bookmarkEnd w:id="0"/>
+          </w:p>
+        </w:comment>
+      </w:comments>`;
+    const parsed = parseComments(commentsXml, null, null, new Map(), new Map());
+
+    expect(parsed[0]?.annotationReferenceFormatting?.styleId).toBe("LocalizedCommentReference");
+    expect(parsed[0]?.content[0]?.content.at(0)?.type).toBe("bookmarkStart");
+
+    const serialized = serializeComments(parsed);
+    expect(serialized.match(/<w:annotationRef\/>/gu)).toHaveLength(1);
+    expect(serialized).toContain('<w:rStyle w:val="LocalizedCommentReference"/>');
+    expect(parseComments(serialized, null, null, new Map(), new Map())).toEqual(parsed);
   });
 });
 

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -126,6 +126,23 @@ describe("serializeComments", () => {
     expect(serialized).toContain('<w:rStyle w:val="LocalizedCommentReference"/>');
     expect(parseComments(serialized, null, null, new Map(), new Map())).toEqual(parsed);
   });
+
+  test("preserves localized annotation-reference formatting for an empty comment", () => {
+    const comment: Comment = {
+      id: 1,
+      author: "Tester",
+      annotationReferenceFormatting: { styleId: "LocalizedCommentReference" },
+      content: [],
+    };
+
+    const serialized = serializeComments([comment]);
+    expect(serialized).toContain('<w:rStyle w:val="LocalizedCommentReference"/>');
+
+    const reparsed = parseComments(serialized, null, null, new Map(), new Map()).at(0);
+    expect(reparsed?.annotationReferenceFormatting).toEqual(comment.annotationReferenceFormatting);
+    expect(reparsed?.content).toHaveLength(1);
+    expect(reparsed?.content.at(0)?.content).toEqual([]);
+  });
 });
 
 describe("serializeCommentsExtended", () => {

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -6,25 +6,38 @@
 
 import { deterministicHexId } from "../../utils/hexId";
 import type { Comment, Paragraph } from "../../types/content";
+import type { TextFormatting } from "../../types/formatting";
 import { serializeParagraph } from "./paragraphSerializer";
+import { serializeTextFormatting } from "./runSerializer";
 import { escapeXml } from "./xmlUtils";
 
-const ANNOTATION_REFERENCE_XML =
-  '<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:annotationRef/></w:r>';
+const DEFAULT_ANNOTATION_REFERENCE_PROPERTIES =
+  '<w:rPr><w:rStyle w:val="CommentReference"/></w:rPr>';
 const PARAGRAPH_PROPERTIES_END = "</w:pPr>";
 
+const serializeAnnotationReference = (formatting: TextFormatting | undefined): string => {
+  const properties = formatting
+    ? serializeTextFormatting(formatting)
+    : DEFAULT_ANNOTATION_REFERENCE_PROPERTIES;
+  return `<w:r>${properties}<w:annotationRef/></w:r>`;
+};
+
 /** Serialize a paragraph, prepending an annotationRef run (required by Word in first paragraph of a comment) */
-function serializeParagraphWithAnnotationRef(paragraph: Paragraph): string {
+function serializeParagraphWithAnnotationRef(
+  paragraph: Paragraph,
+  formatting: TextFormatting | undefined,
+): string {
   const xml = serializeParagraph(paragraph);
+  const annotationReference = serializeAnnotationReference(formatting);
   const propertiesEnd = xml.indexOf(PARAGRAPH_PROPERTIES_END);
   if (propertiesEnd !== -1) {
     const contentStart = propertiesEnd + PARAGRAPH_PROPERTIES_END.length;
-    return `${xml.slice(0, contentStart)}${ANNOTATION_REFERENCE_XML}${xml.slice(contentStart)}`;
+    return `${xml.slice(0, contentStart)}${annotationReference}${xml.slice(contentStart)}`;
   }
 
   return xml.replace(
     /^<w:p(?=[\s>])[^>]*>/u,
-    (openingTag) => `${openingTag}${ANNOTATION_REFERENCE_XML}`,
+    (openingTag) => `${openingTag}${annotationReference}`,
   );
 }
 
@@ -41,15 +54,17 @@ function serializeComment(comment: Comment): string {
   if (comment.content.length > 0) {
     // First paragraph must contain an annotationRef run for Word to link the comment
     // SAFETY: length > 0 verified by condition above
-    xml += serializeParagraphWithAnnotationRef(comment.content[0]!);
+    xml += serializeParagraphWithAnnotationRef(
+      comment.content[0]!,
+      comment.annotationReferenceFormatting,
+    );
     for (let i = 1; i < comment.content.length; i++) {
       // SAFETY: i < comment.content.length in for loop
       xml += serializeParagraph(comment.content[i]!);
     }
   } else {
     // Empty comment — still needs a paragraph with annotationRef
-    xml +=
-      '<w:p><w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:annotationRef/></w:r></w:p>';
+    xml += `<w:p>${serializeAnnotationReference(comment.annotationReferenceFormatting)}</w:p>`;
   }
   xml += "</w:comment>";
   return xml;

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -906,6 +906,8 @@ export type Comment = {
   date?: string;
   /** Comment content (paragraphs) */
   content: Paragraph[];
+  /** Formatting of the structural annotation-reference run in the first paragraph */
+  annotationReferenceFormatting?: TextFormatting;
   /** Parent comment ID (for replies) */
   parentId?: number;
   /** Whether the comment is resolved/done */


### PR DESCRIPTION
## Summary

- model comment annotation-reference formatting separately from editable paragraph content
- preserve authored localized style identifiers when comments are serialized
- keep the canonical default marker implicit for stable round trips
- cover localized and canonical marker behavior with synthetic tests

## Validation

- `bun run format`
- focused comment parser and serializer tests
- `bun --filter @stll/docx-core typecheck`
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run validate-dist`
- `bun run api:check`
- `bunx changeset status`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DOCX comments now preserve formatting for localised annotation references during serialisation and round trips.
  * Existing comment content and annotation-reference placement remain intact, including for empty comments.

* **New Features**
  * Comment data can now retain optional annotation-reference formatting, improving fidelity when editing and re-saving DOCX files.

* **Tests**
  * Expanded coverage verifies formatting, styles, ordering and round-trip preservation for localised annotation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->