### PR TITLE
fix(core): preserve paragraph spacing provenance

### DIFF
--- a/.changeset/spacing-write-preservation.md
+++ b/.changeset/spacing-write-preservation.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve direct paragraph spacing edits without inlining inherited line spacing, including explicit zero overrides.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -194,6 +194,7 @@ export type ParagraphAttrs = {
     spaceAfter?: number;
     lineSpacing?: number;
     lineSpacingRule?: import__stll_docx_core_model.LineSpacingRule;
+    lineSpacingExplicit?: boolean;
     snapToGrid?: boolean;
     spacingExplicit?: SpacingExplicit;
     spacingFromDocDefaults?: SpacingExplicit;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -296,6 +296,7 @@ export type ParagraphAttrs = {
     spaceAfter?: number;
     lineSpacing?: number;
     lineSpacingRule?: import__stll_docx_core_model.LineSpacingRule;
+    lineSpacingExplicit?: boolean;
     snapToGrid?: boolean;
     spacingExplicit?: SpacingExplicit;
     spacingFromDocDefaults?: SpacingExplicit;

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -271,6 +271,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   optionalNumber(attrs, "spaceBefore", "paragraph.attrs.spaceBefore", issues);
   optionalNumber(attrs, "spaceAfter", "paragraph.attrs.spaceAfter", issues);
   optionalNumber(attrs, "lineSpacing", "paragraph.attrs.lineSpacing", issues);
+  optionalBoolean(attrs, "lineSpacingExplicit", "paragraph.attrs.lineSpacingExplicit", issues);
   optionalBoolean(attrs, "snapToGrid", "paragraph.attrs.snapToGrid", issues);
   optionalOneOf(
     attrs,

--- a/packages/core/src/prosemirror/commands/propertyChangeScope.ts
+++ b/packages/core/src/prosemirror/commands/propertyChangeScope.ts
@@ -66,6 +66,7 @@ export const PPR_CHANGE_SCOPED_ATTR_KEYS = [
   "spaceAfter",
   "lineSpacing",
   "lineSpacingRule",
+  "lineSpacingExplicit",
   "snapToGrid",
   "spacingExplicit",
   "indentLeft",

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -639,6 +639,53 @@ describe("fromProseDoc", () => {
     expect((block.formatting as Record<string, unknown>)["_autospacingBase"]).toBeUndefined();
   });
 
+  test("round-trips inherited line spacing without inlining the style value", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              pPr: { lineSpacing: 240, lineSpacingRule: "auto" },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "Normal" },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Inherited line spacing" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles: document.package.styles });
+    const attrs = expectParagraphAttrs(pmDoc.child(0));
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(attrs.lineSpacing).toBe(240);
+    expect(attrs.lineSpacingRule).toBe("auto");
+    expect(attrs.lineSpacingExplicit).toBeUndefined();
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.styleId).toBe("Normal");
+    expect(block.formatting?.lineSpacing).toBeUndefined();
+    expect(block.formatting?.lineSpacingRule).toBeUndefined();
+  });
+
   test("saves edited inherited auto spacing as direct spacing with auto disabled", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1130,6 +1130,7 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     typeof spaceBefore === "number" && (!beforeHasAutospacingBase || beforeAutospacingEdited);
   const shouldSerializeSpaceAfter =
     typeof spaceAfter === "number" && (!afterHasAutospacingBase || afterAutospacingEdited);
+  const hasDirectLineSpacing = attrs.lineSpacingExplicit === true;
 
   if (attrs._originalFormatting) {
     const orig = attrs._originalFormatting;
@@ -1149,6 +1150,31 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
         result.spaceAfter = spaceAfter;
       } else {
         delete result.spaceAfter;
+      }
+    }
+
+    // A spacing command is a direct override even when the imported value was
+    // inherited from a style. Keep the explicit zero instead of dropping the
+    // side and letting the style value reappear on the next load.
+    if (attrs.spacingExplicit?.before && typeof spaceBefore === "number") {
+      result.spaceBefore = spaceBefore;
+    }
+    if (attrs.spacingExplicit?.after && typeof spaceAfter === "number") {
+      result.spaceAfter = spaceAfter;
+    }
+
+    const originalHasDirectLineSpacing =
+      orig.lineSpacing !== undefined || orig.lineSpacingRule !== undefined;
+    if (hasDirectLineSpacing || originalHasDirectLineSpacing) {
+      if (typeof attrs.lineSpacing === "number") {
+        result.lineSpacing = attrs.lineSpacing;
+      } else {
+        Reflect.deleteProperty(result, "lineSpacing");
+      }
+      if (attrs.lineSpacingRule) {
+        result.lineSpacingRule = attrs.lineSpacingRule;
+      } else {
+        Reflect.deleteProperty(result, "lineSpacingRule");
       }
     }
 
@@ -1220,7 +1246,7 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
     shouldSerializeSpaceAfter ||
     beforeAutospacingEdited ||
     afterAutospacingEdited ||
-    attrs.lineSpacing ||
+    hasDirectLineSpacing ||
     attrs.snapToGrid != null ||
     attrs.indentLeft ||
     attrs.indentRight ||
@@ -1262,10 +1288,10 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
   if (afterAutospacingEdited) {
     f.afterAutospacing = false;
   }
-  if (attrs.lineSpacing) {
+  if (hasDirectLineSpacing && typeof attrs.lineSpacing === "number") {
     f.lineSpacing = attrs.lineSpacing;
   }
-  if (attrs.lineSpacingRule) {
+  if (hasDirectLineSpacing && attrs.lineSpacingRule) {
     f.lineSpacingRule = attrs.lineSpacingRule;
   }
   if (attrs.snapToGrid != null) {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -690,6 +690,12 @@ function paragraphFormattingToAttrs(
     set("spaceAfter", formatting?.spaceAfter ?? stylePpr?.spaceAfter);
     set("lineSpacing", formatting?.lineSpacing ?? stylePpr?.lineSpacing);
     set("lineSpacingRule", formatting?.lineSpacingRule ?? stylePpr?.lineSpacingRule);
+    set(
+      "lineSpacingExplicit",
+      formatting?.lineSpacing !== undefined || formatting?.lineSpacingRule !== undefined
+        ? true
+        : undefined,
+    );
     set("snapToGrid", formatting?.snapToGrid ?? stylePpr?.snapToGrid);
     set("spacingExplicit", formatting?.spacingExplicit);
     const paragraphStyle = styleId

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.test.ts
@@ -3,6 +3,8 @@ import { EditorState, TextSelection } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 
 import { toFlowBlocks } from "../../../layout-bridge/convert/toFlowBlocks";
+import type { Document } from "../../../types/document";
+import { fromProseDoc } from "../../conversion/fromProseDoc";
 import { AUTO_PARAGRAPH_SPACING_PX, formatPx } from "../../../utils/units";
 import { schema, singletonManager } from "../../schema";
 
@@ -83,6 +85,110 @@ describe("ParagraphExtension", () => {
     const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
     expect(domAttrs["style"]).toContain("margin-top: 16px");
     expect(domAttrs["style"]).not.toContain(`margin-top: ${formatPx(AUTO_PARAGRAPH_SPACING_PX)}`);
+  });
+
+  test("line-spacing edits preserve the imported before and after sides", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 120,
+          spaceAfter: 240,
+          lineSpacing: 240,
+          lineSpacingRule: "auto",
+          _originalFormatting: {
+            spaceBefore: 120,
+            spaceAfter: 240,
+            lineSpacing: 240,
+            lineSpacingRule: "auto",
+          },
+        },
+        [schema.text("x")],
+      ),
+    ]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+
+    const setLineSpacing = singletonManager.getCommand("setLineSpacing");
+    if (!setLineSpacing) {
+      throw new Error("Missing setLineSpacing command");
+    }
+    setLineSpacing(480)(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+
+    const baseDocument: Document = { package: { document: { content: [] } } };
+    const paragraph = fromProseDoc(state.doc, baseDocument).package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.formatting?.lineSpacing).toBe(480);
+    expect(paragraph.formatting?.spaceBefore).toBe(120);
+    expect(paragraph.formatting?.spaceAfter).toBe(240);
+  });
+
+  test("setting zero line spacing writes a direct override", () => {
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, [schema.text("x")])]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+
+    const setLineSpacing = singletonManager.getCommand("setLineSpacing");
+    if (!setLineSpacing) {
+      throw new Error("Missing setLineSpacing command");
+    }
+    setLineSpacing(0)(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+
+    const baseDocument: Document = { package: { document: { content: [] } } };
+    const paragraph = fromProseDoc(state.doc, baseDocument).package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.formatting?.lineSpacing).toBe(0);
+    expect(paragraph.formatting?.lineSpacingRule).toBe("auto");
+  });
+
+  test("removing inherited spacing writes an explicit zero", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 200,
+          _originalFormatting: { styleId: "Normal" },
+        },
+        [schema.text("x")],
+      ),
+    ]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+
+    const setSpaceBefore = singletonManager.getCommand("setSpaceBefore");
+    if (!setSpaceBefore) {
+      throw new Error("Missing setSpaceBefore command");
+    }
+    setSpaceBefore(0)(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+
+    const baseDocument: Document = { package: { document: { content: [] } } };
+    const paragraph = fromProseDoc(state.doc, baseDocument).package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.formatting?.spaceBefore).toBe(0);
   });
 
   test("applying a style with spacing overrides imported auto-spacing (#823)", () => {

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -289,6 +289,7 @@ function extractParagraphAttrsFromStyle(element: HTMLElement): Partial<Paragraph
     if (spacing) {
       attrs.lineSpacing = spacing.lineSpacing;
       attrs.lineSpacingRule = spacing.lineSpacingRule;
+      attrs.lineSpacingExplicit = true;
     }
   }
 
@@ -327,6 +328,7 @@ const paragraphNodeSpec: NodeSpec = {
     spaceAfter: { default: null },
     lineSpacing: { default: null },
     lineSpacingRule: { default: null },
+    lineSpacingExplicit: { default: null },
     snapToGrid: { default: null },
     spacingExplicit: { default: null },
     spacingFromDocDefaults: { default: null },
@@ -511,6 +513,37 @@ function setParagraphAttr(attr: string, value: unknown): Command {
   };
 }
 
+function setParagraphSpacingAttr(side: "before" | "after", twips: number): Command {
+  return (state, dispatch) => {
+    const { $from, $to } = state.selection;
+
+    if (!dispatch) {
+      return true;
+    }
+
+    let tr = state.tr;
+    const seen = new Set<number>();
+
+    state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+      if (node.type.name === "paragraph" && !seen.has(pos)) {
+        seen.add(pos);
+        const spacingExplicit = {
+          ...node.attrs["spacingExplicit"],
+          [side]: true,
+        };
+        tr = tr.setNodeMarkup(pos, undefined, {
+          ...node.attrs,
+          [side === "before" ? "spaceBefore" : "spaceAfter"]: twips,
+          spacingExplicit,
+        });
+      }
+    });
+
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+
 function setParagraphAttrsCmd(attrs: Record<string, unknown>): Command {
   return (state, dispatch) => {
     const { $from, $to } = state.selection;
@@ -567,6 +600,7 @@ function makeSetLineSpacing(value: number, rule: LineSpacingRule = "auto"): Comm
     setParagraphAttrsCmd({
       lineSpacing: value,
       lineSpacingRule: rule,
+      lineSpacingExplicit: true,
     })(state, dispatch);
 }
 
@@ -823,8 +857,8 @@ export const ParagraphExtension = createNodeExtension({
         singleSpacing: () => makeSetLineSpacing(240),
         oneAndHalfSpacing: () => makeSetLineSpacing(360),
         doubleSpacing: () => makeSetLineSpacing(480),
-        setSpaceBefore: (twips: number) => setParagraphAttr("spaceBefore", twips),
-        setSpaceAfter: (twips: number) => setParagraphAttr("spaceAfter", twips),
+        setSpaceBefore: (twips: number) => setParagraphSpacingAttr("before", twips),
+        setSpaceAfter: (twips: number) => setParagraphSpacingAttr("after", twips),
         increaseIndent: (amount?: number) => makeIncreaseIndent(amount),
         decreaseIndent: (amount?: number) => makeDecreaseIndent(amount),
         setIndentLeft: (twips: number) => setParagraphAttr("indentLeft", twips > 0 ? twips : null),

--- a/packages/core/src/prosemirror/plugins/selectionTracker.ts
+++ b/packages/core/src/prosemirror/plugins/selectionTracker.ts
@@ -90,7 +90,7 @@ export function extractSelectionContext(state: EditorState): SelectionContext {
     if (paragraph.attrs["alignment"]) {
       paragraphFormatting.alignment = paragraph.attrs["alignment"];
     }
-    if (paragraph.attrs["lineSpacing"]) {
+    if (typeof paragraph.attrs["lineSpacing"] === "number") {
       paragraphFormatting.lineSpacing = paragraph.attrs["lineSpacing"];
       paragraphFormatting.lineSpacingRule = paragraph.attrs["lineSpacingRule"];
     }

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -81,6 +81,7 @@ export type ParagraphAttrs = {
   spaceAfter?: number;
   lineSpacing?: number;
   lineSpacingRule?: LineSpacingRule;
+  lineSpacingExplicit?: boolean;
   snapToGrid?: boolean;
   spacingExplicit?: SpacingExplicit;
   /** Layout provenance: document defaults survive on empty paragraphs. */

--- a/packages/core/src/prosemirror/selectionState.test.ts
+++ b/packages/core/src/prosemirror/selectionState.test.ts
@@ -72,4 +72,26 @@ describe("extractSelectionState — bold detection", () => {
 
     expect(result?.textFormatting.bold).toBeUndefined();
   });
+
+  test("preserves zero line spacing in paragraph selection state", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          lineSpacing: 0,
+          lineSpacingRule: "auto",
+        },
+        [schema.text("Zero")],
+      ),
+    ]);
+    const state = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, 2, 2),
+    });
+
+    const result = extractSelectionState(state);
+
+    expect(result?.paragraphFormatting.lineSpacing).toBe(0);
+    expect(result?.paragraphFormatting.lineSpacingRule).toBe("auto");
+  });
 });

