### PR TITLE
fix: advance continuous section page restarts

### DIFF
--- a/.changeset/calm-pages-count.md
+++ b/.changeset/calm-pages-count.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Advance continuous-section page restarts across shared-page content.

--- a/.oxlint-plugins/folio-fragment-ownership.ts
+++ b/.oxlint-plugins/folio-fragment-ownership.ts
@@ -1,0 +1,71 @@
+// Page-fragment insertion belongs to the paginator. It consumes pending
+// section transitions before committing a fragment, including already-
+// positioned floating and anchored content. Writing to `page.fragments`
+// elsewhere bypasses that state transition and can shift section restarts.
+
+type AstNode = Record<string, unknown> & { type: string };
+
+type RuleContext = {
+  report: (descriptor: { node: unknown; messageId: "directPageFragmentPush" }) => void;
+};
+
+const isAstNode = (value: unknown): value is AstNode =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof (value as { type: unknown }).type === "string";
+
+const memberName = (node: unknown): string | null => {
+  if (!isAstNode(node) || node.type !== "MemberExpression") {
+    return null;
+  }
+  const property = node.property;
+  if (!isAstNode(property)) {
+    return null;
+  }
+  if (property.type === "Identifier") {
+    return typeof property.name === "string" ? property.name : null;
+  }
+  if (property.type === "Literal") {
+    return typeof property.value === "string" ? property.value : null;
+  }
+  return null;
+};
+
+const isDirectPageFragmentPush = (node: AstNode): boolean => {
+  const callee = node.callee;
+  if (!isAstNode(callee) || callee.type !== "MemberExpression" || memberName(callee) !== "push") {
+    return false;
+  }
+  const fragments = callee.object;
+  if (!isAstNode(fragments) || memberName(fragments) !== "fragments") {
+    return false;
+  }
+  return memberName(fragments.object) === "page";
+};
+
+export default {
+  meta: { name: "folio-fragment-ownership" },
+  rules: {
+    "no-direct-page-fragment-push": {
+      meta: {
+        type: "problem",
+        messages: {
+          directPageFragmentPush:
+            "Commit layout fragments through the paginator. Direct `page.fragments.push(...)` " +
+            "bypasses pending section and page-number transitions; use `addFragment(...)` for " +
+            "flow content or `addUnflowedFragment(...)` for already-positioned content.",
+        },
+      },
+      create(context: RuleContext) {
+        return {
+          CallExpression: (node: unknown) => {
+            if (isAstNode(node) && isDirectPageFragmentPush(node)) {
+              context.report({ node, messageId: "directPageFragmentPush" });
+            }
+          },
+        };
+      },
+    },
+  },
+};

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -123,6 +123,7 @@ export function createPaginator(options: PaginatorOptions): {
         x: number;
         y: number;
     };
