### PR TITLE
fix: mark a tracked row's cell content, not only the row

### DIFF
--- a/.changeset/quiet-rows-mark-cells.md
+++ b/.changeset/quiet-rows-mark-cells.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+---
+
+A tracked table-row insertion or deletion now marks the runs in its cells as
+well as the row, the way Word writes it, and resolves both halves together.

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -118,10 +118,37 @@ const firstBlockIdWithin = ({
   return blockId;
 };
 
+/** An enclosing table row whose structural revision also marked its runs. */
+type RowRevisionScope = {
+  /** Document position one past the row, where the scope ends. */
+  end: number;
+  /** The run revision the row's marker wrote (`insertion` for `w:trPr/w:ins`). */
+  kind: "insertion" | "deletion";
+  /** The row's own change, which the folded run marks belong to. */
+  change: FolioReviewChange;
+};
+
+/**
+ * Whether a run's revision inside a marked row is that row's own. Folio writes
+ * both halves under one revision id; Word mints a fresh `w:id` per element, so
+ * an author + timestamp match counts too. A third party's edit inside the row
+ * matches neither and keeps its own entry.
+ */
+const belongsToRowRevision = (
+  scope: RowRevisionScope,
+  revision: { id: number; author: string; date: string | null },
+): boolean =>
+  revision.id === scope.change.id ||
+  (revision.author === scope.change.author && revision.date === scope.change.date);
+
 /**
  * The tracked changes present in the body, read from inline marks and
  * structural node attributes. Runs of one inline revision within a block fold
  * into a single entry.
+ *
+ * A tracked row insertion or deletion marks the row AND every run in its
+ * cells, the way Word writes it. Both halves are one change, so the run marks
+ * fold into the row's entry rather than reporting a second time.
  */
 export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
   const insertionType = doc.type.schema.marks["insertion"];
@@ -129,9 +156,15 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
   const blockStarts = blockStartIdsFromDoc(doc);
   const grouped = new Map<string, FolioReviewChange>();
   const structuralChangeCellPositions = new Map<string, Set<number>>();
+  // Innermost enclosing marked row first: a table nested in a marked row can
+  // carry a marked row of its own.
+  const rowRevisionScopes: RowRevisionScope[] = [];
   let currentBlockId: string | null = null;
 
   doc.descendants((node, pos) => {
+    while (pos >= (rowRevisionScopes.at(-1)?.end ?? Number.POSITIVE_INFINITY)) {
+      rowRevisionScopes.pop();
+    }
     const nodeRevisionCarriers = getFolioNodeRevisionCarriers(node, pos);
     if (nodeRevisionCarriers.length > 0) {
       const blockId = node.isTextblock
@@ -168,13 +201,19 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
         const revisionId = marker.revisionId;
         const author = "author" in marker ? marker.author : undefined;
         const date = "date" in marker ? marker.date : undefined;
-        grouped.set(`row:${kind}:${revisionId}:${String(pos)}`, {
+        const change: FolioReviewChange = {
           id: revisionId,
           type: kind,
           author: typeof author === "string" ? author : "",
           date: typeof date === "string" ? date : null,
           text: node.textContent,
           blockId: firstBlockIdWithin({ node, nodePos: pos, blockStarts }),
+        };
+        grouped.set(`row:${kind}:${revisionId}:${String(pos)}`, change);
+        rowRevisionScopes.push({
+          end: pos + node.nodeSize,
+          kind: kind === "rowInserted" ? "insertion" : "deletion",
+          change,
         });
       }
     }
@@ -290,22 +329,24 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
         continue;
       }
       const revisionId = mark.attrs["revisionId"];
+      const author = mark.attrs["author"];
+      const date = mark.attrs["date"];
+      const revision = {
+        id: revisionId,
+        author: typeof author === "string" ? author : "",
+        date: typeof date === "string" ? date : null,
+      };
+      const rowScope = rowRevisionScopes.at(-1);
+      if (rowScope?.kind === kind && belongsToRowRevision(rowScope, revision)) {
+        continue;
+      }
       const key = `${currentBlockId ?? ""}:${kind}:${revisionId}`;
       const existing = grouped.get(key);
       if (existing) {
         existing.text += text;
         continue;
       }
-      const author = mark.attrs["author"];
-      const date = mark.attrs["date"];
-      grouped.set(key, {
-        id: revisionId,
-        type: kind,
-        author: typeof author === "string" ? author : "",
-        date: typeof date === "string" ? date : null,
-        text,
-        blockId: currentBlockId,
-      });
+      grouped.set(key, { ...revision, type: kind, text, blockId: currentBlockId });
     }
     return undefined;
   });

