### PR TITLE
fix: suppress automatic spacing at cell edges

### DIFF
--- a/.changeset/warm-cell-boundaries.md
+++ b/.changeset/warm-cell-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Suppress automatic paragraph spacing at table-cell boundaries while preserving interior and authored spacing.

--- a/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
@@ -197,6 +197,34 @@ describe("table cell block flow", () => {
     expect(finishTableCellFlow(state)).toBe(18);
   });
 
+  test("suppresses automatic paragraph spacing at table-cell boundaries", () => {
+    const state = createTableCellFlowState();
+    const block = paragraph("body", "body", { before: 14, after: 14 });
+    block.attrs = {
+      ...block.attrs,
+      automaticSpacing: { before: true, after: true },
+    };
+
+    const placement = placeTableCellBlock(state, block, measure(10, 28));
+
+    expect(placement.leadingSpacing).toBe(0);
+    expect(finishTableCellFlow(state)).toBe(10);
+  });
+
+  test("preserves automatic paragraph spacing inside a table cell", () => {
+    const state = createTableCellFlowState();
+    const first = paragraph("first", "first", { after: 14 });
+    first.attrs = { ...first.attrs, automaticSpacing: { after: true } };
+    const second = paragraph("second", "second", { before: 14 });
+    second.attrs = { ...second.attrs, automaticSpacing: { before: true } };
+
+    placeTableCellBlock(state, first, measure(10, 14));
+    const placement = placeTableCellBlock(state, second, measure(10, 14));
+
+    expect(placement.leadingSpacing).toBe(14);
+    expect(finishTableCellFlow(state)).toBe(34);
+  });
+
   test("keeps a suppressed empty paragraph at zero height", () => {
     const state = createTableCellFlowState();
     const block = paragraph("marker", "", { before: 8, after: 8 });

--- a/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.test.ts
@@ -7,6 +7,8 @@ import type {
   ParagraphMeasure,
   TableCell,
   TableCellMeasure,
+  TextBoxBlock,
+  TextBoxMeasure,
 } from "../types";
 import {
   createTableCellFlowState,
@@ -57,6 +59,22 @@ const suppressedMeasure: ParagraphMeasure = {
     },
   ],
   totalHeight: 0,
+};
+
+const textBox = (displayMode: "block" | "float"): TextBoxBlock => ({
+  kind: "textBox",
+  id: `box-${displayMode}`,
+  width: 20,
+  height: 20,
+  content: [],
+  displayMode,
+});
+
+const textBoxMeasure: TextBoxMeasure = {
+  kind: "textBox",
+  width: 20,
+  height: 20,
+  innerMeasures: [],
 };
 
 describe("table cell block flow", () => {
@@ -223,6 +241,32 @@ describe("table cell block flow", () => {
 
     expect(placement.leadingSpacing).toBe(14);
     expect(finishTableCellFlow(state)).toBe(34);
+  });
+
+  test("keeps a floating text box outside cell flow and preserves the leading boundary", () => {
+    const state = createTableCellFlowState();
+    const automatic = paragraph("body", "body", { before: 14 });
+    automatic.attrs = { ...automatic.attrs, automaticSpacing: { before: true } };
+
+    const floatingPlacement = placeTableCellBlock(state, textBox("float"), textBoxMeasure);
+    const paragraphPlacement = placeTableCellBlock(state, automatic, measure(10, 14));
+
+    expect(floatingPlacement.contentHeight).toBe(0);
+    expect(paragraphPlacement.leadingSpacing).toBe(0);
+    expect(finishTableCellFlow(state)).toBe(10);
+  });
+
+  test("an in-flow text box consumes the cell boundary", () => {
+    const state = createTableCellFlowState();
+    const automatic = paragraph("body", "body", { before: 14 });
+    automatic.attrs = { ...automatic.attrs, automaticSpacing: { before: true } };
+
+    const boxPlacement = placeTableCellBlock(state, textBox("block"), textBoxMeasure);
+    const paragraphPlacement = placeTableCellBlock(state, automatic, measure(10, 14));
+
+    expect(boxPlacement.contentHeight).toBe(20);
+    expect(paragraphPlacement.leadingSpacing).toBe(14);
+    expect(finishTableCellFlow(state)).toBe(44);
   });
 
   test("keeps a suppressed empty paragraph at zero height", () => {

--- a/packages/core/src/layout-engine/measure/tableCellFlow.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.ts
@@ -123,6 +123,11 @@ export const placeTableCellBlock = (
   ) {
     return { top, contentTop: top, contentHeight: 0, leadingSpacing: 0 };
   }
+  // Floating text boxes paint outside the cell's block flow. Keeping this a
+  // no-op matches the painter and preserves the boundary for visible content.
+  if (block.kind === "textBox" && isFloatingTextBoxBlock(block)) {
+    return { top, contentTop: top, contentHeight: 0, leadingSpacing: 0 };
+  }
   if (block.kind !== "paragraph" || measure.kind !== "paragraph") {
     const leadingSpacing = trailingSpacingValue(state.trailingSpacing);
     const contentTop = top + leadingSpacing;

--- a/packages/core/src/layout-engine/measure/tableCellFlow.ts
+++ b/packages/core/src/layout-engine/measure/tableCellFlow.ts
@@ -15,20 +15,60 @@ export type TableCellBlockPlacement = {
   leadingSpacing: number;
 };
 
+const TABLE_CELL_FLOW_POSITION = {
+  start: "start",
+  interior: "interior",
+} as const;
+type TableCellFlowPosition =
+  (typeof TABLE_CELL_FLOW_POSITION)[keyof typeof TABLE_CELL_FLOW_POSITION];
+
+const TABLE_CELL_TRAILING_SPACING_TYPE = {
+  none: "none",
+  authored: "authored",
+  automatic: "automatic",
+} as const;
+
+type TableCellTrailingSpacing =
+  | { type: typeof TABLE_CELL_TRAILING_SPACING_TYPE.none }
+  | { type: typeof TABLE_CELL_TRAILING_SPACING_TYPE.authored; value: number }
+  | { type: typeof TABLE_CELL_TRAILING_SPACING_TYPE.automatic; value: number };
+
 export type TableCellFlowState = {
   height: number;
+  position: TableCellFlowPosition;
   previousParagraphWasEmpty: boolean;
-  trailingSpacing: number;
+  trailingSpacing: TableCellTrailingSpacing;
 };
 
 export const createTableCellFlowState = (): TableCellFlowState => ({
   height: 0,
+  position: TABLE_CELL_FLOW_POSITION.start,
   previousParagraphWasEmpty: false,
-  trailingSpacing: 0,
+  trailingSpacing: { type: TABLE_CELL_TRAILING_SPACING_TYPE.none },
 });
 
-export const finishTableCellFlow = (state: TableCellFlowState): number =>
-  state.height + state.trailingSpacing;
+const trailingSpacingValue = (spacing: TableCellTrailingSpacing): number => {
+  switch (spacing.type) {
+    case TABLE_CELL_TRAILING_SPACING_TYPE.none:
+      return 0;
+    case TABLE_CELL_TRAILING_SPACING_TYPE.authored:
+    case TABLE_CELL_TRAILING_SPACING_TYPE.automatic:
+      return spacing.value;
+    default: {
+      const unhandled: never = spacing;
+      return unhandled;
+    }
+  }
+};
+
+export const finishTableCellFlow = (state: TableCellFlowState): number => {
+  // Automatic HTML paragraph spacing is suppressed at a table-cell boundary;
+  // authored spacing remains part of the cell box.
+  if (state.trailingSpacing.type === TABLE_CELL_TRAILING_SPACING_TYPE.automatic) {
+    return state.height;
+  }
+  return state.height + trailingSpacingValue(state.trailingSpacing);
+};
 
 const isSuppressedParagraphMeasure = (measure: ParagraphMeasure): boolean =>
   measure.totalHeight === 0 && measure.lines.every(({ lineHeight }) => lineHeight === 0);
@@ -84,23 +124,35 @@ export const placeTableCellBlock = (
     return { top, contentTop: top, contentHeight: 0, leadingSpacing: 0 };
   }
   if (block.kind !== "paragraph" || measure.kind !== "paragraph") {
-    const leadingSpacing = state.trailingSpacing;
+    const leadingSpacing = trailingSpacingValue(state.trailingSpacing);
     const contentTop = top + leadingSpacing;
     state.height = contentTop + contentHeight;
+    state.position = TABLE_CELL_FLOW_POSITION.interior;
     state.previousParagraphWasEmpty = false;
-    state.trailingSpacing = 0;
+    state.trailingSpacing = { type: TABLE_CELL_TRAILING_SPACING_TYPE.none };
     return { top, contentTop, contentHeight, leadingSpacing };
   }
 
   const spacing = paragraphSpacing(block, measure);
   const empty = isEmptyParagraph(block);
+  // Apply the same boundary rule to the first visible paragraph in the cell.
+  const before =
+    state.position === TABLE_CELL_FLOW_POSITION.start &&
+    block.attrs?.automaticSpacing?.before === true
+      ? 0
+      : spacing.before;
+  const trailingSpacing = trailingSpacingValue(state.trailingSpacing);
   const leadingSpacing =
     empty && state.previousParagraphWasEmpty
-      ? spacing.before + state.trailingSpacing
-      : collapseParagraphSpacing({ before: spacing.before, after: state.trailingSpacing });
+      ? before + trailingSpacing
+      : collapseParagraphSpacing({ before, after: trailingSpacing });
   const contentTop = top + leadingSpacing;
   state.height = contentTop + contentHeight;
+  state.position = TABLE_CELL_FLOW_POSITION.interior;
   state.previousParagraphWasEmpty = empty;
-  state.trailingSpacing = spacing.after;
+  state.trailingSpacing =
+    block.attrs?.automaticSpacing?.after === true
+      ? { type: TABLE_CELL_TRAILING_SPACING_TYPE.automatic, value: spacing.after }
+      : { type: TABLE_CELL_TRAILING_SPACING_TYPE.authored, value: spacing.after };
   return { top, contentTop, contentHeight, leadingSpacing };
 };


### PR DESCRIPTION
## Summary

- suppress automatic leading and trailing paragraph spacing at table-cell boundaries
- preserve authored boundary spacing and automatic spacing between cell paragraphs
- model trailing cell spacing provenance explicitly so measurement and painting share the same rule
- keep out-of-flow text boxes from consuming the cell boundary

## Validation

- 110 focused layout tests pass
- targeted lint and formatting checks pass
- visual verification restores text clipped by exact-height table rows
- missing reference lines in the three-page parity probe decrease from 7 to 3