### PR TITLE
fix: keep collapsed-space carets on the text row

### DIFF
--- a/.changeset/clear-replaced-run-background.md
+++ b/.changeset/clear-replaced-run-background.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Clear inherited highlight and shading across AI-replaced text while preserving suggestion rejection.

--- a/.changeset/fix-nested-list-counter-reentry.md
+++ b/.changeset/fix-nested-list-counter-reentry.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+---
+
+Restart a nested list counter after returning to its parent level, and never
+paint a non-finite counter value into a document marker.

--- a/.changeset/fix-shared-caret-boundary.md
+++ b/.changeset/fix-shared-caret-boundary.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Prefer collapsed line-edge spans when adjacent runs share a caret boundary.

--- a/.changeset/fix-shared-caret-boundary.md
+++ b/.changeset/fix-shared-caret-boundary.md
@@ -3,4 +3,5 @@
 "@stll/folio-react": patch
 ---
 
-Prefer collapsed line-edge spans when adjacent runs share a caret boundary.
+Prefer collapsed line-edge spans when adjacent runs share a caret boundary, and
+advance the caret by the measured width of each collapsed trailing space.

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -158,8 +158,17 @@ type ApplyInlineFormattingOptions = {
   schema: Schema;
   from: number;
   to: number;
-  formatting: Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"];
+  formatting: InlineFormattingPatch;
 };
