### PR TITLE
fix(core): preserve typed XML inspection errors

### DIFF
--- a/.changeset/typed-result-boundary.md
+++ b/.changeset/typed-result-boundary.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve typed errors when inspecting malformed XML package parts.

--- a/packages/core/src/docx/server/inspectDocxPackage.test.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.test.ts
@@ -101,6 +101,23 @@ describe("inspectDocxPackage", () => {
     expect(inspection.xmlParts.map(({ text }) => text)).toEqual(["", "<"]);
   });
 
+  test("reports malformed XML bytes as a typed inspection error", async () => {
+    const bytes = await mutateEmptyPackage((zip) => {
+      zip.file("malformed.xml", new Uint8Array([0xc3, 0x28]));
+    });
+
+    const error = await rejection(inspectDocxPackage(bytes, { xmlParts: ["malformed.xml"] }));
+
+    expect(error).toMatchObject({
+      message: 'Failed to decode XML package part "malformed.xml"',
+      code: "xml-decode-failed",
+      part: "malformed.xml",
+    });
+    expect(error).toBeInstanceOf(FolioDocxPackageInspectionError);
+    expect(error).toHaveProperty("cause");
+    expect(error.cause).toBeInstanceOf(TypeError);
+  });
+
   test("rejects missing, binary, and duplicate requested parts", async () => {
     const bytes = await mutateEmptyPackage((zip) => {
       zip.file("word/media/payload.bin", "data");

--- a/packages/core/src/docx/server/inspectDocxPackage.ts
+++ b/packages/core/src/docx/server/inspectDocxPackage.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { TaggedError } from "better-result";
+import { Result, TaggedError } from "better-result";
 
 import { getAttributeAnyPrefix, getLocalName, parseXmlDocument } from "../xmlParser";
 import type { DocxArchiveEntry, DocxArchiveOptions } from "./boundedArchive";
@@ -104,16 +104,20 @@ const decodeXml = (bytes: Uint8Array, part: string): string => {
     encoding = "utf-16be";
   }
 
-  try {
-    return new TextDecoder(encoding, { fatal: true }).decode(bytes);
-  } catch (cause) {
-    throw new FolioDocxPackageInspectionError({
-      message: `Failed to decode XML package part "${part}"`,
-      code: "xml-decode-failed",
-      part,
-      cause,
-    });
+  const decoded = Result.try({
+    try: () => new TextDecoder(encoding, { fatal: true }).decode(bytes),
+    catch: (cause) =>
+      new FolioDocxPackageInspectionError({
+        message: `Failed to decode XML package part "${part}"`,
+        code: "xml-decode-failed",
+        part,
+        cause,
+      }),
+  });
+  if (decoded.isOk()) {
+    return decoded.value;
   }
+  throw decoded.error;
 };
 
 const parseContentTypes = (xml: string | null): ContentTypeDeclarations => {


### PR DESCRIPTION
## Summary

- use the typed `Result.try` boundary for fatal XML decoding
- preserve `FolioDocxPackageInspectionError`, its code, part, and original cause
- cover malformed UTF-8 package parts with a regression test

## Validation

- `bun test src` (4,597 pass, 2 optional skips)
- `bun run typecheck` (packages/core)
- `bun run build` (packages/core)
- `bun run lint`
- `bun run format:check`
- `bun run api:check`