### PR TITLE
fix: render nested VML freeform artwork

### DIFF
--- a/.changeset/warm-vml-freeforms.md
+++ b/.changeset/warm-vml-freeforms.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render bounded nested VML freeform paths with their authored local coordinates.

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -60,6 +60,7 @@ import {
 } from "./modelValidation";
 import { extractMetafileRaster, isMetafileMimeType } from "./metafileRaster";
 import { renderEmfSvg } from "./metafileSvg";
+import { enforcePackageVmlPreviewBudget } from "./vmlPreview";
 import { parseNumbering } from "./numberingParser";
 import { parseFontTable } from "./fontTableParser";
 import type { NumberingMap } from "./numberingParser";
@@ -438,6 +439,7 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
       ...(templateVariables !== undefined ? { templateVariables } : {}),
       ...(requiredFonts.length > 0 ? { requiredFonts } : {}),
     };
+    enforcePackageVmlPreviewBudget(document.package);
 
     const validation = validateFolioDocumentModel(document);
     const parsedCompleteModel = parseHeadersFooters && parseNotes;

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -17,6 +17,7 @@ import type { DrawingContent, Paragraph, Run, Table } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { repackDocx, validateDocx } from "./rezip";
+import { enforcePackageVmlPreviewBudget } from "./vmlPreview";
 
 const XML = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 const ONE_PIXEL_PNG_BASE64 =
