### PR TITLE
fix: defer DOCX extraction until validation completes

### DIFF
--- a/.changeset/safe-docx-extraction.md
+++ b/.changeset/safe-docx-extraction.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Defer DOCX ZIP entry extraction until archive validation completes.

--- a/packages/core/src/docx/unzip.ts
+++ b/packages/core/src/docx/unzip.ts
@@ -292,11 +292,11 @@ export async function unzipDocx(
   };
 
   let totalUncompressedBytes = 0;
-  const extractionTasks: Promise<ExtractedEntry | null>[] = [];
+  const extractionTasks: (() => Promise<ExtractedEntry | null>)[] = [];
 
   // Validate the complete package before decompressing accepted entries. The
-  // extraction promises are awaited together so independent ZIP parts do not
-  // pay JSZip's scheduling overhead one at a time.
+  // extraction tasks are started only after validation completes so an early
+  // security rejection cannot leave unobserved decompression promises running.
   for (const [path, file] of entries) {
     if (!isSafeDocxPath(path)) {
       throw new DocxSecurityError("DOCX file contains an unsafe entry path");
@@ -322,7 +322,7 @@ export async function unzipDocx(
       if (options.extractAllXml === false && !shouldExtractXmlPart(lowerPath)) {
         continue;
       }
-      extractionTasks.push(
+      extractionTasks.push(() =>
         file.async("text").then((xmlContent) => {
           assertExtractedSize(path, xmlContent.length, limits.maxXmlBytes);
           return { type: "xml", path, lowerPath, content: xmlContent };
@@ -340,7 +340,7 @@ export async function unzipDocx(
         );
         continue;
       }
-      extractionTasks.push(
+      extractionTasks.push(() =>
         file.async("arraybuffer").then((binaryContent) => {
           if (binaryContent.byteLength > limits.maxMediaBytes) {
             content.warnings.push(
@@ -360,7 +360,7 @@ export async function unzipDocx(
       if (isEntryTooLarge(declaredSize, limits.maxFontBytes)) {
         continue;
       }
-      extractionTasks.push(
+      extractionTasks.push(() =>
         file.async("arraybuffer").then((binaryContent) => {
           if (binaryContent.byteLength > limits.maxFontBytes) {
             return null;
@@ -371,7 +371,7 @@ export async function unzipDocx(
     }
   }
 
-  for (const extracted of await Promise.all(extractionTasks)) {
+  for (const extracted of await Promise.all(extractionTasks.map((extract) => extract()))) {
     if (!extracted) {
       continue;
     }


### PR DESCRIPTION
### Motivation
- The previous batched extraction started `file.async(...)` while still validating later ZIP entries, which could leave decompression promises running or rejected after an early security check throws. 
- The change prevents unobserved/background decompression and enforces that archive path and aggregate-size checks complete before any extraction work begins.

### Description
- Change `extractionTasks` to store deferred extraction thunks (`() => Promise<ExtractedEntry | null>`) instead of starting `file.async(...)` immediately in the validation loop in `packages/core/src/docx/unzip.ts`.
- Push extraction thunks for XML, media, and font entries and start them only after the validation loop using `Promise.all(extractionTasks.map(extract => extract()))` so all validation runs before any decompression begins.
- Add a patch changeset `.changeset/safe-docx-extraction.md` for `@stll/folio-core` describing the fix.

### Testing
- Ran `git diff --check` which succeeded.
- Ran `git diff --cached --check` which succeeded.
- Attempted `bun test packages/core/src/docx/unzip.test.ts` but it failed to run because dependencies were not installed; `bun install` was blocked by npm registry `403` responses so the unit test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62072c219483338df3ab82ed02d45a)