### PR TITLE
fix: keep bilingual list markers inside columns

### DIFF
--- a/.changeset/scale-bilingual-hanging-indent.md
+++ b/.changeset/scale-bilingual-hanging-indent.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep numbered-list markers visible when projecting paragraphs into bilingual columns.

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -223,6 +223,18 @@ describe("createBilingualDocument", () => {
           indentFirstLine: 540,
         },
       },
+      {
+        ...paragraph("Numbered clause"),
+        formatting: {
+          indentFirstLine: -360,
+          hangingIndent: true,
+          tabs: [{ position: 360, alignment: "left" }],
+        },
+      },
+      {
+        ...paragraph("Extreme hanging clause"),
+        formatting: { indentFirstLine: -20_000, hangingIndent: true },
+      },
     ];
     const stamped = await ensureParaIds(await createDocx(source));
     const parsed = await parseDocx(stamped.docx, { preloadFonts: false });
@@ -239,6 +251,19 @@ describe("createBilingualDocument", () => {
           { position: 4153, alignment: "left" },
         ],
       });
+    }
+    for (const projected of [left.at(1), right.at(1)]) {
+      expect(projected?.formatting).toMatchObject({
+        indentLeft: 180,
+        indentFirstLine: -180,
+        hangingIndent: true,
+        tabs: [{ position: 180, alignment: "left" }],
+      });
+    }
+    for (const projected of [left.at(2), right.at(2)]) {
+      const indentLeft = projected?.formatting?.indentLeft ?? 0;
+      const indentFirstLine = projected?.formatting?.indentFirstLine ?? 0;
+      expect(indentLeft + indentFirstLine).toBe(0);
     }
     expect(getParagraphText(left.at(0)!)).toBe("Signature field");
     expect(getParagraphText(right.at(0)!)).toBe("Signature field");

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -202,6 +202,10 @@ describe("createBilingualDocument", () => {
 
   test("projects direct and inherited full-page geometry into each column", async () => {
     const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    const bulletNumId = findStyle(source, "ListParagraph")?.pPr?.numPr?.numId;
+    if (bulletNumId === undefined) {
+      throw new Error("preset lost its bullet numbering");
+    }
     source.package.styles?.styles.push({
       styleId: "FormLine",
       type: "paragraph",
@@ -224,7 +228,7 @@ describe("createBilingualDocument", () => {
         },
       },
       {
-        ...paragraph("Numbered clause"),
+        ...paragraph("Numbered clause", undefined, { numId: bulletNumId, ilvl: 0 }),
         formatting: {
           indentFirstLine: -360,
           hangingIndent: true,
@@ -261,6 +265,7 @@ describe("createBilingualDocument", () => {
       });
     }
     for (const projected of [left.at(2), right.at(2)]) {
+      expect(projected).toBeDefined();
       const indentLeft = projected?.formatting?.indentLeft ?? 0;
       const indentFirstLine = projected?.formatting?.indentFirstLine ?? 0;
       expect(indentLeft + indentFirstLine).toBe(0);

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -696,20 +696,25 @@ const projectParagraphIntoColumn = (
   const maxSideIndent = Math.max(0, columnWidth - MIN_COLUMN_TEXT_WIDTH_TWIPS);
   let indentLeft = projectSideIndent(geometry.indentLeft, scale, maxSideIndent);
   let indentRight = projectSideIndent(geometry.indentRight, scale, maxSideIndent);
-  const excess = indentLeft + indentRight - maxSideIndent;
-  if (excess > 0) {
-    const total = indentLeft + indentRight;
-    indentLeft = Math.round((indentLeft / total) * maxSideIndent);
+  const indentFirstLine =
+    geometry.indentFirstLine === undefined
+      ? undefined
+      : Math.max(-maxSideIndent, Math.round(geometry.indentFirstLine * scale));
+  const minimumLeftIndent = Math.min(maxSideIndent, Math.max(0, -(indentFirstLine ?? 0)));
+  indentLeft = Math.max(indentLeft, minimumLeftIndent);
+  const flexibleLeft = indentLeft - minimumLeftIndent;
+  const flexibleTotal = flexibleLeft + indentRight;
+  const flexibleMaximum = maxSideIndent - minimumLeftIndent;
+  if (flexibleTotal > flexibleMaximum) {
+    indentLeft = minimumLeftIndent + Math.round((flexibleLeft / flexibleTotal) * flexibleMaximum);
     indentRight = maxSideIndent - indentLeft;
   }
 
   const formatting: ParagraphFormatting = {
     ...paragraph.formatting,
-    ...(geometry.indentLeft !== undefined && { indentLeft }),
+    ...((geometry.indentLeft !== undefined || minimumLeftIndent > 0) && { indentLeft }),
     ...(geometry.indentRight !== undefined && { indentRight }),
-    ...(geometry.indentFirstLine !== undefined && {
-      indentFirstLine: Math.round(geometry.indentFirstLine * scale),
-    }),
+    ...(indentFirstLine !== undefined && { indentFirstLine }),
     ...(geometry.hangingIndent !== undefined && { hangingIndent: geometry.hangingIndent }),
     ...(geometry.tabs !== undefined && {
       tabs: geometry.tabs.map((tab) => ({


### PR DESCRIPTION
## Summary

- reserve enough projected left indent for negative first-line offsets
- clamp extreme hanging offsets to the available column width
- cover normal and extreme hanging-indent geometry with a regression test

## Testing

- `bun test packages/core/src/docx/server/createBilingualDocument.test.ts`
- `bun --filter @stll/folio-core typecheck`
- `bunx oxlint packages/core/src/docx/server/createBilingualDocument.ts packages/core/src/docx/server/createBilingualDocument.test.ts`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bilingual document layouts for numbered lists and hanging indents.
  * Keeps list markers visible and ensures first-line text remains within column boundaries.
  * Better balances indentation when content is projected into bilingual columns.

* **Tests**
  * Added coverage for hanging-indent and extreme-indent scenarios.

* **Release**
  * Patch release prepared for the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->