### PR TITLE
feat(core): a run carries what its advances were measured with

### DIFF
--- a/.changeset/runs-carry-what-was-measured.md
+++ b/.changeset/runs-carry-what-was-measured.md
@@ -1,0 +1,28 @@
+---
+"@stll/folio-core": minor
+---
+
+Carry what the measurer applied on the glyph run, so a backend can reproduce
+the width the line was fitted at.
+
+`advancesPx` folded letter spacing, a horizontal scale, justification, kerning
+and small capitals into one number per code point. A backend that hands the run
+to a shaper cannot recover any of them from the text: the shaper advances glyphs
+by what the font says, and none of those five is in the font. The DOM backend
+therefore painted runs at the glyphs' own width rather than the laid-out one,
+by as much as 78 px on a justified line.
+
+`DisplayGlyphRun` now names them: `adjustments` carries the letter spacing,
+horizontal scale and per-space justification delta, and `kerning` and
+`smallCaps` state what the advances were measured with. `DisplayFontFace` gains
+`fallbacks`, the families between the first and the generic, because a face is a
+stack and a backend handed only its first entry paints a different face from the
+one measured wherever that entry is missing.
+
+A run's advances now also sum to the width the line was broken on. They were the
+sum of per-character measurements, which differs from the string's own width
+wherever a pair kerns or ligates; the difference is spread across the run rather
+than left as an extent no backend paints.
+
+The editor's run-drift check gates the painted extent as well as the origin:
+every run in the two fixtures now lands within one browser layout quantum.

--- a/packages/core/scripts/paint-equivalence.baseline.json
+++ b/packages/core/scripts/paint-equivalence.baseline.json
@@ -1,7 +1,7 @@
 {
-  "tests/visual/fixtures/docx-editor-demo.docx": 0.9803,
-  "tests/visual/fixtures/sample.docx": 0.9857,
-  "tests/visual/fixtures/podily-bps.docx": 0.9578,
-  "packages/core/src/docx/__tests__/__fixtures__/corpus/diacritics-latin-ext.docx": 0.9878,
-  "packages/core/src/docx/__tests__/__fixtures__/corpus/rtl-arabic-shaping.docx": 0.9965
+  "tests/visual/fixtures/docx-editor-demo.docx": 0.9839,
+  "tests/visual/fixtures/sample.docx": 0.9882,
+  "tests/visual/fixtures/podily-bps.docx": 0.9622,
+  "packages/core/src/docx/__tests__/__fixtures__/corpus/diacritics-latin-ext.docx": 0.9916,
+  "packages/core/src/docx/__tests__/__fixtures__/corpus/rtl-arabic-shaping.docx": 0.9964
 }

--- a/packages/core/scripts/paint-equivalence.ts
+++ b/packages/core/scripts/paint-equivalence.ts
@@ -27,7 +27,7 @@
  *    ligatures, and then painted by a *browser*, which shapes. A run is one
  *    element and the browser advances the glyphs inside it, so the two
  *    disagree by whatever shaping changes: measured over `podily-bps.docx`,
- *    median 0.163 px and p90 4.078 px, worst 64.9 px.
+ *    median 0.047 px and p90 0.261 px, worst 20.3 px.
  *
  *    That number is reported here and gated nowhere, because it does not
  *    describe what the editor does. In the editor the same list is built by

