### PR TITLE
fix(core): parse complete ST_OnOff values

### DIFF
--- a/.changeset/style-default-on.md
+++ b/.changeset/style-default-on.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Parse every OOXML `ST_OnOff` spelling consistently across style and drawing attributes.

--- a/packages/core/src/docx/imageParser.ts
+++ b/packages/core/src/docx/imageParser.ts
@@ -53,6 +53,7 @@ import {
   getChildElements,
   getAttribute,
   parseNumericAttribute,
+  parseOnOffValue,
   findByFullName,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -173,7 +174,7 @@ function parseDocProps(docPr: XmlElement | null): {
 
   // Check for decorative flag (accessibility)
   // In newer OOXML, this is indicated by a:decorative element or attribute
-  const decorative = getAttribute(docPr, null, "decorative") === "1";
+  const decorative = parseOnOffValue(getAttribute(docPr, null, "decorative")) === true;
 
   // Check for hyperlink (a:hlinkClick) — clickable image
   const hlinkClickEl = findChild(docPr, "a", "hlinkClick");
@@ -202,8 +203,8 @@ function parseTransform(xfrm: XmlElement | null): ImageTransform | undefined {
   }
 
   const rot = getAttribute(xfrm, null, "rot");
-  const flipH = getAttribute(xfrm, null, "flipH") === "1";
-  const flipV = getAttribute(xfrm, null, "flipV") === "1";
+  const flipH = parseOnOffValue(getAttribute(xfrm, null, "flipH")) === true;
+  const flipV = parseOnOffValue(getAttribute(xfrm, null, "flipV")) === true;
 
   const rotation = rotToDegrees(rot);
 
@@ -309,17 +310,7 @@ function parseImageCrop(blipFill: XmlElement | null): ImageCrop | undefined {
  * spec-defined default.
  */
 function parseOnOffAttr(element: XmlElement, name: string): boolean | undefined {
-  const raw = getAttribute(element, null, name);
-  if (raw === null) {
-    return undefined;
-  }
-  if (raw === "1" || raw === "true" || raw === "on") {
-    return true;
-  }
-  if (raw === "0" || raw === "false" || raw === "off") {
-    return false;
-  }
-  return undefined;
+  return parseOnOffValue(getAttribute(element, null, name));
 }
 
 /**
@@ -696,7 +687,7 @@ function parseAnchor(
   const props = parseDocProps(docPr);
 
   // Check behindDoc attribute
-  const behindDoc = getAttribute(anchorEl, null, "behindDoc") === "1";
+  const behindDoc = parseOnOffValue(getAttribute(anchorEl, null, "behindDoc")) === true;
 
   // OOXML defaults `layoutInCell` and `allowOverlap` to "1" (true) when the
   // attributes are absent. We only record the value when the document

--- a/packages/core/src/docx/styleParser.test.ts
+++ b/packages/core/src/docx/styleParser.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { serializeStylesXml } from "./serializer/stylesSerializer";
-import { parseStyleDefinitions, parseStyles } from "./styleParser";
+import { getDefaultParagraphStyle, parseStyleDefinitions, parseStyles } from "./styleParser";
 
 const STYLES_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 
@@ -40,6 +40,43 @@ describe("docDefaults presence (#909)", () => {
       val: "cs-CZ",
       eastAsia: "ja-JP",
       bidi: "ar-SA",
+    });
+  });
+});
+
+describe("style default ST_OnOff values", () => {
+  test("recognizes on as a default paragraph style value", () => {
+    const styles = parseStyles(
+      `<w:styles ${STYLES_NS}>
+        <w:style w:type="paragraph" w:default="on" w:styleId="BodyText">
+          <w:name w:val="Body Text"/>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+
+    expect(styles.get("BodyText")?.default).toBe(true);
+    expect(getDefaultParagraphStyle(styles)?.styleId).toBe("BodyText");
+  });
+
+  test("uses the same decoder for latent and table style flags", () => {
+    const definitions = parseStyleDefinitions(
+      `<w:styles ${STYLES_NS}>
+        <w:latentStyles w:defLockedState="on" w:defQFormat="off"/>
+        <w:style w:type="table" w:styleId="Grid">
+          <w:tblPr><w:tblLook w:firstRow="on" w:lastRow="off"/></w:tblPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+
+    expect(definitions.latentStyles).toMatchObject({
+      defLockedState: true,
+      defQFormat: false,
+    });
+    expect(definitions.styles.at(0)?.tblPr?.look).toMatchObject({
+      firstRow: true,
+      lastRow: false,
     });
   });
 });

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -69,6 +69,7 @@ import {
   parseBooleanElement,
   parseNumberingLevelAttribute,
   parseNumericAttribute,
+  parseOnOffValue,
   parseTableMeasurementValue,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -523,12 +524,12 @@ function parseBorderSpec(border: XmlElement | null): BorderSpec | undefined {
 
   const shadowAttr = getAttribute(border, "w", "shadow");
   if (shadowAttr) {
-    spec.shadow = shadowAttr === "1" || shadowAttr === "true";
+    spec.shadow = parseOnOffValue(shadowAttr) ?? false;
   }
 
   const frame = getAttribute(border, "w", "frame");
   if (frame) {
-    spec.frame = frame === "1" || frame === "true";
+    spec.frame = parseOnOffValue(frame) ?? false;
   }
 
   return spec;
@@ -629,12 +630,12 @@ function parseParagraphProperties(
 
     const beforeAuto = getAttribute(spacing, "w", "beforeAutospacing");
     if (beforeAuto) {
-      formatting.beforeAutospacing = beforeAuto === "1" || beforeAuto === "true";
+      formatting.beforeAutospacing = parseOnOffValue(beforeAuto) ?? false;
     }
 
     const afterAuto = getAttribute(spacing, "w", "afterAutospacing");
     if (afterAuto) {
-      formatting.afterAutospacing = afterAuto === "1" || afterAuto === "true";
+      formatting.afterAutospacing = parseOnOffValue(afterAuto) ?? false;
     }
   }
 
@@ -969,32 +970,32 @@ function parseTableLook(tblLook: XmlElement | null): TableLook | undefined {
   // Individual attributes override
   const firstColumn = getAttribute(tblLook, "w", "firstColumn");
   if (firstColumn) {
-    look.firstColumn = firstColumn === "1";
+    look.firstColumn = parseOnOffValue(firstColumn) ?? false;
   }
 
   const firstRow = getAttribute(tblLook, "w", "firstRow");
   if (firstRow) {
-    look.firstRow = firstRow === "1";
+    look.firstRow = parseOnOffValue(firstRow) ?? false;
   }
 
   const lastColumn = getAttribute(tblLook, "w", "lastColumn");
   if (lastColumn) {
-    look.lastColumn = lastColumn === "1";
+    look.lastColumn = parseOnOffValue(lastColumn) ?? false;
   }
 
   const lastRow = getAttribute(tblLook, "w", "lastRow");
   if (lastRow) {
-    look.lastRow = lastRow === "1";
+    look.lastRow = parseOnOffValue(lastRow) ?? false;
   }
 
   const noHBand = getAttribute(tblLook, "w", "noHBand");
   if (noHBand) {
-    look.noHBand = noHBand === "1";
+    look.noHBand = parseOnOffValue(noHBand) ?? false;
   }
 
   const noVBand = getAttribute(tblLook, "w", "noVBand");
   if (noVBand) {
-    look.noVBand = noVBand === "1";
+    look.noVBand = parseOnOffValue(noVBand) ?? false;
   }
 
   return Object.keys(look).length > 0 ? look : undefined;
@@ -1364,7 +1365,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   // Default flag
   const defaultAttr = getAttribute(styleEl, "w", "default");
   if (defaultAttr) {
-    style.default = defaultAttr === "1" || defaultAttr === "true";
+    style.default = parseOnOffValue(defaultAttr) ?? false;
   }
 
   const children = collectStyleChildren(styleEl);
@@ -1738,10 +1739,12 @@ function parseStyleDefinitionsFromDocument(
     const latentStylesEl = findChild(doc, "w", "latentStyles");
     if (latentStylesEl) {
       const latentStyles: NonNullable<StyleDefinitions["latentStyles"]> = {
-        defLockedState: getAttribute(latentStylesEl, "w", "defLockedState") === "1",
-        defSemiHidden: getAttribute(latentStylesEl, "w", "defSemiHidden") === "1",
-        defUnhideWhenUsed: getAttribute(latentStylesEl, "w", "defUnhideWhenUsed") === "1",
-        defQFormat: getAttribute(latentStylesEl, "w", "defQFormat") === "1",
+        defLockedState:
+          parseOnOffValue(getAttribute(latentStylesEl, "w", "defLockedState")) ?? false,
+        defSemiHidden: parseOnOffValue(getAttribute(latentStylesEl, "w", "defSemiHidden")) ?? false,
+        defUnhideWhenUsed:
+          parseOnOffValue(getAttribute(latentStylesEl, "w", "defUnhideWhenUsed")) ?? false,
+        defQFormat: parseOnOffValue(getAttribute(latentStylesEl, "w", "defQFormat")) ?? false,
       };
       const defUIPriority = parseNumericAttribute(latentStylesEl, "w", "defUIPriority");
       if (defUIPriority !== undefined) {

--- a/packages/core/src/docx/xmlParser.test.ts
+++ b/packages/core/src/docx/xmlParser.test.ts
@@ -5,6 +5,7 @@ import {
   collectXmlnsDeclarations,
   elementToXml,
   NAMESPACES,
+  parseOnOffValue,
   parseXmlDocument,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -80,6 +81,24 @@ describe("OOXML parsing", () => {
     expect(serialized).toContain(`xmlns:w="${NAMESPACES.w}"`);
     expect(serialized).toContain(`xmlns:v="${NAMESPACES.v}"`);
     expect(serialized).toContain(`xmlns:r="${NAMESPACES.r}"`);
+  });
+});
+
+describe("ST_OnOff values", () => {
+  test("recognizes every on and off spelling", () => {
+    for (const value of ["1", "true", "on"]) {
+      expect(parseOnOffValue(value)).toBe(true);
+    }
+    for (const value of ["0", "false", "off"]) {
+      expect(parseOnOffValue(value)).toBe(false);
+    }
+  });
+
+  test("leaves absent and invalid values unresolved", () => {
+    expect(parseOnOffValue(null)).toBeUndefined();
+    expect(parseOnOffValue(undefined)).toBeUndefined();
+    expect(parseOnOffValue("yes")).toBeUndefined();
+    expect(parseOnOffValue(" TRUE ")).toBeUndefined();
   });
 });
 

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -790,13 +790,7 @@ export function hasFlag(
     return false;
   }
 
-  // Explicitly false
-  if (value === "0" || value === "false" || value === "off") {
-    return false;
-  }
-
-  // Any other value (including "1", "true", "on", or empty string) means true
-  return true;
+  return parseOnOffValue(value) ?? true;
 }
 
 /**
@@ -913,12 +907,34 @@ export function parseTableMeasurementValue(
 }
 
 /**
+ * Parse an OOXML `ST_OnOff` lexical value.
+ */
+export function parseOnOffValue(value: string | null | undefined): boolean | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  switch (value) {
+    case "1":
+    case "true":
+    case "on":
+      return true;
+    case "0":
+    case "false":
+    case "off":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Parse a boolean value from an attribute or element presence
  *
  * OOXML boolean conventions:
  * - Element presence with no val attribute = true
- * - w:val="true" or w:val="1" = true
- * - w:val="false" or w:val="0" = false
+ * - w:val="true", w:val="1", or w:val="on" = true
+ * - w:val="false", w:val="0", or w:val="off" = false
  *
  * @param element - Element to check
  * @param namespace - Namespace for val attribute
@@ -967,12 +983,7 @@ export function parseBooleanElement(
     return true;
   }
 
-  // Explicit false values
-  if (val === "0" || val === "false" || val === "off") {
-    return false;
-  }
-
-  return true;
+  return parseOnOffValue(val) ?? true;
 }
 
 /**


### PR DESCRIPTION
## Summary

- centralize OOXML `ST_OnOff` decoding
- recognize `on`/`off` across style and drawing attributes
- cover the lexical invariant and downstream style resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX compatibility by correctly interpreting standard on/off attribute values such as `true`, `false`, `on`, and `off`.
  * Fixed recognition of default paragraph styles and style, border, spacing, table, drawing, and image settings using these values.

* **Tests**
  * Added coverage for supported boolean spellings, defaults, and invalid or missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->