### PR TITLE
fix: align justified list continuation fitting

### DIFF
--- a/.changeset/calm-lists-justify.md
+++ b/.changeset/calm-lists-justify.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align justified list continuation fitting with measured space capacity.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -486,7 +486,10 @@ export type MeasuredLine = {
     ascent: number;
     descent: number;
     lineHeight: number;
-    justificationShrinkBudgetPx?: number;
+    justificationPaint?: {
+        type: "space-contraction";
+        contractionPx: number;
+    };
     leftOffset?: number;
     rightOffset?: number;
     floatSkipBefore?: number;

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -486,6 +486,7 @@ export type MeasuredLine = {
     ascent: number;
     descent: number;
     lineHeight: number;
+    justificationShrinkBudgetPx?: number;
     leftOffset?: number;
     rightOffset?: number;
     floatSkipBefore?: number;

--- a/packages/core/src/layout-engine/justifiedLineFit.ts
+++ b/packages/core/src/layout-engine/justifiedLineFit.ts
@@ -3,20 +3,6 @@ import type { ParagraphBlock } from "./types";
 export const JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO = 0.025;
 export const JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO = 0.32;
 
-type JustifiedListFinalLineShrinkBudgetOptions = {
-  availableWidth: number;
-  compressibleSpaceWidth: number;
-};
-
-export const calculateJustifiedListFinalLineShrinkBudget = ({
-  availableWidth,
-  compressibleSpaceWidth,
-}: JustifiedListFinalLineShrinkBudgetOptions): number =>
-  Math.min(
-    Math.max(0, availableWidth) * JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
-    Math.max(0, compressibleSpaceWidth) * JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
-  );
-
 export const supportsJustifiedListFinalLineContraction = (block: ParagraphBlock): boolean =>
   block.attrs?.justificationCompatibility?.type !== "legacy" &&
   block.attrs?.listMarker !== undefined;

--- a/packages/core/src/layout-engine/justifiedLineFit.ts
+++ b/packages/core/src/layout-engine/justifiedLineFit.ts
@@ -1,6 +1,21 @@
 import type { ParagraphBlock } from "./types";
 
 export const JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO = 0.025;
+export const JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO = 0.32;
+
+type JustifiedListFinalLineShrinkBudgetOptions = {
+  availableWidth: number;
+  compressibleSpaceWidth: number;
+};
+
+export const calculateJustifiedListFinalLineShrinkBudget = ({
+  availableWidth,
+  compressibleSpaceWidth,
+}: JustifiedListFinalLineShrinkBudgetOptions): number =>
+  Math.min(
+    Math.max(0, availableWidth) * JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
+    Math.max(0, compressibleSpaceWidth) * JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
+  );
 
 export const supportsJustifiedListFinalLineContraction = (block: ParagraphBlock): boolean =>
   block.attrs?.justificationCompatibility?.type !== "legacy" &&

--- a/packages/core/src/layout-engine/justifiedLineFit.ts
+++ b/packages/core/src/layout-engine/justifiedLineFit.ts
@@ -1,0 +1,7 @@
+import type { ParagraphBlock } from "./types";
+
+export const JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO = 0.025;
+
+export const supportsJustifiedListFinalLineContraction = (block: ParagraphBlock): boolean =>
+  block.attrs?.justificationCompatibility?.type !== "legacy" &&
+  block.attrs?.listMarker !== undefined;

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1635,6 +1635,42 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
+  test("keeps an admitted plan on the final line before an ignorable cached boundary suffix", () => {
+    const prefix = "a ".repeat(50);
+
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-final-token-cached-boundary",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${prefix}bbb` },
+              { kind: "renderedPageBreak" },
+              { kind: "text", text: "" },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+        const plannedLineIndex = measure.lines.findIndex(
+          (line) => line.justificationPaint?.type === "space-contraction",
+        );
+        expect(plannedLineIndex).toBe(measure.lines.length - 1);
+        expect(measure.lines.at(-1)?.justificationPaint?.contractionPx).toBeCloseTo(2.4);
+      },
+      { charWidth: (char) => (char === "b" ? 0.8 : 1) },
+    );
+  });
+
   test("separates CJK hanging punctuation from admitted final-list space contraction", () => {
     const finalText = `${"a ".repeat(50)}bb。`;
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1626,9 +1626,40 @@ describe("measureParagraph justified shrink tolerance", () => {
         );
 
         expect(finalTokenMeasure.lines).toHaveLength(2);
+        expect(finalTokenMeasure.lines.at(-1)?.justificationShrinkBudgetPx).toBeCloseTo(2.5);
         expect(intermediateTokenMeasure.lines).toHaveLength(3);
+        expect(intermediateTokenMeasure.lines.at(1)?.justificationShrinkBudgetPx).toBeUndefined();
       },
       { charWidth: (char) => (char === "b" ? 0.8 : 1) },
+    );
+  });
+
+  test("wraps an unbreakable paragraph tail beyond its sparse ASCII-space budget", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-sparse-final-tail",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${"a".repeat(96)} bbb` },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+
+        expect(measure.lines).toHaveLength(3);
+        expect(measure.lines.at(1)?.toChar).toBe(97);
+        expect(measure.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+      },
+      { charWidth: (char) => (char === "b" ? 1.2 : 1) },
     );
   });
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1552,7 +1552,7 @@ describe("measureParagraph justified shrink tolerance", () => {
               indent: { left: 36, hanging: 36 },
             },
           },
