### PR TITLE
fix: allow edits around preserved shapes

### DIFF
--- a/.changeset/quiet-shapes-edit.md
+++ b/.changeset/quiet-shapes-edit.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/docx-core": patch
+---
+
+Allow text editing when unsupported drawings are preserved as inert raw OOXML.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -151,6 +151,7 @@ export type ImageAttrs = {
     hlinkHref?: string;
     hlinkRId?: string;
     _docxRawXml?: string;
+    _docxRawXmlMode?: import__stll_docx_core_model.DrawingRawXmlMode;
     _docxObjectPreview?: boolean;
 };
 

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -231,6 +231,7 @@ export type ImageAttrs = {
     hlinkHref?: string;
     hlinkRId?: string;
     _docxRawXml?: string;
+    _docxRawXmlMode?: import__stll_docx_core_model.DrawingRawXmlMode;
     _docxObjectPreview?: boolean;
 };
 

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -241,11 +241,20 @@ export type DocxPackage = {
 };
 
 // @public
+export const DRAWING_RAW_XML_MODES: {
+    readonly PRESERVE_ONLY: "preserveOnly";
+};
+
+// @public
 export type DrawingContent = {
     type: "drawing";
     image: Image_2;
     rawXml?: string;
+    rawXmlMode?: DrawingRawXmlMode;
 };
+
+// @public
+export type DrawingRawXmlMode = (typeof DRAWING_RAW_XML_MODES)[keyof typeof DRAWING_RAW_XML_MODES];
 
 // @public
 export type EmphasisMark = "none" | "dot" | "comma" | "circle" | "underDot";

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -250,7 +250,12 @@ export type DrawingContent = {
     type: "drawing";
     image: Image_2;
     rawXml?: string;
-    rawXmlMode?: DrawingRawXmlMode;
+    rawXmlMode?: never;
+} | {
+    type: "drawing";
+    image: Image_2;
+    rawXml: string;
+    rawXmlMode: typeof DRAWING_RAW_XML_MODES.PRESERVE_ONLY;
 };
 
 // @public

--- a/packages/core/src/docx/compatibility.test.ts
+++ b/packages/core/src/docx/compatibility.test.ts
@@ -1,10 +1,98 @@
 import { describe, expect, test } from "bun:test";
 import { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
+import JSZip from "jszip";
+import { EditorState } from "prosemirror-state";
 
-import type { Document } from "../types/document";
+import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import type { Document, DrawingContent } from "../types/document";
 import { inspectDocxCompatibility } from "./compatibility";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx } from "./rezip";
 
