### PR TITLE
fix: bound generated redline operations to avoid unbounded formatting expansion

### DIFF
--- a/.changeset/limit-redline-operations.md
+++ b/.changeset/limit-redline-operations.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Bound generated redline operations for fragmented formatting changes.

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -391,6 +391,22 @@ describe("generateRedlineDocx", () => {
     expect(rejecting.snapshot().blocks.at(0)?.previewRuns).toEqual(baseFormatting);
   });
 
+  test("bounds generated operations for highly fragmented formatting changes", async () => {
+    const runCount = 10_001;
+    const base = await buildFormattedRunDocxBuffer([{ text: "a".repeat(runCount) }], "00000001");
+    const revised = await buildFormattedRunDocxBuffer(
+      Array.from({ length: runCount }, (_, index) => ({
+        text: "a",
+        formatting: index % 2 === 0 ? { bold: true } : { italic: true },
+      })),
+      "00000001",
+    );
+
+    await expect(generateRedlineDocx(base, revised)).rejects.toThrow(
+      "The document comparison exceeds the generated operation limit.",
+    );
+  });
+
   test("a relocated block redlines as delete + insert and still satisfies both invariants", async () => {
     const base = await buildDocxBuffer([
       { text: "Governing law shall be Czech law.", paraId: "00000001" },

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -22,6 +22,10 @@ import { parseDocx } from "./docx/parser";
 import { createDocx } from "./docx/rezip";
 import { repackDocx } from "./docx/rezip";
 import { generateRedlineDocx, InvalidGenerateRedlineDocxOptionsError } from "./redline";
+import {
+  GenerateRedlineDocxOperationLimitError,
+  MAX_GENERATED_REDLINE_OPERATIONS,
+} from "./redlineOperationLimit";
 import type { HeaderFooter, Paragraph } from "./types/document";
 import { createEmptyDocument } from "./utils/createDocument";
 
@@ -31,6 +35,22 @@ type ParagraphSpec = {
   text: string;
   paraId?: string;
   formatting?: InlineFormattingSpec;
+};
+
+const buildInsertedParagraphs = (count: number): ParagraphSpec[] =>
+  Array.from({ length: count }, (_, index) => ({ text: `Inserted paragraph ${index}` }));
+
+const expectOperationLimitError = async (promise: Promise<unknown>) => {
+  const error = await promise.then(
+    () => null,
+    (reason) => reason,
+  );
+
+  expect(error).toBeInstanceOf(GenerateRedlineDocxOperationLimitError);
+  expect(error).toMatchObject({
+    _tag: "GenerateRedlineDocxOperationLimitError",
+    message: "The document comparison exceeds the generated operation limit.",
+  });
 };
 
 const CORE_PROPERTIES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cp:coreProperties xmlns:cp="urn:properties" xmlns:dc="urn:descriptive" xmlns:dcterms="urn:terms"><dc:title>Private title</dc:title><dc:creator>Private creator</dc:creator><cp:lastModifiedBy>Private modifier</cp:lastModifiedBy><cp:revision>7</cp:revision><dcterms:created>2026-07-01T10:30:00Z</dcterms:created><dcterms:modified>2026-07-02T11:45:00Z</dcterms:modified></cp:coreProperties>`;
@@ -391,8 +411,29 @@ describe("generateRedlineDocx", () => {
     expect(rejecting.snapshot().blocks.at(0)?.previewRuns).toEqual(baseFormatting);
   });
 
+  test("allows exactly the generated operation limit for ordinary block operations", async () => {
+    const [base, revised] = await Promise.all([
+      buildDocxBuffer([]),
+      buildDocxBuffer(buildInsertedParagraphs(MAX_GENERATED_REDLINE_OPERATIONS)),
+    ]);
+
+    const result = await generateRedlineDocx(base, revised);
+
+    expect(result.applied).toHaveLength(MAX_GENERATED_REDLINE_OPERATIONS);
+    expect(result.skipped).toEqual([]);
+  }, 60_000);
+
+  test("rejects the first ordinary block operation beyond the limit", async () => {
+    const [base, revised] = await Promise.all([
+      buildDocxBuffer([]),
+      buildDocxBuffer(buildInsertedParagraphs(MAX_GENERATED_REDLINE_OPERATIONS + 1)),
+    ]);
+
+    await expectOperationLimitError(generateRedlineDocx(base, revised));
+  }, 60_000);
+
   test("bounds generated operations for highly fragmented formatting changes", async () => {
-    const runCount = 10_001;
+    const runCount = MAX_GENERATED_REDLINE_OPERATIONS + 1;
     const base = await buildFormattedRunDocxBuffer([{ text: "a".repeat(runCount) }], "00000001");
     const revised = await buildFormattedRunDocxBuffer(
       Array.from({ length: runCount }, (_, index) => ({
@@ -402,9 +443,7 @@ describe("generateRedlineDocx", () => {
       "00000001",
     );
 
-    await expect(generateRedlineDocx(base, revised)).rejects.toThrow(
-      "The document comparison exceeds the generated operation limit.",
-    );
+    await expectOperationLimitError(generateRedlineDocx(base, revised));
   });
 
   test("a relocated block redlines as delete + insert and still satisfies both invariants", async () => {

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -36,6 +36,10 @@ import {
   type FolioDocumentPrivacyOptions,
   type FolioDocumentPrivacyReport,
 } from "./docx/metadataPrivacy";
+import {
+  GenerateRedlineDocxOperationLimitError,
+  MAX_GENERATED_REDLINE_OPERATIONS,
+} from "./redlineOperationLimit";
 import { alignFolioBlocks, type FolioAlignedBlockEvent } from "./version-comparison";
 
 /** Options for {@link generateRedlineDocx}. */
@@ -58,12 +62,6 @@ export class InvalidGenerateRedlineDocxOptionsError extends TaggedError(
   option: "baseView" | "revisedView";
   receivedValue: unknown;
 }> {}
-
-class GenerateRedlineDocxOperationLimitError extends TaggedError(
-  "GenerateRedlineDocxOperationLimitError",
-)<{
-  message: string;
-}>() {}
 
 /** A document story that could not be paired across the two input packages. */
 export type GenerateRedlineUnprocessedStory = {
@@ -115,8 +113,6 @@ type RedlineFormattingSegment = {
   endOffset: number;
   formatting: FolioAIInlineFormatting;
 };
-
-const MAX_GENERATED_REDLINE_OPERATIONS = 10_000;
 
 const changedSupportedFormatting = (
   base: FolioAIBlockPreviewRun,

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -59,6 +59,12 @@ export class InvalidGenerateRedlineDocxOptionsError extends TaggedError(
   receivedValue: unknown;
 }> {}
 
+class GenerateRedlineDocxOperationLimitError extends TaggedError(
+  "GenerateRedlineDocxOperationLimitError",
+)<{
+  message: string;
+}>() {}
+
 /** A document story that could not be paired across the two input packages. */
 export type GenerateRedlineUnprocessedStory = {
   /** Story in the base package, or `null` when it exists only in the revision. */
@@ -109,6 +115,8 @@ type RedlineFormattingSegment = {
   endOffset: number;
   formatting: FolioAIInlineFormatting;
 };
+
+const MAX_GENERATED_REDLINE_OPERATIONS = 10_000;
 
 const changedSupportedFormatting = (
   base: FolioAIBlockPreviewRun,
@@ -186,6 +194,11 @@ const formattingSegments = (
       ) {
         previous.endOffset += length;
       } else {
+        if (segments.length >= MAX_GENERATED_REDLINE_OPERATIONS) {
+          throw new GenerateRedlineDocxOperationLimitError({
+            message: "The document comparison exceeds the generated operation limit.",
+          });
+        }
         segments.push({
           startOffset: textOffset,
           endOffset: textOffset + length,
@@ -371,7 +384,14 @@ export const generateRedlineDocx = async (
   const skipped: FolioAIEditSkippedOperation[] = [];
   const unprocessedStories: GenerateRedlineUnprocessedStory[] = [];
   let operationSequence = 0;
-  const nextOperationId = () => `redline-${++operationSequence}`;
+  const nextOperationId = () => {
+    if (operationSequence >= MAX_GENERATED_REDLINE_OPERATIONS) {
+      throw new GenerateRedlineDocxOperationLimitError({
+        message: "The document comparison exceeds the generated operation limit.",
+      });
+    }
+    return `redline-${++operationSequence}`;
+  };
 
   for (const pair of pairFolioDocumentStories(baseStories, revisedStories)) {
     if (!pair.baseStory) {

--- a/packages/core/src/redlineOperationLimit.ts
+++ b/packages/core/src/redlineOperationLimit.ts
@@ -1,0 +1,9 @@
+import { TaggedError } from "better-result";
+
+export const MAX_GENERATED_REDLINE_OPERATIONS = 10_000;
+
+export class GenerateRedlineDocxOperationLimitError extends TaggedError(
+  "GenerateRedlineDocxOperationLimitError",
+)<{
+  message: string;
+}> {}


### PR DESCRIPTION
### Motivation

Generated redline work needs a deterministic upper bound for heavily fragmented or unusually large comparisons.

### Changes

- Cap generated redline operations at 10,000 across ordinary block operations and formatting segments.
- Return one typed operation-limit error from both enforcement paths.
- Keep the limit and tagged error in one internal source shared by implementation and tests.
- Cover the exact 10,000/10,001 boundary and the fragmented-formatting path.
- Add a patch changeset for `@stll/folio-core`.

### Validation

- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run typecheck:budget`
- `bun run test`
- `bun run build`
- `bun run api:check`
- `bun run api:budget`

CC on behalf of jan-kubica