### PR TITLE
fix: use self-bound npm release tooling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@5628b97fb3c560c0d961baa60c272c598eddcab5 # v1.7.0
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@2b8697f04b39187c934afc04f7b04ad1a18bd827 # package latest-pointer policy
     with:
       artifact-pattern: npm-tarball-*
       artifact-run-id: ${{ inputs.artifact-run-id }}


### PR DESCRIPTION
## Summary

Advance the immutable shared npm-release workflow pin to the revision that checks out its action implementation from the called workflow commit. This makes the existing offset-pagination duplicate guard effective during package publication.

The previous reusable workflow revision loaded older action tooling, so a release repeated across a moving page boundary was treated as two distinct releases.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use the latest pinned version of the shared publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->