### PR TITLE
fix(core): seven numbering, table, paste and review defects

### DIFF
--- a/.changeset/silent-fixes-round.md
+++ b/.changeset/silent-fixes-round.md
@@ -1,0 +1,19 @@
+---
+"@stll/folio-core": patch
+---
+
+Seven fidelity and review fixes:
+
+- A paragraph whose `w:pPr` states only `w:ilvl` now keeps the `w:numId` its
+  style supplies, so a demoted styled list paragraph stays numbered.
+- Inserting a table row through a vertical merge extends the merge instead of
+  splitting the grid.
+- Adjacent paragraphs in a table cell that share a border definition draw one
+  frame with the `w:between` rule, as they already do elsewhere.
+- Every vertical `w:textDirection`, not only `btLr`, rotates its cell text.
+- An abrupt-closing HTML comment (`<!-->`) no longer swallows the rest of a
+  paste.
+- A tracked replace whose two halves carry different timestamps is one review
+  card again.
+- Striking a selection leaves another author's existing deletion attributed to
+  them.

--- a/packages/core/src/docx/paragraphParser-numbering-indent.test.ts
+++ b/packages/core/src/docx/paragraphParser-numbering-indent.test.ts
@@ -233,3 +233,95 @@ describe("style-attached numbering and indentation (#765)", () => {
     expect(para.formatting?.numPrFromStyle).toBeUndefined();
   });
 });
