### PR TITLE
fix: keep every package part a save does not model

### DIFF
--- a/.changeset/full-repack-keeps-parts.md
+++ b/.changeset/full-repack-keeps-parts.md
@@ -1,0 +1,10 @@
+---
+"@stll/folio-core": patch
+---
+
+A save now carries every part of the source package byte for byte — embeddings,
+media, custom XML, fonts, macro projects, ActiveX controls, parts folio does not
+model — and a macro-enabled document keeps its main-part content type. The only
+entry a save refuses is one whose path would escape the package, and its
+relationships and content-type entries leave with it, so a saved package never
+references a part it no longer holds.

--- a/packages/core/src/docx/__tests__/repack-package-parts.test.ts
+++ b/packages/core/src/docx/__tests__/repack-package-parts.test.ts
@@ -1,0 +1,341 @@
+/**
+ * The full repack must hand back every part of the source package it did not
+ * model, byte for byte — macro projects and ActiveX controls included, because
+ * the document belongs to its author — and must never leave a relationship or
+ * content-type override naming a part the output does not hold.
+ *
+ * The one thing a save refuses is an entry PATH that would escape the package,
+ * which is a property of the archive rather than of the document.
+ *
+ * The fixtures are built here rather than checked in: a package with an
+ * embedded workbook and a binary media part is three files and a relationship,
+ * and spelling it out makes the shape under test readable.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import JSZip from "jszip";
+
+import { propertyConfig, propertyTestTimeout } from "../../../../../test/property-testing";
+
+import {
+  isUnsafePackagePath,
+  reconcilePackageReferences,
+  removeUnsafeEntries,
+} from "../packageParts";
+import { parseDocx } from "../parser";
+import { repackDocx } from "../rezip";
+import { extractFile, getFileList, unzipDocx } from "../unzip";
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const RELATIONSHIP_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/relationships";
+const OFFICE_RELATIONSHIP = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+const DOCUMENT_XML = `${XML_DECL}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="${OFFICE_RELATIONSHIP}">
+  <w:body>
+    <w:p w14:paraId="60000001"><w:r><w:t>Hello world</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const STYLES_XML = `${XML_DECL}<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style></w:styles>`;
+
+const CORE_PROPS_XML = `${XML_DECL}<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dc:title>fx</dc:title><dcterms:modified xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00.000Z</dcterms:modified></cp:coreProperties>`;
+
+const PACKAGE_RELS = `${XML_DECL}<Relationships xmlns="${RELATIONSHIP_NAMESPACE}"><Relationship Id="rId1" Type="${OFFICE_RELATIONSHIP}/officeDocument" Target="word/document.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/></Relationships>`;
+
+/** One extra part to hang off `word/document.xml.rels`. */
+type ExtraPart = {
+  /** Path inside the package. */
+  path: string;
+  /** Bytes the repack must hand back unchanged. */
+  bytes: Uint8Array;
+  /** Relationship type URI, or null for a part nothing references. */
+  relationshipType: string | null;
+  /** `<Override>` content type, or null when a `<Default>` extension covers it. */
+  contentType: string | null;
+  /** Extension for a `<Default>` declaration, when the part needs one. */
+  defaultExtension?: { extension: string; contentType: string };
+};
+
+const EMBEDDED_WORKBOOK: ExtraPart = {
+  path: "word/embeddings/Microsoft_Excel_Worksheet.xlsx",
+  bytes: new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00, 0x11, 0x22, 0x33]),
+  relationshipType: `${OFFICE_RELATIONSHIP}/package`,
+  contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+};
+
+const OLE_MEDIA: ExtraPart = {
+  path: "word/media/image9.bin",
+  bytes: new Uint8Array([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
+  relationshipType: `${OFFICE_RELATIONSHIP}/image`,
+  contentType: null,
+  defaultExtension: {
+    extension: "bin",
+    contentType: "application/vnd.openxmlformats-officedocument.oleObject",
+  },
+};
+
+const DOCX_MAIN_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+/** A `.docm`'s main part. Word decides a document is macro-enabled by this. */
+const DOCM_MAIN_CONTENT_TYPE = "application/vnd.ms-word.document.macroEnabled.main+xml";
+
+type BuildPackageOptions = {
+  extras?: readonly ExtraPart[];
+  documentContentType?: string;
+};
+
+const buildPackage = async ({
+  extras = [],
+  documentContentType = DOCX_MAIN_CONTENT_TYPE,
+}: BuildPackageOptions = {}): Promise<ArrayBuffer> => {
+  const defaults = new Map<string, string>([
+    ["rels", "application/vnd.openxmlformats-package.relationships+xml"],
+    ["xml", "application/xml"],
+  ]);
+  const overrides: string[] = [
+    `<Override PartName="/word/document.xml" ContentType="${documentContentType}"/>`,
+    `<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>`,
+    `<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>`,
+  ];
+  const relationships: string[] = [];
+
+  extras.forEach((extra, index) => {
+    if (extra.defaultExtension) {
+      defaults.set(extra.defaultExtension.extension, extra.defaultExtension.contentType);
+    }
+    if (extra.contentType) {
+      overrides.push(`<Override PartName="/${extra.path}" ContentType="${extra.contentType}"/>`);
+    }
+    if (extra.relationshipType) {
+      relationships.push(
+        `<Relationship Id="rIdExtra${String(index)}" Type="${extra.relationshipType}" Target="${extra.path.replace(/^word\//u, "")}"/>`,
+      );
+    }
+  });
+
+  const contentTypes = `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">${[
+    ...defaults,
+  ]
+    .map(
+      ([extension, contentType]) =>
+        `<Default Extension="${extension}" ContentType="${contentType}"/>`,
+    )
+    .join("")}${overrides.join("")}</Types>`;
+
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("_rels/.rels", PACKAGE_RELS);
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML_DECL}<Relationships xmlns="${RELATIONSHIP_NAMESPACE}">${relationships.join("")}</Relationships>`,
+  );
+  zip.file("word/document.xml", DOCUMENT_XML);
+  zip.file("word/styles.xml", STYLES_XML);
+  zip.file("docProps/core.xml", CORE_PROPS_XML);
+  for (const extra of extras) {
+    zip.file(extra.path, extra.bytes);
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+};
+
+const repack = async (buffer: ArrayBuffer): Promise<JSZip> => {
+  const document = await parseDocx(buffer, { detectVariables: false, preloadFonts: false });
+  return JSZip.loadAsync(await repackDocx(document, { updateModifiedDate: false }));
+};
+
+const partBytes = async (zip: JSZip, path: string): Promise<Uint8Array | null> => {
+  const entry = zip.file(path);
+  return entry ? entry.async("uint8array") : null;
+};
+
+const MACRO_PROJECT: ExtraPart = {
+  path: "word/vbaProject.bin",
+  bytes: new Uint8Array([0xd0, 0xcf, 0x11, 0xe0, 0x5a, 0x5a, 0x5a, 0x5a]),
+  relationshipType: "http://schemas.microsoft.com/office/2006/relationships/vbaProject",
+  contentType: "application/vnd.ms-office.vbaProject",
+};
+
+const ACTIVEX_CONTROL: ExtraPart = {
+  path: "word/activeX/activeX1.xml",
+  bytes: new TextEncoder().encode('<ax:ocx xmlns:ax="urn:activex" ax:classid="{0002}"/>'),
+  relationshipType: `${OFFICE_RELATIONSHIP}/control`,
+  contentType: "application/vnd.ms-office.activeX+xml",
+};
+
+describe("the repack carries the parts the model does not represent", () => {
+  test("an embedded workbook and a binary media part survive byte for byte", async () => {
+    const extras = [EMBEDDED_WORKBOOK, OLE_MEDIA];
+    const output = await repack(await buildPackage({ extras }));
+
+    for (const extra of extras) {
+      expect(await partBytes(output, extra.path)).toEqual(extra.bytes);
+    }
+
+    const rels = await output.file("word/_rels/document.xml.rels")?.async("text");
+    expect(rels).toContain('Target="embeddings/Microsoft_Excel_Worksheet.xlsx"');
+    expect(rels).toContain('Target="media/image9.bin"');
+
+    const contentTypes = await output.file("[Content_Types].xml")?.async("text");
+    expect(contentTypes).toContain('PartName="/word/embeddings/Microsoft_Excel_Worksheet.xlsx"');
+    expect(contentTypes).toContain('Extension="bin"');
+  });
+
+  test("the output holds every part the source package declares", async () => {
+    const output = await repack(
+      await buildPackage({
+        extras: [EMBEDDED_WORKBOOK, OLE_MEDIA, MACRO_PROJECT, ACTIVEX_CONTROL],
+      }),
+    );
+
+    // Reconciliation reports exactly the declarations the package cannot
+    // satisfy, so an empty repair is "every declared part is here".
+    expect(await reconcilePackageReferences(output, 6)).toEqual({
+      danglingRelationships: [],
+      danglingOverrides: [],
+    });
+  });
+
+  test("a macro project and an ActiveX control come back untouched", async () => {
+    const extras = [MACRO_PROJECT, ACTIVEX_CONTROL];
+    const output = await repack(await buildPackage({ extras }));
+
+    for (const extra of extras) {
+      expect(await partBytes(output, extra.path)).toEqual(extra.bytes);
+    }
+
+    const rels = await output.file("word/_rels/document.xml.rels")?.async("text");
+    expect(rels).toContain('Target="vbaProject.bin"');
+    expect(rels).toContain('Target="activeX/activeX1.xml"');
+
+    const contentTypes = await output.file("[Content_Types].xml")?.async("text");
+    expect(contentTypes).toContain('PartName="/word/vbaProject.bin"');
+    expect(contentTypes).toContain('PartName="/word/activeX/activeX1.xml"');
+  });
+
+  test("a macro-enabled document stays macro-enabled", async () => {
+    const output = await repack(
+      await buildPackage({
+        extras: [MACRO_PROJECT],
+        documentContentType: DOCM_MAIN_CONTENT_TYPE,
+      }),
+    );
+
+    const contentTypes = await output.file("[Content_Types].xml")?.async("text");
+    expect(contentTypes).toContain(DOCM_MAIN_CONTENT_TYPE);
+    expect(contentTypes).not.toContain(DOCX_MAIN_CONTENT_TYPE);
+  });
+});
+
+describe("folio reads document content, it does not interpret it", () => {
+  test("macro, ActiveX and OLE parts are never decoded into the model", async () => {
+    const buffer = await buildPackage({
+      extras: [MACRO_PROJECT, ACTIVEX_CONTROL, EMBEDDED_WORKBOOK, OLE_MEDIA],
+    });
+    const content = await unzipDocx(buffer);
+
+    for (const extra of [MACRO_PROJECT, ACTIVEX_CONTROL, EMBEDDED_WORKBOOK, OLE_MEDIA]) {
+      expect(content.allXml.has(extra.path)).toBe(false);
+      expect(content.media.has(extra.path)).toBe(false);
+      expect(await extractFile(content, extra.path)).toBeNull();
+      expect(getFileList(content)).not.toContain(extra.path);
+    }
+
+    // The archive still holds them, byte for byte, for the save path to carry.
+    expect(await partBytes(content.originalZip, MACRO_PROJECT.path)).toEqual(MACRO_PROJECT.bytes);
+  });
+});
+
+describe("a path that would escape the package is refused", () => {
+  test.each(["../outside.xml", "/absolute.xml", "word\\backslash.xml", "word/../../escape.bin"])(
+    "%s is unsafe",
+    (path) => {
+      expect(isUnsafePackagePath(path)).toBe(true);
+    },
+  );
+
+  test.each(["word/document.xml", "[Content_Types].xml", "word/embeddings/book.xlsx"])(
+    "%s is safe",
+    (path) => {
+      expect(isUnsafePackagePath(path)).toBe(false);
+    },
+  );
+
+  test("an escaping entry leaves with its relationship and its override", async () => {
+    const zip = await JSZip.loadAsync(await buildPackage({ extras: [EMBEDDED_WORKBOOK] }));
+    zip.file("../escape.bin", new Uint8Array([1, 2, 3]));
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML_DECL}<Relationships xmlns="${RELATIONSHIP_NAMESPACE}"><Relationship Id="rIdEscape" Type="${OFFICE_RELATIONSHIP}/package" Target="../../escape.bin"/></Relationships>`,
+    );
+
+    removeUnsafeEntries(zip);
+    expect(zip.file("../escape.bin")).toBeNull();
+    expect(zip.file("word/embeddings/Microsoft_Excel_Worksheet.xlsx")).not.toBeNull();
+
+    const repair = await reconcilePackageReferences(zip, 6);
+    expect(repair.danglingRelationships).toEqual(["escape.bin"]);
+    const rels = await zip.file("word/_rels/document.xml.rels")?.async("text");
+    expect(rels).not.toContain("escape.bin");
+  });
+});
+
+describe("a repacked package needs no further repair", () => {
+  const extensionArb = fc.constantFrom("bin", "xlsx", "docx", "emf", "dat", "vml");
+  const partArb = fc
+    .tuple(
+      fc.constantFrom("word/embeddings", "word/media", "customXml", "word/charts", "word/unknown"),
+      fc.stringMatching(/^[a-z][a-z0-9]{0,7}$/u),
+      extensionArb,
+      fc.uint8Array({ minLength: 1, maxLength: 24 }),
+      fc.boolean(),
+      fc.boolean(),
+    )
+    .map(([directory, name, extension, bytes, referenced, overridden]) => ({
+      path: `${directory}/${name}.${extension}`,
+      bytes,
+      relationshipType: referenced ? `${OFFICE_RELATIONSHIP}/customXml` : null,
+      contentType: overridden ? "application/octet-stream" : null,
+      defaultExtension: { extension, contentType: "application/octet-stream" },
+    }));
+
+  test(
+    "every source part comes back with identical bytes and no dangling reference",
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.uniqueArray(partArb, {
+            minLength: 1,
+            maxLength: 5,
+            selector: (part) => part.path,
+          }),
+          async (extras) => {
+            // A relationship target is resolved against `word/`, so only parts
+            // under it can be referenced from `document.xml.rels`.
+            const referenceable = extras.map((extra) => ({
+              ...extra,
+              relationshipType: extra.path.startsWith("word/") ? extra.relationshipType : null,
+            }));
+            const output = await repack(await buildPackage({ extras: referenceable }));
+
+            for (const extra of referenceable) {
+              expect(await partBytes(output, extra.path)).toEqual(extra.bytes);
+            }
+
+            // Reconciliation is a fixed point on a healthy package: a second
+            // pass over the output finds nothing to remove.
+            expect(await reconcilePackageReferences(output, 6)).toEqual({
+              danglingRelationships: [],
+              danglingOverrides: [],
+            });
+          },
+        ),
+        propertyConfig({ numRuns: 30 }),
+      );
+    },
+    propertyTestTimeout(30_000),
+  );
+});

