### PR TITLE
fix: synchronize all Rust workspace versions during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "api:check": "bun scripts/api-reports.ts",
     "api:budget": "bun scripts/api-surface-budget.ts --check",
     "api:budget:write": "bun run api:update && bun scripts/api-surface-budget.ts --write",
-    "changeset:version": "changeset version && bun scripts/sync-docx-kernel-version.ts --write && bun scripts/check-lockfile-workspace-versions.ts --write && bun install --frozen-lockfile && bun --filter '@stll/docx-core' wasm:generate",
+    "changeset:version": "changeset version && bun scripts/sync-docx-kernel-version.ts --write && bun scripts/check-lockfile-workspace-versions.ts --write && bun install --frozen-lockfile && bun --filter '*' wasm:generate",
     "bench": "bun benchmarks/index.ts",
     "bench:cross-language": "bun benchmarks/cross-language/run.ts",
     "parity": "bun parity/cli.ts",

--- a/scripts/bun-lock-workspace-versions.test.ts
+++ b/scripts/bun-lock-workspace-versions.test.ts
@@ -51,13 +51,13 @@ describe("bun.lock workspace self-version synchronization", () => {
     ]);
   });
 
-  test("release versioning synchronizes lock and generated kernel artifacts", () => {
+  test("release versioning synchronizes lock and all generated workspace artifacts", () => {
     const command = packageJson.scripts["changeset:version"];
 
     expect(command).not.toMatch(/\brm\b/);
     expect(command).toContain("sync-docx-kernel-version.ts --write");
     expect(command).toContain("check-lockfile-workspace-versions.ts --write");
     expect(command).toContain("bun install --frozen-lockfile");
-    expect(command).toEndWith("bun --filter '@stll/docx-core' wasm:generate");
+    expect(command).toEndWith("bun --filter '*' wasm:generate");
   });
 });

--- a/scripts/sync-docx-kernel-version.test.ts
+++ b/scripts/sync-docx-kernel-version.test.ts
@@ -21,19 +21,15 @@ test("version changes synchronize every inherited crate and reach a fixed point"
       path.join(root, "Cargo.toml"),
       '[workspace]\nmembers = ["crates/*"]\nresolver = "2"\n\n[workspace.package]\nversion = "1.0.0"\n',
     );
-    const names = [
-      "stella-docx-kernel",
-      "stella-text-shaper",
-      "future-member",
-      "independent-member",
-    ];
+    const independentMember = "independent-member";
+    const names = ["stella-docx-kernel", "stella-text-shaper", "future-member", independentMember];
     for (const name of names) {
       const crate = path.join(root, "crates", name);
       await mkdir(path.join(crate, "src"), { recursive: true });
       await writeFile(path.join(crate, "src/lib.rs"), "pub const VALUE: u8 = 1;\n");
       await writeFile(
         path.join(crate, "Cargo.toml"),
-        `[package]\nname = "${name}"\n${name === "independent-member" ? 'version = "0.5.0"' : "version.workspace = true"}\nedition = "2021"\n`,
+        `[package]\nname = "${name}"\n${name === independentMember ? 'version = "0.5.0"' : "version.workspace = true"}\nedition = "2021"\n`,
       );
     }
     const run = (command: string[]) =>
