### PR TITLE
feat: resolve numbered REF field switches

### DIFF
--- a/.changeset/calm-refs-renumber.md
+++ b/.changeset/calm-refs-renumber.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Resolve numbered REF fields from live bookmark and list state, and refresh safe cached results on save.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -35,6 +35,18 @@ export type BlockSdtAttrs = {
 };
 
 // @public (undocumented)
+export type BookmarkBoundaryAttrs = {
+    type: "start";
+    id: number;
+    name: string;
+    colFirst?: number;
+    colLast?: number;
+} | {
+    type: "end";
+    id: number;
+};
+
+// @public (undocumented)
 export type CharacterSpacingAttrs = {
     spacing?: number;
     position?: number;
@@ -72,6 +84,7 @@ export type FieldAttrs = {
     fieldType: import__stll_docx_core_model.FieldType;
     instruction: string;
     displayText: string;
+    _numberedRefBaseline?: string;
     fieldKind: "simple" | "complex";
     fldLock?: boolean;
     dirty?: boolean;

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -2764,7 +2764,7 @@ describe("headless docx review notes read surface", () => {
       part: "word/footnotes.xml",
       removedParaId: "B2000001",
       idProfile: "without paragraph ids",
-      expectedText: "See INSERTED MOVED TO LINK SDT.TABLE CELL",
+      expectedText: "See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT.TABLE CELL",
       preservedParagraph: '<w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
     },
     {
@@ -2780,7 +2780,7 @@ describe("headless docx review notes read surface", () => {
       part: "word/footnotes.xml",
       removedParaId: null,
       idProfile: "with paragraph ids",
-      expectedText: "See INSERTED MOVED TO LINK SDT.TABLE CELL",
+      expectedText: "See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT.TABLE CELL",
       preservedParagraph: '<w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
     },
     {
@@ -2836,7 +2836,7 @@ describe("headless docx review notes read surface", () => {
       part: "word/footnotes.xml",
       prefix: "altw",
       namespace: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
-      expectedText: "See INSERTED MOVED TO LINK SDT.TABLE CELL",
+      expectedText: "See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT.TABLE CELL",
     },
     {
       story: { type: "endnote", noteId: 3 } as const,

--- a/packages/core/src/docx/numberingParser-custom-format.test.ts
+++ b/packages/core/src/docx/numberingParser-custom-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveListTemplate } from "../layout-bridge/convert/toFlowBlocks";
+import { resolveListTemplate } from "../prosemirror/listMarker";
 import { computeListRendering, formatNumber, parseNumbering } from "./numberingParser";
 
 const W = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
@@ -37,9 +37,19 @@ describe("custom numFmt inside mc:AlternateContent (#765)", () => {
   });
 
   test("renders zero-padded markers through the lvlText template", () => {
-    expect(resolveListTemplate("[%1]", [1], ["decimalZero4"])).toBe("[0001]");
-    expect(resolveListTemplate("[%1]", [12], ["decimalZero4"])).toBe("[0012]");
-    expect(resolveListTemplate("[%1]", [12_345], ["decimalZero4"])).toBe("[12345]");
+    expect(
+      resolveListTemplate({ template: "[%1]", counters: [1], levelFormats: ["decimalZero4"] }),
+    ).toBe("[0001]");
+    expect(
+      resolveListTemplate({ template: "[%1]", counters: [12], levelFormats: ["decimalZero4"] }),
+    ).toBe("[0012]");
+    expect(
+      resolveListTemplate({
+        template: "[%1]",
+        counters: [12_345],
+        levelFormats: ["decimalZero4"],
+      }),
+    ).toBe("[12345]");
   });
 
   test("uses the mc:Fallback when the Choice format is not implemented", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.list-counters.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.list-counters.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import {
+  advanceListMarker,
+  cloneListCounterState,
+  createListCounterState,
+} from "../../prosemirror/listMarker";
 import type { Document, Paragraph } from "../../types/document";
 import { toFlowBlocks } from "./toFlowBlocks";
 
@@ -56,6 +61,17 @@ function markersOf(blocks: ReturnType<typeof toFlowBlocks>): string[] {
 }
 
 describe("toFlowBlocks counter sharing by abstractNumId", () => {
+  test("rejects levels outside the OOXML 0..8 boundary before growing counter state", () => {
+    for (const ilvl of [-1, 9, 1_000_000, Number.POSITIVE_INFINITY]) {
+      const state = createListCounterState();
+
+      expect(advanceListMarker({ numPr: { numId: 1, ilvl }, listMarker: "%1." }, state)).toBeNull();
+      expect(state.counters.size).toBe(0);
+      expect(state.abstractCounters.size).toBe(0);
+      expect(state.seenLevels.size).toBe(0);
+    }
+  });
+
   test("top-level numIds with the same abstractNum keep independent counters", () => {
     const doc = documentWith([
       listParagraph({ numId: 1, abstractNumId: 4, text: "a" }),
@@ -64,6 +80,21 @@ describe("toFlowBlocks counter sharing by abstractNumId", () => {
     ]);
 
     expect(markersOf(toFlowBlocks(toProseDoc(doc), {}))).toEqual(["(1)", "(1)", "(2)"]);
+  });
+
+  test("numId zero templates reuse the most recently advanced interleaved list", () => {
+    const state = createListCounterState();
+
+    expect(advanceListMarker({ numPr: { numId: 1, ilvl: 0 } }, state)).toBe("1.");
+    expect(advanceListMarker({ numPr: { numId: 2, ilvl: 0 } }, state)).toBe("1.");
+    expect(advanceListMarker({ numPr: { numId: 1, ilvl: 0 } }, state)).toBe("2.");
+    const cloned = cloneListCounterState(state);
+    expect(
+      advanceListMarker(
+        { numPr: { numId: 0, ilvl: 0 }, listMarker: "(%1)", listIsBullet: false },
+        cloned,
+      ),
+    ).toBe("(2)");
   });
 
   test("startOverride resets only the concrete numId on first encounter", () => {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -1901,6 +1901,38 @@ describe("toFlowBlocks list numbering", () => {
     });
   });
 
+  test("styles a resolved removed-numbering marker as a tracked deletion", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _propertyChanges: [
+            {
+              type: "paragraphPropertyChange",
+              info: { id: 14, author: "Reviewer", date: "2026-01-03" },
+              previousFormatting: {
+                numPr: { numId: 2, ilvl: 0 },
+                listIsBullet: false,
+                listNumFmt: "decimal",
+              },
+            },
+          ],
+        },
+        [schema.text("Removed list item")],
+      ),
+    ]);
+
+    const block = toFlowBlocks(doc).at(0);
+
+    expect(block?.attrs?.listMarker).toBe("1.");
+    expect(block?.attrs?.listMarkerRevision).toEqual({
+      kind: "del",
+      author: "Reviewer",
+      date: "2026-01-03",
+      revisionId: 14,
+    });
+  });
+
   test("removed-numbering deletion numbers off the original stream", () => {
     // An inserted list item (numId 6) advances the final stream to (1). The
     // next item shares that numId but had its numbering removed; in the

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -9,7 +9,6 @@ import type { Node as PMNode, Mark } from "prosemirror-model";
 
 import { convertBulletToUnicode } from "../../docx/bulletMarkers";
 import { resolveDocumentGridLinePitch } from "../../docx/documentGrid";
-import { formatOoxmlCounter } from "../../docx/ooxmlCounterFormatter";
 import type {
   FlowBlock,
   ParagraphBlock,
@@ -80,13 +79,15 @@ import type {
   ParagraphAttrs as PMParagraphAttrs,
 } from "../../prosemirror/schema/nodes";
 import { assertValidProseMirrorDocument } from "../../prosemirror/validation";
-import type {
-  ColorValue,
-  Theme,
-  SectionProperties,
-  NumberFormat,
-  TextFormatting,
-} from "../../types/document";
+import {
+  advanceListMarker,
+  advanceVisibleListMarker,
+  cloneListCounterState,
+  type ListCounterState,
+  type ListCounterStreams,
+} from "../../prosemirror/listMarker";
+import { resolveNumberedRefFields } from "../../prosemirror/numberedRefFields";
+import type { ColorValue, Theme, SectionProperties, TextFormatting } from "../../types/document";
 import { resolveColor, resolveHighlightToCss } from "../../utils/colorResolver";
 import { resolveThemeFont } from "../../utils/fontResolver";
 import { resolveShadingFill } from "../../utils/formatToStyle";
@@ -99,6 +100,8 @@ import {
   halfPointsToPoints,
 } from "../../utils/units";
 import { groupParagraphFrames } from "./paragraphFrames";
+
+export { formatCounter, resolveListTemplate } from "../../prosemirror/listMarker";
 
 /**
  * Options for the conversion.
@@ -150,6 +153,11 @@ export type ToFlowBlocksOptions = {
   automaticHyphenation?: NonNullable<ParagraphAttrs["automaticHyphenation"]>;
   /** Line pitch for the final body section, whose properties live outside the PM body. */
   finalSectionDocumentGridLinePitchTwips?: number;
+};
+
+type FlowConversionOptions = ToFlowBlocksOptions & {
+  listCounterStreams: ListCounterStreams;
+  numberedRefResults?: ReadonlyMap<PMNode, string>;
 };
 
 const DEFAULT_FONT = "Calibri";
@@ -208,57 +216,6 @@ function nextBlockId(): string {
   return `block-${++blockIdCounter}`;
 }
 
-function formatNumberedMarker(counters: number[], level: number): string {
-  const parts: number[] = [];
-  for (let i = 0; i <= level; i += 1) {
-    const value = counters[i] ?? 0;
-    if (!Number.isFinite(value) || value <= 0) {
-      break;
-    }
-    parts.push(value);
-  }
-  if (parts.length === 0) {
-    return "1.";
-  }
-  return `${parts.join(".")}.`;
-}
-
-export function formatCounter(value: number, format: NumberFormat | undefined): string {
-  return formatOoxmlCounter(value, format);
-}
-
-export function resolveListTemplate(
-  template: string,
-  counters: number[],
-  levelFormats: NumberFormat[] | undefined,
-  forceDecimal = false,
-): string {
-  return template.replace(/%(?<digit>\d)(?<punct>[.):\]])?/gu, (...args) => {
-    const { digit, punct = "" } = args.at(-1) as {
-      digit: string;
-      punct?: string;
-    };
-    const index = Number.parseInt(digit, 10) - 1;
-    if (index < 0) {
-      return "";
-    }
-    const counter = counters[index];
-    if (counter === undefined || Number.isNaN(counter)) {
-      return "";
-    }
-    const formatted = formatCounter(counter, forceDecimal ? "decimal" : levelFormats?.[index]);
-    return formatted ? `${formatted}${punct}` : "";
-  });
-}
-
-function getLastListCounters(listCounters: Map<number, number[]>): number[] | undefined {
-  let lastCounters: number[] | undefined;
-  for (const counters of listCounters.values()) {
-    lastCounters = counters;
-  }
-  return lastCounters;
-}
-
 function applyMarkerAllCaps(marker: string | null, allCaps: boolean | undefined): string | null {
   if (marker === null || !allCaps) {
     return marker;
@@ -266,102 +223,8 @@ function applyMarkerAllCaps(marker: string | null, allCaps: boolean | undefined)
   return marker.toLocaleUpperCase();
 }
 
-function computeListMarker(
-  pmAttrs: PMParagraphAttrs,
-  listCounters: Map<number, number[]>,
-  abstractCounters: Map<number, number[]>,
-  seenNumIds: Set<string>,
-): string | null {
-  const numId = pmAttrs.numPr?.numId;
-  if (numId === undefined || numId === 0) {
-    if (pmAttrs.listMarker?.includes("%") && !pmAttrs.listIsBullet) {
-      const counters = getLastListCounters(listCounters);
-      if (counters) {
-        return resolveListTemplate(
-          pmAttrs.listMarker,
-          counters,
-          pmAttrs.listLevelNumFmts,
-          pmAttrs.listIsLegal,
-        );
-      }
-    }
-    return null;
-  }
-
-  if (pmAttrs.listIsBullet) {
-    return convertBulletToUnicode(pmAttrs.listMarker || "");
-  }
-
-  const level = pmAttrs.numPr?.ilvl ?? 0;
-  const counters =
-    listCounters.get(numId) ?? (Array.from({ length: 9 }, () => Number.NaN) as number[]);
-  const abstractNumId = pmAttrs.listAbstractNumId;
-  if (level > 0) {
-    const latestAbstractCounters =
-      abstractNumId === undefined ? undefined : abstractCounters.get(abstractNumId);
-    if (counters.slice(0, level).every((counter) => !Number.isFinite(counter))) {
-      for (let i = 0; i < level; i += 1) {
-        const latestCounter = latestAbstractCounters?.[i];
-        counters[i] =
-          latestCounter !== undefined && Number.isFinite(latestCounter)
-            ? latestCounter
-            : (pmAttrs.listLevelStarts?.[i] ?? 1);
-      }
-    }
-  }
-
-  const seenKey = `${numId}:${level}`;
-  if (!seenNumIds.has(seenKey)) {
-    seenNumIds.add(seenKey);
-    if (pmAttrs.listStartOverride != null) {
-      counters[level] = pmAttrs.listStartOverride - 1;
-    }
-  }
-  // Returning to a parent level clears every deeper counter. A later child at
-  // a level seen earlier must therefore restart from its authored start; the
-  // lifetime `seenNumIds` set cannot stand in for live counter state.
-  if (!Number.isFinite(counters[level])) {
-    counters[level] = (pmAttrs.listLevelStarts?.[level] ?? 1) - 1;
-  }
-
-  counters[level] = (counters[level] ?? 0) + 1;
-  for (let i = level + 1; i < counters.length; i += 1) {
-    counters[i] = Number.NaN;
-  }
-  // Word's default LISTNUM field advances the counter at one ilvl deeper
-  // than the host paragraph. Carrying the consumed advances forward here
-  // means a later sibling at that depth (e.g. an OutNum3 "(b)" following an
-  // OutNum2 "(a)") picks up the next letter instead of restarting at "(a)".
-  const childAdvances = pmAttrs.listImplicitChildLevelAdvances ?? 0;
-  if (childAdvances > 0 && level + 1 < counters.length) {
-    const childCounter = counters[level + 1];
-    counters[level + 1] =
-      (childCounter === undefined || !Number.isFinite(childCounter) ? 0 : childCounter) +
-      childAdvances;
-  }
-  listCounters.set(numId, counters);
-  if (abstractNumId !== undefined) {
-    abstractCounters.set(abstractNumId, [...counters]);
-  }
-
-  const levelFormats =
-    pmAttrs.listLevelNumFmts ?? (pmAttrs.listNumFmt ? [pmAttrs.listNumFmt] : undefined);
-  if (pmAttrs.listMarker && pmAttrs.listMarker.includes("%")) {
-    return resolveListTemplate(pmAttrs.listMarker, counters, levelFormats, pmAttrs.listIsLegal);
-  }
-  if (pmAttrs.listMarker) {
-    return pmAttrs.listMarker;
-  }
-  // OOXML allows a list level to set lvlText="" with numFmt="none" to attach
-  // numbering metadata (counters, indents) without painting a marker — Word
-  // glossary/definition styles use this. An empty listMarker means the level
-  // explicitly opts out; synthesising a decimal counter here would forge a
-  // marker the source never authored.
-  const levelFormat = levelFormats?.[level] ?? pmAttrs.listNumFmt;
-  if (levelFormat === "none" || pmAttrs.listMarker === "") {
-    return null;
-  }
-  return formatNumberedMarker(counters, level);
+function computeListMarker(pmAttrs: PMParagraphAttrs, state: ListCounterState): string | null {
+  return advanceListMarker(pmAttrs, state);
 }
 
 /**
@@ -1092,7 +955,7 @@ function stripTocHyperlinkStyle(formatting: RunFormatting): void {
 /**
  * Convert a paragraph node to runs.
  */
-function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksOptions): Run[] {
+function paragraphToRuns(node: PMNode, startPos: number, _options: FlowConversionOptions): Run[] {
   const runs: Run[] = [];
   const offset = startPos + 1; // +1 for opening tag
   const theme = _options.theme;
@@ -1111,6 +974,9 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
   // tab/image and silently dropped fields, math, and nested SDTs even
   // when the parser preserved them (see eigenpal #482).
   function pushRunsForChild(child: PMNode, childPos: number): void {
+    if (child.type.name === "bookmarkBoundary") {
+      return;
+    }
     if (child.type.name === "renderedPageBreak") {
       if (leadingRenderedPageBreakPending) {
         leadingRenderedPageBreakPending = false;
@@ -1211,7 +1077,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
       runs.push(run);
       return;
     }
-    if (child.type.name === "field") {
+    if (child.type.name === "field" || child.type.name === "structuredField") {
       // Marks on the field node (bold/italic/underline applied to the
       // field result inside `<w:fldChar separate>...</w:fldChar end>`)
       // must propagate to the run formatting, otherwise complex REF
@@ -1248,7 +1114,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
         kind: "field",
         fieldType: mappedType,
         instruction: attrs.instruction,
-        fallback: attrs.displayText || "",
+        fallback: _options.numberedRefResults?.get(child) ?? attrs.displayText ?? "",
         ...(attrs.fldLock ? { fldLock: true } : {}),
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
@@ -1434,21 +1300,14 @@ function toPreviousListAttrs(previousFormatting: ListPropertyFormatting): PMPara
 
 function resolveDeletedListMarker(
   previousListAttrs: PMParagraphAttrs,
-  listCounters: Map<number, number[]> | undefined,
-  listAbstractCounters: Map<number, number[]> | undefined,
-  listSeenNumIds: Set<string> | undefined,
+  listCounterState: ListCounterState | undefined,
 ): string | null {
-  if (listCounters && previousListAttrs.numPr) {
+  if (listCounterState && previousListAttrs.numPr) {
     // Advance the original counter stream in place (no clone): a
     // removed-numbering deletion occupied a number in the pre-revision
     // document, so it must progress the counter exactly like a deleted list
     // item — otherwise a following deletion on the same numId reuses it.
-    const marker = computeListMarker(
-      previousListAttrs,
-      listCounters,
-      listAbstractCounters ?? new Map<number, number[]>(),
-      listSeenNumIds ?? new Set<string>(),
-    );
+    const marker = computeListMarker(previousListAttrs, listCounterState);
     if (marker) {
       return marker;
     }
@@ -1470,18 +1329,11 @@ function resolveDeletedListMarker(
 function applyDeletedListMarkerAttrs(
   attrs: ParagraphAttrs,
   change: ListPropertyChange & { previousFormatting: ListPropertyFormatting },
-  listCounters: Map<number, number[]> | undefined,
-  listAbstractCounters: Map<number, number[]> | undefined,
-  listSeenNumIds: Set<string> | undefined,
+  listCounterState: ListCounterState | undefined,
   theme: Theme | null | undefined,
 ): void {
   const previousListAttrs = toPreviousListAttrs(change.previousFormatting);
-  const marker = resolveDeletedListMarker(
-    previousListAttrs,
-    listCounters,
-    listAbstractCounters,
-    listSeenNumIds,
-  );
+  const marker = resolveDeletedListMarker(previousListAttrs, listCounterState);
   if (!marker) {
     return;
   }
@@ -1508,16 +1360,15 @@ function applyDeletedListMarkerAttrs(
   }
 }
 
+type ConvertParagraphAttrsOptions = {
+  theme: Theme | null | undefined;
+  listCounterStreams: ListCounterStreams;
+  defaultTabStopTwips: number | undefined;
+};
+
 function convertParagraphAttrs(
   pmAttrs: PMParagraphAttrs,
-  theme?: Theme | null,
-  listCounters?: Map<number, number[]>,
-  listAbstractCounters?: Map<number, number[]>,
-  listSeenNumIds?: Set<string>,
-  defaultTabStopTwips?: number,
-  originalListCounters?: Map<number, number[]>,
-  originalListAbstractCounters?: Map<number, number[]>,
-  originalListSeenNumIds?: Set<string>,
+  { theme, listCounterStreams, defaultTabStopTwips }: ConvertParagraphAttrsOptions,
 ): ParagraphAttrs {
   const attrs: ParagraphAttrs = {};
 
@@ -1827,58 +1678,8 @@ function convertParagraphAttrs(
       }
     }
   }
-  // Tracked-deletion list items number off a separate "original" stream so the
-  // inserted list (a, b) and the deleted list (a, b, c) restart independently
-  // instead of running one shared counter (a, b, c, d, e). Insertions and normal
-  // items use the final stream; normal items also advance the original stream so
-  // a later deleted sibling continues from the surviving count (Word parity).
-  const useOriginalStream =
-    attrs.listMarkerRevision?.kind === "del" && originalListCounters !== undefined;
-  const streamCounters = useOriginalStream ? originalListCounters : listCounters;
-  const streamAbstractCounters = useOriginalStream
-    ? originalListAbstractCounters
-    : listAbstractCounters;
-  const streamSeenNumIds = useOriginalStream ? originalListSeenNumIds : listSeenNumIds;
-  const resolvedMarker = applyMarkerAllCaps(
-    streamCounters
-      ? computeListMarker(
-          pmAttrs,
-          streamCounters,
-          streamAbstractCounters ?? new Map(),
-          streamSeenNumIds ?? new Set(),
-        )
-      : null,
-    pmAttrs.listMarkerAllCaps,
-  );
-  const numberedNumId = pmAttrs.numPr?.numId;
-  if (
-    attrs.listMarkerRevision === undefined &&
-    !pmAttrs.listIsBullet &&
-    originalListCounters !== undefined &&
-    numberedNumId !== undefined &&
-    numberedNumId !== 0
-  ) {
-    computeListMarker(
-      pmAttrs,
-      originalListCounters,
-      originalListAbstractCounters ?? new Map(),
-      originalListSeenNumIds ?? new Set(),
-    );
-  } else if (changedNumberingChange !== undefined && originalListCounters !== undefined) {
-    // Changed numbering is shown as an insertion of the new numId, but in the
-    // pre-revision document the paragraph sat under its PREVIOUS numId. Advance
-    // that original stream so a later deletion on the old numId continues from
-    // the right count instead of reusing this item's number.
-    const previousListAttrs = toPreviousListAttrs(changedNumberingChange.previousFormatting);
-    if (previousListAttrs.numPr && !previousListAttrs.listIsBullet) {
-      computeListMarker(
-        previousListAttrs,
-        originalListCounters,
-        originalListAbstractCounters ?? new Map(),
-        originalListSeenNumIds ?? new Set(),
-      );
-    }
-  }
+  const visibleMarker = advanceVisibleListMarker(pmAttrs, listCounterStreams);
+  const resolvedMarker = applyMarkerAllCaps(visibleMarker.marker, pmAttrs.listMarkerAllCaps);
   if (resolvedMarker !== null) {
     attrs.listMarker = resolvedMarker;
   } else if (pmAttrs.listMarker) {
@@ -1910,14 +1711,11 @@ function convertParagraphAttrs(
       // Number removed-numbering deletions off the original stream too (like
       // deleted list items): the struck-through marker must reflect the
       // pre-revision number, not the final counter that insertions advanced.
-      applyDeletedListMarkerAttrs(
-        attrs,
-        numberingRemovedChange,
-        originalListCounters,
-        originalListAbstractCounters,
-        originalListSeenNumIds,
-        theme,
-      );
+      applyDeletedListMarkerAttrs(attrs, numberingRemovedChange, undefined, theme);
+      if (resolvedMarker !== null) {
+        attrs.listMarker = resolvedMarker;
+        attrs.listMarkerRevision = toListMarkerRevision("del", numberingRemovedChange.info);
+      }
     }
   }
   if (defaultTabStopTwips !== undefined) {
@@ -1990,21 +1788,15 @@ function hasOnlyVisuallyEmptyTextRuns(runs: Run[]): boolean {
 function convertParagraph(
   node: PMNode,
   startPos: number,
-  options: ToFlowBlocksOptions,
+  options: FlowConversionOptions,
 ): ParagraphBlock {
   const pmAttrs = expectParagraphAttrs(node);
   const runs = paragraphToRuns(node, startPos, options);
-  const attrs = convertParagraphAttrs(
-    pmAttrs,
-    options.theme,
-    options.listCounters,
-    options.listAbstractCounters,
-    options.listSeenNumIds,
-    options.defaultTabStopTwips,
-    options.originalListCounters,
-    options.originalListAbstractCounters,
-    options.originalListSeenNumIds,
-  );
+  const attrs = convertParagraphAttrs(pmAttrs, {
+    theme: options.theme,
+    listCounterStreams: options.listCounterStreams,
+    defaultTabStopTwips: options.defaultTabStopTwips,
+  });
   if (options.lineBreakRules) {
     attrs.lineBreakRules = options.lineBreakRules;
   }
@@ -2292,7 +2084,7 @@ function extractCellBorders(
 function convertTableCell(
   node: PMNode,
   startPos: number,
-  options: ToFlowBlocksOptions,
+  options: FlowConversionOptions,
   tableCellMargins?: {
     top?: number;
     bottom?: number;
@@ -2397,7 +2189,7 @@ function convertTableCell(
 function convertTableRow(
   node: PMNode,
   startPos: number,
-  options: ToFlowBlocksOptions,
+  options: FlowConversionOptions,
   tableCellMargins?: {
     top?: number;
     bottom?: number;
@@ -2448,7 +2240,7 @@ function convertTableRow(
 /**
  * Convert a table node to a TableBlock.
  */
-function convertTable(node: PMNode, startPos: number, options: ToFlowBlocksOptions): TableBlock {
+function convertTable(node: PMNode, startPos: number, options: FlowConversionOptions): TableBlock {
   const rows: TableRow[] = [];
   let offset = startPos + 1; // +1 for opening tag
   const attrs = expectTableAttrs(node);
@@ -2669,7 +2461,7 @@ function convertImage(node: PMNode, startPos: number, pageContentHeight?: number
 function convertTextBoxNode(
   node: PMNode,
   startPos: number,
-  opts: ToFlowBlocksOptions,
+  opts: FlowConversionOptions,
 ): TextBoxBlock {
   const attrs = expectTextBoxAttrs(node);
   const contentBlocks: (ParagraphBlock | TableBlock)[] = [];
@@ -2757,6 +2549,14 @@ function convertTextBoxNode(
   return textBox;
 }
 
+function getLastMapKey<K, V>(map: ReadonlyMap<K, V>): K | undefined {
+  let lastKey: K | undefined;
+  for (const key of map.keys()) {
+    lastKey = key;
+  }
+  return lastKey;
+}
+
 /**
  * Convert a ProseMirror document to FlowBlock array.
  *
@@ -2768,17 +2568,43 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
 
   resetBlockIdCounter();
 
-  const opts: ToFlowBlocksOptions = {
+  const listCounters = options.listCounters ?? new Map<number, number[]>();
+  const originalListCounters = options.originalListCounters ?? new Map<number, number[]>();
+  const lastAdvancedNumId = getLastMapKey(listCounters);
+  const lastAdvancedOriginalNumId = getLastMapKey(originalListCounters);
+  const listCounterState: ListCounterState = {
+    counters: listCounters,
+    abstractCounters: options.listAbstractCounters ?? new Map<number, number[]>(),
+    seenLevels: options.listSeenNumIds ?? new Set<string>(),
+    ...(lastAdvancedNumId !== undefined ? { lastAdvancedNumId } : {}),
+  };
+  const originalListCounterState: ListCounterState = {
+    counters: originalListCounters,
+    abstractCounters: options.originalListAbstractCounters ?? new Map<number, number[]>(),
+    seenLevels: options.originalListSeenNumIds ?? new Set<string>(),
+    ...(lastAdvancedOriginalNumId !== undefined
+      ? { lastAdvancedNumId: lastAdvancedOriginalNumId }
+      : {}),
+  };
+
+  const opts: FlowConversionOptions = {
     ...options,
     defaultFont: options.defaultFont ?? DEFAULT_FONT,
     defaultSize: options.defaultSize ?? DEFAULT_SIZE,
-    listCounters: options.listCounters ?? new Map<number, number[]>(),
-    listAbstractCounters: options.listAbstractCounters ?? new Map<number, number[]>(),
-    listSeenNumIds: options.listSeenNumIds ?? new Set<string>(),
-    originalListCounters: options.originalListCounters ?? new Map<number, number[]>(),
-    originalListAbstractCounters:
-      options.originalListAbstractCounters ?? new Map<number, number[]>(),
-    originalListSeenNumIds: options.originalListSeenNumIds ?? new Set<string>(),
+    listCounters: listCounterState.counters,
+    listAbstractCounters: listCounterState.abstractCounters,
+    listSeenNumIds: listCounterState.seenLevels,
+    originalListCounters: originalListCounterState.counters,
+    originalListAbstractCounters: originalListCounterState.abstractCounters,
+    originalListSeenNumIds: originalListCounterState.seenLevels,
+    listCounterStreams: {
+      final: listCounterState,
+      original: originalListCounterState,
+    },
+    numberedRefResults: resolveNumberedRefFields(doc, {
+      listCounterState: cloneListCounterState(listCounterState),
+      originalListCounterState: cloneListCounterState(originalListCounterState),
+    }),
   };
 
   const blocks: FlowBlock[] = [];

--- a/packages/core/src/markdown/renderParagraph.ts
+++ b/packages/core/src/markdown/renderParagraph.ts
@@ -6,7 +6,7 @@
  * PR #595.
  */
 
-import { resolveListTemplate } from "../layout-bridge/convert/toFlowBlocks";
+import { resolveListTemplate } from "../prosemirror/listMarker";
 import type { DocxPackage, ListRendering, Paragraph } from "../types/document";
 import { isHeadingStyle, parseHeadingLevel } from "./headings";
 import { renderParagraphInline } from "./renderRuns";
@@ -105,5 +105,10 @@ function resolveTemplateMarker(ctx: RenderContext, list: ListRendering): string 
   }
   ctx.listCounters.set(list.numId, counters);
   const levelFormats = list.levelNumFmts ?? (list.numFmt ? [list.numFmt] : undefined);
-  return resolveListTemplate(list.marker, counters, levelFormats, list.isLegal).trim();
+  return resolveListTemplate({
+    template: list.marker,
+    counters,
+    levelFormats,
+    forceDecimal: list.isLegal,
+  }).trim();
 }

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -653,11 +653,12 @@ export const expectImageAttrs = (node: PMNode): ImageAttrs =>
 export const readFieldAttrs = (node: PMNode): ReadProseMirrorAttrsResult<FieldAttrs> => {
   const attrs = attrsRecord(node.attrs);
   const issues: ProseMirrorAttrIssue[] = [];
-  expectNodeType(node, "field", issues);
+  expectNodeTypeOneOf(node, ["field", "structuredField"], issues);
 
   requiredOneOf(attrs, "fieldType", "field.attrs.fieldType", issues, FIELD_TYPE_VALUES);
   requiredString(attrs, "instruction", "field.attrs.instruction", issues);
   requiredString(attrs, "displayText", "field.attrs.displayText", issues);
+  optionalString(attrs, "_numberedRefBaseline", "field.attrs._numberedRefBaseline", issues);
   requiredOneOf(attrs, "fieldKind", "field.attrs.fieldKind", issues, FIELD_KINDS);
   optionalBoolean(attrs, "fldLock", "field.attrs.fldLock", issues);
   optionalBoolean(attrs, "dirty", "field.attrs.dirty", issues);

--- a/packages/core/src/prosemirror/bookmarkBoundaryAttrs.ts
+++ b/packages/core/src/prosemirror/bookmarkBoundaryAttrs.ts
@@ -1,0 +1,93 @@
+import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type { ProseMirrorAttrIssue, ReadProseMirrorAttrsResult } from "./attrs";
+import type { BookmarkBoundaryAttrs } from "./schema/nodes";
+
+const attrsCache = new WeakMap<PMNode, BookmarkBoundaryAttrs>();
+
+export const readBookmarkBoundaryAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<BookmarkBoundaryAttrs> => {
+  const issues: ProseMirrorAttrIssue[] = [];
+  if (node.type.name !== "bookmarkBoundary") {
+    issues.push({
+      path: "bookmarkBoundary.type.name",
+      message: `Expected bookmarkBoundary, got ${node.type.name}.`,
+    });
+  }
+  const type = node.attrs["type"];
+  if (type !== "start" && type !== "end") {
+    issues.push({
+      path: "bookmarkBoundary.attrs.type",
+      message: 'Expected "start" or "end".',
+    });
+  }
+  const id = node.attrs["id"];
+  if (typeof id !== "number" || !Number.isInteger(id) || id < 0) {
+    issues.push({
+      path: "bookmarkBoundary.attrs.id",
+      message: "Expected a non-negative integer.",
+    });
+  }
+  const name = node.attrs["name"];
+  if (type === "start" && (typeof name !== "string" || name.length === 0)) {
+    issues.push({
+      path: "bookmarkBoundary.attrs.name",
+      message: "Expected a non-empty string for a bookmark start.",
+    });
+  }
+  const colFirst = node.attrs["colFirst"];
+  if (
+    colFirst !== undefined &&
+    colFirst !== null &&
+    (typeof colFirst !== "number" || !Number.isInteger(colFirst) || colFirst < 0)
+  ) {
+    issues.push({
+      path: "bookmarkBoundary.attrs.colFirst",
+      message: "Expected a non-negative integer.",
+    });
+  }
+  const colLast = node.attrs["colLast"];
+  if (
+    colLast !== undefined &&
+    colLast !== null &&
+    (typeof colLast !== "number" || !Number.isInteger(colLast) || colLast < 0)
+  ) {
+    issues.push({
+      path: "bookmarkBoundary.attrs.colLast",
+      message: "Expected a non-negative integer.",
+    });
+  }
+
+  if (issues.length > 0 || typeof id !== "number") {
+    return { ok: false, issues };
+  }
+  if (type === "start" && typeof name === "string") {
+    return {
+      ok: true,
+      value: {
+        type,
+        id,
+        name,
+        ...(typeof colFirst === "number" ? { colFirst } : {}),
+        ...(typeof colLast === "number" ? { colLast } : {}),
+      },
+    };
+  }
+  return { ok: true, value: { type: "end", id } };
+};
+
+export const expectBookmarkBoundaryAttrs = (node: PMNode): BookmarkBoundaryAttrs => {
+  const cached = attrsCache.get(node);
+  if (cached) {
+    return cached;
+  }
+  const result = readBookmarkBoundaryAttrs(node);
+  if (!result.ok) {
+    const details = result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("\n");
+    panic(`Invalid ProseMirror bookmark boundary attrs:\n${details}`);
+  }
+  attrsCache.set(node, result.value);
+  return result.value;
+};

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -19,6 +19,320 @@ import { fromProseDoc, proseDocToBlocks } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
 describe("fromProseDoc", () => {
+  test("round-trips naked bookmark boundaries through a JSON-cloned editor model", () => {
+    const paragraph = {
+      type: "paragraph",
+      formatting: { spaceAfter: 160 },
+      content: [
+        { type: "bookmarkStart", id: 17, name: "clause", colFirst: 2, colLast: 4 },
+        { type: "run", content: [{ type: "text", text: "Clause" }] },
+        { type: "bookmarkEnd", id: 17 },
+      ],
+    } as const satisfies Paragraph;
+    const document: Document = {
+      package: { document: { content: [paragraph] } },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const cloned = pmDoc.type.schema.nodeFromJSON(pmDoc.toJSON());
+    const roundTripped = fromProseDoc(cloned);
+
+    expect(roundTripped.package.document.content).toEqual([paragraph]);
+  });
+
+  test.each([
+    {
+      name: "starts outside and ends inside a hyperlink",
+      content: [
+        { type: "bookmarkStart", id: 18, name: "crossing-link", colFirst: 1, colLast: 3 },
+        {
+          type: "hyperlink",
+          href: "https://example.com/terms",
+          rId: "rId18",
+          tooltip: "Terms",
+          children: [
+            { type: "run", content: [{ type: "text", text: "Terms" }] },
+            { type: "bookmarkEnd", id: 18 },
+          ],
+        },
+      ],
+    },
+    {
+      name: "starts inside and ends outside a hyperlink",
+      content: [
+        {
+          type: "hyperlink",
+          href: "https://example.com/terms",
+          rId: "rId19",
+          tooltip: "Terms",
+          children: [
+            { type: "bookmarkStart", id: 19, name: "crossing-link" },
+            { type: "run", content: [{ type: "text", text: "Terms" }] },
+          ],
+        },
+        { type: "bookmarkEnd", id: 19 },
+      ],
+    },
+  ] as const)("round-trips a bookmark that $name", ({ content }) => {
+    const paragraph = {
+      type: "paragraph",
+      formatting: { spaceAfter: 160 },
+      content,
+    } as const satisfies Paragraph;
+    const document: Document = {
+      package: { document: { content: [paragraph] } },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const cloned = pmDoc.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(pmDoc.toJSON())));
+    const roundTripped = fromProseDoc(cloned);
+
+    expect(roundTripped.package.document.content).toEqual([paragraph]);
+  });
+
+  test.each([
+    {
+      name: "ends in a simple-field hyperlink",
+      content: [
+        { type: "bookmarkStart", id: 20, name: "field-link" },
+        {
+          type: "simpleField",
+          instruction: " REF field-link \\h ",
+          fieldType: "REF",
+          content: [
+            {
+              type: "hyperlink",
+              href: "https://example.com/field",
+              rId: "rId20",
+              children: [
+                { type: "run", content: [{ type: "text", text: "Field value" }] },
+                { type: "bookmarkEnd", id: 20 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "starts and ends in a simple-field hyperlink",
+      content: [
+        {
+          type: "simpleField",
+          instruction: " REF field-link \\h ",
+          fieldType: "REF",
+          content: [
+            {
+              type: "hyperlink",
+              anchor: "field-link",
+              tooltip: "Field target",
+              children: [
+                { type: "bookmarkStart", id: 21, name: "field-link" },
+                { type: "run", content: [{ type: "text", text: "Field value" }] },
+                { type: "bookmarkEnd", id: 21 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ] as const)("round-trips a bookmark that $name", ({ content }) => {
+    const paragraph = {
+      type: "paragraph",
+      formatting: { spaceAfter: 160 },
+      content,
+    } as const satisfies Paragraph;
+    const document: Document = {
+      package: { document: { content: [paragraph] } },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const field =
+      content.at(0)?.type === "simpleField"
+        ? pmDoc.firstChild?.firstChild
+        : pmDoc.firstChild?.lastChild;
+    expect(field?.type.name).toBe("structuredField");
+    expect(field?.childCount).toBeGreaterThan(0);
+    expect(field?.attrs["_docxSimpleFieldContent"]).toBeUndefined();
+    const cloned = pmDoc.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(pmDoc.toJSON())));
+    const roundTripped = fromProseDoc(cloned);
+
+    expect(roundTripped.package.document.content).toEqual([paragraph]);
+  });
+
+  test("round-trips a complex field result without structural payload", () => {
+    const paragraph = {
+      type: "paragraph",
+      formatting: { spaceAfter: 160 },
+      content: [
+        {
+          type: "complexField",
+          instruction: " PAGE ",
+          fieldType: "PAGE",
+          fieldCode: [],
+          fieldResult: [{ type: "run", content: [{ type: "text", text: "7" }] }],
+        },
+      ],
+    } as const satisfies Paragraph;
+    const document: Document = {
+      package: { document: { content: [paragraph] } },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const field = pmDoc.firstChild?.firstChild;
+    expect(field?.type.name).toBe("field");
+    expect(field?.childCount).toBe(0);
+    const cloned = pmDoc.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(pmDoc.toJSON())));
+
+    expect(fromProseDoc(cloned).package.document.content).toEqual([paragraph]);
+  });
+
+  test("uses a leaf field when an empty hyperlink leaves no converted link content", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "simpleField",
+                  instruction: " REF target ",
+                  fieldType: "REF",
+                  content: [
+                    { type: "run", content: [{ type: "text", text: "Target" }] },
+                    { type: "hyperlink", href: "https://example.test", children: [] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const field = toProseDoc(document).firstChild?.firstChild;
+
+    expect(field?.type.name).toBe("field");
+    expect(field?.childCount).toBe(0);
+    expect(field?.textContent).toBe("Target");
+  });
+
+  test("does not classify a bookmark end that precedes its start as an inline pair", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "bookmarkEnd", id: 29 },
+                { type: "run", content: [{ type: "text", text: "Target" }] },
+                { type: "bookmarkStart", id: 29, name: "reversed" },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const paragraph = toProseDoc(document).firstChild;
+
+    expect(paragraph?.childCount).toBe(1);
+    expect(paragraph?.firstChild?.type.name).toBe("text");
+    expect(paragraph ? expectParagraphAttrs(paragraph).bookmarks : undefined).toEqual([
+      { id: 29, name: "reversed" },
+    ]);
+  });
+
+  test("round-trips a text-box anchor inside a structured field hyperlink", () => {
+    const hyperlink = schema.mark("hyperlink", {
+      href: "https://example.test/box",
+      _docxHyperlinkIndex: 1,
+    });
+    const structuredField = schema.node(
+      "structuredField",
+      {
+        fieldType: "REF",
+        instruction: " REF box-link \\h ",
+        displayText: "Box",
+        fieldKind: "simple",
+      },
+      [
+        schema.text("Box", [hyperlink]),
+        schema.node("textBoxAnchor", { anchorId: "field-box" }, null, [hyperlink]),
+      ],
+    );
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [structuredField]),
+      schema.node("textBox", { _docxPlacement: "inlineWithPrevious", _docxAnchorId: "field-box" }, [
+        schema.node("paragraph", null, [schema.text("Inside")]),
+      ]),
+    ]);
+    const cloned = pmDoc.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(pmDoc.toJSON())));
+    const roundTripped = fromProseDoc(cloned);
+    const paragraph = roundTripped.package.document.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+    const field = paragraph.content.at(0);
+    if (field?.type !== "simpleField") {
+      throw new Error("Expected simple field");
+    }
+    expect(field.content.every((content) => content.type === "hyperlink")).toBe(true);
+    expect(inlineContentOrder(field.content)).toEqual(["Box", "textBox"]);
+  });
+
+  test.each([
+    {
+      name: "ordinary-field child",
+      nodeType: "field",
+      fieldKind: "simple",
+      message: "Ordinary fields cannot contain structured result children.",
+    },
+    {
+      name: "plain structured simple-field child",
+      nodeType: "structuredField",
+      fieldKind: "simple",
+      message: "Structured simple fields require hyperlink content.",
+    },
+    {
+      name: "structured complex-field child",
+      nodeType: "structuredField",
+      fieldKind: "complex",
+      message: "Complex fields cannot contain structured result children.",
+    },
+  ] as const)(
+    "fails closed before saving a JSON-cloned $name",
+    ({ nodeType, fieldKind, message }) => {
+      const field = schema.nodes[nodeType]?.create(
+        {
+          fieldType: "REF",
+          instruction: " REF target ",
+          displayText: "Target",
+          fieldKind,
+        },
+        schema.text("Target"),
+      );
+      if (!field) {
+        throw new Error(`Missing ${nodeType} schema node`);
+      }
+      const pmDoc = schema.node("doc", null, [schema.node("paragraph", null, [field])]);
+      const cloned = pmDoc.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(pmDoc.toJSON())));
+
+      expect(() => fromProseDoc(cloned)).toThrow(message);
+    },
+  );
+
+  test("fails closed before serializing an unpaired bookmark boundary", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("bookmarkBoundary", { type: "start", id: 99, name: "unpaired" }),
+      ]),
+    ]);
+
+    expect(() => fromProseDoc(pmDoc)).toThrow("Bookmark id 99 has no matching end boundary.");
+  });
+
   test("round-trips table row structural revision markers through the editor model", () => {
     const document: Document = {
       package: {
@@ -1138,6 +1452,68 @@ describe("fromProseDoc", () => {
     expect(run.content.at(0)?.type).toBe("drawing");
   });
 
+  test.each(["insertion", "deletion", "moveFrom", "moveTo"] as const)(
+    "preserves a bookmarked hyperlink as one %s wrapper",
+    (type) => {
+      const info = {
+        id: 91,
+        author: "Reviewer",
+        date: "2026-08-29T10:15:00Z",
+        initials: "RV",
+      } satisfies TrackedChangeInfo;
+      const hyperlink = {
+        type: "hyperlink",
+        href: "https://example.com/terms",
+        rId: "rId91",
+        tooltip: "Defined term",
+        children: [
+          {
+            type: "bookmarkStart",
+            id: 91,
+            name: "defined-term",
+            colFirst: 2,
+            colLast: 4,
+          },
+          { type: "run", content: [{ type: "text", text: "Agreement" }] },
+          { type: "bookmarkEnd", id: 91 },
+        ],
+      } satisfies TrackedRunChange["content"][number];
+      const trackedChange = trackedRunWrapper(type, info, hyperlink);
+      const document: Document = {
+        package: {
+          document: {
+            content: [{ type: "paragraph", content: [trackedChange] }],
+          },
+        },
+      };
+
+      const pmDoc = toProseDoc(document);
+      const boundaries: PMNode[] = [];
+      pmDoc.descendants((node) => {
+        if (node.type.name === "bookmarkBoundary") {
+          boundaries.push(node);
+        }
+      });
+      expect(boundaries).toHaveLength(2);
+      expect(
+        boundaries.every((node) =>
+          node.marks.some(
+            (mark) =>
+              mark.type.name ===
+              (type === "deletion" || type === "moveFrom" ? "deletion" : "insertion"),
+          ),
+        ),
+      ).toBe(true);
+
+      const roundTripped = fromProseDoc(pmDoc, document);
+      const paragraph = roundTripped.package.document.content.at(0);
+      if (paragraph?.type !== "paragraph") {
+        throw new Error("Expected round-tripped paragraph");
+      }
+      expect(paragraph.content).toEqual([trackedChange]);
+    },
+  );
+
   test("preserves drawing content in vMerge continuation cells", () => {
     const rawXml = "<w:drawing><wp:anchor/></w:drawing>";
     const document: Document = {
@@ -2017,7 +2393,7 @@ describe("fromProseDoc", () => {
         author: "Reviewer",
         date: "2026-07-15T12:00:00Z",
       } satisfies TrackedChangeInfo;
-      paragraph.content = [trackedTextBoxWrapper(type, info, run)];
+      paragraph.content = [trackedRunWrapper(type, info, run)];
 
       const pmDoc = toProseDoc(document);
       const textBoxNode = pmDoc.firstChild;
@@ -2227,7 +2603,7 @@ describe("fromProseDoc", () => {
         {
           type: "inlineSdt",
           properties: { sdtType: "richText", alias: "Tracked shape" },
-          content: [trackedTextBoxWrapper(type, info, textBoxRun)],
+          content: [trackedRunWrapper(type, info, textBoxRun)],
         },
       ];
 
@@ -2367,7 +2743,7 @@ describe("fromProseDoc", () => {
     expect(firstShapeType(block)).toBe("textBox");
   });
 
-  test("keeps a wrapper paragraph when text-box-only content carries boundary attrs", () => {
+  test("keeps a wrapper paragraph when text-box-only content carries bookmark boundaries", () => {
     const document = documentWithTextBoxParagraph({ includeText: false });
     const sourceBlock = document.package.document.content.at(0);
 
@@ -2389,7 +2765,12 @@ describe("fromProseDoc", () => {
     expect(pmDoc.child(0).type.name).toBe("paragraph");
     expect(pmDoc.child(1).type.name).toBe("textBox");
     const attrs = expectParagraphAttrs(pmDoc.child(0));
-    expect(attrs.bookmarks).toEqual([{ id: 7, name: "box-boundary" }]);
+    expect(
+      Array.from(
+        { length: pmDoc.child(0).childCount },
+        (_, index) => pmDoc.child(0).child(index).type.name,
+      ),
+    ).toEqual(["bookmarkBoundary", "textBoxAnchor", "bookmarkBoundary"]);
     expect(attrs._emptyHyperlinks).toHaveLength(1);
 
     expect(block?.type).toBe("paragraph");
@@ -2937,21 +3318,21 @@ function documentWithTextBoxParagraph({
   };
 }
 
-function trackedTextBoxWrapper(
+function trackedRunWrapper(
   type: TrackedRunChange["type"],
   info: TrackedChangeInfo,
-  run: Run,
+  content: TrackedRunChange["content"][number],
 ): TrackedRunChange {
   if (type === "insertion") {
-    return { type, info, content: [run] };
+    return { type, info, content: [content] };
   }
   if (type === "deletion") {
-    return { type, info, content: [run] };
+    return { type, info, content: [content] };
   }
   if (type === "moveFrom") {
-    return { type, info, content: [run] };
+    return { type, info, content: [content] };
   }
-  return { type, info, content: [run] };
+  return { type, info, content: [content] };
 }
 
 function cellWithText(text: string): TableCell {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -69,6 +69,7 @@ import {
   type OutlineStyleCssAlias,
 } from "../../types/documentEnumValues";
 import { pixelsToEmu } from "../../utils/units";
+import { expectBookmarkBoundaryAttrs } from "../bookmarkBoundaryAttrs";
 import {
   expectCharacterSpacingMarkAttrs,
   expectCharacterStyleMarkAttrs,
@@ -118,6 +119,7 @@ import type {
   TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
+import { resolveNumberedRefFields } from "../numberedRefFields";
 import { expectTextBoxAnchorAttrs } from "../textBoxAnchorAttrs";
 import { runShadingAttrsToShading } from "./runShadingMark";
 import { decodeSdtListItems, sdtPropertiesFromAttrs, sdtPropertiesMatchAttrs } from "./sdtAttrs";
@@ -424,12 +426,48 @@ function stripSuggestedProvenance(doc: PMNode): PMNode {
  * Extract block content (paragraphs, tables, block SDTs) from a ProseMirror
  * document.
  */
-function extractBlocks(inputDoc: PMNode): BlockContent[] {
+type RefResolutionMode = "resolve" | "inherit";
+
+function materializeNumberedRefValues(doc: PMNode): PMNode {
+  const results = resolveNumberedRefFields(doc);
+  if (results.size === 0) {
+    return doc;
+  }
+  const visit = (node: PMNode): PMNode => {
+    if (node.type.name === "field" || node.type.name === "structuredField") {
+      const displayText = results.get(node);
+      if (displayText !== undefined) {
+        return node.type.create({ ...node.attrs, displayText }, node.content, node.marks);
+      }
+      return node;
+    }
+    if (node.childCount === 0) {
+      return node;
+    }
+    const children: PMNode[] = [];
+    let changed = false;
+    // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+    node.forEach((child) => {
+      const mappedChild = visit(child);
+      children.push(mappedChild);
+      changed ||= mappedChild !== child;
+    });
+    return changed ? node.copy(Fragment.fromArray(children)) : node;
+  };
+  return visit(doc);
+}
+
+function extractBlocks(
+  inputDoc: PMNode,
+  refResolution: RefResolutionMode = "resolve",
+): BlockContent[] {
   // CLASS GUARD: every serialization path (export, copy, header/footer
   // conversion, previews) funnels through `extractBlocks`. Stripping suggested
   // provenance here — with no opt-out — makes it structurally impossible for an
   // AI-proposed edit to reach OOXML output before a human accepts it.
-  const pmDoc = stripSuggestedProvenance(inputDoc);
+  const strippedDoc = stripSuggestedProvenance(inputDoc);
+  const pmDoc =
+    refResolution === "resolve" ? materializeNumberedRefValues(strippedDoc) : strippedDoc;
   const blocks: BlockContent[] = [];
   const textBoxAnchorMarkers = new Map<string, Run>();
   const documentCounts = buildDocumentTrackedChangeCounts(pmDoc);
@@ -567,7 +605,7 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
   // Recursively materialize children. PM `blockSdt` content is `block+`, so a
   // mini-doc node is a convenient way to reuse extractBlocks.
   const innerDoc = node.type.schema.node("doc", null, node.content);
-  const extracted = extractBlocks(innerDoc);
+  const extracted = extractBlocks(innerDoc, "inherit");
 
   // `toProseDoc` inserts a synthetic filler paragraph into any blockSdt
   // whose source had an empty `<w:sdtContent/>` and stamps the
@@ -803,6 +841,8 @@ function editTextBoxAnchorInContent(
     let nestedContent: ParagraphContent[] | undefined;
     if (item?.type === "hyperlink") {
       nestedContent = item.children;
+    } else if (item?.type === "simpleField") {
+      nestedContent = item.content;
     } else if (
       item?.type === "inlineSdt" ||
       item?.type === "insertion" ||
@@ -1351,6 +1391,28 @@ function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting 
  * Coalesces consecutive text with the same marks into single Runs
  * for efficient DOCX representation.
  */
+type TrackedRunWrapper = Extract<
+  ParagraphContent,
+  { type: "insertion" | "deletion" | "moveFrom" | "moveTo" }
+>;
+
+function createTrackedRunWrapper(
+  type: TrackedRunWrapper["type"],
+  info: TrackedChangeInfo,
+  child: Run | Hyperlink,
+): TrackedRunWrapper {
+  if (type === "insertion") {
+    return { type, info, content: [child] };
+  }
+  if (type === "deletion") {
+    return { type, info, content: [child] };
+  }
+  if (type === "moveFrom") {
+    return { type, info, content: [child] };
+  }
+  return { type, info, content: [child] };
+}
+
 function extractParagraphContent(
   paragraph: PMNode,
   // Parameter retained for signature compatibility with the call sites
@@ -1378,6 +1440,13 @@ function extractParagraphContent(
   let currentMarksKey: string | null = null;
   let currentHyperlink: Hyperlink | null = null;
   let currentHyperlinkKey: string | null = null;
+  let currentTrackedChange:
+    | {
+        key: string;
+        hyperlink: Hyperlink;
+        hyperlinkKey: string;
+      }
+    | undefined;
   const openedComments = new Set<number>();
 
   // A single comment id must round-trip to a single contiguous comment range.
@@ -1433,6 +1502,7 @@ function extractParagraphContent(
     }
 
     flushCurrentInline();
+    currentTrackedChange = undefined;
 
     // Stable id ordering keeps shared-boundary emission deterministic.
     for (const commentId of toClose.toSorted((a, b) => a - b)) {
@@ -1453,6 +1523,7 @@ function extractParagraphContent(
       }
       nextEmptyHyperlink += 1;
       flushCurrentInline();
+      currentTrackedChange = undefined;
       content.push(createEmptyHyperlink(item.attrs));
     }
   };
@@ -1469,8 +1540,12 @@ function extractParagraphContent(
     const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
     const insertionMark = node.marks.find((m) => m.type.name === "insertion");
     const deletionMark = node.marks.find((m) => m.type.name === "deletion");
+    if (!insertionMark && !deletionMark) {
+      currentTrackedChange = undefined;
+    }
     if (node.type.name === "textBoxAnchor") {
       flushCurrentInline();
+      currentTrackedChange = undefined;
       if (!textBoxAnchorMarkers) {
         return;
       }
@@ -1523,14 +1598,6 @@ function extractParagraphContent(
       const otherMarks = node.marks.filter(
         (m) => m.type.name !== "insertion" && m.type.name !== "deletion",
       );
-      const run = createTrackedChangeRun({ inheritedFormatting, marks: otherMarks, node });
-      if (!run) {
-        return;
-      }
-      const trackedContent: Run | Hyperlink = linkMark
-        ? { ...createHyperlink(linkMark), children: [run] }
-        : run;
-
       const info: TrackedChangeInfo = {
         id: changeAttrs.revisionId,
         author: changeAttrs.author || "Unknown",
@@ -1549,16 +1616,46 @@ function extractParagraphContent(
       // typically don't), and unrelated `w:ins w:id="5"` /
       // `w:del w:id="5"` from different reviewers would coincidentally
       // fuse into a phantom move pair.
+      let type: TrackedRunWrapper["type"];
       if (insertionMark) {
-        if (changeAttrs.moveKind === "moveTo") {
-          content.push({ type: "moveTo", info, content: [trackedContent] });
-        } else {
-          content.push({ type: "insertion", info, content: [trackedContent] });
-        }
-      } else if (changeAttrs.moveKind === "moveFrom") {
-        content.push({ type: "moveFrom", info, content: [trackedContent] });
+        type = changeAttrs.moveKind === "moveTo" ? "moveTo" : "insertion";
       } else {
-        content.push({ type: "deletion", info, content: [trackedContent] });
+        type = changeAttrs.moveKind === "moveFrom" ? "moveFrom" : "deletion";
+      }
+      const trackedChangeKey = `${type}:${JSON.stringify(info)}`;
+      if (linkMark) {
+        const linkKey = getLinkKey(linkMark);
+        if (
+          !currentTrackedChange ||
+          currentTrackedChange.key !== trackedChangeKey ||
+          currentTrackedChange.hyperlinkKey !== linkKey
+        ) {
+          const hyperlink = createHyperlink(linkMark);
+          const wrapper = createTrackedRunWrapper(type, info, hyperlink);
+          content.push(wrapper);
+          currentTrackedChange = { key: trackedChangeKey, hyperlink, hyperlinkKey: linkKey };
+        }
+
+        if (node.type.name === "bookmarkBoundary") {
+          addNodeToHyperlink({
+            hyperlink: currentTrackedChange.hyperlink,
+            inheritedFormatting,
+            node,
+          });
+          return;
+        }
+
+        const run = createTrackedChangeRun({ inheritedFormatting, marks: otherMarks, node });
+        if (run) {
+          currentTrackedChange.hyperlink.children.push(run);
+        }
+        return;
+      }
+
+      currentTrackedChange = undefined;
+      const run = createTrackedChangeRun({ inheritedFormatting, marks: otherMarks, node });
+      if (run) {
+        content.push(createTrackedRunWrapper(type, info, run));
       }
       return;
     }
@@ -1595,7 +1692,21 @@ function extractParagraphContent(
     }
 
     // Handle node types
-    if (node.isText) {
+    if (node.type.name === "bookmarkBoundary") {
+      flushCurrentInline();
+      const attrs = expectBookmarkBoundaryAttrs(node);
+      if (attrs.type === "start") {
+        content.push({
+          type: "bookmarkStart",
+          id: attrs.id,
+          name: attrs.name,
+          ...(attrs.colFirst !== undefined ? { colFirst: attrs.colFirst } : {}),
+          ...(attrs.colLast !== undefined ? { colLast: attrs.colLast } : {}),
+        });
+      } else {
+        content.push({ type: "bookmarkEnd", id: attrs.id });
+      }
+    } else if (node.isText) {
       const marksKey = getMarksKey(node.marks);
 
       if (currentRun && currentMarksKey === marksKey) {
@@ -1635,10 +1746,15 @@ function extractParagraphContent(
     } else if (node.type.name === "renderedPageBreak") {
       flushCurrentInline();
       content.push(createRenderedPageBreakRun());
-    } else if (node.type.name === "field") {
+    } else if (node.type.name === "field" || node.type.name === "structuredField") {
       // Field ends current run and emits a field content item
       flushCurrentInline();
-      content.push(createFieldFromNode(node, node.marks));
+      content.push(
+        createFieldFromNode(node, {
+          marks: node.marks,
+          textBoxAnchorMarkers,
+        }),
+      );
     } else if (node.type.name === "sdt") {
       // SDT ends current run and emits an InlineSdt content item
       flushCurrentInline();
@@ -1874,6 +1990,21 @@ function addNodeToHyperlink({
   inheritedFormatting,
   node,
 }: AddNodeToHyperlinkOptions): void {
+  if (node.type.name === "bookmarkBoundary") {
+    const attrs = expectBookmarkBoundaryAttrs(node);
+    if (attrs.type === "start") {
+      hyperlink.children.push({
+        type: "bookmarkStart",
+        id: attrs.id,
+        name: attrs.name,
+        ...(attrs.colFirst !== undefined ? { colFirst: attrs.colFirst } : {}),
+        ...(attrs.colLast !== undefined ? { colLast: attrs.colLast } : {}),
+      });
+    } else {
+      hyperlink.children.push({ type: "bookmarkEnd", id: attrs.id });
+    }
+    return;
+  }
   const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
   if (noteRefMark) {
     hyperlink.children.push(createNoteReferenceRun(noteRefMark, node.marks));
@@ -2082,13 +2213,20 @@ function createTabRun(node: PMNode, marks?: readonly Mark[]): Run {
 /**
  * Create a SimpleField or ComplexField from a PM field node
  */
-function createFieldFromNode(node: PMNode, marks?: readonly Mark[]): SimpleField | ComplexField {
-  const attrs = expectFieldAttrs(node);
+type CreateFieldFromNodeOptions = {
+  marks?: readonly Mark[];
+  textBoxAnchorMarkers?: Map<string, Run> | undefined;
+};
 
+function createFieldFromNode(
+  node: PMNode,
+  { marks, textBoxAnchorMarkers }: CreateFieldFromNodeOptions,
+): SimpleField | ComplexField {
+  const attrs = expectFieldAttrs(node);
   const formatting = marks && marks.length > 0 ? marksToTextFormatting(marks) : undefined;
 
   // Provide fallback display text for dynamic fields so <w:t> is never empty
-  let displayText = attrs.displayText || "";
+  let displayText = attrs.displayText ?? "";
   if (!displayText) {
     switch (attrs.fieldType) {
       case "PAGE":
@@ -2108,6 +2246,18 @@ function createFieldFromNode(node: PMNode, marks?: readonly Mark[]): SimpleField
     content: [{ type: "text" as const, text: displayText }],
     ...(formatting && Object.keys(formatting).length > 0 ? { formatting } : {}),
   };
+  const extractedContent = extractParagraphContent(
+    node,
+    undefined,
+    undefined,
+    textBoxAnchorMarkers,
+  ).filter(
+    (content): content is Run | Hyperlink => content.type === "run" || content.type === "hyperlink",
+  );
+  const fieldContent =
+    extractedContent.length > 0
+      ? synchronizeFieldDisplayText(extractedContent, displayText, displayRun)
+      : [];
 
   if (attrs.fieldKind === "complex") {
     const complex: ComplexField = {
@@ -2115,7 +2265,10 @@ function createFieldFromNode(node: PMNode, marks?: readonly Mark[]): SimpleField
       instruction: attrs.instruction,
       fieldType: attrs.fieldType,
       fieldCode: [],
-      fieldResult: [displayRun],
+      fieldResult:
+        fieldContent.length > 0
+          ? fieldContent.filter((content): content is Run => content.type === "run")
+          : [displayRun],
     };
     if (attrs.fldLock) {
       complex.fldLock = true;
@@ -2130,7 +2283,7 @@ function createFieldFromNode(node: PMNode, marks?: readonly Mark[]): SimpleField
     type: "simpleField",
     instruction: attrs.instruction,
     fieldType: attrs.fieldType,
-    content: [displayRun],
+    content: fieldContent.length > 0 ? fieldContent : [displayRun],
   };
   if (attrs.fldLock) {
     simple.fldLock = true;
@@ -2140,6 +2293,60 @@ function createFieldFromNode(node: PMNode, marks?: readonly Mark[]): SimpleField
   }
   return simple;
 }
+
+const synchronizeFieldDisplayText = (
+  content: (Run | Hyperlink)[],
+  displayText: string,
+  fallbackRun: Run,
+): (Run | Hyperlink)[] => {
+  let currentText = "";
+  const visitRuns = (visit: (run: Run) => void): void => {
+    for (const child of content) {
+      if (child.type === "run") {
+        visit(child);
+        continue;
+      }
+      for (const hyperlinkChild of child.children) {
+        if (hyperlinkChild.type === "run") {
+          visit(hyperlinkChild);
+        }
+      }
+    }
+  };
+  visitRuns((run) => {
+    for (const runContent of run.content) {
+      if (runContent.type === "text") {
+        currentText += runContent.text;
+      }
+    }
+  });
+  if (currentText === displayText) {
+    return content;
+  }
+
+  let replacedText = false;
+  visitRuns((run) => {
+    for (const runContent of run.content) {
+      if (runContent.type !== "text") {
+        continue;
+      }
+      runContent.text = replacedText ? "" : displayText;
+      replacedText = true;
+    }
+  });
+  if (replacedText) {
+    return content;
+  }
+
+  const hyperlink = content.find((child) => child.type === "hyperlink");
+  if (!hyperlink) {
+    content.push(fallbackRun);
+    return content;
+  }
+  const firstEnd = hyperlink.children.findIndex((child) => child.type === "bookmarkEnd");
+  hyperlink.children.splice(firstEnd < 0 ? hyperlink.children.length : firstEnd, 0, fallbackRun);
+  return content;
+};
 
 /**
  * Create a MathEquation from a PM math node

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -70,6 +70,7 @@ import type {
   TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
+import { stampNumberedRefFieldBaselines } from "../numberedRefFields";
 import {
   resolveEffectiveTableCellFormatting,
   type TableCellMarginsAttrs,
@@ -128,6 +129,123 @@ const createHyperlinkInstanceIndexAllocator = (): HyperlinkInstanceIndexAllocato
   return () => index++;
 };
 
+type BookmarkBoundaryCount = {
+  starts: number;
+  ends: number;
+  firstStart?: number;
+  firstEnd?: number;
+};
+
+/**
+ * Find bookmark pairs across every editable inline wrapper in a document story.
+ * Each endpoint is converted at its own structural position, so a range may
+ * start outside a hyperlink and end inside it (or the inverse).
+ */
+const collectPairedBookmarkIds = (blocks: readonly BlockContent[]): ReadonlySet<number> => {
+  const counts = new Map<number, BookmarkBoundaryCount>();
+  let position = 0;
+  const countBoundary = (id: number, type: "start" | "end"): void => {
+    const count = counts.get(id) ?? { starts: 0, ends: 0 };
+    if (type === "start") {
+      count.starts += 1;
+      count.firstStart ??= position;
+    } else {
+      count.ends += 1;
+      count.firstEnd ??= position;
+    }
+    position += 1;
+    counts.set(id, count);
+  };
+
+  const visitRun = (run: Run): void => {
+    for (const content of run.content) {
+      if (content.type === "shape" && content.shape.textBody) {
+        visitBlocks(content.shape.textBody.content);
+      }
+    }
+  };
+
+  const visitHyperlink = (hyperlink: Hyperlink): void => {
+    for (const child of hyperlink.children) {
+      if (child.type === "bookmarkStart") {
+        countBoundary(child.id, "start");
+      } else if (child.type === "bookmarkEnd") {
+        countBoundary(child.id, "end");
+      } else {
+        visitRun(child);
+      }
+    }
+  };
+
+  const visitParagraphContent = (content: Paragraph["content"][number]): void => {
+    if (content.type === "bookmarkStart") {
+      countBoundary(content.id, "start");
+    } else if (content.type === "bookmarkEnd") {
+      countBoundary(content.id, "end");
+    } else if (content.type === "run") {
+      visitRun(content);
+    } else if (content.type === "hyperlink") {
+      visitHyperlink(content);
+    } else if (content.type === "simpleField") {
+      for (const child of content.content) {
+        if (child.type === "hyperlink") {
+          visitHyperlink(child);
+        } else {
+          visitRun(child);
+        }
+      }
+    } else if (content.type === "complexField") {
+      for (const run of [...(content.fieldCode ?? []), ...content.fieldResult]) {
+        visitRun(run);
+      }
+    } else if (content.type === "inlineSdt") {
+      for (const child of content.content) {
+        visitParagraphContent(child);
+      }
+    } else if (
+      content.type === "insertion" ||
+      content.type === "deletion" ||
+      content.type === "moveFrom" ||
+      content.type === "moveTo"
+    ) {
+      for (const child of content.content) {
+        visitParagraphContent(child);
+      }
+    }
+  };
+
+  const visitBlocks = (nestedBlocks: readonly BlockContent[]): void => {
+    for (const block of nestedBlocks) {
+      if (block.type === "paragraph") {
+        for (const content of block.content) {
+          visitParagraphContent(content);
+        }
+      } else if (block.type === "table") {
+        for (const row of block.rows) {
+          for (const cell of row.cells) {
+            visitBlocks(cell.content);
+          }
+        }
+      } else {
+        visitBlocks(block.content);
+      }
+    }
+  };
+
+  visitBlocks(blocks);
+  return new Set(
+    [...counts].flatMap(([id, count]) =>
+      count.starts === 1 &&
+      count.ends === 1 &&
+      count.firstStart !== undefined &&
+      count.firstEnd !== undefined &&
+      count.firstStart < count.firstEnd
+        ? [id]
+        : [],
+    ),
+  );
+};
+
 /**
  * Convert a Document to a ProseMirror document
  *
@@ -147,7 +265,13 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
   const theme = options?.theme ?? document.package.theme ?? null;
   const nextTextBoxGroupId = createTextBoxGroupIdFactory();
   const nextHyperlinkInstanceIndex = createHyperlinkInstanceIndexAllocator();
-  const conversionContext = { theme, nextTextBoxGroupId, nextHyperlinkInstanceIndex };
+  const pairedBookmarkIds = collectPairedBookmarkIds(paragraphs);
+  const conversionContext = {
+    theme,
+    nextTextBoxGroupId,
+    nextHyperlinkInstanceIndex,
+    pairedBookmarkIds,
+  };
 
   const convertBodyBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
@@ -214,7 +338,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
     nodes.push(schema.node("paragraph", {}, []));
   }
 
-  const pmDoc = schema.node("doc", null, nodes);
+  const pmDoc = stampNumberedRefFieldBaselines(schema.node("doc", null, nodes));
   assertValidProseMirrorDocument(
     pmDoc,
     "Document conversion produced an invalid ProseMirror document",
@@ -276,6 +400,7 @@ function convertParagraph(
   paragraph: Paragraph,
   styleResolver: StyleEngine | null,
   nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator,
+  pairedBookmarkIds: ReadonlySet<number>,
   activeCommentIds?: Set<number>,
   extraRunFormatting?: TextFormatting,
   tableParagraphOverlay?: TableCellParagraphSpacingOverlay,
@@ -468,7 +593,14 @@ function convertParagraph(
       }
       emitInlineNodes(linkNodes);
     } else if (content.type === "simpleField" || content.type === "complexField") {
-      emitInlineNode(convertField(content, getInheritedRunFormatting, styleResolver));
+      emitInlineNode(
+        convertField(content, {
+          getInheritedRunFormatting,
+          styleResolver,
+          nextHyperlinkInstanceIndex,
+          textBoxAnchors,
+        }),
+      );
     } else if (content.type === "inlineSdt") {
       emitInlineNode(
         convertInlineSdt(
@@ -485,9 +617,21 @@ function convertParagraph(
       emitTrackedChange(content, "deletion", content.type === "moveFrom" ? "moveFrom" : null);
     } else if (content.type === "mathEquation") {
       emitInlineNode(convertMathEquation(content));
-    }
-    // Collect bookmarkStart entries for round-trip
-    if (content.type === "bookmarkStart") {
+    } else if (content.type === "bookmarkStart" && pairedBookmarkIds.has(content.id)) {
+      emitInlineNode(
+        schema.node("bookmarkBoundary", {
+          type: "start",
+          id: content.id,
+          name: content.name,
+          colFirst: content.colFirst,
+          colLast: content.colLast,
+        }),
+      );
+    } else if (content.type === "bookmarkEnd" && pairedBookmarkIds.has(content.id)) {
+      emitInlineNode(schema.node("bookmarkBoundary", { type: "end", id: content.id }));
+    } else if (content.type === "bookmarkStart") {
+      // Legacy structural placement records only the start on a paragraph and
+      // uses the paragraph attr to preserve its existing save behavior.
       if (!bookmarksArr) {
         bookmarksArr = [];
       }
@@ -628,6 +772,7 @@ function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
         node.type.name === "hardBreak" ||
         node.type.name === "tab" ||
         node.type.name === "symbol" ||
+        node.type.name === "bookmarkBoundary" ||
         node.type.name === "textBoxAnchor"))
   );
 }
@@ -1533,6 +1678,7 @@ type TableConversionContext = {
   theme: Theme | null | undefined;
   nextTextBoxGroupId: () => string;
   nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator;
+  pairedBookmarkIds: ReadonlySet<number>;
 };
 
 function convertTable(
@@ -2181,7 +2327,12 @@ export function standaloneTableCellToProseMirror(
   return convertTableCell({
     cell,
     styleResolver: null,
-    context: { theme: null, nextTextBoxGroupId, nextHyperlinkInstanceIndex },
+    context: {
+      theme: null,
+      nextTextBoxGroupId,
+      nextHyperlinkInstanceIndex,
+      pairedBookmarkIds: collectPairedBookmarkIds(cell.content),
+    },
     isHeader: nodeType === "tableHeader",
     gridWidthPercent: undefined,
     conditionalStyle: undefined,
@@ -2200,26 +2351,77 @@ export function standaloneTableCellToProseMirror(
  * Accepts a run formatting resolver so fields inherit paragraph-level
  * formatting the same way regular text runs do.
  */
+type ConvertFieldOptions = {
+  getInheritedRunFormatting: RunFormattingResolver;
+  styleResolver: StyleEngine | null | undefined;
+  nextHyperlinkInstanceIndex: HyperlinkInstanceIndexAllocator;
+  textBoxAnchors: ReadonlyMap<Shape, string> | undefined;
+};
+
 function convertField(
   field: SimpleField | ComplexField,
-  getInheritedRunFormatting: RunFormattingResolver,
-  styleResolver?: StyleEngine | null,
+  {
+    getInheritedRunFormatting,
+    styleResolver,
+    nextHyperlinkInstanceIndex,
+    textBoxAnchors,
+  }: ConvertFieldOptions,
 ): PMNode | null {
   // Extract display text and formatting from field content/result
   let displayText = "";
   let fieldFormatting: TextFormatting | undefined;
-  const runs = field.type === "simpleField" ? field.content : field.fieldResult;
-  for (const r of runs) {
-    if (r.type === "run") {
-      for (const c of r.content) {
-        if (c.type === "text") {
-          displayText += c.text;
+  const inlineNodes: PMNode[] = [];
+  const hasStructuredSourceContent =
+    field.type === "simpleField" && field.content.some((content) => content.type === "hyperlink");
+  const appendRun = (run: Run): void => {
+    for (const content of run.content) {
+      if (content.type === "text") {
+        displayText += content.text;
+      }
+    }
+    // Use formatting from the first run that has it.
+    fieldFormatting ??= run.formatting;
+    if (!hasStructuredSourceContent) {
+      return;
+    }
+    inlineNodes.push(
+      ...convertRun(
+        run,
+        getInheritedRunFormatting(run.formatting, field.fieldType),
+        styleResolver,
+        textBoxAnchors,
+      ),
+    );
+  };
+  if (field.type === "simpleField") {
+    for (const content of field.content) {
+      if (content.type === "run") {
+        appendRun(content);
+        continue;
+      }
+      for (const child of content.children) {
+        if (child.type === "run") {
+          for (const runContent of child.content) {
+            if (runContent.type === "text") {
+              displayText += runContent.text;
+            }
+          }
+          fieldFormatting ??= child.formatting;
         }
       }
-      // Use formatting from the first run that has it
-      if (!fieldFormatting && r.formatting) {
-        fieldFormatting = r.formatting;
-      }
+      inlineNodes.push(
+        ...convertHyperlink(content, {
+          getInheritedRunFormatting: (formatting) =>
+            getInheritedRunFormatting(formatting, field.fieldType),
+          styleResolver,
+          hyperlinkIndex: nextHyperlinkInstanceIndex(),
+          textBoxAnchors,
+        }),
+      );
+    }
+  } else {
+    for (const run of field.fieldResult) {
+      appendRun(run);
     }
   }
 
@@ -2241,8 +2443,13 @@ function convertField(
   const inheritedFormatting = getInheritedRunFormatting(fieldFormatting, field.fieldType);
   const { marks } = buildRunMarks(fieldFormatting, inheritedFormatting, styleResolver);
 
+  const hasConvertedHyperlinkContent = inlineNodes.some((node) =>
+    node.marks.some((mark) => mark.type.name === "hyperlink"),
+  );
+
+  const createStructuredField = hasStructuredSourceContent && hasConvertedHyperlinkContent;
   return schema.node(
-    "field",
+    createStructuredField ? "structuredField" : "field",
     {
       fieldType: field.fieldType,
       instruction: field.instruction,
@@ -2251,7 +2458,7 @@ function convertField(
       fldLock: field.fldLock ?? false,
       dirty: field.dirty ?? false,
     },
-    undefined,
+    createStructuredField ? inlineNodes : undefined,
     marks,
   );
 }
@@ -2299,7 +2506,12 @@ function convertInlineSdt(
       });
       inlineNodes.push(...linkNodes);
     } else if (content.type === "simpleField" || content.type === "complexField") {
-      const fieldNode = convertField(content, getInheritedRunFormatting, styleResolver);
+      const fieldNode = convertField(content, {
+        getInheritedRunFormatting,
+        styleResolver,
+        nextHyperlinkInstanceIndex,
+        textBoxAnchors,
+      });
       if (fieldNode) {
         inlineNodes.push(fieldNode);
       }
@@ -2921,6 +3133,29 @@ function convertHyperlink(
   });
 
   for (const child of hyperlink.children) {
+    if (child.type === "bookmarkStart") {
+      nodes.push(
+        schema.node(
+          "bookmarkBoundary",
+          {
+            type: "start",
+            id: child.id,
+            name: child.name,
+            colFirst: child.colFirst,
+            colLast: child.colLast,
+          },
+          undefined,
+          [linkMark],
+        ),
+      );
+      continue;
+    }
+    if (child.type === "bookmarkEnd") {
+      nodes.push(
+        schema.node("bookmarkBoundary", { type: "end", id: child.id }, undefined, [linkMark]),
+      );
+      continue;
+    }
     if (child.type === "run") {
       // Merge style formatting with run's inline formatting
       const inheritedFormatting = getInheritedRunFormatting(child.formatting);
@@ -3310,6 +3545,7 @@ function convertParagraphWithTextBoxes(
     block,
     styleResolver,
     context.nextHyperlinkInstanceIndex,
+    context.pairedBookmarkIds,
     undefined,
     extraRunFormatting,
     tableParagraphOverlay,
@@ -3750,7 +3986,13 @@ export function headerFooterToProseDoc(
   const theme = options?.theme ?? null;
   const nextTextBoxGroupId = createTextBoxGroupIdFactory();
   const nextHyperlinkInstanceIndex = createHyperlinkInstanceIndexAllocator();
-  const conversionContext = { theme, nextTextBoxGroupId, nextHyperlinkInstanceIndex };
+  const pairedBookmarkIds = collectPairedBookmarkIds(content);
+  const conversionContext = {
+    theme,
+    nextTextBoxGroupId,
+    nextHyperlinkInstanceIndex,
+    pairedBookmarkIds,
+  };
 
   const convertBlocks = (blocks: BlockContent[]): PMNode[] => {
     const out: PMNode[] = [];
@@ -3783,7 +4025,7 @@ export function headerFooterToProseDoc(
     nodes.push(schema.node("paragraph", {}, []));
   }
 
-  const pmDoc = schema.node("doc", null, nodes);
+  const pmDoc = stampNumberedRefFieldBaselines(schema.node("doc", null, nodes));
   assertValidProseMirrorDocument(
     pmDoc,
     "Header/footer conversion produced an invalid ProseMirror document",

--- a/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -68,7 +68,8 @@ import {
 } from "./marks/TrackedChangeExtensions";
 import { UnderlineExtension } from "./marks/UnderlineExtension";
 import { BlockSdtExtension } from "./nodes/BlockSdtExtension";
-import { FieldExtension } from "./nodes/FieldExtension";
+import { BookmarkBoundaryExtension } from "./nodes/BookmarkBoundaryExtension";
+import { FieldExtension, StructuredFieldExtension } from "./nodes/FieldExtension";
 // Nodes
 import { HardBreakExtension } from "./nodes/HardBreakExtension";
 import { HorizontalRuleExtension } from "./nodes/HorizontalRuleExtension";
@@ -103,6 +104,11 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   const disabled = options.disable ? new Set(options.disable) : new Set<string>();
 
   const extensions: AnyExtension[] = [];
+  let internalClipboardToken: string | undefined;
+  const getInternalClipboardToken = (): string => {
+    internalClipboardToken ??= globalThis.crypto.randomUUID();
+    return internalClipboardToken;
+  };
 
   function add(name: string, ext: AnyExtension): void {
     if (!disabled.has(name)) {
@@ -161,12 +167,13 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add("runPropertyChange", RunPropertyChangeExtension());
 
   // Nodes
+  add("bookmarkBoundary", BookmarkBoundaryExtension({ getInternalClipboardToken }));
   add("hardBreak", HardBreakExtension());
   add("tab", TabExtension());
   add("symbol", SymbolExtension());
   add("image", ImageExtension());
   add("textBox", TextBoxExtension());
-  add("textBoxAnchor", TextBoxAnchorExtension());
+  add("textBoxAnchor", TextBoxAnchorExtension({ getInternalClipboardToken }));
   add("shape", ShapeExtension());
   add("imageDrag", ImageDragExtension());
   add("imagePaste", ImagePasteExtension());
@@ -176,6 +183,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add("pageBreak", PageBreakExtension());
   add("renderedPageBreak", RenderedPageBreakExtension());
   add("field", FieldExtension());
+  add("field", StructuredFieldExtension({ getInternalClipboardToken }));
   add("sdt", SdtExtension());
   add("blockSdt", BlockSdtExtension());
   add("math", MathExtension());
@@ -186,7 +194,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   }
 
   // Features
-  add("pasteCleanup", PasteCleanupExtension());
+  add("pasteCleanup", PasteCleanupExtension({ getInternalClipboardToken }));
   add("pasteStyleInliner", PasteStyleInlinerExtension());
   add("list", ListExtension());
   add("baseKeymap", BaseKeymapExtension());

--- a/packages/core/src/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -16,6 +16,7 @@ import type { Node as PMNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 
 import type { ParagraphDirection } from "../../paragraphDirection";
+import { schema as docxSchema } from "../../schema";
 import {
   AutoBidiDetectionExtension,
   ensureBaseDirectionInState,
@@ -35,6 +36,15 @@ const schema = new Schema({
       group: "inline",
       inline: true,
       atom: true,
+      attrs: { displayText: { default: "" } },
+      leafText: (node) => node.attrs["displayText"],
+      toDOM: () => ["span"],
+    },
+    structuredField: {
+      group: "inline",
+      inline: true,
+      atom: true,
+      content: "text*",
       attrs: { displayText: { default: "" } },
       toDOM: () => ["span", 0],
     },
@@ -141,6 +151,34 @@ describe("ensureBaseDirectionInState (initial load)", () => {
   test("detects RTL from an inline field's display text", () => {
     const state = ensureBaseDirectionInState(stateOf(fieldLedPara("عربي", "")));
     expect(dirs(state)).toEqual(["auto"]);
+  });
+
+  test("uses an empty PAGE field fallback before later directional text", () => {
+    const page = docxSchema.node("field", {
+      fieldType: "PAGE",
+      instruction: " PAGE ",
+      displayText: "",
+      fieldKind: "complex",
+    });
+    const paragraph = docxSchema.node("paragraph", null, [page, docxSchema.text(" عربي")]);
+    const docxRuntime = AutoBidiDetectionExtension().onSchemaReady({ schema: docxSchema });
+    const state = EditorState.create({
+      doc: docxSchema.node("doc", null, [paragraph]),
+      plugins: docxRuntime.plugins ?? [],
+    });
+
+    expect(dirs(ensureBaseDirectionInState(state))).toEqual(["none"]);
+  });
+
+  test("uses structured field children once instead of prepending cached display text", () => {
+    const structured = schema.node(
+      "structuredField",
+      { displayText: "عربي" },
+      schema.text("Agreement"),
+    );
+    const paragraph = schema.node("paragraph", { direction: null }, [structured]);
+
+    expect(dirs(ensureBaseDirectionInState(stateOf(paragraph)))).toEqual(["none"]);
   });
 
   test("detects RTL from text inside an inline content control (SDT)", () => {

--- a/packages/core/src/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -48,26 +48,27 @@ type BidiUpdate = {
 };
 
 // First-strong detection needs the paragraph's directional text in document
-// order. `node.textContent` skips inline field atoms (MERGEFIELD/REF results
-// keep their rendered text in attrs, not child text), which would mis-detect a
-// field-led paragraph. Walk descendants so text nested in inline content
-// controls (SDT) and hyperlinks is included, and fold in field display text.
+// order. Walk descendants so text nested in structured fields, inline content
+// controls (SDT), and hyperlinks is included. Ordinary field leaves expose
+// their display through `leafText`; structured field text comes from children.
 const paragraphDirectionalText = (node: PMNode): string => {
   let text = "";
   node.descendants((child) => {
+    const deleted = child.marks.some((mark) => mark.type.name === "deletion");
+    if (deleted) {
+      return false;
+    }
     if (child.isText) {
       // Deleted and moved-away text both carry the `deletion` mark; it is not
       // live content, so it must not drive base-direction detection.
-      const deleted = child.marks.some((mark) => mark.type.name === "deletion");
-      if (!deleted) {
-        text += child.text ?? "";
-      }
-    } else if (child.type.name === "field") {
-      const display = child.attrs["displayText"];
-      if (typeof display === "string") {
-        text += display;
-      }
+      text += child.text ?? "";
+      return false;
     }
+    if (child.isLeaf && child.textContent) {
+      text += child.textContent;
+      return false;
+    }
+    return true;
   });
   return text;
 };

--- a/packages/core/src/prosemirror/extensions/features/PasteCleanupExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/PasteCleanupExtension.ts
@@ -19,17 +19,25 @@ import { pasteWithoutFormatting } from "../../commands/pastePlainText";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 import { Priority } from "../types";
-import { cleanPastedHtml } from "./pasteCleanup";
+import { cleanPastedHtml, removeUnpairedBookmarkBoundaries } from "./pasteCleanup";
 
-export const PasteCleanupExtension = createExtension({
+type PasteCleanupOptions = {
+  getInternalClipboardToken?: () => string;
+};
+
+export const PasteCleanupExtension = createExtension<PasteCleanupOptions>({
   name: "pasteCleanup",
   priority: Priority.Highest,
-  onSchemaReady(): ExtensionRuntime {
+  onSchemaReady(_context, options): ExtensionRuntime {
     const plugin = new Plugin({
       props: {
         transformPastedHTML(html: string): string {
-          return cleanPastedHtml(html);
+          const internalClipboardToken = options.getInternalClipboardToken?.();
+          return cleanPastedHtml(html, {
+            ...(internalClipboardToken ? { internalClipboardToken } : {}),
+          });
         },
+        transformPasted: removeUnpairedBookmarkBoundaries,
       },
     });
 

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { Fragment, Slice } from "prosemirror-model";
 
-import { cleanPastedHtml } from "./pasteCleanup";
+import { schema } from "../../schema";
+import { cleanPastedHtml, removeUnpairedBookmarkBoundaries } from "./pasteCleanup";
 
 describe("cleanPastedHtml — Office cruft removal", () => {
   test("strips mso-* declarations but keeps real CSS", () => {
@@ -180,6 +182,12 @@ describe("cleanPastedHtml — safety and robustness", () => {
     expect(performance.now() - start).toBeLessThan(2000);
     expect(out).toBe("");
   });
+
+  test("fails closed when an unexpected sanitizer input throws", () => {
+    const malformedInput = {} as unknown as string;
+
+    expect(cleanPastedHtml(malformedInput, { internalClipboardToken: "test-capability" })).toBe("");
+  });
 });
 
 describe("cleanPastedHtml — text-box anchor hijack via paste", () => {
@@ -199,10 +207,32 @@ describe("cleanPastedHtml — text-box anchor hijack via paste", () => {
     // prosemirror-view's clipboard wrapper, which stamps `data-pm-slice` on
     // the outer element. That must not be treated as external DOM.
     const html =
-      '<div data-pm-slice="0 0 []"><p><span data-docx-textbox-anchor="0:0">​</span>Real box</p></div>';
-    const out = cleanPastedHtml(html);
+      '<div data-pm-slice="0 0 []"><p><span data-docx-textbox-anchor="0:0" data-docx-internal-clipboard="test-capability">​</span>Real box</p></div>';
+    const out = cleanPastedHtml(html, { internalClipboardToken: "test-capability" });
     expect(out).toContain("data-docx-textbox-anchor");
+    expect(out).not.toContain("data-docx-internal-clipboard");
     expect(out).toContain("Real box");
+  });
+
+  test("preserves an empty text-box anchor only with the internal clipboard capability", () => {
+    const html =
+      '<div data-pm-slice="0 0 []"><span data-docx-textbox-anchor="0:0" data-docx-internal-clipboard="test-capability"></span></div>';
+
+    const internal = cleanPastedHtml(html, { internalClipboardToken: "test-capability" });
+    const external = cleanPastedHtml(html);
+
+    expect(internal).toContain('data-docx-textbox-anchor="0:0"');
+    expect(internal).not.toContain("data-docx-internal-clipboard");
+    expect(external).not.toContain("data-docx-textbox-anchor");
+  });
+
+  test("does not trust a forged ProseMirror slice marker", () => {
+    const html =
+      '<div data-pm-slice="0 0 []"><span data-docx-textbox-anchor="0:0">forged</span></div>';
+
+    expect(cleanPastedHtml(html, { internalClipboardToken: "test-capability" })).not.toContain(
+      "data-docx-textbox-anchor",
+    );
   });
 
   test("strips a single- or double-quoted anchor attribute value", () => {
@@ -212,5 +242,150 @@ describe("cleanPastedHtml — text-box anchor hijack via paste", () => {
     expect(cleanPastedHtml('<span data-docx-textbox-anchor="0:0">x</span>')).not.toContain(
       "data-docx-textbox-anchor",
     );
+  });
+});
+
+describe("cleanPastedHtml — bookmark boundaries", () => {
+  test("keeps a structured hyperlink field only with its wrapper capability", () => {
+    const html =
+      '<span class="docx-field" data-field-kind="simple" data-field-structured="true" data-docx-internal-clipboard="test-capability"><a href="https://example.test">Clause</a></span>';
+
+    const internal = cleanPastedHtml(html, { internalClipboardToken: "test-capability" });
+    const external = cleanPastedHtml(html);
+
+    expect(internal).toContain('data-field-structured="true"');
+    expect(internal).not.toContain("data-docx-internal-clipboard");
+    expect(external).not.toContain("data-field-structured");
+    expect(external).toContain("Clause");
+  });
+
+  test("preserves structured-field boundaries only for the internal clipboard capability", () => {
+    const html =
+      '<span class="docx-field" data-field-type="REF" data-field-kind="simple" data-field-structured="true"><a href="https://example.test"><span data-docx-bookmark-boundary="start" data-docx-bookmark-id="12" data-docx-bookmark-name="clause" data-docx-internal-clipboard="test-capability"></span>Clause<span data-docx-bookmark-boundary="end" data-docx-bookmark-id="12" data-docx-internal-clipboard="test-capability"></span></a></span>';
+
+    const internal = cleanPastedHtml(html, { internalClipboardToken: "test-capability" });
+    const external = cleanPastedHtml(html);
+
+    expect(internal.match(/data-docx-bookmark-boundary=/g)).toHaveLength(2);
+    expect(internal).toContain('data-field-structured="true"');
+    expect(internal).not.toContain("data-docx-internal-clipboard");
+    expect(external).not.toContain("data-docx-bookmark-");
+    expect(external).not.toContain("data-field-structured");
+    expect(external).toContain("Clause");
+  });
+
+  test("keeps an internal boundary atom and its reconstruction attributes", () => {
+    const html =
+      '<div data-pm-slice="0 0 []"><p><span data-docx-bookmark-boundary="start" data-docx-bookmark-id="12" data-docx-bookmark-name="clause" data-docx-bookmark-col-first="2" data-docx-bookmark-col-last="4" data-docx-internal-clipboard="test-capability"></span>Clause</p></div>';
+
+    const out = cleanPastedHtml(html, { internalClipboardToken: "test-capability" });
+
+    expect(out).toContain('data-docx-bookmark-boundary="start"');
+    expect(out).toContain('data-docx-bookmark-id="12"');
+    expect(out).toContain('data-docx-bookmark-name="clause"');
+    expect(out).toContain('data-docx-bookmark-col-first="2"');
+    expect(out).toContain('data-docx-bookmark-col-last="4"');
+    expect(out).not.toContain("data-docx-internal-clipboard");
+  });
+
+  test("strips reconstruction attributes from external HTML", () => {
+    const html =
+      '<p><span data-docx-bookmark-boundary="start" data-docx-bookmark-id="12" data-docx-bookmark-name="clause" data-docx-bookmark-col-first="2" data-docx-bookmark-col-last="4">marker</span>Clause</p>';
+
+    const out = cleanPastedHtml(html);
+
+    expect(out).not.toContain("data-docx-bookmark-");
+    expect(out).toContain("marker");
+    expect(out).toContain("Clause");
+  });
+
+  test("strips unquoted reconstruction attributes from external HTML", () => {
+    const out = cleanPastedHtml(
+      "<span data-docx-bookmark-boundary=start data-docx-bookmark-id=12>marker</span>",
+    );
+
+    expect(out).not.toContain("data-docx-bookmark-");
+    expect(out).toContain("marker");
+  });
+
+  test("strips a boundary from HTML with a forged ProseMirror slice marker", () => {
+    const html =
+      '<div data-pm-slice="0 0 []"><span data-docx-bookmark-boundary="start" data-docx-bookmark-id="12" data-docx-bookmark-name="clause">marker</span></div>';
+
+    const out = cleanPastedHtml(html, { internalClipboardToken: "test-capability" });
+
+    expect(out).not.toContain("data-docx-bookmark-");
+    expect(out).toContain("marker");
+  });
+});
+
+describe("removeUnpairedBookmarkBoundaries", () => {
+  const boundaryTypes = (slice: Slice): string[] => {
+    const types: string[] = [];
+    slice.content.descendants((node) => {
+      if (node.type.name === "bookmarkBoundary") {
+        types.push(`${node.attrs["type"]}:${node.attrs["id"]}`);
+      }
+      return true;
+    });
+    return types;
+  };
+
+  test.each(["start", "end"] as const)("drops a slice with only a bookmark %s", (type) => {
+    const attrs = type === "start" ? { type, id: 1, name: "one" } : { type, id: 1 };
+    const slice = new Slice(
+      Fragment.from(
+        schema.node("paragraph", null, [
+          schema.node("bookmarkBoundary", attrs),
+          schema.text("kept"),
+        ]),
+      ),
+      0,
+      0,
+    );
+
+    const filtered = removeUnpairedBookmarkBoundaries(slice);
+
+    expect(boundaryTypes(filtered)).toEqual([]);
+    expect(filtered.content.textBetween(0, filtered.content.size)).toBe("kept");
+  });
+
+  test("keeps complete crossing bookmark pairs in source order", () => {
+    const slice = new Slice(
+      Fragment.from(
+        schema.node("paragraph", null, [
+          schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" }),
+          schema.node("bookmarkBoundary", { type: "start", id: 2, name: "two" }),
+          schema.text("kept"),
+          schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+          schema.node("bookmarkBoundary", { type: "end", id: 2 }),
+        ]),
+      ),
+      0,
+      0,
+    );
+
+    expect(boundaryTypes(removeUnpairedBookmarkBoundaries(slice))).toEqual([
+      "start:1",
+      "start:2",
+      "end:1",
+      "end:2",
+    ]);
+  });
+
+  test("drops a reversed end-before-start pair", () => {
+    const slice = new Slice(
+      Fragment.from(
+        schema.node("paragraph", null, [
+          schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+          schema.text("kept"),
+          schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" }),
+        ]),
+      ),
+      0,
+      0,
+    );
+
+    expect(boundaryTypes(removeUnpairedBookmarkBoundaries(slice))).toEqual([]);
   });
 });

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -18,7 +18,10 @@
  * audience).
  */
 
+import { Fragment, Slice, type Node as PMNode } from "prosemirror-model";
+
 import { stripXmlDeclarations } from "../../../utils/stripXmlDeclarations";
+import { readBookmarkBoundaryAttrs } from "../../bookmarkBoundaryAttrs";
 
 /**
  * Remove every HTML comment, including downlevel conditional comments
@@ -165,13 +168,8 @@ const NOISE_TAG = new RegExp(`<\\/?(?:font|meta|link)${TAG_TAIL}>`, "gi");
 const EMPTY_SPAN = new RegExp(`<span(?:\\s${TAG_TAIL})?><\\/span>`, "gi");
 const MAX_EMPTY_SPAN_PASSES = 5;
 
-// ProseMirror's own clipboard serializer wraps a copied slice's top element
-// with `data-pm-slice="<openStart> <openEnd> <context>"` (see
-// prosemirror-view's `serializeForClipboard`). Its presence is the only
-// signal available at this string-transform layer that the incoming HTML
-// came from a ProseMirror editor's own copy rather than an arbitrary
-// external DOM (another app, a browser page, a hand-crafted paste).
-const PM_SLICE_MARKER = /\bdata-pm-slice\s*=/i;
+const INTERNAL_CLIPBOARD_ATTR_PATTERN =
+  /\s+data-docx-internal-clipboard(?:="([^"]*)"|='([^']*)'|=([^\s>]+))?/gi;
 
 // `data-docx-textbox-anchor` is an internal reconstruction marker
 // (`TextBoxAnchorExtension`) that `fromProseDoc` uses to relocate a
@@ -183,18 +181,50 @@ const PM_SLICE_MARKER = /\bdata-pm-slice\s*=/i;
 // hyperlink). Strip the attribute so a matching span parses as an inert,
 // zero-width `<span>` instead of a `textBoxAnchor` node.
 const TEXTBOX_ANCHOR_ATTR = /\s+data-docx-textbox-anchor(?:="[^"]*"|='[^']*')?/gi;
+// Bookmark boundaries use the same internal reconstruction pattern. Their
+// complete attribute family must either survive together in an internal slice
+// or be removed together before external HTML reaches the schema parser.
+const BOOKMARK_BOUNDARY_ATTR =
+  /\s+data-docx-bookmark-(?:boundary|id|name|col-first|col-last)(?:="[^"]*"|='[^']*'|=[^\s>]+)?/gi;
+const STRUCTURED_FIELD_ATTR = /\s+data-field-structured(?:="[^"]*"|='[^']*'|=[^\s>]+)?/gi;
 
 /**
- * Remove the `data-docx-textbox-anchor` marker from HTML that did not come
- * from a ProseMirror clipboard slice (see {@link PM_SLICE_MARKER}). Internal
- * copy/paste of a real text box carries the marker HTML unmodified so it
- * keeps working; anything else has the marker stripped defensively.
+ * Treat reconstruction attributes as internal only when the HTML carries the
+ * unguessable capability created with this editor schema. `data-pm-slice`
+ * cannot establish trust because arbitrary external HTML can forge it.
  */
-function stripForeignTextBoxAnchors(html: string, originalHtml: string): string {
-  if (PM_SLICE_MARKER.test(originalHtml)) {
+function hasInternalClipboardCapability(html: string, token: string | undefined): boolean {
+  if (!token) {
+    return false;
+  }
+  INTERNAL_CLIPBOARD_ATTR_PATTERN.lastIndex = 0;
+  for (const match of html.matchAll(INTERNAL_CLIPBOARD_ATTR_PATTERN)) {
+    if ((match[1] ?? match[2] ?? match[3]) === token) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function stripForeignTextBoxAnchors(html: string, internal: boolean): string {
+  if (internal) {
     return html;
   }
   return html.replace(TEXTBOX_ANCHOR_ATTR, "");
+}
+
+function stripForeignBookmarkBoundaries(html: string, internal: boolean): string {
+  if (internal) {
+    return html;
+  }
+  return html.replace(BOOKMARK_BOUNDARY_ATTR, "");
+}
+
+function stripForeignStructuredFields(html: string, internal: boolean): string {
+  if (internal) {
+    return html;
+  }
+  return html.replace(STRUCTURED_FIELD_ATTR, "");
 }
 
 /**
@@ -203,10 +233,18 @@ function stripForeignTextBoxAnchors(html: string, originalHtml: string): string 
  * spacer runs never collapse two words together). Repeated a bounded number of
  * times to unwrap nested empties (`<span><span></span></span>`).
  */
-function stripEmptySpans(html: string): string {
+function stripEmptySpans(html: string, preserveInternalAtoms: boolean): string {
   let current = html;
   for (let pass = 0; pass < MAX_EMPTY_SPAN_PASSES; pass++) {
-    const next = current.replace(EMPTY_SPAN, "");
+    const next = current.replace(EMPTY_SPAN, (span) => {
+      if (
+        preserveInternalAtoms &&
+        /\bdata-docx-(?:bookmark-boundary|textbox-anchor)\s*=/i.test(span)
+      ) {
+        return span;
+      }
+      return "";
+    });
     if (next === current) {
       break;
     }
@@ -218,27 +256,98 @@ function stripEmptySpans(html: string): string {
 /**
  * Strip Office/web producer cruft from a raw clipboard HTML string.
  *
- * Best-effort and non-throwing: any unexpected failure returns the original
- * markup so a paste degrades to the browser default rather than losing content.
+ * Best-effort and non-throwing: any unexpected failure returns empty markup so
+ * reconstruction capabilities and other untrusted attributes fail closed.
  * `<style>` blocks are intentionally left in place for the downstream style
  * inliner, which resolves class-based CSS before the schema parser runs.
  */
-export function cleanPastedHtml(html: string): string {
+type CleanPastedHtmlOptions = {
+  internalClipboardToken?: string;
+};
+
+export function cleanPastedHtml(html: string, options: CleanPastedHtmlOptions = {}): string {
   if (!html) {
     return html;
   }
 
   try {
+    const internal = hasInternalClipboardCapability(html, options.internalClipboardToken);
     let cleaned = stripHtmlComments(html);
     cleaned = stripXmlDeclarations(cleaned);
     cleaned = cleaned.replace(NAMESPACED_TAG, "");
     cleaned = cleaned.replace(STRAY_XML_TAG, "");
     cleaned = cleaned.replace(NOISE_TAG, "");
     cleaned = stripMsoStyles(cleaned);
-    cleaned = stripEmptySpans(cleaned);
-    cleaned = stripForeignTextBoxAnchors(cleaned, html);
+    cleaned = stripEmptySpans(cleaned, internal);
+    cleaned = stripForeignTextBoxAnchors(cleaned, internal);
+    cleaned = stripForeignBookmarkBoundaries(cleaned, internal);
+    cleaned = stripForeignStructuredFields(cleaned, internal);
+    cleaned = cleaned.replace(INTERNAL_CLIPBOARD_ATTR_PATTERN, "");
     return cleaned.trim();
   } catch {
-    return html;
+    return "";
   }
+}
+
+type BoundaryCounts = {
+  starts: number;
+  ends: number;
+  firstStart?: number;
+  firstEnd?: number;
+};
+
+/** Remove incomplete or duplicate bookmark pairs at copied slice edges. */
+export function removeUnpairedBookmarkBoundaries(slice: Slice): Slice {
+  const counts = new Map<number, BoundaryCounts>();
+  let boundaryIndex = 0;
+  slice.content.descendants((node) => {
+    if (node.type.name !== "bookmarkBoundary") {
+      return true;
+    }
+    const result = readBookmarkBoundaryAttrs(node);
+    if (!result.ok) {
+      return false;
+    }
+    const attrs = result.value;
+    const count = counts.get(attrs.id) ?? { starts: 0, ends: 0 };
+    if (attrs.type === "start") {
+      count.starts += 1;
+      count.firstStart ??= boundaryIndex;
+    } else {
+      count.ends += 1;
+      count.firstEnd ??= boundaryIndex;
+    }
+    boundaryIndex += 1;
+    counts.set(attrs.id, count);
+    return false;
+  });
+  const pairedIds = new Set(
+    [...counts].flatMap(([id, count]) =>
+      count.starts === 1 &&
+      count.ends === 1 &&
+      count.firstStart !== undefined &&
+      count.firstEnd !== undefined &&
+      count.firstStart < count.firstEnd
+        ? [id]
+        : [],
+    ),
+  );
+
+  const filterFragment = (fragment: Fragment): Fragment => {
+    const children: PMNode[] = [];
+    // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Fragment.forEach
+    fragment.forEach((node) => {
+      if (node.type.name === "bookmarkBoundary") {
+        const result = readBookmarkBoundaryAttrs(node);
+        if (result.ok && pairedIds.has(result.value.id)) {
+          children.push(node);
+        }
+        return;
+      }
+      children.push(node.childCount === 0 ? node : node.copy(filterFragment(node.content)));
+    });
+    return Fragment.fromArray(children);
+  };
+
+  return new Slice(filterFragment(slice.content), slice.openStart, slice.openEnd);
 }

--- a/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../schema";
+
+class FakeHTMLElement {
+  constructor(private readonly attrs: Readonly<Record<string, string>>) {}
+
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+}
+
+const parseBookmarkBoundary = (attrs: Readonly<Record<string, string>>) => {
+  const getAttrs = schema.nodes.bookmarkBoundary.spec.parseDOM?.at(0)?.getAttrs;
+  if (!getAttrs) {
+    throw new Error("BookmarkBoundaryExtension must define parseDOM[0].getAttrs");
+  }
+  return getAttrs(new FakeHTMLElement(attrs) as unknown as HTMLElement);
+};
+
+describe("BookmarkBoundaryExtension DOM round-trip", () => {
+  test("preserves table-column bookmark bounds", () => {
+    const attrs = {
+      type: "start",
+      id: 12,
+      name: "clause",
+      colFirst: 2,
+      colLast: 4,
+    } as const;
+    const node = schema.node("bookmarkBoundary", attrs);
+    const toDOM = node.type.spec.toDOM;
+    if (!toDOM) {
+      throw new Error("BookmarkBoundaryExtension must define toDOM");
+    }
+
+    expect(toDOM(node)).toEqual([
+      "span",
+      expect.objectContaining({
+        "data-docx-bookmark-boundary": "start",
+        "data-docx-bookmark-id": "12",
+        "data-docx-bookmark-name": "clause",
+        "data-docx-bookmark-col-first": "2",
+        "data-docx-bookmark-col-last": "4",
+        "aria-hidden": "true",
+        contenteditable: "false",
+        style: "display: none;",
+        "data-docx-internal-clipboard": expect.any(String),
+      }),
+    ]);
+    expect(
+      parseBookmarkBoundary({
+        "data-docx-bookmark-boundary": "start",
+        "data-docx-bookmark-id": "12",
+        "data-docx-bookmark-name": "clause",
+        "data-docx-bookmark-col-first": "2",
+        "data-docx-bookmark-col-last": "4",
+      }),
+    ).toEqual(attrs);
+  });
+
+  test("rejects malformed table-column bookmark bounds", () => {
+    expect(
+      parseBookmarkBoundary({
+        "data-docx-bookmark-boundary": "start",
+        "data-docx-bookmark-id": "12",
+        "data-docx-bookmark-name": "clause",
+        "data-docx-bookmark-col-first": "-1",
+      }),
+    ).toBe(false);
+    expect(
+      parseBookmarkBoundary({
+        "data-docx-bookmark-boundary": "start",
+        "data-docx-bookmark-id": "12junk",
+        "data-docx-bookmark-name": "clause",
+      }),
+    ).toBe(false);
+  });
+
+  test("shares one internal clipboard capability with text-box anchors", () => {
+    const boundary = schema.node("bookmarkBoundary", { type: "end", id: 12 });
+    const anchor = schema.node("textBoxAnchor", { anchorId: "0:0" });
+    const boundaryToDOM = boundary.type.spec.toDOM;
+    const anchorToDOM = anchor.type.spec.toDOM;
+    if (!boundaryToDOM || !anchorToDOM) {
+      throw new Error("Reconstruction atoms must define toDOM");
+    }
+
+    const boundaryDom = boundaryToDOM(boundary) as [string, Record<string, string>];
+    const anchorDom = anchorToDOM(anchor) as [string, Record<string, string>];
+
+    expect(boundaryDom[1]["data-docx-internal-clipboard"]).toBeTruthy();
+    expect(anchorDom[1]["data-docx-internal-clipboard"]).toBe(
+      boundaryDom[1]["data-docx-internal-clipboard"],
+    );
+  });
+});

--- a/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.ts
@@ -1,0 +1,91 @@
+/** Zero-width bookmark boundary that preserves its position through ProseMirror edits. */
+
+import { expectBookmarkBoundaryAttrs } from "../../bookmarkBoundaryAttrs";
+import { createNodeExtension } from "../create";
+
+type BookmarkBoundaryOptions = {
+  getInternalClipboardToken?: () => string;
+};
+
+function readNonnegativeInteger(value: string | null): number | false {
+  if (value === null || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    return false;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : false;
+}
+
+function readOptionalColumn(dom: HTMLElement, attribute: string): number | undefined | false {
+  const value = dom.getAttribute(attribute);
+  return value === null ? undefined : readNonnegativeInteger(value);
+}
+
+export const BookmarkBoundaryExtension = createNodeExtension<BookmarkBoundaryOptions>({
+  name: "bookmarkBoundary",
+  schemaNodeName: "bookmarkBoundary",
+  nodeSpec: (options) => ({
+    inline: true,
+    group: "inline",
+    marks: "_",
+    atom: true,
+    selectable: false,
+    attrs: {
+      type: {},
+      id: {},
+      name: { default: null },
+      colFirst: { default: null },
+      colLast: { default: null },
+    },
+    parseDOM: [
+      {
+        tag: "span[data-docx-bookmark-boundary]",
+        getAttrs(dom) {
+          const type = dom.getAttribute("data-docx-bookmark-boundary");
+          const id = readNonnegativeInteger(dom.getAttribute("data-docx-bookmark-id"));
+          if ((type !== "start" && type !== "end") || id === false) {
+            return false;
+          }
+          const name = dom.getAttribute("data-docx-bookmark-name");
+          if (type === "start" && !name) {
+            return false;
+          }
+          const colFirst = readOptionalColumn(dom, "data-docx-bookmark-col-first");
+          const colLast = readOptionalColumn(dom, "data-docx-bookmark-col-last");
+          if (colFirst === false || colLast === false) {
+            return false;
+          }
+          return {
+            type,
+            id,
+            ...(name ? { name } : {}),
+            ...(colFirst !== undefined ? { colFirst } : {}),
+            ...(colLast !== undefined ? { colLast } : {}),
+          };
+        },
+      },
+    ],
+    toDOM(node) {
+      const attrs = expectBookmarkBoundaryAttrs(node);
+      return [
+        "span",
+        {
+          "data-docx-bookmark-boundary": attrs.type,
+          "data-docx-bookmark-id": String(attrs.id),
+          ...(attrs.type === "start" ? { "data-docx-bookmark-name": attrs.name } : {}),
+          ...(attrs.type === "start" && attrs.colFirst !== undefined
+            ? { "data-docx-bookmark-col-first": String(attrs.colFirst) }
+            : {}),
+          ...(attrs.type === "start" && attrs.colLast !== undefined
+            ? { "data-docx-bookmark-col-last": String(attrs.colLast) }
+            : {}),
+          "aria-hidden": "true",
+          contenteditable: "false",
+          style: "display: none;",
+          ...(options.getInternalClipboardToken
+            ? { "data-docx-internal-clipboard": options.getInternalClipboardToken() }
+            : {}),
+        },
+      ];
+    },
+  }),
+});

--- a/packages/core/src/prosemirror/extensions/nodes/FieldExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/FieldExtension.test.ts
@@ -16,11 +16,13 @@ describe("FieldExtension", () => {
       throw new Error("Expected field node to provide toDOM");
     }
 
-    const domSpec = toDOM(field) as [string, Record<string, string>, string];
+    const domSpec = toDOM(field);
 
-    expect(domSpec[0]).toBe("span");
-    expect(domSpec[1]["data-field-type"]).toBe("MERGEFIELD");
-    expect(domSpec[2]).toBe("«Client Name»");
+    expect(domSpec).toEqual([
+      "span",
+      expect.objectContaining({ "data-field-type": "MERGEFIELD" }),
+      "«Client Name»",
+    ]);
   });
 
   test("keeps cached display text for fields the layout path does not recompute", () => {
@@ -36,9 +38,110 @@ describe("FieldExtension", () => {
       throw new Error("Expected field node to provide toDOM");
     }
 
-    const domSpec = toDOM(field) as [string, Record<string, string>, string];
+    const domSpec = toDOM(field);
 
-    expect(domSpec[1]["data-field-type"]).toBe("REF");
-    expect(domSpec[2]).toBe("Clause 4.2");
+    expect(domSpec).toEqual([
+      "span",
+      expect.objectContaining({ "data-field-type": "REF" }),
+      "Clause 4.2",
+    ]);
+    expect(field.textContent).toBe("Clause 4.2");
+    expect(schema.node("paragraph", null, [field]).textBetween(0, field.nodeSize)).toBe(
+      "Clause 4.2",
+    );
+  });
+
+  test("uses one fallback for an empty complex PAGE field in DOM and text semantics", () => {
+    const field = schema.node("field", {
+      fieldType: "PAGE",
+      instruction: " PAGE ",
+      displayText: "",
+      fieldKind: "complex",
+    });
+    const toDOM = field.type.spec.toDOM;
+    if (!toDOM) {
+      throw new Error("Expected field node to provide toDOM");
+    }
+
+    expect(toDOM(field)).toEqual([
+      "span",
+      expect.objectContaining({ "data-field-type": "PAGE" }),
+      "{page}",
+    ]);
+    expect(field.textContent).toBe("{page}");
+    expect(schema.node("paragraph", null, [field]).textBetween(0, field.nodeSize)).toBe("{page}");
+  });
+
+  test("preserves hyperlink bookmark boundaries through DOM serialization", () => {
+    const hyperlink = schema.mark("hyperlink", {
+      href: "https://example.test/field",
+      _docxHyperlinkIndex: 1,
+    });
+    const field = schema.node(
+      "structuredField",
+      {
+        fieldType: "REF",
+        instruction: " REF target \\h ",
+        displayText: "Target",
+        fieldKind: "simple",
+      },
+      [
+        schema.node("bookmarkBoundary", { type: "start", id: 31, name: "target" }, null, [
+          hyperlink,
+        ]),
+        schema.text("Target", [hyperlink]),
+        schema.node("bookmarkBoundary", { type: "end", id: 31 }, null, [hyperlink]),
+      ],
+    );
+    const toDOM = field.type.spec.toDOM;
+    if (!toDOM) {
+      throw new Error("FieldExtension must define toDOM");
+    }
+
+    expect(toDOM(field)).toEqual([
+      "span",
+      expect.objectContaining({
+        class: "docx-field docx-field-ref",
+        "data-field-type": "REF",
+        "data-field-structured": "true",
+        "data-instruction": " REF target \\h ",
+        "data-docx-internal-clipboard": expect.any(String),
+      }),
+      0,
+    ]);
+    expect(JSON.stringify(toDOM(field))).not.toContain("aria-hidden");
+    expect(JSON.stringify(toDOM(field))).not.toContain("Target");
+    expect(field.textContent).toBe("Target");
+    expect(field.content.toJSON().map((child) => child.type)).toEqual([
+      "bookmarkBoundary",
+      "text",
+      "bookmarkBoundary",
+    ]);
+  });
+
+  test("keeps ordinary and structured DOM parse rules disjoint", () => {
+    const parseRules = schema.nodes.field.spec.parseDOM ?? [];
+    const structuredRules = schema.nodes.structuredField.spec.parseDOM ?? [];
+    const leafRule = parseRules.at(0);
+    const structuredRule = structuredRules.at(0);
+
+    expect(structuredRule?.tag).toBe('span.docx-field[data-field-structured="true"]');
+    expect(leafRule?.tag).toBe("span.docx-field:not([data-field-structured])");
+    expect(schema.nodes.field.isLeaf).toBe(true);
+    expect(schema.nodes.structuredField.isLeaf).toBe(false);
+  });
+
+  test.each([
+    { fieldKind: "complex", hasHyperlink: true },
+    { fieldKind: "simple", hasHyperlink: false },
+  ])("rejects malformed structured field DOM ($fieldKind, link=$hasHyperlink)", (input) => {
+    const structuredRule = schema.nodes.structuredField.spec.parseDOM?.at(0);
+    const dom = Object.assign(Object.create(null), {
+      dataset: { fieldKind: input.fieldKind },
+      textContent: "forged",
+      querySelector: () => (input.hasHyperlink ? Object.create(null) : null),
+    });
+
+    expect(structuredRule?.getAttrs?.(dom)).toBe(false);
   });
 });

--- a/packages/core/src/prosemirror/extensions/nodes/FieldExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/FieldExtension.ts
@@ -1,13 +1,76 @@
 /**
- * Field Extension — inline field node (PAGE, NUMPAGES, DATE, MERGEFIELD, etc.)
+ * Field extensions — atomic inline fields (PAGE, NUMPAGES, REF, etc.).
  *
- * Represents OOXML simple and complex fields as an atomic inline node.
- * At render time, field values are substituted (e.g., PAGE → actual page number).
+ * Ordinary fields are true ProseMirror leaves, so `textContent`, `textBetween`,
+ * and the default plain-text clipboard serializer can use `leafText`.
+ * Simple fields that must preserve hyperlink structure use a distinct atomic
+ * node with inline children; their visible text comes from those children.
  */
+
+import type { Node as PMNode } from "prosemirror-model";
 
 import { parseFieldInstruction } from "../../../docx/fieldParser";
 import { expectFieldAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
+
+type StructuredFieldOptions = {
+  getInternalClipboardToken?: () => string;
+};
+
+const createFieldAttrs = () => ({
+  fieldType: { default: "UNKNOWN" },
+  instruction: { default: "" },
+  displayText: { default: "" },
+  _numberedRefBaseline: { default: undefined },
+  fieldKind: { default: "simple" },
+  fldLock: { default: false },
+  dirty: { default: false },
+});
+
+const readFieldDomAttrs = (dom: HTMLElement) => ({
+  fieldType: dom.dataset["fieldType"] ?? "UNKNOWN",
+  instruction: dom.dataset["instruction"] ?? "",
+  displayText: dom.textContent ?? "",
+  fieldKind: dom.dataset["fieldKind"] ?? "simple",
+  fldLock: dom.dataset["fldLock"] === "true",
+  dirty: dom.dataset["dirty"] === "true",
+});
+
+const getFieldDomAttrs = (node: PMNode) => {
+  const { fieldType, instruction, fieldKind, fldLock, dirty } = expectFieldAttrs(node);
+  return {
+    class: `docx-field docx-field-${fieldType.toLowerCase()}`,
+    "data-field-type": fieldType,
+    "data-instruction": instruction,
+    "data-field-kind": fieldKind,
+    ...(fldLock ? { "data-fld-lock": "true" } : {}),
+    ...(dirty ? { "data-dirty": "true" } : {}),
+    style:
+      "outline: 1px solid var(--doc-field-outline, rgba(200,200,200,0.4)); padding: 0 1px; border-radius: 2px;",
+  };
+};
+
+const getFieldVisibleText = (node: PMNode): string => {
+  const { fieldType, instruction, displayText } = expectFieldAttrs(node);
+  if (displayText) {
+    return displayText;
+  }
+  switch (fieldType) {
+    case "PAGE":
+      return "{page}";
+    case "NUMPAGES":
+      return "{pages}";
+    case "DATE":
+    case "TIME":
+    case "CREATEDATE":
+    case "SAVEDATE":
+      return new Date().toLocaleDateString();
+    case "MERGEFIELD":
+      return `«${getMergeFieldName(instruction)}»`;
+    default:
+      return `{${fieldType}}`;
+  }
+};
 
 export const FieldExtension = createNodeExtension({
   name: "field",
@@ -17,79 +80,56 @@ export const FieldExtension = createNodeExtension({
     group: "inline",
     atom: true,
     selectable: true,
-    attrs: {
-      /** Field type: PAGE, NUMPAGES, DATE, MERGEFIELD, etc. */
-      fieldType: { default: "UNKNOWN" },
-      /** Full field instruction (e.g., "PAGE \\* MERGEFORMAT") */
-      instruction: { default: "" },
-      /** Display text (the current/cached field value) */
-      displayText: { default: "" },
-      /** Whether this is a simple or complex field */
-      fieldKind: { default: "simple" },
-      /** Field is locked */
-      fldLock: { default: false },
-      /** Field is dirty (needs update) */
-      dirty: { default: false },
-    },
+    attrs: createFieldAttrs(),
+    leafText: getFieldVisibleText,
     parseDOM: [
       {
-        tag: "span.docx-field",
+        tag: "span.docx-field:not([data-field-structured])",
+        getAttrs: readFieldDomAttrs,
+      },
+    ],
+    toDOM(node) {
+      return ["span", getFieldDomAttrs(node), getFieldVisibleText(node)];
+    },
+  },
+});
+
+export const StructuredFieldExtension = createNodeExtension<StructuredFieldOptions>({
+  name: "structuredField",
+  schemaNodeName: "structuredField",
+  nodeSpec: (options) => ({
+    inline: true,
+    group: "inline",
+    content:
+      "(text | bookmarkBoundary | tab | symbol | hardBreak | image | shape | renderedPageBreak | textBoxAnchor)+",
+    atom: true,
+    selectable: true,
+    attrs: createFieldAttrs(),
+    parseDOM: [
+      {
+        tag: 'span.docx-field[data-field-structured="true"]',
         getAttrs(dom) {
-          return {
-            fieldType: dom.dataset["fieldType"] ?? "UNKNOWN",
-            instruction: dom.dataset["instruction"] ?? "",
-            displayText: dom.textContent,
-            fieldKind: dom.dataset["fieldKind"] ?? "simple",
-            fldLock: dom.dataset["fldLock"] === "true",
-            dirty: dom.dataset["dirty"] === "true",
-          };
+          if (dom.dataset["fieldKind"] !== "simple" || !dom.querySelector("a[href]")) {
+            return false;
+          }
+          return readFieldDomAttrs(dom);
         },
       },
     ],
     toDOM(node) {
-      const { fieldType, instruction, displayText, fieldKind, fldLock, dirty } =
-        expectFieldAttrs(node);
-
-      // Dynamic fields show a placeholder; static fields show their display text
-      let text = displayText || "";
-      if (!text) {
-        switch (fieldType) {
-          case "PAGE":
-            text = "{page}";
-            break;
-          case "NUMPAGES":
-            text = "{pages}";
-            break;
-          case "DATE":
-          case "TIME":
-          case "CREATEDATE":
-          case "SAVEDATE":
-            text = new Date().toLocaleDateString();
-            break;
-          case "MERGEFIELD":
-            text = `«${getMergeFieldName(instruction)}»`;
-            break;
-          default:
-            text = `{${fieldType}}`;
-        }
-      }
-
       return [
         "span",
         {
-          class: `docx-field docx-field-${fieldType.toLowerCase()}`,
-          "data-field-type": fieldType,
-          "data-instruction": instruction,
-          "data-field-kind": fieldKind,
-          ...(fldLock ? { "data-fld-lock": "true" } : {}),
-          ...(dirty ? { "data-dirty": "true" } : {}),
-          style:
-            "outline: 1px solid var(--doc-field-outline, rgba(200,200,200,0.4)); padding: 0 1px; border-radius: 2px;",
+          ...getFieldDomAttrs(node),
+          "data-field-structured": "true",
+          ...(options.getInternalClipboardToken
+            ? { "data-docx-internal-clipboard": options.getInternalClipboardToken() }
+            : {}),
         },
-        text,
+        0,
       ];
     },
-  },
+  }),
 });
 
 function getMergeFieldName(instruction: string): string {

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
@@ -9,10 +9,14 @@
 import { expectTextBoxAnchorAttrs } from "../../textBoxAnchorAttrs";
 import { createNodeExtension } from "../create";
 
-export const TextBoxAnchorExtension = createNodeExtension({
+type TextBoxAnchorOptions = {
+  getInternalClipboardToken?: () => string;
+};
+
+export const TextBoxAnchorExtension = createNodeExtension<TextBoxAnchorOptions>({
   name: "textBoxAnchor",
   schemaNodeName: "textBoxAnchor",
-  nodeSpec: {
+  nodeSpec: (options) => ({
     inline: true,
     group: "inline",
     marks: "_",
@@ -43,8 +47,11 @@ export const TextBoxAnchorExtension = createNodeExtension({
           contenteditable: "false",
           style:
             "display: inline-block; width: 0; height: 0; overflow: hidden; pointer-events: none;",
+          ...(options.getInternalClipboardToken
+            ? { "data-docx-internal-clipboard": options.getInternalClipboardToken() }
+            : {}),
         },
       ];
     },
-  },
+  }),
 });

--- a/packages/core/src/prosemirror/listMarker.ts
+++ b/packages/core/src/prosemirror/listMarker.ts
@@ -1,0 +1,326 @@
+import { formatOoxmlCounter } from "../docx/ooxmlCounterFormatter";
+import { convertBulletToUnicode } from "../docx/bulletMarkers";
+import type { NumberFormat } from "../types/document";
+import type { ParagraphAttrs } from "./schema/nodes";
+
+export type ListCounterState = {
+  counters: Map<number, number[]>;
+  abstractCounters: Map<number, number[]>;
+  seenLevels: Set<string>;
+  lastAdvancedNumId?: number;
+};
+
+export type ListCounterStreams = {
+  final: ListCounterState;
+  original: ListCounterState;
+};
+
+export type ListCounterStream = keyof ListCounterStreams;
+
+export type AdvancedListMarker = {
+  marker: string | null;
+  counterAttrs: ParagraphAttrs;
+  counterState: ListCounterState;
+  stream: ListCounterStream;
+};
+
+export type VisibleListMarker = {
+  marker: string | null;
+  counterAttrs: ParagraphAttrs;
+  counterState: ListCounterState;
+  stream: ListCounterStream;
+  advances: readonly AdvancedListMarker[];
+};
+
+export type ResolvedListComponent = {
+  level: number;
+  relativeStart: number;
+  start: number;
+  end: number;
+};
+
+export type ResolvedListTemplate = {
+  value: string;
+  components: readonly ResolvedListComponent[];
+};
+
+export const MAX_LIST_LEVEL = 8;
+
+export function createListCounterState(): ListCounterState {
+  return {
+    counters: new Map(),
+    abstractCounters: new Map(),
+    seenLevels: new Set(),
+  };
+}
+
+export function cloneListCounterState(state: ListCounterState): ListCounterState {
+  const counters = new Map<number, number[]>();
+  for (const [numId, values] of state.counters) {
+    counters.set(numId, [...values]);
+  }
+  const abstractCounters = new Map<number, number[]>();
+  for (const [abstractNumId, values] of state.abstractCounters) {
+    abstractCounters.set(abstractNumId, [...values]);
+  }
+  return {
+    counters,
+    abstractCounters,
+    seenLevels: new Set(state.seenLevels),
+    ...(state.lastAdvancedNumId !== undefined
+      ? { lastAdvancedNumId: state.lastAdvancedNumId }
+      : {}),
+  };
+}
+
+const isListNumPr = (
+  value: ParagraphAttrs["numPr"] | null | undefined,
+): value is NonNullable<ParagraphAttrs["numPr"]> => value !== undefined && value !== null;
+
+const sameListNumPr = (
+  left: NonNullable<ParagraphAttrs["numPr"]>,
+  right: NonNullable<ParagraphAttrs["numPr"]>,
+): boolean => left.numId === right.numId && left.ilvl === right.ilvl;
+
+function previousListAttrs(attrs: ParagraphAttrs): ParagraphAttrs | null {
+  const change = attrs._propertyChanges?.find(({ previousFormatting }) => {
+    const previousNumPr = previousFormatting?.numPr;
+    return (
+      isListNumPr(previousNumPr) && (!attrs.numPr || !sameListNumPr(previousNumPr, attrs.numPr))
+    );
+  });
+  const previous = change?.previousFormatting;
+  if (!previous || !isListNumPr(previous.numPr)) {
+    return null;
+  }
+  return {
+    numPr: previous.numPr,
+    ...(previous.listIsBullet !== undefined ? { listIsBullet: previous.listIsBullet } : {}),
+    ...(previous.listIsLegal !== undefined ? { listIsLegal: previous.listIsLegal } : {}),
+    ...(previous.listNumFmt !== undefined ? { listNumFmt: previous.listNumFmt } : {}),
+    ...(previous.listMarker !== undefined ? { listMarker: previous.listMarker } : {}),
+    ...(previous.listMarkerHidden !== undefined
+      ? { listMarkerHidden: previous.listMarkerHidden }
+      : {}),
+    ...(previous.listLevelNumFmts !== undefined
+      ? { listLevelNumFmts: previous.listLevelNumFmts }
+      : {}),
+    ...(previous.listLevelStarts !== undefined
+      ? { listLevelStarts: previous.listLevelStarts }
+      : {}),
+    ...(previous.listAbstractNumId !== undefined
+      ? { listAbstractNumId: previous.listAbstractNumId }
+      : {}),
+    ...(previous.listStartOverride !== undefined
+      ? { listStartOverride: previous.listStartOverride }
+      : {}),
+  };
+}
+
+/**
+ * Advance the counter stream that paints this paragraph's marker. Normal
+ * paragraphs advance both final and original streams; inserted/deleted list
+ * paragraphs advance only the document view in which they exist.
+ */
+export function advanceVisibleListMarker(
+  attrs: ParagraphAttrs,
+  streams: ListCounterStreams,
+): VisibleListMarker {
+  const advances: AdvancedListMarker[] = [];
+  const advance = (counterAttrs: ParagraphAttrs, stream: ListCounterStream): AdvancedListMarker => {
+    const counterState = streams[stream];
+    const advanced = {
+      marker: advanceListMarker(counterAttrs, counterState),
+      counterAttrs,
+      counterState,
+      stream,
+    };
+    advances.push(advanced);
+    return advanced;
+  };
+  const previous = previousListAttrs(attrs);
+  if (!attrs.numPr) {
+    const counterAttrs = previous ?? attrs;
+    const visible = advance(counterAttrs, previous ? "original" : "final");
+    return { ...visible, advances };
+  }
+
+  if (attrs.pPrMark?.kind === "del") {
+    const visible = advance(attrs, "original");
+    return { ...visible, advances };
+  }
+
+  const numberingWasAdded = attrs._propertyChanges?.some(
+    ({ previousFormatting }) =>
+      previousFormatting &&
+      Object.hasOwn(previousFormatting, "numPr") &&
+      previousFormatting.numPr == null,
+  );
+  const numberingChanged =
+    previous?.numPr !== undefined && !sameListNumPr(previous.numPr, attrs.numPr);
+  const visible = advance(attrs, "final");
+  if (attrs.pPrMark?.kind !== "ins" && !numberingWasAdded && !numberingChanged) {
+    advance(attrs, "original");
+  } else if (numberingChanged && previous) {
+    advance(previous, "original");
+  }
+  return { ...visible, advances };
+}
+
+export function formatCounter(value: number, format: NumberFormat | undefined): string {
+  return formatOoxmlCounter(value, format);
+}
+
+type ResolveListTemplateOptions = {
+  template: string;
+  counters: number[];
+  levelFormats?: NumberFormat[] | undefined;
+  forceDecimal?: boolean | undefined;
+};
+
+export function resolveListTemplate(options: ResolveListTemplateOptions): string {
+  return resolveListTemplateWithComponents(options).value;
+}
+
+export function resolveListTemplateWithComponents({
+  template,
+  counters,
+  levelFormats,
+  forceDecimal = false,
+}: ResolveListTemplateOptions): ResolvedListTemplate {
+  const components: ResolvedListComponent[] = [];
+  let value = "";
+  let sourceEnd = 0;
+  for (const match of template.matchAll(/%(?<digit>\d)(?<punct>[.):\]])?/gu)) {
+    const sourceStart = match.index;
+    const relativeStart = value.length;
+    value += template.slice(sourceEnd, sourceStart);
+    sourceEnd = sourceStart + match[0].length;
+
+    const index = Number.parseInt(match.groups?.["digit"] ?? "", 10) - 1;
+    if (index < 0) {
+      continue;
+    }
+    const counter = counters[index];
+    if (counter === undefined || Number.isNaN(counter)) {
+      continue;
+    }
+    const formatted = formatCounter(counter, forceDecimal ? "decimal" : levelFormats?.[index]);
+    if (!formatted) {
+      continue;
+    }
+    const start = value.length;
+    value += formatted;
+    components.push({ level: index, relativeStart, start, end: value.length });
+    value += match.groups?.["punct"] ?? "";
+  }
+  value += template.slice(sourceEnd);
+  return { value, components };
+}
+
+function getLastListCounters(state: ListCounterState): number[] | undefined {
+  return state.lastAdvancedNumId === undefined
+    ? undefined
+    : state.counters.get(state.lastAdvancedNumId);
+}
+
+function formatNumberedMarker(counters: number[], level: number): string {
+  const parts: number[] = [];
+  for (let index = 0; index <= level; index += 1) {
+    const value = counters[index] ?? 0;
+    if (!Number.isFinite(value) || value <= 0) {
+      break;
+    }
+    parts.push(value);
+  }
+  return parts.length === 0 ? "1." : `${parts.join(".")}.`;
+}
+
+export function advanceListMarker(attrs: ParagraphAttrs, state: ListCounterState): string | null {
+  const level = attrs.numPr?.ilvl ?? 0;
+  if (!Number.isInteger(level) || level < 0 || level > MAX_LIST_LEVEL) {
+    return null;
+  }
+  const numId = attrs.numPr?.numId;
+  if (numId === undefined || numId === 0) {
+    if (attrs.listMarker?.includes("%") && !attrs.listIsBullet) {
+      const counters = getLastListCounters(state);
+      if (counters) {
+        return resolveListTemplate({
+          template: attrs.listMarker,
+          counters,
+          levelFormats: attrs.listLevelNumFmts,
+          forceDecimal: attrs.listIsLegal,
+        });
+      }
+    }
+    return null;
+  }
+
+  if (attrs.listIsBullet) {
+    return convertBulletToUnicode(attrs.listMarker ?? "");
+  }
+
+  const counters = state.counters.get(numId) ?? Array.from({ length: 9 }, () => Number.NaN);
+  const abstractNumId = attrs.listAbstractNumId;
+  if (level > 0) {
+    const latestAbstractCounters =
+      abstractNumId === undefined ? undefined : state.abstractCounters.get(abstractNumId);
+    if (counters.slice(0, level).every((counter) => !Number.isFinite(counter))) {
+      for (let index = 0; index < level; index += 1) {
+        const latestCounter = latestAbstractCounters?.[index];
+        counters[index] =
+          latestCounter !== undefined && Number.isFinite(latestCounter)
+            ? latestCounter
+            : (attrs.listLevelStarts?.[index] ?? 1);
+      }
+    }
+  }
+
+  const seenKey = `${numId}:${level}`;
+  if (!state.seenLevels.has(seenKey)) {
+    state.seenLevels.add(seenKey);
+    if (attrs.listStartOverride != null) {
+      counters[level] = attrs.listStartOverride - 1;
+    }
+  }
+  if (!Number.isFinite(counters[level])) {
+    counters[level] = (attrs.listLevelStarts?.[level] ?? 1) - 1;
+  }
+
+  counters[level] = (counters[level] ?? 0) + 1;
+  for (let index = level + 1; index < counters.length; index += 1) {
+    counters[index] = Number.NaN;
+  }
+  const childAdvances = attrs.listImplicitChildLevelAdvances ?? 0;
+  if (childAdvances > 0 && level + 1 < counters.length) {
+    const childCounter = counters[level + 1];
+    counters[level + 1] =
+      (childCounter === undefined || !Number.isFinite(childCounter) ? 0 : childCounter) +
+      childAdvances;
+  }
+  state.counters.set(numId, counters);
+  state.lastAdvancedNumId = numId;
+  if (abstractNumId !== undefined) {
+    state.abstractCounters.set(abstractNumId, [...counters]);
+  }
+
+  const levelFormats =
+    attrs.listLevelNumFmts ?? (attrs.listNumFmt ? [attrs.listNumFmt] : undefined);
+  if (attrs.listMarker?.includes("%")) {
+    return resolveListTemplate({
+      template: attrs.listMarker,
+      counters,
+      levelFormats,
+      forceDecimal: attrs.listIsLegal,
+    });
+  }
+  if (attrs.listMarker) {
+    return attrs.listMarker;
+  }
+  const levelFormat = levelFormats?.[level] ?? attrs.listNumFmt;
+  if (levelFormat === "none" || attrs.listMarker === "") {
+    return null;
+  }
+  return formatNumberedMarker(counters, level);
+}

--- a/packages/core/src/prosemirror/numberedRefFields.test.ts
+++ b/packages/core/src/prosemirror/numberedRefFields.test.ts
@@ -1,0 +1,582 @@
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type {
+  ComplexField,
+  Document,
+  Hyperlink,
+  Paragraph,
+  ParagraphContent,
+  SimpleField,
+} from "../types/document";
+import { toFlowBlocks } from "../layout-bridge/convert/toFlowBlocks";
+import { fromProseDoc } from "./conversion/fromProseDoc";
+import { toProseDoc } from "./conversion/toProseDoc";
+import { parseNumberedRefInstruction, resolveNumberedRefFields } from "./numberedRefFields";
+
+const textRun = (text: string) => ({
+  type: "run" as const,
+  content: [{ type: "text" as const, text }],
+});
+
+function numberedParagraph(options: {
+  text: string;
+  level: number;
+  marker: string;
+  bookmark?: string;
+  numId?: number;
+  abstractNumId?: number;
+  startOverride?: number;
+  decimalLevels?: boolean;
+  pPrMark?: Paragraph["pPrMark"];
+}): Paragraph {
+  const bookmarkContent: ParagraphContent[] = options.bookmark
+    ? [
+        { type: "bookmarkStart", id: options.level + 1, name: options.bookmark },
+        textRun(options.text),
+        { type: "bookmarkEnd", id: options.level + 1 },
+      ]
+    : [textRun(options.text)];
+  return {
+    type: "paragraph",
+    formatting: { numPr: { numId: options.numId ?? 5, ilvl: options.level } },
+    content: bookmarkContent,
+    listRendering: {
+      marker: options.marker,
+      level: options.level,
+      numId: options.numId ?? 5,
+      abstractNumId: options.abstractNumId ?? 7,
+      isBullet: false,
+      numFmt: options.decimalLevels || options.level !== 2 ? "decimal" : "lowerLetter",
+      levelNumFmts: options.decimalLevels
+        ? ["decimal", "decimal", "decimal"]
+        : ["decimal", "decimal", "lowerLetter"],
+      levelStarts: [1, 1, 1],
+      ...(options.startOverride === undefined ? {} : { startOverride: options.startOverride }),
+    },
+    ...(options.pPrMark ? { pPrMark: options.pPrMark } : {}),
+  };
+}
+
+function refField(
+  instruction: string,
+  displayText: string,
+  kind: "simple" | "complex" = "complex",
+): SimpleField | ComplexField {
+  if (kind === "simple") {
+    return {
+      type: "simpleField",
+      instruction,
+      fieldType: "REF",
+      content: [textRun(displayText)],
+    };
+  }
+  return {
+    type: "complexField",
+    instruction,
+    fieldType: "REF",
+    fieldCode: [],
+    fieldResult: [textRun(displayText)],
+  };
+}
+
+function documentOf(content: Paragraph[]): Document {
+  return { package: { document: { content } } };
+}
+
+function fieldFallbacks(pmDoc: PMNode): string[] {
+  return toFlowBlocks(pmDoc).flatMap((block) =>
+    block.kind === "paragraph"
+      ? block.runs.flatMap((run) => (run.kind === "field" ? [run.fallback ?? ""] : []))
+      : [],
+  );
+}
+
+function savedFieldTexts(pmDoc: PMNode): string[] {
+  const model = fromProseDoc(pmDoc);
+  return model.package.document.content.flatMap((block) => {
+    if (block.type !== "paragraph") {
+      return [];
+    }
+    return block.content.flatMap((content) => {
+      let runs: SimpleField["content"] | ComplexField["fieldResult"] = [];
+      if (content.type === "simpleField") {
+        runs = content.content;
+      } else if (content.type === "complexField") {
+        runs = content.fieldResult;
+      }
+      return runs.flatMap((run) =>
+        run.type === "run"
+          ? run.content.flatMap((item) => (item.type === "text" ? [item.text] : []))
+          : [],
+      );
+    });
+  });
+}
+
+function resolvedFieldValues(pmDoc: PMNode): (string | undefined)[] {
+  const resolved = resolveNumberedRefFields(pmDoc);
+  const values: (string | undefined)[] = [];
+  pmDoc.descendants((node) => {
+    if (node.type.name !== "field" && node.type.name !== "structuredField") {
+      return true;
+    }
+    values.push(resolved.get(node));
+    return false;
+  });
+  return values;
+}
+
+describe("numbered REF instructions", () => {
+  test("accepts one numbered switch and inert hyperlink/format switches", () => {
+    expect(parseNumberedRefInstruction(' ref "clause-a" \\w \\h \\* MERGEFORMAT ')).toEqual({
+      bookmark: "clause-a",
+      numberSwitch: "w",
+    });
+    expect(parseNumberedRefInstruction("REF clause-a \\n")?.numberSwitch).toBe("n");
+    expect(parseNumberedRefInstruction("REF clause-a \\r")?.numberSwitch).toBe("r");
+  });
+
+  test("fails closed for ambiguous or unsupported instructions", () => {
+    expect(parseNumberedRefInstruction("REF clause-a \\n \\w")).toBeNull();
+    expect(parseNumberedRefInstruction("REF clause-a \\t \\w")).toBeNull();
+    expect(parseNumberedRefInstruction(`REF ${"a".repeat(257)} \\w`)).toBeNull();
+  });
+});
+
+describe("numbered REF projection", () => {
+  test("uses the same tracked-change counter stream as the visible marker", () => {
+    const inserted = {
+      kind: "ins",
+      info: { id: 1, author: "Reviewer", date: "2026-08-29T10:00:00Z" },
+    } as const;
+    const deleted = {
+      kind: "del",
+      info: { id: 2, author: "Reviewer", date: "2026-08-29T10:01:00Z" },
+    } as const;
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Inserted one", level: 0, marker: "%1.", pPrMark: inserted }),
+        numberedParagraph({ text: "Inserted two", level: 0, marker: "%1.", pPrMark: inserted }),
+        numberedParagraph({
+          text: "Deleted target",
+          level: 0,
+          marker: "%1.",
+          bookmark: "deleted-target",
+          pPrMark: deleted,
+        }),
+        { type: "paragraph", content: [refField(" REF deleted-target \\n ", "1")] },
+      ]),
+    );
+
+    const blocks = toFlowBlocks(pmDoc);
+    const markers = blocks.flatMap((block) =>
+      block.kind === "paragraph" && block.attrs?.listMarker ? [block.attrs.listMarker] : [],
+    );
+
+    expect(markers).toEqual(["1.", "2.", "1."]);
+    expect(resolvedFieldValues(pmDoc)).toEqual(["1"]);
+    expect(fieldFallbacks(pmDoc)).toEqual(["1"]);
+  });
+
+  test("keeps full-number contexts separate for final and original tracked streams", () => {
+    const inserted = {
+      kind: "ins",
+      info: { id: 1, author: "Reviewer", date: "2026-08-29T10:00:00Z" },
+    } as const;
+    const deleted = {
+      kind: "del",
+      info: { id: 2, author: "Reviewer", date: "2026-08-29T10:01:00Z" },
+    } as const;
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Original parent", level: 0, marker: "%1.", startOverride: 5 }),
+        numberedParagraph({ text: "Inserted parent", level: 0, marker: "%1.", pPrMark: inserted }),
+        numberedParagraph({
+          text: "Deleted child",
+          level: 1,
+          marker: "%2.",
+          bookmark: "deleted-child",
+          pPrMark: deleted,
+        }),
+        { type: "paragraph", content: [refField(" REF deleted-child \\w ", "5.1")] },
+      ]),
+    );
+
+    const blocks = toFlowBlocks(pmDoc);
+    const markers = blocks.flatMap((block) =>
+      block.kind === "paragraph" && block.attrs?.listMarker ? [block.attrs.listMarker] : [],
+    );
+
+    expect(markers).toEqual(["5.", "6.", "1."]);
+    expect(resolvedFieldValues(pmDoc)).toEqual(["5.1"]);
+    expect(fieldFallbacks(pmDoc)).toEqual(["5.1"]);
+  });
+
+  test("distinguishes current-level and full-context values", () => {
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Article", level: 0, marker: "%1." }),
+        numberedParagraph({ text: "Section", level: 1, marker: "%1.%2" }),
+        numberedParagraph({ text: "Clause", level: 2, marker: "(%3)", bookmark: "clause" }),
+        {
+          type: "paragraph",
+          content: [
+            refField(" REF clause \\n ", "(a)", "simple"),
+            refField(" REF clause \\w ", "1.1(a)"),
+          ],
+        },
+      ]),
+    );
+
+    expect(fieldFallbacks(pmDoc)).toEqual(["(a)", "1.1(a)"]);
+    expect(savedFieldTexts(pmDoc)).toEqual(["(a)", "1.1(a)"]);
+  });
+
+  test("resolves relative numbering from the REF field paragraph", () => {
+    const sharedAncestorSource = numberedParagraph({
+      text: "Source 4.3.1",
+      level: 2,
+      marker: "%1.%2.%3.",
+      decimalLevels: true,
+    });
+    sharedAncestorSource.content.push(refField(" REF target \\r ", "5.2"));
+    const sameParentSource = numberedParagraph({
+      text: "Source 4.5.1",
+      level: 2,
+      marker: "%1.%2.%3.",
+      decimalLevels: true,
+    });
+    sameParentSource.content.push(refField(" REF target \\r ", "2"));
+
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({
+          text: "Root 4",
+          level: 0,
+          marker: "%1.",
+          startOverride: 4,
+          decimalLevels: true,
+        }),
+        numberedParagraph({
+          text: "Branch 4.3",
+          level: 1,
+          marker: "%1.%2.",
+          startOverride: 3,
+          decimalLevels: true,
+        }),
+        sharedAncestorSource,
+        numberedParagraph({
+          text: "Branch 4.4",
+          level: 1,
+          marker: "%1.%2.",
+          decimalLevels: true,
+        }),
+        numberedParagraph({
+          text: "Branch 4.5",
+          level: 1,
+          marker: "%1.%2.",
+          decimalLevels: true,
+        }),
+        sameParentSource,
+        numberedParagraph({
+          text: "Target 4.5.2",
+          level: 2,
+          marker: "%1.%2.%3.",
+          bookmark: "target",
+          decimalLevels: true,
+        }),
+      ]),
+    );
+
+    expect(resolvedFieldValues(pmDoc)).toEqual(["5.2", "2"]);
+    expect(fieldFallbacks(pmDoc)).toEqual(["5.2", "2"]);
+    expect(savedFieldTexts(pmDoc)).toEqual(["5.2", "2"]);
+  });
+
+  test("uses full context when no numbered prefix is shared", () => {
+    const source = numberedParagraph({
+      text: "Source 4.1",
+      level: 1,
+      marker: "%1.%2.",
+      decimalLevels: true,
+    });
+    source.content.push(refField(" REF target \\r ", "5.1"));
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({
+          text: "Root 4",
+          level: 0,
+          marker: "%1.",
+          startOverride: 4,
+          decimalLevels: true,
+        }),
+        source,
+        numberedParagraph({
+          text: "Root 5",
+          level: 0,
+          marker: "%1.",
+          decimalLevels: true,
+        }),
+        numberedParagraph({
+          text: "Target 5.1",
+          level: 1,
+          marker: "%1.%2.",
+          bookmark: "target",
+          decimalLevels: true,
+        }),
+      ]),
+    );
+
+    expect(resolvedFieldValues(pmDoc)).toEqual(["5.1"]);
+  });
+
+  test("uses provable full context without a source numbering context", () => {
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({
+          text: "Target",
+          level: 0,
+          marker: "%1.",
+          bookmark: "target",
+        }),
+        { type: "paragraph", content: [refField(" REF target \\r ", "1")] },
+      ]),
+    );
+
+    expect(resolvedFieldValues(pmDoc)).toEqual(["1"]);
+    expect(fieldFallbacks(pmDoc)).toEqual(["1"]);
+    expect(savedFieldTexts(pmDoc)).toEqual(["1"]);
+  });
+
+  test("derives relative suffixes from counter components across variant templates", () => {
+    const source = numberedParagraph({
+      text: "Source",
+      level: 2,
+      marker: "Clause %1.%2.%3.",
+      decimalLevels: true,
+    });
+    source.content.push(refField(" REF target \\r ", "5-2"));
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({
+          text: "Root",
+          level: 0,
+          marker: "Article %1.",
+          startOverride: 4,
+          decimalLevels: true,
+        }),
+        numberedParagraph({
+          text: "Source branch",
+          level: 1,
+          marker: "Part %1/%2.",
+          startOverride: 3,
+          decimalLevels: true,
+        }),
+        source,
+        numberedParagraph({
+          text: "Target branch",
+          level: 1,
+          marker: "Division %1:%2.",
+          numId: 6,
+          startOverride: 5,
+          decimalLevels: true,
+        }),
+        numberedParagraph({
+          text: "Target",
+          level: 2,
+          marker: "§ %1-%2-%3.",
+          bookmark: "target",
+          numId: 6,
+          startOverride: 2,
+          decimalLevels: true,
+        }),
+      ]),
+    );
+
+    expect(resolvedFieldValues(pmDoc)).toEqual(["5-2"]);
+    expect(fieldFallbacks(pmDoc)).toEqual(["5-2"]);
+  });
+
+  test("keeps current-level spelling around a same-parent relative number", () => {
+    const source = numberedParagraph({ text: "Source", level: 2, marker: "(%3)" });
+    source.content.push(refField(" REF target \\r ", "(b)"));
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Root", level: 0, marker: "%1." }),
+        numberedParagraph({ text: "Parent", level: 1, marker: "%1.%2." }),
+        source,
+        numberedParagraph({ text: "Target", level: 2, marker: "(%3)", bookmark: "target" }),
+      ]),
+    );
+
+    expect(resolvedFieldValues(pmDoc)).toEqual(["(b)"]);
+  });
+
+  test("uses the layout caller's preseeded continuation state", () => {
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Target", level: 0, marker: "%1.", bookmark: "target" }),
+        { type: "paragraph", content: [refField(" REF target \\w ", "8")] },
+      ]),
+    );
+    const listCounters = new Map([[5, [7, ...Array.from({ length: 8 }, () => Number.NaN)]]]);
+    const blocks = toFlowBlocks(pmDoc, {
+      listCounters,
+      listAbstractCounters: new Map([[7, [7, ...Array.from({ length: 8 }, () => Number.NaN)]]]),
+      listSeenNumIds: new Set(["5:0"]),
+    });
+
+    expect(
+      blocks.flatMap((block) =>
+        block.kind === "paragraph" && block.attrs?.listMarker ? [block.attrs.listMarker] : [],
+      ),
+    ).toEqual(["8."]);
+    expect(
+      blocks.flatMap((block) =>
+        block.kind === "paragraph"
+          ? block.runs.flatMap((run) => (run.kind === "field" ? [run.fallback] : []))
+          : [],
+      ),
+    ).toEqual(["8"]);
+    expect(listCounters.get(5)?.at(0)).toBe(8);
+  });
+
+  test("keeps bookmark targets nested in hyperlinks through layout and round-trip", () => {
+    const hyperlink = {
+      type: "hyperlink",
+      href: "https://example.test",
+      children: [
+        textRun("before"),
+        { type: "bookmarkStart", id: 41, name: "linked-target", colFirst: 2, colLast: 3 },
+        textRun("inside"),
+        { type: "bookmarkEnd", id: 41 },
+        textRun("after"),
+      ],
+    } as const satisfies Hyperlink;
+    const target = numberedParagraph({ text: "unused", level: 0, marker: "%1." });
+    target.content = [hyperlink];
+    const pmDoc = toProseDoc(
+      documentOf([
+        target,
+        { type: "paragraph", content: [refField(" REF linked-target \\w ", "1")] },
+      ]),
+    );
+
+    expect(fieldFallbacks(pmDoc)).toEqual(["1"]);
+    expect(
+      Array.from(
+        { length: pmDoc.child(0).childCount },
+        (_, index) => pmDoc.child(0).child(index).type.name,
+      ),
+    ).toEqual(["text", "bookmarkBoundary", "text", "bookmarkBoundary", "text"]);
+    expect(
+      pmDoc
+        .child(0)
+        .child(1)
+        .marks.some((mark) => mark.type.name === "hyperlink"),
+    ).toBe(true);
+    const cloned = pmDoc.type.schema.nodeFromJSON(pmDoc.toJSON());
+    expect(fieldFallbacks(cloned)).toEqual(["1"]);
+    const saved = fromProseDoc(cloned);
+    const savedTarget = saved.package.document.content.at(0);
+    expect(savedTarget?.type === "paragraph" ? savedTarget.content : null).toEqual([hyperlink]);
+    expect(fieldFallbacks(toProseDoc(saved))).toEqual(["1"]);
+  });
+
+  test("resolves a bookmark target nested in a simple-field hyperlink", () => {
+    const field = {
+      type: "simpleField",
+      instruction: " DOCVARIABLE target ",
+      fieldType: "DOCVARIABLE",
+      content: [
+        {
+          type: "hyperlink",
+          anchor: "field-target",
+          children: [
+            { type: "bookmarkStart", id: 42, name: "field-target" },
+            textRun("inside"),
+            { type: "bookmarkEnd", id: 42 },
+          ],
+        },
+      ],
+    } as const satisfies SimpleField;
+    const target = numberedParagraph({ text: "unused", level: 0, marker: "%1." });
+    target.content = [field];
+    const pmDoc = toProseDoc(
+      documentOf([
+        target,
+        { type: "paragraph", content: [refField(" REF field-target \\w ", "1")] },
+      ]),
+    );
+
+    expect(resolvedFieldValues(pmDoc)).toEqual([undefined, "1"]);
+    const cloned = pmDoc.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(pmDoc.toJSON())));
+    const savedTarget = fromProseDoc(cloned).package.document.content.at(0);
+    expect(savedTarget?.type === "paragraph" ? savedTarget.content : null).toEqual([field]);
+  });
+
+  test("keeps authored caches when a target or calibration is unavailable", () => {
+    const pmDoc = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Target", level: 0, marker: "%1.", bookmark: "target" }),
+        {
+          type: "paragraph",
+          content: [
+            refField(" REF target \\w ", "Section 1"),
+            refField(" REF missing \\w ", "missing-cache"),
+            refField(" REF target \\t \\w ", "unsupported-cache"),
+          ],
+        },
+      ]),
+    );
+
+    expect(fieldFallbacks(pmDoc)).toEqual(["Section 1", "missing-cache", "unsupported-cache"]);
+    expect(savedFieldTexts(pmDoc)).toEqual(["Section 1", "missing-cache", "unsupported-cache"]);
+  });
+
+  test("the first bookmark declaration wins even when it is not numbered", () => {
+    const pmDoc = toProseDoc(
+      documentOf([
+        {
+          type: "paragraph",
+          content: [
+            { type: "bookmarkStart", id: 2, name: "duplicate" },
+            textRun("First"),
+            { type: "bookmarkEnd", id: 2 },
+          ],
+        },
+        numberedParagraph({
+          text: "Second",
+          level: 0,
+          marker: "%1.",
+          bookmark: "duplicate",
+        }),
+        { type: "paragraph", content: [refField(" REF duplicate \\w ", "kept")] },
+      ]),
+    );
+
+    expect(fieldFallbacks(pmDoc)).toEqual(["kept"]);
+    expect(savedFieldTexts(pmDoc)).toEqual(["kept"]);
+  });
+
+  test("a calibrated field follows renumbering and refreshes the saved cache", () => {
+    const initial = toProseDoc(
+      documentOf([
+        numberedParagraph({ text: "Before", level: 0, marker: "%1." }),
+        numberedParagraph({ text: "Target", level: 0, marker: "%1.", bookmark: "target" }),
+        { type: "paragraph", content: [refField(" REF target \\w ", "2")] },
+      ]),
+    );
+    expect(fieldFallbacks(initial)).toEqual(["2"]);
+
+    const cloned = initial.type.schema.nodeFromJSON(JSON.parse(JSON.stringify(initial.toJSON())));
+    expect(fieldFallbacks(cloned)).toEqual(fieldFallbacks(initial));
+    const target = cloned.child(1);
+    const reference = cloned.child(2);
+    const renumbered = cloned.type.create(cloned.attrs, [target, reference]);
+
+    expect(fieldFallbacks(renumbered)).toEqual(["1"]);
+    expect(savedFieldTexts(renumbered)).toEqual(["1"]);
+  });
+});

--- a/packages/core/src/prosemirror/numberedRefFields.ts
+++ b/packages/core/src/prosemirror/numberedRefFields.ts
@@ -1,0 +1,493 @@
+import { Fragment, type Node as PMNode } from "prosemirror-model";
+
+import { expectBookmarkBoundaryAttrs } from "./bookmarkBoundaryAttrs";
+import { expectFieldAttrs, expectParagraphAttrs } from "./attrs";
+import {
+  advanceVisibleListMarker,
+  createListCounterState,
+  MAX_LIST_LEVEL,
+  resolveListTemplateWithComponents,
+  type ListCounterState,
+  type ListCounterStream,
+  type ListCounterStreams,
+  type ResolvedListComponent,
+} from "./listMarker";
+
+const MAX_FIELD_INSTRUCTION_CHARS = 2048;
+const MAX_BOOKMARK_NAME_CHARS = 256;
+const MAX_NUMBERED_REF_FIELDS = 1024;
+const MAX_BOOKMARK_TARGETS = 2048;
+
+type NumberSwitch = "n" | "r" | "w";
+
+type NumberedRefSpec = {
+  bookmark: string;
+  numberSwitch: NumberSwitch;
+};
+
+type NumberedTarget = {
+  current: string;
+  full: string | null;
+  path: NumberingPath | null;
+};
+
+type NumberingScheme = { type: "abstract"; id: number } | { type: "instance"; id: number };
+
+type NumberingPath = {
+  scheme: NumberingScheme;
+  counters: readonly number[];
+  rendered: RenderedNumber;
+};
+
+type RenderedNumber = {
+  value: string;
+  components: readonly ResolvedListComponent[];
+};
+
+type NumberingContexts = {
+  byNumId: Map<number, (RenderedNumber | undefined)[]>;
+  byAbstractNumId: Map<number, (RenderedNumber | undefined)[]>;
+};
+
+type NumberingContextStreams = Record<ListCounterStream, NumberingContexts>;
+
+export type NumberedRefResolutionOptions = {
+  /** Counter snapshot at the start of this body story. The resolver consumes it in place. */
+  listCounterState?: ListCounterState;
+  /** Counter snapshot for tracked deletions in the original document view. */
+  originalListCounterState?: ListCounterState;
+};
+
+function tokenizeInstruction(instruction: string): string[] | null {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < instruction.length) {
+    while (/\s/u.test(instruction[index] ?? "")) {
+      index += 1;
+    }
+    if (index >= instruction.length) {
+      break;
+    }
+    if (instruction[index] === '"') {
+      const close = instruction.indexOf('"', index + 1);
+      if (close === -1) {
+        return null;
+      }
+      tokens.push(instruction.slice(index + 1, close));
+      index = close + 1;
+      continue;
+    }
+    let end = index;
+    while (end < instruction.length && !/\s/u.test(instruction[end] ?? "")) {
+      end += 1;
+    }
+    tokens.push(instruction.slice(index, end));
+    index = end;
+  }
+  return tokens;
+}
+
+export function parseNumberedRefInstruction(instruction: string): NumberedRefSpec | null {
+  if (instruction.length > MAX_FIELD_INSTRUCTION_CHARS) {
+    return null;
+  }
+  const tokens = tokenizeInstruction(instruction);
+  if (tokens === null || tokens.length < 3 || tokens.at(0)?.toUpperCase() !== "REF") {
+    return null;
+  }
+  const bookmark = tokens.at(1);
+  if (!bookmark || bookmark.length > MAX_BOOKMARK_NAME_CHARS || bookmark.startsWith("\\")) {
+    return null;
+  }
+
+  let numberSwitch: NumberSwitch | null = null;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]?.toUpperCase();
+    if (token === "\\N" || token === "\\R" || token === "\\W") {
+      if (numberSwitch !== null) {
+        return null;
+      }
+      if (token === "\\N") {
+        numberSwitch = "n";
+      } else if (token === "\\R") {
+        numberSwitch = "r";
+      } else {
+        numberSwitch = "w";
+      }
+      continue;
+    }
+    if (token === "\\H") {
+      continue;
+    }
+    if (token === "\\*MERGEFORMAT") {
+      continue;
+    }
+    if (token === "\\*" && tokens[index + 1]?.toUpperCase() === "MERGEFORMAT") {
+      index += 1;
+      continue;
+    }
+    return null;
+  }
+  return numberSwitch === null ? null : { bookmark, numberSwitch };
+}
+
+function trimTrailingPeriod(value: string): string {
+  return value.length > 1 && value.endsWith(".") ? value.slice(0, -1) : value;
+}
+
+function firstReferencedLevel(template: string): number | null {
+  let first: number | null = null;
+  for (const match of template.matchAll(/%(?<level>[1-9])/gu)) {
+    const level = Number.parseInt(match.groups?.["level"] ?? "", 10) - 1;
+    if (Number.isNaN(level)) {
+      continue;
+    }
+    first = first === null ? level : Math.min(first, level);
+  }
+  return first;
+}
+
+function numberTargetForParagraph(
+  node: PMNode,
+  contextStreams: NumberingContextStreams,
+  streams: ListCounterStreams,
+): NumberedTarget | null {
+  const resolution = advanceVisibleListMarker(expectParagraphAttrs(node), streams);
+  let visibleTarget: NumberedTarget | null = null;
+  for (const advanced of resolution.advances) {
+    const target = numberTargetForAdvancedMarker(
+      advanced.counterAttrs,
+      advanced.marker,
+      advanced.counterState,
+      contextStreams[advanced.stream],
+    );
+    if (
+      advanced.stream === resolution.stream &&
+      advanced.counterAttrs === resolution.counterAttrs
+    ) {
+      visibleTarget = target;
+    }
+  }
+  return visibleTarget;
+}
+
+function numberTargetForAdvancedMarker(
+  attrs: ReturnType<typeof expectParagraphAttrs>,
+  resolvedMarker: string | null,
+  state: ListCounterState,
+  contexts: NumberingContexts,
+): NumberedTarget | null {
+  const numId = attrs.numPr?.numId;
+  if (
+    numId === undefined ||
+    numId === 0 ||
+    attrs.listIsBullet ||
+    attrs.listMarkerHidden ||
+    attrs.listNumFmt === "none" ||
+    !resolvedMarker
+  ) {
+    return null;
+  }
+  const marker = attrs.listMarkerAllCaps ? resolvedMarker.toLocaleUpperCase() : resolvedMarker;
+
+  const level = attrs.numPr?.ilvl ?? 0;
+  if (!Number.isInteger(level) || level < 0 || level > MAX_LIST_LEVEL) {
+    return null;
+  }
+  const counters = state.counters.get(numId)?.slice(0, level + 1);
+  const levelFormats =
+    attrs.listLevelNumFmts ?? (attrs.listNumFmt ? [attrs.listNumFmt] : undefined);
+  let renderedMarker: RenderedNumber = { value: marker, components: [] };
+  if (attrs.listMarker?.includes("%") && counters?.length === level + 1) {
+    const rendered = resolveListTemplateWithComponents({
+      template: attrs.listMarker,
+      counters,
+      levelFormats,
+      forceDecimal: attrs.listIsLegal,
+    });
+    const renderedValue = attrs.listMarkerAllCaps
+      ? rendered.value.toLocaleUpperCase()
+      : rendered.value;
+    if (renderedValue === marker) {
+      renderedMarker = { value: marker, components: rendered.components };
+    }
+  }
+  const abstractContexts =
+    attrs.listAbstractNumId === undefined
+      ? undefined
+      : contexts.byAbstractNumId.get(attrs.listAbstractNumId);
+  const ownContexts = contexts.byNumId.get(numId) ?? [...(abstractContexts ?? [])];
+  const firstLevel = firstReferencedLevel(attrs.listMarker ?? "");
+  let renderedFull: RenderedNumber | null;
+  if (level === 0 || firstLevel === 0) {
+    renderedFull = renderedMarker;
+  } else {
+    const parentLevel = (firstLevel ?? level) - 1;
+    const prefix = ownContexts[parentLevel] ?? abstractContexts?.[parentLevel];
+    renderedFull =
+      prefix === undefined
+        ? null
+        : {
+            value: `${prefix.value}${marker}`,
+            components: [
+              ...prefix.components,
+              ...renderedMarker.components.map((component) => ({
+                level: component.level,
+                relativeStart: component.relativeStart + prefix.value.length,
+                start: component.start + prefix.value.length,
+                end: component.end + prefix.value.length,
+              })),
+            ],
+          };
+  }
+
+  ownContexts[level] = renderedFull ?? undefined;
+  ownContexts.splice(level + 1);
+  contexts.byNumId.set(numId, ownContexts);
+  if (attrs.listAbstractNumId !== undefined) {
+    contexts.byAbstractNumId.set(attrs.listAbstractNumId, [...ownContexts]);
+  }
+
+  const path =
+    counters?.length === level + 1 && counters.every(Number.isFinite) && renderedFull !== null
+      ? {
+          scheme:
+            attrs.listAbstractNumId === undefined
+              ? { type: "instance" as const, id: numId }
+              : { type: "abstract" as const, id: attrs.listAbstractNumId },
+          counters,
+          rendered: renderedFull,
+        }
+      : null;
+
+  return {
+    current: trimTrailingPeriod(marker),
+    full: renderedFull === null ? null : trimTrailingPeriod(renderedFull.value),
+    path,
+  };
+}
+
+function sameNumberingScheme(left: NumberingScheme, right: NumberingScheme): boolean {
+  return left.type === right.type && left.id === right.id;
+}
+
+function relativeNumber(target: NumberedTarget, source: NumberedTarget | null): string | null {
+  if (source === null || source.path === null || target.path === null) {
+    return target.full;
+  }
+  if (!sameNumberingScheme(source.path.scheme, target.path.scheme)) {
+    return target.full;
+  }
+
+  let sharedLevels = 0;
+  const comparedLevels = Math.min(source.path.counters.length, target.path.counters.length);
+  while (
+    sharedLevels < comparedLevels &&
+    source.path.counters[sharedLevels] === target.path.counters[sharedLevels]
+  ) {
+    sharedLevels += 1;
+  }
+  if (sharedLevels === 0) {
+    return target.full;
+  }
+  if (sharedLevels >= target.path.counters.length) {
+    return null;
+  }
+
+  const firstRelativeComponent = target.path.rendered.components.find(
+    (component) => component.level >= sharedLevels,
+  );
+  if (firstRelativeComponent === undefined) {
+    return null;
+  }
+  const suffix = target.path.rendered.value
+    .slice(firstRelativeComponent.relativeStart)
+    .replace(/^[\s,.:;/-]+/u, "");
+  return suffix.length === 0 ? null : trimTrailingPeriod(suffix);
+}
+
+function normalizeCachedResult(value: string): string {
+  return value.replaceAll("\u00a0", " ").replace(/\s+/gu, " ").trim();
+}
+
+type NumberedRefCandidate = {
+  node: PMNode;
+  cached: string;
+  value: string;
+};
+
+function collectNumberedRefCandidates(
+  doc: PMNode,
+  options: NumberedRefResolutionOptions,
+): NumberedRefCandidate[] {
+  const fields: { node: PMNode; spec: NumberedRefSpec; cached: string }[] = [];
+  doc.descendants((node) => {
+    if (node.type.name !== "field" && node.type.name !== "structuredField") {
+      return true;
+    }
+    if (fields.length >= MAX_NUMBERED_REF_FIELDS) {
+      return false;
+    }
+    const attrs = expectFieldAttrs(node);
+    if (attrs.fieldType !== "REF" || attrs.fldLock) {
+      return false;
+    }
+    const spec = parseNumberedRefInstruction(attrs.instruction);
+    if (spec !== null) {
+      fields.push({ node, spec, cached: attrs.displayText });
+    }
+    return false;
+  });
+  if (fields.length === 0) {
+    return [];
+  }
+
+  const referencedBookmarks = new Set(fields.map(({ spec }) => spec.bookmark));
+  const fieldNodes = new Set(fields.map(({ node }) => node));
+  const sourceByField = new WeakMap<PMNode, NumberedTarget | null>();
+  const targets = new Map<string, NumberedTarget | null>();
+  const streams: ListCounterStreams = {
+    final: options.listCounterState ?? createListCounterState(),
+    original: options.originalListCounterState ?? createListCounterState(),
+  };
+  const createContexts = (): NumberingContexts => ({
+    byNumId: new Map(),
+    byAbstractNumId: new Map(),
+  });
+  const contextStreams: NumberingContextStreams = {
+    final: createContexts(),
+    original: createContexts(),
+  };
+
+  doc.descendants((node) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+
+    const target = numberTargetForParagraph(node, contextStreams, streams);
+    node.descendants((descendant) => {
+      if (descendant.type.name === "bookmarkBoundary") {
+        const attrs = expectBookmarkBoundaryAttrs(descendant);
+        if (
+          attrs.type === "start" &&
+          targets.size < MAX_BOOKMARK_TARGETS &&
+          referencedBookmarks.has(attrs.name) &&
+          !targets.has(attrs.name)
+        ) {
+          targets.set(attrs.name, target);
+        }
+        return false;
+      }
+      if (descendant.type.name !== "field" && descendant.type.name !== "structuredField") {
+        return true;
+      }
+      if (fieldNodes.has(descendant)) {
+        sourceByField.set(descendant, target);
+      }
+      return true;
+    });
+    const paragraphAttrs = expectParagraphAttrs(node);
+    if (targets.size < MAX_BOOKMARK_TARGETS) {
+      for (const bookmark of paragraphAttrs.bookmarks ?? []) {
+        if (referencedBookmarks.has(bookmark.name) && !targets.has(bookmark.name)) {
+          targets.set(bookmark.name, target);
+        }
+      }
+    }
+    return false;
+  });
+
+  const candidates: NumberedRefCandidate[] = [];
+  for (const field of fields) {
+    const target = targets.get(field.spec.bookmark);
+    if (target === undefined || target === null) {
+      continue;
+    }
+    let value: string | null;
+    if (field.spec.numberSwitch === "n") {
+      value = target.current;
+    } else if (field.spec.numberSwitch === "r") {
+      value = relativeNumber(target, sourceByField.get(field.node) ?? null);
+    } else {
+      value = target.full;
+    }
+    if (value !== null) {
+      candidates.push({ node: field.node, cached: field.cached, value });
+    }
+  }
+  return candidates;
+}
+
+const isCalibratedCandidate = ({ node, cached, value }: NumberedRefCandidate): boolean => {
+  const normalizedCache = normalizeCachedResult(cached);
+  const baseline = expectFieldAttrs(node)._numberedRefBaseline;
+  return (
+    normalizedCache.length === 0 ||
+    normalizedCache === normalizeCachedResult(value) ||
+    (baseline !== undefined && normalizedCache === normalizeCachedResult(baseline))
+  );
+};
+
+const mapDocument = (node: PMNode, transform: (node: PMNode) => PMNode): PMNode => {
+  let mapped = node;
+  if (node.childCount > 0) {
+    const children: PMNode[] = [];
+    let changed = false;
+    // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+    node.forEach((child) => {
+      const mappedChild = mapDocument(child, transform);
+      children.push(mappedChild);
+      changed ||= mappedChild !== child;
+    });
+    if (changed) {
+      mapped = node.copy(Fragment.fromArray(children));
+    }
+  }
+  return transform(mapped);
+};
+
+/** Stamp only proven numbered REF fields with clone-safe calibration state. */
+export function stampNumberedRefFieldBaselines(doc: PMNode): PMNode {
+  const baselines = new WeakMap<PMNode, string>();
+  let hasBaselines = false;
+  for (const candidate of collectNumberedRefCandidates(doc, {})) {
+    if (isCalibratedCandidate(candidate)) {
+      baselines.set(candidate.node, candidate.cached);
+      hasBaselines = true;
+    }
+  }
+  if (!hasBaselines) {
+    return doc;
+  }
+  return mapDocument(doc, (node) => {
+    const baseline = baselines.get(node);
+    if (
+      baseline === undefined ||
+      (node.type.name !== "field" && node.type.name !== "structuredField")
+    ) {
+      return node;
+    }
+    return node.type.create(
+      { ...node.attrs, _numberedRefBaseline: baseline },
+      node.content,
+      node.marks,
+    );
+  });
+}
+
+/**
+ * Resolve bounded, numbered REF fields against bookmarks in the ProseMirror body story.
+ * Unsupported or uncalibrated fields are absent from the returned map and retain their cache.
+ */
+export function resolveNumberedRefFields(
+  doc: PMNode,
+  options: NumberedRefResolutionOptions = {},
+): ReadonlyMap<PMNode, string> {
+  const results = new Map<PMNode, string>();
+  for (const candidate of collectNumberedRefCandidates(doc, options)) {
+    if (isCalibratedCandidate(candidate)) {
+      results.set(candidate.node, candidate.value);
+    }
+  }
+  return results;
+}

--- a/packages/core/src/prosemirror/paraText.test.ts
+++ b/packages/core/src/prosemirror/paraText.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { Fragment, Slice } from "prosemirror-model";
+
+import { collectBlockChunks, joinChunks, offsetToDocPos } from "./plugins/pmTextScan";
+import { findTextInPmParagraph, getVanillaNodeText, getVanillaTextBetween } from "./paraText";
+import { schema } from "./schema";
+
+describe("field text extraction", () => {
+  test("exposes leaf and structured field results exactly once", () => {
+    const hyperlink = schema.mark("hyperlink", {
+      href: "https://example.test/target",
+      _docxHyperlinkIndex: 1,
+    });
+    const structuredField = schema.node(
+      "structuredField",
+      {
+        fieldType: "REF",
+        instruction: " REF target \\h ",
+        displayText: "Target",
+        fieldKind: "simple",
+      },
+      [
+        schema.node("bookmarkBoundary", { type: "start", id: 31, name: "target" }, null, [
+          hyperlink,
+        ]),
+        schema.text("Target", [hyperlink]),
+        schema.node("bookmarkBoundary", { type: "end", id: 31 }, null, [hyperlink]),
+      ],
+    );
+    const pageField = schema.node("field", {
+      fieldType: "PAGE",
+      instruction: " PAGE ",
+      displayText: "",
+      fieldKind: "complex",
+    });
+    const paragraph = schema.node("paragraph", null, [
+      schema.text("Page "),
+      pageField,
+      schema.text(" / "),
+      structuredField,
+      schema.text(" after"),
+    ]);
+    const doc = schema.node("doc", null, [paragraph]);
+    const expected = "Page {page} / Target after";
+
+    expect(paragraph.textContent).toBe(expected);
+    expect(paragraph.textBetween(0, paragraph.content.size)).toBe(expected);
+    const clipboardSlice = new Slice(Fragment.from(paragraph), 0, 0);
+    expect(clipboardSlice.content.textBetween(0, clipboardSlice.content.size, "\n\n")).toBe(
+      expected,
+    );
+    expect(getVanillaNodeText(paragraph)).toBe(expected);
+    expect(collectBlockChunks(doc).map(joinChunks)).toEqual([expected]);
+
+    for (const searchText of ["{page}", "Target"]) {
+      const match = findTextInPmParagraph(doc, 0, doc.content.size, searchText);
+      expect(match).not.toBeNull();
+      if (match) {
+        expect(getVanillaTextBetween(doc, match.from, match.to)).toBe(searchText);
+      }
+    }
+    expect(findTextInPmParagraph(doc, 0, doc.content.size, "page")).toBeNull();
+    expect(findTextInPmParagraph(doc, 0, doc.content.size, "{page")).toBeNull();
+    expect(findTextInPmParagraph(doc, 0, doc.content.size, "page}")).toBeNull();
+
+    const chunks = collectBlockChunks(doc).at(0) ?? [];
+    const pageOffset = joinChunks(chunks).indexOf("{page}");
+    const pageFrom = offsetToDocPos(chunks, pageOffset);
+    const pageTo = offsetToDocPos(chunks, pageOffset + "{page}".length, "end");
+    expect(doc.nodeAt(pageFrom)?.type.name).toBe("field");
+    expect(pageTo).toBe(pageFrom + pageField.nodeSize);
+  });
+});

--- a/packages/core/src/prosemirror/paraText.ts
+++ b/packages/core/src/prosemirror/paraText.ts
@@ -19,9 +19,15 @@ import type { Node as PMNode } from "prosemirror-model";
 export function getVanillaNodeText(node: PMNode): string {
   const parts: string[] = [];
   node.descendants((child) => {
-    if (!child.isText || !child.text) return true;
     if (child.marks.some((m) => m.type.name === "insertion")) return false;
-    parts.push(child.text);
+    if (child.isText && child.text) {
+      parts.push(child.text);
+      return false;
+    }
+    if (child.isLeaf && child.textContent) {
+      parts.push(child.textContent);
+      return false;
+    }
     return true;
   });
   return parts.join("");
@@ -32,14 +38,28 @@ export function getVanillaTextBetween(doc: PMNode, from: number, to: number): st
   if (from >= to) return "";
   const parts: string[] = [];
   doc.nodesBetween(from, to, (child, pos) => {
-    if (!child.isText || !child.text) return;
-    if (child.marks.some((m) => m.type.name === "insertion")) return;
-    const start = Math.max(from, pos);
-    const end = Math.min(to, pos + child.text.length);
-    if (start < end) parts.push(child.text.slice(start - pos, end - pos));
+    if (child.marks.some((m) => m.type.name === "insertion")) return false;
+    if (child.isText && child.text) {
+      const start = Math.max(from, pos);
+      const end = Math.min(to, pos + child.text.length);
+      if (start < end) parts.push(child.text.slice(start - pos, end - pos));
+      return false;
+    }
+    if (child.isLeaf && child.textContent) {
+      parts.push(child.textContent);
+      return false;
+    }
+    return true;
   });
   return parts.join("");
 }
+
+type TextPosition = {
+  text: string;
+  pos: number;
+  pmLength: number;
+  atomic: boolean;
+};
 
 /**
  * Find `searchText` within a PM paragraph range and return its position.
@@ -63,13 +83,21 @@ export function findTextInPmParagraph(
   if (!searchText) return null;
 
   let fullText = "";
-  const textPositions: { pos: number; len: number }[] = [];
+  const textPositions: TextPosition[] = [];
 
   doc.nodesBetween(paragraphFrom, paragraphTo, (node, pos) => {
-    if (!node.isText || !node.text) return;
-    if (node.marks.some((m) => m.type.name === "insertion")) return;
-    textPositions.push({ pos, len: node.text.length });
-    fullText += node.text;
+    if (node.marks.some((m) => m.type.name === "insertion")) return false;
+    if (node.isText && node.text) {
+      textPositions.push({ text: node.text, pos, pmLength: node.text.length, atomic: false });
+      fullText += node.text;
+      return false;
+    }
+    if (node.isLeaf && node.textContent) {
+      textPositions.push({ text: node.textContent, pos, pmLength: node.nodeSize, atomic: true });
+      fullText += node.textContent;
+      return false;
+    }
+    return true;
   });
 
   const firstMatch = fullText.indexOf(searchText);
@@ -78,18 +106,34 @@ export function findTextInPmParagraph(
   const secondMatch = fullText.indexOf(searchText, firstMatch + 1);
   if (secondMatch !== -1) return null;
 
+  const matchEnd = firstMatch + searchText.length;
+  let segmentStart = 0;
+  for (const position of textPositions) {
+    const segmentEnd = segmentStart + position.text.length;
+    if (
+      position.atomic &&
+      ((segmentStart < firstMatch && firstMatch < segmentEnd) ||
+        (segmentStart < matchEnd && matchEnd < segmentEnd))
+    ) {
+      return null;
+    }
+    segmentStart = segmentEnd;
+  }
+
   // Map string offset back to PM position.
   let charOffset = 0;
   let fromPos = paragraphFrom;
   let toPos = paragraphFrom;
 
   for (const tp of textPositions) {
-    const segEnd = charOffset + tp.len;
+    const segEnd = charOffset + tp.text.length;
     if (charOffset <= firstMatch && firstMatch < segEnd) {
-      fromPos = tp.pos + (firstMatch - charOffset);
+      const localOffset = firstMatch - charOffset;
+      fromPos = tp.atomic ? tp.pos : tp.pos + localOffset;
     }
     if (charOffset <= firstMatch + searchText.length && firstMatch + searchText.length <= segEnd) {
-      toPos = tp.pos + (firstMatch + searchText.length - charOffset);
+      const localOffset = firstMatch + searchText.length - charOffset;
+      toPos = tp.atomic ? tp.pos + tp.pmLength : tp.pos + localOffset;
       break;
     }
     charOffset = segEnd;

--- a/packages/core/src/prosemirror/plugins/anonymizationDecorations.ts
+++ b/packages/core/src/prosemirror/plugins/anonymizationDecorations.ts
@@ -127,7 +127,7 @@ const buildMatches = (doc: PMNode, terms: readonly AnonymizationTerm[]): Anonymi
       let match: RegExpExecArray | null = regex.exec(joined);
       while (match !== null) {
         const from = offsetToDocPos(chunks, match.index);
-        const to = offsetToDocPos(chunks, match.index + match[0].length);
+        const to = offsetToDocPos(chunks, match.index + match[0].length, "end");
         matches.push({
           from,
           to,

--- a/packages/core/src/prosemirror/plugins/pmTextScan.ts
+++ b/packages/core/src/prosemirror/plugins/pmTextScan.ts
@@ -18,6 +18,8 @@ export type TextChunk = {
   text: string;
   /** PM doc position where this chunk's first char lives. */
   start: number;
+  /** PM position after this chunk; differs from text length for atomic fields. */
+  end?: number;
 };
 
 /**
@@ -35,7 +37,14 @@ export const collectBlockChunks = (doc: PMNode): TextChunk[][] => {
           // pos is the textblock's PM position; +1 accounts for the
           // textblock's opening token, +offset is the position of
           // this text node inside the textblock.
-          chunks.push({ text: child.text, start: pos + 1 + offset });
+          const start = pos + 1 + offset;
+          chunks.push({ text: child.text, start, end: start + child.text.length });
+          return false;
+        }
+        if (child.isLeaf && child.textContent) {
+          const start = pos + 1 + offset;
+          chunks.push({ text: child.textContent, start, end: start + child.nodeSize });
+          return false;
         }
         return true;
       });
@@ -50,17 +59,32 @@ export const collectBlockChunks = (doc: PMNode): TextChunk[][] => {
 };
 
 /** Map a joined-string offset back to its PM doc position. */
-export const offsetToDocPos = (chunks: TextChunk[], offset: number): number => {
+export const offsetToDocPos = (
+  chunks: TextChunk[],
+  offset: number,
+  bias: "start" | "end" = "start",
+): number => {
   let consumed = 0;
   for (const chunk of chunks) {
     if (offset <= consumed + chunk.text.length) {
-      return chunk.start + (offset - consumed);
+      const localOffset = offset - consumed;
+      const end = chunk.end ?? chunk.start + chunk.text.length;
+      if (end - chunk.start === chunk.text.length) {
+        return chunk.start + localOffset;
+      }
+      if (localOffset === 0) {
+        return chunk.start;
+      }
+      if (localOffset === chunk.text.length || bias === "end") {
+        return end;
+      }
+      return chunk.start;
     }
     consumed += chunk.text.length;
   }
   // Past the end: clamp to the final chunk's last position.
   const last = chunks.at(-1);
-  return last ? last.start + last.text.length : 0;
+  return last ? (last.end ?? last.start + last.text.length) : 0;
 };
 
 /** Join a block's chunks into the single string callers scan. */

--- a/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
@@ -65,6 +65,23 @@ describe("scanDirectives", () => {
     expect(blockKinds).toEqual(["if", "endif"]);
   });
 
+  test("whole-paragraph directive fields use the atomic node endpoint", () => {
+    const field = schema.node("field", {
+      fieldType: "UNKNOWN",
+      instruction: " QUOTE ",
+      displayText: "{{#if hasSpouse}}",
+      fieldKind: "simple",
+    });
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, [field])]);
+
+    const [range] = scanDirectives(doc);
+
+    expect(range?.block).toBe(true);
+    expect(range?.from).toBe(1);
+    expect(range?.to).toBe(1 + field.nodeSize);
+    expect(doc.textBetween(range?.from ?? 0, range?.to ?? 0)).toBe("{{#if hasSpouse}}");
+  });
+
   test("emits mid-line each markers as inline (block:false) ranges", () => {
     const doc = docOf("Items: {{#each items}}{{items.name}}{{/each}} end.");
     const tokens = scanDirectives(doc).map((r) => `${r.kind}:${r.expr}:${String(r.block)}`);

--- a/packages/core/src/prosemirror/plugins/templateDirectives.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.ts
@@ -134,7 +134,7 @@ export const scanDirectives = (doc: PMNode): DirectiveRange[] => {
       const last = chunks.at(-1);
       ranges.push({
         from: chunks[0]?.start ?? 0,
-        to: last ? last.start + last.text.length : 0,
+        to: last ? (last.end ?? last.start + last.text.length) : 0,
         kind: sole.meta.kind,
         expr: directiveExpr(sole.meta),
         block: true,
@@ -151,7 +151,7 @@ export const scanDirectives = (doc: PMNode): DirectiveRange[] => {
       const clauseVersion = marker.meta.kind === "clause" ? marker.meta.version : undefined;
       ranges.push({
         from: offsetToDocPos(chunks, marker.start),
-        to: offsetToDocPos(chunks, marker.end),
+        to: offsetToDocPos(chunks, marker.end, "end"),
         kind: marker.meta.kind,
         expr: directiveExpr(marker.meta),
         block: false,

--- a/packages/core/src/prosemirror/schema/index.ts
+++ b/packages/core/src/prosemirror/schema/index.ts
@@ -16,6 +16,7 @@ export type {
   HardBreakAttrs,
   TabAttrs,
   SymbolAttrs,
+  BookmarkBoundaryAttrs,
   ParagraphAttrs,
   ParagraphPropertyChangeAttrs,
   FieldAttrs,

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -61,6 +61,19 @@ export type SymbolAttrs = {
   char: string;
 };
 
+export type BookmarkBoundaryAttrs =
+  | {
+      type: "start";
+      id: number;
+      name: string;
+      colFirst?: number;
+      colLast?: number;
+    }
+  | {
+      type: "end";
+      id: number;
+    };
+
 /**
  * Paragraph node attributes - maps to ParagraphFormatting
  */
@@ -397,6 +410,8 @@ export type FieldAttrs = {
   instruction: string;
   /** Current/cached display text */
   displayText: string;
+  /** Imported cache that proved numbered REF resolution for this field. */
+  _numberedRefBaseline?: string;
   /** Whether the field came from w:fldSimple or a complex fldChar range */
   fieldKind: "simple" | "complex";
   /** Field is locked */

--- a/packages/core/src/prosemirror/validation.test.ts
+++ b/packages/core/src/prosemirror/validation.test.ts
@@ -39,4 +39,215 @@ describe("ProseMirror document validation", () => {
       "ProseMirror document error at doc.content[0].paragraph.attrs.lineSpacing",
     );
   });
+
+  test.each([
+    {
+      name: "lone start",
+      content: [schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" })],
+      message: "Bookmark id 1 has no matching end boundary.",
+    },
+    {
+      name: "lone end",
+      content: [schema.node("bookmarkBoundary", { type: "end", id: 1 })],
+      message: "Bookmark id 1 has no open start boundary.",
+    },
+    {
+      name: "duplicate starts",
+      content: [
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" }),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name: "duplicate" }),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+      ],
+      message: "Bookmark id 1 has more than one start boundary.",
+    },
+  ])("rejects $name bookmark boundaries", ({ content, message }) => {
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, content)]);
+
+    const result = validateProseMirrorDocument(doc);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(message);
+  });
+
+  test("allows paired bookmark ranges to overlap", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" }),
+        schema.node("bookmarkBoundary", { type: "start", id: 2, name: "two" }),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+        schema.node("bookmarkBoundary", { type: "end", id: 2 }),
+      ]),
+    ]);
+
+    expect(validateProseMirrorDocument(doc)).toEqual({ valid: true, issues: [] });
+  });
+
+  test("allows a bookmark to overlap a tracked hyperlink", () => {
+    const hyperlink = schema.mark("hyperlink", {
+      href: "https://example.test",
+      _docxHyperlinkIndex: 1,
+    });
+    const insertion = schema.mark("insertion", {
+      revisionId: 7,
+      author: "Reviewer",
+      date: null,
+      initials: null,
+      moveKind: null,
+    });
+    const marks = [hyperlink, insertion];
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" }, null, marks),
+        schema.text("outside"),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }, null, marks),
+      ]),
+    ]);
+
+    const result = validateProseMirrorDocument(doc);
+
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  test("rejects a tracked boundary placement the document model cannot serialize", () => {
+    const insertion = schema.mark("insertion", {
+      revisionId: 7,
+      author: "Reviewer",
+      date: null,
+      initials: null,
+      moveKind: null,
+    });
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" }, null, [insertion]),
+        schema.text("tracked", [insertion]),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }, null, [insertion]),
+      ]),
+    ]);
+
+    const result = validateProseMirrorDocument(doc);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Bookmark boundaries inside tracked changes require a hyperlink serialization parent.",
+    );
+  });
+
+  test("rejects a field boundary without its required hyperlink parent", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node(
+          "structuredField",
+          {
+            fieldType: "REF",
+            instruction: " REF target ",
+            displayText: "Target",
+            fieldKind: "simple",
+          },
+          [
+            schema.node("bookmarkBoundary", { type: "start", id: 3, name: "target" }),
+            schema.text("Target"),
+            schema.node("bookmarkBoundary", { type: "end", id: 3 }),
+          ],
+        ),
+      ]),
+    ]);
+
+    expect(validateProseMirrorDocument(doc).issues.map((issue) => issue.message)).toContain(
+      "Bookmark boundaries inside fields require a hyperlink parent.",
+    );
+  });
+
+  test("rejects children forged onto an ordinary field leaf", () => {
+    const field = schema.nodes.field.create(
+      {
+        fieldType: "PAGE",
+        instruction: " PAGE ",
+        displayText: "1",
+        fieldKind: "complex",
+      },
+      schema.text("forged"),
+    );
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, [field])]);
+
+    expect(validateProseMirrorDocument(doc).issues.map((issue) => issue.message)).toContain(
+      "Ordinary fields cannot contain structured result children.",
+    );
+  });
+
+  test("rejects any structured children in complex field results", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node(
+          "structuredField",
+          {
+            fieldType: "PAGE",
+            instruction: " PAGE ",
+            displayText: "1",
+            fieldKind: "complex",
+          },
+          [schema.text("1")],
+        ),
+      ]),
+    ]);
+
+    expect(validateProseMirrorDocument(doc).issues.map((issue) => issue.message)).toContain(
+      "Complex fields cannot contain structured result children.",
+    );
+  });
+
+  test("rejects structured simple field children without a hyperlink", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node(
+          "structuredField",
+          {
+            fieldType: "REF",
+            instruction: " REF target ",
+            displayText: "Target",
+            fieldKind: "simple",
+          },
+          [schema.text("Target")],
+        ),
+      ]),
+    ]);
+
+    expect(validateProseMirrorDocument(doc).issues.map((issue) => issue.message)).toContain(
+      "Structured simple fields require hyperlink content.",
+    );
+  });
+
+  test("rejects ids shared by legacy paragraph bookmarks and boundary atoms", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { bookmarks: [{ id: 1, name: "legacy" }] }, [
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name: "pasted" }),
+        schema.text("collision"),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+      ]),
+    ]);
+
+    const result = validateProseMirrorDocument(doc);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Bookmark id 1 has more than one start boundary.",
+    );
+  });
+
+  test("rejects an internally pasted pair that collides with an existing id", () => {
+    const pair = (name: string) =>
+      schema.node("paragraph", null, [
+        schema.node("bookmarkBoundary", { type: "start", id: 1, name }),
+        schema.text(name),
+        schema.node("bookmarkBoundary", { type: "end", id: 1 }),
+      ]);
+    const doc = schema.node("doc", null, [pair("existing"), pair("pasted")]);
+
+    const result = validateProseMirrorDocument(doc);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Bookmark id 1 has more than one start boundary.",
+    );
+  });
 });

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -1,6 +1,7 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
 import type { ProseMirrorAttrIssue, ReadProseMirrorAttrsResult } from "./attrs";
+import { readBookmarkBoundaryAttrs } from "./bookmarkBoundaryAttrs";
 import {
   readCharacterSpacingMarkAttrs,
   readCharacterStyleMarkAttrs,
@@ -71,11 +72,100 @@ export const validateProseMirrorDocument = (doc: PMNode): ValidateProseMirrorDoc
   }
 
   validateNode(doc, "doc", issues);
+  validateBookmarkBoundaryStructure(doc, issues);
 
   return {
     valid: issues.length === 0,
     issues,
   };
+};
+
+type OpenBookmarkBoundary = {
+  id: number;
+  path: string;
+};
+
+const validateBookmarkBoundaryStructure = (
+  doc: PMNode,
+  issues: ProseMirrorDocumentValidationIssue[],
+): void => {
+  // Bookmark boundaries pair by id, not by stack order. Word permits ranges
+  // to overlap (start A, start B, end A, end B), so crossing pairs are valid.
+  const open = new Map<number, OpenBookmarkBoundary>();
+  const startedIds = new Set<number>();
+
+  const registerStart = (id: number, path: string): void => {
+    if (startedIds.has(id)) {
+      issues.push({ path, message: `Bookmark id ${id} has more than one start boundary.` });
+      return;
+    }
+    startedIds.add(id);
+    open.set(id, { id, path });
+  };
+
+  const registerEnd = (id: number, path: string): void => {
+    const start = open.get(id);
+    if (!start) {
+      issues.push({ path, message: `Bookmark id ${id} has no open start boundary.` });
+      return;
+    }
+    open.delete(id);
+  };
+
+  const visit = (node: PMNode, path: string): void => {
+    const paragraphAttrs = node.type.name === "paragraph" ? readParagraphAttrs(node) : null;
+    if (paragraphAttrs?.ok) {
+      for (const [index, bookmark] of (paragraphAttrs.value.bookmarks ?? []).entries()) {
+        registerStart(bookmark.id, `${path}.paragraph.attrs.bookmarks[${index}]`);
+      }
+    }
+
+    if (node.type.name === "bookmarkBoundary") {
+      const result = readBookmarkBoundaryAttrs(node);
+      if (result.ok) {
+        const attrs = result.value;
+        const hasHyperlink = node.marks.some((mark) => mark.type.name === "hyperlink");
+        const trackedChanges = node.marks.filter(
+          (mark) => mark.type.name === "insertion" || mark.type.name === "deletion",
+        );
+        if (trackedChanges.length > 1) {
+          issues.push({
+            path,
+            message: "Bookmark boundaries cannot carry multiple tracked-change parents.",
+          });
+        } else if (trackedChanges.length === 1 && !hasHyperlink) {
+          issues.push({
+            path,
+            message:
+              "Bookmark boundaries inside tracked changes require a hyperlink serialization parent.",
+          });
+        }
+        if (attrs.type === "start") {
+          registerStart(attrs.id, path);
+        } else {
+          registerEnd(attrs.id, path);
+        }
+      }
+    }
+
+    // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+    node.forEach((child, _offset, index) => {
+      visit(child, `${path}.content[${index}]`);
+    });
+    if (paragraphAttrs?.ok) {
+      for (const [index, bookmark] of (paragraphAttrs.value.bookmarks ?? []).entries()) {
+        registerEnd(bookmark.id, `${path}.paragraph.attrs.bookmarks[${index}]`);
+      }
+    }
+  };
+
+  visit(doc, "doc");
+  for (const boundary of open.values()) {
+    issues.push({
+      path: boundary.path,
+      message: `Bookmark id ${boundary.id} has no matching end boundary.`,
+    });
+  }
 };
 
 export const assertValidProseMirrorDocument = (doc: PMNode, context: string): void => {
@@ -134,6 +224,10 @@ const validateNodeAttrs = (
     case "renderedPageBreak":
       return;
 
+    case "bookmarkBoundary":
+      appendAttrIssues(path, readBookmarkBoundaryAttrs(node), issues);
+      return;
+
     case "tab":
       appendAttrIssues(path, readTabAttrs(node), issues);
       return;
@@ -169,6 +263,46 @@ const validateNodeAttrs = (
 
     case "field":
       appendAttrIssues(path, readFieldAttrs(node), issues);
+      if (node.childCount > 0) {
+        issues.push({
+          path: `${path}.content`,
+          message: "Ordinary fields cannot contain structured result children.",
+        });
+      }
+      return;
+
+    case "structuredField":
+      {
+        const fieldAttrs = readFieldAttrs(node);
+        appendAttrIssues(path, fieldAttrs, issues);
+        if (fieldAttrs.ok) {
+          const hasStructuredHyperlink = node.content.content.some((child) =>
+            child.marks.some((mark) => mark.type.name === "hyperlink"),
+          );
+          if (fieldAttrs.value.fieldKind === "complex") {
+            issues.push({
+              path: `${path}.content`,
+              message: "Complex fields cannot contain structured result children.",
+            });
+          } else if (!hasStructuredHyperlink) {
+            issues.push({
+              path: `${path}.content`,
+              message: "Structured simple fields require hyperlink content.",
+            });
+          }
+          // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+          node.forEach((child, _offset, index) => {
+            const childPath = `${path}.content[${index}]`;
+            const hasHyperlink = child.marks.some((mark) => mark.type.name === "hyperlink");
+            if (child.type.name === "bookmarkBoundary" && !hasHyperlink) {
+              issues.push({
+                path: childPath,
+                message: "Bookmark boundaries inside fields require a hyperlink parent.",
+              });
+            }
+          });
+        }
+      }
       return;
 
     case "math":

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -32,7 +32,7 @@
     "instantiations": 815996
   },
   "parity": {
-    "types": 61308,
-    "instantiations": 47672
+    "types": 64715,
+    "instantiations": 50973
   }
 }


### PR DESCRIPTION
## Summary

- resolve numbered REF field switches against original and final list contexts
- preserve bookmark boundaries and structured hyperlink field content through editor conversion and paste
- keep field display text consistent across rendering, search, clipboard, and bidi detection
- validate field shapes and reject unsupported structured forms at parse and save boundaries

## Validation

- focused conversion, style, field, bookmark, validation, paste, and list suites
- core typecheck, build, API extraction, lint, format, and dependency audit
- DOCX parse, editor conversion, and round-trip smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Numbered REF fields now update from current bookmark and list numbering, with safe cached values refreshed when saving.
  * Bookmark ranges are preserved across hyperlinks, fields, tracked changes, tables and copy/paste.
  * Structured fields retain inline content and hyperlink details.
  * List numbering and markers are handled more consistently, including tracked revisions and invalid levels.

* **Bug Fixes**
  * Improved text extraction, search positioning, direction detection and anonymisation for fields and other inline elements.
  * Invalid or incomplete bookmark data is rejected safely during validation and paste operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->