### PR TITLE
fix: keep indented justified lines within margins

### DIFF
--- a/.changeset/calm-tabs-stay-contained.md
+++ b/.changeset/calm-tabs-stay-contained.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep justified tabbed first lines within the paragraph's right margin.

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -91,12 +91,12 @@ function renderJustifiedFirstLine(firstLine: number): {
     runs: [{ kind: "text", text: "first second third fourth fifth sixth" }],
     attrs: { alignment: "justify", indent: { firstLine } },
   };
-  const line = (toChar: number, fromChar: number) => ({
+  const line = (toChar: number, fromChar: number, width: number) => ({
     fromRun: 0,
     fromChar,
     toRun: 0,
     toChar,
-    width: 380,
+    width,
     ascent: 10,
     descent: 3,
     lineHeight: 14,
@@ -104,7 +104,10 @@ function renderJustifiedFirstLine(firstLine: number): {
   const measure: ParagraphMeasure = {
     kind: "paragraph",
     // Two lines: the first is justified, the second is the (left-aligned) last.
-    lines: [line(18, 0), line(36, 18)],
+    // The first line's measured capacity is 400 - 30 = 370px. The painter
+    // keeps the outer line box at 400px and lets text-indent reserve those
+    // 30px; the measured content itself cannot occupy the full 400px.
+    lines: [line(18, 0, 370), line(36, 18, 380)],
     totalHeight: 28,
   };
   const fragment: ParagraphFragment = {
@@ -296,6 +299,42 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(lineEl.style.textAlign).toBe("left");
     expect(lineEl.style.textAlignLast).toBe("auto");
     expect(lineEl.style.wordSpacing).toBe("20px");
+  });
+
+  test("does not distribute space into a positive first-line indent", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-first-line-tab-capacity",
+      runs: [{ kind: "tab" }, { kind: "text", text: "alpha beta" }],
+      attrs: { alignment: "justify", indent: { firstLine: 30 } },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: 10,
+      // The measurer subtracts the 30px first-line shift from the 100px
+      // paragraph width. This line already fills that complete 70px budget.
+      width: 70,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: false,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      firstLineIndentPx: 30,
+    });
+
+    // The line box stays at the full paragraph width so CSS text-indent can
+    // place the first line. Explicit word spacing must use the remaining 70px
+    // capacity, or it expands the text by the indent and overruns the margin.
+    expect(lineEl.style.width).toBe("100px");
+    expect(lineEl.style.wordSpacing).toBeUndefined();
+    expect(lineEl.style.textAlign).toBe("justify");
   });
 
   test("includes a hanging first-line region in justified tab capacity", () => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2029,6 +2029,7 @@ export function renderLine(
 
     if (shouldJustify) {
       const firstLineIndentPx = options.isFirstLine ? (options.firstLineIndentPx ?? 0) : 0;
+      const firstLinePositiveIndentPx = Math.max(0, firstLineIndentPx);
       const firstLineHangingPx = Math.max(0, -firstLineIndentPx);
       const hasVisibleListMarker =
         options.isFirstLine && block.attrs?.listMarker && !block.attrs.listMarkerHidden;
@@ -2041,7 +2042,14 @@ export function renderLine(
       const firstLineHangingExpansionPx = hasVisibleListMarker
         ? Math.min(firstLineHangingPx, Math.max(0, options.leftIndentPx ?? 0))
         : firstLineHangingPx;
-      const justifyCapacityPx = options.availableWidth + firstLineHangingExpansionPx;
+      // Keep the explicit word-spacing budget identical to the measurer's
+      // first-line width. The line box itself stays at the full paragraph
+      // width because CSS text-indent consumes the positive first-line region.
+      // Counting that region again here lets tab-bearing justified lines
+      // distribute it as extra word spacing, shifting their right edge past
+      // the paragraph margin by exactly the first-line indent.
+      const justifyCapacityPx =
+        options.availableWidth - firstLinePositiveIndentPx + firstLineHangingExpansionPx;
       const overfullPx = line.width - justifyCapacityPx;
       const shrinkableSpaces = countShrinkableSpaces(
         runsForLine.filter((run) => !isTextRun(run) || !isCollapsedLineEdgeSpaceRun(run)),


### PR DESCRIPTION
Correct the explicit word-spacing budget for justified first lines with positive indentation. The painter now uses the same available content width as measurement, preventing tab-bearing lines from extending into the right margin.

Adds regression coverage for positive first-line indents and updates the existing synthetic measurement fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved justified paragraph rendering when the first line has a positive indentation.
  * Prevented underfilled tabbed lines from receiving excessive word spacing.
  * Ensured justified lines retain their full available width while respecting paragraph margins.

* **Release**
  * Included these improvements in a patch release of the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->