### PR TITLE
fix: preserve bilingual document layout fidelity

### DIFF
--- a/.changeset/clear-bilingual-columns.md
+++ b/.changeset/clear-bilingual-columns.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Keep bilingual columns and merged-cell widths valid, and preserve highlighted text contrast on dark document canvases.

--- a/.changeset/clear-bilingual-columns.md
+++ b/.changeset/clear-bilingual-columns.md
@@ -3,4 +3,4 @@
 "@stll/folio-react": patch
 ---
 
-Keep bilingual columns and merged-cell widths valid, and preserve highlighted text contrast on dark document canvases.
+Keep bilingual columns and merged-cell widths valid, preserve signature-field rules, and maintain highlighted text contrast on dark document canvases.

--- a/packages/core/src/ai-edits/table-cell-mutations.test.ts
+++ b/packages/core/src/ai-edits/table-cell-mutations.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { Schema } from "prosemirror-model";
+import { history, undo } from "prosemirror-history";
 import { EditorState } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
+import { standaloneTableCellFromProseMirror } from "../prosemirror/conversion/fromProseDoc";
 import { mergeTableRectangle, splitTableRectangle } from "./table-cell-mutations";
 
 const schema = new Schema({
@@ -26,6 +28,9 @@ const schema = new Schema({
         colspan: { default: 1 },
         rowspan: { default: 1 },
         colwidth: { default: null },
+        width: { default: null },
+        widthType: { default: null },
+        _originalFormatting: { default: null },
         _preserveVMergeRestart: { default: null },
         _docxVMergeContinuationCells: { default: null },
       },
@@ -35,6 +40,34 @@ const schema = new Schema({
 
 const cell = (text: string) =>
   schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text(text)])]);
+
+type WidthCellOptions = {
+  text: string;
+  width: number;
+  widthType: "dxa" | "pct";
+  colwidth?: number;
+  preserveOriginalFormatting?: boolean;
+};
+
+const widthCell = ({
+  text,
+  width,
+  widthType,
+  colwidth,
+  preserveOriginalFormatting = true,
+}: WidthCellOptions) =>
+  schema.node(
+    "tableCell",
+    {
+      colwidth: colwidth === undefined ? null : [colwidth],
+      width,
+      widthType,
+      _originalFormatting: preserveOriginalFormatting
+        ? { width: { value: width, type: widthType } }
+        : null,
+    },
+    [schema.node("paragraph", null, [schema.text(text)])],
+  );
 
 const table = schema.node("table", null, [
   schema.node("tableRow", null, [cell("A"), cell("B"), cell("X")]),
@@ -92,5 +125,147 @@ describe("table cell mutations", () => {
       }),
     ).toBeNull();
     expect(tr.steps).toEqual([]);
+  });
+
+  test("sums compatible preferred widths and restores them on undo", () => {
+    const bilingualRow = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        widthCell({ text: "Source", width: 2500, widthType: "pct", colwidth: 4860 }),
+        widthCell({ text: "Translation", width: 2500, widthType: "pct", colwidth: 4860 }),
+      ]),
+    ]);
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [bilingualRow]),
+      plugins: [history()],
+    });
+    const merged = mergeTableRectangle({
+      tr: state.tr,
+      tablePosition: 0,
+      table: state.doc.child(0),
+      rectangle: { left: 0, top: 0, right: 2, bottom: 1 },
+    });
+    if (!merged) {
+      throw new Error("Expected the bilingual row to merge.");
+    }
+    state = state.apply(merged);
+
+    const mergedCell = state.doc.child(0).child(0).child(0);
+    expect(mergedCell.attrs).toMatchObject({
+      colspan: 2,
+      colwidth: [4860, 4860],
+      width: 5000,
+      widthType: "pct",
+    });
+    expect(standaloneTableCellFromProseMirror(mergedCell).formatting?.width).toEqual({
+      value: 5000,
+      type: "pct",
+    });
+
+    expect(
+      undo(state, (transaction) => {
+        state = state.apply(transaction);
+      }),
+    ).toBe(true);
+    const restoredRow = state.doc.child(0).child(0);
+    expect(restoredRow.childCount).toBe(2);
+    expect(restoredRow.child(0).attrs).toMatchObject({
+      colwidth: [4860],
+      width: 2500,
+      widthType: "pct",
+    });
+    expect(restoredRow.child(1).attrs).toMatchObject({
+      colwidth: [4860],
+      width: 2500,
+      widthType: "pct",
+    });
+  });
+
+  test("sums fixed preferred widths", () => {
+    const fixedWidthRow = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        widthCell({ text: "First", width: 2400, widthType: "dxa" }),
+        widthCell({ text: "Second", width: 3600, widthType: "dxa" }),
+      ]),
+    ]);
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [fixedWidthRow]),
+    });
+    const merged = mergeTableRectangle({
+      tr: state.tr,
+      tablePosition: 0,
+      table: state.doc.child(0),
+      rectangle: { left: 0, top: 0, right: 2, bottom: 1 },
+    });
+    if (!merged) {
+      throw new Error("Expected the fixed-width row to merge.");
+    }
+
+    expect(merged.doc.child(0).child(0).child(0).attrs).toMatchObject({
+      width: 6000,
+      widthType: "dxa",
+    });
+  });
+
+  test("clears incompatible preferred widths instead of retaining the first cell width", () => {
+    const mixedWidthRow = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        widthCell({ text: "First", width: 2500, widthType: "pct" }),
+        widthCell({ text: "Second", width: 3600, widthType: "dxa" }),
+      ]),
+    ]);
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [mixedWidthRow]),
+    });
+    const merged = mergeTableRectangle({
+      tr: state.tr,
+      tablePosition: 0,
+      table: state.doc.child(0),
+      rectangle: { left: 0, top: 0, right: 2, bottom: 1 },
+    });
+    if (!merged) {
+      throw new Error("Expected the mixed-width row to merge.");
+    }
+
+    const mergedCell = merged.doc.child(0).child(0).child(0);
+    expect(mergedCell.attrs).toMatchObject({ width: null, widthType: null });
+    expect(standaloneTableCellFromProseMirror(mergedCell).formatting?.width).toBeUndefined();
+  });
+
+  test("omits an incompatible merged width when no original cell formatting exists", () => {
+    const mixedWidthRow = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        widthCell({
+          text: "First",
+          width: 2500,
+          widthType: "pct",
+          preserveOriginalFormatting: false,
+        }),
+        widthCell({
+          text: "Second",
+          width: 3600,
+          widthType: "dxa",
+          preserveOriginalFormatting: false,
+        }),
+      ]),
+    ]);
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [mixedWidthRow]),
+    });
+    const merged = mergeTableRectangle({
+      tr: state.tr,
+      tablePosition: 0,
+      table: state.doc.child(0),
+      rectangle: { left: 0, top: 0, right: 2, bottom: 1 },
+    });
+    if (!merged) {
+      throw new Error("Expected the mixed-width row to merge.");
+    }
+
+    const mergedCell = merged.doc.child(0).child(0).child(0);
+    expect(standaloneTableCellFromProseMirror(mergedCell).formatting).toEqual({ gridSpan: 2 });
   });
 });

