### PR TITLE
fix(agents): split multi-line insert text into paragraphs

### DIFF
--- a/.changeset/split-multiline-insert-text.md
+++ b/.changeset/split-multiline-insert-text.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-agents": patch
+---
+
+Split `insertAfterBlock` / `insertBeforeBlock` text on line breaks into consecutive paragraphs instead of one paragraph with embedded newlines, and report the split as a `splitMultilineText` normalization (`FolioAIEditApplyResult.normalizations`, surfaced through `suggest_changes`' `normalizations`). Only the first paragraph keeps `styleId` / `inheritFormatting`; later paragraphs get body formatting.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -152,7 +152,18 @@ export type FolioAIEditApplyMode = "direct" | "tracked-changes" | "suggested";
 export type FolioAIEditApplyResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
+    normalizations?: FolioAIEditNormalization[];
 };
+
+// @public
+export type FolioAIEditNormalization = {
+    id: string;
+    code: FolioAIEditNormalizationCode;
+    paragraphCount: number;
+};
+
+// @public
+export type FolioAIEditNormalizationCode = "splitMultilineText";
 
 // @public (undocumented)
 export type FolioAIEditOperation = FolioAIEditReviewMeta & {

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -528,7 +528,18 @@ export type FolioAIEditApplyMode = "direct" | "tracked-changes" | "suggested";
 export type FolioAIEditApplyResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
+    normalizations?: FolioAIEditNormalization[];
 };
+
+// @public
+export type FolioAIEditNormalization = {
+    id: string;
+    code: FolioAIEditNormalizationCode;
+    paragraphCount: number;
+};
+
+// @public
+export type FolioAIEditNormalizationCode = "splitMultilineText";
 
 // @public (undocumented)
 export type FolioAIEditOperation = FolioAIEditReviewMeta & {

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -528,7 +528,18 @@ export type FolioAIEditApplyMode = "direct" | "tracked-changes" | "suggested";
 export type FolioAIEditApplyResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
+    normalizations?: FolioAIEditNormalization[];
 };
