### PR TITLE
fix: honor sparse VML text box insets

### DIFF
--- a/.changeset/calm-vml-insets.md
+++ b/.changeset/calm-vml-insets.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor sparse legacy VML text-box inset values.

--- a/packages/core/src/docx/headerFooterParser.test.ts
+++ b/packages/core/src/docx/headerFooterParser.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import type { HeaderFooter, Paragraph } from "../types/document";
+import { toFlowBlocks } from "../layout-bridge/convert/toFlowBlocks";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import type { Document, HeaderFooter, Paragraph } from "../types/document";
 import { parseFooter, parseHeader } from "./headerFooterParser";
 
 const NAMESPACES = [
@@ -161,5 +163,93 @@ describe("header/footer text boxes", () => {
       fill: { type: "none" },
       textBody: { margins: { left: 0, top: 0, right: 0, bottom: 0 } },
     });
+  });
+
+  test("applies authored and default values in sparse VML text-box insets", () => {
+    const footer = parseFooter(`
+      <w:ftr ${NAMESPACES}>
+        <w:p><w:r><w:pict>
+          <v:shape id="sparse-inset" style="position:absolute;width:216pt;height:18pt" filled="f" stroked="f">
+            <v:textbox inset="20pt,0,,0">
+              <w:txbxContent><w:p><w:r><w:t>Sparse inset</w:t></w:r></w:p></w:txbxContent>
+            </v:textbox>
+          </v:shape>
+        </w:pict></w:r></w:p>
+        <w:p><w:r><w:t>Adjacent footer</w:t></w:r></w:p>
+      </w:ftr>`);
+
+    const paragraph = footer.content.at(0);
+    const run = paragraph?.type === "paragraph" ? paragraph.content.at(0) : undefined;
+    const shapeContent = run?.type === "run" ? run.content.at(0) : undefined;
+    if (shapeContent?.type !== "shape") {
+      throw new Error("Expected sparse-inset text box");
+    }
+    expect(shapeContent.shape.textBody?.margins).toEqual({
+      left: 254_000,
+      top: 0,
+      right: 91_440,
+      bottom: 0,
+    });
+
+    const document: Document = { package: { document: { content: footer.content } } };
+    const blocks = toFlowBlocks(toProseDoc(document));
+    const textBox = blocks.at(0);
+    if (textBox?.kind !== "textBox") {
+      throw new Error("Expected sparse-inset text box flow block");
+    }
+    expect(textBox.margins).toEqual({
+      left: 27,
+      top: 0,
+      right: 10,
+      bottom: 0,
+    });
+    expect(blocks.at(1)?.kind).toBe("paragraph");
+  });
+
+  test("uses standard VML text-box insets when the attribute is absent", () => {
+    const footer = parseFooter(`
+      <w:ftr ${NAMESPACES}>
+        <w:p><w:r><w:pict>
+          <v:shape style="width:216pt;height:18pt">
+            <v:textbox>
+              <w:txbxContent><w:p><w:r><w:t>Default inset</w:t></w:r></w:p></w:txbxContent>
+            </v:textbox>
+          </v:shape>
+        </w:pict></w:r></w:p>
+      </w:ftr>`);
+
+    const paragraph = footer.content.at(0);
+    const run = paragraph?.type === "paragraph" ? paragraph.content.at(0) : undefined;
+    const shapeContent = run?.type === "run" ? run.content.at(0) : undefined;
+    if (shapeContent?.type !== "shape") {
+      throw new Error("Expected default-inset text box");
+    }
+    expect(shapeContent.shape.textBody?.margins).toEqual({
+      left: 91_440,
+      top: 45_720,
+      right: 91_440,
+      bottom: 45_720,
+    });
+  });
+
+  test("rejects VML text-box inset values beyond the four-field bound", () => {
+    const footer = parseFooter(`
+      <w:ftr ${NAMESPACES}>
+        <w:p><w:r><w:pict>
+          <v:shape style="width:216pt;height:18pt">
+            <v:textbox inset="1pt 2pt 3pt 4pt 5pt">
+              <w:txbxContent><w:p><w:r><w:t>Bounded inset</w:t></w:r></w:p></w:txbxContent>
+            </v:textbox>
+          </v:shape>
+        </w:pict></w:r></w:p>
+      </w:ftr>`);
+
+    const paragraph = footer.content.at(0);
+    const run = paragraph?.type === "paragraph" ? paragraph.content.at(0) : undefined;
+    const shapeContent = run?.type === "run" ? run.content.at(0) : undefined;
+    if (shapeContent?.type !== "shape") {
+      throw new Error("Expected bounded-inset text box");
+    }
+    expect(shapeContent.shape.textBody?.margins).toBeUndefined();
   });
 });

