### PR TITLE
fix: preserve coalesced section page ordinals

### DIFF
--- a/.changeset/steady-section-ordinals.md
+++ b/.changeset/steady-section-ordinals.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve section page numbers and default furniture when adjacent hard breaks share a physical page.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -135,7 +135,7 @@ export function createPaginator(options: PaginatorOptions): {
         w: number;
         h: number;
     }, newMargins?: PageMargins, applyImmediately?: boolean) => void;
-    startSection: (sectionIndex: number, pageNumbering?: SectionPageNumbering, placement?: SectionStartPlacement) => void;
+    startSection: (input: StartSectionOptions) => void;
 };
 
 // @public

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -126,6 +126,7 @@ export function createPaginator(options: PaginatorOptions): {
     addUnflowedFragment: (fragment: Fragment) => PageState;
     addFootnoteHeight: (additionalHeight: number, footnoteIds?: number[]) => void;
     forcePageBreak: (breakOptions?: ForcePageBreakOptions) => PageState;
+    coalescePageBreak: () => PageState;
     retargetCurrentBlankPage: () => boolean;
     forceColumnBreak: () => PageState;
     getColumnX: (columnIndex: number) => number;
@@ -134,7 +135,7 @@ export function createPaginator(options: PaginatorOptions): {
         w: number;
         h: number;
     }, newMargins?: PageMargins, applyImmediately?: boolean) => void;
-    startSection: (sectionIndex: number, pageNumbering?: SectionPageNumbering) => void;
+    startSection: (sectionIndex: number, pageNumbering?: SectionPageNumbering, placement?: SectionStartPlacement) => void;
 };
 
 // @public

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -256,6 +256,12 @@ describe("continuous section break geometry", () => {
     const result = layoutDocument(blocks, measures, {
       pageSize: { w: 800, h: 1000 },
       margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageNumbering: { type: "restart", start: 0 },
+      sectionHeaderFooterRefs: [
+        { footerDefault: "cover-footer" },
+        { titlePg: true, footerDefault: "middle-footer" },
+        { titlePg: true, footerDefault: "body-footer" },
+      ],
     });
 
     expect(result.pages).toHaveLength(2);
@@ -264,6 +270,12 @@ describe("continuous section break geometry", () => {
       "carrier",
       "body",
     ]);
+    expect(result.pages[1]).toMatchObject({
+      logicalNumber: 1,
+      sectionIndex: 2,
+      sectionPageNumber: 2,
+      headerFooterRefs: { titlePg: true, footerDefault: "body-footer" },
+    });
   });
 
   test("a hard-break page is not coalesced through a continuous section", () => {
@@ -610,7 +622,7 @@ describe("continuous section break geometry", () => {
     expect(result.pages).toHaveLength(2);
     expect(result.pages[0]?.sectionIndex).toBe(0);
     expect(result.pages[1]?.sectionIndex).toBe(1);
-    expect(result.pages[1]?.sectionPageNumber).toBe(1);
+    expect(result.pages[1]?.sectionPageNumber).toBe(2);
     expect(
       result.pages[1]?.fragments.some((f) => f.kind === "paragraph" && f.blockId === "c"),
     ).toBe(true);
@@ -642,11 +654,55 @@ describe("continuous section break geometry", () => {
 
     expect(result.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([1, 3]);
     expect(result.pages[0]).toMatchObject({ sectionIndex: 0, sectionPageNumber: 1 });
-    expect(result.pages[1]).toMatchObject({ sectionIndex: 1, sectionPageNumber: 1 });
+    expect(result.pages[1]).toMatchObject({ sectionIndex: 1, sectionPageNumber: 2 });
     expect(
       result.pages[0]?.fragments.some(
         (fragment) => fragment.kind === "paragraph" && fragment.blockId === "shared-incoming",
       ),
     ).toBe(true);
+  });
+
+  test("consumes the first-page slot before an explicit break in a continuous section", () => {
+    const outgoing = paragraph("outgoing", 100);
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "section",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const pageBreak: FlowBlock = { kind: "pageBreak", id: "page" };
+    const incoming = paragraph("incoming", 100);
+
+    const result = layoutDocument(
+      [outgoing.block, sectionBreak, pageBreak, incoming.block],
+      [
+        outgoing.measure,
+        { kind: "sectionBreak" },
+        { kind: "pageBreak" },
+        incoming.measure,
+      ] as never,
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+        finalPageSize: { w: 800, h: 1000 },
+        finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+        sectionHeaderFooterRefs: [
+          { footerDefault: "outgoing-footer" },
+          { titlePg: true, footerFirst: "first-footer", footerDefault: "default-footer" },
+        ],
+      },
+    );
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[1]).toMatchObject({
+      sectionIndex: 1,
+      sectionPageNumber: 2,
+      headerFooterRefs: {
+        titlePg: true,
+        footerFirst: "first-footer",
+        footerDefault: "default-footer",
+      },
+    });
   });
 });

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -710,7 +710,7 @@ describe("continuous section break geometry", () => {
         { kind: "sectionBreak" },
         { kind: "pageBreak" },
         incoming.measure,
-      ] as never,
+      ] satisfies Measure[],
       {
         pageSize: { w: 800, h: 1000 },
         margins: { top: 50, right: 50, bottom: 50, left: 50 },

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -278,6 +278,35 @@ describe("continuous section break geometry", () => {
     });
   });
 
