### PR TITLE
fix: align IME candidate window with caret

### DIFF
--- a/.changeset/quiet-waves-align.md
+++ b/.changeset/quiet-waves-align.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Anchor CJK IME candidate windows to the painted document caret.

--- a/packages/core/src/layout-bridge/dom/imeCaretAnchor.test.ts
+++ b/packages/core/src/layout-bridge/dom/imeCaretAnchor.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import { resetImeCaretAnchor, syncImeCaretAnchor } from "./imeCaretAnchor";
+
+type MockEditorViewOptions = {
+  focused?: boolean;
+  composing?: boolean;
+  empty?: boolean;
+  head?: number;
+  coords?: { left: number; top: number };
+  throws?: boolean;
+};
+
+const mockEditorView = ({
+  focused = true,
+  composing = false,
+  empty = true,
+  head = 5,
+  coords = { left: -9999, top: 0 },
+  throws = false,
+}: MockEditorViewOptions = {}) => ({
+  composing,
+  hasFocus: () => focused,
+  state: { selection: { empty, head } },
+  coordsAtPos: () => {
+    if (throws) {
+      throw new RangeError("Stale editor selection");
+    }
+    return coords;
+  },
+});
+
+const createHost = (transform = "") => ({ style: { transform } });
+
+describe("syncImeCaretAnchor", () => {
+  test("translates the hidden caret onto the painted caret", () => {
+    const host = createHost();
+
+    const anchored = syncImeCaretAnchor({
+      hiddenHost: host,
+      editorView: mockEditorView(),
+      visibleCaret: { left: 320, top: 240 },
+    });
+
+    expect(anchored).toBe(true);
+    expect(host.style.transform).toBe("translate3d(10319px, 240px, 0)");
+  });
+
+  test("measures from the untransformed baseline on repeated updates", () => {
+    const host = createHost("translate3d(10319px, 240px, 0)");
+    const editorView = mockEditorView();
+    editorView.coordsAtPos = () => {
+      expect(host.style.transform).toBe("");
+      return { left: -9999, top: 0 };
+    };
+
+    syncImeCaretAnchor({
+      hiddenHost: host,
+      editorView,
+      visibleCaret: { left: 321, top: 241 },
+    });
+
+    expect(host.style.transform).toBe("translate3d(10320px, 241px, 0)");
+  });
+
+  test("resets the anchor for range selections and unfocused editors", () => {
+    const host = createHost("translate3d(10px, 20px, 0)");
+
+    expect(
+      syncImeCaretAnchor({
+        hiddenHost: host,
+        editorView: mockEditorView({ empty: false }),
+        visibleCaret: { left: 10, top: 20 },
+      }),
+    ).toBe(false);
+    expect(host.style.transform).toBe("");
+
+    host.style.transform = "translate3d(10px, 20px, 0)";
+    expect(
+      syncImeCaretAnchor({
+        hiddenHost: host,
+        editorView: mockEditorView({ focused: false }),
+        visibleCaret: { left: 10, top: 20 },
+      }),
+    ).toBe(false);
+    expect(host.style.transform).toBe("");
+  });
+
+  test("preserves the anchor while composition is active", () => {
+    const host = createHost("translate3d(10px, 20px, 0)");
+
+    expect(
+      syncImeCaretAnchor({
+        hiddenHost: host,
+        editorView: mockEditorView({ composing: true }),
+        visibleCaret: null,
+      }),
+    ).toBe(false);
+    expect(host.style.transform).toBe("translate3d(10px, 20px, 0)");
+
+    resetImeCaretAnchor(host);
+    expect(host.style.transform).toBe("");
+  });
+
+  test("restores the previous anchor when native caret measurement fails", () => {
+    const host = createHost("translate3d(10px, 20px, 0)");
+
+    expect(
+      syncImeCaretAnchor({
+        hiddenHost: host,
+        editorView: mockEditorView({ throws: true }),
+        visibleCaret: { left: 320, top: 240 },
+      }),
+    ).toBe(false);
+    expect(host.style.transform).toBe("translate3d(10px, 20px, 0)");
+  });
+});

