### PR TITLE
chore: upgrade better-result to v3

### DIFF
--- a/.changeset/bright-errors-upgrade.md
+++ b/.changeset/bright-errors-upgrade.md
@@ -1,0 +1,8 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
+---
+
+Upgrade `better-result` to v3.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -551,7 +551,10 @@ export type FolioDocumentStoryHandle = {
 };
 
 // @public (undocumented)
-export class FolioDocumentStoryNotFoundError extends FolioDocumentStoryNotFoundError_base {}
+export class FolioDocumentStoryNotFoundError extends FolioDocumentStoryNotFoundError_base<{
+    message: string;
+    story: FolioEditableDocumentStoryHandle;
+}> {}
 
 // @public (undocumented)
 export type FolioEditableDocumentStoryHandle = FolioDocumentStoryHandle;
@@ -621,7 +624,11 @@ export const getTrackedChangesFromDoc: (doc: Node_2) => FolioReviewChange[];
 export const hashFolioAIBlockText: (text: string) => string;
 
 // @public (undocumented)
-export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
+export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base<{
+    message: string;
+    path: string;
+    reason: string;
+}> {}
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;
@@ -654,10 +661,16 @@ export const resolveFolioAITextRange: (input: ResolveFolioAITextRangeOptions) =>
 export const resolvePassageRange: (input: ResolvePassageRangeOptions) => DocPositionRange | null;
 
 // @public (undocumented)
-export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
+export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base<{
+    message: string;
+    receivedVersion: unknown;
+}> {}
 
 // @public (undocumented)