+
+// abstractNum 20 / numId 3 — two levels, so a level-only `w:numPr` has a level
+// to move to and a marker that proves which one resolved.
+const NUMBERING_TWO_LEVEL = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W}>
+  <w:abstractNum w:abstractNumId="20">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/>
+    </w:lvl>
+    <w:lvl w:ilvl="1">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2."/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="3"><w:abstractNumId w:val="20"/></w:num>
+</w:numbering>`;
+
+// LegalHeading1 names the `w:num`; LegalHeading2 states only the level and
+// inherits the id through `w:basedOn` — the shape Word writes for a numbered
+// heading family.
+const LEVEL_ONLY_STYLES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles ${W}>
+  <w:style w:type="paragraph" w:styleId="LegalHeading1">
+    <w:name w:val="LegalHeading1"/>
+    <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="LegalHeading2">
+    <w:name w:val="LegalHeading2"/>
+    <w:basedOn w:val="LegalHeading1"/>
+    <w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>
+  </w:style>
+</w:styles>`;
+
+describe("w:numId and w:ilvl inherit independently", () => {
+  const numbering = parseNumbering(NUMBERING_TWO_LEVEL);
+  const styles = parseStyles(LEVEL_ONLY_STYLES_XML, null);
+
+  test("a style that states only w:ilvl keeps the id from its basedOn chain", () => {
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="LegalHeading2"/></w:pPr>',
+      styles,
+      numbering,
+    );
+
+    expect(para.listRendering?.numId).toBe(3);
+    expect(para.listRendering?.level).toBe(1);
+    expect(para.listRendering?.marker).toBe("%1.%2.");
+  });
+
+  test("a direct level-only w:numPr keeps the id the style supplies", () => {
+    // Demoting a styled list paragraph in Word writes the level alone into
+    // w:pPr. Reading that as a whole replacement dropped the id and left the
+    // paragraph unnumbered.
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="LegalHeading1"/><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>',
+      styles,
+      numbering,
+    );
+
+    expect(para.listRendering?.numId).toBe(3);
+    expect(para.listRendering?.level).toBe(1);
+    expect(para.listRendering?.marker).toBe("%1.%2.");
+  });
+
+  test("a direct level-only w:numPr still records the style as the id's source", () => {
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="LegalHeading1"/><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>',
+      styles,
+      numbering,
+    );
+
+    expect(para.formatting?.numPr).toEqual({ numId: 3, ilvl: 1 });
+    // The style tier, not the merged value: the serializer drops only a numPr
+    // the paragraph never stated.
+    expect(para.formatting?.numPrFromStyle).toEqual({ numId: 3, ilvl: 0 });
+  });
+
+  test('a direct w:numId w:val="0" switches the style numbering off', () => {
+    // ECMA-376 §17.9.18: numId 0 is the null numbering definition.
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="LegalHeading1"/><w:numPr><w:numId w:val="0"/></w:numPr></w:pPr>',
+      styles,
+      numbering,
+    );
+
+    expect(para.listRendering).toBeUndefined();
+    expect(para.formatting?.numPrFromStyle).toBeUndefined();
+  });
+});

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1820,21 +1820,34 @@ export function parseParagraph(
   paragraph.content = consolidateParagraphContent(rawContent);
 
   // Compute list rendering if this is a list item.
-  // numPr can come from inline pPr or from the referenced paragraph style.
-  let effectiveNumPr = paragraph.formatting?.numPr;
+  //
+  // `w:numId` and `w:ilvl` inherit INDEPENDENTLY (ECMA-376 §17.3.1.19): a tier
+  // that states only the level keeps the id it inherits, and a tier that states
+  // only the id keeps the inherited level. Word writes the level-only shape
+  // whenever a styled list paragraph is demoted (`<w:numPr><w:ilvl w:val="1"/>
+  // </w:numPr>` with the `w:num` named by the style), so treating a direct
+  // `w:numPr` as a whole replacement dropped the id and left the paragraph
+  // unnumbered. The style chain itself already merges per field
+  // (mergeParagraphFormatting); this is the last tier, direct over style.
+  const paragraphFormatting = paragraph.formatting;
+  const directNumPr = paragraphFormatting?.numPr;
+  const styleNumPr =
+    paragraphFormatting?.styleId && styles
+      ? styles.get(paragraphFormatting.styleId)?.pPr?.numPr
+      : undefined;
+  let effectiveNumPr = directNumPr;
+  // Drives indent precedence below: true when the numbering REFERENCE came from
+  // the style chain, whether or not the paragraph stated its own level.
   let numPrFromStyle = false;
-  if (!effectiveNumPr && paragraph.formatting?.styleId && styles) {
-    const style = styles.get(paragraph.formatting.styleId);
-    if (style?.pPr?.numPr) {
-      effectiveNumPr = style.pPr.numPr;
-      numPrFromStyle = true;
-      // Store it on the paragraph formatting so downstream code sees it,
-      // and record the provenance so the serializer can drop it again —
-      // materializing style numbering as direct <w:numPr> flips Word's
-      // level-indent precedence on the saved file.
-      paragraph.formatting.numPr = effectiveNumPr;
-      paragraph.formatting.numPrFromStyle = effectiveNumPr;
-    }
+  if (paragraphFormatting && styleNumPr && directNumPr?.numId === undefined) {
+    effectiveNumPr = { ...styleNumPr, ...directNumPr };
+    numPrFromStyle = true;
+    // Store it on the paragraph formatting so downstream code sees it, and
+    // record the style tier so the serializer can drop a numPr the paragraph
+    // never stated — materializing style numbering as direct <w:numPr> flips
+    // Word's level-indent precedence on the saved file.
+    paragraphFormatting.numPr = effectiveNumPr;
+    paragraphFormatting.numPrFromStyle = styleNumPr;
   }
 
   if (effectiveNumPr && numbering) {

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -246,13 +246,26 @@ function renderCellContent({
         ...(paragraphBlock.pmEnd !== undefined ? { pmEnd: paragraphBlock.pmEnd } : {}),
       };
 
+      // Consecutive paragraphs sharing a border definition are ONE frame with an
+      // interior `w:between` rule, not a frame each (§17.3.1.7). The neighbours
+      // decide that, so they have to reach the fragment renderer here exactly as
+      // they do in a text box and in the body flow.
+      const previousBlock = cell.blocks[i - 1];
+      const nextBlock = cell.blocks[i + 1];
+      const prevBorders =
+        previousBlock?.kind === "paragraph" ? previousBlock.attrs?.borders : undefined;
+      const nextBorders = nextBlock?.kind === "paragraph" ? nextBlock.attrs?.borders : undefined;
       const cellContext = { ...context, insideTableCell: true as const };
       const fragEl = renderParagraphFragment(
         syntheticFragment,
         paragraphBlock,
         paragraphMeasure,
         cellContext,
-        { document: doc },
+        {
+          document: doc,
+          ...(prevBorders !== undefined ? { prevBorders } : {}),
+          ...(nextBorders !== undefined ? { nextBorders } : {}),
+        },
       );
 
       fragEl.style.position = "relative";

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -79,6 +79,31 @@ const CELL_DIAGONAL_BORDER_CLASS = "layout-table-cell-diagonal-border";
 const CELL_BOTTOM_BORDER_CLASS = "layout-table-cell-bottom-border";
 
 /**
+ * Quarter turn a `w:textDirection` puts on cell content (§17.18.93, plus the
+ * short spellings Word also writes).
+ *
+ * `btLr` runs bottom-to-top up the left edge, so it turns counter-clockwise;
+ * every top-to-bottom direction runs down the right edge and turns clockwise.
+ * The horizontal directions are the identity — `rl` is bidi, not rotation.
+ * Only `btLr` was handled, so a rotated header cell (the common `tbRl` shape)
+ * painted horizontally and overflowed its column.
+ *
+ * Total over the union on purpose: a new direction has to state its turn here
+ * rather than silently falling back to horizontal.
+ */
+const CELL_TEXT_ROTATION_DEGREES = {
+  lr: 0,
+  lrV: 0,
+  rl: 0,
+  rlV: 0,
+  tb: 90,
+  tbV: 90,
+  tbRl: 90,
+  tbRlV: 90,
+  btLr: -90,
+} as const satisfies Record<NonNullable<TableCell["textDirection"]>, number>;
+
+/**
  * Options for rendering a table fragment
  */
 export type RenderTableFragmentOptions = {
@@ -714,8 +739,9 @@ function renderTableCell({
   }
 
   // Render cell content
+  const cellTextRotation = cell.textDirection ? CELL_TEXT_ROTATION_DEGREES[cell.textDirection] : 0;
   const contentWidthOverride =
-    cell.textDirection === "btLr" ? Math.max(1, rowHeight - padTop - padBottom) : undefined;
+    cellTextRotation === 0 ? undefined : Math.max(1, rowHeight - padTop - padBottom);
   const renderedContent = renderCellContent({
     cell,
     cellMeasure,
@@ -732,11 +758,11 @@ function renderTableCell({
         }
       : {}),
   });
-  if (cell.textDirection === "btLr") {
+  if (cellTextRotation !== 0) {
     renderedContent.content.style.position = "absolute";
     renderedContent.content.style.left = "50%";
     renderedContent.content.style.top = "50%";
-    renderedContent.content.style.transform = "translate(-50%, -50%) rotate(-90deg)";
+    renderedContent.content.style.transform = `translate(-50%, -50%) rotate(${cellTextRotation}deg)`;
   }
   if (renderedContent.floatingLayers.length > 0) {
     renderedContent.content.style.height = "100%";

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { withFakeTextMeasure } from "../layout-engine/measure/__tests__/fakeTextMeasure";
-import type { ImageRun, TableBlock, TableFragment, TableMeasure } from "../layout-engine/types";
+import type {
+  ImageRun,
+  TableBlock,
+  TableCell,
+  TableFragment,
+  TableMeasure,
+} from "../layout-engine/types";
 import type { PageGeometry } from "./anchoredImagePosition";
 import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
 import type { RenderContext } from "./renderUtils";
@@ -1119,5 +1125,86 @@ describe("renderTableFragment paragraph border groups", () => {
       expect(boxes[1]?.style["borderTop"]).toContain("dotted");
       expect(boxes[1]?.style["borderBottom"]).toContain("solid");
     });
+  });
+});
+
+describe("renderTableFragment vertical cell text", () => {
+  const rotatedCellTable = (
+    textDirection: NonNullable<TableCell["textDirection"]>,
+  ): { fragment: TableFragment; block: TableBlock; measure: TableMeasure } => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              textDirection,
+              blocks: [{ kind: "paragraph", id: "p", runs: [{ kind: "text", text: "Header" }] }],
+            },
+          ],
+        },
+      ],
+      columnWidths: [40],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [{ kind: "paragraph", lines: [], totalHeight: 20 }],
+              width: 40,
+              height: 120,
+            },
+          ],
+          height: 120,
+        },
+      ],
+      columnWidths: [40],
+      totalWidth: 40,
+      totalHeight: 120,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 120,
+      fromRow: 0,
+      toRow: 1,
+    };
+    return { fragment, block, measure };
+  };
+
+  const contentTransform = (textDirection: NonNullable<TableCell["textDirection"]>) => {
+    let transform: string | undefined;
+    withFakeTextMeasure(() => {
+      const { fragment, block, measure } = rotatedCellTable(textDirection);
+      const table = renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+        pageGeometry,
+      }) as unknown as FakeElement;
+      transform = findByClass(table, TABLE_CLASS_NAMES.cellContent).at(0)?.style["transform"];
+    });
+    return transform;
+  };
+
+  test("a top-to-bottom cell turns clockwise", () => {
+    expect(contentTransform("tbRl")).toContain("rotate(90deg)");
+    expect(contentTransform("tbRlV")).toContain("rotate(90deg)");
+    expect(contentTransform("tb")).toContain("rotate(90deg)");
+  });
+
+  test("a bottom-to-top cell turns counter-clockwise", () => {
+    expect(contentTransform("btLr")).toContain("rotate(-90deg)");
+  });
+
+  test("a horizontal cell is not turned", () => {
+    expect(contentTransform("lr")).toBeUndefined();
+    expect(contentTransform("rl")).toBeUndefined();
   });
 });

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -1043,3 +1043,81 @@ describe("renderTableFragment cell floating images", () => {
     expect(image?.style["opacity"]).toBe("0.6");
   });
 });
