### PR TITLE
fix: serialize schema-valid OOXML properties

### DIFF
--- a/.changeset/valid-properties-serialize.md
+++ b/.changeset/valid-properties-serialize.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Serialize run, rendered-page-break, and table-cell properties in schema-valid OOXML order and form.

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -1130,7 +1130,28 @@ function injectRenderedPageBreakIntoFirstRun(xml: string): string | null {
   ) {
     return xml;
   }
-  return xml.replace(runOpeningTag, (match) => `${match}<w:lastRenderedPageBreak/>`);
+  const contentStart = openingTag.index + openingTag[0].length;
+  let insertionOffset = contentStart;
+  if (xml.startsWith("<w:rPr", contentStart)) {
+    const propertyTag = /<\/?w:rPr(?=[\s>/])[^>]*>/gu;
+    propertyTag.lastIndex = contentStart;
+    let depth = 0;
+    for (const match of xml.matchAll(propertyTag)) {
+      if (match.index !== contentStart && depth === 0) {
+        break;
+      }
+      if (match[0].startsWith("</")) {
+        depth--;
+      } else if (!match[0].endsWith("/>")) {
+        depth++;
+      }
+      if (depth === 0) {
+        insertionOffset = match.index + match[0].length;
+        break;
+      }
+    }
+  }
+  return `${xml.slice(0, insertionOffset)}<w:lastRenderedPageBreak/>${xml.slice(insertionOffset)}`;
 }
 
 /**

--- a/packages/core/src/docx/serializer/runSerializer.test.ts
+++ b/packages/core/src/docx/serializer/runSerializer.test.ts
@@ -175,6 +175,119 @@ describe("runSerializer emphasis marks", () => {
   });
 });
 
+describe("runSerializer property order", () => {
+  test("emits language after the formatting properties that precede it in CT_RPr", () => {
+    const xml = serializeRun({
+      type: "run",
+      formatting: {
+        fontFamily: { ascii: "Aptos" },
+        bold: true,
+        italic: true,
+        color: { rgb: "112233" },
+        fontSize: 22,
+        emphasisMark: "dot",
+        language: { val: "en-US" },
+      },
+      content: [{ type: "text", text: "Text" }],
+    });
+
+    expect(xml).toMatch(
+      /<w:rPr><w:rFonts [^>]+\/><w:b\/><w:i\/><w:color [^>]+\/><w:sz [^>]+\/><w:em [^>]+\/><w:lang [^>]+\/><\/w:rPr>/u,
+    );
+  });
+
+  test("emits every supported run property in CT_RPr order", () => {
+    const xml = serializeRun({
+      type: "run",
+      formatting: {
+        styleId: "Emphasis",
+        fontFamily: { ascii: "Aptos" },
+        bold: true,
+        boldCs: true,
+        italic: true,
+        italicCs: true,
+        allCaps: true,
+        smallCaps: true,
+        strike: true,
+        doubleStrike: true,
+        outline: true,
+        shadow: true,
+        emboss: true,
+        imprint: true,
+        hidden: true,
+        color: { rgb: "112233" },
+        spacing: 1,
+        scale: 100,
+        kerning: 2,
+        position: 1,
+        fontSize: 22,
+        fontSizeCs: 22,
+        highlight: "yellow",
+        underline: { style: "single" },
+        effect: "blinkBackground",
+        shading: { fill: { rgb: "445566" } },
+        vertAlign: "superscript",
+        rtl: true,
+        cs: true,
+        emphasisMark: "dot",
+        language: { val: "en-US" },
+      },
+      content: [{ type: "text", text: "Text" }],
+    });
+    const propertyNames = [...xml.matchAll(/<w:([A-Za-z]+)(?:\s[^>]*)?\/>/gu)].map(
+      ([, name]) => name,
+    );
+
+    expect(propertyNames).toEqual([
+      "rStyle",
+      "rFonts",
+      "b",
+      "bCs",
+      "i",
+      "iCs",
+      "caps",
+      "smallCaps",
+      "strike",
+      "dstrike",
+      "outline",
+      "shadow",
+      "emboss",
+      "imprint",
+      "vanish",
+      "color",
+      "spacing",
+      "w",
+      "kern",
+      "position",
+      "sz",
+      "szCs",
+      "highlight",
+      "u",
+      "effect",
+      "shd",
+      "vertAlign",
+      "rtl",
+      "cs",
+      "em",
+      "lang",
+    ]);
+  });
+
+  test("emits a custom highlight fallback at the shading position", () => {
+    const xml = serializeRun({
+      type: "run",
+      formatting: {
+        highlight: "#445566",
+        underline: { style: "single" },
+        vertAlign: "superscript",
+      },
+      content: [{ type: "text", text: "Text" }],
+    });
+
+    expect(xml).toMatch(/<w:u [^>]+\/><w:shd [^>]+\/><w:vertAlign [^>]+\/>/u);
+  });
+});
+
 describe("image EMU attributes are integer-only (issue #417)", () => {
   test("inline image with float dimensions serializes integer cx/cy/effectExtent", () => {
     const xml = serializeRun(FLOAT_INLINE_IMAGE);

--- a/packages/core/src/docx/serializer/runSerializer.ts
+++ b/packages/core/src/docx/serializer/runSerializer.ts
@@ -230,22 +230,6 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     }
   }
 
-  if (formatting.language) {
-    const languageAttrs: string[] = [];
-    if (formatting.language.val) {
-      languageAttrs.push(`w:val="${escapeXml(formatting.language.val)}"`);
-    }
-    if (formatting.language.eastAsia) {
-      languageAttrs.push(`w:eastAsia="${escapeXml(formatting.language.eastAsia)}"`);
-    }
-    if (formatting.language.bidi) {
-      languageAttrs.push(`w:bidi="${escapeXml(formatting.language.bidi)}"`);
-    }
-    if (languageAttrs.length > 0) {
-      parts.push(`<w:lang ${languageAttrs.join(" ")}/>`);
-    }
-  }
-
   // Bold
   if (formatting.bold === true) {
     parts.push("<w:b/>");
@@ -369,9 +353,10 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     parts.push(`<w:szCs w:val="${intAttr(formatting.fontSizeCs)}"/>`);
   }
 
-  // Highlight — emit valid OOXML named colors via w:highlight,
-  // including `none`, which explicitly cancels an inherited highlight.
-  // Fall back to w:shd for custom hex colors.
+  // Highlight — emit valid OOXML named colors via w:highlight, including
+  // `none`, which explicitly cancels an inherited highlight. A custom color
+  // falls back to w:shd at that property's later CT_RPr position.
+  let customHighlightShadingXml = "";
   if (formatting.highlight) {
     if (VALID_HIGHLIGHT_COLORS.has(formatting.highlight)) {
       parts.push(`<w:highlight w:val="${formatting.highlight}"/>`);
@@ -380,7 +365,7 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
       // Only emit if value looks like a valid hex color.
       const hex = formatting.highlight.replace(/^#/u, "");
       if (/^[0-9a-fA-F]{6}$/u.test(hex)) {
-        parts.push(`<w:shd w:val="clear" w:color="auto" w:fill="${hex}"/>`);
+        customHighlightShadingXml = `<w:shd w:val="clear" w:color="auto" w:fill="${hex}"/>`;
       }
     }
   }
@@ -410,13 +395,8 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     parts.push(`<w:effect w:val="${formatting.effect}"/>`);
   }
 
-  // Emphasis mark
-  if (formatting.emphasisMark) {
-    parts.push(`<w:em w:val="${formatting.emphasisMark}"/>`);
-  }
-
   // Shading
-  const shadingXml = serializeShading(formatting.shading);
+  const shadingXml = serializeShading(formatting.shading) || customHighlightShadingXml;
   if (shadingXml) {
     parts.push(shadingXml);
   }
@@ -439,6 +419,27 @@ export function serializeTextFormatting(formatting: TextFormatting | undefined):
     parts.push("<w:cs/>");
   } else if (formatting.cs === false) {
     parts.push('<w:cs w:val="0"/>');
+  }
+
+  // Emphasis mark
+  if (formatting.emphasisMark) {
+    parts.push(`<w:em w:val="${formatting.emphasisMark}"/>`);
+  }
+
+  if (formatting.language) {
+    const languageAttrs: string[] = [];
+    if (formatting.language.val) {
+      languageAttrs.push(`w:val="${escapeXml(formatting.language.val)}"`);
+    }
+    if (formatting.language.eastAsia) {
+      languageAttrs.push(`w:eastAsia="${escapeXml(formatting.language.eastAsia)}"`);
+    }
+    if (formatting.language.bidi) {
+      languageAttrs.push(`w:bidi="${escapeXml(formatting.language.bidi)}"`);
+    }
+    if (languageAttrs.length > 0) {
+      parts.push(`<w:lang ${languageAttrs.join(" ")}/>`);
+    }
   }
 
   if (parts.length === 0) {

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -696,8 +696,10 @@ export function serializeTableCellFormatting(
     }
 
     // Hide mark
-    if (formatting.hideMark !== undefined) {
-      parts.push(formatting.hideMark ? "<w:hideMark/>" : '<w:hideMark w:val="false"/>');
+    if (formatting.hideMark === true) {
+      parts.push("<w:hideMark/>");
+    } else if (formatting.hideMark === false) {
+      parts.push('<w:hideMark w:val="off"/>');
     }
   }
 

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -60,12 +60,12 @@ describe("rowless tables", () => {
 });
 
 describe("table cell marker visibility", () => {
-  test("preserves an explicit false value so it can override a table style", () => {
+  test("uses hideMark's schema-valid off token for an explicit false override", () => {
     const root = parseXmlDocument(`<w:tcPr ${NS}><w:hideMark w:val="false"/></w:tcPr>`);
     const formatting = parseTableCellProperties(root);
 
     expect(formatting?.hideMark).toBe(false);
-    expect(serializeTableCellFormatting(formatting)).toContain('<w:hideMark w:val="false"/>');
+    expect(serializeTableCellFormatting(formatting)).toContain('<w:hideMark w:val="off"/>');
   });
 });
 

--- a/packages/core/src/prosemirror/conversion/renderedPageBreakRoundtrip.test.ts
+++ b/packages/core/src/prosemirror/conversion/renderedPageBreakRoundtrip.test.ts
@@ -19,8 +19,32 @@ describe("renderedPageBreakBefore round-trip", () => {
 
     const xml = serializeParagraph(parsed as never);
     expect(xml).toMatch(/<w:lastRenderedPageBreak\/>/u);
-    expect(xml).toMatch(/<w:r[^>]*><w:lastRenderedPageBreak\/>/u);
+    expect(xml).toMatch(/<w:r[^>]*>(?:<w:rPr>.*<\/w:rPr>)?<w:lastRenderedPageBreak\/>/u);
     expect(xml.match(/<w:lastRenderedPageBreak\/>/gu)).toHaveLength(1);
+  });
+
+  test("injects the marker after run properties, including a nested previous-property snapshot", () => {
+    const xml = serializeParagraph({
+      type: "paragraph",
+      renderedPageBreakBefore: true,
+      content: [
+        {
+          type: "run",
+          formatting: { bold: true },
+          propertyChanges: [
+            {
+              info: { id: 1, author: "Reviewer" },
+              previousFormatting: { italic: true },
+            },
+          ],
+          content: [{ type: "text", text: "Attachment 1" }],
+        },
+      ],
+    } as never);
+
+    expect(xml).toMatch(
+      /<w:r><w:rPr><w:b\/><w:rPrChange [^>]+><w:rPr><w:i\/><\/w:rPr><\/w:rPrChange><\/w:rPr><w:lastRenderedPageBreak\/><w:t>/u,
+    );
   });
 
   test("preserves an inline cached boundary at its editable position", () => {

--- a/packages/core/src/prosemirror/conversion/renderedPageBreakRoundtrip.test.ts
+++ b/packages/core/src/prosemirror/conversion/renderedPageBreakRoundtrip.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { panic } from "better-result";
 
 import { serializeParagraph } from "../../docx/serializer/paragraphSerializer";
 import { schema } from "../schema";
@@ -12,12 +13,13 @@ describe("renderedPageBreakBefore round-trip", () => {
     const doc = schema.node("doc", null, [paragraph]);
 
     const document = fromProseDoc(doc);
-    const parsed = document.package.document.content[0] as {
-      renderedPageBreakBefore?: boolean;
-    };
+    const parsed = document.package.document.content.at(0);
+    if (parsed?.type !== "paragraph") {
+      panic("Expected the converted paragraph");
+    }
     expect(parsed.renderedPageBreakBefore).toBe(true);
 
-    const xml = serializeParagraph(parsed as never);
+    const xml = serializeParagraph(parsed);
     expect(xml).toMatch(/<w:lastRenderedPageBreak\/>/u);
     expect(xml).toMatch(/<w:r[^>]*>(?:<w:rPr>.*<\/w:rPr>)?<w:lastRenderedPageBreak\/>/u);
     expect(xml.match(/<w:lastRenderedPageBreak\/>/gu)).toHaveLength(1);
@@ -40,7 +42,7 @@ describe("renderedPageBreakBefore round-trip", () => {
           content: [{ type: "text", text: "Attachment 1" }],
         },
       ],
-    } as never);
+    });
 
     expect(xml).toMatch(
       /<w:r><w:rPr><w:b\/><w:rPrChange [^>]+><w:rPr><w:i\/><\/w:rPr><\/w:rPrChange><\/w:rPr><w:lastRenderedPageBreak\/><w:t>/u,
@@ -64,9 +66,7 @@ describe("renderedPageBreakBefore round-trip", () => {
         { type: "run", content: [{ type: "text", text: "Next page" }] },
       ],
     });
-    expect(serializeParagraph(parsed as never).match(/<w:lastRenderedPageBreak\/>/gu)).toHaveLength(
-      1,
-    );
+    expect(serializeParagraph(parsed).match(/<w:lastRenderedPageBreak\/>/gu)).toHaveLength(1);
   });
 
   test("serializer injects marker into the first run inside a hyperlink wrapper", () => {


### PR DESCRIPTION
DOCX export now emits supported run properties in schema order, places cached page breaks after complete run-property blocks, and writes explicit disabled cell hide-mark values as `off`. This includes custom-highlight shading and nested previous-property snapshots.

Synthetic ordering and round-trip regressions pass (59 focused tests), including an old-order mutation check. Core typecheck and scoped lint pass; a fully formatted synthetic DOCX validates with zero Microsoft Open XML SDK errors.
