### PR TITLE
ci: allowlist the provenance updater for the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,6 +32,8 @@ jobs:
       )
     uses: stella/.github/.github/workflows/cla.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     with:
-      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],cursoragent
+      # Automation accounts cannot sign a CLA, so any app that opens PRs here
+      # has to be listed or its every PR fails the check permanently.
+      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],stella-provenance-updater[bot],cursoragent
     secrets:
       CLA_APP_PRIVATE_KEY: ${{ secrets.CLA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
PR #561 is red, and the only failing check is `cla / cla`:

```
##[error]Committers of Pull Request number 561 have to sign the CLA
```

Every other check on it passes. The committer is `stella-provenance-updater[bot]`, which is not in the allowlist:

```
allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],cursoragent
```

An automation account has no way to sign a CLA, so this is not a transient failure: every PR that app opens fails the check permanently, and #561 cannot go green without either this change or an admin override.

Adds it alongside the other bots that already carry the exemption.

Unblocks #561 (`chore(deps): remove expired quarantine excludes`, 0 additions / 1 deletion) and any future PR from the same app.