### PR TITLE
ci: classify generated DOCX artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
             Cargo.lock
             Cargo.toml
             bun.lock
+            packages/docx-core/src/generated/**
             packages/docx-core/CHANGELOG.md
             packages/docx-core/package.json
             packages/core/CHANGELOG.md


### PR DESCRIPTION
Treat committed DOCX kernel bindings as generated release output in the changeset policy. This lets the Version Packages PR refresh version-dependent canonical artifacts without creating a second release entry.

Source and manifest changes remain covered by the existing release paths and version synchronization checks.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release validation to recognise generated document-processing files when checking for required release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->