### PR TITLE
feat(core): deterministic two-document compare with tracked changes

### DIFF
--- a/.changeset/quiet-jars-compare.md
+++ b/.changeset/quiet-jars-compare.md
@@ -1,0 +1,15 @@
+---
+"@stll/folio-core": minor
+---
+
+Add `compareDocx(base, target, { author, timestamp })`: a deterministic
+two-document compare returning the base package with tracked changes that
+accept back to the target and reject back to the base, plus a JSON change list
+(`insert`, `delete`, `replace`, `move`, `format`, `table-row-insert`,
+`table-row-delete`). Header, footer, footnote, and endnote stories are reported
+as unsupported rather than silently skipped.
+
+The call reads no clock and no random source, so the same inputs give
+byte-identical output. Supporting that, `FolioRevisionStamp` lets any apply
+batch pin its revision date and id seed, and `FolioAIBlock.table` records the
+block's enclosing table cell.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -24,6 +24,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     author?: string;
     createCommentId?: (text: string) => number;
     createUndoHandle?: () => FolioDocumentOperationUndoHandle;
+    revisionStamp?: FolioRevisionStamp;
 };
 
 // @public (undocumented)
@@ -103,6 +104,7 @@ export type FolioAIBlock = {
     displayLabel?: string;
     styleId?: string;
     previewRuns?: FolioAIBlockPreviewRun[];
+    table?: FolioAIBlockTableLocation;
 };
 
 // @public (undocumented)
@@ -129,6 +131,14 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+};
+
+// @public
+export type FolioAIBlockTableLocation = {
+    tableIndex: number;
+    rowIndex: number;
+    cellIndex: number;
+    paragraphIndex: number;
 };
 
 // @public (undocumented)
@@ -621,6 +631,12 @@ export type FolioReviewedStory = {
 
 // @public (undocumented)
 export type FolioReviewedView = (typeof FOLIO_REVIEWED_VIEWS)[number];
+
+// @public
+export type FolioRevisionStamp = {
+    date: string;
+    idSeed: number;
+};
 
 // @public
 export const getCommentAnchorsFromDoc: (doc: Node_2) => FolioCommentAnchor[];

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -13,6 +13,7 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { Node as Node_2 } from 'prosemirror-model';
 import { Plugin as Plugin_2 } from 'prosemirror-state';
 import { PluginKey } from 'prosemirror-state';
+import { Result } from 'better-result';
 import { TaggedErrorClass } from 'better-result';
 import { Transaction } from 'prosemirror-state';
 
@@ -165,6 +166,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     author?: string;
     createCommentId?: (text: string) => number;
     createUndoHandle?: () => FolioDocumentOperationUndoHandle;
+    revisionStamp?: FolioRevisionStamp;
 };
 
 // @public (undocumented)
@@ -245,6 +247,131 @@ export const clearAutocompleteSuggestion: (tr: Transaction) => Transaction;
 
 // @public
 export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
+
+// @public
+export const COMPARE_UNSUPPORTED_REASONS: readonly ["secondary-story", "story-missing-in-base", "story-missing-in-target"];
+
+// @public
+export type CompareChange = {
+    kind: "insert";
+    location: CompareChangeLocation;
+    targetBlockId: string;
+    after: string;
+} | {
+    kind: "delete";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    before: string;
+} | {
+    kind: "replace";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    targetBlockId: string;
+    before: string;
+    after: string;
+} | {
+    kind: "move";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    targetBlockId: string;
+    text: string;
+} | {
+    kind: "format";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    targetBlockId: string;
+    text: string;
+    ranges: readonly CompareFormatRange[];
+} | {
+    kind: "table-row-insert";
+    location: CompareChangeLocation;
+    tableIndex: number;
+    rowIndex: number;
+    cells: readonly string[];
+    targetBlockIds: readonly string[];
+} | {
+    kind: "table-row-delete";
+    location: CompareChangeLocation;
+    tableIndex: number;
+    rowIndex: number;
+    cells: readonly string[];
+    baseBlockIds: readonly string[];
+};
+
+// @public
+export type CompareChangeLocation = {
+    story: FolioDocumentStoryHandle;
+    cell?: FolioAIBlockTableLocation;
+};
+
+// @public
+export const compareDocx: (base: ArrayBuffer, target: ArrayBuffer, options: CompareDocxOptions) => Promise<Result<CompareResult, CompareDocxError>>;
+
+// @public
+export class CompareDocxApplyError extends CompareDocxApplyError_base<{
+    message: string;
+    skipped: readonly FolioAIEditSkippedOperation[];
+}> {}
+
+// @public (undocumented)
+export type CompareDocxError = CompareDocxApplyError | CompareDocxOperationLimitError | CompareDocxParseError | CompareDocxRoundTripError | CompareDocxSerializeError | InvalidCompareDocxOptionsError;
+
+// @public
+export class CompareDocxOperationLimitError extends CompareDocxOperationLimitError_base<{
+    message: string;
+    limit: number;
+}> {}
+
+// @public
+export type CompareDocxOptions = {
+    author: string;
+    timestamp: string;
+};
+
+// @public (undocumented)
+export class CompareDocxParseError extends CompareDocxParseError_base<{
+    message: string;
+    side: "base" | "target";
+    cause: unknown;
+}> {}
+
+// @public
+export class CompareDocxRoundTripError extends CompareDocxRoundTripError_base<{
+    message: string;
+    story: FolioDocumentStoryHandle;
+    acceptedText: readonly string[];
+    targetText: readonly string[];
+}> {}
+
+// @public (undocumented)
+export class CompareDocxSerializeError extends CompareDocxSerializeError_base<{
+    message: string;
+    cause: unknown;
+}> {}
+
+// @public
+export type CompareFormatRange = {
+    startOffset: number;
+    endOffset: number;
+    formatting: FolioAIInlineFormatting;
+};
+
+// @public (undocumented)
+export type CompareResult = {
+    buffer: ArrayBuffer;
+    changes: readonly CompareChange[];
+    unsupported: readonly CompareUnsupportedPart[];
+};
+
+// @public
+export type CompareUnsupportedPart = {
+    reason: CompareUnsupportedReason;
+    baseStory: FolioDocumentStoryHandle | null;
+    targetStory: FolioDocumentStoryHandle | null;
+};
+
+// @public (undocumented)
+export type CompareUnsupportedReason = (typeof COMPARE_UNSUPPORTED_REASONS)[number];
 
 // @public
 export const consumeTemplateSlashQuery: (state: EditorState) => {
@@ -479,6 +606,7 @@ export type FolioAIBlock = {
     displayLabel?: string;
     styleId?: string;
     previewRuns?: FolioAIBlockPreviewRun[];
+    table?: FolioAIBlockTableLocation;
 };
 
 // @public (undocumented)
@@ -505,6 +633,14 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+};
+
+// @public
+export type FolioAIBlockTableLocation = {
+    tableIndex: number;
+    rowIndex: number;
+    cellIndex: number;
+    paragraphIndex: number;
 };
 
 // @public (undocumented)
@@ -855,6 +991,12 @@ export type FolioDocxCompatibilityHost = "browser" | "server" | "unknown";
 export type FolioDocxCompatibilityProfile = import__stll_docx_core_model.DocxConformanceClass;
 
 // @public
+export type FolioRevisionStamp = {
+    date: string;
+    idSeed: number;
+};
+
+// @public
 export function fromMarkdown(markdown: string): import__stll_docx_core_model.Document;
 
 // @public
