### PR TITLE
fix: preserve bookmarks inside tracked revisions

### DIFF
--- a/.changeset/tracked-bookmark-boundaries.md
+++ b/.changeset/tracked-bookmark-boundaries.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": minor
+"@stll/folio-core": minor
+---
+
+Preserve bookmark boundaries inside tracked inline changes so accepting and rejecting revisions keeps bookmark ownership intact.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -147,7 +147,7 @@ export type ConditionalFormatStyle = {
 export type Deletion = {
     type: "deletion";
     info: TrackedChangeInfo;
-    content: (Run | Hyperlink)[];
+    content: TrackedRunContent[];
 };
 
 // @public
@@ -493,7 +493,7 @@ export type InlineSdt = {
 export type Insertion = {
     type: "insertion";
     info: TrackedChangeInfo;
-    content: (Run | Hyperlink)[];
+    content: TrackedRunContent[];
 };
 
 // @public
@@ -584,7 +584,7 @@ export type MediaFile = {
 export type MoveFrom = {
     type: "moveFrom";
     info: TrackedChangeInfo;
-    content: (Run | Hyperlink)[];
+    content: TrackedRunContent[];
 };
 
 // @public
@@ -604,7 +604,7 @@ export type MoveFromRangeStart = {
 export type MoveTo = {
     type: "moveTo";
     info: TrackedChangeInfo;
-    content: (Run | Hyperlink)[];
+    content: TrackedRunContent[];
 };
 
 // @public
@@ -1411,6 +1411,9 @@ export type TrackedChangeInfo = {
 
 // @public
 export type TrackedRunChange = Insertion | Deletion | MoveFrom | MoveTo;
+
+// @public
+export type TrackedRunContent = Run | Hyperlink | BookmarkStart | BookmarkEnd;
 
 // @public
 export type UnderlineStyle = "none" | "single" | "words" | "double" | "thick" | "dotted" | "dottedHeavy" | "dash" | "dashedHeavy" | "dashLong" | "dashLongHeavy" | "dotDash" | "dashDotHeavy" | "dotDotDash" | "dashDotDotHeavy" | "wave" | "wavyHeavy" | "wavyDouble";

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -4796,9 +4796,8 @@ describe("deleteBlock over inline content that is not text", () => {
     expect(view.state.doc.child(0).textContent).toBe("kept");
   });
 
-  // A bookmark boundary is zero-width, and the format cannot say one was
-  // deleted outside a hyperlink: marking it produces a document the serializer
-  // refuses to write, and leaving it must not keep the paragraph alive.
+  // A bookmark boundary is zero-width. Deleting the surrounding words did not
+  // delete the bookmark itself, and leaving it must not keep the paragraph alive.
   test("leaves a bookmark boundary unmarked and still removes the paragraph", () => {
     const view = deleteSecondBlock([schema.node("bookmarkBoundary"), schema.text("words")]);
 

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -252,12 +252,10 @@ const REVISION_MARK_NAMES: ReadonlySet<string> = new Set(["insertion", "deletion
  * Strip insertion and deletion marks from the zero-width anchors the batch
  * touched.
  *
- * An operation marks a RANGE, and a bookmark boundary between two words is
- * inside it. The format has no way to say a bookmark boundary was inserted or
- * deleted outside a hyperlink, so a document carrying one is a document the
- * serializer refuses to write — an edit that applied cleanly and then could
- * not be saved. Marking is by range everywhere, so the guard is here, once,
- * rather than at each of the dozen call sites that would have to remember.
+ * An operation marks a RANGE, and a zero-width anchor between two words is
+ * inside it. The operation did not create or delete that anchor, so the anchor
+ * must keep its existing revision ownership. Marking is by range everywhere;
+ * the guard lives here once rather than at every call site.
  */
 const withoutRevisionsOnZeroWidthAnchors = (
   tr: Transaction,
@@ -290,9 +288,8 @@ const withoutRevisionsOnZeroWidthAnchors = (
  * positions in `tr.doc`.
  *
  * Skips what is already deleted, so an earlier revision's run is not marked
- * twice, and skips the zero-width anchors: they are not content, and the
- * format cannot say one was deleted outside a hyperlink, so marking one
- * produces a document the serializer refuses to write.
+ * twice, and skips zero-width anchors because the operation did not create or
+ * delete them; their existing revision ownership must remain unchanged.
  */
 const undeletedContentAtomRanges = (
   tr: Transaction,

--- a/packages/core/src/compare/bookmarkSerialization.test.ts
+++ b/packages/core/src/compare/bookmarkSerialization.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { buildBodySequenceDocx } from "./__fixtures__/body-sequence";
+import { compareDocx } from "./compare";
+
+const documentPartOf = async (buffer: ArrayBuffer): Promise<string> =>
+  (await (await JSZip.loadAsync(buffer)).file("word/document.xml")?.async("string")) ?? "";
+
+const withTrackedBookmark = async (type: "ins" | "del", text: string): Promise<ArrayBuffer> => {
+  const buffer = await buildBodySequenceDocx([{ kind: "paragraph", text: "Before after." }]);
+  const zip = await JSZip.loadAsync(buffer);
+  const xml = await documentPartOf(buffer);
+  const textElement = type === "del" ? "delText" : "t";
+  const tracked =
+    `<w:${type} w:id="7" w:author="Reviewer" w:date="2026-09-06T12:00:00Z">` +
+    '<w:bookmarkStart w:id="9" w:name="TrackedTerm"/>' +
+    `<w:r><w:${textElement}>${text}</w:${textElement}></w:r>` +
+    '<w:bookmarkEnd w:id="9"/>' +
+    `</w:${type}>`;
+  zip.file(
+    "word/document.xml",
+    xml.replace(
+      '<w:r><w:t xml:space="preserve">Before after.</w:t></w:r>',
+      `<w:r><w:t xml:space="preserve">Before </w:t></w:r>${tracked}<w:r><w:t>after.</w:t></w:r>`,
+    ),
+  );
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
+describe("tracked bookmark serialization", () => {
+  test("compare removes a deleted bookmark with its accepted revision", async () => {
+    const base = await withTrackedBookmark("del", "deleted ");
+    const target = await buildBodySequenceDocx([{ kind: "paragraph", text: "Before after." }]);
+    const result = await compareDocx(base, target, {
+      author: "compare",
+      timestamp: "2026-09-06T12:00:00.000Z",
+    });
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.verification).toEqual({ status: "verified" });
+    const xml = await documentPartOf(result.value.buffer);
+    expect(xml).not.toContain("bookmarkStart");
+    expect(xml).not.toContain("bookmarkEnd");
+    expect(xml).not.toContain("deleted");
+  });
+
+  test("rejecting an inserted range removes its bookmark boundaries", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await withTrackedBookmark("ins", "inserted "),
+    );
+    const story = reviewer.listStories().at(0)?.handle;
+    if (!story) {
+      throw new Error("Expected document story");
+    }
+    reviewer.resolveReviewedStory({ story, view: "original" });
+
+    const xml = await documentPartOf(await reviewer.toBuffer());
+    expect(xml).not.toContain("bookmarkStart");
+    expect(xml).not.toContain("bookmarkEnd");
+    expect(xml).not.toContain("inserted");
+  });
+});

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -14,6 +14,49 @@ function parseParagraphXml(xml: string) {
 }
 
 describe("parseParagraph tracked-change hardening", () => {
+  for (const { tag, type, deleted } of [
+    { tag: "ins", type: "insertion", deleted: false },
+    { tag: "del", type: "deletion", deleted: true },
+    { tag: "moveFrom", type: "moveFrom", deleted: true },
+    { tag: "moveTo", type: "moveTo", deleted: false },
+  ] as const) {
+    test(`keeps bookmark boundaries inside w:${tag}`, () => {
+      const textTag = deleted ? "delText" : "t";
+      const paragraph = parseParagraphXml(`
+        <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:${tag} w:id="7" w:author="Reviewer">
+            <w:bookmarkStart w:id="9" w:name="TrackedTerm"/>
+            <w:r><w:${textTag}>term</w:${textTag}></w:r>
+            <w:bookmarkEnd w:id="9"/>
+          </w:${tag}>
+        </w:p>
+      `);
+
+      const change = paragraph.content.at(0);
+      expect(change?.type).toBe(type);
+      if (
+        !change ||
+        (change.type !== "insertion" &&
+          change.type !== "deletion" &&
+          change.type !== "moveFrom" &&
+          change.type !== "moveTo")
+      ) {
+        return;
+      }
+      expect(change.content.map(({ type: childType }) => childType)).toEqual([
+        "bookmarkStart",
+        "run",
+        "bookmarkEnd",
+      ]);
+
+      const serialized = serializeParagraph(paragraph);
+      expect(serialized).toContain(
+        `<w:${tag} w:id="7" w:author="Reviewer"><w:bookmarkStart w:id="9" w:name="TrackedTerm"/>`,
+      );
+      expect(serialized).toContain(`<w:bookmarkEnd w:id="9"/></w:${tag}>`);
+    });
+  }
+
   test("parses deletion text from w:delText runs", () => {
     const paragraph = parseParagraphXml(`
       <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
@@ -110,17 +153,14 @@ describe("parseParagraph tracked-change hardening", () => {
       </w:p>
     `);
 
-    expect(paragraph.content.map((content) => content.type)).toEqual([
-      "insertion",
-      "bookmarkStart",
-    ]);
+    expect(paragraph.content.map((content) => content.type)).toEqual(["insertion"]);
     const insertion = paragraph.content.at(0);
     expect(insertion?.type).toBe("insertion");
     if (!insertion || insertion.type !== "insertion") {
       return;
     }
     expect(insertion.info).toMatchObject({ id: 12, author: "Reviewer" });
-    expect(insertion.content).toHaveLength(0);
+    expect(insertion.content).toEqual([{ type: "bookmarkStart", id: 5, name: "insertedMarker" }]);
   });
 
   test("preserves inline SDT metadata for marker-only controls", () => {
@@ -203,7 +243,7 @@ describe("parseParagraph tracked-change hardening", () => {
     });
   });
 
-  test("lifts bookmark markers out of tracked-change wrappers", () => {
+  test("keeps a bookmark boundary owned by its tracked-change wrapper", () => {
     const paragraph = parseParagraphXml(`
       <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
         <w:bookmarkStart w:id="5" w:name="deletedRange"/>
@@ -214,15 +254,13 @@ describe("parseParagraph tracked-change hardening", () => {
       </w:p>
     `);
 
-    expect(paragraph.content.map((content) => content.type)).toEqual([
-      "bookmarkStart",
-      "deletion",
-      "bookmarkEnd",
-    ]);
-    expect(paragraph.content.at(2)).toMatchObject({
-      type: "bookmarkEnd",
-      id: 5,
-    });
+    expect(paragraph.content.map((content) => content.type)).toEqual(["bookmarkStart", "deletion"]);
+    const deletion = paragraph.content.at(1);
+    expect(deletion?.type).toBe("deletion");
+    if (deletion?.type !== "deletion") {
+      return;
+    }
+    expect(deletion.content.at(-1)).toEqual({ type: "bookmarkEnd", id: 5 });
   });
 
   test("folds an out-of-range id on an inline w:ins into the int32 range (eigenpal #1093)", () => {

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -33,6 +33,7 @@ import type {
   ParagraphMarkChange,
   ParagraphPropertyChange,
   TrackedChangeInfo,
+  TrackedRunChange,
   MathEquation,
   RunContent,
 } from "../types/document";
@@ -1037,8 +1038,15 @@ function parseParagraphMarkChange(pPr: XmlElement | null): ParagraphMarkChange |
   return undefined;
 }
 
-function isTrackedChangeWrapperChild(content: ParagraphContent): content is Run | Hyperlink {
-  return content.type === "run" || content.type === "hyperlink";
+function isTrackedChangeWrapperChild(
+  content: ParagraphContent,
+): content is TrackedRunChange["content"][number] {
+  return (
+    content.type === "run" ||
+    content.type === "hyperlink" ||
+    content.type === "bookmarkStart" ||
+    content.type === "bookmarkEnd"
+  );
 }
 
 // Mirror of upstream eigenpal/docx-editor PR #482 (commit 29f95751d):
@@ -1067,7 +1075,7 @@ type PushTrackedChangeWrapperParams = {
   contents: ParagraphContent[];
   type: TrackedChangeWrapperType;
   info: TrackedChangeInfo;
-  content: readonly (Run | Hyperlink)[];
+  content: readonly TrackedRunChange["content"][number][];
   preserveEmpty?: boolean;
 };
 
@@ -1125,7 +1133,7 @@ function pushTrackedChangeSegments({
     return;
   }
 
-  const segment: (Run | Hyperlink)[] = [];
+  const segment: TrackedRunChange["content"] = [];
 
   for (const content of parsedContent) {
     if (isTrackedChangeWrapperChild(content)) {

--- a/packages/core/src/docx/paragraphTraversal.ts
+++ b/packages/core/src/docx/paragraphTraversal.ts
@@ -9,6 +9,7 @@ import type {
   ParagraphContent,
   Run,
   Table,
+  TrackedRunChange,
 } from "../types/document";
 
 export type DocxParagraphSurfaces = {
@@ -33,13 +34,15 @@ export const visitParagraphRuns = (paragraph: Paragraph, visit: (run: Run) => vo
     }
   };
 
-  const visitInlineContent = (content: readonly (Run | Hyperlink)[]): void => {
+  const visitInlineContent = (content: readonly TrackedRunChange["content"][number][]): void => {
     for (const child of content) {
       if (child.type === "run") {
         visitRun(child);
         continue;
       }
-      visitHyperlink(child);
+      if (child.type === "hyperlink") {
+        visitHyperlink(child);
+      }
     }
   };
 

--- a/packages/core/src/docx/renderedPageBreakNormalization.ts
+++ b/packages/core/src/docx/renderedPageBreakNormalization.ts
@@ -6,6 +6,7 @@ import type {
   Hyperlink,
   ParagraphContent,
   Run,
+  TrackedRunContent,
 } from "../types/document";
 import { visitDocxParagraphs } from "./paragraphTraversal";
 
@@ -74,11 +75,16 @@ const scanHyperlink = (hyperlink: Hyperlink, scan: RenderedPageBreakScan): boole
 };
 
 const scanInlineContent = (
-  content: readonly (Run | Hyperlink)[],
+  content: readonly TrackedRunContent[],
   scan: RenderedPageBreakScan,
 ): boolean | undefined => {
   for (const child of content) {
-    const result = child.type === "run" ? scanRun(child, scan) : scanHyperlink(child, scan);
+    let result: boolean | undefined;
+    if (child.type === "run") {
+      result = scanRun(child, scan);
+    } else if (child.type === "hyperlink") {
+      result = scanHyperlink(child, scan);
+    }
     if (result !== undefined) {
       return result;
     }

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -974,7 +974,12 @@ function serializeTrackedChange(
         }
         return serializeRun(item);
       }
-      return serializeHyperlink(item);
+      if (item.type === "hyperlink") {
+        return serializeHyperlink(item);
+      }
+      return item.type === "bookmarkStart"
+        ? serializeBookmarkStart(item)
+        : serializeBookmarkEnd(item);
     })
     .join("");
 

--- a/packages/core/src/markdown/renderRuns.ts
+++ b/packages/core/src/markdown/renderRuns.ts
@@ -22,6 +22,7 @@ import type {
   ParagraphContent,
   Run,
   RunContent,
+  TrackedRunContent,
 } from "../types/document";
 import { decodeOoxmlSymbolCharacter } from "../utils/ooxmlSymbol";
 import { wrapComment, wrapDeletion, wrapInsertion, wrapMoveFrom, wrapMoveTo } from "./annotations";
@@ -258,26 +259,23 @@ function renderTrackedWrapper(
   wrapper: Insertion | Deletion | MoveFrom | MoveTo,
   paraId: string | undefined,
 ): string {
+  const renderChild = (child: TrackedRunContent): string => {
+    if (child.type === "run") {
+      return renderRun(ctx, pkg, child, paraId);
+    }
+    if (child.type === "hyperlink") {
+      return renderHyperlink(ctx, pkg, child, paraId);
+    }
+    return "";
+  };
   if (ctx.opts.trackedChanges === "clean") {
     // Insertions become real text; deletions vanish.
     if (wrapper.type === "insertion" || wrapper.type === "moveTo") {
-      return wrapper.content
-        .map((child) =>
-          child.type === "run"
-            ? renderRun(ctx, pkg, child, paraId)
-            : renderHyperlink(ctx, pkg, child, paraId),
-        )
-        .join("");
+      return wrapper.content.map(renderChild).join("");
     }
     return "";
   }
-  const inner = wrapper.content
-    .map((child) =>
-      child.type === "run"
-        ? renderRun(ctx, pkg, child, paraId)
-        : renderHyperlink(ctx, pkg, child, paraId),
-    )
-    .join("");
+  const inner = wrapper.content.map(renderChild).join("");
   switch (wrapper.type) {
     case "insertion":
       return wrapInsertion(ctx, wrapper.info, inner);

--- a/packages/core/src/markdown/renderTable.ts
+++ b/packages/core/src/markdown/renderTable.ts
@@ -11,6 +11,7 @@ import type {
   Hyperlink,
   ParagraphContent,
   Run,
+  TrackedRunContent,
   Table,
   TableCell,
   TableRow,
@@ -295,15 +296,19 @@ function renderHtmlInline(
 function renderHtmlChildren(
   ctx: RenderContext,
   pkg: DocxPackage | undefined,
-  children: (Run | Hyperlink)[],
+  children: readonly TrackedRunContent[],
   paraId: string | undefined,
 ): string {
   return children
-    .map((c) =>
-      c.type === "run"
-        ? renderHtmlRun(ctx, pkg, c, paraId)
-        : renderHtmlHyperlink(ctx, pkg, c, paraId),
-    )
+    .map((child) => {
+      if (child.type === "run") {
+        return renderHtmlRun(ctx, pkg, child, paraId);
+      }
+      if (child.type === "hyperlink") {
+        return renderHtmlHyperlink(ctx, pkg, child, paraId);
+      }
+      return "";
+    })
     .join("");
 }
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -1516,6 +1516,40 @@ describe("fromProseDoc", () => {
     },
   );
 
+  test.each(["insertion", "deletion", "moveFrom", "moveTo"] as const)(
+    "preserves direct bookmark boundaries inside one %s wrapper",
+    (type) => {
+      const info = {
+        id: 92,
+        author: "Reviewer",
+        date: "2026-08-29T10:15:00Z",
+      } satisfies TrackedChangeInfo;
+      const trackedChange: TrackedRunChange = {
+        type,
+        info,
+        content: [
+          { type: "bookmarkStart", id: 92, name: "defined-term" },
+          { type: "run", content: [{ type: "text", text: "Agreement" }] },
+          { type: "bookmarkEnd", id: 92 },
+        ],
+      };
+      const document: Document = {
+        package: {
+          document: {
+            content: [{ type: "paragraph", content: [trackedChange] }],
+          },
+        },
+      };
+
+      const roundTripped = fromProseDoc(toProseDoc(document), document);
+      const paragraph = roundTripped.package.document.content.at(0);
+      if (paragraph?.type !== "paragraph") {
+        throw new Error("Expected round-tripped paragraph");
+      }
+      expect(paragraph.content).toEqual([trackedChange]);
+    },
+  );
+
   test("preserves drawing content in vMerge continuation cells", () => {
     const rawXml = "<w:drawing><wp:anchor/></w:drawing>";
     const document: Document = {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1401,18 +1401,19 @@ type TrackedRunWrapper = Extract<
 function createTrackedRunWrapper(
   type: TrackedRunWrapper["type"],
   info: TrackedChangeInfo,
-  child: Run | Hyperlink,
+  child?: TrackedRunWrapper["content"][number],
 ): TrackedRunWrapper {
+  const content = child ? [child] : [];
   if (type === "insertion") {
-    return { type, info, content: [child] };
+    return { type, info, content };
   }
   if (type === "deletion") {
-    return { type, info, content: [child] };
+    return { type, info, content };
   }
   if (type === "moveFrom") {
-    return { type, info, content: [child] };
+    return { type, info, content };
   }
-  return { type, info, content: [child] };
+  return { type, info, content };
 }
 
 function extractParagraphContent(
@@ -1444,7 +1445,14 @@ function extractParagraphContent(
   let currentHyperlinkKey: string | null = null;
   let currentTrackedChange:
     | {
+        type: "direct";
         key: string;
+        wrapper: TrackedRunWrapper;
+      }
+    | {
+        type: "hyperlink";
+        key: string;
+        wrapper: TrackedRunWrapper;
         hyperlink: Hyperlink;
         hyperlinkKey: string;
       }
@@ -1629,15 +1637,25 @@ function extractParagraphContent(
         const linkKey = getLinkKey(linkMark);
         if (
           !currentTrackedChange ||
+          currentTrackedChange.type !== "hyperlink" ||
           currentTrackedChange.key !== trackedChangeKey ||
           currentTrackedChange.hyperlinkKey !== linkKey
         ) {
           const hyperlink = createHyperlink(linkMark);
           const wrapper = createTrackedRunWrapper(type, info, hyperlink);
           content.push(wrapper);
-          currentTrackedChange = { key: trackedChangeKey, hyperlink, hyperlinkKey: linkKey };
+          currentTrackedChange = {
+            type: "hyperlink",
+            key: trackedChangeKey,
+            wrapper,
+            hyperlink,
+            hyperlinkKey: linkKey,
+          };
         }
 
+        if (currentTrackedChange.type !== "hyperlink") {
+          panic("A tracked hyperlink lost its serialization parent");
+        }
         if (node.type.name === "bookmarkBoundary") {
           addNodeToHyperlink({
             hyperlink: currentTrackedChange.hyperlink,
@@ -1654,10 +1672,33 @@ function extractParagraphContent(
         return;
       }
 
-      currentTrackedChange = undefined;
+      if (
+        !currentTrackedChange ||
+        currentTrackedChange.type !== "direct" ||
+        currentTrackedChange.key !== trackedChangeKey
+      ) {
+        const wrapper = createTrackedRunWrapper(type, info);
+        content.push(wrapper);
+        currentTrackedChange = { type: "direct", key: trackedChangeKey, wrapper };
+      }
+      if (node.type.name === "bookmarkBoundary") {
+        const attrs = expectBookmarkBoundaryAttrs(node);
+        const boundary: TrackedRunWrapper["content"][number] =
+          attrs.type === "start"
+            ? {
+                type: "bookmarkStart",
+                id: attrs.id,
+                name: attrs.name,
+                ...(attrs.colFirst !== undefined ? { colFirst: attrs.colFirst } : {}),
+                ...(attrs.colLast !== undefined ? { colLast: attrs.colLast } : {}),
+              }
+            : { type: "bookmarkEnd", id: attrs.id };
+        currentTrackedChange.wrapper.content.push(boundary);
+        return;
+      }
       const run = createTrackedChangeRun({ inheritedFormatting, marks: otherMarks, node });
       if (run) {
-        content.push(createTrackedRunWrapper(type, info, run));
+        currentTrackedChange.wrapper.content.push(run);
       }
       return;
     }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -45,6 +45,8 @@ import type {
   DrawingContent,
   MoveFrom,
   MoveTo,
+  BookmarkStart,
+  BookmarkEnd,
   MathEquation,
   ShapeTextBody,
   Theme,
@@ -734,7 +736,7 @@ function convertTrackedChange(
           textBoxAnchors,
         ),
       );
-    } else {
+    } else if (item.type === "hyperlink") {
       const currentHyperlinkIndex = nextHyperlinkInstanceIndex();
       nodes.push(
         ...convertHyperlink(item, {
@@ -744,6 +746,18 @@ function convertTrackedChange(
           textBoxAnchors,
         }),
       );
+    } else if (item.type === "bookmarkStart") {
+      nodes.push(
+        schema.node("bookmarkBoundary", {
+          type: "start",
+          id: item.id,
+          name: item.name,
+          colFirst: item.colFirst,
+          colLast: item.colLast,
+        }),
+      );
+    } else {
+      nodes.push(schema.node("bookmarkBoundary", { type: "end", id: item.id }));
     }
   }
 
@@ -3720,7 +3734,9 @@ function extractTextBoxes(paragraph: Paragraph, textBoxGroupId: string): Extract
         visitRun(item, { ...context, trackedChange });
         continue;
       }
-      visitHyperlink(item, { ...context, trackedChange });
+      if (item.type === "hyperlink") {
+        visitHyperlink(item, { ...context, trackedChange });
+      }
     }
   };
 
@@ -4181,7 +4197,9 @@ function findParagraphPageBreakPosition(paragraph: Paragraph): "before" | "after
   // content; an empty wrapper must not be treated as visible — an empty
   // bookmark-only hyperlink before a page break should still classify the
   // break as "before".
-  function visitRunOrHyperlinkList(children: (Run | Hyperlink)[]): boolean {
+  function visitRunOrHyperlinkList(
+    children: readonly (Run | Hyperlink | BookmarkStart | BookmarkEnd)[],
+  ): boolean {
     for (const child of children) {
       if (child.type === "run" && visitRun(child)) {
         return true;

--- a/packages/core/src/prosemirror/validation.test.ts
+++ b/packages/core/src/prosemirror/validation.test.ts
@@ -152,7 +152,7 @@ describe("ProseMirror document validation", () => {
     expect(result).toEqual({ valid: true, issues: [] });
   });
 
-  test("rejects a tracked boundary placement the document model cannot serialize", () => {
+  test("allows a bookmark boundary directly inside a tracked change", () => {
     const insertion = schema.mark("insertion", {
       revisionId: 7,
       author: "Reviewer",
@@ -170,11 +170,7 @@ describe("ProseMirror document validation", () => {
 
     const result = validateProseMirrorDocument(doc);
 
-    expect(result.valid).toBe(false);
-    expectIssueContaining(
-      result,
-      "Bookmark boundaries inside tracked changes require a hyperlink serialization parent",
-    );
+    expect(result).toEqual({ valid: true, issues: [] });
   });
 
   test("rejects a field boundary without its required hyperlink parent", () => {

--- a/packages/core/src/prosemirror/validation.ts
+++ b/packages/core/src/prosemirror/validation.ts
@@ -199,7 +199,6 @@ const validateBookmarkBoundaryStructure = (
       const result = readBookmarkBoundaryAttrs(node);
       if (result.ok) {
         const attrs = result.value;
-        const hasHyperlink = node.marks.some((mark) => mark.type.name === "hyperlink");
         const trackedChanges = node.marks.filter(
           (mark) => mark.type.name === "insertion" || mark.type.name === "deletion",
         );
@@ -207,11 +206,6 @@ const validateBookmarkBoundaryStructure = (
           issues.push({
             path,
             message: `Bookmark boundaries cannot carry multiple tracked-change parents (${enclosingParagraph}).`,
-          });
-        } else if (trackedChanges.length === 1 && !hasHyperlink) {
-          issues.push({
-            path,
-            message: `Bookmark boundaries inside tracked changes require a hyperlink serialization parent (${enclosingParagraph}).`,
           });
         }
         if (attrs.type === "start") {

--- a/packages/core/src/types/content.ts
+++ b/packages/core/src/types/content.ts
@@ -83,6 +83,7 @@ export type {
   TextBox,
   TextContent,
   TrackedChangeInfo,
+  TrackedRunContent,
   TrackedRunChange,
   VerticalAlign,
 } from "@stll/docx-core/model";

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1052,6 +1052,9 @@ export type PropertyChangeInfo = {
   rsid?: string;
 } & TrackedChangeInfo;
 
+/** Inline content that may sit inside a run-level tracked-change wrapper. */
+export type TrackedRunContent = Run | Hyperlink | BookmarkStart | BookmarkEnd;
+
 /**
  * Insertion wrapper (w:ins) — runs inserted by tracked changes
  */
@@ -1060,7 +1063,7 @@ export type Insertion = {
   /** Tracked change metadata */
   info: TrackedChangeInfo;
   /** Inserted content */
-  content: (Run | Hyperlink)[];
+  content: TrackedRunContent[];
 };
 
 /**
@@ -1071,7 +1074,7 @@ export type Deletion = {
   /** Tracked change metadata */
   info: TrackedChangeInfo;
   /** Deleted content */
-  content: (Run | Hyperlink)[];
+  content: TrackedRunContent[];
 };
 
 /**
@@ -1082,7 +1085,7 @@ export type MoveFrom = {
   /** Tracked change metadata */
   info: TrackedChangeInfo;
   /** Moved content */
-  content: (Run | Hyperlink)[];
+  content: TrackedRunContent[];
 };
 
 /**
@@ -1093,7 +1096,7 @@ export type MoveTo = {
   /** Tracked change metadata */
   info: TrackedChangeInfo;
   /** Moved content */
-  content: (Run | Hyperlink)[];
+  content: TrackedRunContent[];
 };
 
 /**

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -118,6 +118,7 @@ export type {
   CommentReference,
   MathEquation,
   TrackedChangeInfo,
+  TrackedRunContent,
   TrackedRunChange,
   PropertyChangeInfo,
   Insertion,

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -204,6 +204,28 @@ describe("canonical DOCX document model validation", () => {
     });
   });
 
+  test("counts bookmark boundaries inside tracked run changes", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            {
+              type: "insertion",
+              info: { id: 7, author: "Reviewer" },
+              content: [
+                { type: "bookmarkStart", id: 9, name: "inserted" },
+                textRun("Inserted term"),
+                { type: "bookmarkEnd", id: 9 },
+              ],
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
   test("rejects invalid table shape", () => {
     const result = validateDocumentModel(
       createDocument({

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -626,7 +626,12 @@ const validateTrackedRunChange = (
   }
 
   for (const [index, child] of change.content.entries()) {
-    validateFieldChild(child, `${path}.content[${index}]`, ctx);
+    const childPath = `${path}.content[${index}]`;
+    if (child.type === "hyperlink") {
+      validateHyperlink(child, childPath, ctx);
+      continue;
+    }
+    validateHyperlinkChild(child, childPath, ctx);
   }
 };
 


### PR DESCRIPTION
Run-level tracked changes can contain bookmark boundaries. Lifting those boundaries out of their revision leaves empty bookmarks after accepting a deletion or rejecting an insertion.

Preserve bookmark ownership through the document model, parser, editor conversion, serialization, and validation. Keep the guard that prevents text-edit ranges from assigning new revision ownership to existing zero-width anchors.

Validation: focused parser, conversion, Markdown, and compare regressions pass; reverting parser ownership fails the new accept/reject regressions. Scoped lint, core/document-model typechecks, builds, and API reports pass. Native Word accept/reject confirms insertion and deletion ownership.
