### PR TITLE
feat: headless report builders and table-of-contents field

### DIFF
--- a/.changeset/headless-report-primitives.md
+++ b/.changeset/headless-report-primitives.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": minor
+"@stll/docx-core": minor
+---
+
+Headless DOCX report generation: `/server` exports typed builders (`heading`, `paragraph`, `run`, `table`, `pageBreak`, `hyperlink`, `bookmark`, `endnote`, `createTableOfContentsField`); external hyperlinks inside headers, footers, footnotes and endnotes now get relationships in their own rels part; `createEmptyDocument` initialises `package.relationships` so in-memory headers and footers materialise; `DocumentSettings.updateFields` round-trips; the Stella style set gains `Heading1`-`Heading6`, `TOCHeading`, `TOC1`-`TOC3`, `EndnoteReference` and `EndnoteText`; complex fields keep `w:dirty`/`w:fldLock` across parse and save.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -1306,6 +1306,9 @@ export class InvalidFolioDocxXmlPatchProposalError extends InvalidFolioDocxXmlPa
 // @public (undocumented)
 export class InvalidFolioDocxXmlPatchProposalOptionsError extends InvalidFolioDocxXmlPatchProposalOptionsError_base {}
 
+// @public
+export class InvalidFolioReportBuilderOptionsError extends InvalidFolioReportBuilderOptionsError_base {}
+
 // @public (undocumented)
 export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
 

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -4,8 +4,16 @@
 
 ```ts
 
+import { Hyperlink } from '@stll/docx-core/model';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
+import { Paragraph } from '@stll/docx-core/model';
+import { ParagraphContent } from '@stll/docx-core/model';
+import { ParagraphFormatting } from '@stll/docx-core/model';
+import { Run } from '@stll/docx-core/model';
+import { ShadingProperties } from '@stll/docx-core/model';
+import { Table } from '@stll/docx-core/model';
 import { TaggedErrorClass } from 'better-result';
+import { TextFormatting } from '@stll/docx-core/model';
 
 // @public
 export const applyDocxXmlPatchProposal: (input: ApplyDocxXmlPatchProposalArgs) => Promise<FolioDocxXmlPatchApplication>;
@@ -42,6 +50,9 @@ export const applyFolioVersionDiffPrivacy: (diff: FolioVersionDiff, options: Fol
 export const assertSupportedFolioDocumentOperationVersion: (value: unknown) => typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
 
 // @public
+export const bookmark: (input: BookmarkOptions) => ParagraphContent[];
+
+// @public
 export const compareDocxVersions: (base: ArrayBuffer, revised: ArrayBuffer, options?: FolioCompareDocxVersionsOptions) => Promise<FolioVersionDiff>;
 
 // @public (undocumented)
@@ -69,6 +80,9 @@ export const createStellaStyleDocumentPreset: () => DocumentPreset;
 
 // @public
 export const createStellaStyleSet: () => DocumentStyleSet;
+
+// @public
+export const createTableOfContentsField: (input?: TableOfContentsOptions) => Paragraph;
 
 // @public (undocumented)
 export const deriveBlockId: (input: DeriveBlockIdInput) => FolioBlockId;
@@ -151,6 +165,9 @@ export type DocxTableRowPosition = {
 
 // @public
 export function docxToMarkdown(input: ArrayBuffer | Uint8Array, opts?: MarkdownOptions): Promise<string>;
+
+// @public
+export const endnote: (doc: import__stll_docx_core_model.Document, content: string | Paragraph[]) => Run;
 
 // @public
 export const ensureParaIds: (docx: Uint8Array | ArrayBuffer, options?: EnsureParaIdsOptions) => Promise<EnsureParaIdsResult>;
@@ -1249,6 +1266,18 @@ export const getFolioParaIdFromBlockId: (id: string) => string | null;
 // @public (undocumented)
 export const hashFolioAIBlockText: (text: string) => string;
 
+// @public
+export const heading: (input: HeadingOptions) => Paragraph;
+
+// @public (undocumented)
+export const HEADING_LEVELS: readonly [1, 2, 3, 4, 5, 6];
+
+// @public (undocumented)
+export type HeadingLevel = (typeof HEADING_LEVELS)[number];
+
+// @public
+export const hyperlink: (input: HyperlinkOptions) => Hyperlink;
+
 // @public (undocumented)
 export const inspectDocumentStyles: (document: import__stll_docx_core_model.Document) => DocumentStyleCatalog;
 
@@ -1313,11 +1342,32 @@ export const isSupportedFolioDocumentOperationVersion: (value: unknown) => value
 // @public (undocumented)
 export const normalizeFolioAIBlockText: (text: string) => string;
 
+// @public
+export const pageBreak: () => Paragraph;
+
+// @public (undocumented)
+export const paragraph: (content: string | ParagraphContent[], formatting?: ParagraphFormatting) => Paragraph;
+
+// @public
+export function parseDocx(input: DocxInput, options?: ParseOptions): Promise<import__stll_docx_core_model.Document>;
+
 // @public (undocumented)
 export const parseFolioDocumentOperationBatch: (value: unknown) => FolioDocumentOperationBatch;
 
 // @public (undocumented)
 export const parseFolioDocxXmlPatchProposal: (value: unknown) => FolioDocxXmlPatchProposal;
+
+// @public
+export type ParseOptions = {
+    onProgress?: ProgressCallback;
+    preloadFonts?: boolean;
+    parseHeadersFooters?: boolean;
+    parseNotes?: boolean;
+    detectVariables?: boolean;
+    password?: string | undefined;
+    unzipLimits?: DocxUnzipOptions;
+    mediaResolver?: MediaResolver;
+};
 
 // @public
 export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: FolioDocumentSectionHandle) => FolioDocumentSectionReadResult;
@@ -1335,7 +1385,21 @@ export type RewriteDocxMetadataPrivacyResult = {
 };
 
 // @public (undocumented)
+export const run: (text: string, formatting?: TextFormatting) => Run;
+
+// @public (undocumented)
 export const STELLA_STYLE_SET_NAME = "Stella Style";
+
+// @public
+export const table: (input: TableOptions) => Table;
+
+// @public (undocumented)
+export type TableCellSpec = string | {
+    content: Paragraph[];
+    shading?: ShadingProperties;
+    gridSpan?: number;
+    vMerge?: "restart" | "continue";
+};
 
 // @public (undocumented)
 export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -179,6 +179,7 @@ export type DocumentSettings = {
     compatibilityMode?: number;
     defaultTabStop: number;
     evenAndOddHeaders?: boolean;
+    updateFields?: boolean;
     themeFontLang?: {
         eastAsia?: string;
         bidi?: string;

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -774,3 +774,28 @@ describe("parseParagraph native frame geometry", () => {
     });
   });
 });
+
+describe("complex field begin flags", () => {
+  test("keeps w:dirty and w:fldLock from the begin fldChar and re-serialises them", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r><w:fldChar w:fldCharType="begin" w:dirty="true" w:fldLock="true"/></w:r>
+        <w:r><w:instrText xml:space="preserve"> TOC \\o "1-3" </w:instrText></w:r>
+        <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+        <w:r><w:t>placeholder</w:t></w:r>
+        <w:r><w:fldChar w:fldCharType="end"/></w:r>
+      </w:p>
+    `);
+
+    const field = paragraph.content[0];
+    expect(field?.type).toBe("complexField");
+    if (field?.type !== "complexField") {
+      return;
+    }
+    expect(field.dirty).toBe(true);
+    expect(field.fldLock).toBe(true);
+
+    const xml = serializeParagraph(paragraph);
+    expect(xml).toContain('w:fldCharType="begin" w:fldLock="true" w:dirty="true"');
+  });
+});

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1311,6 +1311,8 @@ function parseParagraphContents(
 
         // Look for field characters
         let hasFieldBegin = false;
+        let beginFldLock = false;
+        let beginDirty = false;
         let hasFieldSeparate = false;
         let hasFieldEnd = false;
         let endOriginalValue: string | undefined;
@@ -1320,12 +1322,8 @@ function parseParagraphContents(
           if (content.type === "fieldChar") {
             if (content.charType === "begin") {
               hasFieldBegin = true;
-              if (content.fldLock) {
-                complexFieldLock = true;
-              }
-              if (content.dirty) {
-                complexFieldDirty = true;
-              }
+              beginFldLock = content.fldLock === true;
+              beginDirty = content.dirty === true;
             } else if (content.charType === "separate") {
               hasFieldSeparate = true;
             } else {
@@ -1357,8 +1355,9 @@ function parseParagraphContents(
           complexFieldInstr = "";
           complexFieldCodeRuns = [];
           complexFieldResultRuns = [];
-          complexFieldLock = false;
-          complexFieldDirty = false;
+          // `w:fldLock` / `w:dirty` live on the begin fldChar of this field.
+          complexFieldLock = beginFldLock;
+          complexFieldDirty = beginDirty;
           // The structural run carrying `begin` often holds the field's run
           // formatting (e.g. a footer PAGE field collapsed into one run).
           complexFieldFormatting = run.formatting;

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -724,9 +724,29 @@ function parseNotesContent(
   rels: RelationshipMap,
   media: Map<string, MediaFile>,
 ): { footnotes: Footnote[]; endnotes: Endnote[] } {
-  const footnoteMap = parseFootnotes(raw.footnotesXml, styles, theme, numbering, rels, media);
+  // Note parts own their relationships (word/_rels/footnotes.xml.rels); fall
+  // back to the document rels only when the part has none.
+  const relsForNotePart = (partPath: string): RelationshipMap => {
+    const xml = getMapCaseInsensitive(raw.allXml, getRelationshipsPathForPart(partPath));
+    return xml ? parseRelationships(xml) : rels;
+  };
+  const footnoteMap = parseFootnotes(
+    raw.footnotesXml,
+    styles,
+    theme,
+    numbering,
+    relsForNotePart("word/footnotes.xml"),
+    media,
+  );
 
-  const endnoteMap = parseEndnotes(raw.endnotesXml, styles, theme, numbering, rels, media);
+  const endnoteMap = parseEndnotes(
+    raw.endnotesXml,
+    styles,
+    theme,
+    numbering,
+    relsForNotePart("word/endnotes.xml"),
+    media,
+  );
 
   return {
     footnotes: footnoteMap.getNormalFootnotes(),

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -85,6 +85,7 @@ import {
   getNamespaceUri,
   matchesName,
   parseXml,
+  WORDPROCESSINGML_NAMESPACE_URIS,
   type XmlElement,
 } from "./xmlParser";
 import { assertXmlResourceLimits } from "./xmlResourceLimits";
@@ -112,14 +113,9 @@ export function findMaxRId(relsXml: string): number {
   return maxId;
 }
 
-const WORDPROCESSINGML_NAMESPACES: ReadonlySet<string> = new Set([
-  "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
-  "http://purl.oclc.org/ooxml/wordprocessingml/main",
-]);
-
 const isWordprocessingElement = (element: XmlElement, localName: string): boolean =>
   getLocalName(element.name) === localName &&
-  WORDPROCESSINGML_NAMESPACES.has(getNamespaceUri(element) ?? "");
+  WORDPROCESSINGML_NAMESPACE_URIS.has(getNamespaceUri(element) ?? "");
 
 const countDocumentSections = (xml: string): number => {
   assertXmlResourceLimits(xml);
@@ -398,9 +394,11 @@ function relativeTargetForPart(partPath: string, absoluteTarget: string): string
  * Every package part whose block content may mint relationships (images,
  * external hyperlinks), paired with the rels part those relationships belong
  * to. Header/footer parts own `word/_rels/<part>.rels`; footnotes and endnotes
- * own `word/_rels/footnotes.xml.rels` / `endnotes.xml.rels`.
+ * own `word/_rels/<notes part>.rels`, derived from the ZIP entry the note
+ * serializer resolves (case-insensitively) so a producer's casing is reused
+ * instead of minting a second, lowercase rels part.
  */
-function collectDocxParts(doc: Document): DocxPart[] {
+function collectDocxParts(doc: Document, zip: JSZip): DocxPart[] {
   const parts: DocxPart[] = [
     {
       relsPath: "word/_rels/document.xml.rels",
@@ -427,14 +425,21 @@ function collectDocxParts(doc: Document): DocxPart[] {
   addHeaderFooterParts(doc.package.headers, RELATIONSHIP_TYPES.header);
   addHeaderFooterParts(doc.package.footers, RELATIONSHIP_TYPES.footer);
 
-  const addNoteParts = (notes: readonly (Footnote | Endnote)[] | undefined, relsPath: string) => {
+  const addNoteParts = (
+    notes: readonly (Footnote | Endnote)[] | undefined,
+    conventionalLowerPath: "word/footnotes.xml" | "word/endnotes.xml",
+  ) => {
     if (!notes || notes.length === 0) {
       return;
     }
-    parts.push({ relsPath, blocks: notes.flatMap((note) => note.content) });
+    const partPath = findNotePartEntry(zip, conventionalLowerPath)?.name ?? conventionalLowerPath;
+    parts.push({
+      relsPath: notePartRelsPath(partPath),
+      blocks: notes.flatMap((note) => note.content),
+    });
   };
-  addNoteParts(doc.package.footnotes, "word/_rels/footnotes.xml.rels");
-  addNoteParts(doc.package.endnotes, "word/_rels/endnotes.xml.rels");
+  addNoteParts(doc.package.footnotes, "word/footnotes.xml");
+  addNoteParts(doc.package.endnotes, "word/endnotes.xml");
 
   return parts;
 }
@@ -828,7 +833,7 @@ const finishRepack = async ({
 }: FinishRepackOptions): Promise<ArrayBuffer> => {
   await materializeNewHeaderFooterParts(document, outputZip, compressionLevel);
 
-  const parts = collectDocxParts(document);
+  const parts = collectDocxParts(document, outputZip);
   await processNewImages(parts, outputZip, compressionLevel);
   await processNewHyperlinks(parts, outputZip, compressionLevel);
 
@@ -959,7 +964,7 @@ export async function repackDocxFromRaw(
   // into a newly created header/footer's own rels.
   await materializeNewHeaderFooterParts(exportDocument, newZip, compressionLevel);
 
-  const parts = collectDocxParts(exportDocument);
+  const parts = collectDocxParts(exportDocument, newZip);
   await processNewImages(parts, newZip, compressionLevel);
   await processNewHyperlinks(parts, newZip, compressionLevel);
 
@@ -2051,6 +2056,12 @@ function collectChangedNoteParaIds(baselineXml: string, currentXml: string): Set
     }
   }
   return changed;
+}
+
+/** `word/Footnotes.xml` -> `word/_rels/Footnotes.xml.rels` (casing preserved). */
+export function notePartRelsPath(partPath: string): string {
+  const lastSlash = partPath.lastIndexOf("/");
+  return `${partPath.slice(0, lastSlash + 1)}_rels/${partPath.slice(lastSlash + 1)}.rels`;
 }
 
 /**

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -32,7 +32,16 @@
 import { panic } from "better-result";
 import JSZip from "jszip";
 
-import type { BlockContent, Comment, HeaderFooter, Image, Hyperlink, Run } from "../types/content";
+import type {
+  BlockContent,
+  Comment,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Image,
+  Hyperlink,
+  Run,
+} from "../types/content";
 import type { Document, Watermark } from "../types/document";
 import { applyReplyThreadMarkers } from "./commentReplyMarkers";
 import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
@@ -385,20 +394,23 @@ function relativeTargetForPart(partPath: string, absoluteTarget: string): string
   return `${"../".repeat(fromDir.length - shared)}${to.slice(shared).join("/")}`;
 }
 
-function collectImageParts(doc: Document): DocxPart[] {
+/**
+ * Every package part whose block content may mint relationships (images,
+ * external hyperlinks), paired with the rels part those relationships belong
+ * to. Header/footer parts own `word/_rels/<part>.rels`; footnotes and endnotes
+ * own `word/_rels/footnotes.xml.rels` / `endnotes.xml.rels`.
+ */
+function collectDocxParts(doc: Document): DocxPart[] {
   const parts: DocxPart[] = [
     {
       relsPath: "word/_rels/document.xml.rels",
       blocks: doc.package.document.content,
     },
   ];
-  const rels = doc.package.relationships;
-  if (!rels) {
-    return parts;
-  }
 
+  const rels = doc.package.relationships;
   const addHeaderFooterParts = (map: Map<string, HeaderFooter> | undefined, type: string) => {
-    if (!map) {
+    if (!map || !rels) {
       return;
     }
     for (const [rId, headerFooter] of map.entries()) {
@@ -412,9 +424,17 @@ function collectImageParts(doc: Document): DocxPart[] {
       });
     }
   };
-
   addHeaderFooterParts(doc.package.headers, RELATIONSHIP_TYPES.header);
   addHeaderFooterParts(doc.package.footers, RELATIONSHIP_TYPES.footer);
+
+  const addNoteParts = (notes: readonly (Footnote | Endnote)[] | undefined, relsPath: string) => {
+    if (!notes || notes.length === 0) {
+      return;
+    }
+    parts.push({ relsPath, blocks: notes.flatMap((note) => note.content) });
+  };
+  addNoteParts(doc.package.footnotes, "word/_rels/footnotes.xml.rels");
+  addNoteParts(doc.package.endnotes, "word/_rels/endnotes.xml.rels");
 
   return parts;
 }
@@ -649,7 +669,7 @@ async function processNewImages(
  * Collect all hyperlinks that have an href but no rId from block content.
  * These are newly created hyperlinks that need relationship entries.
  */
-function collectHyperlinksWithoutRId(blocks: BlockContent[]): Hyperlink[] {
+export function collectHyperlinksWithoutRId(blocks: BlockContent[]): Hyperlink[] {
   const hyperlinks: Hyperlink[] = [];
 
   for (const block of blocks) {
@@ -665,6 +685,8 @@ function collectHyperlinksWithoutRId(blocks: BlockContent[]): Hyperlink[] {
           hyperlinks.push(...collectHyperlinksWithoutRId(cell.content));
         }
       }
+    } else {
+      hyperlinks.push(...collectHyperlinksWithoutRId(block.content));
     }
   }
 
@@ -672,49 +694,48 @@ function collectHyperlinksWithoutRId(blocks: BlockContent[]): Hyperlink[] {
 }
 
 /**
- * Process newly created hyperlinks: assign rIds and add relationship entries.
- * Mutates the hyperlinks' rId fields in-place.
+ * Process newly created hyperlinks in every part: assign rIds and add
+ * relationship entries to the owning part's rels. Mutates the hyperlinks' rId
+ * fields in-place.
  */
 async function processNewHyperlinks(
-  newHyperlinks: Hyperlink[],
+  parts: DocxPart[],
   zip: JSZip,
   compressionLevel: number,
 ): Promise<void> {
-  if (newHyperlinks.length === 0) {
-    return;
-  }
-
-  const relsPath = "word/_rels/document.xml.rels";
-  const relsFile = zip.file(relsPath);
-  if (!relsFile) {
-    return;
-  }
-  let relsXml = await relsFile.async("text");
-
-  let maxId = findMaxRId(relsXml);
-  const relEntries: string[] = [];
-
-  for (const hyperlink of newHyperlinks) {
-    maxId++;
-    const newRId = `rId${maxId}`;
-
-    if (!hyperlink.href) {
+  for (const { relsPath, blocks } of parts) {
+    const newHyperlinks = collectHyperlinksWithoutRId(blocks);
+    if (newHyperlinks.length === 0) {
       continue;
     }
-    relEntries.push(
-      `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.hyperlink}" Target="${escapeXml(hyperlink.href)}" TargetMode="External"/>`,
+
+    // oxlint-disable-next-line no-await-in-loop -- rels parts are read and rewritten one at a time so each part's rId counter stays consistent
+    const relsXml = await readRelsOrStub(zip, relsPath);
+    let maxId = findMaxRId(relsXml);
+    const relEntries: string[] = [];
+
+    for (const hyperlink of newHyperlinks) {
+      if (!hyperlink.href) {
+        continue;
+      }
+      maxId++;
+      const newRId = `rId${maxId}`;
+      relEntries.push(
+        `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.hyperlink}" Target="${escapeXml(hyperlink.href)}" TargetMode="External"/>`,
+      );
+
+      // Rewrite the hyperlink's rId so the serializer outputs the correct reference
+      hyperlink.rId = newRId;
+    }
+
+    zip.file(
+      relsPath,
+      relsXml.replace("</Relationships>", `${relEntries.join("")}</Relationships>`),
+      {
+        compression: "DEFLATE",
+        compressionOptions: { level: compressionLevel },
+      },
     );
-
-    // Rewrite the hyperlink's rId so the serializer outputs the correct reference
-    hyperlink.rId = newRId;
-  }
-
-  if (relEntries.length > 0) {
-    relsXml = relsXml.replace("</Relationships>", `${relEntries.join("")}</Relationships>`);
-    zip.file(relsPath, relsXml, {
-      compression: "DEFLATE",
-      compressionOptions: { level: compressionLevel },
-    });
   }
 }
 
@@ -807,10 +828,9 @@ const finishRepack = async ({
 }: FinishRepackOptions): Promise<ArrayBuffer> => {
   await materializeNewHeaderFooterParts(document, outputZip, compressionLevel);
 
-  await processNewImages(collectImageParts(document), outputZip, compressionLevel);
-
-  const newHyperlinks = collectHyperlinksWithoutRId(document.package.document.content);
-  await processNewHyperlinks(newHyperlinks, outputZip, compressionLevel);
+  const parts = collectDocxParts(document);
+  await processNewImages(parts, outputZip, compressionLevel);
+  await processNewHyperlinks(parts, outputZip, compressionLevel);
 
   assertValidFolioDocumentModel(document, "Cannot repack invalid DOCX document model");
 
@@ -935,14 +955,13 @@ export async function repackDocxFromRaw(
   }
 
   // Promote in-memory header/footer parts to real parts/relationships first, so
-  // collectImageParts sees them and processNewImages can write image relations
+  // collectDocxParts sees them and processNewImages can write image relations
   // into a newly created header/footer's own rels.
   await materializeNewHeaderFooterParts(exportDocument, newZip, compressionLevel);
 
-  await processNewImages(collectImageParts(exportDocument), newZip, compressionLevel);
-
-  const newHyperlinks = collectHyperlinksWithoutRId(exportDocument.package.document.content);
-  await processNewHyperlinks(newHyperlinks, newZip, compressionLevel);
+  const parts = collectDocxParts(exportDocument);
+  await processNewImages(parts, newZip, compressionLevel);
+  await processNewHyperlinks(parts, newZip, compressionLevel);
 
   assertValidFolioDocumentModel(exportDocument, "Cannot repack invalid DOCX document model");
 
@@ -1406,24 +1425,31 @@ async function materializeNewHeaderFooterParts(
   zip: JSZip,
   compressionLevel: number,
 ): Promise<void> {
-  const rels = doc.package.relationships;
-  if (!rels) {
-    return;
-  }
   // Cheap guard so the common repack (no in-memory parts) skips the zip scans
   // and rels walk below.
   if (!hasUnmaterializedHeaderFooter(doc)) {
     return;
   }
+  // A from-scratch document has no relationship map yet; the minted
+  // relationships below become its first entries.
+  doc.package.relationships ??= new Map();
+  const rels = doc.package.relationships;
 
   const relEntries: string[] = [];
   const overrides: string[] = [];
   let maxHeaderNum = findMaxHeaderFooterNum(zip, "header");
   let maxFooterNum = findMaxHeaderFooterNum(zip, "footer");
+  // The zip's document rels may hold relationships the model map does not
+  // (the fresh-document seed writes styles/numbering/settings rels directly),
+  // so they count as taken ids too.
+  const relsPath = "word/_rels/document.xml.rels";
+  const relsXml = await readRelsOrStub(zip, relsPath);
+  const zipRels = parseRelationships(relsXml);
   // Seed the rId counter above every numeric id already in use — in the
-  // relationship map AND as a header/footer map key — so a freshly minted id
-  // can never collide with another (possibly not-yet-materialized) part.
-  let maxRId = 0;
+  // relationship map, the zip rels, AND as a header/footer map key — so a
+  // freshly minted id can never collide with another (possibly
+  // not-yet-materialized) part.
+  let maxRId = findMaxRId(relsXml);
   const considerNumericRId = (id: string): void => {
     const match = /^rId(?<num>\d+)$/u.exec(id);
     if (match) {
@@ -1463,7 +1489,7 @@ async function materializeNewHeaderFooterParts(
       return;
     }
     for (const rId of [...map.keys()]) {
-      const existing = rels.get(rId);
+      const existing = rels.get(rId) ?? zipRels.get(rId);
       if (existing && existing.type === relType && existing.target) {
         continue; // Already a materialized part of this kind.
       }
@@ -1518,8 +1544,6 @@ async function materializeNewHeaderFooterParts(
   }
 
   const compressionOptions = { level: compressionLevel };
-  const relsPath = "word/_rels/document.xml.rels";
-  const relsXml = await readRelsOrStub(zip, relsPath);
   zip.file(
     relsPath,
     relsXml.replace("</Relationships>", `${relEntries.join("")}</Relationships>`),

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -385,10 +385,22 @@ export async function attemptSelectiveSave(
   if (originalBuffer.byteLength > maxBytes) {
     return null;
   }
-  // Check for new images/hyperlinks that need relationship management
+  // Check for new images/hyperlinks that need relationship management; a
+  // header, footer, or note part mints them into its own rels, which only the
+  // full repack path writes.
   const content = doc.package.document.content;
   if (hasNewImagesOrHyperlinks(content)) {
     return null;
+  }
+  for (const part of [
+    ...(doc.package.headers?.values() ?? []),
+    ...(doc.package.footers?.values() ?? []),
+    ...(doc.package.footnotes ?? []),
+    ...(doc.package.endnotes ?? []),
+  ]) {
+    if (hasNewImagesOrHyperlinks(part.content)) {
+      return null;
+    }
   }
   // A header/footer created in memory needs a new part + relationship +
   // [Content_Types] Override, which only the full repack path writes.

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -684,11 +684,15 @@ function serializeComplexField(field: ComplexField): string {
   const structuralFormatting = field.formatting ?? field.fieldResult[0]?.formatting;
   const rPrXml = structuralFormatting ? serializeTextFormatting(structuralFormatting) : "";
 
-  // Begin field character (never set dirty — dirty causes apps to recalculate
-  // and potentially discard run formatting)
+  // Begin field character. `dirty` is emitted only when the model asks for it:
+  // it makes consumers recompute the field on open (and may discard result
+  // run formatting), which is what a generated TOC wants and nothing else.
   const beginAttrs: string[] = ['w:fldCharType="begin"'];
   if (field.fldLock) {
     beginAttrs.push('w:fldLock="true"');
+  }
+  if (field.dirty) {
+    beginAttrs.push('w:dirty="true"');
   }
   parts.push(`<w:r>${rPrXml}<w:fldChar ${beginAttrs.join(" ")}/></w:r>`);
 

--- a/packages/core/src/docx/serializer/settingsSerializer.ts
+++ b/packages/core/src/docx/serializer/settingsSerializer.ts
@@ -8,6 +8,9 @@ export const serializeSettingsXml = (settings: DocumentSettings): string => {
   if (settings.evenAndOddHeaders) {
     parts.push("<w:evenAndOddHeaders/>");
   }
+  if (settings.updateFields) {
+    parts.push('<w:updateFields w:val="true"/>');
+  }
   if (settings.themeFontLang) {
     const attrs: string[] = [];
     if (settings.themeFontLang.eastAsia) {

--- a/packages/core/src/docx/server/build.test.ts
+++ b/packages/core/src/docx/server/build.test.ts
@@ -13,7 +13,9 @@ import {
   createTableOfContentsField,
   endnote,
   heading,
+  type HeadingLevel,
   hyperlink,
+  InvalidFolioReportBuilderOptionsError,
   pageBreak,
   paragraph,
   run,
@@ -64,6 +66,43 @@ describe("hyperlink relationships outside the main body", () => {
 
     const parsed = await parseDocx(buffer, { preloadFonts: false });
     expect(firstHyperlinkHref(parsed.package.endnotes?.at(0)?.content ?? [])).toBe(LINK);
+  });
+
+  test("a note part cased by the producer keeps its own rels part", async () => {
+    const doc = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const ref = endnote(doc, [paragraph([run("See "), hyperlink({ text: "source", href: LINK })])]);
+    doc.package.document.content = [paragraph([run("Claim"), ref])];
+    const zip = await JSZip.loadAsync(await createDocx(doc));
+
+    // Re-case the note part and its rels the way some producers do.
+    const rename = async (from: string, to: string) => {
+      const xml = await zip.file(from)?.async("string");
+      expect(xml).toBeDefined();
+      zip.remove(from);
+      zip.file(to, xml ?? "");
+    };
+    await rename("word/endnotes.xml", "word/Endnotes.xml");
+    await rename("word/_rels/endnotes.xml.rels", "word/_rels/Endnotes.xml.rels");
+    const recase = async (path: string) => {
+      const xml = await zip.file(path)?.async("string");
+      zip.file(path, (xml ?? "").replaceAll("endnotes.xml", "Endnotes.xml"));
+    };
+    await recase("[Content_Types].xml");
+    await recase("word/_rels/document.xml.rels");
+
+    const parsed = await parseDocx(await zip.generateAsync({ type: "arraybuffer" }), {
+      preloadFonts: false,
+    });
+    const note = parsed.package.endnotes?.at(0);
+    expect(note).toBeDefined();
+    const secondLink = `${LINK}/second`;
+    note?.content.push(paragraph([hyperlink({ text: "more", href: secondLink })]));
+
+    const buffer = await createDocx(parsed);
+    expect(await zipText(buffer, "word/_rels/endnotes.xml.rels")).toBeUndefined();
+    expect(
+      externalHyperlinkRel(await zipText(buffer, "word/_rels/Endnotes.xml.rels"), secondLink),
+    ).toBe(true);
   });
 
   test("a footer hyperlink is minted into the footer's own rels", async () => {
@@ -173,6 +212,55 @@ describe("table of contents field", () => {
       hyperlinks: false,
     }).content.at(0);
     expect(field?.type === "complexField" && field.instruction).toBe('TOC \\o "1-2" \\z \\u');
+  });
+});
+
+describe("builder input validation", () => {
+  const invalidTocLevels = [
+    { from: 0, to: 3 },
+    { from: 1, to: 10 },
+    { from: 3, to: 1 },
+    { from: 1.5, to: 3 },
+    { from: Number.NaN, to: 3 },
+  ];
+  test.each(invalidTocLevels)("rejects TOC levels %o", (levels) => {
+    expect(() => createTableOfContentsField({ levels })).toThrow(
+      InvalidFolioReportBuilderOptionsError,
+    );
+  });
+
+  test("accepts the full 1-9 TOC range", () => {
+    expect(() => createTableOfContentsField({ levels: { from: 1, to: 9 } })).not.toThrow();
+  });
+
+  test.each([0, -1, 1.5, Number.NaN])("rejects gridSpan %p", (gridSpan) => {
+    expect(() => table({ rows: [[{ content: [paragraph("x")], gridSpan }]] })).toThrow(
+      InvalidFolioReportBuilderOptionsError,
+    );
+  });
+
+  test.each([0, -100, 0.5, Number.POSITIVE_INFINITY])("rejects column width %p", (width) => {
+    expect(() => table({ rows: [["a", "b"]], columnWidths: [1000, width] })).toThrow(
+      InvalidFolioReportBuilderOptionsError,
+    );
+  });
+
+  test("column widths are validated even when no row uses them", () => {
+    expect(() => table({ rows: [], columnWidths: [0] })).toThrow(
+      InvalidFolioReportBuilderOptionsError,
+    );
+  });
+
+  test("rejects a heading level outside HEADING_LEVELS", () => {
+    // SAFETY: test deliberately bypasses the static type to exercise the runtime guard
+    const level = 7 as HeadingLevel;
+    expect(() => heading({ text: "x", level })).toThrow(InvalidFolioReportBuilderOptionsError);
+  });
+
+  test("the error carries the offending path", () => {
+    expect(() => table({ rows: [["a"]], columnWidths: [1000, -1] })).toThrow(
+      expect.objectContaining({ path: "columnWidths[1]" }),
+    );
   });
 });
 

--- a/packages/core/src/docx/server/build.test.ts
+++ b/packages/core/src/docx/server/build.test.ts
@@ -1,0 +1,243 @@
+import { validateDocumentModel, validateDocxPackage } from "@stll/docx-core";
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { createStellaStyleDocumentPreset } from "../../style-sets/stellaStyle";
+import type { HeaderFooter } from "../../types/document";
+import { createEmptyDocument } from "../../utils/createDocument";
+import { parseDocx } from "../parser";
+import { RELATIONSHIP_TYPES } from "../relsParser";
+import { createDocx } from "../rezip";
+import {
+  bookmark,
+  createTableOfContentsField,
+  endnote,
+  heading,
+  hyperlink,
+  pageBreak,
+  paragraph,
+  run,
+  table,
+} from "./build";
+
+const LINK = "https://example.test/source";
+
+const zipText = async (buffer: ArrayBuffer, path: string): Promise<string | undefined> =>
+  JSZip.loadAsync(buffer).then((zip) => zip.file(path)?.async("string"));
+
+const externalHyperlinkRel = (relsXml: string | undefined, href: string): boolean =>
+  relsXml !== undefined &&
+  [...relsXml.matchAll(/<Relationship\b[^>]*\/>/gu)].some(
+    ({ 0: rel }) =>
+      rel.includes(`Type="${RELATIONSHIP_TYPES.hyperlink}"`) &&
+      rel.includes(`Target="${href}"`) &&
+      rel.includes('TargetMode="External"'),
+  );
+
+const firstHyperlinkHref = (blocks: HeaderFooter["content"]): string | undefined => {
+  for (const block of blocks) {
+    if (block.type !== "paragraph") {
+      continue;
+    }
+    const link = block.content.find((item) => item.type === "hyperlink");
+    if (link?.type === "hyperlink") {
+      return link.href;
+    }
+  }
+  return undefined;
+};
+
+describe("hyperlink relationships outside the main body", () => {
+  test("an endnote hyperlink is minted into endnotes.xml.rels and round-trips", async () => {
+    const doc = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const ref = endnote(doc, [paragraph([run("See "), hyperlink({ text: "source", href: LINK })])]);
+    doc.package.document.content = [paragraph([run("Claim"), ref])];
+
+    const buffer = await createDocx(doc);
+
+    expect(externalHyperlinkRel(await zipText(buffer, "word/_rels/endnotes.xml.rels"), LINK)).toBe(
+      true,
+    );
+    expect(externalHyperlinkRel(await zipText(buffer, "word/_rels/document.xml.rels"), LINK)).toBe(
+      false,
+    );
+
+    const parsed = await parseDocx(buffer, { preloadFonts: false });
+    expect(firstHyperlinkHref(parsed.package.endnotes?.at(0)?.content ?? [])).toBe(LINK);
+  });
+
+  test("a footer hyperlink is minted into the footer's own rels", async () => {
+    const doc = createEmptyDocument();
+    const footerRId = "rIdFooter";
+    doc.package.footers = new Map([
+      [
+        footerRId,
+        {
+          type: "footer",
+          hdrFtrType: "default",
+          content: [paragraph([hyperlink({ text: "Site", href: LINK })])],
+        },
+      ],
+    ]);
+    doc.package.document.finalSectionProperties.footerReferences = [
+      { type: "default", rId: footerRId },
+    ];
+
+    const buffer = await createDocx(doc);
+    expect(externalHyperlinkRel(await zipText(buffer, "word/_rels/footer1.xml.rels"), LINK)).toBe(
+      true,
+    );
+
+    const parsed = await parseDocx(buffer, { preloadFonts: false });
+    const footer = [...(parsed.package.footers?.values() ?? [])].at(0);
+    expect(firstHyperlinkHref(footer?.content ?? [])).toBe(LINK);
+  });
+});
+
+describe("from-scratch header materialisation", () => {
+  test("a header referenced from section properties becomes a real part", async () => {
+    const doc = createEmptyDocument();
+    // The seed rels already use rId1 for styles; the header must not collide.
+    const headerRId = "rId1";
+    doc.package.headers = new Map([
+      [headerRId, { type: "header", hdrFtrType: "default", content: [paragraph("Report")] }],
+    ]);
+    doc.package.document.finalSectionProperties.headerReferences = [
+      { type: "default", rId: headerRId },
+    ];
+
+    const buffer = await createDocx(doc);
+    const zip = await JSZip.loadAsync(buffer);
+    expect(zip.file("word/header1.xml")).not.toBeNull();
+
+    const relsXml = await zip.file("word/_rels/document.xml.rels")!.async("string");
+    const ids = [...relsXml.matchAll(/Id="(?<id>[^"]+)"/gu)].map((match) => match.groups!.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(relsXml).toContain(`Type="${RELATIONSHIP_TYPES.header}" Target="header1.xml"`);
+
+    const parsed = await parseDocx(buffer, { preloadFonts: false });
+    const header = [...(parsed.package.headers?.values() ?? [])].at(0);
+    expect(header?.content.at(0)?.type).toBe("paragraph");
+    expect(parsed.package.document.finalSectionProperties.headerReferences).toHaveLength(1);
+  });
+});
+
+describe("table of contents field", () => {
+  test("serialises a dirty TOC field and the supporting styles", async () => {
+    const doc = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    doc.package.settings = { ...doc.package.settings, defaultTabStop: 720, updateFields: true };
+    doc.package.document.content = [
+      createTableOfContentsField(),
+      heading({ text: "One", level: 1 }),
+      heading({ text: "Two", level: 2 }),
+      heading({ text: "Three", level: 3 }),
+    ];
+
+    const buffer = await createDocx(doc);
+    const documentXml = await zipText(buffer, "word/document.xml");
+    expect(documentXml).toContain('<w:fldChar w:fldCharType="begin" w:dirty="true"/>');
+    expect(await zipText(buffer, "word/settings.xml")).toContain('<w:updateFields w:val="true"/>');
+
+    const stylesXml = (await zipText(buffer, "word/styles.xml")) ?? "";
+    for (const styleId of [
+      "TOCHeading",
+      "TOC1",
+      "TOC2",
+      "TOC3",
+      "Heading1",
+      "Heading6",
+      "EndnoteReference",
+      "EndnoteText",
+    ]) {
+      expect(stylesXml).toContain(`w:styleId="${styleId}"`);
+    }
+
+    const parsed = await parseDocx(buffer, { preloadFonts: false });
+    const first = parsed.package.document.content.at(0);
+    const field = first?.type === "paragraph" ? first.content.at(0) : undefined;
+    expect(field?.type).toBe("complexField");
+    if (field?.type !== "complexField") {
+      return;
+    }
+    expect(field.fieldType).toBe("TOC");
+    expect(field.instruction).toBe('TOC \\o "1-3" \\h \\z \\u');
+    expect(field.dirty).toBe(true);
+    expect(parsed.package.settings?.updateFields).toBe(true);
+    const heading1 = parsed.package.styles?.styles.find((style) => style.styleId === "Heading1");
+    expect(heading1?.pPr?.outlineLevel).toBe(0);
+  });
+
+  test("honours level and hyperlink options", () => {
+    const field = createTableOfContentsField({
+      levels: { from: 1, to: 2 },
+      hyperlinks: false,
+    }).content.at(0);
+    expect(field?.type === "complexField" && field.instruction).toBe('TOC \\o "1-2" \\z \\u');
+  });
+});
+
+describe("report builders end to end", () => {
+  test("builds a report that round-trips and validates", async () => {
+    const doc = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const shade = { fill: { rgb: "D9E2F3" }, pattern: "clear" as const };
+    const ref = endnote(doc, [
+      paragraph([run("Methodology: "), hyperlink({ text: "public record", href: LINK })]),
+    ]);
+    doc.package.document.content = [
+      paragraph(bookmark({ name: "cover", content: [run("Annual findings", { bold: true })] }), {
+        styleId: "Title",
+      }),
+      createTableOfContentsField(),
+      pageBreak(),
+      heading({ text: "Summary", level: 1 }),
+      paragraph([run("See the "), hyperlink({ text: "cover", anchor: "cover" }), run("."), ref]),
+      heading({ text: "Findings", level: 2 }),
+      table({
+        header: ["Area", "Finding", "Severity"],
+        headerShading: shade,
+        columnWidths: [2400, 4800, 1800],
+        rows: [
+          [{ content: [paragraph("Contracts")], vMerge: "restart" }, "Missing signature", "High"],
+          [{ content: [], vMerge: "continue" }, "Expired term", "Low"],
+          [{ content: [paragraph("Total")], gridSpan: 2 }, "2"],
+        ],
+      }),
+    ];
+
+    const model = validateDocumentModel(doc);
+    expect(model.issues.filter((issue) => issue.severity === "error")).toEqual([]);
+
+    const buffer = await createDocx(doc);
+    expect(await validateDocxPackage(buffer)).toEqual({ valid: true });
+
+    const parsed = await parseDocx(buffer, { preloadFonts: false });
+    expect(validateDocumentModel(parsed).issues.filter((i) => i.severity === "error")).toEqual([]);
+
+    const blocks = parsed.package.document.content;
+    const title = blocks.at(0);
+    expect(
+      title?.type === "paragraph" && title.content.some((c) => c.type === "bookmarkStart"),
+    ).toBe(true);
+    const headings = blocks.flatMap((block) =>
+      block.type === "paragraph" && block.formatting?.styleId?.startsWith("Heading")
+        ? [block.formatting.styleId]
+        : [],
+    );
+    expect(headings).toEqual(["Heading1", "Heading2"]);
+
+    const parsedTable = blocks.find((block) => block.type === "table");
+    expect(parsedTable?.type).toBe("table");
+    if (parsedTable?.type !== "table") {
+      return;
+    }
+    expect(parsedTable.rows).toHaveLength(4);
+    expect(parsedTable.rows[0]?.formatting?.header).toBe(true);
+    expect(parsedTable.rows[0]?.cells[0]?.formatting?.shading?.fill?.rgb).toBe("D9E2F3");
+    expect(parsedTable.rows[1]?.cells[0]?.formatting?.vMerge).toBe("restart");
+    expect(parsedTable.rows[2]?.cells[0]?.formatting?.vMerge).toBe("continue");
+    expect(parsedTable.rows[3]?.cells[0]?.formatting?.gridSpan).toBe(2);
+
+    expect(parsed.package.endnotes).toHaveLength(1);
+    expect(firstHyperlinkHref(parsed.package.endnotes?.at(0)?.content ?? [])).toBe(LINK);
+  });
+});

--- a/packages/core/src/docx/server/build.ts
+++ b/packages/core/src/docx/server/build.ts
@@ -1,0 +1,326 @@
+/**
+ * Headless document builders.
+ *
+ * Thin constructors for the `@stll/docx-core` model so a server can assemble
+ * a report in code (`createEmptyDocument` → push blocks → `createDocx`)
+ * without hand-writing model literals. They build model values only; the
+ * serializer owns the OOXML.
+ */
+
+import type { ShadingProperties } from "../../types/colors";
+import type {
+  BookmarkEnd,
+  BookmarkStart,
+  ComplexField,
+  Endnote,
+  Hyperlink,
+  Paragraph,
+  ParagraphContent,
+  Run,
+  Table,
+  TableCell,
+  TableRow,
+} from "../../types/content";
+import type { Document } from "../../types/document";
+import type { ParagraphFormatting, TextFormatting } from "../../types/formatting";
+
+/** Character style applied to hyperlink text; present in the bundled style sets. */
+const HYPERLINK_STYLE_ID = "Hyperlink";
+/** Character style applied to the endnote reference mark. */
+const ENDNOTE_REFERENCE_STYLE_ID = "EndnoteReference";
+/** Paragraph style applied to endnote body paragraphs. */
+const ENDNOTE_TEXT_STYLE_ID = "EndnoteText";
+/** Table style used by `table()`; present in the bundled style sets. */
+const TABLE_STYLE_ID = "TableGrid";
+/** `w:tblW w:type="pct"` is in fiftieths of a percent: 5000 = 100%. */
+const FULL_WIDTH_PCT = 5000;
+
+export const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
+export type HeadingLevel = (typeof HEADING_LEVELS)[number];
+
+export const run = (text: string, formatting?: TextFormatting): Run => ({
+  type: "run",
+  ...(formatting ? { formatting } : {}),
+  content: [{ type: "text", text }],
+});
+
+export const paragraph = (
+  content: string | ParagraphContent[],
+  formatting?: ParagraphFormatting,
+): Paragraph => ({
+  type: "paragraph",
+  ...(formatting ? { formatting } : {}),
+  content: typeof content === "string" ? [run(content)] : content,
+});
+
+type HeadingOptions = {
+  text: string;
+  level: HeadingLevel;
+};
+
+/** A paragraph in the `Heading<level>` style. */
+export const heading = ({ text, level }: HeadingOptions): Paragraph =>
+  paragraph(text, { styleId: `Heading${level}` });
+
+/** An empty paragraph carrying a hard page break. */
+export const pageBreak = (): Paragraph => ({
+  type: "paragraph",
+  content: [{ type: "run", content: [{ type: "break", breakType: "page" }] }],
+});
+
+type HyperlinkTarget = { href: string; anchor?: never } | { anchor: string; href?: never };
+
+type HyperlinkOptions = HyperlinkTarget & {
+  text: string;
+  formatting?: TextFormatting;
+  tooltip?: string;
+};
+
+/**
+ * An external (`href`) or in-document (`anchor`, a bookmark name) link. The
+ * relationship for an external link is minted when the document is written.
+ */
+export const hyperlink = ({
+  text,
+  formatting,
+  tooltip,
+  href,
+  anchor,
+}: HyperlinkOptions): Hyperlink => ({
+  type: "hyperlink",
+  ...(href !== undefined ? { href } : { anchor }),
+  ...(tooltip !== undefined ? { tooltip } : {}),
+  children: [run(text, { styleId: HYPERLINK_STYLE_ID, ...formatting })],
+});
+
+type BookmarkOptions = {
+  name: string;
+  content: ParagraphContent[];
+  /**
+   * Bookmark id, unique per document. Defaults to a process-wide counter,
+   * which is unique for documents built from scratch; pass an explicit id
+   * when adding bookmarks to a parsed document.
+   */
+  id?: number;
+};
+
+let nextBookmarkId = 0;
+
+/** `content` wrapped in a named bookmark, the target of `hyperlink({ anchor })`. */
+export const bookmark = ({ name, content, id }: BookmarkOptions): ParagraphContent[] => {
+  const bookmarkId = id ?? nextBookmarkId++;
+  const start: BookmarkStart = { type: "bookmarkStart", id: bookmarkId, name };
+  const end: BookmarkEnd = { type: "bookmarkEnd", id: bookmarkId };
+  return [start, ...content, end];
+};
+
+export type TableCellSpec =
+  | string
+  | {
+      content: Paragraph[];
+      shading?: ShadingProperties;
+      gridSpan?: number;
+      vMerge?: "restart" | "continue";
+    };
+
+type TableOptions = {
+  /** Header row labels; rendered bold, optionally shaded and repeated per page. */
+  header?: string[];
+  rows: TableCellSpec[][];
+  /** Grid column widths in twips. Omitted: the consumer autofits. */
+  columnWidths?: number[];
+  headerShading?: ShadingProperties;
+  /** Repeat the header row at the top of every page (default true). */
+  repeatHeader?: boolean;
+};
+
+type BuildCellOptions = {
+  spec: TableCellSpec;
+  columnWidths: number[] | undefined;
+  /** Grid column this cell starts at, for width lookup. */
+  gridIndex: number;
+  shading: ShadingProperties | undefined;
+  textFormatting: TextFormatting | undefined;
+};
+
+const cellWidth = (
+  columnWidths: number[] | undefined,
+  gridIndex: number,
+  gridSpan: number,
+): number | undefined => {
+  if (!columnWidths) {
+    return undefined;
+  }
+  let width = 0;
+  for (let column = gridIndex; column < gridIndex + gridSpan; column++) {
+    const columnWidth = columnWidths.at(column);
+    if (columnWidth === undefined) {
+      return undefined;
+    }
+    width += columnWidth;
+  }
+  return width;
+};
+
+const buildCell = ({
+  spec,
+  columnWidths,
+  gridIndex,
+  shading,
+  textFormatting,
+}: BuildCellOptions): TableCell => {
+  const resolved =
+    typeof spec === "string"
+      ? { content: [paragraph([run(spec, textFormatting)])], shading }
+      : { ...spec, shading: spec.shading ?? shading };
+  const gridSpan = resolved.gridSpan ?? 1;
+  const width = cellWidth(columnWidths, gridIndex, gridSpan);
+  const formatting = {
+    ...(width !== undefined ? { width: { type: "dxa" as const, value: width } } : {}),
+    ...(resolved.shading ? { shading: resolved.shading } : {}),
+    ...(resolved.gridSpan !== undefined ? { gridSpan: resolved.gridSpan } : {}),
+    ...(resolved.vMerge !== undefined ? { vMerge: resolved.vMerge } : {}),
+  };
+  return {
+    type: "tableCell",
+    ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
+    // A cell must end with a paragraph; a merged-away cell is typically empty.
+    content: resolved.content.length > 0 ? resolved.content : [paragraph([])],
+  };
+};
+
+type BuildRowOptions = {
+  cells: TableCellSpec[];
+  columnWidths: number[] | undefined;
+  shading: ShadingProperties | undefined;
+  textFormatting: TextFormatting | undefined;
+  header: boolean;
+};
+
+const buildRow = ({
+  cells,
+  columnWidths,
+  shading,
+  textFormatting,
+  header,
+}: BuildRowOptions): TableRow => {
+  const built: TableCell[] = [];
+  let gridIndex = 0;
+  for (const spec of cells) {
+    const cell = buildCell({ spec, columnWidths, gridIndex, shading, textFormatting });
+    built.push(cell);
+    gridIndex += cell.formatting?.gridSpan ?? 1;
+  }
+  return {
+    type: "tableRow",
+    ...(header ? { formatting: { header: true, cantSplit: true } } : {}),
+    cells: built,
+  };
+};
+
+/**
+ * A full-width grid table in the `TableGrid` style. A string cell becomes one
+ * plain paragraph; an object cell supplies its own paragraphs plus optional
+ * shading and horizontal (`gridSpan`) or vertical (`vMerge`) merge.
+ */
+export const table = ({
+  header,
+  rows,
+  columnWidths,
+  headerShading,
+  repeatHeader = true,
+}: TableOptions): Table => {
+  const builtRows: TableRow[] = [];
+  if (header) {
+    builtRows.push(
+      buildRow({
+        cells: header,
+        columnWidths,
+        shading: headerShading,
+        textFormatting: { bold: true },
+        header: repeatHeader,
+      }),
+    );
+  }
+  for (const cells of rows) {
+    builtRows.push(
+      buildRow({
+        cells,
+        columnWidths,
+        shading: undefined,
+        textFormatting: undefined,
+        header: false,
+      }),
+    );
+  }
+  return {
+    type: "table",
+    formatting: {
+      styleId: TABLE_STYLE_ID,
+      width: { type: "pct", value: FULL_WIDTH_PCT },
+      layout: columnWidths ? "fixed" : "autofit",
+    },
+    ...(columnWidths ? { columnWidths } : {}),
+    rows: builtRows,
+  };
+};
+
+/**
+ * Register an endnote on `doc` and return the reference run to place in body
+ * text. Allocates the next free endnote id (Word reserves 0 and -1 for the
+ * separator notes) and pushes the note into `doc.package.endnotes`.
+ */
+export const endnote = (doc: Document, content: string | Paragraph[]): Run => {
+  const endnotes = doc.package.endnotes ?? [];
+  doc.package.endnotes = endnotes;
+  const id = Math.max(0, ...endnotes.map((note) => note.id)) + 1;
+  const body =
+    typeof content === "string"
+      ? [paragraph(content, { styleId: ENDNOTE_TEXT_STYLE_ID })]
+      : content;
+  const note: Endnote = { type: "endnote", id, content: body };
+  endnotes.push(note);
+  return {
+    type: "run",
+    formatting: { styleId: ENDNOTE_REFERENCE_STYLE_ID },
+    content: [{ type: "endnoteRef", id }],
+  };
+};
+
+type TableOfContentsOptions = {
+  /** Heading levels to include (default 1-3). */
+  levels?: { from: number; to: number };
+  /** Make entries hyperlinks (`\h`, default true). */
+  hyperlinks?: boolean;
+  /** Result text shown until the consumer recomputes the field. */
+  placeholderText?: string;
+};
+
+const DEFAULT_TOC_LEVELS = { from: 1, to: 3 };
+const DEFAULT_TOC_PLACEHOLDER = "Update the field to build the table of contents.";
+
+/**
+ * A paragraph holding a dirty `TOC` field, so the consumer recomputes the
+ * table on open. Set `package.settings.updateFields` as well to have Word
+ * recompute without prompting for each field.
+ */
+export const createTableOfContentsField = ({
+  levels = DEFAULT_TOC_LEVELS,
+  hyperlinks = true,
+  placeholderText = DEFAULT_TOC_PLACEHOLDER,
+}: TableOfContentsOptions = {}): Paragraph => {
+  const switches = [`\\o "${levels.from}-${levels.to}"`];
+  if (hyperlinks) {
+    switches.push("\\h");
+  }
+  switches.push("\\z", "\\u");
+  const field: ComplexField = {
+    type: "complexField",
+    instruction: `TOC ${switches.join(" ")}`,
+    fieldType: "TOC",
+    fieldCode: [],
+    fieldResult: [run(placeholderText)],
+    dirty: true,
+  };
+  return { type: "paragraph", content: [field] };
+};

--- a/packages/core/src/docx/server/build.ts
+++ b/packages/core/src/docx/server/build.ts
@@ -7,6 +7,8 @@
  * serializer owns the OOXML.
  */
 
+import { TaggedError } from "better-result";
+
 import type { ShadingProperties } from "../../types/colors";
 import type {
   BookmarkEnd,
@@ -38,6 +40,51 @@ const FULL_WIDTH_PCT = 5000;
 export const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
 export type HeadingLevel = (typeof HEADING_LEVELS)[number];
 
+/** Outline levels a `TOC \o` switch may name (ECMA-376 `w:outlineLvl` 0-8). */
+const TOC_LEVEL_MIN = 1;
+const TOC_LEVEL_MAX = 9;
+
+/**
+ * A builder received a value outside the model's domain (a zero `gridSpan`,
+ * a negative column width, a reversed TOC range). Thrown at the boundary so
+ * the invalid value never reaches the serializer.
+ */
+export class InvalidFolioReportBuilderOptionsError extends TaggedError(
+  "InvalidFolioReportBuilderOptionsError",
+)<{
+  message: string;
+  path: string;
+}>() {}
+
+const assertPositiveInteger = (value: number, path: string): void => {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new InvalidFolioReportBuilderOptionsError({
+      message: `${path} must be a positive integer, got ${String(value)}`,
+      path,
+    });
+  }
+};
+
+const assertHeadingLevel = (level: number): void => {
+  if (!HEADING_LEVELS.some((known) => known === level)) {
+    throw new InvalidFolioReportBuilderOptionsError({
+      message: `level must be one of ${HEADING_LEVELS.join(", ")}, got ${String(level)}`,
+      path: "level",
+    });
+  }
+};
+
+const assertTocLevels = ({ from, to }: { from: number; to: number }): void => {
+  const inRange = (value: number) =>
+    Number.isInteger(value) && value >= TOC_LEVEL_MIN && value <= TOC_LEVEL_MAX;
+  if (!inRange(from) || !inRange(to) || from > to) {
+    throw new InvalidFolioReportBuilderOptionsError({
+      message: `levels must satisfy ${TOC_LEVEL_MIN} <= from <= to <= ${TOC_LEVEL_MAX}, got ${String(from)}-${String(to)}`,
+      path: "levels",
+    });
+  }
+};
+
 export const run = (text: string, formatting?: TextFormatting): Run => ({
   type: "run",
   ...(formatting ? { formatting } : {}),
@@ -59,8 +106,10 @@ type HeadingOptions = {
 };
 
 /** A paragraph in the `Heading<level>` style. */
-export const heading = ({ text, level }: HeadingOptions): Paragraph =>
-  paragraph(text, { styleId: `Heading${level}` });
+export const heading = ({ text, level }: HeadingOptions): Paragraph => {
+  assertHeadingLevel(level);
+  return paragraph(text, { styleId: `Heading${level}` });
+};
 
 /** An empty paragraph carrying a hard page break. */
 export const pageBreak = (): Paragraph => ({
@@ -174,6 +223,7 @@ const buildCell = ({
       ? { content: [paragraph([run(spec, textFormatting)])], shading }
       : { ...spec, shading: spec.shading ?? shading };
   const gridSpan = resolved.gridSpan ?? 1;
+  assertPositiveInteger(gridSpan, "gridSpan");
   const width = cellWidth(columnWidths, gridIndex, gridSpan);
   const formatting = {
     ...(width !== undefined ? { width: { type: "dxa" as const, value: width } } : {}),
@@ -230,6 +280,7 @@ export const table = ({
   headerShading,
   repeatHeader = true,
 }: TableOptions): Table => {
+  columnWidths?.forEach((width, index) => assertPositiveInteger(width, `columnWidths[${index}]`));
   const builtRows: TableRow[] = [];
   if (header) {
     builtRows.push(
@@ -288,7 +339,7 @@ export const endnote = (doc: Document, content: string | Paragraph[]): Run => {
 };
 
 type TableOfContentsOptions = {
-  /** Heading levels to include (default 1-3). */
+  /** Heading levels to include, `1 <= from <= to <= 9` (default 1-3). */
   levels?: { from: number; to: number };
   /** Make entries hyperlinks (`\h`, default true). */
   hyperlinks?: boolean;
@@ -309,6 +360,7 @@ export const createTableOfContentsField = ({
   hyperlinks = true,
   placeholderText = DEFAULT_TOC_PLACEHOLDER,
 }: TableOfContentsOptions = {}): Paragraph => {
+  assertTocLevels(levels);
   const switches = [`\\o "${levels.from}-${levels.to}"`];
   if (hyperlinks) {
     switches.push("\\h");

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -225,3 +225,30 @@ describe("parseSettings — break-only paragraph placement", () => {
     expect(parseSettings(wrap("")).splitPageBreakAndParagraphMark).toBeUndefined();
   });
 });
+
+describe("parseSettings — on/off flags resolve by namespace URI", () => {
+  const TRANSITIONAL_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+  const STRICT_HEAD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="http://purl.oclc.org/ooxml/wordprocessingml/main">`;
+  const FOREIGN_HEAD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="${TRANSITIONAL_NS}" xmlns:x="urn:example:foreign">`;
+  const flags = ["updateFields", "evenAndOddHeaders", "mirrorMargins"] as const;
+
+  test.each(flags)("%s: transitional, strict, and alternate-prefix forms are honoured", (flag) => {
+    expect(parseSettings(wrap(`<w:${flag}/>`))[flag]).toBe(true);
+    expect(parseSettings(`${STRICT_HEAD}<w:${flag}/>${SETTINGS_TAIL}`)[flag]).toBe(true);
+    expect(
+      parseSettings(`${FOREIGN_HEAD}<x:${flag} xmlns:x="${TRANSITIONAL_NS}"/>${SETTINGS_TAIL}`)[
+        flag
+      ],
+    ).toBe(true);
+  });
+
+  test.each(flags)(
+    "%s: a foreign-namespace element with the same local name is ignored",
+    (flag) => {
+      expect(parseSettings(`${FOREIGN_HEAD}<x:${flag}/>${SETTINGS_TAIL}`)[flag]).toBeUndefined();
+      expect(parseSettings(`${FOREIGN_HEAD}<${flag}/>${SETTINGS_TAIL}`)[flag]).toBeUndefined();
+    },
+  );
+});

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -66,6 +66,10 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
   if (mirrorMargins && parseBooleanElement(mirrorMargins)) {
     settings.mirrorMargins = true;
   }
+  const updateFields = root ? findChild(root, "w", "updateFields") : null;
+  if (updateFields && parseBooleanElement(updateFields)) {
+    settings.updateFields = true;
+  }
 
   // `w:themeFontLang` selects the concrete typeface for the empty `<a:ea>` /
   // `<a:cs>` theme slots (see eigenpal/docx-editor#949). Record only the

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -12,10 +12,12 @@
 import type { DocumentSettings } from "../types/document";
 import {
   findChild,
+  findChildByNamespaceUri,
   findChildren,
   getAttribute,
   parseBooleanElement,
   parseXmlDocument,
+  WORDPROCESSINGML_NAMESPACE_URIS,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
@@ -56,18 +58,22 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
   const settings: FolioDocumentSettings = {
     defaultTabStop: parseDefaultTabStop(root),
   };
+  // On/off flags are resolved by namespace URI: a foreign-namespace element
+  // that happens to share the local name must not switch them on (and
+  // `updateFields` in particular makes the consumer recompute every field).
+  const wordprocessingFlag = (localName: string): boolean => {
+    const element = findChildByNamespaceUri(root, WORDPROCESSINGML_NAMESPACE_URIS, localName);
+    return element !== null && parseBooleanElement(element);
+  };
   // `w:evenAndOddHeaders` lives in settings.xml, not sectPr. Only record the
   // "on" state; absence means odd/even share one header.
-  const evenAndOddHeaders = root ? findChild(root, "w", "evenAndOddHeaders") : null;
-  if (evenAndOddHeaders && parseBooleanElement(evenAndOddHeaders)) {
+  if (wordprocessingFlag("evenAndOddHeaders")) {
     settings.evenAndOddHeaders = true;
   }
-  const mirrorMargins = root ? findChild(root, "w", "mirrorMargins") : null;
-  if (mirrorMargins && parseBooleanElement(mirrorMargins)) {
+  if (wordprocessingFlag("mirrorMargins")) {
     settings.mirrorMargins = true;
   }
-  const updateFields = root ? findChild(root, "w", "updateFields") : null;
-  if (updateFields && parseBooleanElement(updateFields)) {
+  if (wordprocessingFlag("updateFields")) {
     settings.updateFields = true;
   }
 

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -335,6 +335,37 @@ export function getNamespacePrefix(name: string): string | null {
 /** Namespace URI resolved from the element's in-scope XML declarations. */
 export const getNamespaceUri = (element: XmlElement): string | undefined => element.namespaceUri;
 
+/** WordprocessingML main namespace, Transitional and Strict (ECMA-376 Parts 1 and 4). */
+export const WORDPROCESSINGML_NAMESPACE_URIS: ReadonlySet<string> = new Set([
+  NAMESPACES.w,
+  "http://purl.oclc.org/ooxml/wordprocessingml/main",
+]);
+
+/**
+ * First child whose local name matches AND whose resolved namespace URI is
+ * one of `namespaceUris`. Unlike {@link findChild}, a same-named element
+ * from a foreign namespace is not accepted.
+ */
+export function findChildByNamespaceUri(
+  parent: XmlElement | null | undefined,
+  namespaceUris: ReadonlySet<string>,
+  localName: string,
+): XmlElement | null {
+  if (!parent?.elements) {
+    return null;
+  }
+  for (const child of parent.elements) {
+    if (
+      child.type === "element" &&
+      hasLocalName(child.name, localName) &&
+      namespaceUris.has(child.namespaceUri ?? "")
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
 /** Get an attribute whose prefix resolves to one of the accepted namespace URIs. */
 export function getAttributeByNamespaceUri(
   element: XmlElement | null | undefined,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -55,6 +55,7 @@ export {
   heading,
   HEADING_LEVELS,
   hyperlink,
+  InvalidFolioReportBuilderOptionsError,
   pageBreak,
   paragraph,
   run,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -48,6 +48,20 @@ export {
 export { replyToComment, type CreateCommentReplyInput } from "./docx/replyToComment";
 export { createEmptyDocument, type CreateEmptyDocumentOptions } from "./utils/createDocument";
 export {
+  bookmark,
+  createTableOfContentsField,
+  endnote,
+  heading,
+  HEADING_LEVELS,
+  hyperlink,
+  pageBreak,
+  paragraph,
+  run,
+  table,
+  type HeadingLevel,
+  type TableCellSpec,
+} from "./docx/server/build";
+export {
   extractDocumentStyleSet,
   extractDocumentStyleSetFromDocx,
   inspectDocumentStyles,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -39,6 +39,7 @@ export {
   type FolioBlockId,
 } from "./types/block-id";
 export { createDocx } from "./docx/rezip";
+export { parseDocx, type ParseOptions } from "./docx/parser";
 export {
   ensureParaIds,
   EnsureParaIdsError,

--- a/packages/core/src/style-sets/stellaStyle.ts
+++ b/packages/core/src/style-sets/stellaStyle.ts
@@ -139,6 +139,8 @@ export const createStellaStyleSet = (): DocumentStyleSet => ({
         pPr: { keepNext: true, spaceBefore: 240 },
         rPr: { bold: true },
       },
+      ...createHeadingStyles(),
+      ...createTableOfContentsStyles(),
       ...createClauseStyles(),
       ...createDefinitionStyles(),
       {
@@ -205,6 +207,39 @@ export const createStellaStyleSet = (): DocumentStyleSet => ({
         styleId: "FootnoteReference",
         type: "character",
         name: "Footnote Reference",
+        basedOn: "DefaultParagraphFont",
+        semiHidden: true,
+        unhideWhenUsed: true,
+        uiPriority: 99,
+        rPr: { vertAlign: "superscript" },
+      },
+      {
+        styleId: "EndnoteText",
+        type: "paragraph",
+        name: "Endnote Text",
+        basedOn: "Normal",
+        link: "EndnoteTextChar",
+        semiHidden: true,
+        unhideWhenUsed: true,
+        uiPriority: 99,
+        pPr: { spaceAfter: 0 },
+        rPr: { fontSize: 18, fontSizeCs: 18 },
+      },
+      {
+        styleId: "EndnoteTextChar",
+        type: "character",
+        name: "Endnote Text Char",
+        basedOn: "DefaultParagraphFont",
+        link: "EndnoteText",
+        semiHidden: true,
+        unhideWhenUsed: true,
+        uiPriority: 99,
+        rPr: { fontSize: 18, fontSizeCs: 18 },
+      },
+      {
+        styleId: "EndnoteReference",
+        type: "character",
+        name: "Endnote Reference",
         basedOn: "DefaultParagraphFont",
         semiHidden: true,
         unhideWhenUsed: true,
@@ -282,6 +317,63 @@ export const createStellaStyleDocumentPreset = (): DocumentPreset => ({
     verticalAlign: "top",
   },
 });
+
+/**
+ * Built-in `Heading1`..`Heading6` with outline levels, so a TOC field and
+ * the document navigation pane pick the headings up.
+ */
+const createHeadingStyles = (): DocumentStyleSet["styles"]["styles"] => {
+  const levels = [
+    { styleId: "Heading1", name: "heading 1", fontSize: 28, spaceBefore: 360 },
+    { styleId: "Heading2", name: "heading 2", fontSize: 24, spaceBefore: 240 },
+    { styleId: "Heading3", name: "heading 3", fontSize: 22, spaceBefore: 240 },
+    { styleId: "Heading4", name: "heading 4", fontSize: 20, spaceBefore: 120 },
+    { styleId: "Heading5", name: "heading 5", fontSize: 20, spaceBefore: 120 },
+    { styleId: "Heading6", name: "heading 6", fontSize: 20, spaceBefore: 120 },
+  ] as const;
+  return levels.map(({ styleId, name, fontSize, spaceBefore }, level) => ({
+    styleId,
+    type: "paragraph",
+    name,
+    basedOn: "Normal",
+    next: "BodyText",
+    qFormat: true,
+    uiPriority: 9,
+    pPr: { keepNext: true, keepLines: true, spaceBefore, spaceAfter: 120, outlineLevel: level },
+    rPr: { bold: true, fontSize, fontSizeCs: fontSize },
+  }));
+};
+
+/** `TOCHeading` plus `TOC1`..`TOC3`, the styles a `TOC \o "1-3"` field fills. */
+const createTableOfContentsStyles = (): DocumentStyleSet["styles"]["styles"] => {
+  const levels = [
+    { styleId: "TOC1", name: "toc 1", indent: 0 },
+    { styleId: "TOC2", name: "toc 2", indent: 220 },
+    { styleId: "TOC3", name: "toc 3", indent: 440 },
+  ] as const;
+  return [
+    {
+      styleId: "TOCHeading",
+      type: "paragraph",
+      name: "TOC Heading",
+      basedOn: "Heading1",
+      next: "BodyText",
+      unhideWhenUsed: true,
+      uiPriority: 39,
+      pPr: { outlineLevel: 9 },
+    },
+    ...levels.map(({ styleId, name, indent }) => ({
+      styleId,
+      type: "paragraph" as const,
+      name,
+      basedOn: "Normal",
+      next: "Normal",
+      unhideWhenUsed: true,
+      uiPriority: 39,
+      pPr: { indentLeft: indent, spaceAfter: 100 },
+    })),
+  ];
+};
 
 const createClauseStyles = (): DocumentStyleSet["styles"]["styles"] => {
   const levels = [

--- a/packages/core/src/utils/createDocument.ts
+++ b/packages/core/src/utils/createDocument.ts
@@ -368,6 +368,7 @@ export function createEmptyDocument(options: CreateEmptyDocumentOptions = {}): D
   const docxPackage: DocxPackage = {
     conformanceClass: DOCX_CONFORMANCE_CLASSES.TRANSITIONAL,
     document: documentBody,
+    relationships: new Map(),
     styles: structuredClone(styleSet?.styles ?? defaultStyleDefinitions),
   };
   if (styleSet?.numbering) {

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -203,6 +203,12 @@ export type DocumentSettings = {
    */
   evenAndOddHeaders?: boolean;
   /**
+   * `w:updateFields` (§17.15.1.93) — ask the consuming application to
+   * recompute every field when the document opens. Set by generators that
+   * emit a TOC or cross-references without computed results.
+   */
+  updateFields?: boolean;
+  /**
    * `w:themeFontLang` (§17.15.1.88) — language Word uses to fill empty
    * `<a:ea>`/`<a:cs>` theme font slots from the script-specific
    * `<a:font script="…">` entries. Absent for non-CJK/bidi docs.

--- a/scripts/validate-dist.ts
+++ b/scripts/validate-dist.ts
@@ -248,6 +248,7 @@ const runtimeExpect: Record<string, Record<string, string[]>> = {
       "createEmptyDocument",
       "createDocx",
       "createTableOfContentsField",
+      "parseDocx",
       "FolioDocxReviewer",
       "applyFolioAIEditsToBuffer",
     ],

--- a/scripts/validate-dist.ts
+++ b/scripts/validate-dist.ts
@@ -247,6 +247,7 @@ const runtimeExpect: Record<string, Record<string, string[]>> = {
       "deriveBlockId",
       "createEmptyDocument",
       "createDocx",
+      "createTableOfContentsField",
       "FolioDocxReviewer",
       "applyFolioAIEditsToBuffer",
     ],


### PR DESCRIPTION
## Summary

Makes `@stll/folio-core` usable as a headless DOCX generator (build a `Document` in code, `createDocx`).

- `/server` exports typed builders: `heading`, `paragraph`, `run`, `table`, `pageBreak`, `hyperlink`, `bookmark`, `endnote`, `createTableOfContentsField` (`packages/core/src/docx/server/build.ts`). Thin constructors over the docx-core model; the serializer still owns the OOXML.
- External hyperlinks inside headers, footers, footnotes and endnotes now get relationships minted in their own rels part; the parser resolves note hyperlinks from the note part's rels; selective save bails to a full repack when any part carries an unminted link.
- `createEmptyDocument` initialises `package.relationships`, so in-memory headers/footers materialise for from-scratch documents.
- `DocumentSettings.updateFields` round-trips.
- Stella style set gains `Heading1`-`Heading6`, `TOCHeading`, `TOC1`-`TOC3`, `EndnoteReference`, `EndnoteText`.
- Fix: complex-field `w:dirty` / `w:fldLock` were reset by the parser and never emitted by the serializer; both now round-trip (regression in `paragraphParser.test.ts`).

## Test plan

- `packages/core/src/docx/server/build.test.ts`: cover + TOC + headings + shaded/merged findings table + endnote with external hyperlink, `createDocx` → `parseDocx` round-trip, docx validator reports zero errors, rels land in `endnotes.xml.rels`.
- Header materialisation from `createEmptyDocument`.
- Core suite 4568 pass; docx-core 54 pass; lint and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added headless DOCX builders for runs, paragraphs, headings, hyperlinks, bookmarks, tables, page breaks, endnotes and tables of contents.
  - Added server-side exports for report-generation helpers and table specifications.
  - Added heading, table-of-contents and endnote styles to the Stella style set.
  - Added an option to update document fields when opened.

- **Bug Fixes**
  - Improved relationship handling for hyperlinks and images across document parts.
  - Preserved complex-field locking and dirty-state attributes during parsing and serialisation.
  - Improved support for empty documents and note-specific relationships.
  - Extended validation when selectively saving documents containing new media or links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->