### PR TITLE
fix: resume staged package releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@c47bb87cc82047b5fdc2540983148d4e3efa9a37 # v1.3.0
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@aa71261ae4ac03405195b3470b16b0bf5669be67 # v1.4.0
     with:
       artifact-pattern: npm-tarball-*
       package-files: |


### PR DESCRIPTION
## Summary

- pin the independent npm release workflow to v1.4.0
- resume package versions that already have exact draft release assets

## Verification

- `actionlint .github/workflows/publish.yml`
- `git diff --check`
- verified the pinned commit matches the published v1.4.0 tag

CC on behalf of @jan-kubica