+
+describe("renderTableFragment paragraph border groups", () => {
+  const BORDERS = {
+    top: { style: "solid", width: 1, color: "#000000" },
+    bottom: { style: "solid", width: 1, color: "#000000" },
+    between: { style: "dotted", width: 1, color: "#000000" },
+  } as const;
+
+  const borderedCellTable = (): {
+    fragment: TableFragment;
+    block: TableBlock;
+    measure: TableMeasure;
+  } => {
+    const paragraph = (id: string, text: string) => ({
+      kind: "paragraph" as const,
+      id,
+      runs: [{ kind: "text" as const, text }],
+      attrs: { borders: { ...BORDERS } },
+    });
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [{ id: "cell", blocks: [paragraph("p1", "One"), paragraph("p2", "Two")] }],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const cellMeasure = {
+      blocks: [
+        { kind: "paragraph" as const, lines: [], totalHeight: 20 },
+        { kind: "paragraph" as const, lines: [], totalHeight: 20 },
+      ],
+      width: 100,
+      height: 40,
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [{ cells: [cellMeasure], height: 40 }],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 40,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      fromRow: 0,
+      toRow: 1,
+    };
+    return { fragment, block, measure };
+  };
+
+  test("two identically bordered cell paragraphs draw one frame, not two", () => {
+    withFakeTextMeasure(() => {
+      const { fragment, block, measure } = borderedCellTable();
+      const table = renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+        pageGeometry,
+      }) as unknown as FakeElement;
+
+      const boxes = findByClass(table, "layout-paragraph-border");
+      expect(boxes).toHaveLength(2);
+      // First of the group: the frame's top rule, no closing rule.
+      expect(boxes[0]?.style["borderTop"]).toContain("solid");
+      expect(boxes[0]?.style["borderBottom"]).toBeUndefined();
+      // Last of the group: the interior `w:between` rule on top, the frame's
+      // bottom rule below. Painting `top` here would double the interior line.
+      expect(boxes[1]?.style["borderTop"]).toContain("dotted");
+      expect(boxes[1]?.style["borderBottom"]).toContain("solid");
+    });
+  });
+});

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.test.ts
@@ -171,6 +171,14 @@ describe("cleanPastedHtml — safety and robustness", () => {
     expect(cleanPastedHtml("safe<!--dangling")).toBe("safe");
   });
 
