### PR TITLE
fix: normalize horizontal text scale

### DIFF
--- a/.changeset/normalize-horizontal-text-scale.md
+++ b/.changeset/normalize-horizontal-text-scale.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Normalize horizontal text scales across parsing, layout, and rendering.

--- a/packages/core/src/docx/__tests__/horizontalScaleRoundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/horizontalScaleRoundtrip.test.ts
@@ -26,7 +26,7 @@ describe("horizontal text scale round-trip", () => {
   ])("preserves schema-valid scale %s", (value, expected) => {
     const formatting = parseScale(value);
 
-    expect(formatting.scale).toBe(expected);
+    expect(formatting?.scale).toBe(expected);
     expect(serializeTextFormatting(formatting)).toContain(`<w:w w:val="${expected}"/>`);
   });
 

--- a/packages/core/src/docx/__tests__/horizontalScaleRoundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/horizontalScaleRoundtrip.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseRunProperties } from "../runParser";
+import { serializeTextFormatting } from "../serializer/runSerializer";
+import { parseXml } from "../xmlParser";
+
+const parseScale = (value: string) => {
+  const parsed = parseXml(
+    `<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:w w:val="${value}"/></w:rPr>`,
+  );
+  const runProperties = parsed.elements.at(0);
+  if (!runProperties || runProperties.type !== "element") {
+    throw new Error("Expected run properties element");
+  }
+  return parseRunProperties(runProperties, null);
+};
+
+describe("horizontal text scale round-trip", () => {
+  test.each([
+    ["0", 0],
+    ["0%", 0],
+    ["50%", 50],
+    ["600", 600],
+    ["600%", 600],
+  ])("preserves schema-valid scale %s", (value, expected) => {
+    const formatting = parseScale(value);
+
+    expect(formatting.scale).toBe(expected);
+    expect(serializeTextFormatting(formatting)).toContain(`<w:w w:val="${expected}"/>`);
+  });
+
+  test.each(["-1", "601", "Infinity", "not-a-scale"])(
+    "drops malformed scale %s at parse and serialization boundaries",
+    (value) => {
+      const formatting = parseScale(value);
+
+      expect(formatting?.scale).toBeUndefined();
+      expect(serializeTextFormatting(formatting)).not.toContain("<w:w ");
+    },
+  );
+});

--- a/packages/core/src/docx/__tests__/horizontalScaleRoundtrip.test.ts
+++ b/packages/core/src/docx/__tests__/horizontalScaleRoundtrip.test.ts
@@ -22,6 +22,7 @@ describe("horizontal text scale round-trip", () => {
     ["50%", 50],
     ["600", 600],
     ["600%", 600],
+    [" 50% ", 50],
   ])("preserves schema-valid scale %s", (value, expected) => {
     const formatting = parseScale(value);
 
@@ -29,13 +30,22 @@ describe("horizontal text scale round-trip", () => {
     expect(serializeTextFormatting(formatting)).toContain(`<w:w w:val="${expected}"/>`);
   });
 
-  test.each(["-1", "601", "Infinity", "not-a-scale"])(
-    "drops malformed scale %s at parse and serialization boundaries",
-    (value) => {
-      const formatting = parseScale(value);
+  test.each([
+    "",
+    "   ",
+    "-1",
+    "601",
+    "601%",
+    "0garbage",
+    "1e2",
+    "600oops",
+    "0x10",
+    "Infinity",
+    "not-a-scale",
+  ])("drops malformed scale %s at parse and serialization boundaries", (value) => {
+    const formatting = parseScale(value);
 
-      expect(formatting?.scale).toBeUndefined();
-      expect(serializeTextFormatting(formatting)).not.toContain("<w:w ");
-    },
-  );
+    expect(formatting?.scale).toBeUndefined();
+    expect(serializeTextFormatting(formatting)).not.toContain("<w:w ");
+  });
 });

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -65,7 +65,7 @@ import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
 import { requiresXmlSpacePreserve } from "./textWhitespace";
 import { isValidHexColor } from "../utils/colorResolver";
