### PR TITLE
fix: render OOXML symbols with declared fonts

### DIFF
--- a/.changeset/swift-symbols-render.md
+++ b/.changeset/swift-symbols-render.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Render OOXML symbol characters with their declared fonts and preserve them through editing.

--- a/api-reports/core/prosemirror-attrs.api.md
+++ b/api-reports/core/prosemirror-attrs.api.md
@@ -77,6 +77,9 @@ export const expectShapeAttrs: (node: Node_2) => ShapeAttrs;
 export const expectStrikeMarkAttrs: (mark: Mark) => StrikeAttrs;
 
 // @public (undocumented)
+export const expectSymbolAttrs: (node: Node_2) => SymbolAttrs;
+
+// @public (undocumented)
 export const expectTabAttrs: (node: Node_2) => TabAttrs;
 
 // @public (undocumented)
@@ -198,6 +201,9 @@ export const readShapeAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<ShapeA
 
 // @public (undocumented)
 export const readStrikeMarkAttrs: (mark: Mark) => ReadProseMirrorAttrsResult<StrikeAttrs>;
+
+// @public (undocumented)
+export const readSymbolAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<SymbolAttrs>;
 
 // @public (undocumented)
 export const readTabAttrs: (node: Node_2) => ReadProseMirrorAttrsResult<TabAttrs>;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -358,6 +358,12 @@ export type StrikeAttrs = {
 };
 
 // @public (undocumented)
+export type SymbolAttrs = {
+    font: string;
+    char: string;
+};
+
+// @public (undocumented)
 export type TabAttrs = {
     positional?: import__stll_docx_core_model.PositionalTab;
 };

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -487,6 +487,9 @@ export type InstrTextContent = {
     text: string;
 };
 
