### PR TITLE
fix: align continuation table row borders

### DIFF
--- a/.changeset/rounded-continuation-row-edges.md
+++ b/.changeset/rounded-continuation-row-edges.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Align collapsed borders between minimum-height table rows across page continuations.

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -59,6 +59,7 @@ import { applyImageVisualAttrs, hasImageCrop, hasImageVisualAttrs } from "./rend
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTextBoxFragment } from "./renderTextBox";
 import type { RenderContext } from "./renderUtils";
+import { ownedRowBottomBorderOffsets } from "./tableRowPaintGeometry";
 
 /**
  * CSS class names for table elements
@@ -75,6 +76,7 @@ export const TABLE_CLASS_NAMES = {
 };
 
 const CELL_DIAGONAL_BORDER_CLASS = "layout-table-cell-diagonal-border";
+const CELL_BOTTOM_BORDER_CLASS = "layout-table-cell-bottom-border";
 
 /**
  * Options for rendering a table fragment
@@ -591,6 +593,7 @@ type RenderTableCellOptions = {
   rowHeight: number;
   borderFlags: {
     drawTop: boolean;
+    drawBottom: boolean;
     isLastRow: boolean;
     drawLeft: boolean;
     isLastCol: boolean;
@@ -648,7 +651,9 @@ function renderTableCell({
       applyBorder(cellEl, "top", cell.borders.top);
     }
     applyBorder(cellEl, "right", cell.borders.right);
-    applyBorder(cellEl, "bottom", cell.borders.bottom);
+    if (borderFlags.drawBottom) {
+      applyBorder(cellEl, "bottom", cell.borders.bottom);
+    }
     if (borderFlags.drawLeft) {
       applyBorder(cellEl, "left", cell.borders.left);
     }
@@ -780,6 +785,60 @@ function renderTableCell({
 const hasVisibleBorder = (border: { width?: number; style?: string } | undefined): boolean =>
   border !== undefined && border.style !== "none" && border.style !== "nil";
 
+const isMinimumHeightRow = (row: TableBlock["rows"][number] | undefined): boolean =>
+  row?.height !== undefined && row.heightRule !== "exact";
+
+const rowHasVerticalMerge = (row: TableBlock["rows"][number] | undefined): boolean =>
+  row?.cells.some((cell) => (cell.rowSpan ?? 1) > 1) === true;
+
+const continuationRowBottomBorderOffsets = (
+  fragment: TableFragment,
+  block: TableBlock,
+  measure: TableMeasure,
+  cellGrid: TableCellGrid,
+): number[] => {
+  const rowHeights = measure.rows
+    .slice(fragment.fromRow, fragment.toRow)
+    .map(({ height }) => height);
+  const fragmentHasVerticalMerge = block.rows
+    .slice(fragment.fromRow, fragment.toRow)
+    .some(
+      (row, fragmentRowIndex) =>
+        rowHasVerticalMerge(row) ||
+        (cellGrid.occupiedColumnsByRow.get(fragment.fromRow + fragmentRowIndex)?.size ?? 0) > 0,
+    );
+  if (
+    fragment.continuesFromPrev !== true ||
+    fragment.headerRowCount ||
+    fragment.topClip !== undefined ||
+    fragment.bottomClip !== undefined ||
+    fragmentHasVerticalMerge
+  ) {
+    return rowHeights.map(() => 0);
+  }
+
+  const snapAfterRow = rowHeights.slice(0, -1).map((_, fragmentRowIndex) => {
+    const rowIndex = fragment.fromRow + fragmentRowIndex;
+    const row = block.rows[rowIndex];
+    const nextRow = block.rows[rowIndex + 1];
+    return (
+      isMinimumHeightRow(row) &&
+      isMinimumHeightRow(nextRow) &&
+      !rowHasVerticalMerge(row) &&
+      !rowHasVerticalMerge(nextRow) &&
+      row?.cells.some((cell) => hasVisibleBorder(cell.borders?.bottom)) === true
+    );
+  });
+  if (!snapAfterRow.some(Boolean)) {
+    return rowHeights.map(() => 0);
+  }
+  return ownedRowBottomBorderOffsets({
+    origin: fragment.y,
+    rowHeights,
+    snapAfterRow,
+  });
+};
+
 /**
  * Render a table row with rowSpan support
  */
