### PR TITLE
fix(core): preserve rounding tolerance for legacy justified lines

### DIFF
--- a/.changeset/lucky-lines-measure.md
+++ b/.changeset/lucky-lines-measure.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep the last word of a justified line that fills its measure exactly in documents that predate the current justification rules.

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1237,6 +1237,34 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
+  test.each([
+    { slack: 0.25, expectedLines: 1, label: "keeps" },
+    { slack: 2, expectedLines: 2, label: "drops" },
+  ])(
+    "$label the last word of a legacy justified line that misses the measure by $slack px",
+    ({ slack, expectedLines }) => {
+      withFakeTextMeasure(
+        () => {
+          const measure = measureParagraph(
+            {
+              kind: "paragraph",
+              id: "legacy-justified-sub-pixel-fit",
+              runs: [{ kind: "text", text: `${"a".repeat(9)} b` }],
+              attrs: {
+                alignment: "justify",
+                justificationCompatibility: { type: "legacy" },
+              },
+            },
+            110 - slack,
+          );
+
+          expect(measure.lines).toHaveLength(expectedLines);
+        },
+        { charWidth: fixedCharWidth(10) },
+      );
+    },
+  );
+
   test("does not count non-breaking spaces toward justified shrink capacity", () => {
     const fixedSpaceText = `${"a".repeat(99)}\u00a0bbb`;
 

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -645,7 +645,6 @@ function uppercaseLetterRatio(text: string): number {
 }
 
 type JustifyFitStrategy =
-  | { type: "strict" }
   | { type: "rounding" }
   | { type: "space"; ratio: number; maxWidthRatio?: number }
   | { type: "width"; ratio: number };
@@ -661,7 +660,9 @@ function resolveJustifyFitStrategy(
   profile: JustificationProfile,
 ): JustifyFitStrategy {
   if (block.attrs?.justificationCompatibility?.type === "legacy") {
-    return { type: "strict" };
+    // No space contraction, but the fit test still absorbs sub-pixel
+    // accumulation the way an unjustified paragraph does.
+    return { type: "rounding" };
   }
   if (isShallowFullHangingListContinuation(block, isFirstLine)) {
     return { type: "rounding" };
@@ -828,9 +829,6 @@ function justifyFitTolerance(
   strategy: JustifyFitStrategy,
   candidateSpaceWidth: number,
 ): number {
-  if (strategy.type === "strict") {
-    return 0;
-  }
   if (strategy.type === "rounding") {
     return WIDTH_TOLERANCE;
   }


### PR DESCRIPTION
Legacy justified paragraphs could wrap their last word when accumulated text widths exceeded the line measure by a fraction of a pixel. Use the existing rounding tolerance while continuing to reject space contraction.

All 133 paragraph-measurement tests pass. Restoring the previous implementation makes the new 0.25 px regression fail; the 2 px overflow case still wraps. The repository dependency audit passes. Full validation runs in CI.
