### PR TITLE
feat(core): single-line height for eleven more requested faces

### DIFF
--- a/.changeset/olive-fonts-measured.md
+++ b/.changeset/olive-fonts-measured.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Give the Arabic, narrow and ClearType faces documents actually request their own single-line height instead of the generic default.

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -43,6 +43,14 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["garamond", 1.1273],
     ["century gothic", 1.2261],
     ["lucida console", 1.0],
+    ["arial narrow", 1.1475],
+    ["bookman old style", 1.1738],
+    ["franklin gothic book", 1.1338],
+    ["calibri light", 1.2207],
+    ["candara", 1.2207],
+    ["constantia", 1.2207],
+    ["corbel", 1.2075],
+    ["dubai", 1.688],
   ];
 
   for (const [font, expectedRatio] of verifiedRatios) {
@@ -159,6 +167,23 @@ describe("fontResolver — previously wrong ratios are corrected and reach consu
   for (const [font, correctedRatio] of correctedCases) {
     test(`${font} resolves to the corrected ratio via getResolvedData`, () => {
       expect(getResolvedData(font).singleLineRatio).toBeCloseTo(correctedRatio, 4);
+    });
+  }
+});
+
+describe("fontResolver — faces without a readable font file carry a measured ratio", () => {
+  // These ship with the office suite rather than as a font file this repository
+  // can read hhea metrics from, so the ratio comes from a measured line pitch.
+  // They are far above the 1.15 default, which is what makes them worth pinning.
+  const measuredCases: [font: string, ratio: number][] = [
+    ["helvetica", 1.2],
+    ["simplified arabic", 1.6582],
+    ["sakkal majalla", 1.3964],
+  ];
+
+  for (const [font, ratio] of measuredCases) {
+    test(`${font} resolves to its measured ratio`, () => {
+      expect(getResolvedData(font).singleLineRatio).toBeCloseTo(ratio, 4);
     });
   }
 });

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -408,6 +408,136 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     }), // 1.1709 (was hand-transcribed 1.1626 — wrong)
   },
 
+  "arial narrow": {
+    googleFont: "Arimo",
+    category: "sans-serif",
+    fallbackStack: ["Arial Narrow", "Arimo", "Arial", "Helvetica", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1916,
+      hheaDescent: -434,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1475
+  },
+  helvetica: {
+    googleFont: "Arimo",
+    category: "sans-serif",
+    fallbackStack: ["Helvetica", "Arimo", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "measured",
+      ratio: 1.2,
+      note: "Measured at 11pt against a 13.2pt reference-layout line pitch. Helvetica's hhea ascent and descent sum to exactly one em, and that 1.0 ratio is not the rendered pitch, so the formula does not apply here.",
+    }),
+  },
+  "bookman old style": {
+    googleFont: "EB Garamond",
+    category: "serif",
+    fallbackStack: ["Bookman Old Style", "EB Garamond", "Georgia", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1929,
+      hheaDescent: -475,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1738
+  },
+  "franklin gothic book": {
+    googleFont: "Libre Franklin",
+    category: "sans-serif",
+    fallbackStack: ["Franklin Gothic Book", "Libre Franklin", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1877,
+      hheaDescent: -445,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.1338
+  },
+  "calibri light": {
+    googleFont: "Carlito",
+    category: "sans-serif",
+    fallbackStack: ["Calibri Light", "Calibri", "Carlito", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1950,
+      hheaDescent: -550,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.2207
+  },
+  candara: {
+    googleFont: "Carlito",
+    category: "sans-serif",
+    fallbackStack: ["Candara", "Carlito", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1484,
+      hheaDescent: -564,
+      hheaLineGap: 452,
+      unitsPerEm: 2048,
+    }), // 1.2207
+  },
+  constantia: {
+    googleFont: "Caladea",
+    category: "serif",
+    fallbackStack: ["Constantia", "Caladea", "Georgia", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1538,
+      hheaDescent: -510,
+      hheaLineGap: 452,
+      unitsPerEm: 2048,
+    }), // 1.2207
+  },
+  corbel: {
+    googleFont: "Carlito",
+    category: "sans-serif",
+    fallbackStack: ["Corbel", "Carlito", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1523,
+      hheaDescent: -525,
+      hheaLineGap: 425,
+      unitsPerEm: 2048,
+    }), // 1.2075
+  },
+
+  // Arabic faces. Their line height is far above the 1.15 default, so leaving
+  // them unmapped understates every line box by a third or more.
+  dubai: {
+    googleFont: "Noto Sans Arabic",
+    category: "sans-serif",
+    fallbackStack: ["Dubai", "Noto Sans Arabic", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1129,
+      hheaDescent: -559,
+      hheaLineGap: 0,
+      unitsPerEm: 1000,
+    }), // 1.688
+  },
+  "simplified arabic": {
+    googleFont: "Noto Naskh Arabic",
+    category: "serif",
+    fallbackStack: ["Simplified Arabic", "Noto Naskh Arabic", "Times New Roman", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "measured",
+      ratio: 1.6582,
+      note: "Measured at 11pt against an 18.24pt reference-layout line pitch; the face ships with the office suite, not as a readable font file.",
+    }),
+  },
+  "sakkal majalla": {
+    googleFont: "Noto Naskh Arabic",
+    category: "serif",
+    fallbackStack: ["Sakkal Majalla", "Noto Naskh Arabic", "Times New Roman", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "measured",
+      ratio: 1.3964,
+      note: "Measured at 11pt against a 15.36pt reference-layout line pitch; the face ships with the office suite, not as a readable font file.",
+    }),
+  },
+
   // CJK fonts
   "ms mincho": {
     googleFont: "Noto Serif JP",


### PR DESCRIPTION
## What was wrong

`FONT_MAPPINGS` has no entry for a number of families that documents routinely
request, so `resolveFontFamily` falls through to `DEFAULT_SINGLE_LINE_RATIO`
(1.15). Every line box in such a document is then measured against a height the
face does not have, and the error compounds down the page: a paragraph breaks a
line early or late, and the page break lands in the wrong place.

Three Arabic faces are the extreme case. Their rendered single-line pitch is
1.40 to 1.69 times the point size, so the generic default understates each line
by a third to nearly a half.

## How it is derived now

Each new entry follows the rule the table already documents: the ratio is
`(hheaAscent + |hheaDescent| + hheaLineGap) / unitsPerEm`, taken from the face's
own `hhea` table, never hand-written.

| face | source |
| --- | --- |
| Dubai | `hhea` |
| Arial Narrow | `hhea` |
| Bookman Old Style | `hhea` |
| Franklin Gothic Book | `hhea` |
| Calibri Light | `hhea` |
| Candara, Constantia, Corbel | `hhea` |
| Simplified Arabic, Sakkal Majalla | `measured` |
| Helvetica | `measured` |

Simplified Arabic and Sakkal Majalla ship with the office suite rather than as a
font file this repository can read, so they use the `measured` source with a
note recording the pitch and the size it was taken at, exactly as Garamond and
the Japanese faces already do.

Helvetica is a deliberate `measured` entry rather than an `hhea` one: its `hhea`
ascent and descent sum to exactly one em, and that 1.0 ratio is not the pitch
anything renders, so the formula does not describe this face. The note says so.

## Tests

`utils/fontResolver.test.ts` extends the `verifiedRatios` table with the eight
`hhea`-derived faces, so a future edit that hand-writes a different decimal into
`FONT_MAPPINGS` fails there. The three measured faces get their own block,
asserted through `getResolvedData`, which is the path the layout engine and
`measureContainer` actually use.
