### PR TITLE
fix: reflow columns around footnote areas

### DIFF
--- a/.changeset/calm-columns-reflow.md
+++ b/.changeset/calm-columns-reflow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep earlier columns above footnote areas discovered during later-column layout.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -558,6 +558,8 @@ export type PageState = {
     contentBottom: number;
     rawContentBottom: number;
     footnoteHeight: number;
+    footnoteHeightFloor: number;
+    footnoteDemandHeight: number;
     trailingSpacing: number;
 };
 
@@ -1023,6 +1025,7 @@ export type TextBoxFlowAttrs = Pick<TextBoxBlock, "displayMode" | "wrapType">;
 export type TextBoxFragment = FragmentBase & {
     kind: "textBox";
     height: number;
+    isPositioned?: true;
 };
 
 // @public

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -693,7 +693,8 @@ export function runLayoutPipeline<THfPMs>(
       // Build footnote content and measure heights up front. The
       // per-fn height table feeds into the layout engine so each
       // body line carrying an fn ref reserves space for that fn
-      // on its host page in a single pass — no convergence loop.
+      // on its host page during placement. The engine retries only when
+      // a later column grows the shared footnote band past earlier content.
       footnoteContentMap = buildFootnoteContentMap(
         documentFootnotes,
         footnoteRefs,

--- a/packages/core/src/layout-engine/footnoteColumnReflow.test.ts
+++ b/packages/core/src/layout-engine/footnoteColumnReflow.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+
+import { reflowFootnoteColumns } from "./footnoteColumnReflow";
+import type { Fragment, Layout } from "./types";
+
+const overlappingLayout = (fragments: Fragment[]): Layout => ({
+  pageSize: { w: 100, h: 100 },
+  columns: { count: 2, gap: 10 },
+  pages: [
+    {
+      number: 1,
+      logicalNumber: 1,
+      fragments,
+      margins: { top: 0, right: 0, bottom: 0, left: 0 },
+      size: { w: 100, h: 100 },
+      columns: { count: 2, gap: 10 },
+      footnoteReservedHeight: 20,
+    },
+  ],
+});
+
+const fragmentPosition = {
+  blockId: "out-of-flow",
+  x: 0,
+  y: 75,
+  width: 10,
+  height: 10,
+};
+
+describe("footnote column reflow", () => {
+  test("ignores fragments that do not participate in body flow", () => {
+    const layout = overlappingLayout([
+      {
+        kind: "table",
+        ...fragmentPosition,
+        fromRow: 0,
+        toRow: 1,
+        isFloating: true,
+      },
+      { kind: "image", ...fragmentPosition, isAnchored: true },
+      { kind: "textBox", ...fragmentPosition, isPositioned: true },
+    ]);
+    let passes = 0;
+
+    const result = reflowFootnoteColumns({
+      initialLayout: layout,
+      runLayout: () => {
+        passes += 1;
+        return layout;
+      },
+    });
+
+    expect(result.pages[0]!.footnoteReservedHeight).toBeUndefined();
+    expect(passes).toBe(0);
+  });
+
+  test("returns a stable fallback when flow overlap persists", () => {
+    const flowFragments: Fragment[] = [
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        fromLine: 0,
+        toLine: 1,
+      },
+      {
+        kind: "table",
+        ...fragmentPosition,
+        fromRow: 0,
+        toRow: 1,
+      },
+      { kind: "image", ...fragmentPosition },
+      { kind: "textBox", ...fragmentPosition },
+    ];
+
+    for (const fragment of flowFragments) {
+      const layout = overlappingLayout([fragment]);
+      let passes = 0;
+
+      const result = reflowFootnoteColumns({
+        initialLayout: layout,
+        runLayout: () => {
+          passes += 1;
+          return layout;
+        },
+      });
+
+      expect(result.pages[0]!.footnoteReservedHeight).toBeUndefined();
+      expect(passes).toBe(1);
+    }
+  });
+
+  test("stops when the reserve-floor state repeats", () => {
+    const first = overlappingLayout([
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        fromLine: 0,
+        toLine: 1,
+      },
+    ]);
+    const second = overlappingLayout([
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        y: 76,
+        fromLine: 0,
+        toLine: 1,
+      },
+    ]);
+    first.pages[0]!.footnoteIds = [7];
+    second.pages[0]!.footnoteIds = [7];
+    let passes = 0;
+
+    const result = reflowFootnoteColumns({
+      initialLayout: first,
+      runLayout: () => {
+        passes += 1;
+        return passes % 2 === 1 ? second : first;
+      },
+    });
+
+    expect(result).toBe(second);
+    expect(passes).toBe(1);
+  });
+
+  test("cleans orphan reservations on a repeated two-page floor state", () => {
+    const initial = overlappingLayout([
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        fromLine: 0,
+        toLine: 1,
+      },
+    ]);
+    initial.pages[0]!.footnoteIds = [7];
+    const returned = {
+      ...initial,
+      pages: [
+        {
+          ...initial.pages[0]!,
+          fragments: [{ ...initial.pages[0]!.fragments[0]!, y: 76 }],
+        },
+        {
+          ...initial.pages[0]!,
+          number: 2,
+          logicalNumber: 2,
+          fragments: [],
+          footnoteIds: [],
+        },
+      ],
+    };
+    const returnedPage = returned.pages[1]!;
+
+    const result = reflowFootnoteColumns({
+      initialLayout: initial,
+      runLayout: () => returned,
+    });
+
+    expect(result).not.toBe(returned);
+    expect(result.pages[1]).not.toBe(returnedPage);
+    expect(result.pages[1]!.footnoteReservedHeight).toBeUndefined();
+    expect(returnedPage.footnoteReservedHeight).toBe(20);
+  });
+
+  test("keeps a caller floor when observed reservation is smaller", () => {
+    const initial = overlappingLayout([
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        fromLine: 0,
+        toLine: 1,
+      },
+    ]);
+    initial.pages[0]!.footnoteIds = [7];
+    let receivedFloors: Map<number, number> | undefined;
+
+    const result = reflowFootnoteColumns({
+      initialLayout: initial,
+      initialReserveFloors: new Map([[1, 80]]),
+      runLayout: (floors) => {
+        receivedFloors = floors;
+        const page = initial.pages[0]!;
+        return {
+          ...initial,
+          pages: [
+            {
+              ...page,
+              fragments: [{ ...page.fragments[0]!, y: 70 }],
+              footnoteReservedHeight: floors.get(1),
+            },
+          ],
+        };
+      },
+    });
+
+    expect(receivedFloors?.get(1)).toBe(80);
+    expect(result.pages[0]!.footnoteReservedHeight).toBe(80);
+  });
+
+  test("cleans orphan reservations with copy-on-write", () => {
+    const initial = overlappingLayout([
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        fromLine: 0,
+        toLine: 1,
+      },
+    ]);
+    const initialPage = initial.pages[0]!;
+    const cleanedInitial = reflowFootnoteColumns({
+      initialLayout: {
+        ...initial,
+        pages: [{ ...initialPage, fragments: [{ ...initialPage.fragments[0]!, y: 70 }] }],
+      },
+      runLayout: () => initial,
+    });
+
+    expect(cleanedInitial).not.toBe(initial);
+    expect(cleanedInitial.pages[0]).not.toBe(initialPage);
+    expect(cleanedInitial.pages[0]!.footnoteReservedHeight).toBeUndefined();
+    expect(initialPage.footnoteReservedHeight).toBe(20);
+
+    const returned = overlappingLayout([
+      {
+        kind: "paragraph",
+        ...fragmentPosition,
+        y: 70,
+        fromLine: 0,
+        toLine: 1,
+      },
+    ]);
+    const returnedPage = returned.pages[0]!;
+    const cleanedReturned = reflowFootnoteColumns({
+      initialLayout: initial,
+      runLayout: () => returned,
+    });
+
+    expect(cleanedReturned).not.toBe(returned);
+    expect(cleanedReturned.pages[0]).not.toBe(returnedPage);
+    expect(cleanedReturned.pages[0]!.footnoteReservedHeight).toBeUndefined();
+    expect(returnedPage.footnoteReservedHeight).toBe(20);
+  });
+});

