### PR TITLE
perf(core): seed headless paraIds into the doc instead of one step per paragraph

### DIFF
--- a/.changeset/headless-paraid-seeding.md
+++ b/.changeset/headless-paraid-seeding.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Seed headless `paraId` attributes by rebuilding the document instead of applying one ProseMirror step per paragraph, removing two quadratics from `FolioDocxReviewer.fromBuffer` (-29% on a real DOCX corpus, -45% on the largest file). Also seeds RTL base direction explicitly, which previously rode on the paraId transaction and was skipped entirely for documents that already carried Word-authored paraIds.

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -19,6 +19,8 @@
  */
 
 import { TaggedError } from "better-result";
+import { Fragment } from "prosemirror-model";
+import type { Node as PMNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import type { Command } from "prosemirror-state";
 import type { Plugin } from "prosemirror-state";
@@ -47,11 +49,11 @@ import {
   headerFooterToProseDoc,
   toProseDoc,
 } from "../prosemirror/conversion/toProseDoc";
+import { ensureBaseDirectionInState } from "../prosemirror/extensions/features/AutoBidiDetectionExtension";
 import {
   getChangedParagraphIds,
   hasStructuralChanges,
   hasUntrackedChanges,
-  ignoreTrackedChanges,
 } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { schema, singletonManager } from "../prosemirror/schema";
 import type { Comment } from "../types/content";
@@ -131,44 +133,56 @@ type FolioDocumentOperationUndoEntry = {
  *
  * The shared `ParaIdAllocatorExtension` mints RANDOM ids (correct for freshly
  * typed paragraphs in the live editor); this load-time pass is deterministic so
- * a paraId-less corpus document anchors reproducibly. The transaction is marked
- * ignore-tracked so the change baseline stays clean.
+ * a paraId-less corpus document anchors reproducibly.
+ *
+ * Rebuilding only the changed branches, like {@link ensureParaIdsInDoc}, keeps
+ * the pass linear in paragraph count. Seeding through a transaction instead
+ * costs one `setNodeMarkup` step per paragraph, and both halves of that are
+ * quadratic: every step rebuilds the containing fragment, and the plugin
+ * `appendTransaction` chain rescans the accumulated step maps. Because the pass
+ * runs before the state exists, no history, mapping, or change-tracking
+ * semantics depend on it.
  */
-const ensureDeterministicParaIdsInState = (state: EditorState): EditorState => {
+const ensureDeterministicParaIdsInDoc = (doc: PMNode): PMNode => {
   const seen = new Set<string>();
-  const updates: { pos: number; attrs: Record<string, unknown> }[] = [];
   let ordinal = 0;
 
-  state.doc.descendants((node, pos) => {
-    if (node.type.name !== "paragraph") {
-      return undefined;
-    }
-    ordinal += 1;
-    const existing = node.attrs["paraId"];
-    if (typeof existing === "string" && existing.length > 0 && !seen.has(existing)) {
-      seen.add(existing);
-      return false;
-    }
-    let paraId = deterministicHexId(`${node.textContent}:${ordinal}`);
-    for (let salt = 1; seen.has(paraId); salt++) {
-      paraId = deterministicHexId(`${node.textContent}:${ordinal}:${salt}`);
-    }
-    seen.add(paraId);
-    updates.push({ pos, attrs: { ...node.attrs, paraId } });
-    return false;
-  });
+  const rewrite = (parent: PMNode): Fragment => {
+    let changed = false;
+    const children: PMNode[] = [];
 
-  if (updates.length === 0) {
-    return state;
-  }
+    parent.forEach((child) => {
+      let next = child;
+      if (child.type.name === "paragraph") {
+        ordinal += 1;
+        const existing = child.attrs["paraId"];
+        if (typeof existing === "string" && existing.length > 0 && !seen.has(existing)) {
+          seen.add(existing);
+        } else {
+          let paraId = deterministicHexId(`${child.textContent}:${ordinal}`);
+          for (let salt = 1; seen.has(paraId); salt++) {
+            paraId = deterministicHexId(`${child.textContent}:${ordinal}:${salt}`);
+          }
+          seen.add(paraId);
+          next = child.type.create({ ...child.attrs, paraId }, child.content, child.marks);
+        }
+      } else if (child.childCount > 0) {
+        const content = rewrite(child);
+        if (content !== child.content) {
+          next = child.copy(content);
+        }
+      }
+      if (next !== child) {
+        changed = true;
+      }
+      children.push(next);
+    });
 
-  const tr = state.tr;
-  for (const update of updates) {
-    tr.setNodeMarkup(update.pos, undefined, update.attrs);
-  }
-  ignoreTrackedChanges(tr);
-  tr.setMeta("addToHistory", false);
-  return state.apply(tr);
+    return changed ? Fragment.fromArray(children) : parent.content;
+  };
+
+  const content = rewrite(doc);
+  return content === doc.content ? doc : doc.copy(content);
 };
 
 /** Options for {@link FolioDocxReviewer.fromBuffer}. */
@@ -504,8 +518,17 @@ export class FolioDocxReviewer {
     // paraId-less document yields the SAME block ids on every parse: ops built
     // from one parse's snapshot then resolve against another parse of the same
     // bytes instead of skipping as stale anchors.
-    const state = ensureDeterministicParaIdsInState(
-      EditorState.create({ schema, doc: toProseDoc(baseDocument), plugins }),
+    //
+    // `ensureBaseDirectionInState` seeds `dir` on RTL paragraphs the same way
+    // the editor load path does. It used to run only as a side effect of the
+    // paraId transaction, so a document that already carried a complete set of
+    // Word-authored paraIds silently skipped bidi seeding.
+    const state = ensureBaseDirectionInState(
+      EditorState.create({
+        schema,
+        doc: ensureDeterministicParaIdsInDoc(toProseDoc(baseDocument)),
+        plugins,
+      }),
     );
     return new FolioDocxReviewer({
       baseDocument,
@@ -1113,13 +1136,14 @@ export class FolioDocxReviewer {
         theme: this.baseDocument.package.theme,
       }),
     };
-    const state = ensureDeterministicParaIdsInState(
+    const storyDoc =
+      story.type === "header" || story.type === "footer"
+        ? headerFooterToProseDoc(source.content, conversionOptions)
+        : footnoteToProseDoc(source.content, conversionOptions);
+    const state = ensureBaseDirectionInState(
       EditorState.create({
         schema,
-        doc:
-          story.type === "header" || story.type === "footer"
-            ? headerFooterToProseDoc(source.content, conversionOptions)
-            : footnoteToProseDoc(source.content, conversionOptions),
+        doc: ensureDeterministicParaIdsInDoc(storyDoc),
         plugins: singletonManager.getPlugins(),
       }),
     );


### PR DESCRIPTION
## Problem

`FolioDocxReviewer.fromBuffer` seeded deterministic `w14:paraId` attributes by applying one `setNodeMarkup` step per paragraph in a single transaction, after the `EditorState` already existed. Both halves of that are quadratic:

- every `ReplaceStep` rebuilds the containing fragment, so N steps cost O(N) each;
- `getTransactionDirtyRange` calls `transaction.mapping.slice(i + 1)` per step and maps through every following map, so the plugin `appendTransaction` chain is O(S²) in step count.

Word writes no `paraId` attributes, so every paragraph of a typical document needed one. This is the common case, not an edge case.

Splitting the phase on real Word-authored documents:

| paragraphs | scan | setNodeMarkup steps | state.apply | of which dirtyRange |
|---|---|---|---|---|
| 504 | 0.8 ms | 3.7 ms | 3.1 ms | 0.9 ms |
| 2008 | 2.8 ms | 28.6 ms | 49.6 ms | 21.9 ms |

4x the paragraphs, 24x the dirty-range time.

## Change

Seed the ids by rebuilding only the changed branches of the ProseMirror doc *before* the state is constructed, which keeps the pass linear in paragraph count. `ensureParaIdsInDoc` already solved this same problem for the editor load path ("avoids applying one ProseMirror transaction step per missing paragraph"); the headless path was the remaining instance.

Because the pass now runs before the state exists, no history, mapping, or change-tracking semantics depend on it, so the `ignoreTrackedChanges` / `addToHistory: false` bookkeeping goes away with the transaction.

### Bidi seeding was riding on that transaction

The paraId transaction was incidentally triggering RTL `dir` seeding through the auto-bidi `appendTransaction`. This calls `ensureBaseDirectionInState` explicitly instead, the same way `hiddenEditorManager` does.

That also fixes a latent bug: a document that already carried a complete set of Word-authored paraIds produced no transaction, and therefore skipped bidi seeding entirely.

## Results

Median of 7 runs, warmup 2, Bun 1.3.14, on real Word-authored DOCX (38K-149K):

| file | before | after |
|---|---|---|
| 38K | 23.3 ms | 20.2 ms |
| 58K | 42.1 ms | 37.9 ms |
| 116K | 149.6 ms | 104.4 ms |
| 149K | 184.1 ms | 101.6 ms |
| total | 581.6 ms | 412.3 ms |

-29% overall, -45% on the largest file, and the curve is now flat in document size rather than superlinear. No file regressed, so the explicit bidi scan costs less than run-to-run noise.

## Correctness

Compared before and after in-tree on all 8 documents: snapshot block ids, anchors, `getNotesAsText`, `getContentAsText` (plain and annotated), `getComments`, `getChanges`, and every written package part are byte-identical.

`toBuffer` zip bytes differ run-to-run on `main` as well (entry timestamps and `docProps/core.xml`), so the comparison is against unzipped parts.

`bun --filter @stll/folio-core test`: 4465 pass, 0 fail. Typecheck and oxlint clean.

## Not included

Three further items surfaced while profiling and are left for separate changes:

- **Parsed styles are re-parsed per document.** Worth a flat ~16 ms per `fromBuffer` regardless of document size, with a near-100% cache hit rate wherever documents share a style set. Needs the parsed styles proven read-only first, since they are handed to `toProseDoc` via `baseDocument.package.styles`.
- **`getTransactionDirtyRange` is still O(S²).** This change removes its trigger from the parse path, but it stays live in `PagedEditor.tsx` and `useDocxEditor.ts` for any many-step transaction (accept-all-changes, replace-all, batched operations). The fix is to accumulate forward instead of slicing per step, and it wants a property test asserting equivalence, because assoc handling at deletion boundaries can differ.
- **`document.xml` is parsed twice** when a caller runs `extractDocxText` and `fromBuffer` together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when reviewing documents with missing or duplicate paragraph identifiers.
  - Ensured right-to-left paragraph direction is correctly detected and applied during review.
  - Improved reviewer state initialisation across primary and secondary document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->