### PR TITLE
fix: preserve section column width mode

### DIFF
--- a/.changeset/bright-columns-wave.md
+++ b/.changeset/bright-columns-wave.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit unequal-width section column settings without companion attributes.

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -233,4 +233,18 @@ describe("serializeSectionProperties", () => {
     expect(serialized).toContain('w:num="1"');
     expect(parseSectPr(serialized).columnCount).toBe(1);
   });
+
+  test("round-trips an explicit unequal-width column mode without other attributes", () => {
+    const section = parseSectPr(`
+      <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:cols w:equalWidth="0"/>
+      </w:sectPr>
+    `);
+
+    expect(section.equalWidth).toBe(false);
+
+    const serialized = serializeSectionProperties(section);
+    expect(serialized).toContain('<w:cols w:equalWidth="0">');
+    expect(parseSectPr(serialized).equalWidth).toBe(false);
+  });
 });

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -120,12 +120,14 @@ function serializePaperSource(props: SectionProperties): string {
 
 function serializeColumns(props: SectionProperties): string {
   // A single-column section still carries its gutter as `<w:cols w:space=".."/>`,
-  // so bail only when there is genuinely nothing to emit (no count, no explicit
-  // columns, and no space) — otherwise the column spacing is dropped on save.
+  // so bail only when there is genuinely nothing to emit (no count, explicit
+  // columns, spacing, or width mode) — otherwise authored column settings are
+  // dropped on save.
   if (
     props.columnCount === undefined &&
     !props.columns?.length &&
-    props.columnSpace === undefined
+    props.columnSpace === undefined &&
+    props.equalWidth === undefined
   ) {
     return "";
   }


### PR DESCRIPTION
## Summary

- retain an authored `w:equalWidth` value even when a section column element has no count, spacing, or child columns
- keep the serializer early return limited to sections with no column state to emit
- cover minimal unequal-width column markup with a parse–serialize–parse regression test

## Validation

- `bun test packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run validate-dist`
- `bunx changeset status`