### PR TITLE
feat: compare tracked strike-through formatting

### DIFF
--- a/.changeset/strong-lines-compare.md
+++ b/.changeset/strong-lines-compare.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Compare strikethrough as a tracked inline-formatting change.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -436,6 +436,7 @@ export type FolioAIInlineFormatting = {
     bold?: boolean;
     italic?: boolean;
     underline?: boolean;
+    strike?: boolean;
 };
 
 // @public

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -253,7 +253,7 @@ export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
 export const COMPARE_UNSUPPORTED_REASONS: readonly ["story-missing-in-base", "story-missing-in-target", "story-not-editable"];
 
 // @public
-export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "whitespace", "text"];
+export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "inline-formatting", "whitespace", "text"];
 
 // @public
 export const COMPARE_VERIFICATION_INVARIANTS: readonly ["accept-reproduces-target", "reject-reproduces-base"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -253,7 +253,7 @@ export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
 export const COMPARE_UNSUPPORTED_REASONS: readonly ["story-missing-in-base", "story-missing-in-target", "story-not-editable"];
 
 // @public
-export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "whitespace", "text"];
+export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "inline-formatting", "whitespace", "text"];
 
 // @public
 export const COMPARE_VERIFICATION_INVARIANTS: readonly ["accept-reproduces-target", "reject-reproduces-base"];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -740,6 +740,7 @@ export type FolioAIInlineFormatting = {
     bold?: boolean;
     italic?: boolean;
     underline?: boolean;
+    strike?: boolean;
 };
 
 // @public

