### PR TITLE
chore(core): parser and serializer maintenance

### DIFF
--- a/.changeset/parser-serializer-maintenance.md
+++ b/.changeset/parser-serializer-maintenance.md
@@ -1,0 +1,11 @@
+---
+"@stll/folio-core": patch
+---
+
+Escape theme-font, page-background and chapter-separator attributes on save;
+narrow theme-font references and `w:shd` colours at parse; drop the attached
+template reference from saved packages; convert only referenced media, with a
+package-wide decode budget; preflight XML resource limits at unzip and bound
+extracted text; bound `xmlns` declaration values; narrow run hyperlink targets
+in the painter; let the save path materialize a header/footer added through
+`createEmptyHeaderFooter`.

--- a/packages/core/src/docx/__tests__/color-roundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/color-roundtrip.test.ts
@@ -267,3 +267,38 @@ describe("Combined formatting round-trip", () => {
     expect(serialized).toContain('w:color="FF0000"');
   });
 });
+
+// ============================================================================
+// Shading values that are not colours
+// ============================================================================
+
+describe("Shading colour narrowing", () => {
+  // `w:shd/@w:color` and `@w:fill` are ST_HexColor. The pasted-DOM path already
+  // rejected anything else before storing it; the DOCX path stored it verbatim,
+  // and both feed the same rendered style declaration.
+  test("a fill that is not hex digits is dropped", () => {
+    const { formatting, serialized } = roundTrip(
+      '<w:shd w:val="clear" w:fill="red;background-image:url(https://example.com/a)"/>',
+    );
+
+    expect(formatting?.shading?.fill).toBeUndefined();
+    expect(serialized).not.toContain("background-image");
+  });
+
+  test("a pattern colour that is not hex digits is dropped", () => {
+    const { formatting } = roundTrip(
+      '<w:shd w:val="pct25" w:color="not a colour" w:fill="FFFFFF"/>',
+    );
+
+    expect(formatting?.shading?.color).toBeUndefined();
+    expect(formatting?.shading?.fill?.rgb).toBe("FFFFFF");
+  });
+
+  test("auto keeps its meaning", () => {
+    const { formatting } = roundTrip('<w:shd w:val="clear" w:color="auto" w:fill="auto"/>');
+
+    expect(formatting?.shading?.color).toBeUndefined();
+    expect(formatting?.shading?.fill).toBeUndefined();
+    expect(formatting?.shading?.pattern).toBe("clear");
+  });
+});