--- a/packages/core/src/layout-bridge/dom/imeCaretAnchor.ts
+++ b/packages/core/src/layout-bridge/dom/imeCaretAnchor.ts
@@ -1,0 +1,127 @@
+type ImeCaretHost = {
+  style: {
+    transform: string;
+  };
+};
+
+type ImeCaretEditorView = {
+  readonly composing: boolean;
+  readonly dom?: HTMLElement;
+  readonly state: {
+    readonly selection: {
+      readonly empty: boolean;
+      readonly head: number;
+    };
+  };
+  hasFocus: () => boolean;
+  coordsAtPos: (position: number) => { left: number; top: number };
+};
+
+type VisibleCaretViewportRect = {
+  left: number;
+  top: number;
+};
+
+type SyncImeCaretAnchorOptions = {
+  hiddenHost: ImeCaretHost | null | undefined;
+  editorView: ImeCaretEditorView | null | undefined;
+  visibleCaret: VisibleCaretViewportRect | null | undefined;
+};
+
+const resetHostTransform = (hiddenHost: ImeCaretHost | null | undefined): void => {
+  if (hiddenHost) {
+    hiddenHost.style.transform = "";
+  }
+};
+
+const getNativeSelectionCaret = (
+  editorView: ImeCaretEditorView,
+): { left: number; top: number } | null => {
+  const editorDom = editorView.dom;
+  const selection = editorDom?.ownerDocument.getSelection();
+  if (!editorDom || !selection || selection.rangeCount === 0) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!editorDom.contains(range.startContainer)) {
+    return null;
+  }
+
+  const rect = range.getBoundingClientRect();
+  if (
+    range.getClientRects().length === 0 ||
+    (rect.left === 0 && rect.top === 0 && rect.width === 0 && rect.height === 0)
+  ) {
+    return null;
+  }
+  return { left: rect.left, top: rect.top };
+};
+
+/**
+ * Align the real off-screen ProseMirror caret with the painted document caret.
+ *
+ * Native IME candidate windows follow the focused contenteditable selection,
+ * not folio's visual caret overlay. Translating the hidden input host preserves
+ * split rendering while anchoring CJK candidate UI at the visible insertion
+ * point.
+ */
+export const syncImeCaretAnchor = ({
+  hiddenHost,
+  editorView,
+  visibleCaret,
+}: SyncImeCaretAnchorOptions): boolean => {
+  if (!hiddenHost) {
+    return false;
+  }
+
+  if (!editorView) {
+    resetHostTransform(hiddenHost);
+    return false;
+  }
+
+  // Moving a live composition target can dismiss or corrupt the native IME.
+  // Keep the last valid anchor pinned until composition ends.
+  if (editorView.composing) {
+    return false;
+  }
+
+  if (!visibleCaret || !editorView.hasFocus() || !editorView.state.selection.empty) {
+    resetHostTransform(hiddenHost);
+    return false;
+  }
+
+  const previousTransform = hiddenHost.style.transform;
+  hiddenHost.style.transform = "";
+
+  let hiddenCaret: { left: number; top: number };
+  try {
+    // DOM selection geometry is the browser's actual native-UI anchor. Fall
+    // back to ProseMirror geometry when the selection is temporarily stale.
+    hiddenCaret =
+      getNativeSelectionCaret(editorView) ??
+      editorView.coordsAtPos(editorView.state.selection.head);
+  } catch {
+    hiddenHost.style.transform = previousTransform;
+    return false;
+  }
+
+  if (
+    !Number.isFinite(hiddenCaret.left) ||
+    !Number.isFinite(hiddenCaret.top) ||
+    !Number.isFinite(visibleCaret.left) ||
+    !Number.isFinite(visibleCaret.top)
+  ) {
+    resetHostTransform(hiddenHost);
+    return false;
+  }
+
+  const dx = Math.round(visibleCaret.left - hiddenCaret.left);
+  const dy = Math.round(visibleCaret.top - hiddenCaret.top);
+  hiddenHost.style.transform = `translate3d(${dx}px, ${dy}px, 0)`;
+  return true;
+};
+
+export const resetImeCaretAnchor = (hiddenHost: ImeCaretHost | null | undefined): void => {
+  resetHostTransform(hiddenHost);
+};

--- a/packages/react/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/react/src/components/HiddenHeaderFooterPMs.tsx
@@ -23,6 +23,7 @@ export type HfPartKind = HeaderFooterPartKind;
 export type HfPartKey = HeaderFooterPartKey;
 
 export type HiddenHeaderFooterPMsRef = {
+  getHostElement: () => HTMLElement | null;
   getView: (rId: string) => EditorView | null;
   listSlots: () => HfPartKey[];
 };
@@ -96,13 +97,14 @@ export const HiddenHeaderFooterPMs = memo(
     useImperativeHandle(
       ref,
       () => ({
+        getHostElement: () => hostRef.current,
         getView: (rId) => managerRef.current?.getView(rId) ?? null,
         listSlots: () => managerRef.current?.listSlots() ?? [],
       }),
       [],
     );
 
-    return <div ref={hostRef} style={HOST_STYLES} />;
+    return <div ref={hostRef} className="paged-editor__hidden-hf-pm" style={HOST_STYLES} />;
   }),
 );
 /* eslint-enable prefer-arrow-callback */