--- a/benchmarks/compare/refusals.ts
+++ b/benchmarks/compare/refusals.ts
@@ -40,6 +40,7 @@ export const REFUSAL_BUCKETS = Object.freeze({
   "round-trip-container": "Every block's text matched, but one sits in the wrong container.",
   "round-trip-style": "A block kept a paragraph style the other side changed.",
   "round-trip-list-level": "A block kept a list level the other side changed.",
+  "round-trip-inline-formatting": "A planned formatting change did not round-trip.",
   "round-trip-whitespace": "A block's text differs only in whitespace.",
   "round-trip-text": "A block's text does not match.",
 } as const);

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -180,6 +180,7 @@ export type FolioAIInlineFormatting = {
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;
+  strike?: boolean;
 };
 
 /**

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -223,8 +223,13 @@ const rowBlockCount = (blocks: readonly FolioAIBlock[], index: number): number =
 };
 
 const formattingArb = fc
-  .record({ bold: fc.boolean(), italic: fc.boolean(), underline: fc.boolean() })
-  .filter(({ bold, italic, underline }) => bold || italic || underline);
+  .record({
+    bold: fc.boolean(),
+    italic: fc.boolean(),
+    underline: fc.boolean(),
+    strike: fc.boolean(),
+  })
+  .filter(({ bold, italic, underline, strike }) => bold || italic || underline || strike);
 
 /** Steps that only change formatting, for the formatting-only property. */
 const formatStepArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScriptStep> | null => {

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -63,6 +63,7 @@ import {
 } from "./types";
 import {
   classifyProjectionMismatch,
+  projectSupportedInlineFormatting,
   type CompareVerification,
   type CompareVerificationFailure,
 } from "./verification";
@@ -123,12 +124,7 @@ const existingRevisionsOf = (reviewer: FolioDocxReviewer): ExistingRevisions => 
  * the table cell it sits in. The tag is what makes the self-check below see a
  * paragraph that landed beside a table instead of inside it.
  */
-const projectStory = (
-  reviewer: FolioDocxReviewer,
-  story: FolioDocumentStoryHandle,
-  view: "final" | "original" = "final",
-): string[] => {
-  const blocks = reviewer.readReviewedStory({ story, view })?.snapshot.blocks ?? [];
+const projectBlocks = (blocks: readonly FolioAIBlock[]): string[] => {
   return blocks.map(({ text, table, styleId, listLevel }) => {
     const container = table
       ? `t${String(table.tableIndex)}r${String(table.rowIndex)}c${String(table.cellIndex)}g${String(table.gridColumnIndex)}x${String(table.columnSpan)}y${String(table.rowSpan)}p${String(table.paragraphIndex)}`
@@ -139,17 +135,6 @@ const projectStory = (
     return `${container}|${styleId ?? ""}|${listLevel ?? ""}|${text}`;
   });
 };
-
-/** Effective supported formatting, normalized into character-length runs. */
-const projectSupportedInlineFormatting = ({ text, previewRuns }: FolioAIBlock): string =>
-  (previewRuns ?? [{ text }])
-    .map(
-      ({ text: runText, bold, italic, underline, strike }) =>
-        `${runText.length}:${bold === true ? "b" : ""}${italic === true ? "i" : ""}${
-          underline === true ? "u" : ""
-        }${strike === true ? "s" : ""}`,
-    )
-    .join(",");
 
 type FormattingRoundTripFailureOptions = {
   invariant: CompareVerificationFailure["invariant"];
@@ -169,17 +154,21 @@ const formattingRoundTripFailure = ({
   expectedBlocks,
   expectedBlockId,
 }: FormattingRoundTripFailureOptions): CompareVerificationFailure | null => {
-  const actualById = new Map(actualBlocks.map((block) => [block.id, block]));
-  const expectedById = new Map(expectedBlocks.map((block) => [block.id, block]));
   for (const change of changes) {
     if (change.kind !== "format") {
       continue;
     }
-    const actual = actualById.get(change.baseBlockId);
-    const expected = expectedById.get(expectedBlockId(change));
-    // Text/structure verification owns missing or displaced blocks.
-    if (!actual || !expected) {
-      continue;
+    const expectedId = expectedBlockId(change);
+    const expectedIndex = expectedBlocks.findIndex(({ id }) => id === expectedId);
+    const expected = expectedBlocks.at(expectedIndex);
+    const actual = actualBlocks.at(expectedIndex);
+    if (expectedIndex === -1 || !actual || !expected) {
+      return {
+        invariant,
+        cause: "inline-formatting",
+        story,
+        detail: "a text-equal aligned block could not be projected for formatting verification",
+      };
     }
     if (projectSupportedInlineFormatting(actual) !== projectSupportedInlineFormatting(expected)) {
       return {
@@ -399,7 +388,7 @@ export type AppliedComparison = {
  * are both legitimate asks and only the caller knows which one it is making.
  */
 export const applyComparison = (
-  { reviewer, targetReviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
+  { reviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
   planned: readonly PlannedStoryComparison[],
 ): Result<AppliedComparison, CompareDocxApplyError> => {
   const changes: CompareChange[] = [...numberingChanges];
@@ -417,7 +406,9 @@ export const applyComparison = (
 
     // Read before the operations land: this is the document the redline is
     // written against, and rejecting every revision has to return to it.
-    const baseBefore = projectStory(reviewer, pair.baseStory);
+    const baseBeforeBlocks =
+      reviewer.readReviewedStory({ story: pair.baseStory, view: "final" })?.snapshot.blocks ?? [];
+    const baseBefore = projectBlocks(baseBeforeBlocks);
 
     const { skipped, nextRevisionId } = reviewer.applyDocumentOperationsToStory({
       story: pair.baseStory,
@@ -452,8 +443,8 @@ export const applyComparison = (
     const acceptFailure = classifyProjectionMismatch({
       invariant: "accept-reproduces-target",
       story: pair.baseStory,
-      actual: projectStory(reviewer, pair.baseStory),
-      expected: projectStory(targetReviewer, pair.targetStory),
+      actual: projectBlocks(acceptedStory?.snapshot.blocks ?? []),
+      expected: projectBlocks(pair.targetSnapshot.blocks),
     });
     if (acceptFailure) {
       failures.push(acceptFailure);
@@ -474,7 +465,7 @@ export const applyComparison = (
     const rejectFailure = classifyProjectionMismatch({
       invariant: "reject-reproduces-base",
       story: pair.baseStory,
-      actual: projectStory(reviewer, pair.baseStory, "original"),
+      actual: projectBlocks(rejectedStory?.snapshot.blocks ?? []),
       expected: baseBefore,
     });
     if (rejectFailure) {

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -154,12 +154,18 @@ const formattingRoundTripFailure = ({
   expectedBlocks,
   expectedBlockId,
 }: FormattingRoundTripFailureOptions): CompareVerificationFailure | null => {
+  const expectedIndexById = new Map(expectedBlocks.map(({ id }, index) => [id, index]));
+  const checkedExpectedIds = new Set<string>();
   for (const change of changes) {
     if (change.kind !== "format") {
       continue;
     }
     const expectedId = expectedBlockId(change);
-    const expectedIndex = expectedBlocks.findIndex(({ id }) => id === expectedId);
+    if (checkedExpectedIds.has(expectedId)) {
+      continue;
+    }
+    checkedExpectedIds.add(expectedId);
+    const expectedIndex = expectedIndexById.get(expectedId) ?? -1;
     const expected = expectedBlocks.at(expectedIndex);
     const actual = actualBlocks.at(expectedIndex);
     if (expectedIndex === -1 || !actual || !expected) {

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -42,7 +42,7 @@ import {
   type FolioNumberingLevel,
   type FolioRevisionStamp,
 } from "../ai-edits/headless";
-import type { FolioAIEditSnapshot } from "../ai-edits/types";
+import type { FolioAIBlock, FolioAIEditSnapshot } from "../ai-edits/types";
 import type { WordDiffGranularity } from "../ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
 import { pairFolioDocumentStories } from "../document-stories";
@@ -138,6 +138,59 @@ const projectStory = (
     // and leaves a list item at the wrong level.
     return `${container}|${styleId ?? ""}|${listLevel ?? ""}|${text}`;
   });
+};
+
+/** Effective supported formatting, normalized into character-length runs. */
+const projectSupportedInlineFormatting = ({ text, previewRuns }: FolioAIBlock): string =>
+  (previewRuns ?? [{ text }])
+    .map(
+      ({ text: runText, bold, italic, underline, strike }) =>
+        `${runText.length}:${bold === true ? "b" : ""}${italic === true ? "i" : ""}${
+          underline === true ? "u" : ""
+        }${strike === true ? "s" : ""}`,
+    )
+    .join(",");
+
+type FormattingRoundTripFailureOptions = {
+  invariant: CompareVerificationFailure["invariant"];
+  story: FolioDocumentStoryHandle;
+  changes: readonly CompareChange[];
+  actualBlocks: readonly FolioAIBlock[];
+  expectedBlocks: readonly FolioAIBlock[];
+  expectedBlockId: (change: Extract<CompareChange, { kind: "format" }>) => string;
+};
+
+/** Verify formatting only where the plan claims a text-equal formatting change. */
+const formattingRoundTripFailure = ({
+  invariant,
+  story,
+  changes,
+  actualBlocks,
+  expectedBlocks,
+  expectedBlockId,
+}: FormattingRoundTripFailureOptions): CompareVerificationFailure | null => {
+  const actualById = new Map(actualBlocks.map((block) => [block.id, block]));
+  const expectedById = new Map(expectedBlocks.map((block) => [block.id, block]));
+  for (const change of changes) {
+    if (change.kind !== "format") {
+      continue;
+    }
+    const actual = actualById.get(change.baseBlockId);
+    const expected = expectedById.get(expectedBlockId(change));
+    // Text/structure verification owns missing or displaced blocks.
+    if (!actual || !expected) {
+      continue;
+    }
+    if (projectSupportedInlineFormatting(actual) !== projectSupportedInlineFormatting(expected)) {
+      return {
+        invariant,
+        cause: "inline-formatting",
+        story,
+        detail: "supported inline formatting differs in a text-equal aligned block",
+      };
+    }
+  }
+  return null;
 };
 
 const numberingKey = ({ numId, level }: FolioNumberingLevel): string =>
@@ -395,6 +448,7 @@ export const applyComparison = (
       );
     }
 
+    const acceptedStory = reviewer.readReviewedStory({ story: pair.baseStory, view: "final" });
     const acceptFailure = classifyProjectionMismatch({
       invariant: "accept-reproduces-target",
       story: pair.baseStory,
@@ -403,7 +457,20 @@ export const applyComparison = (
     });
     if (acceptFailure) {
       failures.push(acceptFailure);
+    } else {
+      const formattingFailure = formattingRoundTripFailure({
+        invariant: "accept-reproduces-target",
+        story: pair.baseStory,
+        changes: plan.changes,
+        actualBlocks: acceptedStory?.snapshot.blocks ?? [],
+        expectedBlocks: pair.targetSnapshot.blocks,
+        expectedBlockId: ({ targetBlockId }) => targetBlockId,
+      });
+      if (formattingFailure) {
+        failures.push(formattingFailure);
+      }
     }
+    const rejectedStory = reviewer.readReviewedStory({ story: pair.baseStory, view: "original" });
     const rejectFailure = classifyProjectionMismatch({
       invariant: "reject-reproduces-base",
       story: pair.baseStory,
@@ -412,6 +479,18 @@ export const applyComparison = (
     });
     if (rejectFailure) {
       failures.push(rejectFailure);
+    } else {
+      const formattingFailure = formattingRoundTripFailure({
+        invariant: "reject-reproduces-base",
+        story: pair.baseStory,
+        changes: plan.changes,
+        actualBlocks: rejectedStory?.snapshot.blocks ?? [],
+        expectedBlocks: pair.baseSnapshot.blocks,
+        expectedBlockId: ({ baseBlockId }) => baseBlockId,
+      });
+      if (formattingFailure) {
+        failures.push(formattingFailure);
+      }
     }
   }
   return Result.ok({

--- a/packages/core/src/compare/formatting.test.ts
+++ b/packages/core/src/compare/formatting.test.ts
@@ -21,9 +21,9 @@ describe("inlineFormattingSegments", () => {
     ]);
     const joined = block([{ text: "Contract", strike: true }]);
 
-    expect(inlineFormattingSegments({ baseBlock: split, targetBlock: joined, maxSegments: 10 })).toEqual(
-      [],
-    );
+    expect(
+      inlineFormattingSegments({ baseBlock: split, targetBlock: joined, maxSegments: 10 }),
+    ).toEqual([]);
     expect(projectSupportedInlineFormatting(split)).toBe(projectSupportedInlineFormatting(joined));
   });
 

--- a/packages/core/src/compare/formatting.test.ts
+++ b/packages/core/src/compare/formatting.test.ts
@@ -14,8 +14,10 @@ const block = (previewRuns: FolioAIBlock["previewRuns"]): FolioAIBlock => ({
 describe("inlineFormattingSegments", () => {
   test("treats equivalent formatting across different run splits as equal", () => {
     const split = block([
+      { text: "", bold: true },
       { text: "Con", strike: true },
       { text: "tract", strike: true },
+      { text: "", italic: true },
     ]);
     const joined = block([{ text: "Contract", strike: true }]);
 

--- a/packages/core/src/compare/formatting.test.ts
+++ b/packages/core/src/compare/formatting.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FolioAIBlock } from "../ai-edits/types";
+import { inlineFormattingSegments } from "./formatting";
+
+const block = (previewRuns: FolioAIBlock["previewRuns"]): FolioAIBlock => ({
+  id: "block",
+  kind: "paragraph",
+  text: "Contract",
+  previewRuns,
+});
+
+describe("inlineFormattingSegments", () => {
+  test("treats equivalent formatting across different run splits as equal", () => {
+    expect(
+      inlineFormattingSegments({
+        baseBlock: block([
+          { text: "Con", strike: true },
+          { text: "tract", strike: true },
+        ]),
+        targetBlock: block([{ text: "Contract", strike: true }]),
+        maxSegments: 10,
+      }),
+    ).toEqual([]);
+  });
+
+  test("coalesces adjacent strike changes across target run boundaries", () => {
+    expect(
+      inlineFormattingSegments({
+        baseBlock: block([{ text: "Contract" }]),
+        targetBlock: block([
+          { text: "Con", strike: true },
+          { text: "tract", strike: true },
+        ]),
+        maxSegments: 10,
+      }),
+    ).toEqual([{ startOffset: 0, endOffset: 8, formatting: { strike: true } }]);
+  });
+});

--- a/packages/core/src/compare/formatting.test.ts
+++ b/packages/core/src/compare/formatting.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { FolioAIBlock } from "../ai-edits/types";
 import { inlineFormattingSegments } from "./formatting";
+import { projectSupportedInlineFormatting } from "./verification";
 
 const block = (previewRuns: FolioAIBlock["previewRuns"]): FolioAIBlock => ({
   id: "block",
@@ -12,16 +13,16 @@ const block = (previewRuns: FolioAIBlock["previewRuns"]): FolioAIBlock => ({
 
 describe("inlineFormattingSegments", () => {
   test("treats equivalent formatting across different run splits as equal", () => {
-    expect(
-      inlineFormattingSegments({
-        baseBlock: block([
-          { text: "Con", strike: true },
-          { text: "tract", strike: true },
-        ]),
-        targetBlock: block([{ text: "Contract", strike: true }]),
-        maxSegments: 10,
-      }),
-    ).toEqual([]);
+    const split = block([
+      { text: "Con", strike: true },
+      { text: "tract", strike: true },
+    ]);
+    const joined = block([{ text: "Contract", strike: true }]);
+
+    expect(inlineFormattingSegments({ baseBlock: split, targetBlock: joined, maxSegments: 10 })).toEqual(
+      [],
+    );
+    expect(projectSupportedInlineFormatting(split)).toBe(projectSupportedInlineFormatting(joined));
   });
 
   test("coalesces adjacent strike changes across target run boundaries", () => {

--- a/packages/core/src/compare/formatting.ts
+++ b/packages/core/src/compare/formatting.ts
@@ -30,18 +30,25 @@ const changedSupportedFormatting = (
   ...(Boolean(base.underline) !== Boolean(target.underline) && {
     underline: Boolean(target.underline),
   }),
+  ...(Boolean(base.strike) !== Boolean(target.strike) && {
+    strike: Boolean(target.strike),
+  }),
 });
 
 const sameInlineFormatting = (
   left: FolioAIInlineFormatting,
   right: FolioAIInlineFormatting,
 ): boolean =>
-  left.bold === right.bold && left.italic === right.italic && left.underline === right.underline;
+  left.bold === right.bold &&
+  left.italic === right.italic &&
+  left.underline === right.underline &&
+  left.strike === right.strike;
 
 const hasInlineFormatting = (formatting: FolioAIInlineFormatting): boolean =>
   formatting.bold !== undefined ||
   formatting.italic !== undefined ||
-  formatting.underline !== undefined;
+  formatting.underline !== undefined ||
+  formatting.strike !== undefined;
 
 /**
  * A block's runs, or `null` when they cannot describe the block's text.
@@ -62,7 +69,7 @@ type InlineFormattingSegmentsOptions = {
 };
 
 /**
- * Segments where `targetBlock`'s bold / italic / underline differs from
+ * Segments where `targetBlock`'s bold / italic / underline / strike differs from
  * `baseBlock`'s, for two blocks that carry the same text. Returns `null` only
  * when the diff would exceed `maxSegments`.
  *

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -426,7 +426,13 @@ describe("single-mutation probes", () => {
   test("format_only_strike: striking a phrase round-trips as tracked formatting", async () => {
     const blockIndex = wordyBlockIndex(PROSE_BLOCKS, 4);
     const target = await applyEditScript(PROSE_BASE, [
-      { type: "formatRange", blockIndex, startOffset: 0, endOffset: 4, formatting: { strike: true } },
+      {
+        type: "formatRange",
+        blockIndex,
+        startOffset: 0,
+        endOffset: 4,
+        formatting: { strike: true },
+      },
     ]);
     if (target.isErr()) {
       throw target.error;
@@ -440,8 +446,12 @@ describe("single-mutation probes", () => {
     expect(result.value.changes.map(({ kind }) => kind)).toEqual(["format"]);
     expect(result.value.verification).toEqual({ status: "verified" });
     const accepted = await FolioDocxReviewer.fromBuffer(result.value.buffer);
-    const acceptedBlock = accepted.readReviewedStory({ view: "final" })?.snapshot.blocks[blockIndex];
-    const rejectedBlock = accepted.readReviewedStory({ view: "original" })?.snapshot.blocks[blockIndex];
+    const acceptedBlock = accepted.readReviewedStory({ view: "final" })?.snapshot.blocks[
+      blockIndex
+    ];
+    const rejectedBlock = accepted.readReviewedStory({ view: "original" })?.snapshot.blocks[
+      blockIndex
+    ];
     expect(acceptedBlock?.previewRuns?.at(0)?.strike).toBe(true);
     expect(rejectedBlock?.previewRuns?.at(0)?.strike).not.toBe(true);
   });

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -423,6 +423,29 @@ describe("single-mutation probes", () => {
     expect(change?.kind === "format" && change.ranges.length).toBe(1);
   });
 
+  test("format_only_strike: striking a phrase round-trips as tracked formatting", async () => {
+    const blockIndex = wordyBlockIndex(PROSE_BLOCKS, 4);
+    const target = await applyEditScript(PROSE_BASE, [
+      { type: "formatRange", blockIndex, startOffset: 0, endOffset: 4, formatting: { strike: true } },
+    ]);
+    if (target.isErr()) {
+      throw target.error;
+    }
+
+    const result = await compareDocx(PROSE_BASE, target.value.buffer, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["format"]);
+    expect(result.value.verification).toEqual({ status: "verified" });
+    const accepted = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+    const acceptedBlock = accepted.readReviewedStory({ view: "final" })?.snapshot.blocks[blockIndex];
+    const rejectedBlock = accepted.readReviewedStory({ view: "original" })?.snapshot.blocks[blockIndex];
+    expect(acceptedBlock?.previewRuns?.at(0)?.strike).toBe(true);
+    expect(rejectedBlock?.previewRuns?.at(0)?.strike).not.toBe(true);
+  });
+
   test("renumbering: an added list item does not report the items after it", async () => {
     // Inserting at the top renumbers every item below. Labels are rendered
     // from the numbering definitions rather than stored in the paragraphs, so

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -89,6 +89,9 @@ export const projectSupportedInlineFormatting = ({
 }: FolioAIBlock): string => {
   const projected: { length: number; style: string }[] = [];
   for (const run of previewRuns ?? [{ text }]) {
+    if (run.text.length === 0) {
+      continue;
+    }
     const style = supportedInlineStyle(run);
     const previous = projected.at(-1);
     if (previous?.style === style) {

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -83,10 +83,7 @@ const supportedInlineStyle = ({
   }`;
 
 /** Effective supported formatting with equivalent adjacent runs normalized. */
-export const projectSupportedInlineFormatting = ({
-  text,
-  previewRuns,
-}: FolioAIBlock): string => {
+export const projectSupportedInlineFormatting = ({ text, previewRuns }: FolioAIBlock): string => {
   const projected: { length: number; style: string }[] = [];
   for (const run of previewRuns ?? [{ text }]) {
     if (run.text.length === 0) {

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -14,6 +14,7 @@
  */
 
 import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
+import type { FolioAIBlock, FolioAIBlockPreviewRun } from "../ai-edits/types";
 
 /** The two directions of the round trip, each an invariant of its own. */
 export const COMPARE_VERIFICATION_INVARIANTS = Object.freeze([
@@ -70,6 +71,34 @@ export type CompareVerificationFailure = {
 export type CompareVerification =
   | { status: "verified" }
   | { status: "unverified"; failures: readonly CompareVerificationFailure[] };
+
+const supportedInlineStyle = ({
+  bold,
+  italic,
+  underline,
+  strike,
+}: FolioAIBlockPreviewRun): string =>
+  `${bold === true ? "b" : ""}${italic === true ? "i" : ""}${underline === true ? "u" : ""}${
+    strike === true ? "s" : ""
+  }`;
+
+/** Effective supported formatting with equivalent adjacent runs normalized. */
+export const projectSupportedInlineFormatting = ({
+  text,
+  previewRuns,
+}: FolioAIBlock): string => {
+  const projected: { length: number; style: string }[] = [];
+  for (const run of previewRuns ?? [{ text }]) {
+    const style = supportedInlineStyle(run);
+    const previous = projected.at(-1);
+    if (previous?.style === style) {
+      previous.length += run.text.length;
+      continue;
+    }
+    projected.push({ length: run.text.length, style });
+  }
+  return projected.map(({ length, style }) => `${String(length)}:${style}`).join(",");
+};
 
 /**
  * One block of a projection. `projectStory` writes

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -44,6 +44,7 @@ export const COMPARE_VERIFICATION_CAUSES = Object.freeze([
   "container",
   "style",
   "list-level",
+  "inline-formatting",
   "whitespace",
   "text",
 ] as const);

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -19,6 +19,7 @@ import type {
   FolioAIEditSeverity,
   FolioAIEditSkippedOperation,
   FolioAIEditSnapshot,
+  FolioAIInlineFormatting,
   FolioAITextRangeHandle,
 } from "./ai-edits/types";
 
@@ -454,23 +455,30 @@ const readTextRange = (value: Record<string, unknown>, path: string): FolioAITex
 const readInlineFormatting = (
   value: Record<string, unknown>,
   path: string,
-): { bold?: boolean; italic?: boolean; underline?: boolean } => {
+): FolioAIInlineFormatting => {
   const candidate = value["formatting"];
   const formattingPath = `${path}.formatting`;
   if (!isPlainObject(candidate)) {
     return invalidBatch(formattingPath, "expected an object");
   }
-  assertAllowedKeys(candidate, formattingPath, ["bold", "italic", "underline"]);
+  assertAllowedKeys(candidate, formattingPath, ["bold", "italic", "underline", "strike"]);
   const bold = readOptionalBoolean(candidate, "bold", formattingPath);
   const italic = readOptionalBoolean(candidate, "italic", formattingPath);
   const underline = readOptionalBoolean(candidate, "underline", formattingPath);
-  if (bold === undefined && italic === undefined && underline === undefined) {
+  const strike = readOptionalBoolean(candidate, "strike", formattingPath);
+  if (
+    bold === undefined &&
+    italic === undefined &&
+    underline === undefined &&
+    strike === undefined
+  ) {
     return invalidBatch(formattingPath, "expected at least one formatting property");
   }
   return {
     ...(bold !== undefined && { bold }),
     ...(italic !== undefined && { italic }),
     ...(underline !== undefined && { underline }),
+    ...(strike !== undefined && { strike }),
   };
 };
 


### PR DESCRIPTION
A strike-through-only difference produced no formatting change because comparison and operation validation accepted only bold, italic, and underline.

Add tracked strike-through support and verify the four supported boolean formatting properties on text-equal blocks for which the plan emits a formatting change. Normalize equivalent run segmentation and ignore empty runs; index and deduplicate checked blocks so verification stays linear.

This check covers in-memory formatting-only edits. Text-changing edits and inserted paragraphs retain the existing text/container verification boundary.

Validation: focused compare and run-segmentation tests, formatting properties, scoped lint/typecheck, build, and API reports pass. A mutation emitting bold instead of strike fails the formatting round-trip invariant. Native Word opens the generated DOCX: accepting keeps strike-through and rejecting removes it, with no pending formatting revisions afterward.
