### PR TITLE
fix: make package builds reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Reproducible package builds
+        run: bun run check:build-reproducibility
+
       - name: API surface report
         run: bun run api:check
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:export-parity": "node scripts/check-export-parity.mjs",
     "check:react-compiler": "bun scripts/react-compiler-bailouts.ts --check",
     "check:lockfile-versions": "bun scripts/check-lockfile-workspace-versions.ts",
+    "check:build-reproducibility": "bun scripts/check-build-reproducibility.ts",
     "specifications:check": "bun scripts/specification-sources.ts check",
     "specifications:fetch": "bun scripts/specification-sources.ts fetch",
     "specifications:generate": "bun scripts/generate-ooxml-schema-graph.ts write",

--- a/packages/agents/tsdown.config.ts
+++ b/packages/agents/tsdown.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsdown";
 
+import { stableRelativeImportOrder } from "../../scripts/lib/stable-relative-import-order.ts";
+
 // @stll/folio-agents publishes a source-mirrored dist, same shape as
 // @stll/folio-core: every source module maps 1:1 to a `dist/*.js` +
 // `dist/*.d.ts` (`unbundle: true`), and the package's `exports` expose a
@@ -28,6 +30,11 @@ const shared = {
 // `.d.ts`). Neither pass may `clean` (tsdown runs array configs
 // concurrently); the `build` script clears `dist` up front instead.
 export default defineConfig([
-  { ...shared, dts: false, clean: false },
+  {
+    ...shared,
+    dts: false,
+    clean: false,
+    plugins: [stableRelativeImportOrder()],
+  },
   { ...shared, dts: { emitDtsOnly: true }, clean: false },
 ]);

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsdown";
 
+import { stableRelativeImportOrder } from "../../scripts/lib/stable-relative-import-order.ts";
+
 // @stll/folio-core publishes a source-mirrored dist: every source module maps
 // 1:1 to a `dist/*.js` + `dist/*.d.ts` (`unbundle: true`). The package's
 // `exports` expose a `"./*"` subpath wildcard onto that tree, so adapters
@@ -42,6 +44,11 @@ const shared = {
 // tsdown runs array configs concurrently, so neither pass may `clean` (it would
 // race the other's output). The `build` script clears `dist` up front instead.
 export default defineConfig([
-  { ...shared, dts: false, clean: false },
+  {
+    ...shared,
+    dts: false,
+    clean: false,
+    plugins: [stableRelativeImportOrder()],
+  },
   { ...shared, dts: { emitDtsOnly: true }, clean: false },
 ]);

--- a/scripts/check-build-reproducibility.ts
+++ b/scripts/check-build-reproducibility.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env bun
+
+import { panic } from "better-result";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build } from "tsdown";
+
+import agentsConfigs from "../packages/agents/tsdown.config";
+import coreConfigs from "../packages/core/tsdown.config";
+
+const BUILD_COUNT = 5;
+const ROOT = join(import.meta.dirname, "..");
+const targets = [
+  {
+    name: "@stll/folio-core",
+    directory: join(ROOT, "packages/core"),
+    config: coreConfigs.at(0),
+  },
+  {
+    name: "@stll/folio-agents",
+    directory: join(ROOT, "packages/agents"),
+    config: agentsConfigs.at(0),
+  },
+];
+
+const hashDirectory = async (directory: string): Promise<string> => {
+  const files = Array.from(
+    new Bun.Glob("**/*").scanSync({ cwd: directory, onlyFiles: true }),
+  ).sort();
+  const hash = createHash("sha256");
+  for (const file of files) {
+    const content = new Uint8Array(await Bun.file(join(directory, file)).arrayBuffer());
+    hash.update(`${file.length}:`);
+    hash.update(file);
+    hash.update(`${content.byteLength}:`);
+    hash.update(content);
+  }
+  return hash.digest("hex");
+};
+
+const tempRoot = await mkdtemp(join(tmpdir(), "folio-reproducible-build-"));
+const originalDirectory = process.cwd();
+
+try {
+  for (const { name, directory, config } of targets) {
+    if (!config) {
+      panic(`Missing JavaScript build config for ${name}`);
+    }
+
+    process.chdir(directory);
+    const digests: string[] = [];
+    for (let index = 0; index < BUILD_COUNT; index += 1) {
+      const outDir = join(tempRoot, name.replaceAll("/", "-"), String(index));
+      await build({ ...config, outDir, clean: true, logLevel: "silent" });
+      digests.push(await hashDirectory(outDir));
+    }
+
+    if (new Set(digests).size !== 1) {
+      panic(`${name} emitted non-reproducible JavaScript: ${digests.join(", ")}`);
+    }
+    console.log(`${name}: ${BUILD_COUNT} byte-identical JavaScript builds`);
+  }
+} finally {
+  process.chdir(originalDirectory);
+  await rm(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/lib/stable-relative-import-order.test.ts
+++ b/scripts/lib/stable-relative-import-order.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import coreConfigs from "../../packages/core/tsdown.config";
+import agentsConfigs from "../../packages/agents/tsdown.config";
+import {
+  canonicalizeRelativeImportOrder,
+  STABLE_RELATIVE_IMPORT_ORDER_PLUGIN,
+} from "./stable-relative-import-order";
+
+const RELATIVE_IMPORTS = [
+  'import { alpha } from "./alpha.js";',
+  'import { beta } from "../beta.js";',
+  'import "./side-effect-free.js";',
+  'import { zeta } from "./zeta.js";',
+] as const;
+
+const firstGroupPermutation = fc.uniqueArray(fc.integer({ min: 0, max: 1 }), {
+  minLength: 2,
+  maxLength: 2,
+});
+const secondGroupPermutation = fc.uniqueArray(fc.integer({ min: 2, max: 3 }), {
+  minLength: 2,
+  maxLength: 2,
+});
+
+const importSource = (line: string) => line.match(/"([^"]+)"/)?.at(1);
+
+const sortImports = (imports: readonly string[]) =>
+  [...imports].sort((left, right) => {
+    const leftSource = importSource(left) ?? "";
+    const rightSource = importSource(right) ?? "";
+    if (leftSource !== rightSource) {
+      return leftSource < rightSource ? -1 : 1;
+    }
+    if (left === right) {
+      return 0;
+    }
+    return left < right ? -1 : 1;
+  });
+
+const relativeImportSpans = (lines: readonly string[]) => {
+  let offset = 0;
+  let group = 0;
+  let previousWasRelative = false;
+  const spans: { start: number; end: number; source: string; group: number }[] = [];
+  for (const line of lines) {
+    const source = importSource(line);
+    if (source?.startsWith(".") && (line.startsWith('import "') || line.includes(' from ".'))) {
+      if (!previousWasRelative) {
+        group += 1;
+      }
+      spans.push({ start: offset, end: offset + line.length, source, group });
+      previousWasRelative = true;
+    } else {
+      previousWasRelative = false;
+    }
+    offset += line.length + 1;
+  }
+  return spans;
+};
+
+describe("stableRelativeImportOrder", () => {
+  test("canonicalizes every relative-import permutation without moving external imports", () => {
+    fc.assert(
+      fc.property(firstGroupPermutation, secondGroupPermutation, (first, second) => {
+        const firstGroup = first.flatMap((index) => {
+          const line = RELATIVE_IMPORTS.at(index);
+          return line ? [line] : [];
+        });
+        const secondGroup = second.flatMap((index) => {
+          const line = RELATIVE_IMPORTS.at(index);
+          return line ? [line] : [];
+        });
+        const lines = [
+          ...firstGroup,
+          'import { externalA } from "external-a";',
+          ...secondGroup,
+          'import "external-b";',
+          "export {};",
+        ];
+        const expected = [
+          ...sortImports(firstGroup),
+          'import { externalA } from "external-a";',
+          ...sortImports(secondGroup),
+          'import "external-b";',
+          "export {};",
+        ].join("\n");
+        const code = lines.join("\n");
+        const canonical = canonicalizeRelativeImportOrder(code, relativeImportSpans(lines));
+
+        expect(canonical).toBe(expected);
+        expect(
+          canonicalizeRelativeImportOrder(canonical, relativeImportSpans(expected.split("\n"))),
+        ).toBe(canonical);
+      }),
+    );
+  });
+
+  test("source-mirrored JavaScript builds install the canonicalizer", () => {
+    for (const config of [coreConfigs.at(0), agentsConfigs.at(0)]) {
+      expect(config?.plugins).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: STABLE_RELATIVE_IMPORT_ORDER_PLUGIN }),
+        ]),
+      );
+    }
+  });
+});

