### PR TITLE
fix(core): align Arabic tables and displayed URLs

### DIFF
--- a/.changeset/bright-lions-align.md
+++ b/.changeset/bright-lions-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align Arabic header wrap bands, RTL table cells, and displayed URLs with Word layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -259,6 +259,7 @@ export type HeaderFooterContent = {
     visualBottom?: number;
     marginPushTop?: number;
     marginPushBottom?: number;
+    bodyTopClearance?: number;
     rId?: string;
     textSig?: string;
 };
@@ -721,6 +722,9 @@ export type RenderedPageBreakRun = RunFormatting & {
 
 // @public (undocumented)
 export const resolveSectionHeaderFooterRefs: (documentModel: import__stll_docx_core_model.Document | null | undefined) => PageHeaderFooterRefs[] | undefined;
+
+// @public
+export const resolveTableCellPadding: (cell: Pick<TableCell, "padding"> | undefined) => TableCellPadding;
 
 // @public
 export type Run = TextRun | TabRun | ImageRun | LineBreakRun | RenderedPageBreakRun | FieldRun | MathRun;

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -667,6 +667,30 @@ describe("runLayoutPipeline", () => {
     expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(MARGINS.top);
   });
 
+  test("moves body content below a page-top header wrap band", () => {
+    const state = makeState();
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        headerContent: { type: "header", hdrFtrType: "default", content: [] },
+        renderHfFromContentOrPm: (hf, _rId, _hfPMs, _contentWidth, metrics) =>
+          hf && metrics.section === "header"
+            ? {
+                blocks: [],
+                measures: [],
+                height: 0,
+                marginPushTop: 0,
+                marginPushBottom: 0,
+                bodyTopClearance: 160,
+              }
+            : undefined,
+      }),
+      state,
+    );
+
+    expect(outcome.layout?.pages.at(0)?.margins.top).toBe(160);
+    expect(outcome.layout?.pages.at(0)?.fragments.at(0)?.y).toBe(160);
+  });
+
   test("uses authored margins for a blank even-page header and footer", () => {
     const content = { type: "header", hdrFtrType: "default", content: [] } as const;
     const outcome = runLayoutPipeline(

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -178,11 +178,12 @@ function bodyMarginsClearHeaderFooter({
     ? (authoredMargins.footer ?? 0) + (preparedFooter.marginPushBottom ?? preparedFooter.height)
     : authoredMargins.bottom;
   const top = Math.max(authoredMargins.top, headerBottom);
+  const clearedTop = Math.max(top, preparedHeader?.bodyTopClearance ?? 0);
   const bottom = Math.max(authoredMargins.bottom, footerClearance);
-  if (top === authoredMargins.top && bottom === authoredMargins.bottom) {
+  if (clearedTop === authoredMargins.top && bottom === authoredMargins.bottom) {
     return authoredMargins;
   }
-  return { ...authoredMargins, top, bottom };
+  return { ...authoredMargins, top: clearedTop, bottom };
 }
 
 type SectionHeaderFooterClearanceOptions = {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -6,6 +6,7 @@ import { schema } from "../../prosemirror/schema";
 import type { HeaderFooter } from "../../types/document";
 import type { HeaderFooterMetrics } from "./headerFooterLayout";
 import {
+  calculateHeaderFooterBodyTopClearance,
   calculateHeaderFooterMarginPushBounds,
   calculateHeaderFooterVisualBounds,
   convertHeaderFooterPmDocToContent,
@@ -484,6 +485,80 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
     );
 
     expect(bounds).toEqual({ top: 0, bottom: 12 });
+  });
+});
+
+describe("calculateHeaderFooterBodyTopClearance", () => {
+  test("reserves a page-top wrapTopAndBottom anchor even when it paints behind text", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "header-anchor",
+        runs: [
+          {
+            kind: "image",
+            src: "logo.png",
+            width: 220,
+            height: 160,
+            wrapType: "topAndBottom",
+            position: {
+              horizontal: { relativeTo: "page", align: "left" },
+              vertical: { relativeTo: "page", align: "top" },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(calculateHeaderFooterBodyTopClearance(blocks, 0, metrics)).toBe(160);
+  });
+
+  test("does not turn ordinary behindDoc artwork into body clearance", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "letterhead",
+        runs: [
+          {
+            kind: "image",
+            src: "letterhead.png",
+            width: 600,
+            height: 800,
+            wrapType: "behind",
+            position: {
+              horizontal: { relativeTo: "page", align: "left" },
+              vertical: { relativeTo: "page", align: "top" },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(calculateHeaderFooterBodyTopClearance(blocks, 0, metrics)).toBeUndefined();
+  });
+
+  test("does not flatten a mid-page wrap band into the top margin", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "mid-page-anchor",
+        runs: [
+          {
+            kind: "image",
+            src: "banner.png",
+            width: 300,
+            height: 100,
+            wrapType: "topAndBottom",
+            position: {
+              horizontal: { relativeTo: "page", align: "left" },
+              vertical: { relativeTo: "page", posOffset: 2_857_500 },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(calculateHeaderFooterBodyTopClearance(blocks, 0, metrics)).toBeUndefined();
   });
 });
 

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -641,6 +641,53 @@ export function calculateHeaderFooterMarginPushBounds(
   return { top, bottom };
 }
 
+/**
+ * Find the lower page edge of header `wrapTopAndBottom` artwork that overlaps
+ * the authored body start. Unlike ordinary anchored artwork, this wrap mode
+ * reserves a full-width horizontal band even when the drawing paints behind
+ * text. Bands wholly below the body start need page-local flow support and are
+ * intentionally not flattened into a top margin here.
+ */
+export function calculateHeaderFooterBodyTopClearance(
+  blocks: FlowBlock[],
+  flowHeight: number,
+  metrics: HeaderFooterMetrics,
+): number | undefined {
+  if (metrics.section !== "header") {
+    return undefined;
+  }
+
+  const flowTop = metrics.margins.header ?? 48;
+  let clearance = 0;
+  for (const block of blocks) {
+    if (block.kind !== "paragraph") {
+      continue;
+    }
+    for (const run of block.runs) {
+      if (
+        run.kind !== "image" ||
+        run.wrapType !== "topAndBottom" ||
+        (run.position?.vertical?.relativeTo !== "page" &&
+          run.position?.vertical?.relativeTo !== "margin")
+      ) {
+        continue;
+      }
+      const pageTop =
+        flowTop + resolveHeaderFooterVisualTop(run, 0, flowHeight, metrics) - (run.distTop ?? 0);
+      if (pageTop > metrics.margins.top) {
+        continue;
+      }
+      const pageBottom = Math.min(
+        metrics.pageSize.h,
+        pageTop + (run.distTop ?? 0) + run.height + (run.distBottom ?? 0),
+      );
+      clearance = Math.max(clearance, pageBottom);
+    }
+  }
+
+  return clearance > 0 ? clearance : undefined;
+}
+
 // =============================================================================
 // 4. HeaderFooter -> HeaderFooterContent (the public entry point)
 // =============================================================================
@@ -795,6 +842,7 @@ function finalizeHeaderFooterContent(
     flowHeight,
     metrics,
   );
+  const bodyTopClearance = calculateHeaderFooterBodyTopClearance(blocks, flowHeight, metrics);
 
   return {
     blocks,
@@ -804,6 +852,7 @@ function finalizeHeaderFooterContent(
     visualBottom,
     marginPushTop,
     marginPushBottom,
+    ...(bodyTopClearance !== undefined ? { bodyTopClearance } : {}),
     textSig: computeHeaderFooterTextSig(blocks),
     ...(options.rId ? { rId: options.rId } : {}),
   };

--- a/packages/core/src/layout-bridge/engine/selectionRects.test.ts
+++ b/packages/core/src/layout-bridge/engine/selectionRects.test.ts
@@ -524,7 +524,7 @@ describe("selection rect geometry", () => {
 
     expect(rects).toHaveLength(1);
     expect(rects[0]?.x).toBe(7);
-    expect(rects[0]?.y).toBe(1);
+    expect(rects[0]?.y).toBe(0);
   });
 
   test("selection rect clipping accounts for cell top padding", () => {

--- a/packages/core/src/layout-bridge/engine/selectionRects.ts
+++ b/packages/core/src/layout-bridge/engine/selectionRects.ts
@@ -10,7 +10,7 @@
 
 import { getHeaderRowsHeight } from "../../layout-engine/index";
 import { measuredLineContentOffset } from "../../layout-engine/lineFlow";
-import { getTableRowLeadingWidth } from "../../layout-engine/types";
+import { getTableRowLeadingWidth, resolveTableCellPadding } from "../../layout-engine/types";
 import { measureParagraph } from "../../layout-engine/measure";
 import { buildRunFontStyle } from "../../layout-engine/measure/measureHelpers";
 import { measureRun } from "../../layout-engine/measure/measureProvider";
@@ -83,9 +83,6 @@ export type CaretPosition = {
   pageIndex: number;
 };
 
-const DEFAULT_TABLE_CELL_PADDING_LEFT = 7;
-const DEFAULT_TABLE_CELL_PADDING_TOP = 1;
-
 // =============================================================================
 // HELPER FUNCTIONS
 // =============================================================================
@@ -120,7 +117,7 @@ function getCellContentOffsetY(
   cellMeasure: TableCellMeasure,
   rowHeight: number,
 ): number {
-  const padTop = cell.padding?.top ?? DEFAULT_TABLE_CELL_PADDING_TOP;
+  const { top: padTop } = resolveTableCellPadding(cell);
   const spareHeight = Math.max(0, rowHeight - cellMeasure.height);
   if (cell.verticalAlign === "bottom") {
     return padTop + spareHeight;
@@ -132,7 +129,7 @@ function getCellContentOffsetY(
 }
 
 function getCellContentOffsetX(cell: TableCell): number {
-  return cell.padding?.left ?? DEFAULT_TABLE_CELL_PADDING_LEFT;
+  return resolveTableCellPadding(cell).left;
 }
 
 function getMeasuredBlockHeight(measure: Measure | undefined): number {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_TEXTBOX_MARGINS,
   floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
+  resolveTableCellPadding,
   tableColumnsArePinned,
 } from "../types";
 import type {
@@ -124,9 +125,6 @@ export function measureTableBlock(
   contentWidth: number,
   fieldValues?: ReadonlyMap<number, string>,
 ): TableMeasure {
-  const DEFAULT_CELL_PADDING_X = 7; // Word default: 108 twips ≈ 7px
-  const DEFAULT_CELL_PADDING_Y = 0; // OOXML/TableNormal default: top=0, bottom=0
-
   // columnWidths are already in pixels (converted in toFlowBlocks)
   let columnWidths = tableBlock.columnWidths ?? [];
   const explicitWidthPx = resolveTableWidthPx(tableBlock.width, tableBlock.widthType, contentWidth);
@@ -185,8 +183,7 @@ export function measureTableBlock(
         }
         columnIndex = getFirstAvailableColumn(cellGrid, rowIdx, columnIndex + colSpan);
 
-        const padLeft = cell.padding?.left ?? DEFAULT_CELL_PADDING_X;
-        const padRight = cell.padding?.right ?? DEFAULT_CELL_PADDING_X;
+        const { left: padLeft, right: padRight } = resolveTableCellPadding(cell);
         const cellContentWidth = Math.max(1, cellWidth - padLeft - padRight);
         // `w:noWrap` (§17.4.30): in an auto-width table Word honors it by
         // widening the column, so measure against an effectively unbounded
@@ -251,8 +248,7 @@ export function measureTableBlock(
         placeTableCellBlock(flowState, sourceBlock, blockMeasure);
       }
       cell.height = finishTableCellFlow(flowState);
-      const padTop = sourceCell?.padding?.top ?? DEFAULT_CELL_PADDING_Y;
-      const padBottom = sourceCell?.padding?.bottom ?? DEFAULT_CELL_PADDING_Y;
+      const { top: padTop, bottom: padBottom } = resolveTableCellPadding(sourceCell);
       cell.height += padTop + padBottom;
       if ((sourceCell?.rowSpan ?? 1) > 1) {
         continue;

--- a/packages/core/src/layout-engine/measure/tableCellFloating.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFloating.ts
@@ -1,7 +1,12 @@
 import { emuToPixels } from "../../utils/units";
 import { createTableCellFlowState, placeTableCellBlock } from "./tableCellFlow";
-import type { ImageRun, TableCell, TableCellMeasure } from "../types";
-import { isFloatingImageRun } from "../types";
+import {
+  isFloatingImageRun,
+  resolveTableCellPadding,
+  type ImageRun,
+  type TableCell,
+  type TableCellMeasure,
+} from "../types";
 import { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
 import type { FloatingImageZone } from "./floatingZones";
 
@@ -86,8 +91,7 @@ export function getTableCellContentWidth(
   cell: TableCell | undefined,
   cellMeasure: TableCellMeasure,
 ): number {
-  const padLeft = cell?.padding?.left ?? 7;
-  const padRight = cell?.padding?.right ?? 7;
+  const { left: padLeft, right: padRight } = resolveTableCellPadding(cell);
   return Math.max(0, cellMeasure.width - padLeft - padRight);
 }
 

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -430,7 +430,7 @@ describe("buildTableRowBreakInfo / snapRowBreak", () => {
     expect(info.breakOffsets[0]).toEqual([35, 85, 100]);
   });
 
-  test("uses rendered default top padding for implicit cell offsets", () => {
+  test("shares TableNormal's zero top margin with measurement and paint", () => {
     const block: TableBlock = {
       kind: "table",
       id: "t",
@@ -474,7 +474,7 @@ describe("buildTableRowBreakInfo / snapRowBreak", () => {
 
     const info = buildTableRowBreakInfo(block, measure);
 
-    expect(info.breakOffsets[0]).toEqual([21, 41, 42]);
+    expect(info.breakOffsets[0]).toEqual([20, 40, 42]);
   });
 
   test("keeps only row break offsets that are safe for every cell", () => {

--- a/packages/core/src/layout-engine/tableRowBreak.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.ts
@@ -21,7 +21,13 @@ import {
 } from "./measure/tableCellFloating";
 import { createTableCellFlowState, placeTableCellBlock } from "./measure/tableCellFlow";
 import { isEmptyParagraph } from "./paragraphSpacing";
-import type { TableBlock, TableCell, TableCellMeasure, TableMeasure } from "./types";
+import {
+  resolveTableCellPadding,
+  type TableBlock,
+  type TableCell,
+  type TableCellMeasure,
+  type TableMeasure,
+} from "./types";
 
 type UnsafeBreakRange = {
   top: number;
@@ -35,8 +41,6 @@ type CellBreakGeometry = {
 };
 
 const BREAK_OFFSET_EPSILON = 0.01;
-
-const DEFAULT_TABLE_CELL_PADDING_TOP = 1;
 
 function isInsideRange(offset: number, range: UnsafeBreakRange): boolean {
   return offset > range.top && offset < range.bottom;
@@ -86,7 +90,7 @@ function cellBreakGeometry(
   const suppressibleLeadingRanges: UnsafeBreakRange[] = [];
   const cellBlocks = cell?.blocks;
   const blockMeasures = measure.blocks;
-  const padTop = cell?.padding?.top ?? DEFAULT_TABLE_CELL_PADDING_TOP;
+  const { top: padTop } = resolveTableCellPadding(cell);
   const contentWidth = getTableCellContentWidth(cell, measure);
   const floatingImages =
     cell !== undefined ? getTableCellFloatingImages(cell, measure, contentWidth) : [];

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -636,6 +636,25 @@ export type TableCell = {
   noWrap?: boolean;
 };
 
+type TableCellPadding = NonNullable<TableCell["padding"]>;
+
+const DEFAULT_TABLE_CELL_PADDING = {
+  top: 0,
+  right: 7,
+  bottom: 0,
+  left: 7,
+} as const satisfies TableCellPadding;
+
+/** Resolve authored cell margins against the TableNormal defaults. */
+export const resolveTableCellPadding = (
+  cell: Pick<TableCell, "padding"> | undefined,
+): TableCellPadding => ({
+  top: cell?.padding?.top ?? DEFAULT_TABLE_CELL_PADDING.top,
+  right: cell?.padding?.right ?? DEFAULT_TABLE_CELL_PADDING.right,
+  bottom: cell?.padding?.bottom ?? DEFAULT_TABLE_CELL_PADDING.bottom,
+  left: cell?.padding?.left ?? DEFAULT_TABLE_CELL_PADDING.left,
+});
+
 /**
  * A table row containing cells.
  */
@@ -1424,6 +1443,8 @@ export type HeaderFooterContent = {
    */
   marginPushTop?: number;
   marginPushBottom?: number;
+  /** Page-coordinate lower edge of a header wrap band overlapping the body top. */
+  bodyTopClearance?: number;
   /**
    * Relationship id (`rId`) of the source HF part. Emitted as `data-rid`
    * on the painted `.layout-page-header` / `.layout-page-footer` so the

--- a/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -122,6 +122,19 @@ function render(runs: (TextRun | FieldRun)[], attrs?: ParagraphAttrs): HTMLEleme
   );
 }
 
+function findByTag(element: FakeElement, tagName: string): FakeElement | undefined {
+  if (element.tagName === tagName) {
+    return element;
+  }
+  for (const child of element.children) {
+    const match = findByTag(child, tagName);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
 const text = (value: string, rtl?: boolean): TextRun => ({
   kind: "text",
   text: value,
@@ -204,5 +217,37 @@ describe("Issue #719 — RTL base direction detection", () => {
     // must not trigger RTL. A run led by them whose first *letter* is Latin is
     // LTR.
     expect(render([text("١٢٣ Hello", true)]).dir).toBe("");
+  });
+
+  test("isolates a displayed URL left-to-right inside an RTL paragraph", () => {
+    const paragraph = render(
+      [
+        {
+          kind: "text",
+          text: "https://www.jobaccess.gov.au/find-a-provider",
+          hyperlink: { href: "https://www.jobaccess.gov.au/find-a-provider" },
+        },
+      ],
+      { bidi: true },
+    ) as unknown as FakeElement;
+
+    expect(findByTag(paragraph, "a")?.dir).toBe("ltr");
+  });
+
+  test("does not force a link label or Arabic link text left-to-right", () => {
+    const renderLink = (value: string): FakeElement =>
+      render(
+        [
+          {
+            kind: "text",
+            text: value,
+            hyperlink: { href: "https://example.com" },
+          },
+        ],
+        { bidi: true },
+      ) as unknown as FakeElement;
+
+    expect(findByTag(renderLink("معلومات إضافية"), "a")?.dir).toBe("");
+    expect(findByTag(renderLink("Job Access"), "a")?.dir).toBe("");
   });
 });

--- a/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -135,6 +135,14 @@ function findByTag(element: FakeElement, tagName: string): FakeElement | undefin
   return undefined;
 }
 
+function findAllByTag(element: FakeElement, tagName: string): FakeElement[] {
+  const matches = element.tagName === tagName ? [element] : [];
+  for (const child of element.children) {
+    matches.push(...findAllByTag(child, tagName));
+  }
+  return matches;
+}
+
 const text = (value: string, rtl?: boolean): TextRun => ({
   kind: "text",
   text: value,
@@ -234,6 +242,19 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(findByTag(paragraph, "a")?.dir).toBe("ltr");
   });
 
+  test("isolates every formatting fragment of a displayed URL", () => {
+    const href = "https://www.jobaccess.gov.au/find-a-provider";
+    const paragraph = render(
+      [
+        { kind: "text", text: "https://www.jobaccess.", hyperlink: { href } },
+        { kind: "text", text: "gov.au/find-a-provider", bold: true, hyperlink: { href } },
+      ],
+      { bidi: true },
+    ) as unknown as FakeElement;
+
+    expect(findAllByTag(paragraph, "a").map((anchor) => anchor.dir)).toEqual(["ltr", "ltr"]);
+  });
+
   test("does not force a link label or Arabic link text left-to-right", () => {
     const renderLink = (value: string): FakeElement =>
       render(
@@ -249,5 +270,18 @@ describe("Issue #719 — RTL base direction detection", () => {
 
     expect(findByTag(renderLink("معلومات إضافية"), "a")?.dir).toBe("");
     expect(findByTag(renderLink("Job Access"), "a")?.dir).toBe("");
+  });
+
+  test("does not force a split link label left-to-right", () => {
+    const href = "https://example.com";
+    const paragraph = render(
+      [
+        { kind: "text", text: "Job", hyperlink: { href } },
+        { kind: "text", text: " Access", italic: true, hyperlink: { href } },
+      ],
+      { bidi: true },
+    ) as unknown as FakeElement;
+
+    expect(findAllByTag(paragraph, "a").map((anchor) => anchor.dir)).toEqual(["", ""]);
   });
 });

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -38,6 +38,7 @@ import type {
   MathRun,
   TabStop,
   ParagraphAttrs,
+  HyperlinkInfo,
 } from "../layout-engine/types";
 import { calculateTabWidth } from "../prosemirror/utils/tabCalculator";
 import type { TabContext, TabStop as TabCalcStop } from "../prosemirror/utils/tabCalculator";
@@ -89,6 +90,10 @@ export const PARAGRAPH_CLASS_NAMES = {
   lineBreak: "layout-run-linebreak",
 };
 
+const LEFT_TO_RIGHT_DIRECTION = "ltr";
+const RIGHT_TO_LEFT_DIRECTION = "rtl";
+const DISPLAYED_URL_PATTERN = /^(?:https?:\/\/|www\.)\S+$/iu;
+
 // Text wrapping around floating images is implemented via measurement-time
 // per-line leftOffset/rightOffset. renderPage.ts re-measures paragraphs with
 // FloatingImageZone[] when floating images are present on the page.
@@ -114,6 +119,54 @@ export type RenderParagraphOptions = {
  */
 function isTextRun(run: Run): run is TextRun {
   return run.kind === "text";
+}
+
+function hyperlinksMatch(left: HyperlinkInfo, right: HyperlinkInfo): boolean {
+  return (
+    left.href === right.href &&
+    left.tooltip === right.tooltip &&
+    left.noDefaultStyle === right.noDefaultStyle
+  );
+}
+
+function collectLeftToRightDisplayedUrlHyperlinks(runs: Run[]): ReadonlySet<HyperlinkInfo> {
+  const result = new Set<HyperlinkInfo>();
+  let index = 0;
+
+  while (index < runs.length) {
+    const first = runs[index];
+    if (!first || !isTextRun(first) || !first.hyperlink) {
+      index += 1;
+      continue;
+    }
+
+    const hyperlinks: HyperlinkInfo[] = [];
+    let displayedText = "";
+    let groupEnd = index;
+    while (groupEnd < runs.length) {
+      const run = runs[groupEnd];
+      if (
+        !run ||
+        !isTextRun(run) ||
+        !run.hyperlink ||
+        !hyperlinksMatch(first.hyperlink, run.hyperlink)
+      ) {
+        break;
+      }
+      displayedText += toPaintedText(run.text);
+      hyperlinks.push(run.hyperlink);
+      groupEnd += 1;
+    }
+
+    if (DISPLAYED_URL_PATTERN.test(displayedText.trim())) {
+      for (const hyperlink of hyperlinks) {
+        result.add(hyperlink);
+      }
+    }
+    index = groupEnd;
+  }
+
+  return result;
 }
 
 /**
@@ -307,9 +360,9 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   // just this run, independent of the paragraph direction. `false` is an
   // explicit override that disables inherited paragraph/style RTL.
   if (run.rtl === true) {
-    element.dir = "rtl";
+    element.dir = RIGHT_TO_LEFT_DIRECTION;
   } else if (run.rtl === false) {
-    element.dir = "ltr";
+    element.dir = LEFT_TO_RIGHT_DIRECTION;
   }
 
   // Text effect animation (w:effect). Host CSS opts in to the actual
@@ -545,7 +598,11 @@ function applyPmPositions(element: HTMLElement, pmStart?: number, pmEnd?: number
 /**
  * Render a text run
  */
-function renderTextRun(run: TextRun, doc: Document): HTMLElement {
+function renderTextRun(
+  run: TextRun,
+  doc: Document,
+  hyperlinkDirection?: typeof LEFT_TO_RIGHT_DIRECTION,
+): HTMLElement {
   const span = doc.createElement("span");
   span.className = `${PARAGRAPH_CLASS_NAMES.run} ${PARAGRAPH_CLASS_NAMES.text}`;
 
@@ -575,8 +632,8 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
   if (run.hyperlink) {
     const anchor = doc.createElement("a");
     anchor.href = run.hyperlink.href;
-    if (/^(?:https?:\/\/|www\.)\S+$/iu.test(paintedText.trim())) {
-      anchor.dir = "ltr";
+    if (hyperlinkDirection || DISPLAYED_URL_PATTERN.test(paintedText.trim())) {
+      anchor.dir = LEFT_TO_RIGHT_DIRECTION;
     }
     // Internal bookmark links (starting with #) should scroll within the document
     // External links should open in a new tab
@@ -1529,6 +1586,8 @@ type RenderLineOptions = {
   floatingMargins?: { leftMargin: number; rightMargin: number };
   /** Track inline image runs already rendered in this paragraph fragment to prevent duplicates */
   renderedInlineImageKeys?: Set<string>;
+  /** Hyperlink fragments whose complete displayed text is a URL. */
+  leftToRightDisplayedUrlHyperlinks?: ReadonlySet<HyperlinkInfo>;
   /**
    * Rightmost x where inline content may render, in content-area coords. Used
    * by the right-tab anchor (TOC pattern); passed in directly rather than
@@ -1946,7 +2005,11 @@ export function renderLine(
     return withCursiveJoiners(runEl, run, cursiveJoinerPlan, applyJoinerRunStyles, doc);
   };
   const renderLineTextRun = (run: TextRun): HTMLElement => {
-    const runEl = renderTextRun(run, doc);
+    const hyperlinkDirection =
+      run.hyperlink && options?.leftToRightDisplayedUrlHyperlinks?.has(run.hyperlink)
+        ? LEFT_TO_RIGHT_DIRECTION
+        : undefined;
+    const runEl = renderTextRun(run, doc, hyperlinkDirection);
     if (collapsedLeadingSpaceRuns.has(run)) {
       runEl.dataset["collapsedLeadingSpaces"] = "true";
     }
@@ -2813,6 +2876,9 @@ export function renderParagraphFragment(
   // Render each line with per-line floating margin calculation
   let _cumulativeLineY = 0; // Track Y position within the fragment
   const renderedInlineImageKeys = options.renderedInlineImageKeys ?? new Set<string>();
+  const leftToRightDisplayedUrlHyperlinks = isRtl
+    ? collectLeftToRightDisplayedUrlHyperlinks(block.runs)
+    : undefined;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!; // SAFETY: i < lines.length
@@ -2851,6 +2917,9 @@ export function renderParagraphFragment(
         rightMargin: lineRightOffset,
       },
       renderedInlineImageKeys,
+      ...(leftToRightDisplayedUrlHyperlinks === undefined
+        ? {}
+        : { leftToRightDisplayedUrlHyperlinks }),
       // Absolute right edge in content-area coords. The fragment starts at
       // content-area-x=0 with full content-area width; the rightmost x where
       // inline content can land is `fragment.width - indentRight - lineRightOffset`.

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -575,6 +575,9 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
   if (run.hyperlink) {
     const anchor = doc.createElement("a");
     anchor.href = run.hyperlink.href;
+    if (/^(?:https?:\/\/|www\.)\S+$/iu.test(paintedText.trim())) {
+      anchor.dir = "ltr";
+    }
     // Internal bookmark links (starting with #) should scroll within the document
     // External links should open in a new tab
     if (!run.hyperlink.href.startsWith("#")) {

--- a/packages/core/src/layout-painter/renderTable-bidi.test.ts
+++ b/packages/core/src/layout-painter/renderTable-bidi.test.ts
@@ -172,6 +172,13 @@ function render(bidi: boolean): FakeElement[] {
 }
 
 describe("renderTableFragment RTL column order (w:bidiVisual)", () => {
+  test("uses the measured zero vertical margin when OOXML omits cell padding", () => {
+    const cells = render(true);
+
+    expect(cellByColumn(cells, "0").style["padding"]).toBe("0px 7px 0px 7px");
+    expect(cellByColumn(cells, "1").style["padding"]).toBe("0px 7px 0px 7px");
+  });
+
   test("LTR paints logical column 0 on the left", () => {
     const cells = render(false);
     expect(cellByColumn(cells, "0").style["left"]).toBe("0px");

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -37,6 +37,7 @@ import {
   getTableRowLeadingWidth,
   isFloatingImageRun,
   isFloatingTextBoxBlock,
+  resolveTableCellPadding,
   tableColumnsArePinned,
 } from "../layout-engine/types";
 import { emuToPixels } from "../utils/units";
@@ -597,10 +598,12 @@ function renderTableCell({
   cellEl.style.overflow = "hidden";
   cellEl.style.boxSizing = "border-box";
   // Use per-cell padding from DOCX margins, default to Word's visual rendering
-  const padTop = cell.padding?.top ?? 1;
-  const padRight = cell.padding?.right ?? 7;
-  const padBottom = cell.padding?.bottom ?? 1;
-  const padLeft = cell.padding?.left ?? 7;
+  const {
+    top: padTop,
+    right: padRight,
+    bottom: padBottom,
+    left: padLeft,
+  } = resolveTableCellPadding(cell);
   cellEl.style.padding = `${padTop}px ${padRight}px ${padBottom}px ${padLeft}px`;
 
   // Apply borders - use cell borders if available, otherwise no border


### PR DESCRIPTION
## Summary

- reserve page-top header `wrapTopAndBottom` bands before body layout
- isolate displayed URLs as LTR inside RTL paragraphs
- share TableNormal cell-padding defaults across measurement, pagination, selection, and paint

Validated with the full core suite, workspace typecheck, lint, formatting, API reports, build, and a real Arabic DOCX comparison against LibreOffice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Arabic and right-to-left paragraph layout, including correct left-to-right alignment for displayed URLs.
  - Prevented page-top header artwork from overlapping body content by preserving the required clearance.
  - Corrected table-cell padding and row-break calculations, including cases where padding is omitted.
  - Improved table selection positioning and bidirectional table rendering.
- **Documentation**
  - Added release information covering Arabic header wrapping, RTL table cells, and Word-style URL alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->