### PR TITLE
chore(ci): opt into the shared label-sync workflow

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,29 @@
+name: Label Sync
+
+# Applies the org label manifest from stella/.github to this repository.
+# Manual only: labels should not drift under a push, and a run that writes
+# is a decision.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: What the run is allowed to do
+        type: choice
+        default: plan
+        options:
+          - plan
+          - apply
+          - apply-with-prune
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label-sync:
+    # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
+    # Do not switch to `secrets: inherit` — that widens the blast radius
+    # if the reusable ever starts touching named secrets.
+    uses: stella/.github/.github/workflows/label-sync.yml@76d4e3ab6e89ea897c177b026e6ef91c5c46ecc2
+    with:
+      mode: ${{ inputs.mode }}


### PR DESCRIPTION
Opts this repository into the org label manifest in `stella/.github`.

This repo currently carries only the GitHub default labels, so it is missing the org baseline entirely: no `size/*`, no `run-ci`, no `⚡ epic`, and the `enhancement` and `bug` colors and descriptions still differ from the org standard.

Manual dispatch only, defaulting to `plan`, which reports drift and writes nothing. The reusable workflow uses this repo's own `GITHUB_TOKEN` with `issues: write`; it holds no stored credential and cannot reach another repository.

This repo takes the baseline as-is, with no overlay, so none of the application-specific labels (`📬 outlook plugin`, `🧮 table`, `react-doctor: *`) come with it.

Expected `plan`, from a local dry run:

```
create=18 update=2 prune=1 keep=0 mode=plan
```

The single prune candidate is `documentation`, which is unused here and superseded by `docs` org-wide. Prune only runs under `apply-with-prune`, so it is a preview, not a scheduled deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered workflow for synchronising repository labels.
  * Supports planning changes, applying updates, or applying updates while removing obsolete labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->