+  test("an abrupt-closing comment does not swallow the rest of the paste", () => {
+    // `<!-->` and `<!--->` close at that `>` (HTML §13.2.5.42-43). Scanning for
+    // `-->` past them found nothing and dropped the whole document.
+    expect(cleanPastedHtml("<!--><p>keep me</p>")).toBe("<p>keep me</p>");
+    expect(cleanPastedHtml("<!---><p>keep me</p>")).toBe("<p>keep me</p>");
+    expect(cleanPastedHtml("<p>a</p><!--><p>b</p>")).toBe("<p>a</p><p>b</p>");
+  });
+
   test("empty input returns empty", () => {
     expect(cleanPastedHtml("")).toBe("");
   });

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -20,6 +20,7 @@
 
 import { Fragment, Slice, type Node as PMNode } from "prosemirror-model";
 
+import { htmlCommentEnd } from "../../../utils/htmlComments";
 import { stripXmlDeclarations } from "../../../utils/stripXmlDeclarations";
 import { readBookmarkBoundaryAttrs } from "../../bookmarkBoundaryAttrs";
 
@@ -69,12 +70,12 @@ function stripHtmlComments(html: string): string {
     }
 
     result += html.slice(cursor, commentStart);
-    const commentEnd = html.indexOf("-->", commentStart + 4);
-    if (commentEnd === -1) {
+    const commentEnd = htmlCommentEnd(html, commentStart);
+    if (commentEnd === null) {
       break;
     }
 
-    cursor = commentEnd + 3;
+    cursor = commentEnd;
   }
 
   return result;

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.test.ts
@@ -473,3 +473,83 @@ describe("table cell paste — dataset.bgcolor validation", () => {
     expect(attrs["backgroundColor"]).toBe("336699");
   });
 });
+
+describe("inserting a row through a vertical merge", () => {
+  const cell = (text: string, attrs: Record<string, unknown> = {}) =>
+    schema.node("tableCell", attrs, [schema.node("paragraph", null, [schema.text(text)])]);
+
+  /**
+   * Two columns, three rows; column 0 is one cell merged across all three, so
+   * rows 1 and 2 carry a single cell each — the `w:vMerge="continue"` shape.
+   */
+  const mergedColumnState = (caretText: string) => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [cell("merged", { rowspan: 3 }), cell("r0")]),
+        schema.node("tableRow", null, [cell("r1")]),
+        schema.node("tableRow", null, [cell("r2")]),
+      ]),
+    ]);
+
+    const caret = { value: null as number | null };
+    doc.descendants((node, pos) => {
+      if (caret.value !== null || node.text !== caretText) {
+        return;
+      }
+      caret.value = pos;
+      return false;
+    });
+    if (caret.value === null) {
+      throw new Error(`Expected a cell containing ${caretText}`);
+    }
+
+    return EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, caret.value),
+    });
+  };
+
+  const tableOf = (doc: PMNode) => {
+    const table = { value: null as PMNode | null };
+    doc.descendants((node) => {
+      if (table.value !== null || node.type.name !== "table") {
+        return;
+      }
+      table.value = node;
+      return false;
+    });
+    if (table.value === null) {
+      throw new Error("Expected a table");
+    }
+    return table.value;
+  };
+
+  test("a merge spanning the boundary grows instead of gaining a stray cell", () => {
+    const state = runTableCommand(mergedColumnState("r1"), "addRowBelow");
+    const table = tableOf(state.doc);
+
+    expect(table.childCount).toBe(4);
+    expect(table.child(0).child(0).attrs["rowspan"]).toBe(4);
+    // The boundary opens only column 1, so the inserted row carries one cell.
+    expect(table.child(2).childCount).toBe(1);
+  });
+
+  test("a boundary outside the merge still gets a full row", () => {
+    const state = runTableCommand(mergedColumnState("r2"), "addRowBelow");
+    const table = tableOf(state.doc);
+
+    expect(table.childCount).toBe(4);
+    expect(table.child(0).child(0).attrs["rowspan"]).toBe(3);
+    expect(table.child(3).childCount).toBe(2);
+  });
+
+  test("inserting above the first row does not extend the merge", () => {
+    const state = runTableCommand(mergedColumnState("r0"), "addRowAbove");
+    const table = tableOf(state.doc);
+
+    expect(table.childCount).toBe(4);
+    expect(table.child(0).childCount).toBe(2);
+    expect(table.child(1).child(0).attrs["rowspan"]).toBe(3);
+  });
+});

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -1131,7 +1131,26 @@ export const TablePluginExtension = createExtension({
       };
     }
 
