### PR TITLE
feat(core): materialize Yjs snapshots as DOCX

### DIFF
--- a/.changeset/strong-ravens-collaborate.md
+++ b/.changeset/strong-ravens-collaborate.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add server-side materialization of Folio Yjs snapshots into fidelity-preserving DOCX files.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -418,6 +418,15 @@ export const FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS: readonly ["remove-attr
 // @public
 export const FOLIO_VERSION_COMPARISON_SCOPES: readonly ["text", "formatting", "metadata"];
 
+// @public
+export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES: readonly ["empty_update", "invalid_update", "missing_document", "update_too_large"];
+
+// @public
+export const FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME = "prosemirror";
+
+// @public
+export const FOLIO_YJS_UPDATE_MAX_BYTES: number;
+
 // @public (undocumented)
 export type FolioAIBlock = {
     id: string;
@@ -1305,6 +1314,16 @@ export type FolioVersionDiffSummaryCounts = {
 };
 
 // @public
+export class FolioYjsDocxMaterializationError extends FolioYjsDocxMaterializationError_base<{
+    code: FolioYjsDocxMaterializationErrorCode;
+    message: string;
+    cause?: unknown;
+}> {}
+
+// @public
+export type FolioYjsDocxMaterializationErrorCode = (typeof FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES)[number];
+
+// @public
 export const generateRedlineDocx: (base: ArrayBuffer, revised: ArrayBuffer, options?: GenerateRedlineDocxOptions) => Promise<GenerateRedlineDocxResult>;
 
 // @public
@@ -1455,6 +1474,15 @@ export const isSequentialFolioBlockId: (id: string) => boolean;
 
 // @public (undocumented)
 export const isSupportedFolioDocumentOperationVersion: (value: unknown) => value is typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
+
+// @public
+export const materializeYjsDocx: (input: MaterializeYjsDocxOptions) => Promise<ArrayBuffer>;
+
+// @public
+export type MaterializeYjsDocxOptions = {
+    sourceDocx: ArrayBuffer | Uint8Array;
+    yjsUpdate: Uint8Array;
+};
 
 // @public (undocumented)
 export const normalizeFolioAIBlockText: (text: string) => string;

--- a/packages/core/src/docx/server/materializeYjsDocx.test.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import { EditorState } from "prosemirror-state";
+import { prosemirrorToYXmlFragment } from "y-prosemirror";
+import * as Y from "yjs";
+
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { parseDocx } from "../parser";
+import { createDocx } from "../rezip";
+import { createEmptyDocument } from "../../utils/createDocument";
+import { extractDocxText } from "./extractDocxText";
+import {
+  FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME,
+  FOLIO_YJS_UPDATE_MAX_BYTES,
+  FolioYjsDocxMaterializationError,
+  materializeYjsDocx,
+} from "./materializeYjsDocx";
+
+const createCollaborativeUpdate = async (sourceDocx: ArrayBuffer, text: string) => {
+  const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+  const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
+  const bodyEnd = initialState.doc.content.size - 1;
+  const nextState = initialState.apply(
+    initialState.tr.replaceWith(1, bodyEnd, initialState.schema.text(text)),
+  );
+  const ydoc = new Y.Doc();
+  prosemirrorToYXmlFragment(
+    nextState.doc,
+    ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME),
+  );
+  const update = Y.encodeStateAsUpdate(ydoc);
+  ydoc.destroy();
+  return update;
+};
+
+describe("materializeYjsDocx", () => {
+  test("replaces body content while preserving the source DOCX package", async () => {
+    const sourceDocx = await createDocx(createEmptyDocument({ initialText: "Original text" }));
+    const yjsUpdate = await createCollaborativeUpdate(sourceDocx, "Collaborative text");
+
+    const output = await materializeYjsDocx({ sourceDocx, yjsUpdate });
+    const extracted = await extractDocxText(output);
+    const [sourceZip, outputZip] = await Promise.all([
+      JSZip.loadAsync(sourceDocx),
+      JSZip.loadAsync(output),
+    ]);
+
+    expect(extracted.paragraphs.map(({ text }) => text)).toContain("Collaborative text");
+    expect(extracted.paragraphs.map(({ text }) => text)).not.toContain("Original text");
+    expect(await outputZip.file("word/styles.xml")?.async("text")).toBe(
+      await sourceZip.file("word/styles.xml")?.async("text"),
+    );
+  });
+
+  test("rejects a state update without Folio's document fragment", async () => {
+    const sourceDocx = await createDocx(createEmptyDocument());
+    const ydoc = new Y.Doc();
+    ydoc.getMap("unrelated").set("value", true);
+    const yjsUpdate = Y.encodeStateAsUpdate(ydoc);
+    ydoc.destroy();
+
+    expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
+      _tag: "FolioYjsDocxMaterializationError",
+      code: "missing_document",
+    } satisfies Partial<FolioYjsDocxMaterializationError>);
+  });
+
+  test("rejects an update above the materialization limit", async () => {
+    const sourceDocx = await createDocx(createEmptyDocument());
+
+    expect(
+      materializeYjsDocx({
+        sourceDocx,
+        yjsUpdate: new Uint8Array(FOLIO_YJS_UPDATE_MAX_BYTES + 1),
+      }),
+    ).rejects.toMatchObject({
+      _tag: "FolioYjsDocxMaterializationError",
+      code: "update_too_large",
+    } satisfies Partial<FolioYjsDocxMaterializationError>);
+  });
+});

