### PR TITLE
fix(core): the table indent reference edge depends on the document's compatibility mode

### DIFF
--- a/.changeset/plain-headers-anchor.md
+++ b/.changeset/plain-headers-anchor.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Place inline header and footer tables through the shared table placement rule, so `w:jc`, `w:tblInd` and `w:bidiVisual` behave as they do in the body.

--- a/.changeset/tidy-tables-anchor.md
+++ b/.changeset/tidy-tables-anchor.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Measure `w:tblInd` from the leading cell's text edge in documents whose `compatibilityMode` predates the border-edge rule.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -899,6 +899,9 @@ export type TableBlock = {
     layout?: "fixed" | "autofit";
     justification?: "left" | "center" | "right";
     indent?: number;
+    indentCompatibility?: {
+        type: "legacy";
+    };
     bidi?: boolean;
     floating?: FloatingTablePosition;
     pmStart?: number;

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -32,6 +32,7 @@ import { getColumns } from "../layout-bridge/sectionColumns";
 import { layoutDocument } from "../layout-engine";
 import type { ColumnLayout, SectionLayoutConfig } from "../layout-engine";
 import { resolveJustificationCompatibility } from "../layout-engine/justificationCompatibility";
+import { resolveTableIndentCompatibility } from "../layout-engine/tableIndentCompatibility";
 import {
   recordLayoutComplete,
   recordLayoutError,
@@ -387,6 +388,12 @@ export function runLayoutPipeline<THfPMs>(
     if (justificationCompatibility) {
       flowOpts.justificationCompatibility = justificationCompatibility;
     }
+    const tableIndentCompatibility = resolveTableIndentCompatibility(
+      documentSettings?.compatibilityMode,
+    );
+    if (tableIndentCompatibility) {
+      flowOpts.tableIndentCompatibility = tableIndentCompatibility;
+    }
     if (documentSettings?.autoHyphenation === true) {
       flowOpts.automaticHyphenation = {
         enabled: true,
@@ -496,6 +503,9 @@ export function runLayoutPipeline<THfPMs>(
         ...(flowOpts.lineBreakRules ? { lineBreakRules: flowOpts.lineBreakRules } : {}),
         ...(flowOpts.justificationCompatibility
           ? { justificationCompatibility: flowOpts.justificationCompatibility }
+          : {}),
+        ...(flowOpts.tableIndentCompatibility
+          ? { tableIndentCompatibility: flowOpts.tableIndentCompatibility }
           : {}),
         ...(flowOpts.automaticHyphenation
           ? { automaticHyphenation: flowOpts.automaticHyphenation }
@@ -750,6 +760,9 @@ export function runLayoutPipeline<THfPMs>(
           }
           if (flowOpts.justificationCompatibility) {
             footnoteOptions.justificationCompatibility = flowOpts.justificationCompatibility;
+          }
+          if (flowOpts.tableIndentCompatibility) {
+            footnoteOptions.tableIndentCompatibility = flowOpts.tableIndentCompatibility;
           }
           if (flowOpts.automaticHyphenation) {
             footnoteOptions.automaticHyphenation = flowOpts.automaticHyphenation;

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -51,6 +51,7 @@ export type ConvertFootnoteOptions = {
   defaultTabStopTwips?: number;
   lineBreakRules?: ToFlowBlocksOptions["lineBreakRules"];
   justificationCompatibility?: ToFlowBlocksOptions["justificationCompatibility"];
+  tableIndentCompatibility?: ToFlowBlocksOptions["tableIndentCompatibility"];
   automaticHyphenation?: ToFlowBlocksOptions["automaticHyphenation"];
 };
 
@@ -351,6 +352,9 @@ export function convertFootnoteToContent(
   }
   if (options.justificationCompatibility) {
     flowOptions.justificationCompatibility = options.justificationCompatibility;
+  }
+  if (options.tableIndentCompatibility) {
+    flowOptions.tableIndentCompatibility = options.tableIndentCompatibility;
   }
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -701,6 +701,7 @@ export type ConvertHeaderFooterOptions = {
   defaultTabStopTwips?: number;
   lineBreakRules?: ToFlowBlocksOptions["lineBreakRules"];
   justificationCompatibility?: ToFlowBlocksOptions["justificationCompatibility"];
+  tableIndentCompatibility?: ToFlowBlocksOptions["tableIndentCompatibility"];
   automaticHyphenation?: ToFlowBlocksOptions["automaticHyphenation"];
   /**
    * Relationship id of the source HF part. Stamped onto the returned
@@ -758,6 +759,9 @@ export function convertHeaderFooterToContent(
   if (options.justificationCompatibility) {
     flowOptions.justificationCompatibility = options.justificationCompatibility;
   }
+  if (options.tableIndentCompatibility) {
+    flowOptions.tableIndentCompatibility = options.tableIndentCompatibility;
+  }
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;
   }
@@ -804,6 +808,9 @@ export function convertHeaderFooterPmDocToContent(
   }
   if (options.justificationCompatibility) {
     flowOptions.justificationCompatibility = options.justificationCompatibility;
+  }
+  if (options.tableIndentCompatibility) {
+    flowOptions.tableIndentCompatibility = options.tableIndentCompatibility;
   }
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-table-bidi.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-table-bidi.test.ts
@@ -48,4 +48,22 @@ describe("toFlowBlocks table indent compatibility", () => {
   test("leaves the policy unset when the document uses border-edge indents", () => {
     expect(firstTable(tableDoc(null)).indentCompatibility).toBeUndefined();
   });
+
+  test("drops the policy for a table whose indent measurement cannot be applied", () => {
+    const block = toFlowBlocks(tableDoc({ indent: { value: 108, type: "pct" } }), {
+      tableIndentCompatibility: { type: "legacy" },
+    }).find((b) => b.kind === "table");
+
+    expect(block?.indent).toBeUndefined();
+    expect(block?.indentCompatibility).toBeUndefined();
+  });
+
+  test("keeps the policy for a table with a usable indent measurement", () => {
+    const block = toFlowBlocks(tableDoc({ indent: { value: 108, type: "dxa" } }), {
+      tableIndentCompatibility: { type: "legacy" },
+    }).find((b) => b.kind === "table");
+
+    expect(block?.indent).toBeCloseTo(7.2, 3);
+    expect(block?.indentCompatibility).toEqual({ type: "legacy" });
+  });
 });

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-table-bidi.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-table-bidi.test.ts
@@ -35,3 +35,17 @@ describe("toFlowBlocks table bidiVisual", () => {
     expect(firstTable(tableDoc({})).bidi).toBeUndefined();
   });
 });
+
+describe("toFlowBlocks table indent compatibility", () => {
+  test("carries the document's text-edge indent policy onto every table block", () => {
+    const block = toFlowBlocks(tableDoc(null), {
+      tableIndentCompatibility: { type: "legacy" },
+    }).find((b) => b.kind === "table");
+
+    expect(block?.indentCompatibility).toEqual({ type: "legacy" });
+  });
+
+  test("leaves the policy unset when the document uses border-edge indents", () => {
+    expect(firstTable(tableDoc(null)).indentCompatibility).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -154,6 +154,8 @@ export type ToFlowBlocksOptions = {
   };
   /** Document-generation policy for justified line fitting. */
   justificationCompatibility?: NonNullable<ParagraphAttrs["justificationCompatibility"]>;
+  /** Document-generation policy for where `w:tblInd` is measured from. */
+  tableIndentCompatibility?: NonNullable<TableBlock["indentCompatibility"]>;
   /** Document-wide automatic hyphenation policy. */
   automaticHyphenation?: NonNullable<ParagraphAttrs["automaticHyphenation"]>;
   /** Line pitch for the final body section, whose properties live outside the PM body. */
@@ -2447,6 +2449,9 @@ function convertTable(node: PMNode, startPos: number, options: FlowConversionOpt
   }
   if (indentPx !== undefined) {
     tableBlock.indent = indentPx;
+  }
+  if (options.tableIndentCompatibility) {
+    tableBlock.indentCompatibility = options.tableIndentCompatibility;
   }
   if (floatingPx) {
     tableBlock.floating = floatingPx;

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2373,6 +2373,10 @@ function convertTable(node: PMNode, startPos: number, options: FlowConversionOpt
     effectiveIndent?.value !== undefined && effectiveIndent?.type === "dxa"
       ? twipsToPixels(effectiveIndent.value)
       : undefined;
+  // An indent measurement folio cannot apply must not half-apply: pairing the
+  // text-edge compensation with a dropped `w:tblInd` would shift the table by
+  // the leading cell margin alone, which no indent asked for.
+  const dropsAuthoredIndent = effectiveIndent?.value !== undefined && indentPx === undefined;
 
   const floating = attrs.floating as
     | {
@@ -2450,7 +2454,7 @@ function convertTable(node: PMNode, startPos: number, options: FlowConversionOpt
   if (indentPx !== undefined) {
     tableBlock.indent = indentPx;
   }
-  if (options.tableIndentCompatibility) {
+  if (options.tableIndentCompatibility && !dropsAuthoredIndent) {
     tableBlock.indentCompatibility = options.tableIndentCompatibility;
   }
   if (floatingPx) {

--- a/packages/core/src/layout-engine/measure/tableInlinePlacement.test.ts
+++ b/packages/core/src/layout-engine/measure/tableInlinePlacement.test.ts
@@ -60,3 +60,56 @@ describe("resolveTableInlinePlacement", () => {
     });
   });
 });
+
+describe("resolveTableInlinePlacement with a text-edge indent", () => {
+  const legacyTable = (bidi: boolean, padding: number): TableBlock => {
+    const table = tableWithLeadingPadding(bidi, padding);
+    table.indentCompatibility = { type: "legacy" };
+    return table;
+  };
+
+  test.each([
+    { bidi: false, alignment: "left" as const },
+    { bidi: true, alignment: "right" as const },
+  ])("pulls the $alignment border back by the leading cell margin", ({ bidi, alignment }) => {
+    for (const padding of [0, 7, 12, 96]) {
+      expect(resolveTableInlinePlacement(legacyTable(bidi, padding))).toEqual({
+        alignment,
+        offset: 12 - padding,
+      });
+    }
+  });
+
+  test("moves an unindented table border out by the default leading cell margin", () => {
+    const table = legacyTable(false, 7);
+    delete table.indent;
+
+    expect(resolveTableInlinePlacement(table)).toEqual({ alignment: "left", offset: -7 });
+  });
+
+  test("leaves the trailing edge of a right-justified table alone", () => {
+    const table = legacyTable(false, 7);
+    table.justification = "right";
+
+    expect(resolveTableInlinePlacement(table)).toEqual({ alignment: "right", offset: 0 });
+  });
+
+  test("leaves a centered table alone", () => {
+    const table = legacyTable(false, 7);
+    table.justification = "center";
+
+    expect(resolveTableInlinePlacement(table)).toEqual({ alignment: "center" });
+  });
+
+  test("falls back to the default cell margin when the table has no rows", () => {
+    expect(
+      resolveTableInlinePlacement({
+        kind: "table",
+        id: "empty",
+        rows: [],
+        indent: 12,
+        indentCompatibility: { type: "legacy" },
+      }),
+    ).toEqual({ alignment: "left", offset: 5 });
+  });
+});

--- a/packages/core/src/layout-engine/measure/tableInlinePlacement.ts
+++ b/packages/core/src/layout-engine/measure/tableInlinePlacement.ts
@@ -1,12 +1,32 @@
-import type { TableBlock } from "../types";
+import { resolveTableCellPadding, type TableBlock } from "../types";
 
 type TableInlinePlacement =
   | { alignment: "center" }
   | { alignment: "left" | "right"; offset: number };
 
+type LeadingEdgeTable = Pick<
+  TableBlock,
+  "bidi" | "indent" | "indentCompatibility" | "justification" | "rows"
+>;
+
+/**
+ * Distance the leading border is pulled back so the leading cell's text lands
+ * on `w:tblInd`. Zero unless the document uses the pre-Word-2013 indent
+ * semantics, where the indent measures to that text edge rather than to the
+ * border. Only the leading, indent-bearing edge compensates; centered and
+ * trailing-edge tables are placed by their border box.
+ */
+const leadingEdgeCompensation = (table: LeadingEdgeTable): number => {
+  if (table.indentCompatibility?.type !== "legacy") {
+    return 0;
+  }
+  const padding = resolveTableCellPadding(table.rows.at(0)?.cells.at(0));
+  return table.bidi === true ? padding.right : padding.left;
+};
+
 /** Resolve an inline table's horizontal anchor without losing RTL leading-edge semantics. */
 export const resolveTableInlinePlacement = (
-  table: Pick<TableBlock, "bidi" | "indent" | "justification">,
+  table: LeadingEdgeTable,
   rowJustification?: TableBlock["justification"],
 ): TableInlinePlacement => {
   const logicalJustification = rowJustification ?? table.justification ?? "left";
@@ -14,11 +34,10 @@ export const resolveTableInlinePlacement = (
     return { alignment: "center" };
   }
 
-  // w:tblInd adds space before the table's leading edge. Cell margins affect
-  // content inside that edge and therefore must not move the table itself.
   // OOXML justification is logical: bidiVisual mirrors left/right only after
   // deciding whether the leading-edge indent applies.
-  const offset = logicalJustification === "left" ? (table.indent ?? 0) : 0;
+  const offset =
+    logicalJustification === "left" ? (table.indent ?? 0) - leadingEdgeCompensation(table) : 0;
   if (table.bidi !== true) {
     return { alignment: logicalJustification, offset };
   }
@@ -29,7 +48,7 @@ export const resolveTableInlinePlacement = (
 };
 
 type ResolveTableInlineOffsetOptions = {
-  table: Pick<TableBlock, "bidi" | "indent" | "justification">;
+  table: LeadingEdgeTable;
   rowJustification?: TableBlock["justification"];
   frameWidth: number;
   tableWidth: number;

--- a/packages/core/src/layout-engine/tableIndentCompatibility.test.ts
+++ b/packages/core/src/layout-engine/tableIndentCompatibility.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveTableIndentCompatibility } from "./tableIndentCompatibility";
+
+describe("resolveTableIndentCompatibility", () => {
+  test.each([undefined, 11, 12, 14])("reads compatibilityMode %p as a text-edge indent", (mode) => {
+    expect(resolveTableIndentCompatibility(mode)).toEqual({ type: "legacy" });
+  });
+
+  test.each([15, 16])("reads compatibilityMode %p as a border-edge indent", (mode) => {
+    expect(resolveTableIndentCompatibility(mode)).toBeUndefined();
+  });
+});

--- a/packages/core/src/layout-engine/tableIndentCompatibility.ts
+++ b/packages/core/src/layout-engine/tableIndentCompatibility.ts
@@ -1,0 +1,21 @@
+import type { TableBlock } from "./types";
+
+/**
+ * First `compatibilityMode` that measures `w:tblInd` to the table border.
+ *
+ * Word 2013 moved the reference edge: from that mode on, `w:tblInd` offsets
+ * the border and the leading cell margin pushes the text further in. Earlier
+ * modes measure the indent to the leading cell's text edge and pull the border
+ * back by that cell's leading margin, so the first character lands exactly on
+ * the indent. A document that declares no `compatSetting` at all is read with
+ * the oldest semantics, so it takes the legacy rule too.
+ */
+const FIRST_BORDER_EDGE_INDENT_COMPATIBILITY_MODE = 15;
+
+export const resolveTableIndentCompatibility = (
+  compatibilityMode: number | undefined,
+): NonNullable<TableBlock["indentCompatibility"]> | undefined =>
+  compatibilityMode !== undefined &&
+  compatibilityMode >= FIRST_BORDER_EDGE_INDENT_COMPATIBILITY_MODE
+    ? undefined
+    : { type: "legacy" };

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1119,6 +1119,32 @@ describe("left-aligned table placement", () => {
   });
 });
 
+describe("text-edge table placement", () => {
+  test("lands the leading cell text on an authored w:tblInd", () => {
+    const { block, measure } = tallTable(1);
+    block.indent = 10;
+    block.indentCompatibility = { type: "legacy" };
+    block.rows[0]!.cells[0]!.padding.left = 7;
+
+    const fragment = tableFragments(block, measure).at(0);
+
+    expect((fragment?.x ?? 0) + 7).toBe(OPTIONS.margins.left + 10);
+  });
+
+  test("lands the logical leading cell text on an authored w:tblInd in an RTL table", () => {
+    const { block, measure } = tallTable(1);
+    block.bidi = true;
+    block.indent = 10;
+    block.indentCompatibility = { type: "legacy" };
+    block.rows[0]!.cells[0]!.padding.right = 7;
+
+    const fragment = tableFragments(block, measure).at(0);
+    const contentRight = OPTIONS.pageSize.w - OPTIONS.margins.right;
+
+    expect((fragment?.x ?? 0) + measure.totalWidth - 7).toBe(contentRight - 10);
+  });
+});
+
 describe("RTL table placement", () => {
   test.each([
     { justification: "left" as const, expectedX: 30 },

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -724,6 +724,12 @@ export type TableBlock = {
   justification?: "left" | "center" | "right";
   /** Table indent from the leading margin (in pixels, from w:tblInd). */
   indent?: number;
+  /**
+   * Pre-Word-2013 `w:tblInd` semantics: the indent measures to the leading
+   * cell's text edge instead of the table border. Derived from the document's
+   * `compatibilityMode` (see `resolveTableIndentCompatibility`).
+   */
+  indentCompatibility?: { type: "legacy" };
   /** Right-to-left column order (w:bidiVisual): logical column 0 paints on the right. */
   bidi?: boolean;
   /** Floating table properties (pixel values). */

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -452,6 +452,54 @@ describe("header and footer rendering", () => {
     ).toBeUndefined();
   });
 
+  test.each([
+    { policy: undefined, expectedLeft: "24px" },
+    { policy: { type: "legacy" } as const, expectedLeft: "17px" },
+  ])(
+    "places an inline header table by the document's w:tblInd policy",
+    ({ policy, expectedLeft }) => {
+      const block: TableBlock = {
+        kind: "table",
+        id: "hf-table",
+        indent: 24,
+        ...(policy ? { indentCompatibility: policy } : {}),
+        rows: [
+          {
+            id: "hf-row",
+            cells: [
+              {
+                id: "hf-cell",
+                blocks: [],
+                padding: { top: 0, right: 7, bottom: 0, left: 7 },
+              },
+            ],
+          },
+        ],
+        columnWidths: [200],
+      };
+      const measure: TableMeasure = {
+        kind: "table",
+        rows: [{ cells: [{ blocks: [], width: 200, height: 20 }], height: 20 }],
+        columnWidths: [200],
+        totalWidth: 200,
+        totalHeight: 20,
+      };
+      const content: HeaderFooterContent = {
+        blocks: [block],
+        measures: [measure],
+        height: 20,
+      };
+
+      const pageElement = renderPage(
+        { ...page, fragments: [] },
+        { pageNumber: 1, totalPages: 1, section: "body" },
+        { document: fakeDocument, headerContent: content },
+      ) as unknown as FakeElement;
+
+      expect(findByClass(pageElement, "layout-table")?.style.left).toBe(expectedLeft);
+    },
+  );
+
   test("keeps horizontal paragraph rule endpoints visible outside the text band", () => {
     const content: HeaderFooterContent = {
       blocks: [

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -14,6 +14,7 @@ import {
 } from "../layout-engine/measure";
 import type { FloatingExclusionRect, FloatingImageZone } from "../layout-engine/measure";
 import { MIN_WRAP_SEGMENT_WIDTH } from "../layout-engine/measure/measureParagraph";
+import { resolveTableInlineOffset } from "../layout-engine/measure/tableInlinePlacement";
 import {
   FOOTNOTE_ENTRY_MARGIN_BOTTOM,
   FOOTNOTE_FALLBACK_LINE_HEIGHT,
@@ -1198,16 +1199,14 @@ function renderHeaderFooterContent(
         // floating table weren't there (Word semantics for unwrapped
         // floating tables).
       } else {
-        // Honor `w:jc` / `w:tblInd` for inline HF tables, matching the body
-        // pagination path (see core/layout-engine `desiredX` computation).
-        let inlineLeft = 0;
-        if (block.justification === "center") {
-          inlineLeft = (contentWidth - measure.totalWidth) / 2;
-        } else if (block.justification === "right") {
-          inlineLeft = contentWidth - measure.totalWidth;
-        } else if (block.indent) {
-          inlineLeft = block.indent;
-        }
+        // Inline header/footer tables resolve `w:jc` / `w:tblInd` through the
+        // same owner as the body pagination path, so one placement rule covers
+        // both stories.
+        const inlineLeft = resolveTableInlineOffset({
+          table: block,
+          frameWidth: contentWidth,
+          tableWidth: measure.totalWidth,
+        });
         fragEl.style.position = "absolute";
         fragEl.style.top = `${cursorY}px`;
         fragEl.style.left = `${inlineLeft}px`;


### PR DESCRIPTION
## What was wrong

`w:tblInd` does not measure from a fixed edge. The reference edge depends on the
document's `compatibilityMode`:

- from mode 15 on, the indent offsets the **table border**, and the leading
  cell margin pushes the cell text further in;
- in earlier modes, and in a document that declares no `compatSetting` at all,
  the indent measures to the **leading cell's text edge**: the border is pulled
  back by that cell's leading margin so the first character lands exactly on the
  indent.

The layout engine applied the mode-15 rule to every document, so in an older
document every table, and every line inside it, sat one cell margin too far in.
`w:tblCellMar` and `w:tcMar` change how far, so the error varied by document.

## How it is derived now

`resolveTableIndentCompatibility` reads the policy once from the document
settings and `toFlowBlocks` stamps it onto every table block, the way
justified-line fitting already carries its own generation policy. Body,
header, footer and footnote flows therefore agree without a second decision
point.

`resolveTableInlinePlacement` subtracts the leading cell's margin only for the
leading, indent-bearing edge. Centred and trailing-edge tables keep their
border-box placement in both modes, and RTL tables take the leading margin from
the trailing side of the first cell.

Two related defects fall out of putting the rule in one place:

- the header/footer painter re-derived the placement itself, so it read `w:jc`
  and `w:tblInd` directly, ignored `w:bidiVisual`, and could not see the new
  policy. It now calls `resolveTableInlineOffset`, leaving one owner for the
  rule.
- table conversion applies `w:tblInd` only when the measurement is `dxa`.
  Stamping the text-edge policy on a table whose indent was discarded left the
  compensation without its indent and moved the table into the margin by a cell
  margin nothing asked for. The policy now travels only with an indent the
  converter actually applied.

## Tests

- `layout-engine/tableIndentCompatibility.test.ts` covers the mode mapping,
  including the unset case.
- `layout-engine/measure/tableInlinePlacement.test.ts` adds a text-edge suite:
  leading-edge compensation for LTR and RTL, an unindented table, an explicit
  zero indent, and the untouched centred and trailing-edge cases.
- `layout-engine/tableRowBreak.test.ts` asserts the laid-out fragment geometry
  for both directions: the leading cell text lands on the authored indent.
- `layout-bridge/convert/toFlowBlocks-table-bidi.test.ts` covers policy
  threading, including the dropped-measurement case.
- `layout-painter/renderPage.test.ts` asserts an inline header table's position
  under both policies.

The existing border-edge tests are unchanged, which is the point: mode 15
documents lay out exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected table indentation and horizontal placement for documents using older compatibility modes.
  - Ensured tables in body content, headers, footers and footnotes follow consistent indentation rules.
  - Improved placement for left-to-right and right-to-left tables, including tables with cell padding.
  - Preserved existing positioning for newer document formats and supported alignment modes.

- **Tests**
  - Added coverage for legacy compatibility behaviour, unsupported indentation values, and inline tables in headers and footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->