### PR TITLE
fix: recognize localized TOC styles

### DIFF
--- a/.changeset/imported-hyperlink-formatting.md
+++ b/.changeset/imported-hyperlink-formatting.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Recognize localized table-of-contents styles so entry hyperlinks use TOC typography.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -228,6 +228,7 @@ export type ParagraphAttrs = {
     listAbstractNumId?: number;
     listStartOverride?: number;
     styleId?: string;
+    _tableOfContentsLevel?: number;
     borders?: {
         top?: import__stll_docx_core_model.BorderSpec;
         bottom?: import__stll_docx_core_model.BorderSpec;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -325,6 +325,7 @@ export type ParagraphAttrs = {
     listAbstractNumId?: number;
     listStartOverride?: number;
     styleId?: string;
+    _tableOfContentsLevel?: number;
     borders?: {
         top?: import__stll_docx_core_model.BorderSpec;
         bottom?: import__stll_docx_core_model.BorderSpec;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1150,6 +1150,72 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
     expect(run.underline).toBeUndefined();
   });
 
+  test("recognizes a localized TOC style id from its canonical style name", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "LocalizedBody",
+              type: "paragraph",
+              default: true,
+            },
+            {
+              styleId: "LocalizedTocEntry",
+              type: "paragraph",
+              name: "toc 1",
+              basedOn: "LocalizedBody",
+            },
+            {
+              styleId: "LocalizedLink",
+              type: "character",
+              name: "Hyperlink",
+              rPr: {
+                color: { rgb: "654321" },
+                underline: { style: "single" },
+              },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "LocalizedTocEntry" },
+              content: [
+                {
+                  type: "hyperlink",
+                  anchor: "generic-section",
+                  children: [
+                    {
+                      type: "run",
+                      formatting: { styleId: "LocalizedLink" },
+                      content: [{ type: "text", text: "Generic entry" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const blocks = toFlowBlocks(toProseDoc(document, { styles: document.package.styles }));
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const run = paragraph.runs.at(0);
+    if (run?.kind !== "text") {
+      throw new Error("Expected text run");
+    }
+
+    expect(run.hyperlink?.noDefaultStyle).toBe(true);
+    expect(run.color).toBeUndefined();
+    expect(run.underline).toBeUndefined();
+  });
+
   // The page-number end of a TOC entry is a PAGEREF field inside the
   // hyperlink — the strip must reach field runs too, not just text runs.
   test("strips resolved color/underline on a field run inside a TOC paragraph", () => {
@@ -1194,8 +1260,7 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
   });
 
   // Non-TOC paragraphs must NOT be stripped — Word still renders normal-body
-  // hyperlinks with the Hyperlink character style (blue + underline). The
-  // strip is keyed to styleId /^TOC\d*$/i; everything else passes through.
+  // hyperlinks with the Hyperlink character style (blue + underline).
   test("does not strip hyperlinks in non-TOC paragraphs", () => {
     const linkMark = schema.marks["hyperlink"]?.create({
       href: "https://example.com",
@@ -1227,7 +1292,7 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
 
   // TOC, TOC1..TOC9 should all match. TOCHeading (Word's TOC title) is its
   // own styleId and is NOT a TOC entry — no strip.
-  test("TOC styleId regex matches TOC and TOC1..N but not TOCHeading", () => {
+  test("recognizes standard TOC style ids but not TOCHeading", () => {
     const linkMark = schema.marks["hyperlink"]?.create({ href: "#x" });
     if (!linkMark) {
       throw new Error("Expected hyperlink mark");

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -89,6 +89,7 @@ import { resolveColor, resolveHighlightToCss } from "../../utils/colorResolver";
 import { resolveThemeFont } from "../../utils/fontResolver";
 import { resolveShadingFill } from "../../utils/formatToStyle";
 import { decodeOoxmlSymbolCharacter } from "../../utils/ooxmlSymbol";
+import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
 import {
   AUTO_PARAGRAPH_SPACING_PX,
   pointsToPixels,
@@ -994,13 +995,6 @@ function buildImageRun(
 }
 
 /**
- * Paragraph styleId pattern used by Word for TOC entries (TOC, TOC1, TOC2, …).
- * Hyperlinks inside these paragraphs must render in the paragraph's own colour,
- * not the Hyperlink character style — see {@link stripTocHyperlinkStyle}.
- */
-const TOC_STYLE_ID = /^TOC\d*$/iu;
-
-/**
  * In TOC paragraphs, strip the resolved Hyperlink character-style colour and
  * underline so the painter's link fallback doesn't fire. The PM doc keeps the
  * original marks so copy/paste out of a TOC still carries the Hyperlink
@@ -1029,7 +1023,8 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
   const paraDefaults = paragraphRunDefaults(pmAttrs, theme);
   const paragraphStyleId = pmAttrs.styleId;
   const inTocParagraph =
-    typeof paragraphStyleId === "string" && TOC_STYLE_ID.test(paragraphStyleId);
+    pmAttrs._tableOfContentsLevel !== undefined ||
+    tableOfContentsStyleLevel({ styleId: paragraphStyleId }) !== undefined;
   let leadingRenderedPageBreakPending = pmAttrs.renderedPageBreakBefore === true;
 
   // Single dispatcher for one inline PM child. Recurses on `sdt` so nested

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -258,6 +258,7 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
     PARAGRAPH_ALIGNMENT_VALUES,
   );
   optionalString(attrs, "styleId", "paragraph.attrs.styleId", issues);
+  optionalNumber(attrs, "_tableOfContentsLevel", "paragraph.attrs._tableOfContentsLevel", issues);
   optionalBoolean(attrs, "kinsoku", "paragraph.attrs.kinsoku", issues);
   optionalBoolean(attrs, "overflowPunctuation", "paragraph.attrs.overflowPunctuation", issues);
   optionalBoolean(attrs, "suppressAutoHyphens", "paragraph.attrs.suppressAutoHyphens", issues);

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -54,6 +54,7 @@ import {
 } from "../../utils/paragraphFormattingMerge";
 import { resolveColorValueToHex } from "../../docx/drawingUtils";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
+import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
 import { emuToPixels } from "../../utils/units";
 import { setAutospacingBaseValue } from "../autospacingBase";
 import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
@@ -95,11 +96,6 @@ type RunFormattingResolver = (
   formatting: TextFormatting | undefined,
   fieldType?: string,
 ) => TextFormatting | undefined;
-
-const TOC_STYLE_ID = /^TOC\d*$/iu;
-
-const isTocStyleId = (styleId: string | undefined): boolean =>
-  styleId !== undefined && TOC_STYLE_ID.test(styleId);
 
 /**
  * Build a `nextTextBoxGroupId()` generator salted with a random per-load
@@ -279,7 +275,7 @@ function convertParagraph(
   textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode {
   const attrs = paragraphFormattingToAttrs(paragraph, styleResolver, tableParagraphOverlay);
-  const isTocParagraph = isTocStyleId(paragraph.formatting?.styleId);
+  const isTocParagraph = attrs._tableOfContentsLevel !== undefined;
   const inlineNodes: PMNode[] = [];
   let inlineOffset = 0;
   let bookmarksArr: { id: number; name: string }[] | undefined;
@@ -598,6 +594,11 @@ function paragraphFormattingToAttrs(
 ): ParagraphAttrs {
   const formatting = paragraph.formatting;
   const styleId = formatting?.styleId;
+  const styleName = styleId ? styleResolver?.getStyle(styleId)?.name : undefined;
+  const tableOfContentsLevel = tableOfContentsStyleLevel({
+    styleId,
+    ...(styleName ? { styleName } : {}),
+  });
 
   // Start with base attrs — only include defined values
   const attrs: ParagraphAttrs = {};
@@ -610,6 +611,9 @@ function paragraphFormattingToAttrs(
   }
   if (styleId) {
     attrs.styleId = styleId;
+  }
+  if (tableOfContentsLevel !== undefined) {
+    attrs._tableOfContentsLevel = tableOfContentsLevel;
   }
   if (formatting?.numPr) {
     attrs.numPr = formatting.numPr;
@@ -802,7 +806,7 @@ function paragraphFormattingToAttrs(
     set(
       "defaultTextFormatting",
       resolveParagraphDefaultTextFormatting(styleId, formatting, styleResolver, {
-        includeParagraphMarkRunProperties: !isTocStyleId(styleId),
+        includeParagraphMarkRunProperties: tableOfContentsLevel === undefined,
       }),
     );
 

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.test.ts
@@ -21,6 +21,52 @@ const paragraphDomAttrs = (attrs: Record<string, unknown>): Record<string, strin
 };
 
 describe("ParagraphExtension", () => {
+  test("carries an imported TOC level through editor DOM", () => {
+    expect(paragraphDomAttrs({ _tableOfContentsLevel: 2 })).toMatchObject({
+      "data-table-of-contents-level": "2",
+    });
+    expect(paragraphDomAttrs({})).not.toHaveProperty("data-table-of-contents-level");
+  });
+
+  test("recomputes the TOC role when paragraph styles change", () => {
+    const hyperlink = schema.marks["hyperlink"]?.create({ href: "#generic-section" });
+    if (!hyperlink) {
+      throw new Error("Expected hyperlink mark");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { styleId: "LocalizedTocEntry", _tableOfContentsLevel: 1 }, [
+        schema.text("Generic entry", [hyperlink]),
+      ]),
+    ]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+    const applyStyle = singletonManager.getCommand("applyStyle");
+    const clearStyle = singletonManager.getCommand("clearStyle");
+    if (!applyStyle || !clearStyle) {
+      throw new Error("Missing paragraph style commands");
+    }
+
+    applyStyle("LocalizedBody", { styleName: "Body Text" })(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+    expect(state.doc.firstChild?.attrs["_tableOfContentsLevel"]).toBeNull();
+    const bodyRun = toFlowBlocks(state.doc).at(0)?.runs.at(0);
+    expect(bodyRun?.hyperlink?.noDefaultStyle).toBeUndefined();
+
+    applyStyle("LocalizedTocEntry", { styleName: "toc 1" })(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+    expect(state.doc.firstChild?.attrs["_tableOfContentsLevel"]).toBe(1);
+
+    clearStyle()(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+    expect(state.doc.firstChild?.attrs["_tableOfContentsLevel"]).toBeNull();
+  });
+
   test("preserves explicit list paragraph left indent", () => {
     const attrs = paragraphDomAttrs({
       indentLeft: 1440,

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -23,6 +23,7 @@ import type {
 } from "../../../types/document";
 import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
+import { tableOfContentsStyleLevel } from "../../../utils/tableOfContentsStyle";
 import { expectParagraphAttrs } from "../../attrs";
 import { autospacingMatchesBase } from "../../autospacingBase";
 import { directionIsRtl } from "../../paragraphDirection";
@@ -355,6 +356,7 @@ const paragraphNodeSpec: NodeSpec = {
     listAbstractNumId: { default: null },
     listStartOverride: { default: null },
     styleId: { default: null },
+    _tableOfContentsLevel: { default: null },
     borders: { default: null },
     shading: { default: null },
     tabs: { default: null },
@@ -397,6 +399,7 @@ const paragraphNodeSpec: NodeSpec = {
         const paraId = element.dataset["paraId"];
         const alignment = element.dataset["alignment"] as ParagraphAlignment | undefined;
         const styleId = element.dataset["styleId"];
+        const tableOfContentsLevel = Number(element.dataset["tableOfContentsLevel"]);
         const sectionBreakType = element.dataset["sectionBreak"] as
           | NonNullable<ParagraphAttrs["sectionBreakType"]>
           | undefined;
@@ -404,6 +407,9 @@ const paragraphNodeSpec: NodeSpec = {
           ...(paraId ? { paraId } : {}),
           ...(alignment ? { alignment } : {}),
           ...(styleId ? { styleId } : {}),
+          ...(Number.isSafeInteger(tableOfContentsLevel) && tableOfContentsLevel > 0
+            ? { _tableOfContentsLevel: tableOfContentsLevel }
+            : {}),
           ...(sectionBreakType ? { sectionBreakType } : {}),
         };
 
@@ -462,6 +468,10 @@ const paragraphNodeSpec: NodeSpec = {
 
     if (attrs.styleId) {
       domAttrs["data-style-id"] = attrs.styleId;
+    }
+
+    if (typeof attrs._tableOfContentsLevel === "number") {
+      domAttrs["data-table-of-contents-level"] = String(attrs._tableOfContentsLevel);
     }
 
     if (attrs.listMarker) {
@@ -575,6 +585,8 @@ function setParagraphAttrsCmd(attrs: Record<string, unknown>): Command {
 export type ResolvedStyleAttrs = {
   paragraphFormatting?: ParagraphFormatting;
   runFormatting?: TextFormatting;
+  /** Canonical OOXML style name, used when the document-local style id is localized. */
+  styleName?: string;
   /**
    * Numbering definitions from the document package. When the applied style
    * carries a `w:numPr`, these resolve the numbering level into the list
@@ -737,6 +749,7 @@ function makeApplyStyle(schema: Schema) {
           const newAttrs: Record<string, unknown> = {
             ...node.attrs,
             styleId,
+            _tableOfContentsLevel: tableOfContentsStyleLevel({ styleId }) ?? null,
           };
 
           if (resolvedAttrs) {
@@ -748,7 +761,13 @@ function makeApplyStyle(schema: Schema) {
             // both paths produce identical paragraph attrs — and the resulting
             // `defaultTextFormatting` lets EmptyParagraphFormatExtension keep
             // typed text styled after the style picker steals focus.
-            Object.assign(newAttrs, paragraphAttrsFromResolvedStyle(resolvedAttrs));
+            Object.assign(
+              newAttrs,
+              paragraphAttrsFromResolvedStyle(resolvedAttrs, {
+                styleId,
+                ...(resolvedAttrs.styleName ? { styleName: resolvedAttrs.styleName } : {}),
+              }),
+            );
             // A style with `w:numPr` attaches its numbering (numPr + marker
             // attrs). A style without numbering leaves existing list attrs
             // untouched — direct numbering survives a style switch in Word.
@@ -869,7 +888,7 @@ export const ParagraphExtension = createNodeExtension({
           }),
         applyStyle: (styleId: string, resolvedAttrs?: ResolvedStyleAttrs) =>
           applyStyleFn(styleId, resolvedAttrs),
-        clearStyle: () => setParagraphAttr("styleId", null),
+        clearStyle: () => setParagraphAttrsCmd({ styleId: null, _tableOfContentsLevel: null }),
         insertSectionBreak: (breakType: "nextPage" | "continuous" | "oddPage" | "evenPage") =>
           setParagraphAttr("sectionBreakType", breakType),
         removeSectionBreak: () => setParagraphAttr("sectionBreakType", null),

--- a/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -96,6 +96,7 @@ const clearIndentOnBackspace: Command = (state, dispatch) => {
 const INHERITED_PARA_ATTRS = [
   "defaultTextFormatting",
   "styleId",
+  "_tableOfContentsLevel",
   "lineSpacing",
   "lineSpacingRule",
   "snapToGrid",
@@ -128,6 +129,7 @@ function applyNextParagraphStyle(
   }
 
   const resolved = resolver.resolveParagraphStyle(nextStyleId);
+  const styleName = resolver.getStyle(nextStyleId)?.name;
   const { $from } = tr.selection;
   // `paragraphAttrsFromResolvedStyle` already projects the next style's
   // borders (or null), which both clears the source paragraph's leftover
@@ -135,7 +137,10 @@ function applyNextParagraphStyle(
   tr.setNodeMarkup($from.before(), undefined, {
     ...newPara.attrs,
     styleId: nextStyleId,
-    ...paragraphAttrsFromResolvedStyle(resolved),
+    ...paragraphAttrsFromResolvedStyle(resolved, {
+      styleId: nextStyleId,
+      ...(styleName ? { styleName } : {}),
+    }),
   });
 
   // setStoredMarks MUST come after setNodeMarkup — every step clears it.

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -159,6 +159,8 @@ export type ParagraphAttrs = {
 
   // Style reference
   styleId?: string;
+  /** Imported built-in TOC entry level, resolved from the canonical style name. */
+  _tableOfContentsLevel?: number;
 
   // Borders
   borders?: {

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -10,9 +10,15 @@
  */
 
 import { computeListRendering, type NumberingMap } from "../../docx/numberingParser";
+import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
 import { setAutospacingBaseValue } from "../autospacingBase";
 import type { ParagraphAttrs } from "../schema/nodes";
 import type { ResolvedParagraphStyle } from "./styleResolver";
+
+type ResolvedStyleIdentity = {
+  styleId: string;
+  styleName?: string;
+};
 
 /**
  * The paragraph attrs a style definition controls. Applying a style resets
@@ -22,6 +28,7 @@ import type { ResolvedParagraphStyle } from "./styleResolver";
  */
 export function paragraphAttrsFromResolvedStyle(
   resolved: ResolvedParagraphStyle,
+  identity: ResolvedStyleIdentity,
 ): Record<string, unknown> {
   const ppr = resolved.paragraphFormatting;
   const runFormatting = resolved.runFormatting;
@@ -53,6 +60,7 @@ export function paragraphAttrsFromResolvedStyle(
     // and the formatting typed text inherits (see EmptyParagraphFormatExtension).
     defaultTextFormatting: hasRunFormatting ? runFormatting : null,
     _autospacingBase: autospacingBaseFromResolvedParagraphFormatting(ppr),
+    _tableOfContentsLevel: tableOfContentsStyleLevel(identity) ?? null,
   };
 }
 

--- a/packages/core/src/utils/tableOfContentsStyle.ts
+++ b/packages/core/src/utils/tableOfContentsStyle.ts
@@ -1,0 +1,27 @@
+const TABLE_OF_CONTENTS_STYLE_ID = /^TOC(?<level>\d*)$/iu;
+const TABLE_OF_CONTENTS_STYLE_NAME = /^toc\s+(?<level>\d+)$/iu;
+
+type TableOfContentsStyleIdentity = {
+  styleId: string | undefined;
+  styleName?: string;
+};
+
+const parsedLevel = (match: RegExpExecArray | null): number | undefined => {
+  if (!match) {
+    return undefined;
+  }
+  const rawLevel = match.groups?.["level"];
+  if (rawLevel === "") {
+    return 1;
+  }
+  const level = Number(rawLevel);
+  return Number.isSafeInteger(level) && level > 0 ? level : undefined;
+};
+
+/** Resolve a built-in TOC entry style without relying on its localized style id. */
+export const tableOfContentsStyleLevel = ({
+  styleId,
+  styleName,
+}: TableOfContentsStyleIdentity): number | undefined =>
+  parsedLevel(TABLE_OF_CONTENTS_STYLE_ID.exec(styleId ?? "")) ??
+  parsedLevel(TABLE_OF_CONTENTS_STYLE_NAME.exec(styleName ?? ""));

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -2197,6 +2197,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
               if (resolved.runFormatting) {
                 styleAttrs.runFormatting = resolved.runFormatting;
               }
+              const styleName = styleResolver.getStyle(action.value)?.name;
+              if (styleName) {
+                styleAttrs.styleName = styleName;
+              }
               styleAttrs.numbering = currentDoc?.package.numbering
                 ? getCachedNumberingMap(currentDoc.package.numbering)
                 : null;

--- a/packages/vue/src/composables/useFormattingActions.ts
+++ b/packages/vue/src/composables/useFormattingActions.ts
@@ -68,6 +68,8 @@ export function useFormattingActions(opts: UseFormattingActionsOptions) {
       };
       if (resolved.paragraphFormatting) attrs.paragraphFormatting = resolved.paragraphFormatting;
       if (resolved.runFormatting) attrs.runFormatting = resolved.runFormatting;
+      const styleName = resolver.getStyle(styleId)?.name;
+      if (styleName) attrs.styleName = styleName;
       applyStyle(styleId, attrs)(view.state, (tr) => view.dispatch(tr));
     } else {
       applyStyle(styleId)(view.state, (tr) => view.dispatch(tr));


### PR DESCRIPTION
## Summary

- Resolve built-in table-of-contents entry roles from canonical style names when document-local style IDs differ.
- Preserve the derived role through editor DOM and recompute it when paragraph styles change.
- Keep TOC hyperlinks aligned with paragraph typography while ordinary hyperlinks retain their normal styling.
- Add synthetic regressions and updated public API snapshots.

## Validation

- `bun --filter @stll/folio-core test`
- `bun run typecheck`
- `bun run lint`
- `bun run format`
- `bun run build`
- `bun run api:check`
- `bun run api:budget`

CC on behalf of jan-kubica