### PR TITLE
fix(core): align complex RTL document geometry

### DIFF
--- a/.changeset/quiet-apples-align.md
+++ b/.changeset/quiet-apples-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Match Word's RTL table, paragraph, and mixed-link geometry.

--- a/packages/core/src/__tests__/tableCellPlacementGeometry.integration.test.ts
+++ b/packages/core/src/__tests__/tableCellPlacementGeometry.integration.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { clearAllCaches } from "../layout-engine/measure";
+import {
+  installCanvasMeasureProvider,
+  resetCanvasContext,
+} from "../layout-engine/measure/measureContainer";
+import type {
+  Layout,
+  ParagraphBlock,
+  ParagraphMeasure,
+  TableBlock,
+  TableFragment,
+  TableMeasure,
+} from "../layout-engine/types";
+import { hitTestTableCell } from "../layout-bridge/engine/hitTest";
+import { selectionToRects } from "../layout-bridge/engine/selectionRects";
+import { renderTableFragment, TABLE_CLASS_NAMES } from "../layout-painter/renderTable";
+import type { RenderContext } from "../layout-painter/renderUtils";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  querySelectorAll(): FakeElement[] {
+    return [];
+  }
+}
+
+const fakeDocument = {
+  createElement(): FakeElement {
+    return new FakeElement();
+  },
+  createTextNode(): FakeElement {
+    return new FakeElement();
+  },
+} as unknown as Document;
+
+const renderContext: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+const originalDocument = globalThis.document;
+
+beforeEach(() => {
+  installCanvasMeasureProvider();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      createElement(tagName: string) {
+        if (tagName !== "canvas") {
+          return {};
+        }
+        return {
+          getContext() {
+            return {
+              font: "",
+              measureText(text: string) {
+                return { width: text.length * 7 };
+              },
+            };
+          },
+        };
+      },
+    },
+  });
+  clearAllCaches();
+  resetCanvasContext();
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  });
+  clearAllCaches();
+  resetCanvasContext();
+});
+
+const emptyParagraph = (id: string): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: [],
+});
+
+const emptyParagraphMeasure = (): ParagraphMeasure => ({
+  kind: "paragraph",
+  lines: [],
+  totalHeight: 0,
+});
+
+const findCells = (element: FakeElement): FakeElement[] => {
+  const cells = element.className.split(" ").includes(TABLE_CLASS_NAMES.cell) ? [element] : [];
+  for (const child of element.children) {
+    cells.push(...findCells(child));
+  }
+  return cells;
+};
+
+const renderContinuation = (bidi: boolean): FakeElement[] => {
+  const block: TableBlock = {
+    kind: "table",
+    id: "continuation-table",
+    ...(bidi ? { bidi: true } : {}),
+    columnWidths: [100, 80, 120],
+    rows: [
+      {
+        id: "source-row",
+        cells: [
+          {
+            id: "spanning-cell",
+            rowSpan: 2,
+            blocks: [emptyParagraph("span")],
+          },
+          {
+            id: "source-body",
+            colSpan: 2,
+            blocks: [emptyParagraph("source-body-p")],
+          },
+        ],
+      },
+      {
+        id: "continued-row",
+        cells: [
+          {
+            id: "continued-body",
+            colSpan: 2,
+            blocks: [emptyParagraph("continued-body-p")],
+          },
+        ],
+      },
+    ],
+  };
+  const measure: TableMeasure = {
+    kind: "table",
+    columnWidths: [100, 80, 120],
+    totalWidth: 300,
+    totalHeight: 40,
+    rows: [
+      {
+        height: 20,
+        cells: [
+          { width: 100, height: 40, blocks: [emptyParagraphMeasure()] },
+          { width: 200, height: 20, blocks: [emptyParagraphMeasure()] },
+        ],
+      },
+      {
+        height: 20,
+        cells: [{ width: 200, height: 20, blocks: [emptyParagraphMeasure()] }],
+      },
+    ],
+  };
+  const fragment: TableFragment = {
+    kind: "table",
+    blockId: block.id,
+    x: 0,
+    y: 0,
+    width: 300,
+    height: 20,
+    fromRow: 1,
+    toRow: 2,
+    continuesFromPrev: true,
+  };
+
+  const rendered = renderTableFragment(fragment, block, measure, renderContext, {
+    document: fakeDocument,
+  }) as unknown as FakeElement;
+  return findCells(rendered);
+};
+
+describe("canonical table-cell placement", () => {
+  test("places LTR and RTL continuations beneath a prior-fragment row span", () => {
+    for (const [bidi, expectedLeft] of [
+      [false, "100px"],
+      [true, "0px"],
+    ] as const) {
+      const cells = renderContinuation(bidi);
+
+      expect(cells).toHaveLength(1);
+      expect(cells[0]?.dataset["columnIndex"]).toBe("1");
+      expect(cells[0]?.style["left"]).toBe(expectedLeft);
+      expect(cells[0]?.style["width"]).toBe("200px");
+    }
+  });
+
+  test("honors gridBefore and clamps an oversized colSpan to the remaining grid", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "grid-before-table",
+      columnWidths: [40, 60, 100],
+      rows: [
+        {
+          id: "grid-before-row",
+          gridBefore: 2,
+          cells: [
+            {
+              id: "grid-before-cell",
+              colSpan: 5,
+              blocks: [emptyParagraph("grid-before-p")],
+            },
+          ],
+        },
+      ],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      columnWidths: [40, 60, 100],
+      totalWidth: 200,
+      totalHeight: 20,
+      rows: [
+        {
+          height: 20,
+          cells: [{ width: 100, height: 20, blocks: [emptyParagraphMeasure()] }],
+        },
+      ],
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: block.id,
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 20,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    const rendered = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const cell = findCells(rendered)[0];
+
+    expect(cell?.dataset["columnIndex"]).toBe("2");
+    expect(cell?.style["left"]).toBe("100px");
+    expect(cell?.style["width"]).toBe("100px");
+  });
+
+  test("uses the same asymmetric RTL cell boxes for hit testing and selection", () => {
+    const firstParagraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "first-p",
+      pmStart: 1,
+      pmEnd: 2,
+      runs: [{ kind: "text", text: "a", pmStart: 1, pmEnd: 2 }],
+    };
+    const secondParagraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "second-p",
+      pmStart: 3,
+      pmEnd: 4,
+      runs: [{ kind: "text", text: "b", pmStart: 3, pmEnd: 4 }],
+    };
+    const lineMeasure = (): ParagraphMeasure => ({
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 1,
+          width: 7,
+          ascent: 10,
+          descent: 4,
+          lineHeight: 14,
+        },
+      ],
+      totalHeight: 14,
+    });
+    const block: TableBlock = {
+      kind: "table",
+      id: "interaction-table",
+      bidi: true,
+      columnWidths: [100, 200],
+      rows: [
+        {
+          id: "interaction-row",
+          cells: [
+            { id: "first-cell", blocks: [firstParagraph] },
+            { id: "second-cell", blocks: [secondParagraph] },
+          ],
+        },
+      ],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      columnWidths: [100, 200],
+      totalWidth: 300,
+      totalHeight: 14,
+      rows: [
+        {
+          height: 14,
+          cells: [
+            { width: 100, height: 14, blocks: [lineMeasure()] },
+            { width: 200, height: 14, blocks: [lineMeasure()] },
+          ],
+        },
+      ],
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: block.id,
+      x: 10,
+      y: 0,
+      width: 300,
+      height: 14,
+      fromRow: 0,
+      toRow: 1,
+    };
+    const layout: Layout = {
+      pageGap: 0,
+      pages: [
+        {
+          number: 1,
+          size: { w: 320, h: 100 },
+          margins: { top: 0, right: 0, bottom: 0, left: 0 },
+          fragments: [fragment],
+        },
+      ],
+    };
+    const page = layout.pages[0];
+    if (!page) {
+      throw new Error("expected table page");
+    }
+
+    const leftHit = hitTestTableCell({ pageIndex: 0, page, pageY: 7 }, [block], [measure], {
+      x: 50,
+      y: 7,
+    });
+    const rightHit = hitTestTableCell({ pageIndex: 0, page, pageY: 7 }, [block], [measure], {
+      x: 250,
+      y: 7,
+    });
+
+    expect(leftHit?.colIndex).toBe(1);
+    expect(leftHit?.cellLocalX).toBe(33);
+    expect(rightHit?.colIndex).toBe(0);
+    expect(rightHit?.cellLocalX).toBe(33);
+    expect(selectionToRects(layout, [block], [measure], 3, 4)[0]?.x).toBe(17);
+  });
+});

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import { getHyperlinkInstanceIndex } from "../../layout-engine/measure/hyperlinkInstance";
 import { getTextBoxGroupId } from "../../layout-engine/textBoxGroup";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import { schema } from "../../prosemirror/schema";
+import type { Document } from "../../types/document";
 import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
@@ -1251,6 +1254,192 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
     expect(firstRunHyperlinkStripped("toc3")).toBe(true);
     expect(firstRunHyperlinkStripped("TOCHeading")).toBe(false);
     expect(firstRunHyperlinkStripped("Normal")).toBe(false);