+  test("pageBreakBefore advances ordinals on a page opened by a section boundary", () => {
+    const cover = paragraph("cover", 100);
+    const body = paragraph("body", 100);
+    body.block.attrs = { pageBreakBefore: true };
+
+    const result = layoutDocument(
+      [cover.block, { kind: "sectionBreak", id: "cover-end" }, body.block],
+      [cover.measure, { kind: "sectionBreak" }, body.measure],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+        finalPageNumbering: { type: "restart", start: 9 },
+        sectionHeaderFooterRefs: [
+          { footerDefault: "cover-footer" },
+          { titlePg: true, footerDefault: "body-footer" },
+        ],
+      },
+    );
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[1]).toMatchObject({
+      logicalNumber: 10,
+      sectionIndex: 1,
+      sectionPageNumber: 2,
+      headerFooterRefs: { titlePg: true, footerDefault: "body-footer" },
+    });
+    expect(result.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual(["body"]);
+  });
+
   test("a hard-break page is not coalesced through a continuous section", () => {
     const first = paragraph("first", 100);
     const body = paragraph("body", 100);

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -433,8 +433,12 @@ function layoutDocumentPass(
       hasExplicitPageBreak,
       renderedBreakNeedsSnap,
     });
-    if (breakDecision.pageAdvance === "physical" && block.kind !== "pageBreak") {
-      paginator.forcePageBreak();
+    if (block.kind !== "pageBreak") {
+      if (breakDecision.pageAdvance === "physical") {
+        paginator.forcePageBreak();
+      } else if (breakDecision.pageAdvance === "coalesced") {
+        paginator.coalescePageBreak();
+      }
     }
     renderedBreakState = breakDecision.state;
 

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -433,7 +433,7 @@ function layoutDocumentPass(
       hasExplicitPageBreak,
       renderedBreakNeedsSnap,
     });
-    if (breakDecision.forcePageBreak && block.kind !== "pageBreak") {
+    if (breakDecision.pageAdvance === "physical" && block.kind !== "pageBreak") {
       paginator.forcePageBreak();
     }
     renderedBreakState = breakDecision.state;
@@ -491,8 +491,10 @@ function layoutDocumentPass(
         break;
 
       case "pageBreak":
-        if (breakDecision.forcePageBreak) {
+        if (breakDecision.pageAdvance === "physical") {
           paginator.forcePageBreak();
+        } else if (breakDecision.pageAdvance === "coalesced") {
+          paginator.coalescePageBreak();
         }
         break;
 
@@ -1770,7 +1772,11 @@ function handleSectionBreak(
         (Math.round(nextSize.w) !== Math.round(currentPage.size.w) ||
           Math.round(nextSize.h) !== Math.round(currentPage.size.h));
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
+        paginator.startSection(
+          nextSectionIndex,
+          nextSectionConfig.pageNumbering,
+          pageSizeChanges ? "nextPage" : "continuous",
+        );
       }
       if (pageSizeChanges) {
         // Promote to a page break, but reuse an already blank current page as

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -15,7 +15,7 @@ import {
   hasPageBreakBefore,
 } from "./keep-together";
 import { measuredLineAdvance } from "./lineFlow";
-import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
+import { FOOTNOTE_SEPARATOR_HEIGHT, SECTION_START_PLACEMENT, createPaginator } from "./paginator";
 import type { PageState } from "./paginator";
 import { getParagraphFragmentPmRange } from "./paragraphFragmentRange";
 import {
@@ -28,6 +28,7 @@ import {
 } from "./paragraphSpacing";
 import {
   INITIAL_RENDERED_BREAK_STATE,
+  PAGE_ADVANCE,
   reconcileAfterBlock,
   reconcileBreakBeforeBlock,
   recordReflowBoundary,
@@ -434,9 +435,9 @@ function layoutDocumentPass(
       renderedBreakNeedsSnap,
     });
     if (block.kind !== "pageBreak") {
-      if (breakDecision.pageAdvance === "physical") {
+      if (breakDecision.pageAdvance === PAGE_ADVANCE.PHYSICAL) {
         paginator.forcePageBreak();
-      } else if (breakDecision.pageAdvance === "coalesced") {
+      } else if (breakDecision.pageAdvance === PAGE_ADVANCE.COALESCED) {
         paginator.coalescePageBreak();
       }
     }
@@ -495,9 +496,9 @@ function layoutDocumentPass(
         break;
 
       case "pageBreak":
-        if (breakDecision.pageAdvance === "physical") {
+        if (breakDecision.pageAdvance === PAGE_ADVANCE.PHYSICAL) {
           paginator.forcePageBreak();
-        } else if (breakDecision.pageAdvance === "coalesced") {
+        } else if (breakDecision.pageAdvance === PAGE_ADVANCE.COALESCED) {
           paginator.coalescePageBreak();
         }
         break;
@@ -1723,7 +1724,10 @@ function handleSectionBreak(
     case "nextPage":
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
+        paginator.startSection({
+          sectionIndex: nextSectionIndex,
+          pageNumbering: nextSectionConfig.pageNumbering,
+        });
       }
       paginator.forcePageBreak({ coalesceBlankPage: true });
       break;
@@ -1735,7 +1739,10 @@ function handleSectionBreak(
       }
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
+        paginator.startSection({
+          sectionIndex: nextSectionIndex,
+          pageNumbering: nextSectionConfig.pageNumbering,
+        });
       }
       if (!paginator.retargetCurrentBlankPage()) {
         panic("Even-page section target must be blank");
@@ -1750,7 +1757,10 @@ function handleSectionBreak(
       }
       paginator.updatePageLayout(nextSectionConfig.pageSize, nextSectionConfig.margins);
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(nextSectionIndex, nextSectionConfig.pageNumbering);
+        paginator.startSection({
+          sectionIndex: nextSectionIndex,
+          pageNumbering: nextSectionConfig.pageNumbering,
+        });
       }
       if (!paginator.retargetCurrentBlankPage()) {
         panic("Odd-page section target must be blank");
@@ -1776,11 +1786,13 @@ function handleSectionBreak(
         (Math.round(nextSize.w) !== Math.round(currentPage.size.w) ||
           Math.round(nextSize.h) !== Math.round(currentPage.size.h));
       if (nextSectionIndex !== undefined) {
-        paginator.startSection(
-          nextSectionIndex,
-          nextSectionConfig.pageNumbering,
-          pageSizeChanges ? "nextPage" : "continuous",
-        );
+        paginator.startSection({
+          sectionIndex: nextSectionIndex,
+          pageNumbering: nextSectionConfig.pageNumbering,
+          placement: pageSizeChanges
+            ? SECTION_START_PLACEMENT.NEXT_PAGE
+            : SECTION_START_PLACEMENT.CONTINUOUS,
+        });
       }
       if (pageSizeChanges) {
         // Promote to a page break, but reuse an already blank current page as

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createPaginator } from "./paginator";
+import { SECTION_START_PLACEMENT, createPaginator } from "./paginator";
 import type { ParagraphFragment } from "./types";
 
 const SIZE = { w: 800, h: 1000 };
@@ -70,7 +70,7 @@ describe("paginator even-page margins", () => {
       sectionEvenPageMargins: [undefined, evenMargins],
     });
     paginator.forcePageBreak();
-    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.startSection({ sectionIndex: 1, pageNumbering: { type: "restart", start: 2 } });
 
     const page = paginator.forcePageBreak({ coalesceBlankPage: true }).page;
 
@@ -90,9 +90,9 @@ describe("paginator logical page numbers", () => {
 
     const first = paginator.getCurrentState().page;
     const second = paginator.forcePageBreak().page;
-    paginator.startSection(1, { type: "continue" });
+    paginator.startSection({ sectionIndex: 1, pageNumbering: { type: "continue" } });
     const continued = paginator.forcePageBreak().page;
-    paginator.startSection(2, { type: "restart", start: 4 });
+    paginator.startSection({ sectionIndex: 2, pageNumbering: { type: "restart", start: 4 } });
     const restarted = paginator.forcePageBreak().page;
 
     expect([first.number, second.number, continued.number, restarted.number]).toEqual([1, 2, 3, 4]);
@@ -114,7 +114,11 @@ describe("paginator logical page numbers", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
 
-    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
+    paginator.startSection({
+      sectionIndex: 1,
+      pageNumbering: { type: "restart", start: 2 },
+      placement: SECTION_START_PLACEMENT.CONTINUOUS,
+    });
     paginator.addFragment(paragraphFragment("incoming"), 20);
     const shared = paginator.pages[0];
     const following = paginator.forcePageBreak().page;
@@ -128,7 +132,11 @@ describe("paginator logical page numbers", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
 
-    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
+    paginator.startSection({
+      sectionIndex: 1,
+      pageNumbering: { type: "restart", start: 2 },
+      placement: SECTION_START_PLACEMENT.CONTINUOUS,
+    });
     paginator.addUnflowedFragment({
       kind: "image",
       blockId: "anchored-incoming",
@@ -148,7 +156,11 @@ describe("paginator logical page numbers", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 900);
 
-    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
+    paginator.startSection({
+      sectionIndex: 1,
+      pageNumbering: { type: "restart", start: 2 },
+      placement: SECTION_START_PLACEMENT.CONTINUOUS,
+    });
     paginator.addFragment(paragraphFragment("incoming"), 20);
 
     expect(paginator.pages).toHaveLength(2);
@@ -160,7 +172,7 @@ describe("paginator logical page numbers", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
 
-    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.startSection({ sectionIndex: 1, pageNumbering: { type: "restart", start: 2 } });
     paginator.forcePageBreak();
     paginator.addFragment(paragraphFragment("incoming"), 20);
 
@@ -173,7 +185,11 @@ describe("paginator logical page numbers", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
 
-    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
+    paginator.startSection({
+      sectionIndex: 1,
+      pageNumbering: { type: "restart", start: 2 },
+      placement: SECTION_START_PLACEMENT.CONTINUOUS,
+    });
     const following = paginator.forcePageBreak().page;
 
     expect(paginator.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([1, 3]);
@@ -183,7 +199,7 @@ describe("paginator logical page numbers", () => {
   test("advances authored ordinals when a hard break reuses the current sheet", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
-    paginator.startSection(1, { type: "restart", start: 0 });
+    paginator.startSection({ sectionIndex: 1, pageNumbering: { type: "restart", start: 0 } });
     paginator.forcePageBreak();
 
     const reused = paginator.coalescePageBreak().page;
@@ -245,7 +261,7 @@ describe("paginator forcePageBreak", () => {
     const nextSize = { w: 600, h: 700 };
     const nextMargins = { top: 30, right: 40, bottom: 50, left: 60 };
     paginator.updatePageLayout(nextSize, nextMargins);
-    paginator.startSection(1);
+    paginator.startSection({ sectionIndex: 1 });
 
     expect(paginator.retargetCurrentBlankPage()).toBe(true);
     expect(paginator.pages.length).toBe(1);
@@ -267,7 +283,7 @@ describe("paginator forcePageBreak", () => {
 
     const nextSize = { w: 600, h: 700 };
     paginator.updatePageLayout(nextSize, MARGINS);
-    paginator.startSection(1);
+    paginator.startSection({ sectionIndex: 1 });
 
     expect(paginator.retargetCurrentBlankPage()).toBe(false);
     expect(state.page.size).toEqual(SIZE);

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -114,21 +114,21 @@ describe("paginator logical page numbers", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
 
-    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
     paginator.addFragment(paragraphFragment("incoming"), 20);
     const shared = paginator.pages[0];
     const following = paginator.forcePageBreak().page;
 
     expect(shared?.fragments.map(({ blockId }) => blockId)).toEqual(["outgoing", "incoming"]);
     expect(shared).toMatchObject({ logicalNumber: 1, sectionIndex: 0, sectionPageNumber: 1 });
-    expect(following).toMatchObject({ logicalNumber: 3, sectionIndex: 1, sectionPageNumber: 1 });
+    expect(following).toMatchObject({ logicalNumber: 3, sectionIndex: 1, sectionPageNumber: 2 });
   });
 
   test("consumes a section restart on its first unflowed shared-page fragment", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 20);
 
-    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
     paginator.addUnflowedFragment({
       kind: "image",
       blockId: "anchored-incoming",
@@ -141,14 +141,14 @@ describe("paginator logical page numbers", () => {
     const following = paginator.forcePageBreak().page;
 
     expect(paginator.pages[0]).toMatchObject({ logicalNumber: 1, sectionIndex: 0 });
-    expect(following).toMatchObject({ logicalNumber: 3, sectionIndex: 1, sectionPageNumber: 1 });
+    expect(following).toMatchObject({ logicalNumber: 3, sectionIndex: 1, sectionPageNumber: 2 });
   });
 
   test("defers a restart when the first section fragment advances to a fresh page", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     paginator.addFragment(paragraphFragment("outgoing"), 900);
 
-    paginator.startSection(1, { type: "restart", start: 2 });
+    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
     paginator.addFragment(paragraphFragment("incoming"), 20);
 
     expect(paginator.pages).toHaveLength(2);
@@ -167,6 +167,29 @@ describe("paginator logical page numbers", () => {
     expect(paginator.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([1, 2]);
     expect(paginator.pages[0]?.sectionIndex).toBe(0);
     expect(paginator.pages[1]).toMatchObject({ sectionIndex: 1, sectionPageNumber: 1 });
+  });
+
+  test("consumes a continuous section first-page slot before a forced break", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.addFragment(paragraphFragment("outgoing"), 20);
+
+    paginator.startSection(1, { type: "restart", start: 2 }, "continuous");
+    const following = paginator.forcePageBreak().page;
+
+    expect(paginator.pages.map(({ logicalNumber }) => logicalNumber)).toEqual([1, 3]);
+    expect(following).toMatchObject({ sectionIndex: 1, sectionPageNumber: 2 });
+  });
+
+  test("advances authored ordinals when a hard break reuses the current sheet", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.addFragment(paragraphFragment("outgoing"), 20);
+    paginator.startSection(1, { type: "restart", start: 0 });
+    paginator.forcePageBreak();
+
+    const reused = paginator.coalescePageBreak().page;
+
+    expect(paginator.pages).toHaveLength(2);
+    expect(reused).toMatchObject({ logicalNumber: 1, sectionIndex: 1, sectionPageNumber: 2 });
   });
 });
 

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -92,9 +92,20 @@ type ForcePageBreakOptions = {
   coalesceBlankPage?: boolean;
 };
 
-type SectionStartPlacement = "continuous" | "nextPage";
+export const SECTION_START_PLACEMENT = {
+  CONTINUOUS: "continuous",
+  NEXT_PAGE: "nextPage",
+} as const;
+
+type SectionStartPlacement = (typeof SECTION_START_PLACEMENT)[keyof typeof SECTION_START_PLACEMENT];
 
 type SectionStartState = { type: "pending"; placement: SectionStartPlacement } | { type: "placed" };
+
+type StartSectionOptions = {
+  sectionIndex: number;
+  pageNumbering?: SectionPageNumbering;
+  placement?: SectionStartPlacement;
+};
 
 /** Calculate active column widths, preferring authored unequal widths. */
 function calculateColumnWidths(
@@ -685,11 +696,11 @@ export function createPaginator(options: PaginatorOptions) {
     pendingMargins = undefined;
   }
 
-  function startSection(
-    sectionIndex: number,
-    pageNumbering: SectionPageNumbering = { type: "continue" },
-    placement: SectionStartPlacement = "nextPage",
-  ): void {
+  function startSection({
+    sectionIndex,
+    pageNumbering = { type: "continue" },
+    placement = SECTION_START_PLACEMENT.NEXT_PAGE,
+  }: StartSectionOptions): void {
     currentSectionIndex = sectionIndex;
     currentSectionPageNumber = 0;
     currentPageNumbering = pageNumbering;

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -92,6 +92,10 @@ type ForcePageBreakOptions = {
   coalesceBlankPage?: boolean;
 };
 
+type SectionStartPlacement = "continuous" | "nextPage";
+
+type SectionStartState = { type: "pending"; placement: SectionStartPlacement } | { type: "placed" };
+
 /** Calculate active column widths, preferring authored unequal widths. */
 function calculateColumnWidths(
   pageWidth: number,
@@ -146,7 +150,7 @@ export function createPaginator(options: PaginatorOptions) {
   let currentPageNumbering: SectionPageNumbering = options.pageNumbering ?? { type: "continue" };
   let nextLogicalPageNumber =
     currentPageNumbering.type === "restart" ? currentPageNumbering.start : 1;
-  let sectionStartPending = true;
+  let sectionStart: SectionStartState = { type: "pending", placement: "nextPage" };
 
   const pages: Page[] = [];
   const states: PageState[] = [];
@@ -247,7 +251,7 @@ export function createPaginator(options: PaginatorOptions) {
     const pageNumber = pages.length + 1;
     const logicalNumber = nextLogicalPageNumber;
     nextLogicalPageNumber += 1;
-    sectionStartPending = false;
+    sectionStart = { type: "placed" };
     currentSectionPageNumber += 1;
     // Page 1 of the document may use first-page margins (extended top to
     // clear an overflowing first-page header on a titlePg section) while
@@ -424,18 +428,28 @@ export function createPaginator(options: PaginatorOptions) {
     return { state, x, y };
   }
 
-  function commitFragment(state: PageState, fragment: Fragment): void {
+  function consumeSharedSectionPage(state: PageState): void {
+    if (
+      sectionStart.type !== "pending" ||
+      sectionStart.placement !== "continuous" ||
+      state.page.sectionIndex === currentSectionIndex
+    ) {
+      return;
+    }
+
     // A continuous section can begin after content already placed on a page
     // owned by the outgoing section. That shared page keeps its owner and
-    // displayed number, but its incoming content consumes the authored restart
-    // for page-number arithmetic. The next page therefore advances past the
-    // restart while remaining the incoming section's first owned page.
-    if (sectionStartPending && state.page.sectionIndex !== currentSectionIndex) {
-      if (currentPageNumbering.type === "restart") {
-        nextLogicalPageNumber = currentPageNumbering.start + 1;
-      }
-      sectionStartPending = false;
+    // displayed number, but it consumes the incoming section's first-page
+    // slot and any authored page-number restart.
+    if (currentPageNumbering.type === "restart") {
+      nextLogicalPageNumber = currentPageNumbering.start + 1;
     }
+    currentSectionPageNumber = 1;
+    sectionStart = { type: "placed" };
+  }
+
+  function commitFragment(state: PageState, fragment: Fragment): void {
+    consumeSharedSectionPage(state);
 
     const fragments = state.page.fragments;
     fragments.push(fragment);
@@ -498,6 +512,9 @@ export function createPaginator(options: PaginatorOptions) {
    */
   function forcePageBreak(breakOptions: ForcePageBreakOptions = {}): PageState {
     const current = states.at(-1);
+    if (current?.page.fragments.length) {
+      consumeSharedSectionPage(current);
+    }
     if (
       breakOptions.coalesceBlankPage &&
       current &&
@@ -513,6 +530,44 @@ export function createPaginator(options: PaginatorOptions) {
       }
     }
     return createNewPage();
+  }
+
+  function coalescePageBreak(): PageState {
+    const state = getCurrentState();
+    consumeSharedSectionPage(state);
+
+    // A section boundary may already have opened the physical page that an
+    // adjacent hard break targets. Reusing that sheet removes only the blank
+    // page: the hard break still advances the section and authored PAGE
+    // ordinals that select first/default furniture and field values.
+    const previousMargins = state.page.margins;
+    const logicalNumber = nextLogicalPageNumber;
+    nextLogicalPageNumber += 1;
+    currentSectionPageNumber += 1;
+    state.page.logicalNumber = logicalNumber;
+    if (currentPageNumbering.format === undefined) {
+      delete state.page.logicalNumberFormat;
+    } else {
+      state.page.logicalNumberFormat = currentPageNumbering.format;
+    }
+    applySectionMetadata(state.page);
+
+    const pageMargins = getPageMargins(state.page.number, logicalNumber);
+    const xDelta = pageMargins.left - previousMargins.left;
+    const yDelta = pageMargins.top - previousMargins.top;
+    for (const fragment of state.page.fragments) {
+      fragment.x += xDelta;
+      fragment.y += yDelta;
+    }
+    state.page.margins = pageMargins;
+    state.topMargin = pageMargins.top;
+    state.cursorY += yDelta;
+    state.rawContentBottom = pageSize.h - pageMargins.bottom;
+    state.contentBottom = state.rawContentBottom - state.footnoteHeight;
+    columnRegionTop += yDelta;
+    columnRegionMaxBottom += yDelta;
+
+    return state;
   }
 
   function retargetCurrentBlankPage(): boolean {
@@ -633,11 +688,12 @@ export function createPaginator(options: PaginatorOptions) {
   function startSection(
     sectionIndex: number,
     pageNumbering: SectionPageNumbering = { type: "continue" },
+    placement: SectionStartPlacement = "nextPage",
   ): void {
     currentSectionIndex = sectionIndex;
     currentSectionPageNumber = 0;
     currentPageNumbering = pageNumbering;
-    sectionStartPending = true;
+    sectionStart = { type: "pending", placement };
     if (pageNumbering.type === "restart") {
       nextLogicalPageNumber = pageNumbering.start;
     }
@@ -645,11 +701,11 @@ export function createPaginator(options: PaginatorOptions) {
 
   function retargetSectionMetadata(page: Page): void {
     currentSectionPageNumber = 1;
-    if (sectionStartPending && currentPageNumbering.type === "restart") {
+    if (sectionStart.type === "pending" && currentPageNumbering.type === "restart") {
       page.logicalNumber = currentPageNumbering.start;
       nextLogicalPageNumber = currentPageNumbering.start + 1;
     }
-    sectionStartPending = false;
+    sectionStart = { type: "placed" };
     if (currentPageNumbering.format === undefined) {
       delete page.logicalNumberFormat;
     } else {
@@ -703,6 +759,8 @@ export function createPaginator(options: PaginatorOptions) {
     addFootnoteHeight,
     /** Force a page break. */
     forcePageBreak,
+    /** Reuse the current sheet while advancing authored page ordinals. */
+    coalescePageBreak,
     /** Reuse an already blank current page for the active section/layout. */
     retargetCurrentBlankPage,
     /** Force a column break. */

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -50,7 +50,7 @@ describe("rendered break reconciliation", () => {
     });
 
     expect(decision).toEqual({
-      forcePageBreak: true,
+      pageAdvance: "physical",
       suppressSpaceBefore: false,
       state: INITIAL_RENDERED_BREAK_STATE,
     });
@@ -69,7 +69,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
     expect(decision.suppressSpaceBefore).toBe(true);
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
@@ -86,7 +86,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.suppressSpaceBefore).toBe(false);
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
@@ -103,7 +103,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
@@ -122,7 +122,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
     expect(decision.suppressSpaceBefore).toBe(true);
   });
 
@@ -138,7 +138,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
     expect(decision.suppressSpaceBefore).toBe(true);
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
@@ -155,7 +155,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.suppressSpaceBefore).toBe(true);
   });
 
@@ -176,7 +176,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.suppressSpaceBefore).toBe(false);
   });
 
@@ -196,7 +196,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.suppressSpaceBefore).toBe(true);
   });
 
@@ -216,7 +216,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
     expect(decision.suppressSpaceBefore).toBe(false);
   });
 
@@ -236,7 +236,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.suppressSpaceBefore).toBe(false);
   });
 
@@ -269,7 +269,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.suppressSpaceBefore).toBe(true);
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
@@ -406,7 +406,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
@@ -426,7 +426,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
   });
 
   test("different tab layouts leave a cached marker authoritative", () => {
@@ -453,7 +453,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
   });
 
   test("pages containing only empty paragraphs do not force another break", () => {
@@ -468,7 +468,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: true,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("none");
   });
 
   test("pageBreakBefore does not create an empty page after an authored boundary", () => {
@@ -488,7 +488,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(false);
+    expect(decision.pageAdvance).toBe("coalesced");
   });
 
   test("a hard page break reuses a page already opened by a carried section boundary", () => {
@@ -509,7 +509,7 @@ describe("rendered break reconciliation", () => {
     });
 
     expect(firstDecision).toMatchObject({
-      forcePageBreak: false,
+      pageAdvance: "coalesced",
       state: { boundary: "sectionBreak", nextHardBreak: "advance" },
     });
 
@@ -523,7 +523,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(secondDecision.forcePageBreak).toBe(true);
+    expect(secondDecision.pageAdvance).toBe("physical");
   });
 
   test("pageBreakBefore still advances a page with visible body content", () => {
@@ -538,7 +538,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
   });
 
   test("pageBreakBefore preserves a distinct preceding hard-break boundary", () => {
@@ -556,7 +556,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.forcePageBreak).toBe(true);
+    expect(decision.pageAdvance).toBe("physical");
   });
 });
 

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -27,7 +27,7 @@ type ReconcileBeforeBlockOptions = {
 };
 
 type BreakDecision = {
-  forcePageBreak: boolean;
+  pageAdvance: "coalesced" | "none" | "physical";
   suppressSpaceBefore: boolean;
   state: RenderedBreakState;
 };
@@ -57,7 +57,7 @@ export const reconcileBreakBeforeBlock = ({
       state.nextHardBreak === "coalesce" &&
       !pageHasVisibleBodyContent(page, blocksById);
     return {
-      forcePageBreak: !sectionBoundaryAlreadyOpenedPage,
+      pageAdvance: sectionBoundaryAlreadyOpenedPage ? "coalesced" : "physical",
       suppressSpaceBefore: false,
       state: sectionBoundaryAlreadyOpenedPage
         ? {
@@ -70,7 +70,7 @@ export const reconcileBreakBeforeBlock = ({
     };
   }
   if (block.kind !== "paragraph" || block.attrs?.renderedPageBreakBefore !== true) {
-    return { forcePageBreak: false, suppressSpaceBefore: false, state };
+    return { pageAdvance: "none", suppressSpaceBefore: false, state };
   }
 
   const markerAlreadySatisfied =
@@ -107,7 +107,7 @@ export const reconcileBreakBeforeBlock = ({
     followsPageBreakingSection;
 
   return {
-    forcePageBreak,
+    pageAdvance: forcePageBreak ? "physical" : "none",
     // The boundary consumes inherited/default leading spacing. Preserve only
     // spacing authored directly on the first paragraph of a section.
     suppressSpaceBefore: markerAccountsForBoundary && !preserveSectionLeadingSpacing,

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -26,8 +26,16 @@ type ReconcileBeforeBlockOptions = {
   renderedBreakNeedsSnap: boolean;
 };
 
+export const PAGE_ADVANCE = {
+  COALESCED: "coalesced",
+  NONE: "none",
+  PHYSICAL: "physical",
+} as const;
+
+type PageAdvance = (typeof PAGE_ADVANCE)[keyof typeof PAGE_ADVANCE];
+
 type BreakDecision = {
-  pageAdvance: "coalesced" | "none" | "physical";
+  pageAdvance: PageAdvance;
   suppressSpaceBefore: boolean;
   state: RenderedBreakState;
 };
@@ -57,7 +65,9 @@ export const reconcileBreakBeforeBlock = ({
       state.nextHardBreak === "coalesce" &&
       !pageHasVisibleBodyContent(page, blocksById);
     return {
-      pageAdvance: sectionBoundaryAlreadyOpenedPage ? "coalesced" : "physical",
+      pageAdvance: sectionBoundaryAlreadyOpenedPage
+        ? PAGE_ADVANCE.COALESCED
+        : PAGE_ADVANCE.PHYSICAL,
       suppressSpaceBefore: false,
       state: sectionBoundaryAlreadyOpenedPage
         ? {
@@ -70,7 +80,7 @@ export const reconcileBreakBeforeBlock = ({
     };
   }
   if (block.kind !== "paragraph" || block.attrs?.renderedPageBreakBefore !== true) {
-    return { pageAdvance: "none", suppressSpaceBefore: false, state };
+    return { pageAdvance: PAGE_ADVANCE.NONE, suppressSpaceBefore: false, state };
   }
 
   const markerAlreadySatisfied =
@@ -107,7 +117,7 @@ export const reconcileBreakBeforeBlock = ({
     followsPageBreakingSection;
 
   return {
-    pageAdvance: forcePageBreak ? "physical" : "none",
+    pageAdvance: forcePageBreak ? PAGE_ADVANCE.PHYSICAL : PAGE_ADVANCE.NONE,
     // The boundary consumes inherited/default leading spacing. Preserve only
     // spacing authored directly on the first paragraph of a section.
     suppressSpaceBefore: markerAccountsForBoundary && !preserveSectionLeadingSpacing,


### PR DESCRIPTION
## Summary

- distinguish physical, coalesced, and absent page advances during break reconciliation
- advance authored and section page ordinals when an adjacent hard break reuses an existing sheet
- preserve section furniture selection and cover the behavior with focused pagination regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page numbering when section breaks and explicit page breaks share the same physical page.
  * Preserved section page numbers, headers and footers across adjacent hard breaks.
  * Corrected continuous-section behaviour when page dimensions change.
  * Ensured default page furniture remains available after coalesced page breaks.

* **Release**
  * Prepared a patch release for `@stll/folio-core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->