### PR TITLE
fix(core): preserve run mark attributes

### DIFF
--- a/.changeset/green-geckos-hug.md
+++ b/.changeset/green-geckos-hug.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve run font slots and underline color when formatting marks are rewritten at a selection or collapsed caret.

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -3,6 +3,7 @@ import type { Mark, Node as PMNode } from "prosemirror-model";
 
 import {
   FIELD_TYPE_VALUES,
+  FONT_THEME_VALUES,
   HIGHLIGHT_COLOR_VALUES,
   IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
   IMAGE_HORIZONTAL_RELATIVE_TO_VALUES,
@@ -933,10 +934,16 @@ export const readFontFamilyMarkAttrs = (
   optionalString(attrs, "eastAsia", "fontFamily.attrs.eastAsia", issues);
   optionalString(attrs, "cs", "fontFamily.attrs.cs", issues);
   optionalString(attrs, "hint", "fontFamily.attrs.hint", issues);
-  optionalString(attrs, "asciiTheme", "fontFamily.attrs.asciiTheme", issues);
-  optionalString(attrs, "hAnsiTheme", "fontFamily.attrs.hAnsiTheme", issues);
-  optionalString(attrs, "eastAsiaTheme", "fontFamily.attrs.eastAsiaTheme", issues);
-  optionalString(attrs, "csTheme", "fontFamily.attrs.csTheme", issues);
+  optionalOneOf(attrs, "asciiTheme", "fontFamily.attrs.asciiTheme", issues, FONT_THEME_VALUES);
+  optionalOneOf(attrs, "hAnsiTheme", "fontFamily.attrs.hAnsiTheme", issues, FONT_THEME_VALUES);
+  optionalOneOf(
+    attrs,
+    "eastAsiaTheme",
+    "fontFamily.attrs.eastAsiaTheme",
+    issues,
+    FONT_THEME_VALUES,
+  );
+  optionalOneOf(attrs, "csTheme", "fontFamily.attrs.csTheme", issues, FONT_THEME_VALUES);
 
   return attrsResult(attrs, issues);
 };

--- a/packages/core/src/prosemirror/extensions/marks/UnderlineExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/UnderlineExtension.ts
@@ -3,13 +3,12 @@
  */
 
 import { panic } from "better-result";
-import { toggleMark } from "prosemirror-commands";
 
 import { expectUnderlineMarkAttrs } from "../../attrs";
 import type { TextColorAttrs } from "../../schema/marks";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
-import { setMark } from "./markUtils";
+import { setMark, toggleUnderlineMark } from "./markUtils";
 
 export const UnderlineExtension = createMarkExtension({
   name: "underline",
@@ -23,16 +22,21 @@ export const UnderlineExtension = createMarkExtension({
       { tag: "u" },
       {
         style: "text-decoration",
-        getAttrs: (value) => (value.includes("underline") ? {} : false),
+        getAttrs: (value) => {
+          if (value.includes("underline")) {
+            return {};
+          }
+          return value.includes("none") ? { style: "none" } : false;
+        },
       },
     ],
     toDOM(mark) {
       const attrs = expectUnderlineMarkAttrs(mark);
       const style = attrs.style;
       const colorRgb = attrs.color?.rgb;
-      const cssStyle: string[] = ["text-decoration: underline"];
+      const cssStyle: string[] = [`text-decoration: ${style === "none" ? "none" : "underline"}`];
 
-      if (style && style !== "single") {
+      if (style && style !== "single" && style !== "none") {
         const styleMap: Record<string, string> = {
           double: "double",
           dotted: "dotted",
@@ -59,12 +63,12 @@ export const UnderlineExtension = createMarkExtension({
     }
     return {
       commands: {
-        toggleUnderline: () => toggleMark(underlineType),
+        toggleUnderline: () => toggleUnderlineMark(underlineType),
         setUnderlineStyle: (style: string, color?: TextColorAttrs) =>
           setMark(underlineType, { style, color }),
       },
       keyboardShortcuts: {
-        "Mod-u": toggleMark(underlineType),
+        "Mod-u": toggleUnderlineMark(underlineType),
       },
     };
   },

--- a/packages/core/src/prosemirror/extensions/marks/markUtils.test.ts
+++ b/packages/core/src/prosemirror/extensions/marks/markUtils.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, test } from "bun:test";
+import { panic } from "better-result";
 import { EditorState, TextSelection } from "prosemirror-state";
+import type { Command } from "prosemirror-state";
 
 import { schema } from "../../schema";
-import { setMark, textFormattingToMarks } from "./markUtils";
+import { setMark, textFormattingToMarks, toggleUnderlineMark } from "./markUtils";
+
+function applyCommand(state: EditorState, command: Command): EditorState {
+  let nextState = state;
+  command(state, (tr) => {
+    nextState = nextState.apply(tr);
+  });
+  return nextState;
+}
 
 describe("rtl run direction round-trips through the mark helpers", () => {
   // eigenpal/docx-editor#806: the conversion path handled `rtl`, but the
@@ -12,7 +22,7 @@ describe("rtl run direction round-trips through the mark helpers", () => {
   test("textFormattingToMarks emits the rtl mark", () => {
     const rtl = schema.marks.rtl;
     if (!rtl) {
-      throw new Error("Expected rtl mark in schema");
+      panic("Expected rtl mark in schema");
     }
     const marks = textFormattingToMarks({ rtl: true }, schema);
     expect(marks.some((mark) => mark.type === rtl)).toBe(true);
@@ -21,7 +31,7 @@ describe("rtl run direction round-trips through the mark helpers", () => {
   test("setMark(rtl) records rtl in the paragraph default text formatting", () => {
     const rtl = schema.marks.rtl;
     if (!rtl) {
-      throw new Error("Expected rtl mark in schema");
+      panic("Expected rtl mark in schema");
     }
     let state = EditorState.create({
       doc: schema.node("doc", null, [schema.node("paragraph")]),
@@ -43,7 +53,7 @@ describe("mark commands", () => {
   test("preserve stored marks when setting formatting in an empty paragraph", () => {
     const fontSize = schema.marks.fontSize;
     if (!fontSize) {
-      throw new Error("Expected fontSize mark in schema");
+      panic("Expected fontSize mark in schema");
     }
 
     let state = EditorState.create({
@@ -61,5 +71,229 @@ describe("mark commands", () => {
     expect(state.doc.firstChild?.attrs.defaultTextFormatting).toEqual({
       fontSize: 32,
     });
+  });
+
+  test("selection font-family writes preserve untouched script slots and hint", () => {
+    const fontFamily = schema.marks.fontFamily;
+    if (!fontFamily) {
+      panic("Expected fontFamily mark in schema");
+    }
+
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("text", [
+            fontFamily.create({
+              ascii: "Arial",
+              hAnsi: "Arial",
+              eastAsia: "SimSun",
+              cs: "Arial Unicode MS",
+              hint: "eastAsia",
+              asciiTheme: "majorHAnsi",
+              hAnsiTheme: "majorHAnsi",
+            }),
+          ]),
+        ]),
+      ]),
+      schema,
+    });
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 5)));
+    state = applyCommand(state, setMark(fontFamily, { ascii: "Georgia", hAnsi: "Georgia" }));
+
+    const mark = fontFamily.isInSet(state.doc.firstChild?.firstChild?.marks ?? []);
+    expect(mark?.attrs).toMatchObject({
+      ascii: "Georgia",
+      hAnsi: "Georgia",
+      eastAsia: "SimSun",
+      cs: "Arial Unicode MS",
+      hint: "eastAsia",
+    });
+    expect(mark?.attrs["asciiTheme"]).toBeNull();
+    expect(mark?.attrs["hAnsiTheme"]).toBeNull();
+  });
+
+  test("font-family mark conversion preserves every script and theme slot", () => {
+    const marks = textFormattingToMarks(
+      {
+        fontFamily: {
+          ascii: "Arial",
+          hAnsi: "Arial",
+          eastAsia: "SimSun",
+          cs: "Arial Unicode MS",
+          hint: "eastAsia",
+          asciiTheme: "majorAscii",
+          hAnsiTheme: "majorHAnsi",
+          eastAsiaTheme: "majorEastAsia",
+          csTheme: "majorBidi",
+        },
+      },
+      schema,
+    );
+    const mark = marks.find(({ type }) => type.name === "fontFamily");
+
+    expect(mark?.attrs).toMatchObject({
+      ascii: "Arial",
+      hAnsi: "Arial",
+      eastAsia: "SimSun",
+      cs: "Arial Unicode MS",
+      hint: "eastAsia",
+      asciiTheme: "majorAscii",
+      hAnsiTheme: "majorHAnsi",
+      eastAsiaTheme: "majorEastAsia",
+      csTheme: "majorBidi",
+    });
+  });
+
+  test("collapsed-caret font-family writes preserve untouched script slots", () => {
+    const fontFamily = schema.marks.fontFamily;
+    if (!fontFamily) {
+      panic("Expected fontFamily mark in schema");
+    }
+
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("text", [
+            fontFamily.create({
+              ascii: "Arial",
+              hAnsi: "Arial",
+              eastAsia: "SimSun",
+              cs: "Arial Unicode MS",
+              hint: "eastAsia",
+            }),
+          ]),
+        ]),
+      ]),
+      schema,
+    });
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 3)));
+    state = applyCommand(state, setMark(fontFamily, { ascii: "Verdana", hAnsi: "Verdana" }));
+
+    const mark = fontFamily.isInSet(state.storedMarks ?? []);
+    expect(mark?.attrs).toMatchObject({
+      ascii: "Verdana",
+      hAnsi: "Verdana",
+      eastAsia: "SimSun",
+      cs: "Arial Unicode MS",
+      hint: "eastAsia",
+    });
+  });
+
+  test("selection underline toggles preserve authored color across off and on", () => {
+    const underline = schema.marks.underline;
+    if (!underline) {
+      panic("Expected underline mark in schema");
+    }
+
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("text", [
+            underline.create({
+              style: "single",
+              color: { rgb: "FF0000" },
+            }),
+          ]),
+        ]),
+      ]),
+      schema,
+    });
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 5)));
+    state = applyCommand(state, toggleUnderlineMark(underline));
+    state = applyCommand(state, toggleUnderlineMark(underline));
+
+    const mark = underline.isInSet(state.doc.firstChild?.firstChild?.marks ?? []);
+    expect(mark?.attrs).toEqual({
+      style: "single",
+      color: { rgb: "FF0000" },
+    });
+  });
+
+  test("collapsed-caret underline toggles preserve authored color across off and on", () => {
+    const underline = schema.marks.underline;
+    if (!underline) {
+      panic("Expected underline mark in schema");
+    }
+
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("text", [
+            underline.create({
+              style: "single",
+              color: { rgb: "FF0000" },
+            }),
+          ]),
+        ]),
+      ]),
+      schema,
+    });
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 3)));
+    state = applyCommand(state, toggleUnderlineMark(underline));
+    state = applyCommand(state, toggleUnderlineMark(underline));
+
+    const mark = underline.isInSet(state.storedMarks ?? []);
+    expect(mark?.attrs).toEqual({
+      style: "single",
+      color: { rgb: "FF0000" },
+    });
+  });
+
+  test("collapsed-caret underline toggles on when no underline mark is present", () => {
+    const underline = schema.marks.underline;
+    if (!underline) {
+      panic("Expected underline mark in schema");
+    }
+
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [schema.node("paragraph", null, [schema.text("text")])]),
+      schema,
+    });
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 3)));
+    state = applyCommand(state, toggleUnderlineMark(underline));
+
+    const mark = underline.isInSet(state.storedMarks ?? []);
+    expect(mark?.attrs).toMatchObject({ style: "single" });
+  });
+
+  test("underline none removes the visual decoration", () => {
+    const underline = schema.marks.underline;
+    if (!underline) {
+      panic("Expected underline mark in schema");
+    }
+
+    const paragraph = schema.node("paragraph", null, [
+      schema.text("text", [underline.create({ style: "none" })]),
+    ]);
+    const underlineMark = paragraph.child(0).marks.at(0);
+    if (!underlineMark) {
+      panic("Expected underline mark on text");
+    }
+    const domSpec = underlineMark.type.spec.toDOM?.(underlineMark);
+    if (!Array.isArray(domSpec)) {
+      panic("Expected underline mark to provide a DOM spec");
+    }
+    expect(domSpec[1]).toEqual({ style: "text-decoration: none" });
+  });
+
+  test("underline none survives the text-decoration parser", () => {
+    const underline = schema.marks.underline;
+    if (!underline) {
+      panic("Expected underline mark in schema");
+    }
+    const parseRule = underline.spec.parseDOM?.find(
+      (rule) => "style" in rule && rule.style === "text-decoration",
+    );
+    if (!parseRule || !("style" in parseRule) || !parseRule.getAttrs) {
+      panic("Expected underline text-decoration parse rule");
+    }
+
+    expect(parseRule.getAttrs("none")).toEqual({ style: "none" });
+    expect(parseRule.getAttrs("underline")).toEqual({});
   });
 });

