### PR TITLE
fix: align table indents to cell text

### DIFF
--- a/.changeset/gentle-table-indents.md
+++ b/.changeset/gentle-table-indents.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align inline table indentation to the leading cell text edge.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -765,7 +765,7 @@ describe("toFlowBlocks style cascade", () => {
         ],
       },
     },
-  ])("keeps $name zero table indentation authored", ({ formatting, styles }) => {
+  ])("positions $name zero table indentation at the cell text edge", ({ formatting, styles }) => {
     const table: Table = {
       type: "table",
       formatting,
@@ -793,7 +793,10 @@ describe("toFlowBlocks style cascade", () => {
     expect(tableBlock?.kind).toBe("table");
     if (tableBlock?.kind === "table") {
       expect(tableBlock.indent).toBe(0);
-      expect(firstTableX(tableBlock)).toBe(40);
+      const tableX = firstTableX(tableBlock);
+      const leadingCellPadding = tableBlock.rows.at(0)?.cells.at(0)?.padding?.left ?? 0;
+      expect(tableX).toBeDefined();
+      expect((tableX ?? 0) + leadingCellPadding).toBe(40);
     }
   });
 

--- a/packages/core/src/layout-engine/measure/tableInlinePlacement.ts
+++ b/packages/core/src/layout-engine/measure/tableInlinePlacement.ts
@@ -17,8 +17,16 @@ export const resolveTableInlinePlacement = (
 
   const firstCell = table.rows.at(0)?.cells.at(0);
   const firstCellPadding = firstCell ? resolveTableCellPadding(firstCell) : undefined;
+  // w:tblInd positions the leading cell's text edge, so move the table border
+  // back by that cell's leading margin for both authored and default indents.
   if (table.justification === "left" || table.bidi !== true) {
-    return { alignment: "left", offset: table.indent ?? -(firstCellPadding?.left ?? 0) };
+    return {
+      alignment: "left",
+      offset: (table.indent ?? 0) - (firstCellPadding?.left ?? 0),
+    };
   }
-  return { alignment: "right", offset: table.indent ?? -(firstCellPadding?.right ?? 0) };
+  return {
+    alignment: "right",
+    offset: (table.indent ?? 0) - (firstCellPadding?.right ?? 0),
+  };
 };

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1089,24 +1089,37 @@ describe("left-aligned table placement", () => {
     expect((fragment?.x ?? 0) + 7).toBe(OPTIONS.margins.left);
   });
 
-  test("applies an authored w:tblInd to the table border", () => {
+  test("applies an authored w:tblInd to the first-cell text edge", () => {
     const { block, measure } = tallTable(1);
     block.indent = 10;
     block.rows[0]!.cells[0]!.padding.left = 7;
 
     const fragment = tableFragments(block, measure).at(0);
 
-    expect(fragment?.x).toBe(OPTIONS.margins.left + 10);
+    expect(fragment?.x).toBe(OPTIONS.margins.left + 3);
+    expect((fragment?.x ?? 0) + 7).toBe(OPTIONS.margins.left + 10);
   });
 
-  test("aligns an authored zero-indent table border with the content edge", () => {
+  test("aligns an authored zero-indent first-cell text edge with the content edge", () => {
     const { block, measure } = tallTable(1);
     block.indent = 0;
     delete block.rows[0]!.cells[0]!.padding;
 
     const fragment = tableFragments(block, measure).at(0);
 
-    expect(fragment?.x).toBe(OPTIONS.margins.left);
+    expect(fragment?.x).toBe(OPTIONS.margins.left - 7);
+    expect((fragment?.x ?? 0) + 7).toBe(OPTIONS.margins.left);
+  });
+
+  test("allows a negative authored indent to move the first-cell text into the margin", () => {
+    const { block, measure } = tallTable(1);
+    block.indent = -10;
+    block.rows[0]!.cells[0]!.padding.left = 7;
+
+    const fragment = tableFragments(block, measure).at(0);
+
+    expect(fragment?.x).toBe(OPTIONS.margins.left - 17);
+    expect((fragment?.x ?? 0) + 7).toBe(OPTIONS.margins.left - 10);
   });
 });
 
@@ -1115,11 +1128,13 @@ describe("RTL table placement", () => {
     const { block, measure } = tallTable(1);
     block.bidi = true;
     block.indent = 10;
+    block.rows[0]!.cells[0]!.padding.right = 7;
 
     const fragment = tableFragments(block, measure).at(0);
     const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
 
-    expect(fragment?.x).toBe(contentRight - measure.totalWidth - 10);
+    expect(fragment?.x).toBe(contentRight - measure.totalWidth - 3);
+    expect((fragment?.x ?? 0) + measure.totalWidth - 7).toBe(contentRight - 10);
   });
 
   test("keeps a negative authored indent distinct from an absent indent", () => {
@@ -1131,7 +1146,8 @@ describe("RTL table placement", () => {
     const fragment = tableFragments(block, measure).at(0);
     const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
 
-    expect(fragment?.x).toBe(contentRight - measure.totalWidth + 10);
+    expect(fragment?.x).toBe(contentRight - measure.totalWidth + 17);
+    expect((fragment?.x ?? 0) + measure.totalWidth - 7).toBe(contentRight + 10);
   });
 
   test("aligns an unindented logical first-cell text edge using default cell padding", () => {
@@ -1145,7 +1161,7 @@ describe("RTL table placement", () => {
     expect((fragment?.x ?? 0) + measure.totalWidth - 7).toBe(contentRight);
   });
 
-  test("aligns an authored zero-indent table border with the right content edge", () => {
+  test("aligns an authored zero-indent first-cell text edge with the right content edge", () => {
     const { block, measure } = tallTable(1);
     block.bidi = true;
     block.indent = 0;
@@ -1154,7 +1170,7 @@ describe("RTL table placement", () => {
     const fragment = tableFragments(block, measure).at(0);
     const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
 
-    expect((fragment?.x ?? 0) + measure.totalWidth).toBe(contentRight);
+    expect((fragment?.x ?? 0) + measure.totalWidth - 7).toBe(contentRight);
   });
 });
 

--- a/packages/core/src/layout-painter/renderTable-bidi.test.ts
+++ b/packages/core/src/layout-painter/renderTable-bidi.test.ts
@@ -255,10 +255,10 @@ describe("renderNestedTable RTL placement", () => {
     ) as unknown as FakeElement;
 
     expect(tableEl.style["marginLeft"]).toBe("auto");
-    expect(tableEl.style["marginRight"]).toBe("10px");
+    expect(tableEl.style["marginRight"]).toBe("3px");
   });
 
-  test("distinguishes absent indentation from an authored zero", () => {
+  test("aligns absent and authored-zero indentation to the same text edge", () => {
     const absent = buildTwoColumnTable(true);
     const absentEl = renderNestedTable(
       absent.block,
@@ -277,12 +277,27 @@ describe("renderNestedTable RTL placement", () => {
     ) as unknown as FakeElement;
 
     expect(absentEl.style["marginRight"]).toBe("-7px");
-    expect(zeroEl.style["marginRight"]).toBe("0px");
+    expect(zeroEl.style["marginRight"]).toBe("-7px");
+  });
+
+  test("subtracts non-default leading cell padding from an authored indent", () => {
+    const { block, measure } = buildTwoColumnTable(true);
+    block.indent = 10;
+    block.rows[0]!.cells[0]!.padding = { top: 0, right: 12, bottom: 0, left: 7 };
+
+    const tableEl = renderNestedTable(
+      block,
+      measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    expect(tableEl.style["marginRight"]).toBe("-2px");
   });
 });
 
 describe("renderNestedTable LTR placement", () => {
-  test("distinguishes absent indentation from an authored zero with default padding", () => {
+  test("aligns absent and authored-zero indentation to the same text edge", () => {
     const absent = buildTwoColumnTable(false);
     const absentEl = renderNestedTable(
       absent.block,
@@ -301,6 +316,21 @@ describe("renderNestedTable LTR placement", () => {
     ) as unknown as FakeElement;
 
     expect(absentEl.style["marginLeft"]).toBe("-7px");
-    expect(zeroEl.style["marginLeft"]).toBe("0px");
+    expect(zeroEl.style["marginLeft"]).toBe("-7px");
+  });
+
+  test("subtracts non-default leading cell padding from an authored indent", () => {
+    const { block, measure } = buildTwoColumnTable(false);
+    block.indent = 10;
+    block.rows[0]!.cells[0]!.padding = { top: 0, right: 7, bottom: 0, left: 12 };
+
+    const tableEl = renderNestedTable(
+      block,
+      measure,
+      renderContext,
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    expect(tableEl.style["marginLeft"]).toBe("-2px");
   });
 });


### PR DESCRIPTION
## Summary

- interpret inline table indentation from the leading cell text edge
- account for default and authored cell margins in LTR and bidi tables
- share the corrected placement with nested-table rendering

## Validation

- 67 focused layout and painter tests pass
- targeted lint and formatting checks pass
- geometry parity on the three-page probe improves from 88.4% to 96.1%
- affected table-cell horizontal error drops from about 5.4pt to at most 0.17pt