--- a/packages/core/src/ai-edits/table-cell-mutations.ts
+++ b/packages/core/src/ai-edits/table-cell-mutations.ts
@@ -47,6 +47,7 @@ export const mergeTableRectangle = ({
   const tableStart = tablePosition + 1;
   const seen = new Set<number>();
   const cells: { position: number; cell: PMNode }[] = [];
+  const topRowCells: PMNode[] = [];
   let appendedContent = Fragment.empty;
   for (let row = rectangle.top; row < rectangle.bottom; row++) {
     for (let column = rectangle.left; column < rectangle.right; column++) {
@@ -60,6 +61,9 @@ export const mergeTableRectangle = ({
       }
       seen.add(cellPosition);
       cells.push({ position: cellPosition, cell });
+      if (row === rectangle.top) {
+        topRowCells.push(cell);
+      }
       if (cells.length > 1 && !isEmptyTableCell(cell)) {
         appendedContent = appendedContent.append(cell.content);
       }
@@ -89,10 +93,8 @@ export const mergeTableRectangle = ({
     return null;
   }
   const mergedColspan = rectangle.right - rectangle.left;
-  const nextColwidth = Array.isArray(colwidth) ? [...colwidth] : null;
-  while (nextColwidth && nextColwidth.length < mergedColspan) {
-    nextColwidth.push(0);
-  }
+  const nextColwidth = mergeTopRowColwidths(topRowCells, mergedColspan);
+  const preferredWidth = mergeTopRowPreferredWidths(topRowCells);
   const mapFrom = tr.mapping.maps.length;
   for (const { position: cellPosition, cell } of cells.slice(1)) {
     const position = tr.mapping.slice(mapFrom).map(tableStart + cellPosition);
@@ -104,6 +106,8 @@ export const mergeTableRectangle = ({
     colspan: mergedColspan,
     rowspan: rectangle.bottom - rectangle.top,
     colwidth: nextColwidth,
+    width: preferredWidth.type === "value" ? preferredWidth.width : null,
+    widthType: preferredWidth.type === "value" ? preferredWidth.widthType : null,
   });
   if (appendedContent.size > 0) {
     const contentEnd = absoluteMergedPosition + 1 + merged.cell.content.size;
@@ -111,6 +115,55 @@ export const mergeTableRectangle = ({
     tr = tr.replaceWith(contentStart, contentEnd, appendedContent);
   }
   return tr;
+};
+
+const mergeTopRowColwidths = (cells: PMNode[], mergedColspan: number): number[] | null => {
+  const widths: number[] = [];
+  for (const cell of cells) {
+    const colspan: unknown = cell.attrs["colspan"];
+    const colwidth: unknown = cell.attrs["colwidth"];
+    if (
+      typeof colspan !== "number" ||
+      !Number.isInteger(colspan) ||
+      colspan < 1 ||
+      !Array.isArray(colwidth) ||
+      colwidth.length !== colspan ||
+      !colwidth.every((width) => typeof width === "number" && width > 0)
+    ) {
+      return null;
+    }
+    widths.push(...colwidth);
+  }
+  return widths.length === mergedColspan ? widths : null;
+};
+
+type MergedPreferredWidth =
+  | { type: "value"; width: number; widthType: "dxa" | "pct" }
+  | { type: "absent" };
+
+/** A horizontal merge owns the whole top-row span. Sum compatible explicit
+ * preferred widths; retaining only the first cell's width makes a 50%+50%
+ * bilingual row serialize as a 50%-wide spanning cell. Mixed/implicit units
+ * cannot be composed safely, so clear the preference and let the table grid
+ * define the merged width. */
+const mergeTopRowPreferredWidths = (cells: PMNode[]): MergedPreferredWidth => {
+  let width = 0;
+  let widthType: "dxa" | "pct" | undefined;
+  for (const cell of cells) {
+    const candidateWidth: unknown = cell.attrs["width"];
+    const candidateType: unknown = cell.attrs["widthType"];
+    if (
+      typeof candidateWidth !== "number" ||
+      !Number.isFinite(candidateWidth) ||
+      (candidateType !== "dxa" && candidateType !== "pct") ||
+      (widthType !== undefined && candidateType !== widthType)
+    ) {
+      return { type: "absent" };
+    }
+    width += candidateWidth;
+    widthType = candidateType;
+  }
+  return widthType === undefined ? { type: "absent" } : { type: "value", width, widthType };
 };
 
 export const mergeTrackedVerticalTableCells = ({

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../types/document";
 import { createEmptyDocument } from "../../utils/createDocument";
 import { ensureParaIds } from "../ensureParaIds";
+import { getParagraphText } from "../paragraphParser";
 import { parseDocx } from "../parser";
 import { createDocx } from "../rezip";
 import {
@@ -185,7 +186,7 @@ describe("createBilingualDocument", () => {
     expect(content[1]?.type === "paragraph" && content[1].sectionProperties).toBeTruthy();
   });
 
-  test("keeps the left column identical to the source blocks", async () => {
+  test("keeps the left column content and identities from the source blocks", async () => {
     const source = await buildSource();
     const { document } = createBilingualDocument(source, await bilingualDocumentOptions(source));
 
@@ -194,7 +195,53 @@ describe("createBilingualDocument", () => {
         ? [block]
         : [],
     );
-    expect(columnParagraphs(document).left).toEqual(sourceParagraphs);
+    expect(
+      columnParagraphs(document).left.map(({ formatting: _formatting, ...content }) => content),
+    ).toEqual(sourceParagraphs.map(({ formatting: _formatting, ...content }) => content));
+  });
+
+  test("projects direct and inherited full-page geometry into each column", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    source.package.styles?.styles.push({
+      styleId: "FormLine",
+      type: "paragraph",
+      name: "Form Line",
+      pPr: {
+        indentLeft: 5040,
+        indentRight: -360,
+        tabs: [
+          { position: 4320, alignment: "left" },
+          { position: 9648, alignment: "left" },
+        ],
+      },
+    });
+    source.package.document.content = [
+      {
+        ...paragraph("Signature field", "FormLine"),
+        formatting: {
+          styleId: "FormLine",
+          indentFirstLine: 540,
+        },
+      },
+    ];
+    const stamped = await ensureParaIds(await createDocx(source));
+    const parsed = await parseDocx(stamped.docx, { preloadFonts: false });
+    const { document } = createBilingualDocument(parsed, await bilingualDocumentOptions(parsed));
+    const { left, right } = columnParagraphs(document);
+
+    for (const projected of [left.at(0), right.at(0)]) {
+      expect(projected?.formatting).toMatchObject({
+        indentLeft: 2520,
+        indentRight: 0,
+        indentFirstLine: 270,
+        tabs: [
+          { position: 2160, alignment: "left" },
+          { position: 4153, alignment: "left" },
+        ],
+      });
+    }
+    expect(getParagraphText(left.at(0)!)).toBe("Signature field");
+    expect(getParagraphText(right.at(0)!)).toBe("Signature field");
   });
 
   test("keeps a source table once, in a row spanning both columns", async () => {

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -6,7 +6,10 @@
  * cloned per language, so both columns count independently (1. / 1. instead of
  * 1. / 2.) and stay live in Word. Right-column paragraphs receive fresh
  * `paraId`s so callers can address each row later (for example to replace the
- * placeholder copy with a translation by block id).
+ * placeholder copy with a translation by block id). Horizontal paragraph
+ * geometry is projected into the half-width cells: full-page indents and tab
+ * stops otherwise place signature fields outside their column and let prose
+ * overlap the translation.
  *
  * Section breaks cannot live inside a table cell, so the body is split at
  * paragraphs carrying `sectionProperties`: each section becomes its own table
@@ -113,6 +116,8 @@ const HALF_WIDTH_PCT = 2500;
 const A4_TEXT_WIDTH_TWIPS = 9072;
 const ROW_ID_NAMESPACE = "folio-bilingual";
 const BILINGUAL_TABLE_STYLE_ID = "FolioBilingualTranslation";
+const MIN_COLUMN_TEXT_WIDTH_TWIPS = 720;
+const MIN_TAB_TRAILING_WIDTH_TWIPS = 360;
 
 const GRID_BORDER = { style: "single", size: 4, space: 0 } as const;
 
@@ -203,7 +208,7 @@ export function createBilingualDocument(
       }
       const { copy, ref } = copyParagraph(block);
       rows.push({ kind: classifyParagraph(block, styleById), rowId: ref.targetParaId, ...ref });
-      sectionRows.push(buildRow(block, copy));
+      sectionRows.push(buildRow(block, copy, styleById, textWidth));
       continue;
     }
     const paragraphs = collectTableParagraphs(block)
@@ -612,11 +617,116 @@ const collectTableParagraphs = (table: Table): Paragraph[] => {
 // Output table
 // ----------------------------------------------------------------------------
 
-const buildRow = (left: Paragraph, right: Paragraph): Table["rows"][number] => ({
-  type: "tableRow",
-  formatting: { cantSplit: true },
-  cells: [buildCell(left), buildCell(right)],
-});
+const buildRow = (
+  left: Paragraph,
+  right: Paragraph,
+  styleById: Map<string, Style>,
+  textWidth: number,
+): Table["rows"][number] => {
+  const columnWidth = Math.floor(textWidth / 2);
+  const geometry = resolveHorizontalParagraphGeometry(left, styleById);
+  return {
+    type: "tableRow",
+    formatting: { cantSplit: true },
+    cells: [
+      buildCell(projectParagraphIntoColumn(left, geometry, textWidth, columnWidth)),
+      buildCell(projectParagraphIntoColumn(right, geometry, textWidth, columnWidth)),
+    ],
+  };
+};
+
+type HorizontalParagraphGeometry = Pick<
+  ParagraphFormatting,
+  "indentLeft" | "indentRight" | "indentFirstLine" | "hangingIndent" | "tabs"
+>;
+
+const HORIZONTAL_PARAGRAPH_KEYS = [
+  "indentLeft",
+  "indentRight",
+  "indentFirstLine",
+  "hangingIndent",
+  "tabs",
+] as const satisfies readonly (keyof HorizontalParagraphGeometry)[];
+
+/** Resolve only the paragraph properties whose coordinates change when a
+ * full-width paragraph is placed in a half-width cell. Direct pPr wins over
+ * the basedOn style chain, matching Word's paragraph-style cascade. */
+const resolveHorizontalParagraphGeometry = (
+  paragraph: Paragraph,
+  styleById: Map<string, Style>,
+): HorizontalParagraphGeometry => {
+  const chain: Style[] = [];
+  const seen = new Set<string>();
+  let style = paragraph.formatting?.styleId
+    ? styleById.get(paragraph.formatting.styleId)
+    : undefined;
+  while (style && !seen.has(style.styleId)) {
+    seen.add(style.styleId);
+    chain.push(style);
+    style = style.basedOn ? styleById.get(style.basedOn) : undefined;
+  }
+
+  const geometry: HorizontalParagraphGeometry = {};
+  for (const current of chain.toReversed()) {
+    assignHorizontalParagraphGeometry(geometry, current.pPr);
+  }
+  assignHorizontalParagraphGeometry(geometry, paragraph.formatting);
+  return geometry;
+};
+
+const assignHorizontalParagraphGeometry = (
+  target: HorizontalParagraphGeometry,
+  source: ParagraphFormatting | undefined,
+): void => {
+  for (const key of HORIZONTAL_PARAGRAPH_KEYS) {
+    const value = source?.[key];
+    if (value !== undefined) {
+      Object.assign(target, { [key]: value });
+    }
+  }
+};
+
+const projectParagraphIntoColumn = (
+  paragraph: Paragraph,
+  geometry: HorizontalParagraphGeometry,
+  sourceWidth: number,
+  columnWidth: number,
+): Paragraph => {
+  const scale = columnWidth / sourceWidth;
+  const maxSideIndent = Math.max(0, columnWidth - MIN_COLUMN_TEXT_WIDTH_TWIPS);
+  let indentLeft = projectSideIndent(geometry.indentLeft, scale, maxSideIndent);
+  let indentRight = projectSideIndent(geometry.indentRight, scale, maxSideIndent);
+  const excess = indentLeft + indentRight - maxSideIndent;
+  if (excess > 0) {
+    const total = indentLeft + indentRight;
+    indentLeft = Math.round((indentLeft / total) * maxSideIndent);
+    indentRight = maxSideIndent - indentLeft;
+  }
+
+  const formatting: ParagraphFormatting = {
+    ...paragraph.formatting,
+    ...(geometry.indentLeft !== undefined && { indentLeft }),
+    ...(geometry.indentRight !== undefined && { indentRight }),
+    ...(geometry.indentFirstLine !== undefined && {
+      indentFirstLine: Math.round(geometry.indentFirstLine * scale),
+    }),
+    ...(geometry.hangingIndent !== undefined && { hangingIndent: geometry.hangingIndent }),
+    ...(geometry.tabs !== undefined && {
+      tabs: geometry.tabs.map((tab) => ({
+        ...tab,
+        position: Math.min(
+          Math.max(0, Math.round(tab.position * scale)),
+          Math.max(0, columnWidth - MIN_TAB_TRAILING_WIDTH_TWIPS),
+        ),
+      })),
+    }),
+  };
+
+  return { ...paragraph, formatting };
+};
+
+const projectSideIndent = (value: number | undefined, scale: number, maximum: number): number =>
+  Math.min(Math.max(0, Math.round((value ?? 0) * scale)), maximum);
 
 const buildCell = (paragraph: Paragraph): TableCell => ({
   type: "tableCell",

--- a/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
@@ -473,6 +473,8 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#000000");
+    expect(textEl?.className).toContain("docx-run-background-text");
+    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#000000");
   });
 
   test("keeps automatic text readable on dark DOCX highlights", () => {
@@ -503,6 +505,7 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
+    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#FFFFFF");
   });
 
   test("keeps inherited default-black text readable on dark DOCX highlights", () => {
@@ -568,6 +571,7 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
     expect(anchorEl?.style.color).toBe("#FFFFFF");
+    expect(anchorEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#FFFFFF");
   });
 
   test("keeps inherited default-black hyperlink text readable on dark DOCX highlights", () => {
@@ -603,6 +607,7 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
     expect(anchorEl?.style.color).toBe("#FFFFFF");
+    expect(anchorEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#FFFFFF");
   });
 
   test("preserves direct black hyperlink text without DOCX highlights", () => {
@@ -765,6 +770,43 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
+    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe(
+      TEST_EXPLICIT_TEXT_COLOR,
+    );
+  });
+
+  test("preserves resolved theme text colors on DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          color: TEST_EXPLICIT_TEXT_COLOR,
+          textColorSource: "paragraphDefault",
+          highlight: TEST_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
+    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe(
+      TEST_EXPLICIT_TEXT_COLOR,
+    );
   });
 
   test("exposes explicit run color as --doc-run-color for dark-mode inversion", () => {
@@ -822,6 +864,7 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#000000");
+    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#000000");
   });
 
   test("preserves tracked-change author colors on DOCX highlights", () => {

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -496,7 +496,7 @@ describe("renderLine box model", () => {
     expect(text?.style["fontSize"]).toBeUndefined();
   });
 
-  test("renders underlined tabs as a continuous rule without a text underline mark", () => {
+  test("paints underlined tabs inside the line box without a text underline mark", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",
       id: "signature-line",
@@ -526,7 +526,8 @@ describe("renderLine box model", () => {
 
     const tabEl = findTabEl(lineEl);
     expect(tabEl).toBeDefined();
-    expect(tabEl?.style["borderBottom"]).toBe("1px solid currentColor");
+    expect(tabEl?.style["boxShadow"]).toBe("inset 0 -1px 0 currentColor");
+    expect(tabEl?.style["borderBottom"]).toBeUndefined();
     expect(tabEl?.style["textDecorationLine"]).toBe("");
   });
 
@@ -687,7 +688,8 @@ describe("renderLine box model", () => {
     }) as unknown as FakeElement;
     const space = lineEl.children.at(0);
 
-    expect(space?.style["borderBottom"]).toBe("1px solid currentColor");
+    expect(space?.style["boxShadow"]).toBe("inset 0 -1px 0 currentColor");
+    expect(space?.style["borderBottom"]).toBeUndefined();
     expect(space?.style["textDecorationLine"]).toBe("");
   });
 });

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -740,15 +740,22 @@ function removeUnderlineTextDecoration(element: HTMLElement): void {
   element.style.textDecorationLine = textDecorationLines.join(" ");
 }
 
+function applyContinuousUnderline(
+  element: HTMLElement,
+  underline: NonNullable<TextRun["underline"]>,
+): void {
+  removeUnderlineTextDecoration(element);
+  const color = typeof underline === "object" && underline.color ? underline.color : "currentColor";
+  // Paint inside the inline box. A bottom border grows the box by one pixel;
+  // fixed line boxes then let the following line paint over that border.
+  element.style.boxShadow = `inset 0 -1px 0 ${color}`;
+}
+
 function applyWhitespaceUnderline(element: HTMLElement, run: TextRun): void {
   if (!run.underline || run.text.trim().length > 0) {
     return;
   }
-  removeUnderlineTextDecoration(element);
-  element.style.borderBottom = "1px solid currentColor";
-  if (typeof run.underline === "object" && run.underline.color) {
-    element.style.borderBottomColor = run.underline.color;
-  }
+  applyContinuousUnderline(element, run.underline);
 }
 
 /**
@@ -826,11 +833,7 @@ function applyTabUnderline(element: HTMLElement, run: TabRun): void {
   if (!run.underline) {
     return;
   }
-  removeUnderlineTextDecoration(element);
-  element.style.borderBottom = "1px solid currentColor";
-  if (typeof run.underline === "object" && run.underline.color) {
-    element.style.borderBottomColor = run.underline.color;
-  }
+  applyContinuousUnderline(element, run.underline);
 }
 
 /**

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -228,6 +228,18 @@ const SUGGESTION_TINT_CSS = "var(--suggestion-bg, color-mix(in oklch, #6d3bd6 12
 // painted via background-color earlier in applyRunStyles — stay visible
 // underneath the proposal wash instead of being replaced by it.
 const SUGGESTION_TINT_LAYER_CSS = `linear-gradient(${SUGGESTION_TINT_CSS}, ${SUGGESTION_TINT_CSS})`;
+const RUN_BACKGROUND_TEXT_COLOR_VAR = "--doc-run-background-text-color";
+
+const setRunBackgroundTextColor = (element: HTMLElement, color: string): void => {
+  element.classList.add("docx-run-background-text");
+  element.style.setProperty(RUN_BACKGROUND_TEXT_COLOR_VAR, color);
+};
+
+const hasRunBackgroundTextSurface = (run: TextRun | TabRun): boolean =>
+  Boolean(run.highlight ?? run.shading) &&
+  !run.isInsertion &&
+  !run.isDeletion &&
+  !(run.commentIds !== undefined && run.commentIds.length > 0);
 
 function normalizeTextColorValue(color: string): string {
   return color.trim().toLowerCase().replace(/^#/u, "");
@@ -428,6 +440,15 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
         : getAutomaticTextColorForBackground(runBackground);
     if (automaticTextColor) {
       element.style.color = automaticTextColor;
+    }
+    const backgroundTextColor = hasExplicitTextColor ? textColor : automaticTextColor;
+    if (backgroundTextColor && hasRunBackgroundTextSurface(run)) {
+      // Dark-mode canvas rules deliberately invert ordinary run colors, but an
+      // authored highlight/shading is its own local color surface. Preserve the
+      // foreground chosen for that surface so a bright yellow highlight does
+      // not turn direct/theme black (or automatic contrast black) into white.
+      // The CSS custom property is presentation-only; saved OOXML is untouched.
+      setRunBackgroundTextColor(element, backgroundTextColor);
     }
   }
 
@@ -674,6 +695,12 @@ function renderTextRun(
       // the paragraph's inverted colour.
       anchor.style.setProperty("--doc-run-color", hyperlinkColor);
       span.style.setProperty("--doc-run-color", hyperlinkColor);
+      if (hasRunBackgroundTextSurface(run)) {
+        // The anchor paints over the run span, so it must carry the same local
+        // surface foreground contract as the span after hyperlink styling wins.
+        setRunBackgroundTextColor(span, hyperlinkColor);
+        setRunBackgroundTextColor(anchor, hyperlinkColor);
+      }
     }
     span.append(anchor);
   } else {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -3255,12 +3255,15 @@ function tableCellAttrsToFormatting(attrs: TableCellAttrs): TableCellFormatting 
       delete result.vMerge;
     }
     const cellWidth = attrs.width;
-    // Width: keep null absent while preserving explicit width=0 values.
-    if (cellWidth !== undefined) {
+    // A merge clears an unsafe preferred width with the schema's null value;
+    // do not resurrect `_originalFormatting.width` from the first source cell.
+    if (typeof cellWidth === "number") {
       result.width = {
         value: cellWidth,
         type: attrs.widthType ?? "dxa",
       };
+    } else {
+      delete result.width;
     }
     if (attrs.verticalAlign !== (orig.verticalAlign ?? undefined)) {
       if (attrs.verticalAlign) {
@@ -3294,7 +3297,7 @@ function tableCellAttrsToFormatting(attrs: TableCellAttrs): TableCellFormatting 
   const hasFormatting =
     attrs.colspan > 1 ||
     attrs.rowspan > 1 ||
-    cellWidth !== undefined ||
+    typeof cellWidth === "number" ||
     attrs.verticalAlign ||
     backgroundChanged ||
     attrs.borders ||
@@ -3312,7 +3315,7 @@ function tableCellAttrsToFormatting(attrs: TableCellAttrs): TableCellFormatting 
   if (attrs.rowspan > 1) {
     f.vMerge = "restart";
   }
-  if (cellWidth !== undefined) {
+  if (typeof cellWidth === "number") {
     f.width = {
       value: cellWidth,
       type: attrs.widthType ?? "dxa",

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -343,6 +343,18 @@
   color: oklch(from var(--doc-run-color) clamp(0, 1.22 - 0.95 * l, 1) calc(c * 0.6) h) !important;
 }
 
+/* An authored run background is a local color surface: the painter chooses
+ * its foreground from direct/theme text color or automatic contrast. This
+ * rule must follow both broad dark-canvas rules above so their !important
+ * inversion cannot repaint black-on-yellow as white-on-yellow. */
+.dark
+  .layout-page
+  [style*="--doc-run-background-text-color"].docx-run-background-text:not(.docx-insertion):not(
+    .docx-deletion
+  ) {
+  color: var(--doc-run-background-text-color) !important;
+}
+
 /* Tracked-change spans color from --tc-color (author colour), not
  * --doc-run-color, so invert that channel instead — otherwise the broad rule
  * above would repaint the red insertions/deletions as inverted body grey.

--- a/packages/react/src/styles/highlightContrast.test.ts
+++ b/packages/react/src/styles/highlightContrast.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const BACKGROUND_TEXT_SELECTOR =
+  '[style*="--doc-run-background-text-color"].docx-run-background-text';
+const EXPLICIT_COLOR_SELECTOR =
+  '.dark .layout-page [style*="--doc-run-color"]:not(.docx-insertion):not(.docx-deletion)';
+
+describe("dark-mode authored run backgrounds", () => {
+  test("the local background foreground wins after ordinary run-color inversion", () => {
+    const css = readFileSync(new URL("editor.css", import.meta.url), "utf-8");
+    const explicitColorRule = css.indexOf(EXPLICIT_COLOR_SELECTOR);
+    const backgroundTextRule = css.indexOf(BACKGROUND_TEXT_SELECTOR);
+
+    expect(explicitColorRule).toBeGreaterThanOrEqual(0);
+    expect(backgroundTextRule).toBeGreaterThan(explicitColorRule);
+    const ruleStart = css.lastIndexOf(".dark", backgroundTextRule);
+    expect(css.slice(ruleStart, css.indexOf("}", backgroundTextRule) + 1)).toContain(
+      "color: var(--doc-run-background-text-color) !important",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- project inherited paragraph geometry into bilingual table columns
- preserve merged-cell preferred widths and round-trip invariants
- retain highlighted-run contrast and signature-field rules in painted documents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bilingual document layout by correctly scaling paragraph indents and tab stops between columns.
  * Fixed merged table cells so compatible widths are preserved and incompatible widths are cleared.
  * Corrected handling of missing cell-width values.
  * Preserved authored highlight text colours in dark mode for improved contrast.
  * Improved underline rendering for tabs and whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->