### PR TITLE
fix: render vector-only EMF previews

### DIFF
--- a/.changeset/fuzzy-emfs-preview.md
+++ b/.changeset/fuzzy-emfs-preview.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render bounded vector-only EMF logos as browser-safe SVG previews.

--- a/packages/core/src/docx/metafileSvg.test.ts
+++ b/packages/core/src/docx/metafileSvg.test.ts
@@ -59,8 +59,10 @@ type VectorEmfOptions = {
   viewportOrigin?: { x: number; y: number };
   extraRecord?: Uint8Array;
   brushHandle?: number;
+  deleteBrushBeforePolygon?: boolean;
   mapMode?: 1 | 8;
   includeMoveTo?: boolean;
+  polygonPointCount?: number;
 };
 
 const vectorEmf = ({
@@ -69,9 +71,22 @@ const vectorEmf = ({
   viewportOrigin = { x: 0, y: 0 },
   extraRecord,
   brushHandle = 1,
+  deleteBrushBeforePolygon = false,
   mapMode = 8,
   includeMoveTo = true,
+  polygonPointCount = 3,
 }: VectorEmfOptions = {}): Uint8Array => {
+  const polygon =
+    polygonPointCount === 3
+      ? [
+          { x: 500, y: 500 },
+          { x: 700, y: 500 },
+          { x: 600, y: 700 },
+        ]
+      : Array.from({ length: polygonPointCount }, (_, index) => ({
+          x: -32_000 + (index % 64_000),
+          y: -31_000 + ((index * 17) % 62_000),
+        }));
   const records = [
     uint32Record(17, mapMode),
     pointRecord(10, windowOrigin.x, windowOrigin.y),
@@ -101,17 +116,12 @@ const vectorEmf = ({
     record(61, 8),
     record(60, 8),
     record(62, 24),
+    ...(deleteBrushBeforePolygon ? [uint32Record(40, 1)] : []),
     uint32Record(19, 2),
-    polyPolygon16([
-      [
-        { x: 500, y: 500 },
-        { x: 700, y: 500 },
-        { x: 600, y: 700 },
-      ],
-    ]),
+    polyPolygon16([polygon]),
     ...(extraRecord ? [extraRecord] : []),
     uint32Record(34, 0xffff_ffff),
-    uint32Record(40, 1),
+    ...(!deleteBrushBeforePolygon ? [uint32Record(40, 1)] : []),
     uint32Record(40, 2),
     record(14, 20),
   ];
@@ -200,6 +210,10 @@ describe("renderEmfSvg", () => {
     expect(svg).toContain('d="M0 0 C20 10 20 20 10 20 Z"');
   });
 
+  test("does not reuse a selected brush after its object is deleted", () => {
+    expect(renderEmfSvg(vectorEmf({ deleteBrushBeforePolygon: true }))).toBeNull();
+  });
+
   test("rejects point counts that exceed their record payload", () => {
     const bytes = vectorEmf();
     const view = new DataView(bytes.buffer);
@@ -234,5 +248,44 @@ describe("vector-only EMF package previews", () => {
     const outputZip = await JSZip.loadAsync(output);
     const roundTripped = await outputZip.file("word/media/image1.emf")?.async("uint8array");
     expect(roundTripped).toEqual(emf);
+  });
+
+  test("bounds generated previews across the complete package", async () => {
+    const zip = await JSZip.loadAsync(readFileSync(FIXTURE));
+    const emf = vectorEmf({
+      polygonPointCount: 19_990,
+      windowExtent: { x: 1, y: 1 },
+    });
+    const relationshipPath = "word/_rels/document.xml.rels";
+    const relationships = await zip.file(relationshipPath)?.async("string");
+    if (!relationships) {
+      throw new Error("Fixture is missing document relationships");
+    }
+    const mediaCount = 24;
+    const addedRelationships = Array.from(
+      { length: mediaCount },
+      (_, index) =>
+        `<Relationship Id="rEmfBudget${index}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/budget-${index}.emf"/>`,
+    ).join("");
+    zip.file(
+      relationshipPath,
+      relationships.replace("</Relationships>", `${addedRelationships}</Relationships>`),
+    );
+    for (let index = 0; index < mediaCount; index += 1) {
+      zip.file(`word/media/budget-${index}.emf`, emf);
+    }
+
+    const input = await zip.generateAsync({ type: "arraybuffer" });
+    const document = await parseDocx(input, { preloadFonts: false });
+    const previews = Array.from({ length: mediaCount }, (_, index) =>
+      document.package.media?.get(`word/media/budget-${index}.emf`),
+    );
+    const generatedCount = previews.filter((media) =>
+      media?.dataUrl?.startsWith("data:image/svg+xml"),
+    ).length;
+
+    expect(generatedCount).toBeGreaterThan(0);
+    expect(generatedCount).toBeLessThan(mediaCount);
+    expect(previews.at(-1)?.dataUrl).toStartWith("data:image/x-emf");
   });
 });

--- a/packages/core/src/docx/metafileSvg.test.ts
+++ b/packages/core/src/docx/metafileSvg.test.ts
@@ -1,0 +1,238 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "./parser";
+import { repackDocx } from "./rezip";
+import { renderEmfSvg } from "./metafileSvg";
+
+const FIXTURE = resolve(import.meta.dir, "__fixtures__/header-vml-emf.docx");
+
+const record = (type: number, size: number, write?: (view: DataView) => void): Uint8Array => {
+  const bytes = new Uint8Array(size);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, type, true);
+  view.setUint32(4, size, true);
+  write?.(view);
+  return bytes;
+};
+
+const uint32Record = (type: number, value: number): Uint8Array =>
+  record(type, 12, (view) => view.setUint32(8, value, true));
+
+const pointRecord = (type: number, x: number, y: number): Uint8Array =>
+  record(type, 16, (view) => {
+    view.setInt32(8, x, true);
+    view.setInt32(12, y, true);
+  });
+
+const polyBezierTo16 = (points: readonly { x: number; y: number }[]): Uint8Array =>
+  record(88, 28 + points.length * 4, (view) => {
+    view.setUint32(24, points.length, true);
+    for (const [index, point] of points.entries()) {
+      view.setInt16(28 + index * 4, point.x, true);
+      view.setInt16(30 + index * 4, point.y, true);
+    }
+  });
+
+const polyPolygon16 = (polygons: readonly (readonly { x: number; y: number }[])[]): Uint8Array => {
+  const points = polygons.flat();
+  return record(91, 32 + polygons.length * 4 + points.length * 4, (view) => {
+    view.setUint32(24, polygons.length, true);
+    view.setUint32(28, points.length, true);
+    for (const [index, polygon] of polygons.entries()) {
+      view.setUint32(32 + index * 4, polygon.length, true);
+    }
+    const pointsOffset = 32 + polygons.length * 4;
+    for (const [index, point] of points.entries()) {
+      view.setInt16(pointsOffset + index * 4, point.x, true);
+      view.setInt16(pointsOffset + index * 4 + 2, point.y, true);
+    }
+  });
+};
+
+type VectorEmfOptions = {
+  windowExtent?: { x: number; y: number };
+  windowOrigin?: { x: number; y: number };
+  viewportOrigin?: { x: number; y: number };
+  extraRecord?: Uint8Array;
+  brushHandle?: number;
+  mapMode?: 1 | 8;
+  includeMoveTo?: boolean;
+};
+
+const vectorEmf = ({
+  windowExtent = { x: 1_000, y: 1_000 },
+  windowOrigin = { x: 0, y: 0 },
+  viewportOrigin = { x: 0, y: 0 },
+  extraRecord,
+  brushHandle = 1,
+  mapMode = 8,
+  includeMoveTo = true,
+}: VectorEmfOptions = {}): Uint8Array => {
+  const records = [
+    uint32Record(17, mapMode),
+    pointRecord(10, windowOrigin.x, windowOrigin.y),
+    pointRecord(12, viewportOrigin.x, viewportOrigin.y),
+    pointRecord(9, windowExtent.x, windowExtent.y),
+    pointRecord(11, 100, 100),
+    record(33, 8),
+    uint32Record(19, 1),
+    record(39, 24, (view) => {
+      view.setUint32(8, 1, true);
+      view.setUint32(12, 0, true);
+      view.setUint32(16, 0x0033_2211, true);
+    }),
+    uint32Record(37, brushHandle),
+    record(95, 52, (view) => {
+      view.setUint32(8, 2, true);
+      view.setUint32(28, 5, true);
+    }),
+    uint32Record(37, 2),
+    record(59, 8),
+    ...(includeMoveTo ? [pointRecord(27, 100, 100)] : []),
+    polyBezierTo16([
+      { x: 200, y: 100 },
+      { x: 200, y: 200 },
+      { x: 100, y: 200 },
+    ]),
+    record(61, 8),
+    record(60, 8),
+    record(62, 24),
+    uint32Record(19, 2),
+    polyPolygon16([
+      [
+        { x: 500, y: 500 },
+        { x: 700, y: 500 },
+        { x: 600, y: 700 },
+      ],
+    ]),
+    ...(extraRecord ? [extraRecord] : []),
+    uint32Record(34, 0xffff_ffff),
+    uint32Record(40, 1),
+    uint32Record(40, 2),
+    record(14, 20),
+  ];
+  const byteLength = 88 + records.reduce((sum, item) => sum + item.byteLength, 0);
+  const header = record(1, 88, (view) => {
+    view.setInt32(8, 0, true);
+    view.setInt32(12, 0, true);
+    view.setInt32(16, 100, true);
+    view.setInt32(20, 100, true);
+    view.setInt32(24, 0, true);
+    view.setInt32(28, 0, true);
+    view.setInt32(32, 2_646, true);
+    view.setInt32(36, 2_646, true);
+    view.setUint32(40, 0x464d_4520, true);
+    view.setUint32(44, 0x0001_0000, true);
+    view.setUint32(48, byteLength, true);
+    view.setUint32(52, records.length + 1, true);
+    view.setUint16(56, 3, true);
+    view.setInt32(72, 100, true);
+    view.setInt32(76, 100, true);
+    view.setInt32(80, 26, true);
+    view.setInt32(84, 26, true);
+  });
+  const bytes = new Uint8Array(byteLength);
+  bytes.set(header);
+  let offset = header.byteLength;
+  for (const item of records) {
+    bytes.set(item, offset);
+    offset += item.byteLength;
+  }
+  return bytes;
+};
+
+describe("renderEmfSvg", () => {
+  test("maps filled Bezier and polygon paths into the EMF bounds", () => {
+    const svg = renderEmfSvg(vectorEmf());
+
+    expect(svg).toContain('viewBox="0 0 100 100"');
+    expect(svg).toContain('d="M10 10 C20 10 20 20 10 20 Z"');
+    expect(svg).toContain('fill="#112233" fill-rule="evenodd"');
+    expect(svg).toContain('d="M50 50 L70 50 L60 70 Z"');
+    expect(svg).toContain('fill="#112233" fill-rule="nonzero"');
+    expect(svg).not.toContain("stroke=");
+  });
+
+  test("rejects invalid signatures, truncation, and unsupported records", () => {
+    const invalidSignature = vectorEmf();
+    new DataView(invalidSignature.buffer).setUint32(40, 0, true);
+    expect(renderEmfSvg(invalidSignature)).toBeNull();
+
+    const valid = vectorEmf();
+    expect(renderEmfSvg(valid.subarray(0, valid.length - 4))).toBeNull();
+    expect(renderEmfSvg(vectorEmf({ extraRecord: record(42, 24) }))).toBeNull();
+  });
+
+  test("rejects zero mapping extents before evaluating any points", () => {
+    expect(renderEmfSvg(vectorEmf({ windowExtent: { x: 0, y: 1_000 } }))).toBeNull();
+  });
+
+  test("selects stock brushes using unsigned EMF handles", () => {
+    const svg = renderEmfSvg(vectorEmf({ brushHandle: 0x8000_0004 }));
+    expect(svg).toContain('fill="#000000"');
+  });
+
+  test("uses device coordinates for MM_TEXT instead of anisotropic extents", () => {
+    const svg = renderEmfSvg(
+      vectorEmf({
+        mapMode: 1,
+        windowOrigin: { x: 10, y: 20 },
+        viewportOrigin: { x: 5, y: 7 },
+      }),
+    );
+    expect(svg).toContain('d="M95 87 C195 87 195 187 95 187 Z"');
+  });
+
+  test("rejects MM_TEXT coordinates far outside the declared output", () => {
+    const bytes = vectorEmf({ mapMode: 1 });
+    const view = new DataView(bytes.buffer);
+    view.setInt32(8, -2_000_000_000, true);
+    view.setInt32(16, -1_999_999_900, true);
+    expect(renderEmfSvg(bytes)).toBeNull();
+  });
+
+  test("starts a Bezier path from the current GDI point", () => {
+    const svg = renderEmfSvg(vectorEmf({ includeMoveTo: false }));
+    expect(svg).toContain('d="M0 0 C20 10 20 20 10 20 Z"');
+  });
+
+  test("rejects point counts that exceed their record payload", () => {
+    const bytes = vectorEmf();
+    const view = new DataView(bytes.buffer);
+    let offset = 88;
+    while (offset + 8 <= bytes.length) {
+      const type = view.getUint32(offset, true);
+      const size = view.getUint32(offset + 4, true);
+      if (type === 88) {
+        view.setUint32(offset + 24, 1_000_001, true);
+        break;
+      }
+      offset += size;
+    }
+    expect(renderEmfSvg(bytes)).toBeNull();
+  });
+});
+
+describe("vector-only EMF package previews", () => {
+  test("uses generated SVG while preserving original EMF bytes and MIME", async () => {
+    const zip = await JSZip.loadAsync(readFileSync(FIXTURE));
+    const emf = vectorEmf();
+    zip.file("word/media/image1.emf", emf);
+    const input = await zip.generateAsync({ type: "arraybuffer" });
+
+    const document = await parseDocx(input, { preloadFonts: false });
+    const media = document.package.media?.get("word/media/image1.emf");
+    expect(media?.dataUrl).toStartWith("data:image/svg+xml");
+    expect(media?.mimeType).toBe("image/x-emf");
+    expect(new Uint8Array(media?.data ?? new ArrayBuffer(0))).toEqual(emf);
+
+    const output = await repackDocx(document);
+    const outputZip = await JSZip.loadAsync(output);
+    const roundTripped = await outputZip.file("word/media/image1.emf")?.async("uint8array");
+    expect(roundTripped).toEqual(emf);
+  });
+});

--- a/packages/core/src/docx/metafileSvg.test.ts
+++ b/packages/core/src/docx/metafileSvg.test.ts
@@ -60,9 +60,11 @@ type VectorEmfOptions = {
   extraRecord?: Uint8Array;
   brushHandle?: number;
   deleteBrushBeforePolygon?: boolean;
+  duplicateBrushHandle?: boolean;
   mapMode?: 1 | 8;
   includeMoveTo?: boolean;
   polygonPointCount?: number;
+  polygonBeforeFillPath?: boolean;
 };
 
 const vectorEmf = ({
@@ -72,9 +74,11 @@ const vectorEmf = ({
   extraRecord,
   brushHandle = 1,
   deleteBrushBeforePolygon = false,
+  duplicateBrushHandle = false,
   mapMode = 8,
   includeMoveTo = true,
   polygonPointCount = 3,
+  polygonBeforeFillPath = false,
 }: VectorEmfOptions = {}): Uint8Array => {
   const polygon =
     polygonPointCount === 3
@@ -100,6 +104,15 @@ const vectorEmf = ({
       view.setUint32(12, 0, true);
       view.setUint32(16, 0x0033_2211, true);
     }),
+    ...(duplicateBrushHandle
+      ? [
+          record(39, 24, (view) => {
+            view.setUint32(8, 1, true);
+            view.setUint32(12, 0, true);
+            view.setUint32(16, 0x0066_5544, true);
+          }),
+        ]
+      : []),
     uint32Record(37, brushHandle),
     record(95, 52, (view) => {
       view.setUint32(8, 2, true);
@@ -115,6 +128,7 @@ const vectorEmf = ({
     ]),
     record(61, 8),
     record(60, 8),
+    ...(polygonBeforeFillPath ? [polyPolygon16([polygon])] : []),
     record(62, 24),
     ...(deleteBrushBeforePolygon ? [uint32Record(40, 1)] : []),
     uint32Record(19, 2),
@@ -212,6 +226,17 @@ describe("renderEmfSvg", () => {
 
   test("does not reuse a selected brush after its object is deleted", () => {
     expect(renderEmfSvg(vectorEmf({ deleteBrushBeforePolygon: true }))).toBeNull();
+  });
+
+  test("preserves a completed path while rendering standalone geometry", () => {
+    const svg = renderEmfSvg(vectorEmf({ polygonBeforeFillPath: true }));
+
+    expect(svg).toContain('d="M10 10 C20 10 20 20 10 20 Z"');
+    expect(svg?.match(/<path /gu)).toHaveLength(3);
+  });
+
+  test("rejects object handles that are recreated before deletion", () => {
+    expect(renderEmfSvg(vectorEmf({ duplicateBrushHandle: true }))).toBeNull();
   });
 
   test("rejects point counts that exceed their record payload", () => {

--- a/packages/core/src/docx/metafileSvg.ts
+++ b/packages/core/src/docx/metafileSvg.ts
@@ -48,6 +48,11 @@ type Brush = { type: "brush"; fill: string | null };
 type Pen = { type: "pen"; stroke: null };
 type GraphicsObject = Brush | Pen;
 
+type PathState =
+  | { type: "idle" }
+  | { type: "building"; commands: string[] }
+  | { type: "completed"; commands: string[] };
+
 type DeviceState = {
   mapMode: typeof MAP_MODE_TEXT | typeof MAP_MODE_ANISOTROPIC;
   windowOrigin: { x: number; y: number };
@@ -224,9 +229,7 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
   let offset = headerSize;
   let recordCount = 1;
   let pointCount = 0;
-  let buildingPath = false;
-  let completedPath: string[] | null = null;
-  let path: string[] = [];
+  let pathState: PathState = { type: "idle" };
   const renderedPaths: string[] = [];
   let sawEof = false;
 
@@ -370,16 +373,38 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
         if (size !== 12 || handle === undefined) {
           return null;
         }
+        const object = objects.get(handle);
+        if (object === state.brush) {
+          state.brush = null;
+        } else if (object === state.pen) {
+          state.pen = null;
+        }
+        for (const savedState of stack) {
+          if (object === savedState.brush) {
+            savedState.brush = null;
+          } else if (object === savedState.pen) {
+            savedState.pen = null;
+          }
+        }
         objects.delete(handle);
         break;
       }
-      case EMR.beginPath:
-        if (size !== 8 || buildingPath || completedPath) {
+      case EMR.beginPath: {
+        if (size !== 8) {
           return null;
         }
-        buildingPath = true;
-        path = [];
+        switch (pathState.type) {
+          case "idle":
+            pathState = { type: "building", commands: [] };
+            break;
+          case "building":
+          case "completed":
+            return null;
+          default:
+            pathState satisfies never;
+        }
         break;
+      }
       case EMR.moveToEx: {
         const x = int32(view, offset + 8, end);
         const y = int32(view, offset + 12, end);
@@ -387,18 +412,35 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
           return null;
         }
         state.currentPoint = { x, y };
-        if (buildingPath) {
-          const mapped = mappedPoint(state, bounds, x, y);
-          if (!mapped) {
-            return null;
+        switch (pathState.type) {
+          case "idle":
+          case "completed":
+            break;
+          case "building": {
+            const mapped = mappedPoint(state, bounds, x, y);
+            if (!mapped) {
+              return null;
+            }
+            pathState.commands.push(pathPoint("M", mapped));
+            break;
           }
-          path.push(pathPoint("M", mapped));
+          default:
+            pathState satisfies never;
         }
         break;
       }
       case EMR.polyBezierTo16: {
-        if (!buildingPath) {
-          return null;
+        let commands: string[];
+        switch (pathState.type) {
+          case "building":
+            commands = pathState.commands;
+            break;
+          case "idle":
+          case "completed":
+            return null;
+          default:
+            pathState satisfies never;
+            return null;
         }
         const count = uint32(view, offset + 24, end);
         if (
@@ -411,12 +453,12 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
           return null;
         }
         pointCount += count;
-        if (path.length === 0) {
+        if (commands.length === 0) {
           const mapped = mappedPoint(state, bounds, state.currentPoint.x, state.currentPoint.y);
           if (!mapped) {
             return null;
           }
-          path.push(pathPoint("M", mapped));
+          commands.push(pathPoint("M", mapped));
         }
         for (let index = 0; index < count; index += 3) {
           const points: { x: number; y: number }[] = [];
@@ -438,7 +480,7 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
           if (!first || !second || !third) {
             return null;
           }
-          path.push(
+          commands.push(
             `C${numberText(first.x)} ${numberText(first.y)} ${numberText(second.x)} ${numberText(second.y)} ${numberText(third.x)} ${numberText(third.y)}`,
           );
         }
@@ -489,40 +531,77 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
         if (consumedPoints !== totalPoints) {
           return null;
         }
-        if (buildingPath) {
-          path.push(...polygonPath);
-        } else {
-          if (!state.brush?.fill) {
+        switch (pathState.type) {
+          case "building":
+            pathState.commands.push(...polygonPath);
+            break;
+          case "idle":
+            if (!state.brush?.fill) {
+              return null;
+            }
+            renderedPaths.push(
+              `<path d="${polygonPath.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
+            );
+            break;
+          case "completed":
             return null;
-          }
-          renderedPaths.push(
-            `<path d="${polygonPath.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
-          );
+          default:
+            pathState satisfies never;
         }
         break;
       }
-      case EMR.closeFigure:
-        if (size !== 8 || !buildingPath) {
+      case EMR.closeFigure: {
+        if (size !== 8) {
           return null;
         }
-        path.push("Z");
+        switch (pathState.type) {
+          case "building":
+            pathState.commands.push("Z");
+            break;
+          case "idle":
+          case "completed":
+            return null;
+          default:
+            pathState satisfies never;
+        }
         break;
-      case EMR.endPath:
-        if (size !== 8 || !buildingPath || path.length === 0) {
+      }
+      case EMR.endPath: {
+        if (size !== 8) {
           return null;
         }
-        buildingPath = false;
-        completedPath = path;
-        path = [];
+        switch (pathState.type) {
+          case "building":
+            if (pathState.commands.length === 0) {
+              return null;
+            }
+            pathState = { type: "completed", commands: pathState.commands };
+            break;
+          case "idle":
+          case "completed":
+            return null;
+          default:
+            pathState satisfies never;
+        }
         break;
+      }
       case EMR.fillPath: {
-        if (size !== 24 || buildingPath || !completedPath || !state.brush?.fill) {
+        if (size !== 24 || !state.brush?.fill) {
           return null;
         }
-        renderedPaths.push(
-          `<path d="${completedPath.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
-        );
-        completedPath = null;
+        switch (pathState.type) {
+          case "completed":
+            renderedPaths.push(
+              `<path d="${pathState.commands.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
+            );
+            pathState = { type: "idle" };
+            break;
+          case "idle":
+          case "building":
+            return null;
+          default:
+            pathState satisfies never;
+        }
         break;
       }
       default:
@@ -539,11 +618,18 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
     !sawEof ||
     offset !== bytes.byteLength ||
     recordCount !== declaredRecords ||
-    buildingPath ||
-    completedPath ||
     renderedPaths.length === 0
   ) {
     return null;
+  }
+  switch (pathState.type) {
+    case "idle":
+      break;
+    case "building":
+    case "completed":
+      return null;
+    default:
+      pathState satisfies never;
   }
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${numberText(width)} ${numberText(height)}">${renderedPaths.join("")}</svg>`;
   return svg.length <= MAX_EMF_SVG_CHARACTERS ? svg : null;

--- a/packages/core/src/docx/metafileSvg.ts
+++ b/packages/core/src/docx/metafileSvg.ts
@@ -329,7 +329,14 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
         const handle = uint32(view, offset + 8, end);
         const style = uint32(view, offset + 12, end);
         const color = uint32(view, offset + 16, end);
-        if (size !== 24 || handle === undefined || style === undefined || color === undefined) {
+        if (
+          size !== 24 ||
+          handle === undefined ||
+          handle >= STOCK_OBJECT_FLAG ||
+          objects.has(handle) ||
+          style === undefined ||
+          color === undefined
+        ) {
           return null;
         }
         if (style !== 0 && style !== 1) {
@@ -350,6 +357,8 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
         if (
           size !== 52 ||
           handle === undefined ||
+          handle >= STOCK_OBJECT_FLAG ||
+          objects.has(handle) ||
           style === undefined ||
           bmiBytes !== 0 ||
           bitmapBytes !== 0 ||
@@ -536,6 +545,7 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
             pathState.commands.push(...polygonPath);
             break;
           case "idle":
+          case "completed":
             if (!state.brush?.fill) {
               return null;
             }
@@ -543,8 +553,6 @@ export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
               `<path d="${polygonPath.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
             );
             break;
-          case "completed":
-            return null;
           default:
             pathState satisfies never;
         }

--- a/packages/core/src/docx/metafileSvg.ts
+++ b/packages/core/src/docx/metafileSvg.ts
@@ -1,0 +1,550 @@
+/**
+ * Render a deliberately small, browser-safe EMF subset to generated SVG.
+ *
+ * This covers vector logos built from filled paths. Unsupported records fail
+ * closed: a partial metafile is more misleading than the existing placeholder.
+ * Original EMF bytes remain the source of truth for DOCX round-trip.
+ */
+
+const EMF_SIGNATURE = 0x464d_4520;
+const MAX_EMF_RECORDS = 10_000;
+const MAX_EMF_POINTS = 20_000;
+const MAX_EMF_DIMENSION = 100_000;
+const MAX_EMF_SVG_CHARACTERS = 1_000_000;
+const MAX_EMF_STATE_DEPTH = 256;
+
+const EMR = {
+  header: 1,
+  setWindowExtEx: 9,
+  setWindowOrgEx: 10,
+  setViewportExtEx: 11,
+  setViewportOrgEx: 12,
+  eof: 14,
+  setMapMode: 17,
+  setBackgroundMode: 18,
+  setPolyFillMode: 19,
+  moveToEx: 27,
+  saveDc: 33,
+  restoreDc: 34,
+  selectObject: 37,
+  createBrushIndirect: 39,
+  deleteObject: 40,
+  beginPath: 59,
+  endPath: 60,
+  closeFigure: 61,
+  fillPath: 62,
+  polyBezierTo16: 88,
+  polyPolygon16: 91,
+  extCreatePen: 95,
+} as const;
+
+const MAP_MODE_TEXT = 1;
+const MAP_MODE_ANISOTROPIC = 8;
+const POLY_FILL_ALTERNATE = 1;
+const POLY_FILL_WINDING = 2;
+const STOCK_OBJECT_FLAG = 0x8000_0000;
+
+type Brush = { type: "brush"; fill: string | null };
+type Pen = { type: "pen"; stroke: null };
+type GraphicsObject = Brush | Pen;
+
+type DeviceState = {
+  mapMode: typeof MAP_MODE_TEXT | typeof MAP_MODE_ANISOTROPIC;
+  windowOrigin: { x: number; y: number };
+  windowExtent: { x: number; y: number };
+  viewportOrigin: { x: number; y: number };
+  viewportExtent: { x: number; y: number };
+  fillRule: "evenodd" | "nonzero";
+  brush: Brush | null;
+  pen: Pen | null;
+  currentPoint: { x: number; y: number };
+};
+
+const initialState = (): DeviceState => ({
+  mapMode: MAP_MODE_TEXT,
+  windowOrigin: { x: 0, y: 0 },
+  windowExtent: { x: 1, y: 1 },
+  viewportOrigin: { x: 0, y: 0 },
+  viewportExtent: { x: 1, y: 1 },
+  fillRule: "nonzero",
+  brush: null,
+  pen: null,
+  currentPoint: { x: 0, y: 0 },
+});
+
+const cloneState = (state: DeviceState): DeviceState => ({
+  ...state,
+  windowOrigin: { ...state.windowOrigin },
+  windowExtent: { ...state.windowExtent },
+  viewportOrigin: { ...state.viewportOrigin },
+  viewportExtent: { ...state.viewportExtent },
+  currentPoint: { ...state.currentPoint },
+});
+
+const int16 = (view: DataView, offset: number, end: number): number | undefined =>
+  offset >= 0 && offset + 2 <= end ? view.getInt16(offset, true) : undefined;
+
+const uint32 = (view: DataView, offset: number, end: number): number | undefined =>
+  offset >= 0 && offset + 4 <= end ? view.getUint32(offset, true) : undefined;
+
+const int32 = (view: DataView, offset: number, end: number): number | undefined =>
+  offset >= 0 && offset + 4 <= end ? view.getInt32(offset, true) : undefined;
+
+const numberText = (value: number): string => {
+  const rounded = Math.round(value * 10_000) / 10_000;
+  return Object.is(rounded, -0) ? "0" : String(rounded);
+};
+
+const colorRefToCss = (color: number): string => {
+  const red = color & 0xff;
+  const green = (color >>> 8) & 0xff;
+  const blue = (color >>> 16) & 0xff;
+  return `#${red.toString(16).padStart(2, "0")}${green
+    .toString(16)
+    .padStart(2, "0")}${blue.toString(16).padStart(2, "0")}`;
+};
+
+const stockObject = (handle: number): GraphicsObject | undefined => {
+  switch (handle) {
+    case 0x8000_0000:
+      return { type: "brush", fill: "#ffffff" };
+    case 0x8000_0001:
+      return { type: "brush", fill: "#c0c0c0" };
+    case 0x8000_0002:
+      return { type: "brush", fill: "#808080" };
+    case 0x8000_0003:
+      return { type: "brush", fill: "#404040" };
+    case 0x8000_0004:
+      return { type: "brush", fill: "#000000" };
+    case 0x8000_0005:
+      return { type: "brush", fill: null };
+    case 0x8000_0008:
+      return { type: "pen", stroke: null };
+    default:
+      return undefined;
+  }
+};
+
+type EmfBounds = { left: number; top: number; width: number; height: number };
+
+const mappedPoint = (
+  state: DeviceState,
+  bounds: EmfBounds,
+  x: number,
+  y: number,
+): { x: number; y: number } | undefined => {
+  let mappedX: number;
+  let mappedY: number;
+  if (state.mapMode === MAP_MODE_TEXT) {
+    mappedX = x - state.windowOrigin.x + state.viewportOrigin.x - bounds.left;
+    mappedY = y - state.windowOrigin.y + state.viewportOrigin.y - bounds.top;
+  } else {
+    const { windowExtent, windowOrigin, viewportExtent, viewportOrigin } = state;
+    if (windowExtent.x === 0 || windowExtent.y === 0) {
+      return undefined;
+    }
+    mappedX =
+      ((x - windowOrigin.x) * viewportExtent.x) / windowExtent.x + viewportOrigin.x - bounds.left;
+    mappedY =
+      ((y - windowOrigin.y) * viewportExtent.y) / windowExtent.y + viewportOrigin.y - bounds.top;
+  }
+  if (!Number.isFinite(mappedX) || !Number.isFinite(mappedY)) {
+    return undefined;
+  }
+  if (Math.abs(mappedX) > MAX_EMF_DIMENSION * 100 || Math.abs(mappedY) > MAX_EMF_DIMENSION * 100) {
+    return undefined;
+  }
+  return { x: mappedX, y: mappedY };
+};
+
+const pathPoint = (command: string, point: { x: number; y: number }): string =>
+  `${command}${numberText(point.x)} ${numberText(point.y)}`;
+
+const selectGraphicsObject = (
+  state: DeviceState,
+  objects: Map<number, GraphicsObject>,
+  handle: number,
+): boolean => {
+  const object = handle >= STOCK_OBJECT_FLAG ? stockObject(handle) : objects.get(handle);
+  if (!object) {
+    return false;
+  }
+  if (object.type === "brush") {
+    state.brush = object;
+  } else {
+    state.pen = object;
+  }
+  return true;
+};
+
+/** Convert the supported filled-path EMF subset to inert generated SVG. */
+export function renderEmfSvg(data: ArrayBuffer | Uint8Array): string | null {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  if (bytes.byteLength < 88) {
+    return null;
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const headerType = uint32(view, 0, bytes.byteLength);
+  const headerSize = uint32(view, 4, bytes.byteLength);
+  const signature = uint32(view, 40, bytes.byteLength);
+  const declaredBytes = uint32(view, 48, bytes.byteLength);
+  const declaredRecords = uint32(view, 52, bytes.byteLength);
+  const left = int32(view, 8, bytes.byteLength);
+  const top = int32(view, 12, bytes.byteLength);
+  const right = int32(view, 16, bytes.byteLength);
+  const bottom = int32(view, 20, bytes.byteLength);
+  if (
+    headerType !== EMR.header ||
+    headerSize === undefined ||
+    headerSize < 88 ||
+    headerSize % 4 !== 0 ||
+    headerSize > bytes.byteLength ||
+    signature !== EMF_SIGNATURE ||
+    declaredBytes !== bytes.byteLength ||
+    declaredRecords === undefined ||
+    declaredRecords < 2 ||
+    declaredRecords > MAX_EMF_RECORDS ||
+    left === undefined ||
+    top === undefined ||
+    right === undefined ||
+    bottom === undefined
+  ) {
+    return null;
+  }
+  const width = right - left;
+  const height = bottom - top;
+  if (width <= 0 || height <= 0 || width > MAX_EMF_DIMENSION || height > MAX_EMF_DIMENSION) {
+    return null;
+  }
+
+  const bounds = { left, top, width, height };
+  const objects = new Map<number, GraphicsObject>();
+  const stack: DeviceState[] = [];
+  let state = initialState();
+  let offset = headerSize;
+  let recordCount = 1;
+  let pointCount = 0;
+  let buildingPath = false;
+  let completedPath: string[] | null = null;
+  let path: string[] = [];
+  const renderedPaths: string[] = [];
+  let sawEof = false;
+
+  while (offset + 8 <= bytes.byteLength && recordCount < MAX_EMF_RECORDS) {
+    const type = uint32(view, offset, bytes.byteLength);
+    const size = uint32(view, offset + 4, bytes.byteLength);
+    if (
+      type === undefined ||
+      size === undefined ||
+      size < 8 ||
+      size % 4 !== 0 ||
+      size > bytes.byteLength - offset
+    ) {
+      return null;
+    }
+    const end = offset + size;
+    recordCount += 1;
+
+    switch (type) {
+      case EMR.eof:
+        if (size !== 20 || end !== bytes.byteLength || recordCount !== declaredRecords) {
+          return null;
+        }
+        sawEof = true;
+        break;
+      case EMR.setMapMode: {
+        const mode = int32(view, offset + 8, end);
+        if (size !== 12 || (mode !== MAP_MODE_TEXT && mode !== MAP_MODE_ANISOTROPIC)) {
+          return null;
+        }
+        state.mapMode = mode;
+        break;
+      }
+      case EMR.setBackgroundMode:
+        if (size !== 12 || uint32(view, offset + 8, end) === undefined) {
+          return null;
+        }
+        break;
+      case EMR.setPolyFillMode: {
+        const mode = uint32(view, offset + 8, end);
+        if (size !== 12 || (mode !== POLY_FILL_ALTERNATE && mode !== POLY_FILL_WINDING)) {
+          return null;
+        }
+        state.fillRule = mode === POLY_FILL_ALTERNATE ? "evenodd" : "nonzero";
+        break;
+      }
+      case EMR.setWindowOrgEx:
+      case EMR.setWindowExtEx:
+      case EMR.setViewportOrgEx:
+      case EMR.setViewportExtEx: {
+        const x = int32(view, offset + 8, end);
+        const y = int32(view, offset + 12, end);
+        if (size !== 16 || x === undefined || y === undefined) {
+          return null;
+        }
+        if (type === EMR.setWindowOrgEx) {
+          state.windowOrigin = { x, y };
+        } else if (type === EMR.setWindowExtEx) {
+          if (state.mapMode === MAP_MODE_ANISOTROPIC) {
+            if (x === 0 || y === 0) {
+              return null;
+            }
+            state.windowExtent = { x, y };
+          }
+        } else if (type === EMR.setViewportOrgEx) {
+          state.viewportOrigin = { x, y };
+        } else if (state.mapMode === MAP_MODE_ANISOTROPIC) {
+          if (x === 0 || y === 0) {
+            return null;
+          }
+          state.viewportExtent = { x, y };
+        }
+        break;
+      }
+      case EMR.saveDc:
+        if (size !== 8 || stack.length >= MAX_EMF_STATE_DEPTH) {
+          return null;
+        }
+        stack.push(cloneState(state));
+        break;
+      case EMR.restoreDc: {
+        const relative = int32(view, offset + 8, end);
+        if (size !== 12 || relative === undefined || relative >= 0 || -relative > stack.length) {
+          return null;
+        }
+        let restored: DeviceState | undefined;
+        for (let index = 0; index < -relative; index += 1) {
+          restored = stack.pop();
+        }
+        if (!restored) {
+          return null;
+        }
+        state = restored;
+        break;
+      }
+      case EMR.createBrushIndirect: {
+        const handle = uint32(view, offset + 8, end);
+        const style = uint32(view, offset + 12, end);
+        const color = uint32(view, offset + 16, end);
+        if (size !== 24 || handle === undefined || style === undefined || color === undefined) {
+          return null;
+        }
+        if (style !== 0 && style !== 1) {
+          return null;
+        }
+        objects.set(handle, {
+          type: "brush",
+          fill: style === 1 ? null : colorRefToCss(color),
+        });
+        break;
+      }
+      case EMR.extCreatePen: {
+        const handle = uint32(view, offset + 8, end);
+        const style = uint32(view, offset + 28, end);
+        const bmiBytes = uint32(view, offset + 16, end);
+        const bitmapBytes = uint32(view, offset + 24, end);
+        const styleEntries = uint32(view, offset + 48, end);
+        if (
+          size !== 52 ||
+          handle === undefined ||
+          style === undefined ||
+          bmiBytes !== 0 ||
+          bitmapBytes !== 0 ||
+          styleEntries !== 0 ||
+          (style & 0x0f) !== 5
+        ) {
+          return null;
+        }
+        objects.set(handle, { type: "pen", stroke: null });
+        break;
+      }
+      case EMR.selectObject: {
+        const handle = uint32(view, offset + 8, end);
+        if (size !== 12 || handle === undefined || !selectGraphicsObject(state, objects, handle)) {
+          return null;
+        }
+        break;
+      }
+      case EMR.deleteObject: {
+        const handle = uint32(view, offset + 8, end);
+        if (size !== 12 || handle === undefined) {
+          return null;
+        }
+        objects.delete(handle);
+        break;
+      }
+      case EMR.beginPath:
+        if (size !== 8 || buildingPath || completedPath) {
+          return null;
+        }
+        buildingPath = true;
+        path = [];
+        break;
+      case EMR.moveToEx: {
+        const x = int32(view, offset + 8, end);
+        const y = int32(view, offset + 12, end);
+        if (size !== 16 || x === undefined || y === undefined) {
+          return null;
+        }
+        state.currentPoint = { x, y };
+        if (buildingPath) {
+          const mapped = mappedPoint(state, bounds, x, y);
+          if (!mapped) {
+            return null;
+          }
+          path.push(pathPoint("M", mapped));
+        }
+        break;
+      }
+      case EMR.polyBezierTo16: {
+        if (!buildingPath) {
+          return null;
+        }
+        const count = uint32(view, offset + 24, end);
+        if (
+          count === undefined ||
+          count === 0 ||
+          count % 3 !== 0 ||
+          count > MAX_EMF_POINTS - pointCount ||
+          size !== 28 + count * 4
+        ) {
+          return null;
+        }
+        pointCount += count;
+        if (path.length === 0) {
+          const mapped = mappedPoint(state, bounds, state.currentPoint.x, state.currentPoint.y);
+          if (!mapped) {
+            return null;
+          }
+          path.push(pathPoint("M", mapped));
+        }
+        for (let index = 0; index < count; index += 3) {
+          const points: { x: number; y: number }[] = [];
+          for (let controlIndex = 0; controlIndex < 3; controlIndex += 1) {
+            const pointOffset = offset + 28 + (index + controlIndex) * 4;
+            const x = int16(view, pointOffset, end);
+            const y = int16(view, pointOffset + 2, end);
+            if (x === undefined || y === undefined) {
+              return null;
+            }
+            const mapped = mappedPoint(state, bounds, x, y);
+            if (!mapped) {
+              return null;
+            }
+            points.push(mapped);
+            state.currentPoint = { x, y };
+          }
+          const [first, second, third] = points;
+          if (!first || !second || !third) {
+            return null;
+          }
+          path.push(
+            `C${numberText(first.x)} ${numberText(first.y)} ${numberText(second.x)} ${numberText(second.y)} ${numberText(third.x)} ${numberText(third.y)}`,
+          );
+        }
+        break;
+      }
+      case EMR.polyPolygon16: {
+        const polygonCount = uint32(view, offset + 24, end);
+        const totalPoints = uint32(view, offset + 28, end);
+        if (
+          polygonCount === undefined ||
+          totalPoints === undefined ||
+          polygonCount === 0 ||
+          totalPoints === 0 ||
+          polygonCount > totalPoints ||
+          totalPoints > MAX_EMF_POINTS - pointCount ||
+          polygonCount > Math.floor((end - (offset + 32)) / 4)
+        ) {
+          return null;
+        }
+        const pointsOffset = offset + 32 + polygonCount * 4;
+        if (size !== 32 + polygonCount * 4 + totalPoints * 4) {
+          return null;
+        }
+        pointCount += totalPoints;
+        let consumedPoints = 0;
+        const polygonPath: string[] = [];
+        for (let polygonIndex = 0; polygonIndex < polygonCount; polygonIndex += 1) {
+          const count = uint32(view, offset + 32 + polygonIndex * 4, end);
+          if (count === undefined || count < 2 || count > totalPoints - consumedPoints) {
+            return null;
+          }
+          for (let index = 0; index < count; index += 1) {
+            const pointOffset = pointsOffset + (consumedPoints + index) * 4;
+            const x = int16(view, pointOffset, end);
+            const y = int16(view, pointOffset + 2, end);
+            if (x === undefined || y === undefined) {
+              return null;
+            }
+            const mapped = mappedPoint(state, bounds, x, y);
+            if (!mapped) {
+              return null;
+            }
+            polygonPath.push(pathPoint(index === 0 ? "M" : "L", mapped));
+          }
+          polygonPath.push("Z");
+          consumedPoints += count;
+        }
+        if (consumedPoints !== totalPoints) {
+          return null;
+        }
+        if (buildingPath) {
+          path.push(...polygonPath);
+        } else {
+          if (!state.brush?.fill) {
+            return null;
+          }
+          renderedPaths.push(
+            `<path d="${polygonPath.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
+          );
+        }
+        break;
+      }
+      case EMR.closeFigure:
+        if (size !== 8 || !buildingPath) {
+          return null;
+        }
+        path.push("Z");
+        break;
+      case EMR.endPath:
+        if (size !== 8 || !buildingPath || path.length === 0) {
+          return null;
+        }
+        buildingPath = false;
+        completedPath = path;
+        path = [];
+        break;
+      case EMR.fillPath: {
+        if (size !== 24 || buildingPath || !completedPath || !state.brush?.fill) {
+          return null;
+        }
+        renderedPaths.push(
+          `<path d="${completedPath.join(" ")}" fill="${state.brush.fill}" fill-rule="${state.fillRule}"/>`,
+        );
+        completedPath = null;
+        break;
+      }
+      default:
+        return null;
+    }
+
+    offset = end;
+    if (sawEof) {
+      break;
+    }
+  }
+
+  if (
+    !sawEof ||
+    offset !== bytes.byteLength ||
+    recordCount !== declaredRecords ||
+    buildingPath ||
+    completedPath ||
+    renderedPaths.length === 0
+  ) {
+    return null;
+  }
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${numberText(width)} ${numberText(height)}">${renderedPaths.join("")}</svg>`;
+  return svg.length <= MAX_EMF_SVG_CHARACTERS ? svg : null;
+}

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -59,6 +59,7 @@ import {
   validateFolioDocumentModel,
 } from "./modelValidation";
 import { extractMetafileRaster, isMetafileMimeType } from "./metafileRaster";
+import { renderEmfSvg } from "./metafileSvg";
 import { parseNumbering } from "./numberingParser";
 import { parseFontTable } from "./fontTableParser";
 import type { NumberingMap } from "./numberingParser";
@@ -88,8 +89,8 @@ export type ProgressCallback = (stage: string, percent: number) => void;
  * (EMF/WMF/TIFF) into a displayable `data:` or `blob:` URL. Receives the
  * parsed {@link MediaFile} (original bytes on `.data`); return the replacement
  * URL, or `null`/`undefined` to keep the built-in handling. Built-in handling
- * already extracts an embedded PNG/JPEG from EMF/WMF when one exists; this
- * hook is for vector-only metafiles where the host rasterizes server-side.
+ * extracts embedded PNG/JPEG previews and renders a bounded filled-path EMF
+ * subset; this hook covers remaining formats and unsupported vector records.
  */
 export type MediaResolver = (file: MediaFile) => Promise<string | null | undefined>;
 
@@ -561,6 +562,24 @@ async function buildMediaMap(
         mimeType,
         data,
         dataUrl: mediaToDataUrl(copyBytesToArrayBuffer(raster.bytes), raster.mimeType),
+      };
+      media.set(path, mediaFile);
+      const normalizedPath = path.replace(/^word\//u, "");
+      if (normalizedPath !== path) {
+        media.set(normalizedPath, mediaFile);
+      }
+      continue;
+    }
+
+    const emfSvg = isReferenced && mimeType === "image/x-emf" ? renderEmfSvg(data) : null;
+    if (emfSvg) {
+      const svgBytes = new TextEncoder().encode(emfSvg);
+      const mediaFile: MediaFile = {
+        path,
+        filename,
+        mimeType,
+        data,
+        dataUrl: mediaToDataUrl(copyBytesToArrayBuffer(svgBytes), "image/svg+xml"),
       };
       media.set(path, mediaFile);
       const normalizedPath = path.replace(/^word\//u, "");

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -75,6 +75,10 @@ import { DocxEncryptionError } from "./encryption/errors";
 import { unzipDocx, getMediaMimeType, mediaToDataUrl } from "./unzip";
 import type { DocxUnzipOptions, RawDocxContent } from "./unzip";
 
+const EMF_MIME_TYPE = "image/x-emf";
+const SVG_MIME_TYPE = "image/svg+xml";
+const MAX_PACKAGE_EMF_PREVIEW_BYTES = 8 * 1024 * 1024;
+
 // ============================================================================
 // PROGRESS CALLBACK
 // ============================================================================
@@ -518,6 +522,7 @@ async function buildMediaMap(
   const media = new Map<string, MediaFile>();
   const referenced = collectReferencedMediaPaths(raw, rels);
   let remainingTiffPixels = MAX_PACKAGE_TIFF_PIXELS;
+  let remainingEmfPreviewBytes = MAX_PACKAGE_EMF_PREVIEW_BYTES;
 
   // Process each media file
   for (const [path, data] of raw.media.entries()) {
@@ -571,22 +576,30 @@ async function buildMediaMap(
       continue;
     }
 
-    const emfSvg = isReferenced && mimeType === "image/x-emf" ? renderEmfSvg(data) : null;
+    const emfSvg =
+      isReferenced && mimeType === EMF_MIME_TYPE && remainingEmfPreviewBytes > 0
+        ? renderEmfSvg(data)
+        : null;
     if (emfSvg) {
       const svgBytes = new TextEncoder().encode(emfSvg);
-      const mediaFile: MediaFile = {
-        path,
-        filename,
-        mimeType,
-        data,
-        dataUrl: mediaToDataUrl(copyBytesToArrayBuffer(svgBytes), "image/svg+xml"),
-      };
-      media.set(path, mediaFile);
-      const normalizedPath = path.replace(/^word\//u, "");
-      if (normalizedPath !== path) {
-        media.set(normalizedPath, mediaFile);
+      if (svgBytes.byteLength <= remainingEmfPreviewBytes) {
+        remainingEmfPreviewBytes -= svgBytes.byteLength;
+        const mediaFile: MediaFile = {
+          path,
+          filename,
+          mimeType,
+          data,
+          dataUrl: mediaToDataUrl(copyBytesToArrayBuffer(svgBytes), SVG_MIME_TYPE),
+        };
+        media.set(path, mediaFile);
+        const normalizedPath = path.replace(/^word\//u, "");
+        if (normalizedPath !== path) {
+          media.set(normalizedPath, mediaFile);
+        }
+        continue;
       }
-      continue;
+      // Do not repeatedly render previews that cannot fit the retained package budget.
+      remainingEmfPreviewBytes = 0;
     }
 
     const mediaFile: MediaFile = {


### PR DESCRIPTION
Summary
- render a bounded filled-path EMF subset as generated SVG when no embedded raster preview exists
- validate record structure, object state, mapping modes, point counts, coordinates, and output size; unsupported records fail closed
- keep the original EMF bytes and MIME type for round-trip, with raster previews still taking priority

Validation
- 17 focused EMF extraction, parser integration, malformed-input, and byte-preservation tests
- targeted oxlint and oxfmt checks
- Microsoft Word visual comparison: restored the missing footer artwork at its authored page anchor; raster similarity improved from 90.31% to 90.40% with page count and text geometry unchanged

Security
- generated SVG contains only validated numeric path data and normalized colors; no source XML, script, or external reference is copied
- conversion is capped at 10,000 records, 20,000 points, 256 saved states, 100,000-unit bounds, and 1,000,000 SVG characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-safe SVG previews for supported bounded, vector-only EMF logos embedded in DOCX files.
  * Preserved the original EMF data and MIME type when documents are repacked.
  * Added fallback handling for unsupported or malformed EMF content, preventing incomplete previews from being displayed.

* **Bug Fixes**
  * Improved media resolution for embedded EMF assets using normalised document paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->