### PR TITLE
fix(core): gate first layout on the resolved font stack, not authored names

### DIFF
--- a/.changeset/font-readiness-resolved-stack.md
+++ b/.changeset/font-readiness-resolved-stack.md
@@ -1,0 +1,9 @@
+---
+"@stll/folio-core": patch
+---
+
+Wait for the fonts the renderer actually uses, not just the names the document wrote.
+
+`resolveFontFamily` turns an authored family into a CSS stack that appends folio's bundled metric-compatible substitutes and a script fallback, so an authored `Arial` run paints its Arabic in the bundled Arabic face. The font-readiness gate collected only authored names, so it released the first layout before those faces had loaded; measurement taken against the pre-load fallback then disagreed with what was ultimately painted, by as much as a third of a line's width.
+
+The gate now expands each family through the resolver and waits for every concrete face in the stack. That also removes a hand-kept substitute table which duplicated the resolver's own mapping and was free to drift from it.

--- a/packages/core/src/controller/fontReadiness.test.ts
+++ b/packages/core/src/controller/fontReadiness.test.ts
@@ -129,6 +129,30 @@ describe("initial layout font loading", () => {
     expect(collectInitialLayoutFontFamilies(null, pmDoc)).toContain(family);
   });
 
+  // The 64px measure/paint divergence this fixed: every resolved stack ends with
+  // folio's bundled Arabic face, so an authored "Arial" run paints its Arabic in
+  // that face. Waiting only for authored names released the first layout before
+  // it had loaded, and the measurement taken then disagreed with what was drawn.
+  test("waits for the substitutes and fallbacks the renderer actually uses", () => {
+    const fontFamily = schema.marks["fontFamily"]?.create({ ascii: "Arial", hAnsi: "Arial" });
+    if (!fontFamily) {
+      throw new Error("Expected a fontFamily mark in schema");
+    }
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("text", [fontFamily])]),
+    ]);
+
+    const families = collectInitialLayoutFontFamilies(null, pmDoc);
+
+    // The authored name, its metric-compatible substitute, and the script
+    // fallback the resolver appends.
+    expect(families).toContain("Arial");
+    expect(families).toContain("Arimo");
+    expect(families).toContain("Noto Sans Arabic");
+    // Generic CSS families are not loadable faces and must not be requested.
+    expect(families).not.toContain("sans-serif");
+  });
+
   test("always includes the default layout font family for a null document model", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("plain")]),

--- a/packages/core/src/controller/fontReadiness.test.ts
+++ b/packages/core/src/controller/fontReadiness.test.ts
@@ -153,6 +153,22 @@ describe("initial layout font loading", () => {
     expect(families).not.toContain("sans-serif");
   });
 
+  test("a quoted stack entry containing a comma stays one family", () => {
+    const fontFamily = schema.marks["fontFamily"]?.create({ ascii: "Foo, Bar", hAnsi: "Foo, Bar" });
+    if (!fontFamily) {
+      throw new Error("Expected a fontFamily mark in schema");
+    }
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("text", [fontFamily])]),
+    ]);
+
+    const families = collectInitialLayoutFontFamilies(null, pmDoc);
+
+    expect(families).toContain("Foo, Bar");
+    expect(families).not.toContain("Foo");
+    expect(families).not.toContain("Bar");
+  });
+
   test("always includes the default layout font family for a null document model", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("plain")]),

--- a/packages/core/src/controller/fontReadiness.ts
+++ b/packages/core/src/controller/fontReadiness.ts
@@ -13,6 +13,7 @@ import type { Mark, Node as PMNode } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 
 import { expectFontFamilyMarkAttrs } from "../prosemirror/attrs";