--- a/packages/core/src/docx/attachedTemplate.test.ts
+++ b/packages/core/src/docx/attachedTemplate.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `word/settings.xml` and its `.rels` part are preserved from the source
+ * package. `w:attachedTemplate` points at a template outside the package
+ * through a `TargetMode="External"` relationship; the document model has no
+ * field for it, so a preserved copy would carry a reference folio can neither
+ * read nor rewrite. Save filters both sides instead of copying them verbatim.
+ */
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "./parser";
+import {
+  createEmptyDocx,
+  removeAttachedTemplateElement,
+  removeExternalRelationships,
+  repackDocx,
+} from "./rezip";
+import { attemptSelectiveSave } from "./selectiveSave";
+
+const SETTINGS_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"' +
+  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+  '<w:defaultTabStop w:val="720"/><w:attachedTemplate r:id="rId1"/></w:settings>';
+
+const SETTINGS_RELS =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1"' +
+  ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate"' +
+  ' Target="https://example.com/template.dotm" TargetMode="External"/>' +
+  "</Relationships>";
+
+describe("attached template reference", () => {
+  test("removeAttachedTemplateElement drops the element in either form", () => {
+    expect(removeAttachedTemplateElement(SETTINGS_XML)).not.toContain("attachedTemplate");
+    expect(removeAttachedTemplateElement(SETTINGS_XML)).toContain('w:defaultTabStop w:val="720"');
+    expect(
+      removeAttachedTemplateElement(
+        '<w:settings><w:attachedTemplate r:id="rId1"></w:attachedTemplate></w:settings>',
+      ),
+    ).toBe("<w:settings></w:settings>");
+    expect(
+      removeAttachedTemplateElement('<w:settings><x:attachedTemplate r:id="rId1"/></w:settings>'),
+    ).toBe("<w:settings></w:settings>");
+  });
+
+  test("removeExternalRelationships keeps package-internal entries", () => {
+    expect(removeExternalRelationships(SETTINGS_RELS)).not.toContain('Id="rId1"');
+
+    const internal =
+      '<Relationships><Relationship Id="rId2" Type="urn:t" Target="styles.xml"/></Relationships>';
+    expect(removeExternalRelationships(internal)).toBe(internal);
+  });
+
+  const seedSource = async (): Promise<ArrayBuffer> => {
+    const seeded = new JSZip();
+    await seeded.loadAsync(await createEmptyDocx());
+    seeded.file("word/settings.xml", SETTINGS_XML);
+    seeded.file("word/_rels/settings.xml.rels", SETTINGS_RELS);
+    return seeded.generateAsync({ type: "arraybuffer" });
+  };
+
+  const expectFiltered = async (out: ArrayBuffer): Promise<void> => {
+    const zip = await JSZip.loadAsync(out);
+    const settings = await zip.file("word/settings.xml")!.async("text");
+    expect(settings).not.toContain("attachedTemplate");
+    expect(settings).toContain('w:defaultTabStop w:val="720"');
+
+    const rels = await zip.file("word/_rels/settings.xml.rels")!.async("text");
+    expect(rels).not.toContain("template.dotm");
+    expect(rels).not.toContain('TargetMode="External"');
+  };
+
+  test("a full repack drops the reference and its relationship", async () => {
+    const doc = await parseDocx(await seedSource(), { preloadFonts: false });
+
+    await expectFiltered(await repackDocx(doc, { updateModifiedDate: false }));
+  });
+
+  test("a selective save drops them the same way", async () => {
+    // Both save paths must emit the same package for the same source.
+    const source = await seedSource();
+    const doc = await parseDocx(source, { preloadFonts: false });
+    const out = await attemptSelectiveSave(doc, source, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(out).not.toBeNull();
+    await expectFiltered(out!);
+  });
+});

--- a/packages/core/src/docx/attachedTemplate.test.ts
+++ b/packages/core/src/docx/attachedTemplate.test.ts
@@ -4,53 +4,90 @@
  * through a `TargetMode="External"` relationship; the document model has no
  * field for it, so a preserved copy would carry a reference folio can neither
  * read nor rewrite. Save filters both sides instead of copying them verbatim.
+ *
+ * The element is resolved by namespace URI plus local name, so the Transitional
+ * and Strict profiles are both covered and a same-named foreign element stays.
+ * Only the relationships the removed elements reference are dropped: the
+ * settings part also carries mail-merge and transform relationships whose
+ * `r:id` values must keep resolving.
  */
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import { parseDocx } from "./parser";
-import {
-  createEmptyDocx,
-  removeAttachedTemplateElement,
-  removeExternalRelationships,
-  repackDocx,
-} from "./rezip";
+import { createEmptyDocx, repackDocx, withoutAttachedTemplate } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
+
+const TRANSITIONAL_W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const TRANSITIONAL_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+const STRICT_W = "http://purl.oclc.org/ooxml/wordprocessingml/main";
+const STRICT_R = "http://purl.oclc.org/ooxml/officeDocument/relationships";
 
 const SETTINGS_XML =
   '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
-  '<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"' +
-  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+  `<w:settings xmlns:w="${TRANSITIONAL_W}" xmlns:r="${TRANSITIONAL_R}">` +
   '<w:defaultTabStop w:val="720"/><w:attachedTemplate r:id="rId1"/></w:settings>';
+
+const relationship = (id: string, type: string, target: string): string =>
+  `<Relationship Id="${id}"` +
+  ` Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/${type}"` +
+  ` Target="${target}" TargetMode="External"/>`;
 
 const SETTINGS_RELS =
   '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
   '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
-  '<Relationship Id="rId1"' +
-  ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate"' +
-  ' Target="https://example.com/template.dotm" TargetMode="External"/>' +
+  relationship("rId1", "attachedTemplate", "https://example.com/template.dotm") +
+  relationship("rId2", "mailMergeSource", "https://example.com/recipients.csv") +
   "</Relationships>";
 
 describe("attached template reference", () => {
-  test("removeAttachedTemplateElement drops the element in either form", () => {
-    expect(removeAttachedTemplateElement(SETTINGS_XML)).not.toContain("attachedTemplate");
-    expect(removeAttachedTemplateElement(SETTINGS_XML)).toContain('w:defaultTabStop w:val="720"');
-    expect(
-      removeAttachedTemplateElement(
-        '<w:settings><w:attachedTemplate r:id="rId1"></w:attachedTemplate></w:settings>',
-      ),
-    ).toBe("<w:settings></w:settings>");
-    expect(
-      removeAttachedTemplateElement('<w:settings><x:attachedTemplate r:id="rId1"/></w:settings>'),
-    ).toBe("<w:settings></w:settings>");
+  test("removes the Transitional element and only the relationship it names", () => {
+    const filtered = withoutAttachedTemplate(SETTINGS_XML, SETTINGS_RELS);
+
+    expect(filtered.settingsXml).not.toContain("attachedTemplate");
+    expect(filtered.settingsXml).toContain('w:defaultTabStop w:val="720"');
+    // A mail-merge source is a separate settings relationship; its `r:id` must
+    // keep resolving after the template reference goes.
+    expect(filtered.relsXml).not.toContain("template.dotm");
+    expect(filtered.relsXml).toContain('Id="rId2"');
+    expect(filtered.relsXml).toContain("recipients.csv");
   });
 
-  test("removeExternalRelationships keeps package-internal entries", () => {
-    expect(removeExternalRelationships(SETTINGS_RELS)).not.toContain('Id="rId1"');
+  test("removes the Strict element", () => {
+    const strict =
+      `<settings xmlns="${STRICT_W}" xmlns:r="${STRICT_R}">` +
+      '<defaultTabStop w:val="720" xmlns:w="' +
+      STRICT_W +
+      '"/><attachedTemplate r:id="rId1"/></settings>';
 
-    const internal =
-      '<Relationships><Relationship Id="rId2" Type="urn:t" Target="styles.xml"/></Relationships>';
-    expect(removeExternalRelationships(internal)).toBe(internal);
+    expect(withoutAttachedTemplate(strict, undefined).settingsXml).not.toContain(
+      "attachedTemplate",
+    );
+  });
+
+  test("keeps a same-named element from a foreign namespace", () => {
+    const foreign =
+      `<w:settings xmlns:w="${TRANSITIONAL_W}" xmlns:r="${TRANSITIONAL_R}" xmlns:x="urn:example:ext">` +
+      '<x:attachedTemplate r:id="rId1"/></w:settings>';
+
+    // No WordprocessingML element matched, so neither part is rewritten.
+    expect(withoutAttachedTemplate(foreign, SETTINGS_RELS)).toEqual({
+      settingsXml: undefined,
+      relsXml: undefined,
+    });
+  });
+
+  test("removes a paired element and leaves an unrelated part untouched", () => {
+    const paired =
+      `<w:settings xmlns:w="${TRANSITIONAL_W}" xmlns:r="${TRANSITIONAL_R}">` +
+      '<w:attachedTemplate r:id="rId1"></w:attachedTemplate></w:settings>';
+
+    expect(withoutAttachedTemplate(paired, undefined).settingsXml).toBe(
+      `<w:settings xmlns:w="${TRANSITIONAL_W}" xmlns:r="${TRANSITIONAL_R}"></w:settings>`,
+    );
+    expect(
+      withoutAttachedTemplate('<w:settings xmlns:w="' + TRANSITIONAL_W + '"/>', undefined),
+    ).toEqual({ settingsXml: undefined, relsXml: undefined });
   });
 
   const seedSource = async (): Promise<ArrayBuffer> => {
@@ -69,7 +106,7 @@ describe("attached template reference", () => {
 
     const rels = await zip.file("word/_rels/settings.xml.rels")!.async("text");
     expect(rels).not.toContain("template.dotm");
-    expect(rels).not.toContain('TargetMode="External"');
+    expect(rels).toContain("recipients.csv");
   };
 
   test("a full repack drops the reference and its relationship", async () => {

--- a/packages/core/src/docx/header-vml-emf.test.ts
+++ b/packages/core/src/docx/header-vml-emf.test.ts
@@ -34,6 +34,26 @@ describe("parseDocx — header with EMF media", () => {
     expect(getHeaderFooterVerbatimXml(header!)).toContain("<w:object");
   });
 
+  test("media outside the relationship graph is stored without conversion", async () => {
+    // Conversion is driven by references, not by what the ZIP happens to hold:
+    // a `word/media/` entry no relationship points at is kept byte for byte so
+    // the round-trip is unchanged, but nothing decodes or re-encodes it.
+    const zip = await JSZip.loadAsync(load(FIXTURE));
+    const referencedBytes = await zip.file("word/media/image1.emf")!.async("uint8array");
+    zip.file("word/media/orphan.emf", referencedBytes);
+    const seeded = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(seeded, { preloadFonts: false });
+
+    const referenced = doc.package.media?.get("word/media/image1.emf");
+    expect(referenced?.dataUrl?.startsWith("data:image/png")).toBe(true);
+
+    const orphan = doc.package.media?.get("word/media/orphan.emf");
+    expect(orphan).toBeDefined();
+    expect(orphan!.data.byteLength).toBe(referencedBytes.byteLength);
+    expect(orphan!.dataUrl?.startsWith("data:image/x-emf")).toBe(true);
+  });
+
   test("mediaResolver hook can override the display URL", async () => {
     const seen: string[] = [];
     const doc = await parseDocx(load(FIXTURE), {

--- a/packages/core/src/docx/headerFooterMaterialize.test.ts
+++ b/packages/core/src/docx/headerFooterMaterialize.test.ts
@@ -27,6 +27,7 @@ import {
   validateDocx,
 } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
+import { createEmptyHeaderFooter } from "../utils/headerFooter";
 import { unzipDocx } from "./unzip";
 
 const headerWithInlineImage = (rId: string): HeaderFooter => ({
@@ -262,5 +263,42 @@ describe("header/footer part materialization on save", () => {
     ).join("\n");
     expect(allHeaderXml).toContain("HEADER-ONE");
     expect(allHeaderXml).toContain("HEADER-TWO");
+  });
+
+  test("materializes a header added through createEmptyHeaderFooter", async () => {
+    // The editor's add-header flow enters through `createEmptyHeaderFooter`,
+    // which leaves the new part unmaterialized. Anything that mints the
+    // relationship earlier makes `hasUnmaterializedHeaderFooter` false, and the
+    // save then writes neither the `.rels` entry nor the content-type override
+    // while `w:headerReference` still names the rId.
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      marginTop: 1440,
+    };
+
+    const withHeader = createEmptyHeaderFooter(doc, "header", false);
+    expect(withHeader).not.toBeNull();
+    expect(hasUnmaterializedHeaderFooter(withHeader!)).toBe(true);
+
+    const rId = [...(withHeader!.package.headers?.keys() ?? [])][0]!;
+    const out = await repackDocx(withHeader!, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const headerPath = Object.keys(zip.files).find((p) => /^word\/header\d+\.xml$/u.test(p));
+    expect(headerPath).toBeDefined();
+
+    const documentXml = await zip.file("word/document.xml")!.async("text");
+    expect(documentXml).toContain(`r:id="${rId}"`);
+
+    const rels = await zip.file("word/_rels/document.xml.rels")!.async("text");
+    expect(rels).toContain(`Id="${rId}"`);
+    expect(rels).toContain(`Target="${headerPath!.replace(/^word\//u, "")}"`);
+
+    expect(await zip.file("[Content_Types].xml")!.async("text")).toContain(
+      `PartName="/${headerPath}"`,
+    );
   });
 });

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -64,6 +64,7 @@ import { consolidateParagraphContent } from "./runConsolidator";
 import { parseRun, parseRunProperties } from "./runParser";
 import { parseSdtProperties } from "./sdtProperties";
 import { parseSectionProperties } from "./sectionParser";
+import { isValidHexColor } from "../utils/colorResolver";
 import type { StyleMap } from "./styleParser";
 import {
   findChild,
@@ -165,13 +166,16 @@ function parseShadingProperties(shd: XmlElement | null): ShadingProperties | und
 
   const props: ShadingProperties = {};
 
+  // `w:color` and `w:fill` are ST_HexColor: `auto` or hex digits. Both values
+  // are resolved straight into a rendered style declaration, so a value that is
+  // not a colour is dropped here rather than carried through the model.
   const color = getAttribute(shd, "w", "color");
-  if (color && color !== "auto") {
+  if (color && color !== "auto" && isValidHexColor(color)) {
     props.color = { rgb: color };
   }
 
   const fill = getAttribute(shd, "w", "fill");
-  if (fill && fill !== "auto") {
+  if (fill && fill !== "auto" && isValidHexColor(fill)) {
     props.fill = { rgb: fill };
   }
 

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -35,7 +35,11 @@ import type {
 import { toArrayBuffer } from "../utils/docxInput";
 import type { DocxInput } from "../utils/docxInput";
 import { loadFontsWithMapping } from "../utils/fontLoader";
-import { convertTiffToPngDataUrl, isTiffMimeType } from "../utils/tiffConverter";
+import {
+  convertTiffToPngDataUrl,
+  isTiffMimeType,
+  MAX_PACKAGE_TIFF_PIXELS,
+} from "../utils/tiffConverter";
 import { parseComments } from "./commentParser";
 import { normalizeCommentReferences } from "./commentReferenceNormalization";
 import { detectDocxConformanceClass } from "./conformance";
@@ -477,16 +481,48 @@ function copyBytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return buffer;
 }
 
+/**
+ * Media paths reachable from the package relationship graph: the document's own
+ * relationships plus every `.rels` part the unzip kept. Entries outside it are
+ * still stored so a round-trip keeps their bytes, but nothing decodes them.
+ */
+function collectReferencedMediaPaths(raw: RawDocxContent, rels: RelationshipMap): Set<string> {
+  const referenced = new Set<string>();
+
+  const addTargets = (map: RelationshipMap, relsPath: string): void => {
+    for (const relationship of map.values()) {
+      if (!relationship.target || relationship.targetMode === "External") {
+        continue;
+      }
+      const partPath = resolveRelativePath(relsPath, relationship.target);
+      referenced.add(partPath.toLowerCase());
+      referenced.add(partPath.replace(/^word\//u, "").toLowerCase());
+    }
+  };
+
+  addTargets(rels, DOCUMENT_RELATIONSHIPS_PATH);
+  for (const [path, xml] of raw.allXml.entries()) {
+    if (path.toLowerCase().endsWith(".rels")) {
+      addTargets(parseRelationships(xml), path);
+    }
+  }
+
+  return referenced;
+}
+
 async function buildMediaMap(
   raw: RawDocxContent,
-  _rels: RelationshipMap,
+  rels: RelationshipMap,
 ): Promise<Map<string, MediaFile>> {
   const media = new Map<string, MediaFile>();
+  const referenced = collectReferencedMediaPaths(raw, rels);
+  let remainingTiffPixels = MAX_PACKAGE_TIFF_PIXELS;
 
   // Process each media file
   for (const [path, data] of raw.media.entries()) {
     const filename = path.split("/").pop() || path;
     const mimeType = getMediaMimeType(path);
+    const isReferenced = referenced.has(path.toLowerCase());
 
     // TIFF: browsers don't render TIFF in <img>, so decode + re-encode as
     // PNG eagerly. The mimeType, data, and filename extension are all
@@ -495,10 +531,11 @@ async function buildMediaMap(
     // dimensions exceed the safety cap), fall through to lazy attachment
     // with the original TIFF data — the round-trip survives even if the
     // in-browser preview is broken.
-    if (isTiffMimeType(mimeType)) {
+    if (isReferenced && isTiffMimeType(mimeType) && remainingTiffPixels > 0) {
       // oxlint-disable-next-line no-await-in-loop -- TIFF decode uses a shared Canvas; conversions must stay serialized to avoid contention
-      const converted = await convertTiffToPngDataUrl(data);
+      const converted = await convertTiffToPngDataUrl(data, remainingTiffPixels);
       if (converted) {
+        remainingTiffPixels -= converted.pixels;
         const mediaFile: MediaFile = {
           path,
           filename: filename.replace(/\.tiff?$/iu, ".png"),
@@ -515,7 +552,8 @@ async function buildMediaMap(
       }
     }
 
-    const raster = isMetafileMimeType(mimeType) ? extractMetafileRaster(data) : null;
+    const raster =
+      isReferenced && isMetafileMimeType(mimeType) ? extractMetafileRaster(data) : null;
     if (raster) {
       const mediaFile: MediaFile = {
         path,

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -874,6 +874,8 @@ const finishRepack = async ({
 
   await serializeCommentsToZip(document, outputZip, compressionLevel);
 
+  await dropAttachedTemplateReference(outputZip, compressionLevel);
+
   if (updateModifiedDate && originalCorePropertiesXml) {
     const updatedCoreProperties = updateCoreProperties(originalCorePropertiesXml, {
       updateModifiedDate,
@@ -1039,6 +1041,8 @@ export async function repackDocxFromRaw(
   // Serialize comments
   await serializeCommentsToZip(exportDocument, newZip, compressionLevel);
 
+  await dropAttachedTemplateReference(newZip, compressionLevel);
+
   // Optionally update core properties
   if (updateModifiedDate && rawContent.corePropsXml) {
     const updatedCoreProps = updateCoreProperties(rawContent.corePropsXml, {
@@ -1106,6 +1110,70 @@ export function addCommentsExtendedRelationship(relsXml: string): string {
 
 export function removeCommentsExtendedRelationship(relsXml: string): string {
   return relsXml.replace(/<Relationship\b[^>]*commentsExtended\.xml[^>]*\/>/giu, "");
+}
+
+// ============================================================================
+// SETTINGS PART: ATTACHED TEMPLATE REFERENCE
+// ============================================================================
+
+const SETTINGS_PART = "word/settings.xml";
+const SETTINGS_RELS_PART = "word/_rels/settings.xml.rels";
+
+// The element carries no children and may use any prefix bound to the
+// WordprocessingML namespace, so the local name is matched prefix-agnostically.
+// Applied only to `word/settings.xml`, where `attachedTemplate` is unambiguous.
+const ATTACHED_TEMPLATE_ELEMENT =
+  /<(?:[\w.-]+:)?attachedTemplate\b[^>]*?(?:\/>|>\s*<\/(?:[\w.-]+:)?attachedTemplate>)/giu;
+
+const EXTERNAL_TARGET_MODE = /TargetMode\s*=\s*(?<quote>["'])External\k<quote>/iu;
+
+/** Drop `w:attachedTemplate` from a `word/settings.xml` payload. */
+export function removeAttachedTemplateElement(settingsXml: string): string {
+  return settingsXml.replace(ATTACHED_TEMPLATE_ELEMENT, "");
+}
+
+/** Drop every `TargetMode="External"` entry from a `.rels` payload. */
+export function removeExternalRelationships(relsXml: string): string {
+  return relsXml.replace(/<Relationship\b[^>]*?(?:\/>|>\s*<\/Relationship>)/giu, (relationship) =>
+    EXTERNAL_TARGET_MODE.test(relationship) ? "" : relationship,
+  );
+}
+
+/**
+ * The settings part and its relationships are otherwise copied from the source
+ * package byte for byte. `w:attachedTemplate` resolves through a relationship
+ * whose target sits outside the package (`TargetMode="External"`); the document
+ * model has no field for it, so a preserved copy would carry a reference folio
+ * can neither read nor rewrite. Both sides are filtered on save: the element in
+ * `word/settings.xml` and every external relationship in its `.rels` part.
+ * Hyperlink and external-image relationships live in other `.rels` parts and
+ * are untouched.
+ */
+async function dropAttachedTemplateReference(zip: JSZip, compressionLevel: number): Promise<void> {
+  const settingsFile = zip.file(SETTINGS_PART);
+  if (settingsFile) {
+    const settingsXml = await settingsFile.async("text");
+    const filtered = removeAttachedTemplateElement(settingsXml);
+    if (filtered !== settingsXml) {
+      zip.file(SETTINGS_PART, filtered, {
+        compression: "DEFLATE",
+        compressionOptions: { level: compressionLevel },
+      });
+    }
+  }
+
+  const relsFile = zip.file(SETTINGS_RELS_PART);
+  if (!relsFile) {
+    return;
+  }
+  const relsXml = await relsFile.async("text");
+  const filteredRels = removeExternalRelationships(relsXml);
+  if (filteredRels !== relsXml) {
+    zip.file(SETTINGS_RELS_PART, filteredRels, {
+      compression: "DEFLATE",
+      compressionOptions: { level: compressionLevel },
+    });
+  }
 }
 
 /**

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -83,11 +83,13 @@ import { isPreservableDocxEntry } from "./unzip";
 import type { RawDocxContent } from "./unzip";
 import {
   findChild,
+  getAttribute,
   getChildElements,
   getLocalName,
   getNamespaceUri,
   matchesName,
   parseXml,
+  parseXmlDocument,
   WORDPROCESSINGML_NAMESPACE_URIS,
   type XmlElement,
 } from "./xmlParser";
@@ -1119,24 +1121,92 @@ export function removeCommentsExtendedRelationship(relsXml: string): string {
 const SETTINGS_PART = "word/settings.xml";
 const SETTINGS_RELS_PART = "word/_rels/settings.xml.rels";
 
-// The element carries no children and may use any prefix bound to the
-// WordprocessingML namespace, so the local name is matched prefix-agnostically.
-// Applied only to `word/settings.xml`, where `attachedTemplate` is unambiguous.
+const ATTACHED_TEMPLATE_LOCAL_NAME = "attachedTemplate";
+
+// Candidate spans in the raw payload. Which of them are actually removed is
+// decided from the parsed tree, not from the prefix these patterns capture.
 const ATTACHED_TEMPLATE_ELEMENT =
-  /<(?:[\w.-]+:)?attachedTemplate\b[^>]*?(?:\/>|>\s*<\/(?:[\w.-]+:)?attachedTemplate>)/giu;
+  /<(?<prefix>[\w.-]+:)?attachedTemplate\b[^>]*?(?:\/>|>\s*<\/(?:[\w.-]+:)?attachedTemplate>)/giu;
 
-const EXTERNAL_TARGET_MODE = /TargetMode\s*=\s*(?<quote>["'])External\k<quote>/iu;
+const RELATIONSHIP_ELEMENT = /<Relationship\b[^>]*?(?:\/>|>\s*<\/Relationship>)/giu;
 
-/** Drop `w:attachedTemplate` from a `word/settings.xml` payload. */
-export function removeAttachedTemplateElement(settingsXml: string): string {
-  return settingsXml.replace(ATTACHED_TEMPLATE_ELEMENT, "");
+// `Id` is spelled exactly that way in the package relationships schema.
+const RELATIONSHIP_ID_ATTRIBUTE = /\bId\s*=\s*(?<quote>["'])(?<value>[^"']*)\k<quote>/u;
+
+/** Result of filtering the settings part; `undefined` means "leave as it is". */
+type SettingsWithoutAttachedTemplate = {
+  settingsXml: string | undefined;
+  relsXml: string | undefined;
+};
+
+/**
+ * Drop `w:attachedTemplate` from a `word/settings.xml` payload together with the
+ * relationships it resolves through.
+ *
+ * The elements are located in the parsed tree by namespace URI plus local name,
+ * so both the Transitional and the Strict WordprocessingML namespace are
+ * covered and a same-named element from a foreign namespace is left alone. Only
+ * the relationship ids those elements reference are removed from the `.rels`
+ * part: the settings part may also carry mail-merge and transform
+ * relationships, and their `r:id` values must keep resolving.
+ *
+ * The removal itself is a byte splice, so everything else in both parts
+ * round-trips exactly as authored.
+ */
+export function withoutAttachedTemplate(
+  settingsXml: string,
+  relsXml: string | undefined,
+): SettingsWithoutAttachedTemplate {
+  const root = parseXmlDocument(settingsXml);
+  if (!root) {
+    return { settingsXml: undefined, relsXml: undefined };
+  }
+
+  // Prefixes (empty string for the default namespace) that actually bind to
+  // WordprocessingML on an `attachedTemplate` element in this part.
+  const prefixes = new Set<string>();
+  const referencedRIds = new Set<string>();
+  for (const element of getChildElements(root)) {
+    if (
+      getLocalName(element.name) !== ATTACHED_TEMPLATE_LOCAL_NAME ||
+      !WORDPROCESSINGML_NAMESPACE_URIS.has(getNamespaceUri(element) ?? "")
+    ) {
+      continue;
+    }
+    const name = element.name ?? "";
+    const separatorIndex = name.indexOf(":");
+    prefixes.add(separatorIndex === -1 ? "" : name.slice(0, separatorIndex));
+    const rId = getAttribute(element, "r", "id");
+    if (rId) {
+      referencedRIds.add(rId);
+    }
+  }
+
+  if (prefixes.size === 0) {
+    return { settingsXml: undefined, relsXml: undefined };
+  }
+
+  const filteredSettings = settingsXml.replace(
+    ATTACHED_TEMPLATE_ELEMENT,
+    (match, prefix: string | undefined) => (prefixes.has(prefix?.slice(0, -1) ?? "") ? "" : match),
+  );
+
+  return {
+    settingsXml: filteredSettings === settingsXml ? undefined : filteredSettings,
+    relsXml: relsXml === undefined ? undefined : withoutRelationships(relsXml, referencedRIds),
+  };
 }
 
-/** Drop every `TargetMode="External"` entry from a `.rels` payload. */
-export function removeExternalRelationships(relsXml: string): string {
-  return relsXml.replace(/<Relationship\b[^>]*?(?:\/>|>\s*<\/Relationship>)/giu, (relationship) =>
-    EXTERNAL_TARGET_MODE.test(relationship) ? "" : relationship,
-  );
+/** Drop the named relationships from a `.rels` payload; `undefined` when unchanged. */
+function withoutRelationships(relsXml: string, ids: ReadonlySet<string>): string | undefined {
+  if (ids.size === 0) {
+    return undefined;
+  }
+  const filtered = relsXml.replace(RELATIONSHIP_ELEMENT, (relationship) => {
+    const id = RELATIONSHIP_ID_ATTRIBUTE.exec(relationship)?.groups?.["value"];
+    return id !== undefined && ids.has(id) ? "" : relationship;
+  });
+  return filtered === relsXml ? undefined : filtered;
 }
 
 /**
@@ -1144,32 +1214,27 @@ export function removeExternalRelationships(relsXml: string): string {
  * package byte for byte. `w:attachedTemplate` resolves through a relationship
  * whose target sits outside the package (`TargetMode="External"`); the document
  * model has no field for it, so a preserved copy would carry a reference folio
- * can neither read nor rewrite. Both sides are filtered on save: the element in
- * `word/settings.xml` and every external relationship in its `.rels` part.
- * Hyperlink and external-image relationships live in other `.rels` parts and
- * are untouched.
+ * can neither read nor rewrite. Both sides are filtered on save.
  */
 async function dropAttachedTemplateReference(zip: JSZip, compressionLevel: number): Promise<void> {
   const settingsFile = zip.file(SETTINGS_PART);
-  if (settingsFile) {
-    const settingsXml = await settingsFile.async("text");
-    const filtered = removeAttachedTemplateElement(settingsXml);
-    if (filtered !== settingsXml) {
-      zip.file(SETTINGS_PART, filtered, {
-        compression: "DEFLATE",
-        compressionOptions: { level: compressionLevel },
-      });
-    }
-  }
-
-  const relsFile = zip.file(SETTINGS_RELS_PART);
-  if (!relsFile) {
+  if (!settingsFile) {
     return;
   }
-  const relsXml = await relsFile.async("text");
-  const filteredRels = removeExternalRelationships(relsXml);
-  if (filteredRels !== relsXml) {
-    zip.file(SETTINGS_RELS_PART, filteredRels, {
+  const relsFile = zip.file(SETTINGS_RELS_PART);
+  const filtered = withoutAttachedTemplate(
+    await settingsFile.async("text"),
+    await relsFile?.async("text"),
+  );
+
+  if (filtered.settingsXml !== undefined) {
+    zip.file(SETTINGS_PART, filtered.settingsXml, {
+      compression: "DEFLATE",
+      compressionOptions: { level: compressionLevel },
+    });
+  }
+  if (filtered.relsXml !== undefined) {
+    zip.file(SETTINGS_RELS_PART, filtered.relsXml, {
       compression: "DEFLATE",
       compressionOptions: { level: compressionLevel },
     });

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -64,6 +64,7 @@ import { isTextBoxDrawing } from "./textBoxParser";
 import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
 import { requiresXmlSpacePreserve } from "./textWhitespace";
+import { isValidHexColor } from "../utils/colorResolver";
 import {
   cloneWithXmlnsDeclarations,
   findAllDeep,
@@ -134,13 +135,16 @@ function parseShadingProperties(shd: XmlElement | null): ShadingProperties | und
 
   const props: ShadingProperties = {};
 
+  // `w:color` and `w:fill` are ST_HexColor: `auto` or hex digits. Both values
+  // are resolved straight into a rendered style declaration, so a value that is
+  // not a colour is dropped here rather than carried through the model.
   const color = getAttribute(shd, "w", "color");
-  if (color && color !== "auto") {
+  if (color && color !== "auto" && isValidHexColor(color)) {
     props.color = { rgb: color };
   }
 
   const fill = getAttribute(shd, "w", "fill");
-  if (fill && fill !== "auto") {
+  if (fill && fill !== "auto" && isValidHexColor(fill)) {
     props.fill = { rgb: fill };
   }
 
@@ -508,7 +512,7 @@ export function parseRunProperties(
       }
     }
 
-    const hAnsiTheme = getAttribute(rFonts, "w", "hAnsiTheme");
+    const hAnsiTheme = narrowEnum(getAttribute(rFonts, "w", "hAnsiTheme"), FontThemeSchema);
     if (hAnsiTheme) {
       fontFamily.hAnsiTheme = hAnsiTheme;
       if (theme && !fontFamily.hAnsi) {
@@ -519,7 +523,7 @@ export function parseRunProperties(
       }
     }
 
-    const eastAsiaTheme = getAttribute(rFonts, "w", "eastAsiaTheme");
+    const eastAsiaTheme = narrowEnum(getAttribute(rFonts, "w", "eastAsiaTheme"), FontThemeSchema);
     if (eastAsiaTheme) {
       fontFamily.eastAsiaTheme = eastAsiaTheme;
       if (theme && !fontFamily.eastAsia) {
@@ -530,7 +534,7 @@ export function parseRunProperties(
       }
     }
 
-    const csTheme = getAttribute(rFonts, "w", "cstheme");
+    const csTheme = narrowEnum(getAttribute(rFonts, "w", "cstheme"), FontThemeSchema);
     if (csTheme) {
       fontFamily.csTheme = csTheme;
       if (theme && !fontFamily.cs) {

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -32,6 +32,8 @@ import {
   COMMENTS_EXTENDED_PART_LOWER,
   addCommentsExtendedOverride,
   addCommentsExtendedRelationship,
+  removeAttachedTemplateElement,
+  removeExternalRelationships,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
 import {
@@ -365,6 +367,32 @@ export type SelectiveSaveOptions = {
  * Returns the saved ArrayBuffer, or null if selective save is not possible
  * (caller should fall back to full repack).
  */
+/**
+ * Queue the filtered `word/settings.xml` and `word/_rels/settings.xml.rels`
+ * when the source package carries an attached-template reference. Mirrors
+ * `dropAttachedTemplateReference` on the full-repack path.
+ */
+const queueSettingsUpdates = async (zip: JSZip, updates: Map<string, string>): Promise<void> => {
+  const settingsFile = zip.file("word/settings.xml");
+  if (settingsFile) {
+    const settingsXml = await settingsFile.async("text");
+    const filtered = removeAttachedTemplateElement(settingsXml);
+    if (filtered !== settingsXml) {
+      updates.set("word/settings.xml", filtered);
+    }
+  }
+
+  const relsFile = zip.file("word/_rels/settings.xml.rels");
+  if (!relsFile) {
+    return;
+  }
+  const relsXml = await relsFile.async("text");
+  const filteredRels = removeExternalRelationships(relsXml);
+  if (filteredRels !== relsXml) {
+    updates.set("word/_rels/settings.xml.rels", filteredRels);
+  }
+};
+
 export async function attemptSelectiveSave(
   doc: Document,
   originalBuffer: ArrayBuffer,
@@ -562,6 +590,10 @@ export async function attemptSelectiveSave(
     for (const [path, xml] of headerFooterUpdates) {
       updates.set(path, xml);
     }
+
+    // Same settings filtering the full-repack path applies, so both saves emit
+    // the same package for a source carrying an attached-template reference.
+    await queueSettingsUpdates(zip, updates);
 
     // Update modification date in docProps/core.xml
     const corePropsFile = zip.file("docProps/core.xml");

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -32,8 +32,7 @@ import {
   COMMENTS_EXTENDED_PART_LOWER,
   addCommentsExtendedOverride,
   addCommentsExtendedRelationship,
-  removeAttachedTemplateElement,
-  removeExternalRelationships,
+  withoutAttachedTemplate,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
 import {
@@ -369,27 +368,26 @@ export type SelectiveSaveOptions = {
  */
 /**
  * Queue the filtered `word/settings.xml` and `word/_rels/settings.xml.rels`
- * when the source package carries an attached-template reference. Mirrors
- * `dropAttachedTemplateReference` on the full-repack path.
+ * when the source package carries an attached-template reference. Shares
+ * `withoutAttachedTemplate` with the full-repack path so both saves emit the
+ * same package for the same source.
  */
 const queueSettingsUpdates = async (zip: JSZip, updates: Map<string, string>): Promise<void> => {
   const settingsFile = zip.file("word/settings.xml");
-  if (settingsFile) {
-    const settingsXml = await settingsFile.async("text");
-    const filtered = removeAttachedTemplateElement(settingsXml);
-    if (filtered !== settingsXml) {
-      updates.set("word/settings.xml", filtered);
-    }
-  }
-
-  const relsFile = zip.file("word/_rels/settings.xml.rels");
-  if (!relsFile) {
+  if (!settingsFile) {
     return;
   }
-  const relsXml = await relsFile.async("text");
-  const filteredRels = removeExternalRelationships(relsXml);
-  if (filteredRels !== relsXml) {
-    updates.set("word/_rels/settings.xml.rels", filteredRels);
+  const relsFile = zip.file("word/_rels/settings.xml.rels");
+  const filtered = withoutAttachedTemplate(
+    await settingsFile.async("text"),
+    await relsFile?.async("text"),
+  );
+
+  if (filtered.settingsXml !== undefined) {
+    updates.set("word/settings.xml", filtered.settingsXml);
+  }
+  if (filtered.relsXml !== undefined) {
+    updates.set("word/_rels/settings.xml.rels", filtered.relsXml);
   }
 };
 

--- a/packages/core/src/docx/serializer/attributeEscaping.test.ts
+++ b/packages/core/src/docx/serializer/attributeEscaping.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Attribute values that reach the serializer from parsed input must be
+ * escaped, and OOXML enum attributes must be narrowed where they are read.
+ *
+ * `w:rFonts` carries four theme-font references. `w:asciiTheme` was narrowed
+ * through `FontThemeSchema` at both parse sites while its three siblings were
+ * copied verbatim and interpolated into the saved attribute without escaping,
+ * so a value carrying a quote reopened the element. Same shape in
+ * `w:background` and `w:pgNumType`, whose values are plain parsed strings.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { SectionProperties, TextFormatting } from "../../types/document";
+import { parseRunProperties } from "../runParser";
+import { parseXmlDocument } from "../xmlParser";
+import type { XmlElement } from "../xmlParser";
+import { serializeTextFormatting } from "./runSerializer";
+import { serializeSectionProperties } from "./sectionPropertiesSerializer";
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+const parseRPr = (rPrXml: string): TextFormatting | undefined => {
+  const root = parseXmlDocument(`<w:rPr xmlns:w="${W_NS}">${rPrXml}</w:rPr>`) as XmlElement | null;
+  return parseRunProperties(root, null);
+};
+
+const THEME_FONT_ATTRIBUTES = [
+  "w:asciiTheme",
+  "w:hAnsiTheme",
+  "w:eastAsiaTheme",
+  "w:cstheme",
+] as const;
+
+describe("theme font references", () => {
+  test("round-trip keeps every recognised reference", () => {
+    const formatting = parseRPr(
+      '<w:rFonts w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi"' +
+        ' w:eastAsiaTheme="minorEastAsia" w:cstheme="minorBidi"/>',
+    );
+
+    expect(formatting?.fontFamily).toMatchObject({
+      asciiTheme: "minorHAnsi",
+      hAnsiTheme: "minorHAnsi",
+      eastAsiaTheme: "minorEastAsia",
+      csTheme: "minorBidi",
+    });
+
+    const xml = serializeTextFormatting(formatting);
+    expect(xml).toContain('w:hAnsiTheme="minorHAnsi"');
+    expect(xml).toContain('w:eastAsiaTheme="minorEastAsia"');
+    expect(xml).toContain('w:cstheme="minorBidi"');
+  });
+
+  test("a reference outside the enum is dropped at parse", () => {
+    for (const attribute of THEME_FONT_ATTRIBUTES) {
+      const formatting = parseRPr(`<w:rFonts ${attribute}="notATheme"/>`);
+      expect(serializeTextFormatting(formatting)).not.toContain("notATheme");
+    }
+  });
+
+  test("a reference set on the model is escaped on the way out", () => {
+    const xml = serializeTextFormatting({
+      fontFamily: {
+        hAnsiTheme: 'minorHAnsi" w:hAnsi="Injected',
+        eastAsiaTheme: 'a"b',
+        csTheme: "a&b",
+      },
+    });
+
+    expect(xml).not.toContain('w:hAnsi="Injected');
+    expect(xml).toContain("&quot;");
+    expect(xml).toContain("&amp;");
+    expect(parseXmlDocument(`<w:rPr xmlns:w="${W_NS}">${xml}</w:rPr>`)).not.toBeNull();
+  });
+});
+
+describe("section property attributes", () => {
+  test("page background and chapter separator are escaped", () => {
+    const props = {
+      background: {
+        color: { rgb: 'FFFFFF" w:themeColor="accent1' },
+        themeTint: 'a"b',
+        themeShade: "a&b",
+      },
+      pageNumbering: { chapterSeparator: 'hyphen" w:start="9' },
+    } as const satisfies SectionProperties;
+
+    const xml = serializeSectionProperties(props);
+
+    expect(xml).not.toContain('w:themeColor="accent1"');
+    expect(xml).not.toContain('w:start="9"');
+    expect(xml).toContain("&quot;");
+    expect(xml).toContain("&amp;");
+    expect(parseXmlDocument(`<w:body xmlns:w="${W_NS}">${xml}</w:body>`)).not.toBeNull();
+  });
+});

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -209,19 +209,19 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
       fontAttrs.push(`w:hint="${escapeXml(formatting.fontFamily.hint)}"`);
     }
     if (formatting.fontFamily.asciiTheme) {
-      fontAttrs.push(`w:asciiTheme="${formatting.fontFamily.asciiTheme}"`);
+      fontAttrs.push(`w:asciiTheme="${escapeXml(formatting.fontFamily.asciiTheme)}"`);
     }
     if (formatting.fontFamily.hAnsiTheme) {
-      fontAttrs.push(`w:hAnsiTheme="${formatting.fontFamily.hAnsiTheme}"`);
+      fontAttrs.push(`w:hAnsiTheme="${escapeXml(formatting.fontFamily.hAnsiTheme)}"`);
     }
     if (formatting.fontFamily.eastAsiaTheme) {
-      fontAttrs.push(`w:eastAsiaTheme="${formatting.fontFamily.eastAsiaTheme}"`);
+      fontAttrs.push(`w:eastAsiaTheme="${escapeXml(formatting.fontFamily.eastAsiaTheme)}"`);
     }
     if (formatting.fontFamily.csTheme) {
       // OOXML spells this attribute all-lowercase (`w:cstheme`), unlike its
       // camelCase siblings above; the parser reads `w:cstheme`, so emitting
       // `w:csTheme` would silently drop the CS theme font on round-trip.
-      fontAttrs.push(`w:cstheme="${formatting.fontFamily.csTheme}"`);
+      fontAttrs.push(`w:cstheme="${escapeXml(formatting.fontFamily.csTheme)}"`);
     }
     if (fontAttrs.length > 0) {
       parts.push(`<w:rFonts ${fontAttrs.join(" ")}/>`);

--- a/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/core/src/docx/serializer/sectionPropertiesSerializer.ts
@@ -206,7 +206,7 @@ function serializePageNumbering(props: SectionProperties): string {
     attrs.push(`w:chapStyle="${intAttr(pageNumbering.chapterStyle)}"`);
   }
   if (pageNumbering.chapterSeparator) {
-    attrs.push(`w:chapSep="${pageNumbering.chapterSeparator}"`);
+    attrs.push(`w:chapSep="${escapeXml(pageNumbering.chapterSeparator)}"`);
   }
 
   return attrs.length > 0 ? `<w:pgNumType ${attrs.join(" ")}/>` : "";
@@ -268,16 +268,22 @@ function serializeBackground(props: SectionProperties): string {
   if (background.color?.auto) {
     attrs.push('w:color="auto"');
   } else if (background.color?.rgb) {
-    attrs.push(`w:color="${background.color.rgb}"`);
+    attrs.push(`w:color="${escapeXml(background.color.rgb)}"`);
   }
   if (background.themeColor ?? background.color?.themeColor) {
-    attrs.push(`w:themeColor="${background.themeColor ?? background.color?.themeColor}"`);
+    attrs.push(
+      `w:themeColor="${escapeXml(background.themeColor ?? background.color?.themeColor ?? "")}"`,
+    );
   }
   if (background.themeTint ?? background.color?.themeTint) {
-    attrs.push(`w:themeTint="${background.themeTint ?? background.color?.themeTint}"`);
+    attrs.push(
+      `w:themeTint="${escapeXml(background.themeTint ?? background.color?.themeTint ?? "")}"`,
+    );
   }
   if (background.themeShade ?? background.color?.themeShade) {
-    attrs.push(`w:themeShade="${background.themeShade ?? background.color?.themeShade}"`);
+    attrs.push(
+      `w:themeShade="${escapeXml(background.themeShade ?? background.color?.themeShade ?? "")}"`,
+    );
   }
 
   return attrs.length > 0 ? `<w:background ${attrs.join(" ")}/>` : "";

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -282,7 +282,7 @@ const MAX_TABLE_COLUMNS = 256;
 /** Bound the mutual recursion between a cell and the tables nested inside it. */
 const MAX_NESTED_TABLE_DEPTH = 8;
 
-/** Rows read from one `w:tbl`. The column cap alone leaves row count unbounded. */
+/** Rows collected from one `w:tbl`. The column cap alone leaves row count unbounded. */
 const MAX_TABLE_ROWS = 8192;
 
 /**
@@ -299,11 +299,20 @@ const MAX_EXTRACTED_CHARS = 8_000_000;
  * The walk stops at `w:tbl` and `w:p` so a nested table's rows and cells never
  * leak into the grid of the table that contains them.
  */
-const collectTableParts = (parent: XmlElement, localName: "tr" | "tc"): XmlElement[] => {
+const collectTableParts = (
+  parent: XmlElement,
+  localName: "tr" | "tc",
+  limit: number,
+): XmlElement[] => {
   const parts: XmlElement[] = [];
 
   const walk = (node: XmlElement) => {
     for (const child of childElements(node)) {
+      // Bound the collection itself: a caller that drops the tail afterwards
+      // has already paid for the whole array, and every table walk shares this.
+      if (parts.length >= limit) {
+        return;
+      }
       const childName = wordElementName(child);
       if (childName === localName) {
         parts.push(child);
@@ -347,8 +356,8 @@ const readCellSourceParagraphs = (
         if (depth >= MAX_NESTED_TABLE_DEPTH) {
           continue;
         }
-        for (const row of collectTableParts(child, "tr")) {
-          for (const nestedCell of collectTableParts(row, "tc")) {
+        for (const row of collectTableParts(child, "tr", MAX_TABLE_ROWS)) {
+          for (const nestedCell of collectTableParts(row, "tc", MAX_TABLE_COLUMNS)) {
             for (const paragraph of readCellSourceParagraphs(nestedCell, depth + 1)) {
               paragraphs.push(paragraph);
             }
@@ -396,8 +405,8 @@ const readCellRenderedLines = (cell: XmlElement, depth: number): string[] => {
 const flattenNestedTable = (table: XmlElement, depth: number): string[] => {
   const lines: string[] = [];
 
-  for (const row of collectTableParts(table, "tr")) {
-    const cells = collectTableParts(row, "tc").map((cell) =>
+  for (const row of collectTableParts(table, "tr", MAX_TABLE_ROWS)) {
+    const cells = collectTableParts(row, "tc", MAX_TABLE_COLUMNS).map((cell) =>
       readCellRenderedLines(cell, depth).join("\n"),
     );
     if (cells.some((text) => text.length > 0)) {
@@ -486,7 +495,7 @@ const readTableGrid = (table: XmlElement): TableGrid => {
   let columnCount = 0;
   let firstRowIsHeader = false;
 
-  for (const [rowIndex, row] of collectTableParts(table, "tr").entries()) {
+  for (const [rowIndex, row] of collectTableParts(table, "tr", MAX_TABLE_ROWS).entries()) {
     if (rowIndex === 0) {
       firstRowIsHeader = declaresHeaderRow(row);
     }
@@ -495,7 +504,7 @@ const readTableGrid = (table: XmlElement): TableGrid => {
     for (let index = 0; index < gridBefore; index += 1) {
       columns.push(emptyTableCell());
     }
-    for (const cell of collectTableParts(row, "tc")) {
+    for (const cell of collectTableParts(row, "tc", MAX_TABLE_COLUMNS)) {
       if (columns.length >= MAX_TABLE_COLUMNS) {
         break;
       }
@@ -519,9 +528,6 @@ const readTableGrid = (table: XmlElement): TableGrid => {
       columnCount = columns.length;
     }
     rows.push(columns);
-    if (rows.length >= MAX_TABLE_ROWS) {
-      break;
-    }
   }
 
   return { rows, columnCount, firstRowIsHeader };

--- a/packages/core/src/docx/server/extractDocxText.ts
+++ b/packages/core/src/docx/server/extractDocxText.ts
@@ -282,6 +282,17 @@ const MAX_TABLE_COLUMNS = 256;
 /** Bound the mutual recursion between a cell and the tables nested inside it. */
 const MAX_NESTED_TABLE_DEPTH = 8;
 
+/** Rows read from one `w:tbl`. The column cap alone leaves row count unbounded. */
+const MAX_TABLE_ROWS = 8192;
+
+/**
+ * Characters one extraction emits, shared by the body and every header/footer
+ * part. Element count is bounded at unzip, but a bounded element count still
+ * renders an unbounded number of table rows once `w:gridSpan` padding and the
+ * GFM scaffolding are counted, so the emitted side carries its own ceiling.
+ */
+const MAX_EXTRACTED_CHARS = 8_000_000;
+
 /**
  * Collect a table's `w:tr`, or a row's `w:tc`, seeing through the wrappers Word
  * puts around them (`w:sdt` / `w:sdtContent` content controls, `w:customXml`).
@@ -508,6 +519,9 @@ const readTableGrid = (table: XmlElement): TableGrid => {
       columnCount = columns.length;
     }
     rows.push(columns);
+    if (rows.length >= MAX_TABLE_ROWS) {
+      break;
+    }
   }
 
   return { rows, columnCount, firstRowIsHeader };
@@ -579,11 +593,17 @@ const renderTableRows = (table: XmlElement, tableIndex: number): RenderedTableRo
 // Container walk
 // ---------------------------------------------------------------------------
 
+/** Mutable remainder of {@link MAX_EXTRACTED_CHARS}, shared across parts. */
+type CharBudget = { remaining: number };
+
+const createCharBudget = (): CharBudget => ({ remaining: MAX_EXTRACTED_CHARS });
+
 type ExtractContainerOptions = {
   container: XmlElement;
   source: DocxParagraphSource;
   startIndex: number;
   startTableIndex: number;
+  budget: CharBudget;
 };
 
 type ExtractContainerResult = {
@@ -598,6 +618,7 @@ const extractContainer = ({
   source,
   startIndex,
   startTableIndex,
+  budget,
 }: ExtractContainerOptions): ExtractContainerResult => {
   const paragraphs: ExtractedDocxParagraph[] = [];
   let charCount = 0;
@@ -614,6 +635,7 @@ const extractContainer = ({
 
     paragraphs.push(entry);
     charCount += text.length;
+    budget.remaining -= text.length;
   };
 
   const pushTableRow = ({ text, position }: RenderedTableRow) => {
@@ -624,6 +646,7 @@ const extractContainer = ({
       tableRow: position,
     });
     charCount += text.length;
+    budget.remaining -= text.length;
   };
 
   /**
@@ -634,6 +657,9 @@ const extractContainer = ({
    */
   const walkBlocks = (node: XmlElement) => {
     for (const child of childElements(node)) {
+      if (budget.remaining <= 0) {
+        return;
+      }
       const childName = wordElementName(child);
       if (childName === "tbl") {
         for (const row of renderTableRows(child, startTableIndex + tableCount)) {
@@ -661,6 +687,7 @@ type ExtractPartsOptions = {
   startTableIndex: number;
   /** Part paths to read, in extraction order — see {@link resolveReferencedHeaderFooterParts}. */
   paths: readonly string[];
+  budget: CharBudget;
 };
 
 const extractParts = async ({
@@ -670,6 +697,7 @@ const extractParts = async ({
   startIndex,
   startTableIndex,
   paths,
+  budget,
 }: ExtractPartsOptions): Promise<ExtractContainerResult> => {
   const paragraphs: ExtractedDocxParagraph[] = [];
   let charCount = 0;
@@ -692,6 +720,7 @@ const extractParts = async ({
       source,
       startIndex: nextIndex,
       startTableIndex: startTableIndex + tableCount,
+      budget,
     });
     for (const paragraph of result.paragraphs) {
       paragraphs.push(paragraph);
@@ -794,6 +823,7 @@ export const extractDocxText = async (
   }
 
   const referencedParts = await resolveReferencedHeaderFooterParts(archive, root);
+  const budget = createCharBudget();
 
   const headers = await extractParts({
     archive,
@@ -802,12 +832,14 @@ export const extractDocxText = async (
     startIndex: 0,
     startTableIndex: 0,
     paths: referencedParts.headers,
+    budget,
   });
   const bodyResult = extractContainer({
     container: body,
     source: "body",
     startIndex: headers.paragraphs.length,
     startTableIndex: headers.tableCount,
+    budget,
   });
   const footers = await extractParts({
     archive,
@@ -816,6 +848,7 @@ export const extractDocxText = async (
     startIndex: headers.paragraphs.length + bodyResult.paragraphs.length,
     startTableIndex: headers.tableCount + bodyResult.tableCount,
     paths: referencedParts.footers,
+    budget,
   });
 
   return {

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -38,6 +38,7 @@ import type {
 } from "../types/document";
 import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
 import { mergeTextFormatting } from "../utils/textFormattingMerge";
+import { isValidHexColor } from "../utils/colorResolver";
 import {
   BorderStyleSchema,
   ConditionalStyleTypeSchema,
@@ -259,7 +260,7 @@ function parseRunProperties(
         }
       }
     }
-    const hAnsiTheme = getAttribute(rFonts, "w", "hAnsiTheme");
+    const hAnsiTheme = narrowEnum(getAttribute(rFonts, "w", "hAnsiTheme"), FontThemeSchema);
     if (hAnsiTheme) {
       fontFamily.hAnsiTheme = hAnsiTheme;
       if (theme && !fontFamily.hAnsi) {
@@ -269,7 +270,7 @@ function parseRunProperties(
         }
       }
     }
-    const eastAsiaTheme = getAttribute(rFonts, "w", "eastAsiaTheme");
+    const eastAsiaTheme = narrowEnum(getAttribute(rFonts, "w", "eastAsiaTheme"), FontThemeSchema);
     if (eastAsiaTheme) {
       fontFamily.eastAsiaTheme = eastAsiaTheme;
       if (theme && !fontFamily.eastAsia) {
@@ -279,7 +280,7 @@ function parseRunProperties(
         }
       }
     }
-    const csTheme = getAttribute(rFonts, "w", "cstheme");
+    const csTheme = narrowEnum(getAttribute(rFonts, "w", "cstheme"), FontThemeSchema);
     if (csTheme) {
       fontFamily.csTheme = csTheme;
       if (theme && !fontFamily.cs) {
@@ -448,13 +449,16 @@ function parseShadingProperties(shd: XmlElement | null): ShadingProperties | und
 
   const props: ShadingProperties = {};
 
+  // `w:color` and `w:fill` are ST_HexColor: `auto` or hex digits. Both values
+  // are resolved straight into a rendered style declaration, so a value that is
+  // not a colour is dropped here rather than carried through the model.
   const color = getAttribute(shd, "w", "color");
-  if (color && color !== "auto") {
+  if (color && color !== "auto" && isValidHexColor(color)) {
     props.color = { rgb: color };
   }
 
   const fill = getAttribute(shd, "w", "fill");
-  if (fill && fill !== "auto") {
+  if (fill && fill !== "auto" && isValidHexColor(fill)) {
     props.fill = { rgb: fill };
   }
 

--- a/packages/core/src/docx/unzip.ts
+++ b/packages/core/src/docx/unzip.ts
@@ -377,7 +377,7 @@ export async function unzipDocx(
       continue;
     }
     if (extracted.type === "xml") {
-      assignXmlContent(content, extracted);
+      assignXmlContent(content, extracted, limits);
       continue;
     }
     if (extracted.type === "media") {
@@ -400,9 +400,16 @@ const PREFLIGHT_XML_PARTS = new Set(["word/document.xml", "word/styles.xml", "wo
 function assignXmlContent(
   content: RawDocxContent,
   { path, lowerPath, content: xmlContent }: Extract<ExtractedEntry, { type: "xml" }>,
+  limits: DocxUnzipLimits,
 ): void {
   if (PREFLIGHT_XML_PARTS.has(lowerPath)) {
-    assertXmlResourceLimits(xmlContent);
+    // `maxXmlBytes` is the caller-configurable ceiling the entry-size checks
+    // above already honour; the preflight shares it rather than re-imposing the
+    // default.
+    assertXmlResourceLimits(xmlContent, {
+      ...FOLIO_XML_RESOURCE_LIMITS,
+      maxBytes: limits.maxXmlBytes,
+    });
   }
 
   content.allXml.set(path, xmlContent);

--- a/packages/core/src/docx/unzip.ts
+++ b/packages/core/src/docx/unzip.ts
@@ -28,7 +28,7 @@ import JSZip from "jszip";
 
 import { openDocxBuffer } from "./encryption/openEncryptedDocx";
 import { DOCX_CONTAINER_TYPES, detectDocxContainerType } from "./encryption/containerFormat";
-import { FOLIO_XML_RESOURCE_LIMITS } from "./xmlResourceLimits";
+import { assertXmlResourceLimits, FOLIO_XML_RESOURCE_LIMITS } from "./xmlResourceLimits";
 
 export class DocxSecurityError extends Error {
   constructor(message: string) {
@@ -390,10 +390,21 @@ export async function unzipDocx(
   return content;
 }
 
+/**
+ * Parts that every consumer expands into an object tree. Preflighting them once
+ * here puts the bound on the unzip, so `parseDocx`, the selective save and the
+ * repack path all share it instead of each entry point carrying its own.
+ */
+const PREFLIGHT_XML_PARTS = new Set(["word/document.xml", "word/styles.xml", "word/numbering.xml"]);
+
 function assignXmlContent(
   content: RawDocxContent,
   { path, lowerPath, content: xmlContent }: Extract<ExtractedEntry, { type: "xml" }>,
 ): void {
+  if (PREFLIGHT_XML_PARTS.has(lowerPath)) {
+    assertXmlResourceLimits(xmlContent);
+  }
+
   content.allXml.set(path, xmlContent);
 
   if (lowerPath === "word/document.xml") {

--- a/packages/core/src/docx/xmlParser.test.ts
+++ b/packages/core/src/docx/xmlParser.test.ts
@@ -4,6 +4,7 @@ import {
   cloneWithXmlnsDeclarations,
   collectXmlnsDeclarations,
   elementToXml,
+  mergeXmlnsDeclarations,
   NAMESPACES,
   parseOnOffValue,
   parseXmlDocument,
@@ -111,5 +112,49 @@ describe("collectXmlnsDeclarations", () => {
     const element: XmlElement = { type: "element", name: "w:pict", attributes };
 
     expect(Object.keys(collectXmlnsDeclarations(element))).toHaveLength(64);
+  });
+
+  test("drops a declaration whose value is longer than a namespace URI", () => {
+    const element: XmlElement = {
+      type: "element",
+      name: "w:pict",
+      attributes: {
+        "xmlns:a": "urn:example:a",
+        "xmlns:b": `urn:${"x".repeat(600)}`,
+      },
+    };
+
+    expect(collectXmlnsDeclarations(element)).toEqual({ "xmlns:a": "urn:example:a" });
+  });
+});
+
+describe("mergeXmlnsDeclarations", () => {
+  test("merges own declarations over the inherited set", () => {
+    const element: XmlElement = {
+      type: "element",
+      name: "w:p",
+      attributes: { "xmlns:w": "urn:w:new", "xmlns:v": "urn:v" },
+    };
+
+    expect(mergeXmlnsDeclarations({ "xmlns:w": "urn:w:old" }, element)).toEqual({
+      "xmlns:w": "urn:w:new",
+      "xmlns:v": "urn:v",
+    });
+  });
+
+  test("keeps the inherited set when merging would exceed the chain budget", () => {
+    // Each ancestor contributes to the set a captured subtree replays, so the
+    // accumulated size is bounded as well as the per-element count.
+    const inherited: Record<string, string> = {};
+    for (let i = 0; i < 40; i++) {
+      inherited[`xmlns:in${String(i)}`] = `urn:${"y".repeat(200)}:${String(i)}`;
+    }
+    const attributes: Record<string, string> = {};
+    for (let i = 0; i < 40; i++) {
+      attributes[`xmlns:own${String(i)}`] = `urn:${"z".repeat(200)}:${String(i)}`;
+    }
+    const element: XmlElement = { type: "element", name: "w:p", attributes };
+
+    expect(mergeXmlnsDeclarations(inherited, element)).toBe(inherited);
   });
 });

--- a/packages/core/src/docx/xmlParser.test.ts
+++ b/packages/core/src/docx/xmlParser.test.ts
@@ -126,6 +126,26 @@ describe("collectXmlnsDeclarations", () => {
 
     expect(collectXmlnsDeclarations(element)).toEqual({ "xmlns:a": "urn:example:a" });
   });
+
+  test("stops once the collected set reaches the chain budget", () => {
+    // The merge step compares the accumulated set against the same budget, so
+    // bounding the collected set here keeps every set this module hands out
+    // within it — including the root set a capture inherits unchanged.
+    const attributes: Record<string, string> = {};
+    for (let i = 0; i < 60; i++) {
+      attributes[`xmlns:ns${String(i)}`] = `urn:${"y".repeat(400)}:${String(i)}`;
+    }
+    const element: XmlElement = { type: "element", name: "w:pict", attributes };
+
+    const collected = collectXmlnsDeclarations(element);
+    const chars = Object.entries(collected).reduce(
+      (total, [name, value]) => total + name.length + value.length,
+      0,
+    );
+
+    expect(chars).toBeLessThanOrEqual(8192);
+    expect(Object.keys(collected).length).toBeGreaterThan(0);
+  });
 });
 
 describe("mergeXmlnsDeclarations", () => {

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -1092,10 +1092,10 @@ const MAX_XMLNS_DECLARATIONS_PER_ELEMENT = 64;
 const MAX_XMLNS_VALUE_LENGTH = 512;
 
 /**
- * Sanity cap on the accumulated declaration set carried down one ancestor
- * chain. The per-element count and per-value length bound a single element;
- * this bounds what the chain hands to a captured `w:pict` subtree, since every
- * ancestor contributes and the merged set is replayed on each capture.
+ * Sanity cap on an accumulated declaration set. Applied both when collecting one
+ * element's declarations and when merging down the ancestor chain, so every set
+ * this module produces or returns is bounded and a captured `w:pict` subtree
+ * replays at most this much regardless of how the chain was built.
  */
 const MAX_XMLNS_DECLARATION_CHARS = 8192;
 
@@ -1123,6 +1123,7 @@ export function collectXmlnsDeclarations(element: XmlElement): Record<string, st
     return out;
   }
   let declarationCount = 0;
+  let declarationChars = 0;
   for (const key in attrs) {
     if (declarationCount >= MAX_XMLNS_DECLARATIONS_PER_ELEMENT) {
       break;
@@ -1138,8 +1139,12 @@ export function collectXmlnsDeclarations(element: XmlElement): Record<string, st
     if (declaration.length > MAX_XMLNS_VALUE_LENGTH) {
       continue;
     }
+    if (declarationChars + key.length + declaration.length > MAX_XMLNS_DECLARATION_CHARS) {
+      break;
+    }
     out[key] = declaration;
     declarationCount += 1;
+    declarationChars += key.length + declaration.length;
   }
   return out;
 }

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -1085,6 +1085,29 @@ export function findAllDeep(
 const MAX_XMLNS_DECLARATIONS_PER_ELEMENT = 64;
 
 /**
+ * Sanity cap on one declaration's value. Namespace URIs are short; a longer
+ * binding is dropped rather than replayed onto every captured subtree that
+ * inherits from the declaring element.
+ */
+const MAX_XMLNS_VALUE_LENGTH = 512;
+
+/**
+ * Sanity cap on the accumulated declaration set carried down one ancestor
+ * chain. The per-element count and per-value length bound a single element;
+ * this bounds what the chain hands to a captured `w:pict` subtree, since every
+ * ancestor contributes and the merged set is replayed on each capture.
+ */
+const MAX_XMLNS_DECLARATION_CHARS = 8192;
+
+const xmlnsDeclarationChars = (declarations: Record<string, string>): number => {
+  let chars = 0;
+  for (const [name, value] of Object.entries(declarations)) {
+    chars += name.length + value.length;
+  }
+  return chars;
+};
+
+/**
  * Collect every `xmlns` / `xmlns:*` declaration from an element's attributes.
  *
  * The serializer's hard-coded root namespaces only cover canonical prefixes
@@ -1105,10 +1128,18 @@ export function collectXmlnsDeclarations(element: XmlElement): Record<string, st
       break;
     }
     const value = attrs[key];
-    if ((key === "xmlns" || key.startsWith("xmlns:")) && value !== undefined) {
-      out[key] = String(value);
-      declarationCount += 1;
+    if (key !== "xmlns" && !key.startsWith("xmlns:")) {
+      continue;
     }
+    if (value === undefined) {
+      continue;
+    }
+    const declaration = String(value);
+    if (declaration.length > MAX_XMLNS_VALUE_LENGTH) {
+      continue;
+    }
+    out[key] = declaration;
+    declarationCount += 1;
   }
   return out;
 }
@@ -1127,7 +1158,8 @@ export function mergeXmlnsDeclarations(
 ): Record<string, string> {
   const own = collectXmlnsDeclarations(element);
   for (const _key in own) {
-    return { ...inherited, ...own };
+    const merged = { ...inherited, ...own };
+    return xmlnsDeclarationChars(merged) > MAX_XMLNS_DECLARATION_CHARS ? inherited : merged;
   }
   return inherited;
 }

--- a/packages/core/src/layout-painter/renderParagraph-hyperlink-target.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-hyperlink-target.test.ts
@@ -65,7 +65,7 @@ const LINE_OPTIONS = {
   lineRightEdgePx: 600,
 };
 
-const renderAnchor = (href: string): FakeElement => {
+const renderRun = (href: string): { anchors: FakeElement[]; text: string } => {
   const run: TextRun = { kind: "text", text: "link", hyperlink: { href } };
   const block: ParagraphBlock = { kind: "paragraph", id: "p", runs: [run] };
   const line: MeasuredLine = {
@@ -96,7 +96,21 @@ const renderAnchor = (href: string): FakeElement => {
     }
   };
   walk(lineEl);
-  const anchor = anchors.at(0);
+  const texts: string[] = [];
+  const collectText = (element: FakeElement) => {
+    if (element.textContent) {
+      texts.push(element.textContent);
+    }
+    for (const child of element.children) {
+      collectText(child);
+    }
+  };
+  collectText(lineEl);
+  return { anchors, text: texts.join("") };
+};
+
+const renderAnchor = (href: string): FakeElement => {
+  const anchor = renderRun(href).anchors.at(0);
   if (!anchor) {
     throw new Error("expected an anchor element");
   }
@@ -119,9 +133,14 @@ describe("run hyperlink targets", () => {
     expect(anchor.target).toBe("");
   });
 
-  test("drops a target outside the navigable protocols", () => {
+  test("renders no anchor at all for a target outside the navigable protocols", () => {
+    // An empty `href` still resolves to the current document, so the run must
+    // carry no anchor rather than an anchor with a blank target.
     for (const href of ["javascript:void 0", "data:text/html,<p>x</p>", "ftp://example.com/f"]) {
-      expect(renderAnchor(href).href).toBe("");
+      const rendered = renderRun(href);
+
+      expect(rendered.anchors).toHaveLength(0);
+      expect(rendered.text).toContain("link");
     }
   });
 });

--- a/packages/core/src/layout-painter/renderParagraph-hyperlink-target.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-hyperlink-target.test.ts
@@ -1,0 +1,127 @@
+// Run hyperlink targets go through the same narrowing as image hyperlinks
+// (`renderImage`): only the protocols the painter navigates to reach `href`.
+// Bookmark targets (`#name`) scroll inside the document and stay verbatim.
+
+import { describe, expect, test } from "bun:test";
+
+import type { MeasuredLine, ParagraphBlock, TextRun } from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> & { setProperty: (name: string, value: string) => void };
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  href = "";
+  target = "";
+  rel = "";
+  title = "";
+  dir = "";
+  readonly tagName: string;
+  textContent = "";
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+    this.style = { setProperty: () => undefined } as FakeElement["style"];
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  get firstElementChild(): FakeElement | null {
+    return this.children.at(0) ?? null;
+  }
+
+  getContext(): null {
+    return null;
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+const LINE_OPTIONS = {
+  availableWidth: 600,
+  isLastLine: true,
+  isFirstLine: true,
+  paragraphEndsWithLineBreak: false,
+  tabStops: [],
+  leftIndentPx: 0,
+  lineRightEdgePx: 600,
+};
+
+const renderAnchor = (href: string): FakeElement => {
+  const run: TextRun = { kind: "text", text: "link", hyperlink: { href } };
+  const block: ParagraphBlock = { kind: "paragraph", id: "p", runs: [run] };
+  const line: MeasuredLine = {
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: run.text.length,
+    width: 200,
+    ascent: 12,
+    descent: 3,
+    lineHeight: 15,
+  };
+
+  const lineEl = renderLine(
+    block,
+    line,
+    undefined,
+    fakeDocument,
+    LINE_OPTIONS,
+  ) as unknown as FakeElement;
+  const anchors: FakeElement[] = [];
+  const walk = (element: FakeElement) => {
+    if (element.tagName === "a") {
+      anchors.push(element);
+    }
+    for (const child of element.children) {
+      walk(child);
+    }
+  };
+  walk(lineEl);
+  const anchor = anchors.at(0);
+  if (!anchor) {
+    throw new Error("expected an anchor element");
+  }
+  return anchor;
+};
+
+describe("run hyperlink targets", () => {
+  test("keeps an http target and opens it in a new tab", () => {
+    const anchor = renderAnchor("https://example.com/a?b=1#c");
+
+    expect(anchor.href).toBe("https://example.com/a?b=1#c");
+    expect(anchor.target).toBe("_blank");
+    expect(anchor.rel).toBe("noopener noreferrer");
+  });
+
+  test("keeps a bookmark target verbatim and in-document", () => {
+    const anchor = renderAnchor("#_Toc12345");
+
+    expect(anchor.href).toBe("#_Toc12345");
+    expect(anchor.target).toBe("");
+  });
+
+  test("drops a target outside the navigable protocols", () => {
+    for (const href of ["javascript:void 0", "data:text/html,<p>x</p>", "ftp://example.com/f"]) {
+      expect(renderAnchor(href).href).toBe("");
+    }
+  });
+});

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -56,6 +56,7 @@ import { planCursiveJoiners, withCursiveJoiners } from "./cursiveJoiners";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
+import { sanitizeExternalUrl } from "../utils/urlSecurity";
 import {
   inlineImageBoundingBox,
   parseRotationDegrees,
@@ -640,13 +641,18 @@ function renderTextRun(
   // Handle hyperlinks
   if (run.hyperlink) {
     const anchor = doc.createElement("a");
-    anchor.href = run.hyperlink.href;
+    // Internal bookmark links (starting with #) scroll within the document and
+    // stay verbatim; every other target is narrowed to the protocols the
+    // painter navigates to, matching the image hyperlink path.
+    const isBookmarkTarget = run.hyperlink.href.startsWith("#");
+    anchor.href = isBookmarkTarget
+      ? run.hyperlink.href
+      : (sanitizeExternalUrl(run.hyperlink.href) ?? "");
     if (hyperlinkDirection || DISPLAYED_URL_PATTERN.test(paintedText.trim())) {
       anchor.dir = LEFT_TO_RIGHT_DIRECTION;
     }
-    // Internal bookmark links (starting with #) should scroll within the document
     // External links should open in a new tab
-    if (!run.hyperlink.href.startsWith("#")) {
+    if (!isBookmarkTarget) {
       anchor.target = "_blank";
       anchor.rel = "noopener noreferrer";
     }

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -638,16 +638,13 @@ function renderTextRun(
   applyPmPositions(span, run.pmStart, run.pmEnd);
   const paintedText = toPaintedText(run.text);
 
+  const isBookmarkTarget = run.hyperlink?.href.startsWith("#") === true;
+  const hyperlinkHref = resolveHyperlinkHref(run.hyperlink?.href, isBookmarkTarget);
+
   // Handle hyperlinks
-  if (run.hyperlink) {
+  if (run.hyperlink && hyperlinkHref !== undefined) {
     const anchor = doc.createElement("a");
-    // Internal bookmark links (starting with #) scroll within the document and
-    // stay verbatim; every other target is narrowed to the protocols the
-    // painter navigates to, matching the image hyperlink path.
-    const isBookmarkTarget = run.hyperlink.href.startsWith("#");
-    anchor.href = isBookmarkTarget
-      ? run.hyperlink.href
-      : (sanitizeExternalUrl(run.hyperlink.href) ?? "");
+    anchor.href = hyperlinkHref;
     if (hyperlinkDirection || DISPLAYED_URL_PATTERN.test(paintedText.trim())) {
       anchor.dir = LEFT_TO_RIGHT_DIRECTION;
     }
@@ -686,6 +683,23 @@ function renderTextRun(
   applyWhitespaceUnderline(span, run);
 
   return span;
+}
+
+/**
+ * Bookmark targets (`#name`) scroll within the document and stay verbatim;
+ * every other target is narrowed to the protocols the painter navigates to,
+ * matching the image hyperlink path. `undefined` means the run gets no anchor:
+ * an empty `href` resolves to the current document, so a rejected target would
+ * otherwise stay navigable.
+ */
+function resolveHyperlinkHref(
+  href: string | undefined,
+  isBookmarkTarget: boolean,
+): string | undefined {
+  if (href === undefined) {
+    return undefined;
+  }
+  return isBookmarkTarget ? href : sanitizeExternalUrl(href);
 }
 
 function isNoteReferenceRun(run: TextRun | TabRun): boolean {

--- a/packages/core/src/utils/headerFooter.test.ts
+++ b/packages/core/src/utils/headerFooter.test.ts
@@ -144,14 +144,12 @@ describe("createEmptyHeaderFooter", () => {
     expect(next?.package.document.finalSectionProperties?.headerReferences).toEqual([
       { type: "default", rId },
     ]);
-    expect(next?.package.relationships?.get(rId)).toEqual({
-      id: rId,
-      type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header",
-      target: "header1.xml",
-    });
+    // The relationship is minted by the save path, which owns the part
+    // filename, the `.rels` entry and the content-type override together.
+    expect(next?.package.relationships?.has(rId) ?? false).toBe(false);
   });
 
-  test("allocates collision-free relationship ids and part targets", () => {
+  test("allocates collision-free relationship ids", () => {
     const body: DocumentBody = {
       content: [paragraph],
       finalSectionProperties: { marginTop: 1440 },
@@ -176,9 +174,8 @@ describe("createEmptyHeaderFooter", () => {
     const next = createEmptyHeaderFooter(document, "header", false);
 
     expect(next?.package.headers?.has("rId_new_header_default_2")).toBe(true);
-    expect(next?.package.relationships?.get("rId_new_header_default_2")?.target).toBe(
-      "header2.xml",
-    );
+    expect(next?.package.relationships?.has("rId_new_header_default_2")).toBe(false);
+    expect(next?.package.relationships?.get("rIdExisting")?.target).toBe("header1.xml");
   });
 });
 

--- a/packages/core/src/utils/headerFooter.ts
+++ b/packages/core/src/utils/headerFooter.ts
@@ -321,33 +321,18 @@ export const createEmptyHeaderFooter = (
   const existingRefs = sectionProps[refKey] ?? [];
   const newRef = { type: hdrFtrType, rId };
 
-  const usedTargets = new Set<string>();
-  for (const relationship of pkg.relationships?.values() ?? []) {
-    if (relationship.target) {
-      usedTargets.add(relationship.target);
-    }
-  }
-  let targetNumber = 1;
-  while (usedTargets.has(`${position}${targetNumber}.xml`)) {
-    targetNumber++;
-  }
-  const relationshipType =
-    position === "header"
-      ? "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header"
-      : "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer";
-  const relationships = new Map(pkg.relationships);
-  relationships.set(rId, {
-    id: rId,
-    type: relationshipType,
-    target: `${position}${targetNumber}.xml`,
-  });
-
+  // The new part is left unmaterialized on purpose: no relationship entry.
+  // `materializeNewHeaderFooterParts` keys off "in the header/footer map,
+  // absent from the relationship map" to pick the part filename, write
+  // `word/_rels/document.xml.rels` and add the `[Content_Types].xml`
+  // override on save. A relationship minted here satisfies that predicate
+  // early, so the save writes none of them and the reference resolves to
+  // nothing.
   return {
     ...document,
     package: {
       ...pkg,
       [mapKey]: newMap,
-      relationships,
       document: {
         ...pkg.document,
         finalSectionProperties: {

--- a/packages/core/src/utils/tiffConverter.ts
+++ b/packages/core/src/utils/tiffConverter.ts
@@ -17,6 +17,14 @@
  */
 const MAX_TIFF_PIXELS = 64_000_000;
 
+/**
+ * Budget shared by every TIFF in one package. The per-image cap bounds a single
+ * decode; without a running total a package of many large TIFFs still adds up.
+ * Callers pass what is left of the budget and subtract the pixels each
+ * conversion reports.
+ */
+export const MAX_PACKAGE_TIFF_PIXELS = 256_000_000;
+
 export function isTiffMimeType(mimeType: string): boolean {
   const lower = mimeType.toLowerCase();
   return lower === "image/tiff" || lower === "image/tif";
@@ -25,10 +33,13 @@ export function isTiffMimeType(mimeType: string): boolean {
 export type ConvertedTiff = {
   dataUrl: string;
   data: ArrayBuffer;
+  /** Pixels decoded, so callers can draw down a package-wide budget. */
+  pixels: number;
 };
 
 export async function convertTiffToPngDataUrl(
   tiffData: ArrayBuffer,
+  maxPixels: number = MAX_TIFF_PIXELS,
 ): Promise<ConvertedTiff | null> {
   // Bail out before any decode if Canvas isn't available — without it we
   // can't produce a PNG anyway, and TIFF decoding + RGBA conversion would
@@ -55,7 +66,7 @@ export async function convertTiffToPngDataUrl(
     if (!declaredWidth || !declaredHeight) {
       return null;
     }
-    if (declaredWidth * declaredHeight > MAX_TIFF_PIXELS) {
+    if (declaredWidth * declaredHeight > Math.min(maxPixels, MAX_TIFF_PIXELS)) {
       return null;
     }
 
@@ -91,7 +102,7 @@ export async function convertTiffToPngDataUrl(
     if (!data) {
       return null;
     }
-    return { dataUrl, data };
+    return { dataUrl, data, pixels: width * height };
   } catch {
     return null;
   }


### PR DESCRIPTION
Routine maintenance across the DOCX parse, save and paint paths. Each item is an
invariant the code already held on one side and not the other.

- `w:rFonts` theme references: `w:hAnsiTheme`, `w:eastAsiaTheme` and `w:cstheme`
  are now escaped on the way out and narrowed through `FontThemeSchema` at both
  parse sites, matching `w:asciiTheme`. Note the model still types the three
  siblings as `string` while `asciiTheme` is a union; tightening that is a
  separate change.
- Serializer survey for the same shape: `w:background`'s `w:color` /
  `w:themeColor` / `w:themeTint` / `w:themeShade` and `w:pgNumType`'s `w:chapSep`
  are escaped. Every other raw attribute interpolation in
  `docx/serializer/` carries a number, a constant, or a value already narrowed at
  parse.
- `w:shd/@w:color` and `@w:fill` are validated with the shared `isValidHexColor`
  at all three parse sites (run, paragraph, style), matching the DOM path. `auto`
  keeps its meaning.
- Saved packages no longer preserve the attached-template reference: the
  `w:attachedTemplate` element in `word/settings.xml` and external-target
  relationships in `word/_rels/settings.xml.rels` are filtered. Applied on both
  the full-repack and selective-save paths so they emit the same package.
- Media conversion is driven by the relationship graph. Entries no relationship
  points at are stored byte for byte but never decoded, and TIFF decoding draws
  down a package-wide pixel budget on top of the existing per-image cap.
- `assertXmlResourceLimits` runs at unzip for `word/document.xml`,
  `word/styles.xml` and `word/numbering.xml`, so every parse entry point shares
  one bound. `extractDocxText` caps rows per table and total emitted characters
  across body plus header/footer parts.
- `xmlns` declarations carried down the ancestor chain are bounded by value
  length and by accumulated size, alongside the existing per-element count.
- Run hyperlink targets in the painter go through `sanitizeExternalUrl`, matching
  the image hyperlink path; `#bookmark` targets stay verbatim.
- `createEmptyHeaderFooter` no longer pre-mints a relationship. The save path
  owns the part filename, the `.rels` entry and the content-type override
  together; minting one early made `hasUnmaterializedHeaderFooter` false, so the
  save wrote none of them and `w:headerReference` resolved to nothing.

Not changed, reported instead:

- Style-numbered list parsing already uses a per-parse index, so the reported
  per-paragraph scan is not there. There is real super-linear growth in that
  code, driven by the number of list instances a document uses and by the
  counter-propagation writes rather than by lookup; fixing it means changing how
  `computeListMarker` stores counters, which belongs in its own change.
- Rejecting one of several stacked run-property revisions on a range keeps the
  other revision records but restores formatting from the earliest matched
  change, undoing the still-pending later revision. The contained guard would
  trade a wrong restore for a skipped one; composing the correct target needs a
  design decision, so it is left as is.

https://claude.ai/code/session_01Mh2FSuNXnqAUXhrmpjGenW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Newly created headers and footers are included when documents are saved.
  - Unreferenced media is preserved without unnecessary conversion.
- **Bug Fixes**
  - Improved handling of invalid colours, font themes and XML-sensitive formatting values.
  - Hyperlinks now safely support web addresses and internal bookmarks.
  - Attached template references are removed when saving.
- **Security & Reliability**
  - Added safeguards for oversized XML, namespace data, extracted text and media conversion.
  - Improved preservation of document content during round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->