### PR TITLE
fix: preserve break clear behavior

### DIFF
--- a/.changeset/soft-breaks-flow.md
+++ b/.changeset/soft-breaks-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve authored clear behavior on every break type.

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -327,3 +327,17 @@ describe("run formatting integer attributes (issue #417)", () => {
     expect(xml).toContain('<w:position w:val="-6"/>');
   });
 });
+
+describe("break clear serialization", () => {
+  test.each(["none", "left", "right", "all"] as const)(
+    "preserves %s clear behavior independently of the break type",
+    (clear) => {
+      const xml = serializeRun({
+        type: "run",
+        content: [{ type: "break", breakType: "page", clear }],
+      });
+
+      expect(xml).toContain(`<w:br w:type="page" w:clear="${clear}"/>`);
+    },
+  );
+});

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -531,9 +531,10 @@ function serializeBreakContent(content: BreakContent): string {
     attrs.push('w:type="column"');
   } else if (content.breakType === "textWrapping") {
     attrs.push('w:type="textWrapping"');
-    if (content.clear && content.clear !== "none") {
-      attrs.push(`w:clear="${content.clear}"`);
-    }
+  }
+
+  if (content.clear !== undefined) {
+    attrs.push(`w:clear="${content.clear}"`);
   }
 
   if (attrs.length === 0) {


### PR DESCRIPTION
## Summary

- serialize authored `w:clear` values independently of the break type
- preserve all modeled clear states, including explicit `none`
- cover every supported clear value with focused serializer tests

## Validation

- `bun test packages/core/src/docx/serializer/runSerializer.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run validate-dist`
- `bunx changeset status`