--- a/packages/core/src/layout-engine/footnoteColumnReflow.ts
+++ b/packages/core/src/layout-engine/footnoteColumnReflow.ts
@@ -1,0 +1,140 @@
+import type { Fragment, Layout } from "./types";
+
+function isFlowFragment(fragment: Fragment): boolean {
+  switch (fragment.kind) {
+    case "paragraph":
+      return true;
+    case "table":
+      return !fragment.isFloating;
+    case "image":
+      return !fragment.isAnchored;
+    case "textBox":
+      return !fragment.isPositioned;
+    default: {
+      const exhaustive: never = fragment;
+      return exhaustive;
+    }
+  }
+}
+
+function hasFootnoteColumnOverlap(layout: Layout): boolean {
+  for (const page of layout.pages) {
+    if ((page.columns?.count ?? 1) < 2 || !page.footnoteReservedHeight) {
+      continue;
+    }
+    const bodyBottom = page.size.h - page.margins.bottom - page.footnoteReservedHeight;
+    if (
+      page.fragments.some(
+        (fragment) => isFlowFragment(fragment) && fragment.y + fragment.height > bodyBottom,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function growFootnoteReserveFloors(
+  layout: Layout,
+  initialReserveFloors: ReadonlyMap<number, number> | undefined,
+): Map<number, number> {
+  const next = new Map<number, number>();
+  for (const page of layout.pages) {
+    // In the dynamic footnote path, a retry floor is owned by the IDs on its
+    // page. A caller floor is authoritative while those IDs remain, and the
+    // current observed reservation can only increase it. Entries without
+    // current IDs are intentionally omitted so a moved note cannot strand a
+    // floor on its former page. Static floors remain supported by
+    // layoutDocument when no dynamic footnote map is supplied.
+    if ((page.footnoteIds?.length ?? 0) === 0) {
+      continue;
+    }
+    const observed = page.footnoteReservedHeight ?? 0;
+    const callerFloor = initialReserveFloors?.get(page.number) ?? 0;
+    const floor = Math.max(callerFloor, observed);
+    if (floor > 0) {
+      next.set(page.number, floor);
+    }
+  }
+  return next;
+}
+
+function reserveFloorFingerprint(floors: ReadonlyMap<number, number>): string {
+  return JSON.stringify(
+    [...floors.entries()].sort(([leftPage], [rightPage]) => leftPage - rightPage),
+  );
+}
+
+function clearOrphanedFootnoteReservations(layout: Layout): Layout {
+  let pagesChanged = false;
+  const pages = layout.pages.map((page) => {
+    if ((page.footnoteIds?.length ?? 0) > 0 || page.footnoteReservedHeight === undefined) {
+      return page;
+    }
+    pagesChanged = true;
+    const cleanedPage = { ...page };
+    delete cleanedPage.footnoteReservedHeight;
+    return cleanedPage;
+  });
+
+  if (!pagesChanged) {
+    return layout;
+  }
+  return { ...layout, pages };
+}
+
+function getPassBudget(layout: Layout): number {
+  const fragmentCount = layout.pages.reduce((count, page) => count + page.fragments.length, 0);
+  const footnoteCount = new Set(layout.pages.flatMap((page) => page.footnoteIds ?? [])).size;
+
+  // Every retry must change a finite page/fragment assignment or terminate.
+  // The budget scales with the document state rather than imposing a small
+  // constant that rejects long but valid cascades.
+  return layout.pages.length + fragmentCount + footnoteCount + 1;
+}
+
+type ReflowFootnoteColumnsOptions = {
+  initialLayout: Layout;
+  initialReserveFloors?: ReadonlyMap<number, number>;
+  runLayout: (reserveFloors: Map<number, number>) => Layout;
+};
+
+/**
+ * Re-run a multi-column layout until its body flow clears the shared footnote band.
+ * Reserve floors follow the current page-to-footnote assignment. Repeated floor states
+ * and persistent overlap use a stable fallback layout instead of throwing.
+ */
+export function reflowFootnoteColumns({
+  initialLayout,
+  initialReserveFloors,
+  runLayout,
+}: ReflowFootnoteColumnsOptions): Layout {
+  let layout = initialLayout;
+  if (!hasFootnoteColumnOverlap(layout)) {
+    return clearOrphanedFootnoteReservations(layout);
+  }
+
+  const seenReserveStates = new Set<string>();
+  const passBudget = getPassBudget(layout);
+  for (let pass = 0; pass < passBudget; pass += 1) {
+    const reserveFloors = growFootnoteReserveFloors(layout, initialReserveFloors);
+    const reserveState = reserveFloorFingerprint(reserveFloors);
+    if (seenReserveStates.has(reserveState)) {
+      // A deterministic cycle has no new geometry to discover. Preserve the
+      // latest layout as an explicit stable fallback instead of throwing from
+      // an untrusted document's layout path.
+      return clearOrphanedFootnoteReservations(layout);
+    }
+    seenReserveStates.add(reserveState);
+
+    layout = runLayout(reserveFloors);
+    if (!hasFootnoteColumnOverlap(layout)) {
+      return clearOrphanedFootnoteReservations(layout);
+    }
+  }
+
+  // The document-state budget was exhausted without a non-overlapping fixed
+  // point. Keep the last deterministic layout; callers can still render and
+  // inspect the document, including the footnote IDs assigned to each page.
+  return clearOrphanedFootnoteReservations(layout);
+}

--- a/packages/core/src/layout-engine/footnoteLineReservation.test.ts
+++ b/packages/core/src/layout-engine/footnoteLineReservation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { layoutDocument } from "./index";
+import { FOOTNOTE_SEPARATOR_HEIGHT } from "./types";
 import type {
   FlowBlock,
   LayoutOptions,
@@ -13,11 +14,9 @@ import type {
   TableMeasure,
 } from "./types";
 
-// Single-pass footnote layout: each body line carrying a footnote ref
-// reserves space for that fn's content on the same page. Replaces the
-// earlier static-reservation + iterative-convergence loop, which
-// produced either body-overflow into the footer or large gaps above
-// the fn area on documents with multiple long footnotes per page.
+// Each body line carrying a footnote ref reserves space for that fn's
+// content on the same page. Multi-column pages retry with the observed
+// shared reservation when a later column invalidates earlier placement.
 
 const MARGINS: PageMargins = { top: 0, right: 0, bottom: 0, left: 0 };
 
@@ -228,6 +227,78 @@ describe("footnote line-level reservation", () => {
     // Page 2 carries the fn for the moved line.
     const p2Fn = layout.pages[1]!.footnoteReservedHeight ?? 0;
     expect(p2Fn).toBeGreaterThanOrEqual(40);
+  });
+
+  test("keeps every column above a footnote area discovered in a later column", () => {
+    const { block: firstColumn, measure: firstColumnMeasure } = makePara(
+      0,
+      [textRun(1, "first column")],
+      13,
+      10,
+    );
+    const { block: reference, measure: referenceMeasure } = makePara(
+      1,
+      [textRun(20, "1", 7)],
+      1,
+      10,
+    );
+
+    const layout = layoutDocument(
+      [firstColumn, reference],
+      [firstColumnMeasure, referenceMeasure],
+      {
+        pageSize: { w: 600, h: 100 },
+        margins: MARGINS,
+        pageGap: 0,
+        columns: { count: 2, gap: 20 },
+        footnoteHeightById: new Map([[7, 10]]),
+      },
+    );
+
+    const page = layout.pages[0]!;
+    const bodyBottom = page.size.h - page.margins.bottom - (page.footnoteReservedHeight ?? 0);
+    expect(page.footnoteIds).toEqual([7]);
+    expect(page.footnoteReservedHeight).toBe(10 + FOOTNOTE_SEPARATOR_HEIGHT);
+    for (const fragment of page.fragments) {
+      expect(fragment.y + fragment.height).toBeLessThanOrEqual(bodyBottom);
+    }
+  });
+
+  test("drops a retry floor when its footnote moves to a later page", () => {
+    const { block: body, measure: bodyMeasure } = makePara(0, [textRun(1, "body")], 15, 10);
+    const { block: reference, measure: referenceMeasure } = makePara(
+      1,
+      [textRun(20, "1", 7)],
+      1,
+      10,
+    );
+
+    const layout = layoutDocument([body, reference], [bodyMeasure, referenceMeasure], {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+      columns: { count: 2, gap: 20 },
+      footnoteHeightById: new Map([[7, 10]]),
+    });
+
+    expect(layout.pages[0]!.footnoteIds ?? []).toEqual([]);
+    expect(layout.pages[0]!.footnoteReservedHeight).toBeUndefined();
+    expect(layout.pages[1]!.footnoteIds).toEqual([7]);
+  });
+
+  test("returns a stable layout for a footnote taller than the page", () => {
+    const { block, measure } = makePara(0, [textRun(1, "1", 99)], 1, 10);
+
+    const layout = layoutDocument([block], [measure], {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+      columns: { count: 2, gap: 20 },
+      footnoteHeightById: new Map([[99, 200]]),
+    });
+
+    expect(layout.pages[0]!.footnoteIds).toEqual([99]);
+    expect(layout.pages[0]!.footnoteReservedHeight).toBeGreaterThanOrEqual(200);
   });
 
   test("ignored when footnoteHeightById is not provided", () => {

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -7,6 +7,7 @@
 import { panic } from "better-result";
 
 import { emuToPixels } from "../utils/units";
+import { reflowFootnoteColumns } from "./footnoteColumnReflow";
 import {
   computeKeepNextChains,
   calculateChainHeight,
@@ -15,6 +16,7 @@ import {
 } from "./keep-together";
 import { measuredLineAdvance } from "./lineFlow";
 import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
+import type { PageState } from "./paginator";
 import { getParagraphFragmentPmRange } from "./paragraphFragmentRange";
 import {
   collapseParagraphSpacing,
@@ -273,13 +275,34 @@ export function applyContextualSpacing(blocks: FlowBlock[]): void {
 /**
  * Layout a document: convert blocks + measures into pages with positioned fragments.
  *
- * Algorithm:
- * 1. Walk blocks in order with their corresponding measures
- * 2. For each block, create appropriate fragment(s)
- * 3. Use paginator to manage page/column state
- * 4. Handle page breaks, section breaks, and keepNext chains
+ * A reference discovered after the first column has already been placed can shrink the
+ * shared body band below earlier-column fragments. Retry those documents with the observed
+ * reservations as page floors so every column participates in the same footnote geometry.
  */
 export function layoutDocument(
+  blocks: FlowBlock[],
+  measures: Measure[],
+  options: LayoutOptions,
+): Layout {
+  const layout = layoutDocumentPass(blocks, measures, options);
+  if (!options.footnoteHeightById) {
+    return layout;
+  }
+
+  return reflowFootnoteColumns({
+    initialLayout: layout,
+    ...(options.footnoteReservedHeights
+      ? { initialReserveFloors: options.footnoteReservedHeights }
+      : {}),
+    runLayout: (reserveFloors) =>
+      layoutDocumentPass(blocks, measures, {
+        ...options,
+        footnoteReservedHeights: reserveFloors,
+      }),
+  });
+}
+
+function layoutDocumentPass(
   blocks: FlowBlock[],
   measures: Measure[],
   options: LayoutOptions,
@@ -580,15 +603,19 @@ function getLineFootnoteRefs(
   return { ids, height };
 }
 
+function projectedFootnoteReserveGrowth(state: PageState, additionalDemandHeight: number): number {
+  const projectedDemand = state.footnoteDemandHeight + additionalDemandHeight;
+  return Math.max(state.footnoteHeightFloor, projectedDemand) - state.footnoteHeight;
+}
+
 /**
  * Layout a paragraph block onto pages.
  *
  * When `footnoteHeightById` is provided, each line carrying a footnote
  * ref additionally reserves space on its host page for the fn's
- * content. Pagination decisions look at the line's effective height
- * (`lineHeight + lineFnHeight`) so a line cannot land on a page that
- * lacks room for both — preventing footnote overflow without the
- * static-reservation iteration loop.
+ * content. Pagination decisions include only the reservation growth
+ * beyond any retry floor, so a line cannot land on a page that lacks
+ * room for both body and note content.
  */
 type LayoutParagraphOptions = {
   block: ParagraphBlock;
@@ -677,7 +704,9 @@ function layoutParagraph({
         firstLine.toRun,
         footnoteHeightById,
       );
-      const firstLineHeight = measuredLineAdvance(firstLine) + firstLineRefs.height;
+      const firstLineHeight =
+        measuredLineAdvance(firstLine) +
+        projectedFootnoteReserveGrowth(state, firstLineRefs.height);
       const collapsedLead = collapseParagraphSpacing({
         before: spaceBefore,
         after: state.trailingSpacing,
@@ -732,8 +761,8 @@ function layoutParagraph({
       }
       const lineRefs = getLineFootnoteRefs(block, line.fromRun, line.toRun, footnoteHeightById);
       const totalWithLine = linesHeight + lineAdvance;
-      const withSpacing =
-        totalWithLine + firstFragmentSpaceBefore + linesFnHeight + lineRefs.height;
+      const footnoteGrowth = projectedFootnoteReserveGrowth(state, linesFnHeight + lineRefs.height);
+      const withSpacing = totalWithLine + firstFragmentSpaceBefore + footnoteGrowth;
 
       if (withSpacing <= availableHeight || fittingLines === 0) {
         linesHeight = totalWithLine;
@@ -816,18 +845,23 @@ function layoutParagraph({
     //    would force an unnecessary page advance and split the
     //    paragraph between pages even though the line + fn still fit.
     //
-    // 2. After the first `ensureFits`, re-read the page state. If we
-    //    landed on a *fresh* page (`footnoteHeight === 0`), the next
-    //    `addFootnoteHeight` call *will* reserve a separator — so we
-    //    need to verify the line + fn + separator all still fit on
-    //    that page. Otherwise the post-commit `addFootnoteHeight`
-    //    drops contentBottom past the just-committed line.
+    // 2. After the first `ensureFits`, re-read the page state. If it has
+    //    no dynamic footnote demand, the next `addFootnoteHeight` call
+    //    includes a separator. Verify that remaining growth still fits;
+    //    a retry floor may already cover some or all of it.
     if (linesFnHeight > 0) {
-      paginator.ensureFits(effectiveSpaceBefore + linesHeight + linesFnHeight);
+      const stateBefore = paginator.getCurrentState();
+      paginator.ensureFits(
+        effectiveSpaceBefore +
+          linesHeight +
+          projectedFootnoteReserveGrowth(stateBefore, linesFnHeight),
+      );
       const stateAfter = paginator.getCurrentState();
-      if (stateAfter.footnoteHeight === 0) {
+      if (stateAfter.footnoteDemandHeight === 0) {
         paginator.ensureFits(
-          effectiveSpaceBefore + linesHeight + linesFnHeight + FOOTNOTE_SEPARATOR_HEIGHT,
+          effectiveSpaceBefore +
+            linesHeight +
+            projectedFootnoteReserveGrowth(stateAfter, linesFnHeight + FOOTNOTE_SEPARATOR_HEIGHT),
         );
       }
     }
@@ -1223,17 +1257,16 @@ function layoutTable(
         fragmentFootnoteIds.push(id);
         rowFootnoteHeight += footnoteHeightById?.get(id) ?? 0;
       }
+      const candidateFootnoteHeight = fragmentFootnoteHeight + rowFootnoteHeight;
       const separatorHeight =
-        pageFootnoteIds.size === 0 && fragmentFootnoteHeight + rowFootnoteHeight > 0
+        state.footnoteDemandHeight === 0 && candidateFootnoteHeight > 0
           ? FOOTNOTE_SEPARATOR_HEIGHT
           : 0;
-      const totalWithRow =
-        rowsHeight +
-        rowHeight +
-        normalHeaderOverhead +
-        fragmentFootnoteHeight +
-        rowFootnoteHeight +
-        separatorHeight;
+      const footnoteGrowth = projectedFootnoteReserveGrowth(
+        state,
+        candidateFootnoteHeight + separatorHeight,
+      );
+      const totalWithRow = rowsHeight + rowHeight + normalHeaderOverhead + footnoteGrowth;
 
       if (totalWithRow <= availableHeight) {
         rowsHeight += rowHeight;
@@ -1588,6 +1621,7 @@ function layoutTextBox(
       y: state.topMargin + bandTop,
       width: measure.width,
       height: measure.height,
+      isPositioned: true,
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
       ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };
@@ -1627,6 +1661,7 @@ function layoutTextBox(
       y,
       width: measure.width,
       height: measure.height,
+      isPositioned: true,
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
       ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -49,6 +49,10 @@ export type PageState = {
   rawContentBottom: number;
   /** Total height reserved for footnotes on this page (grows as refs are placed). */
   footnoteHeight: number;
+  /** Static reservation supplied by a layout retry. */
+  footnoteHeightFloor: number;
+  /** Footnote demand discovered while placing reference-bearing content. */
+  footnoteDemandHeight: number;
   /** Accumulated trailing spacing (space after previous block). */
   trailingSpacing: number;
 };
@@ -256,12 +260,11 @@ export function createPaginator(options: PaginatorOptions) {
     const contentBottom = pageSize.h - pageMargins.bottom;
 
     // Reduce content bottom by footnote reserved height for this page.
-    // Used as a static reservation only when the layout engine isn't
-    // tracking footnote demand dynamically per line. The dynamic path
-    // (see `addFootnoteHeight`) starts at zero and grows as fn-ref-
-    // carrying lines are placed.
-    const footnoteHeight = options.footnoteReservedHeights?.get(pageNumber) ?? 0;
-    const pageContentBottom = contentBottom - footnoteHeight;
+    // A multi-column retry may supply a static floor so earlier columns
+    // begin inside the shared footnote band. Dynamic demand still starts
+    // at zero and grows as reference-bearing lines are placed.
+    const footnoteHeightFloor = options.footnoteReservedHeights?.get(pageNumber) ?? 0;
+    const pageContentBottom = contentBottom - footnoteHeightFloor;
 
     const page: Page = {
       number: pageNumber,
@@ -272,7 +275,7 @@ export function createPaginator(options: PaginatorOptions) {
       fragments: [],
       margins: pageMargins,
       size: { ...pageSize },
-      ...(footnoteHeight > 0 ? { footnoteReservedHeight: footnoteHeight } : {}),
+      ...(footnoteHeightFloor > 0 ? { footnoteReservedHeight: footnoteHeightFloor } : {}),
       // Set initial columns; may be overwritten by updateColumns() for continuous section breaks
       ...(columns.count > 1 ? { columns: { ...columns } } : {}),
     };
@@ -285,7 +288,9 @@ export function createPaginator(options: PaginatorOptions) {
       topMargin,
       contentBottom: pageContentBottom,
       rawContentBottom: contentBottom,
-      footnoteHeight,
+      footnoteHeight: footnoteHeightFloor,
+      footnoteHeightFloor,
+      footnoteDemandHeight: 0,
       trailingSpacing: 0,
     };
 
@@ -445,8 +450,9 @@ export function createPaginator(options: PaginatorOptions) {
       return;
     }
     const state = getCurrentState();
-    const separatorOverhead = state.footnoteHeight === 0 ? FOOTNOTE_SEPARATOR_HEIGHT : 0;
-    state.footnoteHeight += additionalHeight + separatorOverhead;
+    const separatorOverhead = state.footnoteDemandHeight === 0 ? FOOTNOTE_SEPARATOR_HEIGHT : 0;
+    state.footnoteDemandHeight += additionalHeight + separatorOverhead;
+    state.footnoteHeight = Math.max(state.footnoteHeightFloor, state.footnoteDemandHeight);
     state.contentBottom = state.rawContentBottom - state.footnoteHeight;
     state.page.footnoteReservedHeight = state.footnoteHeight;
     // Record which fn IDs landed on *this* page. Driven by the
@@ -501,12 +507,12 @@ export function createPaginator(options: PaginatorOptions) {
     const pageMargins = getPageMargins(current.page.number, current.page.logicalNumber);
     const topMargin = pageMargins.top;
     const rawContentBottom = pageSize.h - pageMargins.bottom;
-    const footnoteHeight = options.footnoteReservedHeights?.get(current.page.number) ?? 0;
+    const footnoteHeightFloor = options.footnoteReservedHeights?.get(current.page.number) ?? 0;
 
     current.page.size = { ...pageSize };
     current.page.margins = pageMargins;
-    if (footnoteHeight > 0) {
-      current.page.footnoteReservedHeight = footnoteHeight;
+    if (footnoteHeightFloor > 0) {
+      current.page.footnoteReservedHeight = footnoteHeightFloor;
     } else {
       delete current.page.footnoteReservedHeight;
     }
@@ -520,8 +526,10 @@ export function createPaginator(options: PaginatorOptions) {
     current.cursorY = topMargin;
     current.columnIndex = 0;
     current.rawContentBottom = rawContentBottom;
-    current.footnoteHeight = footnoteHeight;
-    current.contentBottom = rawContentBottom - footnoteHeight;
+    current.footnoteHeight = footnoteHeightFloor;
+    current.footnoteHeightFloor = footnoteHeightFloor;
+    current.footnoteDemandHeight = 0;
+    current.contentBottom = rawContentBottom - footnoteHeightFloor;
     current.trailingSpacing = 0;
     columnRegionTop = topMargin;
 

--- a/packages/core/src/layout-engine/textbox-band.test.ts
+++ b/packages/core/src/layout-engine/textbox-band.test.ts
@@ -104,6 +104,7 @@ describe("topAndBottom band text box layout", () => {
 
     // relativeTo=page, offset 0 → the very top of the page (y=0, in the margin).
     expect(box?.y).toBe(0);
+    expect(box?.isPositioned).toBe(true);
     // Flow not advanced by the banner: the paragraph still starts at the top
     // (the measure pass, not layout, reserves the band that pushes text down).
     expect(paragraph?.y).toBe(MARGINS.top);
@@ -182,6 +183,7 @@ describe("topAndBottom band text box layout", () => {
 
     // In-flow box at the top, paragraph pushed below it by the box height.
     expect(box?.y).toBe(MARGINS.top);
+    expect(box?.isPositioned).toBeUndefined();
     expect(paragraph?.y).toBe(MARGINS.top + BOX_HEIGHT);
   });
 
@@ -195,6 +197,7 @@ describe("topAndBottom band text box layout", () => {
     const paragraph = frags.find((fragment) => fragment.kind === "paragraph");
 
     expect(box?.y).toBe(MARGINS.top + 96);
+    expect(box?.isPositioned).toBe(true);
     expect(paragraph?.y).toBe(MARGINS.top);
   });
 

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -1165,6 +1165,8 @@ export type TextBoxFragment = FragmentBase & {
   kind: "textBox";
   /** Height of the text box. */
   height: number;
+  /** True if this text box is positioned outside normal body flow. */
+  isPositioned?: true;
 };
 
 /**
@@ -1339,18 +1341,21 @@ export type LayoutOptions = {
   evenAndOddHeaders?: boolean;
   /** Swap left/right margins on even physical pages. */
   mirrorMargins?: boolean;
-  /** Per-page footnote reserved heights (pageNumber → height in pixels). */
+  /**
+   * Per-page footnote reserved heights (pageNumber → height in pixels).
+   * When `footnoteHeightById` is also supplied, a value is a retry floor only
+   * while that page has assigned footnote IDs; without the dynamic height map,
+   * the value remains a static reservation.
+   */
   footnoteReservedHeights?: Map<number, number>;
   /**
    * Footnote content heights keyed by internal footnote id (the OOXML
    * `<w:footnoteReference w:id>`). When provided, the layout engine
    * tracks footnote demand per body line: each line carrying a fn ref
    * grows its page's reservation by that fn's height before the next
-   * line is fitted. This single-pass approach avoids the static-
-   * reservation + iterative-convergence loop that produced oscillation
-   * (and either body-overflow into the footer or large empty gaps
-   * above the fn area) on documents with multiple long footnotes per
-   * page.
+   * line is fitted. Multi-column pages may retry with the observed
+   * reservation as a shared floor when a later column invalidates
+   * earlier-column placement.
    */
   footnoteHeightById?: Map<number, number>;
   /** Header/footer references for each document section, by section index. */


### PR DESCRIPTION
## Summary

- reflow multi-column pages when a later column expands the shared footnote area
- keep reserve floors attached to their current footnote assignments and terminate deterministic cycles safely
- distinguish in-flow text boxes from positioned text boxes during overlap checks

## Validation

- focused footnote and layout regression suites
- core typecheck
- repository lint and format check
- dependency audit
- independent correctness review