### PR TITLE
fix(docx): extract tables as markdown rows

### DIFF
--- a/.changeset/docx-extract-tables.md
+++ b/.changeset/docx-extract-tables.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Extract DOCX tables as markdown rows instead of a flat row-major paragraph list, so a cell stays associated with its column. `ExtractedDocxParagraph` gains an optional `tableRow` describing which table a row belongs to and whether it carries cells.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -137,6 +137,15 @@ export type DocxArchiveOptions = {
 export type DocxParagraphSource = "header" | "body" | "footer";
 
 // @public
+export type DocxTableRowKind = "cells" | "syntheticHeader" | "delimiter";
+
+// @public
+export type DocxTableRowPosition = {
+    table: number;
+    kind: DocxTableRowKind;
+};
+
+// @public
 export function docxToMarkdown(input: ArrayBuffer | Uint8Array, opts?: MarkdownOptions): Promise<string>;
 
 // @public
@@ -195,6 +204,7 @@ export type ExtractedDocxParagraph = {
     bold?: boolean;
     fontSize?: number;
     alignment?: "left" | "center" | "right" | "both";
+    tableRow?: DocxTableRowPosition;
 };
 
 // @public

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -84,6 +84,23 @@ const makeDocx = async ({
 
 const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
+const table = (rows: string, properties = "") => `<w:tbl>${properties}${rows}</w:tbl>`;
+const row = (cells: string, properties = "") => `<w:tr>${properties}${cells}</w:tr>`;
+const cell = (content: string, properties = "") =>
+  `<w:tc><w:tcPr>${properties}</w:tcPr>${content}</w:tc>`;
+
+/** `w:tblPr` as Word writes it on every table, header row or not. */
+const DEFAULT_TABLE_PROPERTIES = `<w:tblPr><w:tblLook w:firstColumn="1" w:firstRow="1" w:lastRow="0" w:val="04A0"/></w:tblPr>`;
+
+/** `w:trPr` for a row Word repeats at the top of each page: OOXML's header row. */
+const HEADER_ROW_PROPERTIES = `<w:trPr><w:tblHeader/></w:trPr>`;
+
+/**
+ * Cells in one rendered row. Escaped pipes are HTML entities, so every
+ * remaining `|` between the outer delimiters separates two columns.
+ */
+const columnCount = (line: string): number => line.slice(1, -1).split("|").length;
+
 describe("extractDocxText", () => {
   test("returns deterministic paragraphs across document parts", async () => {
     const bytes = await makeDocx({
@@ -113,12 +130,16 @@ describe("extractDocxText", () => {
       { index: 0, text: "Header 1", source: "header" },
       { index: 1, text: "Header 2", source: "header" },
       { index: 2, text: "Before", source: "body" },
-      { index: 3, text: "Cell", source: "body" },
-      { index: 4, text: "Control", source: "body" },
-      { index: 5, text: "After", source: "body" },
-      { index: 6, text: "Footer", source: "footer" },
+      { index: 3, text: "|  |", source: "body" },
+      { index: 4, text: "| --- |", source: "body" },
+      { index: 5, text: "| Cell |", source: "body" },
+      { index: 6, text: "Control", source: "body" },
+      { index: 7, text: "After", source: "body" },
+      { index: 8, text: "Footer", source: "footer" },
     ]);
-    expect(result.charCount).toBe("Header 1Header 2BeforeCellControlAfterFooter".length);
+    expect(result.charCount).toBe(
+      result.paragraphs.reduce((sum, { text }) => sum + text.length, 0),
+    );
     expect(result.view).toBe("accepted");
   });
 
@@ -197,6 +218,221 @@ describe("extractDocxText", () => {
 
     expect(result.paragraphs.at(0)?.text).toBe("Alternate");
     expect(result.paragraphs.at(0)?.style).toBe("Title");
+  });
+
+  test("emits table cells as markdown rows, not a flat row-major paragraph list", async () => {
+    // Shaped like an SEC cover page: a row of values over a row of labels.
+    // Flattened row-major, nothing ties an EIN to the column that names it.
+    const bytes = await makeDocx({
+      body: table(
+        row(cell(paragraph("Delaware")) + cell(paragraph("4911")) + cell(paragraph("83-4027615"))) +
+          row(
+            cell(paragraph("(State or Other Jurisdiction of Incorporation or Organization)")) +
+              cell(paragraph("(Primary Standard Industrial Classification Code Number)")) +
+              cell(paragraph("(I.R.S. Employer Identification Number)")),
+          ),
+        DEFAULT_TABLE_PROPERTIES,
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |  |",
+      "| --- | --- | --- |",
+      "| Delaware | 4911 | 83-4027615 |",
+      "| (State or Other Jurisdiction of Incorporation or Organization) | (Primary Standard Industrial Classification Code Number) | (I.R.S. Employer Identification Number) |",
+    ]);
+  });
+
+  test("marks table rows with their table and role, and leaves prose unmarked", async () => {
+    const oneByOne = table(row(cell(paragraph("x"))));
+    const bytes = await makeDocx({
+      body: paragraph("Prose") + oneByOne + oneByOne,
+      headers: { "word/header1.xml": oneByOne },
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text, tableRow }) => [text, tableRow])).toEqual([
+      ["|  |", { table: 0, kind: "syntheticHeader" }],
+      ["| --- |", { table: 0, kind: "delimiter" }],
+      ["| x |", { table: 0, kind: "cells" }],
+      ["Prose", undefined],
+      ["|  |", { table: 1, kind: "syntheticHeader" }],
+      ["| --- |", { table: 1, kind: "delimiter" }],
+      ["| x |", { table: 1, kind: "cells" }],
+      ["|  |", { table: 2, kind: "syntheticHeader" }],
+      ["| --- |", { table: 2, kind: "delimiter" }],
+      ["| x |", { table: 2, kind: "cells" }],
+    ]);
+  });
+
+  test("promotes the first row only where the document marks it as a header row", async () => {
+    const cells = cell(paragraph("H1")) + cell(paragraph("H2"));
+    const data = row(cell(paragraph("v1")) + cell(paragraph("v2")));
+
+    const declared = await extractDocxText(
+      await makeDocx({
+        body: table(row(cells, HEADER_ROW_PROPERTIES) + data, DEFAULT_TABLE_PROPERTIES),
+      }),
+    );
+    // `w:tblLook/@w:firstRow` is conditional formatting Word writes on every
+    // table, so on its own it must not turn a row of data into column names.
+    const undeclared = await extractDocxText(
+      await makeDocx({ body: table(row(cells) + data, DEFAULT_TABLE_PROPERTIES) }),
+    );
+
+    expect(declared.paragraphs.map(({ text }) => text)).toEqual([
+      "| H1 | H2 |",
+      "| --- | --- |",
+      "| v1 | v2 |",
+    ]);
+    expect(undeclared.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |",
+      "| --- | --- |",
+      "| H1 | H2 |",
+      "| v1 | v2 |",
+    ]);
+    expect(declared.paragraphs.at(0)?.tableRow).toEqual({ table: 0, kind: "cells" });
+    expect(undeclared.paragraphs.at(0)?.tableRow).toEqual({ table: 0, kind: "syntheticHeader" });
+  });
+
+  test("flattens a horizontally merged cell across the grid columns it spans", async () => {
+    const bytes = await makeDocx({
+      body: table(
+        row(cell(paragraph("Spans two"), `<w:gridSpan w:val="2"/>`) + cell(paragraph("C"))) +
+          row(cell(paragraph("a1")) + cell(paragraph("a2")) + cell(paragraph("a3"))),
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |  |",
+      "| --- | --- | --- |",
+      "| Spans two |  | C |",
+      "| a1 | a2 | a3 |",
+    ]);
+  });
+
+  test("renders a vertical-merge continuation as an empty column", async () => {
+    const bytes = await makeDocx({
+      body: table(
+        row(cell(paragraph("Merged down"), `<w:vMerge w:val="restart"/>`) + cell(paragraph("r1"))) +
+          // Word renders no content for a continuation cell. Content left here
+          // by a producer must not surface, and the anchor must not be repeated:
+          // either would invent a fact the document does not show.
+          row(cell(paragraph("Stale"), `<w:vMerge/>`) + cell(paragraph("r2"))),
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |",
+      "| --- | --- |",
+      "| Merged down | r1 |",
+      "|  | r2 |",
+    ]);
+  });
+
+  test("flattens a nested table into the cell that contains it", async () => {
+    const bytes = await makeDocx({
+      body: table(
+        row(
+          cell(paragraph("outer")) +
+            cell(
+              table(
+                row(cell(paragraph("in1")) + cell(paragraph("in2"))) +
+                  row(cell(paragraph("in3")) + cell(paragraph("in4"))),
+              ),
+            ),
+        ),
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |",
+      "| --- | --- |",
+      "| outer | in1 / in2<br>in3 / in4 |",
+    ]);
+  });
+
+  test("keeps a multi-paragraph cell on one row and escapes what would split it", async () => {
+    const bytes = await makeDocx({
+      body: table(
+        row(
+          cell(paragraph("first") + `<w:p/>` + paragraph("second")) +
+            cell("") +
+            cell(paragraph("pipe|inside")) +
+            cell(`<w:p><w:r><w:t>break</w:t><w:br/><w:t>after</w:t></w:r></w:p>`),
+        ),
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |  |  |",
+      "| --- | --- | --- | --- |",
+      "| first<br>second |  | pipe&#124;inside | break<br>after |",
+    ]);
+  });
+
+  test("gives every row of a table the same column count", async () => {
+    const bytes = await makeDocx({
+      body: table(
+        row(cell(paragraph("wide"), `<w:gridSpan w:val="3"/>`)) +
+          row(cell(paragraph("a")) + cell(paragraph("b"))) +
+          row(cell(paragraph("only"))) +
+          row(""),
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+    const counts = result.paragraphs.map(({ text }) => columnCount(text));
+
+    expect(new Set(counts)).toEqual(new Set([3]));
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |  |  |",
+      "| --- | --- | --- |",
+      "| wide |  |  |",
+      "| a | b |  |",
+      "| only |  |  |",
+      "|  |  |  |",
+    ]);
+  });
+
+  test("emits nothing for a table that has no cell at all", async () => {
+    const bytes = await makeDocx({
+      body: paragraph("Before") + table("") + table(row("")) + paragraph("After"),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual(["Before", "After"]);
+  });
+
+  test("counts every emitted paragraph's text, table rows included", async () => {
+    const bytes = await makeDocx({
+      body:
+        paragraph("Prose") +
+        table(
+          row(cell(paragraph("a")) + cell(paragraph("b")), HEADER_ROW_PROPERTIES),
+          DEFAULT_TABLE_PROPERTIES,
+        ),
+      headers: { "word/header1.xml": table(row(cell(paragraph("h")))) },
+      footers: { "word/footer1.xml": paragraph("Footer") },
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.charCount).toBe(
+      result.paragraphs.reduce((sum, { text }) => sum + text.length, 0),
+    );
   });
 
   test("returns an empty result when the main document part is absent", async () => {

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -1,5 +1,6 @@
 import type { DocxArchive } from "./boundedArchive";
 import { loadDocxArchive } from "./boundedArchive";
+import { escapeTableCell } from "../../markdown/escape";
 import { parseRelationships, RELATIONSHIP_TYPES } from "../relsParser";
 import {
   findAllDeep,
@@ -18,6 +19,24 @@ const DOCUMENT_RELS_PATH = "word/_rels/document.xml.rels";
 /** Document part containing an extracted paragraph. */
 export type DocxParagraphSource = "header" | "body" | "footer";
 
+/**
+ * Role of an emitted markdown table row.
+ *
+ * - `cells` — a `w:tr` rendered as a pipe row, including the first row when the
+ *   table declares it as its header.
+ * - `syntheticHeader` — the empty header row emitted for a table that declares
+ *   no header row; GFM has no headerless table.
+ * - `delimiter` — the `| --- |` line GFM requires under the header.
+ */
+export type DocxTableRowKind = "cells" | "syntheticHeader" | "delimiter";
+
+/** Table membership of a paragraph whose `text` is a markdown table row. */
+export type DocxTableRowPosition = {
+  /** 0-based index of the source `w:tbl`, in extraction order across all parts. */
+  table: number;
+  kind: DocxTableRowKind;
+};
+
 /** Paragraph text and lightweight formatting metadata from a DOCX archive. */
 export type ExtractedDocxParagraph = {
   index: number;
@@ -27,6 +46,13 @@ export type ExtractedDocxParagraph = {
   bold?: boolean;
   fontSize?: number;
   alignment?: "left" | "center" | "right" | "both";
+  /**
+   * Present only when `text` is a markdown table row rendered from a `w:tbl`,
+   * absent for ordinary prose paragraphs. Consumers that join `text` across
+   * paragraphs need no change; consumers that want to regroup a table's rows,
+   * or drop the rows GFM forced into existence, can key off this.
+   */
+  tableRow?: DocxTableRowPosition;
 };
 
 /** Accepted-revision paragraph text extracted in deterministic part order. */
@@ -138,29 +164,273 @@ const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
   return metrics;
 };
 
+// ---------------------------------------------------------------------------
+// Tables
+//
+// A `w:tbl` renders as GFM pipe rows, one extracted paragraph per row. Emitting
+// the cells as a flat row-major paragraph list — every value, then every label —
+// destroys the column-to-label association that downstream review and indexing
+// depend on.
+//
+// This is deliberately GFM-only, unlike `markdown/renderTable.ts`, which falls
+// back to an inline HTML `<table>` for merged or nested cells. That renderer
+// targets a markdown document, where a lossless `colspan`/`rowspan` grid is
+// worth the HTML; this one targets a flat paragraph list consumed as text, where
+// one line per row is the property that matters. Merges therefore flatten into
+// grid columns (see `readTableCell`) rather than switching output modes.
+// ---------------------------------------------------------------------------
+
+const TABLE_DELIMITER_CELL = "---";
+
+/** GFM cannot nest tables; an inner table joins its cells inside the outer cell. */
+const NESTED_TABLE_CELL_SEPARATOR = " / ";
+
+/** Word supports 63 table columns; cap well above that so a hostile `w:gridSpan` cannot balloon a row. */
+const MAX_TABLE_COLUMNS = 256;
+
+/** Bound the mutual recursion between a cell and the tables nested inside it. */
+const MAX_NESTED_TABLE_DEPTH = 8;
+
+/**
+ * Collect a table's `w:tr`, or a row's `w:tc`, seeing through the wrappers Word
+ * puts around them (`w:sdt` / `w:sdtContent` content controls, `w:customXml`).
+ * The walk stops at `w:tbl` and `w:p` so a nested table's rows and cells never
+ * leak into the grid of the table that contains them.
+ */
+const collectTableParts = (parent: XmlElement, localName: "tr" | "tc"): XmlElement[] => {
+  const parts: XmlElement[] = [];
+
+  const walk = (node: XmlElement) => {
+    for (const child of childElements(node)) {
+      const childName = getLocalName(child.name ?? "");
+      if (childName === localName) {
+        parts.push(child);
+        continue;
+      }
+      if (childName === "tbl" || childName === "p") {
+        continue;
+      }
+      walk(child);
+    }
+  };
+
+  walk(parent);
+  return parts;
+};
+
+/**
+ * Raw (unescaped) text of one cell: its paragraphs in order, one per line.
+ * Blank paragraphs are dropped so a cell padded with empty paragraphs does not
+ * render as a run of `<br>`. A nested table contributes one line per inner row.
+ */
+const readCellText = (cell: XmlElement, depth: number): string => {
+  const lines: string[] = [];
+
+  const walk = (node: XmlElement) => {
+    for (const child of childElements(node)) {
+      const childName = getLocalName(child.name ?? "");
+      if (childName === "p") {
+        const text = collectText(child);
+        if (text.length > 0) {
+          lines.push(text);
+        }
+        // `collectText` already descended for text, including any textbox
+        // inside the paragraph; descending again would duplicate the cell text.
+        continue;
+      }
+      if (childName === "tbl") {
+        if (depth >= MAX_NESTED_TABLE_DEPTH) {
+          continue;
+        }
+        for (const line of flattenNestedTable(child, depth + 1)) {
+          lines.push(line);
+        }
+        continue;
+      }
+      walk(child);
+    }
+  };
+
+  walk(cell);
+  return lines.join("\n");
+};
+
+const flattenNestedTable = (table: XmlElement, depth: number): string[] => {
+  const lines: string[] = [];
+
+  for (const row of collectTableParts(table, "tr")) {
+    const cells = collectTableParts(row, "tc").map((cell) => readCellText(cell, depth));
+    if (cells.some((text) => text.length > 0)) {
+      lines.push(cells.join(NESTED_TABLE_CELL_SEPARATOR));
+    }
+  }
+
+  return lines;
+};
+
+type ExtractedTableCell = {
+  /** Raw cell text; escaped only when it reaches a row line. */
+  text: string;
+  /** Grid columns the cell occupies (`w:gridSpan`), at least 1. */
+  gridSpan: number;
+};
+
+const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
+  const properties = findChild(cell, "w", "tcPr");
+
+  const gridSpanValue = getAttributeAnyPrefix(findChild(properties, "w", "gridSpan"), "val");
+  const parsedGridSpan = gridSpanValue === null ? 1 : Number.parseInt(gridSpanValue, 10);
+  const gridSpan = Number.isFinite(parsedGridSpan) && parsedGridSpan > 1 ? parsedGridSpan : 1;
+
+  // A `w:vMerge` without `w:val="restart"` continues the cell above it. Word
+  // renders no content of its own there, so emit an empty grid column: it holds
+  // the row's column alignment without repeating the anchor cell's value or
+  // surfacing content Word itself never shows.
+  const vMerge = findChild(properties, "w", "vMerge");
+  if (vMerge !== null && getAttributeAnyPrefix(vMerge, "val") !== "restart") {
+    return { text: "", gridSpan };
+  }
+
+  return { text: readCellText(cell, depth), gridSpan };
+};
+
+/**
+ * Does the row declare itself a header? `w:tblHeader` is the only OOXML signal
+ * that says so: it marks the row Word repeats at the top of each page. The
+ * neighbouring `w:tblLook/@w:firstRow` is conditional *formatting* that Word
+ * writes on essentially every table (its default `w:val="04A0"`), so keying off
+ * it would promote the first data row of almost every document.
+ *
+ * Without the flag the table is headerless and GFM gets a synthetic empty header
+ * row: a table's first row is data until the document says otherwise, and column
+ * names invented here would be read back as facts about the document.
+ */
+const declaresHeaderRow = (row: XmlElement): boolean => {
+  const header = findChild(findChild(row, "w", "trPr"), "w", "tblHeader");
+  if (header === null) {
+    return false;
+  }
+  const value = getAttributeAnyPrefix(header, "val");
+  return value !== "0" && value !== "false";
+};
+
+type TableGrid = {
+  /** Raw cell text per row, already expanded across the grid columns each cell spans. */
+  rows: string[][];
+  columnCount: number;
+  firstRowIsHeader: boolean;
+};
+
+const readTableGrid = (table: XmlElement): TableGrid => {
+  const rows: string[][] = [];
+  let columnCount = 0;
+  let firstRowIsHeader = false;
+
+  for (const [rowIndex, row] of collectTableParts(table, "tr").entries()) {
+    if (rowIndex === 0) {
+      firstRowIsHeader = declaresHeaderRow(row);
+    }
+    const columns: string[] = [];
+    for (const cell of collectTableParts(row, "tc")) {
+      if (columns.length >= MAX_TABLE_COLUMNS) {
+        break;
+      }
+      const { text, gridSpan } = readTableCell(cell, 0);
+      columns.push(text);
+      // A horizontally merged cell holds its text in the first column it spans;
+      // the rest stay empty so every row keeps the same column boundaries.
+      const padding = Math.min(gridSpan - 1, MAX_TABLE_COLUMNS - columns.length);
+      for (let index = 0; index < padding; index++) {
+        columns.push("");
+      }
+    }
+    if (columns.length > columnCount) {
+      columnCount = columns.length;
+    }
+    rows.push(columns);
+  }
+
+  return { rows, columnCount, firstRowIsHeader };
+};
+
+/** Pad a row to the table's column count and escape each cell into a pipe row. */
+const toRowLine = (columns: readonly string[], columnCount: number): string => {
+  const cells: string[] = [];
+  for (let column = 0; column < columnCount; column++) {
+    cells.push(escapeTableCell(columns[column] ?? ""));
+  }
+  return `| ${cells.join(" | ")} |`;
+};
+
+type RenderedTableRow = {
+  text: string;
+  position: DocxTableRowPosition;
+};
+
+/** Render a `w:tbl` as GFM rows. A table with no cell at all renders nothing. */
+const renderTableRows = (table: XmlElement, tableIndex: number): RenderedTableRow[] => {
+  const { rows, columnCount, firstRowIsHeader } = readTableGrid(table);
+  const [firstRow, ...remainingRows] = rows;
+  if (columnCount === 0 || firstRow === undefined) {
+    return [];
+  }
+
+  const rendered: RenderedTableRow[] = [];
+  const push = (text: string, kind: DocxTableRowKind) => {
+    rendered.push({ text, position: { table: tableIndex, kind } });
+  };
+
+  if (firstRowIsHeader) {
+    push(toRowLine(firstRow, columnCount), "cells");
+  } else {
+    push(toRowLine([], columnCount), "syntheticHeader");
+  }
+  push(
+    toRowLine(
+      Array.from({ length: columnCount }, () => TABLE_DELIMITER_CELL),
+      columnCount,
+    ),
+    "delimiter",
+  );
+  for (const row of firstRowIsHeader ? remainingRows : rows) {
+    push(toRowLine(row, columnCount), "cells");
+  }
+
+  return rendered;
+};
+
+// ---------------------------------------------------------------------------
+// Container walk
+// ---------------------------------------------------------------------------
+
 type ExtractContainerOptions = {
   container: XmlElement;
   source: DocxParagraphSource;
   startIndex: number;
+  startTableIndex: number;
 };
 
 type ExtractContainerResult = {
   paragraphs: ExtractedDocxParagraph[];
   charCount: number;
+  /** `w:tbl` elements rendered, so the next part continues the table numbering. */
+  tableCount: number;
 };
 
 const extractContainer = ({
   container,
   source,
   startIndex,
+  startTableIndex,
 }: ExtractContainerOptions): ExtractContainerResult => {
   const paragraphs: ExtractedDocxParagraph[] = [];
   let charCount = 0;
+  let tableCount = 0;
 
-  for (const [offset, paragraph] of findAllDeep(container, "w", "p").entries()) {
+  const pushProse = (paragraph: XmlElement) => {
     const text = collectText(paragraph);
     const entry: ExtractedDocxParagraph = {
-      index: startIndex + offset,
+      index: startIndex + paragraphs.length,
       text,
       source,
     };
@@ -187,9 +457,43 @@ const extractContainer = ({
 
     paragraphs.push(entry);
     charCount += text.length;
-  }
+  };
 
-  return { paragraphs, charCount };
+  const pushTableRow = ({ text, position }: RenderedTableRow) => {
+    paragraphs.push({
+      index: startIndex + paragraphs.length,
+      text,
+      source,
+      tableRow: position,
+    });
+    charCount += text.length;
+  };
+
+  /**
+   * Walk block content in document order. Descent mirrors the previous
+   * `findAllDeep(container, "w", "p")` — every wrapper (`w:sdt`, textboxes) is
+   * still entered — except that a `w:tbl` is consumed as a table instead of
+   * having its cell paragraphs emitted individually.
+   */
+  const walkBlocks = (node: XmlElement) => {
+    for (const child of childElements(node)) {
+      const childName = getLocalName(child.name ?? "");
+      if (childName === "tbl") {
+        for (const row of renderTableRows(child, startTableIndex + tableCount)) {
+          pushTableRow(row);
+        }
+        tableCount += 1;
+        continue;
+      }
+      if (childName === "p") {
+        pushProse(child);
+      }
+      walkBlocks(child);
+    }
+  };
+
+  walkBlocks(container);
+  return { paragraphs, charCount, tableCount };
 };
 
 type ExtractPartsOptions = {
@@ -197,6 +501,7 @@ type ExtractPartsOptions = {
   source: "header" | "footer";
   rootName: "hdr" | "ftr";
   startIndex: number;
+  startTableIndex: number;
   /** Part paths to read, in extraction order — see {@link resolveReferencedHeaderFooterParts}. */
   paths: readonly string[];
 };
@@ -206,10 +511,12 @@ const extractParts = async ({
   source,
   rootName,
   startIndex,
+  startTableIndex,
   paths,
 }: ExtractPartsOptions): Promise<ExtractContainerResult> => {
   const paragraphs: ExtractedDocxParagraph[] = [];
   let charCount = 0;
+  let tableCount = 0;
   let nextIndex = startIndex;
 
   for (const path of paths) {
@@ -227,13 +534,15 @@ const extractParts = async ({
       container,
       source,
       startIndex: nextIndex,
+      startTableIndex: startTableIndex + tableCount,
     });
     paragraphs.push(...result.paragraphs);
     charCount += result.charCount;
+    tableCount += result.tableCount;
     nextIndex += result.paragraphs.length;
   }
 
-  return { paragraphs, charCount };
+  return { paragraphs, charCount, tableCount };
 };
 
 /** A `word/_rels/document.xml.rels` `Target` is relative to `word/`; resolve it to a full archive-entry path. */
@@ -332,18 +641,21 @@ export const extractDocxText = async (
     source: "header",
     rootName: "hdr",
     startIndex: 0,
+    startTableIndex: 0,
     paths: referencedParts.headers,
   });
   const bodyResult = extractContainer({
     container: body,
     source: "body",
     startIndex: headers.paragraphs.length,
+    startTableIndex: headers.tableCount,
   });
   const footers = await extractParts({
     archive,
     source: "footer",
     rootName: "ftr",
     startIndex: headers.paragraphs.length + bodyResult.paragraphs.length,
+    startTableIndex: headers.tableCount + bodyResult.tableCount,
     paths: referencedParts.footers,
   });
 

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -174,6 +174,8 @@ export {
 export {
   extractDocxText,
   type DocxParagraphSource,
+  type DocxTableRowKind,
+  type DocxTableRowPosition,
   type ExtractedDocxParagraph,
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";


### PR DESCRIPTION
## Problem

`extractDocxText` walked paragraphs and had no handling for `w:tbl`, so table cells were emitted as a flat row-major paragraph list and the association between a value and its column label was lost. An SEC Form S-1 cover page came out as:

```
Delaware
4911
83-4027615
(State or Other Jurisdiction of Incorporation or Organization)
(Primary Standard Industrial Classification Code Number)
(I.R.S. Employer Identification Number)
```

Every value, then every label. Nothing downstream can recover that `83-4027615` is the EIN. Consumers join the paragraphs into one string, so this is the text that reaches search indexes and language models.

## Change

A `w:tbl` now emits GFM pipe rows, one `ExtractedDocxParagraph` per row:

```
|  |  |  |
| --- | --- | --- |
| Delaware | 4911 | 83-4027615 |
| (State or Other Jurisdiction of Incorporation or Organization) | (Primary Standard Industrial Classification Code Number) | (I.R.S. Employer Identification Number) |
```

`ExtractedDocxParagraph` gains an optional `tableRow: { table: number; kind: "cells" | "syntheticHeader" | "delimiter" }`, so a caller that wants the structure back can regroup a table's rows or drop the rows GFM requires. `kind` is a named discriminator rather than a boolean, since the set of row roles can grow.

The paragraph shape is otherwise unchanged and indices stay sequential, so existing consumers keep working without a code change and get the fix for free. Emitting positional metadata *instead* of rows would not have fixed anything for them: they join `text`, and the joined text would have stayed exactly as broken.

Cell rendering follows `markdown/renderTable.ts` and reuses `escapeTableCell` (pipes to `&#124;`, newlines to `<br>`). It diverges from `renderTable` in one respect, documented in a header comment: `renderTable` switches to inline HTML `<table>` for merged and nested cells, while this path stays GFM-only, because its output is a flat paragraph list consumed as text and one line per row is the property that matters.

## Header rows: `w:tblLook` is not a header signal

Keying promotion off `w:tblLook/@w:firstRow` looks correct and matches what other converters produce on the SEC cover page. It is wrong.

Across a corpus of Word-authored documents, every document carries exactly one distinct `w:tblLook` — Word's default `04A0`, with `firstRow="1"` — including 38 out of 38 tables in a single filing, and `w:trPr/w:tblHeader` appears zero times anywhere. The attribute is conditional *formatting*, not a header declaration, so keying off it promotes the first **data** row of essentially every Word document to column names.

This promotes only when `w:tblHeader` declares a header row, and emits a synthetic empty header otherwise. It never asserts that data are column names. The cost is one extra line per table.

## Behaviour on the awkward cases

| Case | Result |
|---|---|
| `w:gridSpan="N"` | Text in the first grid column, `N-1` empty columns after it, so rows keep the same column boundaries |
| `w:vMerge` restart | Ordinary cell |
| `w:vMerge` continue | Empty column; the anchor value is not filled down, and content a producer left in the continuation cell is dropped (Word renders none) |
| Nested table | Flattened into the containing cell, inner cells joined `" / "`, inner rows joined `<br>`; depth capped at 8 |
| Multi-paragraph cell | Paragraphs joined `<br>`, blank paragraphs dropped |
| Short row | Padded to the table's widest row |
| Table with no cells | Emits nothing |

Filling `w:vMerge` continuations down was rejected deliberately: it would fabricate text the document does not show at that position. A consumer that needs rowspan semantics wants the HTML path.

There is a 256 grid-column cap per row as a bound against a hostile `w:gridSpan`.

## Tests

10 tests added or rewritten, on in-memory JSZip fixtures per the existing convention: the association regression; `tableRow` roles and table numbering across header and body parts; header promotion **and** the negative case that `w:tblLook` alone must not promote; `gridSpan`; a `w:vMerge` continuation fixture that deliberately carries stale text; nested tables; multi-paragraph, empty, pipe-containing and `w:br` cells; empty tables; the invariant that every row of a table has the same column count, asserted as set equality rather than a spot check; and `charCount === Σ text.length`.

`bun run test` in `packages/core`: 4475 pass, 1 skip, 0 fail. Typecheck and oxlint clean, `api-reports/core/server.api.md` regenerated.

No performance regression: on 8 real DOCX (median of 7, warmup 2), after-timings sit inside the before spread on every file, including the 38-table filing.

## Caller-visible consequence

`charCount` now includes the markdown scaffolding (pipes, `---`) for table-heavy documents. The `charCount === Σ text.length` invariant still holds and is tested, but the number is no longer a count of content characters, and a caller applying a character budget spends a little of it on scaffolding.

## Not covered

- No inline emphasis in cells; extraction is plain text everywhere. Table-row paragraphs also carry no `style`/`alignment`/`bold`/`fontSize`, since a row aggregates many cells.
- Nested tables lose their own grid: inner `gridSpan`/`vMerge` are ignored and inner columns are not aligned.
- Only `|` and newlines are escaped, consistent with the rest of this function's plain-text output. A cell containing `*x*` renders as emphasis if the whole output is later parsed as markdown.
- Tracked-deleted rows render as empty rows rather than disappearing, since the accepted view drops the deleted runs but leaves the row's grid.
- Tables in footnotes, endnotes and comments are still not extracted; `extractDocxText` does not read those parts. Unchanged here.
