### PR TITLE
fix: regenerate DOCX kernel during versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "validate-dist:vue": "bun scripts/validate-dist.ts vue",
     "api:update": "bun scripts/api-reports.ts --update",
     "api:check": "bun scripts/api-reports.ts",
-    "changeset:version": "changeset version && bun scripts/sync-docx-kernel-version.ts --write && bun scripts/check-lockfile-workspace-versions.ts --write && bun install --frozen-lockfile",
+    "changeset:version": "changeset version && bun scripts/sync-docx-kernel-version.ts --write && bun scripts/check-lockfile-workspace-versions.ts --write && bun install --frozen-lockfile && bun --filter '@stll/docx-core' wasm:generate",
     "bench": "bun benchmarks/index.ts",
     "bench:cross-language": "bun benchmarks/cross-language/run.ts",
     "parity": "bun parity/cli.ts",

--- a/scripts/bun-lock-workspace-versions.test.ts
+++ b/scripts/bun-lock-workspace-versions.test.ts
@@ -51,12 +51,13 @@ describe("bun.lock workspace self-version synchronization", () => {
     ]);
   });
 
-  test("release versioning cannot delete or regenerate bun.lock", () => {
+  test("release versioning synchronizes lock and generated kernel artifacts", () => {
     const command = packageJson.scripts["changeset:version"];
 
     expect(command).not.toMatch(/\brm\b/);
     expect(command).toContain("sync-docx-kernel-version.ts --write");
     expect(command).toContain("check-lockfile-workspace-versions.ts --write");
-    expect(command).toEndWith("bun install --frozen-lockfile");
+    expect(command).toContain("bun install --frozen-lockfile");
+    expect(command).toEndWith("bun --filter '@stll/docx-core' wasm:generate");
   });
 });


### PR DESCRIPTION
## Summary

- regenerate canonical DOCX kernel artifacts after Changesets synchronizes package and Cargo versions
- enforce the versioning command contract with a focused test

## Validation

- `bun test scripts/bun-lock-workspace-versions.test.ts`
- `bun run format:check`
- `bun run lint`

CC on behalf of jan-kubica