--- a/packages/react/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/react/src/paged-editor/HiddenProseMirror.tsx
@@ -109,6 +109,8 @@ export type HiddenProseMirrorRef = {
   ensureView: () => void;
   /** Whether view creation has been requested. */
   isViewRequested: () => boolean;
+  /** Get the off-screen host element. */
+  getHostElement: () => HTMLElement | null;
   /** Get the ProseMirror EditorState */
   getState: () => EditorState | null;
   /** Get the ProseMirror EditorView */
@@ -405,7 +407,14 @@ export const HiddenProseMirror = forwardRef<HiddenProseMirrorRef, HiddenProseMir
     // Imperative Handle
     // ========================================================================
 
-    useImperativeHandle(ref, () => managerRef.current!.api, []);
+    useImperativeHandle(
+      ref,
+      () => ({
+        ...managerRef.current!.api,
+        getHostElement: () => hostRef.current,
+      }),
+      [],
+    );
 
     if (hasCollaboration && collaborationModulesError) {
       let detail = "unknown error";

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -69,6 +69,10 @@ import type {
 import { templatePreviewDirtyRange } from "@stll/folio-core/layout-bridge/convert/templatePreviewFlow";
 import { clickToPositionDom } from "@stll/folio-core/layout-bridge/dom/clickToPositionDom";
 import {
+  resetImeCaretAnchor,
+  syncImeCaretAnchor,
+} from "@stll/folio-core/layout-bridge/dom/imeCaretAnchor";
+import {
   findBodyEmptyRuns,
   findBodyPmAnchor,
   findBodyPmSpans,
@@ -677,10 +681,14 @@ type HfCaretSelection = {
 function HfCaretOverlay({
   selection,
   pagesContainer,
+  hiddenHost,
+  editorView,
   zoom,
 }: {
   selection: HfCaretSelection;
   pagesContainer: HTMLDivElement | null;
+  hiddenHost: HTMLElement | null;
+  editorView: EditorView | null;
   zoom: number;
 }) {
   const [caret, setCaret] = useState<{
@@ -724,6 +732,7 @@ function HfCaretOverlay({
         // (Codex #487 P2: 20:32 review).
         const hit = findHfCaretSpan(pageScope, selection.kind, selection.rId, selection.from);
         if (!hit) {
+          syncImeCaretAnchor({ hiddenHost, editorView, visibleCaret: null });
           setCaret(null);
           setRangeRects([]);
           return;
@@ -770,9 +779,15 @@ function HfCaretOverlay({
           y: (absY - cr.top) / zoomDivisor,
           height: absHeight / zoomDivisor,
         });
+        syncImeCaretAnchor({
+          hiddenHost,
+          editorView,
+          visibleCaret: { left: absX, top: absY },
+        });
         setRangeRects([]);
         return;
       }
+      syncImeCaretAnchor({ hiddenHost, editorView, visibleCaret: null });
       // Range selection — walk every painted pm span inside the slot
       // and project the union of those whose [pmStart,pmEnd] intersect
       // [from,to). The painter emits one span per run so this is good
@@ -832,9 +847,29 @@ function HfCaretOverlay({
     };
     recompute();
     const onPainted = () => recompute();
+    let animationFrame: number | null = null;
+    const scheduleRecompute = () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+      }
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = null;
+        recompute();
+      });
+    };
     pagesContainer.addEventListener(PAINTER_PAINTED_EVENT, onPainted);
+    hiddenHost?.addEventListener("focusin", recompute);
+    hiddenHost?.addEventListener("compositionend", scheduleRecompute);
+    window.addEventListener("scroll", scheduleRecompute, true);
     return () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+      }
       pagesContainer.removeEventListener(PAINTER_PAINTED_EVENT, onPainted);
+      hiddenHost?.removeEventListener("focusin", recompute);
+      hiddenHost?.removeEventListener("compositionend", scheduleRecompute);
+      window.removeEventListener("scroll", scheduleRecompute, true);
+      resetImeCaretAnchor(hiddenHost);
     };
     // Destructure selection so the effect only re-runs when a field
     // actually changes; otherwise every handleHfPmTransaction-driven
@@ -847,6 +882,8 @@ function HfCaretOverlay({
     selection.to,
     selection.pageNumber,
     pagesContainer,
+    hiddenHost,
+    editorView,
     zoom,
   ]);
 
@@ -2230,6 +2267,31 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       [],
     );
 
+    const refreshBodyImeCaretAnchor = useCallback(() => {
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+
+      const { selection } = view.state;
+      const domCaret = selection.empty ? getCaretFromDom(selection.head, zoom) : null;
+      const overlay = pagesContainerRef.current?.parentElement?.querySelector(
+        '[data-testid="selection-overlay"]',
+      );
+      const overlayRect = overlay?.getBoundingClientRect();
+      syncImeCaretAnchor({
+        hiddenHost: hiddenPMRef.current?.getHostElement(),
+        editorView: view,
+        visibleCaret:
+          domCaret && overlayRect
+            ? {
+                left: overlayRect.left + domCaret.x * zoom,
+                top: overlayRect.top + domCaret.y * zoom,
+              }
+            : null,
+      });
+    }, [getCaretFromDom, zoom]);
+
     /**
      * Update selection overlay from PM selection.
      */
@@ -2264,6 +2326,11 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         if (suppressSelectionOverlayRef.current) {
           setCaretPosition(null);
           setSelectionRects([]);
+          syncImeCaretAnchor({
+            hiddenHost: hiddenPMRef.current?.getHostElement(),
+            editorView: hiddenPMRef.current?.getView(),
+            visibleCaret: null,
+          });
           return;
         }
 
@@ -2306,6 +2373,11 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         }
 
         if (!layout || blocks.length === 0) {
+          syncImeCaretAnchor({
+            hiddenHost: hiddenPMRef.current?.getHostElement(),
+            editorView: hiddenPMRef.current?.getView(),
+            visibleCaret: null,
+          });
           return;
         }
 
@@ -2315,6 +2387,20 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           const domCaret = getCaretFromDom(from, zoom);
           if (domCaret) {
             setCaretPosition(domCaret);
+            const overlay = pagesContainerRef.current?.parentElement?.querySelector(
+              '[data-testid="selection-overlay"]',
+            );
+            const overlayRect = overlay?.getBoundingClientRect();
+            syncImeCaretAnchor({
+              hiddenHost: hiddenPMRef.current?.getHostElement(),
+              editorView: hiddenPMRef.current?.getView(),
+              visibleCaret: overlayRect
+                ? {
+                    left: overlayRect.left + domCaret.x * zoom,
+                    top: overlayRect.top + domCaret.y * zoom,
+                  }
+                : null,
+            });
           } else {
             // Fallback to layout-based calculation if DOM not ready
             const overlay = pagesContainerRef.current?.parentElement?.querySelector(
@@ -2334,29 +2420,58 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
 
                   const caret = getCaretPosition(layout, blocks, measures, from);
                   if (caret) {
-                    setCaretPosition({
+                    const fallbackCaret = {
                       ...caret,
                       x: caret.x + (pageRect.left - overlayRect.left) / zoom,
                       y: caret.y + (pageRect.top - overlayRect.top) / zoom,
+                    };
+                    setCaretPosition(fallbackCaret);
+                    syncImeCaretAnchor({
+                      hiddenHost: hiddenPMRef.current?.getHostElement(),
+                      editorView: hiddenPMRef.current?.getView(),
+                      visibleCaret: {
+                        left: overlayRect.left + fallbackCaret.x * zoom,
+                        top: overlayRect.top + fallbackCaret.y * zoom,
+                      },
                     });
                   } else {
                     setCaretPosition(null);
+                    syncImeCaretAnchor({
+                      hiddenHost: hiddenPMRef.current?.getHostElement(),
+                      editorView: hiddenPMRef.current?.getView(),
+                      visibleCaret: null,
+                    });
                   }
                   return undefined;
                 },
                 () => {
                   if (isCurrentRequest()) {
                     setCaretPosition(null);
+                    syncImeCaretAnchor({
+                      hiddenHost: hiddenPMRef.current?.getHostElement(),
+                      editorView: hiddenPMRef.current?.getView(),
+                      visibleCaret: null,
+                    });
                   }
                   return undefined;
                 },
               );
             } else {
               setCaretPosition(null);
+              syncImeCaretAnchor({
+                hiddenHost: hiddenPMRef.current?.getHostElement(),
+                editorView: hiddenPMRef.current?.getView(),
+                visibleCaret: null,
+              });
             }
           }
           setSelectionRects([]);
         } else {
+          syncImeCaretAnchor({
+            hiddenHost: hiddenPMRef.current?.getHostElement(),
+            editorView: hiddenPMRef.current?.getView(),
+            visibleCaret: null,
+          });
           // Range selection - show highlight rectangles using DOM-based approach
           const overlay = pagesContainerRef.current?.parentElement?.querySelector(
             '[data-testid="selection-overlay"]',
@@ -3401,8 +3516,12 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         ensureHiddenEditorView();
       }
       hiddenPMRef.current?.focus();
+      const view = hiddenPMRef.current?.getView();
+      if (view) {
+        updateSelectionOverlay(view.state);
+      }
       setIsFocused(true);
-    }, [ensureHiddenEditorView, readOnly]);
+    }, [ensureHiddenEditorView, readOnly, updateSelectionOverlay]);
 
     const startPointerTextSelection = useCallback(
       (clientX: number, clientY: number) => {
@@ -5364,6 +5483,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
 
             applyPendingHiddenEditorInput(view);
             view.focus();
+            refreshBodyImeCaretAnchor();
             setIsFocused(true);
           });
         };