-    function addRowAbove(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
+    /**
+     * Insert an empty row so that it lands ABOVE grid row `boundaryRow`.
+     *
+     * A vertically merged cell that covers both sides of the boundary is
+     * EXTENDED, not duplicated: Word grows the merge through the inserted row
+     * (`w:vMerge="continue"` gains one row) rather than splitting it. Cloning
+     * the caret row cell-for-cell instead emitted a cell for a column the merge
+     * already occupies, which widens the grid and desynchronises every later
+     * row — the opposite of `deleteRow`, which is merge-correct because it
+     * delegates to prosemirror-tables.
+     *
+     * Only the columns the boundary actually opens get a new cell, and each is
+     * shaped from the cell covering that column so widths, borders, margins and
+     * text direction survive.
+     */
+    function insertTableRow(
+      state: EditorState,
+      dispatch: ((tr: Transaction) => void) | undefined,
+      boundaryOffset: 0 | 1,
+    ): boolean {
       const context = getTableContext(state);
       if (
         !context.isInTable ||
@@ -1141,74 +1160,75 @@ export const TablePluginExtension = createExtension({
       ) {
         return false;
       }
-
-      if (dispatch) {
-        const tr = state.tr;
-        const rowNode = context.table.child(context.rowIndex);
-        const cells: PMNode[] = [];
-        // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-        rowNode.forEach((cell) => {
-          const paragraph = nodeTypeParagraph.create();
-          const cellAttrs = buildCellAttrsFromTemplate(cell);
-          cells.push(nodeTypeTableCell.create(cellAttrs, paragraph));
-        });
-        const newRow = nodeTypeTableRow.create(
-          {
-            height: rowNode.attrs["height"] ?? 360,
-            heightRule: rowNode.attrs["heightRule"] ?? "atLeast",
-          },
-          cells,
-        );
-
-        let rowPos = context.tablePos + 1;
-        for (let i = 0; i < context.rowIndex; i++) {
-          rowPos += context.table.child(i).nodeSize;
-        }
-
-        tr.insert(rowPos, newRow);
-        dispatch(tr.scrollIntoView());
+      if (!dispatch) {
+        return true;
       }
+
+      const { table, tablePos, rowIndex } = context;
+      const boundaryRow = rowIndex + boundaryOffset;
+      const map = TableMap.get(table);
+      const tableStart = tablePos + 1;
+      const tr = state.tr;
+
+      const cells: PMNode[] = [];
+      const extended = new Set<number>();
+      let lastTemplatePos = -1;
+      for (let column = 0; column < map.width; column += 1) {
+        const below = boundaryRow < map.height ? map.map[boundaryRow * map.width + column] : undefined;
+        const above = boundaryRow > 0 ? map.map[(boundaryRow - 1) * map.width + column] : undefined;
+        if (below !== undefined && below === above) {
+          // One cell covers both sides of the boundary: grow it by a row.
+          if (!extended.has(below)) {
+            extended.add(below);
+            const merged = table.nodeAt(below);
+            if (merged) {
+              tr.setNodeMarkup(tableStart + below, undefined, {
+                ...merged.attrs,
+                rowspan: (Number(merged.attrs["rowspan"]) || 1) + 1,
+              });
+            }
+          }
+          continue;
+        }
+        const templatePos = below ?? above;
+        // A colspan cell reports the same position for every column it covers.
+        if (templatePos === undefined || templatePos === lastTemplatePos) {
+          continue;
+        }
+        lastTemplatePos = templatePos;
+        cells.push(
+          nodeTypeTableCell.create(
+            buildCellAttrsFromTemplate(table.nodeAt(templatePos)),
+            nodeTypeParagraph.create(),
+          ),
+        );
+      }
+
+      const rowNode = table.child(rowIndex);
+      const newRow = nodeTypeTableRow.create(
+        {
+          height: rowNode.attrs["height"] ?? 360,
+          heightRule: rowNode.attrs["heightRule"] ?? "atLeast",
+        },
+        cells,
+      );
+
+      let rowPos = tableStart;
+      for (let i = 0; i < boundaryRow; i += 1) {
+        rowPos += table.child(i).nodeSize;
+      }
+
+      tr.insert(rowPos, newRow);
+      dispatch(tr.scrollIntoView());
       return true;
     }
 
+    function addRowAbove(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
+      return insertTableRow(state, dispatch, 0);
+    }
+
     function addRowBelow(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
-      const context = getTableContext(state);
-      if (
-        !context.isInTable ||
-        context.rowIndex === undefined ||
-        !context.table ||
-        context.tablePos === undefined
-      ) {
-        return false;
-      }
-
-      if (dispatch) {
-        const tr = state.tr;
-        const rowNode = context.table.child(context.rowIndex);
-        const cells: PMNode[] = [];
-        // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-        rowNode.forEach((cell) => {
-          const paragraph = nodeTypeParagraph.create();
-          const cellAttrs = buildCellAttrsFromTemplate(cell);
-          cells.push(nodeTypeTableCell.create(cellAttrs, paragraph));
-        });
-        const newRow = nodeTypeTableRow.create(
-          {
-            height: rowNode.attrs["height"] ?? 360,
-            heightRule: rowNode.attrs["heightRule"] ?? "atLeast",
-          },
-          cells,
-        );
-
-        let rowPos = context.tablePos + 1;
-        for (let i = 0; i <= context.rowIndex; i++) {
-          rowPos += context.table.child(i).nodeSize;
-        }
-
-        tr.insert(rowPos, newRow);
-        dispatch(tr.scrollIntoView());
-      }
-      return true;
+      return insertTableRow(state, dispatch, 1);
     }
 
     function deleteRow(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -1174,7 +1174,8 @@ export const TablePluginExtension = createExtension({
       const extended = new Set<number>();
       let lastTemplatePos = -1;
       for (let column = 0; column < map.width; column += 1) {
-        const below = boundaryRow < map.height ? map.map[boundaryRow * map.width + column] : undefined;
+        const below =
+          boundaryRow < map.height ? map.map[boundaryRow * map.width + column] : undefined;
         const above = boundaryRow > 0 ? map.map[(boundaryRow - 1) * map.width + column] : undefined;
         if (below !== undefined && below === above) {
           // One cell covers both sides of the boundary: grow it by a row.

--- a/packages/core/src/prosemirror/plugins/suggestionMode.test.ts
+++ b/packages/core/src/prosemirror/plugins/suggestionMode.test.ts
@@ -244,6 +244,48 @@ describe("SuggestionMode Plugin", () => {
       expect(get().selection.empty).toBe(true);
     });
 
+    test("striking text another author already struck keeps their attribution", () => {
+      // Re-marking a range that already carries a deletion overwrote the first
+      // author's revision id, author and date with ours, so the file lost who
+      // proposed the deletion. The single-character delete path already steps
+      // over such a node, and markRangeAsInserted already guards the same way.
+      const theirDeletion = schema.marks.deletion.create({
+        revisionId: 77,
+        author: "Other Author",
+        date: "2026-01-01T10:00:00Z",
+      });
+      const doc = schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("The "),
+          schema.text("lazy", [theirDeletion]),
+          schema.text(" dog"),
+        ]),
+      ]);
+      let state = EditorState.create({
+        doc,
+        plugins: [createSuggestionModePlugin(true, "TestUser")],
+      });
+      state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 5, 9)));
+
+      const { view, get } = mockView(state);
+      const slice = new Slice(Fragment.from(schema.text("quick")), 0, 0);
+      const pluginState = suggestionModeKey.getState(state)!;
+      expect(handleSuggestionPaste(view, slice, pluginState)).toBe(true);
+
+      const struck = { value: null as null | Record<string, unknown> };
+      get().doc.descendants((node) => {
+        if (node.text !== "lazy") {
+          return;
+        }
+        struck.value = node.marks.find((m) => m.type.name === "deletion")?.attrs ?? null;
+      });
+      expect(struck.value).toMatchObject({
+        revisionId: 77,
+        author: "Other Author",
+        date: "2026-01-01T10:00:00Z",
+      });
+    });
+
     test("pasting block content over a selection fits the slice and tracks it", () => {
       // Select "lazy" and paste two whole paragraphs (block content). A raw
       // `replace` at the inline point would fail or drop structure; the

--- a/packages/core/src/prosemirror/plugins/suggestionMode.ts
+++ b/packages/core/src/prosemirror/plugins/suggestionMode.ts
@@ -146,6 +146,13 @@ function markRangeAsDeleted(
     const isOwnInsert = node.marks.some(
       (m) => m.type === insertionType && m.attrs["author"] === pluginState.author,
     );
+    // Already struck by someone: re-marking it would overwrite their author,
+    // date and revision id with ours, losing who proposed the deletion. The
+    // single-character path already steps over such a node; the range path
+    // has to agree.
+    if (node.marks.some((m) => m.type === deletionType)) {
+      return;
+    }
     ranges.push({ from: start, to: end, isOwnInsert });
   });
 

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
@@ -251,3 +251,47 @@ describe("extractTrackedChanges: foreign-doc coalescing by (author, date)", () =
     expect(entries).toHaveLength(3);
   });
 });
