### PR TITLE
fix: coalesce section-adjacent page breaks

### DIFF
--- a/.changeset/neat-section-pages.md
+++ b/.changeset/neat-section-pages.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Coalesce redundant hard breaks with pages already opened by section transitions.

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -42,6 +42,44 @@ function paragraph(
   };
 }
 
+type EmptyParagraphOptions = {
+  id: string;
+  attrs?: ParagraphBlock["attrs"];
+  lineHeight?: number;
+};
+
+function emptyParagraph({ id, attrs = {}, lineHeight = 20 }: EmptyParagraphOptions): {
+  block: ParagraphBlock;
+  measure: ParagraphMeasure;
+} {
+  return {
+    block: {
+      kind: "paragraph",
+      id,
+      pmStart: 0,
+      pmEnd: 0,
+      runs: [],
+      attrs,
+    },
+    measure: {
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 0,
+          width: 0,
+          ascent: 0,
+          descent: 0,
+          lineHeight,
+        },
+      ],
+      totalHeight: lineHeight,
+    },
+  };
+}
+
 describe("continuous section break geometry", () => {
   test("balances a short paragraph-only multi-column section", () => {
     const intro = paragraph("intro", 100);
@@ -184,6 +222,106 @@ describe("continuous section break geometry", () => {
       "second",
     ]);
     expect(result.pages[1]?.fragments.map((fragment) => fragment.blockId)).toEqual(["third"]);
+  });
+
+  test("a hard break reuses the blank page opened by a preceding section boundary", () => {
+    const cover = paragraph("cover", 100);
+    const spacer = emptyParagraph({ id: "spacer" });
+    const carrier = emptyParagraph({
+      id: "carrier",
+      attrs: { suppressEmptyParagraphHeight: true },
+      lineHeight: 0,
+    });
+    const body = paragraph("body", 100);
+    body.block.attrs = { renderedPageBreakBefore: true };
+    const blocks: FlowBlock[] = [
+      cover.block,
+      { kind: "sectionBreak", id: "cover-end" },
+      { kind: "sectionBreak", id: "continuous-marker", type: "continuous" },
+      spacer.block,
+      { kind: "pageBreak", id: "redundant-page-break" },
+      carrier.block,
+      body.block,
+    ];
+    const measures = [
+      cover.measure,
+      { kind: "sectionBreak" },
+      { kind: "sectionBreak" },
+      spacer.measure,
+      { kind: "pageBreak" },
+      carrier.measure,
+      body.measure,
+    ] satisfies Measure[];
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([
+      "spacer",
+      "carrier",
+      "body",
+    ]);
+  });
+
+  test("a hard-break page is not coalesced through a continuous section", () => {
+    const first = paragraph("first", 100);
+    const body = paragraph("body", 100);
+    const result = layoutDocument(
+      [
+        first.block,
+        { kind: "pageBreak", id: "first-hard-break" },
+        { kind: "sectionBreak", id: "continuous-marker", type: "continuous" },
+        { kind: "pageBreak", id: "second-hard-break" },
+        body.block,
+      ],
+      [
+        first.measure,
+        { kind: "pageBreak" },
+        { kind: "sectionBreak" },
+        { kind: "pageBreak" },
+        body.measure,
+      ],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    );
+
+    expect(result.pages).toHaveLength(3);
+    expect(result.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual(["body"]);
+  });
+
+  test("visible empty-paragraph decoration consumes section-break coalescence", () => {
+    const cover = paragraph("cover", 100);
+    const decorated = emptyParagraph({ id: "decorated", attrs: { shading: "#FFFF00" } });
+    const body = paragraph("body", 100);
+    const result = layoutDocument(
+      [
+        cover.block,
+        { kind: "sectionBreak", id: "cover-end" },
+        decorated.block,
+        { kind: "pageBreak", id: "hard-break" },
+        body.block,
+      ],
+      [
+        cover.measure,
+        { kind: "sectionBreak" },
+        decorated.measure,
+        { kind: "pageBreak" },
+        body.measure,
+      ],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    );
+
+    expect(result.pages).toHaveLength(3);
+    expect(result.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual(["decorated"]);
+    expect(result.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual(["body"]);
   });
 
   test("does not apply final section config to a preceding omitted transition", () => {

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -294,6 +294,38 @@ describe("continuous section break geometry", () => {
     expect(result.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual(["body"]);
   });
 
+  test("a column break consumes section-break coalescence before a hard break", () => {
+    const cover = paragraph("cover", 100);
+    const body = paragraph("body", 100);
+    const result = layoutDocument(
+      [
+        cover.block,
+        { kind: "sectionBreak", id: "cover-end" },
+        { kind: "columnBreak", id: "column-break" },
+        { kind: "pageBreak", id: "page-break" },
+        body.block,
+      ],
+      [
+        cover.measure,
+        { kind: "sectionBreak" },
+        { kind: "columnBreak" },
+        { kind: "pageBreak" },
+        body.measure,
+      ],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+        finalColumns: { count: 2, gap: 20 },
+      },
+    );
+
+    expect(result.pages).toHaveLength(3);
+    expect(result.pages[1]?.fragments).toHaveLength(0);
+    expect(result.pages[2]?.fragments.map(({ blockId, x }) => ({ blockId, x }))).toEqual([
+      { blockId: "body", x: 50 },
+    ]);
+  });
+
   test("visible empty-paragraph decoration consumes section-break coalescence", () => {
     const cover = paragraph("cover", 100);
     const decorated = emptyParagraph({ id: "decorated", attrs: { shading: "#FFFF00" } });

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -423,7 +423,7 @@ function layoutDocumentPass(
         (firstLineAdvance > 0 &&
           paginator.getAvailableHeight() <=
             firstLineAdvance * RENDERED_BREAK_REFLOW_TOLERANCE_LINES));
-    const hasExplicitPageBreak = hasPageBreakBefore(block);
+    const hasExplicitPageBreak = block.kind === "pageBreak" || hasPageBreakBefore(block);
     const breakDecision = reconcileBreakBeforeBlock({
       state: renderedBreakState,
       block,
@@ -433,7 +433,7 @@ function layoutDocumentPass(
       hasExplicitPageBreak,
       renderedBreakNeedsSnap,
     });
-    if (breakDecision.forcePageBreak) {
+    if (breakDecision.forcePageBreak && block.kind !== "pageBreak") {
       paginator.forcePageBreak();
     }
     renderedBreakState = breakDecision.state;
@@ -491,7 +491,9 @@ function layoutDocumentPass(
         break;
 
       case "pageBreak":
-        paginator.forcePageBreak();
+        if (breakDecision.forcePageBreak) {
+          paginator.forcePageBreak();
+        }
         break;
 
       case "columnBreak":

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -346,6 +346,7 @@ describe("rendered break reconciliation", () => {
       type: "pageAdvance",
       reason: "authoredBoundary",
       boundary: "sectionBreak",
+      nextHardBreak: "advance",
     });
     expect(decision.suppressSpaceBefore).toBe(false);
   });
@@ -477,6 +478,7 @@ describe("rendered break reconciliation", () => {
         type: "pageAdvance",
         reason: "authoredBoundary",
         boundary: "sectionBreak",
+        nextHardBreak: "coalesce",
       },
       block,
       previousBlock: { kind: "sectionBreak", id: "section", type: "nextPage" },
@@ -487,6 +489,41 @@ describe("rendered break reconciliation", () => {
     });
 
     expect(decision.forcePageBreak).toBe(false);
+  });
+
+  test("a hard page break reuses a page already opened by a carried section boundary", () => {
+    const empty = paragraph(2, {}, []);
+    const firstDecision = reconcileBreakBeforeBlock({
+      state: {
+        type: "pageAdvance",
+        reason: "authoredBoundary",
+        boundary: "sectionBreak",
+        nextHardBreak: "coalesce",
+      },
+      block: { kind: "pageBreak", id: "hard-break" },
+      previousBlock: empty,
+      page: page([paragraphFragment(2)]),
+      blocksById: new Map([["2", empty]]),
+      hasExplicitPageBreak: true,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(firstDecision).toMatchObject({
+      forcePageBreak: false,
+      state: { boundary: "sectionBreak", nextHardBreak: "advance" },
+    });
+
+    const secondDecision = reconcileBreakBeforeBlock({
+      state: firstDecision.state,
+      block: { kind: "pageBreak", id: "second-hard-break" },
+      previousBlock: { kind: "pageBreak", id: "hard-break" },
+      page: page([paragraphFragment(2)]),
+      blocksById: new Map([["2", empty]]),
+      hasExplicitPageBreak: true,
+      renderedBreakNeedsSnap: false,
+    });
+
+    expect(secondDecision.forcePageBreak).toBe(true);
   });
 
   test("pageBreakBefore still advances a page with visible body content", () => {

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -60,7 +60,12 @@ export const reconcileBreakBeforeBlock = ({
       forcePageBreak: !sectionBoundaryAlreadyOpenedPage,
       suppressSpaceBefore: false,
       state: sectionBoundaryAlreadyOpenedPage
-        ? { ...state, nextHardBreak: "advance" }
+        ? {
+            type: "pageAdvance",
+            reason: "authoredBoundary",
+            boundary: "sectionBreak",
+            nextHardBreak: "advance",
+          }
         : INITIAL_RENDERED_BREAK_STATE,
     };
   }
@@ -135,7 +140,17 @@ export const reconcileAfterBlock = ({
   if (isStructuralBreak(block)) {
     if (pageNumberAfter <= pageNumberBefore) {
       if (state.type === "pageAdvance" && state.reason === "authoredBoundary") {
-        if (block.kind !== "sectionBreak" || state.boundary === "sectionBreak") {
+        if (block.kind !== "sectionBreak") {
+          return state.boundary === "sectionBreak"
+            ? {
+                type: "pageAdvance",
+                reason: "authoredBoundary",
+                boundary: "sectionBreak",
+                nextHardBreak: "advance",
+              }
+            : state;
+        }
+        if (state.boundary === "sectionBreak") {
           return state;
         }
         return {

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -4,10 +4,12 @@ import type { FlowBlock, Page, ParagraphBlock } from "./types";
 export type RenderedBreakState =
   | { type: "noPageAdvance" }
   | { type: "pageAdvance"; reason: "ordinary" | "reflowBoundary" }
+  | { type: "pageAdvance"; reason: "authoredBoundary"; boundary: "hardBreak" }
   | {
       type: "pageAdvance";
       reason: "authoredBoundary";
-      boundary: "hardBreak" | "sectionBreak";
+      boundary: "sectionBreak";
+      nextHardBreak: "coalesce" | "advance";
     };
 
 export const INITIAL_RENDERED_BREAK_STATE: RenderedBreakState = {
@@ -48,16 +50,18 @@ export const reconcileBreakBeforeBlock = ({
   renderedBreakNeedsSnap,
 }: ReconcileBeforeBlockOptions): BreakDecision => {
   if (hasExplicitPageBreak) {
-    const followsSameSectionBoundary =
+    const sectionBoundaryAlreadyOpenedPage =
       state.type === "pageAdvance" &&
       state.reason === "authoredBoundary" &&
       state.boundary === "sectionBreak" &&
-      previousBlock?.kind === "sectionBreak" &&
-      previousBlock.type !== "continuous";
+      state.nextHardBreak === "coalesce" &&
+      !pageHasVisibleBodyContent(page, blocksById);
     return {
-      forcePageBreak: !followsSameSectionBoundary,
+      forcePageBreak: !sectionBoundaryAlreadyOpenedPage,
       suppressSpaceBefore: false,
-      state: INITIAL_RENDERED_BREAK_STATE,
+      state: sectionBoundaryAlreadyOpenedPage
+        ? { ...state, nextHardBreak: "advance" }
+        : INITIAL_RENDERED_BREAK_STATE,
     };
   }
   if (block.kind !== "paragraph" || block.attrs?.renderedPageBreakBefore !== true) {
@@ -131,15 +135,27 @@ export const reconcileAfterBlock = ({
   if (isStructuralBreak(block)) {
     if (pageNumberAfter <= pageNumberBefore) {
       if (state.type === "pageAdvance" && state.reason === "authoredBoundary") {
-        return block.kind === "sectionBreak" ? { ...state, boundary: "sectionBreak" } : state;
+        if (block.kind !== "sectionBreak" || state.boundary === "sectionBreak") {
+          return state;
+        }
+        return {
+          type: "pageAdvance",
+          reason: "authoredBoundary",
+          boundary: "sectionBreak",
+          nextHardBreak: "advance",
+        };
       }
       return INITIAL_RENDERED_BREAK_STATE;
     }
-    return {
-      type: "pageAdvance",
-      reason: "authoredBoundary",
-      boundary: block.kind === "sectionBreak" ? "sectionBreak" : "hardBreak",
-    };
+    if (block.kind === "sectionBreak") {
+      return {
+        type: "pageAdvance",
+        reason: "authoredBoundary",
+        boundary: "sectionBreak",
+        nextHardBreak: "coalesce",
+      };
+    }
+    return { type: "pageAdvance", reason: "authoredBoundary", boundary: "hardBreak" };
   }
   if (block.kind === "paragraph" && isPaginationEmptyParagraph(block)) {
     return state;


### PR DESCRIPTION
## Summary

- route structural hard breaks through rendered-break reconciliation
- make section-boundary coalescence explicit and one-shot
- preserve intentional blank pages when visible content or another hard boundary intervenes
- add flow-level regression coverage and a patch changeset

## Validation

- focused layout suite: 45 passed
- lint: passed
- reference-renderer comparison: page count corrected from 6/5 to 5/5; raster similarity increased from 79.9% to 95.6%
- full repository checks delegated to CI due local system load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination when section breaks and hard page breaks occur together.
  * Prevented redundant blank pages caused by consecutive break instructions.
  * Ensured explicit page breaks only advance pagination when required.
* **Tests**
  * Added coverage for empty paragraphs, section boundaries, and hard-break coalescence.
* **Release**
  * Patch release for `@stll/folio-core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->