### PR TITLE
chore(ci): guard quarantine excludes and expire the temporary ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,20 @@ jobs:
       - name: Lockfile workspace-version check
         run: bun run check:lockfile-versions
 
+      - name: Quarantine-exclude guard
+        # The 5-day release-age quarantine is excluded per package for the
+        # first-party @stll/* code folio pulls from npm, and bun matches those
+        # entries EXACTLY (a `@stll/*` glob is accepted and ignored). List a
+        # napi package without its platform subpackages and the parent installs
+        # while its binaries stay quarantined — and a quarantined
+        # optionalDependency is skipped SILENTLY, so the package imports fine
+        # and throws on first use. This fails when the exclude list stops
+        # covering everything in the lock. Temporary third-party exemptions
+        # carry an exact expiry so the same check also fails once Bun's
+        # release-age gate can take over again. The guard's own self-test runs
+        # with `bun run test` below.
+        run: bun run check:quarantine-excludes
+
       - name: Dependency audit
         run: bun run audit
 

--- a/.github/workflows/quarantine-prune.yml
+++ b/.github/workflows/quarantine-prune.yml
@@ -1,0 +1,124 @@
+name: Quarantine Exclude Prune
+
+# A temporary `minimumReleaseAgeExcludes` entry stops being needed at a
+# wall-clock instant, and stops being safe at the same moment: it would let the
+# next version of that package publish straight past the release-age gate. So
+# the removal is proposed automatically rather than waiting to be noticed, and
+# the guard in ci.yml only tolerates an expired entry while this PR is open.
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: quarantine-prune
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  PRUNE_BRANCH: chore/prune-quarantine-excludes
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  prune:
+    name: Propose removing expired excludes
+    if: github.repository == 'stella/folio'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      # Pinned to the default branch: without a ref, a manual dispatch from a
+      # feature branch would prune that branch's bunfig.toml and force-push its
+      # commits into the removal PR along with it.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      # The script only reads bunfig.toml and bun.lock, so no install is needed.
+      - name: Prune expired excludes
+        id: prune
+        run: |
+          set -euo pipefail
+
+          bun scripts/check-quarantine-excludes.ts --prune
+
+          if git diff --quiet -- bunfig.toml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing expired." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          # The pruned file must satisfy the guard, or the PR would land a
+          # bunfig.toml that fails CI for a different reason.
+          bun scripts/check-quarantine-excludes.ts
+
+      # The same app identity that maintains the Version Packages PR; folio has
+      # no repository-level secrets, and these are org-level with `all`
+      # visibility.
+      - name: Mint app token
+        if: steps.prune.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          # Push the branch and open the PR, nothing else the app can reach.
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Open or update the removal PR
+        if: steps.prune.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+
+          bot_id="$(gh api "users/${APP_SLUG}[bot]" --jq '.id')"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          git checkout -b "$PRUNE_BRANCH"
+          git add bunfig.toml
+          git commit -m "chore(deps): remove expired quarantine excludes
+
+          The release-age gate admits these packages on its own now, and an
+          entry left behind would let their next version skip it."
+
+          # Force-with-lease is unsafe against a branch this job does not own,
+          # so the branch name is reserved for this job alone. Re-running
+          # replaces its own proposal with one computed from the default branch.
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force "$remote" "HEAD:refs/heads/${PRUNE_BRANCH}"
+
+          if [[ -n "$(gh pr list --head "$PRUNE_BRANCH" --state open --json number --jq '.[0].number // ""')" ]]; then
+            echo "Updated the open removal PR." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body_file="$RUNNER_TEMP/prune-pr-body.md"
+          # shellcheck disable=SC2016 # backticks are markdown, not substitution
+          printf '%s\n' \
+            'These temporary `minimumReleaseAgeExcludes` entries have passed their annotated expiry, so the release-age gate admits the packages without them.' \
+            '' \
+            'Leaving an expired entry in place is not neutral: it would let the next version of that package publish straight past the gate. Merging this restores that check.' \
+            '' \
+            'Opened automatically. The removal is what `bun scripts/check-quarantine-excludes.ts --prune` produces.' \
+            > "$body_file"
+
+          gh pr create \
+            --base "$DEFAULT_BRANCH" \
+            --head "$PRUNE_BRANCH" \
+            --title "chore(deps): remove expired quarantine excludes" \
+            --body-file "$body_file" >> "$GITHUB_STEP_SUMMARY"

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,6 +2,22 @@
 # 5-day quarantine: reject package versions published
 # less than 5 days ago to mitigate supply chain attacks.
 minimumReleaseAge = 432_000
