### PR TITLE
feat(core): a comparison reports what its self-check found

### DIFF
--- a/.changeset/olive-checks-emit.md
+++ b/.changeset/olive-checks-emit.md
@@ -1,0 +1,27 @@
+---
+"@stll/folio-core": minor
+---
+
+`compareDocx` now reports what its self-check found instead of only acting on
+it, and can be asked for its best attempt when it cannot prove one.
+
+Every successful result carries `verification`: `{ status: "verified" }`, or
+`{ status: "unverified", failures }` where each failure names the invariant that
+did not hold (`accept-reproduces-target` or `reject-reproduces-base`), the
+projection field that diverged (`container`, `block-count`, `style`,
+`list-level`, `invisible-structure`, `whitespace`, `text`), the story it
+happened in, and a structural detail carrying no phrase of either document.
+
+The default is unchanged: an unproven redline is refused, because a reader
+cannot tell one that lost something from one that did not.
+`CompareDocxRoundTripError` now names the invariant and the cause and carries
+the whole failure list, in place of the two block-text arrays it used to hold.
+
+`onUnverified: "emit"` is the opt-in for the other trade — the redline it could
+build, plus the typed list of what it could not represent. A parse, apply or
+serialize failure is still an error under either setting: there is no redline
+to emit.
+
+Both directions of the round trip are now checked. The self-check previously
+proved only that accepting reproduces the target; it also proves that rejecting
+reproduces the base it was written against.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -253,6 +253,12 @@ export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
 export const COMPARE_UNSUPPORTED_REASONS: readonly ["story-missing-in-base", "story-missing-in-target", "story-not-editable"];
 
 // @public
