### PR TITLE
fix: keep revision element IDs unique on export

### DIFF
--- a/.changeset/tidy-revisions-smile.md
+++ b/.changeset/tidy-revisions-smile.md
@@ -1,0 +1,5 @@
+---
+"@stll/core": patch
+---
+
+Keep physical tracked-change revision IDs unique when saving DOCX packages.

--- a/.changeset/tidy-revisions-smile.md
+++ b/.changeset/tidy-revisions-smile.md
@@ -1,5 +1,5 @@
 ---
-"@stll/core": patch
+"@stll/folio-core": patch
 ---
 
 Keep physical tracked-change revision IDs unique when saving DOCX packages.

--- a/.changeset/tidy-revisions-smile.md
+++ b/.changeset/tidy-revisions-smile.md
@@ -1,5 +1,6 @@
 ---
 "@stll/folio-core": patch
+"@stll/docx-core": patch
 ---
 
 Keep physical tracked-change revision IDs unique when saving DOCX packages.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -1413,7 +1413,7 @@ export type TrackedChangeInfo = {
 export type TrackedRunChange = Insertion | Deletion | MoveFrom | MoveTo;
 
 // @public
-export type TrackedRunContent = Run | Hyperlink | BookmarkStart | BookmarkEnd;
+export type TrackedRunContent = Run | Hyperlink | BookmarkStart | BookmarkEnd | SimpleField | ComplexField | TrackedRunChange;
 
 // @public
 export type UnderlineStyle = "none" | "single" | "words" | "double" | "thick" | "dotted" | "dottedHeavy" | "dash" | "dashedHeavy" | "dashLong" | "dashLongHeavy" | "dotDash" | "dashDotHeavy" | "dotDotDash" | "dashDotDotHeavy" | "wave" | "wavyHeavy" | "wavyDouble";

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1045,7 +1045,13 @@ function isTrackedChangeWrapperChild(
     content.type === "run" ||
     content.type === "hyperlink" ||
     content.type === "bookmarkStart" ||
-    content.type === "bookmarkEnd"
+    content.type === "bookmarkEnd" ||
+    content.type === "simpleField" ||
+    content.type === "complexField" ||
+    content.type === "insertion" ||
+    content.type === "deletion" ||
+    content.type === "moveFrom" ||
+    content.type === "moveTo"
   );
 }
 

--- a/packages/core/src/docx/revisionIdNormalization.test.ts
+++ b/packages/core/src/docx/revisionIdNormalization.test.ts
@@ -41,3 +41,12 @@ test("normalizes every tracked revision element kind", () => {
   expect(new Set(ids).size).toBe(ids.length);
   expect(ids.at(0)).toBe("5");
 });
+
+test("respects Strict namespaces and nested prefix rebinding", () => {
+  const strict = "http://purl.oclc.org/ooxml/wordprocessingml/main";
+  const xml = `<w:document xmlns:w="${strict}"><w:del w:id="8"/><w:del xmlns:w="urn:foreign" w:id="8"/><w:del w:id="8"/></w:document>`;
+  const normalized = normalizeRevisionIdsInXmlParts(new Map([["word/document.xml", xml]]));
+  expect(normalized.get("word/document.xml")).toBe(
+    xml.replace('<w:del w:id="8"/></w:document>', '<w:del w:id="0"/></w:document>'),
+  );
+});