+# First-party @stll packages folio consumes from public npm. They share a
+# release cadence and would otherwise be blocked on every publish cycle.
+# folio's own published packages are absent on purpose: they resolve through
+# the `workspace:` protocol and never reach the registry.
+#
+# A napi package must be listed WITH its platform subpackages. They publish in
+# the same minute, but they are optionalDependencies: quarantine one and bun
+# skips it silently, leaving the parent installed with no native binding and
+# every call failing at runtime. Bun matches these names exactly — a `@stll/*`
+# glob is accepted and then ignored.
+#
+# A third-party entry that is only needed until the release-age gate catches up
+# carries its own expiry, `"pkg", # quarantine-expires: <ISO UTC instant>`, and
+# is removed automatically once that instant passes.
+#
+# `bun run check:quarantine-excludes` enforces all of the above.
 minimumReleaseAgeExcludes = [
   "@stll/conditions",
   "@stll/docx-utils",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:export-parity": "node scripts/check-export-parity.mjs",
     "check:react-compiler": "bun scripts/react-compiler-bailouts.ts --check",
     "check:lockfile-versions": "bun scripts/check-lockfile-workspace-versions.ts",
+    "check:quarantine-excludes": "bun scripts/check-quarantine-excludes.ts",
     "check:build-reproducibility": "bun scripts/check-build-reproducibility.ts",
     "check:docx-kernel": "bun --filter '@stll/docx-core' wasm:check",
     "check:docx-kernel-version": "bun scripts/sync-docx-kernel-version.ts",

--- a/scripts/check-quarantine-excludes.test.ts
+++ b/scripts/check-quarantine-excludes.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import packageJson from "../package.json";
+import { checkQuarantineExcludes, pruneExpiredExcludes } from "./check-quarantine-excludes";
+
+const SCRIPT_PATH = "scripts/check-quarantine-excludes.ts";
+
+// Shaped like folio's real lockfile: a first-party package pulled from the
+// registry, next to a workspace member that never reaches it.
+const lockfile = `
+"packages": {
+  "@stll/conditions": ["@stll/conditions@0.1.0", "", { "dependencies": { "valibot": "1.4.1" } }, "sha512-test"],
+  "@stll/folio-core": ["@stll/folio-core@workspace:packages/core"],
+}
+`;
+
+const createBunfig = (temporaryLine: string) => `
+[install]
+minimumReleaseAge = 432_000
+minimumReleaseAgeExcludes = [
+  "@stll/conditions",
+  ${temporaryLine}
+]
+`;
+
+describe("quarantine exclude guard", () => {
+  test("accepts a temporary exclusion before its exact expiry", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z'),
+      lockfile,
+      now: new Date("2026-08-08T14:16:00.209Z"),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.activeTemporaryCount).toBe(1);
+  });
+
+  // Nothing to say before it expires: the removal arrives on its own.
+  test("stays silent until the expiry", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z'),
+      lockfile,
+      now: new Date("2026-08-08T14:16:00.209Z"),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  // An expiry is a wall-clock instant. Failing at it turns every open branch
+  // red at once for a change nobody made, so the instant only warns.
+  test("warns rather than fails at the exact expiry", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z'),
+      lockfile,
+      now: new Date("2026-08-08T14:16:00.210Z"),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.at(0)).toContain('temporary quarantine exclude "dompurify" expired at');
+  });
+
+  test("still only warns just inside the notice window", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z'),
+      lockfile,
+      now: new Date("2026-08-09T14:16:00.209Z"),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  test("fails once an expired exclusion is ignored past the notice window", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z'),
+      lockfile,
+      now: new Date("2026-08-09T14:16:00.210Z"),
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.at(0)).toContain(
+      'temporary quarantine exclude "dompurify" expired at 2026-08-08T14:16:00.210Z and is still here',
+    );
+  });
+
+  test("rejects malformed expiry annotations", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08'),
+      lockfile,
+    });
+
+    expect(result.errors).toContain(
+      'bunfig.toml temporary quarantine exclude "dompurify" has an invalid UTC expiry: 2026-08-08',
+    );
+  });
+
+  // folio's own published packages resolve through `workspace:` and never hit
+  // the registry, so the release-age gate cannot apply to them.
+  test("exempts workspace members and requires registry-resolved packages", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify",'),
+      lockfile,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.firstPartyCount).toBe(1);
+  });
+
+  // A fixed-width lookahead read past the entry, so a workspace member on the
+  // next line marked its registry-resolved neighbour as a workspace member
+  // too, and the coverage check silently stopped requiring it.
+  test("counts a registry package followed by a workspace member", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify",'),
+      lockfile: `
+"packages": {
+  "@stll/conditions": ["@stll/conditions@0.1.0", "", {}, "sha512-test"],
+  "@stll/docx-utils": ["@stll/docx-utils@0.1.0", "", { "dependencies": { "jszip": "3.10.1" } }, "sha512-test"],
+  "@stll/folio-core": ["@stll/folio-core@workspace:packages/core"],
+}
+`,
+    });
+
+    expect(result.firstPartyCount).toBe(2);
+    expect(result.errors.at(0)).toContain('"@stll/docx-utils",');
+  });
+
+  // A napi package's platform binaries are optionalDependencies with their own
+  // lockfile entries. Excluding only the parent installs it with every binding
+  // silently skipped, so each child has to be required in its own right.
+  test("requires the platform subpackages of a napi package, not just the parent", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"@stll/stdnum",'),
+      lockfile: `
+"packages": {
+  "@stll/conditions": ["@stll/conditions@0.1.0", "", {}, "sha512-test"],
+  "@stll/stdnum": ["@stll/stdnum@2.3.1", "", { "optionalDependencies": { "@stll/stdnum-darwin-arm64": "2.3.1", "@stll/stdnum-linux-x64-gnu": "2.3.1" } }, "sha512-test"],
+  "@stll/stdnum-darwin-arm64": ["@stll/stdnum-darwin-arm64@2.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-test"],
+  "@stll/stdnum-linux-x64-gnu": ["@stll/stdnum-linux-x64-gnu@2.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-test"],
+}
+`,
+    });
+
+    expect(result.errors.at(0)).toContain('"@stll/stdnum-darwin-arm64",');
+    expect(result.errors.at(0)).toContain('"@stll/stdnum-linux-x64-gnu",');
+  });
+
+  // Bun keys nested resolutions by path; those are not package names.
+  test("ignores nested resolution keys", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify",'),
+      lockfile: `
+"packages": {
+  "@stll/conditions": ["@stll/conditions@0.1.0", "", {}, "sha512-test"],
+  "@stll/template-conditions/better-result": ["better-result@2.9.2", "", {}, "sha512-test"],
+}
+`,
+    });
+
+    expect(result.firstPartyCount).toBe(1);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("retains the first-party package coverage guard", () => {
+    const result = checkQuarantineExcludes({
+      bunfig: createBunfig('"dompurify",'),
+      lockfile: `${lockfile}\n"@stll/missing": ["@stll/missing@1.0.0"]`,
+    });
+
+    expect(result.errors.at(0)).toContain('"@stll/missing",');
+  });
+});
+
+describe("quarantine exclude prune", () => {
+  test("prunes only the expired entries", () => {
+    const bunfig = `
+[install]
+minimumReleaseAge = 432_000
+minimumReleaseAgeExcludes = [
+  "@stll/conditions",
+  # Security patches for dependency-audit findings.
+  "dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z
+  "nanoid", # quarantine-expires: 2026-08-09T10:39:22.487Z
+  "@stll/oxlint-config",
+]
+`;
+    const result = pruneExpiredExcludes({
+      bunfig,
+      now: new Date("2026-08-08T15:00:00.000Z"),
+    });
+
+    expect(result.pruned).toEqual(["dompurify"]);
+    expect(result.bunfig).not.toContain("dompurify");
+    expect(result.bunfig).toContain('"nanoid", # quarantine-expires:');
+    expect(result.bunfig).toContain('"@stll/conditions"');
+    expect(result.bunfig).toContain('"@stll/oxlint-config"');
+    // The pruned file is what the guard should then accept.
+    expect(
+      checkQuarantineExcludes({
+        bunfig: result.bunfig,
+        lockfile,
+        now: new Date("2026-08-08T15:00:00.000Z"),
+      }).errors,
+    ).toEqual([]);
+  });
+
+  // The prune deletes at the instant the guard starts warning, so the removal
+  // PR is already open for the whole notice window.
+  test("prunes at the exact expiry", () => {
+    const result = pruneExpiredExcludes({
+      bunfig: createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z'),
+      now: new Date("2026-08-08T14:16:00.210Z"),
+    });
+
+    expect(result.pruned).toEqual(["dompurify"]);
+  });
+
+  // Matching by name would take the renewed entry with the expired one, which
+  // silently drops a package back out of the quarantine before its time.
+  test("keeps a renewed entry when an expired one shares its name", () => {
+    const bunfig = `
+[install]
+minimumReleaseAge = 432_000
+minimumReleaseAgeExcludes = [
+  "@stll/conditions",
+  "nanoid", # quarantine-expires: 2026-08-09T10:39:22.487Z
+  "nanoid", # quarantine-expires: 2026-09-01T10:39:22.487Z
+]
+`;
+    const result = pruneExpiredExcludes({
+      bunfig,
+      now: new Date("2026-08-10T00:00:00.000Z"),
+    });
+
+    expect(result.pruned).toEqual(["nanoid"]);
+    expect(result.bunfig).toContain('"nanoid", # quarantine-expires: 2026-09-01T10:39:22.487Z');
+    expect(result.bunfig).not.toContain("2026-08-09T10:39:22.487Z");
+  });
+
+  test("leaves a malformed annotation for the guard to report", () => {
+    const bunfig = createBunfig('"dompurify", # quarantine-expires: nope');
+    const result = pruneExpiredExcludes({ bunfig, now: new Date("2026-09-01T00:00:00.000Z") });
+
+    expect(result.pruned).toEqual([]);
+    expect(result.bunfig).toBe(bunfig);
+  });
+
+  test("leaves a file with nothing expired untouched", () => {
+    const bunfig = createBunfig('"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z');
+    const result = pruneExpiredExcludes({ bunfig, now: new Date("2026-08-06T00:00:00.000Z") });
+
+    expect(result.pruned).toEqual([]);
+    expect(result.bunfig).toBe(bunfig);
+  });
+});
+
+// Renaming the script silently unwires CI and the prune job, and neither
+// failure shows up as a test failure anywhere else.
+describe("quarantine exclude wiring", () => {
+  test("the package script runs this guard", () => {
+    expect(packageJson.scripts["check:quarantine-excludes"]).toBe(`bun ${SCRIPT_PATH}`);
+  });
+
+  test("CI runs the package script", async () => {
+    const ci = await Bun.file(join(import.meta.dirname, "../.github/workflows/ci.yml")).text();
+
+    expect(ci).toContain("bun run check:quarantine-excludes");
+  });
+
+  test("the prune workflow runs this guard in both modes", async () => {
+    const workflow = await Bun.file(
+      join(import.meta.dirname, "../.github/workflows/quarantine-prune.yml"),
+    ).text();
+
+    expect(workflow).toContain(`bun ${SCRIPT_PATH} --prune`);
+    expect(workflow).toContain(`bun ${SCRIPT_PATH}\n`);
+  });
+});