+    addUnflowedFragment: (fragment: Fragment) => PageState;
     addFootnoteHeight: (additionalHeight: number, footnoteIds?: number[]) => void;
     forcePageBreak: (breakOptions?: ForcePageBreakOptions) => PageState;
     retargetCurrentBlankPage: () => boolean;

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -65,6 +65,7 @@ export default library({
   jsPlugins: [
     "./.oxlint-plugins/folio-layer-boundaries.ts",
     "./.oxlint-plugins/folio-asset-urls.ts",
+    "./.oxlint-plugins/folio-fragment-ownership.ts",
     "./.oxlint-plugins/no-untranslated-jsx-literal.ts",
   ],
   ignorePatterns: [
@@ -113,6 +114,18 @@ export default library({
         "typescript/no-unsafe-argument": "off",
         "typescript/strict-boolean-expressions": "off",
         "typescript/no-redundant-type-constituents": "off",
+      },
+    },
+    {
+      // The paginator owns page-fragment commits because insertion may consume
+      // a pending section transition. The fixtures verify this custom rule;
+      // repo-wide lint ignores their deliberate violation.
+      files: [
+        "packages/core/src/layout-engine/**/*.{ts,tsx}",
+        "test/__fixtures__/fragment-ownership.*.ts",
+      ],
+      rules: {
+        "folio-fragment-ownership/no-direct-page-fragment-push": "error",
       },
     },
     {

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -445,4 +445,38 @@ describe("continuous section break geometry", () => {
       result.pages[1]?.fragments.some((f) => f.kind === "paragraph" && f.blockId === "c"),
     ).toBe(true);
   });
+
+  test("advances a restart past incoming content retained on the shared page", () => {
+    const first = paragraph("outgoing", 700);
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "sb",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const shared = paragraph("shared-incoming", 150);
+    const next = paragraph("next-incoming", 700);
+
+    const result = layoutDocument(
+      [first.block, sectionBreak, shared.block, next.block],
+      [first.measure, { kind: "sectionBreak" }, shared.measure, next.measure] as never,
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+        finalPageSize: { w: 800, h: 1000 },
+        finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+        finalPageNumbering: { type: "restart", start: 2 },
+      },
+    );
+
+    expect(result.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([1, 3]);
+    expect(result.pages[0]).toMatchObject({ sectionIndex: 0, sectionPageNumber: 1 });
+    expect(result.pages[1]).toMatchObject({ sectionIndex: 1, sectionPageNumber: 1 });
+    expect(
+      result.pages[0]?.fragments.some(
+        (fragment) => fragment.kind === "paragraph" && fragment.blockId === "shared-incoming",
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1462,8 +1462,7 @@ function layoutFloatingTable(
     ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
   };
 
-  // Add directly without advancing cursor
-  state.page.fragments.push(fragment);
+  paginator.addUnflowedFragment(fragment);
 }
 
 /**
@@ -1530,8 +1529,7 @@ function layoutAnchoredImage(
     zIndex: anchor.behindDoc ? -1 : 1,
   };
 
-  // Add directly to page without affecting cursor
-  state.page.fragments.push(fragment);
+  paginator.addUnflowedFragment(fragment);
 }
 
 type LayoutTextBoxOptions = {
@@ -1591,7 +1589,7 @@ function layoutTextBox(
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
       ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };
-    state.page.fragments.push(fragment);
+    paginator.addUnflowedFragment(fragment);
     return;
   }
 
@@ -1630,7 +1628,7 @@ function layoutTextBox(
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
       ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };
-    state.page.fragments.push(fragment);
+    paginator.addUnflowedFragment(fragment);
     return;
   }
 

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, test } from "bun:test";
 
 import { createPaginator } from "./paginator";
+import type { ParagraphFragment } from "./types";
 
 const SIZE = { w: 800, h: 1000 };
 const MARGINS = { top: 50, right: 50, bottom: 50, left: 50 };
+
+const paragraphFragment = (blockId: string): ParagraphFragment => ({
+  kind: "paragraph",
+  blockId,
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 20,
+  fromLine: 0,
+  toLine: 1,
+});
 
 describe("paginator mirrored margins", () => {
   test("swaps left and right margins on even physical pages", () => {
@@ -97,6 +109,65 @@ describe("paginator logical page numbers", () => {
       restarted.sectionPageNumber,
     ]).toEqual([1, 2, 1, 1]);
   });
+
+  test("consumes a section restart on its first shared-page fragment", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.addFragment(paragraphFragment("outgoing"), 20);
+
+    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.addFragment(paragraphFragment("incoming"), 20);
+    const shared = paginator.pages[0];
+    const following = paginator.forcePageBreak().page;
+
+    expect(shared?.fragments.map(({ blockId }) => blockId)).toEqual(["outgoing", "incoming"]);
+    expect(shared).toMatchObject({ logicalNumber: 1, sectionIndex: 0, sectionPageNumber: 1 });
+    expect(following).toMatchObject({ logicalNumber: 3, sectionIndex: 1, sectionPageNumber: 1 });
+  });
+
+  test("consumes a section restart on its first unflowed shared-page fragment", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.addFragment(paragraphFragment("outgoing"), 20);
+
+    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.addUnflowedFragment({
+      kind: "image",
+      blockId: "anchored-incoming",
+      x: 100,
+      y: 100,
+      width: 20,
+      height: 20,
+      isAnchored: true,
+    });
+    const following = paginator.forcePageBreak().page;
+
+    expect(paginator.pages[0]).toMatchObject({ logicalNumber: 1, sectionIndex: 0 });
+    expect(following).toMatchObject({ logicalNumber: 3, sectionIndex: 1, sectionPageNumber: 1 });
+  });
+
+  test("defers a restart when the first section fragment advances to a fresh page", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.addFragment(paragraphFragment("outgoing"), 900);
+
+    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.addFragment(paragraphFragment("incoming"), 20);
+
+    expect(paginator.pages).toHaveLength(2);
+    expect(paginator.pages[0]).toMatchObject({ logicalNumber: 1, sectionIndex: 0 });
+    expect(paginator.pages[1]).toMatchObject({ logicalNumber: 2, sectionIndex: 1 });
+  });
+
+  test("defers a restart when the first section fragment follows a forced break", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.addFragment(paragraphFragment("outgoing"), 20);
+
+    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.forcePageBreak();
+    paginator.addFragment(paragraphFragment("incoming"), 20);
+
+    expect(paginator.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([1, 2]);
+    expect(paginator.pages[0]?.sectionIndex).toBe(0);
+    expect(paginator.pages[1]).toMatchObject({ sectionIndex: 1, sectionPageNumber: 1 });
+  });
 });
 
 describe("paginator forcePageBreak", () => {
@@ -120,7 +191,7 @@ describe("paginator forcePageBreak", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     const state = paginator.getCurrentState();
     state.cursorY += 100;
-    state.page.fragments.push({ kind: "paragraph" } as never);
+    paginator.addUnflowedFragment(paragraphFragment("content"));
 
     paginator.forcePageBreak();
     paginator.forcePageBreak();
@@ -169,7 +240,7 @@ describe("paginator forcePageBreak", () => {
   test("retargetCurrentBlankPage leaves nonblank pages unchanged", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     const state = paginator.getCurrentState();
-    state.page.fragments.push({ kind: "paragraph" } as never);
+    paginator.addUnflowedFragment(paragraphFragment("content"));
 
     const nextSize = { w: 600, h: 700 };
     paginator.updatePageLayout(nextSize, MARGINS);

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -410,14 +410,36 @@ export function createPaginator(options: PaginatorOptions) {
     fragment.x = x;
     fragment.y = y;
 
-    // Add to page
-    state.page.fragments.push(fragment);
+    commitFragment(state, fragment);
 
     // Update cursor
     state.cursorY = y + height;
     state.trailingSpacing = spaceAfter;
 
     return { state, x, y };
+  }
+
+  function commitFragment(state: PageState, fragment: Fragment): void {
+    // A continuous section can begin after content already placed on a page
+    // owned by the outgoing section. That shared page keeps its owner and
+    // displayed number, but its incoming content consumes the authored restart
+    // for page-number arithmetic. The next page therefore advances past the
+    // restart while remaining the incoming section's first owned page.
+    if (sectionStartPending && state.page.sectionIndex !== currentSectionIndex) {
+      if (currentPageNumbering.type === "restart") {
+        nextLogicalPageNumber = currentPageNumbering.start + 1;
+      }
+      sectionStartPending = false;
+    }
+
+    const fragments = state.page.fragments;
+    fragments.push(fragment);
+  }
+
+  function addUnflowedFragment(fragment: Fragment): PageState {
+    const state = getCurrentState();
+    commitFragment(state, fragment);
+    return state;
   }
 
   /**
@@ -667,6 +689,8 @@ export function createPaginator(options: PaginatorOptions) {
     ensureFits,
     /** Add a fragment to current page. */
     addFragment,
+    /** Add an already-positioned fragment without advancing normal flow. */
+    addUnflowedFragment,
     /** Reserve additional footnote area on the current page. */
     addFootnoteHeight,
     /** Force a page break. */

--- a/scripts/fragment-ownership-lint.test.ts
+++ b/scripts/fragment-ownership-lint.test.ts
@@ -1,0 +1,36 @@
+/** Wiring test for the page-fragment ownership lint rule. */
+
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+const RULE_MARKER = "folio-fragment-ownership(no-direct-page-fragment-push)";
+
+setDefaultTimeout(30_000);
+
+const lintFixture = (fixture: string) => {
+  const result = Bun.spawnSync(
+    [
+      "bun",
+      "--bun",
+      "oxlint",
+      "-c",
+      "oxlint.config.ts",
+      "--no-ignore",
+      path.join("test", "__fixtures__", fixture),
+    ],
+    { cwd: REPO_ROOT },
+  );
+  const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+  return output.split(RULE_MARKER).length - 1;
+};
+
+describe("page fragment ownership", () => {
+  test("rejects direct page fragment insertion", () => {
+    expect(lintFixture("fragment-ownership.invalid.ts")).toBe(1);
+  });
+
+  test("accepts paginator-owned insertion", () => {
+    expect(lintFixture("fragment-ownership.valid.ts")).toBe(0);
+  });
+});

--- a/test/__fixtures__/fragment-ownership.invalid.ts
+++ b/test/__fixtures__/fragment-ownership.invalid.ts
@@ -1,0 +1,4 @@
+declare const state: { page: { fragments: unknown[] } };
+declare const fragment: unknown;
+
+state.page.fragments.push(fragment);

--- a/test/__fixtures__/fragment-ownership.valid.ts
+++ b/test/__fixtures__/fragment-ownership.valid.ts
@@ -1,0 +1,4 @@
+declare const paginator: { addUnflowedFragment: (fragment: unknown) => void };
+declare const fragment: unknown;
+
+paginator.addUnflowedFragment(fragment);


### PR DESCRIPTION
## Summary

- advance authored page-number restarts when a continuous section retains content on the outgoing section’s page
- keep the shared page’s existing owner and displayed number while numbering the next section-owned page correctly
- centralize flowed and positioned fragment commits in the paginator, with a lint guard against bypassing section transitions

## Validation

- 29 focused paginator and continuous-section tests
- 2 fragment-ownership lint-rule wiring tests
- `bun --filter @stll/folio-core typecheck`
- `bun run typecheck:parity`
- `bun run typecheck:tooling`
- `bun run lint`
- focused format checks
- `bun audit`