### PR TITLE
fix(core): preserve resolved stories with threaded comments

### DIFF
--- a/.changeset/persist-final-comment-anchors.md
+++ b/.changeset/persist-final-comment-anchors.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Keep Final-view persistence validation stable when a resolved story contains comment anchors.
+Keep resolved-view persistence stable with anchored and threaded comments across every document story.

--- a/.changeset/persist-final-comment-anchors.md
+++ b/.changeset/persist-final-comment-anchors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep Final-view persistence validation stable when a resolved story contains comment anchors.

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -2601,6 +2601,37 @@ describe("headless docx review annotated read surface", () => {
     expect(reopened.getContentAsText()).toContain("Intro paragraph.");
   });
 
+  test("persists a resolved final main story with a comment anchor", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await makeParaIdBaseline(readFixture()), {
+      author: "Reviewer",
+    });
+    const target = findBlock(reviewer.snapshot().blocks, "Heading");
+    reviewer.applyOperations([
+      {
+        id: "final-comment-replace",
+        type: "replaceInBlock",
+        blockId: target.id,
+        find: "Heading",
+        replace: "Intro",
+      },
+      {
+        id: "final-comment-anchor",
+        type: "commentOnBlock",
+        blockId: target.id,
+        comment: { text: "Keep this comment." },
+      },
+    ]);
+
+    expect(reviewer.resolveReviewedStory({ view: "final" })).toBe(true);
+    const saved = await reviewer.toBuffer();
+    const reopened = await FolioDocxReviewer.fromBuffer(saved);
+    expect(reopened.readReviewedStory({ view: "current-markup" })?.changes).toEqual([]);
+    expect(reopened.getComments().at(0)).toMatchObject({
+      text: "Keep this comment.",
+      anchoredText: expect.stringContaining("Intro paragraph."),
+    });
+  });
+
   test("rejects an unsupported reviewed view at the public boundary", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(await makeParaIdBaseline(readFixture()));
     expect(() =>

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -1122,7 +1122,7 @@ export class FolioDocxReviewer {
         serialized &&
         serializedState &&
         serialized.changes.length === 0 &&
-        serialized.text === text &&
+        formatStoryStateForLLM(serializedState, false) === text &&
         JSON.stringify(createFolioAIEditSnapshot(serializedState.doc).blocks) ===
           JSON.stringify(blocks)
       ) {
@@ -1132,7 +1132,7 @@ export class FolioDocxReviewer {
         message: "Resolved document story did not persist to the serialized DOCX.",
         story,
         expectedText: text,
-        actualText: serialized?.text ?? null,
+        actualText: serializedState ? formatStoryStateForLLM(serializedState, false) : null,
         remainingChangeCount: serialized?.changes.length ?? null,
       });
     }

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -30,6 +30,32 @@ export type FolioReviewChangeKind =
   | "cellMerged"
   | FolioNodeRevisionKind;
 
+/**
+ * Runtime census of every tracked-change discriminator the reviewer exposes.
+ *
+ * The total Record is intentional: adding a new FolioReviewChangeKind without
+ * adding it here is a compile-time error. Cross-product persistence tests use
+ * this census, so a newly modeled revision cannot silently miss the resolver
+ * and serialization matrix.
+ */
+export const FOLIO_REVIEW_CHANGE_KINDS = Object.freeze({
+  insertion: "insertion",
+  deletion: "deletion",
+  formatting: "formatting",
+  rowInserted: "rowInserted",
+  rowDeleted: "rowDeleted",
+  cellInserted: "cellInserted",
+  cellDeleted: "cellDeleted",
+  cellMerged: "cellMerged",
+  paragraphMarkInserted: "paragraphMarkInserted",
+  paragraphMarkDeleted: "paragraphMarkDeleted",
+  paragraphPropertiesChanged: "paragraphPropertiesChanged",
+  sectionPropertiesChanged: "sectionPropertiesChanged",
+  tablePropertiesChanged: "tablePropertiesChanged",
+  rowPropertiesChanged: "rowPropertiesChanged",
+  cellPropertiesChanged: "cellPropertiesChanged",
+} as const satisfies Record<FolioReviewChangeKind, FolioReviewChangeKind>);
+
 /** A tracked change discovered in the document body. */
 export type FolioReviewChange = {
   /**

--- a/packages/core/src/ai-edits/revisionEnumeration.test.ts
+++ b/packages/core/src/ai-edits/revisionEnumeration.test.ts
@@ -1,19 +1,29 @@
 import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
 import { EditorState } from "prosemirror-state";
 
 import { createDocx } from "../docx/rezip";
 import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import { acceptAIEditRevision, rejectAIEditRevision } from "../prosemirror/commands/comments";
-import type { Paragraph, Table } from "../types/document";
+import type { BlockContent, Paragraph, Table } from "../types/document";
 import { createEmptyDocument } from "../utils/createDocument";
-import { FolioDocxReviewer } from "./headless";
-import { getTrackedChangesFromDoc } from "./read";
+import {
+  FOLIO_RESOLVED_REVIEWED_VIEWS,
+  type FolioEditableDocumentStoryHandle,
+  FolioDocxReviewer,
+} from "./headless";
+import { FOLIO_REVIEW_CHANGE_KINDS, getTrackedChangesFromDoc } from "./read";
 
 const AUTHOR = "Reviewer";
 const DATE = "2026-08-16T10:00:00Z";
 
 const REVISION = {
+  insertion: 1,
+  deletion: 2,
+  formatting: 3,
+  moveFrom: 4,
+  moveTo: 5,
   paragraphMarkInserted: 101,
   paragraphMarkDeleted: 102,
   paragraphPropertiesChanged: 103,
@@ -21,6 +31,11 @@ const REVISION = {
   tablePropertiesChanged: 105,
   rowPropertiesChanged: 106,
   cellPropertiesChanged: 107,
+  rowInserted: 201,
+  rowDeleted: 202,
+  cellInserted: 203,
+  cellDeleted: 204,
+  cellMerged: 205,
 } as const;
 
 const revisionInfo = (id: number) => ({ id, author: AUTHOR, date: DATE });
@@ -29,9 +44,47 @@ const paragraphContent = (text: string): Paragraph["content"] => [
   { type: "run", content: [{ type: "text", text }] },
 ];
 
-const revisionDocument = () => {
-  const document = createEmptyDocument();
+const revisionContent = (): BlockContent[] => {
   const paragraphs = [
+    {
+      type: "paragraph",
+      paraId: "A0000100",
+      content: [
+        { type: "run", content: [{ type: "text", text: "Stable <&> 日本語 " }] },
+        {
+          type: "insertion",
+          info: revisionInfo(REVISION.insertion),
+          content: [{ type: "run", content: [{ type: "text", text: "Inserted" }] }],
+        },
+        {
+          type: "deletion",
+          info: revisionInfo(REVISION.deletion),
+          content: [{ type: "run", content: [{ type: "text", text: "Deleted" }] }],
+        },
+        {
+          type: "run",
+          formatting: { italic: true },
+          propertyChanges: [
+            {
+              type: "runPropertyChange",
+              info: revisionInfo(REVISION.formatting),
+              previousFormatting: { bold: true },
+            },
+          ],
+          content: [{ type: "text", text: " Formatted" }],
+        },
+        {
+          type: "moveFrom",
+          info: revisionInfo(REVISION.moveFrom),
+          content: [{ type: "run", content: [{ type: "text", text: " Moved from" }] }],
+        },
+        {
+          type: "moveTo",
+          info: revisionInfo(REVISION.moveTo),
+          content: [{ type: "run", content: [{ type: "text", text: " Moved to" }] }],
+        },
+      ],
+    },
     {
       type: "paragraph",
       paraId: "A0000101",
@@ -120,13 +173,132 @@ const revisionDocument = () => {
           },
         ],
       },
+      {
+        type: "tableRow",
+        structuralChange: {
+          type: "tableRowInsertion",
+          info: revisionInfo(REVISION.rowInserted),
+        },
+        cells: [
+          {
+            type: "tableCell",
+            content: [
+              {
+                type: "paragraph",
+                paraId: "A0000107",
+                content: paragraphContent("Inserted row"),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "tableRow",
+        structuralChange: {
+          type: "tableRowDeletion",
+          info: revisionInfo(REVISION.rowDeleted),
+        },
+        cells: [
+          {
+            type: "tableCell",
+            content: [
+              {
+                type: "paragraph",
+                paraId: "A0000108",
+                content: paragraphContent("Deleted row"),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "tableRow",
+        cells: [
+          {
+            type: "tableCell",
+            structuralChange: {
+              type: "tableCellInsertion",
+              info: revisionInfo(REVISION.cellInserted),
+            },
+            content: [
+              {
+                type: "paragraph",
+                paraId: "A0000109",
+                content: paragraphContent("Inserted cell"),
+              },
+            ],
+          },
+          {
+            type: "tableCell",
+            structuralChange: {
+              type: "tableCellDeletion",
+              info: revisionInfo(REVISION.cellDeleted),
+            },
+            content: [
+              {
+                type: "paragraph",
+                paraId: "A0000110",
+                content: paragraphContent("Deleted cell"),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "tableRow",
+        cells: [
+          {
+            type: "tableCell",
+            formatting: { vMerge: "restart" },
+            content: [
+              {
+                type: "paragraph",
+                paraId: "A0000111",
+                content: paragraphContent("Merge origin"),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "tableRow",
+        cells: [
+          {
+            type: "tableCell",
+            formatting: { vMerge: "continue" },
+            structuralChange: {
+              type: "tableCellMerge",
+              info: revisionInfo(REVISION.cellMerged),
+              verticalMerge: "continue",
+              verticalMergeOriginal: "rest",
+            },
+            content: [
+              {
+                type: "paragraph",
+                paraId: "A0000112",
+                content: paragraphContent("Merge continuation"),
+              },
+            ],
+          },
+        ],
+      },
     ],
   } satisfies Table;
-  document.package.document.content = [...paragraphs, table];
+  return [...paragraphs, table];
+};
+
+const revisionDocument = () => {
+  const document = createEmptyDocument();
+  document.package.document.content = revisionContent();
   return document;
 };
 
 const expectedChanges = [
+  { id: REVISION.insertion, type: "insertion", text: "Inserted" },
+  { id: REVISION.deletion, type: "deletion", text: "Deleted" },
+  { id: REVISION.formatting, type: "formatting", text: " Formatted" },
+  { id: REVISION.moveFrom, type: "deletion", text: " Moved from" },
+  { id: REVISION.moveTo, type: "insertion", text: " Moved to" },
   { id: REVISION.paragraphMarkInserted, type: "paragraphMarkInserted", text: "Inserted boundary" },
   { id: REVISION.paragraphMarkDeleted, type: "paragraphMarkDeleted", text: "Deleted boundary" },
   {
@@ -139,10 +311,134 @@ const expectedChanges = [
     type: "sectionPropertiesChanged",
     text: "Property changes",
   },
-  { id: REVISION.tablePropertiesChanged, type: "tablePropertiesChanged", text: "Cell" },
+  {
+    id: REVISION.tablePropertiesChanged,
+    type: "tablePropertiesChanged",
+    text: "CellInserted rowDeleted rowInserted cellDeleted cellMerge originMerge continuation",
+  },
   { id: REVISION.rowPropertiesChanged, type: "rowPropertiesChanged", text: "Cell" },
   { id: REVISION.cellPropertiesChanged, type: "cellPropertiesChanged", text: "Cell" },
+  { id: REVISION.rowInserted, type: "rowInserted", text: "Inserted row" },
+  { id: REVISION.rowDeleted, type: "rowDeleted", text: "Deleted row" },
+  { id: REVISION.cellInserted, type: "cellInserted", text: "Inserted cell" },
+  { id: REVISION.cellDeleted, type: "cellDeleted", text: "Deleted cell" },
+  { id: REVISION.cellMerged, type: "cellMerged", text: "Merge continuation" },
 ] as const;
+
+const HEADER_RELATIONSHIP_ID = "rId_revision_header";
+const FOOTER_RELATIONSHIP_ID = "rId_revision_footer";
+const PRESERVATION_SENTINEL_PART = "customXml/revision-preservation.xml";
+const PRESERVATION_SENTINEL = new TextEncoder().encode(
+  '<?xml version="1.0" encoding="UTF-8"?><preserve value="&lt;&amp; 日本語"/>',
+);
+
+const REVIEW_STORY_HANDLES = {
+  main: { type: "main" },
+  header: { type: "header", relationshipId: HEADER_RELATIONSHIP_ID },
+  footer: { type: "footer", relationshipId: FOOTER_RELATIONSHIP_ID },
+  footnote: { type: "footnote", noteId: 2 },
+  endnote: { type: "endnote", noteId: 3 },
+} as const satisfies Record<
+  FolioEditableDocumentStoryHandle["type"],
+  FolioEditableDocumentStoryHandle
+>;
+
+const REVIEW_STORIES = Object.values(REVIEW_STORY_HANDLES);
+
+const makeRevisionMatrixDocument = () => {
+  const document = revisionDocument();
+  document.package.headers = new Map([
+    [
+      HEADER_RELATIONSHIP_ID,
+      { type: "header", hdrFtrType: "default", content: structuredClone(revisionContent()) },
+    ],
+  ]);
+  document.package.footers = new Map([
+    [
+      FOOTER_RELATIONSHIP_ID,
+      { type: "footer", hdrFtrType: "default", content: structuredClone(revisionContent()) },
+    ],
+  ]);
+  document.package.document.finalSectionProperties = {
+    ...document.package.document.finalSectionProperties,
+    headerReferences: [{ type: "default", rId: HEADER_RELATIONSHIP_ID }],
+    footerReferences: [{ type: "default", rId: FOOTER_RELATIONSHIP_ID }],
+  };
+  document.package.footnotes = [
+    { type: "footnote", id: 2, noteType: "normal", content: structuredClone(revisionContent()) },
+  ];
+  document.package.endnotes = [
+    { type: "endnote", id: 3, noteType: "normal", content: structuredClone(revisionContent()) },
+  ];
+  return document;
+};
+
+const makeRevisionMatrixDocx = async (paragraphIds: "with" | "without"): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await createDocx(makeRevisionMatrixDocument()));
+  if (paragraphIds === "without") {
+    for (const path of [
+      "word/document.xml",
+      "word/header1.xml",
+      "word/footer1.xml",
+      "word/footnotes.xml",
+      "word/endnotes.xml",
+    ]) {
+      const file = zip.file(path);
+      if (!file) {
+        throw new Error(`revision matrix is missing ${path}`);
+      }
+      zip.file(path, (await file.async("text")).replace(/ w14:paraId="[^"]+"/gu, ""));
+    }
+  }
+  zip.file(PRESERVATION_SENTINEL_PART, PRESERVATION_SENTINEL);
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const storyKey = (story: FolioEditableDocumentStoryHandle): string => JSON.stringify(story);
+
+const commentProjection = (reviewer: FolioDocxReviewer) =>
+  reviewer.getComments().map(({ id, author, text, anchoredText, blockId, replies, done }) => ({
+    id,
+    author,
+    text,
+    anchoredText,
+    blockId,
+    replies: replies.map(({ id: replyId, author: replyAuthor, text: replyText }) => ({
+      id: replyId,
+      author: replyAuthor,
+      text: replyText,
+    })),
+    done,
+  }));
+
+const storyProjection = (reviewer: FolioDocxReviewer, story: FolioEditableDocumentStoryHandle) => {
+  const reviewed = reviewer.readReviewedStory({ story, view: "current-markup" });
+  if (!reviewed) {
+    throw new Error(`revision matrix is missing ${storyKey(story)}`);
+  }
+  return {
+    blocks: reviewed.snapshot.blocks.map(({ kind, text, previewRuns }) => ({
+      kind,
+      text,
+      previewRuns,
+    })),
+    changes: reviewed.changes,
+  };
+};
+
+const partBytes = async (buffer: ArrayBuffer, path: string): Promise<Uint8Array> => {
+  const file = (await JSZip.loadAsync(buffer)).file(path);
+  if (!file) {
+    throw new Error(`revision matrix is missing ${path}`);
+  }
+  return file.async("uint8array");
+};
+
+const MATRIX_CASES = FOLIO_RESOLVED_REVIEWED_VIEWS.flatMap((view) =>
+  (["with", "without"] as const).flatMap((paragraphIds) =>
+    (["none", "thread"] as const).map((comments) => ({ view, paragraphIds, comments })),
+  ),
+);
 
 describe("body revision enumeration", () => {
   test("enumerates every property and paragraph-mark carrier the resolver supports", () => {
@@ -199,5 +495,78 @@ describe("body revision enumeration", () => {
       const reopened = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
       expect(reopened.getChanges()).toEqual([]);
     },
+  );
+});
+
+describe("resolved story serialization structural matrix", () => {
+  test.each(MATRIX_CASES)(
+    "preserves every revision kind in $view view, $paragraphIds paragraph ids, comments: $comments",
+    async ({ view, paragraphIds, comments }) => {
+      const baseline = await makeRevisionMatrixDocx(paragraphIds);
+      const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: AUTHOR });
+
+      if (comments === "thread") {
+        const target = reviewer.snapshot().blocks.find(({ text }) => text.includes("Stable <&>"));
+        if (!target) {
+          throw new Error("revision matrix is missing the stable comment target");
+        }
+        const result = reviewer.applyOperations([
+          {
+            id: "matrix-comment",
+            type: "commentOnBlock",
+            blockId: target.id,
+            comment: { text: "Parent <&> 日本語" },
+          },
+        ]);
+        expect(result.applied).toHaveLength(1);
+        const parent = reviewer.getComments().at(0);
+        if (!parent) {
+          throw new Error("revision matrix did not create the parent comment");
+        }
+        expect(
+          reviewer.replyTo(parent, { author: "Second reviewer", text: "Reply <&> العربية" }),
+        ).not.toBeNull();
+        expect(reviewer.resolveComment(String(parent.id))).toBe(true);
+      }
+
+      const expectedByStory = new Map<string, ReturnType<typeof storyProjection>>();
+      for (const story of REVIEW_STORIES) {
+        const current = reviewer.readReviewedStory({ story, view: "current-markup" });
+        const resolved = reviewer.readReviewedStory({ story, view });
+        if (!current || !resolved) {
+          throw new Error(`revision matrix is missing ${storyKey(story)}`);
+        }
+        expect(new Set(current.changes.map(({ type }) => type))).toEqual(
+          new Set(Object.values(FOLIO_REVIEW_CHANGE_KINDS)),
+        );
+        expect(reviewer.resolveReviewedStory({ story, view })).toBe(true);
+        expectedByStory.set(storyKey(story), storyProjection(reviewer, story));
+      }
+      const expectedComments = commentProjection(reviewer);
+
+      const saved = await reviewer.toBuffer();
+      expect(await partBytes(saved, PRESERVATION_SENTINEL_PART)).toEqual(PRESERVATION_SENTINEL);
+      const reopened = await FolioDocxReviewer.fromBuffer(saved);
+      for (const story of REVIEW_STORIES) {
+        const actual = storyProjection(reopened, story);
+        expect(actual.changes).toEqual([]);
+        expect(actual).toEqual(expectedByStory.get(storyKey(story)));
+      }
+      expect(commentProjection(reopened)).toEqual(expectedComments);
+
+      for (const story of REVIEW_STORIES) {
+        expect(reopened.resolveReviewedStory({ story, view })).toBe(true);
+      }
+      const savedAgain = await reopened.toBuffer();
+      expect(await partBytes(savedAgain, PRESERVATION_SENTINEL_PART)).toEqual(
+        PRESERVATION_SENTINEL,
+      );
+      const reopenedAgain = await FolioDocxReviewer.fromBuffer(savedAgain);
+      for (const story of REVIEW_STORIES) {
+        expect(storyProjection(reopenedAgain, story)).toEqual(expectedByStory.get(storyKey(story)));
+      }
+      expect(commentProjection(reopenedAgain)).toEqual(expectedComments);
+    },
+    30_000,
   );
 });

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -459,20 +459,28 @@ const resolveParagraphStyleFontFamily = (
 
 /**
  * Apply comment marks to PM nodes within a comment range.
- * Only the first active comment ID is used (comments don't overlap visually).
  */
 function applyCommentMarks(nodes: PMNode[], commentIds: Set<number>): PMNode[] {
   if (commentIds.size === 0) {
     return nodes;
   }
-  const commentId = [...commentIds][0]; // Use first active comment
-  const commentMark = schema.marks["comment"]!.create({ commentId });
+  const commentMarkType = schema.marks["comment"];
+  if (!commentMarkType) {
+    return nodes;
+  }
+  const commentMarks = [...commentIds]
+    .toSorted((left, right) => left - right)
+    .map((commentId) => commentMarkType.create({ commentId }));
 
   return nodes.map((node) => {
-    if (node.isText || (node.isInline && node.type.allowsMarkType(commentMark.type))) {
-      return node.mark(commentMark.addToSet(node.marks));
+    if (!node.isText && (!node.isInline || !node.type.allowsMarkType(commentMarkType))) {
+      return node;
     }
-    return node;
+    let marks = node.marks;
+    for (const commentMark of commentMarks) {
+      marks = commentMark.addToSet(marks);
+    }
+    return node.mark(marks);
   });
 }
 

--- a/packages/core/src/prosemirror/extensions/marks/CommentExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/CommentExtension.ts
@@ -12,6 +12,10 @@ export const CommentExtension = createMarkExtension({
   name: "comment",
   schemaMarkName: "comment",
   markSpec: {
+    // Word permits nested/overlapping comment ranges, including the identical
+    // anchors it emits for a thread root and each reply. Keep multiple comment
+    // marks on one inline node so parsing one range cannot evict another.
+    excludes: "",
     attrs: {
       /** Comment ID (matches Comment.id) */
       commentId: { default: 0 },


### PR DESCRIPTION
## Summary

- validate persisted resolved stories through the same clean projection used to record the expectation
- preserve overlapping Word comment ranges so a thread root and its replies retain the same anchor
- bind every exposed review-change discriminator to a total runtime census
- exhaustively test the structural cross-product of review kind, editable story, Original/Final view, paragraph-ID profile, and comment topology

## Validation

- `bun test packages/core/src/ai-edits/revisionEnumeration.test.ts packages/core/src/docx/commentReplyThreads.test.ts packages/core/src/prosemirror/conversion/toProseDoc.test.ts packages/core/src/prosemirror/conversion/fromProseDoc.test.ts`
- `bun test packages/core/src/docx/saveEquivalence.property.test.ts`
- `bun run lint`
- `bun --filter @stll/folio-core typecheck`
- `bun run format:check`
- full core suite: 4,737 passed; one existing 30-second property timeout under full-suite contention passed in 3.5 seconds when rerun alone

CC on behalf of jan-kubica