### PR TITLE
fix(core): anchor drawings to authored page margins

### DIFF
--- a/.changeset/body-drawing-bottom-margin-frame.md
+++ b/.changeset/body-drawing-bottom-margin-frame.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Anchor body drawings to authored bottom margins and repaint when margin frames change.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -492,6 +492,7 @@ export type Page = {
     number: number;
     fragments: Fragment[];
     margins: PageMargins;
+    authoredMargins?: PageMargins;
     size: {
         w: number;
         h: number;

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -227,6 +227,48 @@ function bodyBlocksClearSectionHeaderFooter(
   return changed ? nextBlocks : blocks;
 }
 
+const arePageMarginsEqual = (left: PageMargins, right: PageMargins): boolean =>
+  left.top === right.top &&
+  left.right === right.right &&
+  left.bottom === right.bottom &&
+  left.left === right.left &&
+  left.header === right.header &&
+  left.footer === right.footer;
+
+const mirrorPageMarginsIfNeeded = (
+  authoredMargins: PageMargins,
+  pageNumber: number,
+  mirrorMargins: boolean,
+): PageMargins =>
+  mirrorMargins && pageNumber % 2 === 0
+    ? { ...authoredMargins, left: authoredMargins.right, right: authoredMargins.left }
+    : authoredMargins;
+
+function attachAuthoredMarginsToLayoutPages(
+  layout: Layout,
+  options: {
+    authoredMargins: PageMargins;
+    mirrorMargins: boolean;
+    sectionPropertiesForMargins: readonly (SectionProperties | undefined)[];
+  },
+): Layout {
+  let changed = false;
+  const pages = layout.pages.map((page) => {
+    const sectionProperties = options.sectionPropertiesForMargins[page.sectionIndex ?? 0];
+    const authoredMargins = mirrorPageMarginsIfNeeded(
+      sectionProperties ? getMargins(sectionProperties) : options.authoredMargins,
+      page.number,
+      options.mirrorMargins,
+    );
+    if (page.authoredMargins && arePageMarginsEqual(page.authoredMargins, authoredMargins)) {
+      return page;
+    }
+    changed = true;
+    return { ...page, authoredMargins };
+  });
+  return changed ? { ...layout, pages } : layout;
+}
+
 export function runLayoutPipeline<THfPMs>(
   deps: LayoutPipelineDeps<THfPMs>,
   state: EditorState,
@@ -810,6 +852,12 @@ export function runLayoutPipeline<THfPMs>(
     // (typing) path to keep keystrokes cheap.
     let stabilizedFieldValues: Map<number, string> | undefined;
     stabilizeFieldWidths();
+
+    newLayout = attachAuthoredMarginsToLayoutPages(newLayout, {
+      authoredMargins: margins,
+      mirrorMargins,
+      sectionPropertiesForMargins,
+    });
 
     const rebuildHeaderFooterForLayout = (): void => {
       const seqValues = buildSeqValues(newBlocks);

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1149,6 +1149,12 @@ export type Page = {
   fragments: Fragment[];
   /** Page margins. */
   margins: PageMargins;
+  /**
+   * Authored section margins before header/footer clearance expands the body
+   * content box insets. Page-margin-relative anchors use these page-setup
+   * landmarks instead of furniture-expanded content insets.
+   */
+  authoredMargins?: PageMargins;
   /** Page size (width, height). */
   size: { w: number; h: number };
   /** Page orientation. */

--- a/packages/core/src/layout-painter/anchoredImagePosition.test.ts
+++ b/packages/core/src/layout-painter/anchoredImagePosition.test.ts
@@ -202,6 +202,58 @@ describe("resolveAnchoredImagePosition — vertical align (eigenpal #424)", () =
     expect(result.y).toBe(CONTENT_HEIGHT); // 912
   });
 
+  test("relativeFrom='bottomMargin' uses the authored margin frame when footer clearance expands the inset", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "bottomMargin", align: "top" },
+    });
+    const footerExpandedGeometry = {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: PAGE.pageHeight - 120 - 160,
+      ...PAGE,
+      marginTop: 120,
+      marginBottom: 160,
+      authoredMargins: { top: 72, right: 72, bottom: 72, left: 72 },
+    };
+    const result = resolveAnchoredImagePosition(run, fragmentY, footerExpandedGeometry);
+    expect(result.y).toBe(PAGE.pageHeight - footerExpandedGeometry.marginTop - 72);
+    expect(result.y).not.toBe(footerExpandedGeometry.contentHeight);
+  });
+
+  test("margin reference bands remain authored when furniture expands content insets", () => {
+    const geometry = {
+      contentWidth: PAGE.pageWidth - 120 - 160,
+      contentHeight: PAGE.pageHeight - 120 - 160,
+      ...PAGE,
+      marginTop: 120,
+      marginRight: 160,
+      marginBottom: 160,
+      marginLeft: 120,
+      authoredMargins: { top: 72, right: 72, bottom: 72, left: 72 },
+    };
+    const top = resolveAnchoredImagePosition(
+      baseRun({
+        horizontal: { relativeTo: "leftMargin", align: "right" },
+        vertical: { relativeTo: "topMargin", align: "bottom" },
+      }),
+      fragmentY,
+      geometry,
+    );
+    const bottom = resolveAnchoredImagePosition(
+      baseRun({
+        horizontal: { relativeTo: "rightMargin", align: "left" },
+        vertical: { relativeTo: "bottomMargin", align: "top" },
+      }),
+      fragmentY,
+      geometry,
+    );
+
+    expect(top.x).toBe(-120 + 72 - IMG_W);
+    expect(top.y).toBe(-120 + 72 - IMG_H);
+    expect(bottom.x).toBe(PAGE.pageWidth - 120 - 72);
+    expect(bottom.y).toBe(PAGE.pageHeight - 120 - 72);
+  });
+
   test("relativeFrom='topMargin' with posOffset shifts down from the top margin strip", () => {
     const run = baseRun({
       horizontal: { relativeTo: "margin" },

--- a/packages/core/src/layout-painter/anchoredImagePosition.ts
+++ b/packages/core/src/layout-painter/anchoredImagePosition.ts
@@ -1,4 +1,4 @@
-import type { ImageRun } from "../layout-engine/types";
+import type { ImageRun, PageMargins } from "../layout-engine/types";
 import { emuToPixels } from "./renderUtils";
 
 export type PageGeometry = {
@@ -8,6 +8,7 @@ export type PageGeometry = {
   marginTop: number;
   marginRight: number;
   marginBottom: number;
+  authoredMargins?: PageMargins;
   contentWidth: number;
   contentHeight: number;
 };
@@ -19,19 +20,31 @@ export type AnchoredImagePosition = {
   side: "left" | "right";
 };
 
+const authoredMargins = (geometry: PageGeometry): PageMargins =>
+  geometry.authoredMargins ?? {
+    top: geometry.marginTop,
+    right: geometry.marginRight,
+    bottom: geometry.marginBottom,
+    left: geometry.marginLeft,
+  };
+
 function resolveHorizontalBand(
   relativeTo: string | undefined,
   geometry: PageGeometry,
 ): { baseX: number; bandWidth: number } {
+  const margins = authoredMargins(geometry);
   switch (relativeTo) {
     case "page":
       return { baseX: -geometry.marginLeft, bandWidth: geometry.pageWidth };
     case "leftMargin":
     case "insideMargin":
-      return { baseX: -geometry.marginLeft, bandWidth: geometry.marginLeft };
+      return { baseX: -geometry.marginLeft, bandWidth: margins.left };
     case "rightMargin":
     case "outsideMargin":
-      return { baseX: geometry.contentWidth, bandWidth: geometry.marginRight };
+      return {
+        baseX: geometry.pageWidth - geometry.marginLeft - margins.right,
+        bandWidth: margins.right,
+      };
     case "character":
       return { baseX: 0, bandWidth: 0 };
     default:
@@ -44,13 +57,17 @@ function resolveVerticalBand(
   fragmentY: number,
   geometry: PageGeometry,
 ): { baseY: number; bandHeight: number } {
+  const margins = authoredMargins(geometry);
   switch (relativeTo) {
     case "page":
       return { baseY: -geometry.marginTop, bandHeight: geometry.pageHeight };
     case "topMargin":
-      return { baseY: -geometry.marginTop, bandHeight: geometry.marginTop };
+      return { baseY: -geometry.marginTop, bandHeight: margins.top };
     case "bottomMargin":
-      return { baseY: geometry.contentHeight, bandHeight: geometry.marginBottom };
+      return {
+        baseY: geometry.pageHeight - geometry.marginTop - margins.bottom,
+        bandHeight: margins.bottom,
+      };
     case "paragraph":
     case "line":
       return { baseY: fragmentY, bandHeight: 0 };

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -368,6 +368,29 @@ function textBoxMeasure(width: number, height: number): TextBoxMeasure {
 }
 
 describe("render page fingerprint", () => {
+  test("changes when the authored margin frame changes without changing effective margins", () => {
+    const withAuthoredMargins = {
+      ...page,
+      authoredMargins: { top: 72, right: 72, bottom: 72, left: 72 },
+    };
+
+    expect(computePageFingerprint(withAuthoredMargins)).not.toBe(
+      computePageFingerprint({
+        ...withAuthoredMargins,
+        authoredMargins: { ...withAuthoredMargins.authoredMargins, bottom: 96 },
+      }),
+    );
+  });
+
+  test("changes when a header or footer distance changes", () => {
+    expect(computePageFingerprint(page)).not.toBe(
+      computePageFingerprint({
+        ...page,
+        margins: { ...page.margins, header: 48 },
+      }),
+    );
+  });
+
   test("changes when comment annotations change without layout geometry changing", () => {
     expect(computePageFingerprint(page, lookup(blockWithComment()))).not.toBe(
       computePageFingerprint(page, lookup(blockWithComment(123))),
@@ -932,6 +955,59 @@ describe("header and footer rendering", () => {
     expect(image?.style.zIndex).toBe("0");
     expect(image?.dataset["hfSlotKind"]).toBe("footer");
     expect(image?.dataset["hfRid"]).toBe("rIdFooter");
+  });
+
+  test("uses authored bottom margins for body bottom-margin anchors after footer clearance expands", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "body-float",
+      runs: [
+        {
+          kind: "image",
+          src: "body-float.png",
+          width: 80,
+          height: 24,
+          displayMode: "float",
+          wrapType: "behind",
+          position: {
+            vertical: { relativeTo: "bottomMargin", align: "top" },
+          },
+        },
+      ],
+    };
+    const blockLookup: BlockLookup = new Map([
+      ["body-float", { block, measure: { kind: "paragraph", lines: [], totalHeight: 0 } }],
+    ]);
+
+    const pageElement = renderPage(
+      {
+        ...page,
+        authoredMargins: { top: 72, right: 72, bottom: 72, left: 72 },
+        margins: { top: 120, right: 72, bottom: 160, left: 72 },
+        fragments: [
+          {
+            kind: "paragraph",
+            blockId: "body-float",
+            x: 72,
+            y: 120,
+            width: 672,
+            height: 0,
+            fromLine: 0,
+            toLine: 0,
+          },
+        ],
+      },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        blockLookup,
+      },
+    ) as unknown as FakeElement;
+
+    const image = pageElement.querySelector("img");
+    const floatContainer = image?.parent;
+    expect(floatContainer?.style.top).toBe(`${page.size.h - 120 - 72}px`);
+    expect(floatContainer?.style.top).not.toBe(`${page.size.h - 120 - 160}px`);
   });
 });
 

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -46,6 +46,7 @@ import type {
   TextBoxFragment,
   FootnoteContent,
   HeaderFooterContent,
+  PageMargins,
 } from "../layout-engine/types";
 import type { BorderSpec, Theme, Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
@@ -1660,6 +1661,7 @@ export function renderPage(
     marginTop: page.margins.top,
     marginRight: page.margins.right,
     marginBottom: page.margins.bottom,
+    ...(page.authoredMargins ? { authoredMargins: page.authoredMargins } : {}),
     contentWidth,
     contentHeight: page.size.h - page.margins.top - page.margins.bottom,
   };
@@ -2435,6 +2437,16 @@ function computePageRenderFingerprint(page: Page, blockLookup?: BlockLookup): st
   });
 }
 
+const pageMarginsFingerprint = (margins: PageMargins): string =>
+  [
+    margins.top,
+    margins.right,
+    margins.bottom,
+    margins.left,
+    margins.header ?? "",
+    margins.footer ?? "",
+  ].join(",");
+
 function computePageFingerprintInternal(
   page: Page,
   blockLookup: BlockLookup | undefined,
@@ -2444,9 +2456,10 @@ function computePageFingerprintInternal(
 
   // Page-level properties
   parts.push(`s:${page.size.w},${page.size.h}`);
-  parts.push(
-    `m:${page.margins.top},${page.margins.right},${page.margins.bottom},${page.margins.left}`,
-  );
+  parts.push(`m:${pageMarginsFingerprint(page.margins)}`);
+  if (page.authoredMargins) {
+    parts.push(`am:${pageMarginsFingerprint(page.authoredMargins)}`);
+  }
   parts.push(`n:${page.number}`);
   if (page.sectionIndex !== undefined) {
     parts.push(`si:${page.sectionIndex}`);


### PR DESCRIPTION
## Summary

- preserve authored page margins alongside effective header/footer clearance
- anchor explicit page-margin frames to authored landmarks
- include complete margin frames in virtualized page fingerprints

## Validation

- focused layout and painter tests
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun run format:check`
- `bun --filter @stll/folio-core build`