-          136,
+          138.5,
         );
         const overflowingMeasure = measureParagraph(
           {
@@ -1569,7 +1569,7 @@ describe("measureParagraph justified shrink tolerance", () => {
               indent: { left: 36, hanging: 36 },
             },
           },
-          135.8,
+          138.2,
         );
 
         expect(fittingMeasure.lines).toHaveLength(2);
@@ -1578,10 +1578,57 @@ describe("measureParagraph justified shrink tolerance", () => {
       {
         charWidth: (char) => {
           if (char === "b") return 5.3;
-          if (char === " ") return 0.55;
+          if (char === " ") return 0.9;
           return 8;
         },
       },
+    );
+  });
+
+  test("allows wider bounded contraction only for the paragraph-tail token", () => {
+    const prefix = "a ".repeat(50);
+
+    withFakeTextMeasure(
+      () => {
+        const finalTokenMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-final-token-contraction",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${prefix}bbb` },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+        const intermediateTokenMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-intermediate-token-contraction",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${prefix}bbb c` },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+
+        expect(finalTokenMeasure.lines).toHaveLength(2);
+        expect(intermediateTokenMeasure.lines).toHaveLength(3);
+      },
+      { charWidth: (char) => (char === "b" ? 0.8 : 1) },
     );
   });
 
@@ -1761,13 +1808,30 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
-  test("keeps inset list continuation lines on the conservative tolerance", () => {
+  test("bases inset list continuation fitting on compressible spaces", () => {
     withFakeTextMeasure(
       () => {
-        const measure = measureParagraph(
+        const spaceRichMeasure = measureParagraph(
           {
             kind: "paragraph",
-            id: "justified-inset-list-continuation",
+            id: "justified-inset-list-space-budget",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${"a ".repeat(10)}${"a".repeat(60)}bbb` },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+        const spacePoorMeasure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-inset-list-small-space-budget",
             runs: [
               { kind: "text", text: "first line" },
               { kind: "lineBreak" },
@@ -1782,7 +1846,8 @@ describe("measureParagraph justified shrink tolerance", () => {
           136,
         );
 
-        expect(measure.lines).toHaveLength(3);
+        expect(spaceRichMeasure.lines).toHaveLength(2);
+        expect(spacePoorMeasure.lines).toHaveLength(3);
       },
       {
         charWidth: fractionalWidth,

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1626,11 +1626,49 @@ describe("measureParagraph justified shrink tolerance", () => {
         );
 
         expect(finalTokenMeasure.lines).toHaveLength(2);
-        expect(finalTokenMeasure.lines.at(-1)?.justificationShrinkBudgetPx).toBeCloseTo(2.5);
+        expect(finalTokenMeasure.lines.at(-1)?.justificationPaint?.type).toBe("space-contraction");
+        expect(finalTokenMeasure.lines.at(-1)?.justificationPaint?.contractionPx).toBeCloseTo(2.4);
         expect(intermediateTokenMeasure.lines).toHaveLength(3);
-        expect(intermediateTokenMeasure.lines.at(1)?.justificationShrinkBudgetPx).toBeUndefined();
+        expect(intermediateTokenMeasure.lines.at(1)?.justificationPaint).toBeUndefined();
       },
       { charWidth: (char) => (char === "b" ? 0.8 : 1) },
+    );
+  });
+
+  test("separates CJK hanging punctuation from admitted final-list space contraction", () => {
+    const finalText = `${"a ".repeat(50)}bb。`;
+
+    withFakeTextMeasure(
+      () => {
+        const paragraph = (overflowPunctuation: boolean): ParagraphBlock => ({
+          kind: "paragraph",
+          id: `justified-list-cjk-hanging-${String(overflowPunctuation)}`,
+          runs: [
+            { kind: "text", text: "first line" },
+            { kind: "lineBreak" },
+            { kind: "text", text: finalText, language: { eastAsia: "zh-CN" } },
+          ],
+          attrs: {
+            alignment: "justify",
+            listMarker: "1.",
+            indent: { left: 36, hanging: 18 },
+            overflowPunctuation,
+          },
+        });
+
+        const hanging = measureParagraph(paragraph(true), 136);
+        const contained = measureParagraph(paragraph(false), 136);
+
+        expect(hanging.lines).toHaveLength(2);
+        expect(hanging.lines.at(-1)?.width).toBe(103);
+        expect(hanging.lines.at(-1)?.justificationPaint).toEqual({
+          type: "space-contraction",
+          contractionPx: 2,
+        });
+        expect(contained.lines).toHaveLength(3);
+        expect(contained.lines.at(-1)?.justificationPaint).toBeUndefined();
+      },
+      { charWidth: fixedCharWidth(1) },
     );
   });
 
@@ -1657,13 +1695,13 @@ describe("measureParagraph justified shrink tolerance", () => {
 
         expect(measure.lines).toHaveLength(3);
         expect(measure.lines.at(1)?.toChar).toBe(97);
-        expect(measure.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+        expect(measure.lines.at(-1)?.justificationPaint).toBeUndefined();
       },
       { charWidth: (char) => (char === "b" ? 1.2 : 1) },
     );
   });
 
-  test("does not expose a shrink budget when a sparse unbreakable tail needs only rounding", () => {
+  test("does not expose a contraction paint plan when a sparse tail needs only rounding", () => {
     withFakeTextMeasure(
       () => {
         const measure = measureParagraph(
@@ -1685,13 +1723,13 @@ describe("measureParagraph justified shrink tolerance", () => {
         );
 
         expect(measure.lines).toHaveLength(2);
-        expect(measure.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+        expect(measure.lines.at(-1)?.justificationPaint).toBeUndefined();
       },
       { charWidth: (char) => (char === "b" ? 1.1 : 1) },
     );
   });
 
-  test("does not expose a final-text budget for single-line lists or opaque final runs", () => {
+  test("does not expose a final-text paint plan for single-line lists or opaque final runs", () => {
     withFakeTextMeasure(
       () => {
         const attrs = {
@@ -1741,9 +1779,9 @@ describe("measureParagraph justified shrink tolerance", () => {
           300,
         );
 
-        expect(singleLine.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
-        expect(fieldTail.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
-        expect(mathTail.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+        expect(singleLine.lines.at(-1)?.justificationPaint).toBeUndefined();
+        expect(fieldTail.lines.at(-1)?.justificationPaint).toBeUndefined();
+        expect(mathTail.lines.at(-1)?.justificationPaint).toBeUndefined();
       },
       { charWidth: fixedCharWidth(1) },
     );

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ParagraphBlock, Run } from "../types";
+import type { ParagraphAttrs, ParagraphBlock, Run } from "../types";
 import {
   smallCapsAwareCharWidth,
   withFakeTextMeasure,
@@ -1660,6 +1660,92 @@ describe("measureParagraph justified shrink tolerance", () => {
         expect(measure.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
       },
       { charWidth: (char) => (char === "b" ? 1.2 : 1) },
+    );
+  });
+
+  test("does not expose a shrink budget when a sparse unbreakable tail needs only rounding", () => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-rounded-final-tail",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: `${"a".repeat(96)} bbb` },
+            ],
+            attrs: {
+              alignment: "justify",
+              listMarker: "1.",
+              indent: { left: 36, hanging: 18 },
+            },
+          },
+          136,
+        );
+
+        expect(measure.lines).toHaveLength(2);
+        expect(measure.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+      },
+      { charWidth: (char) => (char === "b" ? 1.1 : 1) },
+    );
+  });
+
+  test("does not expose a final-text budget for single-line lists or opaque final runs", () => {
+    withFakeTextMeasure(
+      () => {
+        const attrs = {
+          alignment: "justify",
+          listMarker: "1.",
+          indent: { left: 36, hanging: 18 },
+        } as const satisfies ParagraphAttrs;
+        const singleLine = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-single-line-list-no-final-budget",
+            runs: [{ kind: "text", text: "alpha beta" }],
+            attrs,
+          },
+          300,
+        );
+        const fieldTail = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-field-tail-no-final-budget",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "field", fieldType: "OTHER", fallback: "alpha beta" },
+            ],
+            attrs,
+          },
+          300,
+        );
+        const mathTail = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-list-math-tail-no-final-budget",
+            runs: [
+              { kind: "text", text: "first line" },
+              { kind: "lineBreak" },
+              { kind: "text", text: "alpha beta " },
+              {
+                kind: "math",
+                display: "inline",
+                ommlXml: "<m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>",
+                plainText: "x",
+              },
+            ],
+            attrs,
+          },
+          300,
+        );
+
+        expect(singleLine.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+        expect(fieldTail.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+        expect(mathTail.lines.at(-1)?.justificationShrinkBudgetPx).toBeUndefined();
+      },
+      { charWidth: fixedCharWidth(1) },
     );
   });
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -18,7 +18,6 @@ import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
 import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import { measuredLineAdvance } from "../lineFlow";
 import {
-  calculateJustifiedListFinalLineShrinkBudget,
   JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
   JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
   supportsJustifiedListFinalLineContraction,
@@ -152,8 +151,8 @@ type LineState = {
   trailingWhitespaceWidth: number;
   /** Spaces the layout may compress while justifying this line. */
   regularSpaceWidth: number;
-  /** Paint budget set only when final-text contraction admits a candidate. */
-  justificationShrinkBudgetPx?: number;
+  /** Paint plan set only when final-text contraction admits a candidate. */
+  justificationPaint?: NonNullable<MeasuredLine["justificationPaint"]>;
   maxFontSize: number;
   maxFontMetrics: FontMetrics | null;
   /** Maximum inline image height in pixels (already in px, not points) */
@@ -745,7 +744,7 @@ type TextCandidateFit =
   | {
       type: "final-contraction-admitted";
       tolerancePx: number;
-      shrinkBudgetPx: number;
+      paint: NonNullable<MeasuredLine["justificationPaint"]>;
     };
 
 type ResolveTextCandidateFitOptions = {
@@ -788,10 +787,10 @@ function resolveTextCandidateFit({
   return {
     type: "final-contraction-admitted",
     tolerancePx: finalTolerancePx,
-    shrinkBudgetPx: calculateJustifiedListFinalLineShrinkBudget({
-      availableWidth: line.availableWidth,
-      compressibleSpaceWidth: line.regularSpaceWidth + candidateSpaceWidth,
-    }),
+    paint: {
+      type: "space-contraction",
+      contractionPx: candidateWidth - line.availableWidth,
+    },
   };
 }
 
@@ -1560,8 +1559,8 @@ export function measureParagraph(
       toChar: currentLine.toChar,
       width: Math.max(0, currentLine.width - currentLine.trailingWhitespaceWidth),
       ...finalTypography,
-      ...(currentLine.justificationShrinkBudgetPx !== undefined
-        ? { justificationShrinkBudgetPx: currentLine.justificationShrinkBudgetPx }
+      ...(currentLine.justificationPaint !== undefined
+        ? { justificationPaint: currentLine.justificationPaint }
         : {}),
       ...(currentLine.discretionaryHyphen
         ? { discretionaryHyphen: currentLine.discretionaryHyphen }
@@ -2251,7 +2250,7 @@ export function measureParagraph(
         }
 
         if (candidateFit?.type === "final-contraction-admitted") {
-          currentLine.justificationShrinkBudgetPx = candidateFit.shrinkBudgetPx;
+          currentLine.justificationPaint = candidateFit.paint;
         }
 
         // Add word to current line

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -17,6 +17,10 @@ import { isRtlParagraph } from "../../utils/paragraphBaseDirection";
 import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
 import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import { measuredLineAdvance } from "../lineFlow";
+import {
+  JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
+  supportsJustifiedListFinalLineContraction,
+} from "../justifiedLineFit";
 import type {
   ParagraphBlock,
   ParagraphMeasure,
@@ -77,10 +81,8 @@ const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 const JUSTIFY_SPACE_CONTRACTION_RATIO = 0.075;
 const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
 const JUSTIFY_DEEP_HANGING_LIST_MARKER_SHRINK_TOLERANCE_RATIO = 0.022;
-// Full-hanging continuations allow stronger space contraction with bounded total shrink.
+// List continuations allow stronger space contraction with bounded total shrink.
 const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.32;
-const JUSTIFY_LIST_CONTINUATION_MAX_SHRINK_TOLERANCE_RATIO = 0.015;
-const JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO = 0.015;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
 const DEFAULT_LIST_HANGING_INDENT_PX = 24;
@@ -674,14 +676,10 @@ function resolveJustifyFitStrategy(
             ratio: JUSTIFY_DEEP_HANGING_LIST_MARKER_SHRINK_TOLERANCE_RATIO,
           };
     }
-    const left = block.attrs.indent?.left ?? 0;
-    if (hanging > 0 && left > hanging) {
-      return { type: "width", ratio: JUSTIFY_INSET_LIST_SHRINK_TOLERANCE_RATIO };
-    }
     return {
       type: "space",
       ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO,
-      maxWidthRatio: JUSTIFY_LIST_CONTINUATION_MAX_SHRINK_TOLERANCE_RATIO,
+      maxWidthRatio: JUSTIFY_SHRINK_TOLERANCE_RATIO,
     };
   }
 
@@ -705,6 +703,38 @@ function resolveJustifyFitStrategy(
     return { type: "width", ratio: JUSTIFY_SHRINK_TOLERANCE_RATIO };
   }
   return { type: "space", ratio: JUSTIFY_SPACE_CONTRACTION_RATIO };
+}
+
+function resolveFinalLineJustifyFitStrategy(
+  block: ParagraphBlock,
+  profile: JustificationProfile,
+): JustifyFitStrategy {
+  if (supportsJustifiedListFinalLineContraction(block)) {
+    return {
+      type: "space",
+      ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO,
+      maxWidthRatio: JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
+    };
+  }
+  return resolveJustifyFitStrategy(block, false, profile);
+}
+
+function isFinalTextCandidate(block: ParagraphBlock, runIndex: number, nextBreak: number): boolean {
+  const currentRun = block.runs[runIndex];
+  if (!currentRun || !isTextRun(currentRun) || nextBreak !== currentRun.text.length) {
+    return false;
+  }
+  for (let index = runIndex + 1; index < block.runs.length; index += 1) {
+    const run = block.runs[index];
+    if (run?.kind === "renderedPageBreak") {
+      continue;
+    }
+    if (run && isTextRun(run) && run.text.length === 0) {
+      continue;
+    }
+    return false;
+  }
+  return true;
 }
 
 function compressibleSpaceWidth(text: string, style: FontStyle): number {
@@ -1161,6 +1191,10 @@ export function measureParagraph(
   const continuationJustifyFitStrategy = resolveJustifyFitStrategy(
     block,
     false,
+    justificationProfile,
+  );
+  const finalLineJustifyFitStrategy = resolveFinalLineJustifyFitStrategy(
+    block,
     justificationProfile,
   );
 
@@ -1931,12 +1965,13 @@ export function measureParagraph(
         );
         const isFirstLine = lines.length === 0;
         const regularSpaceWidth = compressibleSpaceWidth(measuredWord, style);
+        const justifyFitStrategy = isFirstLine
+          ? firstLineJustifyFitStrategy
+          : isFinalTextCandidate(block, runIndex, nextBreak)
+            ? finalLineJustifyFitStrategy
+            : continuationJustifyFitStrategy;
         const widthTolerance = isJustifiedParagraph
-          ? justifyFitTolerance(
-              currentLine,
-              isFirstLine ? firstLineJustifyFitStrategy : continuationJustifyFitStrategy,
-              regularSpaceWidth,
-            )
+          ? justifyFitTolerance(currentLine, justifyFitStrategy, regularSpaceWidth)
           : WIDTH_TOLERANCE;
 
         const automaticHyphenation = effectiveLineBreakPolicy.automaticHyphenation;

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -720,6 +720,30 @@ function resolveFinalLineJustifyFitStrategy(
   return resolveJustifyFitStrategy(block, false, profile);
 }
 
+type ResolveCandidateJustifyFitStrategyOptions = {
+  isFirstLine: boolean;
+  isFinalCandidate: boolean;
+  firstLineStrategy: JustifyFitStrategy;
+  continuationStrategy: JustifyFitStrategy;
+  finalLineStrategy: JustifyFitStrategy;
+};
+
+function resolveCandidateJustifyFitStrategy({
+  isFirstLine,
+  isFinalCandidate,
+  firstLineStrategy,
+  continuationStrategy,
+  finalLineStrategy,
+}: ResolveCandidateJustifyFitStrategyOptions): JustifyFitStrategy {
+  if (isFirstLine) {
+    return firstLineStrategy;
+  }
+  if (isFinalCandidate) {
+    return finalLineStrategy;
+  }
+  return continuationStrategy;
+}
+
 function isFinalTextCandidate(block: ParagraphBlock, runIndex: number, nextBreak: number): boolean {
   const currentRun = block.runs[runIndex];
   if (!currentRun || !isTextRun(currentRun) || nextBreak !== currentRun.text.length) {
@@ -2025,11 +2049,13 @@ export function measureParagraph(
         );
         const isFirstLine = lines.length === 0;
         const regularSpaceWidth = compressibleSpaceWidth(measuredWord, style);
-        const justifyFitStrategy = isFirstLine
-          ? firstLineJustifyFitStrategy
-          : isFinalTextCandidate(block, runIndex, nextBreak)
-            ? finalLineJustifyFitStrategy
-            : continuationJustifyFitStrategy;
+        const justifyFitStrategy = resolveCandidateJustifyFitStrategy({
+          isFirstLine,
+          isFinalCandidate: isFinalTextCandidate(block, runIndex, nextBreak),
+          firstLineStrategy: firstLineJustifyFitStrategy,
+          continuationStrategy: continuationJustifyFitStrategy,
+          finalLineStrategy: finalLineJustifyFitStrategy,
+        });
         const widthTolerance = isJustifiedParagraph
           ? justifyFitTolerance(currentLine, justifyFitStrategy, regularSpaceWidth)
           : WIDTH_TOLERANCE;

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -152,6 +152,8 @@ type LineState = {
   trailingWhitespaceWidth: number;
   /** Spaces the layout may compress while justifying this line. */
   regularSpaceWidth: number;
+  /** Paint budget set only when final-text contraction admits a candidate. */
+  justificationShrinkBudgetPx?: number;
   maxFontSize: number;
   maxFontMetrics: FontMetrics | null;
   /** Maximum inline image height in pixels (already in px, not points) */
@@ -735,6 +737,62 @@ function isFinalTextCandidate(block: ParagraphBlock, runIndex: number, nextBreak
     return false;
   }
   return true;
+}
+
+type TextCandidateFit =
+  | { type: "ordinary"; tolerancePx: number }
+  | { type: "final-contraction-rejected"; tolerancePx: number }
+  | {
+      type: "final-contraction-admitted";
+      tolerancePx: number;
+      shrinkBudgetPx: number;
+    };
+
+type ResolveTextCandidateFitOptions = {
+  block: ParagraphBlock;
+  line: LineState;
+  isFirstLine: boolean;
+  isFinalCandidate: boolean;
+  candidateWidth: number;
+  candidateSpaceWidth: number;
+  fallbackTolerancePx: number;
+  continuationStrategy: JustifyFitStrategy;
+  finalStrategy: JustifyFitStrategy;
+};
+
+function resolveTextCandidateFit({
+  block,
+  line,
+  isFirstLine,
+  isFinalCandidate,
+  candidateWidth,
+  candidateSpaceWidth,
+  fallbackTolerancePx,
+  continuationStrategy,
+  finalStrategy,
+}: ResolveTextCandidateFitOptions): TextCandidateFit {
+  if (isFirstLine || !isFinalCandidate || !supportsJustifiedListFinalLineContraction(block)) {
+    return { type: "ordinary", tolerancePx: fallbackTolerancePx };
+  }
+
+  const ordinaryTolerancePx = justifyFitTolerance(line, continuationStrategy, candidateSpaceWidth);
+  if (candidateWidth <= line.availableWidth + ordinaryTolerancePx) {
+    return { type: "ordinary", tolerancePx: ordinaryTolerancePx };
+  }
+
+  const finalTolerancePx = justifyFitTolerance(line, finalStrategy, candidateSpaceWidth);
+  if (candidateWidth > line.availableWidth + finalTolerancePx) {
+    return { type: "final-contraction-rejected", tolerancePx: finalTolerancePx };
+  }
+
+  return {
+    type: "final-contraction-admitted",
+    tolerancePx: finalTolerancePx,
+    shrinkBudgetPx: calculateJustifiedListFinalLineShrinkBudget({
+      availableWidth: line.availableWidth,
+      compressibleSpaceWidth: line.regularSpaceWidth + candidateSpaceWidth,
+    }),
+  };
 }
 
 function compressibleSpaceWidth(text: string, style: FontStyle): number {
@@ -1492,15 +1550,8 @@ export function measureParagraph(
   /**
    * Finalize and push the current line to the lines array
    */
-  const finalizeLine = (isParagraphEnd: boolean = false): void => {
+  const finalizeLine = (): void => {
     const finalTypography = calculateLineTypography(currentLine);
-    const justificationShrinkBudgetPx =
-      isParagraphEnd && supportsJustifiedListFinalLineContraction(block)
-        ? calculateJustifiedListFinalLineShrinkBudget({
-            availableWidth: currentLine.availableWidth,
-            compressibleSpaceWidth: currentLine.regularSpaceWidth,
-          })
-        : 0;
 
     const line: MeasuredLine = {
       fromRun: currentLine.fromRun,
@@ -1509,7 +1560,9 @@ export function measureParagraph(
       toChar: currentLine.toChar,
       width: Math.max(0, currentLine.width - currentLine.trailingWhitespaceWidth),
       ...finalTypography,
-      ...(justificationShrinkBudgetPx > 0 ? { justificationShrinkBudgetPx } : {}),
+      ...(currentLine.justificationShrinkBudgetPx !== undefined
+        ? { justificationShrinkBudgetPx: currentLine.justificationShrinkBudgetPx }
+        : {}),
       ...(currentLine.discretionaryHyphen
         ? { discretionaryHyphen: currentLine.discretionaryHyphen }
         : {}),
@@ -2168,6 +2221,20 @@ export function measureParagraph(
             ? rawGlueWidth
             : 0;
         const hangingAllowance = glueWidth === 0 ? hangingPunctuationWidth : 0;
+        const candidateFit = isJustifiedParagraph
+          ? resolveTextCandidateFit({
+              block,
+              line: currentLine,
+              isFirstLine,
+              isFinalCandidate: isFinalTextCandidate(block, runIndex, nextBreak),
+              candidateWidth: currentLine.width + wordWidth + glueWidth - hangingAllowance,
+              candidateSpaceWidth: regularSpaceWidth,
+              fallbackTolerancePx: widthTolerance,
+              continuationStrategy: continuationJustifyFitStrategy,
+              finalStrategy: finalLineJustifyFitStrategy,
+            })
+          : undefined;
+        const finalWrapTolerance = candidateFit?.tolerancePx ?? widthTolerance;
         // Let collapsible whitespace remain at the previous line's tail until
         // visible content decides whether to wrap. Starting a line from an
         // overflowed space creates whitespace-only soft-wrap lines.
@@ -2175,12 +2242,16 @@ export function measureParagraph(
           wordWidth > 0 &&
           currentLine.width > 0 &&
           currentLine.width + wordWidth + glueWidth >
-            currentLine.availableWidth + widthTolerance + hangingAllowance
+            currentLine.availableWidth + finalWrapTolerance + hangingAllowance
         ) {
           // Word doesn't fit, start new line
           startNewLine(runIndex, charIndex);
           // Re-apply font metrics to the new line (startNewLine resets maxFontSize)
           updateMaxFont(lineHeightStyle);
+        }
+
+        if (candidateFit?.type === "final-contraction-admitted") {
+          currentLine.justificationShrinkBudgetPx = candidateFit.shrinkBudgetPx;
         }
 
         // Add word to current line
@@ -2217,7 +2288,7 @@ export function measureParagraph(
   }
 
   // Finalize the last line
-  finalizeLine(true);
+  finalizeLine();
 
   // Calculate total height — include floatSkipBefore from lines bumped past
   // floats so containers stay sized correctly.

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -744,6 +744,9 @@ function resolveCandidateJustifyFitStrategy({
   return continuationStrategy;
 }
 
+const isIgnorableFinalTailRun = (run: Run): boolean =>
+  run.kind === "renderedPageBreak" || (isTextRun(run) && run.text.length === 0);
+
 function isFinalTextCandidate(block: ParagraphBlock, runIndex: number, nextBreak: number): boolean {
   const currentRun = block.runs[runIndex];
   if (!currentRun || !isTextRun(currentRun) || nextBreak !== currentRun.text.length) {
@@ -751,10 +754,7 @@ function isFinalTextCandidate(block: ParagraphBlock, runIndex: number, nextBreak
   }
   for (let index = runIndex + 1; index < block.runs.length; index += 1) {
     const run = block.runs[index];
-    if (run?.kind === "renderedPageBreak") {
-      continue;
-    }
-    if (run && isTextRun(run) && run.text.length === 0) {
+    if (run && isIgnorableFinalTailRun(run)) {
       continue;
     }
     return false;
@@ -1698,7 +1698,7 @@ export function measureParagraph(
     if (run.kind === "renderedPageBreak") {
       const hasFollowingContent = runs
         .slice(runIndex + 1)
-        .some((followingRun) => followingRun.kind !== "renderedPageBreak");
+        .some((followingRun) => !isIgnorableFinalTailRun(followingRun));
       if (!hasFollowingContent) {
         currentLine.toRun = runIndex;
         currentLine.toChar = 0;

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -18,7 +18,9 @@ import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
 import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import { measuredLineAdvance } from "../lineFlow";
 import {
+  calculateJustifiedListFinalLineShrinkBudget,
   JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
+  JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
   supportsJustifiedListFinalLineContraction,
 } from "../justifiedLineFit";
 import type {
@@ -81,8 +83,6 @@ const JUSTIFY_SHRINK_TOLERANCE_RATIO = 0.016;
 const JUSTIFY_SPACE_CONTRACTION_RATIO = 0.075;
 const JUSTIFY_LIST_MARKER_SPACE_CONTRACTION_RATIO = 0.195;
 const JUSTIFY_DEEP_HANGING_LIST_MARKER_SHRINK_TOLERANCE_RATIO = 0.022;
-// List continuations allow stronger space contraction with bounded total shrink.
-const JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO = 0.32;
 const JUSTIFY_LITERAL_TAB_CONTINUATION_SHRINK_TOLERANCE_RATIO = 0.017;
 const JUSTIFY_HANGING_TAB_SHRINK_TOLERANCE_RATIO = 0.021;
 const DEFAULT_LIST_HANGING_INDENT_PX = 24;
@@ -678,7 +678,7 @@ function resolveJustifyFitStrategy(
     }
     return {
       type: "space",
-      ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO,
+      ratio: JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
       maxWidthRatio: JUSTIFY_SHRINK_TOLERANCE_RATIO,
     };
   }
@@ -712,7 +712,7 @@ function resolveFinalLineJustifyFitStrategy(
   if (supportsJustifiedListFinalLineContraction(block)) {
     return {
       type: "space",
-      ratio: JUSTIFY_LIST_CONTINUATION_SPACE_CONTRACTION_RATIO,
+      ratio: JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
       maxWidthRatio: JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
     };
   }
@@ -1492,8 +1492,15 @@ export function measureParagraph(
   /**
    * Finalize and push the current line to the lines array
    */
-  const finalizeLine = (): void => {
+  const finalizeLine = (isParagraphEnd: boolean = false): void => {
     const finalTypography = calculateLineTypography(currentLine);
+    const justificationShrinkBudgetPx =
+      isParagraphEnd && supportsJustifiedListFinalLineContraction(block)
+        ? calculateJustifiedListFinalLineShrinkBudget({
+            availableWidth: currentLine.availableWidth,
+            compressibleSpaceWidth: currentLine.regularSpaceWidth,
+          })
+        : 0;
 
     const line: MeasuredLine = {
       fromRun: currentLine.fromRun,
@@ -1502,6 +1509,7 @@ export function measureParagraph(
       toChar: currentLine.toChar,
       width: Math.max(0, currentLine.width - currentLine.trailingWhitespaceWidth),
       ...finalTypography,
+      ...(justificationShrinkBudgetPx > 0 ? { justificationShrinkBudgetPx } : {}),
       ...(currentLine.discretionaryHyphen
         ? { discretionaryHyphen: currentLine.discretionaryHyphen }
         : {}),
@@ -2209,7 +2217,7 @@ export function measureParagraph(
   }
 
   // Finalize the last line
-  finalizeLine();
+  finalizeLine(true);
 
   // Calculate total height — include floatSkipBefore from lines bumped past
   // floats so containers stay sized correctly.

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -963,8 +963,8 @@ export type MeasuredLine = {
   descent: number;
   /** Total line height in pixels. */
   lineHeight: number;
-  /** Maximum measured ASCII-space contraction admitted for this final line. */
-  justificationShrinkBudgetPx?: number;
+  /** Paint adjustment admitted by measurement for this line. */
+  justificationPaint?: { type: "space-contraction"; contractionPx: number };
   /** Left offset from floating images (pixels from content left edge). */
   leftOffset?: number;
   /** Right offset from floating images (pixels from content right edge). */

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -963,6 +963,8 @@ export type MeasuredLine = {
   descent: number;
   /** Total line height in pixels. */
   lineHeight: number;
+  /** Maximum measured ASCII-space contraction admitted for this final line. */
+  justificationShrinkBudgetPx?: number;
   /** Left offset from floating images (pixels from content left edge). */
   leftOffset?: number;
   /** Right offset from floating images (pixels from content right edge). */

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -83,6 +83,18 @@ const fakeDocument = {
   },
 } as unknown as Document;
 
+function paintedVisualSpaceContraction(element: FakeElement, ancestorScale = 1): number {
+  const transformScale = /^scaleX\(([^)]+)\)$/u.exec(element.style.transform ?? "")?.at(1);
+  const effectiveScale = ancestorScale * (transformScale ? Number(transformScale) : 1);
+  const wordSpacing = Number.parseFloat(element.style.wordSpacing ?? "0");
+  const asciiSpaces = [...element.textContent].filter((character) => character === " ").length;
+  let contraction = -wordSpacing * asciiSpaces * effectiveScale;
+  for (const child of element.children) {
+    contraction += paintedVisualSpaceContraction(child, effectiveScale);
+  }
+  return contraction;
+}
+
 function renderJustifiedFirstLine(firstLine: number): {
   firstLineEl: HTMLElement;
 } {
@@ -298,6 +310,168 @@ describe("Issue #868 — justify first line to full content width on indented pa
 
     expect(lineEl.style.wordSpacing).toBe("0");
     expect((lineEl as unknown as FakeElement).children.at(0)?.style.wordSpacing).toBe("-0.04px");
+  });
+
+  test("compensates final-list space contraction inside 50% scaled text", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-half-scale",
+      runs: [{ kind: "text", text: "alpha beta gamma", horizontalScale: 50 }],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 204,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 4 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 200,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.children.at(0)?.style.wordSpacing).toBe("-4px");
+    expect(paintedVisualSpaceContraction(lineEl)).toBeCloseTo(4);
+  });
+
+  test("compensates final-list space contraction through a 150% scaled field wrapper", () => {
+    const fieldText = "甲 alpha beta";
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-field-one-half-scale",
+      runs: [
+        {
+          kind: "field",
+          fieldType: "OTHER",
+          instruction: "REF target",
+          fallback: fieldText,
+          pmStart: 1,
+          horizontalScale: 150,
+          eastAsiaFontFamily: "Noto Sans CJK SC",
+        },
+      ],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 204,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 4 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 200,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+      context: {
+        pageNumber: 1,
+        totalPages: 1,
+        section: "body",
+        bookmarkText: new Map([["target", fieldText]]),
+      },
+    }) as unknown as FakeElement;
+    const fieldWrapper = lineEl.children.at(0);
+    const latinSegment = fieldWrapper?.children.at(1);
+
+    expect(fieldWrapper?.style.transform).toBe("scaleX(1.5)");
+    expect(latinSegment?.style.wordSpacing).toBe("-1.3333333333333333px");
+    expect(paintedVisualSpaceContraction(lineEl)).toBeCloseTo(4);
+  });
+
+  test("allocates mixed-scale final-list contraction in visual coordinates", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-mixed-scale",
+      runs: [
+        { kind: "text", text: "a b", horizontalScale: 50 },
+        { kind: "text", text: "c d", horizontalScale: 150 },
+        { kind: "text", text: "e f" },
+      ],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 3,
+      width: 306,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 6 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 300,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.children.map((child) => child.style.wordSpacing)).toEqual([
+      "-4px",
+      "-1.3333333333333333px",
+      "-2px",
+    ]);
+    expect(paintedVisualSpaceContraction(lineEl)).toBeCloseTo(6);
+  });
+
+  test("excludes zero-scale spaces from final-list contraction", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-zero-scale",
+      runs: [
+        { kind: "text", text: "a b", horizontalScale: 0 },
+        { kind: "text", text: "c d" },
+        {
+          kind: "field",
+          fieldType: "OTHER",
+          fallback: "甲 e f",
+          eastAsiaFontFamily: "Noto Sans CJK SC",
+          horizontalScale: 0,
+        },
+      ],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 204,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 4 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 200,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+      context: { pageNumber: 1, totalPages: 1, section: "body" },
+    }) as unknown as FakeElement;
+
+    expect(lineEl.children.at(0)?.style.transform).toBe("scaleX(0)");
+    expect(lineEl.children.at(0)?.style.wordSpacing).toBeUndefined();
+    expect(lineEl.children.at(1)?.style.wordSpacing).toBe("-4px");
+    expect(lineEl.children.at(2)?.style.transform).toBe("scaleX(0)");
+    expect(paintedVisualSpaceContraction(lineEl)).toBeCloseTo(4);
   });
 
   test("keeps MathML whitespace neutral while final text opts into contraction", () => {

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -388,6 +388,7 @@ describe("Issue #868 — justify first line to full content width on indented pa
     const latinSegment = fieldWrapper?.children.at(1);
 
     expect(fieldWrapper?.style.transform).toBe("scaleX(1.5)");
+    expect(fieldWrapper?.style.width).toBe("122px");
     expect(latinSegment?.style.wordSpacing).toBe("-1.3333333333333333px");
     expect(paintedVisualSpaceContraction(lineEl)).toBeCloseTo(4);
   });
@@ -427,7 +428,48 @@ describe("Issue #868 — justify first line to full content width on indented pa
       "-1.3333333333333333px",
       "-2px",
     ]);
+    expect(lineEl.children.map((child) => child.style.width)).toEqual([
+      "8.5px",
+      "29.5px",
+      undefined,
+    ]);
     expect(paintedVisualSpaceContraction(lineEl)).toBeCloseTo(6);
+  });
+
+  test("uses contracted scaled-run advance when resolving a following tab", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-scaled-tab-advance",
+      runs: [
+        { kind: "text", text: "a b", horizontalScale: 50 },
+        { kind: "tab" },
+        { kind: "text", text: "c d" },
+      ],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 3,
+      width: 104,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 4 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    }) as unknown as FakeElement;
+    const scaledRun = lineEl.children.at(0);
+    const tab = lineEl.children.find((child) => child.className.includes("layout-run-tab"));
+
+    expect(scaledRun?.style.width).toBe("8.5px");
+    expect(tab?.style.width).toBe("39.5px");
   });
 
   test("excludes zero-scale spaces from final-list contraction", () => {

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -41,6 +41,7 @@ class FakeElement {
   className = "";
   dataset: Record<string, string> = {};
   innerHTML = "";
+  textContent = "";
   dir = "";
   style: Record<string, string> = createFakeStyle();
   children: FakeElement[] = [];
@@ -204,6 +205,7 @@ describe("Issue #868 — justify first line to full content width on indented pa
       ascent: 10,
       descent: 3,
       lineHeight: 14,
+      justificationShrinkBudgetPx: 2,
     });
     const options = {
       availableWidth: 100,
@@ -222,6 +224,39 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(beyondContractionLimit.style.wordSpacing).toBeUndefined();
     expect(underfull.style.width).toBeUndefined();
     expect(underfull.style.wordSpacing).toBeUndefined();
+  });
+
+  test("contracts only measured ASCII spaces when the final line also contains NBSP", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-fixed-space",
+      runs: [{ kind: "text", text: "alpha beta\u00a0gamma" }],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 102,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationShrinkBudgetPx: 2,
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    });
+
+    expect(lineEl.style.wordSpacing).toBe("-2px");
+    const paintedRun = (lineEl as unknown as FakeElement).children.at(0);
+    expect(paintedRun?.children.at(0)?.style.wordSpacing).toBe("-2px");
+    expect(paintedRun?.children.at(1)?.textContent).toBe("\u00a0");
+    expect(paintedRun?.children.at(1)?.style.wordSpacing).toBe("0");
   });
 
   test("counts resolved field text when compressing an overfull line", () => {

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -188,6 +188,42 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(lineEl.style.wordSpacing).toBe("-5px");
   });
 
+  test("compresses an overfull final justified line without expanding an underfull one", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-contraction",
+      runs: [{ kind: "text", text: "alpha beta gamma" }],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line = (width: number): MeasuredLine => ({
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+    });
+    const options = {
+      availableWidth: 100,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    };
+
+    const overfull = renderLine(block, line(102), "justify", fakeDocument, options);
+    const beyondContractionLimit = renderLine(block, line(103), "justify", fakeDocument, options);
+    const underfull = renderLine(block, line(90), "justify", fakeDocument, options);
+
+    expect(overfull.style.width).toBe("100px");
+    expect(overfull.style.wordSpacing).toBe("-1px");
+    expect(beyondContractionLimit.style.width).toBeUndefined();
+    expect(beyondContractionLimit.style.wordSpacing).toBeUndefined();
+    expect(underfull.style.width).toBeUndefined();
+    expect(underfull.style.wordSpacing).toBeUndefined();
+  });
+
   test("counts resolved field text when compressing an overfull line", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -186,7 +186,8 @@ describe("Issue #868 — justify first line to full content width on indented pa
     expect(lineEl.style.width).toBe("100px");
     expect(lineEl.style.textAlign).toBe("left");
     expect(lineEl.style.textAlignLast).toBe("auto");
-    expect(lineEl.style.wordSpacing).toBe("-5px");
+    expect(lineEl.style.wordSpacing).toBe("0");
+    expect((lineEl as unknown as FakeElement).children.at(0)?.style.wordSpacing).toBe("-5px");
   });
 
   test("compresses an overfull final justified line without expanding an underfull one", () => {
@@ -196,17 +197,25 @@ describe("Issue #868 — justify first line to full content width on indented pa
       runs: [{ kind: "text", text: "alpha beta gamma" }],
       attrs: { alignment: "justify", listMarker: "1." },
     };
-    const line = (width: number): MeasuredLine => ({
-      fromRun: 0,
-      fromChar: 0,
-      toRun: 0,
-      toChar: 16,
-      width,
-      ascent: 10,
-      descent: 3,
-      lineHeight: 14,
-      justificationShrinkBudgetPx: 2,
-    });
+    const line = (width: number, admission: "admitted" | "unadmitted"): MeasuredLine => {
+      const measuredLine = {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 16,
+        width,
+        ascent: 10,
+        descent: 3,
+        lineHeight: 14,
+      } satisfies MeasuredLine;
+      if (admission === "unadmitted") {
+        return measuredLine;
+      }
+      return {
+        ...measuredLine,
+        justificationPaint: { type: "space-contraction", contractionPx: 2 },
+      };
+    };
     const options = {
       availableWidth: 100,
       isLastLine: true,
@@ -214,14 +223,15 @@ describe("Issue #868 — justify first line to full content width on indented pa
       paragraphEndsWithLineBreak: false,
     };
 
-    const overfull = renderLine(block, line(102), "justify", fakeDocument, options);
-    const beyondContractionLimit = renderLine(block, line(103), "justify", fakeDocument, options);
-    const underfull = renderLine(block, line(90), "justify", fakeDocument, options);
+    const overfull = renderLine(block, line(102, "admitted"), "justify", fakeDocument, options);
+    const unadmitted = renderLine(block, line(103, "unadmitted"), "justify", fakeDocument, options);
+    const underfull = renderLine(block, line(90, "admitted"), "justify", fakeDocument, options);
 
     expect(overfull.style.width).toBe("100px");
-    expect(overfull.style.wordSpacing).toBe("-1px");
-    expect(beyondContractionLimit.style.width).toBeUndefined();
-    expect(beyondContractionLimit.style.wordSpacing).toBeUndefined();
+    expect(overfull.style.wordSpacing).toBe("0");
+    expect((overfull as unknown as FakeElement).children.at(0)?.style.wordSpacing).toBe("-1px");
+    expect(unadmitted.style.width).toBeUndefined();
+    expect(unadmitted.style.wordSpacing).toBeUndefined();
     expect(underfull.style.width).toBeUndefined();
     expect(underfull.style.wordSpacing).toBeUndefined();
   });
@@ -242,7 +252,7 @@ describe("Issue #868 — justify first line to full content width on indented pa
       ascent: 10,
       descent: 3,
       lineHeight: 14,
-      justificationShrinkBudgetPx: 2,
+      justificationPaint: { type: "space-contraction", contractionPx: 2 },
     };
 
     const lineEl = renderLine(block, line, "justify", fakeDocument, {
@@ -252,11 +262,84 @@ describe("Issue #868 — justify first line to full content width on indented pa
       paragraphEndsWithLineBreak: false,
     });
 
-    expect(lineEl.style.wordSpacing).toBe("-2px");
+    expect(lineEl.style.wordSpacing).toBe("0");
     const paintedRun = (lineEl as unknown as FakeElement).children.at(0);
     expect(paintedRun?.children.at(0)?.style.wordSpacing).toBe("-2px");
     expect(paintedRun?.children.at(1)?.textContent).toBe("\u00a0");
     expect(paintedRun?.children.at(1)?.style.wordSpacing).toBe("0");
+  });
+
+  test("contracts beside hanging CJK punctuation without pulling the hanging glyph inward", () => {
+    const text = `${"a ".repeat(50)}bb。`;
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-cjk-hanging",
+      runs: [{ kind: "text", text, language: { eastAsia: "zh-CN" } }],
+      attrs: { alignment: "justify", listMarker: "1.", overflowPunctuation: true },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: text.length,
+      width: 103,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 2 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    });
+
+    expect(lineEl.style.wordSpacing).toBe("0");
+    expect((lineEl as unknown as FakeElement).children.at(0)?.style.wordSpacing).toBe("-0.04px");
+  });
+
+  test("keeps MathML whitespace neutral while final text opts into contraction", () => {
+    const finalText = " alpha beta";
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-final-line-math-neutral-spacing",
+      runs: [
+        {
+          kind: "math",
+          display: "inline",
+          ommlXml:
+            '<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"><m:r><m:t>m n\u00a0o\u2003p</m:t></m:r></m:oMath>',
+          plainText: "m n\u00a0o\u2003p",
+        },
+        { kind: "text", text: finalText },
+      ],
+      attrs: { alignment: "justify", listMarker: "1." },
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: finalText.length,
+      width: 102,
+      ascent: 10,
+      descent: 3,
+      lineHeight: 14,
+      justificationPaint: { type: "space-contraction", contractionPx: 2 },
+    };
+
+    const lineEl = renderLine(block, line, "justify", fakeDocument, {
+      availableWidth: 100,
+      isLastLine: true,
+      isFirstLine: false,
+      paragraphEndsWithLineBreak: false,
+    });
+    const children = (lineEl as unknown as FakeElement).children;
+
+    expect(lineEl.style.wordSpacing).toBe("0");
+    expect(children.at(0)?.style.wordSpacing).not.toBe("-1px");
+    expect(children.at(1)?.style.wordSpacing).toBe("-1px");
   });
 
   test("counts resolved field text when compressing an overfull line", () => {
@@ -298,7 +381,8 @@ describe("Issue #868 — justify first line to full content width on indented pa
       },
     });
 
-    expect(lineEl.style.wordSpacing).toBe("-5px");
+    expect(lineEl.style.wordSpacing).toBe("0");
+    expect((lineEl as unknown as FakeElement).children.at(0)?.style.wordSpacing).toBe("-5px");
   });
 
   test("does not treat native math spaces as compressible line spaces", () => {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -10,6 +10,10 @@ import { parseXmlDocument } from "../docx/xmlParser";
 import { evaluateFieldInstruction } from "../fields/evaluateField";
 import type { FieldContext } from "../fields/fieldContext";
 import {
+  JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
+  supportsJustifiedListFinalLineContraction,
+} from "../layout-engine/justifiedLineFit";
+import {
   getListMarkerInlineWidth,
   getListMarkerVisualOffset,
   resolveListMarkerFont,
@@ -2240,37 +2244,45 @@ export function renderLine(
   const isJustify = alignment === "justify";
 
   if (isJustify && options) {
-    // Justify all lines except the last line (unless it ends with line break)
+    const firstLineIndentPx = options.isFirstLine ? (options.firstLineIndentPx ?? 0) : 0;
+    const firstLinePositiveIndentPx = Math.max(0, firstLineIndentPx);
+    const firstLineHangingPx = Math.max(0, -firstLineIndentPx);
+    const hasVisibleListMarker =
+      options.isFirstLine && block.attrs?.listMarker && !block.attrs.listMarkerHidden;
+    // A list marker consumes the hanging slot inline. When the marker starts
+    // before the content edge, its negative margin cancels the part of that
+    // slot outside the paragraph; only the portion between the content edge
+    // and the body start can expand the line box. Letting the full hanging
+    // value expand a zero-left list pushed justified text past the right
+    // margin by exactly one hanging slot.
+    const firstLineHangingExpansionPx = hasVisibleListMarker
+      ? Math.min(firstLineHangingPx, Math.max(0, options.leftIndentPx ?? 0))
+      : firstLineHangingPx;
+    // Keep the explicit word-spacing budget identical to the measurer's
+    // first-line width. The line box itself stays at the full paragraph
+    // width because CSS text-indent consumes the positive first-line region.
+    // Counting that region again here lets tab-bearing justified lines
+    // distribute it as extra word spacing, shifting their right edge past
+    // the paragraph margin by exactly the first-line indent.
+    const justifyCapacityPx =
+      options.availableWidth - firstLinePositiveIndentPx + firstLineHangingExpansionPx;
+    const overfullPx = line.width - justifyCapacityPx;
+    const shrinkableSpaces = countShrinkableSpaces(
+      runsForLine.filter((run) => !isTextRun(run) || !isCollapsedLineEdgeSpaceRun(run)),
+      options.context,
+    );
+    // Underfull final lines remain ragged, while a final line that the
+    // measurer admitted through bounded contraction must paint inside the
+    // same right edge as every other line.
     const shouldJustify = !options.isLastLine || options.paragraphEndsWithLineBreak;
+    const shouldCompressFinalLine =
+      options.isLastLine &&
+      supportsJustifiedListFinalLineContraction(block) &&
+      overfullPx > RIGHT_EDGE_EPSILON_PX &&
+      overfullPx <= justifyCapacityPx * JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO &&
+      shrinkableSpaces > 0;
 
-    if (shouldJustify) {
-      const firstLineIndentPx = options.isFirstLine ? (options.firstLineIndentPx ?? 0) : 0;
-      const firstLinePositiveIndentPx = Math.max(0, firstLineIndentPx);
-      const firstLineHangingPx = Math.max(0, -firstLineIndentPx);
-      const hasVisibleListMarker =
-        options.isFirstLine && block.attrs?.listMarker && !block.attrs.listMarkerHidden;
-      // A list marker consumes the hanging slot inline. When the marker starts
-      // before the content edge, its negative margin cancels the part of that
-      // slot outside the paragraph; only the portion between the content edge
-      // and the body start can expand the line box. Letting the full hanging
-      // value expand a zero-left list pushed justified text past the right
-      // margin by exactly one hanging slot.
-      const firstLineHangingExpansionPx = hasVisibleListMarker
-        ? Math.min(firstLineHangingPx, Math.max(0, options.leftIndentPx ?? 0))
-        : firstLineHangingPx;
-      // Keep the explicit word-spacing budget identical to the measurer's
-      // first-line width. The line box itself stays at the full paragraph
-      // width because CSS text-indent consumes the positive first-line region.
-      // Counting that region again here lets tab-bearing justified lines
-      // distribute it as extra word spacing, shifting their right edge past
-      // the paragraph margin by exactly the first-line indent.
-      const justifyCapacityPx =
-        options.availableWidth - firstLinePositiveIndentPx + firstLineHangingExpansionPx;
-      const overfullPx = line.width - justifyCapacityPx;
-      const shrinkableSpaces = countShrinkableSpaces(
-        runsForLine.filter((run) => !isTextRun(run) || !isCollapsedLineEdgeSpaceRun(run)),
-        options.context,
-      );
+    if (shouldJustify || shouldCompressFinalLine) {
       if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
         lineEl.style.textAlign = "left";
         lineEl.style.textAlignLast = "auto";

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -751,7 +751,7 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
       host: anchor,
       text: paintedText,
       doc,
-      contractedWordSpacing,
+      ...(contractedWordSpacing !== undefined ? { contractedWordSpacing } : {}),
     });
     // TOC entries opt out of the Hyperlink character style — Word renders
     // them in the paragraph's own colour, no underline. The bridge sets
@@ -783,7 +783,7 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
       host: span,
       text: paintedText,
       doc,
-      contractedWordSpacing,
+      ...(contractedWordSpacing !== undefined ? { contractedWordSpacing } : {}),
     });
   }
   applyWhitespaceUnderline(span, run);
@@ -1303,7 +1303,7 @@ function renderFieldRun(
   };
   if (resolvedRun.forceComplexScript && hasComplexScriptFormatting(resolvedRun)) {
     return renderTextRun(applyComplexScriptFormatting(resolvedRun, resolvedRun), doc, {
-      visualSpaceContractionPx,
+      ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
     });
   }
 
@@ -1341,7 +1341,7 @@ function renderFieldRun(
       );
       wrapper.append(
         renderTextRun(segmentRun, doc, {
-          visualSpaceContractionPx,
+          ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
           ancestorHorizontalScaleFactor: horizontalScaleFactor,
         }),
       );
@@ -1349,7 +1349,9 @@ function renderFieldRun(
     return wrapper;
   }
 
-  return renderTextRun(resolvedRun, doc, { visualSpaceContractionPx });
+  return renderTextRun(resolvedRun, doc, {
+    ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
+  });
 }
 
 /**
@@ -2204,7 +2206,10 @@ export function renderLine(
       run.hyperlink && options?.leftToRightDisplayedUrlHyperlinks?.has(run.hyperlink)
         ? LEFT_TO_RIGHT_DIRECTION
         : undefined;
-    const runEl = renderTextRun(run, doc, { hyperlinkDirection, visualSpaceContractionPx });
+    const runEl = renderTextRun(run, doc, {
+      ...(hyperlinkDirection !== undefined ? { hyperlinkDirection } : {}),
+      ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
+    });
     if (collapsedLeadingSpaceRuns.has(run)) {
       runEl.dataset["collapsedLeadingSpaces"] = "true";
     }
@@ -2589,7 +2594,7 @@ export function renderLine(
             lineEl.append(
               renderFieldRun(next, doc, {
                 context: options.context,
-                visualSpaceContractionPx,
+                ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
               }),
             );
           } else if (isImageRun(next)) {
@@ -2703,7 +2708,7 @@ export function renderLine(
       // Render field run with context for PAGE/NUMPAGES substitution
       const runEl = renderFieldRun(run, doc, {
         context: options.context,
-        visualSpaceContractionPx,
+        ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
       });
       lineEl.append(runEl);
       if (!measureText) {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -665,8 +665,14 @@ function appendPaintedText({
   doc,
   contractedWordSpacing,
 }: AppendPaintedTextOptions): void {
-  if (!contractedWordSpacing || !HAS_NON_COMPRESSIBLE_WHITESPACE_PATTERN.test(text)) {
+  if (!contractedWordSpacing) {
     host.textContent = text;
+    return;
+  }
+
+  if (!HAS_NON_COMPRESSIBLE_WHITESPACE_PATTERN.test(text)) {
+    host.textContent = text;
+    host.style.wordSpacing = countCompressibleSpaces(text) > 0 ? contractedWordSpacing : "0";
     return;
   }
 
@@ -2326,23 +2332,31 @@ export function renderLine(
       runsForLine.filter((run) => !isTextRun(run) || !isCollapsedLineEdgeSpaceRun(run)),
       options.context,
     );
-    // Underfull final lines remain ragged, while a final line that the
-    // measurer admitted through bounded contraction must paint inside the
-    // same right edge as every other line.
+    // Underfull final lines remain ragged. A measured final-line paint plan
+    // contracts ordinary spaces only; any separately admitted hanging glyph
+    // remains outside the content edge.
     const shouldJustify = !options.isLastLine || options.paragraphEndsWithLineBreak;
+    const finalContractionPx =
+      line.justificationPaint?.type === "space-contraction"
+        ? line.justificationPaint.contractionPx
+        : undefined;
     const shouldCompressFinalLine =
       options.isLastLine &&
-      line.justificationShrinkBudgetPx !== undefined &&
+      finalContractionPx !== undefined &&
+      finalContractionPx > RIGHT_EDGE_EPSILON_PX &&
       overfullPx > RIGHT_EDGE_EPSILON_PX &&
-      overfullPx <= line.justificationShrinkBudgetPx &&
       shrinkableSpaces > 0;
 
     if (shouldJustify || shouldCompressFinalLine) {
-      if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
+      const contractionPx = shouldCompressFinalLine ? finalContractionPx : overfullPx;
+      if (contractionPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
         lineEl.style.textAlign = "left";
         lineEl.style.textAlignLast = "auto";
-        contractedWordSpacing = `${-overfullPx / shrinkableSpaces}px`;
-        lineEl.style.wordSpacing = contractedWordSpacing;
+        contractedWordSpacing = `${-contractionPx / shrinkableSpaces}px`;
+        // Keep non-text hosts (MathML, images, tabs) neutral. Text and field
+        // segments opt into this contraction only where they contain counted
+        // ASCII spaces.
+        lineEl.style.wordSpacing = "0";
       } else if (hasTabRuns && shrinkableSpaces > 0 && -overfullPx > RIGHT_EDGE_EPSILON_PX) {
         // CSS justification does not expand preserved spaces reliably when a
         // line also contains an inline tab span. The layout engine has already

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -10,10 +10,6 @@ import { parseXmlDocument } from "../docx/xmlParser";
 import { evaluateFieldInstruction } from "../fields/evaluateField";
 import type { FieldContext } from "../fields/fieldContext";
 import {
-  JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
-  supportsJustifiedListFinalLineContraction,
-} from "../layout-engine/justifiedLineFit";
-import {
   getListMarkerInlineWidth,
   getListMarkerVisualOffset,
   resolveListMarkerFont,
@@ -648,11 +644,49 @@ function applyPmPositions(element: HTMLElement, pmStart?: number, pmEnd?: number
 /**
  * Render a text run
  */
-function renderTextRun(
-  run: TextRun,
-  doc: Document,
-  hyperlinkDirection?: typeof LEFT_TO_RIGHT_DIRECTION,
-): HTMLElement {
+type RenderTextRunOptions = {
+  hyperlinkDirection?: typeof LEFT_TO_RIGHT_DIRECTION;
+  contractedWordSpacing?: string;
+};
+
+const NON_COMPRESSIBLE_WHITESPACE_PATTERN = /([^\S ]+)/gu;
+const HAS_NON_COMPRESSIBLE_WHITESPACE_PATTERN = /[^\S ]/u;
+
+type AppendPaintedTextOptions = {
+  host: HTMLElement;
+  text: string;
+  doc: Document;
+  contractedWordSpacing?: string;
+};
+
+function appendPaintedText({
+  host,
+  text,
+  doc,
+  contractedWordSpacing,
+}: AppendPaintedTextOptions): void {
+  if (!contractedWordSpacing || !HAS_NON_COMPRESSIBLE_WHITESPACE_PATTERN.test(text)) {
+    host.textContent = text;
+    return;
+  }
+
+  // CSS word-spacing also reaches fixed separators in some engines. Keep the
+  // host neutral, then opt only segments containing ordinary ASCII spaces
+  // into the contraction measured for this line.
+  host.style.wordSpacing = "0";
+  for (const segment of text.split(NON_COMPRESSIBLE_WHITESPACE_PATTERN)) {
+    if (segment.length === 0) {
+      continue;
+    }
+    const segmentEl = doc.createElement("span");
+    segmentEl.textContent = segment;
+    segmentEl.style.wordSpacing =
+      countCompressibleSpaces(segment) > 0 ? contractedWordSpacing : "0";
+    host.append(segmentEl);
+  }
+}
+
+function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptions): HTMLElement {
   const span = doc.createElement("span");
   span.className = `${PARAGRAPH_CLASS_NAMES.run} ${PARAGRAPH_CLASS_NAMES.text}`;
 
@@ -685,7 +719,7 @@ function renderTextRun(
   if (run.hyperlink && hyperlinkHref !== undefined) {
     const anchor = doc.createElement("a");
     anchor.href = hyperlinkHref;
-    if (hyperlinkDirection || DISPLAYED_URL_PATTERN.test(paintedText.trim())) {
+    if (options?.hyperlinkDirection || DISPLAYED_URL_PATTERN.test(paintedText.trim())) {
       anchor.dir = LEFT_TO_RIGHT_DIRECTION;
     }
     // External links should open in a new tab
@@ -696,7 +730,12 @@ function renderTextRun(
     if (run.hyperlink.tooltip) {
       anchor.title = run.hyperlink.tooltip;
     }
-    anchor.textContent = paintedText;
+    appendPaintedText({
+      host: anchor,
+      text: paintedText,
+      doc,
+      contractedWordSpacing: options?.contractedWordSpacing,
+    });
     // TOC entries opt out of the Hyperlink character style — Word renders
     // them in the paragraph's own colour, no underline. The bridge sets
     // `noDefaultStyle: true` and strips resolved colour/underline; here we
@@ -723,8 +762,12 @@ function renderTextRun(
     }
     span.append(anchor);
   } else {
-    // Set text content
-    span.textContent = paintedText;
+    appendPaintedText({
+      host: span,
+      text: paintedText,
+      doc,
+      contractedWordSpacing: options?.contractedWordSpacing,
+    });
   }
   applyWhitespaceUnderline(span, run);
 
@@ -1218,7 +1261,16 @@ function resolveFieldText(run: FieldRun, context: RenderContext | undefined): st
   });
 }
 
-function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): HTMLElement {
+type RenderFieldRunOptions = {
+  context: RenderContext;
+  contractedWordSpacing?: string;
+};
+
+function renderFieldRun(
+  run: FieldRun,
+  doc: Document,
+  { context, contractedWordSpacing }: RenderFieldRunOptions,
+): HTMLElement {
   const text = resolveFieldText(run, context);
 
   // Spread the whole FieldRun so every RunFormatting field carries through —
@@ -1233,7 +1285,9 @@ function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): H
     text,
   };
   if (resolvedRun.forceComplexScript && hasComplexScriptFormatting(resolvedRun)) {
-    return renderTextRun(applyComplexScriptFormatting(resolvedRun, resolvedRun), doc);
+    return renderTextRun(applyComplexScriptFormatting(resolvedRun, resolvedRun), doc, {
+      contractedWordSpacing,
+    });
   }
 
   // A CJK field result is generated text inside one atomic pm range, so the
@@ -1267,12 +1321,12 @@ function renderFieldRun(run: FieldRun, doc: Document, context: RenderContext): H
         },
         segment.script,
       );
-      wrapper.append(renderTextRun(segmentRun, doc));
+      wrapper.append(renderTextRun(segmentRun, doc, { contractedWordSpacing }));
     }
     return wrapper;
   }
 
-  return renderTextRun(resolvedRun, doc);
+  return renderTextRun(resolvedRun, doc, { contractedWordSpacing });
 }
 
 /**
@@ -1378,7 +1432,7 @@ function renderRun(run: Run, doc: Document, context?: RenderContext): HTMLElemen
     return renderLineBreakRun(run, doc);
   }
   if (isFieldRun(run) && context) {
-    return renderFieldRun(run, doc, context);
+    return renderFieldRun(run, doc, { context });
   }
   if (isMathRun(run)) {
     return renderMathRun(run, doc);
@@ -2115,12 +2169,13 @@ export function renderLine(
     }
     return withCursiveJoiners(runEl, run, cursiveJoinerPlan, applyJoinerRunStyles, doc);
   };
+  let contractedWordSpacing: string | undefined;
   const renderLineTextRun = (run: TextRun): HTMLElement => {
     const hyperlinkDirection =
       run.hyperlink && options?.leftToRightDisplayedUrlHyperlinks?.has(run.hyperlink)
         ? LEFT_TO_RIGHT_DIRECTION
         : undefined;
-    const runEl = renderTextRun(run, doc, hyperlinkDirection);
+    const runEl = renderTextRun(run, doc, { hyperlinkDirection, contractedWordSpacing });
     if (collapsedLeadingSpaceRuns.has(run)) {
       runEl.dataset["collapsedLeadingSpaces"] = "true";
     }
@@ -2277,16 +2332,17 @@ export function renderLine(
     const shouldJustify = !options.isLastLine || options.paragraphEndsWithLineBreak;
     const shouldCompressFinalLine =
       options.isLastLine &&
-      supportsJustifiedListFinalLineContraction(block) &&
+      line.justificationShrinkBudgetPx !== undefined &&
       overfullPx > RIGHT_EDGE_EPSILON_PX &&
-      overfullPx <= justifyCapacityPx * JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO &&
+      overfullPx <= line.justificationShrinkBudgetPx &&
       shrinkableSpaces > 0;
 
     if (shouldJustify || shouldCompressFinalLine) {
       if (overfullPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
         lineEl.style.textAlign = "left";
         lineEl.style.textAlignLast = "auto";
-        lineEl.style.wordSpacing = `${-overfullPx / shrinkableSpaces}px`;
+        contractedWordSpacing = `${-overfullPx / shrinkableSpaces}px`;
+        lineEl.style.wordSpacing = contractedWordSpacing;
       } else if (hasTabRuns && shrinkableSpaces > 0 && -overfullPx > RIGHT_EDGE_EPSILON_PX) {
         // CSS justification does not expand preserved spaces reliably when a
         // line also contains an inline tab span. The layout engine has already
@@ -2493,7 +2549,9 @@ export function renderLine(
           if (isTextRun(next)) {
             lineEl.append(...withJoiners(renderLineTextRun(next), next));
           } else if (isFieldRun(next) && options?.context) {
-            lineEl.append(renderFieldRun(next, doc, options.context));
+            lineEl.append(
+              renderFieldRun(next, doc, { context: options.context, contractedWordSpacing }),
+            );
           } else if (isImageRun(next)) {
             // Floating images render in dedicated layers — skip here so we
             // don't double-render. Inline images render via getInlineImageRunKey
@@ -2603,7 +2661,10 @@ export function renderLine(
       lineEl.append(runEl);
     } else if (isFieldRun(run) && options?.context) {
       // Render field run with context for PAGE/NUMPAGES substitution
-      const runEl = renderFieldRun(run, doc, options.context);
+      const runEl = renderFieldRun(run, doc, {
+        context: options.context,
+        contractedWordSpacing,
+      });
       lineEl.append(runEl);
       if (!measureText) {
         continue;

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -1320,6 +1320,7 @@ function renderFieldRun(
     // horizontalScale lives on the wrapper (inline-block so the reserved width
     // the render loop sets via reserveScaledAdvance applies, scaleX so the
     // segments scale uniformly); the segments drop it to avoid double-scaling.
+    const horizontalScaleFactor = getHorizontalScaleFactor(resolvedRun.horizontalScale);
     applyHorizontalScaleTransform(wrapper, resolvedRun.horizontalScale);
     // The pm range lives on the wrapper; segments carry none (the field is one
     // atomic unit), so drop pmStart/pmEnd (and the wrapper-applied scale) before

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -617,16 +617,28 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   }
 }
 
-function reserveScaledAdvance(
-  element: HTMLElement,
-  unscaledWidth: number,
-  horizontalScale: number | undefined,
-): void {
+type ReserveScaledAdvanceOptions = {
+  element: HTMLElement;
+  unscaledWidth: number;
+  horizontalScale?: number;
+  visualSpaceContractionPx?: number;
+};
+
+function reserveScaledAdvance({
+  element,
+  unscaledWidth,
+  horizontalScale,
+  visualSpaceContractionPx,
+}: ReserveScaledAdvanceOptions): number {
   const horizontalScaleFactor = getHorizontalScaleFactor(horizontalScale);
-  if (horizontalScaleFactor === 1) {
-    return;
+  const visualAdvance = Math.max(
+    0,
+    unscaledWidth * horizontalScaleFactor - (visualSpaceContractionPx ?? 0),
+  );
+  if (horizontalScaleFactor !== 1) {
+    element.style.width = `${visualAdvance}px`;
   }
-  element.style.width = `${unscaledWidth * horizontalScaleFactor}px`;
+  return visualAdvance;
 }
 
 /**
@@ -1794,6 +1806,23 @@ function countShrinkableSpaces(runs: Run[], context: RenderContext | undefined):
   return count;
 }
 
+type RunVisualSpaceContractionOptions = {
+  text: string;
+  horizontalScale?: number;
+  visualSpaceContractionPx?: number;
+};
+
+function runVisualSpaceContraction({
+  text,
+  horizontalScale,
+  visualSpaceContractionPx,
+}: RunVisualSpaceContractionOptions): number {
+  if (visualSpaceContractionPx === undefined || getHorizontalScaleFactor(horizontalScale) === 0) {
+    return 0;
+  }
+  return countCompressibleSpaces(text) * visualSpaceContractionPx;
+}
+
 /**
  * Build the shared measurement style from a paintable text run.
  */
@@ -2676,8 +2705,17 @@ export function renderLine(
         fontFamily,
         runMeasureStyle(run),
       );
-      reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
-      currentX += measuredWidth * getHorizontalScaleFactor(run.horizontalScale);
+      const runContractionPx = runVisualSpaceContraction({
+        text: run.text,
+        ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+        ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
+      });
+      currentX += reserveScaledAdvance({
+        element: runEl,
+        unscaledWidth: measuredWidth,
+        ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+        ...(runContractionPx > 0 ? { visualSpaceContractionPx: runContractionPx } : {}),
+      });
     } else if (isImageRun(run)) {
       // Skip floating images - they're rendered separately at page level.
       // Exception: inside table cells, floating images must render in-flow
@@ -2725,8 +2763,17 @@ export function renderLine(
         fontFamily,
         runMeasureStyle(run),
       );
-      reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
-      currentX += measuredWidth * getHorizontalScaleFactor(run.horizontalScale);
+      const runContractionPx = runVisualSpaceContraction({
+        text: fieldText,
+        ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+        ...(visualSpaceContractionPx !== undefined ? { visualSpaceContractionPx } : {}),
+      });
+      currentX += reserveScaledAdvance({
+        element: runEl,
+        unscaledWidth: measuredWidth,
+        ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+        ...(runContractionPx > 0 ? { visualSpaceContractionPx: runContractionPx } : {}),
+      });
     } else if (isMathRun(run)) {
       const runEl = renderMathRun(run, doc);
       lineEl.append(runEl);
@@ -2739,8 +2786,11 @@ export function renderLine(
         run.fontFamily ?? "Cambria Math",
         runMeasureStyle(run),
       );
-      reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
-      currentX += measuredWidth * getHorizontalScaleFactor(run.horizontalScale);
+      currentX += reserveScaledAdvance({
+        element: runEl,
+        unscaledWidth: measuredWidth,
+        ...(run.horizontalScale !== undefined ? { horizontalScale: run.horizontalScale } : {}),
+      });
     } else {
       // Fallback for unknown run types
       const runEl = renderRun(run, doc, options?.context);

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -646,7 +646,8 @@ function applyPmPositions(element: HTMLElement, pmStart?: number, pmEnd?: number
  */
 type RenderTextRunOptions = {
   hyperlinkDirection?: typeof LEFT_TO_RIGHT_DIRECTION;
-  contractedWordSpacing?: string;
+  visualSpaceContractionPx?: number;
+  ancestorHorizontalScaleFactor?: number;
 };
 
 const NON_COMPRESSIBLE_WHITESPACE_PATTERN = /([^\S ]+)/gu;
@@ -717,6 +718,16 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
   applyRunStyles(span, run);
   applyPmPositions(span, run.pmStart, run.pmEnd);
   const paintedText = toPaintedText(run.text);
+  const visualSpaceContractionPx = options?.visualSpaceContractionPx;
+  const effectiveHorizontalScaleFactor =
+    getHorizontalScaleFactor(run.horizontalScale) * (options?.ancestorHorizontalScaleFactor ?? 1);
+  // CSS transforms scale word-spacing with the glyphs. Convert the visual
+  // per-space plan back into the pre-transform length so every counted space
+  // contributes exactly the contraction admitted by measurement.
+  const contractedWordSpacing =
+    visualSpaceContractionPx === undefined || effectiveHorizontalScaleFactor === 0
+      ? undefined
+      : `${-visualSpaceContractionPx / effectiveHorizontalScaleFactor}px`;
 
   const isBookmarkTarget = run.hyperlink?.href.startsWith("#") === true;
   const hyperlinkHref = resolveHyperlinkHref(run.hyperlink?.href, isBookmarkTarget);
@@ -740,7 +751,7 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
       host: anchor,
       text: paintedText,
       doc,
-      contractedWordSpacing: options?.contractedWordSpacing,
+      contractedWordSpacing,
     });
     // TOC entries opt out of the Hyperlink character style — Word renders
     // them in the paragraph's own colour, no underline. The bridge sets
@@ -772,7 +783,7 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
       host: span,
       text: paintedText,
       doc,
-      contractedWordSpacing: options?.contractedWordSpacing,
+      contractedWordSpacing,
     });
   }
   applyWhitespaceUnderline(span, run);
@@ -1269,13 +1280,13 @@ function resolveFieldText(run: FieldRun, context: RenderContext | undefined): st
 
 type RenderFieldRunOptions = {
   context: RenderContext;
-  contractedWordSpacing?: string;
+  visualSpaceContractionPx?: number;
 };
 
 function renderFieldRun(
   run: FieldRun,
   doc: Document,
-  { context, contractedWordSpacing }: RenderFieldRunOptions,
+  { context, visualSpaceContractionPx }: RenderFieldRunOptions,
 ): HTMLElement {
   const text = resolveFieldText(run, context);
 
@@ -1292,7 +1303,7 @@ function renderFieldRun(
   };
   if (resolvedRun.forceComplexScript && hasComplexScriptFormatting(resolvedRun)) {
     return renderTextRun(applyComplexScriptFormatting(resolvedRun, resolvedRun), doc, {
-      contractedWordSpacing,
+      visualSpaceContractionPx,
     });
   }
 
@@ -1327,12 +1338,17 @@ function renderFieldRun(
         },
         segment.script,
       );
-      wrapper.append(renderTextRun(segmentRun, doc, { contractedWordSpacing }));
+      wrapper.append(
+        renderTextRun(segmentRun, doc, {
+          visualSpaceContractionPx,
+          ancestorHorizontalScaleFactor: horizontalScaleFactor,
+        }),
+      );
     }
     return wrapper;
   }
 
-  return renderTextRun(resolvedRun, doc, { contractedWordSpacing });
+  return renderTextRun(resolvedRun, doc, { visualSpaceContractionPx });
 }
 
 /**
@@ -1761,8 +1777,14 @@ function countShrinkableSpaces(runs: Run[], context: RenderContext | undefined):
   let count = 0;
   for (const run of runs) {
     if (isTextRun(run)) {
+      if (getHorizontalScaleFactor(run.horizontalScale) === 0) {
+        continue;
+      }
       count += countCompressibleSpaces(run.text ?? "");
     } else if (isFieldRun(run)) {
+      if (getHorizontalScaleFactor(run.horizontalScale) === 0) {
+        continue;
+      }
       count += countCompressibleSpaces(resolveFieldText(run, context));
     }
   }
@@ -2175,13 +2197,13 @@ export function renderLine(
     }
     return withCursiveJoiners(runEl, run, cursiveJoinerPlan, applyJoinerRunStyles, doc);
   };
-  let contractedWordSpacing: string | undefined;
+  let visualSpaceContractionPx: number | undefined;
   const renderLineTextRun = (run: TextRun): HTMLElement => {
     const hyperlinkDirection =
       run.hyperlink && options?.leftToRightDisplayedUrlHyperlinks?.has(run.hyperlink)
         ? LEFT_TO_RIGHT_DIRECTION
         : undefined;
-    const runEl = renderTextRun(run, doc, { hyperlinkDirection, contractedWordSpacing });
+    const runEl = renderTextRun(run, doc, { hyperlinkDirection, visualSpaceContractionPx });
     if (collapsedLeadingSpaceRuns.has(run)) {
       runEl.dataset["collapsedLeadingSpaces"] = "true";
     }
@@ -2352,7 +2374,7 @@ export function renderLine(
       if (contractionPx > RIGHT_EDGE_EPSILON_PX && shrinkableSpaces > 0) {
         lineEl.style.textAlign = "left";
         lineEl.style.textAlignLast = "auto";
-        contractedWordSpacing = `${-contractionPx / shrinkableSpaces}px`;
+        visualSpaceContractionPx = contractionPx / shrinkableSpaces;
         // Keep non-text hosts (MathML, images, tabs) neutral. Text and field
         // segments opt into this contraction only where they contain counted
         // ASCII spaces.
@@ -2564,7 +2586,10 @@ export function renderLine(
             lineEl.append(...withJoiners(renderLineTextRun(next), next));
           } else if (isFieldRun(next) && options?.context) {
             lineEl.append(
-              renderFieldRun(next, doc, { context: options.context, contractedWordSpacing }),
+              renderFieldRun(next, doc, {
+                context: options.context,
+                visualSpaceContractionPx,
+              }),
             );
           } else if (isImageRun(next)) {
             // Floating images render in dedicated layers — skip here so we
@@ -2677,7 +2702,7 @@ export function renderLine(
       // Render field run with context for PAGE/NUMPAGES substitution
       const runEl = renderFieldRun(run, doc, {
         context: options.context,
-        contractedWordSpacing,
+        visualSpaceContractionPx,
       });
       lineEl.append(runEl);
       if (!measureText) {


### PR DESCRIPTION
## Summary

- bound justified list-continuation fitting by measured ASCII-space contraction capacity
- carry an explicit paint plan only when final-text contraction admits the candidate
- keep hanging punctuation, MathML, non-ASCII whitespace, and zero-scale runs outside the contraction budget
- preserve contracted visual advances through scaled text and field hosts, including following tabs and siblings
- share final-tail semantics across measurement and rendered page breaks

## Visual validation

A legal-document parity case improved from 0.84 to 0.96 geometry similarity: divergences fell from 6 to 1 while preserving all 25 lines and the single-page count. Raster similarity improved from 0.9600 to 0.9604.

## Validation

- 144 focused measurement and justification tests pass
- 27 adjacent horizontal-scale, decimal-tab, and line-box tests pass
- focused lint, formatting, and diff hygiene pass
- broad validation runs in CI

CC on behalf of jan-kubica
