### PR TITLE
fix(core): wait for complex-script and East-Asian fonts before first layout

### DIFF
--- a/.changeset/font-readiness-script-slots.md
+++ b/.changeset/font-readiness-script-slots.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+---
+
+Wait for the complex-script and East-Asian fonts before the first layout, not just the Latin ones.
+
+The font-readiness gate collected only the `ascii` and `hAnsi` slots of a run's font. Word writes the Arabic and Hebrew face into `w:cs` and the CJK face into `w:eastAsia`, so a document that styles those scripts the standard way had its font ignored by the gate. The first layout then measured a fallback face while the painter later drew the real one once it loaded, and the two disagreed for exactly the scripts whose advances differ most from a Latin fallback.

--- a/packages/core/src/controller/fontReadiness.test.ts
+++ b/packages/core/src/controller/fontReadiness.test.ts
@@ -110,6 +110,25 @@ describe("initial layout font loading", () => {
     expect(documentFontsAreLoaded()).toBe(true);
   });
 
+  // Word writes the Arabic and Hebrew face into `w:cs` and the CJK face into
+  // `w:eastAsia`, not into ascii/hAnsi. Collecting only the Latin slots left the
+  // first layout measuring a fallback for exactly the scripts whose advances
+  // differ most from it, and the painted result then disagreed with it.
+  test.each([
+    ["cs", "Noto Sans Arabic"],
+    ["eastAsia", "Noto Sans JP"],
+  ])("waits for the %s font slot", (slot, family) => {
+    const fontFamily = schema.marks["fontFamily"]?.create({ [slot]: family });
+    if (!fontFamily) {
+      throw new Error("Expected a fontFamily mark in schema");
+    }
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("text", [fontFamily])]),
+    ]);
+
+    expect(collectInitialLayoutFontFamilies(null, pmDoc)).toContain(family);
+  });
+
   test("always includes the default layout font family for a null document model", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("plain")]),

--- a/packages/core/src/controller/fontReadiness.ts
+++ b/packages/core/src/controller/fontReadiness.ts
@@ -231,9 +231,21 @@ function addLayoutFontFamilyFace(
     return;
   }
 
-  const fontFamily = value as { ascii?: unknown; hAnsi?: unknown };
+  // Every slot, not just the Latin ones. `w:cs` carries the complex-script face
+  // (Word writes Arabic and Hebrew there) and `w:eastAsia` the CJK face, so
+  // collecting only ascii/hAnsi left the first layout measuring a fallback for
+  // exactly the scripts whose advances differ most from it, then repainting in
+  // the real face once it loaded.
+  const fontFamily = value as {
+    ascii?: unknown;
+    hAnsi?: unknown;
+    cs?: unknown;
+    eastAsia?: unknown;
+  };
   addLayoutFontFamilyFace(faces, fontFamily.ascii, descriptor);
   addLayoutFontFamilyFace(faces, fontFamily.hAnsi, descriptor);
+  addLayoutFontFamilyFace(faces, fontFamily.cs, descriptor);
+  addLayoutFontFamilyFace(faces, fontFamily.eastAsia, descriptor);
 }
 
 function addLayoutFontFamilyNameFace(


### PR DESCRIPTION
The font-readiness gate that holds back the first layout collected only the
`ascii` and `hAnsi` slots of a run's font:

```ts
const fontFamily = value as { ascii?: unknown; hAnsi?: unknown };
addLayoutFontFamilyFace(faces, fontFamily.ascii, descriptor);
addLayoutFontFamilyFace(faces, fontFamily.hAnsi, descriptor);
```

Word writes the Arabic and Hebrew face into `w:cs` and the CJK face into
`w:eastAsia`. A document that styles those scripts the standard way therefore
had its font ignored by the gate: the first layout measured a Latin fallback,
the painter drew the real face once it loaded, and the two disagreed. The
scripts this hits are precisely the ones whose advances differ most from a
Latin fallback, so it is the worst case rather than a marginal one.

This also means the existing East-Asian font work was measuring against a
fallback on first paint whenever the CJK face was a bundled webfont.

## How it surfaced

Not by inspection. Adding a measure/paint parity oracle in #556 and pointing a
fixture at a bundled Arabic webfont produced a 64px divergence on a 194px line,
which was too large to be a shaping residual and led here.

## Verification

Both new cases were confirmed to **fail without the fix** rather than assumed to
cover it: reverting the two added lines turns them red, restoring it turns them
green.

- `bun --filter @stll/folio-core test`: 4489 pass, 0 fail
- `bun --filter @stll/folio-core typecheck`: clean
- `oxlint`: clean

## Scope

Deliberately just the collection gap. The 2s gate timeout, the
`OFFICE_FONT_FAMILY_MAP` substitution table (which has no entries for
non-Latin faces), and re-layout on late font load are all untouched and are
separate questions.