@@ -926,6 +1068,13 @@ export const inspectDocxCompatibility: (doc: import__stll_docx_core_model.Docume
 export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
 
 // @public (undocumented)
+export class InvalidCompareDocxOptionsError extends InvalidCompareDocxOptionsError_base<{
+    message: string;
+    option: "timestamp";
+    receivedValue: unknown;
+}> {}
+
+// @public (undocumented)
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base<{
     message: string;
     path: string;
@@ -963,6 +1112,9 @@ export type MarkdownResult = {
     images: Map<string, ImageRef>;
     warnings: string[];
 };
+
+// @public
+export const MAX_COMPARE_OPERATIONS = 10000;
 
 // @public
 export function mergeDocumentContent(target: import__stll_docx_core_model.Document, source: import__stll_docx_core_model.Document): import__stll_docx_core_model.Document;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -13,6 +13,7 @@ import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { Node as Node_2 } from 'prosemirror-model';
 import { Plugin as Plugin_2 } from 'prosemirror-state';
 import { PluginKey } from 'prosemirror-state';
+import { Result } from 'better-result';
 import { TaggedErrorClass } from 'better-result';
 import { Transaction } from 'prosemirror-state';
 
@@ -165,6 +166,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     author?: string;
     createCommentId?: (text: string) => number;
     createUndoHandle?: () => FolioDocumentOperationUndoHandle;
+    revisionStamp?: FolioRevisionStamp;
 };
 
 // @public (undocumented)
@@ -245,6 +247,131 @@ export const clearAutocompleteSuggestion: (tr: Transaction) => Transaction;
 
 // @public
 export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
+
+// @public
+export const COMPARE_UNSUPPORTED_REASONS: readonly ["secondary-story", "story-missing-in-base", "story-missing-in-target"];
+
+// @public
+export type CompareChange = {
+    kind: "insert";
+    location: CompareChangeLocation;
+    targetBlockId: string;
+    after: string;
+} | {
+    kind: "delete";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    before: string;
+} | {
+    kind: "replace";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    targetBlockId: string;
+    before: string;
+    after: string;
+} | {
+    kind: "move";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    targetBlockId: string;
+    text: string;
+} | {
+    kind: "format";
+    location: CompareChangeLocation;
+    baseBlockId: string;
+    targetBlockId: string;
+    text: string;
+    ranges: readonly CompareFormatRange[];
+} | {
+    kind: "table-row-insert";
+    location: CompareChangeLocation;
+    tableIndex: number;
+    rowIndex: number;
+    cells: readonly string[];
+    targetBlockIds: readonly string[];
+} | {
+    kind: "table-row-delete";
+    location: CompareChangeLocation;
+    tableIndex: number;
+    rowIndex: number;
+    cells: readonly string[];
+    baseBlockIds: readonly string[];
+};
+
+// @public
+export type CompareChangeLocation = {
+    story: FolioDocumentStoryHandle;
+    cell?: FolioAIBlockTableLocation;
+};
+
+// @public
+export const compareDocx: (base: ArrayBuffer, target: ArrayBuffer, options: CompareDocxOptions) => Promise<Result<CompareResult, CompareDocxError>>;
+
+// @public
+export class CompareDocxApplyError extends CompareDocxApplyError_base<{
+    message: string;
+    skipped: readonly FolioAIEditSkippedOperation[];
+}> {}
+
+// @public (undocumented)
+export type CompareDocxError = CompareDocxApplyError | CompareDocxOperationLimitError | CompareDocxParseError | CompareDocxRoundTripError | CompareDocxSerializeError | InvalidCompareDocxOptionsError;
+
+// @public
+export class CompareDocxOperationLimitError extends CompareDocxOperationLimitError_base<{
+    message: string;
+    limit: number;
+}> {}
+
+// @public
+export type CompareDocxOptions = {
+    author: string;
+    timestamp: string;
+};
+
+// @public (undocumented)
+export class CompareDocxParseError extends CompareDocxParseError_base<{
+    message: string;
+    side: "base" | "target";
+    cause: unknown;
+}> {}
+
+// @public
+export class CompareDocxRoundTripError extends CompareDocxRoundTripError_base<{
+    message: string;
+    story: FolioDocumentStoryHandle;
+    acceptedText: readonly string[];
+    targetText: readonly string[];
+}> {}
+
+// @public (undocumented)
+export class CompareDocxSerializeError extends CompareDocxSerializeError_base<{
+    message: string;
+    cause: unknown;
+}> {}
+
+// @public
+export type CompareFormatRange = {
+    startOffset: number;
+    endOffset: number;
+    formatting: FolioAIInlineFormatting;
+};
+
+// @public (undocumented)
+export type CompareResult = {
+    buffer: ArrayBuffer;
+    changes: readonly CompareChange[];
+    unsupported: readonly CompareUnsupportedPart[];
+};
+
+// @public
+export type CompareUnsupportedPart = {
+    reason: CompareUnsupportedReason;
+    baseStory: FolioDocumentStoryHandle | null;
+    targetStory: FolioDocumentStoryHandle | null;
+};
+
+// @public (undocumented)
+export type CompareUnsupportedReason = (typeof COMPARE_UNSUPPORTED_REASONS)[number];
 
 // @public
 export const consumeTemplateSlashQuery: (state: EditorState) => {
@@ -479,6 +606,7 @@ export type FolioAIBlock = {
     displayLabel?: string;
     styleId?: string;
     previewRuns?: FolioAIBlockPreviewRun[];
+    table?: FolioAIBlockTableLocation;
 };
 
 // @public (undocumented)
@@ -505,6 +633,14 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+};
+
+// @public
+export type FolioAIBlockTableLocation = {
+    tableIndex: number;
+    rowIndex: number;
+    cellIndex: number;
+    paragraphIndex: number;
 };
 
 // @public (undocumented)
@@ -855,6 +991,12 @@ export type FolioDocxCompatibilityHost = "browser" | "server" | "unknown";
 export type FolioDocxCompatibilityProfile = import__stll_docx_core_model.DocxConformanceClass;
 
 // @public
+export type FolioRevisionStamp = {
+    date: string;
+    idSeed: number;
+};
+
+// @public
 export function fromMarkdown(markdown: string): import__stll_docx_core_model.Document;
 
 // @public
@@ -926,6 +1068,13 @@ export const inspectDocxCompatibility: (doc: import__stll_docx_core_model.Docume
 export type InspectDocxCompatibilityOptions = Partial<DocxCompatibilityContext>;
 
 // @public (undocumented)
+export class InvalidCompareDocxOptionsError extends InvalidCompareDocxOptionsError_base<{
+    message: string;
+    option: "timestamp";
+    receivedValue: unknown;
+}> {}
+
+// @public (undocumented)
 export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumentOperationBatchError_base<{
     message: string;
     path: string;
@@ -963,6 +1112,9 @@ export type MarkdownResult = {
     images: Map<string, ImageRef>;
     warnings: string[];
 };
+
+// @public
+export const MAX_COMPARE_OPERATIONS = 10000;
 
 // @public
 export function mergeDocumentContent(target: import__stll_docx_core_model.Document, source: import__stll_docx_core_model.Document): import__stll_docx_core_model.Document;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -472,6 +472,7 @@ export type FolioAIBlock = {
     displayLabel?: string;
     styleId?: string;
     previewRuns?: FolioAIBlockPreviewRun[];
+    table?: FolioAIBlockTableLocation;
 };
 
 // @public (undocumented)
@@ -665,6 +666,7 @@ export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOpera
 export type FolioApplyOperationsOptions = {
     mode?: FolioAIEditApplyMode;
     snapshot?: FolioAIEditSnapshot;
+    revisionStamp?: FolioRevisionStamp;
 };
 
 // @public

--- a/packages/core/scripts/compare.ts
+++ b/packages/core/scripts/compare.ts
@@ -100,6 +100,42 @@ const describeChange = (change: CompareChange): string => {
 const describeUnsupported = ({ reason, baseStory, targetStory }: CompareUnsupportedPart): string =>
   `unsupported (${reason}): ${JSON.stringify(baseStory ?? targetStory)}`;
 
+const describeError = (value: unknown): string => {
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}`;
+  }
+  return typeof value === "string" ? value : JSON.stringify(value);
+};
+
+/** Guard against a chain that loops or is pathologically deep. */
+const MAX_CAUSE_DEPTH = 8;
+
+const readCause = (value: unknown): unknown =>
+  typeof value === "object" && value !== null && "cause" in value ? value.cause : undefined;
+
+/**
+ * The error and every cause behind it, outermost first.
+ *
+ * A parse failure says only that the document could not be parsed; which part
+ * refused it lives in the cause. Printing the tag alone left a failing file
+ * undiagnosable from the CLI.
+ */
+const causeChain = (error: unknown): string[] => {
+  const lines: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    if (lines.length >= MAX_CAUSE_DEPTH) {
+      lines.push("... further causes omitted");
+      break;
+    }
+    seen.add(current);
+    lines.push(describeError(current));
+    current = readCause(current);
+  }
+  return lines;
+};
+
 const args = parseArgs(process.argv.slice(2));
 if (!args) {
   console.error(USAGE);
@@ -113,6 +149,9 @@ const result = await compareDocx(readDocx(args.basePath), readDocx(args.targetPa
 
 if (result.isErr()) {
   console.error(`${result.error._tag}: ${result.error.message}`);
+  for (const [index, line] of causeChain(readCause(result.error)).entries()) {
+    console.error(`${"  ".repeat(index + 1)}caused by: ${line}`);
+  }
   process.exit(1);
 }
 

--- a/packages/core/scripts/compare.ts
+++ b/packages/core/scripts/compare.ts
@@ -1,0 +1,132 @@
+/**
+ * Compare two `.docx` files from a terminal.
+ *
+ *   bun run scripts/compare.ts <base.docx> <target.docx> <out.docx> [--json]
+ *
+ * Writes `out.docx` — the base carrying the tracked changes that turn it into
+ * the target — and prints the change list. `--json` prints it as JSON for a
+ * script to consume; without it the output is one line per change.
+ *
+ * `--author` and `--timestamp` pin what the generated revisions are stamped
+ * with. Both default to fixed values rather than the current user and clock, so
+ * running the script twice over the same pair produces the same file.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+import { compareDocx } from "../src/compare/compare";
+import type { CompareChange, CompareUnsupportedPart } from "../src/compare/types";
+
+const DEFAULT_AUTHOR = "folio compare";
+const DEFAULT_TIMESTAMP = "1970-01-01T00:00:00.000Z";
+
+const USAGE =
+  "usage: bun run scripts/compare.ts <base.docx> <target.docx> <out.docx> [--json] [--author <name>] [--timestamp <iso8601>]";
+
+type ParsedArgs = {
+  basePath: string;
+  targetPath: string;
+  outPath: string;
+  json: boolean;
+  author: string;
+  timestamp: string;
+};
+
+const parseArgs = (argv: readonly string[]): ParsedArgs | null => {
+  const positional: string[] = [];
+  let json = false;
+  let author = DEFAULT_AUTHOR;
+  let timestamp = DEFAULT_TIMESTAMP;
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--author" || arg === "--timestamp") {
+      const value = argv[++index];
+      if (value === undefined) {
+        return null;
+      }
+      if (arg === "--author") {
+        author = value;
+      } else {
+        timestamp = value;
+      }
+      continue;
+    }
+    if (arg === undefined || arg.startsWith("--")) {
+      return null;
+    }
+    positional.push(arg);
+  }
+
+  const [basePath, targetPath, outPath] = positional;
+  if (positional.length !== 3 || !basePath || !targetPath || !outPath) {
+    return null;
+  }
+  return { basePath, targetPath, outPath, json, author, timestamp };
+};
+
+const readDocx = (filePath: string): ArrayBuffer => {
+  const bytes = readFileSync(filePath);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+};
+
+const describeChange = (change: CompareChange): string => {
+  const where =
+    change.location.cell === undefined
+      ? "body"
+      : `table ${String(change.location.cell.tableIndex)} row ${String(change.location.cell.rowIndex)} cell ${String(change.location.cell.cellIndex)}`;
+  switch (change.kind) {
+    case "insert":
+      return `insert  [${where}] ${change.after}`;
+    case "delete":
+      return `delete  [${where}] ${change.before}`;
+    case "replace":
+      return `replace [${where}] ${change.before} -> ${change.after}`;
+    case "move":
+      return `move    [${where}] ${change.text}`;
+    case "format":
+      return `format  [${where}] ${String(change.ranges.length)} range(s) in ${change.text}`;
+    case "table-row-insert":
+      return `row +   [table ${String(change.tableIndex)} row ${String(change.rowIndex)}] ${change.cells.join(" | ")}`;
+    case "table-row-delete":
+      return `row -   [table ${String(change.tableIndex)} row ${String(change.rowIndex)}] ${change.cells.join(" | ")}`;
+  }
+};
+
+const describeUnsupported = ({ reason, baseStory, targetStory }: CompareUnsupportedPart): string =>
+  `unsupported (${reason}): ${JSON.stringify(baseStory ?? targetStory)}`;
+
+const args = parseArgs(process.argv.slice(2));
+if (!args) {
+  console.error(USAGE);
+  process.exit(2);
+}
+
+const result = await compareDocx(readDocx(args.basePath), readDocx(args.targetPath), {
+  author: args.author,
+  timestamp: args.timestamp,
+});
+
+if (result.isErr()) {
+  console.error(`${result.error._tag}: ${result.error.message}`);
+  process.exit(1);
+}
+
+const { buffer, changes, unsupported } = result.value;
+writeFileSync(args.outPath, new Uint8Array(buffer));
+
+if (args.json) {
+  console.log(JSON.stringify({ changes, unsupported }, null, 2));
+} else {
+  for (const change of changes) {
+    console.log(describeChange(change));
+  }
+  for (const part of unsupported) {
+    console.log(describeUnsupported(part));
+  }
+  console.log(`${String(changes.length)} change(s) written to ${args.outPath}`);
+}

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -72,6 +72,21 @@ export type FolioAIEditView = {
   dispatch: (transaction: Transaction) => void;
 };
 
+/**
+ * Fixed revision provenance, for callers whose output must be reproducible.
+ * Both halves of the stamp travel together because either one left to the
+ * ambient clock (`new Date()` for the date, a `Date.now()`-seeded cursor for
+ * the ids) makes the produced package differ between two runs over the same
+ * inputs. `idSeed` starts a contiguous range the batch allocates from, so it
+ * must sit above every revision id the target document already carries.
+ */
+export type FolioRevisionStamp = {
+  /** ISO-8601 date stamped on every `w:ins` / `w:del` this batch produces. */
+  date: string;
+  /** First revision id the batch may allocate. */
+  idSeed: number;
+};
+
 type ApplyFolioAIEditOperationsOptions = {
   view: FolioAIEditView;
   snapshot: FolioAIEditSnapshot;
@@ -81,6 +96,8 @@ type ApplyFolioAIEditOperationsOptions = {
   /** Optional author initials (w:initials) stamped alongside the author. */
   initials?: string;
   createCommentId?: (text: string) => number;
+  /** Omit to stamp revisions from the wall clock and the shared id cursor. */
+  revisionStamp?: FolioRevisionStamp;
 };
 
 type ApplyFolioAIEditOperationsInternalOptions = ApplyFolioAIEditOperationsOptions & {
@@ -635,6 +652,7 @@ const applyFolioAIEditOperationsInternal = ({
   author = "AI",
   initials,
   createCommentId,
+  revisionStamp,
   revisionIdSeed,
 }: ApplyFolioAIEditOperationsInternalOptions): FolioAIEditApplyResult => {
   const applied: FolioAIEditAppliedOperation[] = [];
@@ -747,8 +765,9 @@ const applyFolioAIEditOperationsInternal = ({
     (total, item) => total + estimateRevisionIdReservation(item),
     0,
   );
-  let revisionSeed = revisionIdSeed ?? nextRevisionSeed(revisionIdReservation);
-  const date = new Date().toISOString();
+  let revisionSeed =
+    revisionIdSeed ?? revisionStamp?.idSeed ?? nextRevisionSeed(revisionIdReservation);
+  const date = revisionStamp?.date ?? new Date().toISOString();
   const insertedColumnCounts = new Map<string, number>();
 
   // Sort right-to-left so each tr.insert / tr.delete leaves earlier

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -4,6 +4,7 @@ import { TableMap } from "prosemirror-tables";
 
 import { expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
 import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
+import { requestDeterministicParaIds } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import type { RunPropertyChange } from "../types/document";
 import { stripBlockIdentityAttrs } from "./block-identity";
@@ -1454,6 +1455,13 @@ const applyFolioAIEditOperationsInternal = ({
   }
 
   if (tr.docChanged) {
+    if (revisionStamp) {
+      // Paragraphs this batch creates get their `w14:paraId` from the
+      // allocator plugin, which is random by default. A stamped batch has
+      // promised its caller a reproducible package, so the ids must be
+      // derived from the stamp too.
+      requestDeterministicParaIds(tr, `${revisionStamp.date}:${String(revisionStamp.idSeed)}`);
+    }
     view.dispatch(tr);
   }
 

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -67,6 +67,7 @@ import {
   type FolioDocumentOperationUndoHandle,
   type FolioDocumentOperationUndoResult,
 } from "../document-operations";
+import type { FolioRevisionStamp } from "./apply";
 import { buildAnnotatedBlockText } from "./clean-text";
 import {
   getCommentAnchorsFromDoc,
@@ -203,6 +204,8 @@ export type FolioApplyOperationsOptions = {
    * `snapshot()` -> build ops -> `applyOperations()` on the same reviewer.
    */
   snapshot?: FolioAIEditSnapshot;
+  /** Omit to stamp revisions from the wall clock and the shared id cursor. */
+  revisionStamp?: FolioRevisionStamp;
 };
 
 /** Options for {@link FolioDocxReviewer.applyDocumentOperations}. */
@@ -287,6 +290,8 @@ export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOpera
   batch: FolioDocumentOperationBatch;
 };
 
+export type { FolioRevisionStamp };
+
 type FolioHeaderFooterStoryHandle = Extract<
   FolioEditableDocumentStoryHandle,
   { type: "header" | "footer" }
@@ -315,6 +320,7 @@ type ApplyDocumentOperationsInternalOptions = {
   story: FolioEditableDocumentStoryHandle;
   batch: FolioDocumentOperationBatch;
   snapshot?: FolioAIEditSnapshot;
+  revisionStamp?: FolioRevisionStamp;
   createUndoEntry: boolean;
 };
 
@@ -656,6 +662,7 @@ export class FolioDocxReviewer {
         mode: options.mode ?? "tracked-changes",
       },
       ...(options.snapshot !== undefined && { snapshot: options.snapshot }),
+      ...(options.revisionStamp !== undefined && { revisionStamp: options.revisionStamp }),
       createUndoEntry: false,
     });
     return { applied, skipped };
@@ -675,6 +682,7 @@ export class FolioDocxReviewer {
       story: MAIN_STORY,
       batch,
       ...(options.snapshot !== undefined && { snapshot: options.snapshot }),
+      ...(options.revisionStamp !== undefined && { revisionStamp: options.revisionStamp }),
       createUndoEntry: true,
     });
   }
@@ -684,11 +692,13 @@ export class FolioDocxReviewer {
     story,
     batch,
     snapshot,
+    revisionStamp,
   }: FolioApplyDocumentOperationsToStoryOptions): FolioDocumentOperationResult {
     return this.applyDocumentOperationsInternal({
       story,
       batch,
       ...(snapshot !== undefined && { snapshot }),
+      ...(revisionStamp !== undefined && { revisionStamp }),
       createUndoEntry: true,
     });
   }
@@ -697,6 +707,7 @@ export class FolioDocxReviewer {
     story,
     batch,
     snapshot,
+    revisionStamp,
     createUndoEntry,
   }: ApplyDocumentOperationsInternalOptions): FolioDocumentOperationResult {
     const beforeState = this.requireEditableStoryState(story);
@@ -714,6 +725,7 @@ export class FolioDocxReviewer {
       batch,
       story: story.type === "main" ? "main" : story,
       author: this.author,
+      ...(revisionStamp !== undefined && { revisionStamp }),
       createCommentId: (text) => {
         const comment = createReviewerComment(this.nextCommentId(), text, this.author);
         this.createdComments.push(comment);

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -1,8 +1,4 @@
-export {
-  applyFolioAIEditOperations,
-  type FolioAIEditView,
-  type FolioRevisionStamp,
-} from "./apply";
+export { applyFolioAIEditOperations, type FolioAIEditView, type FolioRevisionStamp } from "./apply";
 export {
   clampRangeToDocSize,
   resolveFolioAIBlockRange,

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -1,4 +1,8 @@
-export { applyFolioAIEditOperations, type FolioAIEditView } from "./apply";
+export {
+  applyFolioAIEditOperations,
+  type FolioAIEditView,
+  type FolioRevisionStamp,
+} from "./apply";
 export {
   clampRangeToDocSize,
   resolveFolioAIBlockRange,
@@ -46,6 +50,7 @@ export type {
   FolioAIBlockAnchor,
   FolioAIBlockKind,
   FolioAIBlockPreviewRun,
+  FolioAIBlockTableLocation,
   FolioAIComment,
   FolioAIEditAppliedOperation,
   FolioAIEditApplyMode,

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -7,6 +7,7 @@ import type {
   FolioAIBlockAnchor,
   FolioAIBlockKind,
   FolioAIBlockPreviewRun,
+  FolioAIBlockTableLocation,
   FolioAIEditSnapshot,
   FolioAITextRangeHandle,
 } from "./types";
@@ -75,6 +76,46 @@ const isInHiddenTableRow = (doc: PMNode, pos: number): boolean => {
   return false;
 };
 
+const TABLE_ROLE_TABLE = "table";
+const TABLE_ROLE_ROW = "row";
+
+/**
+ * Locate `pos` inside its innermost enclosing table, or `undefined` when it
+ * sits outside every table.
+ */
+const getTableLocation = (
+  doc: PMNode,
+  pos: number,
+  tableIndexByStart: ReadonlyMap<number, number>,
+): FolioAIBlockTableLocation | undefined => {
+  const $pos = doc.resolve(pos);
+  for (let cellDepth = $pos.depth; cellDepth > 1; cellDepth--) {
+    const role = $pos.node(cellDepth).type.spec["tableRole"];
+    if (role !== "cell" && role !== "header_cell") {
+      continue;
+    }
+    const rowDepth = cellDepth - 1;
+    const tableDepth = rowDepth - 1;
+    if (
+      $pos.node(rowDepth).type.spec["tableRole"] !== TABLE_ROLE_ROW ||
+      $pos.node(tableDepth).type.spec["tableRole"] !== TABLE_ROLE_TABLE
+    ) {
+      return undefined;
+    }
+    const tableIndex = tableIndexByStart.get($pos.before(tableDepth));
+    if (tableIndex === undefined) {
+      return undefined;
+    }
+    return {
+      tableIndex,
+      rowIndex: $pos.index(tableDepth),
+      cellIndex: $pos.index(rowDepth),
+      paragraphIndex: $pos.index(cellDepth),
+    };
+  }
+  return undefined;
+};
+
 export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   const draftBlocks: {
     block: FolioAIBlock;
@@ -82,6 +123,10 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   }[] = [];
   const hashCounts = new Map<string, number>();
   const usedBlockIds = new Set<string>();
+  // Table start position -> document-order index, filled by the walk below.
+  // `descendants` reaches a table before any textblock inside it, so a nested
+  // block's lookup always finds its table already numbered.
+  const tableIndexByStart = new Map<number, number>();
   const emptyAnchorState: {
     candidate: { from: number; to: number; paraId: string | null } | null;
     textblockCount: number;
@@ -90,6 +135,9 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   let blockIndex = 0;
   doc.descendants((node, pos, parent) => {
     if (!node.isTextblock) {
+      if (node.type.spec["tableRole"] === TABLE_ROLE_TABLE) {
+        tableIndexByStart.set(pos, tableIndexByStart.size);
+      }
       return true;
     }
 
@@ -151,6 +199,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     const displayLabel = getDisplayLabel(node);
     const styleId = getStyleId(node);
     const previewRuns = getPreviewRuns(node);
+    const table = getTableLocation(doc, pos, tableIndexByStart);
 
     draftBlocks.push({
       block: {
@@ -161,6 +210,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
         ...(displayLabel !== undefined && { displayLabel }),
         ...(styleId !== undefined && { styleId }),
         ...(previewRuns !== undefined && { previewRuns }),
+        ...(table !== undefined && { table }),
       },
       anchor: {
         id,

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -11,6 +11,21 @@ export type FolioAIBlockPreviewRun = {
   color?: string;
 };
 
+/**
+ * Where a block sits inside its innermost enclosing table. Every index is
+ * zero-based: `tableIndex` counts tables in document order across the story,
+ * `rowIndex` is the row's index in that table, `cellIndex` is the cell's
+ * PHYSICAL index within the row (a merged cell occupies one slot, so this is
+ * not a grid column), and `paragraphIndex` orders the block among the cell's
+ * own blocks. Absent on a block that is not inside a table.
+ */
+export type FolioAIBlockTableLocation = {
+  tableIndex: number;
+  rowIndex: number;
+  cellIndex: number;
+  paragraphIndex: number;
+};
+
 export type FolioAIBlock = {
   id: string;
   kind: FolioAIBlockKind;
@@ -20,6 +35,7 @@ export type FolioAIBlock = {
   displayLabel?: string;
   styleId?: string;
   previewRuns?: FolioAIBlockPreviewRun[];
+  table?: FolioAIBlockTableLocation;
 };
 
 export type FolioAIEditSnapshot = {

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -1,0 +1,96 @@
+# compare
+
+`compareDocx(base, target, { author, timestamp })` returns the base `.docx`
+carrying the tracked changes that turn it into the target, plus a JSON change
+list describing them.
+
+```ts
+const result = await compareDocx(base, target, {
+  author: "folio compare",
+  timestamp: "2024-03-01T00:00:00.000Z",
+});
+if (result.isOk()) {
+  const { buffer, changes, unsupported } = result.value;
+}
+```
+
+The buffer opens as ordinary revisions in any OOXML consumer. `changes` is a
+discriminated union on `kind` (`insert`, `delete`, `replace`, `move`, `format`,
+`table-row-insert`, `table-row-delete`), for an agent that wants the summary
+rather than the document.
+
+## Determinism contract
+
+The call is a pure function of its three arguments. Nothing reads a clock or a
+random source:
+
+- revision dates come from `options.timestamp`, which is required rather than
+  defaulted so a caller cannot get an irreproducible package by omission;
+- revision ids start one past the highest id the base package already carries;
+- `w14:paraId`s for paragraphs the comparison creates are derived from the
+  stamp instead of `Math.random()`;
+- ZIP entry dates are restamped from the same timestamp, because JSZip
+  otherwise writes the current time into every part it rewrites.
+
+Two runs over the same inputs therefore produce byte-identical buffers and
+deeply equal change lists. `compare.property.test.ts` holds this as a property,
+along with the round trip (accept-all yields the target, reject-all yields the
+base), self-comparison, a churn bound, and the reporting of formatting-only and
+move-only edits.
+
+## How the alignment works
+
+Aligning every paragraph in one pass cannot see structure: it pairs on text and
+document order, so it will put a cell of one row opposite a cell of the next, or
+a paragraph inside a table opposite one outside it. Rewriting such a pair in
+place leaves the target's text in the wrong container. So the story is aligned
+in three nested passes, each over things that can stand in for one another:
+
+1. **Segments** — maximal runs of body text and of one table each, normalized to
+   alternate, and paired by position.
+2. **Rows** inside a paired table, by exact row text and then positionally, so a
+   whole-row change stays whole and becomes `insertTableRow` / `deleteTableRow`.
+3. **Cells** inside a paired row, by physical cell index.
+
+Changed paragraphs go through `diffWordSegments` at apply time, so a redline
+marks only the divergent words. Formatting-only differences are emitted as
+`formatRange` operations and reported as `format`, never as a deletion and
+reinsertion of identical text.
+
+`compareDocx` checks its own work before returning: accepting the generated
+revisions must reproduce the target, table cell coordinates included. A
+difference the operation vocabulary cannot express fails with
+`CompareDocxRoundTripError` rather than returning a redline that reads
+plausibly and is wrong.
+
+## Limitations
+
+- **Main story only.** Headers, footers, footnotes, and endnotes are reported in
+  `unsupported`, not compared. So are parts present on one side only.
+- **Moves are reported, not represented.** The document carries a deletion at
+  the source and an insertion at the destination; the change list keeps the
+  relocation visible as `kind: "move"`. A relocated block needs at least three
+  words to be recognized as a move, so boilerplate one-liners do not pair.
+- **Tables cannot be created or destroyed.** The operation vocabulary has no
+  "add a table", so a pair whose table count differs fails the round-trip check.
+- **Empty cells are invisible.** A cell with no text carries no block, so a row
+  whose cells are all empty is not seen as a row at all.
+- **Column operations are out of scope.** A column added or removed reads as
+  cell-level changes.
+- **Row pairing degrades when a table's row count changes.** Rows match on exact
+  text first and positionally after that, so a row deletion combined with cell
+  edits can report per cell instead of as one row change. The result still
+  accepts back to the target; it is just more granular than the edit was.
+- **Numbering is not compared.** List renumbering that follows from an insertion
+  or deletion is a property of the numbering definitions, not of block text, and
+  no change is reported for it.
+
+## Files
+
+- `compare.ts` — the entry point, story pairing, and the round-trip self-check.
+- `plan.ts` — alignment and operation derivation. Pure.
+- `formatting.ts` — the inline-formatting diff, shared with the redline
+  generator.
+- `reproducible-package.ts` — ZIP entry-date restamping.
+- `scenario.ts` — the edit-script DSL the property tests build targets with.
+- `../../scripts/compare.ts` — a manual runner for humans.

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -162,17 +162,15 @@ const formatStepArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScript
   if (indexes.length === 0) {
     return null;
   }
-  return fc
-    .constantFrom(...indexes)
-    .chain((blockIndex) =>
-      fc.record({
-        type: fc.constant("formatRange" as const),
-        blockIndex: fc.constant(blockIndex),
-        startOffset: fc.constant(0),
-        endOffset: fc.nat({ max: (blocks[blockIndex]?.text.length ?? 1) - 1 }).map((n) => n + 1),
-        formatting: formattingArb,
-      }),
-    );
+  return fc.constantFrom(...indexes).chain((blockIndex) =>
+    fc.record({
+      type: fc.constant("formatRange" as const),
+      blockIndex: fc.constant(blockIndex),
+      startOffset: fc.constant(0),
+      endOffset: fc.nat({ max: (blocks[blockIndex]?.text.length ?? 1) - 1 }).map((n) => n + 1),
+      formatting: formattingArb,
+    }),
+  );
 };
 
 const editStepArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScriptStep> => {
@@ -294,18 +292,18 @@ const touchedBlockBudget = (
       return tableIndex === undefined ? [] : [tableIndex];
     }),
   );
-  const tableBudget = [...rowCountChanged].reduce(
-    (total, tableIndex) =>
-      total + blocks.filter((block) => block.table?.tableIndex === tableIndex).length,
-    0,
-  );
-  return applied.reduce((total, step) => {
+  let budget = 0;
+  for (const tableIndex of rowCountChanged) {
+    budget += blocks.filter((block) => block.table?.tableIndex === tableIndex).length;
+  }
+  for (const step of applied) {
     const tableIndex = blocks[step.blockIndex]?.table?.tableIndex;
     if (tableIndex !== undefined && rowCountChanged.has(tableIndex)) {
-      return total;
+      continue;
     }
-    return total + (step.type === "moveParagraph" ? 2 : 1);
-  }, tableBudget);
+    budget += step.type === "moveParagraph" ? 2 : 1;
+  }
+  return budget;
 };
 
 describe("compareDocx", () => {

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Properties of {@link compareDocx} over scripted edits of real fixtures.
+ *
+ * Every case is ground truth by construction: an {@link EditScript} is applied
+ * directly to a base document to build the target, so the difference between
+ * the two is known before the comparison runs. The properties then pin what the
+ * comparison must recover from it.
+ *
+ * Fixture provenance and licensing: see
+ * `../docx/__tests__/__fixtures__/corpus/PROVENANCE.md`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { propertyConfig, propertyTestTimeout } from "../../../../test/property-testing";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import type { FolioAIBlock } from "../ai-edits/types";
+import { compareDocx } from "./compare";
+import { applyEditScript, type EditScript, type EditScriptStep } from "./scenario";
+import type { CompareChange, CompareResult } from "./types";
+
+const FIXTURES_DIR = path.join(import.meta.dir, "../docx/__tests__/__fixtures__/corpus");
+
+const readFixture = (filename: string): ArrayBuffer => {
+  const bytes = readFileSync(path.join(FIXTURES_DIR, filename));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+};
+
+/**
+ * A synthetic base built from the empty-document fixture, so the corpus is not
+ * the only shape under test: a plain run of paragraphs with no styles, no
+ * tables, and no Word-authored paraIds.
+ */
+const buildSyntheticBase = async (): Promise<ArrayBuffer> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(readFixture("upstream-empty.docx"));
+  const anchor = reviewer.snapshot();
+  const anchorId = anchor.blocks.at(0)?.id ?? anchor.emptyDocumentAnchorId;
+  if (anchorId === undefined) {
+    throw new Error("The empty fixture offers no anchor to build a synthetic base on.");
+  }
+  reviewer.applyOperations(
+    Array.from({ length: 6 }, (_unused, index) => ({
+      id: `synthetic-${String(index)}`,
+      type: "insertAfterBlock" as const,
+      blockId: anchorId,
+      text: `Synthetic clause ${String(index)} sets out the agreed position.`,
+    })),
+    { mode: "direct" },
+  );
+  return await reviewer.toBuffer();
+};
+
+const FIXTURE_FILES = [
+  "upstream-styled-content.docx",
+  "upstream-with-tables.docx",
+  "upstream-complex-styles.docx",
+] as const;
+
+const SYNTHETIC_BASE = await buildSyntheticBase();
+
+const BASE_DOCUMENTS: readonly { name: string; buffer: ArrayBuffer }[] = [
+  ...FIXTURE_FILES.map((name) => ({ name, buffer: readFixture(name) })),
+  { name: "synthetic", buffer: SYNTHETIC_BASE },
+];
+
+const OPTIONS = { author: "compare", timestamp: "2024-03-01T00:00:00.000Z" } as const;
+
+const blocksOf = async (buffer: ArrayBuffer): Promise<FolioAIBlock[]> =>
+  (await FolioDocxReviewer.fromBuffer(buffer)).getContent();
+
+/** Parsed once at module scope: `describe` bodies run synchronously. */
+const BASE_CASES = await Promise.all(
+  BASE_DOCUMENTS.map(async ({ name, buffer }) => ({
+    name,
+    buffer,
+    blocks: await blocksOf(buffer),
+  })),
+);
+
+/**
+ * The text-and-structure projection the round-trip properties compare on:
+ * every block's text plus where it sits in a table. Two documents that agree
+ * on it hold the same content in the same table shape; block ids and revision
+ * bookkeeping are deliberately excluded, since a redline necessarily rewrites
+ * those.
+ */
+type BlockProjection = { text: string; table: FolioAIBlock["table"] | null };
+
+const projectView = async (
+  buffer: ArrayBuffer,
+  view: "original" | "final",
+): Promise<BlockProjection[]> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(buffer);
+  const story = reviewer.readReviewedStory({ view });
+  return (story?.snapshot.blocks ?? []).map((block) => ({
+    text: block.text,
+    table: block.table ?? null,
+  }));
+};
+
+const compareOrThrow = async (base: ArrayBuffer, target: ArrayBuffer): Promise<CompareResult> => {
+  const result = await compareDocx(base, target, OPTIONS);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+/** Every block index of `blocks`, so a generated step always addresses a real block. */
+const blockIndexArb = (blocks: readonly FolioAIBlock[]) => fc.nat({ max: blocks.length - 1 });
+
+const wordArb = fc.stringMatching(/^[A-Za-z]{3,9}$/u);
+const sentenceArb = fc
+  .array(wordArb, { minLength: 3, maxLength: 6 })
+  .map((words) => words.join(" "));
+
+/** A word already present in some block, so `replaceWords` resolves. */
+const findableWordArb = (blocks: readonly FolioAIBlock[]) => {
+  const candidates: { blockIndex: number; find: string }[] = [];
+  blocks.forEach((block, blockIndex) => {
+    const word = /[A-Za-z]{3,}/u.exec(block.text);
+    if (word) {
+      candidates.push({ blockIndex, find: word[0] });
+    }
+  });
+  return candidates.length === 0 ? null : fc.constantFrom(...candidates);
+};
+
+const tableBlockIndexArb = (blocks: readonly FolioAIBlock[]) => {
+  const indexes = blocks.flatMap((block, index) => (block.table ? [index] : []));
+  return indexes.length === 0 ? null : fc.constantFrom(...indexes);
+};
+
+/**
+ * Blocks in the same table row as `blocks[index]`. An inserted row is
+ * generated with exactly this many cell texts: a cell left empty carries no
+ * block at all, so a short row would erase the row boundary the comparison
+ * reads structure from, and the script would no longer describe what changed.
+ */
+const rowBlockCount = (blocks: readonly FolioAIBlock[], index: number): number => {
+  const table = blocks[index]?.table;
+  if (!table) {
+    return 1;
+  }
+  return blocks.filter(
+    (block) =>
+      block.table?.tableIndex === table.tableIndex && block.table.rowIndex === table.rowIndex,
+  ).length;
+};
+
+const formattingArb = fc
+  .record({ bold: fc.boolean(), italic: fc.boolean(), underline: fc.boolean() })
+  .filter(({ bold, italic, underline }) => bold || italic || underline);
+
+/** Steps that only change formatting, for the formatting-only property. */
+const formatStepArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScriptStep> | null => {
+  const indexes = blocks.flatMap((block, index) => (block.text.length >= 4 ? [index] : []));
+  if (indexes.length === 0) {
+    return null;
+  }
+  return fc
+    .constantFrom(...indexes)
+    .chain((blockIndex) =>
+      fc.record({
+        type: fc.constant("formatRange" as const),
+        blockIndex: fc.constant(blockIndex),
+        startOffset: fc.constant(0),
+        endOffset: fc.nat({ max: (blocks[blockIndex]?.text.length ?? 1) - 1 }).map((n) => n + 1),
+        formatting: formattingArb,
+      }),
+    );
+};
+
+const editStepArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScriptStep> => {
+  const steps: fc.Arbitrary<EditScriptStep>[] = [
+    fc.record({
+      type: fc.constant("insertParagraphAfter" as const),
+      blockIndex: blockIndexArb(blocks),
+      text: sentenceArb,
+    }),
+    fc.record({
+      type: fc.constant("deleteParagraph" as const),
+      blockIndex: blockIndexArb(blocks),
+    }),
+    fc.record({
+      type: fc.constant("moveParagraph" as const),
+      blockIndex: blockIndexArb(blocks),
+      beforeBlockIndex: blockIndexArb(blocks),
+    }),
+  ];
+
+  const findable = findableWordArb(blocks);
+  if (findable) {
+    steps.push(
+      findable.chain(({ blockIndex, find }) =>
+        fc.record({
+          type: fc.constant("replaceWords" as const),
+          blockIndex: fc.constant(blockIndex),
+          find: fc.constant(find),
+          replace: wordArb,
+        }),
+      ),
+    );
+  }
+
+  const formatStep = formatStepArb(blocks);
+  if (formatStep) {
+    steps.push(formatStep);
+  }
+
+  const tableIndex = tableBlockIndexArb(blocks);
+  if (tableIndex) {
+    steps.push(
+      tableIndex.chain((blockIndex) =>
+        fc.record({
+          type: fc.constant("insertTableRow" as const),
+          blockIndex: fc.constant(blockIndex),
+          cellTexts: fc.array(wordArb, {
+            minLength: rowBlockCount(blocks, blockIndex),
+            maxLength: rowBlockCount(blocks, blockIndex),
+          }),
+        }),
+      ),
+      fc.record({ type: fc.constant("deleteTableRow" as const), blockIndex: tableIndex }),
+      fc.record({
+        type: fc.constant("editTableCell" as const),
+        blockIndex: tableIndex,
+        text: sentenceArb,
+      }),
+    );
+  }
+
+  return fc.oneof(...steps);
+};
+
+/**
+ * Scripts whose steps address distinct blocks. Two edits to one block would
+ * coalesce into a single reported change, which property 4 counts against the
+ * script; keeping targets distinct lets it compare like with like.
+ */
+const editScriptArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScript> =>
+  fc
+    .array(editStepArb(blocks), { minLength: 1, maxLength: 4 })
+    .map((steps) => distinctByBlock(steps));
+
+const distinctByBlock = (steps: readonly EditScriptStep[]): EditScriptStep[] => {
+  const seen = new Set<number>();
+  const distinct: EditScriptStep[] = [];
+  for (const step of steps) {
+    const touched =
+      step.type === "moveParagraph" ? [step.blockIndex, step.beforeBlockIndex] : [step.blockIndex];
+    if (touched.some((index) => seen.has(index))) {
+      continue;
+    }
+    for (const index of touched) {
+      seen.add(index);
+    }
+    distinct.push(step);
+  }
+  return distinct;
+};
+
+const kindsOf = (changes: readonly CompareChange[]): string[] => changes.map(({ kind }) => kind);
+
+/**
+ * Changes one script may legitimately produce.
+ *
+ * A paragraph step touches one block. A relocation touches two, and is
+ * reported as two when the move pass declines to pair it (its text is below
+ * the word floor, or it landed where the alignment can still walk forward).
+ *
+ * A table whose row COUNT changed is budgeted at its whole size. Rows pair on
+ * exact text first and positionally after that, so once the counts differ the
+ * surviving rows can line up one row off and every cell in the table reports as
+ * changed. The result still accepts back to the target — that is a separate
+ * property — but it is more granular than the script was. Bounding it at one
+ * table keeps the real guarantee: the comparison never invents work beyond the
+ * content the script disturbed.
+ */
+const touchedBlockBudget = (
+  applied: readonly EditScriptStep[],
+  blocks: readonly FolioAIBlock[],
+): number => {
+  const rowCountChanged = new Set(
+    applied.flatMap((step) => {
+      if (step.type !== "insertTableRow" && step.type !== "deleteTableRow") {
+        return [];
+      }
+      const tableIndex = blocks[step.blockIndex]?.table?.tableIndex;
+      return tableIndex === undefined ? [] : [tableIndex];
+    }),
+  );
+  const tableBudget = [...rowCountChanged].reduce(
+    (total, tableIndex) =>
+      total + blocks.filter((block) => block.table?.tableIndex === tableIndex).length,
+    0,
+  );
+  return applied.reduce((total, step) => {
+    const tableIndex = blocks[step.blockIndex]?.table?.tableIndex;
+    if (tableIndex !== undefined && rowCountChanged.has(tableIndex)) {
+      return total;
+    }
+    return total + (step.type === "moveParagraph" ? 2 : 1);
+  }, tableBudget);
+};
+
+describe("compareDocx", () => {
+  test("base documents are present", () => {
+    expect(BASE_DOCUMENTS.length).toBeGreaterThan(1);
+  });
+
+  test.each(BASE_CASES)(
+    "comparing a document with itself reports nothing and changes nothing ($name)",
+    async ({ buffer: base }) => {
+      const { changes, buffer } = await compareOrThrow(base, base);
+      expect(changes).toEqual([]);
+      const [original, final, expected] = await Promise.all([
+        projectView(buffer, "original"),
+        projectView(buffer, "final"),
+        projectView(base, "final"),
+      ]);
+      expect(original).toEqual(expected);
+      expect(final).toEqual(expected);
+    },
+  );
+
+  for (const { name, buffer: base, blocks: baseBlocks } of BASE_CASES) {
+    test(
+      `accepting every change yields the target and rejecting yields the base (${name})`,
+      async () => {
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const target = scripted.value.buffer;
+            const { buffer } = await compareOrThrow(base, target);
+            const [accepted, rejected, targetProjection, baseProjection] = await Promise.all([
+              projectView(buffer, "final"),
+              projectView(buffer, "original"),
+              projectView(target, "final"),
+              projectView(base, "final"),
+            ]);
+            expect(accepted).toEqual(targetProjection);
+            expect(rejected).toEqual(baseProjection);
+          }),
+          propertyConfig({ numRuns: 12 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
+
+    test(
+      `two runs produce byte-identical buffers and equal change lists (${name})`,
+      async () => {
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const target = scripted.value.buffer;
+            // Sequential on purpose. The contract is that the same inputs give
+            // the same output, not that two comparisons may share one realm:
+            // the editor plugins the reviewer mounts are process singletons.
+            const first = await compareOrThrow(base, target);
+            const second = await compareOrThrow(base, target);
+            expect(Buffer.from(first.buffer).equals(Buffer.from(second.buffer))).toBe(true);
+            expect(first.changes).toEqual(second.changes);
+          }),
+          propertyConfig({ numRuns: 8 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
+
+    test(
+      `the change count never exceeds the blocks the script touched (${name})`,
+      async () => {
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const { changes } = await compareOrThrow(base, scripted.value.buffer);
+            expect(changes.length).toBeLessThanOrEqual(
+              touchedBlockBudget(scripted.value.applied, baseBlocks),
+            );
+          }),
+          propertyConfig({ numRuns: 12 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
+
+    const formatOnly = formatStepArb(baseBlocks);
+    if (formatOnly) {
+      test(
+        `a formatting-only script produces only format changes (${name})`,
+        async () => {
+          await fc.assert(
+            fc.asyncProperty(
+              fc.array(formatOnly, { minLength: 1, maxLength: 3 }).map(distinctByBlock),
+              async (script) => {
+                const scripted = await applyEditScript(base, script);
+                if (scripted.isErr()) {
+                  throw scripted.error;
+                }
+                if (scripted.value.applied.length === 0) {
+                  return;
+                }
+                const { changes } = await compareOrThrow(base, scripted.value.buffer);
+                expect(new Set(kindsOf(changes))).toEqual(
+                  changes.length === 0 ? new Set() : new Set(["format"]),
+                );
+              },
+            ),
+            propertyConfig({ numRuns: 10 }),
+          );
+        },
+        propertyTestTimeout(120_000),
+      );
+    }
+  }
+
+  test(
+    "a move-only script reports the relocation as a move",
+    async () => {
+      const base = SYNTHETIC_BASE;
+      const baseBlocks = BASE_CASES.at(-1)?.blocks ?? [];
+      await fc.assert(
+        fc.asyncProperty(
+          fc
+            .tuple(blockIndexArb(baseBlocks), blockIndexArb(baseBlocks))
+            .filter(([from, to]) => Math.abs(from - to) > 1),
+          async ([blockIndex, beforeBlockIndex]) => {
+            const scripted = await applyEditScript(base, [
+              { type: "moveParagraph", blockIndex, beforeBlockIndex },
+            ]);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            if (scripted.value.applied.length === 0) {
+              return;
+            }
+            const { changes } = await compareOrThrow(base, scripted.value.buffer);
+            // The alignment may absorb a move whose text still lands in an
+            // order the LCS can walk forward; what it must never do is report
+            // the relocation as unrelated churn.
+            expect(kindsOf(changes).every((kind) => kind === "move")).toBe(true);
+          },
+        ),
+        propertyConfig({ numRuns: 15 }),
+      );
+    },
+    propertyTestTimeout(120_000),
+  );
+});

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -30,11 +30,14 @@ import {
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
 import { pairFolioDocumentStories } from "../document-stories";
 import { planStoryCompare } from "./plan";
+import { withFixedPackageDates } from "./reproducible-package";
 import {
   CompareDocxApplyError,
   CompareDocxOperationLimitError,
   CompareDocxParseError,
+  CompareDocxRoundTripError,
   CompareDocxSerializeError,
+  InvalidCompareDocxOptionsError,
   type CompareChange,
   type CompareDocxError,
   type CompareDocxOptions,
@@ -82,6 +85,24 @@ const revisionIdSeedFor = (reviewer: FolioDocxReviewer): number => {
 const isMainStory = (story: FolioDocumentStoryHandle): boolean => story.type === "main";
 
 /**
+ * One story's text-and-structure projection: every block's text tagged with
+ * the table cell it sits in. The tag is what makes the self-check below see a
+ * paragraph that landed beside a table instead of inside it.
+ */
+const projectStory = (
+  reviewer: FolioDocxReviewer,
+  story: FolioDocumentStoryHandle,
+): string[] => {
+  const blocks = reviewer.readReviewedStory({ story, view: "final" })?.snapshot.blocks ?? [];
+  return blocks.map(({ text, table }) => {
+    const container = table
+      ? `t${String(table.tableIndex)}r${String(table.rowIndex)}c${String(table.cellIndex)}p${String(table.paragraphIndex)}`
+      : "body";
+    return `${container}|${text}`;
+  });
+};
+
+/**
  * Compare `base` against `target` and return `base` carrying the tracked
  * changes that turn it into `target`, alongside the change list describing
  * them.
@@ -91,6 +112,17 @@ export const compareDocx = async (
   target: ArrayBuffer,
   options: CompareDocxOptions,
 ): Promise<Result<CompareResult, CompareDocxError>> => {
+  const packageDate = new Date(options.timestamp);
+  if (Number.isNaN(packageDate.getTime())) {
+    return Result.err(
+      new InvalidCompareDocxOptionsError({
+        message: "timestamp must be a date the package can be stamped with.",
+        option: "timestamp",
+        receivedValue: options.timestamp,
+      }),
+    );
+  }
+
   const baseParse = await parseSide(base, "base", options.author);
   if (baseParse.isErr()) {
     return Result.err(baseParse.error);
@@ -171,10 +203,27 @@ export const compareDocx = async (
         }),
       );
     }
+
+    // Self-check rather than trust: accepting the story's generated revisions
+    // must reproduce the target, structure included. A difference the
+    // operation vocabulary cannot express would otherwise leave a redline that
+    // reads plausibly and is wrong.
+    const accepted = projectStory(reviewer, baseStory);
+    const expected = projectStory(targetReviewer, targetStory);
+    if (accepted.join(" ") !== expected.join(" ")) {
+      return Result.err(
+        new CompareDocxRoundTripError({
+          message: "Accepting the generated tracked changes does not reproduce the target.",
+          story: baseStory,
+          acceptedText: accepted,
+          targetText: expected,
+        }),
+      );
+    }
   }
 
   const serialized = await Result.tryPromise({
-    try: async () => await reviewer.toBuffer(),
+    try: async () => await withFixedPackageDates(await reviewer.toBuffer(), packageDate),
     catch: (cause) =>
       new CompareDocxSerializeError({
         message: "The compared document could not be serialized.",

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -89,10 +89,7 @@ const isMainStory = (story: FolioDocumentStoryHandle): boolean => story.type ===
  * the table cell it sits in. The tag is what makes the self-check below see a
  * paragraph that landed beside a table instead of inside it.
  */
-const projectStory = (
-  reviewer: FolioDocxReviewer,
-  story: FolioDocumentStoryHandle,
-): string[] => {
+const projectStory = (reviewer: FolioDocxReviewer, story: FolioDocumentStoryHandle): string[] => {
   const blocks = reviewer.readReviewedStory({ story, view: "final" })?.snapshot.blocks ?? [];
   return blocks.map(({ text, table }) => {
     const container = table

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -1,0 +1,188 @@
+/**
+ * Deterministic `.docx` compare: two packages in, one redlined package plus a
+ * JSON change list out.
+ *
+ * ## Determinism contract
+ *
+ * `compareDocx(base, target, options)` is a pure function of its three
+ * arguments. It reads no clock and no randomness: revision dates come from
+ * `options.timestamp`, and revision ids from a seed derived from the base
+ * document's own highest existing revision id, so two runs over the same
+ * inputs produce byte-identical buffers and deeply equal change lists.
+ *
+ * ## Round-trip contract
+ *
+ * Accepting every tracked change in the result yields the target's content;
+ * rejecting every one yields the base's. Anything the comparison does not
+ * cover is reported in `unsupported`, or fails the call, rather than being
+ * silently dropped.
+ *
+ * @packageDocumentation
+ */
+
+import { Result } from "better-result";
+
+import {
+  FolioDocxReviewer,
+  type FolioDocumentStoryHandle,
+  type FolioRevisionStamp,
+} from "../ai-edits/headless";
+import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
+import { pairFolioDocumentStories } from "../document-stories";
+import { planStoryCompare } from "./plan";
+import {
+  CompareDocxApplyError,
+  CompareDocxOperationLimitError,
+  CompareDocxParseError,
+  CompareDocxSerializeError,
+  type CompareChange,
+  type CompareDocxError,
+  type CompareDocxOptions,
+  type CompareResult,
+  type CompareUnsupportedPart,
+} from "./types";
+
+/**
+ * Cap on operations one comparison generates. Both inputs are untrusted
+ * documents, and each operation costs a document walk plus revision ids.
+ */
+export const MAX_COMPARE_OPERATIONS = 10_000;
+
+const parseSide = async (
+  buffer: ArrayBuffer,
+  side: "base" | "target",
+  author: string,
+): Promise<Result<FolioDocxReviewer, CompareDocxParseError>> =>
+  await Result.tryPromise({
+    try: async () => await FolioDocxReviewer.fromBuffer(buffer, { author }),
+    catch: (cause) =>
+      new CompareDocxParseError({
+        message: `The ${side} document could not be parsed.`,
+        side,
+        cause,
+      }),
+  });
+
+/**
+ * One past the highest revision id the base package already uses, across every
+ * story. Seeding there keeps generated ids from colliding with revisions the
+ * base already carries, while staying a pure function of the base bytes.
+ */
+const revisionIdSeedFor = (reviewer: FolioDocxReviewer): number => {
+  let highest = 0;
+  for (const { handle } of reviewer.listStories()) {
+    const story = reviewer.readReviewedStory({ story: handle, view: "current-markup" });
+    for (const change of story?.changes ?? []) {
+      highest = Math.max(highest, change.id);
+    }
+  }
+  return highest + 1;
+};
+
+const isMainStory = (story: FolioDocumentStoryHandle): boolean => story.type === "main";
+
+/**
+ * Compare `base` against `target` and return `base` carrying the tracked
+ * changes that turn it into `target`, alongside the change list describing
+ * them.
+ */
+export const compareDocx = async (
+  base: ArrayBuffer,
+  target: ArrayBuffer,
+  options: CompareDocxOptions,
+): Promise<Result<CompareResult, CompareDocxError>> => {
+  const baseParse = await parseSide(base, "base", options.author);
+  if (baseParse.isErr()) {
+    return Result.err(baseParse.error);
+  }
+  const targetParse = await parseSide(target, "target", options.author);
+  if (targetParse.isErr()) {
+    return Result.err(targetParse.error);
+  }
+
+  const reviewer = baseParse.value;
+  const targetReviewer = targetParse.value;
+  const revisionStamp: FolioRevisionStamp = {
+    date: options.timestamp,
+    idSeed: revisionIdSeedFor(reviewer),
+  };
+
+  const baseStories = reviewer.listStories().map(({ handle }) => handle);
+  const targetStories = targetReviewer.listStories().map(({ handle }) => handle);
+  const changes: CompareChange[] = [];
+  const unsupported: CompareUnsupportedPart[] = [];
+
+  for (const { baseStory, revisedStory: targetStory } of pairFolioDocumentStories(
+    baseStories,
+    targetStories,
+  )) {
+    if (!baseStory) {
+      unsupported.push({ reason: "story-missing-in-base", baseStory: null, targetStory });
+      continue;
+    }
+    if (!targetStory) {
+      unsupported.push({ reason: "story-missing-in-target", baseStory, targetStory: null });
+      continue;
+    }
+    const baseSnapshot = isMainStory(baseStory) ? reviewer.snapshotStory(baseStory) : null;
+    const targetSnapshot = isMainStory(targetStory)
+      ? targetReviewer.snapshotStory(targetStory)
+      : null;
+    if (!baseSnapshot || !targetSnapshot) {
+      unsupported.push({ reason: "secondary-story", baseStory, targetStory });
+      continue;
+    }
+
+    const plan = planStoryCompare({
+      story: baseStory,
+      baseSnapshot,
+      targetBlocks: targetSnapshot.blocks,
+      maxOperations: MAX_COMPARE_OPERATIONS,
+    });
+    if (plan === null) {
+      return Result.err(
+        new CompareDocxOperationLimitError({
+          message: "The comparison needs more operations than the engine generates.",
+          limit: MAX_COMPARE_OPERATIONS,
+        }),
+      );
+    }
+    changes.push(...plan.changes);
+    if (plan.operations.length === 0) {
+      continue;
+    }
+
+    const { skipped } = reviewer.applyDocumentOperationsToStory({
+      story: baseStory,
+      snapshot: baseSnapshot,
+      revisionStamp,
+      batch: {
+        version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+        mode: "tracked-changes",
+        operations: plan.operations,
+      },
+    });
+    if (skipped.length > 0) {
+      return Result.err(
+        new CompareDocxApplyError({
+          message:
+            "Some derived operations were refused, so the result would not match the target.",
+          skipped,
+        }),
+      );
+    }
+  }
+
+  const serialized = await Result.tryPromise({
+    try: async () => await reviewer.toBuffer(),
+    catch: (cause) =>
+      new CompareDocxSerializeError({
+        message: "The compared document could not be serialized.",
+        cause,
+      }),
+  });
+  if (serialized.isErr()) {
+    return Result.err(serialized.error);
+  }
+  return Result.ok({ buffer: serialized.value, changes, unsupported });
+};

--- a/packages/core/src/compare/formatting.ts
+++ b/packages/core/src/compare/formatting.ts
@@ -1,0 +1,149 @@
+/**
+ * Character-aligned inline-formatting diff of two text-equal blocks.
+ *
+ * Owned here and consumed by both the redline generator and
+ * {@link ./compare.compareDocx}, so a formatting-only difference is described
+ * the same way in the generated tracked changes and in the change list.
+ */
+
+import type {
+  FolioAIBlock,
+  FolioAIBlockPreviewRun,
+  FolioAIInlineFormatting,
+} from "../ai-edits/types";
+
+/** One run of characters whose supported inline formatting differs. */
+export type InlineFormattingSegment = {
+  /** Zero-based UTF-16 offset into the block's visible text. */
+  startOffset: number;
+  endOffset: number;
+  /** Only the properties that differ, set to the target document's value. */
+  formatting: FolioAIInlineFormatting;
+};
+
+const changedSupportedFormatting = (
+  base: FolioAIBlockPreviewRun,
+  target: FolioAIBlockPreviewRun,
+): FolioAIInlineFormatting => ({
+  ...(Boolean(base.bold) !== Boolean(target.bold) && { bold: Boolean(target.bold) }),
+  ...(Boolean(base.italic) !== Boolean(target.italic) && { italic: Boolean(target.italic) }),
+  ...(Boolean(base.underline) !== Boolean(target.underline) && {
+    underline: Boolean(target.underline),
+  }),
+});
+
+const sameInlineFormatting = (
+  left: FolioAIInlineFormatting,
+  right: FolioAIInlineFormatting,
+): boolean =>
+  left.bold === right.bold && left.italic === right.italic && left.underline === right.underline;
+
+const hasInlineFormatting = (formatting: FolioAIInlineFormatting): boolean =>
+  formatting.bold !== undefined ||
+  formatting.italic !== undefined ||
+  formatting.underline !== undefined;
+
+/**
+ * A block's runs, or `null` when they cannot describe the block's text.
+ * Non-text inline content (a field, an image) leaves the concatenated run text
+ * shorter than the block text; attributing formatting by offset would then
+ * point at the wrong characters, so the caller must back off instead.
+ */
+const previewRunsForBlock = (block: FolioAIBlock): readonly FolioAIBlockPreviewRun[] | null => {
+  const runs = block.previewRuns ?? [{ text: block.text }];
+  return runs.map(({ text }) => text).join("") === block.text ? runs : null;
+};
+
+type InlineFormattingSegmentsOptions = {
+  baseBlock: FolioAIBlock;
+  targetBlock: FolioAIBlock;
+  /** Refuse (return `null`) rather than build more segments than this. */
+  maxSegments: number;
+};
+
+/**
+ * Segments where `targetBlock`'s bold / italic / underline differs from
+ * `baseBlock`'s, for two blocks that carry the same text. Returns `null` only
+ * when the diff would exceed `maxSegments`.
+ *
+ * A block whose runs cannot be aligned to its text reports no segments rather
+ * than guessing: attributing formatting to the wrong characters is worse than
+ * missing a formatting-only change, and the caller has no offset it could
+ * trust instead.
+ */
+export const inlineFormattingSegments = ({
+  baseBlock,
+  targetBlock,
+  maxSegments,
+}: InlineFormattingSegmentsOptions): InlineFormattingSegment[] | null => {
+  const baseRuns = previewRunsForBlock(baseBlock);
+  const targetRuns = previewRunsForBlock(targetBlock);
+  if (!baseRuns || !targetRuns || baseBlock.text.length === 0) {
+    return [];
+  }
+
+  const segments: InlineFormattingSegment[] = [];
+  let baseRunIndex = 0;
+  let targetRunIndex = 0;
+  let baseRunOffset = 0;
+  let targetRunOffset = 0;
+  let textOffset = 0;
+
+  while (baseRunIndex < baseRuns.length && targetRunIndex < targetRuns.length) {
+    const baseRun = baseRuns[baseRunIndex];
+    const targetRun = targetRuns[targetRunIndex];
+    if (!baseRun || !targetRun) {
+      break;
+    }
+    const length = Math.min(
+      baseRun.text.length - baseRunOffset,
+      targetRun.text.length - targetRunOffset,
+    );
+    if (length <= 0) {
+      if (baseRunOffset >= baseRun.text.length) {
+        baseRunIndex++;
+        baseRunOffset = 0;
+      }
+      if (targetRunOffset >= targetRun.text.length) {
+        targetRunIndex++;
+        targetRunOffset = 0;
+      }
+      continue;
+    }
+
+    const formatting = changedSupportedFormatting(baseRun, targetRun);
+    if (hasInlineFormatting(formatting)) {
+      const previous = segments.at(-1);
+      if (
+        previous &&
+        previous.endOffset === textOffset &&
+        sameInlineFormatting(previous.formatting, formatting)
+      ) {
+        previous.endOffset += length;
+      } else {
+        if (segments.length >= maxSegments) {
+          return null;
+        }
+        segments.push({
+          startOffset: textOffset,
+          endOffset: textOffset + length,
+          formatting,
+        });
+      }
+    }
+
+    textOffset += length;
+    baseRunOffset += length;
+    targetRunOffset += length;
+    if (baseRunOffset >= baseRun.text.length) {
+      baseRunIndex++;
+      baseRunOffset = 0;
+    }
+    if (targetRunOffset >= targetRun.text.length) {
+      targetRunIndex++;
+      targetRunOffset = 0;
+    }
+  }
+
+  return segments;
+};

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -1,0 +1,533 @@
+/**
+ * Turn two block snapshots of one story into the change list a caller reads
+ * and the {@link FolioAIEditOperation}s that reproduce the target when every
+ * generated tracked change is accepted.
+ *
+ * Pure: no parsing, no serialization, no clock. The alignment itself is
+ * {@link alignFolioBlocks}, shared with the version-diff and redline paths, so
+ * all three interpret one document walk rather than re-deriving it.
+ *
+ * ## Structural passes over the alignment
+ *
+ * 1. **Whole-row collapse.** A run of consecutive base-only (or target-only)
+ *    blocks that covers every block of one table row is a row deletion (or
+ *    insertion), and is emitted as `deleteTableRow` / `insertTableRow`. Left as
+ *    paragraph operations it would strand the target row's text outside the
+ *    table, because a block insertion anchored inside a table lands as a
+ *    sibling of the table, not as a new row.
+ * 2. **Move detection.** A base-only and a target-only block with identical
+ *    text and at least {@link MOVE_MINIMUM_WORD_COUNT} words are one relocation.
+ *    The operations stay a delete plus an insert (the tracked-change grammar
+ *    Word round-trips has no durable "moved from here" mark for this path), but
+ *    the change list reports a single `move` so the relocation is not read as
+ *    unrelated churn. The word floor keeps boilerplate one-liners from pairing
+ *    as spurious moves.
+ */
+
+import { panic } from "better-result";
+
+import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
+import { createFolioAITextRangeHandle } from "../ai-edits/snapshot";
+import type {
+  FolioAIBlock,
+  FolioAIBlockTableLocation,
+  FolioAIEditOperation,
+  FolioAIEditSnapshot,
+} from "../ai-edits/types";
+import { alignFolioBlocks } from "../version-comparison";
+import { inlineFormattingSegments } from "./formatting";
+import type { CompareChange, CompareChangeLocation } from "./types";
+
+/** Words a relocated block needs before the move pass will pair it. */
+const MOVE_MINIMUM_WORD_COUNT = 3;
+
+/**
+ * Cap on same-text base-only blocks the move pass keeps per text. Without it a
+ * document repeating one paragraph thousands of times would make the pass
+ * quadratic on attacker-controlled input.
+ */
+const MAX_MOVE_CANDIDATES_PER_TEXT = 64;
+
+const rowKey = ({ tableIndex, rowIndex }: FolioAIBlockTableLocation): string =>
+  `${tableIndex}:${rowIndex}`;
+
+/** How many blocks each table row holds, so a partial run is not read as a whole-row change. */
+const countBlocksPerRow = (blocks: readonly FolioAIBlock[]): ReadonlyMap<string, number> => {
+  const counts = new Map<string, number>();
+  for (const { table } of blocks) {
+    if (table) {
+      const key = rowKey(table);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return counts;
+};
+
+const wordCountReaches = (text: string, minimum: number): boolean => {
+  let count = 0;
+  for (const word of text.split(/\s+/u)) {
+    if (word.length > 0 && ++count >= minimum) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * One step of the interpreted alignment. `baseRow` / `targetRow` are the
+ * whole-row collapses; the rest mirror {@link alignFolioBlocks}'s events with
+ * the revised side renamed to the target side.
+ */
+type CompareStep =
+  | { type: "pair"; baseBlock: FolioAIBlock; targetBlock: FolioAIBlock }
+  | { type: "baseOnly"; block: FolioAIBlock }
+  | { type: "targetOnly"; block: FolioAIBlock }
+  | { type: "baseRow"; blocks: readonly FolioAIBlock[]; location: FolioAIBlockTableLocation }
+  | { type: "targetRow"; blocks: readonly FolioAIBlock[]; location: FolioAIBlockTableLocation };
+
+/**
+ * The blocks a same-side run covers, grouped into maximal same-row prefixes.
+ * A group whose size matches the row's block count is a whole-row change.
+ */
+const collapseRun = (
+  run: readonly FolioAIBlock[],
+  blocksPerRow: ReadonlyMap<string, number>,
+  side: "base" | "target",
+): CompareStep[] => {
+  const steps: CompareStep[] = [];
+  let index = 0;
+  while (index < run.length) {
+    const first = run[index];
+    if (!first) {
+      break;
+    }
+    const { table } = first;
+    if (!table) {
+      steps.push(
+        side === "base"
+          ? { type: "baseOnly", block: first }
+          : { type: "targetOnly", block: first },
+      );
+      index++;
+      continue;
+    }
+    const key = rowKey(table);
+    let end = index;
+    while (end < run.length) {
+      const candidate = run[end]?.table;
+      if (!candidate || rowKey(candidate) !== key) {
+        break;
+      }
+      end++;
+    }
+    const group = run.slice(index, end);
+    if (group.length === blocksPerRow.get(key)) {
+      steps.push(
+        side === "base"
+          ? { type: "baseRow", blocks: group, location: table }
+          : { type: "targetRow", blocks: group, location: table },
+      );
+    } else {
+      for (const block of group) {
+        steps.push(
+          side === "base" ? { type: "baseOnly", block } : { type: "targetOnly", block },
+        );
+      }
+    }
+    index = end;
+  }
+  return steps;
+};
+
+type BuildStepsOptions = {
+  baseBlocks: readonly FolioAIBlock[];
+  targetBlocks: readonly FolioAIBlock[];
+};
+
+const buildSteps = ({ baseBlocks, targetBlocks }: BuildStepsOptions): CompareStep[] => {
+  const baseBlocksPerRow = countBlocksPerRow(baseBlocks);
+  const targetBlocksPerRow = countBlocksPerRow(targetBlocks);
+  const steps: CompareStep[] = [];
+  let baseRun: FolioAIBlock[] = [];
+  let targetRun: FolioAIBlock[] = [];
+
+  const flush = () => {
+    if (baseRun.length > 0) {
+      steps.push(...collapseRun(baseRun, baseBlocksPerRow, "base"));
+      baseRun = [];
+    }
+    if (targetRun.length > 0) {
+      steps.push(...collapseRun(targetRun, targetBlocksPerRow, "target"));
+      targetRun = [];
+    }
+  };
+
+  for (const event of alignFolioBlocks(baseBlocks, targetBlocks)) {
+    switch (event.type) {
+      case "pair":
+        flush();
+        steps.push({ type: "pair", baseBlock: event.baseBlock, targetBlock: event.revisedBlock });
+        break;
+      case "baseOnly":
+        baseRun.push(event.block);
+        break;
+      case "revisedOnly":
+        targetRun.push(event.block);
+        break;
+      default: {
+        const unreachable: never = event;
+        panic("Unhandled block alignment event", { event: unreachable });
+      }
+    }
+  }
+  flush();
+  return steps;
+};
+
+/** Base block id -> target block id for every relocation the move pass found. */
+const detectMoves = (steps: readonly CompareStep[]): ReadonlyMap<string, string> => {
+  const candidatesByText = new Map<string, string[]>();
+  for (const step of steps) {
+    if (step.type !== "baseOnly" || !wordCountReaches(step.block.text, MOVE_MINIMUM_WORD_COUNT)) {
+      continue;
+    }
+    const queue = candidatesByText.get(step.block.text);
+    if (!queue) {
+      candidatesByText.set(step.block.text, [step.block.id]);
+      continue;
+    }
+    if (queue.length < MAX_MOVE_CANDIDATES_PER_TEXT) {
+      queue.push(step.block.id);
+    }
+  }
+
+  const movesByBaseBlockId = new Map<string, string>();
+  for (const step of steps) {
+    if (step.type !== "targetOnly") {
+      continue;
+    }
+    const queue = candidatesByText.get(step.block.text);
+    const baseBlockId = queue?.shift();
+    if (baseBlockId !== undefined) {
+      movesByBaseBlockId.set(baseBlockId, step.block.id);
+    }
+  }
+  return movesByBaseBlockId;
+};
+
+/**
+ * For each step, the id of the next base block at or after it — the anchor a
+ * target-only insertion is placed before. `null` once no base block follows.
+ */
+const nextBaseBlockIdByStep = (steps: readonly CompareStep[]): (string | null)[] => {
+  const anchors = Array.from<string | null>({ length: steps.length });
+  let next: string | null = null;
+  for (let index = steps.length - 1; index >= 0; index--) {
+    anchors[index] = next;
+    const step = steps[index];
+    if (step?.type === "pair") {
+      next = step.baseBlock.id;
+    } else if (step?.type === "baseOnly") {
+      next = step.block.id;
+    } else if (step?.type === "baseRow") {
+      next = step.blocks[0]?.id ?? next;
+    }
+  }
+  return anchors;
+};
+
+/** A base block sitting inside a table, and whether it precedes or follows the step. */
+type RowAnchor = { blockId: string; position: "after" | "before" };
+
+const baseTableBlockOf = (step: CompareStep): FolioAIBlock | null => {
+  switch (step.type) {
+    case "pair":
+      return step.baseBlock.table ? step.baseBlock : null;
+    case "baseOnly":
+      return step.block.table ? step.block : null;
+    case "baseRow":
+      return step.blocks[0] ?? null;
+    case "targetOnly":
+    case "targetRow":
+      return null;
+    default: {
+      const unreachable: never = step;
+      return panic("Unhandled compare step", { step: unreachable });
+    }
+  }
+};
+
+/**
+ * The base-document row a new row is inserted next to: the nearest base block
+ * inside a table, preferring the one before the insertion so a run of new rows
+ * keeps its order.
+ */
+const findRowAnchor = (steps: readonly CompareStep[], stepIndex: number): RowAnchor | null => {
+  for (let index = stepIndex - 1; index >= 0; index--) {
+    const step = steps[index];
+    const block = step ? baseTableBlockOf(step) : null;
+    if (block) {
+      return { blockId: block.id, position: "after" };
+    }
+  }
+  for (let index = stepIndex + 1; index < steps.length; index++) {
+    const step = steps[index];
+    const block = step ? baseTableBlockOf(step) : null;
+    if (block) {
+      return { blockId: block.id, position: "before" };
+    }
+  }
+  return null;
+};
+
+/** A row's blocks joined per physical cell, in cell order. */
+const rowCellTexts = (blocks: readonly FolioAIBlock[]): string[] => {
+  const byCell = new Map<number, string[]>();
+  for (const block of blocks) {
+    if (!block.table) {
+      continue;
+    }
+    const texts = byCell.get(block.table.cellIndex);
+    if (texts) {
+      texts.push(block.text);
+    } else {
+      byCell.set(block.table.cellIndex, [block.text]);
+    }
+  }
+  return [...byCell.keys()]
+    .toSorted((left, right) => left - right)
+    .map((cellIndex) => (byCell.get(cellIndex) ?? []).join("\n"));
+};
+
+const locationOf = (story: FolioDocumentStoryHandle, block: FolioAIBlock): CompareChangeLocation =>
+  block.table ? { story, cell: block.table } : { story };
+
+export type CompareStoryPlan = {
+  changes: CompareChange[];
+  operations: FolioAIEditOperation[];
+};
+
+export type PlanStoryCompareOptions = {
+  story: FolioDocumentStoryHandle;
+  baseSnapshot: FolioAIEditSnapshot;
+  targetBlocks: readonly FolioAIBlock[];
+  /** Cap on generated operations; the caller turns `null` into its own error. */
+  maxOperations: number;
+};
+
+/**
+ * Plan one story's comparison, or `null` when it needs more operations than
+ * `maxOperations`.
+ */
+export const planStoryCompare = ({
+  story,
+  baseSnapshot,
+  targetBlocks,
+  maxOperations,
+}: PlanStoryCompareOptions): CompareStoryPlan | null => {
+  const steps = buildSteps({ baseBlocks: baseSnapshot.blocks, targetBlocks });
+  const movesByBaseBlockId = detectMoves(steps);
+  const moveSourceByTargetBlockId = new Map<string, string>();
+  for (const [baseBlockId, targetBlockId] of movesByBaseBlockId) {
+    moveSourceByTargetBlockId.set(targetBlockId, baseBlockId);
+  }
+
+  const anchorIds = nextBaseBlockIdByStep(steps);
+  const changes: CompareChange[] = [];
+  const operations: FolioAIEditOperation[] = [];
+  const trailingInserts: FolioAIBlock[] = [];
+  const lastBaseBlockId = baseSnapshot.blocks.at(-1)?.id ?? null;
+  let operationSequence = 0;
+
+  const nextOperationId = (): string => `compare-${++operationSequence}`;
+
+  const pushInsertOperation = (block: FolioAIBlock, anchorId: string | null): void => {
+    if (anchorId === null) {
+      trailingInserts.push(block);
+      return;
+    }
+    operations.push({
+      id: nextOperationId(),
+      type: "insertBeforeBlock",
+      blockId: anchorId,
+      text: block.text,
+      ...(block.styleId !== undefined && { styleId: block.styleId }),
+    });
+  };
+
+  for (const [stepIndex, step] of steps.entries()) {
+    switch (step.type) {
+      case "pair": {
+        const { baseBlock, targetBlock } = step;
+        if (baseBlock.text !== targetBlock.text) {
+          changes.push({
+            kind: "replace",
+            location: locationOf(story, baseBlock),
+            baseBlockId: baseBlock.id,
+            targetBlockId: targetBlock.id,
+            before: baseBlock.text,
+            after: targetBlock.text,
+          });
+          operations.push({
+            id: nextOperationId(),
+            type: "replaceBlock",
+            blockId: baseBlock.id,
+            text: targetBlock.text,
+          });
+          break;
+        }
+        const segments = inlineFormattingSegments({
+          baseBlock,
+          targetBlock,
+          maxSegments: maxOperations,
+        });
+        if (segments === null) {
+          return null;
+        }
+        if (segments.length === 0) {
+          break;
+        }
+        changes.push({
+          kind: "format",
+          location: locationOf(story, baseBlock),
+          baseBlockId: baseBlock.id,
+          targetBlockId: targetBlock.id,
+          text: baseBlock.text,
+          ranges: segments,
+        });
+        for (const { startOffset, endOffset, formatting } of segments) {
+          const range = createFolioAITextRangeHandle({
+            blockId: baseBlock.id,
+            text: baseBlock.text,
+            startOffset,
+            endOffset,
+          });
+          if (!range) {
+            panic("An aligned formatting range could not be represented");
+          }
+          operations.push({ id: nextOperationId(), type: "formatRange", range, formatting });
+        }
+        break;
+      }
+      case "baseOnly": {
+        const targetBlockId = movesByBaseBlockId.get(step.block.id);
+        if (targetBlockId === undefined) {
+          changes.push({
+            kind: "delete",
+            location: locationOf(story, step.block),
+            baseBlockId: step.block.id,
+            before: step.block.text,
+          });
+        }
+        operations.push({ id: nextOperationId(), type: "deleteBlock", blockId: step.block.id });
+        break;
+      }
+      case "targetOnly": {
+        const baseBlockId = moveSourceByTargetBlockId.get(step.block.id);
+        changes.push(
+          baseBlockId === undefined
+            ? {
+                kind: "insert",
+                location: locationOf(story, step.block),
+                targetBlockId: step.block.id,
+                after: step.block.text,
+              }
+            : {
+                kind: "move",
+                location: locationOf(story, step.block),
+                baseBlockId,
+                targetBlockId: step.block.id,
+                text: step.block.text,
+              },
+        );
+        pushInsertOperation(step.block, anchorIds[stepIndex] ?? null);
+        break;
+      }
+      case "baseRow": {
+        const anchorBlockId = step.blocks[0]?.id;
+        if (anchorBlockId === undefined) {
+          panic("A collapsed table row carried no blocks");
+        }
+        changes.push({
+          kind: "table-row-delete",
+          location: { story, cell: step.location },
+          tableIndex: step.location.tableIndex,
+          rowIndex: step.location.rowIndex,
+          cells: rowCellTexts(step.blocks),
+          baseBlockIds: step.blocks.map(({ id }) => id),
+        });
+        operations.push({ id: nextOperationId(), type: "deleteTableRow", blockId: anchorBlockId });
+        break;
+      }
+      case "targetRow": {
+        const anchor = findRowAnchor(steps, stepIndex);
+        const cells = rowCellTexts(step.blocks);
+        changes.push({
+          kind: "table-row-insert",
+          location: { story, cell: step.location },
+          tableIndex: step.location.tableIndex,
+          rowIndex: step.location.rowIndex,
+          cells,
+          targetBlockIds: step.blocks.map(({ id }) => id),
+        });
+        if (anchor === null) {
+          // The base story has no table to grow, so the row's text can only
+          // land as ordinary paragraphs.
+          for (const block of step.blocks) {
+            pushInsertOperation(block, anchorIds[stepIndex] ?? null);
+          }
+          break;
+        }
+        operations.push({
+          id: nextOperationId(),
+          type: "insertTableRow",
+          blockId: anchor.blockId,
+          position: anchor.position,
+          cellTexts: cells,
+        });
+        break;
+      }
+      default: {
+        const unreachable: never = step;
+        panic("Unhandled compare step", { step: unreachable });
+      }
+    }
+    if (operations.length > maxOperations) {
+      return null;
+    }
+  }
+
+  // An empty base document has no block to insert after, only the hidden
+  // anchor paragraph. Its first addition therefore replaces that paragraph
+  // instead of following it, so the result does not open with a stray blank.
+  const emptyBaseAnchorId =
+    lastBaseBlockId === null ? baseSnapshot.emptyDocumentAnchorId : undefined;
+  const anchorId = lastBaseBlockId ?? emptyBaseAnchorId;
+  for (const [insertIndex, block] of trailingInserts.entries()) {
+    if (anchorId === undefined) {
+      // Nothing to anchor to: an empty base with no anchor paragraph cannot
+      // receive tracked insertions at all.
+      break;
+    }
+    const styleId = block.styleId === undefined ? {} : { styleId: block.styleId };
+    if (insertIndex === 0 && emptyBaseAnchorId !== undefined) {
+      operations.push({
+        id: nextOperationId(),
+        type: "replaceBlock",
+        blockId: emptyBaseAnchorId,
+        text: block.text,
+        ...styleId,
+      });
+      continue;
+    }
+    operations.push({
+      id: nextOperationId(),
+      type: "insertAfterBlock",
+      blockId: anchorId,
+      text: block.text,
+      ...styleId,
+    });
+  }
+
+  return operations.length > maxOperations ? null : { changes, operations };
+};

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -3,25 +3,37 @@
  * and the {@link FolioAIEditOperation}s that reproduce the target when every
  * generated tracked change is accepted.
  *
- * Pure: no parsing, no serialization, no clock. The alignment itself is
- * {@link alignFolioBlocks}, shared with the version-diff and redline paths, so
- * all three interpret one document walk rather than re-deriving it.
+ * Pure: no parsing, no serialization, no clock. Every alignment runs through
+ * {@link alignFolioBlocks}, shared with the version-diff and redline paths.
  *
- * ## Structural passes over the alignment
+ * ## Aligning by container, not by block
  *
- * 1. **Whole-row collapse.** A run of consecutive base-only (or target-only)
- *    blocks that covers every block of one table row is a row deletion (or
- *    insertion), and is emitted as `deleteTableRow` / `insertTableRow`. Left as
- *    paragraph operations it would strand the target row's text outside the
- *    table, because a block insertion anchored inside a table lands as a
- *    sibling of the table, not as a new row.
- * 2. **Move detection.** A base-only and a target-only block with identical
- *    text and at least {@link MOVE_MINIMUM_WORD_COUNT} words are one relocation.
- *    The operations stay a delete plus an insert (the tracked-change grammar
- *    Word round-trips has no durable "moved from here" mark for this path), but
- *    the change list reports a single `move` so the relocation is not read as
- *    unrelated churn. The word floor keeps boilerplate one-liners from pairing
- *    as spurious moves.
+ * A single alignment over every paragraph in the story cannot see structure.
+ * It pairs on text and document order, so it will put a paragraph inside a
+ * table cell opposite one outside it, or a cell of one row opposite a cell of
+ * the next — and rewriting either pair in place leaves the target's text in
+ * the wrong container. A whole row that was added or removed likewise arrives
+ * as a scatter of unmatched paragraphs, which no block operation can turn back
+ * into a row: a block insertion anchored in a table lands beside the table,
+ * never as a new row in it.
+ *
+ * So the story is aligned in three nested passes, each over things that can
+ * actually stand in for one another:
+ *
+ * 1. **Segments.** Maximal runs of body text and of one table each, so a table
+ *    is only ever compared against a table.
+ * 2. **Rows**, within a paired table segment, so a whole-row change stays whole
+ *    and becomes `insertTableRow` / `deleteTableRow`.
+ * 3. **Cells**, within a paired row, matched by physical cell index.
+ *
+ * ## Move detection
+ *
+ * A base-only and a target-only block with identical text and at least
+ * {@link MOVE_MINIMUM_WORD_COUNT} words are one relocation. The operations stay
+ * a delete plus an insert — the tracked-change grammar Word round-trips has no
+ * durable "moved from here" mark on this path — but the change list reports a
+ * single `move` so the relocation is not read as unrelated churn. The word
+ * floor keeps boilerplate one-liners from pairing as spurious moves.
  */
 
 import { panic } from "better-result";
@@ -48,21 +60,6 @@ const MOVE_MINIMUM_WORD_COUNT = 3;
  */
 const MAX_MOVE_CANDIDATES_PER_TEXT = 64;
 
-const rowKey = ({ tableIndex, rowIndex }: FolioAIBlockTableLocation): string =>
-  `${tableIndex}:${rowIndex}`;
-
-/** How many blocks each table row holds, so a partial run is not read as a whole-row change. */
-const countBlocksPerRow = (blocks: readonly FolioAIBlock[]): ReadonlyMap<string, number> => {
-  const counts = new Map<string, number>();
-  for (const { table } of blocks) {
-    if (table) {
-      const key = rowKey(table);
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-  }
-  return counts;
-};
-
 const wordCountReaches = (text: string, minimum: number): boolean => {
   let count = 0;
   for (const word of text.split(/\s+/u)) {
@@ -74,9 +71,8 @@ const wordCountReaches = (text: string, minimum: number): boolean => {
 };
 
 /**
- * One step of the interpreted alignment. `baseRow` / `targetRow` are the
- * whole-row collapses; the rest mirror {@link alignFolioBlocks}'s events with
- * the revised side renamed to the target side.
+ * One step of the interpreted alignment. `baseRow` / `targetRow` are whole-row
+ * changes; the rest are block-level.
  */
 type CompareStep =
   | { type: "pair"; baseBlock: FolioAIBlock; targetBlock: FolioAIBlock }
@@ -86,57 +82,220 @@ type CompareStep =
   | { type: "targetRow"; blocks: readonly FolioAIBlock[]; location: FolioAIBlockTableLocation };
 
 /**
- * The blocks a same-side run covers, grouped into maximal same-row prefixes.
- * A group whose size matches the row's block count is a whole-row change.
+ * A maximal run of blocks that share a container: body text, or one table.
+ * Blocks arrive in document order and a table's blocks are contiguous, so a
+ * single forward scan recovers the document's structure.
  */
-const collapseRun = (
-  run: readonly FolioAIBlock[],
-  blocksPerRow: ReadonlyMap<string, number>,
-  side: "base" | "target",
-): CompareStep[] => {
-  const steps: CompareStep[] = [];
-  let index = 0;
-  while (index < run.length) {
-    const first = run[index];
-    if (!first) {
-      break;
-    }
-    const { table } = first;
-    if (!table) {
-      steps.push(
-        side === "base"
-          ? { type: "baseOnly", block: first }
-          : { type: "targetOnly", block: first },
-      );
-      index++;
+type DocumentSegment =
+  | { kind: "body"; blocks: FolioAIBlock[] }
+  | { kind: "table"; blocks: FolioAIBlock[] };
+
+/**
+ * The document's segments, normalized to strictly alternate body, table, body,
+ * ... and to begin and end with a body segment — inserting empty body segments
+ * where the document has none.
+ *
+ * Without the padding the two sides can hold different segment shapes (a
+ * document that opens with a table against one that opens with a heading), and
+ * the alignment's positional fallback would then put a body segment opposite a
+ * table. That pair is unusable, so the whole table would be reissued as a
+ * deletion plus an insertion. Padding keeps like opposite like.
+ */
+const splitSegments = (blocks: readonly FolioAIBlock[]): DocumentSegment[] => {
+  const segments: DocumentSegment[] = [];
+  let currentTableIndex: number | null = null;
+  for (const block of blocks) {
+    const tableIndex = block.table?.tableIndex ?? null;
+    const current = segments.at(-1);
+    if (current !== undefined && currentTableIndex === tableIndex) {
+      current.blocks.push(block);
       continue;
     }
-    const key = rowKey(table);
-    let end = index;
-    while (end < run.length) {
-      const candidate = run[end]?.table;
-      if (!candidate || rowKey(candidate) !== key) {
-        break;
-      }
-      end++;
+    if (block.table && segments.at(-1)?.kind !== "body") {
+      segments.push({ kind: "body", blocks: [] });
     }
-    const group = run.slice(index, end);
-    if (group.length === blocksPerRow.get(key)) {
-      steps.push(
-        side === "base"
-          ? { type: "baseRow", blocks: group, location: table }
-          : { type: "targetRow", blocks: group, location: table },
-      );
+    segments.push({ kind: block.table ? "table" : "body", blocks: [block] });
+    currentTableIndex = tableIndex;
+  }
+  if (segments.length === 0 || segments.at(-1)?.kind === "table") {
+    segments.push({ kind: "body", blocks: [] });
+  }
+  return segments;
+};
+
+/**
+ * A stand-in block used only to run {@link alignFolioBlocks} over table rows,
+ * which are not paragraphs. The id is always the `seq-NNNN` shape, which the
+ * alignment treats as unstable, so it pairs rows on text and position alone
+ * instead of mistaking a synthetic id for identity.
+ */
+const proxyBlock = (index: number, text: string): FolioAIBlock => ({
+  id: `seq-${String(index + 1).padStart(4, "0")}`,
+  kind: "paragraph",
+  text,
+});
+
+/** Blocks of one table grouped into rows, in row order. */
+const groupRows = (blocks: readonly FolioAIBlock[]): FolioAIBlock[][] => {
+  const rows = new Map<number, FolioAIBlock[]>();
+  for (const block of blocks) {
+    if (!block.table) {
+      continue;
+    }
+    const row = rows.get(block.table.rowIndex);
+    if (row) {
+      row.push(block);
     } else {
-      for (const block of group) {
-        steps.push(
-          side === "base" ? { type: "baseOnly", block } : { type: "targetOnly", block },
-        );
+      rows.set(block.table.rowIndex, [block]);
+    }
+  }
+  return [...rows.keys()].toSorted((left, right) => left - right).map((key) => rows.get(key) ?? []);
+};
+
+const rowText = (row: readonly FolioAIBlock[]): string =>
+  row.map(({ text }) => text).join(" ");
+
+const rowLocation = (row: readonly FolioAIBlock[]): FolioAIBlockTableLocation | null =>
+  row.at(0)?.table ?? null;
+
+/** Zip one paired row's cells by physical cell index, then by paragraph order. */
+const alignRowCells = (
+  baseRow: readonly FolioAIBlock[],
+  targetRow: readonly FolioAIBlock[],
+): CompareStep[] => {
+  const byCell = (row: readonly FolioAIBlock[]): Map<number, FolioAIBlock[]> => {
+    const cells = new Map<number, FolioAIBlock[]>();
+    for (const block of row) {
+      const cellIndex = block.table?.cellIndex ?? 0;
+      const blocks = cells.get(cellIndex);
+      if (blocks) {
+        blocks.push(block);
+      } else {
+        cells.set(cellIndex, [block]);
       }
     }
-    index = end;
+    return cells;
+  };
+
+  const baseCells = byCell(baseRow);
+  const targetCells = byCell(targetRow);
+  const cellIndexes = [...new Set([...baseCells.keys(), ...targetCells.keys()])].toSorted(
+    (left, right) => left - right,
+  );
+
+  const steps: CompareStep[] = [];
+  for (const cellIndex of cellIndexes) {
+    const baseBlocks = baseCells.get(cellIndex) ?? [];
+    const targetBlocks = targetCells.get(cellIndex) ?? [];
+    const paired = Math.min(baseBlocks.length, targetBlocks.length);
+    for (let index = 0; index < paired; index++) {
+      const baseBlock = baseBlocks[index];
+      const targetBlock = targetBlocks[index];
+      if (baseBlock && targetBlock) {
+        steps.push({ type: "pair", baseBlock, targetBlock });
+      }
+    }
+    for (const block of baseBlocks.slice(paired)) {
+      steps.push({ type: "baseOnly", block });
+    }
+    for (const block of targetBlocks.slice(paired)) {
+      steps.push({ type: "targetOnly", block });
+    }
   }
   return steps;
+};
+
+/**
+ * Align one table's rows, then its cells.
+ *
+ * Running the block alignment straight over a table's paragraphs cannot see
+ * rows: it happily pairs a cell of one row with a cell of another, and a row
+ * that was wholly added or removed shows up as a scatter of unmatched
+ * paragraphs. Aligning rows first — each row standing in as one proxy block of
+ * its joined cell text — keeps a whole-row change whole, and confines every
+ * other difference to a cell that really corresponds.
+ */
+const buildTableSteps = (
+  baseBlocks: readonly FolioAIBlock[],
+  targetBlocks: readonly FolioAIBlock[],
+): CompareStep[] => {
+  const baseRows = groupRows(baseBlocks);
+  const targetRows = groupRows(targetBlocks);
+  const steps: CompareStep[] = [];
+
+  let baseCursor = 0;
+  let targetCursor = 0;
+  for (const event of alignFolioBlocks(
+    baseRows.map((row, index) => proxyBlock(index, rowText(row))),
+    targetRows.map((row, index) => proxyBlock(index, rowText(row))),
+  )) {
+    switch (event.type) {
+      case "pair": {
+        const baseRow = baseRows[baseCursor++];
+        const targetRow = targetRows[targetCursor++];
+        if (baseRow && targetRow) {
+          steps.push(...alignRowCells(baseRow, targetRow));
+        }
+        break;
+      }
+      case "baseOnly": {
+        const row = baseRows[baseCursor++];
+        const location = row ? rowLocation(row) : null;
+        if (row && location) {
+          steps.push({ type: "baseRow", blocks: row, location });
+        }
+        break;
+      }
+      case "revisedOnly": {
+        const row = targetRows[targetCursor++];
+        const location = row ? rowLocation(row) : null;
+        if (row && location) {
+          steps.push({ type: "targetRow", blocks: row, location });
+        }
+        break;
+      }
+      default: {
+        const unreachable: never = event;
+        panic("Unhandled block alignment event", { event: unreachable });
+      }
+    }
+  }
+  return steps;
+};
+
+const buildBodySteps = (
+  baseBlocks: readonly FolioAIBlock[],
+  targetBlocks: readonly FolioAIBlock[],
+): CompareStep[] =>
+  alignFolioBlocks(baseBlocks, targetBlocks).map((event) => {
+    switch (event.type) {
+      case "pair":
+        return { type: "pair", baseBlock: event.baseBlock, targetBlock: event.revisedBlock };
+      case "baseOnly":
+        return { type: "baseOnly", block: event.block };
+      case "revisedOnly":
+        return { type: "targetOnly", block: event.block };
+      default: {
+        const unreachable: never = event;
+        return panic("Unhandled block alignment event", { event: unreachable });
+      }
+    }
+  });
+
+/** Every block of an unpaired segment, as one-sided steps. */
+const unpairedSegmentSteps = (segment: DocumentSegment, side: "base" | "target"): CompareStep[] => {
+  if (segment.kind === "table") {
+    return groupRows(segment.blocks).flatMap((row) => {
+      const location = rowLocation(row);
+      if (!location) {
+        return [];
+      }
+      return [{ type: side === "base" ? "baseRow" : "targetRow", blocks: row, location }];
+    });
+  }
+  return segment.blocks.map((block) =>
+    side === "base" ? { type: "baseOnly", block } : { type: "targetOnly", block },
+  );
 };
 
 type BuildStepsOptions = {
@@ -144,43 +303,55 @@ type BuildStepsOptions = {
   targetBlocks: readonly FolioAIBlock[];
 };
 
+/**
+ * Align the two stories segment by segment, in order.
+ *
+ * Segments are paired by position rather than by text. Both sides have been
+ * normalized to the same alternating shape, so position already carries the
+ * meaning: the nth table of one document answers to the nth table of the
+ * other, and the body text between two tables answers to the body text between
+ * the same two tables. Matching segments on text instead lets a paragraph that
+ * moved across a table steal the table's own pairing, which reissues the whole
+ * table as a deletion and an insertion.
+ *
+ * When the two documents hold different numbers of tables the shapes diverge,
+ * and the surplus segments are reported one-sided. The operation vocabulary
+ * cannot create or destroy a table, so `compareDocx`'s round-trip self-check
+ * refuses those comparisons rather than returning a package that silently
+ * drops one.
+ */
 const buildSteps = ({ baseBlocks, targetBlocks }: BuildStepsOptions): CompareStep[] => {
-  const baseBlocksPerRow = countBlocksPerRow(baseBlocks);
-  const targetBlocksPerRow = countBlocksPerRow(targetBlocks);
+  const baseSegments = splitSegments(baseBlocks);
+  const targetSegments = splitSegments(targetBlocks);
+  const pairedCount = Math.min(baseSegments.length, targetSegments.length);
   const steps: CompareStep[] = [];
-  let baseRun: FolioAIBlock[] = [];
-  let targetRun: FolioAIBlock[] = [];
 
-  const flush = () => {
-    if (baseRun.length > 0) {
-      steps.push(...collapseRun(baseRun, baseBlocksPerRow, "base"));
-      baseRun = [];
+  for (let index = 0; index < pairedCount; index++) {
+    const baseSegment = baseSegments[index];
+    const targetSegment = targetSegments[index];
+    if (!baseSegment || !targetSegment) {
+      continue;
     }
-    if (targetRun.length > 0) {
-      steps.push(...collapseRun(targetRun, targetBlocksPerRow, "target"));
-      targetRun = [];
+    if (baseSegment.kind !== targetSegment.kind) {
+      steps.push(
+        ...unpairedSegmentSteps(baseSegment, "base"),
+        ...unpairedSegmentSteps(targetSegment, "target"),
+      );
+      continue;
     }
-  };
-
-  for (const event of alignFolioBlocks(baseBlocks, targetBlocks)) {
-    switch (event.type) {
-      case "pair":
-        flush();
-        steps.push({ type: "pair", baseBlock: event.baseBlock, targetBlock: event.revisedBlock });
-        break;
-      case "baseOnly":
-        baseRun.push(event.block);
-        break;
-      case "revisedOnly":
-        targetRun.push(event.block);
-        break;
-      default: {
-        const unreachable: never = event;
-        panic("Unhandled block alignment event", { event: unreachable });
-      }
-    }
+    steps.push(
+      ...(baseSegment.kind === "table"
+        ? buildTableSteps(baseSegment.blocks, targetSegment.blocks)
+        : buildBodySteps(baseSegment.blocks, targetSegment.blocks)),
+    );
   }
-  flush();
+
+  for (const segment of baseSegments.slice(pairedCount)) {
+    steps.push(...unpairedSegmentSteps(segment, "base"));
+  }
+  for (const segment of targetSegments.slice(pairedCount)) {
+    steps.push(...unpairedSegmentSteps(segment, "target"));
+  }
   return steps;
 };
 
@@ -280,23 +451,19 @@ const findRowAnchor = (steps: readonly CompareStep[], stepIndex: number): RowAnc
   return null;
 };
 
-/** A row's blocks joined per physical cell, in cell order. */
+/**
+ * A row's text per physical cell, indexed BY cell so an empty cell keeps its
+ * slot. An empty cell carries no block at all, so packing only the cells that
+ * have text would shift every later cell one column left.
+ */
 const rowCellTexts = (blocks: readonly FolioAIBlock[]): string[] => {
-  const byCell = new Map<number, string[]>();
+  const byCell: (string | undefined)[] = [];
   for (const block of blocks) {
-    if (!block.table) {
-      continue;
-    }
-    const texts = byCell.get(block.table.cellIndex);
-    if (texts) {
-      texts.push(block.text);
-    } else {
-      byCell.set(block.table.cellIndex, [block.text]);
-    }
+    const cellIndex = block.table?.cellIndex ?? 0;
+    const existing = byCell[cellIndex];
+    byCell[cellIndex] = existing === undefined ? block.text : `${existing}\n${block.text}`;
   }
-  return [...byCell.keys()]
-    .toSorted((left, right) => left - right)
-    .map((cellIndex) => (byCell.get(cellIndex) ?? []).join("\n"));
+  return Array.from(byCell, (text) => text ?? "");
 };
 
 const locationOf = (story: FolioDocumentStoryHandle, block: FolioAIBlock): CompareChangeLocation =>

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -152,8 +152,7 @@ const groupRows = (blocks: readonly FolioAIBlock[]): FolioAIBlock[][] => {
   return [...rows.keys()].toSorted((left, right) => left - right).map((key) => rows.get(key) ?? []);
 };
 
-const rowText = (row: readonly FolioAIBlock[]): string =>
-  row.map(({ text }) => text).join(" ");
+const rowText = (row: readonly FolioAIBlock[]): string => row.map(({ text }) => text).join(" ");
 
 const rowLocation = (row: readonly FolioAIBlock[]): FolioAIBlockTableLocation | null =>
   row.at(0)?.table ?? null;

--- a/packages/core/src/compare/reproducible-package.ts
+++ b/packages/core/src/compare/reproducible-package.ts
@@ -1,0 +1,33 @@
+/**
+ * The last clock in the compare path is the ZIP container itself.
+ *
+ * Every part the serializer rewrites is stored with JSZip's default entry
+ * date, which is `new Date()`. The XML is identical between two runs, but the
+ * DOS timestamp fields in the local headers are not, and they only agree when
+ * both runs land in the same two-second bucket — so the packages match most of
+ * the time and differ occasionally, which is worse than differing always.
+ *
+ * Restamping every entry from the comparison's own timestamp removes it. It
+ * also states the truth about the package: a generated redline is dated by the
+ * comparison that produced it, not by the second it happened to be written.
+ */
+
+import JSZip from "jszip";
+
+/** JSZip deflate level `repackDocx` writes DOCX parts at. */
+const DOCX_COMPRESSION_LEVEL = 6;
+
+export const withFixedPackageDates = async (
+  buffer: ArrayBuffer,
+  date: Date,
+): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(buffer);
+  zip.forEach((_path, file) => {
+    file.date = date;
+  });
+  return await zip.generateAsync({
+    type: "arraybuffer",
+    compression: "DEFLATE",
+    compressionOptions: { level: DOCX_COMPRESSION_LEVEL },
+  });
+};

--- a/packages/core/src/compare/scenario.ts
+++ b/packages/core/src/compare/scenario.ts
@@ -1,0 +1,264 @@
+/**
+ * Edit scripts: ground truth for the compare engine, by construction.
+ *
+ * A property test cannot assert "this redline is right" against a document it
+ * only guessed at. It can assert it against a document it BUILT: take a real
+ * base, apply a scripted edit directly (no tracked changes), and the result is
+ * a target whose difference from the base is known exactly. `compareDocx` then
+ * has to rediscover that difference, and the script says what it should have
+ * found.
+ *
+ * Every step is applied through the same headless applier `compareDocx` writes
+ * its own operations through, in `"direct"` mode — so the target is an ordinary
+ * document, not one carrying revisions the comparison would have to resolve
+ * first.
+ *
+ * Steps address blocks by their index in the base story's block list rather
+ * than by id, so a generator can pick targets without first parsing the
+ * document. A step that does not resolve is reported in `unresolved`, never
+ * dropped: a script silently doing less than it says would weaken every
+ * property built on it.
+ */
+
+import { panic, Result } from "better-result";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { createFolioAITextRangeHandle } from "../ai-edits/snapshot";
+import type {
+  FolioAIBlock,
+  FolioAIEditOperation,
+  FolioAIInlineFormatting,
+} from "../ai-edits/types";
+import { CompareDocxParseError, CompareDocxSerializeError } from "./types";
+
+export type EditScriptStep =
+  | { type: "insertParagraphAfter"; blockIndex: number; text: string }
+  | { type: "deleteParagraph"; blockIndex: number }
+  | { type: "replaceWords"; blockIndex: number; find: string; replace: string }
+  /** Delete the block at `blockIndex` and reinsert its text before `beforeBlockIndex`. */
+  | { type: "moveParagraph"; blockIndex: number; beforeBlockIndex: number }
+  | {
+      type: "formatRange";
+      blockIndex: number;
+      startOffset: number;
+      endOffset: number;
+      formatting: FolioAIInlineFormatting;
+    }
+  | { type: "insertTableRow"; blockIndex: number; cellTexts: readonly string[] }
+  | { type: "deleteTableRow"; blockIndex: number }
+  | { type: "editTableCell"; blockIndex: number; text: string };
+
+export type EditScript = readonly EditScriptStep[];
+
+export const EDIT_SCRIPT_UNRESOLVED_REASONS = Object.freeze([
+  "block-out-of-range",
+  "block-not-in-table",
+  "range-out-of-bounds",
+  "text-not-found",
+  /** The applier refused the operation the step produced. */
+  "refused",
+] as const);
+
+export type EditScriptUnresolvedReason = (typeof EDIT_SCRIPT_UNRESOLVED_REASONS)[number];
+
+export type EditScriptUnresolvedStep = {
+  step: EditScriptStep;
+  reason: EditScriptUnresolvedReason;
+};
+
+export type EditScriptResult = {
+  /** The base document with every applied step written in directly. */
+  buffer: ArrayBuffer;
+  /** The steps that reached the document, in script order. */
+  applied: readonly EditScriptStep[];
+  unresolved: readonly EditScriptUnresolvedStep[];
+};
+
+type PlannedStep = {
+  step: EditScriptStep;
+  operations: readonly FolioAIEditOperation[];
+};
+
+type StepPlan =
+  | { status: "planned"; operations: readonly FolioAIEditOperation[] }
+  | { status: "unresolved"; reason: EditScriptUnresolvedReason };
+
+const blockAt = (blocks: readonly FolioAIBlock[], index: number): FolioAIBlock | undefined =>
+  Number.isInteger(index) && index >= 0 ? blocks.at(index) : undefined;
+
+type PlanStepOptions = {
+  step: EditScriptStep;
+  blocks: readonly FolioAIBlock[];
+  nextOperationId: () => string;
+};
+
+const planStep = ({ step, blocks, nextOperationId }: PlanStepOptions): StepPlan => {
+  const block = blockAt(blocks, step.blockIndex);
+  if (!block) {
+    return { status: "unresolved", reason: "block-out-of-range" };
+  }
+
+  switch (step.type) {
+    case "insertParagraphAfter":
+      return {
+        status: "planned",
+        operations: [
+          { id: nextOperationId(), type: "insertAfterBlock", blockId: block.id, text: step.text },
+        ],
+      };
+    case "deleteParagraph":
+      return {
+        status: "planned",
+        operations: [{ id: nextOperationId(), type: "deleteBlock", blockId: block.id }],
+      };
+    case "replaceWords":
+      return block.text.includes(step.find)
+        ? {
+            status: "planned",
+            operations: [
+              {
+                id: nextOperationId(),
+                type: "replaceInBlock",
+                blockId: block.id,
+                find: step.find,
+                replace: step.replace,
+              },
+            ],
+          }
+        : { status: "unresolved", reason: "text-not-found" };
+    case "moveParagraph": {
+      const destination = blockAt(blocks, step.beforeBlockIndex);
+      if (!destination || destination.id === block.id) {
+        return { status: "unresolved", reason: "block-out-of-range" };
+      }
+      return {
+        status: "planned",
+        operations: [
+          { id: nextOperationId(), type: "deleteBlock", blockId: block.id },
+          {
+            id: nextOperationId(),
+            type: "insertBeforeBlock",
+            blockId: destination.id,
+            text: block.text,
+          },
+        ],
+      };
+    }
+    case "formatRange": {
+      const range = createFolioAITextRangeHandle({
+        blockId: block.id,
+        text: block.text,
+        startOffset: step.startOffset,
+        endOffset: step.endOffset,
+      });
+      return range
+        ? {
+            status: "planned",
+            operations: [
+              { id: nextOperationId(), type: "formatRange", range, formatting: step.formatting },
+            ],
+          }
+        : { status: "unresolved", reason: "range-out-of-bounds" };
+    }
+    case "insertTableRow":
+      return block.table
+        ? {
+            status: "planned",
+            operations: [
+              {
+                id: nextOperationId(),
+                type: "insertTableRow",
+                blockId: block.id,
+                position: "after",
+                cellTexts: [...step.cellTexts],
+              },
+            ],
+          }
+        : { status: "unresolved", reason: "block-not-in-table" };
+    case "deleteTableRow":
+      return block.table
+        ? {
+            status: "planned",
+            operations: [
+              { id: nextOperationId(), type: "deleteTableRow", blockId: block.id },
+            ],
+          }
+        : { status: "unresolved", reason: "block-not-in-table" };
+    case "editTableCell":
+      return block.table
+        ? {
+            status: "planned",
+            operations: [
+              { id: nextOperationId(), type: "replaceBlock", blockId: block.id, text: step.text },
+            ],
+          }
+        : { status: "unresolved", reason: "block-not-in-table" };
+    default: {
+      const unreachable: never = step;
+      return panic("Unhandled edit script step", { step: unreachable });
+    }
+  }
+};
+
+/**
+ * Apply `script` to `base` directly and return the resulting target document.
+ */
+export const applyEditScript = async (
+  base: ArrayBuffer,
+  script: EditScript,
+): Promise<Result<EditScriptResult, CompareDocxParseError | CompareDocxSerializeError>> => {
+  const parsed = await Result.tryPromise({
+    try: async () => await FolioDocxReviewer.fromBuffer(base),
+    catch: (cause) =>
+      new CompareDocxParseError({
+        message: "The edit script's base document could not be parsed.",
+        side: "base",
+        cause,
+      }),
+  });
+  if (parsed.isErr()) {
+    return Result.err(parsed.error);
+  }
+
+  const reviewer = parsed.value;
+  const snapshot = reviewer.snapshot();
+  const unresolved: EditScriptUnresolvedStep[] = [];
+  const planned: PlannedStep[] = [];
+  let operationSequence = 0;
+  const nextOperationId = (): string => `scenario-${++operationSequence}`;
+
+  for (const step of script) {
+    const plan = planStep({ step, blocks: snapshot.blocks, nextOperationId });
+    if (plan.status === "unresolved") {
+      unresolved.push({ step, reason: plan.reason });
+      continue;
+    }
+    planned.push({ step, operations: plan.operations });
+  }
+
+  const { skipped } = reviewer.applyOperations(
+    planned.flatMap(({ operations }) => [...operations]),
+    { mode: "direct", snapshot },
+  );
+  const skippedIds = new Set(skipped.map(({ id }) => id));
+  const applied: EditScriptStep[] = [];
+  for (const { step, operations } of planned) {
+    if (operations.some(({ id }) => skippedIds.has(id))) {
+      unresolved.push({ step, reason: "refused" });
+      continue;
+    }
+    applied.push(step);
+  }
+
+  const serialized = await Result.tryPromise({
+    try: async () => await reviewer.toBuffer(),
+    catch: (cause) =>
+      new CompareDocxSerializeError({
+        message: "The edit script's target document could not be serialized.",
+        cause,
+      }),
+  });
+  return serialized.isErr()
+    ? Result.err(serialized.error)
+    : Result.ok({ buffer: serialized.value, applied, unresolved });
+};

--- a/packages/core/src/compare/scenario.ts
+++ b/packages/core/src/compare/scenario.ts
@@ -179,9 +179,7 @@ const planStep = ({ step, blocks, nextOperationId }: PlanStepOptions): StepPlan 
       return block.table
         ? {
             status: "planned",
-            operations: [
-              { id: nextOperationId(), type: "deleteTableRow", blockId: block.id },
-            ],
+            operations: [{ id: nextOperationId(), type: "deleteTableRow", blockId: block.id }],
           }
         : { status: "unresolved", reason: "block-not-in-table" };
     case "editTableCell":

--- a/packages/core/src/compare/types.ts
+++ b/packages/core/src/compare/types.ts
@@ -1,0 +1,174 @@
+/**
+ * Public vocabulary of {@link ./compare.compareDocx}: the change list, the
+ * options that pin its output, and the failures it reports.
+ */
+
+import { TaggedError } from "better-result";
+
+import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
+import type {
+  FolioAIBlockTableLocation,
+  FolioAIEditSkippedOperation,
+  FolioAIInlineFormatting,
+} from "../ai-edits/types";
+
+/** Everything {@link compareDocx} needs; nothing it reads from the ambient clock. */
+export type CompareDocxOptions = {
+  /** Author recorded on every generated tracked change. */
+  author: string;
+  /**
+   * ISO-8601 date stamped on every generated tracked change. Required rather
+   * than defaulted so a caller cannot get a nondeterministic package by
+   * omission; pass the base document's own timestamp, a release date, or a
+   * fixed epoch.
+   */
+  timestamp: string;
+};
+
+/** Where one change sits in the base or target document. */
+export type CompareChangeLocation = {
+  story: FolioDocumentStoryHandle;
+  /** Innermost table cell, when the change is inside a table. */
+  cell?: FolioAIBlockTableLocation;
+};
+
+/** One run of characters whose inline formatting differs, in base-block offsets. */
+export type CompareFormatRange = {
+  startOffset: number;
+  endOffset: number;
+  /** Only the properties that differ, set to the target document's value. */
+  formatting: FolioAIInlineFormatting;
+};
+
+/**
+ * One difference between the two documents, in target-document order with
+ * base-only entries slotted where they sat. Every variant is plain JSON, so a
+ * caller can hand the list to an agent instead of the package.
+ *
+ * A `move` is reported, not represented: the tracked-change grammar has no
+ * "this paragraph came from there" mark that Word round-trips, so the buffer
+ * carries a deletion at the source and an insertion at the destination while
+ * the change list keeps the relocation visible.
+ */
+export type CompareChange =
+  | {
+      kind: "insert";
+      location: CompareChangeLocation;
+      /** Id of the inserted block in the target document. */
+      targetBlockId: string;
+      after: string;
+    }
+  | {
+      kind: "delete";
+      location: CompareChangeLocation;
+      baseBlockId: string;
+      before: string;
+    }
+  | {
+      kind: "replace";
+      location: CompareChangeLocation;
+      baseBlockId: string;
+      targetBlockId: string;
+      before: string;
+      after: string;
+    }
+  | {
+      kind: "move";
+      location: CompareChangeLocation;
+      /** The block's id where it sat in the base document. */
+      baseBlockId: string;
+      /** The same content's id where it sits in the target document. */
+      targetBlockId: string;
+      text: string;
+    }
+  | {
+      kind: "format";
+      location: CompareChangeLocation;
+      baseBlockId: string;
+      targetBlockId: string;
+      text: string;
+      ranges: readonly CompareFormatRange[];
+    }
+  | {
+      kind: "table-row-insert";
+      location: CompareChangeLocation;
+      tableIndex: number;
+      /** Row index in the target document's table. */
+      rowIndex: number;
+      /** The new row's cell texts, in physical cell order. */
+      cells: readonly string[];
+      targetBlockIds: readonly string[];
+    }
+  | {
+      kind: "table-row-delete";
+      location: CompareChangeLocation;
+      tableIndex: number;
+      /** Row index in the base document's table. */
+      rowIndex: number;
+      cells: readonly string[];
+      baseBlockIds: readonly string[];
+    };
+
+/** Why a part of the package is absent from `changes`. */
+export const COMPARE_UNSUPPORTED_REASONS = Object.freeze([
+  /** Header, footer, footnote, and endnote stories are out of scope this iteration. */
+  "secondary-story",
+  /** The story exists only in the target package; creating a part is not a text edit. */
+  "story-missing-in-base",
+  /** The story exists only in the base package. */
+  "story-missing-in-target",
+] as const);
+
+export type CompareUnsupportedReason = (typeof COMPARE_UNSUPPORTED_REASONS)[number];
+
+/**
+ * A package part the comparison did not cover. Reported rather than dropped so
+ * a caller can tell "no differences" from "not looked at".
+ */
+export type CompareUnsupportedPart = {
+  reason: CompareUnsupportedReason;
+  baseStory: FolioDocumentStoryHandle | null;
+  targetStory: FolioDocumentStoryHandle | null;
+};
+
+export type CompareResult = {
+  /** The base package carrying the generated tracked changes. */
+  buffer: ArrayBuffer;
+  changes: readonly CompareChange[];
+  unsupported: readonly CompareUnsupportedPart[];
+};
+
+export class CompareDocxParseError extends TaggedError("CompareDocxParseError")<{
+  message: string;
+  side: "base" | "target";
+  cause: unknown;
+}> {}
+
+/**
+ * The applier refused at least one derived operation, so accepting the result
+ * would not reproduce the target. Reported instead of returning a package that
+ * silently under-represents the difference.
+ */
+export class CompareDocxApplyError extends TaggedError("CompareDocxApplyError")<{
+  message: string;
+  skipped: readonly FolioAIEditSkippedOperation[];
+}> {}
+
+/** The difference needs more operations than the engine will generate. */
+export class CompareDocxOperationLimitError extends TaggedError(
+  "CompareDocxOperationLimitError",
+)<{
+  message: string;
+  limit: number;
+}> {}
+
+export class CompareDocxSerializeError extends TaggedError("CompareDocxSerializeError")<{
+  message: string;
+  cause: unknown;
+}> {}
+
+export type CompareDocxError =
+  | CompareDocxApplyError
+  | CompareDocxOperationLimitError
+  | CompareDocxParseError
+  | CompareDocxSerializeError;

--- a/packages/core/src/compare/types.ts
+++ b/packages/core/src/compare/types.ts
@@ -175,9 +175,7 @@ export class CompareDocxRoundTripError extends TaggedError("CompareDocxRoundTrip
 }> {}
 
 /** The difference needs more operations than the engine will generate. */
-export class CompareDocxOperationLimitError extends TaggedError(
-  "CompareDocxOperationLimitError",
-)<{
+export class CompareDocxOperationLimitError extends TaggedError("CompareDocxOperationLimitError")<{
   message: string;
   limit: number;
 }> {}

--- a/packages/core/src/compare/types.ts
+++ b/packages/core/src/compare/types.ts
@@ -138,6 +138,12 @@ export type CompareResult = {
   unsupported: readonly CompareUnsupportedPart[];
 };
 
+export class InvalidCompareDocxOptionsError extends TaggedError("InvalidCompareDocxOptionsError")<{
+  message: string;
+  option: "timestamp";
+  receivedValue: unknown;
+}> {}
+
 export class CompareDocxParseError extends TaggedError("CompareDocxParseError")<{
   message: string;
   side: "base" | "target";
@@ -152,6 +158,20 @@ export class CompareDocxParseError extends TaggedError("CompareDocxParseError")<
 export class CompareDocxApplyError extends TaggedError("CompareDocxApplyError")<{
   message: string;
   skipped: readonly FolioAIEditSkippedOperation[];
+}> {}
+
+/**
+ * The generated tracked changes do not accept back to the target. Raised by
+ * the self-check {@link compareDocx} runs before returning: a redline that
+ * quietly loses part of the difference is worse than no redline, so the
+ * mismatch is surfaced instead of the document.
+ */
+export class CompareDocxRoundTripError extends TaggedError("CompareDocxRoundTripError")<{
+  message: string;
+  story: FolioDocumentStoryHandle;
+  /** Block texts the accepted result holds where the target differs. */
+  acceptedText: readonly string[];
+  targetText: readonly string[];
 }> {}
 
 /** The difference needs more operations than the engine will generate. */
@@ -171,4 +191,6 @@ export type CompareDocxError =
   | CompareDocxApplyError
   | CompareDocxOperationLimitError
   | CompareDocxParseError
-  | CompareDocxSerializeError;
+  | CompareDocxRoundTripError
+  | CompareDocxSerializeError
+  | InvalidCompareDocxOptionsError;

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -3,6 +3,7 @@ import { TaggedError } from "better-result";
 import {
   applyFolioAIEditOperations,
   type FolioAIEditView,
+  type FolioRevisionStamp,
   previewFolioAIEditOperations,
 } from "./ai-edits/apply";
 import type {
@@ -1142,6 +1143,8 @@ export type ApplyFolioDocumentOperationsOptions = {
   author?: string;
   createCommentId?: (text: string) => number;
   createUndoHandle?: () => FolioDocumentOperationUndoHandle;
+  /** Omit to stamp revisions from the wall clock and the shared id cursor. */
+  revisionStamp?: FolioRevisionStamp;
 };
 
 type ApplyParsedDocumentOperationBatchOptions = {
@@ -1158,6 +1161,7 @@ export const applyFolioDocumentOperations = ({
   author,
   createCommentId,
   createUndoHandle,
+  revisionStamp,
 }: ApplyFolioDocumentOperationsOptions): FolioDocumentOperationResult => {
   const parsedBatch = parseFolioDocumentOperationBatch(batch);
   const apply = ({
@@ -1173,6 +1177,7 @@ export const applyFolioDocumentOperations = ({
       mode: parsedBatch.mode ?? "tracked-changes",
       ...(author !== undefined && { author }),
       ...(targetCreateCommentId !== undefined && { createCommentId: targetCreateCommentId }),
+      ...(revisionStamp !== undefined && { revisionStamp }),
     });
   };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,26 @@ export {
   type DocumentPreset,
   type DocumentStyleSet,
 } from "./style-sets/types";
+// Deterministic two-document compare: a redlined package plus a JSON change
+// list. See `./compare/README.md` for the determinism contract and limitations.
+export { compareDocx, MAX_COMPARE_OPERATIONS } from "./compare/compare";
+export {
+  COMPARE_UNSUPPORTED_REASONS,
+  CompareDocxApplyError,
+  CompareDocxOperationLimitError,
+  CompareDocxParseError,
+  CompareDocxRoundTripError,
+  CompareDocxSerializeError,
+  InvalidCompareDocxOptionsError,
+  type CompareChange,
+  type CompareChangeLocation,
+  type CompareDocxError,
+  type CompareDocxOptions,
+  type CompareFormatRange,
+  type CompareResult,
+  type CompareUnsupportedPart,
+  type CompareUnsupportedReason,
+} from "./compare/types";
 export { createDocx } from "./docx/rezip";
 export { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
 export type { Document, DocxConformanceClass } from "./types/document";
@@ -78,6 +98,8 @@ export {
   type WordDiffSegment,
   type FolioAIBlock,
   type FolioAIBlockAnchor,
+  type FolioAIBlockTableLocation,
+  type FolioRevisionStamp,
   type FolioAIBlockKind,
   type FolioAIBlockPreviewRun,
   type FolioAIComment,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -330,7 +330,9 @@ describe("fromProseDoc", () => {
       ]),
     ]);
 
-    expect(() => fromProseDoc(pmDoc)).toThrow("Bookmark id 99 has no matching end boundary.");
+    expect(() => fromProseDoc(pmDoc)).toThrow(
+      'Bookmark "unpaired" (id 99) has no matching end boundary',
+    );
   });
 
   test("round-trips table row structural revision markers through the editor model", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc-duplicate-bookmarks.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc-duplicate-bookmarks.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression: a `.docx` whose bookmark boundaries do not pair cleanly must
+ * still load.
+ *
+ * Real contract templates carry untidy bookmarks — an id repeated across
+ * paragraphs, a start Word never closed, an end whose start was edited away.
+ * Word and LibreOffice open those files; conversion used to reject the whole
+ * document, so nothing downstream (the editor, the reviewer, `compareDocx`)
+ * could touch them.
+ *
+ * The document here is built from the typed model rather than copied from any
+ * real file, so the fixture carries the shape and none of the content.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { FolioDocxReviewer } from "../../ai-edits/headless";
+import { compareDocx } from "../../compare/compare";
+import { createDocx } from "../../docx/rezip";
+import { parseDocx } from "../../docx/parser";
+import type { Paragraph } from "../../types/document";
+import { createEmptyDocument } from "../../utils/createDocument";
+import { toProseDoc } from "./toProseDoc";
+
+type ParagraphSpec = {
+  paraId: string;
+  text: string;
+  content?: Paragraph["content"];
+};
+
+const buildDocxBuffer = (paragraphs: readonly ParagraphSpec[]): Promise<ArrayBuffer> => {
+  const template = createEmptyDocument();
+  return createDocx({
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: paragraphs.map(({ paraId, text, content }) => ({
+          type: "paragraph",
+          paraId,
+          content: [...(content ?? []), { type: "run", content: [{ type: "text", text }] }],
+        })),
+      },
+    },
+  });
+};
+
+/**
+ * The shape that used to fail: bookmark id 0 started in two different
+ * paragraphs, plus a start with no end and an end with no start.
+ */
+const buildUntidyBookmarkDocx = (): Promise<ArrayBuffer> =>
+  buildDocxBuffer([
+    {
+      paraId: "C0000001",
+      text: "First clause.",
+      content: [{ type: "bookmarkStart", id: 0, name: "_GoBack" }],
+    },
+    {
+      paraId: "C0000002",
+      text: "Second clause.",
+      content: [{ type: "bookmarkStart", id: 0, name: "_GoBack" }],
+    },
+    {
+      paraId: "C0000003",
+      text: "Third clause.",
+      content: [{ type: "bookmarkStart", id: 7, name: "_Unclosed" }],
+    },
+    {
+      paraId: "C0000004",
+      text: "Fourth clause.",
+      content: [{ type: "bookmarkEnd", id: 99 }],
+    },
+  ]);
+
+const BLOCK_TEXTS = ["First clause.", "Second clause.", "Third clause.", "Fourth clause."] as const;
+
+describe("bookmark boundaries that do not pair", () => {
+  test("toProseDoc converts a document with a duplicate bookmark id", async () => {
+    const document = await parseDocx(await buildUntidyBookmarkDocx(), {
+      detectVariables: false,
+      preloadFonts: false,
+    });
+
+    const doc = toProseDoc(document);
+
+    expect(doc.textContent).toContain("First clause.");
+    expect(doc.textContent).toContain("Second clause.");
+  });
+
+  test("the reviewer loads it and keeps every block", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await buildUntidyBookmarkDocx());
+
+    expect(reviewer.getContent().map((block) => block.text)).toEqual([...BLOCK_TEXTS]);
+  });
+
+  test("it survives a save and reload", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await buildUntidyBookmarkDocx());
+    const reloaded = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
+
+    expect(reloaded.getContent().map((block) => block.text)).toEqual([...BLOCK_TEXTS]);
+  });
+
+  test("compareDocx reports the edit instead of failing to parse", async () => {
+    const base = await buildUntidyBookmarkDocx();
+    const target = await buildDocxBuffer([
+      {
+        paraId: "C0000001",
+        text: "First clause, amended.",
+        content: [{ type: "bookmarkStart", id: 0, name: "_GoBack" }],
+      },
+      {
+        paraId: "C0000002",
+        text: "Second clause.",
+        content: [{ type: "bookmarkStart", id: 0, name: "_GoBack" }],
+      },
+      {
+        paraId: "C0000003",
+        text: "Third clause.",
+        content: [{ type: "bookmarkStart", id: 7, name: "_Unclosed" }],
+      },
+      { paraId: "C0000004", text: "Fourth clause.", content: [{ type: "bookmarkEnd", id: 99 }] },
+    ]);
+
+    const result = await compareDocx(base, target, {
+      author: "compare",
+      timestamp: "2024-03-01T00:00:00.000Z",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.changes.map((change) => change.kind)).toEqual(["replace"]);
+  });
+});

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -290,10 +290,10 @@ const createParaIdAllocatorPlugin = (): Plugin =>
       }
 
       const keeperPositions = mapKeeperPositions(oldState.doc, transactions);
-      const seed = transactions.reduce<string | null>(
-        (found, transaction) => found ?? transaction.getMeta(deterministicParaIdSeedKey) ?? null,
-        null,
-      );
+      const seed =
+        transactions
+          .map((transaction) => transaction.getMeta(deterministicParaIdSeedKey))
+          .find((value) => typeof value === "string") ?? null;
       const updates = collectParaIdUpdates(newState.doc, keeperPositions, seed);
       if (updates.length === 0) {
         return null;

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -39,12 +39,49 @@ import { Fragment, type Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 
-import { generateHexId } from "../../../utils/hexId";
+import { deterministicHexId, generateHexId } from "../../../utils/hexId";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
 
 export const paraIdAllocatorKey = new PluginKey("paraIdAllocator");
+
+/**
+ * Transaction meta asking this plugin to derive the ids it mints from a
+ * caller-supplied seed instead of `Math.random()`.
+ *
+ * A live editor wants random ids: two people typing must not collide. A
+ * generator whose whole output has to be reproducible — the document compare —
+ * cannot afford them, and it is the only party that knows its run is meant to
+ * be deterministic, so it says so on its own transaction rather than leaving
+ * the plugin to guess.
+ */
+export const deterministicParaIdSeedKey = new PluginKey<string>("deterministicParaIdSeed");
+
+/** Ask the allocator to mint reproducible ids for the paragraphs `tr` creates. */
+export const requestDeterministicParaIds = (tr: Transaction, seed: string): Transaction =>
+  tr.setMeta(deterministicParaIdSeedKey, seed);
+
+/**
+ * A fresh id not already in `taken`: derived from `seed` and the paragraph's
+ * position when the caller asked for reproducibility, random otherwise. Both
+ * loops terminate — the id space is 2^31 wide and `taken` holds at most one
+ * entry per paragraph.
+ */
+const mintParaId = (taken: ReadonlySet<string>, seed: string | null, pos: number): string => {
+  if (seed === null) {
+    let id = generateHexId();
+    while (taken.has(id)) {
+      id = generateHexId();
+    }
+    return id;
+  }
+  let id = deterministicHexId(`${seed}:${String(pos)}`);
+  for (let salt = 1; taken.has(id); salt++) {
+    id = deterministicHexId(`${seed}:${String(pos)}:${String(salt)}`);
+  }
+  return id;
+};
 
 type ParaIdUpdate = {
   pos: number;
@@ -99,6 +136,7 @@ const mapKeeperPositions = (
 const collectParaIdUpdates = (
   doc: PMNode,
   keeperPositions?: Map<string, number>,
+  deterministicSeed: string | null = null,
 ): ParaIdUpdate[] => {
   // Pass 1: paragraphs without a usable id, and occurrences per id.
   const missing: ParagraphOccurrence[] = [];
@@ -143,10 +181,7 @@ const collectParaIdUpdates = (
   const taken = new Set(occurrencesById.keys());
   const updates: ParaIdUpdate[] = [];
   for (const { pos, attrs } of needFreshId) {
-    let newId = generateHexId();
-    while (taken.has(newId)) {
-      newId = generateHexId();
-    }
+    const newId = mintParaId(taken, deterministicSeed, pos);
     taken.add(newId);
     updates.push({ pos, attrs: { ...attrs, paraId: newId } });
   }
@@ -255,7 +290,11 @@ const createParaIdAllocatorPlugin = (): Plugin =>
       }
 
       const keeperPositions = mapKeeperPositions(oldState.doc, transactions);
-      const updates = collectParaIdUpdates(newState.doc, keeperPositions);
+      const seed = transactions.reduce<string | null>(
+        (found, transaction) => found ?? transaction.getMeta(deterministicParaIdSeedKey) ?? null,
+        null,
+      );
+      const updates = collectParaIdUpdates(newState.doc, keeperPositions, seed);
       if (updates.length === 0) {
         return null;
       }

--- a/packages/core/src/prosemirror/validation.test.ts
+++ b/packages/core/src/prosemirror/validation.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, test } from "bun:test";
 import { schema } from "./schema";
 import { assertValidProseMirrorDocument, validateProseMirrorDocument } from "./validation";
 
+/**
+ * Assert an issue whose message starts with `fragment`. Bookmark messages carry
+ * the bookmark's name and its paragraph so a failing document is diagnosable;
+ * the tests pin the reason, not that decoration.
+ */
+const expectIssueContaining = (
+  result: ReturnType<typeof validateProseMirrorDocument>,
+  fragment: string,
+): void => {
+  expect(result.issues.map((issue) => issue.message)).toEqual(
+    expect.arrayContaining([expect.stringContaining(fragment)]),
+  );
+};
+
 describe("ProseMirror document validation", () => {
   test("reports attr issues with document paths", () => {
     const highlight = schema.mark("highlight", { color: "customYellow" });
@@ -44,12 +58,12 @@ describe("ProseMirror document validation", () => {
     {
       name: "lone start",
       content: [schema.node("bookmarkBoundary", { type: "start", id: 1, name: "one" })],
-      message: "Bookmark id 1 has no matching end boundary.",
+      message: 'Bookmark "one" (id 1) has no matching end boundary',
     },
     {
       name: "lone end",
       content: [schema.node("bookmarkBoundary", { type: "end", id: 1 })],
-      message: "Bookmark id 1 has no open start boundary.",
+      message: "Bookmark id 1 has no open start boundary",
     },
     {
       name: "duplicate starts",
@@ -59,7 +73,7 @@ describe("ProseMirror document validation", () => {
         schema.node("bookmarkBoundary", { type: "start", id: 1, name: "duplicate" }),
         schema.node("bookmarkBoundary", { type: "end", id: 1 }),
       ],
-      message: "Bookmark id 1 has more than one start boundary.",
+      message: 'Bookmark "duplicate" (id 1) has more than one start boundary',
     },
   ])("rejects $name bookmark boundaries", ({ content, message }) => {
     const doc = schema.node("doc", null, [schema.node("paragraph", null, content)]);
@@ -67,7 +81,36 @@ describe("ProseMirror document validation", () => {
     const result = validateProseMirrorDocument(doc);
 
     expect(result.valid).toBe(false);
-    expect(result.issues.map((issue) => issue.message)).toContain(message);
+    expectIssueContaining(result, message);
+  });
+
+  test("tolerates one id repeated across paragraph bookmark attrs", () => {
+    // Real documents repeat a bookmark id this way (a stray `_GoBack`, a
+    // template assembled from several sources). Word and LibreOffice keep the
+    // first start and open the file; refusing it here made those documents
+    // unloadable. The attr serializes as a start and an end around its own
+    // paragraph, so the repeat writes back exactly what was read.
+    const paragraph = (paraId: string) =>
+      schema.node("paragraph", { paraId, bookmarks: [{ id: 0, name: "_GoBack" }] }, [
+        schema.text(`clause ${paraId}`),
+      ]);
+    const doc = schema.node("doc", null, [paragraph("A0000001"), paragraph("A0000002")]);
+
+    expect(validateProseMirrorDocument(doc)).toEqual({ valid: true, issues: [] });
+  });
+
+  test("names the bookmark and the paragraph a boundary failure sits in", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: "B0000001" }, [
+        schema.node("bookmarkBoundary", { type: "start", id: 4, name: "unclosed" }),
+        schema.text("body"),
+      ]),
+    ]);
+
+    expectIssueContaining(
+      validateProseMirrorDocument(doc),
+      'Bookmark "unclosed" (id 4) has no matching end boundary (paragraph B0000001)',
+    );
   });
 
   test("allows paired bookmark ranges to overlap", () => {
@@ -128,8 +171,9 @@ describe("ProseMirror document validation", () => {
     const result = validateProseMirrorDocument(doc);
 
     expect(result.valid).toBe(false);
-    expect(result.issues.map((issue) => issue.message)).toContain(
-      "Bookmark boundaries inside tracked changes require a hyperlink serialization parent.",
+    expectIssueContaining(
+      result,
+      "Bookmark boundaries inside tracked changes require a hyperlink serialization parent",
     );
   });
 
@@ -229,9 +273,7 @@ describe("ProseMirror document validation", () => {
     const result = validateProseMirrorDocument(doc);
 
     expect(result.valid).toBe(false);
-    expect(result.issues.map((issue) => issue.message)).toContain(
-      "Bookmark id 1 has more than one start boundary.",
-    );
+    expectIssueContaining(result, 'Bookmark "pasted" (id 1) has more than one start boundary');
   });
 
   test("rejects an internally pasted pair that collides with an existing id", () => {
@@ -246,8 +288,6 @@ describe("ProseMirror document validation", () => {
     const result = validateProseMirrorDocument(doc);
 
     expect(result.valid).toBe(false);
-    expect(result.issues.map((issue) => issue.message)).toContain(
-      "Bookmark id 1 has more than one start boundary.",
-    );
+    expectIssueContaining(result, 'Bookmark "pasted" (id 1) has more than one start boundary');
   });
 });

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -36,6 +36,7 @@ import {
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
 } from "./attrs";
+import type { ParagraphAttrs } from "./schema/nodes";
 import { readTextBoxAnchorAttrs } from "./textBoxAnchorAttrs";
 
 export type ProseMirrorDocumentValidationIssue = {
@@ -80,10 +81,41 @@ export const validateProseMirrorDocument = (doc: PMNode): ValidateProseMirrorDoc
   };
 };
 
+/**
+ * Where a bookmark boundary came from. A `bookmarkBoundary` node is emitted by
+ * this codebase's own conversion, always in matched pairs. A
+ * `paragraph.attrs.bookmarks` entry is input data the conversion could not pair
+ * (see `collectPairedBookmarkIds`) and is written back out as a start and an end
+ * around that one paragraph. The distinction decides how strictly a duplicate
+ * id is treated.
+ */
+type BookmarkBoundaryOrigin = "attr" | "node";
+
 type OpenBookmarkBoundary = {
   id: number;
+  name: string | null;
   path: string;
+  paragraph: string;
+  origin: BookmarkBoundaryOrigin;
 };
+
+/**
+ * Locate a bookmark boundary by the paragraph holding it, so a failure names a
+ * place a reader can find rather than only a node path.
+ *
+ * The paragraph's text is deliberately left out. Validation messages travel
+ * into logs and error reports, and document text is not log data.
+ */
+const describeParagraph = (
+  attrs: ReadProseMirrorAttrsResult<ParagraphAttrs> | null,
+  path: string,
+): string => {
+  const paraId = attrs?.ok === true ? attrs.value.paraId : undefined;
+  return paraId !== undefined && paraId.length > 0 ? `paragraph ${paraId}` : `paragraph at ${path}`;
+};
+
+const describeBookmark = (id: number, name: string | null): string =>
+  name === null || name.length === 0 ? `Bookmark id ${id}` : `Bookmark "${name}" (id ${id})`;
 
 const validateBookmarkBoundaryStructure = (
   doc: PMNode,
@@ -91,32 +123,75 @@ const validateBookmarkBoundaryStructure = (
 ): void => {
   // Bookmark boundaries pair by id, not by stack order. Word permits ranges
   // to overlap (start A, start B, end A, end B), so crossing pairs are valid.
+  //
+  // A duplicate id is an error EXCEPT when both occurrences are paragraph-attr
+  // bookmarks. Real documents repeat an id that way — a stray `_GoBack`, a
+  // template assembled from several sources, a file round-tripped through
+  // another editor — and Word and LibreOffice keep the first start and open the
+  // file rather than refusing it. Rejecting the document instead made every such
+  // file unopenable here, and the attr carries no range to corrupt: it
+  // serializes as a start and an end around its own paragraph, so the tolerated
+  // occurrence writes back exactly what was read.
+  //
+  // A duplicate involving a `bookmarkBoundary` node stays an error. Those this
+  // codebase emits itself, in pairs, so a collision there means an editing
+  // operation (a paste carrying an id the document already uses) produced an
+  // ambiguous anchor rather than an input document being untidy.
   const open = new Map<number, OpenBookmarkBoundary>();
-  const startedIds = new Set<number>();
+  const startedBy = new Map<number, BookmarkBoundaryOrigin>();
 
-  const registerStart = (id: number, path: string): void => {
-    if (startedIds.has(id)) {
-      issues.push({ path, message: `Bookmark id ${id} has more than one start boundary.` });
-      return;
+  /** Whether the boundary opened, and so needs a matching end registered later. */
+  const registerStart = (boundary: OpenBookmarkBoundary): boolean => {
+    const { id, name, path, paragraph, origin } = boundary;
+    const previousOrigin = startedBy.get(id);
+    if (previousOrigin !== undefined) {
+      if (origin === "attr" && previousOrigin === "attr") {
+        return false;
+      }
+      issues.push({
+        path,
+        message: `${describeBookmark(id, name)} has more than one start boundary (${paragraph}).`,
+      });
+      return false;
     }
-    startedIds.add(id);
-    open.set(id, { id, path });
+    startedBy.set(id, origin);
+    open.set(id, boundary);
+    return true;
   };
 
-  const registerEnd = (id: number, path: string): void => {
-    const start = open.get(id);
-    if (!start) {
-      issues.push({ path, message: `Bookmark id ${id} has no open start boundary.` });
+  const registerEnd = (id: number, path: string, paragraph: string): void => {
+    if (!open.has(id)) {
+      issues.push({
+        path,
+        message: `${describeBookmark(id, null)} has no open start boundary (${paragraph}).`,
+      });
       return;
     }
     open.delete(id);
   };
 
-  const visit = (node: PMNode, path: string): void => {
+  const visit = (node: PMNode, path: string, paragraph: string): void => {
     const paragraphAttrs = node.type.name === "paragraph" ? readParagraphAttrs(node) : null;
+    const enclosingParagraph =
+      node.type.name === "paragraph" ? describeParagraph(paragraphAttrs, path) : paragraph;
+
+    // Only the attr bookmarks that actually opened are closed after the
+    // children. A tolerated duplicate never opened, so registering its end
+    // would report an unmatched end that is not there.
+    const openedAttrBookmarks: { id: number; path: string }[] = [];
     if (paragraphAttrs?.ok) {
       for (const [index, bookmark] of (paragraphAttrs.value.bookmarks ?? []).entries()) {
-        registerStart(bookmark.id, `${path}.paragraph.attrs.bookmarks[${index}]`);
+        const bookmarkPath = `${path}.paragraph.attrs.bookmarks[${index}]`;
+        const opened = registerStart({
+          id: bookmark.id,
+          name: bookmark.name,
+          path: bookmarkPath,
+          paragraph: enclosingParagraph,
+          origin: "attr",
+        });
+        if (opened) {
+          openedAttrBookmarks.push({ id: bookmark.id, path: bookmarkPath });
+        }
       }
     }
 
@@ -131,39 +206,43 @@ const validateBookmarkBoundaryStructure = (
         if (trackedChanges.length > 1) {
           issues.push({
             path,
-            message: "Bookmark boundaries cannot carry multiple tracked-change parents.",
+            message: `Bookmark boundaries cannot carry multiple tracked-change parents (${enclosingParagraph}).`,
           });
         } else if (trackedChanges.length === 1 && !hasHyperlink) {
           issues.push({
             path,
-            message:
-              "Bookmark boundaries inside tracked changes require a hyperlink serialization parent.",
+            message: `Bookmark boundaries inside tracked changes require a hyperlink serialization parent (${enclosingParagraph}).`,
           });
         }
         if (attrs.type === "start") {
-          registerStart(attrs.id, path);
+          registerStart({
+            id: attrs.id,
+            name: attrs.name ?? null,
+            path,
+            paragraph: enclosingParagraph,
+            origin: "node",
+          });
         } else {
-          registerEnd(attrs.id, path);
+          registerEnd(attrs.id, path, enclosingParagraph);
         }
       }
     }
 
     // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
     node.forEach((child, _offset, index) => {
-      visit(child, `${path}.content[${index}]`);
+      visit(child, `${path}.content[${index}]`, enclosingParagraph);
     });
-    if (paragraphAttrs?.ok) {
-      for (const [index, bookmark] of (paragraphAttrs.value.bookmarks ?? []).entries()) {
-        registerEnd(bookmark.id, `${path}.paragraph.attrs.bookmarks[${index}]`);
-      }
+
+    for (const { id, path: bookmarkPath } of openedAttrBookmarks) {
+      registerEnd(id, bookmarkPath, enclosingParagraph);
     }
   };
 
-  visit(doc, "doc");
+  visit(doc, "doc", "the document root");
   for (const boundary of open.values()) {
     issues.push({
       path: boundary.path,
-      message: `Bookmark id ${boundary.id} has no matching end boundary.`,
+      message: `${describeBookmark(boundary.id, boundary.name)} has no matching end boundary (${boundary.paragraph}).`,
     });
   }
 };

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -22,11 +22,9 @@ import { createFolioAITextRangeHandle } from "./ai-edits/snapshot";
 import type {
   FolioAIBlock,
   FolioAIEditAppliedOperation,
-  FolioAIInlineFormatting,
   FolioAIEditOperation,
   FolioAIEditSkippedOperation,
   FolioAIEditSnapshot,
-  FolioAIBlockPreviewRun,
 } from "./ai-edits/types";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "./document-operations";
 import { pairFolioDocumentStories } from "./document-stories";
@@ -36,6 +34,7 @@ import {
   type FolioDocumentPrivacyOptions,
   type FolioDocumentPrivacyReport,
 } from "./docx/metadataPrivacy";
+import { inlineFormattingSegments } from "./compare/formatting";
 import {
   GenerateRedlineDocxOperationLimitError,
   MAX_GENERATED_REDLINE_OPERATIONS,
@@ -108,117 +107,6 @@ type BuildRedlineOperationsOptions = {
   nextOperationId: () => string;
 };
 
-type RedlineFormattingSegment = {
-  startOffset: number;
-  endOffset: number;
-  formatting: FolioAIInlineFormatting;
-};
-
-const changedSupportedFormatting = (
-  base: FolioAIBlockPreviewRun,
-  revised: FolioAIBlockPreviewRun,
-): FolioAIInlineFormatting => ({
-  ...(Boolean(base.bold) !== Boolean(revised.bold) && { bold: Boolean(revised.bold) }),
-  ...(Boolean(base.italic) !== Boolean(revised.italic) && { italic: Boolean(revised.italic) }),
-  ...(Boolean(base.underline) !== Boolean(revised.underline) && {
-    underline: Boolean(revised.underline),
-  }),
-});
-
-const sameInlineFormatting = (
-  left: FolioAIInlineFormatting,
-  right: FolioAIInlineFormatting,
-): boolean =>
-  left.bold === right.bold && left.italic === right.italic && left.underline === right.underline;
-
-const hasInlineFormatting = (formatting: FolioAIInlineFormatting): boolean =>
-  formatting.bold !== undefined ||
-  formatting.italic !== undefined ||
-  formatting.underline !== undefined;
-
-const previewRunsForBlock = (block: FolioAIBlock): readonly FolioAIBlockPreviewRun[] | null => {
-  const runs = block.previewRuns ?? [{ text: block.text }];
-  return runs.map(({ text }) => text).join("") === block.text ? runs : null;
-};
-
-const formattingSegments = (
-  baseBlock: FolioAIBlock,
-  revisedBlock: FolioAIBlock,
-): RedlineFormattingSegment[] => {
-  const baseRuns = previewRunsForBlock(baseBlock);
-  const revisedRuns = previewRunsForBlock(revisedBlock);
-  if (!baseRuns || !revisedRuns || baseBlock.text.length === 0) {
-    return [];
-  }
-
-  const segments: RedlineFormattingSegment[] = [];
-  let baseRunIndex = 0;
-  let revisedRunIndex = 0;
-  let baseRunOffset = 0;
-  let revisedRunOffset = 0;
-  let textOffset = 0;
-
-  while (baseRunIndex < baseRuns.length && revisedRunIndex < revisedRuns.length) {
-    const baseRun = baseRuns[baseRunIndex];
-    const revisedRun = revisedRuns[revisedRunIndex];
-    if (!baseRun || !revisedRun) {
-      break;
-    }
-    const length = Math.min(
-      baseRun.text.length - baseRunOffset,
-      revisedRun.text.length - revisedRunOffset,
-    );
-    if (length <= 0) {
-      if (baseRunOffset >= baseRun.text.length) {
-        baseRunIndex++;
-        baseRunOffset = 0;
-      }
-      if (revisedRunOffset >= revisedRun.text.length) {
-        revisedRunIndex++;
-        revisedRunOffset = 0;
-      }
-      continue;
-    }
-
-    const formatting = changedSupportedFormatting(baseRun, revisedRun);
-    if (hasInlineFormatting(formatting)) {
-      const previous = segments.at(-1);
-      if (
-        previous &&
-        previous.endOffset === textOffset &&
-        sameInlineFormatting(previous.formatting, formatting)
-      ) {
-        previous.endOffset += length;
-      } else {
-        if (segments.length >= MAX_GENERATED_REDLINE_OPERATIONS) {
-          throw new GenerateRedlineDocxOperationLimitError({
-            message: "The document comparison exceeds the generated operation limit.",
-          });
-        }
-        segments.push({
-          startOffset: textOffset,
-          endOffset: textOffset + length,
-          formatting,
-        });
-      }
-    }
-
-    textOffset += length;
-    baseRunOffset += length;
-    revisedRunOffset += length;
-    if (baseRunOffset >= baseRun.text.length) {
-      baseRunIndex++;
-      baseRunOffset = 0;
-    }
-    if (revisedRunOffset >= revisedRun.text.length) {
-      revisedRunIndex++;
-      revisedRunOffset = 0;
-    }
-  }
-
-  return segments;
-};
-
 type BuildFormattingRedlineOperationsOptions = {
   baseBlock: FolioAIBlock;
   revisedBlock: FolioAIBlock;
@@ -230,11 +118,18 @@ const buildFormattingRedlineOperations = ({
   revisedBlock,
   nextOperationId,
 }: BuildFormattingRedlineOperationsOptions): FolioAIEditOperation[] => {
-  const operations: FolioAIEditOperation[] = [];
-  for (const { startOffset, endOffset, formatting } of formattingSegments(
+  const segments = inlineFormattingSegments({
     baseBlock,
-    revisedBlock,
-  )) {
+    targetBlock: revisedBlock,
+    maxSegments: MAX_GENERATED_REDLINE_OPERATIONS,
+  });
+  if (segments === null) {
+    throw new GenerateRedlineDocxOperationLimitError({
+      message: "The document comparison exceeds the generated operation limit.",
+    });
+  }
+  const operations: FolioAIEditOperation[] = [];
+  for (const { startOffset, endOffset, formatting } of segments) {
     const range = createFolioAITextRangeHandle({
       blockId: baseBlock.id,
       text: baseBlock.text,


### PR DESCRIPTION
Adds `compareDocx(base, target, { author, timestamp })` to `@stll/folio-core`: a deterministic two-document compare that returns the base package carrying the tracked changes which turn it into the target, plus a JSON change list for callers that want the summary rather than the document.

## Contract

- `buffer`: the base `.docx` with ordinary revision marks. Accepting every change yields the target's content; rejecting every change yields the base's. `compareDocx` verifies this round trip before returning and fails with `CompareDocxRoundTripError` instead of returning a plausible-looking wrong redline.
- `changes`: discriminated union on `kind` (`insert`, `delete`, `replace`, `move`, `format`, `table-row-insert`, `table-row-delete`) with block ids, story, and before/after text.
- `unsupported`: stories the compare does not cover yet (header, footer, footnote, endnote), reported explicitly.
- Pure function of its arguments. `author` and `timestamp` are required so a caller cannot get an irreproducible package by omission; identical inputs give byte-identical output.

## How it works

Reuses the existing headless review path (`FolioDocxReviewer`, tracked-changes mode, `diffWordSegments`) rather than a second redline writer. The new part is alignment: segments (body text runs and tables) are paired by position, rows inside a paired table by text then position, cells by index; changed paragraphs are word-diffed at apply time; formatting-only differences become `formatRange` operations and are reported as `format`, never as delete plus insert of identical text. Identical blocks that disappear at one position and appear at another are reported as `move` (represented in the document as deletion and insertion).

## Determinism fixes in shared code

Three sources of nondeterminism had to be closed for the property to hold, each in the module that owned it: a `FolioRevisionStamp` (date plus id seed) threaded through the apply path so revision dates and ids do not come from the clock; paragraph ids for inserted paragraphs derived from the stamp when a transaction asks (the live editor keeps random ids); and ZIP entry dates restamped, since JSZip otherwise writes the current time into every rewritten part.

## Tests

`compare.property.test.ts` drives fast-check edit scripts (`scenario.ts`: insert, delete, replace words, move, format, table row insert/delete, cell edit) against fixture documents, so the true diff is known by construction, and asserts: accept-all equals target and reject-all equals base; compare(A, A) is empty; determinism (byte-identical buffers, deep-equal change lists); change count bounded by the script; formatting-only and move-only scripts are classified as such. The properties surfaced and fixed a cell-indexing bug in inserted rows, the ZIP-date leak, and two cross-container mis-pairings.

## Limitations (documented in `packages/core/src/compare/README.md`)

Main story only. Moves are reported, not represented, and need three or more words. Tables cannot be created or destroyed by a compare (differing table counts fail the self-check). Empty cells carry no block. Column operations read as cell changes. Numbering definitions are not compared.

## Also

`packages/core/scripts/compare.ts <base> <target> <out> [--json]` for manual runs; API reports updated, budgets unchanged; changeset (`@stll/folio-core` minor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic comparison of two DOCX documents, producing tracked changes, structured change details and unsupported-content reporting.
  - Added a command-line comparison tool with human-readable or JSON output.
  - Added table location metadata for AI edit blocks and revision stamps for reproducible document revisions.

- **Bug Fixes**
  - Improved handling and reporting of duplicate or unpaired bookmarks.

- **Documentation**
  - Added comparison usage guidance, result details, determinism behaviour and limitations.

- **Tests**
  - Added comprehensive coverage for comparison scenarios and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->