--- a/scripts/check-quarantine-excludes.ts
+++ b/scripts/check-quarantine-excludes.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env bun
+/**
+ * Guard `bunfig.toml`'s `minimumReleaseAgeExcludes`:
+ *
+ * 1. Every `@stll/*` package the lockfile resolves FROM NPM must be excluded.
+ *    folio's own published packages (`@stll/folio-core`, `@stll/folio-react`,
+ *    `@stll/folio-vue`, `@stll/folio-nuxt`, `@stll/folio-agents`,
+ *    `@stll/docx-core`) resolve through the `workspace:` protocol and never
+ *    reach the registry, so they are exempt. The packages that DO need an
+ *    exclusion are the first-party ones folio CONSUMES from npm, which is why
+ *    the set is read out of the lockfile rather than hard-coded: the moment a
+ *    workspace member is dropped, or a new `@stll/*` dependency is added, the
+ *    requirement follows on its own.
+ * 2. A temporary third-party exclusion annotated with
+ *    `# quarantine-expires: <timestamp>` must be removed once Bun's release-age
+ *    gate can take over again.
+ *
+ * An expiry is a wall-clock instant, so failing at that instant turns every
+ * open branch red at once for a change nobody made. Removal is automatic
+ * instead: `quarantine-prune.yml` runs `--prune` hourly and opens the PR that
+ * deletes the entry. An expired entry is therefore only a warning while that
+ * PR waits to be merged, and fails once it has been ignored past the window.
+ * It has to fail eventually: a stale exclude is not inert, because the next
+ * version of that package published would skip the quarantine unnoticed.
+ *
+ * The 5-day quarantine is a supply-chain control for third-party code.
+ * First-party packages publish continuously, so they are excluded by name. The
+ * failure this guards is not the exclusion itself but a PARTIAL one: a napi
+ * package ships its platform binaries as separate `optionalDependencies`
+ * published in the same minute, each recorded as its own lockfile entry. List
+ * the parent and forget the children and the parent installs while every binary
+ * is quarantined — and because they are optional, bun skips them without a
+ * word. The package then resolves, imports cleanly, and throws on first use, on
+ * every platform. folio ships no napi package today (`crates/docx-kernel` is
+ * compiled to WebAssembly and committed inside `@stll/docx-core`), so the rule
+ * reads the lockfile rather than a list: platform subpackages appear there as
+ * ordinary entries and become required the day one arrives.
+ *
+ * Bun matches these entries EXACTLY. A `@stll/*` glob is accepted and silently
+ * ignored, which is why this cannot be solved by pattern and needs a guard.
+ *
+ * Reads `bunfig.toml` and `bun.lock` and nothing else, so it runs without an
+ * install — `quarantine-prune.yml` depends on that.
+ *
+ * Run: `bun run check:quarantine-excludes`
+ */
+
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+const LOCKFILE = "bun.lock";
+const BUNFIG = "bunfig.toml";
+const SCRIPT_PATH = "scripts/check-quarantine-excludes.ts";
+const EXPIRY_MARKER = "quarantine-expires:";
+const EXACT_UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+
+/** Packages resolved from the workspace itself never hit the registry. */
+const WORKSPACE_PROTOCOL = "workspace:";
+
+const readExcludeBlock = (bunfig: string): string => {
+  const start = bunfig.indexOf("minimumReleaseAgeExcludes");
+  if (start === -1) return "";
+  const end = bunfig.indexOf("]", start);
+  return bunfig.slice(start, end === -1 ? undefined : end);
+};
+
+const readExcludes = (bunfig: string): Set<string> =>
+  new Set(
+    [...readExcludeBlock(bunfig).matchAll(/"(?<name>@?[^"]+)"/gu)].flatMap((match) => {
+      const name = match.groups?.["name"];
+      return name === undefined ? [] : [name];
+    }),
+  );
+
+type TemporaryExclude = {
+  name: string;
+  expiresAt: string;
+};
+
+type TemporaryExcludesResult = {
+  entries: TemporaryExclude[];
+  errors: string[];
+};
+
+type ParsedTemporaryExclude =
+  | { kind: "error"; error: string }
+  | { kind: "entry"; name: string; expiresAt: string };
+
+/**
+ * One annotated line. Both the guard and the prune read it through here, so
+ * neither can disagree with the other about what a line means.
+ */
+const parseTemporaryExcludeLine = (line: string): ParsedTemporaryExclude => {
+  const commentStart = line.indexOf("#");
+  const declaration = line.slice(0, commentStart).trim();
+  const comment = line.slice(commentStart + 1).trim();
+  const quotedName = declaration.endsWith(",") ? declaration.slice(0, -1).trim() : declaration;
+  const isQuotedName =
+    quotedName.startsWith('"') &&
+    quotedName.endsWith('"') &&
+    !quotedName.slice(1, -1).includes('"');
+  if (!comment.startsWith(EXPIRY_MARKER) || !isQuotedName) {
+    return {
+      kind: "error",
+      error: `${BUNFIG} has a malformed temporary quarantine annotation: ${line.trim()}`,
+    };
+  }
+
+  const name = quotedName.slice(1, -1);
+  const expiresAt = comment.slice(EXPIRY_MARKER.length).trim();
+  const expiresAtMs = Date.parse(expiresAt);
+  if (
+    !EXACT_UTC_TIMESTAMP.test(expiresAt) ||
+    Number.isNaN(expiresAtMs) ||
+    new Date(expiresAtMs).toISOString() !== expiresAt
+  ) {
+    return {
+      kind: "error",
+      error: `${BUNFIG} temporary quarantine exclude "${name}" has an invalid UTC expiry: ${expiresAt}`,
+    };
+  }
+
+  return { kind: "entry", name, expiresAt };
+};
+
+const readTemporaryExcludes = (bunfig: string): TemporaryExcludesResult => {
+  const entries: TemporaryExclude[] = [];
+  const errors: string[] = [];
+
+  for (const line of readExcludeBlock(bunfig).split("\n")) {
+    if (!line.includes(EXPIRY_MARKER)) continue;
+
+    const parsed = parseTemporaryExcludeLine(line);
+    if (parsed.kind === "error") {
+      errors.push(parsed.error);
+      continue;
+    }
+
+    entries.push({ name: parsed.name, expiresAt: parsed.expiresAt });
+  }
+
+  return { entries, errors };
+};
+
+/**
+ * `@stll` packages the lockfile pulls from the registry. Workspace members
+ * resolve locally and are never subject to the release-age gate.
+ */
+const readRegistryFirstPartyPackages = (lockfile: string): Set<string> =>
+  new Set(
+    // Scope plus exactly one segment. Bun also keys nested resolutions by path
+    // ("@stll/template-conditions/better-result"); those are not package names.
+    [...lockfile.matchAll(/"(?<name>@stll\/[^"/]+)":\s*\[/gu)].flatMap((match) => {
+      const name = match.groups?.["name"];
+      if (name === undefined) return [];
+      // The entry's own resolution follows the name; workspace members carry
+      // the workspace protocol instead of a registry tarball. Read to the end
+      // of that line and no further: a fixed-width window spills into the next
+      // entry, and one workspace neighbour then hides a registry-resolved
+      // package from the coverage check entirely.
+      const lineEnd = lockfile.indexOf("\n", match.index);
+      const entry = lockfile.slice(match.index, lineEnd === -1 ? undefined : lineEnd);
+      return entry.includes(WORKSPACE_PROTOCOL) ? [] : [name];
+    }),
+  );
+
+const HOUR_MS = 60 * 60 * 1000;
+/** How long an expired entry is tolerated while its removal PR waits. */
+const NOTICE_WINDOW_MS = 24 * HOUR_MS;
+
+export type QuarantineExcludeCheckResult = {
+  errors: string[];
+  warnings: string[];
+  excludeCount: number;
+  firstPartyCount: number;
+  activeTemporaryCount: number;
+};
+
+export const checkQuarantineExcludes = ({
+  bunfig,
+  lockfile,
+  now = new Date(),
+}: {
+  bunfig: string;
+  lockfile: string;
+  now?: Date;
+}): QuarantineExcludeCheckResult => {
+  const excludes = readExcludes(bunfig);
+  const firstPartyPackages = readRegistryFirstPartyPackages(lockfile);
+  const missing = [...firstPartyPackages].filter((name) => !excludes.has(name)).sort();
+  const temporary = readTemporaryExcludes(bunfig);
+  const errors = [...temporary.errors];
+
+  if (missing.length > 0) {
+    errors.push(
+      `${BUNFIG} minimumReleaseAgeExcludes is missing ${missing.length} first-party package(s):\n${missing
+        .map((name) => `  "${name}",`)
+        .join("\n")}\n\nAdd them. Until then, a fresh publish of any of these installs ` +
+        `partially: the quarantine blocks it, and an optionalDependency that is ` +
+        `blocked is skipped silently, so the failure surfaces at runtime rather ` +
+        `than at install.`,
+    );
+  }
+
+  const nowMs = now.getTime();
+  const warnings: string[] = [];
+  for (const { name, expiresAt } of temporary.entries) {
+    const expiresAtMs = Date.parse(expiresAt);
+
+    if (nowMs >= expiresAtMs + NOTICE_WINDOW_MS) {
+      errors.push(
+        `${BUNFIG} temporary quarantine exclude "${name}" expired at ${expiresAt} ` +
+          `and is still here. Remove it (\`bun ${SCRIPT_PATH} --prune\`): the ` +
+          `release-age gate admits the package on its own now, and leaving the ` +
+          `entry lets the next version of it publish straight past the quarantine.`,
+      );
+      continue;
+    }
+
+    if (nowMs >= expiresAtMs) {
+      warnings.push(
+        `${BUNFIG} temporary quarantine exclude "${name}" expired at ${expiresAt}. ` +
+          `Its removal PR opens automatically; merge it, or run ` +
+          `\`bun ${SCRIPT_PATH} --prune\` to do it by hand.`,
+      );
+    }
+  }
+
+  return {
+    errors,
+    warnings,
+    excludeCount: excludes.size,
+    firstPartyCount: firstPartyPackages.size,
+    activeTemporaryCount: temporary.entries.length,
+  };
+};
+
+export type PruneResult = {
+  bunfig: string;
+  pruned: string[];
+};
+
+/**
+ * Drops the entries whose expiry has passed. Only the entry line goes: the
+ * comments above the block explain why the remaining entries are there.
+ */
+export const pruneExpiredExcludes = ({
+  bunfig,
+  now = new Date(),
+}: {
+  bunfig: string;
+  now?: Date;
+}): PruneResult => {
+  const blockStart = bunfig.indexOf("minimumReleaseAgeExcludes");
+  if (blockStart === -1) return { bunfig, pruned: [] };
+  const blockEnd = bunfig.indexOf("]", blockStart);
+  const pruned: string[] = [];
+
+  // Each line is judged by its own annotation. Matching by name instead would
+  // delete every entry sharing that name, including one whose expiry was
+  // renewed and has not passed.
+  const block = bunfig
+    .slice(blockStart, blockEnd)
+    .split("\n")
+    .filter((line) => {
+      if (!line.includes(EXPIRY_MARKER)) return true;
+      const parsed = parseTemporaryExcludeLine(line);
+      // A malformed annotation is the guard's to report, not this to delete.
+      if (parsed.kind !== "entry") return true;
+      if (now.getTime() < Date.parse(parsed.expiresAt)) return true;
+      pruned.push(parsed.name);
+      return false;
+    })
+    .join("\n");
+
+  if (pruned.length === 0) return { bunfig, pruned: [] };
+
+  return { bunfig: bunfig.slice(0, blockStart) + block + bunfig.slice(blockEnd), pruned };
+};
+
+const prune = async (): Promise<void> => {
+  const bunfigPath = join(ROOT, BUNFIG);
+  const { bunfig, pruned } = pruneExpiredExcludes({
+    bunfig: await Bun.file(bunfigPath).text(),
+  });
+
+  if (pruned.length === 0) {
+    console.log(`${BUNFIG}: no expired quarantine excludes to remove.`);
+    return;
+  }
+
+  await Bun.write(bunfigPath, bunfig);
+  console.log(
+    `${BUNFIG}: removed ${pruned.length} expired quarantine exclude(s): ${pruned.join(", ")}.`,
+  );
+};
+
+const check = async (): Promise<void> => {
+  const result = checkQuarantineExcludes({
+    bunfig: await Bun.file(join(ROOT, BUNFIG)).text(),
+    lockfile: await Bun.file(join(ROOT, LOCKFILE)).text(),
+  });
+
+  if (result.warnings.length > 0) {
+    console.warn(`${result.warnings.join("\n")}\n`);
+  }
+
+  if (result.errors.length > 0) {
+    console.error(result.errors.join("\n\n"));
+    process.exit(1);
+  }
+
+  console.log(
+    `${BUNFIG}: ${result.excludeCount} quarantine excludes cover all ` +
+      `${result.firstPartyCount} registry-backed first-party packages; ` +
+      `${result.activeTemporaryCount} temporary exclude(s) remain active.`,
+  );
+};
+
+if (import.meta.main) {
+  await (process.argv.includes("--prune") ? prune() : check());
+}