--- a/scripts/lib/stable-relative-import-order.ts
+++ b/scripts/lib/stable-relative-import-order.ts
@@ -1,0 +1,101 @@
+import type { TsdownPlugin } from "tsdown";
+
+export const STABLE_RELATIVE_IMPORT_ORDER_PLUGIN = "stable-relative-import-order";
+
+type RelativeImport = {
+  start: number;
+  end: number;
+  source: string;
+  group: number;
+};
+
+const compareCodeUnits = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+};
+
+/**
+ * Canonicalize only consecutive relative-import groups. External imports and
+ * their ordering boundaries stay untouched; callers must additionally limit
+ * this to source-mirrored packages that declare `sideEffects: false`.
+ */
+export const canonicalizeRelativeImportOrder = (
+  code: string,
+  imports: readonly RelativeImport[],
+): string => {
+  if (imports.length < 2) {
+    return code;
+  }
+
+  const sortedByGroup = new Map<number, { code: string; source: string }[]>();
+  for (const importDeclaration of imports) {
+    const group = sortedByGroup.get(importDeclaration.group) ?? [];
+    group.push({
+      code: code.slice(importDeclaration.start, importDeclaration.end),
+      source: importDeclaration.source,
+    });
+    sortedByGroup.set(importDeclaration.group, group);
+  }
+  for (const group of sortedByGroup.values()) {
+    group.sort(
+      (left, right) =>
+        compareCodeUnits(left.source, right.source) || compareCodeUnits(left.code, right.code),
+    );
+  }
+
+  let cursor = 0;
+  let result = "";
+  const groupIndexes = new Map<number, number>();
+  for (const statement of imports) {
+    const groupIndex = groupIndexes.get(statement.group) ?? 0;
+    const replacement = sortedByGroup.get(statement.group)?.at(groupIndex);
+    if (!replacement) {
+      return code;
+    }
+    groupIndexes.set(statement.group, groupIndex + 1);
+    result += code.slice(cursor, statement.start);
+    result += replacement.code;
+    cursor = statement.end;
+  }
+  return result + code.slice(cursor);
+};
+
+export const stableRelativeImportOrder = (): TsdownPlugin => ({
+  name: STABLE_RELATIVE_IMPORT_ORDER_PLUGIN,
+  renderChunk(code, _chunk, options) {
+    if (options.sourcemap) {
+      this.error(`${STABLE_RELATIVE_IMPORT_ORDER_PLUGIN} requires sourcemaps to remain disabled`);
+    }
+
+    const imports: RelativeImport[] = [];
+    let group = 0;
+    let previousWasRelative = false;
+    for (const statement of this.parse(code).body) {
+      if (statement.type === "ImportDeclaration" && statement.source.value.startsWith(".")) {
+        if (!previousWasRelative) {
+          group += 1;
+        }
+        imports.push({
+          start: statement.start,
+          end: statement.end,
+          source: statement.source.value,
+          group,
+        });
+        previousWasRelative = true;
+        continue;
+      }
+      previousWasRelative = false;
+    }
+
+    const canonical = canonicalizeRelativeImportOrder(code, imports);
+    if (canonical === code) {
+      return null;
+    }
+    return { code: canonical, map: null };
+  },
+});


### PR DESCRIPTION
Canonicalize consecutive relative-import groups in source-mirrored, side-effect-free package builds while preserving external import boundaries.

Add a property-based fixed-point invariant and a CI check that compares five independent JavaScript builds for each affected package.