--- a/packages/core/src/display-list/build/fontTable.ts
+++ b/packages/core/src/display-list/build/fontTable.ts
@@ -136,6 +136,12 @@ export class FontTable {
       weight,
       italic: isItalic,
       generic: genericOf(stack),
+      // Everything the measurer would fall through before reaching the
+      // generic. Dropping it is what makes a backend paint a different face
+      // from the one measured when the first family is not installed.
+      fallbacks: stack
+        .slice(1)
+        .filter((entry) => GENERIC_FAMILIES[entry.toLowerCase() as GenericFamily] === undefined),
       fontBoxAscentRatio: metrics.fontBoxAscent * scale,
       fontBoxDescentRatio: metrics.fontBoxDescent * scale,
       ...(embedded === undefined ? {} : { embedded }),

--- a/packages/core/src/display-list/build/glyphs.test.ts
+++ b/packages/core/src/display-list/build/glyphs.test.ts
@@ -1,0 +1,172 @@
+/**
+ * A run's advances have to say what the line was fitted with, and name what
+ * went into them: a backend that hands the text to a shaper cannot recover
+ * letter spacing, a horizontal scale, justification, kerning or small capitals
+ * from the text, and would paint the run at the glyphs' own width instead.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  FontMetrics,
+  FontStyle,
+  RunMeasurement,
+} from "../../layout-engine/measure/measureTypes";
+import {
+  getMeasureProvider,
+  setMeasureProvider,
+} from "../../layout-engine/measure/measureProvider";
+import { buildGlyphs } from "./glyphs";
+
+const METRICS: FontMetrics = {
+  fontSize: 12,
+  ascent: 9,
+  descent: 3,
+  fontBoxAscent: 9,
+  fontBoxDescent: 3,
+  lineHeight: 12,
+  fontFamily: "Test",
+  singleLineRatio: 1,
+};
+
+/** Every character is 10 wide. `stringWidth` overrides what the run measures. */
+const install = (stringWidth?: (text: string) => number): void => {
+  const charWidths = (text: string): number[] =>
+    [...text].flatMap((char) => (char.length === 2 ? [10, 0] : [10]));
+  setMeasureProvider({
+    getFontMetrics: () => METRICS,
+    measureTextWidth: (text: string) => stringWidth?.(text) ?? [...text].length * 10,
+    measureText: (text: string) => ({
+      width: [...text].length * 10,
+      height: 12,
+      ascent: 9,
+      descent: 3,
+    }),
+    measureRun: (text: string): RunMeasurement => ({
+      width: [...text].length * 10,
+      charWidths: charWidths(text),
+      metrics: METRICS,
+    }),
+  });
+};
+
+const sum = (values: readonly number[]): number =>
+  values.reduce((total, value) => total + value, 0);
+
+const PLAIN: FontStyle = { fontSize: 12 };
+
+describe("buildGlyphs", () => {
+  let restore: ReturnType<typeof getMeasureProvider>;
+
+  beforeEach(() => {
+    restore = getMeasureProvider();
+  });
+
+  afterEach(() => {
+    setMeasureProvider(restore);
+  });
+
+  test("a run with nothing added to it names no adjustments", () => {
+    install();
+
+    const glyphs = buildGlyphs({
+      text: "ab",
+      style: PLAIN,
+      allCaps: false,
+      spaceDeltaPx: 0,
+      collapsed: false,
+    });
+
+    expect(glyphs.adjustments).toBeUndefined();
+    expect(glyphs.kerning).toBe(false);
+    expect(glyphs.smallCaps).toBe(false);
+    expect(glyphs.advancesPx).toEqual([10, 10]);
+  });
+
+  test("letter spacing, a horizontal scale and justification are named, not only folded in", () => {
+    install();
+
+    const glyphs = buildGlyphs({
+      text: "a b",
+      style: { ...PLAIN, letterSpacing: 2, horizontalScale: 150 },
+      allCaps: false,
+      spaceDeltaPx: -1.5,
+      collapsed: false,
+    });
+
+    expect(glyphs.adjustments).toEqual({
+      // Reported in painted pixels, as the advances are: the measured spacing
+      // is pre-scale and the scale multiplies it.
+      letterSpacingPx: 3,
+      horizontalScale: 1.5,
+      wordSpacingPx: -1.5,
+    });
+  });
+
+  test("a collapsed run names no spacing, because it is painted at no width", () => {
+    install();
+
+    const glyphs = buildGlyphs({
+      text: "a b",
+      style: { ...PLAIN, letterSpacing: 2 },
+      allCaps: false,
+      spaceDeltaPx: -1.5,
+      collapsed: true,
+    });
+
+    expect(glyphs.adjustments).toBeUndefined();
+    expect(sum(glyphs.advancesPx)).toBe(0);
+  });
+
+  test("the measurement's own settings travel with the advances", () => {
+    install();
+
+    const glyphs = buildGlyphs({
+      text: "ab",
+      style: { ...PLAIN, kerning: true, fontVariant: "small-caps" },
+      allCaps: false,
+      spaceDeltaPx: 0,
+      collapsed: false,
+    });
+
+    expect(glyphs.kerning).toBe(true);
+    expect(glyphs.smallCaps).toBe(true);
+  });
+
+  test("the advances sum to the width the line was broken on", () => {
+    // A pair that kerns or ligates makes the string narrower than its
+    // characters are apart. Line breaking used the string's width, so a run
+    // whose advances summed to anything else would declare an extent no
+    // backend paints.
+    install(() => 27);
+
+    const glyphs = buildGlyphs({
+      text: "abc",
+      style: PLAIN,
+      allCaps: false,
+      spaceDeltaPx: 0,
+      collapsed: false,
+    });
+
+    expect(sum(glyphs.advancesPx)).toBeCloseTo(27, 10);
+    expect(glyphs.widthPx).toBeCloseTo(27, 10);
+    // Spread over the run rather than dropped on its last glyph.
+    expect(glyphs.advancesPx).toEqual([9, 9, 9]);
+  });
+
+  test("justification is added after the shaped width, not scaled by it", () => {
+    install(() => 20);
+
+    const glyphs = buildGlyphs({
+      text: "a b",
+      style: PLAIN,
+      allCaps: false,
+      spaceDeltaPx: 3,
+      collapsed: false,
+    });
+
+    // Three characters measured at 30, shaped to 20, so each is 20/30 of its
+    // measured width; the space then gains the justification delta whole.
+    expect(sum(glyphs.advancesPx)).toBeCloseTo(23, 10);
+  });
+});

--- a/packages/core/src/display-list/build/glyphs.ts
+++ b/packages/core/src/display-list/build/glyphs.ts
@@ -6,13 +6,28 @@
  * here are the numbers line breaking and pagination were decided on.
  */
 
-import { measureRun } from "../../layout-engine/measure/measureProvider";
+import { measureRun, measureTextWidth } from "../../layout-engine/measure/measureProvider";
+import {
+  FONT_KERNING_MODE,
+  getFontKerningMode,
+} from "../../layout-engine/measure/textMeasurementPolicy";
 import type { FontStyle } from "../../layout-engine/measure/measureTypes";
+import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
+import type { DisplayRunAdjustments } from "../types";
 
 export type Glyphs = {
   readonly text: string;
   readonly advancesPx: number[];
   readonly widthPx: number;
+  /** Whether these advances were measured with kerning on. */
+  readonly kerning: boolean;
+  /** Whether they were measured as small capitals. */
+  readonly smallCaps: boolean;
+  /**
+   * What went into the advances beyond the glyphs' own widths. Absent when
+   * nothing did, which keeps the common run's primitive as small as it was.
+   */
+  readonly adjustments?: DisplayRunAdjustments;
 };
 
 export type BuildGlyphsOptions = {
@@ -36,21 +51,18 @@ export type BuildGlyphsOptions = {
  * advance on the first output code point and gives the rest zero, so the sum
  * still equals what the measurer decided the line on.
  */
-export const buildGlyphs = ({
-  text,
-  style,
-  allCaps,
-  spaceDeltaPx,
-  collapsed,
-}: BuildGlyphsOptions): Glyphs => {
+export const buildGlyphs = (options: BuildGlyphsOptions): Glyphs => {
+  const { text, style, allCaps, spaceDeltaPx, collapsed } = options;
+  const adjustments = adjustmentsOf(options);
   const { charWidths } = measureRun(text, style);
   const advancesPx: number[] = [];
   let painted = "";
   let widthPx = 0;
   let unitOffset = 0;
+  const shapedScale = shapedScaleOf(text, style, charWidths);
 
   for (const char of text) {
-    const measured = charWidths[unitOffset] ?? 0;
+    const measured = (charWidths[unitOffset] ?? 0) * shapedScale;
     unitOffset += char.length;
     const advance = collapsed ? 0 : measured + (char === " " ? spaceDeltaPx : 0);
     widthPx += advance;
@@ -63,5 +75,73 @@ export const buildGlyphs = ({
     }
   }
 
-  return { text: painted, advancesPx, widthPx };
+  return {
+    text: painted,
+    advancesPx,
+    widthPx,
+    kerning: getFontKerningMode(style) === FONT_KERNING_MODE.enabled,
+    smallCaps: style.fontVariant === "small-caps",
+    ...(adjustments === undefined ? {} : { adjustments }),
+  };
 };
+
+/**
+ * What every per-character width has to be multiplied by for the run to occupy
+ * the width the line was fitted at.
+ *
+ * The two numbers come from the same measurer and differ by what shaping does
+ * across a boundary: a pair that kerns or ligates is narrower in the string
+ * than the two characters are apart. Line breaking used the string's width, so
+ * that is the run's width, and advances that summed to anything else would
+ * declare an extent no backend paints.
+ *
+ * Spread over every character rather than dropped on the last, because the
+ * difference is not one boundary's: concentrating it would move the run's final
+ * glyph by the whole of it.
+ */
+const shapedScaleOf = (text: string, style: FontStyle, charWidths: readonly number[]): number => {
+  const perCharacterPx = charWidths.reduce((total, width) => total + width, 0);
+  if (perCharacterPx <= 0) {
+    return 1;
+  }
+  return measureTextWidth(text, style) / perCharacterPx;
+};
+
+/**
+ * The three adjustments named, or nothing when none applies.
+ *
+ * A collapsed run carries no advances at all, so it has nothing to reapply
+ * either: naming a spacing on a run painted at zero width would have a backend
+ * widen what the line was fitted without.
+ */
+const adjustmentsOf = ({
+  style,
+  spaceDeltaPx,
+  collapsed,
+}: BuildGlyphsOptions): DisplayRunAdjustments | undefined => {
+  const horizontalScale = getHorizontalScaleFactor(style.horizontalScale);
+  // Measured letter spacing is pre-scale, as CSS letter-spacing is; the advances
+  // carry it scaled, so it is reported the same way.
+  const letterSpacingPx = collapsed ? 0 : (style.letterSpacing ?? 0) * horizontalScale;
+  const wordSpacingPx = collapsed ? 0 : spaceDeltaPx;
+  if (letterSpacingPx === 0 && wordSpacingPx === 0 && horizontalScale === 1) {
+    return undefined;
+  }
+  return { letterSpacingPx, horizontalScale, wordSpacingPx };
+};
+
+/**
+ * Everything a measured run contributes to a `glyphRun`.
+ *
+ * One helper rather than three fields at each emission site: what went into the
+ * advances has to travel with them, and a call site that carried the advances
+ * and forgot the adjustments would silently paint a run the line was not fitted
+ * with.
+ */
+export const glyphRunText = (glyphs: Glyphs) => ({
+  text: glyphs.text,
+  advancesPx: glyphs.advancesPx,
+  kerning: glyphs.kerning,
+  smallCaps: glyphs.smallCaps,
+  ...(glyphs.adjustments === undefined ? {} : { adjustments: glyphs.adjustments }),
+});

--- a/packages/core/src/display-list/build/paragraphPrimitives.ts
+++ b/packages/core/src/display-list/build/paragraphPrimitives.ts
@@ -80,7 +80,7 @@ import type {
 } from "../types";
 import { type BuildContext, trackedChangeColor } from "./buildContext";
 import { DOC_CANVAS_TEXT, parseDisplayColor } from "./colors";
-import { buildGlyphs, type Glyphs } from "./glyphs";
+import { buildGlyphs, glyphRunText, type Glyphs } from "./glyphs";
 import { paintImage } from "./imagePrimitives";
 import { decorationPatternForStyle, resolveBorderStroke } from "./strokes";
 import {
@@ -610,8 +610,7 @@ const emitGlyphRun = ({
     color,
     xPx: paintXPx,
     baselineYPx: runBaselineYPx,
-    text: glyphs.text,
-    advancesPx: glyphs.advancesPx,
+    ...glyphRunText(glyphs),
     direction: isRtl ? "rtl" : "ltr",
     ...(stroke === undefined ? {} : { stroke }),
     ...(pmRange === undefined ? {} : { pmRange }),
@@ -716,14 +715,14 @@ const reportRunEffects = (run: TextRun, context: BuildContext): void => {
     unsupported.report(
       UNSUPPORTED_CONSTRUCT.smallCaps,
       pageIndex,
-      "w:smallCaps advances are measured, but the display list carries no small-cap glyph selection",
+      "w:smallCaps is carried on the run and painted by the DOM backend; the PDF backend paints full-size glyphs for it",
     );
   }
   if (getHorizontalScaleFactor(run.horizontalScale) !== 1) {
     unsupported.report(
       UNSUPPORTED_CONSTRUCT.horizontalScale,
       pageIndex,
-      `w:w ${String(run.horizontalScale)}% is folded into the advances, but the glyphs are not narrowed`,
+      `w:w ${String(run.horizontalScale)}% is carried on the run and painted by the DOM backend; the PDF backend paints unnarrowed glyphs at the measured advances`,
     );
   }
   if (run.textEffect) {
@@ -1039,8 +1038,7 @@ const paintListMarker = ({
     color,
     xPx: paintXPx,
     baselineYPx,
-    text: glyphs.text,
-    advancesPx: glyphs.advancesPx,
+    ...glyphRunText(glyphs),
     direction: (formatting.rtl ?? isRtl) ? "rtl" : "ltr",
   });
 
@@ -1178,8 +1176,7 @@ const paintTab = ({
                   : (parseDisplayColor(run.color) ?? DOC_CANVAS_TEXT),
               xPx: paintXPx,
               baselineYPx,
-              text: glyphs.text,
-              advancesPx: glyphs.advancesPx,
+              ...glyphRunText(glyphs),
               direction: "ltr",
             },
           ],

--- a/packages/core/src/display-list/build/watermarkPrimitives.ts
+++ b/packages/core/src/display-list/build/watermarkPrimitives.ts
@@ -21,7 +21,7 @@ import type { Watermark } from "../../types/document";
 import type { DisplayImagePrimitive, DisplayPrimitive, DisplayRect } from "../types";
 import type { BuildContext } from "./buildContext";
 import { parseDisplayColor } from "./colors";
-import { buildGlyphs } from "./glyphs";
+import { buildGlyphs, glyphRunText } from "./glyphs";
 import { UNSUPPORTED_CONSTRUCT } from "./unsupported";
 
 /**
@@ -104,8 +104,7 @@ const paintTextWatermark = (
               color,
               xPx: centerXPx - glyphs.widthPx / 2,
               baselineYPx,
-              text: glyphs.text,
-              advancesPx: glyphs.advancesPx,
+              ...glyphRunText(glyphs),
               direction: "ltr",
             },
           ],

--- a/packages/core/src/display-list/dom/renderDisplayListToDom.test.ts
+++ b/packages/core/src/display-list/dom/renderDisplayListToDom.test.ts
@@ -71,6 +71,7 @@ const FONT: DisplayFontFace = {
   weight: 400,
   italic: false,
   generic: "serif",
+  fallbacks: [],
   fontBoxAscentRatio: 0.75,
   fontBoxDescentRatio: 0.25,
 };
@@ -79,6 +80,7 @@ const EMBEDDED_FONT: DisplayFontFace = {
   ...FONT,
   family: "Folio Sans",
   generic: "sans-serif",
+  fallbacks: [],
   embedded: { id: "embedded-1", bytes: new Uint8Array([0, 1, 0, 0]) },
 };
 
@@ -100,11 +102,14 @@ const emptyPage = (primitives: readonly DisplayPrimitive[]): DisplayPage => ({
   links: [],
 });
 
-const renderPrimitives = (primitives: readonly DisplayPrimitive[]) =>
+const renderPrimitives = (
+  primitives: readonly DisplayPrimitive[],
+  fonts: readonly DisplayFontFace[] = [FONT],
+) =>
   asStub(
     renderDisplayPageToDom(emptyPage(primitives), {
       doc: stubDocument(),
-      fonts: [FONT],
+      fonts,
       images: [IMAGE],
       pageIndex: 0,
     }),
@@ -128,6 +133,8 @@ const PRIMITIVE_SAMPLES = {
     text: "abc",
     advancesPx: [5, 6, 7],
     direction: "ltr",
+    kerning: false,
+    smallCaps: false,
   },
   rect: {
     kind: "rect",
@@ -220,6 +227,68 @@ describe("renderDisplayListToDom", () => {
     expect(span?.style.textAlign).toBeUndefined();
     expect(span?.style.textIndent).toBeUndefined();
     expect(span?.style.unicodeBidi).toBeUndefined();
+  });
+
+  test("states whether the run kerns rather than leaving it to the browser", () => {
+    // A browser asked nothing kerns whenever the face has the table, and OOXML
+    // kerns only above `w:kern`. A run measured unkerned and painted kerned is
+    // narrower than the line it was fitted into.
+    expect(renderRun({ kerning: false })?.style.fontKerning).toBe("none");
+    expect(renderRun({ kerning: true })?.style.fontKerning).toBe("normal");
+  });
+
+  test("draws a small-caps run as small caps", () => {
+    expect(renderRun({ smallCaps: true })?.style.fontVariant).toBe("small-caps");
+    expect(renderRun({ smallCaps: false })?.style.fontVariant).toBeUndefined();
+  });
+
+  test("reapplies the spacing the advances were measured with", () => {
+    const span = renderRun({
+      adjustments: { letterSpacingPx: 2, horizontalScale: 1, wordSpacingPx: -1.5 },
+    });
+
+    expect(span?.style.letterSpacing).toBe("2px");
+    expect(span?.style.wordSpacing).toBe("-1.5px");
+    expect(span?.style.transform).toBeUndefined();
+  });
+
+  test("scales a run's glyphs and states its box before the scale", () => {
+    // The transform scales whatever it is given, so a box already at the
+    // declared width would be scaled twice, and so would the spacing.
+    const span = renderRun({
+      advancesPx: [10, 10],
+      text: "ab",
+      adjustments: { letterSpacingPx: 3, horizontalScale: 2, wordSpacingPx: 4 },
+    });
+
+    expect(span?.style.transform).toBe("scaleX(2)");
+    expect(span?.style.transformOrigin).toBe("left center");
+    expect(span?.style.width).toBe("10px");
+    expect(span?.dataset.advanceSum).toBe("20");
+    expect(span?.style.letterSpacing).toBe("1.5px");
+    expect(span?.style.wordSpacing).toBe("2px");
+  });
+
+  test("a run with nothing added to its advances carries no spacing at all", () => {
+    const span = renderRun({});
+
+    expect(span?.style.letterSpacing).toBeUndefined();
+    expect(span?.style.wordSpacing).toBeUndefined();
+    expect(span?.style.transform).toBeUndefined();
+  });
+
+  test("names every family the measurer would have fallen through", () => {
+    // A face is a stack. Handed only its first entry, a host missing that entry
+    // drops straight to the generic and paints a face nothing was measured in.
+    const face: DisplayFontFace = {
+      ...FONT,
+      family: "Calibri",
+      fallbacks: ["Carlito", "Arial"],
+      generic: "sans-serif",
+    };
+    const page = renderPrimitives([PRIMITIVE_SAMPLES.glyphRun], [face]);
+
+    expect(page.children.at(0)?.style.fontFamily).toBe(`"Calibri", "Carlito", "Arial", sans-serif`);
   });
 
   test("gives an rtl run the same box as an ltr one", () => {

--- a/packages/core/src/display-list/dom/renderDisplayListToDom.ts
+++ b/packages/core/src/display-list/dom/renderDisplayListToDom.ts
@@ -47,6 +47,7 @@ import type {
   DisplayFontFace,
   DisplayFontRef,
   DisplayGlyphRun,
+  DisplayRunAdjustments,
   DisplayImagePrimitive,
   DisplayImageRef,
   DisplayImageSource,
@@ -118,8 +119,16 @@ const quoteFontFamily = (family: string) => `"${family.replaceAll('"', '\\"')}"`
  * An embedded face wins over any installed face of the same name by being
  * named first, under the id its `@font-face` rule was registered with.
  */
-const fontFamilyStack = ({ family, generic, embedded }: DisplayFontFace) => {
-  const resolved = `${quoteFontFamily(family)}, ${generic}`;
+/**
+ * The stack the measurer resolved, rebuilt in CSS.
+ *
+ * Every entry, not just the first: the browser picks the first family it has,
+ * and so did the measurement. A shorter stack here paints a different face on
+ * any host missing the first one.
+ */
+const fontFamilyStack = ({ family, fallbacks, generic, embedded }: DisplayFontFace) => {
+  const names = [family, ...fallbacks].map(quoteFontFamily).join(", ");
+  const resolved = `${names}, ${generic}`;
   return embedded === undefined ? resolved : `${quoteFontFamily(embedded.id)}, ${resolved}`;
 };
 
@@ -345,6 +354,40 @@ const paintLineSegment = (line: DisplayLine, context: PaintContext) => {
   context.parent.append(element);
 };
 
+/**
+ * Reapply what the measurer added to the advances.
+ *
+ * The browser shapes the run's text and advances it by what the font says, and
+ * none of these three is in the font: without them the painted run is as wide
+ * as the glyphs alone, which is not the width the line was fitted at. The CSS
+ * is the same CSS the legacy painter emits, so the two agree by construction
+ * rather than by coincidence.
+ *
+ * Spacing goes on before the transform scales it, so the painted-pixel numbers
+ * the list carries are divided by the scale first.
+ */
+const applyAdjustments = (
+  span: HTMLElement,
+  adjustments: DisplayRunAdjustments | undefined,
+): void => {
+  if (adjustments === undefined) {
+    return;
+  }
+  const { letterSpacingPx, horizontalScale, wordSpacingPx } = adjustments;
+  if (letterSpacingPx !== 0) {
+    span.style.letterSpacing = px(letterSpacingPx / horizontalScale);
+  }
+  if (wordSpacingPx !== 0) {
+    span.style.wordSpacing = px(wordSpacingPx / horizontalScale);
+  }
+  if (horizontalScale !== 1) {
+    // The run's own box is already the scaled width, so the transform must not
+    // widen it again: it scales the glyphs inside a box the list sized.
+    span.style.transform = `scaleX(${String(horizontalScale)})`;
+    span.style.transformOrigin = "left center";
+  }
+};
+
 const paintGlyphRun = (run: DisplayGlyphRun, context: PaintContext) => {
   if ([...run.text].length !== run.advancesPx.length) {
     panic(
@@ -366,10 +409,12 @@ const paintGlyphRun = (run: DisplayGlyphRun, context: PaintContext) => {
   span.style.lineHeight = px(ascentPx + descentPx);
   span.style.display = "inline-block";
   span.style.boxSizing = "content-box";
-  // The declared extent. The browser shapes and advances the glyphs inside
-  // it, so the painted extent can differ from this by the shaper's rounding;
-  // that residue is measured rather than assumed (see the module header).
-  span.style.width = px(advanceSum);
+  // The declared extent. The browser shapes and advances the glyphs inside it,
+  // so the painted extent can differ from this by the shaper's rounding; that
+  // residue is measured rather than assumed (see the module header). A scaled
+  // run's box is stated before the transform, which then scales it to the
+  // declared width.
+  span.style.width = px(advanceSum / (run.adjustments?.horizontalScale ?? 1));
   span.style.whiteSpace = "pre";
   span.style.fontFamily = fontFamilyStack(face);
   span.style.fontSize = px(run.fontSizePx);
@@ -384,6 +429,13 @@ const paintGlyphRun = (run: DisplayGlyphRun, context: PaintContext) => {
     // is lost here, where PDF can dash it.
     span.style.webkitTextStroke = `${px(run.stroke.thicknessPx)} ${cssColor(run.stroke.color)}`;
   }
+  // Stated, never defaulted: a browser asked nothing kerns whenever the face
+  // has the table, and these advances may have been measured with it off.
+  span.style.fontKerning = run.kerning ? "normal" : "none";
+  if (run.smallCaps) {
+    span.style.fontVariant = "small-caps";
+  }
+  applyAdjustments(span, run.adjustments);
   // The producer's own number, readable back out of the DOM by the
   // equivalence harness without measuring anything.
   span.dataset["advanceSum"] = String(advanceSum);

--- a/packages/core/src/display-list/paintEquivalence.test.ts
+++ b/packages/core/src/display-list/paintEquivalence.test.ts
@@ -160,6 +160,7 @@ const FACE: DisplayFontFace = {
   weight: 400,
   italic: false,
   generic: "sans-serif",
+  fallbacks: [],
   fontBoxAscentRatio: 0.9,
   fontBoxDescentRatio: 0.2,
 };
@@ -195,6 +196,8 @@ const PRIMITIVE_SAMPLES = {
     text: "abc",
     advancesPx: [9, 9, 9],
     direction: "ltr",
+    kerning: false,
+    smallCaps: false,
   },
   rect: {
     kind: "rect",

--- a/packages/core/src/display-list/types.ts
+++ b/packages/core/src/display-list/types.ts
@@ -98,6 +98,17 @@ export type DisplayFontFace = {
   /** Category to fall back on when the family itself is unavailable. */
   readonly generic: "serif" | "sans-serif" | "monospace" | "cursive" | "fantasy";
   /**
+   * The concrete families between `family` and `generic`, in the order the
+   * measurer would fall through them.
+   *
+   * A face is a stack, not a name: the measurer resolves one and measures with
+   * whichever entry the host actually has. A backend handed only the first
+   * entry falls straight to the generic when that entry is missing, and paints
+   * a different face from the one the page was laid out in. Empty when the
+   * resolved stack is one family and a generic.
+   */
+  readonly fallbacks: readonly string[];
+  /**
    * The face's own box, above and below the baseline, as fractions of the font
    * size, exactly as the measurer reported it (`FontMetrics.fontBox*`).
    *
@@ -148,6 +159,33 @@ export type DisplayImageSource = {
  * never emits a run that spans a direction change, so no backend runs the bidi
  * algorithm and no two backends can disagree about its result.
  */
+/**
+ * What the measurer added on top of the glyphs' own advances.
+ *
+ * `advancesPx` already carries all three, because that is what line breaking
+ * decided the page on. They are named again here because a backend that hands
+ * the text to a shaper cannot recover them from it: a shaper advances glyphs by
+ * what the font says, and letter spacing, a horizontal scale and the space
+ * compression a justified line was fitted with are not in the font. Such a
+ * backend reapplies them and lands on the same extent; one that positions every
+ * glyph itself ignores this and reads `advancesPx`.
+ *
+ * Absent means none of the three applies, which is the common run.
+ *
+ * Every number is in the same painted pixels as `advancesPx`: `letterSpacingPx`
+ * and `wordSpacingPx` are what a code point actually gained on the page, after
+ * `horizontalScale`. A backend that applies the scale as a transform divides by
+ * it first, because a transform scales the spacing it is given.
+ */
+export type DisplayRunAdjustments = {
+  /** Added after every code point of the run but the last. */
+  readonly letterSpacingPx: number;
+  /** Multiplies every advance. 1 when the run carries no `w:w`. */
+  readonly horizontalScale: number;
+  /** Added to each compressible space, negative on a contracted line. */
+  readonly wordSpacingPx: number;
+};
+
 export type DisplayGlyphRun = {
   readonly kind: "glyphRun";
   readonly font: DisplayFontRef;
@@ -159,6 +197,27 @@ export type DisplayGlyphRun = {
   readonly text: string;
   readonly advancesPx: readonly number[];
   readonly direction: "ltr" | "rtl";
+  /**
+   * Whether the glyphs kern.
+   *
+   * Stated rather than left to the backend's default, because the two defaults
+   * disagree: OOXML kerns only above the `w:kern` size and a run without it
+   * does not kern at all, while a browser asked nothing kerns whenever the face
+   * has the table. A run measured unkerned and painted kerned is narrower on
+   * the page than the line it was fitted into.
+   */
+  readonly kerning: boolean;
+  /**
+   * Whether the run's lowercase letters are drawn as small capitals.
+   *
+   * Carried because it changes every advance in the run: a backend that paints
+   * the text at full size occupies a different width from the one the line was
+   * fitted to. Which glyphs a face uses for them, real `smcp` forms or scaled
+   * capitals, is the backend's business.
+   */
+  readonly smallCaps: boolean;
+  /** What the measurer added to the advances; absent when it added nothing. */
+  readonly adjustments?: DisplayRunAdjustments;
   /**
    * Glyph outline stroke, for `w:outline` and the emboss/imprint effects.
    * Absent means fill only.

--- a/packages/core/src/pdf/fonts.test.ts
+++ b/packages/core/src/pdf/fonts.test.ts
@@ -28,6 +28,7 @@ const FACE: DisplayFontFace = {
   weight: 400,
   italic: false,
   generic: "sans-serif",
+  fallbacks: [],
   fontBoxAscentRatio: 0.9,
   fontBoxDescentRatio: 0.2,
 };
@@ -74,6 +75,8 @@ const listFor = (advances: readonly number[]): DisplayList => ({
           text: TEXT,
           advancesPx: advances,
           direction: "ltr",
+          kerning: false,
+          smallCaps: false,
         },
       ],
       links: [],

--- a/packages/core/src/pdf/glyphCoverage.test.ts
+++ b/packages/core/src/pdf/glyphCoverage.test.ts
@@ -43,6 +43,7 @@ const FACE: DisplayFontFace = {
   weight: 400,
   italic: false,
   generic: "sans-serif",
+  fallbacks: [],
   fontBoxAscentRatio: 0.9,
   fontBoxDescentRatio: 0.2,
 };
@@ -113,6 +114,8 @@ const listFor = ({ text, advances }: ListOptions): DisplayList => ({
           text,
           advancesPx: advances,
           direction: "ltr",
+          kerning: false,
+          smallCaps: false,
         },
       ],
       links: [],

--- a/packages/core/src/pdf/writePdf.test.ts
+++ b/packages/core/src/pdf/writePdf.test.ts
@@ -17,6 +17,7 @@ const FACE: DisplayFontFace = {
   weight: 400,
   italic: false,
   generic: "sans-serif",
+  fallbacks: [],
   fontBoxAscentRatio: 0.9,
   fontBoxDescentRatio: 0.2,
 };
@@ -68,6 +69,8 @@ const textRun = (text: string): DisplayPrimitive => ({
   text,
   advancesPx: [...text].map(() => 9),
   direction: "ltr",
+  kerning: false,
+  smallCaps: false,
 });
 
 const FIXTURE = listWith([
@@ -301,6 +304,8 @@ describe("malformed display lists", () => {
         text: "abc",
         advancesPx: [1, 2],
         direction: "ltr",
+        kerning: false,
+        smallCaps: false,
       },
     ]);
     expect((await writePdf(broken, { fonts: NO_FONTS, timestamp: TIMESTAMP })).isErr()).toBe(true);
@@ -363,6 +368,8 @@ describe("right-to-left runs", () => {
         text: "abc",
         advancesPx: [10, 20, 30],
         direction: "rtl",
+        kerning: false,
+        smallCaps: false,
       },
     ]);
     const content = contentStreamOf((await write(rtl)).bytes);

--- a/tests/visual/display-list-run-drift.measure-parity.spec.ts
+++ b/tests/visual/display-list-run-drift.measure-parity.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Does the display-list renderer paint runs where the display list says?
+ * Does the display-list renderer paint runs where, and as wide as, the display
+ * list says?
  *
  * This is the arrangement the editor actually uses, and it is the only one
  * worth gating: the display list is built by the canvas measure provider
@@ -9,14 +10,12 @@
  * baseline is not, and the same reason `measure-parity.spec.ts` is safe to
  * gate on.
  *
- * What is gated is the run's *origin*, because that is what the display list
- * decides. Where each glyph lands inside a run is the shaper's business, and
- * so is the run's painted extent: `advancesPx` folds in letter spacing,
- * horizontal scale and justification adjustments, and one shaped text node
- * cannot reproduce those from its text alone. The extent difference is
- * therefore measured and reported here rather than asserted. Closing it would
- * mean carrying those adjustments in the paint IR beside the advances instead
- * of folded into them, so a backend could reapply them.
+ * Both the run's origin and its extent are gated. The extent used to be
+ * reported only, because `advancesPx` folded in letter spacing, a horizontal
+ * scale, justification and small capitals, and a shaped text node cannot
+ * reproduce those from its text alone. The list now carries each of them
+ * beside the advances, so the backend reapplies them and the extent is a
+ * property the renderer either honours or does not.
  *
  * The paint-equivalence harness measures a different arrangement again, a list
  * built from font-table advances and painted by a shaper that kerns, and
@@ -27,23 +26,23 @@
 import { expect, test, type Page } from "@playwright/test";
 
 /**
- * How far a run's painted left edge may sit from its declared one.
+ * How far a run's painted geometry may sit from its declared geometry.
  *
- * A browser snaps each layout value to 1/64 px (0.0156), and an origin is set
- * directly rather than accumulated, so a correctly placed run can miss by one
- * quantum and no more. Two quanta bounds the observed disagreement rather than
- * hiding it; a run placed from inline flow instead of from the display list
- * would miss by whole pixels and fail here.
+ * A browser snaps each layout value to 1/64 px (0.0156), and both an origin and
+ * an extent are set directly rather than accumulated, so a correctly painted
+ * run can miss by one quantum and no more. Two quanta bounds the observed
+ * disagreement rather than hiding it; a run painted from inline flow, or one
+ * whose spacing the backend did not reapply, misses by whole pixels.
  */
-const ORIGIN_TOLERANCE_PX = 0.032;
+const TOLERANCE_PX = 0.032;
 
 type RunDrift = {
   readonly text: string;
   readonly declaredPx: number;
   readonly paintedPx: number;
-  /** Painted extent against declared: reported, not gated. */
+  /** Painted extent against what the list declares the run occupies. */
   readonly extentDeltaPx: number;
-  /** Painted left edge against declared: gated. */
+  /** Painted left edge against declared. */
   readonly originDeltaPx: number;
 };
 
@@ -54,19 +53,21 @@ type RunDrift = {
  */
 const collectRunDrift = (page: Page): Promise<RunDrift[]> =>
   page.evaluate(() => {
-    const axisAligned = (element: HTMLElement): boolean => {
-      for (let node: HTMLElement | null = element; node; node = node.parentElement) {
+    /** A rotated page cannot be compared; a run's own horizontal scale can. */
+    const comparable = (element: HTMLElement): boolean => {
+      for (let node = element.parentElement; node; node = node.parentElement) {
         const { transform } = getComputedStyle(node);
         if (transform !== "none" && transform !== "") {
           return false;
         }
       }
-      return true;
+      const own = new DOMMatrixReadOnly(getComputedStyle(element).transform);
+      return own.b === 0 && own.c === 0;
     };
 
     const drifts: RunDrift[] = [];
     for (const run of document.querySelectorAll<HTMLElement>("[data-advance-sum]")) {
-      if (!axisAligned(run)) {
+      if (!comparable(run)) {
         continue;
       }
       const declaredPx = Number(run.dataset["advanceSum"]);
@@ -80,6 +81,13 @@ const collectRunDrift = (page: Page): Promise<RunDrift[]> =>
       if (paintedPx <= 0) {
         continue;
       }
+      const style = getComputedStyle(run);
+      // CSS puts a letter-space after the run's last character; OOXML counts
+      // the gaps between characters, so the declared width has one fewer. The
+      // difference is the whole of it, and it scales with the run.
+      const letterSpacingPx = Number.parseFloat(style.letterSpacing);
+      const scale = new DOMMatrixReadOnly(style.transform).a;
+      const trailingPx = Number.isFinite(letterSpacingPx) ? letterSpacingPx * scale : 0;
       const declaredLeft = Number.parseFloat(run.style.left);
       const parent = run.offsetParent;
       const paintedLeft =
@@ -89,7 +97,7 @@ const collectRunDrift = (page: Page): Promise<RunDrift[]> =>
         text: run.textContent ?? "",
         declaredPx,
         paintedPx,
-        extentDeltaPx: Math.abs(paintedPx - declaredPx),
+        extentDeltaPx: Math.abs(paintedPx - (declaredPx + trailingPx)),
         originDeltaPx: Number.isFinite(declaredLeft) ? Math.abs(paintedLeft - declaredLeft) : 0,
       });
     }
@@ -109,44 +117,52 @@ const percentile = (values: readonly number[], fraction: number): number => {
   return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))] ?? 0;
 };
 
-const reportExtents = (label: string, drifts: readonly RunDrift[]): void => {
-  const deltas = drifts.map((drift) => drift.extentDeltaPx);
-  const ratios = drifts.map((drift) => drift.extentDeltaPx / drift.declaredPx);
+const report = (label: string, drifts: readonly RunDrift[]): void => {
+  const extents = drifts.map((drift) => drift.extentDeltaPx);
+  const origins = drifts.map((drift) => drift.originDeltaPx);
   // eslint-disable-next-line no-console -- the measurement is the deliverable
   console.log(
     `${label}: ${String(drifts.length)} runs | extent px median ` +
-      `${percentile(deltas, 0.5).toFixed(3)} p90 ${percentile(deltas, 0.9).toFixed(3)} ` +
-      `worst ${percentile(deltas, 1).toFixed(3)} | extent ratio median ` +
-      `${(percentile(ratios, 0.5) * 100).toFixed(3)}% p90 ${(percentile(ratios, 0.9) * 100).toFixed(3)}%`,
+      `${percentile(extents, 0.5).toFixed(3)} p90 ${percentile(extents, 0.9).toFixed(3)} ` +
+      `worst ${percentile(extents, 1).toFixed(3)} | origin px p90 ` +
+      `${percentile(origins, 0.9).toFixed(3)} worst ${percentile(origins, 1).toFixed(3)}`,
   );
 };
 
-const describeOrigin = (drift: RunDrift) =>
-  `"${drift.text.slice(0, 40)}": origin off by ${drift.originDeltaPx.toFixed(4)}px`;
+const describe = (drift: RunDrift, kind: "origin" | "extent", deltaPx: number) =>
+  `"${drift.text.slice(0, 40)}": ${kind} off by ${deltaPx.toFixed(4)}px ` +
+  `(declared ${drift.declaredPx.toFixed(3)}, painted ${drift.paintedPx.toFixed(3)})`;
 
-const expectOriginsHonoured = (drifts: readonly RunDrift[]): void => {
+const expectGeometryHonoured = (drifts: readonly RunDrift[]): void => {
   expect(drifts.length, "no glyph runs were painted").toBeGreaterThan(0);
   expect(
-    drifts.filter((drift) => drift.originDeltaPx > ORIGIN_TOLERANCE_PX).map(describeOrigin),
+    drifts
+      .filter((drift) => drift.originDeltaPx > TOLERANCE_PX)
+      .map((drift) => describe(drift, "origin", drift.originDeltaPx)),
+  ).toEqual([]);
+  expect(
+    drifts
+      .filter((drift) => drift.extentDeltaPx > TOLERANCE_PX)
+      .map((drift) => describe(drift, "extent", drift.extentDeltaPx)),
   ).toEqual([]);
 };
 
 test.describe("display-list run drift", () => {
-  test("a run is painted at the origin the display list declares", async ({ page }) => {
+  test("a run is painted where and as wide as the display list declares", async ({ page }) => {
     await openWithDisplayListRenderer(page, "sample.docx");
     const drifts = await collectRunDrift(page);
 
-    reportExtents("sample.docx", drifts);
-    expectOriginsHonoured(drifts);
+    report("sample.docx", drifts);
+    expectGeometryHonoured(drifts);
   });
 
-  test("a multi-page document honours every run's origin", async ({ page }) => {
+  test("a multi-page document honours every run's geometry", async ({ page }) => {
     // Past the virtualization threshold, so the incremental path is measured
     // rather than the eager small-document path.
     await openWithDisplayListRenderer(page, "podily-bps.docx");
     const drifts = await collectRunDrift(page);
 
-    reportExtents("podily-bps.docx", drifts);
-    expectOriginsHonoured(drifts);
+    report("podily-bps.docx", drifts);
+    expectGeometryHonoured(drifts);
   });
 });


### PR DESCRIPTION
`advancesPx` folded five separate things into one number per code point:
letter spacing, a horizontal scale, the space compression a justified line was
fitted with, kerning, and small capitals. A backend that positions every glyph
itself does not care. A backend that hands the run's text to a shaper cannot
recover any of them, because a shaper advances glyphs by what the font says and
none of the five is in the font.

So the DOM backend painted runs at the glyphs' own width rather than the width
the line was fitted at, by as much as 78 px on one justified line, and the
run-drift check could only report that rather than gate it.

## What the run carries now

`DisplayGlyphRun` gains `adjustments` (letter spacing, horizontal scale,
per-space justification delta; absent when none applies) and two stated
settings, `kerning` and `smallCaps`. The advances still carry all five, because
that is what line breaking decided the page on; naming them is what lets a
backend reapply them and land on the same extent.

The DOM backend reapplies each as the CSS the legacy painter already emits
(`letter-spacing`, `word-spacing`, `scaleX`, `font-kerning`, `font-variant`), so
the two renderers agree by construction rather than by coincidence. Spacing goes
on before a transform scales it, so the painted-pixel numbers the list carries
are divided by the scale first, and a scaled run's box is stated pre-transform.

Two things surfaced while closing the gap, both of the same kind:

- **`kerning` had to be stated, not defaulted.** OOXML kerns only above the
  `w:kern` size and a run without it does not kern at all; a browser asked
  nothing kerns whenever the face has the table. That default disagreement was
  the whole p90 tail, ~1.1 px on every heading.
- **`DisplayFontFace` needed the whole stack.** It carried the first family and
  the generic, dropping everything between. A face is a stack, and the measurer
  measures with whichever entry the host actually has; a backend handed only the
  first drops to the generic wherever that entry is missing and paints a face
  nothing was measured in. `fallbacks` carries the rest.

## The advances now sum to the width the line was broken on

They were the sum of per-character measurements. Line breaking used
`measureTextWidth` over the whole string, and the two differ wherever a pair
kerns or ligates, so the run declared an extent no backend paints. `buildGlyphs`
now scales the per-character advances to the string's own width, spread across
the run rather than dropped on its last glyph. On a heading that was 0.77 px.

## The extent is a gate

`display-list-run-drift.measure-parity.spec.ts` asserts the painted extent
against the declared one, at the same one-quantum tolerance as the origin. It
also stops skipping horizontally scaled runs: a scale is axis-aligned and
comparable, and only a rotation is not.

| fixture | extent p90 before → after | extent worst before → after |
| --- | --- | --- |
| `sample.docx` (49 runs) | 1.083 → **0.013** px | 1.423 → **0.014** px |
| `podily-bps.docx` (186 runs) | 1.852 → **0.014** px | 77.734 → **0.016** px |

0.016 px is one browser layout quantum (1/64). Origins are unchanged at p90
0.012–0.014 px.

One quirk is accounted for rather than hidden: CSS puts a letter-space after a
run's last character and OOXML counts only the gaps between characters, so a run
with `w:spacing` paints exactly one letter-space wider than it declares. The
gate expects that and the spec says why. Making the measurement include it would
match both CSS and Word, and would move every line that has character spacing;
that belongs in its own change.

## Equivalence

Every fixture in the paint-equivalence harness improved, and its own advance
drift over `podily-bps.docx` fell from p90 1.137 px / worst 64.9 px to p90
0.261 px / worst 20.3 px:

| fixture | before | after |
| --- | --- | --- |
| `docx-editor-demo.docx` | 0.9803 | **0.9839** |
| `sample.docx` | 0.9857 | **0.9882** |
| `podily-bps.docx` | 0.9578 | **0.9622** |
| `diacritics-latin-ext.docx` | 0.9878 | **0.9916** |
| `rtl-arabic-shaping.docx` | 0.9965 | 0.9964 |

The baseline is updated so a regression is caught.

## Reports

The producer reported `smallCaps` and `w:w` as constructs the display list could
not express. It expresses both now, and the DOM backend paints both, so the two
reports say what is actually true: the PDF backend paints full-size, unnarrowed
glyphs at the measured advances. Teaching it to synthesize small capitals and a
narrowed scale is follow-up work.

## Noted, not fixed

The new fields are required, and no test fixture failed to compile when they
were added: `packages/core`'s `typecheck` runs over `tsconfig.build.json`, which
excludes every test. The fixtures failed at runtime instead. Making tests
typecheck needs `bun-types` wired into the base config first (~1,900 errors
today, nearly all `Cannot find module 'bun:test'`), which is its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved text rendering for letter spacing, word spacing, horizontal scaling, justification, kerning and small capitals.
  - Font fallback families are now preserved and reapplied during rendering.
  - Glyph-run widths now align more reliably with line-breaking measurements.

- **Bug Fixes**
  - Reduced text positioning and sizing discrepancies across rendered output.
  - Improved support for accurately measuring and painting styled text runs.

- **Tests**
  - Expanded coverage for typography adjustments, fallback fonts and painted text extents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->