### PR TITLE
fix: stop remote selection render loops

### DIFF
--- a/.changeset/calm-cursors-rest.md
+++ b/.changeset/calm-cursors-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-react": patch
+---
+
+Prevent remote collaborator cursor geometry updates from causing render loops.

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -139,6 +139,10 @@ import {
 // Selection sync
 import { LayoutSelectionGate } from "@stll/folio-core/paged-layout/LayoutSelectionGate";
 import {
+  retainRemoteSelectionGeometry,
+  type RemoteSelectionGeometry,
+} from "./remoteSelectionGeometry";
+import {
   collectRunFontsAtPmPositions,
   type DirectiveGutterGeometry,
   measureDirectiveGutter,
@@ -1107,10 +1111,7 @@ const RemoteSelectionOverlay = ({
   remoteSelection,
   zoom,
 }: RemoteSelectionOverlayProps) => {
-  const [geometry, setGeometry] = useState<{
-    caretPosition: CaretPosition | null;
-    selectionRects: SelectionRect[];
-  } | null>(null);
+  const [geometry, setGeometry] = useState<RemoteSelectionGeometry | null>(null);
 
   useEffect(() => {
     if (!pagesContainer) {
@@ -1151,10 +1152,12 @@ const RemoteSelectionOverlay = ({
             }
           : null;
 
-        setGeometry({
-          caretPosition,
-          selectionRects: nextSelectionRects,
-        });
+        setGeometry((previous) =>
+          retainRemoteSelectionGeometry(previous, {
+            caretPosition,
+            selectionRects: nextSelectionRects,
+          }),
+        );
         return undefined;
       },
       () => {

--- a/packages/react/src/paged-editor/remoteSelectionGeometry.test.ts
+++ b/packages/react/src/paged-editor/remoteSelectionGeometry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { retainRemoteSelectionGeometry } from "./remoteSelectionGeometry";
+
+const geometry = () => ({
+  caretPosition: { height: 18, pageIndex: 0, x: 24, y: 48 },
+  selectionRects: [
+    { height: 18, pageIndex: 0, width: 72, x: 24, y: 48 },
+    { height: 18, pageIndex: 0, width: 32, x: 24, y: 66 },
+  ],
+});
+
+describe("retainRemoteSelectionGeometry", () => {
+  test("reaches a fixed point for equivalent recomputations", () => {
+    const previous = geometry();
+    const retained = retainRemoteSelectionGeometry(previous, geometry());
+
+    expect(retained).toBe(previous);
+    expect(retainRemoteSelectionGeometry(retained, geometry())).toBe(previous);
+  });
+
+  test("adopts changed caret and selection geometry", () => {
+    const previous = geometry();
+    const movedCaret = geometry();
+    movedCaret.caretPosition.x += 1;
+    const resizedSelection = geometry();
+    const firstRect = resizedSelection.selectionRects.at(0);
+    if (firstRect === undefined) {
+      throw new Error("Expected selection rectangle fixture.");
+    }
+    firstRect.width += 1;
+
+    expect(retainRemoteSelectionGeometry(previous, movedCaret)).toBe(movedCaret);
+    expect(retainRemoteSelectionGeometry(previous, resizedSelection)).toBe(resizedSelection);
+  });
+});

--- a/packages/react/src/paged-editor/remoteSelectionGeometry.ts
+++ b/packages/react/src/paged-editor/remoteSelectionGeometry.ts
@@ -1,0 +1,49 @@
+import type {
+  CaretPosition,
+  SelectionRect,
+} from "@stll/folio-core/layout-bridge/engine/selectionRects";
+
+export type RemoteSelectionGeometry = {
+  caretPosition: CaretPosition | null;
+  selectionRects: SelectionRect[];
+};
+
+const hasSameCaretPosition = (previous: CaretPosition | null, next: CaretPosition | null) => {
+  if (previous === null || next === null) {
+    return previous === next;
+  }
+
+  return (
+    previous.height === next.height &&
+    previous.pageIndex === next.pageIndex &&
+    previous.x === next.x &&
+    previous.y === next.y
+  );
+};
+
+const hasSameSelectionRect = (previous: SelectionRect, next: SelectionRect) =>
+  previous.height === next.height &&
+  previous.pageIndex === next.pageIndex &&
+  previous.width === next.width &&
+  previous.x === next.x &&
+  previous.y === next.y;
+
+export const retainRemoteSelectionGeometry = (
+  previous: RemoteSelectionGeometry | null,
+  next: RemoteSelectionGeometry,
+) => {
+  if (
+    previous === null ||
+    !hasSameCaretPosition(previous.caretPosition, next.caretPosition) ||
+    previous.selectionRects.length !== next.selectionRects.length
+  ) {
+    return next;
+  }
+
+  return previous.selectionRects.every((rect, index) => {
+    const nextRect = next.selectionRects.at(index);
+    return nextRect !== undefined && hasSameSelectionRect(rect, nextRect);
+  })
+    ? previous
+    : next;
+};


### PR DESCRIPTION
## Summary

- retain the existing remote-selection geometry when recomputation is structurally identical
- prevent layout identity churn from causing a state/effect feedback loop
- cover the equality guard with a fixed-point regression test

## Validation

- `bun test packages/react/src/paged-editor/remoteSelectionGeometry.test.ts`
- `bun --filter @stll/folio-react typecheck`
- targeted `oxlint` and `oxfmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote collaborator cursor and selection rendering.
  * Prevented incomplete geometry updates from causing unnecessary render loops.
  * Preserved stable cursor and selection visuals when geometry remains unchanged.

* **Tests**
  * Added coverage for unchanged geometry and updates to caret or selection rectangles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->