--- a/packages/core/src/ai-edits/table-row-column-mutations.ts
+++ b/packages/core/src/ai-edits/table-row-column-mutations.ts
@@ -1,4 +1,4 @@
-import type { Node as PMNode } from "prosemirror-model";
+import type { Mark, Node as PMNode } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import {
   columnIsHeader,
@@ -147,7 +147,89 @@ export const applyTableRowInsertion = ({
     : null;
   const row = insertion.rowType.create(rowAttrs, insertion.cells);
   tr.insert(insertion.rowPosition, populateTableRow(row, cellTexts));
+  if (revision) {
+    markTableRowContent({ tr, rowPosition: insertion.rowPosition, kind: "insertion", revision });
+  }
   return applied(tr, revision);
+};
+
+type MarkTableRowContentOptions = {
+  tr: Transaction;
+  rowPosition: number;
+  kind: "insertion" | "deletion";
+  revision: TableStructureRevision;
+};
+
+/**
+ * Mark the runs inside a row whose structural revision was just written.
+ *
+ * Word records a tracked row insertion or deletion twice: on the row
+ * (`w:trPr/w:ins` | `w:trPr/w:del`) AND around every run in its cells
+ * (`w:ins` | `w:del`, the latter with `w:delText`). A consumer that reads only
+ * run-level revisions — which is most of them — keeps a deleted row's text on
+ * accept and an inserted row's text on reject when the row marker stands
+ * alone, so the two must always be written together.
+ *
+ * Two kinds of run stay unmarked. A run that already carries a revision keeps
+ * it, because OOXML nests `w:ins`/`w:del` but the editable model holds one
+ * wrapper per run and overwriting would drop the earlier revision. A cell that
+ * spans into the row below survives the deletion — `removeRow` moves it down
+ * and shortens its span — so marking its text would delete content the
+ * accepted document must still hold.
+ */
+const markTableRowContent = ({
+  tr,
+  rowPosition,
+  kind,
+  revision,
+}: MarkTableRowContentOptions): void => {
+  const row = tr.doc.nodeAt(rowPosition);
+  const markType = tr.doc.type.schema.marks[kind];
+  if (!row || row.type.spec["tableRole"] !== "row" || !markType) {
+    return;
+  }
+  const mark = markType.create({
+    revisionId: revision.revisionId,
+    author: revision.author,
+    date: revision.date,
+    ...(revision.initials != null && { initials: revision.initials }),
+    ...(revision.provenance != null && { provenance: revision.provenance }),
+    ...(revision.suggestionId != null && { suggestionId: revision.suggestionId }),
+  });
+  const contentFrom = rowPosition + 1;
+  const markable: { from: number; to: number }[] = [];
+  let wholeRowMarkable = true;
+  row.descendants((node, offset) => {
+    if (isRowSpanningCell(node)) {
+      wholeRowMarkable = false;
+      return false;
+    }
+    if (!node.isInline) {
+      return true;
+    }
+    if (node.marks.some(isTrackedChangeMark)) {
+      wholeRowMarkable = false;
+      return false;
+    }
+    const from = contentFrom + offset;
+    markable.push({ from, to: from + node.nodeSize });
+    return false;
+  });
+  if (wholeRowMarkable) {
+    tr.addMark(contentFrom, rowPosition + row.nodeSize - 1, mark);
+    return;
+  }
+  for (const range of markable) {
+    tr.addMark(range.from, range.to, mark);
+  }
+};
+
+const isTrackedChangeMark = (mark: Mark): boolean =>
+  mark.type.name === "insertion" || mark.type.name === "deletion";
+
+const isRowSpanningCell = (node: PMNode): boolean => {
+  const role = node.type.spec["tableRole"];
+  return (role === "cell" || role === "header_cell") && Number(node.attrs["rowspan"]) > 1;
 };
 
 type ApplyTableColumnInsertionOptions = {
@@ -287,6 +369,7 @@ export const applyTableRowDeletion = ({
       return { type: "unsupported" };
     }
     tr.setNodeAttribute(rowPosition, "trDel", revision);
+    markTableRowContent({ tr, rowPosition, kind: "deletion", revision });
     markStructuralChange(tr);
     return applied(tr, revision);
   }

--- a/packages/core/src/ai-edits/table-row-revision-content.test.ts
+++ b/packages/core/src/ai-edits/table-row-revision-content.test.ts
@@ -1,0 +1,313 @@
+/**
+ * A tracked table-row insertion or deletion is marked twice: on the row
+ * (`w:trPr/w:ins` | `w:trPr/w:del`) AND around every run in its cells
+ * (`w:ins` | `w:del`, the latter carrying `w:delText`). Word writes both, and a
+ * consumer that reads only run-level revisions — which is most of them — keeps
+ * a deleted row's text on accept and an inserted row's text on reject when the
+ * row marker stands alone.
+ *
+ * The fixtures are built from the typed model rather than authored in Word, so
+ * the shape under test is spelled out in the test rather than hidden in bytes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import JSZip from "jszip";
+
+import { propertyConfig, propertyTestTimeout } from "../../../../test/property-testing";
+
+import { parseDocx } from "../docx/parser";
+import { createDocx } from "../docx/rezip";
+import type { Table, TableCell, TableRow, TrackedChangeInfo } from "../types/document";
+import { createEmptyDocument } from "../utils/createDocument";
+import { FolioDocxReviewer } from "./headless";
+
+const REVISION: TrackedChangeInfo = {
+  id: 41,
+  author: "Reviewer",
+  date: "2026-01-02T03:04:05Z",
+};
+
+type RowSpec = {
+  texts: readonly string[];
+  revision?: "insertion" | "deletion";
+};
+
+const cell = (text: string, revision: RowSpec["revision"]): TableCell => {
+  const run = { type: "run", content: [{ type: "text", text }] } as const;
+  return {
+    type: "tableCell",
+    content: [
+      {
+        type: "paragraph",
+        content: revision ? [{ type: revision, info: REVISION, content: [run] }] : [run],
+      },
+    ],
+  };
+};
+
+const row = ({ texts, revision }: RowSpec): TableRow => ({
+  type: "tableRow",
+  cells: texts.map((text) => cell(text, revision)),
+  ...(revision && {
+    structuralChange: {
+      type: revision === "insertion" ? "tableRowInsertion" : "tableRowDeletion",
+      info: REVISION,
+    },
+  }),
+});
+
+const buildTableDocx = (rows: readonly RowSpec[]): Promise<ArrayBuffer> => {
+  const template = createEmptyDocument();
+  const table: Table = { type: "table", rows: rows.map(row) };
+  return createDocx({
+    ...template,
+    package: {
+      ...template.package,
+      document: { ...template.package.document, content: [table] },
+    },
+  });
+};
+
+const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const entry = (await JSZip.loadAsync(buffer)).file("word/document.xml");
+  if (!entry) {
+    throw new Error("expected word/document.xml");
+  }
+  return entry.async("string");
+};
+
+const tableRows = async (buffer: ArrayBuffer): Promise<TableRow[]> => {
+  const parsed = await parseDocx(buffer, { detectVariables: false, preloadFonts: false });
+  const table = parsed.package.document.content.at(0);
+  if (table?.type !== "table") {
+    throw new Error("expected a table");
+  }
+  return table.rows;
+};
+
+const rowTexts = (rows: readonly TableRow[]): string[][] =>
+  rows.map((tableRow) =>
+    tableRow.cells.map((tableCell) =>
+      tableCell.content
+        .map((block) => (block.type === "paragraph" ? blockText(block) : ""))
+        .join(""),
+    ),
+  );
+
+const blockText = (paragraph: { content?: unknown[] }): string => {
+  let text = "";
+  const visit = (items: readonly unknown[]): void => {
+    for (const item of items) {
+      if (typeof item !== "object" || item === null) {
+        continue;
+      }
+      const node = item as { type?: string; text?: string; content?: unknown[] };
+      if (node.type === "text" && typeof node.text === "string") {
+        text += node.text;
+        continue;
+      }
+      if (Array.isArray(node.content)) {
+        visit(node.content);
+      }
+    }
+  };
+  visit(paragraph.content ?? []);
+  return text;
+};
+
+describe("a Word-style tracked row carries its cell content with it", () => {
+  test("an inserted row accepts to the row and rejects to nothing", async () => {
+    const buffer = await buildTableDocx([
+      { texts: ["Kept"] },
+      { texts: ["Added"], revision: "insertion" },
+    ]);
+
+    const accepting = await FolioDocxReviewer.fromBuffer(buffer);
+    accepting.acceptAll();
+    const accepted = await accepting.toBuffer();
+    expect(rowTexts(await tableRows(accepted))).toEqual([["Kept"], ["Added"]]);
+    expect(await documentXml(accepted)).not.toContain("<w:ins ");
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(buffer);
+    rejecting.rejectAll();
+    const rejected = await rejecting.toBuffer();
+    expect(rowTexts(await tableRows(rejected))).toEqual([["Kept"]]);
+    expect(await documentXml(rejected)).not.toContain("<w:ins ");
+  });
+
+  test("a deleted row accepts to nothing and rejects to the row", async () => {
+    const buffer = await buildTableDocx([
+      { texts: ["Kept"] },
+      { texts: ["Removed"], revision: "deletion" },
+    ]);
+
+    const accepting = await FolioDocxReviewer.fromBuffer(buffer);
+    accepting.acceptAll();
+    const accepted = await accepting.toBuffer();
+    expect(rowTexts(await tableRows(accepted))).toEqual([["Kept"]]);
+    expect(await documentXml(accepted)).not.toContain("<w:del ");
+
+    const rejecting = await FolioDocxReviewer.fromBuffer(buffer);
+    rejecting.rejectAll();
+    const rejected = await rejecting.toBuffer();
+    expect(rowTexts(await tableRows(rejected))).toEqual([["Kept"], ["Removed"]]);
+    const rejectedXml = await documentXml(rejected);
+    expect(rejectedXml).not.toContain("<w:del ");
+    expect(rejectedXml).not.toContain("<w:delText");
+  });
+
+  test("the row marker and its run marks are one change, not two", async () => {
+    for (const revision of ["insertion", "deletion"] as const) {
+      const reviewer = await FolioDocxReviewer.fromBuffer(
+        await buildTableDocx([{ texts: ["Kept"] }, { texts: ["Moved"], revision }]),
+      );
+      expect(reviewer.getChanges().map(({ type }) => type)).toEqual([
+        revision === "insertion" ? "rowInserted" : "rowDeleted",
+      ]);
+    }
+  });
+
+  test("serializing a tracked row is a byte fixed point", async () => {
+    for (const revision of ["insertion", "deletion"] as const) {
+      const source = await buildTableDocx([{ texts: ["Kept"] }, { texts: ["Marked"], revision }]);
+      const once = await (await FolioDocxReviewer.fromBuffer(source)).toBuffer();
+      const twice = await (await FolioDocxReviewer.fromBuffer(once)).toBuffer();
+      expect(await documentXml(twice)).toBe(await documentXml(once));
+    }
+  });
+});
+
+describe("folio writes both halves of a row revision", () => {
+  const findRowBlock = async (reviewer: FolioDocxReviewer, text: string): Promise<string> => {
+    const block = reviewer.snapshot().blocks.find((candidate) => candidate.text === text);
+    if (!block) {
+      throw new Error(`expected a block reading "${text}"`);
+    }
+    return block.id;
+  };
+
+  test("a tracked row deletion marks the row and strikes its runs", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await buildTableDocx([{ texts: ["Alpha"] }, { texts: ["Beta"] }]),
+      { author: "Reviewer" },
+    );
+    reviewer.applyOperations([
+      { id: "delete-row", type: "deleteTableRow", blockId: await findRowBlock(reviewer, "Beta") },
+    ]);
+
+    const xml = await documentXml(await reviewer.toBuffer());
+    expect(xml).toContain("<w:trPr>");
+    expect(xml).toContain("<w:delText");
+    expect(xml).toContain("<w:del ");
+  });
+
+  test("a tracked row insertion marks the row and its runs", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await buildTableDocx([{ texts: ["Alpha"] }]),
+      { author: "Reviewer" },
+    );
+    reviewer.applyOperations([
+      {
+        id: "insert-row",
+        type: "insertTableRow",
+        blockId: await findRowBlock(reviewer, "Alpha"),
+        cellTexts: ["Gamma"],
+      },
+    ]);
+
+    const xml = await documentXml(await reviewer.toBuffer());
+    expect(xml).toContain("<w:ins ");
+    // The inserted run is inside the row, not only on the row marker.
+    expect(/<w:ins [^>]*>\s*<w:r>/u.test(xml)).toBe(true);
+  });
+
+  test("resolving one revision clears the row marker and the run marks together", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await buildTableDocx([{ texts: ["Alpha"] }, { texts: ["Beta"] }]),
+      { author: "Reviewer" },
+    );
+    reviewer.applyOperations([
+      { id: "delete-row", type: "deleteTableRow", blockId: await findRowBlock(reviewer, "Beta") },
+    ]);
+    const change = reviewer.getChanges().at(0);
+    if (!change) {
+      throw new Error("expected a pending row deletion");
+    }
+
+    expect(reviewer.rejectChange(change)).toBe(true);
+    expect(reviewer.getChanges()).toEqual([]);
+    const xml = await documentXml(await reviewer.toBuffer());
+    expect(xml).not.toContain("<w:del ");
+    expect(xml).not.toContain("<w:delText");
+  });
+});
+
+describe("row insert/delete round trips through the reviewed views", () => {
+  const cellWord = fc.stringMatching(/^[A-Za-z]{2,8}$/u);
+
+  /**
+   * The reviewed view prefixes each block with its stable id, which is derived
+   * from content and position and so differs between two reviewers holding the
+   * same text. The comparison is about the text the views resolve to.
+   */
+  const storyText = (reviewer: FolioDocxReviewer, view: "original" | "final"): string => {
+    const story = reviewer.readReviewedStory({ view });
+    if (!story) {
+      throw new Error("expected the main story");
+    }
+    return story.text.replaceAll(/^\[[^\]]+\]\s?/gmu, "");
+  };
+
+  test(
+    "the final view is the target and the original view is the base",
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(fc.array(cellWord, { minLength: 1, maxLength: 3 }), {
+            minLength: 1,
+            maxLength: 4,
+          }),
+          fc.constantFrom("insertTableRow" as const, "deleteTableRow" as const),
+          fc.nat(),
+          fc.array(cellWord, { minLength: 1, maxLength: 3 }),
+          async (grid, type, selector, cellTexts) => {
+            // A ragged grid is not a table any consumer would write; pad every
+            // row to the widest one so the fixture is a real rectangle.
+            const width = Math.max(...grid.map((cells) => cells.length));
+            const rows = grid.map((cells) => ({
+              texts: [...cells, ...Array.from({ length: width - cells.length }, () => "pad")],
+            }));
+            const buffer = await buildTableDocx(rows);
+
+            const base = await FolioDocxReviewer.fromBuffer(buffer, { author: "Reviewer" });
+            const blocks = base.snapshot().blocks;
+            if (blocks.length === 0) {
+              return;
+            }
+            const blockId = blocks[selector % blocks.length]!.id;
+            const operation =
+              type === "insertTableRow"
+                ? { id: "row", type, blockId, cellTexts }
+                : { id: "row", type, blockId };
+
+            const direct = await FolioDocxReviewer.fromBuffer(buffer, { author: "Reviewer" });
+            if (direct.applyOperations([operation], { mode: "direct" }).applied.length === 0) {
+              return;
+            }
+
+            const tracked = await FolioDocxReviewer.fromBuffer(buffer, { author: "Reviewer" });
+            if (tracked.applyOperations([operation]).applied.length === 0) {
+              return;
+            }
+
+            expect(storyText(tracked, "final")).toBe(storyText(direct, "final"));
+            expect(storyText(tracked, "original")).toBe(storyText(base, "final"));
+          },
+        ),
+        propertyConfig({ numRuns: 40 }),
+      );
+    },
+    propertyTestTimeout(30_000),
+  );
+});

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -4,7 +4,7 @@
  * PM commands for adding/removing comments and accepting/rejecting tracked changes.
  */
 