### PR DESCRIPTION
## Problem

#550 added a 5-day release-age quarantine but no way to hold a temporary exclusion accountable. A security patch published yesterday has to be excluded to be installable at all, and that exclusion then sits in `bunfig.toml` forever.

A stale exclude is not inert. It stops being *needed* and stops being *safe* at the same instant: the next version of that package published would skip the release-age gate entirely, unnoticed.

## Change

An exclusion may be annotated with an expiry:

```toml
"dompurify", # quarantine-expires: 2026-08-08T14:16:00.210Z
```

`scripts/check-quarantine-excludes.ts` enforces two rules:

1. Every first-party package the lockfile resolves **from the registry** must be excluded. Anything resolved through `workspace:` never reaches npm and is exempt, so today this covers exactly the four packages folio consumes: `@stll/conditions`, `@stll/docx-utils`, `@stll/oxlint-config`, `@stll/template-conditions`. The six packages folio publishes are all workspace-resolved and correctly not required.
2. An annotated exclusion must be removed once the gate can take over again.

The set is derived from `bun.lock`, not hardcoded, so it stays correct as packages move between workspace and registry resolution.

### Why a guard is needed at all

Bun matches these entries **exactly**. A `@stll/*` glob is accepted and then silently ignored, so the rule cannot be expressed as a pattern.