@@ -516,6 +517,44 @@ describe("VML w:pict inline images", () => {
     expect(svg).toContain('d="M 0 0 L 10 0"');
     expect(svg).toContain('fill="none" stroke="black"');
     expect(svg).not.toContain(" Z");
+  });
+
+  test("renders multiple subpaths before the VML end command", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="10,10"><v:shape style="left:0;top:0;width:10;height:10" coordsize="10,10" path="m0,0l10,0m2,2l2,8e" stroked="f"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
+    expect(svg).toContain('d="M 0 0 L 10 0 M 2 2 L 2 8"');
+  });
+
+  test("bounds retained generated previews across a package model", () => {
+    const first = {
+      type: "image",
+      filename: "vml-shape-preview.svg",
+      src: "123456",
+    };
+    const second = {
+      type: "image",
+      filename: "vml-shape-preview.svg",
+      src: "123456",
+    };
+    const model = {
+      first: { image: first, rawXml: '<w:pict id="first"/>' },
+      second: { image: second, rawXml: '<w:pict id="second"/>' },
+    };
+
+    enforcePackageVmlPreviewBudget(model, 10);
+
+    expect(first.src).toBe("123456");
+    expect(second.src).toBeUndefined();
+    expect(model.second.rawXml).toBe('<w:pict id="second"/>');
   });
 
   test("skips non-painting and text-box descendants without hiding valid siblings", async () => {

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -471,6 +471,130 @@ describe("VML w:pict inline images", () => {
     expect(svg).toContain("<rect");
   });
 
+  test("renders nested freeform paths in their authored local coordinate spaces", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="position:absolute;margin-left:10pt;margin-top:20pt;width:100pt;height:100pt;z-index:1;mso-position-horizontal-relative:page;mso-position-vertical-relative:page" coordorigin="0,0" coordsize="100,100"><v:group style="left:10;top:20;width:40;height:20" coordorigin="100,200" coordsize="200,100"><v:shape style="left:100;top:200;width:200;height:100" coordsize="10,10" path="m5,l10,,10,10r-10,e" fillcolor="#e60000" stroked="f"/><v:shape style="left:150;top:225;width:50;height:50" coordsize="10,10" path="m0,0l10,0,10,10,0,10e" stroked="f"/></v:group><v:rect style="left:0;top:0;width:100;height:100" filled="f" stroked="f"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    expect(drawing?.image.size).toEqual({ width: 1_270_000, height: 1_270_000 });
+    expect(drawing?.image.wrap.type).toBe("inFront");
+    expect(drawing?.image.position).toEqual({
+      horizontal: { relativeTo: "page", posOffset: 127_000 },
+      vertical: { relativeTo: "page", posOffset: 254_000 },
+    });
+    const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
+    expect(svg).toContain('viewBox="0 0 100 100"');
+    expect(svg).toContain('transform="matrix(0.2 0 0 0.2 -10 -20)"');
+    expect(svg).toContain('transform="matrix(20 0 0 10 100 200)"');
+    expect(svg).toContain('d="M 5 0 L 10 0 L 10 10 L 0 10"');
+    const redPath = svg.indexOf('fill="#e60000"');
+    const whitePath = svg.indexOf('fill="white"');
+    expect(redPath).toBeGreaterThan(-1);
+    expect(whitePath).toBeGreaterThan(redPath);
+    expect(svg).not.toContain("<rect");
+    expect(drawing?.rawXml).toContain('path="m5,l10,,10,10r-10,e"');
+  });
+
+  test("treats the VML end command as distinct from closing a stroked path", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="10,10"><v:shape style="left:0;top:0;width:10;height:10" coordsize="10,10" path="m0,0l10,0e" filled="f"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
+    expect(svg).toContain('d="M 0 0 L 10 0"');
+    expect(svg).toContain('fill="none" stroke="black"');
+    expect(svg).not.toContain(" Z");
+  });
+
+  test("skips non-painting and text-box descendants without hiding valid siblings", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="10,10"><v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>Owned elsewhere</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape><v:shape style="left:0;top:0;width:10;height:10" path="m0,0l10,0,10,10e" filled="f" stroked="f"/><v:shape style="left:0;top:0;width:10;height:10" coordsize="10,10" path="m0,0l10,0,10,10e" fillcolor="red" stroked="f"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
+    expect(svg.match(/<path\b/gu)).toHaveLength(1);
+    expect(svg).not.toContain("Owned elsewhere");
+  });
+
+  test("fails closed for malformed or unsupported freeform path commands", async () => {
+    const paths = [
+      "m0,0l1e",
+      "m0,0l1,2,e",
+      "l0,0e",
+      "m0,0c1,1e",
+      "m0,0l1000001,0e",
+      "m0,0l1,1em2,2e",
+    ];
+    for (const path of paths) {
+      const doc = await parseDocx(
+        await pictDocx({
+          runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="10,10"><v:shape style="left:0;top:0;width:10;height:10" coordsize="10,10" path="${path}"/></v:group></w:pict>`,
+          imageRel: false,
+          media: false,
+        }),
+        { preloadFonts: false },
+      );
+
+      expect(firstDrawing(doc.package.document.content.at(0))).toBeUndefined();
+    }
+  });
+
+  test("enforces preview limits across nested VML groups", async () => {
+    let nested = `<v:shape style="left:0;top:0;width:1;height:1" coordsize="1,1" path="m0,0l1,1e"/>`;
+    for (let depth = 0; depth < 17; depth += 1) {
+      nested = `<v:group style="left:0;top:0;width:1;height:1" coordsize="1,1">${nested}</v:group>`;
+    }
+    const depthDoc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="1,1">${nested}</v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+    expect(firstDrawing(depthDoc.package.document.content.at(0))).toBeUndefined();
+
+    const rectangles = `<v:rect style="left:0;top:0;width:1;height:1"/>`.repeat(256);
+    const elementDoc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="1,1"><v:group style="left:0;top:0;width:1;height:1" coordsize="1,1">${rectangles}</v:group></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+    expect(firstDrawing(elementDoc.package.document.content.at(0))).toBeUndefined();
+
+    const pathPoints = Array.from({ length: 20_000 }, () => "1,1").join(",");
+    const pathDoc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="1,1"><v:shape style="left:0;top:0;width:1;height:1" coordsize="1,1" path="m0,0l${pathPoints}e"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+    expect(firstDrawing(pathDoc.package.document.content.at(0))).toBeUndefined();
+  });
+
   test("skips solid-shape previews with unsafe dimensions", async () => {
     const doc = await parseDocx(
       await pictDocx({

--- a/packages/core/src/docx/vmlImageParser.test.ts
+++ b/packages/core/src/docx/vmlImageParser.test.ts
@@ -515,7 +515,7 @@ describe("VML w:pict inline images", () => {
     const drawing = firstDrawing(doc.package.document.content.at(0));
     const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
     expect(svg).toContain('d="M 0 0 L 10 0"');
-    expect(svg).toContain('fill="none" stroke="black"');
+    expect(svg).toContain('fill="none" fill-rule="evenodd" stroke="black"');
     expect(svg).not.toContain(" Z");
   });
 
@@ -532,28 +532,75 @@ describe("VML w:pict inline images", () => {
     const drawing = firstDrawing(doc.package.document.content.at(0));
     const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
     expect(svg).toContain('d="M 0 0 L 10 0 M 2 2 L 2 8"');
+    expect(svg).toContain('fill-rule="evenodd"');
+  });
+
+  test("accepts space-delimited path coordinates", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="10,10"><v:shape style="left:0;top:0;width:10;height:10" coordsize="10,10" path="m 0 0 l 10 0 10 10 e" stroked="f"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
+    expect(svg).toContain('d="M 0 0 L 10 0 L 10 10"');
+  });
+
+  test("superimposes independently ended path sets", async () => {
+    const doc = await parseDocx(
+      await pictDocx({
+        runXml: `<w:pict><v:group style="width:10pt;height:10pt" coordsize="10,10"><v:shape style="left:0;top:0;width:10;height:10" coordsize="10,10" path="m0,0l10,0,10,10em2,2l8,2,8,8e" stroked="f"/></v:group></w:pict>`,
+        imageRel: false,
+        media: false,
+      }),
+      { preloadFonts: false },
+    );
+
+    const drawing = firstDrawing(doc.package.document.content.at(0));
+    const svg = decodeURIComponent(drawing?.image.src?.split(",").at(1) ?? "");
+    expect(svg.match(/<path\b/gu)).toHaveLength(2);
+    expect(svg.indexOf('d="M 0 0 L 10 0 L 10 10"')).toBeLessThan(
+      svg.indexOf('d="M 2 2 L 8 2 L 8 8"'),
+    );
   });
 
   test("bounds retained generated previews across a package model", () => {
     const first = {
       type: "image",
       filename: "vml-shape-preview.svg",
-      src: "123456",
+      mimeType: "image/svg+xml",
+      rId: "",
+      src: "data:image/svg+xml;charset=utf-8,123456",
     };
     const second = {
       type: "image",
       filename: "vml-shape-preview.svg",
-      src: "123456",
+      mimeType: "image/svg+xml",
+      rId: "",
+      src: "data:image/svg+xml;charset=utf-8,123456",
+    };
+    const relationshipBacked = {
+      type: "image",
+      filename: "vml-shape-preview.svg",
+      mimeType: "image/svg+xml",
+      rId: "rId1",
+      src: "relationship-backed",
     };
     const model = {
       first: { image: first, rawXml: '<w:pict id="first"/>' },
       second: { image: second, rawXml: '<w:pict id="second"/>' },
+      third: { image: relationshipBacked },
     };
 
-    enforcePackageVmlPreviewBudget(model, 10);
+    enforcePackageVmlPreviewBudget(model, first.src.length);
 
-    expect(first.src).toBe("123456");
+    expect(first.src).toBe("data:image/svg+xml;charset=utf-8,123456");
     expect(second.src).toBeUndefined();
+    expect(relationshipBacked.src).toBe("relationship-backed");
     expect(model.second.rawXml).toBe('<w:pict id="second"/>');
   });
 
@@ -580,7 +627,7 @@ describe("VML w:pict inline images", () => {
       "l0,0e",
       "m0,0c1,1e",
       "m0,0l1000001,0e",
-      "m0,0l1,1em2,2e",
+      "m0,0l1,1el2,2e",
     ];
     for (const path of paths) {
       const doc = await parseDocx(

--- a/packages/core/src/docx/vmlImageParser.ts
+++ b/packages/core/src/docx/vmlImageParser.ts
@@ -44,141 +44,26 @@ import {
   elementToXml,
   findAllDeep,
   findChild,
-  findDeep,
   getChildElements,
   getAttribute,
   getLocalName,
   type XmlElement,
 } from "./xmlParser";
+import {
+  isValidVmlPreviewDimension,
+  parseVmlNumber,
+  parseVmlStyle,
+  renderStandaloneVmlPreview,
+  renderVmlGroupPreview,
+  vmlCssLengthToPx,
+  vmlSvgDataUrl,
+  type VmlPreviewResult,
+} from "./vmlPreview";
 
-const MAX_VML_PREVIEW_SHAPES = 256;
-const MAX_VML_PREVIEW_DIMENSION_PX = 20_000;
-const MAX_VML_SVG_CHARACTERS = 1_000_000;
-const SAFE_VML_COLORS = new Set([
-  "black",
-  "white",
-  "red",
-  "green",
-  "blue",
-  "yellow",
-  "gray",
-  "grey",
-  "silver",
-  "maroon",
-  "purple",
-  "fuchsia",
-  "lime",
-  "olive",
-  "navy",
-  "teal",
-  "aqua",
-]);
 const VML_POSITION_ABSOLUTE = "absolute";
 const IMAGE_WRAP_INLINE = "inline";
 const IMAGE_WRAP_BEHIND = "behind";
 const IMAGE_WRAP_IN_FRONT = "inFront";
-
-/**
- * Convert a CSS length (pt/in/px/cm/mm/pc, default px) to pixels. Units are
- * matched case-insensitively (`2IN`, `2Pt` are valid VML). The numeric part
- * must be a single well-formed decimal, so malformed input like `1.2.3` is
- * rejected rather than truncated to `1.2`.
- */
-function cssLengthToPx(raw: string | undefined): number | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const match = /^(?<amount>-?(?:\d+(?:\.\d+)?|\.\d+))\s*(?<unit>pt|in|px|cm|mm|pc)?$/iu.exec(
-    raw.trim(),
-  );
-  const amountText = match?.groups?.["amount"];
-  if (amountText === undefined) {
-    return undefined;
-  }
-  const value = Number.parseFloat(amountText);
-  if (!Number.isFinite(value)) {
-    return undefined;
-  }
-  switch (match?.groups?.["unit"]?.toLowerCase()) {
-    case "pt":
-      return (value / 72) * 96;
-    case "in":
-      return value * 96;
-    case "cm":
-      return (value / 2.54) * 96;
-    case "mm":
-      return (value / 25.4) * 96;
-    case "pc":
-      return (value / 6) * 96;
-    case "px":
-    case undefined:
-      return value;
-    default:
-      return undefined;
-  }
-}
-
-const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-/** Read a `style="k1:v1;k2:v2"` attribute into a lowercased key/value record. */
-function parseStyleAttr(style: string | null): Record<string, string> {
-  // Null prototype: the style string is attacker-controlled when the DOCX is
-  // untrusted, so the record must not inherit from (or shadow) Object.prototype.
-  const out: Record<string, string> = Object.create(null);
-  if (!style) {
-    return out;
-  }
-  for (const decl of style.split(";")) {
-    const colon = decl.indexOf(":");
-    if (colon < 0) {
-      continue;
-    }
-    const key = decl.slice(0, colon).trim().toLowerCase();
-    const value = decl.slice(colon + 1).trim();
-    // Skip keys that would pollute Object.prototype — the style string is
-    // attacker-controlled when the DOCX is untrusted.
-    if (!key || PROTOTYPE_POLLUTION_KEYS.has(key)) {
-      continue;
-    }
-    out[key] = value;
-  }
-  return out;
-}
-
-const finiteNumber = (raw: string | null | undefined): number | undefined => {
-  if (!raw || !/^-?(?:\d+(?:\.\d+)?|\.\d+)$/u.test(raw.trim())) {
-    return undefined;
-  }
-  const value = Number.parseFloat(raw);
-  return Number.isFinite(value) ? value : undefined;
-};
-
-const coordinatePair = (raw: string | null): { first: number; second: number } | undefined => {
-  const [firstRaw, secondRaw, extra] = raw?.split(",").map((part) => part.trim()) ?? [];
-  if (extra !== undefined) {
-    return undefined;
-  }
-  const first = finiteNumber(firstRaw);
-  const second = finiteNumber(secondRaw);
-  return first === undefined || second === undefined ? undefined : { first, second };
-};
-
-const safeColor = (raw: string | null, fallback: string): string => {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return fallback;
-  }
-  if (SAFE_VML_COLORS.has(normalized)) {
-    return normalized;
-  }
-  if (/^#[0-9a-f]{3}(?:[0-9a-f]{3})?$/u.test(normalized)) {
-    return normalized;
-  }
-  return /^[0-9a-f]{6}$/u.test(normalized) ? `#${normalized}` : fallback;
-};
-
-const validPreviewDimension = (value: number | undefined): value is number =>
-  value !== undefined && value > 0 && value <= MAX_VML_PREVIEW_DIMENSION_PX;
 
 const pixelsToSafeEmu = (pixels: number): number | undefined => {
   const emu = pixelsToEmu(pixels);
@@ -240,9 +125,9 @@ const vmlImageLayout = (
     return { wrap: { type: IMAGE_WRAP_INLINE } };
   }
 
-  const leftPx = cssLengthToPx(style["margin-left"] ?? style["left"]) ?? 0;
-  const topPx = cssLengthToPx(style["margin-top"] ?? style["top"]) ?? 0;
-  const zIndex = finiteNumber(style["z-index"]);
+  const leftPx = vmlCssLengthToPx(style["margin-left"] ?? style["left"]) ?? 0;
+  const topPx = vmlCssLengthToPx(style["margin-top"] ?? style["top"]) ?? 0;
+  const zIndex = parseVmlNumber(style["z-index"]);
   return {
     wrap: {
       type: zIndex !== undefined && zIndex < 0 ? IMAGE_WRAP_BEHIND : IMAGE_WRAP_IN_FRONT,
@@ -260,23 +145,6 @@ const vmlImageLayout = (
   };
 };
 
-const svgDataUrl = (svg: string): string | undefined =>
-  svg.length <= MAX_VML_SVG_CHARACTERS
-    ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
-    : undefined;
-
-const vmlShapeSvg = (shape: XmlElement, width: number, height: number, x = 0, y = 0): string => {
-  const fill = safeColor(getAttribute(shape, null, "fillcolor"), "white");
-  const stroked = getAttribute(shape, null, "stroked")?.toLowerCase() !== "f";
-  const stroke = stroked ? safeColor(getAttribute(shape, null, "strokecolor"), "black") : "none";
-  const localName = getLocalName(shape.name ?? "");
-  if (localName === "oval") {
-    return `<ellipse cx="${x + width / 2}" cy="${y + height / 2}" rx="${width / 2}" ry="${height / 2}" fill="${fill}" stroke="${stroke}"/>`;
-  }
-  const radius = localName === "roundrect" ? Math.min(width, height) * 0.1 : 0;
-  return `<rect x="${x}" y="${y}" width="${width}" height="${height}" rx="${radius}" fill="${fill}" stroke="${stroke}"/>`;
-};
-
 const previewImage = (
   pictElement: XmlElement,
   svg: string,
@@ -285,15 +153,15 @@ const previewImage = (
   style: Record<string, string>,
   rootXmlns: Record<string, string>,
 ): DrawingContent | null => {
-  const src = svgDataUrl(svg);
+  const src = vmlSvgDataUrl(svg);
   if (!src) {
     return null;
   }
-  const leftPx = cssLengthToPx(style["margin-left"] ?? style["left"]) ?? 0;
-  const topPx = cssLengthToPx(style["margin-top"] ?? style["top"]) ?? 0;
+  const leftPx = vmlCssLengthToPx(style["margin-left"] ?? style["left"]) ?? 0;
+  const topPx = vmlCssLengthToPx(style["margin-top"] ?? style["top"]) ?? 0;
   const horizontalRelative = style["mso-position-horizontal-relative"] === "page";
   const verticalRelative = style["mso-position-vertical-relative"] === "page";
-  const zIndex = finiteNumber(style["z-index"]);
+  const zIndex = parseVmlNumber(style["z-index"]);
   const image: Image = {
     type: "image",
     rId: "",
@@ -320,85 +188,27 @@ const previewImage = (
   };
 };
 
-const parseStandaloneShapePreview = (
+const previewDrawing = (
   pictElement: XmlElement,
-  shape: XmlElement,
+  preview: VmlPreviewResult,
   rootXmlns: Record<string, string>,
 ): DrawingContent | null => {
-  // A VML text box is an editable document shape, not a preview image. Its
-  // content is owned by paragraphTextBoxEnrichment; rendering it here as a
-  // synthetic SVG would materialize the same OOXML object twice.
-  if (findDeep(shape, "v", "textbox")) {
-    return null;
+  switch (preview.type) {
+    case "rendered":
+      return previewImage(
+        pictElement,
+        preview.svg,
+        preview.widthPx,
+        preview.heightPx,
+        preview.style,
+        rootXmlns,
+      );
+    case "empty":
+    case "invalid":
+      return null;
+    default:
+      return preview satisfies never;
   }
-  const style = parseStyleAttr(getAttribute(shape, null, "style"));
-  const widthPx = cssLengthToPx(style["width"]);
-  const heightPx = cssLengthToPx(style["height"]);
-  if (!validPreviewDimension(widthPx) || !validPreviewDimension(heightPx)) {
-    return null;
-  }
-  const content = vmlShapeSvg(shape, widthPx, heightPx);
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${widthPx} ${heightPx}" width="${widthPx}" height="${heightPx}">${content}</svg>`;
-  return previewImage(pictElement, svg, widthPx, heightPx, style, rootXmlns);
-};
-
-const parseGroupPreview = (
-  pictElement: XmlElement,
-  group: XmlElement,
-  rootXmlns: Record<string, string>,
-): DrawingContent | null => {
-  const style = parseStyleAttr(getAttribute(group, null, "style"));
-  const widthPx = cssLengthToPx(style["width"]);
-  const heightPx = cssLengthToPx(style["height"]);
-  if (!validPreviewDimension(widthPx) || !validPreviewDimension(heightPx)) {
-    return null;
-  }
-  const origin = coordinatePair(getAttribute(group, null, "coordorigin")) ?? {
-    first: 0,
-    second: 0,
-  };
-  const size = coordinatePair(getAttribute(group, null, "coordsize")) ?? {
-    first: widthPx,
-    second: heightPx,
-  };
-  if (size.first <= 0 || size.second <= 0) {
-    return null;
-  }
-  const content = getChildElements(group)
-    .slice(0, MAX_VML_PREVIEW_SHAPES)
-    .map((child) => {
-      const localName = getLocalName(child.name ?? "");
-      if (findDeep(child, "v", "textbox")) {
-        return "";
-      }
-      if (localName === "line") {
-        const from = coordinatePair(getAttribute(child, null, "from"));
-        const to = coordinatePair(getAttribute(child, null, "to"));
-        if (!from || !to) {
-          return "";
-        }
-        const stroke = safeColor(getAttribute(child, null, "strokecolor"), "black");
-        return `<line x1="${from.first}" y1="${from.second}" x2="${to.first}" y2="${to.second}" stroke="${stroke}"/>`;
-      }
-      if (localName !== "rect" && localName !== "roundrect" && localName !== "oval") {
-        return "";
-      }
-      const childStyle = parseStyleAttr(getAttribute(child, null, "style"));
-      const x = finiteNumber(childStyle["left"]);
-      const y = finiteNumber(childStyle["top"]);
-      const width = finiteNumber(childStyle["width"]);
-      const height = finiteNumber(childStyle["height"]);
-      if (x === undefined || y === undefined || width === undefined || height === undefined) {
-        return "";
-      }
-      return vmlShapeSvg(child, width, height, x, y);
-    })
-    .join("");
-  if (!content) {
-    return null;
-  }
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${origin.first} ${origin.second} ${size.first} ${size.second}" width="${widthPx}" height="${heightPx}">${content}</svg>`;
-  return previewImage(pictElement, svg, widthPx, heightPx, style, rootXmlns);
 };
 
 /**
@@ -464,14 +274,14 @@ export function parseVmlImageContent(
       media ?? undefined,
     );
 
-    const shapeStyle = parseStyleAttr(getAttribute(shape, null, "style"));
-    const widthPx = cssLengthToPx(shapeStyle["width"]);
-    const heightPx = cssLengthToPx(shapeStyle["height"]);
+    const shapeStyle = parseVmlStyle(getAttribute(shape, null, "style"));
+    const widthPx = vmlCssLengthToPx(shapeStyle["width"]);
+    const heightPx = vmlCssLengthToPx(shapeStyle["height"]);
     const isEmbeddedObject = getLocalName(pictElement.name ?? "") === "object";
     if (
       isEmbeddedObject &&
-      ((widthPx !== undefined && !validPreviewDimension(widthPx)) ||
-        (heightPx !== undefined && !validPreviewDimension(heightPx)))
+      ((widthPx !== undefined && !isValidVmlPreviewDimension(widthPx)) ||
+        (heightPx !== undefined && !isValidVmlPreviewDimension(heightPx)))
     ) {
       continue;
     }
@@ -516,14 +326,14 @@ export function parseVmlImageContent(
   for (const child of getChildElements(pictElement)) {
     const localName = getLocalName(child.name ?? "");
     if (localName === "group") {
-      const preview = parseGroupPreview(pictElement, child, rootXmlns);
+      const preview = previewDrawing(pictElement, renderVmlGroupPreview(child), rootXmlns);
       if (preview) {
         return preview;
       }
       continue;
     }
     if (localName === "rect" || localName === "roundrect" || localName === "oval") {
-      const preview = parseStandaloneShapePreview(pictElement, child, rootXmlns);
+      const preview = previewDrawing(pictElement, renderStandaloneVmlPreview(child), rootXmlns);
       if (preview) {
         return preview;
       }

--- a/packages/core/src/docx/vmlPreview.ts
+++ b/packages/core/src/docx/vmlPreview.ts
@@ -13,6 +13,7 @@ const MAX_VML_PREVIEW_PATH_POINTS = 20_000;
 const MAX_VML_PREVIEW_COORDINATE = 1_000_000;
 const MAX_VML_PREVIEW_DIMENSION_PX = 20_000;
 const MAX_VML_SVG_CHARACTERS = 1_000_000;
+const MAX_PACKAGE_VML_PREVIEW_CHARACTERS = 8 * 1024 * 1024;
 const SAFE_VML_COLORS = new Set([
   "black",
   "white",
@@ -71,12 +72,12 @@ type CoordinateViewport = CoordinatePair & {
 type PathState =
   | { type: "idle" }
   | {
-      type: "positioned";
+      type: "building";
       x: number;
       y: number;
       commands: string[];
+      hasLine: boolean;
     }
-  | { type: "drawing"; x: number; y: number; commands: string[] }
   | { type: "ended-empty" }
   | { type: "ended-painted"; commands: string[] };
 
@@ -291,23 +292,71 @@ const consumePathPoint = (budget: PreviewBudget): boolean => {
   return true;
 };
 
-const pathArgumentPairs = (raw: string): CoordinatePair[] | undefined => {
-  const parts = raw.split(",").map((part) => part.trim());
-  if (parts.length === 0 || parts.length % 2 !== 0) {
+const parsePathCoordinate = (raw: string): number | undefined => {
+  const trimmed = raw.trim();
+  const value = trimmed === "" ? 0 : parseVmlNumber(trimmed);
+  return validCoordinate(value) ? value : undefined;
+};
+
+const parseMovePair = (raw: string, budget: PreviewBudget): CoordinatePair | undefined => {
+  const separator = raw.indexOf(",");
+  if (separator < 0 || raw.indexOf(",", separator + 1) >= 0) {
     return undefined;
   }
-  const pairs: CoordinatePair[] = [];
-  for (let index = 0; index < parts.length; index += 2) {
-    const xRaw = parts.at(index);
-    const yRaw = parts.at(index + 1);
-    const x = xRaw === "" ? 0 : parseVmlNumber(xRaw);
-    const y = yRaw === "" ? 0 : parseVmlNumber(yRaw);
-    if (!validCoordinate(x) || !validCoordinate(y)) {
+  const x = parsePathCoordinate(raw.slice(0, separator));
+  const y = parsePathCoordinate(raw.slice(separator + 1));
+  return x !== undefined && y !== undefined && consumePathPoint(budget) ? { x, y } : undefined;
+};
+
+type AppendLinePairsOptions = {
+  budget: PreviewBudget;
+  commands: string[];
+  relative: boolean;
+  raw: string;
+  startX: number;
+  startY: number;
+};
+
+const appendLinePairs = ({
+  raw,
+  budget,
+  commands,
+  relative,
+  startX,
+  startY,
+}: AppendLinePairsOptions): CoordinatePair | undefined => {
+  let fieldStart = 0;
+  let pendingX: number | undefined;
+  let x = startX;
+  let y = startY;
+  let pairCount = 0;
+  for (let offset = 0; offset <= raw.length; offset += 1) {
+    if (offset < raw.length && raw.charAt(offset) !== ",") {
+      continue;
+    }
+    const value = parsePathCoordinate(raw.slice(fieldStart, offset));
+    if (value === undefined) {
       return undefined;
     }
-    pairs.push({ x, y });
+    if (pendingX === undefined) {
+      pendingX = value;
+    } else {
+      x = relative ? x + pendingX : pendingX;
+      y = relative ? y + value : value;
+      if (
+        !validCoordinate(x) ||
+        !validCoordinate(y) ||
+        !consumePathPoint(budget) ||
+        !appendPathCommand(commands, `L ${x} ${y}`, budget)
+      ) {
+        return undefined;
+      }
+      pendingX = undefined;
+      pairCount += 1;
+    }
+    fieldStart = offset + 1;
   }
-  return pairs;
+  return pendingX === undefined && pairCount > 0 ? { x, y } : undefined;
 };
 
 const appendPathCommand = (commands: string[], command: string, budget: PreviewBudget): boolean => {
@@ -347,60 +396,56 @@ const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
 
     switch (command) {
       case "m": {
-        const pairs = pathArgumentPairs(rawArguments);
-        const point = pairs?.at(0);
-        if (state.type !== "idle" || pairs?.length !== 1 || !point || !consumePathPoint(budget)) {
+        const point = parseMovePair(rawArguments, budget);
+        if (!point) {
           return INVALID_RESULT;
         }
-        const commands: string[] = [];
+        const commands = state.type === "building" ? state.commands : [];
+        const hasLine = state.type === "building" && state.hasLine;
         if (!appendPathCommand(commands, `M ${point.x} ${point.y}`, budget)) {
           return INVALID_RESULT;
         }
         state = {
-          type: "positioned",
+          type: "building",
           x: point.x,
           y: point.y,
           commands,
+          hasLine,
         };
         break;
       }
       case "l":
       case "r": {
-        if (state.type !== "positioned" && state.type !== "drawing") {
+        if (state.type !== "building") {
           return INVALID_RESULT;
         }
-        const pairs = pathArgumentPairs(rawArguments);
-        if (!pairs) {
+        const endPoint = appendLinePairs({
+          raw: rawArguments,
+          budget,
+          commands: state.commands,
+          relative: command === "r",
+          startX: state.x,
+          startY: state.y,
+        });
+        if (!endPoint) {
           return INVALID_RESULT;
-        }
-        let x: number = state.x;
-        let y: number = state.y;
-        for (const point of pairs) {
-          x = command === "r" ? x + point.x : point.x;
-          y = command === "r" ? y + point.y : point.y;
-          if (!validCoordinate(x) || !validCoordinate(y) || !consumePathPoint(budget)) {
-            return INVALID_RESULT;
-          }
-          if (!appendPathCommand(state.commands, `L ${x} ${y}`, budget)) {
-            return INVALID_RESULT;
-          }
         }
         state = {
-          type: "drawing",
-          x,
-          y,
+          type: "building",
+          x: endPoint.x,
+          y: endPoint.y,
           commands: state.commands,
+          hasLine: true,
         };
         break;
       }
       case "e": {
-        if (rawArguments || state.type === "idle") {
+        if (rawArguments || state.type !== "building") {
           return INVALID_RESULT;
         }
-        state =
-          state.type === "positioned"
-            ? { type: "ended-empty" }
-            : { type: "ended-painted", commands: state.commands };
+        state = state.hasLine
+          ? { type: "ended-painted", commands: state.commands }
+          : { type: "ended-empty" };
         break;
       }
       default:
@@ -414,8 +459,7 @@ const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
     case "ended-empty":
       return EMPTY_RESULT;
     case "idle":
-    case "positioned":
-    case "drawing":
+    case "building":
       return INVALID_RESULT;
     default:
       return state satisfies never;
@@ -620,4 +664,55 @@ export const renderVmlGroupPreview = (group: XmlElement): VmlPreviewResult => {
     return INVALID_RESULT;
   }
   return { type: "rendered", svg, widthPx, heightPx, style };
+};
+
+/** Bound retained synthetic VML previews while preserving their raw replay nodes. */
+export const enforcePackageVmlPreviewBudget = (
+  root: unknown,
+  maxCharacters = MAX_PACKAGE_VML_PREVIEW_CHARACTERS,
+): void => {
+  let remainingCharacters = Math.max(0, maxCharacters);
+  const visited = new WeakSet<object>();
+
+  const visit = (value: unknown): void => {
+    if (value === null || typeof value !== "object" || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+      return;
+    }
+    if (value instanceof Map) {
+      for (const child of value.values()) {
+        visit(child);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        visit(child);
+      }
+      return;
+    }
+    if (
+      "type" in value &&
+      value.type === "image" &&
+      "filename" in value &&
+      value.filename === "vml-shape-preview.svg" &&
+      "src" in value &&
+      typeof value.src === "string"
+    ) {
+      if (value.src.length <= remainingCharacters) {
+        remainingCharacters -= value.src.length;
+      } else {
+        remainingCharacters = 0;
+        delete value.src;
+      }
+    }
+    for (const child of Object.values(value)) {
+      visit(child);
+    }
+  };
+
+  visit(root);
 };

--- a/packages/core/src/docx/vmlPreview.ts
+++ b/packages/core/src/docx/vmlPreview.ts
@@ -14,6 +14,9 @@ const MAX_VML_PREVIEW_COORDINATE = 1_000_000;
 const MAX_VML_PREVIEW_DIMENSION_PX = 20_000;
 const MAX_VML_SVG_CHARACTERS = 1_000_000;
 const MAX_PACKAGE_VML_PREVIEW_CHARACTERS = 8 * 1024 * 1024;
+const VML_PREVIEW_DATA_URL_PREFIX = "data:image/svg+xml;charset=utf-8,";
+const VML_PREVIEW_FILENAME = "vml-shape-preview.svg";
+const VML_PREVIEW_MIME_TYPE = "image/svg+xml";
 const SAFE_VML_COLORS = new Set([
   "black",
   "white",
@@ -70,18 +73,25 @@ type CoordinateViewport = CoordinatePair & {
 };
 
 type PathState =
-  | { type: "idle" }
+  | { type: "between-sets"; pathSets: string[] }
   | {
       type: "building";
       x: number;
       y: number;
       commands: string[];
       hasLine: boolean;
-    }
-  | { type: "ended-empty" }
-  | { type: "ended-painted"; commands: string[] };
+      pathSets: string[];
+    };
 
-type PathResult = { type: "painted"; pathData: string } | { type: "empty" } | { type: "invalid" };
+type PathResult = { type: "painted"; pathSets: string[] } | { type: "empty" } | { type: "invalid" };
+
+type PathNumberCursor = {
+  afterComma: boolean;
+  offset: number;
+  raw: string;
+};
+
+type PathNumberResult = { type: "value"; value: number } | { type: "end" } | { type: "invalid" };
 
 type ShapePaint = { type: "painted"; fill: string; stroke: string } | { type: "empty" };
 
@@ -174,7 +184,7 @@ export const isValidVmlPreviewDimension = (value: number | undefined): value is 
 /** Encode a generated, already-sanitized SVG without exceeding its output cap. */
 export const vmlSvgDataUrl = (svg: string): string | undefined =>
   svg.length <= MAX_VML_SVG_CHARACTERS
-    ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+    ? `${VML_PREVIEW_DATA_URL_PREFIX}${encodeURIComponent(svg)}`
     : undefined;
 
 const validCoordinate = (value: number | undefined): value is number =>
@@ -292,20 +302,60 @@ const consumePathPoint = (budget: PreviewBudget): boolean => {
   return true;
 };
 
-const parsePathCoordinate = (raw: string): number | undefined => {
-  const trimmed = raw.trim();
-  const value = trimmed === "" ? 0 : parseVmlNumber(trimmed);
-  return validCoordinate(value) ? value : undefined;
+const skipPathWhitespace = (cursor: PathNumberCursor): void => {
+  while (/\s/u.test(cursor.raw.charAt(cursor.offset))) {
+    cursor.offset += 1;
+  }
 };
 
-const parseMovePair = (raw: string, budget: PreviewBudget): CoordinatePair | undefined => {
-  const separator = raw.indexOf(",");
-  if (separator < 0 || raw.indexOf(",", separator + 1) >= 0) {
-    return undefined;
+const nextPathNumber = (cursor: PathNumberCursor): PathNumberResult => {
+  skipPathWhitespace(cursor);
+  if (cursor.offset >= cursor.raw.length) {
+    if (!cursor.afterComma) {
+      return { type: "end" };
+    }
+    cursor.afterComma = false;
+    return { type: "value", value: 0 };
   }
-  const x = parsePathCoordinate(raw.slice(0, separator));
-  const y = parsePathCoordinate(raw.slice(separator + 1));
-  return x !== undefined && y !== undefined && consumePathPoint(budget) ? { x, y } : undefined;
+
+  if (cursor.raw.charAt(cursor.offset) === ",") {
+    cursor.offset += 1;
+    cursor.afterComma = true;
+    return { type: "value", value: 0 };
+  }
+
+  cursor.afterComma = false;
+  const start = cursor.offset;
+  while (cursor.offset < cursor.raw.length && !/[,\s]/u.test(cursor.raw.charAt(cursor.offset))) {
+    cursor.offset += 1;
+  }
+  const value = parseVmlNumber(cursor.raw.slice(start, cursor.offset));
+  if (!validCoordinate(value)) {
+    return INVALID_RESULT;
+  }
+
+  skipPathWhitespace(cursor);
+  if (cursor.raw.charAt(cursor.offset) === ",") {
+    cursor.offset += 1;
+    cursor.afterComma = true;
+  }
+  return { type: "value", value };
+};
+
+const pathNumberCursor = (raw: string): PathNumberCursor => ({
+  afterComma: false,
+  offset: 0,
+  raw,
+});
+
+const parseMovePair = (raw: string, budget: PreviewBudget): CoordinatePair | undefined => {
+  const cursor = pathNumberCursor(raw);
+  const x = nextPathNumber(cursor);
+  const y = nextPathNumber(cursor);
+  const end = nextPathNumber(cursor);
+  return x.type === "value" && y.type === "value" && end.type === "end" && consumePathPoint(budget)
+    ? { x: x.value, y: y.value }
+    : undefined;
 };
 
 type AppendLinePairsOptions = {
@@ -325,38 +375,31 @@ const appendLinePairs = ({
   startX,
   startY,
 }: AppendLinePairsOptions): CoordinatePair | undefined => {
-  let fieldStart = 0;
-  let pendingX: number | undefined;
+  const cursor = pathNumberCursor(raw);
   let x = startX;
   let y = startY;
   let pairCount = 0;
-  for (let offset = 0; offset <= raw.length; offset += 1) {
-    if (offset < raw.length && raw.charAt(offset) !== ",") {
-      continue;
+  while (true) {
+    const nextX = nextPathNumber(cursor);
+    if (nextX.type === "end") {
+      return pairCount > 0 ? { x, y } : undefined;
     }
-    const value = parsePathCoordinate(raw.slice(fieldStart, offset));
-    if (value === undefined) {
+    const nextY = nextPathNumber(cursor);
+    if (nextX.type !== "value" || nextY.type !== "value") {
       return undefined;
     }
-    if (pendingX === undefined) {
-      pendingX = value;
-    } else {
-      x = relative ? x + pendingX : pendingX;
-      y = relative ? y + value : value;
-      if (
-        !validCoordinate(x) ||
-        !validCoordinate(y) ||
-        !consumePathPoint(budget) ||
-        !appendPathCommand(commands, `L ${x} ${y}`, budget)
-      ) {
-        return undefined;
-      }
-      pendingX = undefined;
-      pairCount += 1;
+    x = relative ? x + nextX.value : nextX.value;
+    y = relative ? y + nextY.value : nextY.value;
+    if (
+      !validCoordinate(x) ||
+      !validCoordinate(y) ||
+      !consumePathPoint(budget) ||
+      !appendPathCommand(commands, `L ${x} ${y}`, budget)
+    ) {
+      return undefined;
     }
-    fieldStart = offset + 1;
+    pairCount += 1;
   }
-  return pendingX === undefined && pairCount > 0 ? { x, y } : undefined;
 };
 
 const appendPathCommand = (commands: string[], command: string, budget: PreviewBudget): boolean => {
@@ -367,11 +410,31 @@ const appendPathCommand = (commands: string[], command: string, budget: PreviewB
   return true;
 };
 
+const startPathSubpath = (
+  state: PathState,
+  point: CoordinatePair,
+  budget: PreviewBudget,
+): PathState | undefined => {
+  const commands = state.type === "building" ? state.commands : [];
+  const hasLine = state.type === "building" && state.hasLine;
+  if (!appendPathCommand(commands, `M ${point.x} ${point.y}`, budget)) {
+    return undefined;
+  }
+  return {
+    type: "building",
+    x: point.x,
+    y: point.y,
+    commands,
+    hasLine,
+    pathSets: state.pathSets,
+  };
+};
+
 const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
   if (raw.length > MAX_VML_SVG_CHARACTERS) {
     return INVALID_RESULT;
   }
-  let state: PathState = { type: "idle" };
+  let state: PathState = { type: "between-sets", pathSets: [] };
   let offset = 0;
   while (offset < raw.length) {
     while (/\s/u.test(raw.charAt(offset))) {
@@ -390,28 +453,17 @@ const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
       offset += 1;
     }
     const rawArguments = raw.slice(argumentStart, offset).trim();
-    if (state.type === "ended-empty" || state.type === "ended-painted") {
-      return INVALID_RESULT;
-    }
-
     switch (command) {
       case "m": {
         const point = parseMovePair(rawArguments, budget);
         if (!point) {
           return INVALID_RESULT;
         }
-        const commands = state.type === "building" ? state.commands : [];
-        const hasLine = state.type === "building" && state.hasLine;
-        if (!appendPathCommand(commands, `M ${point.x} ${point.y}`, budget)) {
+        const nextState = startPathSubpath(state, point, budget);
+        if (!nextState) {
           return INVALID_RESULT;
         }
-        state = {
-          type: "building",
-          x: point.x,
-          y: point.y,
-          commands,
-          hasLine,
-        };
+        state = nextState;
         break;
       }
       case "l":
@@ -436,6 +488,7 @@ const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
           y: endPoint.y,
           commands: state.commands,
           hasLine: true,
+          pathSets: state.pathSets,
         };
         break;
       }
@@ -443,9 +496,10 @@ const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
         if (rawArguments || state.type !== "building") {
           return INVALID_RESULT;
         }
-        state = state.hasLine
-          ? { type: "ended-painted", commands: state.commands }
-          : { type: "ended-empty" };
+        if (state.hasLine) {
+          state.pathSets.push(state.commands.join(" "));
+        }
+        state = { type: "between-sets", pathSets: state.pathSets };
         break;
       }
       default:
@@ -454,11 +508,10 @@ const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
   }
 
   switch (state.type) {
-    case "ended-painted":
-      return { type: "painted", pathData: state.commands.join(" ") };
-    case "ended-empty":
-      return EMPTY_RESULT;
-    case "idle":
+    case "between-sets":
+      return state.pathSets.length > 0
+        ? { type: "painted", pathSets: state.pathSets }
+        : EMPTY_RESULT;
     case "building":
       return INVALID_RESULT;
     default:
@@ -529,11 +582,15 @@ const pathShapeFragment = (shape: XmlElement, budget: PreviewBudget): PreviewFra
   if (path.type !== "painted") {
     return path;
   }
-  const svg = `<path transform="${transform}" d="${path.pathData}" fill="${paint.fill}" stroke="${paint.stroke}"/>`;
-  const wrapperCharacters = svg.length - path.pathData.length;
-  return consumeSvgCharacters(budget, wrapperCharacters)
-    ? { type: "painted", svg }
-    : INVALID_RESULT;
+  const fragments: string[] = [];
+  for (const pathData of path.pathSets) {
+    const svg = `<path transform="${transform}" d="${pathData}" fill="${paint.fill}" fill-rule="evenodd" stroke="${paint.stroke}"/>`;
+    if (!consumeSvgCharacters(budget, svg.length - pathData.length)) {
+      return INVALID_RESULT;
+    }
+    fragments.push(svg);
+  }
+  return { type: "painted", svg: fragments.join("") };
 };
 
 const renderGroupChildren = (
@@ -697,10 +754,15 @@ export const enforcePackageVmlPreviewBudget = (
     if (
       "type" in value &&
       value.type === "image" &&
+      "rId" in value &&
+      value.rId === "" &&
+      "mimeType" in value &&
+      value.mimeType === VML_PREVIEW_MIME_TYPE &&
       "filename" in value &&
-      value.filename === "vml-shape-preview.svg" &&
+      value.filename === VML_PREVIEW_FILENAME &&
       "src" in value &&
-      typeof value.src === "string"
+      typeof value.src === "string" &&
+      value.src.startsWith(VML_PREVIEW_DATA_URL_PREFIX)
     ) {
       if (value.src.length <= remainingCharacters) {
         remainingCharacters -= value.src.length;

--- a/packages/core/src/docx/vmlPreview.ts
+++ b/packages/core/src/docx/vmlPreview.ts
@@ -1,0 +1,623 @@
+import {
+  findChild,
+  findDeep,
+  getAttribute,
+  getChildElements,
+  getLocalName,
+  type XmlElement,
+} from "./xmlParser";
+
+const MAX_VML_PREVIEW_DEPTH = 16;
+const MAX_VML_PREVIEW_ELEMENTS = 256;
+const MAX_VML_PREVIEW_PATH_POINTS = 20_000;
+const MAX_VML_PREVIEW_COORDINATE = 1_000_000;
+const MAX_VML_PREVIEW_DIMENSION_PX = 20_000;
+const MAX_VML_SVG_CHARACTERS = 1_000_000;
+const SAFE_VML_COLORS = new Set([
+  "black",
+  "white",
+  "red",
+  "green",
+  "blue",
+  "yellow",
+  "gray",
+  "grey",
+  "silver",
+  "maroon",
+  "purple",
+  "fuchsia",
+  "lime",
+  "olive",
+  "navy",
+  "teal",
+  "aqua",
+]);
+const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export type VmlPreviewResult =
+  | {
+      type: "rendered";
+      svg: string;
+      widthPx: number;
+      heightPx: number;
+      style: Record<string, string>;
+    }
+  | { type: "empty" }
+  | { type: "invalid" };
+
+type PreviewFragmentResult =
+  | { type: "painted"; svg: string }
+  | { type: "empty" }
+  | { type: "invalid" };
+
+type PreviewBudget = {
+  elements: number;
+  pathPoints: number;
+  svgCharacters: number;
+};
+
+type CoordinatePair = { x: number; y: number };
+
+type LocalCoordinateSpace = {
+  origin: CoordinatePair;
+  size: CoordinatePair;
+};
+
+type CoordinateViewport = CoordinatePair & {
+  width: number;
+  height: number;
+};
+
+type PathState =
+  | { type: "idle" }
+  | {
+      type: "positioned";
+      x: number;
+      y: number;
+      commands: string[];
+    }
+  | { type: "drawing"; x: number; y: number; commands: string[] }
+  | { type: "ended-empty" }
+  | { type: "ended-painted"; commands: string[] };
+
+type PathResult = { type: "painted"; pathData: string } | { type: "empty" } | { type: "invalid" };
+
+type ShapePaint = { type: "painted"; fill: string; stroke: string } | { type: "empty" };
+
+const EMPTY_RESULT = { type: "empty" } as const;
+const INVALID_RESULT = { type: "invalid" } as const;
+
+type VmlPathCommand = "e" | "l" | "m" | "r";
+
+const isVmlPathCommand = (value: string): value is VmlPathCommand => {
+  switch (value) {
+    case "e":
+    case "l":
+    case "m":
+    case "r":
+      return true;
+    default:
+      return false;
+  }
+};
+
+/** Parse a VML/CSS length into CSS pixels without accepting partial numbers. */
+export const vmlCssLengthToPx = (raw: string | undefined): number | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  const match = /^(?<amount>-?(?:\d+(?:\.\d+)?|\.\d+))\s*(?<unit>pt|in|px|cm|mm|pc)?$/iu.exec(
+    raw.trim(),
+  );
+  const amountText = match?.groups?.["amount"];
+  if (amountText === undefined) {
+    return undefined;
+  }
+  const value = Number.parseFloat(amountText);
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  switch (match?.groups?.["unit"]?.toLowerCase()) {
+    case "pt":
+      return (value / 72) * 96;
+    case "in":
+      return value * 96;
+    case "cm":
+      return (value / 2.54) * 96;
+    case "mm":
+      return (value / 25.4) * 96;
+    case "pc":
+      return (value / 6) * 96;
+    case "px":
+    case undefined:
+      return value;
+    default:
+      return undefined;
+  }
+};
+
+/** Read a VML `style` attribute into a prototype-free lowercased record. */
+export const parseVmlStyle = (style: string | null): Record<string, string> => {
+  const result: Record<string, string> = Object.create(null);
+  if (!style) {
+    return result;
+  }
+  for (const declaration of style.split(";")) {
+    const colon = declaration.indexOf(":");
+    if (colon < 0) {
+      continue;
+    }
+    const key = declaration.slice(0, colon).trim().toLowerCase();
+    const value = declaration.slice(colon + 1).trim();
+    if (!key || PROTOTYPE_POLLUTION_KEYS.has(key)) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+};
+
+/** Parse a finite VML number without exponent or partial-number coercion. */
+export const parseVmlNumber = (raw: string | null | undefined): number | undefined => {
+  if (!raw || !/^-?(?:\d+(?:\.\d+)?|\.\d+)$/u.test(raw.trim())) {
+    return undefined;
+  }
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) ? value : undefined;
+};
+
+/** Check a physical preview dimension against the retained SVG layout bound. */
+export const isValidVmlPreviewDimension = (value: number | undefined): value is number =>
+  value !== undefined && value > 0 && value <= MAX_VML_PREVIEW_DIMENSION_PX;
+
+/** Encode a generated, already-sanitized SVG without exceeding its output cap. */
+export const vmlSvgDataUrl = (svg: string): string | undefined =>
+  svg.length <= MAX_VML_SVG_CHARACTERS
+    ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+    : undefined;
+
+const validCoordinate = (value: number | undefined): value is number =>
+  value !== undefined && Math.abs(value) <= MAX_VML_PREVIEW_COORDINATE;
+
+const validExtent = (value: number | undefined): value is number =>
+  value !== undefined && value > 0 && value <= MAX_VML_PREVIEW_COORDINATE;
+
+const coordinatePair = (raw: string | null): CoordinatePair | undefined => {
+  const [xRaw, yRaw, extra] = raw?.split(",").map((part) => part.trim()) ?? [];
+  if (extra !== undefined) {
+    return undefined;
+  }
+  const x = parseVmlNumber(xRaw);
+  const y = parseVmlNumber(yRaw);
+  return validCoordinate(x) && validCoordinate(y) ? { x, y } : undefined;
+};
+
+const localCoordinateSpace = (
+  element: XmlElement,
+  fallbackWidth: number,
+  fallbackHeight: number,
+): LocalCoordinateSpace | undefined => {
+  const originRaw = getAttribute(element, null, "coordorigin");
+  const sizeRaw = getAttribute(element, null, "coordsize");
+  const origin = originRaw ? coordinatePair(originRaw) : { x: 0, y: 0 };
+  const size = sizeRaw ? coordinatePair(sizeRaw) : { x: fallbackWidth, y: fallbackHeight };
+  if (!origin || !size) {
+    return undefined;
+  }
+  return validExtent(size.x) && validExtent(size.y) ? { origin, size } : undefined;
+};
+
+const coordinateViewport = (style: Record<string, string>): CoordinateViewport | undefined => {
+  const x = parseVmlNumber(style["left"]) ?? 0;
+  const y = parseVmlNumber(style["top"]) ?? 0;
+  const width = parseVmlNumber(style["width"]);
+  const height = parseVmlNumber(style["height"]);
+  return validCoordinate(x) && validCoordinate(y) && validExtent(width) && validExtent(height)
+    ? { x, y, width, height }
+    : undefined;
+};
+
+const transformMatrix = (
+  viewport: CoordinateViewport,
+  space: LocalCoordinateSpace,
+): string | undefined => {
+  const scaleX = viewport.width / space.size.x;
+  const scaleY = viewport.height / space.size.y;
+  const translateX = viewport.x - space.origin.x * scaleX;
+  const translateY = viewport.y - space.origin.y * scaleY;
+  const values = [scaleX, scaleY, translateX, translateY];
+  if (
+    values.some((value) => !Number.isFinite(value) || Math.abs(value) > MAX_VML_PREVIEW_COORDINATE)
+  ) {
+    return undefined;
+  }
+  return `matrix(${scaleX} 0 0 ${scaleY} ${translateX} ${translateY})`;
+};
+
+const safeColor = (raw: string | null, fallback: string): string => {
+  const normalized = raw?.trim().toLowerCase();
+  if (!normalized) {
+    return fallback;
+  }
+  if (normalized === "none") {
+    return "none";
+  }
+  if (SAFE_VML_COLORS.has(normalized)) {
+    return normalized;
+  }
+  if (/^#[0-9a-f]{3}(?:[0-9a-f]{3})?$/u.test(normalized)) {
+    return normalized;
+  }
+  return /^[0-9a-f]{6}$/u.test(normalized) ? `#${normalized}` : fallback;
+};
+
+const isVmlFalse = (raw: string | null): boolean => {
+  switch (raw?.trim().toLowerCase()) {
+    case "0":
+    case "f":
+    case "false":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const shapePaint = (shape: XmlElement): ShapePaint => {
+  const fill = isVmlFalse(getAttribute(shape, null, "filled"))
+    ? "none"
+    : safeColor(getAttribute(shape, null, "fillcolor"), "white");
+  const stroke = isVmlFalse(getAttribute(shape, null, "stroked"))
+    ? "none"
+    : safeColor(getAttribute(shape, null, "strokecolor"), "black");
+  return fill === "none" && stroke === "none" ? EMPTY_RESULT : { type: "painted", fill, stroke };
+};
+
+const isHidden = (style: Record<string, string>): boolean =>
+  style["visibility"]?.toLowerCase() === "hidden" || style["display"]?.toLowerCase() === "none";
+
+const consumeSvgCharacters = (budget: PreviewBudget, count: number): boolean => {
+  if (budget.svgCharacters + count > MAX_VML_SVG_CHARACTERS) {
+    return false;
+  }
+  budget.svgCharacters += count;
+  return true;
+};
+
+const consumePathPoint = (budget: PreviewBudget): boolean => {
+  if (budget.pathPoints >= MAX_VML_PREVIEW_PATH_POINTS) {
+    return false;
+  }
+  budget.pathPoints += 1;
+  return true;
+};
+
+const pathArgumentPairs = (raw: string): CoordinatePair[] | undefined => {
+  const parts = raw.split(",").map((part) => part.trim());
+  if (parts.length === 0 || parts.length % 2 !== 0) {
+    return undefined;
+  }
+  const pairs: CoordinatePair[] = [];
+  for (let index = 0; index < parts.length; index += 2) {
+    const xRaw = parts.at(index);
+    const yRaw = parts.at(index + 1);
+    const x = xRaw === "" ? 0 : parseVmlNumber(xRaw);
+    const y = yRaw === "" ? 0 : parseVmlNumber(yRaw);
+    if (!validCoordinate(x) || !validCoordinate(y)) {
+      return undefined;
+    }
+    pairs.push({ x, y });
+  }
+  return pairs;
+};
+
+const appendPathCommand = (commands: string[], command: string, budget: PreviewBudget): boolean => {
+  if (!consumeSvgCharacters(budget, command.length + 1)) {
+    return false;
+  }
+  commands.push(command);
+  return true;
+};
+
+const renderVmlPath = (raw: string, budget: PreviewBudget): PathResult => {
+  if (raw.length > MAX_VML_SVG_CHARACTERS) {
+    return INVALID_RESULT;
+  }
+  let state: PathState = { type: "idle" };
+  let offset = 0;
+  while (offset < raw.length) {
+    while (/\s/u.test(raw.charAt(offset))) {
+      offset += 1;
+    }
+    if (offset >= raw.length) {
+      break;
+    }
+    const command = raw.charAt(offset).toLowerCase();
+    if (!isVmlPathCommand(command)) {
+      return INVALID_RESULT;
+    }
+    offset += 1;
+    const argumentStart = offset;
+    while (offset < raw.length && !/[a-z]/iu.test(raw.charAt(offset))) {
+      offset += 1;
+    }
+    const rawArguments = raw.slice(argumentStart, offset).trim();
+    if (state.type === "ended-empty" || state.type === "ended-painted") {
+      return INVALID_RESULT;
+    }
+
+    switch (command) {
+      case "m": {
+        const pairs = pathArgumentPairs(rawArguments);
+        const point = pairs?.at(0);
+        if (state.type !== "idle" || pairs?.length !== 1 || !point || !consumePathPoint(budget)) {
+          return INVALID_RESULT;
+        }
+        const commands: string[] = [];
+        if (!appendPathCommand(commands, `M ${point.x} ${point.y}`, budget)) {
+          return INVALID_RESULT;
+        }
+        state = {
+          type: "positioned",
+          x: point.x,
+          y: point.y,
+          commands,
+        };
+        break;
+      }
+      case "l":
+      case "r": {
+        if (state.type !== "positioned" && state.type !== "drawing") {
+          return INVALID_RESULT;
+        }
+        const pairs = pathArgumentPairs(rawArguments);
+        if (!pairs) {
+          return INVALID_RESULT;
+        }
+        let x: number = state.x;
+        let y: number = state.y;
+        for (const point of pairs) {
+          x = command === "r" ? x + point.x : point.x;
+          y = command === "r" ? y + point.y : point.y;
+          if (!validCoordinate(x) || !validCoordinate(y) || !consumePathPoint(budget)) {
+            return INVALID_RESULT;
+          }
+          if (!appendPathCommand(state.commands, `L ${x} ${y}`, budget)) {
+            return INVALID_RESULT;
+          }
+        }
+        state = {
+          type: "drawing",
+          x,
+          y,
+          commands: state.commands,
+        };
+        break;
+      }
+      case "e": {
+        if (rawArguments || state.type === "idle") {
+          return INVALID_RESULT;
+        }
+        state =
+          state.type === "positioned"
+            ? { type: "ended-empty" }
+            : { type: "ended-painted", commands: state.commands };
+        break;
+      }
+      default:
+        command satisfies never;
+    }
+  }
+
+  switch (state.type) {
+    case "ended-painted":
+      return { type: "painted", pathData: state.commands.join(" ") };
+    case "ended-empty":
+      return EMPTY_RESULT;
+    case "idle":
+    case "positioned":
+    case "drawing":
+      return INVALID_RESULT;
+    default:
+      return state satisfies never;
+  }
+};
+
+const primitiveShapeFragment = (
+  shape: XmlElement,
+  viewport: CoordinateViewport,
+  budget: PreviewBudget,
+): PreviewFragmentResult => {
+  const paint = shapePaint(shape);
+  if (paint.type === "empty") {
+    return EMPTY_RESULT;
+  }
+  const localName = getLocalName(shape.name ?? "");
+  let svg: string;
+  if (localName === "oval") {
+    svg = `<ellipse cx="${viewport.x + viewport.width / 2}" cy="${viewport.y + viewport.height / 2}" rx="${viewport.width / 2}" ry="${viewport.height / 2}" fill="${paint.fill}" stroke="${paint.stroke}"/>`;
+  } else {
+    const radius = localName === "roundrect" ? Math.min(viewport.width, viewport.height) * 0.1 : 0;
+    svg = `<rect x="${viewport.x}" y="${viewport.y}" width="${viewport.width}" height="${viewport.height}" rx="${radius}" fill="${paint.fill}" stroke="${paint.stroke}"/>`;
+  }
+  return consumeSvgCharacters(budget, svg.length) ? { type: "painted", svg } : INVALID_RESULT;
+};
+
+const lineFragment = (line: XmlElement, budget: PreviewBudget): PreviewFragmentResult => {
+  if (isVmlFalse(getAttribute(line, null, "stroked"))) {
+    return EMPTY_RESULT;
+  }
+  const from = coordinatePair(getAttribute(line, null, "from"));
+  const to = coordinatePair(getAttribute(line, null, "to"));
+  if (!from || !to) {
+    return INVALID_RESULT;
+  }
+  const stroke = safeColor(getAttribute(line, null, "strokecolor"), "black");
+  const svg = `<line x1="${from.x}" y1="${from.y}" x2="${to.x}" y2="${to.y}" stroke="${stroke}"/>`;
+  return consumeSvgCharacters(budget, svg.length) ? { type: "painted", svg } : INVALID_RESULT;
+};
+
+const pathShapeFragment = (shape: XmlElement, budget: PreviewBudget): PreviewFragmentResult => {
+  if (findChild(shape, "v", "textbox") || findChild(shape, "v", "imagedata")) {
+    return EMPTY_RESULT;
+  }
+  const style = parseVmlStyle(getAttribute(shape, null, "style"));
+  if (isHidden(style)) {
+    return EMPTY_RESULT;
+  }
+  const paint = shapePaint(shape);
+  if (paint.type === "empty") {
+    return EMPTY_RESULT;
+  }
+  const rawPath = getAttribute(shape, null, "path");
+  if (!rawPath) {
+    return EMPTY_RESULT;
+  }
+  const viewport = coordinateViewport(style);
+  if (!viewport) {
+    return INVALID_RESULT;
+  }
+  const space = localCoordinateSpace(shape, viewport.width, viewport.height);
+  const transform = space ? transformMatrix(viewport, space) : undefined;
+  if (!transform) {
+    return INVALID_RESULT;
+  }
+  const path = renderVmlPath(rawPath, budget);
+  if (path.type !== "painted") {
+    return path;
+  }
+  const svg = `<path transform="${transform}" d="${path.pathData}" fill="${paint.fill}" stroke="${paint.stroke}"/>`;
+  const wrapperCharacters = svg.length - path.pathData.length;
+  return consumeSvgCharacters(budget, wrapperCharacters)
+    ? { type: "painted", svg }
+    : INVALID_RESULT;
+};
+
+const renderGroupChildren = (
+  group: XmlElement,
+  budget: PreviewBudget,
+  depth: number,
+): PreviewFragmentResult => {
+  const fragments: string[] = [];
+  for (const child of getChildElements(group)) {
+    if (budget.elements >= MAX_VML_PREVIEW_ELEMENTS) {
+      return INVALID_RESULT;
+    }
+    budget.elements += 1;
+    const localName = getLocalName(child.name ?? "");
+    let result: PreviewFragmentResult;
+    switch (localName) {
+      case "group": {
+        if (depth >= MAX_VML_PREVIEW_DEPTH) {
+          return INVALID_RESULT;
+        }
+        const style = parseVmlStyle(getAttribute(child, null, "style"));
+        if (isHidden(style)) {
+          result = EMPTY_RESULT;
+          break;
+        }
+        const viewport = coordinateViewport(style);
+        const space = viewport
+          ? localCoordinateSpace(child, viewport.width, viewport.height)
+          : undefined;
+        const transform = viewport && space ? transformMatrix(viewport, space) : undefined;
+        if (!transform) {
+          return INVALID_RESULT;
+        }
+        const content = renderGroupChildren(child, budget, depth + 1);
+        if (content.type !== "painted") {
+          result = content;
+          break;
+        }
+        const svg = `<g transform="${transform}">${content.svg}</g>`;
+        const wrapperCharacters = svg.length - content.svg.length;
+        result = consumeSvgCharacters(budget, wrapperCharacters)
+          ? { type: "painted", svg }
+          : INVALID_RESULT;
+        break;
+      }
+      case "shape":
+        result = pathShapeFragment(child, budget);
+        break;
+      case "line":
+        result = lineFragment(child, budget);
+        break;
+      case "oval":
+      case "rect":
+      case "roundrect": {
+        const style = parseVmlStyle(getAttribute(child, null, "style"));
+        if (isHidden(style)) {
+          result = EMPTY_RESULT;
+          break;
+        }
+        const viewport = coordinateViewport(style);
+        result = viewport ? primitiveShapeFragment(child, viewport, budget) : INVALID_RESULT;
+        break;
+      }
+      default:
+        result = EMPTY_RESULT;
+    }
+    switch (result.type) {
+      case "painted":
+        fragments.push(result.svg);
+        break;
+      case "empty":
+        break;
+      case "invalid":
+        return INVALID_RESULT;
+      default:
+        result satisfies never;
+    }
+  }
+  return fragments.length > 0 ? { type: "painted", svg: fragments.join("") } : EMPTY_RESULT;
+};
+
+/** Render a bounded standalone VML rectangle or oval preview. */
+export const renderStandaloneVmlPreview = (shape: XmlElement): VmlPreviewResult => {
+  if (findDeep(shape, "v", "textbox")) {
+    return EMPTY_RESULT;
+  }
+  const style = parseVmlStyle(getAttribute(shape, null, "style"));
+  const widthPx = vmlCssLengthToPx(style["width"]);
+  const heightPx = vmlCssLengthToPx(style["height"]);
+  if (!isValidVmlPreviewDimension(widthPx) || !isValidVmlPreviewDimension(heightPx)) {
+    return INVALID_RESULT;
+  }
+  const budget: PreviewBudget = { elements: 1, pathPoints: 0, svgCharacters: 0 };
+  const content = primitiveShapeFragment(
+    shape,
+    { x: 0, y: 0, width: widthPx, height: heightPx },
+    budget,
+  );
+  if (content.type !== "painted") {
+    return content;
+  }
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${widthPx} ${heightPx}" width="${widthPx}" height="${heightPx}">${content.svg}</svg>`;
+  if (!consumeSvgCharacters(budget, svg.length - content.svg.length)) {
+    return INVALID_RESULT;
+  }
+  return { type: "rendered", svg, widthPx, heightPx, style };
+};
+
+/** Render a VML group through bounded, non-clipping local-coordinate transforms. */
+export const renderVmlGroupPreview = (group: XmlElement): VmlPreviewResult => {
+  const style = parseVmlStyle(getAttribute(group, null, "style"));
+  const widthPx = vmlCssLengthToPx(style["width"]);
+  const heightPx = vmlCssLengthToPx(style["height"]);
+  if (!isValidVmlPreviewDimension(widthPx) || !isValidVmlPreviewDimension(heightPx)) {
+    return INVALID_RESULT;
+  }
+  const space = localCoordinateSpace(group, widthPx, heightPx);
+  if (!space) {
+    return INVALID_RESULT;
+  }
+  const budget: PreviewBudget = { elements: 1, pathPoints: 0, svgCharacters: 0 };
+  const content = renderGroupChildren(group, budget, 0);
+  if (content.type !== "painted") {
+    return content;
+  }
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${space.origin.x} ${space.origin.y} ${space.size.x} ${space.size.y}" width="${widthPx}" height="${heightPx}">${content.svg}</svg>`;
+  if (!consumeSvgCharacters(budget, svg.length - content.svg.length)) {
+    return INVALID_RESULT;
+  }
+  return { type: "rendered", svg, widthPx, heightPx, style };
+};


### PR DESCRIPTION
## Summary

- render nested legacy VML groups through bounded local-coordinate transforms
- support filled and stroked freeform paths using the `m`, `l`, `r`, and `e` command subset
- accept comma or whitespace coordinate delimiters, omitted comma fields, compound subpaths, and independently painted path sets
- preserve source order, positioning, raw XML replay, and existing embedded-image precedence
- fail closed on malformed paths and enforce per-preview plus package-wide resource limits

## Validation

- 39 focused VML parser tests (169 assertions)
- focused format and lint checks
- `@stll/folio-core` typecheck
- visual interoperability comparison confirmed the restored artwork without geometry, raster, or pagination regressions