-import { normalizeHorizontalScalePercent } from "../utils/horizontalScale";
+import { parseHorizontalScalePercent } from "../utils/horizontalScale";
 import {
   cloneWithXmlnsDeclarations,
   findAllDeep,
@@ -584,7 +584,7 @@ export function parseRunProperties(
   // Horizontal text scale percentage (w:w)
   const w = propertyChildren.w;
   if (w) {
-    const val = normalizeHorizontalScalePercent(parseNumericAttribute(w, "w", "val"));
+    const val = parseHorizontalScalePercent(getAttribute(w, "w", "val"));
     if (val !== undefined) {
       formatting.scale = val;
     }

--- a/packages/core/src/docx/runParser.ts
+++ b/packages/core/src/docx/runParser.ts
@@ -65,6 +65,7 @@ import { parseVmlImageContent } from "./vmlImageParser";
 import { resolveThemeFontRef } from "./themeParser";
 import { requiresXmlSpacePreserve } from "./textWhitespace";
 import { isValidHexColor } from "../utils/colorResolver";
+import { normalizeHorizontalScalePercent } from "../utils/horizontalScale";
 import {
   cloneWithXmlnsDeclarations,
   findAllDeep,
@@ -583,7 +584,7 @@ export function parseRunProperties(
   // Horizontal text scale percentage (w:w)
   const w = propertyChildren.w;
   if (w) {
-    const val = parseNumericAttribute(w, "w", "val");
+    const val = normalizeHorizontalScalePercent(parseNumericAttribute(w, "w", "val"));
     if (val !== undefined) {
       formatting.scale = val;
     }

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -393,6 +393,29 @@ describe("run formatting integer attributes (issue #417)", () => {
     expect(xml).toContain('<w:kern w:val="18"/>');
     expect(xml).toContain('<w:position w:val="-6"/>');
   });
+
+  test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "omits malformed horizontal scale %p",
+    (scale) => {
+      const xml = serializeRun({
+        type: "run",
+        content: [{ type: "text", text: "x" }],
+        formatting: { scale },
+      });
+
+      expect(xml).not.toContain("<w:w ");
+    },
+  );
+
+  test.each([0, 600])("preserves boundary horizontal scale %p", (scale) => {
+    const xml = serializeRun({
+      type: "run",
+      content: [{ type: "text", text: "x" }],
+      formatting: { scale },
+    });
+
+    expect(xml).toContain(`<w:w w:val="${scale}"/>`);
+  });
 });
 
 describe("break clear serialization", () => {

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -42,7 +42,7 @@ import type {
 import { requiresXmlSpacePreserve } from "../textWhitespace";
 import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
 import { isValidHexColor } from "../../utils/colorResolver";
-import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
+import { roundHorizontalScalePercentForSerialization } from "../../utils/horizontalScale";
 import { THEME_COLOR_TO_DRAWING_SCHEME } from "../drawingUtils";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: shape textboxes hold paragraphs, paragraphs hold runs
 import { serializeParagraph } from "./paragraphSerializer";
@@ -345,7 +345,7 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
   }
 
   // Scale (w:w)
-  const horizontalScale = normalizeHorizontalScalePercent(formatting.scale);
+  const horizontalScale = roundHorizontalScalePercentForSerialization(formatting.scale);
   if (horizontalScale !== undefined) {
     parts.push(`<w:w w:val="${intAttr(horizontalScale)}"/>`);
   }

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -42,6 +42,7 @@ import type {
 import { requiresXmlSpacePreserve } from "../textWhitespace";
 import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
 import { isValidHexColor } from "../../utils/colorResolver";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { THEME_COLOR_TO_DRAWING_SCHEME } from "../drawingUtils";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: shape textboxes hold paragraphs, paragraphs hold runs
 import { serializeParagraph } from "./paragraphSerializer";
@@ -344,8 +345,9 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
   }
 
   // Scale (w:w)
-  if (formatting.scale !== undefined) {
-    parts.push(`<w:w w:val="${intAttr(formatting.scale)}"/>`);
+  const horizontalScale = normalizeHorizontalScalePercent(formatting.scale);
+  if (horizontalScale !== undefined) {
+    parts.push(`<w:w w:val="${intAttr(horizontalScale)}"/>`);
   }
 
   // Kerning

--- a/packages/core/src/docx/styleParser.test.ts
+++ b/packages/core/src/docx/styleParser.test.ts
@@ -100,6 +100,32 @@ describe("style run toggle parsing", () => {
   });
 });
 
+describe("style horizontal text scale parsing", () => {
+  const parseStyleScale = (value: string) =>
+    parseStyles(
+      `<w:styles ${STYLES_NS}>
+        <w:style w:type="character" w:styleId="Scaled">
+          <w:rPr><w:w w:val="${value}"/></w:rPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    ).get("Scaled")?.rPr?.scale;
+
+  test.each([
+    [" 0% ", 0],
+    ["600%", 600],
+  ])("preserves strict scale %s", (value, expected) => {
+    expect(parseStyleScale(value)).toBe(expected);
+  });
+
+  test.each(["", "   ", "0garbage", "1e2", "600oops", "0x10", "601%"])(
+    "drops malformed scale %p",
+    (value) => {
+      expect(parseStyleScale(value)).toBeUndefined();
+    },
+  );
+});
+
 describe("style tab leader normalization", () => {
   test("normalizes the default leader to a save/reopen fixed point", () => {
     const parsed = parseStyleDefinitions(

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -39,6 +39,7 @@ import type {
 import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
 import { mergeStyleTextFormatting } from "../utils/textFormattingMerge";
 import { isValidHexColor } from "../utils/colorResolver";
+import { normalizeHorizontalScalePercent } from "../utils/horizontalScale";
 import {
   BorderStyleSchema,
   ConditionalStyleTypeSchema,
@@ -332,7 +333,7 @@ function parseRunProperties(
   // Scale (horizontal text scale percentage)
   const w = findChild(rPr, "w", "w");
   if (w) {
-    const val = parseNumericAttribute(w, "w", "val");
+    const val = normalizeHorizontalScalePercent(parseNumericAttribute(w, "w", "val"));
     if (val !== undefined) {
       formatting.scale = val;
     }

--- a/packages/core/src/docx/styleParser.ts
+++ b/packages/core/src/docx/styleParser.ts
@@ -39,7 +39,7 @@ import type {
 import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
 import { mergeStyleTextFormatting } from "../utils/textFormattingMerge";
 import { isValidHexColor } from "../utils/colorResolver";
-import { normalizeHorizontalScalePercent } from "../utils/horizontalScale";
+import { parseHorizontalScalePercent } from "../utils/horizontalScale";
 import {
   BorderStyleSchema,
   ConditionalStyleTypeSchema,
@@ -333,7 +333,7 @@ function parseRunProperties(
   // Scale (horizontal text scale percentage)
   const w = findChild(rPr, "w", "w");
   if (w) {
-    const val = normalizeHorizontalScalePercent(parseNumericAttribute(w, "w", "val"));
+    const val = parseHorizontalScalePercent(getAttribute(w, "w", "val"));
     if (val !== undefined) {
       formatting.scale = val;
     }

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
@@ -272,6 +272,21 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(run.kerningMinPt).toBeUndefined();
   });
 
+  test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "normalizes malformed character scale %p at the layout boundary",
+    (scale) => {
+      const blocks = toFlowBlocks(buildSingleRunDoc("text", "characterSpacing", { scale }), {});
+
+      expect(firstRun(blocks).horizontalScale).toBeUndefined();
+    },
+  );
+
+  test("preserves zero-width character scale", () => {
+    const blocks = toFlowBlocks(buildSingleRunDoc("text", "characterSpacing", { scale: 0 }), {});
+
+    expect(firstRun(blocks).horizontalScale).toBe(0);
+  });
+
   test("explicit zero spacing suppresses paragraph-default character spacing", () => {
     const mark = schema.marks.characterSpacing?.create({ spacing: 0 });
     if (!mark) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts
@@ -287,6 +287,20 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(firstRun(blocks).horizontalScale).toBe(0);
   });
 
+  test("explicit 100% scale suppresses paragraph-default horizontal scale", () => {
+    const mark = schema.marks.characterSpacing?.create({ scale: 100 });
+    if (!mark) {
+      throw new Error("characterSpacing mark is unavailable");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { defaultTextFormatting: { scale: 150 } }, [
+        schema.text("Signature name", [mark]),
+      ]),
+    ]);
+
+    expect(firstRun(toFlowBlocks(doc, {})).horizontalScale).toBe(100);
+  });
+
   test("explicit zero spacing suppresses paragraph-default character spacing", () => {
     const mark = schema.marks.characterSpacing?.create({ spacing: 0 });
     if (!mark) {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -375,7 +375,7 @@ function extractRunFormatting(
           formatting.positionPx = halfPointsToPixels(attrs.position);
         }
         const horizontalScale = normalizeHorizontalScalePercent(attrs.scale);
-        if (horizontalScale !== undefined && horizontalScale !== 100) {
+        if (horizontalScale !== undefined) {
           formatting.horizontalScale = horizontalScale;
         }
         if (attrs.kerning !== undefined && attrs.kerning > 0) {
@@ -610,6 +610,9 @@ function mergeRunFormatting(paraDefaults: RunFormatting, formatting: RunFormatti
   }
   if (merged.letterSpacing === 0) {
     delete merged.letterSpacing;
+  }
+  if (formatting.horizontalScale === 100 && paraDefaults.horizontalScale === undefined) {
+    delete merged.horizontalScale;
   }
   return merged;
 }

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -38,6 +38,7 @@ import { setHyperlinkInstanceIndex } from "../../layout-engine/measure/hyperlink
 import { setTextBoxGroupId } from "../../layout-engine/textBoxGroup";
 import { setParagraphFrame } from "../../layout-engine/paragraphFrame";
 import { DEFAULT_TEXTBOX_MARGINS, DEFAULT_TEXTBOX_WIDTH } from "../../layout-engine/types";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { getColumns } from "../sectionColumns";
 import {
   expectBlockSdtAttrs,
@@ -373,8 +374,9 @@ function extractRunFormatting(
         if (attrs.position !== undefined && attrs.position !== 0) {
           formatting.positionPx = halfPointsToPixels(attrs.position);
         }
-        if (attrs.scale !== undefined && attrs.scale !== 100) {
-          formatting.horizontalScale = attrs.scale;
+        const horizontalScale = normalizeHorizontalScalePercent(attrs.scale);
+        if (horizontalScale !== undefined && horizontalScale !== 100) {
+          formatting.horizontalScale = horizontalScale;
         }
         if (attrs.kerning !== undefined && attrs.kerning > 0) {
           formatting.kerningMinPt = halfPointsToPoints(attrs.kerning);
@@ -845,8 +847,9 @@ function textFormattingToRunFormatting(
   if (defaultTextFormatting.position !== undefined && defaultTextFormatting.position !== 0) {
     result.positionPx = halfPointsToPixels(defaultTextFormatting.position);
   }
-  if (defaultTextFormatting.scale !== undefined && defaultTextFormatting.scale !== 100) {
-    result.horizontalScale = defaultTextFormatting.scale;
+  const horizontalScale = normalizeHorizontalScalePercent(defaultTextFormatting.scale);
+  if (horizontalScale !== undefined && horizontalScale !== 100) {
+    result.horizontalScale = horizontalScale;
   }
   if (defaultTextFormatting.kerning !== undefined && defaultTextFormatting.kerning > 0) {
     result.kerningMinPt = halfPointsToPoints(defaultTextFormatting.kerning);

--- a/packages/core/src/layout-bridge/engine/selectionRects.ts
+++ b/packages/core/src/layout-bridge/engine/selectionRects.ts
@@ -15,6 +15,7 @@ import { measureParagraph } from "../../layout-engine/measure";
 import { buildRunFontStyle } from "../../layout-engine/measure/measureHelpers";
 import { measureRun } from "../../layout-engine/measure/measureProvider";
 import type { FontStyle } from "../../layout-engine/measure/measureTypes";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import {
   buildTableCellGrid,
   buildTableCellPlacements,
@@ -101,13 +102,14 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
 }
 
 function mathRunToFontStyle(run: MathRun): FontStyle {
+  const horizontalScale = normalizeHorizontalScalePercent(run.horizontalScale);
   return {
     fontFamily: run.fontFamily ?? "Cambria Math",
     fontSize: run.fontSize ?? 11,
     ...(run.bold !== undefined ? { bold: run.bold } : {}),
     ...(run.italic !== undefined ? { italic: run.italic } : {}),
     ...(run.letterSpacing !== undefined ? { letterSpacing: run.letterSpacing } : {}),
-    ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+    ...(horizontalScale !== undefined ? { horizontalScale } : {}),
   };
 }
 

--- a/packages/core/src/layout-engine/measure/measureContainer.ts
+++ b/packages/core/src/layout-engine/measure/measureContainer.ts
@@ -26,6 +26,7 @@ import {
   segmentByScript,
   type ScriptClass,
 } from "../../utils/scriptSegments";
+import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import {
   getCachedFontMetrics,
   getCachedTextWidth,
@@ -222,7 +223,7 @@ function canvasMeasureTextWidth(text: string, sourceStyle: FontStyle): number {
   const ctx = getCanvasContext();
   const font = buildFontString(style);
   const letterSpacing = style.letterSpacing ?? 0;
-  const horizontalScale = getHorizontalScaleFactor(style);
+  const horizontalScale = getHorizontalScaleFactor(style.horizontalScale);
   const fontKerning = getFontKerningMode(style);
   const fontCacheKey = style.kerning
     ? `${font}|kerning:normal|scale:${horizontalScale}`
@@ -360,7 +361,7 @@ function scriptStyle(style: FontStyle, script: ScriptClass): FontStyle {
 
 function measureMixedScriptWidth(measuredText: string, style: FontStyle): number {
   const letterSpacing = style.letterSpacing ?? 0;
-  const horizontalScale = getHorizontalScaleFactor(style);
+  const horizontalScale = getHorizontalScaleFactor(style.horizontalScale);
 
   let glyphWidth = 0;
   for (const segment of segmentByScript(measuredText)) {
@@ -483,7 +484,7 @@ function canvasMeasureRun(text: string, sourceStyle: FontStyle): RunMeasurement 
       : undefined;
 
   const letterSpacing = style.letterSpacing ?? 0;
-  const scale = getHorizontalScaleFactor(style);
+  const scale = getHorizontalScaleFactor(style.horizontalScale);
   const charWidths: number[] = [];
   let totalWidth = 0;
 
@@ -551,8 +552,4 @@ function applyTextTransform(text: string, style: FontStyle): string {
     return text.toLocaleUpperCase();
   }
   return text;
-}
-
-function getHorizontalScaleFactor(style: FontStyle): number {
-  return (style.horizontalScale ?? 100) / 100;
 }

--- a/packages/core/src/layout-engine/measure/measureHelpers.ts
+++ b/packages/core/src/layout-engine/measure/measureHelpers.ts
@@ -10,6 +10,7 @@
 
 import { resolveFontFamily } from "../../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../../utils/fontWeights";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import type { RunFormatting } from "../types";
 import type { FontStyle } from "./measureTypes";
 import { FONT_KERNING_MODE, getRunFontKerningMode } from "./textMeasurementPolicy";
@@ -40,6 +41,7 @@ export function buildRunFontStyle(
   const baseFontSize = run.fontSize ?? fallbackFontSize;
   const fontSize =
     run.superscript || run.subscript ? baseFontSize * DOCX_SCRIPT_FONT_SCALE : baseFontSize;
+  const horizontalScale = normalizeHorizontalScalePercent(run.horizontalScale);
   return {
     fontFamily: run.fontFamily ?? fallbackFontFamily,
     ...(run.alternateFontFamily !== undefined
@@ -69,7 +71,7 @@ export function buildRunFontStyle(
     ...(run.letterSpacing !== undefined ? { letterSpacing: run.letterSpacing } : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
     ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
-    ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+    ...(horizontalScale !== undefined ? { horizontalScale } : {}),
     kerning: getRunFontKerningMode(run, fallbackFontSize) === FONT_KERNING_MODE.enabled,
   };
 }

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -51,6 +51,48 @@ describe("text measurement cache", () => {
     }, fakeMeasure);
   });
 
+  test("enforces the OOXML horizontal scale range in measurement", () => {
+    withFakeTextMeasure((getMeasureCount) => {
+      const text = "invalid scale";
+      const normalWidth = measureTextWidth(text, {
+        fontFamily: "Arial",
+        fontSize: 11,
+      });
+
+      expect(
+        measureTextWidth(text, {
+          fontFamily: "Arial",
+          fontSize: 11,
+          horizontalScale: 0,
+        }),
+      ).toBe(0);
+      expect(
+        measureTextWidth(text, {
+          fontFamily: "Arial",
+          fontSize: 11,
+          horizontalScale: 600,
+        }),
+      ).toBe(normalWidth * 6);
+
+      for (const horizontalScale of [
+        -50,
+        601,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ]) {
+        expect(
+          measureTextWidth(text, {
+            fontFamily: "Arial",
+            fontSize: 11,
+            horizontalScale,
+          }),
+        ).toBe(normalWidth);
+      }
+      expect(getMeasureCount()).toBe(3);
+    }, fakeMeasure);
+  });
+
   test("keeps enabled kerning in the text width cache key", () => {
     withFakeTextMeasure((getMeasureCount) => {
       const text = "AVAV";

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -15,6 +15,7 @@ import {
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
 import { isRtlParagraph } from "../../utils/paragraphBaseDirection";
 import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
+import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import { measuredLineAdvance } from "../lineFlow";
 import type {
   ParagraphBlock,
@@ -781,7 +782,7 @@ function measureWordWithTrailingWhitespace(
   const trailingWhitespaceWidth = measureTextWidth(trailingWhitespace, style);
   const boundarySpacing =
     measuredWord.length > 0
-      ? (style.letterSpacing ?? 0) * ((style.horizontalScale ?? 100) / 100)
+      ? (style.letterSpacing ?? 0) * getHorizontalScaleFactor(style.horizontalScale)
       : 0;
   return {
     measuredWord,

--- a/packages/core/src/layout-painter/renderMath.test.ts
+++ b/packages/core/src/layout-painter/renderMath.test.ts
@@ -384,6 +384,24 @@ describe("painter — OMML math run", () => {
     expect(fallback?.textContent).toBe("empty");
   });
 
+  test("scales MathML and fallback paint to the measured zero-width advance", () => {
+    const mathLine = renderMathRunOnce(mathRun({ horizontalScale: 0 }));
+    const mathHost = findElement(mathLine, (el) => el.className.includes("docx-math-inline"));
+    const fallbackLine = renderMathRunOnce(
+      mathRun({ ommlXml: "<not-actually-omml>", horizontalScale: 0 }),
+    );
+    const fallbackHost = findElement(fallbackLine, (el) =>
+      el.className.includes("docx-math-fallback"),
+    );
+
+    for (const host of [mathHost, fallbackHost]) {
+      expect(host?.style.display).toBe("inline-block");
+      expect(host?.style.transform).toBe("scaleX(0)");
+      expect(host?.style.transformOrigin).toBe("left center");
+      expect(host?.style.width).toBe("0px");
+    }
+  });
+
   test("sets alttext on the <math> root for screen readers", () => {
     const line = renderMathRunOnce(
       mathRun({

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -51,6 +51,7 @@ import type {
 import type { BorderSpec, Theme, Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { borderToStyle } from "../utils/formatToStyle";
+import { normalizeHorizontalScalePercent } from "../utils/horizontalScale";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { eighthsToPixels, pointsToPixels } from "../utils/units";
 import {
@@ -2756,8 +2757,9 @@ function runContentKey(run: Run): string {
   if (run.positionPx !== undefined) {
     parts.push(`pp:${run.positionPx}`);
   }
-  if (run.horizontalScale !== undefined && run.horizontalScale !== 100) {
-    parts.push(`hs:${run.horizontalScale}`);
+  const horizontalScale = normalizeHorizontalScalePercent(run.horizontalScale);
+  if (horizontalScale !== undefined && horizontalScale !== 100) {
+    parts.push(`hs:${horizontalScale}`);
   }
   if (run.imprint) {
     parts.push("imp");

--- a/packages/core/src/layout-painter/renderParagraph-horizontal-scale.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-horizontal-scale.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MeasuredLine, ParagraphBlock, Run } from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  textContent = "";
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): { font: string; measureText: (text: string) => { width: number } } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText: (text: string) => ({ width: text.length * 7 }),
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+const renderSingleRun = (run: Run): FakeElement => {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "horizontal-scale",
+    runs: [run],
+  };
+  const line: MeasuredLine = {
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: run.kind === "text" ? run.text.length : 1,
+    width: 28,
+    ascent: 10,
+    descent: 2,
+    lineHeight: 12,
+  };
+
+  const lineElement = renderLine(block, line, undefined, fakeDocument, {
+    availableWidth: 360,
+    context: { pageNumber: 1, totalPages: 1, section: "body" },
+  }) as unknown as FakeElement;
+  const runElement = lineElement.children.at(0);
+  if (!runElement) {
+    throw new Error("Expected painted run");
+  }
+  return runElement;
+};
+
+describe("horizontal text scale painting", () => {
+  test.each([
+    [0, "scaleX(0)", "0px"],
+    [600, "scaleX(6)", "168px"],
+  ])("preserves valid boundary scale %p", (horizontalScale, transform, width) => {
+    const runElement = renderSingleRun({ kind: "text", text: "abcd", horizontalScale });
+
+    expect(runElement.style["transform"]).toBe(transform);
+    expect(runElement.style["width"]).toBe(width);
+  });
+
+  test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "does not emit CSS for malformed scale %p",
+    (horizontalScale) => {
+      const runElement = renderSingleRun({ kind: "text", text: "abcd", horizontalScale });
+
+      expect(runElement.style["transform"]).toBeUndefined();
+      expect(runElement.style["width"]).toBeUndefined();
+    },
+  );
+
+  test("normalizes the field wrapper and reserved advance together", () => {
+    const runElement = renderSingleRun({
+      kind: "field",
+      fieldType: "OTHER",
+      fallback: "A合",
+      eastAsiaFontFamily: "Noto Sans CJK",
+      horizontalScale: 0,
+    });
+
+    expect(runElement.style["transform"]).toBe("scaleX(0)");
+    expect(runElement.style["width"]).toBe("0px");
+  });
+});

--- a/packages/core/src/layout-painter/renderParagraph-horizontal-scale.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-horizontal-scale.test.ts
@@ -44,6 +44,7 @@ const fakeDocument = {
   createElement(tagName: string): FakeElement {
     return new FakeElement(tagName);
   },
+  // SAFETY: renderSingleRun uses only Document.createElement.
 } as unknown as Document;
 
 const renderSingleRun = (run: Run): FakeElement => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -304,6 +304,19 @@ function getRaisedRunFontSize(run: TextRun | TabRun): string {
   return `${DOCX_SCRIPT_FONT_SCALE}em`;
 }
 
+function applyHorizontalScaleTransform(
+  element: HTMLElement,
+  horizontalScale: number | undefined,
+): void {
+  const horizontalScaleFactor = getHorizontalScaleFactor(horizontalScale);
+  if (horizontalScaleFactor === 1) {
+    return;
+  }
+  element.style.display = "inline-block";
+  element.style.transform = `scaleX(${horizontalScaleFactor})`;
+  element.style.transformOrigin = "left center";
+}
+
 /**
  * Apply text run styles to an element
  */
@@ -360,12 +373,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   if (run.positionPx) {
     element.style.verticalAlign = `${run.positionPx}px`;
   }
-  const horizontalScaleFactor = getHorizontalScaleFactor(run.horizontalScale);
-  if (horizontalScaleFactor !== 1) {
-    element.style.display = "inline-block";
-    element.style.transform = `scaleX(${horizontalScaleFactor})`;
-    element.style.transformOrigin = "left center";
-  }
+  applyHorizontalScaleTransform(element, run.horizontalScale);
   element.style.fontKerning = getRunFontKerningMode(run, DEFAULT_FONT_SIZE);
   if (run.emboss) {
     element.style.textShadow = "1px 1px 1px rgba(255,255,255,0.5), -1px -1px 1px rgba(0,0,0,0.3)";
@@ -1237,12 +1245,7 @@ function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): H
     // horizontalScale lives on the wrapper (inline-block so the reserved width
     // the render loop sets via reserveScaledAdvance applies, scaleX so the
     // segments scale uniformly); the segments drop it to avoid double-scaling.
-    const horizontalScaleFactor = getHorizontalScaleFactor(resolvedRun.horizontalScale);
-    if (horizontalScaleFactor !== 1) {
-      wrapper.style.display = "inline-block";
-      wrapper.style.transform = `scaleX(${horizontalScaleFactor})`;
-      wrapper.style.transformOrigin = "left center";
-    }
+    applyHorizontalScaleTransform(wrapper, resolvedRun.horizontalScale);
     // The pm range lives on the wrapper; segments carry none (the field is one
     // atomic unit), so drop pmStart/pmEnd (and the wrapper-applied scale) before
     // spreading into each segment.
@@ -1310,6 +1313,7 @@ function renderMathRun(run: MathRun, doc: Document): HTMLElement {
 
   // Cambria Math fallback chain for browsers that don't ship a math font.
   host.style.fontFamily = '"Cambria Math", "Latin Modern Math", "STIX Two Math", serif';
+  applyHorizontalScaleTransform(host, run.horizontalScale);
 
   try {
     // safe-html: mathml is built by ommlToMathml(), which escapes every text token via escapeXml() and emits only a fixed MathML tag vocabulary
@@ -1345,6 +1349,7 @@ function renderMathFallback(
   }
   span.style.fontStyle = "italic";
   span.style.fontFamily = '"Cambria Math", "Latin Modern Math", "STIX Two Math", serif';
+  applyHorizontalScaleTransform(span, run.horizontalScale);
   span.textContent = fallbackText;
   applyPmPositions(span, run.pmStart, run.pmEnd);
   return span;

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -56,6 +56,7 @@ import {
 import { planCursiveJoiners, withCursiveJoiners } from "./cursiveJoiners";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
+import { getHorizontalScaleFactor } from "../utils/horizontalScale";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { sanitizeExternalUrl } from "../utils/urlSecurity";
 import {
@@ -359,9 +360,10 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   if (run.positionPx) {
     element.style.verticalAlign = `${run.positionPx}px`;
   }
-  if (run.horizontalScale && run.horizontalScale !== 100) {
+  const horizontalScaleFactor = getHorizontalScaleFactor(run.horizontalScale);
+  if (horizontalScaleFactor !== 1) {
     element.style.display = "inline-block";
-    element.style.transform = `scaleX(${run.horizontalScale / 100})`;
+    element.style.transform = `scaleX(${horizontalScaleFactor})`;
     element.style.transformOrigin = "left center";
   }
   element.style.fontKerning = getRunFontKerningMode(run, DEFAULT_FONT_SIZE);
@@ -612,10 +614,11 @@ function reserveScaledAdvance(
   unscaledWidth: number,
   horizontalScale: number | undefined,
 ): void {
-  if (horizontalScale === undefined || horizontalScale === 100) {
+  const horizontalScaleFactor = getHorizontalScaleFactor(horizontalScale);
+  if (horizontalScaleFactor === 1) {
     return;
   }
-  element.style.width = `${unscaledWidth * (horizontalScale / 100)}px`;
+  element.style.width = `${unscaledWidth * horizontalScaleFactor}px`;
 }
 
 /**
@@ -1234,9 +1237,10 @@ function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): H
     // horizontalScale lives on the wrapper (inline-block so the reserved width
     // the render loop sets via reserveScaledAdvance applies, scaleX so the
     // segments scale uniformly); the segments drop it to avoid double-scaling.
-    if (resolvedRun.horizontalScale && resolvedRun.horizontalScale !== 100) {
+    const horizontalScaleFactor = getHorizontalScaleFactor(resolvedRun.horizontalScale);
+    if (horizontalScaleFactor !== 1) {
       wrapper.style.display = "inline-block";
-      wrapper.style.transform = `scaleX(${resolvedRun.horizontalScale / 100})`;
+      wrapper.style.transform = `scaleX(${horizontalScaleFactor})`;
       wrapper.style.transformOrigin = "left center";
     }
     // The pm range lives on the wrapper; segments carry none (the field is one
@@ -1755,17 +1759,13 @@ function measureFollowingContentWidth(
     if (isTabRun(run) || isLineBreakRun(run)) {
       break;
     }
-    // Apply horizontalScale to match what the renderer's main loop does to
-    // currentX (`measuredWidth * (run.horizontalScale ?? 100) / 100`). Without
-    // this, expanded/compressed text after a tab over/under-estimates the
-    // trailing width and the right-edge check fires (or doesn't) at the wrong
-    // threshold, causing alignment drift on scaled TOC entries.
-    const scale = (run as { horizontalScale?: number }).horizontalScale ?? 100;
+    // Mirror the main render loop's scale so tab-aligned trailing content
+    // reserves the same width it paints.
     if (isTextRun(run)) {
       const text = run.allCaps ? run.text.toLocaleUpperCase() : run.text;
       width +=
         measureText(text, run.fontSize ?? 11, run.fontFamily ?? "Calibri", runMeasureStyle(run)) *
-        (scale / 100);
+        getHorizontalScaleFactor(run.horizontalScale);
     } else if (isFieldRun(run)) {
       const fieldText = resolveFieldText(run, context);
       width +=
@@ -1774,8 +1774,7 @@ function measureFollowingContentWidth(
           run.fontSize ?? 11,
           run.fontFamily ?? "Calibri",
           runMeasureStyle(run),
-        ) *
-        (scale / 100);
+        ) * getHorizontalScaleFactor(run.horizontalScale);
     } else if (isImageRun(run) && !isFloatingImageRun(run)) {
       // Inline images aren't horizontally scaled by w:w on the surrounding
       // text run; their own width attribute is authoritative. Rotated images
@@ -1789,8 +1788,7 @@ function measureFollowingContentWidth(
           run.fontSize ?? 11,
           run.fontFamily ?? "Cambria Math",
           runMeasureStyle(run),
-        ) *
-        (scale / 100);
+        ) * getHorizontalScaleFactor(run.horizontalScale);
     }
   }
   return width;
@@ -1841,15 +1839,14 @@ function measureDecimalPrefixWidth(
 
     const take = Math.min(runText.length, decimalIndex - consumed);
     if (take > 0) {
-      const scale = run.horizontalScale ?? 100;
+      const horizontalScaleFactor = getHorizontalScaleFactor(run.horizontalScale);
       width +=
         measureText(
           runText.slice(0, take),
           run.fontSize ?? 11,
           run.fontFamily ?? "Calibri",
           runMeasureStyle(run),
-        ) *
-        (scale / 100);
+        ) * horizontalScaleFactor;
     }
     consumed += runText.length;
   }
@@ -2128,8 +2125,7 @@ export function renderLine(
           run.fontSize || 11,
           run.fontFamily || "Calibri",
           runMeasureStyle(run),
-        ) ?? 0) *
-        ((run.horizontalScale ?? 100) / 100);
+        ) ?? 0) * getHorizontalScaleFactor(run.horizontalScale);
       runEl.dataset["collapsedSpaceAdvance"] = String(spaceAdvance);
       runEl.style.fontSize = "0";
       runEl.style.letterSpacing = "0";
@@ -2312,8 +2308,7 @@ export function renderLine(
   const hasScaledTextRun = runsForLine.some(
     (run) =>
       (isTextRun(run) || isFieldRun(run) || isMathRun(run)) &&
-      run.horizontalScale !== undefined &&
-      run.horizontalScale !== 100,
+      getHorizontalScaleFactor(run.horizontalScale) !== 1,
   );
   const measureText =
     collapsedSpaceMeasureText ??
@@ -2562,7 +2557,7 @@ export function renderLine(
         runMeasureStyle(run),
       );
       reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
-      currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
+      currentX += measuredWidth * getHorizontalScaleFactor(run.horizontalScale);
     } else if (isImageRun(run)) {
       // Skip floating images - they're rendered separately at page level.
       // Exception: inside table cells, floating images must render in-flow
@@ -2608,7 +2603,7 @@ export function renderLine(
         runMeasureStyle(run),
       );
       reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
-      currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
+      currentX += measuredWidth * getHorizontalScaleFactor(run.horizontalScale);
     } else if (isMathRun(run)) {
       const runEl = renderMathRun(run, doc);
       lineEl.append(runEl);
@@ -2622,7 +2617,7 @@ export function renderLine(
         runMeasureStyle(run),
       );
       reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
-      currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
+      currentX += measuredWidth * getHorizontalScaleFactor(run.horizontalScale);
     } else {
       // Fallback for unknown run types
       const runEl = renderRun(run, doc, options?.context);

--- a/packages/core/src/prosemirror/attrs/index.test.ts
+++ b/packages/core/src/prosemirror/attrs/index.test.ts
@@ -5,6 +5,7 @@ import {
   expectParagraphAttrs,
   readHardBreakAttrs,
   readCommentMarkAttrs,
+  readCharacterSpacingMarkAttrs,
   readFontSizeMarkAttrs,
   readHighlightMarkAttrs,
   readHyperlinkMarkAttrs,
@@ -34,6 +35,29 @@ const issueMessages = (result: ReturnType<typeof readParagraphAttrs>) => {
 };
 
 describe("ProseMirror attr readers", () => {
+  test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "normalizes out-of-range character scale %p",
+    (scale) => {
+      const mark = schema.marks.characterSpacing.create({ scale });
+      const result = readCharacterSpacingMarkAttrs(mark);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.scale).toBeUndefined();
+      }
+    },
+  );
+
+  test("preserves zero-width character scale", () => {
+    const mark = schema.marks.characterSpacing.create({ scale: 0 });
+    const result = readCharacterSpacingMarkAttrs(mark);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.scale).toBe(0);
+    }
+  });
+
   test("accepts valid paragraph attrs with preservation payloads", () => {
     const node = schema.nodes.paragraph.create({
       paraId: "para-1",

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -35,6 +35,7 @@ import {
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
 import type { ParagraphFormatting } from "../../types/document";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { DRAWING_RAW_XML_MODES, isOoxmlSymbolCharacter } from "@stll/docx-core/model";
 import { isParagraphDirection } from "../paragraphDirection";
 import type {
@@ -1002,7 +1003,17 @@ export const readCharacterSpacingMarkAttrs = (
   optionalNumber(attrs, "scale", "characterSpacing.attrs.scale", issues);
   optionalNumber(attrs, "kerning", "characterSpacing.attrs.kerning", issues);
 
-  return attrsResult(attrs, issues);
+  const result = attrsResult<CharacterSpacingAttrs>(attrs, issues);
+  if (!result.ok) {
+    return result;
+  }
+  const { scale, ...rest } = result.value;
+  const horizontalScale = normalizeHorizontalScalePercent(scale);
+  result.value = {
+    ...rest,
+    ...(horizontalScale !== undefined ? { scale: horizontalScale } : {}),
+  };
+  return result;
 };
 
 export const expectCharacterSpacingMarkAttrs = (mark: Mark): CharacterSpacingAttrs =>

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -16,6 +16,7 @@ import type { Node as PMNode, Mark } from "prosemirror-model";
 import { Fragment } from "prosemirror-model";
 
 import { numPrEqual } from "../../docx/numberingParser";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { parseShapeGeometryAdjustments } from "../shapeGeometryAdjustments";
 import { narrowEnum, ShapeOutlineStyleSchema } from "../../docx/parserEnums";
 import type {
@@ -2835,8 +2836,9 @@ export function marksToTextFormatting(
         if (attrs.position !== undefined) {
           formatting.position = attrs.position;
         }
-        if (attrs.scale !== undefined) {
-          formatting.scale = attrs.scale;
+        const horizontalScale = normalizeHorizontalScalePercent(attrs.scale);
+        if (horizontalScale !== undefined) {
+          formatting.scale = horizontalScale;
         }
         if (attrs.kerning !== undefined) {
           formatting.kerning = attrs.kerning;

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -56,6 +56,7 @@ import { resolveColorValueToHex } from "../../docx/drawingUtils";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
 import { emuToPixels } from "../../utils/units";
+import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { setAutospacingBaseValue } from "../autospacingBase";
 import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
 import { directionFromBidi } from "../paragraphDirection";
@@ -3312,7 +3313,7 @@ export function textFormattingToMarks(
   // Character spacing (spacing, position, scale, kerning)
   const spacing = typeof formatting.spacing === "number" ? formatting.spacing : null;
   const position = typeof formatting.position === "number" ? formatting.position : null;
-  const scale = typeof formatting.scale === "number" ? formatting.scale : null;
+  const scale = normalizeHorizontalScalePercent(formatting.scale) ?? null;
   const kerning = typeof formatting.kerning === "number" ? formatting.kerning : null;
   if (spacing !== null || position !== null || scale !== null || kerning !== null) {
     marks.push(

--- a/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.test.ts
@@ -8,6 +8,7 @@ const parseScale = (scale: string) => {
     throw new Error("CharacterSpacingExtension must define parseDOM[0].getAttrs");
   }
 
+  // SAFETY: getAttrs reads only HTMLElement.dataset in this test fixture.
   const attrs = getAttrs({ dataset: { scale } } as unknown as HTMLElement);
   if (!attrs) {
     throw new Error("CharacterSpacingExtension must return mark attributes");
@@ -15,18 +16,45 @@ const parseScale = (scale: string) => {
   return attrs["scale"];
 };
 
+const serializeScale = (scale: number) => {
+  const toDOM = CharacterSpacingExtension().config.markSpec.toDOM;
+  if (!toDOM) {
+    throw new Error("CharacterSpacingExtension must define toDOM");
+  }
+  // SAFETY: toDOM reads only the character-spacing mark's attrs in this fixture.
+  const mark = {
+    type: { name: "characterSpacing" },
+    attrs: { scale },
+  } as Parameters<typeof toDOM>[0];
+  const output = toDOM(mark, true);
+  if (!Array.isArray(output)) {
+    throw new TypeError("Expected character-spacing DOM output to be an array");
+  }
+  // SAFETY: CharacterSpacingExtension always emits an attribute record at index 1.
+  return output[1] as Record<string, string>;
+};
+
 describe("CharacterSpacingExtension horizontal scale parsing", () => {
   test.each([
     [" 0% ", 0],
+    ["100", 100],
     ["600%", 600],
   ])("preserves strict data-scale %p", (scale, expected) => {
     expect(parseScale(scale)).toBe(expected);
   });
 
-  test.each(["", "   ", "0garbage", "1e2", "600oops", "0x10", "601%"])(
+  test.each(["", "   ", "12.5", "0garbage", "1e2", "600oops", "0x10", "601%"])(
     "drops malformed data-scale %p",
     (scale) => {
       expect(parseScale(scale)).toBeUndefined();
     },
   );
+
+  test("preserves an explicit 100% override through DOM serialization", () => {
+    expect(serializeScale(100)["data-scale"]).toBe("100");
+  });
+
+  test("does not serialize a fractional scale outside the OOXML model domain", () => {
+    expect(serializeScale(12.5)["data-scale"]).toBeUndefined();
+  });
 });

--- a/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { CharacterSpacingExtension } from "./CharacterSpacingExtension";
+
+const parseScale = (scale: string) => {
+  const getAttrs = CharacterSpacingExtension().config.markSpec.parseDOM?.at(0)?.getAttrs;
+  if (!getAttrs) {
+    throw new Error("CharacterSpacingExtension must define parseDOM[0].getAttrs");
+  }
+
+  const attrs = getAttrs({ dataset: { scale } } as unknown as HTMLElement);
+  if (!attrs) {
+    throw new Error("CharacterSpacingExtension must return mark attributes");
+  }
+  return attrs["scale"];
+};
+
+describe("CharacterSpacingExtension horizontal scale parsing", () => {
+  test.each([
+    [" 0% ", 0],
+    ["600%", 600],
+  ])("preserves strict data-scale %p", (scale, expected) => {
+    expect(parseScale(scale)).toBe(expected);
+  });
+
+  test.each(["", "   ", "0garbage", "1e2", "600oops", "0x10", "601%"])(
+    "drops malformed data-scale %p",
+    (scale) => {
+      expect(parseScale(scale)).toBeUndefined();
+    },
+  );
+});

--- a/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.ts
@@ -66,10 +66,12 @@ export const CharacterSpacingExtension = createMarkExtension({
         dataAttrs["data-position"] = String(position);
       }
 
-      if (scale !== undefined && scale !== 100) {
-        styles.push(`transform: scaleX(${getHorizontalScaleFactor(scale)})`);
-        styles.push("display: inline-block");
+      if (scale !== undefined) {
         dataAttrs["data-scale"] = String(scale);
+        if (scale !== 100) {
+          styles.push(`transform: scaleX(${getHorizontalScaleFactor(scale)})`);
+          styles.push("display: inline-block");
+        }
       }
 
       if (kerning !== undefined) {

--- a/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.ts
@@ -8,6 +8,10 @@
  */
 
 import { twipsToPixels, formatPx } from "../../../utils/units";
+import {
+  getHorizontalScaleFactor,
+  normalizeHorizontalScalePercent,
+} from "../../../utils/horizontalScale";
 import { expectCharacterSpacingMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 
@@ -31,13 +35,21 @@ export const CharacterSpacingExtension = createMarkExtension({
         getAttrs: (dom) => ({
           spacing: dom.dataset["spacing"] ? Number(dom.dataset["spacing"]) : null,
           position: dom.dataset["position"] ? Number(dom.dataset["position"]) : null,
-          scale: dom.dataset["scale"] ? Number(dom.dataset["scale"]) : null,
+          scale: normalizeHorizontalScalePercent(
+            dom.dataset["scale"] ? Number(dom.dataset["scale"]) : null,
+          ),
           kerning: dom.dataset["kerning"] ? Number(dom.dataset["kerning"]) : null,
         }),
       },
     ],
     toDOM(mark) {
-      const { spacing, position, scale, kerning } = expectCharacterSpacingMarkAttrs(mark);
+      const {
+        spacing,
+        position,
+        scale: authoredScale,
+        kerning,
+      } = expectCharacterSpacingMarkAttrs(mark);
+      const scale = normalizeHorizontalScalePercent(authoredScale);
 
       const styles: string[] = [];
       const dataAttrs: Record<string, string> = {
@@ -56,7 +68,7 @@ export const CharacterSpacingExtension = createMarkExtension({
       }
 
       if (scale !== undefined && scale !== 100) {
-        styles.push(`transform: scaleX(${scale / 100})`);
+        styles.push(`transform: scaleX(${getHorizontalScaleFactor(scale)})`);
         styles.push("display: inline-block");
         dataAttrs["data-scale"] = String(scale);
       }

--- a/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/CharacterSpacingExtension.ts
@@ -11,6 +11,7 @@ import { twipsToPixels, formatPx } from "../../../utils/units";
 import {
   getHorizontalScaleFactor,
   normalizeHorizontalScalePercent,
+  parseHorizontalScalePercent,
 } from "../../../utils/horizontalScale";
 import { expectCharacterSpacingMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
@@ -35,9 +36,7 @@ export const CharacterSpacingExtension = createMarkExtension({
         getAttrs: (dom) => ({
           spacing: dom.dataset["spacing"] ? Number(dom.dataset["spacing"]) : null,
           position: dom.dataset["position"] ? Number(dom.dataset["position"]) : null,
-          scale: normalizeHorizontalScalePercent(
-            dom.dataset["scale"] ? Number(dom.dataset["scale"]) : null,
-          ),
+          scale: parseHorizontalScalePercent(dom.dataset["scale"]),
           kerning: dom.dataset["kerning"] ? Number(dom.dataset["kerning"]) : null,
         }),
       },

--- a/packages/core/src/utils/formatToStyle.ts
+++ b/packages/core/src/utils/formatToStyle.ts
@@ -24,6 +24,7 @@ import type {
 } from "../types/document";
 import { resolveColor, resolveHighlightToCss, resolveShadingColor } from "./colorResolver";
 import { resolveFontFamily, resolveThemeFont } from "./fontResolver";
+import { getHorizontalScaleFactor, normalizeHorizontalScalePercent } from "./horizontalScale";
 import {
   AUTO_PARAGRAPH_SPACING_PX,
   halfPointsToPixels,
@@ -224,9 +225,10 @@ export function textToStyle(
   }
 
   // Horizontal scale (w:w) - stretch/compress text
-  if (formatting.scale !== undefined && formatting.scale !== 100) {
+  const horizontalScale = normalizeHorizontalScalePercent(formatting.scale);
+  if (horizontalScale !== undefined && horizontalScale !== 100) {
     // CSS doesn't have direct text scale, use transform
-    style.transform = `scaleX(${formatting.scale / 100})`;
+    style.transform = `scaleX(${getHorizontalScaleFactor(horizontalScale)})`;
     style.display = "inline-block";
   }
 

--- a/packages/core/src/utils/horizontalScale.test.ts
+++ b/packages/core/src/utils/horizontalScale.test.ts
@@ -4,6 +4,7 @@ import {
   getHorizontalScaleFactor,
   normalizeHorizontalScalePercent,
   parseHorizontalScalePercent,
+  roundHorizontalScalePercentForSerialization,
 } from "./horizontalScale";
 
 describe("horizontal text scale normalization", () => {
@@ -49,4 +50,12 @@ describe("horizontal text scale normalization", () => {
       expect(parseHorizontalScalePercent(scale)).toBeUndefined();
     },
   );
+
+  test("quantizes only in-range finite serialization values", () => {
+    expect(roundHorizontalScalePercentForSerialization(99.99999)).toBe(100);
+    expect(roundHorizontalScalePercentForSerialization(12.5)).toBe(13);
+    expect(roundHorizontalScalePercentForSerialization(-0.1)).toBeUndefined();
+    expect(roundHorizontalScalePercentForSerialization(600.1)).toBeUndefined();
+    expect(roundHorizontalScalePercentForSerialization(Number.NaN)).toBeUndefined();
+  });
 });

--- a/packages/core/src/utils/horizontalScale.test.ts
+++ b/packages/core/src/utils/horizontalScale.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { getHorizontalScaleFactor, normalizeHorizontalScalePercent } from "./horizontalScale";
+
+describe("horizontal text scale normalization", () => {
+  test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "defaults malformed scale %p to 100%%",
+    (scale) => {
+      expect(normalizeHorizontalScalePercent(scale)).toBeUndefined();
+      expect(getHorizontalScaleFactor(scale)).toBe(1);
+    },
+  );
+
+  test.each([
+    [0, 0],
+    [50, 0.5],
+    [100, 1],
+    [150, 1.5],
+    [600, 6],
+  ])("preserves valid scale %p", (scale, factor) => {
+    expect(normalizeHorizontalScalePercent(scale)).toBe(scale);
+    expect(getHorizontalScaleFactor(scale)).toBe(factor);
+  });
+});

--- a/packages/core/src/utils/horizontalScale.test.ts
+++ b/packages/core/src/utils/horizontalScale.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { getHorizontalScaleFactor, normalizeHorizontalScalePercent } from "./horizontalScale";
+import {
+  getHorizontalScaleFactor,
+  normalizeHorizontalScalePercent,
+  parseHorizontalScalePercent,
+} from "./horizontalScale";
 
 describe("horizontal text scale normalization", () => {
   test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
@@ -21,4 +25,23 @@ describe("horizontal text scale normalization", () => {
     expect(normalizeHorizontalScalePercent(scale)).toBe(scale);
     expect(getHorizontalScaleFactor(scale)).toBe(factor);
   });
+
+  test.each([
+    ["0", 0],
+    ["0%", 0],
+    ["600", 600],
+    ["600%", 600],
+    ["000600%", 600],
+    [" \t50%\r\n", 50],
+    [" +100 ", 100],
+  ])("parses strict lexical scale %p", (scale, expected) => {
+    expect(parseHorizontalScalePercent(scale)).toBe(expected);
+  });
+
+  test.each(["", "   ", "0garbage", "1e2", "600oops", "0x10", "50 %", "+50%", "-1", "601", "601%"])(
+    "rejects malformed lexical scale %p",
+    (scale) => {
+      expect(parseHorizontalScalePercent(scale)).toBeUndefined();
+    },
+  );
 });

--- a/packages/core/src/utils/horizontalScale.test.ts
+++ b/packages/core/src/utils/horizontalScale.test.ts
@@ -7,13 +7,18 @@ import {
 } from "./horizontalScale";
 
 describe("horizontal text scale normalization", () => {
-  test.each([-50, 601, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
-    "defaults malformed scale %p to 100%%",
-    (scale) => {
-      expect(normalizeHorizontalScalePercent(scale)).toBeUndefined();
-      expect(getHorizontalScaleFactor(scale)).toBe(1);
-    },
-  );
+  test.each([
+    -50,
+    12.5,
+    99.99,
+    601,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])("defaults malformed scale %p to 100%%", (scale) => {
+    expect(normalizeHorizontalScalePercent(scale)).toBeUndefined();
+    expect(getHorizontalScaleFactor(scale)).toBe(1);
+  });
 
   test.each([
     [0, 0],

--- a/packages/core/src/utils/horizontalScale.ts
+++ b/packages/core/src/utils/horizontalScale.ts
@@ -1,0 +1,24 @@
+/**
+ * Normalize OOXML `w:w` horizontal text scale percentages.
+ *
+ * The OOXML value is bounded from 0% through 600%. Missing or malformed
+ * values use the document default (100%) and stay absent in the model.
+ */
+export function normalizeHorizontalScalePercent(
+  horizontalScale: number | null | undefined,
+): number | undefined {
+  if (
+    horizontalScale === null ||
+    horizontalScale === undefined ||
+    !Number.isFinite(horizontalScale) ||
+    horizontalScale < 0 ||
+    horizontalScale > 600
+  ) {
+    return undefined;
+  }
+  return horizontalScale;
+}
+
+export function getHorizontalScaleFactor(horizontalScale: number | null | undefined): number {
+  return (normalizeHorizontalScalePercent(horizontalScale) ?? 100) / 100;
+}

--- a/packages/core/src/utils/horizontalScale.ts
+++ b/packages/core/src/utils/horizontalScale.ts
@@ -11,6 +11,7 @@ export function normalizeHorizontalScalePercent(
     horizontalScale === null ||
     horizontalScale === undefined ||
     !Number.isFinite(horizontalScale) ||
+    !Number.isInteger(horizontalScale) ||
     horizontalScale < 0 ||
     horizontalScale > 600
   ) {

--- a/packages/core/src/utils/horizontalScale.ts
+++ b/packages/core/src/utils/horizontalScale.ts
@@ -19,6 +19,29 @@ export function normalizeHorizontalScalePercent(
   return horizontalScale;
 }
 
+/**
+ * Parse the lexical forms accepted by OOXML `ST_TextScale`.
+ *
+ * Decimal values use the XML Schema integer grammar; percent values use the
+ * unsigned decimal grammar defined by `ST_TextScalePercent`. Surrounding
+ * whitespace is ignored, but an empty value or partial numeric prefix is not.
+ */
+export function parseHorizontalScalePercent(
+  horizontalScale: string | null | undefined,
+): number | undefined {
+  if (horizontalScale === null || horizontalScale === undefined) {
+    return undefined;
+  }
+
+  const lexicalValue = horizontalScale.trim();
+  if (!/^(?:[+-]?\d+|\d+%)$/u.test(lexicalValue)) {
+    return undefined;
+  }
+
+  const numericValue = lexicalValue.endsWith("%") ? lexicalValue.slice(0, -1) : lexicalValue;
+  return normalizeHorizontalScalePercent(Number(numericValue));
+}
+
 export function getHorizontalScaleFactor(horizontalScale: number | null | undefined): number {
   return (normalizeHorizontalScalePercent(horizontalScale) ?? 100) / 100;
 }

--- a/packages/core/src/utils/horizontalScale.ts
+++ b/packages/core/src/utils/horizontalScale.ts
@@ -46,3 +46,26 @@ export function parseHorizontalScalePercent(
 export function getHorizontalScaleFactor(horizontalScale: number | null | undefined): number {
   return (normalizeHorizontalScalePercent(horizontalScale) ?? 100) / 100;
 }
+
+/**
+ * Quantize an in-range model value for OOXML's integer-only representation.
+ *
+ * Imported documents use strict integer normalization. Serialization also
+ * tolerates finite floating-point residue produced by editing calculations,
+ * preserving the existing integer-attribute contract without emitting an
+ * invalid fractional value.
+ */
+export function roundHorizontalScalePercentForSerialization(
+  horizontalScale: number | null | undefined,
+): number | undefined {
+  if (
+    horizontalScale === null ||
+    horizontalScale === undefined ||
+    !Number.isFinite(horizontalScale) ||
+    horizontalScale < 0 ||
+    horizontalScale > 600
+  ) {
+    return undefined;
+  }
+  return Math.round(horizontalScale);
+}


### PR DESCRIPTION
## Summary

- normalize horizontal text scale through a shared 0–600 percent domain
- parse OOXML integer and percent lexical forms strictly
- preserve zero scale and explicit 100% run overrides across parse, serialize, ProseMirror, layout, measurement, and paint
- keep MathML, fields, text, CSS transforms, reserved advances, and measurement cache geometry consistent

## Validation

- focused horizontal-scale, DOCX round-trip, ProseMirror, layout conversion, painter, and MathML tests pass
- focused lint, formatting, and diff hygiene pass
- broad validation runs in CI

CC on behalf of jan-kubica