@@ -54,7 +50,7 @@ test("version changes synchronize every inherited crate and reach a fixed point"
       const lock = await readFile(path.join(root, "Cargo.lock"), "utf8");
       for (const name of names) {
         expect(lock).toContain(
-          `name = "${name}"\nversion = "${name === "independent-member" ? "0.5.0" : version}"`,
+          `name = "${name}"\nversion = "${name === independentMember ? "0.5.0" : version}"`,
         );
       }
       expect(check().exitCode).toBe(0);

--- a/scripts/sync-docx-kernel-version.test.ts
+++ b/scripts/sync-docx-kernel-version.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test";
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+test("version changes synchronize every inherited crate and reach a fixed point", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "folio-cargo-version-"));
+  try {
+    await mkdir(path.join(root, "scripts"));
+    await mkdir(path.join(root, "packages/docx-core"), { recursive: true });
+    await cp(
+      import.meta.path.replace(".test.ts", ".ts"),
+      path.join(root, "scripts/sync-docx-kernel-version.ts"),
+    );
+    await symlink(
+      path.resolve(import.meta.dir, "../node_modules"),
+      path.join(root, "node_modules"),
+      "dir",
+    );
+    await writeFile(
+      path.join(root, "Cargo.toml"),
+      '[workspace]\nmembers = ["crates/*"]\nresolver = "2"\n\n[workspace.package]\nversion = "1.0.0"\n',
+    );
+    const names = [
+      "stella-docx-kernel",
+      "stella-text-shaper",
+      "future-member",
+      "independent-member",
+    ];
+    for (const name of names) {
+      const crate = path.join(root, "crates", name);
+      await mkdir(path.join(crate, "src"), { recursive: true });
+      await writeFile(path.join(crate, "src/lib.rs"), "pub const VALUE: u8 = 1;\n");
+      await writeFile(
+        path.join(crate, "Cargo.toml"),
+        `[package]\nname = "${name}"\n${name === "independent-member" ? 'version = "0.5.0"' : "version.workspace = true"}\nedition = "2021"\n`,
+      );
+    }
+    const run = (command: string[]) =>
+      Bun.spawnSync(command, { cwd: root, env: { ...process.env, CARGO_NET_OFFLINE: "true" } });
+    const synchronize = () =>
+      run([process.execPath, "scripts/sync-docx-kernel-version.ts", "--write"]);
+    const check = () => run([process.execPath, "scripts/sync-docx-kernel-version.ts"]);
+    expect(run(["cargo", "generate-lockfile"]).exitCode).toBe(0);
+    const initialLock = await readFile(path.join(root, "Cargo.lock"), "utf8");
+    for (const version of ["2.0.0", "2.0.1", "1.0.0"]) {
+      await writeFile(
+        path.join(root, "packages/docx-core/package.json"),
+        JSON.stringify({ version }),
+      );
+      expect(check().exitCode).not.toBe(0);
+      const result = synchronize();
+      expect(result.exitCode).toBe(0);
+      const lock = await readFile(path.join(root, "Cargo.lock"), "utf8");
+      for (const name of names) {
+        expect(lock).toContain(
+          `name = "${name}"\nversion = "${name === "independent-member" ? "0.5.0" : version}"`,
+        );
+      }
+      expect(check().exitCode).toBe(0);
+      expect(synchronize().exitCode).toBe(0);
+      expect(await readFile(path.join(root, "Cargo.lock"), "utf8")).toBe(lock);
+    }
+    expect(await readFile(path.join(root, "Cargo.lock"), "utf8")).toBe(initialLock);
+    const lockPath = path.join(root, "Cargo.lock");
+    await writeFile(
+      lockPath,
+      initialLock.replace(
+        'name = "stella-text-shaper"\nversion = "1.0.0"',
+        'name = "stella-text-shaper"\nversion = "0.9.0"',
+      ),
+    );
+    expect(check().exitCode).not.toBe(0);
+    expect(synchronize().exitCode).toBe(0);
+    expect(await readFile(lockPath, "utf8")).toBe(initialLock);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/scripts/sync-docx-kernel-version.ts
+++ b/scripts/sync-docx-kernel-version.ts
@@ -12,7 +12,6 @@ if (process.argv.length > 3 || (process.argv[2] !== undefined && !write)) {
 const repoRoot = path.resolve(import.meta.dir, "..");
 const packageJsonPath = path.join(repoRoot, "packages", "docx-core", "package.json");
 const cargoManifestPath = path.join(repoRoot, "Cargo.toml");
-const cargoLockPath = path.join(repoRoot, "Cargo.lock");
 const packageJson = (await Bun.file(packageJsonPath).json()) as { version?: unknown };
 if (typeof packageJson.version !== "string") {
   panic("@stll/docx-core package.json has no string version");
@@ -23,11 +22,6 @@ const manifestVersionPattern = /(\[workspace\.package\][\s\S]*?\nversion = ")([^
 const manifestMatch = manifest.match(manifestVersionPattern);
 const manifestVersion = manifestMatch?.[2] ?? panic("Cargo workspace package version is missing");
 
-const lock = await readFile(cargoLockPath, "utf8");
-const lockVersionPattern = /(\[\[package\]\]\nname = "stella-docx-kernel"\nversion = ")([^"]+)(")/u;
-const lockMatch = lock.match(lockVersionPattern);
-const lockVersion = lockMatch?.[2] ?? panic("stella-docx-kernel Cargo.lock entry is missing");
-
 if (write) {
   await writeFile(
     cargoManifestPath,
@@ -37,20 +31,23 @@ if (write) {
         `${prefix}${packageJson.version}${suffix}`,
     ),
   );
-  await writeFile(
-    cargoLockPath,
-    lock.replace(
-      lockVersionPattern,
-      (_match, prefix: string, _version: string, suffix: string) =>
-        `${prefix}${packageJson.version}${suffix}`,
-    ),
-  );
+  // Cargo owns the lock graph, including every crate inheriting the workspace version.
+  const update = Bun.spawnSync(["cargo", "update", "--workspace"], {
+    cwd: repoRoot,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  if (update.exitCode !== 0) panic("Failed to synchronize Cargo workspace lock versions");
   console.log(`Synchronized DOCX kernel to ${packageJson.version}`);
 } else {
-  if (manifestVersion !== packageJson.version || lockVersion !== packageJson.version) {
-    panic(
-      `DOCX kernel version drift: npm=${packageJson.version}, Cargo.toml=${manifestVersion}, Cargo.lock=${lockVersion}`,
-    );
+  if (manifestVersion !== packageJson.version) {
+    panic(`DOCX kernel version drift: npm=${packageJson.version}, Cargo.toml=${manifestVersion}`);
   }
+  const metadata = Bun.spawnSync(["cargo", "metadata", "--locked", "--format-version", "1"], {
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "inherit",
+  });
+  if (metadata.exitCode !== 0) panic("Cargo.lock is not synchronized with the workspace");
   console.log(`DOCX kernel version ${packageJson.version} is synchronized`);
 }


### PR DESCRIPTION
Release versioning updated only the DOCX kernel lock entry even though multiple Rust crates inherit the workspace version, causing locked Cargo metadata to reject the version bump. Let Cargo synchronize the workspace lock graph, validate the complete graph in check mode, and regenerate every workspace WASM artifact after shared Cargo inputs change.

The offline integration regression covers multiple inherited crates, an independently versioned crate, upgrades, downgrades, stale sibling entries, and fixed points. Restoring the previous script makes it fail on the unsynchronized sibling; focused tests, scoped lint, formatting, and dependency audit pass.

A disposable-checkout run of the complete `bun run changeset:version` command passed, including both WASM generators and their loadability/size gates. The Cargo.lock delta contains only the two inherited workspace crate version bumps; registry dependencies remain unchanged.
