### PR TITLE
fix(parity): right-to-left extraction spelling is not a text difference

### DIFF
--- a/parity/__tests__/textNorm.test.ts
+++ b/parity/__tests__/textNorm.test.ts
@@ -36,6 +36,33 @@ describe("normalizeLineText", () => {
     expect(normalizeLineText("\uf0b7 First item")).toBe("• First item");
   });
 
+  test("folds Persian code points a PDF font map returns for Arabic letters", () => {
+    expect(
+      normalizeLineText(
+        "\u0648\u0632\u0627\u0631\u0629 \u0627\u0644\u062a\u0639\u0644\u06cc\u0645",
+      ),
+    ).toBe(
+      normalizeLineText(
+        "\u0648\u0632\u0627\u0631\u0629 \u0627\u0644\u062a\u0639\u0644\u064a\u0645",
+      ),
+    );
+    expect(normalizeLineText("\u0627\u0644\u0645\u0642\u0628\u0648\u0644\u0629 \u06be\u064a")).toBe(
+      normalizeLineText("\u0627\u0644\u0645\u0642\u0628\u0648\u0644\u0629 \u0647\u064a"),
+    );
+  });
+
+  test("folds mirrored bracket pairs on an RTL line", () => {
+    expect(normalizeLineText(")\u0633\u0628\u0628 \u0627\u0644\u063a\u064a\u0627\u0628(")).toBe(
+      normalizeLineText("(\u0633\u0628\u0628 \u0627\u0644\u063a\u064a\u0627\u0628)"),
+    );
+  });
+
+  test("keeps bracket direction on an LTR line", () => {
+    expect(normalizeLineText(")Reason for absence(")).not.toBe(
+      normalizeLineText("(Reason for absence)"),
+    );
+  });
+
   test("folds CJK radical aliases emitted by PDF font maps", () => {
     expect(normalizeLineText("⺟甲⼄丙丁")).toBe("母甲乙丙丁");
   });

--- a/parity/textNorm.ts
+++ b/parity/textNorm.ts
@@ -7,6 +7,35 @@ import { detectBaseDirection } from "../packages/core/src/utils/baseDirection";
 
 const RTL_LEADER_LINE_PATTERN = /^(?<page>[\p{Decimal_Number}]+)\s+…\s+(?<title>.+)$/u;
 
+const MIRRORABLE_BRACKET_PATTERN = /[()[\]{}]/u;
+const MIRRORABLE_BRACKETS_PATTERN = /[()[\]{}]/gu;
+const BRACKET_PAIR_REPRESENTATIVE: Record<string, string> = {
+  "(": "(",
+  ")": "(",
+  "[": "[",
+  "]": "[",
+  "{": "{",
+  "}": "{",
+};
+
+/**
+ * A PDF records the mirrored glyph an RTL line actually paints, while a DOM
+ * carries the logical character, so one extractor reports `)…(` where the other
+ * reports `(…)`. Neither text model observes painted mirroring (the browser
+ * mirrors at paint time), so comparing bracket direction on an RTL line only
+ * manufactures text differences. Fold each pair to one representative instead;
+ * LTR lines keep both characters distinct.
+ */
+const canonicalizeRtlBracketPairs = (text: string): string => {
+  if (!MIRRORABLE_BRACKET_PATTERN.test(text) || detectBaseDirection(text) !== "rtl") {
+    return text;
+  }
+  return text.replace(
+    MIRRORABLE_BRACKETS_PATTERN,
+    (bracket) => BRACKET_PAIR_REPRESENTATIVE[bracket] ?? bracket,
+  );
+};
+
 const normalizeRtlLeaderOrder = (text: string): string => {
   const match = text.match(RTL_LEADER_LINE_PATTERN);
   const page = match?.groups?.["page"];
@@ -30,11 +59,16 @@ export const normalizeLineText = (text: string): string => {
     .replace(/[­​-‍﻿]/gu, "")
     .replace(/\uf0b7/gu, "•")
     .replace(/\uf0e3/gu, "ã")
+    // A PDF's ToUnicode map answers shaped Arabic glyphs with the Persian code
+    // points (Farsi Yeh, Heh Doachashmee) even for documents that authored the
+    // Arabic letters, so extraction spelling would read as a text difference.
+    .replace(/\u06cc/gu, "\u064a")
+    .replace(/\u06be/gu, "\u0647")
     .replace(/\s*\.{3,}\s*/gu, " … ")
     .replace(/(?:\s*…\s*){2,}/gu, " … ")
     .replace(/\s+/gu, " ")
     .trim();
-  return normalizeRtlLeaderOrder(normalized);
+  return canonicalizeRtlBracketPairs(normalizeRtlLeaderOrder(normalized));
 };
 
 /** Levenshtein-based similarity in [0, 1]; 1 means identical. */


### PR DESCRIPTION
## What was wrong

Reading text back out of a PDF loses two things on a right-to-left line, and the
comparator counted both as content differences even though the characters agree.

**Arabic letter identity.** A PDF's `ToUnicode` map answers a shaped Arabic glyph
with the Persian code point, so a document that authored Arabic Yeh (U+064A) or
Heh (U+0647) comes back spelled with Farsi Yeh (U+06CC) or Heh Doachashmee
(U+06BE). Every affected line was reported as a text mismatch, which also pulled
the sequence alignment off and manufactured follow-on missing and extra lines.

**Bracket direction.** A PDF records the glyph a line actually paints, so an RTL
line's parentheses come back mirrored, while a DOM carries the logical character.
One side reads `)…(` where the other reads `(…)`.

## How it is derived now

Both are handled in `normalizeLineText`, which every extractor and the comparator
already share, so the two sides stay normalised identically.

The Persian code points fold to their Arabic counterparts alongside the existing
Symbol-font and CJK-radical glyph aliases: same class of problem, same seam.

Bracket pairs fold to one representative per pair, but only on a line whose base
direction is RTL. Folding rather than swapping is deliberate: a swap is an
involution, so applying it to both sides keeps them different. Nothing is lost by
folding, because neither text model observes painted mirroring in the first place
(the browser mirrors at paint time, so the DOM text cannot show it). LTR lines
keep both characters distinct.

## Tests

`parity/__tests__/textNorm.test.ts` covers the Yeh and Heh folds, an RTL line
whose brackets are mirrored, and an LTR line whose bracket direction must still
be compared.
