### PR TITLE
fix(core): honor hanging indent precedence

### DIFF
--- a/.changeset/strict-indent-precedence.md
+++ b/.changeset/strict-indent-precedence.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor the hanging-indent flag when generating paragraph CSS.

--- a/packages/core/src/utils/formatToStyle-indent.test.ts
+++ b/packages/core/src/utils/formatToStyle-indent.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { paragraphToStyle } from "./formatToStyle";
+
+describe("paragraphToStyle indentation", () => {
+  test("hangingIndent wins when both first-line fields are present", () => {
+    expect(paragraphToStyle({ indentFirstLine: 720, hangingIndent: true }).textIndent).toBe(
+      "-48px",
+    );
+  });
+
+  test("keeps a regular first-line indent positive", () => {
+    expect(paragraphToStyle({ indentFirstLine: 720 }).textIndent).toBe("48px");
+  });
+});

--- a/packages/core/src/utils/formatToStyle.ts
+++ b/packages/core/src/utils/formatToStyle.ts
@@ -363,9 +363,11 @@ export function paragraphToStyle(
 
   // First line indent / hanging indent
   if (formatting.indentFirstLine !== undefined) {
-    // Both hanging indent and regular first-line indent use the same CSS:
-    // text-indent handles both (negative for hanging, positive for regular).
-    style.textIndent = formatPx(twipsToPixels(formatting.indentFirstLine));
+    // ProseMirror stores hanging indents as a positive magnitude plus this flag.
+    const textIndent = formatting.hangingIndent
+      ? -Math.abs(formatting.indentFirstLine)
+      : formatting.indentFirstLine;
+    style.textIndent = formatPx(twipsToPixels(textIndent));
   }
 
   // ============================================================================


### PR DESCRIPTION
## Summary

- make the hanging-indent flag authoritative when rendering paragraph CSS
- preserve regular positive first-line indents
- cover both states with focused tests

## Validation

- `bun test packages/core/src/utils/formatToStyle-indent.test.ts packages/core/src/utils/formatToStyle-autospacing.test.ts packages/core/src/utils/paragraphFormattingMerge.test.ts`
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun run format:check`
- `bun --filter @stll/folio-core build`