### PR TITLE
feat(docx): expose structured table cells

### DIFF
--- a/.changeset/structured-docx-table-cells.md
+++ b/.changeset/structured-docx-table-cells.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Expose source cell paragraphs alongside extracted DOCX table rows.

--- a/.changeset/structured-docx-table-cells.md
+++ b/.changeset/structured-docx-table-cells.md
@@ -1,5 +1,5 @@
 ---
-"@stll/folio-core": patch
+"@stll/folio-core": minor
 ---
 
 Expose source cell paragraphs alongside extracted DOCX table rows.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -213,7 +213,16 @@ export type ExtractedDocxParagraph = {
 
 // @public
 export type ExtractedDocxTableCell = {
-    paragraphs: readonly string[];
+    paragraphs: readonly ExtractedDocxTableCellParagraph[];
+};
+
+// @public
+export type ExtractedDocxTableCellParagraph = {
+    text: string;
+    style?: string;
+    bold?: boolean;
+    fontSize?: number;
+    alignment?: "left" | "center" | "right" | "both";
 };
 
 // @public

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -139,7 +139,7 @@ export type DocxParagraphSource = "header" | "body" | "footer";
 // @public
 export type DocxTableRowKind = "cells" | "syntheticHeader" | "delimiter";
 
-// @public (undocumented)
+// @public
 export type DocxTableRowPosition = {
     table: number;
     kind: "cells";

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -139,10 +139,14 @@ export type DocxParagraphSource = "header" | "body" | "footer";
 // @public
 export type DocxTableRowKind = "cells" | "syntheticHeader" | "delimiter";
 
-// @public
+// @public (undocumented)
 export type DocxTableRowPosition = {
     table: number;
-    kind: DocxTableRowKind;
+    kind: "cells";
+    cells: readonly ExtractedDocxTableCell[];
+} | {
+    table: number;
+    kind: "syntheticHeader" | "delimiter";
 };
 
 // @public
@@ -205,6 +209,11 @@ export type ExtractedDocxParagraph = {
     fontSize?: number;
     alignment?: "left" | "center" | "right" | "both";
     tableRow?: DocxTableRowPosition;
+};
+
+// @public
+export type ExtractedDocxTableCell = {
+    paragraphs: readonly string[];
 };
 
 // @public

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -232,10 +232,15 @@ describe("extractDocxText", () => {
         `<x:p xmlns:x="urn:not-wordprocessingml"><x:r><x:t>foreign prose</x:t></x:r></x:p>` +
         table(
           row(
-            cell(
+            `<w:tc>` +
+              `<x:tcPr xmlns:x="urn:not-wordprocessingml"><x:gridSpan x:val="256"/><x:vMerge/></x:tcPr>` +
+              `<w:tcPr/>` +
               `<x:p xmlns:x="urn:not-wordprocessingml"><x:r><x:t>foreign cell</x:t></x:r></x:p>` +
-                paragraph("strict cell"),
-            ),
+              paragraph("strict cell") +
+              `</w:tc>` +
+              `<w:tc><w:tcPr><w:gridSpan xmlns:x="urn:not-wordprocessingml" x:val="256" w:val="1"/></w:tcPr>` +
+              paragraph("strict attributes") +
+              `</w:tc>`,
           ),
         ),
       wordNamespace: STRICT_W_NS,
@@ -244,14 +249,17 @@ describe("extractDocxText", () => {
     const result = await extractDocxText(bytes);
 
     expect(result.paragraphs.map(({ text }) => text)).toEqual([
-      "|  |",
-      "| --- |",
-      "| strict cell |",
+      "|  |  |",
+      "| --- | --- |",
+      "| strict cell | strict attributes |",
     ]);
     expect(result.paragraphs.at(2)?.tableRow).toEqual({
       table: 0,
       kind: "cells",
-      cells: [{ paragraphs: [{ text: "strict cell" }] }],
+      cells: [
+        { paragraphs: [{ text: "strict cell" }] },
+        { paragraphs: [{ text: "strict attributes" }] },
+      ],
     });
   });
 

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -257,14 +257,14 @@ describe("extractDocxText", () => {
     expect(result.paragraphs.map(({ text, tableRow }) => [text, tableRow])).toEqual([
       ["|  |", { table: 0, kind: "syntheticHeader" }],
       ["| --- |", { table: 0, kind: "delimiter" }],
-      ["| x |", { table: 0, kind: "cells" }],
+      ["| x |", { table: 0, kind: "cells", cells: [{ paragraphs: ["x"] }] }],
       ["Prose", undefined],
       ["|  |", { table: 1, kind: "syntheticHeader" }],
       ["| --- |", { table: 1, kind: "delimiter" }],
-      ["| x |", { table: 1, kind: "cells" }],
+      ["| x |", { table: 1, kind: "cells", cells: [{ paragraphs: ["x"] }] }],
       ["|  |", { table: 2, kind: "syntheticHeader" }],
       ["| --- |", { table: 2, kind: "delimiter" }],
-      ["| x |", { table: 2, kind: "cells" }],
+      ["| x |", { table: 2, kind: "cells", cells: [{ paragraphs: ["x"] }] }],
     ]);
   });
 
@@ -294,7 +294,11 @@ describe("extractDocxText", () => {
       "| H1 | H2 |",
       "| v1 | v2 |",
     ]);
-    expect(declared.paragraphs.at(0)?.tableRow).toEqual({ table: 0, kind: "cells" });
+    expect(declared.paragraphs.at(0)?.tableRow).toEqual({
+      table: 0,
+      kind: "cells",
+      cells: [{ paragraphs: ["H1"] }, { paragraphs: ["H2"] }],
+    });
     expect(undeclared.paragraphs.at(0)?.tableRow).toEqual({ table: 0, kind: "syntheticHeader" });
   });
 
@@ -380,6 +384,16 @@ describe("extractDocxText", () => {
       "| --- | --- | --- | --- |",
       "| first<br>second |  | pipe&#124;inside | break<br>after |",
     ]);
+    expect(result.paragraphs.at(2)?.tableRow).toEqual({
+      table: 0,
+      kind: "cells",
+      cells: [
+        { paragraphs: ["first", "second"] },
+        { paragraphs: [] },
+        { paragraphs: ["pipe|inside"] },
+        { paragraphs: ["break\nafter"] },
+      ],
+    });
   });
 
   test("gives every row of a table the same column count", async () => {

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -363,6 +363,16 @@ describe("extractDocxText", () => {
       "| --- | --- |",
       "| outer | in1 / in2<br>in3 / in4 |",
     ]);
+    expect(result.paragraphs.at(2)?.tableRow).toEqual({
+      table: 0,
+      kind: "cells",
+      cells: [
+        { paragraphs: [{ text: "outer" }] },
+        {
+          paragraphs: [{ text: "in1" }, { text: "in2" }, { text: "in3" }, { text: "in4" }],
+        },
+      ],
+    });
   });
 
   test("keeps a multi-paragraph cell on one row and escapes what would split it", async () => {

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -257,14 +257,14 @@ describe("extractDocxText", () => {
     expect(result.paragraphs.map(({ text, tableRow }) => [text, tableRow])).toEqual([
       ["|  |", { table: 0, kind: "syntheticHeader" }],
       ["| --- |", { table: 0, kind: "delimiter" }],
-      ["| x |", { table: 0, kind: "cells", cells: [{ paragraphs: ["x"] }] }],
+      ["| x |", { table: 0, kind: "cells", cells: [{ paragraphs: [{ text: "x" }] }] }],
       ["Prose", undefined],
       ["|  |", { table: 1, kind: "syntheticHeader" }],
       ["| --- |", { table: 1, kind: "delimiter" }],
-      ["| x |", { table: 1, kind: "cells", cells: [{ paragraphs: ["x"] }] }],
+      ["| x |", { table: 1, kind: "cells", cells: [{ paragraphs: [{ text: "x" }] }] }],
       ["|  |", { table: 2, kind: "syntheticHeader" }],
       ["| --- |", { table: 2, kind: "delimiter" }],
-      ["| x |", { table: 2, kind: "cells", cells: [{ paragraphs: ["x"] }] }],
+      ["| x |", { table: 2, kind: "cells", cells: [{ paragraphs: [{ text: "x" }] }] }],
     ]);
   });
 
@@ -297,7 +297,7 @@ describe("extractDocxText", () => {
     expect(declared.paragraphs.at(0)?.tableRow).toEqual({
       table: 0,
       kind: "cells",
-      cells: [{ paragraphs: ["H1"] }, { paragraphs: ["H2"] }],
+      cells: [{ paragraphs: [{ text: "H1" }] }, { paragraphs: [{ text: "H2" }] }],
     });
     expect(undeclared.paragraphs.at(0)?.tableRow).toEqual({ table: 0, kind: "syntheticHeader" });
   });
@@ -369,7 +369,12 @@ describe("extractDocxText", () => {
     const bytes = await makeDocx({
       body: table(
         row(
-          cell(paragraph("first") + `<w:p/>` + paragraph("second")) +
+          cell(
+            `<w:p><w:pPr><w:pStyle w:val="Heading2"/><w:jc w:val="center"/></w:pPr>` +
+              `<w:r><w:rPr><w:b/><w:sz w:val="32"/></w:rPr><w:t>first</w:t></w:r></w:p>` +
+              `<w:p/>` +
+              paragraph("second"),
+          ) +
             cell("") +
             cell(paragraph("pipe|inside")) +
             cell(`<w:p><w:r><w:t>break</w:t><w:br/><w:t>after</w:t></w:r></w:p>`),
@@ -388,10 +393,21 @@ describe("extractDocxText", () => {
       table: 0,
       kind: "cells",
       cells: [
-        { paragraphs: ["first", "second"] },
+        {
+          paragraphs: [
+            {
+              text: "first",
+              style: "Heading2",
+              bold: true,
+              fontSize: 32,
+              alignment: "center",
+            },
+            { text: "second" },
+          ],
+        },
         { paragraphs: [] },
-        { paragraphs: ["pipe|inside"] },
-        { paragraphs: ["break\nafter"] },
+        { paragraphs: [{ text: "pipe|inside" }] },
+        { paragraphs: [{ text: "break\nafter" }] },
       ],
     });
   });
@@ -423,9 +439,9 @@ describe("extractDocxText", () => {
         .slice(2)
         .map(({ tableRow }) => (tableRow?.kind === "cells" ? tableRow.cells : undefined)),
     ).toEqual([
-      [{ paragraphs: ["wide"] }, { paragraphs: [] }, { paragraphs: [] }],
-      [{ paragraphs: ["a"] }, { paragraphs: ["b"] }, { paragraphs: [] }],
-      [{ paragraphs: ["only"] }, { paragraphs: [] }, { paragraphs: [] }],
+      [{ paragraphs: [{ text: "wide" }] }, { paragraphs: [] }, { paragraphs: [] }],
+      [{ paragraphs: [{ text: "a" }] }, { paragraphs: [{ text: "b" }] }, { paragraphs: [] }],
+      [{ paragraphs: [{ text: "only" }] }, { paragraphs: [] }, { paragraphs: [] }],
       [{ paragraphs: [] }, { paragraphs: [] }, { paragraphs: [] }],
     ]);
   });

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -5,6 +5,7 @@ import { RELATIONSHIP_TYPES } from "../relsParser";
 import { extractDocxText } from "./extractDocxText";
 
 const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const STRICT_W_NS = "http://purl.oclc.org/ooxml/wordprocessingml/main";
 const R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 const PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships";
 
@@ -19,6 +20,7 @@ type MakeDocxOptions = {
    * actually wires up, the way a stale or planted part would look.
    */
   orphanParts?: Record<string, "header" | "footer">;
+  wordNamespace?: string;
 };
 
 /**
@@ -33,6 +35,7 @@ const makeDocx = async ({
   headers = {},
   footers = {},
   orphanParts = {},
+  wordNamespace = W_NS,
 }: MakeDocxOptions): Promise<Uint8Array> => {
   const zip = new JSZip();
   const relationships: string[] = [];
@@ -46,7 +49,7 @@ const makeDocx = async ({
   ): void => {
     const rootName = kind === "header" ? "hdr" : "ftr";
     for (const [path, content] of Object.entries(parts)) {
-      zip.file(path, `<w:${rootName} xmlns:w="${W_NS}">${content}</w:${rootName}>`);
+      zip.file(path, `<w:${rootName} xmlns:w="${wordNamespace}">${content}</w:${rootName}>`);
       const rId = `rId${nextRId++}`;
       const target = path.replace(/^word\//, "");
       relationships.push(
@@ -61,7 +64,10 @@ const makeDocx = async ({
 
   for (const [path, kind] of Object.entries(orphanParts)) {
     const rootName = kind === "header" ? "hdr" : "ftr";
-    zip.file(path, `<w:${rootName} xmlns:w="${W_NS}">${paragraph("Orphan")}</w:${rootName}>`);
+    zip.file(
+      path,
+      `<w:${rootName} xmlns:w="${wordNamespace}">${paragraph("Orphan")}</w:${rootName}>`,
+    );
     // Deliberately no Relationship entry and no section reference — this
     // part exists in the archive but nothing wires it up.
   }
@@ -70,7 +76,7 @@ const makeDocx = async ({
     sectionReferences.length > 0 ? `<w:sectPr>${sectionReferences.join("")}</w:sectPr>` : "";
   zip.file(
     "word/document.xml",
-    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${body}${sectPr}</w:body></w:document>`,
+    `<w:document xmlns:w="${wordNamespace}" xmlns:r="${R_NS}"><w:body>${body}${sectPr}</w:body></w:document>`,
   );
   if (relationships.length > 0) {
     zip.file(
@@ -218,6 +224,35 @@ describe("extractDocxText", () => {
 
     expect(result.paragraphs.at(0)?.text).toBe("Alternate");
     expect(result.paragraphs.at(0)?.style).toBe("Title");
+  });
+
+  test("accepts Strict WordprocessingML and ignores foreign local-name collisions", async () => {
+    const bytes = await makeDocx({
+      body:
+        `<x:p xmlns:x="urn:not-wordprocessingml"><x:r><x:t>foreign prose</x:t></x:r></x:p>` +
+        table(
+          row(
+            cell(
+              `<x:p xmlns:x="urn:not-wordprocessingml"><x:r><x:t>foreign cell</x:t></x:r></x:p>` +
+                paragraph("strict cell"),
+            ),
+          ),
+        ),
+      wordNamespace: STRICT_W_NS,
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  |",
+      "| --- |",
+      "| strict cell |",
+    ]);
+    expect(result.paragraphs.at(2)?.tableRow).toEqual({
+      table: 0,
+      kind: "cells",
+      cells: [{ paragraphs: [{ text: "strict cell" }] }],
+    });
   });
 
   test("emits table cells as markdown rows, not a flat row-major paragraph list", async () => {

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -419,9 +419,9 @@ describe("extractDocxText", () => {
       "|  |  |  |",
     ]);
     expect(
-      result.paragraphs.slice(2).map(({ tableRow }) =>
-        tableRow?.kind === "cells" ? tableRow.cells : undefined,
-      ),
+      result.paragraphs
+        .slice(2)
+        .map(({ tableRow }) => (tableRow?.kind === "cells" ? tableRow.cells : undefined)),
     ).toEqual([
       [{ paragraphs: ["wide"] }, { paragraphs: [] }, { paragraphs: [] }],
       [{ paragraphs: ["a"] }, { paragraphs: ["b"] }, { paragraphs: [] }],

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -212,11 +212,11 @@ describe("extractDocxText", () => {
     expect(result.paragraphs.at(1)?.alignment).toBe("left");
   });
 
-  test("ignores foreign text when calculating run formatting metadata", async () => {
+  test("ignores controls and foreign text when calculating run formatting metadata", async () => {
     const bytes = await makeDocx({
       body:
-        `<w:p><w:r><w:t>Plain text</w:t></w:r>` +
-        `<w:r><w:rPr><w:b/><w:sz w:val="99"/></w:rPr>` +
+        `<w:p><w:r><w:rPr><w:b/><w:sz w:val="99"/></w:rPr><w:br/><w:tab/></w:r>` +
+        `<w:r><w:t>Plain text</w:t></w:r><w:r><w:rPr><w:b/><w:sz w:val="99"/></w:rPr>` +
         `<x:t xmlns:x="urn:not-wordprocessingml">Foreign text that must not affect metrics</x:t>` +
         `</w:r></w:p>`,
     });
@@ -225,7 +225,7 @@ describe("extractDocxText", () => {
 
     expect(result.paragraphs.at(0)).toEqual({
       index: 0,
-      text: "Plain text",
+      text: "\n\tPlain text",
       source: "body",
     });
   });

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -418,6 +418,16 @@ describe("extractDocxText", () => {
       "| only |  |  |",
       "|  |  |  |",
     ]);
+    expect(
+      result.paragraphs.slice(2).map(({ tableRow }) =>
+        tableRow?.kind === "cells" ? tableRow.cells : undefined,
+      ),
+    ).toEqual([
+      [{ paragraphs: ["wide"] }, { paragraphs: [] }, { paragraphs: [] }],
+      [{ paragraphs: ["a"] }, { paragraphs: ["b"] }, { paragraphs: [] }],
+      [{ paragraphs: ["only"] }, { paragraphs: [] }, { paragraphs: [] }],
+      [{ paragraphs: [] }, { paragraphs: [] }, { paragraphs: [] }],
+    ]);
   });
 
   test("emits nothing for a table that has no cell at all", async () => {

--- a/packages/core/src/docx/server/extractDocxText.test.ts
+++ b/packages/core/src/docx/server/extractDocxText.test.ts
@@ -212,6 +212,24 @@ describe("extractDocxText", () => {
     expect(result.paragraphs.at(1)?.alignment).toBe("left");
   });
 
+  test("ignores foreign text when calculating run formatting metadata", async () => {
+    const bytes = await makeDocx({
+      body:
+        `<w:p><w:r><w:t>Plain text</w:t></w:r>` +
+        `<w:r><w:rPr><w:b/><w:sz w:val="99"/></w:rPr>` +
+        `<x:t xmlns:x="urn:not-wordprocessingml">Foreign text that must not affect metrics</x:t>` +
+        `</w:r></w:p>`,
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.at(0)).toEqual({
+      index: 0,
+      text: "Plain text",
+      source: "body",
+    });
+  });
+
   test("supports alternate prefixes for the main OOXML namespace", async () => {
     const zip = new JSZip();
     zip.file(
@@ -361,6 +379,33 @@ describe("extractDocxText", () => {
       "| Spans two |  | C |",
       "| a1 | a2 | a3 |",
     ]);
+  });
+
+  test("preserves leading and trailing grid omissions", async () => {
+    const bytes = await makeDocx({
+      body: table(
+        row(cell(paragraph("H2")), `<w:trPr><w:gridBefore w:val="1"/><w:tblHeader/></w:trPr>`) +
+          row(cell(paragraph("v1")), `<w:trPr><w:gridAfter w:val="1"/></w:trPr>`),
+      ),
+    });
+
+    const result = await extractDocxText(bytes);
+
+    expect(result.paragraphs.map(({ text }) => text)).toEqual([
+      "|  | H2 |",
+      "| --- | --- |",
+      "| v1 |  |",
+    ]);
+    expect(result.paragraphs.at(0)?.tableRow).toEqual({
+      table: 0,
+      kind: "cells",
+      cells: [{ paragraphs: [] }, { paragraphs: [{ text: "H2" }] }],
+    });
+    expect(result.paragraphs.at(2)?.tableRow).toEqual({
+      table: 0,
+      kind: "cells",
+      cells: [{ paragraphs: [{ text: "v1" }] }, { paragraphs: [] }],
+    });
   });
 
   test("renders a vertical-merge continuation as an empty column", async () => {

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -4,10 +4,9 @@ import { escapeTableCell } from "../../markdown/escape";
 import { parseRelationships, RELATIONSHIP_TYPES } from "../relsParser";
 import {
   findAllDeep,
-  findChild,
   findDeep,
   getAttribute,
-  getAttributeAnyPrefix,
+  getAttributeByNamespaceUri,
   getLocalName,
   getNamespaceUri,
   getTextContent,
@@ -106,6 +105,21 @@ const wordElementName = (element: XmlElement): string | null =>
     ? getLocalName(element.name)
     : null;
 
+const findWordChild = (
+  parent: XmlElement | null | undefined,
+  localName: string,
+): XmlElement | null => {
+  if (!parent) {
+    return null;
+  }
+  return childElements(parent).find((child) => wordElementName(child) === localName) ?? null;
+};
+
+const getWordAttribute = (
+  element: XmlElement | null | undefined,
+  localName: string,
+): string | null => getAttributeByNamespaceUri(element, WORDPROCESSINGML_NAMESPACES, localName);
+
 const collectText = (element: XmlElement): string => {
   let text = "";
 
@@ -136,20 +150,20 @@ const collectText = (element: XmlElement): string => {
 };
 
 const readParagraphProperties = (paragraph: XmlElement): ParagraphProperties => {
-  const properties = findChild(paragraph, "w", "pPr");
+  const properties = findWordChild(paragraph, "pPr");
   if (!properties) {
     return {};
   }
 
   const result: ParagraphProperties = {};
-  const style = findChild(properties, "w", "pStyle");
-  const styleValue = getAttributeAnyPrefix(style, "val");
+  const style = findWordChild(properties, "pStyle");
+  const styleValue = getWordAttribute(style, "val");
   if (styleValue !== null) {
     result.style = styleValue;
   }
 
-  const justification = findChild(properties, "w", "jc");
-  const alignment = getAttributeAnyPrefix(justification, "val");
+  const justification = findWordChild(properties, "jc");
+  const alignment = getWordAttribute(justification, "val");
   if (
     alignment === "left" ||
     alignment === "center" ||
@@ -169,13 +183,13 @@ const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
       continue;
     }
 
-    const properties = findChild(run, "w", "rPr");
-    const boldProperty = findChild(properties, "w", "b");
-    const boldValue = getAttributeAnyPrefix(boldProperty, "val");
+    const properties = findWordChild(run, "rPr");
+    const boldProperty = findWordChild(properties, "b");
+    const boldValue = getWordAttribute(boldProperty, "val");
     const bold = boldProperty !== null && boldValue !== "0" && boldValue !== "false";
 
-    const sizeProperty = findChild(properties, "w", "sz");
-    const sizeValue = getAttributeAnyPrefix(sizeProperty, "val");
+    const sizeProperty = findWordChild(properties, "sz");
+    const sizeValue = getWordAttribute(sizeProperty, "val");
     const parsedSize = sizeValue === null ? Number.NaN : Number.parseInt(sizeValue, 10);
     const fontSize = Number.isFinite(parsedSize) && parsedSize > 0 ? parsedSize : undefined;
 
@@ -371,9 +385,9 @@ type ExtractedTableCell = {
 };
 
 const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
-  const properties = findChild(cell, "w", "tcPr");
+  const properties = findWordChild(cell, "tcPr");
 
-  const gridSpanValue = getAttributeAnyPrefix(findChild(properties, "w", "gridSpan"), "val");
+  const gridSpanValue = getWordAttribute(findWordChild(properties, "gridSpan"), "val");
   const parsedGridSpan = gridSpanValue === null ? 1 : Number.parseInt(gridSpanValue, 10);
   const gridSpan = Number.isFinite(parsedGridSpan) && parsedGridSpan > 1 ? parsedGridSpan : 1;
 
@@ -381,8 +395,8 @@ const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
   // renders no content of its own there, so emit an empty grid column: it holds
   // the row's column alignment without repeating the anchor cell's value or
   // surfacing content Word itself never shows.
-  const vMerge = findChild(properties, "w", "vMerge");
-  if (vMerge !== null && getAttributeAnyPrefix(vMerge, "val") !== "restart") {
+  const vMerge = findWordChild(properties, "vMerge");
+  if (vMerge !== null && getWordAttribute(vMerge, "val") !== "restart") {
     return { text: "", paragraphs: [], gridSpan };
   }
 
@@ -406,11 +420,11 @@ const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
  * names invented here would be read back as facts about the document.
  */
 const declaresHeaderRow = (row: XmlElement): boolean => {
-  const header = findChild(findChild(row, "w", "trPr"), "w", "tblHeader");
+  const header = findWordChild(findWordChild(row, "trPr"), "tblHeader");
   if (header === null) {
     return false;
   }
-  const value = getAttributeAnyPrefix(header, "val");
+  const value = getWordAttribute(header, "val");
   return value !== "0" && value !== "false";
 };
 

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -31,11 +31,24 @@ export type DocxParagraphSource = "header" | "body" | "footer";
 export type DocxTableRowKind = "cells" | "syntheticHeader" | "delimiter";
 
 /** Table membership of a paragraph whose `text` is a markdown table row. */
-export type DocxTableRowPosition = {
-  /** 0-based index of the source `w:tbl`, in extraction order across all parts. */
-  table: number;
-  kind: DocxTableRowKind;
+export type ExtractedDocxTableCell = {
+  /** Source `w:p` text in document order; empty padding cells have no entries. */
+  paragraphs: readonly string[];
 };
+
+export type DocxTableRowPosition =
+  | {
+      /** 0-based index of the source `w:tbl`, in extraction order across all parts. */
+      table: number;
+      kind: "cells";
+      /** Source cells aligned to the rendered GFM columns. */
+      cells: readonly ExtractedDocxTableCell[];
+    }
+  | {
+      /** 0-based index of the source `w:tbl`, in extraction order across all parts. */
+      table: number;
+      kind: "syntheticHeader" | "delimiter";
+    };
 
 /** Paragraph text and lightweight formatting metadata from a DOCX archive. */
 export type ExtractedDocxParagraph = {
@@ -223,7 +236,7 @@ const collectTableParts = (parent: XmlElement, localName: "tr" | "tc"): XmlEleme
  * Blank paragraphs are dropped so a cell padded with empty paragraphs does not
  * render as a run of `<br>`. A nested table contributes one line per inner row.
  */
-const readCellText = (cell: XmlElement, depth: number): string => {
+const readCellParagraphs = (cell: XmlElement, depth: number): string[] => {
   const lines: string[] = [];
 
   const walk = (node: XmlElement) => {
@@ -252,14 +265,16 @@ const readCellText = (cell: XmlElement, depth: number): string => {
   };
 
   walk(cell);
-  return lines.join("\n");
+  return lines;
 };
 
 const flattenNestedTable = (table: XmlElement, depth: number): string[] => {
   const lines: string[] = [];
 
   for (const row of collectTableParts(table, "tr")) {
-    const cells = collectTableParts(row, "tc").map((cell) => readCellText(cell, depth));
+    const cells = collectTableParts(row, "tc").map((cell) =>
+      readCellParagraphs(cell, depth).join("\n"),
+    );
     if (cells.some((text) => text.length > 0)) {
       lines.push(cells.join(NESTED_TABLE_CELL_SEPARATOR));
     }
@@ -271,6 +286,8 @@ const flattenNestedTable = (table: XmlElement, depth: number): string[] => {
 type ExtractedTableCell = {
   /** Raw cell text; escaped only when it reaches a row line. */
   text: string;
+  /** Source paragraphs before GFM joins them with `<br>`. */
+  paragraphs: string[];
   /** Grid columns the cell occupies (`w:gridSpan`), at least 1. */
   gridSpan: number;
 };
@@ -288,10 +305,11 @@ const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
   // surfacing content Word itself never shows.
   const vMerge = findChild(properties, "w", "vMerge");
   if (vMerge !== null && getAttributeAnyPrefix(vMerge, "val") !== "restart") {
-    return { text: "", gridSpan };
+    return { text: "", paragraphs: [], gridSpan };
   }
 
-  return { text: readCellText(cell, depth), gridSpan };
+  const paragraphs = readCellParagraphs(cell, depth);
+  return { text: paragraphs.join("\n"), paragraphs, gridSpan };
 };
 
 /**
@@ -316,13 +334,13 @@ const declaresHeaderRow = (row: XmlElement): boolean => {
 
 type TableGrid = {
   /** Raw cell text per row, already expanded across the grid columns each cell spans. */
-  rows: string[][];
+  rows: ExtractedTableCell[][];
   columnCount: number;
   firstRowIsHeader: boolean;
 };
 
 const readTableGrid = (table: XmlElement): TableGrid => {
-  const rows: string[][] = [];
+  const rows: ExtractedTableCell[][] = [];
   let columnCount = 0;
   let firstRowIsHeader = false;
 
@@ -330,18 +348,18 @@ const readTableGrid = (table: XmlElement): TableGrid => {
     if (rowIndex === 0) {
       firstRowIsHeader = declaresHeaderRow(row);
     }
-    const columns: string[] = [];
+    const columns: ExtractedTableCell[] = [];
     for (const cell of collectTableParts(row, "tc")) {
       if (columns.length >= MAX_TABLE_COLUMNS) {
         break;
       }
-      const { text, gridSpan } = readTableCell(cell, 0);
-      columns.push(text);
+      const extractedCell = readTableCell(cell, 0);
+      columns.push(extractedCell);
       // A horizontally merged cell holds its text in the first column it spans;
       // the rest stay empty so every row keeps the same column boundaries.
-      const padding = Math.min(gridSpan - 1, MAX_TABLE_COLUMNS - columns.length);
+      const padding = Math.min(extractedCell.gridSpan - 1, MAX_TABLE_COLUMNS - columns.length);
       for (let index = 0; index < padding; index++) {
-        columns.push("");
+        columns.push({ text: "", paragraphs: [], gridSpan: 1 });
       }
     }
     if (columns.length > columnCount) {
@@ -354,10 +372,10 @@ const readTableGrid = (table: XmlElement): TableGrid => {
 };
 
 /** Pad a row to the table's column count and escape each cell into a pipe row. */
-const toRowLine = (columns: readonly string[], columnCount: number): string => {
+const toRowLine = (columns: readonly ExtractedTableCell[], columnCount: number): string => {
   const cells: string[] = [];
   for (let column = 0; column < columnCount; column++) {
-    cells.push(escapeTableCell(columns[column] ?? ""));
+    cells.push(escapeTableCell(columns[column]?.text ?? ""));
   }
   return `| ${cells.join(" | ")} |`;
 };
@@ -376,24 +394,38 @@ const renderTableRows = (table: XmlElement, tableIndex: number): RenderedTableRo
   }
 
   const rendered: RenderedTableRow[] = [];
-  const push = (text: string, kind: DocxTableRowKind) => {
+  const pushScaffolding = (text: string, kind: "syntheticHeader" | "delimiter") => {
     rendered.push({ text, position: { table: tableIndex, kind } });
+  };
+  const pushCells = (cells: readonly ExtractedTableCell[]) => {
+    rendered.push({
+      text: toRowLine(cells, columnCount),
+      position: {
+        table: tableIndex,
+        kind: "cells",
+        cells: cells.map(({ paragraphs }) => ({ paragraphs })),
+      },
+    });
   };
 
   if (firstRowIsHeader) {
-    push(toRowLine(firstRow, columnCount), "cells");
+    pushCells(firstRow);
   } else {
-    push(toRowLine([], columnCount), "syntheticHeader");
+    pushScaffolding(toRowLine([], columnCount), "syntheticHeader");
   }
-  push(
+  pushScaffolding(
     toRowLine(
-      Array.from({ length: columnCount }, () => TABLE_DELIMITER_CELL),
+      Array.from({ length: columnCount }, () => ({
+        text: TABLE_DELIMITER_CELL,
+        paragraphs: [],
+        gridSpan: 1,
+      })),
       columnCount,
     ),
     "delimiter",
   );
   for (const row of firstRowIsHeader ? remainingRows : rows) {
-    push(toRowLine(row, columnCount), "cells");
+    pushCells(row);
   }
 
   return rendered;

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -193,10 +193,7 @@ const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
     const parsedSize = sizeValue === null ? Number.NaN : Number.parseInt(sizeValue, 10);
     const fontSize = Number.isFinite(parsedSize) && parsedSize > 0 ? parsedSize : undefined;
 
-    let chars = 0;
-    for (const textNode of findAllDeep(run, "w", "t")) {
-      chars += getTextContent(textNode).length;
-    }
+    const chars = collectText(run).length;
     if (chars === 0) {
       continue;
     }
@@ -320,7 +317,9 @@ const readCellSourceParagraphs = (
         }
         for (const row of collectTableParts(child, "tr")) {
           for (const nestedCell of collectTableParts(row, "tc")) {
-            paragraphs.push(...readCellSourceParagraphs(nestedCell, depth + 1));
+            for (const paragraph of readCellSourceParagraphs(nestedCell, depth + 1)) {
+              paragraphs.push(paragraph);
+            }
           }
         }
         continue;
@@ -348,7 +347,9 @@ const readCellRenderedLines = (cell: XmlElement, depth: number): string[] => {
       }
       if (childName === "tbl") {
         if (depth < MAX_NESTED_TABLE_DEPTH) {
-          lines.push(...flattenNestedTable(child, depth + 1));
+          for (const line of flattenNestedTable(child, depth + 1)) {
+            lines.push(line);
+          }
         }
         continue;
       }
@@ -383,6 +384,12 @@ type ExtractedTableCell = {
   /** Grid columns the cell occupies (`w:gridSpan`), at least 1. */
   gridSpan: number;
 };
+
+const emptyTableCell = (): ExtractedTableCell => ({
+  text: "",
+  paragraphs: [],
+  gridSpan: 1,
+});
 
 const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
   const properties = findWordChild(cell, "tcPr");
@@ -428,6 +435,13 @@ const declaresHeaderRow = (row: XmlElement): boolean => {
   return value !== "0" && value !== "false";
 };
 
+const readRowGridOffset = (row: XmlElement, localName: "gridBefore" | "gridAfter"): number => {
+  const properties = findWordChild(row, "trPr");
+  const value = getWordAttribute(findWordChild(properties, localName), "val");
+  const parsed = value === null ? 0 : Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, MAX_TABLE_COLUMNS) : 0;
+};
+
 type TableGrid = {
   /** Raw cell text per row, already expanded across the grid columns each cell spans. */
   rows: ExtractedTableCell[][];
@@ -445,6 +459,10 @@ const readTableGrid = (table: XmlElement): TableGrid => {
       firstRowIsHeader = declaresHeaderRow(row);
     }
     const columns: ExtractedTableCell[] = [];
+    const gridBefore = readRowGridOffset(row, "gridBefore");
+    for (let index = 0; index < gridBefore; index += 1) {
+      columns.push(emptyTableCell());
+    }
     for (const cell of collectTableParts(row, "tc")) {
       if (columns.length >= MAX_TABLE_COLUMNS) {
         break;
@@ -455,8 +473,15 @@ const readTableGrid = (table: XmlElement): TableGrid => {
       // the rest stay empty so every row keeps the same column boundaries.
       const padding = Math.min(extractedCell.gridSpan - 1, MAX_TABLE_COLUMNS - columns.length);
       for (let index = 0; index < padding; index++) {
-        columns.push({ text: "", paragraphs: [], gridSpan: 1 });
+        columns.push(emptyTableCell());
       }
+    }
+    const gridAfter = Math.min(
+      readRowGridOffset(row, "gridAfter"),
+      MAX_TABLE_COLUMNS - columns.length,
+    );
+    for (let index = 0; index < gridAfter; index += 1) {
+      columns.push(emptyTableCell());
     }
     if (columns.length > columnCount) {
       columnCount = columns.length;
@@ -647,7 +672,9 @@ const extractParts = async ({
       startIndex: nextIndex,
       startTableIndex: startTableIndex + tableCount,
     });
-    paragraphs.push(...result.paragraphs);
+    for (const paragraph of result.paragraphs) {
+      paragraphs.push(paragraph);
+    }
     charCount += result.charCount;
     tableCount += result.tableCount;
     nextIndex += result.paragraphs.length;

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -9,12 +9,17 @@ import {
   getAttribute,
   getAttributeAnyPrefix,
   getLocalName,
+  getNamespaceUri,
   getTextContent,
   parseXml,
   type XmlElement,
 } from "../xmlParser";
 
 const DOCUMENT_RELS_PATH = "word/_rels/document.xml.rels";
+const WORDPROCESSINGML_NAMESPACES: ReadonlySet<string> = new Set([
+  "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+  "http://purl.oclc.org/ooxml/wordprocessingml/main",
+]);
 
 /** Document part containing an extracted paragraph. */
 export type DocxParagraphSource = "header" | "body" | "footer";
@@ -96,11 +101,16 @@ type RunMetrics = {
 const childElements = (element: XmlElement): XmlElement[] =>
   element.elements?.filter((child) => child.type === "element") ?? [];
 
+const wordElementName = (element: XmlElement): string | null =>
+  WORDPROCESSINGML_NAMESPACES.has(getNamespaceUri(element) ?? "")
+    ? getLocalName(element.name)
+    : null;
+
 const collectText = (element: XmlElement): string => {
   let text = "";
 
   const walk = (node: XmlElement) => {
-    const localName = getLocalName(node.name ?? "");
+    const localName = wordElementName(node);
     if (localName === "t") {
       text += getTextContent(node);
       return;
@@ -155,7 +165,7 @@ const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
   const metrics: RunMetrics[] = [];
 
   for (const run of childElements(paragraph)) {
-    if (getLocalName(run.name ?? "") !== "r") {
+    if (wordElementName(run) !== "r") {
       continue;
     }
 
@@ -251,7 +261,7 @@ const collectTableParts = (parent: XmlElement, localName: "tr" | "tc"): XmlEleme
 
   const walk = (node: XmlElement) => {
     for (const child of childElements(node)) {
-      const childName = getLocalName(child.name ?? "");
+      const childName = wordElementName(child);
       if (childName === localName) {
         parts.push(child);
         continue;
@@ -280,7 +290,7 @@ const readCellSourceParagraphs = (
 
   const walk = (node: XmlElement) => {
     for (const child of childElements(node)) {
-      const childName = getLocalName(child.name ?? "");
+      const childName = wordElementName(child);
       if (childName === "p") {
         const paragraph = readParagraph(child);
         if (paragraph.text.length > 0) {
@@ -314,7 +324,7 @@ const readCellRenderedLines = (cell: XmlElement, depth: number): string[] => {
 
   const walk = (node: XmlElement) => {
     for (const child of childElements(node)) {
-      const childName = getLocalName(child.name ?? "");
+      const childName = wordElementName(child);
       if (childName === "p") {
         const text = collectText(child);
         if (text.length > 0) {
@@ -564,7 +574,7 @@ const extractContainer = ({
    */
   const walkBlocks = (node: XmlElement) => {
     for (const child of childElements(node)) {
-      const childName = getLocalName(child.name ?? "");
+      const childName = wordElementName(child);
       if (childName === "tbl") {
         for (const row of renderTableRows(child, startTableIndex + tableCount)) {
           pushTableRow(row);

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -149,6 +149,27 @@ const collectText = (element: XmlElement): string => {
   return text;
 };
 
+const countAcceptedTextChars = (element: XmlElement): number => {
+  let chars = 0;
+
+  const walk = (node: XmlElement) => {
+    const localName = wordElementName(node);
+    if (localName === "t") {
+      chars += getTextContent(node).length;
+      return;
+    }
+    if (localName === "del" || localName === "delText" || localName === "moveFrom") {
+      return;
+    }
+    for (const child of childElements(node)) {
+      walk(child);
+    }
+  };
+
+  walk(element);
+  return chars;
+};
+
 const readParagraphProperties = (paragraph: XmlElement): ParagraphProperties => {
   const properties = findWordChild(paragraph, "pPr");
   if (!properties) {
@@ -193,7 +214,7 @@ const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
     const parsedSize = sizeValue === null ? Number.NaN : Number.parseInt(sizeValue, 10);
     const fontSize = Number.isFinite(parsedSize) && parsedSize > 0 ? parsedSize : undefined;
 
-    const chars = collectText(run).length;
+    const chars = countAcceptedTextChars(run);
     if (chars === 0) {
       continue;
     }

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -403,7 +403,9 @@ const renderTableRows = (table: XmlElement, tableIndex: number): RenderedTableRo
       position: {
         table: tableIndex,
         kind: "cells",
-        cells: cells.map(({ paragraphs }) => ({ paragraphs })),
+        cells: Array.from({ length: columnCount }, (_, column) => ({
+          paragraphs: cells.at(column)?.paragraphs ?? [],
+        })),
       },
     });
   };

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -39,12 +39,13 @@ export type ExtractedDocxTableCellParagraph = {
   alignment?: "left" | "center" | "right" | "both";
 };
 
-/** Table membership of a paragraph whose `text` is a markdown table row. */
+/** Source paragraphs contained by one physical table cell. */
 export type ExtractedDocxTableCell = {
   /** Source `w:p` records in document order; empty padding cells have no entries. */
   paragraphs: readonly ExtractedDocxTableCellParagraph[];
 };
 
+/** Table membership of a paragraph whose `text` is a markdown table row. */
 export type DocxTableRowPosition =
   | {
       /** 0-based index of the source `w:tbl`, in extraction order across all parts. */
@@ -271,8 +272,11 @@ const collectTableParts = (parent: XmlElement, localName: "tr" | "tc"): XmlEleme
  * Blank paragraphs are dropped so a cell padded with empty paragraphs does not
  * render as a run of `<br>`. A nested table contributes one line per inner row.
  */
-const readCellParagraphs = (cell: XmlElement, depth: number): ExtractedDocxTableCellParagraph[] => {
-  const lines: ExtractedDocxTableCellParagraph[] = [];
+const readCellSourceParagraphs = (
+  cell: XmlElement,
+  depth: number,
+): ExtractedDocxTableCellParagraph[] => {
+  const paragraphs: ExtractedDocxTableCellParagraph[] = [];
 
   const walk = (node: XmlElement) => {
     for (const child of childElements(node)) {
@@ -280,7 +284,7 @@ const readCellParagraphs = (cell: XmlElement, depth: number): ExtractedDocxTable
       if (childName === "p") {
         const paragraph = readParagraph(child);
         if (paragraph.text.length > 0) {
-          lines.push(paragraph);
+          paragraphs.push(paragraph);
         }
         // `collectText` already descended for text, including any textbox
         // inside the paragraph; descending again would duplicate the cell text.
@@ -290,8 +294,37 @@ const readCellParagraphs = (cell: XmlElement, depth: number): ExtractedDocxTable
         if (depth >= MAX_NESTED_TABLE_DEPTH) {
           continue;
         }
-        for (const line of flattenNestedTable(child, depth + 1)) {
-          lines.push({ text: line });
+        for (const row of collectTableParts(child, "tr")) {
+          for (const nestedCell of collectTableParts(row, "tc")) {
+            paragraphs.push(...readCellSourceParagraphs(nestedCell, depth + 1));
+          }
+        }
+        continue;
+      }
+      walk(child);
+    }
+  };
+
+  walk(cell);
+  return paragraphs;
+};
+
+const readCellRenderedLines = (cell: XmlElement, depth: number): string[] => {
+  const lines: string[] = [];
+
+  const walk = (node: XmlElement) => {
+    for (const child of childElements(node)) {
+      const childName = getLocalName(child.name ?? "");
+      if (childName === "p") {
+        const text = collectText(child);
+        if (text.length > 0) {
+          lines.push(text);
+        }
+        continue;
+      }
+      if (childName === "tbl") {
+        if (depth < MAX_NESTED_TABLE_DEPTH) {
+          lines.push(...flattenNestedTable(child, depth + 1));
         }
         continue;
       }
@@ -308,9 +341,7 @@ const flattenNestedTable = (table: XmlElement, depth: number): string[] => {
 
   for (const row of collectTableParts(table, "tr")) {
     const cells = collectTableParts(row, "tc").map((cell) =>
-      readCellParagraphs(cell, depth)
-        .map(({ text }) => text)
-        .join("\n"),
+      readCellRenderedLines(cell, depth).join("\n"),
     );
     if (cells.some((text) => text.length > 0)) {
       lines.push(cells.join(NESTED_TABLE_CELL_SEPARATOR));
@@ -345,9 +376,9 @@ const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
     return { text: "", paragraphs: [], gridSpan };
   }
 
-  const paragraphs = readCellParagraphs(cell, depth);
+  const paragraphs = readCellSourceParagraphs(cell, depth);
   return {
-    text: paragraphs.map(({ text }) => text).join("\n"),
+    text: readCellRenderedLines(cell, depth).join("\n"),
     paragraphs,
     gridSpan,
   };

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -30,10 +30,19 @@ export type DocxParagraphSource = "header" | "body" | "footer";
  */
 export type DocxTableRowKind = "cells" | "syntheticHeader" | "delimiter";
 
+/** Source paragraph inside a structured table cell. */
+export type ExtractedDocxTableCellParagraph = {
+  text: string;
+  style?: string;
+  bold?: boolean;
+  fontSize?: number;
+  alignment?: "left" | "center" | "right" | "both";
+};
+
 /** Table membership of a paragraph whose `text` is a markdown table row. */
 export type ExtractedDocxTableCell = {
-  /** Source `w:p` text in document order; empty padding cells have no entries. */
-  paragraphs: readonly string[];
+  /** Source `w:p` records in document order; empty padding cells have no entries. */
+  paragraphs: readonly ExtractedDocxTableCellParagraph[];
 };
 
 export type DocxTableRowPosition =
@@ -177,6 +186,32 @@ const readRunMetrics = (paragraph: XmlElement): RunMetrics[] => {
   return metrics;
 };
 
+const readParagraph = (paragraph: XmlElement): ExtractedDocxTableCellParagraph => {
+  const entry: ExtractedDocxTableCellParagraph = { text: collectText(paragraph) };
+  const { style, alignment } = readParagraphProperties(paragraph);
+  if (style !== undefined) {
+    entry.style = style;
+  }
+  if (alignment !== undefined) {
+    entry.alignment = alignment;
+  }
+
+  const runs = readRunMetrics(paragraph);
+  if (runs.length === 0) {
+    return entry;
+  }
+  const totalChars = runs.reduce((sum, run) => sum + run.chars, 0);
+  const boldChars = runs.reduce((sum, run) => sum + (run.bold ? run.chars : 0), 0);
+  if (boldChars > totalChars / 2) {
+    entry.bold = true;
+  }
+  const firstFontSize = runs.find((run) => run.fontSize !== undefined)?.fontSize;
+  if (firstFontSize !== undefined) {
+    entry.fontSize = firstFontSize;
+  }
+  return entry;
+};
+
 // ---------------------------------------------------------------------------
 // Tables
 //
@@ -236,16 +271,16 @@ const collectTableParts = (parent: XmlElement, localName: "tr" | "tc"): XmlEleme
  * Blank paragraphs are dropped so a cell padded with empty paragraphs does not
  * render as a run of `<br>`. A nested table contributes one line per inner row.
  */
-const readCellParagraphs = (cell: XmlElement, depth: number): string[] => {
-  const lines: string[] = [];
+const readCellParagraphs = (cell: XmlElement, depth: number): ExtractedDocxTableCellParagraph[] => {
+  const lines: ExtractedDocxTableCellParagraph[] = [];
 
   const walk = (node: XmlElement) => {
     for (const child of childElements(node)) {
       const childName = getLocalName(child.name ?? "");
       if (childName === "p") {
-        const text = collectText(child);
-        if (text.length > 0) {
-          lines.push(text);
+        const paragraph = readParagraph(child);
+        if (paragraph.text.length > 0) {
+          lines.push(paragraph);
         }
         // `collectText` already descended for text, including any textbox
         // inside the paragraph; descending again would duplicate the cell text.
@@ -256,7 +291,7 @@ const readCellParagraphs = (cell: XmlElement, depth: number): string[] => {
           continue;
         }
         for (const line of flattenNestedTable(child, depth + 1)) {
-          lines.push(line);
+          lines.push({ text: line });
         }
         continue;
       }
@@ -273,7 +308,9 @@ const flattenNestedTable = (table: XmlElement, depth: number): string[] => {
 
   for (const row of collectTableParts(table, "tr")) {
     const cells = collectTableParts(row, "tc").map((cell) =>
-      readCellParagraphs(cell, depth).join("\n"),
+      readCellParagraphs(cell, depth)
+        .map(({ text }) => text)
+        .join("\n"),
     );
     if (cells.some((text) => text.length > 0)) {
       lines.push(cells.join(NESTED_TABLE_CELL_SEPARATOR));
@@ -287,7 +324,7 @@ type ExtractedTableCell = {
   /** Raw cell text; escaped only when it reaches a row line. */
   text: string;
   /** Source paragraphs before GFM joins them with `<br>`. */
-  paragraphs: string[];
+  paragraphs: ExtractedDocxTableCellParagraph[];
   /** Grid columns the cell occupies (`w:gridSpan`), at least 1. */
   gridSpan: number;
 };
@@ -309,7 +346,11 @@ const readTableCell = (cell: XmlElement, depth: number): ExtractedTableCell => {
   }
 
   const paragraphs = readCellParagraphs(cell, depth);
-  return { text: paragraphs.join("\n"), paragraphs, gridSpan };
+  return {
+    text: paragraphs.map(({ text }) => text).join("\n"),
+    paragraphs,
+    gridSpan,
+  };
 };
 
 /**
@@ -462,32 +503,13 @@ const extractContainer = ({
   let tableCount = 0;
 
   const pushProse = (paragraph: XmlElement) => {
-    const text = collectText(paragraph);
+    const extracted = readParagraph(paragraph);
+    const { text } = extracted;
     const entry: ExtractedDocxParagraph = {
       index: startIndex + paragraphs.length,
-      text,
       source,
+      ...extracted,
     };
-    const { style, alignment } = readParagraphProperties(paragraph);
-    if (style !== undefined) {
-      entry.style = style;
-    }
-    if (alignment !== undefined) {
-      entry.alignment = alignment;
-    }
-
-    const runs = readRunMetrics(paragraph);
-    if (runs.length > 0) {
-      const totalChars = runs.reduce((sum, run) => sum + run.chars, 0);
-      const boldChars = runs.reduce((sum, run) => sum + (run.bold ? run.chars : 0), 0);
-      if (boldChars > totalChars / 2) {
-        entry.bold = true;
-      }
-      const firstFontSize = runs.find((run) => run.fontSize !== undefined)?.fontSize;
-      if (firstFontSize !== undefined) {
-        entry.fontSize = firstFontSize;
-      }
-    }
 
     paragraphs.push(entry);
     charCount += text.length;

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -42,9 +42,15 @@ export type XmlElement = {
   name?: string;
   /** Resolved namespace URI; non-enumerable so legacy structural comparisons stay stable. */
   namespaceUri?: string;
-  /** In-scope namespace bindings; non-enumerable so legacy structural comparisons stay stable. */
-  namespaceBindings?: ReadonlyMap<string, string>;
+  /** In-scope namespace declarations; non-enumerable so legacy comparisons stay stable. */
+  namespaceScope?: XmlNamespaceScope;
   elements?: XmlElement[];
+};
+
+/** Parent-linked XML namespace declarations; each scope stores only local overrides. */
+export type XmlNamespaceScope = {
+  bindings: ReadonlyMap<string, string>;
+  parent?: XmlNamespaceScope;
 };
 
 // ---------------------------------------------------------------------------
@@ -105,6 +111,23 @@ const XML_CARRIAGE_RETURN_REFERENCE = "&#13;";
 
 type MutableFxpNode = XmlElement & Record<string, unknown>;
 
+const EMPTY_NAMESPACE_SCOPE: XmlNamespaceScope = { bindings: new Map() };
+
+const resolveNamespaceUri = (
+  scope: XmlNamespaceScope | undefined,
+  prefix: string,
+): string | undefined => {
+  let current = scope;
+  while (current) {
+    const value = current.bindings.get(prefix);
+    if (value !== undefined) {
+      return value;
+    }
+    current = current.parent;
+  }
+  return undefined;
+};
+
 /**
  * Convert a fast-xml-parser preserveOrder node into an XmlElement.
  *
@@ -114,7 +137,7 @@ type MutableFxpNode = XmlElement & Record<string, unknown>;
  */
 function fxpNodeToElement(
   node: Record<string, unknown>,
-  inheritedNamespaces: ReadonlyMap<string, string> = new Map(),
+  inheritedNamespaceScope: XmlNamespaceScope = EMPTY_NAMESPACE_SCOPE,
 ): MutableFxpNode {
   // Text node: { "#text": "some text" }
   if (TEXT_KEY in node) {
@@ -140,29 +163,32 @@ function fxpNodeToElement(
       element.attributes = attrs;
     }
 
-    let mutableNamespaces: Map<string, string> | null = null;
+    let localBindings: Map<string, string> | null = null;
     if (attrs) {
       for (const [attribute, value] of Object.entries(attrs)) {
         if (attribute !== "xmlns" && !attribute.startsWith("xmlns:")) {
           continue;
         }
-        mutableNamespaces ??= new Map(inheritedNamespaces);
+        localBindings ??= new Map();
         const prefix = attribute === "xmlns" ? "" : attribute.slice("xmlns:".length);
-        mutableNamespaces.set(prefix, value);
+        localBindings.set(prefix, value);
       }
     }
-    const namespaces = mutableNamespaces ?? inheritedNamespaces;
+    const namespaceScope =
+      localBindings === null
+        ? inheritedNamespaceScope
+        : { bindings: localBindings, parent: inheritedNamespaceScope };
 
-    Object.defineProperty(element, "namespaceBindings", {
+    Object.defineProperty(element, "namespaceScope", {
       configurable: false,
       enumerable: false,
-      value: namespaces,
+      value: namespaceScope,
       writable: false,
     });
 
     const colonIndex = key.indexOf(":");
     const prefix = colonIndex === -1 ? "" : key.slice(0, colonIndex);
-    const namespaceUri = namespaces.get(prefix);
+    const namespaceUri = resolveNamespaceUri(namespaceScope, prefix);
     if (namespaceUri !== undefined) {
       Object.defineProperty(element, "namespaceUri", {
         configurable: false,
@@ -174,7 +200,7 @@ function fxpNodeToElement(
 
     if (children.length > 0) {
       for (let index = 0; index < children.length; index += 1) {
-        children[index] = fxpNodeToElement(children[index]!, namespaces);
+        children[index] = fxpNodeToElement(children[index]!, namespaceScope);
       }
       element.elements = children;
     }
@@ -324,7 +350,10 @@ export function getAttributeByNamespaceUri(
       continue;
     }
     const prefix = getNamespacePrefix(name);
-    if (prefix !== null && namespaceUris.has(element.namespaceBindings?.get(prefix) ?? "")) {
+    if (
+      prefix !== null &&
+      namespaceUris.has(resolveNamespaceUri(element.namespaceScope, prefix) ?? "")
+    ) {
       return String(value);
     }
   }

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -42,6 +42,8 @@ export type XmlElement = {
   name?: string;
   /** Resolved namespace URI; non-enumerable so legacy structural comparisons stay stable. */
   namespaceUri?: string;
+  /** In-scope namespace bindings; non-enumerable so legacy structural comparisons stay stable. */
+  namespaceBindings?: ReadonlyMap<string, string>;
   elements?: XmlElement[];
 };
 
@@ -138,19 +140,25 @@ function fxpNodeToElement(
       element.attributes = attrs;
     }
 
-    let namespaces = inheritedNamespaces;
+    let mutableNamespaces: Map<string, string> | null = null;
     if (attrs) {
       for (const [attribute, value] of Object.entries(attrs)) {
         if (attribute !== "xmlns" && !attribute.startsWith("xmlns:")) {
           continue;
         }
-        if (namespaces === inheritedNamespaces) {
-          namespaces = new Map(inheritedNamespaces);
-        }
+        mutableNamespaces ??= new Map(inheritedNamespaces);
         const prefix = attribute === "xmlns" ? "" : attribute.slice("xmlns:".length);
-        (namespaces as Map<string, string>).set(prefix, value);
+        mutableNamespaces.set(prefix, value);
       }
     }
+    const namespaces = mutableNamespaces ?? inheritedNamespaces;
+
+    Object.defineProperty(element, "namespaceBindings", {
+      configurable: false,
+      enumerable: false,
+      value: namespaces,
+      writable: false,
+    });
 
     const colonIndex = key.indexOf(":");
     const prefix = colonIndex === -1 ? "" : key.slice(0, colonIndex);
@@ -300,6 +308,29 @@ export function getNamespacePrefix(name: string): string | null {
 
 /** Namespace URI resolved from the element's in-scope XML declarations. */
 export const getNamespaceUri = (element: XmlElement): string | undefined => element.namespaceUri;
+
+/** Get an attribute whose prefix resolves to one of the accepted namespace URIs. */
+export function getAttributeByNamespaceUri(
+  element: XmlElement | null | undefined,
+  namespaceUris: ReadonlySet<string>,
+  localName: string,
+): string | null {
+  if (!element?.attributes) {
+    return null;
+  }
+
+  for (const [name, value] of Object.entries(element.attributes)) {
+    if (value === undefined || getLocalName(name) !== localName) {
+      continue;
+    }
+    const prefix = getNamespacePrefix(name);
+    if (prefix !== null && namespaceUris.has(element.namespaceBindings?.get(prefix) ?? "")) {
+      return String(value);
+    }
+  }
+
+  return null;
+}
 
 function hasLocalName(name: string | undefined, localName: string): boolean {
   if (!name) {

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -40,6 +40,8 @@ export type XmlElement = {
   text?: string | number | boolean;
   type?: string;
   name?: string;
+  /** Resolved namespace URI; non-enumerable so legacy structural comparisons stay stable. */
+  namespaceUri?: string;
   elements?: XmlElement[];
 };
 
@@ -108,7 +110,10 @@ type MutableFxpNode = XmlElement & Record<string, unknown>;
  * (the tag name or `#text`) whose value is the children array, plus an
  * optional `:@` key holding the attributes object.
  */
-function fxpNodeToElement(node: Record<string, unknown>): MutableFxpNode {
+function fxpNodeToElement(
+  node: Record<string, unknown>,
+  inheritedNamespaces: ReadonlyMap<string, string> = new Map(),
+): MutableFxpNode {
   // Text node: { "#text": "some text" }
   if (TEXT_KEY in node) {
     return { type: "text", text: node[TEXT_KEY] as string };
@@ -133,9 +138,35 @@ function fxpNodeToElement(node: Record<string, unknown>): MutableFxpNode {
       element.attributes = attrs;
     }
 
+    let namespaces = inheritedNamespaces;
+    if (attrs) {
+      for (const [attribute, value] of Object.entries(attrs)) {
+        if (attribute !== "xmlns" && !attribute.startsWith("xmlns:")) {
+          continue;
+        }
+        if (namespaces === inheritedNamespaces) {
+          namespaces = new Map(inheritedNamespaces);
+        }
+        const prefix = attribute === "xmlns" ? "" : attribute.slice("xmlns:".length);
+        (namespaces as Map<string, string>).set(prefix, value);
+      }
+    }
+
+    const colonIndex = key.indexOf(":");
+    const prefix = colonIndex === -1 ? "" : key.slice(0, colonIndex);
+    const namespaceUri = namespaces.get(prefix);
+    if (namespaceUri !== undefined) {
+      Object.defineProperty(element, "namespaceUri", {
+        configurable: false,
+        enumerable: false,
+        value: namespaceUri,
+        writable: false,
+      });
+    }
+
     if (children.length > 0) {
       for (let index = 0; index < children.length; index += 1) {
-        children[index] = fxpNodeToElement(children[index]!);
+        children[index] = fxpNodeToElement(children[index]!, namespaces);
       }
       element.elements = children;
     }
@@ -266,6 +297,9 @@ export function getNamespacePrefix(name: string): string | null {
   const colonIndex = name.indexOf(":");
   return colonIndex !== -1 ? name.slice(0, colonIndex) : null;
 }
+
+/** Namespace URI resolved from the element's in-scope XML declarations. */
+export const getNamespaceUri = (element: XmlElement): string | undefined => element.namespaceUri;
 
 function hasLocalName(name: string | undefined, localName: string): boolean {
   if (!name) {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -178,6 +178,7 @@ export {
   type DocxTableRowPosition,
   type ExtractedDocxParagraph,
   type ExtractedDocxTableCell,
+  type ExtractedDocxTableCellParagraph,
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";
 export { docxToMarkdown } from "./docx/server/docxToMarkdown";

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -177,6 +177,7 @@ export {
   type DocxTableRowKind,
   type DocxTableRowPosition,
   type ExtractedDocxParagraph,
+  type ExtractedDocxTableCell,
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";
 export { docxToMarkdown } from "./docx/server/docxToMarkdown";


### PR DESCRIPTION
## Summary

- preserve each source table cell's paragraph text alongside GFM row output
- distinguish real cell rows from synthetic Markdown scaffolding in the public type
- cover multi-cell, multi-paragraph, merged, and empty-cell extraction

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DOCX table extraction now preserves each cell’s source paragraphs, including text and available formatting details.
  - Table row metadata includes structured cell information for rows containing cells.
  - New cell information is available through the public API.

- **Bug Fixes**
  - Improved handling of multi-paragraph, empty, escaped, line-break, merged, padded and nested table cells.
  - DOCX extraction now recognises supported WordprocessingML namespaces and ignores unrelated elements with matching names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->