### PR TITLE
fix: preserve paragraph formatting in move scenarios

### DIFF
--- a/.changeset/calm-moves-keep-formatting.md
+++ b/.changeset/calm-moves-keep-formatting.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve paragraph style and list level in generated move scenarios.

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -32,7 +32,7 @@ export type CellContent = string | readonly BodyItem[];
 
 /** One body-level item: a paragraph, or a table given row by row. */
 export type BodyItem =
-  | { kind: "paragraph"; text: string }
+  | { kind: "paragraph"; text: string; styleId?: string }
   | {
       kind: "table";
       rows: readonly (readonly CellContent[])[];
@@ -49,8 +49,12 @@ export type BodyItem =
  * holds for a blank line or an empty cell. It is not the same thing as a
  * paragraph whose run carries an empty string, and both shapes occur.
  */
-const paragraph = (text: string): string =>
-  text.length === 0 ? `<w:p/>` : `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+const paragraph = (text: string, styleId?: string): string => {
+  const properties = styleId === undefined ? "" : `<w:pPr><w:pStyle w:val="${styleId}"/></w:pPr>`;
+  return text.length === 0
+    ? `<w:p>${properties}</w:p>`
+    : `<w:p>${properties}<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+};
 
 const EMPTY_PARAGRAPH = { kind: "paragraph", text: "" } as const satisfies BodyItem;
 
@@ -89,7 +93,9 @@ const table = (item: Extract<BodyItem, { kind: "table" }>): string => {
 };
 
 const itemsXml = (items: readonly BodyItem[]): string =>
-  items.map((item) => (item.kind === "paragraph" ? paragraph(item.text) : table(item))).join("");
+  items
+    .map((item) => (item.kind === "paragraph" ? paragraph(item.text, item.styleId) : table(item)))
+    .join("");
 
 const bodyXml = (items: readonly BodyItem[]): string => itemsXml(closedSequence(items));
 
@@ -117,6 +123,7 @@ export const buildBodySequenceDocx = async (items: readonly BodyItem[]): Promise
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<w:styles xmlns:w="${NAMESPACE}">` +
       `<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>` +
+      `<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/></w:style>` +
       `</w:styles>`,
     "word/document.xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +

--- a/packages/core/src/compare/scenario.test.ts
+++ b/packages/core/src/compare/scenario.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { buildBodySequenceDocx } from "./__fixtures__/body-sequence";
+import { buildNumberedListDocx } from "./__fixtures__/numbered-list";
+import { applyEditScript } from "./scenario";
+
+const blocksOf = async (buffer: ArrayBuffer) =>
+  (await FolioDocxReviewer.fromBuffer(buffer)).getContent();
+
+type MovedBlocksOptions = {
+  base: ArrayBuffer;
+  blockIndex: number;
+  beforeBlockIndex: number;
+};
+
+const movedBlocks = async ({ base, blockIndex, beforeBlockIndex }: MovedBlocksOptions) => {
+  const result = await applyEditScript(base, [
+    { type: "moveParagraph", blockIndex, beforeBlockIndex },
+  ]);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  expect(result.value.unresolved).toEqual([]);
+  return await blocksOf(result.value.buffer);
+};
+
+describe("move paragraph scenarios", () => {
+  test.each([
+    {
+      source: "plain",
+      sourceStyleId: undefined,
+      destination: "plain",
+      destinationStyleId: undefined,
+    },
+    {
+      source: "plain",
+      sourceStyleId: undefined,
+      destination: "Heading1",
+      destinationStyleId: "Heading1",
+    },
+    {
+      source: "Heading1",
+      sourceStyleId: "Heading1",
+      destination: "plain",
+      destinationStyleId: undefined,
+    },
+    {
+      source: "Heading1",
+      sourceStyleId: "Heading1",
+      destination: "Heading1",
+      destinationStyleId: "Heading1",
+    },
+  ] as const)(
+    "preserve source style $source when moving before destination style $destination",
+    async ({ sourceStyleId, destinationStyleId }) => {
+      const base = await buildBodySequenceDocx([
+        { kind: "paragraph", text: "Source", styleId: sourceStyleId },
+        { kind: "paragraph", text: "Middle" },
+        { kind: "paragraph", text: "Destination", styleId: destinationStyleId },
+      ]);
+
+      const blocks = await movedBlocks({ base, blockIndex: 0, beforeBlockIndex: 2 });
+
+      expect(blocks.map(({ text, styleId }) => ({ text, styleId: styleId ?? null }))).toEqual([
+        { text: "Middle", styleId: null },
+        { text: "Source", styleId: sourceStyleId ?? null },
+        { text: "Destination", styleId: destinationStyleId ?? null },
+      ]);
+    },
+  );
+
+  test.each([
+    { source: "level 1", sourceLevel: 1, destination: "level 0", destinationLevel: 0 },
+    { source: "unnumbered", sourceLevel: null, destination: "level 1", destinationLevel: 1 },
+  ] as const)(
+    "preserve source list state $source when moving before destination $destination",
+    async ({ sourceLevel, destinationLevel }) => {
+      const items = [
+        { level: sourceLevel, text: "Source" },
+        { level: 0, text: "Middle" },
+        { level: destinationLevel, text: "Destination" },
+      ];
+      const base = await buildNumberedListDocx(items);
+
+      const blocks = await movedBlocks({ base, blockIndex: 0, beforeBlockIndex: 2 });
+
+      expect(blocks.map(({ text, listLevel }) => ({ text, listLevel: listLevel ?? null }))).toEqual(
+        [
+          { text: "Middle", listLevel: 0 },
+          { text: "Source", listLevel: sourceLevel },
+          { text: "Destination", listLevel: destinationLevel },
+        ],
+      );
+    },
+  );
+});

--- a/packages/core/src/compare/scenario.ts
+++ b/packages/core/src/compare/scenario.ts
@@ -152,6 +152,8 @@ const planStep = ({ step, blocks, nextOperationId }: PlanStepOptions): StepPlan 
             type: "insertBeforeBlock",
             blockId: destination.id,
             text: block.text,
+            styleId: block.styleId ?? null,
+            listLevel: block.listLevel ?? null,
           },
         ],
       };


### PR DESCRIPTION
Moving a paragraph in an edit scenario inserted only its text, so it inherited the destination's paragraph style and list level. This introduced extra formatting changes and could fail the comparison change-count property.

Carry the source style and list level explicitly, including null values for plain or unnumbered paragraphs. Synthetic state matrices cover both preserving and clearing those properties.

Validation: six scenario tests and four change-count property cases pass; the failing move-then-delete case now produces three changes within its existing budget. Mutations removing either property assignment fail its regression. Scoped lint and core typecheck pass.
