### PR TITLE
fix: retry npm release staging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@6c814558499cf9792072dad3bb36ca3983202dd2 # v1.5.0
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@8948af7f6f794f6b2e8b9bd50ccb4f160eb0aca0 # v1.5.2
     with:
       artifact-pattern: npm-tarball-*
       artifact-run-id: ${{ inputs.artifact-run-id }}


### PR DESCRIPTION
## Summary

- adopt the immutable shared npm release workflow with bounded draft-state retries
- preserve the existing fail-closed staging and artifact verification behavior

## Validation

- YAML parse check
- `git diff --check`
- shared workflow v1.5.2 contract tests and actionlint passed

CC on behalf of jan-kubica