### PR TITLE
chore(deps): quarantine freshly published dependency versions

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,10 @@
+[install]
+# 5-day quarantine: reject package versions published
+# less than 5 days ago to mitigate supply chain attacks.
+minimumReleaseAge = 432_000
+minimumReleaseAgeExcludes = [
+  "@stll/conditions",
+  "@stll/docx-utils",
+  "@stll/oxlint-config",
+  "@stll/template-conditions",
+]


### PR DESCRIPTION
`bunfig.toml` did not exist here, so installs had no release-age gate: a
version published minutes ago was installed without question. Every sibling
repository gates on a 5-day age, and this repository's own `update-deps` skill
documents the convention as if it were already in place.

The excluded packages are the four first-party ones this lockfile resolves from
the registry. They publish continuously, so the gate would block ordinary
upgrades; and a blocked `optionalDependency` is skipped silently rather than
failing the install, which surfaces as a runtime error instead of an install
error.

`bun install --frozen-lockfile` is unaffected: the gate applies when versions
are resolved, so the first effect will be on the next dependency update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated package management configuration to enforce a five-day minimum release age for dependencies, with specific exclusions for certain vendor packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->