### PR TITLE
fix(core): improve complex Arabic DOCX parity

### DIFF
--- a/.changeset/quiet-emus-render.md
+++ b/.changeset/quiet-emus-render.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": minor
+---
+
+Improve Arabic DOCX parity for no-wrap text boxes, boundary-owned section pagination, RTL tabs, and page-number formats.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -7,6 +7,7 @@
 import { ImagePosition } from '@stll/docx-core/model';
 import { ImageWrap } from '@stll/docx-core/model';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
+import { NumberFormat } from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
 import { ShapeTextBody } from '@stll/docx-core/model';
@@ -441,7 +442,6 @@ export type LayoutOptions = {
     mirrorMargins?: boolean;
     footnoteReservedHeights?: Map<number, number>;
     footnoteHeightById?: Map<number, number>;
-    bodyBreakType?: "continuous" | "nextPage" | "evenPage" | "oddPage";
     sectionHeaderFooterRefs?: PageHeaderFooterRefs[];
 };
 
@@ -497,7 +497,7 @@ export type MeasuredLine = {
 export type Page = {
     number: number;
     logicalNumber: number;
-    logicalNumberFormat?: string;
+    logicalNumberFormat?: NumberFormat;
     fragments: Fragment[];
     margins: PageMargins;
     authoredMargins?: PageMargins;
@@ -841,11 +841,11 @@ export type SectionLayoutConfig = {
 // @public
 export type SectionPageNumbering = {
     type: "continue";
-    format?: string;
+    format?: NumberFormat;
 } | {
     type: "restart";
     start: number;
-    format?: string;
+    format?: NumberFormat;
 };
 
 // @public
@@ -991,6 +991,7 @@ export type TextBoxBlock = {
     width: number;
     height?: number;
     autoFit?: ShapeTextBody["autoFit"];
+    textWrap?: ShapeTextBody["textWrap"];
     fillColor?: string;
     outlineWidth?: number;
     outlineColor?: string;

--- a/api-reports/core/layout-painter.api.md
+++ b/api-reports/core/layout-painter.api.md
@@ -7,6 +7,7 @@
 import { ImagePosition } from '@stll/docx-core/model';
 import { ImageWrap } from '@stll/docx-core/model';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
+import { NumberFormat } from '@stll/docx-core/model';
 import { SdtProperties } from '@stll/docx-core/model';
 import { SdtType } from '@stll/docx-core/model';
 import { ShapeTextBody } from '@stll/docx-core/model';
@@ -123,7 +124,7 @@ export type PainterOptions = {
 // @public
 export type RenderContext = {
     pageNumber: number;
-    pageNumberFormat?: string;
+    pageNumberFormat?: import__stll_docx_core_model.NumberFormat;
     totalPages: number;
     section: "body" | "header" | "footer";
     bookmarkPages?: ReadonlyMap<string, number>;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -487,6 +487,7 @@ export type TextBoxAttrs = {
     width?: number;
     height?: number;
     autoFit?: import__stll_docx_core_model.ShapeTextBody["autoFit"];
+    textWrap?: import__stll_docx_core_model.ShapeTextBody["textWrap"];
     textBoxId?: string;
     fillColor?: string;
     outlineWidth?: number;

--- a/api-reports/docx-core/index.api.md
+++ b/api-reports/docx-core/index.api.md
@@ -257,7 +257,7 @@ export type SectionProperties = {
         restart?: LineNumberRestart;
     };
     pageNumbering?: {
-        format?: string;
+        format?: NumberFormat;
         start?: number;
         chapterStyle?: number;
         chapterSeparator?: string;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -867,7 +867,7 @@ export type SectionProperties = {
         restart?: LineNumberRestart;
     };
     pageNumbering?: {
-        format?: string;
+        format?: NumberFormat;
         start?: number;
         chapterStyle?: number;
         chapterSeparator?: string;
@@ -986,6 +986,7 @@ export type ShapeTextBody = {
     anchor?: "top" | "middle" | "bottom" | "distributed" | "justified";
     anchorCenter?: boolean;
     autoFit?: "none" | "normal" | "shape";
+    textWrap?: "square" | "none";
     margins?: {
         top?: number;
         bottom?: number;
@@ -1248,6 +1249,7 @@ export type TextBox = {
     outline?: ShapeOutline;
     content: (Paragraph | Table)[];
     autoFit?: ShapeTextBody["autoFit"];
+    textWrap?: ShapeTextBody["textWrap"];
     margins?: {
         top?: number;
         bottom?: number;

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -1693,7 +1693,6 @@ describe("Section Breaks", () => {
       blocks,
       measures,
       makeLayoutOptions({
-        bodyBreakType: type,
         finalPageNumbering: { type: "restart", start: 13 },
       }),
     );
@@ -1751,6 +1750,35 @@ describe("Section Breaks", () => {
     expect(layout.pages.length).toBe(4);
     expect(layout.pages[2].fragments).toEqual([]);
     expect(layout.pages[3].fragments.some((f) => f.blockId === 2)).toBe(true);
+  });
+
+  test("applies each section transition at its own boundary", () => {
+    const blocks: FlowBlock[] = [
+      makeParagraphBlock("first", "First", 1),
+      { kind: "sectionBreak", id: "first-break" },
+      makeParagraphBlock("second", "Second", 1),
+      { kind: "pageBreak", id: "inside-second" },
+      makeParagraphBlock("second-tail", "Second tail", 1),
+      { kind: "sectionBreak", id: "second-break", type: "oddPage" },
+      makeParagraphBlock("third", "Third", 1),
+    ];
+    const paragraphMeasure = makeParagraphMeasure([makeLine(0, 0, 0, 5, 50, 24)]);
+    const measures: Measure[] = [
+      paragraphMeasure,
+      { kind: "sectionBreak" },
+      paragraphMeasure,
+      { kind: "pageBreak" },
+      paragraphMeasure,
+      { kind: "sectionBreak" },
+      paragraphMeasure,
+    ];
+
+    const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+    expect(layout.pages).toHaveLength(5);
+    expect(layout.pages[1]?.fragments.some(({ blockId }) => blockId === "second")).toBe(true);
+    expect(layout.pages[3]?.fragments).toEqual([]);
+    expect(layout.pages[4]?.fragments.some(({ blockId }) => blockId === "third")).toBe(true);
   });
 });
 

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -872,7 +872,7 @@ describe("runLayoutPipeline", () => {
     });
   });
 
-  test("uses the final section start mode for an implicit paragraph boundary", () => {
+  test("does not apply the final section start mode to an earlier implicit boundary", () => {
     const state = makeImplicitSectionBoundaryState();
     const continuous = runLayoutPipeline(
       makeDeps(createLayoutSession(), {
@@ -889,7 +889,7 @@ describe("runLayoutPipeline", () => {
       state,
     );
 
-    expect(continuous.layout?.pages).toHaveLength(1);
+    expect(continuous.layout?.pages).toHaveLength(2);
     expect(nextPage.layout?.pages).toHaveLength(2);
   });
 

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -652,16 +652,6 @@ export function runLayoutPipeline<THfPMs>(
     let footnoteContentMap = new Map<number, FootnoteContent>();
 
     // Common layout options for all passes
-    // SAFETY: `sectionStart` may be `"nextColumn"`, which the layout engine's
-    // `bodyBreakType` does not model; the adapter narrows it away and passes the
-    // value through unchanged at runtime. Preserved verbatim from the adapter.
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    const bodyBreakType = finalSectionProperties?.sectionStart as
-      | "continuous"
-      | "nextPage"
-      | "evenPage"
-      | "oddPage"
-      | undefined;
     const buildLayoutOpts = (): Parameters<typeof layoutDocument>[2] => {
       const nextLayoutOpts: Parameters<typeof layoutDocument>[2] = {
         pageSize,
@@ -685,9 +675,6 @@ export function runLayoutPipeline<THfPMs>(
       }
       if (columns !== undefined) {
         nextLayoutOpts.columns = columns;
-      }
-      if (bodyBreakType !== undefined) {
-        nextLayoutOpts.bodyBreakType = bodyBreakType;
       }
       if (sectionHeaderFooterRefs !== undefined) {
         nextLayoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;

--- a/packages/core/src/docx/documentParser.test.ts
+++ b/packages/core/src/docx/documentParser.test.ts
@@ -281,7 +281,7 @@ describe("parseDocumentBody text box enrichment", () => {
       <w:r><w:t>Before </w:t></w:r>
       <w:r><w:t>merged</w:t>${textBoxDrawingXml(
         "Inside text box",
-        "<wps:bodyPr><a:spAutoFit/></wps:bodyPr>",
+        '<wps:bodyPr wrap="none"><a:spAutoFit/></wps:bodyPr>',
       )}</w:r>
       <w:bookmarkStart w:id="1" w:name="afterTextbox"/>
       <w:bookmarkEnd w:id="1"/>
@@ -316,6 +316,7 @@ describe("parseDocumentBody text box enrichment", () => {
     expect(shapeContent.shape.shapeType).toBe("textBox");
     expect(shapeContent.shape.textBody?.content.at(0)?.type).toBe("paragraph");
     expect(shapeContent.shape.textBody?.autoFit).toBe("shape");
+    expect(shapeContent.shape.textBody?.textWrap).toBe("none");
 
     const bookmarkStartIndex = paragraph.content.findIndex(
       (content) => content.type === "bookmarkStart",

--- a/packages/core/src/docx/fieldParser.ts
+++ b/packages/core/src/docx/fieldParser.ts
@@ -31,7 +31,9 @@ import type {
   Run,
   TextContent,
   Theme,
+  NumberFormat,
 } from "../types/document";
+import { formatOoxmlCounter } from "./ooxmlCounterFormatter";
 import { FieldTypeSchema, narrowEnum } from "./parserEnums";
 import { parseRun } from "./runParser";
 import type { StyleMap } from "./styleParser";
@@ -545,7 +547,7 @@ export function isTocField(field: Field): boolean {
 export function computePageNumber(
   pageNumber: number,
   instruction?: ParsedFieldInstruction,
-  sectionFormat?: string,
+  sectionFormat?: NumberFormat,
 ): string {
   const format = instruction ? getFormatSwitch(instruction) : undefined;
   if (!format || format.toUpperCase() === "MERGEFORMAT") {
@@ -563,20 +565,8 @@ export function computePageNumber(
   }
 }
 
-function formatSectionPageNumber(pageNumber: number, format: string | undefined): string {
-  switch (format) {
-    case "upperRoman":
-      return toRoman(pageNumber);
-    case "lowerRoman":
-      return toRoman(pageNumber).toLowerCase();
-    case "upperLetter":
-      return toLetter(pageNumber);
-    case "lowerLetter":
-      return toLetter(pageNumber).toLowerCase();
-    default:
-      return String(pageNumber);
-  }
-}
+const formatSectionPageNumber = (pageNumber: number, format: NumberFormat | undefined): string =>
+  formatOoxmlCounter(pageNumber, format);
 
 /**
  * Convert number to uppercase Roman numerals

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -311,6 +311,7 @@ const enrichTextBoxRuns = ({
         textBody: {
           content: textBox.content,
           ...(textBox.autoFit !== undefined ? { autoFit: textBox.autoFit } : {}),
+          ...(textBox.textWrap !== undefined ? { textWrap: textBox.textWrap } : {}),
           ...(textBox.margins !== undefined ? { margins: textBox.margins } : {}),
         },
       };

--- a/packages/core/src/docx/sectionParser.ts
+++ b/packages/core/src/docx/sectionParser.ts
@@ -34,7 +34,12 @@ import type {
 import { normalizeRevisionId } from "@stll/docx-core/model";
 import { parseHeaderReference, parseFooterReference } from "./headerFooterRefParser";
 import { parseFootnoteProperties, parseEndnoteProperties } from "./notePropertiesParser";
-import { BorderStyleSchema, ThemeColorSlotSchema, narrowEnum } from "./parserEnums";
+import {
+  BorderStyleSchema,
+  NumberFormatSchema,
+  ThemeColorSlotSchema,
+  narrowEnum,
+} from "./parserEnums";
 import {
   findChild,
   findChildren,
@@ -592,7 +597,7 @@ export function parseSectionProperties(sectPr: XmlElement | null): SectionProper
   if (pgNumType) {
     const pageNumbering: NonNullable<SectionProperties["pageNumbering"]> = {};
 
-    const format = getAttribute(pgNumType, "w", "fmt");
+    const format = narrowEnum(getAttribute(pgNumType, "w", "fmt"), NumberFormatSchema);
     if (format) {
       pageNumbering.format = format;
     }

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -300,6 +300,7 @@ describe("text box fitting serialization", () => {
             size: { width: 914_400, height: 457_200 },
             textBody: {
               autoFit,
+              textWrap: "none",
               content: [{ type: "paragraph", content: [] }],
             },
           },
@@ -309,6 +310,7 @@ describe("text box fitting serialization", () => {
 
     const xml = serializeRun(run);
     expect(xml).toContain(expected);
+    expect(xml).toContain('wrap="none"');
     expect(xml).not.toContain(absentA);
     expect(xml).not.toContain(absentB);
   });

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -1004,6 +1004,9 @@ function serializeShapeContent(content: ShapeContent): string {
   if (shape.textBody) {
     const tb = shape.textBody;
     const bpAttrs: string[] = ['rot="0"', 'vert="horz"'];
+    if (tb.textWrap) {
+      bpAttrs.push(`wrap="${tb.textWrap}"`);
+    }
     if (tb.anchor) {
       bpAttrs.push(`anchor="${tb.anchor === "middle" ? "ctr" : tb.anchor}"`);
     }

--- a/packages/core/src/docx/textBoxParser.ts
+++ b/packages/core/src/docx/textBoxParser.ts
@@ -76,6 +76,7 @@ const DEFAULT_MARGIN_EMU = 91_440;
 function parseBodyProperties(bodyPr: XmlElement | null): {
   margins?: TextBox["margins"];
   autoFit?: ShapeTextBody["autoFit"];
+  textWrap?: ShapeTextBody["textWrap"];
 } {
   if (!bodyPr) {
     return {};
@@ -84,7 +85,13 @@ function parseBodyProperties(bodyPr: XmlElement | null): {
   const result: {
     margins?: TextBox["margins"];
     autoFit?: ShapeTextBody["autoFit"];
+    textWrap?: ShapeTextBody["textWrap"];
   } = {};
+
+  const textWrap = getAttribute(bodyPr, null, "wrap");
+  if (textWrap === "none" || textWrap === "square") {
+    result.textWrap = textWrap;
+  }
 
   if (findChildByLocalName(bodyPr, "spAutoFit")) {
     result.autoFit = "shape";
@@ -344,6 +351,9 @@ export function parseTextBox(drawingEl: XmlElement): TextBox | null {
   if (bodyProps.autoFit) {
     textBox.autoFit = bodyProps.autoFit;
   }
+  if (bodyProps.textWrap) {
+    textBox.textWrap = bodyProps.textWrap;
+  }
 
   // Parse position for anchored text boxes
   if (isAnchor) {
@@ -434,6 +444,9 @@ export function parseTextBoxFromShape(
   }
   if (bodyProps.autoFit) {
     textBox.autoFit = bodyProps.autoFit;
+  }
+  if (bodyProps.textWrap) {
+    textBox.textWrap = bodyProps.textWrap;
   }
   if (position) {
     textBox.position = position;

--- a/packages/core/src/fields/evaluateField.test.ts
+++ b/packages/core/src/fields/evaluateField.test.ts
@@ -38,6 +38,13 @@ describe("evaluateField page-number family", () => {
     expect(evalInstr("PAGE \\* ROMAN", ctx)).toBe("XIII");
   });
 
+  test("PAGE uses the complete OOXML section-number format contract", () => {
+    const ctx = baseContext({ pageNumber: 3, pageNumberFormat: "arabicAbjad" });
+
+    expect(evalInstr("PAGE", ctx)).toBe("\u200cج");
+    expect(evalInstr("PAGE \\* MERGEFORMAT", ctx)).toBe("\u200cج");
+  });
+
   test("locked fields preserve their cached fallback", () => {
     const ctx = baseContext();
     expect(

--- a/packages/core/src/fields/fieldContext.ts
+++ b/packages/core/src/fields/fieldContext.ts
@@ -1,3 +1,5 @@
+import type { NumberFormat } from "../types/document";
+
 /**
  * Resolution context for evaluating dynamic DOCX fields against a laid-out
  * document. Built once per layout pass (see the field-resolution pass) and
@@ -9,7 +11,7 @@ export type FieldContext = {
   /** 1-indexed page the field is on (PAGE). */
   pageNumber: number;
   /** OOXML section-level format used when PAGE has no explicit format switch. */
-  pageNumberFormat?: string;
+  pageNumberFormat?: NumberFormat;
   /** Total pages in the document (NUMPAGES). */
   totalPages: number;
   /** Pages in the field's current section (SECTIONPAGES); omit until the

--- a/packages/core/src/fields/resolveFieldValues.ts
+++ b/packages/core/src/fields/resolveFieldValues.ts
@@ -1,6 +1,7 @@
 import { computePageNumber, getFormatSwitch, parseFieldInstruction } from "../docx/fieldParser";
 import type { ParsedFieldInstruction } from "../docx/fieldParser";
 import type { BlockId, FieldRun, FlowBlock, Page } from "../layout-engine/types";
+import type { NumberFormat } from "../types/document";
 import { evaluateField } from "./evaluateField";
 import type { FieldContext } from "./fieldContext";
 
@@ -20,7 +21,7 @@ export type HeaderFooterFieldInputs = Pick<
   "bookmarkPages" | "bookmarkText" | "seqValues" | "sectionPageCounts"
 >;
 
-type BlockLocation = { page: number; pageFormat?: string; sectionIndex: number };
+type BlockLocation = { page: number; pageFormat?: NumberFormat; sectionIndex: number };
 type FieldAnchor =
   | { type: "block"; blockId: BlockId; run: FieldRun }
   | { type: "tableRow"; blockId: BlockId; rowIndex: number; run: FieldRun };

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2625,6 +2625,9 @@ function convertTextBoxNode(
   if (attrs.autoFit !== undefined) {
     textBox.autoFit = attrs.autoFit;
   }
+  if (attrs.textWrap !== undefined) {
+    textBox.textWrap = attrs.textWrap;
+  }
   if (attrs.fillColor !== undefined) {
     textBox.fillColor = attrs.fillColor;
   }

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -135,7 +135,6 @@ describe("continuous section break geometry", () => {
       pageSize: { w: 800, h: 1000 },
       margins: { top: 50, right: 50, bottom: 50, left: 50 },
       finalColumns: { count: 2, gap: 20, widths: [200, 300], gaps: [100] },
-      bodyBreakType: "continuous",
     });
 
     expect(result.pages).toHaveLength(1);
@@ -146,7 +145,7 @@ describe("continuous section break geometry", () => {
     expect(secondColumnFragment?.width).toBe(300);
   });
 
-  test("an omitted next section type defaults to a new page", () => {
+  test("an omitted transition defaults to a new page at its own boundary", () => {
     const first = paragraph("first", 100);
     const firstBreak: SectionBreakBlock = {
       kind: "sectionBreak",
@@ -177,15 +176,31 @@ describe("continuous section break geometry", () => {
     const result = layoutDocument(blocks, measures, {
       pageSize: { w: 800, h: 1000 },
       margins: { top: 50, right: 50, bottom: 50, left: 50 },
-      bodyBreakType: "continuous",
     });
 
     expect(result.pages).toHaveLength(2);
-    expect(result.pages[0]?.fragments.map((fragment) => fragment.blockId)).toEqual(["first"]);
-    expect(result.pages[1]?.fragments.map((fragment) => fragment.blockId)).toEqual([
+    expect(result.pages[0]?.fragments.map((fragment) => fragment.blockId)).toEqual([
+      "first",
       "second",
-      "third",
     ]);
+    expect(result.pages[1]?.fragments.map((fragment) => fragment.blockId)).toEqual(["third"]);
+  });
+
+  test("does not apply final section config to a preceding omitted transition", () => {
+    const first = paragraph("first", 100);
+    const second = paragraph("second", 100);
+    const result = layoutDocument(
+      [first.block, { kind: "sectionBreak", id: "break" }, second.block],
+      [first.measure, { kind: "sectionBreak" }, second.measure],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    );
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual(["first"]);
+    expect(result.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual(["second"]);
   });
 
   test("content after a continuous column section resumes below its tallest column", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -475,15 +475,11 @@ export function layoutDocument(
         break;
 
       case "sectionBreak": {
-        // A concrete following section with no authored type uses the format
-        // default. Only the final body retains the current type as a fallback
-        // when direct engine callers cannot supply its section properties.
+        // A section-break block carries the transition authored at that
+        // boundary. Looking ahead shifts every transition by one section,
+        // which moves odd/even filler pages to the wrong boundary.
         const nextSectionConfig = sectionConfigs[sectionIdx + 1] ?? initialConfig;
-        let nextType =
-          options.bodyBreakType ?? sectionBreakTypes[sectionIdx] ?? DEFAULT_SECTION_BREAK_TYPE;
-        if (sectionIdx + 1 < sectionBreakTypes.length) {
-          nextType = sectionBreakTypes[sectionIdx + 1] ?? DEFAULT_SECTION_BREAK_TYPE;
-        }
+        const nextType = sectionBreakTypes[sectionIdx] ?? DEFAULT_SECTION_BREAK_TYPE;
         handleSectionBreak(
           block as SectionBreakBlock,
           paginator,

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -129,6 +129,62 @@ describe("text box fitting", () => {
     }, fakeMeasure);
   });
 
+  test("shape fitting expands no-wrap text horizontally without soft line breaks", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureBlock(
+        {
+          kind: "textBox",
+          id: "rtl-classification",
+          width: 40,
+          height: 20,
+          autoFit: "shape",
+          textWrap: "none",
+          margins: { top: 0, right: 20, bottom: 0, left: 0 },
+          content: [para("inner", "عنوان عربي")],
+        },
+        500,
+      );
+
+      expect(measure.kind).toBe("textBox");
+      if (measure.kind !== "textBox") {
+        return;
+      }
+      expect(measure.width).toBe(70);
+      const paragraph = measure.innerMeasures.at(0);
+      expect(paragraph?.kind).toBe("paragraph");
+      if (paragraph?.kind === "paragraph") {
+        expect(paragraph.lines).toHaveLength(1);
+      }
+    }, fakeMeasure);
+  });
+
+  test("shape fitting includes paragraph indents in the no-wrap width", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureBlock(
+        {
+          kind: "textBox",
+          id: "indented-no-wrap",
+          width: 40,
+          autoFit: "shape",
+          textWrap: "none",
+          margins: { top: 0, right: 0, bottom: 0, left: 0 },
+          content: [
+            {
+              ...para("inner", "abcdefghij"),
+              attrs: { indent: { left: 100, right: 50 } },
+            },
+          ],
+        },
+        500,
+      );
+
+      expect(measure.kind).toBe("textBox");
+      if (measure.kind === "textBox") {
+        expect(measure.width).toBe(200);
+      }
+    }, fakeMeasure);
+  });
+
   test.each([undefined, "none", "normal"] as const)(
     "keeps the authored height for the %s fitting mode",
     (autoFit) => {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -825,8 +825,35 @@ export function measureTextBoxBlock(
     if (block.kind === "table") {
       return measureTableBlock(block, innerWidth, fieldValues);
     }
-    return measureParagraph(block, innerWidth, fieldValues ? { fieldValues } : undefined);
+    const measureWidth = tb.textWrap === "none" ? NO_WRAP_MEASURE_WIDTH : innerWidth;
+    return measureParagraph(block, measureWidth, fieldValues ? { fieldValues } : undefined);
   });
+  let naturalContentWidth = 0;
+  for (let index = 0; index < innerMeasures.length; index++) {
+    const measure = innerMeasures[index]!;
+    if (measure.kind === "table") {
+      naturalContentWidth = Math.max(naturalContentWidth, measure.totalWidth);
+      continue;
+    }
+    const block = tb.content[index];
+    if (!block || block.kind !== "paragraph") {
+      continue;
+    }
+    const indent = block.attrs?.indent;
+    const left = indent?.left ?? 0;
+    const right = indent?.right ?? 0;
+    for (let lineIndex = 0; lineIndex < measure.lines.length; lineIndex++) {
+      const line = measure.lines[lineIndex]!;
+      const firstLineOffset =
+        lineIndex === 0 ? (indent?.firstLine ?? 0) - (indent?.hanging ?? 0) : 0;
+      const start = left + firstLineOffset;
+      const end = start + line.width + right;
+      naturalContentWidth = Math.max(naturalContentWidth, Math.max(0, end) - Math.min(0, start));
+    }
+  }
+  const fittedWidth = naturalContentWidth + margins.left + margins.right;
+  const totalWidth =
+    tb.autoFit === "shape" && tb.textWrap === "none" ? Math.max(tb.width, fittedWidth) : tb.width;
   const contentHeight = layoutTextBoxContent(tb.content, innerMeasures).totalHeight;
   const contentBoxHeight = contentHeight + margins.top + margins.bottom;
   const totalHeight =
@@ -835,7 +862,7 @@ export function measureTextBoxBlock(
       : (tb.height ?? contentBoxHeight);
   return {
     kind: "textBox",
-    width: tb.width,
+    width: totalWidth,
     height: totalHeight,
     innerMeasures,
   };

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -220,6 +220,151 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
     });
   });
 
+  test("preserves the logical endpoint of an RTL TOC end tab", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "rtl-toc-end-tab",
+            runs: [
+              { kind: "text", text: "عنوان عربي", fontSize: 11 },
+              { kind: "tab" },
+              { kind: "text", text: "1", fontSize: 11 },
+            ],
+            attrs: {
+              bidi: true,
+              alignment: "justify",
+              indent: { left: 48, right: 48, hanging: 48 },
+              tabs: [{ val: "end", pos: 9000, leader: "dot" }],
+            },
+          },
+          624,
+        );
+
+        expect(measure.lines).toHaveLength(1);
+        expect(measure.lines[0]?.width).toBe(600);
+      },
+      { charWidth: () => 5 },
+    );
+  });
+
+  test("uses the same inferred RTL direction for measurement and painting", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "inferred-rtl-end-tab",
+            runs: [
+              { kind: "text", text: "عنوان عربي", fontSize: 11, rtl: true },
+              { kind: "tab" },
+              { kind: "text", text: "1", fontSize: 11, rtl: true },
+            ],
+            attrs: {
+              indent: { left: 48, right: 48, hanging: 48 },
+              tabs: [{ val: "end", pos: 9000, leader: "dot" }],
+            },
+          },
+          624,
+        );
+
+        expect(measure.lines).toHaveLength(1);
+        expect(measure.lines[0]?.width).toBe(600);
+      },
+      { charWidth: () => 5 },
+    );
+  });
+
+  test("does not expand an RTL line to a tab stop beyond the content box", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "bounded-rtl-end-tab",
+            runs: [
+              { kind: "text", text: "عنوان عربي", fontSize: 11 },
+              { kind: "tab" },
+              { kind: "text", text: "1", fontSize: 11 },
+            ],
+            attrs: {
+              bidi: true,
+              indent: { left: 48, right: 48, hanging: 48 },
+              tabs: [{ val: "end", pos: 100_000_000, leader: "dot" }],
+            },
+          },
+          624,
+        );
+
+        expect(measure.lines.every(({ width }) => width <= 624)).toBe(true);
+      },
+      { charWidth: () => 5 },
+    );
+  });
+
+  test("does not expand an RTL end tab through a right-side float", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "rtl-end-tab-right-float",
+            runs: [
+              { kind: "text", text: "عنوان عربي", fontSize: 11 },
+              { kind: "tab" },
+              { kind: "text", text: "1", fontSize: 11 },
+            ],
+            attrs: {
+              bidi: true,
+              indent: { left: 48, right: 48, hanging: 48 },
+              tabs: [{ val: "end", pos: 9000, leader: "dot" }],
+            },
+          },
+          624,
+          {
+            floatingZones: [{ leftMargin: 0, rightMargin: 300, topY: 0, bottomY: 100 }],
+          },
+        );
+
+        expect(measure.lines).toHaveLength(1);
+        expect(measure.lines[0]).toMatchObject({ width: 276, rightOffset: 300 });
+      },
+      { charWidth: () => 5 },
+    );
+  });
+
+  test("includes a left-side float in the RTL tab coordinate", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "rtl-end-tab-left-float",
+            runs: [
+              { kind: "text", text: "عنوان عربي", fontSize: 11 },
+              { kind: "tab" },
+              { kind: "text", text: "1", fontSize: 11 },
+            ],
+            attrs: {
+              bidi: true,
+              indent: { left: 48, right: 48, hanging: 48 },
+              tabs: [{ val: "end", pos: 9000, leader: "dot" }],
+            },
+          },
+          624,
+          {
+            floatingZones: [{ leftMargin: 300, rightMargin: 0, topY: 0, bottomY: 100 }],
+          },
+        );
+
+        expect(measure.lines).toHaveLength(1);
+        expect(measure.lines[0]).toMatchObject({ width: 300, leftOffset: 300 });
+      },
+      { charWidth: () => 5 },
+    );
+  });
+
   test("right tab reserves rotated inline image bbox width in following width", () => {
     withFakeTextMeasure(() => {
       const block = {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -13,6 +13,7 @@ import {
   isCjkFont,
 } from "../../utils/fontResolver";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
+import { isRtlParagraph } from "../../utils/paragraphBaseDirection";
 import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
 import { measuredLineAdvance } from "../lineFlow";
 import type {
@@ -1138,6 +1139,7 @@ export function measureParagraph(
 ): ParagraphMeasure {
   const runs = block.runs;
   const attrs = block.attrs;
+  const isRtl = isRtlParagraph(block);
   const spacing = attrs?.spacing;
   const isJustifiedParagraph = attrs?.alignment === "justify";
   const justificationProfile: JustificationProfile = {
@@ -1636,6 +1638,12 @@ export function measureParagraph(
         decimalPrefixWidth,
       });
       let tabWidth = tabResult.width;
+      const authoredEndpoint = contentX + tabWidth + followingWidth;
+      const activeContentRightEdge = maxWidth - currentLine.rightOffset;
+      const preservesLogicalRtlEndStop =
+        isRtl &&
+        tabResult.alignment === "end" &&
+        authoredEndpoint <= activeContentRightEdge + WIDTH_TOLERANCE;
       const landsOnLeftIndent =
         tabResult.alignment === "start" &&
         indentLeft > 0 &&
@@ -1647,6 +1655,7 @@ export function measureParagraph(
         currentLine.availableWidth +
         currentLine.leftOffset;
       if (
+        !preservesLogicalRtlEndStop &&
         !landsOnLeftIndent &&
         !hasFollowingTabOnLine(runs, runIndex) &&
         canClampTabToRightEdge(
@@ -1660,6 +1669,19 @@ export function measureParagraph(
         contentX + tabWidth + followingWidth > lineRightEdgeX + WIDTH_TOLERANCE
       ) {
         tabWidth = Math.max(1, lineRightEdgeX - contentX - followingWidth);
+      }
+
+      // OOXML tab positions remain logical in bidi paragraphs. The browser's
+      // `dir="rtl"` mirrors this endpoint, so an authored end stop may extend
+      // past the paragraph's physical right-indent edge and still land inside
+      // the page at the corresponding left-side position. Preserve enough
+      // line budget for the tab and its trailing content instead of wrapping
+      // a valid RTL TOC entry at that physical edge.
+      if (preservesLogicalRtlEndStop) {
+        currentLine.availableWidth = Math.max(
+          currentLine.availableWidth,
+          currentLine.width + tabWidth + followingWidth,
+        );
       }
 
       if (currentLine.width + tabWidth > currentLine.availableWidth + WIDTH_TOLERANCE) {

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -469,6 +469,58 @@ describe("rendered break reconciliation", () => {
 
     expect(decision.forcePageBreak).toBe(false);
   });
+
+  test("pageBreakBefore does not create an empty page after an authored boundary", () => {
+    const block = paragraph(2, { pageBreakBefore: true });
+    const decision = reconcileBreakBeforeBlock({
+      state: {
+        type: "pageAdvance",
+        reason: "authoredBoundary",
+        boundary: "sectionBreak",
+      },
+      block,
+      previousBlock: { kind: "sectionBreak", id: "section", type: "nextPage" },
+      page: page([]),
+      blocksById: new Map(),
+      hasExplicitPageBreak: true,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(false);
+  });
+
+  test("pageBreakBefore still advances a page with visible body content", () => {
+    const previous = paragraph(1, {}, [{ kind: "text", text: "Previous" }]);
+    const decision = reconcileBreakBeforeBlock({
+      state: INITIAL_RENDERED_BREAK_STATE,
+      block: paragraph(2, { pageBreakBefore: true }),
+      previousBlock: previous,
+      page: page([paragraphFragment(1)]),
+      blocksById: new Map([["1", previous]]),
+      hasExplicitPageBreak: true,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(true);
+  });
+
+  test("pageBreakBefore preserves a distinct preceding hard-break boundary", () => {
+    const decision = reconcileBreakBeforeBlock({
+      state: {
+        type: "pageAdvance",
+        reason: "authoredBoundary",
+        boundary: "hardBreak",
+      },
+      block: paragraph(2, { pageBreakBefore: true }),
+      previousBlock: { kind: "pageBreak", id: "hard-break" },
+      page: page([]),
+      blocksById: new Map(),
+      hasExplicitPageBreak: true,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(decision.forcePageBreak).toBe(true);
+  });
 });
 
 describe("rendered break state transitions", () => {

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -48,8 +48,14 @@ export const reconcileBreakBeforeBlock = ({
   renderedBreakNeedsSnap,
 }: ReconcileBeforeBlockOptions): BreakDecision => {
   if (hasExplicitPageBreak) {
+    const followsSameSectionBoundary =
+      state.type === "pageAdvance" &&
+      state.reason === "authoredBoundary" &&
+      state.boundary === "sectionBreak" &&
+      previousBlock?.kind === "sectionBreak" &&
+      previousBlock.type !== "continuous";
     return {
-      forcePageBreak: true,
+      forcePageBreak: !followsSameSectionBoundary,
       suppressSpaceBefore: false,
       state: INITIAL_RENDERED_BREAK_STATE,
     };

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -8,6 +8,7 @@
 import type {
   ImagePosition,
   ImageWrap,
+  NumberFormat,
   ShapeTextBody,
   SdtProperties,
   SdtType,
@@ -783,8 +784,8 @@ export type SectionBreakBlock = {
 
 /** Normalized section page-number policy. An omitted OOXML start continues numbering. */
 export type SectionPageNumbering =
-  | { type: "continue"; format?: string }
-  | { type: "restart"; start: number; format?: string };
+  | { type: "continue"; format?: NumberFormat }
+  | { type: "restart"; start: number; format?: NumberFormat };
 
 export type PageHeaderFooterRefs = {
   titlePg?: boolean;
@@ -835,6 +836,8 @@ export type TextBoxBlock = {
   height?: number;
   /** Text fitting behavior */
   autoFit?: ShapeTextBody["autoFit"];
+  /** Horizontal text wrapping inside the box */
+  textWrap?: ShapeTextBody["textWrap"];
   /** Fill/background color */
   fillColor?: string;
   /** Border width in pixels */
@@ -1196,7 +1199,7 @@ export type Page = {
   /** Authored page number shown by PAGE fields. */
   logicalNumber: number;
   /** OOXML number format for this page's section. */
-  logicalNumberFormat?: string;
+  logicalNumberFormat?: NumberFormat;
   /** Fragments positioned on this page. */
   fragments: Fragment[];
   /** Page margins. */
@@ -1350,8 +1353,6 @@ export type LayoutOptions = {
    * page.
    */
   footnoteHeightById?: Map<number, number>;
-  /** Section break type for the body-level (final) section (for section transition logic). */
-  bodyBreakType?: "continuous" | "nextPage" | "evenPage" | "oddPage";
   /** Header/footer references for each document section, by section index. */
   sectionHeaderFooterRefs?: PageHeaderFooterRefs[];
 };

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -310,6 +310,189 @@ describe("renderLine right-tab flex anchor", () => {
     expect(trailing.length).toBeGreaterThanOrEqual(1);
   });
 
+  test("keeps an RTL TOC end tab logical instead of flex-anchoring it physically", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "rtl-toc",
+      attrs: { bidi: true },
+      runs: [{ kind: "text", text: "عنوان عربي" }, { kind: "tab" }, { kind: "text", text: "1" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 600,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 528,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 9000, leader: "dot" }],
+      leftIndentPx: 48,
+      firstLineIndentPx: -48,
+      isRtl: true,
+      contentWidthPx: 624,
+      lineRightEdgePx: 576,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(lineEl.style["display"]).toBeUndefined();
+    expect(findTabEl(lineEl)?.style["width"]).toBe("523px");
+  });
+
+  test("uses the authored tab origin when RTL swaps asymmetric physical indents", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "rtl-toc-level-2",
+      attrs: { bidi: true },
+      runs: [{ kind: "text", text: "عنوان عربي" }, { kind: "tab" }, { kind: "text", text: "1" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 552,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 528,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 9000, leader: "dot" }],
+      // Physical left is zero after RTL swaps w:left=1440 to the right edge.
+      leftIndentPx: 0,
+      // Tab stops still use the authored logical w:left coordinate.
+      tabLeftIndentPx: 96,
+      firstLineIndentPx: -48,
+      isRtl: true,
+      contentWidthPx: 624,
+      lineRightEdgePx: 528,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(findTabEl(lineEl)?.style["width"]).toBe("475px");
+  });
+
+  test("bounds an RTL end tab authored beyond the content box", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "rtl-toc-out-of-bounds",
+      attrs: { bidi: true },
+      runs: [{ kind: "text", text: "عنوان عربي" }, { kind: "tab" }, { kind: "text", text: "1" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 600,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 528,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 100_000_000, leader: "dot" }],
+      leftIndentPx: 48,
+      firstLineIndentPx: -48,
+      isRtl: true,
+      contentWidthPx: 624,
+      lineRightEdgePx: 576,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(Number.parseFloat(findTabEl(lineEl)?.style["width"] ?? "Infinity")).toBeLessThan(624);
+  });
+
+  test("bounds an RTL end tab at a right-side floating exclusion", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "rtl-toc-right-float",
+      attrs: { bidi: true },
+      runs: [{ kind: "text", text: "عنوان عربي" }, { kind: "tab" }, { kind: "text", text: "1" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 276,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+      rightOffset: 300,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 228,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 9000, leader: "dot" }],
+      leftIndentPx: 48,
+      firstLineIndentPx: -48,
+      isRtl: true,
+      contentWidthPx: 624,
+      floatingMargins: { leftMargin: 0, rightMargin: 300 },
+      lineRightEdgePx: 276,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(findTabEl(lineEl)?.style["width"]).toBe("199px");
+  });
+
+  test("includes a left-side floating exclusion in the RTL tab coordinate", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "rtl-toc-left-float",
+      attrs: { bidi: true },
+      runs: [{ kind: "text", text: "عنوان عربي" }, { kind: "tab" }, { kind: "text", text: "1" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 300,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+      leftOffset: 300,
+    };
+
+    const lineEl = renderLine(block, line, "right", fakeDocument, {
+      availableWidth: 228,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 9000, leader: "dot" }],
+      leftIndentPx: 48,
+      firstLineIndentPx: -48,
+      isRtl: true,
+      contentWidthPx: 624,
+      floatingMargins: { leftMargin: 300, rightMargin: 0 },
+      lineRightEdgePx: 576,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(findTabEl(lineEl)?.style["width"]).toBe("223px");
+  });
+
   test("does NOT promote to flex when the right-aligned tab is not the last on the line", () => {
     // Two end-aligned tabs on one line — the first tab must NOT fire the
     // anchor (it has a following tab), so its trailing content lays out

--- a/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -158,6 +158,18 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(render([text("hello")], { bidi: true }).dir).toBe("rtl");
   });
 
+  test("applies an asymmetric hanging indent at the RTL logical start edge", () => {
+    const paragraph = render([text("عنوان عربي", true)], {
+      bidi: true,
+      indent: { left: 96, hanging: 48 },
+    }) as unknown as FakeElement;
+    const line = paragraph.children.at(0);
+
+    expect(line?.style["paddingRight"]).toBe("96px");
+    expect(line?.style["paddingLeft"]).toBeUndefined();
+    expect(line?.style["textIndent"]).toBe("-48px");
+  });
+
   test("explicit w:bidi=false wins over rtl runs (stays LTR)", () => {
     // `<w:bidi w:val="0"/>` is an explicit LTR override; first-strong detection
     // must not re-enable RTL for a Hebrew run inside it.

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -43,7 +43,7 @@ import type {
 import { calculateTabWidth } from "../prosemirror/utils/tabCalculator";
 import type { TabContext, TabStop as TabCalcStop } from "../prosemirror/utils/tabCalculator";
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
-import { detectBaseDirection } from "../utils/baseDirection";
+import { isRtlParagraph } from "../utils/paragraphBaseDirection";
 import {
   hasComplexScriptFormatting,
   resolveComplexScriptFormatting,
@@ -1580,8 +1580,14 @@ type RenderLineOptions = {
   context?: RenderContext;
   /** Left indent in pixels */
   leftIndentPx?: number;
+  /** Authored OOXML left indent used by logical tab-stop calculations. */
+  tabLeftIndentPx?: number;
   /** First line indent in pixels (positive) or hanging indent (negative) */
   firstLineIndentPx?: number;
+  /** Paragraph base direction for logical first-line indentation. */
+  isRtl?: boolean;
+  /** Full paragraph content-box width before physical indents. */
+  contentWidthPx?: number;
   /** Line-specific floating image margins (calculated per-line based on Y overlap) */
   floatingMargins?: { leftMargin: number; rightMargin: number };
   /** Track inline image runs already rendered in this paragraph fragment to prevent duplicates */
@@ -2221,7 +2227,8 @@ export function renderLine(
     // The leftIndent serves two purposes in the tab calculator:
     // 1. For hanging indent paragraphs, it adds an implicit tab stop at the left margin
     // 2. Default tab stops are generated at regular intervals from the left margin
-    const leftIndentTwips = options?.leftIndentPx ? Math.round(options.leftIndentPx * 15) : 0;
+    const tabLeftIndentPx = options?.tabLeftIndentPx ?? options?.leftIndentPx ?? 0;
+    const leftIndentTwips = Math.round(tabLeftIndentPx * 15);
 
     tabContext = {
       ...(explicitStops !== undefined ? { explicitStops } : {}),
@@ -2237,6 +2244,8 @@ export function renderLine(
   // We need to track where on that coordinate system our text is
   let currentX: number;
   const leftIndentPx = options?.leftIndentPx ?? 0;
+  const tabLeftIndentPx = options?.tabLeftIndentPx ?? leftIndentPx;
+  const floatingLeftOffsetPx = options?.floatingMargins?.leftMargin ?? 0;
 
   if (options?.isFirstLine) {
     // First line position depends on first-line indent or hanging indent:
@@ -2248,10 +2257,10 @@ export function renderLine(
     // measureParagraph.ts contentX comment).
     const firstLineIndentPx = options.firstLineIndentPx ?? 0;
     const markerInlineWidth = getListMarkerInlineWidth(block);
-    currentX = leftIndentPx + firstLineIndentPx + markerInlineWidth;
+    currentX = tabLeftIndentPx + firstLineIndentPx + markerInlineWidth + floatingLeftOffsetPx;
   } else {
     // Non-first lines start at the left indent position
-    currentX = leftIndentPx;
+    currentX = tabLeftIndentPx + floatingLeftOffsetPx;
   }
 
   // Render each run
@@ -2304,6 +2313,7 @@ export function renderLine(
       }
       const useRightAnchor =
         lineRightEdgeX !== undefined &&
+        options?.isRtl !== true &&
         tabResult.alignment === "end" &&
         !hasFollowingTab &&
         currentX + tabResult.width + followingWidthForCheck >=
@@ -2344,19 +2354,20 @@ export function renderLine(
         tabEl.style.width = "auto";
         lineEl.append(tabEl);
 
-        // Re-apply the first-line indent as margin-left on the first flex
-        // child now that we know what it is (the tab itself when no prior
+        // Re-apply the first-line indent on the first child now that we know
+        // what it is (the tab itself when no prior
         // runs rendered, or the earlier text/image otherwise). Done AFTER
         // append so we don't no-op on tab-first lines (firstElementChild
         // would be null pre-append). Both negative (hanging) and positive
         // (firstLine) offsets are honoured.
+        const firstFlexChild = lineEl.firstElementChild ?? undefined;
         if (
           options?.isFirstLine &&
           options.firstLineIndentPx !== undefined &&
           options.firstLineIndentPx !== 0 &&
-          lineEl.firstElementChild instanceof HTMLElement
+          isStyleableHTMLElement(firstFlexChild)
         ) {
-          lineEl.firstElementChild.style.marginLeft = `${options.firstLineIndentPx}px`;
+          firstFlexChild.style.marginLeft = `${options.firstLineIndentPx}px`;
         }
 
         // Render the remaining runs into the line at their natural width.
@@ -2396,11 +2407,22 @@ export function renderLine(
       // the content area (Word TOC styles author stops a hair beyond the
       // margin); without this, the painted tab spills into the right margin.
       let tabWidth = tabResult.width;
+      const activeContentRightEdge =
+        options?.contentWidthPx === undefined
+          ? undefined
+          : options.contentWidthPx - (options.floatingMargins?.rightMargin ?? 0);
+      const preservesLogicalRtlEndStop =
+        options?.isRtl === true &&
+        tabResult.alignment === "end" &&
+        activeContentRightEdge !== undefined &&
+        currentX + tabWidth + followingWidthForCheck <=
+          activeContentRightEdge + RIGHT_EDGE_EPSILON_PX;
       const landsOnLeftIndent =
         tabResult.alignment === "start" &&
-        leftIndentPx > 0 &&
-        Math.abs(currentX + tabWidth - leftIndentPx) <= RIGHT_EDGE_EPSILON_PX;
+        tabLeftIndentPx > 0 &&
+        Math.abs(currentX + tabWidth - tabLeftIndentPx) <= RIGHT_EDGE_EPSILON_PX;
       if (
+        !preservesLogicalRtlEndStop &&
         !landsOnLeftIndent &&
         lineRightEdgeX !== undefined &&
         canClampTabToRightEdge(
@@ -2586,34 +2608,6 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
 }
 
 /**
- * Decide whether a paragraph without an explicit `w:bidi` flag should still be
- * laid out right-to-left. Only paragraphs that carry at least one `w:rtl` run
- * are candidates; among those the base direction follows the first strong
- * directional character (the `dir="auto"` rule), so Hebrew/Arabic-led lines
- * order RTL while an English- (or CJK-/Devanagari-/…) led line stays LTR.
- * eigenpal #723 (#719).
- */
-function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
-  // Text runs plus field runs (a field result like a cross-reference renders as
-  // text, so it can be the paragraph's first strong character).
-  const runs = block.runs.filter((r) => isTextRun(r) || isFieldRun(r));
-  if (!runs.some((r) => r.rtl)) {
-    return false;
-  }
-  const text = runs
-    .map((r) => {
-      if (isTextRun(r)) {
-        return r.text;
-      }
-      return isFieldRun(r) ? (r.fallback ?? "") : "";
-    })
-    .join("");
-  // First strong directional character decides; nothing strong (null) => honor
-  // w:rtl, "rtl" => RTL; only an explicit "ltr" first char stays LTR.
-  return detectBaseDirection(text) !== "ltr";
-}
-
-/**
  * Render a paragraph fragment
  *
  * @param fragment - The fragment to render
@@ -2678,7 +2672,7 @@ export function renderParagraphFragment(
   // `dir`-marked spans (each an isolate), so without a base `dir` on the
   // fragment the runs stay in logical LTR order and reversed Hebrew/Arabic
   // reads backwards. eigenpal #723 (#719).
-  const isRtl = block.attrs?.bidi ?? paragraphBaseIsRtl(block);
+  const isRtl = isRtlParagraph(block);
   if (isRtl) {
     fragmentEl.dir = "rtl";
   }
@@ -2910,7 +2904,10 @@ export function renderParagraphFragment(
       paragraphEndsWithLineBreak,
       ...(block.attrs?.tabs !== undefined ? { tabStops: block.attrs.tabs } : {}),
       leftIndentPx: indentLeft,
+      tabLeftIndentPx: indent?.left ?? 0,
       firstLineIndentPx: isFirstLine ? firstLineIndentPx : 0,
+      isRtl,
+      contentWidthPx: fragment.width,
       context,
       floatingMargins: {
         leftMargin: lineLeftOffset,
@@ -2966,27 +2963,18 @@ export function renderParagraphFragment(
     const hasFirstLine = indent?.firstLine && indent.firstLine > 0;
 
     if (isFirstLine) {
-      // First line handling
-      if (indentLeft !== 0 && hasHanging) {
-        // Hanging indent: first line starts at (indentLeft - hanging)
-        lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
-        if (!isFlexLine) {
-          lineEl.style.textIndent = `-${indent.hanging ?? 0}px`;
-        }
-      } else if (indentLeft !== 0 && hasFirstLine) {
-        // First line indent: first line starts at (indentLeft + firstLine)
-        lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
-        if (!isFlexLine) {
-          lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
-        }
-      } else if (indentLeft > 0) {
-        // Just left indent, no special first line treatment
+      if (indentLeft > 0) {
         lineEl.style.paddingLeft = `${indentLeft}px`;
+      }
+      // CSS text-indent follows the inline start edge, so it applies at the
+      // right for an RTL line. Keep it independent of physical left padding:
+      // asymmetric RTL indents can have no left padding while still carrying
+      // a logical hanging indent at the right edge.
+      if (hasHanging && !isFlexLine) {
+        lineEl.style.textIndent = `-${indent.hanging ?? 0}px`;
       } else if (hasFirstLine && !isFlexLine) {
-        // No left indent, but has first line indent.
         lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
       }
-      // No hanging without left indent (handled by firstLineOffset in measurement)
     } else if (indentLeft > 0) {
       // Body lines (not first line)
       lineEl.style.paddingLeft = `${indentLeft}px`;

--- a/packages/core/src/layout-painter/renderTextBox.ts
+++ b/packages/core/src/layout-painter/renderTextBox.ts
@@ -61,7 +61,7 @@ export function renderTextBoxFragment(
   containerEl.style.position = "absolute";
   containerEl.style.width = `${fragment.width}px`;
   containerEl.style.height = `${fragment.height}px`;
-  containerEl.style.overflow = "hidden";
+  containerEl.style.overflow = block.textWrap === "none" ? "visible" : "hidden";
   containerEl.style.boxSizing = "border-box";
 
   // Fill color

--- a/packages/core/src/layout-painter/renderUtils.ts
+++ b/packages/core/src/layout-painter/renderUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ImageRun } from "../layout-engine/types";
+import type { NumberFormat } from "../types/document";
 
 // `isFloatingImageRun` and `isTextWrappingFloatingImageRun` are pure
 // predicates over `ImageRun` and now live in `layout-engine/types` so the
@@ -47,7 +48,7 @@ export type RenderContext = {
   /** Current page number (1-indexed) */
   pageNumber: number;
   /** OOXML section-level format for the current logical page number. */
-  pageNumberFormat?: string;
+  pageNumberFormat?: NumberFormat;
   /** Total number of pages */
   totalPages: number;
   /** Which section is being rendered */

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -103,6 +103,10 @@ const TEXT_BOX_AUTO_FIT_VALUES = [
   "shape",
 ] as const satisfies readonly NonNullable<TextBoxAttrs["autoFit"]>[];
 
+const TEXT_BOX_TEXT_WRAP_VALUES = ["square", "none"] as const satisfies readonly NonNullable<
+  TextBoxAttrs["textWrap"]
+>[];
+
 const FIELD_KINDS = ["simple", "complex"] as const satisfies readonly FieldAttrs["fieldKind"][];
 
 const MATH_DISPLAYS = ["inline", "block"] as const satisfies readonly NonNullable<
@@ -769,6 +773,7 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
   optionalNumber(attrs, "width", "textBox.attrs.width", issues);
   optionalNumber(attrs, "height", "textBox.attrs.height", issues);
   optionalOneOf(attrs, "autoFit", "textBox.attrs.autoFit", issues, TEXT_BOX_AUTO_FIT_VALUES);
+  optionalOneOf(attrs, "textWrap", "textBox.attrs.textWrap", issues, TEXT_BOX_TEXT_WRAP_VALUES);
   optionalString(attrs, "textBoxId", "textBox.attrs.textBoxId", issues);
   optionalString(attrs, "fillColor", "textBox.attrs.fillColor", issues);
   optionalNumber(attrs, "outlineWidth", "textBox.attrs.outlineWidth", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -1662,7 +1662,7 @@ describe("fromProseDoc", () => {
 
   test("converts textBox nodes back to DOCX text box shapes", () => {
     const pmDoc = schema.node("doc", null, [
-      schema.node("textBox", { width: 120, height: 60, autoFit: "shape" }, [
+      schema.node("textBox", { width: 120, height: 60, autoFit: "shape", textWrap: "none" }, [
         schema.node("paragraph", null, [schema.text("Inside")]),
       ]),
     ]);
@@ -1685,6 +1685,7 @@ describe("fromProseDoc", () => {
     expect(firstRunContent.shape.shapeType).toBe("textBox");
     expect(firstRunContent.shape.textBody?.content).toHaveLength(1);
     expect(firstRunContent.shape.textBody?.autoFit).toBe("shape");
+    expect(firstRunContent.shape.textBody?.textWrap).toBe("none");
   });
 
   test("converts tables inside text boxes back to shape content", () => {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -3354,6 +3354,7 @@ function convertPMTextBox(node: PMNode): Paragraph {
     textBody: {
       content: childBlocks.length > 0 ? childBlocks : [{ type: "paragraph", content: [] }],
       ...(attrs.autoFit !== undefined ? { autoFit: attrs.autoFit } : {}),
+      ...(attrs.textWrap !== undefined ? { textWrap: attrs.textWrap } : {}),
       margins: (() => {
         const m: {
           top?: number;

--- a/packages/core/src/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
@@ -26,6 +26,7 @@ function textBoxAttrsFromImport(args: {
   distLEmu?: number;
   distREmu?: number;
   autoFit?: "none" | "normal" | "shape";
+  textWrap?: "square" | "none";
 }): TextBoxAttrs {
   const document: Document = {
     package: {
@@ -68,6 +69,7 @@ function textBoxAttrsFromImport(args: {
                       },
                       textBody: {
                         ...(args.autoFit !== undefined ? { autoFit: args.autoFit } : {}),
+                        ...(args.textWrap !== undefined ? { textWrap: args.textWrap } : {}),
                         content: [
                           {
                             type: "paragraph",
@@ -103,9 +105,14 @@ function textBoxAttrsFromImport(args: {
 
 describe("toProseDoc propagates text-box wrap attributes", () => {
   test("preserves the text fitting mode", () => {
-    const attrs = textBoxAttrsFromImport({ wrapType: "inline", autoFit: "shape" });
+    const attrs = textBoxAttrsFromImport({
+      wrapType: "inline",
+      autoFit: "shape",
+      textWrap: "none",
+    });
 
     expect(attrs["autoFit"]).toBe("shape");
+    expect(attrs["textWrap"]).toBe("none");
   });
 
   test("wrap='square' + wrapText='right' becomes a left-floating wrap", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -3290,6 +3290,9 @@ function textBoxFromShape(shape: Shape, textBody: ShapeTextBody): TextBox {
   if (textBody.autoFit) {
     textBox.autoFit = textBody.autoFit;
   }
+  if (textBody.textWrap) {
+    textBox.textWrap = textBody.textWrap;
+  }
   return textBox;
 }
 
@@ -3433,6 +3436,7 @@ function convertTextBox(
       width: widthPx,
       height: heightPx,
       autoFit: textBox.autoFit,
+      textWrap: textBox.textWrap,
       textBoxId: textBox.id,
       fillColor,
       outlineWidth,

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -19,6 +19,8 @@ export type TextBoxAttrs = {
   height?: number;
   /** Text fitting behavior */
   autoFit?: ShapeTextBody["autoFit"];
+  /** Horizontal text wrapping inside the box */
+  textWrap?: ShapeTextBody["textWrap"];
   /** Unique identifier */
   textBoxId?: string;
   /** Fill color as CSS color */
@@ -100,6 +102,13 @@ function parseTextBoxAutoFit(raw: string | undefined): TextBoxAttrs["autoFit"] {
   return undefined;
 }
 
+function parseTextBoxTextWrap(raw: string | undefined): TextBoxAttrs["textWrap"] {
+  if (raw === "none" || raw === "square") {
+    return raw;
+  }
+  return undefined;
+}
+
 export const TextBoxExtension = createNodeExtension({
   name: "textBox",
   schemaNodeName: "textBox",
@@ -112,6 +121,7 @@ export const TextBoxExtension = createNodeExtension({
       width: { default: 200 },
       height: { default: null },
       autoFit: { default: null },
+      textWrap: { default: null },
       textBoxId: { default: null },
       fillColor: { default: null },
       outlineWidth: { default: null },
@@ -149,10 +159,12 @@ export const TextBoxExtension = createNodeExtension({
           const position = parseTextBoxPosition(d["position"]);
           const wrapType = parseTextBoxWrapType(d["wrapType"]);
           const autoFit = parseTextBoxAutoFit(d["autoFit"]);
+          const textWrap = parseTextBoxTextWrap(d["textWrap"]);
           return {
             ...(d["width"] ? { width: Number(d["width"]) } : {}),
             ...(d["height"] ? { height: Number(d["height"]) } : {}),
             ...(autoFit ? { autoFit } : {}),
+            ...(textWrap ? { textWrap } : {}),
             ...(d["textboxId"] ? { textBoxId: d["textboxId"] } : {}),
             ...(d["fillColor"] ? { fillColor: d["fillColor"] } : {}),
             ...(d["outlineWidth"] ? { outlineWidth: Number(d["outlineWidth"]) } : {}),
@@ -207,6 +219,9 @@ export const TextBoxExtension = createNodeExtension({
       }
       if (attrs.autoFit) {
         domAttrs["data-auto-fit"] = attrs.autoFit;
+      }
+      if (attrs.textWrap) {
+        domAttrs["data-text-wrap"] = attrs.textWrap;
       }
       if (attrs.textBoxId) {
         domAttrs["data-textbox-id"] = attrs.textBoxId;

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -566,6 +566,8 @@ export type TextBoxAttrs = {
   height?: number;
   /** Text fitting behavior */
   autoFit?: ShapeTextBody["autoFit"];
+  /** Horizontal text wrapping inside the box */
+  textWrap?: ShapeTextBody["textWrap"];
   /** Unique identifier */
   textBoxId?: string;
   /** Fill color as CSS color */

--- a/packages/core/src/utils/paragraphBaseDirection.ts
+++ b/packages/core/src/utils/paragraphBaseDirection.ts
@@ -1,0 +1,18 @@
+import type { FieldRun, ParagraphBlock, TextRun } from "../layout-engine/types";
+import { detectBaseDirection } from "./baseDirection";
+
+const isDirectionalTextRun = (run: ParagraphBlock["runs"][number]): run is TextRun | FieldRun =>
+  run.kind === "text" || run.kind === "field";
+
+/** Resolve the paragraph direction used by both measurement and painting. */
+export const isRtlParagraph = (block: ParagraphBlock): boolean => {
+  if (block.attrs?.bidi !== undefined) {
+    return block.attrs.bidi;
+  }
+  const runs = block.runs.filter(isDirectionalTextRun);
+  if (!runs.some(({ rtl }) => rtl === true)) {
+    return false;
+  }
+  const text = runs.map((run) => (run.kind === "text" ? run.text : (run.fallback ?? ""))).join("");
+  return detectBaseDirection(text) !== "ltr";
+};

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -775,6 +775,8 @@ export type ShapeTextBody = {
   anchorCenter?: boolean;
   /** Auto fit */
   autoFit?: "none" | "normal" | "shape";
+  /** Horizontal text wrapping inside the shape */
+  textWrap?: "square" | "none";
   /** Text margins */
   margins?: {
     top?: number;
@@ -836,6 +838,8 @@ export type TextBox = {
   content: (Paragraph | Table)[];
   /** Text fitting behavior */
   autoFit?: ShapeTextBody["autoFit"];
+  /** Horizontal text wrapping inside the box */
+  textWrap?: ShapeTextBody["textWrap"];
   /** Internal margins */
   margins?: {
     top?: number;
@@ -1725,7 +1729,7 @@ export type SectionProperties = {
   // Page numbers
   /** Page numbering settings */
   pageNumbering?: {
-    format?: string;
+    format?: NumberFormat;
     start?: number;
     chapterStyle?: number;
     chapterSeparator?: string;

--- a/parity/__tests__/textNorm.test.ts
+++ b/parity/__tests__/textNorm.test.ts
@@ -10,6 +10,18 @@ describe("normalizeLineText", () => {
     ).toBe("Definitions … 2");
   });
 
+  test("canonicalizes PDF visual order for RTL dot-leader entries", () => {
+    expect(normalizeLineText("1 ........ ........ أ- عنوان عربي")).toBe("أ- عنوان عربي … 1");
+    expect(normalizeLineText("أ- عنوان عربي ........ 1")).toBe("أ- عنوان عربي … 1");
+    expect(normalizeLineText("1 ........ 𞤀𞤣𞤢𞤤")).toBe("𞤀𞤣𞤢𞤤 … 1");
+  });
+
+  test("does not reorder LTR or non-leader numeric text", () => {
+    expect(normalizeLineText("1 ........ Definitions")).toBe("1 … Definitions");
+    expect(normalizeLineText("1 عنوان عربي")).toBe("1 عنوان عربي");
+    expect(normalizeLineText("1 ........ Terms وشروط")).toBe("1 … Terms وشروط");
+  });
+
   test("normalizes Symbol-font copyright extraction noise", () => {
     expect(normalizeLineText("\uf0e3 Loan Market Association")).toBe("ã Loan Market Association");
   });

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -831,6 +831,19 @@ export const extractSinglePage = (page: Page, domIndex: number): Promise<RawPage
             return rect.width > 0 && rect.height > 0 ? rect : null;
           }
 
+          // Leader tabs paint a deliberately overlong dot/hyphen string in an
+          // overflow-clipped child. A Range reports that child's unpainted
+          // thousands-of-pixels width, so use the clipping tab box as its ink
+          // extent. This keeps parity geometry aligned with the screenshot and
+          // the PDF extractor while retaining the leader text for comparison.
+          if (
+            segmentEl.classList.contains("layout-run-tab") &&
+            segmentEl.querySelector(":scope > span")?.textContent
+          ) {
+            const rect = segmentEl.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0 ? rect : null;
+          }
+
           const walker = document.createTreeWalker(segmentEl, NodeFilter.SHOW_TEXT);
           let firstNode: Text | null = null;
           let firstOffset = 0;

--- a/parity/textNorm.ts
+++ b/parity/textNorm.ts
@@ -1,13 +1,27 @@
+import { detectBaseDirection } from "../packages/core/src/utils/baseDirection";
+
 /**
  * Text normalisation shared by every extractor and the comparator. Both sides
  * of the diff must normalise identically or alignment falls apart.
  */
 
+const RTL_LEADER_LINE_PATTERN = /^(?<page>[\p{Decimal_Number}]+)\s+…\s+(?<title>.+)$/u;
+
+const normalizeRtlLeaderOrder = (text: string): string => {
+  const match = text.match(RTL_LEADER_LINE_PATTERN);
+  const page = match?.groups?.["page"];
+  const title = match?.groups?.["title"];
+  if (!page || !title || detectBaseDirection(title) !== "rtl") {
+    return text;
+  }
+  return `${title} … ${page}`;
+};
+
 /** NFC-normalise, fold known PDF glyph aliases, drop soft hyphens and
  * zero-width characters, fold all whitespace (incl. NBSP variants and tabs)
  * to single spaces, trim. */
-export const normalizeLineText = (text: string): string =>
-  text
+export const normalizeLineText = (text: string): string => {
+  const normalized = text
     .normalize("NFC")
     // Some CJK PDF font maps expose an ordinary ideograph as the equivalent
     // CJK or Kangxi radical (for example 乙 as U+2F04). The visual glyph and
@@ -17,8 +31,11 @@ export const normalizeLineText = (text: string): string =>
     .replace(/\uf0b7/gu, "•")
     .replace(/\uf0e3/gu, "ã")
     .replace(/\s*\.{3,}\s*/gu, " … ")
+    .replace(/(?:\s*…\s*){2,}/gu, " … ")
     .replace(/\s+/gu, " ")
     .trim();
+  return normalizeRtlLeaderOrder(normalized);
+};
 
 /** Levenshtein-based similarity in [0, 1]; 1 means identical. */
 export const textSimilarity = (a: string, b: string): number => {


### PR DESCRIPTION
## Summary

- preserve DrawingML no-wrap text boxes through parse, edit, save, and shape autofit
- keep section transitions boundary-owned and coalesce only duplicate section advances
- align RTL logical tabs across measurement, painting, floating exclusions, and mixed-direction links
- render PAGE fields with typed OOXML number formats and make parity extraction bidi-aware

## Validation

- bun run typecheck
- bun run lint
- bun run format:check
- bun run test
- bun run build
- bun run validate-dist
- bun run api:check
- Microsoft Word parity: 12/12 pages in the exercised complex Arabic slice

CC on behalf of jan-kubica