### PR TITLE
fix: preserve disabled title page sections

### DIFF
--- a/.changeset/tidy-pages-rest.md
+++ b/.changeset/tidy-pages-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicitly disabled first-page section headers and footers.

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -39,6 +39,20 @@ describe("serializeSectionProperties", () => {
     expect(xml.indexOf("<w:bidi/>")).toBeGreaterThan(xml.indexOf("<w:titlePg/>"));
   });
 
+  test("preserves an explicitly disabled title page", () => {
+    const section = parseSectPr(`
+      <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:titlePg w:val="0"/>
+      </w:sectPr>
+    `);
+
+    expect(section.titlePg).toBe(false);
+
+    const xml = serializeSectionProperties(section);
+    expect(xml).toContain('<w:titlePg w:val="0"/>');
+    expect(parseSectPr(xml).titlePg).toBe(false);
+  });
+
   test("does not serialize evenAndOddHeaders inside sectPr", () => {
     const xml = serializeSectionProperties({
       evenAndOddHeaders: true,

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -379,8 +379,9 @@ export function serializeSectionProperties(props: SectionProperties | undefined)
   if (props.textDirection) {
     parts.push(`<w:textDirection w:val="${props.textDirection}"/>`);
   }
-  if (props.titlePg) {
-    parts.push("<w:titlePg/>");
+  const titlePgXml = serializeOnOffElement(props.titlePg, "titlePg");
+  if (titlePgXml) {
+    parts.push(titlePgXml);
   }
   const bidiXml = serializeOnOffElement(props.bidi, "bidi");
   if (bidiXml) {


### PR DESCRIPTION
## Summary

- serialize explicit false `w:titlePg` section toggles instead of dropping them
- reuse the existing section on/off serializer so true, false, and absent remain distinct
- cover parse–serialize–parse fidelity with a focused regression test

## Validation

- `bun test packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run validate-dist`
- `bunx changeset status`