--- a/packages/core/src/docx/packageParts.ts
+++ b/packages/core/src/docx/packageParts.ts
@@ -1,0 +1,199 @@
+/**
+ * What a repack carries out of the source package, and the guarantee that
+ * nothing in the output points at a part the output does not hold.
+ *
+ * A `.docx` is an OPC package: `[Content_Types].xml` declares every part in it
+ * and the `.rels` parts wire them together. Folio models a handful of those
+ * parts (the document body, headers, footers, notes, numbering, styles,
+ * comments) and rewrites them on save. Everything else — embedded objects,
+ * media, custom XML, fonts, charts, macro projects, parts folio has never heard
+ * of — belongs to the author, and a repack hands it back byte for byte.
+ *
+ * Folio never executes document content and never removes it. The document is
+ * the user's; the only thing a save refuses is a package path that would let
+ * the archive escape its own directory when a host writes it out, which is a
+ * property of the package structure rather than of the content. A macro-enabled
+ * document therefore stays macro-enabled, main-part content type included:
+ * silently handing back a `.docm` stripped of its project is data loss dressed
+ * up as safety.
+ *
+ * A refused path loses its relationships and its content-type override with it.
+ * That is the invariant this module exists for: Word and LibreOffice both
+ * refuse a package whose `document.xml.rels` points at nothing, so a repack
+ * that removes a part without removing its references produces a file that
+ * does not open.
+ */
+
+import type JSZip from "jszip";
+
+import { resolveRelativePath } from "./relsParser";
+
+const CONTENT_TYPE_ELEMENT = /<(?:Default|Override)\b[^>]*?\/?>/giu;
+const PART_NAME_ATTRIBUTE = /\bPartName\s*=\s*(?<quote>["'])(?<value>[^"']*)\k<quote>/u;
+const RELATIONSHIP_ELEMENT = /<Relationship\b[^>]*?(?:\/>|>\s*<\/Relationship>)/giu;
+const TARGET_ATTRIBUTE = /\bTarget\s*=\s*(?<quote>["'])(?<value>[^"']*)\k<quote>/u;
+const TARGET_MODE_ATTRIBUTE = /\bTargetMode\s*=\s*(?<quote>["'])(?<value>[^"']*)\k<quote>/u;
+const CONTENT_TYPES_PATTERN = /^\[Content_Types\]\.xml$/iu;
+
+/** Normalize a package path for comparison: lower case, no leading slash. */
+const normalizePartPath = (path: string): string =>
+  (path.startsWith("/") ? path.slice(1) : path).toLowerCase();
+
+/**
+ * Decode `%XX` escapes in a part name. `decodeURI` throws on a malformed
+ * escape, and a malformed target is exactly the input this has to survive, so
+ * the replacement is done by hand.
+ */
+const decodePartName = (name: string): string =>
+  name.replaceAll(/%[0-9A-Fa-f]{2}/gu, (escape) =>
+    String.fromCharCode(Number.parseInt(escape.slice(1), 16)),
+  );
+
+/**
+ * Whether an entry path would escape the package when a host writes the archive
+ * to disk: absolute, backslash-separated, or climbing out through `..`. This is
+ * the only thing a save refuses, and it is about the archive, not the document.
+ *
+ * The full repack removes such an entry along with its references; the
+ * selective path bails to the full repack rather than overlay one part on top
+ * of a package carrying one. Both read this predicate, so neither can drift
+ * into passing what the other blocks.
+ */
+export const isUnsafePackagePath = (path: string): boolean => {
+  if (!path || path.startsWith("/") || path.includes("\\")) {
+    return true;
+  }
+  return path.split("/").some((segment) => segment === "..");
+};
+
+/** Drop the entries whose path a save refuses. Every other part survives. */
+export const removeUnsafeEntries = (zip: JSZip): void => {
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && isUnsafePackagePath(path)) {
+      zip.remove(path);
+    }
+  }
+};
+
+const presentPartPaths = (zip: JSZip): Set<string> => {
+  const present = new Set<string>();
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir) {
+      present.add(normalizePartPath(path));
+    }
+  }
+  return present;
+};
+
+const isPresent = (present: ReadonlySet<string>, partPath: string): boolean =>
+  present.has(normalizePartPath(partPath)) ||
+  present.has(normalizePartPath(decodePartName(partPath)));
+
+/** The part a relationship names, or null when it points outside the package. */
+const relationshipTarget = (element: string, relsPath: string): string | null => {
+  if (TARGET_MODE_ATTRIBUTE.exec(element)?.groups?.["value"] === "External") {
+    return null;
+  }
+  const target = TARGET_ATTRIBUTE.exec(element)?.groups?.["value"];
+  return target === undefined ? null : resolveRelativePath(relsPath, target);
+};
+
+/** What reconciliation removed to make the package internally consistent. */
+export type PackageReferenceRepair = {
+  /** Parts a relationship named that the package does not hold. */
+  danglingRelationships: string[];
+  /** Parts a content-type override named that the package does not hold. */
+  danglingOverrides: string[];
+};
+
+type RelationshipPart = {
+  path: string;
+  xml: string;
+};
+
+/**
+ * Every `.rels` part with its text. Read one at a time rather than through
+ * `Promise.all`: a package holds a handful of tiny relationship parts, and the
+ * sequential read keeps the output order stable.
+ */
+const readRelationshipParts = async (zip: JSZip): Promise<RelationshipPart[]> => {
+  const parts: RelationshipPart[] = [];
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (file.dir || !normalizePartPath(path).endsWith(".rels")) {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- a handful of tiny parts, read in package order
+    parts.push({ path, xml: await file.async("text") });
+  }
+  return parts;
+};
+
+type WritePartOptions = {
+  zip: JSZip;
+  path: string;
+  xml: string;
+  compressionLevel: number;
+};
+
+const writePart = ({ zip, path, xml, compressionLevel }: WritePartOptions): void => {
+  zip.file(path, xml, {
+    compression: "DEFLATE",
+    compressionOptions: { level: compressionLevel },
+  });
+};
+
+/**
+ * Make the package internally consistent before it is written: every internal
+ * relationship target and every content-type override must name a part the
+ * output actually holds.
+ *
+ * A part is rewritten only when something was dropped from it, so a package
+ * that needs no repair leaves byte for byte as it arrived. Running this on an
+ * already-reconciled package therefore reports nothing and changes nothing,
+ * which is what the repack tests assert about their own output.
+ */
+export const reconcilePackageReferences = async (
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<PackageReferenceRepair> => {
+  const present = presentPartPaths(zip);
+  const repair: PackageReferenceRepair = { danglingRelationships: [], danglingOverrides: [] };
+
+  for (const { path, xml } of await readRelationshipParts(zip)) {
+    let dropped = false;
+    const pruned = xml.replaceAll(RELATIONSHIP_ELEMENT, (element) => {
+      const target = relationshipTarget(element, path);
+      if (target === null || isPresent(present, target)) {
+        return element;
+      }
+      repair.danglingRelationships.push(target);
+      dropped = true;
+      return "";
+    });
+    if (dropped) {
+      writePart({ zip, path, xml: pruned, compressionLevel });
+    }
+  }
+
+  const contentTypes = zip.file(CONTENT_TYPES_PATTERN)[0];
+  if (!contentTypes) {
+    return repair;
+  }
+  let droppedOverride = false;
+  const prunedContentTypes = (await contentTypes.async("text")).replaceAll(
+    CONTENT_TYPE_ELEMENT,
+    (element) => {
+      const partName = PART_NAME_ATTRIBUTE.exec(element)?.groups?.["value"];
+      if (partName === undefined || isPresent(present, partName)) {
+        return element;
+      }
+      repair.danglingOverrides.push(normalizePartPath(decodePartName(partName)));
+      droppedOverride = true;
+      return "";
+    },
+  );
+  if (droppedOverride) {
+    writePart({ zip, path: contentTypes.name, xml: prunedContentTypes, compressionLevel });
+  }
+  return repair;
+};

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -423,14 +423,16 @@ describe("repackDocx", () => {
     );
   });
 
-  test("reuses a sanitized source package while preserving later model edits", async () => {
+  test("reuses the cached source package while preserving later model edits", async () => {
     const sourceZip = await JSZip.loadAsync(await createHeaderFixture());
     sourceZip.file("word/vbaProject.bin", new Uint8Array([1, 2, 3]));
     const sourceBuffer = await sourceZip.generateAsync({ type: "arraybuffer" });
     const document = await parseDocx(sourceBuffer, { preloadFonts: false });
 
     const firstSave = await createDocx(document);
-    expect((await JSZip.loadAsync(firstSave)).file("word/vbaProject.bin")).toBeNull();
+    expect(
+      await (await JSZip.loadAsync(firstSave)).file("word/vbaProject.bin")?.async("uint8array"),
+    ).toEqual(new Uint8Array([1, 2, 3]));
 
     const body = document.package.document.content.at(0);
     if (!body || body.type !== "paragraph") {
@@ -452,8 +454,9 @@ describe("repackDocx", () => {
     expect(await secondZip.file("word/document.xml")?.async("text")).toContain(
       "Edited after first save",
     );
-    expect(secondZip.file("word/vbaProject.bin")).toBeNull();
-    expect((await JSZip.loadAsync(sourceBuffer)).file("word/vbaProject.bin")).not.toBeNull();
+    expect(await secondZip.file("word/vbaProject.bin")?.async("uint8array")).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
   });
 
   test("drops orphan comment references before full repack validation", async () => {

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -79,7 +79,11 @@ import { serializeSettingsXml } from "./serializer/settingsSerializer";
 import { serializeStyle, serializeStylesXml } from "./serializer/stylesSerializer";
 import { serializeThemeXml } from "./serializer/themeSerializer";
 import { escapeXml } from "./serializer/xmlUtils";
-import { isPreservableDocxEntry } from "./unzip";
+import {
+  isUnsafePackagePath,
+  reconcilePackageReferences,
+  removeUnsafeEntries,
+} from "./packageParts";
 import type { RawDocxContent } from "./unzip";
 import {
   findChild,
@@ -767,12 +771,19 @@ export type RepackOptions = {
   changedNoteParaIds?: ReadonlySet<string>;
 };
 
-const generateDocxZip = (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> =>
-  zip.generateAsync({
+/**
+ * The single exit for a repacked package. Reconciliation runs here rather than
+ * at each caller so no save path can emit a package whose relationships or
+ * content types name a part it does not hold.
+ */
+const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> => {
+  await reconcilePackageReferences(zip, compressionLevel);
+  return zip.generateAsync({
     type: "arraybuffer",
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
+};
 
 type ParsedZipSource = {
   buffer: ArrayBuffer;
@@ -782,14 +793,6 @@ type ParsedZipSource = {
 };
 
 const parsedZipSources = new WeakMap<Document, ParsedZipSource>();
-
-const removeNonPreservableEntries = (zip: JSZip): void => {
-  for (const [path, file] of Object.entries(zip.files)) {
-    if (!file.dir && !isPreservableDocxEntry(path)) {
-      zip.remove(path);
-    }
-  }
-};
 
 const loadParsedZipSource = async (
   document: Document,
@@ -801,7 +804,7 @@ const loadParsedZipSource = async (
   }
 
   const zip = await JSZip.loadAsync(buffer);
-  removeNonPreservableEntries(zip);
+  removeUnsafeEntries(zip);
   const [documentXml, corePropertiesXml] = await Promise.all([
     zip.file("word/document.xml")?.async("text"),
     zip.file("docProps/core.xml")?.async("text"),
@@ -925,7 +928,7 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
     originalZip.file("docProps/core.xml")?.async("text"),
   ]);
 
-  removeNonPreservableEntries(originalZip);
+  removeUnsafeEntries(originalZip);
   const newZip = cloneDocxZip(originalZip);
 
   return finishRepack({
@@ -973,7 +976,7 @@ export async function repackDocxFromRaw(
       continue;
     }
 
-    if (!isPreservableDocxEntry(path)) {
+    if (isUnsafePackagePath(path)) {
       continue;
     }
 
@@ -1058,14 +1061,7 @@ export async function repackDocxFromRaw(
     });
   }
 
-  // Generate the new DOCX file
-  const arrayBuffer = await newZip.generateAsync({
-    type: "arraybuffer",
-    compression: "DEFLATE",
-    compressionOptions: { level: compressionLevel },
-  });
-
-  return arrayBuffer;
+  return generateDocxZip(newZip, compressionLevel);
 }
 
 // ============================================================================

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -18,8 +18,8 @@ import { hasUnsynthesizedReplyRanges } from "./commentReplyMarkers";
 import { validateFolioDocumentModel } from "./modelValidation";
 import { isNewDataUrlDrawing } from "./newImage";
 import { parseNumbering } from "./numberingParser";
+import { isUnsafePackagePath } from "./packageParts";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { isPreservableDocxEntry } from "./unzip";
 import {
   applyUpdatesToZip,
   findMaxRId,
@@ -463,16 +463,14 @@ export async function attemptSelectiveSave(
     const JSZip = (await import("jszip")).default;
     const zip = await JSZip.loadAsync(originalBuffer);
 
-    // The selective path only ever overlays a handful of known-safe parts
-    // (document.xml, comments, headers/footers, numbering, core props) on
-    // top of the ORIGINAL zip and re-emits everything else verbatim —
-    // unlike the full repack (`repackDocx`), which drops every entry that
-    // fails `isPreservableDocxEntry` (macros, OLE embeddings, disallowed
-    // media). An untrusted DOCX carrying one of those would otherwise
-    // round-trip its active content unfiltered through a selective save.
-    // Bail to the full repack, which owns that filtering.
+    // The selective path overlays a handful of parts on top of the ORIGINAL
+    // zip and re-emits everything else verbatim, which is what the document's
+    // own content deserves. An entry whose PATH would escape the package is
+    // the one thing it cannot re-emit: the full repack drops such an entry and
+    // reconciles the references to it, so bail there. Both paths read one
+    // predicate, so neither can drift into passing what the other blocks.
     for (const [path, file] of Object.entries(zip.files)) {
-      if (!file.dir && !isPreservableDocxEntry(path)) {
+      if (!file.dir && isUnsafePackagePath(path)) {
         return null;
       }
     }

--- a/packages/core/src/docx/selectiveSaveGuards.test.ts
+++ b/packages/core/src/docx/selectiveSaveGuards.test.ts
@@ -266,14 +266,11 @@ describe("fallback contract", () => {
   });
 });
 
-describe("non-preservable entry guard", () => {
-  test("bails to full repack when the original zip carries a vbaProject.bin macro part", async () => {
-    // attemptSelectiveSave loads the ORIGINAL buffer into JSZip and overlays
-    // only a handful of known-safe part updates — unlike repackDocx, which
-    // drops every entry failing isPreservableDocxEntry (macros, OLE
-    // embeddings, disallowed media). Without this guard, an attacker DOCX
-    // carrying an active-content part would round-trip it unfiltered
-    // through the selective path.
+describe("package entry guard", () => {
+  test("takes the selective path for a macro-enabled document", async () => {
+    // The document is the author's: a macro project is carried verbatim by
+    // both save paths, so the selective path has no reason to bail. It only
+    // refuses an entry PATH that would escape the package.
     const zip = new JSZip();
     zip.file("[Content_Types].xml", CONTENT_TYPES);
     zip.file("_rels/.rels", PACKAGE_RELS);
@@ -291,13 +288,17 @@ describe("non-preservable entry guard", () => {
       hasUntrackedChanges: false,
     });
 
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    const saved = await JSZip.loadAsync(result!);
+    expect(await saved.file("word/vbaProject.bin")?.async("uint8array")).toEqual(
+      new Uint8Array([0, 1, 2, 3]),
+    );
   });
 
   test("does not bail on the Word package preview thumbnail", async () => {
     // `docProps/thumbnail.jpeg` is plain preview media Word writes into
-    // nearly every authored file; if the guard treated it as active
-    // content, the selective path would be dead code for real documents.
+    // nearly every authored file; the selective path carries it like any
+    // other part.
     const zip = new JSZip();
     zip.file("[Content_Types].xml", CONTENT_TYPES);
     zip.file("_rels/.rels", PACKAGE_RELS);
@@ -318,9 +319,8 @@ describe("non-preservable entry guard", () => {
     expect(result).not.toBeNull();
   });
 
-  test("still takes the selective path when every entry is preservable", async () => {
-    // Control case: the same fixture shape without the macro part must
-    // still take the selective path, so the new guard is not overly broad.
+  test("still takes the selective path for an ordinary package", async () => {
+    // Control case: the plain fixture shape, so the guard is not overly broad.
     const buffer = await makeFixture();
     const doc = await parseDocx(buffer, { preloadFonts: false });
 

--- a/packages/core/src/docx/unzip.test.ts
+++ b/packages/core/src/docx/unzip.test.ts
@@ -93,6 +93,36 @@ describe("unzipDocx security limits", () => {
     expect(error).toBeInstanceOf(DocxSecurityError);
   });
 
+  test("counts an entry the parser never reads toward the expansion ceiling", async () => {
+    // A save carries every part of the package, so an entry folio does not
+    // model still passes through the host. The ceiling has to see it.
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("word/embeddings/workbook.xlsx", "\0".repeat(4 * 1024 * 1024));
+
+    const buffer = await zip.generateAsync({ compression: "DEFLATE", type: "arraybuffer" });
+    const error = await getRejectedError(
+      unzipDocx(buffer, { maxTotalUncompressedBytes: 1024 * 1024 }),
+    );
+
+    expect(error).toBeInstanceOf(DocxSecurityError);
+  });
+
+  test("carries a macro project through the archive without reading it", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("word/vbaProject.bin", new Uint8Array([0xd0, 0xcf, 0x11, 0xe0]));
+
+    const content = await unzipDocx(await zip.generateAsync({ type: "arraybuffer" }));
+
+    expect(content.allXml.has("word/vbaProject.bin")).toBe(false);
+    expect(getFileList(content)).not.toContain("word/vbaProject.bin");
+    expect(await extractFile(content, "word/vbaProject.bin")).toBeNull();
+    expect(content.originalZip.file("word/vbaProject.bin")).not.toBeNull();
+  });
+
   test("skips media entries with mismatched content signatures", async () => {
     const zip = new JSZip();
     zip.file("[Content_Types].xml", "<Types />");

--- a/packages/core/src/docx/unzip.ts
+++ b/packages/core/src/docx/unzip.ts
@@ -303,19 +303,24 @@ export async function unzipDocx(
       throw new DocxSecurityError("DOCX file contains an unsafe entry path");
     }
 
-    if (!isPreservableDocxEntry(path)) {
-      continue;
-    }
-
-    const lowerPath = path.toLowerCase();
+    // The expansion ceiling covers EVERY entry, including the ones this parser
+    // never reads: a save hands the whole package back, so a part folio does
+    // not model still passes through the host's memory on the way out, and a
+    // package that inflates past the ceiling has to be refused whether or not
+    // anything here looks inside it.
     const declaredSize = getEntryUncompressedSize(file);
-
     if (declaredSize !== null) {
       totalUncompressedBytes += declaredSize;
       if (totalUncompressedBytes > limits.maxTotalUncompressedBytes) {
         throw new DocxSecurityError("DOCX file expands beyond the maximum allowed size");
       }
     }
+
+    if (!isParsedDocxEntry(path)) {
+      continue;
+    }
+
+    const lowerPath = path.toLowerCase();
 
     // Determine file type and extract
     if (lowerPath.endsWith(".xml") || lowerPath.endsWith(".rels")) {
@@ -619,20 +624,43 @@ function isSafeDocxPath(path: string): boolean {
   return !path.split("/").some((part) => part === "..");
 }
 
-export function isPreservableDocxEntry(path: string): boolean {
+/**
+ * Parts folio never looks inside. A macro project and an ActiveX control carry
+ * code; folio models neither, so it reads neither — not into the document
+ * model, not even into the raw XML map. The save path carries them anyway,
+ * straight from the source archive, which is what keeps a `.docm` a `.docm`.
+ */
+const UNINTERPRETED_PART_NAMES = new Set(["word/vbaproject.bin", "word/vbadata.xml"]);
+
+const isUninterpretedPart = (lowerPath: string): boolean =>
+  UNINTERPRETED_PART_NAMES.has(lowerPath) || lowerPath.startsWith("word/activex/");
+
+/**
+ * Whether this entry is one the PARSER reads into the document model. It says
+ * nothing about what a save keeps: a repack hands back every part of the
+ * package (see `packageParts.ts`), including the ones this returns false for.
+ *
+ * That asymmetry is the point. A macro project, an ActiveX control and an OLE
+ * embedding are opaque bytes to folio — never decoded, never interpreted,
+ * never executed — and they travel from the source archive to the saved one
+ * without any code here looking inside them.
+ */
+function isParsedDocxEntry(path: string): boolean {
   if (!isSafeDocxPath(path)) {
     return false;
   }
 
   const lowerPath = path.toLowerCase();
+  if (isUninterpretedPart(lowerPath)) {
+    return false;
+  }
   if (lowerPath.startsWith("word/media/")) {
     return PRESERVABLE_MEDIA_MIME_TYPES.has(getMediaMimeType(path));
   }
 
   // Word writes an optional package preview image (`docProps/thumbnail.jpeg`,
-  // `.wmf`, or `.emf`) into nearly every authored file. It is plain media,
-  // not active content; treat it like `word/media/` so neither the repack
-  // nor the selective-save non-preservable-entry guard drops it.
+  // `.wmf`, or `.emf`) into nearly every authored file. It is plain media the
+  // renderer can use, so the parser reads it like `word/media/`.
   if (lowerPath.startsWith("docprops/thumbnail.")) {
     return PRESERVABLE_MEDIA_MIME_TYPES.has(getMediaMimeType(path));
   }
@@ -734,7 +762,7 @@ export function getFileList(content: RawDocxContent): string[] {
   const files: string[] = [];
 
   for (const path of Object.keys(content.originalZip.files)) {
-    if (!content.originalZip.files[path]?.dir && isPreservableDocxEntry(path)) {
+    if (!content.originalZip.files[path]?.dir && isParsedDocxEntry(path)) {
       files.push(path);
     }
   }
@@ -808,7 +836,7 @@ export function extractFile(
   path: string,
 ): Promise<string | ArrayBuffer | null> {
   const file = content.originalZip.file(path);
-  if (!file || !isPreservableDocxEntry(path)) {
+  if (!file || !isParsedDocxEntry(path)) {
     return Promise.resolve(null);
   }
 


### PR DESCRIPTION
## The posture

Folio never executes document content and never removes it. Parts it does not
model are carried unchanged; the only refusals protect the processing host from
the package structure itself.

## The defect

The full repack decided what to keep with a hand-kept list of path prefixes and
extensions. Anything outside it was dropped — `word/embeddings/*.xlsx`, `.bin`
media, macro projects, any part shape nobody had added to the list — while the
relationships and content-type entries naming it stayed behind.

## The symptom

A saved package whose `word/_rels/document.xml.rels` points at parts the package
no longer contains. Word and LibreOffice both refuse such a package, so some
repacked documents stopped opening; the ones that did open had lost the author's
embedded objects, and a `.docm` came back without its project.

## The fix

- **Every part is carried, byte for byte.** Embeddings, media of any type,
  custom XML, fonts, charts, macro projects, ActiveX controls, parts folio has
  never heard of. A macro-enabled document keeps its main-part content type, so
  a `.docm` stays a `.docm` rather than being silently downgraded.
- **`isUnsafePackagePath` is the only refusal**, and it is about the archive
  rather than the document: an entry path that would escape the package when a
  host writes it out (absolute, backslash-separated, or climbing through `..`).
- **`reconcilePackageReferences` runs at `generateDocxZip`**, the single exit
  every repacked package goes through, and removes any internal relationship or
  content-type override naming a part the output does not hold. Whatever drops
  a part — the path rule, a future change, a caller — cannot leave a dangling
  reference behind. A part is rewritten only when something was removed from
  it, so a package that needs no repair is emitted unchanged.
- **`attemptSelectiveSave` reads the same predicate**, so the two save paths
  cannot drift into disagreeing about what leaves the editor. A macro-enabled
  document now takes the selective path instead of bailing to a full repack.

## Folio does not look inside any of it

`isPreservableDocxEntry` is renamed `isParsedDocxEntry` and moved off the save
path entirely: it now says only which entries the PARSER reads into the document
model. Macro projects, `vbaData.xml` and ActiveX parts are excluded from it, so
they never reach the document model — not even the raw XML map — and travel from
the source archive to the saved one as opaque bytes. Nothing decodes,
interprets or evaluates them anywhere.

Conflating "do I parse this?" with "do I preserve this?" in one predicate is
what produced the defect.

## Host protection

The package structure is what a save has to defend against, and the existing
guards are unchanged except to widen their reach:

- unsafe entry paths are rejected at parse (`DocxSecurityError`) and dropped
  with their references at save;
- input size (50 MiB), entry count (5000), per-entry XML / media / font
  ceilings, and a total-expansion ceiling (250 MiB) all still apply;
- the total-expansion ceiling is now charged for **every** entry, including the
  ones the parser skips — a save carries those bytes through the host too, so
  a package that inflates past the ceiling has to be refused whether or not
  anything here reads it.

## Tests

`packages/core/src/docx/__tests__/repack-package-parts.test.ts`, over packages
built in the test rather than checked in:

- an embedded workbook and a binary media part repack byte-identical, with
  their relationships and content-type entries intact;
- a macro project and an ActiveX control come back untouched, with their
  relationships and overrides intact;
- a macro-enabled document keeps `application/vnd.ms-word.document.macroEnabled.main+xml`
  and does not acquire the non-macro content type;
- every part the source package declares is present in the output, asserted
  through reconciliation reporting nothing left to repair;
- macro, ActiveX and OLE parts are never decoded into the model — absent from
  `allXml`, from `media`, from `getFileList` and from `extractFile` — while the
  archive still holds their exact bytes for the save path to carry;
- an escaping entry path is recognised as unsafe, is dropped, and its
  relationship is reconciled away with it;
- a property over packages carrying up to five random extra parts: every source
  part comes back with identical bytes, and reconciling the output a second
  time finds nothing left to repair.

`unzip.test.ts` gains: an entry the parser never reads still counts toward the
expansion ceiling, and a macro project travels through the archive without
being read. `selectiveSaveGuards.test.ts` now asserts a macro-enabled document
takes the selective path with its project intact, rather than bailing.
