### PR TITLE
fix: keep rewritten tracked changes readable

### DIFF
--- a/.changeset/calm-words-flow.md
+++ b/.changeset/calm-words-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep rewritten tracked-change clauses readable by matching words with their surrounding whitespace.

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1098,15 +1098,15 @@ describe("Folio AI edit operations", () => {
       marksByText[node.text ?? ""] = node.marks.map((mark) => mark.type.name);
     });
     // Shared tokens carry no tracked-change marks.
-    for (const shared of ["The buyer ", " pay the seller within ", " days."]) {
+    for (const shared of ["The buyer", " pay the seller within", " days."]) {
       expect(marksByText[shared] ?? []).not.toContain("insertion");
       expect(marksByText[shared] ?? []).not.toContain("deletion");
     }
-    // Diverging tokens carry exactly the right marks.
-    expect(marksByText["shall"]).toContain("deletion");
-    expect(marksByText["must"]).toContain("insertion");
-    expect(marksByText["thirty"]).toContain("deletion");
-    expect(marksByText["sixty"]).toContain("insertion");
+    // Diverging tokens carry their leading whitespace and exactly the right marks.
+    expect(marksByText[" shall"]).toContain("deletion");
+    expect(marksByText[" must"]).toContain("insertion");
+    expect(marksByText[" thirty"]).toContain("deletion");
+    expect(marksByText[" sixty"]).toContain("insertion");
   });
 
   test("snapshot and apply ignore existing tracked-change marks", () => {
@@ -1550,8 +1550,8 @@ describe("Folio AI edit operations", () => {
   test("word-level diff works for non-Latin scripts split on whitespace", () => {
     // Czech / German / French / Polish all split on whitespace, so
     // the same LCS path applies — only the diverging Czech token
-    // should carry tracked-change marks. Locks in that the regex
-    // tokeniser handles diacritics without pre/post-processing.
+    // should carry tracked-change marks. Locks in that the tokeniser
+    // handles diacritics without pre/post-processing.
     const view = makeView(makeState(["Kupující musí zaplatit do třiceti dnů."]));
     const snapshot = createFolioAIEditSnapshot(view.state.doc);
 
@@ -1576,9 +1576,9 @@ describe("Folio AI edit operations", () => {
       }
       marksByText[node.text ?? ""] = node.marks.map((mark) => mark.type.name);
     });
-    expect(marksByText["třiceti"]).toContain("deletion");
-    expect(marksByText["šedesáti"]).toContain("insertion");
-    expect(marksByText["Kupující musí zaplatit do "] ?? []).not.toContain("deletion");
+    expect(marksByText[" třiceti"]).toContain("deletion");
+    expect(marksByText[" šedesáti"]).toContain("insertion");
+    expect(marksByText["Kupující musí zaplatit do"] ?? []).not.toContain("deletion");
   });
 
   test("insertAfterBlock anchored inside a table cell lands after the table, not in the cell", () => {

--- a/packages/core/src/ai-edits/word-diff.test.ts
+++ b/packages/core/src/ai-edits/word-diff.test.ts
@@ -29,6 +29,48 @@ describe("diffWordSegments", () => {
     expect(segments.some((s) => s.type === "ins" && s.text.includes("slow"))).toBe(true);
   });
 
+  test("does not use whitespace-only matches to interleave rewritten clauses", () => {
+    const before =
+      "The Supplier shall deliver the Goods within thirty days after receipt of the Purchase Order.";
+    const after =
+      "The Vendor must provide all Products no later than twenty business days following receipt of a valid order.";
+
+    const segments = diffWordSegments(before, after);
+
+    expect(segments).toEqual([
+      { type: "equal", text: "The" },
+      {
+        type: "del",
+        text: " Supplier shall deliver the Goods within thirty",
+      },
+      {
+        type: "ins",
+        text: " Vendor must provide all Products no later than twenty business",
+      },
+      { type: "equal", text: " days" },
+      { type: "del", text: " after" },
+      { type: "ins", text: " following" },
+      { type: "equal", text: " receipt of" },
+      { type: "del", text: " the Purchase Order." },
+      { type: "ins", text: " a valid order." },
+    ]);
+    expect(
+      segments.filter(({ type }) => type === "equal").every(({ text }) => /\S/u.test(text)),
+    ).toBe(true);
+    expect(
+      segments
+        .filter(({ type }) => type !== "ins")
+        .map(({ text }) => text)
+        .join(""),
+    ).toBe(before);
+    expect(
+      segments
+        .filter(({ type }) => type !== "del")
+        .map(({ text }) => text)
+        .join(""),
+    ).toBe(after);
+  });
+
   test("returns empty segments for two empty strings", () => {
     expect(diffWordSegments("", "")).toEqual([]);
   });
@@ -37,8 +79,7 @@ describe("diffWordSegments", () => {
     // Regression guard for the word-diff DoS fix: diffWordSegments used to
     // allocate an unbounded (m+1)*(n+1) DP table for two attacker-controlled
     // strings inside one `modified` block pair. 2,001 distinct words each
-    // tokenize (tokenize() also emits the whitespace runs as their own
-    // tokens) to 4,001 tokens; 4,001 * 4,001 = 16,008,001 cells, well over
+    // tokenize to 2,001 tokens; 2,001 * 2,001 = 4,004,001 cells, just over
     // the 4,000,000-cell budget, so the DP must be skipped entirely.
     const before = Array.from({ length: 2001 }, (_, i) => `before${i}`).join(" ");
     const after = Array.from({ length: 2001 }, (_, i) => `after${i}`).join(" ");

--- a/packages/core/src/ai-edits/word-diff.ts
+++ b/packages/core/src/ai-edits/word-diff.ts
@@ -15,7 +15,36 @@ export type WordDiffSegment = {
   text: string;
 };
 
-const tokenize = (s: string): string[] => s.match(/\s+|\S+/gu) ?? [];
+const WHITESPACE = /\s/u;
+
+const tokenize = (s: string): string[] => {
+  const tokens = [];
+  let tokenStart = 0;
+  let cursor = 0;
+  // Walk once instead of backtracking across untrusted whitespace-only document text.
+  while (cursor < s.length) {
+    while (cursor < s.length && WHITESPACE.test(s.charAt(cursor))) {
+      cursor++;
+    }
+    if (cursor === s.length) {
+      break;
+    }
+    while (cursor < s.length && !WHITESPACE.test(s.charAt(cursor))) {
+      cursor++;
+    }
+    tokens.push(s.slice(tokenStart, cursor));
+    tokenStart = cursor;
+  }
+
+  const last = tokens.at(-1);
+  if (last === undefined) {
+    return s.length === 0 ? [] : [s];
+  }
+  if (tokenStart < s.length) {
+    tokens[tokens.length - 1] = last + s.slice(tokenStart);
+  }
+  return tokens;
+};
 
 /**
  * Cell budget for the O(n*m) word-diff DP table below, mirroring

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -262,9 +262,9 @@ describe("compareDocxVersions: real w14:paraId alignment", () => {
     }
     expect(modified.kind).toBe("paragraph");
     expect(modified.segments).toEqual([
-      { type: "equal", text: "Beta " },
-      { type: "del", text: "paragraph." },
-      { type: "ins", text: "clause." },
+      { type: "equal", text: "Beta" },
+      { type: "del", text: " paragraph." },
+      { type: "ins", text: " clause." },
     ]);
 
     const deleted = findChange(diff.changes, "00000003");


### PR DESCRIPTION
## Summary

- bind whitespace to lexical tokens so whitespace-only matches cannot fragment rewritten clauses
- preserve exact original and revised text reconstruction while improving native tracked-change boundaries
- cover word diffs, AI edits, and version comparison expectations; include a patch changeset

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracked-change rewriting so surrounding whitespace remains attached to the correct words.
  * Enhanced readability of rewritten clauses and paragraph differences.
  * Corrected handling of whitespace-only differences and all-whitespace text.

* **Tests**
  * Added coverage for whitespace-aware word comparisons and large-text fallback behaviour.
  * Updated diff expectations to reflect more accurate segment boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->