### PR TITLE
fix(core): preserve complete note story text

### DIFF
--- a/.changeset/quiet-notes-speak.md
+++ b/.changeset/quiet-notes-speak.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve accepted tracked changes, wrapped text, and tables when reading note stories.

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -2594,7 +2594,57 @@ const readNotesFixture = async (): Promise<ArrayBuffer> => {
   return zip.generateAsync({ type: "arraybuffer" });
 };
 
+const readRichNotesFixture = async (): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await readNotesFixture());
+  const footnotesFile = zip.file("word/footnotes.xml");
+  if (!footnotesFile) {
+    throw new Error("fixture missing word/footnotes.xml");
+  }
+  const footnotesXml = await footnotesFile.async("text");
+  zip.file(
+    "word/footnotes.xml",
+    footnotesXml.replace(
+      /<w:footnote w:id="2">.*?<\/w:footnote>/u,
+      `<w:footnote w:id="2">
+        <w:p w14:paraId="B2000001">
+          <w:r><w:t xml:space="preserve">See </w:t></w:r>
+          <w:ins w:id="1" w:author="Reviewer"><w:r><w:t xml:space="preserve">INSERTED </w:t></w:r></w:ins>
+          <w:del w:id="2" w:author="Reviewer"><w:r><w:delText xml:space="preserve">DELETED </w:delText></w:r></w:del>
+          <w:moveFrom w:id="3" w:author="Reviewer"><w:r><w:t xml:space="preserve">MOVED FROM </w:t></w:r></w:moveFrom>
+          <w:moveTo w:id="4" w:author="Reviewer"><w:r><w:t xml:space="preserve">MOVED TO </w:t></w:r></w:moveTo>
+          <w:hyperlink w:anchor="citation"><w:r><w:t xml:space="preserve">LINK </w:t></w:r></w:hyperlink>
+          <w:fldSimple w:instr=" REF citation "><w:r><w:t xml:space="preserve">SIMPLE </w:t></w:r></w:fldSimple>
+          <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+          <w:r><w:instrText xml:space="preserve"> REF citation </w:instrText></w:r>
+          <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+          <w:r><w:t xml:space="preserve">COMPLEX </w:t></w:r>
+          <w:r><w:fldChar w:fldCharType="end"/></w:r>
+          <w:sdt><w:sdtPr/><w:sdtContent><w:r><w:t>SDT.</w:t></w:r></w:sdtContent></w:sdt>
+        </w:p>
+        <w:tbl><w:tr><w:tc><w:p><w:r><w:t>TABLE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
+      </w:footnote>`,
+    ),
+  );
+  zip.file(
+    "word/endnotes.xml",
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="B2000002"><w:r><w:t xml:space="preserve">Endnote </w:t></w:r><w:ins w:id="5" w:author="Reviewer"><w:r><w:t>INSERTED</w:t></w:r></w:ins><w:del w:id="6" w:author="Reviewer"><w:r><w:delText>DELETED</w:delText></w:r></w:del></w:p><w:tbl><w:tr><w:tc><w:p><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:endnote></w:endnotes>',
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
 describe("headless docx review notes read surface", () => {
+  test("reads every visible note content kind in the accepted view", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await readRichNotesFixture());
+    const footnote = reviewer
+      .listStories()
+      .find(({ handle }) => handle.type === "footnote" && handle.noteId === 2);
+
+    expect(footnote?.text).toBe("See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT. TABLE CELL");
+    expect(reviewer.readStory({ type: "endnote", noteId: 3 })?.text).toBe(
+      "Endnote INSERTED ENDNOTE CELL",
+    );
+  });
+
   test("edits a footnote through story-scoped document operations", async () => {
     const baseline = await readNotesFixture();
     const story = { type: "footnote", noteId: 2 } as const;

--- a/packages/core/src/docx/footnoteParser.ts
+++ b/packages/core/src/docx/footnoteParser.ts
@@ -29,7 +29,8 @@ import type {
   MediaFile,
 } from "../types/document";
 import type { NumberingMap } from "./numberingParser";
-import { parseParagraph } from "./paragraphParser";
+import { getParagraphText, parseParagraph } from "./paragraphParser";
+import { panic } from "better-result";
 import { parseSdtProperties } from "./sdtProperties";
 import type { StyleMap } from "./styleParser";
 import { parseTable } from "./tableParser";
@@ -408,10 +409,7 @@ export { parseFootnoteProperties, parseEndnoteProperties } from "./notePropertie
 /**
  * Get plain text content of a footnote.
  *
- * Recurses into block-level SDTs so a citation slot inside a note still
- * contributes its text; without recursion, the BlockSdt addition from
- * the previous commit would silently hide the slot's body from this
- * helper.
+ * Uses the accepted tracked-change view and recurses through every note block.
  */
 export function getFootnoteText(footnote: Footnote): string {
   return collectNoteBlockTexts(footnote.content).join("\n");
@@ -427,23 +425,28 @@ export function getEndnoteText(endnote: Endnote): string {
 function collectNoteBlockTexts(blocks: readonly (Paragraph | Table | BlockSdt)[]): string[] {
   const texts: string[] = [];
   for (const block of blocks) {
-    if (block.type === "paragraph") {
-      const paraTexts: string[] = [];
-      for (const content of block.content) {
-        if (content.type === "run") {
-          for (const runContent of content.content) {
-            if (runContent.type === "text") {
-              paraTexts.push(runContent.text);
-            }
+    switch (block.type) {
+      case "paragraph":
+        texts.push(getParagraphText(block));
+        break;
+      case "table":
+        for (const row of block.rows) {
+          if (row.formatting?.hidden === true) {
+            continue;
           }
+          texts.push(
+            row.cells.map((cell) => collectNoteBlockTexts(cell.content).join("\n")).join("\t"),
+          );
         }
+        break;
+      case "blockSdt":
+        texts.push(...collectNoteBlockTexts(block.content));
+        break;
+      default: {
+        const unsupported: never = block;
+        panic(`Unsupported note block in plain-text extraction: ${JSON.stringify(unsupported)}`);
       }
-      texts.push(paraTexts.join(""));
-    } else if (block.type === "blockSdt") {
-      texts.push(...collectNoteBlockTexts(block.content));
     }
-    // Table cells aren't surfaced by this helper today; pre-existing
-    // limitation, leaving out of scope.
   }
   return texts;
 }

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -34,8 +34,10 @@ import type {
   ParagraphPropertyChange,
   TrackedChangeInfo,
   MathEquation,
+  RunContent,
 } from "../types/document";
 import { normalizeRevisionId } from "@stll/docx-core/model";
+import { panic } from "better-result";
 import { isValidHexId } from "../utils/hexId";
 import {
   parseBookmarkStart as parseBookmarkStartFromModule,
@@ -2061,6 +2063,101 @@ function styleChainInd(
 // UTILITY FUNCTIONS
 // ============================================================================
 
+const getRunContentText = (content: RunContent): string => {
+  switch (content.type) {
+    case "text":
+      return content.text;
+    case "tab":
+      return "\t";
+    case "break":
+      return content.breakType === "page" ? "\f" : "\n";
+    case "noBreakHyphen":
+      return "\u2011";
+    case "softHyphen":
+      return "\u00ad";
+    case "drawing":
+    case "endnoteRef":
+    case "fieldChar":
+    case "footnoteRef":
+    case "instrText":
+    case "renderedPageBreak":
+    case "shape":
+    case "symbol":
+      return "";
+    default: {
+      const unsupported: never = content;
+      return panic(
+        `Unsupported run content in plain-text extraction: ${JSON.stringify(unsupported)}`,
+      );
+    }
+  }
+};
+
+const getRunText = (run: Run): string => {
+  if (run.formatting?.hidden === true) {
+    return "";
+  }
+  return run.content.map(getRunContentText).join("");
+};
+
+const getHyperlinkText = (hyperlink: Hyperlink): string =>
+  hyperlink.children
+    .map((child) => {
+      switch (child.type) {
+        case "run":
+          return getRunText(child);
+        case "bookmarkStart":
+        case "bookmarkEnd":
+          return "";
+        default: {
+          const unsupported: never = child;
+          return panic(
+            `Unsupported hyperlink child in plain-text extraction: ${JSON.stringify(unsupported)}`,
+          );
+        }
+      }
+    })
+    .join("");
+
+const getParagraphContentText = (content: ParagraphContent): string => {
+  switch (content.type) {
+    case "run":
+      return getRunText(content);
+    case "hyperlink":
+      return getHyperlinkText(content);
+    case "simpleField":
+      return content.content.map(getParagraphContentText).join("");
+    case "complexField":
+      return content.fieldResult.map(getRunText).join("");
+    case "inlineSdt":
+      return content.content.map(getParagraphContentText).join("");
+    case "insertion":
+    case "moveTo":
+      return content.content.map(getParagraphContentText).join("");
+    case "deletion":
+    case "moveFrom":
+      return "";
+    case "mathEquation":
+      return content.plainText ?? "";
+    case "bookmarkEnd":
+    case "bookmarkStart":
+    case "commentRangeEnd":
+    case "commentRangeStart":
+    case "commentReference":
+    case "moveFromRangeEnd":
+    case "moveFromRangeStart":
+    case "moveToRangeEnd":
+    case "moveToRangeStart":
+      return "";
+    default: {
+      const unsupported: never = content;
+      return panic(
+        `Unsupported paragraph content in plain-text extraction: ${JSON.stringify(unsupported)}`,
+      );
+    }
+  }
+};
+
 /**
  * Get plain text from a paragraph
  *
@@ -2068,55 +2165,7 @@ function styleChainInd(
  * @returns Concatenated text content
  */
 export function getParagraphText(paragraph: Paragraph): string {
-  let text = "";
-
-  for (const content of paragraph.content) {
-    if (content.type === "run") {
-      for (const runContent of content.content) {
-        if (runContent.type === "text") {
-          text += runContent.text;
-        } else if (runContent.type === "tab") {
-          text += "\t";
-        } else if (runContent.type === "break") {
-          if (runContent.breakType === "page") {
-            text += "\f";
-          } else {
-            text += "\n";
-          }
-        }
-      }
-    } else if (content.type === "hyperlink") {
-      for (const child of content.children) {
-        if (child.type === "run") {
-          for (const runContent of child.content) {
-            if (runContent.type === "text") {
-              text += runContent.text;
-            }
-          }
-        }
-      }
-    } else if (content.type === "simpleField") {
-      for (const child of content.content) {
-        if (child.type === "run") {
-          for (const runContent of child.content) {
-            if (runContent.type === "text") {
-              text += runContent.text;
-            }
-          }
-        }
-      }
-    } else if (content.type === "complexField") {
-      for (const run of content.fieldResult) {
-        for (const runContent of run.content) {
-          if (runContent.type === "text") {
-            text += runContent.text;
-          }
-        }
-      }
-    }
-  }
-
-  return text;
+  return paragraph.content.map(getParagraphContentText).join("");
 }
 
 /**


### PR DESCRIPTION
Fixes #583

## Summary

- reuse exhaustive accepted-view paragraph text extraction for footnotes and endnotes
- preserve tracked insertions, move destinations, hyperlinks, fields, inline content controls, and nested table-cell text
- exclude deleted, moved-from, and hidden content from the accepted view
- add public reviewer regression coverage for both note kinds

## Root cause

Note stories used a narrower extraction path than document paragraphs and only visited direct run children. Valid OOXML wrappers and table blocks were never traversed, so the exposed story text was incomplete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved note text extraction to preserve accepted tracked changes and wrapped text.
  - Included visible content from tables in footnotes and endnotes, while excluding hidden rows.
  - Added support for hyperlinks, fields, structured content, page breaks, tabs, and moves.
  - Correctly omits deleted or hidden content from extracted note text.
  - Improved handling of unsupported note content to prevent silent extraction errors.

- **Tests**
  - Added comprehensive coverage for rich note content, including tracked changes, tables, fields, hyperlinks, and structured content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->