--- a/packages/core/src/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/core/src/prosemirror/extensions/marks/markUtils.ts
@@ -8,12 +8,43 @@ import type { MarkType, Mark, Schema } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 
 import type { TextFormatting, UnderlineStyle, ThemeColorSlot } from "../../../types/document";
+import { FONT_THEME_VALUES } from "../../../types/documentEnumValues";
+import { mergeFontFamily } from "../../../utils/fontFamilyMerge";
+import { expectFontFamilyMarkAttrs } from "../../attrs";
+import type { FontFamilyAttrs } from "../../schema/marks";
 import {
   applyRunFormattingOverrideMark,
   buildRunFormattingOverrideAttrs,
 } from "./RunFormattingOverrideExtension";
 
 type MarkAttrs = Record<string, unknown>;
+type FontFamilyFormatting = NonNullable<TextFormatting["fontFamily"]>;
+type FontTheme = NonNullable<FontFamilyFormatting["asciiTheme"]>;
+
+const isFontTheme = (value: string | undefined): value is FontTheme =>
+  value !== undefined && FONT_THEME_VALUES.some((theme) => theme === value);
+
+const fontFamilyAttrsToFormatting = ({
+  ascii,
+  hAnsi,
+  eastAsia,
+  cs,
+  hint,
+  asciiTheme,
+  hAnsiTheme,
+  eastAsiaTheme,
+  csTheme,
+}: FontFamilyAttrs): FontFamilyFormatting => ({
+  ...(ascii !== undefined ? { ascii } : {}),
+  ...(hAnsi !== undefined ? { hAnsi } : {}),
+  ...(eastAsia !== undefined ? { eastAsia } : {}),
+  ...(cs !== undefined ? { cs } : {}),
+  ...(hint !== undefined ? { hint } : {}),
+  ...(isFontTheme(asciiTheme) ? { asciiTheme } : {}),
+  ...(hAnsiTheme !== undefined ? { hAnsiTheme } : {}),
+  ...(eastAsiaTheme !== undefined ? { eastAsiaTheme } : {}),
+  ...(csTheme !== undefined ? { csTheme } : {}),
+});
 
 // ============================================================================
 // PARAGRAPH DEFAULT FORMATTING HELPERS
