### PR TITLE
fix: align intrinsic paragraph frames

### DIFF
--- a/.changeset/calm-frames-align.md
+++ b/.changeset/calm-frames-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Size paragraph frames without an authored width to their content before resolving anchored alignment.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -1002,6 +1002,7 @@ export type TextBoxBlock = {
     kind: "textBox";
     id: BlockId;
     width: number;
+    widthMode?: "intrinsic";
     height?: number;
     autoFit?: ShapeTextBody["autoFit"];
     textWrap?: ShapeTextBody["textWrap"];

--- a/packages/core/src/layout-bridge/convert/paragraphFrames.ts
+++ b/packages/core/src/layout-bridge/convert/paragraphFrames.ts
@@ -103,10 +103,11 @@ function toFrameTextBox(
 ): TextBoxBlock {
   const first = content.at(0);
   const last = content.at(-1);
+  const hasAuthoredWidth = frame.width !== undefined;
   const textBox: TextBoxBlock = {
     kind: "textBox",
     id: nextBlockId(),
-    width: frame.width ?? 200,
+    width: frame.width ?? 0,
     margins: { top: 0, right: 0, bottom: 0, left: 0 },
     content,
     displayMode: "float",
@@ -119,6 +120,11 @@ function toFrameTextBox(
     ...(first?.pmStart !== undefined ? { pmStart: first.pmStart } : {}),
     ...(last?.pmEnd !== undefined ? { pmEnd: last.pmEnd } : {}),
   };
+  if (!hasAuthoredWidth) {
+    textBox.widthMode = "intrinsic";
+    textBox.autoFit = "shape";
+    textBox.textWrap = "none";
+  }
   if (frame.height !== undefined) {
     textBox.height = frame.height;
   }

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -652,6 +652,31 @@ describe("toFlowBlocks paragraph formatting", () => {
     ]);
   });
 
+  test("keeps an omitted paragraph-frame width intrinsic", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _originalFormatting: {
+            frame: { hAnchor: "margin", xAlign: "right", wrap: "around" },
+          },
+        },
+        [schema.text("frame")],
+      ),
+    ]);
+
+    const framed = toFlowBlocks(doc).at(0);
+
+    expect(framed).toMatchObject({
+      kind: "textBox",
+      width: 0,
+      widthMode: "intrinsic",
+      autoFit: "shape",
+      textWrap: "none",
+      position: { horizontal: { relativeTo: "margin", align: "right" } },
+    });
+  });
+
   test("keeps page-anchored frames in one wrap set across an empty anchor paragraph", () => {
     const frame = {
       width: 1440,

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -5,7 +5,12 @@ import { markParagraphFrameTextBox } from "../paragraphFrame";
 import { setTextBoxGroupId } from "../textBoxGroup";
 import { pixelsToEmu } from "../../utils/units";
 import { fixedCharWidth, withFakeTextMeasure } from "./__tests__/fakeTextMeasure";
-import { measureBlock, measureBlocks, measureTableBlock } from "./measureBlocks";
+import {
+  measureBlock,
+  measureBlocks,
+  measureTableBlock,
+  measureTextBoxBlock,
+} from "./measureBlocks";
 
 const fakeMeasure = { charWidth: fixedCharWidth(5) };
 
@@ -836,6 +841,29 @@ describe("measureBlocks", () => {
       }
 
       expect(bodyMeasure.lines.at(0)?.floatSkipBefore).toBeUndefined();
+    }, fakeMeasure);
+  });
+
+  test("fits an omitted-width paragraph frame to its longest unwrapped line", () => {
+    withFakeTextMeasure(() => {
+      const frame: TextBoxBlock = {
+        kind: "textBox",
+        id: "intrinsic-frame",
+        width: 0,
+        widthMode: "intrinsic",
+        autoFit: "shape",
+        textWrap: "none",
+        margins: { top: 0, right: 0, bottom: 0, left: 0 },
+        content: [para("short", "short"), para("long", "longest line")],
+        displayMode: "float",
+        wrapType: "square",
+        position: { horizontal: { relativeTo: "margin", align: "right" } },
+      };
+      markParagraphFrameTextBox(frame);
+
+      const measure = measureTextBoxBlock(frame);
+
+      expect(measure.width).toBe(60);
     }, fakeMeasure);
   });
 

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -845,6 +845,8 @@ export type TextBoxBlock = {
   id: BlockId;
   /** Width in pixels */
   width: number;
+  /** Whether width is authored or derived from the live rendered content. */
+  widthMode?: "intrinsic";
   /** Height in pixels (may be auto-calculated) */
   height?: number;
   /** Text fitting behavior */

--- a/packages/core/src/layout-painter/header-footer-float-left.test.ts
+++ b/packages/core/src/layout-painter/header-footer-float-left.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { resolveHeaderFooterFloatLeft, type HeaderFooterLayoutInfo } from "./renderPage";
+import {
+  resolveHeaderFooterFloatLeft,
+  resolveHeaderFooterIntrinsicFrameHorizontalPosition,
+  type HeaderFooterLayoutInfo,
+} from "./renderPage";
 
 const layout: HeaderFooterLayoutInfo = {
   flowTop: 50,
@@ -41,6 +45,30 @@ describe("resolveHeaderFooterFloatLeft", () => {
     // (contentWidth 400 - 200) / 2 = 100
     expect(resolveHeaderFooterFloatLeft(200, { align: "center" }, layout)).toBe("100px");
   });
+
+  test.each([
+    ["left", "0"],
+    ["center", "175px"],
+    ["right", "350px"],
+  ] as const)("%s relative to the margin box uses the intrinsic frame width", (align, left) => {
+    expect(resolveHeaderFooterFloatLeft(50, { relativeTo: "margin", align }, layout)).toBe(left);
+  });
+
+  test.each([
+    ["margin", "left", { left: "0" }],
+    ["margin", "center", { left: "200px", transform: "translateX(-50%)" }],
+    ["margin", "right", { left: "400px", transform: "translateX(-100%)" }],
+    ["page", "left", { left: "-100px" }],
+    ["page", "center", { left: "206px", transform: "translateX(-50%)" }],
+    ["page", "right", { left: "512px", transform: "translateX(-100%)" }],
+  ] as const)(
+    "%s-relative intrinsic frame at %s anchors its dynamic content edge",
+    (relativeTo, align, expected) => {
+      expect(
+        resolveHeaderFooterIntrinsicFrameHorizontalPosition({ relativeTo, align }, layout),
+      ).toEqual(expected);
+    },
+  );
 
   test("inside aliases left, outside aliases right (single-sided rendering)", () => {
     // inside → left relative to page: -flowLeft = -100

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -583,6 +583,49 @@ function getPositionAlignment(
   return position?.align ?? position?.alignment;
 }
 
+type HeaderFooterHorizontalAnchorPoint = {
+  left: number;
+  alignment: "left" | "center" | "right";
+};
+
+type HeaderFooterHorizontalPosition = {
+  relativeTo?: string;
+  posOffset?: number;
+  align?: string;
+  alignment?: string;
+};
+
+function resolveHeaderFooterHorizontalAnchorPoint(
+  h: HeaderFooterHorizontalPosition | undefined,
+  layout: HeaderFooterLayoutInfo,
+): HeaderFooterHorizontalAnchorPoint {
+  if (!h) {
+    return { left: 0, alignment: "left" };
+  }
+
+  if (h.posOffset !== undefined) {
+    const pageOffset = h.relativeTo === "page" ? -layout.flowLeft : 0;
+    return { left: emuToPixels(h.posOffset) + pageOffset, alignment: "left" };
+  }
+
+  let align = getPositionAlignment(h);
+  if (align === "inside") {
+    align = "left";
+  } else if (align === "outside") {
+    align = "right";
+  }
+  const alignment = align === "center" || align === "right" ? align : "left";
+  const frameWidth = h.relativeTo === "page" ? layout.pageWidth : layout.contentWidth;
+  const frameLeft = h.relativeTo === "page" ? -layout.flowLeft : 0;
+  if (alignment === "center") {
+    return { left: frameLeft + frameWidth / 2, alignment };
+  }
+  if (alignment === "right") {
+    return { left: frameLeft + frameWidth, alignment };
+  }
+  return { left: frameLeft, alignment };
+}
+
 function resolveHeaderFooterFloatTop(
   floatImg: {
     height: number;
@@ -702,58 +745,32 @@ function resolveHeaderFooterFloatingTablePosition(
  */
 export function resolveHeaderFooterFloatLeft(
   width: number,
-  h:
-    | {
-        relativeTo?: string;
-        posOffset?: number;
-        align?: string;
-        alignment?: string;
-      }
-    | undefined,
+  h: HeaderFooterHorizontalPosition | undefined,
   layout: HeaderFooterLayoutInfo,
 ): string {
-  if (!h) {
-    return "0";
+  const anchor = resolveHeaderFooterHorizontalAnchorPoint(h, layout);
+  let widthFactor = 0;
+  if (anchor.alignment === "right") {
+    widthFactor = 1;
+  } else if (anchor.alignment === "center") {
+    widthFactor = 0.5;
   }
+  const left = anchor.left - width * widthFactor;
+  return left === 0 ? "0" : `${left}px`;
+}
 
-  // Single-sided rendering: OOXML `inside`/`outside` alias `left`/`right`
-  // (matching resolveAnchoredImagePosition / the floating-table resolver).
-  let align = getPositionAlignment(h);
-  if (align === "inside") {
-    align = "left";
-  } else if (align === "outside") {
-    align = "right";
+export function resolveHeaderFooterIntrinsicFrameHorizontalPosition(
+  h: HeaderFooterHorizontalPosition | undefined,
+  layout: HeaderFooterLayoutInfo,
+): { left: string; transform?: string } {
+  const anchor = resolveHeaderFooterHorizontalAnchorPoint(h, layout);
+  if (anchor.alignment === "center") {
+    return { left: `${anchor.left}px`, transform: "translateX(-50%)" };
   }
-
-  if (h.relativeTo === "page") {
-    if (h.posOffset !== undefined) {
-      return `${emuToPixels(h.posOffset) - layout.flowLeft}px`;
-    }
-    if (align === "right") {
-      return `${layout.pageWidth - width - layout.flowLeft}px`;
-    }
-    if (align === "center") {
-      return `${(layout.pageWidth - width) / 2 - layout.flowLeft}px`;
-    }
-    if (align === "left") {
-      return `${-layout.flowLeft}px`;
-    }
+  if (anchor.alignment === "right") {
+    return { left: `${anchor.left}px`, transform: "translateX(-100%)" };
   }
-
-  // `relativeTo: margin` falls through here intentionally: the header/footer
-  // content width IS the margin box, so the content-relative branch is already
-  // margin-correct.
-  if (h.posOffset !== undefined) {
-    return `${emuToPixels(h.posOffset)}px`;
-  }
-  if (align === "right") {
-    return `${layout.contentWidth - width}px`;
-  }
-  if (align === "center") {
-    return `${(layout.contentWidth - width) / 2}px`;
-  }
-
-  return "0";
+  return { left: anchor.left === 0 ? "0" : `${anchor.left}px` };
 }
 
 function applyHeaderFooterFloatHorizontalPosition(
@@ -1222,6 +1239,15 @@ function renderHeaderFooterContent(
         block.position?.horizontal,
         layout,
       );
+      if (block.widthMode === "intrinsic") {
+        const horizontalPosition = resolveHeaderFooterIntrinsicFrameHorizontalPosition(
+          block.position?.horizontal,
+          layout,
+        );
+        fragEl.style.width = "max-content";
+        fragEl.style.left = horizontalPosition.left;
+        fragEl.style.transform = horizontalPosition.transform ?? "";
+      }
       if (block.wrapType === "behind") {
         fragEl.style.zIndex = "-1";
       }


### PR DESCRIPTION
## Summary

- size paragraph frames without an authored width from their rendered content
- resolve left, center, and right header/footer anchors against intrinsic frame width
- preserve fixed-width frame positioning

## Validation

- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts packages/core/src/layout-engine/measure/measureBlocks.test.ts packages/core/src/layout-painter/header-footer-float-left.test.ts`
- `bun audit`

CC on behalf of jan-kubica