--- a/packages/core/src/docx/server/materializeYjsDocx.test.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.test.ts
@@ -59,18 +59,16 @@ describe("materializeYjsDocx", () => {
     const yjsUpdate = Y.encodeStateAsUpdate(ydoc);
     ydoc.destroy();
 
-    expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
+    await expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
       _tag: "FolioYjsDocxMaterializationError",
       code: "missing_document",
     } satisfies Partial<FolioYjsDocxMaterializationError>);
   });
 
-  test("rejects an update above the materialization limit", async () => {
-    const sourceDocx = await createDocx(createEmptyDocument());
-
-    expect(
+  test("rejects an oversized update before parsing the source DOCX", async () => {
+    await expect(
       materializeYjsDocx({
-        sourceDocx,
+        sourceDocx: new Uint8Array([1, 2, 3]),
         yjsUpdate: new Uint8Array(FOLIO_YJS_UPDATE_MAX_BYTES + 1),
       }),
     ).rejects.toMatchObject({

--- a/packages/core/src/docx/server/materializeYjsDocx.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.ts
@@ -7,9 +7,13 @@ import { schema } from "../../prosemirror/schema";
 import { parseDocx } from "../parser";
 import { repackDocx } from "../rezip";
 
+/** Yjs fragment that stores Folio's canonical ProseMirror document. */
 export const FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME = "prosemirror";
+
+/** Maximum accepted size of a complete Yjs collaboration state update. */
 export const FOLIO_YJS_UPDATE_MAX_BYTES = 10 * 1024 * 1024;
 
+/** Stable failure codes returned by server-side Yjs-to-DOCX materialization. */
 export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES = [
   "empty_update",
   "invalid_update",
@@ -17,9 +21,11 @@ export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES = [
   "update_too_large",
 ] as const;
 
+/** Failure code for a rejected Yjs-to-DOCX materialization request. */
 export type FolioYjsDocxMaterializationErrorCode =
   (typeof FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES)[number];
 
+/** Typed failure raised when a collaboration snapshot cannot be materialized. */
 export class FolioYjsDocxMaterializationError extends TaggedError(
   "FolioYjsDocxMaterializationError",
 )<{
@@ -28,6 +34,7 @@ export class FolioYjsDocxMaterializationError extends TaggedError(
   cause?: unknown;
 }> {}
 
+/** Inputs for materializing a complete Yjs state update into a DOCX package. */
 export type MaterializeYjsDocxOptions = {
   /** Original DOCX whose package parts and non-body stories must be preserved. */
   sourceDocx: ArrayBuffer | Uint8Array;

--- a/packages/core/src/docx/server/materializeYjsDocx.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.ts
@@ -1,0 +1,90 @@
+import { TaggedError } from "better-result";
+import { initProseMirrorDoc } from "y-prosemirror";
+import * as Y from "yjs";
+
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { schema } from "../../prosemirror/schema";
+import { parseDocx } from "../parser";
+import { repackDocx } from "../rezip";
+
+export const FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME = "prosemirror";
+export const FOLIO_YJS_UPDATE_MAX_BYTES = 10 * 1024 * 1024;
+
+export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES = [
+  "empty_update",
+  "invalid_update",
+  "missing_document",
+  "update_too_large",
+] as const;
+
+export type FolioYjsDocxMaterializationErrorCode =
+  (typeof FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES)[number];
+
+export class FolioYjsDocxMaterializationError extends TaggedError(
+  "FolioYjsDocxMaterializationError",
+)<{
+  code: FolioYjsDocxMaterializationErrorCode;
+  message: string;
+  cause?: unknown;
+}> {}
+
+export type MaterializeYjsDocxOptions = {
+  /** Original DOCX whose package parts and non-body stories must be preserved. */
+  sourceDocx: ArrayBuffer | Uint8Array;
+  /** Complete Yjs state update containing Folio's ProseMirror fragment. */
+  yjsUpdate: Uint8Array;
+};
+
+const readProseMirrorDocument = (yjsUpdate: Uint8Array) => {
+  if (yjsUpdate.byteLength === 0) {
+    throw new FolioYjsDocxMaterializationError({
+      code: "empty_update",
+      message: "Cannot materialize DOCX from an empty Yjs update.",
+    });
+  }
+  if (yjsUpdate.byteLength > FOLIO_YJS_UPDATE_MAX_BYTES) {
+    throw new FolioYjsDocxMaterializationError({
+      code: "update_too_large",
+      message: "Yjs update exceeds the DOCX materialization limit.",
+    });
+  }
+
+  const ydoc = new Y.Doc();
+  try {
+    Y.applyUpdate(ydoc, yjsUpdate);
+    const fragment = ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME);
+    if (fragment.length === 0) {
+      throw new FolioYjsDocxMaterializationError({
+        code: "missing_document",
+        message: "Yjs update does not contain a Folio document.",
+      });
+    }
+
+    return initProseMirrorDoc(fragment, schema).doc;
+  } catch (error) {
+    if (error instanceof FolioYjsDocxMaterializationError) {
+      throw error;
+    }
+    throw new FolioYjsDocxMaterializationError({
+      code: "invalid_update",
+      message: "Yjs update is not a valid Folio collaboration snapshot.",
+      cause: error,
+    });
+  } finally {
+    ydoc.destroy();
+  }
+};
+
+/**
+ * Materialize a complete Folio Yjs state update into a DOCX while preserving
+ * package parts from the source document. This is the server-side equivalent
+ * of the browser editor's full save path for the main document story.
+ */
+export const materializeYjsDocx = async ({
+  sourceDocx,
+  yjsUpdate,
+}: MaterializeYjsDocxOptions): Promise<ArrayBuffer> => {
+  const baseDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+  const proseMirrorDocument = readProseMirrorDocument(yjsUpdate);
+  return await repackDocx(fromProseDoc(proseMirrorDocument, baseDocument));
+};

--- a/packages/core/src/docx/server/materializeYjsDocx.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.ts
@@ -1,4 +1,4 @@
-import { TaggedError } from "better-result";
+import { Result, TaggedError } from "better-result";
 import { initProseMirrorDoc } from "y-prosemirror";
 import * as Y from "yjs";
 
@@ -57,29 +57,32 @@ const readProseMirrorDocument = (yjsUpdate: Uint8Array) => {
   }
 
   const ydoc = new Y.Doc();
-  try {
-    Y.applyUpdate(ydoc, yjsUpdate);
-    const fragment = ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME);
-    if (fragment.length === 0) {
-      throw new FolioYjsDocxMaterializationError({
-        code: "missing_document",
-        message: "Yjs update does not contain a Folio document.",
-      });
-    }
-
-    return initProseMirrorDoc(fragment, schema).doc;
-  } catch (error) {
-    if (error instanceof FolioYjsDocxMaterializationError) {
-      throw error;
-    }
-    throw new FolioYjsDocxMaterializationError({
-      code: "invalid_update",
-      message: "Yjs update is not a valid Folio collaboration snapshot.",
-      cause: error,
-    });
-  } finally {
-    ydoc.destroy();
+  const parsed = Result.try({
+    try: () => {
+      Y.applyUpdate(ydoc, yjsUpdate);
+      const fragment = ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME);
+      if (fragment.length === 0) {
+        throw new FolioYjsDocxMaterializationError({
+          code: "missing_document",
+          message: "Yjs update does not contain a Folio document.",
+        });
+      }
+      return initProseMirrorDoc(fragment, schema).doc;
+    },
+    catch: (cause) =>
+      cause instanceof FolioYjsDocxMaterializationError
+        ? cause
+        : new FolioYjsDocxMaterializationError({
+            code: "invalid_update",
+            message: "Yjs update is not a valid Folio collaboration snapshot.",
+            cause,
+          }),
+  });
+  ydoc.destroy();
+  if (parsed.isOk()) {
+    return parsed.value;
   }
+  throw parsed.error;
 };
 
 /**
@@ -91,7 +94,7 @@ export const materializeYjsDocx = async ({
   sourceDocx,
   yjsUpdate,
 }: MaterializeYjsDocxOptions): Promise<ArrayBuffer> => {
-  const baseDocument = await parseDocx(sourceDocx, { preloadFonts: false });
   const proseMirrorDocument = readProseMirrorDocument(yjsUpdate);
+  const baseDocument = await parseDocx(sourceDocx, { preloadFonts: false });
   return await repackDocx(fromProseDoc(proseMirrorDocument, baseDocument));
 };

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -199,6 +199,15 @@ export {
 } from "./docx/server/extractDocxText";
 export { docxToMarkdown } from "./docx/server/docxToMarkdown";
 export {
+  FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES,
+  FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME,
+  FOLIO_YJS_UPDATE_MAX_BYTES,
+  FolioYjsDocxMaterializationError,
+  materializeYjsDocx,
+  type FolioYjsDocxMaterializationErrorCode,
+  type MaterializeYjsDocxOptions,
+} from "./docx/server/materializeYjsDocx";
+export {
   createBilingualDocument,
   InvalidBilingualDocumentOptionsError,
   readBilingualDocument,


### PR DESCRIPTION
## Summary

- add a server-only API that materializes a complete Folio Yjs state update against its source DOCX
- preserve source package parts through the existing parser and fidelity-checked repack pipeline
- reject empty, malformed, missing-document, and oversized updates with a typed error
- publish the collaboration fragment name and input ceiling so hosts share the same boundary contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side conversion of Folio Yjs snapshots into fidelity-preserving DOCX files.
  * Preserves existing DOCX package content while updating document body text.
  * Added clear error reporting for empty, invalid, oversized, or incomplete snapshots.
  * Added a 10 MB limit for incoming Yjs updates.

* **Tests**
  * Added coverage for successful conversion, package preservation, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->