### PR TITLE
feat: support adjusted right-brace shapes

### DIFF
--- a/.changeset/adjusted-braces.md
+++ b/.changeset/adjusted-braces.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Parse, render, and round-trip adjusted right-brace shapes as editable geometry.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -327,6 +327,7 @@ export type SdtAttrs = {
 // @public
 export type ShapeAttrs = {
     shapeType?: string;
+    geometryAdjustments?: string;
     shapeId?: string;
     width?: number;
     height?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -940,6 +940,7 @@ export type ShadingProperties = {
 export type Shape = {
     type: "shape";
     shapeType: ShapeType;
+    geometryAdjustments?: ShapeGeometryAdjustment[];
     id?: string;
     name?: string;
     size: ImageSize;
@@ -971,6 +972,12 @@ export type ShapeFill = {
             color: ColorValue;
         }[];
     };
+};
+
+// @public
+export type ShapeGeometryAdjustment = {
+    name: string;
+    formula: string;
 };
 
 // @public

--- a/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/shape-roundtrip.test.ts
@@ -89,6 +89,30 @@ describe("shape parse → serialize round-trip", () => {
     expect(xml).toContain('cy="457200"');
   });
 
+  test("preserves supported preset geometry adjustments", () => {
+    const source = shapeDrawingXml({ prst: "rightBrace" }).replace(
+      "<a:avLst/>",
+      '<a:avLst><a:gd name="adj1" fmla="val 12500"/><a:gd name="adj2" fmla="val 62500"/></a:avLst>',
+    );
+    const root = parseXmlDocument(source);
+    const shape = root ? parseShapeFromDrawing(root) : null;
+    expect(shape?.geometryAdjustments).toEqual([
+      { name: "adj1", formula: "val 12500" },
+      { name: "adj2", formula: "val 62500" },
+    ]);
+    if (!shape) {
+      return;
+    }
+
+    const xml = serializeRun({
+      type: "run",
+      content: [{ type: "shape", shape }],
+    });
+    expect(xml).toContain(
+      '<a:prstGeom prst="rightBrace"><a:avLst><a:gd name="adj1" fmla="val 12500"/><a:gd name="adj2" fmla="val 62500"/></a:avLst></a:prstGeom>',
+    );
+  });
+
   test("preserves solid fill colour through round-trip", () => {
     const root = parseXmlDocument(
       shapeDrawingXml({

--- a/packages/core/src/docx/compatibility.test.ts
+++ b/packages/core/src/docx/compatibility.test.ts
@@ -5,7 +5,7 @@ import { EditorState } from "prosemirror-state";
 
 import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
-import type { Document, DrawingContent } from "../types/document";
+import type { Document, DrawingContent, ShapeContent } from "../types/document";
 import { inspectDocxCompatibility } from "./compatibility";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
@@ -13,8 +13,14 @@ import { repackDocx } from "./rezip";
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const createAdjustedShapeDocx = async (): Promise<ArrayBuffer> => {
+const createAdjustedShapeDocx = async (
+  preset: "rightBrace" | "roundRect",
+): Promise<ArrayBuffer> => {
   const zip = new JSZip();
+  const adjustments =
+    preset === "rightBrace"
+      ? '<a:gd name="adj1" fmla="val 12500"/><a:gd name="adj2" fmla="val 62500"/>'
+      : '<a:gd name="adj" fmla="val 25000"/>';
   zip.file(
     "[Content_Types].xml",
     `${XML_DECLARATION}
@@ -51,7 +57,7 @@ const createAdjustedShapeDocx = async (): Promise<ArrayBuffer> => {
         <wp:docPr id="1" name="Adjusted shape"/>
         <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
           <wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>
-            <a:prstGeom prst="bracePair"><a:avLst><a:gd name="adj" fmla="val 25000"/></a:avLst></a:prstGeom>
+            <a:prstGeom prst="${preset}"><a:avLst>${adjustments}</a:avLst></a:prstGeom>
             <a:noFill/><a:ln><a:solidFill><a:srgbClr val="666666"/></a:solidFill></a:ln>
           </wps:spPr></wps:wsp>
         </a:graphicData></a:graphic>
@@ -84,6 +90,18 @@ const firstRawDrawing = (document: Document): DrawingContent | undefined => {
       (content): content is DrawingContent =>
         content.type === "drawing" && content.rawXml !== undefined,
     );
+};
+
+const firstShape = (document: Document): ShapeContent | undefined => {
+  const paragraph = document.package.document.content.at(0);
+  if (paragraph?.type !== "paragraph") {
+    return undefined;
+  }
+
+  return paragraph.content
+    .filter((item) => item.type === "run")
+    .flatMap((run) => run.content)
+    .find((content): content is ShapeContent => content.type === "shape");
 };
 
 type CreateDocumentOptions = {
@@ -176,7 +194,7 @@ describe("DOCX compatibility inspection", () => {
   });
 
   test("allows text edits while preserving an unmodeled drawing verbatim", async () => {
-    const source = await createAdjustedShapeDocx();
+    const source = await createAdjustedShapeDocx("roundRect");
     const parsed = await parseDocx(source, { detectVariables: false, preloadFonts: false });
     const originalDrawing = firstRawDrawing(parsed);
 
@@ -212,6 +230,33 @@ describe("DOCX compatibility inspection", () => {
 
     expect(toProseDoc(reopened).textContent).toContain("Updated text");
     expect(reopenedDrawing?.rawXml).toBe(originalDrawing?.rawXml);
+    expect(inspectDocxCompatibility(reopened).canSafelyEdit).toBe(true);
+  });
+
+  test("treats a supported adjusted right brace as editable shape content", async () => {
+    const source = await createAdjustedShapeDocx("rightBrace");
+    const parsed = await parseDocx(source, { detectVariables: false, preloadFonts: false });
+    const expectedAdjustments = [
+      { name: "adj1", formula: "val 12500" },
+      { name: "adj2", formula: "val 62500" },
+    ];
+
+    expect(firstShape(parsed)?.shape).toMatchObject({
+      shapeType: "rightBrace",
+      geometryAdjustments: expectedAdjustments,
+    });
+    expect(firstRawDrawing(parsed)).toBeUndefined();
+    expect(inspectDocxCompatibility(parsed).canSafelyEdit).toBe(true);
+
+    const pmRoundTripped = fromProseDoc(toProseDoc(parsed), parsed);
+    expect(firstShape(pmRoundTripped)?.shape.geometryAdjustments).toEqual(expectedAdjustments);
+
+    const saved = await repackDocx(pmRoundTripped, { updateModifiedDate: false });
+    const reopened = await parseDocx(saved, { detectVariables: false, preloadFonts: false });
+    expect(firstShape(reopened)?.shape).toMatchObject({
+      shapeType: "rightBrace",
+      geometryAdjustments: expectedAdjustments,
+    });
     expect(inspectDocxCompatibility(reopened).canSafelyEdit).toBe(true);
   });
 

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -961,6 +961,16 @@ function serializeShapeTextBody(
     .join("");
 }
 
+function serializeGeometryAdjustments(shape: ShapeContent["shape"]): string {
+  if (!shape.geometryAdjustments || shape.geometryAdjustments.length === 0) {
+    return "<a:avLst/>";
+  }
+  const adjustments = shape.geometryAdjustments
+    .map(({ name, formula }) => `<a:gd name="${escapeXml(name)}" fmla="${escapeXml(formula)}"/>`)
+    .join("");
+  return `<a:avLst>${adjustments}</a:avLst>`;
+}
+
 /**
  * Serialize shape content to full DrawingML XML (wps:wsp inside w:drawing)
  */
@@ -993,7 +1003,7 @@ function serializeShapeContent(content: ShapeContent): string {
     '<a:off x="0" y="0"/>',
     `<a:ext cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
     "</a:xfrm>",
-    `<a:prstGeom prst="${shape.shapeType === "textBox" ? "rect" : shape.shapeType}"><a:avLst/></a:prstGeom>`,
+    `<a:prstGeom prst="${shape.shapeType === "textBox" ? "rect" : shape.shapeType}">${serializeGeometryAdjustments(shape)}</a:prstGeom>`,
     serializeFill(shape.fill),
     serializeOutline(shape.outline),
     "</wps:spPr>",

--- a/packages/core/src/docx/shapeParser.test.ts
+++ b/packages/core/src/docx/shapeParser.test.ts
@@ -125,15 +125,40 @@ describe("parseShapeFromDrawing — preset geometry", () => {
     expect(root ? shouldPreserveRawShapeDrawing(root) : false).toBe(true);
   });
 
-  test("preset geometry adjustments are preserved as raw drawings", () => {
+  test("supported preset geometry adjustments remain editable", () => {
     const root = parseXmlDocument(
       drawingWith(`<wps:spPr>
         <a:xfrm>
           <a:off x="0" y="0"/>
           <a:ext cx="914400" cy="457200"/>
         </a:xfrm>
-        <a:prstGeom prst="roundRect">
-          <a:avLst><a:gd name="adj" fmla="val 25000"/></a:avLst>
+        <a:prstGeom prst="rightBrace">
+          <a:avLst>
+            <a:gd name="adj1" fmla="val 12500"/>
+            <a:gd name="adj2" fmla="val 62500"/>
+          </a:avLst>
+        </a:prstGeom>
+      </wps:spPr>`),
+    );
+    expect(root ? parseShapeFromDrawing(root) : null).toMatchObject({
+      shapeType: "rightBrace",
+      geometryAdjustments: [
+        { name: "adj1", formula: "val 12500" },
+        { name: "adj2", formula: "val 62500" },
+      ],
+    });
+    expect(root ? shouldPreserveRawShapeDrawing(root) : false).toBe(false);
+  });
+
+  test("unsupported adjustment formulas remain preservation-only", () => {
+    const root = parseXmlDocument(
+      drawingWith(`<wps:spPr>
+        <a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>
+        <a:prstGeom prst="rightBrace">
+          <a:avLst>
+            <a:gd name="adj1" fmla="*/ 1 2 3"/>
+            <a:gd name="adj2" fmla="val 62500"/>
+          </a:avLst>
         </a:prstGeom>
       </wps:spPr>`),
     );

--- a/packages/core/src/docx/shapeParser.ts
+++ b/packages/core/src/docx/shapeParser.ts
@@ -32,7 +32,9 @@ import { narrowEnum, ShapeTypeSchema } from "./parserEnums";
 import {
   findAllDeep,
   findChildByLocalName,
+  findChildren,
   getAttribute,
+  getChildElements,
   parseNumericAttribute,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -124,11 +126,46 @@ function hasUnsupportedGeometry(spPr: XmlElement | null): boolean {
     return findChildByLocalName(spPr, "custGeom") !== null;
   }
   const avLst = findChildByLocalName(prstGeom, "avLst");
-  if (avLst?.elements?.some((child) => child.type === "element")) {
+  const prst = getAttribute(prstGeom, null, "prst");
+  if (narrowEnum(prst, ShapeTypeSchema) === undefined) {
     return true;
   }
-  const prst = getAttribute(prstGeom, null, "prst");
-  return narrowEnum(prst, ShapeTypeSchema) === undefined;
+  const adjustmentChildren = avLst ? getChildElements(avLst) : [];
+  if (adjustmentChildren.length === 0) {
+    return false;
+  }
+  const adjustments = findChildren(avLst, "a", "gd");
+  const adjustmentNames = new Set(
+    adjustments.map((adjustment) => getAttribute(adjustment, null, "name")),
+  );
+  return !(
+    prst === "rightBrace" &&
+    adjustments.length === 2 &&
+    adjustmentChildren.length === adjustments.length &&
+    adjustmentNames.size === 2 &&
+    adjustmentNames.has("adj1") &&
+    adjustmentNames.has("adj2") &&
+    adjustments.every((adjustment) =>
+      /^val\s+-?\d+$/u.test(getAttribute(adjustment, null, "fmla") ?? ""),
+    )
+  );
+}
+
+function parseGeometryAdjustments(spPr: XmlElement | null): Shape["geometryAdjustments"] {
+  const prstGeom = spPr ? findChildByLocalName(spPr, "prstGeom") : null;
+  const avLst = prstGeom ? findChildByLocalName(prstGeom, "avLst") : null;
+  if (!avLst) {
+    return undefined;
+  }
+  const adjustments: NonNullable<Shape["geometryAdjustments"]> = [];
+  for (const adjustment of findChildren(avLst, "a", "gd")) {
+    const name = getAttribute(adjustment, null, "name");
+    const formula = getAttribute(adjustment, null, "fmla");
+    if (name !== null && formula !== null) {
+      adjustments.push({ name, formula });
+    }
+  }
+  return adjustments.length === 0 ? undefined : adjustments;
 }
 
 function hasUnsupportedRgbColorModifiers(spPr: XmlElement | null): boolean {
@@ -192,6 +229,10 @@ export function parseShape(node: XmlElement): Shape {
     shapeType,
     size,
   };
+  const geometryAdjustments = parseGeometryAdjustments(spPr);
+  if (geometryAdjustments !== undefined) {
+    shape.geometryAdjustments = geometryAdjustments;
+  }
   if (id !== undefined) {
     shape.id = id;
   }

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -737,6 +737,7 @@ export const readShapeAttrs = (node: PMNode): ReadProseMirrorAttrsResult<ShapeAt
   expectNodeType(node, "shape", issues);
 
   optionalString(attrs, "shapeType", "shape.attrs.shapeType", issues);
+  optionalString(attrs, "geometryAdjustments", "shape.attrs.geometryAdjustments", issues);
   optionalString(attrs, "shapeId", "shape.attrs.shapeId", issues);
   optionalNumber(attrs, "width", "shape.attrs.width", issues);
   optionalNumber(attrs, "height", "shape.attrs.height", issues);

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -16,6 +16,7 @@ import type { Node as PMNode, Mark } from "prosemirror-model";
 import { Fragment } from "prosemirror-model";
 
 import { numPrEqual } from "../../docx/numberingParser";
+import { parseShapeGeometryAdjustments } from "../shapeGeometryAdjustments";
 import { narrowEnum, ShapeOutlineStyleSchema } from "../../docx/parserEnums";
 import type {
   ImageWrap,
@@ -2319,6 +2320,10 @@ function createShapeRun(node: PMNode): Run {
   };
   if (attrs.shapeId) {
     shape.id = attrs.shapeId;
+  }
+  const geometryAdjustments = parseShapeGeometryAdjustments(attrs.geometryAdjustments);
+  if (geometryAdjustments !== undefined) {
+    shape.geometryAdjustments = geometryAdjustments;
   }
   const shapeTransform = parseTransformAttr(attrs.transform);
   if (shapeTransform) {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -3030,6 +3030,10 @@ function convertShape(shape: Shape): PMNode {
 
   return schema.node("shape", {
     shapeType: shapeAttrs.shapeType ?? "rect",
+    geometryAdjustments:
+      shape.geometryAdjustments === undefined
+        ? undefined
+        : JSON.stringify(shape.geometryAdjustments),
     shapeId: shape.id,
     width: widthPx,
     height: heightPx,

--- a/packages/core/src/prosemirror/extensions/nodes/ShapeExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ShapeExtension.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildRightBracePaths,
   buildShapePolygonPoints,
   parseGradientStops,
   sanitizeColor,
@@ -12,6 +13,28 @@ import {
   sanitizeTransform,
   strokeDashArrayForOutlineStyle,
 } from "./ShapeExtension";
+
+describe("ShapeExtension.buildRightBracePaths", () => {
+  test("maps the authored adjustments to the preset's exact arc sequence", () => {
+    const authored = [
+      { name: "adj1", formula: "val 12500" },
+      { name: "adj2", formula: "val 62500" },
+    ];
+    expect(buildRightBracePaths(100, 80, authored)).toEqual({
+      fill: "M 0 0 A 50 10 0 0 1 50 10 L 50 40 A 50 10 0 0 0 100 50 A 50 10 0 0 0 50 60 L 50 70 A 50 10 0 0 1 0 80 Z",
+      outline:
+        "M 0 0 A 50 10 0 0 1 50 10 L 50 40 A 50 10 0 0 0 100 50 A 50 10 0 0 0 50 60 L 50 70 A 50 10 0 0 1 0 80",
+    });
+  });
+
+  test("clamps thickness using the cusp-dependent DrawingML bound", () => {
+    const oversized = [
+      { name: "adj1", formula: "val 90000" },
+      { name: "adj2", formula: "val 62500" },
+    ];
+    expect(buildRightBracePaths(100, 80, oversized).outline).toContain("L 50 35");
+  });
+});
 
 describe("ShapeExtension.sanitizeColor", () => {
   test("accepts six-digit hex colors", () => {

--- a/packages/core/src/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -7,6 +7,8 @@
 
 import { expectShapeAttrs } from "../../attrs";
 import type { ImagePositionAttrs, ShapeAttrs as SchemaShapeAttrs } from "../../schema/nodes";
+import { parseShapeGeometryAdjustments } from "../../shapeGeometryAdjustments";
+import type { ShapeGeometryAdjustment } from "../../../types/document";
 import { createNodeExtension } from "../create";
 
 export type ShapeAttrs = SchemaShapeAttrs;
@@ -176,6 +178,65 @@ function fmt(n: number): string {
   return Number.isInteger(n) ? String(n) : Number(n.toFixed(3)).toString();
 }
 
+const RIGHT_BRACE_DEFAULT_THICKNESS = 8_333;
+const RIGHT_BRACE_DEFAULT_CUSP = 50_000;
+const GEOMETRY_PERCENT_SCALE = 100_000;
+
+const geometryAdjustment = (
+  adjustments: readonly ShapeGeometryAdjustment[],
+  name: string,
+  fallback: number,
+): number => {
+  const authored = adjustments.find((adjustment) => adjustment.name === name);
+  if (!authored) {
+    return fallback;
+  }
+  const match = /^val\s+(-?\d+)$/u.exec(authored.formula);
+  if (!match) {
+    return fallback;
+  }
+  return Number(match.at(1));
+};
+
+type RightBracePaths = {
+  fill: string;
+  outline: string;
+};
+
+export function buildRightBracePaths(
+  w: number,
+  h: number,
+  adjustments: readonly ShapeGeometryAdjustment[],
+): RightBracePaths {
+  const shortSide = Math.min(w, h);
+  const cuspAdjustment = Math.min(
+    GEOMETRY_PERCENT_SCALE,
+    Math.max(0, geometryAdjustment(adjustments, "adj2", RIGHT_BRACE_DEFAULT_CUSP)),
+  );
+  const nearestEdge = Math.min(cuspAdjustment, GEOMETRY_PERCENT_SCALE - cuspAdjustment);
+  const maxThickness = ((nearestEdge / 2) * h) / shortSide;
+  const thicknessAdjustment = Math.min(
+    maxThickness,
+    Math.max(0, geometryAdjustment(adjustments, "adj1", RIGHT_BRACE_DEFAULT_THICKNESS)),
+  );
+  const radius = (shortSide * thicknessAdjustment) / GEOMETRY_PERCENT_SCALE;
+  const halfWidth = w / 2;
+  const cusp = (h * cuspAdjustment) / GEOMETRY_PERCENT_SCALE;
+  const upperStemEnd = cusp - radius;
+  const lowerStemStart = cusp + radius;
+  const bottomCurveStart = h - radius;
+  const commands = [
+    "M 0 0",
+    `A ${fmt(halfWidth)} ${fmt(radius)} 0 0 1 ${fmt(halfWidth)} ${fmt(radius)}`,
+    `L ${fmt(halfWidth)} ${fmt(upperStemEnd)}`,
+    `A ${fmt(halfWidth)} ${fmt(radius)} 0 0 0 ${fmt(w)} ${fmt(cusp)}`,
+    `A ${fmt(halfWidth)} ${fmt(radius)} 0 0 0 ${fmt(halfWidth)} ${fmt(lowerStemStart)}`,
+    `L ${fmt(halfWidth)} ${fmt(bottomCurveStart)}`,
+    `A ${fmt(halfWidth)} ${fmt(radius)} 0 0 1 0 ${fmt(h)}`,
+  ].join(" ");
+  return { fill: `${commands} Z`, outline: commands };
+}
+
 /**
  * Build the `points` string for a polygon-based shape preset.
  *
@@ -272,7 +333,12 @@ export function buildShapePolygonPoints(type: string, w: number, h: number): str
  * displays. The original `<a:prstGeom prst>` value round-trips through the
  * model regardless of what the renderer chooses to draw.
  */
-function createShapeElement(type: string, w: number, h: number): SVGElement {
+function createShapeElement(
+  type: string,
+  w: number,
+  h: number,
+  adjustments: readonly ShapeGeometryAdjustment[],
+): SVGElement {
   switch (type) {
     case "ellipse":
     case "oval": {
@@ -300,6 +366,19 @@ function createShapeElement(type: string, w: number, h: number): SVGElement {
       setNum(el, "x2", w);
       setNum(el, "y2", h / 2);
       return el;
+    }
+    case "rightBrace": {
+      const paths = buildRightBracePaths(w, h, adjustments);
+      const group = document.createElementNS(SVG_NS, "g");
+      const fill = document.createElementNS(SVG_NS, "path");
+      fill.setAttribute("d", paths.fill);
+      fill.setAttribute("stroke", "none");
+      group.append(fill);
+      const outline = document.createElementNS(SVG_NS, "path");
+      outline.setAttribute("d", paths.outline);
+      outline.setAttribute("fill", "none");
+      group.append(outline);
+      return group;
     }
     default: {
       const points = buildShapePolygonPoints(type, w, h);
@@ -405,6 +484,7 @@ export const ShapeExtension = createNodeExtension({
     atom: true,
     attrs: {
       shapeType: { default: "rect" },
+      geometryAdjustments: { default: null },
       shapeId: { default: null },
       width: { default: 100 },
       height: { default: 80 },
@@ -449,6 +529,7 @@ export const ShapeExtension = createNodeExtension({
           const outlineTailEnd = parseShapeLineEnd(d["outlineTailEnd"]);
           return {
             shapeType: d["shapeType"] || "rect",
+            ...(d["geometryAdjustments"] ? { geometryAdjustments: d["geometryAdjustments"] } : {}),
             ...(d["shapeId"] ? { shapeId: d["shapeId"] } : {}),
             ...(d["width"] ? { width: Number(d["width"]) } : {}),
             ...(d["height"] ? { height: Number(d["height"]) } : {}),
@@ -520,6 +601,9 @@ export const ShapeExtension = createNodeExtension({
         class: "docx-shape",
         "data-shape-type": attrs.shapeType || "rect",
       };
+      if (attrs.geometryAdjustments) {
+        domAttrs["data-geometry-adjustments"] = attrs.geometryAdjustments;
+      }
 
       // Data attributes for round-trip
       if (attrs.shapeId) {
@@ -696,7 +780,8 @@ export const ShapeExtension = createNodeExtension({
         svg.append(defs);
       }
 
-      const shapeEl = createShapeElement(attrs.shapeType || "rect", w, h);
+      const geometryAdjustments = parseShapeGeometryAdjustments(attrs.geometryAdjustments) ?? [];
+      const shapeEl = createShapeElement(attrs.shapeType || "rect", w, h, geometryAdjustments);
       const strokeDasharray = strokeDashArrayForOutlineStyle(attrs.outlineStyle);
       if (strokeDasharray) {
         shapeEl.setAttribute("stroke-dasharray", strokeDasharray);

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -493,6 +493,8 @@ export type BlockSdtAttrs = {
 export type ShapeAttrs = {
   /** Shape type preset */
   shapeType?: string;
+  /** Preset geometry adjustments serialized as JSON. */
+  geometryAdjustments?: string;
   /** Unique identifier */
   shapeId?: string;
   /** Width in pixels */

--- a/packages/core/src/prosemirror/shapeGeometryAdjustments.test.ts
+++ b/packages/core/src/prosemirror/shapeGeometryAdjustments.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseShapeGeometryAdjustments } from "./shapeGeometryAdjustments";
+
+describe("parseShapeGeometryAdjustments", () => {
+  test("accepts bounded named formulas", () => {
+    expect(
+      parseShapeGeometryAdjustments(JSON.stringify([{ name: "adj", formula: "val 25000" }])),
+    ).toEqual([{ name: "adj", formula: "val 25000" }]);
+  });
+
+  test.each([
+    "not json",
+    "{}",
+    JSON.stringify([{ name: "adj" }]),
+    JSON.stringify([{ name: "", formula: "val 1" }]),
+    JSON.stringify(Array.from({ length: 33 }, () => ({ name: "adj", formula: "val 1" }))),
+  ])("rejects malformed or unbounded input", (raw) => {
+    expect(parseShapeGeometryAdjustments(raw)).toBeUndefined();
+  });
+});

--- a/packages/core/src/prosemirror/shapeGeometryAdjustments.ts
+++ b/packages/core/src/prosemirror/shapeGeometryAdjustments.ts
@@ -1,0 +1,40 @@
+import type { ShapeGeometryAdjustment } from "../types/document";
+
+const MAX_ADJUSTMENT_COUNT = 32;
+const MAX_ADJUSTMENT_NAME_LENGTH = 64;
+const MAX_ADJUSTMENT_FORMULA_LENGTH = 128;
+
+export const parseShapeGeometryAdjustments = (
+  raw: string | undefined,
+): ShapeGeometryAdjustment[] | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed) || parsed.length > MAX_ADJUSTMENT_COUNT) {
+      return undefined;
+    }
+    const adjustments: ShapeGeometryAdjustment[] = [];
+    for (const item of parsed) {
+      if (
+        typeof item !== "object" ||
+        item === null ||
+        !("name" in item) ||
+        typeof item.name !== "string" ||
+        item.name.length === 0 ||
+        item.name.length > MAX_ADJUSTMENT_NAME_LENGTH ||
+        !("formula" in item) ||
+        typeof item.formula !== "string" ||
+        item.formula.length === 0 ||
+        item.formula.length > MAX_ADJUSTMENT_FORMULA_LENGTH
+      ) {
+        return undefined;
+      }
+      adjustments.push({ name: item.name, formula: item.formula });
+    }
+    return adjustments.length === 0 ? undefined : adjustments;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -66,6 +66,7 @@ export type {
   ShapeOutline,
   ShapeTextBody,
   ShapeType,
+  ShapeGeometryAdjustment,
   SimpleField,
   SdtProperties,
   SdtType,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -76,6 +76,7 @@ export type {
 
   // Shapes & Text Boxes
   ShapeType,
+  ShapeGeometryAdjustment,
   ShapeFill,
   ShapeOutline,
   ShapeTextBody,

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -711,6 +711,12 @@ export type ShapeType =
   | "swooshArrow"
   | "textBox";
 
+/** Authored adjustment formula for a preset DrawingML geometry. */
+export type ShapeGeometryAdjustment = {
+  name: string;
+  formula: string;
+};
+
 /**
  * Shape fill type
  */
@@ -812,6 +818,8 @@ export type Shape = {
   type: "shape";
   /** Shape type preset */
   shapeType: ShapeType;
+  /** Authored preset-geometry adjustments, in document order. */
+  geometryAdjustments?: ShapeGeometryAdjustment[];
   /** Unique ID */
   id?: string;
   /** Name */

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -102,6 +102,7 @@ export type {
   ImageCrop,
   Image,
   ShapeType,
+  ShapeGeometryAdjustment,
   ShapeFill,
   ShapeOutline,
   ShapeTextBody,


### PR DESCRIPTION
Parse supported right-brace adjustment formulas into editable geometry, preserve them through the editor and DOCX serializer, and render the DrawingML arc sequence in SVG. Unsupported adjusted presets remain preservation-only.

Adds bounded editor-attribute decoding, generalized synthetic parse/save/reopen coverage, and public API snapshots.

CC on behalf of jan-kubica