### PR TITLE
fix(react): keep nested header furniture inert

### DIFF
--- a/.changeset/calm-hf-pointer.md
+++ b/.changeset/calm-hf-pointer.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": patch
+---
+
+Keep nested header and footer drawings inert until their region is being edited.

--- a/packages/react/src/styles/headerFooterPointerEvents.test.ts
+++ b/packages/react/src/styles/headerFooterPointerEvents.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("header and footer pointer ownership", () => {
+  test("covers every descendant in inactive and editing modes", () => {
+    const css = readFileSync(new URL("prosemirror-layer.css", import.meta.url), "utf-8");
+
+    expect(css).toMatch(
+      /\.layout-page-header \*,\n\.layout-page-footer \* \{\n  pointer-events: none;\n\}/u,
+    );
+    expect(css).toMatch(
+      /\.paged-editor--editing-header \.layout-page-header \*,\n\.paged-editor--editing-footer \.layout-page-footer \* \{\n  pointer-events: auto;\n\}/u,
+    );
+  });
+});

--- a/packages/react/src/styles/prosemirror-layer.css
+++ b/packages/react/src/styles/prosemirror-layer.css
@@ -668,14 +668,14 @@
    for the document text. The band element itself keeps pointer events so it
    stays the double-click-to-edit target; only its content is passed through.
    See eigenpal/docx-editor#869. */
-.layout-page-header > *,
-.layout-page-footer > * {
+.layout-page-header *,
+.layout-page-footer * {
   pointer-events: none;
 }
 /* While editing a region, its content is hittable again so clicks map to
    header/footer caret positions. */
-.paged-editor--editing-header .layout-page-header > *,
-.paged-editor--editing-footer .layout-page-footer > * {
+.paged-editor--editing-header .layout-page-header *,
+.paged-editor--editing-footer .layout-page-footer * {
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary

- keep every header/footer descendant inert outside editing mode
- restore pointer events for the active editing region
- enforce both selector invariants with a focused test