The failure worth guarding is not an exclusion but a *partial* one. A napi package ships its platform binaries as separate `optionalDependencies` published in the same minute. List the parent and forget the children and the parent installs while every binary is quarantined — and because they are optional, bun skips them without a word. The package resolves, imports cleanly, and throws on first use, on every platform.

folio has no napi package today (`crates/docx-kernel` compiles to WebAssembly committed inside `@stll/docx-core`, not a platform-subpackage fan-out). Because the rule is derived from the lockfile, it will demand the children automatically the day one arrives; there is a regression test over a real parent-plus-platform-children lockfile shape asserting exactly that.

### Expiry is graded, not a cliff

An expiry is a wall-clock instant. Failing at that instant would turn every open branch red at once for a change nobody made, so removal is proposed instead of demanded:

| state | behaviour |
|---|---|
| before expiry | silent |
| at expiry | warning, exit 0 |
| 24h past expiry | error, exit 1 |
| malformed annotation | error; `--prune` leaves the line alone |

`.github/workflows/quarantine-prune.yml` runs hourly, runs `--prune`, and opens or updates a single removal PR on a reserved branch. Pruning happens at the same instant the guard starts warning, so the PR is open for the entire notice window. The guard only fails once that PR has been ignored past it.

Judgement is per line, never per name, so a renewed entry survives its expired twin.

