### PR TITLE
feat(docx-core): parse legal source as GFM markdown plus directives

### DIFF
--- a/.changeset/markdown-legal-source-compiler.md
+++ b/.changeset/markdown-legal-source-compiler.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": patch
+---
+
+Parse legal-source drafts as GFM markdown plus `@` directives with `marked`: clause bodies, list items, and table cells keep inline emphasis, links, and code spans; markdown lists and pipe tables outside a directive become real list and table blocks. `compileMarkdownToContent` and `sanitizeExternalUrl` move into `@stll/docx-core`, and `@stll/folio-core`'s `fromMarkdown` now wraps them.

--- a/.oxlint-plugins/folio-layer-boundaries.ts
+++ b/.oxlint-plugins/folio-layer-boundaries.ts
@@ -467,6 +467,13 @@ const isUrlConstruction = (node: AstNode): boolean => {
   return isAstNode(callee) && callee.type === "Identifier" && callee.name === "URL";
 };
 
+// `new URL(specifier, import.meta.url)` resolves a module-relative asset,
+// which is how a kernel bundle would be loaded. A single-argument `new
+// URL(value)` only parses an absolute URL (link validation) and cannot reach
+// a package asset, so it is not a boundary reference.
+const isModuleRelativeUrlConstruction = (node: AstNode): boolean =>
+  isUrlConstruction(node) && Array.isArray(node.arguments) && node.arguments.length >= 2;
+
 const generatedKernelAssetOf = (node: AstNode): string | null => {
   if (!isUrlConstruction(node)) {
     return null;
@@ -486,7 +493,7 @@ const checkProjectionBoundary = (context: RuleContext, node: AstNode): void => {
   const specifier = importSpecifierOf(node);
   const generatedAsset = generatedKernelAssetOf(node);
   const opaqueBoundaryReference =
-    (isUrlConstruction(node) && generatedAsset === null) ||
+    (isModuleRelativeUrlConstruction(node) && generatedAsset === null) ||
     (node.type === "ImportExpression" && specifier === null);
   const importerPath = filenameOf(context);
   if (

--- a/api-reports/docx-core/index.api.md
+++ b/api-reports/docx-core/index.api.md
@@ -41,6 +41,9 @@ export const compileLegalSourceToDocument: (source: string, options?: LegalSourc
 export const compileLegalSourceToDocx: (source: string, options?: LegalSourceCompileOptions) => Promise<LegalSourceDocxCompileResult>;
 
 // @public
+export const compileMarkdownToContent: (markdown: string) => MarkdownContent;
+
+// @public
 type Document_2 = {
     package: DocxPackage;
     originalBuffer?: ArrayBuffer;
@@ -114,7 +117,7 @@ export type LegalDraft = {
     blocks: LegalDraftBlock[];
 };
 
-// @public (undocumented)
+// @public
 export type LegalDraftBlock = {
     type: "title";
     text: string;
@@ -185,6 +188,12 @@ export type LegalSourceParseResult = {
     diagnostics: LegalDraftDiagnostic[];
 };
 
+// @public
+export type MarkdownContent = {
+    content: BlockContent[];
+    numbering?: NumberingDefinitions;
+};
+
 // @public (undocumented)
 export type Paragraph = {
     type: "paragraph";
@@ -224,6 +233,9 @@ export type Run = {
 
 // @public
 export type RunContent = TextContent | TabContent | BreakContent | SymbolContent | NoteReferenceContent | FieldCharContent | InstrTextContent | SoftHyphenContent | NoBreakHyphenContent | RenderedPageBreakContent | DrawingContent | ShapeContent;
+
+// @public
+export const sanitizeExternalUrl: (rawUrl: string | undefined) => string | undefined;
 
 // @public (undocumented)
 export type SectionProperties = {

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,6 @@
         "fast-xml-parser": "^5.10.1",
         "hyphen": "1.14.1",
         "jszip": "3.10.1",
-        "marked": "^18.0.5",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-gapcursor": "^1.4.1",
@@ -93,6 +92,7 @@
         "better-result": "3.0.1",
         "fast-xml-parser": "^5.10.1",
         "jszip": "3.10.1",
+        "marked": "^18.0.5",
       },
       "devDependencies": {
         "bun-types": "1.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,6 @@
     "fast-xml-parser": "^5.10.1",
     "hyphen": "1.14.1",
     "jszip": "3.10.1",
-    "marked": "^18.0.5",
     "prosemirror-commands": "^1.7.1",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-gapcursor": "^1.4.1",

--- a/packages/core/src/markdown/fromMarkdown.ts
+++ b/packages/core/src/markdown/fromMarkdown.ts
@@ -1,364 +1,25 @@
 /**
  * Markdown → DOCX-document import — the inverse of {@link toMarkdown} and the
- * second half of the skills bridge. Parses the GFM subset skill bodies use
- * (headings, paragraphs, bold/italic/strike, inline code, bullet + ordered
- * lists incl. nesting, pipe tables, blockquotes, links) into the docx
- * `Document` model so a skill's markdown can be edited in the Folio editor and
- * re-exported with {@link toMarkdown} without drift.
+ * second half of the skills bridge. The parsing lives in `@stll/docx-core`
+ * (`compileMarkdownToContent`), the same GFM reader the legal-source compiler
+ * uses; this wrapper only places the blocks into an editor-ready `Document`.
  *
  * Round-trip notes:
- * - Lists are emitted as real list paragraphs (`listRendering`), so the editor
- *   shows a marker and {@link toMarkdown} re-derives `- ` / `1. ` rather than
- *   leaking a literal bullet glyph into the text.
- * - Inline code uses `Courier New` — a whitelisted monospace family that
- *   {@link toMarkdown} infers back to a backtick span (Folio renders it via its
- *   bundled Cousine substitute).
+ * - Lists arrive as real list paragraphs (`listRendering` plus `numPr`) with a
+ *   matching `document.package.numbering`, so the editor shows a marker and
+ *   {@link toMarkdown} re-derives `- ` / `1. ` rather than leaking a literal
+ *   bullet glyph. Merging this content onto another document that has its own
+ *   numbering (e.g. a styled preset) needs `mergeDocumentContent` to renumber
+ *   the two numbering namespaces apart.
  * - Markdown carries no page geometry, so the section is flattened to a
  *   continuous, header/footer-free band (a skill body is a document, not a
  *   Word page). Headers/footers live outside `document.content` and are never
  *   produced here.
- * - Every markdown list also gets a matching `w:abstractNum`/`w:num` pair in
- *   `document.package.numbering` (see {@link buildNumbering}), so the result
- *   is self-consistent and `createDocx` never has to fail with a missing
- *   numbering definition. Merging this content onto another document that
- *   has its own numbering (e.g. a styled preset) needs `mergeDocumentContent`
- *   to renumber the two numbering namespaces apart — appending
- *   `document.package.document.content` directly can collide.
  */
-import { marked, type Token, type Tokens } from "marked";
+import { compileMarkdownToContent } from "@stll/docx-core";
 
-import type {
-  AbstractNumbering,
-  BlockContent,
-  Document,
-  ListLevel,
-  NumberingDefinitions,
-  NumberingInstance,
-  ParagraphContent,
-  ListRendering,
-  Paragraph,
-  Run,
-  Table,
-  TableCell,
-  TableRow,
-} from "../types/document";
+import type { Document } from "../types/document";
 import { createEmptyDocument } from "../utils/createDocument";
-import { sanitizeExternalUrl } from "../utils/urlSecurity";
-
-// Whitelisted by toMarkdown's monospace inference, so a codespan survives the
-// round-trip. Folio renders Courier New through its bundled Cousine face.
-const MONO_FONT = { ascii: "Courier New", hAnsi: "Courier New" } as const;
-
-// marked's `Token` union carries a `Tokens.Generic` member whose `type: string`
-// overlaps every literal (and whose `any` index signature absorbs the whole
-// union, so `Exclude` can't strip it). A plain `token.type === "x"` guard thus
-// narrows to `Tokens.X | Tokens.Generic` and field access stays `any`. This
-// predicate maps the discriminator to the concrete token; the runtime type is
-// exactly the one the discriminator matched because marked only emits Generic
-// for custom extensions, which this lexer setup does not register.
-type HandledTokens = {
-  blockquote: Tokens.Blockquote;
-  code: Tokens.Code;
-  codespan: Tokens.Codespan;
-  del: Tokens.Del;
-  em: Tokens.Em;
-  heading: Tokens.Heading;
-  link: Tokens.Link;
-  list: Tokens.List;
-  paragraph: Tokens.Paragraph;
-  strong: Tokens.Strong;
-  table: Tokens.Table;
-  text: Tokens.Text;
-};
-
-const isTokenType = <T extends keyof HandledTokens>(
-  token: Token,
-  type: T,
-): token is HandledTokens[T] => token.type === type;
-
-type RunFormat = {
-  bold?: boolean;
-  italic?: boolean;
-  strike?: boolean;
-  mono?: boolean;
-};
-
-const textRun = (text: string, fmt: RunFormat = {}): Run => {
-  const formatting = {
-    ...(fmt.bold ? { bold: true } : {}),
-    ...(fmt.italic ? { italic: true } : {}),
-    ...(fmt.strike ? { strike: true } : {}),
-    ...(fmt.mono ? { fontFamily: MONO_FONT } : {}),
-  };
-  // A Word run can't carry a raw newline — a soft/hard break (e.g. two lines in
-  // one blockquote) must be an explicit break node, or the layout engine renders
-  // the lines on top of each other. Split on "\n" into text + break content.
-  const segments = text.split("\n");
-  const content: Run["content"] = [];
-  for (const [index, segment] of segments.entries()) {
-    if (index > 0) {
-      content.push({ type: "break" });
-    }
-    if (segment.length > 0) {
-      content.push({ type: "text", text: segment });
-    }
-  }
-  if (content.length === 0) {
-    content.push({ type: "text", text: "" });
-  }
-  return { type: "run", formatting, content };
-};
-
-const sanitizeMarkdownHref = (rawHref: string): string | undefined => {
-  const trimmed = rawHref.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-
-  if (trimmed.startsWith("#")) {
-    const anchor = trimmed.slice(1);
-    if (!anchor || hasUnsafeAnchorCharacter(anchor)) {
-      return undefined;
-    }
-    return `#${anchor}`;
-  }
-
-  return sanitizeExternalUrl(trimmed);
-};
-
-const hasUnsafeAnchorCharacter = (anchor: string): boolean => {
-  for (const char of anchor) {
-    const codePoint = char.codePointAt(0) ?? 0;
-    if (codePoint <= 0x20 || codePoint === 0x7f || char.trim() === "") {
-      return true;
-    }
-  }
-  return false;
-};
-
-const inlineToRuns = (
-  tokens: Token[] | undefined,
-  fallback: string,
-  base: RunFormat,
-): ParagraphContent[] => {
-  if (!tokens || tokens.length === 0) {
-    return [textRun(fallback, base)];
-  }
-  const runs: ParagraphContent[] = [];
-  for (const token of tokens) {
-    if (isTokenType(token, "strong")) {
-      runs.push(...inlineToRuns(token.tokens, token.text, { ...base, bold: true }));
-    } else if (isTokenType(token, "em")) {
-      runs.push(...inlineToRuns(token.tokens, token.text, { ...base, italic: true }));
-    } else if (isTokenType(token, "del")) {
-      runs.push(...inlineToRuns(token.tokens, token.text, { ...base, strike: true }));
-    } else if (isTokenType(token, "codespan")) {
-      runs.push(textRun(token.text, { ...base, mono: true }));
-    } else if (isTokenType(token, "link")) {
-      const children = inlineToRuns(token.tokens, token.text, base).filter(
-        (child): child is Run => child.type === "run",
-      );
-      const href = sanitizeMarkdownHref(token.href);
-      const linkChildren = children.length > 0 ? children : [textRun(token.text, base)];
-      if (!href) {
-        runs.push(...linkChildren);
-        continue;
-      }
-
-      const anchor = href.startsWith("#") ? href.slice(1) : undefined;
-      runs.push({
-        type: "hyperlink",
-        href,
-        ...(anchor ? { anchor } : {}),
-        children: linkChildren,
-      });
-    } else if (isTokenType(token, "paragraph")) {
-      runs.push(...inlineToRuns(token.tokens, token.text, base));
-    } else if (token.type === "br") {
-      runs.push({ type: "run", content: [{ type: "break" }] });
-    } else if (token.type === "space") {
-      if (runs.length > 0 && token.raw.includes("\n")) {
-        runs.push(textRun("\n", base));
-      }
-    } else if (isTokenType(token, "text")) {
-      const nested = token.tokens;
-      if (nested && nested.length > 0) {
-        runs.push(...inlineToRuns(nested, token.text, base));
-      } else {
-        runs.push(textRun(token.text, base));
-      }
-    } else if ("text" in token && typeof token.text === "string") {
-      runs.push(textRun(token.text, base));
-    }
-  }
-  return runs.length > 0 ? runs : [textRun(fallback, base)];
-};
-
-const para = (runs: ParagraphContent[], styleId?: string): Paragraph => ({
-  type: "paragraph",
-  formatting: styleId ? { styleId } : {},
-  content: runs.length > 0 ? runs : [textRun("")],
-});
-
-const listPara = (runs: ParagraphContent[], rendering: ListRendering): Paragraph => ({
-  type: "paragraph",
-  // Real numbering properties, not just display metadata: the editor's list
-  // commands (Enter continues the list, Tab indents, toggle) and the live
-  // marker counters all key off `numPr`.
-  formatting: { numPr: { numId: rendering.numId, ilvl: rendering.level } },
-  listRendering: rendering,
-  content: runs.length > 0 ? runs : [textRun("")],
-});
-
-// Header cells are not bolded: in GFM the header is positional (first row + the
-// `---` separator), so bolding it would re-export as `**A**` and break the
-// round-trip.
-const cellOf = (cell: Tokens.TableCell): TableCell => ({
-  type: "tableCell",
-  content: [para(inlineToRuns(cell.tokens, cell.text, {}))],
-});
-
-const tableFromToken = (token: Tokens.Table): Table => ({
-  type: "table",
-  rows: [
-    { type: "tableRow", cells: token.header.map((c) => cellOf(c)) },
-    ...token.rows.map(
-      (row): TableRow => ({
-        type: "tableRow",
-        cells: row.map((c) => cellOf(c)),
-      }),
-    ),
-  ],
-});
-
-// Twips (720 = 0.5"). Each deeper level indents one more half-inch, matching
-// the step folio's other synthesized numbering (legal-source's checklist
-// profile) uses for a single-column marker + hanging indent.
-const LIST_INDENT_STEP_TWIPS = 720;
-const LIST_HANGING_INDENT_TWIPS = 360;
-
-/**
- * One `w:abstractNum` level per (numId, ilvl) pair actually used by the
- * markdown, keyed by ilvl. Built alongside the blocks so {@link fromMarkdown}
- * can synthesize `document.package.numbering` afterwards — the DOCX
- * serializer reads numbering defs only from there, never from the
- * editor-only `listRendering` hint (see `numberingSerializer.ts`).
- */
-type NumIdLevels = Map<number, ListLevel>;
-
-const buildListLevel = (ilvl: number, isBullet: boolean, start: number): ListLevel => ({
-  ilvl,
-  ...(!isBullet && { start }),
-  numFmt: isBullet ? "bullet" : "decimal",
-  lvlText: isBullet ? "•" : `%${ilvl + 1}.`,
-  suffix: "tab",
-  pPr: {
-    indentLeft: LIST_INDENT_STEP_TWIPS * (ilvl + 1),
-    indentFirstLine: -LIST_HANGING_INDENT_TWIPS,
-    hangingIndent: true,
-  },
-});
-
-// Real list paragraphs with Word-style template markers ("%1." resolves to the
-// live counter at level 0), so inserted/split items renumber instead of
-// repeating a baked-in number. Each top-level markdown list gets its own numId
-// so separate lists restart at 1; nested lists share the parent's numId at a
-// deeper ilvl. toMarkdown resolves the templates back to concrete "N." markers
-// and normalises bullets to "- ", so the markdown round-trips exactly.
-const listBlocks = (
-  list: Tokens.List,
-  level: number,
-  numId: number,
-  levels: NumIdLevels,
-): BlockContent[] => {
-  const out: BlockContent[] = [];
-  const start = Number(list.start) || 1;
-  const decimalLevels = Array.from({ length: level + 1 }, () => "decimal" as const);
-  // First list to reach this (numId, ilvl) defines the synthesized level —
-  // a nested list that later reuses the same depth under the same numId
-  // shares that counter, matching how `listRendering` already treats it.
-  if (!levels.has(level)) {
-    levels.set(level, buildListLevel(level, !list.ordered, start));
-  }
-  for (const item of list.items) {
-    const rendering: ListRendering = list.ordered
-      ? {
-          marker: `%${level + 1}.`,
-          level,
-          numId,
-          isBullet: false,
-          numFmt: "decimal",
-          levelNumFmts: decimalLevels,
-          ...(start !== 1 && { startOverride: start }),
-        }
-      : { marker: "•", level, numId, isBullet: true };
-    const inlineTokens: Token[] = [];
-    const nestedLists: Tokens.List[] = [];
-    for (const child of item.tokens) {
-      if (isTokenType(child, "list")) {
-        nestedLists.push(child);
-      } else {
-        inlineTokens.push(child);
-      }
-    }
-    out.push(listPara(inlineToRuns(inlineTokens, item.text, {}), rendering));
-    for (const nested of nestedLists) {
-      out.push(...listBlocks(nested, level + 1, numId, levels));
-    }
-  }
-  return out;
-};
-
-/**
- * Allocates one numId per markdown list so each list counts independently,
- * and collects the level definitions {@link fromMarkdown} needs to
- * synthesize `document.package.numbering` for every list it mints.
- */
-type NumIdAllocator = { next: number; levels: Map<number, NumIdLevels> };
-
-const blocksFromTokens = (tokens: Token[] | undefined, numIds: NumIdAllocator): BlockContent[] => {
-  const blocks: BlockContent[] = [];
-  for (const token of tokens ?? []) {
-    if (isTokenType(token, "heading")) {
-      const level = Math.min(Math.max(token.depth, 1), 4);
-      blocks.push(para(inlineToRuns(token.tokens, token.text, {}), `Heading${level}`));
-    } else if (isTokenType(token, "paragraph")) {
-      blocks.push(para(inlineToRuns(token.tokens, token.text, {})));
-    } else if (isTokenType(token, "list")) {
-      const numId = numIds.next++;
-      const levels: NumIdLevels = new Map();
-      numIds.levels.set(numId, levels);
-      blocks.push(...listBlocks(token, 0, numId, levels));
-    } else if (isTokenType(token, "table")) {
-      blocks.push(tableFromToken(token));
-    } else if (isTokenType(token, "code")) {
-      for (const line of token.text.split("\n")) {
-        blocks.push(para([textRun(line.length > 0 ? line : " ", { mono: true })]));
-      }
-    } else if (isTokenType(token, "blockquote")) {
-      for (const inner of blocksFromTokens(token.tokens, numIds)) {
-        const styled: BlockContent =
-          inner.type === "paragraph"
-            ? {
-                ...inner,
-                formatting: { ...inner.formatting, styleId: "Quote" },
-              }
-            : inner;
-        blocks.push(styled);
-      }
-    } else if (token.type === "hr") {
-      blocks.push(para([textRun("———")]));
-    } else if (
-      token.type !== "space" &&
-      "text" in token &&
-      typeof token.text === "string" &&
-      token.text.trim().length > 0
-    ) {
-      blocks.push(para([textRun(token.text)]));
-    }
-  }
-  return blocks;
-};
 
 // Markdown has no running header/footer, so flatten that band (content sits
 // near the top, no inter-page header/footer gap). The page width and side
@@ -380,29 +41,6 @@ const applyMarkdownPageGeometry = (document: Document): void => {
   section.footerDistance = 0;
 };
 
-// One `w:abstractNum` per numId (a 1:1 mapping, so `abstractNumId === numId`
-// keeps the synthesis trivial to reason about — callers merging this into a
-// document with its own numbering should not assume the mapping stays 1:1
-// after remapping; see `mergeDocumentContent`, which renumbers both ids
-// independently). Every level actually visited by that markdown list becomes
-// one `w:lvl`, so `createDocx(fromMarkdown(md))` never references a numId
-// with no definition (`DocxModelValidationError: Numbering definition N is
-// missing`) and the DOCX round-trips through `docxToMarkdown` unchanged.
-const buildNumbering = (numIdLevels: Map<number, NumIdLevels>): NumberingDefinitions => {
-  const abstractNums: AbstractNumbering[] = [];
-  const nums: NumberingInstance[] = [];
-  for (const [numId, levels] of numIdLevels) {
-    const sortedLevels = [...levels.entries()].sort(([a], [b]) => a - b).map(([, lvl]) => lvl);
-    abstractNums.push({
-      abstractNumId: numId,
-      multiLevelType: sortedLevels.length > 1 ? "multilevel" : "singleLevel",
-      levels: sortedLevels,
-    });
-    nums.push({ numId, abstractNumId: numId });
-  }
-  return { abstractNums, nums };
-};
-
 /**
  * Convert a markdown string to a parsed `Document`. Synchronous. The result is
  * ready to hand to the editor (`<DocxEditor document={…} />`) and to re-export
@@ -410,13 +48,12 @@ const buildNumbering = (numIdLevels: Map<number, NumIdLevels>): NumberingDefinit
  */
 export function fromMarkdown(markdown: string): Document {
   const document = createEmptyDocument();
-  const numIds: NumIdAllocator = { next: 1, levels: new Map() };
-  const blocks = blocksFromTokens(marked.lexer(markdown), numIds);
-  if (blocks.length > 0) {
-    document.package.document.content = blocks;
+  const { content, numbering } = compileMarkdownToContent(markdown);
+  if (content.length > 0) {
+    document.package.document.content = content;
   }
-  if (numIds.levels.size > 0) {
-    document.package.numbering = buildNumbering(numIds.levels);
+  if (numbering) {
+    document.package.numbering = numbering;
   }
   applyMarkdownPageGeometry(document);
   return document;

--- a/packages/core/src/utils/urlSecurity.ts
+++ b/packages/core/src/utils/urlSecurity.ts
@@ -1,32 +1,10 @@
-const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+import { sanitizeExternalUrl } from "@stll/docx-core";
+
 const ALLOWED_TARGETS = new Set(["_blank", "_self", "_parent", "_top"]);
 
-export function sanitizeExternalUrl(rawUrl: string | undefined): string | undefined {
-  if (!rawUrl) {
-    return undefined;
-  }
-
-  const trimmed = rawUrl.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-
-  try {
-    const parsed = new URL(trimmed);
-    if (!ALLOWED_URL_PROTOCOLS.has(parsed.protocol)) {
-      return undefined;
-    }
-    if (
-      (parsed.protocol === "mailto:" || parsed.protocol === "tel:") &&
-      parsed.pathname.trim() === ""
-    ) {
-      return undefined;
-    }
-    return parsed.href;
-  } catch {
-    return undefined;
-  }
-}
+// One allowlist for every link that enters a document, whether typed in the
+// editor or parsed from markdown: the rule lives in docx-core.
+export { sanitizeExternalUrl };
 
 export function normalizeUserUrl(rawUrl: string): string {
   const trimmed = rawUrl.trim();

--- a/packages/docx-core/README.md
+++ b/packages/docx-core/README.md
@@ -4,8 +4,9 @@ A typed OOXML/DOCX document model with parsing, validation, and serialization.
 
 The package exposes a structured document model (paragraphs, runs, tables,
 styles, section properties) together with the tools to produce and check DOCX
-packages, plus a legal-source compiler that turns a plain legal draft into that
-model or a finished DOCX file.
+packages, plus a legal-source compiler that turns a legal draft (GFM markdown
+plus `@` directives) into that model or a finished DOCX file, and a plain
+markdown reader (`compileMarkdownToContent`) that shares its parser.
 
 ```ts
 import { compileLegalSourceToDocx, validateDocxPackage } from "@stll/docx-core";
@@ -30,7 +31,8 @@ bun add @stll/docx-core
 
 - `.` — the document model types, the legal-source compiler
   (`parseLegalSource`, `compileLegalSourceToDocument`,
-  `compileLegalSourceToDocx`, `validateLegalDraft`), DOCX serialization
+  `compileLegalSourceToDocx`, `validateLegalDraft`), the markdown reader
+  (`compileMarkdownToContent`, `sanitizeExternalUrl`), DOCX serialization
   (`serializeDocumentToDocx`), and validation (`validateDocxPackage`,
   `validateDocumentModel`, `assertValidDocumentModel`).
 - `./model` — the document model types only.

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "better-result": "3.0.1",
     "fast-xml-parser": "^5.10.1",
-    "jszip": "3.10.1"
+    "jszip": "3.10.1",
+    "marked": "^18.0.5"
   },
   "devDependencies": {
     "bun-types": "1.4.0",

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -35,6 +35,9 @@ export type {
   LegalSourceDocxCompileResult,
   LegalSourceParseResult,
 } from "./legal-source";
+export { compileMarkdownToContent } from "./markdown/content";
+export type { MarkdownContent } from "./markdown/content";
+export { sanitizeExternalUrl } from "./markdown/href";
 export { serializeDocumentToDocx } from "./serialize/docx";
 export {
   assertValidDocumentModel,

--- a/packages/docx-core/src/legal-source/compile.ts
+++ b/packages/docx-core/src/legal-source/compile.ts
@@ -2,7 +2,6 @@ import type {
   BlockContent,
   Document,
   Paragraph,
-  Run,
   SectionProperties,
   StyleDefinitions,
   Table,
@@ -10,6 +9,8 @@ import type {
   TableRow,
 } from "../model/document";
 import type { NumberingDefinitions } from "../model/lists";
+import { inlineMarkdownToRuns, textRun } from "../markdown/inline";
+import type { InlineRunFormat } from "../markdown/inline";
 import { parseLegalSource } from "./parser";
 import type {
   Autofix,
@@ -206,11 +207,12 @@ const appendParagraphs = (content: BlockContent[], paragraphs: string[], styleId
   }
 };
 
-type RunOptions = {
-  bold?: boolean;
-  italic?: boolean;
-};
+type RunOptions = Pick<InlineRunFormat, "bold" | "italic">;
 
+// Draft text is inline GFM markdown: `**bold**`, `*italic*`, links, code
+// spans, and `[[…]]` placeholders, which get a yellow highlight so the
+// reviewing lawyer sees at a glance everything still pending. Surrounding
+// text inherits the run options (bold/italic) but not the highlight.
 const paragraph = (
   text: string,
   styleId: string,
@@ -224,49 +226,16 @@ const paragraph = (
     ...(numPr ? { numPr } : {}),
     ...(pageBreakBefore ? { pageBreakBefore: true } : {}),
   },
-  content: textRunsWithPlaceholders(text, runOptions),
+  content: inlineMarkdownToRuns(text, { base: runOptions, placeholders: true }),
 });
 
-// Split text on `[[…]]` markers into a sequence of runs. Each
-// placeholder becomes its own run with a yellow highlight so the
-// reviewing lawyer sees at a glance everything still pending.
-// Surrounding text inherits the run options (bold/italic) but not
-// the highlight.
-const PLACEHOLDER_PATTERN = /\[\[(?<inner>[^\][]+?)\]\]/gu;
-
-const textRunsWithPlaceholders = (text: string, options: RunOptions = {}): Run[] => {
-  if (!text.includes("[[")) {
-    return [textRun(text, options)];
-  }
-  const runs: Run[] = [];
-  let cursor = 0;
-  for (const match of text.matchAll(PLACEHOLDER_PATTERN)) {
-    const start = match.index;
-    if (start > cursor) {
-      runs.push(textRun(text.slice(cursor, start), options));
-    }
-    const inner = match.groups?.["inner"] ?? "";
-    runs.push(textRun(inner, options, { highlight: "yellow" }));
-    cursor = start + match[0].length;
-  }
-  if (cursor < text.length) {
-    runs.push(textRun(text.slice(cursor), options));
-  }
-  return runs.length > 0 ? runs : [textRun(text, options)];
-};
-
-const textRun = (
-  text: string,
-  options: RunOptions = {},
-  extra: { highlight?: "yellow" } = {},
-): Run => ({
-  type: "run",
-  formatting: {
-    ...(options.bold ? { bold: true } : {}),
-    ...(options.italic ? { italic: true } : {}),
-    ...(extra.highlight ? { highlight: extra.highlight } : {}),
-  },
-  content: [{ type: "text", text, preserveSpace: true }],
+// Signature fields are data (a party name, a signatory, the underscore
+// rule), never markdown; a name with an asterisk or underscore must not
+// turn into emphasis.
+const plainParagraph = (text: string, styleId: string, runOptions: RunOptions = {}): Paragraph => ({
+  type: "paragraph",
+  formatting: { styleId },
+  content: [textRun(text, runOptions)],
 });
 
 const table = (headers: string[], rows: string[][]): Table => ({
@@ -292,20 +261,20 @@ const tableCell = (text: string, header: boolean): TableCell => ({
 // it wrote the document in).
 const signatureTable = (parties: { name: string; signatory?: string; title?: string }[]): Table => {
   const partyList = parties.length > 0 ? parties : [{ name: "", signatory: "", title: "" }];
-  const empty = (): Paragraph => paragraph("", "SignatureSpacer");
+  const empty = (): Paragraph => plainParagraph("", "SignatureSpacer");
 
   const buildCell = (party: { name: string; signatory?: string; title?: string }): TableCell => {
     const cellContent: (Paragraph | Table)[] = [
-      paragraph(party.name, "SignatureParty", { bold: true }),
+      plainParagraph(party.name, "SignatureParty", { bold: true }),
       empty(),
       empty(),
-      paragraph(SIGNATURE_LINE, "SignatureRule"),
+      plainParagraph(SIGNATURE_LINE, "SignatureRule"),
     ];
     if (party.signatory) {
-      cellContent.push(paragraph(party.signatory, "SignatureField"));
+      cellContent.push(plainParagraph(party.signatory, "SignatureField"));
     }
     if (party.title) {
-      cellContent.push(paragraph(party.title, "SignatureField", { italic: true }));
+      cellContent.push(plainParagraph(party.title, "SignatureField", { italic: true }));
     }
     return { type: "tableCell", content: cellContent };
   };

--- a/packages/docx-core/src/legal-source/compile.ts
+++ b/packages/docx-core/src/legal-source/compile.ts
@@ -9,7 +9,7 @@ import type {
   TableRow,
 } from "../model/document";
 import type { NumberingDefinitions } from "../model/lists";
-import { inlineMarkdownToRuns, textRun } from "../markdown/inline";
+import { inlineMarkdownToRuns, plainTextRuns } from "../markdown/inline";
 import type { InlineRunFormat } from "../markdown/inline";
 import { parseLegalSource } from "./parser";
 import type {
@@ -231,11 +231,12 @@ const paragraph = (
 
 // Signature fields are data (a party name, a signatory, the underscore
 // rule), never markdown; a name with an asterisk or underscore must not
-// turn into emphasis.
+// turn into emphasis. Placeholders still get their highlight: a model
+// that does not know the signatory writes `[[name]]` here too.
 const plainParagraph = (text: string, styleId: string, runOptions: RunOptions = {}): Paragraph => ({
   type: "paragraph",
   formatting: { styleId },
-  content: [textRun(text, runOptions)],
+  content: plainTextRuns(text, runOptions),
 });
 
 const table = (headers: string[], rows: string[][]): Table => ({

--- a/packages/docx-core/src/legal-source/legal-source.test.ts
+++ b/packages/docx-core/src/legal-source/legal-source.test.ts
@@ -451,6 +451,100 @@ describe("Stella Legal Source — markdown bodies", () => {
     );
   });
 
+  test("a blank line before a directive never swallows it", () => {
+    const result = parseLegalSource(
+      ["", "@doc title=T", "", "@title T", "", "@clause A", "body", "", "@pagebreak", "", "@clause B", "more"].join(
+        "\n",
+      ),
+    );
+    expect(result.draft.blocks).toEqual([
+      { type: "title", text: "T" },
+      { type: "clause", level: 1, heading: "A", paragraphs: ["body"] },
+      { type: "pageBreak" },
+      { type: "clause", level: 1, heading: "B", paragraphs: ["more"] },
+    ]);
+  });
+
+  test("fenced code stays literal through the inline renderer", () => {
+    const result = compileLegalSourceToDocument(
+      ['@doc title="Code"', "@paragraph", "```", "**not bold** [[not a placeholder]]", "```"].join(
+        "\n",
+      ),
+    );
+    const [body] = bodyParagraphs(result);
+    expect(body).toBeDefined();
+    const runs = body ? runsOf(body) : [];
+    // Escaped characters come back as separate runs; the joined text is
+    // what matters.
+    expect(
+      runs
+        .map((run) =>
+          "content" in run
+            ? run.content.map((item) => (item.type === "text" ? item.text : "")).join("")
+            : "",
+        )
+        .join(""),
+    ).toBe("**not bold** [[not a placeholder]]");
+    expect(JSON.stringify(body)).not.toContain('"bold":true');
+    expect(JSON.stringify(body)).not.toContain('"highlight"');
+  });
+
+  test("a list or quote directly followed by a directive does not swallow it", () => {
+    const result = parseLegalSource(
+      [
+        '@doc title="Boundaries"',
+        "@clause Duties",
+        "- deliver",
+        "- report",
+        "@clause Fees",
+        "> quoted intro",
+        "@subclause Rates",
+        "Hourly.",
+      ].join("\n"),
+    );
+    expect(result.draft.blocks).toEqual([
+      { type: "clause", level: 1, heading: "Duties", paragraphs: [] },
+      { type: "list", ordered: false, items: ["deliver", "report"] },
+      { type: "clause", level: 1, heading: "Fees", paragraphs: ["quoted intro"] },
+      { type: "clause", level: 2, heading: "Rates", paragraphs: ["Hourly."] },
+    ]);
+  });
+
+  test("diagnostics keep the author's line numbers after boundary insertion", () => {
+    const result = parseLegalSource(
+      ['@doc title="Lines"', "@list", "- one", "@bogus directive", "@clause A"].join("\n"),
+    );
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "unknown-directive", line: 4 }),
+    );
+  });
+
+  test("tolerates closing directives a model invents", () => {
+    const result = parseLegalSource(
+      ['@doc title="Closers"', "@list", "- one", "- two", "@endlist", "@clause A", "body", "@end"].join(
+        "\n",
+      ),
+    );
+    expect(result.diagnostics).toEqual([]);
+    expect(result.fixes.filter((fix) => fix.code === "closing-directive-ignored")).toHaveLength(2);
+    expect(result.draft.blocks).toEqual([
+      { type: "list", ordered: false, items: ["one", "two"] },
+      { type: "clause", level: 1, heading: "A", paragraphs: ["body"] },
+    ]);
+  });
+
+  test("warns about a body paragraph that is bold end to end instead of rewriting it", () => {
+    const result = compileLegalSourceToDocument(
+      ['@doc title="Bold"', "@paragraph", "**Whole sentence carried over from chat.**"].join("\n"),
+    );
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") {
+      return;
+    }
+    expect(result.warnings.map((warning) => warning.code)).toEqual(["whole-paragraph-emphasis"]);
+    expect(JSON.stringify(bodyParagraphs(result))).toContain('"bold":true');
+  });
+
   test("signature fields stay literal, never markdown, but keep placeholder highlights", () => {
     const result = compileLegalSourceToDocument(
       [

--- a/packages/docx-core/src/legal-source/legal-source.test.ts
+++ b/packages/docx-core/src/legal-source/legal-source.test.ts
@@ -334,3 +334,133 @@ describe("Stella Legal Source", () => {
     expect(numberingXml).toContain('<w:suff w:val="tab"/><w:lvlText');
   });
 });
+
+const bodyParagraphs = (result: ReturnType<typeof compileLegalSourceToDocument>) =>
+  result.status === "ok"
+    ? result.document.package.document.content.flatMap((block) =>
+        block.type === "paragraph" && block.formatting?.styleId === "BodyText" ? [block] : [],
+      )
+    : [];
+
+const runsOf = (paragraph: { content: { type: string }[] }) =>
+  paragraph.content.flatMap((node) => {
+    if (node.type === "run" && "formatting" in node && "content" in node) {
+      return [node];
+    }
+    if (node.type === "hyperlink" && "children" in node && Array.isArray(node.children)) {
+      return node.children;
+    }
+    return [];
+  });
+
+describe("Stella Legal Source — markdown bodies", () => {
+  test("renders inline markdown in a clause body as formatted runs", () => {
+    const result = compileLegalSourceToDocument(
+      [
+        '@doc title="Inline"',
+        "@clause Payment",
+        "The **Buyer** pays *promptly*, see [the schedule](https://example.com/s).",
+      ].join("\n"),
+    );
+    const [body] = bodyParagraphs(result);
+    expect(body).toBeDefined();
+    const hyperlink = body?.content.find((node) => node.type === "hyperlink");
+    expect(hyperlink?.type === "hyperlink" ? hyperlink.href : undefined).toBe(
+      "https://example.com/s",
+    );
+    expect(JSON.stringify(body)).toContain('"bold":true');
+    expect(JSON.stringify(body)).toContain('"italic":true');
+    expect(JSON.stringify(body)).not.toContain("**");
+  });
+
+  test("keeps [[placeholders]] highlighted inside emphasised text", () => {
+    const result = compileLegalSourceToDocument(
+      ['@doc title="Placeholders"', "@paragraph", "**[[Party]]** shall pay [[Amount]]."].join("\n"),
+    );
+    const [body] = bodyParagraphs(result);
+    const highlighted = (body ? runsOf(body) : []).filter(
+      (run) => "formatting" in run && run.formatting?.highlight === "yellow",
+    );
+    expect(highlighted).toHaveLength(2);
+  });
+
+  test("a markdown list inside a clause body becomes a list block in place", () => {
+    const result = parseLegalSource(
+      [
+        '@doc title="Lists"',
+        "@clause Duties",
+        "The Supplier shall:",
+        "- deliver on time",
+        "- report monthly",
+        "",
+        "Both duties are ongoing.",
+      ].join("\n"),
+    );
+    expect(result.draft.blocks).toEqual([
+      { type: "clause", level: 1, heading: "Duties", paragraphs: ["The Supplier shall:"] },
+      { type: "list", ordered: false, items: ["deliver on time", "report monthly"] },
+      { type: "paragraph", paragraphs: ["Both duties are ongoing."] },
+    ]);
+  });
+
+  test("a GFM pipe table outside @table is a table block", () => {
+    const result = parseLegalSource(
+      ['@doc title="Tables"', "| Item | Owner |", "| --- | --- |", "| Approval | Alpha |"].join(
+        "\n",
+      ),
+    );
+    expect(result.draft.blocks).toEqual([
+      { type: "table", table: { headers: ["Item", "Owner"], rows: [["Approval", "Alpha"]] } },
+    ]);
+  });
+
+  test("a directive line never merges into the paragraph above it", () => {
+    const result = parseLegalSource(
+      ['@doc title="T"', "@clause First", "Body line", "@clause Next", "More"].join("\n"),
+    );
+    expect(result.draft.blocks).toEqual([
+      { type: "clause", level: 1, heading: "First", paragraphs: ["Body line"] },
+      { type: "clause", level: 1, heading: "Next", paragraphs: ["More"] },
+    ]);
+  });
+
+  test("soft-wrapped lines stay one paragraph", () => {
+    const result = parseLegalSource(
+      [
+        '@doc title="Wrap"',
+        "@paragraph",
+        "This sentence",
+        "continues here.",
+        "",
+        "Second one.",
+      ].join("\n"),
+    );
+    expect(result.draft.blocks).toEqual([
+      { type: "paragraph", paragraphs: ["This sentence continues here.", "Second one."] },
+    ]);
+  });
+
+  test("reports an unknown directive as the author spelled it", () => {
+    const result = parseLegalSource(['@doc title="T"', "@Whereas the parties agree"].join("\n"));
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "unknown-directive",
+        message: 'Unknown legal directive "@Whereas".',
+        line: 2,
+      }),
+    );
+  });
+
+  test("signature fields stay literal, never markdown", () => {
+    const result = compileLegalSourceToDocument(
+      ['@doc title="Sign"', "@signatures", "Party: A_B_C Ltd", "By: *Jane*"].join("\n"),
+    );
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") {
+      return;
+    }
+    const serialized = JSON.stringify(result.document.package.document.content);
+    expect(serialized).toContain("A_B_C Ltd");
+    expect(serialized).toContain("*Jane*");
+  });
+});

--- a/packages/docx-core/src/legal-source/legal-source.test.ts
+++ b/packages/docx-core/src/legal-source/legal-source.test.ts
@@ -451,9 +451,16 @@ describe("Stella Legal Source — markdown bodies", () => {
     );
   });
 
-  test("signature fields stay literal, never markdown", () => {
+  test("signature fields stay literal, never markdown, but keep placeholder highlights", () => {
     const result = compileLegalSourceToDocument(
-      ['@doc title="Sign"', "@signatures", "Party: A_B_C Ltd", "By: *Jane*"].join("\n"),
+      [
+        '@doc title="Sign"',
+        "@signatures",
+        "Party: A_B_C Ltd",
+        "By: *Jane*",
+        "Party: [[Seller legal name]]",
+        "By: [[name of signatory]]",
+      ].join("\n"),
     );
     expect(result.status).toBe("ok");
     if (result.status !== "ok") {
@@ -462,5 +469,11 @@ describe("Stella Legal Source — markdown bodies", () => {
     const serialized = JSON.stringify(result.document.package.document.content);
     expect(serialized).toContain("A_B_C Ltd");
     expect(serialized).toContain("*Jane*");
+    expect(serialized).not.toContain("[[");
+    expect(serialized).toContain(
+      JSON.stringify({ text: "Seller legal name", preserveSpace: true }).slice(1, -1),
+    );
+    const highlighted = (serialized.match(/"highlight":"yellow"/gu) ?? []).length;
+    expect(highlighted).toBe(2);
   });
 });

--- a/packages/docx-core/src/legal-source/legal-source.test.ts
+++ b/packages/docx-core/src/legal-source/legal-source.test.ts
@@ -453,9 +453,20 @@ describe("Stella Legal Source — markdown bodies", () => {
 
   test("a blank line before a directive never swallows it", () => {
     const result = parseLegalSource(
-      ["", "@doc title=T", "", "@title T", "", "@clause A", "body", "", "@pagebreak", "", "@clause B", "more"].join(
-        "\n",
-      ),
+      [
+        "",
+        "@doc title=T",
+        "",
+        "@title T",
+        "",
+        "@clause A",
+        "body",
+        "",
+        "@pagebreak",
+        "",
+        "@clause B",
+        "more",
+      ].join("\n"),
     );
     expect(result.draft.blocks).toEqual([
       { type: "title", text: "T" },
@@ -521,9 +532,16 @@ describe("Stella Legal Source — markdown bodies", () => {
 
   test("tolerates closing directives a model invents", () => {
     const result = parseLegalSource(
-      ['@doc title="Closers"', "@list", "- one", "- two", "@endlist", "@clause A", "body", "@end"].join(
-        "\n",
-      ),
+      [
+        '@doc title="Closers"',
+        "@list",
+        "- one",
+        "- two",
+        "@endlist",
+        "@clause A",
+        "body",
+        "@end",
+      ].join("\n"),
     );
     expect(result.diagnostics).toEqual([]);
     expect(result.fixes.filter((fix) => fix.code === "closing-directive-ignored")).toHaveLength(2);

--- a/packages/docx-core/src/legal-source/parser.ts
+++ b/packages/docx-core/src/legal-source/parser.ts
@@ -1,3 +1,20 @@
+/**
+ * Legal-source parser: GFM markdown plus `@` directives, read from one
+ * `marked` token stream (see `../markdown/lexer.ts`). Directive lines
+ * structure the draft (title, recitals, clauses, schedules, signatures); the
+ * markdown between them is ordinary GFM, so headings, emphasis, links, lists,
+ * and pipe tables all mean what they mean in markdown. Paragraph strings on
+ * the draft keep their inline markdown; the compiler renders it into runs.
+ *
+ * Three directive bodies stay line-oriented on purpose: `@list` (manual
+ * markers such as `2)` or `3.1` are stripped rather than parsed), `@table`
+ * (a pipe table without the `---` separator row still counts), and
+ * `@signatures` (`key: value` lines). Their bodies are taken as raw text.
+ */
+import type { Token, Tokens } from "marked";
+
+import { isLegalDirectiveToken, isTokenType, lexLegalSource } from "../markdown/lexer";
+import type { LegalDirectiveToken } from "../markdown/lexer";
 import type {
   Autofix,
   LegalDraft,
@@ -16,6 +33,7 @@ const DEFAULT_LOCALE = "en-GB";
 const DEFAULT_NUMBERING = "legal" satisfies LegalNumberingProfile;
 const DEFAULT_PAGE_SIZE = "A4" satisfies LegalPageSize;
 const DEFAULT_ORIENTATION = "portrait" satisfies LegalPageOrientation;
+const MAX_CLAUSE_LEVEL = 6;
 
 const DIRECTIVE_ALIASES: Record<string, string> = {
   "@annex": "@schedule",
@@ -44,240 +62,383 @@ const DIRECTIVES = new Set([
   "@pagebreak",
 ]);
 
-type PendingBlock =
-  | { type: "title"; line: number; heading: string; lines: string[] }
-  | { type: "recital"; line: number; heading: string; lines: string[] }
-  | {
-      type: "clause";
-      line: number;
-      level: number;
-      heading: string;
-      lines: string[];
+/**
+ * Walks the top-level token stream. Line numbers come from the newlines in
+ * the consumed tokens' `raw` text, which marked keeps contiguous with the
+ * source, so diagnostics point at the directive line that produced them.
+ */
+class TokenCursor {
+  private readonly tokens: readonly Token[];
+  private index = 0;
+  private lineNumber = 1;
+
+  constructor(tokens: readonly Token[]) {
+    this.tokens = tokens;
+  }
+
+  get current(): Token | undefined {
+    return this.tokens.at(this.index);
+  }
+
+  get line(): number {
+    return this.lineNumber;
+  }
+
+  advance(): Token | undefined {
+    const token = this.current;
+    if (token === undefined) {
+      return undefined;
     }
-  | { type: "paragraph"; line: number; heading: string; lines: string[] }
-  | {
-      type: "list";
-      line: number;
-      ordered: boolean;
-      heading: string;
-      lines: string[];
+    this.index += 1;
+    this.lineNumber += countNewlines(token.raw);
+    return token;
+  }
+}
+
+const countNewlines = (text: string): number => {
+  let count = 0;
+  for (const char of text) {
+    if (char === "\n") {
+      count += 1;
     }
-  | { type: "table"; line: number; heading: string; lines: string[] }
-  | { type: "schedule"; line: number; heading: string; lines: string[] }
-  | { type: "signatures"; line: number; heading: string; lines: string[] };
+  }
+  return count;
+};
+
+/** A token that starts a new structural block, so no body may run past it. */
+const startsStructure = (token: Token): boolean =>
+  isLegalDirectiveToken(token) || isTokenType(token, "heading");
+
+type ParseState = {
+  blocks: LegalDraftBlock[];
+  diagnostics: LegalDraftDiagnostic[];
+  fixes: Autofix[];
+  meta: LegalDraft["meta"];
+  cursor: TokenCursor;
+};
 
 export const parseLegalSource = (
   source: string,
   options: { titleFallback?: string } = {},
 ): LegalSourceParseResult => {
-  const fixes: Autofix[] = [];
-  const diagnostics: LegalDraftDiagnostic[] = [];
-  const blocks: LegalDraftBlock[] = [];
-  const meta: LegalDraft["meta"] = {
-    kind: DEFAULT_KIND,
-    locale: DEFAULT_LOCALE,
-    numbering: DEFAULT_NUMBERING,
-    page: {
-      size: DEFAULT_PAGE_SIZE,
-      orientation: DEFAULT_ORIENTATION,
+  const state: ParseState = {
+    blocks: [],
+    diagnostics: [],
+    fixes: [],
+    meta: {
+      kind: DEFAULT_KIND,
+      locale: DEFAULT_LOCALE,
+      numbering: DEFAULT_NUMBERING,
+      page: {
+        size: DEFAULT_PAGE_SIZE,
+        orientation: DEFAULT_ORIENTATION,
+      },
+      title: null,
     },
-    title: null as string | null,
+    cursor: new TokenCursor(lexLegalSource(source)),
   };
 
-  let pending: PendingBlock | null = null;
-
-  const pushPending = () => {
-    if (!pending) {
-      return;
+  for (;;) {
+    const token = state.cursor.current;
+    if (token === undefined) {
+      break;
     }
-
-    const block = pendingToBlock(pending, diagnostics, fixes);
-    if (block) {
-      blocks.push(block);
-      if (block.type === "title") {
-        meta.title = block.text;
-      }
-    }
-    pending = null;
-  };
-
-  const lines = source.replace(/\r\n?/gu, "\n").split("\n");
-  for (const [index, rawLine] of lines.entries()) {
-    const lineNumber = index + 1;
-    const line = rawLine.trimEnd();
-    const trimmed = line.trim();
-
-    if (!trimmed) {
-      pending?.lines.push("");
+    const line = state.cursor.line;
+    if (isLegalDirectiveToken(token)) {
+      state.cursor.advance();
+      parseDirective(token, line, state);
       continue;
     }
-
-    const markdownHeading = parseMarkdownHeading(trimmed);
-    if (markdownHeading) {
-      pushPending();
-      const { depth, heading } = markdownHeading;
-      if (depth === 1) {
-        // Title blocks have no body — only the heading text survives
-        // through `pendingToBlock`. Flush immediately so subsequent
-        // non-directive lines start a fresh paragraph block via the
-        // fallback below, instead of silently dropping into the
-        // title's discarded `lines` array.
-        pending = { type: "title", line: lineNumber, heading, lines: [] };
-        pushPending();
-      } else {
-        pending = {
-          type: "clause",
-          line: lineNumber,
-          level: Math.min(depth - 1, 6),
-          heading,
-          lines: [],
-        };
-      }
-      fixes.push({
-        code: "markdown-heading-normalized",
-        message: "Converted a Markdown heading into a legal directive.",
-        line: lineNumber,
-      });
+    if (isTokenType(token, "heading")) {
+      state.cursor.advance();
+      parseMarkdownHeading(token, line, state);
       continue;
     }
-
-    if (trimmed.startsWith("@")) {
-      const [rawDirective = "", ...rest] = trimmed.split(/\s+/u);
-      const canonicalDirective =
-        DIRECTIVE_ALIASES[rawDirective.toLowerCase()] ?? rawDirective.toLowerCase();
-      const argument = rest.join(" ").trim();
-
-      if (!DIRECTIVES.has(canonicalDirective)) {
-        diagnostics.push({
-          code: "unknown-directive",
-          message: `Unknown legal directive "${rawDirective}".`,
-          severity: "error",
-          line: lineNumber,
-        });
-        pending?.lines.push(line);
-        continue;
-      }
-
-      if (canonicalDirective !== rawDirective.toLowerCase()) {
-        fixes.push({
-          code: "directive-alias-normalized",
-          message: `Normalized ${rawDirective} to ${canonicalDirective}.`,
-          line: lineNumber,
-        });
-      }
-
-      pushPending();
-
-      switch (canonicalDirective) {
-        case "@doc":
-          parseDocDirective(argument, meta, diagnostics, lineNumber);
-          break;
-        case "@title":
-          // Title blocks have no body — flush immediately (same as
-          // markdown `# Title`) so the next non-directive line starts
-          // a paragraph block instead of dropping into the title's
-          // discarded `lines` array.
-          pending = {
-            type: "title",
-            line: lineNumber,
-            heading: argument,
-            lines: [],
-          };
-          pushPending();
-          break;
-        case "@recital":
-          pending = {
-            type: "recital",
-            line: lineNumber,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@clause":
-          pending = {
-            type: "clause",
-            line: lineNumber,
-            level: 1,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@subclause":
-          pending = {
-            type: "clause",
-            line: lineNumber,
-            level: 2,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@paragraph":
-          pending = {
-            type: "paragraph",
-            line: lineNumber,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@list":
-          pending = {
-            type: "list",
-            line: lineNumber,
-            ordered: /\bordered\b/iu.test(argument),
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@table":
-          pending = {
-            type: "table",
-            line: lineNumber,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@schedule":
-          pending = {
-            type: "schedule",
-            line: lineNumber,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@signatures":
-          pending = {
-            type: "signatures",
-            line: lineNumber,
-            heading: argument,
-            lines: [],
-          };
-          break;
-        case "@pagebreak":
-          blocks.push({ type: "pageBreak" });
-          break;
-        default:
-          break;
-      }
-      continue;
-    }
-
-    pending ??= { type: "paragraph", line: lineNumber, heading: "", lines: [] };
-    pending.lines.push(line);
+    parseBareMarkdown(state);
   }
 
-  pushPending();
-
-  if (!meta.title) {
-    const firstTitle = blocks.find((block) => block.type === "title");
-    meta.title =
+  if (!state.meta.title) {
+    const firstTitle = state.blocks.find((block) => block.type === "title");
+    state.meta.title =
       firstTitle?.type === "title"
         ? firstTitle.text
         : (options.titleFallback ?? "Untitled document");
   }
 
-  const draft: LegalDraft = { meta, blocks };
-  return applyDocumentAutofixes({ diagnostics, draft, fixes });
+  const draft: LegalDraft = { meta: state.meta, blocks: state.blocks };
+  return applyDocumentAutofixes({ diagnostics: state.diagnostics, draft, fixes: state.fixes });
 };
+
+const pushBlock = (state: ParseState, block: LegalDraftBlock | null) => {
+  if (!block) {
+    return;
+  }
+  state.blocks.push(block);
+  if (block.type === "title") {
+    state.meta.title = block.text;
+  }
+};
+
+const parseDirective = (token: LegalDirectiveToken, line: number, state: ParseState) => {
+  const { diagnostics, fixes, meta } = state;
+  const rawDirective = token.directive;
+  const directive = DIRECTIVE_ALIASES[rawDirective] ?? rawDirective;
+  const { argument } = token;
+
+  if (!DIRECTIVES.has(directive)) {
+    // Report the directive as the author spelled it, not lower-cased.
+    const spelled = token.raw.trim().split(/\s+/u).at(0) ?? rawDirective;
+    diagnostics.push({
+      code: "unknown-directive",
+      message: `Unknown legal directive "${spelled}".`,
+      severity: "error",
+      line,
+    });
+    return;
+  }
+
+  if (directive !== rawDirective) {
+    fixes.push({
+      code: "directive-alias-normalized",
+      message: `Normalized ${rawDirective} to ${directive}.`,
+      line,
+    });
+  }
+
+  switch (directive) {
+    case "@doc":
+      parseDocDirective(argument, meta, diagnostics, line);
+      return;
+    case "@title":
+      // Title blocks have no body: the argument is the title, and the next
+      // block starts fresh (a bare paragraph after `@title` is body text).
+      pushBlock(state, argument ? { type: "title", text: argument } : null);
+      return;
+    case "@recital":
+      pushBlock(state, { type: "recital", paragraphs: takeParagraphs(state) });
+      return;
+    case "@clause":
+      pushBlock(state, clauseBlock(1, argument, line, state));
+      return;
+    case "@subclause":
+      pushBlock(state, clauseBlock(2, argument, line, state));
+      return;
+    case "@paragraph":
+      pushBlock(state, { type: "paragraph", paragraphs: takeParagraphs(state) });
+      return;
+    case "@list": {
+      const ordered = /\bordered\b/iu.test(argument);
+      const items = takeRawLines(state).flatMap((rawLine) => {
+        const stripped = stripListMarker(rawLine, ordered);
+        return stripped ? [stripped] : [];
+      });
+      pushBlock(state, { type: "list", ordered, items });
+      return;
+    }
+    case "@table":
+      pushBlock(state, parseTableBlock(takeRawLines(state), line, diagnostics, fixes));
+      return;
+    case "@schedule":
+      pushBlock(state, {
+        type: "schedule",
+        heading: stripManualNumbering(argument, line, fixes),
+        paragraphs: takeParagraphs(state),
+      });
+      return;
+    case "@signatures":
+      pushBlock(state, {
+        type: "signatures",
+        parties: parseSignatureParties(takeRawLines(state), argument),
+      });
+      return;
+    case "@pagebreak":
+      pushBlock(state, { type: "pageBreak" });
+      return;
+    default:
+      return;
+  }
+};
+
+const clauseBlock = (
+  level: number,
+  rawHeading: string,
+  line: number,
+  state: ParseState,
+): LegalDraftBlock => {
+  const heading = stripManualNumbering(rawHeading, line, state.fixes);
+  const paragraphs = takeParagraphs(state);
+  // The AI sometimes uses `@clause` as a generic "section" wrapper without
+  // giving it a title. Rather than rejecting, downgrade to a plain paragraph
+  // block: same body content, no clause numbering or heading row. The fix
+  // log keeps the event visible without blocking compile.
+  if (!heading) {
+    state.fixes.push({
+      code: "headingless-clause-downgraded",
+      message: "Converted a headingless @clause into a paragraph block.",
+      line,
+    });
+    return { type: "paragraph", paragraphs };
+  }
+  return { type: "clause", level, heading, paragraphs };
+};
+
+// A markdown heading is the directive-free spelling of a title (`#`) or a
+// clause (`##` and deeper), so a model that writes plain markdown still gets
+// legal structure.
+const parseMarkdownHeading = (token: Tokens.Heading, line: number, state: ParseState) => {
+  const heading = token.text.trim();
+  state.fixes.push({
+    code: "markdown-heading-normalized",
+    message: "Converted a Markdown heading into a legal directive.",
+    line,
+  });
+  if (token.depth === 1) {
+    pushBlock(state, heading ? { type: "title", text: heading } : null);
+    return;
+  }
+  pushBlock(state, clauseBlock(Math.min(token.depth - 1, MAX_CLAUSE_LEVEL), heading, line, state));
+};
+
+/**
+ * Markdown outside any directive. Consecutive prose stays one paragraph
+ * block (several paragraphs), while a list or table is its own block so
+ * markdown lists get real numbering instead of literal `-` markers.
+ */
+const parseBareMarkdown = (state: ParseState) => {
+  const token = state.cursor.current;
+  if (token === undefined) {
+    return;
+  }
+  if (isTokenType(token, "list")) {
+    state.cursor.advance();
+    pushBlock(state, {
+      type: "list",
+      ordered: token.ordered,
+      items: flattenListItems(token),
+    });
+    return;
+  }
+  if (isTokenType(token, "table")) {
+    state.cursor.advance();
+    pushBlock(state, {
+      type: "table",
+      table: {
+        headers: token.header.map((cell) => cellText(cell)),
+        rows: token.rows.map((row) => row.map((cell) => cellText(cell))),
+      },
+    });
+    return;
+  }
+  const paragraphs = takeParagraphs(state);
+  if (paragraphs.length > 0) {
+    pushBlock(state, { type: "paragraph", paragraphs });
+    return;
+  }
+  // Whitespace, a rule, or another token that carries no prose.
+  state.cursor.advance();
+};
+
+/**
+ * Consecutive prose tokens as paragraph strings: paragraphs (soft line
+ * breaks collapsed to spaces), blockquotes, code blocks, and raw HTML. Stops
+ * at the next directive, heading, list, or table so those keep their order.
+ */
+const takeParagraphs = (state: ParseState): string[] => {
+  const paragraphs: string[] = [];
+  for (;;) {
+    const token = state.cursor.current;
+    if (token === undefined || startsStructure(token)) {
+      return paragraphs;
+    }
+    if (isTokenType(token, "list") || isTokenType(token, "table")) {
+      return paragraphs;
+    }
+    const prose = proseParagraphs(token);
+    if (prose === null) {
+      return paragraphs;
+    }
+    state.cursor.advance();
+    paragraphs.push(...prose);
+  }
+};
+
+/** The paragraph strings of one prose token, or `null` when the token is not prose. */
+const proseParagraphs = (token: Token): string[] | null => {
+  if (token.type === "space" || token.type === "hr") {
+    return [];
+  }
+  if (isTokenType(token, "paragraph") || isTokenType(token, "text")) {
+    const text = collapseSoftBreaks(token.text);
+    return text ? [text] : [];
+  }
+  if (isTokenType(token, "blockquote")) {
+    return token.tokens.flatMap((inner) => proseParagraphs(inner) ?? []);
+  }
+  if (isTokenType(token, "code")) {
+    return token.text.split("\n").flatMap((codeLine) => {
+      const trimmed = codeLine.trim();
+      return trimmed ? [trimmed] : [];
+    });
+  }
+  if (isTokenType(token, "html")) {
+    const text = collapseSoftBreaks(token.text);
+    return text ? [text] : [];
+  }
+  return null;
+};
+
+/**
+ * Raw source lines of everything up to the next directive or heading, for
+ * the line-oriented directive bodies (`@list`, `@table`, `@signatures`).
+ */
+const takeRawLines = (state: ParseState): string[] => {
+  let raw = "";
+  for (;;) {
+    const token = state.cursor.current;
+    if (token === undefined || startsStructure(token)) {
+      break;
+    }
+    state.cursor.advance();
+    raw += token.raw;
+  }
+  return raw.split("\n").map((rawLine) => rawLine.trimEnd());
+};
+
+// Nested items lose their depth (the draft's list block is flat), matching
+// how indented `- ` lines under `@list` have always read.
+const flattenListItems = (list: Tokens.List): string[] => {
+  const items: string[] = [];
+  for (const item of list.items) {
+    const parts: string[] = [];
+    const nested: Tokens.List[] = [];
+    for (const child of item.tokens) {
+      if (isTokenType(child, "list")) {
+        nested.push(child);
+        continue;
+      }
+      parts.push(...(proseParagraphs(child) ?? []));
+    }
+    const text = parts.join(" ").trim();
+    if (text) {
+      items.push(text);
+    }
+    for (const nestedList of nested) {
+      items.push(...flattenListItems(nestedList));
+    }
+  }
+  return items;
+};
+
+const cellText = (cell: Tokens.TableCell): string => collapseSoftBreaks(cell.text);
+
+// A paragraph's soft-wrapped lines are one paragraph; trim and join with a
+// single space so the wrapped markdown reads as continuous prose.
+const collapseSoftBreaks = (text: string): string =>
+  text
+    .split("\n")
+    .map((textLine) => textLine.trim())
+    .filter((textLine) => textLine.length > 0)
+    .join(" ");
 
 const parseDocDirective = (
   argument: string,
@@ -466,111 +627,20 @@ const isAsciiAlphaNumeric = (char: string): boolean => {
   return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
 };
 
-const parseMarkdownHeading = (line: string): { depth: number; heading: string } | null => {
-  let depth = 0;
-  for (const char of line) {
-    if (char !== "#") {
-      break;
-    }
-    depth++;
-  }
-
-  if (depth < 1 || depth > 6 || line.at(depth) !== " ") {
-    return null;
-  }
-
-  const heading = line.slice(depth + 1).trim();
-  return heading ? { depth, heading } : null;
-};
-
-const pendingToBlock = (
-  pending: PendingBlock,
-  diagnostics: LegalDraftDiagnostic[],
-  fixes: Autofix[],
-): LegalDraftBlock | null => {
-  switch (pending.type) {
-    case "title": {
-      const text = pending.heading || paragraphText(pending.lines);
-      if (!text) {
-        return null;
-      }
-      return { type: "title", text };
-    }
-    case "recital":
-      return { type: "recital", paragraphs: compactParagraphs(pending.lines) };
-    case "clause": {
-      const heading = stripManualNumbering(pending.heading, pending.line, fixes);
-      // The AI sometimes uses `@clause` as a generic "section"
-      // wrapper without giving it a title. Rather than rejecting,
-      // downgrade to a plain paragraph block — same body content,
-      // no clause numbering or heading row. The fix log keeps the
-      // event visible without blocking compile.
-      if (!heading) {
-        fixes.push({
-          code: "headingless-clause-downgraded",
-          message: "Converted a headingless @clause into a paragraph block.",
-          line: pending.line,
-        });
-        return {
-          type: "paragraph",
-          paragraphs: compactParagraphs(pending.lines),
-        };
-      }
-      return {
-        type: "clause",
-        level: pending.level,
-        heading,
-        paragraphs: compactParagraphs(pending.lines),
-      };
-    }
-    case "paragraph":
-      return {
-        type: "paragraph",
-        paragraphs: compactParagraphs(pending.lines),
-      };
-    case "list":
-      return {
-        type: "list",
-        ordered: pending.ordered,
-        items: pending.lines.flatMap((line) => {
-          const stripped = stripListMarker(line, pending.ordered);
-          return stripped ? [stripped] : [];
-        }),
-      };
-    case "table":
-      return parseTableBlock(pending, diagnostics, fixes);
-    case "schedule": {
-      const heading = stripManualNumbering(pending.heading, pending.line, fixes);
-      return {
-        type: "schedule",
-        heading,
-        paragraphs: compactParagraphs(pending.lines),
-      };
-    }
-    case "signatures":
-      return {
-        type: "signatures",
-        parties: parseSignatureParties(pending.lines, pending.heading),
-      };
-    default:
-      pending satisfies never;
-      return null;
-  }
-};
-
 const parseTableBlock = (
-  pending: Extract<PendingBlock, { type: "table" }>,
+  lines: string[],
+  line: number,
   diagnostics: LegalDraftDiagnostic[],
   fixes: Autofix[],
 ): LegalDraftBlock => {
-  const tableLines = pending.lines.flatMap((rawLine) => {
-    const line = rawLine.trim();
+  const tableLines = lines.flatMap((rawLine) => {
+    const trimmed = rawLine.trim();
     // A leading pipe is enough to recognise a row; tolerate a missing trailing
     // pipe (a common hand-written/AI variant) so the row is not silently dropped.
-    return line.startsWith("|") ? [line] : [];
+    return trimmed.startsWith("|") ? [trimmed] : [];
   });
-  const rows = tableLines.flatMap((line) => {
-    const row = parsePipeRow(line);
+  const rows = tableLines.flatMap((tableLine) => {
+    const row = parsePipeRow(tableLine);
     return row.length > 0 ? [row] : [];
   });
 
@@ -583,7 +653,7 @@ const parseTableBlock = (
     fixes.push({
       code: "table-row-width-normalized",
       message: "Normalized a table row to match the header width.",
-      line: pending.line,
+      line,
     });
     return header.map((_, index) => row.at(index) ?? "");
   });
@@ -593,7 +663,7 @@ const parseTableBlock = (
       code: "missing-table-header",
       message: "Table directives must include a pipe-table header row.",
       severity: "error",
-      line: pending.line,
+      line,
     });
   }
 
@@ -751,8 +821,8 @@ const parseSignatureParties = (lines: string[], heading: string): LegalSignature
     startParty(heading.trim().replace(/^party:\s*/iu, ""));
   }
 
-  for (const line of lines) {
-    const trimmed = line.trim();
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
     if (!trimmed) {
       continue;
     }
@@ -800,16 +870,16 @@ const parseSignatureParties = (lines: string[], heading: string): LegalSignature
 const ORDERED_LIST_MARKER_RE = /^(?:\d+(?:\.\d+)+|\d+[.)])\s+/u;
 const MANUAL_NUMBERING_PREFIX_RE = /^(?:\d+(?:\.\d+)+|\d+[.)]|[A-Za-z][.)]|\([a-zivx]+\))\s+/u;
 
-const stripListMarker = (line: string, ordered: boolean): string => {
-  const trimmed = line.trim();
+const stripListMarker = (rawLine: string, ordered: boolean): string => {
+  const trimmed = rawLine.trim();
   if (ordered) {
     return trimmed.replace(ORDERED_LIST_MARKER_RE, "");
   }
   return trimmed.replace(/^[-*•]\s+/u, "");
 };
 
-const parsePipeRow = (line: string): string[] =>
-  line
+const parsePipeRow = (tableLine: string): string[] =>
+  tableLine
     .replace(/^\|/u, "")
     .replace(/\|$/u, "")
     .split("|")
@@ -817,31 +887,6 @@ const parsePipeRow = (line: string): string[] =>
 
 const isMarkdownDividerRow = (row: string[]): boolean =>
   row.every((cell) => /^:?-{3,}:?$/u.test(cell));
-
-const compactParagraphs = (lines: string[]): string[] => {
-  const paragraphs: string[] = [];
-  let current: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) {
-      if (current.length > 0) {
-        paragraphs.push(current.join(" "));
-        current = [];
-      }
-      continue;
-    }
-    current.push(trimmed);
-  }
-
-  if (current.length > 0) {
-    paragraphs.push(current.join(" "));
-  }
-
-  return paragraphs;
-};
-
-const paragraphText = (lines: string[]): string => compactParagraphs(lines).join(" ");
 
 const stripManualNumbering = (value: string, line: number, fixes: Autofix[]): string => {
   // Numeric and letter branches both require a delimiter so legit

--- a/packages/docx-core/src/legal-source/parser.ts
+++ b/packages/docx-core/src/legal-source/parser.ts
@@ -14,7 +14,7 @@
 import type { Token, Tokens } from "marked";
 
 import { isLegalDirectiveToken, isTokenType, lexLegalSource } from "../markdown/lexer";
-import type { LegalDirectiveToken } from "../markdown/lexer";
+import type { LegalDirectiveToken, LegalSourceLexResult } from "../markdown/lexer";
 import type {
   Autofix,
   LegalDraft,
@@ -48,6 +48,8 @@ const DIRECTIVE_ALIASES: Record<string, string> = {
   "@subsection": "@subclause",
 };
 
+const CLOSING_DIRECTIVE_PATTERN = /^@end[a-z]*$/u;
+
 const DIRECTIVES = new Set([
   "@doc",
   "@title",
@@ -69,19 +71,27 @@ const DIRECTIVES = new Set([
  */
 class TokenCursor {
   private readonly tokens: readonly Token[];
+  private readonly originalLineOf: (line: number) => number;
   private index = 0;
   private lineNumber = 1;
 
-  constructor(tokens: readonly Token[]) {
+  constructor({ tokens, originalLineOf }: LegalSourceLexResult) {
     this.tokens = tokens;
+    this.originalLineOf = originalLineOf;
   }
 
   get current(): Token | undefined {
     return this.tokens.at(this.index);
   }
 
+  /** The author's line number for the current token. */
   get line(): number {
-    return this.lineNumber;
+    return this.originalLineOf(this.lineNumber);
+  }
+
+  /** Index of the current token; lets a caller tell whether a helper consumed anything. */
+  get position(): number {
+    return this.index;
   }
 
   advance(): Token | undefined {
@@ -184,6 +194,18 @@ const parseDirective = (token: LegalDirectiveToken, line: number, state: ParseSt
   const rawDirective = token.directive;
   const directive = DIRECTIVE_ALIASES[rawDirective] ?? rawDirective;
   const { argument } = token;
+
+  // Models raised on HTML and LaTeX close what they open (`@endlist`,
+  // `@end`). Blocks here end where the next one starts, so a closer changes
+  // nothing; accept it and say so rather than failing the whole draft.
+  if (CLOSING_DIRECTIVE_PATTERN.test(directive)) {
+    fixes.push({
+      code: "closing-directive-ignored",
+      message: `Ignored ${rawDirective}: blocks end where the next directive starts.`,
+      line,
+    });
+    return;
+  }
 
   if (!DIRECTIVES.has(directive)) {
     // Report the directive as the author spelled it, not lower-cased.
@@ -329,13 +351,18 @@ const parseBareMarkdown = (state: ParseState) => {
     });
     return;
   }
+  const before = state.cursor.position;
   const paragraphs = takeParagraphs(state);
   if (paragraphs.length > 0) {
     pushBlock(state, { type: "paragraph", paragraphs });
     return;
   }
-  // Whitespace, a rule, or another token that carries no prose.
-  state.cursor.advance();
+  // Nothing prose-like here. When the helper already consumed whitespace or
+  // a rule, the cursor now sits on a directive or heading that the main loop
+  // must dispatch; only a token the helper refused to touch is skipped.
+  if (state.cursor.position === before) {
+    state.cursor.advance();
+  }
 };
 
 /**
@@ -375,9 +402,12 @@ const proseParagraphs = (token: Token): string[] | null => {
     return token.tokens.flatMap((inner) => proseParagraphs(inner) ?? []);
   }
   if (isTokenType(token, "code")) {
+    // Fenced code is literal by markdown semantics; the compiler reads every
+    // paragraph string as inline markdown, so escape the characters that
+    // would otherwise turn into emphasis, links, or placeholders.
     return token.text.split("\n").flatMap((codeLine) => {
       const trimmed = codeLine.trim();
-      return trimmed ? [trimmed] : [];
+      return trimmed ? [escapeInlineMarkdown(trimmed)] : [];
     });
   }
   if (isTokenType(token, "html")) {
@@ -430,6 +460,12 @@ const flattenListItems = (list: Tokens.List): string[] => {
 };
 
 const cellText = (cell: Tokens.TableCell): string => collapseSoftBreaks(cell.text);
+
+const INLINE_MARKDOWN_SPECIALS = /[\\`*_[\]<>~!]/gu;
+
+/** Backslash-escape the inline markdown syntax so the text renders verbatim. */
+const escapeInlineMarkdown = (text: string): string =>
+  text.replaceAll(INLINE_MARKDOWN_SPECIALS, (char) => `\\${char}`);
 
 // A paragraph's soft-wrapped lines are one paragraph; trim and join with a
 // single space so the wrapped markdown reads as continuous prose.

--- a/packages/docx-core/src/legal-source/types.ts
+++ b/packages/docx-core/src/legal-source/types.ts
@@ -36,6 +36,12 @@ export type LegalSignatureParty = {
   title?: string;
 };
 
+/**
+ * A parsed draft block. Every `text`, `heading`, paragraph, list item, and
+ * table cell string keeps its inline GFM markdown (`**bold**`, `*italic*`,
+ * `[link](https://…)`, `` `code` ``) and `[[placeholder]]` markers; the
+ * compiler renders them into runs.
+ */
 export type LegalDraftBlock =
   | { type: "title"; text: string }
   | { type: "recital"; paragraphs: string[] }

--- a/packages/docx-core/src/legal-source/validate.ts
+++ b/packages/docx-core/src/legal-source/validate.ts
@@ -1,7 +1,49 @@
-import type { LegalDraft, LegalDraftDiagnostic } from "./types";
+import type { LegalDraft, LegalDraftBlock, LegalDraftDiagnostic } from "./types";
+
+// `**whole paragraph**` or `__whole paragraph__`: emphasis wrapping every
+// character of a body string.
+const WHOLE_TEXT_EMPHASIS = /^(?:\*\*[^*]+\*\*|__[^_]+__)$/u;
+
+/** Body strings of a block that a reader would expect to be prose, not a heading. */
+const bodyStrings = (block: LegalDraftBlock): string[] => {
+  switch (block.type) {
+    case "paragraph":
+    case "recital":
+    case "clause":
+    case "schedule":
+      return block.paragraphs;
+    case "list":
+      return block.items;
+    case "table":
+      return block.table.rows.flat();
+    case "title":
+    case "signatures":
+    case "pageBreak":
+      return [];
+    default:
+      block satisfies never;
+      return [];
+  }
+};
 
 export const validateLegalDraft = (draft: LegalDraft): LegalDraftDiagnostic[] => {
   const diagnostics: LegalDraftDiagnostic[] = [];
+
+  // A body paragraph bold from end to end usually carries chat prose over
+  // into the draft; in a two-column bilingual table it turns a whole column
+  // into a heading. The compiler renders it as written and reports it, so
+  // the author can decide.
+  for (const block of draft.blocks) {
+    if (bodyStrings(block).some((text) => WHOLE_TEXT_EMPHASIS.test(text.trim()))) {
+      diagnostics.push({
+        code: "whole-paragraph-emphasis",
+        message:
+          "A body paragraph, list item, or table cell is bold from end to end; use a clause heading for headings and keep bold for short labels.",
+        severity: "warning",
+      });
+      break;
+    }
+  }
 
   if (!draft.meta.title?.trim()) {
     diagnostics.push({

--- a/packages/docx-core/src/markdown/content.ts
+++ b/packages/docx-core/src/markdown/content.ts
@@ -1,0 +1,246 @@
+/**
+ * GFM markdown → document block content. Parses the subset skill bodies and
+ * AI drafts use (headings, paragraphs, bold/italic/strike, inline code, bullet
+ * and ordered lists incl. nesting, pipe tables, blockquotes, links) into the
+ * docx `Document` block model, so the markdown can be edited in a DOCX editor
+ * and re-exported without drift.
+ *
+ * Round-trip notes:
+ * - Lists are emitted as real list paragraphs (`listRendering` plus `numPr`),
+ *   so an editor shows a marker and a markdown exporter re-derives `- ` /
+ *   `1. ` rather than leaking a literal bullet glyph into the text.
+ * - Inline code uses `Courier New`, a monospace family a markdown exporter can
+ *   infer back to a backtick span.
+ * - Every markdown list gets a matching `w:abstractNum`/`w:num` pair in the
+ *   returned `numbering` (see {@link buildNumbering}), so the result is
+ *   self-consistent and serialization never fails with a missing numbering
+ *   definition. Merging this content onto a document that has its own
+ *   numbering needs the two numbering namespaces renumbered apart.
+ */
+import type { Token, Tokens } from "marked";
+
+import type {
+  AbstractNumbering,
+  BlockContent,
+  ListLevel,
+  ListRendering,
+  NumberingDefinitions,
+  NumberingInstance,
+  Paragraph,
+  ParagraphContent,
+  Table,
+  TableCell,
+  TableRow,
+} from "../model/document";
+import { inlineTokensToRuns, textRun } from "./inline";
+import { isTokenType, lexMarkdown } from "./lexer";
+
+/** Block content and the numbering definitions its list paragraphs reference. */
+export type MarkdownContent = {
+  content: BlockContent[];
+  /** Present only when the markdown contained at least one list. */
+  numbering?: NumberingDefinitions;
+};
+
+const para = (runs: ParagraphContent[], styleId?: string): Paragraph => ({
+  type: "paragraph",
+  formatting: styleId ? { styleId } : {},
+  content: runs.length > 0 ? runs : [textRun("")],
+});
+
+const listPara = (runs: ParagraphContent[], rendering: ListRendering): Paragraph => ({
+  type: "paragraph",
+  // Real numbering properties, not just display metadata: an editor's list
+  // commands (Enter continues the list, Tab indents, toggle) and the live
+  // marker counters all key off `numPr`.
+  formatting: { numPr: { numId: rendering.numId, ilvl: rendering.level } },
+  listRendering: rendering,
+  content: runs.length > 0 ? runs : [textRun("")],
+});
+
+// Header cells are not bolded: in GFM the header is positional (first row + the
+// `---` separator), so bolding it would re-export as `**A**` and break the
+// round-trip.
+const cellOf = (cell: Tokens.TableCell): TableCell => ({
+  type: "tableCell",
+  content: [para(inlineTokensToRuns(cell.tokens, cell.text))],
+});
+
+const tableFromToken = (token: Tokens.Table): Table => ({
+  type: "table",
+  rows: [
+    { type: "tableRow", cells: token.header.map((cell) => cellOf(cell)) },
+    ...token.rows.map(
+      (row): TableRow => ({
+        type: "tableRow",
+        cells: row.map((cell) => cellOf(cell)),
+      }),
+    ),
+  ],
+});
+
+// Twips (720 = 0.5"). Each deeper level indents one more half-inch, matching
+// the step the legal-source checklist profile uses for a single-column marker
+// plus hanging indent.
+const LIST_INDENT_STEP_TWIPS = 720;
+const LIST_HANGING_INDENT_TWIPS = 360;
+
+/**
+ * One `w:abstractNum` level per (numId, ilvl) pair actually used by the
+ * markdown, keyed by ilvl. Built alongside the blocks so the caller can
+ * synthesize `numbering` afterwards: the DOCX serializer reads numbering
+ * definitions only from there, never from the editor-only `listRendering`
+ * hint.
+ */
+type NumIdLevels = Map<number, ListLevel>;
+
+const buildListLevel = (ilvl: number, isBullet: boolean, start: number): ListLevel => ({
+  ilvl,
+  ...(!isBullet && { start }),
+  numFmt: isBullet ? "bullet" : "decimal",
+  lvlText: isBullet ? "•" : `%${ilvl + 1}.`,
+  suffix: "tab",
+  pPr: {
+    indentLeft: LIST_INDENT_STEP_TWIPS * (ilvl + 1),
+    indentFirstLine: -LIST_HANGING_INDENT_TWIPS,
+    hangingIndent: true,
+  },
+});
+
+// Real list paragraphs with Word-style template markers ("%1." resolves to the
+// live counter at level 0), so inserted/split items renumber instead of
+// repeating a baked-in number. Each top-level markdown list gets its own numId
+// so separate lists restart at 1; nested lists share the parent's numId at a
+// deeper ilvl. A markdown exporter resolves the templates back to concrete
+// "N." markers and normalises bullets to "- ", so the markdown round-trips.
+const listBlocks = (
+  list: Tokens.List,
+  level: number,
+  numId: number,
+  levels: NumIdLevels,
+): BlockContent[] => {
+  const out: BlockContent[] = [];
+  const start = Number(list.start) || 1;
+  const decimalLevels = Array.from({ length: level + 1 }, () => "decimal" as const);
+  // First list to reach this (numId, ilvl) defines the synthesized level: a
+  // nested list that later reuses the same depth under the same numId shares
+  // that counter, matching how `listRendering` already treats it.
+  if (!levels.has(level)) {
+    levels.set(level, buildListLevel(level, !list.ordered, start));
+  }
+  for (const item of list.items) {
+    const rendering: ListRendering = list.ordered
+      ? {
+          marker: `%${level + 1}.`,
+          level,
+          numId,
+          isBullet: false,
+          numFmt: "decimal",
+          levelNumFmts: decimalLevels,
+          ...(start !== 1 && { startOverride: start }),
+        }
+      : { marker: "•", level, numId, isBullet: true };
+    const inlineTokens: Token[] = [];
+    const nestedLists: Tokens.List[] = [];
+    for (const child of item.tokens) {
+      if (isTokenType(child, "list")) {
+        nestedLists.push(child);
+      } else {
+        inlineTokens.push(child);
+      }
+    }
+    out.push(listPara(inlineTokensToRuns(inlineTokens, item.text), rendering));
+    for (const nested of nestedLists) {
+      out.push(...listBlocks(nested, level + 1, numId, levels));
+    }
+  }
+  return out;
+};
+
+/**
+ * Allocates one numId per markdown list so each list counts independently,
+ * and collects the level definitions needed to synthesize `numbering` for
+ * every list it mints.
+ */
+type NumIdAllocator = { next: number; levels: Map<number, NumIdLevels> };
+
+const MAX_HEADING_LEVEL = 4;
+
+const blocksFromTokens = (tokens: Token[] | undefined, numIds: NumIdAllocator): BlockContent[] => {
+  const blocks: BlockContent[] = [];
+  for (const token of tokens ?? []) {
+    if (isTokenType(token, "heading")) {
+      const level = Math.min(Math.max(token.depth, 1), MAX_HEADING_LEVEL);
+      blocks.push(para(inlineTokensToRuns(token.tokens, token.text), `Heading${level}`));
+    } else if (isTokenType(token, "paragraph")) {
+      blocks.push(para(inlineTokensToRuns(token.tokens, token.text)));
+    } else if (isTokenType(token, "list")) {
+      const numId = numIds.next++;
+      const levels: NumIdLevels = new Map();
+      numIds.levels.set(numId, levels);
+      blocks.push(...listBlocks(token, 0, numId, levels));
+    } else if (isTokenType(token, "table")) {
+      blocks.push(tableFromToken(token));
+    } else if (isTokenType(token, "code")) {
+      for (const line of token.text.split("\n")) {
+        blocks.push(para([textRun(line.length > 0 ? line : " ", { mono: true })]));
+      }
+    } else if (isTokenType(token, "blockquote")) {
+      for (const inner of blocksFromTokens(token.tokens, numIds)) {
+        const styled: BlockContent =
+          inner.type === "paragraph"
+            ? {
+                ...inner,
+                formatting: { ...inner.formatting, styleId: "Quote" },
+              }
+            : inner;
+        blocks.push(styled);
+      }
+    } else if (token.type === "hr") {
+      blocks.push(para([textRun("———")]));
+    } else if (
+      token.type !== "space" &&
+      "text" in token &&
+      typeof token.text === "string" &&
+      token.text.trim().length > 0
+    ) {
+      blocks.push(para([textRun(token.text)]));
+    }
+  }
+  return blocks;
+};
+
+// One `w:abstractNum` per numId (a 1:1 mapping, so `abstractNumId === numId`
+// keeps the synthesis trivial to reason about; callers merging this into a
+// document with its own numbering should not assume the mapping stays 1:1
+// after remapping). Every level actually visited by that markdown list
+// becomes one `w:lvl`, so serializing the content never references a numId
+// with no definition.
+const buildNumbering = (numIdLevels: Map<number, NumIdLevels>): NumberingDefinitions => {
+  const abstractNums: AbstractNumbering[] = [];
+  const nums: NumberingInstance[] = [];
+  for (const [numId, levels] of numIdLevels) {
+    const sortedLevels = [...levels.entries()].sort(([a], [b]) => a - b).map(([, lvl]) => lvl);
+    abstractNums.push({
+      abstractNumId: numId,
+      multiLevelType: sortedLevels.length > 1 ? "multilevel" : "singleLevel",
+      levels: sortedLevels,
+    });
+    nums.push({ numId, abstractNumId: numId });
+  }
+  return { abstractNums, nums };
+};
+
+/**
+ * Parse GFM markdown into document blocks plus the numbering its lists need.
+ * Synchronous. The caller places the blocks into a `Document` of its own
+ * (page geometry, styles, and presets are the host's decision).
+ */
+export const compileMarkdownToContent = (markdown: string): MarkdownContent => {
+  const numIds: NumIdAllocator = { next: 1, levels: new Map() };
+  const content = blocksFromTokens(lexMarkdown(markdown), numIds);
+  return {
+    content,
+    ...(numIds.levels.size > 0 && { numbering: buildNumbering(numIds.levels) }),
+  };
+};

--- a/packages/docx-core/src/markdown/content.ts
+++ b/packages/docx-core/src/markdown/content.ts
@@ -113,21 +113,47 @@ const buildListLevel = (ilvl: number, isBullet: boolean, start: number): ListLev
 // so separate lists restart at 1; nested lists share the parent's numId at a
 // deeper ilvl. A markdown exporter resolves the templates back to concrete
 // "N." markers and normalises bullets to "- ", so the markdown round-trips.
+/**
+ * The numId a list renders under. The first list to reach a (numId, ilvl)
+ * pair defines that level; a later list at the same depth under the same
+ * parent shares it when it is the same kind (so sibling nested bullets share
+ * one counter), and gets a numId of its own when it is not (a nested ordered
+ * list must not inherit a sibling's bullet definition).
+ */
+const resolveListNumId = (
+  numIds: NumIdAllocator,
+  parentNumId: number,
+  level: ListLevel,
+): number => {
+  const levels = numIds.levels.get(parentNumId);
+  const existing = levels?.get(level.ilvl);
+  if (levels !== undefined && existing === undefined) {
+    levels.set(level.ilvl, level);
+    return parentNumId;
+  }
+  if (
+    levels !== undefined &&
+    existing !== undefined &&
+    existing.numFmt === level.numFmt &&
+    existing.start === level.start
+  ) {
+    return parentNumId;
+  }
+  const numId = numIds.next++;
+  numIds.levels.set(numId, new Map([[level.ilvl, level]]));
+  return numId;
+};
+
 const listBlocks = (
   list: Tokens.List,
   level: number,
-  numId: number,
-  levels: NumIdLevels,
+  parentNumId: number,
+  numIds: NumIdAllocator,
 ): BlockContent[] => {
   const out: BlockContent[] = [];
   const start = Number(list.start) || 1;
   const decimalLevels = Array.from({ length: level + 1 }, () => "decimal" as const);
-  // First list to reach this (numId, ilvl) defines the synthesized level: a
-  // nested list that later reuses the same depth under the same numId shares
-  // that counter, matching how `listRendering` already treats it.
-  if (!levels.has(level)) {
-    levels.set(level, buildListLevel(level, !list.ordered, start));
-  }
+  const numId = resolveListNumId(numIds, parentNumId, buildListLevel(level, !list.ordered, start));
   for (const item of list.items) {
     const rendering: ListRendering = list.ordered
       ? {
@@ -151,7 +177,7 @@ const listBlocks = (
     }
     out.push(listPara(inlineTokensToRuns(inlineTokens, item.text), rendering));
     for (const nested of nestedLists) {
-      out.push(...listBlocks(nested, level + 1, numId, levels));
+      out.push(...listBlocks(nested, level + 1, numId, numIds));
     }
   }
   return out;
@@ -176,9 +202,8 @@ const blocksFromTokens = (tokens: Token[] | undefined, numIds: NumIdAllocator): 
       blocks.push(para(inlineTokensToRuns(token.tokens, token.text)));
     } else if (isTokenType(token, "list")) {
       const numId = numIds.next++;
-      const levels: NumIdLevels = new Map();
-      numIds.levels.set(numId, levels);
-      blocks.push(...listBlocks(token, 0, numId, levels));
+      numIds.levels.set(numId, new Map());
+      blocks.push(...listBlocks(token, 0, numId, numIds));
     } else if (isTokenType(token, "table")) {
       blocks.push(tableFromToken(token));
     } else if (isTokenType(token, "code")) {

--- a/packages/docx-core/src/markdown/href.ts
+++ b/packages/docx-core/src/markdown/href.ts
@@ -1,0 +1,68 @@
+const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+/**
+ * Keep only http(s), mailto, and tel URLs, normalised through the URL parser.
+ * Anything else (javascript:, data:, relative paths, malformed input) drops to
+ * `undefined` so a markdown link degrades to its text instead of carrying an
+ * executable target into the document.
+ */
+export const sanitizeExternalUrl = (rawUrl: string | undefined): string | undefined => {
+  if (!rawUrl) {
+    return undefined;
+  }
+
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = parseUrl(trimmed);
+  if (!parsed || !ALLOWED_URL_PROTOCOLS.has(parsed.protocol)) {
+    return undefined;
+  }
+  if (
+    (parsed.protocol === "mailto:" || parsed.protocol === "tel:") &&
+    parsed.pathname.trim() === ""
+  ) {
+    return undefined;
+  }
+  return parsed.href;
+};
+
+// `URL` throws on malformed input; an unparseable link is a normal outcome
+// here (the link renders as plain text), not a failure to propagate.
+const parseUrl = (value: string): URL | null => {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+};
+
+const hasUnsafeAnchorCharacter = (anchor: string): boolean => {
+  for (const char of anchor) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (codePoint <= 0x20 || codePoint === 0x7f || char.trim() === "") {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** A `#anchor` stays a document-internal target; anything else must pass {@link sanitizeExternalUrl}. */
+export const sanitizeMarkdownHref = (rawHref: string): string | undefined => {
+  const trimmed = rawHref.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed.startsWith("#")) {
+    const anchor = trimmed.slice(1);
+    if (!anchor || hasUnsafeAnchorCharacter(anchor)) {
+      return undefined;
+    }
+    return `#${anchor}`;
+  }
+
+  return sanitizeExternalUrl(trimmed);
+};

--- a/packages/docx-core/src/markdown/inline.ts
+++ b/packages/docx-core/src/markdown/inline.ts
@@ -66,6 +66,13 @@ export const textRun = (text: string, format: InlineRunFormat = {}): Run => {
 // formatting but not the highlight.
 const PLACEHOLDER_PATTERN = /\[\[(?<inner>[^\][]+?)\]\]/gu;
 
+/**
+ * Literal text (no markdown reading) with `[[…]]` placeholders highlighted:
+ * for fields that are data rather than prose, such as signature parties.
+ */
+export const plainTextRuns = (text: string, format: InlineRunFormat = {}): Run[] =>
+  placeholderRuns(text, format);
+
 const placeholderRuns = (text: string, format: InlineRunFormat): Run[] => {
   if (!text.includes("[[")) {
     return [textRun(text, format)];

--- a/packages/docx-core/src/markdown/inline.ts
+++ b/packages/docx-core/src/markdown/inline.ts
@@ -1,0 +1,179 @@
+/**
+ * Inline markdown (emphasis, strikethrough, code spans, links, line breaks)
+ * rendered into document runs. Shared by the plain markdown profile and the
+ * legal-source compiler so both surfaces read `**bold**` the same way.
+ */
+import type { Token } from "marked";
+
+import type { ParagraphContent, Run } from "../model/document";
+import { sanitizeMarkdownHref } from "./href";
+import { isTokenType, lexInlineMarkdown } from "./lexer";
+
+// Whitelisted by folio-core's `toMarkdown` monospace inference, so a code span
+// survives a DOCX → markdown round-trip. Folio renders Courier New through its
+// bundled Cousine face.
+const MONO_FONT = { ascii: "Courier New", hAnsi: "Courier New" } as const;
+
+/** Run-level formatting an inline token adds to the text it wraps. */
+export type InlineRunFormat = {
+  bold?: boolean;
+  italic?: boolean;
+  strike?: boolean;
+  mono?: boolean;
+  highlight?: "yellow";
+};
+
+export type InlineMarkdownOptions = {
+  /** Formatting every run starts from (a bold clause heading, an italic recital). */
+  base?: InlineRunFormat;
+  /**
+   * Wrap each `[[…]]` span in a yellow highlight. Legal drafts mark the
+   * points a reviewing lawyer still has to fill in that way; plain markdown
+   * keeps the brackets as text.
+   */
+  placeholders?: boolean;
+};
+
+/**
+ * One run. A Word run cannot carry a raw newline (the layout engine renders
+ * such lines on top of each other), so "\n" becomes an explicit break node.
+ */
+export const textRun = (text: string, format: InlineRunFormat = {}): Run => {
+  const formatting = {
+    ...(format.bold ? { bold: true } : {}),
+    ...(format.italic ? { italic: true } : {}),
+    ...(format.strike ? { strike: true } : {}),
+    ...(format.mono ? { fontFamily: MONO_FONT } : {}),
+    ...(format.highlight ? { highlight: format.highlight } : {}),
+  };
+  const content: Run["content"] = [];
+  for (const [index, segment] of text.split("\n").entries()) {
+    if (index > 0) {
+      content.push({ type: "break" });
+    }
+    if (segment.length > 0) {
+      content.push({ type: "text", text: segment, preserveSpace: true });
+    }
+  }
+  if (content.length === 0) {
+    content.push({ type: "text", text: "", preserveSpace: true });
+  }
+  return { type: "run", formatting, content };
+};
+
+// Split text on `[[…]]` markers into a sequence of runs. Each placeholder
+// becomes its own highlighted run; the surrounding text inherits the base
+// formatting but not the highlight.
+const PLACEHOLDER_PATTERN = /\[\[(?<inner>[^\][]+?)\]\]/gu;
+
+const placeholderRuns = (text: string, format: InlineRunFormat): Run[] => {
+  if (!text.includes("[[")) {
+    return [textRun(text, format)];
+  }
+  const runs: Run[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(PLACEHOLDER_PATTERN)) {
+    const start = match.index;
+    if (start > cursor) {
+      runs.push(textRun(text.slice(cursor, start), format));
+    }
+    runs.push(textRun(match.groups?.["inner"] ?? "", { ...format, highlight: "yellow" }));
+    cursor = start + match[0].length;
+  }
+  if (cursor < text.length) {
+    runs.push(textRun(text.slice(cursor), format));
+  }
+  return runs.length > 0 ? runs : [textRun(text, format)];
+};
+
+const plainRuns = (text: string, format: InlineRunFormat, placeholders: boolean): Run[] =>
+  placeholders ? placeholderRuns(text, format) : [textRun(text, format)];
+
+type InlineContext = {
+  placeholders: boolean;
+};
+
+const tokensToRuns = (
+  tokens: Token[] | undefined,
+  fallback: string,
+  format: InlineRunFormat,
+  context: InlineContext,
+): ParagraphContent[] => {
+  if (!tokens || tokens.length === 0) {
+    return plainRuns(fallback, format, context.placeholders);
+  }
+  const runs: ParagraphContent[] = [];
+  for (const token of tokens) {
+    if (isTokenType(token, "strong")) {
+      runs.push(...tokensToRuns(token.tokens, token.text, { ...format, bold: true }, context));
+    } else if (isTokenType(token, "em")) {
+      runs.push(...tokensToRuns(token.tokens, token.text, { ...format, italic: true }, context));
+    } else if (isTokenType(token, "del")) {
+      runs.push(...tokensToRuns(token.tokens, token.text, { ...format, strike: true }, context));
+    } else if (isTokenType(token, "codespan")) {
+      runs.push(textRun(token.text, { ...format, mono: true }));
+    } else if (isTokenType(token, "link")) {
+      runs.push(...linkRuns(token.tokens, token.text, token.href, format, context));
+    } else if (isTokenType(token, "paragraph")) {
+      runs.push(...tokensToRuns(token.tokens, token.text, format, context));
+    } else if (token.type === "br") {
+      runs.push({ type: "run", content: [{ type: "break" }] });
+    } else if (token.type === "space") {
+      if (runs.length > 0 && token.raw.includes("\n")) {
+        runs.push(textRun("\n", format));
+      }
+    } else if (isTokenType(token, "text")) {
+      const nested = token.tokens;
+      if (nested && nested.length > 0) {
+        runs.push(...tokensToRuns(nested, token.text, format, context));
+      } else {
+        runs.push(...plainRuns(token.text, format, context.placeholders));
+      }
+    } else if ("text" in token && typeof token.text === "string") {
+      runs.push(...plainRuns(token.text, format, context.placeholders));
+    }
+  }
+  return runs.length > 0 ? runs : plainRuns(fallback, format, context.placeholders);
+};
+
+const linkRuns = (
+  tokens: Token[] | undefined,
+  text: string,
+  rawHref: string,
+  format: InlineRunFormat,
+  context: InlineContext,
+): ParagraphContent[] => {
+  const children = tokensToRuns(tokens, text, format, context).filter(
+    (child): child is Run => child.type === "run",
+  );
+  const linkChildren = children.length > 0 ? children : [textRun(text, format)];
+  const href = sanitizeMarkdownHref(rawHref);
+  if (!href) {
+    return linkChildren;
+  }
+  const anchor = href.startsWith("#") ? href.slice(1) : undefined;
+  return [
+    {
+      type: "hyperlink",
+      href,
+      ...(anchor ? { anchor } : {}),
+      children: linkChildren,
+    },
+  ];
+};
+
+/** Render already-lexed inline tokens; `fallback` is the source text when the tokens are empty. */
+export const inlineTokensToRuns = (
+  tokens: Token[] | undefined,
+  fallback: string,
+  options: InlineMarkdownOptions = {},
+): ParagraphContent[] =>
+  tokensToRuns(tokens, fallback, options.base ?? {}, {
+    placeholders: options.placeholders ?? false,
+  });
+
+/** Lex and render one paragraph's inline markdown. */
+export const inlineMarkdownToRuns = (
+  text: string,
+  options: InlineMarkdownOptions = {},
+): ParagraphContent[] => inlineTokensToRuns(lexInlineMarkdown(text), text, options);

--- a/packages/docx-core/src/markdown/lexer.ts
+++ b/packages/docx-core/src/markdown/lexer.ts
@@ -1,0 +1,100 @@
+/**
+ * One `marked` configuration for every markdown surface in docx-core. Plain
+ * markdown (`compileMarkdownToContent`) and the legal-source compiler read the
+ * same GFM token stream; the legal profile adds a block-level extension that
+ * turns an `@directive` line into its own token so the line never merges into
+ * a neighbouring paragraph.
+ */
+import { Marked, type Token, type TokenizerExtension, type Tokens } from "marked";
+
+/** A `@directive [argument]` line of a legal draft, tokenized as its own block. */
+export type LegalDirectiveToken = {
+  type: "legalDirective";
+  raw: string;
+  /** Lower-cased, with the leading `@` (`@clause`, `@doc`). */
+  directive: string;
+  /** The rest of the line, trimmed; empty when the directive stands alone. */
+  argument: string;
+};
+
+const LEGAL_DIRECTIVE_TOKEN_TYPE = "legalDirective";
+
+// A directive is `@` plus an identifier at the start of a line. Leading
+// indentation is tolerated (models indent freely); `@` followed by anything
+// else (`@ 5%`) is ordinary prose.
+const DIRECTIVE_LINE_PATTERN =
+  /^[ \t]*@(?<name>[A-Za-z][A-Za-z0-9_-]*)(?<argument>[^\n]*)(?:\n|$)/u;
+const DIRECTIVE_LINE_START_PATTERN = /^[ \t]*@[A-Za-z]/mu;
+
+const legalDirectiveExtension: TokenizerExtension = {
+  name: LEGAL_DIRECTIVE_TOKEN_TYPE,
+  level: "block",
+  // Lets marked's paragraph tokenizer stop a paragraph right before the next
+  // directive line instead of swallowing it as a soft-wrapped continuation.
+  start: (src) => {
+    const index = src.search(DIRECTIVE_LINE_START_PATTERN);
+    return index === -1 ? undefined : index;
+  },
+  tokenizer: (src) => {
+    const match = DIRECTIVE_LINE_PATTERN.exec(src);
+    const name = match?.groups?.["name"];
+    if (!match || name === undefined) {
+      return undefined;
+    }
+    const token: LegalDirectiveToken = {
+      type: LEGAL_DIRECTIVE_TOKEN_TYPE,
+      raw: match[0],
+      directive: `@${name.toLowerCase()}`,
+      argument: (match.groups?.["argument"] ?? "").trim(),
+    };
+    return token;
+  },
+};
+
+// Instances, not `marked.use`: the global `marked` singleton is shared with
+// every other consumer in the process, and the directive extension must only
+// apply to legal drafts.
+const plainMarkdown = new Marked({ gfm: true });
+const legalMarkdown = new Marked({ gfm: true, extensions: [legalDirectiveExtension] });
+
+/** GFM block tokens of a markdown document. */
+export const lexMarkdown = (source: string): Token[] => plainMarkdown.lexer(source);
+
+/** GFM block tokens of a legal draft, with `@directive` lines as {@link LegalDirectiveToken}s. */
+export const lexLegalSource = (source: string): Token[] => legalMarkdown.lexer(source);
+
+/** Inline tokens (emphasis, code spans, links, breaks) of one paragraph's text. */
+export const lexInlineMarkdown = (text: string): Token[] =>
+  plainMarkdown.Lexer.lexInline(text, plainMarkdown.defaults);
+
+export const isLegalDirectiveToken = (token: Token): token is LegalDirectiveToken =>
+  token.type === LEGAL_DIRECTIVE_TOKEN_TYPE;
+
+// marked's `Token` union carries a `Tokens.Generic` member whose `type: string`
+// overlaps every literal (and whose `any` index signature absorbs the whole
+// union, so `Exclude` can't strip it). A plain `token.type === "x"` guard thus
+// narrows to `Tokens.X | Tokens.Generic` and field access stays `any`. This
+// predicate maps the discriminator to the concrete token; the runtime type is
+// exactly the one the discriminator matched because marked only emits Generic
+// for custom extensions, and the one extension registered here has its own
+// predicate above.
+type HandledTokens = {
+  blockquote: Tokens.Blockquote;
+  code: Tokens.Code;
+  codespan: Tokens.Codespan;
+  del: Tokens.Del;
+  em: Tokens.Em;
+  heading: Tokens.Heading;
+  html: Tokens.HTML;
+  link: Tokens.Link;
+  list: Tokens.List;
+  paragraph: Tokens.Paragraph;
+  strong: Tokens.Strong;
+  table: Tokens.Table;
+  text: Tokens.Text;
+};
+
+export const isTokenType = <T extends keyof HandledTokens>(
+  token: Token,
+  type: T,
+): token is HandledTokens[T] => token.type === type;

--- a/packages/docx-core/src/markdown/lexer.ts
+++ b/packages/docx-core/src/markdown/lexer.ts
@@ -24,6 +24,8 @@ const LEGAL_DIRECTIVE_TOKEN_TYPE = "legalDirective";
 // else (`@ 5%`) is ordinary prose.
 const DIRECTIVE_LINE_PATTERN =
   /^[ \t]*@(?<name>[A-Za-z][A-Za-z0-9_-]*)(?<argument>[^\n]*)(?:\n|$)/u;
+// Line-anchored (`m`) so it serves both the block-start lookahead over a
+// multi-line remainder and the per-line boundary pass in `lexLegalSource`.
 const DIRECTIVE_LINE_START_PATTERN = /^[ \t]*@[A-Za-z]/mu;
 
 const legalDirectiveExtension: TokenizerExtension = {
@@ -60,8 +62,57 @@ const legalMarkdown = new Marked({ gfm: true, extensions: [legalDirectiveExtensi
 /** GFM block tokens of a markdown document. */
 export const lexMarkdown = (source: string): Token[] => plainMarkdown.lexer(source);
 
+export type LegalSourceLexResult = {
+  tokens: Token[];
+  /** Maps a line number in the lexed text back to the author's source. */
+  originalLineOf: (line: number) => number;
+};
+
+/**
+ * A directive line always starts a block. marked's paragraph tokenizer asks
+ * block extensions where the next block starts, but its list and blockquote
+ * tokenizers treat any following non-blank line as lazy continuation, so
+ * `- item\n@clause Next` would swallow the directive. Inserting one blank
+ * line before every directive that lacks one gives every tokenizer the same
+ * boundary; the returned map keeps diagnostics on the author's line numbers.
+ */
+const separateDirectiveLines = (
+  source: string,
+): { text: string; originalLineOf: (line: number) => number } => {
+  const lines = source.split("\n");
+  const output: string[] = [];
+  // insertedBefore[i]: blank lines added ahead of output line i (0-based).
+  const insertedBefore: number[] = [];
+  let inserted = 0;
+  for (const [index, line] of lines.entries()) {
+    const previous = output.at(-1);
+    if (
+      index > 0 &&
+      DIRECTIVE_LINE_START_PATTERN.test(line) &&
+      previous !== undefined &&
+      previous.trim() !== ""
+    ) {
+      output.push("");
+      insertedBefore.push(inserted);
+      inserted += 1;
+    }
+    output.push(line);
+    insertedBefore.push(inserted);
+  }
+  return {
+    text: output.join("\n"),
+    originalLineOf: (line) => line - (insertedBefore.at(line - 1) ?? inserted),
+  };
+};
+
 /** GFM block tokens of a legal draft, with `@directive` lines as {@link LegalDirectiveToken}s. */
-export const lexLegalSource = (source: string): Token[] => legalMarkdown.lexer(source);
+export const lexLegalSource = (source: string): LegalSourceLexResult => {
+  const prepared = separateDirectiveLines(source);
+  return {
+    tokens: legalMarkdown.lexer(prepared.text),
+    originalLineOf: prepared.originalLineOf,
+  };
+};
 
 /** Inline tokens (emphasis, code spans, links, breaks) of one paragraph's text. */
 export const lexInlineMarkdown = (text: string): Token[] =>

--- a/packages/docx-core/src/markdown/markdown.test.ts
+++ b/packages/docx-core/src/markdown/markdown.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "../../../../test/property-testing";
+import type { BlockContent, Paragraph, ParagraphContent, Run } from "../model/document";
+import { compileMarkdownToContent } from "./content";
+import { sanitizeMarkdownHref } from "./href";
+import { inlineMarkdownToRuns } from "./inline";
+
+const paragraphs = (content: BlockContent[]): Paragraph[] =>
+  content.flatMap((block) => (block.type === "paragraph" ? [block] : []));
+
+const runText = (run: Run): string =>
+  run.content.map((node) => (node.type === "text" ? node.text : "")).join("");
+
+const flattenRuns = (content: ParagraphContent[]): Run[] =>
+  content.flatMap((node) => {
+    if (node.type === "run") {
+      return [node];
+    }
+    if (node.type === "hyperlink") {
+      return node.children.flatMap((child) => (child.type === "run" ? [child] : []));
+    }
+    return [];
+  });
+
+/** Text plus formatting of each run, for `toContainEqual` assertions. */
+const describeRuns = (content: ParagraphContent[]) =>
+  flattenRuns(content).map((run) => ({ text: runText(run), formatting: run.formatting }));
+
+describe("inlineMarkdownToRuns", () => {
+  test("renders emphasis, code spans, and links as formatted runs", () => {
+    const runs = inlineMarkdownToRuns(
+      "The **Buyer** pays *promptly*, see [the schedule](https://example.com/s) and `Section 4`.",
+    );
+    const hyperlink = runs.find((node) => node.type === "hyperlink");
+    expect(hyperlink?.type === "hyperlink" ? hyperlink.href : undefined).toBe(
+      "https://example.com/s",
+    );
+    const formatted = describeRuns(runs);
+    expect(formatted).toContainEqual({ text: "Buyer", formatting: { bold: true } });
+    expect(formatted).toContainEqual({ text: "promptly", formatting: { italic: true } });
+    expect(formatted).toContainEqual({
+      text: "Section 4",
+      formatting: { fontFamily: { ascii: "Courier New", hAnsi: "Courier New" } },
+    });
+  });
+
+  test("highlights [[placeholders]] only when asked, inheriting the surrounding emphasis", () => {
+    const highlighted = describeRuns(
+      inlineMarkdownToRuns("**[[Party]]** shall pay [[Amount]].", { placeholders: true }),
+    );
+    expect(highlighted).toContainEqual({
+      text: "Party",
+      formatting: { bold: true, highlight: "yellow" },
+    });
+    expect(highlighted).toContainEqual({ text: "Amount", formatting: { highlight: "yellow" } });
+    expect(highlighted.some((run) => run.text.includes("[["))).toBe(false);
+
+    const literal = flattenRuns(inlineMarkdownToRuns("[[Party]] shall pay."));
+    expect(literal.map(runText).join("")).toBe("[[Party]] shall pay.");
+  });
+
+  test("drops executable link targets but keeps their text", () => {
+    const runs = inlineMarkdownToRuns("[bad](javascript:alert(1)) and [data](data:text/html,x)");
+    expect(runs.every((node) => node.type === "run")).toBe(true);
+    expect(flattenRuns(runs).map(runText).join("")).toBe("bad and data");
+  });
+
+  test("the rendered text equals the plain text for any plain sentence", () => {
+    // Words of letters only never form markdown syntax, so the runs must
+    // reproduce the sentence verbatim (no lost or doubled characters).
+    const word = fc.stringMatching(/^[a-z]{1,8}$/u);
+    const sentence = fc.array(word, { minLength: 1, maxLength: 6 }).map((words) => words.join(" "));
+    fc.assert(
+      fc.property(sentence, (text) => {
+        const runs = flattenRuns(inlineMarkdownToRuns(text));
+        return runs.map(runText).join("") === text;
+      }),
+      propertyConfig({ numRuns: 100 }),
+    );
+  });
+});
+
+describe("sanitizeMarkdownHref", () => {
+  test("keeps document anchors and safe external targets", () => {
+    expect(sanitizeMarkdownHref("#intro")).toBe("#intro");
+    expect(sanitizeMarkdownHref("https://example.com/a")).toBe("https://example.com/a");
+    expect(sanitizeMarkdownHref("mailto:legal@example.com")).toBe("mailto:legal@example.com");
+  });
+
+  test("rejects empty, whitespace-bearing, and executable targets", () => {
+    expect(sanitizeMarkdownHref("")).toBeUndefined();
+    expect(sanitizeMarkdownHref("#with space")).toBeUndefined();
+    expect(sanitizeMarkdownHref("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeMarkdownHref("mailto:")).toBeUndefined();
+  });
+});
+
+describe("compileMarkdownToContent", () => {
+  test("maps headings to Heading styles and quotes to the Quote style", () => {
+    const { content } = compileMarkdownToContent("# Title\n\n### Deep\n\n> cited");
+    expect(paragraphs(content).map((paragraph) => paragraph.formatting?.styleId)).toEqual([
+      "Heading1",
+      "Heading3",
+      "Quote",
+    ]);
+  });
+
+  test("carries no numbering without lists", () => {
+    expect(compileMarkdownToContent("Just prose.").numbering).toBeUndefined();
+  });
+
+  test("every list paragraph references a numbering instance it synthesized", () => {
+    const item = fc.stringMatching(/^[a-z]{1,6}$/u);
+    const list = (marker: string, indent: string) =>
+      fc
+        .array(item, { minLength: 1, maxLength: 3 })
+        .map((items) => items.map((text) => `${indent}${marker} ${text}`).join("\n"));
+    const markdown = fc
+      .tuple(list("-", ""), list("1.", "  "), list("-", ""))
+      .map(([first, nested, second]) => `${first}\n${nested}\n\n${second}`);
+    fc.assert(
+      fc.property(markdown, (source) => {
+        const { content, numbering } = compileMarkdownToContent(source);
+        const defined = new Set(numbering?.nums.map((num) => num.numId) ?? []);
+        return paragraphs(content).every(
+          (paragraph) =>
+            paragraph.formatting?.numPr === undefined ||
+            defined.has(paragraph.formatting.numPr.numId),
+        );
+      }),
+      propertyConfig({ numRuns: 50 }),
+    );
+  });
+});

--- a/packages/docx-core/src/markdown/markdown.test.ts
+++ b/packages/docx-core/src/markdown/markdown.test.ts
@@ -109,7 +109,9 @@ describe("compileMarkdownToContent", () => {
 
   test("a nested ordered list does not inherit a sibling's bullet level", () => {
     const { content, numbering } = compileMarkdownToContent("- a\n  - x\n- b\n  1. y");
-    const nested = paragraphs(content).filter((paragraph) => paragraph.formatting?.numPr?.ilvl === 1);
+    const nested = paragraphs(content).filter(
+      (paragraph) => paragraph.formatting?.numPr?.ilvl === 1,
+    );
     expect(nested).toHaveLength(2);
     const [bulletItem, orderedItem] = nested;
     const bulletNumId = bulletItem?.formatting?.numPr?.numId;

--- a/packages/docx-core/src/markdown/markdown.test.ts
+++ b/packages/docx-core/src/markdown/markdown.test.ts
@@ -107,6 +107,20 @@ describe("compileMarkdownToContent", () => {
     ]);
   });
 
+  test("a nested ordered list does not inherit a sibling's bullet level", () => {
+    const { content, numbering } = compileMarkdownToContent("- a\n  - x\n- b\n  1. y");
+    const nested = paragraphs(content).filter((paragraph) => paragraph.formatting?.numPr?.ilvl === 1);
+    expect(nested).toHaveLength(2);
+    const [bulletItem, orderedItem] = nested;
+    const bulletNumId = bulletItem?.formatting?.numPr?.numId;
+    const orderedNumId = orderedItem?.formatting?.numPr?.numId;
+    expect(orderedNumId).not.toBe(bulletNumId);
+    const orderedLevel = numbering?.abstractNums
+      .find((abstract) => abstract.abstractNumId === orderedNumId)
+      ?.levels.find((level) => level.ilvl === 1);
+    expect(orderedLevel?.numFmt).toBe("decimal");
+  });
+
   test("carries no numbering without lists", () => {
     expect(compileMarkdownToContent("Just prose.").numbering).toBeUndefined();
   });

--- a/scripts/api-surface-budget.json
+++ b/scripts/api-surface-budget.json
@@ -1,21 +1,21 @@
 {
   "docx-core": {
-    "reportBytes": 59300,
-    "reportLines": 1918,
-    "declarationBytes": 96687,
-    "declarationLines": 2514
+    "reportBytes": 60393,
+    "reportLines": 1955,
+    "declarationBytes": 99695,
+    "declarationLines": 2567
   },
   "core": {
-    "reportBytes": 237942,
-    "reportLines": 7742,
-    "declarationBytes": 1569351,
-    "declarationLines": 32099
+    "reportBytes": 246894,
+    "reportLines": 7952,
+    "declarationBytes": 1620894,
+    "declarationLines": 33023
   },
   "react": {
-    "reportBytes": 56418,
-    "reportLines": 1632,
-    "declarationBytes": 81801,
-    "declarationLines": 1695
+    "reportBytes": 56922,
+    "reportLines": 1630,
+    "declarationBytes": 82838,
+    "declarationLines": 1703
   },
   "agents": {
     "reportBytes": 13171,
@@ -24,10 +24,10 @@
     "declarationLines": 1053
   },
   "vue": {
-    "reportBytes": 54329,
-    "reportLines": 1552,
-    "declarationBytes": 148163,
-    "declarationLines": 3143
+    "reportBytes": 54675,
+    "reportLines": 1559,
+    "declarationBytes": 149875,
+    "declarationLines": 3174
   },
   "nuxt": {
     "reportBytes": 463,

--- a/scripts/controller-boundary-lint.test.ts
+++ b/scripts/controller-boundary-lint.test.ts
@@ -152,6 +152,15 @@ describe("Rust projection boundary lint", () => {
     expect(lintPath("packages/docx-core/src/projection.ts", PROJECTION_RULE_MARKER)).toBe(0);
   });
 
+  test("accepts absolute URL parsing that carries no module base", () => {
+    expect(
+      lintPath(
+        "test/__fixtures__/packages/docx-core/src/url-parse.valid.ts",
+        PROJECTION_RULE_MARKER,
+      ),
+    ).toBe(0);
+  });
+
   test("accepts allow-listed CommonJS imports at the canonical projection boundary", () => {
     expect(
       lintPath(

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -1,38 +1,38 @@
 {
   "docx-core": {
-    "types": 7438,
-    "instantiations": 5788
+    "types": 8589,
+    "instantiations": 7249
   },
   "core": {
-    "types": 106165,
-    "instantiations": 76444
+    "types": 111472,
+    "instantiations": 82091
   },
   "react": {
-    "types": 134167,
-    "instantiations": 283583
+    "types": 139563,
+    "instantiations": 289321
   },
   "agents": {
-    "types": 68036,
-    "instantiations": 57690
+    "types": 71542,
+    "instantiations": 61574
   },
   "vue": {
-    "types": 165153,
-    "instantiations": 825845
+    "types": 170053,
+    "instantiations": 832018
   },
   "nuxt": {
-    "types": 99728,
-    "instantiations": 102505
+    "types": 104025,
+    "instantiations": 107671
   },
   "playground": {
-    "types": 133988,
-    "instantiations": 186355
+    "types": 139479,
+    "instantiations": 192213
   },
   "playground-vue": {
-    "types": 162488,
-    "instantiations": 815996
+    "types": 167733,
+    "instantiations": 822450
   },
   "parity": {
-    "types": 64715,
-    "instantiations": 50973
+    "types": 66281,
+    "instantiations": 52672
   }
 }

--- a/test/__fixtures__/packages/docx-core/src/url-parse.valid.ts
+++ b/test/__fixtures__/packages/docx-core/src/url-parse.valid.ts
@@ -1,0 +1,3 @@
+// Plain URL parsing (link validation) has no module base and cannot load a
+// kernel asset, so it is allowed anywhere in docx-core.
+export const parseAbsoluteUrl = (value: string): URL => new URL(value);


### PR DESCRIPTION
## Summary

- `@stll/docx-core` gains a `marked`-based markdown module: shared lexer (with a block extension for `@directive` lines), inline renderer (emphasis, code spans, sanitized links, `[[placeholder]]` highlights), and `compileMarkdownToContent` for plain GFM.
- The legal-source parser reads that token stream. Body strings keep their inline markdown and are rendered at compile time; bare markdown lists and pipe tables become list and table blocks; `@list`, `@table`, and `@signatures` bodies stay line-oriented. Invented closers (`@endlist`) are ignored with a fix entry; a body string bold end to end raises a `whole-paragraph-emphasis` warning.
- `@stll/folio-core`'s `fromMarkdown` wraps `compileMarkdownToContent`; `sanitizeExternalUrl` is re-exported from docx-core; `marked` moves to docx-core.
- The `rust-projection-boundary` lint rule flags only module-relative `new URL(x, import.meta.url)` constructions.

Changeset: docx-core minor, folio-core patch.
