### PR TITLE
fix(ci): keep latest release pointer current

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,3 +118,23 @@ jobs:
         packages/agents/package.json
         packages/vue/package.json
         packages/nuxt/package.json
+
+  latest-release:
+    name: Mark latest core release
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source-ref || github.sha }}
+
+      - name: Mark canonical GitHub release as latest
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          core_version="$(node -p "require('./packages/core/package.json').version")"
+          gh release edit "@stll/folio-core@${core_version}" --latest


### PR DESCRIPTION
## Summary

After a successful package release, explicitly mark that commit’s `@stll/folio-core` release as GitHub Latest. This keeps the repository release badge current after recovery publishes.