--- a/packages/core/src/docx/revisionIdNormalization.test.ts
+++ b/packages/core/src/docx/revisionIdNormalization.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+
+import { normalizeRevisionIdsInXmlParts, REVISION_ELEMENT_NAMES } from "./revisionIdNormalization";
+
+const W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+test("keeps unique revision ids and paired range ids byte-identical", () => {
+  const xml = `<x:document xmlns:x="${W}"><x:moveFromRangeStart x:id="4" x:name="m"/><x:moveFrom x:id="7" x:author="A"/><x:moveFromRangeEnd x:id="4"/></x:document>`;
+  expect(
+    normalizeRevisionIdsInXmlParts(new Map([["word/document.xml", xml]])).get("word/document.xml"),
+  ).toBe(xml);
+});
+
+test("assigns fresh ids to repeated physical revisions across parts idempotently", () => {
+  const parts = new Map([
+    [
+      "word/document.xml",
+      `<?xml version="1.0"?>\r\n<x:document xmlns:x="${W}"><?keep value?><x:del x:id="9" x:author="A &amp; &quot;B&quot;"/><!-- exact --><![CDATA[<x:del x:id="9"/>]]><x:del x:id='9'/><x:bookmarkStart x:id="9"/></x:document>`,
+    ],
+    ["word/header1.xml", `<ž:hdr xmlns:ž="${W}"><ž:ins ž:id="9"/></ž:hdr>`],
+  ]);
+  const once = normalizeRevisionIdsInXmlParts(parts);
+  const twice = normalizeRevisionIdsInXmlParts(once);
+  expect(once.get("word/document.xml")).toContain("<x:del x:id='0'/>");
+  expect(once.get("word/header1.xml")).toContain('<ž:ins ž:id="1"/>');
+  expect(twice).toEqual(once);
+  expect(once.get("word/document.xml")).toContain(
+    '<?keep value?><x:del x:id="9" x:author="A &amp; &quot;B&quot;"/><!-- exact --><![CDATA[<x:del x:id="9"/>]]>',
+  );
+  expect(once.get("word/document.xml")).toContain('<x:bookmarkStart x:id="9"/>');
+});
+
+test("normalizes every tracked revision element kind", () => {
+  const revisions = [...REVISION_ELEMENT_NAMES].map((name) => `<w:${name} w:id="5"/>`).join("");
+  const xml = `<w:document xmlns:w="${W}">${revisions}</w:document>`;
+  const normalized = normalizeRevisionIdsInXmlParts(new Map([["word/document.xml", xml]])).get(
+    "word/document.xml",
+  );
+  const ids = [...(normalized ?? "").matchAll(/w:id="(\d+)"/gu)].map((match) => match[1]);
+  expect(ids).toHaveLength(REVISION_ELEMENT_NAMES.size);
+  expect(new Set(ids).size).toBe(ids.length);
+  expect(ids.at(0)).toBe("5");
+});