@@ -5432,6 +5552,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         document,
         updateAutocompleteOverlay,
         readOnly,
+        refreshBodyImeCaretAnchor,
       ],
     );
 
@@ -5702,6 +5823,39 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
       return () => observer.disconnect();
     }, [updateSelectionOverlay]);
 
+    // Native IME UI follows the focused contenteditable in viewport space.
+    // Focus and scrolling can move that anchor without a PM transaction.
+    useEffect(() => {
+      const hiddenHost = hiddenPMRef.current?.getHostElement();
+      if (!hiddenHost) {
+        return;
+      }
+
+      let animationFrame: number | null = null;
+      const scheduleRefresh = () => {
+        if (animationFrame !== null) {
+          cancelAnimationFrame(animationFrame);
+        }
+        animationFrame = requestAnimationFrame(() => {
+          animationFrame = null;
+          refreshBodyImeCaretAnchor();
+        });
+      };
+      const refreshOnFocus = () => refreshBodyImeCaretAnchor();
+
+      hiddenHost.addEventListener("focusin", refreshOnFocus);
+      hiddenHost.addEventListener("compositionend", scheduleRefresh);
+      window.addEventListener("scroll", scheduleRefresh, true);
+      return () => {
+        if (animationFrame !== null) {
+          cancelAnimationFrame(animationFrame);
+        }
+        hiddenHost.removeEventListener("focusin", refreshOnFocus);
+        hiddenHost.removeEventListener("compositionend", scheduleRefresh);
+        window.removeEventListener("scroll", scheduleRefresh, true);
+      };
+    }, [refreshBodyImeCaretAnchor]);
+
     // =========================================================================
     // Imperative Handle
     // =========================================================================