+
+const REPLACEMENT_BACKGROUND_CLEAR_FORMATTING = {
+  highlight: false,
+  runShading: false,
+} as const;
+
+type InlineFormattingPatch =
+  | Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"]
+  | typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING;
 
 const applyInlineFormatting = ({
   tr,
@@ -188,7 +197,7 @@ const applyInlineFormatting = ({
 
 const formattingWouldChange = (
   marks: readonly Mark[],
-  formatting: Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"],
+  formatting: InlineFormattingPatch,
 ): boolean =>
   Object.entries(formatting).some(([name, enabled]) => {
     const mark = marks.find((candidate) => candidate.type.name === name);
@@ -210,6 +219,61 @@ type ApplyTrackedInlineFormattingOptions = ApplyInlineFormattingOptions & {
   initials?: string | undefined;
   /** Non-null stamps the produced `runPropertyChange` mark as a suggestion. */
   suggestionId?: string | null;
+};
+
+type ClearReplacementBackgroundOptions = {
+  tr: Transaction;
+  schema: Schema;
+  from: number;
+  to: number;
+  mode: FolioAIEditApplyMode;
+  revisionId: number;
+  author: string;
+  date: string;
+  initials?: string | undefined;
+  suggestionId?: string | null;
+};
+
+const clearReplacementBackground = ({
+  tr,
+  schema,
+  from,
+  to,
+  mode,
+  revisionId,
+  author,
+  date,
+  initials,
+  suggestionId = null,
+}: ClearReplacementBackgroundOptions): Transaction => {
+  const hasBackground = [schema.marks["highlight"], schema.marks["runShading"]].some(
+    (markType) => markType !== undefined && tr.doc.rangeHasMark(from, to, markType),
+  );
+  if (!hasBackground) {
+    return tr;
+  }
+  if (mode === "direct") {
+    return applyInlineFormatting({
+      tr,
+      schema,
+      from,
+      to,
+      formatting: REPLACEMENT_BACKGROUND_CLEAR_FORMATTING,
+    });
+  }
+  return applyTrackedInlineFormatting({
+    tr,
+    schema,
+    doc: tr.doc,
+    from,
+    to,
+    formatting: REPLACEMENT_BACKGROUND_CLEAR_FORMATTING,
+    revisionId,
+    author,
+    date,
+    initials,
+    suggestionId,
+  });
 };
 
 const applyTrackedInlineFormatting = ({
@@ -283,9 +347,10 @@ type LiveBlockEntry = { from: number; to: number; node: PMNode };
  */
 let revisionIdCursor = Date.now() * 1000;
 const nextRevisionSeed = (count: number): number => {
-  // Each replace allocates two ids per op; insert/delete one each.
+  // Each replacement allocates up to three ids: deletion, insertion, and
+  // background-format clearing. Insert/delete operations use one each.
   // Reserve `count * 4` to be safely above any conceivable per-op
-  // allocation (current max is 2). Returning the start of the
+  // allocation (current max is 3). Returning the start of the
   // reserved range as the seed is enough — the caller bumps it.
   const start = revisionIdCursor;
   revisionIdCursor += Math.max(count, 1) * 4;
@@ -732,6 +797,21 @@ const applyFolioAIEditOperationsInternal = ({
       case "replaceRange": {
         const revisionIdDelete = revisionSeed++;
         const revisionIdInsert = revisionSeed++;
+        const revisionIdBackground = revisionSeed++;
+        const stepsBeforeBackgroundClear = tr.steps.length;
+        tr = clearReplacementBackground({
+          tr,
+          schema: view.state.schema,
+          from: item.from,
+          to: item.to,
+          mode,
+          revisionId: revisionIdBackground,
+          author,
+          date,
+          initials,
+          suggestionId,
+        });
+        const clearedBackground = tr.steps.length > stepsBeforeBackgroundClear;
         tr = applyTextReplacement({
           tr,
           item,
@@ -745,7 +825,11 @@ const applyFolioAIEditOperationsInternal = ({
           initials,
         });
         if (producesTrackedChanges) {
-          appliedRevisionIds = [revisionIdDelete, revisionIdInsert];
+          appliedRevisionIds = [
+            revisionIdDelete,
+            revisionIdInsert,
+            ...(clearedBackground ? [revisionIdBackground] : []),
+          ];
         }
         break;
       }
@@ -786,6 +870,7 @@ const applyFolioAIEditOperationsInternal = ({
       case "replaceBlock": {
         const revisionIdDelete = revisionSeed++;
         const revisionIdInsert = revisionSeed++;
+        const revisionIdBackground = revisionSeed++;
         // Default to preserving formatting (existing behaviour);
         // when explicitly disabled and we're in direct mode, swap
         // the whole block node for a fresh paragraph that drops
@@ -828,6 +913,20 @@ const applyFolioAIEditOperationsInternal = ({
           tr = tr.replaceWith(item.blockFrom, item.blockTo, node);
           break;
         }
+        const stepsBeforeBackgroundClear = tr.steps.length;
+        tr = clearReplacementBackground({
+          tr,
+          schema: view.state.schema,
+          from: item.from,
+          to: item.to,
+          mode,
+          revisionId: revisionIdBackground,
+          author,
+          date,
+          initials,
+          suggestionId,
+        });
+        const clearedBackground = tr.steps.length > stepsBeforeBackgroundClear;
         tr = applyTextReplacement({
           tr,
           item,
@@ -842,7 +941,11 @@ const applyFolioAIEditOperationsInternal = ({
         });
         tr = applyReplaceBlockStyleId({ item, tr });
         if (producesTrackedChanges) {
-          appliedRevisionIds = [revisionIdDelete, revisionIdInsert];
+          appliedRevisionIds = [
+            revisionIdDelete,
+            revisionIdInsert,
+            ...(clearedBackground ? [revisionIdBackground] : []),
+          ];
         }
         break;
       }

--- a/packages/core/src/ai-edits/suggestionMode.test.ts
+++ b/packages/core/src/ai-edits/suggestionMode.test.ts
@@ -40,6 +40,33 @@ const makeView = (text: string) => {
   return view;
 };
 
+const makeHighlightedView = (text: string, highlightedText: string) => {
+  const start = text.indexOf(highlightedText);
+  if (start === -1) {
+    throw new Error("expected highlighted text");
+  }
+  const highlight = schema.marks["highlight"]?.create({ color: "yellow" });
+  const runShading = schema.marks["runShading"]?.create({ rgb: "FFFF00" });
+  if (!highlight || !runShading) {
+    throw new Error("expected background marks");
+  }
+  const content = [
+    ...(start === 0 ? [] : [schema.text(text.slice(0, start))]),
+    schema.text(highlightedText, [highlight, runShading]),
+    ...(start + highlightedText.length === text.length
+      ? []
+      : [schema.text(text.slice(start + highlightedText.length))]),
+  ];
+  const doc = schema.node("doc", null, [schema.node("paragraph", {}, content)]);
+  const view = {
+    state: EditorState.create({ schema, doc }),
+    dispatch(transaction: Transaction) {
+      view.state = view.state.apply(transaction);
+    },
+  };
+  return view;
+};
+
 const marksInDoc = (state: EditorState): Mark[] => {
   const marks: Mark[] = [];
   state.doc.descendants((node) => {
@@ -326,6 +353,36 @@ describe("suggestion commands", () => {
     expect(xml).toContain("<w:ins");
     expect(xml).toContain("swift");
     expect(xml).toContain('w:author="Alice"');
+  });
+
+  test("replacement clears the whole highlighted value and rejection restores it", () => {
+    const applyAmountReplacement = () => {
+      const view = makeHighlightedView("Penalty 2000 CZK", "2000");
+      applySuggestedReplace(view, "2000", "3000");
+      return view;
+    };
+    const backgroundMarkNames = new Set(["highlight", "runShading"]);
+    const backgroundMarks = (view: ReturnType<typeof makeHighlightedView>) =>
+      marksInDoc(view.state).filter((mark) => backgroundMarkNames.has(mark.type.name));
+
+    const accepting = applyAmountReplacement();
+    expect(backgroundMarks(accepting)).toEqual([]);
+    expect(
+      acceptSuggestion("op-1", {
+        author: "Alice",
+        date: "2026-07-17T12:00:00.000Z",
+      })(accepting.state, accepting.dispatch),
+    ).toBe(true);
+    expect(backgroundMarks(accepting)).toEqual([]);
+
+    const rejecting = applyAmountReplacement();
+    expect(rejectSuggestion("op-1")(rejecting.state, rejecting.dispatch)).toBe(true);
+    expect(rejecting.state.doc.textContent).toBe("Penalty 2000 CZK");
+    expect(
+      backgroundMarks(rejecting)
+        .map((mark) => mark.type.name)
+        .toSorted(),
+    ).toEqual(["highlight", "runShading"]);
   });
 
   test("rejectSuggestion removes the proposed insertion text", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1920,6 +1920,30 @@ describe("toFlowBlocks list numbering", () => {
     expect(blocks.map((block) => block.attrs?.listMarker)).toEqual(["1.", "1.1.", "2.", "2.1."]);
   });
 
+  test("never emits a non-finite list marker", () => {
+    const nonFiniteCounters = [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+    const doc = schema.node(
+      "doc",
+      null,
+      nonFiniteCounters.map((listStartOverride, index) =>
+        schema.node(
+          "paragraph",
+          {
+            numPr: { numId: index + 10, ilvl: 0 },
+            listLevelStarts: [4],
+            listStartOverride,
+          },
+          [schema.text(`Item ${index + 1}`)],
+        ),
+      ),
+    );
+
+    const markers = toFlowBlocks(doc).map((block) => block.attrs?.listMarker);
+
+    expect(markers).toEqual(["4.", "4.", "4."]);
+    expect(markers.every((marker) => !/NaN|Infinity/.test(marker ?? ""))).toBe(true);
+  });
+
   test("uses authored starts when a nested list begins without parent paragraphs", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1905,6 +1905,21 @@ describe("toFlowBlocks list numbering", () => {
     expect(blocks.at(1)?.attrs?.listMarker).toBe("I.a)");
   });
 
+  test("restarts a child counter after returning to its parent level", () => {
+    const paragraph = (level: number, text: string) =>
+      schema.node("paragraph", { numPr: { numId: 3, ilvl: level } }, [schema.text(text)]);
+    const doc = schema.node("doc", null, [
+      paragraph(0, "First parent"),
+      paragraph(1, "First child"),
+      paragraph(0, "Second parent"),
+      paragraph(1, "Second child"),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    expect(blocks.map((block) => block.attrs?.listMarker)).toEqual(["1.", "1.1.", "2.", "2.1."]);
+  });
+
   test("uses authored starts when a nested list begins without parent paragraphs", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -363,11 +363,11 @@ function computeListMarker(
   if (level > 0) {
     const latestAbstractCounters =
       abstractNumId === undefined ? undefined : abstractCounters.get(abstractNumId);
-    if (counters.slice(0, level).every(Number.isNaN)) {
+    if (counters.slice(0, level).every((counter) => !Number.isFinite(counter))) {
       for (let i = 0; i < level; i += 1) {
         const latestCounter = latestAbstractCounters?.[i];
         counters[i] =
-          latestCounter !== undefined && !Number.isNaN(latestCounter)
+          latestCounter !== undefined && Number.isFinite(latestCounter)
             ? latestCounter
             : (pmAttrs.listLevelStarts?.[i] ?? 1);
       }
@@ -384,7 +384,7 @@ function computeListMarker(
   // Returning to a parent level clears every deeper counter. A later child at
   // a level seen earlier must therefore restart from its authored start; the
   // lifetime `seenNumIds` set cannot stand in for live counter state.
-  if (Number.isNaN(counters[level])) {
+  if (!Number.isFinite(counters[level])) {
     counters[level] = (pmAttrs.listLevelStarts?.[level] ?? 1) - 1;
   }
 
@@ -400,7 +400,8 @@ function computeListMarker(
   if (childAdvances > 0 && level + 1 < counters.length) {
     const childCounter = counters[level + 1];
     counters[level + 1] =
-      (childCounter === undefined || Number.isNaN(childCounter) ? 0 : childCounter) + childAdvances;
+      (childCounter === undefined || !Number.isFinite(childCounter) ? 0 : childCounter) +
+      childAdvances;
   }
   listCounters.set(numId, counters);
   if (abstractNumId !== undefined) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -207,7 +207,7 @@ function formatNumberedMarker(counters: number[], level: number): string {
   const parts: number[] = [];
   for (let i = 0; i <= level; i += 1) {
     const value = counters[i] ?? 0;
-    if (value <= 0) {
+    if (!Number.isFinite(value) || value <= 0) {
       break;
     }
     parts.push(value);
@@ -379,9 +379,13 @@ function computeListMarker(
     seenNumIds.add(seenKey);
     if (pmAttrs.listStartOverride != null) {
       counters[level] = pmAttrs.listStartOverride - 1;
-    } else if (Number.isNaN(counters[level])) {
-      counters[level] = (pmAttrs.listLevelStarts?.[level] ?? 1) - 1;
     }
+  }
+  // Returning to a parent level clears every deeper counter. A later child at
+  // a level seen earlier must therefore restart from its authored start; the
+  // lifetime `seenNumIds` set cannot stand in for live counter state.
+  if (Number.isNaN(counters[level])) {
+    counters[level] = (pmAttrs.listLevelStarts?.[level] ?? 1) - 1;
   }
 
   counters[level] = (counters[level] ?? 0) + 1;

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
@@ -190,6 +190,45 @@ const buildCollapsedTrailingSpaceContainer = (): HTMLElement => {
   return container as unknown as HTMLElement;
 };
 
+const buildCollapsedLeadingSpaceContainer = (): HTMLElement => {
+  const container = new FakeHTMLElement();
+  const page = new FakeHTMLElement(["layout-page"]);
+  page.dataset["pageNumber"] = "1";
+  const content = new FakeHTMLElement(["layout-page-content"]);
+  const line = new FakeHTMLElement(
+    ["layout-line"],
+    { left: 10, top: 15, width: 80, height: 80 },
+    80,
+  );
+  const spaces = new FakeHTMLElement(["layout-run-text"], {
+    left: 10,
+    top: 70,
+    right: 10,
+    bottom: 70,
+    width: 0,
+    height: 0,
+  });
+  spaces.dataset["pmStart"] = "1";
+  spaces.dataset["pmEnd"] = "3";
+  spaces.dataset["collapsedLeadingSpaces"] = "true";
+  spaces.firstChild = { nodeType: 3, length: 2 };
+  const visible = new FakeHTMLElement(
+    ["layout-run-text"],
+    { left: 10, top: 20, right: 30, bottom: 38, width: 20, height: 18 },
+    18,
+  );
+  visible.dataset["pmStart"] = "3";
+  visible.dataset["pmEnd"] = "8";
+  visible.firstChild = textNode;
+
+  container.append(page);
+  page.append(content);
+  content.append(line);
+  line.append(spaces, visible);
+
+  return container as unknown as HTMLElement;
+};
+
 let originalHTMLElement: unknown;
 let originalNode: unknown;
 
@@ -233,5 +272,19 @@ describe("getCaretPositionFromDom caret height", () => {
     const caret = getCaretPositionFromDom(buildCollapsedTrailingSpaceContainer(), 7, rect({}));
 
     expect(caret).toEqual({ x: 30, y: 20, height: 18, pageIndex: 0 });
+  });
+
+  test("prefers collapsed trailing-space geometry at the shared run boundary", () => {
+    rangeTop = 70;
+    const caret = getCaretPositionFromDom(buildCollapsedTrailingSpaceContainer(), 6, rect({}));
+
+    expect(caret).toEqual({ x: 30, y: 20, height: 18, pageIndex: 0 });
+  });
+
+  test("keeps collapsed leading-space geometry at the shared run boundary", () => {
+    rangeTop = 70;
+    const caret = getCaretPositionFromDom(buildCollapsedLeadingSpaceContainer(), 3, rect({}));
+
+    expect(caret).toEqual({ x: 10, y: 20, height: 18, pageIndex: 0 });
   });
 });

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
@@ -180,6 +180,7 @@ const buildCollapsedTrailingSpaceContainer = (): HTMLElement => {
   spaces.dataset["pmStart"] = "6";
   spaces.dataset["pmEnd"] = "8";
   spaces.dataset["collapsedTrailingSpaces"] = "true";
+  spaces.dataset["collapsedSpaceAdvance"] = "4";
   spaces.firstChild = { nodeType: 3, length: 2 };
 
   container.append(page);
@@ -271,7 +272,7 @@ describe("getCaretPositionFromDom caret height", () => {
     rangeTop = 70;
     const caret = getCaretPositionFromDom(buildCollapsedTrailingSpaceContainer(), 7, rect({}));
 
-    expect(caret).toEqual({ x: 30, y: 20, height: 18, pageIndex: 0 });
+    expect(caret).toEqual({ x: 34, y: 20, height: 18, pageIndex: 0 });
   });
 
   test("prefers collapsed trailing-space geometry at the shared run boundary", () => {
@@ -279,6 +280,12 @@ describe("getCaretPositionFromDom caret height", () => {
     const caret = getCaretPositionFromDom(buildCollapsedTrailingSpaceContainer(), 6, rect({}));
 
     expect(caret).toEqual({ x: 30, y: 20, height: 18, pageIndex: 0 });
+  });
+
+  test("advances once for every collapsed trailing space", () => {
+    const caret = getCaretPositionFromDom(buildCollapsedTrailingSpaceContainer(), 8, rect({}));
+
+    expect(caret).toEqual({ x: 38, y: 20, height: 18, pageIndex: 0 });
   });
 
   test("keeps collapsed leading-space geometry at the shared run boundary", () => {

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
@@ -513,6 +513,7 @@ export type CollapsedLineEdgeCaretGeometry = {
  */
 export function getCollapsedLineEdgeCaretGeometry(
   spanEl: HTMLElement,
+  pmPos?: number,
 ): CollapsedLineEdgeCaretGeometry | null {
   const isLeading = spanEl.dataset["collapsedLeadingSpaces"] === "true";
   const isTrailing = spanEl.dataset["collapsedTrailingSpaces"] === "true";
@@ -535,9 +536,23 @@ export function getCollapsedLineEdgeCaretGeometry(
   const line = closestHtmlElement(spanEl, ".layout-line");
   const anchorRect = sibling?.getBoundingClientRect() ?? line?.getBoundingClientRect() ?? spanRect;
   const lineRect = line?.getBoundingClientRect();
+  const pmStart = Number(spanEl.dataset["pmStart"]);
+  const pmEnd = Number(spanEl.dataset["pmEnd"]);
+  const storedSpaceAdvance = Number(spanEl.dataset["collapsedSpaceAdvance"]);
+  const lineScale =
+    line && line.offsetWidth > 0 && lineRect ? lineRect.width / line.offsetWidth : 1;
+  const trailingSpaceCount =
+    isTrailing && pmPos !== undefined && Number.isFinite(pmStart) && Number.isFinite(pmEnd)
+      ? Math.max(0, Math.min(pmPos, pmEnd) - pmStart)
+      : 0;
+  const inlineDirection = spanRect.left <= anchorRect.left ? -1 : 1;
+  const trailingAdvance =
+    Number.isFinite(storedSpaceAdvance) && lineScale > 0
+      ? trailingSpaceCount * storedSpaceAdvance * lineScale * inlineDirection
+      : 0;
 
   return {
-    left: spanRect.left,
+    left: spanRect.left + trailingAdvance,
     top: anchorRect.top,
     height: anchorRect.height || lineRect?.height || 16,
   };
@@ -564,7 +579,7 @@ export function findCollapsedLineEdgeCaretTarget(
       continue;
     }
 
-    const geometry = getCollapsedLineEdgeCaretGeometry(span);
+    const geometry = getCollapsedLineEdgeCaretGeometry(span, pmPos);
     if (geometry) {
       return { span, geometry };
     }

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
@@ -543,6 +543,35 @@ export function getCollapsedLineEdgeCaretGeometry(
   };
 }
 
+export type CollapsedLineEdgeCaretTarget = {
+  span: HTMLElement;
+  geometry: CollapsedLineEdgeCaretGeometry;
+};
+
+/**
+ * Prefer a collapsed line-edge span when multiple painted spans share the PM
+ * position. Generic text runs use inclusive endpoints, so DOM order alone
+ * cannot decide which span owns a boundary.
+ */
+export function findCollapsedLineEdgeCaretTarget(
+  spans: readonly HTMLElement[],
+  pmPos: number,
+): CollapsedLineEdgeCaretTarget | null {
+  for (const span of spans) {
+    const pmStart = Number(span.dataset["pmStart"]);
+    const pmEnd = Number(span.dataset["pmEnd"]);
+    if (pmPos < pmStart || pmPos > pmEnd) {
+      continue;
+    }
+
+    const geometry = getCollapsedLineEdgeCaretGeometry(span);
+    if (geometry) {
+      return { span, geometry };
+    }
+  }
+  return null;
+}
+
 export function getCaretPositionFromDom(
   container: HTMLElement,
   pmPos: number,
@@ -555,6 +584,18 @@ export function getCaretPositionFromDom(
   // scope, body selections paint phantom rects on HF text and clicks in
   // body coords could resolve to HF positions.
   const spans = htmlQueryAll(container, ".layout-page-content span[data-pm-start][data-pm-end]");
+
+  const collapsedTarget = findCollapsedLineEdgeCaretTarget(spans, pmPos);
+  if (collapsedTarget) {
+    const pageEl = closestHtmlElement(collapsedTarget.span, ".layout-page");
+    const pageIndex = pageEl ? Number(pageEl.dataset["pageNumber"] || 1) - 1 : 0;
+    return {
+      x: collapsedTarget.geometry.left - overlayRect.left,
+      y: collapsedTarget.geometry.top - overlayRect.top,
+      height: collapsedTarget.geometry.height,
+      pageIndex,
+    };
+  }
 
   for (const spanEl of spans) {
     const pmStart = Number(spanEl.dataset["pmStart"]);
@@ -583,18 +624,6 @@ export function getCaretPositionFromDom(
 
     // For text runs, use inclusive range
     if (pmPos >= pmStart && pmPos <= pmEnd) {
-      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(spanEl);
-      if (collapsedGeometry) {
-        const pageEl = closestHtmlElement(spanEl, ".layout-page");
-        const pageIndex = pageEl ? Number(pageEl.dataset["pageNumber"] || 1) - 1 : 0;
-        return {
-          x: collapsedGeometry.left - overlayRect.left,
-          y: collapsedGeometry.top - overlayRect.top,
-          height: collapsedGeometry.height,
-          pageIndex,
-        };
-      }
-
       const textNode = spanEl.firstChild;
       if (!textNode || textNode.nodeType !== Node.TEXT_NODE) {
         // No text - use span bounds

--- a/packages/core/src/layout-bridge/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/headerFooterLayout.ts
@@ -125,7 +125,7 @@ export function computeHfCaretRectFromView(
     const end = Number(span.dataset["pmEnd"]);
     if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
     if (pmPos >= start && pmPos <= end) {
-      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(span);
+      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(span, pmPos);
       if (collapsedGeometry) {
         return {
           top: collapsedGeometry.top,

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -323,6 +323,7 @@ describe("renderLine box model", () => {
     expect(spaces?.dataset["pmStart"]).toBe("19");
     expect(spaces?.dataset["pmEnd"]).toBe("22");
     expect(spaces?.dataset["collapsedTrailingSpaces"]).toBe("true");
+    expect(Number(spaces?.dataset["collapsedSpaceAdvance"])).toBeGreaterThan(0);
     expect(spaces?.style["fontSize"]).toBe("0");
   });
 

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1816,6 +1816,11 @@ export function renderLine(
   } = splitCollapsibleLineEdgeSpaces(splitRuns, startsAfterSoftWrap(block, line));
   const isCollapsedLineEdgeSpaceRun = (run: TextRun): boolean =>
     collapsedLeadingSpaceRuns.has(run) || collapsedTrailingSpaceRuns.has(run);
+  const hasCollapsedLineEdgeSpaceRuns =
+    collapsedLeadingSpaceRuns.size > 0 || collapsedTrailingSpaceRuns.size > 0;
+  const collapsedSpaceMeasureText = hasCollapsedLineEdgeSpaceRuns
+    ? createTextMeasurer(doc)
+    : undefined;
   const renderLineTextRun = (run: TextRun): HTMLElement => {
     const runEl = renderTextRun(run, doc);
     if (collapsedLeadingSpaceRuns.has(run)) {
@@ -1825,6 +1830,15 @@ export function renderLine(
       runEl.dataset["collapsedTrailingSpaces"] = "true";
     }
     if (isCollapsedLineEdgeSpaceRun(run)) {
+      const spaceAdvance =
+        (collapsedSpaceMeasureText?.(
+          " ",
+          run.fontSize || 11,
+          run.fontFamily || "Calibri",
+          runMeasureStyle(run),
+        ) ?? 0) *
+        ((run.horizontalScale ?? 100) / 100);
+      runEl.dataset["collapsedSpaceAdvance"] = String(spaceAdvance);
       runEl.style.fontSize = "0";
       runEl.style.letterSpacing = "0";
       runEl.style.wordSpacing = "0";
@@ -2000,7 +2014,9 @@ export function renderLine(
       run.horizontalScale !== undefined &&
       run.horizontalScale !== 100,
   );
-  const measureText = hasTabRuns || hasScaledTextRun ? createTextMeasurer(doc) : undefined;
+  const measureText =
+    collapsedSpaceMeasureText ??
+    (hasTabRuns || hasScaledTextRun ? createTextMeasurer(doc) : undefined);
 
   if (hasTabRuns) {
     // Convert tab stops from layout engine format to tab calculator format

--- a/packages/core/src/render-dom/RenderedDomContext.ts
+++ b/packages/core/src/render-dom/RenderedDomContext.ts
@@ -5,7 +5,7 @@
  */
 
 import { findBodyEmptyRuns, findBodyPmSpans } from "../layout-bridge/dom/findBodyPmSpans";
-import { getCollapsedLineEdgeCaretGeometry } from "../layout-bridge/dom/clickToPositionDom";
+import { findCollapsedLineEdgeCaretTarget } from "../layout-bridge/dom/clickToPositionDom";
 import { closestHtmlElement } from "../utils/domGuards";
 
 export type RenderedDomPoint = {
@@ -61,7 +61,17 @@ export class RenderedDomContextImpl implements RenderedDomContext {
 
   getCoordinatesForPosition(pmPos: number): RenderedDomPoint | null {
     const containerRect = this.#pagesContainer.getBoundingClientRect();
-    for (const span of findBodyPmSpans(this.#pagesContainer)) {
+    const spans = findBodyPmSpans(this.#pagesContainer);
+    const collapsedTarget = findCollapsedLineEdgeCaretTarget(spans, pmPos);
+    if (collapsedTarget) {
+      return {
+        x: (collapsedTarget.geometry.left - containerRect.left) / this.#zoom,
+        y: (collapsedTarget.geometry.top - containerRect.top) / this.#zoom,
+        height: lineHeightFor(collapsedTarget.span, this.#zoom),
+      };
+    }
+
+    for (const span of spans) {
       const pmStart = Number(span.dataset["pmStart"]);
       const pmEnd = Number(span.dataset["pmEnd"]);
       const containsPosition = span.classList.contains("layout-run-tab")
@@ -76,15 +86,6 @@ export class RenderedDomContextImpl implements RenderedDomContext {
         return {
           x: (spanRect.left - containerRect.left) / this.#zoom,
           y: (spanRect.top - containerRect.top) / this.#zoom,
-          height: lineHeightFor(span, this.#zoom),
-        };
-      }
-
-      const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(span);
-      if (collapsedGeometry) {
-        return {
-          x: (collapsedGeometry.left - containerRect.left) / this.#zoom,
-          y: (collapsedGeometry.top - containerRect.top) / this.#zoom,
           height: lineHeightFor(span, this.#zoom),
         };
       }

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -69,7 +69,7 @@ import type {
 import { templatePreviewDirtyRange } from "@stll/folio-core/layout-bridge/convert/templatePreviewFlow";
 import {
   clickToPositionDom,
-  getCollapsedLineEdgeCaretGeometry,
+  findCollapsedLineEdgeCaretTarget,
 } from "@stll/folio-core/layout-bridge/dom/clickToPositionDom";
 import {
   resetImeCaretAnchor,
@@ -2174,6 +2174,16 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         // Find spans with PM position data
         const spans = findBodyPmSpans(pagesContainerRef.current);
 
+        const collapsedTarget = findCollapsedLineEdgeCaretTarget(spans, pmPos);
+        if (collapsedTarget) {
+          return {
+            x: (collapsedTarget.geometry.left - overlayRect.left) / currentZoom,
+            y: (collapsedTarget.geometry.top - overlayRect.top) / currentZoom,
+            height: getLineHeight(collapsedTarget.span),
+            pageIndex: getPageIndex(collapsedTarget.span),
+          };
+        }
+
         for (const spanEl of spans) {
           const pmStart = Number(spanEl.dataset["pmStart"]);
           const pmEnd = Number(spanEl.dataset["pmEnd"]);
@@ -2209,16 +2219,6 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
             pmPos <= pmEnd &&
             spanEl.firstChild?.nodeType === Node.TEXT_NODE
           ) {
-            const collapsedGeometry = getCollapsedLineEdgeCaretGeometry(spanEl);
-            if (collapsedGeometry) {
-              return {
-                x: (collapsedGeometry.left - overlayRect.left) / currentZoom,
-                y: (collapsedGeometry.top - overlayRect.top) / currentZoom,
-                height: getLineHeight(spanEl),
-                pageIndex: getPageIndex(spanEl),
-              };
-            }
-
             const textNode = spanEl.firstChild as Text;
             const charIndex = Math.min(pmPos - pmStart, textNode.length);
 

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -103,7 +103,7 @@ async function openTableCellMenu(page: Page): Promise<Locator> {
 }
 
 test.describe("typing + undo", () => {
-  test("typing a collapsed trailing space keeps the caret on the text row", async ({ page }) => {
+  test("a collapsed trailing space owns its shared caret boundary", async ({ page }) => {
     await mountFixture(page, "sample.docx");
 
     const paragraph = page.locator(".layout-paragraph").first();
@@ -126,6 +126,23 @@ test.describe("typing + undo", () => {
 
     const collapsedRuns = line.locator('[data-collapsed-trailing-spaces="true"]');
     await expect.poll(() => collapsedRuns.count()).toBeGreaterThan(0);
+    const sharedBoundary = await collapsedRuns.first().evaluate((run) => {
+      const pmStart = (run as HTMLElement).dataset["pmStart"];
+      if (pmStart === undefined) throw new Error("collapsed run has no PM start");
+      return Number(pmStart);
+    });
+    await page.evaluate((pmPos) => {
+      globalThis.__folioPlayground?.getEditorRef()?.getEditorRef()?.setSelection(pmPos);
+    }, sharedBoundary);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            globalThis.__folioPlayground?.getEditorRef()?.getEditorRef()?.getView()?.state.selection
+              .from ?? null,
+        ),
+      )
+      .toBe(sharedBoundary);
     await expect(caret).toBeVisible();
 
     await expect

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -144,6 +144,24 @@ test.describe("typing + undo", () => {
       )
       .toBe(sharedBoundary);
     await expect(caret).toBeVisible();
+    const caretAtSharedBoundary = await caret.boundingBox();
+    if (!caretAtSharedBoundary) throw new Error("no caret at shared boundary");
+
+    await page.evaluate((pmPos) => {
+      globalThis.__folioPlayground
+        ?.getEditorRef()
+        ?.getEditorRef()
+        ?.setSelection(pmPos + 1);
+    }, sharedBoundary);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            globalThis.__folioPlayground?.getEditorRef()?.getEditorRef()?.getView()?.state.selection
+              .from ?? null,
+        ),
+      )
+      .toBe(sharedBoundary + 1);
 
     await expect
       .poll(async () => {
@@ -158,6 +176,12 @@ test.describe("typing + undo", () => {
         );
       })
       .toBeLessThan(1);
+    await expect
+      .poll(async () => {
+        const caretBox = await caret.boundingBox();
+        return caretBox ? caretBox.x - caretAtSharedBoundary.x : 0;
+      })
+      .toBeGreaterThan(1);
   });
 
   test("a rapid burst types as a group, and one undo reverts the whole burst", async ({ page }) => {


### PR DESCRIPTION
Centralizes collapsed line-edge boundary selection so core, React, and rendered-DOM caret consumers resolve shared positions consistently. Adds unit coverage for leading and trailing boundaries plus a React interaction regression at the visible caret overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret positioning at boundaries between adjacent text runs, including leading and trailing spaces.
  * Ensured clicking and selecting at shared line edges uses the correct caret geometry.
  * Improved caret coordinate accuracy in paged editing views.
  * Fixed nested list numbering when returning to a parent list level.
  * Prevented invalid list counter values from being displayed.

* **Tests**
  * Added coverage for collapsed-space caret boundaries and list numbering.
  * Expanded interaction tests to verify selection behaviour after moving beyond shared boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->