### PR TITLE
fix: read bounded archives without Node streams

### DIFF
--- a/.changeset/neutral-archive-streams.md
+++ b/.changeset/neutral-archive-streams.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Read bounded DOCX archive entries through JSZip's platform-neutral internal stream instead of Node streams, so `ensureParaIds` and `loadDocxArchive` work in browsers and web workers.

--- a/packages/core/src/docx/ensureParaIds.test.ts
+++ b/packages/core/src/docx/ensureParaIds.test.ts
@@ -69,6 +69,23 @@ const collectTextIds = (xml: string): string[] =>
 const PARA = (text: string, attrs = ""): string =>
   `<w:p${attrs}><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
+/** JSZip reports this capability at runtime; the published typings omit it. */
+const NODE_STREAM_SUPPORT = "nodestream";
+
+/**
+ * Run `work` with JSZip reporting the capabilities of a browser or web worker,
+ * where `readable-stream` is absent and `nodeStream` throws.
+ */
+const withoutNodeStreamSupport = async <T>(work: () => Promise<T>): Promise<T> => {
+  const supported: unknown = Reflect.get(JSZip.support, NODE_STREAM_SUPPORT);
+  Reflect.set(JSZip.support, NODE_STREAM_SUPPORT, false);
+  try {
+    return await work();
+  } finally {
+    Reflect.set(JSZip.support, NODE_STREAM_SUPPORT, supported);
+  }
+};
+
 describe("ensureParaIds", () => {
   test("backfills paraId + textId on every paragraph, including table cells", async () => {
     const input = await buildDocx({
@@ -387,6 +404,20 @@ describe("ensureParaIds", () => {
     const input = await zip.generateAsync({ type: "uint8array" });
 
     await expect(ensureParaIds(input)).rejects.toThrow(EnsureParaIdsError);
+  });
+
+  test("normalizes a package on a platform without Node streams", async () => {
+    // `@stll/folio-core/server` is DOM-free, not Node-only: browsers and web
+    // workers have no `readable-stream`, so no read path may reach
+    // `JSZipObject.nodeStream`.
+    const input = await buildDocx({
+      "word/document.xml": documentXml(`${PARA("First")}${PARA("Second")}`),
+    });
+
+    const result = await withoutNodeStreamSupport(async () => await ensureParaIds(input));
+
+    expect(result.assigned).toBe(2);
+    expect(collectIds(await getPart(result.docx, "word/document.xml"))).toHaveLength(2);
   });
 
   test("wraps malformed ZIP input in EnsureParaIdsError", async () => {

--- a/packages/core/src/docx/server/boundedArchive.test.ts
+++ b/packages/core/src/docx/server/boundedArchive.test.ts
@@ -3,12 +3,29 @@ import JSZip from "jszip";
 
 import { DocxArchiveError, loadDocxArchive } from "./boundedArchive";
 
-const makeZip = async (entries: Record<string, string>): Promise<Uint8Array> => {
+const makeZip = async (entries: Record<string, string | Uint8Array>): Promise<Uint8Array> => {
   const zip = new JSZip();
   for (const [path, content] of Object.entries(entries)) {
     zip.file(path, content);
   }
   return await zip.generateAsync({ type: "uint8array" });
+};
+
+/** JSZip reports this capability at runtime; the published typings omit it. */
+const NODE_STREAM_SUPPORT = "nodestream";
+
+/**
+ * Run `work` with JSZip reporting the capabilities of a browser or web worker,
+ * where `readable-stream` is absent and `nodeStream` throws.
+ */
+const withoutNodeStreamSupport = async <T>(work: () => Promise<T>): Promise<T> => {
+  const supported: unknown = Reflect.get(JSZip.support, NODE_STREAM_SUPPORT);
+  Reflect.set(JSZip.support, NODE_STREAM_SUPPORT, false);
+  try {
+    return await work();
+  } finally {
+    Reflect.set(JSZip.support, NODE_STREAM_SUPPORT, supported);
+  }
 };
 
 const rejection = async (promise: Promise<unknown>): Promise<unknown> => {
@@ -131,6 +148,57 @@ describe("loadDocxArchive", () => {
     expect(results.map(({ status }) => status)).toEqual(["fulfilled", "fulfilled", "rejected"]);
     expect(results.at(2)).toMatchObject({
       reason: { reason: "total-too-large" },
+    });
+  });
+
+  test("keeps a UTF-8 BOM in decoded part text", async () => {
+    // Word writes a BOM on OOXML parts. Callers splice part text and write it
+    // back, so decoding must not silently drop it.
+    const bytes = await makeZip({
+      "word/document.xml": new Uint8Array([0xef, 0xbb, 0xbf, 0x3c, 0x61, 0x2f, 0x3e]),
+    });
+    const archive = await loadDocxArchive(bytes);
+
+    expect(await archive.readEntryString("word/document.xml")).toBe("\uFEFF<a/>");
+  });
+});
+
+describe("loadDocxArchive on a platform without Node streams", () => {
+  test("the simulation removes the Node stream path", async () => {
+    const zip = await JSZip.loadAsync(await makeZip({ entry: "content" }));
+    const entry = zip.file("entry");
+    if (!entry) {
+      throw new Error("Expected the fixture entry to exist");
+    }
+
+    await withoutNodeStreamSupport(async () => {
+      expect(() => entry.nodeStream()).toThrow("nodestream is not supported by this platform");
+    });
+  });
+
+  test("reads text and bytes and still enforces the entry cap", async () => {
+    await withoutNodeStreamSupport(async () => {
+      const archive = await loadDocxArchive(await makeZip({ large: "12345", small: "123" }));
+
+      expect(await archive.readEntryString("large")).toBe("12345");
+      expect(await archive.readEntryUint8("small")).toEqual(new Uint8Array([49, 50, 51]));
+      await expect(archive.readEntryUint8("large", { maxBytes: 4 })).rejects.toMatchObject({
+        reason: "entry-too-large",
+      });
+    });
+  });
+
+  test("still enforces the cumulative cap across reads", async () => {
+    await withoutNodeStreamSupport(async () => {
+      const archive = await loadDocxArchive(await makeZip({ a: "12345", b: "678" }), {
+        maxTotalBytes: 8,
+      });
+
+      expect(await archive.readEntryString("a")).toBe("12345");
+      expect(await archive.readEntryString("b")).toBe("678");
+      await expect(archive.readEntryString("a")).rejects.toMatchObject({
+        reason: "total-too-large",
+      });
     });
   });
 });

--- a/packages/core/src/docx/server/boundedArchive.ts
+++ b/packages/core/src/docx/server/boundedArchive.ts
@@ -1,6 +1,19 @@
 import { TaggedError } from "better-result";
 import JSZip from "jszip";
 
+declare module "jszip" {
+  // oxlint-disable-next-line typescript/consistent-type-definitions -- declaration merging requires an interface
+  interface JSZipObject {
+    /**
+     * Chunked read of the entry content, missing from the published typings.
+     * `nodeStream` is this stream wrapped in a Node.js `Readable`, which
+     * browsers and web workers cannot provide; the stream itself is
+     * platform-neutral.
+     */
+    internalStream(type: "uint8array"): JSZip.JSZipStreamHelper<Uint8Array>;
+  }
+}
+
 export const DOCX_MAX_ENTRY_BYTES = 128 * 1024 * 1024;
 export const DOCX_MAX_TOTAL_BYTES = 256 * 1024 * 1024;
 export const DOCX_MAX_ENTRIES = 4096;
@@ -43,52 +56,69 @@ export type DocxArchive = {
   readEntryUint8: (path: string, options?: DocxArchiveReadOptions) => Promise<Uint8Array | null>;
 };
 
+const concatChunks = (chunks: readonly Uint8Array[]): Uint8Array => {
+  let totalBytes = 0;
+  for (const chunk of chunks) {
+    totalBytes += chunk.length;
+  }
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+};
+
 type CollectStreamOptions = {
-  stream: NodeJS.ReadableStream;
+  stream: JSZip.JSZipStreamHelper<Uint8Array>;
   maxEntryBytes: number;
   remainingBytes: number;
   maxTotalBytes: number;
   path: string;
 };
 
+/**
+ * Accumulate an entry chunk by chunk, checking both caps before each chunk is
+ * retained. Pausing the stream abandons a decompression bomb mid-inflate, so
+ * the caps bound memory instead of merely reporting the overrun afterwards.
+ */
 const collectStream = async ({
   stream,
   maxEntryBytes,
   remainingBytes,
   maxTotalBytes,
   path,
-}: CollectStreamOptions): Promise<Buffer> =>
-  await new Promise<Buffer>((resolve, reject) => {
-    const chunks: Buffer[] = [];
+}: CollectStreamOptions): Promise<Uint8Array> =>
+  await new Promise<Uint8Array>((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
     let entryBytes = 0;
 
     const fail = (reason: "entry-too-large" | "total-too-large", message: string) => {
-      const destroy: unknown = Reflect.get(stream, "destroy");
-      if (typeof destroy === "function") {
-        Reflect.apply(destroy, stream, []);
-      }
+      stream.pause();
       reject(new DocxArchiveError({ message, reason }));
     };
 
-    stream.on("data", (chunk: Buffer | string) => {
-      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      entryBytes += bytes.length;
+    stream
+      .on("data", (chunk) => {
+        entryBytes += chunk.length;
 
-      if (entryBytes > maxEntryBytes) {
-        fail("entry-too-large", `DOCX entry "${path}" exceeded the ${maxEntryBytes}-byte limit`);
-        return;
-      }
-      if (entryBytes > remainingBytes) {
-        fail(
-          "total-too-large",
-          `DOCX archive exceeded the ${maxTotalBytes}-byte cumulative limit while reading "${path}"`,
-        );
-        return;
-      }
-      chunks.push(bytes);
-    });
-    stream.on("end", () => resolve(Buffer.concat(chunks)));
-    stream.on("error", reject);
+        if (entryBytes > maxEntryBytes) {
+          fail("entry-too-large", `DOCX entry "${path}" exceeded the ${maxEntryBytes}-byte limit`);
+          return;
+        }
+        if (entryBytes > remainingBytes) {
+          fail(
+            "total-too-large",
+            `DOCX archive exceeded the ${maxTotalBytes}-byte cumulative limit while reading "${path}"`,
+          );
+          return;
+        }
+        chunks.push(chunk);
+      })
+      .on("end", () => resolve(concatChunks(chunks)))
+      .on("error", reject)
+      .resume();
   });
 
 const getDeclaredUncompressedBytes = (entry: JSZip.JSZipObject): number | null => {
@@ -200,26 +230,26 @@ export const loadDocxArchive = async (
   const readEntry = async (
     path: string,
     readOptions: DocxArchiveReadOptions = {},
-  ): Promise<Buffer | null> => {
+  ): Promise<Uint8Array | null> => {
     const requestedMaxBytes = resolveByteLimit({
       value: readOptions.maxBytes,
       fallback: maxEntryBytes,
       name: "DOCX entry read byte limit",
     });
-    const work = async (): Promise<Buffer | null> => {
+    const work = async (): Promise<Uint8Array | null> => {
       const entry = zip.file(path);
       if (!entry) {
         return null;
       }
-      const buffer = await collectStream({
-        stream: entry.nodeStream("nodebuffer"),
+      const content = await collectStream({
+        stream: entry.internalStream("uint8array"),
         maxEntryBytes: Math.min(requestedMaxBytes, maxEntryBytes),
         remainingBytes: maxTotalBytes - totalBytesRead,
         maxTotalBytes,
         path,
       });
-      totalBytesRead += buffer.length;
-      return buffer;
+      totalBytesRead += content.length;
+      return content;
     };
 
     const next = readChain.then(work, work);
@@ -240,12 +270,14 @@ export const loadDocxArchive = async (
       })),
     ),
     async readEntryString(path) {
-      const buffer = await readEntry(path);
-      return buffer === null ? null : buffer.toString("utf-8");
+      const content = await readEntry(path);
+      // `ignoreBOM` keeps a leading U+FEFF in the string: OOXML parts written
+      // by Word carry a UTF-8 BOM, and callers that splice a part and write it
+      // back must not silently drop it.
+      return content === null
+        ? null
+        : new TextDecoder("utf-8", { ignoreBOM: true }).decode(content);
     },
-    async readEntryUint8(path, readOptions) {
-      const buffer = await readEntry(path, readOptions);
-      return buffer === null ? null : new Uint8Array(buffer);
-    },
+    readEntryUint8: readEntry,
   };
 };


### PR DESCRIPTION
## Proposed change

<!--
  Brief description of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

## Checklist

<!--
  Put into **bold** for each item the appropriate option.
  Then mark the item with an `x` like so:
  `- [ ] BUILD ASSURANCE | Confirm that your code builds correctly and without any errors or warnings.
-->

- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [ ] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DOCX archive processing now works in browser and web-worker environments without Node.js stream support.
  - Improved handling preserves leading UTF-8 byte-order marks when reading archive entries.

- **Bug Fixes**
  - Archive entry and cumulative size limits are now enforced consistently across supported environments.
  - Paragraph identifiers can now be normalised reliably when processing DOCX files outside Node.js.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->