@@ -5741,7 +5895,11 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           ensureHiddenEditorView(options);
         },
         focus() {
-          getActiveEditorStory().view?.focus();
+          const target = getActiveEditorStory();
+          target.view?.focus();
+          if (target.type === "body") {
+            refreshBodyImeCaretAnchor();
+          }
           setIsFocused(true);
         },
         blur() {
@@ -5848,6 +6006,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         ensureHiddenEditorView,
         folioEditor,
         getActiveEditorStory,
+        refreshBodyImeCaretAnchor,
         scrollToPageImpl,
         scrollToParaIdImpl,
         scrollToPositionImpl,
@@ -6080,6 +6239,8 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
               <HfCaretOverlay
                 selection={hfCaretSelection}
                 pagesContainer={pagesContainerRef.current}
+                hiddenHost={hfPMsRef.current?.getHostElement() ?? null}
+                editorView={hfPMsRef.current?.getView(hfCaretSelection.rId) ?? null}
                 zoom={zoom}
               />
             )}

--- a/packages/vue/src/components/DocxEditor.vue
+++ b/packages/vue/src/components/DocxEditor.vue
@@ -210,6 +210,8 @@
             />
 
             <HeaderFooterSelectionOverlay
+              :editor-view="getActiveHeaderFooterView()"
+              :hidden-container="hiddenHfPmRef"
               :pages-container="pagesRef"
               :selection="activeHeaderFooterSelection"
               :zoom="zoom"
