### PR TITLE
fix: improve Microsoft Word layout parity

### DIFF
--- a/.changeset/calm-tables-align.md
+++ b/.changeset/calm-tables-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align unindented tables, preserve paragraph direction and section page numbering, and paginate independent table rows.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -132,7 +132,7 @@ export function createPaginator(options: PaginatorOptions): {
         w: number;
         h: number;
     }, newMargins?: PageMargins, applyImmediately?: boolean) => void;
-    startSection: (sectionIndex: number) => void;
+    startSection: (sectionIndex: number, pageNumbering?: SectionPageNumbering) => void;
 };
 
 // @public
@@ -428,6 +428,7 @@ export type LayoutOptions = {
     };
     finalMargins?: PageMargins;
     finalColumns?: ColumnLayout;
+    finalPageNumbering?: SectionPageNumbering;
     columns?: ColumnLayout;
     pageGap?: number;
     defaultLineHeight?: number;
@@ -490,6 +491,8 @@ export type MeasuredLine = {
 // @public
 export type Page = {
     number: number;
+    logicalNumber: number;
+    logicalNumberFormat?: string;
     fragments: Fragment[];
     margins: PageMargins;
     authoredMargins?: PageMargins;
@@ -566,6 +569,7 @@ export type PaginatorOptions = {
     mirrorMargins?: boolean;
     firstPageMargins?: PageMargins;
     sectionEvenPageMargins?: (PageMargins | undefined)[];
+    pageNumbering?: SectionPageNumbering;
     columns?: ColumnLayout;
     footnoteReservedHeights?: Map<number, number>;
     sectionHeaderFooterRefs?: PageHeaderFooterRefs[];
@@ -804,6 +808,7 @@ export type SectionBreakBlock = {
     orientation?: "portrait" | "landscape";
     margins?: PageMargins;
     columns?: ColumnLayout;
+    pageNumbering?: SectionPageNumbering;
     documentGridLinePitchTwips?: number;
 };
 
@@ -819,7 +824,18 @@ export type SectionLayoutConfig = {
         h: number;
     };
     margins: PageMargins;
+    pageNumbering: SectionPageNumbering;
     columns?: ColumnLayout;
+};
+
+// @public
+export type SectionPageNumbering = {
+    type: "continue";
+    format?: string;
+} | {
+    type: "restart";
+    start: number;
+    format?: string;
 };
 
 // @public

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -422,6 +422,7 @@ export type LayoutOptions = {
     margins: PageMargins;
     firstPageMargins?: PageMargins;
     sectionEvenPageMargins?: (PageMargins | undefined)[];
+    pageNumbering?: SectionPageNumbering;
     finalPageSize?: {
         w: number;
         h: number;

--- a/api-reports/core/layout-painter.api.md
+++ b/api-reports/core/layout-painter.api.md
@@ -123,6 +123,7 @@ export type PainterOptions = {
 // @public
 export type RenderContext = {
     pageNumber: number;
+    pageNumberFormat?: string;
     totalPages: number;
     section: "body" | "header" | "footer";
     bookmarkPages?: ReadonlyMap<string, number>;

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -198,6 +198,16 @@ describe("Layout Engine - Page Production", () => {
       expect(resolved.values.get(field?.pmStart ?? -1)).toBe("13");
     });
 
+    test("starts logical numbering from the initial section policy", () => {
+      const layout = layoutDocument(
+        [makeParagraphBlock(0, "First", 1)],
+        [makeParagraphMeasure([makeLine(0, 0, 0, 5, 50, 24)])],
+        makeLayoutOptions({ pageNumbering: { type: "restart", start: 13 } }),
+      );
+
+      expect(layout.pages.at(0)).toMatchObject({ number: 1, logicalNumber: 13 });
+    });
+
     test("positions a text-anchored floating table from the current text cursor", () => {
       const paragraph = makeParagraphBlock(0, "Anchor", 1);
       const table: TableBlock = {
@@ -1660,6 +1670,46 @@ describe("Section Breaks", () => {
     expect(layout.pages.map(({ number }) => number)).toEqual([1, 2, 3]);
     expect(layout.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([13, 14, 4]);
     expect(layout.pages.map(({ sectionPageNumber }) => sectionPageNumber)).toEqual([1, 1, 1]);
+  });
+
+  test.each([
+    { type: "evenPage" as const, leadingBreaks: 1, targetPage: 4 },
+    { type: "oddPage" as const, leadingBreaks: 0, targetPage: 3 },
+  ])("keeps $type filler pages in the previous section", ({ type, leadingBreaks, targetPage }) => {
+    const blocks: FlowBlock[] = [makeParagraphBlock(0, "Before", 1)];
+    const measures: Measure[] = [makeParagraphMeasure([makeLine(0, 0, 0, 5, 50, 24)])];
+    for (let index = 0; index < leadingBreaks; index += 1) {
+      blocks.push({ kind: "pageBreak", id: `page-break-${index}` });
+      measures.push({ kind: "pageBreak" });
+      blocks.push(makeParagraphBlock(`before-${index}`, "Before", 1));
+      measures.push(makeParagraphMeasure([makeLine(0, 0, 0, 5, 50, 24)]));
+    }
+    blocks.push({ kind: "sectionBreak", id: "section", type });
+    measures.push({ kind: "sectionBreak" });
+    blocks.push(makeParagraphBlock("after", "After", 1));
+    measures.push(makeParagraphMeasure([makeLine(0, 0, 0, 5, 50, 24)]));
+
+    const layout = layoutDocument(
+      blocks,
+      measures,
+      makeLayoutOptions({
+        bodyBreakType: type,
+        finalPageNumbering: { type: "restart", start: 13 },
+      }),
+    );
+
+    const target = layout.pages.at(-1);
+    expect(target).toMatchObject({
+      number: targetPage,
+      logicalNumber: 13,
+      sectionIndex: 1,
+      sectionPageNumber: 1,
+    });
+    expect(layout.pages.at(-2)).toMatchObject({
+      number: targetPage - 1,
+      logicalNumber: targetPage - 1,
+      sectionIndex: 0,
+    });
   });
 
   test("continuous section break does not force new page", () => {

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -9,12 +9,17 @@
 
 import { describe, test, expect } from "bun:test";
 
+import { parseDocumentBody } from "../docx/documentParser";
+import { resolveFieldValues } from "../fields/resolveFieldValues";
 import {
   clickToPosition,
   clickToPositionInParagraph,
 } from "../layout-bridge/engine/clickToPosition";
 import { hitTestPage, hitTestFragment, getPageTop } from "../layout-bridge/engine/hitTest";
 import { layoutDocument } from "../layout-engine/index";
+import { toFlowBlocks } from "../layout-bridge/convert/toFlowBlocks";
+import { getPageNumbering } from "../paged-layout/sectionGeometry";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type {
   ParagraphBlock,
   ParagraphMeasure,
@@ -152,6 +157,45 @@ describe("Layout Engine - Page Production", () => {
       const fragment = layout.pages[0].fragments[0];
       expect(fragment.kind).toBe("paragraph");
       expect(fragment.blockId).toBe(0);
+    });
+
+    test("renders PAGE from a final sectPr restart instead of the physical page", () => {
+      const body = parseDocumentBody(`
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:body>
+            <w:p>
+              <w:fldSimple w:instr="PAGE"><w:r><w:t>1</w:t></w:r></w:fldSimple>
+            </w:p>
+            <w:sectPr><w:pgNumType w:start="13"/></w:sectPr>
+          </w:body>
+        </w:document>
+      `);
+      const blocks = toFlowBlocks(toProseDoc({ package: { document: body } }), {});
+      const paragraph = blocks.at(0);
+      expect(paragraph?.kind).toBe("paragraph");
+      if (paragraph?.kind !== "paragraph") {
+        throw new Error("expected PAGE field paragraph");
+      }
+      const field = paragraph.runs.find((run) => run.kind === "field");
+      expect(field?.pmStart).toBeDefined();
+      const layout = layoutDocument(
+        blocks,
+        [makeParagraphMeasure([makeLine(0, 0, 0, 1, 10, 24)])],
+        makeLayoutOptions({
+          finalPageNumbering: getPageNumbering(body.finalSectionProperties),
+        }),
+      );
+      const resolved = resolveFieldValues(blocks, layout.pages, {
+        totalPages: layout.pages.length,
+        bookmarkPages: new Map(),
+        bookmarkText: new Map(),
+        seqValues: new Map(),
+        sectionPageCounts: new Map([[0, 1]]),
+        now: new Date(0),
+      });
+
+      expect(layout.pages.at(0)).toMatchObject({ number: 1, logicalNumber: 13 });
+      expect(resolved.values.get(field?.pmStart ?? -1)).toBe("13");
     });
 
     test("positions a text-anchored floating table from the current text cursor", () => {
@@ -1578,6 +1622,44 @@ describe("Section Breaks", () => {
     expect(layout.pages[0].sectionPageNumber).toBe(1);
     expect(layout.pages[0].headerFooterRefs?.footerDefault).toBe("next-footer");
     expect(layout.pages[0].fragments.some((f) => f.blockId === 2)).toBe(true);
+  });
+
+  test("continues and restarts authored page numbers across section configs", () => {
+    const blocks: FlowBlock[] = [
+      makeParagraphBlock(0, "First", 1),
+      {
+        kind: "sectionBreak",
+        id: 1,
+        type: "nextPage",
+        pageNumbering: { type: "restart", start: 13 },
+      },
+      makeParagraphBlock(2, "Second", 10),
+      {
+        kind: "sectionBreak",
+        id: 3,
+        type: "nextPage",
+        pageNumbering: { type: "continue" },
+      },
+      makeParagraphBlock(4, "Third", 20),
+    ];
+    const paragraphMeasure = makeParagraphMeasure([makeLine(0, 0, 0, 5, 50, 24)]);
+    const measures: Measure[] = [
+      paragraphMeasure,
+      { kind: "sectionBreak" },
+      paragraphMeasure,
+      { kind: "sectionBreak" },
+      paragraphMeasure,
+    ];
+
+    const layout = layoutDocument(
+      blocks,
+      measures,
+      makeLayoutOptions({ finalPageNumbering: { type: "restart", start: 4 } }),
+    );
+
+    expect(layout.pages.map(({ number }) => number)).toEqual([1, 2, 3]);
+    expect(layout.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([13, 14, 4]);
+    expect(layout.pages.map(({ sectionPageNumber }) => sectionPageNumber)).toEqual([1, 1, 1]);
   });
 
   test("continuous section break does not force new page", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -665,6 +665,7 @@ export function runLayoutPipeline<THfPMs>(
       const nextLayoutOpts: Parameters<typeof layoutDocument>[2] = {
         pageSize,
         margins: initialBodyMargins,
+        pageNumbering: bodyLayoutConfig.pageNumbering,
         pageGap,
         mirrorMargins,
       };

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -63,7 +63,12 @@ import { tryBuildIncrementalMeasures } from "../paged-layout/incrementalMeasure"
 import type { DirtyRange } from "../paged-layout/incrementalMeasure";
 import type { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
 import { computePerBlockMeasureInputs } from "../paged-layout/sectionBlockWidths";
-import { getMargins, getPageSize, twipsToPixels } from "../paged-layout/sectionGeometry";
+import {
+  getMargins,
+  getPageNumbering,
+  getPageSize,
+  twipsToPixels,
+} from "../paged-layout/sectionGeometry";
 import { templatePreviewValuesKey } from "../prosemirror/plugins/templatePreviewValues";
 import type { TemplatePreviewEntry } from "../prosemirror/plugins/templatePreviewValues";
 import type {
@@ -563,6 +568,7 @@ export function runLayoutPipeline<THfPMs>(
     const bodyLayoutConfig: SectionLayoutConfig = {
       pageSize,
       margins: initialBodyMargins,
+      pageNumbering: getPageNumbering(sectionProperties),
     };
     if (columns !== undefined) {
       bodyLayoutConfig.columns = columns;
@@ -590,6 +596,7 @@ export function runLayoutPipeline<THfPMs>(
             preparedHeader: finalHeaderForLayout,
             preparedFooter: finalFooterForLayout,
           }),
+          pageNumbering: getPageNumbering(finalSectionProperties),
         }
       : bodyLayoutConfig;
     const finalColumns = getColumns(finalSectionProperties);
@@ -672,6 +679,7 @@ export function runLayoutPipeline<THfPMs>(
         nextLayoutOpts.finalPageSize = finalLayoutConfig.pageSize;
         nextLayoutOpts.finalMargins = finalLayoutConfig.margins;
         nextLayoutOpts.finalColumns = finalLayoutConfig.columns ?? { count: 1, gap: 0 };
+        nextLayoutOpts.finalPageNumbering = finalLayoutConfig.pageNumbering;
       }
       if (columns !== undefined) {
         nextLayoutOpts.columns = columns;

--- a/packages/core/src/docx/fieldParser.ts
+++ b/packages/core/src/docx/fieldParser.ts
@@ -545,14 +545,11 @@ export function isTocField(field: Field): boolean {
 export function computePageNumber(
   pageNumber: number,
   instruction?: ParsedFieldInstruction,
+  sectionFormat?: string,
 ): string {
-  if (!instruction) {
-    return String(pageNumber);
-  }
-
-  const format = getFormatSwitch(instruction);
-  if (!format) {
-    return String(pageNumber);
+  const format = instruction ? getFormatSwitch(instruction) : undefined;
+  if (!format || format.toUpperCase() === "MERGEFORMAT") {
+    return formatSectionPageNumber(pageNumber, sectionFormat);
   }
 
   // Handle common format switches
@@ -561,6 +558,21 @@ export function computePageNumber(
       return toRoman(pageNumber);
     case "ALPHABETIC":
       return toLetter(pageNumber);
+    default:
+      return String(pageNumber);
+  }
+}
+
+function formatSectionPageNumber(pageNumber: number, format: string | undefined): string {
+  switch (format) {
+    case "upperRoman":
+      return toRoman(pageNumber);
+    case "lowerRoman":
+      return toRoman(pageNumber).toLowerCase();
+    case "upperLetter":
+      return toLetter(pageNumber);
+    case "lowerLetter":
+      return toLetter(pageNumber).toLowerCase();
     default:
       return String(pageNumber);
   }

--- a/packages/core/src/fields/bookmarkPages.test.ts
+++ b/packages/core/src/fields/bookmarkPages.test.ts
@@ -45,6 +45,7 @@ const tableFragment = (blockId: string, fromRow: number, toRow: number): TableFr
 
 const page = (number: number, blockIds: string[]): Page => ({
   number,
+  logicalNumber: number,
   fragments: blockIds.map(fragment),
   margins: MARGINS,
   size: { w: 816, h: 1056 },
@@ -65,6 +66,12 @@ describe("buildBookmarkPageMap", () => {
     expect(map.get("schedule")).toBe(2);
     expect(map.get("exhibit")).toBe(2);
     expect(map.size).toBe(3);
+  });
+
+  test("maps bookmarks to authored logical page numbers", () => {
+    const logicalPage = { ...page(1, ["a"]), logicalNumber: 13 };
+
+    expect(buildBookmarkPageMap([logicalPage], [para("a", ["target"])]).get("target")).toBe(13);
   });
 
   test("a bookmark whose paragraph splits across pages takes the first page", () => {
@@ -95,6 +102,7 @@ describe("buildBookmarkPageMap", () => {
     const pages: Page[] = [
       {
         number: 4,
+        logicalNumber: 4,
         fragments: [tableFragment("table", 0, 1)],
         margins: MARGINS,
         size: { w: 816, h: 1056 },
@@ -126,12 +134,14 @@ describe("buildBookmarkPageMap", () => {
     const pages: Page[] = [
       {
         number: 8,
+        logicalNumber: 8,
         fragments: [tableFragment("table", 0, 1)],
         margins: MARGINS,
         size: { w: 816, h: 1056 },
       },
       {
         number: 9,
+        logicalNumber: 9,
         fragments: [tableFragment("table", 1, 2)],
         margins: MARGINS,
         size: { w: 816, h: 1056 },

--- a/packages/core/src/fields/bookmarkPages.ts
+++ b/packages/core/src/fields/bookmarkPages.ts
@@ -31,7 +31,7 @@ export function buildBookmarkPageMap(
         if (!fragmentContainsAnchor(fragment, anchor)) {
           continue;
         }
-        assignBookmarkPage(pageByBookmark, anchor.names, page.number);
+        assignBookmarkPage(pageByBookmark, anchor.names, page.logicalNumber);
       }
     }
   }

--- a/packages/core/src/fields/evaluateField.test.ts
+++ b/packages/core/src/fields/evaluateField.test.ts
@@ -30,6 +30,14 @@ describe("evaluateField page-number family", () => {
     expect(evalInstr("SECTIONPAGES", ctx)).toBe("5");
   });
 
+  test("PAGE uses the section format unless its field instruction overrides it", () => {
+    const ctx = baseContext({ pageNumber: 13, pageNumberFormat: "lowerRoman" });
+
+    expect(evalInstr("PAGE", ctx)).toBe("xiii");
+    expect(evalInstr("PAGE \\* MERGEFORMAT", ctx)).toBe("xiii");
+    expect(evalInstr("PAGE \\* ROMAN", ctx)).toBe("XIII");
+  });
+
   test("locked fields preserve their cached fallback", () => {
     const ctx = baseContext();
     expect(

--- a/packages/core/src/fields/evaluateField.ts
+++ b/packages/core/src/fields/evaluateField.ts
@@ -62,7 +62,7 @@ export function evaluateField(
 
   switch (parsed.type) {
     case "PAGE":
-      return computePageNumber(ctx.pageNumber, parsed);
+      return computePageNumber(ctx.pageNumber, parsed, ctx.pageNumberFormat);
     case "NUMPAGES":
       return computePageNumber(ctx.totalPages, parsed);
     case "SECTIONPAGES":

--- a/packages/core/src/fields/fieldContext.ts
+++ b/packages/core/src/fields/fieldContext.ts
@@ -8,6 +8,8 @@
 export type FieldContext = {
   /** 1-indexed page the field is on (PAGE). */
   pageNumber: number;
+  /** OOXML section-level format used when PAGE has no explicit format switch. */
+  pageNumberFormat?: string;
   /** Total pages in the document (NUMPAGES). */
   totalPages: number;
   /** Pages in the field's current section (SECTIONPAGES); omit until the

--- a/packages/core/src/fields/resolveFieldValues.test.ts
+++ b/packages/core/src/fields/resolveFieldValues.test.ts
@@ -53,6 +53,7 @@ const tableFragment = (blockId: string, fromRow: number, toRow: number): TableFr
 
 const page = (number: number, blockIds: string[]): Page => ({
   number,
+  logicalNumber: number,
   fragments: blockIds.map(fragment),
   margins: MARGINS,
   size: { w: 816, h: 1056 },
@@ -81,6 +82,13 @@ describe("resolveFieldValues", () => {
     expect(values.get(10)).toBe("1"); // block a on page 1
     expect(values.get(20)).toBe("3"); // block b on page 3
     expect(values.get(30)).toBe("4"); // NUMPAGES = totalPages
+  });
+
+  test("evaluates PAGE from the authored logical number", () => {
+    const blocks = [para("a", [field(10, "PAGE")])];
+    const logicalPage = { ...page(1, ["a"]), logicalNumber: 13 };
+
+    expect(resolveFieldValues(blocks, [logicalPage], shared()).values.get(10)).toBe("13");
   });
 
   test("resolves PAGEREF and SEQ from the shared inputs", () => {
@@ -149,6 +157,7 @@ describe("resolveFieldValues", () => {
     const pages: Page[] = [
       {
         number: 9,
+        logicalNumber: 9,
         fragments: [tableFragment("table", 0, 1)],
         margins: MARGINS,
         size: { w: 816, h: 1056 },
@@ -156,6 +165,7 @@ describe("resolveFieldValues", () => {
       },
       {
         number: 10,
+        logicalNumber: 10,
         fragments: [tableFragment("table", 1, 2)],
         margins: MARGINS,
         size: { w: 816, h: 1056 },

--- a/packages/core/src/fields/resolveFieldValues.ts
+++ b/packages/core/src/fields/resolveFieldValues.ts
@@ -20,7 +20,7 @@ export type HeaderFooterFieldInputs = Pick<
   "bookmarkPages" | "bookmarkText" | "seqValues" | "sectionPageCounts"
 >;
 
-type BlockLocation = { page: number; sectionIndex: number };
+type BlockLocation = { page: number; pageFormat?: string; sectionIndex: number };
 type FieldAnchor =
   | { type: "block"; blockId: BlockId; run: FieldRun }
   | { type: "tableRow"; blockId: BlockId; rowIndex: number; run: FieldRun };
@@ -66,6 +66,7 @@ export function resolveFieldValues(
     const sectionPages = location ? shared.sectionPageCounts.get(location.sectionIndex) : undefined;
     const context: FieldContext = {
       pageNumber: location?.page ?? 1,
+      ...(location?.pageFormat === undefined ? {} : { pageNumberFormat: location.pageFormat }),
       totalPages: shared.totalPages,
       bookmarkPages: shared.bookmarkPages,
       bookmarkText: shared.bookmarkText,
@@ -235,7 +236,10 @@ function buildBlockPageMap(pages: readonly Page[]): Map<BlockId, BlockLocation> 
     for (const fragment of page.fragments) {
       if (!map.has(fragment.blockId)) {
         map.set(fragment.blockId, {
-          page: page.number,
+          page: page.logicalNumber,
+          ...(page.logicalNumberFormat === undefined
+            ? {}
+            : { pageFormat: page.logicalNumberFormat }),
           sectionIndex: page.sectionIndex ?? 0,
         });
       }
@@ -255,7 +259,10 @@ function buildTableRowPageMap(pages: readonly Page[]): Map<string, BlockLocation
         const key = tableRowKey(fragment.blockId, rowIndex);
         if (!map.has(key)) {
           map.set(key, {
-            page: page.number,
+            page: page.logicalNumber,
+            ...(page.logicalNumberFormat === undefined
+              ? {}
+              : { pageFormat: page.logicalNumberFormat }),
             sectionIndex: page.sectionIndex ?? 0,
           });
         }

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-bidi.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-bidi.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseParagraph } from "../../docx/paragraphParser";
+import { parseXmlDocument } from "../../docx/xmlParser";
+import { expectParagraphAttrs } from "../../prosemirror/attrs";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import type { Document } from "../../types/document";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+const bidiElement = (bidi?: boolean): string => {
+  if (bidi === undefined) {
+    return "";
+  }
+  return bidi ? "<w:bidi/>" : '<w:bidi w:val="0"/>';
+};
+
+const documentWithParagraph = (text: string, bidi?: boolean): Document => {
+  const root = parseXmlDocument(`
+    <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:pPr>${bidiElement(bidi)}</w:pPr>
+      <w:r><w:t>${text}</w:t></w:r>
+    </w:p>
+  `);
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  const paragraph = parseParagraph(root, null, null, null, null, null);
+
+  return { package: { document: { content: [paragraph] } } };
+};
+
+const projectBidi = (text: string, bidi?: boolean) => {
+  const pmDoc = toProseDoc(documentWithParagraph(text, bidi));
+  const pmAttrs = expectParagraphAttrs(pmDoc.child(0));
+  const block = toFlowBlocks(pmDoc).at(0);
+  if (block?.kind !== "paragraph") {
+    throw new Error("Expected paragraph flow block");
+  }
+
+  return { direction: pmAttrs.direction, bidi: block.attrs?.bidi };
+};
+
+describe("toFlowBlocks paragraph bidi tri-state", () => {
+  test("preserves explicit LTR for mixed Arabic and Latin text", () => {
+    expect(projectBidi("اتفاقية Folio 2026", false)).toEqual({
+      direction: { source: "manual", value: "ltr" },
+      bidi: false,
+    });
+  });
+
+  test("preserves explicit RTL", () => {
+    expect(projectBidi("اتفاقية", true)).toEqual({
+      direction: { source: "manual", value: "rtl" },
+      bidi: true,
+    });
+  });
+
+  test("leaves an undecided paragraph absent for painter auto-direction", () => {
+    expect(projectBidi("اتفاقية")).toEqual({ direction: undefined, bidi: undefined });
+  });
+});

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from "bun:test";
 import type {
   ParagraphBlock,
   TableBlock as LayoutTableBlock,
+  TableMeasure,
   TextRun,
 } from "../../layout-engine/types";
+import { layoutDocument } from "../../layout-engine";
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import type { Document, Paragraph, StyleDefinitions, Table } from "../../types/document";
 import { toFlowBlocks } from "./toFlowBlocks";
@@ -34,6 +36,27 @@ function firstTableRun(blocks: unknown[]): TextRun {
   ) as LayoutTableBlock;
   const paragraph = table.rows[0]?.cells[0]?.blocks[0] as ParagraphBlock;
   return paragraph.runs[0] as TextRun;
+}
+
+function firstTableX(block: LayoutTableBlock): number | undefined {
+  const measure: TableMeasure = {
+    kind: "table",
+    rows: [
+      {
+        cells: [{ blocks: [], width: 100, height: 20 }],
+        height: 20,
+      },
+    ],
+    columnWidths: [100],
+    totalWidth: 100,
+    totalHeight: 20,
+  };
+  const layout = layoutDocument([block], [measure], {
+    pageSize: { w: 300, h: 200 },
+    margins: { top: 40, right: 40, bottom: 40, left: 40 },
+    pageGap: 20,
+  });
+  return layout.pages.at(0)?.fragments.find((fragment) => fragment.kind === "table")?.x;
 }
 
 describe("toFlowBlocks style cascade", () => {
@@ -371,7 +394,7 @@ describe("toFlowBlocks style cascade", () => {
     expect(firstTableRun(blocks).fontFamily).toBe("Arial");
   });
 
-  test("default table style supplies cell margins when table has no style ID", () => {
+  test("default table style supplies cell margins without authoring its zero indent", () => {
     const styles: StyleDefinitions = {
       styles: [
         {
@@ -427,15 +450,68 @@ describe("toFlowBlocks style cascade", () => {
       left: 144,
       right: 288,
     });
-    expect(tableNode?.attrs["_resolvedIndent"]).toEqual({ value: 0, type: "dxa" });
+    expect(tableNode?.attrs["_resolvedIndent"]).toBeNull();
     expect(tableNode?.attrs["_originalFormatting"]?.indent).toBeUndefined();
 
     const tableBlock = toFlowBlocks(pmDoc, {})[0];
     expect(tableBlock?.kind).toBe("table");
     if (tableBlock?.kind === "table") {
-      expect(tableBlock.indent).toBe(0);
+      expect(tableBlock.indent).toBeUndefined();
       expect(tableBlock.rows[0]?.cells[0]?.padding?.left).toBeCloseTo(9.6, 1);
       expect(tableBlock.rows[0]?.cells[0]?.padding?.right).toBeCloseTo(19.2, 1);
+      expect(firstTableX(tableBlock)).toBeCloseTo(30.4, 1);
+    }
+  });
+
+  test.each([
+    {
+      name: "direct",
+      formatting: { indent: { value: 0, type: "dxa" as const } },
+      styles: undefined,
+    },
+    {
+      name: "explicit style",
+      formatting: { styleId: "AuthoredTable" },
+      styles: {
+        styles: [
+          {
+            styleId: "AuthoredTable",
+            type: "table" as const,
+            name: "Authored Table",
+            tblPr: { indent: { value: 0, type: "dxa" as const } },
+          },
+        ],
+      },
+    },
+  ])("keeps $name zero table indentation authored", ({ formatting, styles }) => {
+    const table: Table = {
+      type: "table",
+      formatting,
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [{ type: "paragraph", content: [] }],
+            },
+          ],
+        },
+      ],
+    };
+    const document: Document = {
+      package: {
+        document: { content: [table] },
+        ...(styles ? { styles } : {}),
+      },
+    };
+
+    const tableBlock = toFlowBlocks(toProseDoc(document, styles ? { styles } : {}), {}).at(0);
+
+    expect(tableBlock?.kind).toBe("table");
+    if (tableBlock?.kind === "table") {
+      expect(tableBlock.indent).toBe(0);
+      expect(firstTableX(tableBlock)).toBe(40);
     }
   });
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -6,6 +6,19 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("projects authored section page-number restarts", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", {
+        _sectionProperties: { pageNumbering: { start: 13, format: "lowerRoman" } },
+      }),
+    ]);
+
+    expect(toFlowBlocks(doc, {}).at(0)).toMatchObject({
+      kind: "sectionBreak",
+      pageNumbering: { type: "restart", start: 13, format: "lowerRoman" },
+    });
+  });
+
   test("stamps each top-level paragraph with its section line pitch", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -68,7 +68,8 @@ import {
 } from "../../prosemirror/attrs";
 import { autospacingMatchesBase } from "../../prosemirror/autospacingBase";
 import { runShadingAttrsToShading } from "../../prosemirror/conversion/runShadingMark";
-import { directionIsRtl } from "../../prosemirror/paragraphDirection";
+import { directionToBidi } from "../../prosemirror/paragraphDirection";
+import { getPageNumbering } from "../../paged-layout/sectionGeometry";
 import type { RunFormattingOverrideAttrs } from "../../prosemirror/schema/marks";
 import type {
   ImageAttrs,
@@ -1747,8 +1748,9 @@ function convertParagraphAttrs(
   if (pmAttrs.runInWithNext) {
     attrs.runInWithNext = true;
   }
-  if (directionIsRtl(pmAttrs.direction)) {
-    attrs.bidi = true;
+  const bidi = directionToBidi(pmAttrs.direction);
+  if (bidi !== undefined) {
+    attrs.bidi = bidi;
   }
   if (pmAttrs.styleId) {
     attrs.styleId = pmAttrs.styleId;
@@ -3024,6 +3026,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
           }
 
           if (secProps) {
+            sectionBreak.pageNumbering = getPageNumbering(secProps);
             const documentGridLinePitchTwips = resolveDocumentGridLinePitch(secProps.docGrid);
             if (documentGridLinePitchTwips !== undefined) {
               sectionBreak.documentGridLinePitchTwips = documentGridLinePitchTwips;

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -322,7 +322,7 @@ export function layoutDocument(
   const bodyConfig: SectionLayoutConfig = {
     pageSize,
     margins,
-    pageNumbering: CONTINUE_PAGE_NUMBERING,
+    pageNumbering: options.pageNumbering ?? CONTINUE_PAGE_NUMBERING,
   };
   if (options.columns !== undefined) {
     bodyConfig.columns = options.columns;
@@ -330,7 +330,7 @@ export function layoutDocument(
   const finalConfig: SectionLayoutConfig = {
     pageSize: finalPageSize,
     margins: finalMargins,
-    pageNumbering: options.finalPageNumbering ?? CONTINUE_PAGE_NUMBERING,
+    pageNumbering: options.finalPageNumbering ?? bodyConfig.pageNumbering,
   };
   const finalColumns = options.finalColumns ?? options.columns;
   if (finalColumns !== undefined) {
@@ -1658,27 +1658,31 @@ function handleSectionBreak(
       break;
 
     case "evenPage": {
+      const target = paginator.forcePageBreak({ coalesceBlankPage: true });
+      if (target.page.number % 2 !== 0) {
+        paginator.forcePageBreak();
+      }
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
         paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
       }
-      const state = paginator.forcePageBreak({ coalesceBlankPage: true });
-      // If landed on odd page, add another page
-      if (state.page.number % 2 !== 0) {
-        paginator.forcePageBreak();
+      if (!paginator.retargetCurrentBlankPage()) {
+        panic("Even-page section target must be blank");
       }
       break;
     }
 
     case "oddPage": {
+      const target = paginator.forcePageBreak({ coalesceBlankPage: true });
+      if (target.page.number % 2 === 0) {
+        paginator.forcePageBreak();
+      }
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
         paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
       }
-      const state = paginator.forcePageBreak({ coalesceBlankPage: true });
-      // If landed on even page, add another page
-      if (state.page.number % 2 === 0) {
-        paginator.forcePageBreak();
+      if (!paginator.retargetCurrentBlankPage()) {
+        panic("Odd-page section target must be blank");
       }
       break;
     }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -20,6 +20,7 @@ import {
   collapseParagraphSpacing,
   getParagraphSpacingAfter,
   getParagraphSpacingBefore,
+  isEmptyParagraph,
   paragraphsShareStyle,
   resolveEffectiveParagraphSpacingTree,
 } from "./paragraphSpacing";
@@ -53,6 +54,7 @@ import type {
   TextBoxMeasure,
   TextBoxFragment,
   SectionBreakBlock,
+  SectionPageNumbering,
 } from "./types";
 
 const RENDERED_BREAK_REFLOW_TOLERANCE_LINES = 3;
@@ -60,11 +62,13 @@ const RENDERED_BREAK_REFLOW_TOLERANCE_LINES = 3;
 export type SectionLayoutConfig = {
   pageSize: { w: number; h: number };
   margins: PageMargins;
+  pageNumbering: SectionPageNumbering;
   columns?: ColumnLayout;
 };
 
 const DEFAULT_COLUMNS: ColumnLayout = { count: 1, gap: 0 };
 const DEFAULT_SECTION_BREAK_TYPE = "nextPage";
+const CONTINUE_PAGE_NUMBERING: SectionPageNumbering = { type: "continue" };
 
 export function collectSectionConfigs(
   blocks: FlowBlock[],
@@ -88,6 +92,7 @@ export function collectSectionConfigs(
     const config: SectionLayoutConfig = {
       pageSize: sectionBreak.pageSize ?? previousConfig.pageSize,
       margins: sectionBreak.margins ?? previousConfig.margins,
+      pageNumbering: sectionBreak.pageNumbering ?? CONTINUE_PAGE_NUMBERING,
     };
     if (sectionBreak.columns !== undefined) {
       config.columns = sectionBreak.columns;
@@ -317,6 +322,7 @@ export function layoutDocument(
   const bodyConfig: SectionLayoutConfig = {
     pageSize,
     margins,
+    pageNumbering: CONTINUE_PAGE_NUMBERING,
   };
   if (options.columns !== undefined) {
     bodyConfig.columns = options.columns;
@@ -324,6 +330,7 @@ export function layoutDocument(
   const finalConfig: SectionLayoutConfig = {
     pageSize: finalPageSize,
     margins: finalMargins,
+    pageNumbering: options.finalPageNumbering ?? CONTINUE_PAGE_NUMBERING,
   };
   const finalColumns = options.finalColumns ?? options.columns;
   if (finalColumns !== undefined) {
@@ -349,6 +356,7 @@ export function layoutDocument(
       ? { sectionEvenPageMargins: options.sectionEvenPageMargins }
       : {}),
     columns: initialConfig.columns ?? DEFAULT_COLUMNS,
+    pageNumbering: initialConfig.pageNumbering,
     ...(options.footnoteReservedHeights !== undefined
       ? { footnoteReservedHeights: options.footnoteReservedHeights }
       : {}),
@@ -888,11 +896,47 @@ export function getHeaderRowsHeight(measure: TableMeasure, headerRowCount: numbe
   return height;
 }
 
-const tableRowStartsWithRenderedPageBreak = (block: TableBlock, rowIndex: number): boolean =>
-  block.rows[rowIndex]?.cells.some((cell) => {
-    const firstBlock = cell.blocks.at(0);
-    return firstBlock?.kind === "paragraph" && firstBlock.attrs?.renderedPageBreakBefore === true;
-  }) ?? false;
+const tableRowStartsWithRenderedPageBreak = (block: TableBlock, rowIndex: number): boolean => {
+  const visibleCells = block.rows[rowIndex]?.cells.filter((cell) =>
+    cell.blocks.some((cellBlock) => cellBlock.kind !== "paragraph" || !isEmptyParagraph(cellBlock)),
+  );
+  if (!visibleCells || visibleCells.length === 0) {
+    return false;
+  }
+  return visibleCells.every((cell) => {
+    const firstVisibleBlock = cell.blocks.find(
+      (cellBlock) => cellBlock.kind !== "paragraph" || !isEmptyParagraph(cellBlock),
+    );
+    return (
+      firstVisibleBlock?.kind === "paragraph" &&
+      firstVisibleBlock.attrs?.renderedPageBreakBefore === true
+    );
+  });
+};
+
+const getVerticallyMergedRows = (block: TableBlock): Set<number> => {
+  const mergedRows = new Set<number>();
+  for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex += 1) {
+    const row = block.rows[rowIndex];
+    if (!row) {
+      continue;
+    }
+    for (const cell of row.cells) {
+      const rowSpan = cell.rowSpan ?? 1;
+      if (rowSpan <= 1) {
+        continue;
+      }
+      for (
+        let mergedRowIndex = rowIndex;
+        mergedRowIndex < Math.min(block.rows.length, rowIndex + rowSpan);
+        mergedRowIndex += 1
+      ) {
+        mergedRows.add(mergedRowIndex);
+      }
+    }
+  }
+  return mergedRows;
+};
 
 const flowBlockHasTrackedChanges = (block: FlowBlock): boolean => {
   if (block.kind === "paragraph") {
@@ -941,9 +985,7 @@ function layoutTable(
   let currentRowIndex = 0;
 
   const breakInfo = buildTableRowBreakInfo(block, measure);
-  const hasVerticalMerges = block.rows.some((row) =>
-    row.cells.some((cell) => (cell.rowSpan ?? 1) > 1),
-  );
+  const verticallyMergedRows = getVerticallyMergedRows(block);
   // X position from justification / indent, recomputed per fragment because the
   // active column can change across section breaks.
   const computeTableX = (columnIndex: number): number => {
@@ -993,7 +1035,13 @@ function layoutTable(
   const canSplitRow = (rowIndex: number, state = paginator.getCurrentState()): boolean => {
     const row = rows[rowIndex];
     const sourceRow = block.rows[rowIndex];
-    if (!row || !sourceRow || sourceRow.cantSplit || sourceRow.isHeader || hasVerticalMerges) {
+    if (
+      !row ||
+      !sourceRow ||
+      sourceRow.cantSplit ||
+      sourceRow.isHeader ||
+      verticallyMergedRows.has(rowIndex)
+    ) {
       return false;
     }
     if ((breakInfo.breakOffsets[rowIndex]?.length ?? 0) <= 1) {
@@ -1604,7 +1652,7 @@ function handleSectionBreak(
     case "nextPage":
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex);
+        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
       }
       paginator.forcePageBreak({ coalesceBlankPage: true });
       break;
@@ -1612,7 +1660,7 @@ function handleSectionBreak(
     case "evenPage": {
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex);
+        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
       }
       const state = paginator.forcePageBreak({ coalesceBlankPage: true });
       // If landed on odd page, add another page
@@ -1625,7 +1673,7 @@ function handleSectionBreak(
     case "oddPage": {
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex);
+        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
       }
       const state = paginator.forcePageBreak({ coalesceBlankPage: true });
       // If landed on even page, add another page
@@ -1653,7 +1701,7 @@ function handleSectionBreak(
         (Math.round(nextSize.w) !== Math.round(currentPage.size.w) ||
           Math.round(nextSize.h) !== Math.round(currentPage.size.h));
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex);
+        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
       }
       if (pageSizeChanges) {
         // Promote to a page break, but reuse an already blank current page as

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -37,6 +37,66 @@ describe("paginator even-page margins", () => {
     expect(paginator.forcePageBreak().page.margins).toEqual(evenMargins);
     expect(paginator.forcePageBreak().page.margins).toEqual(MARGINS);
   });
+
+  test("uses authored page-number parity after a restart", () => {
+    const evenMargins = { ...MARGINS, top: 30, bottom: 35 };
+    const paginator = createPaginator({
+      pageSize: SIZE,
+      margins: MARGINS,
+      pageNumbering: { type: "restart", start: 2 },
+      sectionEvenPageMargins: [evenMargins],
+    });
+
+    expect(paginator.getCurrentState().page.margins).toEqual(evenMargins);
+  });
+
+  test("retargets a coalesced section page with its restarted parity", () => {
+    const evenMargins = { ...MARGINS, top: 30, bottom: 35 };
+    const paginator = createPaginator({
+      pageSize: SIZE,
+      margins: MARGINS,
+      sectionEvenPageMargins: [undefined, evenMargins],
+    });
+    paginator.forcePageBreak();
+    paginator.startSection(1, { type: "restart", start: 2 });
+
+    const page = paginator.forcePageBreak({ coalesceBlankPage: true }).page;
+
+    expect(paginator.pages).toHaveLength(1);
+    expect(page.logicalNumber).toBe(2);
+    expect(page.margins).toEqual(evenMargins);
+  });
+});
+
+describe("paginator logical page numbers", () => {
+  test("keeps physical, logical, and section page numbers distinct", () => {
+    const paginator = createPaginator({
+      pageSize: SIZE,
+      margins: MARGINS,
+      pageNumbering: { type: "restart", start: 13 },
+    });
+
+    const first = paginator.getCurrentState().page;
+    const second = paginator.forcePageBreak().page;
+    paginator.startSection(1, { type: "continue" });
+    const continued = paginator.forcePageBreak().page;
+    paginator.startSection(2, { type: "restart", start: 4 });
+    const restarted = paginator.forcePageBreak().page;
+
+    expect([first.number, second.number, continued.number, restarted.number]).toEqual([1, 2, 3, 4]);
+    expect([
+      first.logicalNumber,
+      second.logicalNumber,
+      continued.logicalNumber,
+      restarted.logicalNumber,
+    ]).toEqual([13, 14, 15, 4]);
+    expect([
+      first.sectionPageNumber,
+      second.sectionPageNumber,
+      continued.sectionPageNumber,
+      restarted.sectionPageNumber,
+    ]).toEqual([1, 2, 1, 1]);
+  });
 });
 
 describe("paginator forcePageBreak", () => {

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -8,7 +8,14 @@
 import { panic } from "better-result";
 
 import { collapseParagraphSpacing } from "./paragraphSpacing";
-import type { Page, PageMargins, Fragment, ColumnLayout, PageHeaderFooterRefs } from "./types";
+import type {
+  Page,
+  PageMargins,
+  Fragment,
+  ColumnLayout,
+  PageHeaderFooterRefs,
+  SectionPageNumbering,
+} from "./types";
 import { FOOTNOTE_SEPARATOR_HEIGHT } from "./types";
 
 /**
@@ -63,8 +70,10 @@ export type PaginatorOptions = {
    * first-page header) vs. its body pages. Pages 2+ use `margins`.
    */
   firstPageMargins?: PageMargins;
-  /** Per-section body margins used on even section pages. */
+  /** Per-section body margins used on even authored page numbers. */
   sectionEvenPageMargins?: (PageMargins | undefined)[];
+  /** Page-number policy for the initial section. */
+  pageNumbering?: SectionPageNumbering;
   /** Column configuration (optional). */
   columns?: ColumnLayout;
   /** Per-page footnote reserved heights (pageNumber → height in pixels). */
@@ -130,6 +139,10 @@ export function createPaginator(options: PaginatorOptions) {
   let pendingMargins: PageMargins | undefined;
   let currentSectionIndex = 0;
   let currentSectionPageNumber = 0;
+  let currentPageNumbering: SectionPageNumbering = options.pageNumbering ?? { type: "continue" };
+  let nextLogicalPageNumber =
+    currentPageNumbering.type === "restart" ? currentPageNumbering.start : 1;
+  let sectionStartPending = true;
 
   const pages: Page[] = [];
   const states: PageState[] = [];
@@ -154,7 +167,7 @@ export function createPaginator(options: PaginatorOptions) {
       arePageSizesEqual(state.page.size, pageSize) &&
       areMarginsEqual(
         state.page.margins,
-        getPageMargins(state.page.number, state.page.sectionPageNumber ?? currentSectionPageNumber),
+        getPageMargins(state.page.number, state.page.logicalNumber),
       )
     );
   }
@@ -184,9 +197,9 @@ export function createPaginator(options: PaginatorOptions) {
     recalculateColumnWidths();
   }
 
-  function getPageMargins(pageNumber: number, sectionPageNumber: number): PageMargins {
+  function getPageMargins(pageNumber: number, logicalPageNumber: number): PageMargins {
     const evenMargins =
-      sectionPageNumber % 2 === 0
+      logicalPageNumber % 2 === 0
         ? options.sectionEvenPageMargins?.[currentSectionIndex]
         : undefined;
     const pageMargins =
@@ -210,7 +223,8 @@ export function createPaginator(options: PaginatorOptions) {
    * Get X position for a given column index.
    */
   function getColumnX(columnIndex: number): number {
-    const activeLeftMargin = states.at(-1)?.page.margins.left ?? getPageMargins(1, 1).left;
+    const activeLeftMargin =
+      states.at(-1)?.page.margins.left ?? getPageMargins(1, nextLogicalPageNumber).left;
     let x = activeLeftMargin;
     for (let index = 0; index < columnIndex; index++) {
       x += (columnWidths[index] ?? columnWidths[0] ?? 0) + gapAfterColumn(columns, index);
@@ -227,6 +241,9 @@ export function createPaginator(options: PaginatorOptions) {
     }
 
     const pageNumber = pages.length + 1;
+    const logicalNumber = nextLogicalPageNumber;
+    nextLogicalPageNumber += 1;
+    sectionStartPending = false;
     currentSectionPageNumber += 1;
     // Page 1 of the document may use first-page margins (extended top to
     // clear an overflowing first-page header on a titlePg section) while
@@ -234,7 +251,7 @@ export function createPaginator(options: PaginatorOptions) {
     // every page in the section would inherit page 1's title-page top
     // margin, leaving large empty space at the top of pages 2+ on
     // first-page-header docs (NVCA-style templates).
-    const pageMargins = getPageMargins(pageNumber, currentSectionPageNumber);
+    const pageMargins = getPageMargins(pageNumber, logicalNumber);
     const topMargin = pageMargins.top;
     const contentBottom = pageSize.h - pageMargins.bottom;
 
@@ -248,6 +265,10 @@ export function createPaginator(options: PaginatorOptions) {
 
     const page: Page = {
       number: pageNumber,
+      logicalNumber,
+      ...(currentPageNumbering.format === undefined
+        ? {}
+        : { logicalNumberFormat: currentPageNumbering.format }),
       fragments: [],
       margins: pageMargins,
       size: { ...pageSize },
@@ -453,14 +474,15 @@ export function createPaginator(options: PaginatorOptions) {
       breakOptions.coalesceBlankPage &&
       current &&
       current.page.fragments.length === 0 &&
-      current.cursorY === current.topMargin &&
-      currentPageUsesActiveLayout(current)
+      current.cursorY === current.topMargin
     ) {
       if (current.page.sectionIndex !== currentSectionIndex) {
-        currentSectionPageNumber = 1;
-        applySectionMetadata(current.page);
+        retargetCurrentBlankPage();
+        return current;
       }
-      return current;
+      if (currentPageUsesActiveLayout(current)) {
+        return current;
+      }
     }
     return createNewPage();
   }
@@ -475,7 +497,8 @@ export function createPaginator(options: PaginatorOptions) {
       applyPendingLayout();
     }
 
-    const pageMargins = getPageMargins(current.page.number, 1);
+    retargetSectionMetadata(current.page);
+    const pageMargins = getPageMargins(current.page.number, current.page.logicalNumber);
     const topMargin = pageMargins.top;
     const rawContentBottom = pageSize.h - pageMargins.bottom;
     const footnoteHeight = options.footnoteReservedHeights?.get(current.page.number) ?? 0;
@@ -502,8 +525,6 @@ export function createPaginator(options: PaginatorOptions) {
     current.trailingSpacing = 0;
     columnRegionTop = topMargin;
 
-    currentSectionPageNumber = 1;
-    applySectionMetadata(current.page);
     return true;
   }
 
@@ -579,9 +600,32 @@ export function createPaginator(options: PaginatorOptions) {
     pendingMargins = undefined;
   }
 
-  function startSection(sectionIndex: number): void {
+  function startSection(
+    sectionIndex: number,
+    pageNumbering: SectionPageNumbering = { type: "continue" },
+  ): void {
     currentSectionIndex = sectionIndex;
     currentSectionPageNumber = 0;
+    currentPageNumbering = pageNumbering;
+    sectionStartPending = true;
+    if (pageNumbering.type === "restart") {
+      nextLogicalPageNumber = pageNumbering.start;
+    }
+  }
+
+  function retargetSectionMetadata(page: Page): void {
+    currentSectionPageNumber = 1;
+    if (sectionStartPending && currentPageNumbering.type === "restart") {
+      page.logicalNumber = currentPageNumbering.start;
+      nextLogicalPageNumber = currentPageNumbering.start + 1;
+    }
+    sectionStartPending = false;
+    if (currentPageNumbering.format === undefined) {
+      delete page.logicalNumberFormat;
+    } else {
+      page.logicalNumberFormat = currentPageNumbering.format;
+    }
+    applySectionMetadata(page);
   }
 
   function applySectionMetadata(page: Page): void {

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -129,6 +129,72 @@ function markFirstTableParagraphWithRenderedBreak(block: TableBlock): void {
   firstBlock.attrs = { renderedPageBreakBefore: true };
 }
 
+function tableWithVerticalMergeAndTallBody(): {
+  block: TableBlock;
+  measure: TableMeasure;
+} {
+  const shortCellBlock = (id: string) => ({
+    kind: "paragraph" as const,
+    id,
+    runs: [{ kind: "text" as const, text: id }],
+  });
+  const shortCellMeasure = {
+    blocks: [paraMeasure(1)],
+    width: 110,
+    height: LINE,
+  };
+  const tallHeight = 15 * LINE;
+  return {
+    block: {
+      kind: "table",
+      id: "t-merged",
+      rows: [
+        {
+          id: "r-merge-origin",
+          cells: [
+            {
+              id: "c-merge",
+              rowSpan: 2,
+              blocks: [shortCellBlock("p-merge")],
+            },
+            { id: "c-origin", blocks: [shortCellBlock("p-origin")] },
+          ],
+        },
+        {
+          id: "r-merge-continuation",
+          cells: [{ id: "c-continuation", blocks: [shortCellBlock("p-continuation")] }],
+        },
+        {
+          id: "r-tall",
+          cells: [
+            {
+              id: "c-tall",
+              colSpan: 2,
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [shortCellBlock("p-tall")],
+            },
+          ],
+        },
+      ],
+      columnWidths: [110, 110],
+    },
+    measure: {
+      kind: "table",
+      rows: [
+        { cells: [shortCellMeasure, shortCellMeasure], height: LINE },
+        { cells: [shortCellMeasure], height: LINE },
+        {
+          cells: [{ blocks: [paraMeasure(15)], width: 220, height: tallHeight }],
+          height: tallHeight,
+        },
+      ],
+      columnWidths: [110, 110],
+      totalWidth: 220,
+      totalHeight: 2 * LINE + tallHeight,
+    },
+  };
+}
+
 function tableWithHeaderAndTallBody(bodyLines: number): {
   block: TableBlock;
   measure: TableMeasure;
@@ -1195,6 +1261,48 @@ describe("oversized table row splits across pages (#570)", () => {
     expect(fragment).toMatchObject({ y: OPTIONS.margins.top + 20, height: 3 * LINE });
   });
 
+  test("does not promote one cell's cached boundary to the whole row", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 70);
+    const { block, measure } = tallTable(5);
+    markFirstTableParagraphWithRenderedBreak(block);
+    block.rows[0]!.cells.push({
+      id: "c1",
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      blocks: [
+        {
+          kind: "paragraph",
+          id: "p1",
+          runs: [{ kind: "text", text: "continues before the cached boundary" }],
+        },
+      ],
+    });
+    block.columnWidths = [110, 110];
+    measure.rows[0]!.cells.push({
+      blocks: [paraMeasure(5)],
+      width: 110,
+      height: 5 * LINE,
+    });
+    measure.rows[0]!.cells[0]!.width = 110;
+    measure.columnWidths = [110, 110];
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const firstPageFragment = layout.pages[0]?.fragments.find(
+      (fragment): fragment is TableFragment => fragment.kind === "table",
+    );
+
+    expect(firstPageFragment).toMatchObject({
+      y: OPTIONS.margins.top + 70,
+      fromRow: 0,
+      toRow: 1,
+      bottomClip: 2 * LINE,
+    });
+  });
+
   test("still splits an oversized cached-boundary row on the fresh page", () => {
     const spacer: FlowBlock = {
       kind: "paragraph",
@@ -1214,6 +1322,61 @@ describe("oversized table row splits across pages (#570)", () => {
     expect(frags.length).toBeGreaterThan(1);
     expect(frags[0]).toMatchObject({ y: OPTIONS.margins.top, bottomClip: 6 * LINE });
     expect(frags.at(-1)?.bottomClip).toBeUndefined();
+  });
+
+  test("splits an ordinary oversized row when another row has a vertical merge", () => {
+    const { block, measure } = tableWithVerticalMergeAndTallBody();
+
+    const fragments = tableFragments(block, measure);
+    const mergedFragments = fragments.filter((fragment) => fragment.fromRow < 2);
+    const tallRowFragments = fragments.filter((fragment) => fragment.fromRow === 2);
+
+    expect(
+      mergedFragments.every(
+        ({ topClip, bottomClip }) => topClip === undefined && bottomClip === undefined,
+      ),
+    ).toBe(true);
+    expect(tallRowFragments.length).toBeGreaterThan(1);
+    expect(tallRowFragments.at(0)?.bottomClip).toBeDefined();
+    expect(tallRowFragments.at(-1)?.topClip).toBeDefined();
+    expect(tallRowFragments.at(-1)?.bottomClip).toBeUndefined();
+  });
+
+  test("keeps every row covered by a vertical merge unsplit", () => {
+    const { block, measure } = tableWithVerticalMergeAndTallBody();
+    measure.rows[1] = {
+      cells: [{ blocks: [paraMeasure(15)], width: 110, height: 15 * LINE }],
+      height: 15 * LINE,
+    };
+    measure.totalHeight += 14 * LINE;
+
+    const mergedContinuationFragments = tableFragments(block, measure).filter(
+      (fragment) => fragment.fromRow === 1,
+    );
+
+    expect(mergedContinuationFragments).toHaveLength(1);
+    expect(mergedContinuationFragments[0]?.topClip).toBeUndefined();
+    expect(mergedContinuationFragments[0]?.bottomClip).toBeUndefined();
+  });
+
+  test("keeps an oversized vertical-merge origin unsplit", () => {
+    const { block, measure } = tableWithVerticalMergeAndTallBody();
+    measure.rows[0] = {
+      cells: [
+        { blocks: [paraMeasure(15)], width: 110, height: 15 * LINE },
+        { blocks: [paraMeasure(1)], width: 110, height: LINE },
+      ],
+      height: 15 * LINE,
+    };
+    measure.totalHeight += 14 * LINE;
+
+    const mergeOriginFragments = tableFragments(block, measure).filter(
+      (fragment) => fragment.fromRow === 0,
+    );
+
+    expect(mergeOriginFragments).toHaveLength(1);
+    expect(mergeOriginFragments[0]?.topClip).toBeUndefined();
+    expect(mergeOriginFragments[0]?.bottomClip).toBeUndefined();
   });
 
   test("splits a break-permitted row after adjacent table rows", () => {

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -734,9 +734,16 @@ export type SectionBreakBlock = {
   orientation?: "portrait" | "landscape";
   margins?: PageMargins;
   columns?: ColumnLayout;
+  /** Authored page-number continuation or restart policy for the section ending here. */
+  pageNumbering?: SectionPageNumbering;
   /** Line pitch authored by the section properties that end at this boundary, in twips. */
   documentGridLinePitchTwips?: number;
 };
+
+/** Normalized section page-number policy. An omitted OOXML start continues numbering. */
+export type SectionPageNumbering =
+  | { type: "continue"; format?: string }
+  | { type: "restart"; start: number; format?: string };
 
 export type PageHeaderFooterRefs = {
   titlePg?: boolean;
@@ -1143,8 +1150,12 @@ export type PageMargins = {
  * A rendered page containing positioned fragments.
  */
 export type Page = {
-  /** Page number (1-indexed). */
+  /** Physical page number (1-indexed), used for navigation and page counts. */
   number: number;
+  /** Authored page number shown by PAGE fields. */
+  logicalNumber: number;
+  /** OOXML number format for this page's section. */
+  logicalNumberFormat?: string;
   /** Fragments positioned on this page. */
   fragments: Fragment[];
   /** Page margins. */
@@ -1256,7 +1267,7 @@ export type LayoutOptions = {
    * same extension.
    */
   firstPageMargins?: PageMargins;
-  /** Per-section body margins used on even section pages. */
+  /** Per-section body margins used on even authored page numbers. */
   sectionEvenPageMargins?: (PageMargins | undefined)[];
   /** Body-level final section page size. */
   finalPageSize?: { w: number; h: number };
@@ -1264,6 +1275,8 @@ export type LayoutOptions = {
   finalMargins?: PageMargins;
   /** Body-level final section column configuration. */
   finalColumns?: ColumnLayout;
+  /** Body-level final section page-number policy. */
+  finalPageNumbering?: SectionPageNumbering;
   /** Column configuration. */
   columns?: ColumnLayout;
   /** Gap between rendered pages (for UI). */

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1269,6 +1269,8 @@ export type LayoutOptions = {
   firstPageMargins?: PageMargins;
   /** Per-section body margins used on even authored page numbers. */
   sectionEvenPageMargins?: (PageMargins | undefined)[];
+  /** Page-number policy for the initial section. */
+  pageNumbering?: SectionPageNumbering;
   /** Body-level final section page size. */
   finalPageSize?: { w: number; h: number };
   /** Body-level final section margins. */

--- a/packages/core/src/layout-painter/index.ts
+++ b/packages/core/src/layout-painter/index.ts
@@ -181,7 +181,10 @@ export class LayoutPainter {
     for (const i_item of pages) {
       const page = i_item;
       const context: RenderContext = {
-        pageNumber: page.number,
+        pageNumber: page.logicalNumber,
+        ...(page.logicalNumberFormat === undefined
+          ? {}
+          : { pageNumberFormat: page.logicalNumberFormat }),
         totalPages: this.totalPages,
         section: "body",
       };

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -1082,7 +1082,12 @@ describe("footnote rendering", () => {
         footnoteReservedHeight: 24,
         fragments: [],
       },
-      { pageNumber: 7, totalPages: 9, section: "body" },
+      {
+        pageNumber: 7,
+        pageNumberFormat: "upperRoman",
+        totalPages: 9,
+        section: "body",
+      },
       {
         document: fakeDocument,
         footnoteArea: [
@@ -1098,7 +1103,7 @@ describe("footnote rendering", () => {
       },
     );
 
-    expect(pageEl.textContent).toContain("Page 7 of 9");
+    expect(pageEl.textContent).toContain("Page VII of 9");
   });
 
   test("renders structured table footnote content without body PM anchors", () => {

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -260,6 +260,7 @@ function withFakeTextMeasure(runTest: () => void): void {
 
 const page: Page = {
   number: 1,
+  logicalNumber: 1,
   margins: { top: 72, right: 72, bottom: 72, left: 72 },
   size: { w: 816, h: 1056 },
   fragments: [
@@ -368,6 +369,12 @@ function textBoxMeasure(width: number, height: number): TextBoxMeasure {
 }
 
 describe("render page fingerprint", () => {
+  test("changes when the authored page number changes", () => {
+    expect(computePageFingerprint(page)).not.toBe(
+      computePageFingerprint({ ...page, logicalNumber: 13 }),
+    );
+  });
+
   test("changes when the authored margin frame changes without changing effective margins", () => {
     const withAuthoredMargins = {
       ...page,
@@ -685,12 +692,13 @@ describe("header and footer rendering", () => {
     });
   });
 
-  test("resolves even footers from the section page number when enabled", () => {
+  test("resolves even footers from the logical page number when enabled", () => {
     const pageOptions = {};
     const applied = applySectionHeaderFooterOptions(
       {
         ...page,
         number: 2,
+        logicalNumber: 14,
         sectionPageNumber: 2,
         headerFooterRefs: {
           evenAndOddHeaders: true,
@@ -714,6 +722,33 @@ describe("header and footer rendering", () => {
     });
   });
 
+  test("uses first-page furniture by section ordinal even when its logical number is even", () => {
+    const pageOptions = {};
+    applySectionHeaderFooterOptions(
+      {
+        ...page,
+        logicalNumber: 14,
+        sectionPageNumber: 1,
+        headerFooterRefs: {
+          titlePg: true,
+          evenAndOddHeaders: true,
+          footerFirst: "first-footer",
+          footerEven: "even-footer",
+        },
+        fragments: [],
+      },
+      pageOptions,
+      {
+        footerContentByRId: new Map([
+          ["first-footer", headerFooterTextContent("First footer")],
+          ["even-footer", headerFooterTextContent("Even footer")],
+        ]),
+      },
+    );
+
+    expect(pageOptions).toEqual({ footerContent: headerFooterTextContent("First footer") });
+  });
+
   test("leaves enabled even-page slots blank when no even part exists", () => {
     const pageOptions = {
       headerContent: headerFooterTextContent("Odd header"),
@@ -723,6 +758,7 @@ describe("header and footer rendering", () => {
       {
         ...page,
         number: 2,
+        logicalNumber: 2,
         sectionPageNumber: 2,
         headerFooterRefs: {
           evenAndOddHeaders: true,

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -2268,8 +2268,7 @@ export function applySectionHeaderFooterOptions(
 
   const isFirstSectionPage = page.sectionPageNumber === 1;
   const useFirst = refs.titlePg === true && isFirstSectionPage;
-  const sectionPageNumber = page.sectionPageNumber ?? page.number;
-  const useEven = refs.evenAndOddHeaders === true && sectionPageNumber % 2 === 0;
+  const useEven = refs.evenAndOddHeaders === true && page.logicalNumber % 2 === 0;
 
   const headerRId = (() => {
     if (useFirst) {
@@ -2355,7 +2354,10 @@ function buildPageRenderArgs(
   options: FullPageOptions,
 ): { context: RenderContext; pageOptions: RenderPageOptions } {
   const context: RenderContext = {
-    pageNumber: page.number,
+    pageNumber: page.logicalNumber,
+    ...(page.logicalNumberFormat === undefined
+      ? {}
+      : { pageNumberFormat: page.logicalNumberFormat }),
     totalPages,
     section: "body",
     ...(options.bookmarkPages ? { bookmarkPages: options.bookmarkPages } : {}),
@@ -2461,6 +2463,7 @@ function computePageFingerprintInternal(
     parts.push(`am:${pageMarginsFingerprint(page.authoredMargins)}`);
   }
   parts.push(`n:${page.number}`);
+  parts.push(`ln:${page.logicalNumber},${page.logicalNumberFormat ?? ""}`);
   if (page.sectionIndex !== undefined) {
     parts.push(`si:${page.sectionIndex}`);
   }

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -1385,6 +1385,9 @@ function renderFootnoteContent(
 
   const renderContext: RenderContext = {
     pageNumber: context?.pageNumber ?? 0,
+    ...(context?.pageNumberFormat === undefined
+      ? {}
+      : { pageNumberFormat: context.pageNumberFormat }),
     totalPages: context?.totalPages ?? 0,
     section: context?.section ?? "body",
     contentWidth,

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1058,6 +1058,9 @@ function resolveFieldText(run: FieldRun, context: RenderContext | undefined): st
   }
   const fieldContext: FieldContext = {
     pageNumber: context.pageNumber,
+    ...(context.pageNumberFormat === undefined
+      ? {}
+      : { pageNumberFormat: context.pageNumberFormat }),
     totalPages: context.totalPages,
     bookmarkPages: context.bookmarkPages ?? EMPTY_BOOKMARK_PAGES,
     bookmarkText: context.bookmarkText ?? EMPTY_BOOKMARK_TEXT,

--- a/packages/core/src/layout-painter/renderUtils.ts
+++ b/packages/core/src/layout-painter/renderUtils.ts
@@ -46,6 +46,8 @@ export function resolveImageLineAlign(
 export type RenderContext = {
   /** Current page number (1-indexed) */
   pageNumber: number;
+  /** OOXML section-level format for the current logical page number. */
+  pageNumberFormat?: string;
   /** Total number of pages */
   totalPages: number;
   /** Which section is being rendered */

--- a/packages/core/src/paged-layout/sectionBlockWidths.test.ts
+++ b/packages/core/src/paged-layout/sectionBlockWidths.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
+import type { SectionLayoutConfig } from "../layout-engine";
 import type { FlowBlock, ParagraphBlock } from "../layout-engine/types";
 import { computePerBlockMeasureInputs, computePerBlockWidths } from "./sectionBlockWidths";
 
 const BODY_CONFIG = {
   pageSize: { w: 1000, h: 1200 },
   margins: { top: 50, right: 100, bottom: 50, left: 100 },
-};
+  pageNumbering: { type: "continue" },
+} satisfies SectionLayoutConfig;
 
 function paragraph(id: string): ParagraphBlock {
   return {

--- a/packages/core/src/paged-layout/sectionGeometry.test.ts
+++ b/packages/core/src/paged-layout/sectionGeometry.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_HEADER_FOOTER_DISTANCE_PX,
   DEFAULT_PAGE_WIDTH_PX,
   getMargins,
+  getPageNumbering,
   getPageSize,
   twipsToPixels,
   twipsToPxOr,
@@ -55,5 +56,17 @@ describe("paged editor section geometry", () => {
     expect(page.w).toBe(twipsToPixels(1001));
     expect(margins.left).toBe(twipsToPixels(101));
     expect(page.w - margins.left - margins.right).toBeCloseTo(twipsToPixels(698), 10);
+  });
+
+  test("normalizes omitted starts as continuation and authored starts as restarts", () => {
+    expect(getPageNumbering(undefined)).toEqual({ type: "continue" });
+    expect(getPageNumbering({ pageNumbering: { format: "lowerRoman" } })).toEqual({
+      type: "continue",
+      format: "lowerRoman",
+    });
+    expect(getPageNumbering({ pageNumbering: { start: 13 } })).toEqual({
+      type: "restart",
+      start: 13,
+    });
   });
 });

--- a/packages/core/src/paged-layout/sectionGeometry.ts
+++ b/packages/core/src/paged-layout/sectionGeometry.ts
@@ -1,4 +1,4 @@
-import type { PageMargins } from "../layout-engine/types";
+import type { PageMargins, SectionPageNumbering } from "../layout-engine/types";
 import type { SectionProperties } from "../types/document";
 
 export const DEFAULT_PAGE_WIDTH_PX = 816;
@@ -44,3 +44,16 @@ export const getMargins = (sectionProps: SectionProperties | null | undefined): 
   header: twipsToPxOr(sectionProps?.headerDistance, DEFAULT_HEADER_FOOTER_DISTANCE_PX),
   footer: twipsToPxOr(sectionProps?.footerDistance, DEFAULT_HEADER_FOOTER_DISTANCE_PX),
 });
+
+export const getPageNumbering = (
+  sectionProps: SectionProperties | null | undefined,
+): SectionPageNumbering => {
+  const pageNumbering = sectionProps?.pageNumbering;
+  const format = pageNumbering?.format;
+  if (pageNumbering?.start === undefined) {
+    return format === undefined ? { type: "continue" } : { type: "continue", format };
+  }
+  return format === undefined
+    ? { type: "restart", start: pageNumbering.start }
+    : { type: "restart", start: pageNumbering.start, format };
+};

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1422,8 +1422,13 @@ function convertTable(
   const conditionalTableStyleId = tableStyle?.styleId ?? fallbackTableStyle?.styleId;
   const resolvedTableBorders =
     table.formatting?.borders ?? tableStyle?.tblPr?.borders ?? fallbackTableStyle?.tblPr?.borders;
+  const fallbackTableIndent = fallbackTableStyle?.tblPr?.indent;
+  // TableNormal's zero is Word's unindented default: keep it absent so layout
+  // aligns first-cell text with the margin. Direct and explicit-style zero remain authored.
   const resolvedTableIndent =
-    table.formatting?.indent ?? tableStyle?.tblPr?.indent ?? fallbackTableStyle?.tblPr?.indent;
+    table.formatting?.indent ??
+    tableStyle?.tblPr?.indent ??
+    (fallbackTableIndent?.value === 0 ? undefined : fallbackTableIndent);
 
   // Resolve default cell margins through the same table-style cascade.
   const tableCellMargins =


### PR DESCRIPTION
## Summary

- apply cached table page-break hints only when every visible cell confirms the row boundary; keep vertical-merge constraints local to affected rows
- preserve physical, authored, and section page identities so PAGE fields, numbering formats, headers, footers, and margins follow OOXML semantics
- retain explicit paragraph direction and distinguish Word's default unindented table style from authored zero indent
- cover each behavior through parser-to-layout integration and focused regression tests

Validated with the full core suite, property suite, repo-wide typecheck/build, packed-package validation, lint/format checks, and browser interactions. A five-document Word comparison set kept the exact control unchanged, improved a table-heavy document from 0.353 to 0.537, and improved the page-number/table-indent document from 0.690 to 0.709.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed page numbering across sections, including restarts, continuation, logical numbering and Roman/letter formats.
  - Corrected PAGE fields, bookmarks, headers and footers to use authored page numbers.
  - Improved table pagination, including vertically merged rows and independent row breaks.
  - Preserved paragraph text direction and authored table indentation.
  - Corrected handling of unindented tables and section page numbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->