### PR TITLE
fix: normalize positioned text box offsets

### DIFF
--- a/.changeset/clean-boxes-rest.md
+++ b/.changeset/clean-boxes-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize omitted offsets on positioned legacy text boxes.

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -485,11 +485,11 @@ const parseVmlTextBoxShape = (
     shape.position = {
       horizontal: {
         relativeTo: horizontalRelativeTo(style["mso-position-horizontal-relative"]),
-        ...(left === undefined ? {} : { posOffset: pixelsToEmu(left) }),
+        posOffset: pixelsToEmu(left ?? 0),
       },
       vertical: {
         relativeTo: verticalRelativeTo(style["mso-position-vertical-relative"]),
-        ...(top === undefined ? {} : { posOffset: pixelsToEmu(top) }),
+        posOffset: pixelsToEmu(top ?? 0),
       },
     };
   }

--- a/packages/core/src/docx/textBoxDrawingOwnership.test.ts
+++ b/packages/core/src/docx/textBoxDrawingOwnership.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
+import type { ImagePosition } from "../types/document";
 import { parseDocx } from "./parser";
 import { createEmptyDocx, repackDocx } from "./rezip";
 
@@ -97,6 +98,26 @@ const bodyShapeWrapTypes = ({ package: { document } }: ParsedDocx): string[] => 
   return wrapTypes;
 };
 
+const bodyShapePositions = ({ package: { document } }: ParsedDocx): ImagePosition[] => {
+  const positions: ImagePosition[] = [];
+  for (const block of document.content) {
+    if (block.type !== "paragraph") {
+      continue;
+    }
+    for (const content of block.content) {
+      if (content.type !== "run") {
+        continue;
+      }
+      for (const item of content.content) {
+        if (item.type === "shape" && item.shape.position) {
+          positions.push(item.shape.position);
+        }
+      }
+    }
+  }
+  return positions;
+};
+
 const savedDocumentXml = async (buffer: ArrayBuffer): Promise<string> => {
   const zip = await JSZip.loadAsync(buffer);
   return zip.file("word/document.xml")!.async("text");
@@ -163,5 +184,51 @@ describe("text-box drawing ownership", () => {
     const saved = await repackDocx(parsed, { updateModifiedDate: false });
     const reopened = await parseDocx(saved, { preloadFonts: false });
     expect(bodyShapeWrapTypes(reopened)).toEqual(["inline"]);
+  });
+
+  test("positioned VML text boxes normalize every omitted axis offset before DrawingML conversion", async () => {
+    const cases = [
+      {
+        style: "top:10pt",
+        expectedPosition: {
+          horizontal: { relativeTo: "character", posOffset: 0 },
+          vertical: { relativeTo: "paragraph", posOffset: 127_000 },
+        },
+      },
+      {
+        style: "left:20pt",
+        expectedPosition: {
+          horizontal: { relativeTo: "character", posOffset: 254_000 },
+          vertical: { relativeTo: "paragraph", posOffset: 0 },
+        },
+      },
+      {
+        style: "",
+        expectedPosition: {
+          horizontal: { relativeTo: "character", posOffset: 0 },
+          vertical: { relativeTo: "paragraph", posOffset: 0 },
+        },
+      },
+    ] as const satisfies readonly {
+      style: string;
+      expectedPosition: ImagePosition;
+    }[];
+
+    for (const { style, expectedPosition } of cases) {
+      const source = await buildDocx(`
+        <w:pict>
+          <v:shape style="position:absolute;${style};width:2in;height:1in">
+            <v:textbox>
+              <w:txbxContent><w:p><w:r><w:t>Legacy text</w:t></w:r></w:p></w:txbxContent>
+            </v:textbox>
+          </v:shape>
+        </w:pict>`);
+      const parsed = await parseDocx(source, { preloadFonts: false });
+      expect(bodyShapePositions(parsed)).toEqual([expectedPosition]);
+
+      const saved = await repackDocx(parsed, { updateModifiedDate: false });
+      const reopened = await parseDocx(saved, { preloadFonts: false });
+      expect(bodyShapePositions(reopened)).toEqual([expectedPosition]);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- materialize zero offsets for omitted axes on positioned legacy text boxes
- preserve the normalized position through DrawingML conversion and save/reopen
- cover horizontal-only, vertical-only, and fully omitted offsets with one invariant test

## Validation

- `bun test packages/core/src/docx/textBoxDrawingOwnership.test.ts`
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `bun run validate-dist`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalised missing horizontal and vertical offsets for positioned legacy text boxes.
  * Ensured text box positioning remains consistent when documents are converted, repacked, and reopened.

* **Tests**
  * Added coverage for preserving omitted position offsets throughout the document processing cycle.

* **Chores**
  * Recorded a patch release for the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->