--- a/packages/core/src/prosemirror/selectionState.ts
+++ b/packages/core/src/prosemirror/selectionState.ts
@@ -149,7 +149,7 @@ export function extractSelectionState(state: EditorState): SelectionState | null
     if (paragraph.attrs["alignment"]) {
       paragraphFormatting.alignment = paragraph.attrs["alignment"];
     }
-    if (paragraph.attrs["lineSpacing"]) {
+    if (typeof paragraph.attrs["lineSpacing"] === "number") {
       paragraphFormatting.lineSpacing = paragraph.attrs["lineSpacing"];
       paragraphFormatting.lineSpacingRule = paragraph.attrs["lineSpacingRule"];
     }

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -33,6 +33,7 @@ export function paragraphAttrsFromResolvedStyle(
     spaceAfter: ppr?.spaceAfter ?? null,
     lineSpacing: ppr?.lineSpacing ?? null,
     lineSpacingRule: ppr?.lineSpacingRule ?? null,
+    lineSpacingExplicit: null,
     snapToGrid: ppr?.snapToGrid ?? null,
     indentLeft: ppr?.indentLeft ?? null,
     indentRight: ppr?.indentRight ?? null,


### PR DESCRIPTION
## Summary

- preserve direct before, after, and line-spacing edits
- avoid inlining style-inherited line spacing during round trips
- retain explicit zero spacing in selection and serialization paths

## Validation

- 4,584 core tests passed; 2 optional differential tests skipped
- core typecheck and build
- repository lint and format check
- public API snapshot check