@@ -801,6 +860,7 @@ type RenderTableRowOptions = {
   contentClip?: CellContentClip;
   pageContentPosition?: PageContentPosition;
   inlineOffset?: number;
+  bottomBorderOffset?: number;
 };
 
 function renderTableRow({
@@ -821,6 +881,7 @@ function renderTableRow({
   contentClip,
   pageContentPosition,
   inlineOffset = 0,
+  bottomBorderOffset = 0,
 }: RenderTableRowOptions): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
@@ -877,13 +938,21 @@ function renderTableRow({
     const drawTop = isFirstRow || !hasVisibleBorder(aboveCell?.borders?.bottom);
     const drawLeft = isFirstCol || !hasVisibleBorder(leftCell?.borders?.right);
 
+    const paintBottomBorderSeparately =
+      bottomBorderOffset > 0 && hasVisibleBorder(cell.borders?.bottom);
     const cellEl = renderTableCell({
       cell,
       cellMeasure,
       x: cellLeft,
       width,
       rowHeight: cellHeight,
-      borderFlags: { drawTop, isLastRow, drawLeft, isLastCol },
+      borderFlags: {
+        drawTop,
+        drawBottom: !paintBottomBorderSeparately,
+        isLastRow,
+        drawLeft,
+        isLastCol,
+      },
       columnsPinned,
       context,
       doc,
@@ -907,6 +976,20 @@ function renderTableRow({
     }
 
     rowEl.append(cellEl);
+    if (paintBottomBorderSeparately) {
+      const bottomBorderEl = doc.createElement("div");
+      bottomBorderEl.className = CELL_BOTTOM_BORDER_CLASS;
+      bottomBorderEl.style.position = "absolute";
+      bottomBorderEl.style.left = `${cellLeft}px`;
+      bottomBorderEl.style.top = "0";
+      bottomBorderEl.style.width = `${width}px`;
+      bottomBorderEl.style.height = `${cellHeight + bottomBorderOffset}px`;
+      bottomBorderEl.style.boxSizing = "border-box";
+      bottomBorderEl.style.pointerEvents = "none";
+      bottomBorderEl.style.zIndex = "1";
+      applyBorder(bottomBorderEl, "bottom", cell.borders?.bottom);
+      rowEl.append(bottomBorderEl);
+    }
   }
 
   return rowEl;
@@ -1007,6 +1090,12 @@ export function renderTableFragment(
     columnWidths: measure.columnWidths,
     bidi: block.bidi === true,
   });
+  const contentRowBottomBorderOffsets = continuationRowBottomBorderOffsets(
+    fragment,
+    block,
+    measure,
+    cellGrid,
+  );
 
   // Render repeated header rows for continuation fragments. For a mid-content
   // row break (eigenpal #698), keep repeated headers pinned to the fragment top
@@ -1115,6 +1204,7 @@ export function renderTableFragment(
       columnsPinned,
       cellGrid,
       cellPlacements,
+      bottomBorderOffset: contentRowBottomBorderOffsets[rowIndex - fragment.fromRow] ?? 0,
       ...(contentClip ? { contentClip } : {}),
       ...(tablePageContentPosition
         ? {

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -869,25 +869,27 @@ describe("renderTableFragment floating cell content", () => {
       toRow: 1,
     };
 
-    const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
-      document: fakeDocument,
-    }) as unknown as FakeElement;
-    const cell = findByClass(tableEl, TABLE_CLASS_NAMES.cell).at(0);
-    const content = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent).at(0);
-    const imageLayer = findByClass(tableEl, "layout-cell-floating-images-layer").at(0);
-    const textBoxLayer = findByClass(tableEl, "layout-cell-floating-text-boxes-layer").at(0);
-    const textBox = findByClass(tableEl, "layout-textbox").at(1);
+    withFakeTextMeasure(() => {
+      const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+      }) as unknown as FakeElement;
+      const cell = findByClass(tableEl, TABLE_CLASS_NAMES.cell).at(0);
+      const content = findByClass(tableEl, TABLE_CLASS_NAMES.cellContent).at(0);
+      const imageLayer = findByClass(tableEl, "layout-cell-floating-images-layer").at(0);
+      const textBoxLayer = findByClass(tableEl, "layout-cell-floating-text-boxes-layer").at(0);
+      const textBox = findByClass(tableEl, "layout-textbox").at(1);
 
-    expect(tableEl.style["overflow"]).toBe("visible");
-    expect(cell?.style["overflow"]).toBe("visible");
-    expect(content?.style["overflow"]).toBe("hidden");
-    expect(imageLayer?.style["left"]).toBe("4px");
-    expect(imageLayer?.style["top"]).toBe("2px");
-    expect(imageLayer?.style["overflow"]).toBe("visible");
-    expect(textBoxLayer?.style["left"]).toBe("4px");
-    expect(textBoxLayer?.style["top"]).toBe("2px");
-    expect(textBox?.style["left"]).toBe("20px");
-    expect(Number.parseFloat(textBox?.style["top"] ?? "0")).toBeGreaterThan(50);
+      expect(tableEl.style["overflow"]).toBe("visible");
+      expect(cell?.style["overflow"]).toBe("visible");
+      expect(content?.style["overflow"]).toBe("hidden");
+      expect(imageLayer?.style["left"]).toBe("4px");
+      expect(imageLayer?.style["top"]).toBe("2px");
+      expect(imageLayer?.style["overflow"]).toBe("visible");
+      expect(textBoxLayer?.style["left"]).toBe("4px");
+      expect(textBoxLayer?.style["top"]).toBe("2px");
+      expect(textBox?.style["left"]).toBe("20px");
+      expect(Number.parseFloat(textBox?.style["top"] ?? "0")).toBeGreaterThan(50);
+    });
   });
 });
 

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -219,6 +219,64 @@ describe("renderTableFragment clipped header continuations", () => {
   });
 });
 