## Adaptations from the `stella/stella` original

- **App token.** The original uses `PROVENANCE_APP_ID` / `PROVENANCE_APP_PRIVATE_KEY`. Those do not exist for this repository, and not at the organisation level either, so a verbatim copy would fail at the token step every hour. This uses `CHANGELOG_APP_ID` / `CHANGELOG_APP_PRIVATE_KEY`: organisation-level, visibility `all`, and already the credentials `release-pr.yml` passes to the shared release workflow, which mints a token with the same action pin and the same `contents: write` + `pull-requests: write` pair. That app already pushes branches and opens PRs here (#546, #542, #540).
- **Actions.** This repository does not use the shared `setup-bun-cached` action anywhere, so the workflow uses `oven-sh/setup-bun` with `bun-version-file: package.json` and this repository's own `actions/checkout` pin.
- **`--base` is threaded from `github.event.repository.default_branch`** rather than hardcoded, so it cannot drift from the checkout ref.
- **Naming** drops the original's `stll` infix. Inside an `@stll`-scoped repository it reads as "guard folio's own packages", which is the opposite of what the rule requires; `check-quarantine-excludes.ts` matches the existing `check-*.ts` family.
- **No separate CI step for the self-test.** `bun run test` already runs `bun test scripts`, which picks the test file up.

Security properties of the original are preserved: `permissions: {}` at the top level, `contents: read` on the job, `persist-credentials: false`, checkout pinned to the default branch, a branch name reserved for this job, and force-push only to that branch.

The script imports nothing outside `node:path`, so the prune job needs no `bun install`.

## Guarding against silent unwiring

A rename could quietly disconnect any of the four places this script is referenced. The test asserts that the package script, the CI step, and both prune-workflow invocations all point at the same path.

## Validation

- `bun run check:quarantine-excludes` on unmodified `main` — passes: *4 quarantine excludes cover all 4 registry-backed first-party packages; 0 temporary exclude(s) remain active*
- `bun test scripts` — 119 pass, 0 fail
- `bun run lint`, `bun run format:check`, `bun run typecheck` — clean
- Hand-tested against the real `bunfig.toml` with three annotated entries (expired 2h, expired 72h, expiring in 48h): warning for the first, error for the second, silence for the third; `--prune` removed exactly the expired lines and left the future entry, its comment, and every other byte untouched; guard passed afterwards; reverted with `bun install --frozen-lockfile` clean.

## Note for whoever merges second

#553 appends two annotated entries directly below `"@stll/template-conditions",` while this branch adds a comment block just above the list opener. In a file this short those hunks share context, so expect a trivial `bunfig.toml` conflict. #553's entries are already in the format this guard parses, and its `nanoid` entry expires 2026-08-08T10:39:22.487Z, so the prune job will propose its removal on the next hourly run after both land.