@@ -35,7 +66,12 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         const underlineStyle = (
           typeof mark.attrs["style"] === "string" ? mark.attrs["style"] : "single"
         ) as UnderlineStyle;
-        formatting.underline = { style: underlineStyle };
+        formatting.underline = {
+          style: underlineStyle,
+          ...(mark.attrs["color"] !== null && mark.attrs["color"] !== undefined
+            ? { color: mark.attrs["color"] }
+            : {}),
+        };
         break;
       }
       case "strike":
@@ -79,21 +115,7 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         formatting.fontSize = Number(mark.attrs["size"]);
         break;
       case "fontFamily": {
-        // SAFETY: fontFamily mark always has ascii/hAnsi attrs per schema
-        const ascii =
-          mark.attrs["ascii"] !== null && mark.attrs["ascii"] !== undefined
-            ? String(mark.attrs["ascii"])
-            : undefined;
-        const hAnsi =
-          mark.attrs["hAnsi"] !== null && mark.attrs["hAnsi"] !== undefined
-            ? String(mark.attrs["hAnsi"])
-            : undefined;
-        const hint = mark.attrs["hint"];
-        formatting.fontFamily = {
-          ...(ascii !== undefined ? { ascii } : {}),
-          ...(hAnsi !== undefined ? { hAnsi } : {}),
-          ...(hint === "default" || hint === "eastAsia" || hint === "cs" ? { hint } : {}),
-        };
+        formatting.fontFamily = fontFamilyAttrsToFormatting(expectFontFamilyMarkAttrs(mark));
         break;
       }
       case "language": {
@@ -176,17 +198,77 @@ function dispatchStoredMarks(
   dispatch(tr);
 }
 
+function compactAttrs(attrs: MarkAttrs | undefined): MarkAttrs {
+  if (!attrs) {
+    return {};
+  }
+
+  const result: MarkAttrs = {};
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value !== null && value !== undefined) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function mergeMarkAttrs(
+  markType: MarkType,
+  currentMark: Mark | undefined,
+  nextAttrs: MarkAttrs,
+): MarkAttrs {
+  const next = compactAttrs(nextAttrs);
+
+  switch (markType.name) {
+    case "fontFamily": {
+      const current = currentMark
+        ? fontFamilyAttrsToFormatting(expectFontFamilyMarkAttrs(currentMark))
+        : undefined;
+      const incoming = fontFamilyAttrsToFormatting(
+        expectFontFamilyMarkAttrs(markType.create(next)),
+      );
+      return mergeFontFamily(current, incoming);
+    }
+    case "underline":
+      return {
+        ...compactAttrs(currentMark?.attrs),
+        ...next,
+      };
+    default:
+      return nextAttrs;
+  }
+}
+
+function markRequiresAttrMerge(markType: MarkType): boolean {
+  return markType.name === "fontFamily" || markType.name === "underline";
+}
+
+function createMarkWithMergedAttrs(
+  markType: MarkType,
+  currentMark: Mark | undefined,
+  nextAttrs: MarkAttrs,
+): Mark {
+  if (!markRequiresAttrMerge(markType)) {
+    return markType.create(nextAttrs);
+  }
+
+  return markType.create(mergeMarkAttrs(markType, currentMark, nextAttrs));
+}
+
 export function setMark(markType: MarkType, attrs: MarkAttrs): Command {
   return (state, dispatch) => {
     const { from, to, empty } = state.selection;
-    const mark = markType.create(attrs);
 
     if (empty) {
       if (dispatch) {
         const current = state.storedMarks ?? state.selection.$from.marks();
+        const currentMark = markType.isInSet(current);
         const marks = markType.isInSet(current)
           ? current.filter((m) => m.type !== markType)
           : current;
+        const mark = createMarkWithMergedAttrs(markType, currentMark, attrs);
 
         dispatchStoredMarks(state, dispatch, [...marks, mark]);
       }
@@ -194,11 +276,62 @@ export function setMark(markType: MarkType, attrs: MarkAttrs): Command {
     }
 
     if (dispatch) {
-      dispatch(state.tr.addMark(from, to, mark).scrollIntoView());
+      if (!markRequiresAttrMerge(markType)) {
+        dispatch(state.tr.addMark(from, to, markType.create(attrs)).scrollIntoView());
+        return true;
+      }
+
+      let tr = state.tr;
+      state.doc.nodesBetween(from, to, (node, pos) => {
+        if (!node.isText) {
+          return;
+        }
+
+        const start = Math.max(from, pos);
+        const end = Math.min(to, pos + node.nodeSize);
+        const currentMark = markType.isInSet(node.marks);
+        const mark = createMarkWithMergedAttrs(markType, currentMark, attrs);
+        tr = tr.addMark(start, end, mark);
+      });
+
+      dispatch(tr.scrollIntoView());
     }
 
     return true;
   };
+}
+
+function selectionHasVisibleUnderline(state: EditorState, markType: MarkType): boolean {
+  const { from, to, empty, $from } = state.selection;
+
+  if (empty) {
+    const mark = markType.isInSet(state.storedMarks ?? $from.marks());
+    return mark !== undefined && mark.attrs["style"] !== "none";
+  }
+
+  let hasVisibleUnderline = false;
+  state.doc.nodesBetween(from, to, (node) => {
+    if (!node.isText) {
+      return true;
+    }
+
+    const mark = markType.isInSet(node.marks);
+    if (mark && mark.attrs["style"] !== "none") {
+      hasVisibleUnderline = true;
+      return false;
+    }
+
+    return true;
+  });
+
+  return hasVisibleUnderline;
+}
+
+export function toggleUnderlineMark(markType: MarkType): Command {
+  return (state, dispatch) =>
+    setMark(markType, {
+      style: selectionHasVisibleUnderline(state, markType) ? "none" : "single",
+    })(state, dispatch);
 }
 
 export function removeMark(markType: MarkType): Command {
@@ -351,8 +484,13 @@ export function textFormattingToMarks(formatting: TextFormatting, schema: Schema
       schema.marks["fontFamily"].create({
         ascii: formatting.fontFamily.ascii,
         hAnsi: formatting.fontFamily.hAnsi,
+        eastAsia: formatting.fontFamily.eastAsia,
+        cs: formatting.fontFamily.cs,
         hint: formatting.fontFamily.hint,
         asciiTheme: formatting.fontFamily.asciiTheme,
+        hAnsiTheme: formatting.fontFamily.hAnsiTheme,
+        eastAsiaTheme: formatting.fontFamily.eastAsiaTheme,
+        csTheme: formatting.fontFamily.csTheme,
       }),
     );
   }

--- a/packages/core/src/prosemirror/plugins/selectionTracker.test.ts
+++ b/packages/core/src/prosemirror/plugins/selectionTracker.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { panic } from "better-result";
+import { TextSelection, EditorState } from "prosemirror-state";
+
+import { schema } from "../schema";
+import { extractSelectionContext } from "./selectionTracker";
+
+describe("extractSelectionContext", () => {
+  test("reports marks found anywhere in a non-collapsed selection", () => {
+    const bold = schema.marks.bold;
+    const underline = schema.marks.underline;
+    if (!bold || !underline) {
+      panic("Expected bold and underline marks in schema");
+    }
+
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("plain"),
+        schema.text("bold", [bold.create()]),
+        schema.text("underlined", [underline.create({ style: "single" })]),
+      ]),
+    ]);
+    const state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1, 18),
+    });
+
+    const context = extractSelectionContext(state);
+
+    expect(context.hasSelection).toBe(true);
+    expect(context.textFormatting.bold).toBe(true);
+    expect(context.textFormatting.underline).toMatchObject({ style: "single" });
+  });
+
+  test("prefers visible underline when hidden underline occurs first", () => {
+    const underline = schema.marks.underline;
+    if (!underline) {
+      panic("Expected underline mark in schema");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("hidden", [underline.create({ style: "none" })]),
+        schema.text("visible", [underline.create({ style: "single" })]),
+      ]),
+    ]);
+    const state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1, 14),
+    });
+
+    expect(extractSelectionContext(state).textFormatting.underline).toMatchObject({
+      style: "single",
+    });
+  });
+});