+describe("renderTableFragment continuation row boundaries", () => {
+  test("rounds independently painted borders without changing continuation row geometry", () => {
+    const contentRowHeights = [10.2, 7.7, 5.4];
+    const rowHeights = [20, ...contentRowHeights];
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      columnWidths: [100],
+      rows: rowHeights.map((_, index) => ({
+        id: `row-${index}`,
+        height: [20, 10, 7, 5][index],
+        heightRule: "atLeast",
+        cells: [
+          {
+            id: `cell-${index}`,
+            blocks: [],
+            borders: { bottom: { width: 0.5, style: "solid" } },
+          },
+        ],
+      })),
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 43.3,
+      rows: rowHeights.map((height) => ({
+        height,
+        cells: [{ blocks: [], width: 100, height: 0 }],
+      })),
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0.25,
+      width: 100,
+      height: 23.3,
+      fromRow: 1,
+      toRow: 4,
+      continuesFromPrev: true,
+    };
+
+    const table = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const rows = findRows(table);
+
+    expect(rows.map((row) => row.style["top"])).toEqual(["0px", "10.2px", "17.9px"]);
+    expect(rows.map((row) => row.style["height"])).toEqual(["10.2px", "7.7px", "5.4px"]);
+    const bottomBorders = findByClass(table, "layout-table-cell-bottom-border");
+    expect(bottomBorders.map((border) => border.style["height"])).toEqual(["10.75px", "8.55px"]);
+    const finalTop = Number.parseFloat(rows.at(-1)?.style["top"] ?? "0");
+    const finalHeight = Number.parseFloat(rows.at(-1)?.style["height"] ?? "0");
+    expect(finalTop + finalHeight).toBeCloseTo(fragment.height, 10);
+  });
+});
+
 describe("renderTableFragment split-row cell content", () => {
   test("clips ordinary cell content to each intersecting row slice", () => {
     const block: TableBlock = {

--- a/packages/core/src/layout-painter/tableRowPaintGeometry.test.ts
+++ b/packages/core/src/layout-painter/tableRowPaintGeometry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { ownedRowBottomBorderOffsets } from "./tableRowPaintGeometry";
+
+describe("ownedRowBottomBorderOffsets", () => {
+  test("rounds cumulative owned edges from a fractional origin", () => {
+    expect(
+      ownedRowBottomBorderOffsets({
+        origin: 0.25,
+        rowHeights: [10.2, 7.7, 5.4],
+        snapAfterRow: [true, true],
+      }),
+    ).toEqual([0.5500000000000007, 0.8500000000000014, 0]);
+  });
+
+  test("is stable across fractional origins and three-or-more-row partitions", () => {
+    const origins = [0, 0.125, 0.5, 0.875];
+    const partitions = [
+      [10.2, 7.7, 5.4],
+      [1.125, 2.25, 3.375, 4.5],
+      [40.01, 0.99, 12.625],
+    ];
+
+    for (const origin of origins) {
+      for (const rowHeights of partitions) {
+        const snapAfterRow = rowHeights.slice(0, -1).map(() => true);
+        const once = ownedRowBottomBorderOffsets({ origin, rowHeights, snapAfterRow });
+        const twice = ownedRowBottomBorderOffsets({ origin, rowHeights, snapAfterRow });
+
+        expect(twice).toEqual(once);
+        expect(once.at(-1)).toBe(0);
+        expect(once.every((offset) => offset >= 0 && offset < 1)).toBe(true);
+      }
+    }
+  });
+
+  test("leaves unowned and final edges unchanged", () => {
+    expect(
+      ownedRowBottomBorderOffsets({
+        origin: 0.25,
+        rowHeights: [10.2, 7.7, 5.4],
+        snapAfterRow: [false, true],
+      }),
+    ).toEqual([0, 0.8500000000000014, 0]);
+  });
+});

--- a/packages/core/src/layout-painter/tableRowPaintGeometry.ts
+++ b/packages/core/src/layout-painter/tableRowPaintGeometry.ts
@@ -1,0 +1,31 @@
+const CSS_PIXEL_ROUNDING_EPSILON = 1e-6;
+
+type OwnedRowBottomBorderOffsetsOptions = {
+  origin: number;
+  rowHeights: readonly number[];
+  /** Whether the row ending at this index owns a visible shared bottom edge. */
+  snapAfterRow: readonly boolean[];
+};
+
+/**
+ * Offset bottom-owned shared edges onto CSS pixel boundaries. Source row
+ * geometry remains unchanged, so content floors and the final band edge stay
+ * exact; only the independently painted border moves.
+ */
+export const ownedRowBottomBorderOffsets = ({
+  origin,
+  rowHeights,
+  snapAfterRow,
+}: OwnedRowBottomBorderOffsetsOptions): number[] => {
+  const offsets: number[] = [];
+  let boundary = origin;
+  for (let rowIndex = 0; rowIndex < rowHeights.length; rowIndex++) {
+    boundary += rowHeights[rowIndex] ?? 0;
+    if (rowIndex === rowHeights.length - 1 || snapAfterRow[rowIndex] !== true) {
+      offsets.push(0);
+      continue;
+    }
+    offsets.push(Math.ceil(boundary - CSS_PIXEL_ROUNDING_EPSILON) - boundary);
+  }
+  return offsets;
+};


### PR DESCRIPTION
## Summary

- align bottom-owned borders on continued table rows to stable pixel boundaries
- preserve row height, content, pagination, and resize-handle geometry
- exclude clipped rows, repeated headers, and vertically merged cells
- keep the floating-cell render test self-contained

## Validation

- `bun test packages/core/src/layout-painter/tableRowPaintGeometry.test.ts packages/core/src/layout-painter/renderTableFragment.test.ts`
- targeted `oxlint` and `oxfmt --check`
- `bun audit`

CC on behalf of jan-kubica