### PR TITLE
chore: use Bun isolated global store

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,8 @@
 [install]
+# Bun 1.4 supports isolated workspace installs backed by a shared immutable
+# package store across local checkouts and worktrees.
+linker = "isolated"
+globalStore = true
 # 5-day quarantine: reject package versions published
 # less than 5 days ago to mitigate supply chain attacks.
 minimumReleaseAge = 432_000


### PR DESCRIPTION
## Summary

- enable Bun 1.4's isolated workspace linker
- share immutable package installations through Bun's global store across checkouts and worktrees
- keep strict isolation without a public-hoist compatibility bridge