### PR TITLE
feat(core): bilingual two-column document transform

### DIFF
--- a/.changeset/bilingual-document.md
+++ b/.changeset/bilingual-document.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add `createBilingualDocument` / `createBilingualDocx` to the server entry: lay a document body out as a two-column table (source | copy) with numbering and numbered paragraph styles cloned per language so both columns count independently. Repacking now appends numbering definitions and styles the model adds to the original parts.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -49,11 +49,60 @@ export const applyFolioVersionDiffPrivacy: (diff: FolioVersionDiff, options: Fol
 // @public (undocumented)
 export const assertSupportedFolioDocumentOperationVersion: (value: unknown) => typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
 
+// @public (undocumented)
+export type BilingualBorders = "none" | "grid";
+
+// @public
+export type BilingualParagraphRef = {
+    sourceParaId: string | undefined;
+    targetParaId: string;
+    sourceText: string;
+};
+
+// @public (undocumented)
+export type BilingualRow = ({
+    kind: BilingualRowKind;
+    rowId: string;
+} & BilingualParagraphRef) | {
+    kind: "table";
+    rowId: string;
+    paragraphs: BilingualParagraphRef[];
+};
+
+// @public (undocumented)
+export type BilingualRowKind = "paragraph" | "heading" | "listItem";
+
 // @public
 export const bookmark: (input: BookmarkOptions) => ParagraphContent[];
 
 // @public
 export const compareDocxVersions: (base: ArrayBuffer, revised: ArrayBuffer, options?: FolioCompareDocxVersionsOptions) => Promise<FolioVersionDiff>;
+
+// @public (undocumented)
+export function createBilingualDocument(source: import__stll_docx_core_model.Document, options: CreateBilingualDocumentOptions): CreateBilingualDocumentResult;
+
+// @public (undocumented)
+export type CreateBilingualDocumentOptions = {
+    targetStyleSuffix: string;
+    borders?: BilingualBorders;
+};
+
+// @public (undocumented)
+export type CreateBilingualDocumentResult = {
+    document: import__stll_docx_core_model.Document;
+    rows: BilingualRow[];
+    warnings: string[];
+};
+
+// @public
+export function createBilingualDocx(input: ArrayBuffer | Uint8Array, options: CreateBilingualDocumentOptions): Promise<CreateBilingualDocxResult>;
+
+// @public (undocumented)
+export type CreateBilingualDocxResult = {
+    buffer: ArrayBuffer;
+    rows: BilingualRow[];
+    warnings: string[];
+};
 
 // @public (undocumented)
 export type CreateCommentReplyInput = {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -1350,6 +1350,9 @@ export type InspectDocxPackageOptions = {
 };
 
 // @public (undocumented)
+export class InvalidBilingualDocumentOptionsError extends InvalidBilingualDocumentOptionsError_base {}
+
+// @public (undocumented)
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
 
 // @public (undocumented)

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -66,11 +66,17 @@ export type BilingualRow = ({
 } & BilingualParagraphRef) | {
     kind: "table";
     rowId: string;
-    paragraphs: BilingualParagraphRef[];
+    paragraphs: BilingualTableParagraphRef[];
 };
 
 // @public (undocumented)
 export type BilingualRowKind = "paragraph" | "heading" | "listItem";
+
+// @public (undocumented)
+export type BilingualTableParagraphRef = {
+    paraId: string | undefined;
+    sourceText: string;
+};
 
 // @public
 export const bookmark: (input: BookmarkOptions) => ParagraphContent[];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -1428,6 +1428,12 @@ export type ParseOptions = {
 };
 
 // @public
+export function readBilingualDocument(document: import__stll_docx_core_model.Document): BilingualRow[];
+
+// @public
+export function readBilingualDocx(input: ArrayBuffer | Uint8Array): Promise<BilingualRow[]>;
+
+// @public
 export const readFolioDocumentSection: (snapshot: FolioAIEditSnapshot, handle: FolioDocumentSectionHandle) => FolioDocumentSectionReadResult;
 
 // @public

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -2037,7 +2037,7 @@ async function serializeAddedStylesIntoZip(
   const file = findNotePartEntry(originalZip, STYLES_PART_PATH);
   const originalXml = file ? await file.async("text") : null;
   const rootClose = originalXml?.lastIndexOf(STYLES_CLOSE_ROOT) ?? -1;
-  if (originalXml === null || rootClose < 0) {
+  if (file === null || originalXml === null || rootClose < 0) {
     // No usable styles part: write the whole model serialization so every
     // style `document.xml` references resolves, and wire the part up.
     await materializeNewNotePart({

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -51,9 +51,11 @@ import { isNewDataUrlDrawing } from "./newImage";
 import { parseNumbering } from "./numberingParser";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import {
+  appendNumberingDefs,
   buildParagraphOffsetIndex,
   buildPatchedNoteXml,
   buildPatchedNumberingXml,
+  collectAddedNumberingDefs,
   collectChangedNumberingDefs,
   collectParaIds,
 } from "./selectiveXmlPatch";
@@ -73,7 +75,7 @@ import {
 import { serializeNumberingXml } from "./serializer/numberingSerializer";
 import { serializeFontTableXml } from "./serializer/fontTableSerializer";
 import { serializeSettingsXml } from "./serializer/settingsSerializer";
-import { serializeStylesXml } from "./serializer/stylesSerializer";
+import { serializeStyle, serializeStylesXml } from "./serializer/stylesSerializer";
 import { serializeThemeXml } from "./serializer/themeSerializer";
 import { escapeXml } from "./serializer/xmlUtils";
 import { isPreservableDocxEntry } from "./unzip";
@@ -857,6 +859,7 @@ const finishRepack = async ({
   await serializeNotesToZip(document, originalZip, outputZip, compressionLevel);
 
   await serializeNumberingIntoZip(document, originalZip, outputZip, compressionLevel);
+  await serializeAddedStylesIntoZip(document, originalZip, outputZip, compressionLevel);
 
   await serializeCommentsToZip(document, outputZip, compressionLevel);
 
@@ -998,6 +1001,12 @@ export async function repackDocxFromRaw(
   // Splice edited numbering definitions back into word/numbering.xml (untouched
   // definitions and the parts the model omits stay byte-exact).
   await serializeNumberingIntoZip(exportDocument, rawContent.originalZip, newZip, compressionLevel);
+  await serializeAddedStylesIntoZip(
+    exportDocument,
+    rawContent.originalZip,
+    newZip,
+    compressionLevel,
+  );
 
   // Serialize comments
   await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
@@ -1982,13 +1991,71 @@ async function serializeNumberingIntoZip(
   }
   const currentXml = serializeNumberingXml(numbering);
   const changed = collectChangedNumberingDefs(baseline.serializedXml, currentXml);
-  if (changed.abstractNums.size === 0 && changed.nums.size === 0) {
+  const added = collectAddedNumberingDefs(baseline.serializedXml, currentXml);
+  const hasChanged = changed.abstractNums.size > 0 || changed.nums.size > 0;
+  const hasAdded = added.abstractNums.size > 0 || added.nums.size > 0;
+  if (!hasChanged && !hasAdded) {
     return;
   }
-  const patched = buildPatchedNumberingXml(baseline.originalXml, currentXml, changed);
+  const spliced = buildPatchedNumberingXml(baseline.originalXml, currentXml, changed);
+  if (spliced === null) {
+    return;
+  }
+  // Definitions the model minted (no counterpart in the original part) are
+  // appended after the in-place splice; splicing by id cannot place them.
+  const patched = appendNumberingDefs(spliced, currentXml, added);
   if (patched === null) {
     return;
   }
+  newZip.file(file.name, patched, {
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
+}
+
+const STYLES_PART_PATH = "word/styles.xml";
+const STYLES_CLOSE_ROOT = "</w:styles>";
+const STYLE_ID_PATTERN = /<w:style\b[^>]*?\bw:styleId="(?<id>[^"]+)"/gu;
+
+/**
+ * Append styles the model defines but the original `word/styles.xml` lacks.
+ * Existing styles stay byte-exact (edits to them are not written here, the
+ * part is otherwise preserved verbatim); only minted definitions, such as the
+ * per-language clones a bilingual transform adds, are emitted before the root
+ * close so paragraphs referencing them resolve on reopen.
+ */
+async function serializeAddedStylesIntoZip(
+  doc: Document,
+  originalZip: JSZip,
+  newZip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const styles = doc.package.styles;
+  if (!styles || styles.styles.length === 0) {
+    return;
+  }
+  const file = findNotePartEntry(originalZip, STYLES_PART_PATH);
+  if (!file) {
+    return;
+  }
+  const originalXml = await file.async("text");
+  const rootClose = originalXml.lastIndexOf(STYLES_CLOSE_ROOT);
+  if (rootClose < 0) {
+    return;
+  }
+  const existing = new Set<string>();
+  for (const match of originalXml.matchAll(STYLE_ID_PATTERN)) {
+    // SAFETY: named group `id` always exists when this pattern matches.
+    existing.add(match.groups!["id"]!);
+  }
+  const added = styles.styles.filter((style) => !existing.has(style.styleId));
+  if (added.length === 0) {
+    return;
+  }
+  const patched =
+    originalXml.slice(0, rootClose) +
+    added.map(serializeStyle).join("") +
+    originalXml.slice(rootClose);
   newZip.file(file.name, patched, {
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -1883,7 +1883,7 @@ async function serializeNotesToZip(
 type MaterializeNewNotePartOptions = {
   contentType: string;
   newZip: JSZip;
-  partPath: "word/footnotes.xml" | "word/endnotes.xml";
+  partPath: "word/footnotes.xml" | "word/endnotes.xml" | typeof STYLES_PART_PATH;
   relationshipType: string;
   serializedPart: string;
   compressionLevel: number;
@@ -2035,12 +2035,19 @@ async function serializeAddedStylesIntoZip(
     return;
   }
   const file = findNotePartEntry(originalZip, STYLES_PART_PATH);
-  if (!file) {
-    return;
-  }
-  const originalXml = await file.async("text");
-  const rootClose = originalXml.lastIndexOf(STYLES_CLOSE_ROOT);
-  if (rootClose < 0) {
+  const originalXml = file ? await file.async("text") : null;
+  const rootClose = originalXml?.lastIndexOf(STYLES_CLOSE_ROOT) ?? -1;
+  if (originalXml === null || rootClose < 0) {
+    // No usable styles part: write the whole model serialization so every
+    // style `document.xml` references resolves, and wire the part up.
+    await materializeNewNotePart({
+      contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
+      newZip,
+      partPath: STYLES_PART_PATH,
+      relationshipType: RELATIONSHIP_TYPES.styles,
+      serializedPart: serializeStylesXml(styles),
+      compressionLevel,
+    });
     return;
   }
   const existing = new Set<string>();

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -902,6 +902,115 @@ export function buildPatchedNumberingXml(
   return result;
 }
 
+/**
+ * Numbering definitions present in `currentXml` (the model's serialization)
+ * but absent from `baselineXml` (the re-parsed original): definitions a
+ * transform minted. `collectChangedNumberingDefs` deliberately skips these
+ * because they cannot be spliced by id; they are appended instead.
+ */
+export function collectAddedNumberingDefs(
+  baselineXml: string,
+  currentXml: string,
+): ChangedNumberingDefs {
+  const addedForKind = (kind: NumberingElementKind): Set<string> => {
+    const added = new Set<string>();
+    const baselineIndex = buildNumberingElementOffsetIndex(baselineXml, kind);
+    const currentIndex = buildNumberingElementOffsetIndex(currentXml, kind);
+    for (const [id, range] of currentIndex) {
+      if (range && !baselineIndex.has(id)) {
+        added.add(id);
+      }
+    }
+    return added;
+  };
+  return { abstractNums: addedForKind("abstractNum"), nums: addedForKind("num") };
+}
+
+const NUMBERING_CLOSE_ROOT = "</w:numbering>";
+
+/**
+ * Append added `w:abstractNum` / `w:num` definitions from `currentXml` to
+ * `xml`. ECMA-376 §17.9 orders every `w:abstractNum` before the first `w:num`,
+ * so abstract definitions go right before the first `<w:num ` (or the root
+ * close when the part has none) and instances before the root close. A
+ * synthetic numFmt in an added abstract is restored from the original
+ * definition it was cloned from (the one with an identical body), so a custom
+ * format survives cloning. Returns null when an added id cannot be extracted
+ * or the part has no `</w:numbering>`.
+ */
+export function appendNumberingDefs(
+  xml: string,
+  currentXml: string,
+  added: ChangedNumberingDefs,
+): string | null {
+  if (added.abstractNums.size === 0 && added.nums.size === 0) {
+    return xml;
+  }
+  const rootClose = xml.lastIndexOf(NUMBERING_CLOSE_ROOT);
+  if (rootClose < 0) {
+    return null;
+  }
+  const abstractXmls: string[] = [];
+  for (const id of added.abstractNums) {
+    const def = extractNumberingElementXml(currentXml, "abstractNum", id);
+    if (def === null) {
+      return null;
+    }
+    abstractXmls.push(restoreClonedLevelNumFmts(xml, currentXml, def, id));
+  }
+  const numXmls: string[] = [];
+  for (const id of added.nums) {
+    const def = extractNumberingElementXml(currentXml, "num", id);
+    if (def === null) {
+      return null;
+    }
+    numXmls.push(def);
+  }
+
+  const firstNum = findFirstElement(xml, NUMBERING_OPEN_LITERAL.num, NUMBERING_CLOSE_TAG.num);
+  const abstractInsertAt = firstNum ? firstNum.start : rootClose;
+  const head = xml.slice(0, abstractInsertAt);
+  const middle = xml.slice(abstractInsertAt, rootClose);
+  const tail = xml.slice(rootClose);
+  return head + abstractXmls.join("") + middle + numXmls.join("") + tail;
+}
+
+/**
+ * For an added abstract definition that still carries a synthetic numFmt, find
+ * the original abstract it was cloned from (same serialized body apart from the
+ * id) and restore the level formats from it.
+ */
+function restoreClonedLevelNumFmts(
+  originalXml: string,
+  currentXml: string,
+  addedDefXml: string,
+  addedId: string,
+): string {
+  if (!SYNTHETIC_NUM_FMT_PATTERN.test(addedDefXml)) {
+    return addedDefXml;
+  }
+  const addedBody = stripAbstractNumId(addedDefXml, addedId);
+  const originalIds = collectElementIds(
+    originalXml,
+    NUMBERING_OPEN_LITERAL.abstractNum,
+    NUMBERING_ID_ATTR.abstractNum,
+  );
+  for (const [id] of originalIds) {
+    const candidate = extractNumberingElementXml(currentXml, "abstractNum", id);
+    if (candidate === null || stripAbstractNumId(candidate, id) !== addedBody) {
+      continue;
+    }
+    const originalDef = extractNumberingElementXml(originalXml, "abstractNum", id);
+    if (originalDef !== null) {
+      return restoreLevelNumFmts(originalDef, addedDefXml);
+    }
+  }
+  return restoreLevelNumFmts("", addedDefXml);
+}
+
+const stripAbstractNumId = (defXml: string, id: string): string =>
+  defXml.replace(`${NUMBERING_ID_ATTR.abstractNum}="${id}"`, "");
+
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }

--- a/packages/core/src/docx/serializer/stylesSerializer.ts
+++ b/packages/core/src/docx/serializer/stylesSerializer.ts
@@ -39,7 +39,7 @@ const serializeLatentStyles = (definitions: StyleDefinitions): string => {
   return `<w:latentStyles${attrs.length > 0 ? ` ${attrs.join(" ")}` : ""}/>`;
 };
 
-const serializeStyle = (style: Style): string => {
+export const serializeStyle = (style: Style): string => {
   const attrs = [`w:type="${style.type}"`, `w:styleId="${escapeXml(style.styleId)}"`];
   if (style.default) {
     attrs.push('w:default="1"');

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
 
 import { createStellaStyleDocumentPreset } from "../../style-sets/stellaStyle";
 import type {
@@ -12,7 +13,10 @@ import type {
 import { createEmptyDocument } from "../../utils/createDocument";
 import { parseDocx } from "../parser";
 import { createDocx } from "../rezip";
-import { createBilingualDocument } from "./createBilingualDocument";
+import {
+  createBilingualDocument,
+  InvalidBilingualDocumentOptionsError,
+} from "./createBilingualDocument";
 import { createBilingualDocx, readBilingualDocx } from "./createBilingualDocx";
 
 const SUFFIX = "en";
@@ -299,7 +303,7 @@ describe("createBilingualDocument", () => {
   test("rejects a style suffix that cannot form a style id", async () => {
     const source = await buildSource();
     expect(() => createBilingualDocument(source, { targetStyleSuffix: "en US" })).toThrow(
-      RangeError,
+      InvalidBilingualDocumentOptionsError,
     );
   });
 
@@ -370,6 +374,71 @@ describe("createBilingualDocx", () => {
     }
     // A plain document has no bilingual table to read.
     expect(await readBilingualDocx(source.originalBuffer!)).toEqual([]);
+  });
+
+  test("materializes a styles part when the source package has none", async () => {
+    const source = await buildSource();
+    // Strip word/styles.xml and its relationship: legal OOXML, and the path
+    // where minted styles used to be dropped silently on save.
+    const zip = await JSZip.loadAsync(source.originalBuffer!);
+    zip.remove("word/styles.xml");
+    const relsPath = "word/_rels/document.xml.rels";
+    const rels = await zip.file(relsPath)!.async("text");
+    zip.file(relsPath, rels.replace(/<Relationship [^>]*relationships\/styles"[^>]*\/>/u, ""));
+    const stripped = await parseDocx(await zip.generateAsync({ type: "arraybuffer" }), {
+      preloadFonts: false,
+    });
+    expect(stripped.package.styles).toBeUndefined();
+
+    // Give the model a numbered style the body uses, so the copy must mint a
+    // clone that only a written styles part can carry.
+    const numId = stripped.package.numbering?.nums.at(0)?.numId;
+    expect(numId).toBeDefined();
+    const styled: Document = {
+      ...stripped,
+      package: {
+        ...stripped.package,
+        styles: {
+          styles: [
+            {
+              styleId: "Clause",
+              type: "paragraph",
+              name: "Clause",
+              pPr: { numPr: { numId: numId!, ilvl: 0 } },
+            },
+          ],
+        },
+        document: {
+          ...stripped.package.document,
+          content: stripped.package.document.content.map((block): BlockContent => {
+            if (
+              block.type !== "paragraph" ||
+              block.content.length === 0 ||
+              block.sectionProperties
+            ) {
+              return block;
+            }
+            const restyled: Paragraph = {
+              type: "paragraph",
+              content: block.content,
+              formatting: { styleId: "Clause" },
+            };
+            return restyled;
+          }),
+        },
+      },
+    };
+    const { document } = createBilingualDocument(styled, { targetStyleSuffix: SUFFIX });
+    expect(findStyle(document, `Clause-${SUFFIX}`)).toBeDefined();
+
+    const reparsed = await parseDocx(await createDocx(document), { preloadFonts: false });
+    expect(findStyle(reparsed, `Clause-${SUFFIX}`)).toBeDefined();
+    const relsAfter = await (
+      await JSZip.loadAsync(await createDocx(document))
+    )
+      .file(relsPath)!
+      .async("text");
+    expect(relsAfter).toContain("relationships/styles");
   });
 
   test("leaves a document without numbering free of clones", async () => {

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -13,7 +13,7 @@ import { createEmptyDocument } from "../../utils/createDocument";
 import { parseDocx } from "../parser";
 import { createDocx } from "../rezip";
 import { createBilingualDocument } from "./createBilingualDocument";
-import { createBilingualDocx } from "./createBilingualDocx";
+import { createBilingualDocx, readBilingualDocx } from "./createBilingualDocx";
 
 const SUFFIX = "en";
 
@@ -352,6 +352,24 @@ describe("createBilingualDocx", () => {
       }
       expect(rightIds.has(row.targetParaId)).toBe(true);
     }
+  });
+
+  test("reads the same row manifest back from the saved document", async () => {
+    const source = await buildSource();
+    const { buffer, rows } = await createBilingualDocx(source.originalBuffer!, {
+      targetStyleSuffix: SUFFIX,
+    });
+
+    const read = await readBilingualDocx(buffer);
+    expect(read).toEqual(rows);
+    // Every left paragraph is addressable: the stamp pass gave it a paraId.
+    for (const row of read) {
+      if (row.kind !== "table") {
+        expect(row.sourceParaId).toBeDefined();
+      }
+    }
+    // A plain document has no bilingual table to read.
+    expect(await readBilingualDocx(source.originalBuffer!)).toEqual([]);
   });
 
   test("leaves a document without numbering free of clones", async () => {

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -115,8 +115,12 @@ const columnParagraphs = (doc: Document): ColumnParagraphs => {
   for (const table of bodyTables(doc)) {
     for (const row of table.rows) {
       const [leftCell, rightCell] = row.cells;
-      if (!leftCell || !rightCell) {
-        throw new Error("bilingual row without two cells");
+      if (!leftCell) {
+        throw new Error("bilingual row without cells");
+      }
+      if (!rightCell) {
+        // A spanning row carries a source table once; not a column pair.
+        continue;
       }
       left.push(...cellParagraphs(leftCell));
       right.push(...cellParagraphs(rightCell));
@@ -164,16 +168,40 @@ describe("createBilingualDocument", () => {
     const source = await buildSource();
     const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
 
-    const sourceParagraphs = source.package.document.content.flatMap((block): Paragraph[] => {
-      if (block.type === "table") {
-        return block.rows.flatMap((row) => row.cells.flatMap(cellParagraphs));
-      }
-      if (block.type === "paragraph" && !block.sectionProperties && block.content.length > 0) {
-        return [block];
-      }
-      return [];
-    });
+    const sourceParagraphs = source.package.document.content.flatMap((block): Paragraph[] =>
+      block.type === "paragraph" && !block.sectionProperties && block.content.length > 0
+        ? [block]
+        : [],
+    );
     expect(columnParagraphs(document).left).toEqual(sourceParagraphs);
+  });
+
+  test("keeps a source table once, in a row spanning both columns", async () => {
+    const source = await buildSource();
+    const { document, rows } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+
+    const allRows = bodyTables(document).flatMap((table) => table.rows);
+    const spanningRows = allRows.filter((row) => row.cells.length === 1);
+    expect(spanningRows).toHaveLength(1);
+    expect(allRows.every((row) => row.cells.length === 1 || row.cells.length === 2)).toBe(true);
+
+    const spanningCell = spanningRows[0]!.cells[0]!;
+    expect(spanningCell.formatting?.gridSpan).toBe(2);
+    const nested = spanningCell.content.filter((item): item is Table => item.type === "table");
+    expect(nested).toHaveLength(1);
+    const originalTable = source.package.document.content.find(
+      (block): block is Table => block.type === "table",
+    );
+    expect(nested[0]).toEqual(originalTable!);
+
+    // The manifest points at the table's own paragraphs (translated in place).
+    const tableRow = rows.find((row) => row.kind === "table");
+    const tableParaIds = originalTable!.rows.flatMap((row) =>
+      row.cells.flatMap((c) => cellParagraphs(c).map((p) => p.paraId)),
+    );
+    expect(tableRow?.kind === "table" && tableRow.paragraphs.map((p) => p.paraId)).toEqual(
+      tableParaIds,
+    );
   });
 
   test("right column never shares a numbering instance or abstract with the left", async () => {
@@ -319,11 +347,10 @@ describe("createBilingualDocx", () => {
     // paragraph in the reparsed right column.
     const rightIds = new Set(right.map((p) => p.paraId));
     for (const row of rows) {
-      const ids =
-        row.kind === "table" ? row.paragraphs.map((p) => p.targetParaId) : [row.targetParaId];
-      for (const id of ids) {
-        expect(rightIds.has(id)).toBe(true);
+      if (row.kind === "table") {
+        continue;
       }
+      expect(rightIds.has(row.targetParaId)).toBe(true);
     }
   });
 

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, test } from "bun:test";
+
+import { createStellaStyleDocumentPreset } from "../../style-sets/stellaStyle";
+import type {
+  BlockContent,
+  Document,
+  Paragraph,
+  Style,
+  Table,
+  TableCell,
+} from "../../types/document";
+import { createEmptyDocument } from "../../utils/createDocument";
+import { parseDocx } from "../parser";
+import { createDocx } from "../rezip";
+import { createBilingualDocument } from "./createBilingualDocument";
+import { createBilingualDocx } from "./createBilingualDocx";
+
+const SUFFIX = "en";
+
+const paragraph = (
+  text: string,
+  styleId?: string,
+  numPr?: { numId: number; ilvl: number },
+): Paragraph => ({
+  type: "paragraph",
+  formatting: {
+    ...(styleId !== undefined && { styleId }),
+    ...(numPr !== undefined && { numPr }),
+  },
+  content: text === "" ? [] : [{ type: "run", formatting: {}, content: [{ type: "text", text }] }],
+});
+
+const cell = (content: (Paragraph | Table)[]): TableCell => ({ type: "tableCell", content });
+
+const sourceTable = (): Table => ({
+  type: "table",
+  rows: [
+    {
+      type: "tableRow",
+      cells: [cell([paragraph("Cell A1")]), cell([paragraph("Cell B1")])],
+    },
+  ],
+});
+
+/**
+ * A contract-shaped source: style-linked clause numbering from the Stella
+ * preset (ClauseHeading / ClauseParagraph1), a directly numbered list that
+ * reuses the preset's bullet instance, a nested table, an empty paragraph and
+ * a section break. Serialized and re-parsed so the document carries
+ * `originalBuffer`, paraIds and style-materialized `numPr`, exactly like a
+ * document loaded from disk.
+ */
+const buildSource = async (): Promise<Document> => {
+  const doc = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+  const bulletNumId = findStyle(doc, "ListParagraph")?.pPr?.numPr?.numId;
+  if (bulletNumId === undefined) {
+    throw new Error("preset lost its bullet numbering");
+  }
+  const firstSection: BlockContent[] = [
+    paragraph("Preamble", "Normal"),
+    paragraph("Definitions", "ClauseHeading1"),
+    paragraph("Agreement means this contract.", "ClauseParagraph1"),
+    paragraph(""),
+    paragraph("first bullet", "Normal", { numId: bulletNumId, ilvl: 0 }),
+    sourceTable(),
+  ];
+  const sectionBreak: Paragraph = {
+    type: "paragraph",
+    content: [],
+    sectionProperties: { pageWidth: 11_906, pageHeight: 16_838 },
+  };
+  const secondSection: BlockContent[] = [
+    paragraph("Term", "ClauseHeading1"),
+    paragraph("This Agreement lasts one year.", "ClauseParagraph1"),
+  ];
+  doc.package.document.content = [...firstSection, sectionBreak, ...secondSection];
+  return parseDocx(await createDocx(doc), { preloadFonts: false });
+};
+
+const findStyle = (doc: Document, styleId: string): Style | undefined =>
+  doc.package.styles?.styles.find((style) => style.styleId === styleId);
+
+const bodyTables = (doc: Document): Table[] =>
+  doc.package.document.content.filter((block): block is Table => block.type === "table");
+
+/**
+ * Paragraphs in a bilingual cell, excluding the empty filler paragraph a cell
+ * must end with when it holds a nested table (OOXML forbids a bare `w:tbl`
+ * as the last cell child).
+ */
+const cellParagraphs = (tableCell: TableCell): Paragraph[] => {
+  const out: Paragraph[] = [];
+  const visit = (item: Paragraph | Table): void => {
+    if (item.type === "paragraph") {
+      if (item.content.length > 0) {
+        out.push(item);
+      }
+      return;
+    }
+    for (const row of item.rows) {
+      for (const inner of row.cells) {
+        inner.content.forEach(visit);
+      }
+    }
+  };
+  tableCell.content.forEach(visit);
+  return out;
+};
+
+type ColumnParagraphs = { left: Paragraph[]; right: Paragraph[] };
+
+const columnParagraphs = (doc: Document): ColumnParagraphs => {
+  const left: Paragraph[] = [];
+  const right: Paragraph[] = [];
+  for (const table of bodyTables(doc)) {
+    for (const row of table.rows) {
+      const [leftCell, rightCell] = row.cells;
+      if (!leftCell || !rightCell) {
+        throw new Error("bilingual row without two cells");
+      }
+      left.push(...cellParagraphs(leftCell));
+      right.push(...cellParagraphs(rightCell));
+    }
+  }
+  return { left, right };
+};
+
+const effectiveNumId = (doc: Document, p: Paragraph): number | undefined => {
+  const direct = p.formatting?.numPr?.numId;
+  if (direct !== undefined) {
+    return direct;
+  }
+  const style = p.formatting?.styleId ? findStyle(doc, p.formatting.styleId) : undefined;
+  return style?.pPr?.numPr?.numId;
+};
+
+const abstractNumIdOf = (doc: Document, numId: number): number | undefined =>
+  doc.package.numbering?.nums.find((num) => num.numId === numId)?.abstractNumId;
+
+describe("createBilingualDocument", () => {
+  test("lays every non-empty block out as a two-column row, one table per section", async () => {
+    const source = await buildSource();
+    const { document, rows } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+
+    const content = document.package.document.content;
+    expect(content.map((block) => block.type)).toEqual(["table", "paragraph", "table"]);
+    const [first, second] = bodyTables(document);
+    // Preamble, heading, clause, bullet, table (the empty paragraph is dropped).
+    expect(first?.rows).toHaveLength(5);
+    expect(second?.rows).toHaveLength(2);
+    expect(rows.map((row) => row.kind)).toEqual([
+      "paragraph",
+      "heading",
+      "listItem",
+      "listItem",
+      "table",
+      "heading",
+      "listItem",
+    ]);
+    expect(content[1]?.type === "paragraph" && content[1].sectionProperties).toBeTruthy();
+  });
+
+  test("keeps the left column identical to the source blocks", async () => {
+    const source = await buildSource();
+    const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+
+    const sourceParagraphs = source.package.document.content.flatMap((block): Paragraph[] => {
+      if (block.type === "table") {
+        return block.rows.flatMap((row) => row.cells.flatMap(cellParagraphs));
+      }
+      if (block.type === "paragraph" && !block.sectionProperties && block.content.length > 0) {
+        return [block];
+      }
+      return [];
+    });
+    expect(columnParagraphs(document).left).toEqual(sourceParagraphs);
+  });
+
+  test("right column never shares a numbering instance or abstract with the left", async () => {
+    const source = await buildSource();
+    const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const { left, right } = columnParagraphs(document);
+    expect(right).toHaveLength(left.length);
+
+    const leftNumIds = new Set(
+      left.map((p) => effectiveNumId(document, p)).filter((id) => id !== undefined),
+    );
+    const leftAbstracts = new Set(
+      [...leftNumIds].map((id) => abstractNumIdOf(document, id)).filter((id) => id !== undefined),
+    );
+    expect(leftNumIds.size).toBeGreaterThan(1);
+
+    let numberedPairs = 0;
+    for (const [index, rightParagraph] of right.entries()) {
+      const leftParagraph = left[index];
+      if (!leftParagraph) {
+        throw new Error("column length mismatch");
+      }
+      const leftNumId = effectiveNumId(document, leftParagraph);
+      const rightNumId = effectiveNumId(document, rightParagraph);
+      if (leftNumId === undefined) {
+        expect(rightNumId).toBeUndefined();
+        continue;
+      }
+      numberedPairs += 1;
+      expect(rightNumId).toBeDefined();
+      expect(leftNumIds.has(rightNumId!)).toBe(false);
+      expect(leftAbstracts.has(abstractNumIdOf(document, rightNumId!)!)).toBe(false);
+      // Same level, same marker template: the clone renders like the source.
+      expect(rightParagraph.listRendering?.marker).toBe(leftParagraph.listRendering?.marker);
+      expect(rightParagraph.listRendering?.level).toBe(leftParagraph.listRendering?.level);
+    }
+    expect(numberedPairs).toBe(5);
+  });
+
+  test("clones numbered paragraph styles with the suffix and rewrites only their numPr", async () => {
+    const source = await buildSource();
+    const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+
+    const original = findStyle(source, "ClauseParagraph1");
+    const clone = findStyle(document, `ClauseParagraph1-${SUFFIX}`);
+    expect(original).toBeDefined();
+    expect(clone).toBeDefined();
+    expect(clone?.pPr?.numPr?.numId).not.toBe(original?.pPr?.numPr?.numId);
+    expect(clone?.pPr?.numPr?.ilvl).toBe(original?.pPr?.numPr?.ilvl);
+    expect({
+      ...clone,
+      styleId: "",
+      name: "",
+      pPr: undefined,
+      next: undefined,
+      default: undefined,
+    }).toEqual({
+      ...original,
+      styleId: "",
+      name: "",
+      pPr: undefined,
+      next: undefined,
+      default: undefined,
+    });
+    // Unnumbered styles are not cloned.
+    expect(findStyle(document, `Normal-${SUFFIX}`)).toBeUndefined();
+    // The source styles are untouched.
+    expect(document.package.styles?.styles.slice(0, source.package.styles?.styles.length)).toEqual(
+      source.package.styles?.styles ?? [],
+    );
+  });
+
+  test("mints stable, unique right-column paraIds and reports them as row handles", async () => {
+    const source = await buildSource();
+    const first = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const second = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+
+    const handles = first.rows.map((row) => row.rowId);
+    expect(new Set(handles).size).toBe(handles.length);
+    expect(second.rows.map((row) => row.rowId)).toEqual(handles);
+
+    const { left, right } = columnParagraphs(first.document);
+    const leftIds = new Set(left.map((p) => p.paraId));
+    for (const p of right) {
+      expect(p.paraId).toBeDefined();
+      expect(leftIds.has(p.paraId)).toBe(false);
+    }
+    const tableRow = first.rows.find((row) => row.kind === "table");
+    expect(tableRow?.kind === "table" && tableRow.paragraphs.map((p) => p.sourceText)).toEqual([
+      "Cell A1",
+      "Cell B1",
+    ]);
+  });
+
+  test("rejects a style suffix that cannot form a style id", async () => {
+    const source = await buildSource();
+    expect(() => createBilingualDocument(source, { targetStyleSuffix: "en US" })).toThrow(
+      RangeError,
+    );
+  });
+
+  test("does not mutate the source document", async () => {
+    const source = await buildSource();
+    const snapshot = JSON.stringify({ ...source, originalBuffer: undefined });
+    createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    expect(JSON.stringify({ ...source, originalBuffer: undefined })).toBe(snapshot);
+  });
+});
+
+describe("createBilingualDocx", () => {
+  test("round-trips cloned styles and numbering through the repacked package", async () => {
+    const source = await buildSource();
+    const { buffer, rows } = await createBilingualDocx(source.originalBuffer!, {
+      targetStyleSuffix: SUFFIX,
+    });
+    const reparsed = await parseDocx(buffer, { preloadFonts: false });
+
+    expect(findStyle(reparsed, `ClauseParagraph1-${SUFFIX}`)).toBeDefined();
+    expect(findStyle(reparsed, `ClauseHeading1-${SUFFIX}`)).toBeDefined();
+
+    const sourceNumIds = new Set(source.package.numbering?.nums.map((num) => num.numId));
+    const addedNums = reparsed.package.numbering?.nums.filter(
+      (num) => !sourceNumIds.has(num.numId),
+    );
+    expect(addedNums?.length).toBeGreaterThan(0);
+
+    const { left, right } = columnParagraphs(reparsed);
+    expect(right).toHaveLength(left.length);
+    for (const [index, rightParagraph] of right.entries()) {
+      const leftParagraph = left[index]!;
+      const leftNumId = effectiveNumId(reparsed, leftParagraph);
+      const rightNumId = effectiveNumId(reparsed, rightParagraph);
+      if (leftNumId === undefined) {
+        continue;
+      }
+      expect(rightNumId).toBeDefined();
+      expect(rightNumId).not.toBe(leftNumId);
+      expect(abstractNumIdOf(reparsed, rightNumId!)).not.toBe(abstractNumIdOf(reparsed, leftNumId));
+      expect(rightParagraph.listRendering?.marker).toBe(leftParagraph.listRendering?.marker);
+    }
+
+    // Row handles survive the save: every reported target paraId is a real
+    // paragraph in the reparsed right column.
+    const rightIds = new Set(right.map((p) => p.paraId));
+    for (const row of rows) {
+      const ids =
+        row.kind === "table" ? row.paragraphs.map((p) => p.targetParaId) : [row.targetParaId];
+      for (const id of ids) {
+        expect(rightIds.has(id)).toBe(true);
+      }
+    }
+  });
+
+  test("leaves a document without numbering free of clones", async () => {
+    const doc = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    doc.package.document.content = [
+      paragraph("Plain one", "Normal"),
+      paragraph("Plain two", "Normal"),
+    ];
+    const bytes = await createDocx(doc);
+    const { buffer, rows, warnings } = await createBilingualDocx(bytes, {
+      targetStyleSuffix: SUFFIX,
+    });
+    const reparsed = await parseDocx(buffer, { preloadFonts: false });
+
+    expect(warnings).toEqual([]);
+    expect(rows).toHaveLength(2);
+    expect(
+      reparsed.package.styles?.styles.some((style) => style.styleId.endsWith(`-${SUFFIX}`)),
+    ).toBe(false);
+    expect(reparsed.package.numbering?.nums.length).toBe(doc.package.numbering?.nums.length);
+  });
+});

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -664,3 +664,84 @@ const createParaIdMinter = (taken: Set<string>): ParaIdMinter => {
     },
   };
 };
+
+// ----------------------------------------------------------------------------
+// Reading a bilingual document back
+// ----------------------------------------------------------------------------
+
+/**
+ * Re-derive the row manifest from a document produced by
+ * {@link createBilingualDocument}. Detection is structural: a top-level table
+ * whose rows are all either a left | right pair of single-paragraph cells or
+ * one cell spanning both columns. Rows are returned in document order; the
+ * right paragraph's `paraId` is the row handle, as at creation.
+ */
+export function readBilingualDocument(document: Document): BilingualRow[] {
+  const styleById = new Map(
+    (document.package.styles?.styles ?? []).map((style) => [style.styleId, style]),
+  );
+  const rows: BilingualRow[] = [];
+  let ordinal = 0;
+  for (const block of flattenBlocks(document.package.document.content)) {
+    if (block.type !== "table" || !isBilingualTable(block)) {
+      continue;
+    }
+    for (const row of block.rows) {
+      ordinal += 1;
+      const [left, right] = row.cells;
+      if (!left) {
+        continue;
+      }
+      if (!right) {
+        const paragraphs = left.content
+          .filter((item): item is Table => item.type === "table")
+          .flatMap(collectTableParagraphs)
+          .map((paragraph) => ({
+            paraId: paragraph.paraId,
+            sourceText: getParagraphText(paragraph),
+          }));
+        rows.push({
+          kind: "table",
+          rowId: paragraphs.at(0)?.paraId ?? `table-${ordinal}`,
+          paragraphs,
+        });
+        continue;
+      }
+      const source = left.content.at(0);
+      const target = right.content.at(0);
+      if (source?.type !== "paragraph" || target?.type !== "paragraph" || !target.paraId) {
+        continue;
+      }
+      rows.push({
+        kind: classifyParagraph(source, styleById),
+        rowId: target.paraId,
+        sourceParaId: source.paraId,
+        targetParaId: target.paraId,
+        sourceText: getParagraphText(source),
+      });
+    }
+  }
+  return rows;
+}
+
+const isBilingualTable = (table: Table): boolean => {
+  let pairs = 0;
+  for (const row of table.rows) {
+    const cells = row.cells;
+    if (cells.length === 2) {
+      const singleParagraphCells = cells.every(
+        (cell) => cell.content.length === 1 && cell.content[0]?.type === "paragraph",
+      );
+      if (!singleParagraphCells) {
+        return false;
+      }
+      pairs += 1;
+      continue;
+    }
+    if (cells.length === 1 && cells[0]?.formatting?.gridSpan === 2) {
+      continue;
+    }
+    return false;
+  }
+  return pairs > 0;
+};

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -10,8 +10,9 @@
  *
  * Section breaks cannot live inside a table cell, so the body is split at
  * paragraphs carrying `sectionProperties`: each section becomes its own table
- * and the break paragraph stays between the tables. Nested source tables become
- * one row holding the table in both cells.
+ * and the break paragraph stays between the tables. A source table (parties,
+ * signature block) is kept once, in a row spanning both columns: it is signed
+ * and read once, and its labels are translated inline rather than duplicated.
  */
 
 import { getParagraphText } from "../paragraphParser";
@@ -54,9 +55,17 @@ export type BilingualRow =
   | {
       kind: "table";
       rowId: string;
-      /** Every paragraph inside the copied table, in document order. */
-      paragraphs: BilingualParagraphRef[];
+      /**
+       * Every paragraph inside the table, in document order. The table is not
+       * copied, so these are the paragraphs to translate in place.
+       */
+      paragraphs: BilingualTableParagraphRef[];
     };
+
+export type BilingualTableParagraphRef = {
+  paraId: string | undefined;
+  sourceText: string;
+};
 
 export type BilingualBorders = "none" | "grid";
 
@@ -170,19 +179,16 @@ export function createBilingualDocument(
       sectionRows.push(buildRow(block, copy));
       continue;
     }
-    const paragraphs: BilingualParagraphRef[] = [];
-    const copy = cloneTableForTarget(block, (paragraph) => {
-      const result = copyParagraph(paragraph);
-      paragraphs.push(result.ref);
-      return result.copy;
-    });
-    const firstParagraph = paragraphs.at(0);
+    const paragraphs = collectTableParagraphs(block).map((paragraph) => ({
+      paraId: paragraph.paraId,
+      sourceText: getParagraphText(paragraph),
+    }));
     rows.push({
       kind: "table",
-      rowId: firstParagraph ? firstParagraph.targetParaId : paraIds.mint(undefined),
+      rowId: paragraphs.at(0)?.paraId ?? paraIds.mint(undefined),
       paragraphs,
     });
-    sectionRows.push(buildRow(block, copy));
+    sectionRows.push(buildSpanningRow(block));
   }
   flushSection();
 
@@ -531,37 +537,54 @@ const remapListRendering = (rendering: ListRendering, cloner: NumberingCloner): 
   };
 };
 
-const cloneTableForTarget = (
-  table: Table,
-  copyParagraph: (paragraph: Paragraph) => Paragraph,
-): Table => ({
-  ...table,
-  rows: table.rows.map((row) => ({
-    ...row,
-    cells: row.cells.map((cell) => ({
-      ...cell,
-      content: cell.content.map((item) =>
-        item.type === "paragraph" ? copyParagraph(item) : cloneTableForTarget(item, copyParagraph),
-      ),
-    })),
-  })),
-});
+const collectTableParagraphs = (table: Table): Paragraph[] => {
+  const out: Paragraph[] = [];
+  for (const row of table.rows) {
+    for (const cell of row.cells) {
+      for (const item of cell.content) {
+        if (item.type === "paragraph") {
+          out.push(item);
+        } else {
+          out.push(...collectTableParagraphs(item));
+        }
+      }
+    }
+  }
+  return out;
+};
 
 // ----------------------------------------------------------------------------
 // Output table
 // ----------------------------------------------------------------------------
 
-const buildRow = (left: BodyBlock, right: BodyBlock): Table["rows"][number] => ({
+const buildRow = (left: Paragraph, right: Paragraph): Table["rows"][number] => ({
   type: "tableRow",
   formatting: { cantSplit: true },
   cells: [buildCell(left), buildCell(right)],
 });
 
-const buildCell = (block: BodyBlock): TableCell => ({
+const buildCell = (paragraph: Paragraph): TableCell => ({
   type: "tableCell",
   formatting: { width: { value: HALF_WIDTH_PCT, type: "pct" }, verticalAlign: "top" },
-  // A cell must end with a paragraph; a bare nested table is invalid OOXML.
-  content: block.type === "table" ? [block, { type: "paragraph", content: [] }] : [block],
+  content: [paragraph],
+});
+
+/** A source table kept once, across both columns. */
+const buildSpanningRow = (table: Table): Table["rows"][number] => ({
+  type: "tableRow",
+  formatting: { cantSplit: true },
+  cells: [
+    {
+      type: "tableCell",
+      formatting: {
+        width: { value: FULL_WIDTH_PCT, type: "pct" },
+        gridSpan: 2,
+        verticalAlign: "top",
+      },
+      // A cell must end with a paragraph; a bare nested table is invalid OOXML.
+      content: [table, { type: "paragraph", content: [] }],
+    },
+  ],
 });
 
 const buildTable = (rows: Table["rows"], borders: BilingualBorders, textWidth: number): Table => ({

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -1,0 +1,643 @@
+/**
+ * Bilingual document transform: body -> two-column table, one row per block.
+ *
+ * The left column keeps every source block untouched; the right column holds a
+ * copy of the same block whose numbering and numbered paragraph styles are
+ * cloned per language, so both columns count independently (1. / 1. instead of
+ * 1. / 2.) and stay live in Word. Right-column paragraphs receive fresh
+ * `paraId`s so callers can address each row later (for example to replace the
+ * placeholder copy with a translation by block id).
+ *
+ * Section breaks cannot live inside a table cell, so the body is split at
+ * paragraphs carrying `sectionProperties`: each section becomes its own table
+ * and the break paragraph stays between the tables. Nested source tables become
+ * one row holding the table in both cells.
+ */
+
+import { getParagraphText } from "../paragraphParser";
+import type {
+  AbstractNumbering,
+  BlockContent,
+  Document,
+  ListRendering,
+  NumberingDefinitions,
+  NumberingInstance,
+  Paragraph,
+  ParagraphFormatting,
+  SectionProperties,
+  Style,
+  StyleDefinitions,
+  Table,
+  TableBorders,
+  TableCell,
+} from "../../types/document";
+import { deterministicHexId } from "../../utils/hexId";
+
+export type BilingualRowKind = "paragraph" | "heading" | "listItem";
+
+/** One translatable unit: a source paragraph and its right-column copy. */
+export type BilingualParagraphRef = {
+  /** `paraId` of the untouched source paragraph (left column). */
+  sourceParaId: string | undefined;
+  /** `paraId` minted for the right-column copy; stable across re-runs. */
+  targetParaId: string;
+  /** Plain text of the source paragraph. */
+  sourceText: string;
+};
+
+export type BilingualRow =
+  | ({
+      kind: BilingualRowKind;
+      /** Equals `targetParaId`; the handle callers use to address the row. */
+      rowId: string;
+    } & BilingualParagraphRef)
+  | {
+      kind: "table";
+      rowId: string;
+      /** Every paragraph inside the copied table, in document order. */
+      paragraphs: BilingualParagraphRef[];
+    };
+
+export type BilingualBorders = "none" | "grid";
+
+export type CreateBilingualDocumentOptions = {
+  /**
+   * Suffix for cloned style ids and names (for example `"en"` turns
+   * `Heading1` into `Heading1-en`). Must be a non-empty token of letters,
+   * digits, or `-`.
+   */
+  targetStyleSuffix: string;
+  /** Table borders; legal practice is usually `"none"`. Default `"none"`. */
+  borders?: BilingualBorders;
+};
+
+export type CreateBilingualDocumentResult = {
+  document: Document;
+  rows: BilingualRow[];
+  /** Non-fatal fidelity notes (for example an unresolvable numbering style link). */
+  warnings: string[];
+};
+
+const STYLE_SUFFIX_PATTERN = /^[A-Za-z0-9-]+$/u;
+const FULL_WIDTH_PCT = 5000;
+const HALF_WIDTH_PCT = 2500;
+const A4_TEXT_WIDTH_TWIPS = 9072;
+const ROW_ID_NAMESPACE = "folio-bilingual";
+
+const GRID_BORDER = { style: "single", size: 4, space: 0 } as const;
+
+const TABLE_BORDERS: Record<BilingualBorders, TableBorders> = {
+  none: {
+    top: { style: "nil" },
+    bottom: { style: "nil" },
+    left: { style: "nil" },
+    right: { style: "nil" },
+    insideH: { style: "nil" },
+    insideV: { style: "nil" },
+  },
+  grid: {
+    top: GRID_BORDER,
+    bottom: GRID_BORDER,
+    left: GRID_BORDER,
+    right: GRID_BORDER,
+    insideH: GRID_BORDER,
+    insideV: GRID_BORDER,
+  },
+};
+
+export function createBilingualDocument(
+  source: Document,
+  options: CreateBilingualDocumentOptions,
+): CreateBilingualDocumentResult {
+  if (!STYLE_SUFFIX_PATTERN.test(options.targetStyleSuffix)) {
+    throw new RangeError(
+      `targetStyleSuffix must match ${STYLE_SUFFIX_PATTERN}; received ${JSON.stringify(options.targetStyleSuffix)}`,
+    );
+  }
+  const borders = options.borders ?? "none";
+  const warnings: string[] = [];
+
+  const styles = source.package.styles;
+  const numbering = source.package.numbering;
+  const styleById = new Map((styles?.styles ?? []).map((style) => [style.styleId, style]));
+
+  const blocks = flattenBlocks(source.package.document.content);
+  const cloner = createNumberingCloner({ numbering, styleById, warnings });
+  const styleCloner = createStyleCloner({
+    styleById,
+    suffix: options.targetStyleSuffix,
+    cloner,
+  });
+  const paraIds = createParaIdMinter(collectParaIds(blocks));
+
+  const rows: BilingualRow[] = [];
+  const content: BlockContent[] = [];
+  let sectionRows: Table["rows"] = [];
+  const textWidth = resolveTextWidthTwips(source);
+
+  const flushSection = (): void => {
+    if (sectionRows.length > 0) {
+      content.push(buildTable(sectionRows, borders, textWidth));
+    }
+    sectionRows = [];
+  };
+
+  const copyParagraph = (paragraph: Paragraph): { copy: Paragraph; ref: BilingualParagraphRef } => {
+    const targetParaId = paraIds.mint(paragraph.paraId);
+    const copy = cloneParagraphForTarget(paragraph, targetParaId, styleCloner, cloner);
+    return {
+      copy,
+      ref: {
+        sourceParaId: paragraph.paraId,
+        targetParaId,
+        sourceText: getParagraphText(paragraph),
+      },
+    };
+  };
+
+  for (const block of blocks) {
+    if (block.type === "paragraph" && block.sectionProperties) {
+      flushSection();
+      content.push(block);
+      continue;
+    }
+    if (block.type === "paragraph") {
+      if (isEmptyParagraph(block)) {
+        continue;
+      }
+      const { copy, ref } = copyParagraph(block);
+      rows.push({ kind: classifyParagraph(block, styleById), rowId: ref.targetParaId, ...ref });
+      sectionRows.push(buildRow(block, copy));
+      continue;
+    }
+    const paragraphs: BilingualParagraphRef[] = [];
+    const copy = cloneTableForTarget(block, (paragraph) => {
+      const result = copyParagraph(paragraph);
+      paragraphs.push(result.ref);
+      return result.copy;
+    });
+    const firstParagraph = paragraphs.at(0);
+    rows.push({
+      kind: "table",
+      rowId: firstParagraph ? firstParagraph.targetParaId : paraIds.mint(undefined),
+      paragraphs,
+    });
+    sectionRows.push(buildRow(block, copy));
+  }
+  flushSection();
+
+  const document: Document = {
+    ...source,
+    package: {
+      ...source.package,
+      document: { ...source.package.document, content },
+      ...(cloner.hasClones() && { numbering: cloner.toDefinitions() }),
+      ...(styleCloner.hasClones() && styles && { styles: styleCloner.toDefinitions(styles) }),
+    },
+  };
+
+  return { document, rows, warnings };
+}
+
+// ----------------------------------------------------------------------------
+// Blocks
+// ----------------------------------------------------------------------------
+
+type BodyBlock = Paragraph | Table;
+
+/** Top-level body blocks with content controls flattened to their children. */
+const flattenBlocks = (content: BlockContent[]): BodyBlock[] => {
+  const out: BodyBlock[] = [];
+  const visit = (block: BlockContent): void => {
+    if (block.type === "paragraph" || block.type === "table") {
+      out.push(block);
+      return;
+    }
+    for (const child of block.content) {
+      visit(child);
+    }
+  };
+  for (const block of content) {
+    visit(block);
+  }
+  return out;
+};
+
+const isEmptyParagraph = (paragraph: Paragraph): boolean => {
+  if (getParagraphText(paragraph).trim().length > 0) {
+    return false;
+  }
+  // Anything that is not a plain text run (drawings, fields, footnote refs,
+  // content controls) keeps the paragraph as a row.
+  return paragraph.content.every(
+    (item) => item.type === "run" && item.content.every((part) => part.type === "text"),
+  );
+};
+
+/** Heading style families across Word UI languages (en, cs/sk, de, fr, pl). */
+const HEADING_STYLE_PATTERN = /heading|nadpis|berschrift|titre|nag[łl]/iu;
+
+const classifyParagraph = (
+  paragraph: Paragraph,
+  styleById: Map<string, Style>,
+): BilingualRowKind => {
+  const formatting = paragraph.formatting;
+  const style = formatting?.styleId ? styleById.get(formatting.styleId) : undefined;
+  const outlineLevel = formatting?.outlineLevel ?? resolveInheritedOutlineLevel(style, styleById);
+  if (outlineLevel !== undefined && outlineLevel < 9) {
+    return "heading";
+  }
+  if (
+    style &&
+    (HEADING_STYLE_PATTERN.test(style.styleId) || HEADING_STYLE_PATTERN.test(style.name ?? ""))
+  ) {
+    return "heading";
+  }
+  if (effectiveNumPr(paragraph, styleById) !== undefined) {
+    return "listItem";
+  }
+  return "paragraph";
+};
+
+const resolveInheritedOutlineLevel = (
+  style: Style | undefined,
+  styleById: Map<string, Style>,
+): number | undefined => {
+  const seen = new Set<string>();
+  let current = style;
+  while (current && !seen.has(current.styleId)) {
+    seen.add(current.styleId);
+    if (current.pPr?.outlineLevel !== undefined) {
+      return current.pPr.outlineLevel;
+    }
+    current = current.basedOn ? styleById.get(current.basedOn) : undefined;
+  }
+  return undefined;
+};
+
+type NumPr = NonNullable<ParagraphFormatting["numPr"]>;
+
+/** The numbering a paragraph renders with: direct `numPr`, else the style chain's. */
+const effectiveNumPr = (paragraph: Paragraph, styleById: Map<string, Style>): NumPr | undefined => {
+  const direct = paragraph.formatting?.numPr;
+  if (direct?.numId !== undefined) {
+    return direct.numId === 0 ? undefined : direct;
+  }
+  const styleId = paragraph.formatting?.styleId;
+  return styleId ? styleNumPr(styleById.get(styleId), styleById) : undefined;
+};
+
+const styleNumPr = (style: Style | undefined, styleById: Map<string, Style>): NumPr | undefined => {
+  const seen = new Set<string>();
+  let current = style;
+  while (current && !seen.has(current.styleId)) {
+    seen.add(current.styleId);
+    const numPr = current.pPr?.numPr;
+    if (numPr?.numId !== undefined) {
+      return numPr.numId === 0 ? undefined : numPr;
+    }
+    current = current.basedOn ? styleById.get(current.basedOn) : undefined;
+  }
+  return undefined;
+};
+
+// ----------------------------------------------------------------------------
+// Numbering clones
+// ----------------------------------------------------------------------------
+
+type NumberingCloner = {
+  /** Cloned `numId` for a source `numId`; minted on first use. */
+  cloneNumId: (numId: number) => number;
+  /** Cloned `abstractNumId` for a source one, when it was cloned. */
+  clonedAbstractNumId: (abstractNumId: number) => number | undefined;
+  hasClones: () => boolean;
+  toDefinitions: () => NumberingDefinitions;
+};
+
+type CreateNumberingClonerOptions = {
+  numbering: NumberingDefinitions | undefined;
+  styleById: Map<string, Style>;
+  warnings: string[];
+};
+
+const createNumberingCloner = ({
+  numbering,
+  styleById,
+  warnings,
+}: CreateNumberingClonerOptions): NumberingCloner => {
+  const abstractNums = numbering?.abstractNums ?? [];
+  const nums = numbering?.nums ?? [];
+  const abstractById = new Map(abstractNums.map((item) => [item.abstractNumId, item]));
+  const numById = new Map(nums.map((item) => [item.numId, item]));
+  let nextAbstractNumId = Math.max(0, ...abstractNums.map((item) => item.abstractNumId)) + 1;
+  let nextNumId = Math.max(0, ...nums.map((item) => item.numId)) + 1;
+
+  const clonedAbstract = new Map<number, AbstractNumbering>();
+  const clonedNum = new Map<number, NumberingInstance>();
+
+  /**
+   * Word keys list counters by the abstract definition a `w:num` points at;
+   * two instances sharing one abstract continue the same sequence. A clone
+   * therefore needs its own abstract, and an abstract that only links to a
+   * numbering style must be materialized from that style's levels, otherwise
+   * both clones resolve to the same linked definition and share counters.
+   */
+  const cloneAbstract = (sourceId: number): AbstractNumbering | undefined => {
+    const existing = clonedAbstract.get(sourceId);
+    if (existing) {
+      return existing;
+    }
+    const source = abstractById.get(sourceId);
+    if (!source) {
+      return undefined;
+    }
+    const resolved = resolveLinkedAbstract(source);
+    const { numStyleLink: _numStyleLink, styleLink: _styleLink, ...rest } = resolved;
+    const clone: AbstractNumbering = {
+      ...rest,
+      abstractNumId: nextAbstractNumId,
+      levels: structuredClone(resolved.levels),
+    };
+    nextAbstractNumId += 1;
+    clonedAbstract.set(sourceId, clone);
+    return clone;
+  };
+
+  const resolveLinkedAbstract = (abstract: AbstractNumbering): AbstractNumbering => {
+    const seen = new Set<number>();
+    let current = abstract;
+    while (current.numStyleLink && !seen.has(current.abstractNumId)) {
+      seen.add(current.abstractNumId);
+      const linkedStyle = styleById.get(current.numStyleLink);
+      const linkedNumId = linkedStyle?.pPr?.numPr?.numId;
+      const linkedNum = linkedNumId === undefined ? undefined : numById.get(linkedNumId);
+      const linkedAbstract = linkedNum ? abstractById.get(linkedNum.abstractNumId) : undefined;
+      if (!linkedAbstract) {
+        warnings.push(
+          `Numbering style link "${current.numStyleLink}" on abstractNum ${current.abstractNumId} could not be resolved; the clone keeps the link.`,
+        );
+        return current;
+      }
+      current = linkedAbstract;
+    }
+    return current;
+  };
+
+  const cloneNumId = (numId: number): number => {
+    const existing = clonedNum.get(numId);
+    if (existing) {
+      return existing.numId;
+    }
+    const source = numById.get(numId);
+    if (!source) {
+      return numId;
+    }
+    const abstract = cloneAbstract(source.abstractNumId);
+    const clone: NumberingInstance = {
+      ...source,
+      numId: nextNumId,
+      abstractNumId: abstract ? abstract.abstractNumId : source.abstractNumId,
+    };
+    nextNumId += 1;
+    clonedNum.set(numId, clone);
+    return clone.numId;
+  };
+
+  return {
+    cloneNumId,
+    clonedAbstractNumId: (abstractNumId) => clonedAbstract.get(abstractNumId)?.abstractNumId,
+    hasClones: () => clonedNum.size > 0,
+    toDefinitions: () => ({
+      abstractNums: [...abstractNums, ...clonedAbstract.values()],
+      nums: [...nums, ...clonedNum.values()],
+    }),
+  };
+};
+
+// ----------------------------------------------------------------------------
+// Style clones
+// ----------------------------------------------------------------------------
+
+type StyleCloner = {
+  /** Cloned style id for a source style id, or the source id when no clone is needed. */
+  styleIdFor: (styleId: string) => string;
+  hasClones: () => boolean;
+  toDefinitions: (styles: StyleDefinitions) => StyleDefinitions;
+};
+
+type CreateStyleClonerOptions = {
+  styleById: Map<string, Style>;
+  suffix: string;
+  cloner: NumberingCloner;
+};
+
+/**
+ * A paragraph style is cloned only when its chain carries numbering. The clone
+ * keeps `basedOn` and every other property; only `pPr.numPr` is rewritten to
+ * the cloned instance, so indent precedence stays "style-sourced" exactly as
+ * in the source (see `ParagraphFormatting.numPrFromStyle`).
+ */
+const createStyleCloner = ({
+  styleById,
+  suffix,
+  cloner,
+}: CreateStyleClonerOptions): StyleCloner => {
+  const clones = new Map<string, Style>();
+
+  const styleIdFor = (styleId: string): string => {
+    const existing = clones.get(styleId);
+    if (existing) {
+      return existing.styleId;
+    }
+    const style = styleById.get(styleId);
+    if (!style || style.type !== "paragraph") {
+      return styleId;
+    }
+    const numPr = styleNumPr(style, styleById);
+    if (numPr?.numId === undefined) {
+      return styleId;
+    }
+    const cloneId = `${styleId}-${suffix}`;
+    if (styleById.has(cloneId)) {
+      return cloneId;
+    }
+    const clone: Style = {
+      ...style,
+      styleId: cloneId,
+      name: `${style.name ?? style.styleId} (${suffix})`,
+      ...(style.next !== undefined && { next: style.next === styleId ? cloneId : style.next }),
+      default: false,
+      pPr: { ...style.pPr, numPr: { ...numPr, numId: cloner.cloneNumId(numPr.numId) } },
+    };
+    clones.set(styleId, clone);
+    return cloneId;
+  };
+
+  return {
+    styleIdFor,
+    hasClones: () => clones.size > 0,
+    toDefinitions: (styles) => ({ ...styles, styles: [...styles.styles, ...clones.values()] }),
+  };
+};
+
+// ----------------------------------------------------------------------------
+// Paragraph / table copies
+// ----------------------------------------------------------------------------
+
+const cloneParagraphForTarget = (
+  paragraph: Paragraph,
+  targetParaId: string,
+  styleCloner: StyleCloner,
+  cloner: NumberingCloner,
+): Paragraph => {
+  const { textId: _textId, sectionProperties: _sectionProperties, ...rest } = paragraph;
+  const formatting = paragraph.formatting;
+  const nextFormatting: ParagraphFormatting | undefined = formatting && {
+    ...formatting,
+    ...(formatting.styleId !== undefined && {
+      styleId: styleCloner.styleIdFor(formatting.styleId),
+    }),
+    ...(formatting.numPr?.numId !== undefined &&
+      formatting.numPr.numId !== 0 && {
+        numPr: { ...formatting.numPr, numId: cloner.cloneNumId(formatting.numPr.numId) },
+      }),
+    ...(formatting.numPrFromStyle?.numId !== undefined &&
+      formatting.numPrFromStyle.numId !== 0 && {
+        numPrFromStyle: {
+          ...formatting.numPrFromStyle,
+          numId: cloner.cloneNumId(formatting.numPrFromStyle.numId),
+        },
+      }),
+  };
+  return {
+    ...rest,
+    paraId: targetParaId,
+    ...(nextFormatting && { formatting: nextFormatting }),
+    ...(paragraph.listRendering && {
+      listRendering: remapListRendering(paragraph.listRendering, cloner),
+    }),
+  };
+};
+
+const remapListRendering = (rendering: ListRendering, cloner: NumberingCloner): ListRendering => {
+  const clonedAbstract =
+    rendering.abstractNumId === undefined
+      ? undefined
+      : cloner.clonedAbstractNumId(rendering.abstractNumId);
+  return {
+    ...rendering,
+    numId: cloner.cloneNumId(rendering.numId),
+    ...(clonedAbstract !== undefined && { abstractNumId: clonedAbstract }),
+  };
+};
+
+const cloneTableForTarget = (
+  table: Table,
+  copyParagraph: (paragraph: Paragraph) => Paragraph,
+): Table => ({
+  ...table,
+  rows: table.rows.map((row) => ({
+    ...row,
+    cells: row.cells.map((cell) => ({
+      ...cell,
+      content: cell.content.map((item) =>
+        item.type === "paragraph" ? copyParagraph(item) : cloneTableForTarget(item, copyParagraph),
+      ),
+    })),
+  })),
+});
+
+// ----------------------------------------------------------------------------
+// Output table
+// ----------------------------------------------------------------------------
+
+const buildRow = (left: BodyBlock, right: BodyBlock): Table["rows"][number] => ({
+  type: "tableRow",
+  formatting: { cantSplit: true },
+  cells: [buildCell(left), buildCell(right)],
+});
+
+const buildCell = (block: BodyBlock): TableCell => ({
+  type: "tableCell",
+  formatting: { width: { value: HALF_WIDTH_PCT, type: "pct" }, verticalAlign: "top" },
+  // A cell must end with a paragraph; a bare nested table is invalid OOXML.
+  content: block.type === "table" ? [block, { type: "paragraph", content: [] }] : [block],
+});
+
+const buildTable = (rows: Table["rows"], borders: BilingualBorders, textWidth: number): Table => ({
+  type: "table",
+  formatting: {
+    width: { value: FULL_WIDTH_PCT, type: "pct" },
+    layout: "fixed",
+    borders: TABLE_BORDERS[borders],
+    look: { firstRow: false, firstColumn: false, noHBand: true, noVBand: true },
+  },
+  columnWidths: [Math.floor(textWidth / 2), Math.ceil(textWidth / 2)],
+  rows,
+});
+
+const resolveTextWidthTwips = (doc: Document): number => {
+  const section: SectionProperties | undefined =
+    doc.package.document.finalSectionProperties ?? doc.package.document.sections?.at(0)?.properties;
+  if (!section?.pageWidth) {
+    return A4_TEXT_WIDTH_TWIPS;
+  }
+  const width = section.pageWidth - (section.marginLeft ?? 0) - (section.marginRight ?? 0);
+  return width > 0 ? width : A4_TEXT_WIDTH_TWIPS;
+};
+
+// ----------------------------------------------------------------------------
+// paraIds
+// ----------------------------------------------------------------------------
+
+const collectParaIds = (blocks: BodyBlock[]): Set<string> => {
+  const ids = new Set<string>();
+  const visitParagraph = (paragraph: Paragraph): void => {
+    if (paragraph.paraId) {
+      ids.add(paragraph.paraId);
+    }
+  };
+  const visitTable = (table: Table): void => {
+    for (const row of table.rows) {
+      for (const cell of row.cells) {
+        for (const item of cell.content) {
+          if (item.type === "paragraph") {
+            visitParagraph(item);
+          } else {
+            visitTable(item);
+          }
+        }
+      }
+    }
+  };
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      visitParagraph(block);
+    } else {
+      visitTable(block);
+    }
+  }
+  return ids;
+};
+
+type ParaIdMinter = { mint: (sourceParaId: string | undefined) => string };
+
+/**
+ * Fresh ids derived from the source id (so re-running on the same source
+ * yields the same handles), salted past any id already in the document.
+ */
+const createParaIdMinter = (taken: Set<string>): ParaIdMinter => {
+  let ordinal = 0;
+  return {
+    mint: (sourceParaId) => {
+      ordinal += 1;
+      const seed = `${ROW_ID_NAMESPACE}:${sourceParaId ?? `ordinal-${ordinal}`}`;
+      let id = deterministicHexId(seed);
+      for (let salt = 1; taken.has(id); salt += 1) {
+        id = deterministicHexId(`${seed}:${salt}`);
+      }
+      taken.add(id);
+      return id;
+    },
+  };
+};

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -15,6 +15,8 @@
  * and read once, and its labels are translated inline rather than duplicated.
  */
 
+import { TaggedError } from "better-result";
+
 import { getParagraphText } from "../paragraphParser";
 import type {
   AbstractNumbering,
@@ -88,6 +90,13 @@ export type CreateBilingualDocumentResult = {
 };
 
 const STYLE_SUFFIX_PATTERN = /^[A-Za-z0-9-]+$/u;
+
+export class InvalidBilingualDocumentOptionsError extends TaggedError(
+  "InvalidBilingualDocumentOptionsError",
+)<{
+  message: string;
+  option: "targetStyleSuffix";
+}>() {}
 const FULL_WIDTH_PCT = 5000;
 const HALF_WIDTH_PCT = 2500;
 const A4_TEXT_WIDTH_TWIPS = 9072;
@@ -119,9 +128,10 @@ export function createBilingualDocument(
   options: CreateBilingualDocumentOptions,
 ): CreateBilingualDocumentResult {
   if (!STYLE_SUFFIX_PATTERN.test(options.targetStyleSuffix)) {
-    throw new RangeError(
-      `targetStyleSuffix must match ${STYLE_SUFFIX_PATTERN}; received ${JSON.stringify(options.targetStyleSuffix)}`,
-    );
+    throw new InvalidBilingualDocumentOptionsError({
+      message: `targetStyleSuffix must match ${STYLE_SUFFIX_PATTERN}; received ${JSON.stringify(options.targetStyleSuffix)}`,
+      option: "targetStyleSuffix",
+    });
   }
   const borders = options.borders ?? "none";
   const warnings: string[] = [];
@@ -137,7 +147,7 @@ export function createBilingualDocument(
     suffix: options.targetStyleSuffix,
     cloner,
   });
-  const paraIds = createParaIdMinter(collectParaIds(blocks));
+  const paraIds = createParaIdMinter(collectPackageParaIds(source.package));
 
   const rows: BilingualRow[] = [];
   const content: BlockContent[] = [];
@@ -185,7 +195,7 @@ export function createBilingualDocument(
     }));
     rows.push({
       kind: "table",
-      rowId: paragraphs.at(0)?.paraId ?? paraIds.mint(undefined),
+      rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),
       paragraphs,
     });
     sectionRows.push(buildSpanningRow(block));
@@ -210,6 +220,10 @@ export function createBilingualDocument(
 // ----------------------------------------------------------------------------
 
 type BodyBlock = Paragraph | Table;
+
+/** Handle for a table row whose paragraphs carry no `paraId`: its position in
+ *  the manifest, which creation and reading derive identically. */
+const tableRowHandle = (index: number): string => `table-${index}`;
 
 /** Top-level body blocks with content controls flattened to their children. */
 const flattenBlocks = (content: BlockContent[]): BodyBlock[] => {
@@ -396,9 +410,17 @@ const createNumberingCloner = ({
     }
     const source = numById.get(numId);
     if (!source) {
+      warnings.push(
+        `Numbering instance ${numId} is not defined; paragraphs using it keep the source instance.`,
+      );
       return numId;
     }
     const abstract = cloneAbstract(source.abstractNumId);
+    if (!abstract) {
+      warnings.push(
+        `Numbering instance ${numId} references abstractNum ${source.abstractNumId}, which is not defined; its copy shares the source counters.`,
+      );
+    }
     const clone: NumberingInstance = {
       ...source,
       numId: nextNumId,
@@ -517,6 +539,9 @@ const cloneParagraphForTarget = (
   };
   return {
     ...rest,
+    // Own content nodes: repacking assigns rIds to images and hyperlinks in
+    // place, which must not hit one shared node graph twice.
+    content: structuredClone(paragraph.content),
     paraId: targetParaId,
     ...(nextFormatting && { formatting: nextFormatting }),
     ...(paragraph.listRendering && {
@@ -613,33 +638,43 @@ const resolveTextWidthTwips = (doc: Document): number => {
 // paraIds
 // ----------------------------------------------------------------------------
 
-const collectParaIds = (blocks: BodyBlock[]): Set<string> => {
+/**
+ * Every `paraId` anywhere in the package (body, headers, footers, notes,
+ * comments), so a minted id cannot collide with a part the body never sees.
+ * Walks the model generically: any object with `type: "paragraph"` and a
+ * string `paraId` counts.
+ */
+const collectPackageParaIds = (pkg: Document["package"]): Set<string> => {
   const ids = new Set<string>();
-  const visitParagraph = (paragraph: Paragraph): void => {
-    if (paragraph.paraId) {
-      ids.add(paragraph.paraId);
+  const seen = new Set<object>();
+  const visit = (value: unknown): void => {
+    if (typeof value !== "object" || value === null || seen.has(value)) {
+      return;
     }
-  };
-  const visitTable = (table: Table): void => {
-    for (const row of table.rows) {
-      for (const cell of row.cells) {
-        for (const item of cell.content) {
-          if (item.type === "paragraph") {
-            visitParagraph(item);
-          } else {
-            visitTable(item);
-          }
-        }
+    seen.add(value);
+    if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
       }
+      return;
+    }
+    if (value instanceof Map) {
+      for (const item of value.values()) {
+        visit(item);
+      }
+      return;
+    }
+    if (isParagraphWithId(value)) {
+      ids.add(value.paraId);
+    }
+    for (const child of Object.values(value)) {
+      visit(child);
     }
   };
-  for (const block of blocks) {
-    if (block.type === "paragraph") {
-      visitParagraph(block);
-    } else {
-      visitTable(block);
-    }
-  }
+  visit(pkg);
   return ids;
 };
 
@@ -681,13 +716,11 @@ export function readBilingualDocument(document: Document): BilingualRow[] {
     (document.package.styles?.styles ?? []).map((style) => [style.styleId, style]),
   );
   const rows: BilingualRow[] = [];
-  let ordinal = 0;
   for (const block of flattenBlocks(document.package.document.content)) {
     if (block.type !== "table" || !isBilingualTable(block)) {
       continue;
     }
     for (const row of block.rows) {
-      ordinal += 1;
       const [left, right] = row.cells;
       if (!left) {
         continue;
@@ -702,7 +735,7 @@ export function readBilingualDocument(document: Document): BilingualRow[] {
           }));
         rows.push({
           kind: "table",
-          rowId: paragraphs.at(0)?.paraId ?? `table-${ordinal}`,
+          rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),
           paragraphs,
         });
         continue;
@@ -745,3 +778,9 @@ const isBilingualTable = (table: Table): boolean => {
   }
   return pairs > 0;
 };
+
+const isParagraphWithId = (value: object): value is { type: "paragraph"; paraId: string } =>
+  "type" in value &&
+  value.type === "paragraph" &&
+  "paraId" in value &&
+  typeof value.paraId === "string";

--- a/packages/core/src/docx/server/createBilingualDocx.ts
+++ b/packages/core/src/docx/server/createBilingualDocx.ts
@@ -1,9 +1,11 @@
+import { ensureParaIds } from "../ensureParaIds";
 import { parseDocx } from "../parser";
 import { createDocx } from "../rezip";
 import {
   type BilingualRow,
   type CreateBilingualDocumentOptions,
   createBilingualDocument,
+  readBilingualDocument,
 } from "./createBilingualDocument";
 
 export type CreateBilingualDocxResult = {
@@ -13,17 +15,25 @@ export type CreateBilingualDocxResult = {
 };
 
 /**
- * Bytes-in / bytes-out form of {@link createBilingualDocument}: parse the DOCX
- * (no font preloading, so it never touches the DOM), lay the body out as a
- * two-column table, and repack onto the original package so theme, fonts,
+ * Bytes-in / bytes-out form of {@link createBilingualDocument}: stamp every
+ * paragraph with a `paraId` (so left-column rows are addressable later), parse
+ * the DOCX (no font preloading, so it never touches the DOM), lay the body out
+ * as a two-column table, and repack onto the original package so theme, fonts,
  * media, headers and footers carry over untouched.
  */
 export async function createBilingualDocx(
   input: ArrayBuffer | Uint8Array,
   options: CreateBilingualDocumentOptions,
 ): Promise<CreateBilingualDocxResult> {
-  const source = await parseDocx(input, { preloadFonts: false });
+  const stamped = await ensureParaIds(input);
+  const source = await parseDocx(stamped.docx, { preloadFonts: false });
   const { document, rows, warnings } = createBilingualDocument(source, options);
   const buffer = await createDocx(document);
   return { buffer, rows, warnings };
+}
+
+/** Bytes-in form of {@link readBilingualDocument}. */
+export async function readBilingualDocx(input: ArrayBuffer | Uint8Array): Promise<BilingualRow[]> {
+  const document = await parseDocx(input, { preloadFonts: false });
+  return readBilingualDocument(document);
 }

--- a/packages/core/src/docx/server/createBilingualDocx.ts
+++ b/packages/core/src/docx/server/createBilingualDocx.ts
@@ -1,0 +1,29 @@
+import { parseDocx } from "../parser";
+import { createDocx } from "../rezip";
+import {
+  type BilingualRow,
+  type CreateBilingualDocumentOptions,
+  createBilingualDocument,
+} from "./createBilingualDocument";
+
+export type CreateBilingualDocxResult = {
+  buffer: ArrayBuffer;
+  rows: BilingualRow[];
+  warnings: string[];
+};
+
+/**
+ * Bytes-in / bytes-out form of {@link createBilingualDocument}: parse the DOCX
+ * (no font preloading, so it never touches the DOM), lay the body out as a
+ * two-column table, and repack onto the original package so theme, fonts,
+ * media, headers and footers carry over untouched.
+ */
+export async function createBilingualDocx(
+  input: ArrayBuffer | Uint8Array,
+  options: CreateBilingualDocumentOptions,
+): Promise<CreateBilingualDocxResult> {
+  const source = await parseDocx(input, { preloadFonts: false });
+  const { document, rows, warnings } = createBilingualDocument(source, options);
+  const buffer = await createDocx(document);
+  return { buffer, rows, warnings };
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -204,6 +204,7 @@ export {
   type BilingualParagraphRef,
   type BilingualRow,
   type BilingualRowKind,
+  type BilingualTableParagraphRef,
   type CreateBilingualDocumentOptions,
   type CreateBilingualDocumentResult,
 } from "./docx/server/createBilingualDocument";

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -200,6 +200,7 @@ export {
 export { docxToMarkdown } from "./docx/server/docxToMarkdown";
 export {
   createBilingualDocument,
+  InvalidBilingualDocumentOptionsError,
   readBilingualDocument,
   type BilingualBorders,
   type BilingualParagraphRef,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -198,6 +198,19 @@ export {
   type ExtractedDocxText,
 } from "./docx/server/extractDocxText";
 export { docxToMarkdown } from "./docx/server/docxToMarkdown";
+export {
+  createBilingualDocument,
+  type BilingualBorders,
+  type BilingualParagraphRef,
+  type BilingualRow,
+  type BilingualRowKind,
+  type CreateBilingualDocumentOptions,
+  type CreateBilingualDocumentResult,
+} from "./docx/server/createBilingualDocument";
+export {
+  createBilingualDocx,
+  type CreateBilingualDocxResult,
+} from "./docx/server/createBilingualDocx";
 export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";
 export {
   applyDocxXmlPatchProposal,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -200,6 +200,7 @@ export {
 export { docxToMarkdown } from "./docx/server/docxToMarkdown";
 export {
   createBilingualDocument,
+  readBilingualDocument,
   type BilingualBorders,
   type BilingualParagraphRef,
   type BilingualRow,
@@ -210,6 +211,7 @@ export {
 } from "./docx/server/createBilingualDocument";
 export {
   createBilingualDocx,
+  readBilingualDocx,
   type CreateBilingualDocxResult,
 } from "./docx/server/createBilingualDocx";
 export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";


### PR DESCRIPTION
## Summary

- `createBilingualDocument` / `createBilingualDocx` on the `/server` entry: the body becomes a two-column table (source | copy), one row per block, one table per section; the left column keeps source blocks untouched, the right column gets numbering instances, abstract definitions and numbered paragraph styles cloned per language (`Heading1-en`) so both columns count independently; right-column paragraphs get fresh deterministic `paraId`s reported as a row manifest.
- Repack onto an original package now appends numbering definitions and styles the model added; the selective splice only handled changed definitions, so added ones were dropped on save.

## Verification

- `createBilingualDocument.test.ts`: layout, left-column identity, no shared `numId`/`abstractNumId` across columns, style clones, stable handles, repack round trip, no-numbering documents. Round-trip test fails when either append path is removed (mutation checked).
- Output of a real two-column conversion validates with `validateDocxConformance` and renders `2. / 2.`, `2.1 / 2.1`, `A) / A)` in LibreOffice.
- API report updated for `core/server`; changeset minor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added APIs to create and read bilingual documents and DOCX files.
  * Bilingual documents now display source and translated content in separate columns with independent numbering.
  * Added support for configurable borders, tables, paragraph references, warnings, and structural row information.
  * Added DOCX round-tripping that preserves numbering, styles, tables, and document structure.
* **Documentation**
  * Added public type and API declarations for bilingual document workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->