### PR TITLE
fix: advance GitHub Latest after package releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,10 +106,11 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@2b8697f04b39187c934afc04f7b04ad1a18bd827 # package latest-pointer policy
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@68f07b8d089564fcbd9383824ddc8af31ff8d4ba # configurable latest-pointer policy
     with:
       artifact-pattern: npm-tarball-*
       artifact-run-id: ${{ inputs.artifact-run-id }}
+      github-latest-policy: newest-published-stable
       source-ref: ${{ inputs.source-ref || github.sha }}
       package-files: |
         packages/docx-core/package.json


### PR DESCRIPTION
## Summary

- pin the shared publisher with an explicit GitHub Latest policy
- promote the newest stable package release from each verified release commit
- keep npm publication and prerelease behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use the latest stable publishing workflow.
  * Existing artefact handling and recovery behaviour remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->