-export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base {}
+export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base<{
+    message: string;
+    receivedView: unknown;
+}> {}
 
 // @public
 export type WordDiffSegment = {

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -893,7 +893,11 @@ export const inspectDocxCompatibility: (doc: import__stll_docx_core_model.Docume
 export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
 
 // @public (undocumented)
-export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
+export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base<{
+    message: string;
+    path: string;
+    reason: string;
+}> {}
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
@@ -1070,7 +1074,10 @@ export function toMarkdown(doc: import__stll_docx_core_model.Document, opts?: Ma
 export function toMarkdownResult(doc: import__stll_docx_core_model.Document, opts?: MarkdownOptions): MarkdownResult;
 
 // @public (undocumented)
-export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
+export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base<{
+    message: string;
+    receivedVersion: unknown;
+}> {}
 
 // @public
 export type WordDiffSegment = {

--- a/api-reports/core/content-controls.api.md
+++ b/api-reports/core/content-controls.api.md
@@ -8,7 +8,13 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { TaggedErrorClass } from 'better-result';
 
 // @public
-export class ContentControlBoundError extends ContentControlBoundError_base {}
+export class ContentControlBoundError extends ContentControlBoundError_base<{
+    message: string;
+    xpath: string;
+    storeItemID?: string;
+    tag?: string;
+    alias?: string;
+}> {}
 
 // @public (undocumented)
 export type ContentControlFilter = {
@@ -20,7 +26,12 @@ export type ContentControlFilter = {
 };
 
 // @public
-export class ContentControlLockedError extends ContentControlLockedError_base {}
+export class ContentControlLockedError extends ContentControlLockedError_base<{
+    message: string;
+    lock: NonNullable<import__stll_docx_core_model.SdtProperties["lock"]>;
+    tag?: string;
+    alias?: string;
+}> {}
 
 // @public (undocumented)
 export type ContentControlMatch = {
@@ -31,7 +42,13 @@ export type ContentControlMatch = {
 };
 
 // @public
-export class ContentControlTypeError extends ContentControlTypeError_base {}
+export class ContentControlTypeError extends ContentControlTypeError_base<{
+    message: string;
+    sdtType: import__stll_docx_core_model.SdtProperties["sdtType"];
+    reason: string;
+    tag?: string;
+    alias?: string;
+}> {}
 
 // @public (undocumented)
 export function findContentControl(doc: import__stll_docx_core_model.Document, filter: ContentControlFilter): ContentControlMatch | null;

--- a/api-reports/core/docx.api.md
+++ b/api-reports/core/docx.api.md
@@ -30,7 +30,11 @@ export const DOCX_ENCRYPTION_ERROR_CODES: {
 };
 
 // @public (undocumented)
-export class DocxEncryptionError extends DocxEncryptionError_base {}
+export class DocxEncryptionError extends DocxEncryptionError_base<{
+    message: string;
+    code: DocxEncryptionErrorCode;
+    cause?: unknown;
+}> {}
 
 // @public (undocumented)
 export type DocxEncryptionErrorCode = (typeof DOCX_ENCRYPTION_ERROR_CODES)[keyof typeof DOCX_ENCRYPTION_ERROR_CODES];
@@ -45,7 +49,11 @@ export const FOLIO_DOCUMENT_PRIVACY_TRANSFORMS: readonly ["remove-attribution", 
 export type FolioDocumentMetadataProperty = (typeof FOLIO_DOCUMENT_METADATA_PROPERTIES)[number];
 
 // @public (undocumented)
-export class FolioDocumentPrivacyArchiveError extends FolioDocumentPrivacyArchiveError_base {}
+export class FolioDocumentPrivacyArchiveError extends FolioDocumentPrivacyArchiveError_base<{
+    message: string;
+    reason: "input-too-large" | "load-failed" | "too-many-entries" | "core-properties-too-large";
+    cause?: unknown;
+}> {}
 
 // @public (undocumented)
 export type FolioDocumentPrivacyOptions = {
@@ -65,7 +73,10 @@ export type FolioDocumentPrivacyTransform = (typeof FOLIO_DOCUMENT_PRIVACY_TRANS
 export function getCachedNumberingMap(definitions: import__stll_docx_core_model.NumberingDefinitions): NumberingMap;
 
 // @public (undocumented)
-export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
+export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base<{
+    message: string;
+    receivedValue: unknown;
+}> {}
 
 // @public (undocumented)
 export const isDocxEncryptionError: (error: unknown) => error is DocxEncryptionError;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -893,7 +893,11 @@ export const inspectDocxCompatibility: (doc: import__stll_docx_core_model.Docume
 export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
 
 // @public (undocumented)
-export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
+export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base<{
+    message: string;
+    path: string;
+    reason: string;
+}> {}
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
@@ -1070,7 +1074,10 @@ export function toMarkdown(doc: import__stll_docx_core_model.Document, opts?: Ma
 export function toMarkdownResult(doc: import__stll_docx_core_model.Document, opts?: MarkdownOptions): MarkdownResult;
 
 // @public (undocumented)
-export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
+export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base<{
+    message: string;
+    receivedVersion: unknown;
+}> {}
 
 // @public
 export type WordDiffSegment = {

--- a/api-reports/core/redline.api.md
+++ b/api-reports/core/redline.api.md
@@ -34,7 +34,11 @@ export type GenerateRedlineUnprocessedStory = {
 };
 
 // @public
-export class InvalidGenerateRedlineDocxOptionsError extends InvalidGenerateRedlineDocxOptionsError_base {}
+export class InvalidGenerateRedlineDocxOptionsError extends InvalidGenerateRedlineDocxOptionsError_base<{
+    message: string;
+    option: "baseView" | "revisedView";
+    receivedValue: unknown;
+}> {}
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -192,7 +192,11 @@ export type DocumentStyleSet = {
 };
 
 // @public
-export class DocxArchiveError extends DocxArchiveError_base {}
+export class DocxArchiveError extends DocxArchiveError_base<{
+    message: string;
+    reason: "load-failed" | "input-too-large" | "too-many-entries" | "entry-too-large" | "total-too-large" | "invalid-options";
+    cause?: unknown;
+}> {}
 
 // @public (undocumented)
 export type DocxArchiveOptions = {
@@ -228,7 +232,10 @@ export const endnote: (doc: import__stll_docx_core_model.Document, content: stri
 export const ensureParaIds: (docx: Uint8Array | ArrayBuffer, options?: EnsureParaIdsOptions) => Promise<EnsureParaIdsResult>;
 
 // @public
-export class EnsureParaIdsError extends EnsureParaIdsError_base {}
+export class EnsureParaIdsError extends EnsureParaIdsError_base<{
+    message: string;
+    cause?: unknown;
+}> {}
 
 // @public
 export type EnsureParaIdsOptions = {
@@ -832,7 +839,11 @@ export type FolioDocumentOutlineEntry = {
 };
 
 // @public (undocumented)
-export class FolioDocumentPrivacyArchiveError extends FolioDocumentPrivacyArchiveError_base {}
+export class FolioDocumentPrivacyArchiveError extends FolioDocumentPrivacyArchiveError_base<{
+    message: string;
+    reason: "input-too-large" | "load-failed" | "too-many-entries" | "core-properties-too-large";
+    cause?: unknown;
+}> {}
 
 // @public (undocumented)
 export type FolioDocumentPrivacyOptions = {
@@ -898,7 +909,10 @@ export type FolioDocumentStoryHandle = {
 };
 
 // @public (undocumented)
-export class FolioDocumentStoryNotFoundError extends FolioDocumentStoryNotFoundError_base {}
+export class FolioDocumentStoryNotFoundError extends FolioDocumentStoryNotFoundError_base<{
+    message: string;
+    story: FolioEditableDocumentStoryHandle;
+}> {}
 
 // @public (undocumented)
 export type FolioDocxConformanceCheck = {
@@ -958,7 +972,12 @@ export type FolioDocxPackageInspection = {
 };
 
 // @public (undocumented)
-export class FolioDocxPackageInspectionError extends FolioDocxPackageInspectionError_base {}
+export class FolioDocxPackageInspectionError extends FolioDocxPackageInspectionError_base<{
+    message: string;
+    code: FolioDocxPackageInspectionErrorCode;
+    part?: string;
+    cause?: unknown;
+}> {}
 
 // @public (undocumented)
 export type FolioDocxPackageInspectionErrorCode = (typeof FOLIO_DOCX_PACKAGE_INSPECTION_ERROR_CODES)[number];
@@ -1066,7 +1085,12 @@ export type FolioDocxXmlPatchApplication = {
 };
 
 // @public (undocumented)
-export class FolioDocxXmlPatchApplicationError extends FolioDocxXmlPatchApplicationError_base {}
+export class FolioDocxXmlPatchApplicationError extends FolioDocxXmlPatchApplicationError_base<{
+    message: string;
+    stage: "verify" | "load" | "replace" | "generate";
+    part?: string;
+    cause?: unknown;
+}> {}
 
 // @public (undocumented)
 export type FolioDocxXmlPatchApplicationReceipt = {
@@ -1350,28 +1374,56 @@ export type InspectDocxPackageOptions = {
 };
 
 // @public (undocumented)
-export class InvalidBilingualDocumentOptionsError extends InvalidBilingualDocumentOptionsError_base {}
+export class InvalidBilingualDocumentOptionsError extends InvalidBilingualDocumentOptionsError_base<{
+    message: string;
+    option: "targetStyleSuffix";
+}> {}
 
 // @public (undocumented)
-export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base {}
+export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base<{
+    message: string;
+    path: string;
+    reason: string;
+}> {}
 
 // @public (undocumented)
-export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base {}
+export class InvalidFolioDocumentPrivacyOptionsError extends InvalidFolioDocumentPrivacyOptionsError_base<{
+    message: string;
+    receivedValue: unknown;
+}> {}
 
 // @public (undocumented)
-export class InvalidFolioDocxXmlPatchProposalError extends InvalidFolioDocxXmlPatchProposalError_base {}
+export class InvalidFolioDocxXmlPatchProposalError extends InvalidFolioDocxXmlPatchProposalError_base<{
+    message: string;
+    path: string;
+    reason: string;
+}> {}
 
 // @public (undocumented)
-export class InvalidFolioDocxXmlPatchProposalOptionsError extends InvalidFolioDocxXmlPatchProposalOptionsError_base {}
+export class InvalidFolioDocxXmlPatchProposalOptionsError extends InvalidFolioDocxXmlPatchProposalOptionsError_base<{
+    message: string;
+    path: string;
+}> {}
 
 // @public
-export class InvalidFolioReportBuilderOptionsError extends InvalidFolioReportBuilderOptionsError_base {}
+export class InvalidFolioReportBuilderOptionsError extends InvalidFolioReportBuilderOptionsError_base<{
+    message: string;
+    path: string;
+}> {}
 
 // @public (undocumented)
-export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base {}
+export class InvalidFolioVersionComparisonOptionsError extends InvalidFolioVersionComparisonOptionsError_base<{
+    message: string;
+    option: "include" | "privacy.transforms";
+    receivedValue: unknown;
+}> {}
 
 // @public
-export class InvalidGenerateRedlineDocxOptionsError extends InvalidGenerateRedlineDocxOptionsError_base {}
+export class InvalidGenerateRedlineDocxOptionsError extends InvalidGenerateRedlineDocxOptionsError_base<{
+    message: string;
+    option: "baseView" | "revisedView";
+    receivedValue: unknown;
+}> {}
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;
@@ -1469,13 +1521,22 @@ export type TableCellSpec = string | {
 };
 
 // @public (undocumented)
-export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base {}
+export class UnsupportedFolioDocumentOperationVersionError extends UnsupportedFolioDocumentOperationVersionError_base<{
+    message: string;
+    receivedVersion: unknown;
+}> {}
 
 // @public (undocumented)
-export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends UnsupportedFolioDocxXmlPatchApplicationProfileError_base {}
+export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends UnsupportedFolioDocxXmlPatchApplicationProfileError_base<{
+    message: string;
+    profile: unknown;
+}> {}
 
 // @public (undocumented)
-export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base {}
+export class UnsupportedFolioReviewedViewError extends UnsupportedFolioReviewedViewError_base<{
+    message: string;
+    receivedView: unknown;
+}> {}
 
 // @public
 export const validateDocxConformance: (bytes: ArrayBuffer | Uint8Array, options?: ValidateDocxConformanceOptions) => Promise<FolioDocxConformanceReport>;

--- a/api-reports/docx-core/projection.api.md
+++ b/api-reports/docx-core/projection.api.md
@@ -28,7 +28,10 @@ export type DocxProjectionAlignmentValue = "center" | "justify" | "left" | "righ
 export type DocxProjectionBookmarkFact = readonly [paragraphOrdinal: number, bookmarkId: number, name: string, span: DocxProjectionStructuralSpan];
 
 // @public (undocumented)
-export class DocxProjectionError extends DocxProjectionError_base {}
+export class DocxProjectionError extends DocxProjectionError_base<{
+    message: string;
+    cause: unknown;
+}> {}
 
 // @public (undocumented)
 export type DocxProjectionFactSet<T> = readonly [status: "known", items: readonly T[]] | readonly [status: "unknown", reason: DocxProjectionUnknownReason];
@@ -46,7 +49,10 @@ export type DocxProjectionFormattingUnknownReason = "document-part-only" | "styl
 export type DocxProjectionIndentationFact = readonly [paragraphOrdinal: number, firstLineTwips: number | null, hangingTwips: number | null, leftTwips: number | null, rightTwips: number | null, startTwips: number | null, endTwips: number | null, firstLineCharsHundredths: number | null, hangingCharsHundredths: number | null, leftCharsHundredths: number | null, rightCharsHundredths: number | null, startCharsHundredths: number | null, endCharsHundredths: number | null];
 
 // @public (undocumented)
-export class DocxProjectionInitializationError extends DocxProjectionInitializationError_base {}
+export class DocxProjectionInitializationError extends DocxProjectionInitializationError_base<{
+    message: string;
+    cause: unknown;
+}> {}
 
 // @public (undocumented)
 export type DocxProjectionNumberingFact = readonly [paragraphOrdinal: number, parentParagraphOrdinal: number | null, childParagraphOrdinals: readonly number[]];

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitejs/plugin-react": "^6.0.3",
         "babel-plugin-react-compiler": "^1.0.0",
-        "better-result": "2.10.0",
+        "better-result": "3.0.1",
         "binaryen": "131.0.0",
         "bun-types": "1.4.0",
         "fast-check": "^4.9.0",
@@ -54,7 +54,7 @@
         "@stll/docx-core": "workspace:^",
         "@stll/docx-utils": "^0.1.0",
         "@stll/template-conditions": "^0.1.0",
-        "better-result": "2.10.0",
+        "better-result": "3.0.1",
         "csstype": "^3.1.3",
         "dompurify": "^3.4.13",
         "fast-xml-parser": "^5.9.3",
@@ -84,7 +84,7 @@
       "name": "@stll/docx-core",
       "version": "0.15.0",
       "dependencies": {
-        "better-result": "2.10.0",
+        "better-result": "3.0.1",
         "jszip": "3.10.1",
       },
       "devDependencies": {
@@ -165,7 +165,7 @@
         "@fontsource/source-sans-3": "^5.2.9",
         "@fontsource/tinos": "^5.2.7",
         "@stll/folio-core": "workspace:^",
-        "better-result": "2.10.0",
+        "better-result": "3.0.1",
         "lucide-react": "1.24.0",
         "prosemirror-history": "^1.5.0",
         "prosemirror-model": "^1.25.9",
@@ -191,7 +191,7 @@
       "version": "0.12.2",
       "dependencies": {
         "@stll/folio-core": "workspace:^",
-        "better-result": "2.10.0",
+        "better-result": "3.0.1",
         "use-intl": "^4.13.0",
         "yjs": "^13.6.31",
       },
@@ -1097,7 +1097,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.1", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A=="],
 
-    "better-result": ["better-result@2.10.0", "", {}, "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw=="],
+    "better-result": ["better-result@3.0.1", "", {}, "sha512-rnCeqEXkKPHmz5MO5ZroPRDyHe4YvlNPyy7qj8cVcWs/GnvSvC3086G74/220W+wWcIWlXgzvcjskFV0A4blUQ=="],
 
     "binaryen": ["binaryen@131.0.0", "", { "bin": { "wasm-as": "bin/wasm-as", "wasm2js": "bin/wasm2js", "wasm-dis": "bin/wasm-dis", "wasm-opt": "bin/wasm-opt", "wasm-merge": "bin/wasm-merge", "wasm-shell": "bin/wasm-shell", "wasm-reduce": "bin/wasm-reduce", "wasm-metadce": "bin/wasm-metadce", "wasm-ctor-eval": "bin/wasm-ctor-eval" } }, "sha512-anblNezmBjfWGfOMvZq1j5MwhVnMs+gezqbDz4FBFwx6twDwOsQSed+E8i4UKmLYXb3r+f3HWmz7Lx5sx5qOyQ=="],
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitejs/plugin-react": "^6.0.3",
     "babel-plugin-react-compiler": "^1.0.0",
-    "better-result": "2.10.0",
+    "better-result": "3.0.1",
     "binaryen": "131.0.0",
     "bun-types": "1.4.0",
     "fast-check": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "@stll/docx-core": "workspace:^",
     "@stll/docx-utils": "^0.1.0",
     "@stll/template-conditions": "^0.1.0",
-    "better-result": "2.10.0",
+    "better-result": "3.0.1",
     "csstype": "^3.1.3",
     "dompurify": "^3.4.13",
     "fast-xml-parser": "^5.9.3",

--- a/packages/core/scripts/profile-editor.ts
+++ b/packages/core/scripts/profile-editor.ts
@@ -151,7 +151,7 @@ type BrowserPerfStats = PerfStats & {
 class FolioPerfError extends TaggedError("FolioPerfError")<{
   message: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 const HOST = "127.0.0.1";
 const DEFAULT_PORT = 4201;

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -263,14 +263,14 @@ export class UnsupportedFolioReviewedViewError extends TaggedError(
 )<{
   message: string;
   receivedView: unknown;
-}>() {}
+}> {}
 
 export class FolioDocumentStoryNotFoundError extends TaggedError(
   "FolioDocumentStoryNotFoundError",
 )<{
   message: string;
   story: FolioEditableDocumentStoryHandle;
-}>() {}
+}> {}
 
 export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOperationsOptions & {
   story: FolioEditableDocumentStoryHandle;

--- a/packages/core/src/content-controls/errors.ts
+++ b/packages/core/src/content-controls/errors.ts
@@ -18,7 +18,7 @@ export class ContentControlLockedError extends TaggedError("ContentControlLocked
   lock: NonNullable<SdtProperties["lock"]>;
   tag?: string;
   alias?: string;
-}>() {}
+}> {}
 
 /**
  * Refused because the target control is bound to a `<w:dataBinding>`.
@@ -40,7 +40,7 @@ export class ContentControlBoundError extends TaggedError("ContentControlBoundEr
   storeItemID?: string;
   tag?: string;
   alias?: string;
-}>() {}
+}> {}
 
 /**
  * Refused because the requested operation does not make sense for the
@@ -53,4 +53,4 @@ export class ContentControlTypeError extends TaggedError("ContentControlTypeErro
   reason: string;
   tag?: string;
   alias?: string;
-}>() {}
+}> {}

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -154,7 +154,7 @@ export class UnsupportedFolioDocumentOperationVersionError extends TaggedError(
 )<{
   message: string;
   receivedVersion: unknown;
-}>() {}
+}> {}
 
 export class InvalidFolioDocumentOperationBatchError extends TaggedError(
   "InvalidFolioDocumentOperationBatchError",
@@ -162,7 +162,7 @@ export class InvalidFolioDocumentOperationBatchError extends TaggedError(
   message: string;
   path: string;
   reason: string;
-}>() {}
+}> {}
 
 export const assertSupportedFolioDocumentOperationVersion = (
   value: unknown,

--- a/packages/core/src/docx/encryption/errors.ts
+++ b/packages/core/src/docx/encryption/errors.ts
@@ -15,7 +15,7 @@ export class DocxEncryptionError extends TaggedError("DocxEncryptionError")<{
   message: string;
   code: DocxEncryptionErrorCode;
   cause?: unknown;
-}>() {}
+}> {}
 
 export const isDocxEncryptionError = (error: unknown): error is DocxEncryptionError =>
   error instanceof DocxEncryptionError;

--- a/packages/core/src/docx/ensureParaIds.ts
+++ b/packages/core/src/docx/ensureParaIds.ts
@@ -59,7 +59,7 @@ import { loadDocxArchive } from "./server/boundedArchive";
 export class EnsureParaIdsError extends TaggedError("EnsureParaIdsError")<{
   message: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 /** Counts and normalized bytes returned by {@link ensureParaIds}. */
 export type EnsureParaIdsResult = {

--- a/packages/core/src/docx/metadataPrivacy.ts
+++ b/packages/core/src/docx/metadataPrivacy.ts
@@ -52,7 +52,7 @@ export class InvalidFolioDocumentPrivacyOptionsError extends TaggedError(
 )<{
   message: string;
   receivedValue: unknown;
-}>() {}
+}> {}
 
 export class FolioDocumentPrivacyArchiveError extends TaggedError(
   "FolioDocumentPrivacyArchiveError",
@@ -60,7 +60,7 @@ export class FolioDocumentPrivacyArchiveError extends TaggedError(
   message: string;
   reason: "input-too-large" | "load-failed" | "too-many-entries" | "core-properties-too-large";
   cause?: unknown;
-}>() {}
+}> {}
 
 export const PRIVATE_METADATA_PROPERTIES_BY_TRANSFORM = {
   "remove-attribution": ["creator", "lastModifiedBy"],

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -462,7 +462,7 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
 export class DocxParseError extends TaggedError("DocxParseError")<{
   message: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 // ============================================================================
 // HELPER FUNCTIONS

--- a/packages/core/src/docx/server/applyDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/applyDocxXmlPatchProposal.ts
@@ -101,7 +101,7 @@ export class UnsupportedFolioDocxXmlPatchApplicationProfileError extends TaggedE
 )<{
   message: string;
   profile: unknown;
-}>() {}
+}> {}
 
 export class FolioDocxXmlPatchApplicationError extends TaggedError(
   "FolioDocxXmlPatchApplicationError",
@@ -110,7 +110,7 @@ export class FolioDocxXmlPatchApplicationError extends TaggedError(
   stage: "verify" | "load" | "replace" | "generate";
   part?: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
 

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -17,7 +17,7 @@ export class DocxArchiveError extends TaggedError("DocxArchiveError")<{
     | "total-too-large"
     | "invalid-options";
   cause?: unknown;
-}>() {}
+}> {}
 
 export type DocxArchiveOptions = {
   maxInputBytes?: number;

--- a/packages/core/src/docx/server/build.ts
+++ b/packages/core/src/docx/server/build.ts
@@ -54,7 +54,7 @@ export class InvalidFolioReportBuilderOptionsError extends TaggedError(
 )<{
   message: string;
   path: string;
-}>() {}
+}> {}
 
 const assertPositiveInteger = (value: number, path: string): void => {
   if (!Number.isInteger(value) || value < 1) {

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -96,7 +96,7 @@ export class InvalidBilingualDocumentOptionsError extends TaggedError(
 )<{
   message: string;
   option: "targetStyleSuffix";
-}>() {}
+}> {}
 const FULL_WIDTH_PCT = 5000;
 const HALF_WIDTH_PCT = 2500;
 const A4_TEXT_WIDTH_TWIPS = 9072;

--- a/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
+++ b/packages/core/src/docx/server/evaluateDocxXmlPatchProposal.ts
@@ -115,14 +115,14 @@ export class InvalidFolioDocxXmlPatchProposalError extends TaggedError(
   message: string;
   path: string;
   reason: string;
-}>() {}
+}> {}
 
 export class InvalidFolioDocxXmlPatchProposalOptionsError extends TaggedError(
   "InvalidFolioDocxXmlPatchProposalOptionsError",
 )<{
   message: string;
   path: string;
-}>() {}
+}> {}
 
 const SHA256_PATTERN = /^[\da-f]{64}$/u;
 const XML_DECLARED_ENCODING_PATTERN =

--- a/packages/core/src/docx/server/inspectDocxPackage.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.ts
@@ -34,7 +34,7 @@ export class FolioDocxPackageInspectionError extends TaggedError(
   code: FolioDocxPackageInspectionErrorCode;
   part?: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 export type FolioDocxPackageInspectionLimits = {
   readonly maxXmlParts?: number;

--- a/packages/core/src/docx/xmlResourceLimits.ts
+++ b/packages/core/src/docx/xmlResourceLimits.ts
@@ -21,7 +21,7 @@ type XmlResourceLimitKind = "bytes" | "depth" | "nodes" | "syntax";
 export class XmlResourceLimitError extends TaggedError("XmlResourceLimitError")<{
   message: string;
   limit: XmlResourceLimitKind;
-}>() {}
+}> {}
 
 const exceedsUtf8ByteLimit = (value: string, maxBytes: number): boolean => {
   let bytes = 0;

--- a/packages/core/src/layout-engine/measure/font-metrics.worker.ts
+++ b/packages/core/src/layout-engine/measure/font-metrics.worker.ts
@@ -29,7 +29,7 @@ import type { FontKerningMode } from "./textMeasurementPolicy";
 
 class WorkerInitError extends TaggedError("WorkerInitError")<{
   message: string;
-}>() {}
+}> {}
 
 type WorkerCanvasContext = {
   font: string;

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -57,7 +57,7 @@ export class InvalidGenerateRedlineDocxOptionsError extends TaggedError(
   message: string;
   option: "baseView" | "revisedView";
   receivedValue: unknown;
-}>() {}
+}> {}
 
 /** A document story that could not be paired across the two input packages. */
 export type GenerateRedlineUnprocessedStory = {

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -121,7 +121,7 @@ export class InvalidFolioVersionComparisonOptionsError extends TaggedError(
   message: string;
   option: "include" | "privacy.transforms";
   receivedValue: unknown;
-}>() {}
+}> {}
 
 export { FOLIO_DOCUMENT_METADATA_PROPERTIES };
 export type { FolioDocumentMetadataProperty };

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -50,7 +50,7 @@
     "prepack": "bun run build"
   },
   "dependencies": {
-    "better-result": "2.10.0",
+    "better-result": "3.0.1",
     "jszip": "3.10.1"
   },
   "devDependencies": {

--- a/packages/docx-core/src/projection.ts
+++ b/packages/docx-core/src/projection.ts
@@ -68,12 +68,12 @@ export class DocxProjectionInitializationError extends TaggedError(
 )<{
   message: string;
   cause: unknown;
-}>() {}
+}> {}
 
 export class DocxProjectionError extends TaggedError("DocxProjectionError")<{
   message: string;
   cause: unknown;
-}>() {}
+}> {}
 
 export type DocxProjectionWasmSource =
   | RequestInfo

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,7 +57,7 @@
     "@fontsource/source-sans-3": "^5.2.9",
     "@fontsource/tinos": "^5.2.7",
     "@stll/folio-core": "workspace:^",
-    "better-result": "2.10.0",
+    "better-result": "3.0.1",
     "lucide-react": "1.24.0",
     "prosemirror-history": "^1.5.0",
     "prosemirror-model": "^1.25.9",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@stll/folio-core": "workspace:^",
-    "better-result": "2.10.0",
+    "better-result": "3.0.1",
     "use-intl": "^4.13.0",
     "yjs": "^13.6.31"
   },

--- a/scripts/generate-joining-types.ts
+++ b/scripts/generate-joining-types.ts
@@ -31,7 +31,7 @@ const GENERAL_CATEGORY_ID = "unicode-derived-general-category";
 
 class GenerateJoiningTypesError extends TaggedError("GenerateJoiningTypesError")<{
   message: string;
-}>() {}
+}> {}
 
 /**
  * Joining_Type values this generator distinguishes.

--- a/scripts/generate-ooxml-schema-graph.ts
+++ b/scripts/generate-ooxml-schema-graph.ts
@@ -153,7 +153,7 @@ type WalkContext = {
 class SchemaGraphError extends TaggedError("SchemaGraphError")<{
   message: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
 const OUTPUT_PATH = path.join(

--- a/scripts/specification-sources.ts
+++ b/scripts/specification-sources.ts
@@ -51,7 +51,7 @@ type SpecificationSourceManifest = {
 class SpecificationSourceError extends TaggedError("SpecificationSourceError")<{
   message: string;
   cause?: unknown;
-}>() {}
+}> {}
 
 const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
 const MANIFEST_PATH = path.join(REPOSITORY_ROOT, "specifications", "sources.json");


### PR DESCRIPTION
## Summary

- upgrade every `better-result` pin from 2.10.0 to 3.0.1
- migrate all `TaggedError` declarations to the v3 constructor syntax
- record patch releases for the four published packages that expose or consume the migrated errors