+
+describe("extractTrackedChanges: replacement pairing", () => {
+  const del = (id: number, author: string, date: string, text: string) =>
+    schema.text(text, [schema.marks.deletion.create({ revisionId: id, author, date })]);
+  const ins = (id: number, author: string, date: string, text: string) =>
+    schema.text(text, [schema.marks.insertion.create({ revisionId: id, author, date })]);
+
+  test("pairs a replace whose halves carry different timestamps", () => {
+    // One replace, but the clock ticked between the two halves. Requiring the
+    // stamps to match surfaced a Deleted card and an Inserted card, so accept
+    // or reject only ever acted on half the change.
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, [
+        del(1, AUTHOR, "2026-01-01T10:00:00Z", "old"),
+        ins(2, AUTHOR, "2026-01-01T13:20:00Z", "new"),
+      ]),
+    ]);
+
+    const { entries } = extractTrackedChanges(makeState(doc));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      type: "replacement",
+      deletedText: "old",
+      text: "new",
+      author: AUTHOR,
+      revisionId: 1,
+      insertionRevisionId: 2,
+    });
+  });
+
+  test("does not pair across authors", () => {
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, [
+        del(1, "Jane", DATE, "old"),
+        ins(2, "Bob", DATE, "new"),
+      ]),
+    ]);
+
+    const { entries } = extractTrackedChanges(makeState(doc));
+
+    expect(entries.map((entry) => entry.type)).toEqual(["deletion", "insertion"]);
+  });
+});

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.test.ts
@@ -284,10 +284,7 @@ describe("extractTrackedChanges: replacement pairing", () => {
 
   test("does not pair across authors", () => {
     const doc = schema.nodes.doc.create({}, [
-      schema.nodes.paragraph.create({}, [
-        del(1, "Jane", DATE, "old"),
-        ins(2, "Bob", DATE, "new"),
-      ]),
+      schema.nodes.paragraph.create({}, [del(1, "Jane", DATE, "old"), ins(2, "Bob", DATE, "new")]),
     ]);
 
     const { entries } = extractTrackedChanges(makeState(doc));

--- a/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
+++ b/packages/core/src/prosemirror/utils/extractTrackedChanges.ts
@@ -1,8 +1,8 @@
 /**
  * Walk the PM doc once and derive (a) the tracked-change list and (b) a
  * comment→revision overlap map for threading. Adjacent entries from the
- * same revision are merged; deletion+insertion pairs from the same
- * author/date become a single `replacement` entry (matches Word's UX
+ * same revision are merged; an adjacent deletion+insertion pair from the
+ * same author becomes a single `replacement` entry (matches Word's UX
  * for replace ops).
  *
  * Pure function — no React, no Vue, no side effects. Single O(N) walk
@@ -171,8 +171,8 @@ const foldIntoRowRevision = (scope: RowRevisionScope | undefined, mark: Mark): b
  * Walk the PM doc and extract every tracked change as a flat list of
  * `TrackedChangeEntry` plus a comment→revision overlap map. Adjacent
  * inline marks coalesce by `(type, revisionId, author, date)`; a
- * deletion immediately followed by an insertion (same author + same
- * date) collapses into a single `replacement` entry; paragraph-mark
+ * deletion immediately followed by the same author's insertion
+ * collapses into a single `replacement` entry; paragraph-mark
  * cards (`paragraphMarkInsertion` / `paragraphMarkDeletion`) are
  * hidden when an inline entry already covers their revision triple
  * (one Accept clears every site of one conceptual change).
@@ -677,9 +677,13 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
     }
   }
 
-  // Detect replacement pairs: adjacent deletion + insertion from the
-  // same author/date. Word assigns different w:id values but same
-  // author+date for a single replace.
+  // Detect replacement pairs: a deletion immediately followed by the same
+  // author's insertion. Author plus adjacency is the whole identity of a
+  // replace — the two halves carry different `w:id` values, and their
+  // `w:date` stamps differ whenever the clock ticked between them or the
+  // producer rounded them differently. Requiring the stamps to match split
+  // such a replace into a Deleted card and an Inserted card, so accepting or
+  // rejecting the change only ever acted on half of it.
   const final: TrackedChangeEntry[] = [];
   for (let i = 0; i < merged.length; i++) {
     const curr = merged[i]!;
@@ -689,7 +693,6 @@ export function extractTrackedChanges(state: EditorState | null): TrackedChanges
       next &&
       next.type === "insertion" &&
       curr.author === next.author &&
-      curr.date === next.date &&
       curr.to === next.from
     ) {
       final.push({

--- a/packages/core/src/utils/clipboard.ts
+++ b/packages/core/src/utils/clipboard.ts
@@ -11,6 +11,7 @@
 import createDOMPurify from "dompurify";
 
 import type { Run, TextFormatting, Paragraph } from "../types/document";
+import { htmlCommentEnd } from "./htmlComments";
 import { stripXmlDeclarations } from "./stripXmlDeclarations";
 
 // DOMPurify's default export only binds `sanitize` when a `window` exists.
@@ -462,12 +463,12 @@ function stripHtmlComments(html: string): string {
     }
 
     result += html.slice(cursor, start);
-    const end = html.indexOf("-->", start + 4);
-    if (end === -1) {
+    const end = htmlCommentEnd(html, start);
+    if (end === null) {
       break;
     }
 
-    cursor = end + 3;
+    cursor = end;
   }
 
   return result;

--- a/packages/core/src/utils/htmlComments.test.ts
+++ b/packages/core/src/utils/htmlComments.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { htmlCommentEnd } from "./htmlComments";
+
+describe("htmlCommentEnd", () => {
+  test("closes an abrupt comment at its own '>'", () => {
+    expect(htmlCommentEnd("<!--><p>keep me</p>", 0)).toBe(5);
+    expect(htmlCommentEnd("<!---><p>keep me</p>", 0)).toBe(6);
+  });
+
+  test("closes an ordinary comment past its terminator", () => {
+    expect(htmlCommentEnd("<!-- note --><p>keep me</p>", 0)).toBe(13);
+  });
+
+  test("reports an unterminated comment", () => {
+    expect(htmlCommentEnd("before<!--dangling", 6)).toBeNull();
+  });
+
+  test("a comment whose body starts with a dash is not abrupt", () => {
+    // `<!---x-->`: the third dash opens the body, it does not close the comment.
+    expect(htmlCommentEnd("<!---x-->", 0)).toBe(9);
+  });
+});

--- a/packages/core/src/utils/htmlComments.ts
+++ b/packages/core/src/utils/htmlComments.ts
@@ -1,0 +1,23 @@
+/**
+ * Index just past the HTML comment that opens at `start`, or `null` when the
+ * comment is never closed.
+ *
+ * `<!-->` and `<!--->` are ABRUPT-CLOSING comments: the tokenizer's comment
+ * start and comment-start-dash states end the comment at that `>` (HTML
+ * §13.2.5.42-43). Scanning for `-->` from `start + 4` runs straight past them,
+ * finds nothing, and every caller then treats the rest of the document as one
+ * unterminated comment — a pasted payload that opens with `<!-->` is dropped
+ * whole and silently.
+ *
+ * Both comment strippers resolve the terminator here so the two cannot drift.
+ */
+export const htmlCommentEnd = (html: string, start: number): number | null => {
+  if (html[start + 4] === ">") {
+    return start + 5;
+  }
+  if (html[start + 4] === "-" && html[start + 5] === ">") {
+    return start + 6;
+  }
+  const end = html.indexOf("-->", start + 4);
+  return end === -1 ? null : end + 3;
+};


### PR DESCRIPTION
Seven independent defects, one commit each, each with a test that fails without its fix.

| # | Commit | Defect | Fix | Test |
|---|---|---|---|---|
| 1 | `fix(core): a level-only w:numPr drops its list numbering` | `w:numId` and `w:ilvl` inherit independently (§17.3.1.19). A direct `w:pPr/w:numPr` was read as a whole replacement of the style tier, so a paragraph stating only `w:ilvl` — what Word writes when a styled list paragraph is demoted — lost the id and rendered unnumbered. | Merge the direct tier over the style tier per field in `paragraphParser`. The style chain already merged this way. `w:numId w:val="0"` still switches numbering off (§17.9.18); the style stays recorded as the id's source so it keeps its indent precedence. | `paragraphParser-numbering-indent.test.ts`: level-only direct tier, level-only style tier, recorded provenance, null numbering definition |
| 2 | `fix(core): inserting a row splits a vertical merge instead of extending it` | `addRowAbove`/`addRowBelow` cloned the caret row cell-for-cell. A row inside a vertical merge carries no cell for the merged column, so the clone emitted a cell for a column the merge already occupies: the grid widened and every later row desynchronised. The merge was never grown, so the saved file lost it. | Resolve the boundary through `TableMap`. A cell covering both sides gains a row; only columns the boundary opens get a new cell, shaped from the cell covering that column. `deleteRow` was already merge-correct, so the two directions now agree. | `TableExtension.test.ts`: boundary inside the merge, below it, above the first row |
| 3 | `fix(core): a table cell frames every bordered paragraph separately` | Adjacent paragraphs sharing a `w:pBdr` are one frame with an interior `w:between` rule (§17.3.1.7). The table-cell path called the fragment renderer without the neighbours' borders, so every bordered paragraph in a cell drew a closed box and the between rule never painted. The text-box and body-flow paths already passed them. | Thread the neighbouring blocks' borders through the cell path. | `renderTableFragment.test.ts`: one frame across two identically bordered cell paragraphs |
| 4 | `fix(core): a top-to-bottom cell paints its text horizontally` | Only `btLr` was rotated. `tbRl`, its vertical variants and the `tb` short spelling fell through to horizontal paint and overflowed the column, because rotated content is laid out against the row height and the cell never asked for that width. | Replace the two `=== "btLr"` checks with a total map from the direction union to its quarter turn, so a direction added later must state its turn. | `renderTableFragment.test.ts`: both turns and the horizontal case |
| 5 | `fix(core): an abrupt-closing HTML comment swallows the whole paste` | `<!-->` and `<!--->` close at that `>` (HTML §13.2.5.42-43). Both comment strippers scanned for `-->` from `start + 4`, found none, and treated the whole remainder as one unterminated comment — a paste opening with `<!-->` was dropped silently. | One shared `htmlCommentEnd` helper both strippers call, so the duplicated line cannot drift again. | `htmlComments.test.ts` + `pasteCleanup.test.ts`: both abrupt spellings, a body starting with a dash, ordinary and unterminated comments |
| 6 | `fix(core): a replace whose halves differ by a second becomes two review cards` | Author plus adjacency is the whole identity of a tracked replace; the halves' `w:date` stamps differ whenever the clock ticked or the producer rounded differently. Requiring the stamps to match split a replace into a Deleted and an Inserted card, so accept/reject acted on half the change. | Drop the stamp term from the pairing predicate. Coalescing same-type bursts still keys on the date, so unrelated edits are not merged. | `extractTrackedChanges.test.ts`: differing timestamps pair; two authors still do not |
| 7 | `fix(core): striking a selection overwrites another author's deletion` | Marking a range deleted re-marked every node in it, including nodes already struck, replacing the original reviewer's revision id, author and date with the current author's. | Skip nodes already struck, as the single-character delete path does and as the sibling insertion walk already guards. | `suggestionMode.test.ts`: pasting over a range another author struck keeps their attribution |

Plus a changeset.

## Checks

`bun run lint`, `bun run typecheck` and `bun run test` are green on this head, except one pre-existing failure: `redline.test.ts > allows exactly the generated operation limit for ordinary block operations` times out (60s budget, ~90-220s actual). It fails the same way on `origin/main` at `1cc0c5a4`, so it is not from this branch.