+
+// @public
+export type FolioAIEditNormalization = {
+    id: string;
+    code: FolioAIEditNormalizationCode;
+    paragraphCount: number;
+};
+
+// @public
+export type FolioAIEditNormalizationCode = "splitMultilineText";
 
 // @public (undocumented)
 export type FolioAIEditOperation = FolioAIEditReviewMeta & {

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -512,7 +512,18 @@ export type FolioAIEditApplyMode = "direct" | "tracked-changes" | "suggested";
 export type FolioAIEditApplyResult = {
     applied: FolioAIEditAppliedOperation[];
     skipped: FolioAIEditSkippedOperation[];
+    normalizations?: FolioAIEditNormalization[];
 };
+
+// @public
+export type FolioAIEditNormalization = {
+    id: string;
+    code: FolioAIEditNormalizationCode;
+    paragraphCount: number;
+};
+
+// @public
+export type FolioAIEditNormalizationCode = "splitMultilineText";
 
 // @public (undocumented)
 export type FolioAIEditOperation = FolioAIEditReviewMeta & {

--- a/packages/agents/src/execute.test.ts
+++ b/packages/agents/src/execute.test.ts
@@ -307,6 +307,58 @@ describe("executeFolioToolCall: happy path against a real FolioDocxReviewer", ()
     expect(afterResolveOpen).toHaveLength(0);
   });
 
+  test("suggest_changes: insertAfterBlock with multi-line text splits into paragraphs and reports a normalization", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(readFixture(), { author: "AI Reviewer" });
+    const bridge = createReviewerBridge(reviewer);
+
+    const blocks = expectOk(executeFolioToolCall(FOLIO_AGENT_TOOL_NAMES.readDocument, {}, bridge));
+    const heading = blocks.find((block) => block.text.includes("Heading"));
+    if (!heading) {
+      throw new Error("expected a block containing 'Heading'");
+    }
+
+    // A cheap model routinely sends a whole clause — heading plus body — as
+    // one operation with embedded newlines instead of one operation per
+    // paragraph. This must not land as one paragraph with literal newlines.
+    const suggestResult = expectOk(
+      executeFolioToolCall(
+        FOLIO_AGENT_TOOL_NAMES.suggestChanges,
+        {
+          operations: [
+            {
+              id: "op-1",
+              type: "insertAfterBlock",
+              blockId: heading.blockId,
+              text: "6. Force Majeure\nNeither party shall be liable for delays beyond its control.",
+              styleId: "Heading2",
+            },
+          ],
+        },
+        bridge,
+      ),
+    );
+    expect(suggestResult.applied).toHaveLength(1);
+    expect(suggestResult.skipped).toEqual([]);
+    expect(suggestResult.normalizations).toEqual([
+      {
+        path: "operations[id=op-1].text",
+        message: expect.stringContaining("split into 2"),
+      },
+    ]);
+
+    const afterInsert = expectOk(
+      executeFolioToolCall(FOLIO_AGENT_TOOL_NAMES.readDocument, {}, bridge),
+    );
+    expect(afterInsert.some((block) => block.text === "6. Force Majeure")).toBe(true);
+    expect(
+      afterInsert.some(
+        (block) => block.text === "Neither party shall be liable for delays beyond its control.",
+      ),
+    ).toBe(true);
+    // No block anywhere in the document carries a literal newline.
+    expect(afterInsert.every((block) => !block.text.includes("\n"))).toBe(true);
+  });
+
   test("suggest_changes reports a plain-language skip reason for a missing block", async () => {
     const reviewer = await FolioDocxReviewer.fromBuffer(readFixture());
     const bridge = createReviewerBridge(reviewer);

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -7,6 +7,7 @@ import {
   normalizeFolioAIBlockText,
   readFolioDocumentSection,
   type FolioAIBlock,
+  type FolioAIEditNormalization,
   type FolioAITextRangeHandle,
   type FolioDocumentOperation,
   type FolioDocumentOperationBatchPrecondition,
@@ -539,6 +540,31 @@ const explainSkipReason = (reason: string): string => {
   return reason;
 };
 
+/**
+ * Turn one apply-time `FolioAIEditNormalization` (an automatic adjustment the
+ * applier made to an operation's input, e.g. splitting a multi-line
+ * `insertAfterBlock` / `insertBeforeBlock` `text` into several paragraphs)
+ * into the same `{ path, message }` shape lenient decoding reports, so the
+ * model sees every normalization in one list regardless of where it happened.
+ */
+const explainApplyNormalization = (
+  normalization: FolioAIEditNormalization,
+): FolioAgentInputNormalization => {
+  if (normalization.code === "splitMultilineText") {
+    return {
+      path: `operations[id=${normalization.id}].text`,
+      message:
+        `\`text\` contained line breaks; split into ${normalization.paragraphCount} ` +
+        "consecutive paragraphs (one per non-blank line) instead of one paragraph with " +
+        "embedded newlines.",
+    };
+  }
+  return {
+    path: `operations[id=${normalization.id}]`,
+    message: `input was normalized (${normalization.code}).`,
+  };
+};
+
 type ApplyResultLike = {
   version: typeof FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION;
   applied: { id: string }[];
@@ -546,6 +572,7 @@ type ApplyResultLike = {
   skipped: { id: string; reason: string }[];
   issues?: FolioAgentApplyOperationsSummary["issues"];
   receipts?: FolioAgentApplyOperationsSummary["receipts"];
+  normalizations?: readonly FolioAIEditNormalization[];
 };
 
 const summarizeApplyResult = (
@@ -561,7 +588,10 @@ const summarizeApplyResult = (
   })),
   issues: result.issues ?? [],
   receipts: result.receipts ?? [],
-  normalizations: [...normalizations],
+  normalizations: [
+    ...normalizations,
+    ...(result.normalizations ?? []).map(explainApplyNormalization),
+  ],
 });
 
 /** Every operation skipped for one batch-wide reason, before anything reached the bridge. */

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -240,7 +240,15 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: FolioJsonSchema = {
         ...suggestionIdProperty,
         type: { type: "string", enum: ["insertAfterBlock"] },
         blockId: blockIdProperty,
-        text: { type: "string", description: "The paragraph text to insert." },
+        text: {
+          type: "string",
+          description:
+            "The paragraph text to insert. A line break splits this into consecutive " +
+            "paragraphs at the same anchor instead of one paragraph with embedded newlines " +
+            "— only the first paragraph gets `styleId` / `inheritFormatting`, later ones use " +
+            "body formatting. Prefer one paragraph per operation; only rely on the split for " +
+            "a heading immediately followed by its body text.",
+        },
         inheritFormatting: {
           type: "boolean",
           description: "Inherit the anchor block's formatting for the inserted paragraph.",
@@ -266,7 +274,15 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: FolioJsonSchema = {
         ...suggestionIdProperty,
         type: { type: "string", enum: ["insertBeforeBlock"] },
         blockId: blockIdProperty,
-        text: { type: "string", description: "The paragraph text to insert." },
+        text: {
+          type: "string",
+          description:
+            "The paragraph text to insert. A line break splits this into consecutive " +
+            "paragraphs at the same anchor instead of one paragraph with embedded newlines " +
+            "— only the first paragraph gets `styleId` / `inheritFormatting`, later ones use " +
+            "body formatting. Prefer one paragraph per operation; only rely on the split for " +
+            "a heading immediately followed by its body text.",
+        },
         inheritFormatting: {
           type: "boolean",
           description: "Inherit the anchor block's formatting for the inserted paragraph.",

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -976,6 +976,147 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.child(2).textContent).toBe("Second inserted.");
   });
 
+  test("splits multi-line insertAfterBlock text into consecutive paragraphs and reports a normalization", () => {
+    // A model routinely sends a whole clause — heading plus body — as one
+    // `text` with embedded newlines. Word has no paragraph-with-a-line-break
+    // primitive, so this must become several paragraphs, not literal
+    // newline characters inside one.
+    const view = makeView(makeState(["5. Confidentiality body."]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "6. Force Majeure\nNeither party shall be liable for delays beyond its control.",
+          styleId: "Heading2",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(3);
+    // Only the first resulting paragraph is the one the model styled.
+    expect(view.state.doc.child(1).textContent).toBe("6. Force Majeure");
+    expect(view.state.doc.child(1).attrs["styleId"]).toBe("Heading2");
+    // The body line lands as its own, separately-styled paragraph.
+    expect(view.state.doc.child(2).textContent).toBe(
+      "Neither party shall be liable for delays beyond its control.",
+    );
+    expect(view.state.doc.child(2).attrs["styleId"]).toBeNull();
+    expect(result.normalizations).toEqual([
+      { id: "op-1", code: "splitMultilineText", paragraphCount: 2 },
+    ]);
+  });
+
+  test("leaves a single-line insertAfterBlock unchanged and reports no normalization", () => {
+    const view = makeView(makeState(["Anchor block."]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "Single paragraph, no line breaks.",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(1).textContent).toBe("Single paragraph, no line breaks.");
+    expect(result.normalizations).toBeUndefined();
+  });
+
+  test("splits insertAfterBlock text on CRLF line endings", () => {
+    const view = makeView(makeState(["Anchor block."]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "First line.\r\nSecond line.",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(1).textContent).toBe("First line.");
+    expect(view.state.doc.child(2).textContent).toBe("Second line.");
+    expect(result.normalizations).toEqual([
+      { id: "op-1", code: "splitMultilineText", paragraphCount: 2 },
+    ]);
+  });
+
+  test("collapses blank and trailing lines when splitting multi-line insert text", () => {
+    const view = makeView(makeState(["Anchor block."]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "6. Force Majeure\n\nNeither party shall be liable.\n\n\n",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    // Blank lines are dropped rather than becoming empty paragraphs, and the
+    // trailing newlines do not add a trailing empty block.
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(1).textContent).toBe("6. Force Majeure");
+    expect(view.state.doc.child(2).textContent).toBe("Neither party shall be liable.");
+    expect(result.normalizations).toEqual([
+      { id: "op-1", code: "splitMultilineText", paragraphCount: 2 },
+    ]);
+  });
+
+  test("gives every paragraph from a split insert its own tracked-change revision id", () => {
+    const view = makeView(makeState(["Anchor block."]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "Heading\nBody line.",
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(result.applied[0]?.revisionIds).toHaveLength(2);
+    expect(new Set(result.applied[0]?.revisionIds).size).toBe(2);
+  });
+
   test("inheritFormatting does not copy identity attrs (paraId / textId)", () => {
     // The new block synthesized for an insertAfterBlock with
     // inheritFormatting must keep formatting attrs (listMarker,

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1117,6 +1117,68 @@ describe("Folio AI edit operations", () => {
     expect(new Set(result.applied[0]?.revisionIds).size).toBe(2);
   });
 
+  test("does not leak a list-item anchor's listMarker onto later paragraphs of a split insert", () => {
+    // baseAttrs (inherited from the anchor) must only land on the first
+    // paragraph. A body-text continuation line is not a list item just
+    // because the anchor it followed was.
+    const view = makeView(makeState([{ text: "Payment one.", listMarker: "7.5.1" }]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "Payment two.\nSubject to the schedule in Annex A.",
+          inheritFormatting: true,
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(1).textContent).toBe("Payment two.");
+    expect(view.state.doc.child(1).attrs["listMarker"]).toBe("7.5.1");
+    expect(view.state.doc.child(2).textContent).toBe("Subject to the schedule in Annex A.");
+    expect(view.state.doc.child(2).attrs["listMarker"]).toBeNull();
+  });
+
+  test("does not leak a heading anchor's styleId onto later paragraphs of a split insert", () => {
+    // Same contract from the other direction: when the ANCHOR (not the
+    // operation's own styleId override) carries a styleId, only the first
+    // synthesized paragraph may inherit it.
+    const view = makeView(makeState([{ text: "1. Definitions", styleId: "Heading2" }]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: "seq-0001",
+          text: "In this agreement, the following terms apply.\nMore body text.",
+          inheritFormatting: true,
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(1).textContent).toBe(
+      "In this agreement, the following terms apply.",
+    );
+    expect(view.state.doc.child(1).attrs["styleId"]).toBe("Heading2");
+    expect(view.state.doc.child(2).textContent).toBe("More body text.");
+    expect(view.state.doc.child(2).attrs["styleId"]).toBeNull();
+  });
+
   test("inheritFormatting does not copy identity attrs (paraId / textId)", () => {
     // The new block synthesized for an insertAfterBlock with
     // inheritFormatting must keep formatting attrs (listMarker,

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -352,15 +352,35 @@ type LiveBlockEntry = { from: number; to: number; node: PMNode };
  * uniqueness across overlapping calls in the same JS realm.
  */
 let revisionIdCursor = Date.now() * 1000;
-const nextRevisionSeed = (count: number): number => {
-  // Each replacement allocates up to three ids: deletion, insertion, and
-  // background-format clearing. Insert/delete operations use one each.
-  // Reserve `count * 4` to be safely above any conceivable per-op
-  // allocation (current max is 3). Returning the start of the
-  // reserved range as the seed is enough — the caller bumps it.
+const nextRevisionSeed = (revisionIdCount: number): number => {
+  // The caller has already summed a safe per-operation reservation (see
+  // `estimateRevisionIdReservation`); reserving exactly that many ids keeps
+  // this batch's range from overlapping the next `nextRevisionSeed` call's
+  // range. Returning the start of the reserved range as the seed is enough
+  // — the caller bumps it.
   const start = revisionIdCursor;
-  revisionIdCursor += Math.max(count, 1) * 4;
+  revisionIdCursor += Math.max(revisionIdCount, 1);
   return start;
+};
+
+/**
+ * Ids one resolved operation may allocate from the shared revision-id range
+ * reserved by `nextRevisionSeed`. Most operation types allocate at most
+ * three (delete + insert + background-format clearing); reserving four per
+ * operation is a safe cushion above that. A multi-paragraph
+ * `insertAfterBlock` / `insertBeforeBlock` (`text` split on line breaks,
+ * see `splitInsertParagraphTexts`) allocates one id per paragraph in
+ * tracked-changes mode, so it needs more than four once split into more
+ * than four paragraphs — reserving less than that would let a later
+ * `nextRevisionSeed` call reuse an id this operation already stamped on
+ * the document.
+ */
+const REVISION_IDS_PER_OPERATION = 4;
+const estimateRevisionIdReservation = (item: ResolvedOperation): number => {
+  if (item.operation.type === "insertAfterBlock" || item.operation.type === "insertBeforeBlock") {
+    return Math.max(item.insertTexts?.length ?? 1, REVISION_IDS_PER_OPERATION);
+  }
+  return REVISION_IDS_PER_OPERATION;
 };
 
 /**
@@ -723,7 +743,11 @@ const applyFolioAIEditOperationsInternal = ({
   }
 
   let tr = view.state.tr;
-  let revisionSeed = revisionIdSeed ?? nextRevisionSeed(executableResolved.length);
+  const revisionIdReservation = executableResolved.reduce(
+    (total, item) => total + estimateRevisionIdReservation(item),
+    0,
+  );
+  let revisionSeed = revisionIdSeed ?? nextRevisionSeed(revisionIdReservation);
   const date = new Date().toISOString();
   const insertedColumnCounts = new Map<string, number>();
 
@@ -1009,10 +1033,12 @@ const applyFolioAIEditOperationsInternal = ({
         // read from.
         const operation = item.operation;
 
-        // Inherit formatting attrs (listMarker, styleId, …) from
-        // the source block but never reuse identity attrs — a new
-        // paragraph must get fresh paraId/textId so trackers don't
-        // collide. Shared by every paragraph the insert produces.
+        // Inherit formatting attrs (listMarker, styleId, …) from the source
+        // block but never reuse identity attrs — a new paragraph must get
+        // fresh paraId/textId so trackers don't collide. Applied to the
+        // first paragraph only: a paragraph synthesized from a later line
+        // in a split `text` is body text, not a clone of the anchor, so it
+        // must not carry the anchor's heading/list styling either.
         const baseAttrs =
           operation.inheritFormatting === false
             ? {}
@@ -1052,7 +1078,7 @@ const applyFolioAIEditOperationsInternal = ({
           const content =
             text.length > 0 ? buildEmphasisInlineContent(view.state.schema, text, marks) : null;
 
-          const attrs: Record<string, unknown> = { ...baseAttrs };
+          const attrs: Record<string, unknown> = isFirstParagraph ? { ...baseAttrs } : {};
           if (isFirstParagraph && operation.pageBreakBefore === true) {
             attrs["pageBreakBefore"] = true;
           }

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -49,6 +49,7 @@ import type {
   FolioAIEditAppliedOperation,
   FolioAIEditApplyMode,
   FolioAIEditApplyResult,
+  FolioAIEditNormalization,
   FolioAIEditOperation,
   FolioAIEditSnapshot,
   FolioAIEditSkipReason,
@@ -115,7 +116,12 @@ type ResolvedOperation = {
   blockFrom: number;
   blockTo: number;
   blockNode: PMNode;
-  insertText?: string;
+  /**
+   * One entry per paragraph the insert produces. Usually a single entry;
+   * more than one when the operation's `text` contained a line break and
+   * was split into consecutive paragraphs (see {@link splitInsertParagraphTexts}).
+   */
+  insertTexts?: readonly string[];
   tableRowInsertion?: TableRowInsertion;
   tableRowDeletion?: TableRowDeletion;
   tableColumnInsertion?: TableColumnInsertion;
@@ -547,6 +553,24 @@ const buildSignatureTableNode = ({
   return tableType.create({}, row);
 };
 
+const LINE_BREAK_PATTERN = /\r\n|\r|\n/;
+
+/**
+ * Split `insertAfterBlock` / `insertBeforeBlock` text on line breaks into one
+ * string per paragraph the operation should produce. A model routinely sends
+ * a whole clause — heading plus body — as one `text` with embedded newlines;
+ * Word has no such thing as a paragraph containing a line break, so each line
+ * becomes its own paragraph instead of literal newline characters inside one.
+ * Blank (whitespace-only) lines are dropped rather than becoming empty
+ * paragraphs, so a trailing/leading newline collapses away. Falls back to a
+ * single empty string when every line is blank, so callers never get zero
+ * paragraphs out of non-empty input.
+ */
+const splitInsertParagraphTexts = (text: string): string[] => {
+  const nonBlankLines = text.split(LINE_BREAK_PATTERN).filter((line) => line.trim().length > 0);
+  return nonBlankLines.length > 0 ? nonBlankLines : [""];
+};
+
 /**
  * Build the inline content for an inserted or replaced block, promoting the
  * model's `**bold**` / `***bold italic***` markdown into real Word marks (the
@@ -595,6 +619,7 @@ const applyFolioAIEditOperationsInternal = ({
 }: ApplyFolioAIEditOperationsInternalOptions): FolioAIEditApplyResult => {
   const applied: FolioAIEditAppliedOperation[] = [];
   const skipped: FolioAIEditSkippedOperation[] = [];
+  const normalizations: FolioAIEditNormalization[] = [];
   const resolved: ResolvedOperation[] = [];
   const insertionType = view.state.schema.marks["insertion"];
   const deletionType = view.state.schema.marks["deletion"];
@@ -664,6 +689,17 @@ const applyFolioAIEditOperationsInternal = ({
       claimedTableColumns.add(columnKey);
     }
 
+    if (
+      (operation.type === "insertAfterBlock" || operation.type === "insertBeforeBlock") &&
+      LINE_BREAK_PATTERN.test(operation.text)
+    ) {
+      normalizations.push({
+        id: operation.id,
+        code: "splitMultilineText",
+        paragraphCount: resolution.operation.insertTexts?.length ?? 1,
+      });
+    }
+
     const commentId = commentText !== undefined ? createCommentId?.(commentText) : undefined;
     resolved.push({
       ...resolution.operation,
@@ -683,7 +719,7 @@ const applyFolioAIEditOperationsInternal = ({
   const executableResolved = tablePlan.executable;
 
   if (executableResolved.length === 0) {
-    return { applied, skipped };
+    return { applied, skipped, ...(normalizations.length > 0 && { normalizations }) };
   }
 
   let tr = view.state.tr;
@@ -951,10 +987,12 @@ const applyFolioAIEditOperationsInternal = ({
       }
       case "insertAfterBlock":
       case "insertBeforeBlock": {
+        const insertTexts = item.insertTexts ?? [""];
+        const isEmptyInsert = insertTexts.length === 1 && insertTexts[0]?.length === 0;
         if (
           mode === "tracked-changes" &&
           item.operation.pageBreakBefore === true &&
-          (!item.insertText || item.insertText.length === 0)
+          isEmptyInsert
         ) {
           skipped.push({
             id: item.operation.id,
@@ -963,72 +1001,83 @@ const applyFolioAIEditOperationsInternal = ({
           continue;
         }
 
-        const marks = [];
-        let insertedBlockRevisionId: number | null = null;
-        if (producesTrackedChanges && insertionType) {
-          const revisionId = revisionSeed++;
-          insertedBlockRevisionId = revisionId;
-          marks.push(
-            insertionType.create({
-              revisionId,
-              author,
-              date,
-              ...trackedRevisionExtras,
-            }),
-          );
-          appliedRevisionIds = [revisionId];
-        }
-        if (commentMark) {
-          marks.push(commentMark);
-        }
-        const content =
-          item.insertText && item.insertText.length > 0
-            ? buildEmphasisInlineContent(view.state.schema, item.insertText, marks)
-            : null;
         // Inherit formatting attrs (listMarker, styleId, …) from
         // the source block but never reuse identity attrs — a new
         // paragraph must get fresh paraId/textId so trackers don't
-        // collide.
+        // collide. Shared by every paragraph the insert produces.
         const baseAttrs =
           item.operation.inheritFormatting === false
             ? {}
             : stripBlockIdentityAttrs(item.blockNode.attrs);
-        const attrs: Record<string, unknown> = { ...baseAttrs };
-        if (item.operation.pageBreakBefore === true) {
-          attrs["pageBreakBefore"] = true;
-        }
-        if (item.operation.styleId !== undefined) {
-          // Heading / clause style ids (e.g. ClauseHeading1) take
-          // precedence over the source block's style so the
-          // inserted paragraph renders as the requested kind, not
-          // as a clone of the anchor.
-          attrs["styleId"] = item.operation.styleId;
-          // A heading is logically a fresh block; drop list marker
-          // attrs that would otherwise leak from the anchor and
-          // render the heading as a list item.
-          if (item.operation.inheritFormatting !== false) {
-            attrs["listMarker"] = null;
-            attrs["listMarkerHidden"] = null;
-            attrs["listLevelNumFmts"] = null;
-            attrs["listLevelStarts"] = null;
-            attrs["listAbstractNumId"] = null;
-            attrs["listStartOverride"] = null;
+
+        const insertedBlockRevisionIds: number[] = [];
+        const nodes = insertTexts.map((text, paragraphIndex) => {
+          // `text` was split from one operation's `text` field on a line
+          // break (see `splitInsertParagraphTexts`); only the first
+          // resulting paragraph is the one the model actually styled —
+          // later ones are body text that happened to share the call.
+          const isFirstParagraph = paragraphIndex === 0;
+
+          const marks: Mark[] = [];
+          let paragraphRevisionId: number | null = null;
+          if (producesTrackedChanges && insertionType) {
+            paragraphRevisionId = revisionSeed++;
+            marks.push(
+              insertionType.create({
+                revisionId: paragraphRevisionId,
+                author,
+                date,
+                ...trackedRevisionExtras,
+              }),
+            );
+            insertedBlockRevisionIds.push(paragraphRevisionId);
           }
+          if (commentMark) {
+            marks.push(commentMark);
+          }
+          const content =
+            text.length > 0 ? buildEmphasisInlineContent(view.state.schema, text, marks) : null;
+
+          const attrs: Record<string, unknown> = { ...baseAttrs };
+          if (isFirstParagraph && item.operation.pageBreakBefore === true) {
+            attrs["pageBreakBefore"] = true;
+          }
+          if (isFirstParagraph && item.operation.styleId !== undefined) {
+            // Heading / clause style ids (e.g. ClauseHeading1) take
+            // precedence over the source block's style so the
+            // inserted paragraph renders as the requested kind, not
+            // as a clone of the anchor.
+            attrs["styleId"] = item.operation.styleId;
+            // A heading is logically a fresh block; drop list marker
+            // attrs that would otherwise leak from the anchor and
+            // render the heading as a list item.
+            if (item.operation.inheritFormatting !== false) {
+              attrs["listMarker"] = null;
+              attrs["listMarkerHidden"] = null;
+              attrs["listLevelNumFmts"] = null;
+              attrs["listLevelStarts"] = null;
+              attrs["listAbstractNumId"] = null;
+              attrs["listStartOverride"] = null;
+            }
+          }
+          // In suggested mode, mark the whole inserted paragraph so the strip
+          // drops it from serialized DOCX until accepted (the inline insertion
+          // marks alone would leave an empty paragraph behind).
+          if (isSuggested && suggestionId !== null && paragraphRevisionId !== null) {
+            attrs["_suggestedInsert"] = {
+              suggestionId,
+              revisionId: paragraphRevisionId,
+              author,
+              date,
+              ...(initials ? { initials } : {}),
+            };
+          }
+          return item.blockNode.type.create(attrs, content);
+        });
+        if (insertedBlockRevisionIds.length > 0) {
+          appliedRevisionIds = insertedBlockRevisionIds;
         }
-        // In suggested mode, mark the whole inserted paragraph so the strip
-        // drops it from serialized DOCX until accepted (the inline insertion
-        // marks alone would leave an empty paragraph behind).
-        if (isSuggested && suggestionId !== null && insertedBlockRevisionId !== null) {
-          attrs["_suggestedInsert"] = {
-            suggestionId,
-            revisionId: insertedBlockRevisionId,
-            author,
-            date,
-            ...(initials ? { initials } : {}),
-          };
-        }
-        const node = item.blockNode.type.create(attrs, content);
-        tr = tr.insert(item.from, node);
+        tr = tr.insert(item.from, nodes);
         break;
       }
       case "insertSignatureTable": {
@@ -1349,7 +1398,7 @@ const applyFolioAIEditOperationsInternal = ({
     view.dispatch(tr);
   }
 
-  return { applied, skipped };
+  return { applied, skipped, ...(normalizations.length > 0 && { normalizations }) };
 };
 
 export const applyFolioAIEditOperations = (
@@ -1378,6 +1427,7 @@ export const previewFolioAIEditOperations = (
   return {
     applied: result.applied.map(({ id }) => ({ id })),
     skipped: result.skipped,
+    ...(result.normalizations !== undefined && { normalizations: result.normalizations }),
   };
 };
 
@@ -1750,6 +1800,9 @@ const resolveOperation = ({
     } else {
       insertFrom = isInsertAfter ? blockTo : blockFrom;
     }
+    const insertTexts = LINE_BREAK_PATTERN.test(operation.text)
+      ? splitInsertParagraphTexts(operation.text)
+      : [operation.text];
     return {
       type: "resolved",
       operation: {
@@ -1759,7 +1812,7 @@ const resolveOperation = ({
         blockFrom,
         blockTo,
         blockNode,
-        insertText: operation.text,
+        insertTexts,
       },
     };
   }

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1001,17 +1001,31 @@ const applyFolioAIEditOperationsInternal = ({
           continue;
         }
 
+        // Captured once into a `const`, not re-read as `item.operation.*`
+        // inside the loop below: the switch's discriminant narrows
+        // `item.operation` here, but that narrowing does not reliably
+        // survive a property-chain re-read from inside a nested loop body,
+        // whereas a `const` binding's type is fixed for every scope it is
+        // read from.
+        const operation = item.operation;
+
         // Inherit formatting attrs (listMarker, styleId, …) from
         // the source block but never reuse identity attrs — a new
         // paragraph must get fresh paraId/textId so trackers don't
         // collide. Shared by every paragraph the insert produces.
         const baseAttrs =
-          item.operation.inheritFormatting === false
+          operation.inheritFormatting === false
             ? {}
             : stripBlockIdentityAttrs(item.blockNode.attrs);
 
+        // Built with a plain `for` loop rather than `.map()`: a function
+        // declared inside this outer loop that closes over `revisionSeed`
+        // (mutated every iteration via `revisionSeed++`) trips oxlint's
+        // no-loop-func rule, even though this callback always runs
+        // synchronously and never outlives the iteration.
         const insertedBlockRevisionIds: number[] = [];
-        const nodes = insertTexts.map((text, paragraphIndex) => {
+        const nodes: PMNode[] = [];
+        for (const [paragraphIndex, text] of insertTexts.entries()) {
           // `text` was split from one operation's `text` field on a line
           // break (see `splitInsertParagraphTexts`); only the first
           // resulting paragraph is the one the model actually styled —
@@ -1039,19 +1053,19 @@ const applyFolioAIEditOperationsInternal = ({
             text.length > 0 ? buildEmphasisInlineContent(view.state.schema, text, marks) : null;
 
           const attrs: Record<string, unknown> = { ...baseAttrs };
-          if (isFirstParagraph && item.operation.pageBreakBefore === true) {
+          if (isFirstParagraph && operation.pageBreakBefore === true) {
             attrs["pageBreakBefore"] = true;
           }
-          if (isFirstParagraph && item.operation.styleId !== undefined) {
+          if (isFirstParagraph && operation.styleId !== undefined) {
             // Heading / clause style ids (e.g. ClauseHeading1) take
             // precedence over the source block's style so the
             // inserted paragraph renders as the requested kind, not
             // as a clone of the anchor.
-            attrs["styleId"] = item.operation.styleId;
+            attrs["styleId"] = operation.styleId;
             // A heading is logically a fresh block; drop list marker
             // attrs that would otherwise leak from the anchor and
             // render the heading as a list item.
-            if (item.operation.inheritFormatting !== false) {
+            if (operation.inheritFormatting !== false) {
               attrs["listMarker"] = null;
               attrs["listMarkerHidden"] = null;
               attrs["listLevelNumFmts"] = null;
@@ -1072,8 +1086,8 @@ const applyFolioAIEditOperationsInternal = ({
               ...(initials ? { initials } : {}),
             };
           }
-          return item.blockNode.type.create(attrs, content);
-        });
+          nodes.push(item.blockNode.type.create(attrs, content));
+        }
         if (insertedBlockRevisionIds.length > 0) {
           appliedRevisionIds = insertedBlockRevisionIds;
         }

--- a/packages/core/src/ai-edits/headlessReview.property.test.ts
+++ b/packages/core/src/ai-edits/headlessReview.property.test.ts
@@ -260,4 +260,55 @@ describe("headless reviewer invariants (full corpus)", () => {
     },
     propertyTestTimeout(25_000),
   );
+
+  test(
+    "insertAfterBlock never leaves a block whose text contains a line break",
+    async () => {
+      // A model routinely sends a whole clause — heading plus body — as one
+      // `text` with embedded newlines. Word has no paragraph-with-a-line-break
+      // primitive, so the applier must split it into several paragraphs
+      // instead; this checks that invariant across the full fixture corpus
+      // and random line shapes rather than pinning one example.
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom(...FIXTURE_FILES),
+          fc.nat(),
+          fc.array(fc.stringMatching(/^[A-Za-z0-9 ]{0,20}$/u), { minLength: 1, maxLength: 4 }),
+          fc.constantFrom("\n", "\r\n"),
+          async (filename, selector, lines, lineBreak) => {
+            const text = lines.join(lineBreak);
+            if (text.trim().length === 0) {
+              return;
+            }
+            const buffer = readFixture(filename);
+            const probe = await FolioDocxReviewer.fromBuffer(buffer, { author: "AI" });
+            const targets = editTargets(probe.snapshot().blocks);
+            if (targets.length === 0) {
+              return;
+            }
+            const target = targets[selector % targets.length]!;
+            const op: FolioAIEditOperation = {
+              id: "1",
+              type: "insertAfterBlock",
+              blockId: target.blockId,
+              text,
+            };
+
+            const reviewer = await FolioDocxReviewer.fromBuffer(buffer, { author: "AI" });
+            const applied = reviewer.applyOperations([op], { mode: "direct" });
+            if (applied.applied.length === 0) {
+              return;
+            }
+
+            for (const blockText of blockTexts(reviewer)) {
+              expect(blockText).not.toContain("\n");
+              expect(blockText).not.toContain("\r");
+            }
+          },
+        ),
+        propertyConfig({ numRuns: 30 }),
+      );
+    },
+    propertyTestTimeout(20_000),
+  );
 });

--- a/packages/core/src/ai-edits/headlessReview.property.test.ts
+++ b/packages/core/src/ai-edits/headlessReview.property.test.ts
@@ -311,4 +311,63 @@ describe("headless reviewer invariants (full corpus)", () => {
     },
     propertyTestTimeout(20_000),
   );
+
+  test(
+    "revision ids stay unique across a multi-paragraph tracked insert followed by another apply",
+    async () => {
+      // The shared revision-id range is reserved once per apply call, sized
+      // from the operations in that call (see `estimateRevisionIdReservation`
+      // in apply.ts). A tracked-changes insert whose `text` splits into more
+      // paragraphs than the reservation anticipates must not spill into the
+      // range the NEXT apply call reserves — that would stamp two different
+      // marks with the same revision id.
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom(...FIXTURE_FILES),
+          fc.nat(),
+          fc.nat(),
+          // Non-blank after trim (starts with an alnum) so every requested
+          // line survives the applier's blank-line collapse, guaranteeing a
+          // paragraph count that exceeds the fixed 4-id-per-operation
+          // cushion `estimateRevisionIdReservation` used to fall back to.
+          fc.array(fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9 ]{0,19}$/u), {
+            minLength: 5,
+            maxLength: 9,
+          }),
+          async (filename, selectorA, selectorB, lines) => {
+            const buffer = readFixture(filename);
+            const probe = await FolioDocxReviewer.fromBuffer(buffer, { author: "AI" });
+            const targets = editTargets(probe.snapshot().blocks);
+            if (targets.length < 2) {
+              return;
+            }
+            const targetA = targets[selectorA % targets.length]!;
+            const targetB = targets[selectorB % targets.length]!;
+
+            const reviewer = await FolioDocxReviewer.fromBuffer(buffer, { author: "AI" });
+            const firstApply = reviewer.applyOperations([
+              {
+                id: "insert-1",
+                type: "insertAfterBlock",
+                blockId: targetA.blockId,
+                text: lines.join("\n"),
+              },
+            ]);
+            const secondApply = reviewer.applyOperations([replaceOp(targetB, "ZZWORD")]);
+
+            const revisionIds = [
+              ...firstApply.applied.flatMap((op) => op.revisionIds ?? []),
+              ...secondApply.applied.flatMap((op) => op.revisionIds ?? []),
+            ];
+            if (revisionIds.length === 0) {
+              return;
+            }
+            expect(new Set(revisionIds).size).toBe(revisionIds.length);
+          },
+        ),
+        propertyConfig({ numRuns: 30 }),
+      );
+    },
+    propertyTestTimeout(20_000),
+  );
 });

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -50,6 +50,8 @@ export type {
   FolioAIEditAppliedOperation,
   FolioAIEditApplyMode,
   FolioAIEditApplyResult,
+  FolioAIEditNormalization,
+  FolioAIEditNormalizationCode,
   FolioAIEditOperation,
   FolioAIEditPrecondition,
   FolioAIEditReviewMeta,

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -177,6 +177,14 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         id: string;
         type: "insertAfterBlock" | "insertBeforeBlock";
         blockId: string;
+        /**
+         * The paragraph text to insert. A line break splits `text` into
+         * consecutive paragraphs at the same anchor instead of becoming
+         * literal newlines inside one paragraph: only the first paragraph
+         * gets `styleId` / `inheritFormatting`, later ones use body
+         * formatting. Blank lines are dropped. Reported as a
+         * `splitMultilineText` normalization when it happens.
+         */
         text: string;
         inheritFormatting?: boolean;
         /**
@@ -363,7 +371,25 @@ export type FolioAIEditSkippedOperation = {
   reason: FolioAIEditSkipReason;
 };
 
+/** One automatic adjustment `apply.ts` made to an operation's input to keep the applied result well-formed. */
+export type FolioAIEditNormalizationCode = "splitMultilineText";
+
+/**
+ * A line-break in `insertAfterBlock` / `insertBeforeBlock`'s `text` cannot become
+ * one paragraph with an embedded break (Word paragraphs are single lines); the
+ * applier splits it into one paragraph per non-blank line instead and reports it
+ * here so the caller can see what happened to the text it sent.
+ */
+export type FolioAIEditNormalization = {
+  id: string;
+  code: FolioAIEditNormalizationCode;
+  /** Number of paragraphs the operation's `text` was split into. */
+  paragraphCount: number;
+};
+
 export type FolioAIEditApplyResult = {
   applied: FolioAIEditAppliedOperation[];
   skipped: FolioAIEditSkippedOperation[];
+  /** Present only when at least one operation triggered a normalization. */
+  normalizations?: FolioAIEditNormalization[];
 };

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -9,6 +9,7 @@ import type {
   FolioAIEditAppliedOperation,
   FolioAIEditApplyMode,
   FolioAIEditApplyResult,
+  FolioAIEditNormalization,
   FolioAIEditOperation,
   FolioAIEditPrecondition,
   FolioAIEditReviewMeta,
@@ -914,6 +915,8 @@ type FolioDocumentOperationResultBase = {
   issues: FolioDocumentOperationIssue[];
   /** Successful effects in input-operation order; skipped operations are omitted. */
   receipts: FolioDocumentOperationReceipt[];
+  /** Present when at least one operation triggered an automatic input normalization. */
+  normalizations?: FolioAIEditNormalization[];
   /** Present when the execution surface can undo this committed batch. */
   undoHandle: FolioDocumentOperationUndoHandle | null;
 };
@@ -1193,6 +1196,9 @@ export const applyFolioDocumentOperations = ({
       skipped,
       issues: getFolioDocumentOperationIssues(parsedBatch.operations, skipped),
       receipts: [],
+      ...(previewResult.normalizations !== undefined && {
+        normalizations: previewResult.normalizations,
+      }),
       undoHandle: null,
     };
   };
@@ -1212,6 +1218,9 @@ export const applyFolioDocumentOperations = ({
         operations: parsedBatch.operations,
         applied: previewResult.applied,
         story,
+      }),
+      ...(previewResult.normalizations !== undefined && {
+        normalizations: previewResult.normalizations,
       }),
       undoHandle: null,
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,8 @@ export {
   type FolioAIEditAppliedOperation,
   type FolioAIEditApplyMode,
   type FolioAIEditApplyResult,
+  type FolioAIEditNormalization,
+  type FolioAIEditNormalizationCode,
   type FolioAIEditOperation,
   type FolioAIEditPrecondition,
   type FolioAIEditReviewMeta,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -14,6 +14,8 @@ export type {
   FolioAIBlockAnchor,
   FolioAIBlockKind,
   FolioAIBlockPreviewRun,
+  FolioAIEditNormalization,
+  FolioAIEditNormalizationCode,
   FolioAIEditSnapshot,
   FolioAIInlineFormatting,
   FolioAITextRangeHandle,


### PR DESCRIPTION
## Summary
- `insertAfterBlock` / `insertBeforeBlock` documented `text` as one paragraph, but a newline-bearing value landed as one paragraph with embedded line breaks. `apply.ts` now splits `text` on line breaks into consecutive paragraphs at the same anchor; only the first paragraph keeps `styleId` / `inheritFormatting`, the rest use body formatting.
- Reports the split as a `splitMultilineText` normalization (`FolioAIEditApplyResult.normalizations`), threaded through `document-operations.ts` and surfaced in `suggest_changes`' existing `normalizations` list.
- Updates `operation-schema.ts`'s `text` field descriptions for both insert operations to document the split.

## Test plan
- [x] `bun test packages/core/src/ai-edits` (341 pass) — new unit tests for split/unchanged/CRLF/blank-line-collapse cases plus a per-paragraph tracked-change revisionId test
- [x] `bun test packages/core/src/ai-edits/headlessReview.property.test.ts` — new corpus-wide property: no block text contains a line break after an `insertAfterBlock`
- [x] `bun test packages/agents/src` (179 pass) — new end-to-end `suggest_changes` test against a real `FolioDocxReviewer`
- [x] `bun test packages/core/src/document-operations.test.ts`
- [x] `bun run api:update` / `bun run api:budget` for the changed public surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiline text inserted before or after blocks is now split into separate paragraphs, with blank lines removed.
  * Formatting inheritance is applied to the first paragraph, while subsequent paragraphs use default formatting.
  * Edit results and previews now report when multiline text has been normalised, including the number of paragraphs created.

* **Documentation**
  * Updated operation guidance to explain multiline insertion and formatting behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->