+  });
+});
+
+describe("toFlowBlocks hyperlink identity", () => {
+  const getHyperlinkIndexes = (document: Document): (number | undefined)[] => {
+    const paragraphs = toFlowBlocks(toProseDoc(document)).filter(
+      (block) => block.kind === "paragraph",
+    );
+    return paragraphs.flatMap((paragraph) =>
+      paragraph.runs.flatMap((run) =>
+        run.hyperlink ? [getHyperlinkInstanceIndex(run.hyperlink)] : [],
+      ),
+    );
+  };
+
+  test("keeps adjacent same-target imported hyperlinks distinct", () => {
+    const href = "https://example.test";
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { bidi: true },
+              content: [
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [{ type: "run", content: [{ type: "text", text: href }] }],
+                },
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [{ type: "run", content: [{ type: "text", text: "رابط" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const paragraph = toFlowBlocks(toProseDoc(document)).at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const hyperlinks = paragraph.runs.flatMap((run) => (run.hyperlink ? [run.hyperlink] : []));
+
+    expect(hyperlinks.map(getHyperlinkInstanceIndex)).toEqual([0, 1]);
+    expect(JSON.stringify(paragraph)).not.toContain("HyperlinkIndex");
+  });
+
+  test("keeps one imported hyperlink grouped across formatting splits", () => {
+    const href = "https://example.test";
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [
+                    { type: "run", content: [{ type: "text", text: "https://example." }] },
+                    {
+                      type: "run",
+                      formatting: { bold: true },
+                      content: [{ type: "text", text: "test" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getHyperlinkIndexes(document)).toEqual([0, 0]);
+  });
+
+  test("allocates distinct identities through nested inline SDTs", () => {
+    const href = "https://example.test";
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [{ type: "run", content: [{ type: "text", text: href }] }],
+                },
+                {
+                  type: "inlineSdt",
+                  properties: { sdtType: "richText" },
+                  content: [
+                    {
+                      type: "hyperlink",
+                      href,
+                      children: [{ type: "run", content: [{ type: "text", text: "رابط" }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getHyperlinkIndexes(document)).toEqual([0, 1]);
+  });
+
+  test("allocates distinct identities through tracked changes", () => {
+    const href = "https://example.test";
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [{ type: "run", content: [{ type: "text", text: href }] }],
+                },
+                {
+                  type: "insertion",
+                  info: { id: 1, author: "Reviewer" },
+                  content: [
+                    {
+                      type: "hyperlink",
+                      href,
+                      children: [{ type: "run", content: [{ type: "text", text: "رابط" }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getHyperlinkIndexes(document)).toEqual([0, 1]);
+  });
+
+  test("keeps identities distinct when run-in paragraphs merge", () => {
+    const href = "https://example.test";
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { runInWithNext: true },
+              content: [
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [{ type: "run", content: [{ type: "text", text: href }] }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  href,
+                  children: [{ type: "run", content: [{ type: "text", text: "رابط" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getHyperlinkIndexes(document)).toEqual([0, 1]);
   });
 });
 

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -34,6 +34,7 @@ import type {
   TabStop,
   FloatingTablePosition,
 } from "../../layout-engine/types";
+import { setHyperlinkInstanceIndex } from "../../layout-engine/measure/hyperlinkInstance";
 import { setTextBoxGroupId } from "../../layout-engine/textBoxGroup";
 import { setParagraphFrame } from "../../layout-engine/paragraphFrame";
 import { DEFAULT_TEXTBOX_MARGINS, DEFAULT_TEXTBOX_WIDTH } from "../../layout-engine/types";
@@ -560,6 +561,9 @@ function extractRunFormatting(marks: readonly Mark[], theme?: Theme | null): Run
         if (attrs.tooltip !== undefined) {
           link.tooltip = attrs.tooltip;
         }
+        if (attrs._docxHyperlinkIndex !== undefined) {
+          setHyperlinkInstanceIndex(link, attrs._docxHyperlinkIndex);
+        }
         formatting.hyperlink = link;
         break;
       }
@@ -1009,7 +1013,7 @@ function stripTocHyperlinkStyle(formatting: RunFormatting): void {
   if (!formatting.hyperlink) {
     return;
   }
-  formatting.hyperlink = { ...formatting.hyperlink, noDefaultStyle: true };
+  formatting.hyperlink.noDefaultStyle = true;
   delete formatting.color;
   delete formatting.underline;
 }

--- a/packages/core/src/layout-bridge/engine/clickToPosition.ts
+++ b/packages/core/src/layout-bridge/engine/clickToPosition.ts
@@ -25,6 +25,10 @@ import type {
   TabRun,
 } from "../../layout-engine/types";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
+import {
+  resolvePhysicalParagraphInlineLayout,
+  type PhysicalParagraphInlineLayout,
+} from "../../utils/paragraphInlineLayout";
 import type { FragmentHit, TableCellHit } from "./hitTest";
 
 // =============================================================================
@@ -254,12 +258,21 @@ function findLineAtY(
  * @param availableWidth - Available width for alignment calculations.
  * @returns Character offset and PM position.
  */
-function findCharacterInLine(
-  block: ParagraphBlock,
-  line: MeasuredLine,
-  x: number,
-  availableWidth: number,
-): { charOffset: number; pmPosition: number } {
+type FindCharacterInLineOptions = {
+  block: ParagraphBlock;
+  line: MeasuredLine;
+  x: number;
+  availableWidth: number;
+  alignment: PhysicalParagraphInlineLayout["alignment"];
+};
+
+function findCharacterInLine({
+  block,
+  line,
+  x,
+  availableWidth,
+  alignment,
+}: FindCharacterInLineOptions): { charOffset: number; pmPosition: number } {
   const { pmStart, pmEnd } = computeLinePmRange(block, line);
 
   if (pmStart === undefined || pmEnd === undefined) {
@@ -267,7 +280,6 @@ function findCharacterInLine(
   }
 
   // Calculate alignment offset
-  const alignment = block.attrs?.alignment ?? "left";
   let alignmentOffset = 0;
 
   if (alignment === "center") {
@@ -439,21 +451,21 @@ export function clickToPositionInParagraph(fragmentHit: FragmentHit): PositionRe
   }
 
   // Calculate available width (accounting for indentation)
-  const indent = paragraphBlock.attrs?.indent;
-  const indentLeft = indent?.left ?? 0;
-  const indentRight = indent?.right ?? 0;
+  const { alignment, indentLeft, indentRight } =
+    resolvePhysicalParagraphInlineLayout(paragraphBlock);
   const availableWidth = Math.max(0, fragment.width - indentLeft - indentRight);
 
   // Adjust X for left indent
   const adjustedX = localX - indentLeft;
 
   // Find character at X position
-  const { charOffset, pmPosition } = findCharacterInLine(
-    paragraphBlock,
+  const { charOffset, pmPosition } = findCharacterInLine({
+    block: paragraphBlock,
     line,
-    adjustedX,
+    x: adjustedX,
     availableWidth,
-  );
+    alignment,
+  });
 
   return {
     pmPosition,
@@ -469,7 +481,7 @@ export function clickToPositionInParagraph(fragmentHit: FragmentHit): PositionRe
  * @returns PM position, or null if mapping fails.
  */
 export function clickToPositionInTableCell(tableCellHit: TableCellHit): number | null {
-  const { cellBlock, cellMeasure, cellLocalX, cellLocalY } = tableCellHit;
+  const { cellBlock, cellMeasure, cellLocalX, cellLocalY, cellContentWidth } = tableCellHit;
 
   if (!cellBlock || !cellMeasure) {
     return null;
@@ -482,7 +494,7 @@ export function clickToPositionInTableCell(tableCellHit: TableCellHit): number |
       blockId: cellBlock.id,
       x: 0,
       y: 0,
-      width: getMaxLineWidth(cellMeasure.lines, 100),
+      width: cellContentWidth,
       fromLine: 0,
       toLine: cellMeasure.lines.length,
       height: cellMeasure.totalHeight,
@@ -631,14 +643,6 @@ export function positionToX(
   return null;
 }
 
-const getMaxLineWidth = (lines: readonly { width: number }[], fallback: number): number => {
-  let maxWidth = fallback;
-  for (const line of lines) {
-    maxWidth = Math.max(maxWidth, line.width);
-  }
-  return maxWidth;
-};
-
 /**
  * Get the bounding rect for a PM position (for caret rendering).
  */
@@ -657,10 +661,7 @@ export function getPositionRect(
   }
 
   // Calculate alignment offset
-  const alignment = block.attrs?.alignment ?? "left";
-  const indent = block.attrs?.indent;
-  const indentLeft = indent?.left ?? 0;
-  const indentRight = indent?.right ?? 0;
+  const { alignment, indentLeft, indentRight } = resolvePhysicalParagraphInlineLayout(block);
   const availableWidth = Math.max(0, fragmentWidth - indentLeft - indentRight);
 
   const line = measure.lines[result.lineIndex];

--- a/packages/core/src/layout-bridge/engine/hitTest.ts
+++ b/packages/core/src/layout-bridge/engine/hitTest.ts
@@ -7,7 +7,12 @@
 
 import { getHeaderRowsHeight } from "../../layout-engine/index";
 import { measuredLineRangeHeight } from "../../layout-engine/lineFlow";
-import { getTableRowLeadingWidth } from "../../layout-engine/types";
+import { getTableCellContentWidth } from "../../layout-engine/measure/tableCellFloating";
+import {
+  buildTableCellGrid,
+  buildTableCellPlacements,
+} from "../../layout-engine/measure/tableCellGrid";
+import { resolveTableCellPadding } from "../../layout-engine/types";
 import type {
   Layout,
   Page,
@@ -87,6 +92,8 @@ export type TableCellHit = {
   cellMeasure?: ParagraphMeasure;
   /** X position relative to cell content area. */
   cellLocalX: number;
+  /** Width of the cell content area after physical padding. */
+  cellContentWidth: number;
   /** Y position relative to cell content area. */
   cellLocalY: number;
 };
@@ -435,30 +442,47 @@ export function hitTestTableCell(
       continue;
     }
 
-    // Find column at localX
-    let colX = getTableRowLeadingWidth(row, tableMeasure.columnWidths);
     let colIndex = -1;
+    let cellLeft = 0;
 
     if (rowMeasure.cells.length === 0 || row.cells.length === 0) {
       continue;
     }
 
-    for (let c = 0; c < rowMeasure.cells.length; c++) {
-      // SAFETY: c is bounded by rowMeasure.cells.length
-      const cellMeasure = rowMeasure.cells[c]!;
-      if (localX >= colX && localX < colX + cellMeasure.width) {
-        colIndex = c;
-        break;
-      }
-      colX += cellMeasure.width;
-    }
-
-    // If no column found, use last column
-    if (colIndex === -1) {
-      colIndex = rowMeasure.cells.length - 1;
-      if (colIndex < 0) {
+    const cellGrid = buildTableCellGrid(tableBlock.rows, tableMeasure.columnWidths.length);
+    const cellPlacements = buildTableCellPlacements({
+      grid: cellGrid,
+      columnWidths: tableMeasure.columnWidths,
+      bidi: tableBlock.bidi === true,
+    });
+    let nearestDistance = Infinity;
+    for (let c = 0; c < row.cells.length; c++) {
+      const cell = row.cells[c];
+      if (!cell) {
         continue;
       }
+      const placement = cellPlacements.get(cell);
+      if (!placement) {
+        continue;
+      }
+      if (localX >= placement.left && localX < placement.left + placement.width) {
+        colIndex = c;
+        cellLeft = placement.left;
+        break;
+      }
+      const distance = Math.min(
+        Math.abs(localX - placement.left),
+        Math.abs(localX - placement.left - placement.width),
+      );
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        colIndex = c;
+        cellLeft = placement.left;
+      }
+    }
+
+    if (colIndex === -1) {
+      continue;
     }
 
     const cellMeasure = rowMeasure.cells[colIndex];
@@ -484,12 +508,6 @@ export function hitTestTableCell(
       }
     }
 
-    // Find the cumulative column X for the found column
-    let colLeft = 0;
-    for (let c = 0; c < colIndex; c++) {
-      colLeft += rowMeasure.cells[c]?.width ?? 0;
-    }
-
     // Get first paragraph in cell
     let cellBlock: ParagraphBlock | undefined;
     let cellBlockMeasure: ParagraphMeasure | undefined;
@@ -504,8 +522,12 @@ export function hitTestTableCell(
       }
     }
 
-    // Calculate position within cell (rough - doesn't account for padding)
-    const cellLocalX = localX - colLeft;
+    // `cellLeft` is the physical cell start, including any grid-before width.
+    // Expose content-relative geometry so click mapping uses the same box as
+    // measurement and painting.
+    const { left: padLeft } = resolveTableCellPadding(cell);
+    const cellLocalX = localX - cellLeft - padLeft;
+    const cellContentWidth = getTableCellContentWidth(cell, cellMeasure);
     const clipOffset = isClickOnHeader ? 0 : (tableFragment.topClip ?? 0);
     const cellLocalY = localY - rowTop + clipOffset;
 
@@ -519,6 +541,7 @@ export function hitTestTableCell(
       ...(cellBlock !== undefined ? { cellBlock } : {}),
       ...(cellBlockMeasure !== undefined ? { cellMeasure: cellBlockMeasure } : {}),
       cellLocalX: Math.max(0, cellLocalX),
+      cellContentWidth,
       cellLocalY: Math.max(0, cellLocalY),
     };
   }

--- a/packages/core/src/layout-bridge/engine/paragraphInlineLayoutGeometry.test.ts
+++ b/packages/core/src/layout-bridge/engine/paragraphInlineLayoutGeometry.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { clearAllCaches } from "../../layout-engine/measure";
+import {
+  installCanvasMeasureProvider,
+  resetCanvasContext,
+} from "../../layout-engine/measure/measureContainer";
+import type {
+  Layout,
+  Measure,
+  ParagraphBlock,
+  ParagraphFragment,
+  ParagraphMeasure,
+  TableBlock,
+  TableMeasure,
+} from "../../layout-engine/types";
+import {
+  clickToPositionInParagraph,
+  clickToPositionInTableCell,
+  getPositionRect,
+} from "./clickToPosition";
+import { hitTestTableCell } from "./hitTest";
+import { getCaretPosition, selectionToRects } from "./selectionRects";
+
+const originalDocument = globalThis.document;
+
+beforeEach(() => {
+  installCanvasMeasureProvider();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      createElement(tagName: string) {
+        if (tagName !== "canvas") {
+          return {};
+        }
+        return {
+          getContext() {
+            return {
+              font: "",
+              measureText(text: string) {
+                return { width: text.length * 7 };
+              },
+            };
+          },
+        };
+      },
+    },
+  });
+  clearAllCaches();
+  resetCanvasContext();
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  });
+  clearAllCaches();
+  resetCanvasContext();
+});
+
+const makeFixture = (alignment: "left" | "right", bidi?: boolean) => {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "footer-page-number",
+    pmStart: 1,
+    pmEnd: 7,
+    runs: [{ kind: "text", text: "abcd", pmStart: 1, pmEnd: 5 }],
+    attrs: {
+      alignment,
+      ...(bidi === undefined ? {} : { bidi }),
+      indent: { left: 10, right: 30 },
+    },
+  };
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 4,
+        width: 28,
+        ascent: 10,
+        descent: 4,
+        lineHeight: 14,
+      },
+    ],
+    totalHeight: 14,
+  };
+  const fragment: ParagraphFragment = {
+    kind: "paragraph",
+    blockId: block.id,
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 14,
+    fromLine: 0,
+    toLine: 1,
+  };
+  const layout: Layout = {
+    pageGap: 0,
+    pages: [
+      {
+        number: 1,
+        size: { w: 200, h: 200 },
+        margins: { top: 0, right: 0, bottom: 0, left: 0 },
+        fragments: [fragment],
+      },
+    ],
+  };
+  const measures: Measure[] = [measure];
+
+  return { block, fragment, layout, measure, measures };
+};
+
+const makeTableFixture = () => {
+  const paragraph: ParagraphBlock = {
+    kind: "paragraph",
+    id: "table-paragraph",
+    pmStart: 1,
+    pmEnd: 5,
+    runs: [{ kind: "text", text: "abcd", pmStart: 1, pmEnd: 5 }],
+    attrs: {
+      alignment: "left",
+      bidi: true,
+      indent: { left: 10, right: 30 },
+    },
+  };
+  const paragraphMeasure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 4,
+        width: 28,
+        ascent: 10,
+        descent: 4,
+        lineHeight: 14,
+      },
+    ],
+    totalHeight: 14,
+  };
+  const block: TableBlock = {
+    kind: "table",
+    id: "table",
+    rows: [
+      {
+        id: "row",
+        cells: [
+          {
+            id: "cell",
+            padding: { top: 0, right: 15, bottom: 0, left: 5 },
+            blocks: [paragraph],
+          },
+        ],
+      },
+    ],
+    columnWidths: [200],
+  };
+  const measure: TableMeasure = {
+    kind: "table",
+    rows: [
+      {
+        cells: [
+          {
+            blocks: [paragraphMeasure],
+            width: 200,
+            height: 14,
+          },
+        ],
+        height: 14,
+      },
+    ],
+    columnWidths: [200],
+    totalWidth: 200,
+    totalHeight: 14,
+  };
+  const layout: Layout = {
+    pageGap: 0,
+    pages: [
+      {
+        number: 1,
+        size: { w: 240, h: 200 },
+        margins: { top: 0, right: 0, bottom: 0, left: 0 },
+        fragments: [
+          {
+            kind: "table",
+            blockId: block.id,
+            x: 20,
+            y: 0,
+            width: 200,
+            height: 14,
+            fromRow: 0,
+            toRow: 1,
+          },
+        ],
+      },
+    ],
+  };
+
+  return { block, layout, measure };
+};
+
+describe("bidi paragraph interaction geometry", () => {
+  test("keeps click, caret, and selection on the mirrored physical left", () => {
+    const { block, fragment, layout, measure, measures } = makeFixture("right", true);
+    const click = clickToPositionInParagraph({
+      fragment,
+      block,
+      measure,
+      pageIndex: 0,
+      localX: 38,
+      localY: 7,
+    });
+    const directCaret = getPositionRect(block, measure, 1, 0, 0, fragment.width, 0);
+    const caret = getCaretPosition(layout, [block], measures, 1);
+    const selection = selectionToRects(layout, [block], measures, 1, 5);
+
+    expect(click?.charOffset).toBe(1);
+    expect(directCaret?.x).toBe(30);
+    expect(caret?.x).toBe(30);
+    expect(selection[0]?.x).toBe(30);
+  });
+
+  test("mirrors bidi left to physical right with asymmetric indents", () => {
+    const { block, fragment, layout, measure, measures } = makeFixture("left", true);
+    const expectedStart = 30 + (fragment.width - 30 - 10 - 28);
+
+    expect(getPositionRect(block, measure, 1, 0, 0, fragment.width, 0)?.x).toBe(expectedStart);
+    expect(getCaretPosition(layout, [block], measures, 1)?.x).toBe(expectedStart);
+    expect(selectionToRects(layout, [block], measures, 1, 5)[0]?.x).toBe(expectedStart);
+  });
+
+  test("leaves explicit bidi=false physical geometry unchanged", () => {
+    const { block, fragment, measure } = makeFixture("right", false);
+    const expectedStart = 10 + (fragment.width - 10 - 30 - 28);
+
+    expect(getPositionRect(block, measure, 1, 0, 0, fragment.width, 0)?.x).toBe(expectedStart);
+  });
+
+  test("leaves absent bidi physical geometry unchanged", () => {
+    const { block, fragment, measure } = makeFixture("right");
+    const expectedStart = 10 + (fragment.width - 10 - 30 - 28);
+
+    expect(getPositionRect(block, measure, 1, 0, 0, fragment.width, 0)?.x).toBe(expectedStart);
+  });
+
+  test("keeps table-cell click and selection on the painted physical side", () => {
+    const { block, layout, measure } = makeTableFixture();
+    const page = layout.pages[0];
+    if (!page) {
+      throw new Error("expected table page");
+    }
+    const hit = hitTestTableCell({ pageIndex: 0, page, pageY: 7 }, [block], [measure], {
+      x: 175,
+      y: 7,
+    });
+    if (!hit) {
+      throw new Error("expected table cell hit");
+    }
+
+    // Content width is 200 - 5 - 15 = 180. Bidi mirrors the authored
+    // indents to physical left=30/right=10 and authored left alignment to
+    // physical right, placing the 28px line at x=20+5+30+(140-28)=167.
+    expect(hit.cellContentWidth).toBe(180);
+    expect(hit.cellLocalX).toBe(150);
+    expect(clickToPositionInTableCell(hit)).toBe(2);
+    expect(selectionToRects(layout, [block], [measure], 1, 5)[0]?.x).toBe(167);
+  });
+});

--- a/packages/core/src/layout-bridge/engine/selectionRects.ts
+++ b/packages/core/src/layout-bridge/engine/selectionRects.ts
@@ -10,11 +10,16 @@
 
 import { getHeaderRowsHeight } from "../../layout-engine/index";
 import { measuredLineContentOffset } from "../../layout-engine/lineFlow";
-import { getTableRowLeadingWidth, resolveTableCellPadding } from "../../layout-engine/types";
+import { resolveTableCellPadding } from "../../layout-engine/types";
 import { measureParagraph } from "../../layout-engine/measure";
 import { buildRunFontStyle } from "../../layout-engine/measure/measureHelpers";
 import { measureRun } from "../../layout-engine/measure/measureProvider";
 import type { FontStyle } from "../../layout-engine/measure/measureTypes";
+import {
+  buildTableCellGrid,
+  buildTableCellPlacements,
+  type TableCellPlacements,
+} from "../../layout-engine/measure/tableCellGrid";
 import {
   buildTableCellFloatingZones,
   getTableCellContentWidth,
@@ -39,6 +44,7 @@ import type {
   BlockId,
 } from "../../layout-engine/types";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
+import { resolvePhysicalParagraphInlineLayout } from "../../utils/paragraphInlineLayout";
 import { getPageTop } from "./hitTest";
 
 /**
@@ -459,6 +465,7 @@ export function selectionToRects(
   const selTo = Math.max(from, to);
 
   const rects: SelectionRect[] = [];
+  const tableCellPlacements = new WeakMap<TableBlock, TableCellPlacements>();
 
   // Walk through all pages and fragments
   for (let pageIndex = 0; pageIndex < layout.pages.length; pageIndex++) {
@@ -486,6 +493,9 @@ export function selectionToRects(
         const paragraphBlock = block as ParagraphBlock;
         const paragraphMeasure = measure as ParagraphMeasure;
         const paragraphFragment = fragment as ParagraphFragment;
+        const { alignment, indentLeft, indentRight } =
+          resolvePhysicalParagraphInlineLayout(paragraphBlock);
+        const availableWidth = Math.max(0, fragment.width - indentLeft - indentRight);
 
         // Find lines that intersect with selection
         const intersectingLines = findLinesInRange(
@@ -526,18 +536,11 @@ export function selectionToRects(
           const charOffsetFrom = pmPosToCharOffset(paragraphBlock, line, sliceFrom);
           const charOffsetTo = pmPosToCharOffset(paragraphBlock, line, sliceTo);
 
-          // Calculate indentation
-          const indent = paragraphBlock.attrs?.indent;
-          const indentLeft = indent?.left ?? 0;
-          const indentRight = indent?.right ?? 0;
-          const availableWidth = Math.max(0, fragment.width - indentLeft - indentRight);
-
           // Get X coordinates for selection bounds
           const startX = charOffsetToX(paragraphBlock, line, charOffsetFrom, availableWidth);
           const endX = charOffsetToX(paragraphBlock, line, charOffsetTo, availableWidth);
 
           // Calculate alignment offset
-          const alignment = paragraphBlock.attrs?.alignment ?? "left";
           let alignmentOffset = 0;
           if (alignment === "center") {
             alignmentOffset = Math.max(0, (availableWidth - line.width) / 2);
@@ -588,6 +591,16 @@ export function selectionToRects(
         const tableBlock = block as TableBlock;
         const tableMeasure = measure as TableMeasure;
         const tableFragment = fragment as TableFragment;
+        let cellPlacements = tableCellPlacements.get(tableBlock);
+        if (!cellPlacements) {
+          const cellGrid = buildTableCellGrid(tableBlock.rows, tableMeasure.columnWidths.length);
+          cellPlacements = buildTableCellPlacements({
+            grid: cellGrid,
+            columnWidths: tableMeasure.columnWidths,
+            bidi: tableBlock.bidi === true,
+          });
+          tableCellPlacements.set(tableBlock, cellPlacements);
+        }
 
         // Account for repeated header rows in continuation fragments
         const hdrCount = tableFragment.headerRowCount ?? 0;
@@ -611,12 +624,14 @@ export function selectionToRects(
           const clipTop = tableFragment.topClip ?? 0;
           const clipBottom = tableFragment.bottomClip ?? rowMeasure.height;
 
-          // Walk through cells
-          let cellX = getTableRowLeadingWidth(row, tableMeasure.columnWidths);
           for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex++) {
             const cell = row.cells[cellIndex];
             const cellMeasure = rowMeasure.cells[cellIndex];
             if (!cell || !cellMeasure) {
+              continue;
+            }
+            const placement = cellPlacements.get(cell);
+            if (!placement) {
               continue;
             }
             const contentWidth = getTableCellContentWidth(cell, cellMeasure);
@@ -648,6 +663,9 @@ export function selectionToRects(
                   paragraphYOffset: blockY,
                 });
               }
+              const { alignment, indentLeft, indentRight } =
+                resolvePhysicalParagraphInlineLayout(paragraphBlock);
+              const availableWidth = Math.max(0, contentWidth - indentLeft - indentRight);
 
               // Find lines that intersect with selection
               const intersectingLines = findLinesInRange(
@@ -677,8 +695,14 @@ export function selectionToRects(
                 const charOffsetFrom = pmPosToCharOffset(paragraphBlock, line, sliceFrom);
                 const charOffsetTo = pmPosToCharOffset(paragraphBlock, line, sliceTo);
 
-                const startX = charOffsetToX(paragraphBlock, line, charOffsetFrom, contentWidth);
-                const endX = charOffsetToX(paragraphBlock, line, charOffsetTo, contentWidth);
+                const startX = charOffsetToX(paragraphBlock, line, charOffsetFrom, availableWidth);
+                const endX = charOffsetToX(paragraphBlock, line, charOffsetTo, availableWidth);
+                let alignmentOffset = 0;
+                if (alignment === "center") {
+                  alignmentOffset = Math.max(0, (availableWidth - line.width) / 2);
+                } else if (alignment === "right") {
+                  alignmentOffset = Math.max(0, availableWidth - line.width);
+                }
 
                 const lineY = measuredLineContentOffset(paragraphMeasure.lines, 0, index);
                 const clippedLineY = contentOffsetY + blockY + lineY;
@@ -687,7 +711,13 @@ export function selectionToRects(
                 }
 
                 rects.push({
-                  x: tableFragment.x + cellX + contentOffsetX + Math.min(startX, endX),
+                  x:
+                    tableFragment.x +
+                    placement.left +
+                    contentOffsetX +
+                    indentLeft +
+                    alignmentOffset +
+                    Math.min(startX, endX),
                   y: tableFragment.y + rowY + clippedLineY - clipTop + pageTopY,
                   width: isEmptyLine
                     ? EMPTY_PARAGRAPH_SLIVER_WIDTH
@@ -699,8 +729,6 @@ export function selectionToRects(
 
               blockY += paragraphMeasure.totalHeight;
             }
-
-            cellX += cellMeasure.width;
           }
 
           rowY += rowMeasure.height;
@@ -799,15 +827,13 @@ export function getCaretPosition(
             const charOffset = pmPosToCharOffset(paragraphBlock, line, pmPosition);
 
             // Calculate indentation
-            const indent = paragraphBlock.attrs?.indent;
-            const indentLeft = indent?.left ?? 0;
-            const indentRight = indent?.right ?? 0;
+            const { alignment, indentLeft, indentRight } =
+              resolvePhysicalParagraphInlineLayout(paragraphBlock);
             const availableWidth = Math.max(0, fragment.width - indentLeft - indentRight);
 
             const x = charOffsetToX(paragraphBlock, line, charOffset, availableWidth);
 
             // Calculate alignment offset
-            const alignment = paragraphBlock.attrs?.alignment ?? "left";
             let alignmentOffset = 0;
             if (alignment === "center") {
               alignmentOffset = Math.max(0, (availableWidth - line.width) / 2);

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -33,6 +33,7 @@ import {
 import { buildTableRowBreakInfo, getRowContinuationSkip, snapRowBreak } from "./tableRowBreak";
 import { bandFragmentX, bandTopContentY, isPageFrameRelativeAnchor } from "./textBoxFlow";
 import { resolveFloatingTableX } from "./measure/floatingTablePosition";
+import { resolveTableInlinePlacement } from "./measure/tableInlinePlacement";
 import { floatingTextBoxReservesBand } from "./types";
 import type {
   FlowBlock,
@@ -985,21 +986,15 @@ function layoutTable(
   // X position from justification / indent, recomputed per fragment because the
   // active column can change across section breaks.
   const computeTableX = (columnIndex: number): number => {
-    let x = paginator.getColumnX(columnIndex);
-    if (block.justification === "center") {
-      x += (paginator.columnWidth - measure.totalWidth) / 2;
-    } else if (block.justification === "right") {
-      x = x + paginator.columnWidth - measure.totalWidth;
-    } else if (block.indent !== undefined) {
-      // An authored w:tblInd offsets the table border from the content margin.
-      // Keep the absent-value path separate because Word's inherited default
-      // aligns the first-cell text edge instead.
-      x += block.indent;
-    } else {
-      const leadingCellMargin = block.rows.at(0)?.cells.at(0)?.padding?.left ?? 0;
-      x -= leadingCellMargin;
+    const x = paginator.getColumnX(columnIndex);
+    const placement = resolveTableInlinePlacement(block);
+    if (placement.alignment === "center") {
+      return x + (paginator.columnWidth - measure.totalWidth) / 2;
     }
-    return x;
+    if (placement.alignment === "right") {
+      return x + paginator.columnWidth - measure.totalWidth - placement.offset;
+    }
+    return x + placement.offset;
   };
 
   const getCurrentRowCapacity = (state = paginator.getCurrentState()): number =>

--- a/packages/core/src/layout-engine/measure/hyperlinkInstance.ts
+++ b/packages/core/src/layout-engine/measure/hyperlinkInstance.ts
@@ -1,0 +1,16 @@
+import type { HyperlinkInfo } from "../types";
+
+// Imported hyperlink wrappers carry a conversion-wide index in ProseMirror.
+// Keep it out of the public Flow shape while letting the painter distinguish
+// adjacent, separate links that happen to share the same visible metadata.
+const hyperlinkInstanceIndexes = new WeakMap<HyperlinkInfo, number>();
+
+export const setHyperlinkInstanceIndex = (
+  hyperlink: HyperlinkInfo,
+  instanceIndex: number,
+): void => {
+  hyperlinkInstanceIndexes.set(hyperlink, instanceIndex);
+};
+
+export const getHyperlinkInstanceIndex = (hyperlink: HyperlinkInfo): number | undefined =>
+  hyperlinkInstanceIndexes.get(hyperlink);

--- a/packages/core/src/layout-engine/measure/tableCellGrid.ts
+++ b/packages/core/src/layout-engine/measure/tableCellGrid.ts
@@ -6,6 +6,21 @@ export type TableCellGrid = {
   sourceColumnsByCell: ReadonlyMap<TableCell, number>;
 };
 
+export type TableCellPlacement = {
+  sourceColumn: number;
+  columnSpan: number;
+  left: number;
+  width: number;
+};
+
+export type TableCellPlacements = ReadonlyMap<TableCell, TableCellPlacement>;
+
+type BuildTableCellPlacementsOptions = {
+  grid: TableCellGrid;
+  columnWidths: readonly number[];
+  bidi: boolean;
+};
+
 export const buildTableCellGrid = (
   rows: readonly TableRow[],
   columnCount: number,
@@ -20,10 +35,11 @@ export const buildTableCellGrid = (
       continue;
     }
 
-    let columnIndex = firstAvailableColumn(occupiedColumnsByRow.get(rowIndex), row.gridBefore ?? 0);
+    const gridBefore = Math.max(0, Math.min(columnCount, Math.trunc(row.gridBefore ?? 0)));
+    let columnIndex = firstAvailableColumn(occupiedColumnsByRow.get(rowIndex), gridBefore);
     for (const cell of row.cells) {
-      const columnSpan = cell.colSpan ?? 1;
-      const rowSpan = cell.rowSpan ?? 1;
+      const columnSpan = Math.max(1, Math.trunc(cell.colSpan ?? 1));
+      const rowSpan = Math.max(1, Math.trunc(cell.rowSpan ?? 1));
       sourceColumnsByCell.set(cell, columnIndex);
 
       const rowEnd = Math.min(rows.length, rowIndex + rowSpan);
@@ -36,14 +52,10 @@ export const buildTableCellGrid = (
       }
 
       if (rowSpan > 1) {
-        for (
-          let spannedRowIndex = rowIndex + 1;
-          spannedRowIndex < rowIndex + rowSpan;
-          spannedRowIndex++
-        ) {
+        for (let spannedRowIndex = rowIndex + 1; spannedRowIndex < rowEnd; spannedRowIndex++) {
           const occupied = getOrCreateOccupiedRow(occupiedColumnsByRow, spannedRowIndex);
-          for (let columnOffset = 0; columnOffset < columnSpan; columnOffset++) {
-            occupied.add(columnIndex + columnOffset);
+          for (let gridColumnIndex = columnIndex; gridColumnIndex < columnEnd; gridColumnIndex++) {
+            occupied.add(gridColumnIndex);
           }
         }
       }
@@ -72,6 +84,39 @@ export const getSourceCellAt = (
 
 export const getSourceCellColumn = (grid: TableCellGrid, cell: TableCell): number | undefined =>
   grid.sourceColumnsByCell.get(cell);
+
+/** Resolve all source cells to canonical logical columns and physical boxes. */
+export const buildTableCellPlacements = ({
+  grid,
+  columnWidths,
+  bidi,
+}: BuildTableCellPlacementsOptions): TableCellPlacements => {
+  const columnOffsets = [0];
+  for (const columnWidth of columnWidths) {
+    columnOffsets.push((columnOffsets.at(-1) ?? 0) + columnWidth);
+  }
+  const tableWidth = columnOffsets.at(-1) ?? 0;
+  const placements = new Map<TableCell, TableCellPlacement>();
+
+  for (const [cell, sourceColumn] of grid.sourceColumnsByCell) {
+    if (sourceColumn < 0 || sourceColumn >= columnWidths.length) {
+      continue;
+    }
+    const declaredColumnSpan = Math.max(1, Math.trunc(cell.colSpan ?? 1));
+    const columnSpan = Math.min(declaredColumnSpan, columnWidths.length - sourceColumn);
+    const logicalLeft = columnOffsets.at(sourceColumn) ?? 0;
+    const logicalRight = columnOffsets.at(sourceColumn + columnSpan) ?? logicalLeft;
+    const width = logicalRight - logicalLeft;
+    placements.set(cell, {
+      sourceColumn,
+      columnSpan,
+      left: bidi ? tableWidth - logicalRight : logicalLeft,
+      width,
+    });
+  }
+
+  return placements;
+};
 
 export const getTableCellVerticalBorderHeight = (
   grid: TableCellGrid,

--- a/packages/core/src/layout-engine/measure/tableInlinePlacement.ts
+++ b/packages/core/src/layout-engine/measure/tableInlinePlacement.ts
@@ -1,0 +1,24 @@
+import { resolveTableCellPadding, type TableBlock } from "../types";
+
+type TableInlinePlacement =
+  | { alignment: "center" }
+  | { alignment: "left" | "right"; offset: number };
+
+/** Resolve an inline table's horizontal anchor without losing RTL leading-edge semantics. */
+export const resolveTableInlinePlacement = (
+  table: Pick<TableBlock, "bidi" | "indent" | "justification" | "rows">,
+): TableInlinePlacement => {
+  if (table.justification === "center") {
+    return { alignment: "center" };
+  }
+  if (table.justification === "right") {
+    return { alignment: "right", offset: 0 };
+  }
+
+  const firstCell = table.rows.at(0)?.cells.at(0);
+  const firstCellPadding = firstCell ? resolveTableCellPadding(firstCell) : undefined;
+  if (table.justification === "left" || table.bidi !== true) {
+    return { alignment: "left", offset: table.indent ?? -(firstCellPadding?.left ?? 0) };
+  }
+  return { alignment: "right", offset: table.indent ?? -(firstCellPadding?.right ?? 0) };
+};

--- a/packages/core/src/layout-engine/paragraphInlineLayout.test.ts
+++ b/packages/core/src/layout-engine/paragraphInlineLayout.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolvePhysicalParagraphInlineLayout } from "../utils/paragraphInlineLayout";
+import type { ParagraphAttrs } from "./types";
+
+const resolve = (attrs?: ParagraphAttrs, text = "text") =>
+  resolvePhysicalParagraphInlineLayout({
+    kind: "paragraph",
+    id: "paragraph",
+    runs: [{ kind: "text", text, rtl: text === "مرحبا" }],
+    attrs,
+  });
+
+describe("physical paragraph inline layout", () => {
+  test("mirrors explicit horizontal alignment and asymmetric indents under bidi", () => {
+    expect(
+      resolve({ alignment: "right", bidi: true, indent: { left: 12, right: 34 } }),
+    ).toMatchObject({
+      alignment: "left",
+      explicitAlignment: "left",
+      indentLeft: 34,
+      indentRight: 12,
+      isRtl: true,
+    });
+    expect(resolve({ alignment: "left", bidi: true })).toMatchObject({
+      alignment: "right",
+      explicitAlignment: "right",
+    });
+  });
+
+  test("preserves center and justify under bidi", () => {
+    expect(resolve({ alignment: "center", bidi: true }).alignment).toBe("center");
+    expect(resolve({ alignment: "justify", bidi: true }).alignment).toBe("justify");
+  });
+
+  test("does not mirror explicit false or inferred RTL paragraphs", () => {
+    expect(
+      resolve({ alignment: "right", bidi: false, indent: { left: 12, right: 34 } }),
+    ).toMatchObject({ alignment: "right", indentLeft: 12, indentRight: 34, isRtl: false });
+    expect(resolve({ alignment: "left", indent: { left: 12, right: 34 } }, "مرحبا")).toMatchObject({
+      alignment: "left",
+      indentLeft: 12,
+      indentRight: 34,
+      isRtl: true,
+    });
+  });
+
+  test("defaults RTL paragraphs to physical right without inventing explicit alignment", () => {
+    expect(resolve({ bidi: true })).toEqual({
+      alignment: "right",
+      indentLeft: 0,
+      indentRight: 0,
+      isRtl: true,
+    });
+  });
+});

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1079,14 +1079,14 @@ function tableFragments(block: TableBlock, measure: TableMeasure): TableFragment
 }
 
 describe("left-aligned table placement", () => {
-  test("aligns an unindented first-cell text edge with the content edge", () => {
+  test("aligns an unindented first-cell text edge using default cell padding", () => {
     const { block, measure } = tallTable(1);
-    block.rows[0]!.cells[0]!.padding.left = 7;
+    delete block.rows[0]!.cells[0]!.padding;
 
     const fragment = tableFragments(block, measure).at(0);
 
     expect(fragment?.x).toBe(OPTIONS.margins.left - 7);
-    expect((fragment?.x ?? 0) + block.rows[0]!.cells[0]!.padding.left).toBe(OPTIONS.margins.left);
+    expect((fragment?.x ?? 0) + 7).toBe(OPTIONS.margins.left);
   });
 
   test("applies an authored w:tblInd to the table border", () => {
@@ -1102,11 +1102,59 @@ describe("left-aligned table placement", () => {
   test("aligns an authored zero-indent table border with the content edge", () => {
     const { block, measure } = tallTable(1);
     block.indent = 0;
-    block.rows[0]!.cells[0]!.padding.left = 7;
+    delete block.rows[0]!.cells[0]!.padding;
 
     const fragment = tableFragments(block, measure).at(0);
 
     expect(fragment?.x).toBe(OPTIONS.margins.left);
+  });
+});
+
+describe("RTL table placement", () => {
+  test("applies an authored indent from the right leading edge", () => {
+    const { block, measure } = tallTable(1);
+    block.bidi = true;
+    block.indent = 10;
+
+    const fragment = tableFragments(block, measure).at(0);
+    const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
+
+    expect(fragment?.x).toBe(contentRight - measure.totalWidth - 10);
+  });
+
+  test("keeps a negative authored indent distinct from an absent indent", () => {
+    const { block, measure } = tallTable(1);
+    block.bidi = true;
+    block.indent = -10;
+    block.rows[0]!.cells[0]!.padding.right = 7;
+
+    const fragment = tableFragments(block, measure).at(0);
+    const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
+
+    expect(fragment?.x).toBe(contentRight - measure.totalWidth + 10);
+  });
+
+  test("aligns an unindented logical first-cell text edge using default cell padding", () => {
+    const { block, measure } = tallTable(1);
+    block.bidi = true;
+    delete block.rows[0]!.cells[0]!.padding;
+
+    const fragment = tableFragments(block, measure).at(0);
+    const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
+
+    expect((fragment?.x ?? 0) + measure.totalWidth - 7).toBe(contentRight);
+  });
+
+  test("aligns an authored zero-indent table border with the right content edge", () => {
+    const { block, measure } = tallTable(1);
+    block.bidi = true;
+    block.indent = 0;
+    delete block.rows[0]!.cells[0]!.padding;
+
+    const fragment = tableFragments(block, measure).at(0);
+    const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
+
+    expect((fragment?.x ?? 0) + measure.totalWidth).toBe(contentRight);
   });
 });
 

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -709,7 +709,7 @@ export type TableBlock = {
   layout?: "fixed" | "autofit";
   /** Table horizontal alignment */
   justification?: "left" | "center" | "right";
-  /** Table indent from left margin (in pixels, from w:tblInd) */
+  /** Table indent from the leading margin (in pixels, from w:tblInd). */
   indent?: number;
   /** Right-to-left column order (w:bidiVisual): logical column 0 paints on the right. */
   bidi?: boolean;

--- a/packages/core/src/layout-painter/renderMath.test.ts
+++ b/packages/core/src/layout-painter/renderMath.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { MathRun } from "../layout-engine/types";
+import type { MathRun, ParagraphAttrs } from "../layout-engine/types";
 import { renderLine } from "./renderParagraph";
 
 // Render-side tests for OMML math runs (`feat/folio-omml-math-render`).
@@ -271,11 +271,11 @@ function mathRun(overrides: Partial<MathRun>): MathRun {
   };
 }
 
-function renderMathRunOnce(run: MathRun): FakeElement {
+function renderMathRunOnce(run: MathRun, attrs: ParagraphAttrs = {}): FakeElement {
   const block = {
     kind: "paragraph",
     runs: [run],
-    attrs: {},
+    attrs,
     styleId: undefined,
   } as unknown as Parameters<typeof renderLine>[0];
 
@@ -330,6 +330,30 @@ describe("painter — OMML math run", () => {
     expect(host).not.toBeNull();
     expect(host?.dataset["display"]).toBe("block");
     expect(host?.innerHTML).toContain('display="block"');
+  });
+
+  test("centres display math when bidi right resolves to physical left", () => {
+    const line = renderMathRunOnce(mathRun({ display: "block" }), {
+      alignment: "right",
+      bidi: true,
+    });
+
+    expect(line.style.textAlign).toBe("center");
+  });
+
+  test("preserves explicit physical-right display math alignment under bidi", () => {
+    const line = renderMathRunOnce(mathRun({ display: "block" }), {
+      alignment: "left",
+      bidi: true,
+    });
+
+    expect(line.style.textAlign).toBe("");
+  });
+
+  test("centres display math in RTL with no explicit alignment", () => {
+    const line = renderMathRunOnce(mathRun({ display: "block", plainText: "س" }), { bidi: true });
+
+    expect(line.style.textAlign).toBe("center");
   });
 
   test("falls back to italic plain-text span when OMML XML is malformed", () => {

--- a/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -16,6 +16,7 @@ import type {
   ParagraphMeasure,
   TextRun,
 } from "../layout-engine/types";
+import { setHyperlinkInstanceIndex } from "../layout-engine/measure/hyperlinkInstance";
 import { renderParagraphFragment } from "./renderParagraph";
 
 function createFakeStyle(): Record<string, string> {
@@ -170,6 +171,23 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(line?.style["textIndent"]).toBe("-48px");
   });
 
+  test("mirrors explicit bidi justification onto the physical page", () => {
+    expect(render([text("13")], { alignment: "right", bidi: true }).style.textAlign).toBe("left");
+    expect(render([text("13")], { alignment: "left", bidi: true }).style.textAlign).toBe("right");
+  });
+
+  test("does not mirror explicit alignment or indents for inferred RTL", () => {
+    const paragraph = render([text("مرحبا", true)], {
+      alignment: "right",
+      indent: { left: 96, right: 24 },
+    }) as unknown as FakeElement;
+    const line = paragraph.children.at(0);
+
+    expect(paragraph.style["textAlign"]).toBe("right");
+    expect(line?.style["paddingLeft"]).toBe("96px");
+    expect(line?.style["paddingRight"]).toBe("24px");
+  });
+
   test("explicit w:bidi=false wins over rtl runs (stays LTR)", () => {
     // `<w:bidi w:val="0"/>` is an explicit LTR override; first-strong detection
     // must not re-enable RTL for a Hebrew run inside it.
@@ -265,6 +283,23 @@ describe("Issue #719 — RTL base direction detection", () => {
     ) as unknown as FakeElement;
 
     expect(findAllByTag(paragraph, "a").map((anchor) => anchor.dir)).toEqual(["ltr", "ltr"]);
+  });
+
+  test("does not merge adjacent same-target hyperlink instances", () => {
+    const href = "https://example.test";
+    const urlHyperlink = { href };
+    const labelHyperlink = { href };
+    setHyperlinkInstanceIndex(urlHyperlink, 0);
+    setHyperlinkInstanceIndex(labelHyperlink, 1);
+    const paragraph = render(
+      [
+        { kind: "text", text: href, hyperlink: urlHyperlink },
+        { kind: "text", text: "رابط", hyperlink: labelHyperlink },
+      ],
+      { bidi: true },
+    ) as unknown as FakeElement;
+
+    expect(findAllByTag(paragraph, "a").map((anchor) => anchor.dir)).toEqual(["ltr", ""]);
   });
 
   test("does not force a link label or Arabic link text left-to-right", () => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -15,6 +15,7 @@ import {
   resolveListMarkerFont,
 } from "../layout-engine/measure/listMarkerWidth";
 import { DEFAULT_FONT_SIZE, DOCX_SCRIPT_FONT_SCALE } from "../layout-engine/measure/measureHelpers";
+import { getHyperlinkInstanceIndex } from "../layout-engine/measure/hyperlinkInstance";
 import {
   FONT_KERNING_MODE,
   countCompressibleSpaces,
@@ -43,7 +44,10 @@ import type {
 import { calculateTabWidth } from "../prosemirror/utils/tabCalculator";
 import type { TabContext, TabStop as TabCalcStop } from "../prosemirror/utils/tabCalculator";
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
-import { isRtlParagraph } from "../utils/paragraphBaseDirection";
+import {
+  resolvePhysicalParagraphInlineLayout,
+  type PhysicalParagraphInlineLayout,
+} from "../utils/paragraphInlineLayout";
 import {
   hasComplexScriptFormatting,
   resolveComplexScriptFormatting,
@@ -122,6 +126,11 @@ function isTextRun(run: Run): run is TextRun {
 }
 
 function hyperlinksMatch(left: HyperlinkInfo, right: HyperlinkInfo): boolean {
+  const leftInstanceIndex = getHyperlinkInstanceIndex(left);
+  const rightInstanceIndex = getHyperlinkInstanceIndex(right);
+  if (leftInstanceIndex !== undefined || rightInstanceIndex !== undefined) {
+    return leftInstanceIndex === rightInstanceIndex;
+  }
   return (
     left.href === right.href &&
     left.tooltip === right.tooltip &&
@@ -1586,6 +1595,8 @@ type RenderLineOptions = {
   firstLineIndentPx?: number;
   /** Paragraph base direction for logical first-line indentation. */
   isRtl?: boolean;
+  /** Explicit alignment after resolving authored bidi physical sides. */
+  explicitAlignment?: PhysicalParagraphInlineLayout["explicitAlignment"];
   /** Full paragraph content-box width before physical indents. */
   contentWidthPx?: number;
   /** Line-specific floating image margins (calculated per-line based on Y overlap) */
@@ -2050,7 +2061,8 @@ export function renderLine(
     // Only an EXPLICIT right alignment suppresses display-math centering; a
     // right default synthesized from RTL base direction must not (the equation
     // still centres in an RTL paragraph). (#723)
-    block.attrs?.alignment !== "right"
+    (options?.explicitAlignment ??
+      resolvePhysicalParagraphInlineLayout(block).explicitAlignment) !== "right"
   ) {
     lineEl.style.textAlign = "center";
   }
@@ -2657,7 +2669,8 @@ export function renderParagraphFragment(
 
   // Get the lines for this fragment
   const lines = measure.lines.slice(fragment.fromLine, fragment.toLine);
-  const alignment = block.attrs?.alignment;
+  const inlineLayout = resolvePhysicalParagraphInlineLayout(block);
+  const { alignment, indentLeft, indentRight, isRtl } = inlineLayout;
 
   // Apply paragraph-level styles
   if (block.attrs?.styleId) {
@@ -2672,7 +2685,6 @@ export function renderParagraphFragment(
   // `dir`-marked spans (each an isolate), so without a base `dir` on the
   // fragment the runs stay in logical LTR order and reversed Hebrew/Arabic
   // reads backwards. eigenpal #723 (#719).
-  const isRtl = isRtlParagraph(block);
   if (isRtl) {
     fragmentEl.dir = "rtl";
   }
@@ -2680,54 +2692,23 @@ export function renderParagraphFragment(
   // Apply text alignment at paragraph level
   // For justify: use text-align: left and apply word-spacing per line
   // For RTL paragraphs, default alignment is right
-  if (alignment) {
-    if (alignment === "center") {
-      fragmentEl.style.textAlign = "center";
-    } else if (alignment === "right") {
-      fragmentEl.style.textAlign = "right";
-    } else if (alignment === "left") {
-      fragmentEl.style.textAlign = "left";
-    } else {
-      // 'justify' uses text-align: left (or right for RTL)
-      // Justify is implemented via word-spacing on individual lines
-      fragmentEl.style.textAlign = isRtl ? "right" : "left";
-    }
-  } else if (isRtl) {
-    // No explicit alignment on RTL paragraph — default to right
-    fragmentEl.style.textAlign = "right";
+  // Justify is implemented via word-spacing on individual lines; the
+  // fragment retains the paragraph's physical base-side alignment.
+  let fragmentAlignment = alignment;
+  if (alignment === "justify") {
+    fragmentAlignment = isRtl ? "right" : "left";
   }
+  fragmentEl.style.textAlign = fragmentAlignment;
 
   // An RTL paragraph with no explicit alignment defaults to right; pass that
   // through to per-line rendering so flex-promoted lines (image-only,
   // image+text, right-tab anchors) align to the start side too, not just the
   // fragment text-align. (#723)
-  const effectiveAlignment = alignment ?? (isRtl ? "right" : undefined);
+  const effectiveAlignment = alignment;
 
   // Track indentation for line-level application
   // Indentation is applied per-line, not at fragment level
   const indent = block.attrs?.indent;
-  let indentLeft = 0;
-  let indentRight = 0;
-
-  if (indent) {
-    // Track indent values for line-level application
-    // For RTL paragraphs, swap left/right indentation
-    if (isRtl) {
-      if (indent.left !== undefined) {
-        indentRight = indent.left;
-      }
-      if (indent.right !== undefined) {
-        indentLeft = indent.right;
-      }
-    } else {
-      if (indent.left !== undefined) {
-        indentLeft = indent.left;
-      }
-      if (indent.right !== undefined) {
-        indentRight = indent.right;
-      }
-    }
-  }
 
   // Note: Line spacing is applied per-line div (renderLine sets lineEl.style.height
   // and lineEl.style.lineHeight), not at fragment level. Fragment-level line-height
@@ -2907,6 +2888,9 @@ export function renderParagraphFragment(
       tabLeftIndentPx: indent?.left ?? 0,
       firstLineIndentPx: isFirstLine ? firstLineIndentPx : 0,
       isRtl,
+      ...(inlineLayout.explicitAlignment === undefined
+        ? {}
+        : { explicitAlignment: inlineLayout.explicitAlignment }),
       contentWidthPx: fragment.width,
       context,
       floatingMargins: {

--- a/packages/core/src/layout-painter/renderTable-bidi.test.ts
+++ b/packages/core/src/layout-painter/renderTable-bidi.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
-import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
+import { renderNestedTable, renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
 import type { RenderContext } from "./renderUtils";
 
 // Minimal DOM stand-in (mirrors renderTableFragment.test.ts) so the painter can
@@ -239,5 +239,68 @@ describe("renderTableFragment RTL column order (w:bidiVisual)", () => {
       (child) => child.className === TABLE_CLASS_NAMES.resizeHandle,
     );
     expect(internal?.dataset["bidi"]).toBe("true");
+  });
+});
+
+describe("renderNestedTable RTL placement", () => {
+  test("anchors an authored indent from the right leading edge", () => {
+    const { block, measure } = buildTwoColumnTable(true);
+    block.indent = 10;
+
+    const tableEl = renderNestedTable(
+      block,
+      measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    expect(tableEl.style["marginLeft"]).toBe("auto");
+    expect(tableEl.style["marginRight"]).toBe("10px");
+  });
+
+  test("distinguishes absent indentation from an authored zero", () => {
+    const absent = buildTwoColumnTable(true);
+    const absentEl = renderNestedTable(
+      absent.block,
+      absent.measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    const zero = buildTwoColumnTable(true);
+    zero.block.indent = 0;
+    const zeroEl = renderNestedTable(
+      zero.block,
+      zero.measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    expect(absentEl.style["marginRight"]).toBe("-7px");
+    expect(zeroEl.style["marginRight"]).toBe("0px");
+  });
+});
+
+describe("renderNestedTable LTR placement", () => {
+  test("distinguishes absent indentation from an authored zero with default padding", () => {
+    const absent = buildTwoColumnTable(false);
+    const absentEl = renderNestedTable(
+      absent.block,
+      absent.measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    const zero = buildTwoColumnTable(false);
+    zero.block.indent = 0;
+    const zeroEl = renderNestedTable(
+      zero.block,
+      zero.measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    expect(absentEl.style["marginLeft"]).toBe("-7px");
+    expect(zeroEl.style["marginLeft"]).toBe("0px");
   });
 });

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -34,12 +34,19 @@ import type {
   TextBoxFragment,
 } from "../layout-engine/types";
 import {
-  getTableRowLeadingWidth,
   isFloatingImageRun,
   isFloatingTextBoxBlock,
   resolveTableCellPadding,
   tableColumnsArePinned,
 } from "../layout-engine/types";
+import {
+  buildTableCellGrid,
+  buildTableCellPlacements,
+  getSourceCellAt,
+  type TableCellGrid,
+  type TableCellPlacements,
+} from "../layout-engine/measure/tableCellGrid";
+import { resolveTableInlinePlacement } from "../layout-engine/measure/tableInlinePlacement";
 import { emuToPixels } from "../utils/units";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
@@ -399,13 +406,15 @@ export function renderNestedTable(
   tableEl.style.width = `${measure.totalWidth}px`;
   tableEl.style.display = "block";
 
-  if (block.justification === "center") {
+  const placement = resolveTableInlinePlacement(block);
+  if (placement.alignment === "center") {
     tableEl.style.marginLeft = "auto";
     tableEl.style.marginRight = "auto";
-  } else if (block.justification === "right") {
+  } else if (placement.alignment === "right") {
     tableEl.style.marginLeft = "auto";
-  } else if (block.indent) {
-    tableEl.style.marginLeft = `${block.indent}px`;
+    tableEl.style.marginRight = `${placement.offset}px`;
+  } else {
+    tableEl.style.marginLeft = `${placement.offset}px`;
   }
 
   // Store metadata
@@ -427,12 +436,14 @@ export function renderNestedTable(
   }
   rowYPositions.push(yPos);
 
-  // Track spanning cells across rows
-  const spanningCells = new Map<string, SpanningCell>();
-
   // Render all rows
   const columnsPinned = tableColumnsArePinned(block);
-  const cellGrid = buildTableCellGrid(block, measure.columnWidths.length);
+  const cellGrid = buildTableCellGrid(block.rows, measure.columnWidths.length);
+  const cellPlacements = buildTableCellPlacements({
+    grid: cellGrid,
+    columnWidths: measure.columnWidths,
+    bidi: block.bidi === true,
+  });
   let y = 0;
   for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
     const row = block.rows[rowIndex];
@@ -455,11 +466,11 @@ export function renderNestedTable(
       totalRows: block.rows.length,
       context,
       doc,
-      spanningCells,
       rowYPositions,
       bidi: block.bidi === true,
       columnsPinned,
       cellGrid,
+      cellPlacements,
     });
     tableEl.append(rowEl);
     y += rowMeasure.height;
@@ -560,6 +571,7 @@ type RenderTableCellOptions = {
   cell: TableCell;
   cellMeasure: TableCellMeasure;
   x: number;
+  width: number;
   rowHeight: number;
   borderFlags: {
     drawTop: boolean;
@@ -578,6 +590,7 @@ function renderTableCell({
   cell,
   cellMeasure,
   x,
+  width,
   rowHeight,
   borderFlags,
   columnsPinned,
@@ -593,7 +606,7 @@ function renderTableCell({
   cellEl.style.position = "absolute";
   cellEl.style.left = `${x}px`;
   cellEl.style.top = "0";
-  cellEl.style.width = `${cellMeasure.width}px`;
+  cellEl.style.width = `${width}px`;
   cellEl.style.height = `${rowHeight}px`;
   cellEl.style.overflow = "hidden";
   cellEl.style.boxSizing = "border-box";
@@ -708,7 +721,7 @@ function renderTableCell({
   const topLeftToBottomRight = renderCellDiagonalBorder({
     border: cell.borders?.topLeftToBottomRight,
     direction: "top-left-to-bottom-right",
-    cellWidth: cellMeasure.width,
+    cellWidth: width,
     cellHeight: rowHeight,
     doc,
   });
@@ -718,7 +731,7 @@ function renderTableCell({
   const topRightToBottomLeft = renderCellDiagonalBorder({
     border: cell.borders?.topRightToBottomLeft,
     direction: "top-right-to-bottom-left",
-    cellWidth: cellMeasure.width,
+    cellWidth: width,
     cellHeight: rowHeight,
     doc,
   });
@@ -748,54 +761,6 @@ function renderTableCell({
   return cellEl;
 }
 
-/**
- * Track cells that span multiple rows
- */
-type SpanningCell = {
-  cell: TableCell;
-  cellMeasure: TableCellMeasure;
-  columnIndex: number;
-  startRow: number;
-  rowSpan: number;
-  colSpan: number;
-  x: number;
-  totalHeight: number;
-};
-
-type TableCellGrid = Map<string, TableCell>;
-
-const tableCellGridKey = (rowIndex: number, columnIndex: number): string =>
-  `${rowIndex}:${columnIndex}`;
-
-function buildTableCellGrid(block: TableBlock, columnCount: number): TableCellGrid {
-  const grid: TableCellGrid = new Map();
-
-  for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
-    const row = block.rows[rowIndex];
-    if (!row) {
-      continue;
-    }
-    let columnIndex = 0;
-    for (const cell of row.cells) {
-      while (grid.has(tableCellGridKey(rowIndex, columnIndex))) {
-        columnIndex += 1;
-      }
-      const colSpan = cell.colSpan ?? 1;
-      const rowSpan = cell.rowSpan ?? 1;
-      const rowEnd = Math.min(block.rows.length, rowIndex + rowSpan);
-      const columnEnd = Math.min(columnCount, columnIndex + colSpan);
-      for (let gridRow = rowIndex; gridRow < rowEnd; gridRow++) {
-        for (let gridColumn = columnIndex; gridColumn < columnEnd; gridColumn++) {
-          grid.set(tableCellGridKey(gridRow, gridColumn), cell);
-        }
-      }
-      columnIndex += colSpan;
-    }
-  }
-
-  return grid;
-}
-
 const hasVisibleBorder = (border: { width?: number; style?: string } | undefined): boolean =>
   border !== undefined && border.style !== "none" && border.style !== "nil";
 
@@ -811,12 +776,12 @@ type RenderTableRowOptions = {
   totalRows: number;
   context: RenderContext;
   doc: Document;
-  spanningCells?: Map<string, SpanningCell>;
   rowYPositions?: number[];
   isFirstRowInFragment?: boolean;
   bidi?: boolean;
   columnsPinned?: boolean;
-  cellGrid?: TableCellGrid;
+  cellGrid: TableCellGrid;
+  cellPlacements: TableCellPlacements;
   contentClip?: CellContentClip;
   pageContentPosition?: PageContentPosition;
 };
@@ -830,22 +795,17 @@ function renderTableRow({
   totalRows,
   context,
   doc,
-  spanningCells,
   rowYPositions,
   isFirstRowInFragment,
   bidi = false,
   columnsPinned = false,
   cellGrid,
+  cellPlacements,
   contentClip,
   pageContentPosition,
 }: RenderTableRowOptions): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
-
-  // RTL tables (w:bidiVisual) mirror columns: logical column 0 paints on the
-  // right. Geometry-only — cell content and saved DOCX are unchanged
-  // (eigenpal/docx-editor#940).
-  const tableWidth = bidi ? columnWidths.reduce((sum, columnWidth) => sum + columnWidth, 0) : 0;
 
   // Positioning
   rowEl.style.position = "absolute";
@@ -857,32 +817,6 @@ function renderTableRow({
   // Data attributes
   rowEl.dataset["rowIndex"] = String(rowIndex);
 
-  // Build set of columns occupied by spanning cells from previous rows
-  const occupiedColumns = new Set<number>();
-  if (spanningCells) {
-    for (const [, spanCell] of spanningCells) {
-      // Check if this spanning cell covers the current row
-      if (spanCell.startRow < rowIndex && spanCell.startRow + spanCell.rowSpan > rowIndex) {
-        for (let c = 0; c < spanCell.colSpan; c++) {
-          occupiedColumns.add(spanCell.columnIndex + c);
-        }
-      }
-    }
-  }
-
-  // Render cells
-  // Track actual column index separately from cell index
-  // because cells with colSpan > 1 span multiple columns
-  const gridBefore = row.gridBefore ?? 0;
-  let x = getTableRowLeadingWidth(row, columnWidths);
-  let columnIndex = gridBefore;
-
-  // Skip columns occupied by spanning cells
-  while (occupiedColumns.has(columnIndex)) {
-    x += columnWidths[columnIndex] ?? 0;
-    columnIndex++;
-  }
-
   for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex++) {
     const cell = row.cells[cellIndex];
     const cellMeasure = rowMeasure.cells[cellIndex];
@@ -891,7 +825,11 @@ function renderTableRow({
       continue;
     }
 
-    const colSpan = cell.colSpan ?? 1;
+    const placement = cellPlacements.get(cell);
+    if (!placement) {
+      continue;
+    }
+    const { sourceColumn: columnIndex, columnSpan: colSpan, left: cellLeft, width } = placement;
     const rowSpan = cell.rowSpan ?? 1;
 
     // Calculate cell height - for spanning cells, use total height of spanned rows
@@ -907,12 +845,6 @@ function renderTableRow({
       }
     }
 
-    let cellWidth = 0;
-    for (let c = 0; c < colSpan && columnIndex + c < columnWidths.length; c++) {
-      cellWidth += columnWidths[columnIndex + c] ?? 0;
-    }
-    const cellLeft = bidi ? tableWidth - x - cellWidth : x;
-
     const isFirstRow = rowIndex === 0 || isFirstRowInFragment === true;
     const isLastRow = rowIndex + rowSpan >= totalRows;
     // Outer-border sides are visual: in RTL the logical last column is the
@@ -921,9 +853,9 @@ function renderTableRow({
     const atLogicalEnd = columnIndex + colSpan >= columnWidths.length;
     const isFirstCol = bidi ? atLogicalEnd : atLogicalStart;
     const isLastCol = bidi ? atLogicalStart : atLogicalEnd;
-    const aboveCell = cellGrid?.get(tableCellGridKey(rowIndex - 1, columnIndex));
+    const aboveCell = getSourceCellAt(cellGrid, rowIndex - 1, columnIndex);
     const leftNeighborColumn = bidi ? columnIndex + colSpan : columnIndex - 1;
-    const leftCell = cellGrid?.get(tableCellGridKey(rowIndex, leftNeighborColumn));
+    const leftCell = getSourceCellAt(cellGrid, rowIndex, leftNeighborColumn);
     const drawTop = isFirstRow || !hasVisibleBorder(aboveCell?.borders?.bottom);
     const drawLeft = isFirstCol || !hasVisibleBorder(leftCell?.borders?.right);
 
@@ -931,6 +863,7 @@ function renderTableRow({
       cell,
       cellMeasure,
       x: cellLeft,
+      width,
       rowHeight: cellHeight,
       borderFlags: { drawTop, isLastRow, drawLeft, isLastCol },
       columnsPinned,
@@ -956,33 +889,6 @@ function renderTableRow({
     }
 
     rowEl.append(cellEl);
-
-    // Track this cell as spanning if it spans multiple rows
-    if (rowSpan > 1 && spanningCells) {
-      const key = `${rowIndex}-${columnIndex}`;
-      spanningCells.set(key, {
-        cell,
-        cellMeasure,
-        columnIndex,
-        startRow: rowIndex,
-        rowSpan,
-        colSpan,
-        x: cellLeft,
-        totalHeight: cellHeight,
-      });
-    }
-
-    // Advance the logical running offset by the columns this cell spans
-    x += cellWidth;
-
-    // Advance column index by colSpan
-    columnIndex += colSpan;
-
-    // Skip columns occupied by spanning cells
-    while (occupiedColumns.has(columnIndex)) {
-      x += columnWidths[columnIndex] ?? 0;
-      columnIndex++;
-    }
   }
 
   return rowEl;
@@ -1076,10 +982,13 @@ export function renderTableFragment(
   }
   rowYPositions.push(yPos); // Add final position for height calculation
 
-  // Track spanning cells across rows
-  const spanningCells = new Map<string, SpanningCell>();
   const columnsPinned = tableColumnsArePinned(block);
-  const cellGrid = buildTableCellGrid(block, measure.columnWidths.length);
+  const cellGrid = buildTableCellGrid(block.rows, measure.columnWidths.length);
+  const cellPlacements = buildTableCellPlacements({
+    grid: cellGrid,
+    columnWidths: measure.columnWidths,
+    bidi: block.bidi === true,
+  });
 
   // Render repeated header rows for continuation fragments. For a mid-content
   // row break (eigenpal #698), keep repeated headers pinned to the fragment top
@@ -1107,12 +1016,12 @@ export function renderTableFragment(
         totalRows: block.rows.length,
         context,
         doc,
-        spanningCells,
         rowYPositions,
         isFirstRowInFragment: hdrIdx === 0,
         bidi: block.bidi === true,
         columnsPinned,
         cellGrid,
+        cellPlacements,
         ...(tablePageContentPosition
           ? {
               pageContentPosition: {
@@ -1182,12 +1091,12 @@ export function renderTableFragment(
       totalRows: block.rows.length,
       context,
       doc,
-      spanningCells,
       rowYPositions,
       isFirstRowInFragment,
       bidi: block.bidi === true,
       columnsPinned,
       cellGrid,
+      cellPlacements,
       ...(contentClip ? { contentClip } : {}),
       ...(tablePageContentPosition
         ? {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -116,6 +116,14 @@ const createTextBoxGroupIdFactory = (): (() => string) => {
   return () => `${salt}:${index++}`;
 };
 
+type HyperlinkInstanceIndexAllocator = () => number;
+
+/** Keep imported hyperlink identity unique across every nested conversion scope. */
+const createHyperlinkInstanceIndexAllocator = (): HyperlinkInstanceIndexAllocator => {
+  let index = 0;
+  return () => index++;
+};
+
 /**
  * Convert a Document to a ProseMirror document
  *
@@ -134,6 +142,8 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
   const styleResolver = createStyleEngine(options?.styles ?? document.package.styles);
   const theme = options?.theme ?? document.package.theme ?? null;
   const nextTextBoxGroupId = createTextBoxGroupIdFactory();
+  const nextHyperlinkInstanceIndex = createHyperlinkInstanceIndexAllocator();
+  const conversionContext = { theme, nextTextBoxGroupId, nextHyperlinkInstanceIndex };
 
   const convertBodyBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
@@ -145,7 +155,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
         }
         const converted = convertParagraphWithTextBoxes(block, styleResolver, {
           textBoxGroupId: nextTextBoxGroupId(),
-          context: { theme, nextTextBoxGroupId },
+          context: conversionContext,
         });
         const firstConverted = converted.at(0);
         if (
@@ -178,7 +188,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
           out.push(schema.node("pageBreak"));
         }
       } else if (block.type === "table") {
-        out.push(convertTable(block, styleResolver, { theme, nextTextBoxGroupId }));
+        out.push(convertTable(block, styleResolver, conversionContext));
       } else {
         out.push(convertBlockSdt(block, convertBodyBlocks));
       }
@@ -261,6 +271,7 @@ function convertBlockSdt(
 function convertParagraph(
   paragraph: Paragraph,
   styleResolver: StyleEngine | null,
+  nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator,
   activeCommentIds?: Set<number>,
   extraRunFormatting?: TextFormatting,
   tableParagraphOverlay?: TableCellParagraphSpacingOverlay,
@@ -272,7 +283,6 @@ function convertParagraph(
   let inlineOffset = 0;
   let bookmarksArr: { id: number; name: string }[] | undefined;
   let emptyHyperlinks: NonNullable<ParagraphAttrs["_emptyHyperlinks"]> | undefined;
-  let hyperlinkIndex = 0;
 
   // Track active comment ranges for this paragraph
   const commentIds = activeCommentIds ?? new Set<number>();
@@ -364,6 +374,7 @@ function convertParagraph(
       convertTrackedChange(
         change,
         markType,
+        nextHyperlinkInstanceIndex,
         getInheritedRunFormatting,
         styleResolver,
         moveKind,
@@ -389,8 +400,7 @@ function convertParagraph(
         ),
       );
     } else if (content.type === "hyperlink") {
-      const currentHyperlinkIndex = hyperlinkIndex;
-      hyperlinkIndex += 1;
+      const currentHyperlinkIndex = nextHyperlinkInstanceIndex();
       const linkNodes = convertHyperlink(content, {
         getInheritedRunFormatting,
         styleResolver,
@@ -413,7 +423,13 @@ function convertParagraph(
       emitInlineNode(convertField(content, getInheritedRunFormatting, styleResolver));
     } else if (content.type === "inlineSdt") {
       emitInlineNode(
-        convertInlineSdt(content, getInheritedRunFormatting, styleResolver, textBoxAnchors),
+        convertInlineSdt(
+          content,
+          nextHyperlinkInstanceIndex,
+          getInheritedRunFormatting,
+          styleResolver,
+          textBoxAnchors,
+        ),
       );
     } else if (content.type === "insertion" || content.type === "moveTo") {
       emitTrackedChange(content, "insertion", content.type === "moveTo" ? "moveTo" : null);
@@ -507,13 +523,13 @@ function anchorPointComment(nodes: PMNode[], commentId: number): void {
 function convertTrackedChange(
   change: Insertion | Deletion | MoveFrom | MoveTo,
   markType: "insertion" | "deletion",
+  nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator,
   getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleEngine | null,
   moveKind: "moveFrom" | "moveTo" | null = null,
   textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode[] {
   const nodes: PMNode[] = [];
-  let hyperlinkIndex = 0;
   for (const item of change.content) {
     if (item.type === "run") {
       nodes.push(
@@ -525,8 +541,7 @@ function convertTrackedChange(
         ),
       );
     } else {
-      const currentHyperlinkIndex = hyperlinkIndex;
-      hyperlinkIndex += 1;
+      const currentHyperlinkIndex = nextHyperlinkInstanceIndex();
       nodes.push(
         ...convertHyperlink(item, {
           getInheritedRunFormatting,
@@ -1397,6 +1412,7 @@ function paragraphContentHasMeaningfulContent(content: Paragraph["content"][numb
 type TableConversionContext = {
   theme: Theme | null | undefined;
   nextTextBoxGroupId: () => string;
+  nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator;
 };
 
 function convertTable(
@@ -2041,10 +2057,11 @@ export function standaloneTableCellToProseMirror(
   nodeType: "tableCell" | "tableHeader",
 ): PMNode {
   const nextTextBoxGroupId = createTextBoxGroupIdFactory();
+  const nextHyperlinkInstanceIndex = createHyperlinkInstanceIndexAllocator();
   return convertTableCell({
     cell,
     styleResolver: null,
-    context: { theme: null, nextTextBoxGroupId },
+    context: { theme: null, nextTextBoxGroupId, nextHyperlinkInstanceIndex },
     isHeader: nodeType === "tableHeader",
     gridWidthPercent: undefined,
     conditionalStyle: undefined,
@@ -2135,13 +2152,13 @@ function convertMathEquation(math: MathEquation): PMNode | null {
  */
 function convertInlineSdt(
   sdt: InlineSdt,
+  nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator,
   getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleEngine | null,
   textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode | null {
   const props = sdt.properties;
   const inlineNodes: PMNode[] = [];
-  let hyperlinkIndex = 0;
 
   for (const content of sdt.content) {
     if (content.type === "run") {
@@ -2153,8 +2170,7 @@ function convertInlineSdt(
       );
       inlineNodes.push(...runNodes);
     } else if (content.type === "hyperlink") {
-      const currentHyperlinkIndex = hyperlinkIndex;
-      hyperlinkIndex += 1;
+      const currentHyperlinkIndex = nextHyperlinkInstanceIndex();
       const linkNodes = convertHyperlink(content, {
         getInheritedRunFormatting,
         styleResolver,
@@ -2170,6 +2186,7 @@ function convertInlineSdt(
     } else if (content.type === "inlineSdt") {
       const nestedSdt = convertInlineSdt(
         content,
+        nextHyperlinkInstanceIndex,
         getInheritedRunFormatting,
         styleResolver,
         textBoxAnchors,
@@ -2182,6 +2199,7 @@ function convertInlineSdt(
         ...convertTrackedChange(
           content,
           "insertion",
+          nextHyperlinkInstanceIndex,
           getInheritedRunFormatting,
           styleResolver,
           null,
@@ -2193,6 +2211,7 @@ function convertInlineSdt(
         ...convertTrackedChange(
           content,
           "deletion",
+          nextHyperlinkInstanceIndex,
           getInheritedRunFormatting,
           styleResolver,
           null,
@@ -2204,6 +2223,7 @@ function convertInlineSdt(
         ...convertTrackedChange(
           content,
           "insertion",
+          nextHyperlinkInstanceIndex,
           getInheritedRunFormatting,
           styleResolver,
           "moveTo",
@@ -2215,6 +2235,7 @@ function convertInlineSdt(
         ...convertTrackedChange(
           content,
           "deletion",
+          nextHyperlinkInstanceIndex,
           getInheritedRunFormatting,
           styleResolver,
           "moveFrom",
@@ -3050,6 +3071,7 @@ function convertParagraphWithTextBoxes(
   const pmParagraph = convertParagraph(
     block,
     styleResolver,
+    context.nextHyperlinkInstanceIndex,
     undefined,
     extraRunFormatting,
     tableParagraphOverlay,
@@ -3489,6 +3511,8 @@ export function headerFooterToProseDoc(
   const styleResolver = options?.styles ? createStyleEngine(options.styles) : null;
   const theme = options?.theme ?? null;
   const nextTextBoxGroupId = createTextBoxGroupIdFactory();
+  const nextHyperlinkInstanceIndex = createHyperlinkInstanceIndexAllocator();
+  const conversionContext = { theme, nextTextBoxGroupId, nextHyperlinkInstanceIndex };
 
   const convertBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
@@ -3497,11 +3521,11 @@ export function headerFooterToProseDoc(
         out.push(
           ...convertParagraphWithTextBoxes(block, styleResolver, {
             textBoxGroupId: nextTextBoxGroupId(),
-            context: { theme, nextTextBoxGroupId },
+            context: conversionContext,
           }),
         );
       } else if (block.type === "table") {
-        out.push(convertTable(block, styleResolver, { theme, nextTextBoxGroupId }));
+        out.push(convertTable(block, styleResolver, conversionContext));
       } else {
         out.push(convertBlockSdt(block, convertBlocks));
       }

--- a/packages/core/src/utils/paragraphInlineLayout.ts
+++ b/packages/core/src/utils/paragraphInlineLayout.ts
@@ -1,0 +1,46 @@
+import type { ParagraphAttrs, ParagraphBlock } from "../layout-engine/types";
+import { isRtlParagraph } from "./paragraphBaseDirection";
+
+type ParagraphAlignment = NonNullable<ParagraphAttrs["alignment"]>;
+
+export type PhysicalParagraphInlineLayout = {
+  alignment: ParagraphAlignment;
+  explicitAlignment?: ParagraphAlignment;
+  indentLeft: number;
+  indentRight: number;
+  isRtl: boolean;
+};
+
+const mirrorHorizontalAlignment = (
+  alignment: ParagraphAlignment | undefined,
+): ParagraphAlignment | undefined => {
+  if (alignment === "left") {
+    return "right";
+  }
+  if (alignment === "right") {
+    return "left";
+  }
+  return alignment;
+};
+
+/** Resolve logical OOXML paragraph sides into physical inline geometry. */
+export const resolvePhysicalParagraphInlineLayout = (
+  block: ParagraphBlock,
+): PhysicalParagraphInlineLayout => {
+  const attrs = block.attrs;
+  const isRtl = isRtlParagraph(block);
+  const mirrorsHorizontalSides = attrs?.bidi === true;
+  const explicitAlignment = mirrorsHorizontalSides
+    ? mirrorHorizontalAlignment(attrs?.alignment)
+    : attrs?.alignment;
+  const indentLeft = attrs?.indent?.left ?? 0;
+  const indentRight = attrs?.indent?.right ?? 0;
+
+  return {
+    alignment: explicitAlignment ?? (isRtl ? "right" : "left"),
+    ...(explicitAlignment === undefined ? {} : { explicitAlignment }),
+    indentLeft: mirrorsHorizontalSides ? indentRight : indentLeft,
+    indentRight: mirrorsHorizontalSides ? indentLeft : indentRight,
+    isRtl,
+  };
+};


### PR DESCRIPTION
## Summary

- resolve authored bidi alignment, indents, and table leading edges into one physical geometry contract
- preserve distinct imported hyperlink instances across nested conversion scopes
- reuse the canonical table grid for fragmented row spans, painting, hit testing, caret placement, and selection
- avoid repeated RTL scans in multiline paint paths

## Validation

- 210 focused geometry and conversion tests pass
- full typecheck, compiler-cost budgets, lint, and formatting pass
- build, distribution validation, full tests, and interaction tests pass
- Microsoft Word comparison verifies the formerly clipped continuation table at full width