### PR TITLE
fix(core): align bilingual rows with editable snapshot

### DIFF
--- a/.changeset/clean-bilingual-breaks.md
+++ b/.changeset/clean-bilingual-breaks.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Derive bilingual translation manifests from the canonical AI-edit snapshot, preserving structural-only paragraphs while rejecting unaddressable row handles.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -91,6 +91,7 @@ export function createBilingualDocument(source: import__stll_docx_core_model.Doc
 export type CreateBilingualDocumentOptions = {
     targetStyleSuffix: string;
     borders?: BilingualBorders;
+    editableParagraphIds: ReadonlySet<string>;
 };
 
 // @public (undocumented)
@@ -101,7 +102,10 @@ export type CreateBilingualDocumentResult = {
 };
 
 // @public
-export function createBilingualDocx(input: ArrayBuffer | Uint8Array, options: CreateBilingualDocumentOptions): Promise<CreateBilingualDocxResult>;
+export function createBilingualDocx(input: ArrayBuffer | Uint8Array, options: CreateBilingualDocxOptions): Promise<CreateBilingualDocxResult>;
+
+// @public (undocumented)
+export type CreateBilingualDocxOptions = Omit<CreateBilingualDocumentOptions, "editableParagraphIds">;
 
 // @public (undocumented)
 export type CreateBilingualDocxResult = {
@@ -1483,7 +1487,7 @@ export type ParseOptions = {
 };
 
 // @public
-export function readBilingualDocument(document: import__stll_docx_core_model.Document): BilingualRow[];
+export function readBilingualDocument(document: import__stll_docx_core_model.Document, editableParagraphIds: ReadonlySet<string>): BilingualRow[];
 
 // @public
 export function readBilingualDocx(input: ArrayBuffer | Uint8Array): Promise<BilingualRow[]>;

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
+import { FolioDocxReviewer } from "../../ai-edits/headless";
 import { createStellaStyleDocumentPreset } from "../../style-sets/stellaStyle";
 import type {
   BlockContent,
@@ -11,6 +12,7 @@ import type {
   TableCell,
 } from "../../types/document";
 import { createEmptyDocument } from "../../utils/createDocument";
+import { ensureParaIds } from "../ensureParaIds";
 import { parseDocx } from "../parser";
 import { createDocx } from "../rezip";
 import {
@@ -78,8 +80,20 @@ const buildSource = async (): Promise<Document> => {
     paragraph("This Agreement lasts one year.", "ClauseParagraph1"),
   ];
   doc.package.document.content = [...firstSection, sectionBreak, ...secondSection];
-  return parseDocx(await createDocx(doc), { preloadFonts: false });
+  const stamped = await ensureParaIds(await createDocx(doc));
+  return parseDocx(stamped.docx, { preloadFonts: false });
 };
+
+const bilingualDocumentOptions = async (
+  source: Document,
+): Promise<Parameters<typeof createBilingualDocument>[1]> => ({
+  targetStyleSuffix: SUFFIX,
+  editableParagraphIds: new Set(
+    (await FolioDocxReviewer.fromBuffer(source.originalBuffer ?? (await createDocx(source))))
+      .snapshot()
+      .blocks.map(({ id }) => id),
+  ),
+});
 
 const findStyle = (doc: Document, styleId: string): Style | undefined =>
   doc.package.styles?.styles.find((style) => style.styleId === styleId);
@@ -148,7 +162,10 @@ const abstractNumIdOf = (doc: Document, numId: number): number | undefined =>
 describe("createBilingualDocument", () => {
   test("lays every non-empty block out as a two-column row, one table per section", async () => {
     const source = await buildSource();
-    const { document, rows } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const { document, rows } = createBilingualDocument(
+      source,
+      await bilingualDocumentOptions(source),
+    );
 
     const content = document.package.document.content;
     expect(content.map((block) => block.type)).toEqual(["table", "paragraph", "table"]);
@@ -170,7 +187,7 @@ describe("createBilingualDocument", () => {
 
   test("keeps the left column identical to the source blocks", async () => {
     const source = await buildSource();
-    const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const { document } = createBilingualDocument(source, await bilingualDocumentOptions(source));
 
     const sourceParagraphs = source.package.document.content.flatMap((block): Paragraph[] =>
       block.type === "paragraph" && !block.sectionProperties && block.content.length > 0
@@ -182,7 +199,10 @@ describe("createBilingualDocument", () => {
 
   test("keeps a source table once, in a row spanning both columns", async () => {
     const source = await buildSource();
-    const { document, rows } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const { document, rows } = createBilingualDocument(
+      source,
+      await bilingualDocumentOptions(source),
+    );
 
     const allRows = bodyTables(document).flatMap((table) => table.rows);
     const spanningRows = allRows.filter((row) => row.cells.length === 1);
@@ -210,7 +230,7 @@ describe("createBilingualDocument", () => {
 
   test("right column never shares a numbering instance or abstract with the left", async () => {
     const source = await buildSource();
-    const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const { document } = createBilingualDocument(source, await bilingualDocumentOptions(source));
     const { left, right } = columnParagraphs(document);
     expect(right).toHaveLength(left.length);
 
@@ -247,7 +267,7 @@ describe("createBilingualDocument", () => {
 
   test("clones numbered paragraph styles with the suffix and rewrites only their numPr", async () => {
     const source = await buildSource();
-    const { document } = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const { document } = createBilingualDocument(source, await bilingualDocumentOptions(source));
 
     const original = findStyle(source, "ClauseParagraph1");
     const clone = findStyle(document, `ClauseParagraph1-${SUFFIX}`);
@@ -280,8 +300,9 @@ describe("createBilingualDocument", () => {
 
   test("mints stable, unique right-column paraIds and reports them as row handles", async () => {
     const source = await buildSource();
-    const first = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
-    const second = createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    const options = await bilingualDocumentOptions(source);
+    const first = createBilingualDocument(source, options);
+    const second = createBilingualDocument(source, options);
 
     const handles = first.rows.map((row) => row.rowId);
     expect(new Set(handles).size).toBe(handles.length);
@@ -302,15 +323,16 @@ describe("createBilingualDocument", () => {
 
   test("rejects a style suffix that cannot form a style id", async () => {
     const source = await buildSource();
-    expect(() => createBilingualDocument(source, { targetStyleSuffix: "en US" })).toThrow(
-      InvalidBilingualDocumentOptionsError,
-    );
+    const options = await bilingualDocumentOptions(source);
+    expect(() =>
+      createBilingualDocument(source, { ...options, targetStyleSuffix: "en US" }),
+    ).toThrow(InvalidBilingualDocumentOptionsError);
   });
 
   test("does not mutate the source document", async () => {
     const source = await buildSource();
     const snapshot = JSON.stringify({ ...source, originalBuffer: undefined });
-    createBilingualDocument(source, { targetStyleSuffix: SUFFIX });
+    createBilingualDocument(source, await bilingualDocumentOptions(source));
     expect(JSON.stringify({ ...source, originalBuffer: undefined })).toBe(snapshot);
   });
 });
@@ -376,6 +398,111 @@ describe("createBilingualDocx", () => {
     expect(await readBilingualDocx(source.originalBuffer!)).toEqual([]);
   });
 
+  test("keeps structural-only paragraphs out of the editable row manifest", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const columnBreak: Paragraph = {
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "break", breakType: "column" }] }],
+    };
+    source.package.document.content = [
+      paragraph("Before break", "Normal"),
+      columnBreak,
+      paragraph("After break", "Normal"),
+    ];
+
+    const { buffer } = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+    });
+    const rows = await readBilingualDocx(buffer);
+    const editableIds = new Set(
+      (await FolioDocxReviewer.fromBuffer(buffer)).snapshot().blocks.map(({ id }) => id),
+    );
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      if (row.kind === "table") {
+        continue;
+      }
+      expect(row.sourceParaId).toBeDefined();
+      if (row.sourceParaId !== undefined) {
+        expect(editableIds.has(row.sourceParaId)).toBe(true);
+      }
+      expect(editableIds.has(row.targetParaId)).toBe(true);
+    }
+
+    const reparsed = await parseDocx(buffer, { preloadFonts: false });
+    expect(reparsed.package.document.content).toHaveLength(3);
+    expect(reparsed.package.document.content.at(1)).toMatchObject(columnBreak);
+  });
+
+  test("keeps field-only paragraphs out of the editable row manifest", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const fieldOnly: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "complexField",
+          instruction: 'TOC \\o "1-3"',
+          fieldType: "TOC",
+          fieldCode: [],
+          fieldResult: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "Update this field in Word" }],
+            },
+          ],
+        },
+      ],
+    };
+    source.package.document.content = [
+      paragraph("Before field", "Normal"),
+      fieldOnly,
+      paragraph("After field", "Normal"),
+    ];
+
+    const { buffer, rows } = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+    });
+
+    expect(rows).toHaveLength(2);
+    const reparsed = await parseDocx(buffer, { preloadFonts: false });
+    expect(reparsed.package.document.content).toHaveLength(3);
+    expect(reparsed.package.document.content.at(1)).toMatchObject({
+      type: "paragraph",
+      content: [
+        {
+          type: "complexField",
+          instruction: 'TOC \\o "1-3"',
+          fieldResult: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "Update this field in Word" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("refuses a manifest whose handles are absent from the canonical edit snapshot", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    source.package.document.content = [paragraph("Hidden translation row")];
+    const valid = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+    });
+    const malformed = await parseDocx(valid.buffer, { preloadFonts: false });
+    const table = bodyTables(malformed).at(0);
+    const row = table?.rows.at(0);
+    if (!row) {
+      throw new Error("bilingual fixture lost its translation row");
+    }
+    row.formatting = { ...row.formatting, hidden: true };
+
+    await expect(readBilingualDocx(await createDocx(malformed))).rejects.toThrow(
+      "Bilingual manifest contains handles absent from the Folio AI-edit snapshot.",
+    );
+  });
+
   test("materializes a styles part when the source package has none", async () => {
     const source = await buildSource();
     // Strip word/styles.xml and its relationship: legal OOXML, and the path
@@ -418,17 +545,15 @@ describe("createBilingualDocx", () => {
             ) {
               return block;
             }
-            const restyled: Paragraph = {
-              type: "paragraph",
-              content: block.content,
+            const restyled: Paragraph = Object.assign({}, block, {
               formatting: { styleId: "Clause" },
-            };
+            });
             return restyled;
           }),
         },
       },
     };
-    const { document } = createBilingualDocument(styled, { targetStyleSuffix: SUFFIX });
+    const { document } = createBilingualDocument(styled, await bilingualDocumentOptions(styled));
     expect(findStyle(document, `Clause-${SUFFIX}`)).toBeDefined();
 
     const reparsed = await parseDocx(await createDocx(document), { preloadFonts: false });

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -484,6 +484,40 @@ describe("createBilingualDocx", () => {
     });
   });
 
+  test("keeps a structural-only source table out of the editable row manifest", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const structuralTable: Table = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            cell([
+              {
+                type: "paragraph",
+                content: [{ type: "run", content: [{ type: "break", breakType: "column" }] }],
+              },
+            ]),
+          ],
+        },
+      ],
+    };
+    source.package.document.content = [
+      paragraph("Before table"),
+      structuralTable,
+      paragraph("After table"),
+    ];
+
+    const { buffer, rows } = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+    });
+
+    expect(rows).toHaveLength(2);
+    const reparsed = await parseDocx(buffer, { preloadFonts: false });
+    expect(reparsed.package.document.content).toHaveLength(3);
+    expect(reparsed.package.document.content.at(1)).toMatchObject(structuralTable);
+  });
+
   test("refuses a manifest whose handles are absent from the canonical edit snapshot", async () => {
     const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
     source.package.document.content = [paragraph("Hidden translation row")];

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -13,6 +13,8 @@
  * and the break paragraph stays between the tables. A source table (parties,
  * signature block) is kept once, in a row spanning both columns: it is signed
  * and read once, and its labels are translated inline rather than duplicated.
+ * Structural-only paragraphs are also kept once between tables; they have no
+ * independently editable text for a translation row to address.
  */
 
 import { TaggedError } from "better-result";
@@ -80,6 +82,11 @@ export type CreateBilingualDocumentOptions = {
   targetStyleSuffix: string;
   /** Table borders; legal practice is usually `"none"`. Default `"none"`. */
   borders?: BilingualBorders;
+  /**
+   * Paragraph handles exposed by Folio's canonical AI-edit snapshot for the
+   * source DOCX. Only these paragraphs may become translation rows.
+   */
+  editableParagraphIds: ReadonlySet<string>;
 };
 
 export type CreateBilingualDocumentResult = {
@@ -97,10 +104,15 @@ export class InvalidBilingualDocumentOptionsError extends TaggedError(
   message: string;
   option: "targetStyleSuffix";
 }> {}
+class UneditableBilingualManifestError extends TaggedError("UneditableBilingualManifestError")<{
+  message: string;
+  missingHandleCount: number;
+}> {}
 const FULL_WIDTH_PCT = 5000;
 const HALF_WIDTH_PCT = 2500;
 const A4_TEXT_WIDTH_TWIPS = 9072;
 const ROW_ID_NAMESPACE = "folio-bilingual";
+const BILINGUAL_TABLE_STYLE_ID = "FolioBilingualTranslation";
 
 const GRID_BORDER = { style: "single", size: 4, space: 0 } as const;
 
@@ -184,15 +196,25 @@ export function createBilingualDocument(
       if (isEmptyParagraph(block)) {
         continue;
       }
+      if (block.paraId === undefined || !options.editableParagraphIds.has(block.paraId)) {
+        flushSection();
+        content.push(block);
+        continue;
+      }
       const { copy, ref } = copyParagraph(block);
       rows.push({ kind: classifyParagraph(block, styleById), rowId: ref.targetParaId, ...ref });
       sectionRows.push(buildRow(block, copy));
       continue;
     }
-    const paragraphs = collectTableParagraphs(block).map((paragraph) => ({
-      paraId: paragraph.paraId,
-      sourceText: getParagraphText(paragraph),
-    }));
+    const paragraphs = collectTableParagraphs(block)
+      .filter(
+        (paragraph): paragraph is Paragraph & { paraId: string } =>
+          paragraph.paraId !== undefined && options.editableParagraphIds.has(paragraph.paraId),
+      )
+      .map((paragraph) => ({
+        paraId: paragraph.paraId,
+        sourceText: getParagraphText(paragraph),
+      }));
     rows.push({
       kind: "table",
       rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),
@@ -247,10 +269,13 @@ const isEmptyParagraph = (paragraph: Paragraph): boolean => {
   if (getParagraphText(paragraph).trim().length > 0) {
     return false;
   }
-  // Anything that is not a plain text run (drawings, fields, footnote refs,
-  // content controls) keeps the paragraph as a row.
+  // Anything that is not a visible plain-text run (drawings, fields, breaks,
+  // hidden text, content controls) must be preserved rather than discarded.
   return paragraph.content.every(
-    (item) => item.type === "run" && item.content.every((part) => part.type === "text"),
+    (item) =>
+      item.type === "run" &&
+      item.formatting?.hidden !== true &&
+      item.content.every((part) => part.type === "text"),
   );
 };
 
@@ -616,6 +641,7 @@ const buildTable = (rows: Table["rows"], borders: BilingualBorders, textWidth: n
   type: "table",
   formatting: {
     width: { value: FULL_WIDTH_PCT, type: "pct" },
+    styleId: BILINGUAL_TABLE_STYLE_ID,
     layout: "fixed",
     borders: TABLE_BORDERS[borders],
     look: { firstRow: false, firstColumn: false, noHBand: true, noVBand: true },
@@ -706,16 +732,20 @@ const createParaIdMinter = (taken: Set<string>): ParaIdMinter => {
 
 /**
  * Re-derive the row manifest from a document produced by
- * {@link createBilingualDocument}. Detection is structural: a top-level table
- * whose rows are all either a left | right pair of single-paragraph cells or
- * one cell spanning both columns. Rows are returned in document order; the
- * right paragraph's `paraId` is the row handle, as at creation.
+ * {@link createBilingualDocument}. A dedicated table-style discriminator keeps
+ * ordinary two-column source tables from being mistaken for bilingual output;
+ * the expected row structure is validated as a second check. Rows are returned
+ * in document order; the right paragraph's `paraId` is the row handle.
  */
-export function readBilingualDocument(document: Document): BilingualRow[] {
+export function readBilingualDocument(
+  document: Document,
+  editableParagraphIds: ReadonlySet<string>,
+): BilingualRow[] {
   const styleById = new Map(
     (document.package.styles?.styles ?? []).map((style) => [style.styleId, style]),
   );
   const rows: BilingualRow[] = [];
+  let missingHandleCount = 0;
   for (const block of flattenBlocks(document.package.document.content)) {
     if (block.type !== "table" || !isBilingualTable(block)) {
       continue;
@@ -729,6 +759,10 @@ export function readBilingualDocument(document: Document): BilingualRow[] {
         const paragraphs = left.content
           .filter((item): item is Table => item.type === "table")
           .flatMap(collectTableParagraphs)
+          .filter(
+            (paragraph): paragraph is Paragraph & { paraId: string } =>
+              paragraph.paraId !== undefined && editableParagraphIds.has(paragraph.paraId),
+          )
           .map((paragraph) => ({
             paraId: paragraph.paraId,
             sourceText: getParagraphText(paragraph),
@@ -742,7 +776,22 @@ export function readBilingualDocument(document: Document): BilingualRow[] {
       }
       const source = left.content.at(0);
       const target = right.content.at(0);
-      if (source?.type !== "paragraph" || target?.type !== "paragraph" || !target.paraId) {
+      if (source?.type !== "paragraph" || target?.type !== "paragraph") {
+        continue;
+      }
+      if (target.paraId === undefined) {
+        missingHandleCount += 1;
+        continue;
+      }
+      const sourceMissing = source.paraId === undefined || !editableParagraphIds.has(source.paraId);
+      const targetMissing = !editableParagraphIds.has(target.paraId);
+      if (sourceMissing) {
+        missingHandleCount += 1;
+      }
+      if (targetMissing) {
+        missingHandleCount += 1;
+      }
+      if (sourceMissing || targetMissing) {
         continue;
       }
       rows.push({
@@ -754,10 +803,19 @@ export function readBilingualDocument(document: Document): BilingualRow[] {
       });
     }
   }
+  if (missingHandleCount > 0) {
+    throw new UneditableBilingualManifestError({
+      message: "Bilingual manifest contains handles absent from the Folio AI-edit snapshot.",
+      missingHandleCount,
+    });
+  }
   return rows;
 }
 
 const isBilingualTable = (table: Table): boolean => {
+  if (table.formatting?.styleId !== BILINGUAL_TABLE_STYLE_ID) {
+    return false;
+  }
   let pairs = 0;
   for (const row of table.rows) {
     const cells = row.cells;

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -215,6 +215,11 @@ export function createBilingualDocument(
         paraId: paragraph.paraId,
         sourceText: getParagraphText(paragraph),
       }));
+    if (paragraphs.length === 0) {
+      flushSection();
+      content.push(block);
+      continue;
+    }
     rows.push({
       kind: "table",
       rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),

--- a/packages/core/src/docx/server/createBilingualDocx.ts
+++ b/packages/core/src/docx/server/createBilingualDocx.ts
@@ -1,3 +1,5 @@
+import { FolioDocxReviewer } from "../../ai-edits/headless";
+import { toArrayBuffer } from "../../utils/docxInput";
 import { ensureParaIds } from "../ensureParaIds";
 import { parseDocx } from "../parser";
 import { createDocx } from "../rezip";
@@ -7,6 +9,11 @@ import {
   createBilingualDocument,
   readBilingualDocument,
 } from "./createBilingualDocument";
+
+export type CreateBilingualDocxOptions = Omit<
+  CreateBilingualDocumentOptions,
+  "editableParagraphIds"
+>;
 
 export type CreateBilingualDocxResult = {
   buffer: ArrayBuffer;
@@ -23,17 +30,29 @@ export type CreateBilingualDocxResult = {
  */
 export async function createBilingualDocx(
   input: ArrayBuffer | Uint8Array,
-  options: CreateBilingualDocumentOptions,
+  options: CreateBilingualDocxOptions,
 ): Promise<CreateBilingualDocxResult> {
   const stamped = await ensureParaIds(input);
-  const source = await parseDocx(stamped.docx, { preloadFonts: false });
-  const { document, rows, warnings } = createBilingualDocument(source, options);
+  const stampedBuffer = await toArrayBuffer(stamped.docx);
+  const editableParagraphIds = new Set(
+    (await FolioDocxReviewer.fromBuffer(stampedBuffer)).snapshot().blocks.map(({ id }) => id),
+  );
+  const source = await parseDocx(stampedBuffer, { preloadFonts: false });
+  const { document, warnings } = createBilingualDocument(source, {
+    ...options,
+    editableParagraphIds,
+  });
   const buffer = await createDocx(document);
+  const rows = await readBilingualDocx(buffer);
   return { buffer, rows, warnings };
 }
 
 /** Bytes-in form of {@link readBilingualDocument}. */
 export async function readBilingualDocx(input: ArrayBuffer | Uint8Array): Promise<BilingualRow[]> {
-  const document = await parseDocx(input, { preloadFonts: false });
-  return readBilingualDocument(document);
+  const buffer = await toArrayBuffer(input);
+  const document = await parseDocx(buffer, { preloadFonts: false });
+  const editableParagraphIds = new Set(
+    (await FolioDocxReviewer.fromBuffer(buffer)).snapshot().blocks.map(({ id }) => id),
+  );
+  return readBilingualDocument(document, editableParagraphIds);
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -213,6 +213,7 @@ export {
 export {
   createBilingualDocx,
   readBilingualDocx,
+  type CreateBilingualDocxOptions,
   type CreateBilingualDocxResult,
 } from "./docx/server/createBilingualDocx";
 export { DocxArchiveError, type DocxArchiveOptions } from "./docx/server/boundedArchive";


### PR DESCRIPTION
## Summary

- derive bilingual row eligibility from the canonical AI-edit snapshot and validate serialized manifests against the same contract
- preserve structural-only paragraphs once instead of exposing unaddressable translation handles
- mark generated bilingual tables explicitly so ordinary two-column tables are not misclassified
- cover break-only, field-only, and missing-handle cases with synthetic regressions

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bilingual DOCX documents now generate translation rows only for paragraphs marked as editable.
  * Structural and field-only content is preserved without unnecessary translation rows.
  * Bilingual tables are handled consistently, including editable paragraph filtering.
* **Bug Fixes**
  * Improved handling of empty paragraphs and non-text content.
  * Added validation to reject translation manifests containing paragraphs that are not available for editing.
* **Documentation**
  * Updated the public API to reflect the latest bilingual document options and reading requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->