### PR TITLE
fix: apply OOXML style toggle inheritance

### DIFF
--- a/.changeset/calm-styles-toggle.md
+++ b/.changeset/calm-styles-toggle.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Apply level-aware OOXML style toggle inheritance while keeping direct run formatting explicit.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -283,7 +283,9 @@ export type ParagraphPropertyChangeAttrs = Omit<import__stll_docx_core_model.Par
 };
 
 // @public (undocumented)
-export type RunFormattingOverrideAttrs = { [K in keyof Pick<import__stll_docx_core_model.TextFormatting, "bold" | "italic" | "strike" | "doubleStrike" | "allCaps" | "smallCaps" | "hidden" | "emboss" | "imprint" | "shadow" | "outline" | "rtl">]?: false; } & {
+export type RunFormattingOverrideAttrs = { [K in keyof Pick<import__stll_docx_core_model.TextFormatting, "bold" | "italic" | "strike" | "allCaps" | "smallCaps" | "hidden" | "emboss" | "imprint" | "shadow" | "outline">]?: boolean; } & {
+    doubleStrike?: false;
+    rtl?: false;
     boldCs?: boolean;
     cs?: boolean;
     fontSizeCs?: number;

--- a/packages/core/src/docx/styleParser.test.ts
+++ b/packages/core/src/docx/styleParser.test.ts
@@ -81,6 +81,25 @@ describe("style default ST_OnOff values", () => {
   });
 });
 
