### PR TITLE
fix: preserve disabled emphasis marks

### DIFF
--- a/.changeset/tidy-runs-emphasize.md
+++ b/.changeset/tidy-runs-emphasize.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit disabled emphasis marks in run formatting.

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Run } from "../../types/document";
+import { EMPHASIS_MARK_VALUES } from "../../types/documentEnumValues";
 import { serializeRun } from "./runSerializer";
 
 // Issue #417 (eigenpal): image and shape dimension/offset attributes leaked
@@ -137,6 +138,18 @@ describe("runSerializer vertical alignment", () => {
 
     expect(xml).toContain('<w:vertAlign w:val="baseline"/>');
     expect(xml).toContain('<w:footnoteReference w:id="1"/>');
+  });
+});
+
+describe("runSerializer emphasis marks", () => {
+  test.each(EMPHASIS_MARK_VALUES)("serializes the explicit %s value", (emphasisMark) => {
+    const xml = serializeRun({
+      type: "run",
+      formatting: { emphasisMark },
+      content: [{ type: "text", text: "Text" }],
+    });
+
+    expect(xml).toContain(`<w:em w:val="${emphasisMark}"/>`);
   });
 });
 

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -408,7 +408,7 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
   }
 
   // Emphasis mark
-  if (formatting.emphasisMark && formatting.emphasisMark !== "none") {
+  if (formatting.emphasisMark) {
     parts.push(`<w:em w:val="${formatting.emphasisMark}"/>`);
   }
 


### PR DESCRIPTION
Preserve explicit disabled emphasis marks during run-property serialization so style inheritance is not accidentally reactivated. Cover every supported emphasis-mark value with a focused serializer regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly disabled emphasis marks when formatting and exporting documents.
  * Ensured all emphasis mark settings, including “none”, are accurately represented in exported Word documents.

* **Release**
  * Included this correction in a patch release of the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->