### PR TITLE
fix: keep collapsed-space caret aligned

### DIFF
--- a/.changeset/tidy-caret-anchor.md
+++ b/.changeset/tidy-caret-anchor.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Keep the caret aligned with its text row after typing collapsible whitespace.

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
@@ -26,6 +26,22 @@ class FakeHTMLElement {
     return this.height;
   }
 
+  get nextElementSibling(): FakeHTMLElement | null {
+    if (!this.parent) {
+      return null;
+    }
+    const index = this.parent.children.indexOf(this);
+    return this.parent.children.at(index + 1) ?? null;
+  }
+
+  get previousElementSibling(): FakeHTMLElement | null {
+    if (!this.parent) {
+      return null;
+    }
+    const index = this.parent.children.indexOf(this);
+    return index > 0 ? (this.parent.children.at(index - 1) ?? null) : null;
+  }
+
   get ownerDocument(): { createRange: () => Range } {
     return fakeDocument;
   }
@@ -58,6 +74,16 @@ class FakeHTMLElement {
     return rect(this.rect);
   }
 
+  getAttribute(name: string): string | null {
+    if (name === "data-collapsed-leading-spaces") {
+      return this.dataset["collapsedLeadingSpaces"] ?? null;
+    }
+    if (name === "data-collapsed-trailing-spaces") {
+      return this.dataset["collapsedTrailingSpaces"] ?? null;
+    }
+    return null;
+  }
+
   private collect(selector: string, out: FakeHTMLElement[]): void {
     for (const child of this.children) {
       if (child.matches(selector)) {
@@ -83,12 +109,13 @@ class FakeHTMLElement {
 
 const textNode = { nodeType: 3, length: 5 };
 let rangeHeight = 18;
+let rangeTop = 20;
 const fakeDocument = {
   createRange: () =>
     ({
       setStart: () => undefined,
       setEnd: () => undefined,
-      getBoundingClientRect: () => rect({ left: 12, top: 20, height: rangeHeight }),
+      getBoundingClientRect: () => rect({ left: 12, top: rangeTop, height: rangeHeight }),
     }) as Range,
 };
 
@@ -124,10 +151,51 @@ const buildContainer = (): HTMLElement => {
   return container as unknown as HTMLElement;
 };
 
+const buildCollapsedTrailingSpaceContainer = (): HTMLElement => {
+  const container = new FakeHTMLElement();
+  const page = new FakeHTMLElement(["layout-page"]);
+  page.dataset["pageNumber"] = "1";
+  const content = new FakeHTMLElement(["layout-page-content"]);
+  const line = new FakeHTMLElement(
+    ["layout-line"],
+    { left: 10, top: 15, width: 80, height: 80 },
+    80,
+  );
+  const visible = new FakeHTMLElement(
+    ["layout-run-text"],
+    { left: 10, top: 20, right: 30, bottom: 38, width: 20, height: 18 },
+    18,
+  );
+  visible.dataset["pmStart"] = "1";
+  visible.dataset["pmEnd"] = "6";
+  visible.firstChild = textNode;
+  const spaces = new FakeHTMLElement(["layout-run-text"], {
+    left: 30,
+    top: 70,
+    right: 30,
+    bottom: 70,
+    width: 0,
+    height: 0,
+  });
+  spaces.dataset["pmStart"] = "6";
+  spaces.dataset["pmEnd"] = "8";
+  spaces.dataset["collapsedTrailingSpaces"] = "true";
+  spaces.firstChild = { nodeType: 3, length: 2 };
+
+  container.append(page);
+  page.append(content);
+  content.append(line);
+  line.append(visible, spaces);
+
+  return container as unknown as HTMLElement;
+};
+
 let originalHTMLElement: unknown;
 let originalNode: unknown;
 
 beforeEach(() => {
+  rangeHeight = 18;
+  rangeTop = 20;
   originalHTMLElement = globalThis.HTMLElement;
   originalNode = globalThis.Node;
   Object.assign(globalThis, {
@@ -158,5 +226,12 @@ describe("getCaretPositionFromDom caret height", () => {
     const caret = getCaretPositionFromDom(buildContainer(), 3, rect({}));
 
     expect(caret?.height).toBe(80);
+  });
+
+  test("anchors collapsed trailing-space carets to the visible run", () => {
+    rangeTop = 70;
+    const caret = getCaretPositionFromDom(buildCollapsedTrailingSpaceContainer(), 7, rect({}));
+
+    expect(caret).toEqual({ x: 30, y: 20, height: 18, pageIndex: 0 });
   });
 });

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
@@ -499,6 +499,8 @@ export type DomCaretPosition = {
 export type CollapsedLineEdgeCaretGeometry = {
   left: number;
   top: number;
+  /** Viewport height of the visual anchor. Full-line caret painters retain
+   * their own line-height policy instead of using this glyph-box height. */
   height: number;
 };
 

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
@@ -496,6 +496,51 @@ export type DomCaretPosition = {
   pageIndex: number;
 };
 
+export type CollapsedLineEdgeCaretGeometry = {
+  left: number;
+  top: number;
+  height: number;
+};
+
+/**
+ * Resolve viewport geometry for a line-edge space span that the painter keeps
+ * addressable but collapses to zero font size. Browser ranges inside those
+ * spans report their zero-height baseline as `top`, which makes a caret appear
+ * below the line until visible text is typed. Anchor the caret to the nearest
+ * painted sibling instead; an all-whitespace line falls back to its line box.
+ */
+export function getCollapsedLineEdgeCaretGeometry(
+  spanEl: HTMLElement,
+): CollapsedLineEdgeCaretGeometry | null {
+  const isLeading = spanEl.dataset["collapsedLeadingSpaces"] === "true";
+  const isTrailing = spanEl.dataset["collapsedTrailingSpaces"] === "true";
+  if (!isLeading && !isTrailing) {
+    return null;
+  }
+
+  let sibling: Element | null = isTrailing
+    ? spanEl.previousElementSibling
+    : spanEl.nextElementSibling;
+  while (
+    sibling &&
+    (sibling.getAttribute("data-collapsed-leading-spaces") === "true" ||
+      sibling.getAttribute("data-collapsed-trailing-spaces") === "true")
+  ) {
+    sibling = isTrailing ? sibling.previousElementSibling : sibling.nextElementSibling;
+  }
+
+  const spanRect = spanEl.getBoundingClientRect();
+  const line = closestHtmlElement(spanEl, ".layout-line");
+  const anchorRect = sibling?.getBoundingClientRect() ?? line?.getBoundingClientRect() ?? spanRect;
+  const lineRect = line?.getBoundingClientRect();
+
+  return {
+    left: spanRect.left,
+    top: anchorRect.top,
+    height: anchorRect.height || lineRect?.height || 16,
+  };
+}
+
 export function getCaretPositionFromDom(
   container: HTMLElement,
   pmPos: number,
@@ -536,6 +581,18 @@ export function getCaretPositionFromDom(
 
     // For text runs, use inclusive range
     if (pmPos >= pmStart && pmPos <= pmEnd) {
+      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(spanEl);
+      if (collapsedGeometry) {
+        const pageEl = closestHtmlElement(spanEl, ".layout-page");
+        const pageIndex = pageEl ? Number(pageEl.dataset["pageNumber"] || 1) - 1 : 0;
+        return {
+          x: collapsedGeometry.left - overlayRect.left,
+          y: collapsedGeometry.top - overlayRect.top,
+          height: collapsedGeometry.height,
+          pageIndex,
+        };
+      }
+
       const textNode = spanEl.firstChild;
       if (!textNode || textNode.nodeType !== Node.TEXT_NODE) {
         // No text - use span bounds

--- a/packages/core/src/layout-bridge/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/headerFooterLayout.ts
@@ -13,6 +13,8 @@
 
 import type { EditorView } from "prosemirror-view";
 
+import { getCollapsedLineEdgeCaretGeometry } from "./dom/clickToPositionDom";
+
 // ============================================================================
 // HF DOM snapshot cache — shared by the caret + selection-rect computations
 // ============================================================================
@@ -123,6 +125,15 @@ export function computeHfCaretRectFromView(
     const end = Number(span.dataset["pmEnd"]);
     if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
     if (pmPos >= start && pmPos <= end) {
+      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(span);
+      if (collapsedGeometry) {
+        return {
+          top: collapsedGeometry.top,
+          left: collapsedGeometry.left,
+          height: collapsedGeometry.height,
+        };
+      }
+
       const range = host.ownerDocument.createRange();
       const walker = host.ownerDocument.createTreeWalker(span, NodeFilter.SHOW_TEXT);
       let remaining = pmPos - start;

--- a/packages/core/src/render-dom/RenderedDomContext.ts
+++ b/packages/core/src/render-dom/RenderedDomContext.ts
@@ -5,6 +5,7 @@
  */
 
 import { findBodyEmptyRuns, findBodyPmSpans } from "../layout-bridge/dom/findBodyPmSpans";
+import { getCollapsedLineEdgeCaretGeometry } from "../layout-bridge/dom/clickToPositionDom";
 import { closestHtmlElement } from "../utils/domGuards";
 
 export type RenderedDomPoint = {
@@ -75,6 +76,15 @@ export class RenderedDomContextImpl implements RenderedDomContext {
         return {
           x: (spanRect.left - containerRect.left) / this.#zoom,
           y: (spanRect.top - containerRect.top) / this.#zoom,
+          height: lineHeightFor(span, this.#zoom),
+        };
+      }
+
+      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(span);
+      if (collapsedGeometry) {
+        return {
+          x: (collapsedGeometry.left - containerRect.left) / this.#zoom,
+          y: (collapsedGeometry.top - containerRect.top) / this.#zoom,
           height: lineHeightFor(span, this.#zoom),
         };
       }

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -67,7 +67,10 @@ import type {
   HeaderFooterMetrics,
 } from "@stll/folio-core/layout-bridge/convert/headerFooterLayout";
 import { templatePreviewDirtyRange } from "@stll/folio-core/layout-bridge/convert/templatePreviewFlow";
-import { clickToPositionDom } from "@stll/folio-core/layout-bridge/dom/clickToPositionDom";
+import {
+  clickToPositionDom,
+  getCollapsedLineEdgeCaretGeometry,
+} from "@stll/folio-core/layout-bridge/dom/clickToPositionDom";
 import {
   resetImeCaretAnchor,
   syncImeCaretAnchor,
@@ -2206,6 +2209,16 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
             pmPos <= pmEnd &&
             spanEl.firstChild?.nodeType === Node.TEXT_NODE
           ) {
+            const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(spanEl);
+            if (collapsedGeometry) {
+              return {
+                x: (collapsedGeometry.left - overlayRect.left) / currentZoom,
+                y: (collapsedGeometry.top - overlayRect.top) / currentZoom,
+                height: getLineHeight(spanEl),
+                pageIndex: getPageIndex(spanEl),
+              };
+            }
+
             const textNode = spanEl.firstChild as Text;
             const charIndex = Math.min(pmPos - pmStart, textNode.length);
 

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -117,11 +117,15 @@ test.describe("typing + undo", () => {
     if (!runBox) throw new Error("no painted text run");
 
     await page.mouse.click(runBox.x + runBox.width - 1, runBox.y + runBox.height / 2);
+    const caret = page.getByTestId("caret");
+    await expect(caret).toBeVisible();
+    const caretBeforeSpace = await caret.boundingBox();
+    if (!caretBeforeSpace) throw new Error("no painted caret before typing");
+
     await page.keyboard.press("Space");
 
     const collapsedRuns = line.locator('[data-collapsed-trailing-spaces="true"]');
     await expect.poll(() => collapsedRuns.count()).toBeGreaterThan(0);
-    const caret = page.getByTestId("caret");
     await expect(caret).toBeVisible();
 
     await expect
@@ -131,7 +135,10 @@ test.describe("typing + undo", () => {
           visibleRun.boundingBox(),
         ]);
         if (!(caretBox && currentRunBox)) return Number.POSITIVE_INFINITY;
-        return Math.abs(caretBox.y - currentRunBox.y);
+        return Math.max(
+          Math.abs(caretBox.y - currentRunBox.y),
+          Math.abs(caretBox.height - caretBeforeSpace.height),
+        );
       })
       .toBeLessThan(1);
   });

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -103,6 +103,39 @@ async function openTableCellMenu(page: Page): Promise<Locator> {
 }
 
 test.describe("typing + undo", () => {
+  test("typing a collapsed trailing space keeps the caret on the text row", async ({ page }) => {
+    await mountFixture(page, "sample.docx");
+
+    const paragraph = page.locator(".layout-paragraph").first();
+    const line = paragraph.locator(".layout-line").last();
+    const visibleRun = line
+      .locator(
+        'span[data-pm-start][data-pm-end]:not([data-collapsed-leading-spaces="true"]):not([data-collapsed-trailing-spaces="true"])',
+      )
+      .last();
+    const runBox = await visibleRun.boundingBox();
+    if (!runBox) throw new Error("no painted text run");
+
+    await page.mouse.click(runBox.x + runBox.width - 1, runBox.y + runBox.height / 2);
+    await page.keyboard.press("Space");
+
+    const collapsedRuns = line.locator('[data-collapsed-trailing-spaces="true"]');
+    await expect.poll(() => collapsedRuns.count()).toBeGreaterThan(0);
+    const caret = page.getByTestId("caret");
+    await expect(caret).toBeVisible();
+
+    await expect
+      .poll(async () => {
+        const [caretBox, currentRunBox] = await Promise.all([
+          caret.boundingBox(),
+          visibleRun.boundingBox(),
+        ]);
+        if (!(caretBox && currentRunBox)) return Number.POSITIVE_INFINITY;
+        return Math.abs(caretBox.y - currentRunBox.y);
+      })
+      .toBeLessThan(1);
+  });
+
   test("a rapid burst types as a group, and one undo reverts the whole burst", async ({ page }) => {
     await mountFixture(page, "sample.docx");
 


### PR DESCRIPTION
Anchor caret geometry for collapsed line-edge whitespace to the nearest visible run, with a line-box fallback. Apply the shared invariant across body, framework-neutral, and header/footer projections; cover it with unit and browser interaction regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret positioning when typing or clicking within collapsed leading or trailing spaces.
  * Carets now remain aligned with the correct text row and use the visible line height.

* **Tests**
  * Added coverage for collapsed whitespace at line edges.
  * Added an interaction regression test for trailing collapsed spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->