### PR TITLE
fix(react): leave Cmd+R to browser reload

### DIFF
--- a/.changeset/quiet-cats-reload.md
+++ b/.changeset/quiet-cats-reload.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": patch
+---
+
+Leave Cmd+R to browser reload while retaining Ctrl+R for right alignment.

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -40,6 +40,7 @@ import { cn } from "../lib/utils";
 import { useFolioUI } from "../ui/folio-ui";
 import type { ColorPreset } from "../ui/folio-ui";
 import { containedHandler } from "../utils/contained-handler";
+import { shouldClaimRightAlignmentShortcut } from "./formattingShortcutPolicy";
 import { ToolbarButton, ToolbarGroup, ToolbarSeparator } from "./toolbarPrimitives";
 import type { ToolbarProps, FormattingAction } from "./toolbarPrimitives";
 import { AlignmentButtons } from "./ui/AlignmentButtons";
@@ -439,6 +440,9 @@ export function FormattingBar(props: FormattingBarProps) {
           handleAlignmentChange("center");
           break;
         case "r":
+          if (!shouldClaimRightAlignmentShortcut(event)) {
+            break;
+          }
           claimShortcut(event);
           handleAlignmentChange("right");
           break;

--- a/packages/react/src/components/formattingShortcutPolicy.test.ts
+++ b/packages/react/src/components/formattingShortcutPolicy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldClaimRightAlignmentShortcut } from "./formattingShortcutPolicy";
+
+describe("right-alignment shortcut ownership", () => {
+  test("leaves Cmd+R and Cmd+Ctrl+R to the browser", () => {
+    expect(shouldClaimRightAlignmentShortcut({ ctrlKey: false, metaKey: true })).toBe(false);
+    expect(shouldClaimRightAlignmentShortcut({ ctrlKey: true, metaKey: true })).toBe(false);
+  });
+
+  test("claims Ctrl+R only", () => {
+    expect(shouldClaimRightAlignmentShortcut({ ctrlKey: true, metaKey: false })).toBe(true);
+    expect(shouldClaimRightAlignmentShortcut({ ctrlKey: false, metaKey: false })).toBe(false);
+  });
+});

--- a/packages/react/src/components/formattingShortcutPolicy.ts
+++ b/packages/react/src/components/formattingShortcutPolicy.ts
@@ -1,0 +1,7 @@
+type RightAlignmentShortcutEvent = Pick<KeyboardEvent, "ctrlKey" | "metaKey">;
+
+/** Ctrl+R aligns right; any chord containing Meta remains browser-owned. */
+export const shouldClaimRightAlignmentShortcut = ({
+  ctrlKey,
+  metaKey,
+}: RightAlignmentShortcutEvent): boolean => ctrlKey && !metaKey;


### PR DESCRIPTION
## Summary

- leave Meta+R browser-owned
- retain Ctrl+R for right alignment
- cover modifier ownership with an invariant test