--- a/packages/core/src/docx/paragraphTextBoxEnrichment.ts
+++ b/packages/core/src/docx/paragraphTextBoxEnrichment.ts
@@ -50,6 +50,8 @@ const VML_VERTICAL_RELATIVES = new Set<ImagePosition["vertical"]["relativeTo"]>(
   "topMargin",
   "bottomMargin",
 ]);
+const VML_TEXTBOX_INSET_DEFAULTS = ["0.1in", "0.05in", "0.1in", "0.05in"] as const;
+const MAX_VML_TEXTBOX_INSET_TOKEN_CHARACTERS = 64;
 
 const parseVmlStyle = (value: string | null): Record<string, string> => {
   const declarations: Record<string, string> = {};
@@ -113,20 +115,62 @@ const verticalRelativeTo = (value: string | undefined): ImagePosition["vertical"
   return "paragraph";
 };
 
+const parseVmlInsetFields = (rawInset: string): Array<string | undefined> | undefined => {
+  const fields: Array<string | undefined> = [];
+  let offset = 0;
+  let segmentHasField = false;
+
+  while (offset <= rawInset.length) {
+    while (/\s/u.test(rawInset.charAt(offset))) {
+      offset += 1;
+    }
+    if (offset >= rawInset.length) {
+      if (!segmentHasField) {
+        fields.push(undefined);
+      }
+      return fields.length <= VML_TEXTBOX_INSET_DEFAULTS.length ? fields : undefined;
+    }
+    if (rawInset.charAt(offset) === ",") {
+      if (!segmentHasField) {
+        fields.push(undefined);
+      }
+      if (fields.length > VML_TEXTBOX_INSET_DEFAULTS.length) {
+        return undefined;
+      }
+      segmentHasField = false;
+      offset += 1;
+      continue;
+    }
+
+    const tokenStart = offset;
+    while (offset < rawInset.length && !/[,\s]/u.test(rawInset.charAt(offset))) {
+      offset += 1;
+      if (offset - tokenStart > MAX_VML_TEXTBOX_INSET_TOKEN_CHARACTERS) {
+        return undefined;
+      }
+    }
+    fields.push(rawInset.slice(tokenStart, offset));
+    if (fields.length > VML_TEXTBOX_INSET_DEFAULTS.length) {
+      return undefined;
+    }
+    segmentHasField = true;
+  }
+
+  return undefined;
+};
+
 const parseVmlInsets = (
   textBoxEl: XmlElement,
 ): { left: number; top: number; right: number; bottom: number } | undefined => {
-  const [left, top, right, bottom, extra] =
-    getAttribute(textBoxEl, null, "inset")
-      ?.split(",")
-      .map((value) => vmlLengthToPixels(value)) ?? [];
-  if (
-    extra !== undefined ||
-    left === undefined ||
-    top === undefined ||
-    right === undefined ||
-    bottom === undefined
-  ) {
+  const rawInset = getAttribute(textBoxEl, null, "inset") ?? "";
+  const fields = parseVmlInsetFields(rawInset);
+  if (!fields) {
+    return undefined;
+  }
+  const [left, top, right, bottom] = VML_TEXTBOX_INSET_DEFAULTS.map((fallback, index) =>
+    vmlLengthToPixels(fields.at(index) ?? fallback),
+  );
+  if (left === undefined || top === undefined || right === undefined || bottom === undefined) {
     return undefined;
   }
   return {


### PR DESCRIPTION
## Summary

- parse VML text-box inset values separated by commas or whitespace
- apply standard defaults when the attribute or individual left, top, right, or bottom values are omitted
- retain authored zero values and reject extra components
- stop inset tokenization at bounded field and token limits
- preserve resolved margins through editor conversion and layout-flow construction

## Validation

- 7 focused header/footer text-box tests
- focused format and lint checks
- `@stll/folio-core` typecheck
- three-page visual interoperability comparison improved geometry matching from 96.13% to 99.45%, with all 181 reference lines matched and no pagination regression