-import type { Mark, Node as PMNode } from "prosemirror-model";
+import type { Mark, MarkType, Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 import { removeRow, TableMap } from "prosemirror-tables";
 
@@ -328,6 +328,15 @@ function resolveChange(
         }
         if (op.action === "clear") {
           tr.setNodeAttribute(mappedPos, op.attrName, null);
+          // The row keeps its content, so the run-level half of the same
+          // revision has to go with the row attribute: `keepType` is exactly
+          // the mark kind whose row marker resolves by clearing.
+          clearTableRowContentMarks({
+            tr,
+            rowPos: mappedPos,
+            markType: keepType,
+            revision: op.revision,
+          });
           resolvedTableRowStructure = true;
           continue;
         }
@@ -451,10 +460,13 @@ type TableRowStructuralOp = {
   rowPos: number;
   attrName: "trIns" | "trDel";
   action: "clear" | "remove";
+  revision: TableRowRevisionAttr;
 };
 
 type TableRowRevisionAttr = {
   revisionId: number;
+  author?: string;
+  date?: string | null;
 };
 
 type TableCellStructuralOp =
@@ -506,6 +518,7 @@ function collectTableRowStructuralOp(
       rowPos,
       attrName,
       action: keepsRow ? "clear" : "remove",
+      revision: marker,
     };
   }
   return null;
