### PR TITLE
fix: keep authored blank paragraphs with headings

### DIFF
--- a/.changeset/gentle-authored-blanks.md
+++ b/.changeset/gentle-authored-blanks.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep authored empty paragraphs as anchors for keep-with-next pagination.

--- a/packages/core/src/layout-engine/keep-together.test.ts
+++ b/packages/core/src/layout-engine/keep-together.test.ts
@@ -16,6 +16,13 @@ const emptyParagraph = (id: string): ParagraphBlock => ({
   runs: [],
 });
 
+const authoredEmptyParagraph = (id: string): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: [],
+  attrs: { hasDirectParagraphFormatting: true },
+});
+
 const table = (id: string): FlowBlock => ({
   kind: "table",
   id,
@@ -149,6 +156,38 @@ describe("computeKeepNextChains", () => {
     });
   });
 
+  test("stops keepNext at an authored empty spacer", () => {
+    const blocks: FlowBlock[] = [
+      paragraph("heading", true),
+      authoredEmptyParagraph("answer space"),
+      paragraph("next heading", true),
+      paragraph("body"),
+    ];
+
+    expect(computeKeepNextChains(blocks)).toEqual(
+      new Map([
+        [
+          0,
+          {
+            startIndex: 0,
+            endIndex: 0,
+            memberIndices: [0],
+            anchorIndex: 1,
+          },
+        ],
+        [
+          2,
+          {
+            startIndex: 2,
+            endIndex: 2,
+            memberIndices: [2],
+            anchorIndex: 3,
+          },
+        ],
+      ]),
+    );
+  });
+
   test("carries a trailing table separator to the next content paragraph", () => {
     const blocks: FlowBlock[] = [table("table"), emptyParagraph("separator"), paragraph("body")];
 
@@ -158,6 +197,16 @@ describe("computeKeepNextChains", () => {
       memberIndices: [1],
       anchorIndex: 2,
     });
+  });
+
+  test("does not treat an authored blank after a table as a structural separator", () => {
+    const blocks: FlowBlock[] = [
+      table("table"),
+      authoredEmptyParagraph("answer space"),
+      paragraph("body"),
+    ];
+
+    expect(computeKeepNextChains(blocks)).toEqual(new Map());
   });
 
   test("does not implicitly keep an ordinary empty paragraph with the next paragraph", () => {

--- a/packages/core/src/layout-engine/keep-together.ts
+++ b/packages/core/src/layout-engine/keep-together.ts
@@ -5,7 +5,11 @@
  * (keep all lines together) properties that affect pagination.
  */
 
-import { collapseParagraphSpacing } from "./paragraphSpacing";
+import {
+  collapseParagraphSpacing,
+  isAuthoredEmptyParagraph,
+  isEmptyParagraph,
+} from "./paragraphSpacing";
 import type { FlowBlock, ParagraphBlock, Measure } from "./types";
 
 /**
@@ -24,22 +28,27 @@ export type KeepNextChain = {
   anchorIndex: number;
 };
 
-function isVisuallyEmptyParagraph(block: ParagraphBlock): boolean {
-  if (block.runs.length === 0) {
-    return true;
-  }
-  if (block.runs.length !== 1) {
+/**
+ * Whether an empty paragraph is only a structural separator through which a
+ * keep-with-next chain may pass. An explicitly styled or directly formatted
+ * blank is authored layout content: it anchors the preceding keepNext rather
+ * than implicitly linking that heading to later content.
+ */
+function isKeepNextPassThroughParagraph(block: ParagraphBlock): boolean {
+  if (!isEmptyParagraph(block)) {
     return false;
   }
-  const run = block.runs.at(0);
-  return run?.kind === "text" && run.text === "";
+  if (block.attrs?.suppressEmptyParagraphHeight === true) {
+    return true;
+  }
+  return !isAuthoredEmptyParagraph(block);
 }
 
 function startsTrailingTableSeparatorChain(blocks: FlowBlock[], index: number): boolean {
   const block = blocks[index];
   if (
     block?.kind !== "paragraph" ||
-    !isVisuallyEmptyParagraph(block) ||
+    !isKeepNextPassThroughParagraph(block) ||
     blocks[index - 1]?.kind !== "table"
   ) {
     return false;
@@ -50,7 +59,7 @@ function startsTrailingTableSeparatorChain(blocks: FlowBlock[], index: number): 
     if (nextBlock?.kind !== "paragraph") {
       return false;
     }
-    if (!isVisuallyEmptyParagraph(nextBlock)) {
+    if (!isKeepNextPassThroughParagraph(nextBlock)) {
       return true;
     }
   }
@@ -115,7 +124,7 @@ export function computeKeepNextChains(blocks: FlowBlock[]): Map<number, KeepNext
       }
 
       const nextPara = nextBlock;
-      if (nextPara.attrs?.keepNext || isVisuallyEmptyParagraph(nextPara)) {
+      if (nextPara.attrs?.keepNext || isKeepNextPassThroughParagraph(nextPara)) {
         // Word carries keepNext across structural empty paragraphs. Treat
         // them as pass-through members so a blank separator cannot strand a
         // heading at the bottom of the preceding page.
@@ -185,7 +194,7 @@ export function calculateChainHeight(
   let trailingSpacing = firstBlock.attrs?.spacing?.after ?? 0;
   const startsWithTrailingTableSeparator =
     blocks[firstMemberIndex - 1]?.kind === "table" &&
-    isVisuallyEmptyParagraph(firstBlock) &&
+    isEmptyParagraph(firstBlock) &&
     !firstBlock.attrs?.keepNext;
 
   const successorIndices = [...chain.memberIndices.slice(1)];

--- a/packages/core/src/layout-engine/paragraphSpacing.ts
+++ b/packages/core/src/layout-engine/paragraphSpacing.ts
@@ -29,6 +29,13 @@ export function isEmptyParagraph(block: ParagraphBlock): boolean {
   return run?.kind === "text" && run.text === "";
 }
 
+/** Whether a visually empty paragraph carries authored formatting semantics. */
+export const isAuthoredEmptyParagraph = (block: ParagraphBlock): boolean =>
+  isEmptyParagraph(block) &&
+  (block.attrs?.styleId !== undefined ||
+    block.attrs?.hasDirectParagraphFormatting === true ||
+    block.attrs?.hasDirectParagraphMarkFormatting === true);
+
 /**
  * Resolve leading paragraph spacing after applying the empty-paragraph
  * inherited-spacing collapse rule.
@@ -49,7 +56,7 @@ export const resolveEffectiveParagraphSpacing = (
 ): EffectiveParagraphSpacing => {
   const before = block.attrs?.spacing?.before ?? 0;
   const after = block.attrs?.spacing?.after ?? 0;
-  if (!isEmptyParagraph(block) || preservesInheritedEmptySpacing(block)) {
+  if (!isEmptyParagraph(block) || isAuthoredEmptyParagraph(block)) {
     return { before, after };
   }
   return {
@@ -79,13 +86,6 @@ export const resolveEffectiveParagraphSpacingTree = (blocks: FlowBlock[]): FlowB
 
 export const paragraphsShareStyle = (previous: ParagraphBlock, current: ParagraphBlock): boolean =>
   previous.attrs?.styleId === current.attrs?.styleId;
-
-const preservesInheritedEmptySpacing = (block: ParagraphBlock): boolean =>
-  Boolean(
-    block.attrs?.styleId ||
-    block.attrs?.hasDirectParagraphFormatting ||
-    block.attrs?.hasDirectParagraphMarkFormatting,
-  );
 
 const resolveBlockSpacing = (blocks: readonly FlowBlock[], index: number): FlowBlock => {
   const block = blocks[index]!; // SAFETY: called from blocks.map with the same index.


### PR DESCRIPTION
## Summary

- distinguish authored empty paragraphs from structural pass-through separators in keep-with-next chains
- keep styled and directly formatted blanks as pagination anchors
- retain structural empty separators and explicitly suppressed synthetic blanks as pass-through content
- share the empty-paragraph classification with paragraph-spacing resolution

## Validation

- 21 focused keep-with-next and spacing tests
- focused formatting and diff checks
- Microsoft Word comparison: geometry 0.8529 → 0.9265, pagination divergences 5 → 0, raster 0.9679 → 0.9710

CC on behalf of jan-kubica