### PR TITLE
fix: clamp list bodies to hanging indents

### DIFF
--- a/.changeset/warm-rules-align.md
+++ b/.changeset/warm-rules-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep short list markers from pulling text into a hanging indent.

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.test.ts
@@ -100,6 +100,43 @@ describe("getListMarkerInlineWidth", () => {
     }, fakeMeasure);
   });
 
+  test.each(["nothing", "space"] as const)(
+    'w:suff="%s" keeps a short marker body at the hanging-indent anchor',
+    (listMarkerSuffix) => {
+      withFakeTextMeasure(() => {
+        const width = getListMarkerInlineWidth(
+          listBlock({
+            listMarker: "1.",
+            listMarkerSuffix,
+            indent: { left: 60, hanging: 36 },
+          }),
+        );
+
+        expect(width).toBe(36);
+      }, fakeMeasure);
+    },
+  );
+
+  test.each([
+    ["nothing", "1234", 40],
+    ["space", "1234", 50],
+  ] as const)(
+    'w:suff="%s" lets content-bearing marker width exceed the hanging indent',
+    (listMarkerSuffix, listMarker, expectedWidth) => {
+      withFakeTextMeasure(() => {
+        const width = getListMarkerInlineWidth(
+          listBlock({
+            listMarker,
+            listMarkerSuffix,
+            indent: { left: 60, hanging: 36 },
+          }),
+        );
+
+        expect(width).toBe(expectedWidth);
+      }, fakeMeasure);
+    },
+  );
+
   test("right-aligned marker ends at its anchor without consuming body width", () => {
     withFakeTextMeasure(() => {
       const block = listBlock({

--- a/packages/core/src/layout-engine/measure/listMarkerWidth.ts
+++ b/packages/core/src/layout-engine/measure/listMarkerWidth.ts
@@ -90,7 +90,9 @@ export function resolveListMarkerFont(block: ParagraphBlock): {
  *  - hanging indent — body wraps at `indentLeft`, marker sits at
  *    `indentLeft - hanging`. Width is `hanging` so the marker fills the slot.
  *  - `w:suff` (§17.9.25): `nothing` → natural width, `space` → natural +
- *    one space glyph, `tab` (default) → grow to the next tab stop.
+ *    one space glyph, `tab` (default) → grow to the next tab stop. A hanging
+ *    indent remains the minimum footprint so body text cannot enter the
+ *    marker slot.
  *  - `w:tabs` on the paragraph: non-`clear`/non-`bar` stops past the marker.
  *    `bar` (§17.3.1.37) is a vertical line and doesn't advance the cursor.
  *  - default tab grid: stops at multiples of `DEFAULT_TAB_STOP_TWIPS`,
@@ -112,11 +114,12 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
 
   // §17.9.25 — `w:suff` controls what follows the marker before body text.
   const suffix = attrs.listMarkerSuffix ?? "tab";
+  const hanging = attrs.indent?.hanging ?? 0;
   if (suffix === "nothing") {
-    return markerEndOffset;
+    return Math.max(hanging, markerEndOffset);
   }
   if (suffix === "space") {
-    return markerEndOffset + measureTextWidth(" ", style);
+    return Math.max(hanging, markerEndOffset + measureTextWidth(" ", style));
   }
 
   // Default suffix is `tab`. Body text aligns at the next stop past
@@ -126,7 +129,6 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
   const indent = attrs.indent;
   const indentLeft = indent?.left ?? 0;
   const firstLine = indent?.firstLine ?? 0;
-  const hanging = indent?.hanging ?? 0;
   const markerStartPx = hanging > 0 ? indentLeft - hanging : indentLeft + firstLine;
   const minBodyStart = markerStartPx + markerEndOffset;
 


### PR DESCRIPTION
## Summary

- keep short list-marker suffixes from moving body text into the hanging-indent slot
- preserve natural advancement when a marker and its suffix exceed that slot

## Validation

- `bun test packages/core/src/layout-engine/measure/listMarkerWidth.test.ts packages/core/src/layout-engine/measure/measureParagraph-list-marker.test.ts packages/core/src/layout-engine/measure/firstLineListMarker.test.ts`
- `bun --filter @stll/folio-core typecheck`
- `bun run typecheck:parity`
- `bun run typecheck:tooling`
- focused lint and format checks
- `bun audit`