@@ -518,6 +531,67 @@ function isTableRowRevisionAttr(value: unknown): value is TableRowRevisionAttr {
     "revisionId" in value &&
     typeof value.revisionId === "number"
   );
+}
+
+/**
+ * Whether an inline revision mark inside a row belongs to that row's own
+ * structural revision. Folio writes both halves under one id; Word mints a
+ * fresh `w:id` per element, so an author + timestamp match counts too. A third
+ * party's edit inside the same row matches neither and survives untouched.
+ */
+function markBelongsToRowRevision(mark: Mark, revision: TableRowRevisionAttr): boolean {
+  if (mark.attrs["revisionId"] === revision.revisionId) {
+    return true;
+  }
+  return (
+    revision.author !== undefined &&
+    mark.attrs["author"] === revision.author &&
+    (mark.attrs["date"] ?? null) === (revision.date ?? null)
+  );
+}
+
+type ClearTableRowContentMarksOptions = {
+  tr: Transaction;
+  rowPos: number;
+  markType: MarkType | undefined;
+  revision: TableRowRevisionAttr;
+};
+
+/**
+ * Clear the run-level revision marks a row's structural revision wrote.
+ *
+ * A tracked row insertion or deletion is marked twice — on the row and around
+ * every run in its cells — so resolving one half and leaving the other would
+ * hand back a row whose text still reads as inserted (or struck through) after
+ * the change was accepted. Both halves resolve in the caller's transaction.
+ */
+function clearTableRowContentMarks({
+  tr,
+  rowPos,
+  markType,
+  revision,
+}: ClearTableRowContentMarksOptions): void {
+  const row = tr.doc.nodeAt(rowPos);
+  if (!row || !markType) {
+    return;
+  }
+  const contentFrom = rowPos + 1;
+  const removals: { from: number; to: number; mark: Mark }[] = [];
+  row.descendants((node, offset) => {
+    if (!node.isInline) {
+      return true;
+    }
+    for (const mark of node.marks) {
+      if (mark.type === markType && markBelongsToRowRevision(mark, revision)) {
+        const from = contentFrom + offset;
+        removals.push({ from, to: from + node.nodeSize, mark });
+      }
+    }
+    return false;
+  });
+  for (const removal of removals) {
+    tr.removeMark(removal.from, removal.to, removal.mark);
+  }
 }
 
 function collectTableCellStructuralOps(

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
@@ -14,7 +14,7 @@
 import type { EditorState } from "prosemirror-state";
 
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
-import type { Mark } from "prosemirror-model";
+import type { Mark, MarkType } from "prosemirror-model";
 import { expectRunPropertyChangeMarkAttrs } from "../attrs";
 
 /**
@@ -131,6 +131,42 @@ const EMPTY_RESULT: TrackedChangesResult = {
   commentToRevision: new Map(),
 };
 
+/** An enclosing table row whose structural revision also marked its runs. */
+type RowRevisionScope = {
+  /** Document position one past the row, where the scope ends. */
+  end: number;
+  /** The run mark type the row's revision wrote (`insertion` for `w:trPr/w:ins`). */
+  markType: MarkType | undefined;
+  /** The row's own card, which absorbs the run marks' revision ids. */
+  entry: TrackedChangeEntry;
+};
+
+/**
+ * Fold a run's revision mark into the enclosing row's card when both halves
+ * are the same change. Folio writes both under one revision id; Word mints a
+ * fresh `w:id` per element, so an author + timestamp match counts too. Returns
+ * false for a third party's edit inside the row, which keeps its own card.
+ */
+const foldIntoRowRevision = (scope: RowRevisionScope | undefined, mark: Mark): boolean => {
+  if (!scope || mark.type !== scope.markType) {
+    return false;
+  }
+  const revisionId = mark.attrs["revisionId"] as number;
+  const sameRevision =
+    revisionId === scope.entry.revisionId ||
+    ((mark.attrs["author"] as string) === scope.entry.author &&
+      (mark.attrs["date"] as string | undefined) === scope.entry.date);
+  if (!sameRevision) {
+    return false;
+  }
+  if (revisionId !== scope.entry.revisionId) {
+    const ids = new Set(scope.entry.coalescedRevisionIds ?? []);
+    ids.add(revisionId);
+    scope.entry.coalescedRevisionIds = [...ids];
+  }
+  return true;
+};
+
 /**
  * Walk the PM doc and extract every tracked change as a flat list of
  * `TrackedChangeEntry` plus a comment→revision overlap map. Adjacent
@@ -157,7 +193,16 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
   const raw: TrackedChangeEntry[] = [];
   const commentToRevision = new Map<number, number>();
   const commentMetadata = new Map<number, { revisions: Set<number>; hasCleanText: boolean }>();
+  // A tracked row insertion / deletion is marked on the row AND around every
+  // run in its cells, the way Word writes it. Both halves are one change, so
+  // the run marks fold into the row's card instead of listing a second time.
+  // The stack tracks the innermost enclosing marked row: a table nested in a
+  // marked row can carry a marked row of its own.
+  const rowRevisionScopes: RowRevisionScope[] = [];
   doc.descendants((node, pos) => {
+    while (pos >= (rowRevisionScopes.at(-1)?.end ?? Number.POSITIVE_INFINITY)) {
+      rowRevisionScopes.pop();
+    }
     // Structural revisions on the paragraph mark itself
     // (`<w:pPr><w:rPr><w:ins/>` / `<w:del/>`). Surface as their own entry
     // types so the sidebar can label and dispatch them correctly.
@@ -229,7 +274,7 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
         date: string | null;
       } | null;
       if (trIns) {
-        raw.push({
+        const entry: TrackedChangeEntry = {
           type: "rowInserted",
           text: node.textContent || "",
           author: trIns.author || "",
@@ -237,10 +282,12 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
           from: pos,
           to: pos + node.nodeSize,
           revisionId: trIns.revisionId,
-        });
+        };
+        raw.push(entry);
+        rowRevisionScopes.push({ end: pos + node.nodeSize, markType: insertionType, entry });
       }
       if (trDel) {
-        raw.push({
+        const entry: TrackedChangeEntry = {
           type: "rowDeleted",
           text: node.textContent || "",
           author: trDel.author || "",
@@ -248,7 +295,9 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
           from: pos,
           to: pos + node.nodeSize,
           revisionId: trDel.revisionId,
-        });
+        };
+        raw.push(entry);
+        rowRevisionScopes.push({ end: pos + node.nodeSize, markType: deletionType, entry });
       }
       const trPrChange = node.attrs["trPrChange"] as Array<{
         info: { id: number; author: string; date?: string };
@@ -407,13 +456,15 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
           rowRevIds.push(v.revisionId);
         });
         if (allShare) {
-          // Exclude text inside deletion marks: the empty-vs-content switch
-          // downstream compares `text.trim().length` to decide whether to
-          // surface "Inserted table" or defer to an inline card. Deletion-
-          // marked text is still rendered in the doc but represents removed
-          // content, so it shouldn't count as "the table has content".
+          // For an INSERTED table, exclude text inside deletion marks: the
+          // empty-vs-content switch downstream compares `text.trim().length`
+          // to decide whether to surface "Inserted table" or defer to an
+          // inline card, and deletion-marked text is still rendered in the doc
+          // but represents removed content. A DELETED table carries deletion
+          // marks on every run by construction (the row revision marks its
+          // cells too), so the same filter would empty its card.
           let visibleText = "";
-          if (deletionType) {
+          if (deletionType && sharedAttr === "trIns") {
             node.descendants((child) => {
               if (child.isText && !child.marks.some((m) => m.type === deletionType)) {
                 visibleText += child.text || "";
@@ -465,6 +516,10 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
         continue;
       }
       if (mark.type === insertionType || mark.type === deletionType) {
+        tcMark = mark;
+        if (foldIntoRowRevision(rowRevisionScopes.at(-1), mark)) {
+          continue;
+        }
         raw.push({
           type: mark.type === insertionType ? "insertion" : "deletion",
           text: inlineText,
@@ -474,7 +529,6 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
           to: pos + node.nodeSize,
           revisionId: mark.attrs["revisionId"] as number,
         });
-        tcMark = mark;
       }
     }
     if (commentType) {


### PR DESCRIPTION
## The defect

A tracked table-row insertion or deletion was written as `w:trPr/w:ins` or
`w:trPr/w:del` and nothing else: the runs in the row's cells stayed unmarked.
Word marks both the row property and every run inside the cells (`w:ins` /
`w:del` around the runs, `w:delText` for deleted text).

## The symptom

A consumer that reads only run-level revisions — which is most of them — keeps
a deleted row's text when it accepts all changes, and an inserted row's text
when it rejects all changes. The redline reads correctly in Word and resolves
to the wrong document anywhere else.

## The fix

The row-level revision and the content marks are now written and resolved
together.

- `applyTableRowInsertion` / `applyTableRowDeletion` stamp the row's runs with
  the same revision they write on the row. Two kinds of run stay unmarked: one
  that already carries a revision, because OOXML nests `w:ins`/`w:del` but the
  editable model holds one wrapper per run and overwriting would drop the
  earlier revision; and a cell that spans into the row below, because
  `removeRow` moves it down and shortens its span rather than deleting it, so
  marking its text would delete content the accepted document must still hold.
- `resolveChange` clears the run marks alongside the row attribute in the same
  transaction, so `acceptAllChanges`, `rejectAllChanges`, and a single
  accept/reject all leave a fully resolved row. A run's mark counts as the
  row's own when it shares the revision id (how folio writes it) or the author
  and timestamp (how Word writes it, minting a fresh `w:id` per element); a
  third party's edit inside the same row matches neither and survives.
- Both change-list readers (`getTrackedChangesFromDoc` for the headless
  reviewer, `extractTrackedChanges` for the sidebar) fold the run marks into
  the row's entry, so one change is reported once rather than once per run.

The serializer already emitted run-level `w:ins`/`w:del`/`w:delText` from those
marks, and the parser already read a row marker and run markers independently;
neither needed a change beyond the double-counting fold.

## Tests

`packages/core/src/ai-edits/table-row-revision-content.test.ts`, over fixtures
built from the typed model rather than authored in Word:

- a Word-style inserted row accepts to the row with no revision markup left and
  rejects to nothing; a deleted row accepts to nothing and rejects to the row
  with no `w:del` or `w:delText` left;
- the row marker and its run marks report as one change, not two;
- serializing a tracked row is a byte fixed point on `word/document.xml`;
- a folio-authored row deletion writes `w:trPr` and `w:delText`, a row
  insertion writes `w:ins` around a run inside the row, and resolving one
  revision clears both halves;
- a property over generated tables: for any row insert or delete, the
  reviewer's `final` view equals the same operation applied directly and its
  `original` view equals the base document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tracked table-row insertions and deletions now consistently mark the row’s cell content, matching Microsoft Word behaviour.
  - Row-level and text-level revision markers are combined into a single tracked change.
  - Accepting or rejecting a row revision now clears its associated text markers correctly.
  - Improved handling of tracked changes when importing and exporting documents.

- **Tests**
  - Added coverage for row revision acceptance, rejection, serialisation, and final document views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->