--- a/packages/core/src/prosemirror/plugins/selectionTracker.ts
+++ b/packages/core/src/prosemirror/plugins/selectionTracker.ts
@@ -13,6 +13,7 @@ import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import type { TextFormatting, ParagraphFormatting } from "../../types/document";
+import { collectMarksInRange } from "../selectionMarks";
 
 /**
  * Selection context for toolbar state
@@ -169,11 +170,11 @@ export function extractSelectionContext(state: EditorState): SelectionContext {
  * Extract text formatting from current selection/cursor marks
  */
 function extractTextFormatting(state: EditorState): TextFormatting {
-  const { selection } = state;
-  const { empty, $from } = selection;
+  const { selection, doc } = state;
+  const { from, to, empty, $from } = selection;
 
   // Get marks: stored marks take precedence, then marks at cursor
-  const marks = state.storedMarks || (empty ? $from.marks() : []);
+  const marks = empty ? state.storedMarks || $from.marks() : collectMarksInRange({ doc, from, to });
   const formatting: TextFormatting = {};
 
   for (const mark of marks) {
@@ -185,10 +186,12 @@ function extractTextFormatting(state: EditorState): TextFormatting {
         formatting.italic = true;
         break;
       case "underline":
-        formatting.underline = {
-          style: mark.attrs["style"] || "single",
-          color: mark.attrs["color"],
-        };
+        if (mark.attrs["style"] !== "none") {
+          formatting.underline = {
+            style: mark.attrs["style"] || "single",
+            color: mark.attrs["color"],
+          };
+        }
         break;
       case "strike":
         if (mark.attrs["double"]) {

--- a/packages/core/src/prosemirror/selectionMarks.ts
+++ b/packages/core/src/prosemirror/selectionMarks.ts
@@ -1,0 +1,36 @@
+import type { Mark, Node as PMNode } from "prosemirror-model";
+
+const UNDERLINE_MARK = "underline";
+const HIDDEN_UNDERLINE_STYLE = "none";
+
+type CollectMarksInRangeOptions = {
+  doc: PMNode;
+  from: number;
+  to: number;
+};
+
+const shouldReplaceMark = (current: Mark, incoming: Mark): boolean =>
+  current.type.name === UNDERLINE_MARK &&
+  current.attrs["style"] === HIDDEN_UNDERLINE_STYLE &&
+  incoming.attrs["style"] !== HIDDEN_UNDERLINE_STYLE;
+
+/** Collect one representative per mark type, preferring visible underline state. */
+export const collectMarksInRange = ({ doc, from, to }: CollectMarksInRangeOptions): Mark[] => {
+  const seen = new Map<string, Mark>();
+
+  doc.nodesBetween(from, to, (node) => {
+    if (!node.isText) {
+      return;
+    }
+
+    for (const mark of node.marks) {
+      const name = mark.type.name;
+      const current = seen.get(name);
+      if (!current || shouldReplaceMark(current, mark)) {
+        seen.set(name, mark);
+      }
+    }
+  });
+
+  return Array.from(seen.values());
+};

--- a/packages/core/src/prosemirror/selectionState.test.ts
+++ b/packages/core/src/prosemirror/selectionState.test.ts
@@ -5,6 +5,7 @@ import { schema } from "./schema";
 import { extractSelectionState } from "./selectionState";
 
 const bold = schema.marks["bold"]!;
+const underline = schema.marks["underline"]!;
 
 function paragraphWithBoldRun() {
   // Text node layout: "before " (plain) + "Parent" (bold) + " after" (plain).
@@ -93,5 +94,39 @@ describe("extractSelectionState — bold detection", () => {
 
     expect(result?.paragraphFormatting.lineSpacing).toBe(0);
     expect(result?.paragraphFormatting.lineSpacingRule).toBe("auto");
+  });
+});
+
+describe("extractSelectionState — underline none", () => {
+  test('treats underline style "none" as inactive for toolbar state', () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("text", [underline.create({ style: "none", color: { rgb: "FF0000" } })]),
+      ]),
+    ]);
+    const state = EditorState.create({ doc }).apply(
+      EditorState.create({ doc }).tr.setSelection(TextSelection.create(doc, 3, 3)),
+    );
+
+    const result = extractSelectionState(state);
+
+    expect(result?.textFormatting.underline).toBeUndefined();
+  });
+
+  test("prefers visible underline when hidden underline occurs first", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("hidden", [underline.create({ style: "none" })]),
+        schema.text("visible", [underline.create({ style: "single" })]),
+      ]),
+    ]);
+    const state = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, 1, 14),
+    });
+
+    expect(extractSelectionState(state)?.textFormatting.underline).toMatchObject({
+      style: "single",
+    });
   });
 });