--- a/packages/core/src/docx/revisionIdNormalization.ts
+++ b/packages/core/src/docx/revisionIdNormalization.ts
@@ -1,0 +1,145 @@
+import {
+  findAttributeByNamespaceUri,
+  getLocalName,
+  getNamespaceUri,
+  type XmlElement,
+  WORDPROCESSINGML_NAMESPACE_URIS,
+} from "./xmlParser";
+import { rewriteStreamingXmlDecimalAttributes } from "./streamingXmlParser";
+import { assertXmlResourceLimits, XmlResourceLimitError } from "./xmlResourceLimits";
+
+export const REVISION_ELEMENT_NAMES = new Set([
+  "cellDel",
+  "cellIns",
+  "cellMerge",
+  "del",
+  "ins",
+  "moveFrom",
+  "moveTo",
+  "numberingChange",
+  "pPrChange",
+  "rPrChange",
+  "sectPrChange",
+  "tblGridChange",
+  "tblPrChange",
+  "tblPrExChange",
+  "tcPrChange",
+  "trPrChange",
+]);
+
+const REVISION_ELEMENT_CANDIDATE = new RegExp(
+  `<(?:[^\\s<>/:]+:)?(?:${[...REVISION_ELEMENT_NAMES].join("|")})(?:[\\s/>])`,
+  "u",
+);
+
+type RevisionAttribute = { name: string; id: number };
+
+const revisionAttribute = (element: XmlElement): RevisionAttribute | null => {
+  if (
+    !element.name ||
+    !WORDPROCESSINGML_NAMESPACE_URIS.has(getNamespaceUri(element) ?? "") ||
+    !REVISION_ELEMENT_NAMES.has(getLocalName(element.name))
+  ) {
+    return null;
+  }
+  const attribute = findAttributeByNamespaceUri(element, WORDPROCESSINGML_NAMESPACE_URIS, "id");
+  if (!attribute) {
+    return null;
+  }
+  const id = Number(attribute.value);
+  return Number.isSafeInteger(id) && id >= 0 ? { name: attribute.name, id } : null;
+};
+
+/**
+ * Keep physical tracked-change element ids unique across a package.
+ *
+ * Live editor marks and operation receipts keep their logical revision IDs.
+ * Saving assigns fresh IDs only where one logical change was split into
+ * multiple physical OOXML wrappers; reopening therefore exposes the physical
+ * wrapper IDs that the file format requires.
+ */
+export const normalizeRevisionIdsInXmlParts = (
+  parts: ReadonlyMap<string, string>,
+): Map<string, string> => {
+  const candidates = [...parts].filter(([, xml]) => REVISION_ELEMENT_CANDIDATE.test(xml));
+  const occurrencesByPath = new Map<string, number[]>();
+  const reserved = new Set<number>();
+  for (const [path, xml] of candidates) {
+    assertXmlResourceLimits(xml);
+    const ids: number[] = [];
+    const scanned = rewriteStreamingXmlDecimalAttributes(xml, (element) => {
+      const attribute = revisionAttribute(element);
+      if (attribute) {
+        ids.push(attribute.id);
+        reserved.add(attribute.id);
+      }
+      return null;
+    });
+    if (scanned.status === "unsupported") {
+      throw new XmlResourceLimitError({
+        message: `Revision-id normalization could not safely scan ${path}`,
+        limit: "syntax",
+      });
+    }
+    occurrencesByPath.set(path, ids);
+  }
+
+  const repeatedPaths = new Set<string>();
+  const firstSeen = new Set<number>();
+  for (const [path, ids] of occurrencesByPath) {
+    for (const id of ids) {
+      if (firstSeen.has(id)) {
+        repeatedPaths.add(path);
+      } else {
+        firstSeen.add(id);
+      }
+    }
+  }
+
+  let nextId = 0;
+  const allocate = (): number => {
+    while (reserved.has(nextId)) {
+      nextId += 1;
+    }
+    const allocated = nextId;
+    reserved.add(allocated);
+    nextId += 1;
+    return allocated;
+  };
+
+  const seen = new Set<number>();
+  const normalized = new Map(parts);
+  for (const [path, xml] of candidates) {
+    const ids = occurrencesByPath.get(path);
+    if (!ids) {
+      continue;
+    }
+    if (!repeatedPaths.has(path) && ids.every((id) => !seen.has(id))) {
+      for (const id of ids) {
+        seen.add(id);
+      }
+      continue;
+    }
+    const rewritten = rewriteStreamingXmlDecimalAttributes(xml, (element) => {
+      const attribute = revisionAttribute(element);
+      if (!attribute) {
+        return null;
+      }
+      if (!seen.has(attribute.id)) {
+        seen.add(attribute.id);
+        return null;
+      }
+      const replacement = allocate();
+      seen.add(replacement);
+      return new Map([[attribute.name, String(replacement)]]);
+    });
+    if (rewritten.status === "unsupported") {
+      throw new XmlResourceLimitError({
+        message: `Revision-id normalization could not safely rewrite ${path}`,
+        limit: "syntax",
+      });
+    }
+    normalized.set(path, rewritten.value);
+  }
+  return normalized;
+};

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -97,6 +97,7 @@ import {
   WORDPROCESSINGML_NAMESPACE_URIS,
   type XmlElement,
 } from "./xmlParser";
+import { normalizeRevisionIdsInXmlParts } from "./revisionIdNormalization";
 import { assertXmlResourceLimits } from "./xmlResourceLimits";
 import { isAllowedExternalWatermarkImageUrl } from "../watermark";
 
