### PR TITLE
fix: validate block geometry without vertical ordering

### DIFF
--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -56,8 +56,13 @@ export type FolioParityBridge = {
   aiSnapshotBlockCount: () => number;
   /** Painted geometry exposed through the public ref contract. */
   readBlockGeometry: () => {
-    snapshotBlockIds: string[];
-    rects: { blockId: string; page: number; top: number; height: number }[];
+    rects: {
+      snapshotBlockId: string;
+      blockId: string;
+      page: number;
+      top: number;
+      height: number;
+    }[];
     missingIsNull: boolean;
     hasScrollRoot: boolean;
   };
@@ -293,16 +298,23 @@ export function buildParityBridge(
       const ref = getRef();
       const snapshot = ref?.createAIEditSnapshot();
       if (!ref || !snapshot) {
-        return { snapshotBlockIds: [], rects: [], missingIsNull: true, hasScrollRoot: false };
+        return { rects: [], missingIsNull: true, hasScrollRoot: false };
       }
       const blockIds = snapshot.blocks.map(({ id }) => id);
       const rects = ref.getBlockRects(blockIds);
       return {
-        snapshotBlockIds: blockIds,
-        rects: blockIds.flatMap((blockId) => {
-          const rect = rects.get(blockId);
+        rects: blockIds.flatMap((snapshotBlockId) => {
+          const rect = rects.get(snapshotBlockId);
           return rect
-            ? [{ blockId: rect.blockId, page: rect.page, top: rect.top, height: rect.height }]
+            ? [
+                {
+                  snapshotBlockId,
+                  blockId: rect.blockId,
+                  page: rect.page,
+                  top: rect.top,
+                  height: rect.height,
+                },
+              ]
             : [];
         }),
         missingIsNull: ref.getBlockRect("missing-block-id") === null,

--- a/packages/playground-vue/src/parityBridge.ts
+++ b/packages/playground-vue/src/parityBridge.ts
@@ -56,6 +56,7 @@ export type FolioParityBridge = {
   aiSnapshotBlockCount: () => number;
   /** Painted geometry exposed through the public ref contract. */
   readBlockGeometry: () => {
+    snapshotBlockIds: string[];
     rects: { blockId: string; page: number; top: number; height: number }[];
     missingIsNull: boolean;
     hasScrollRoot: boolean;
@@ -292,11 +293,12 @@ export function buildParityBridge(
       const ref = getRef();
       const snapshot = ref?.createAIEditSnapshot();
       if (!ref || !snapshot) {
-        return { rects: [], missingIsNull: true, hasScrollRoot: false };
+        return { snapshotBlockIds: [], rects: [], missingIsNull: true, hasScrollRoot: false };
       }
       const blockIds = snapshot.blocks.map(({ id }) => id);
       const rects = ref.getBlockRects(blockIds);
       return {
+        snapshotBlockIds: blockIds,
         rects: blockIds.flatMap((blockId) => {
           const rect = rects.get(blockId);
           return rect

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -108,6 +108,7 @@ export type FolioParityBridge = {
   aiSnapshotBlockCount: () => number;
   /** Painted geometry exposed through the public ref contract. */
   readBlockGeometry: () => {
+    snapshotBlockIds: string[];
     rects: { blockId: string; page: number; top: number; height: number }[];
     missingIsNull: boolean;
     hasScrollRoot: boolean;
@@ -344,11 +345,12 @@ function buildParityBridge(
       const ref = getRef();
       const snapshot = ref?.createAIEditSnapshot();
       if (!ref || !snapshot) {
-        return { rects: [], missingIsNull: true, hasScrollRoot: false };
+        return { snapshotBlockIds: [], rects: [], missingIsNull: true, hasScrollRoot: false };
       }
       const blockIds = snapshot.blocks.map(({ id }) => id);
       const rects = ref.getBlockRects(blockIds);
       return {
+        snapshotBlockIds: blockIds,
         rects: blockIds.flatMap((blockId) => {
           const rect = rects.get(blockId);
           return rect

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -108,8 +108,13 @@ export type FolioParityBridge = {
   aiSnapshotBlockCount: () => number;
   /** Painted geometry exposed through the public ref contract. */
   readBlockGeometry: () => {
-    snapshotBlockIds: string[];
-    rects: { blockId: string; page: number; top: number; height: number }[];
+    rects: {
+      snapshotBlockId: string;
+      blockId: string;
+      page: number;
+      top: number;
+      height: number;
+    }[];
     missingIsNull: boolean;
     hasScrollRoot: boolean;
   };
@@ -345,16 +350,23 @@ function buildParityBridge(
       const ref = getRef();
       const snapshot = ref?.createAIEditSnapshot();
       if (!ref || !snapshot) {
-        return { snapshotBlockIds: [], rects: [], missingIsNull: true, hasScrollRoot: false };
+        return { rects: [], missingIsNull: true, hasScrollRoot: false };
       }
       const blockIds = snapshot.blocks.map(({ id }) => id);
       const rects = ref.getBlockRects(blockIds);
       return {
-        snapshotBlockIds: blockIds,
-        rects: blockIds.flatMap((blockId) => {
-          const rect = rects.get(blockId);
+        rects: blockIds.flatMap((snapshotBlockId) => {
+          const rect = rects.get(snapshotBlockId);
           return rect
-            ? [{ blockId: rect.blockId, page: rect.page, top: rect.top, height: rect.height }]
+            ? [
+                {
+                  snapshotBlockId,
+                  blockId: rect.blockId,
+                  page: rect.page,
+                  top: rect.top,
+                  height: rect.height,
+                },
+              ]
             : [];
         }),
         missingIsNull: ref.getBlockRect("missing-block-id") === null,

--- a/tests/parity/paged-editor-ref.spec.ts
+++ b/tests/parity/paged-editor-ref.spec.ts
@@ -48,8 +48,8 @@ forEachAdapter(
     const rects = geometry?.rects ?? [];
     // Snapshot order is document order, not vertical order: table cells can
     // share a top coordinate, and later page columns can reset it.
-    expect(rects.map(({ blockId }) => blockId)).toEqual(geometry?.snapshotBlockIds);
     for (const rect of rects) {
+      expect(rect.blockId).toBe(rect.snapshotBlockId);
       expect(Number.isInteger(rect.page)).toBe(true);
       expect(rect.page).toBeGreaterThan(0);
       expect(Number.isFinite(rect.top)).toBe(true);

--- a/tests/parity/paged-editor-ref.spec.ts
+++ b/tests/parity/paged-editor-ref.spec.ts
@@ -46,14 +46,16 @@ forEachAdapter(
     expect(geometry?.rects.length).toBeGreaterThan(1);
 
     const rects = geometry?.rects ?? [];
-    for (let index = 1; index < rects.length; index += 1) {
-      const previous = rects[index - 1];
-      const current = rects[index];
-      if (!previous || !current || previous.page !== current.page) {
-        continue;
-      }
-      expect(current.top).toBeGreaterThan(previous.top);
-      expect(current.height).toBeGreaterThan(0);
+    // Snapshot order is document order, not vertical order: table cells can
+    // share a top coordinate, and later page columns can reset it.
+    expect(rects.map(({ blockId }) => blockId)).toEqual(geometry?.snapshotBlockIds);
+    for (const rect of rects) {
+      expect(Number.isInteger(rect.page)).toBe(true);
+      expect(rect.page).toBeGreaterThan(0);
+      expect(Number.isFinite(rect.top)).toBe(true);
+      expect(rect.top).toBeGreaterThanOrEqual(0);
+      expect(Number.isFinite(rect.height)).toBe(true);
+      expect(rect.height).toBeGreaterThan(0);
     }
   },
 );

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -36,6 +36,7 @@ type FolioParityBridge = {
   countCommentAnchors: () => number;
   aiSnapshotBlockCount: () => number;
   readBlockGeometry: () => {
+    snapshotBlockIds: string[];
     rects: { blockId: string; page: number; top: number; height: number }[];
     missingIsNull: boolean;
     hasScrollRoot: boolean;

--- a/tests/parity/parity-fixture.ts
+++ b/tests/parity/parity-fixture.ts
@@ -36,8 +36,13 @@ type FolioParityBridge = {
   countCommentAnchors: () => number;
   aiSnapshotBlockCount: () => number;
   readBlockGeometry: () => {
-    snapshotBlockIds: string[];
-    rects: { blockId: string; page: number; top: number; height: number }[];
+    rects: {
+      snapshotBlockId: string;
+      blockId: string;
+      page: number;
+      top: number;
+      height: number;
+    }[];
     missingIsNull: boolean;
     hasScrollRoot: boolean;
   };


### PR DESCRIPTION
Fixes the nightly parity assertion for valid two-dimensional layouts. Snapshot document order does not imply strictly increasing vertical coordinates: separate table cells can share a row, and later columns can restart near the page top.

The parity bridge now reports the source snapshot IDs. The cross-adapter check verifies one-to-one snapshot alignment, valid page numbers, finite nonnegative tops, and positive finite heights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block geometry information now includes snapshot block IDs, preserving document-order alignment.
  * Empty geometry responses consistently return an empty snapshot ID list.

* **Tests**
  * Improved validation of block ordering and geometry, including page, position, and height values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->