### PR TITLE
fix: preserve empty comment initials

### DIFF
--- a/.changeset/quiet-comments-remain.md
+++ b/.changeset/quiet-comments-remain.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicitly empty initials on comments.

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -60,6 +60,14 @@ describe("serializeComments", () => {
     expect(xml).toContain('<w:comment w:id="1" w:author=""');
   });
 
+  test("preserves an explicitly empty initials attribute", () => {
+    const comment = { ...makeComment(1), initials: "" };
+    const xml = serializeComments([comment]);
+
+    expect(xml).toContain('w:initials=""');
+    expect(parseComments(xml, null, null, new Map(), new Map()).at(0)?.initials).toBe("");
+  });
+
   test("escapes a paragraph paraId that carries markup instead of a real Word id", () => {
     // A malformed/attacker-supplied `paraId` (e.g. relayed through a
     // collaboration payload) must not be able to break out of the

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -43,7 +43,7 @@ function serializeParagraphWithAnnotationRef(
 
 function serializeComment(comment: Comment): string {
   const attrs: string[] = [`w:id="${comment.id}"`, `w:author="${escapeXml(comment.author)}"`];
-  if (comment.initials) {
+  if (comment.initials !== undefined) {
     attrs.push(`w:initials="${escapeXml(comment.initials)}"`);
   }
   if (comment.date) {


### PR DESCRIPTION
Preserve an explicitly empty comment initials attribute across parse, serialize, and reparse. This keeps absent and authored-empty metadata distinct and adds a focused round-trip regression test.