-const createDocument = (rawXml?: string, paraId?: string): Document => ({
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const createAdjustedShapeDocx = async (): Promise<ArrayBuffer> => {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:v="urn:schemas-microsoft-com:vml">
+  <w:body>
+    <w:p><w:r><mc:AlternateContent>
+      <mc:Choice Requires="wps"><w:drawing><wp:anchor behindDoc="0" layoutInCell="1" allowOverlap="1">
+        <wp:simplePos x="0" y="0"/>
+        <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+        <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+        <wp:extent cx="914400" cy="457200"/><wp:wrapNone/>
+        <wp:docPr id="1" name="Adjusted shape"/>
+        <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+          <wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>
+            <a:prstGeom prst="bracePair"><a:avLst><a:gd name="adj" fmla="val 25000"/></a:avLst></a:prstGeom>
+            <a:noFill/><a:ln><a:solidFill><a:srgbClr val="666666"/></a:solidFill></a:ln>
+          </wps:spPr></wps:wsp>
+        </a:graphicData></a:graphic>
+      </wp:anchor></w:drawing></mc:Choice>
+      <mc:Fallback><w:pict><v:shape id="fallback-shape"/></w:pict></mc:Fallback>
+    </mc:AlternateContent></w:r></w:p>
+    <w:p><w:r><w:t>Editable text</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`,
+  );
+  zip.file(
+    "word/styles.xml",
+    `${XML_DECLARATION}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const firstRawDrawing = (document: Document): DrawingContent | undefined => {
+  const paragraph = document.package.document.content.at(0);
+  if (paragraph?.type !== "paragraph") {
+    return undefined;
+  }
+
+  return paragraph.content
+    .filter((item) => item.type === "run")
+    .flatMap((run) => run.content)
+    .find(
+      (content): content is DrawingContent =>
+        content.type === "drawing" && content.rawXml !== undefined,
+    );
+};
+
+type CreateDocumentOptions = {
+  imageSrc?: string;
+  paraId?: string;
+  rawXml?: string;
+};
+
+const createDocument = ({ imageSrc, paraId, rawXml }: CreateDocumentOptions = {}): Document => ({
   package: {
     document: {
       content: [
@@ -21,6 +109,7 @@ const createDocument = (rawXml?: string, paraId?: string): Document => ({
                   image: {
                     type: "image",
                     rId: "rId1",
+                    ...(imageSrc === undefined ? {} : { src: imageSrc }),
                     size: { width: 9525, height: 9525 },
                     wrap: { type: "inline" },
                   },
@@ -47,8 +136,16 @@ describe("DOCX compatibility inspection", () => {
     });
   });
 
-  test("reports opaque drawing XML at its document location", () => {
-    expect(inspectDocxCompatibility(createDocument("<w:drawing/>", "A1B2C3D4"))).toEqual({
+  test("reports a renderable raw drawing at its document location", () => {
+    expect(
+      inspectDocxCompatibility(
+        createDocument({
+          imageSrc: "data:image/png;base64,AA==",
+          paraId: "A1B2C3D4",
+          rawXml: "<w:drawing/>",
+        }),
+      ),
+    ).toEqual({
       schemaVersion: 1,
       context: { host: "unknown", profile: "unknown" },
       canSafelyEdit: false,
@@ -67,8 +164,63 @@ describe("DOCX compatibility inspection", () => {
     });
   });
 
+  test("reports unresolved raw media without a preservation-only classification", () => {
+    expect(
+      inspectDocxCompatibility(
+        createDocument({
+          paraId: "A1B2C3D4",
+          rawXml: '<w:drawing><a:blip r:embed="rId1"/></w:drawing>',
+        }),
+      ).canSafelyEdit,
+    ).toBe(false);
+  });
+
+  test("allows text edits while preserving an unmodeled drawing verbatim", async () => {
+    const source = await createAdjustedShapeDocx();
+    const parsed = await parseDocx(source, { detectVariables: false, preloadFonts: false });
+    const originalDrawing = firstRawDrawing(parsed);
+
+    expect(originalDrawing?.rawXml).toContain("<mc:AlternateContent");
+    expect(originalDrawing?.rawXmlMode).toBe("preserveOnly");
+    expect(originalDrawing?.image.src).toBeUndefined();
+    expect(inspectDocxCompatibility(parsed).canSafelyEdit).toBe(true);
+
+    const pmDocument = toProseDoc(parsed);
+    let editableTextPosition: number | undefined;
+    pmDocument.descendants((node, position) => {
+      if (node.isText && node.text === "Editable text") {
+        editableTextPosition = position;
+      }
+    });
+    if (editableTextPosition === undefined) {
+      throw new Error("Expected editable fixture text");
+    }
+
+    const state = EditorState.create({ doc: pmDocument });
+    const editedPmDocument = state.apply(
+      state.tr.insertText(
+        "Updated text",
+        editableTextPosition,
+        editableTextPosition + "Editable text".length,
+      ),
+    ).doc;
+    const saved = await repackDocx(fromProseDoc(editedPmDocument, parsed), {
+      updateModifiedDate: false,
+    });
+    const reopened = await parseDocx(saved, { detectVariables: false, preloadFonts: false });
+    const reopenedDrawing = firstRawDrawing(reopened);
+
+    expect(toProseDoc(reopened).textContent).toContain("Updated text");
+    expect(reopenedDrawing?.rawXml).toBe(originalDrawing?.rawXml);
+    expect(inspectDocxCompatibility(reopened).canSafelyEdit).toBe(true);
+  });
+
   test("reports the requested profile, host, and non-body part", () => {
-    const document = createDocument("<w:drawing/>", "A1B2C3D4");
+    const document = createDocument({
+      imageSrc: "data:image/png;base64,AA==",
+      paraId: "A1B2C3D4",
+      rawXml: "<w:drawing/>",
+    });
     const content = document.package.document.content;
     document.package.document.content = [];
     document.package.headers = new Map([
@@ -96,7 +248,10 @@ describe("DOCX compatibility inspection", () => {
   });
 
   test("uses parsed package metadata unless the caller overrides it", () => {
-    const document = createDocument("<w:drawing/>");
+    const document = createDocument({
+      imageSrc: "data:image/png;base64,AA==",
+      rawXml: "<w:drawing/>",
+    });
     document.package.conformanceClass = DOCX_CONFORMANCE_CLASSES.STRICT;
 
     expect(inspectDocxCompatibility(document).context.profile).toBe(

--- a/packages/core/src/docx/compatibility.ts
+++ b/packages/core/src/docx/compatibility.ts
@@ -1,4 +1,4 @@
-import { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
+import { DOCX_CONFORMANCE_CLASSES, DRAWING_RAW_XML_MODES } from "@stll/docx-core/model";
 
 import {
   type BlockContent,
@@ -249,7 +249,14 @@ function inspectHyperlink(
 
 function inspectRun(run: Run, context: InspectionLocationContext & { record: RecordIssue }): void {
   for (const [contentIndex, content] of run.content.entries()) {
-    if (content.type === "drawing" && content.rawXml) {
+    // Preservation-only placeholders carry no editable projection. All other
+    // raw drawings stay blocked because their projected image attributes can
+    // diverge from the authoritative XML replayed during serialization.
+    if (
+      content.type === "drawing" &&
+      content.rawXml &&
+      content.rawXmlMode !== DRAWING_RAW_XML_MODES.PRESERVE_ONLY
+    ) {
       context.record({
         ...(context.blockId === undefined ? {} : { blockId: context.blockId }),
         part: context.part,

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -41,7 +41,7 @@ import type {
   MediaFile,
   ShapeContent,
 } from "../types/document";
-import { normalizeRevisionId } from "@stll/docx-core/model";
+import { DRAWING_RAW_XML_MODES, normalizeRevisionId } from "@stll/docx-core/model";
 import { parseGroupDrawing } from "./groupDrawingParser";
 import { parseImage } from "./imageParser";
 import {
@@ -899,6 +899,7 @@ function parseDrawingContent(
         wrap: { type: "inline" },
       },
       rawXml: elementToXml(element),
+      rawXmlMode: DRAWING_RAW_XML_MODES.PRESERVE_ONLY,
     };
   }
 

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -318,6 +318,24 @@ describe("ProseMirror attr readers", () => {
     );
   });
 
+  test("rejects preservation-only image attrs without replayable XML", () => {
+    const node = schema.nodes.image.create({
+      src: "",
+      _docxRawXmlMode: "preserveOnly",
+    });
+
+    const result = readImageAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected preservation-only image attrs to be rejected");
+    }
+    expect(result.issues).toContainEqual({
+      path: "image.attrs._docxRawXml",
+      message: "Preservation-only drawings require raw XML.",
+    });
+  });
+
   test("clears image attrs with explicit undefined patches", () => {
     const node = schema.nodes.image.create({
       src: "media/image.png",

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -319,21 +319,24 @@ describe("ProseMirror attr readers", () => {
   });
 
   test("rejects preservation-only image attrs without replayable XML", () => {
-    const node = schema.nodes.image.create({
-      src: "",
-      _docxRawXmlMode: "preserveOnly",
-    });
+    for (const rawXml of [undefined, "", "   "]) {
+      const node = schema.nodes.image.create({
+        src: "",
+        _docxRawXml: rawXml,
+        _docxRawXmlMode: "preserveOnly",
+      });
 
-    const result = readImageAttrs(node);
+      const result = readImageAttrs(node);
 
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("Expected preservation-only image attrs to be rejected");
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("Expected preservation-only image attrs to be rejected");
+      }
+      expect(result.issues).toContainEqual({
+        path: "image.attrs._docxRawXml",
+        message: "Preservation-only drawings require raw XML.",
+      });
     }
-    expect(result.issues).toContainEqual({
-      path: "image.attrs._docxRawXml",
-      message: "Preservation-only drawings require raw XML.",
-    });
   });
 
   test("clears image attrs with explicit undefined patches", () => {

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -35,7 +35,7 @@ import {
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
 import type { ParagraphFormatting } from "../../types/document";
-import { isOoxmlSymbolCharacter } from "@stll/docx-core/model";
+import { DRAWING_RAW_XML_MODES, isOoxmlSymbolCharacter } from "@stll/docx-core/model";
 import { isParagraphDirection } from "../paragraphDirection";
 import type {
   BlockSdtAttrs,
@@ -620,6 +620,13 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
   optionalString(attrs, "hlinkHref", "image.attrs.hlinkHref", issues);
   optionalString(attrs, "hlinkRId", "image.attrs.hlinkRId", issues);
   optionalString(attrs, "_docxRawXml", "image.attrs._docxRawXml", issues);
+  optionalOneOf(
+    attrs,
+    "_docxRawXmlMode",
+    "image.attrs._docxRawXmlMode",
+    issues,
+    Object.values(DRAWING_RAW_XML_MODES),
+  );
   optionalBoolean(attrs, "_docxObjectPreview", "image.attrs._docxObjectPreview", issues);
 
   return attrsResult(attrs, issues);

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -627,6 +627,15 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
     issues,
     Object.values(DRAWING_RAW_XML_MODES),
   );
+  if (
+    attrs["_docxRawXmlMode"] === DRAWING_RAW_XML_MODES.PRESERVE_ONLY &&
+    typeof attrs["_docxRawXml"] !== "string"
+  ) {
+    issues.push({
+      path: "image.attrs._docxRawXml",
+      message: "Preservation-only drawings require raw XML.",
+    });
+  }
   optionalBoolean(attrs, "_docxObjectPreview", "image.attrs._docxObjectPreview", issues);
 
   return attrsResult(attrs, issues);

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -627,9 +627,10 @@ export const readImageAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ImageAt
     issues,
     Object.values(DRAWING_RAW_XML_MODES),
   );
+  const rawXml = attrs["_docxRawXml"];
   if (
     attrs["_docxRawXmlMode"] === DRAWING_RAW_XML_MODES.PRESERVE_ONLY &&
-    typeof attrs["_docxRawXml"] !== "string"
+    (typeof rawXml !== "string" || rawXml.trim().length === 0)
   ) {
     issues.push({
       path: "image.attrs._docxRawXml",

--- a/packages/core/src/prosemirror/commands/image.ts
+++ b/packages/core/src/prosemirror/commands/image.ts
@@ -190,7 +190,10 @@ export const constrainImageSize = (
 
 const imageNodeAt = (view: EditorView, pos: number) => {
   const node = view.state.doc.nodeAt(pos);
-  return node && node.type.name === "image" ? node : null;
+  if (!node || node.type.name !== "image") {
+    return null;
+  }
+  return expectImageAttrs(node)._docxRawXmlMode ? null : node;
 };
 
 /** Change the wrap mode of the image at `pos`. Returns whether it applied. */

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -10,6 +10,8 @@
  * - Handle marks -> TextFormatting conversion
  */
 
+import { panic } from "better-result";
+import { DRAWING_RAW_XML_MODES } from "@stll/docx-core/model";
 import type { Node as PMNode, Mark } from "prosemirror-model";
 import { Fragment } from "prosemirror-model";
 
@@ -2279,16 +2281,21 @@ function createImageRun(node: PMNode): Run {
     image.crop = crop;
   }
 
-  const drawingContent: DrawingContent = {
-    type: "drawing",
-    image,
-  };
-  if (attrs._docxRawXml) {
-    drawingContent.rawXml = attrs._docxRawXml;
-  }
-  if (attrs._docxRawXmlMode) {
-    drawingContent.rawXmlMode = attrs._docxRawXmlMode;
-  }
+  const drawingContent: DrawingContent =
+    attrs._docxRawXmlMode === DRAWING_RAW_XML_MODES.PRESERVE_ONLY
+      ? {
+          type: "drawing",
+          image,
+          rawXml:
+            attrs._docxRawXml ??
+            panic("Preservation-only ProseMirror image attrs must include raw XML."),
+          rawXmlMode: DRAWING_RAW_XML_MODES.PRESERVE_ONLY,
+        }
+      : {
+          type: "drawing",
+          image,
+          ...(attrs._docxRawXml ? { rawXml: attrs._docxRawXml } : {}),
+        };
 
   return {
     type: "run",

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -2286,6 +2286,9 @@ function createImageRun(node: PMNode): Run {
   if (attrs._docxRawXml) {
     drawingContent.rawXml = attrs._docxRawXml;
   }
+  if (attrs._docxRawXmlMode) {
+    drawingContent.rawXmlMode = attrs._docxRawXmlMode;
+  }
 
   return {
     type: "run",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -41,6 +41,7 @@ import type {
   InlineSdt,
   Insertion,
   Deletion,
+  DrawingContent,
   MoveFrom,
   MoveTo,
   MathEquation,
@@ -2379,7 +2380,16 @@ function convertRunContent(
       ];
 
     case "drawing":
-      return [withHyperlinkBoundaryMarks(convertImage(content.image, content.rawXml), marks)];
+      return [
+        withHyperlinkBoundaryMarks(
+          convertImage({
+            image: content.image,
+            rawXml: content.rawXml,
+            rawXmlMode: content.rawXmlMode,
+          }),
+          marks,
+        ),
+      ];
 
     case "shape": {
       // Shapes with text body are handled as text boxes at block level
@@ -2463,7 +2473,13 @@ function withHyperlinkBoundaryMarks(node: PMNode, marks: ReturnType<typeof schem
 type PartialImagePosition = Partial<NonNullable<Image["position"]>>;
 type PartialImageSize = Partial<Image["size"]>;
 
-function convertImage(image: Image, rawXml?: string): PMNode {
+type ConvertImageOptions = {
+  image: Image;
+  rawXml: DrawingContent["rawXml"];
+  rawXmlMode: DrawingContent["rawXmlMode"];
+};
+
+function convertImage({ image, rawXml, rawXmlMode }: ConvertImageOptions): PMNode {
   // Convert EMU to pixels for proper sizing
   const imageData: { size?: PartialImageSize } = image;
   const imageSize = imageData.size;
@@ -2654,6 +2670,7 @@ function convertImage(image: Image, rawXml?: string): PMNode {
     hlinkHref: image.hlinkHref,
     hlinkRId: image.hlinkRId,
     _docxRawXml: rawXml,
+    _docxRawXmlMode: rawXmlMode,
     _docxObjectPreview:
       rawXml !== undefined && /<(?:[A-Za-z_][\w.-]*:)?object(?:\s|>)/u.test(rawXml),
   });

--- a/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -44,6 +44,7 @@ export const ImageExtension = createNodeExtension({
       hlinkHref: { default: null },
       hlinkRId: { default: null },
       _docxRawXml: { default: null },
+      _docxRawXmlMode: { default: null },
       _docxObjectPreview: { default: null },
     },
     parseDOM: [

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -13,6 +13,7 @@ import type {
   ParagraphMarkChange,
   ParagraphPropertyChange,
   PositionalTab,
+  DrawingRawXmlMode,
   FieldType,
   Hyperlink,
   LineSpacingRule,
@@ -378,6 +379,8 @@ export type ImageAttrs = {
   hlinkRId?: string;
   /** Original OOXML for opaque/unsupported DOCX drawings. */
   _docxRawXml?: string;
+  /** Raw XML preserved without an editable image projection. */
+  _docxRawXmlMode?: DrawingRawXmlMode;
   /** Embedded-object previews use their authored box as the exact line height. */
   _docxObjectPreview?: boolean;
 };

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -13,6 +13,7 @@ export type {
   Deletion,
   DocumentBody,
   DrawingContent,
+  DrawingRawXmlMode,
   Endnote,
   EndnotePosition,
   EndnoteProperties,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -49,6 +49,7 @@ export type {
   SoftHyphenContent,
   NoBreakHyphenContent,
   DrawingContent,
+  DrawingRawXmlMode,
   ShapeContent,
   RunContent,
   Run,

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -143,16 +143,25 @@ export const DRAWING_RAW_XML_MODES = {
 /** Raw XML handling mode for a drawing. */
 export type DrawingRawXmlMode = (typeof DRAWING_RAW_XML_MODES)[keyof typeof DRAWING_RAW_XML_MODES];
 
-/** Drawing/image reference. */
-export type DrawingContent = {
-  type: "drawing";
-  /** Image data */
-  image: Image;
-  /** Original OOXML for package-preserving round-trips of unsupported drawing markup. */
-  rawXml?: string;
-  /** Explicitly classifies raw XML that has no editable projected representation. */
-  rawXmlMode?: DrawingRawXmlMode;
-};
+/** Drawing/image reference with replayable XML required for preservation-only content. */
+export type DrawingContent =
+  | {
+      type: "drawing";
+      /** Image data */
+      image: Image;
+      /** Original OOXML for package-preserving round-trips of unsupported drawing markup. */
+      rawXml?: string;
+      rawXmlMode?: never;
+    }
+  | {
+      type: "drawing";
+      /** Image data */
+      image: Image;
+      /** Original OOXML required to replay a drawing without an editable projection. */
+      rawXml: string;
+      /** Explicitly classifies raw XML that has no editable projected representation. */
+      rawXmlMode: typeof DRAWING_RAW_XML_MODES.PRESERVE_ONLY;
+    };
 
 /**
  * Shape reference

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -135,15 +135,23 @@ export type RenderedPageBreakContent = {
   type: "renderedPageBreak";
 };
 
-/**
- * Drawing/image reference
- */
+/** Raw XML handling modes for drawings that Folio cannot model completely. */
+export const DRAWING_RAW_XML_MODES = {
+  PRESERVE_ONLY: "preserveOnly",
+} as const;
+
+/** Raw XML handling mode for a drawing. */
+export type DrawingRawXmlMode = (typeof DRAWING_RAW_XML_MODES)[keyof typeof DRAWING_RAW_XML_MODES];
+
+/** Drawing/image reference. */
 export type DrawingContent = {
   type: "drawing";
   /** Image data */
   image: Image;
   /** Original OOXML for package-preserving round-trips of unsupported drawing markup. */
   rawXml?: string;
+  /** Explicitly classifies raw XML that has no editable projected representation. */
+  rawXmlMode?: DrawingRawXmlMode;
 };
 
 /**

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -64,7 +64,12 @@ export type {
 } from "./lists";
 
 // Content Model — shared values
-export { isOoxmlSymbolCharacter, MAX_REVISION_ID, normalizeRevisionId } from "./content";
+export {
+  DRAWING_RAW_XML_MODES,
+  isOoxmlSymbolCharacter,
+  MAX_REVISION_ID,
+  normalizeRevisionId,
+} from "./content";
 
 export type {
   TextContent,
@@ -78,6 +83,7 @@ export type {
   SoftHyphenContent,
   NoBreakHyphenContent,
   DrawingContent,
+  DrawingRawXmlMode,
   ShapeContent,
   RunContent,
   Run,


### PR DESCRIPTION
Classify preservation-only drawing placeholders explicitly so compatibility checks can distinguish them from editable raw image projections.

Preserve unsupported shape OOXML verbatim through editor round-trips while keeping unresolved and raw-backed media read-only.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for editing text in DOCX documents while preserving unsupported drawings as unchanged raw content.
  - Documents containing unsupported drawings can now be saved and reopened without losing them.
  - Added clearer handling for drawings preserved as non-editable content.

- **Bug Fixes**
  - Prevented image editing actions from modifying preserved DOCX drawings.
  - Improved compatibility checks for preserved drawing content.

- **Tests**
  - Expanded coverage for text editing, drawing preservation, unresolved media and DOCX round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->