+describe("style run toggle parsing", () => {
+  test("the final occurrence within one run-properties level wins", () => {
+    const styles = parseStyles(
+      `<w:styles ${STYLES_NS}>
+        <w:style w:type="character" w:styleId="OffLast">
+          <w:rPr><w:b/><w:b w:val="0"/></w:rPr>
+        </w:style>
+        <w:style w:type="character" w:styleId="OnLast">
+          <w:rPr><w:b w:val="false"/><w:b/></w:rPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+
+    expect(styles.get("OffLast")?.rPr?.bold).toBe(false);
+    expect(styles.get("OnLast")?.rPr?.bold).toBe(true);
+  });
+});
+
 describe("style tab leader normalization", () => {
   test("normalizes the default leader to a save/reopen fixed point", () => {
     const parsed = parseStyleDefinitions(

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -37,7 +37,7 @@ import type {
   TableMeasurement,
 } from "../types/document";
 import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
-import { mergeTextFormatting } from "../utils/textFormattingMerge";
+import { mergeStyleTextFormatting } from "../utils/textFormattingMerge";
 import { isValidHexColor } from "../utils/colorResolver";
 import {
   BorderStyleSchema,
@@ -85,6 +85,9 @@ export type ParsedStylesPackage = {
   styles: StyleMap;
 };
 
+const findLastRunToggle = (rPr: XmlElement, localName: string): XmlElement | null =>
+  findChildren(rPr, "w", localName).at(-1) ?? null;
+
 /**
  * Parse text formatting properties (w:rPr)
  */
@@ -99,23 +102,23 @@ function parseRunProperties(
   const formatting: TextFormatting = {};
 
   // Bold
-  const b = findChild(rPr, "w", "b");
+  const b = findLastRunToggle(rPr, "b");
   if (b) {
     formatting.bold = parseBooleanElement(b);
   }
 
-  const bCs = findChild(rPr, "w", "bCs");
+  const bCs = findLastRunToggle(rPr, "bCs");
   if (bCs) {
     formatting.boldCs = parseBooleanElement(bCs);
   }
 
   // Italic
-  const i = findChild(rPr, "w", "i");
+  const i = findLastRunToggle(rPr, "i");
   if (i) {
     formatting.italic = parseBooleanElement(i);
   }
 
-  const iCs = findChild(rPr, "w", "iCs");
+  const iCs = findLastRunToggle(rPr, "iCs");
   if (iCs) {
     formatting.italicCs = parseBooleanElement(iCs);
   }
@@ -140,7 +143,7 @@ function parseRunProperties(
   }
 
   // Strikethrough
-  const strike = findChild(rPr, "w", "strike");
+  const strike = findLastRunToggle(rPr, "strike");
   if (strike) {
     formatting.strike = parseBooleanElement(strike);
   }
@@ -160,18 +163,18 @@ function parseRunProperties(
   }
 
   // Capitalization
-  const smallCaps = findChild(rPr, "w", "smallCaps");
+  const smallCaps = findLastRunToggle(rPr, "smallCaps");
   if (smallCaps) {
     formatting.smallCaps = parseBooleanElement(smallCaps);
   }
 
-  const caps = findChild(rPr, "w", "caps");
+  const caps = findLastRunToggle(rPr, "caps");
   if (caps) {
     formatting.allCaps = parseBooleanElement(caps);
   }
 
   // Hidden
-  const vanish = findChild(rPr, "w", "vanish");
+  const vanish = findLastRunToggle(rPr, "vanish");
   if (vanish) {
     formatting.hidden = parseBooleanElement(vanish);
   }
@@ -363,22 +366,22 @@ function parseRunProperties(
   }
 
   // Other effects
-  const emboss = findChild(rPr, "w", "emboss");
+  const emboss = findLastRunToggle(rPr, "emboss");
   if (emboss) {
     formatting.emboss = parseBooleanElement(emboss);
   }
 
-  const imprint = findChild(rPr, "w", "imprint");
+  const imprint = findLastRunToggle(rPr, "imprint");
   if (imprint) {
     formatting.imprint = parseBooleanElement(imprint);
   }
 
-  const outline = findChild(rPr, "w", "outline");
+  const outline = findLastRunToggle(rPr, "outline");
   if (outline) {
     formatting.outline = parseBooleanElement(outline);
   }
 
-  const shadow = findChild(rPr, "w", "shadow");
+  const shadow = findLastRunToggle(rPr, "shadow");
   if (shadow) {
     formatting.shadow = parseBooleanElement(shadow);
   }
@@ -1637,7 +1640,7 @@ function resolveStyleInheritance(
     resolved.pPr = mergedPPr;
   }
 
-  const mergedRPr = mergeTextFormatting(resolvedParent.rPr, style.rPr);
+  const mergedRPr = mergeStyleTextFormatting(resolvedParent.rPr, style.rPr);
   if (mergedRPr) {
     resolved.rPr = mergedRPr;
   }

--- a/packages/core/src/layout-bridge/convert/complex-script-formatting-pipeline.test.ts
+++ b/packages/core/src/layout-bridge/convert/complex-script-formatting-pipeline.test.ts
@@ -101,6 +101,33 @@ describe("complex-script formatting pipeline", () => {
     });
   });
 
+  test("keeps combined ordinary and complex-script negatives through a JSON clone", () => {
+    const document = documentWithRun("Aع", {
+      bold: false,
+      boldCs: false,
+      italic: false,
+      italicCs: false,
+    });
+    const proseDoc = toProseDoc(document);
+    const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+
+    expect(firstDocumentRunFormatting(fromProseDoc(clonedProseDoc))).toEqual({
+      bold: false,
+      boldCs: false,
+      italic: false,
+      italicCs: false,
+    });
+
+    const paragraph = toFlowBlocks(clonedProseDoc, {}).find((block) => block.kind === "paragraph");
+    const run = paragraph?.runs.find((candidate) => candidate.kind === "text");
+    expect(run).toMatchObject({
+      bold: false,
+      complexScriptBold: false,
+      complexScriptItalic: false,
+      italic: false,
+    });
+  });
+
   test("force-CS selects complex-script formatting even for Latin text", () => {
     const formatting = parseFormatting(
       '<w:rFonts w:ascii="Arial" w:cs="Traditional Arabic"/>' +

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -7,7 +7,9 @@ import type {
   TextRun,
 } from "../../layout-engine/types";
 import { layoutDocument } from "../../layout-engine";
+import { parseStyleDefinitions } from "../../docx/styleParser";
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { schema } from "../../prosemirror/schema";
 import type { Document, Paragraph, StyleDefinitions, Table } from "../../types/document";
 import { toFlowBlocks } from "./toFlowBlocks";
 
@@ -253,6 +255,205 @@ describe("toFlowBlocks style cascade", () => {
     expect(run.allCaps).toBe(false);
   });
 
+  test("matching paragraph and character style toggles cancel", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "EmphasizedParagraph",
+          type: "paragraph",
+          name: "Emphasized Paragraph",
+          rPr: {
+            bold: true,
+            boldCs: true,
+            italic: true,
+            italicCs: true,
+            allCaps: true,
+            emboss: true,
+            hidden: true,
+            imprint: true,
+            outline: true,
+            shadow: true,
+            smallCaps: true,
+            strike: true,
+          },
+        },
+        {
+          styleId: "EmphasizedRun",
+          type: "character",
+          name: "Emphasized Run",
+          rPr: {
+            bold: true,
+            boldCs: true,
+            italic: true,
+            italicCs: true,
+            allCaps: true,
+            emboss: true,
+            hidden: true,
+            imprint: true,
+            outline: true,
+            shadow: true,
+            smallCaps: true,
+            strike: true,
+          },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "EmphasizedParagraph" },
+      content: [
+        {
+          type: "run",
+          formatting: { styleId: "EmphasizedRun" },
+          content: [{ type: "text", text: "regular" }],
+        },
+      ],
+    };
+
+    const proseDoc = toProseDoc(makeDoc(paragraph, styles), { styles });
+    const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+    const blocks = toFlowBlocks(clonedProseDoc, {});
+
+    expect(firstRun(blocks)).toMatchObject({
+      bold: false,
+      complexScriptBold: false,
+      italic: false,
+      complexScriptItalic: false,
+      allCaps: false,
+      emboss: false,
+      hidden: false,
+      imprint: false,
+      textOutline: false,
+      textShadow: false,
+      smallCaps: false,
+      strike: false,
+    });
+  });
+
+  test.each([
+    ["inherited off, character off", false, false, false],
+    ["inherited off, character on", false, true, true],
+    ["inherited on, character off", true, false, true],
+    ["inherited on, character on", true, true, false],
+  ] as const)(
+    "complex-script style toggles resolve %s after a JSON clone",
+    (_label, inherited, character, expected) => {
+      const styles: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "ParagraphEmphasis",
+            type: "paragraph",
+            name: "Paragraph Emphasis",
+            rPr: { boldCs: inherited, italicCs: inherited },
+          },
+          {
+            styleId: "CharacterEmphasis",
+            type: "character",
+            name: "Character Emphasis",
+            rPr: { bold: true, boldCs: character, italic: true, italicCs: character },
+          },
+        ],
+      };
+      const paragraph: Paragraph = {
+        type: "paragraph",
+        formatting: { styleId: "ParagraphEmphasis" },
+        content: [
+          {
+            type: "run",
+            formatting: { styleId: "CharacterEmphasis" },
+            content: [{ type: "text", text: "toggle matrix" }],
+          },
+        ],
+      };
+
+      const proseDoc = toProseDoc(makeDoc(paragraph, styles), { styles });
+      const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+      const run = firstRun(toFlowBlocks(clonedProseDoc, {}));
+
+      expect(run).toMatchObject({
+        bold: true,
+        complexScriptBold: expected,
+        complexScriptItalic: expected,
+        italic: true,
+      });
+    },
+  );
+
+  test("a based-on chain contributes one style-level toggle value", () => {
+    const styles = parseStyleDefinitions(
+      `<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:style w:type="paragraph" w:styleId="Base">
+          <w:rPr><w:b/></w:rPr>
+        </w:style>
+        <w:style w:type="paragraph" w:styleId="Derived">
+          <w:basedOn w:val="Base"/>
+          <w:rPr><w:b/></w:rPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Derived" },
+      content: [{ type: "run", content: [{ type: "text", text: "bold" }] }],
+    };
+
+    const blocks = toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {});
+
+    expect(firstRun(blocks).bold).toBe(true);
+  });
+
+  test("false child toggles preserve inherited true values from parsed styles", () => {
+    const toggleElements = [
+      "b",
+      "bCs",
+      "i",
+      "iCs",
+      "caps",
+      "emboss",
+      "imprint",
+      "outline",
+      "shadow",
+      "smallCaps",
+      "strike",
+      "vanish",
+    ];
+    const styles = parseStyleDefinitions(
+      `<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:style w:type="paragraph" w:styleId="Base">
+          <w:rPr>${toggleElements.map((name) => `<w:${name}/>`).join("")}</w:rPr>
+        </w:style>
+        <w:style w:type="paragraph" w:styleId="Derived">
+          <w:basedOn w:val="Base"/>
+          <w:rPr>${toggleElements.map((name) => `<w:${name} w:val="0"/>`).join("")}</w:rPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Derived" },
+      content: [{ type: "run", content: [{ type: "text", text: "inherited" }] }],
+    };
+
+    const run = firstRun(toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {}));
+
+    expect(run).toMatchObject({
+      bold: true,
+      complexScriptBold: true,
+      italic: true,
+      complexScriptItalic: true,
+      allCaps: true,
+      emboss: true,
+      hidden: true,
+      imprint: true,
+      textOutline: true,
+      textShadow: true,
+      smallCaps: true,
+      strike: true,
+    });
+  });
+
   test("paragraph-mark booleans do not replace inherited paragraph-style booleans", () => {
     const styles: StyleDefinitions = {
       styles: [
@@ -319,6 +520,35 @@ describe("toFlowBlocks style cascade", () => {
     const blocks = toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {});
 
     expect(firstRun(blocks).fontFamily).toBe("Cambria");
+  });
+
+  test("the default character style toggles above a paragraph-style off", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "PlainParagraph",
+          type: "paragraph",
+          default: true,
+          name: "Plain Paragraph",
+          rPr: { bold: false },
+        },
+        {
+          styleId: "DefaultRun",
+          type: "character",
+          default: true,
+          name: "Default Run",
+          rPr: { bold: true },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text: "bold" }] }],
+    };
+
+    const blocks = toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {});
+
+    expect(firstRun(blocks).bold).toBe(true);
   });
 
   test("table conditionals without rPr do not override paragraph run defaults", () => {
@@ -392,6 +622,58 @@ describe("toFlowBlocks style cascade", () => {
     );
 
     expect(firstTableRun(blocks).fontFamily).toBe("Arial");
+  });
+
+  test("paragraph style toggles apply above an explicit table-style off", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "TableText",
+          type: "paragraph",
+          name: "Table Text",
+          rPr: { bold: true },
+        },
+        {
+          styleId: "PlainTable",
+          type: "table",
+          name: "Plain Table",
+          rPr: { bold: false },
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      formatting: { styleId: "PlainTable" },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  formatting: { styleId: "TableText" },
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "bold" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc({ package: { document: { content: [table] }, styles } }, { styles }),
+      {},
+    );
+
+    expect(firstTableRun(blocks).bold).toBe(true);
   });
 
   test("default table style supplies cell margins without authoring its zero indent", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -41,6 +41,7 @@ import { DEFAULT_TEXTBOX_MARGINS, DEFAULT_TEXTBOX_WIDTH } from "../../layout-eng
 import { getColumns } from "../sectionColumns";
 import {
   expectBlockSdtAttrs,
+  expectCharacterStyleMarkAttrs,
   expectCharacterSpacingMarkAttrs,
   expectCommentMarkAttrs,
   expectEmphasisMarkAttrs,
@@ -70,6 +71,7 @@ import {
 import { autospacingMatchesBase } from "../../prosemirror/autospacingBase";
 import { runShadingAttrsToShading } from "../../prosemirror/conversion/runShadingMark";
 import { directionToBidi } from "../../prosemirror/paragraphDirection";
+import { cascadeStyleTextFormatting } from "../../prosemirror/styles/styleToggleCascade";
 import { getPageNumbering } from "../../paged-layout/sectionGeometry";
 import type { RunFormattingOverrideAttrs } from "../../prosemirror/schema/marks";
 import type {
@@ -712,39 +714,114 @@ function mergeRunFormatting(paraDefaults: RunFormatting, formatting: RunFormatti
   return merged;
 }
 
+type ApplyCharacterStyleToggleFormattingOptions = {
+  formatting: RunFormatting;
+  marks: readonly Mark[];
+  paraDefaults: RunFormatting;
+};
+
+/** Restore character-style toggle values that plain visual marks cannot represent. */
+function applyCharacterStyleToggleFormatting({
+  formatting,
+  marks,
+  paraDefaults,
+}: ApplyCharacterStyleToggleFormattingOptions): void {
+  const characterStyleMark = marks.find((mark) => mark.type.name === "characterStyle");
+  if (!characterStyleMark) {
+    return;
+  }
+  const styleRPr = expectCharacterStyleMarkAttrs(characterStyleMark)._styleRPr;
+  if (!styleRPr) {
+    return;
+  }
+
+  const effectiveStyleFormatting = cascadeStyleTextFormatting([
+    {
+      formatting: {
+        bold: paraDefaults.bold ?? false,
+        boldCs: paraDefaults.complexScriptBold ?? false,
+        italic: paraDefaults.italic ?? false,
+        italicCs: paraDefaults.complexScriptItalic ?? false,
+      },
+      type: "direct",
+    },
+    { formatting: styleRPr, type: "style" },
+  ]).formatting;
+
+  if (styleRPr.bold !== undefined && formatting.bold === undefined) {
+    formatting.bold = effectiveStyleFormatting?.bold ?? false;
+  }
+  if (styleRPr.boldCs !== undefined && formatting.complexScriptBold === undefined) {
+    formatting.complexScriptBold = effectiveStyleFormatting?.boldCs ?? false;
+  }
+  if (styleRPr.italic !== undefined && formatting.italic === undefined) {
+    formatting.italic = effectiveStyleFormatting?.italic ?? false;
+  }
+  if (styleRPr.italicCs !== undefined && formatting.complexScriptItalic === undefined) {
+    formatting.complexScriptItalic = effectiveStyleFormatting?.italicCs ?? false;
+  }
+  if (styleRPr.allCaps === true && formatting.allCaps === undefined) {
+    formatting.allCaps = false;
+  }
+  if (styleRPr.emboss === true && formatting.emboss === undefined) {
+    formatting.emboss = false;
+  }
+  if (styleRPr.imprint === true && formatting.imprint === undefined) {
+    formatting.imprint = false;
+  }
+  if (styleRPr.outline === true && formatting.textOutline === undefined) {
+    formatting.textOutline = false;
+  }
+  if (styleRPr.shadow === true && formatting.textShadow === undefined) {
+    formatting.textShadow = false;
+  }
+  if (styleRPr.smallCaps === true && formatting.smallCaps === undefined) {
+    formatting.smallCaps = false;
+  }
+  if (styleRPr.strike === true && formatting.strike === undefined) {
+    formatting.strike = false;
+  }
+  if (styleRPr.hidden === true && formatting.hidden === undefined) {
+    formatting.hidden = false;
+  }
+}
+
 function applyRunFormattingOverrides(
   formatting: RunFormatting,
   attrs: RunFormattingOverrideAttrs,
 ): void {
-  if (attrs.bold === false) {
-    formatting.bold = false;
+  if (attrs.bold !== undefined) {
+    formatting.bold = attrs.bold;
   }
-  if (attrs.italic === false) {
-    formatting.italic = false;
+  if (attrs.italic !== undefined) {
+    formatting.italic = attrs.italic;
   }
   if (attrs.underline === "none") {
     formatting.underline = false;
   }
-  if (attrs.strike === false) {
-    formatting.strike = false;
+  if (attrs.strike !== undefined) {
+    formatting.strike = attrs.strike;
   }
-  if (attrs.allCaps === false) {
-    formatting.allCaps = false;
+  if (attrs.allCaps !== undefined) {
+    formatting.allCaps = attrs.allCaps;
   }
-  if (attrs.smallCaps === false) {
-    formatting.smallCaps = false;
+  if (attrs.smallCaps !== undefined) {
+    formatting.smallCaps = attrs.smallCaps;
   }
-  if (attrs.emboss === false) {
-    formatting.emboss = false;
+  if (attrs.hidden !== undefined) {
+    formatting.hidden = attrs.hidden;
   }
-  if (attrs.imprint === false) {
-    formatting.imprint = false;
+  if (attrs.emboss !== undefined) {
+    formatting.emboss = attrs.emboss;
   }
-  if (attrs.shadow === false) {
-    formatting.textShadow = false;
+  if (attrs.imprint !== undefined) {
+    formatting.imprint = attrs.imprint;
   }
-  if (attrs.outline === false) {
-    formatting.textOutline = false;
+  if (attrs.shadow !== undefined) {
+    formatting.textShadow = attrs.shadow;
+  }
+  if (attrs.outline !== undefined) {
+    formatting.textOutline = attrs.outline;
   }
   if (attrs.rtl === false) {
     formatting.rtl = false;
@@ -1051,6 +1128,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
     }
     if (child.isText && child.text) {
       const formatting = extractRunFormatting(child.marks, theme);
+      applyCharacterStyleToggleFormatting({ formatting, marks: child.marks, paraDefaults });
       if (inTocParagraph) {
         stripTocHyperlinkStyle(formatting);
       }
@@ -1071,6 +1149,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
         return;
       }
       const formatting = extractRunFormatting(child.marks, theme);
+      applyCharacterStyleToggleFormatting({ formatting, marks: child.marks, paraDefaults });
       if (inTocParagraph) {
         stripTocHyperlinkStyle(formatting);
       }
@@ -1094,6 +1173,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
     }
     if (child.type.name === "tab") {
       const formatting = extractRunFormatting(child.marks, theme);
+      applyCharacterStyleToggleFormatting({ formatting, marks: child.marks, paraDefaults });
       const run: TabRun = {
         kind: "tab",
         ...mergeRunFormatting(paraDefaults, formatting),
@@ -1152,6 +1232,11 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
         mappedType = "TIME";
       }
       const extractedFieldFormatting = extractRunFormatting(child.marks, theme);
+      applyCharacterStyleToggleFormatting({
+        formatting: extractedFieldFormatting,
+        marks: child.marks,
+        paraDefaults,
+      });
       if (inTocParagraph) {
         stripTocHyperlinkStyle(extractedFieldFormatting);
       }

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -186,11 +186,10 @@ const HARD_BREAK_TYPES = ["column"] as const satisfies readonly NonNullable<
   HardBreakAttrs["breakType"]
 >[];
 
-const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
+const RUN_FORMATTING_OVERRIDE_BOOLEAN_KEYS = [
   "bold",
   "italic",
   "strike",
-  "doubleStrike",
   "allCaps",
   "smallCaps",
   "hidden",
@@ -198,6 +197,11 @@ const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
   "imprint",
   "shadow",
   "outline",
+] as const satisfies readonly (keyof RunFormattingOverrideAttrs)[];
+
+const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
+  "doubleStrike",
+  "rtl",
 ] as const satisfies readonly (keyof RunFormattingOverrideAttrs)[];
 
 const SECTION_ORIENTATIONS = ["portrait", "landscape"] as const;
@@ -1147,6 +1151,9 @@ export const readRunFormattingOverrideMarkAttrs = (
   const issues: ProseMirrorAttrIssue[] = [];
   expectMarkType(mark, "runFormattingOverride", issues);
 
+  for (const key of RUN_FORMATTING_OVERRIDE_BOOLEAN_KEYS) {
+    optionalBoolean(attrs, key, `runFormattingOverride.attrs.${key}`, issues);
+  }
   for (const key of RUN_FORMATTING_OVERRIDE_FALSE_KEYS) {
     optionalFalse(attrs, key, `runFormattingOverride.attrs.${key}`, issues);
   }

--- a/packages/core/src/prosemirror/commands/formatPainter.test.ts
+++ b/packages/core/src/prosemirror/commands/formatPainter.test.ts
@@ -103,6 +103,25 @@ describe("captureFormatMarks", () => {
     expect(override?.attrs["bold"]).toBe(false);
     expect(override?.attrs["rtl"]).toBeNull();
   });
+
+  test("resolves paragraph defaults through an inline content control", () => {
+    const characterStyle = mark("characterStyle", {
+      styleId: "ComplexToggle",
+      _styleRPr: { boldCs: true },
+    });
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", { defaultTextFormatting: { boldCs: true } }, [
+          schema.node("sdt", { sdtType: "richText" }, [schema.text("source", [characterStyle])]),
+        ]),
+      ]),
+    });
+
+    const captured = captureFormatMarks(select(state, 2, 8));
+
+    expect(findMark(captured, "runFormattingOverride")?.attrs["boldCs"]).toBe(false);
+  });
 });
 
 describe("applyFormatMarks", () => {

--- a/packages/core/src/prosemirror/commands/formatPainter.ts
+++ b/packages/core/src/prosemirror/commands/formatPainter.ts
@@ -9,8 +9,10 @@
  * logic is here so it can be unit-tested without a DOM.
  */
 
-import type { Mark } from "prosemirror-model";
+import type { Mark, ResolvedPos } from "prosemirror-model";
 import type { Command, EditorState } from "prosemirror-state";
+
+import { expectCharacterStyleMarkAttrs, expectParagraphAttrs } from "../attrs";
 
 /**
  * Character-formatting marks the painter copies. Structural marks — comments,
@@ -89,6 +91,71 @@ function sanitizeOverrideMark(mark: Mark): Mark | null {
   return mark.type.create(kept);
 }
 
+const PAINTABLE_STYLE_TOGGLE_MARKS = [
+  ["allCaps", "allCaps"],
+  ["bold", "bold"],
+  ["emboss", "emboss"],
+  ["imprint", "imprint"],
+  ["italic", "italic"],
+  ["outline", "textOutline"],
+  ["shadow", "textShadow"],
+  ["smallCaps", "smallCaps"],
+  ["strike", "strike"],
+] as const;
+
+const PAINTABLE_COMPLEX_SCRIPT_TOGGLES = ["boldCs", "italicCs"] as const;
+
+/** Materialize a copied style cancellation as direct formatting on its new target. */
+type MaterializeStyleToggleNegativesOptions = {
+  inheritedFormatting: ReturnType<typeof expectParagraphAttrs>["defaultTextFormatting"];
+  marks: readonly Mark[];
+};
+
+function materializeStyleToggleNegatives({
+  inheritedFormatting,
+  marks,
+}: MaterializeStyleToggleNegativesOptions): Mark[] {
+  const characterStyle = marks.find((mark) => mark.type.name === "characterStyle");
+  if (!characterStyle) {
+    return [...marks];
+  }
+  const styleRPr = expectCharacterStyleMarkAttrs(characterStyle)._styleRPr;
+  if (!styleRPr) {
+    return [...marks];
+  }
+
+  const negativeAttrs: Record<string, false> = {};
+  for (const [key, markName] of PAINTABLE_STYLE_TOGGLE_MARKS) {
+    if (styleRPr[key] === true && !marks.some((mark) => mark.type.name === markName)) {
+      negativeAttrs[key] = false;
+    }
+  }
+  for (const key of PAINTABLE_COMPLEX_SCRIPT_TOGGLES) {
+    if (styleRPr[key] === undefined) {
+      continue;
+    }
+    const inheritedValue = inheritedFormatting?.[key] ?? false;
+    const effectiveValue = styleRPr[key] === true ? !inheritedValue : false;
+    if (!effectiveValue) {
+      negativeAttrs[key] = false;
+    }
+  }
+  if (Object.keys(negativeAttrs).length === 0) {
+    return [...marks];
+  }
+
+  const existingOverride = marks.find((mark) => mark.type.name === "runFormattingOverride");
+  const overrideType =
+    existingOverride?.type ?? characterStyle.type.schema.marks["runFormattingOverride"];
+  if (!overrideType) {
+    return [...marks];
+  }
+  const override = overrideType.create({ ...negativeAttrs, ...existingOverride?.attrs });
+  return existingOverride
+    ? marks.map((mark) => (mark === existingOverride ? override : mark))
+    : [...marks, override];
+}
+
 /**
  * Marks of the first text node inside [from, to). A word processor's format
  * brush copies from the start of the source selection, so a mixed selection
@@ -109,6 +176,18 @@ function firstTextMarks(state: EditorState, from: number, to: number): readonly 
   });
 
   return marks ?? [];
+}
+
+function paragraphDefaultTextFormatting(
+  position: ResolvedPos,
+): ReturnType<typeof expectParagraphAttrs>["defaultTextFormatting"] {
+  for (let depth = position.depth; depth >= 0; depth -= 1) {
+    const ancestor = position.node(depth);
+    if (ancestor.type.name === "paragraph") {
+      return expectParagraphAttrs(ancestor).defaultTextFormatting;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -135,7 +214,8 @@ export function captureFormatMarks(state: EditorState): Mark[] {
     }
     captured.push(mark);
   }
-  return captured;
+  const inheritedFormatting = paragraphDefaultTextFormatting($from);
+  return materializeStyleToggleNegatives({ inheritedFormatting, marks: captured });
 }
 
 /**

--- a/packages/core/src/prosemirror/conversion/characterStyleRoundtrip.test.ts
+++ b/packages/core/src/prosemirror/conversion/characterStyleRoundtrip.test.ts
@@ -11,8 +11,10 @@
 import { describe, expect, test } from "bun:test";
 import { EditorState, TextSelection } from "prosemirror-state";
 
+import { toFlowBlocks } from "../../layout-bridge/convert/toFlowBlocks";
 import type { Document, Paragraph, Run, StyleDefinitions } from "../../types/document";
 import { schema } from "../schema";
+import { applyFormatMarks, captureFormatMarks } from "../commands/formatPainter";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
@@ -57,7 +59,42 @@ const styles: StyleDefinitions = {
       name: "Strong Heading",
       rPr: { bold: true, color: { rgb: "0000FF" } },
     },
+    {
+      styleId: "ToggleHeading",
+      type: "paragraph",
+      name: "Toggle Heading",
+      rPr: { bold: true },
+    },
+    {
+      styleId: "PlainParagraph",
+      type: "paragraph",
+      name: "Plain Paragraph",
+    },
+    {
+      styleId: "StrongCharacter",
+      type: "character",
+      name: "Strong Character",
+      rPr: { bold: true },
+    },
+    {
+      styleId: "LatinEmphasis",
+      type: "character",
+      name: "Latin Emphasis",
+      rPr: { bold: true, boldCs: false, italic: true, italicCs: false },
+    },
+    {
+      styleId: "DefaultStrongCharacter",
+      type: "character",
+      name: "Default Strong Character",
+      rPr: { bold: true },
+    },
   ],
+};
+
+const stylesWithDefaultCharacter: StyleDefinitions = {
+  styles: styles.styles.map((style) =>
+    style.styleId === "DefaultStrongCharacter" ? { ...style, default: true } : style,
+  ),
 };
 
 const firstParagraph = (document: Document): Paragraph => {
@@ -102,6 +139,14 @@ const markNames = (document: Document, text: string): string[] => {
 describe("characterStyle mark schema registration", () => {
   test("schema includes the characterStyle mark", () => {
     expect(schema.marks["characterStyle"]).toBeDefined();
+  });
+
+  test("run override schema exposes no source-provenance attributes", () => {
+    const attrs = Object.keys(schema.marks["runFormattingOverride"]?.spec.attrs ?? {});
+    expect(attrs).not.toContain("_baseRPr");
+    expect(attrs).not.toContain("_effectiveRPr");
+    expect(attrs).not.toContain("_directRPr");
+    expect(attrs).not.toContain("_sourceStyleId");
   });
 });
 
@@ -178,6 +223,368 @@ describe("character style round-trip", () => {
     const twice = fromProseDoc(toProseDoc(once, { styles }), once);
     expect(findRun(firstParagraph(twice), "Term").formatting).toEqual({
       styleId: "DefinedTerm",
+    });
+  });
+
+  test("matching paragraph and explicit character toggles preserve only the style reference", () => {
+    const input = wrapParagraph({
+      type: "paragraph",
+      formatting: { styleId: "ToggleHeading" },
+      content: [runText("Term", { styleId: "StrongCharacter" })],
+    });
+
+    const proseDoc = toProseDoc(input, { styles });
+    const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+    const out = fromProseDoc(clonedProseDoc, input);
+
+    expect(findRun(firstParagraph(out), "Term").formatting).toEqual({
+      styleId: "StrongCharacter",
+    });
+  });
+
+  test("independent complex-script style toggles survive a JSON clone without direct formatting", () => {
+    const input = wrap(runText("Term", { styleId: "LatinEmphasis" }));
+
+    const proseDoc = toProseDoc(input, { styles });
+    const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+    const out = fromProseDoc(clonedProseDoc, input);
+
+    expect(findRun(firstParagraph(out), "Term").formatting).toEqual({
+      styleId: "LatinEmphasis",
+    });
+  });
+
+  test("all inherited, character, and direct ordinary/CS toggle combinations round-trip", () => {
+    const values = [false, true] as const;
+    const directValues = [undefined, false, true] as const;
+    for (const inheritedOrdinary of values) {
+      for (const inheritedCs of values) {
+        for (const characterOrdinary of values) {
+          for (const characterCs of values) {
+            for (const direct of directValues) {
+              const matrixStyles: StyleDefinitions = {
+                styles: [
+                  {
+                    styleId: "P",
+                    type: "paragraph",
+                    name: "Paragraph",
+                    rPr: {
+                      bold: inheritedOrdinary,
+                      boldCs: inheritedCs,
+                      italic: inheritedOrdinary,
+                      italicCs: inheritedCs,
+                    },
+                  },
+                  {
+                    styleId: "C",
+                    type: "character",
+                    name: "Character",
+                    rPr: {
+                      bold: characterOrdinary,
+                      boldCs: characterCs,
+                      italic: characterOrdinary,
+                      italicCs: characterCs,
+                    },
+                  },
+                ],
+              };
+              const directFormatting =
+                direct === undefined
+                  ? { styleId: "C" }
+                  : {
+                      styleId: "C",
+                      bold: direct,
+                      boldCs: direct,
+                      italic: direct,
+                      italicCs: direct,
+                    };
+              const input = wrapParagraph({
+                type: "paragraph",
+                formatting: { styleId: "P" },
+                content: [runText("Term", directFormatting)],
+              });
+
+              const proseDoc = toProseDoc(input, { styles: matrixStyles });
+              const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+              const out = fromProseDoc(clonedProseDoc, input);
+              const matrixCase = [
+                inheritedOrdinary,
+                inheritedCs,
+                characterOrdinary,
+                characterCs,
+                direct,
+              ].join("/");
+
+              expect({
+                formatting: findRun(firstParagraph(out), "Term").formatting,
+                matrixCase,
+              }).toEqual({ formatting: directFormatting, matrixCase });
+            }
+          }
+        }
+      }
+    }
+  });
+
+  test("authored direct positives remain fixed after a paragraph-style change", () => {
+    const initialStyles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "P",
+          type: "paragraph",
+          name: "Paragraph",
+          rPr: { bold: true, boldCs: true, italic: true, italicCs: true },
+        },
+        {
+          styleId: "C",
+          type: "character",
+          name: "Character",
+          rPr: { bold: false, boldCs: false, italic: false, italicCs: false },
+        },
+      ],
+    };
+    const input = wrapParagraph({
+      type: "paragraph",
+      formatting: { styleId: "P" },
+      content: [
+        runText("Term", {
+          styleId: "C",
+          bold: true,
+          boldCs: true,
+          italic: true,
+          italicCs: true,
+        }),
+      ],
+    });
+    const clonedProseDoc = schema.nodeFromJSON(
+      toProseDoc(input, { styles: initialStyles }).toJSON(),
+    );
+    const saved = fromProseDoc(clonedProseDoc, input);
+    const changedStyles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "P",
+          type: "paragraph",
+          name: "Paragraph",
+          rPr: { bold: false, boldCs: false, italic: false, italicCs: false },
+        },
+        {
+          styleId: "C",
+          type: "character",
+          name: "Character",
+          rPr: { bold: false, boldCs: false, italic: false, italicCs: false },
+        },
+      ],
+    };
+    const changedProseDoc = schema.nodeFromJSON(
+      toProseDoc(saved, { styles: changedStyles }).toJSON(),
+    );
+    const changedFlowParagraph = toFlowBlocks(changedProseDoc, {}).find(
+      (block) => block.kind === "paragraph",
+    );
+    const changedFlowRun = changedFlowParagraph?.runs.find((run) => run.kind === "text");
+
+    expect(findRun(firstParagraph(saved), "Term").formatting).toEqual({
+      styleId: "C",
+      bold: true,
+      boldCs: true,
+      italic: true,
+      italicCs: true,
+    });
+    expect(changedFlowRun).toMatchObject({
+      bold: true,
+      complexScriptBold: true,
+      italic: true,
+      complexScriptItalic: true,
+    });
+  });
+
+  test("an authored direct off survives when the style cascade is already off", () => {
+    const input = wrapParagraph({
+      type: "paragraph",
+      formatting: { styleId: "ToggleHeading" },
+      content: [runText("Term", { styleId: "StrongCharacter", bold: false })],
+    });
+
+    const proseDoc = toProseDoc(input, { styles });
+    const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+    const out = fromProseDoc(clonedProseDoc, input);
+
+    expect(findRun(firstParagraph(out), "Term").formatting).toEqual({
+      styleId: "StrongCharacter",
+      bold: false,
+    });
+  });
+
+  test("matching paragraph and default character toggles add no direct formatting", () => {
+    const input = wrapParagraph({
+      type: "paragraph",
+      formatting: { styleId: "ToggleHeading" },
+      content: [runText("Term")],
+    });
+
+    const proseDoc = toProseDoc(input, { styles: stylesWithDefaultCharacter });
+    const clonedProseDoc = schema.nodeFromJSON(proseDoc.toJSON());
+    const out = fromProseDoc(clonedProseDoc, input);
+
+    expect(findRun(firstParagraph(out), "Term").formatting).toBeUndefined();
+  });
+
+  test("a later paragraph-style change is not masked by a synthesized direct off", () => {
+    const input = wrapParagraph({
+      type: "paragraph",
+      formatting: { styleId: "ToggleHeading" },
+      content: [runText("Term", { styleId: "StrongCharacter" })],
+    });
+    const saved = fromProseDoc(toProseDoc(input, { styles }), input);
+    const changedStyles: StyleDefinitions = {
+      styles: styles.styles.map((style) =>
+        style.styleId === "ToggleHeading" ? { ...style, rPr: { bold: false } } : style,
+      ),
+    };
+
+    const names = toProseDoc(saved, { styles: changedStyles })
+      .child(0)
+      .child(0)
+      .marks.map((mark) => mark.type.name);
+
+    expect(findRun(firstParagraph(saved), "Term").formatting).toEqual({
+      styleId: "StrongCharacter",
+    });
+    expect(names).toContain("bold");
+  });
+
+  test("a later paragraph-style change still reaches the implicit default character style", () => {
+    const input = wrapParagraph({
+      type: "paragraph",
+      formatting: { styleId: "ToggleHeading" },
+      content: [runText("Term")],
+    });
+    const saved = fromProseDoc(toProseDoc(input, { styles: stylesWithDefaultCharacter }), input);
+    const changedStyles: StyleDefinitions = {
+      styles: stylesWithDefaultCharacter.styles.map((style) =>
+        style.styleId === "ToggleHeading" ? { ...style, rPr: { bold: false } } : style,
+      ),
+    };
+
+    const names = toProseDoc(saved, { styles: changedStyles })
+      .child(0)
+      .child(0)
+      .marks.map((mark) => mark.type.name);
+
+    expect(findRun(firstParagraph(saved), "Term").formatting).toBeUndefined();
+    expect(names).toContain("bold");
+  });
+
+  test("serialized editor state stays linear for many inherited toggle runs", () => {
+    const paragraphs = Array.from(
+      { length: 1000 },
+      (_, index): Paragraph => ({
+        type: "paragraph",
+        formatting: { styleId: "ToggleHeading" },
+        content: [runText(`Term ${index}`)],
+      }),
+    );
+    const plain: Document = {
+      package: {
+        document: { content: paragraphs.map(({ content, type }) => ({ content, type })) },
+      },
+    };
+    const styled: Document = {
+      package: { document: { content: paragraphs }, styles: stylesWithDefaultCharacter },
+    };
+
+    const plainSize = JSON.stringify(toProseDoc(plain).toJSON()).length;
+    const styledProseDoc = toProseDoc(styled, { styles: stylesWithDefaultCharacter });
+    const styledJson = JSON.stringify(styledProseDoc.toJSON());
+    const saved = fromProseDoc(styledProseDoc, styled);
+
+    expect(styledJson.length).toBeLessThan(plainSize * 2);
+    expect(styledJson).not.toContain("_effectiveRPr");
+    expect(styledJson).not.toContain("_directRPr");
+    expect(styledJson).not.toContain("runFormattingOverride");
+    expect(saved.package.document.content).toHaveLength(1000);
+    expect(findRun(firstParagraph(saved), "Term 0").formatting).toBeUndefined();
+  });
+
+  test("painting an effective off across paragraph styles saves a direct off", () => {
+    const input: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "ToggleHeading" },
+              content: [runText("From", { styleId: "StrongCharacter" })],
+            },
+            {
+              type: "paragraph",
+              formatting: { styleId: "PlainParagraph" },
+              content: [runText("To")],
+            },
+          ],
+        },
+        styles,
+      },
+    };
+    let state = EditorState.create({ doc: toProseDoc(input, { styles }) });
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 5)));
+    const captured = captureFormatMarks(state);
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 7, 9)));
+    applyFormatMarks(captured)(state, (transaction) => {
+      state = state.apply(transaction);
+    });
+
+    const saved = fromProseDoc(state.doc, input);
+    const target = saved.package.document.content.at(1);
+    if (target?.type !== "paragraph") {
+      throw new Error("Expected target paragraph");
+    }
+
+    expect(findRun(target, "To").formatting).toEqual({
+      styleId: "StrongCharacter",
+      bold: false,
+    });
+  });
+
+  test("painting independent complex-script style toggles saves direct offs", () => {
+    const input: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "PlainParagraph" },
+              content: [runText("From", { styleId: "LatinEmphasis" })],
+            },
+            {
+              type: "paragraph",
+              formatting: { styleId: "PlainParagraph" },
+              content: [runText("To")],
+            },
+          ],
+        },
+        styles,
+      },
+    };
+    let state = EditorState.create({ doc: toProseDoc(input, { styles }) });
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 5)));
+    const captured = captureFormatMarks(state);
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 7, 9)));
+    applyFormatMarks(captured)(state, (transaction) => {
+      state = state.apply(transaction);
+    });
+
+    const saved = fromProseDoc(state.doc, input);
+    const target = saved.package.document.content.at(1);
+    if (target?.type !== "paragraph") {
+      throw new Error("Expected target paragraph");
+    }
+
+    expect(findRun(target, "To").formatting).toEqual({
+      styleId: "LatinEmphasis",
+      boldCs: false,
+      italicCs: false,
     });
   });
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -106,6 +106,7 @@ import {
 import { autospacingMatchesBase, hasAutospacingBaseSide } from "../autospacingBase";
 import { directionToBidi } from "../paragraphDirection";
 import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
+import { cascadeStyleTextFormatting } from "../styles/styleToggleCascade";
 import { applyRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
 import type {
   ParagraphAttrs,
@@ -1362,6 +1363,10 @@ function extractParagraphContent(
   skipLeadingRenderedPageBreak = false,
 ): ParagraphContent[] {
   const content: ParagraphContent[] = [];
+  const inheritedFormatting =
+    paragraph.type.name === "paragraph"
+      ? (expectParagraphAttrs(paragraph).defaultTextFormatting ?? undefined)
+      : undefined;
   const sortedEmptyHyperlinks = (emptyHyperlinks ?? [])
     .map((attrs, order) => ({ attrs, order }))
     .toSorted((left, right) => left.attrs.offset - right.attrs.offset || left.order - right.order);
@@ -1518,7 +1523,7 @@ function extractParagraphContent(
       const otherMarks = node.marks.filter(
         (m) => m.type.name !== "insertion" && m.type.name !== "deletion",
       );
-      const run = createTrackedChangeRun(node, otherMarks);
+      const run = createTrackedChangeRun({ inheritedFormatting, marks: otherMarks, node });
       if (!run) {
         return;
       }
@@ -1580,7 +1585,7 @@ function extractParagraphContent(
         currentHyperlink = createHyperlink(linkMark);
         currentHyperlinkKey = linkKey;
       }
-      addNodeToHyperlink(currentHyperlink, node);
+      addNodeToHyperlink({ hyperlink: currentHyperlink, inheritedFormatting, node });
       return;
     }
 
@@ -1601,7 +1606,11 @@ function extractParagraphContent(
         if (currentRun) {
           content.push(currentRun);
         }
-        currentRun = createRunFromText(node.text || "", node.marks);
+        currentRun = createRunFromText({
+          inheritedFormatting,
+          marks: node.marks,
+          text: node.text || "",
+        });
         currentMarksKey = marksKey;
       }
     } else if (node.type.name === "symbol") {
@@ -1686,13 +1695,26 @@ function extractParagraphContent(
   return content;
 }
 
-function createTrackedChangeRun(node: PMNode, marks: readonly Mark[]): Run | null {
+type RunFormattingContext = {
+  inheritedFormatting: TextFormatting | undefined;
+};
+
+type CreateTrackedChangeRunOptions = RunFormattingContext & {
+  marks: readonly Mark[];
+  node: PMNode;
+};
+
+function createTrackedChangeRun({
+  inheritedFormatting,
+  marks,
+  node,
+}: CreateTrackedChangeRunOptions): Run | null {
   const noteRefMark = marks.find((mark) => mark.type.name === "footnoteRef");
   if (noteRefMark) {
     return createNoteReferenceRun(noteRefMark, marks);
   }
   if (node.isText) {
-    const formatting = marksToTextFormatting(marks);
+    const formatting = marksToTextFormatting(marks, { inheritedFormatting });
     const run: Run = {
       type: "run",
       content: node.text ? [{ type: "text", text: node.text }] : [],
@@ -1842,7 +1864,16 @@ function createHyperlink(linkMark: Mark): Hyperlink {
 /**
  * Add a node to a hyperlink
  */
-function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
+type AddNodeToHyperlinkOptions = RunFormattingContext & {
+  hyperlink: Hyperlink;
+  node: PMNode;
+};
+
+function addNodeToHyperlink({
+  hyperlink,
+  inheritedFormatting,
+  node,
+}: AddNodeToHyperlinkOptions): void {
   const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
   if (noteRefMark) {
     hyperlink.children.push(createNoteReferenceRun(noteRefMark, node.marks));
@@ -1851,7 +1882,7 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
 
   const nonLinkMarks = node.marks.filter((m) => m.type.name !== "hyperlink");
   if (node.isText && node.text) {
-    const run = createRunFromText(node.text, nonLinkMarks);
+    const run = createRunFromText({ inheritedFormatting, marks: nonLinkMarks, text: node.text });
     hyperlink.children.push(run);
     return;
   }
@@ -1925,8 +1956,13 @@ function createNoteReferenceRun(noteRefMark: Mark, marks: readonly Mark[]): Run 
 /**
  * Create a Run from text and marks
  */
-function createRunFromText(text: string, marks: readonly Mark[]): Run {
-  const formatting = getRunFormattingFromMarks(marks);
+type CreateRunFromTextOptions = RunFormattingContext & {
+  marks: readonly Mark[];
+  text: string;
+};
+
+function createRunFromText({ inheritedFormatting, marks, text }: CreateRunFromTextOptions): Run {
+  const formatting = getRunFormattingFromMarks(marks, { inheritedFormatting });
   const textContent: TextContent = {
     type: "text",
     text,
@@ -1964,12 +2000,15 @@ function restoreRunPropertyChanges(run: Run, marks: readonly Mark[]): void {
   run.propertyChanges = [...changes];
 }
 
-function getRunFormattingFromMarks(marks: readonly Mark[] | undefined): TextFormatting | undefined {
+function getRunFormattingFromMarks(
+  marks: readonly Mark[] | undefined,
+  options?: MarksToTextFormattingOptions,
+): TextFormatting | undefined {
   if (!marks || marks.length === 0) {
     return undefined;
   }
 
-  const formatting = marksToTextFormatting(marks);
+  const formatting = marksToTextFormatting(marks, options);
   return Object.keys(formatting).length > 0 ? formatting : undefined;
 }
 
@@ -2435,8 +2474,16 @@ function createShapeRun(node: PMNode): Run {
 /**
  * Convert ProseMirror marks to TextFormatting
  */
-export function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
+type MarksToTextFormattingOptions = {
+  inheritedFormatting: TextFormatting | undefined;
+};
+
+export function marksToTextFormatting(
+  marks: readonly Mark[],
+  options?: MarksToTextFormattingOptions,
+): TextFormatting {
   const formatting: TextFormatting = {};
+  let directOverrideFormatting: TextFormatting | undefined;
   let characterStyleRPr: TextFormatting | undefined;
   let runFormattingOverrideMark: Mark | undefined;
 
@@ -2644,14 +2691,19 @@ export function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
   // independent CS and explicit-negative values after ordinary marks so a
   // bold/font-size mark cannot overwrite their more specific OOXML values.
   if (runFormattingOverrideMark) {
-    applyRunFormattingOverrideAttrs(
-      formatting,
-      expectRunFormattingOverrideMarkAttrs(runFormattingOverrideMark),
-    );
+    const overrideAttrs = expectRunFormattingOverrideMarkAttrs(runFormattingOverrideMark);
+    applyRunFormattingOverrideAttrs(formatting, overrideAttrs);
+    directOverrideFormatting = {};
+    applyRunFormattingOverrideAttrs(directOverrideFormatting, overrideAttrs);
   }
 
   if (characterStyleRPr) {
-    return subtractCharacterStyleFormatting(formatting, characterStyleRPr);
+    return subtractCharacterStyleFormatting({
+      directOverrideFormatting,
+      formatting,
+      inheritedFormatting: options?.inheritedFormatting,
+      styleRPr: characterStyleRPr,
+    });
   }
 
   return formatting;
@@ -2685,24 +2737,35 @@ const NEGATABLE_STYLE_KEYS: readonly [keyof TextFormatting, keyof TextFormatting
  * (the `w:rStyle` reference re-imposes them on load), so a styled run
  * serializes back to a style reference instead of baked direct formatting.
  *
- * `styleRPr` is the load-time snapshot from the characterStyle mark, captured
- * in the same normal form this module produces from marks, so value equality
- * is a faithful "came from the style and is unchanged" check. Values that
- * differ (user edits, direct overrides from the source document) stay as
- * direct formatting, which wins over the style per the OOXML cascade.
+ * `styleRPr` is the load-time snapshot from the characterStyle mark. Resolve it
+ * against the paragraph defaults before comparing with visual marks, so pure
+ * inherited values are not baked into the run. Values that differ (user edits,
+ * direct overrides from the source document) stay as direct formatting, which
+ * wins over the style per the OOXML cascade.
  *
- * When the user *removes* a boolean property the style supplied (e.g. toggling
- * off bold on text whose `w:rStyle` is bold), that key is no longer present in
- * `formatting`, so the subtraction loop above never sees it. Without a counter,
- * the run keeps the style reference and Word re-applies the removed formatting
- * on load. The second pass emits an explicit negative override (`false`) for
- * each negatable boolean the style set to `true` but the run no longer carries.
+ * When a character style is the only source of a negatable property, removing
+ * its visual mark emits an explicit negative override. Authored direct negatives
+ * already ride the runFormattingOverride mark, so this distinction survives
+ * JSON/Yjs clones.
  */
-function subtractCharacterStyleFormatting(
-  formatting: TextFormatting,
-  styleRPr: TextFormatting,
-): TextFormatting {
+type SubtractCharacterStyleFormattingOptions = {
+  directOverrideFormatting: TextFormatting | undefined;
+  formatting: TextFormatting;
+  inheritedFormatting: TextFormatting | undefined;
+  styleRPr: TextFormatting;
+};
+
+function subtractCharacterStyleFormatting({
+  directOverrideFormatting,
+  formatting,
+  inheritedFormatting,
+  styleRPr,
+}: SubtractCharacterStyleFormattingOptions): TextFormatting {
   const result: TextFormatting = {};
+  const effectiveStyleFormatting = cascadeStyleTextFormatting([
+    { formatting: inheritedFormatting, type: "direct" },
+    { formatting: styleRPr, type: "style" },
+  ]).formatting;
 
   // SAFETY: Object.keys over a TextFormatting yields its own keys.
   for (const key of Object.keys(formatting) as (keyof TextFormatting)[]) {
@@ -2710,7 +2773,18 @@ function subtractCharacterStyleFormatting(
     if (value === undefined) {
       continue;
     }
-    const styleValue = key === "styleId" ? undefined : styleRPr[key];
+    if (directOverrideFormatting?.[key] !== undefined) {
+      // SAFETY: dynamic property copy between identical TextFormatting keys.
+      (result as Record<string, unknown>)[key] = value;
+      continue;
+    }
+    const styleValue = key === "styleId" ? undefined : effectiveStyleFormatting?.[key];
+    if ((key === "boldCs" || key === "italicCs") && styleValue === false && value === true) {
+      // Ordinary bold/italic marks also set their CS mirrors. When the character
+      // style cascade leaves that CS toggle off, the mirrored `true` is only a
+      // visual-mark artifact, not authored direct formatting.
+      continue;
+    }
     // Both values come out of marksToTextFormatting, so equal values have
     // identical key insertion order and stringify identically.
     if (styleValue !== undefined && JSON.stringify(value) === JSON.stringify(styleValue)) {
@@ -2721,7 +2795,7 @@ function subtractCharacterStyleFormatting(
   }
 
   for (const [key, csKey] of NEGATABLE_STYLE_KEYS) {
-    if (styleRPr[key] !== true || formatting[key] !== undefined) {
+    if (effectiveStyleFormatting?.[key] !== true || formatting[key] !== undefined) {
       continue;
     }
     // SAFETY: dynamic property copy between known boolean TextFormatting keys.

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -60,6 +60,7 @@ import { setAutospacingBaseValue } from "../autospacingBase";
 import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
 import { directionFromBidi } from "../paragraphDirection";
 import { schema } from "../schema";
+import { cascadeStyleTextFormatting } from "../styles/styleToggleCascade";
 import type {
   ImagePositionAttrs,
   ParagraphAttrs,
@@ -92,10 +93,16 @@ export type ToProseDocOptions = {
   theme?: Theme | null;
 };
 
+type ResolvedRunFormatting = {
+  formatting: TextFormatting | undefined;
+  paragraphMarkOverrides?: TextFormatting;
+  toggleCascade: ReturnType<typeof cascadeStyleTextFormatting>;
+};
+
 type RunFormattingResolver = (
   formatting: TextFormatting | undefined,
   fieldType?: string,
-) => TextFormatting | undefined;
+) => ResolvedRunFormatting;
 
 /**
  * Build a `nextTextBoxGroupId()` generator salted with a random per-load
@@ -302,10 +309,17 @@ function convertParagraph(
 
   // Get style-based text formatting (font size, bold, color, etc.)
   let styleRunFormatting: TextFormatting | undefined;
+  let paragraphStyleRunFormatting: TextFormatting | undefined;
   let paragraphStyleFontFamily: TextFormatting["fontFamily"] | undefined;
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(paragraph.formatting?.styleId);
     styleRunFormatting = resolved.runFormatting;
+    const paragraphStyle = paragraph.formatting?.styleId
+      ? (styleResolver.getStyle(paragraph.formatting.styleId) ??
+        styleResolver.getDefaultParagraphStyle())
+      : styleResolver.getDefaultParagraphStyle();
+    paragraphStyleRunFormatting =
+      paragraphStyle?.type === "paragraph" ? paragraphStyle.rPr : undefined;
     paragraphStyleFontFamily = resolveParagraphStyleFontFamily(
       paragraph.formatting?.styleId,
       styleResolver,
@@ -323,7 +337,17 @@ function convertParagraph(
     inheritableParagraphRunFormatting =
       stripParagraphMarkFormattingForBodyRuns(paragraphRunFormatting);
   }
-  let baseRunFormatting = mergeTextFormatting(styleRunFormatting, extraRunFormatting);
+  const orderedToggleFormatting = cascadeStyleTextFormatting(
+    [
+      { formatting: styleResolver?.getDocDefaults()?.rPr, type: "defaults" },
+      { formatting: extraRunFormatting, type: "style" },
+      { formatting: paragraphStyleRunFormatting, type: "style" },
+    ],
+    {
+      ordinaryFormatting: mergeTextFormatting(styleRunFormatting, extraRunFormatting),
+    },
+  );
+  let baseRunFormatting = orderedToggleFormatting.formatting;
   // A table style can carry legacy theme/fallback fonts from the template
   // that created it. Word keeps the paragraph style's authored font in that
   // case while still applying the table style's color, emphasis, and size.
@@ -338,29 +362,56 @@ function convertParagraph(
   // only fills gaps in the style's body-run defaults. Style-less generated
   // documents use the paragraph mark as their highest-precedence run default.
   const paragraphMarkPrecedesStyle = paragraph.formatting?.styleId !== undefined;
-  const defaultRunFormatting = paragraphMarkPrecedesStyle
+  const ordinaryDefaultRunFormatting = paragraphMarkPrecedesStyle
     ? mergeTextFormatting(inheritableParagraphRunFormatting, baseRunFormatting)
     : mergeTextFormatting(baseRunFormatting, inheritableParagraphRunFormatting);
+  const defaultToggleCascade = paragraphMarkPrecedesStyle
+    ? cascadeStyleTextFormatting([{ cascade: orderedToggleFormatting, type: "carried" }], {
+        ordinaryFormatting: ordinaryDefaultRunFormatting,
+      })
+    : cascadeStyleTextFormatting(
+        [
+          { cascade: orderedToggleFormatting, type: "carried" },
+          { formatting: inheritableParagraphRunFormatting, type: "direct" },
+        ],
+        {
+          ordinaryFormatting: ordinaryDefaultRunFormatting,
+        },
+      );
+  const defaultRunFormatting = defaultToggleCascade.formatting;
   const getInheritedRunFormatting = (
     formatting: TextFormatting | undefined,
     fieldType?: string,
-  ): TextFormatting | undefined => {
+  ): ResolvedRunFormatting => {
     if (fieldType === "TOC") {
-      return hasDirectRunFormatting(formatting)
-        ? suppressParagraphMarkFormatting(baseRunFormatting, undefined, formatting)
-        : baseRunFormatting;
+      return {
+        formatting: hasDirectRunFormatting(formatting)
+          ? suppressParagraphMarkFormatting(baseRunFormatting, undefined, formatting)
+          : baseRunFormatting,
+        toggleCascade: orderedToggleFormatting,
+      };
     }
     const hasExplicitRunFormatting =
       hasDirectRunFormatting(formatting) || formatting?.styleId !== undefined;
     if (!hasExplicitRunFormatting) {
-      return defaultRunFormatting;
+      return { formatting: defaultRunFormatting, toggleCascade: defaultToggleCascade };
     }
-    return suppressParagraphMarkFormatting(
+    const suppressedFormatting = suppressParagraphMarkFormatting(
       baseRunFormatting,
       inheritableParagraphRunFormatting,
       formatting,
       paragraphMarkPrecedesStyle,
     );
+    const paragraphMarkOverrides = getParagraphMarkSuppressionOverrides({
+      directFormatting: formatting,
+      paragraphMarkFormatting: inheritableParagraphRunFormatting,
+      suppressedFormatting,
+    });
+    return {
+      formatting: suppressedFormatting,
+      ...(paragraphMarkOverrides ? { paragraphMarkOverrides } : {}),
+      toggleCascade: orderedToggleFormatting,
+    };
   };
   const emitTrackedChange = (
     change: Insertion | Deletion | MoveFrom | MoveTo,
@@ -1117,6 +1168,21 @@ function stripParagraphMarkFormattingForBodyRuns(
   return Object.keys(bodyRunFormatting).length > 0 ? bodyRunFormatting : undefined;
 }
 
+const PARAGRAPH_MARK_BOOLEAN_KEYS = [
+  "bold",
+  "italic",
+  "strike",
+  "doubleStrike",
+  "allCaps",
+  "smallCaps",
+  "hidden",
+  "emboss",
+  "imprint",
+  "shadow",
+  "outline",
+  "rtl",
+] as const satisfies readonly (keyof TextFormatting)[];
+
 function suppressParagraphMarkFormatting(
   base: TextFormatting | undefined,
   paragraphMark: TextFormatting | undefined,
@@ -1131,18 +1197,9 @@ function suppressParagraphMarkFormatting(
     (paragraphMarkPrecedesStyle
       ? mergeTextFormatting(paragraphMark, base)
       : mergeTextFormatting(base, paragraphMark)) ?? {};
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "bold");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "italic");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "strike");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "doubleStrike");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "allCaps");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "smallCaps");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "hidden");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "emboss");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "imprint");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "shadow");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "outline");
-  suppressBooleanParagraphMark(result, base, paragraphMark, direct, "rtl");
+  for (const key of PARAGRAPH_MARK_BOOLEAN_KEYS) {
+    suppressBooleanParagraphMark(result, base, paragraphMark, direct, key);
+  }
 
   // A direct run suppresses a size stored only on the paragraph mark. Restore
   // the resolved paragraph-style size instead of letting the pilcrow size leak
@@ -1173,6 +1230,40 @@ function suppressParagraphMarkFormatting(
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+type GetParagraphMarkSuppressionOverridesOptions = {
+  directFormatting: TextFormatting | undefined;
+  paragraphMarkFormatting: TextFormatting | undefined;
+  suppressedFormatting: TextFormatting | undefined;
+};
+
+function getParagraphMarkSuppressionOverrides({
+  directFormatting,
+  paragraphMarkFormatting,
+  suppressedFormatting,
+}: GetParagraphMarkSuppressionOverridesOptions): TextFormatting | undefined {
+  if (!paragraphMarkFormatting) {
+    return undefined;
+  }
+  const overrides: TextFormatting = {};
+  for (const key of PARAGRAPH_MARK_BOOLEAN_KEYS) {
+    if (
+      paragraphMarkFormatting[key] !== undefined &&
+      directFormatting?.[key] === undefined &&
+      suppressedFormatting?.[key] === false
+    ) {
+      overrides[key] = false;
+    }
+  }
+  if (
+    paragraphMarkFormatting.underline !== undefined &&
+    directFormatting?.underline === undefined &&
+    suppressedFormatting?.underline?.style === "none"
+  ) {
+    overrides.underline = { style: "none" };
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 function suppressBooleanParagraphMark(
@@ -1233,7 +1324,10 @@ function resolveRunFormattingWithoutDefaults(
   const characterStyleFormatting = formatting.styleId
     ? styleResolver.getRunStyleOwnProperties(formatting.styleId)
     : undefined;
-  return mergeTextFormatting(characterStyleFormatting, formatting);
+  return cascadeStyleTextFormatting([
+    { formatting: characterStyleFormatting, type: "style" },
+    { formatting, type: "direct" },
+  ]).formatting;
 }
 
 function resolveParagraphDefaultTextFormatting(
@@ -1260,16 +1354,37 @@ function resolveParagraphDefaultTextFormatting(
       )
     : undefined;
 
-  const bodyRunDefaults = mergeTextFormatting(
-    mergeTextFormatting(
-      styleResolver.getDocDefaults()?.rPr,
-      styleResolver.getDefaultCharacterStyle()?.rPr,
-    ),
-    paragraphStyleRpr,
+  const orderedBodyToggleFormatting = cascadeStyleTextFormatting(
+    [
+      { formatting: styleResolver.getDocDefaults()?.rPr, type: "defaults" },
+      { formatting: paragraphStyleRpr, type: "style" },
+      { formatting: styleResolver.getDefaultCharacterStyle()?.rPr, type: "style" },
+    ],
+    {
+      ordinaryFormatting: mergeTextFormatting(
+        mergeTextFormatting(
+          styleResolver.getDocDefaults()?.rPr,
+          styleResolver.getDefaultCharacterStyle()?.rPr,
+        ),
+        paragraphStyleRpr,
+      ),
+    },
   );
-  return styleId === undefined
-    ? mergeTextFormatting(bodyRunDefaults, paragraphRunProperties)
-    : mergeTextFormatting(paragraphRunProperties, bodyRunDefaults);
+  const bodyRunDefaults = orderedBodyToggleFormatting.formatting;
+  if (styleId !== undefined) {
+    return cascadeStyleTextFormatting([{ cascade: orderedBodyToggleFormatting, type: "carried" }], {
+      ordinaryFormatting: mergeTextFormatting(paragraphRunProperties, bodyRunDefaults),
+    }).formatting;
+  }
+  return cascadeStyleTextFormatting(
+    [
+      { cascade: orderedBodyToggleFormatting, type: "carried" },
+      { formatting: paragraphRunProperties, type: "direct" },
+    ],
+    {
+      ordinaryFormatting: mergeTextFormatting(bodyRunDefaults, paragraphRunProperties),
+    },
+  ).formatting;
 }
 
 /**
@@ -2268,16 +2383,20 @@ function convertInlineSdt(
  * Convert a Run to ProseMirror text nodes with marks
  *
  * @param run - The run to convert
- * @param styleFormatting - Text formatting from the paragraph's style (e.g., Heading1's font size/color)
+ * @param resolvedStyleFormatting - Paragraph formatting and its explicit style-toggle state
  */
 function convertRun(
   run: Run,
-  styleFormatting?: TextFormatting,
+  resolvedStyleFormatting: ResolvedRunFormatting,
   styleResolver?: StyleEngine | null,
   textBoxAnchors?: ReadonlyMap<Shape, string>,
 ): PMNode[] {
   const nodes: PMNode[] = [];
-  const { marks, mergedFormatting } = buildRunMarks(run.formatting, styleFormatting, styleResolver);
+  const { marks, mergedFormatting } = buildRunMarks(
+    run.formatting,
+    resolvedStyleFormatting,
+    styleResolver,
+  );
   if (run.propertyChanges && run.propertyChanges.length > 0) {
     marks.push(schema.mark("runPropertyChange", { changes: [...run.propertyChanges] }));
   }
@@ -2317,20 +2436,47 @@ type BuiltRunMarks = {
 
 function buildRunMarks(
   runFormatting: TextFormatting | undefined,
-  inheritedFormatting: TextFormatting | undefined,
+  inherited: ResolvedRunFormatting,
   styleResolver: StyleEngine | null | undefined,
 ): BuiltRunMarks {
   const styleId = runFormatting?.styleId;
-  const runStyleFormatting = styleId ? styleResolver?.getRunStyleOwnProperties(styleId) : undefined;
-  const mergedFormatting = mergeTextFormatting(
-    mergeTextFormatting(inheritedFormatting, runStyleFormatting),
-    runFormatting,
+  const characterStyleFormatting = styleId
+    ? styleResolver?.getRunStyleOwnProperties(styleId)
+    : styleResolver?.getDefaultCharacterStyle()?.rPr;
+  let ordinaryRunStyleFormatting = inherited.formatting ? { ...inherited.formatting } : {};
+  if (styleId) {
+    ordinaryRunStyleFormatting =
+      mergeTextFormatting(inherited.formatting, characterStyleFormatting) ?? {};
+  }
+  const cascadedStyleFormatting = cascadeStyleTextFormatting(
+    [
+      { cascade: inherited.toggleCascade, type: "carried" },
+      { formatting: characterStyleFormatting, type: "style" },
+    ],
+    { ordinaryFormatting: ordinaryRunStyleFormatting },
   );
-  const marks = textFormattingToMarks(mergedFormatting);
+  const runStyleFormatting = cascadedStyleFormatting.formatting;
+  const finalToggleFormatting = cascadeStyleTextFormatting(
+    [
+      { cascade: cascadedStyleFormatting, type: "carried" },
+      { formatting: runFormatting, type: "direct" },
+    ],
+    { ordinaryFormatting: mergeTextFormatting(runStyleFormatting, runFormatting) },
+  );
+  const mergedFormatting = finalToggleFormatting.formatting;
+  const overrideFormatting = getRunFormattingOverrides({
+    directFormatting: runFormatting,
+    effectiveStyleFormatting: runStyleFormatting,
+    hasCharacterStyle: styleId !== undefined,
+    paragraphMarkOverrides: inherited.paragraphMarkOverrides,
+  });
+  const marks = textFormattingToMarks(mergedFormatting, {
+    overrideFormatting,
+  });
 
   if (styleId) {
-    const styleRPr = runStyleFormatting
-      ? marksToTextFormatting(textFormattingToMarks(runStyleFormatting))
+    const styleRPr = characterStyleFormatting
+      ? marksToTextFormatting(textFormattingToMarks(characterStyleFormatting))
       : undefined;
     marks.push(
       schema.mark("characterStyle", {
@@ -2341,6 +2487,67 @@ function buildRunMarks(
   }
 
   return { marks, mergedFormatting };
+}
+
+const ORDINARY_STYLE_TOGGLE_KEYS = [
+  "bold",
+  "italic",
+  "strike",
+  "allCaps",
+  "smallCaps",
+  "hidden",
+  "emboss",
+  "imprint",
+  "shadow",
+  "outline",
+] as const satisfies readonly (keyof TextFormatting)[];
+
+type GetRunFormattingOverridesOptions = {
+  directFormatting: TextFormatting | undefined;
+  effectiveStyleFormatting: TextFormatting | undefined;
+  hasCharacterStyle: boolean;
+  paragraphMarkOverrides: TextFormatting | undefined;
+};
+
+function getRunFormattingOverrides({
+  directFormatting,
+  effectiveStyleFormatting,
+  hasCharacterStyle,
+  paragraphMarkOverrides,
+}: GetRunFormattingOverridesOptions): TextFormatting | undefined {
+  const overrides = mergeTextFormatting(paragraphMarkOverrides, directFormatting);
+  if (!overrides || !directFormatting) {
+    return overrides;
+  }
+
+  // A positive PM mark already preserves direct formatting unless character-style
+  // subtraction would mistake it for an inherited visual. Keep only that ambiguous
+  // positive state in the structural override; negative state remains explicit.
+  for (const key of ORDINARY_STYLE_TOGGLE_KEYS) {
+    if (
+      directFormatting[key] === true &&
+      (!hasCharacterStyle || effectiveStyleFormatting?.[key] !== true)
+    ) {
+      Reflect.deleteProperty(overrides, key);
+    }
+  }
+
+  if (
+    directFormatting.boldCs === true &&
+    directFormatting.boldCs === directFormatting.bold &&
+    (!hasCharacterStyle || effectiveStyleFormatting?.boldCs === undefined)
+  ) {
+    Reflect.deleteProperty(overrides, "boldCs");
+  }
+  if (
+    directFormatting.italicCs === true &&
+    directFormatting.italicCs === directFormatting.italic &&
+    (!hasCharacterStyle || effectiveStyleFormatting?.italicCs === undefined)
+  ) {
+    Reflect.deleteProperty(overrides, "italicCs");
+  }
+
+  return overrides;
 }
 
 /**
@@ -2741,15 +2948,21 @@ function convertHyperlink(
 /**
  * Convert TextFormatting to ProseMirror marks
  */
+type TextFormattingToMarksOptions = {
+  overrideFormatting: TextFormatting | undefined;
+};
+
 export function textFormattingToMarks(
   formatting: TextFormatting | undefined,
+  options?: TextFormattingToMarksOptions,
 ): ReturnType<typeof schema.mark>[] {
   if (!formatting) {
     return [];
   }
 
   const marks: ReturnType<typeof schema.mark>[] = [];
-  const overrideAttrs = buildRunFormattingOverrideAttrs(formatting);
+  const overrideFormatting = options ? options.overrideFormatting : formatting;
+  const overrideAttrs = buildRunFormattingOverrideAttrs(overrideFormatting);
 
   if (overrideAttrs) {
     marks.push(schema.mark("runFormattingOverride", overrideAttrs));

--- a/packages/core/src/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
@@ -1,9 +1,9 @@
 /**
  * Run formatting override mark.
  *
- * OOXML can explicitly turn inherited boolean/defaultable run properties off
- * (for example <w:b w:val="0"/>). Plain PM marks cannot distinguish "inherit"
- * from "explicitly off", so this mark carries those negative overrides.
+ * OOXML can explicitly set inherited boolean/defaultable run properties. Plain
+ * PM marks cannot distinguish inherited visuals from authored direct values, so
+ * this mark carries those direct toggle overrides.
  */
 
 import type { Mark } from "prosemirror-model";
@@ -22,49 +22,49 @@ export function buildRunFormattingOverrideAttrs(
 
   const attrs: RunFormattingOverrideAttrs = {};
 
-  if (formatting.bold === false) {
-    attrs.bold = false;
+  if (formatting.bold !== undefined) {
+    attrs.bold = formatting.bold;
   }
-  if (formatting.italic === false) {
-    attrs.italic = false;
+  if (formatting.italic !== undefined) {
+    attrs.italic = formatting.italic;
   }
   if (formatting.underline?.style === "none") {
     attrs.underline = "none";
   }
-  if (formatting.strike === false) {
-    attrs.strike = false;
+  if (formatting.strike !== undefined) {
+    attrs.strike = formatting.strike;
   }
   if (formatting.doubleStrike === false) {
     attrs.doubleStrike = false;
   }
-  if (formatting.allCaps === false) {
-    attrs.allCaps = false;
+  if (formatting.allCaps !== undefined) {
+    attrs.allCaps = formatting.allCaps;
   }
-  if (formatting.smallCaps === false) {
-    attrs.smallCaps = false;
+  if (formatting.smallCaps !== undefined) {
+    attrs.smallCaps = formatting.smallCaps;
   }
-  if (formatting.hidden === false) {
-    attrs.hidden = false;
+  if (formatting.hidden !== undefined) {
+    attrs.hidden = formatting.hidden;
   }
-  if (formatting.emboss === false) {
-    attrs.emboss = false;
+  if (formatting.emboss !== undefined) {
+    attrs.emboss = formatting.emboss;
   }
-  if (formatting.imprint === false) {
-    attrs.imprint = false;
+  if (formatting.imprint !== undefined) {
+    attrs.imprint = formatting.imprint;
   }
-  if (formatting.shadow === false) {
-    attrs.shadow = false;
+  if (formatting.shadow !== undefined) {
+    attrs.shadow = formatting.shadow;
   }
-  if (formatting.outline === false) {
-    attrs.outline = false;
+  if (formatting.outline !== undefined) {
+    attrs.outline = formatting.outline;
   }
   if (formatting.rtl === false) {
     attrs.rtl = false;
   }
-  if (formatting.boldCs !== undefined && formatting.boldCs !== formatting.bold) {
+  if (formatting.boldCs !== undefined) {
     attrs.boldCs = formatting.boldCs;
   }
-  if (formatting.italicCs !== undefined && formatting.italicCs !== formatting.italic) {
+  if (formatting.italicCs !== undefined) {
     attrs.italicCs = formatting.italicCs;
   }
   if (formatting.fontSizeCs !== undefined && formatting.fontSizeCs !== formatting.fontSize) {
@@ -81,41 +81,41 @@ export function applyRunFormattingOverrideAttrs(
   formatting: TextFormatting,
   attrs: RunFormattingOverrideAttrs,
 ): void {
-  if (attrs.bold === false) {
-    formatting.bold = false;
+  if (attrs.bold !== undefined) {
+    formatting.bold = attrs.bold;
   }
-  if (attrs.italic === false) {
-    formatting.italic = false;
+  if (attrs.italic !== undefined) {
+    formatting.italic = attrs.italic;
   }
   if (attrs.underline === "none") {
     formatting.underline = { style: "none" };
   }
-  if (attrs.strike === false) {
-    formatting.strike = false;
+  if (attrs.strike !== undefined) {
+    formatting.strike = attrs.strike;
   }
   if (attrs.doubleStrike === false) {
     formatting.doubleStrike = false;
   }
-  if (attrs.allCaps === false) {
-    formatting.allCaps = false;
+  if (attrs.allCaps !== undefined) {
+    formatting.allCaps = attrs.allCaps;
   }
-  if (attrs.smallCaps === false) {
-    formatting.smallCaps = false;
+  if (attrs.smallCaps !== undefined) {
+    formatting.smallCaps = attrs.smallCaps;
   }
-  if (attrs.hidden === false) {
-    formatting.hidden = false;
+  if (attrs.hidden !== undefined) {
+    formatting.hidden = attrs.hidden;
   }
-  if (attrs.emboss === false) {
-    formatting.emboss = false;
+  if (attrs.emboss !== undefined) {
+    formatting.emboss = attrs.emboss;
   }
-  if (attrs.imprint === false) {
-    formatting.imprint = false;
+  if (attrs.imprint !== undefined) {
+    formatting.imprint = attrs.imprint;
   }
-  if (attrs.shadow === false) {
-    formatting.shadow = false;
+  if (attrs.shadow !== undefined) {
+    formatting.shadow = attrs.shadow;
   }
-  if (attrs.outline === false) {
-    formatting.outline = false;
+  if (attrs.outline !== undefined) {
+    formatting.outline = attrs.outline;
   }
   if (attrs.rtl === false) {
     formatting.rtl = false;

--- a/packages/core/src/prosemirror/schema/marks.ts
+++ b/packages/core/src/prosemirror/schema/marks.ts
@@ -158,7 +158,6 @@ export type RunFormattingOverrideAttrs = {
     | "bold"
     | "italic"
     | "strike"
-    | "doubleStrike"
     | "allCaps"
     | "smallCaps"
     | "hidden"
@@ -166,9 +165,10 @@ export type RunFormattingOverrideAttrs = {
     | "imprint"
     | "shadow"
     | "outline"
-    | "rtl"
-  >]?: false;
+  >]?: boolean;
 } & {
+  doubleStrike?: false;
+  rtl?: false;
   /** Independent complex-script weight (`w:bCs`). */
   boldCs?: boolean;
   /** Force complex-script formatting for the full run (`w:cs`). */

--- a/packages/core/src/prosemirror/styles/styleResolver.ts
+++ b/packages/core/src/prosemirror/styles/styleResolver.ts
@@ -24,7 +24,7 @@ import type {
   TextFormatting,
 } from "../../types/document";
 import { mergeParagraphFormatting } from "../../utils/paragraphFormattingMerge";
-import { mergeTextFormatting } from "../../utils/textFormattingMerge";
+import { cascadeStyleTextFormatting } from "./styleToggleCascade";
 
 /**
  * Resolved style properties ready for rendering
@@ -189,10 +189,6 @@ export class StyleResolver {
     if (this.docDefaults?.pPr) {
       result.paragraphFormatting = { ...this.docDefaults.pPr };
     }
-    if (this.docDefaults?.rPr) {
-      result.runFormatting = { ...this.docDefaults.rPr };
-    }
-
     // Layer 2: enclosing table style's paragraph spacing (cell paragraphs
     // only — undefined for everything else, a no-op here).
     if (tableParagraphOverlay) {
@@ -202,26 +198,23 @@ export class StyleResolver {
       }
     }
 
-    // Layer 3: the paragraph's own style chain (Normal when styleId is absent)
-    if (!styleId) {
-      if (this.defaultParagraphStyle) {
-        this.mergeStyleIntoResult(result, this.defaultParagraphStyle);
+    // Layer 3: the paragraph's own style chain (Normal when absent or unknown).
+    const style = styleId
+      ? (this.stylesById.get(styleId) ?? this.defaultParagraphStyle)
+      : this.defaultParagraphStyle;
+    if (style?.pPr) {
+      const merged = mergeParagraphFormatting(result.paragraphFormatting, style.pPr);
+      if (merged) {
+        result.paragraphFormatting = merged;
       }
-      return result;
     }
-
-    // Get the requested style (already has basedOn chain resolved by styleParser)
-    const style = this.stylesById.get(styleId);
-    if (!style) {
-      // Style not found, fall back to Normal
-      if (this.defaultParagraphStyle) {
-        this.mergeStyleIntoResult(result, this.defaultParagraphStyle);
-      }
-      return result;
+    const runFormatting = cascadeStyleTextFormatting([
+      { formatting: this.docDefaults?.rPr, type: "defaults" },
+      { formatting: style?.rPr, type: "style" },
+    ]).formatting;
+    if (runFormatting) {
+      result.runFormatting = runFormatting;
     }
-
-    // Merge style properties into result
-    this.mergeStyleIntoResult(result, style);
 
     return result;
   }
@@ -280,27 +273,13 @@ export class StyleResolver {
    * @returns Resolved text formatting
    */
   resolveRunStyle(styleId: string | undefined | null): TextFormatting | undefined {
-    // Start with document defaults
-    let result: TextFormatting = {};
-    if (this.docDefaults?.rPr) {
-      result = { ...this.docDefaults.rPr };
-    }
+    const style = styleId ? this.stylesById.get(styleId) : this.defaultCharacterStyle;
+    const result = cascadeStyleTextFormatting([
+      { formatting: this.docDefaults?.rPr, type: "defaults" },
+      { formatting: style?.rPr, type: "style" },
+    ]).formatting;
 
-    const defaultCharacterRpr = this.defaultCharacterStyle?.rPr;
-    if (defaultCharacterRpr) {
-      result = mergeTextFormatting(result, defaultCharacterRpr) ?? {};
-    }
-
-    // Get the requested style
-    const style = styleId ? this.stylesById.get(styleId) : undefined;
-    if (!style?.rPr) {
-      return Object.keys(result).length > 0 ? result : undefined;
-    }
-
-    // Merge style's run properties
-    const merged = mergeTextFormatting(result, style.rPr);
-
-    return merged && Object.keys(merged).length > 0 ? merged : undefined;
+    return result && Object.keys(result).length > 0 ? result : undefined;
   }
 
   /**
@@ -375,21 +354,6 @@ export class StyleResolver {
       return this.stylesById.get("Normal") ?? (this.docDefaults ? undefined : BUILTIN_NORMAL_STYLE);
     }
     return undefined;
-  }
-
-  private mergeStyleIntoResult(result: ResolvedParagraphStyle, style: Style): void {
-    if (style.pPr) {
-      const merged = mergeParagraphFormatting(result.paragraphFormatting, style.pPr);
-      if (merged !== undefined) {
-        result.paragraphFormatting = merged;
-      }
-    }
-    if (style.rPr) {
-      const merged = mergeTextFormatting(result.runFormatting, style.rPr);
-      if (merged !== undefined) {
-        result.runFormatting = merged;
-      }
-    }
   }
 }
 

--- a/packages/core/src/prosemirror/styles/styleToggleCascade.test.ts
+++ b/packages/core/src/prosemirror/styles/styleToggleCascade.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TextFormatting } from "../../types/document";
+import { cascadeStyleTextFormatting } from "./styleToggleCascade";
+
+const toggleKeys = [
+  "bold",
+  "boldCs",
+  "italic",
+  "italicCs",
+  "allCaps",
+  "emboss",
+  "imprint",
+  "outline",
+  "shadow",
+  "smallCaps",
+  "strike",
+  "hidden",
+] as const satisfies readonly (keyof TextFormatting)[];
+
+describe("style toggle cascade", () => {
+  for (const key of toggleKeys) {
+    test(`${key} reverses once per style level`, () => {
+      const lower: TextFormatting = { [key]: true };
+      const upper: TextFormatting = { [key]: true };
+
+      const result = cascadeStyleTextFormatting([
+        { formatting: lower, type: "style" },
+        { formatting: upper, type: "style" },
+      ]);
+
+      expect(result.formatting?.[key]).toBe(false);
+    });
+
+    test(`${key} distinguishes defaults, style, and direct false`, () => {
+      const enabled: TextFormatting = { [key]: true };
+      const disabled: TextFormatting = { [key]: false };
+
+      expect(
+        cascadeStyleTextFormatting([
+          { formatting: enabled, type: "defaults" },
+          { formatting: disabled, type: "style" },
+        ]).formatting?.[key],
+      ).toBe(true);
+      expect(
+        cascadeStyleTextFormatting([
+          { formatting: enabled, type: "style" },
+          { formatting: disabled, type: "style" },
+        ]).formatting?.[key],
+      ).toBe(true);
+      expect(
+        cascadeStyleTextFormatting([
+          { formatting: enabled, type: "style" },
+          { formatting: disabled, type: "direct" },
+        ]).formatting?.[key],
+      ).toBe(false);
+    });
+  }
+
+  test("style off behaves like omission", () => {
+    const inherited = cascadeStyleTextFormatting([{ formatting: { bold: true }, type: "style" }]);
+    const absent = cascadeStyleTextFormatting([
+      { cascade: inherited, type: "carried" },
+      { formatting: { italic: true }, type: "style" },
+    ]);
+    const off = cascadeStyleTextFormatting([
+      { cascade: inherited, type: "carried" },
+      { formatting: { bold: false }, type: "style" },
+    ]);
+
+    expect(absent.formatting?.bold).toBe(true);
+    expect(off.formatting?.bold).toBe(true);
+  });
+
+  test("direct formatting sets rather than toggles", () => {
+    const inherited = cascadeStyleTextFormatting([
+      { formatting: { bold: true }, type: "style" },
+      { formatting: { bold: true }, type: "style" },
+    ]);
+
+    expect(
+      cascadeStyleTextFormatting([
+        { cascade: inherited, type: "carried" },
+        { formatting: { bold: true }, type: "direct" },
+      ]).formatting?.bold,
+    ).toBe(true);
+    expect(
+      cascadeStyleTextFormatting([
+        { cascade: inherited, type: "carried" },
+        { formatting: { bold: false }, type: "direct" },
+      ]).formatting?.bold,
+    ).toBe(false);
+  });
+
+  test("enabled document defaults retain their priority over style toggles", () => {
+    const result = cascadeStyleTextFormatting([
+      { formatting: { bold: true }, type: "defaults" },
+      { formatting: { bold: true }, type: "style" },
+      { formatting: { bold: true }, type: "style" },
+    ]);
+
+    expect(result.formatting?.bold).toBe(true);
+  });
+
+  test("cloning between paragraph and character passes preserves toggle history", () => {
+    const paragraph = cascadeStyleTextFormatting([
+      { formatting: { bold: true }, type: "defaults" },
+      { formatting: { bold: true }, type: "style" },
+    ]);
+    const clonedParagraph = {
+      ...paragraph,
+      formatting: paragraph.formatting ? { ...paragraph.formatting } : undefined,
+      toggleStates: new Map(paragraph.toggleStates),
+    };
+    expect(clonedParagraph.formatting).not.toBe(paragraph.formatting);
+    expect(clonedParagraph.toggleStates).not.toBe(paragraph.toggleStates);
+    const character = cascadeStyleTextFormatting([
+      { cascade: clonedParagraph, type: "carried" },
+      { formatting: { bold: true }, type: "style" },
+    ]);
+
+    expect(character.formatting?.bold).toBe(true);
+  });
+
+  test("an explicit style off preserves the document-default priority", () => {
+    const result = cascadeStyleTextFormatting([
+      { formatting: { bold: true }, type: "defaults" },
+      { formatting: { bold: false }, type: "style" },
+      { formatting: { bold: true }, type: "style" },
+    ]);
+
+    expect(result.formatting?.bold).toBe(true);
+  });
+
+  test("direct formatting clears the document-default priority", () => {
+    const inherited = cascadeStyleTextFormatting([
+      { formatting: { bold: true }, type: "defaults" },
+      { formatting: { bold: true }, type: "style" },
+    ]);
+    const result = cascadeStyleTextFormatting([
+      { cascade: inherited, type: "carried" },
+      { formatting: { bold: false }, type: "direct" },
+    ]);
+
+    expect(result.formatting?.bold).toBe(false);
+  });
+
+  test("double strike keeps ordinary last-defined inheritance", () => {
+    const result = cascadeStyleTextFormatting([
+      { formatting: { doubleStrike: true }, type: "style" },
+      { formatting: { doubleStrike: true }, type: "style" },
+    ]);
+
+    expect(result.formatting?.doubleStrike).toBe(true);
+    expect(
+      cascadeStyleTextFormatting([
+        { formatting: { doubleStrike: true }, type: "style" },
+        { formatting: { doubleStrike: false }, type: "style" },
+      ]).formatting?.doubleStrike,
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/prosemirror/styles/styleToggleCascade.ts
+++ b/packages/core/src/prosemirror/styles/styleToggleCascade.ts
@@ -1,0 +1,98 @@
+import type { TextFormatting } from "../../types/document";
+import { mergeTextFormatting, STYLE_TOGGLE_KEYS } from "../../utils/textFormattingMerge";
+
+type StyleToggleKey = (typeof STYLE_TOGGLE_KEYS)[number];
+
+type ToggleState = {
+  value: boolean;
+  defaultsActive: boolean;
+};
+
+/** Internal formatting value whose toggle history survives copying and separate cascade passes. */
+type StyleTextFormattingCascade = {
+  formatting: TextFormatting | undefined;
+  toggleStates: ReadonlyMap<StyleToggleKey, ToggleState>;
+  type: "styleToggleCascade";
+};
+
+type StyleToggleLevel =
+  | {
+      formatting: TextFormatting | undefined;
+      type: "defaults" | "style" | "direct";
+    }
+  | {
+      cascade: StyleTextFormattingCascade;
+      type: "carried";
+    };
+
+type StyleToggleCascadeOptions = {
+  /** Existing ordinary-property merge whose toggle fields this cascade replaces. */
+  ordinaryFormatting: TextFormatting | undefined;
+};
+
+/**
+ * Resolve run formatting across OOXML style hierarchy levels.
+ *
+ * Ordinary properties retain Folio's existing low-to-high, last-defined merge. Toggle
+ * properties reverse inherited state when a style level states `true`; `false` leaves inherited
+ * style state unchanged, while direct formatting remains an absolute value. The returned value
+ * carries its toggle history explicitly, so paragraph and character style resolution may happen
+ * in separate passes without an object-identity contract.
+ */
+export function cascadeStyleTextFormatting(
+  levels: readonly StyleToggleLevel[],
+  options?: StyleToggleCascadeOptions,
+): StyleTextFormattingCascade {
+  let formatting = options ? mergeTextFormatting(undefined, options.ordinaryFormatting) : undefined;
+  const mergeOrdinaryFormatting = options === undefined;
+  const toggleStates = new Map<StyleToggleKey, ToggleState>();
+
+  for (const level of levels) {
+    if (level.type === "carried") {
+      if (mergeOrdinaryFormatting) {
+        formatting = mergeTextFormatting(formatting, level.cascade.formatting);
+      }
+      for (const [key, state] of level.cascade.toggleStates) {
+        toggleStates.set(key, state);
+      }
+      continue;
+    }
+    if (!level.formatting) {
+      continue;
+    }
+
+    if (mergeOrdinaryFormatting) {
+      formatting = mergeTextFormatting(formatting, level.formatting);
+    }
+    for (const key of STYLE_TOGGLE_KEYS) {
+      const value = level.formatting[key];
+      if (value === undefined) {
+        continue;
+      }
+
+      const inherited = toggleStates.get(key);
+      if (level.type === "direct") {
+        toggleStates.set(key, { value, defaultsActive: false });
+      } else if (!value) {
+        continue;
+      } else if (level.type === "defaults") {
+        toggleStates.set(key, { value: true, defaultsActive: true });
+      } else {
+        toggleStates.set(key, {
+          value: inherited?.defaultsActive === true ? true : !(inherited?.value ?? false),
+          defaultsActive: inherited?.defaultsActive === true,
+        });
+      }
+    }
+  }
+
+  if (!formatting && toggleStates.size > 0) {
+    formatting = {};
+  }
+  for (const [key, state] of toggleStates) {
+    if (formatting) {
+      formatting[key] = state.value;
+    }
+  }
+  return { formatting, toggleStates, type: "styleToggleCascade" };
+}

--- a/packages/core/src/utils/textFormattingMerge.ts
+++ b/packages/core/src/utils/textFormattingMerge.ts
@@ -1,6 +1,51 @@
 import type { ColorValue, TextFormatting } from "../types/document";
 import { mergeFontFamily } from "./fontFamilyMerge";
 
+// Double strike is deliberately absent: it uses ordinary last-defined inheritance.
+export const STYLE_TOGGLE_KEYS = [
+  "bold",
+  "boldCs",
+  "italic",
+  "italicCs",
+  "allCaps",
+  "emboss",
+  "imprint",
+  "outline",
+  "shadow",
+  "smallCaps",
+  "strike",
+  "hidden",
+] as const satisfies readonly (keyof TextFormatting)[];
+
+/**
+ * Merge the properties exposed by one resolved style definition.
+ *
+ * A false toggle at a child style level does not cancel the inherited state. The
+ * ordinary merge remains unchanged for direct formatting and non-toggle properties.
+ */
+export function mergeStyleTextFormatting(
+  target: TextFormatting | undefined,
+  source: TextFormatting | undefined,
+): TextFormatting | undefined {
+  const result = mergeTextFormatting(target, source);
+  if (!result || !source) {
+    return result;
+  }
+
+  for (const key of STYLE_TOGGLE_KEYS) {
+    if (source[key] !== false) {
+      continue;
+    }
+    const inherited = target?.[key];
+    if (inherited === undefined) {
+      Reflect.deleteProperty(result, key);
+    } else {
+      result[key] = inherited;
+    }
+  }
+  return result;
+}
+
 export function mergeTextFormatting(
   target: TextFormatting | undefined,
   source: TextFormatting | undefined,


### PR DESCRIPTION
## Summary

- apply OOXML toggle semantics across document defaults, paragraph styles, character styles, and direct formatting
- keep ordinary and complex-script formatting independent through layout, JSON/Yjs-style cloning, and serialization
- preserve authored direct toggle values in the existing structural override mark while keeping pure inherited runs free of override metadata
- make format painter resolve paragraph defaults through inline content wrappers

## Validation

- 116 focused style, conversion, layout, and format-painter tests
- 48-cell inherited/character/direct ordinary and complex-script matrix
- 1,000-paragraph payload and clone-safety invariant
- core typecheck and build
- public API snapshot check
- repository lint and format check
- dependency audit
- independent correctness review