### PR TITLE
feat(core): a blank paragraph is a block

### DIFF
--- a/.changeset/plain-lines-count.md
+++ b/.changeset/plain-lines-count.md
@@ -1,5 +1,7 @@
 ---
 "@stll/folio-core": minor
+"@stll/docx-core": minor
+"@stll/folio-agents": patch
 ---
 
 Blank paragraphs are blocks. The AI-facing snapshot skipped every paragraph

--- a/.changeset/plain-lines-count.md
+++ b/.changeset/plain-lines-count.md
@@ -1,0 +1,54 @@
+---
+"@stll/folio-core": minor
+---
+
+Blank paragraphs are blocks. The AI-facing snapshot skipped every paragraph
+with no words, so a blank line had no id, nothing could address it, and a
+comparison could neither add nor remove one. It carries them now, under an
+additive `blank-NNNN` id shape that leaves the published `seq-NNNN` numbering
+over the paragraphs that DO carry words exactly where it was, and the reading
+surfaces filter them through one shared helper.
+
+`FolioAIEditSnapshot.emptyDocumentAnchorId` is gone, which is why this is a
+minor rather than a patch. It named the anchor an empty document had no block
+for; an empty document is one blank paragraph, and that paragraph is now a
+block, so its id is `blocks[0].id` like any other. Read that instead.
+
+Three operations follow from that:
+
+- `insertAfterBlock` / `insertBeforeBlock` with `text: ""` insert a blank
+  paragraph rather than being refused as empty.
+- `deleteBlock` on a blank removes it, with its paragraph mark tracked, rather
+  than doing nothing.
+- `insertTableRow` sizes the new row against the table's own column count, so a
+  row a table can hold is no longer refused because a cell in it spans columns.
+
+Five defects the blanks made visible, each of which was already losing content:
+
+- An attribute-only edit — a paragraph mark, a list level, a style on a blank
+  paragraph — never reached the saved file. The change tracker reads positions
+  off each step, and `AttrStep` carries an empty step map, so the selective save
+  wrote the paragraph's original XML and the edit was gone from the document
+  while the editor still showed it.
+- Deleting a block left its images behind. The deletion range is built from the
+  block's text, so an image outside the words kept no mark, and accepting the
+  deletion left a paragraph standing around an orphan picture.
+- Zero-width anchors counted as content. A bookmark boundary, a text-box
+  anchor, or Word's cached pagination boundary (`w:lastRenderedPageBreak`)
+  survived a deletion that took every word, and the emptied paragraph stayed as
+  a blank line nobody asked for. They are not content, they never carry a
+  revision, and a revision landing on one produced a document the serializer
+  refuses to write.
+- Resolving a paragraph's mark could take a section with it. A section's
+  properties live on a paragraph mark, so the paragraph is where the section
+  ends: removing it merged two sections into one and dropped the removed
+  section's page size, margins, and header and footer references. The
+  properties now travel to the paragraph the resolution leaves behind, and a
+  paragraph with nothing after it to carry them keeps its mark.
+- Appending a paragraph at the end of a container handed its paragraph mark to
+  the anchor. That is equivalent only while the two stay adjacent, and a table
+  inserted between them by a later operation in the same batch separated them:
+  the mark then joined the anchor to the table, which is nothing, and the
+  appended paragraph survived a reject that should have closed it. Every
+  inserted paragraph carries its own mark, and resolving a mark with nothing
+  after it removes the emptied paragraph instead of joining.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -251,7 +251,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     preserveFormatting?: boolean;
     styleId?: string;
     comment?: FolioAIComment;
-} | {
+} |
+/**
+* Delete the whole block. A block with words loses them and its paragraph
+* mark; a BLANK block has only a paragraph mark to lose, and loses it, so
+* the empty line goes away rather than the operation doing nothing.
+*/
+    {
     id: string;
     type: "deleteBlock";
     blockId: string;
@@ -410,11 +416,10 @@ export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguous
 */
 "documentNotEditable";
 
-// @public (undocumented)
+// @public
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
     anchors: Record<string, FolioAIBlockAnchor>;
-    emptyDocumentAnchorId?: string;
 };
 
 // @public
@@ -781,6 +786,9 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
     path: string;
     reason: string;
 }> {}
+
+// @public
+export const isFolioAIContentBlock: (input: Pick<FolioAIBlock, "text">) => boolean;
 
 // @public (undocumented)
 export const isFolioDocumentOperationModeSupported: (operationType: FolioDocumentOperationType, mode: FolioDocumentOperationMode) => boolean;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -852,7 +852,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     preserveFormatting?: boolean;
     styleId?: string;
     comment?: FolioAIComment;
-} | {
+} |
+/**
+* Delete the whole block. A block with words loses them and its paragraph
+* mark; a BLANK block has only a paragraph mark to lose, and loses it, so
+* the empty line goes away rather than the operation doing nothing.
+*/
+    {
     id: string;
     type: "deleteBlock";
     blockId: string;
@@ -1011,11 +1017,10 @@ export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguous
 */
 "documentNotEditable";
 
-// @public (undocumented)
+// @public
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
     anchors: Record<string, FolioAIBlockAnchor>;
-    emptyDocumentAnchorId?: string;
 };
 
 // @public
@@ -1292,6 +1297,9 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
     path: string;
     reason: string;
 }> {}
+
+// @public
+export const isFolioAIContentBlock: (input: Pick<FolioAIBlock, "text">) => boolean;
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -852,7 +852,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     preserveFormatting?: boolean;
     styleId?: string;
     comment?: FolioAIComment;
-} | {
+} |
+/**
+* Delete the whole block. A block with words loses them and its paragraph
+* mark; a BLANK block has only a paragraph mark to lose, and loses it, so
+* the empty line goes away rather than the operation doing nothing.
+*/
+    {
     id: string;
     type: "deleteBlock";
     blockId: string;
@@ -1011,11 +1017,10 @@ export type FolioAIEditSkipReason = "missingBlock" | "changedBlock" | "ambiguous
 */
 "documentNotEditable";
 
-// @public (undocumented)
+// @public
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
     anchors: Record<string, FolioAIBlockAnchor>;
-    emptyDocumentAnchorId?: string;
 };
 
 // @public
@@ -1292,6 +1297,9 @@ export class InvalidFolioDocumentOperationBatchError extends InvalidFolioDocumen
     path: string;
     reason: string;
 }> {}
+
+// @public
+export const isFolioAIContentBlock: (input: Pick<FolioAIBlock, "text">) => boolean;
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -600,7 +600,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     preserveFormatting?: boolean;
     styleId?: string;
     comment?: FolioAIComment;
-} | {
+} |
+/**
+* Delete the whole block. A block with words loses them and its paragraph
+* mark; a BLANK block has only a paragraph mark to lose, and loses it, so
+* the empty line goes away rather than the operation doing nothing.
+*/
+    {
     id: string;
     type: "deleteBlock";
     blockId: string;
@@ -723,11 +729,10 @@ export type FolioAIEditPrecondition = {
     blockTextHash: string;
 };
 
-// @public (undocumented)
+// @public
 export type FolioAIEditSnapshot = {
     blocks: FolioAIBlock[];
     anchors: Record<string, FolioAIBlockAnchor>;
-    emptyDocumentAnchorId?: string;
 };
 
 // @public (undocumented)
@@ -1614,6 +1619,9 @@ export class InvalidGenerateRedlineDocxOptionsError extends InvalidGenerateRedli
     option: "baseView" | "revisedView";
     receivedValue: unknown;
 }> {}
+
+// @public
+export const isFolioAIContentBlock: (input: Pick<FolioAIBlock, "text">) => boolean;
 
 // @public
 export const isFolioBlockId: (value: unknown) => value is FolioBlockId;

--- a/api-reports/docx-core/index.api.md
+++ b/api-reports/docx-core/index.api.md
@@ -194,7 +194,7 @@ export type MarkdownContent = {
     numbering?: NumberingDefinitions;
 };
 
