### PR TITLE
fix: preserve cached table page boundaries

### DIFF
--- a/.changeset/tidy-arabic-table-breaks.md
+++ b/.changeset/tidy-arabic-table-breaks.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve safe cached page boundaries inside split table rows.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1087,6 +1087,24 @@ function layoutTable(
     const splittableRow = rows[currentRowIndex]!; // SAFETY: currentRowIndex < rows.length
     if (canSplitRow(currentRowIndex)) {
       let consumed = 0;
+      const renderedBreakHints = tableRowHasTrackedChanges(block, currentRowIndex)
+        ? []
+        : (breakInfo.renderedBreakHints[currentRowIndex] ?? []);
+      let renderedBreakHintIndex = 0;
+      const discardPassedRenderedBreakHints = (): void => {
+        while ((renderedBreakHints[renderedBreakHintIndex]?.offset ?? Infinity) <= consumed) {
+          renderedBreakHintIndex += 1;
+        }
+      };
+      const advanceAfterNaturalFlowBreak = (previousPageNumber: number): void => {
+        discardPassedRenderedBreakHints();
+        if (
+          paginator.getCurrentState().page.number > previousPageNumber &&
+          renderedBreakHintIndex < renderedBreakHints.length
+        ) {
+          renderedBreakHintIndex += 1;
+        }
+      };
       while (consumed < splittableRow.height) {
         const sliceState = paginator.getCurrentState();
         const repeatHeaderRows = shouldRepeatHeaderRows(currentRowIndex, consumed, sliceState);
@@ -1096,13 +1114,16 @@ function layoutTable(
           headerOverhead -
           (consumed === 0 ? sliceState.trailingSpacing : 0);
         let slice = snapRowBreak(breakInfo, currentRowIndex, consumed, sliceAvail);
+        let forceRenderedPageBreak = false;
         if (slice <= 0) {
           const isFreshPage =
             sliceState.cursorY === sliceState.topMargin && sliceState.page.fragments.length === 0;
           if (!isFreshPage) {
             // Not even one line fits in the space left; continue in the next
             // column, or on a fresh page when this is the last column.
+            const previousPageNumber = sliceState.page.number;
             paginator.forceColumnBreak();
+            advanceAfterNaturalFlowBreak(previousPageNumber);
             continue;
           }
           // Fresh page and a single line still exceeds the page height: place
@@ -1110,6 +1131,18 @@ function layoutTable(
           const from = consumed;
           const next = breakInfo.breakOffsets[currentRowIndex]?.find((o) => o > from);
           slice = (next ?? splittableRow.height) - consumed;
+        }
+        discardPassedRenderedBreakHints();
+        const renderedBreakHint = renderedBreakHints[renderedBreakHintIndex];
+        if (
+          renderedBreakHint &&
+          renderedBreakHint.offset <= consumed + slice &&
+          sliceAvail - (renderedBreakHint.offset - consumed) <=
+            renderedBreakHint.lineAdvance * RENDERED_BREAK_REFLOW_TOLERANCE_LINES
+        ) {
+          slice = renderedBreakHint.offset - consumed;
+          renderedBreakHintIndex += 1;
+          forceRenderedPageBreak = true;
         }
         const sliceBottom = consumed + slice;
         const continuationSkip =
@@ -1143,7 +1176,13 @@ function layoutTable(
         sliceFragment.x = computeTableX(sliceResult.state.columnIndex);
         consumed = nextConsumed;
         if (consumed < splittableRow.height) {
-          paginator.forceColumnBreak();
+          if (forceRenderedPageBreak) {
+            paginator.forcePageBreak();
+          } else {
+            const previousPageNumber = paginator.getCurrentState().page.number;
+            paginator.forceColumnBreak();
+            advanceAfterNaturalFlowBreak(previousPageNumber);
+          }
         }
       }
       currentRowIndex += 1;

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -85,6 +85,35 @@ function paraMeasure(n: number): ParagraphMeasure {
   return paraMeasureWithLineHeight(n, LINE);
 }
 
+function markMeasuredLineWithRenderedBreak(measure: TableMeasure, lineIndex: number): void {
+  const paragraph = measure.rows.at(0)?.cells.at(0)?.blocks.at(0);
+  if (paragraph?.kind !== "paragraph") {
+    throw new Error("test table must start with a measured paragraph");
+  }
+  const line = paragraph.lines.at(lineIndex);
+  if (!line) {
+    throw new Error("test paragraph must contain the marked line");
+  }
+  line.renderedPageBreakBefore = true;
+}
+
+function markInternalTableParagraphBreak(
+  block: TableBlock,
+  measure: TableMeasure,
+  lineIndex: number,
+): void {
+  const paragraph = block.rows.at(0)?.cells.at(0)?.blocks.at(0);
+  if (paragraph?.kind !== "paragraph") {
+    throw new Error("test table must start with a paragraph");
+  }
+  paragraph.runs = [
+    { kind: "text", text: "before" },
+    { kind: "renderedPageBreak" },
+    { kind: "text", text: "after" },
+  ];
+  markMeasuredLineWithRenderedBreak(measure, lineIndex);
+}
+
 /** A single-cell, single-paragraph table whose one row is `n` lines tall. */
 function tallTable(n: number): { block: TableBlock; measure: TableMeasure } {
   const height = n * LINE;
@@ -307,6 +336,83 @@ describe("buildTableRowBreakInfo / snapRowBreak", () => {
     const info = buildTableRowBreakInfo(block, measure);
     expect(info.rowTops).toEqual([0, 3 * LINE]);
     expect(info.breakOffsets[0]).toEqual([LINE, 2 * LINE, 3 * LINE]);
+  });
+
+  test("records a rendered break at the marked line top", () => {
+    const { block, measure } = tallTable(3);
+    markMeasuredLineWithRenderedBreak(measure, 1);
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(info.renderedBreakHints[0]).toEqual([{ offset: LINE, lineAdvance: LINE }]);
+  });
+
+  test("shifts rendered break hints with vertical cell alignment", () => {
+    const { block, measure } = tallTable(2);
+    block.rows[0]!.cells[0]!.verticalAlign = "bottom";
+    measure.rows[0]!.height = 4 * LINE;
+    measure.totalHeight = 4 * LINE;
+    markMeasuredLineWithRenderedBreak(measure, 1);
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(info.renderedBreakHints[0]).toEqual([{ offset: 3 * LINE, lineAdvance: LINE }]);
+  });
+
+  test("retains a one-cell rendered break that is safe for its sibling", () => {
+    const { block, measure } = tallTable(3);
+    markMeasuredLineWithRenderedBreak(measure, 1);
+    block.rows[0]!.cells.push({
+      id: "c1",
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      blocks: [
+        {
+          kind: "paragraph",
+          id: "p1",
+          runs: [{ kind: "text", text: "sibling" }],
+        },
+      ],
+    });
+    block.columnWidths = [110, 110];
+    measure.rows[0]!.cells.push({
+      blocks: [paraMeasure(3)],
+      width: 110,
+      height: 3 * LINE,
+    });
+    measure.rows[0]!.cells[0]!.width = 110;
+    measure.columnWidths = [110, 110];
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(info.renderedBreakHints[0]).toEqual([{ offset: LINE, lineAdvance: LINE }]);
+  });
+
+  test("rejects a rendered break that intersects a sibling glyph range", () => {
+    const { block, measure } = tallTable(3);
+    markMeasuredLineWithRenderedBreak(measure, 1);
+    block.rows[0]!.cells.push({
+      id: "c1",
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      blocks: [
+        {
+          kind: "paragraph",
+          id: "p1",
+          runs: [{ kind: "text", text: "sibling" }],
+        },
+      ],
+    });
+    block.columnWidths = [110, 110];
+    measure.rows[0]!.cells.push({
+      blocks: [paraMeasureWithLineHeight(2, 30)],
+      width: 110,
+      height: 3 * LINE,
+    });
+    measure.rows[0]!.cells[0]!.width = 110;
+    measure.columnWidths = [110, 110];
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(info.renderedBreakHints[0]).toEqual([]);
   });
 
   test("seats break offsets on painted line boundaries despite paragraph space-before", () => {
@@ -1259,6 +1365,132 @@ describe("oversized table row splits across pages (#570)", () => {
 
     expect(layout.pages).toHaveLength(1);
     expect(fragment).toMatchObject({ y: OPTIONS.margins.top + 20, height: 3 * LINE });
+  });
+
+  test("snaps a safe internal rendered boundary near the page edge", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 45);
+    const { block, measure } = tallTable(5);
+    markInternalTableParagraphBreak(block, measure, 2);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const fragments = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(fragments.map(({ topClip, bottomClip }) => [topClip, bottomClip])).toEqual([
+      [undefined, 2 * LINE],
+      [2 * LINE, undefined],
+    ]);
+    expect(layout.pages[1]?.fragments.at(0)).toMatchObject({ kind: "table" });
+  });
+
+  test("keeps an early internal rendered boundary advisory", () => {
+    const { block, measure } = tallTable(10);
+    markInternalTableParagraphBreak(block, measure, 1);
+
+    const fragments = tableFragments(block, measure);
+
+    expect(fragments.at(0)?.bottomClip).toBe(6 * LINE);
+  });
+
+  test("ignores an internal rendered boundary when the row has tracked content", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 45);
+    const { block, measure } = tallTable(5);
+    markInternalTableParagraphBreak(block, measure, 2);
+    const paragraph = block.rows.at(0)?.cells.at(0)?.blocks.at(0);
+    const textRun = paragraph?.kind === "paragraph" ? paragraph.runs.at(0) : undefined;
+    if (textRun?.kind !== "text") {
+      throw new Error("test table must start with a text run");
+    }
+    textRun.isInsertion = true;
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const firstTableFragment = layout.pages[0]?.fragments.find(
+      (fragment): fragment is TableFragment => fragment.kind === "table",
+    );
+
+    expect(firstTableFragment?.bottomClip).toBe(3 * LINE);
+  });
+
+  test("consumes a cached boundary after natural reflow already opens a page", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 70);
+    const { block, measure } = tallTable(10);
+    markInternalTableParagraphBreak(block, measure, 5);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const fragments = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(fragments.map(({ bottomClip }) => bottomClip)).toEqual([2 * LINE, 8 * LINE, undefined]);
+  });
+
+  test("applies ordered internal rendered boundaries without gaps or overlaps", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 20);
+    const { block, measure } = tallTable(16);
+    markInternalTableParagraphBreak(block, measure, 4);
+    markMeasuredLineWithRenderedBreak(measure, 10);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const fragments = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+    const bands = fragments.map(({ topClip, bottomClip }) => [
+      topClip ?? 0,
+      bottomClip ?? 16 * LINE,
+    ]);
+
+    expect(bands).toEqual([
+      [0, 4 * LINE],
+      [4 * LINE, 10 * LINE],
+      [10 * LINE, 16 * LINE],
+    ]);
+  });
+
+  test("uses a new page, not the next column, for an internal rendered boundary", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 45);
+    const { block, measure } = tallTable(5);
+    markInternalTableParagraphBreak(block, measure, 2);
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], {
+      ...OPTIONS,
+      columns: { count: 2, gap: 20 },
+    });
+    const firstPageTables =
+      layout.pages[0]?.fragments.filter(
+        (fragment): fragment is TableFragment => fragment.kind === "table",
+      ) ?? [];
+    const secondPageTable = layout.pages[1]?.fragments.find(
+      (fragment): fragment is TableFragment => fragment.kind === "table",
+    );
+
+    expect(firstPageTables).toHaveLength(1);
+    expect(secondPageTable?.x).toBe(OPTIONS.margins.left);
   });
 
   test("does not promote one cell's cached boundary to the whole row", () => {

--- a/packages/core/src/layout-engine/tableRowBreak.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.ts
@@ -14,6 +14,7 @@
  */
 
 import { measureParagraph } from "./measure";
+import { measuredLineAdvance } from "./lineFlow";
 import {
   buildTableCellFloatingZones,
   getTableCellContentWidth,
@@ -34,8 +35,14 @@ type UnsafeBreakRange = {
   bottom: number;
 };
 
+type RenderedRowBreakHint = {
+  offset: number;
+  lineAdvance: number;
+};
+
 type CellBreakGeometry = {
   bottoms: number[];
+  renderedBreakHints: RenderedRowBreakHint[];
   unsafeRanges: UnsafeBreakRange[];
   suppressibleLeadingRanges: UnsafeBreakRange[];
 };
@@ -67,6 +74,10 @@ function shiftCellGeometry(geometry: CellBreakGeometry, offset: number): CellBre
   }
   return {
     bottoms: geometry.bottoms.map((bottom) => bottom + offset),
+    renderedBreakHints: geometry.renderedBreakHints.map((hint) => ({
+      offset: hint.offset + offset,
+      lineAdvance: hint.lineAdvance,
+    })),
     unsafeRanges: geometry.unsafeRanges.map((range) => ({
       top: range.top + offset,
       bottom: range.bottom + offset,
@@ -86,6 +97,7 @@ function cellBreakGeometry(
   // Mirror the painter's shared cell-flow placement so clean row breaks stay
   // aligned with both glyph boundaries and inter-paragraph whitespace.
   const bottoms: number[] = [];
+  const renderedBreakHints: RenderedRowBreakHint[] = [];
   const unsafeRanges: UnsafeBreakRange[] = [];
   const suppressibleLeadingRanges: UnsafeBreakRange[] = [];
   const cellBlocks = cell?.blocks;
@@ -124,6 +136,9 @@ function cellBreakGeometry(
       for (const line of blockMeasure.lines) {
         y += line.floatSkipBefore ?? 0;
         const top = y;
+        if (line.renderedPageBreakBefore === true) {
+          renderedBreakHints.push({ offset: top, lineAdvance: measuredLineAdvance(line) });
+        }
         y += line.lineHeight;
         unsafeRanges.push({ top, bottom: y });
         bottoms.push(y);
@@ -147,8 +162,21 @@ function cellBreakGeometry(
       }
     }
   }
-  return { bottoms, unsafeRanges, suppressibleLeadingRanges };
+  return { bottoms, renderedBreakHints, unsafeRanges, suppressibleLeadingRanges };
 }
+
+const mergeRenderedBreakHints = (hints: RenderedRowBreakHint[]): RenderedRowBreakHint[] => {
+  const merged: RenderedRowBreakHint[] = [];
+  for (const hint of hints.sort((a, b) => a.offset - b.offset)) {
+    const previous = merged.at(-1);
+    if (previous && Math.abs(previous.offset - hint.offset) <= BREAK_OFFSET_EPSILON) {
+      previous.lineAdvance = Math.max(previous.lineAdvance, hint.lineAdvance);
+      continue;
+    }
+    merged.push({ ...hint });
+  }
+  return merged;
+};
 
 const continuationSkipForCell = (
   geometry: CellBreakGeometry,
@@ -194,6 +222,8 @@ export type TableRowBreakInfo = {
    * final boundary.
    */
   breakOffsets: number[][];
+  /** Safe cached page boundaries within each row, relative to the row top. */
+  renderedBreakHints: RenderedRowBreakHint[][];
   /** Suppressible leading paragraph whitespace after each matching break offset. */
   continuationSkips: number[][];
 };
@@ -213,6 +243,7 @@ export function buildTableRowBreakInfo(
   rowTops.push(acc);
 
   const breakOffsets: number[][] = [];
+  const renderedBreakHints: RenderedRowBreakHint[][] = [];
   const continuationSkips: number[][] = [];
   for (let r = 0; r < rowCount; r++) {
     const rowHeight = measure.rows[r]?.height ?? 0;
@@ -247,12 +278,26 @@ export function buildTableRowBreakInfo(
     );
     const sortedOffsets = safeOffsets.sort((a, b) => a - b);
     breakOffsets.push(sortedOffsets);
+    renderedBreakHints.push(
+      mergeRenderedBreakHints(
+        cellGeometries
+          .flatMap((geometry) => geometry.renderedBreakHints)
+          .filter(
+            ({ offset }) =>
+              offset > BREAK_OFFSET_EPSILON &&
+              offset < rowHeight - BREAK_OFFSET_EPSILON &&
+              cellGeometries.every((geometry) =>
+                geometry.unsafeRanges.every((range) => !isInsideRange(offset, range)),
+              ),
+          ),
+      ),
+    );
     continuationSkips.push(
       sortedOffsets.map((offset) => continuationSkipAfter(cellGeometries, offset)),
     );
   }
 
-  return { rowTops, breakOffsets, continuationSkips };
+  return { rowTops, breakOffsets, renderedBreakHints, continuationSkips };
 }
 
 /** Leading empty-paragraph whitespace to consume when a row resumes after `offset`. */


### PR DESCRIPTION
Preserves safe internal `w:lastRenderedPageBreak` hints while splitting table rows.

Hints remain advisory, are rejected across unsafe sibling-cell geometry or tracked edits, and always represent page boundaries rather than column boundaries. Includes a patch changeset for `@stll/folio-core`.