### PR TITLE
fix: preserve final paragraph carrier

### DIFF
--- a/.changeset/final-paragraph-carrier.md
+++ b/.changeset/final-paragraph-carrier.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep the required final body paragraph outside tracked paragraph-mark deletions.

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -358,7 +358,7 @@ export const planComparison = ({
     const plan = planStoryCompare({
       story: pair.baseStory,
       baseSnapshot: pair.baseSnapshot,
-      targetBlocks: pair.targetSnapshot.blocks,
+      targetSnapshot: pair.targetSnapshot,
       maxOperations: MAX_COMPARE_OPERATIONS,
     });
     if (plan === null) {

--- a/packages/core/src/compare/plan.test.ts
+++ b/packages/core/src/compare/plan.test.ts
@@ -18,13 +18,13 @@ const MAIN_STORY = { type: "main" } as const;
 const block = (id: string, text: string): FolioAIBlock => ({ id, kind: "paragraph", text });
 
 /** One single-cell row of a table, as the snapshot would project it. */
-const cell = (id: string, text: string, rowIndex: number): FolioAIBlock => ({
+const cell = (id: string, text: string, rowIndex: number, tableIndex = 0): FolioAIBlock => ({
   id,
   kind: "paragraph",
   text,
   table: {
-    outerTableIndex: 0,
-    tableIndex: 0,
+    outerTableIndex: tableIndex,
+    tableIndex,
     rowIndex,
     cellIndex: 0,
     gridColumnIndex: 0,
@@ -66,7 +66,7 @@ const snapshotOf = (blocks: readonly FolioAIBlock[]): FolioAIEditSnapshot => ({
       {
         id: entry.id,
         from: index * 2,
-        to: index * 2 + 1,
+        to: index * 2 + 2,
         text: entry.text,
         normalizedText: entry.text,
         textHash: entry.text,
@@ -80,7 +80,7 @@ const planOf = (base: readonly FolioAIBlock[], target: readonly FolioAIBlock[]) 
   const plan = planStoryCompare({
     story: MAIN_STORY,
     baseSnapshot: snapshotOf(base),
-    targetBlocks: target,
+    targetSnapshot: snapshotOf(target),
     maxOperations: 1000,
   });
   if (plan === null) {
@@ -126,6 +126,131 @@ describe("table row pairing", () => {
       cell("b", "Delivery is due.", 1),
     ];
     expect(planOf(rows, rows).changes).toEqual([]);
+  });
+});
+
+describe("document-terminal paragraph carrier", () => {
+  test("pairs required blank carriers across preceding table deletion", () => {
+    const base = [
+      cell("kept", "Kept row", 0),
+      block("between", ""),
+      cell("removed", "Removed row", 0, 1),
+      block("base-carrier", ""),
+    ];
+    const target = [cell("kept-target", "Kept row", 0), block("target-carrier", "")];
+
+    const { changes, operations } = planOf(base, target);
+
+    expect(operations).not.toContainEqual(
+      expect.objectContaining({ type: "deleteBlock", blockId: "base-carrier" }),
+    );
+    expect(changes.map(({ kind }) => kind)).toEqual(["delete", "table-delete"]);
+    expect(operations).toEqual([
+      { id: "compare-1", type: "deleteBlock", blockId: "between" },
+      { id: "compare-2", type: "deleteTable", blockId: "removed" },
+    ]);
+  });
+
+  test("still compares paragraph properties on the reserved carrier", () => {
+    const baseCarrier = block("base-carrier", "");
+    const targetCarrier = { ...block("target-carrier", ""), styleId: "CustomStyle" };
+
+    const { changes, operations } = planOf([baseCarrier], [targetCarrier]);
+
+    expect(changes.map(({ kind }) => kind)).toEqual(["paragraph-format"]);
+    expect(operations).toEqual([
+      {
+        id: "compare-1",
+        type: "setBlockParagraphProperties",
+        blockId: "base-carrier",
+        properties: { styleId: "CustomStyle" },
+      },
+    ]);
+  });
+
+  test("reserves empty heading and list carriers while comparing their properties", () => {
+    const cases = [
+      {
+        base: { ...block("base-heading", ""), kind: "heading" as const, styleId: "Heading1" },
+        target: { ...block("target-heading", ""), kind: "heading" as const, styleId: "Heading2" },
+        properties: { styleId: "Heading2" },
+      },
+      {
+        base: { ...block("base-list", ""), kind: "listItem" as const, listLevel: 0 },
+        target: { ...block("target-list", ""), kind: "listItem" as const, listLevel: 1 },
+        properties: { listLevel: 1 },
+      },
+    ];
+
+    for (const { base, target, properties } of cases) {
+      const { changes, operations } = planOf([base], [target]);
+      expect(changes.map(({ kind }) => kind)).toEqual(["paragraph-format"]);
+      expect(operations).toEqual([
+        {
+          id: "compare-1",
+          type: "setBlockParagraphProperties",
+          blockId: base.id,
+          properties,
+        },
+      ]);
+    }
+  });
+
+  test("does not reserve a textless paragraph that contains inline content", () => {
+    const base = [
+      cell("kept", "Kept row", 0),
+      block("between", ""),
+      cell("removed", "Removed row", 0, 1),
+      block("base-carrier", ""),
+    ];
+    const target = [cell("kept-target", "Kept row", 0), block("target-content", "")];
+    const targetSnapshot = snapshotOf(target);
+    const targetAnchor = targetSnapshot.anchors["target-content"];
+    if (!targetAnchor) {
+      throw new Error("The target fixture is missing its anchor.");
+    }
+    targetAnchor.to += 1;
+
+    const plan = planStoryCompare({
+      story: MAIN_STORY,
+      baseSnapshot: snapshotOf(base),
+      targetSnapshot,
+      maxOperations: 1000,
+    });
+    if (plan === null) {
+      throw new Error("The plan exceeded its operation budget.");
+    }
+
+    expect(plan.operations).toContainEqual({
+      id: "compare-2",
+      type: "deleteBlock",
+      blockId: "base-carrier",
+    });
+  });
+
+  test("does not apply the body-only carrier rule to headers", () => {
+    const base = [
+      cell("kept", "Kept row", 0),
+      block("between", ""),
+      cell("removed", "Removed row", 0, 1),
+      block("base-carrier", ""),
+    ];
+    const target = [cell("kept-target", "Kept row", 0), block("target-carrier", "")];
+    const plan = planStoryCompare({
+      story: { type: "header", relationshipId: "rId1" },
+      baseSnapshot: snapshotOf(base),
+      targetSnapshot: snapshotOf(target),
+      maxOperations: 1000,
+    });
+    if (plan === null) {
+      throw new Error("The plan exceeded its operation budget.");
+    }
+
+    expect(plan.operations).toContainEqual({
+      id: "compare-2",
+      type: "deleteBlock",
+      blockId: "base-carrier",
+    });
   });
 });
 

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -469,8 +469,9 @@ const unpairedSegmentSteps = (segment: DocumentSegment, side: "base" | "target")
 };
 
 type BuildStepsOptions = {
-  baseBlocks: readonly FolioAIBlock[];
-  targetBlocks: readonly FolioAIBlock[];
+  story: FolioDocumentStoryHandle;
+  baseSnapshot: FolioAIEditSnapshot;
+  targetSnapshot: FolioAIEditSnapshot;
 };
 
 /**
@@ -576,11 +577,40 @@ const alignSegments = (
   return paired;
 };
 
-const buildSteps = ({ baseBlocks, targetBlocks }: BuildStepsOptions): CompareStep[] => {
+const isEmptyParagraphNode = (block: FolioAIBlock, snapshot: FolioAIEditSnapshot): boolean => {
+  const anchor =
+    snapshot.anchors[block.id] ??
+    panic("A comparison snapshot block has no matching anchor", { blockId: block.id });
+  return (
+    block.text === "" &&
+    block.table === undefined &&
+    anchor.to - anchor.from === 2
+  );
+};
+
+const buildSteps = ({ story, baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {
+  const baseBlocks = baseSnapshot.blocks;
+  const targetBlocks = targetSnapshot.blocks;
+  // Microsoft Word retains the final body paragraph mark when accepting or
+  // rejecting a deletion on it. When both sides end in a truly empty paragraph
+  // node, reserve that structural carrier before general alignment and compare
+  // its supported properties normally.
+  const baseLast = baseBlocks.at(-1);
+  const targetLast = targetBlocks.at(-1);
+  const terminalCarrierPair =
+    story.type === "main" &&
+    baseLast !== undefined &&
+    isEmptyParagraphNode(baseLast, baseSnapshot) &&
+    targetLast !== undefined &&
+    isEmptyParagraphNode(targetLast, targetSnapshot)
+      ? { type: "pair" as const, baseBlock: baseLast, targetBlock: targetLast }
+      : null;
+  const alignedBaseBlocks = terminalCarrierPair ? baseBlocks.slice(0, -1) : baseBlocks;
+  const alignedTargetBlocks = terminalCarrierPair ? targetBlocks.slice(0, -1) : targetBlocks;
   const steps: CompareStep[] = [];
   for (const { baseSegment, targetSegment } of alignSegments(
-    splitSegments(baseBlocks),
-    splitSegments(targetBlocks),
+    splitSegments(alignedBaseBlocks),
+    splitSegments(alignedTargetBlocks),
   )) {
     if (baseSegment && targetSegment) {
       steps.push(
@@ -597,6 +627,9 @@ const buildSteps = ({ baseBlocks, targetBlocks }: BuildStepsOptions): CompareSte
     if (targetSegment) {
       steps.push(...unpairedSegmentSteps(targetSegment, "target"));
     }
+  }
+  if (terminalCarrierPair) {
+    steps.push(terminalCarrierPair);
   }
   return steps;
 };
@@ -939,7 +972,7 @@ export type CompareStoryPlan = {
 export type PlanStoryCompareOptions = {
   story: FolioDocumentStoryHandle;
   baseSnapshot: FolioAIEditSnapshot;
-  targetBlocks: readonly FolioAIBlock[];
+  targetSnapshot: FolioAIEditSnapshot;
   /** Cap on generated operations; the caller turns `null` into its own error. */
   maxOperations: number;
 };
@@ -951,10 +984,10 @@ export type PlanStoryCompareOptions = {
 export const planStoryCompare = ({
   story,
   baseSnapshot,
-  targetBlocks,
+  targetSnapshot,
   maxOperations,
 }: PlanStoryCompareOptions): CompareStoryPlan | null => {
-  const steps = buildSteps({ baseBlocks: baseSnapshot.blocks, targetBlocks });
+  const steps = buildSteps({ story, baseSnapshot, targetSnapshot });
   const paragraphMarkPlans = detectParagraphMarkEdits(steps);
   // The step after each paragraph-mark plan is part of it, so neither the move
   // pass nor the main loop may claim it again.

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -581,11 +581,7 @@ const isEmptyParagraphNode = (block: FolioAIBlock, snapshot: FolioAIEditSnapshot
   const anchor =
     snapshot.anchors[block.id] ??
     panic("A comparison snapshot block has no matching anchor", { blockId: block.id });
-  return (
-    block.text === "" &&
-    block.table === undefined &&
-    anchor.to - anchor.from === 2
-  );
+  return block.text === "" && block.table === undefined && anchor.to - anchor.from === 2;
 };
 
 const buildSteps = ({ story, baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -652,6 +652,35 @@ describe("single-mutation probes", () => {
     expect(deleted.at(0)).not.toMatch(/<w:pPr>[\s\S]*<w:rPr>[\s\S]*<w:del\s/u);
   });
 
+  test("delete_table_before_terminal_carrier: final paragraph mark remains untracked", async () => {
+    // Microsoft Word keeps a body carrier after a terminal table. A deletion
+    // on that paragraph mark cannot resolve because there is no next body
+    // paragraph to join it to.
+    const keptTable = { kind: "table", rows: [["Kept row"]] } as const;
+    const base = await buildBodySequenceDocx([
+      keptTable,
+      { kind: "paragraph", text: "" },
+      { kind: "table", rows: [["Removed row"]] },
+    ]);
+    const target = await buildBodySequenceDocx([keptTable]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["delete", "table-delete"]);
+    const terminalParagraph = paragraphsOf(await documentPartOf(result.value.buffer)).at(-1);
+    expect(terminalParagraph).toBeDefined();
+    expect(terminalParagraph).not.toMatch(/<w:pPr>[\s\S]*<w:rPr>[\s\S]*<w:del\b/u);
+    expect(await projectView(result.value.buffer, "final")).toEqual(
+      await projectView(target, "final"),
+    );
+    expect(await projectView(result.value.buffer, "original")).toEqual(
+      await projectView(base, "final"),
+    );
+  });
+
   test("unrepresentable_difference: refused by default, emitted and named on request", async () => {
     // Every column is empty, so there is no evidence for which of the three
     // target columns is new. Guessing would produce a plausible but misleading


### PR DESCRIPTION
Reserve matching empty terminal body paragraphs before general comparison alignment. This prevents a deletion on the final paragraph mark that Microsoft Word retains after accepting or rejecting revisions, while still comparing supported paragraph properties.

The reservation requires an empty node in both main stories; headers, table cells, and paragraphs containing inline content retain their existing alignment. Validation includes 44 focused tests, a mutation check, package typechecking, lint, and corpus regression checks.