@@ -849,6 +851,7 @@ const {
 
 const selectionSync = useSelectionSync({
   editorView,
+  hiddenContainer: hiddenPmRef,
   pagesRef,
   zoom,
   selectedImage,

--- a/packages/vue/src/components/HeaderFooterSelectionOverlay.vue
+++ b/packages/vue/src/components/HeaderFooterSelectionOverlay.vue
@@ -1,14 +1,21 @@
 <template></template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { onScopeDispose, watch } from "vue";
+import type { EditorView } from "prosemirror-view";
 
+import {
+  resetImeCaretAnchor,
+  syncImeCaretAnchor,
+} from "@stll/folio-core/layout-bridge/dom/imeCaretAnchor";
 import { PAINTER_PAINTED_EVENT } from "@stll/folio-core/layout-painter/renderPage";
 import { HeaderFooterSelectionOverlay } from "@stll/folio-core/render-dom/HeaderFooterSelectionOverlay";
 import type { HeaderFooterSelection } from "@stll/folio-core/render-dom/HeaderFooterSelectionOverlay";
 
 const props = defineProps<{
   pagesContainer: HTMLElement | null;
+  hiddenContainer: HTMLElement | null;
+  editorView: EditorView | null;
   selection: HeaderFooterSelection | null;
   zoom: number;
 }>();
@@ -17,6 +24,13 @@ const overlay = new HeaderFooterSelectionOverlay();
 const sync = (): void => {
   if (!props.pagesContainer) return;
   overlay.sync(props.pagesContainer, props.selection, props.zoom);
+  const paintedCaret = props.pagesContainer.querySelector<HTMLElement>("[data-testid='hf-caret']");
+  const caretRect = paintedCaret?.getBoundingClientRect();
+  syncImeCaretAnchor({
+    hiddenHost: props.hiddenContainer,
+    editorView: props.editorView,
+    visibleCaret: caretRect ? { left: caretRect.left, top: caretRect.top } : null,
+  });
 };
 
 watch(
@@ -40,8 +54,40 @@ watch(
     props.selection?.from,
     props.selection?.to,
     props.selection?.pageNumber,
+    props.hiddenContainer,
+    props.editorView,
     props.zoom,
   ],
   sync,
 );
+
+watch(
+  () => props.hiddenContainer,
+  (hiddenContainer, _previous, onCleanup) => {
+    if (!hiddenContainer) return;
+    hiddenContainer.addEventListener("focusin", sync);
+    hiddenContainer.addEventListener("compositionend", sync);
+    onCleanup(() => {
+      hiddenContainer.removeEventListener("focusin", sync);
+      hiddenContainer.removeEventListener("compositionend", sync);
+    });
+  },
+  { immediate: true },
+);
+
+let animationFrame: number | null = null;
+const scheduleSync = (): void => {
+  if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+  animationFrame = requestAnimationFrame(() => {
+    animationFrame = null;
+    sync();
+  });
+};
+const browserWindow = typeof window === "undefined" ? null : window;
+browserWindow?.addEventListener("scroll", scheduleSync, true);
+onScopeDispose(() => {
+  if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+  browserWindow?.removeEventListener("scroll", scheduleSync, true);
+  resetImeCaretAnchor(props.hiddenContainer);
+});
 </script>

--- a/packages/vue/src/composables/useSelectionSync.ts
+++ b/packages/vue/src/composables/useSelectionSync.ts
@@ -2,6 +2,11 @@ import { onScopeDispose, watch, type Ref, type ShallowRef } from "vue";
 import type { EditorView } from "prosemirror-view";
 
 import { BodySelectionOverlay } from "@stll/folio-core/render-dom/BodySelectionOverlay";
+import { getCaretPositionFromDom } from "@stll/folio-core/layout-bridge/dom/clickToPositionDom";
+import {
+  resetImeCaretAnchor,
+  syncImeCaretAnchor,
+} from "@stll/folio-core/layout-bridge/dom/imeCaretAnchor";
 import type { LayoutSelectionGate } from "@stll/folio-core/paged-layout/LayoutSelectionGate";
 
 import type { ImageSelectionInfo } from "../components/imageSelectionTypes";
@@ -9,6 +14,7 @@ import { Z_INDEX } from "../styles/zIndex";
 
 export type UseSelectionSyncOptions = {
   editorView: Ref<EditorView | null>;
+  hiddenContainer: Ref<HTMLElement | null>;
   pagesRef: Ref<HTMLElement | null>;
   zoom: Ref<number>;
   selectedImage: ShallowRef<ImageSelectionInfo | null>;
@@ -57,6 +63,23 @@ export const useSelectionSync = (opts: UseSelectionSyncOptions): UseSelectionSyn
         zoom: opts.zoom.value,
         zIndex: Z_INDEX.selectionOverlay,
       });
+
+      const { selection } = view.state;
+      const pagesRect = pagesContainer.getBoundingClientRect();
+      const caret = selection.empty
+        ? getCaretPositionFromDom(pagesContainer, selection.head, pagesRect)
+        : null;
+      syncImeCaretAnchor({
+        hiddenHost: opts.hiddenContainer.value,
+        editorView: view,
+        visibleCaret: caret
+          ? {
+              left: pagesRect.left + caret.x,
+              top: pagesRect.top + caret.y,
+            }
+          : null,
+      });
+
       if (result.type === "image") {
         const current = opts.selectedImage.value;
         const width = result.element.offsetWidth;
@@ -84,9 +107,28 @@ export const useSelectionSync = (opts: UseSelectionSyncOptions): UseSelectionSyn
 
   const unsubscribeRender = opts.syncCoordinator.onRender(updateSelectionOverlay);
   watch([opts.zoom, opts.editorView, opts.pagesRef], updateSelectionOverlay, { flush: "post" });
+  watch(
+    opts.hiddenContainer,
+    (hiddenContainer, _previous, onCleanup) => {
+      if (!hiddenContainer) {
+        return;
+      }
+      hiddenContainer.addEventListener("focusin", updateSelectionOverlay);
+      hiddenContainer.addEventListener("compositionend", updateSelectionOverlay);
+      onCleanup(() => {
+        hiddenContainer.removeEventListener("focusin", updateSelectionOverlay);
+        hiddenContainer.removeEventListener("compositionend", updateSelectionOverlay);
+      });
+    },
+    { immediate: true },
+  );
+  const browserWindow = typeof window === "undefined" ? null : window;
+  browserWindow?.addEventListener("scroll", updateSelectionOverlay, true);
   onScopeDispose(() => {
     unsubscribeRender();
     clearOverlay();
+    browserWindow?.removeEventListener("scroll", updateSelectionOverlay, true);
+    resetImeCaretAnchor(opts.hiddenContainer.value);
   });
 
   return { clearOverlay, updateSelectionOverlay };

--- a/tests/parity/ime-caret-anchor.spec.ts
+++ b/tests/parity/ime-caret-anchor.spec.ts
@@ -1,0 +1,118 @@
+import { ensureLiveView, expect, forEachAdapter, openEditor } from "./parity-fixture";
+
+forEachAdapter("CJK IME input caret follows the painted caret", async (adapter, { page }) => {
+  await openEditor(page, adapter);
+  await ensureLiveView(page);
+
+  const readAlignment = () =>
+    page.evaluate(() => {
+      const paintedCaret = document.querySelector<HTMLElement>("[data-folio-caret-rect]");
+      const selection = document.getSelection();
+      if (!paintedCaret || !selection || selection.rangeCount === 0) {
+        return { aligned: false, reason: "missing selection or painted caret" };
+      }
+
+      const range = selection.getRangeAt(0);
+      const hiddenHost = Array.from(
+        document.querySelectorAll<HTMLElement>(".paged-editor__hidden-pm"),
+      ).find((candidate) => candidate.contains(range.startContainer));
+      if (!hiddenHost) {
+        return { aligned: false, reason: "selection is outside the hidden editor" };
+      }
+
+      const nativeCaret = range.getBoundingClientRect();
+      const visibleCaret = paintedCaret.getBoundingClientRect();
+      const deltaX = Math.abs(nativeCaret.left - visibleCaret.left);
+      const deltaY = Math.abs(nativeCaret.top - visibleCaret.top);
+      return {
+        aligned:
+          deltaX <= 1 && deltaY <= 1 && hiddenHost.style.transform.startsWith("translate3d("),
+        deltaX,
+        deltaY,
+        transform: hiddenHost.style.transform,
+      };
+    });
+  const expectAligned = () => expect.poll(readAlignment).toMatchObject({ aligned: true });
+
+  await page.locator(".paged-editor__hidden-pm > .ProseMirror").first().focus();
+  await expectAligned();
+
+  const firstRun = page.locator(".layout-page-content span[data-pm-start][data-pm-end]").first();
+  await firstRun.click({ position: { x: 80, y: 8 } });
+  await expectAligned();
+
+  await firstRun.click({ position: { x: 120, y: 8 } });
+  await expectAligned();
+
+  await page.keyboard.press("End");
+  await page.keyboard.press("Enter");
+  await expectAligned();
+
+  const scrollContainer = page.locator(
+    adapter.name === "react" ? "[data-folio-scroll]" : ".docx-editor-vue__editor-scroll",
+  );
+  await scrollContainer.evaluate((element) => {
+    element.scrollTop += 120;
+  });
+  await expectAligned();
+});
+
+forEachAdapter(
+  "CJK IME input caret follows the painted header caret",
+  async (adapter, { page }) => {
+    await openEditor(page, adapter);
+
+    const header = page.locator(".layout-page-header").first();
+    await header.dblclick();
+    await expect(page.locator(".hf-inline-editor")).toBeVisible();
+    await page
+      .locator(".layout-page-header span[data-pm-start][data-pm-end]")
+      .first()
+      .click({ position: { x: 20, y: 8 } });
+
+    const readAlignment = () =>
+      page.evaluate(() => {
+        const paintedCaret = document.querySelector<HTMLElement>("[data-testid='hf-caret']");
+        const selection = document.getSelection();
+        if (!paintedCaret || !selection || selection.rangeCount === 0) {
+          return {
+            aligned: false,
+            reason: "missing selection or painted caret",
+            hasPaintedCaret: Boolean(paintedCaret),
+            hasSelection: Boolean(selection?.rangeCount),
+          };
+        }
+
+        const range = selection.getRangeAt(0);
+        const hiddenHost = Array.from(
+          document.querySelectorAll<HTMLElement>(".paged-editor__hidden-hf-pm"),
+        ).find((candidate) => candidate.contains(range.startContainer));
+        if (!hiddenHost) {
+          return { aligned: false, reason: "selection is outside the hidden header editor" };
+        }
+
+        const nativeCaret = range.getBoundingClientRect();
+        const visibleCaret = paintedCaret.getBoundingClientRect();
+        const deltaX = Math.abs(nativeCaret.left - visibleCaret.left);
+        const deltaY = Math.abs(nativeCaret.top - visibleCaret.top);
+        return {
+          aligned:
+            deltaX <= 1 && deltaY <= 1 && hiddenHost.style.transform.startsWith("translate3d("),
+          deltaX,
+          deltaY,
+          transform: hiddenHost.style.transform,
+        };
+      });
+    const expectAligned = () => expect.poll(readAlignment).toMatchObject({ aligned: true });
+
+    await expectAligned();
+
+    const scrollContainer = page.locator(
+      adapter.name === "react" ? "[data-folio-scroll]" : ".docx-editor-vue__editor-scroll",
+    );
+    await scrollContainer.evaluate((element) => {
+      element.scrollTop += 120;
+    });
+    await expectAligned();
+  },
+);

--- a/tests/parity/ime-caret-anchor.spec.ts
+++ b/tests/parity/ime-caret-anchor.spec.ts
@@ -1,4 +1,36 @@
+import type { Locator, Page } from "@playwright/test";
+
 import { ensureLiveView, expect, forEachAdapter, openEditor } from "./parity-fixture";
+
+type CompositionAnchorOptions = {
+  expectAligned: () => Promise<void>;
+  hiddenHost: Locator;
+  input: Locator;
+  page: Page;
+};
+
+const COMPOSITION_ANCHOR_SENTINEL = "translate3d(1px, 2px, 0px)";
+
+const verifyCompositionAnchorLifecycle = async ({
+  expectAligned,
+  hiddenHost,
+  input,
+  page,
+}: CompositionAnchorOptions): Promise<void> => {
+  await input.dispatchEvent("compositionstart");
+  await hiddenHost.evaluate((host, transform) => {
+    host.style.transform = transform;
+  }, COMPOSITION_ANCHOR_SENTINEL);
+  await page.evaluate(() => window.dispatchEvent(new Event("scroll")));
+  await expect
+    .poll(() => hiddenHost.evaluate((host) => host.style.transform))
+    .toBe(COMPOSITION_ANCHOR_SENTINEL);
+
+  await input.dispatchEvent("compositionend");
+  await page.waitForTimeout(50);
+  await page.evaluate(() => window.dispatchEvent(new Event("scroll")));
+  await expectAligned();
+};
 
 forEachAdapter("CJK IME input caret follows the painted caret", async (adapter, { page }) => {
   await openEditor(page, adapter);
@@ -48,6 +80,13 @@ forEachAdapter("CJK IME input caret follows the painted caret", async (adapter, 
   await page.keyboard.press("Enter");
   await expectAligned();
 
+  await verifyCompositionAnchorLifecycle({
+    expectAligned,
+    hiddenHost: page.locator(".paged-editor__hidden-pm").first(),
+    input: page.locator(".paged-editor__hidden-pm > .ProseMirror").first(),
+    page,
+  });
+
   const scrollContainer = page.locator(
     adapter.name === "react" ? "[data-folio-scroll]" : ".docx-editor-vue__editor-scroll",
   );
@@ -61,6 +100,7 @@ forEachAdapter(
   "CJK IME input caret follows the painted header caret",
   async (adapter, { page }) => {
     await openEditor(page, adapter);
+    await ensureLiveView(page);
 
     const header = page.locator(".layout-page-header").first();
     await header.dblclick();
@@ -106,6 +146,13 @@ forEachAdapter(
     const expectAligned = () => expect.poll(readAlignment).toMatchObject({ aligned: true });
 
     await expectAligned();
+
+    await verifyCompositionAnchorLifecycle({
+      expectAligned,
+      hiddenHost: page.locator(".paged-editor__hidden-hf-pm"),
+      input: page.locator(".paged-editor__hidden-hf-pm .ProseMirror").first(),
+      page,
+    });
 
     const scrollContainer = page.locator(
       adapter.name === "react" ? "[data-folio-scroll]" : ".docx-editor-vue__editor-scroll",


### PR DESCRIPTION
## Summary

Align the focused hidden editor caret with the painted document caret so native IME candidate windows open at the visible insertion point.

Keep the anchor stable through focus, repeated selection updates, scrolling, empty paragraphs, and active composition, with matching body and header/footer behavior in React and Vue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CJK IME candidate-window positioning by aligning it with the visible caret in body and header/footer editing.
  * Maintained alignment during focus changes, composition, scrolling, layout updates, and selection changes.
  * Added editor host-element accessors for integration scenarios.

* **Bug Fixes**
  * Cleared or restored caret positioning reliably when selections, focus, measurements, or editing state become invalid.

* **Tests**
  * Added comprehensive cross-editor coverage for caret alignment, scrolling, composition, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->