### PR TITLE
chore(ci): bump the shared release workflow to v1.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@8948af7f6f794f6b2e8b9bd50ccb4f160eb0aca0 # v1.5.2
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@5628b97fb3c560c0d961baa60c272c598eddcab5 # v1.7.0
     with:
       artifact-pattern: npm-tarball-*
       artifact-run-id: ${{ inputs.artifact-run-id }}


### PR DESCRIPTION
## Why

The 0.16.0 publish failed in `prepare` with:

```
GitHub returned duplicate releases for '@stll/folio-core@0.3.1'.
```

No duplicate release existed. This repository has passed 100 releases, so the shared action's re-read of `releases?per_page=100` now spans two offset pages, and `@stll/folio-core@0.3.1` sat on the page boundary. A draft becoming visible between the two page requests shifted every later entry down one, and the boundary entry came back on both pages.

The action failed on that instead of letting its own bounded backoff retry, so the release stopped after tagging and staging the drafts, with nothing published to npm. A re-run recovered it: the drafts already existed, so no release was created, the list did not shift, and all four packages published.

`stella/.github` v1.7.0 fixes the underlying handling: the same release seen twice is now tolerated, while two distinct releases sharing one tag still fails.

## Change

Bumps the shared release workflow from v1.5.2 to v1.7.0.

v1.7.0 also carries the changes tagged between v1.5.2 and v1.7.0, none of which this repository's release path uses today: a Dependabot actions bump, a code of conduct, label-manifest reorganisation, a `setup-bun-cached` composite action, and a PR-title rule.

## Verification

Nothing here is exercisable before merge; the workflow only runs on a release commit. The fix itself is covered upstream by tests for both the tolerated repeat and the still-rejected genuine duplicate.

Worth knowing for the next release: this repository crossed the first page boundary recently, and the failure is a race, so a pre-bump release could equally have succeeded. The fix removes the failure mode rather than making a flaky path less likely.