+export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "whitespace", "text"];
+
+// @public
+export const COMPARE_VERIFICATION_INVARIANTS: readonly ["accept-reproduces-target", "reject-reproduces-base"];
+
+// @public
 export type CompareChange = {
     kind: "insert";
     location: CompareChangeLocation;
@@ -394,6 +400,7 @@ export class CompareDocxOperationLimitError extends CompareDocxOperationLimitErr
 export type CompareDocxOptions = {
     author: string;
     timestamp: string;
+    onUnverified?: "refuse" | "emit";
     granularity?: WordDiffGranularity;
 };
 
@@ -408,8 +415,9 @@ export class CompareDocxParseError extends CompareDocxParseError_base<{
 export class CompareDocxRoundTripError extends CompareDocxRoundTripError_base<{
     message: string;
     story: FolioDocumentStoryHandle;
-    acceptedText: readonly string[];
-    targetText: readonly string[];
+    invariant: CompareVerificationInvariant;
+    cause: CompareVerificationCause;
+    failures: readonly CompareVerificationFailure[];
 }> {}
 
 // @public (undocumented)
@@ -429,6 +437,7 @@ export type CompareFormatRange = {
 export type CompareResult = {
     buffer: ArrayBuffer;
     changes: readonly CompareChange[];
+    verification: CompareVerification;
     unsupported: readonly CompareUnsupportedPart[];
 };
 
@@ -441,6 +450,28 @@ export type CompareUnsupportedPart = {
 
 // @public (undocumented)
 export type CompareUnsupportedReason = (typeof COMPARE_UNSUPPORTED_REASONS)[number];
+
+// @public
+export type CompareVerification = {
+    status: "verified";
+} | {
+    status: "unverified";
+    failures: readonly CompareVerificationFailure[];
+};
+
+// @public (undocumented)
+export type CompareVerificationCause = (typeof COMPARE_VERIFICATION_CAUSES)[number];
+
+// @public
+export type CompareVerificationFailure = {
+    invariant: CompareVerificationInvariant;
+    cause: CompareVerificationCause;
+    story: FolioDocumentStoryHandle;
+    detail: string;
+};
+
+// @public (undocumented)
+export type CompareVerificationInvariant = (typeof COMPARE_VERIFICATION_INVARIANTS)[number];
 
 // @public
 export const consumeTemplateSlashQuery: (state: EditorState) => {

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -253,6 +253,12 @@ export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
 export const COMPARE_UNSUPPORTED_REASONS: readonly ["story-missing-in-base", "story-missing-in-target", "story-not-editable"];
 
 // @public
+export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "whitespace", "text"];
+
+// @public
+export const COMPARE_VERIFICATION_INVARIANTS: readonly ["accept-reproduces-target", "reject-reproduces-base"];
+
+// @public
 export type CompareChange = {
     kind: "insert";
     location: CompareChangeLocation;
@@ -394,6 +400,7 @@ export class CompareDocxOperationLimitError extends CompareDocxOperationLimitErr
 export type CompareDocxOptions = {
     author: string;
     timestamp: string;
+    onUnverified?: "refuse" | "emit";
     granularity?: WordDiffGranularity;
 };
 
@@ -408,8 +415,9 @@ export class CompareDocxParseError extends CompareDocxParseError_base<{
 export class CompareDocxRoundTripError extends CompareDocxRoundTripError_base<{
     message: string;
     story: FolioDocumentStoryHandle;
-    acceptedText: readonly string[];
-    targetText: readonly string[];
+    invariant: CompareVerificationInvariant;
+    cause: CompareVerificationCause;
+    failures: readonly CompareVerificationFailure[];
 }> {}
 
 // @public (undocumented)
@@ -429,6 +437,7 @@ export type CompareFormatRange = {
 export type CompareResult = {
     buffer: ArrayBuffer;
     changes: readonly CompareChange[];
+    verification: CompareVerification;
     unsupported: readonly CompareUnsupportedPart[];
 };
 
@@ -441,6 +450,28 @@ export type CompareUnsupportedPart = {
 
 // @public (undocumented)
 export type CompareUnsupportedReason = (typeof COMPARE_UNSUPPORTED_REASONS)[number];
+
+// @public
+export type CompareVerification = {
+    status: "verified";
+} | {
+    status: "unverified";
+    failures: readonly CompareVerificationFailure[];
+};
+
+// @public (undocumented)
+export type CompareVerificationCause = (typeof COMPARE_VERIFICATION_CAUSES)[number];
+
+// @public
+export type CompareVerificationFailure = {
+    invariant: CompareVerificationInvariant;
+    cause: CompareVerificationCause;
+    story: FolioDocumentStoryHandle;
+    detail: string;
+};
+
+// @public (undocumented)
+export type CompareVerificationInvariant = (typeof COMPARE_VERIFICATION_INVARIANTS)[number];
 
 // @public
 export const consumeTemplateSlashQuery: (state: EditorState) => {

--- a/benchmarks/compare/README.md
+++ b/benchmarks/compare/README.md
@@ -118,21 +118,27 @@ fetch one into.
 
 ### Why a corpus was refused
 
-`--refusals` compares every pair of a `--corpus` directory once and reports
-what the refusals were refused for, largest bucket first. On documents nobody
-authored for the engine the interesting number is the refusal rate, and a
-refusal rate is only actionable split by cause: a total says how much was
-refused, a bucket says which part of it is one missing operation and which is
-a document the engine must not process.
+`--refusals` compares every pair of a `--corpus` directory in both modes and
+reports two tables. The strict default refuses what it cannot prove, so its
+number is the refusal rate: what a caller who demands a proven redline gets.
+`onUnverified: "emit"` returns the best redline available and names the
+invariants it could not prove, so its number is the verified share: what the
+engine can stand behind among the redlines it is willing to show.
 
-`refusals.ts` holds the classification. It is total over `compareDocx`'s error
-union, so a new failure class cannot land without a bucket, and it reads the
-round-trip self-check's verdict structurally: the check compares two block
-projections, so which field of the projection diverged says which part of the
-pipeline lost the difference. Every bucket's `shape` string carries counts,
-offsets and container kinds only, never a phrase of either document: the corpus
-it read stays outside this repository, and the table it prints must be safe to
-quote anywhere.
+The second is never worse than the first, and the gap between them is exactly
+the set of documents where the engine has something to offer but cannot stand
+behind all of it. Both are only actionable split by cause: a total says how
+much was refused or left unproven, a bucket says which part of it is one
+missing operation and which is a document the engine must not process.
+
+`refusals.ts` holds the bucketing. It is total over `compareDocx`'s error
+union, so a new failure class cannot land without a bucket. The round-trip
+buckets are not classified here: they are the engine's own verification causes,
+prefixed. A second judgement of the same thing would drift from the one that
+ships, and it is the shipped one a caller sees. Every bucket's `shape` string
+carries counts, offsets and container kinds only, never a phrase of either
+document: the corpus it read stays outside this repository, and the table it
+prints must be safe to quote anywhere.
 
 One bucket is not a defect. `round-trip-invisible-structure` collects the pairs
 whose every block matches, in order, at coordinates the block model cannot

--- a/benchmarks/compare/refusals.ts
+++ b/benchmarks/compare/refusals.ts
@@ -1,26 +1,31 @@
 /**
- * What a refused comparison was refused for.
+ * What a comparison could not prove, and what it refused outright.
  *
- * `compareDocx` returns an error rather than an unverified redline, so on a
- * corpus of documents nobody authored for it the interesting number is not the
- * wall time but the refusal rate — and a refusal rate is only actionable split
- * by cause. A total says how much was refused; a bucket says which part of it
- * is one missing operation and which is a document the engine must not process
- * at all.
+ * `compareDocx` verifies its own work: accepting the generated revisions must
+ * reproduce the target, rejecting them must reproduce the base. It refuses by
+ * default when it cannot prove that, and returns its best attempt plus the
+ * list of failing invariants when asked with `onUnverified: "emit"`.
  *
- * The classification is a total function of the error union: a new error class
- * cannot land without a bucket, because the switch has no default.
+ * This module reports both, over a corpus of documents nobody authored for the
+ * engine: the refusal rate under the strict default, and the verified share
+ * under the best-effort option. Both are only actionable split by cause, and
+ * the causes come from the engine's own typed verdict rather than from a
+ * second classification here — a copy of that judgement would drift from the
+ * one that ships.
  */
 
 import type { CompareDocxError, CompareUnsupportedPart } from "@stll/folio-core/compare/types";
+import type {
+  CompareVerification,
+  CompareVerificationFailure,
+} from "@stll/folio-core/compare/verification";
 
 /**
- * Why one comparison produced no document.
+ * Why one comparison produced nothing under the strict default.
  *
- * Split finely enough that a bucket names one fix. The round-trip buckets are
- * the self-check's verdict read structurally: the check compares two block
- * projections, so WHICH field of the projection diverged says which part of
- * the pipeline lost the difference.
+ * The round-trip buckets are the engine's verification causes, prefixed so a
+ * reader can tell a refusal the self-check produced from one the parser or the
+ * serializer did.
  */
 export const REFUSAL_BUCKETS = Object.freeze({
   "parse-base": "The base package could not be read into an editor model.",
@@ -28,15 +33,15 @@ export const REFUSAL_BUCKETS = Object.freeze({
   "apply-refused": "The applier refused a derived operation.",
   "operation-limit": "The difference needs more operations than the engine generates.",
   serialize: "The redlined package could not be written back out.",
-  "round-trip-invisible-structure":
-    "The target's blocks are all there, in order, at coordinates the block model cannot reach.",
-  "round-trip-block-count": "Accepting left a different number of blocks than the target has.",
-  "round-trip-container": "Every block's text matched, but one landed in the wrong container.",
-  "round-trip-style": "A block kept the base's paragraph style where the target changed it.",
-  "round-trip-list-level": "A block kept the base's list level where the target changed it.",
-  "round-trip-whitespace": "A block's text differs from the target's only in whitespace.",
-  "round-trip-text": "A block's text does not match the target's.",
   "invalid-options": "The call's options were not usable.",
+  "round-trip-invisible-structure":
+    "Every block is there, in order, at coordinates the block model cannot reach.",
+  "round-trip-block-count": "The result holds a different number of blocks than expected.",
+  "round-trip-container": "Every block's text matched, but one sits in the wrong container.",
+  "round-trip-style": "A block kept a paragraph style the other side changed.",
+  "round-trip-list-level": "A block kept a list level the other side changed.",
+  "round-trip-whitespace": "A block's text differs only in whitespace.",
+  "round-trip-text": "A block's text does not match.",
 } as const);
 
 export type RefusalBucket = keyof typeof REFUSAL_BUCKETS;
@@ -51,38 +56,6 @@ export type Refusal = {
    */
   shape: string;
 };
-
-/**
- * One block of the self-check's projection. `projectStory` writes
- * `container|styleId|listLevel|text`, so the text is everything after the
- * third separator and may itself contain one.
- */
-type ProjectedBlock = {
-  container: string;
-  styleId: string;
-  listLevel: string;
-  text: string;
-};
-
-const parseProjection = (entry: string): ProjectedBlock => {
-  const first = entry.indexOf("|");
-  const second = entry.indexOf("|", first + 1);
-  const third = entry.indexOf("|", second + 1);
-  if (first === -1 || second === -1 || third === -1) {
-    return { container: "", styleId: "", listLevel: "", text: entry };
-  }
-  return {
-    container: entry.slice(0, first),
-    styleId: entry.slice(first + 1, second),
-    listLevel: entry.slice(second + 1, third),
-    text: entry.slice(third + 1),
-  };
-};
-
-const containerKind = (container: string): "body" | "cell" =>
-  container.startsWith("t") ? "cell" : "body";
-
-const collapseWhitespace = (text: string): string => text.replace(/\s+/gu, " ").trim();
 
 /**
  * An error message with its variable parts removed, so two failures of one
@@ -102,143 +75,9 @@ const messageShape = (message: string): string =>
 const causeMessage = (cause: unknown): string =>
   cause instanceof Error ? `${cause.name}: ${messageShape(cause.message)}` : "non-Error cause";
 
-/**
- * Where two projections first diverge, and what diverged there. A projection
- * pair that matches everywhere but in length diverges at the shorter one's end.
- */
-const firstDivergence = (
-  accepted: readonly string[],
-  target: readonly string[],
-): { index: number; accepted: ProjectedBlock | null; target: ProjectedBlock | null } => {
-  const shared = Math.min(accepted.length, target.length);
-  for (let index = 0; index < shared; index++) {
-    if (accepted[index] !== target[index]) {
-      return {
-        index,
-        accepted: parseProjection(accepted[index] ?? ""),
-        target: parseProjection(target[index] ?? ""),
-      };
-    }
-  }
-  return {
-    index: shared,
-    accepted: shared < accepted.length ? parseProjection(accepted[shared] ?? "") : null,
-    target: shared < target.length ? parseProjection(target[shared] ?? "") : null,
-  };
-};
-
-const CONTAINER_PATTERN = /^t(\d+)r(\d+)c(\d+)p(\d+)$/u;
-
-/**
- * The same projection with every table coordinate renumbered by first
- * appearance, so it counts the blocks the model holds rather than the
- * paragraphs the package contains.
- *
- * The snapshot skips every empty textblock, so a cell holding a blank
- * paragraph reports its visible paragraph at `p1`, and a table whose first
- * rows are empty reports its visible rows starting at `r3`. No operation can
- * put a block at those coordinates, because no operation can create the empty
- * paragraphs that produce them. When two projections agree here and disagree
- * on the raw coordinates, the redline holds every block the target does, in
- * order, and the difference is one the block model cannot see — which is a
- * different finding from a redline that lost content, and is reported as one.
- */
-const byVisibleOrdinal = (entries: readonly string[]): string[] => {
-  const ordinals = new Map<string, number>();
-  const counts = new Map<string, number>();
-  const ordinalWithin = (scope: string, index: string): number => {
-    const key = `${scope}:${index}`;
-    const existing = ordinals.get(key);
-    if (existing !== undefined) {
-      return existing;
-    }
-    const next = counts.get(scope) ?? 0;
-    counts.set(scope, next + 1);
-    ordinals.set(key, next);
-    return next;
-  };
-
-  const paragraphCounts = new Map<string, number>();
-  return entries.map((entry) => {
-    const first = entry.indexOf("|");
-    const match = CONTAINER_PATTERN.exec(entry.slice(0, first));
-    if (!match) {
-      return entry;
-    }
-    const [, table = "", row = "", cell = ""] = match;
-    const tableOrdinal = ordinalWithin("t", table);
-    const rowScope = `r${String(tableOrdinal)}`;
-    const rowOrdinal = ordinalWithin(rowScope, row);
-    const cellScope = `c${String(tableOrdinal)}.${String(rowOrdinal)}`;
-    const cellOrdinal = ordinalWithin(cellScope, cell);
-    // Separated, so cell 23 of scope `c0.1` is not cell 3 of scope `c0.12`.
-    const cellKey = `${cellScope}:${cell}`;
-    const paragraphOrdinal = paragraphCounts.get(cellKey) ?? 0;
-    paragraphCounts.set(cellKey, paragraphOrdinal + 1);
-    return (
-      `t${String(tableOrdinal)}r${String(rowOrdinal)}c${String(cellOrdinal)}p${String(paragraphOrdinal)}` +
-      entry.slice(first)
-    );
-  });
-};
-
-/** Element by element, never by joining: a block's text may hold the separator. */
-const sameEntries = (left: readonly string[], right: readonly string[]): boolean =>
-  left.length === right.length && left.every((entry, index) => entry === right[index]);
-
-const classifyRoundTrip = (accepted: readonly string[], target: readonly string[]): Refusal => {
-  if (sameEntries(byVisibleOrdinal(accepted), byVisibleOrdinal(target))) {
-    return {
-      bucket: "round-trip-invisible-structure",
-      shape: `every block matches once table coordinates count visible blocks (${String(target.length)} blocks)`,
-    };
-  }
-  const divergence = firstDivergence(accepted, target);
-  const at = `at block ${String(divergence.index)}/${String(target.length)}`;
-  if (divergence.accepted === null || divergence.target === null) {
-    const side = accepted.length > target.length ? "more" : "fewer";
-    return {
-      bucket: "round-trip-block-count",
-      shape: `accepting left ${side} blocks than the target has (${String(accepted.length)} vs ${String(target.length)}), diverging ${at}`,
-    };
-  }
-  const { accepted: left, target: right } = divergence;
-  const counts = `${String(accepted.length)} blocks accepted, ${String(target.length)} expected`;
-  if (left.container !== right.container) {
-    return {
-      bucket: "round-trip-container",
-      shape: `a block landed in a ${containerKind(left.container)} where the target has it in a ${containerKind(right.container)}, ${at} (${counts})`,
-    };
-  }
-  if (left.text === right.text && left.styleId !== right.styleId) {
-    return {
-      bucket: "round-trip-style",
-      shape: `the paragraph style did not move ${at} (${counts})`,
-    };
-  }
-  if (left.text === right.text && left.listLevel !== right.listLevel) {
-    return {
-      bucket: "round-trip-list-level",
-      shape: `the list level did not move ${at} (${counts})`,
-    };
-  }
-  if (collapseWhitespace(left.text) === collapseWhitespace(right.text)) {
-    return {
-      bucket: "round-trip-whitespace",
-      shape: `a block's text differs only in whitespace ${at} (${counts})`,
-    };
-  }
-  if (accepted.length !== target.length) {
-    return {
-      bucket: "round-trip-block-count",
-      shape: `accepting left ${String(accepted.length)} blocks against the target's ${String(target.length)}, first differing ${at}`,
-    };
-  }
-  return {
-    bucket: "round-trip-text",
-    shape: `a ${containerKind(left.container)} block's text does not match ${at}, base-side length ${String(left.text.length)} against ${String(right.text.length)} (${counts})`,
-  };
-};
+/** The bucket one verification cause belongs to. */
+export const bucketOfCause = (cause: CompareVerificationFailure["cause"]): RefusalBucket =>
+  `round-trip-${cause}`;
 
 /** Bucket one refusal. Total over the error union: no default branch. */
 export const classifyRefusal = (error: CompareDocxError): Refusal => {
@@ -256,14 +95,14 @@ export const classifyRefusal = (error: CompareDocxError): Refusal => {
       };
     }
     case "CompareDocxOperationLimitError":
-      return {
-        bucket: "operation-limit",
-        shape: `over ${String(error.limit)} operations`,
-      };
+      return { bucket: "operation-limit", shape: `over ${String(error.limit)} operations` };
     case "CompareDocxSerializeError":
       return { bucket: "serialize", shape: causeMessage(error.cause) };
     case "CompareDocxRoundTripError":
-      return classifyRoundTrip(error.acceptedText, error.targetText);
+      return {
+        bucket: bucketOfCause(error.cause),
+        shape: `${error.invariant}: ${error.failures.at(0)?.detail ?? "no detail"}`,
+      };
     case "InvalidCompareDocxOptionsError":
       return { bucket: "invalid-options", shape: `option ${error.option}` };
     default: {
@@ -273,35 +112,49 @@ export const classifyRefusal = (error: CompareDocxError): Refusal => {
   }
 };
 
-/** One corpus pair's outcome, as the refusal report records it. */
-export type PairOutcome =
-  | {
-      id: string;
-      status: "produced";
-      changes: number;
-      unsupported: readonly CompareUnsupportedPart["reason"][];
-    }
-  | { id: string; status: "refused"; bucket: RefusalBucket; shape: string };
+/** One corpus pair's outcome under both modes. */
+export type PairOutcome = {
+  id: string;
+  /** The strict default: a redline, or nothing. */
+  strict: { status: "produced" } | ({ status: "refused" } & Refusal);
+  /** Best effort: a redline either way, and whether it was proven. */
+  bestEffort:
+    | {
+        status: "verified";
+        changes: number;
+        unsupported: readonly CompareUnsupportedPart["reason"][];
+      }
+    | {
+        status: "unverified";
+        changes: number;
+        buckets: readonly RefusalBucket[];
+        shapes: readonly string[];
+      }
+    | { status: "failed"; bucket: RefusalBucket; shape: string };
+};
+
+/** The best-effort side of one comparison, from its verification verdict. */
+export const summarizeVerification = (
+  verification: CompareVerification,
+): { buckets: RefusalBucket[]; shapes: string[] } => {
+  if (verification.status === "verified") {
+    return { buckets: [], shapes: [] };
+  }
+  return {
+    buckets: verification.failures.map(({ cause }) => bucketOfCause(cause)),
+    shapes: verification.failures.map(({ invariant, detail }) => `${invariant}: ${detail}`),
+  };
+};
 
 type BucketRow = { bucket: RefusalBucket; count: number; shapes: Map<string, number> };
 
-/** The bucket table, largest first, with each bucket's commonest shape. */
-export const summarizeRefusals = (
-  outcomes: readonly PairOutcome[],
-): { bucket: RefusalBucket; count: number; shape: string }[] => {
+const tally = (entries: readonly { bucket: RefusalBucket; shape: string }[]) => {
   const rows = new Map<RefusalBucket, BucketRow>();
-  for (const outcome of outcomes) {
-    if (outcome.status !== "refused") {
-      continue;
-    }
-    const row = rows.get(outcome.bucket) ?? {
-      bucket: outcome.bucket,
-      count: 0,
-      shapes: new Map<string, number>(),
-    };
+  for (const { bucket, shape } of entries) {
+    const row = rows.get(bucket) ?? { bucket, count: 0, shapes: new Map<string, number>() };
     row.count += 1;
-    row.shapes.set(outcome.shape, (row.shapes.get(outcome.shape) ?? 0) + 1);
-    rows.set(outcome.bucket, row);
+    row.shapes.set(shape, (row.shapes.get(shape) ?? 0) + 1);
+    rows.set(bucket, row);
   }
   return [...rows.values()]
     .toSorted((left, right) => right.count - left.count || left.bucket.localeCompare(right.bucket))
@@ -312,3 +165,32 @@ export const summarizeRefusals = (
         [...shapes.entries()].toSorted((left, right) => right[1] - left[1])[0]?.[0] ?? "no shape",
     }));
 };
+
+/** The strict mode's refusals, largest bucket first. */
+export const summarizeRefusals = (outcomes: readonly PairOutcome[]) =>
+  tally(
+    outcomes.flatMap(({ strict }) =>
+      strict.status === "refused" ? [{ bucket: strict.bucket, shape: strict.shape }] : [],
+    ),
+  );
+
+/**
+ * The best-effort mode's unproven invariants, largest bucket first. One
+ * document can contribute more than one: a redline that loses a difference
+ * usually fails both directions of the round trip.
+ */
+export const summarizeUnverified = (outcomes: readonly PairOutcome[]) =>
+  tally(
+    outcomes.flatMap(({ bestEffort }) => {
+      if (bestEffort.status === "failed") {
+        return [{ bucket: bestEffort.bucket, shape: bestEffort.shape }];
+      }
+      if (bestEffort.status === "verified") {
+        return [];
+      }
+      return bestEffort.buckets.map((bucket, index) => ({
+        bucket,
+        shape: bestEffort.shapes[index] ?? "no shape",
+      }));
+    }),
+  );

--- a/benchmarks/compare/run.ts
+++ b/benchmarks/compare/run.ts
@@ -33,7 +33,15 @@ import {
 import { checkInvariants, type InvariantOutcome } from "./invariants";
 import { measureHeapGrowth, sample, summarize, type Distribution } from "./measure";
 import { zipPackage } from "./package-xml";
-import { classifyRefusal, REFUSAL_BUCKETS, summarizeRefusals, type PairOutcome } from "./refusals";
+import {
+  classifyRefusal,
+  REFUSAL_BUCKETS,
+  summarizeRefusals,
+  summarizeUnverified,
+  summarizeVerification,
+  type PairOutcome,
+  type RefusalBucket,
+} from "./refusals";
 import { COMPARE_STAGES, runStagedCompare, type CompareStage } from "./stages";
 import { applyVariant, EDIT_VARIANTS, type EditVariant } from "./variants";
 import { PACKAGE_VALIDATOR_HINT, resolvePackageValidator } from "./validator";
@@ -191,9 +199,49 @@ const corpusPairBytes = (pair: CorpusPair): PairBytes => ({
   target: readDocument(pair.targetPath),
 });
 
+/** One pair's best-effort side: what `onUnverified: "emit"` gave back. */
+const bestEffortOutcome = (
+  result: Awaited<ReturnType<typeof compareDocx>>,
+): PairOutcome["bestEffort"] => {
+  if (result.isErr()) {
+    return { status: "failed", ...classifyRefusal(result.error) };
+  }
+  const { changes, unsupported, verification } = result.value;
+  if (verification.status === "verified") {
+    return {
+      status: "verified",
+      changes: changes.length,
+      unsupported: [...new Set(unsupported.map(({ reason }) => reason))],
+    };
+  }
+  return {
+    status: "unverified",
+    changes: changes.length,
+    ...summarizeVerification(verification),
+  };
+};
+
+const printBucketTable = (
+  rows: readonly { bucket: RefusalBucket; count: number; shape: string }[],
+): void => {
+  console.log("| Bucket | Documents | What it is | A representative shape |");
+  console.log("| ------ | --------: | ---------- | ---------------------- |");
+  for (const { bucket, count, shape } of rows) {
+    console.log(`| \`${bucket}\` | ${String(count)} | ${REFUSAL_BUCKETS[bucket]} | ${shape} |`);
+  }
+};
+
 /**
- * Compare every pair of an external corpus once and report what the refusals
- * were refused for.
+ * Compare every pair of an external corpus in both modes: the strict default,
+ * which refuses what it cannot prove, and `onUnverified: "emit"`, which
+ * returns its best attempt and says which invariants did not hold.
+ *
+ * Both numbers matter and they answer different questions. The refusal rate is
+ * what a caller who demands a proven redline gets; the verified share is what
+ * the engine can prove about the redlines it is willing to show. The second is
+ * never worse than the first, and the gap between them is exactly the set of
+ * documents where the engine has something to offer but cannot stand behind
+ * all of it.
  *
  * Unlike the measurement modes this runs in one process: a refusal is a yes or
  * no that no warm JIT can change, and a process per pair would turn a
@@ -216,30 +264,33 @@ const runRefusals = async (options: CliOptions): Promise<number> => {
       continue;
     }
     const { base, target } = corpusPairBytes(pair);
-    const result = await compareDocx(base, target, OPTIONS);
-    outcomes.push(
-      result.isOk()
-        ? {
-            id: pair.id,
-            status: "produced",
-            changes: result.value.changes.length,
-            unsupported: [...new Set(result.value.unsupported.map(({ reason }) => reason))],
-          }
-        : { id: pair.id, status: "refused", ...classifyRefusal(result.error) },
-    );
+    const strictResult = await compareDocx(base, target, OPTIONS);
+    const emitted = await compareDocx(base, target, { ...OPTIONS, onUnverified: "emit" });
+    outcomes.push({
+      id: pair.id,
+      strict: strictResult.isOk()
+        ? { status: "produced" }
+        : { status: "refused", ...classifyRefusal(strictResult.error) },
+      bestEffort: bestEffortOutcome(emitted),
+    });
   }
 
-  const refused = outcomes.filter(({ status }) => status === "refused").length;
-  const share = outcomes.length === 0 ? 0 : (refused / outcomes.length) * 100;
+  const total = outcomes.length;
+  const share = (count: number): string =>
+    total === 0 ? "0.0%" : `${((count / total) * 100).toFixed(1)}%`;
+  const refused = outcomes.filter(({ strict }) => strict.status === "refused").length;
+  const emittedCount = outcomes.filter(({ bestEffort }) => bestEffort.status !== "failed").length;
+  const verified = outcomes.filter(({ bestEffort }) => bestEffort.status === "verified").length;
+
   console.log(
-    `\n${String(outcomes.length)} pairs, ${String(outcomes.length - refused)} produced, ` +
-      `${String(refused)} refused (${share.toFixed(1)}%).\n`,
+    `\n${String(total)} pairs.\n` +
+      `  strict:      ${String(total - refused)} produced, ${String(refused)} refused (${share(refused)})\n` +
+      `  best effort: ${String(emittedCount)} emitted, of which ${String(verified)} verified (${share(verified)} of all pairs)\n`,
   );
-  console.log("| Bucket | Documents | What it is | A representative shape |");
-  console.log("| ------ | --------: | ---------- | ---------------------- |");
-  for (const { bucket, count, shape } of summarizeRefusals(outcomes)) {
-    console.log(`| \`${bucket}\` | ${String(count)} | ${REFUSAL_BUCKETS[bucket]} | ${shape} |`);
-  }
+  console.log("Refused under the strict default:\n");
+  printBucketTable(summarizeRefusals(outcomes));
+  console.log("\nInvariants left unproven under best effort:\n");
+  printBucketTable(summarizeUnverified(outcomes));
 
   if (options.out !== null) {
     writeFileSync(options.out, `${JSON.stringify(outcomes, null, 2)}\n`);

--- a/benchmarks/compare/stages.ts
+++ b/benchmarks/compare/stages.ts
@@ -67,10 +67,22 @@ export const runStagedCompare = async (
   }
 
   const applyStart = performance.now();
-  const changes = applyComparison(parsed.value, planned.value);
+  const applied = applyComparison(parsed.value, planned.value);
   const apply = performance.now() - applyStart;
-  if (changes.isErr()) {
-    return { status: "failed", stage: "apply", error: describe(changes.error) };
+  if (applied.isErr()) {
+    return { status: "failed", stage: "apply", error: describe(applied.error) };
+  }
+  // The stages compose what `compareDocx` composes, and it refuses an
+  // unverified result by default. Reporting the same refusal keeps the timed
+  // pipeline the shipped one rather than a lenient copy of it.
+  const { verification } = applied.value;
+  if (verification.status === "unverified") {
+    const [failure] = verification.failures;
+    return {
+      status: "failed",
+      stage: "apply",
+      error: `CompareDocxRoundTripError: ${failure?.invariant ?? "unknown"}: ${failure?.detail ?? ""}`,
+    };
   }
 
   const serializeStart = performance.now();
@@ -84,7 +96,7 @@ export const runStagedCompare = async (
     status: "ok",
     durations: { parse, align, apply, serialize },
     buffer: serialized.value,
-    changes: changes.value,
+    changes: applied.value.changes,
     unsupported: parsed.value.unsupported,
     baseBlocks: parsed.value.pairs.reduce(
       (total, { baseSnapshot }) => total + baseSnapshot.blocks.length,

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -10,7 +10,7 @@ const result = await compareDocx(base, target, {
   timestamp: "2024-03-01T00:00:00.000Z",
 });
 if (result.isOk()) {
-  const { buffer, changes, unsupported } = result.value;
+  const { buffer, changes, verification, unsupported } = result.value;
 }
 ```
 
@@ -119,11 +119,49 @@ the way Word does. The self-check's projection carries the style and the list
 level alongside the text, so a redline that reproduces every word and leaves a
 list item at the wrong level fails instead of passing.
 
-`compareDocx` checks its own work before returning: accepting the generated
-revisions must reproduce the target, table cell coordinates included. A
-difference the operation vocabulary cannot express fails with
+## Verification
+
+`compareDocx` checks its own work before returning, in both directions:
+accepting the generated revisions must reproduce the target, and rejecting
+them must reproduce the base they were written against — table cell
+coordinates included.
+
+A difference the operation vocabulary cannot express fails with
 `CompareDocxRoundTripError` rather than returning a redline that reads
-plausibly and is wrong.
+plausibly and is wrong. That is the default, and it is the right default: a
+reader cannot tell a redline that lost something from one that did not.
+
+`onUnverified: "emit"` asks for the other trade. The call then returns the best
+redline it could build and a `verification` that names what it could not prove:
+
+```ts
+const result = await compareDocx(base, target, {
+  author: "folio compare",
+  timestamp: "2024-03-01T00:00:00.000Z",
+  onUnverified: "emit",
+});
+if (result.isOk() && result.value.verification.status === "unverified") {
+  for (const { invariant, cause, story, detail } of result.value.verification.failures) {
+    // invariant: "accept-reproduces-target" | "reject-reproduces-base"
+    // cause: which field of the block projection diverged
+  }
+}
+```
+
+`verification` is on every successful result, so a caller that never passes the
+option still sees `{ status: "verified" }` and can assert on it. `cause` is one
+of `invisible-structure`, `block-count`, `container`, `style`, `list-level`,
+`whitespace`, `text` — the projection field that diverged, which is what names
+the part of the pipeline that lost the difference. `invisible-structure` is the
+one cause that is not a lost difference: every block is present, in order, at
+coordinates the block model cannot reach, because the snapshot carries no block
+for an empty paragraph.
+
+Every `detail` is structural — counts, offsets, container kinds — and carries no
+phrase of either document, so it is safe to log, report, or quote.
+
+A parse, apply or serialize failure is still an error under either setting:
+there is no redline to emit.
 
 ## Inputs that already carry tracked changes
 
@@ -187,6 +225,8 @@ carries the current numbers and the failing cases.
 - `compare.ts` — the four stages (parse, align, apply, serialize), story
   pairing, and the round-trip self-check. `compareDocx` composes them.
 - `plan.ts` — alignment and operation derivation. Pure.
+- `verification.ts` — the round-trip verdict: the invariants, the causes, and
+  the safe-to-quote detail each failure carries. Pure.
 - `formatting.ts` — the inline-formatting diff, shared with the redline
   generator.
 - `reproducible-package.ts` — ZIP entry-date restamping.

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -530,4 +530,36 @@ describe("compareDocx", () => {
       expect(changes).toEqual([]);
     });
   });
+
+  for (const { name, buffer: base, blocks: baseBlocks } of BASE_CASES) {
+    test(
+      `every scripted difference is representable, so the result verifies (${name})`,
+      async () => {
+        // The strict default turns an unproven redline into an error, so the
+        // properties above enforce this by not throwing. Stated directly it
+        // says the stronger thing: asked to emit whatever it can, the engine
+        // still has nothing it could not represent. A scripted edit is built
+        // from the operation vocabulary, so anything unverified here is a
+        // defect in the engine rather than a document it cannot express.
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const result = await compareDocx(base, scripted.value.buffer, {
+              ...OPTIONS,
+              onUnverified: "emit",
+            });
+            if (result.isErr()) {
+              throw result.error;
+            }
+            expect(result.value.verification).toEqual({ status: "verified" });
+          }),
+          propertyConfig({ numRuns: 10 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
+  }
 });

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -13,9 +13,15 @@
  * ## Round-trip contract
  *
  * Accepting every tracked change in the result yields the target's content;
- * rejecting every one yields the base's. Anything the comparison does not
- * cover is reported in `unsupported`, or fails the call, rather than being
- * silently dropped.
+ * rejecting every one yields the base's. Both directions are checked before
+ * the call returns, and the verdict travels with the result as
+ * `verification`. Anything the comparison does not cover is reported in
+ * `unsupported`, or fails the call, rather than being silently dropped.
+ *
+ * An unproven redline is refused by default. `onUnverified: "emit"` returns it
+ * anyway, with every invariant that did not hold named: a caller that would
+ * rather show its best attempt and say what is missing can, and one that wants
+ * a redline it can stand behind still gets nothing else.
  *
  * ## Stages
  *
@@ -55,6 +61,11 @@ import {
   type CompareResult,
   type CompareUnsupportedPart,
 } from "./types";
+import {
+  classifyProjectionMismatch,
+  type CompareVerification,
+  type CompareVerificationFailure,
+} from "./verification";
 
 /**
  * Cap on operations one comparison generates. Both inputs are untrusted
@@ -112,8 +123,12 @@ const existingRevisionsOf = (reviewer: FolioDocxReviewer): ExistingRevisions => 
  * the table cell it sits in. The tag is what makes the self-check below see a
  * paragraph that landed beside a table instead of inside it.
  */
-const projectStory = (reviewer: FolioDocxReviewer, story: FolioDocumentStoryHandle): string[] => {
-  const blocks = reviewer.readReviewedStory({ story, view: "final" })?.snapshot.blocks ?? [];
+const projectStory = (
+  reviewer: FolioDocxReviewer,
+  story: FolioDocumentStoryHandle,
+  view: "final" | "original" = "final",
+): string[] => {
+  const blocks = reviewer.readReviewedStory({ story, view })?.snapshot.blocks ?? [];
   return blocks.map(({ text, table, styleId, listLevel }) => {
     const container = table
       ? `t${String(table.tableIndex)}r${String(table.rowIndex)}c${String(table.cellIndex)}p${String(table.paragraphIndex)}`
@@ -311,18 +326,31 @@ export const planComparison = ({
   return Result.ok(planned);
 };
 
+/** What stage 3 produced: the change list, and whether it was proven. */
+export type AppliedComparison = {
+  changes: readonly CompareChange[];
+  verification: CompareVerification;
+};
+
 /**
  * Stage 3: write the planned operations into the base document as tracked
- * changes, then check the work rather than trust it: accepting the story's
- * generated revisions must reproduce the target, structure included. A
- * difference the operation vocabulary cannot express would otherwise leave a
- * redline that reads plausibly and is wrong.
+ * changes, then check the work rather than trust it. Both directions of the
+ * round trip are checked, structure included: accepting the story's generated
+ * revisions must reproduce the target, and rejecting them must reproduce the
+ * base it was compared from. A difference the operation vocabulary cannot
+ * express would otherwise leave a redline that reads plausibly and is wrong.
+ *
+ * The check reports rather than throws. {@link compareDocx} decides what to do
+ * with an unverified result, because "give me your best attempt and tell me
+ * what you could not represent" and "give me nothing unless you can prove it"
+ * are both legitimate asks and only the caller knows which one it is making.
  */
 export const applyComparison = (
   { reviewer, targetReviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
   planned: readonly PlannedStoryComparison[],
-): Result<readonly CompareChange[], CompareDocxApplyError | CompareDocxRoundTripError> => {
+): Result<AppliedComparison, CompareDocxApplyError> => {
   const changes: CompareChange[] = [...numberingChanges];
+  const failures: CompareVerificationFailure[] = [];
   // Each story gets the range that starts where the previous story's ended.
   // A revision `w:id` is scoped to the package, not the part, so two stories
   // seeded alike would let a reader resolving a header revision resolve a
@@ -333,6 +361,10 @@ export const applyComparison = (
     if (plan.operations.length === 0) {
       continue;
     }
+
+    // Read before the operations land: this is the document the redline is
+    // written against, and rejecting every revision has to return to it.
+    const baseBefore = projectStory(reviewer, pair.baseStory);
 
     const { skipped, nextRevisionId } = reviewer.applyDocumentOperationsToStory({
       story: pair.baseStory,
@@ -363,20 +395,30 @@ export const applyComparison = (
       );
     }
 
-    const accepted = projectStory(reviewer, pair.baseStory);
-    const expected = projectStory(targetReviewer, pair.targetStory);
-    if (accepted.join(" ") !== expected.join(" ")) {
-      return Result.err(
-        new CompareDocxRoundTripError({
-          message: "Accepting the generated tracked changes does not reproduce the target.",
-          story: pair.baseStory,
-          acceptedText: accepted,
-          targetText: expected,
-        }),
-      );
+    const acceptFailure = classifyProjectionMismatch({
+      invariant: "accept-reproduces-target",
+      story: pair.baseStory,
+      actual: projectStory(reviewer, pair.baseStory),
+      expected: projectStory(targetReviewer, pair.targetStory),
+    });
+    if (acceptFailure) {
+      failures.push(acceptFailure);
+    }
+    const rejectFailure = classifyProjectionMismatch({
+      invariant: "reject-reproduces-base",
+      story: pair.baseStory,
+      actual: projectStory(reviewer, pair.baseStory, "original"),
+      expected: baseBefore,
+    });
+    if (rejectFailure) {
+      failures.push(rejectFailure);
     }
   }
-  return Result.ok(changes);
+  return Result.ok({
+    changes,
+    verification:
+      failures.length === 0 ? { status: "verified" } : { status: "unverified", failures },
+  });
 };
 
 /**
@@ -419,6 +461,13 @@ export const serializeComparison = async (
  * Compare `base` against `target` and return `base` carrying the tracked
  * changes that turn it into `target`, alongside the change list describing
  * them.
+ *
+ * The result is verified by default: a redline whose round trip cannot be
+ * proven is refused rather than returned, because one that reads plausibly and
+ * is wrong is worse than none. `onUnverified: "emit"` asks for the opposite
+ * trade — the best redline available, plus the typed list of what could not be
+ * represented — for a caller that would rather show something and say what is
+ * missing.
  */
 export const compareDocx = async (
   base: ArrayBuffer,
@@ -433,9 +482,25 @@ export const compareDocx = async (
   if (planned.isErr()) {
     return Result.err(planned.error);
   }
-  const changes = applyComparison(parsed.value, planned.value);
-  if (changes.isErr()) {
-    return Result.err(changes.error);
+  const applied = applyComparison(parsed.value, planned.value);
+  if (applied.isErr()) {
+    return Result.err(applied.error);
+  }
+  const { changes, verification } = applied.value;
+  if (verification.status === "unverified" && (options.onUnverified ?? "refuse") === "refuse") {
+    const [firstFailure] = verification.failures;
+    if (firstFailure === undefined) {
+      panic("An unverified comparison reported no failing invariant");
+    }
+    return Result.err(
+      new CompareDocxRoundTripError({
+        message: `The generated tracked changes do not satisfy ${firstFailure.invariant}: ${firstFailure.detail}`,
+        story: firstFailure.story,
+        invariant: firstFailure.invariant,
+        cause: firstFailure.cause,
+        failures: verification.failures,
+      }),
+    );
   }
   const serialized = await serializeComparison(parsed.value, planned.value);
   if (serialized.isErr()) {
@@ -443,7 +508,8 @@ export const compareDocx = async (
   }
   return Result.ok({
     buffer: serialized.value,
-    changes: changes.value,
+    changes,
+    verification,
     unsupported: parsed.value.unsupported,
   });
 };

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -514,6 +514,48 @@ describe("single-mutation probes", () => {
     expect(deleted.at(0)).not.toMatch(/<w:pPr>[\s\S]*<w:rPr>[\s\S]*<w:del\s/u);
   });
 
+  test("unrepresentable_difference: refused by default, emitted and named on request", async () => {
+    // The target's row has a cell the base's row does not. No operation puts a
+    // paragraph inside a new cell, so the insertion lands beside the table and
+    // accepting cannot reproduce the target. The default refuses; the opt-in
+    // returns the redline it could build and names the invariant it broke.
+    const base = await buildBodySequenceDocx([
+      { kind: "paragraph", text: "The schedule below records the agreed fees." },
+      { kind: "table", rows: [["Service"]] },
+      { kind: "paragraph", text: "This agreement is governed by the stated law." },
+    ]);
+    const target = await buildBodySequenceDocx([
+      { kind: "paragraph", text: "The schedule below records the agreed fees." },
+      { kind: "table", rows: [["Service", "Fee payable on delivery"]] },
+      { kind: "paragraph", text: "This agreement is governed by the stated law." },
+    ]);
+
+    const refused = await compareDocx(base, target, OPTIONS);
+    expect(refused.isErr()).toBe(true);
+    if (refused.isErr()) {
+      const error = refused.error;
+      expect(error._tag).toBe("CompareDocxRoundTripError");
+      if (error._tag === "CompareDocxRoundTripError") {
+        expect(error.invariant).toBe("accept-reproduces-target");
+        expect(error.cause).toBe("container");
+        expect(error.failures.length).toBeGreaterThan(0);
+        // Structural facts only: nothing a document said.
+        expect(error.failures.at(0)?.detail).not.toContain("Fee payable");
+      }
+    }
+
+    const emitted = await compareDocx(base, target, { ...OPTIONS, onUnverified: "emit" });
+    if (emitted.isErr()) {
+      throw emitted.error;
+    }
+    expect(emitted.value.buffer.byteLength).toBeGreaterThan(0);
+    expect(emitted.value.changes.length).toBeGreaterThan(0);
+    expect(emitted.value.verification.status).toBe("unverified");
+    if (emitted.value.verification.status === "unverified") {
+      expect(emitted.value.verification.failures.map(({ cause }) => cause)).toContain("container");
+    }
+  });
+
   test("append_paragraph_then_table: additions past the last block keep target order", async () => {
     // Both additions resolve to the same position — after the base's last
     // block — so their order in the document is their order in the operation

--- a/packages/core/src/compare/types.ts
+++ b/packages/core/src/compare/types.ts
@@ -13,6 +13,12 @@ import type {
   FolioAIEditSkippedOperation,
   FolioAIInlineFormatting,
 } from "../ai-edits/types";
+import type {
+  CompareVerification,
+  CompareVerificationCause,
+  CompareVerificationFailure,
+  CompareVerificationInvariant,
+} from "./verification";
 
 /** Everything {@link compareDocx} needs; nothing it reads from the ambient clock. */
 export type CompareDocxOptions = {
@@ -25,6 +31,16 @@ export type CompareDocxOptions = {
    * fixed epoch.
    */
   timestamp: string;
+  /**
+   * What to do when the round-trip self-check cannot prove the result.
+   *
+   * `"refuse"` (default) returns a {@link CompareDocxRoundTripError}: a
+   * redline that reads plausibly and is wrong is worse than no redline.
+   * `"emit"` returns the redline anyway, with `verification` naming every
+   * invariant that did not hold, for a caller that would rather show its best
+   * attempt and say what is missing.
+   */
+  onUnverified?: "refuse" | "emit";
   /**
    * Token size a changed paragraph's redline is cut at: `"word"` (default)
    * marks whole words, `"character"` marks the changed letters inside one.
@@ -220,6 +236,12 @@ export type CompareResult = {
   /** The base package carrying the generated tracked changes. */
   buffer: ArrayBuffer;
   changes: readonly CompareChange[];
+  /**
+   * Whether the round trip was proven. Always `verified` unless the call asked
+   * for `onUnverified: "emit"`, which is the only way an unproven redline is
+   * returned at all.
+   */
+  verification: CompareVerification;
   unsupported: readonly CompareUnsupportedPart[];
 };
 
@@ -254,9 +276,16 @@ export class CompareDocxApplyError extends TaggedError("CompareDocxApplyError")<
 export class CompareDocxRoundTripError extends TaggedError("CompareDocxRoundTripError")<{
   message: string;
   story: FolioDocumentStoryHandle;
-  /** Block texts the accepted result holds where the target differs. */
-  acceptedText: readonly string[];
-  targetText: readonly string[];
+  /** The invariant that did not hold, and what diverged under it. */
+  invariant: CompareVerificationInvariant;
+  cause: CompareVerificationCause;
+  /**
+   * Every invariant that failed, not only the one named above: a redline that
+   * loses a difference usually loses it in both directions, and a caller
+   * deciding what to do next wants the whole list. Each detail is structural,
+   * so it is safe to log or quote.
+   */
+  failures: readonly CompareVerificationFailure[];
 }> {}
 
 /** The difference needs more operations than the engine will generate. */

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -1,0 +1,255 @@
+/**
+ * What the round-trip self-check found, and how to say it safely.
+ *
+ * The check compares two block projections: what accepting the generated
+ * revisions leaves against the target, and what rejecting them leaves against
+ * the base. A projection carries each block's container, style, list level and
+ * text, so WHICH field diverged names which part of the pipeline lost the
+ * difference — and that is worth reporting as a typed cause rather than as one
+ * opaque "did not reproduce".
+ *
+ * Every `detail` string here is structural: counts, offsets, container kinds.
+ * Never a phrase of either document, because a caller may log it, put it in a
+ * report, or quote it in a review.
+ */
+
+import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
+
+/** The two directions of the round trip, each an invariant of its own. */
+export const COMPARE_VERIFICATION_INVARIANTS = Object.freeze([
+  "accept-reproduces-target",
+  "reject-reproduces-base",
+] as const);
+
+export type CompareVerificationInvariant = (typeof COMPARE_VERIFICATION_INVARIANTS)[number];
+
+/**
+ * What diverged. Ordered from the structural to the textual: the first cause
+ * that fits is the one reported, because a block in the wrong container is a
+ * different finding from a block whose words are wrong even when both are true.
+ */
+export const COMPARE_VERIFICATION_CAUSES = Object.freeze([
+  /**
+   * Every block is present, in order, at coordinates the block model cannot
+   * reach. The snapshot carries no block for an empty paragraph, so a cell
+   * holding a blank line reports its visible paragraph one position along and
+   * no operation can put a block there. Not a lost difference.
+   */
+  "invisible-structure",
+  "block-count",
+  "container",
+  "style",
+  "list-level",
+  "whitespace",
+  "text",
+] as const);
+
+export type CompareVerificationCause = (typeof COMPARE_VERIFICATION_CAUSES)[number];
+
+/** One invariant that did not hold, in one story. */
+export type CompareVerificationFailure = {
+  invariant: CompareVerificationInvariant;
+  cause: CompareVerificationCause;
+  story: FolioDocumentStoryHandle;
+  /** Structural facts only: counts, offsets, container kinds. Safe to quote. */
+  detail: string;
+};
+
+/**
+ * Whether the redline was proven to round-trip.
+ *
+ * `unverified` is only ever returned when the caller asked for it with
+ * `onUnverified: "emit"`; the default refuses instead, because a redline that
+ * reads plausibly and is wrong is worse than no redline.
+ */
+export type CompareVerification =
+  | { status: "verified" }
+  | { status: "unverified"; failures: readonly CompareVerificationFailure[] };
+
+/**
+ * One block of a projection. `projectStory` writes
+ * `container|styleId|listLevel|text`, so the text is everything after the
+ * third separator and may itself contain one.
+ */
+type ProjectedBlock = {
+  container: string;
+  styleId: string;
+  listLevel: string;
+  text: string;
+};
+
+const parseProjection = (entry: string): ProjectedBlock => {
+  const first = entry.indexOf("|");
+  const second = entry.indexOf("|", first + 1);
+  const third = entry.indexOf("|", second + 1);
+  if (first === -1 || second === -1 || third === -1) {
+    return { container: "", styleId: "", listLevel: "", text: entry };
+  }
+  return {
+    container: entry.slice(0, first),
+    styleId: entry.slice(first + 1, second),
+    listLevel: entry.slice(second + 1, third),
+    text: entry.slice(third + 1),
+  };
+};
+
+const CONTAINER_PATTERN = /^t(\d+)r(\d+)c(\d+)p(\d+)$/u;
+
+const containerKind = (container: string): "body" | "cell" =>
+  CONTAINER_PATTERN.test(container) ? "cell" : "body";
+
+const collapseWhitespace = (text: string): string => text.replace(/\s+/gu, " ").trim();
+
+/** Element by element, never by joining: a block's text may hold the separator. */
+export const sameProjection = (left: readonly string[], right: readonly string[]): boolean =>
+  left.length === right.length && left.every((entry, index) => entry === right[index]);
+
+/**
+ * The same projection with every table coordinate renumbered by first
+ * appearance, so it counts the blocks the model holds rather than the
+ * paragraphs the package contains.
+ *
+ * The snapshot skips every empty textblock, so a cell holding a blank
+ * paragraph reports its visible paragraph at `p1`, and a table whose first
+ * rows are empty reports its visible rows starting at `r3`. No operation can
+ * put a block at those coordinates, because none can create the empty
+ * paragraphs that produce them. When two projections agree here and disagree
+ * on the raw coordinates, the redline holds every block the other side does,
+ * in order, and the difference is one the block model cannot see.
+ */
+const byVisibleOrdinal = (entries: readonly string[]): string[] => {
+  const ordinals = new Map<string, number>();
+  const counts = new Map<string, number>();
+  const ordinalWithin = (scope: string, index: string): number => {
+    const key = `${scope}:${index}`;
+    const existing = ordinals.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const next = counts.get(scope) ?? 0;
+    counts.set(scope, next + 1);
+    ordinals.set(key, next);
+    return next;
+  };
+
+  const paragraphCounts = new Map<string, number>();
+  return entries.map((entry) => {
+    const first = entry.indexOf("|");
+    const match = CONTAINER_PATTERN.exec(entry.slice(0, first));
+    if (!match) {
+      return entry;
+    }
+    const [, table = "", row = "", cell = ""] = match;
+    const tableOrdinal = ordinalWithin("t", table);
+    const rowScope = `r${String(tableOrdinal)}`;
+    const rowOrdinal = ordinalWithin(rowScope, row);
+    const cellScope = `c${String(tableOrdinal)}.${String(rowOrdinal)}`;
+    const cellOrdinal = ordinalWithin(cellScope, cell);
+    const cellKey = `${cellScope}:${cell}`;
+    const paragraphOrdinal = paragraphCounts.get(cellKey) ?? 0;
+    paragraphCounts.set(cellKey, paragraphOrdinal + 1);
+    return (
+      `t${String(tableOrdinal)}r${String(rowOrdinal)}c${String(cellOrdinal)}p${String(paragraphOrdinal)}` +
+      entry.slice(first)
+    );
+  });
+};
+
+/**
+ * Where two projections first diverge, and what diverged there. A pair that
+ * matches everywhere but in length diverges at the shorter one's end.
+ */
+const firstDivergence = (
+  actual: readonly string[],
+  expected: readonly string[],
+): { index: number; actual: ProjectedBlock | null; expected: ProjectedBlock | null } => {
+  const shared = Math.min(actual.length, expected.length);
+  for (let index = 0; index < shared; index++) {
+    if (actual[index] !== expected[index]) {
+      return {
+        index,
+        actual: parseProjection(actual[index] ?? ""),
+        expected: parseProjection(expected[index] ?? ""),
+      };
+    }
+  }
+  return {
+    index: shared,
+    actual: shared < actual.length ? parseProjection(actual[shared] ?? "") : null,
+    expected: shared < expected.length ? parseProjection(expected[shared] ?? "") : null,
+  };
+};
+
+type ClassifyOptions = {
+  invariant: CompareVerificationInvariant;
+  story: FolioDocumentStoryHandle;
+  /** What the redline actually leaves. */
+  actual: readonly string[];
+  /** What the invariant says it should leave. */
+  expected: readonly string[];
+};
+
+/**
+ * The failure two projections describe, or `null` when they agree.
+ *
+ * Total over the causes by construction: the last branch is unconditional, so
+ * a divergence always produces a failure rather than being dropped.
+ */
+export const classifyProjectionMismatch = ({
+  invariant,
+  story,
+  actual,
+  expected,
+}: ClassifyOptions): CompareVerificationFailure | null => {
+  if (sameProjection(actual, expected)) {
+    return null;
+  }
+  const failure = (
+    cause: CompareVerificationCause,
+    detail: string,
+  ): CompareVerificationFailure => ({
+    invariant,
+    cause,
+    story,
+    detail,
+  });
+
+  if (sameProjection(byVisibleOrdinal(actual), byVisibleOrdinal(expected))) {
+    return failure(
+      "invisible-structure",
+      `every block matches once table coordinates count visible blocks (${String(expected.length)} blocks)`,
+    );
+  }
+
+  const divergence = firstDivergence(actual, expected);
+  const at = `at block ${String(divergence.index)}/${String(expected.length)}`;
+  const counts = `${String(actual.length)} blocks against ${String(expected.length)}`;
+  if (divergence.actual === null || divergence.expected === null) {
+    const side = actual.length > expected.length ? "more" : "fewer";
+    return failure("block-count", `${side} blocks than expected (${counts}), diverging ${at}`);
+  }
+  const { actual: left, expected: right } = divergence;
+  if (left.container !== right.container) {
+    return failure(
+      "container",
+      `a block sits in a ${containerKind(left.container)} where it is expected in a ${containerKind(right.container)}, ${at} (${counts})`,
+    );
+  }
+  if (left.text === right.text && left.styleId !== right.styleId) {
+    return failure("style", `the paragraph style did not move ${at} (${counts})`);
+  }
+  if (left.text === right.text && left.listLevel !== right.listLevel) {
+    return failure("list-level", `the list level did not move ${at} (${counts})`);
+  }
+  if (collapseWhitespace(left.text) === collapseWhitespace(right.text)) {
+    return failure("whitespace", `a block's text differs only in whitespace ${at} (${counts})`);
+  }
+  if (actual.length !== expected.length) {
+    return failure("block-count", `${counts}, first differing ${at}`);
+  }
+  return failure(
+    "text",
+    `a ${containerKind(left.container)} block's text does not match ${at}, ` +
+      `length ${String(left.text.length)} against ${String(right.text.length)} (${counts})`,
+  );
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,14 @@ export {
   type CompareUnsupportedPart,
   type CompareUnsupportedReason,
 } from "./compare/types";
+export {
+  COMPARE_VERIFICATION_CAUSES,
+  COMPARE_VERIFICATION_INVARIANTS,
+  type CompareVerification,
+  type CompareVerificationCause,
+  type CompareVerificationFailure,
+  type CompareVerificationInvariant,
+} from "./compare/verification";
 export { createDocx } from "./docx/rezip";
 export { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";
 export type { Document, DocxConformanceClass } from "./types/document";


### PR DESCRIPTION
## What this changes

The round-trip self-check produced one bit: refuse, or return. It knows more
than that. It compares two block projections, so which field diverged names
which part of the pipeline lost the difference — and that is worth handing to a
caller rather than collapsing into "did not reproduce".

### The verdict travels with the result

Every successful `compareDocx` result now carries `verification`, a
discriminated union:

```ts
const { buffer, changes, verification } = result.value;
// { status: "verified" }
// { status: "unverified", failures: [{ invariant, cause, story, detail }, …] }
```

`invariant` is `accept-reproduces-target` or `reject-reproduces-base`. `cause`
is the projection field that diverged: `invisible-structure`, `block-count`,
`container`, `style`, `list-level`, `whitespace`, `text`. `detail` is
structural — counts, offsets, container kinds — and carries no phrase of either
document, so it is safe to log, report, or quote.

### The default does not change

An unproven redline is still refused. A reader cannot tell a redline that lost
something from one that did not, so returning it by default would be handing
over a document that reads plausibly and is wrong.

`CompareDocxRoundTripError` now names the invariant and the cause and carries
the whole failure list, in place of the two block-text arrays it used to hold.

### `onUnverified: "emit"` is the opt-in for the other trade

The best redline the engine could build, plus the typed list of what it could
not represent, for a caller that would rather show something and say what is
missing. Parse, apply and serialize failures stay errors under either setting:
there is nothing to emit.

### Both directions are checked now

The self-check proved only that accepting reproduces the target. It also proves
that rejecting reproduces the base it was written against. This found nothing
new on the generated corpus — the result a check already implied by the
benchmark's own `reject-returns-base` invariant should give.

## Where the classification lives

The benchmark used to parse the same projections a second time to bucket a
refusal. It now reads the engine's typed verdict and prefixes it. A copy of
that judgement would drift from the one that ships, and it is the shipped one a
caller sees.

## Coverage

`bun benchmarks/compare/run.ts --corpus <dir> --refusals` now runs both modes
and prints both tables: refusals under the strict default, unproven invariants
under best effort.

A property in `compare.property.test.ts` states directly what the suite
previously enforced by not throwing: asked to emit whatever it can, a scripted
difference leaves nothing unverified. A probe pins the other side — a target
whose row has a cell the base's does not is refused by default, and under
`onUnverified: "emit"` comes back as a redline plus a `container` failure whose
detail quotes nothing from the document.

## Verification

`bun run lint`, `bun run typecheck`, `bun run format`, `bun run build`,
`bun run api:check`, the full core suite (5,738 pass), and
`bun benchmarks/compare/run.ts --check` — 216 cases, no failing invariant, all
138 recorded digests unchanged. Nothing the generated corpus produces was ever
unverified, so there is no newly emitted variant to record there.
