### PR TITLE
chore: update shared npm release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@dd6e8fa51339814159486cd92b5ae3a051eb15d2 # canonical package latest policy
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@7198083e27bdd963cacc0b7d70ca54fe3ec83393 # canonical package latest policy
     with:
       artifact-pattern: npm-tarball-*
       artifact-run-id: ${{ inputs.artifact-run-id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # npm trusted publishing; build scripts ran without this permission.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@5e7e43a3b1f28bf7f2821410185fc7d4469bfead # canonical package latest policy
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@dd6e8fa51339814159486cd92b5ae3a051eb15d2 # canonical package latest policy
     with:
       artifact-pattern: npm-tarball-*
       artifact-run-id: ${{ inputs.artifact-run-id }}


### PR DESCRIPTION
Update the shared npm release workflow pin to immutable commit dd6e8fa51339814159486cd92b5ae3a051eb15d2, which includes five-minute npm registry visibility polling before completing a release. Caller inputs and release semantics stay unchanged.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use the latest approved publishing workflow revision.
  * No changes to release inputs, permissions or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->