### PR TITLE
fix(core): persist resolved secondary stories

### DIFF
--- a/.changeset/finalize-secondary-stories.md
+++ b/.changeset/finalize-secondary-stories.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Persist resolved review views across every editable Word document story.

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -1667,12 +1667,12 @@ describe("headless docx review round-trip", () => {
         '<w:del w:id="42" w:author="Reviewer"><w:r><w:delText xml:space="preserve">DELETED </w:delText></w:r></w:del>' +
         '<w:moveFrom w:id="43" w:author="Reviewer"><w:r><w:t xml:space="preserve">MOVED FROM </w:t></w:r></w:moveFrom>' +
         '<w:moveTo w:id="44" w:author="Reviewer"><w:r><w:t>MOVED TO</w:t></w:r></w:moveTo>';
-      zip.file(
-        part,
-        (await file.async("text"))
-          .replace(` w14:paraId="${paraId}"`, "")
-          .replace(`<w:r><w:t>${originalText}</w:t></w:r>`, reviewedRuns),
-      );
+      const rewrittenPart = (await file.async("text"))
+        .replace(` w14:paraId="${paraId}"`, "")
+        .replace(`<w:r><w:t>${originalText}</w:t></w:r>`, reviewedRuns);
+      expect(rewrittenPart).not.toContain(`w14:paraId="${paraId}"`);
+      expect(rewrittenPart).not.toContain(`<w:r><w:t>${originalText}</w:t></w:r>`);
+      zip.file(part, rewrittenPart);
       const reviewer = await FolioDocxReviewer.fromBuffer(
         await zip.generateAsync({ type: "arraybuffer" }),
       );
@@ -2769,10 +2769,12 @@ describe("headless docx review notes read surface", () => {
         throw new Error(`fixture missing ${part}`);
       }
       const notesXml = await notesFile.async("text");
-      zip.file(
-        part,
-        removedParaId === null ? notesXml : notesXml.replace(` w14:paraId="${removedParaId}"`, ""),
-      );
+      const rewrittenNotesXml =
+        removedParaId === null ? notesXml : notesXml.replace(` w14:paraId="${removedParaId}"`, "");
+      if (removedParaId !== null) {
+        expect(rewrittenNotesXml).not.toContain(`w14:paraId="${removedParaId}"`);
+      }
+      zip.file(part, rewrittenNotesXml);
       const reviewer = await FolioDocxReviewer.fromBuffer(
         await zip.generateAsync({ type: "arraybuffer" }),
       );

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -1640,6 +1640,61 @@ describe("headless docx review round-trip", () => {
     );
   });
 
+  test.each([
+    {
+      story: { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const,
+      part: "word/header1.xml",
+      originalText: "Header text",
+      paraId: "A1000001",
+    },
+    {
+      story: { type: "footer", relationshipId: FOOTER_RELATIONSHIP_ID } as const,
+      part: "word/footer1.xml",
+      originalText: "Footer text",
+      paraId: "A1000002",
+    },
+  ])(
+    "persists insertion, deletion, and move resolution in a paraId-less $story.type",
+    async ({ story, part, originalText, paraId }) => {
+      const zip = await JSZip.loadAsync(await makeHeaderFooterBaseline());
+      const file = zip.file(part);
+      if (!file) {
+        throw new Error(`fixture missing ${part}`);
+      }
+      const reviewedRuns =
+        '<w:r><w:t xml:space="preserve">Kept </w:t></w:r>' +
+        '<w:ins w:id="41" w:author="Reviewer"><w:r><w:t xml:space="preserve">INSERTED </w:t></w:r></w:ins>' +
+        '<w:del w:id="42" w:author="Reviewer"><w:r><w:delText xml:space="preserve">DELETED </w:delText></w:r></w:del>' +
+        '<w:moveFrom w:id="43" w:author="Reviewer"><w:r><w:t xml:space="preserve">MOVED FROM </w:t></w:r></w:moveFrom>' +
+        '<w:moveTo w:id="44" w:author="Reviewer"><w:r><w:t>MOVED TO</w:t></w:r></w:moveTo>';
+      zip.file(
+        part,
+        (await file.async("text"))
+          .replace(` w14:paraId="${paraId}"`, "")
+          .replace(`<w:r><w:t>${originalText}</w:t></w:r>`, reviewedRuns),
+      );
+      const reviewer = await FolioDocxReviewer.fromBuffer(
+        await zip.generateAsync({ type: "arraybuffer" }),
+      );
+
+      expect(reviewer.readReviewedStory({ story, view: "final" })?.text).toEndWith(
+        "Kept INSERTED MOVED TO",
+      );
+      expect(reviewer.resolveReviewedStory({ story, view: "final" })).toBe(true);
+
+      const saved = await reviewer.toBuffer();
+      const xml = await partText(saved, part);
+      expect(xml).toContain("Kept INSERTED MOVED TO");
+      expect(xml).not.toContain("DELETED");
+      expect(xml).not.toContain("MOVED FROM");
+      expect(xml).not.toMatch(/<w:(?:ins|del|moveFrom|moveTo)\b/u);
+
+      const reopened = await FolioDocxReviewer.fromBuffer(saved);
+      expect(reopened.readReviewedStory({ story, view: "current-markup" })?.changes).toEqual([]);
+      expect(reopened.readStory(story)?.text).toBe("Kept INSERTED MOVED TO");
+    },
+  );
+
   test("rejects a missing editable story before applying operations", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(await makeHeaderFooterBaseline());
     const story = { type: "header", relationshipId: "missing" } as const;
@@ -2519,6 +2574,33 @@ describe("headless docx review annotated read surface", () => {
     expect(reviewer.getContentAsText()).toContain("Intro paragraph.");
   });
 
+  test("persists a resolved final main story and reopens with no revisions", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await makeParaIdBaseline(readFixture()), {
+      author: "Reviewer",
+    });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    reviewer.applyOperations([
+      {
+        id: "final-main-replace",
+        type: "replaceInBlock",
+        blockId: target.id,
+        find: "Heading",
+        replace: "Intro",
+      },
+    ]);
+
+    expect(reviewer.resolveReviewedStory({ view: "final" })).toBe(true);
+    const saved = await reviewer.toBuffer();
+    const documentXml = await partText(saved, "word/document.xml");
+    expect(documentXml).toContain("Intro paragraph.");
+    expect(documentXml).not.toContain("Heading paragraph.");
+    expect(documentXml).not.toMatch(/<w:(?:ins|del|moveFrom|moveTo)\b/u);
+
+    const reopened = await FolioDocxReviewer.fromBuffer(saved);
+    expect(reopened.readReviewedStory({ view: "current-markup" })?.changes).toEqual([]);
+    expect(reopened.getContentAsText()).toContain("Intro paragraph.");
+  });
+
   test("rejects an unsupported reviewed view at the public boundary", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(await makeParaIdBaseline(readFixture()));
     expect(() =>
@@ -2621,13 +2703,13 @@ const readRichNotesFixture = async (): Promise<ArrayBuffer> => {
           <w:r><w:fldChar w:fldCharType="end"/></w:r>
           <w:sdt><w:sdtPr/><w:sdtContent><w:r><w:t>SDT.</w:t></w:r></w:sdtContent></w:sdt>
         </w:p>
-        <w:tbl><w:tr><w:tc><w:p><w:r><w:t>TABLE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
+        <w:tbl><w:tr><w:tc><w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
       </w:footnote>`,
     ),
   );
   zip.file(
     "word/endnotes.xml",
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="B2000002"><w:r><w:t xml:space="preserve">Endnote </w:t></w:r><w:ins w:id="5" w:author="Reviewer"><w:r><w:t>INSERTED</w:t></w:r></w:ins><w:del w:id="6" w:author="Reviewer"><w:r><w:delText>DELETED</w:delText></w:r></w:del></w:p><w:tbl><w:tr><w:tc><w:p><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:endnote></w:endnotes>',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="B2000002"><w:r><w:t xml:space="preserve">Endnote </w:t></w:r><w:ins w:id="5" w:author="Reviewer"><w:r><w:t>INSERTED</w:t></w:r></w:ins><w:del w:id="6" w:author="Reviewer"><w:r><w:delText>DELETED</w:delText></w:r></w:del><w:moveFrom w:id="7" w:author="Reviewer"><w:r><w:t xml:space="preserve"> MOVED FROM </w:t></w:r></w:moveFrom><w:moveTo w:id="8" w:author="Reviewer"><w:r><w:t xml:space="preserve"> MOVED TO </w:t></w:r></w:moveTo></w:p><w:tbl><w:tr><w:tc><w:p w:rsidR="E00D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:endnote></w:endnotes>',
   );
   return zip.generateAsync({ type: "arraybuffer" });
 };
@@ -2641,9 +2723,130 @@ describe("headless docx review notes read surface", () => {
 
     expect(footnote?.text).toBe("See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT. TABLE CELL");
     expect(reviewer.readStory({ type: "endnote", noteId: 3 })?.text).toBe(
-      "Endnote INSERTED ENDNOTE CELL",
+      "Endnote INSERTED MOVED TO ENDNOTE CELL",
     );
   });
+
+  test.each([
+    {
+      story: { type: "footnote", noteId: 2 } as const,
+      part: "word/footnotes.xml",
+      removedParaId: "B2000001",
+      idProfile: "without paragraph ids",
+      expectedText: "See INSERTED MOVED TO LINK SDT.TABLE CELL",
+      preservedParagraph: '<w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
+    },
+    {
+      story: { type: "endnote", noteId: 3 } as const,
+      part: "word/endnotes.xml",
+      removedParaId: "B2000002",
+      idProfile: "without paragraph ids",
+      expectedText: "Endnote INSERTED MOVED TO ENDNOTE CELL",
+      preservedParagraph: '<w:p w:rsidR="E00D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p>',
+    },
+    {
+      story: { type: "footnote", noteId: 2 } as const,
+      part: "word/footnotes.xml",
+      removedParaId: null,
+      idProfile: "with paragraph ids",
+      expectedText: "See INSERTED MOVED TO LINK SDT.TABLE CELL",
+      preservedParagraph: '<w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
+    },
+    {
+      story: { type: "endnote", noteId: 3 } as const,
+      part: "word/endnotes.xml",
+      removedParaId: null,
+      idProfile: "with paragraph ids",
+      expectedText: "Endnote INSERTED MOVED TO ENDNOTE CELL",
+      preservedParagraph: '<w:p w:rsidR="E00D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p>',
+    },
+  ])(
+    "persists a resolved final $story.type $idProfile",
+    async ({ story, part, removedParaId, expectedText, preservedParagraph }) => {
+      const zip = await JSZip.loadAsync(await readRichNotesFixture());
+      const notesFile = zip.file(part);
+      if (!notesFile) {
+        throw new Error(`fixture missing ${part}`);
+      }
+      const notesXml = await notesFile.async("text");
+      zip.file(
+        part,
+        removedParaId === null ? notesXml : notesXml.replace(` w14:paraId="${removedParaId}"`, ""),
+      );
+      const reviewer = await FolioDocxReviewer.fromBuffer(
+        await zip.generateAsync({ type: "arraybuffer" }),
+      );
+
+      expect(reviewer.resolveReviewedStory({ story, view: "final" })).toBe(true);
+      expect(reviewer.readReviewedStory({ story, view: "current-markup" })?.changes).toEqual([]);
+
+      const saved = await reviewer.toBuffer();
+      const savedNotesXml = await partText(saved, part);
+      expect(savedNotesXml).toContain("INSERTED");
+      expect(savedNotesXml).not.toContain("DELETED");
+      expect(savedNotesXml).not.toContain("MOVED FROM");
+      expect(savedNotesXml).not.toContain("<w:ins ");
+      expect(savedNotesXml).not.toContain("<w:del ");
+      expect(savedNotesXml).not.toContain("<w:moveFrom ");
+      expect(savedNotesXml).not.toContain("<w:moveTo ");
+      expect(savedNotesXml).toContain(preservedParagraph);
+
+      const reopened = await FolioDocxReviewer.fromBuffer(saved);
+      expect(reopened.readReviewedStory({ story, view: "current-markup" })?.changes).toEqual([]);
+      expect(reopened.readStory(story)?.text).toBe(expectedText);
+    },
+  );
+
+  test.each([
+    {
+      story: { type: "footnote", noteId: 2 } as const,
+      part: "word/footnotes.xml",
+      element: "footnote",
+      article: "a",
+    },
+    {
+      story: { type: "endnote", noteId: 3 } as const,
+      part: "word/endnotes.xml",
+      element: "endnote",
+      article: "an",
+    },
+  ])(
+    "persists a resolved paragraph-break deletion in $article $story.type",
+    async ({ story, part, element }) => {
+      const zip = await JSZip.loadAsync(await readNotesFixture());
+      const notesFile = zip.file(part);
+      if (!notesFile) {
+        throw new Error(`fixture missing ${part}`);
+      }
+      const notesXml = await notesFile.async("text");
+      zip.file(
+        part,
+        notesXml.replace(
+          new RegExp(`<w:${element} w:id="${story.noteId}">.*?</w:${element}>`, "u"),
+          `<w:${element} w:id="${story.noteId}"><w:p><w:pPr><w:rPr><w:del w:id="50" w:author="Reviewer"/></w:rPr></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>First</w:t></w:r></w:p><w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Second</w:t></w:r></w:p></w:${element}>`,
+        ),
+      );
+      const reviewer = await FolioDocxReviewer.fromBuffer(
+        await zip.generateAsync({ type: "arraybuffer" }),
+      );
+
+      expect(reviewer.resolveReviewedStory({ story, view: "final" })).toBe(true);
+      const saved = await reviewer.toBuffer();
+      const reopened = await FolioDocxReviewer.fromBuffer(saved);
+      const reviewed = reopened.readReviewedStory({ story, view: "current-markup" });
+      expect(reviewed?.changes).toEqual([]);
+      expect(reopened.readStory(story)?.text).toBe("FirstSecond");
+      expect(reviewed?.snapshot.blocks).toEqual([
+        expect.objectContaining({
+          text: "FirstSecond",
+          previewRuns: [
+            expect.objectContaining({ text: "First", bold: true }),
+            expect.objectContaining({ text: "Second", italic: true }),
+          ],
+        }),
+      ]);
+    },
+  );
 
   test("edits a footnote through story-scoped document operations", async () => {
     const baseline = await readNotesFixture();

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -2801,6 +2801,62 @@ describe("headless docx review notes read surface", () => {
     {
       story: { type: "footnote", noteId: 2 } as const,
       part: "word/footnotes.xml",
+      prefix: "altw",
+      namespace: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+      expectedText: "See INSERTED MOVED TO LINK SDT.TABLE CELL",
+    },
+    {
+      story: { type: "endnote", noteId: 3 } as const,
+      part: "word/endnotes.xml",
+      prefix: "strict",
+      namespace: "http://purl.oclc.org/ooxml/wordprocessingml/main",
+      expectedText: "Endnote INSERTED MOVED TO ENDNOTE CELL",
+    },
+  ])(
+    "persists a resolved $story.type using the $prefix WordprocessingML prefix",
+    async ({ story, part, prefix, namespace, expectedText }) => {
+      const zip = await JSZip.loadAsync(await readRichNotesFixture());
+      const notesFile = zip.file(part);
+      if (!notesFile) {
+        throw new Error(`fixture missing ${part}`);
+      }
+      const notesXml = (await notesFile.async("text"))
+        .replace(
+          'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"',
+          `xmlns:${prefix}="${namespace}"`,
+        )
+        .replaceAll("<w:", `<${prefix}:`)
+        .replaceAll("</w:", `</${prefix}:`)
+        .replaceAll(" w:", ` ${prefix}:`);
+      zip.file(part, notesXml);
+      const reviewer = await FolioDocxReviewer.fromBuffer(
+        await zip.generateAsync({ type: "arraybuffer" }),
+      );
+
+      expect(reviewer.resolveReviewedStory({ story, view: "final" })).toBe(true);
+      const saved = await reviewer.toBuffer();
+      const savedNotesXml = await partText(saved, part);
+      expect(savedNotesXml).toContain(`xmlns:${prefix}="${namespace}"`);
+      expect(savedNotesXml).toContain(`<${prefix}:${story.type}`);
+      for (const change of ["ins", "del", "moveFrom", "moveTo"]) {
+        const elementStart = `<${prefix}:${change}`;
+        expect(
+          savedNotesXml.includes(`${elementStart} `) ||
+            savedNotesXml.includes(`${elementStart}>`) ||
+            savedNotesXml.includes(`${elementStart}/`),
+        ).toBe(false);
+      }
+
+      const reopened = await FolioDocxReviewer.fromBuffer(saved);
+      expect(reopened.readReviewedStory({ story, view: "current-markup" })?.changes).toEqual([]);
+      expect(reopened.readStory(story)?.text).toBe(expectedText);
+    },
+  );
+
+  test.each([
+    {
+      story: { type: "footnote", noteId: 2 } as const,
+      part: "word/footnotes.xml",
       element: "footnote",
       article: "a",
     },
@@ -2819,13 +2875,15 @@ describe("headless docx review notes read surface", () => {
         throw new Error(`fixture missing ${part}`);
       }
       const notesXml = await notesFile.async("text");
-      zip.file(
-        part,
-        notesXml.replace(
-          new RegExp(`<w:${element} w:id="${story.noteId}">.*?</w:${element}>`, "u"),
-          `<w:${element} w:id="${story.noteId}"><w:p><w:pPr><w:rPr><w:del w:id="50" w:author="Reviewer"/></w:rPr></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>First</w:t></w:r></w:p><w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Second</w:t></w:r></w:p></w:${element}>`,
-        ),
-      );
+      const noteOpen = `<w:${element} w:id="${story.noteId}">`;
+      const noteClose = `</w:${element}>`;
+      const noteStart = notesXml.indexOf(noteOpen);
+      const noteEnd = notesXml.indexOf(noteClose, noteStart) + noteClose.length;
+      if (noteStart < 0 || noteEnd < noteClose.length) {
+        throw new Error(`fixture missing ${element} ${story.noteId}`);
+      }
+      const replacement = `<w:${element} w:id="${story.noteId}"><w:p><w:pPr><w:rPr><w:del w:id="50" w:author="Reviewer"/></w:rPr></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>First</w:t></w:r></w:p><w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Second</w:t></w:r></w:p></w:${element}>`;
+      zip.file(part, notesXml.slice(0, noteStart) + replacement + notesXml.slice(noteEnd));
       const reviewer = await FolioDocxReviewer.fromBuffer(
         await zip.generateAsync({ type: "arraybuffer" }),
       );

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -272,6 +272,16 @@ export class FolioDocumentStoryNotFoundError extends TaggedError(
   story: FolioEditableDocumentStoryHandle;
 }> {}
 
+class FolioResolvedStorySerializationError extends TaggedError(
+  "FolioResolvedStorySerializationError",
+)<{
+  message: string;
+  story: FolioEditableDocumentStoryHandle;
+  expectedText: string;
+  actualText: string | null;
+  remainingChangeCount: number | null;
+}> {}
+
 export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOperationsOptions & {
   story: FolioEditableDocumentStoryHandle;
   batch: FolioDocumentOperationBatch;
@@ -295,6 +305,12 @@ type FolioSecondaryStoryState = {
   state: EditorState;
 };
 
+type FolioResolvedStoryExpectation = {
+  story: FolioEditableDocumentStoryHandle;
+  text: string;
+  blocks: FolioAIBlock[];
+};
+
 type ApplyDocumentOperationsInternalOptions = {
   story: FolioEditableDocumentStoryHandle;
   batch: FolioDocumentOperationBatch;
@@ -313,6 +329,9 @@ const secondaryStoryKey = (story: FolioSecondaryStoryHandle): string =>
   story.type === "header" || story.type === "footer"
     ? headerFooterStoryKey(story)
     : noteStoryKey(story);
+
+const editableStoryKey = (story: FolioEditableDocumentStoryHandle): string =>
+  story.type === "main" ? "main" : secondaryStoryKey(story);
 
 export const isFolioReviewedView = (value: unknown): value is FolioReviewedView =>
   FOLIO_REVIEWED_VIEWS.some((view) => view === value);
@@ -473,6 +492,7 @@ export class FolioDocxReviewer {
   private readonly originalBuffer: ArrayBuffer;
   private state: EditorState;
   private readonly secondaryStoryStates = new Map<string, FolioSecondaryStoryState>();
+  private readonly resolvedStoryExpectations = new Map<string, FolioResolvedStoryExpectation>();
   private readonly createdComments: Comment[] = [];
   private readonly documentOperationUndoEntries: FolioDocumentOperationUndoEntry[] = [];
   /**
@@ -605,7 +625,13 @@ export class FolioDocxReviewer {
     if (!sourceState) {
       return false;
     }
-    this.setEditableStoryState(story, resolveReviewedState(sourceState, view));
+    const resolvedState = resolveReviewedState(sourceState, view);
+    this.setEditableStoryState(story, resolvedState);
+    this.resolvedStoryExpectations.set(editableStoryKey(story), {
+      story,
+      text: formatStoryStateForLLM(resolvedState, false),
+      blocks: createFolioAIEditSnapshot(resolvedState.doc).blocks,
+    });
     return true;
   }
 
@@ -1073,9 +1099,56 @@ export class FolioDocxReviewer {
     const document = this.toDocument();
     const selective = await this.trySelectiveSave(document);
     if (selective) {
+      await this.assertResolvedStoriesSerialized(selective);
       return selective;
     }
-    return repackDocx({ ...document, originalBuffer: this.originalBuffer });
+    const buffer = await repackDocx(
+      { ...document, originalBuffer: this.originalBuffer },
+      { changedNoteParaIds: this.getChangedNoteParaIds() },
+    );
+    await this.assertResolvedStoriesSerialized(buffer);
+    return buffer;
+  }
+
+  private async assertResolvedStoriesSerialized(buffer: ArrayBuffer): Promise<void> {
+    if (this.resolvedStoryExpectations.size === 0) {
+      return;
+    }
+    const reopened = await FolioDocxReviewer.fromBuffer(buffer);
+    for (const { story, text, blocks } of this.resolvedStoryExpectations.values()) {
+      const serialized = reopened.readReviewedStory({ story, view: "current-markup" });
+      const serializedState = reopened.getEditableStoryState(story);
+      if (
+        serialized &&
+        serializedState &&
+        serialized.changes.length === 0 &&
+        serialized.text === text &&
+        JSON.stringify(createFolioAIEditSnapshot(serializedState.doc).blocks) ===
+          JSON.stringify(blocks)
+      ) {
+        continue;
+      }
+      throw new FolioResolvedStorySerializationError({
+        message: "Resolved document story did not persist to the serialized DOCX.",
+        story,
+        expectedText: text,
+        actualText: serialized?.text ?? null,
+        remainingChangeCount: serialized?.changes.length ?? null,
+      });
+    }
+  }
+
+  private getChangedNoteParaIds(): Set<string> {
+    const changed = new Set<string>();
+    for (const entry of this.secondaryStoryStates.values()) {
+      if (entry.handle.type !== "footnote" && entry.handle.type !== "endnote") {
+        continue;
+      }
+      for (const paraId of getChangedParagraphIds(entry.state)) {
+        changed.add(paraId);
+      }
+    }
+    return changed;
   }
 
   /**
@@ -1160,6 +1233,7 @@ export class FolioDocxReviewer {
   }
 
   private setEditableStoryState(story: FolioEditableDocumentStoryHandle, state: EditorState): void {
+    this.resolvedStoryExpectations.delete(editableStoryKey(story));
     if (story.type === "main") {
       this.state = state;
       return;
@@ -1302,6 +1376,7 @@ export class FolioDocxReviewer {
    * resulting state for {@link toBuffer}.
    */
   private runCommand(command: Command): boolean {
+    this.resolvedStoryExpectations.delete("main");
     const view = {
       state: this.state,
       dispatch: (transaction: Transaction) => {

--- a/packages/core/src/docx/noteSave.test.ts
+++ b/packages/core/src/docx/noteSave.test.ts
@@ -377,10 +377,9 @@ describe("footnote / endnote body write path (full repack)", () => {
 
   test("raw repack persists an edited paraId-less footnote", async () => {
     const sourceZip = await JSZip.loadAsync(await createNotesFixture());
-    sourceZip.file(
-      "word/footnotes.xml",
-      footnotesXml.replace(` w14:paraId="${FOOTNOTE_PARA_ID}"`, ""),
-    );
+    const paraIdLessFootnotesXml = footnotesXml.replace(` w14:paraId="${FOOTNOTE_PARA_ID}"`, "");
+    expect(paraIdLessFootnotesXml).not.toContain(`w14:paraId="${FOOTNOTE_PARA_ID}"`);
+    sourceZip.file("word/footnotes.xml", paraIdLessFootnotesXml);
     const source = await sourceZip.generateAsync({ type: "arraybuffer" });
     const doc = await parseDocx(source, { preloadFonts: false });
     const footnote = doc.package.footnotes?.[0];
@@ -403,6 +402,36 @@ describe("footnote / endnote body write path (full repack)", () => {
 
     expect(noteBodyText(reparsed.package.footnotes?.[0])).toBe(editedText);
     expect(await readPart(result, "word/footnotes.xml")).toContain(FOOTNOTE_SEPARATORS);
+  });
+
+  test("raw repack ignores a dirty paragraph id removed by a note merge", async () => {
+    const removedParaId = "F1000002";
+    const twoParagraphFootnotesXml = footnotesXml.replace(
+      "</w:p></w:footnote></w:footnotes>",
+      `</w:p><w:p w14:paraId="${removedParaId}"><w:r><w:t>Second paragraph</w:t></w:r></w:p></w:footnote></w:footnotes>`,
+    );
+    expect(twoParagraphFootnotesXml).toContain(`w14:paraId="${removedParaId}"`);
+    const sourceZip = await JSZip.loadAsync(await createNotesFixture());
+    sourceZip.file("word/footnotes.xml", twoParagraphFootnotesXml);
+    const source = await sourceZip.generateAsync({ type: "arraybuffer" });
+    const doc = await parseDocx(source, { preloadFonts: false });
+    const footnote = doc.package.footnotes?.at(0);
+    if (!footnote) {
+      throw new Error("expected a parsed footnote");
+    }
+    expect(footnote.content).toHaveLength(2);
+    setFirstNoteText(footnote, "Merged paragraphs");
+    footnote.content.splice(1, 1);
+
+    const result = await repackDocxFromRaw(doc, await unzipDocx(source), {
+      changedNoteParaIds: new Set([FOOTNOTE_PARA_ID, removedParaId]),
+    });
+    const savedFootnotesXml = await readPart(result, "word/footnotes.xml");
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+
+    expect(noteBodyText(reparsed.package.footnotes?.at(0))).toBe("Merged paragraphs");
+    expect(reparsed.package.footnotes?.at(0)?.content).toHaveLength(1);
+    expect(savedFootnotesXml).not.toContain(`w14:paraId="${removedParaId}"`);
   });
 
   test("a repack with no note edit leaves both note parts byte-exact", async () => {

--- a/packages/core/src/docx/noteSave.test.ts
+++ b/packages/core/src/docx/noteSave.test.ts
@@ -18,8 +18,9 @@ import JSZip from "jszip";
 import type { Endnote, Footnote } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { createDocx, repackDocx } from "./rezip";
+import { createDocx, repackDocx, repackDocxFromRaw } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
+import { unzipDocx } from "./unzip";
 import { createEmptyDocument } from "../utils/createDocument";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
@@ -372,6 +373,36 @@ describe("footnote / endnote body write path (full repack)", () => {
     expect(savedEndnotesXml).toContain(ENDNOTE_SEPARATORS);
     expect(savedEndnotesXml).toContain(editedText);
     expect(savedEndnotesXml).not.toContain(ORIGINAL_ENDNOTE_TEXT);
+  });
+
+  test("raw repack persists an edited paraId-less footnote", async () => {
+    const sourceZip = await JSZip.loadAsync(await createNotesFixture());
+    sourceZip.file(
+      "word/footnotes.xml",
+      footnotesXml.replace(` w14:paraId="${FOOTNOTE_PARA_ID}"`, ""),
+    );
+    const source = await sourceZip.generateAsync({ type: "arraybuffer" });
+    const doc = await parseDocx(source, { preloadFonts: false });
+    const footnote = doc.package.footnotes?.[0];
+    if (!footnote) {
+      throw new Error("expected a parsed footnote");
+    }
+    const paragraph = footnote.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("expected a footnote paragraph");
+    }
+    const generatedParaId = "F2000001";
+    paragraph.paraId = generatedParaId;
+    const editedText = "Edited paraId-less footnote via raw repack";
+    setFirstNoteText(footnote, editedText);
+
+    const result = await repackDocxFromRaw(doc, await unzipDocx(source), {
+      changedNoteParaIds: new Set([generatedParaId]),
+    });
+    const reparsed = await parseDocx(result, { preloadFonts: false });
+
+    expect(noteBodyText(reparsed.package.footnotes?.[0])).toBe(editedText);
+    expect(await readPart(result, "word/footnotes.xml")).toContain(FOOTNOTE_SEPARATORS);
   });
 
   test("a repack with no note edit leaves both note parts byte-exact", async () => {

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -53,8 +53,7 @@ import { parseNumbering } from "./numberingParser";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import {
   appendNumberingDefs,
-  buildParagraphOffsetIndex,
-  buildPatchedNoteXml,
+  buildPatchedNotePartXml,
   buildPatchedNumberingXml,
   collectAddedNumberingDefs,
   collectChangedNumberingDefs,
@@ -761,6 +760,8 @@ export type RepackOptions = {
   updateModifiedDate?: boolean;
   /** Custom modifier name for lastModifiedBy */
   modifiedBy?: string;
+  /** Changed note paragraphs that must be serialized even without source paraIds. */
+  changedNoteParaIds?: ReadonlySet<string>;
 };
 
 const generateDocxZip = (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> =>
@@ -822,6 +823,7 @@ type FinishRepackOptions = {
   compressionLevel: number;
   updateModifiedDate: boolean;
   modifiedBy?: string;
+  changedNoteParaIds?: ReadonlySet<string>;
 };
 
 const finishRepack = async ({
@@ -833,6 +835,7 @@ const finishRepack = async ({
   compressionLevel,
   updateModifiedDate,
   modifiedBy,
+  changedNoteParaIds,
 }: FinishRepackOptions): Promise<ArrayBuffer> => {
   await materializeNewHeaderFooterParts(document, outputZip, compressionLevel);
 
@@ -857,7 +860,7 @@ const finishRepack = async ({
 
   serializeHeadersFootersToZip(document, outputZip, compressionLevel);
 
-  await serializeNotesToZip(document, originalZip, outputZip, compressionLevel);
+  await serializeNotesToZip(document, originalZip, outputZip, compressionLevel, changedNoteParaIds);
 
   await serializeNumberingIntoZip(document, originalZip, outputZip, compressionLevel);
   await serializeAddedStylesIntoZip(document, originalZip, outputZip, compressionLevel);
@@ -896,7 +899,12 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
     );
   }
 
-  const { compressionLevel = 6, updateModifiedDate = true, modifiedBy } = options;
+  const {
+    compressionLevel = 6,
+    updateModifiedDate = true,
+    modifiedBy,
+    changedNoteParaIds,
+  } = options;
   const exportDocument = withoutOrphanCommentRanges(doc);
 
   // Load the original ZIP
@@ -918,6 +926,7 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
     compressionLevel,
     updateModifiedDate,
     ...(modifiedBy !== undefined ? { modifiedBy } : {}),
+    ...(changedNoteParaIds !== undefined ? { changedNoteParaIds } : {}),
   });
 }
 
@@ -1834,6 +1843,7 @@ async function serializeNotesToZip(
   originalZip: JSZip,
   newZip: JSZip,
   compressionLevel: number,
+  changedNoteParaIds?: ReadonlySet<string>,
 ): Promise<void> {
   const footnotes = doc.package.footnotes ?? [];
   if (footnotes.length > 0) {
@@ -1841,7 +1851,10 @@ async function serializeNotesToZip(
       await patchNotePartIntoZip(
         "word/footnotes.xml",
         serializeFootnotes(footnotes),
+        serializeNewFootnotesPart(footnotes),
         (xml) => serializeFootnotes(parseFootnotes(xml).getNormalFootnotes()),
+        "footnote",
+        changedNoteParaIds,
         originalZip,
         newZip,
         compressionLevel,
@@ -1863,7 +1876,10 @@ async function serializeNotesToZip(
       await patchNotePartIntoZip(
         "word/endnotes.xml",
         serializeEndnotes(endnotes),
+        serializeNewEndnotesPart(endnotes),
         (xml) => serializeEndnotes(parseEndnotes(xml).getNormalEndnotes()),
+        "endnote",
+        changedNoteParaIds,
         originalZip,
         newZip,
         compressionLevel,
@@ -2073,7 +2089,10 @@ async function serializeAddedStylesIntoZip(
 async function patchNotePartIntoZip(
   conventionalLowerPath: string,
   currentXml: string,
+  replacementXml: string,
   baselineFrom: (originalXml: string) => string,
+  elementName: "footnote" | "endnote",
+  changedNoteParaIds: ReadonlySet<string> | undefined,
   originalZip: JSZip,
   newZip: JSZip,
   compressionLevel: number,
@@ -2083,54 +2102,37 @@ async function patchNotePartIntoZip(
     return;
   }
   const originalXml = await file.async("text");
-  const changedIds = collectChangedNoteParaIds(baselineFrom(originalXml), currentXml);
-  if (changedIds.size === 0) {
+  const baselineXml = baselineFrom(originalXml);
+  const patched = buildPatchedNotePartXml({
+    originalXml,
+    baselineXml,
+    serializedXml: currentXml,
+    replacementXml,
+    elementName,
+    ...(changedNoteParaIds !== undefined ? { changedParaIds: changedNoteParaIds } : {}),
+  });
+  const currentParaIds = collectParaIds(currentXml);
+  const baselineParaIds = collectParaIds(baselineXml);
+  const hasDirtyParagraph =
+    changedNoteParaIds !== undefined &&
+    [...changedNoteParaIds].some(
+      (paraId) => currentParaIds.has(paraId) || baselineParaIds.has(paraId),
+    );
+  if (patched === null || (hasDirtyParagraph && patched === originalXml)) {
+    if (hasDirtyParagraph) {
+      throw new DocxPackageFidelityError(
+        `Cannot serialize changed ${elementName} paragraphs into ${file.name}`,
+      );
+    }
     return;
   }
-  // Splice the edited paragraphs into the ORIGINAL bytes (not the baseline), so
-  // unedited notes keep their verbatim markup.
-  const patched = buildPatchedNoteXml(originalXml, currentXml, changedIds);
-  if (patched === null) {
+  if (patched === originalXml) {
     return;
   }
   newZip.file(file.name, patched, {
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
-}
-
-/**
- * The note paragraphs whose current serialization differs from the baseline
- * (re-parsed original) serialization — i.e. the ones actually edited. A
- * paragraph is only considered when its `paraId` resolves uniquely in both,
- * so it can be spliced safely.
- *
- * Builds one {@link buildParagraphOffsetIndex} per side (a single linear scan
- * each) instead of calling `extractParagraphXml` per candidate id, which
- * re-scanned the whole XML per id — O(note count * XML size) for a document
- * with many footnotes/endnotes. The index turns each lookup below into O(1).
- */
-function collectChangedNoteParaIds(baselineXml: string, currentXml: string): Set<string> {
-  const changed = new Set<string>();
-  const baselineIds = collectParaIds(baselineXml);
-  const baselineOffsets = buildParagraphOffsetIndex(baselineXml);
-  const currentOffsets = buildParagraphOffsetIndex(currentXml);
-  for (const [id, count] of collectParaIds(currentXml)) {
-    if (count !== 1 || baselineIds.get(id) !== 1) {
-      continue;
-    }
-    const beforeRange = baselineOffsets.get(id);
-    const afterRange = currentOffsets.get(id);
-    if (!beforeRange || !afterRange) {
-      continue;
-    }
-    const before = baselineXml.slice(beforeRange.start, beforeRange.end);
-    const after = currentXml.slice(afterRange.start, afterRange.end);
-    if (before !== after) {
-      changed.add(id);
-    }
-  }
-  return changed;
 }
 
 /** `word/Footnotes.xml` -> `word/_rels/Footnotes.xml.rels` (casing preserved). */

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -56,6 +56,7 @@ import {
   buildPatchedNotePartXml,
   buildPatchedNumberingXml,
   collectAddedNumberingDefs,
+  collectChangedNoteParaIds,
   collectChangedNumberingDefs,
   collectParaIds,
 } from "./selectiveXmlPatch";
@@ -943,7 +944,12 @@ export async function repackDocxFromRaw(
   rawContent: RawDocxContent,
   options: RepackOptions = {},
 ): Promise<ArrayBuffer> {
-  const { compressionLevel = 6, updateModifiedDate = true, modifiedBy } = options;
+  const {
+    compressionLevel = 6,
+    updateModifiedDate = true,
+    modifiedBy,
+    changedNoteParaIds,
+  } = options;
   const exportDocument = withoutOrphanCommentRanges(doc);
 
   // Create a new ZIP with all original files
@@ -1006,7 +1012,13 @@ export async function repackDocxFromRaw(
 
   // Splice edited footnote/endnote bodies back into their parts (separators and
   // unedited notes stay byte-exact).
-  await serializeNotesToZip(exportDocument, rawContent.originalZip, newZip, compressionLevel);
+  await serializeNotesToZip(
+    exportDocument,
+    rawContent.originalZip,
+    newZip,
+    compressionLevel,
+    changedNoteParaIds,
+  );
 
   // Splice edited numbering definitions back into word/numbering.xml (untouched
   // definitions and the parts the model omits stay byte-exact).
@@ -2103,21 +2115,21 @@ async function patchNotePartIntoZip(
   }
   const originalXml = await file.async("text");
   const baselineXml = baselineFrom(originalXml);
+  const effectiveChangedNoteParaIds =
+    changedNoteParaIds ?? collectChangedNoteParaIds(baselineXml, currentXml);
   const patched = buildPatchedNotePartXml({
     originalXml,
     baselineXml,
     serializedXml: currentXml,
     replacementXml,
     elementName,
-    ...(changedNoteParaIds !== undefined ? { changedParaIds: changedNoteParaIds } : {}),
+    changedParaIds: effectiveChangedNoteParaIds,
   });
   const currentParaIds = collectParaIds(currentXml);
   const baselineParaIds = collectParaIds(baselineXml);
-  const hasDirtyParagraph =
-    changedNoteParaIds !== undefined &&
-    [...changedNoteParaIds].some(
-      (paraId) => currentParaIds.has(paraId) || baselineParaIds.has(paraId),
-    );
+  const hasDirtyParagraph = [...effectiveChangedNoteParaIds].some(
+    (paraId) => currentParaIds.has(paraId) || baselineParaIds.has(paraId),
+  );
   if (patched === null || (hasDirtyParagraph && patched === originalXml)) {
     if (hasDirtyParagraph) {
       throw new DocxPackageFidelityError(

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -861,7 +861,13 @@ const finishRepack = async ({
 
   serializeHeadersFootersToZip(document, outputZip, compressionLevel);
 
-  await serializeNotesToZip(document, originalZip, outputZip, compressionLevel, changedNoteParaIds);
+  await serializeNotesToZip({
+    doc: document,
+    originalZip,
+    newZip: outputZip,
+    compressionLevel,
+    changedNoteParaIds,
+  });
 
   await serializeNumberingIntoZip(document, originalZip, outputZip, compressionLevel);
   await serializeAddedStylesIntoZip(document, originalZip, outputZip, compressionLevel);
@@ -1012,13 +1018,13 @@ export async function repackDocxFromRaw(
 
   // Splice edited footnote/endnote bodies back into their parts (separators and
   // unedited notes stay byte-exact).
-  await serializeNotesToZip(
-    exportDocument,
-    rawContent.originalZip,
+  await serializeNotesToZip({
+    doc: exportDocument,
+    originalZip: rawContent.originalZip,
     newZip,
     compressionLevel,
     changedNoteParaIds,
-  );
+  });
 
   // Splice edited numbering definitions back into word/numbering.xml (untouched
   // definitions and the parts the model omits stay byte-exact).
@@ -1850,27 +1856,35 @@ function serializeHeadersFootersToZip(doc: Document, zip: JSZip, compressionLeve
  * matches its baseline and is left verbatim (mark intact); only a genuine body
  * edit differs and is spliced.
  */
-async function serializeNotesToZip(
-  doc: Document,
-  originalZip: JSZip,
-  newZip: JSZip,
-  compressionLevel: number,
-  changedNoteParaIds?: ReadonlySet<string>,
-): Promise<void> {
+type SerializeNotesToZipOptions = {
+  doc: Document;
+  originalZip: JSZip;
+  newZip: JSZip;
+  compressionLevel: number;
+  changedNoteParaIds: ReadonlySet<string> | undefined;
+};
+
+async function serializeNotesToZip({
+  doc,
+  originalZip,
+  newZip,
+  compressionLevel,
+  changedNoteParaIds,
+}: SerializeNotesToZipOptions): Promise<void> {
   const footnotes = doc.package.footnotes ?? [];
   if (footnotes.length > 0) {
     if (findNotePartEntry(originalZip, "word/footnotes.xml")) {
-      await patchNotePartIntoZip(
-        "word/footnotes.xml",
-        serializeFootnotes(footnotes),
-        serializeNewFootnotesPart(footnotes),
-        (xml) => serializeFootnotes(parseFootnotes(xml).getNormalFootnotes()),
-        "footnote",
+      await patchNotePartIntoZip({
+        conventionalLowerPath: "word/footnotes.xml",
+        currentXml: serializeFootnotes(footnotes),
+        replacementXml: serializeNewFootnotesPart(footnotes),
+        baselineFrom: (xml) => serializeFootnotes(parseFootnotes(xml).getNormalFootnotes()),
+        elementName: "footnote",
         changedNoteParaIds,
         originalZip,
         newZip,
         compressionLevel,
-      );
+      });
     } else {
       await materializeNewNotePart({
         contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml",
@@ -1885,17 +1899,17 @@ async function serializeNotesToZip(
   const endnotes = doc.package.endnotes ?? [];
   if (endnotes.length > 0) {
     if (findNotePartEntry(originalZip, "word/endnotes.xml")) {
-      await patchNotePartIntoZip(
-        "word/endnotes.xml",
-        serializeEndnotes(endnotes),
-        serializeNewEndnotesPart(endnotes),
-        (xml) => serializeEndnotes(parseEndnotes(xml).getNormalEndnotes()),
-        "endnote",
+      await patchNotePartIntoZip({
+        conventionalLowerPath: "word/endnotes.xml",
+        currentXml: serializeEndnotes(endnotes),
+        replacementXml: serializeNewEndnotesPart(endnotes),
+        baselineFrom: (xml) => serializeEndnotes(parseEndnotes(xml).getNormalEndnotes()),
+        elementName: "endnote",
         changedNoteParaIds,
         originalZip,
         newZip,
         compressionLevel,
-      );
+      });
     } else {
       await materializeNewNotePart({
         contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml",
@@ -2098,17 +2112,29 @@ async function serializeAddedStylesIntoZip(
   });
 }
 
-async function patchNotePartIntoZip(
-  conventionalLowerPath: string,
-  currentXml: string,
-  replacementXml: string,
-  baselineFrom: (originalXml: string) => string,
-  elementName: "footnote" | "endnote",
-  changedNoteParaIds: ReadonlySet<string> | undefined,
-  originalZip: JSZip,
-  newZip: JSZip,
-  compressionLevel: number,
-): Promise<void> {
+type PatchNotePartIntoZipOptions = {
+  conventionalLowerPath: string;
+  currentXml: string;
+  replacementXml: string;
+  baselineFrom: (originalXml: string) => string;
+  elementName: "footnote" | "endnote";
+  changedNoteParaIds: ReadonlySet<string> | undefined;
+  originalZip: JSZip;
+  newZip: JSZip;
+  compressionLevel: number;
+};
+
+async function patchNotePartIntoZip({
+  conventionalLowerPath,
+  currentXml,
+  replacementXml,
+  baselineFrom,
+  elementName,
+  changedNoteParaIds,
+  originalZip,
+  newZip,
+  compressionLevel,
+}: PatchNotePartIntoZipOptions): Promise<void> {
   const file = findNotePartEntry(originalZip, conventionalLowerPath);
   if (!file) {
     return;
@@ -2126,9 +2152,8 @@ async function patchNotePartIntoZip(
     changedParaIds: effectiveChangedNoteParaIds,
   });
   const currentParaIds = collectParaIds(currentXml);
-  const baselineParaIds = collectParaIds(baselineXml);
-  const hasDirtyParagraph = [...effectiveChangedNoteParaIds].some(
-    (paraId) => currentParaIds.has(paraId) || baselineParaIds.has(paraId),
+  const hasDirtyParagraph = [...effectiveChangedNoteParaIds].some((paraId) =>
+    currentParaIds.has(paraId),
   );
   if (patched === null || (hasDirtyParagraph && patched === originalXml)) {
     if (hasDirtyParagraph) {

--- a/packages/core/src/docx/selectiveXmlPatch.test.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.test.ts
@@ -10,6 +10,7 @@ import {
   buildParagraphOffsetIndex,
   validatePatchSafety,
   buildPatchedDocumentXml,
+  buildPatchedNotePartXml,
   countParagraphElements,
 } from "./selectiveXmlPatch";
 
@@ -363,5 +364,35 @@ describe("buildPatchedDocumentXml", () => {
     const origAfterBBB = SIMPLE_DOC.slice(SIMPLE_DOC.indexOf('<w:p w14:paraId="CCC333"'));
     const resultAfterBBB = result.slice(result.indexOf('<w:p w14:paraId="CCC333"'));
     expect(resultAfterBBB).toBe(origAfterBBB);
+  });
+});
+
+describe("buildPatchedNotePartXml", () => {
+  test("binds every serializer namespace when patching an alternate-prefix source", () => {
+    const wordNamespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+    const word2010Namespace = "http://schemas.microsoft.com/office/word/2010/wordml";
+    const word2012Namespace = "http://schemas.microsoft.com/office/word/2012/wordml";
+    const compatibilityNamespace = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+    const originalXml = `<alt:footnotes xmlns:alt="${wordNamespace}" xmlns:p14="${word2010Namespace}" xmlns:p15="${word2012Namespace}" xmlns:compat="${compatibilityNamespace}"><alt:footnote alt:id="1"><alt:p p14:paraId="P1000001"><alt:r><alt:t>Old</alt:t></alt:r></alt:p></alt:footnote></alt:footnotes>`;
+    const baselineXml = `<w:footnotes xmlns:w="${wordNamespace}" xmlns:w14="${word2010Namespace}"><w:footnote w:id="1"><w:p w14:paraId="P1000001"><w:r><w:t>Old</w:t></w:r></w:p></w:footnote></w:footnotes>`;
+    const serializedXml = `<w:footnotes xmlns:w="${wordNamespace}" xmlns:w14="${word2010Namespace}"><w:footnote w:id="1"><w:p w14:paraId="P1000001"><w:r><w:t>New</w:t></w:r></w:p></w:footnote></w:footnotes>`;
+    const replacementXml = `<w:footnotes xmlns:w="${wordNamespace}" xmlns:w14="${word2010Namespace}" xmlns:w15="${word2012Namespace}" xmlns:mc="${compatibilityNamespace}"><w:footnote w:id="1"><w:p w14:paraId="P1000001"><mc:AlternateContent><mc:Choice Requires="w15"><w:r w15:collapsed="1"><w:t>New</w:t></w:r></mc:Choice></mc:AlternateContent></w:p></w:footnote></w:footnotes>`;
+
+    const patched = buildPatchedNotePartXml({
+      originalXml,
+      baselineXml,
+      serializedXml,
+      replacementXml,
+      elementName: "footnote",
+      changedParaIds: new Set(["P1000001"]),
+    });
+
+    expect(patched).not.toBeNull();
+    expect(patched).toContain("<alt:p");
+    expect(patched).toContain(`xmlns:w14="${word2010Namespace}"`);
+    expect(patched).toContain(`xmlns:w15="${word2012Namespace}"`);
+    expect(patched).toContain(`xmlns:mc="${compatibilityNamespace}"`);
+    expect(patched).toContain('<mc:Choice Requires="w15">');
+    expect(patched).toContain('<alt:r w15:collapsed="1">');
   });
 });

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -596,11 +596,12 @@ const findNoteElement = (
 type WordPrefixMapping = {
   source: NoteElementSyntax;
   target: NoteElementSyntax;
+  sourceXmlnsDeclarations: Record<string, string>;
 };
 
 const rewriteWordprocessingPrefixes = (
   xml: string,
-  { source, target }: WordPrefixMapping,
+  { source, target, sourceXmlnsDeclarations }: WordPrefixMapping,
 ): string => {
   let rewritten = "";
   let quote: '"' | "'" | null = null;
@@ -641,7 +642,7 @@ const rewriteWordprocessingPrefixes = (
     }
     rewritten += character;
   }
-  return rewritten;
+  return withXmlnsDeclarations(rewritten, sourceXmlnsDeclarations);
 };
 
 const paragraphRanges = (xml: string, wordPrefix: string): ParagraphOffsets[] => {
@@ -734,15 +735,13 @@ export function buildPatchedNotePartXml({
   const currentElements = collectNoteElementSyntax(serializedXml, elementName);
   const originalElements = collectNoteElementSyntax(originalXml, elementName);
   const replacementElements = collectNoteElementSyntax(replacementXml, elementName);
+  const replacementXmlnsDeclarations = collectXmlnsFromOpeningTag(replacementXml);
   const ordinalReplacements: { start: number; end: number; newXml: string }[] = [];
   const serializedParaIds = collectParaIds(serializedXml);
-  const baselineParaIds = collectParaIds(baselineXml);
   const effectiveChangedParaIds =
     changedParaIds ?? collectChangedNoteParaIds(baselineXml, serializedXml);
   const unroutedChangedParaIds = new Set(
-    [...effectiveChangedParaIds].filter(
-      (paraId) => serializedParaIds.has(paraId) || baselineParaIds.has(paraId),
-    ),
+    [...effectiveChangedParaIds].filter((paraId) => serializedParaIds.has(paraId)),
   );
 
   for (const [id, currentSyntaxEntries] of currentElements) {
@@ -790,6 +789,7 @@ export function buildPatchedNotePartXml({
         newXml: rewriteWordprocessingPrefixes(replacementNote, {
           source: replacementSyntax,
           target: originalSyntax,
+          sourceXmlnsDeclarations: replacementXmlnsDeclarations,
         }),
       });
       continue;
@@ -817,7 +817,11 @@ export function buildPatchedNotePartXml({
         end: originalOffsets.start + originalRange.end,
         newXml: rewriteWordprocessingPrefixes(
           replacementNote.slice(replacementRange.start, replacementRange.end),
-          { source: replacementSyntax, target: originalSyntax },
+          {
+            source: replacementSyntax,
+            target: originalSyntax,
+            sourceXmlnsDeclarations: replacementXmlnsDeclarations,
+          },
         ),
       });
     }

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -6,6 +6,16 @@
  * with proper tag depth counting (not regex) to handle nested elements.
  */
 
+import {
+  findAttributeByNamespaceUri,
+  getChildElements,
+  getLocalName,
+  getNamespacePrefix,
+  getNamespaceUri,
+  parseXmlDocument,
+  WORDPROCESSINGML_NAMESPACE_URIS,
+} from "./xmlParser";
+
 /**
  * Whether `char` ends an element's tag name in XML — a whitespace separator
  * (space, tab, CR, or LF, all valid before attributes per XML 1.0 §3.1), the
@@ -520,35 +530,136 @@ function extractElementByIdAttr(
 
 type NoteElementName = "footnote" | "endnote";
 
-const noteElementSyntax = {
-  footnote: {
-    openLiteral: "<w:footnote",
-    closeTag: "</w:footnote>",
-    idAttr: "w:id",
-  },
-  endnote: {
-    openLiteral: "<w:endnote",
-    closeTag: "</w:endnote>",
-    idAttr: "w:id",
-  },
-} as const satisfies Record<
-  NoteElementName,
-  { openLiteral: string; closeTag: string; idAttr: string }
->;
+type NoteElementSyntax = {
+  elementName: string;
+  idAttributeName: string;
+  elementPrefix: string;
+  attributePrefix: string;
+};
 
-const paragraphRanges = (xml: string): ParagraphOffsets[] => {
+const qualifiedName = (prefix: string, localName: string): string =>
+  prefix.length === 0 ? localName : `${prefix}:${localName}`;
+
+const collectNoteElementSyntax = (
+  xml: string,
+  elementName: NoteElementName,
+): Map<string, NoteElementSyntax[]> => {
+  const byId = new Map<string, NoteElementSyntax[]>();
+  const root = parseXmlDocument(xml);
+  for (const element of getChildElements(root)) {
+    if (
+      getLocalName(element.name) !== elementName ||
+      !WORDPROCESSINGML_NAMESPACE_URIS.has(getNamespaceUri(element) ?? "")
+    ) {
+      continue;
+    }
+    const idAttribute = findAttributeByNamespaceUri(element, WORDPROCESSINGML_NAMESPACE_URIS, "id");
+    if (!element.name || !idAttribute) {
+      continue;
+    }
+    const syntax = {
+      elementName: element.name,
+      idAttributeName: idAttribute.name,
+      elementPrefix: getNamespacePrefix(element.name) ?? "",
+      attributePrefix: getNamespacePrefix(idAttribute.name) ?? "",
+    };
+    const entries = byId.get(idAttribute.value);
+    if (entries) {
+      entries.push(syntax);
+    } else {
+      byId.set(idAttribute.value, [syntax]);
+    }
+  }
+  return byId;
+};
+
+const syntaxLiteral = (syntax: NoteElementSyntax) => ({
+  openLiteral: `<${syntax.elementName}`,
+  closeTag: `</${syntax.elementName}>`,
+  idAttr: syntax.idAttributeName,
+});
+
+const extractNoteElement = (xml: string, syntax: NoteElementSyntax, id: string): string | null => {
+  const { openLiteral, closeTag, idAttr } = syntaxLiteral(syntax);
+  return extractElementByIdAttr(xml, openLiteral, closeTag, idAttr, id);
+};
+
+const findNoteElement = (
+  xml: string,
+  syntax: NoteElementSyntax,
+  id: string,
+): ParagraphOffsets | null => {
+  const { openLiteral, closeTag, idAttr } = syntaxLiteral(syntax);
+  return findElementByIdAttr(xml, openLiteral, closeTag, idAttr, id);
+};
+
+type WordPrefixMapping = {
+  source: NoteElementSyntax;
+  target: NoteElementSyntax;
+};
+
+const rewriteWordprocessingPrefixes = (
+  xml: string,
+  { source, target }: WordPrefixMapping,
+): string => {
+  let rewritten = "";
+  let quote: '"' | "'" | null = null;
+  let insideTag = false;
+  for (let index = 0; index < xml.length; index++) {
+    const character = xml[index];
+    if (!insideTag) {
+      rewritten += character;
+      insideTag = character === "<";
+      continue;
+    }
+    if (quote) {
+      rewritten += character;
+      if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      rewritten += character;
+      continue;
+    }
+    if (character === ">") {
+      insideTag = false;
+      rewritten += character;
+      continue;
+    }
+
+    const previous = xml[index - 1];
+    const isElementName = previous === "<" || (previous === "/" && xml[index - 2] === "<");
+    const sourcePrefix = isElementName ? source.elementPrefix : source.attributePrefix;
+    if (sourcePrefix.length > 0 && xml.startsWith(`${sourcePrefix}:`, index)) {
+      const targetPrefix = isElementName ? target.elementPrefix : target.attributePrefix;
+      rewritten += targetPrefix.length === 0 ? "" : `${targetPrefix}:`;
+      index += sourcePrefix.length;
+      continue;
+    }
+    rewritten += character;
+  }
+  return rewritten;
+};
+
+const paragraphRanges = (xml: string, wordPrefix: string): ParagraphOffsets[] => {
   const ranges: ParagraphOffsets[] = [];
+  const paragraphName = qualifiedName(wordPrefix, "p");
+  const openLiteral = `<${paragraphName}`;
+  const closeTag = `</${paragraphName}>`;
   let pos = 0;
   while (pos < xml.length) {
-    const start = xml.indexOf("<w:p", pos);
+    const start = xml.indexOf(openLiteral, pos);
     if (start === -1) {
       break;
     }
-    if (!isXmlNameBoundary(xml[start + "<w:p".length])) {
+    if (!isXmlNameBoundary(xml[start + openLiteral.length])) {
       pos = start + 1;
       continue;
     }
-    const range = scanElementRange(xml, start, "<w:p", "</w:p>");
+    const range = scanElementRange(xml, start, openLiteral, closeTag);
     if (!range) {
       break;
     }
@@ -558,7 +669,7 @@ const paragraphRanges = (xml: string): ParagraphOffsets[] => {
   return ranges;
 };
 
-const collectChangedParagraphIds = (baselineXml: string, currentXml: string): Set<string> => {
+export const collectChangedNoteParaIds = (baselineXml: string, currentXml: string): Set<string> => {
   const changed = new Set<string>();
   const baselineIds = collectParaIds(baselineXml);
   const baselineOffsets = buildParagraphOffsetIndex(baselineXml);
@@ -620,45 +731,46 @@ export function buildPatchedNotePartXml({
   elementName,
   changedParaIds,
 }: BuildPatchedNotePartXmlOptions): string | null {
-  if (!changedParaIds) {
-    return buildPatchedNoteXml(
-      originalXml,
-      serializedXml,
-      collectChangedParagraphIds(baselineXml, serializedXml),
-    );
-  }
-
-  const { openLiteral, closeTag, idAttr } = noteElementSyntax[elementName];
-  const currentIds = collectElementIds(serializedXml, openLiteral, idAttr);
+  const currentElements = collectNoteElementSyntax(serializedXml, elementName);
+  const originalElements = collectNoteElementSyntax(originalXml, elementName);
+  const replacementElements = collectNoteElementSyntax(replacementXml, elementName);
   const ordinalReplacements: { start: number; end: number; newXml: string }[] = [];
   const serializedParaIds = collectParaIds(serializedXml);
   const baselineParaIds = collectParaIds(baselineXml);
+  const effectiveChangedParaIds =
+    changedParaIds ?? collectChangedNoteParaIds(baselineXml, serializedXml);
   const unroutedChangedParaIds = new Set(
-    [...changedParaIds].filter(
+    [...effectiveChangedParaIds].filter(
       (paraId) => serializedParaIds.has(paraId) || baselineParaIds.has(paraId),
     ),
   );
 
-  for (const [id, count] of currentIds) {
-    if (count !== 1) {
+  for (const [id, currentSyntaxEntries] of currentElements) {
+    const originalSyntaxEntries = originalElements.get(id);
+    const replacementSyntaxEntries = replacementElements.get(id);
+    if (
+      currentSyntaxEntries.length !== 1 ||
+      originalSyntaxEntries?.length !== 1 ||
+      replacementSyntaxEntries?.length !== 1
+    ) {
       return null;
     }
-    const currentNote = extractElementByIdAttr(serializedXml, openLiteral, closeTag, idAttr, id);
-    const originalOffsets = findElementByIdAttr(originalXml, openLiteral, closeTag, idAttr, id);
-    const replacementNote = extractElementByIdAttr(
-      replacementXml,
-      openLiteral,
-      closeTag,
-      idAttr,
-      id,
-    );
+    const currentSyntax = currentSyntaxEntries[0];
+    const originalSyntax = originalSyntaxEntries[0];
+    const replacementSyntax = replacementSyntaxEntries[0];
+    if (!currentSyntax || !originalSyntax || !replacementSyntax) {
+      return null;
+    }
+    const currentNote = extractNoteElement(serializedXml, currentSyntax, id);
+    const originalOffsets = findNoteElement(originalXml, originalSyntax, id);
+    const replacementNote = extractNoteElement(replacementXml, replacementSyntax, id);
     if (!currentNote || !originalOffsets || !replacementNote) {
       return null;
     }
     const originalNote = originalXml.slice(originalOffsets.start, originalOffsets.end);
-    const currentParagraphs = paragraphRanges(currentNote);
-    const originalParagraphs = paragraphRanges(originalNote);
-    const replacementParagraphs = paragraphRanges(replacementNote);
+    const currentParagraphs = paragraphRanges(currentNote, currentSyntax.elementPrefix);
+    const originalParagraphs = paragraphRanges(originalNote, originalSyntax.elementPrefix);
+    const replacementParagraphs = paragraphRanges(replacementNote, replacementSyntax.elementPrefix);
     const noteChangedParaIds = [...collectParaIds(currentNote).keys()].filter((paraId) =>
       unroutedChangedParaIds.has(paraId),
     );
@@ -675,7 +787,10 @@ export function buildPatchedNotePartXml({
       ordinalReplacements.push({
         start: originalOffsets.start,
         end: originalOffsets.end,
-        newXml: replacementNote,
+        newXml: rewriteWordprocessingPrefixes(replacementNote, {
+          source: replacementSyntax,
+          target: originalSyntax,
+        }),
       });
       continue;
     }
@@ -700,7 +815,10 @@ export function buildPatchedNotePartXml({
       ordinalReplacements.push({
         start: originalOffsets.start + originalRange.start,
         end: originalOffsets.start + originalRange.end,
-        newXml: replacementNote.slice(replacementRange.start, replacementRange.end),
+        newXml: rewriteWordprocessingPrefixes(
+          replacementNote.slice(replacementRange.start, replacementRange.end),
+          { source: replacementSyntax, target: originalSyntax },
+        ),
       });
     }
   }

--- a/packages/core/src/docx/selectiveXmlPatch.ts
+++ b/packages/core/src/docx/selectiveXmlPatch.ts
@@ -518,6 +518,199 @@ function extractElementByIdAttr(
   return offsets ? xml.slice(offsets.start, offsets.end) : null;
 }
 
+type NoteElementName = "footnote" | "endnote";
+
+const noteElementSyntax = {
+  footnote: {
+    openLiteral: "<w:footnote",
+    closeTag: "</w:footnote>",
+    idAttr: "w:id",
+  },
+  endnote: {
+    openLiteral: "<w:endnote",
+    closeTag: "</w:endnote>",
+    idAttr: "w:id",
+  },
+} as const satisfies Record<
+  NoteElementName,
+  { openLiteral: string; closeTag: string; idAttr: string }
+>;
+
+const paragraphRanges = (xml: string): ParagraphOffsets[] => {
+  const ranges: ParagraphOffsets[] = [];
+  let pos = 0;
+  while (pos < xml.length) {
+    const start = xml.indexOf("<w:p", pos);
+    if (start === -1) {
+      break;
+    }
+    if (!isXmlNameBoundary(xml[start + "<w:p".length])) {
+      pos = start + 1;
+      continue;
+    }
+    const range = scanElementRange(xml, start, "<w:p", "</w:p>");
+    if (!range) {
+      break;
+    }
+    ranges.push(range);
+    pos = range.end;
+  }
+  return ranges;
+};
+
+const collectChangedParagraphIds = (baselineXml: string, currentXml: string): Set<string> => {
+  const changed = new Set<string>();
+  const baselineIds = collectParaIds(baselineXml);
+  const baselineOffsets = buildParagraphOffsetIndex(baselineXml);
+  const currentOffsets = buildParagraphOffsetIndex(currentXml);
+  for (const [id, count] of collectParaIds(currentXml)) {
+    if (count !== 1 || baselineIds.get(id) !== 1) {
+      continue;
+    }
+    const before = baselineOffsets.get(id);
+    const after = currentOffsets.get(id);
+    if (
+      before &&
+      after &&
+      baselineXml.slice(before.start, before.end) !== currentXml.slice(after.start, after.end)
+    ) {
+      changed.add(id);
+    }
+  }
+  return changed;
+};
+
+const replaceRanges = (
+  xml: string,
+  replacements: readonly { start: number; end: number; newXml: string }[],
+): string => {
+  let result = xml;
+  for (const { start, end, newXml } of [...replacements].toSorted((a, b) => b.start - a.start)) {
+    result = result.slice(0, start) + newXml + result.slice(end);
+  }
+  return result;
+};
+
+type BuildPatchedNotePartXmlOptions = {
+  originalXml: string;
+  baselineXml: string;
+  serializedXml: string;
+  replacementXml: string;
+  elementName: NoteElementName;
+  changedParaIds?: ReadonlySet<string>;
+};
+
+/**
+ * Patch an existing note part from its model serialization.
+ *
+ * Dirty paragraph ids locate their owning note in the model serialization;
+ * `(note w:id, paragraph ordinal)` then locates the corresponding source XML
+ * even when the producer omitted paragraph ids. Equal-shape edits replace only
+ * dirty paragraphs. A tracked paragraph-break resolution can change that
+ * shape, so it replaces the one affected note. Separator notes, unrelated
+ * notes, and unaffected equal-shape paragraphs remain byte-exact.
+ * `replacementXml` also supplies synthesized automatic note-reference marks,
+ * which the parsed model intentionally omits.
+ */
+export function buildPatchedNotePartXml({
+  originalXml,
+  baselineXml,
+  serializedXml,
+  replacementXml,
+  elementName,
+  changedParaIds,
+}: BuildPatchedNotePartXmlOptions): string | null {
+  if (!changedParaIds) {
+    return buildPatchedNoteXml(
+      originalXml,
+      serializedXml,
+      collectChangedParagraphIds(baselineXml, serializedXml),
+    );
+  }
+
+  const { openLiteral, closeTag, idAttr } = noteElementSyntax[elementName];
+  const currentIds = collectElementIds(serializedXml, openLiteral, idAttr);
+  const ordinalReplacements: { start: number; end: number; newXml: string }[] = [];
+  const serializedParaIds = collectParaIds(serializedXml);
+  const baselineParaIds = collectParaIds(baselineXml);
+  const unroutedChangedParaIds = new Set(
+    [...changedParaIds].filter(
+      (paraId) => serializedParaIds.has(paraId) || baselineParaIds.has(paraId),
+    ),
+  );
+
+  for (const [id, count] of currentIds) {
+    if (count !== 1) {
+      return null;
+    }
+    const currentNote = extractElementByIdAttr(serializedXml, openLiteral, closeTag, idAttr, id);
+    const originalOffsets = findElementByIdAttr(originalXml, openLiteral, closeTag, idAttr, id);
+    const replacementNote = extractElementByIdAttr(
+      replacementXml,
+      openLiteral,
+      closeTag,
+      idAttr,
+      id,
+    );
+    if (!currentNote || !originalOffsets || !replacementNote) {
+      return null;
+    }
+    const originalNote = originalXml.slice(originalOffsets.start, originalOffsets.end);
+    const currentParagraphs = paragraphRanges(currentNote);
+    const originalParagraphs = paragraphRanges(originalNote);
+    const replacementParagraphs = paragraphRanges(replacementNote);
+    const noteChangedParaIds = [...collectParaIds(currentNote).keys()].filter((paraId) =>
+      unroutedChangedParaIds.has(paraId),
+    );
+    if (noteChangedParaIds.length === 0) {
+      continue;
+    }
+    if (
+      currentParagraphs.length !== originalParagraphs.length ||
+      currentParagraphs.length !== replacementParagraphs.length
+    ) {
+      for (const paraId of noteChangedParaIds) {
+        unroutedChangedParaIds.delete(paraId);
+      }
+      ordinalReplacements.push({
+        start: originalOffsets.start,
+        end: originalOffsets.end,
+        newXml: replacementNote,
+      });
+      continue;
+    }
+
+    for (let index = 0; index < currentParagraphs.length; index++) {
+      const currentRange = currentParagraphs[index];
+      const originalRange = originalParagraphs[index];
+      const replacementRange = replacementParagraphs[index];
+      if (!currentRange || !originalRange || !replacementRange) {
+        return null;
+      }
+      const currentParagraph = currentNote.slice(currentRange.start, currentRange.end);
+      const routedIds = [...collectParaIds(currentParagraph).keys()].filter((paraId) =>
+        unroutedChangedParaIds.has(paraId),
+      );
+      if (routedIds.length === 0) {
+        continue;
+      }
+      for (const paraId of routedIds) {
+        unroutedChangedParaIds.delete(paraId);
+      }
+      ordinalReplacements.push({
+        start: originalOffsets.start + originalRange.start,
+        end: originalOffsets.start + originalRange.end,
+        newXml: replacementNote.slice(replacementRange.start, replacementRange.end),
+      });
+    }
+  }
+
+  if (unroutedChangedParaIds.size > 0) {
+    return null;
+  }
+  return replaceRanges(originalXml, ordinalReplacements);
+}
+
 /**
  * The full range of the first `<openLiteral …>…</closeTag>` element, or null.
  * Used to locate an unkeyed sub-element (a level's `mc:AlternateContent`).

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -366,12 +366,17 @@ export function findChildByNamespaceUri(
   return null;
 }
 
-/** Get an attribute whose prefix resolves to one of the accepted namespace URIs. */
-export function getAttributeByNamespaceUri(
+export type XmlAttributeMatch = {
+  name: string;
+  value: string;
+};
+
+/** Find an attribute whose prefix resolves to one of the accepted namespace URIs. */
+export function findAttributeByNamespaceUri(
   element: XmlElement | null | undefined,
   namespaceUris: ReadonlySet<string>,
   localName: string,
-): string | null {
+): XmlAttributeMatch | null {
   if (!element?.attributes) {
     return null;
   }
@@ -385,11 +390,20 @@ export function getAttributeByNamespaceUri(
       prefix !== null &&
       namespaceUris.has(resolveNamespaceUri(element.namespaceScope, prefix) ?? "")
     ) {
-      return String(value);
+      return { name, value: String(value) };
     }
   }
 
   return null;
+}
+
+/** Get an attribute whose prefix resolves to one of the accepted namespace URIs. */
+export function getAttributeByNamespaceUri(
+  element: XmlElement | null | undefined,
+  namespaceUris: ReadonlySet<string>,
+  localName: string,
+): string | null {
+  return findAttributeByNamespaceUri(element, namespaceUris, localName)?.value ?? null;
 }
 
 function hasLocalName(name: string | undefined, localName: string): boolean {


### PR DESCRIPTION
## Summary

- persist resolved review views across body, header, footer, footnote, and endnote stories
- route paraId-less note edits by note identity and paragraph position while preserving unrelated raw XML
- fail closed and reparse resolved stories after save to prevent partially serialized review state
- cover inline and paragraph-structural insertions, deletions, and moves with a core patch changeset

## Validation

- `bun --filter @stll/folio-core test` (4,695 passed; 2 optional differential tests skipped)
- `bun --filter @stll/folio-core typecheck`
- targeted Oxlint and Oxfmt checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved tracked changes now persist reliably across main document, header, footer, footnote and endnote stories.
  * Improved handling of moved content, paragraph-break deletions, formatting, fields, tables and structured document content.
  * Fixed saving changes in notes when source paragraphs lack identifiers or use alternate XML prefixes.

* **Reliability**
  * Document updates in notes are applied more accurately, reducing the risk of lost or incomplete changes.
  * Finalised review views are verified before saving to help preserve document fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->