@@ -778,6 +779,22 @@ export type RepackOptions = {
  */
 const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> => {
   await reconcilePackageReferences(zip, compressionLevel);
+  const xmlParts = new Map<string, string>();
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (!file.dir && path.startsWith("word/") && path.endsWith(".xml")) {
+      // oxlint-disable-next-line no-await-in-loop -- package parts share one revision-id namespace and must be collected before rewriting
+      xmlParts.set(path, await file.async("text"));
+    }
+  }
+  const normalizedParts = normalizeRevisionIdsInXmlParts(xmlParts);
+  for (const [path, xml] of normalizedParts) {
+    if (xml !== xmlParts.get(path)) {
+      zip.file(path, xml, {
+        compression: "DEFLATE",
+        compressionOptions: { level: compressionLevel },
+      });
+    }
+  }
   return zip.generateAsync({
     type: "arraybuffer",
     compression: "DEFLATE",

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { parseParagraph } from "../paragraphParser";
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import type { ComplexField, Paragraph } from "../../types/document";
+import { createEmptyDocument } from "../../utils/createDocument";
 import { parseXmlDocument, type XmlElement } from "../xmlParser";
 import { serializeParagraph } from "./paragraphSerializer";
 
@@ -232,6 +235,95 @@ describe("serializeSimpleField structural round-trip", () => {
 });
 
 describe("serializeParagraph tracked-change hardening", () => {
+  test("keeps a complex field inside its authored revision wrapper through the editor model", () => {
+    const namespace = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const source = parseXmlDocument(`
+      <w:p ${namespace}>
+        <w:del w:id="22" w:author="Reviewer">
+          <w:r><w:delText>before </w:delText></w:r>
+          <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+          <w:r><w:delInstrText> REF target </w:delInstrText></w:r>
+          <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+          <w:r><w:delText>1</w:delText></w:r>
+          <w:r><w:fldChar w:fldCharType="end"/></w:r>
+          <w:r><w:delText> after</w:delText></w:r>
+        </w:del>
+      </w:p>
+    `);
+    if (!source) {
+      throw new Error("failed to parse tracked field fixture");
+    }
+    const paragraph = parseParagraph(source, null, null, null, null, null);
+    const deletion = paragraph.content.at(0);
+    expect(deletion?.type).toBe("deletion");
+    if (deletion?.type !== "deletion") {
+      return;
+    }
+    expect(deletion.content.map(({ type }) => type)).toEqual(["run", "complexField", "run"]);
+
+    const document = createEmptyDocument();
+    document.package.document.content = [paragraph];
+    const rebuilt = fromProseDoc(toProseDoc(document), document);
+    const rebuiltParagraph = rebuilt.package.document.content.at(0);
+    expect(rebuiltParagraph?.type).toBe("paragraph");
+    if (rebuiltParagraph?.type !== "paragraph") {
+      return;
+    }
+    const xml = serializeParagraph(rebuiltParagraph);
+    expect(xml.match(/<w:del\b/gu)).toHaveLength(1);
+    expect(xml).toContain("<w:delInstrText");
+  });
+
+  test("keeps nested revisions inside the authored outer wrapper", () => {
+    const namespace = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const source = parseXmlDocument(`
+      <w:p ${namespace}>
+        <w:ins w:id="40" w:author="Outer">
+          <w:r><w:t>added </w:t></w:r>
+          <w:del w:id="41" w:author="Inner"><w:r><w:delText>removed</w:delText></w:r></w:del>
+          <w:r><w:t> text</w:t></w:r>
+        </w:ins>
+      </w:p>
+    `);
+    if (!source) {
+      throw new Error("failed to parse nested revision fixture");
+    }
+    const paragraph = parseParagraph(source, null, null, null, null, null);
+    const insertion = paragraph.content.at(0);
+    expect(insertion?.type).toBe("insertion");
+    if (insertion?.type !== "insertion") {
+      return;
+    }
+    expect(insertion.content.map(({ type }) => type)).toEqual(["run", "deletion", "run"]);
+    const xml = serializeParagraph(paragraph);
+    expect(xml.match(/<w:ins\b/gu)).toHaveLength(1);
+    expect(xml.match(/<w:del\b/gu)).toHaveLength(1);
+    expect(xml.indexOf("<w:del ")).toBeGreaterThan(xml.indexOf("<w:ins "));
+    expect(xml.indexOf("</w:del>")).toBeLessThan(xml.indexOf("</w:ins>"));
+  });
+
+  test("does not absorb untracked content between separate same-id revisions", () => {
+    const info = { id: 7, author: "Reviewer" };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "insertion",
+          info,
+          content: [{ type: "run", content: [{ type: "text", text: "A" }] }],
+        },
+        { type: "run", content: [{ type: "text", text: "B" }] },
+        {
+          type: "insertion",
+          info,
+          content: [{ type: "run", content: [{ type: "text", text: "C" }] }],
+        },
+      ],
+    };
+    const xml = serializeParagraph(paragraph);
+    expect(xml).toContain("</w:ins><w:r><w:t>B</w:t></w:r><w:ins");
+  });
+
   test("serializes deletion runs using delText and delInstrText", () => {
     const paragraph: Paragraph = {
       type: "paragraph",

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -923,6 +923,21 @@ function rewriteRunTextAsDeleted(xml: string): string {
     .replace(/<\/w:instrText>/gu, "</w:delInstrText>");
 }
 
+function trackedChangeTag(
+  change: Insertion | Deletion | MoveFrom | MoveTo,
+): "ins" | "del" | "moveFrom" | "moveTo" {
+  switch (change.type) {
+    case "insertion":
+      return "ins";
+    case "deletion":
+      return "del";
+    case "moveFrom":
+      return "moveFrom";
+    case "moveTo":
+      return "moveTo";
+  }
+}
+
 function serializeTrackedChange(
   tag: "ins" | "del" | "moveFrom" | "moveTo",
   change: Insertion | Deletion | MoveFrom | MoveTo,
@@ -976,6 +991,19 @@ function serializeTrackedChange(
       }
       if (item.type === "hyperlink") {
         return serializeHyperlink(item);
+      }
+      if (item.type === "simpleField" || item.type === "complexField") {
+        const xml =
+          item.type === "simpleField" ? serializeSimpleField(item) : serializeComplexField(item);
+        return tag === "del" || tag === "moveFrom" ? rewriteRunTextAsDeleted(xml) : xml;
+      }
+      if (
+        item.type === "insertion" ||
+        item.type === "deletion" ||
+        item.type === "moveFrom" ||
+        item.type === "moveTo"
+      ) {
+        return serializeTrackedChange(trackedChangeTag(item), item);
       }
       return item.type === "bookmarkStart"
         ? serializeBookmarkStart(item)

--- a/packages/core/src/docx/streamingXmlParser.test.ts
+++ b/packages/core/src/docx/streamingXmlParser.test.ts
@@ -4,7 +4,7 @@ import JSZip from "jszip";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { parseStreamingXml } from "./streamingXmlParser";
+import { parseStreamingXml, rewriteStreamingXmlDecimalAttributes } from "./streamingXmlParser";
 import {
   getAttributeByNamespaceUri,
   getChildElements,
@@ -147,3 +147,12 @@ describe("parseStreamingXml", () => {
     }
   });
 });
+
+test.each(["' injected='yes", '\"/>', "&quot;", "1.5", "-1"])(
+  "refuses a non-decimal attribute replacement: %s",
+  (replacement) => {
+    expect(
+      rewriteStreamingXmlDecimalAttributes('<r id="1"/>', () => new Map([["id", replacement]])),
+    ).toEqual({ status: "unsupported" });
+  },
+);

--- a/packages/core/src/docx/streamingXmlParser.test.ts
+++ b/packages/core/src/docx/streamingXmlParser.test.ts
@@ -148,7 +148,7 @@ describe("parseStreamingXml", () => {
   });
 });
 
-test.each(["' injected='yes", '\"/>', "&quot;", "1.5", "-1"])(
+test.each(["' injected='yes", '"/>', "&quot;", "1.5", "-1"])(
   "refuses a non-decimal attribute replacement: %s",
   (replacement) => {
     expect(

--- a/packages/core/src/docx/streamingXmlParser.ts
+++ b/packages/core/src/docx/streamingXmlParser.ts
@@ -21,9 +21,24 @@ const BUILT_IN_ENTITIES = {
  * pass. Unsupported or malformed constructs return a sentinel so callers can
  * retain the general-purpose parser as a compatibility fallback.
  */
-export const parseStreamingXml = (xml: string): ParseXmlResult => {
+type AttributeValueSpan = { start: number; end: number };
+type OpenTagVisitor = (
+  element: XmlElement,
+  attributeValueSpans: ReadonlyMap<string, AttributeValueSpan>,
+) => ReadonlyMap<string, string> | null;
+
+type XmlReplacement = AttributeValueSpan & { value: string };
+type InternalParseXmlResult =
+  | { status: "parsed"; value: XmlElement; replacements: XmlReplacement[] }
+  | { status: "unsupported" };
+
+const parseStreamingXmlInternal = (
+  xml: string,
+  visitOpenTag?: OpenTagVisitor,
+): InternalParseXmlResult => {
   const root: XmlElement = { elements: [] };
   const stack: ElementFrame[] = [];
+  const replacements: XmlReplacement[] = [];
   let cursor = 0;
   let mergeAdjacentText = false;
 
@@ -91,13 +106,23 @@ export const parseStreamingXml = (xml: string): ParseXmlResult => {
       continue;
     }
 
-    const parsedTag = parseOpenTag(xml, open + 1, close);
+    const parsedTag = parseOpenTag(xml, open + 1, close, visitOpenTag !== undefined);
     if (parsedTag.status === "unsupported") {
       return parsedTag;
     }
 
     const parent = stack.at(-1)?.element ?? root;
     attachXmlNamespaceContext(parsedTag.element, parent.namespaceScope);
+    const rewritten = visitOpenTag?.(parsedTag.element, parsedTag.attributeValueSpans ?? new Map());
+    if (rewritten) {
+      for (const [attributeName, value] of rewritten) {
+        const span = parsedTag.attributeValueSpans?.get(attributeName);
+        if (!span) {
+          return { status: "unsupported" };
+        }
+        replacements.push({ ...span, value });
+      }
+    }
     appendElement(parent, parsedTag.element);
     if (!parsedTag.selfClosing) {
       if (stack.length >= FOLIO_XML_RESOURCE_LIMITS.maxDepth) {
@@ -112,7 +137,38 @@ export const parseStreamingXml = (xml: string): ParseXmlResult => {
   if (stack.length > 0) {
     return { status: "unsupported" };
   }
-  return { status: "parsed", value: root };
+  return { status: "parsed", value: root, replacements };
+};
+
+export const parseStreamingXml = (xml: string): ParseXmlResult => {
+  const parsed = parseStreamingXmlInternal(xml);
+  return parsed.status === "parsed"
+    ? { status: "parsed", value: parsed.value }
+    : { status: "unsupported" };
+};
+
+/** Rewrite selected decimal attribute values while preserving every other source byte. */
+export const rewriteStreamingXmlDecimalAttributes = (
+  xml: string,
+  visitOpenTag: OpenTagVisitor,
+): { status: "rewritten"; value: string } | { status: "unsupported" } => {
+  const parsed = parseStreamingXmlInternal(xml, visitOpenTag);
+  if (parsed.status === "unsupported") {
+    return parsed;
+  }
+  const chunks: string[] = [];
+  let cursor = 0;
+  for (const replacement of parsed.replacements.toSorted(
+    (left, right) => left.start - right.start,
+  )) {
+    if (!/^\d+$/u.test(replacement.value)) {
+      return { status: "unsupported" };
+    }
+    chunks.push(xml.slice(cursor, replacement.start), replacement.value);
+    cursor = replacement.end;
+  }
+  chunks.push(xml.slice(cursor));
+  return { status: "rewritten", value: chunks.join("") };
 };
 
 type ParsedOpenTag =
@@ -121,10 +177,16 @@ type ParsedOpenTag =
       element: XmlElement;
       name: string;
       selfClosing: boolean;
+      attributeValueSpans: ReadonlyMap<string, AttributeValueSpan> | undefined;
     }
   | { status: "unsupported" };
 
-const parseOpenTag = (xml: string, start: number, close: number): ParsedOpenTag => {
+const parseOpenTag = (
+  xml: string,
+  start: number,
+  close: number,
+  captureAttributeSpans: boolean,
+): ParsedOpenTag => {
   let cursor = skipWhitespace(xml, start, close);
   const nameStart = cursor;
   cursor = scanName(xml, cursor, close);
@@ -137,6 +199,9 @@ const parseOpenTag = (xml: string, start: number, close: number): ParsedOpenTag 
     return { status: "unsupported" };
   }
   let attributes: Record<string, string> | undefined;
+  const attributeValueSpans = captureAttributeSpans
+    ? new Map<string, AttributeValueSpan>()
+    : undefined;
   let selfClosing = false;
 
   while (cursor < close) {
@@ -183,6 +248,7 @@ const parseOpenTag = (xml: string, start: number, close: number): ParsedOpenTag 
     }
     attributes ??= {};
     attributes[attributeName] = decoded;
+    attributeValueSpans?.set(attributeName, { start: valueStart, end: cursor });
     cursor += 1;
   }
 
@@ -190,7 +256,7 @@ const parseOpenTag = (xml: string, start: number, close: number): ParsedOpenTag 
   if (attributes) {
     element.attributes = attributes;
   }
-  return { status: "parsed", element, name, selfClosing };
+  return { status: "parsed", element, name, selfClosing, attributeValueSpans };
 };
 
 const appendElement = (parent: XmlElement, child: XmlElement): void => {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1696,6 +1696,15 @@ function extractParagraphContent(
         currentTrackedChange.wrapper.content.push(boundary);
         return;
       }
+      if (node.type.name === "field" || node.type.name === "structuredField") {
+        currentTrackedChange.wrapper.content.push(
+          createFieldFromNode(node, {
+            marks: otherMarks,
+            textBoxAnchorMarkers,
+          }),
+        );
+        return;
+      }
       const run = createTrackedChangeRun({ inheritedFormatting, marks: otherMarks, node });
       if (run) {
         currentTrackedChange.wrapper.content.push(run);

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -13,6 +13,7 @@
  */
 
 import type { MarkType, Node as PMNode } from "prosemirror-model";
+import { panic } from "better-result";
 
 import { createStyleEngine } from "../../style-engine";
 import type { StyleEngine, TableCellParagraphSpacingOverlay } from "../../style-engine";
@@ -45,8 +46,7 @@ import type {
   DrawingContent,
   MoveFrom,
   MoveTo,
-  BookmarkStart,
-  BookmarkEnd,
+  TrackedRunContent,
   MathEquation,
   ShapeTextBody,
   Theme,
@@ -746,6 +746,36 @@ function convertTrackedChange(
           textBoxAnchors,
         }),
       );
+    } else if (item.type === "simpleField" || item.type === "complexField") {
+      const fieldNode = convertField(item, {
+        getInheritedRunFormatting,
+        styleResolver,
+        nextHyperlinkInstanceIndex,
+        textBoxAnchors,
+      });
+      if (fieldNode) {
+        nodes.push(fieldNode);
+      }
+    } else if (
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
+      const nestedMarkType =
+        item.type === "insertion" || item.type === "moveTo" ? "insertion" : "deletion";
+      const nestedMoveKind = item.type === "moveFrom" || item.type === "moveTo" ? item.type : null;
+      nodes.push(
+        ...convertTrackedChange(
+          item,
+          nestedMarkType,
+          nextHyperlinkInstanceIndex,
+          getInheritedRunFormatting,
+          styleResolver,
+          nestedMoveKind,
+          textBoxAnchors,
+        ),
+      );
     } else if (item.type === "bookmarkStart") {
       nodes.push(
         schema.node("bookmarkBoundary", {
@@ -756,8 +786,11 @@ function convertTrackedChange(
           colLast: item.colLast,
         }),
       );
-    } else {
+    } else if (item.type === "bookmarkEnd") {
       nodes.push(schema.node("bookmarkBoundary", { type: "end", id: item.id }));
+    } else {
+      const unsupported: never = item;
+      panic(`Unsupported tracked-run content: ${JSON.stringify(unsupported)}`);
     }
   }
 
@@ -771,6 +804,12 @@ function convertTrackedChange(
   });
 
   return nodes.map((node) => {
+    // ProseMirror marks cannot nest another mark of the same type. Keep the
+    // inner revision intact rather than replacing its identity with the outer
+    // wrapper; the surrounding nodes still retain the outer revision.
+    if (node.marks.some(({ type }) => type.name === "insertion" || type.name === "deletion")) {
+      return node;
+    }
     if (canCarryTrackedRunMark(node, mark.type)) {
       return node.mark(mark.addToSet(node.marks));
     }
@@ -779,17 +818,24 @@ function convertTrackedChange(
 }
 
 function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
+  if (node.isText) {
+    return true;
+  }
+  if (!node.isInline) {
+    return false;
+  }
+  if (node.type.name === "field" || node.type.name === "structuredField") {
+    return true;
+  }
   return (
-    node.isText ||
-    (node.isInline &&
-      node.type.allowsMarkType(markType) &&
-      (node.type.name === "image" ||
-        node.type.name === "shape" ||
-        node.type.name === "hardBreak" ||
-        node.type.name === "tab" ||
-        node.type.name === "symbol" ||
-        node.type.name === "bookmarkBoundary" ||
-        node.type.name === "textBoxAnchor"))
+    node.type.allowsMarkType(markType) &&
+    (node.type.name === "image" ||
+      node.type.name === "shape" ||
+      node.type.name === "hardBreak" ||
+      node.type.name === "tab" ||
+      node.type.name === "symbol" ||
+      node.type.name === "bookmarkBoundary" ||
+      node.type.name === "textBoxAnchor")
   );
 }
 
@@ -4191,20 +4237,48 @@ function findParagraphPageBreakPosition(paragraph: Paragraph): "before" | "after
     return false;
   }
 
-  // Walk a (Run | Hyperlink)[] list — the shared inner shape of tracked-change
-  // wrappers, simple fields, and inline SDTs. We rely on visitRun to set
+  // Walk tracked-wrapper content recursively. We rely on visitRun to set
   // state.seenVisibleContent when (and only when) it encounters visible run
   // content; an empty wrapper must not be treated as visible — an empty
   // bookmark-only hyperlink before a page break should still classify the
   // break as "before".
-  function visitRunOrHyperlinkList(
-    children: readonly (Run | Hyperlink | BookmarkStart | BookmarkEnd)[],
-  ): boolean {
+  function visitRunOrHyperlinkList(children: readonly TrackedRunContent[]): boolean {
     for (const child of children) {
       if (child.type === "run" && visitRun(child)) {
         return true;
       }
       if (child.type === "hyperlink" && visitHyperlinkChildren(child)) {
+        return true;
+      }
+      if (child.type === "simpleField") {
+        for (const fieldChild of child.content) {
+          if (fieldChild.type === "run" && visitRun(fieldChild)) {
+            return true;
+          }
+          if (fieldChild.type === "hyperlink" && visitHyperlinkChildren(fieldChild)) {
+            return true;
+          }
+        }
+      }
+      if (child.type === "complexField") {
+        for (const run of child.fieldCode) {
+          if (visitRun(run)) {
+            return true;
+          }
+        }
+        for (const run of child.fieldResult) {
+          if (visitRun(run)) {
+            return true;
+          }
+        }
+      }
+      if (
+        (child.type === "insertion" ||
+          child.type === "deletion" ||
+          child.type === "moveFrom" ||
+          child.type === "moveTo") &&
+        visitRunOrHyperlinkList(child.content)
+      ) {
         return true;
       }
     }

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1053,7 +1053,14 @@ export type PropertyChangeInfo = {
 } & TrackedChangeInfo;
 
 /** Inline content that may sit inside a run-level tracked-change wrapper. */
-export type TrackedRunContent = Run | Hyperlink | BookmarkStart | BookmarkEnd;
+export type TrackedRunContent =
+  | Run
+  | Hyperlink
+  | BookmarkStart
+  | BookmarkEnd
+  | SimpleField
+  | ComplexField
+  | TrackedRunChange;
 
 /**
  * Insertion wrapper (w:ins) — runs inserted by tracked changes

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -627,11 +627,7 @@ const validateTrackedRunChange = (
 
   for (const [index, child] of change.content.entries()) {
     const childPath = `${path}.content[${index}]`;
-    if (child.type === "hyperlink") {
-      validateHyperlink(child, childPath, ctx);
-      continue;
-    }
-    validateHyperlinkChild(child, childPath, ctx);
+    validateParagraphContent(child, childPath, ctx);
   }
 };
 


### PR DESCRIPTION
DOCX exports now assign distinct IDs to physical tracked-change elements when a logical edit splits across wrappers or package parts. Authored field and nested revision content stays inside its original wrapper during direct serialization, preserving valid existing IDs and full/selective save equivalence. Unique IDs and paired range markers remain intact.

The namespace-aware XML scanner rewrites only decimal attribute values and preserves other bytes. Tests cover cross-part uniqueness, fixed points, namespace rebinding, opaque XML, invalid replacements, and tracked fields through the editor model. All 12 save-equivalence checks pass; focused revision tests, core/docx typechecks, builds, API reports, and scoped lint pass. The editor continues to project nested revisions using the inner revision identity.