-// @public (undocumented)
+// @public
 export type Paragraph = {
     type: "paragraph";
     paraId?: string;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -660,7 +660,7 @@ export type NumberingInstance = {
 // @public
 export type PageOrientation = "portrait" | "landscape";
 
-// @public (undocumented)
+// @public
 export type Paragraph = {
     type: "paragraph";
     paraId?: string;
@@ -673,6 +673,9 @@ export type Paragraph = {
     renderedPageBreakBefore?: boolean;
     sectionProperties?: SectionProperties;
 };
+
+// @public
+export const PARAGRAPH_MARK_CHANGE_KINDS: readonly ["moveFrom", "moveTo", "ins", "del"];
 
 // @public
 export type ParagraphAlignment = "left" | "center" | "right" | "both" | "distribute" | "mediumKashida" | "highKashida" | "lowKashida" | "thaiDistribute";
@@ -746,9 +749,12 @@ export type ParagraphFormatting = {
 
 // @public
 export type ParagraphMarkChange = {
-    kind: "ins" | "del";
+    kind: ParagraphMarkChangeKind;
     info: TrackedChangeInfo;
 };
+
+// @public
+export type ParagraphMarkChangeKind = (typeof PARAGRAPH_MARK_CHANGE_KINDS)[number];
 
 // @public
 export type ParagraphPropertyChange = {

--- a/benchmarks/compare/README.md
+++ b/benchmarks/compare/README.md
@@ -94,6 +94,14 @@ Timings mean nothing without these, so a failing invariant fails the run.
 `--baseline` records a SHA-256 of every product; `--check` reruns and reports
 any that moved. That is how a performance change proves it altered nothing.
 
+A digest that moves needs a reason in the pull request that moves it. The
+recorded set was last re-taken when blank paragraphs became blocks: the
+generated documents themselves changed, because a body may not end with a
+table and the classes that ended on one now carry the paragraph the format
+requires; and the redline's shape changed where a paragraph is appended at a
+container's edge, where a deleted block held an image, and wherever a revision
+used to land on a zero-width anchor.
+
 ## An external corpus (local only)
 
 `--corpus <dir>` adds pairs from a directory outside the repository. Nothing
@@ -142,10 +150,10 @@ prints must be safe to quote anywhere.
 
 One bucket is not a defect. `round-trip-invisible-structure` collects the pairs
 whose every block matches, in order, at coordinates the block model cannot
-reach: the snapshot skips empty textblocks, so a cell holding a blank paragraph
-reports its visible paragraph at `p1` and no operation can put a block there.
-Those are separated from redlines that actually lost content rather than
-resolved by loosening the self-check.
+reach: the snapshot skips a hidden row's whole subtree on purpose, so a table
+hiding a row on one side only shifts every later row's index and no operation
+reaches those positions. Those are separated from redlines that actually lost
+content rather than resolved by loosening the self-check.
 
 Unlike the measurement modes this runs in one process. A refusal is a yes or
 no that no warm JIT can change, so a process per pair would turn a half-minute

--- a/benchmarks/compare/digests.json
+++ b/benchmarks/compare/digests.json
@@ -1,4 +1,32 @@
 {
+  "fields/l/churn": {
+    "buffer": "90a33c540e23f2f3ea07d9322c93f4a24d958370110a4fa36d25a9bc62884a72",
+    "changes": "49e3cd765ac3d95e4a088e22c793ec914e732169f684ab9789108251b3291611"
+  },
+  "fields/l/heavy": {
+    "buffer": "dbcfc941a7b08680b5803369d6bcea3ea0f78db4cd493f1e903b6fb49e9900a4",
+    "changes": "e877878823945f249b8bf28288f7d9124bffdf064d952c5c80d01dac0e65db83"
+  },
+  "fields/l/identical": {
+    "buffer": "1e11467a880ffa28e9fb56c69be5e5c7fd0ee2b34a765186485801f2e11849a2",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "fields/l/light": {
+    "buffer": "d1d76352e7801eb4fc07038f35a0323deda64b09ef3860644b01a23cc1355cdd",
+    "changes": "280bd52b20384485b64c78de7066ef21af6d467963b4ece5c2a4225df5828009"
+  },
+  "fields/l/reorder": {
+    "buffer": "efb5996865ab7d8742f238844250b8f5cae3bee4173510b58ce6f6e1670ec751",
+    "changes": "e1e102c15f38957c285e0c1f2cc8aeca461c0ea190da702df31e749da746cb41"
+  },
+  "fields/l/rewrite": {
+    "buffer": "b209ebab14efab07040f7bf1c240671be544526a9fc1b8b5c89554c57b3d0c8c",
+    "changes": "0199582b63e5b5071775558d530433352c55db17fcb1322073342f6b6a275c37"
+  },
+  "fields/l/structural": {
+    "buffer": "fcb6390c4f4bd2bdac00ff952acc7183da056880d702f32b19a64036d914b4cf",
+    "changes": "b3e76ae2c379980f562bdb387c6a3ed7c85ce9833f2b46f7d79c958de19ff3a8"
+  },
   "fields/m/churn": {
     "buffer": "9925237a259a5e03b5cd2424346b4da635aeb7083c638ce213ab89508fd161c1",
     "changes": "25bcc8e02cc21daa757c4481b2586e87756ce1c99c4b59c39b733bf898b1749f"
@@ -16,7 +44,7 @@
     "changes": "ff7c22007215ec0cfc019cc7f1f71c0ab44dcc9e01318801b0623a7e5337cc27"
   },
   "fields/m/reorder": {
-    "buffer": "3ecd08e8d2bd81a8f3eeee6ba6b41ed5614bfae779dc28f89a1a90de05b8bafc",
+    "buffer": "58494dda8a1a05644c1933d60e4f395e7a91d62af6e2d58e9774b4419573d548",
     "changes": "af0aa47ffd39fad8c1229ad20bf09e1e843dc89fde1467f06f288eca4af4b2f8"
   },
   "fields/m/rewrite": {
@@ -44,7 +72,7 @@
     "changes": "28daf17b145f40796260b947b672f14420b880b799e12be9045070e828b13468"
   },
   "fields/s/reorder": {
-    "buffer": "b135c14ac6f71f168eaba48927e4dc3fb85d9f628e6548f369f459909bba688b",
+    "buffer": "32527ceba4d849af61e416bb5e7e627afb6f48e90816bbdccea4b892df6dce10",
     "changes": "7aa9d59e5988781104381896daf308f9fe7b2bfc15cc3e4f0dd2ecbca1df84a8"
   },
   "fields/s/rewrite": {
@@ -54,6 +82,34 @@
   "fields/s/structural": {
     "buffer": "a8cd17b9cd24670a12b7fb21432b3246453c2e30cb2e22bdadc52895d2ba4664",
     "changes": "4ce57e683684226a619cec843ed65e33adac599b044b84ee0bad2bf1661fa9c8"
+  },
+  "graphics/l/churn": {
+    "buffer": "7e4263a39734e939c25d95984b258f15b9dfb0bd1d1159b8ad5aabe6ee2aa841",
+    "changes": "39495457dfd59f74a07d9ed1625e4ed6421b1212fd09e370f85236345734123d"
+  },
+  "graphics/l/heavy": {
+    "buffer": "90ff422f348f01ae5f0423db8d82c1b540785c4f1859f1cc27099a770bc2e489",
+    "changes": "6b05ea843a8321fdac11ecc4f00da2bc23ba338a381d6497311af47893db1aba"
+  },
+  "graphics/l/identical": {
+    "buffer": "578dd5c1d89d445c267a43c9fc531fd639bd56a0da1a592b7b1cabf9f6ebbb84",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "graphics/l/light": {
+    "buffer": "1062e7c677cf512b908248707a23826d67f0e369e8ebf364f91fbde05e218f78",
+    "changes": "d73d5b2e737da5c8bdb4f5eef44466b4d5f9a461fb6c59ef017bc8dcdc043688"
+  },
+  "graphics/l/reorder": {
+    "buffer": "32c5a2e155d0625ee95df0f5a690aa0672fc6a211464ece5e1f8ff11e4261380",
+    "changes": "4b9d3839953182ef280f6b7dfa3b25137e0083f068b58aa100471c1d9aba095c"
+  },
+  "graphics/l/rewrite": {
+    "buffer": "a9e454597cdf206c6937ca7789b1e973aeaeff98248573e3e270496c60b1b801",
+    "changes": "1781b3785c2afb9a30d1fc262084a7bfbbb24203ade87b035458aa002db3cf60"
+  },
+  "graphics/l/structural": {
+    "buffer": "515fc2be129c856d2cdcba42a746da842160fb066664d5df84b9fef5452120b0",
+    "changes": "add2a662ff633c937bf3052d55e0bcdf1e6fbe1244dfe23165eb96cdadd42d46"
   },
   "graphics/m/churn": {
     "buffer": "5a9a9491749ed0d4a1a5ec6dcfa8cef8cb35eac7d5fe22e630046e6f802f9593",
@@ -72,7 +128,7 @@
     "changes": "8a97da5bfe12c904b6bbff80c1552ce1dda6046f9a5f72b1ca60e155ab97bc96"
   },
   "graphics/m/reorder": {
-    "buffer": "41f626ef16d3a764b479f3bf4332d93cbf85583d69e1c1abd36047f62f763af1",
+    "buffer": "3b2f9157165acc15b6c0c08a7d7714302dfdae9cebc9b9eb7570e08f8f2268f3",
     "changes": "a0c27ff6b07d68a4c41ec45e0f015dcad37a7dc8800e65c0436acc92b65428e1"
   },
   "graphics/m/rewrite": {
@@ -100,7 +156,7 @@
     "changes": "c597f1c3807ea58c1d29530701d82cad97c48befb64ebdb74bf28086925ed4ad"
   },
   "graphics/s/reorder": {
-    "buffer": "c95014d188724b4bb69ac9a969a414d57b047c8f8f2ef2469e16f7e3f121e68d",
+    "buffer": "779d183ea435e1d6c23f43265fb37f4b842c425e973147f3e2bad29304e1c505",
     "changes": "2e8ae414b596fc96d6bf158c7b104fefcbc1a808d24b7424bc1e1d5bb2fc859b"
   },
   "graphics/s/rewrite": {
@@ -110,6 +166,38 @@
   "graphics/s/structural": {
     "buffer": "bc1869b7d0be98d948f0324e3810a1d57cb041604b90d7013a33a69209e79ec0",
     "changes": "8fa5d8ccf271619f4709f2e62fcde684214342b6d4b84315be5fb4b0840aff2b"
+  },
+  "lists/l/churn": {
+    "buffer": "66a83753bbb7b1cac9fa68382dc2a921d7a0cc8b91aa674786a4b1f796dea940",
+    "changes": "d75cfa281197ee2c8f7b99eccd349e6f907799007735caa40b846403ec98eff7"
+  },
+  "lists/l/heavy": {
+    "buffer": "013e0e5febf6fb4ce063c8ddb8118d4b2e28da3d1f2116778b2456c74ab57cdd",
+    "changes": "7d10c68acb79859050b31b4490c8f84447765ec7ec5063bcd60a7af2d72268db"
+  },
+  "lists/l/identical": {
+    "buffer": "9a6f50f6867e2f68315e1e50cbb0b64f3dd3cef18a57bb56101b815f89afaafb",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "lists/l/light": {
+    "buffer": "5d3eb599fdc31bc9f1c5c080cc7993c8d71c62d23d40de1d441f36c4f8a96656",
+    "changes": "e08f2c623626b1dfad84359aa082f0c6fa04d859c40f3e2084268093ff4cc0b0"
+  },
+  "lists/l/numbering": {
+    "buffer": "9a6f50f6867e2f68315e1e50cbb0b64f3dd3cef18a57bb56101b815f89afaafb",
+    "changes": "e28188b324e0ca834432ef770a32d7b5802a04f4a5ecf45c3cb3e8cac07fe86c"
+  },
+  "lists/l/reorder": {
+    "buffer": "564a29e13493838973f0b89f62517707c3227f04fbb6d81a88b90992caa230e0",
+    "changes": "e105597f305855f918c4feb651300d722e5c5c7a6a4eb3670003a678bc9fb8d4"
+  },
+  "lists/l/rewrite": {
+    "buffer": "4e41577b027db917b17dfb026eb09f83c16543da8d518a296b1053171a4b6491",
+    "changes": "18087e137c3ea2396dbc6cb2d31e3ad32dac376cd0fc53a501acccafdeddc968"
+  },
+  "lists/l/structural": {
+    "buffer": "aeb95059025d53c9394141cc98a04add9add1a2d288b3a572726147befa627cf",
+    "changes": "5bbbded9e8beaa78b47951946a30276729b1cbb573c671b69fdf1440f7cd0e18"
   },
   "lists/m/churn": {
     "buffer": "347663b24099727ed1aa2990e649219bc34dc5b9e8e8d39028e92bc2117d21b9",
@@ -132,7 +220,7 @@
     "changes": "e28188b324e0ca834432ef770a32d7b5802a04f4a5ecf45c3cb3e8cac07fe86c"
   },
   "lists/m/reorder": {
-    "buffer": "35828a977c774bc6d1a6d461f728fd3c887b6b0c622d14b93ed2989e5731ff4d",
+    "buffer": "7837bb9801aff3e6d4b1aabe6fa3c7da6176966b4ae76c3550d7f344d39ad059",
     "changes": "72bbb957f11201a145d8ea8ca1f8191de586c42f561bd8b707f0805f2df2b127"
   },
   "lists/m/rewrite": {
@@ -164,7 +252,7 @@
     "changes": "e28188b324e0ca834432ef770a32d7b5802a04f4a5ecf45c3cb3e8cac07fe86c"
   },
   "lists/s/reorder": {
-    "buffer": "28c4856035f06d4f439137111ad6e8ff356b8d8bedf05fbe4482d3b7d3f1ece3",
+    "buffer": "ef7b929731216885b93b9f352ffa2bafa199ed64b35bb82067c47cbde67269bb",
     "changes": "650365d977bdddeb4b4ab51735d117d63ddbd18ea1539c80f76fdd23c52cea66"
   },
   "lists/s/rewrite": {
@@ -174,6 +262,34 @@
   "lists/s/structural": {
     "buffer": "daaaa850a93f9e225942b444808b47f10ab561a2fb90e2a40c727719fd583073",
     "changes": "cc2576068da990111cdd85ac7a1478e7d894718c7effca348ee019bdc2892b4a"
+  },
+  "multiscript/l/churn": {
+    "buffer": "3d8011a5d104621fecda97c8d3318d44476904b8bb85ff73a383038f557f03f2",
+    "changes": "34cc10badeae798041fa44dcb287161dc636bb50240c6b750be6c3b9938b5ed1"
+  },
+  "multiscript/l/heavy": {
+    "buffer": "30a831767bebf1ac638ee8c3f865cfdad7935c02620c5cb9781b12417c6b9448",
+    "changes": "08386b0e70fbd875857af9421e525b6f33b3f735c9f8578db33638eecf07f14e"
+  },
+  "multiscript/l/identical": {
+    "buffer": "6d70e39ba2e87c59dcf161ccc9341d49d62d55ad0406e10caf8b0c46c825f232",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "multiscript/l/light": {
+    "buffer": "bd69fd155905b69530fd1784c3d2ba84eb1f15251f69b199609a864d6c9c69a0",
+    "changes": "ce821cd0b16dd86d52a579bc8384b4743856ac1d3695170e8d9ac3b8e86a0624"
+  },
+  "multiscript/l/reorder": {
+    "buffer": "61c791051af528024cb6abf8c3ca3867a4ea9658b46a57c91dd27079d29ed38e",
+    "changes": "7a00e888ecb81b54df82dd5690b7e437091f9ffbb987e9df7dc5a93bf6a4555f"
+  },
+  "multiscript/l/rewrite": {
+    "buffer": "3b3041ffd45408256890ed93c5b22eb0480d7fbf2f956907d70c382ebbc46fcb",
+    "changes": "1acdeec0f657e6019aa87118c19f80fa92a4cbde57e1de1b73190cf1564d6c89"
+  },
+  "multiscript/l/structural": {
+    "buffer": "f253548529ecbb304a8c0440c7e1d54f2b06b3598577ded2e748dc6b0dd5e448",
+    "changes": "621797665ec305584d416580d987e3690c81775820ae4322daa8ee3a53305888"
   },
   "multiscript/m/churn": {
     "buffer": "979126135a126f4a0fa73a05991ec7ab9e1e9b616e30ab2263898bf91aa5d833",
@@ -192,7 +308,7 @@
     "changes": "f27f75498095a08dff8de4fe150defa5b6804a23f5950809f461a4b0c2291b33"
   },
   "multiscript/m/reorder": {
-    "buffer": "7c8eceeb54f6653a62c51e9d3a605369035ea4d6a650b6c3f72df01b57b756e1",
+    "buffer": "74d3a46a0b9e2d731f916cb0b76013fb6e0945e2d87516d99c0319f2b02a85dc",
     "changes": "af9c61e85547b82e56dfa70033598659546cd2b81717929b0cedab303c54072b"
   },
   "multiscript/m/rewrite": {
@@ -200,8 +316,8 @@
     "changes": "1262b068b7194f8a3941be772d4d6b3ef10e2b8239451817a2338965f7dc754b"
   },
   "multiscript/m/structural": {
-    "buffer": "c428e998d9646f6b416123ce5272ae9bcf5b739bbb7f52a2fc74ab6882942548",
-    "changes": "957dbd169f30c2f1f93bfe1223d246a5ff94f97e0613712200bb1485dd65f5d0"
+    "buffer": "2d26cf7f4271666ef7aef32db240f29c75cc736aa32a253e850b3671ee806b86",
+    "changes": "1f9aaf0e046d8d66b1b66546970d514e08edb9eca710b15b77626431b1dd8ae8"
   },
   "multiscript/s/churn": {
     "buffer": "26364d9718734ac004f0e40fc5a377cc5b1e0ddc9c2c647e91de97026f21cba3",
@@ -220,7 +336,7 @@
     "changes": "73e48099521cb5c01d16d10975276debaa0091af227805214534fc7b88947157"
   },
   "multiscript/s/reorder": {
-    "buffer": "e7e6a4b285ca39ac96173a5d1319c075b451627924403360c8931b0b3d1a1375",
+    "buffer": "193bd4be8484ea4f4f1b58b64ba8122fd0c7f2a35f51b9d15cdfe63ccc87c4c2",
     "changes": "d60b51be02ec3bcb9fc7eb656ba1d18081bf2f5cec3a6d7025e84317d203dbf7"
   },
   "multiscript/s/rewrite": {
@@ -228,8 +344,44 @@
     "changes": "5b95f47a6b6a5a289869c34dfebe937d34313e23fd5d82850a379d2d92de3fbd"
   },
   "multiscript/s/structural": {
-    "buffer": "2f8d450b643dab4289c686f41bdc96c174e0ac5b2ac678a565278bf88345f38a",
-    "changes": "646e441f143084341dbd2df3adee737c1b93b81e496bb5b93ef28154ff98f223"
+    "buffer": "fb07fe8ec814884cda5447f712bb441d4465d0fd08f9557ec8f1cc067bd19980",
+    "changes": "3d0bd4ce2885e6bc4373462ea80d298760f812f2f37a4aecc698817e67a3cf22"
+  },
+  "notes/l/churn": {
+    "buffer": "4cb4e3d5262ca9710b1b862062f9c717b88585f06dc6763cdfe3b873ed23dca3",
+    "changes": "e68451a7f694b4219561b0c5c942d5dfa01ffe9bdc5a631f336524ab5b3fd799"
+  },
+  "notes/l/everywhere": {
+    "buffer": "70bf27150ee9d32498972f3e36aa01ef0570b105facc55134de0421a3ef12d36",
+    "changes": "6ee50637c6784d6cfc6da888e9becfe9a28feb0e8f8aba850e5912909bf9fac1"
+  },
+  "notes/l/heavy": {
+    "buffer": "66c30317d663c50f2b169bd22eb6b81c9a4643aa9fc191f1d5417a49b33ccc04",
+    "changes": "39172edbf980134c3e15a5ff00a078974af42d98a519594d7309034f5d91cadb"
+  },
+  "notes/l/identical": {
+    "buffer": "42fb36bf09fbe08329b18b1914f507c23d4229ee9def74ba7492db6bf2b2c384",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "notes/l/light": {
+    "buffer": "bb6f97b69329c55c7c8b6d16d5383c1c26cf68f252deb2eaf9ceceba17fb90d0",
+    "changes": "984c0ab72c5aa2d46409ec38a554482e3fae900152acc43aa05f72ad311080da"
+  },
+  "notes/l/notes": {
+    "buffer": "b31a4c82f7a3b34a3e9fc82d56b9b6ffbfbeade0f54b713bb61a42c0b0b0920c",
+    "changes": "9ffe302a9b261df2859cd37dc75ef615f4fcdfce4aab1f17f056fea841132ffc"
+  },
+  "notes/l/reorder": {
+    "buffer": "7f5d62c37bb60b946ea04baa55e6f2ec6c7a049f28ff024850612dc18a199477",
+    "changes": "6d49211b70bf6d8e63e2cda03b2f1d9abf06b98d3aac047a3434df75b1fcbd15"
+  },
+  "notes/l/rewrite": {
+    "buffer": "1f1ea1e2fd9f2a20bb883419e2a2ef5043348232f2346de21a273845e53ec3d9",
+    "changes": "917310f30505564e49b9b69f9c71fbbbdeffa0bba69314af61da49cd5ab43486"
+  },
+  "notes/l/structural": {
+    "buffer": "cbdfb36e0bc96ef755d84a77be34f021c1a357bd320e3a26d71b88718edd1a4b",
+    "changes": "27e26e57f13d87eec1e506653a6106cb6db3bcff9aa5ec6030bab92273dba5f7"
   },
   "notes/m/churn": {
     "buffer": "688b09036de5f6987b3b7e2a8b622cf636200be9301cdb42ca6d035925b0a8c7",
@@ -256,7 +408,7 @@
     "changes": "d0b6caef62acf5826056793774cad08539797301f00b7f98f938cf821c9e14da"
   },
   "notes/m/reorder": {
-    "buffer": "8addb53391a94109c6b6362e401fdc0821cefecaf9f04b7acd31e53fe8321068",
+    "buffer": "e663a803809dabb0cf046ed266b1f7dcc2b4d0d762fa211a27558bcc9549980f",
     "changes": "43ad99e123d077f48d99982b7fdfee255ab9ad9287cc7a78bdc5b3d17457b9a4"
   },
   "notes/m/rewrite": {
@@ -292,7 +444,7 @@
     "changes": "17953a14335bf912b9e7b5d63b12e5ca560c6a591998ee8f449ce1a49dfb99f1"
   },
   "notes/s/reorder": {
-    "buffer": "93c225d472de36c299e1599c1f5f498184141a49d908f15e75bf551b0ae6f4f2",
+    "buffer": "616e282a6c9571e3ebdf0c9033141f05865d3fc842fcb6986b0f5eadfede517b",
     "changes": "12ef276c9a5b33e1084bf9dde9721d90f94074e6551033ee3bbe67b3eaa7c3ee"
   },
   "notes/s/rewrite": {
@@ -302,6 +454,34 @@
   "notes/s/structural": {
     "buffer": "77fad06a9bc797cee4b41ed0edc1cfc009a9dd1485888606ec7bff679fb98053",
     "changes": "07bfecf0b870f113431dc62a6d5402a9fcdf0c465e107ef6c46e8ff42647a891"
+  },
+  "prose/l/churn": {
+    "buffer": "50ca7e7289dfacd9c43d661f2196c29dcccf76f9e782083720d3fe49b86b6e7f",
+    "changes": "233d3ee8d9a256b35880fc5690ff60a6d778bb4b94ef5a1d00d87e6720a0812e"
+  },
+  "prose/l/heavy": {
+    "buffer": "ff12a988262c5ad309e6ef43ce657b2ef80b6d11ce73302826cc20ad39e1b219",
+    "changes": "07ae005019ec4858e9cf8ac3bf55d6cfeaa98b5074eeb18ea57d9e8d101ebf2f"
+  },
+  "prose/l/identical": {
+    "buffer": "3702a0043174577a0b3a25f4d875d29ef66393bee9e3739c678cf6c3be8710d3",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "prose/l/light": {
+    "buffer": "9ea308bed4d91778953925c2c26bfb9db5bacc11b9473e71a75d8ec3d2d51ef4",
+    "changes": "519b38d80ee1efc7c281fbc6cb4bd8d7e8b32c479addcf83f89c03b412d94a4a"
+  },
+  "prose/l/reorder": {
+    "buffer": "d024320bbb754e7b985647fb15ea0fa132ae7a59f9551ca96a1991b7e4ed0af3",
+    "changes": "e7cbd1e7b8df9351d962be192a037e4f503131ce49a0eddf23d7d7fe798e56b5"
+  },
+  "prose/l/rewrite": {
+    "buffer": "6cef271b15d30a5ebcccc5280382e7bd7c1a0cf4031684bba7023b281d9f3666",
+    "changes": "794845c60425e90d1547dcdc4464776c56f455f88749088c74ad8170dc4acc8d"
+  },
+  "prose/l/structural": {
+    "buffer": "07a48492d0d6d11f8e7f06e73269228f6be63c3cda12396e3d82a89a109af5e7",
+    "changes": "8d8beac6524112a1095ee85f99ba8e5dec1042f1a84156b4601c1c3dd22d71e4"
   },
   "prose/m/churn": {
     "buffer": "59cedf47d63bc0c01d9756f42e83e805896940063e809a40454e86127020b316",
@@ -320,7 +500,7 @@
     "changes": "319532f55269786d865f3ac508dfa069bbd017640678207d630fd1d19df6a571"
   },
   "prose/m/reorder": {
-    "buffer": "02ed11cc236bdd9b20617ef471af723ecfca3e4de33f839890876a7bf9adf0d5",
+    "buffer": "70ba5a49067f4b73f70f4f129e51289a2c56639439616e6364a502a498f2f6a7",
     "changes": "2970d10fddea492c79c0c3f36beb269f01d1759af4897a72a8c3c8fba3b8ba1e"
   },
   "prose/m/rewrite": {
@@ -348,7 +528,7 @@
     "changes": "a894ca2ebbcc806035ef3a84c77f275aa287a652b0d925ba79d5d60a743bc235"
   },
   "prose/s/reorder": {
-    "buffer": "5a8b5ac7b3bee10931818638bd1068876fbc58a7439741cc3fbf87a012346f40",
+    "buffer": "0c026a0920cfce0b7273dac41d248e66383242af8bcc2747474c26a459349be8",
     "changes": "e9bb627e0f3aad4fb5486841e4dc3fec42121607dc30c6e932ede56382e6422d"
   },
   "prose/s/rewrite": {
@@ -358,6 +538,34 @@
   "prose/s/structural": {
     "buffer": "751f24aaee65c59bfa6ec7c170ce99cef390b995c215fc7eb7eca00233c4e929",
     "changes": "a966546d9cff5723a64cb382431fe9bd0ca10dfbbb4705c74d5c1218fcc5102b"
+  },
+  "revised/l/churn": {
+    "buffer": "55a72712d81a05fca905974520184012dec10842a727c67427314c1db7649cf5",
+    "changes": "4334478e4c1b8d9ad52aeb851ff23e5efcc3aecdd1c1f78b8a3118df81f1e9c5"
+  },
+  "revised/l/heavy": {
+    "buffer": "6506825179d78653d89839dc5f7ee5c642f49e9bb77f2eed44791a4dff4e462e",
+    "changes": "480f76727750c72f2b6cca8b5c7bb13d5ae6c86925eb3c49a42d010482b5ae1a"
+  },
+  "revised/l/identical": {
+    "buffer": "171645c91de2036577135b0087694de00acca1d5b004653cbbaed45a81883af6",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "revised/l/light": {
+    "buffer": "65417627b829457737fafbb60ae5136f4a91721224cace39f67cef0f7be5e26f",
+    "changes": "aa3fc2be3f7e9e5f91d8c4920845e20f5e0d2c2d50b07f0d67d276844387a3ae"
+  },
+  "revised/l/reorder": {
+    "buffer": "508a8c343a12ce457536a9f9e0ff3cd58f1a20721e4f84524b4418d2e1c032dd",
+    "changes": "842f0aae6644aa5f943dafdcf8df70bde9eb425c045fd73884708cf5447d40e9"
+  },
+  "revised/l/rewrite": {
+    "buffer": "aa8d451e3efe26f0303a57933d3539bf5bde89ed2e04d1425fc33eacb74a0eca",
+    "changes": "5a387649671d6f7812bcaef6079ebbc2b44bfe25d051cc9885041db2a6397aed"
+  },
+  "revised/l/structural": {
+    "buffer": "b21c48992de2dde4d21ba103bc69df096817e3f23974062494ff2edfbc05fd68",
+    "changes": "33c6cb2e9c066af1b0dd0366670a3930f3d761586a4b0e5d8a84be04e2db0c24"
   },
   "revised/m/churn": {
     "buffer": "fb6178800e8c24f5fecaf74e39b03b0073faa38cac5669ca32152785c0ac7282",
@@ -376,7 +584,7 @@
     "changes": "acdd58580c0daf4073ed9038a49f12487c7cafe1fce5de6ddc2257e6de0d0281"
   },
   "revised/m/reorder": {
-    "buffer": "4d4d55760ca38bfd5a64e33d97e782f6e4097e4ee6c9f5847e4e15188fc5d5b2",
+    "buffer": "3d80cb5787f3c4c59815b414218b9eb327765f036aac7f586f921d2a92f29995",
     "changes": "d8c69824080968383ac708bd4e125e362136b3f8177b61c9f59eaa6342006ce2"
   },
   "revised/m/rewrite": {
@@ -404,7 +612,7 @@
     "changes": "51305d8b3f1f45e6e052cc26106d30982729b8889f7cb9e0a4e13c21d88d4692"
   },
   "revised/s/reorder": {
-    "buffer": "1b4d4724847170a316f0b265a4de5aaee014cc9dcc089314782f34dc5f0b1b7f",
+    "buffer": "117d9aaec13137f403807f2eab6895e078f00669f64b7850b5fee0406d0844d2",
     "changes": "ee9607cc23fcc29b8cf1b29c47924bc4ca75cdc2ac35185254fd04387481e6b1"
   },
   "revised/s/rewrite": {
@@ -415,9 +623,45 @@
     "buffer": "1185bdd2121c419fc9e5aace576b211349ed6579f6712c48ebaa4af7adc3f2a7",
     "changes": "175e2d69ab6b0e40acef50c7773d5be6cbd9118b02c8b1ea157bbc2bfa680dba"
   },
+  "sections/l/churn": {
+    "buffer": "d444b91c1324f9eddce211d5cf5f096de8d68fa38bba66e5eaa18a8f305a3b67",
+    "changes": "4936ba56de6d956af0095332d87879841f0306e119a3f92959c7c2013977a39e"
+  },
+  "sections/l/everywhere": {
+    "buffer": "a7f4beddb19c197eb7a9bda2b44c7dcc91a4ba5ea8eb449e27a3ff1936c4158f",
+    "changes": "f1297feefa6c19cfd213deb1adf8b3a042242fa5a3384d250668807610518715"
+  },
+  "sections/l/headers": {
+    "buffer": "afeb3350554a23c7d1ebdb3f55162ba9be1d0003c0e51212cbb0d90a06cb7c47",
+    "changes": "27be325b4d66b41ffdb793ef2cd3ba48e15a6cff68d8031c9f9552918096932e"
+  },
+  "sections/l/heavy": {
+    "buffer": "6694c2a51bc7df0cecb3f10d539bc6a875d6e9dc3f29386b1986d41712f73ff5",
+    "changes": "6a04e770baed5df33ca1a3eff408b63808b739e918d6e7c0bf92604f5899673b"
+  },
+  "sections/l/identical": {
+    "buffer": "430f57637c728839868e4b167e5859113a7fe34c749fa6118cd0dafe0bbf3bd0",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "sections/l/light": {
+    "buffer": "5068f65324ba8dfdf06698a5d14cc2dedb8bd548b7894b2914132bfdb3f8e678",
+    "changes": "e9a9c885a19c25f57bda9b4c36a44d0778d1ae23c96a81760d877e284f448dc7"
+  },
+  "sections/l/reorder": {
+    "buffer": "183b0a407fef8c08d022d0948722e784f543092b1a731be44592c15735b8def8",
+    "changes": "931bce4969d3af413fc9b05b4cf019840d8f88d7fc5ff39e4f05eb4e9f3d0c28"
+  },
+  "sections/l/rewrite": {
+    "buffer": "094e432e75b80ff3b15c7f59e5927b56c16a06a7b74a8640c75c68c6c9f01d29",
+    "changes": "ed56a3e9f2d9edb098040462cd2af68ea7e87174767385583916faf7f70df4d6"
+  },
+  "sections/l/structural": {
+    "buffer": "af1378196c455a0c7ddd33429176e9b170fe8332d5aa93f6a327b879ca61d67d",
+    "changes": "a905962916a112fd5bf95e4cddac26406c58959a8e6689b5b07a2901194b5b89"
+  },
   "sections/m/churn": {
-    "buffer": "6b2a70f852e913d4a20d2b4b91ed1cb2df26b739ea06951e75d39c375bc254c1",
-    "changes": "099e9b779352947dc64ad3aea32b6acab86db80f8064f1992d6aea389ec27f57"
+    "buffer": "6b564020157df4bf756a1c22e2cec58eb37600f1885a154d9240e4882f16a6bb",
+    "changes": "f88c4e72810b9aa37c3c9a501301d24365a5f2e592387b48275bf23146464151"
   },
   "sections/m/everywhere": {
     "buffer": "ccfeda45f4dec1060b761f2fa09ac4fdb50fa52bf38e24c02ad5ec7eed8a77e5",
@@ -440,7 +684,7 @@
     "changes": "a58f655a9b284b870a749643bdfd4bcd6e1b86fa8f17a58777a3c6ad57b92110"
   },
   "sections/m/reorder": {
-    "buffer": "ca6c950a20915ef6ef311bd829a16c9244a2f37465d8750f6506e8b0d91616f8",
+    "buffer": "1ba7537b4f7b231783a76eeb224e820dceedd26b921f496e2ba428b7085efa40",
     "changes": "6b165c93bd68ee00747f89f15023ab12f71f6afd8b76d3436445d5a6be90d717"
   },
   "sections/m/rewrite": {
@@ -448,8 +692,8 @@
     "changes": "cfe0b043cf17d97bac892ebeae37027a7f47ca820eb187ccf63937a01486756d"
   },
   "sections/m/structural": {
-    "buffer": "3fa6970333390b7187d76af1a52212e69e0dca7411c32ddd7ff436298a371f05",
-    "changes": "91c7078e40116f4b83cdc8197c1f08c157039d875a4e3e4f42ad071bc6b942da"
+    "buffer": "ffbdf320e1dacb5f3c060016886c10b92c9df1d116e0bdcb39b7088de45e3e4b",
+    "changes": "ea65b1878ca292fd0ae55808dd1cb437a1da2e9690b50a676caa03d06b5a9775"
   },
   "sections/s/churn": {
     "buffer": "b02e64396474d1f7bbe3fe434bcaffc313d07529b2e386d50ac5f21b69435130",
@@ -476,7 +720,7 @@
     "changes": "a25412306510cd5d5cfccedf72d203f2dc7964299ff81c5686e8af597a188d66"
   },
   "sections/s/reorder": {
-    "buffer": "0e7b0a58bf1192896ed16e2f18be92d06dfe0f16034ae78caa289cc23bc3bc35",
+    "buffer": "4dd5fd5a426a39e0c9b8e49d6f57b90f7b344e133125e0093ee1b297a345a7e9",
     "changes": "a3a8c2d28d89e445fe2e89669682922098b2925d833985af4b6d88e18f3fd15f"
   },
   "sections/s/rewrite": {
@@ -484,71 +728,103 @@
     "changes": "fb46580d321a6babdafcb8230b80efc07dbee4a252ecc7f07b030fb6327a021a"
   },
   "sections/s/structural": {
-    "buffer": "1acf2ce691a4a38315059b7fe12746b588891fbf33c685e94fc0f17f0334210c",
-    "changes": "09dcee18f658b8a3173bdadf5b9003a9fc2f502e3da4f837ee95900bed6d4549"
+    "buffer": "aff13484b01a14ca87d73b3224e3e78e9997321f00d042c9a759741c471b69b1",
+    "changes": "f607fa2b5fee2ce4cf85dd41814fee63dc8c9f1b5658592d36679b925b9d994e"
+  },
+  "tables/l/churn": {
+    "buffer": "b806d7863b8d7ada4ad0090052d43941000b95a166e8edc683363eca3ca49093",
+    "changes": "abc65d411d978a194d2680c4c6fc7ba2e949039711529342906ecb43579a4ea0"
+  },
+  "tables/l/heavy": {
+    "buffer": "eedf874809f1cca0299368600d590bb45aa5a0145317e7c57ed29aff86a84116",
+    "changes": "de86966a971c75aa615488091250cb874b4f4be02f405ad0dabd15ad2bd3e2d3"
+  },
+  "tables/l/identical": {
+    "buffer": "1d164280ed55f5c3a0b89e4ea80eb504a0df9e68abd1df9d4e6899d84fd39c7d",
+    "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "tables/l/light": {
+    "buffer": "ef3e08715332fc464d332bbb8b424b10fa2f5877c2a55f2e59c72a7b0c483697",
+    "changes": "3e8bc914c629c5d25ac0153ad551ca666bc46e776404205b5cc86acdde3cbc5b"
+  },
+  "tables/l/reorder": {
+    "buffer": "6f55c4ce0ca2d24b8f27d701b76a1ead8907320ddf44cd40fcce1f2c19400223",
+    "changes": "78787198e8e340ef5269c9611f4d24d20d0039d1b5d9c842e4ecaa5d8b6afee6"
+  },
+  "tables/l/rewrite": {
+    "buffer": "6c2ba4ea92d518befc7a24c939244c79ab4188d3a8871d273426f8c3d5f25c19",
+    "changes": "f9b0a9dd3dff43b4472ed81e776edacfb5799ca7aea3f4375aa0bea1517b6745"
+  },
+  "tables/l/structural": {
+    "buffer": "3070c463b6e4213667968073bc4bdf9eda38a294e7b4beeb5f241951218d01dc",
+    "changes": "887480d080be05d0f418cde69e371686e918e90deee4c23dc025d7045b7896e8"
+  },
+  "tables/l/tablecount": {
+    "buffer": "ab5ecb589960acac70ef83fe925364d381bae5a375dda53563a04c27d9ffe6f1",
+    "changes": "7a5b9678aa325144b20236d6e63d6398e8d0cacb7eac90eae2df8f1403b894bf"
   },
   "tables/m/churn": {
-    "buffer": "b2f90c0d7061e462ddf448eed6340e6a245dd1a421bbb9b6b40bc71ad1bf3f7c",
+    "buffer": "95e1656768a4626fbcfea319ed3016a784f09f6f0061b520bf72337dd94d097a",
     "changes": "652352e4748de4f720fc62c6c4c4e820b3277b5cfbd5f34e941ac28f231206f3"
   },
   "tables/m/heavy": {
-    "buffer": "b2a3ca0ed6a9e8b627577293afe4b6a2742e9265f45241919475f03eafdb3e4c",
+    "buffer": "df2892de9ae9688fc19d6facfac5bc8d68d76bed26b010054ddfaf5be7b506f0",
     "changes": "c0594fbc0f0aeec535c097874b99833d7fe4a0b6e36174f525bed505dabf41b1"
   },
   "tables/m/identical": {
-    "buffer": "46a02e38204b1750c1b510c2ed664b566ab5b9002d69c243458a8b2ea111ef58",
+    "buffer": "09de3e600bda4d7eebf070c2aa4a6f424a3661dc2905aef94c3662e3f8ce8b85",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "tables/m/light": {
-    "buffer": "c6d036c193e5a842e3352e93ead5954fc03e8dbba98bc31c7b584f6bfc9b5b59",
+    "buffer": "3ace2672f18430921c18090bece8946344f38b73c5cd815d0d3ff725c56ace67",
     "changes": "36a065a2ed2429f9844f30a4df7b0f7dbf16c8836281f65301b7c4cf0d61cc8c"
   },
   "tables/m/reorder": {
-    "buffer": "0573fe110683d15d0c117cf091e91039d771896d11858d69ff6c752b31d756e6",
+    "buffer": "250592a51467309b089420d7998e4a59fdb2636ddf118aac16800863ad5a1efc",
     "changes": "8a363d3232c0acaf0aef98d57fcf6137490e96a80f348ee2f59c5093e242558d"
   },
   "tables/m/rewrite": {
-    "buffer": "cc70cabdda673180ba69f534a0503af72c8c069f8057b4d72e06f27c538083ff",
+    "buffer": "26a7e5994c779c8ad0475a894f37efd04eee2035d32079ca406d1748501454a8",
     "changes": "0012a833e4206634e1f6d6657a2c7a181e71efb8195fe947231df33dcfce46f3"
   },
   "tables/m/structural": {
-    "buffer": "57c52150600e322489e5eabaa9a7c0ba0327db4dba8c44cb9e3cc82d9cfa8eed",
-    "changes": "e2da20a28acba283a792bf0d85723a43a5053da6bd2535af282cbdad411372aa"
+    "buffer": "b3fa623d97b20c26c86547d6baacc629f25082e13e74bbb3d97405ebac070322",
+    "changes": "b0da7e59c153b8a827a698c687d2da04ed6070c27eb868f2230061acfb4e1f71"
   },
   "tables/m/tablecount": {
-    "buffer": "d47c26f271b06f275060e438173045dc06d8042d6444760435cadaf1b0446693",
-    "changes": "787c4dd3e79f3ce60bfea8e79d85ed4e033d3fe6d4a72b8e6d9b880b2abd1cb9"
+    "buffer": "4198cb8623f0c1eeaebacd238ba9d65ce323957c94b80adeaf944f6528631a98",
+    "changes": "41593ccc943a24045bf07ef077d6b48e92aa40bc7fa16bb13682339681b3cd42"
   },
   "tables/s/churn": {
-    "buffer": "968bf3df23cc2d7707ff8b6c01f26ee4621a6b6cc121ef8fb2d3b5d2b25a2fe8",
+    "buffer": "41eab46e8b1becef5be399a71698e1913eb07098555a1f4111fca80204fae6c6",
     "changes": "bb39f4d2cbc540a89b75b1027460fcbad3b7d120affa6476a22c0c9a302fe290"
   },
   "tables/s/heavy": {
-    "buffer": "d24acf9a1721e4de8d2a8e19d92bf7fa3c05c1c551a63865be36c1de664f3fe9",
+    "buffer": "90c207995695b3ee813bfb1d3f52d46194045c6c6104943b525473b14385b1dc",
     "changes": "45b89ff808f0e203814b4e97ca85cc3038ae673e5eb7ba11cf8989ba8c332e62"
   },
   "tables/s/identical": {
-    "buffer": "4ac392161d2f5ba60c6329bedb5a6d99af720f9f6780f72692567b570c06cc4f",
+    "buffer": "3f1a3a0605f967da3c9952e4987f6a039f7d924ce754052449df55d32e24ca69",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "tables/s/light": {
-    "buffer": "c931443bdc78082a007125111a1bc7ed103171c020a7750d7faacdc08bdaf866",
+    "buffer": "6f205386525df5eb5631f0374df7db4986075db656d55f87627fa7ec5e4a6ab4",
     "changes": "57453737ee5a3007a610c1c0ee53f533524b57d8826f0cfc87a74e2127cd17d8"
   },
   "tables/s/reorder": {
-    "buffer": "9dff4ad2a9b7b6a868cc06d6ada2beedc2fb335dd8858d2b73e135eef2ec402f",
+    "buffer": "84ca36c44bf3cff415fe84edb81a63669c4f723aa5dc9695abab3c19c79e7a6d",
     "changes": "3a986a4fbc570d0f56640e9e71a44853f0bdac0a42f1dc2e68f9e67bb5a2dbdf"
   },
   "tables/s/rewrite": {
-    "buffer": "b933adf6895b8df443a5581e04e118bae0852c3b426f6935aa26adce751a2197",
+    "buffer": "b6a979fa960a2f9428e47d6f5add64cdb5754eacf17a43d3434e4e8eddaf6c8c",
     "changes": "c0c5d5d764148195c04e13f8ebbe302062d3429bfe989ab349056f1e5f136312"
   },
   "tables/s/structural": {
-    "buffer": "092ff41d4c0644b82afb7b3e67cd095f17f1d6e2dbbf49d60f4a813a48f055c8",
+    "buffer": "d73aaabac70160e0da561acee3082fb0fdb33f73272aa95a7a442df217e99db5",
     "changes": "e5c66d310a500c4ee7f9f0a9fad8ef1d08eee6b0489e492474c5e2aedbf1136d"
   },
   "tables/s/tablecount": {
-    "buffer": "68a3be4e0ca5c3acb3b050d29332f8356f455a48c3e13ffde3171825d71a1578",
-    "changes": "d5310f2978d692d5b225c1e9cc92edb76def4de91b69b8f05430fbdc2d4ea4c7"
+    "buffer": "999bb58602523567b817c66f778aabba4d330253e1f057e7ada6caaef8b32bdd",
+    "changes": "8958499f48b56da1a6e43751cdbff7a26dc75d3eed6823413545c984832bc1df"
   }
 }

--- a/benchmarks/compare/documents.ts
+++ b/benchmarks/compare/documents.ts
@@ -543,6 +543,20 @@ const seedFor = (documentClass: DocumentClass, size: DocumentSize): number => {
   return seed;
 };
 
+/**
+ * A body may not end with a table: the format requires a paragraph after one,
+ * and the section properties do not supply it. A class that ends on a table
+ * gets that paragraph here, once, rather than every builder remembering.
+ *
+ * A document that breaks the rule is malformed INPUT, which the engine has to
+ * survive but which does not belong in a corpus measuring what the engine does
+ * with well-formed documents: with no paragraph at the end there is no anchor
+ * to append after, so a comparison that has to add a table there can only
+ * report the difference it cannot place.
+ */
+const wellFormedBody = (body: string): string =>
+  body.endsWith("</w:tbl>") ? `${body}<w:p/>` : body;
+
 export type BuildDocumentOptions = {
   documentClass: DocumentClass;
   size: DocumentSize;
@@ -600,7 +614,7 @@ export const buildDocumentPackage = ({
     ["word/styles.xml", STYLES_XML],
     [
       "word/document.xml",
-      `${DOCUMENT_OPEN}${build.body}${SECTION_PROPERTIES}</w:body></w:document>`,
+      `${DOCUMENT_OPEN}${wellFormedBody(build.body)}${SECTION_PROPERTIES}</w:body></w:document>`,
     ],
     ...(build.parts ?? []),
   ]);

--- a/benchmarks/compare/variants.ts
+++ b/benchmarks/compare/variants.ts
@@ -236,7 +236,10 @@ const tablecount: BodyRewrite = (children) => {
     '<w:tc><w:tcPr><w:tcW w:w="4680" w:type="dxa"/></w:tcPr><w:p><w:r><w:t xml:space="preserve">Added value</w:t></w:r></w:p></w:tc>' +
     "</w:tr></w:tbl>";
   const rewritten = children.filter((_child, index) => index !== firstTable);
-  rewritten.push(added);
+  // Before the body's closing paragraph, not after it: a table may not be a
+  // body's last child, and a target that breaks the rule would be measuring
+  // the engine against malformed input rather than against the edit.
+  rewritten.splice(rewritten.length - 1, 0, added);
   return rewritten;
 };
 

--- a/docs/durable-block-ids.md
+++ b/docs/durable-block-ids.md
@@ -164,6 +164,21 @@ skipped }` where each applied entry carries `revisionIds` (note: nested per
   contract is published (host server extractors and prompts consume it);
   `seq-` support must remain for legacy snapshots. The goal is that new
   snapshots never contain it.
+- **`seq-NNNN` numbering counts only the paragraphs that carry text.** That is
+  the invariant the published contract rests on: the host extractor derives the
+  same numbers from the same walk, and a `seq-` citation stored against a
+  document has to keep naming the paragraph it named when it was written.
+  A paragraph that holds no text keeps its own `w14:paraId` when it has one,
+  exactly as a paragraph with text does; `deriveBlankBlockId` falls back to a
+  separate `blank-NNNN` sequence only when it does not. Either way, adding,
+  removing or newly surfacing blank paragraphs cannot renumber anything a
+  citation points at. Never number
+  the two into one sequence, and never renumber `seq-` to close its gaps.
+  `snapshot.test.ts` holds this as a property: for any document, the `seq-` ids
+  are the same whether or not the blank paragraphs are present.
+- The snapshot carries blank paragraphs, so `blocks[i].id` is NOT `seq-{i+1}`.
+  Resolve a `seq-` id by counting the blocks that carry text
+  (`resolveSequentialBlockAnchor` does), never by indexing the array.
 - `w:rsid*` attributes on `<w:p>` are dropped on import. Out of scope; leave
   as-is.
 - The serializer emits `w14:paraId` only when truthy; after ingest

--- a/packages/agents/skills/folio-agents/SKILL.md
+++ b/packages/agents/skills/folio-agents/SKILL.md
@@ -124,7 +124,8 @@ stay exported for validation-only paths.
 - Block ids (`blockId`) and comment ids (`commentId`) only ever come from a
   prior tool call in the same conversation — `read_document`, `find_text`, or
   `read_comments`. Never invent or reuse one from outside the conversation;
-  ids are not guessable and change whenever the document's structure changes.
+  ids are opaque values a caller reads, never ones it constructs, and they
+  change whenever the document's structure changes.
 - `suggest_changes` operations that get skipped (`skipped: [{ id, reason }]`)
   return a plain-language reason, not a machine code (e.g. "the block changed
   since your snapshot; re-read the document and retry with fresh ids"). Treat
@@ -147,6 +148,13 @@ stay exported for validation-only paths.
   invent an operation kind or a directive marker; if a document needs a
   structural operation the contract lacks, extend `@stll/folio-core`'s
   ai-edits engine and the contract, then the schema follows.
+- **A blank paragraph is a block like any other.** It has an id, it is
+  addressable, and adding or removing one is a real edit. `insertAfterBlock` /
+  `insertBeforeBlock` with `text: ""` insert a blank line; `deleteBlock` on a
+  blank removes it rather than doing nothing. Only an operation that would
+  change nothing at all is refused.
+- `insertTableRow` builds the new row to the table's own column count, so
+  `cellTexts` fills the columns that exist and any it does not name stay empty.
 - A `queued` list in a `suggest_changes` result means the host parked those
   operations in its own review queue; treat it like `applied` for the purpose
   of "the edit has been proposed", never as a failure.

--- a/packages/agents/src/execute.ts
+++ b/packages/agents/src/execute.ts
@@ -4,6 +4,7 @@ import {
   getFolioDocumentOperationIssues,
   getFolioDocumentOutline,
   hashFolioAIBlockText,
+  isFolioAIContentBlock,
   normalizeFolioAIBlockText,
   readFolioDocumentSection,
   type FolioAIBlock,
@@ -129,7 +130,10 @@ const dispatch = (
 const readDocument = (
   bridge: FolioAgentBridge,
 ): FolioToolCallResultFor<typeof FOLIO_AGENT_TOOL_NAMES.readDocument> => {
-  const { blocks } = bridge.snapshot();
+  // The snapshot carries the document's blank paragraphs so operations and the
+  // comparison can address them. A model reading the document wants its
+  // content, not a line per blank line.
+  const blocks = bridge.snapshot().blocks.filter(isFolioAIContentBlock);
   return ok(
     blocks.map((block) => ({
       blockId: block.id,
@@ -397,7 +401,7 @@ const findText = (
   }
 
   const scope = args["scope"];
-  let blocks = bridge.snapshot().blocks;
+  let blocks = bridge.snapshot().blocks.filter(isFolioAIContentBlock);
   let getTargetPage: ((target: FolioAITextRangeHandle) => number | null) | undefined;
   let pageFilter: number | undefined;
   if (scope !== undefined) {

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -18,11 +18,12 @@ const schema = new Schema({
   nodes: {
     doc: { content: "block+" },
     paragraph: {
-      content: "text*",
+      content: "inline*",
       group: "block",
       attrs: {
         listMarker: { default: null },
         pageBreakBefore: { default: null },
+        pPrMark: { default: null },
         styleId: { default: null },
         // Identity attrs — must NOT be copied when a new block is
         // synthesized from a sibling, otherwise downstream tracking
@@ -32,7 +33,12 @@ const schema = new Schema({
         defaultTextFormatting: { default: null },
       },
     },
-    text: {},
+    text: { group: "inline" },
+    // An inline image is content a block deletion has to take with it; a
+    // bookmark boundary is a zero-width anchor it must leave alone, because
+    // the format cannot say one was deleted outside a hyperlink.
+    image: { inline: true, group: "inline", atom: true, attrs: { src: { default: "" } } },
+    bookmarkBoundary: { inline: true, group: "inline", atom: true },
     table: {
       content: "tableRow+",
       group: "block",
@@ -504,22 +510,25 @@ describe("Folio AI edit operations", () => {
     expect(snapshot.anchors["seq-0001"]?.textHash).toMatch(/^h/u);
   });
 
-  test("an entirely empty document exposes an operation anchor without a visible block", () => {
+  test("an entirely empty document is one blank block", () => {
     const state = makeState([""]);
 
     const snapshot = createFolioAIEditSnapshot(state.doc);
 
-    expect(snapshot.blocks).toEqual([]);
-    expect(snapshot.emptyDocumentAnchorId).toBe("seq-0001");
-    expect(snapshot.anchors["seq-0001"]).toMatchObject({
-      id: "seq-0001",
+    // An empty document is one blank paragraph, not no blocks, and it is a
+    // block like any other: an operation can address it and replace it. The
+    // blank sequence numbers it, so `seq-NNNN` keeps counting only the
+    // paragraphs that carry text.
+    expect(snapshot.blocks).toEqual([{ id: "blank-0001", kind: "paragraph", text: "" }]);
+    expect(snapshot.anchors["blank-0001"]).toMatchObject({
+      id: "blank-0001",
       text: "",
       normalizedText: "",
       hashOccurrenceCount: 1,
     });
   });
 
-  test("an empty table cell is not treated as an empty-document operation anchor", () => {
+  test("an empty table cell is a blank block that names its cell", () => {
     const doc = schema.node("doc", null, [
       schema.node("table", null, [
         schema.node("tableRow", null, [schema.node("tableCell", null, [schema.node("paragraph")])]),
@@ -529,9 +538,24 @@ describe("Folio AI edit operations", () => {
 
     const snapshot = createFolioAIEditSnapshot(state.doc);
 
-    expect(snapshot.blocks).toEqual([]);
-    expect(snapshot.emptyDocumentAnchorId).toBeUndefined();
-    expect(snapshot.anchors).toEqual({});
+    // An empty cell is part of the table's shape, so it is addressable and
+    // carries its location. The document is not empty: its one blank block
+    // sits in a table rather than in the body.
+    expect(snapshot.blocks).toEqual([
+      {
+        id: "blank-0001",
+        kind: "paragraph",
+        text: "",
+        table: {
+          outerTableIndex: 0,
+          tableIndex: 0,
+          rowIndex: 0,
+          cellIndex: 0,
+          paragraphIndex: 0,
+        },
+      },
+    ]);
+    expect(snapshot.anchors["blank-0001"]).toMatchObject({ id: "blank-0001", text: "" });
   });
 
   test("hides text inside a hidden table row from the AI-facing snapshot", () => {
@@ -557,6 +581,45 @@ describe("Folio AI edit operations", () => {
     expect(
       Object.values(snapshot.anchors).some((anchor) => anchor.text.includes("Hidden secret")),
     ).toBe(false);
+  });
+
+  // The snapshot skips a hidden row's whole subtree, so resolution has to skip
+  // it too. A paraId reused across a hidden and a visible paragraph otherwise
+  // resolved the visible block onto content no reader can see, and edited it
+  // there — content the operation was never addressed to.
+  test("resolves past a hidden row that reuses a visible paragraph's paraId", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", { hidden: true }, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: "AAAA0001" }, [schema.text("Hidden secret")]),
+          ]),
+        ]),
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", { paraId: "AAAA0001" }, [schema.text("Visible")]),
+          ]),
+        ]),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "replace", type: "replaceBlock", blockId: "AAAA0001", text: "Rewritten" }],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const texts: string[] = [];
+    view.state.doc.descendants((node) => {
+      if (node.type.name === "paragraph") {
+        texts.push(node.textContent);
+      }
+    });
+    expect(texts).toEqual(["Hidden secret", "Rewritten"]);
   });
 
   test("snapshot uses sequential fallback ids for duplicate paraIds", () => {
@@ -1117,12 +1180,13 @@ describe("Folio AI edit operations", () => {
     });
 
     expect(result.skipped).toEqual([]);
-    // Two paragraphs of inserted runs, and one inserted paragraph MARK: two
-    // paragraphs appended after the document's last block introduce one new
-    // break, because the second reuses the mark that already ended the
-    // document. Rejecting has to close that break, so it carries a revision.
-    expect(result.applied[0]?.revisionIds).toHaveLength(3);
-    expect(new Set(result.applied[0]?.revisionIds).size).toBe(3);
+    // Four: one run revision per inserted paragraph, plus the two paragraph
+    // MARKS the pair introduces. Appended after the document's last block, the
+    // new breaks are the first inserted paragraph's and the ANCHOR's; the last
+    // inserted paragraph ends at the mark that used to end the document and
+    // carries none. Rejecting closes both new breaks, so both are revisions.
+    expect(result.applied[0]?.revisionIds).toHaveLength(4);
+    expect(new Set(result.applied[0]?.revisionIds).size).toBe(4);
   });
 
   test("does not leak a list-item anchor's listMarker onto later paragraphs of a split insert", () => {
@@ -1748,14 +1812,15 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.lastChild?.textContent).toBe("Delta block.");
   });
 
-  test("snapshot omits a block whose entire content is deletion-marked", () => {
-    // After the user accepts the deletion the block becomes empty
-    // anyway, so the AI has nothing useful to anchor against.
-    // Today the snapshot just skips it (zero-length normalized
-    // text). Locks in that behaviour.
+  test("snapshot keeps a block whose entire content is deletion-marked, with no text", () => {
+    // The paragraph is still in the document until the deletion is accepted,
+    // so it is still a block: a comparison that cannot address it cannot
+    // describe what changed around it. Its deletion-marked runs stay out of
+    // the text, which is the post-tracked-changes view every reader gets.
     const { state } = makeTrackedDoc([["del", "Entire block is gone."]]);
     const snapshot = createFolioAIEditSnapshot(state.doc);
-    expect(snapshot.blocks).toHaveLength(0);
+    expect(snapshot.blocks).toHaveLength(1);
+    expect(snapshot.blocks[0]?.text).toBe("");
   });
 
   test("word-level diff works for non-Latin scripts split on whitespace", () => {
@@ -4437,6 +4502,50 @@ describe("Folio AI edit operations", () => {
     });
   });
 
+  // The row a span narrows has fewer cells than the table has columns.
+  // `cellTexts` fills the cells the row actually has, and is only SIZED
+  // against the column count — measuring it against the cells refused a row
+  // the table can perfectly well hold.
+  test("a row inserted under a vertical span takes as many texts as it has cells", () => {
+    const cell = (text: string, attrs: Record<string, unknown> = {}) =>
+      schema.node("tableCell", attrs, [schema.node("paragraph", null, [schema.text(text)])]);
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        cell("spans down", { rowspan: 2 }),
+        cell("b1"),
+        schema.node("tableCell", null, [
+          schema.node("paragraph", { paraId: "anchor-cell" }, [schema.text("c1")]),
+        ]),
+      ]),
+      schema.node("tableRow", null, [cell("b2"), cell("c2")]),
+    ]);
+    const state = EditorState.create({ schema, doc: schema.node("doc", null, [table]) });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [
+        {
+          id: "insert-row",
+          type: "insertTableRow",
+          blockId: "anchor-cell",
+          cellTexts: ["first", "second", "third"],
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const inserted = view.state.doc.child(0).child(1);
+    // Two cells, because the spanning cell above still occupies the first
+    // column; three texts is within the table's three columns, so the
+    // operation is not refused.
+    expect(inserted.childCount).toBe(2);
+    expect(inserted.child(0).textContent).toBe("first");
+    expect(inserted.child(1).textContent).toBe("second");
+  });
+
   test("tracked row insertion rejects a boundary crossed by a vertical span", () => {
     const table = schema.node("table", null, [
       schema.node("tableRow", null, [
@@ -4462,5 +4571,56 @@ describe("Folio AI edit operations", () => {
       skipped: [{ id: "insert-row", reason: "unsupportedBlock" }],
     });
     expect(view.state.doc).toEqual(state.doc);
+  });
+});
+
+describe("deleteBlock over inline content that is not text", () => {
+  const deleteSecondBlock = (children: ReturnType<typeof schema.node>[]) => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: "keep" }, [schema.text("kept")]),
+      schema.node("paragraph", { paraId: "gone" }, children),
+    ]);
+    const state = EditorState.create({ schema, doc });
+    const view = makeView(state);
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "delete", type: "deleteBlock", blockId: "gone" }],
+      mode: "tracked-changes",
+    });
+    expect(result.skipped).toEqual([]);
+    return view;
+  };
+
+  // The deletion range is built from the block's clean TEXT, so an image
+  // outside the words was left unmarked and accepting the deletion kept a
+  // paragraph standing around it.
+  test("takes an inline image with it", () => {
+    const view = deleteSecondBlock([schema.text("words"), schema.node("image", { src: "data:," })]);
+
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("kept");
+  });
+
+  // A bookmark boundary is zero-width, and the format cannot say one was
+  // deleted outside a hyperlink: marking it produces a document the serializer
+  // refuses to write, and leaving it must not keep the paragraph alive.
+  test("leaves a bookmark boundary unmarked and still removes the paragraph", () => {
+    const view = deleteSecondBlock([schema.node("bookmarkBoundary"), schema.text("words")]);
+
+    let markedAnchors = 0;
+    view.state.doc.descendants((node) => {
+      if (node.type.name === "bookmarkBoundary" && node.marks.length > 0) {
+        markedAnchors += 1;
+      }
+    });
+    expect(markedAnchors).toBe(0);
+
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("kept");
   });
 });

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -4651,4 +4651,23 @@ describe("deleteBlock over inline content that is not text", () => {
     expect(result.skipped).toEqual([]);
     expect(view.state.doc.child(0).child(0)?.marks).toEqual([existingRevision]);
   });
+
+  test("reports only the paragraph-mark revision for an empty block", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: "gone" }),
+      schema.node("paragraph", { paraId: "keep" }, schema.text("kept")),
+    ]);
+    const state = EditorState.create({ schema, doc });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "delete", type: "deleteBlock", blockId: "gone" }],
+      mode: "tracked-changes",
+    });
+
+    const paragraphRevisionId = view.state.doc.child(0).attrs["pPrMark"]?.info.id;
+    expect(result.applied.at(0)?.revisionIds).toEqual([paragraphRevisionId]);
+  });
 });

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -4623,4 +4623,32 @@ describe("deleteBlock over inline content that is not text", () => {
     expect(view.state.doc.childCount).toBe(1);
     expect(view.state.doc.child(0).textContent).toBe("kept");
   });
+
+  test("preserves a pre-existing revision on an anchor outside the operation", () => {
+    const insertion = schema.marks["insertion"]!;
+    const existingRevision = insertion.create({
+      revisionId: 1,
+      author: "Alice",
+      date: "2026-05-01",
+    });
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: "anchor" }, [
+        schema.node("bookmarkBoundary", null, null, [existingRevision]),
+        schema.text("kept"),
+      ]),
+      schema.node("paragraph", { paraId: "target" }, schema.text("target")),
+    ]);
+    const state = EditorState.create({ schema, doc });
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot: createFolioAIEditSnapshot(state.doc),
+      operations: [{ id: "insert", type: "insertAfterBlock", blockId: "target", text: "new" }],
+      mode: "tracked-changes",
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(view.state.doc.child(0).child(0)?.marks).toEqual([existingRevision]);
+  });
 });

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1748,10 +1748,12 @@ const applyFolioAIEditOperationsInternal = ({
           // field sits outside it whenever it leads or trails the words.
           // Deleting a block deletes what is in it: left unmarked, accepting
           // the deletion kept a paragraph standing around an orphan image.
-          for (const { from, to } of undeletedContentAtomRanges(tr, item.blockFrom)) {
+          const atomRanges = undeletedContentAtomRanges(tr, item.blockFrom);
+          for (const { from, to } of atomRanges) {
             tr = tr.addMark(from, to, deletionMark);
           }
-          appliedRevisionIds = [revisionId];
+          const inlineRevisionApplied = item.from < item.to || atomRanges.length > 0;
+          appliedRevisionIds = inlineRevisionApplied ? [revisionId] : [];
           // Deleting a paragraph's words leaves its paragraph mark behind, and
           // an accepted redline then holds a blank line where the paragraph
           // was: a deleted paragraph carries `w:pPr/w:rPr/w:del` as well as
@@ -1777,7 +1779,9 @@ const applyFolioAIEditOperationsInternal = ({
               kind: isPairedMove(item.operation.moveId) ? "moveFrom" : "del",
               info: { id: markRevisionId, author, date, ...trackedRevisionExtras },
             });
-            appliedRevisionIds = [revisionId, markRevisionId];
+            appliedRevisionIds = inlineRevisionApplied
+              ? [revisionId, markRevisionId]
+              : [markRevisionId];
           }
         }
         if (commentMark) {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -9,6 +9,7 @@ import type { ParagraphPropertyChangeAttrs } from "../prosemirror/schema/nodes";
 import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { requestDeterministicParaIds } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
+import { isZeroWidthAnchor } from "../prosemirror/zeroWidthAnchors";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import type { RunPropertyChange } from "../types/document";
 import { stripBlockIdentityAttrs } from "./block-identity";
@@ -18,7 +19,7 @@ import {
   parseInlineEmphasisRuns,
   stripInlineEmphasisMarkers,
 } from "./inline-emphasis";
-import { hashFolioAIBlockText, normalizeFolioAIBlockText } from "./snapshot";
+import { hashFolioAIBlockText, isHiddenTableRow, normalizeFolioAIBlockText } from "./snapshot";
 import {
   mergeTableRectangle,
   mergeTrackedVerticalTableCells,
@@ -38,6 +39,7 @@ import {
   findTableColumnInsertion,
   findTableRowInsertion,
   getTableColumnCoordinateKey,
+  splitCellParagraphTexts,
   type TableColumnDeletion,
   type TableColumnInsertion,
   type TableRowDeletion,
@@ -161,8 +163,6 @@ const SUGGESTED_SUPPORTED_OPERATION_TYPES: ReadonlySet<FolioAIEditOperation["typ
   "deleteTableColumn",
 ]);
 
-const PARAGRAPH_NODE_NAME = "paragraph";
-
 /**
  * The attrs that render a list label, cleared together whenever a paragraph
  * stops being a list item. `w:numPr` alone is not enough: the marker attrs the
@@ -245,20 +245,70 @@ const paragraphPropertiesPatch = (
   return Object.keys(patch).length > 0 ? patch : null;
 };
 
+const REVISION_MARK_NAMES: ReadonlySet<string> = new Set(["insertion", "deletion"]);
+
 /**
- * Whether a PARAGRAPH follows the position, so a paragraph mark there has
- * something to be joined with.
+ * Strip insertion and deletion marks from the zero-width anchors the batch
+ * touched.
  *
- * A paragraph-mark revision says "this break was added" or "this break was
- * removed", and resolving it joins the paragraph with the one after it. On the
- * last paragraph of a table cell or of the body there is nothing to join, and
- * a table is not something a paragraph mark can be joined with at all: the
- * revision could not do what it says, so it is not written.
+ * An operation marks a RANGE, and a bookmark boundary between two words is
+ * inside it. The format has no way to say a bookmark boundary was inserted or
+ * deleted outside a hyperlink, so a document carrying one is a document the
+ * serializer refuses to write — an edit that applied cleanly and then could
+ * not be saved. Marking is by range everywhere, so the guard is here, once,
+ * rather than at each of the dozen call sites that would have to remember.
  */
-const paragraphFollows = (doc: PMNode, position: number): boolean => {
-  const resolved = doc.resolve(Math.min(Math.max(position, 0), doc.content.size));
-  const next = resolved.parent.maybeChild(resolved.index());
-  return next?.type.name === PARAGRAPH_NODE_NAME;
+const withoutRevisionsOnZeroWidthAnchors = (tr: Transaction): Transaction => {
+  const anchors: { from: number; to: number; marks: readonly Mark[] }[] = [];
+  tr.doc.descendants((node, pos) => {
+    if (!isZeroWidthAnchor(node)) {
+      return true;
+    }
+    const marks = node.marks.filter(({ type }) => REVISION_MARK_NAMES.has(type.name));
+    if (marks.length > 0) {
+      anchors.push({ from: pos, to: pos + node.nodeSize, marks });
+    }
+    return false;
+  });
+  for (const { from, to, marks } of anchors) {
+    for (const mark of marks) {
+      tr = tr.removeMark(from, to, mark);
+    }
+  }
+  return tr;
+};
+
+/**
+ * The block's non-text inline children a block deletion still has to mark, as
+ * positions in `tr.doc`.
+ *
+ * Skips what is already deleted, so an earlier revision's run is not marked
+ * twice, and skips the zero-width anchors: they are not content, and the
+ * format cannot say one was deleted outside a hyperlink, so marking one
+ * produces a document the serializer refuses to write.
+ */
+const undeletedContentAtomRanges = (
+  tr: Transaction,
+  blockFrom: number,
+): { from: number; to: number }[] => {
+  const position = tr.mapping.map(blockFrom);
+  const block = tr.doc.nodeAt(position);
+  if (!block?.isTextblock) {
+    return [];
+  }
+  const ranges: { from: number; to: number }[] = [];
+  block.forEach((child, offset) => {
+    if (
+      child.isText ||
+      isZeroWidthAnchor(child) ||
+      child.marks.some(({ type }) => type.name === "deletion")
+    ) {
+      return;
+    }
+    const from = position + 1 + offset;
+    ranges.push({ from, to: from + child.nodeSize });
+  });
+  return ranges;
 };
 
 /** The in-scope paragraph properties as they stand, for a `w:pPrChange` record. */
@@ -537,8 +587,16 @@ const estimateRevisionIdReservation = (item: ResolvedOperation): number => {
 const collectLiveBlocksByHash = (doc: PMNode) => {
   const byHash = new Map<string, LiveBlockEntry[]>();
   doc.descendants((node, pos) => {
+    // The snapshot skips a hidden row's whole subtree, and resolution pairs a
+    // snapshot anchor with the live block at the same ordinal among the blocks
+    // sharing its hash. Counting hidden blocks here and not there shifts every
+    // later ordinal, which resolves an operation onto the wrong paragraph
+    // rather than skipping it. The two walks have to agree.
+    if (isHiddenTableRow(node)) {
+      return false;
+    }
     if (!node.isTextblock) {
-      return;
+      return true;
     }
     // Hash from the post-tracked-changes view so the snapshot
     // (taken with the same view) and live doc bucket the same
@@ -550,6 +608,7 @@ const collectLiveBlocksByHash = (doc: PMNode) => {
     const bucket = byHash.get(hash) ?? [];
     bucket.push({ from: pos, to: pos + node.nodeSize, node });
     byHash.set(hash, bucket);
+    return false;
   });
   return byHash;
 };
@@ -565,18 +624,27 @@ const collectLiveBlocksByHash = (doc: PMNode) => {
 const collectLiveBlocksByParaId = (doc: PMNode) => {
   const byParaId = new Map<string, LiveBlockEntry>();
   doc.descendants((node, pos) => {
+    // The same rule as the hash index and the snapshot: a hidden row's whole
+    // subtree is not walked. A paraId is only unique because Word keeps it so,
+    // and a package that reuses one across a hidden and a visible paragraph
+    // would otherwise resolve the visible block onto content no reader can
+    // see, and edit it there. All three walks have to agree on what exists.
+    if (isHiddenTableRow(node)) {
+      return false;
+    }
     if (!node.isTextblock) {
-      return;
+      return true;
     }
     const paraId: unknown = node.attrs["paraId"];
     if (typeof paraId !== "string" || paraId.length === 0) {
-      return;
+      return false;
     }
     // First-write-wins so an Enter-split duplicate (briefly co-existing
     // before the allocator re-issues) doesn't override the original.
     if (!byParaId.has(paraId)) {
       byParaId.set(paraId, { from: pos, to: pos + node.nodeSize, node });
     }
+    return false;
   });
   return byParaId;
 };
@@ -666,7 +734,9 @@ const buildTableNode = ({ schema, rows, revision }: BuildTableNodeOptions): PMNo
       cells.map((text) =>
         cellType.create(
           null,
-          paragraphType.create(null, text.length > 0 ? schema.text(text) : null),
+          splitCellParagraphTexts(text).map((line) =>
+            paragraphType.create(null, line.length > 0 ? schema.text(line) : null),
+          ),
         ),
       ),
     ),
@@ -1362,26 +1432,29 @@ const applyFolioAIEditOperationsInternal = ({
         }
         // A new paragraph brings a new paragraph MARK, and the format records
         // one: `w:pPr/w:rPr/w:ins`, so rejecting closes the paragraph away
-        // instead of leaving an empty one where its words were. The mark
-        // belongs to the paragraph it ends, so the last inserted paragraph
-        // only carries one when a sibling follows it to be joined with.
+        // instead of leaving an empty one where its words were.
         //
-        // Read from the transaction rather than the original document: the
-        // batch applies right to left, so a paragraph an earlier operation
-        // inserted after this position is already there, and is exactly the
-        // sibling the last of these paragraphs would be joined with.
-        if (producesTrackedChanges && !isSuggested && !isPairedMove(operation.moveId)) {
-          const followsASibling = paragraphFollows(tr.doc, tr.mapping.map(item.from));
+        // Every new paragraph carries its own, including the last of a run
+        // appended at the end of a container. Standing the ANCHOR's mark in
+        // for that last one reads closer to what an editor writes, but it is
+        // only equivalent while the two stay adjacent, and a later operation
+        // in the same batch — a table inserted between them — separates them.
+        // The mark then joins the anchor to the table, which is nothing, and
+        // the appended paragraph survives a reject that should have closed it.
+        //
+        // Marking the paragraph itself needs no such adjacency: rejecting
+        // strips its inserted runs and then removes the emptied paragraph when
+        // there is nothing to join it with (see `resolveRevisions`), which is
+        // the same document either way.
+        const marksParagraphs = producesTrackedChanges && !isSuggested;
+        if (marksParagraphs) {
           for (const [index, node] of nodes.entries()) {
-            if (index === nodes.length - 1 && !followsASibling) {
-              continue;
-            }
             const revisionId = revisionSeed++;
             nodes[index] = node.type.create(
               {
                 ...node.attrs,
                 pPrMark: {
-                  kind: "ins",
+                  kind: isPairedMove(operation.moveId) ? "moveTo" : "ins",
                   info: { id: revisionId, author, date, ...trackedRevisionExtras },
                 },
               },
@@ -1657,33 +1730,45 @@ const applyFolioAIEditOperationsInternal = ({
 
         if (deletionType) {
           const revisionId = revisionSeed++;
-          tr = tr.addMark(
-            item.from,
-            item.to,
-            deletionType.create({
-              revisionId,
-              author,
-              date,
-              ...(isPairedMove(item.operation.moveId) && { moveKind: "moveFrom" }),
-              ...trackedRevisionExtras,
-            }),
-          );
+          const deletionMark = deletionType.create({
+            revisionId,
+            author,
+            date,
+            ...(isPairedMove(item.operation.moveId) && { moveKind: "moveFrom" }),
+            ...trackedRevisionExtras,
+          });
+          tr = tr.addMark(item.from, item.to, deletionMark);
+          // The range above spans the block's clean TEXT, so an inline image or
+          // field sits outside it whenever it leads or trails the words.
+          // Deleting a block deletes what is in it: left unmarked, accepting
+          // the deletion kept a paragraph standing around an orphan image.
+          for (const { from, to } of undeletedContentAtomRanges(tr, item.blockFrom)) {
+            tr = tr.addMark(from, to, deletionMark);
+          }
           appliedRevisionIds = [revisionId];
           // Deleting a paragraph's words leaves its paragraph mark behind, and
           // an accepted redline then holds a blank line where the paragraph
           // was: a deleted paragraph carries `w:pPr/w:rPr/w:del` as well as
-          // its deleted runs. The mark belongs to the paragraph it ends, so
-          // the last paragraph of a cell or of the body keeps its own: there
-          // is no sibling to join with. A relocation is left alone — a moved
-          // paragraph's mark is `w:moveFrom`, and writing `w:del` there would
-          // report the move as a deletion as well.
-          if (
-            !isPairedMove(item.operation.moveId) &&
-            paragraphFollows(tr.doc, tr.mapping.map(item.blockTo))
-          ) {
+          // its deleted runs.
+          //
+          // A mark belongs to the paragraph it ends, so the paragraph's own
+          // mark is the one that went. That holds wherever it sat: resolving
+          // the mark joins it with the next paragraph when there is one, and
+          // removes the paragraph outright when there is not, which is what a
+          // document holds after a paragraph before a table is deleted. The
+          // only paragraph that cannot say it is the one its parent cannot do
+          // without: a cell must contain a paragraph, so the last one in a
+          // cell keeps its mark and stays blank.
+          //
+          // A relocation's source break is `w:moveFrom`, not `w:del`: the two
+          // resolve alike, and the kind is what tells a reader this end has a
+          // matching one elsewhere rather than being a deletion of its own.
+          const markPosition = tr.mapping.map(item.blockFrom);
+          const parent = tr.doc.resolve(markPosition).parent;
+          if (parent.childCount > 1 && tr.doc.nodeAt(markPosition)?.attrs["pPrMark"] == null) {
             const markRevisionId = revisionSeed++;
-            tr = tr.setNodeAttribute(item.blockFrom, "pPrMark", {
-              kind: "del",
+            tr = tr.setNodeAttribute(markPosition, "pPrMark", {
+              kind: isPairedMove(item.operation.moveId) ? "moveFrom" : "del",
               info: { id: markRevisionId, author, date, ...trackedRevisionExtras },
             });
             appliedRevisionIds = [revisionId, markRevisionId];
@@ -1891,6 +1976,7 @@ const applyFolioAIEditOperationsInternal = ({
   }
 
   if (tr.docChanged) {
+    tr = withoutRevisionsOnZeroWidthAnchors(tr);
     if (revisionStamp) {
       // Paragraphs this batch creates get their `w14:paraId` from the
       // allocator plugin, which is random by default. A stamped batch has
@@ -2293,14 +2379,11 @@ const resolveOperation = ({
   }
 
   if (operation.type === "insertAfterBlock" || operation.type === "insertBeforeBlock") {
-    // An empty `text` is normally an error, but a page-break-only
-    // paragraph is legitimate (the user just wants whitespace +
-    // forced break). Letting it through with no inline content
-    // means the inserted block renders as an empty paragraph that
-    // starts a new page.
-    if (operation.text.length === 0 && operation.pageBreakBefore !== true) {
-      return { type: "skip", reason: "emptyOperation" };
-    }
+    // An empty `text` inserts a blank paragraph. That is a real edit — a blank
+    // line between two clauses is something a document says — and it is the
+    // only way to write one, so it is not refused. An insertion always changes
+    // the document: there is no empty insert that would leave it as it was.
+    //
     // If the anchor lives inside a `tableCell`, the model meant
     // "place the new block adjacent to the table", not "stuff it
     // into the cell". Override the insertion bounds to the table's
@@ -2359,7 +2442,11 @@ const resolveOperation = ({
   if (operation.type === "insertTableRow") {
     const position = operation.position ?? "after";
     const insertion = findTableRowInsertion({ doc, blockFrom, position });
-    if (!insertion || (operation.cellTexts?.length ?? 0) > insertion.cells.length) {
+    // Sized against the table's COLUMN count, which is what a caller reading
+    // the table counts. `cells.length` is smaller whenever a cell spans
+    // columns or a row above spans down into this one, and refusing on that
+    // would refuse a row the table can perfectly well hold.
+    if (!insertion || (operation.cellTexts?.length ?? 0) > insertion.columnCount) {
       return { type: "skip", reason: "unsupportedBlock" };
     }
     return {
@@ -2645,25 +2732,32 @@ const resolveOperation = ({
     const range = getTextRangeFromCleanBlock(cleanBlock);
     if (!range) {
       const insertionPoint = cleanBlock.offsets.at(0);
-      if (
-        operation.type === "replaceBlock" &&
-        currentText.length === 0 &&
-        operation.text.length > 0 &&
-        insertionPoint !== undefined
-      ) {
-        return {
-          type: "resolved",
-          operation: {
-            operation,
-            from: insertionPoint,
-            to: insertionPoint,
-            blockFrom,
-            blockTo,
-            blockNode,
-          },
-        };
+      if (insertionPoint === undefined) {
+        return { type: "skip", reason: "unsupportedBlock" };
       }
-      return { type: "skip", reason: "unsupportedBlock" };
+      // A blank paragraph has no run range to mark. Deleting one, or writing
+      // into one, is still an edit: what changes is the paragraph itself, and
+      // its MARK is where the revision goes. An empty range resolves both —
+      // `replaceBlock` inserts at it, `deleteBlock` marks nothing inline and
+      // lets the paragraph-mark deletion carry the change.
+      const resolvesOnABlank =
+        operation.type === "deleteBlock"
+          ? true
+          : currentText.length === 0 && operation.text.length > 0;
+      if (!resolvesOnABlank) {
+        return { type: "skip", reason: "unsupportedBlock" };
+      }
+      return {
+        type: "resolved",
+        operation: {
+          operation,
+          from: insertionPoint,
+          to: insertionPoint,
+          blockFrom,
+          blockTo,
+          blockNode,
+        },
+      };
     }
     // The model occasionally emits replaceBlock with text identical
     // to the live block's clean text — usually as a side effect of

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -258,13 +258,19 @@ const REVISION_MARK_NAMES: ReadonlySet<string> = new Set(["insertion", "deletion
  * not be saved. Marking is by range everywhere, so the guard is here, once,
  * rather than at each of the dozen call sites that would have to remember.
  */
-const withoutRevisionsOnZeroWidthAnchors = (tr: Transaction): Transaction => {
+const withoutRevisionsOnZeroWidthAnchors = (
+  tr: Transaction,
+  batchRevisionIds: ReadonlySet<number>,
+): Transaction => {
   const anchors: { from: number; to: number; marks: readonly Mark[] }[] = [];
   tr.doc.descendants((node, pos) => {
     if (!isZeroWidthAnchor(node)) {
       return true;
     }
-    const marks = node.marks.filter(({ type }) => REVISION_MARK_NAMES.has(type.name));
+    const marks = node.marks.filter(
+      ({ attrs, type }) =>
+        REVISION_MARK_NAMES.has(type.name) && batchRevisionIds.has(attrs["revisionId"]),
+    );
     if (marks.length > 0) {
       anchors.push({ from: pos, to: pos + node.nodeSize, marks });
     }
@@ -1976,7 +1982,8 @@ const applyFolioAIEditOperationsInternal = ({
   }
 
   if (tr.docChanged) {
-    tr = withoutRevisionsOnZeroWidthAnchors(tr);
+    const batchRevisionIds = new Set(applied.flatMap(({ revisionIds }) => revisionIds ?? []));
+    tr = withoutRevisionsOnZeroWidthAnchors(tr, batchRevisionIds);
     if (revisionStamp) {
       // Paragraphs this batch creates get their `w14:paraId` from the
       // allocator plugin, which is random by default. A stamped batch has

--- a/packages/core/src/ai-edits/blockRange.ts
+++ b/packages/core/src/ai-edits/blockRange.ts
@@ -11,7 +11,7 @@
 import type { Node as PMNode } from "prosemirror-model";
 
 import { buildCleanBlockText } from "./clean-text";
-import { createFolioAIEditSnapshot, hashFolioAIBlockText } from "./snapshot";
+import { createFolioAIEditSnapshot, hashFolioAIBlockText, isFolioAIContentBlock } from "./snapshot";
 import type { FolioAIBlockAnchor, FolioAIEditSnapshot, FolioAITextRangeHandle } from "./types";
 import { findParagraphByParaId } from "../prosemirror/utils/findParagraphByParaId";
 import { getFolioParaIdFromBlockId, getSequentialFolioBlockIdIndex } from "../types/block-id";
@@ -189,9 +189,13 @@ const matchPassage = (haystack: string, needleSource: string): PassageMatch | nu
  * server's `seq-NNNN`: the direct anchor lookup misses, and a
  * paraId-based live lookup can't match either (no node carries a
  * `seq-` paraId). The seq number is the block's 1-based position in
- * the same non-empty-block walk the server extractor and
- * `createFolioAIEditSnapshot` share, so it indexes the snapshot's
- * ordered `blocks` directly.
+ * the non-empty-block walk the server extractor and
+ * `createFolioAIEditSnapshot` share.
+ *
+ * That walk is not the snapshot's `blocks` array: `blocks` also holds
+ * the document's blank paragraphs, which the seq sequence does not
+ * count. So the position is counted here over the blocks that carry
+ * text, which is what the number means.
  */
 export const resolveSequentialBlockAnchor = (
   blockId: string,
@@ -201,8 +205,17 @@ export const resolveSequentialBlockAnchor = (
   if (index === null) {
     return undefined;
   }
-  const block = snapshot.blocks.at(index - 1);
-  return block ? snapshot.anchors[block.id] : undefined;
+  let remaining = index;
+  for (const block of snapshot.blocks) {
+    if (!isFolioAIContentBlock(block)) {
+      continue;
+    }
+    remaining -= 1;
+    if (remaining === 0) {
+      return snapshot.anchors[block.id];
+    }
+  }
+  return undefined;
 };
 
 /**

--- a/packages/core/src/ai-edits/blockWalkAgreement.property.test.ts
+++ b/packages/core/src/ai-edits/blockWalkAgreement.property.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The snapshot walk and the live-document walk have to agree.
+ *
+ * A snapshot hands out one id per block. Applying an operation resolves that
+ * id back to a position by walking the live document, and the two walks are
+ * separate code. When they disagree about which nodes count — a blank
+ * paragraph, a hidden row's subtree, a paragraph inside a nested table — every
+ * id after the disagreement resolves onto the wrong block, and the edit lands
+ * somewhere nobody asked for. That is not a failure any single example finds
+ * reliably, so it is stated here as a property over generated documents.
+ *
+ * The observable form of the invariant: give every block of a snapshot its own
+ * distinct style, in one batch, addressed by id. Every block must come back
+ * carrying the style meant for it, in the same order, in the same container.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig, propertyTestTimeout } from "../../../../test/property-testing";
+
+import {
+  buildBodySequenceDocx,
+  type BodyItem,
+  type CellContent,
+} from "../compare/__fixtures__/body-sequence";
+import type { FolioAIBlock } from "./types";
+import { FolioDocxReviewer } from "./headless";
+
+const wordArb = fc.stringMatching(/^[A-Za-z]{3,9}$/u);
+
+/** Blank paragraphs are ordinary blocks, so a generated document holds them. */
+const textArb = fc.oneof(
+  { weight: 4, arbitrary: wordArb },
+  { weight: 1, arbitrary: fc.constant("") },
+);
+
+const paragraphArb: fc.Arbitrary<BodyItem> = textArb.map((text) => ({
+  kind: "paragraph",
+  text,
+}));
+
+const nestedCellArb: fc.Arbitrary<CellContent> = fc.oneof(
+  { weight: 5, arbitrary: textArb },
+  {
+    weight: 1,
+    arbitrary: fc.array(textArb, { minLength: 1, maxLength: 2 }).map(
+      (texts): CellContent => [
+        { kind: "paragraph", text: texts[0] ?? "" },
+        // A table as a cell's last child is the container edge the fixture
+        // closes with the paragraph the format requires.
+        { kind: "table", rows: [[texts[1] ?? ""]] },
+      ],
+    ),
+  },
+);
+
+const tableArb: fc.Arbitrary<BodyItem> = fc
+  .record({
+    rows: fc.array(fc.array(nestedCellArb, { minLength: 1, maxLength: 2 }), {
+      minLength: 1,
+      maxLength: 3,
+    }),
+    hiddenRow: fc.option(fc.nat({ max: 2 }), { nil: undefined }),
+  })
+  .map(({ rows, hiddenRow }) => {
+    // Every row the table's full width: a ragged one is not a table any
+    // package holds, and the parser would square it before the snapshot saw it.
+    const width = Math.max(...rows.map((row) => row.length));
+    const squared: CellContent[][] = [];
+    for (const row of rows) {
+      const cells: CellContent[] = [];
+      cells.push(...row);
+      while (cells.length < width) {
+        cells.push("");
+      }
+      squared.push(cells);
+    }
+    // Never hide every row: a table with nothing visible is a different shape
+    // from a table with a hidden row in it.
+    const hides = hiddenRow !== undefined && hiddenRow < squared.length && squared.length > 1;
+    const table: BodyItem = { kind: "table", rows: squared };
+    if (hides) {
+      table.hiddenRows = [hiddenRow];
+    }
+    return table;
+  });
+
+/**
+ * A body always ends with a paragraph: a table may not be a body's or a cell's
+ * last child, and a document that breaks that rule is malformed input rather
+ * than a case this property is about.
+ */
+const bodyArb: fc.Arbitrary<readonly BodyItem[]> = fc
+  .array(fc.oneof({ weight: 3, arbitrary: paragraphArb }, { weight: 1, arbitrary: tableArb }), {
+    minLength: 1,
+    maxLength: 6,
+  })
+  .map((items) => {
+    const body: BodyItem[] = [];
+    body.push(...items);
+    body.push({ kind: "paragraph", text: "closing" });
+    return body;
+  });
+
+type BlockShape = { id: string; container: string; text: string };
+
+const shapeOf = ({ id, text, table }: FolioAIBlock): BlockShape => ({
+  id,
+  text,
+  container: table
+    ? `t${String(table.tableIndex)}r${String(table.rowIndex)}c${String(table.cellIndex)}p${String(table.paragraphIndex)}`
+    : "body",
+});
+
+/** A style id that names the block it was meant for, so a swap is visible. */
+const styleFor = (index: number): string => `Probe${String(index).padStart(3, "0")}`;
+
+describe("block ids resolve against the live document", () => {
+  test(
+    "every block of a snapshot resolves to the block it was taken from",
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(bodyArb, async (items) => {
+          const reviewer = await FolioDocxReviewer.fromBuffer(await buildBodySequenceDocx(items), {
+            author: "probe",
+          });
+          const before = reviewer.snapshot().blocks;
+
+          const { skipped } = reviewer.applyOperations(
+            before.map((block, index) => ({
+              id: `probe-${String(index)}`,
+              type: "setBlockParagraphProperties" as const,
+              blockId: block.id,
+              properties: { styleId: styleFor(index) },
+            })),
+            { mode: "direct" },
+          );
+          expect(skipped).toEqual([]);
+
+          const after = reviewer.snapshot().blocks;
+          // The walk is the same walk: same blocks, same order, same
+          // containers, same text — the batch changed only styles.
+          expect(after.map(shapeOf)).toEqual(before.map(shapeOf));
+          expect(after.map(({ styleId }) => styleId)).toEqual(before.map((_, i) => styleFor(i)));
+        }),
+        propertyConfig({ numRuns: 25 }),
+      );
+    },
+    propertyTestTimeout(120_000),
+  );
+});

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -30,6 +30,7 @@ import {
   applyFolioAIEditsToBuffer,
 } from "./headless";
 import type { FolioReviewChange } from "./headless";
+import { isFolioAIContentBlock } from "./snapshot";
 import type { FolioAIBlock } from "./types";
 
 const FIXTURE = path.join(
@@ -2282,7 +2283,10 @@ describe("headless docx review discovery + resolve", () => {
     const text = reviewer.getContentAsText();
     expect(text).toContain(`[${heading.id}] `);
     expect(text).toContain("Heading paragraph.");
-    for (const block of blocks) {
+    // Every block a reader would see is labelled. The blank paragraphs the
+    // snapshot also holds are not: a model shown the document should see its
+    // content, not a line per empty paragraph.
+    for (const block of blocks.filter(isFolioAIContentBlock)) {
       expect(text).toContain(`[${block.id}]`);
     }
   });

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -75,7 +75,11 @@ import {
   type FolioReviewChange,
   type FolioReviewChangeKind,
 } from "./read";
-import { createFolioAIEditSnapshot, normalizeFolioAIBlockText } from "./snapshot";
+import {
+  createFolioAIEditSnapshot,
+  isFolioAIContentBlock,
+  normalizeFolioAIBlockText,
+} from "./snapshot";
 import type {
   FolioAIBlock,
   FolioAIEditApplyMode,
@@ -377,8 +381,11 @@ const resolveReviewedState = (state: EditorState, view: FolioReviewedView): Edit
 
 const formatStoryStateForLLM = (state: EditorState, annotated: boolean): string => {
   const snapshot = createFolioAIEditSnapshot(state.doc);
+  // A reading surface shows content. The snapshot also carries the document's
+  // blank paragraphs, which are structure rather than something to read.
+  const blocks = snapshot.blocks.filter(isFolioAIContentBlock);
   if (!annotated) {
-    return snapshot.blocks.map(formatBlockForLLM).join("\n");
+    return blocks.map(formatBlockForLLM).join("\n");
   }
   // One walk, not one `doc.nodeAt` per block: `nodeAt` re-descends from the
   // root and scans each level's fragment from index 0, so looking every block
@@ -395,7 +402,7 @@ const formatStoryStateForLLM = (state: EditorState, annotated: boolean): string 
   for (const anchor of Object.values(snapshot.anchors)) {
     startById.set(anchor.id, anchor.from);
   }
-  return snapshot.blocks
+  return blocks
     .map((block) => {
       const from = startById.get(block.id);
       const node = from === undefined ? undefined : nodeByStart.get(from);

--- a/packages/core/src/ai-edits/index.ts
+++ b/packages/core/src/ai-edits/index.ts
@@ -24,6 +24,7 @@ export {
   createFolioAIEditSnapshot,
   createFolioAITextRangeHandle,
   hashFolioAIBlockText,
+  isFolioAIContentBlock,
   normalizeFolioAIBlockText,
 } from "./snapshot";
 export { getFolioDocumentOutline, readFolioDocumentSection } from "./scoped-reading";

--- a/packages/core/src/ai-edits/scoped-reading.test.ts
+++ b/packages/core/src/ai-edits/scoped-reading.test.ts
@@ -75,6 +75,31 @@ describe("scoped document reading", () => {
     }
   });
 
+  // The outline does not call a heading-styled BLANK paragraph a section: it
+  // has no text to name it. The section's END has to agree, or a blank heading
+  // closes a section the outline says is still open and everything after it is
+  // dropped from the read.
+  test("a heading-styled blank paragraph does not end a section", () => {
+    const withBlankHeading = makeSnapshot([
+      { id: "h1", kind: "heading", headingLevel: 1, text: "Agreement" },
+      { id: "p1", kind: "paragraph", text: "Opening" },
+      { id: "blank-0001", kind: "heading", headingLevel: 1, text: "" },
+      { id: "p2", kind: "paragraph", text: "Still the agreement" },
+    ]);
+    const handle = getFolioDocumentOutline(withBlankHeading).sections.at(0)?.handle;
+    if (handle === undefined) {
+      throw new Error("Expected outline handle");
+    }
+
+    const result = readFolioDocumentSection(withBlankHeading, handle);
+
+    expect(result.status).toBe("found");
+    if (result.status !== "found") {
+      return;
+    }
+    expect(result.section.blocks.map(({ id }) => id)).toEqual(["h1", "p1", "p2"]);
+  });
+
   test("distinguishes stale or structurally changed handles from deleted headings", () => {
     const handle = getFolioDocumentOutline(snapshot).sections.at(0)?.handle;
     if (handle === undefined) {

--- a/packages/core/src/ai-edits/scoped-reading.ts
+++ b/packages/core/src/ai-edits/scoped-reading.ts
@@ -1,3 +1,4 @@
+import { isFolioAIContentBlock } from "./snapshot";
 import type {
   FolioAIEditSnapshot,
   FolioDocumentOutline,
@@ -30,7 +31,9 @@ export const getFolioDocumentOutline = (snapshot: FolioAIEditSnapshot): FolioDoc
   const parentStack: FolioDocumentOutlineEntry[] = [];
 
   for (const block of snapshot.blocks) {
-    if (block.headingLevel === undefined) {
+    // A heading-styled blank paragraph is not a section: it has no text to
+    // name it, and every one of them would hash alike and collide as handles.
+    if (block.headingLevel === undefined || !isFolioAIContentBlock(block)) {
       continue;
     }
     const handle = toSectionHandle(snapshot, block.id, block.headingLevel);
@@ -80,10 +83,19 @@ export const readFolioDocumentSection = (
     return { status: "missing" };
   }
 
+  // The same test the outline applies, or the two disagree about what a
+  // section is: a heading-styled BLANK paragraph is not one, and treating it
+  // as a boundary here ended the section early and dropped everything the
+  // outline still counts as inside it.
   let endIndex = snapshot.blocks.length;
   for (let index = startIndex + 1; index < snapshot.blocks.length; index++) {
     const block = snapshot.blocks.at(index);
-    if (block?.headingLevel !== undefined && block.headingLevel <= heading.level) {
+    if (
+      block !== undefined &&
+      block.headingLevel !== undefined &&
+      block.headingLevel <= heading.level &&
+      isFolioAIContentBlock(block)
+    ) {
       endIndex = index;
       break;
     }
@@ -94,7 +106,9 @@ export const readFolioDocumentSection = (
     section: {
       handle,
       heading,
-      blocks: snapshot.blocks.slice(startIndex, endIndex),
+      // A section is what a reader would read. The blank paragraphs between
+      // its blocks are part of the document's shape, not part of the section.
+      blocks: snapshot.blocks.slice(startIndex, endIndex).filter(isFolioAIContentBlock),
     },
   };
 };

--- a/packages/core/src/ai-edits/snapshot.test.ts
+++ b/packages/core/src/ai-edits/snapshot.test.ts
@@ -13,7 +13,8 @@
 import { describe, expect, test } from "bun:test";
 import { type Node as PMNode, Schema } from "prosemirror-model";
 
-import { createFolioAIEditSnapshot } from "./snapshot";
+import { resolveSequentialBlockAnchor } from "./blockRange";
+import { createFolioAIEditSnapshot, isFolioAIContentBlock } from "./snapshot";
 
 const schema = new Schema({
   nodes: {
@@ -138,5 +139,57 @@ describe("createFolioAIEditSnapshot", () => {
     );
 
     expect(createFolioAIEditSnapshot(doc).blocks).toHaveLength(480);
+  });
+
+  test("the seq- ids are the same whether or not blank paragraphs are there", () => {
+    // The published contract: `seq-NNNN` counts the paragraphs that carry
+    // text. A host extractor derives the same numbers, and a stored citation
+    // has to keep naming its paragraph, so blank paragraphs may never take a
+    // position in that sequence however many of them a document grows.
+    const contentTexts = ["first", "second", "third", "fourth"];
+    const withoutBlanks = schema.node(
+      "doc",
+      null,
+      contentTexts.map((text) => paragraph(text)),
+    );
+    const withBlanks = schema.node("doc", null, [
+      paragraph(""),
+      paragraph("first"),
+      paragraph(""),
+      paragraph(""),
+      paragraph("second"),
+      paragraph("third"),
+      paragraph(""),
+      paragraph("fourth"),
+      paragraph(""),
+    ]);
+
+    const seqIdsOf = (doc: PMNode): string[] =>
+      createFolioAIEditSnapshot(doc)
+        .blocks.filter(isFolioAIContentBlock)
+        .map(({ id }) => id);
+
+    expect(seqIdsOf(withoutBlanks)).toEqual(["seq-0001", "seq-0002", "seq-0003", "seq-0004"]);
+    expect(seqIdsOf(withBlanks)).toEqual(seqIdsOf(withoutBlanks));
+
+    // The blanks are addressable, and in their own sequence.
+    expect(
+      createFolioAIEditSnapshot(withBlanks)
+        .blocks.filter((block) => !isFolioAIContentBlock(block))
+        .map(({ id }) => id),
+    ).toEqual(["blank-0001", "blank-0002", "blank-0003", "blank-0004", "blank-0005"]);
+  });
+
+  test("a seq- id resolves to the paragraph it numbered, past any blanks", () => {
+    const doc = schema.node("doc", null, [
+      paragraph(""),
+      paragraph("first"),
+      paragraph(""),
+      paragraph("second"),
+    ]);
+    const snapshot = createFolioAIEditSnapshot(doc);
+
+    expect(resolveSequentialBlockAnchor("seq-0002", snapshot)?.text).toBe("second");
+    expect(resolveSequentialBlockAnchor("seq-0003", snapshot)).toBeUndefined();
   });
 });

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -1,6 +1,6 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
-import { deriveBlockId } from "../types/block-id";
+import { deriveBlankBlockId, deriveBlockId, type FolioBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
 import type {
   FolioAIBlock,
@@ -14,6 +14,49 @@ import type {
 
 export const normalizeFolioAIBlockText = (text: string): string =>
   text.replace(/\s+/gu, " ").trim();
+
+/**
+ * Whether a block carries text a reader would see.
+ *
+ * The snapshot holds every paragraph, blank ones included: an empty cell is
+ * part of a table's shape, an empty row is a row, and a comparison that cannot
+ * address them cannot describe what changed around them. A reading surface
+ * wants the opposite — a model shown a document should see its content, not a
+ * line per blank paragraph.
+ *
+ * So the two needs are split here rather than in the walk: the snapshot is
+ * complete, and every surface that reads it for a person or a model states
+ * that it wants content by calling this. One helper, so "what counts as
+ * content" has a single answer; five inline emptiness checks would drift.
+ */
+export const isFolioAIContentBlock = ({ text }: Pick<FolioAIBlock, "text">): boolean =>
+  normalizeFolioAIBlockText(text).length > 0;
+
+/**
+ * The block that content appended to the end of a story hangs from: the last
+ * paragraph at body level.
+ *
+ * Not simply the last block. A story's last block is often inside a table, and
+ * a paragraph cannot be appended after one: the insertion escapes to the
+ * table's boundary, where the block it was anchored to is not adjacent to it
+ * and its paragraph mark ends a different container's paragraph. Neither
+ * container-edge rule then applies and the addition cannot be rejected
+ * cleanly.
+ *
+ * A body always ends with a paragraph — a table may not be the last child of a
+ * body or a cell, so a package that ends in a table carries a trailing, often
+ * empty, paragraph after it — so this is only `null` for a story with no
+ * body-level paragraph at all, which is a malformed document.
+ */
+export const trailingBodyBlockId = ({ blocks }: FolioAIEditSnapshot): string | null => {
+  for (let index = blocks.length - 1; index >= 0; index--) {
+    const block = blocks[index];
+    if (block !== undefined && block.table === undefined) {
+      return block.id;
+    }
+  }
+  return null;
+};
 
 export const hashFolioAIBlockText = (text: string): string => {
   let hash = 5381;
@@ -81,7 +124,7 @@ type AncestorPathEntry = { node: PMNode; start: number; end: number; index: numb
  * instructions into a row that no human ever sees. The walk skips the row's
  * whole subtree, so a table nested inside a hidden row is hidden with it.
  */
-const isHiddenTableRow = (node: PMNode): boolean =>
+export const isHiddenTableRow = (node: PMNode): boolean =>
   node.type.name === TABLE_ROW_NODE_NAME && node.attrs["hidden"] === true;
 
 type TableLocationOptions = {
@@ -148,17 +191,13 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   // `descendants` reaches a table before any textblock inside it, so a nested
   // block's lookup always finds its table already numbered.
   const tableIndexByStart = new Map<number, number>();
-  const emptyAnchorState: {
-    candidate: { from: number; to: number; paraId: string | null } | null;
-    textblockCount: number;
-  } = { candidate: null, textblockCount: 0 };
-
   // The containers enclosing the node being visited, innermost last. Kept in
   // step with the walk so no block has to resolve its own position.
   const path: AncestorPathEntry[] = [];
 
   let blockIndex = 0;
-  doc.descendants((node, pos, parent, index) => {
+  let blankIndex = 0;
+  doc.descendants((node, pos, _parent, index) => {
     while (pos >= (path.at(-1)?.end ?? Number.POSITIVE_INFINITY)) {
       path.pop();
     }
@@ -184,22 +223,6 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     // operation positions, so the offsets stay consistent.
     const { text } = buildCleanBlockText(node, pos);
     const normalizedText = normalizeFolioAIBlockText(text);
-    if (normalizedText.length === 0) {
-      if (parent?.type !== doc.type) {
-        return true;
-      }
-      emptyAnchorState.textblockCount++;
-      if (emptyAnchorState.candidate === null) {
-        const paraIdAttr: unknown = node.attrs["paraId"];
-        emptyAnchorState.candidate = {
-          from: pos,
-          to: pos + node.nodeSize,
-          paraId: typeof paraIdAttr === "string" && paraIdAttr.length > 0 ? paraIdAttr : null,
-        };
-      }
-      return true;
-    }
-
     const textHash = hashFolioAIBlockText(normalizedText);
     hashCounts.set(textHash, (hashCounts.get(textHash) ?? 0) + 1);
 
@@ -211,16 +234,25 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     // at the wrong paragraph after an insertion-above" surprise.
     //
     // Shared with `apps/api/.../docx-blocks.ts` via `deriveBlockId`,
-    // so a server-emitted citation id is always one of the two shapes
-    // this snapshot produces (paraId verbatim or `seq-NNNN`).
-    blockIndex++;
+    // so a server-emitted citation id is always one of the shapes this
+    // snapshot produces (paraId verbatim, `seq-NNNN`, or `blank-NNNN`).
+    //
+    // `seq-NNNN` counts the paragraphs that carry text, and nothing
+    // else: that count is the published contract the server extractor
+    // derives too, so a stored citation keeps naming its paragraph. A
+    // paragraph with no text is numbered in the separate blank
+    // sequence rather than consuming a position in it.
     const paraIdAttr: unknown = node.attrs["paraId"];
     const paraId = typeof paraIdAttr === "string" && paraIdAttr.length > 0 ? paraIdAttr : null;
-    const id = deriveBlockId({
-      paraId,
-      index: blockIndex,
-      taken: usedBlockIds,
-    });
+    const isBlank = normalizedText.length === 0;
+    let id: FolioBlockId;
+    if (isBlank) {
+      blankIndex++;
+      id = deriveBlankBlockId({ paraId, index: blankIndex, taken: usedBlockIds });
+    } else {
+      blockIndex++;
+      id = deriveBlockId({ paraId, index: blockIndex, taken: usedBlockIds });
+    }
     usedBlockIds.add(id);
     const headingLevel = getHeadingLevel(node);
     const kind = getBlockKind(node, headingLevel);
@@ -264,27 +296,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     };
   }
 
-  const emptyAnchorCandidate = emptyAnchorState.candidate;
-  if (blocks.length > 0 || emptyAnchorCandidate === null) {
-    return { blocks, anchors };
-  }
-
-  const emptyDocumentAnchorId = deriveBlockId({
-    paraId: emptyAnchorCandidate.paraId,
-    index: 1,
-    taken: usedBlockIds,
-  });
-  const normalizedText = "";
-  anchors[emptyDocumentAnchorId] = {
-    id: emptyDocumentAnchorId,
-    from: emptyAnchorCandidate.from,
-    to: emptyAnchorCandidate.to,
-    text: "",
-    normalizedText,
-    textHash: hashFolioAIBlockText(normalizedText),
-    hashOccurrenceCount: emptyAnchorState.textblockCount,
-  };
-  return { blocks, anchors, emptyDocumentAnchorId };
+  return { blocks, anchors };
 };
 
 const getBlockKind = (node: PMNode, headingLevel: number | undefined): FolioAIBlockKind => {

--- a/packages/core/src/ai-edits/table-row-column-mutations.ts
+++ b/packages/core/src/ai-edits/table-row-column-mutations.ts
@@ -24,6 +24,17 @@ export type TableRowInsertion = {
   rowType: PMNode["type"];
   cells: readonly PMNode[];
   rowspanUpdates: readonly number[];
+  /**
+   * The table's column count, which is not `cells.length`. One cell can occupy
+   * several columns (a `colspan`), and one column can have no cell in this row
+   * at all (a `rowspan` from a row above reaches down into it).
+   *
+   * It is what `cellTexts` is SIZED against — the most cells any row of this
+   * table could have — while the texts themselves fill the new row's cells in
+   * order. Sizing against `cells.length` refused a row the table can hold
+   * whenever a span made this row narrower than the table.
+   */
+  columnCount: number;
 };
 
 export type TableRowDeletion = Omit<TableRowTarget, "table">;
@@ -500,24 +511,49 @@ const buildTableRowInsertion = ({
     rowType: tableNodeTypes(table.type.schema).row,
     cells,
     rowspanUpdates,
+    columnCount: map.width,
   };
 };
 
+const CELL_LINE_BREAK_PATTERN = /\r\n|\r|\n/;
+
+/**
+ * Split one cell's text into the paragraphs it describes, one string each.
+ *
+ * A cell holds paragraphs, not lines: a line break starts a new one, and a
+ * blank line is a blank paragraph, exactly as `text: ""` is for an insertion.
+ *
+ * This is deliberately not the prose rule `insertAfterBlock` follows, where a
+ * blank line between two model-written clauses is formatting noise and is
+ * dropped. A cell's text is read off a cell that HAS those paragraphs, so
+ * dropping one would lose a block that was there.
+ */
+export const splitCellParagraphTexts = (text: string): string[] =>
+  text.split(CELL_LINE_BREAK_PATTERN);
+
+/**
+ * Fill the new row's cells from `cellTexts`, in order: the nth text goes in
+ * the nth cell the row actually has, which is how a caller reading the row
+ * through the block snapshot counts them (`table.cellIndex`). Cells the caller
+ * did not name stay empty.
+ */
 const populateTableRow = (row: PMNode, cellTexts: readonly string[] | undefined): PMNode => {
   if (cellTexts === undefined) {
     return row;
   }
   const cells: PMNode[] = [];
   row.forEach((cell, _offset, index) => {
+    const text = cellTexts[index] ?? "";
     const paragraph = cell.firstChild;
     if (!paragraph?.isTextblock) {
       cells.push(cell);
       return;
     }
-    const text = cellTexts[index] ?? "";
-    const content = text.length > 0 ? row.type.schema.text(text) : null;
-    const nextParagraph = paragraph.type.create(stripBlockIdentityAttrs(paragraph.attrs), content);
-    cells.push(cell.type.create(cell.attrs, nextParagraph));
+    const attrs = stripBlockIdentityAttrs(paragraph.attrs);
+    const paragraphs = splitCellParagraphTexts(text).map((line) =>
+      paragraph.type.create(attrs, line.length > 0 ? row.type.schema.text(line) : null),
+    );
+    cells.push(cell.type.create(cell.attrs, paragraphs));
   });
   return row.type.create(row.attrs, cells);
 };

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -67,11 +67,18 @@ export type FolioAIBlockParagraphProperties = {
   listLevel?: number | null;
 };
 
+/**
+ * Every paragraph of one story, blank ones included.
+ *
+ * A blank paragraph is part of a document's shape: an empty cell is a column,
+ * an empty row is a row, and an operation or a comparison that cannot address
+ * them cannot describe what changed around them. A surface that reads the
+ * document for a person or a model wants only the paragraphs that carry text,
+ * and says so with `isFolioAIContentBlock`.
+ */
 export type FolioAIEditSnapshot = {
   blocks: FolioAIBlock[];
   anchors: Record<string, FolioAIBlockAnchor>;
-  /** Hidden empty paragraph used to anchor insertions when `blocks` is empty. */
-  emptyDocumentAnchorId?: string;
 };
 
 export type FolioAIBlockAnchor = {
@@ -229,6 +236,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
          * gets `styleId` / `inheritFormatting`, later ones use body
          * formatting. Blank lines are dropped. Reported as a
          * `splitMultilineText` normalization when it happens.
+         *
+         * `""` inserts a BLANK paragraph, and is a real edit: adding an empty
+         * line is a change a reader sees, and a document that has one where
+         * another does not differs. It is applied like any other insertion,
+         * with a tracked paragraph mark, so rejecting closes it away.
          */
         text: string;
         inheritFormatting?: boolean;
@@ -272,6 +284,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         styleId?: string;
         comment?: FolioAIComment;
       }
+    /**
+     * Delete the whole block. A block with words loses them and its paragraph
+     * mark; a BLANK block has only a paragraph mark to lose, and loses it, so
+     * the empty line goes away rather than the operation doing nothing.
+     */
     | {
         id: string;
         type: "deleteBlock";
@@ -317,7 +334,16 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         blockId: string;
         /** Place the table after the anchor (default) or before it. */
         position?: "after" | "before";
-        /** Cell texts row by row. Every row must hold the same number of cells. */
+        /**
+         * Cell texts row by row. Every row must hold the same number of cells.
+         *
+         * A cell holds paragraphs, not lines: a line break in a cell's text
+         * starts a new paragraph in that cell, and a blank line is a blank
+         * paragraph. That is not the rule `insertAfterBlock` follows for
+         * prose, where a blank line between two model-written clauses is
+         * formatting noise and is dropped — a cell's text describes paragraphs
+         * that exist, so dropping one would lose a block.
+         */
         rows: readonly (readonly string[])[];
       }
     /**
@@ -388,7 +414,18 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
         /** Stable paragraph anchor inside the row that receives the new sibling. */
         blockId: string;
         position?: "after" | "before";
-        /** Initial text for each physical cell in source order; omitted cells stay empty. */
+        /**
+         * Initial text for each cell of the new row, in order — the same order
+         * a block's `table.cellIndex` counts. Cells left unnamed stay empty.
+         *
+         * Sized against the table's COLUMN count, which is the most cells any
+         * row of it could have: more texts than that is refused rather than
+         * silently truncated, and fewer is not, so a row the table can hold is
+         * no longer refused because a span makes it narrower than the table.
+         *
+         * A line break in a cell's text starts a new paragraph in that cell,
+         * as in `insertTable`.
+         */
         cellTexts?: string[];
       }
     | {

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -101,9 +101,39 @@ exactly that: `splitBlock` writes an inserted mark on the paragraph the break
 now ends, `mergeBlockWithNext` a deleted one, and the change list says `split`
 or `merge`. The space the break stands in for travels with the operation as
 `separator`, so accepting reproduces the target's spacing and rejecting
-restores the base's. A mark is never written on the last paragraph of a table
-cell: there is no sibling to join with, so the revision could not do what it
-says.
+restores the base's.
+
+### Which paragraph mark changed
+
+A paragraph mark belongs to the paragraph it ends: a paragraph added or removed
+carries its own mark, inserted or deleted alongside its runs. That holds
+everywhere, including at a container's edge, and what changes at the edge is
+how the mark RESOLVES rather than where it sits.
+
+- **A mark with a paragraph after it resolves by joining.** Accepting a deleted
+  mark closes the break; rejecting an inserted one does the same.
+- **A mark with no paragraph after it resolves by removing the paragraph.** The
+  last paragraph of a body, and a paragraph before a table, have nothing to be
+  joined with. Once the resolution has taken the paragraph's words away, what
+  is left is a paragraph whose break was resolved too, so it goes. The
+  exception is a paragraph its parent cannot do without: a cell must contain
+  one, so the last paragraph of a cell keeps its mark and stays blank.
+
+Handing the last new paragraph's mark to the ANCHOR instead reads closer to
+what an editor writes, and is equivalent only while the two stay adjacent. A
+later operation in the same batch — a table inserted between them — separates
+them, and the mark then joins the anchor to the table, which is nothing. The
+rule above needs no adjacency.
+
+A body and every table cell end with a paragraph: a table may never be a
+container's last child. A comparison that adds a table at the end therefore
+adds the paragraph after it too, and that paragraph is an insertion like any
+other.
+
+A relocated paragraph's break is `w:moveFrom` at the source and `w:moveTo` at
+the destination. They resolve exactly as a deletion and an insertion do; the
+kinds are what tell a reader the two ends belong together rather than being an
+unrelated removal and addition.
 
 Renumbering that FOLLOWS from an edit needs no change of its own: labels are
 rendered from the numbering definitions rather than stored on the paragraphs,
@@ -114,8 +144,8 @@ is the opposite case — every label in the list moves and no block's text does
 
 A paragraph property that moved without any word moving — a list item demoted
 a level, a paragraph restyled — is a `paragraph-format` change, written as
-`w:pPrChange` with the complete previous property set so a reject restores it
-the way Word does. The self-check's projection carries the style and the list
+`w:pPrChange` with the complete previous property set, which is what a reject
+restores. The self-check's projection carries the style and the list
 level alongside the text, so a redline that reproduces every word and leaves a
 list item at the wrong level fails instead of passing.
 
@@ -197,19 +227,15 @@ carries the current numbers and the failing cases.
 - **A move's range markers are not written** (2026-09-06). The relocation
   itself is in the document: the deletion at the source is `w:moveFrom`, the
   insertion at the destination `w:moveTo`, and the change list reports
-  `kind: "move"`. Word also brackets each side with
-  `w:moveFromRangeStart`/`End` and a shared `w:name`; those markers have no
-  ProseMirror representation, so folio drops them on any edited paragraph and
-  the comparison cannot produce them. A consumer reading the runs sees the
-  move; one that groups multi-paragraph moves by range name does not.
-- **Empty cells are invisible** (2026-09-06). A cell with no text carries no
-  block, so a row whose cells are all empty is not seen as a row at all. The
-  snapshot skips every empty textblock, and making it stop is a change to every
-  block list in folio, not to the comparison.
+  `kind: "move"`. The format also brackets each side with
+  `w:moveFromRangeStart`/`End`, `w:moveToRangeStart`/`End` and a shared
+  `w:name`; those markers have no ProseMirror representation, so folio
+  drops them on any edited paragraph and the comparison cannot produce them. A
+  consumer reading the runs sees the move; one that groups multi-paragraph
+  moves by range name does not.
 - **Column operations are out of scope** (2026-09-06). A column added or
   removed reads as cell-level changes. `insertTableColumn` / `deleteTableColumn`
-  exist in the operation vocabulary; nothing detects the difference yet, and
-  detecting it reliably needs the empty cells above.
+  exist in the operation vocabulary; nothing detects the difference yet.
 - **A table nested inside a cell cannot be added or removed** (2026-09-06). A
   whole table added or removed at document level is `table-insert` /
   `table-delete`; the same edit inside a cell would need `insertTable` to
@@ -217,7 +243,7 @@ carries the current numbers and the failing cases.
 - **A numbering definition is reported, not represented** (2026-09-06). A list
   whose format, level template or start changed is a `numbering` change, and
   the redline cannot carry it: OOXML has no tracked-change grammar for
-  `numbering.xml` and Word does not track it either. Accepting the result
+  `numbering.xml` at all. Accepting the result
   therefore reproduces the target's words and keeps the base's numbering.
 
 ## Files

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -37,7 +37,7 @@ export type BodyItem =
       kind: "table";
       rows: readonly (readonly CellContent[])[];
       /**
-       * Rows a package hides with `w:vanish`. The snapshot skips their whole
+       * Rows a package hides with `w:hidden`. The snapshot skips their whole
        * subtree, so a document that has one is the case where the snapshot
        * walk and the live walk could disagree.
        */
@@ -76,7 +76,7 @@ const table = (item: Extract<BodyItem, { kind: "table" }>): string => {
     item.rows
       .map(
         (cells, rowIndex) =>
-          `<w:tr>${hidden.has(rowIndex) ? `<w:trPr><w:vanish/></w:trPr>` : ""}${cells
+          `<w:tr>${hidden.has(rowIndex) ? `<w:trPr><w:hidden/></w:trPr>` : ""}${cells
             .map(
               (content) =>
                 `<w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>${cellXml(content)}</w:tc>`,

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -23,35 +23,75 @@ const FIXED_ZIP_DATE = new Date(Date.UTC(2000, 0, 1));
  */
 const ZIP_ENTRY_OPTIONS = { date: FIXED_ZIP_DATE, createFolders: false } as const;
 
+/**
+ * One cell's content: a line of text, or a sequence of its own — which is how
+ * a nested table, a blank line inside a cell, or a cell that ends with a table
+ * gets written.
+ */
+export type CellContent = string | readonly BodyItem[];
+
 /** One body-level item: a paragraph, or a table given row by row. */
 export type BodyItem =
   | { kind: "paragraph"; text: string }
-  | { kind: "table"; rows: readonly (readonly string[])[] };
+  | {
+      kind: "table";
+      rows: readonly (readonly CellContent[])[];
+      /**
+       * Rows a package hides with `w:vanish`. The snapshot skips their whole
+       * subtree, so a document that has one is the case where the snapshot
+       * walk and the live walk could disagree.
+       */
+      hiddenRows?: readonly number[];
+    };
 
+/**
+ * An empty paragraph is a `w:p` with no run at all, which is what a package
+ * holds for a blank line or an empty cell. It is not the same thing as a
+ * paragraph whose run carries an empty string, and both shapes occur.
+ */
 const paragraph = (text: string): string =>
-  `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+  text.length === 0 ? `<w:p/>` : `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
 
-const table = (rows: readonly (readonly string[])[]): string =>
-  `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
-  rows
-    .map(
-      (cells) =>
-        `<w:tr>${cells
-          .map(
-            (text) =>
-              `<w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>${paragraph(text)}</w:tc>`,
-          )
-          .join("")}</w:tr>`,
-    )
-    .join("") +
-  `</w:tbl>`;
+const EMPTY_PARAGRAPH = { kind: "paragraph", text: "" } as const satisfies BodyItem;
 
-const bodyXml = (items: readonly BodyItem[]): string =>
-  items
-    .map((item) => (item.kind === "paragraph" ? paragraph(item.text) : table(item.rows)))
-    // A table may not be the body's last element: it needs a paragraph after
-    // it, which the section properties do not supply.
-    .join("");
+/**
+ * A container may not end with a table: the format requires a paragraph after
+ * one, and a body's section properties do not supply it. One rule for both
+ * containers, because a fixture that is well formed in a cell and malformed in
+ * the body would be measuring two different things.
+ */
+const closedSequence = (items: readonly BodyItem[]): readonly BodyItem[] => {
+  const last = items.at(-1);
+  return last === undefined || last.kind === "table" ? [...items, EMPTY_PARAGRAPH] : items;
+};
+
+/** A cell must also contain a paragraph, which the empty sequence supplies. */
+const cellXml = (content: CellContent): string =>
+  typeof content === "string" ? paragraph(content) : itemsXml(closedSequence(content));
+
+const table = (item: Extract<BodyItem, { kind: "table" }>): string => {
+  const hidden = new Set(item.hiddenRows ?? []);
+  return (
+    `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
+    item.rows
+      .map(
+        (cells, rowIndex) =>
+          `<w:tr>${hidden.has(rowIndex) ? `<w:trPr><w:vanish/></w:trPr>` : ""}${cells
+            .map(
+              (content) =>
+                `<w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>${cellXml(content)}</w:tc>`,
+            )
+            .join("")}</w:tr>`,
+      )
+      .join("") +
+    `</w:tbl>`
+  );
+};
+
+const itemsXml = (items: readonly BodyItem[]): string =>
+  items.map((item) => (item.kind === "paragraph" ? paragraph(item.text) : table(item))).join("");
+
+const bodyXml = (items: readonly BodyItem[]): string => itemsXml(closedSequence(items));
 
 export const buildBodySequenceDocx = async (items: readonly BodyItem[]): Promise<ArrayBuffer> => {
   const parts: Record<string, string> = {

--- a/packages/core/src/compare/__fixtures__/nested-table.ts
+++ b/packages/core/src/compare/__fixtures__/nested-table.ts
@@ -24,7 +24,15 @@ const FIXED_ZIP_DATE = new Date(Date.UTC(2000, 0, 1));
 const ZIP_ENTRY_OPTIONS = { date: FIXED_ZIP_DATE, createFolders: false } as const;
 
 const paragraph = (text: string): string =>
-  `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+  text.length === 0 ? `<w:p/>` : `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+
+/**
+ * A table may not be the last child of a body or a cell, so every container
+ * that ends with one is closed by a paragraph. Word writes that paragraph and
+ * usually leaves it empty; a fixture that omits it is malformed, and the
+ * comparison should be exercised against the shape real packages have.
+ */
+const closingParagraph = paragraph("");
 
 const cell = (inner: string): string =>
   `<w:tc><w:tcPr><w:tcW w:w="4680" w:type="dxa"/></w:tcPr>${inner}</w:tc>`;
@@ -34,14 +42,14 @@ const table = (rows: readonly string[]): string =>
   `<w:tblGrid><w:gridCol w:w="4680"/><w:gridCol w:w="4680"/></w:tblGrid>` +
   `${rows.join("")}</w:tbl>`;
 
-/** The nested table sits in the outer table's last cell, so it closes the story. */
+/** The nested table sits in the outer table's last cell, deep in the story. */
 const NESTED_TABLE = table([
-  `<w:tr>${cell(paragraph("The nested schedule lists the delivery dates."))}</w:tr>`,
+  `<w:tr>${cell(`${paragraph("The nested schedule lists the delivery dates.")}${closingParagraph}`)}</w:tr>`,
 ]);
 
 const OUTER_TABLE = table([
   `<w:tr>${cell(paragraph("Obligations of the supplier."))}${cell(paragraph("Obligations of the buyer."))}</w:tr>`,
-  `<w:tr>${cell(paragraph("Deliver the goods to the named place."))}${cell(`${paragraph("See the schedule below.")}${NESTED_TABLE}`)}</w:tr>`,
+  `<w:tr>${cell(paragraph("Deliver the goods to the named place."))}${cell(`${paragraph("See the schedule below.")}${NESTED_TABLE}${closingParagraph}`)}</w:tr>`,
 ]);
 
 export type NestedTableDocxOptions = {
@@ -55,7 +63,9 @@ export const buildNestedTableDocx = async ({
   const body =
     paragraph("This agreement is made between the parties named below.") +
     OUTER_TABLE +
-    (trailingParagraph === undefined ? "" : paragraph(trailingParagraph));
+    (trailingParagraph === undefined
+      ? closingParagraph
+      : `${paragraph(trailingParagraph)}${closingParagraph}`);
 
   const parts: Record<string, string> = {
     "[Content_Types].xml":

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -38,7 +38,9 @@ const readFixture = (filename: string): ArrayBuffer => {
 const buildSyntheticBase = async (): Promise<ArrayBuffer> => {
   const reviewer = await FolioDocxReviewer.fromBuffer(readFixture("upstream-empty.docx"));
   const anchor = reviewer.snapshot();
-  const anchorId = anchor.blocks.at(0)?.id ?? anchor.emptyDocumentAnchorId;
+  // An empty document is one blank paragraph, so its first block is the anchor
+  // the synthetic clauses are built on.
+  const anchorId = anchor.blocks.at(0)?.id;
   if (anchorId === undefined) {
     throw new Error("The empty fixture offers no anchor to build a synthetic base on.");
   }
@@ -144,6 +146,43 @@ const compareOrThrow = async (base: ArrayBuffer, target: ArrayBuffer): Promise<C
 /** Every block index of `blocks`, so a generated step always addresses a real block. */
 const blockIndexArb = (blocks: readonly FolioAIBlock[]) => fc.nat({ max: blocks.length - 1 });
 
+/**
+ * Body-level block indexes only.
+ *
+ * A relocation is a deletion here and an insertion there, and an insertion
+ * anchored inside a table cell cannot land in that cell: no operation places a
+ * paragraph in one, so the applier puts it beside the table instead. Moving a
+ * cell's paragraph out to the body, or a body paragraph into a cell, is
+ * therefore not an edit this vocabulary can express, and generating one tests
+ * the engine against a target it never claimed to reach. The property that
+ * every scripted difference is representable means scripted differences have
+ * to stay inside what the vocabulary covers; the cell case is the documented
+ * `container` limitation, measured on real documents rather than asserted here.
+ */
+const bodyBlockIndexArb = (blocks: readonly FolioAIBlock[]) => {
+  const bodyIndexes = blocks.flatMap((block, index) => (block.table ? [] : [index]));
+  return bodyIndexes.length === 0 ? null : fc.constantFrom(...bodyIndexes);
+};
+
+/**
+ * Words a relocated block needs before the move pass will pair its two halves.
+ * Mirrors `MOVE_MINIMUM_WORD_COUNT` in `plan.ts`: below the floor a base-only
+ * and a target-only block with the same text are not called one relocation,
+ * because boilerplate one-liners — and blank paragraphs, which have no words at
+ * all — would pair as spurious moves.
+ */
+const MOVE_MINIMUM_WORD_COUNT = 3;
+
+/** Body-level blocks with enough words for the move pass to pair them. */
+const movableBlockIndexArb = (blocks: readonly FolioAIBlock[]) => {
+  const indexes = blocks.flatMap((block, index) =>
+    !block.table && block.text.trim().split(/\s+/u).length >= MOVE_MINIMUM_WORD_COUNT
+      ? [index]
+      : [],
+  );
+  return indexes.length === 0 ? null : fc.constantFrom(...indexes);
+};
+
 const wordArb = fc.stringMatching(/^[A-Za-z]{3,9}$/u);
 const sentenceArb = fc
   .array(wordArb, { minLength: 3, maxLength: 6 })
@@ -215,12 +254,18 @@ const editStepArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScriptSt
       type: fc.constant("deleteParagraph" as const),
       blockIndex: blockIndexArb(blocks),
     }),
-    fc.record({
-      type: fc.constant("moveParagraph" as const),
-      blockIndex: blockIndexArb(blocks),
-      beforeBlockIndex: blockIndexArb(blocks),
-    }),
   ];
+
+  const bodyIndex = bodyBlockIndexArb(blocks);
+  if (bodyIndex) {
+    steps.push(
+      fc.record({
+        type: fc.constant("moveParagraph" as const),
+        blockIndex: bodyIndex,
+        beforeBlockIndex: bodyIndex,
+      }),
+    );
+  }
 
   const findable = findableWordArb(blocks);
   if (findable) {
@@ -463,11 +508,13 @@ describe("compareDocx", () => {
     async () => {
       const base = SYNTHETIC_BASE;
       const baseBlocks = BASE_CASES.at(-1)?.blocks ?? [];
+      const movable = movableBlockIndexArb(baseBlocks);
+      if (movable === null) {
+        throw new Error("The synthetic base offers no block the move pass would pair.");
+      }
       await fc.assert(
         fc.asyncProperty(
-          fc
-            .tuple(blockIndexArb(baseBlocks), blockIndexArb(baseBlocks))
-            .filter(([from, to]) => Math.abs(from - to) > 1),
+          fc.tuple(movable, movable).filter(([from, to]) => Math.abs(from - to) > 1),
           async ([blockIndex, beforeBlockIndex]) => {
             const scripted = await applyEditScript(base, [
               { type: "moveParagraph", blockIndex, beforeBlockIndex },

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -39,7 +39,7 @@
 import { panic } from "better-result";
 
 import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
-import { createFolioAITextRangeHandle } from "../ai-edits/snapshot";
+import { createFolioAITextRangeHandle, trailingBodyBlockId } from "../ai-edits/snapshot";
 import type {
   FolioAIBlock,
   FolioAIBlockParagraphProperties,
@@ -920,19 +920,22 @@ export const planStoryCompare = ({
   const anchorIds = nextBaseBlockIdByStep(steps);
   const changes: CompareChange[] = [];
   const operations: FolioAIEditOperation[] = [];
-  const lastBaseBlockId = baseSnapshot.blocks.at(-1)?.id ?? null;
   /**
-   * The anchor everything past the base document's last block hangs from, and
-   * the hidden paragraph an empty base offers instead. The applier orders
-   * insertions that resolve to one position by their order in this array, so
-   * the tail is emitted where its step sits rather than collected and appended
-   * — a table and a paragraph both added after the last base block otherwise
-   * come out in operation order, which is not target order.
+   * The anchor everything past the base document's content hangs from: its
+   * last BODY-LEVEL paragraph, which the format guarantees exists because a
+   * table may not be the last child of a body. Anchoring to the last block
+   * instead put the anchor inside a table whenever the story ended with one,
+   * and an insertion anchored there escapes to the table's boundary, where no
+   * paragraph mark can express the break it added.
+   *
+   * The applier orders insertions that resolve to one position by their order
+   * in this array, so the tail is emitted where its step sits rather than
+   * collected and appended — a table and a paragraph both added after the last
+   * base block otherwise come out in operation order, which is not target
+   * order.
    */
-  const tailAnchorId = lastBaseBlockId ?? baseSnapshot.emptyDocumentAnchorId ?? null;
-  const emptyBaseAnchorId =
-    lastBaseBlockId === null ? (baseSnapshot.emptyDocumentAnchorId ?? null) : null;
-  let tailInsertCount = 0;
+  const tailAnchorId = trailingBodyBlockId(baseSnapshot);
+
   let operationSequence = 0;
 
   const nextOperationId = (): string => `compare-${++operationSequence}`;
@@ -968,19 +971,6 @@ export const planStoryCompare = ({
     if (tailAnchorId === null) {
       // An empty base with no anchor paragraph cannot receive tracked
       // insertions at all.
-      return;
-    }
-    // An empty base document has no block to insert after, only the hidden
-    // anchor paragraph. Its first addition therefore replaces that paragraph
-    // instead of following it, so the result does not open with a stray blank.
-    if (tailInsertCount++ === 0 && emptyBaseAnchorId !== null) {
-      operations.push({
-        id: nextOperationId(),
-        type: "replaceBlock",
-        blockId: emptyBaseAnchorId,
-        text: block.text,
-        ...(block.styleId !== undefined && { styleId: block.styleId }),
-      });
       return;
     }
     operations.push({

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -453,10 +453,8 @@ type BuildStepsOptions = {
  * table as a deletion and an insertion.
  *
  * When the two documents hold different numbers of tables the shapes diverge,
- * and the surplus segments are reported one-sided. The operation vocabulary
- * cannot create or destroy a table, so `compareDocx`'s round-trip self-check
- * refuses those comparisons rather than returning a package that silently
- * drops one.
+ * and the surplus segments are reported one-sided. The operation builder turns
+ * those segments into `insertTable` or `deleteTable` operations.
  */
 const segmentText = (segment: DocumentSegment): string =>
   segment.blocks.map(({ text }) => text).join(" ");

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -31,9 +31,13 @@ export type CompareVerificationInvariant = (typeof COMPARE_VERIFICATION_INVARIAN
 export const COMPARE_VERIFICATION_CAUSES = Object.freeze([
   /**
    * Every block is present, in order, at coordinates the block model cannot
-   * reach. The snapshot carries no block for an empty paragraph, so a cell
-   * holding a blank line reports its visible paragraph one position along and
-   * no operation can put a block there. Not a lost difference.
+   * reach, so no operation could have put a block at the expected ones. Not a
+   * lost difference.
+   *
+   * Blank paragraphs no longer cause this: the snapshot carries them. What is
+   * left is the row a package hides, whose whole subtree the snapshot skips on
+   * purpose. A table hiding a row on one side only shifts every later row's
+   * index, and nothing the comparison can do reaches those positions.
    */
   "invisible-structure",
   "block-count",
@@ -109,11 +113,10 @@ export const sameProjection = (left: readonly string[], right: readonly string[]
  * appearance, so it counts the blocks the model holds rather than the
  * paragraphs the package contains.
  *
- * The snapshot skips every empty textblock, so a cell holding a blank
- * paragraph reports its visible paragraph at `p1`, and a table whose first
- * rows are empty reports its visible rows starting at `r3`. No operation can
- * put a block at those coordinates, because none can create the empty
- * paragraphs that produce them. When two projections agree here and disagree
+ * The snapshot skips a hidden row's whole subtree, so a table that hides a row
+ * on one side only reports every later row one position along. No operation
+ * can put a block at those coordinates, because none can create or remove the
+ * hidden row that produces them. When two projections agree here and disagree
  * on the raw coordinates, the redline holds every block the other side does,
  * in order, and the difference is one the block model cannot see.
  */

--- a/packages/core/src/docx/paragraphParser-pPrMark.test.ts
+++ b/packages/core/src/docx/paragraphParser-pPrMark.test.ts
@@ -90,4 +90,39 @@ describe("parseParagraph — paragraph-mark tracked change (ECMA-376 §17.13.5)"
       info: { id: 3, author: "Carol" },
     });
   });
+
+  test("reads paragraph-mark changes in the Strict WordprocessingML namespace", () => {
+    const paragraph = parseParagraphXml(`
+      <x:p xmlns:x="http://purl.oclc.org/ooxml/wordprocessingml/main">
+        <x:pPr>
+          <x:rPr>
+            <x:moveTo x:id="4" x:author="Dana"/>
+          </x:rPr>
+        </x:pPr>
+      </x:p>
+    `);
+
+    expect(paragraph.pPrMark).toEqual({
+      kind: "moveTo",
+      info: { id: 4, author: "Dana" },
+    });
+  });
+
+  test("ignores same-named paragraph-mark elements from a foreign namespace", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p
+        xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        xmlns:foreign="https://example.com/foreign"
+      >
+        <w:pPr>
+          <w:rPr>
+            <foreign:moveFrom w:id="5" w:author="Eve"/>
+            <foreign:del w:id="6" w:author="Frank"/>
+          </w:rPr>
+        </w:pPr>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark).toBeUndefined();
+  });
 });

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -68,6 +68,7 @@ import { isValidHexColor } from "../utils/colorResolver";
 import type { StyleMap } from "./styleParser";
 import {
   findChild,
+  findChildByNamespaceUri,
   findChildren,
   getAttribute,
   getChildElements,
@@ -78,6 +79,7 @@ import {
   parseNumberingLevelAttribute,
   parseNumericAttribute,
   elementToXml,
+  WORDPROCESSINGML_NAMESPACE_URIS,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
@@ -1027,7 +1029,7 @@ function parseParagraphMarkChange(pPr: XmlElement | null): ParagraphMarkChange |
   // the parser silently drops. `moveFrom` / `moveTo` come first: a moved
   // paragraph's mark carries one of them INSTEAD of `del` / `ins`, never both.
   for (const kind of PARAGRAPH_MARK_CHANGE_KINDS) {
-    const element = findChild(rPr, "w", kind);
+    const element = findChildByNamespaceUri(rPr, WORDPROCESSINGML_NAMESPACE_URIS, kind);
     if (element) {
       return { kind, info: parseTrackedChangeInfo(element) };
     }

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -36,7 +36,7 @@ import type {
   MathEquation,
   RunContent,
 } from "../types/document";
-import { normalizeRevisionId } from "@stll/docx-core/model";
+import { normalizeRevisionId, PARAGRAPH_MARK_CHANGE_KINDS } from "@stll/docx-core/model";
 import { panic } from "better-result";
 import { isValidHexId } from "../utils/hexId";
 import {
@@ -1023,13 +1023,14 @@ function parseParagraphMarkChange(pPr: XmlElement | null): ParagraphMarkChange |
   if (!rPr) {
     return undefined;
   }
-  const ins = findChild(rPr, "w", "ins");
-  if (ins) {
-    return { kind: "ins", info: parseTrackedChangeInfo(ins) };
-  }
-  const del = findChild(rPr, "w", "del");
-  if (del) {
-    return { kind: "del", info: parseTrackedChangeInfo(del) };
+  // Driven by the kinds themselves, so a kind the model gains cannot be one
+  // the parser silently drops. `moveFrom` / `moveTo` come first: a moved
+  // paragraph's mark carries one of them INSTEAD of `del` / `ins`, never both.
+  for (const kind of PARAGRAPH_MARK_CHANGE_KINDS) {
+    const element = findChild(rPr, "w", kind);
+    if (element) {
+      return { kind, info: parseTrackedChangeInfo(element) };
+    }
   }
   return undefined;
 }

--- a/packages/core/src/docx/server/createBilingualDocx.ts
+++ b/packages/core/src/docx/server/createBilingualDocx.ts
@@ -1,4 +1,5 @@
 import { FolioDocxReviewer } from "../../ai-edits/headless";
+import { isFolioAIContentBlock } from "../../ai-edits/snapshot";
 import { toArrayBuffer } from "../../utils/docxInput";
 import { ensureParaIds } from "../ensureParaIds";
 import { parseDocx } from "../parser";
@@ -34,8 +35,12 @@ export async function createBilingualDocx(
 ): Promise<CreateBilingualDocxResult> {
   const stamped = await ensureParaIds(input);
   const stampedBuffer = await toArrayBuffer(stamped.docx);
+  // A blank paragraph is not an editable row: it carries nothing to translate.
   const editableParagraphIds = new Set(
-    (await FolioDocxReviewer.fromBuffer(stampedBuffer)).snapshot().blocks.map(({ id }) => id),
+    (await FolioDocxReviewer.fromBuffer(stampedBuffer))
+      .snapshot()
+      .blocks.filter(isFolioAIContentBlock)
+      .map(({ id }) => id),
   );
   const source = await parseDocx(stampedBuffer, { preloadFonts: false });
   const { document, warnings } = createBilingualDocument(source, {
@@ -52,7 +57,10 @@ export async function readBilingualDocx(input: ArrayBuffer | Uint8Array): Promis
   const buffer = await toArrayBuffer(input);
   const document = await parseDocx(buffer, { preloadFonts: false });
   const editableParagraphIds = new Set(
-    (await FolioDocxReviewer.fromBuffer(buffer)).snapshot().blocks.map(({ id }) => id),
+    (await FolioDocxReviewer.fromBuffer(buffer))
+      .snapshot()
+      .blocks.filter(isFolioAIContentBlock)
+      .map(({ id }) => id),
   );
   return readBilingualDocument(document, editableParagraphIds);
 }

--- a/packages/core/src/docx/streamingXmlParser.test.ts
+++ b/packages/core/src/docx/streamingXmlParser.test.ts
@@ -5,7 +5,13 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { parseStreamingXml } from "./streamingXmlParser";
-import { parseXml } from "./xmlParser";
+import {
+  getAttributeByNamespaceUri,
+  getChildElements,
+  getNamespaceUri,
+  parseXml,
+  WORDPROCESSINGML_NAMESPACE_URIS,
+} from "./xmlParser";
 
 const REPO_ROOT = resolve(import.meta.dir, "../../../..");
 const DOCUMENT_FIXTURE_GLOBS = [
@@ -45,6 +51,43 @@ describe("parseStreamingXml", () => {
     expect(parseStreamingXml("<document>&custom;</document>").status).toBe("unsupported");
     expect(parseStreamingXml('<document __proto__="unsafe"/>').status).toBe("unsupported");
     expect(parseStreamingXml(deeplyNested).status).toBe("unsupported");
+  });
+
+  test("matches inherited and rebound namespace metadata", () => {
+    const xml = `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:body>
+        <w:p w:id="transitional"><w:r/></w:p>
+        <x:p xmlns:x="http://purl.oclc.org/ooxml/wordprocessingml/main" x:id="strict"><x:r/></x:p>
+        <w:p xmlns:w="https://example.com/foreign" w:id="foreign"><w:r/></w:p>
+        <w:p w:id="restored"><w:r/></w:p>
+      </w:body>
+    </w:document>`;
+    const streaming = parseStreamingXml(xml);
+    expect(streaming.status).toBe("parsed");
+    if (streaming.status !== "parsed") {
+      return;
+    }
+    const namespaceEntries = (root: ReturnType<typeof parseXml>) => {
+      const entries: [string, string | undefined, string | null][] = [];
+      const visit = (element: typeof root): void => {
+        if (element.name) {
+          entries.push([
+            element.name,
+            getNamespaceUri(element),
+            getAttributeByNamespaceUri(element, WORDPROCESSINGML_NAMESPACE_URIS, "id"),
+          ]);
+        }
+        for (const child of getChildElements(element)) {
+          visit(child);
+        }
+      };
+      for (const child of getChildElements(root)) {
+        visit(child);
+      }
+      return entries;
+    };
+
+    expect(namespaceEntries(streaming.value)).toEqual(namespaceEntries(parseXml(xml)));
   });
 
   test("matches entity and line-ending behavior for generated values", () => {

--- a/packages/core/src/docx/streamingXmlParser.ts
+++ b/packages/core/src/docx/streamingXmlParser.ts
@@ -1,4 +1,4 @@
-import type { XmlElement } from "./xmlParser";
+import { attachXmlNamespaceContext, type XmlElement } from "./xmlParser";
 import { FOLIO_XML_RESOURCE_LIMITS } from "./xmlResourceLimits";
 
 type ParseXmlResult = { status: "parsed"; value: XmlElement } | { status: "unsupported" };
@@ -97,6 +97,7 @@ export const parseStreamingXml = (xml: string): ParseXmlResult => {
     }
 
     const parent = stack.at(-1)?.element ?? root;
+    attachXmlNamespaceContext(parsedTag.element, parent.namespaceScope);
     appendElement(parent, parsedTag.element);
     if (!parsedTag.selfClosing) {
       if (stack.length >= FOLIO_XML_RESOURCE_LIMITS.maxDepth) {

--- a/packages/core/src/docx/xmlParser.ts
+++ b/packages/core/src/docx/xmlParser.ts
@@ -128,6 +128,49 @@ const resolveNamespaceUri = (
   return undefined;
 };
 
+/** Attach the element's resolved namespace metadata from its in-scope declarations. */
+export const attachXmlNamespaceContext = (
+  element: XmlElement,
+  inheritedNamespaceScope: XmlNamespaceScope = EMPTY_NAMESPACE_SCOPE,
+): XmlNamespaceScope => {
+  let localBindings: Map<string, string> | null = null;
+  if (element.attributes) {
+    for (const [attribute, value] of Object.entries(element.attributes)) {
+      if (typeof value !== "string" || (attribute !== "xmlns" && !attribute.startsWith("xmlns:"))) {
+        continue;
+      }
+      localBindings ??= new Map();
+      const prefix = attribute === "xmlns" ? "" : attribute.slice("xmlns:".length);
+      localBindings.set(prefix, value);
+    }
+  }
+  const namespaceScope =
+    localBindings === null
+      ? inheritedNamespaceScope
+      : { bindings: localBindings, parent: inheritedNamespaceScope };
+
+  Object.defineProperty(element, "namespaceScope", {
+    configurable: false,
+    enumerable: false,
+    value: namespaceScope,
+    writable: false,
+  });
+
+  const name = element.name ?? "";
+  const colonIndex = name.indexOf(":");
+  const prefix = colonIndex === -1 ? "" : name.slice(0, colonIndex);
+  const namespaceUri = resolveNamespaceUri(namespaceScope, prefix);
+  if (namespaceUri !== undefined) {
+    Object.defineProperty(element, "namespaceUri", {
+      configurable: false,
+      enumerable: false,
+      value: namespaceUri,
+      writable: false,
+    });
+  }
+  return namespaceScope;
+};
+
 /**
  * Convert a fast-xml-parser preserveOrder node into an XmlElement.
  *
@@ -163,40 +206,7 @@ function fxpNodeToElement(
       element.attributes = attrs;
     }
 
-    let localBindings: Map<string, string> | null = null;
-    if (attrs) {
-      for (const [attribute, value] of Object.entries(attrs)) {
-        if (attribute !== "xmlns" && !attribute.startsWith("xmlns:")) {
-          continue;
-        }
-        localBindings ??= new Map();
-        const prefix = attribute === "xmlns" ? "" : attribute.slice("xmlns:".length);
-        localBindings.set(prefix, value);
-      }
-    }
-    const namespaceScope =
-      localBindings === null
-        ? inheritedNamespaceScope
-        : { bindings: localBindings, parent: inheritedNamespaceScope };
-
-    Object.defineProperty(element, "namespaceScope", {
-      configurable: false,
-      enumerable: false,
-      value: namespaceScope,
-      writable: false,
-    });
-
-    const colonIndex = key.indexOf(":");
-    const prefix = colonIndex === -1 ? "" : key.slice(0, colonIndex);
-    const namespaceUri = resolveNamespaceUri(namespaceScope, prefix);
-    if (namespaceUri !== undefined) {
-      Object.defineProperty(element, "namespaceUri", {
-        configurable: false,
-        enumerable: false,
-        value: namespaceUri,
-        writable: false,
-      });
-    }
+    const namespaceScope = attachXmlNamespaceContext(element, inheritedNamespaceScope);
 
     if (children.length > 0) {
       for (let index = 0; index < children.length; index += 1) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,7 @@ export {
   createFolioAIEditSnapshot,
   diffWordSegments,
   hashFolioAIBlockText,
+  isFolioAIContentBlock,
   normalizeFolioAIBlockText,
   WORD_DIFF_GRANULARITIES,
   type FolioWordDiffOptions,

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -305,7 +305,9 @@ function resolveChange(
         }
         const joinPos = mappedPos + paragraph.nodeSize;
         const nextNode = joinPos < tr.doc.content.size ? tr.doc.nodeAt(joinPos) : null;
-        const joinable = nextNode?.type.name === paragraph.type.name;
+        const joinable =
+          nextNode?.type.name === paragraph.type.name &&
+          !(carriesSection(paragraph) && carriesSection(nextNode));
         if (!joinable) {
           // Nothing to join with: the paragraph ends the document, or the next
           // sibling is a table, or the position lands on a cell boundary where

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -379,6 +379,13 @@ function resolveChange(
           // would survive an otherwise-resolved revision. Drop it now.
           if (emptyFirstParagraph) {
             tr.setNodeMarkup(mappedPos, undefined, nextAttrs);
+          } else if (!carriesSection(paragraph) && carriesSection(nextNode)) {
+            tr.setNodeMarkup(mappedPos, undefined, {
+              ...paragraph.attrs,
+              pPrMark: null,
+              sectionBreakType: nextNode.attrs["sectionBreakType"],
+              _sectionProperties: nextNode.attrs["_sectionProperties"],
+            });
           } else {
             tr.setNodeAttribute(mappedPos, "pPrMark", null);
           }

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -366,29 +366,17 @@ function resolveChange(
         // leaves behind is now that end. Dropping them merges two sections
         // into one and takes the dropped one's page size, margins and
         // header and footer references with it.
-        const nextAttrs = carriesSection(paragraph)
-          ? {
-              ...nextNode.attrs,
-              sectionBreakType: paragraph.attrs["sectionBreakType"],
-              _sectionProperties: paragraph.attrs["_sectionProperties"],
-            }
-          : nextNode.attrs;
+        const formattingOwner = emptyFirstParagraph ? nextNode : paragraph;
+        const sectionOwner = carriesSection(paragraph) ? paragraph : nextNode;
+        const joinedAttrs = {
+          ...formattingOwner.attrs,
+          pPrMark: nextNode.attrs["pPrMark"],
+          sectionBreakType: sectionOwner.attrs["sectionBreakType"],
+          _sectionProperties: sectionOwner.attrs["_sectionProperties"],
+        };
         try {
           tr.join(joinPos);
-          // PM's `join` keeps the first paragraph's attrs, so the marker
-          // would survive an otherwise-resolved revision. Drop it now.
-          if (emptyFirstParagraph) {
-            tr.setNodeMarkup(mappedPos, undefined, nextAttrs);
-          } else if (!carriesSection(paragraph) && carriesSection(nextNode)) {
-            tr.setNodeMarkup(mappedPos, undefined, {
-              ...paragraph.attrs,
-              pPrMark: null,
-              sectionBreakType: nextNode.attrs["sectionBreakType"],
-              _sectionProperties: nextNode.attrs["_sectionProperties"],
-            });
-          } else {
-            tr.setNodeAttribute(mappedPos, "pPrMark", null);
-          }
+          tr.setNodeMarkup(mappedPos, undefined, joinedAttrs);
         } catch {
           // PM rejects the join if the two blocks aren't structurally
           // compatible (e.g. paragraph followed by a table). Leaving the

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -15,9 +15,12 @@ import type {
   TableFormatting,
   TableRowFormatting,
 } from "../../types/document";
+import { PARAGRAPH_MARK_CHANGE_KINDS, type ParagraphMarkChangeKind } from "@stll/docx-core/model";
+
 import { expectParagraphAttrs, expectRunPropertyChangeMarkAttrs } from "../attrs";
 import { textFormattingToMarks } from "../conversion/toProseDoc";
 import { markStructuralChange } from "../extensions/features/ParagraphChangeTrackerExtension";
+import { holdsNoContent } from "../zeroWidthAnchors";
 import { getFolioNodeRevisionCarriers } from "../revisionCarriers";
 import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
 import type { ParagraphPropertyChangeAttrs } from "../schema/nodes";
@@ -301,18 +304,46 @@ function resolveChange(
           continue;
         }
         const joinPos = mappedPos + paragraph.nodeSize;
-        if (joinPos >= tr.doc.content.size) {
-          // No next sibling to join with (paragraph terminates the doc).
-          // Leave the marker in place — Word treats this the same way.
-          continue;
-        }
-        const nextNode = tr.doc.nodeAt(joinPos);
-        if (nextNode?.type.name !== paragraph.type.name) {
-          // The next sibling is a table, or the paragraph ends its cell and
-          // the position lands on the cell boundary. `join` there merges the
-          // containers rather than the paragraphs, which silently loses rows;
-          // an input document may carry such a mark, so this is checked here
-          // and not only where the marks are written.
+        const nextNode = joinPos < tr.doc.content.size ? tr.doc.nodeAt(joinPos) : null;
+        const joinable = nextNode?.type.name === paragraph.type.name;
+        if (!joinable) {
+          // Nothing to join with: the paragraph ends the document, or the next
+          // sibling is a table, or the position lands on a cell boundary where
+          // `join` would merge the containers and silently lose rows.
+          //
+          // Resolving the mark still has a meaning. The paragraph whose break
+          // and content were both resolved away is simply not there any more,
+          // so it is removed rather than left blank — which is what a document
+          // holds after a paragraph before a table is deleted and the deletion
+          // is accepted.
+          //
+          // A cell must contain a paragraph, so its parent's only child stays
+          // blank whatever its mark says.
+          //
+          // A section's properties live on a paragraph mark, so the paragraph
+          // is where its section ENDS. It can still go, but the section cannot
+          // go with it: the content before it is still in that section, which
+          // now ends one paragraph earlier. There is no next paragraph here to
+          // hand the properties to, so they move back to the previous one —
+          // unless that paragraph ends a section of its own, in which case
+          // there is nowhere to put them and the paragraph stays.
+          const resolved = tr.doc.resolve(mappedPos);
+          const previous = resolved.nodeBefore;
+          const sectionCanMoveBack =
+            !carriesSection(paragraph) ||
+            (previous?.type.name === paragraph.type.name && !carriesSection(previous));
+          if (sectionCanMoveBack && holdsNoContent(paragraph) && resolved.parent.childCount > 1) {
+            if (carriesSection(paragraph) && previous) {
+              tr.setNodeMarkup(mappedPos - previous.nodeSize, undefined, {
+                ...previous.attrs,
+                sectionBreakType: paragraph.attrs["sectionBreakType"],
+                _sectionProperties: paragraph.attrs["_sectionProperties"],
+              });
+            }
+            tr.delete(mappedPos, mappedPos + paragraph.nodeSize);
+            continue;
+          }
+          tr.setNodeAttribute(mappedPos, "pPrMark", null);
           continue;
         }
         // The inline sweep above has already run, so a paragraph that is empty
@@ -323,10 +354,23 @@ function resolveChange(
         // paragraph's properties live on its mark. PM's `join` keeps the
         // first node's attrs, so they are restored explicitly; otherwise a
         // deleted heading would hand its style to the paragraph below it.
-        const emptyFirstParagraph = paragraph.content.size === 0;
+        const emptyFirstParagraph = holdsNoContent(paragraph);
         // The next paragraph's own `pPrMark` travels with its attrs: it is a
         // different revision, and resolving this one must not resolve it.
-        const nextAttrs = nextNode.attrs;
+        //
+        // A section's properties are the exception to "the next paragraph's
+        // properties win". They are not formatting the resolved paragraph
+        // owned; they are where a section ENDS, and the paragraph the join
+        // leaves behind is now that end. Dropping them merges two sections
+        // into one and takes the dropped one's page size, margins and
+        // header and footer references with it.
+        const nextAttrs = carriesSection(paragraph)
+          ? {
+              ...nextNode.attrs,
+              sectionBreakType: paragraph.attrs["sectionBreakType"],
+              _sectionProperties: paragraph.attrs["_sectionProperties"],
+            }
+          : nextNode.attrs;
         try {
           tr.join(joinPos);
           // PM's `join` keeps the first paragraph's attrs, so the marker
@@ -769,10 +813,10 @@ function collectPPrMarkOp(
   if (revisionSet !== null && !revisionSet.has(pPrMark.info.id)) {
     return null;
   }
-  // accept-ins / reject-del keep the paragraph break (clear attr).
-  // reject-ins / accept-del remove the paragraph break (join with next).
+  // Accepting an added break, or rejecting a removed one, keeps the break
+  // (clear the attr). The other two remove it (join with the next paragraph).
   const action: PPrMarkOp["action"] =
-    (pPrMark.kind === "ins") === (mode === "accept") ? "clear" : "join";
+    paragraphMarkWasAdded(pPrMark.kind) === (mode === "accept") ? "clear" : "join";
   return { paragraphPos: pos, action };
 }
 
@@ -879,13 +923,15 @@ function resolveTablePropertyChangeAttrs(
   return nextAttrs;
 }
 
-function isPPrMarkAttr(value: unknown): value is { kind: "ins" | "del"; info: { id: number } } {
+function isPPrMarkAttr(
+  value: unknown,
+): value is { kind: ParagraphMarkChangeKind; info: { id: number } } {
   if (typeof value !== "object" || value === null) {
     return false;
   }
   const kind = (value as { kind?: unknown }).kind;
   const info = (value as { info?: unknown }).info;
-  if (kind !== "ins" && kind !== "del") {
+  if (!PARAGRAPH_MARK_CHANGE_KINDS.some((allowed) => allowed === kind)) {
     return false;
   }
   if (typeof info !== "object" || info === null) {
@@ -893,6 +939,26 @@ function isPPrMarkAttr(value: unknown): value is { kind: "ins" | "del"; info: { 
   }
   return typeof (info as { id?: unknown }).id === "number";
 }
+
+/**
+ * Whether the mark says the paragraph break was ADDED. A relocation's
+ * destination break was added exactly as an insertion's was, and its source
+ * break went exactly as a deletion's did; the kinds differ so a reader is told
+ * the two ends belong together, not because they resolve differently.
+ */
+const paragraphMarkWasAdded = (kind: ParagraphMarkChangeKind): boolean =>
+  kind === "ins" || kind === "moveTo";
+
+/**
+ * Whether the paragraph's mark carries a section's properties.
+ *
+ * A section break lives on a paragraph mark, so the paragraph is where the
+ * section ends. Removing it removes the section: a document that had two ends
+ * up with one, and every setting the dropped section carried — page size,
+ * margins, its header and footer references — goes with it.
+ */
+const carriesSection = (paragraph: PMNode): boolean =>
+  paragraph.attrs["sectionBreakType"] != null || paragraph.attrs["_sectionProperties"] != null;
 
 function readRevisionInfo(info: RevisionInfoAttrs | undefined): {
   author?: string;
@@ -979,7 +1045,10 @@ export function findParagraphBoundaryChangeAtPosition(
     return toParagraphBoundaryChange(
       node,
       paragraphPos,
-      pPrMark.kind === "ins" ? "insertion" : "deletion",
+      // A relocation's destination break was added exactly as an insertion's
+      // was; naming the kinds one by one here read `moveTo` as a deletion and
+      // showed the reader a paragraph arriving as one going away.
+      paragraphMarkWasAdded(pPrMark.kind) ? "insertion" : "deletion",
       pPrMark.info,
     );
   }

--- a/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -250,6 +250,32 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
       expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
     });
 
+    test("keeps both paragraphs when the next one ends a section of its own", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            { pPrMark: delMark({ id: 2 }), sectionBreakType: "nextPage" },
+            schema.text("first section"),
+          ),
+          schema.node(
+            "paragraph",
+            { sectionBreakType: "continuous" },
+            schema.text("second section"),
+          ),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(2);
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+      expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+      expect(view.state.doc.child(1).attrs["sectionBreakType"]).toBe("continuous");
+    });
+
     test("moves back a paragraph when there is nothing to join it with", () => {
       const state = EditorState.create({
         schema,

--- a/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -9,11 +9,20 @@ const schema = new Schema({
   nodes: {
     doc: { content: "block+" },
     paragraph: {
-      content: "text*",
+      content: "inline*",
       group: "block",
-      attrs: { pPrMark: { default: null } },
+      attrs: {
+        pPrMark: { default: null },
+        sectionBreakType: { default: null },
+        _sectionProperties: { default: null },
+      },
     },
-    text: { marks: "_" },
+    text: { group: "inline", marks: "_" },
+    // Zero-width anchors: they hold a position, carry no revision of their
+    // own, and therefore outlive a deletion that took every word around them.
+    renderedPageBreak: { inline: true, group: "inline", atom: true },
+    bookmarkBoundary: { inline: true, group: "inline", atom: true },
+    textBoxAnchor: { inline: true, group: "inline", atom: true },
   },
   marks: {
     insertion: {
@@ -149,7 +158,11 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
     expect(view.state.doc.childCount).toBe(2);
   });
 
-  test("acceptAll on a doc-terminal pPrMark='del' leaves the marker (no next sibling)", () => {
+  test("acceptAll on a doc-terminal pPrMark='del' clears a marker it cannot join", () => {
+    // The paragraph keeps its words, so there is nothing to remove: only the
+    // break it claims went, and there is no paragraph after it to join with.
+    // The revision is resolved rather than left standing over a document that
+    // no longer carries it.
     const state = EditorState.create({
       schema,
       doc: schema.node("doc", null, [
@@ -161,7 +174,126 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
     acceptAllChanges()(view.state, view.dispatch);
 
     expect(view.state.doc.childCount).toBe(2);
-    expect(view.state.doc.child(1).attrs["pPrMark"]).toEqual(delMark({ id: 1 }));
+    expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();
+  });
+
+  test("acceptAll removes an emptied paragraph it cannot join", () => {
+    // A paragraph whose words and whose break were both resolved away is not
+    // there any more. Left blank it would be a line the accepted document
+    // never had, which is what happens to a paragraph deleted before a table.
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, schema.text("first")),
+        schema.node("paragraph", { pPrMark: delMark({ id: 1 }) }),
+      ]),
+    });
+    const view = dispatcher(state);
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("first");
+  });
+
+  // A zero-width anchor holds a position and shows nothing. Counting one as
+  // content left an emptied paragraph standing as a blank line around an
+  // invisible node.
+  for (const anchor of ["renderedPageBreak", "bookmarkBoundary", "textBoxAnchor"]) {
+    test(`a ${anchor} does not keep an emptied paragraph alive`, () => {
+      const deletion = schema.marks["deletion"]!;
+      const revision = { revisionId: 1, author: "Alice", date: "2026-05-01" };
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node("paragraph", null, schema.text("first")),
+          schema.node("paragraph", { pPrMark: delMark({ id: 2 }) }, [
+            schema.node(anchor),
+            schema.text("gone", [deletion.create(revision)]),
+          ]),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("first");
+    });
+  }
+
+  // A section break lives on a paragraph mark, so the paragraph is where the
+  // section ends. Resolving the mark away must not take the section with it:
+  // the dropped section's page size, margins and header and footer references
+  // would go too, and a document that had two would end up with one.
+  describe("a section on the resolved paragraph's mark", () => {
+    const deletion = () => schema.marks["deletion"]!;
+    const revision = { revisionId: 1, author: "Alice", date: "2026-05-01" };
+
+    test("travels to the paragraph the join leaves behind", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            { pPrMark: delMark({ id: 2 }), sectionBreakType: "nextPage" },
+            schema.text("gone", [deletion().create(revision)]),
+          ),
+          schema.node("paragraph", null, schema.text("next")),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("next");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+    });
+
+    test("moves back a paragraph when there is nothing to join it with", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node("paragraph", null, schema.text("first")),
+          schema.node(
+            "paragraph",
+            { pPrMark: delMark({ id: 2 }), sectionBreakType: "nextPage" },
+            schema.text("gone", [deletion().create(revision)]),
+          ),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      // The section now ends one paragraph earlier; the content before it is
+      // still in that section.
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("first");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+    });
+
+    test("keeps the paragraph when the one before it ends a section of its own", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node("paragraph", { sectionBreakType: "continuous" }, schema.text("first")),
+          schema.node(
+            "paragraph",
+            { pPrMark: delMark({ id: 2 }), sectionBreakType: "nextPage" },
+            schema.text("gone", [deletion().create(revision)]),
+          ),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(2);
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
+      expect(view.state.doc.child(1).attrs["sectionBreakType"]).toBe("nextPage");
+      expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();
+    });
   });
 
   test("rejectChange + inline insertion on same paragraph resolves both", () => {

--- a/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -276,6 +276,29 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
       expect(view.state.doc.child(1).attrs["sectionBreakType"]).toBe("continuous");
     });
 
+    test("keeps the next paragraph's section when surviving content is joined", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node("paragraph", { pPrMark: delMark({ id: 2 }) }, schema.text("first")),
+          schema.node(
+            "paragraph",
+            { sectionBreakType: "continuous", _sectionProperties: { columns: 2 } },
+            schema.text("second"),
+          ),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("firstsecond");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
+      expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({ columns: 2 });
+      expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+    });
+
     test("moves back a paragraph when there is nothing to join it with", () => {
       const state = EditorState.create({
         schema,

--- a/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -283,20 +283,56 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
           schema.node("paragraph", { pPrMark: delMark({ id: 2 }) }, schema.text("first")),
           schema.node(
             "paragraph",
-            { sectionBreakType: "continuous", _sectionProperties: { columns: 2 } },
+            {
+              pPrMark: insMark({ id: 3 }),
+              sectionBreakType: "continuous",
+              _sectionProperties: { columns: 2 },
+            },
             schema.text("second"),
           ),
         ]),
       });
       const view = dispatcher(state);
 
-      acceptAllChanges()(view.state, view.dispatch);
+      acceptChange(0, view.state.doc.child(0).nodeSize)(view.state, view.dispatch);
 
       expect(view.state.doc.childCount).toBe(1);
       expect(view.state.doc.child(0).textContent).toBe("firstsecond");
       expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
       expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({ columns: 2 });
-      expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+      expect(view.state.doc.child(0).attrs["pPrMark"]).toEqual(insMark({ id: 3 }));
+    });
+
+    test("keeps the next paragraph's revision and section after emptied content is joined", () => {
+      const deletionMark = deletion().create(revision);
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            { pPrMark: delMark({ id: 2 }) },
+            schema.text("gone", [deletionMark]),
+          ),
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: insMark({ id: 3 }),
+              sectionBreakType: "continuous",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("second"),
+          ),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      acceptChange(0, view.state.doc.child(0).nodeSize)(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("second");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
+      expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({ columns: 2 });
+      expect(view.state.doc.child(0).attrs["pPrMark"]).toEqual(insMark({ id: 3 }));
     });
 
     test("moves back a paragraph when there is nothing to join it with", () => {

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
@@ -26,6 +26,7 @@ const schema = new Schema({
       attrs: {
         paraId: { default: null },
         textId: { default: null },
+        pPrMark: { default: null },
       },
       toDOM: () => ["p", 0],
     },
@@ -325,6 +326,45 @@ describe("ParagraphChangeTrackerExtension", () => {
       expect(changed.has("P1")).toBe(true);
       expect(changed.has("P2")).toBe(false);
       expect(changed.has("P3")).toBe(false);
+    });
+  });
+
+  describe("attribute-only edits", () => {
+    // A blank paragraph has no text to mark, so its paragraph mark, its list
+    // level and its style are the only things about it that CAN change. Those
+    // arrive as `AttrStep`s, whose step map is empty: read the position off
+    // the step, or the save writes the paragraph's original XML and the edit
+    // is gone from the file while the editor still shows it.
+    test("tracks the paragraph an attribute step changed", () => {
+      const state = createState([
+        { text: "kept", paraId: "P1" },
+        { text: "", paraId: "P2" },
+      ]);
+      let position = 0;
+      state.doc.descendants((node, pos) => {
+        if (node.type.name === "paragraph" && node.attrs["paraId"] === "P2") {
+          position = pos;
+        }
+      });
+
+      const next = state.apply(
+        state.tr.setNodeAttribute(position, "pPrMark", {
+          kind: "del",
+          info: { id: 1, author: "a", date: "2000-01-01T00:00:00.000Z" },
+        }),
+      );
+
+      expect(getChangedParagraphIds(next).has("P2")).toBe(true);
+      expect(getChangedParagraphIds(next).has("P1")).toBe(false);
+      expect(hasStructuralChanges(next)).toBe(false);
+    });
+
+    test("reports an attribute step on a paragraph with no paraId as untracked", () => {
+      const state = createState([{ text: "" }]);
+
+      const next = state.apply(state.tr.setNodeAttribute(0, "pPrMark", null));
+
+      expect(hasUntrackedChanges(next)).toBe(true);
     });
   });
 

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -11,6 +11,7 @@ import type { EditorState, Transaction } from "prosemirror-state";
 import {
   AddMarkStep,
   AddNodeMarkStep,
+  AttrStep,
   RemoveMarkStep,
   RemoveNodeMarkStep,
 } from "prosemirror-transform";
@@ -195,7 +196,16 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
             continue;
           }
 
-          if (step instanceof AddNodeMarkStep || step instanceof RemoveNodeMarkStep) {
+          // `AttrStep` and the node-mark steps carry a position and an EMPTY
+          // step map, so the generic `stepMap.forEach` below never visits
+          // them. Reading their position directly is what keeps an
+          // attribute-only edit — a paragraph mark on a blank paragraph, a
+          // list level, a style id — from saving as the original XML.
+          if (
+            step instanceof AddNodeMarkStep ||
+            step instanceof RemoveNodeMarkStep ||
+            step instanceof AttrStep
+          ) {
             const pos = mapStepPosition(remap, step.pos, 1);
             const node = tr.doc.nodeAt(pos);
             if (!node) {

--- a/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.ts
@@ -20,9 +20,12 @@ function readOptionalColumn(dom: HTMLElement, attribute: string): number | undef
   return value === null ? undefined : readNonnegativeInteger(value);
 }
 
+/** The node name, for callers asking whether a paragraph holds any content. */
+export const BOOKMARK_BOUNDARY_NODE_NAME = "bookmarkBoundary";
+
 export const BookmarkBoundaryExtension = createNodeExtension<BookmarkBoundaryOptions>({
-  name: "bookmarkBoundary",
-  schemaNodeName: "bookmarkBoundary",
+  name: BOOKMARK_BOUNDARY_NODE_NAME,
+  schemaNodeName: BOOKMARK_BOUNDARY_NODE_NAME,
   nodeSpec: (options) => ({
     inline: true,
     group: "inline",

--- a/packages/core/src/prosemirror/extensions/nodes/RenderedPageBreakExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/RenderedPageBreakExtension.ts
@@ -2,9 +2,16 @@
 
 import { createNodeExtension } from "../create";
 
+/**
+ * The node name, for callers that have to ask whether anything is LEFT in a
+ * paragraph. This node is zero-width and carries no revision of its own, so a
+ * paragraph holding only these holds nothing a reader would see.
+ */
+export const RENDERED_PAGE_BREAK_NODE_NAME = "renderedPageBreak";
+
 export const RenderedPageBreakExtension = createNodeExtension({
-  name: "renderedPageBreak",
-  schemaNodeName: "renderedPageBreak",
+  name: RENDERED_PAGE_BREAK_NODE_NAME,
+  schemaNodeName: RENDERED_PAGE_BREAK_NODE_NAME,
   nodeSpec: {
     inline: true,
     group: "inline",

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxAnchorExtension.ts
@@ -13,9 +13,12 @@ type TextBoxAnchorOptions = {
   getInternalClipboardToken?: () => string;
 };
 
+/** The node name, for callers asking whether a paragraph holds any content. */
+export const TEXT_BOX_ANCHOR_NODE_NAME = "textBoxAnchor";
+
 export const TextBoxAnchorExtension = createNodeExtension<TextBoxAnchorOptions>({
-  name: "textBoxAnchor",
-  schemaNodeName: "textBoxAnchor",
+  name: TEXT_BOX_ANCHOR_NODE_NAME,
+  schemaNodeName: TEXT_BOX_ANCHOR_NODE_NAME,
   nodeSpec: (options) => ({
     inline: true,
     group: "inline",

--- a/packages/core/src/prosemirror/revisionCarriers.ts
+++ b/packages/core/src/prosemirror/revisionCarriers.ts
@@ -1,5 +1,7 @@
 import type { Node as PMNode } from "prosemirror-model";
 
+import { PARAGRAPH_MARK_CHANGE_KINDS, type ParagraphMarkChangeKind } from "@stll/docx-core/model";
+
 import { expectParagraphAttrs } from "./attrs";
 
 export type FolioNodeRevisionKind =
@@ -10,6 +12,24 @@ export type FolioNodeRevisionKind =
   | "tablePropertiesChanged"
   | "rowPropertiesChanged"
   | "cellPropertiesChanged";
+
+/**
+ * Which carrier each paragraph-mark kind reports as. A relocation's break
+ * resolves as the insertion or deletion it is; the kind exists so a reader is
+ * told the two ends belong together, not to change what resolving does.
+ *
+ * Total over the kinds by construction, so a kind the model gains has to be
+ * given a carrier here rather than silently reporting none.
+ */
+const PARAGRAPH_MARK_KIND_CARRIERS = {
+  ins: "paragraphMarkInserted",
+  moveTo: "paragraphMarkInserted",
+  del: "paragraphMarkDeleted",
+  moveFrom: "paragraphMarkDeleted",
+} as const satisfies Record<ParagraphMarkChangeKind, FolioNodeRevisionKind>;
+
+const isParagraphMarkChangeKind = (value: unknown): value is ParagraphMarkChangeKind =>
+  PARAGRAPH_MARK_CHANGE_KINDS.some((kind) => kind === value);
 
 export type FolioNodeRevisionCarrier = {
   id: number;
@@ -86,15 +106,16 @@ export const getFolioNodeRevisionCarriers = (
     const to = nodePos + node.nodeSize;
     const paragraphAttrs = expectParagraphAttrs(node);
     const paragraphMark = node.attrs["pPrMark"];
-    if (
-      isObjectRecord(paragraphMark) &&
-      (paragraphMark["kind"] === "ins" || paragraphMark["kind"] === "del")
-    ) {
+    const paragraphMarkKind =
+      isObjectRecord(paragraphMark) && isParagraphMarkChangeKind(paragraphMark["kind"])
+        ? PARAGRAPH_MARK_KIND_CARRIERS[paragraphMark["kind"]]
+        : undefined;
+    if (paragraphMarkKind !== undefined && isObjectRecord(paragraphMark)) {
       const metadata = revisionMetadata(paragraphMark["info"]);
       if (metadata) {
         carriers.push({
           ...metadata,
-          type: paragraphMark["kind"] === "ins" ? "paragraphMarkInserted" : "paragraphMarkDeleted",
+          type: paragraphMarkKind,
           text: node.textContent,
           from,
           to,

--- a/packages/core/src/prosemirror/zeroWidthAnchors.ts
+++ b/packages/core/src/prosemirror/zeroWidthAnchors.ts
@@ -1,0 +1,47 @@
+/**
+ * Inline nodes that occupy a position and show nothing.
+ *
+ * A bookmark boundary, a text-box anchor and Word's cached pagination
+ * boundary all exist so a position survives an edit. None of them is content:
+ * a reader sees no character where one sits, none carries a revision of its
+ * own, and the format has no way to say one was inserted or deleted outside a
+ * hyperlink.
+ *
+ * Two questions turn on that, and they used to be answered separately, which
+ * is how a deleted paragraph came back as a blank line holding an invisible
+ * anchor:
+ *
+ * - *Does deleting this block have to mark it?* No — marking it produces a
+ *   document the serializer refuses.
+ * - *Does it keep an emptied paragraph alive?* No — a paragraph left holding
+ *   only these is a paragraph whose content is gone.
+ */
+
+import type { Node as PMNode } from "prosemirror-model";
+
+import { BOOKMARK_BOUNDARY_NODE_NAME } from "./extensions/nodes/BookmarkBoundaryExtension";
+import { RENDERED_PAGE_BREAK_NODE_NAME } from "./extensions/nodes/RenderedPageBreakExtension";
+import { TEXT_BOX_ANCHOR_NODE_NAME } from "./extensions/nodes/TextBoxAnchorExtension";
+
+const ZERO_WIDTH_ANCHOR_NODE_NAMES: ReadonlySet<string> = new Set([
+  BOOKMARK_BOUNDARY_NODE_NAME,
+  RENDERED_PAGE_BREAK_NODE_NAME,
+  TEXT_BOX_ANCHOR_NODE_NAME,
+]);
+
+export const isZeroWidthAnchor = (node: PMNode): boolean =>
+  ZERO_WIDTH_ANCHOR_NODE_NAMES.has(node.type.name);
+
+/**
+ * Whether the textblock holds nothing but zero-width anchors, which is what
+ * "everything in it was resolved away" looks like in the document.
+ */
+export const holdsNoContent = (block: PMNode): boolean => {
+  let empty = true;
+  block.forEach((child) => {
+    if (!isZeroWidthAnchor(child)) {
+      empty = false;
+    }
+  });
+  return empty;
+};

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -338,8 +338,13 @@ describe("generateRedlineDocx", () => {
     expect(changes.length).toBeGreaterThan(0);
     expect(new Set(changes.map((change) => change.author))).toEqual(new Set(["folio compare"]));
 
-    // Invariant 1: the as-accepted view (snapshot) equals the revised document.
-    expect(blockTexts(acceptView)).toEqual(revisedTexts);
+    // Invariant 1: the as-accepted view (snapshot) equals the revised
+    // document, plus the paragraph the revision removed. Its runs and its
+    // paragraph mark both carry `w:del`, so it stands blank where it was,
+    // before the Omega paragraph, and closes away only once the deletion is
+    // accepted for real.
+    const removedClauseIndex = revisedTexts.indexOf("Omega paragraph closes the document.");
+    expect(blockTexts(acceptView)).toEqual(revisedTexts.toSpliced(removedClauseIndex, 0, ""));
 
     // Invariant 2: rejecting every change restores the base document.
     const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
@@ -460,9 +465,14 @@ describe("generateRedlineDocx", () => {
     expect(result.skipped).toEqual([]);
 
     const acceptView = await FolioDocxReviewer.fromBuffer(result.buffer);
+    // The relocated block is deleted where it stood and inserted again below.
+    // The deleted paragraph closed the body, so the break that went with it is
+    // the one before it: the preceding paragraph carries `w:pPr/w:rPr/w:del`.
+    // Until that is accepted the emptied paragraph is still there, blank.
     expect(blockTexts(acceptView)).toEqual([
       "Notices must be delivered in writing.",
       "Governing law shall be Czech law.",
+      "",
     ]);
 
     const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
@@ -535,7 +545,9 @@ describe("generateRedlineDocx", () => {
 
     const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
     rejectView.rejectAll();
-    expect(blockTexts(rejectView)).toEqual([]);
+    // The empty base is one blank paragraph, not nothing: a package always
+    // holds at least one. Rejecting the additions restores exactly that.
+    expect(blockTexts(rejectView)).toEqual([""]);
   });
 
   test("a custom author is recorded on the generated changes", async () => {

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -18,7 +18,7 @@ import {
   type FolioDocumentStoryHandle,
   type FolioResolvedReviewedView,
 } from "./ai-edits/headless";
-import { createFolioAITextRangeHandle } from "./ai-edits/snapshot";
+import { createFolioAITextRangeHandle, trailingBodyBlockId } from "./ai-edits/snapshot";
 import type {
   FolioAIBlock,
   FolioAIEditAppliedOperation,
@@ -158,7 +158,12 @@ const buildRedlineOperations = ({
   const anchorIds = nextBaseBlockIdByIndex(events);
   const operations: FolioAIEditOperation[] = [];
   const trailingAdditions: { text: string; styleId?: string }[] = [];
-  const lastBaseBlockId = baseSnapshot.blocks.at(-1)?.id ?? null;
+  // The last BODY-LEVEL paragraph, which the format guarantees exists: a table
+  // may not be the last child of a body. Anchoring to the last block put the
+  // anchor inside a table whenever the story ended with one, and an insertion
+  // anchored there escapes to the table's boundary with no mark able to
+  // express the break it added.
+  const lastBaseBlockId = trailingBodyBlockId(baseSnapshot);
 
   events.forEach((event, eventIndex) => {
     if (event.type === "pair") {
@@ -205,24 +210,14 @@ const buildRedlineOperations = ({
     });
   });
 
-  if (lastBaseBlockId === null && baseSnapshot.emptyDocumentAnchorId !== undefined) {
-    const firstAddition = trailingAdditions.shift();
-    if (firstAddition !== undefined) {
-      operations.push({
-        id: nextOperationId(),
-        type: "replaceBlock",
-        blockId: baseSnapshot.emptyDocumentAnchorId,
-        text: firstAddition.text,
-        ...(firstAddition.styleId !== undefined && { styleId: firstAddition.styleId }),
-      });
-    }
-  }
-
+  // An empty document is one blank paragraph, and the alignment pairs it with
+  // the first addition like any other block: it is replaced, and the rest
+  // follow it. There is no hidden anchor to special-case any more.
   for (const addition of trailingAdditions) {
     operations.push({
       id: nextOperationId(),
       type: "insertAfterBlock",
-      blockId: lastBaseBlockId ?? baseSnapshot.emptyDocumentAnchorId ?? "redline-unanchored",
+      blockId: lastBaseBlockId ?? "redline-unanchored",
       text: addition.text,
       ...(addition.styleId !== undefined && { styleId: addition.styleId }),
     });

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -29,6 +29,7 @@ export type {
 export {
   createFolioAITextRangeHandle,
   hashFolioAIBlockText,
+  isFolioAIContentBlock,
   normalizeFolioAIBlockText,
 } from "./ai-edits/snapshot";
 export { getFolioDocumentOutline, readFolioDocumentSection } from "./ai-edits/scoped-reading";

--- a/packages/core/src/types/block-id.test.ts
+++ b/packages/core/src/types/block-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  deriveBlankBlockId,
   deriveBlockId,
   getFolioParaIdFromBlockId,
   getSequentialFolioBlockIdIndex,
@@ -150,5 +151,29 @@ describe("getSequentialFolioBlockIdIndex", () => {
     expect(getSequentialFolioBlockIdIndex("seq-")).toBeNull();
     expect(getSequentialFolioBlockIdIndex("seq-abc")).toBeNull();
     expect(getSequentialFolioBlockIdIndex("seq-001")).toBeNull();
+  });
+});
+
+// `seq-` and `blank-` name ids this module generated, so a source paraId in
+// either shape would be read back as one and told apart from itself. Every
+// mint routes through these two functions, which is where the reservation
+// belongs.
+describe("the reserved id prefixes", () => {
+  test("a source paraId shaped like a generated id is not used verbatim", () => {
+    for (const paraId of ["seq-0001", "blank-0001", "seq-anything", "blank-x"]) {
+      expect(deriveBlockId({ paraId, index: 3, taken: new Set() })).toBe("seq-0003");
+      expect(deriveBlankBlockId({ paraId, index: 3, taken: new Set() })).toBe("blank-0003");
+    }
+  });
+
+  test("every id either resolves to its source paragraph or reports none", () => {
+    for (const paraId of ["AAAA0001", "seq-0001", "blank-0001", null]) {
+      for (const derive of [deriveBlockId, deriveBlankBlockId]) {
+        const id = derive({ paraId, index: 4, taken: new Set() });
+        expect(isFolioBlockId(id)).toBe(true);
+        const source = getFolioParaIdFromBlockId(id);
+        expect(source === null || source === paraId).toBe(true);
+      }
+    }
   });
 });

--- a/packages/core/src/types/block-id.ts
+++ b/packages/core/src/types/block-id.ts
@@ -10,17 +10,28 @@
  * branded type makes the divergence a compile-time error rather
  * than a silent "scrollToBlock retries 20 times and gives up".
  *
- * Two id shapes are allowed:
+ * Three id shapes are allowed:
  * - Word's `w14:paraId` (or any non-empty allocator-generated id),
  *   surfaced verbatim when the source paragraph carries one.
  * - A zero-padded `seq-NNNN` fallback derived from document order,
  *   used when the paragraph has no paraId or the paraId collides
  *   with one already taken in the same derivation pass.
+ * - A zero-padded `blank-NNNN` fallback for a paragraph that holds no
+ *   text, numbered in its own sequence.
+ *
+ * The two sequences are separate on purpose. `seq-NNNN` counts the
+ * paragraphs that carry text, and that count is the published
+ * contract: the server extractor derives the same numbers, and a
+ * citation stored against one has to keep naming the same paragraph.
+ * Numbering blank paragraphs into the same sequence would renumber
+ * every stored citation after the first blank line in a document.
  */
 
 const SEQUENTIAL_BLOCK_ID_PREFIX = "seq-";
+const BLANK_BLOCK_ID_PREFIX = "blank-";
 const SEQUENTIAL_BLOCK_ID_PADDING = 4;
 const SEQUENTIAL_BLOCK_ID_PATTERN = /^seq-\d{4,}$/u;
+const BLANK_BLOCK_ID_PATTERN = /^blank-\d{4,}$/u;
 
 export type FolioBlockId = string & { readonly __brand: "folio.blockId" };
 
@@ -40,8 +51,11 @@ export type DeriveBlockIdInput = {
   taken: ReadonlySet<string>;
 };
 
+const formatWithPrefix = (prefix: string, index: number): string =>
+  `${prefix}${String(index).padStart(SEQUENTIAL_BLOCK_ID_PADDING, "0")}`;
+
 const formatSequentialBlockId = (index: number): string =>
-  `${SEQUENTIAL_BLOCK_ID_PREFIX}${String(index).padStart(SEQUENTIAL_BLOCK_ID_PADDING, "0")}`;
+  formatWithPrefix(SEQUENTIAL_BLOCK_ID_PREFIX, index);
 
 /**
  * The opaque `FolioBlockId` brand has no constructor; an unchecked
@@ -51,9 +65,29 @@ const formatSequentialBlockId = (index: number): string =>
  */
 const brand = (value: string): FolioBlockId => value as unknown as FolioBlockId;
 
+/**
+ * Whether a source id would be read back as one this module generated.
+ *
+ * `seq-` and `blank-` are reserved: `getFolioParaIdFromBlockId` reports an id
+ * in either shape as having no source paragraph, and `isFolioBlockId` holds
+ * both to their exact pattern. A `w14:paraId` that happened to look like one
+ * would therefore be told apart from itself, so it is not used verbatim and
+ * the paragraph takes a generated id instead. (A real `w14:paraId` is eight
+ * hex digits, so this costs nothing on any package Word writes; it is here so
+ * a hand-written or synthesized source cannot break the round trip.)
+ */
+const isReservedShape = (paraId: string): boolean =>
+  paraId.startsWith(SEQUENTIAL_BLOCK_ID_PREFIX) || paraId.startsWith(BLANK_BLOCK_ID_PREFIX);
+
+const usableParaId = (paraId: string | null, taken: ReadonlySet<string>): string | null =>
+  paraId !== null && paraId.length > 0 && !taken.has(paraId) && !isReservedShape(paraId)
+    ? paraId
+    : null;
+
 export const deriveBlockId = ({ paraId, index, taken }: DeriveBlockIdInput): FolioBlockId => {
-  if (paraId !== null && paraId.length > 0 && !taken.has(paraId)) {
-    return brand(paraId);
+  const usable = usableParaId(paraId, taken);
+  if (usable !== null) {
+    return brand(usable);
   }
   let candidate = index;
   let formatted = formatSequentialBlockId(candidate);
@@ -64,8 +98,29 @@ export const deriveBlockId = ({ paraId, index, taken }: DeriveBlockIdInput): Fol
   return brand(formatted);
 };
 
+/**
+ * The id for a paragraph that holds no text, when it carries no
+ * paraId to be named by. Numbered in its own sequence so the
+ * published `seq-NNNN` positions stay where they are.
+ */
+export const deriveBlankBlockId = ({ paraId, index, taken }: DeriveBlockIdInput): FolioBlockId => {
+  const usable = usableParaId(paraId, taken);
+  if (usable !== null) {
+    return brand(usable);
+  }
+  let candidate = index;
+  let formatted = formatWithPrefix(BLANK_BLOCK_ID_PREFIX, candidate);
+  while (taken.has(formatted)) {
+    candidate += 1;
+    formatted = formatWithPrefix(BLANK_BLOCK_ID_PREFIX, candidate);
+  }
+  return brand(formatted);
+};
+
 export const isSequentialFolioBlockId = (id: string): boolean =>
   SEQUENTIAL_BLOCK_ID_PATTERN.test(id);
+
+export const isBlankFolioBlockId = (id: string): boolean => BLANK_BLOCK_ID_PATTERN.test(id);
 
 /**
  * Extract the paraId an id was derived from, if any. Returns `null`
@@ -74,7 +129,7 @@ export const isSequentialFolioBlockId = (id: string): boolean =>
  * without an upfront brand check.
  */
 export const getFolioParaIdFromBlockId = (id: string): string | null =>
-  isSequentialFolioBlockId(id) ? null : id;
+  isSequentialFolioBlockId(id) || isBlankFolioBlockId(id) ? null : id;
 
 /**
  * The 1-based document position encoded in a sequential fallback id
@@ -108,6 +163,9 @@ export const isFolioBlockId = (value: unknown): value is FolioBlockId => {
   // not by an exhaustive format check here.
   if (value.startsWith(SEQUENTIAL_BLOCK_ID_PREFIX)) {
     return SEQUENTIAL_BLOCK_ID_PATTERN.test(value);
+  }
+  if (value.startsWith(BLANK_BLOCK_ID_PREFIX)) {
+    return BLANK_BLOCK_ID_PATTERN.test(value);
   }
   return true;
 };

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1396,22 +1396,37 @@ export type ParagraphContent =
   | MathEquation;
 
 /**
- * Paragraph (w:p)
- */
-/**
- * Paragraph-mark tracked-change marker (ECMA-376 §17.13.5).
+ * The kinds a paragraph-mark tracked change can be (ECMA-376 §17.13.5).
  *
- * Word writes this as a child of `<w:pPr><w:rPr>` — `<w:ins/>` when the
- * paragraph break itself was inserted in track-changes mode (the user
- * pressed Enter mid-paragraph), `<w:del/>` when the paragraph break is
- * pending deletion (Backspace at paragraph start or Delete at paragraph
- * end). The mark is independent of the inline runs the paragraph carries.
+ * Written as a child of `<w:pPr><w:rPr>` — `<w:ins/>` when the paragraph
+ * break itself was inserted in track-changes mode (the user pressed Enter
+ * mid-paragraph), `<w:del/>` when the paragraph break is pending deletion
+ * (Backspace at paragraph start or Delete at paragraph end). The mark is
+ * independent of the inline runs the paragraph carries.
+ *
+ * A relocated paragraph's break is `<w:moveFrom/>` at the source and
+ * `<w:moveTo/>` at the destination. They resolve exactly as `del` and `ins`
+ * do — a move is a deletion and an insertion that a reader is told belong
+ * together — but they are not those kinds: writing `w:del` on a moved
+ * paragraph's mark reports the relocation as a deletion as well.
  */
+export const PARAGRAPH_MARK_CHANGE_KINDS = Object.freeze([
+  "moveFrom",
+  "moveTo",
+  "ins",
+  "del",
+] as const);
+
+/** One of {@link PARAGRAPH_MARK_CHANGE_KINDS}. */
+export type ParagraphMarkChangeKind = (typeof PARAGRAPH_MARK_CHANGE_KINDS)[number];
+
+/** A paragraph-mark tracked change, written under `<w:pPr><w:rPr>`. */
 export type ParagraphMarkChange = {
-  kind: "ins" | "del";
+  kind: ParagraphMarkChangeKind;
   info: TrackedChangeInfo;
 };
 
+/** Paragraph (w:p) */
 export type Paragraph = {
   type: "paragraph";
   /** Unique paragraph ID */

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -69,6 +69,7 @@ export {
   isOoxmlSymbolCharacter,
   MAX_REVISION_ID,
   normalizeRevisionId,
+  PARAGRAPH_MARK_CHANGE_KINDS,
 } from "./content";
 
 export type {
@@ -141,6 +142,7 @@ export type {
   ParagraphContent,
   Paragraph,
   ParagraphMarkChange,
+  ParagraphMarkChangeKind,
   HeaderFooterType,
   HeaderReference,
   FooterReference,


### PR DESCRIPTION
The AI-facing snapshot skipped every paragraph with no words. A blank line had
no id, no operation could address it, and a comparison could neither add one
nor take one away — it could only report the difference it was unable to
represent.

## Blanks are blocks

They take an additive `blank-NNNN` id. The published `seq-NNNN` numbering runs
over the paragraphs that carry words and is unchanged, so a stored citation
still names its paragraph; a property pins that the `seq-` ids are identical
with and without blanks present. Every reading surface filters blanks through
one shared helper rather than five inline conditions.

Three operations follow, documented in the operation reference and the agent
guidance:

- `insertAfterBlock` / `insertBeforeBlock` with `text: ""` insert a blank
  paragraph. Only an operation that would leave the document as it was is
  still refused.
- `deleteBlock` on a blank removes it, its paragraph mark tracked.
- `insertTableRow` sizes the row against the table's own column count rather
  than against the cells the row happens to build, so a row a table can hold is
  no longer refused because a cell in it spans columns.

A cell holds paragraphs, not lines, so a line break in `insertTable`'s or
`insertTableRow`'s cell text starts a new paragraph in that cell and a blank
line is a blank paragraph. That is deliberately not the prose rule
`insertAfterBlock` follows, where a blank line between two model-written
clauses is formatting noise and is dropped: a cell's text describes paragraphs
that exist, and dropping one would lose a block. Both rules are stated on the
operations they belong to.

## Five defects the blanks made visible

Each was already losing content; a blank paragraph is simply the shape in which
the loss becomes a block you can see.

- **An attribute-only edit never reached the file.** The change tracker reads a
  position off each transaction step, and `AttrStep` carries an empty step map,
  so a paragraph whose only change was its mark, its list level or its style was
  never recorded as changed. The selective save then wrote back its original
  XML: the edit was gone from the document while the editor still showed it.
- **Deleting a block left its images.** The deletion range is built from the
  block's text, so an image outside the words kept no mark and accepting the
  deletion left a paragraph standing around an orphan picture.
- **Zero-width anchors counted as content.** A bookmark boundary, a text-box
  anchor and Word's cached pagination boundary each outlived a deletion that
  took every word, leaving a blank line behind. A revision landing on one also
  produces a document the serializer refuses to write, because the format
  cannot say a bookmark boundary was inserted or deleted outside a hyperlink.
  One module owns what they are, and one guard strips revisions off them.
- **Resolving a paragraph's mark could take a section with it.** A section's
  properties live on a paragraph mark, so the paragraph is where the section
  ends. Removing it merged two sections into one and dropped the removed one's
  page size, margins and header and footer references. They travel to the
  paragraph the resolution leaves behind now, and a paragraph with nothing
  after it to carry them keeps its mark instead.
- **Appending at the end of a container handed the new paragraph's mark to the
  anchor.** That reads closer to what an editor writes and is equivalent only
  while the two stay adjacent. A table inserted between them by a later
  operation in the same batch separates them; the mark then joins the anchor to
  the table, which is nothing, and the appended paragraph survives a reject
  that should have closed it. Every inserted paragraph carries its own mark now,
  and a mark with nothing after it resolves by removing the emptied paragraph
  rather than by joining.

The compare README states the two container rules both fixes turn on: a body
and every table cell end with a paragraph, and a mark with no paragraph after
it resolves by removal rather than by joining.

## Coverage

- A property over generated documents — blank paragraphs, hidden rows, nested
  tables, tables at container edges — that every block of a snapshot resolves
  back to the block it was taken from, so the snapshot walk and the live walk
  cannot drift apart.
- Unit tests for an attribute-only edit reaching the tracker, for a block
  deletion taking an image and sparing a bookmark boundary, and for each
  zero-width anchor failing to keep an emptied paragraph alive.
- A test that a section survives the resolution of the mark it sat on, in both
  the joinable and the non-joinable case.
- The compare fixture builder can now write a hidden row and a nested table, so
  those shapes are generated rather than described.

The benchmark's generated documents obey the container rule now: a class that
ended its body on a table gets the paragraph the format requires, and the
table-count variant adds its table before the body's closing paragraph rather
than after it. A body ending in a table is malformed input — the engine has to
survive it, but it measured nothing about the edit, because there is no anchor
to append after and the comparison could only report a difference it was unable
to place.

Digests were re-recorded, with the reason recorded beside the baseline in the
benchmark README: the generated documents changed, and so did the redline's
shape where a paragraph is appended at a container's edge, where a deleted
block held an image, and wherever a revision used to land on a zero-width
anchor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Blank paragraphs are preserved as addressable blocks with dedicated identifiers.
  - Added support for inserting and deleting blank paragraphs.
  - Table rows now match the table’s column count and support multi-paragraph cell content.
  - Added public helpers for identifying content blocks.

- **Bug Fixes**
  - Improved tracked changes involving images, anchors, paragraph marks, section properties and deleted blocks.
  - Attribute-only edits to blank paragraphs are now saved correctly.
  - Fixed handling of documents ending with tables and hidden table rows.

- **Documentation**
  - Updated guidance for blank paragraphs, table-row operations and public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->