### PR TITLE
fix(core): keep RTL layout geometry deterministic

### DIFF
--- a/.changeset/quiet-rtl-tabs.md
+++ b/.changeset/quiet-rtl-tabs.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep paragraph measurement caching and RTL list geometry deterministic.

--- a/packages/core/src/layout-engine/measure/cache.test.ts
+++ b/packages/core/src/layout-engine/measure/cache.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
 
 import type { ParagraphBlock } from "../types";
+import { fixedCharWidth, withFakeTextMeasure } from "./__tests__/fakeTextMeasure";
 import {
+  clearAllCaches,
   clearTextWidthCache,
   getCachedTextWidth,
   getTextCacheSize,
@@ -9,6 +11,35 @@ import {
   setCachedTextWidth,
   setTextCacheSize,
 } from "./cache";
+import { measureBlock } from "./measureBlocks";
+
+const measureParagraphBlock = (block: ParagraphBlock, width: number) => {
+  const measure = measureBlock(block, width);
+  if (measure.kind !== "paragraph") {
+    throw new Error("expected paragraph measure");
+  }
+  return measure;
+};
+
+const expectCachedMeasurementsMatchFreshInBothOrders = (
+  first: ParagraphBlock,
+  second: ParagraphBlock,
+  width: number,
+): void => {
+  clearAllCaches();
+  const freshFirst = measureParagraphBlock(first, width);
+  clearAllCaches();
+  const freshSecond = measureParagraphBlock(second, width);
+  expect(freshFirst).not.toEqual(freshSecond);
+
+  clearAllCaches();
+  expect(measureParagraphBlock(first, width)).toEqual(freshFirst);
+  expect(measureParagraphBlock(second, width)).toEqual(freshSecond);
+
+  clearAllCaches();
+  expect(measureParagraphBlock(second, width)).toEqual(freshSecond);
+  expect(measureParagraphBlock(first, width)).toEqual(freshFirst);
+};
 
 test("text width cache retains frequently reused entries when it evicts", () => {
   try {
@@ -49,4 +80,320 @@ test("paragraph cache keys include complex-script list marker formatting", () =>
   expect(hashParagraphBlock(paragraphWithMarkerSize(12))).not.toBe(
     hashParagraphBlock(paragraphWithMarkerSize(18)),
   );
+});
+
+test("paragraph cache keys include list paragraph mark font size", () => {
+  const paragraph = {
+    kind: "paragraph",
+    id: "list-paragraph-mark",
+    runs: [{ kind: "text", text: "aaaa aaaa", fontFamily: "Aptos", fontSize: 10.5 }],
+    attrs: {
+      defaultFontSize: 10.5,
+      defaultFontFamily: "Aptos",
+      listMarker: "\u2022",
+      listMarkerSuffix: "nothing",
+      listParagraphMarkFontSize: 11,
+    },
+  } as const satisfies ParagraphBlock;
+
+  expect(hashParagraphBlock(paragraph)).not.toBe(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: { ...paragraph.attrs, listParagraphMarkFontSize: 18 },
+    }),
+  );
+});
+
+test("paragraph cache keys include every tab layout input", () => {
+  const paragraph = {
+    kind: "paragraph",
+    id: "tab-layout",
+    runs: [{ kind: "text", text: "A" }, { kind: "tab" }, { kind: "text", text: "B" }],
+    attrs: {
+      bidi: true,
+      defaultTabStopTwips: 720,
+      tabs: [
+        { val: "start", pos: 1500, leader: "dot" },
+        { val: "end", pos: 3000, leader: "hyphen" },
+      ],
+    },
+  } as const satisfies ParagraphBlock;
+  const hash = hashParagraphBlock(paragraph);
+
+  expect(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: { ...paragraph.attrs, bidi: false },
+    }),
+  ).not.toBe(hash);
+  expect(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: { ...paragraph.attrs, defaultTabStopTwips: 1440 },
+    }),
+  ).not.toBe(hash);
+  expect(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: {
+        ...paragraph.attrs,
+        tabs: [
+          { val: "start", pos: 1501, leader: "dot" },
+          { val: "end", pos: 3000, leader: "hyphen" },
+        ],
+      },
+    }),
+  ).not.toBe(hash);
+  expect(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: {
+        ...paragraph.attrs,
+        tabs: [
+          { val: "center", pos: 1500, leader: "dot" },
+          { val: "end", pos: 3000, leader: "hyphen" },
+        ],
+      },
+    }),
+  ).not.toBe(hash);
+  expect(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: {
+        ...paragraph.attrs,
+        tabs: [
+          { val: "start", pos: 1500, leader: "underscore" },
+          { val: "end", pos: 3000, leader: "hyphen" },
+        ],
+      },
+    }),
+  ).not.toBe(hash);
+  expect(
+    hashParagraphBlock({
+      ...paragraph,
+      attrs: { ...paragraph.attrs, tabs: paragraph.attrs.tabs.toReversed() },
+    }),
+  ).not.toBe(hash);
+});
+
+test("paragraph cache is order-independent across distinct tab stops", () => {
+  withFakeTextMeasure(
+    () => {
+      const measureWidth = (position: number): number => {
+        const measure = measureBlock(
+          {
+            kind: "paragraph",
+            id: `tab-${position}`,
+            runs: [
+              { kind: "text", text: "A", fontSize: 11 },
+              { kind: "tab" },
+              { kind: "text", text: "B", fontSize: 11 },
+            ],
+            attrs: { tabs: [{ val: "start", pos: position }] },
+          },
+          400,
+        );
+        if (measure.kind !== "paragraph") {
+          throw new Error("expected paragraph measure");
+        }
+        return measure.lines.at(0)?.width ?? 0;
+      };
+
+      expect([measureWidth(1500), measureWidth(3000)]).toEqual([105, 205]);
+      clearAllCaches();
+      expect([measureWidth(3000), measureWidth(1500)]).toEqual([205, 105]);
+    },
+    { charWidth: fixedCharWidth(5) },
+  );
+});
+
+test("paragraph cache is order-independent across list paragraph mark sizes", () => {
+  withFakeTextMeasure(
+    () => {
+      const measureLastLineHeight = (listParagraphMarkFontSize: number): number => {
+        const measure = measureBlock(
+          {
+            kind: "paragraph",
+            id: `list-paragraph-mark-${listParagraphMarkFontSize}`,
+            runs: [{ kind: "text", text: "aaaa aaaa", fontFamily: "Aptos", fontSize: 10.5 }],
+            attrs: {
+              defaultFontSize: 10.5,
+              defaultFontFamily: "Aptos",
+              listMarker: "\u2022",
+              listMarkerSuffix: "nothing",
+              listParagraphMarkFontSize,
+            },
+          },
+          60,
+        );
+        if (measure.kind !== "paragraph") {
+          throw new Error("expected paragraph measure");
+        }
+        return measure.lines.at(-1)?.lineHeight ?? 0;
+      };
+
+      const smallThenLarge = [measureLastLineHeight(11), measureLastLineHeight(18)];
+      expect(smallThenLarge[1]).toBeGreaterThan(smallThenLarge[0] ?? 0);
+      clearAllCaches();
+      const largeThenSmall = [measureLastLineHeight(18), measureLastLineHeight(11)];
+      expect(largeThenSmall).toEqual(smallThenLarge.toReversed());
+    },
+    { charWidth: fixedCharWidth(10) },
+  );
+});
+
+test("paragraph cache preserves line spacing units", () => {
+  withFakeTextMeasure(() => {
+    const paragraph = {
+      kind: "paragraph",
+      id: "spacing-unit",
+      runs: [{ kind: "text", text: "Arabic", fontSize: 10 }],
+      attrs: { spacing: { line: 2, lineRule: "auto", lineUnit: "multiplier" } },
+    } as const satisfies ParagraphBlock;
+
+    expectCachedMeasurementsMatchFreshInBothOrders(
+      paragraph,
+      {
+        ...paragraph,
+        attrs: { spacing: { ...paragraph.attrs.spacing, lineUnit: "px" } },
+      },
+      200,
+    );
+  });
+});
+
+test("paragraph cache preserves field, math, and rendered-break runs", () => {
+  withFakeTextMeasure(() => {
+    const field = {
+      kind: "paragraph",
+      id: "field",
+      runs: [{ kind: "field", fieldType: "OTHER", fallback: "1", fontSize: 11 }],
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(
+      field,
+      { ...field, runs: [{ ...field.runs[0], fallback: "123456789" }] },
+      200,
+    );
+
+    const math = {
+      kind: "paragraph",
+      id: "math",
+      runs: [
+        {
+          kind: "math",
+          display: "inline",
+          ommlXml: "<m:oMath/>",
+          plainText: "x",
+          fontSize: 11,
+        },
+      ],
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(
+      math,
+      { ...math, runs: [{ ...math.runs[0], plainText: "x + y + z" }] },
+      200,
+    );
+
+    const textRuns = [
+      { kind: "text", text: "A", fontSize: 11 },
+      { kind: "text", text: "B", fontSize: 11 },
+    ] as const;
+    const plain = {
+      kind: "paragraph",
+      id: "plain",
+      runs: [...textRuns],
+    } as const satisfies ParagraphBlock;
+    const withRenderedBreak = {
+      ...plain,
+      runs: [textRuns[0], { kind: "renderedPageBreak" }, textRuns[1]],
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(plain, withRenderedBreak, 200);
+  });
+});
+
+test("paragraph cache preserves inferred RTL and tab typography", () => {
+  withFakeTextMeasure(() => {
+    const rtlTab = {
+      kind: "paragraph",
+      id: "rtl-tab",
+      runs: [
+        { kind: "text", text: "عنوان عربي", fontSize: 11, rtl: true },
+        { kind: "tab", fontSize: 11 },
+        { kind: "text", text: "1", fontSize: 11, rtl: true },
+      ],
+      attrs: {
+        indent: { left: 48, right: 48, hanging: 48 },
+        tabs: [{ val: "end", pos: 9000, leader: "dot" }],
+      },
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(
+      rtlTab,
+      {
+        ...rtlTab,
+        runs: [
+          { ...rtlTab.runs[0], rtl: false },
+          rtlTab.runs[1],
+          { ...rtlTab.runs[2], rtl: false },
+        ],
+      },
+      624,
+    );
+
+    const smallTab = {
+      kind: "paragraph",
+      id: "tab-typography",
+      runs: [{ kind: "tab", fontFamily: "Aptos", fontSize: 10 }],
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(
+      smallTab,
+      { ...smallTab, runs: [{ ...smallTab.runs[0], fontSize: 30 }] },
+      200,
+    );
+  });
+});
+
+test("paragraph cache preserves image measurement geometry without source payloads", () => {
+  withFakeTextMeasure(() => {
+    const inlineImage = {
+      kind: "paragraph",
+      id: "inline-image",
+      runs: [
+        {
+          kind: "image",
+          src: "data:image/png;base64,large-payload-a",
+          width: 40,
+          height: 20,
+        },
+      ],
+    } as const satisfies ParagraphBlock;
+    const rotatedImage = {
+      ...inlineImage,
+      runs: [{ ...inlineImage.runs[0], transform: "rotate(90deg)" }],
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(inlineImage, rotatedImage, 200);
+
+    const compactBlockImage = {
+      ...inlineImage,
+      runs: [
+        {
+          ...inlineImage.runs[0],
+          displayMode: "block",
+          distTop: 6,
+          distBottom: 6,
+        },
+      ],
+    } as const satisfies ParagraphBlock;
+    const spacedBlockImage = {
+      ...compactBlockImage,
+      runs: [{ ...compactBlockImage.runs[0], distTop: 20, distBottom: 20 }],
+    } as const satisfies ParagraphBlock;
+    expectCachedMeasurementsMatchFreshInBothOrders(compactBlockImage, spacedBlockImage, 200);
+
+    expect(hashParagraphBlock(inlineImage)).toBe(
+      hashParagraphBlock({
+        ...inlineImage,
+        runs: [{ ...inlineImage.runs[0], src: "data:image/png;base64,large-payload-b" }],
+      }),
+    );
+  });
 });

--- a/packages/core/src/layout-engine/measure/cache.ts
+++ b/packages/core/src/layout-engine/measure/cache.ts
@@ -5,8 +5,7 @@
  * Improves performance by avoiding repeated measurements of identical content.
  */
 
-import type { ParagraphBlock, ParagraphMeasure } from "../types";
-import { lineBreakPolicyCacheParts } from "./effectiveLineBreakPolicy";
+import type { ImageRun, ParagraphBlock, ParagraphMeasure, Run } from "../types";
 import { getLineBreakProviderGeneration } from "./lineBreakProvider";
 import { clearFontResolvedCache } from "./measureHelpers";
 
@@ -288,89 +287,88 @@ let paragraphCacheMaxSize = DEFAULT_PARAGRAPH_CACHE_SIZE;
  */
 const paragraphMeasureCache = new Map<string, ParagraphMeasureEntry>();
 
-/**
- * Generate a simple hash for a paragraph block
- * Used as cache key to identify identical content
- */
+type ImageMeasureCacheField =
+  | "kind"
+  | "width"
+  | "height"
+  | "transform"
+  | "wrapType"
+  | "displayMode"
+  | "distTop"
+  | "distBottom"
+  | "exactLineHeight"
+  | "position";
+
+type ImageIgnoredCacheField =
+  | "src"
+  | "alt"
+  | "opacity"
+  | "layoutInCell"
+  | "cssFloat"
+  | "distLeft"
+  | "distRight"
+  | "cropTop"
+  | "cropRight"
+  | "cropBottom"
+  | "cropLeft"
+  | "borderWidth"
+  | "borderColor"
+  | "borderStyle"
+  | "isInsertion"
+  | "isDeletion"
+  | "changeAuthor"
+  | "changeDate"
+  | "changeRevisionId"
+  | "pmStart"
+  | "pmEnd";
+
+type ClassifiedImageCacheField = ImageMeasureCacheField | ImageIgnoredCacheField;
+type ExhaustivelyClassifiedImageRun = [
+  Exclude<keyof ImageRun, ClassifiedImageCacheField>,
+  Exclude<ClassifiedImageCacheField, keyof ImageRun>,
+] extends [never, never]
+  ? ImageRun
+  : never;
+
+/** Keep image payloads bounded while classifying every field as measured or intentionally ignored. */
+const imageMeasureCacheInput = (run: ExhaustivelyClassifiedImageRun) => ({
+  kind: run.kind,
+  width: run.width,
+  height: run.height,
+  transform: run.transform,
+  wrapType: run.wrapType,
+  displayMode: run.displayMode,
+  distTop: run.distTop,
+  distBottom: run.distBottom,
+  exactLineHeight: run.exactLineHeight,
+  positioned: run.position !== undefined,
+});
+
+const runMeasureCacheInput = (run: Run) => {
+  switch (run.kind) {
+    case "text":
+    case "tab":
+    case "lineBreak":
+    case "renderedPageBreak":
+    case "field":
+    case "math":
+      return run;
+    case "image":
+      return imageMeasureCacheInput(run);
+    default: {
+      const exhaustive: never = run;
+      return exhaustive;
+    }
+  }
+};
+
+/** Serialize the complete paragraph measurement contract into a cache key. */
 export function hashParagraphBlock(block: ParagraphBlock): string {
-  // Simple hash based on runs content
-  const parts: string[] = [`lbp:${getLineBreakProviderGeneration()}`];
-
-  for (const run of block.runs) {
-    if (run.kind === "text") {
-      parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.eastAsiaFontFamily}|${run.complexScriptFontFamily}|${run.fontSize}|${run.complexScriptFontSize}|${run.bold}|${run.complexScriptBold}|${run.italic}|${run.complexScriptItalic}|${run.forceComplexScript}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}|${run.language?.val}|${run.language?.eastAsia}|${run.language?.bidi}`,
-      );
-    } else if (run.kind === "tab") {
-      parts.push(`tab:${run.width}`);
-    } else if (run.kind === "image") {
-      parts.push(
-        `img:${run.width}x${run.height}:${run.exactLineHeight === true ? "exact" : "text"}`,
-      );
-    } else if (run.kind === "lineBreak") {
-      parts.push("br");
-    }
-  }
-
-  // Include relevant attrs in hash
-  const attrs = block.attrs;
-  if (attrs) {
-    if (attrs.alignment) {
-      parts.push(`align:${attrs.alignment}`);
-    }
-    if (attrs.outlineLevel !== undefined) {
-      parts.push(`outline:${attrs.outlineLevel}`);
-    }
-    if (attrs.indent) {
-      parts.push(
-        `indent:${attrs.indent.left}|${attrs.indent.right}|${attrs.indent.firstLine}|${attrs.indent.hanging}`,
-      );
-    }
-    if (attrs.spacing) {
-      parts.push(
-        `spacing:${attrs.spacing.before}|${attrs.spacing.after}|${attrs.spacing.line}|${attrs.spacing.lineRule}`,
-      );
-    }
-    // Default font drives line height for empty paragraphs, which otherwise
-    // have no text runs in this cache key.
-    if (attrs.defaultFontSize != null) {
-      parts.push(`dfs:${attrs.defaultFontSize}`);
-    }
-    if (attrs.defaultFontFamily != null) {
-      parts.push(`dff:${attrs.defaultFontFamily}`);
-    }
-    if (attrs.suppressEmptyParagraphHeight) {
-      parts.push("sup");
-    }
-    if (attrs.reserveEmptyOutlineHeight) {
-      parts.push("outline-empty-reserve");
-    }
-    if (attrs.documentGridLinePitch !== undefined) {
-      parts.push(`documentGrid:${attrs.documentGridLinePitch}|${attrs.snapToGrid !== false}`);
-    }
-    if (attrs.justificationCompatibility) {
-      parts.push(`justify-compat:${attrs.justificationCompatibility.type}`);
-    }
-    if (attrs.listMarker !== undefined) {
-      const marker = attrs.listMarkerFormatting;
-      parts.push(
-        `marker:${attrs.listMarker}|${attrs.listMarkerHidden}|${attrs.listMarkerAlignment}|${attrs.listMarkerSuffix}|${marker?.fontFamily}|${marker?.eastAsiaFontFamily}|${marker?.complexScriptFontFamily}|${marker?.fontSize}|${marker?.complexScriptFontSize}|${marker?.bold}|${marker?.complexScriptBold}|${marker?.italic}|${marker?.complexScriptItalic}|${marker?.rtl}|${marker?.forceComplexScript}`,
-      );
-    }
-    parts.push(...lineBreakPolicyCacheParts(attrs));
-    const borders = attrs.borders;
-    if (borders) {
-      const signature = (border?: { width?: number; style?: string; color?: string }): string =>
-        border ? `${border.width ?? ""},${border.style ?? ""},${border.color ?? ""}` : "";
-      parts.push(
-        `bdr:${signature(borders.top)}|${signature(borders.bottom)}|${signature(
-          borders.left,
-        )}|${signature(borders.right)}`,
-      );
-    }
-  }
-
-  return parts.join("||");
+  return JSON.stringify({
+    lineBreakProviderGeneration: getLineBreakProviderGeneration(),
+    attrs: block.attrs,
+    runs: block.runs.map(runMeasureCacheInput),
+  });
 }
 
 /**

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -222,12 +222,6 @@ describe("font metrics cache", () => {
         attrs: { documentGridLinePitch: 24 },
       }),
     );
-    expect(hashParagraphBlock({ ...paragraph, attrs: { documentGridLinePitch: 24 } })).toBe(
-      hashParagraphBlock({
-        ...paragraph,
-        attrs: { documentGridLinePitch: 24, snapToGrid: true },
-      }),
-    );
     expect(hashParagraphBlock({ ...paragraph, attrs: { documentGridLinePitch: 24 } })).not.toBe(
       hashParagraphBlock({
         ...paragraph,

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -85,16 +85,20 @@ const fakeDocument = {
 
 type RenderListItemOptions = {
   indent: { left: number; hanging: number };
+  bidi?: boolean;
   marker?: string;
   markerFormatting?: NonNullable<ParagraphBlock["attrs"]>["listMarkerFormatting"];
   markerAlignment?: "left" | "center" | "right";
+  markerSecondSlotOffsetTwips?: number;
 };
 
 function renderListItem({
   indent,
+  bidi,
   marker = "1.",
   markerFormatting,
   markerAlignment,
+  markerSecondSlotOffsetTwips,
 }: RenderListItemOptions): {
   line: HTMLElement;
   marker: HTMLElement | undefined;
@@ -106,7 +110,11 @@ function renderListItem({
     attrs: {
       listMarker: marker,
       indent,
+      ...(bidi === undefined ? {} : { bidi }),
       listMarkerAlignment: markerAlignment,
+      ...(markerSecondSlotOffsetTwips === undefined
+        ? {}
+        : { listMarkerSecondSlotOffsetTwips: markerSecondSlotOffsetTwips }),
       ...(markerFormatting !== undefined ? { listMarkerFormatting: markerFormatting } : {}),
     },
   };
@@ -248,6 +256,45 @@ describe("Issue #729 — list hanging indent exceeding left indent", () => {
     const { line, marker } = renderListItem({ indent: { left: 0, hanging: 24 } });
     expect(marker?.style.marginLeft).toBe("-24px");
     expect(line.style.paddingLeft).toBe("0px");
+  });
+
+  test("explicit bidi reserves the marker slot from the physical right edge", () => {
+    const { line, marker } = renderListItem({
+      bidi: true,
+      indent: { left: 24, hanging: 24 },
+      marker: "(أ)",
+    });
+
+    expect(line.style.paddingRight).toBe("0px");
+    expect(marker?.style.textAlign).toBe("right");
+    expect(marker?.style.marginRight).toBeFalsy();
+  });
+
+  test.each([
+    ["right", 14],
+    ["center", 7],
+  ] as const)("explicit bidi mirrors %s marker alignment", (markerAlignment, offset) => {
+    const { marker } = renderListItem({
+      bidi: true,
+      indent: { left: 24, hanging: 24 },
+      marker: "1.",
+      markerAlignment,
+    });
+
+    expect(Number.parseFloat(marker?.style.transform?.slice(11) ?? "")).toBeCloseTo(offset, 1);
+  });
+
+  test("explicit bidi positions a folded marker slot from the physical right", () => {
+    const { marker } = renderListItem({
+      bidi: true,
+      indent: { left: 48, hanging: 24 },
+      marker: "7.1\t(أ)",
+      markerSecondSlotOffsetTwips: 300,
+    });
+    const secondSlot = marker?.children[1] as HTMLElement | undefined;
+
+    expect(secondSlot?.style.right).toBe("20px");
+    expect(secondSlot?.style.left).toBeFalsy();
   });
 
   test("left == 0 with hanging: continuation lines stay at the content edge", () => {

--- a/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -86,6 +86,8 @@ const fakeDocument = {
 type RenderListItemOptions = {
   indent: { left: number; hanging: number };
   bidi?: boolean;
+  text?: string;
+  rtl?: boolean;
   marker?: string;
   markerFormatting?: NonNullable<ParagraphBlock["attrs"]>["listMarkerFormatting"];
   markerAlignment?: "left" | "center" | "right";
@@ -95,6 +97,8 @@ type RenderListItemOptions = {
 function renderListItem({
   indent,
   bidi,
+  text = "TEST1",
+  rtl,
   marker = "1.",
   markerFormatting,
   markerAlignment,
@@ -106,7 +110,7 @@ function renderListItem({
   const block: ParagraphBlock = {
     kind: "paragraph",
     id: "p1",
-    runs: [{ kind: "text", text: "TEST1" }],
+    runs: [{ kind: "text", text, ...(rtl === undefined ? {} : { rtl }) }],
     attrs: {
       listMarker: marker,
       indent,
@@ -125,7 +129,7 @@ function renderListItem({
         fromRun: 0,
         fromChar: 0,
         toRun: 0,
-        toChar: 5,
+        toChar: text.length,
         width: 40,
         ascent: 10,
         descent: 3,
@@ -268,6 +272,19 @@ describe("Issue #729 — list hanging indent exceeding left indent", () => {
     expect(line.style.paddingRight).toBe("0px");
     expect(marker?.style.textAlign).toBe("right");
     expect(marker?.style.marginRight).toBeFalsy();
+  });
+
+  test("inferred RTL reserves the marker slot from the physical right edge", () => {
+    const { line, marker } = renderListItem({
+      indent: { left: 24, hanging: 24 },
+      text: "عنوان عربي",
+      rtl: true,
+      marker: "(أ)",
+    });
+
+    expect(line.style.paddingRight).toBe("0px");
+    expect(marker?.style.textAlign).toBe("right");
+    expect(marker?.style.marginRight).toBe("-24px");
   });
 
   test.each([

--- a/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -171,6 +171,15 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(line?.style["textIndent"]).toBe("-48px");
   });
 
+  test("mirrors a negative logical-start indent into the physical right margin", () => {
+    const paragraph = render([text("عنوان عربي", true)], {
+      bidi: true,
+      indent: { left: -9 },
+    }) as unknown as FakeElement;
+
+    expect(paragraph.children.at(0)?.style["marginRight"]).toBe("-9px");
+  });
+
   test("mirrors explicit bidi justification onto the physical page", () => {
     expect(render([text("13")], { alignment: "right", bidi: true }).style.textAlign).toBe("left");
     expect(render([text("13")], { alignment: "left", bidi: true }).style.textAlign).toBe("right");

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2918,10 +2918,11 @@ export function renderParagraphFragment(
     // Apply left offset from floating images (lines start after the floating image)
     // Also constrain width so text doesn't overflow into the image area
     const lineMarginLeft = Math.min(indentLeft, 0) + lineLeftOffset;
+    const lineMarginRight = Math.min(indentRight, 0) + lineRightOffset;
     if (lineMarginLeft !== 0 || lineRightOffset > 0 || indentLeft < 0 || indentRight < 0) {
       lineEl.style.marginLeft = `${lineMarginLeft}px`;
-      if (lineRightOffset > 0) {
-        lineEl.style.marginRight = `${lineRightOffset}px`;
+      if (lineMarginRight !== 0) {
+        lineEl.style.marginRight = `${lineMarginRight}px`;
       }
       // Constrain line width to prevent text from extending into floating image area
       const constrainedWidth = lineAvailableWidth - lineLeftOffset - lineRightOffset;
@@ -2970,8 +2971,8 @@ export function renderParagraphFragment(
 
     // Add list marker to first line
     // List first lines have special handling:
-    // - Marker starts at (indentLeft - hanging)
-    // - Text starts at indentLeft
+    // - Marker starts at (inline-start indent - hanging)
+    // - Text starts at the inline-start indent
     // - The marker box fills the hanging space
     if (isFirstLine && block.attrs?.listMarker && !block.attrs.listMarkerHidden) {
       // Override padding for list first lines.
@@ -2990,30 +2991,42 @@ export function renderParagraphFragment(
       //    use this shape — the body of "(i) Tranche Closing..."
       //    wraps to the page margin, only the first line's marker is
       //    indented.
-      // The marker occupies a `hanging`-wide slot starting `hanging` left of
-      // the body (at `indentLeft - hanging`); the body lands at `indentLeft`.
-      // The offset rides on padding-left (NOT text-indent: Chrome folds
+      // The marker occupies a `hanging`-wide slot before the body. The offset
+      // rides on the physical inline-start padding (NOT text-indent: Chrome folds
       // text-indent into the first inline-block's box, overriding the marker's
       // min-width and breaking tab-stop alignment).
       const hanging = indent?.hanging ?? 0;
       const firstLine = indent?.firstLine ?? 0;
-      const markerStart = hanging > 0 ? indentLeft - hanging : indentLeft + firstLine;
-      lineEl.style.paddingLeft = `${Math.max(0, markerStart)}px`;
+      const markerPhysicalStart = block.attrs.bidi === true ? "right" : "left";
+      const markerIndent = markerPhysicalStart === "right" ? indentRight : indentLeft;
+      const markerStart = hanging > 0 ? markerIndent - hanging : markerIndent + firstLine;
+      const logicalMarkerVisualOffset = getListMarkerVisualOffset(block);
+      if (markerPhysicalStart === "right") {
+        lineEl.style.paddingRight = `${Math.max(0, markerStart)}px`;
+      } else {
+        lineEl.style.paddingLeft = `${Math.max(0, markerStart)}px`;
+      }
       lineEl.style.textIndent = "0"; // Don't use textIndent for lists
 
       // Resolve marker font per ECMA-376 §17.9.6:
       // 1. Numbering level rPr (explicit marker font)
       // 2. First text run's font (paragraph content)
       // 3. Paragraph default font (from style)
-      const marker = renderListMarker(
-        block.attrs.listMarker,
-        getListMarkerInlineWidth(block),
-        getListMarkerVisualOffset(block),
+      const marker = renderListMarker({
+        marker: block.attrs.listMarker,
+        inlineWidth: getListMarkerInlineWidth(block),
+        visualOffset:
+          markerPhysicalStart === "right" ? -logicalMarkerVisualOffset : logicalMarkerVisualOffset,
         doc,
-        resolveListMarkerFont(block),
-        block.attrs.listMarkerRevision,
-        block.attrs.listMarkerSecondSlotOffsetTwips,
-      );
+        formatting: resolveListMarkerFont(block),
+        ...(block.attrs.listMarkerRevision === undefined
+          ? {}
+          : { revision: block.attrs.listMarkerRevision }),
+        ...(block.attrs.listMarkerSecondSlotOffsetTwips === undefined
+          ? {}
+          : { secondSlotOffsetTwips: block.attrs.listMarkerSecondSlotOffsetTwips }),
+        physicalStart: markerPhysicalStart,
+      });
       // When the marker sits left of the line's own start it belongs in the
       // left margin — exactly where Word puts it (a list whose direct `w:ind`
       // has `hanging` > `left`, eigenpal #730 / #729, OR a NEGATIVE `left`, e.g.
@@ -3023,10 +3036,15 @@ export function renderParagraphFragment(
       // that so the marker only takes the REMAINING negative offset: for a
       // positive left indent the line margin is 0 and this is just `markerStart`;
       // for a negative left indent it is `markerStart - indentLeft = -hanging`.
-      const markerLineMargin = Math.min(indentLeft, 0);
+      const markerLineMargin =
+        markerPhysicalStart === "right" ? Math.min(indentRight, 0) : Math.min(indentLeft, 0);
       const markerMarginLeft = markerStart - markerLineMargin;
       if (markerMarginLeft < 0) {
-        marker.style.marginLeft = `${markerMarginLeft}px`;
+        if (markerPhysicalStart === "right") {
+          marker.style.marginRight = `${markerMarginLeft}px`;
+        } else {
+          marker.style.marginLeft = `${markerMarginLeft}px`;
+        }
       }
       lineEl.prepend(marker);
     }
@@ -3046,15 +3064,27 @@ export function renderParagraphFragment(
  * tab grid. Long markers like "1.1.1." therefore grow to the next stop
  * instead of butting against the body text.
  */
-function renderListMarker(
-  marker: string,
-  inlineWidth: number,
-  visualOffset: number,
-  doc: Document,
-  formatting: ReturnType<typeof resolveListMarkerFont>,
-  revision?: ParagraphAttrs["listMarkerRevision"],
-  secondSlotOffsetTwips?: number,
-): HTMLElement {
+type RenderListMarkerOptions = {
+  marker: string;
+  inlineWidth: number;
+  visualOffset: number;
+  doc: Document;
+  formatting: ReturnType<typeof resolveListMarkerFont>;
+  revision?: ParagraphAttrs["listMarkerRevision"];
+  secondSlotOffsetTwips?: number;
+  physicalStart: "left" | "right";
+};
+
+function renderListMarker({
+  marker,
+  inlineWidth,
+  visualOffset,
+  doc,
+  formatting,
+  revision,
+  secondSlotOffsetTwips,
+  physicalStart,
+}: RenderListMarkerOptions): HTMLElement {
   const span = doc.createElement("span");
   span.className = "layout-list-marker";
   span.style.display = "inline-block";
@@ -3079,9 +3109,9 @@ function renderListMarker(
   // `text-align-last` inherits, so a justified paragraph would distribute the
   // marker's internal whitespace across its minWidth box — pushing folded
   // LISTNUM markers like "(a)" away from "7.1" to the right edge. Force the
-  // marker's own last (only) line back to left.
-  span.style.textAlign = "left";
-  span.style.textAlignLast = "left";
+  // marker's own last (only) line back to the paragraph's physical start edge.
+  span.style.textAlign = physicalStart;
+  span.style.textAlignLast = physicalStart;
   span.style.boxSizing = "border-box";
   span.style.width = `${inlineWidth}px`;
   if (visualOffset !== 0) {
@@ -3140,7 +3170,11 @@ function renderListMarker(
     // the first slot's width.
     span.style.position = "relative";
     secondSlot.style.position = "absolute";
-    secondSlot.style.left = `${secondSlotOffsetTwips / 15}px`;
+    if (physicalStart === "right") {
+      secondSlot.style.right = `${secondSlotOffsetTwips / 15}px`;
+    } else {
+      secondSlot.style.left = `${secondSlotOffsetTwips / 15}px`;
+    }
     secondSlot.style.top = "0";
     span.append(firstSlot, secondSlot);
     return span;

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2997,7 +2997,7 @@ export function renderParagraphFragment(
       // min-width and breaking tab-stop alignment).
       const hanging = indent?.hanging ?? 0;
       const firstLine = indent?.firstLine ?? 0;
-      const markerPhysicalStart = block.attrs.bidi === true ? "right" : "left";
+      const markerPhysicalStart = isRtl ? "right" : "left";
       const markerIndent = markerPhysicalStart === "right" ? indentRight : indentLeft;
       const markerStart = hanging > 0 ? markerIndent - hanging : markerIndent + firstLine;
       const logicalMarkerVisualOffset = getListMarkerVisualOffset(block);

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -12,6 +12,7 @@ const makeLine = (overrides: Partial<LineBox> & Pick<LineBox, "text">): LineBox 
   widthPt: 100,
   heightPt: 12,
   region: "body",
+  direction: "unknown",
   ...overrides,
 });
 
@@ -32,13 +33,21 @@ const makeDoc = (source: "word" | "folio", pages: PageGeom[]): DocGeom => ({
 describe("compareGeoms", () => {
   test("merges tabbed legal markers on the same visual row", () => {
     const merged = mergeVisualRows([
-      makeLine({ text: "(b)", xPt: 90, yPt: 100, widthPt: 12.8, heightPt: 12 }),
+      makeLine({
+        text: "(b)",
+        xPt: 90,
+        yPt: 100,
+        widthPt: 12.8,
+        heightPt: 12,
+        direction: "ltr",
+      }),
       makeLine({
         text: "Liquidity Event. If there is a Liquidity Event",
         xPt: 126,
         yPt: 100,
         widthPt: 250,
         heightPt: 12,
+        direction: "ltr",
       }),
     ]);
 
@@ -215,6 +224,95 @@ describe("compareGeoms", () => {
 
     expect(merged).toHaveLength(1);
     expect(merged[0]?.normText).toBe(normalizeLineText("(i) Junior to payment"));
+  });
+
+  test("merges RTL row fragments from physical right to left", () => {
+    const merged = mergeVisualRows([
+      makeLine({
+        text: "التزامات البيئة والمجتمع",
+        xPt: 190,
+        yPt: 100,
+        widthPt: 100,
+        direction: "rtl",
+      }),
+      makeLine({ text: ")د( يقصد", xPt: 300, yPt: 100, widthPt: 100, direction: "rtl" }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.text).toBe(")د( يقصد التزامات البيئة والمجتمع");
+    expect(merged[0]?.direction).toBe("rtl");
+  });
+
+  test("keeps quoted Latin text in an RTL row's right-to-left fragment order", () => {
+    const merged = mergeVisualRows([
+      makeLine({
+        text: "التزامات البيئة والمجتمع والصحة والسلامة",
+        xPt: 180,
+        yPt: 100,
+        widthPt: 110,
+        direction: "rtl",
+      }),
+      makeLine({
+        text: ")د( يقصد بـ “ESHS”",
+        xPt: 300,
+        yPt: 100,
+        widthPt: 120,
+        direction: "rtl",
+      }),
+    ]);
+
+    expect(merged[0]?.text).toBe(")د( يقصد بـ “ESHS” التزامات البيئة والمجتمع والصحة والسلامة");
+  });
+
+  test("does not merge nearby fragments with conflicting base directions", () => {
+    const merged = mergeVisualRows([
+      makeLine({ text: "بند عربي", xPt: 90, yPt: 100, widthPt: 60, direction: "rtl" }),
+      makeLine({ text: "English clause", xPt: 155, yPt: 100, widthPt: 60, direction: "ltr" }),
+    ]);
+
+    expect(merged.map((line) => line.text)).toEqual(["بند عربي", "English clause"]);
+  });
+
+  test("resolves direction per connected component beside an unrelated sibling", () => {
+    const rtlPair = mergeVisualRows([
+      makeLine({ text: "التكملة", xPt: 100, widthPt: 50, direction: "rtl" }),
+      makeLine({ text: "بداية", xPt: 155, widthPt: 50, direction: "rtl" }),
+      makeLine({ text: "English cell", xPt: 300, widthPt: 70, direction: "ltr" }),
+    ]);
+    const ltrPair = mergeVisualRows([
+      makeLine({ text: "Clause", xPt: 100, widthPt: 50, direction: "ltr" }),
+      makeLine({ text: "continued", xPt: 155, widthPt: 50, direction: "ltr" }),
+      makeLine({ text: "خلية", xPt: 300, widthPt: 70, direction: "rtl" }),
+    ]);
+
+    expect(rtlPair.map((line) => line.text)).toEqual(["بداية التكملة", "English cell"]);
+    expect(ltrPair.map((line) => line.text)).toEqual(["Clause continued", "خلية"]);
+  });
+
+  test("orders nearby RTL table-cell boxes symmetrically", () => {
+    const reference = mergeVisualRows([
+      makeLine({ text: "الخلية اليسرى", xPt: 90, widthPt: 60, direction: "rtl" }),
+      makeLine({ text: "الخلية اليمنى", xPt: 155, widthPt: 60, direction: "rtl" }),
+    ]);
+    const folio = mergeVisualRows([
+      makeLine({
+        text: "الخلية اليسرى",
+        xPt: 90,
+        widthPt: 60,
+        direction: "rtl",
+        visualGroup: "table-cell:1",
+      }),
+      makeLine({
+        text: "الخلية اليمنى",
+        xPt: 155,
+        widthPt: 60,
+        direction: "rtl",
+        visualGroup: "table-cell:0",
+      }),
+    ]);
+
+    expect(reference[0]?.text).toBe("الخلية اليمنى الخلية اليسرى");
+    expect(folio[0]?.text).toBe(reference[0]?.text);
   });
 
   test("identical docs score 1 with zero divergences and zero median offset", () => {

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -299,6 +299,18 @@ describe("attributeDivergences", () => {
     expect(attributed.attributed[0]?.features).toEqual(["rtl"]);
   });
 
+  test("preserves token boundaries when canonicalizing brackets", () => {
+    const doc: DocFeatures = {
+      paragraphs: [paragraph("foo(bar)", ["table"]), paragraph("foobar", ["rtl"])],
+      docFeatures: ["headers"],
+    };
+    const result = baseResult([{ kind: "missing-line", page: 1, text: "foobar" }]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(["rtl"]);
+  });
+
   test("rejects duplicate substring matches with different feature sets", () => {
     const doc: DocFeatures = {
       paragraphs: [

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -273,7 +273,63 @@ describe("attributeDivergences", () => {
     expect(attributed.attributed[0]?.features).toEqual(["table"]);
   });
 
-  test("falls back to best textSimilarity above the 0.6 threshold when no substring matches", () => {
+  test("canonicalizes Word Arabic glyph aliases only for paragraph attribution", () => {
+    const doc: DocFeatures = {
+      paragraphs: [
+        paragraph(
+          "يخضع هذا (المستند) لحقوق التأليف والنشر ولا يجوز استخدام هذا المستند أو إعادة إصداره لأغراض تجارية",
+          ["rtl"],
+        ),
+        paragraph("یخضع ھذا ]المستند[ لحقوق التألیف والنشر ولا یجوز استغلال ھذا المستند", [
+          "spacing-multiple",
+        ]),
+      ],
+      docFeatures: ["headers"],
+    };
+    const result = baseResult([
+      {
+        kind: "missing-line",
+        page: 1,
+        text: "یخضع ھذا ]المستند[ لحقوق التألیف والنشر ولا یجوز استخدام ھذا المستند",
+      },
+    ]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(["rtl"]);
+  });
+
+  test("rejects duplicate substring matches with different feature sets", () => {
+    const doc: DocFeatures = {
+      paragraphs: [
+        paragraph("Shared clause", ["table"]),
+        paragraph("X Shared clause", ["spacing-multiple"]),
+      ],
+      docFeatures: ["headers"],
+    };
+    const result = baseResult([{ kind: "missing-line", page: 1, text: "Shared clause" }]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(["doc:headers"]);
+  });
+
+  test("accepts duplicate substring matches when their feature sets agree", () => {
+    const doc: DocFeatures = {
+      paragraphs: [
+        paragraph("First Shared clause text", ["table", "rtl"]),
+        paragraph("Second Shared clause text", ["rtl", "table"]),
+      ],
+      docFeatures: ["headers"],
+    };
+    const result = baseResult([{ kind: "missing-line", page: 1, text: "Shared clause" }]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(["table", "rtl"]);
+  });
+
+  test("falls back to high-confidence fuzzy matching when no substring matches", () => {
     const doc: DocFeatures = {
       paragraphs: [
         paragraph("The quick brown fox jumps over", ["justify"]),
@@ -288,6 +344,41 @@ describe("attributeDivergences", () => {
     ]);
     const attributed = attributeDivergences(result, doc);
     expect(attributed.attributed[0]?.features).toEqual(["justify"]);
+  });
+
+  test("rejects fuzzy candidates with substantially different lengths", () => {
+    const doc: DocFeatures = {
+      paragraphs: [
+        paragraph("The quick brown fox jumps over and keeps running across the entire field", [
+          "spacing-multiple",
+        ]),
+      ],
+      docFeatures: ["headers"],
+    };
+    const result = baseResult([
+      { kind: "missing-line", page: 1, text: "The quick brown fox jumps ovex" },
+    ]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(["doc:headers"]);
+  });
+
+  test("rejects ambiguous fuzzy matches with different feature sets", () => {
+    const doc: DocFeatures = {
+      paragraphs: [
+        paragraph("The quick brown fox jumps over", ["justify"]),
+        paragraph("The quick brown fox jumps oven", ["spacing-multiple"]),
+      ],
+      docFeatures: ["headers"],
+    };
+    const result = baseResult([
+      { kind: "missing-line", page: 1, text: "The quick brown fox jumps ovex" },
+    ]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(["doc:headers"]);
   });
 
   test("falls back to doc:-prefixed docFeatures when nothing matches", () => {
@@ -322,7 +413,7 @@ describe("attributeDivergences", () => {
   test("short strings (< 4 chars) never match by substring, avoiding junk matches", () => {
     // "ab" is too short (< MIN_MATCH_LEN) for the substring step even though
     // it is trivially a substring of "abcdef"; the similarity fallback also
-    // fails ("ab" vs "abcdef" scores well below 0.6), so this falls through
+    // fails ("ab" vs "abcdef" has a low score and length ratio), so this falls through
     // to docFeatures.
     const doc: DocFeatures = {
       paragraphs: [paragraph("abcdef", ["table"])],
@@ -559,6 +650,7 @@ const fontGeom = (source: "word" | "folio", lines: Array<[string, string]>): Doc
         heightPt: 12,
         fontName,
         region: "body",
+        direction: "unknown",
       })),
     },
   ],

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { PX_TO_PT } from "../config";
+import { PLAYGROUND_URL, PX_TO_PT } from "../config";
 import {
   CLEAN_SCREENSHOT_CSS,
   computeZoomFactor,
@@ -29,7 +29,7 @@ const rect = (left: number, top: number, width: number, height: number) => ({
 describe("local font routes", () => {
   test("uses a private browser route without exposing the local path", () => {
     const source = localFontRouteUrl(3, "/private/fonts/Example.ttf");
-    expect(source).toBe("http://localhost:4393/__folio-parity-font/3.ttf");
+    expect(source).toBe(`${PLAYGROUND_URL}/__folio-parity-font/3.ttf`);
     expect(source).not.toContain("/private/fonts");
     expect(localFontContentType("Example.ttf")).toBe("font/ttf");
   });
@@ -418,6 +418,22 @@ describe("toPageGeom", () => {
     });
 
     expect(toPageGeom(rawPage).lines.at(0)?.logicalLineGroup).toBe("layout-line:4");
+  });
+
+  test("derives segment direction symmetrically from first-strong text", () => {
+    const rawPage = makeRawPage({
+      lines: [
+        makeRawLine({ text: "عنوان عربي", rect: rect(0, 0, 40, 10) }),
+        makeRawLine({ text: "https://example.com", rect: rect(0, 20, 40, 10) }),
+        makeRawLine({ text: "(...) 123", rect: rect(0, 40, 40, 10) }),
+      ],
+    });
+
+    expect(toPageGeom(rawPage).lines.map((line) => line.direction)).toEqual([
+      "rtl",
+      "ltr",
+      "unknown",
+    ]);
   });
 
   test("computes fontName/fontSizePt from raw px values, omitting when absent", () => {

--- a/parity/__tests__/lineEndpoints.test.ts
+++ b/parity/__tests__/lineEndpoints.test.ts
@@ -165,4 +165,5 @@ const makeLine = (
   widthPt,
   heightPt: 10,
   region,
+  direction: "unknown",
 });

--- a/parity/__tests__/pdfReference.test.ts
+++ b/parity/__tests__/pdfReference.test.ts
@@ -1,8 +1,66 @@
 import { describe, expect, test } from "bun:test";
 
-import { canReusePagePngCache } from "../pdfReference";
+import { canReusePagePngCache, refreshCachedReferenceGeom } from "../pdfReference";
+import type { DocGeom } from "../types";
 
 describe("PDF reference page cache", () => {
+  test("recomputes stale text-derived facts", () => {
+    const cached = {
+      source: "word",
+      file: "/old.docx",
+      meta: {},
+      pages: [
+        {
+          number: 1,
+          widthPt: 100,
+          heightPt: 100,
+          lines: [
+            {
+              text: "عنوان عربي",
+              normText: "stale",
+              xPt: 0,
+              yPt: 0,
+              widthPt: 10,
+              heightPt: 10,
+              region: "body",
+              direction: "ltr",
+            },
+            {
+              text: "English",
+              normText: "stale",
+              xPt: 0,
+              yPt: 10,
+              widthPt: 10,
+              heightPt: 10,
+              region: "body",
+              direction: "rtl",
+            },
+            {
+              text: "(...) 123",
+              normText: "stale",
+              xPt: 0,
+              yPt: 20,
+              widthPt: 10,
+              heightPt: 10,
+              region: "body",
+              direction: "rtl",
+            },
+          ],
+        },
+      ],
+    } as const satisfies DocGeom;
+
+    const refreshed = refreshCachedReferenceGeom(cached, "/current.docx");
+
+    expect(refreshed.file).toBe("/current.docx");
+    expect(refreshed.pages[0]?.lines.map(({ direction }) => direction)).toEqual([
+      "rtl",
+      "ltr",
+      "unknown",
+    ]);
+    expect(refreshed.pages[0]?.lines[0]?.normText).toBe("عنوان عربي");
+  });
+
   test("does not treat a bounded render as a complete unbounded cache", () => {
     expect(
       canReusePagePngCache({

--- a/parity/__tests__/report.test.ts
+++ b/parity/__tests__/report.test.ts
@@ -41,6 +41,7 @@ const makeGeom = (source: DocGeom["source"], file: string): DocGeom => ({
           widthPt: 100,
           heightPt: 12,
           region: "body",
+          direction: "ltr",
         },
       ],
     },

--- a/parity/__tests__/stextParse.test.ts
+++ b/parity/__tests__/stextParse.test.ts
@@ -186,6 +186,25 @@ describe("parseStextXml", () => {
     expect(box?.region).toBe("unknown");
   });
 
+  test("infers first-strong direction from extracted reference text", () => {
+    const xml = documentEl(
+      pageEl(
+        1,
+        "612",
+        "792",
+        [
+          lineEl({ bbox: "0 0 100 10", chars: ")د( يقصد بـ ESHS" }),
+          lineEl({ bbox: "0 20 100 30", chars: "(12) English" }),
+          lineEl({ bbox: "0 40 100 50", chars: "(...) 123" }),
+        ].join(""),
+      ),
+    );
+
+    const pages = parseStextXml(xml);
+
+    expect(pages[0]?.lines.map((line) => line.direction)).toEqual(["rtl", "ltr", "unknown"]);
+  });
+
   test("uses the median non-whitespace character origin as the line baseline", () => {
     const chars = [
       charEl("A", "0 10 10 10 0 20 10 20").replace('y="0"', 'y="18"'),

--- a/parity/__tests__/textNorm.test.ts
+++ b/parity/__tests__/textNorm.test.ts
@@ -20,6 +20,12 @@ describe("normalizeLineText", () => {
     expect(normalizeLineText("1 ........ Definitions")).toBe("1 … Definitions");
     expect(normalizeLineText("1 عنوان عربي")).toBe("1 عنوان عربي");
     expect(normalizeLineText("1 ........ Terms وشروط")).toBe("1 … Terms وشروط");
+    expect(normalizeLineText("- عنوان عربي 1")).toBe("- عنوان عربي 1");
+    expect(normalizeLineText("- Definitions 1 ........ 2")).toBe("- Definitions 1 … 2");
+    expect(normalizeLineText("- المبلغ 100 ........ 5")).toBe("- المبلغ 100 … 5");
+    expect(normalizeLineText("- رابط https://example.com 2 ........ 7")).toBe(
+      "- رابط https://example.com 2 … 7",
+    );
   });
 
   test("normalizes Symbol-font copyright extraction noise", () => {

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -11,7 +11,14 @@
 
 import { DEFAULT_TOLERANCES } from "./config";
 import { normalizeLineText, textSimilarity } from "./textNorm";
-import type { ComparisonTolerances, Divergence, DocGeom, LineBox, ParityResult } from "./types";
+import type {
+  ComparisonTolerances,
+  Divergence,
+  DocGeom,
+  LineBox,
+  ParityResult,
+  TextDirection,
+} from "./types";
 
 /** Minimum text similarity for two lines to be considered the same line
  * (rather than a gap on one or both sides). */
@@ -146,7 +153,7 @@ const MARKER_ROW_MERGE_GAP_PT = 36;
  * ignored here because reference geometry has no equivalent metadata; using it
  * would normalize the two extractors differently. Logical line identity is
  * used only to recombine segments that came from the same painted line. The
- * result is ordered row-by-row, left-to-right within a row: reference ink boxes on one
+ * result is ordered row-by-row, in base inline direction within a row: reference ink boxes on one
  * visual row can differ by fractions of a pt vertically (e.g. table cells), so
  * a raw (y, x) sort would order the same row differently on the two sides and
  * derail the sequence alignment. Applied to BOTH sides so the pass itself
@@ -165,23 +172,49 @@ export const mergeVisualRows = (lines: LineBox[]): LineBox[] => {
   const merged: LineBox[] = [];
   for (const row of rows) {
     row.sort((a, b) => a.xPt - b.xPt);
-    let current = row[0];
-    if (!current) continue;
-    for (const next of row.slice(1)) {
-      if (shouldMergeRowBoxes(current, next)) {
-        current = mergeBoxes(current, next);
-        continue;
+    const components: LineBox[][] = [];
+    for (const line of row) {
+      const component = components.at(-1);
+      const current = component?.at(-1);
+      if (component && current && shouldMergeRowBoxes(current, line)) {
+        component.push(line);
+      } else {
+        components.push([line]);
       }
-      merged.push(current);
-      current = next;
     }
-    merged.push(current);
+    const mergedComponents = components.flatMap(mergeConnectedComponent);
+    if (resolveDirection(mergedComponents) === "rtl") {
+      mergedComponents.reverse();
+    }
+    merged.push(...mergedComponents);
   }
   return merged;
 };
 
+const mergeConnectedComponent = (component: LineBox[]): LineBox[] => {
+  const direction = resolveDirection(component);
+  component.sort((a, b) => (direction === "rtl" ? b.xPt - a.xPt : a.xPt - b.xPt));
+  const first = component[0];
+  if (!first) return [];
+  const merged: LineBox[] = [];
+  let current = first;
+  for (const next of component.slice(1)) {
+    if (shouldMergeRowBoxes(current, next)) {
+      const combined = mergeBoxes(current, next);
+      if (combined) {
+        current = combined;
+        continue;
+      }
+    }
+    merged.push(current);
+    current = next;
+  }
+  merged.push(current);
+  return merged;
+};
+
 const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
-  if (current.region !== next.region) {
+  if (current.region !== next.region || resolveDirection([current, next]) === null) {
     return false;
   }
   if (
@@ -221,18 +254,33 @@ const mergeBaselines = (a: number | undefined, b: number | undefined): number | 
   return (a + b) / 2;
 };
 
-const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
-  const [left, right] = a.xPt <= b.xPt ? [a, b] : [b, a];
+/** Resolve one base direction when every known fact agrees. Unknown facts do
+ * not override a known direction; conflicting known facts reject the merge. */
+const resolveDirection = (lines: LineBox[]): TextDirection | null => {
+  let resolved: TextDirection = "unknown";
+  for (const line of lines) {
+    if (line.direction === "unknown") continue;
+    if (resolved !== "unknown" && resolved !== line.direction) return null;
+    resolved = line.direction;
+  }
+  return resolved;
+};
+
+/** Merge boxes already supplied in logical reading order. Geometry remains a
+ * physical union; callers choose left-to-right or right-to-left traversal. */
+const mergeBoxes = (a: LineBox, b: LineBox): LineBox | null => {
+  const direction = resolveDirection([a, b]);
+  if (direction === null) return null;
   const xPt = Math.min(a.xPt, b.xPt);
   const yPt = Math.min(a.yPt, b.yPt);
-  const text = `${left.text} ${right.text}`;
-  // Prefer the left box's font, but fall back to the right box's so font
-  // metadata is not discarded when only the right side carries it.
-  const fontName = left.fontName ?? right.fontName;
-  const fontSizePt = left.fontSizePt ?? right.fontSizePt;
+  const text = `${a.text} ${b.text}`;
+  // Prefer the first logical box's font, but retain metadata when only the
+  // following box carries it.
+  const fontName = a.fontName ?? b.fontName;
+  const fontSizePt = a.fontSizePt ?? b.fontSizePt;
   const logicalLineGroup =
-    left.logicalLineGroup !== undefined && left.logicalLineGroup === right.logicalLineGroup
-      ? left.logicalLineGroup
+    a.logicalLineGroup !== undefined && a.logicalLineGroup === b.logicalLineGroup
+      ? a.logicalLineGroup
       : undefined;
   const baselinePt = mergeBaselines(a.baselinePt, b.baselinePt);
   return {
@@ -243,7 +291,8 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox => {
     widthPt: Math.max(a.xPt + a.widthPt, b.xPt + b.widthPt) - xPt,
     heightPt: Math.max(a.yPt + a.heightPt, b.yPt + b.heightPt) - yPt,
     ...(baselinePt !== undefined ? { baselinePt } : {}),
-    region: left.region,
+    region: a.region,
+    direction,
     ...(fontName !== undefined ? { fontName } : {}),
     ...(fontSizePt !== undefined ? { fontSizePt } : {}),
     ...(logicalLineGroup !== undefined ? { logicalLineGroup } : {}),
@@ -1120,15 +1169,21 @@ const groupGapLinesByVisualRow = (idxs: number[], flat: FlatLine[]): number[][] 
 const mergeFlatLines = (idxs: number[], flat: FlatLine[]): FlatLine | null => {
   const members = idxs
     .map((idx) => flat[idx])
-    .filter((member): member is FlatLine => member !== undefined)
-    .sort((left, right) => left.line.xPt - right.line.xPt);
+    .filter((member): member is FlatLine => member !== undefined);
+  const direction = resolveDirection(members.map((member) => member.line));
+  if (direction === null) return null;
+  members.sort((left, right) =>
+    direction === "rtl" ? right.line.xPt - left.line.xPt : left.line.xPt - right.line.xPt,
+  );
   const first = members[0];
   if (!first || members.length !== idxs.length) return null;
   let mergedLine = first.line;
   for (let index = 1; index < members.length; index++) {
     const member = members[index];
     if (!member) return null;
-    mergedLine = mergeBoxes(mergedLine, member.line);
+    const combined = mergeBoxes(mergedLine, member.line);
+    if (!combined) return null;
+    mergedLine = combined;
   }
   return {
     page: first.page,

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -606,33 +606,83 @@ const divergenceSearchText = (divergence: Divergence): string | undefined => {
 };
 
 const MIN_MATCH_LEN = 4;
-const SIMILARITY_THRESHOLD = 0.6;
+const SIMILARITY_THRESHOLD = 0.9;
+const MIN_LENGTH_RATIO = 0.8;
+const MIN_SIMILARITY_MARGIN = 0.05;
 
-/** First tries a (bidirectional, case-sensitive) substring match, requiring
- * the shorter string to carry at least `MIN_MATCH_LEN` chars so short/empty
- * strings cannot match spuriously; falls back to best-`textSimilarity`. */
+/** Canonicalization used only to identify a divergence's source paragraph.
+ * It must not hide text differences from the comparator. */
+const normalizeAttributionText = (text: string): string =>
+  normalizeLineText(text)
+    .normalize("NFKC")
+    .replace(/\u06cc/gu, "\u064a")
+    .replace(/\u06be/gu, "\u0647")
+    .replace(/[()[\]]/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+const featureSetKey = ({ features }: ParagraphFeatures): string =>
+  JSON.stringify([...new Set(features)].toSorted());
+
+type ParagraphCandidate = {
+  paragraph: ParagraphFeatures;
+  normText: string;
+  featureKey: string;
+};
+
+const buildParagraphCandidates = (paragraphs: ParagraphFeatures[]): ParagraphCandidate[] =>
+  paragraphs.flatMap((paragraph) => {
+    const normText = normalizeAttributionText(paragraph.normText);
+    return normText.length === 0
+      ? []
+      : [{ paragraph, normText, featureKey: featureSetKey(paragraph) }];
+  });
+
+const shareFeatureSet = (candidates: ParagraphCandidate[]): boolean => {
+  const first = candidates[0];
+  return (
+    first !== undefined && candidates.every(({ featureKey }) => featureKey === first.featureKey)
+  );
+};
+
+/** Prefer unambiguous substring matches. Fuzzy attribution is limited to
+ * similarly sized, high-confidence candidates with a clear winner. */
 const findMatchingParagraph = (
   searchText: string,
-  paragraphs: ParagraphFeatures[],
+  candidates: ParagraphCandidate[],
 ): ParagraphFeatures | undefined => {
-  for (const paragraph of paragraphs) {
-    if (paragraph.normText.length === 0) continue;
-    const shorterLen = Math.min(paragraph.normText.length, searchText.length);
-    if (shorterLen < MIN_MATCH_LEN) continue;
-    if (paragraph.normText.includes(searchText) || searchText.includes(paragraph.normText)) {
-      return paragraph;
-    }
+  const normalizedSearchText = normalizeAttributionText(searchText);
+
+  const substringMatches = candidates.filter(({ normText }) => {
+    const shorterLen = Math.min(normText.length, normalizedSearchText.length);
+    if (shorterLen < MIN_MATCH_LEN) return false;
+    return normText.includes(normalizedSearchText) || normalizedSearchText.includes(normText);
+  });
+  if (substringMatches.length > 0) {
+    if (substringMatches.length === 1) return substringMatches[0]?.paragraph;
+    return shareFeatureSet(substringMatches) ? substringMatches[0]?.paragraph : undefined;
   }
 
-  let best: { paragraph: ParagraphFeatures; score: number } | undefined;
-  for (const paragraph of paragraphs) {
-    if (paragraph.normText.length === 0) continue;
-    const score = textSimilarity(paragraph.normText, searchText);
-    if (score >= SIMILARITY_THRESHOLD && (!best || score > best.score)) {
-      best = { paragraph, score };
-    }
+  const fuzzyMatches = candidates
+    .flatMap((candidate) => {
+      const { normText } = candidate;
+      const maxLength = Math.max(normText.length, normalizedSearchText.length);
+      const lengthRatio = Math.min(normText.length, normalizedSearchText.length) / maxLength;
+      if (lengthRatio < MIN_LENGTH_RATIO) return [];
+      const score = textSimilarity(normText, normalizedSearchText);
+      return score >= SIMILARITY_THRESHOLD ? [{ candidate, score }] : [];
+    })
+    .toSorted((a, b) => b.score - a.score);
+  const best = fuzzyMatches[0];
+  if (!best) return undefined;
+
+  const competingMatches = fuzzyMatches.filter(
+    ({ score }) => best.score - score < MIN_SIMILARITY_MARGIN,
+  );
+  if (shareFeatureSet(competingMatches.map(({ candidate }) => candidate))) {
+    return best.candidate.paragraph;
   }
-  return best?.paragraph;
+  return undefined;
 };
 
 export const attributeDivergences = (
@@ -641,11 +691,12 @@ export const attributeDivergences = (
 ): FeatureAttributedResult => {
   const docPrefixed =
     doc.docFeatures.length > 0 ? doc.docFeatures.map((f) => `doc:${f}`) : ["doc:unattributed"];
+  const candidates = buildParagraphCandidates(doc.paragraphs);
 
   const attributed: AttributedDivergence[] = result.divergences.map((divergence) => {
     const searchText = divergenceSearchText(divergence);
     if (searchText === undefined) return { divergence, features: docPrefixed };
-    const matched = findMatchingParagraph(searchText, doc.paragraphs);
+    const matched = findMatchingParagraph(searchText, candidates);
     return { divergence, features: matched ? matched.features : docPrefixed };
   });
 

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -617,7 +617,7 @@ const normalizeAttributionText = (text: string): string =>
     .normalize("NFKC")
     .replace(/\u06cc/gu, "\u064a")
     .replace(/\u06be/gu, "\u0647")
-    .replace(/[()[\]]/gu, "")
+    .replace(/[()[\]]/gu, " ")
     .replace(/\s+/gu, " ")
     .trim();
 
@@ -639,7 +639,7 @@ const buildParagraphCandidates = (paragraphs: ParagraphFeatures[]): ParagraphCan
   });
 
 const shareFeatureSet = (candidates: ParagraphCandidate[]): boolean => {
-  const first = candidates[0];
+  const first = candidates.at(0);
   return (
     first !== undefined && candidates.every(({ featureKey }) => featureKey === first.featureKey)
   );
@@ -673,7 +673,7 @@ const findMatchingParagraph = (
       return score >= SIMILARITY_THRESHOLD ? [{ candidate, score }] : [];
     })
     .toSorted((a, b) => b.score - a.score);
-  const best = fuzzyMatches[0];
+  const best = fuzzyMatches.at(0);
   if (!best) return undefined;
 
   const competingMatches = fuzzyMatches.filter(

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -30,6 +30,7 @@ import {
   TMP_FIXTURE_PREFIX,
 } from "./config";
 import { normalizeLineText } from "./textNorm";
+import { firstStrongTextDirection } from "./textDirection";
 import type { DocGeom, LineBox, PageGeom, Region } from "./types";
 
 export class FolioExtractError extends Error {
@@ -476,6 +477,7 @@ export const toPageGeom = (rawPage: RawPage): PageGeom => {
         : {}),
       ...(fontName !== undefined ? { fontName } : {}),
       ...(fontSizePt !== undefined ? { fontSizePt } : {}),
+      direction: firstStrongTextDirection(rawLine.text),
     });
   }
 

--- a/parity/lineEndpoints.ts
+++ b/parity/lineEndpoints.ts
@@ -165,6 +165,7 @@ const endpointToLineBox = ({ text, region }: LineEndpoint, index: number): LineB
     widthPt: normText.length,
     heightPt: 10,
     region,
+    direction: "unknown",
   };
 };
 

--- a/parity/pdfReference.ts
+++ b/parity/pdfReference.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { CACHE_DIR } from "./config";
 import { parseStextXml } from "./stextParse";
 import { normalizeLineText } from "./textNorm";
+import { firstStrongTextDirection } from "./textDirection";
 import type { DocGeom, PageGeom } from "./types";
 
 const PNG_DPI = 96;
@@ -40,6 +41,23 @@ type ReadCachedGeomOptions = {
   absDocxPath: string;
 };
 
+/** Refresh facts derived from cached text so detector and normalization changes
+ * never inherit stale cache metadata. */
+export const refreshCachedReferenceGeom = (geom: DocGeom, absDocxPath: string): DocGeom =>
+  Object.assign({}, geom, {
+    file: absDocxPath,
+    pages: geom.pages.map((page) =>
+      Object.assign({}, page, {
+        lines: page.lines.map((line) =>
+          Object.assign({}, line, {
+            normText: normalizeLineText(line.text),
+            direction: firstStrongTextDirection(line.text),
+          }),
+        ),
+      }),
+    ),
+  });
+
 export const readCachedGeom = async ({
   geomPath,
   absDocxPath,
@@ -47,16 +65,7 @@ export const readCachedGeom = async ({
   const file = Bun.file(geomPath);
   if (!(await file.exists())) return null;
   const geom = (await file.json()) as DocGeom;
-  return Object.assign({}, geom, {
-    file: absDocxPath,
-    pages: geom.pages.map((page) =>
-      Object.assign({}, page, {
-        lines: page.lines.map((line) =>
-          Object.assign({}, line, { normText: normalizeLineText(line.text) }),
-        ),
-      }),
-    ),
-  });
+  return refreshCachedReferenceGeom(geom, absDocxPath);
 };
 
 type ExtractPdfGeometryOptions = {

--- a/parity/stextParse.ts
+++ b/parity/stextParse.ts
@@ -16,6 +16,7 @@
  */
 
 import { normalizeLineText } from "./textNorm";
+import { firstStrongTextDirection } from "./textDirection";
 import type { LineBox, PageGeom } from "./types";
 
 const PAGE_RE = /<page\b([^>]*)>([\s\S]*?)<\/page>/g;
@@ -199,6 +200,7 @@ const parseLines = (pageContent: string): LineBox[] => {
       ...(font.name !== undefined ? { fontName: font.name } : {}),
       ...(font.sizePt !== undefined ? { fontSizePt: font.sizePt } : {}),
       region: "unknown",
+      direction: firstStrongTextDirection(text),
     });
   }
   lines.sort((a, b) => a.yPt - b.yPt || a.xPt - b.xPt);

--- a/parity/textDirection.ts
+++ b/parity/textDirection.ts
@@ -1,0 +1,7 @@
+import { detectBaseDirection } from "../packages/core/src/utils/baseDirection";
+
+import type { TextDirection } from "./types";
+
+/** Preserve an undecided state around the renderer's canonical first-strong detector. */
+export const firstStrongTextDirection = (text: string): TextDirection =>
+  detectBaseDirection(text) ?? "unknown";

--- a/parity/types.ts
+++ b/parity/types.ts
@@ -19,6 +19,11 @@ export type ReferenceRendererInfo = {
 
 export type Region = "body" | "header" | "footer" | "footnote" | "unknown";
 
+/** Base inline direction established by an extractor. `unknown` is reserved
+ * for content without a strong directional character or an unavailable
+ * renderer fact. */
+export type TextDirection = "ltr" | "rtl" | "unknown";
+
 export type LineBox = {
   /** Raw extracted text of the visual line. */
   text: string;
@@ -39,6 +44,7 @@ export type LineBox = {
   fontName?: string;
   fontSizePt?: number;
   region: Region;
+  direction: TextDirection;
   /** DOM visual container, used to keep adjacent table cells distinct. */
   visualGroup?: string;
   /** Page-local identity shared by segments extracted from one logical line. */


### PR DESCRIPTION
## Summary

- key paragraph measurement caching from the complete typed measurement contract
- mirror RTL list-marker slots, offsets, and negative inline-start indentation
- make parity extraction, bidi row merging, and feature attribution symmetric and ambiguity-safe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-to-left paragraph layout, including indents, list markers, alignment and folded marker placement.
  * Corrected line direction detection for Arabic, English and neutral text.
  * Improved mixed-direction geometry ordering and prevented invalid merges.
  * Refined text matching and normalisation for Arabic glyphs, punctuation, URLs and duplicate content.
  * Improved refresh behaviour for cached document reference geometry.

* **Performance**
  * Enhanced paragraph measurement caching for more accurate cache reuse and invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->