### PR TITLE
feat: add stacked bilingual table layout

### DIFF
--- a/.changeset/add-bilingual-table-layouts.md
+++ b/.changeset/add-bilingual-table-layouts.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Add an opt-in stacked layout for bilingual source tables while preserving the inline layout as the default.

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -50,6 +50,9 @@ export const applyFolioVersionDiffPrivacy: (diff: FolioVersionDiff, options: Fol
 export const assertSupportedFolioDocumentOperationVersion: (value: unknown) => typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
 
 // @public (undocumented)
+export const BILINGUAL_TABLE_LAYOUTS: readonly ["inline", "stacked"];
+
+// @public (undocumented)
 export type BilingualBorders = "none" | "grid";
 
 // @public
@@ -65,12 +68,21 @@ export type BilingualRow = ({
     rowId: string;
 } & BilingualParagraphRef) | {
     kind: "table";
+    layout: "inline";
     rowId: string;
     paragraphs: BilingualTableParagraphRef[];
+} | {
+    kind: "table";
+    layout: "stacked";
+    rowId: string;
+    paragraphs: BilingualParagraphRef[];
 };
 
 // @public (undocumented)
 export type BilingualRowKind = "paragraph" | "heading" | "listItem";
+
+// @public (undocumented)
+export type BilingualTableLayout = (typeof BILINGUAL_TABLE_LAYOUTS)[number];
 
 // @public (undocumented)
 export type BilingualTableParagraphRef = {
@@ -91,6 +103,7 @@ export function createBilingualDocument(source: import__stll_docx_core_model.Doc
 export type CreateBilingualDocumentOptions = {
     targetStyleSuffix: string;
     borders?: BilingualBorders;
+    tableLayout?: BilingualTableLayout;
     editableParagraphIds: ReadonlySet<string>;
 };
 
@@ -1399,7 +1412,7 @@ export type InspectDocxPackageOptions = {
 // @public (undocumented)
 export class InvalidBilingualDocumentOptionsError extends InvalidBilingualDocumentOptionsError_base<{
     message: string;
-    option: "targetStyleSuffix";
+    option: "tableLayout" | "targetStyleSuffix";
 }> {}
 
 // @public (undocumented)

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -300,9 +300,45 @@ describe("createBilingualDocument", () => {
     const tableParaIds = originalTable!.rows.flatMap((row) =>
       row.cells.flatMap((c) => cellParagraphs(c).map((p) => p.paraId)),
     );
-    expect(tableRow?.kind === "table" && tableRow.paragraphs.map((p) => p.paraId)).toEqual(
-      tableParaIds,
+    expect(
+      tableRow?.kind === "table" &&
+        tableRow.layout === "inline" &&
+        tableRow.paragraphs.map((p) => p.paraId),
+    ).toEqual(tableParaIds);
+  });
+
+  test("stacks an independently addressable target table below the source table", async () => {
+    const source = await buildSource();
+    const { document, rows } = createBilingualDocument(source, {
+      ...(await bilingualDocumentOptions(source)),
+      tableLayout: "stacked",
+    });
+
+    const spanningRow = bodyTables(document)
+      .flatMap((table) => table.rows)
+      .find((row) => row.cells.length === 1);
+    const nestedTables = spanningRow?.cells
+      .at(0)
+      ?.content.filter((item): item is Table => item.type === "table");
+    expect(nestedTables).toHaveLength(2);
+
+    const originalTable = source.package.document.content.find(
+      (block): block is Table => block.type === "table",
     );
+    expect(nestedTables?.at(0)).toEqual(originalTable);
+    expect(nestedTables?.at(1)).not.toBe(originalTable);
+
+    const tableRow = rows.find((row) => row.kind === "table");
+    expect(tableRow?.kind === "table" && tableRow.layout).toBe("stacked");
+    if (tableRow?.kind !== "table" || tableRow.layout !== "stacked") {
+      throw new Error("stacked table fixture lost its manifest row");
+    }
+    expect(tableRow.paragraphs.map((ref) => ref.sourceText)).toEqual(["Cell A1", "Cell B1"]);
+    expect(tableRow.paragraphs.every(({ sourceParaId }) => sourceParaId !== undefined)).toBe(true);
+    expect(
+      tableRow.paragraphs.every(({ sourceParaId, targetParaId }) => sourceParaId !== targetParaId),
+    ).toBe(true);
+    expect(tableRow.rowId).toBe(tableRow.paragraphs.at(0)?.targetParaId);
   });
 
   test("right column never shares a numbering instance or abstract with the left", async () => {
@@ -475,6 +511,56 @@ describe("createBilingualDocx", () => {
     expect(await readBilingualDocx(source.originalBuffer!)).toEqual([]);
   });
 
+  test("reads the same stacked-table manifest back from the saved document", async () => {
+    const source = await buildSource();
+    const { buffer, rows } = await createBilingualDocx(source.originalBuffer!, {
+      targetStyleSuffix: SUFFIX,
+      tableLayout: "stacked",
+    });
+
+    expect(await readBilingualDocx(buffer)).toEqual(rows);
+    const tableRow = rows.find((row) => row.kind === "table");
+    expect(tableRow?.kind === "table" && tableRow.layout).toBe("stacked");
+  });
+
+  test("reads a stacked manifest from a document containing only a table", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    source.package.document.content = [sourceTable()];
+
+    const { buffer, rows } = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+      tableLayout: "stacked",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows.at(0)).toMatchObject({ kind: "table", layout: "stacked" });
+    expect(await readBilingualDocx(buffer)).toEqual(rows);
+  });
+
+  test("refuses a stacked manifest whose table structures diverge", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    source.package.document.content = [sourceTable()];
+    const valid = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+      tableLayout: "stacked",
+    });
+    const malformed = await parseDocx(valid.buffer, { preloadFonts: false });
+    const wrapper = bodyTables(malformed).at(0);
+    const nestedTables = wrapper?.rows
+      .at(0)
+      ?.cells.at(0)
+      ?.content.filter((item): item is Table => item.type === "table");
+    const targetCell = nestedTables?.at(1)?.rows.at(0)?.cells.at(0);
+    if (!targetCell) {
+      throw new Error("stacked table fixture lost its target cell");
+    }
+    targetCell.content.push(paragraph("Unexpected target row"));
+
+    await expect(readBilingualDocx(await createDocx(malformed))).rejects.toThrow(
+      "Bilingual manifest structure or handles do not match the Folio AI-edit snapshot.",
+    );
+  });
+
   test("keeps structural-only paragraphs out of the editable row manifest", async () => {
     const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
     const columnBreak: Paragraph = {
@@ -610,7 +696,7 @@ describe("createBilingualDocx", () => {
     row.formatting = { ...row.formatting, hidden: true };
 
     await expect(readBilingualDocx(await createDocx(malformed))).rejects.toThrow(
-      "Bilingual manifest contains handles absent from the Folio AI-edit snapshot.",
+      "Bilingual manifest structure or handles do not match the Folio AI-edit snapshot.",
     );
   });
 

--- a/packages/core/src/docx/server/createBilingualDocument.test.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.test.ts
@@ -561,6 +561,47 @@ describe("createBilingualDocx", () => {
     );
   });
 
+  test("refuses a stacked manifest whose spanning row has no nested table", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    source.package.document.content = [sourceTable()];
+    const valid = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+      tableLayout: "stacked",
+    });
+    const malformed = await parseDocx(valid.buffer, { preloadFonts: false });
+    const spanningCell = bodyTables(malformed).at(0)?.rows.at(0)?.cells.at(0);
+    if (!spanningCell) {
+      throw new Error("stacked table fixture lost its spanning cell");
+    }
+    spanningCell.content = spanningCell.content.filter((item) => item.type !== "table");
+
+    await expect(readBilingualDocx(await createDocx(malformed))).rejects.toThrow(
+      "Bilingual manifest structure or handles do not match the Folio AI-edit snapshot.",
+    );
+  });
+
+  test("refuses a stacked manifest whose spanning row has three nested tables", async () => {
+    const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
+    source.package.document.content = [sourceTable()];
+    const valid = await createBilingualDocx(await createDocx(source), {
+      targetStyleSuffix: SUFFIX,
+      tableLayout: "stacked",
+    });
+    const malformed = await parseDocx(valid.buffer, { preloadFonts: false });
+    const spanningCell = bodyTables(malformed).at(0)?.rows.at(0)?.cells.at(0);
+    const sourceNestedTable = spanningCell?.content.find(
+      (item): item is Table => item.type === "table",
+    );
+    if (!spanningCell || !sourceNestedTable) {
+      throw new Error("stacked table fixture lost its source table");
+    }
+    spanningCell.content.push(structuredClone(sourceNestedTable));
+
+    await expect(readBilingualDocx(await createDocx(malformed))).rejects.toThrow(
+      "Bilingual manifest structure or handles do not match the Folio AI-edit snapshot.",
+    );
+  });
+
   test("keeps structural-only paragraphs out of the editable row manifest", async () => {
     const source = createEmptyDocument({ preset: createStellaStyleDocumentPreset() });
     const columnBreak: Paragraph = {

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -1008,6 +1008,7 @@ export function readBilingualDocument(
         const nestedTables = left.content.filter((item): item is Table => item.type === "table");
         const sourceTable = nestedTables.at(0);
         if (!sourceTable) {
+          missingHandleCount += 1;
           continue;
         }
         if (nestedTables.length === 2) {
@@ -1050,6 +1051,7 @@ export function readBilingualDocument(
           continue;
         }
         if (nestedTables.length !== 1) {
+          missingHandleCount += 1;
           continue;
         }
         const paragraphs = collectTableParagraphs(sourceTable)

--- a/packages/core/src/docx/server/createBilingualDocument.ts
+++ b/packages/core/src/docx/server/createBilingualDocument.ts
@@ -13,9 +13,9 @@
  *
  * Section breaks cannot live inside a table cell, so the body is split at
  * paragraphs carrying `sectionProperties`: each section becomes its own table
- * and the break paragraph stays between the tables. A source table (parties,
- * signature block) is kept once, in a row spanning both columns: it is signed
- * and read once, and its labels are translated inline rather than duplicated.
+ * and the break paragraph stays between the tables. Source tables (parties,
+ * signature blocks) can either span both columns for inline translation or be
+ * followed by a full-width target copy, depending on `tableLayout`.
  * Structural-only paragraphs are also kept once between tables; they have no
  * independently editable text for a translation row to address.
  */
@@ -61,12 +61,21 @@ export type BilingualRow =
     } & BilingualParagraphRef)
   | {
       kind: "table";
+      layout: "inline";
       rowId: string;
       /**
        * Every paragraph inside the table, in document order. The table is not
        * copied, so these are the paragraphs to translate in place.
        */
       paragraphs: BilingualTableParagraphRef[];
+    }
+  | {
+      kind: "table";
+      layout: "stacked";
+      /** Equals the first target paragraph id. */
+      rowId: string;
+      /** Source/target paragraph pairs in table document order. */
+      paragraphs: BilingualParagraphRef[];
     };
 
 export type BilingualTableParagraphRef = {
@@ -75,6 +84,9 @@ export type BilingualTableParagraphRef = {
 };
 
 export type BilingualBorders = "none" | "grid";
+
+export const BILINGUAL_TABLE_LAYOUTS = ["inline", "stacked"] as const;
+export type BilingualTableLayout = (typeof BILINGUAL_TABLE_LAYOUTS)[number];
 
 export type CreateBilingualDocumentOptions = {
   /**
@@ -85,6 +97,13 @@ export type CreateBilingualDocumentOptions = {
   targetStyleSuffix: string;
   /** Table borders; legal practice is usually `"none"`. Default `"none"`. */
   borders?: BilingualBorders;
+  /**
+   * Layout for source tables. `"inline"` keeps one full-width table whose
+   * paragraphs are translated in place. `"stacked"` keeps the source table
+   * and adds an independently addressable target copy below it. Default
+   * `"inline"`.
+   */
+  tableLayout?: BilingualTableLayout;
   /**
    * Paragraph handles exposed by Folio's canonical AI-edit snapshot for the
    * source DOCX. Only these paragraphs may become translation rows.
@@ -100,12 +119,13 @@ export type CreateBilingualDocumentResult = {
 };
 
 const STYLE_SUFFIX_PATTERN = /^[A-Za-z0-9-]+$/u;
+const DEFAULT_TABLE_LAYOUT = BILINGUAL_TABLE_LAYOUTS[0];
 
 export class InvalidBilingualDocumentOptionsError extends TaggedError(
   "InvalidBilingualDocumentOptionsError",
 )<{
   message: string;
-  option: "targetStyleSuffix";
+  option: "tableLayout" | "targetStyleSuffix";
 }> {}
 class UneditableBilingualManifestError extends TaggedError("UneditableBilingualManifestError")<{
   message: string;
@@ -140,6 +160,9 @@ const TABLE_BORDERS: Record<BilingualBorders, TableBorders> = {
   },
 };
 
+const isBilingualTableLayout = (value: unknown): value is BilingualTableLayout =>
+  typeof value === "string" && BILINGUAL_TABLE_LAYOUTS.some((layout) => layout === value);
+
 export function createBilingualDocument(
   source: Document,
   options: CreateBilingualDocumentOptions,
@@ -150,7 +173,14 @@ export function createBilingualDocument(
       option: "targetStyleSuffix",
     });
   }
+  if (options.tableLayout !== undefined && !isBilingualTableLayout(options.tableLayout)) {
+    throw new InvalidBilingualDocumentOptionsError({
+      message: `tableLayout must be one of ${BILINGUAL_TABLE_LAYOUTS.join(", ")}; received ${JSON.stringify(options.tableLayout)}`,
+      option: "tableLayout",
+    });
+  }
   const borders = options.borders ?? "none";
+  const tableLayout = options.tableLayout ?? DEFAULT_TABLE_LAYOUT;
   const warnings: string[] = [];
 
   const styles = source.package.styles;
@@ -225,12 +255,35 @@ export function createBilingualDocument(
       content.push(block);
       continue;
     }
-    rows.push({
-      kind: "table",
-      rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),
-      paragraphs,
-    });
-    sectionRows.push(buildSpanningRow(block));
+    if (tableLayout === "inline") {
+      rows.push({
+        kind: "table",
+        layout: "inline",
+        rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),
+        paragraphs,
+      });
+      sectionRows.push(buildInlineTableRow(block));
+      continue;
+    }
+
+    if (tableLayout === "stacked") {
+      const target = cloneTableForTarget({
+        table: block,
+        editableParagraphIds: options.editableParagraphIds,
+        paraIds,
+        styleCloner,
+        cloner,
+      });
+      rows.push({
+        kind: "table",
+        layout: "stacked",
+        rowId: target.paragraphs.at(0)?.targetParaId ?? tableRowHandle(rows.length),
+        paragraphs: target.paragraphs,
+      });
+      sectionRows.push(buildStackedTableRow({ source: block, target: target.table }));
+      continue;
+    }
+    tableLayout satisfies never;
   }
   flushSection();
 
@@ -613,6 +666,55 @@ const collectTableParagraphs = (table: Table): Paragraph[] => {
   return out;
 };
 
+type CloneTableForTargetOptions = {
+  table: Table;
+  editableParagraphIds: ReadonlySet<string>;
+  paraIds: ParaIdMinter;
+  styleCloner: StyleCloner;
+  cloner: NumberingCloner;
+};
+
+type CloneTableForTargetResult = {
+  table: Table;
+  paragraphs: BilingualParagraphRef[];
+};
+
+const cloneTableForTarget = ({
+  table,
+  editableParagraphIds,
+  paraIds,
+  styleCloner,
+  cloner,
+}: CloneTableForTargetOptions): CloneTableForTargetResult => {
+  const paragraphs: BilingualParagraphRef[] = [];
+  const cloneTable = (source: Table): Table => ({
+    ...structuredClone(source),
+    rows: source.rows.map((row) => ({
+      ...structuredClone(row),
+      cells: row.cells.map((cell) => ({
+        ...structuredClone(cell),
+        content: cell.content.map((item) => {
+          if (item.type === "table") {
+            return cloneTable(item);
+          }
+          const targetParaId = paraIds.mint(item.paraId);
+          const copy = cloneParagraphForTarget(item, targetParaId, styleCloner, cloner);
+          if (item.paraId !== undefined && editableParagraphIds.has(item.paraId)) {
+            paragraphs.push({
+              sourceParaId: item.paraId,
+              targetParaId,
+              sourceText: getParagraphText(item),
+            });
+          }
+          return copy;
+        }),
+      })),
+    })),
+  });
+
+  return { table: cloneTable(table), paragraphs };
+};
+
 // ----------------------------------------------------------------------------
 // Output table
 // ----------------------------------------------------------------------------
@@ -740,7 +842,7 @@ const buildCell = (paragraph: Paragraph): TableCell => ({
 });
 
 /** A source table kept once, across both columns. */
-const buildSpanningRow = (table: Table): Table["rows"][number] => ({
+const buildInlineTableRow = (table: Table): Table["rows"][number] => ({
   type: "tableRow",
   formatting: { cantSplit: true },
   cells: [
@@ -753,6 +855,33 @@ const buildSpanningRow = (table: Table): Table["rows"][number] => ({
       },
       // A cell must end with a paragraph; a bare nested table is invalid OOXML.
       content: [table, { type: "paragraph", content: [] }],
+    },
+  ],
+});
+
+/** Full-width source and target tables, stacked without narrowing either one. */
+type BuildStackedTableRowOptions = { source: Table; target: Table };
+
+const buildStackedTableRow = ({
+  source,
+  target,
+}: BuildStackedTableRowOptions): Table["rows"][number] => ({
+  type: "tableRow",
+  formatting: { cantSplit: false },
+  cells: [
+    {
+      type: "tableCell",
+      formatting: {
+        width: { value: FULL_WIDTH_PCT, type: "pct" },
+        gridSpan: 2,
+        verticalAlign: "top",
+      },
+      content: [
+        source,
+        { type: "paragraph", content: [] },
+        target,
+        { type: "paragraph", content: [] },
+      ],
     },
   ],
 });
@@ -855,7 +984,7 @@ const createParaIdMinter = (taken: Set<string>): ParaIdMinter => {
  * {@link createBilingualDocument}. A dedicated table-style discriminator keeps
  * ordinary two-column source tables from being mistaken for bilingual output;
  * the expected row structure is validated as a second check. Rows are returned
- * in document order; the right paragraph's `paraId` is the row handle.
+ * in document order.
  */
 export function readBilingualDocument(
   document: Document,
@@ -876,9 +1005,54 @@ export function readBilingualDocument(
         continue;
       }
       if (!right) {
-        const paragraphs = left.content
-          .filter((item): item is Table => item.type === "table")
-          .flatMap(collectTableParagraphs)
+        const nestedTables = left.content.filter((item): item is Table => item.type === "table");
+        const sourceTable = nestedTables.at(0);
+        if (!sourceTable) {
+          continue;
+        }
+        if (nestedTables.length === 2) {
+          const targetTable = nestedTables.at(1);
+          if (!targetTable) {
+            continue;
+          }
+          const sourceParagraphs = collectTableParagraphs(sourceTable);
+          const targetParagraphs = collectTableParagraphs(targetTable);
+          if (sourceParagraphs.length !== targetParagraphs.length) {
+            missingHandleCount += 1;
+            continue;
+          }
+          const paragraphs: BilingualParagraphRef[] = [];
+          for (const [index, source] of sourceParagraphs.entries()) {
+            if (source.paraId === undefined || !editableParagraphIds.has(source.paraId)) {
+              continue;
+            }
+            const target = targetParagraphs.at(index);
+            if (
+              target?.paraId === undefined ||
+              target.paraId === source.paraId ||
+              !editableParagraphIds.has(target.paraId)
+            ) {
+              missingHandleCount += 1;
+              continue;
+            }
+            paragraphs.push({
+              sourceParaId: source.paraId,
+              targetParaId: target.paraId,
+              sourceText: getParagraphText(source),
+            });
+          }
+          rows.push({
+            kind: "table",
+            layout: "stacked",
+            rowId: paragraphs.at(0)?.targetParaId ?? tableRowHandle(rows.length),
+            paragraphs,
+          });
+          continue;
+        }
+        if (nestedTables.length !== 1) {
+          continue;
+        }
+        const paragraphs = collectTableParagraphs(sourceTable)
           .filter(
             (paragraph): paragraph is Paragraph & { paraId: string } =>
               paragraph.paraId !== undefined && editableParagraphIds.has(paragraph.paraId),
@@ -889,6 +1063,7 @@ export function readBilingualDocument(
           }));
         rows.push({
           kind: "table",
+          layout: "inline",
           rowId: paragraphs.at(0)?.paraId ?? tableRowHandle(rows.length),
           paragraphs,
         });
@@ -925,7 +1100,7 @@ export function readBilingualDocument(
   }
   if (missingHandleCount > 0) {
     throw new UneditableBilingualManifestError({
-      message: "Bilingual manifest contains handles absent from the Folio AI-edit snapshot.",
+      message: "Bilingual manifest structure or handles do not match the Folio AI-edit snapshot.",
       missingHandleCount,
     });
   }
@@ -936,7 +1111,6 @@ const isBilingualTable = (table: Table): boolean => {
   if (table.formatting?.styleId !== BILINGUAL_TABLE_STYLE_ID) {
     return false;
   }
-  let pairs = 0;
   for (const row of table.rows) {
     const cells = row.cells;
     if (cells.length === 2) {
@@ -946,7 +1120,6 @@ const isBilingualTable = (table: Table): boolean => {
       if (!singleParagraphCells) {
         return false;
       }
-      pairs += 1;
       continue;
     }
     if (cells.length === 1 && cells[0]?.formatting?.gridSpan === 2) {
@@ -954,7 +1127,7 @@ const isBilingualTable = (table: Table): boolean => {
     }
     return false;
   }
-  return pairs > 0;
+  return table.rows.length > 0;
 };
 
 const isParagraphWithId = (value: object): value is { type: "paragraph"; paraId: string } =>

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -208,6 +208,7 @@ export {
   type MaterializeYjsDocxOptions,
 } from "./docx/server/materializeYjsDocx";
 export {
+  BILINGUAL_TABLE_LAYOUTS,
   createBilingualDocument,
   InvalidBilingualDocumentOptionsError,
   readBilingualDocument,
@@ -216,6 +217,7 @@ export {
   type BilingualRow,
   type BilingualRowKind,
   type BilingualTableParagraphRef,
+  type BilingualTableLayout,
   type CreateBilingualDocumentOptions,
   type CreateBilingualDocumentResult,
 } from "./docx/server/createBilingualDocument";


### PR DESCRIPTION
## Summary

- add an opt-in `stacked` layout while preserving `inline` as the default
- clone full-width target tables with independent paragraph, style, and numbering handles
- return layout-discriminated manifests and reject structurally divergent saved documents
- export the layout contract and update the public API snapshot

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in stacked layout for bilingual source tables, placing the translated table below the original.
  * The existing inline table layout remains the default.
  * Added table-layout options and validation for bilingual document creation.
* **Bug Fixes**
  * Improved validation when reading bilingual documents, including detection of mismatched stacked table structures.
* **Documentation**
  * Updated public API definitions to describe the supported table layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->