+// @public
+export const isOoxmlSymbolCharacter: (value: string) => boolean;
+
 // @public (undocumented)
 export type KnownBorderStyle = "none" | "single" | "double" | "dotted" | "dashed" | "thick" | "triple" | "thinThickSmallGap" | "thickThinSmallGap" | "thinThickMediumGap" | "thickThinMediumGap" | "thinThickLargeGap" | "thickThinLargeGap" | "wave" | "doubleWave" | "dashSmallGap" | "dashDotStroked" | "threeDEmboss" | "threeDEngrave" | "outset" | "inset" | "nil";
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -56,6 +56,7 @@ import {
   expectParagraphAttrs,
   expectRunFormattingOverrideMarkAttrs,
   expectRunShadingMarkAttrs,
+  expectSymbolAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
@@ -85,6 +86,7 @@ import { NUMBER_FORMAT_VALUES } from "../../types/documentEnumValues";
 import { resolveColor, resolveHighlightToCss } from "../../utils/colorResolver";
 import { resolveThemeFont } from "../../utils/fontResolver";
 import { resolveShadingFill } from "../../utils/formatToStyle";
+import { decodeOoxmlSymbolCharacter } from "../../utils/ooxmlSymbol";
 import {
   AUTO_PARAGRAPH_SPACING_PX,
   pointsToPixels,
@@ -1073,6 +1075,26 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
         pmEnd: childPos + child.nodeSize,
       };
       runs.push(run);
+      return;
+    }
+    if (child.type.name === "symbol") {
+      const attrs = expectSymbolAttrs(child);
+      const text = decodeOoxmlSymbolCharacter(attrs.char);
+      if (text === null) {
+        return;
+      }
+      const formatting = extractRunFormatting(child.marks, theme);
+      if (inTocParagraph) {
+        stripTocHyperlinkStyle(formatting);
+      }
+      runs.push({
+        kind: "text",
+        text,
+        ...mergeRunFormatting(paraDefaults, formatting),
+        fontFamily: attrs.font,
+        pmStart: childPos,
+        pmEnd: childPos + child.nodeSize,
+      });
       return;
     }
     if (child.type.name === "hardBreak") {

--- a/packages/core/src/markdown/renderRuns.ts
+++ b/packages/core/src/markdown/renderRuns.ts
@@ -23,6 +23,7 @@ import type {
   Run,
   RunContent,
 } from "../types/document";
+import { decodeOoxmlSymbolCharacter } from "../utils/ooxmlSymbol";
 import { wrapComment, wrapDeletion, wrapInsertion, wrapMoveFrom, wrapMoveTo } from "./annotations";
 import { escapeAltText, escapeInline, escapeLinkUrl } from "./escape";
 import { registerImage } from "./images";
@@ -136,7 +137,7 @@ function renderRunContent(
         }
         break;
       case "symbol":
-        out += escapeInline(item.char);
+        out += escapeInline(decodeOoxmlSymbolCharacter(item.char) ?? item.char);
         break;
       case "softHyphen":
         // U+00AD soft hyphen. Word displays it only when needed for line

--- a/packages/core/src/markdown/renderTable.ts
+++ b/packages/core/src/markdown/renderTable.ts
@@ -15,6 +15,7 @@ import type {
   TableCell,
   TableRow,
 } from "../types/document";
+import { decodeOoxmlSymbolCharacter } from "../utils/ooxmlSymbol";
 import { escapeTableCell } from "./escape";
 import { registerImage } from "./images";
 import { pushWarning } from "./internals";
@@ -329,7 +330,7 @@ function renderHtmlRun(
         text += "<br>";
         break;
       case "symbol":
-        text += escapeHtml(item.char);
+        text += escapeHtml(decodeOoxmlSymbolCharacter(item.char) ?? item.char);
         break;
       case "noBreakHyphen":
         text += "&#8209;";

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -30,7 +30,7 @@ import {
   THEME_COLOR_SLOT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
-import { isOoxmlSymbolCharacter } from "../../utils/ooxmlSymbol";
+import { isOoxmlSymbolCharacter } from "@stll/docx-core/model";
 import { isParagraphDirection } from "../paragraphDirection";
 import type {
   BlockSdtAttrs,

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -30,6 +30,7 @@ import {
   THEME_COLOR_SLOT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
+import { isOoxmlSymbolCharacter } from "../../utils/ooxmlSymbol";
 import { isParagraphDirection } from "../paragraphDirection";
 import type {
   BlockSdtAttrs,
@@ -46,6 +47,7 @@ import type {
   HyperlinkAttrs,
   HardBreakAttrs,
   TabAttrs,
+  SymbolAttrs,
   ImageAttrs,
   MathAttrs,
   ParagraphAttrs,
@@ -218,6 +220,7 @@ const SECTION_VERTICAL_ALIGNMENTS = ["top", "center", "both", "bottom"] as const
 const paragraphAttrsCache = new WeakMap<PMNode, ParagraphAttrs>();
 const hardBreakAttrsCache = new WeakMap<PMNode, HardBreakAttrs>();
 const tabAttrsCache = new WeakMap<PMNode, TabAttrs>();
+const symbolAttrsCache = new WeakMap<PMNode, SymbolAttrs>();
 const tableAttrsCache = new WeakMap<PMNode, TableAttrs>();
 const tableRowAttrsCache = new WeakMap<PMNode, TableRowAttrs>();
 const tableCellAttrsCache = new WeakMap<PMNode, TableCellAttrs>();
@@ -432,6 +435,29 @@ export const readTabAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TabAttrs>
 
 export const expectTabAttrs = (node: PMNode): TabAttrs =>
   expectCachedNodeAttrs(node, tabAttrsCache, readTabAttrs, "tab attrs");
+
+export const readSymbolAttrs = (node: PMNode): ReadProseMirrorAttrsResult<SymbolAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "symbol", issues);
+
+  requiredString(attrs, "font", "symbol.attrs.font", issues);
+  requiredString(attrs, "char", "symbol.attrs.char", issues);
+  if (typeof attrs["font"] === "string" && attrs["font"].trim() === "") {
+    issues.push({ path: "symbol.attrs.font", message: "Expected a non-empty font name." });
+  }
+  if (typeof attrs["char"] === "string" && !isOoxmlSymbolCharacter(attrs["char"])) {
+    issues.push({
+      path: "symbol.attrs.char",
+      message: "Expected exactly four hexadecimal digits.",
+    });
+  }
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectSymbolAttrs = (node: PMNode): SymbolAttrs =>
+  expectCachedNodeAttrs(node, symbolAttrsCache, readSymbolAttrs, "symbol attrs");
 
 export const readTableAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TableAttrs> => {
   const attrs = attrsRecord(node.attrs);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -49,6 +49,7 @@ import type {
   TableBorders,
   ShapeContent,
   Shape,
+  SymbolContent,
   NoteReferenceContent,
   SimpleField,
   ComplexField,
@@ -87,6 +88,7 @@ import {
   expectBlockSdtAttrs,
   expectSdtAttrs,
   expectShapeAttrs,
+  expectSymbolAttrs,
   expectStrikeMarkAttrs,
   expectTabAttrs,
   expectTableAttrs,
@@ -1588,6 +1590,9 @@ function extractParagraphContent(
         currentRun = createRunFromText(node.text || "", node.marks);
         currentMarksKey = marksKey;
       }
+    } else if (node.type.name === "symbol") {
+      flushCurrentInline();
+      content.push(createSymbolRun(node, node.marks));
     } else if (node.type.name === "hardBreak") {
       // Hard break ends current run
       flushCurrentInline();
@@ -1681,6 +1686,9 @@ function createTrackedChangeRun(node: PMNode, marks: readonly Mark[]): Run | nul
     };
     restoreRunPropertyChanges(run, marks);
     return run;
+  }
+  if (node.type.name === "symbol") {
+    return createSymbolRun(node, marks);
   }
   if (node.type.name === "hardBreak") {
     return createBreakRun(readHardBreakType(node));
@@ -1834,6 +1842,11 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
     return;
   }
 
+  if (node.type.name === "symbol") {
+    hyperlink.children.push(createSymbolRun(node, nonLinkMarks));
+    return;
+  }
+
   if (node.type.name === "hardBreak") {
     hyperlink.children.push(createBreakRun(readHardBreakType(node), nonLinkMarks));
     return;
@@ -1906,6 +1919,18 @@ function createRunFromText(text: string, marks: readonly Mark[]): Run {
   };
 
   const run: Run = { type: "run", content: [textContent] };
+  if (formatting) {
+    run.formatting = formatting;
+  }
+  restoreRunPropertyChanges(run, marks);
+  return run;
+}
+
+function createSymbolRun(node: PMNode, marks: readonly Mark[]): Run {
+  const { font, char } = expectSymbolAttrs(node);
+  const symbolContent: SymbolContent = { type: "symbol", font, char };
+  const run: Run = { type: "run", content: [symbolContent] };
+  const formatting = getRunFormattingFromMarks(marks);
   if (formatting) {
     run.formatting = formatting;
   }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { toFlowBlocks } from "../../layout-bridge/convert/toFlowBlocks";
 import type { Document, ShadingProperties, TableCell, Theme } from "../../types/document";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
@@ -44,6 +45,60 @@ function firstTableCellAttrs(doc: Document): Record<string, unknown> {
 }
 
 describe("toProseDoc", () => {
+  test("renders OOXML symbol characters with their declared font", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "symbol", font: "Wingdings", char: "F06F" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const symbol = pmDoc.firstChild?.firstChild;
+
+    expect(symbol?.type.name).toBe("symbol");
+    expect(symbol?.attrs).toMatchObject({ font: "Wingdings", char: "F06F" });
+    expect(symbol?.type.spec.toDOM?.(symbol)).toEqual([
+      "span",
+      {
+        "data-docx-symbol-char": "F06F",
+        "data-docx-symbol-font": "Wingdings",
+        style: 'font-family: "Wingdings";',
+      },
+      "\uF06F",
+    ]);
+
+    const paragraph = toFlowBlocks(pmDoc).at(0);
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      return;
+    }
+    expect(paragraph.runs).toMatchObject([
+      { kind: "text", text: "\uF06F", fontFamily: "Wingdings" },
+    ]);
+
+    const rebuilt = fromProseDoc(pmDoc, document);
+    const rebuiltParagraph = rebuilt.package.document.content.at(0);
+    const rebuiltRun =
+      rebuiltParagraph?.type === "paragraph" ? rebuiltParagraph.content.at(0) : undefined;
+    expect(rebuiltRun?.type).toBe("run");
+    if (rebuiltRun?.type !== "run") {
+      return;
+    }
+    expect(rebuiltRun.content).toEqual([{ type: "symbol", font: "Wingdings", char: "F06F" }]);
+  });
+
   test("converts table-cell text-box shapes into block nodes", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -556,6 +556,7 @@ function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
         node.type.name === "shape" ||
         node.type.name === "hardBreak" ||
         node.type.name === "tab" ||
+        node.type.name === "symbol" ||
         node.type.name === "textBoxAnchor"))
   );
 }
@@ -2391,9 +2392,7 @@ function convertRunContent(
       return [schema.text("­", marks)];
 
     case "symbol":
-      // Plain Unicode symbol — fall through to text if the parsed
-      // character is available; otherwise drop.
-      return content.char ? [schema.text(content.char, marks)] : [];
+      return [schema.node("symbol", { font: content.font, char: content.char }).mark(marks)];
   }
 }
 

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -78,6 +78,7 @@ import { PageBreakExtension } from "./nodes/PageBreakExtension";
 import { RenderedPageBreakExtension } from "./nodes/RenderedPageBreakExtension";
 import { SdtExtension } from "./nodes/SdtExtension";
 import { ShapeExtension } from "./nodes/ShapeExtension";
+import { SymbolExtension } from "./nodes/SymbolExtension";
 import { TabExtension } from "./nodes/TabExtension";
 import { createTableExtensions } from "./nodes/TableExtension";
 import { TextBoxExtension } from "./nodes/TextBoxExtension";
@@ -162,6 +163,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   // Nodes
   add("hardBreak", HardBreakExtension());
   add("tab", TabExtension());
+  add("symbol", SymbolExtension());
   add("image", ImageExtension());
   add("textBox", TextBoxExtension());
   add("textBoxAnchor", TextBoxAnchorExtension());

--- a/packages/core/src/prosemirror/extensions/nodes/SymbolExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/SymbolExtension.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../schema";
+
+class FakeHTMLElement {
+  readonly dataset: Record<string, string>;
+
+  constructor(dataset: Record<string, string>) {
+    this.dataset = dataset;
+  }
+}
+
+const parseSymbolAttrs = (dataset: Record<string, string>) => {
+  const getAttrs = schema.nodes.symbol.spec.parseDOM?.at(0)?.getAttrs;
+  if (!getAttrs) {
+    throw new Error("SymbolExtension must define parseDOM[0].getAttrs");
+  }
+
+  const originalElement = globalThis.HTMLElement;
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: FakeHTMLElement,
+  });
+
+  try {
+    return getAttrs(new FakeHTMLElement(dataset) as unknown as HTMLElement);
+  } finally {
+    if (originalElement) {
+      Object.defineProperty(globalThis, "HTMLElement", {
+        configurable: true,
+        value: originalElement,
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, "HTMLElement");
+    }
+  }
+};
+
+describe("SymbolExtension parseDOM", () => {
+  test("accepts a non-empty font and four-digit hexadecimal character", () => {
+    expect(
+      parseSymbolAttrs({
+        docxSymbolFont: "Wingdings",
+        docxSymbolChar: "aF4B",
+      }),
+    ).toEqual({ font: "Wingdings", char: "aF4B" });
+  });
+
+  test.each([
+    { docxSymbolFont: "", docxSymbolChar: "F041" },
+    { docxSymbolFont: "   ", docxSymbolChar: "F041" },
+    { docxSymbolFont: "Wingdings", docxSymbolChar: "041" },
+    { docxSymbolFont: "Wingdings", docxSymbolChar: "F0410" },
+    { docxSymbolFont: "Wingdings", docxSymbolChar: "GGGG" },
+  ])("rejects malformed symbol attributes", (dataset) => {
+    expect(parseSymbolAttrs(dataset)).toBe(false);
+  });
+});

--- a/packages/core/src/prosemirror/extensions/nodes/SymbolExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/SymbolExtension.ts
@@ -1,0 +1,53 @@
+import { expectSymbolAttrs } from "../../attrs";
+import { decodeOoxmlSymbolCharacter } from "../../../utils/ooxmlSymbol";
+import { createNodeExtension } from "../create";
+
+const escapeCssString = (value: string): string =>
+  value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\n", "\\a ")
+    .replaceAll("\r", "\\d ")
+    .replaceAll("\f", "\\c ");
+
+export const SymbolExtension = createNodeExtension({
+  name: "symbol",
+  schemaNodeName: "symbol",
+  nodeSpec: {
+    inline: true,
+    group: "inline",
+    atom: true,
+    marks: "_",
+    attrs: {
+      font: {},
+      char: {},
+    },
+    selectable: false,
+    parseDOM: [
+      {
+        tag: "span[data-docx-symbol-char][data-docx-symbol-font]",
+        getAttrs(node) {
+          if (!(node instanceof HTMLElement)) {
+            return false;
+          }
+          const font = node.dataset["docxSymbolFont"];
+          const char = node.dataset["docxSymbolChar"];
+          return font && char ? { font, char } : false;
+        },
+      },
+    ],
+    toDOM(node) {
+      const { font, char } = expectSymbolAttrs(node);
+      const decoded = decodeOoxmlSymbolCharacter(char);
+      return [
+        "span",
+        {
+          "data-docx-symbol-char": char,
+          "data-docx-symbol-font": font,
+          style: `font-family: "${escapeCssString(font)}";`,
+        },
+        decoded ?? "\uFFFD",
+      ];
+    },
+  },
+});

--- a/packages/core/src/prosemirror/extensions/nodes/SymbolExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/SymbolExtension.ts
@@ -1,3 +1,5 @@
+import { isOoxmlSymbolCharacter } from "@stll/docx-core/model";
+
 import { expectSymbolAttrs } from "../../attrs";
 import { decodeOoxmlSymbolCharacter } from "../../../utils/ooxmlSymbol";
 import { createNodeExtension } from "../create";
@@ -32,7 +34,10 @@ export const SymbolExtension = createNodeExtension({
           }
           const font = node.dataset["docxSymbolFont"];
           const char = node.dataset["docxSymbolChar"];
-          return font && char ? { font, char } : false;
+          if (!font || font.trim() === "" || !char || !isOoxmlSymbolCharacter(char)) {
+            return false;
+          }
+          return { font, char };
         },
       },
     ],

--- a/packages/core/src/prosemirror/findReplaceSelection.ts
+++ b/packages/core/src/prosemirror/findReplaceSelection.ts
@@ -1,5 +1,8 @@
 import type { Node as ProseMirrorNode } from "prosemirror-model";
 
+import { decodeOoxmlSymbolCharacter } from "../utils/ooxmlSymbol";
+import { expectSymbolAttrs } from "./attrs";
+
 import { findAllMatches } from "../utils/findReplace";
 import type { FindOptions } from "../utils/findReplace";
 
@@ -192,7 +195,7 @@ function getSearchTextTokenLength(node: ProseMirrorNode): number {
     return node.text?.length ?? 0;
   }
 
-  if (node.type.name === "tab" || node.type.name === "hardBreak") {
+  if (node.type.name === "tab" || node.type.name === "hardBreak" || node.type.name === "symbol") {
     return 1;
   }
 
@@ -212,6 +215,10 @@ function getSearchableParagraphText(paragraph: ProseMirrorNode): string {
     }
     if (node.type.name === "hardBreak") {
       text += "\n";
+      return false;
+    }
+    if (node.type.name === "symbol") {
+      text += decodeOoxmlSymbolCharacter(expectSymbolAttrs(node).char) ?? "";
       return false;
     }
     return true;

--- a/packages/core/src/prosemirror/schema/index.ts
+++ b/packages/core/src/prosemirror/schema/index.ts
@@ -14,6 +14,7 @@ import { createStarterKit } from "../extensions/StarterKit";
 export type {
   HardBreakAttrs,
   TabAttrs,
+  SymbolAttrs,
   ParagraphAttrs,
   FieldAttrs,
   ImageAttrs,

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -54,6 +54,11 @@ export type TabAttrs = {
   positional?: PositionalTab;
 };
 
+export type SymbolAttrs = {
+  font: string;
+  char: string;
+};
+
 /**
  * Paragraph node attributes - maps to ParagraphFormatting
  */

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -24,6 +24,7 @@ import {
   readSdtAttrs,
   readShapeAttrs,
   readStrikeMarkAttrs,
+  readSymbolAttrs,
   readTabAttrs,
   readTableAttrs,
   readTableCellAttrs,
@@ -135,6 +136,10 @@ const validateNodeAttrs = (
 
     case "tab":
       appendAttrIssues(path, readTabAttrs(node), issues);
+      return;
+
+    case "symbol":
+      appendAttrIssues(path, readSymbolAttrs(node), issues);
       return;
 
     case "hardBreak":

--- a/packages/core/src/utils/ooxmlSymbol.ts
+++ b/packages/core/src/utils/ooxmlSymbol.ts
@@ -1,7 +1,4 @@
-const OOXML_SYMBOL_CHARACTER_PATTERN = /^[\dA-Fa-f]{4}$/u;
-
-export const isOoxmlSymbolCharacter = (value: string): boolean =>
-  OOXML_SYMBOL_CHARACTER_PATTERN.test(value);
+import { isOoxmlSymbolCharacter } from "@stll/docx-core/model";
 
 export const decodeOoxmlSymbolCharacter = (value: string): string | null =>
   isOoxmlSymbolCharacter(value) ? String.fromCodePoint(Number.parseInt(value, 16)) : null;

--- a/packages/core/src/utils/ooxmlSymbol.ts
+++ b/packages/core/src/utils/ooxmlSymbol.ts
@@ -1,0 +1,7 @@
+const OOXML_SYMBOL_CHARACTER_PATTERN = /^[\dA-Fa-f]{4}$/u;
+
+export const isOoxmlSymbolCharacter = (value: string): boolean =>
+  OOXML_SYMBOL_CHARACTER_PATTERN.test(value);
+
+export const decodeOoxmlSymbolCharacter = (value: string): string | null =>
+  isOoxmlSymbolCharacter(value) ? String.fromCodePoint(Number.parseInt(value, 16)) : null;

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -71,6 +71,12 @@ export type SymbolContent = {
   char: string;
 };
 
+const OOXML_SYMBOL_CHARACTER_PATTERN = /^[\dA-Fa-f]{4}$/u;
+
+/** Whether a symbol character is exactly four hexadecimal digits. */
+export const isOoxmlSymbolCharacter = (value: string): boolean =>
+  OOXML_SYMBOL_CHARACTER_PATTERN.test(value);
+
 /**
  * Footnote or endnote reference
  */

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -62,8 +62,8 @@ export type {
   NumberingDefinitions,
 } from "./lists";
 
-// Content Model — revision-id bounds (values, not types)
-export { MAX_REVISION_ID, normalizeRevisionId } from "./content";
+// Content Model — shared values
+export { isOoxmlSymbolCharacter, MAX_REVISION_ID, normalizeRevisionId } from "./content";
 
 export type {
   TextContent,

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -97,6 +97,33 @@ describe("canonical DOCX document model validation", () => {
     expect(result.issues).toEqual([]);
   });
 
+  test("rejects malformed symbol attributes", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            {
+              type: "run",
+              content: [{ type: "symbol", font: "", char: "not-hex" }],
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual({
+      path: "package.document.content[0].content[0].content[0].font",
+      message: "Symbol content must include a font name.",
+      severity: "error",
+    });
+    expect(result.issues).toContainEqual({
+      path: "package.document.content[0].content[0].content[0].char",
+      message: "Symbol character must be exactly four hexadecimal digits.",
+      severity: "error",
+    });
+  });
+
   test("rejects a whitespace-only comment author", () => {
     const result = validateDocumentModel(
       createDocument({

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -97,14 +97,19 @@ describe("canonical DOCX document model validation", () => {
     expect(result.issues).toEqual([]);
   });
 
-  test("rejects malformed symbol attributes", () => {
+  test.each([
+    { font: "", char: "F041", invalidPath: "font" },
+    { font: "   ", char: "F041", invalidPath: "font" },
+    { font: "Wingdings", char: "041", invalidPath: "char" },
+    { font: "Wingdings", char: "F0410", invalidPath: "char" },
+  ])("rejects malformed symbol attributes: $invalidPath", ({ font, char, invalidPath }) => {
     const result = validateDocumentModel(
       createDocument({
         content: [
           paragraph([
             {
               type: "run",
-              content: [{ type: "symbol", font: "", char: "not-hex" }],
+              content: [{ type: "symbol", font, char }],
             },
           ]),
         ],
@@ -112,16 +117,34 @@ describe("canonical DOCX document model validation", () => {
     );
 
     expect(result.valid).toBe(false);
-    expect(result.issues).toContainEqual({
-      path: "package.document.content[0].content[0].content[0].font",
-      message: "Symbol content must include a font name.",
-      severity: "error",
-    });
-    expect(result.issues).toContainEqual({
-      path: "package.document.content[0].content[0].content[0].char",
-      message: "Symbol character must be exactly four hexadecimal digits.",
-      severity: "error",
-    });
+    expect(result.issues).toEqual([
+      {
+        path: `package.document.content[0].content[0].content[0].${invalidPath}`,
+        message:
+          invalidPath === "font"
+            ? "Symbol content must include a font name."
+            : "Symbol character must be exactly four hexadecimal digits.",
+        severity: "error",
+      },
+    ]);
+  });
+
+  test("accepts a mixed-case four-digit symbol character", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            {
+              type: "run",
+              content: [{ type: "symbol", font: "Wingdings", char: "aF4B" }],
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
   });
 
   test("rejects a whitespace-only comment author", () => {

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -450,8 +450,13 @@ const validateRunContent = (content: RunContent, path: string, ctx: ValidationCo
     return;
   }
 
-  if (content.type === "symbol" && content.char.trim() === "") {
-    addError(ctx, `${path}.char`, "Symbol content must include a character.");
+  if (content.type === "symbol") {
+    if (content.font.trim() === "") {
+      addError(ctx, `${path}.font`, "Symbol content must include a font name.");
+    }
+    if (!/^[\dA-Fa-f]{4}$/u.test(content.char)) {
+      addError(ctx, `${path}.char`, "Symbol character must be exactly four hexadecimal digits.");
+    }
   }
 };
 

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -1,24 +1,25 @@
 import { panic } from "better-result";
 import JSZip from "jszip";
 
-import type {
-  BlockContent,
-  Comment,
-  Document,
-  HeaderFooter,
-  HeaderFooterType,
-  Hyperlink,
-  Image,
-  Paragraph,
-  ParagraphContent,
-  Run,
-  RunContent,
-  SectionProperties,
-  Shape,
-  Table,
-  TableCell,
-  TableRow,
-  TrackedRunChange,
+import {
+  isOoxmlSymbolCharacter,
+  type BlockContent,
+  type Comment,
+  type Document,
+  type HeaderFooter,
+  type HeaderFooterType,
+  type Hyperlink,
+  type Image,
+  type Paragraph,
+  type ParagraphContent,
+  type Run,
+  type RunContent,
+  type SectionProperties,
+  type Shape,
+  type Table,
+  type TableCell,
+  type TableRow,
+  type TrackedRunChange,
 } from "../model/document";
 
 export type ValidateDocxPackageResult = { valid: true } | { valid: false; error: string };
@@ -454,7 +455,7 @@ const validateRunContent = (content: RunContent, path: string, ctx: ValidationCo
     if (content.font.trim() === "") {
       addError(ctx, `${path}.font`, "Symbol content must include a font name.");
     }
-    if (!/^[\dA-Fa-f]{4}$/u.test(content.char)) {
+    if (!isOoxmlSymbolCharacter(content.char)) {
       addError(ctx, `${path}.char`, "Symbol character must be exactly four hexadecimal digits.");
     }
   }


### PR DESCRIPTION
## Summary

- represent OOXML symbol runs as typed inline editor nodes
- render hexadecimal symbol codes with their declared fonts
- preserve symbol metadata through editing and validate malformed attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering and editing OOXML symbol characters using their declared fonts.
  * Preserved symbols through document conversion, hyperlinks, tracked changes, tables and find-and-replace operations.
  * Added validation for symbol fonts and four-digit hexadecimal character codes.

* **Bug Fixes**
  * Prevented supported symbols from being converted to plain text or lost during editing.
  * Improved symbol display when importing and exporting documents.

* **Tests**
  * Added coverage for symbol rendering, round-trip conversion and invalid symbol data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->