### PR TITLE
fix: preserve DOCX render and section fidelity

### DIFF
--- a/.changeset/calm-pages-render.md
+++ b/.changeset/calm-pages-render.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve renderable drawing namespaces and mixed-section page order during DOCX round-trips.

--- a/packages/core/src/docx/__tests__/repack-paragraph-sectpr.test.ts
+++ b/packages/core/src/docx/__tests__/repack-paragraph-sectpr.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
+import type { Paragraph } from "../../types/document";
 import { parseDocx } from "../parser";
 import { repackDocx } from "../rezip";
 
@@ -22,21 +23,39 @@ const countParagraphSectPrs = (
 ): number =>
   blocks.filter((b) => b.type === "paragraph" && b.sectionProperties !== undefined).length;
 
-// Regression: paragraph-level `<w:pPr><w:sectPr/></w:pPr>` (an empty mid-body
-// section break) was parsed but dropped on serialize, tripping the package
-// fidelity guard. Fixture is a real-world contract from smlouvy.gov.cz that
-// uses an empty paragraph-level sectPr.
+// Regression: this real-world contract places its body-level A4 sectPr before
+// all content, followed by an empty paragraph-level section break. Repacking
+// must canonicalize the element locations without reversing the effective A4
+// then default-page sequence.
 describe("repack preserves paragraph-level section properties", () => {
-  test("round-tripping the fixture does not drop the mid-body sectPr", async () => {
+  test("round-tripping the fixture preserves section count and effective order", async () => {
     const buf = readFixture();
     const doc = await parseDocx(buf);
 
     const originalParagraphSectPrs = countParagraphSectPrs(doc.package.document.content);
     expect(originalParagraphSectPrs).toBeGreaterThan(0);
+    const originalSectionBreak = doc.package.document.content.find(
+      (block): block is Paragraph =>
+        block.type === "paragraph" && block.sectionProperties !== undefined,
+    );
+    expect(originalSectionBreak?.sectionProperties).toMatchObject({
+      pageWidth: 11_906,
+      pageHeight: 16_838,
+    });
+    expect(doc.package.document.finalSectionProperties?.pageWidth).toBeUndefined();
 
     const repacked = await repackDocx(doc, { updateModifiedDate: false });
     const reparsed = await parseDocx(repacked);
 
     expect(countParagraphSectPrs(reparsed.package.document.content)).toBe(originalParagraphSectPrs);
+    const reparsedSectionBreak = reparsed.package.document.content.find(
+      (block): block is Paragraph =>
+        block.type === "paragraph" && block.sectionProperties !== undefined,
+    );
+    expect(reparsedSectionBreak?.sectionProperties).toMatchObject({
+      pageWidth: 11_906,
+      pageHeight: 16_838,
+    });
+    expect(reparsed.package.document.finalSectionProperties?.pageWidth).toBeUndefined();
   });
 });

--- a/packages/core/src/docx/documentParser.test.ts
+++ b/packages/core/src/docx/documentParser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { Paragraph, Run } from "../types/document";
 import { parseDocumentBody } from "./documentParser";
 import { parseNumbering } from "./numberingParser";
+import { serializeDocumentBody } from "./serializer/documentSerializer";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
@@ -77,6 +78,38 @@ const textBoxDrawingContentXml = (content: string, bodyProperties = "<wps:bodyPr
 
 const textBoxDrawingXml = (text: string, bodyProperties = "<wps:bodyPr/>") =>
   textBoxDrawingContentXml(`<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`, bodyProperties);
+
+describe("parseDocumentBody section ordering", () => {
+  test("canonicalizes a leading body sectPr without reversing effective section formats", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/></w:sectPr>
+    <w:p><w:r><w:t>First section</w:t></w:r></w:p>
+    <w:p>
+      <w:pPr><w:sectPr/></w:pPr>
+      <w:r><w:t>Section break</w:t></w:r>
+    </w:p>
+    <w:p><w:r><w:t>Second section</w:t></w:r></w:p>
+  </w:body>
+</w:document>`);
+
+    const sectionBreak = body.content.at(1);
+    expect(sectionBreak?.type).toBe("paragraph");
+    if (sectionBreak?.type !== "paragraph") {
+      throw new Error("expected the second block to be a paragraph");
+    }
+    expect(sectionBreak.sectionProperties).toMatchObject({
+      pageWidth: 11_906,
+      pageHeight: 16_838,
+    });
+    expect(body.finalSectionProperties?.pageWidth).toBeUndefined();
+    expect(body.finalSectionProperties?.pageHeight).toBeUndefined();
+
+    const serialized = serializeDocumentBody(body);
+    expect(serialized.indexOf('w:w="11906"')).toBeLessThan(serialized.lastIndexOf("<w:sectPr/>"));
+  });
+});
 
 describe("parseDocumentBody list numbering", () => {
   test("renders legal multilevel numbering with decimal parent counters", () => {

--- a/packages/core/src/docx/documentParser.ts
+++ b/packages/core/src/docx/documentParser.ts
@@ -28,7 +28,7 @@ import { getParagraphText } from "./paragraphParser";
 import { parseSectionProperties, getDefaultSectionProperties } from "./sectionParser";
 import { parseStreamingXml } from "./streamingXmlParser";
 import type { StyleMap } from "./styleParser";
-import { parseXml, findChild, collectXmlnsDeclarations } from "./xmlParser";
+import { parseXml, findChild, collectXmlnsDeclarations, getLocalName } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 // ============================================================================
@@ -178,6 +178,48 @@ function buildSections(
   return sections;
 }
 
+/**
+ * Some producers place the body-level sectPr before all content. Consumers
+ * apply section properties in source order, but canonical serialization moves
+ * the body-level sectPr to the end and would therefore reverse the effective
+ * formats around paragraph section breaks.
+ *
+ * Rotate that leading property through the canonical paragraph-break slots so
+ * serialization repairs the element order without changing the observed
+ * section sequence.
+ */
+function canonicalizeLeadingBodySectionProperties(
+  bodyElement: XmlElement,
+  body: DocumentBody,
+): void {
+  const firstBodyChild = bodyElement.elements?.find(({ type }) => type === "element");
+  if (
+    getLocalName(firstBodyChild?.name) !== "sectPr" ||
+    body.finalSectionProperties === undefined
+  ) {
+    return;
+  }
+
+  const sectionBreakParagraphs = body.content.filter(
+    (
+      block,
+    ): block is Paragraph & {
+      sectionProperties: SectionProperties;
+    } => block.type === "paragraph" && block.sectionProperties !== undefined,
+  );
+  if (sectionBreakParagraphs.length === 0) {
+    return;
+  }
+
+  let nextProperties = body.finalSectionProperties;
+  for (const paragraph of sectionBreakParagraphs) {
+    const currentProperties = paragraph.sectionProperties;
+    paragraph.sectionProperties = nextProperties;
+    nextProperties = currentProperties;
+  }
+  body.finalSectionProperties = nextProperties;
+}
+
 // ============================================================================
 // MAIN PARSER
 // ============================================================================
@@ -240,6 +282,8 @@ export function parseDocumentBody(
   if (finalSectPr) {
     result.finalSectionProperties = parseSectionProperties(finalSectPr);
   }
+
+  canonicalizeLeadingBodySectionProperties(bodyEl, result);
 
   // Build sections from content
   result.sections = buildSections(result.content, result.finalSectionProperties);

--- a/packages/core/src/docx/serializer/documentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/documentSerializer.test.ts
@@ -35,12 +35,21 @@ describe("document section properties are integer-only (issue #417)", () => {
   test("document root declares the full namespace set needed by raw-replay paths", () => {
     // The parser preserves unmodeled OOXML children (data hashes, cex /
     // cid extensions) inside `rawPropertiesXml`. A canonical
-    // `<w:sdtPr>` with a `<w16sdtdh:dataHash>` would replay an
-    // undeclared prefix if the document root only emits the minimal
-    // set — Word would refuse to open the file. Pin every w16* prefix
-    // here so the regression can't drift.
+    // `<w:sdtPr>` with a `<w16sdtdh:dataHash>` or a captured DrawingML
+    // picture would replay an undeclared prefix if the document root only
+    // emitted the minimal set. Pin the raw-replay namespace set here.
     const xml = serializeDocument(createEmptyDocument());
-    for (const prefix of ["w14", "w15", "w16", "w16cex", "w16cid", "w16sdtdh", "w16se"]) {
+    for (const prefix of [
+      "a",
+      "pic",
+      "w14",
+      "w15",
+      "w16",
+      "w16cex",
+      "w16cid",
+      "w16sdtdh",
+      "w16se",
+    ]) {
       expect(xml).toContain(`xmlns:${prefix}="`);
     }
   });

--- a/packages/core/src/docx/serializer/documentSerializer.ts
+++ b/packages/core/src/docx/serializer/documentSerializer.ts
@@ -26,6 +26,7 @@ import { serializeTable } from "./tableSerializer";
  * Standard OOXML namespaces for document.xml
  */
 const NAMESPACES = {
+  a: "http://schemas.openxmlformats.org/drawingml/2006/main",
   wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
   cx: "http://schemas.microsoft.com/office/drawing/2014/chartex",
   cx1: "http://schemas.microsoft.com/office/drawing/2015/9/8/chartex",
@@ -41,6 +42,7 @@ const NAMESPACES = {
   am3d: "http://schemas.microsoft.com/office/drawing/2017/model3d",
   o: "urn:schemas-microsoft-com:office:office",
   oel: "http://schemas.microsoft.com/office/2019/extlst",
+  pic: "http://schemas.openxmlformats.org/drawingml/2006/picture",
   r: "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
   m: "http://schemas.openxmlformats.org/officeDocument/2006/math",
   v: "urn:schemas-microsoft-com:vml",
@@ -73,9 +75,11 @@ function buildNamespaceDeclarations(): string {
   // document root, the replayed XML would carry undefined prefixes and
   // Word refuses to open the file.
   const declared = {
+    a: NAMESPACES.a,
     wpc: NAMESPACES.wpc,
     mc: NAMESPACES.mc,
     o: NAMESPACES.o,
+    pic: NAMESPACES.pic,
     r: NAMESPACES.r,
     m: NAMESPACES.m,
     v: NAMESPACES.v,


### PR DESCRIPTION
## Summary

- declare required drawing namespaces on serialized document roots
- preserve effective page-format order when normalizing leading body section properties
- add synthetic and fixture-backed round-trip regressions