+import { resolveFontFamily } from "../utils/fontResolver";
 import type { Document, TextFormatting } from "../types/document";
 
 export function getDocumentFontSet(): FontFaceSet | null {
@@ -29,15 +30,6 @@ export function documentFontsAreLoaded(): boolean {
 
 const INITIAL_LAYOUT_FONT_TIMEOUT_MS = 2000;
 const DEFAULT_LAYOUT_FONT_FAMILY = "Calibri";
-const OFFICE_FONT_FAMILY_MAP: Record<string, string> = {
-  Aptos: "Lato",
-  "Aptos Display": "Lato",
-  Arial: "Arimo",
-  Calibri: "Carlito",
-  Cambria: "Caladea",
-  "Times New Roman": "Tinos",
-  "Courier New": "Cousine",
-};
 const CSS_GENERIC_FONT_FAMILIES = new Set([
   "serif",
   "sans-serif",
@@ -259,10 +251,38 @@ function addLayoutFontFamilyNameFace(
   }
 
   addLayoutFontFace(faces, normalized, descriptor);
-  const mappedFamily = OFFICE_FONT_FAMILY_MAP[normalized];
-  if (mappedFamily) {
-    addLayoutFontFace(faces, mappedFamily, descriptor);
+
+  // Wait for the whole stack the renderer will actually use, not just the name
+  // the document wrote. `resolveFontFamily` appends folio's bundled substitutes
+  // and a script fallback, so an authored "Arial" run paints its Arabic in the
+  // bundled Arabic face. Collecting only authored names meant the gate released
+  // the first layout before that face had loaded, and measurement taken against
+  // the pre-load fallback disagreed with what was ultimately painted.
+  //
+  // Derived rather than listed: a hand-kept table of substitutes would be a
+  // second copy of the resolver's mapping, free to drift from it.
+  for (const stackFamily of resolvedStackFamilies(normalized)) {
+    addLayoutFontFace(faces, stackFamily, descriptor);
   }
+}
+
+/**
+ * The concrete families in a resolved CSS font stack, generics dropped.
+ *
+ * Parsed from the stack rather than read from a map because the stack is what
+ * the painter and the measurer put in `ctx.font` and `style.fontFamily`.
+ */
+function resolvedStackFamilies(family: string): string[] {
+  const { cssFallback } = resolveFontFamily(family);
+  const families: string[] = [];
+  for (const entry of cssFallback.split(",")) {
+    const name = entry.trim().replace(/^["']|["']$/gu, "");
+    if (!name || CSS_GENERIC_FONT_FAMILIES.has(name)) {
+      continue;
+    }
+    families.push(name);
+  }
+  return families;
 }
 
 function addLayoutFontFace(

--- a/packages/core/src/controller/fontReadiness.ts
+++ b/packages/core/src/controller/fontReadiness.ts
@@ -13,7 +13,7 @@ import type { Mark, Node as PMNode } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 
 import { expectFontFamilyMarkAttrs } from "../prosemirror/attrs";
-import { resolveFontFamily } from "../utils/fontResolver";
+import { parseFontFamilyList, resolveFontFamily } from "../utils/fontResolver";
 import type { Document, TextFormatting } from "../types/document";
 
 export function getDocumentFontSet(): FontFaceSet | null {
@@ -274,15 +274,7 @@ function addLayoutFontFamilyNameFace(
  */
 function resolvedStackFamilies(family: string): string[] {
   const { cssFallback } = resolveFontFamily(family);
-  const families: string[] = [];
-  for (const entry of cssFallback.split(",")) {
-    const name = entry.trim().replace(/^["']|["']$/gu, "");
-    if (!name || CSS_GENERIC_FONT_FAMILIES.has(name)) {
-      continue;
-    }
-    families.push(name);
-  }
-  return families;
+  return parseFontFamilyList(cssFallback).filter((name) => !CSS_GENERIC_FONT_FAMILIES.has(name));
 }
 
 function addLayoutFontFace(

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -8,6 +8,7 @@ import {
   getGoogleFontsToLoad,
   hasGoogleFontEquivalent,
   isCjkFont,
+  parseFontFamilyList,
   resolveFontFamily,
   setEmbeddedFontFamilyMap,
   setGoogleFontsEnabled,
@@ -369,5 +370,28 @@ describe("fontResolver — untrusted family names are quoted safely", () => {
     expect(cssFallback).toContain("\\a ");
     expect(cssFallback).toContain("\\d ");
     expect(cssFallback).toContain("\\c ");
+  });
+});
+
+describe("fontResolver — parseFontFamilyList inverts the emitted quoting", () => {
+  // Names the resolver must quote: commas, quotes, backslashes, and the
+  // characters `escapeQuotedFontName` hex-escapes. Each round-trips through the
+  // resolved stack as one family, so a comma inside a quoted name never splits
+  // the list (which would leave the gate waiting on faces that do not exist and
+  // never on the one that does).
+  const authored = ["Foo, Bar", 'Say "Hi"', "Back\\slash", "a\nb\rc\fd", "Plain Sans"];
+
+  test.each(authored)("%j survives resolve -> parse as the first stack entry", (name) => {
+    expect(name).not.toBe(resolveFontFamily(name).cssFallback);
+    expect(parseFontFamilyList(resolveFontFamily(name).cssFallback).at(0)).toBe(name);
+  });
+
+  test("keeps every stack entry and drops nothing but whitespace", () => {
+    const { cssFallback } = resolveFontFamily("Foo, Bar");
+    const families = parseFontFamilyList(cssFallback);
+    // The quoted primary plus each comma-separated fallback, generics included.
+    expect(families.length).toBe(cssFallback.split(",").length - 1);
+    expect(families.at(-1)).toBe("sans-serif");
+    expect(families).not.toContain("Foo");
   });
 });

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -379,7 +379,7 @@ describe("fontResolver — parseFontFamilyList inverts the emitted quoting", () 
   // resolved stack as one family, so a comma inside a quoted name never splits
   // the list (which would leave the gate waiting on faces that do not exist and
   // never on the one that does).
-  const authored = ["Foo, Bar", 'Say "Hi"', "Back\\slash", "a\nb\rc\fd", "Plain Sans"];
+  const authored = ["Foo, Bar", 'Say "Hi"', "Back\\slash", "a\nb\rc\fd", " Foo ", "Plain Sans"];
 
   test.each(authored)("%j survives resolve -> parse as the first stack entry", (name) => {
     expect(name).not.toBe(resolveFontFamily(name).cssFallback);

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -859,18 +859,25 @@ export function parseFontFamilyList(list: string): string[] {
   const families: string[] = [];
   let current = "";
   let quote: '"' | "'" | null = null;
+  // Set once an entry's quoted content has been read: separator whitespace
+  // around the quotes is not content, whereas whitespace inside them is.
+  let quoted = false;
   const push = () => {
-    const name = current.trim();
+    const name = quoted ? current : current.trim();
     if (name) {
       families.push(name);
     }
     current = "";
+    quoted = false;
   };
   for (let index = 0; index < list.length; index += 1) {
     const char = list[index]!; // SAFETY: index < list.length
     if (quote === null) {
       if (char === ",") {
         push();
+      } else if (quoted) {
+        // Only separator whitespace may follow a closing quote.
+        continue;
       } else if ((char === '"' || char === "'") && current.trim() === "") {
         quote = char;
         current = "";
@@ -881,6 +888,7 @@ export function parseFontFamilyList(list: string): string[] {
     }
     if (char === quote) {
       quote = null;
+      quoted = true;
       continue;
     }
     if (char !== "\\") {

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -843,6 +843,70 @@ function quoteFontName(fontName: string): string {
   return fontName;
 }
 
+const CSS_NEWLINE_UNESCAPES: Record<string, string> = {
+  a: "\n",
+  d: "\r",
+  c: "\f",
+};
+
+/**
+ * Split a CSS `font-family` list built by `quoteFontName` back into family
+ * names: the inverse of the quoting and escaping applied there. Quoted entries
+ * may contain commas, quotes (backslash-escaped), and the newline escapes
+ * `escapeQuotedFontName` emits; unquoted entries end at the next comma.
+ */
+export function parseFontFamilyList(list: string): string[] {
+  const families: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  const push = () => {
+    const name = current.trim();
+    if (name) {
+      families.push(name);
+    }
+    current = "";
+  };
+  for (let index = 0; index < list.length; index += 1) {
+    const char = list[index]!; // SAFETY: index < list.length
+    if (quote === null) {
+      if (char === ",") {
+        push();
+      } else if ((char === '"' || char === "'") && current.trim() === "") {
+        quote = char;
+        current = "";
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === quote) {
+      quote = null;
+      continue;
+    }
+    if (char !== "\\") {
+      current += char;
+      continue;
+    }
+    const escaped = list[index + 1];
+    if (escaped === undefined) {
+      continue;
+    }
+    index += 1;
+    const newline = CSS_NEWLINE_UNESCAPES[escaped];
+    if (newline === undefined) {
+      current += escaped;
+      continue;
+    }
+    current += newline;
+    // The escape is terminated by one optional space, which is not content.
+    if (list[index + 1] === " ") {
+      index += 1;
+    }
+  }
+  push();
+  return families;
+}
+
 /**
  * Resolve a theme font reference to actual font names
  *


### PR DESCRIPTION
Root cause of the measure/paint divergence the parity oracle in #556 found: a
repaired Arabic line measured **194px** and painted **259px**, a third of the
line.

## Why

`resolveFontFamily` expands an authored family into a CSS stack that appends
folio's bundled metric-compatible substitutes *and* a script fallback:

```
Arial              -> Arial, Arimo, Helvetica, "Noto Sans Arabic", sans-serif
Calibri            -> Calibri, Carlito, Arial, Helvetica, "Noto Sans Arabic", sans-serif
Traditional Arabic -> "Traditional Arabic", Arial, Helvetica, "Noto Sans Arabic", sans-serif
```

Every stack ends with the bundled Arabic face. So an authored `Arial` run does
not paint its Arabic in Arial or in Arimo — it paints in **Noto Sans Arabic**,
which is a webfont that has to load.

The readiness gate collected only the families the document *names*. It waited
for Arial, released the first layout, and the measurer measured whatever Arabic
face the OS supplied through `sans-serif`. The webfont then loaded and the
painter drew that instead. Two faces, two sets of advances, one layout computed
from the wrong one.

This is not Arabic-specific in principle — it is any authored family whose
resolved stack contains a not-yet-loaded bundled face — but Arabic is where it
bites hardest, because the fallback face differs most from a Latin one.

## What changed

The gate now expands each collected family through the resolver and waits for
every concrete face in the stack, generics excluded.

That also retires `OFFICE_FONT_FAMILY_MAP`, a hand-kept table of Office→bundled
substitutions that duplicated the resolver's own mapping and was free to drift
from it. The stack is now the single source of truth, which is the point: the
gate waits for exactly what `ctx.font` and `style.fontFamily` will be set to.

## Verification

- `bun --filter @stll/folio-core test`: 4534 pass, 0 fail
- `bun --filter @stll/folio-core typecheck`, `oxlint`, `api:check`: clean

## Scope

Only which faces the gate waits for. The 2s timeout and the absence of
re-layout on a *late* font load are untouched, and one further gap is worth
noting separately: embedded fonts register under a scoped
`folio-embedded-{nonce}-{name}` family, and the gate still requests their raw
DOCX name, so it waits on a family that is never registered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial layout font readiness by recognising authored fonts, compatible substitutes and script-specific fallbacks.
  * Excluded generic CSS font families from readiness checks to avoid unnecessary waiting.
  * Improved handling of quoted, escaped and comma-containing font-family names.

* **Tests**
  * Added coverage for resolved CSS font stacks, fallback preservation and accurate family-name parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->