### PR TITLE
fix: preserve footnote marker punctuation adjacency

### DIFF
--- a/.changeset/calm-footnote-punctuation.md
+++ b/.changeset/calm-footnote-punctuation.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep authored punctuation adjacent to generated footnote numbers.

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { panic } from "better-result";
 
 import {
   fixedCharWidth,
@@ -16,7 +17,7 @@ function presentedFootnoteParagraph(runs: Run[]): ParagraphBlock {
     8,
   ).at(0);
   if (paragraph?.kind !== "paragraph") {
-    throw new Error("Expected a paragraph block");
+    panic("Expected a paragraph block");
   }
   return paragraph;
 }
@@ -386,7 +387,7 @@ describe("footnote layout", () => {
     const paragraph = applyFootnotePresentation(blocks, 8).at(0);
     expect(paragraph?.kind).toBe("paragraph");
     if (paragraph?.kind !== "paragraph") {
-      throw new Error("Expected a paragraph block");
+      panic("Expected a paragraph block");
     }
 
     expect(paragraph.runs.at(0)).toMatchObject({

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
@@ -391,6 +391,40 @@ describe("footnote layout", () => {
     });
   });
 
+  test.each([") Footnote text", "）脚注テキスト"])(
+    "does not insert a space before authored punctuation: %s",
+    (text) => {
+      const blocks: FlowBlock[] = [
+        {
+          kind: "paragraph",
+          id: "footnote-text",
+          runs: [
+            {
+              kind: "text",
+              text,
+              fontFamily: "Times New Roman",
+              fontSize: 10,
+            },
+          ],
+        },
+      ];
+
+      const paragraph = applyFootnotePresentation(blocks, 8).at(0);
+      expect(paragraph?.kind).toBe("paragraph");
+      if (paragraph?.kind !== "paragraph") {
+        throw new Error("Expected a paragraph block");
+      }
+
+      expect(paragraph.runs.at(0)).toMatchObject({
+        kind: "text",
+        text: "8",
+        fontFamily: "Times New Roman",
+        fontSize: 10,
+        superscript: true,
+      });
+    },
+  );
+
   test("keeps the footnote number alternate paired with its primary source", () => {
     const blocks: FlowBlock[] = [
       {

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
@@ -4,11 +4,49 @@ import {
   fixedCharWidth,
   withFakeTextMeasure,
 } from "../../layout-engine/measure/__tests__/fakeTextMeasure";
-import type { FlowBlock } from "../../layout-engine/types";
+import type { FlowBlock, ParagraphBlock, Run } from "../../layout-engine/types";
 import type { Footnote } from "../../types/document";
 import { applyFootnotePresentation, convertFootnoteToContent } from "./footnoteLayout";
 
 const fakeMeasure = { charWidth: fixedCharWidth(5) };
+
+function presentedFootnoteParagraph(runs: Run[]): ParagraphBlock {
+  const paragraph = applyFootnotePresentation(
+    [{ kind: "paragraph", id: "footnote-text", runs }],
+    8,
+  ).at(0);
+  if (paragraph?.kind !== "paragraph") {
+    throw new Error("Expected a paragraph block");
+  }
+  return paragraph;
+}
+
+function visibleRunSequence(runs: Run[]): string {
+  return runs
+    .map((run) => {
+      switch (run.kind) {
+        case "text":
+          return run.text;
+        case "tab":
+          return "\t";
+        case "image":
+          return "\ufffc";
+        case "lineBreak":
+          return "\n";
+        case "renderedPageBreak":
+          return "";
+        case "field":
+          return run.fallback || "1";
+        case "math":
+          return run.plainText;
+        default: {
+          const exhaustiveRun: never = run;
+          return exhaustiveRun;
+        }
+      }
+    })
+    .join("");
+}
 
 const footnoteWithTable: Footnote = {
   type: "footnote",
@@ -358,6 +396,7 @@ describe("footnote layout", () => {
       fontSize: 10,
       superscript: true,
     });
+    expect(visibleRunSequence(paragraph.runs)).toBe("8 Insert the name of the legal entity.");
   });
 
   test("adds one separator space when footnote text has no leading space", () => {
@@ -389,39 +428,120 @@ describe("footnote layout", () => {
       fontSize: 10,
       superscript: true,
     });
+    expect(visibleRunSequence(paragraph.runs)).toBe("8 Footnote text");
   });
 
-  test.each([") Footnote text", "）脚注テキスト"])(
-    "does not insert a space before authored punctuation: %s",
-    (text) => {
-      const blocks: FlowBlock[] = [
-        {
-          kind: "paragraph",
-          id: "footnote-text",
-          runs: [
-            {
-              kind: "text",
-              text,
-              fontFamily: "Times New Roman",
-              fontSize: 10,
-            },
-          ],
-        },
-      ];
+  test.each([
+    ") Footnote text",
+    "）脚注テキスト",
+    ". Footnote text",
+    "。脚注テキスト",
+    ": Label",
+    "：ラベル",
+  ])("does not insert a space before authored punctuation: %s", (text) => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "footnote-text",
+        runs: [
+          {
+            kind: "text",
+            text,
+            fontFamily: "Times New Roman",
+            fontSize: 10,
+          },
+        ],
+      },
+    ];
 
-      const paragraph = applyFootnotePresentation(blocks, 8).at(0);
-      expect(paragraph?.kind).toBe("paragraph");
-      if (paragraph?.kind !== "paragraph") {
-        throw new Error("Expected a paragraph block");
-      }
+    const paragraph = applyFootnotePresentation(blocks, 8).at(0);
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected a paragraph block");
+    }
 
-      expect(paragraph.runs.at(0)).toMatchObject({
-        kind: "text",
-        text: "8",
-        fontFamily: "Times New Roman",
-        fontSize: 10,
-        superscript: true,
-      });
+    expect(paragraph.runs.at(0)).toMatchObject({
+      kind: "text",
+      text: "8",
+      fontFamily: "Times New Roman",
+      fontSize: 10,
+      superscript: true,
+    });
+    expect(visibleRunSequence(paragraph.runs)).toBe(`8${text}`);
+  });
+
+  test.each([
+    "(See clause 4)",
+    "（条項4参照）",
+    "“Quoted authority”",
+    "— explanatory text",
+    "_connector",
+  ])("keeps a separator before opening or non-attaching punctuation: %s", (text) => {
+    const paragraph = presentedFootnoteParagraph([{ kind: "text", text }]);
+
+    expect(visibleRunSequence(paragraph.runs)).toBe(`8 ${text}`);
+  });
+
+  test.each([
+    {
+      name: "empty run before closing suffix",
+      runs: [
+        { kind: "text", text: "" },
+        { kind: "text", text: ") Footnote text" },
+      ],
+      expected: "8) Footnote text",
+    },
+    {
+      name: "split authored whitespace",
+      runs: [
+        { kind: "text", text: "" },
+        { kind: "text", text: " " },
+        { kind: "text", text: "Footnote text" },
+      ],
+      expected: "8 Footnote text",
+    },
+  ] satisfies { name: string; runs: Run[]; expected: string }[])(
+    "resolves adjacency from the first visible text across $name",
+    ({ runs, expected }) => {
+      const paragraph = presentedFootnoteParagraph(runs);
+
+      expect(visibleRunSequence(paragraph.runs)).toBe(expected);
+    },
+  );
+
+  test.each([
+    {
+      name: "tab separator",
+      runs: [{ kind: "tab" }, { kind: "text", text: "Footnote text" }],
+      expected: "8\tFootnote text",
+    },
+    {
+      name: "field closing suffix",
+      runs: [
+        { kind: "field", fieldType: "OTHER", fallback: ")" },
+        { kind: "text", text: " Footnote text" },
+      ],
+      expected: "8) Footnote text",
+    },
+    {
+      name: "ordinary field text",
+      runs: [{ kind: "field", fieldType: "OTHER", fallback: "Authority" }],
+      expected: "8 Authority",
+    },
+    {
+      name: "inline image",
+      runs: [
+        { kind: "image", src: "data:image/png;base64,", width: 10, height: 10 },
+        { kind: "text", text: "Caption" },
+      ],
+      expected: "8 \ufffcCaption",
+    },
+  ] satisfies { name: string; runs: Run[]; expected: string }[])(
+    "uses the first paint-bearing non-text run for $name",
+    ({ runs, expected }) => {
+      const paragraph = presentedFootnoteParagraph(runs);
+
+      expect(visibleRunSequence(paragraph.runs)).toBe(expected);
     },
   );
 

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -623,7 +623,8 @@ function createFootnoteNumberRun(displayNumber: number, paragraph: ParagraphBloc
   const firstFormattedRun = paragraph.runs.find(
     (run) => run.kind === "text" || run.kind === "tab" || run.kind === "field",
   );
-  const text = firstTextRun?.text.match(/^\s/u) ? `${displayNumber}` : `${displayNumber} `;
+  const hasAuthoredSeparator = /^[\s\p{P}]/u.test(firstTextRun?.text ?? "");
+  const text = hasAuthoredSeparator ? `${displayNumber}` : `${displayNumber} `;
   const numberRun: TextRun = {
     kind: "text",
     text,

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -624,7 +624,7 @@ function createFootnoteNumberRun(displayNumber: number, paragraph: ParagraphBloc
     (run) => run.kind === "text" || run.kind === "tab" || run.kind === "field",
   );
   const suffix = resolveFootnoteNumberSuffix(paragraph.runs);
-  const text = `${displayNumber}${suffix === "space" ? " " : ""}`;
+  const text = `${displayNumber}${suffix === FOOTNOTE_NUMBER_SUFFIX.SEPARATED ? " " : ""}`;
   const numberRun: TextRun = {
     kind: "text",
     text,
@@ -645,7 +645,12 @@ function createFootnoteNumberRun(displayNumber: number, paragraph: ParagraphBloc
   return numberRun;
 }
 
-type FootnoteNumberSuffix = "none" | "space";
+const FOOTNOTE_NUMBER_SUFFIX = {
+  ATTACHED: "none",
+  SEPARATED: "space",
+} as const;
+
+type FootnoteNumberSuffix = (typeof FOOTNOTE_NUMBER_SUFFIX)[keyof typeof FOOTNOTE_NUMBER_SUFFIX];
 
 // Closing/final punctuation belongs to the reconstructed marker. Sentence
 // terminals and common international comma/colon/semicolon forms can also be
@@ -657,9 +662,9 @@ const LEADING_WHITESPACE_PATTERN = /^\s/u;
 
 function resolveTextFootnoteNumberSuffix(text: string): FootnoteNumberSuffix {
   if (LEADING_WHITESPACE_PATTERN.test(text) || ATTACHED_FOOTNOTE_SUFFIX_PATTERN.test(text)) {
-    return "none";
+    return FOOTNOTE_NUMBER_SUFFIX.ATTACHED;
   }
-  return "space";
+  return FOOTNOTE_NUMBER_SUFFIX.SEPARATED;
 }
 
 function resolveRunFootnoteNumberSuffix(run: Run): FootnoteNumberSuffix | undefined {
@@ -668,13 +673,13 @@ function resolveRunFootnoteNumberSuffix(run: Run): FootnoteNumberSuffix | undefi
       return run.text.length === 0 ? undefined : resolveTextFootnoteNumberSuffix(run.text);
     case "tab":
     case "lineBreak":
-      return "none";
+      return FOOTNOTE_NUMBER_SUFFIX.ATTACHED;
     case "field":
       return resolveTextFootnoteNumberSuffix(run.fallback || "1");
     case "image":
-      return isFloatingImageRun(run) ? undefined : "space";
+      return isFloatingImageRun(run) ? undefined : FOOTNOTE_NUMBER_SUFFIX.SEPARATED;
     case "math":
-      return "space";
+      return FOOTNOTE_NUMBER_SUFFIX.SEPARATED;
     case "renderedPageBreak":
       return undefined;
     default: {
@@ -691,7 +696,7 @@ function resolveFootnoteNumberSuffix(runs: Run[]): FootnoteNumberSuffix {
       return suffix;
     }
   }
-  return "space";
+  return FOOTNOTE_NUMBER_SUFFIX.SEPARATED;
 }
 
 function applyFootnoteBlockPresentation(block: FlowBlock): FlowBlock {

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -19,6 +19,7 @@ import type {
   TextRun,
   FootnoteContent,
 } from "../../layout-engine/types";
+import { isFloatingImageRun } from "../../layout-engine/types";
 import {
   DEFAULT_TEXTBOX_MARGINS as TEXTBOX_MARGINS,
   FOOTNOTE_ENTRY_MARGIN_BOTTOM,
@@ -619,12 +620,11 @@ export function applyFootnotePresentation(blocks: FlowBlock[], displayNumber: nu
 }
 
 function createFootnoteNumberRun(displayNumber: number, paragraph: ParagraphBlock): TextRun {
-  const firstTextRun = paragraph.runs.find((run) => run.kind === "text");
   const firstFormattedRun = paragraph.runs.find(
     (run) => run.kind === "text" || run.kind === "tab" || run.kind === "field",
   );
-  const hasAuthoredSeparator = /^[\s\p{P}]/u.test(firstTextRun?.text ?? "");
-  const text = hasAuthoredSeparator ? `${displayNumber}` : `${displayNumber} `;
+  const suffix = resolveFootnoteNumberSuffix(paragraph.runs);
+  const text = `${displayNumber}${suffix === "space" ? " " : ""}`;
   const numberRun: TextRun = {
     kind: "text",
     text,
@@ -643,6 +643,55 @@ function createFootnoteNumberRun(displayNumber: number, paragraph: ParagraphBloc
     numberRun.alternateFontFamily = alternateFontFamily;
   }
   return numberRun;
+}
+
+type FootnoteNumberSuffix = "none" | "space";
+
+// Closing/final punctuation belongs to the reconstructed marker. Sentence
+// terminals and common international comma/colon/semicolon forms can also be
+// authored label suffixes. Opening punctuation/quotes, dashes, and connectors
+// deliberately stay outside this set because they commonly begin ordinary prose.
+const ATTACHED_FOOTNOTE_SUFFIX_PATTERN =
+  /^(?:[\p{Pe}\p{Pf}\p{Sentence_Terminal}]|[,;:\u060c\u061b\u3001\uff0c\uff1a\uff1b])/u;
+const LEADING_WHITESPACE_PATTERN = /^\s/u;
+
+function resolveTextFootnoteNumberSuffix(text: string): FootnoteNumberSuffix {
+  if (LEADING_WHITESPACE_PATTERN.test(text) || ATTACHED_FOOTNOTE_SUFFIX_PATTERN.test(text)) {
+    return "none";
+  }
+  return "space";
+}
+
+function resolveRunFootnoteNumberSuffix(run: Run): FootnoteNumberSuffix | undefined {
+  switch (run.kind) {
+    case "text":
+      return run.text.length === 0 ? undefined : resolveTextFootnoteNumberSuffix(run.text);
+    case "tab":
+    case "lineBreak":
+      return "none";
+    case "field":
+      return resolveTextFootnoteNumberSuffix(run.fallback || "1");
+    case "image":
+      return isFloatingImageRun(run) ? undefined : "space";
+    case "math":
+      return "space";
+    case "renderedPageBreak":
+      return undefined;
+    default: {
+      const exhaustiveRun: never = run;
+      return exhaustiveRun;
+    }
+  }
+}
+
+function resolveFootnoteNumberSuffix(runs: Run[]): FootnoteNumberSuffix {
+  for (const run of runs) {
+    const suffix = resolveRunFootnoteNumberSuffix(run);
+    if (suffix !== undefined) {
+      return suffix;
+    }
+  }
+  return "space";
 }
 
 function applyFootnoteBlockPresentation(block: FlowBlock): FlowBlock {


### PR DESCRIPTION
## Summary

- keep reconstructed footnote numbers adjacent to authored closing and terminal punctuation
- preserve a separator before ordinary prose, opening punctuation, quotes, dashes, and connectors
- resolve adjacency from the first paint-bearing run across empty text, whitespace, fields, tabs, images, math, and cached page boundaries

## Visual validation

A multi-page legal document comparison eliminated its footnote-related pagination divergence. Raster similarity improved from 0.947202 to 0.947323 and differing pixels fell by 647, while the broader document geometry remained unchanged.

## Validation

- 26 focused footnote-layout tests pass with 60 assertions
- focused lint, formatting, and diff hygiene pass
- broad validation runs in CI

CC on behalf of jan-kubica


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved footnote number spacing when followed by authored punctuation.
  * Prevented unwanted spaces before closing punctuation and punctuation in international formats.
  * Preserved appropriate separators before opening or non-attaching punctuation.
  * Improved spacing detection across visible content, including line breaks, fields, images, and mathematical content.

* **Tests**
  * Added coverage for footnote spacing and punctuation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->