### PR TITLE
fix: escape relationship IDs during OOXML serialization

### DIFF
--- a/.changeset/safe-relationship-ids.md
+++ b/.changeset/safe-relationship-ids.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Escape relationship IDs when serializing OOXML attributes.

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -84,6 +84,28 @@ describe("serializeComments", () => {
     expect(xml).toContain("&quot;");
   });
 
+  test("escapes hyperlink relationship ids in comment content", () => {
+    const comment = makeComment(1);
+    comment.content[0]!.content = [
+      {
+        type: "hyperlink",
+        rId: 'rId1"/><w:r><w:t>injected</w:t></w:r><w:hyperlink r:id="rId2',
+        children: [
+          {
+            type: "run",
+            content: [{ type: "text", text: "linked" }],
+          },
+        ],
+      },
+    ];
+
+    const xml = serializeComments([comment]);
+
+    expect(xml).not.toContain('<w:t>injected</w:t>');
+    expect(xml).toContain('r:id="rId1&quot;/&gt;&lt;w:r&gt;&lt;w:t&gt;injected');
+    expect(xml).toContain('<w:t>linked</w:t>');
+  });
+
   test("round-trips supported paragraph and run formatting in comment content", () => {
     const comment = makeComment(1);
     const paragraph = comment.content[0]!;

--- a/packages/core/src/docx/serializer/commentSerializer.test.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.test.ts
@@ -101,9 +101,9 @@ describe("serializeComments", () => {
 
     const xml = serializeComments([comment]);
 
-    expect(xml).not.toContain('<w:t>injected</w:t>');
+    expect(xml).not.toContain("<w:t>injected</w:t>");
     expect(xml).toContain('r:id="rId1&quot;/&gt;&lt;w:r&gt;&lt;w:t&gt;injected');
-    expect(xml).toContain('<w:t>linked</w:t>');
+    expect(xml).toContain("<w:t>linked</w:t>");
   });
 
   test("round-trips supported paragraph and run formatting in comment content", () => {

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -580,7 +580,7 @@ function serializeHyperlink(hyperlink: Hyperlink): string {
   const attrs: string[] = [];
 
   if (hyperlink.rId) {
-    attrs.push(`r:id="${hyperlink.rId}"`);
+    attrs.push(`r:id="${escapeXml(hyperlink.rId)}"`);
   }
 
   if (hyperlink.anchor) {

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -141,6 +141,28 @@ describe("runSerializer vertical alignment", () => {
   });
 });
 
+describe("runSerializer relationship ids", () => {
+  test("escapes image relationship ids", () => {
+    const xml = serializeRun({
+      type: "run",
+      content: [
+        {
+          type: "drawing",
+          image: {
+            type: "image",
+            rId: 'rId1"/><w:t>injected</w:t><a:blip r:embed="rId2',
+            size: { width: 1, height: 1 },
+            wrap: { type: "inline" },
+          },
+        },
+      ],
+    });
+
+    expect(xml).not.toContain("<w:t>injected</w:t>");
+    expect(xml).toContain('r:embed="rId1&quot;/&gt;&lt;w:t&gt;injected');
+  });
+});
+
 describe("runSerializer emphasis marks", () => {
   test.each(EMPHASIS_MARK_VALUES)("serializes the explicit %s value", (emphasisMark) => {
     const xml = serializeRun({

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -779,7 +779,7 @@ function serializeWrap(wrap: ImageWrap): string {
 function serializePicGraphic(image: Image, sharedId: string): string {
   const cx = image.size.width;
   const cy = image.size.height;
-  const rId = image.rId || "rId1";
+  const rId = escapeXml(image.rId || "rId1");
   const id = sharedId;
   const name = image.filename || `image${id}`;
 

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -29,6 +29,19 @@ describe("parseSectionProperties", () => {
 });
 
 describe("serializeSectionProperties", () => {
+  test("escapes every relationship id attribute", () => {
+    const injectedRelationshipId =
+      'rId1"/><w:r><w:t>injected</w:t></w:r><w:printerSettings r:id="rId2';
+    const xml = serializeSectionProperties({
+      headerReferences: [{ type: "default", rId: injectedRelationshipId }],
+      footerReferences: [{ type: "default", rId: injectedRelationshipId }],
+      printerSettingsRelationshipId: injectedRelationshipId,
+    });
+
+    expect(xml).not.toContain("<w:t>injected</w:t>");
+    expect(xml.match(/r:id="rId1&quot;/gu)).toHaveLength(3);
+  });
+
   test("keeps titlePg before bidi in sectPr order", () => {
     const xml = serializeSectionProperties({
       titlePg: true,

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -12,10 +12,10 @@ import { serializeBorder } from "./borderSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
 
 const serializeHeaderReference = (ref: HeaderReference): string =>
-  `<w:headerReference w:type="${ref.type}" r:id="${ref.rId}"/>`;
+  `<w:headerReference w:type="${ref.type}" r:id="${escapeXml(ref.rId)}"/>`;
 
 const serializeFooterReference = (ref: FooterReference): string =>
-  `<w:footerReference w:type="${ref.type}" r:id="${ref.rId}"/>`;
+  `<w:footerReference w:type="${ref.type}" r:id="${escapeXml(ref.rId)}"/>`;
 
 function serializeFootnoteProperties(props: FootnoteProperties | undefined): string {
   if (!props) {
@@ -399,7 +399,7 @@ export function serializeSectionProperties(props: SectionProperties | undefined)
     }
   }
   if (props.printerSettingsRelationshipId) {
-    parts.push(`<w:printerSettings r:id="${props.printerSettingsRelationshipId}"/>`);
+    parts.push(`<w:printerSettings r:id="${escapeXml(props.printerSettingsRelationshipId)}"/>`);
   }
   for (const change of props.propertyChanges ?? []) {
     parts.push(serializeSectionPropertyChange(change));


### PR DESCRIPTION
### Motivation

Dynamic OOXML relationship IDs cross the XML serialization boundary and must not be emitted as raw attribute values.

### Changes

- Escape hyperlink, embedded-image, header/footer, and printer-settings relationship IDs during serialization.
- Add synthetic regression coverage for every dynamic relationship-ID serializer path.
- Add a patch changeset for `@stll/folio-core`.

### Validation

- `bun run audit`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run typecheck:budget`
- `bun run test`
- `bun run build`
- `bun run api:check`
- `bun run api:budget`

CC on behalf of jan-kubica