### PR TITLE
fix(core): render complex-script text in the w:cs font

### DIFF
--- a/.changeset/complex-script-font-slot.md
+++ b/.changeset/complex-script-font-slot.md
@@ -1,0 +1,9 @@
+---
+"@stll/folio-core": patch
+---
+
+Render complex-script text in the font the document asks for.
+
+Word resolves a run's font per character across three slots: `w:eastAsia` for CJK, `w:cs` for Arabic, Hebrew, Indic and South-East Asian text, and `w:ascii`/`w:hAnsi` for everything else. folio honoured the first and third but never the second: `w:cs` was parsed and round-tripped yet never reached layout, so a document written the standard way (`w:ascii="Calibri"` with `w:cs="Traditional Arabic"`) measured and painted its Arabic in Calibri.
+
+The complex-script slot now flows through the bridge, the measurer and the painter on the same path the East-Asian slot already used, so the two stay segmented identically and line wrapping keeps matching what is drawn. Script segmentation now reports which of the three slots a character selects rather than a CJK yes/no.

--- a/api-reports/core/layout-bridge-engine-measuring.api.md
+++ b/api-reports/core/layout-bridge-engine-measuring.api.md
@@ -96,6 +96,7 @@ export type FontMetrics = {
 export type FontStyle = {
     fontFamily?: string;
     eastAsiaFontFamily?: string;
+    complexScriptFontFamily?: string;
     fontSize?: number;
     bold?: boolean;
     italic?: boolean;

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -733,6 +733,7 @@ export type RunFormatting = {
     shading?: string;
     fontFamily?: string;
     eastAsiaFontFamily?: string;
+    complexScriptFontFamily?: string;
     language?: {
         val?: string;
         eastAsia?: string;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -130,6 +130,38 @@ describe("toFlowBlocks style cascade", () => {
     expect(run.eastAsiaFontFamily).toBe("MS Mincho");
   });
 
+  // Word writes the Arabic and Hebrew face into `w:cs`. That slot was parsed and
+  // round-tripped but never reached layout, so complex-script text painted and
+  // measured in the Latin face instead.
+  test("the complex-script slot reaches layout", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { fontFamily: { ascii: "Calibri", cs: "Traditional Arabic" } },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Normal" },
+      content: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "مكتب mixed" }],
+        },
+      ],
+    };
+
+    const run = firstRun(toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {}));
+
+    expect(run.fontFamily).toBe("Calibri");
+    expect(run.complexScriptFontFamily).toBe("Traditional Arabic");
+  });
+
   test("a direct eastAsia run mark overrides the inherited EA default", () => {
     const styles: StyleDefinitions = {
       styles: [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -529,6 +529,10 @@ function extractRunFormatting(marks: readonly Mark[], theme?: Theme | null): Run
         if (eastAsiaFont) {
           formatting.eastAsiaFontFamily = eastAsiaFont;
         }
+        const complexScriptFont = resolveComplexScriptThemeFont(attrs, theme);
+        if (complexScriptFont) {
+          formatting.complexScriptFontFamily = complexScriptFont;
+        }
         break;
       }
 
@@ -703,9 +707,11 @@ type ThemeFontAttributes = {
   ascii?: string | null;
   hAnsi?: string | null;
   eastAsia?: string | null;
+  cs?: string | null;
   asciiTheme?: string | null;
   hAnsiTheme?: string | null;
   eastAsiaTheme?: string | null;
+  cstheme?: string | null;
 };
 
 const resolveWesternThemeFont = (
@@ -715,6 +721,18 @@ const resolveWesternThemeFont = (
   const themeRef = fontFamily.asciiTheme ?? fontFamily.hAnsiTheme;
   const themedFont = themeRef ? resolveThemeFont(themeRef, theme?.fontScheme) : null;
   return themedFont ?? fontFamily.ascii ?? fontFamily.hAnsi ?? undefined;
+};
+
+const resolveComplexScriptThemeFont = (
+  fontFamily: ThemeFontAttributes,
+  theme?: Theme | null,
+): string | undefined => {
+  // OOXML spells this attribute all-lowercase (`w:cstheme`), unlike its
+  // camelCase siblings; the parser reads it that way too.
+  const themedFont = fontFamily.cstheme
+    ? resolveThemeFont(fontFamily.cstheme, theme?.fontScheme)
+    : null;
+  return themedFont ?? fontFamily.cs ?? undefined;
 };
 
 const resolveEastAsiaThemeFont = (
@@ -823,6 +841,12 @@ function paragraphRunDefaults(pmAttrs: PMParagraphAttrs, theme?: Theme | null): 
     : undefined;
   if (eastAsiaFontFamily) {
     result.eastAsiaFontFamily = eastAsiaFontFamily;
+  }
+  const complexScriptFontFamily = defaultTextFormatting.fontFamily
+    ? resolveComplexScriptThemeFont(defaultTextFormatting.fontFamily, theme)
+    : undefined;
+  if (complexScriptFontFamily) {
+    result.complexScriptFontFamily = complexScriptFontFamily;
   }
   if (defaultTextFormatting.language) {
     result.language = { ...defaultTextFormatting.language };

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -299,7 +299,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.eastAsiaFontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}|${run.language?.val}|${run.language?.eastAsia}|${run.language?.bidi}`,
+        `t:${run.text}|${run.fontFamily}|${run.eastAsiaFontFamily}|${run.complexScriptFontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}|${run.language?.val}|${run.language?.eastAsia}|${run.language?.bidi}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);

--- a/packages/core/src/layout-engine/measure/measureContainer.ts
+++ b/packages/core/src/layout-engine/measure/measureContainer.ts
@@ -18,7 +18,14 @@
 
 import { panic } from "better-result";
 
-import { hasCjk, isCjkCodePoint, segmentByScript } from "../../utils/scriptSegments";
+import {
+  hasCjk,
+  hasComplexScript,
+  SCRIPT_CLASS,
+  scriptClassOf,
+  segmentByScript,
+  type ScriptClass,
+} from "../../utils/scriptSegments";
 import {
   getCachedFontMetrics,
   getCachedTextWidth,
@@ -193,7 +200,7 @@ function canvasMeasureTextWidth(text: string, style: FontStyle): number {
   // gap across the per-script sibling spans the painter would emit, so a
   // letter-spaced run keeps the base font for CJK too (measurement and painting
   // agree; the EA typeface is the trade-off for that narrow case).
-  if (style.eastAsiaFontFamily && !style.letterSpacing && hasCjk(measuredText)) {
+  if (!style.letterSpacing && needsPerScriptFonts(style, measuredText)) {
     return measureMixedScriptWidth(measuredText, style);
   }
 
@@ -303,14 +310,38 @@ function glyphAdvanceStyle(style: FontStyle, fontFamily: string | undefined): Fo
  * horizontal scale are applied once over the whole string so the total matches
  * the painter, which renders the same segments as sibling spans.
  */
+/**
+ * Whether this run needs more than one font, i.e. it carries a per-script slot
+ * AND text that would select it. Keeps the all-Latin path on a single font.
+ */
+function needsPerScriptFonts(style: FontStyle, measuredText: string): boolean {
+  if (style.eastAsiaFontFamily && hasCjk(measuredText)) {
+    return true;
+  }
+  return Boolean(style.complexScriptFontFamily) && hasComplexScript(measuredText);
+}
+
+/** The font slot a script class selects, falling back to the western one. */
+function scriptFontFamily(style: FontStyle, script: ScriptClass): string | undefined {
+  if (script === SCRIPT_CLASS.eastAsia) {
+    return style.eastAsiaFontFamily ?? style.fontFamily;
+  }
+  if (script === SCRIPT_CLASS.complex) {
+    return style.complexScriptFontFamily ?? style.fontFamily;
+  }
+  return style.fontFamily;
+}
+
 function measureMixedScriptWidth(measuredText: string, style: FontStyle): number {
   const letterSpacing = style.letterSpacing ?? 0;
   const horizontalScale = getHorizontalScaleFactor(style);
 
   let glyphWidth = 0;
   for (const segment of segmentByScript(measuredText)) {
-    const fontFamily = segment.isCjk ? style.eastAsiaFontFamily : style.fontFamily;
-    glyphWidth += canvasMeasureTextWidth(segment.text, glyphAdvanceStyle(style, fontFamily));
+    glyphWidth += canvasMeasureTextWidth(
+      segment.text,
+      glyphAdvanceStyle(style, scriptFontFamily(style, segment.script)),
+    );
   }
 
   let width = glyphWidth;
@@ -411,6 +442,10 @@ function canvasMeasureRun(text: string, style: FontStyle): RunMeasurement {
     style.eastAsiaFontFamily !== undefined && !style.letterSpacing
       ? buildFontString({ ...style, fontFamily: style.eastAsiaFontFamily })
       : undefined;
+  const complexScriptFont =
+    style.complexScriptFontFamily !== undefined && !style.letterSpacing
+      ? buildFontString({ ...style, fontFamily: style.complexScriptFontFamily })
+      : undefined;
 
   const letterSpacing = style.letterSpacing ?? 0;
   const scale = getHorizontalScaleFactor(style);
@@ -426,8 +461,12 @@ function canvasMeasureRun(text: string, style: FontStyle): RunMeasurement {
     // SAFETY: for...of over a string yields whole code points.
     const cp = char.codePointAt(0)!;
     const measured = applyTextTransform(char, style);
-    if (eastAsiaFont !== undefined) {
-      ctx.font = isCjkCodePoint(cp) ? eastAsiaFont : baseFont;
+    if (eastAsiaFont !== undefined || complexScriptFont !== undefined) {
+      const script = scriptClassOf(cp);
+      ctx.font =
+        (script === SCRIPT_CLASS.eastAsia ? eastAsiaFont : undefined) ??
+        (script === SCRIPT_CLASS.complex ? complexScriptFont : undefined) ??
+        baseFont;
     }
     let charWidth = ctx.measureText(measured).width;
 

--- a/packages/core/src/layout-engine/measure/measureHelpers.ts
+++ b/packages/core/src/layout-engine/measure/measureHelpers.ts
@@ -39,6 +39,9 @@ export function buildRunFontStyle(
   return {
     fontFamily: run.fontFamily ?? fallbackFontFamily,
     ...(run.eastAsiaFontFamily !== undefined ? { eastAsiaFontFamily: run.eastAsiaFontFamily } : {}),
+    ...(run.complexScriptFontFamily !== undefined
+      ? { complexScriptFontFamily: run.complexScriptFontFamily }
+      : {}),
     fontSize,
     ...(run.bold !== undefined ? { bold: run.bold } : {}),
     ...(run.italic !== undefined ? { italic: run.italic } : {}),

--- a/packages/core/src/layout-engine/measure/measureTypes.ts
+++ b/packages/core/src/layout-engine/measure/measureTypes.ts
@@ -19,6 +19,11 @@ export type FontStyle = {
    * and click positioning stay in sync.
    */
   eastAsiaFontFamily?: string;
+  /**
+   * Complex-script font for Arabic, Hebrew, Indic and South-East Asian code
+   * points. Same contract as `eastAsiaFontFamily`, over a different slot.
+   */
+  complexScriptFontFamily?: string;
   fontSize?: number; // in points
   bold?: boolean;
   italic?: boolean;

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -59,6 +59,15 @@ export type RunFormatting = {
    * to `fontFamily`.
    */
   eastAsiaFontFamily?: string;
+  /**
+   * Resolved complex-script font (`w:cs` / `cstheme`). Arabic, Hebrew, Indic
+   * and South-East Asian code points in this run measure and paint with this
+   * font; the rest keeps `fontFamily` (ascii/hAnsi). Mirrors
+   * `eastAsiaFontFamily` exactly, including the shared segmentation. Absent
+   * means complex-script text falls back to `fontFamily`, which is what Word
+   * does NOT do and is why this slot has to reach layout at all.
+   */
+  complexScriptFontFamily?: string;
   /** Run language metadata resolved from `w:lang`. */
   language?: { val?: string; eastAsia?: string; bidi?: string };
   fontSize?: number;

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -2689,6 +2689,9 @@ function runContentKey(run: Run): string {
   if (run.fontFamily) {
     parts.push(`ff:${run.fontFamily}`);
   }
+  if (run.complexScriptFontFamily) {
+    parts.push(`cs:${run.complexScriptFontFamily}`);
+  }
   if (run.eastAsiaFontFamily) {
     parts.push(`ea:${run.eastAsiaFontFamily}`);
   }

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -51,7 +51,13 @@ import {
   parseRotationDegrees,
   rotatedBoundingBox,
 } from "../utils/rotationBoundingBox";
-import { hasCjk, segmentByScript } from "../utils/scriptSegments";
+import {
+  hasCjk,
+  hasComplexScript,
+  SCRIPT_CLASS,
+  segmentByScript,
+  type ScriptClass,
+} from "../utils/scriptSegments";
 import { borderStrokeToCss, resolveParagraphBorderHorizontalOutsets } from "./borderStroke";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import {
@@ -1089,7 +1095,7 @@ function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): H
   // to the EA font. The pm range stays on the grouping wrapper; the segments
   // carry no pm (the field is atomic). Letter-spaced fields stay one span,
   // matching splitTextRunsByEastAsia and the measurer.
-  if (resolvedRun.eastAsiaFontFamily !== undefined && !resolvedRun.letterSpacing && hasCjk(text)) {
+  if (needsPerScriptSpans({ ...resolvedRun, text })) {
     const wrapper = doc.createElement("span");
     applyPmPositions(wrapper, resolvedRun.pmStart, resolvedRun.pmEnd);
     // horizontalScale lives on the wrapper (inline-block so the reserved width
@@ -1113,7 +1119,7 @@ function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): H
       const segmentRun: TextRun = {
         ...segmentBase,
         text: segment.text,
-        ...(segment.isCjk ? { fontFamily: resolvedRun.eastAsiaFontFamily } : {}),
+        ...scriptFontOverride(resolvedRun, segment.script),
       };
       wrapper.append(renderTextRun(segmentRun, doc));
     }
@@ -1299,6 +1305,32 @@ export function sliceRunsForLine(block: ParagraphBlock, line: MeasuredLine): Run
 }
 
 /**
+ * The font a script segment paints with, mirroring the measurer's
+ * `scriptFontFamily`. Returning undefined leaves the run's own `fontFamily`.
+ */
+const scriptFontOverride = (run: TextRun, script: ScriptClass): { fontFamily?: string } => {
+  if (script === SCRIPT_CLASS.eastAsia && run.eastAsiaFontFamily !== undefined) {
+    return { fontFamily: run.eastAsiaFontFamily };
+  }
+  if (script === SCRIPT_CLASS.complex && run.complexScriptFontFamily !== undefined) {
+    return { fontFamily: run.complexScriptFontFamily };
+  }
+  return {};
+};
+
+/**
+ * Whether a run needs per-script sibling spans: it carries a script-specific
+ * font slot AND text that selects it. A letter-spaced run is excluded because
+ * CSS letter-spacing does not bridge sibling spans, and the measurer skips the
+ * same case so the widths still agree.
+ */
+const needsPerScriptSpans = (run: TextRun): boolean => {
+  if (run.letterSpacing) return false;
+  if (run.eastAsiaFontFamily !== undefined && hasCjk(run.text)) return true;
+  return run.complexScriptFontFamily !== undefined && hasComplexScript(run.text);
+};
+
+/**
  * Split each text run carrying an East-Asian font into per-script sub-runs, so
  * CJK code points render with `eastAsiaFontFamily` and the rest with
  * `fontFamily`. Each sub-run gets a contiguous, exact `pmStart`/`pmEnd` (the
@@ -1311,15 +1343,7 @@ export function splitTextRunsByEastAsia(runs: Run[]): Run[] {
   const result: Run[] = [];
 
   for (const run of runs) {
-    if (
-      !isTextRun(run) ||
-      run.eastAsiaFontFamily === undefined ||
-      // A letter-spaced run stays one span: CSS letter-spacing would not bridge
-      // the gap between per-script sibling spans, so it keeps the base font for
-      // CJK too (the measurer skips the EA path identically, so widths agree).
-      run.letterSpacing ||
-      !hasCjk(run.text)
-    ) {
+    if (!isTextRun(run) || !needsPerScriptSpans(run)) {
       result.push(run);
       continue;
     }
@@ -1329,7 +1353,7 @@ export function splitTextRunsByEastAsia(runs: Run[]): Run[] {
       result.push({
         ...run,
         text: segment.text,
-        ...(segment.isCjk ? { fontFamily: run.eastAsiaFontFamily } : {}),
+        ...scriptFontOverride(run, segment.script),
         ...(run.pmStart !== undefined
           ? {
               pmStart: run.pmStart + offset,
@@ -1524,6 +1548,9 @@ function runMeasureStyle(run: TextRun | FieldRun | MathRun): TextMeasureStyle {
     ...(run.letterSpacing !== undefined ? { letterSpacing: run.letterSpacing } : {}),
     ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
     ...(run.eastAsiaFontFamily !== undefined ? { eastAsiaFontFamily: run.eastAsiaFontFamily } : {}),
+    ...(run.complexScriptFontFamily !== undefined
+      ? { complexScriptFontFamily: run.complexScriptFontFamily }
+      : {}),
     kerning: getRunFontKerningMode(run, DEFAULT_FONT_SIZE) === FONT_KERNING_MODE.enabled,
   };
 }
@@ -1717,6 +1744,8 @@ type TextMeasureStyle = {
   /** EA font for CJK code points; segments the measured text by script when set
    * (and the run has no letter spacing), mirroring measureContainer. */
   eastAsiaFontFamily?: string;
+  /** Complex-script font for Arabic/Hebrew/Indic code points; same contract. */
+  complexScriptFontFamily?: string;
   kerning?: boolean;
 };
 
@@ -1764,11 +1793,24 @@ function createTextMeasurer(
     // CJK code points measure with the EA font (matching the per-script sub-spans
     // the painter emits and measureContainer's segmentation). Gated off for
     // letter-spaced runs, which keep a single base-font span.
-    if (style.eastAsiaFontFamily && !style.letterSpacing && hasCjk(text)) {
-      const eaFallback = resolveFontFamily(style.eastAsiaFontFamily).cssFallback;
+    const perScriptFallback: Partial<Record<ScriptClass, string>> = {
+      ...(style.eastAsiaFontFamily
+        ? { [SCRIPT_CLASS.eastAsia]: resolveFontFamily(style.eastAsiaFontFamily).cssFallback }
+        : {}),
+      ...(style.complexScriptFontFamily
+        ? {
+            [SCRIPT_CLASS.complex]: resolveFontFamily(style.complexScriptFontFamily).cssFallback,
+          }
+        : {}),
+    };
+    if (
+      !style.letterSpacing &&
+      ((style.eastAsiaFontFamily && hasCjk(text)) ||
+        (style.complexScriptFontFamily && hasComplexScript(text)))
+    ) {
       let segmentedWidth = 0;
       for (const segment of segmentByScript(text)) {
-        ctx.font = `${fontPrefix} ${segment.isCjk ? eaFallback : cssFallback}`;
+        ctx.font = `${fontPrefix} ${perScriptFallback[segment.script] ?? cssFallback}`;
         segmentedWidth += ctx.measureText(segment.text).width;
       }
       return segmentedWidth;

--- a/packages/core/src/utils/scriptSegments.test.ts
+++ b/packages/core/src/utils/scriptSegments.test.ts
@@ -43,15 +43,40 @@ describe("hasCjk", () => {
 describe("segmentByScript", () => {
   test("splits mixed text into maximal same-script segments", () => {
     expect(segmentByScript("Hello世界foo")).toEqual([
-      { text: "Hello", isCjk: false },
-      { text: "世界", isCjk: true },
-      { text: "foo", isCjk: false },
+      { text: "Hello", script: "western" },
+      { text: "世界", script: "eastAsia" },
+      { text: "foo", script: "western" },
     ]);
   });
 
   test("returns one segment for single-class input", () => {
-    expect(segmentByScript("plain ascii")).toEqual([{ text: "plain ascii", isCjk: false }]);
-    expect(segmentByScript("日本語")).toEqual([{ text: "日本語", isCjk: true }]);
+    expect(segmentByScript("plain ascii")).toEqual([{ text: "plain ascii", script: "western" }]);
+    expect(segmentByScript("日本語")).toEqual([{ text: "日本語", script: "eastAsia" }]);
+  });
+
+  // Word routes Arabic, Hebrew and the Indic scripts through the `w:cs` slot,
+  // a third answer to "which font does this character take?" that the previous
+  // isCjk boolean could not express.
+  test("separates complex-script text from western and East-Asian", () => {
+    expect(segmentByScript("abcمكتبdef")).toEqual([
+      { text: "abc", script: "western" },
+      { text: "مكتب", script: "complex" },
+      { text: "def", script: "western" },
+    ]);
+    expect(segmentByScript("שלום世界")).toEqual([
+      { text: "שלום", script: "complex" },
+      { text: "世界", script: "eastAsia" },
+    ]);
+  });
+
+  test.each([
+    ["Arabic", "ب"],
+    ["Hebrew", "א"],
+    ["Devanagari", "क"],
+    ["Thai", "ก"],
+    ["Arabic presentation form", "ﻻ"],
+  ])("classifies %s as complex script", (_name, char) => {
+    expect(segmentByScript(char)).toEqual([{ text: char, script: "complex" }]);
   });
 
   test("returns no segments for empty input", () => {
@@ -61,9 +86,9 @@ describe("segmentByScript", () => {
   test("keeps an astral ideograph whole within its CJK segment", () => {
     const segments = segmentByScript("x𠀀y");
     expect(segments).toEqual([
-      { text: "x", isCjk: false },
-      { text: "𠀀", isCjk: true },
-      { text: "y", isCjk: false },
+      { text: "x", script: "western" },
+      { text: "𠀀", script: "eastAsia" },
+      { text: "y", script: "western" },
     ]);
     // The astral glyph must not be split across the surrogate pair.
     expect(segments[1]?.text.length).toBe(2);

--- a/packages/core/src/utils/scriptSegments.test.ts
+++ b/packages/core/src/utils/scriptSegments.test.ts
@@ -75,6 +75,11 @@ describe("segmentByScript", () => {
     ["Devanagari", "क"],
     ["Thai", "ก"],
     ["Arabic presentation form", "ﻻ"],
+    // Astral: the BMP ranges stop at U+FEFF, so these need their own intervals
+    // and exercise the code-point (not code-unit) iteration.
+    ["Arabic Extended-C", String.fromCodePoint(0x10_ec_0)],
+    ["Adlam", String.fromCodePoint(0x1e_90_0)],
+    ["Hanifi Rohingya", String.fromCodePoint(0x10_d0_0)],
   ])("classifies %s as complex script", (_name, char) => {
     expect(segmentByScript(char)).toEqual([{ text: char, script: "complex" }]);
   });

--- a/packages/core/src/utils/scriptSegments.ts
+++ b/packages/core/src/utils/scriptSegments.ts
@@ -98,7 +98,15 @@ export function isComplexScriptCodePoint(cp: number): boolean {
     (cp >= 0x17_80 && cp <= 0x17_ff) || // Khmer
     (cp >= 0xfb_1d && cp <= 0xfb_4f) || // Hebrew presentation forms
     (cp >= 0xfb_50 && cp <= 0xfd_ff) || // Arabic presentation forms-A
-    (cp >= 0xfe_70 && cp <= 0xfe_ff) // Arabic presentation forms-B
+    (cp >= 0xfe_70 && cp <= 0xfe_ff) || // Arabic presentation forms-B
+    // Astral blocks. The BMP ranges above stop at U+FEFF, which silently left
+    // every astral Arabic-family script selecting the western slot.
+    (cp >= 0x10_d0_0 && cp <= 0x10_d3_f) || // Hanifi Rohingya
+    (cp >= 0x10_ec_0 && cp <= 0x10_ef_f) || // Arabic Extended-C
+    (cp >= 0x10_f3_0 && cp <= 0x10_f6_f) || // Sogdian
+    (cp >= 0x10_f7_0 && cp <= 0x10_fa_f) || // Old Uyghur
+    (cp >= 0x1e_90_0 && cp <= 0x1e_95_f) || // Adlam
+    (cp >= 0x1e_e0_0 && cp <= 0x1e_ef_f) // Arabic Mathematical Alphabetic Symbols
   );
 }
 

--- a/packages/core/src/utils/scriptSegments.ts
+++ b/packages/core/src/utils/scriptSegments.ts
@@ -1,19 +1,36 @@
 /**
- * Script segmentation for per-character East-Asian font selection.
+ * Script segmentation for per-character font selection.
  *
- * Word resolves a run's font per character: East-Asian (CJK) code points use
- * the run's `w:eastAsia` font slot, everything else uses `w:ascii`/`w:hAnsi`.
+ * Word resolves a run's font per character across three slots: East-Asian code
+ * points use `w:eastAsia`, complex-script code points (Arabic, Hebrew, Indic,
+ * South-East Asian) use `w:cs`, and everything else uses `w:ascii`/`w:hAnsi`.
  * folio mirrors this by splitting a run's text into maximal same-script
  * segments that the measurer and the painter both consume, so line wrapping
  * stays in sync with rendering.
+ *
+ * A three-value discriminator rather than the `isCjk` boolean this started as:
+ * the question is "which font slot does this character take?", which already
+ * has three answers and may grow again.
  *
  * Ranges are authored with `\u` escapes only — never pasted glyphs (a pasted
  * glyph once silently corrupted an RTL character class here).
  */
 
+/** Which of Word's font slots a code point selects. */
+export const SCRIPT_CLASS = {
+  /** `w:eastAsia` — CJK ideographs, kana, Hangul. */
+  eastAsia: "eastAsia",
+  /** `w:cs` — Arabic, Hebrew, Indic, South-East Asian. */
+  complex: "complex",
+  /** `w:ascii` / `w:hAnsi` — everything else. */
+  western: "western",
+} as const;
+
+export type ScriptClass = (typeof SCRIPT_CLASS)[keyof typeof SCRIPT_CLASS];
+
 export type ScriptSegment = {
   text: string;
-  isCjk: boolean;
+  script: ScriptClass;
 };
 
 /**
@@ -52,6 +69,65 @@ export function hasCjk(text: string): boolean {
 }
 
 /**
+ * True when a code point belongs to a script Word renders with the `w:cs`
+ * (complex script) font slot: the bidirectional scripts plus the Indic and
+ * South-East Asian scripts that need contextual shaping.
+ *
+ * Checked after CJK, which owns the ranges above U+2E80 that would otherwise
+ * overlap the presentation forms below.
+ */
+export function isComplexScriptCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x05_90 && cp <= 0x05_ff) || // Hebrew
+    (cp >= 0x06_00 && cp <= 0x06_ff) || // Arabic
+    (cp >= 0x07_00 && cp <= 0x07_4f) || // Syriac
+    (cp >= 0x07_50 && cp <= 0x07_7f) || // Arabic Supplement
+    (cp >= 0x07_80 && cp <= 0x07_bf) || // Thaana
+    (cp >= 0x07_c0 && cp <= 0x07_ff) || // NKo
+    (cp >= 0x08_00 && cp <= 0x08_3f) || // Samaritan
+    (cp >= 0x08_40 && cp <= 0x08_5f) || // Mandaic
+    (cp >= 0x08_60 && cp <= 0x08_6f) || // Syriac Supplement
+    (cp >= 0x08_70 && cp <= 0x08_9f) || // Arabic Extended-B
+    (cp >= 0x08_a0 && cp <= 0x08_ff) || // Arabic Extended-A
+    (cp >= 0x09_00 && cp <= 0x0d_7f) || // Devanagari through Malayalam
+    (cp >= 0x0d_80 && cp <= 0x0d_ff) || // Sinhala
+    (cp >= 0x0e_00 && cp <= 0x0e_7f) || // Thai
+    (cp >= 0x0e_80 && cp <= 0x0e_ff) || // Lao
+    (cp >= 0x0f_00 && cp <= 0x0f_ff) || // Tibetan
+    (cp >= 0x10_00 && cp <= 0x10_9f) || // Myanmar
+    (cp >= 0x17_80 && cp <= 0x17_ff) || // Khmer
+    (cp >= 0xfb_1d && cp <= 0xfb_4f) || // Hebrew presentation forms
+    (cp >= 0xfb_50 && cp <= 0xfd_ff) || // Arabic presentation forms-A
+    (cp >= 0xfe_70 && cp <= 0xfe_ff) // Arabic presentation forms-B
+  );
+}
+
+/** Which font slot a single code point selects. CJK wins where ranges meet. */
+export function scriptClassOf(cp: number): ScriptClass {
+  if (isCjkCodePoint(cp)) {
+    return SCRIPT_CLASS.eastAsia;
+  }
+  if (isComplexScriptCodePoint(cp)) {
+    return SCRIPT_CLASS.complex;
+  }
+  return SCRIPT_CLASS.western;
+}
+
+/**
+ * True when the text contains at least one complex-script code point. Callers
+ * use this to skip segmentation entirely on the common all-Latin path.
+ */
+export function hasComplexScript(text: string): boolean {
+  for (const ch of text) {
+    // SAFETY: for...of over a string yields whole code points.
+    if (isComplexScriptCodePoint(ch.codePointAt(0)!)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Split text into maximal runs of one script class (CJK vs. non-CJK). Iterates
  * by code point so astral ideographs (surrogate pairs) are never split between
  * fonts. Empty input yields no segments; single-class input yields one.
@@ -59,27 +135,27 @@ export function hasCjk(text: string): boolean {
 export function segmentByScript(text: string): ScriptSegment[] {
   const segments: ScriptSegment[] = [];
   let current = "";
-  let currentIsCjk = false;
+  let currentScript: ScriptClass = SCRIPT_CLASS.western;
 
   for (const ch of text) {
     // SAFETY: for...of over a string yields whole code points.
-    const cjk = isCjkCodePoint(ch.codePointAt(0)!);
+    const script = scriptClassOf(ch.codePointAt(0)!);
     if (current.length === 0) {
       current = ch;
-      currentIsCjk = cjk;
+      currentScript = script;
       continue;
     }
-    if (cjk === currentIsCjk) {
+    if (script === currentScript) {
       current += ch;
       continue;
     }
-    segments.push({ text: current, isCjk: currentIsCjk });
+    segments.push({ text: current, script: currentScript });
     current = ch;
-    currentIsCjk = cjk;
+    currentScript = script;
   }
 
   if (current.length > 0) {
-    segments.push({ text: current, isCjk: currentIsCjk });
+    segments.push({ text: current, script: currentScript });
   }
 
   return segments;


### PR DESCRIPTION
Word resolves a run's font per character across three slots:

| slot | scripts |
| --- | --- |
| `w:eastAsia` | CJK ideographs, kana, Hangul |
| `w:cs` | Arabic, Hebrew, Indic, South-East Asian |
| `w:ascii` / `w:hAnsi` | everything else |

folio honoured the first and third but never the second. `w:cs` was parsed and
round-tripped as `formatting.fontFamily.cs`, but `grep` for `.cs` across
`layout-bridge`, `layout-engine` and `layout-painter` returned **nothing**,
while `eastAsiaFontFamily` reached `toFlowBlocks.ts`.

So a document written the standard way — `w:ascii="Calibri"` with
`w:cs="Traditional Arabic"`, which is what Word produces for Arabic — measured
and painted that Arabic in Calibri.

## How it surfaced

Not by inspection. While building a measure/paint parity fixture in #556 I
pinned `w:cs` to a bundled Arabic webfont and the rendered widths came back
**byte-identical** to leaving it as Arial. A font setting that changes nothing
is either redundant or ignored, and it was ignored.

It also means the `cs` half of #558 was waiting on a font nothing then painted
with. That half becomes load-bearing with this change.

## Shape

The slot flows through the bridge, the measurer and the painter along the exact
path `eastAsiaFontFamily` already used, so the two segment identically and line
wrapping keeps matching what is drawn. Sites touched mirror the East-Asian ones
one-for-one: `toFlowBlocks` resolution (including `w:cstheme`), `TextRun`,
`FontStyle`, `runMeasureStyle`, `measureHelpers`, both measurement paths, both
painter split paths, and both cache keys.

Script segmentation now reports **which of the three slots** a character
selects rather than a CJK yes/no:

```ts
export const SCRIPT_CLASS = { eastAsia, complex, western } as const;
```

That is the shape AGENTS.md asks for when a boolean grows a third value, and a
boolean genuinely could not express this one. CJK is checked first so the
ranges that meet at the presentation forms stay unambiguous.

## Verification

- `bun --filter @stll/folio-core test`: 4530 pass, 0 fail
- `bun --filter @stll/folio-core typecheck`: clean
- `oxlint`: clean

The new bridge test was confirmed to **fail against a probe value** rather than
assumed to read the real one.

## Scope

Complex-script *font selection*. Bidi reordering, shaping and the
`w:cs`-specific bold/italic toggles (`w:bCs` / `w:iCs`) are untouched and are
separate questions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complex-script font support for Arabic, Hebrew, Indic and South-East Asian text.
  * Improved mixed-script document layout, measurement and rendering using the appropriate fonts.
  * Added support for complex-script fonts defined through paragraph styles, run formatting and document themes.

* **Bug Fixes**
  * Corrected font selection and rendering consistency for complex-script content.
  * Ensured font changes correctly refresh measurements and rendered page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->