### PR TITLE
fix: preserve absolute VML image anchors

### DIFF
--- a/.changeset/tidy-vml-images.md
+++ b/.changeset/tidy-vml-images.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve absolute VML image positioning without adding page artwork to text flow.

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -231,10 +231,10 @@ describe("VML w:pict inline images", () => {
     });
   });
 
-  test("places negative-z absolute VML images behind text", async () => {
+  test("maps text-relative negative-z VML images behind text", async () => {
     const doc = await parseDocx(
       await pictDocx({
-        runXml: `<w:pict><v:shape type="#_x0000_t75" style="position:absolute;left:12pt;top:6pt;width:2in;height:1in;z-index:-1;mso-position-horizontal-relative:margin;mso-position-vertical-relative:line"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+        runXml: `<w:pict><v:shape type="#_x0000_t75" style="position:absolute;left:12pt;top:6pt;width:2in;height:1in;z-index:-1;mso-position-horizontal-relative:text;mso-position-vertical-relative:text"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
       }),
       { preloadFonts: false },
     );
@@ -242,8 +242,22 @@ describe("VML w:pict inline images", () => {
     const drawing = firstDrawing(doc.package.document.content.at(0));
     expect(drawing?.image.wrap.type).toBe("behind");
     expect(drawing?.image.position).toEqual({
-      horizontal: { relativeTo: "margin", posOffset: 152_400 },
-      vertical: { relativeTo: "line", posOffset: 76_200 },
+      horizontal: { relativeTo: "column", posOffset: 152_400 },
+      vertical: { relativeTo: "paragraph", posOffset: 76_200 },
+    });
+  });
+
+  test("maps VML margin-area anchors to the internal coordinate spaces", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape type="#_x0000_t75" style="position:absolute;width:2in;height:1in;mso-position-horizontal-relative:left-margin-area;mso-position-vertical-relative:top-margin-area"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    expect(firstDrawing(doc.package.document.content.at(0))?.image.position).toEqual({
+      horizontal: { relativeTo: "leftMargin", posOffset: 0 },
+      vertical: { relativeTo: "topMargin", posOffset: 0 },
     });
   });
 

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -516,7 +516,8 @@ describe("VML w:pict inline images", () => {
   });
 
   test("rejects VML lengths too large for finite layout coordinates", async () => {
-    const hugeLength = "9".repeat(400);
+    const hugeLength = "9".repeat(308);
+    expect(Number.isFinite(Number.parseFloat(hugeLength))).toBe(true);
     const doc = await parseDocx(
       await pictDocx({
         runXml: `<w:pict><v:shape style="position:absolute;margin-left:${hugeLength}pt;width:${hugeLength}pt;height:1in"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -215,6 +215,38 @@ describe("VML w:pict inline images", () => {
     expect(drawing?.image.title).toBe("logo");
   });
 
+  test("preserves absolute VML image anchors without adding them to text flow", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape id="Footer logo" type="#_x0000_t75" style="position:absolute;margin-left:514.95pt;margin-top:774.95pt;width:44.5pt;height:45.6pt;z-index:251658240;mso-position-horizontal-relative:page;mso-position-vertical-relative:page"><v:imagedata r:id="rIdImg" o:title="logo"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.wrap.type).toBe("inFront");
+    expect(drawing?.image.position).toEqual({
+      horizontal: { relativeTo: "page", posOffset: 6_539_865 },
+      vertical: { relativeTo: "page", posOffset: 9_841_865 },
+    });
+  });
+
+  test("places negative-z absolute VML images behind text", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape type="#_x0000_t75" style="position:absolute;left:12pt;top:6pt;width:2in;height:1in;z-index:-1;mso-position-horizontal-relative:margin;mso-position-vertical-relative:line"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.wrap.type).toBe("behind");
+    expect(drawing?.image.position).toEqual({
+      horizontal: { relativeTo: "margin", posOffset: 152_400 },
+      vertical: { relativeTo: "line", posOffset: 76_200 },
+    });
+  });
+
   test("preserves the original VML verbatim on save (no DrawingML conversion)", async () => {
     const original = await pictDocx({ runXml: PICT_WITH_IMAGE });
     const doc = await parseDocx(original, { preloadFonts: false });
@@ -481,6 +513,20 @@ describe("VML w:pict inline images", () => {
     // to `1.2`; the valid height still parses.
     expect(drawing?.image.size.width).toBe(0);
     expect(drawing?.image.size.height).toBe(914_400);
+  });
+
+  test("rejects VML lengths too large for finite layout coordinates", async () => {
+    const hugeLength = "9".repeat(400);
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:shape style="position:absolute;margin-left:${hugeLength}pt;width:${hugeLength}pt;height:1in"><v:imagedata r:id="rIdImg"/></v:shape></w:pict>`,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.size).toEqual({ width: 0, height: 914_400 });
+    expect(drawing?.image.position?.horizontal.posOffset).toBe(0);
   });
 
   test("resolves the relationship id from o:relid when r:id is absent", async () => {

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -28,7 +28,13 @@
  * Ported from eigenpal/docx-editor `vmlImageParser.ts`.
  */
 
-import type { DrawingContent, Image, MediaFile, RelationshipMap } from "../types/document";
+import type {
+  DrawingContent,
+  Image,
+  ImagePosition,
+  MediaFile,
+  RelationshipMap,
+} from "../types/document";
 import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import { pixelsToEmu } from "../utils/units";
 import { resolveImageData } from "./imageParser";
@@ -67,6 +73,26 @@ const SAFE_VML_COLORS = new Set([
   "teal",
   "aqua",
 ]);
+const VML_HORIZONTAL_RELATIVES = new Set<ImagePosition["horizontal"]["relativeTo"]>([
+  "character",
+  "column",
+  "insideMargin",
+  "leftMargin",
+  "margin",
+  "outsideMargin",
+  "page",
+  "rightMargin",
+]);
+const VML_VERTICAL_RELATIVES = new Set<ImagePosition["vertical"]["relativeTo"]>([
+  "insideMargin",
+  "line",
+  "margin",
+  "outsideMargin",
+  "page",
+  "paragraph",
+  "topMargin",
+  "bottomMargin",
+]);
 
 /**
  * Convert a CSS length (pt/in/px/cm/mm/pc, default px) to pixels. Units are
@@ -86,7 +112,7 @@ function cssLengthToPx(raw: string | undefined): number | undefined {
     return undefined;
   }
   const value = Number.parseFloat(amountText);
-  if (Number.isNaN(value)) {
+  if (!Number.isFinite(value)) {
     return undefined;
   }
   switch (match?.groups?.["unit"]?.toLowerCase()) {
@@ -169,6 +195,53 @@ const safeColor = (raw: string | null, fallback: string): string => {
 
 const validPreviewDimension = (value: number | undefined): value is number =>
   value !== undefined && value > 0 && value <= MAX_VML_PREVIEW_DIMENSION_PX;
+
+const horizontalRelativeTo = (
+  value: string | undefined,
+): ImagePosition["horizontal"]["relativeTo"] => {
+  for (const relative of VML_HORIZONTAL_RELATIVES) {
+    if (relative.toLowerCase() === value?.toLowerCase()) {
+      return relative;
+    }
+  }
+  return "character";
+};
+
+const verticalRelativeTo = (
+  value: string | undefined,
+): ImagePosition["vertical"]["relativeTo"] => {
+  for (const relative of VML_VERTICAL_RELATIVES) {
+    if (relative.toLowerCase() === value?.toLowerCase()) {
+      return relative;
+    }
+  }
+  return "paragraph";
+};
+
+const vmlImageLayout = (
+  style: Record<string, string>,
+): Pick<Image, "wrap"> & { position?: ImagePosition } => {
+  if (style["position"]?.toLowerCase() !== "absolute") {
+    return { wrap: { type: "inline" } };
+  }
+
+  const leftPx = cssLengthToPx(style["margin-left"] ?? style["left"]) ?? 0;
+  const topPx = cssLengthToPx(style["margin-top"] ?? style["top"]) ?? 0;
+  const zIndex = finiteNumber(style["z-index"]);
+  return {
+    wrap: { type: zIndex !== undefined && zIndex < 0 ? "behind" : "inFront" },
+    position: {
+      horizontal: {
+        relativeTo: horizontalRelativeTo(style["mso-position-horizontal-relative"]),
+        posOffset: pixelsToEmu(leftPx),
+      },
+      vertical: {
+        relativeTo: verticalRelativeTo(style["mso-position-vertical-relative"]),
+        posOffset: pixelsToEmu(topPx),
+      },
+    },
+  };
+};
 
 const svgDataUrl = (svg: string): string | undefined =>
   svg.length <= MAX_VML_SVG_CHARACTERS
@@ -386,9 +459,9 @@ export function parseVmlImageContent(
       continue;
     }
 
-    // VML pictures in a run are inline-flow. Absolute-positioned VML is treated
-    // as inline here too: rendering the picture in flow is far better than
-    // dropping it, and the original XML round-trips verbatim via rawXml.
+    // Static VML pictures participate in the run's inline flow. Absolute VML
+    // pictures are page artwork: preserve their authored anchor so they paint
+    // at the correct location without contributing to paragraph height.
     const image: Image = {
       type: "image",
       rId,
@@ -396,7 +469,7 @@ export function parseVmlImageContent(
         width: widthPx != null ? pixelsToEmu(widthPx) : 0,
         height: heightPx != null ? pixelsToEmu(heightPx) : 0,
       },
-      wrap: { type: "inline" },
+      ...vmlImageLayout(shapeStyle),
     };
     const safeSrc = sanitizeImageSrc(src);
     if (safeSrc) {

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -74,29 +74,9 @@ const SAFE_VML_COLORS = new Set([
   "aqua",
 ]);
 const VML_POSITION_ABSOLUTE = "absolute";
-const IMAGE_WRAP_INLINE = "inline" satisfies Image["wrap"]["type"];
-const IMAGE_WRAP_BEHIND = "behind" satisfies Image["wrap"]["type"];
-const IMAGE_WRAP_IN_FRONT = "inFront" satisfies Image["wrap"]["type"];
-const VML_HORIZONTAL_RELATIVE_TO = new Map<string, ImagePosition["horizontal"]["relativeTo"]>([
-  ["char", "character"],
-  ["text", "column"],
-  ["margin", "margin"],
-  ["page", "page"],
-  ["left-margin-area", "leftMargin"],
-  ["right-margin-area", "rightMargin"],
-  ["inner-margin-area", "insideMargin"],
-  ["outer-margin-area", "outsideMargin"],
-]);
-const VML_VERTICAL_RELATIVE_TO = new Map<string, ImagePosition["vertical"]["relativeTo"]>([
-  ["line", "line"],
-  ["text", "paragraph"],
-  ["margin", "margin"],
-  ["page", "page"],
-  ["top-margin-area", "topMargin"],
-  ["bottom-margin-area", "bottomMargin"],
-  ["inner-margin-area", "insideMargin"],
-  ["outer-margin-area", "outsideMargin"],
-]);
+const IMAGE_WRAP_INLINE = "inline";
+const IMAGE_WRAP_BEHIND = "behind";
+const IMAGE_WRAP_IN_FRONT = "inFront";
 
 /**
  * Convert a CSS length (pt/in/px/cm/mm/pc, default px) to pixels. Units are
@@ -207,11 +187,51 @@ const pixelsToSafeEmu = (pixels: number): number | undefined => {
 
 const horizontalRelativeTo = (
   value: string | undefined,
-): ImagePosition["horizontal"]["relativeTo"] =>
-  VML_HORIZONTAL_RELATIVE_TO.get(value?.toLowerCase() ?? "") ?? "character";
+): ImagePosition["horizontal"]["relativeTo"] => {
+  switch (value?.toLowerCase()) {
+    case "char":
+      return "character";
+    case "text":
+      return "column";
+    case "margin":
+      return "margin";
+    case "page":
+      return "page";
+    case "left-margin-area":
+      return "leftMargin";
+    case "right-margin-area":
+      return "rightMargin";
+    case "inner-margin-area":
+      return "insideMargin";
+    case "outer-margin-area":
+      return "outsideMargin";
+    default:
+      return "character";
+  }
+};
 
-const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"]["relativeTo"] =>
-  VML_VERTICAL_RELATIVE_TO.get(value?.toLowerCase() ?? "") ?? "paragraph";
+const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"]["relativeTo"] => {
+  switch (value?.toLowerCase()) {
+    case "line":
+      return "line";
+    case "text":
+      return "paragraph";
+    case "margin":
+      return "margin";
+    case "page":
+      return "page";
+    case "top-margin-area":
+      return "topMargin";
+    case "bottom-margin-area":
+      return "bottomMargin";
+    case "inner-margin-area":
+      return "insideMargin";
+    case "outer-margin-area":
+      return "outsideMargin";
+    default:
+      return "paragraph";
+  }
+};
 
 const vmlImageLayout = (
   style: Record<string, string>,

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -196,6 +196,11 @@ const safeColor = (raw: string | null, fallback: string): string => {
 const validPreviewDimension = (value: number | undefined): value is number =>
   value !== undefined && value > 0 && value <= MAX_VML_PREVIEW_DIMENSION_PX;
 
+const pixelsToSafeEmu = (pixels: number): number | undefined => {
+  const emu = pixelsToEmu(pixels);
+  return Number.isSafeInteger(emu) ? emu : undefined;
+};
+
 const horizontalRelativeTo = (
   value: string | undefined,
 ): ImagePosition["horizontal"]["relativeTo"] => {
@@ -207,9 +212,7 @@ const horizontalRelativeTo = (
   return "character";
 };
 
-const verticalRelativeTo = (
-  value: string | undefined,
-): ImagePosition["vertical"]["relativeTo"] => {
+const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"]["relativeTo"] => {
   for (const relative of VML_VERTICAL_RELATIVES) {
     if (relative.toLowerCase() === value?.toLowerCase()) {
       return relative;
@@ -233,11 +236,11 @@ const vmlImageLayout = (
     position: {
       horizontal: {
         relativeTo: horizontalRelativeTo(style["mso-position-horizontal-relative"]),
-        posOffset: pixelsToEmu(leftPx),
+        posOffset: pixelsToSafeEmu(leftPx) ?? 0,
       },
       vertical: {
         relativeTo: verticalRelativeTo(style["mso-position-vertical-relative"]),
-        posOffset: pixelsToEmu(topPx),
+        posOffset: pixelsToSafeEmu(topPx) ?? 0,
       },
     },
   };
@@ -288,11 +291,11 @@ const previewImage = (
     position: {
       horizontal: {
         relativeTo: horizontalRelative ? "page" : "character",
-        posOffset: pixelsToEmu(leftPx),
+        posOffset: pixelsToSafeEmu(leftPx) ?? 0,
       },
       vertical: {
         relativeTo: verticalRelative ? "page" : "paragraph",
-        posOffset: pixelsToEmu(topPx),
+        posOffset: pixelsToSafeEmu(topPx) ?? 0,
       },
     },
   };
@@ -466,8 +469,8 @@ export function parseVmlImageContent(
       type: "image",
       rId,
       size: {
-        width: widthPx != null ? pixelsToEmu(widthPx) : 0,
-        height: heightPx != null ? pixelsToEmu(heightPx) : 0,
+        width: widthPx != null ? (pixelsToSafeEmu(widthPx) ?? 0) : 0,
+        height: heightPx != null ? (pixelsToSafeEmu(heightPx) ?? 0) : 0,
       },
       ...vmlImageLayout(shapeStyle),
     };

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -73,25 +73,29 @@ const SAFE_VML_COLORS = new Set([
   "teal",
   "aqua",
 ]);
-const VML_HORIZONTAL_RELATIVES = new Set<ImagePosition["horizontal"]["relativeTo"]>([
-  "character",
-  "column",
-  "insideMargin",
-  "leftMargin",
-  "margin",
-  "outsideMargin",
-  "page",
-  "rightMargin",
+const VML_POSITION_ABSOLUTE = "absolute";
+const IMAGE_WRAP_INLINE = "inline" satisfies Image["wrap"]["type"];
+const IMAGE_WRAP_BEHIND = "behind" satisfies Image["wrap"]["type"];
+const IMAGE_WRAP_IN_FRONT = "inFront" satisfies Image["wrap"]["type"];
+const VML_HORIZONTAL_RELATIVE_TO = new Map<string, ImagePosition["horizontal"]["relativeTo"]>([
+  ["char", "character"],
+  ["text", "column"],
+  ["margin", "margin"],
+  ["page", "page"],
+  ["left-margin-area", "leftMargin"],
+  ["right-margin-area", "rightMargin"],
+  ["inner-margin-area", "insideMargin"],
+  ["outer-margin-area", "outsideMargin"],
 ]);
-const VML_VERTICAL_RELATIVES = new Set<ImagePosition["vertical"]["relativeTo"]>([
-  "insideMargin",
-  "line",
-  "margin",
-  "outsideMargin",
-  "page",
-  "paragraph",
-  "topMargin",
-  "bottomMargin",
+const VML_VERTICAL_RELATIVE_TO = new Map<string, ImagePosition["vertical"]["relativeTo"]>([
+  ["line", "line"],
+  ["text", "paragraph"],
+  ["margin", "margin"],
+  ["page", "page"],
+  ["top-margin-area", "topMargin"],
+  ["bottom-margin-area", "bottomMargin"],
+  ["inner-margin-area", "insideMargin"],
+  ["outer-margin-area", "outsideMargin"],
 ]);
 
 /**
@@ -203,36 +207,26 @@ const pixelsToSafeEmu = (pixels: number): number | undefined => {
 
 const horizontalRelativeTo = (
   value: string | undefined,
-): ImagePosition["horizontal"]["relativeTo"] => {
-  for (const relative of VML_HORIZONTAL_RELATIVES) {
-    if (relative.toLowerCase() === value?.toLowerCase()) {
-      return relative;
-    }
-  }
-  return "character";
-};
+): ImagePosition["horizontal"]["relativeTo"] =>
+  VML_HORIZONTAL_RELATIVE_TO.get(value?.toLowerCase() ?? "") ?? "character";
 
-const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"]["relativeTo"] => {
-  for (const relative of VML_VERTICAL_RELATIVES) {
-    if (relative.toLowerCase() === value?.toLowerCase()) {
-      return relative;
-    }
-  }
-  return "paragraph";
-};
+const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"]["relativeTo"] =>
+  VML_VERTICAL_RELATIVE_TO.get(value?.toLowerCase() ?? "") ?? "paragraph";
 
 const vmlImageLayout = (
   style: Record<string, string>,
 ): Pick<Image, "wrap"> & { position?: ImagePosition } => {
-  if (style["position"]?.toLowerCase() !== "absolute") {
-    return { wrap: { type: "inline" } };
+  if (style["position"]?.toLowerCase() !== VML_POSITION_ABSOLUTE) {
+    return { wrap: { type: IMAGE_WRAP_INLINE } };
   }
 
   const leftPx = cssLengthToPx(style["margin-left"] ?? style["left"]) ?? 0;
   const topPx = cssLengthToPx(style["margin-top"] ?? style["top"]) ?? 0;
   const zIndex = finiteNumber(style["z-index"]);
   return {
-    wrap: { type: zIndex !== undefined && zIndex < 0 ? "behind" : "inFront" },
+    wrap: {
+      type: zIndex !== undefined && zIndex < 0 ? IMAGE_WRAP_BEHIND : IMAGE_WRAP_IN_FRONT,
+    },
     position: {
       horizontal: {
         relativeTo: horizontalRelativeTo(style["mso-position-horizontal-relative"]),


### PR DESCRIPTION
## Summary

- preserve page-relative positions for absolute VML pictures
- map authored z-order to anchored image wrapping while keeping static VML inline
- reject non-finite VML dimensions and offsets at the parser boundary

## Validation

- `bun test packages/core/src/docx/vmlImageParser.test.ts packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts`
- targeted oxlint
- visual interoperability render: page count 3/3; raster similarity improved from 68.1% to 90.4%

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of absolutely positioned VML images, preserving their placement in front of or behind text.
  - Correctly applies page-, margin-, and line-relative positioning based on image styles.
  - Rejects excessively large or invalid image dimensions to prevent incorrect layout coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->