--- a/packages/core/src/prosemirror/selectionState.ts
+++ b/packages/core/src/prosemirror/selectionState.ts
@@ -4,11 +4,11 @@
  * Extracts selection state from ProseMirror for toolbar integration.
  */
 
-import type { Mark } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 
 import type { TextFormatting, ParagraphFormatting } from "../types/document";
 import { directionIsRtl } from "./paragraphDirection";
+import { collectMarksInRange } from "./selectionMarks";
 
 // ============================================================================
 // TYPES
@@ -83,7 +83,7 @@ export function extractSelectionState(state: EditorState): SelectionState | null
   // the toolbar's active state agrees with what a toggle click will toggle.
   const marks = empty
     ? state.storedMarks || selection.$from.marks()
-    : collectMarksInRange(doc, from, to);
+    : collectMarksInRange({ doc, from, to });
 
   // If in empty paragraph with no marks but has defaultTextFormatting, use that
   if (isEmptyParagraph && marks.length === 0 && paragraphDefaultFormatting) {
@@ -100,10 +100,12 @@ export function extractSelectionState(state: EditorState): SelectionState | null
         textFormatting.italic = true;
         break;
       case "underline":
-        textFormatting.underline = {
-          style: mark.attrs["style"] || "single",
-          color: mark.attrs["color"],
-        };
+        if (mark.attrs["style"] !== "none") {
+          textFormatting.underline = {
+            style: mark.attrs["style"] || "single",
+            color: mark.attrs["color"],
+          };
+        }
         break;
       case "strike":
         if (mark.attrs["double"]) {
@@ -191,26 +193,4 @@ export function extractSelectionState(state: EditorState): SelectionState | null
     startParagraphIndex,
     endParagraphIndex,
   };
-}
-
-/**
- * Collect the first occurrence of each mark type found on any text node within
- * the range. Mirrors the "any inline child has this mark" semantics that
- * prosemirror-commands' toggleMark uses to decide add-vs-remove, so the
- * toolbar's active state stays consistent with what a toggle click will do.
- */
-function collectMarksInRange(doc: EditorState["doc"], from: number, to: number): Mark[] {
-  const seen = new Map<string, Mark>();
-  doc.nodesBetween(from, to, (node) => {
-    if (!node.isText) {
-      return;
-    }
-    for (const mark of node.marks) {
-      const name = mark.type.name;
-      if (!seen.has(name)) {
-        seen.set(name, mark);
-      }
-    }
-  });
-  return Array.from(seen.values());
 }


### PR DESCRIPTION
## Summary

- merge font-family writes without dropping untouched script and theme slots
- preserve underline color when toggling selections or collapsed carets
- render and report explicit underline suppression consistently
- validate font theme slots before typed mark merging

## Validation

- 4,592 core tests passed; 2 optional differential tests skipped
- core typecheck and build
- repository lint and format check
- public API snapshot check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Font-family changes now preserve unrelated script-specific font settings and remove outdated theme attributes.
  * Underline formatting preserves existing colours when styles are changed or toggled.
  * Applying formatting at a selection or caret no longer unintentionally removes other formatting.
  * Underline style “none” is now correctly treated as inactive and rendered without decoration.
  * Formatting controls now reflect marks applied anywhere within a selected range.
* **Tests**
  * Expanded coverage for font, underline, selection, and caret formatting behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->