### PR TITLE
fix: create missing footnote and endnote parts

### DIFF
--- a/.changeset/new-note-parts.md
+++ b/.changeset/new-note-parts.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Create required DOCX package parts when adding footnotes or endnotes to a document that had none.

--- a/packages/core/src/docx/noteSave.test.ts
+++ b/packages/core/src/docx/noteSave.test.ts
@@ -18,8 +18,9 @@ import JSZip from "jszip";
 import type { Endnote, Footnote } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { repackDocx } from "./rezip";
+import { createDocx, repackDocx } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
+import { createEmptyDocument } from "../utils/createDocument";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
@@ -261,6 +262,63 @@ describe("footnote / endnote body write path (selective save)", () => {
 });
 
 describe("footnote / endnote body write path (full repack)", () => {
+  test("createDocx materializes new note parts and their package declarations", async () => {
+    const doc = createEmptyDocument({ initialText: "Body text" });
+    const body = doc.package.document.content.at(0);
+    if (!body || body.type !== "paragraph") {
+      throw new Error("expected a body paragraph");
+    }
+    body.content.push(
+      { type: "run", content: [{ type: "footnoteRef", id: 1 }] },
+      { type: "run", content: [{ type: "endnoteRef", id: 1 }] },
+    );
+    doc.package.footnotes = [
+      {
+        type: "footnote",
+        id: 1,
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "run", content: [{ type: "text", text: "New footnote" }] }],
+          },
+        ],
+      },
+    ];
+    doc.package.endnotes = [
+      {
+        type: "endnote",
+        id: 1,
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "run", content: [{ type: "text", text: "New endnote" }] }],
+          },
+        ],
+      },
+    ];
+
+    const result = await createDocx(doc);
+    const contentTypes = await readPart(result, "[Content_Types].xml");
+    const relationships = await readPart(result, "word/_rels/document.xml.rels");
+    const savedFootnotes = await readPart(result, "word/footnotes.xml");
+    const savedEndnotes = await readPart(result, "word/endnotes.xml");
+
+    expect(contentTypes).toContain('PartName="/word/footnotes.xml"');
+    expect(contentTypes).toContain('PartName="/word/endnotes.xml"');
+    expect(relationships).toContain(`Type="${RELATIONSHIP_TYPES.footnotes}"`);
+    expect(relationships).toContain(`Type="${RELATIONSHIP_TYPES.endnotes}"`);
+    expect(savedFootnotes).toContain('<w:footnote w:type="separator" w:id="-1">');
+    expect(savedFootnotes).toContain("<w:footnoteRef/>");
+    expect(savedFootnotes).toContain("New footnote");
+    expect(savedEndnotes).toContain('<w:endnote w:type="separator" w:id="-1">');
+    expect(savedEndnotes).toContain("<w:endnoteRef/>");
+    expect(savedEndnotes).toContain("New endnote");
+
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+    expect(noteBodyText(reparsed.package.footnotes?.at(0))).toBe("New footnote");
+    expect(noteBodyText(reparsed.package.endnotes?.at(0))).toBe("New endnote");
+  });
+
   test("edited footnote body persists through repackDocx; endnote + separators intact", async () => {
     const buffer = await createNotesFixture();
     const originalEndnotesXml = await readPart(buffer, "word/endnotes.xml");

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -55,7 +55,12 @@ import {
 } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
-import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
+import {
+  serializeEndnotes,
+  serializeFootnotes,
+  serializeNewEndnotesPart,
+  serializeNewFootnotesPart,
+} from "./serializer/noteSerializer";
 import { serializeNumberingXml } from "./serializer/numberingSerializer";
 import { serializeFontTableXml } from "./serializer/fontTableSerializer";
 import { serializeSettingsXml } from "./serializer/settingsSerializer";
@@ -1752,26 +1757,108 @@ async function serializeNotesToZip(
 ): Promise<void> {
   const footnotes = doc.package.footnotes ?? [];
   if (footnotes.length > 0) {
-    await patchNotePartIntoZip(
-      "word/footnotes.xml",
-      serializeFootnotes(footnotes),
-      (xml) => serializeFootnotes(parseFootnotes(xml).getNormalFootnotes()),
-      originalZip,
-      newZip,
-      compressionLevel,
-    );
+    if (findNotePartEntry(originalZip, "word/footnotes.xml")) {
+      await patchNotePartIntoZip(
+        "word/footnotes.xml",
+        serializeFootnotes(footnotes),
+        (xml) => serializeFootnotes(parseFootnotes(xml).getNormalFootnotes()),
+        originalZip,
+        newZip,
+        compressionLevel,
+      );
+    } else {
+      await materializeNewNotePart({
+        contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml",
+        newZip,
+        partPath: "word/footnotes.xml",
+        relationshipType: RELATIONSHIP_TYPES.footnotes,
+        serializedPart: serializeNewFootnotesPart(footnotes),
+        compressionLevel,
+      });
+    }
   }
   const endnotes = doc.package.endnotes ?? [];
   if (endnotes.length > 0) {
-    await patchNotePartIntoZip(
-      "word/endnotes.xml",
-      serializeEndnotes(endnotes),
-      (xml) => serializeEndnotes(parseEndnotes(xml).getNormalEndnotes()),
-      originalZip,
-      newZip,
-      compressionLevel,
+    if (findNotePartEntry(originalZip, "word/endnotes.xml")) {
+      await patchNotePartIntoZip(
+        "word/endnotes.xml",
+        serializeEndnotes(endnotes),
+        (xml) => serializeEndnotes(parseEndnotes(xml).getNormalEndnotes()),
+        originalZip,
+        newZip,
+        compressionLevel,
+      );
+    } else {
+      await materializeNewNotePart({
+        contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml",
+        newZip,
+        partPath: "word/endnotes.xml",
+        relationshipType: RELATIONSHIP_TYPES.endnotes,
+        serializedPart: serializeNewEndnotesPart(endnotes),
+        compressionLevel,
+      });
+    }
+  }
+}
+
+type MaterializeNewNotePartOptions = {
+  contentType: string;
+  newZip: JSZip;
+  partPath: "word/footnotes.xml" | "word/endnotes.xml";
+  relationshipType: string;
+  serializedPart: string;
+  compressionLevel: number;
+};
+
+async function materializeNewNotePart({
+  contentType,
+  newZip,
+  partPath,
+  relationshipType,
+  serializedPart,
+  compressionLevel,
+}: MaterializeNewNotePartOptions): Promise<void> {
+  const contentTypesFile = findNotePartEntry(newZip, "[content_types].xml");
+  const relationshipsFile = findNotePartEntry(newZip, "word/_rels/document.xml.rels");
+  if (!contentTypesFile || !relationshipsFile) {
+    throw new DocxPackageFidelityError(
+      `Cannot create ${partPath}: the DOCX package is missing content types or document relationships`,
     );
   }
+
+  const compressionOptions = { level: compressionLevel };
+  const contentTypesXml = await contentTypesFile.async("text");
+  const partName = `/${partPath}`;
+  if (!contentTypesXml.toLowerCase().includes(partName.toLowerCase())) {
+    newZip.file(
+      contentTypesFile.name,
+      contentTypesXml.replace(
+        "</Types>",
+        () => `<Override PartName="${partName}" ContentType="${contentType}"/></Types>`,
+      ),
+      { compression: "DEFLATE", compressionOptions },
+    );
+  }
+
+  const relationshipsXml = await relationshipsFile.async("text");
+  if (!relationshipsXml.includes(relationshipType)) {
+    const relationshipId = `rId${findMaxRId(relationshipsXml) + 1}`;
+    const target = partPath.slice("word/".length);
+    newZip.file(
+      relationshipsFile.name,
+      relationshipsXml.replace(
+        "</Relationships>",
+        () =>
+          `<Relationship Id="${relationshipId}" Type="${relationshipType}" Target="${target}"/></Relationships>`,
+      ),
+      { compression: "DEFLATE", compressionOptions },
+    );
+  }
+
+  newZip.file(partPath, serializedPart, {
+    compression: "DEFLATE",
+    compressionOptions,
+  });
 }
 
 /**

--- a/packages/core/src/docx/serializer/noteSerializer.ts
+++ b/packages/core/src/docx/serializer/noteSerializer.ts
@@ -89,6 +89,57 @@ function serializeNote(elementName: "footnote" | "endnote", note: Footnote | End
   return `<w:${elementName} ${attrs.join(" ")}>${body}</w:${elementName}>`;
 }
 
+const NOTE_SEPARATOR_BODY =
+  '<w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>';
+
+function serializeRequiredNoteSeparators(elementName: "footnote" | "endnote"): string {
+  return (
+    `<w:${elementName} w:type="separator" w:id="-1">${NOTE_SEPARATOR_BODY}` +
+    `<w:r><w:separator/></w:r></w:p></w:${elementName}>` +
+    `<w:${elementName} w:type="continuationSeparator" w:id="0">${NOTE_SEPARATOR_BODY}` +
+    `<w:r><w:continuationSeparator/></w:r></w:p></w:${elementName}>`
+  );
+}
+
+function insertNoteReferenceMark(xml: string, elementName: "footnote" | "endnote"): string {
+  const paragraphOpen = /<w:p(?=[\s>])[^>]*>/u.exec(xml);
+  if (!paragraphOpen) {
+    const referenceParagraph =
+      `<w:p><w:r><w:rPr><w:rStyle w:val="${elementName === "footnote" ? "FootnoteReference" : "EndnoteReference"}"/></w:rPr>` +
+      `<w:${elementName}Ref/></w:r></w:p>`;
+    return `${referenceParagraph}${xml}`;
+  }
+
+  const paragraphStart = paragraphOpen.index + paragraphOpen[0].length;
+  const paragraphEnd = xml.indexOf("</w:p>", paragraphStart);
+  const propertiesEnd = xml.indexOf("</w:pPr>", paragraphStart);
+  const insertAt =
+    propertiesEnd !== -1 && propertiesEnd < paragraphEnd
+      ? propertiesEnd + "</w:pPr>".length
+      : paragraphStart;
+  const referenceRun =
+    `<w:r><w:rPr><w:rStyle w:val="${elementName === "footnote" ? "FootnoteReference" : "EndnoteReference"}"/></w:rPr>` +
+    `<w:${elementName}Ref/></w:r>`;
+  return `${xml.slice(0, insertAt)}${referenceRun}${xml.slice(insertAt)}`;
+}
+
+function serializeNewNotePart(
+  elementName: "footnote" | "endnote",
+  notes: readonly (Footnote | Endnote)[],
+): string {
+  const nsDecl = buildNamespaceDeclarations();
+  const serializedNotes = notes
+    .map((note) => insertNoteReferenceMark(serializeNote(elementName, note), elementName))
+    .join("");
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n` +
+    `<w:${elementName}s ${nsDecl} mc:Ignorable="w14 w15 wp14">` +
+    serializeRequiredNoteSeparators(elementName) +
+    serializedNotes +
+    `</w:${elementName}s>`
+  );
+}
+
 /**
  * Serialize footnotes to a complete word/footnotes.xml string.
  *
@@ -111,4 +162,16 @@ export function serializeEndnotes(endnotes: readonly Endnote[]): string {
   const nsDecl = buildNamespaceDeclarations();
   const notes = endnotes.map((en) => serializeNote("endnote", en)).join("");
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:endnotes ${nsDecl} mc:Ignorable="w14 w15 wp14">${notes}</w:endnotes>`;
+}
+
+/** Serialize a brand-new footnote part, including Word's required separators
+ * and the automatic reference mark at the start of every normal note. */
+export function serializeNewFootnotesPart(footnotes: readonly Footnote[]): string {
+  return serializeNewNotePart("footnote", footnotes);
+}
+
+/** Serialize a brand-new endnote part, including Word's required separators
+ * and the automatic reference mark at the start of every normal note. */
+export function serializeNewEndnotesPart(endnotes: readonly Endnote[]): string {
+  return serializeNewNotePart("endnote", endnotes);
 }


### PR DESCRIPTION
## Summary

- create `footnotes.xml` and `endnotes.xml` when the document model adds notes to a package that had none
- add the required separator notes, automatic reference marks, content-type overrides, and document relationships
- preserve the existing byte-exact patch path when note parts already exist
- add a folio-core patch changeset

## Root cause

The full repack path only patched note parts found in the original archive. Documents created from a blank package could serialize note references in `document.xml`, but the corresponding note part and package declarations were never created.

## Validation

- `bun test packages/core/src/docx/noteSave.test.ts` (7 passed)
- focused `oxlint`
- `git diff --check`

Local typechecking was intentionally left to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DOCX creation when adding footnotes or endnotes to documents that previously had none.
  * Newly added notes now include the required package declarations, relationships, separators and reference markers.
  * Footnote and endnote content is preserved correctly when documents are saved and reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->