### PR TITLE
fix(core): keep a container's final paragraph mark when trailing paragraphs are removed

### DIFF
--- a/.changeset/final-paragraph-mark-deletion.md
+++ b/.changeset/final-paragraph-mark-deletion.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep a container's final paragraph mark when a comparison removes the paragraphs it ends with: the merge chain now runs from the last surviving paragraph forward, and the carrier's properties travel as `w:pPrChange`.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -402,7 +402,13 @@ export class CompareDocxApplyError extends CompareDocxApplyError_base<{
 }> {}
 
 // @public (undocumented)
-export type CompareDocxError = CompareDocxApplyError | CompareDocxOperationLimitError | CompareDocxParseError | CompareDocxRoundTripError | CompareDocxSerializeError | InvalidCompareDocxOptionsError;
+export type CompareDocxError = CompareDocxApplyError | CompareDocxFinalParagraphMarkError | CompareDocxOperationLimitError | CompareDocxParseError | CompareDocxRoundTripError | CompareDocxSerializeError | InvalidCompareDocxOptionsError;
+
+// @public
+export class CompareDocxFinalParagraphMarkError extends CompareDocxFinalParagraphMarkError_base<{
+    message: string;
+    deletions: readonly FinalParagraphMarkDeletion[];
+}> {}
 
 // @public
 export class CompareDocxOperationLimitError extends CompareDocxOperationLimitError_base<{
@@ -669,6 +675,13 @@ export type ExtractDocumentStyleSetOptions = {
 
 // @public
 export function extractEmbeddedFonts(buffer: ArrayBuffer, docNonce?: string): Promise<EmbeddedFont[]>;
+
+// @public
+export type FinalParagraphMarkDeletion = {
+    container: string;
+    paragraphIndex: number;
+    kind: "del" | "moveFrom";
+};
 
 // @public (undocumented)
 export const finishAutocompleteSuggestion: (tr: Transaction, requestId: string) => Transaction;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -402,7 +402,13 @@ export class CompareDocxApplyError extends CompareDocxApplyError_base<{
 }> {}
 
 // @public (undocumented)
-export type CompareDocxError = CompareDocxApplyError | CompareDocxOperationLimitError | CompareDocxParseError | CompareDocxRoundTripError | CompareDocxSerializeError | InvalidCompareDocxOptionsError;
+export type CompareDocxError = CompareDocxApplyError | CompareDocxFinalParagraphMarkError | CompareDocxOperationLimitError | CompareDocxParseError | CompareDocxRoundTripError | CompareDocxSerializeError | InvalidCompareDocxOptionsError;
+
+// @public
+export class CompareDocxFinalParagraphMarkError extends CompareDocxFinalParagraphMarkError_base<{
+    message: string;
+    deletions: readonly FinalParagraphMarkDeletion[];
+}> {}
 
 // @public
 export class CompareDocxOperationLimitError extends CompareDocxOperationLimitError_base<{
@@ -669,6 +675,13 @@ export type ExtractDocumentStyleSetOptions = {
 
 // @public
 export function extractEmbeddedFonts(buffer: ArrayBuffer, docNonce?: string): Promise<EmbeddedFont[]>;
+
+// @public
+export type FinalParagraphMarkDeletion = {
+    container: string;
+    paragraphIndex: number;
+    kind: "del" | "moveFrom";
+};
 
 // @public (undocumented)
 export const finishAutocompleteSuggestion: (tr: Transaction, requestId: string) => Transaction;

--- a/benchmarks/compare/refusals.ts
+++ b/benchmarks/compare/refusals.ts
@@ -33,6 +33,8 @@ export const REFUSAL_BUCKETS = Object.freeze({
   "apply-refused": "The applier refused a derived operation.",
   "operation-limit": "The difference needs more operations than the engine generates.",
   serialize: "The redlined package could not be written back out.",
+  "final-paragraph-mark":
+    "A container's final paragraph mark carried a deletion no consumer could resolve.",
   "invalid-options": "The call's options were not usable.",
   "round-trip-invisible-structure":
     "Every block is there, in order, at coordinates the block model cannot reach.",
@@ -99,6 +101,13 @@ export const classifyRefusal = (error: CompareDocxError): Refusal => {
       return { bucket: "operation-limit", shape: `over ${String(error.limit)} operations` };
     case "CompareDocxSerializeError":
       return { bucket: "serialize", shape: causeMessage(error.cause) };
+    case "CompareDocxFinalParagraphMarkError":
+      return {
+        bucket: "final-paragraph-mark",
+        shape: `${String(error.deletions.length)} container(s), first ${
+          error.deletions.at(0)?.container ?? "unknown"
+        }`,
+      };
     case "CompareDocxRoundTripError":
       return {
         bucket: bucketOfCause(error.cause),

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -4770,10 +4770,13 @@ describe("Folio AI edit operations", () => {
 });
 
 describe("deleteBlock over inline content that is not text", () => {
-  const deleteSecondBlock = (children: ReturnType<typeof schema.node>[]) => {
+  // The deleted paragraph is followed by another: the paragraph that ENDS a
+  // container keeps its mark, so a deletion there resolves to a blank line
+  // rather than to the paragraph going, which is a different case.
+  const deleteFirstBlock = (children: ReturnType<typeof schema.node>[]) => {
     const doc = schema.node("doc", null, [
-      schema.node("paragraph", { paraId: "keep" }, [schema.text("kept")]),
       schema.node("paragraph", { paraId: "gone" }, children),
+      schema.node("paragraph", { paraId: "keep" }, [schema.text("kept")]),
     ]);
     const state = EditorState.create({ schema, doc });
     const view = makeView(state);
@@ -4791,7 +4794,7 @@ describe("deleteBlock over inline content that is not text", () => {
   // outside the words was left unmarked and accepting the deletion kept a
   // paragraph standing around it.
   test("takes an inline image with it", () => {
-    const view = deleteSecondBlock([schema.text("words"), schema.node("image", { src: "data:," })]);
+    const view = deleteFirstBlock([schema.text("words"), schema.node("image", { src: "data:," })]);
 
     acceptAllChanges()(view.state, view.dispatch);
 
@@ -4802,7 +4805,7 @@ describe("deleteBlock over inline content that is not text", () => {
   // A bookmark boundary is zero-width. Deleting the surrounding words did not
   // delete the bookmark itself, and leaving it must not keep the paragraph alive.
   test("leaves a bookmark boundary unmarked and still removes the paragraph", () => {
-    const view = deleteSecondBlock([schema.node("bookmarkBoundary"), schema.text("words")]);
+    const view = deleteFirstBlock([schema.node("bookmarkBoundary"), schema.text("words")]);
 
     let markedAnchors = 0;
     view.state.doc.descendants((node) => {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -1810,7 +1810,21 @@ const applyFolioAIEditOperationsInternal = ({
       }
       case "deleteBlock": {
         if (mode === "direct") {
-          tr = tr.delete(item.blockFrom, item.blockTo);
+          // A container has to END with a paragraph: a body, a cell, a header,
+          // a note and a text box each do, and one left ending in a table is a
+          // package a consumer refuses. Removing the node removes its mark
+          // with it, so the last paragraph of a container that nothing else
+          // could terminate keeps its place and loses only its content. Where
+          // a paragraph precedes it, that one becomes the terminator and this
+          // node goes as any other would — which is what the tracked path
+          // resolves to as well, its mark deleted one paragraph earlier.
+          const at = tr.doc.resolve(item.blockFrom);
+          const endsItsContainer = at.index() === at.parent.childCount - 1;
+          const leavesAParagraph =
+            !endsItsContainer || at.nodeBefore?.type.name === item.blockNode.type.name;
+          tr = leavesAParagraph
+            ? tr.delete(item.blockFrom, item.blockTo)
+            : tr.delete(item.blockFrom + 1, item.blockTo - 1);
           break;
         }
 
@@ -1840,20 +1854,30 @@ const applyFolioAIEditOperationsInternal = ({
           // its deleted runs.
           //
           // A mark belongs to the paragraph it ends, so the paragraph's own
-          // mark is the one that went. That holds wherever it sat: resolving
-          // the mark joins it with the next paragraph when there is one, and
-          // removes the paragraph outright when there is not, which is what a
-          // document holds after a paragraph before a table is deleted. The
-          // only paragraph that cannot say it is the one its parent cannot do
-          // without: a cell must contain a paragraph, so the last one in a
-          // cell keeps its mark and stays blank.
+          // mark is the one that went — except on the paragraph that ends its
+          // container. A deleted mark says "join this paragraph with the one
+          // after it", and a container's last paragraph has none: a body, a
+          // cell, a header, a note and a text box each end with a paragraph
+          // that nothing follows. Such a mark states an edit that cannot be
+          // carried out, and a consumer reading it refuses the package. That
+          // paragraph therefore loses its words and keeps its mark, and the
+          // caller that wants the paragraph gone deletes the mark of the one
+          // BEFORE it, which merges forward into this carrier.
+          //
+          // A paragraph before a TABLE still carries its own mark: the table
+          // is a following sibling, so the paragraph does not end anything.
+          //
+          // Read from the document as it stands, which is exact: operations
+          // run right to left, so everything after this paragraph has already
+          // landed and the paragraph it will end up next to is the one here.
           //
           // A relocation's source break is `w:moveFrom`, not `w:del`: the two
           // resolve alike, and the kind is what tells a reader this end has a
           // matching one elsewhere rather than being a deletion of its own.
           const markPosition = tr.mapping.map(item.blockFrom);
-          const parent = tr.doc.resolve(markPosition).parent;
-          if (parent.childCount > 1 && tr.doc.nodeAt(markPosition)?.attrs["pPrMark"] == null) {
+          const markPlace = tr.doc.resolve(markPosition);
+          const endsItsContainer = markPlace.index() === markPlace.parent.childCount - 1;
+          if (!endsItsContainer && tr.doc.nodeAt(markPosition)?.attrs["pPrMark"] == null) {
             const markRevisionId = revisionSeed++;
             tr = tr.setNodeAttribute(markPosition, "pPrMark", {
               kind: isPairedMove(item.operation.moveId) ? "moveFrom" : "del",

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -107,17 +107,36 @@ restores the base's.
 
 A paragraph mark belongs to the paragraph it ends: a paragraph added or removed
 carries its own mark, inserted or deleted alongside its runs. That holds
-everywhere, including at a container's edge, and what changes at the edge is
-how the mark RESOLVES rather than where it sits.
+everywhere but at the END of a container, which is the one place a mark cannot
+say it went.
 
 - **A mark with a paragraph after it resolves by joining.** Accepting a deleted
   mark closes the break; rejecting an inserted one does the same.
-- **A mark with no paragraph after it resolves by removing the paragraph.** The
-  last paragraph of a body, and a paragraph before a table, have nothing to be
-  joined with. Once the resolution has taken the paragraph's words away, what
-  is left is a paragraph whose break was resolved too, so it goes. The
-  exception is a paragraph its parent cannot do without: a cell must contain
-  one, so the last paragraph of a cell keeps its mark and stays blank.
+- **A mark with a table after it resolves by removing the paragraph.** There is
+  nothing to join with, and once the resolution has taken the paragraph's words
+  away, what is left is a paragraph whose break was resolved too, so it goes.
+- **The mark that ENDS a container is never deleted.** A body, a table cell, a
+  header or footer, a note and a text box each end with a paragraph, and that
+  paragraph has none after it: a deleted mark there asks for a merge that
+  cannot happen, and a consumer refuses the whole package rather than opening
+  it. So a comparison that removes the paragraphs a container ends with runs
+  the chain from the last SURVIVING paragraph forward: its mark goes, each
+  removed paragraph's mark goes with it, and the container's final paragraph
+  loses its words and keeps its mark as the carrier the merged text lands in.
+  A paragraph's properties live on its mark, so the carrier's become the
+  target's, written as `w:pPrChange` — that is bookkeeping for the merge and
+  adds no entry to the change list, which says what it should say: the
+  paragraphs were removed.
+- **An inserted mark at a container's end is the mirror case, and stands.** The
+  break was ADDED, so the paragraph it ends was not there before it, and
+  rejecting the addition removes the paragraph and leaves the container ending
+  where it did.
+
+The serialize stage refuses a package whose final paragraph mark carries a
+deletion, with `CompareDocxFinalParagraphMarkError` naming the container and
+the paragraph. That one is fatal under `onUnverified: "emit"` too: unlike an
+unproven redline there is no partial result worth handing back, because the
+file does not open.
 
 Handing the last new paragraph's mark to the ANCHOR instead reads closer to
 what an editor writes, and is equivalent only while the two stay adjacent. A
@@ -191,7 +210,9 @@ Every `detail` is structural — counts, offsets, container kinds — and carrie
 phrase of either document, so it is safe to log, report, or quote.
 
 A parse, apply or serialize failure is still an error under either setting:
-there is no redline to emit.
+there is no redline to emit. So is a deletion on a container's final paragraph
+mark, for the same reason at the other end — the bytes would be written, and no
+consumer would open them.
 
 ## Inputs that already carry tracked changes
 
@@ -255,7 +276,8 @@ carries the current numbers and the failing cases.
   pairing, and the round-trip self-check. `compareDocx` composes them.
 - `plan.ts` — alignment and operation derivation. Pure.
 - `verification.ts` — the round-trip verdict: the invariants, the causes, and
-  the safe-to-quote detail each failure carries. Pure.
+  the safe-to-quote detail each failure carries, plus the structural guard on a
+  container's final paragraph mark. Pure.
 - `formatting.ts` — the inline-formatting diff, shared with the redline
   generator.
 - `reproducible-package.ts` — ZIP entry-date restamping.

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -99,7 +99,22 @@ const itemsXml = (items: readonly BodyItem[]): string =>
 
 const bodyXml = (items: readonly BodyItem[]): string => itemsXml(closedSequence(items));
 
-export const buildBodySequenceDocx = async (items: readonly BodyItem[]): Promise<ArrayBuffer> => {
+/** The relationship id the default header takes when a fixture asks for one. */
+const HEADER_RELATIONSHIP_ID = "rId2";
+
+export type BodySequenceOptions = {
+  /**
+   * A default header part, written as its own sequence. A header is a story of
+   * its own: it ends with its own paragraph, and a comparison writes it with
+   * its own revision ids.
+   */
+  header?: readonly BodyItem[];
+};
+
+export const buildBodySequenceDocx = async (
+  items: readonly BodyItem[],
+  { header }: BodySequenceOptions = {},
+): Promise<ArrayBuffer> => {
   const parts: Record<string, string> = {
     "[Content_Types].xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -108,6 +123,9 @@ export const buildBodySequenceDocx = async (items: readonly BodyItem[]): Promise
       `<Default Extension="xml" ContentType="application/xml"/>` +
       `<Override PartName="/word/document.xml" ContentType="${WORDPROCESSING}.document.main+xml"/>` +
       `<Override PartName="/word/styles.xml" ContentType="${WORDPROCESSING}.styles+xml"/>` +
+      (header
+        ? `<Override PartName="/word/header1.xml" ContentType="${WORDPROCESSING}.header+xml"/>`
+        : "") +
       `</Types>`,
     "_rels/.rels":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -118,6 +136,9 @@ export const buildBodySequenceDocx = async (items: readonly BodyItem[]): Promise
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<Relationships xmlns="${RELATIONSHIPS}">` +
       `<Relationship Id="rId1" Type="${OFFICE_RELATIONSHIPS}/styles" Target="styles.xml"/>` +
+      (header
+        ? `<Relationship Id="${HEADER_RELATIONSHIP_ID}" Type="${OFFICE_RELATIONSHIPS}/header" Target="header1.xml"/>`
+        : "") +
       `</Relationships>`,
     "word/styles.xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -127,11 +148,20 @@ export const buildBodySequenceDocx = async (items: readonly BodyItem[]): Promise
       `</w:styles>`,
     "word/document.xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-      `<w:document xmlns:w="${NAMESPACE}"><w:body>` +
+      `<w:document xmlns:w="${NAMESPACE}" xmlns:r="${OFFICE_RELATIONSHIPS}"><w:body>` +
       bodyXml(items) +
-      `<w:sectPr><w:pgSz w:w="12240" w:h="15840"/>` +
+      `<w:sectPr>` +
+      (header ? `<w:headerReference w:type="default" r:id="${HEADER_RELATIONSHIP_ID}"/>` : "") +
+      `<w:pgSz w:w="12240" w:h="15840"/>` +
       `<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>` +
       `</w:body></w:document>`,
+    ...(header
+      ? {
+          "word/header1.xml":
+            `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+            `<w:hdr xmlns:w="${NAMESPACE}">${itemsXml(closedSequence(header))}</w:hdr>`,
+        }
+      : {}),
   };
 
   const zip = new JSZip();

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -22,6 +22,7 @@ import type { FolioAIBlock } from "../ai-edits/types";
 import { compareDocx } from "./compare";
 import { applyEditScript, type EditScript, type EditScriptStep } from "./scenario";
 import type { CompareChange, CompareResult } from "./types";
+import { deletedFinalParagraphMarks } from "./verification";
 
 const FIXTURES_DIR = path.join(import.meta.dir, "../docx/__tests__/__fixtures__/corpus");
 
@@ -506,6 +507,33 @@ describe("compareDocx", () => {
         propertyTestTimeout(120_000),
       );
     }
+  }
+
+  for (const { name, buffer: base, blocks: baseBlocks } of BASE_CASES) {
+    test(
+      `no container's final paragraph mark is ever deleted (${name})`,
+      async () => {
+        // A deleted paragraph mark means "merge this paragraph into the
+        // following one", and the last paragraph of a body, a cell, a header,
+        // a note or a text box has no following one: a consumer reading such a
+        // mark refuses the package rather than opening it. Read back from the
+        // bytes the comparison produced, so it covers what was written and not
+        // only what was planned.
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const { buffer } = await compareOrThrow(base, scripted.value.buffer);
+            const written = await FolioDocxReviewer.fromBuffer(buffer);
+            expect(deletedFinalParagraphMarks(written.toDocument())).toEqual([]);
+          }),
+          propertyConfig({ numRuns: 12 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
   }
 
   test(

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -50,6 +50,7 @@ import { planStoryCompare, type CompareStoryPlan } from "./plan";
 import { withFixedPackageDates } from "./reproducible-package";
 import {
   CompareDocxApplyError,
+  CompareDocxFinalParagraphMarkError,
   CompareDocxOperationLimitError,
   CompareDocxParseError,
   CompareDocxRoundTripError,
@@ -63,6 +64,7 @@ import {
 } from "./types";
 import {
   classifyProjectionMismatch,
+  deletedFinalParagraphMarks,
   projectSupportedInlineFormatting,
   type CompareVerification,
   type CompareVerificationFailure,
@@ -519,9 +521,28 @@ export const applyComparison = (
 export const serializeComparison = async (
   { baseBuffer, baseCarriedRevisions, reviewer, packageDate }: ParsedComparison,
   planned: readonly PlannedStoryComparison[],
-): Promise<Result<ArrayBuffer, CompareDocxSerializeError>> => {
+): Promise<Result<ArrayBuffer, CompareDocxSerializeError | CompareDocxFinalParagraphMarkError>> => {
   if (!baseCarriedRevisions && planned.every(({ plan }) => plan.operations.length === 0)) {
     return Result.ok(baseBuffer);
+  }
+  const document = reviewer.toDocument();
+  // A deleted mark on the paragraph that ends a container asks a consumer to
+  // merge it with a paragraph that is not there, and the consumer refuses the
+  // whole package rather than opening it. Nothing downstream can recover from
+  // that, so it is fatal under either `onUnverified` setting: unlike an
+  // unproven redline there is no partial result worth handing back.
+  const deletions = deletedFinalParagraphMarks(document);
+  const [firstDeletion] = deletions;
+  if (firstDeletion !== undefined) {
+    return Result.err(
+      new CompareDocxFinalParagraphMarkError({
+        message:
+          `A container's final paragraph mark carries a ${firstDeletion.kind}, which no ` +
+          `consumer can resolve: ${firstDeletion.container} paragraph ` +
+          `${String(firstDeletion.paragraphIndex)}.`,
+        deletions,
+      }),
+    );
   }
   return await Result.tryPromise({
     try: async () => await withFixedPackageDates(await reviewer.toBuffer(), packageDate),

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -587,10 +587,10 @@ const isEmptyParagraphNode = (block: FolioAIBlock, snapshot: FolioAIEditSnapshot
 const buildSteps = ({ story, baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {
   const baseBlocks = baseSnapshot.blocks;
   const targetBlocks = targetSnapshot.blocks;
-  // Microsoft Word retains the final body paragraph mark when accepting or
-  // rejecting a deletion on it. When both sides end in a truly empty paragraph
-  // node, reserve that structural carrier before general alignment and compare
-  // its supported properties normally.
+  // A body's final paragraph mark survives accepting or rejecting a deletion
+  // on it: nothing follows it to merge into. When both sides end in a truly
+  // empty paragraph node, reserve that structural carrier before general
+  // alignment and compare its supported properties normally.
   const baseLast = baseBlocks.at(-1);
   const targetLast = targetBlocks.at(-1);
   const terminalCarrierPair =
@@ -959,6 +959,151 @@ const changedParagraphProperties = (
 
 const locationOf = (story: FolioDocumentStoryHandle, block: FolioAIBlock): CompareChangeLocation =>
   block.table ? { story, cell: block.table } : { story };
+
+/**
+ * The container a paragraph mark ends: the story's body, or one table cell. A
+ * mark joins the paragraph it ends with the next paragraph of the SAME
+ * container, so two blocks on either side of a boundary are not neighbours for
+ * this purpose however adjacent they read.
+ */
+const containerKeyOf = ({ table }: FolioAIBlock): string =>
+  table
+    ? `t${String(table.tableIndex)}r${String(table.rowIndex)}c${String(table.cellIndex)}`
+    : "body";
+
+/** Each container's last block, in the order the story holds them. */
+const lastBlockByContainer = (
+  blocks: readonly FolioAIBlock[],
+): ReadonlyMap<string, FolioAIBlock> => {
+  const last = new Map<string, FolioAIBlock>();
+  for (const block of blocks) {
+    last.set(containerKeyOf(block), block);
+  }
+  return last;
+};
+
+type TrailingDeletionOptions = {
+  baseSnapshot: FolioAIEditSnapshot;
+  targetSnapshot: FolioAIEditSnapshot;
+  /** The plan so far, read for the blocks it deletes and where it inserts. */
+  operations: readonly FolioAIEditOperation[];
+  nextOperationId: () => string;
+};
+
+/**
+ * The operations that keep a container's final paragraph mark when the plan
+ * deletes the paragraphs that end it.
+ *
+ * A deleted paragraph mark means "merge this paragraph into the following
+ * one". A container's final paragraph has no following one, so the mark cannot
+ * say it: the applier leaves that mark alone, and the removal has to be
+ * expressed one paragraph earlier. The chain therefore runs from the last
+ * SURVIVING paragraph forward — its mark goes, each removed paragraph's mark
+ * goes with it, and the container's final paragraph stays as the carrier the
+ * merged text lands in.
+ *
+ * The carrier keeps its own mark, and a paragraph's properties live on its
+ * mark, so the merged paragraph ends up with the carrier's. Those properties
+ * therefore become the target's, written as `w:pPrChange` so rejecting
+ * restores what the carrier had. That is bookkeeping for the merge rather than
+ * an edit of its own, so it adds no entry to the change list: what the reader
+ * is told is that the paragraphs were removed.
+ *
+ * Nothing is rotated when the plan puts a block inside or after the run. The
+ * carrier is then no longer what ends the container, its mark is deleted like
+ * any other, and the count already works out.
+ */
+const trailingDeletionOperations = ({
+  baseSnapshot,
+  targetSnapshot,
+  operations,
+  nextOperationId,
+}: TrailingDeletionOptions): FolioAIEditOperation[] => {
+  const blocks = baseSnapshot.blocks;
+  const deletedBlockIds = new Set(
+    operations.flatMap((operation) =>
+      operation.type === "deleteBlock" ? [operation.blockId] : [],
+    ),
+  );
+  if (deletedBlockIds.size === 0) {
+    return [];
+  }
+  // Anchors of everything the plan PLACES in a container: a block landing in
+  // the run breaks the merge chain, and one landing after the carrier means
+  // the carrier no longer ends the container.
+  const placedAtBlockIds = new Set(
+    operations.flatMap((operation) =>
+      operation.type === "insertBeforeBlock" ||
+      operation.type === "insertAfterBlock" ||
+      operation.type === "insertTable"
+        ? [operation.blockId]
+        : [],
+    ),
+  );
+  // A block whose own mark the plan already moves is not a chain start: a
+  // split has put a second paragraph after it, and a merge has spent its mark.
+  const markedBlockIds = new Set(
+    operations.flatMap((operation) =>
+      operation.type === "splitBlock" || operation.type === "mergeBlockWithNext"
+        ? [operation.blockId]
+        : [],
+    ),
+  );
+  const targetLastByContainer = lastBlockByContainer(targetSnapshot.blocks);
+  const indexById = new Map(blocks.map((block, index) => [block.id, index]));
+  const added: FolioAIEditOperation[] = [];
+  for (const [container, carrier] of lastBlockByContainer(blocks)) {
+    if (!deletedBlockIds.has(carrier.id)) {
+      continue;
+    }
+    let index =
+      indexById.get(carrier.id) ??
+      panic("A container's last block is not in the snapshot it came from", {
+        blockId: carrier.id,
+      });
+    let chainStart: FolioAIBlock | null = null;
+    let placedInRun = false;
+    // Backwards over the run of deleted paragraphs this container ends with. A
+    // block of another container in between — a table between two body
+    // paragraphs, a table nested in a cell — ends the walk: no mark joins
+    // across it.
+    for (; index >= 0; index--) {
+      const block = blocks[index];
+      if (block === undefined || containerKeyOf(block) !== container) {
+        break;
+      }
+      if (!deletedBlockIds.has(block.id)) {
+        chainStart = markedBlockIds.has(block.id) ? null : block;
+        break;
+      }
+      placedInRun ||= placedAtBlockIds.has(block.id);
+    }
+    if (placedInRun) {
+      continue;
+    }
+    if (chainStart) {
+      added.push({
+        id: nextOperationId(),
+        type: "mergeBlockWithNext",
+        blockId: chainStart.id,
+      });
+    }
+    // The merged paragraph is the target's last one in this container, and it
+    // ends on the carrier's mark, so the carrier is where its properties have
+    // to be.
+    const targetCarrier = targetLastByContainer.get(container);
+    const properties = targetCarrier && changedParagraphProperties(carrier, targetCarrier);
+    if (properties) {
+      added.push({
+        id: nextOperationId(),
+        type: "setBlockParagraphProperties",
+        blockId: carrier.id,
+        properties,
+      });
+    }
+  }
+  return added;
+};
 
 export type CompareStoryPlan = {
   changes: CompareChange[];
@@ -1343,6 +1488,15 @@ export const planStoryCompare = ({
       return null;
     }
   }
+
+  operations.push(
+    ...trailingDeletionOperations({
+      baseSnapshot,
+      targetSnapshot,
+      operations,
+      nextOperationId,
+    }),
+  );
 
   return operations.length > maxOperations ? null : { changes, operations };
 };

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -79,12 +79,29 @@ const buildColumnTableDocx = (rows: readonly (readonly ColumnCell[])[]): Promise
   });
 };
 
+const partOf = async (buffer: ArrayBuffer, name: string): Promise<string> =>
+  (await (await JSZip.loadAsync(buffer)).file(name)?.async("string")) ?? "";
+
 const documentPartOf = async (buffer: ArrayBuffer): Promise<string> =>
-  (await (await JSZip.loadAsync(buffer)).file("word/document.xml")?.async("string")) ?? "";
+  await partOf(buffer, "word/document.xml");
 
 /** Every `w:p` element of a document part, as raw XML. */
 const paragraphsOf = (documentXml: string): string[] =>
   documentXml.match(/<w:p[ >][\s\S]*?<\/w:p>/gu) ?? [];
+
+/**
+ * Whether the paragraph's OWN mark carries a deletion. `w:pPr` is a paragraph's
+ * first child, so reading only that far keeps a deleted RUN's own `w:rPr` out
+ * of the answer.
+ */
+const markIsDeleted = (paragraph: string): boolean => {
+  const properties = /^<w:p\b[^>]*><w:pPr>([\s\S]*?)<\/w:pPr>/u.exec(paragraph)?.[1] ?? "";
+  return /<w:rPr>[\s\S]*?<w:(?:del|moveFrom)\b/u.test(properties);
+};
+
+/** Every paragraph of a part whose own mark carries a deletion, in order. */
+const marksDeletedIn = (partXml: string): string[] =>
+  paragraphsOf(partXml).filter((paragraph) => markIsDeleted(paragraph));
 
 const blocksOf = async (buffer: ArrayBuffer): Promise<FolioAIBlock[]> =>
   (await FolioDocxReviewer.fromBuffer(buffer)).getContent();
@@ -100,6 +117,20 @@ const projectView = async (
   return (story?.snapshot.blocks ?? []).map((block) => ({
     text: block.text,
     table: block.table ?? null,
+  }));
+};
+
+/** The same projection with the paragraph style, for a properties assertion. */
+const styledView = async (
+  buffer: ArrayBuffer,
+  view: "original" | "final",
+): Promise<(BlockProjection & { styleId: string | null })[]> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(buffer);
+  const story = reviewer.readReviewedStory({ view });
+  return (story?.snapshot.blocks ?? []).map((block) => ({
+    text: block.text,
+    table: block.table ?? null,
+    styleId: block.styleId ?? null,
   }));
 };
 
@@ -653,9 +684,9 @@ describe("single-mutation probes", () => {
   });
 
   test("delete_table_before_terminal_carrier: final paragraph mark remains untracked", async () => {
-    // Microsoft Word keeps a body carrier after a terminal table. A deletion
-    // on that paragraph mark cannot resolve because there is no next body
-    // paragraph to join it to.
+    // A body may not end with a table, so a package that does carries a
+    // paragraph after it. A deletion on that paragraph's mark cannot resolve:
+    // there is no next body paragraph to join it to.
     const keptTable = { kind: "table", rows: [["Kept row"]] } as const;
     const base = await buildBodySequenceDocx([
       keptTable,
@@ -679,6 +710,149 @@ describe("single-mutation probes", () => {
     expect(await projectView(result.value.buffer, "original")).toEqual(
       await projectView(base, "final"),
     );
+  });
+
+  /**
+   * Four paragraphs become one: the first is edited and the three after it are
+   * removed. The last of them ends the body, so its mark cannot be deleted —
+   * nothing follows it to merge into. The chain therefore starts at the last
+   * SURVIVING paragraph: the marks of the first three go, the fourth keeps its
+   * own, and the merged paragraph lands on it.
+   */
+  const TRAILING_CLAUSES = [
+    "Alpha clause states the agreed position.",
+    "Bravo clause states the agreed position.",
+    "Charlie clause states the agreed position.",
+    "Delta clause states the agreed position.",
+  ] as const;
+  const REVISED_CLAUSE = "Alpha clause states the revised position.";
+
+  test("delete_trailing_paragraphs: the body's final mark stays, the chain moves back", async () => {
+    const base = await buildBodySequenceDocx(
+      TRAILING_CLAUSES.map((text) => ({ kind: "paragraph", text }) as const),
+    );
+    const target = await buildBodySequenceDocx([{ kind: "paragraph", text: REVISED_CLAUSE }]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual([
+      "replace",
+      "delete",
+      "delete",
+      "delete",
+    ]);
+
+    const paragraphs = paragraphsOf(await documentPartOf(result.value.buffer));
+    expect(paragraphs).toHaveLength(4);
+    expect(paragraphs.map((paragraph) => markIsDeleted(paragraph))).toEqual([
+      true,
+      true,
+      true,
+      false,
+    ]);
+
+    expect(await projectView(result.value.buffer, "final")).toEqual(
+      await projectView(target, "final"),
+    );
+    expect(await projectView(result.value.buffer, "original")).toEqual(
+      await projectView(base, "final"),
+    );
+  });
+
+  test("delete_trailing_paragraphs_in_a_cell: the cell's final mark stays", async () => {
+    const cell = (texts: readonly string[]) =>
+      texts.map((text) => ({ kind: "paragraph", text }) as const);
+    const base = await buildBodySequenceDocx([
+      { kind: "paragraph", text: "The schedule below records the agreed fees." },
+      { kind: "table", rows: [[cell(TRAILING_CLAUSES), "Fee"]] },
+      { kind: "paragraph", text: "This agreement is governed by the stated law." },
+    ]);
+    const target = await buildBodySequenceDocx([
+      { kind: "paragraph", text: "The schedule below records the agreed fees." },
+      { kind: "table", rows: [[cell([REVISED_CLAUSE]), "Fee"]] },
+      { kind: "paragraph", text: "This agreement is governed by the stated law." },
+    ]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const documentXml = await documentPartOf(result.value.buffer);
+    // Three marks go — the edited paragraph's and the two after it — and the
+    // cell's fourth paragraph keeps its own.
+    expect(marksDeletedIn(documentXml)).toHaveLength(3);
+    const cellParagraphs = paragraphsOf(documentXml).filter((paragraph) =>
+      paragraph.includes("clause states"),
+    );
+    expect(cellParagraphs).toHaveLength(4);
+    expect(markIsDeleted(cellParagraphs.at(-1) ?? "")).toBe(false);
+
+    expect(await projectView(result.value.buffer, "final")).toEqual(
+      await projectView(target, "final"),
+    );
+    expect(await projectView(result.value.buffer, "original")).toEqual(
+      await projectView(base, "final"),
+    );
+  });
+
+  test("delete_trailing_paragraphs_in_a_header: the header story keeps its final mark", async () => {
+    const body = [{ kind: "paragraph", text: "The parties agree as set out below." }] as const;
+    const base = await buildBodySequenceDocx(body, {
+      header: TRAILING_CLAUSES.map((text) => ({ kind: "paragraph", text }) as const),
+    });
+    const target = await buildBodySequenceDocx(body, {
+      header: [{ kind: "paragraph", text: REVISED_CLAUSE }],
+    });
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.unsupported).toEqual([]);
+    const headerParagraphs = paragraphsOf(await partOf(result.value.buffer, "word/header1.xml"));
+    expect(headerParagraphs).toHaveLength(4);
+    expect(headerParagraphs.map((paragraph) => markIsDeleted(paragraph))).toEqual([
+      true,
+      true,
+      true,
+      false,
+    ]);
+  });
+
+  test("trailing_deletion_moves_the_surviving_properties_to_the_carrier", async () => {
+    // The merged paragraph ends on the carrier's mark, and a paragraph's
+    // properties live on its mark, so the carrier is where the surviving
+    // paragraph's style has to end up: as `w:pPrChange`, which is what a
+    // rejection reads to put the carrier's own style back.
+    const base = await buildBodySequenceDocx([
+      { kind: "paragraph", text: TRAILING_CLAUSES[0], styleId: "Heading1" },
+      { kind: "paragraph", text: TRAILING_CLAUSES[1] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[2] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[3] },
+    ]);
+    const target = await buildBodySequenceDocx([
+      { kind: "paragraph", text: REVISED_CLAUSE, styleId: "Heading1" },
+    ]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const carrier = paragraphsOf(await documentPartOf(result.value.buffer)).at(-1) ?? "";
+    expect(carrier).toContain(`<w:pStyle w:val="Heading1"/>`);
+    expect(carrier).toContain("<w:pPrChange ");
+    expect(markIsDeleted(carrier)).toBe(false);
+
+    const [accepted, expected, rejected, original] = await Promise.all([
+      styledView(result.value.buffer, "final"),
+      styledView(target, "final"),
+      styledView(result.value.buffer, "original"),
+      styledView(base, "final"),
+    ]);
+    expect(accepted).toEqual(expected);
+    expect(rejected).toEqual(original);
   });
 
   test("unrepresentable_difference: refused by default, emitted and named on request", async () => {

--- a/packages/core/src/compare/types.ts
+++ b/packages/core/src/compare/types.ts
@@ -18,6 +18,7 @@ import type {
   CompareVerificationCause,
   CompareVerificationFailure,
   CompareVerificationInvariant,
+  FinalParagraphMarkDeletion,
 } from "./verification";
 
 /** Everything {@link compareDocx} needs; nothing it reads from the ambient clock. */
@@ -318,8 +319,26 @@ export class CompareDocxSerializeError extends TaggedError("CompareDocxSerialize
   cause: unknown;
 }> {}
 
+/**
+ * A container's final paragraph mark carries a deletion, so the package would
+ * not open.
+ *
+ * A deleted paragraph mark means "merge this paragraph into the following
+ * one", and a container's last paragraph has no following one. Checked before
+ * the package is written, and fatal under either `onUnverified` setting: there
+ * is no redline to emit when a consumer refuses the file.
+ */
+export class CompareDocxFinalParagraphMarkError extends TaggedError(
+  "CompareDocxFinalParagraphMarkError",
+)<{
+  message: string;
+  /** Every container that carries one, each named structurally. */
+  deletions: readonly FinalParagraphMarkDeletion[];
+}> {}
+
 export type CompareDocxError =
   | CompareDocxApplyError
+  | CompareDocxFinalParagraphMarkError
   | CompareDocxOperationLimitError
   | CompareDocxParseError
   | CompareDocxRoundTripError

--- a/packages/core/src/compare/verification.test.ts
+++ b/packages/core/src/compare/verification.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The structural guard the serialize stage runs before a package is written.
+ *
+ * The round-trip verdict is covered where it is produced (`probes.test.ts`,
+ * `compare.property.test.ts`); what is pinned here is the one finding that is
+ * fatal whatever the caller asked for, because the package it describes does
+ * not open.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { deletedFinalParagraphMarks } from "./verification";
+
+const revision = { id: 1, author: "compare", date: "2024-03-01T00:00:00.000Z" };
+
+const paragraph = (text: string, pPrMark?: { kind: string }) => ({
+  type: "paragraph",
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+  ...(pPrMark && { pPrMark: { kind: pPrMark.kind, info: revision } }),
+});
+
+const cell = (content: unknown[]) => ({ type: "tableCell", content });
+
+const table = (cells: unknown[][]) => ({
+  type: "table",
+  rows: [{ type: "tableRow", cells: cells.map((content) => cell(content)) }],
+});
+
+describe("deletedFinalParagraphMarks", () => {
+  test("a body whose last paragraph mark is deleted is named", () => {
+    expect(
+      deletedFinalParagraphMarks({
+        document: { content: [paragraph("first"), paragraph("last", { kind: "del" })] },
+      }),
+    ).toEqual([{ container: "package.document.content", paragraphIndex: 1, kind: "del" }]);
+  });
+
+  test("a relocation's source break counts, because it resolves the same way", () => {
+    expect(
+      deletedFinalParagraphMarks({
+        document: { content: [paragraph("first"), paragraph("last", { kind: "moveFrom" })] },
+      }),
+    ).toEqual([{ container: "package.document.content", paragraphIndex: 1, kind: "moveFrom" }]);
+  });
+
+  test("a mark deleted on a paragraph that something follows is not a finding", () => {
+    expect(
+      deletedFinalParagraphMarks({
+        document: {
+          content: [paragraph("first", { kind: "del" }), paragraph("last")],
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  test("an inserted final mark is not a finding: rejecting it removes the paragraph it added", () => {
+    expect(
+      deletedFinalParagraphMarks({
+        document: { content: [paragraph("first"), paragraph("added", { kind: "ins" })] },
+      }),
+    ).toEqual([]);
+  });
+
+  test("a cell, a header and a note are containers too", () => {
+    const found = deletedFinalParagraphMarks({
+      document: {
+        content: [table([[paragraph("cell", { kind: "del" })]]), paragraph("last")],
+      },
+      headers: new Map([["rId2", { content: [paragraph("header", { kind: "del" })] }]]),
+      footnotes: [{ id: 2, content: [paragraph("note", { kind: "del" })] }],
+    });
+    expect(found.map(({ container }) => container).toSorted()).toEqual([
+      "package.document.content[0].rows[0].cells[0].content",
+      "package.footnotes[0].content",
+      "package.headers.rId2.content",
+    ]);
+  });
+
+  test("a package with nothing on any final mark reports nothing", () => {
+    expect(
+      deletedFinalParagraphMarks({
+        document: { content: [table([[paragraph("cell")]]), paragraph("last")] },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -286,3 +286,75 @@ export const classifyProjectionMismatch = ({
       `length ${String(left.text.length)} against ${String(right.text.length)} (${counts})`,
   );
 };
+
+/**
+ * A container whose last paragraph carries a deletion on its mark.
+ *
+ * Structural facts only — a path through the package model and an index — so
+ * the finding is safe to log, report or quote.
+ */
+export type FinalParagraphMarkDeletion = {
+  /** Where the container sits in the package model, e.g. `package.document.content`. */
+  container: string;
+  /** The paragraph's index among its container's children. */
+  paragraphIndex: number;
+  /** The mark kind found there: `del`, or `moveFrom` for a relocation's source. */
+  kind: "del" | "moveFrom";
+};
+
+/** The mark kinds that resolve by joining the paragraph with the one after it. */
+const JOINS_FORWARD_ON_ACCEPT = Object.freeze(["del", "moveFrom"] as const);
+
+const joinsForwardOnAccept = (value: unknown): value is FinalParagraphMarkDeletion["kind"] =>
+  JOINS_FORWARD_ON_ACCEPT.some((kind) => kind === value);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isParagraph = (value: unknown): value is Record<string, unknown> =>
+  isRecord(value) && value["type"] === "paragraph";
+
+/**
+ * Every container in a package whose final paragraph mark carries a deletion.
+ *
+ * A deleted paragraph mark says "join this paragraph with the one after it".
+ * The last paragraph of a body, a table cell, a header or footer, a note or a
+ * text box has no paragraph after it, so the mark states an edit that cannot
+ * be carried out, and a consumer refuses the package rather than opening it.
+ *
+ * The walk is over the package model rather than over a list of the containers
+ * known today: a container is any sequence that ends in a paragraph, so a part
+ * the model grows later is covered the day it arrives instead of the day
+ * someone remembers this function.
+ */
+export const deletedFinalParagraphMarks = (packageModel: unknown): FinalParagraphMarkDeletion[] => {
+  const found: FinalParagraphMarkDeletion[] = [];
+  const visit = (value: unknown, path: string): void => {
+    if (Array.isArray(value)) {
+      const last: unknown = value.at(-1);
+      const mark = isParagraph(last) ? last["pPrMark"] : undefined;
+      const kind = isRecord(mark) ? mark["kind"] : undefined;
+      if (joinsForwardOnAccept(kind)) {
+        found.push({ container: path, paragraphIndex: value.length - 1, kind });
+      }
+      for (const [index, item] of value.entries()) {
+        visit(item, `${path}[${String(index)}]`);
+      }
+      return;
+    }
+    if (value instanceof Map) {
+      for (const [key, item] of value) {
+        visit(item, `${path}.${String(key)}`);
+      }
+      return;
+    }
+    if (!isRecord(value) || value instanceof Date || ArrayBuffer.isView(value)) {
+      return;
+    }
+    for (const [key, item] of Object.entries(value)) {
+      visit(item, `${path}.${key}`);
+    }
+  };
+  visit(packageModel, "package");
+  return found;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export { compareDocx, MAX_COMPARE_OPERATIONS } from "./compare/compare";
 export {
   COMPARE_UNSUPPORTED_REASONS,
   CompareDocxApplyError,
+  CompareDocxFinalParagraphMarkError,
   CompareDocxOperationLimitError,
   CompareDocxParseError,
   CompareDocxRoundTripError,
@@ -55,6 +56,7 @@ export {
   type CompareVerificationCause,
   type CompareVerificationFailure,
   type CompareVerificationInvariant,
+  type FinalParagraphMarkDeletion,
 } from "./compare/verification";
 export { createDocx } from "./docx/rezip";
 export { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -309,18 +309,27 @@ function resolveChange(
           nextNode?.type.name === paragraph.type.name &&
           !(carriesSection(paragraph) && carriesSection(nextNode));
         if (!joinable) {
-          // Nothing to join with: the paragraph ends the document, or the next
-          // sibling is a table, or the position lands on a cell boundary where
+          // Nothing to join with: the next sibling is a table, or the paragraph
+          // ends its container — a body, a cell, a header, a note or a text box
+          // each end with one, and the position then lands on a boundary where
           // `join` would merge the containers and silently lose rows.
           //
-          // Resolving the mark still has a meaning. The paragraph whose break
-          // and content were both resolved away is simply not there any more,
-          // so it is removed rather than left blank — which is what a document
-          // holds after a paragraph before a table is deleted and the deletion
-          // is accepted.
+          // A paragraph before a TABLE is still gone once its break and its
+          // content are both resolved away: it is simply not there any more, so
+          // it is removed rather than left blank.
           //
-          // A cell must contain a paragraph, so its parent's only child stays
-          // blank whatever its mark says.
+          // At the container's END the two directions part. A break that was
+          // ADDED there added the paragraph it ends, so taking the addition
+          // back removes the paragraph and the container ends where it did
+          // before. A break that was REMOVED there cannot be honoured at all:
+          // it says "join with the paragraph after this one" and there is
+          // none, so the paragraph keeps its place and loses only the mark's
+          // revision. That is also what makes a redline that deleted such a
+          // mark fail its own round trip rather than resolve into a document
+          // no consumer would have reached from it.
+          //
+          // A container must contain a paragraph either way, so its parent's
+          // only child stays blank whatever its mark says.
           //
           // A section's properties live on a paragraph mark, so the paragraph
           // is where its section ENDS. It can still go, but the section cannot
@@ -334,7 +343,14 @@ function resolveChange(
           const sectionCanMoveBack =
             !carriesSection(paragraph) ||
             (previous?.type.name === paragraph.type.name && !carriesSection(previous));
-          if (sectionCanMoveBack && holdsNoContent(paragraph) && resolved.parent.childCount > 1) {
+          const endsItsContainer = resolved.index() === resolved.parent.childCount - 1;
+          const canGo = op.markWasAdded || !endsItsContainer;
+          if (
+            sectionCanMoveBack &&
+            holdsNoContent(paragraph) &&
+            canGo &&
+            resolved.parent.childCount > 1
+          ) {
             if (carriesSection(paragraph) && previous) {
               tr.setNodeMarkup(mappedPos - previous.nodeSize, undefined, {
                 ...previous.attrs,
@@ -520,6 +536,13 @@ const resolveRunPropertyChange = ({
 type PPrMarkOp = {
   paragraphPos: number;
   action: "clear" | "join";
+  /**
+   * Whether the mark said the break was ADDED. A break that was added can be
+   * taken back out at a container's edge, because the paragraph it ends was
+   * not there before it; one that was removed cannot, because that paragraph
+   * is what the container ends with.
+   */
+  markWasAdded: boolean;
 };
 
 type TableRowStructuralOp = {
@@ -812,9 +835,9 @@ function collectPPrMarkOp(
   }
   // Accepting an added break, or rejecting a removed one, keeps the break
   // (clear the attr). The other two remove it (join with the next paragraph).
-  const action: PPrMarkOp["action"] =
-    paragraphMarkWasAdded(pPrMark.kind) === (mode === "accept") ? "clear" : "join";
-  return { paragraphPos: pos, action };
+  const markWasAdded = paragraphMarkWasAdded(pPrMark.kind);
+  const action: PPrMarkOp["action"] = markWasAdded === (mode === "accept") ? "clear" : "join";
+  return { paragraphPos: pos, action, markWasAdded };
 }
 
 function rangeCoversParagraphBoundary(

--- a/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -18,6 +18,9 @@ const schema = new Schema({
       },
     },
     text: { group: "inline", marks: "_" },
+    // A block a paragraph mark cannot join with, and which cannot end a
+    // container: what a table is to the paragraph before it.
+    table: { content: "block+", group: "block" },
     // Zero-width anchors: they hold a position, carry no revision of their
     // own, and therefore outlive a deletion that took every word around them.
     renderedPageBreak: { inline: true, group: "inline", atom: true },
@@ -184,12 +187,57 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
     const state = EditorState.create({
       schema,
       doc: schema.node("doc", null, [
+        schema.node("paragraph", { pPrMark: delMark({ id: 1 }) }),
+        schema.node("table", null, [schema.node("paragraph", null, schema.text("cell"))]),
+        schema.node("paragraph", null, schema.text("last")),
+      ]),
+    });
+    const view = dispatcher(state);
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(0).type.name).toBe("table");
+  });
+
+  test("acceptAll keeps an emptied paragraph that ENDS its container", () => {
+    // Nothing follows it, so the break it claims went cannot be closed over
+    // anything and the container would be left without the paragraph it has to
+    // end with. The revision is resolved; the paragraph stays, blank.
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
         schema.node("paragraph", null, schema.text("first")),
         schema.node("paragraph", { pPrMark: delMark({ id: 1 }) }),
       ]),
     });
     const view = dispatcher(state);
     acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(1).textContent).toBe("");
+    expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();
+  });
+
+  test("rejectAll still removes an emptied paragraph an insertion ADDED at the end", () => {
+    // The mirror case: the break was added, so the paragraph it ends was not
+    // there before it and taking the addition back leaves the container ending
+    // where it did.
+    const insertion = schema.marks["insertion"]!;
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, schema.text("first")),
+        schema.node(
+          "paragraph",
+          { pPrMark: insMark({ id: 1 }) },
+          schema.text("added", [
+            insertion.create({ revisionId: 1, author: "Alice", date: "2026-05-01" }),
+          ]),
+        ),
+      ]),
+    });
+    const view = dispatcher(state);
+    rejectAllChanges()(view.state, view.dispatch);
 
     expect(view.state.doc.childCount).toBe(1);
     expect(view.state.doc.child(0).textContent).toBe("first");
@@ -205,19 +253,20 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
       const state = EditorState.create({
         schema,
         doc: schema.node("doc", null, [
-          schema.node("paragraph", null, schema.text("first")),
           schema.node("paragraph", { pPrMark: delMark({ id: 2 }) }, [
             schema.node(anchor),
             schema.text("gone", [deletion.create(revision)]),
           ]),
+          schema.node("table", null, [schema.node("paragraph", null, schema.text("cell"))]),
+          schema.node("paragraph", null, schema.text("last")),
         ]),
       });
       const view = dispatcher(state);
 
       acceptAllChanges()(view.state, view.dispatch);
 
-      expect(view.state.doc.childCount).toBe(1);
-      expect(view.state.doc.child(0).textContent).toBe("first");
+      expect(view.state.doc.childCount).toBe(2);
+      expect(view.state.doc.child(0).type.name).toBe("table");
     });
   }
 
@@ -345,6 +394,8 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
             { pPrMark: delMark({ id: 2 }), sectionBreakType: "nextPage" },
             schema.text("gone", [deletion().create(revision)]),
           ),
+          schema.node("table", null, [schema.node("paragraph", null, schema.text("cell"))]),
+          schema.node("paragraph", null, schema.text("last")),
         ]),
       });
       const view = dispatcher(state);
@@ -353,7 +404,7 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
 
       // The section now ends one paragraph earlier; the content before it is
       // still in that section.
-      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.childCount).toBe(3);
       expect(view.state.doc.child(0).textContent).toBe("first");
       expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
     });
@@ -368,13 +419,15 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
             { pPrMark: delMark({ id: 2 }), sectionBreakType: "nextPage" },
             schema.text("gone", [deletion().create(revision)]),
           ),
+          schema.node("table", null, [schema.node("paragraph", null, schema.text("cell"))]),
+          schema.node("paragraph", null, schema.text("last")),
         ]),
       });
       const view = dispatcher(state);
 
       acceptAllChanges()(view.state, view.dispatch);
 
-      expect(view.state.doc.childCount).toBe(2);
+      expect(view.state.doc.childCount).toBe(4);
       expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
       expect(view.state.doc.child(1).attrs["sectionBreakType"]).toBe("nextPage");
       expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();


### PR DESCRIPTION
## The defect

`compareDocx` wrote `<w:p><w:pPr><w:rPr><w:del …/></w:rPr></w:pPr>…</w:p>` on the last paragraph of a container. A deleted paragraph mark means "merge this paragraph into the following one", and a container's final paragraph has none: a body, a table cell, a header or footer, a note and a text box each end with a paragraph that nothing follows. The mark states an edit that cannot be carried out, and a consumer refuses the whole package rather than opening it.

Base `A`, `B`, `C`, `D` against target `A'` produced `A` edited, `B` deleted with its mark kept, `C` and `D` deleted with BOTH marks deleted, then `w:sectPr`.

## The rule

The mark that ends a container is never deleted. When the paragraphs a container ends with are removed, the merge chain runs from the last SURVIVING paragraph forward:

- the surviving paragraph's mark is deleted, so it merges forward;
- each removed paragraph but the last loses its words and its mark;
- the container's final paragraph loses its words and KEEPS its mark, as the carrier the merged text lands in.

A paragraph's properties live on its mark, so the merged paragraph ends up with the carrier's. The carrier's properties therefore become the target's, written as `w:pPrChange` with the carrier's own set as the previous one, so accepting yields the target's paragraph properties and rejecting restores the base's. That is bookkeeping for the merge rather than an edit of its own, so it adds no entry to the change list: what the reader is told is that the paragraphs were removed.

For the same base and target the output is now: `A` edited in place, the text of `B`, `C`, `D` deleted, the marks of `A`, `B`, `C` deleted, `D`'s mark kept with `w:pPrChange` where the properties differ. Accept-all is the target and reject-all is the base, text and paragraph properties alike.

Nothing is rotated when the plan places a block inside or after the run: the carrier is then no longer what ends the container, its mark is deleted like any other, and the counts already work out.

An INSERTED mark at a container's end is the mirror case and still stands: the break ADDED the paragraph it ends, so rejecting the addition removes the paragraph and the container ends where it did. That is the existing rule for an append at a container's edge and it is unchanged.

## Why the self-check did not catch it

The round-trip self-check asks the applier to accept and to reject its own output and compares block projections, so it only sees what the applier does with a mark — and the applier's own accept semantics tolerated this one. Resolving a deleted mark with nothing to join to fell into the branch that removes the paragraph outright, which is the right answer for a paragraph before a table and happened to give the right block count here too. Accept-all therefore reproduced the target, reject-all reproduced the base, and the verdict was `verified` over a package no consumer would open. The applier is now aligned: a mark that was REMOVED at a container's end cannot be honoured, so the paragraph keeps its place and only the revision is resolved. A redline that deletes such a mark now fails its own round trip instead of passing.

`deleteBlock` will not produce one either, in tracked mode (the mark is left alone on a paragraph that ends its container) or in direct mode (the node is emptied rather than removed when nothing else could terminate the container — a body left ending in a table is the same malformed package by another route). The two modes agreeing at a container's edge matters here: the scenario DSL builds targets in direct mode, and where the modes disagreed it built targets the tracked vocabulary could not express.

## The guard

The serialize stage walks the package model before writing it and refuses one whose final paragraph mark carries a deletion, with a typed `CompareDocxFinalParagraphMarkError` naming the container (a structural path) and the paragraph index. It is fatal under `onUnverified: "emit"` too: unlike an unproven redline there is no partial result worth handing back, because the file does not open. The walk is over any sequence that ends in a paragraph rather than over a list of the container kinds known today, so a part the model grows later is covered the day it arrives. `benchmarks/compare/refusals.ts` gains its bucket, which is total over the error union.

## Tests

- `probes.test.ts`: `delete_trailing_paragraphs` (four body paragraphs become one — the marks written are `[del, del, del, kept]`), `delete_trailing_paragraphs_in_a_cell`, `delete_trailing_paragraphs_in_a_header`, and `trailing_deletion_moves_the_surviving_properties_to_the_carrier` (the carrier carries the target's `w:pStyle` plus `w:pPrChange`, and accept/reject round-trip with the style).
- `compare.property.test.ts`: `no container's final paragraph mark is ever deleted`, over the existing scenario arbitraries and read back from the bytes the comparison produced. The accept/reject round trip, determinism, churn bound, move and verification properties are unchanged and still hold.
- `verification.test.ts`: the guard itself — a body, a cell, a header and a note each named; a mark with a paragraph after it and an inserted final mark are not findings.
- `pPrMark-accept-reject.test.ts`: the resolution cases that used a doc-terminal paragraph to stand for "cannot join" now use a paragraph before a table, which is what they describe, plus new cases pinning both halves of the container-edge rule.
- Fixtures are generated: `__fixtures__/body-sequence.ts` grows an optional header part, written the same way as the body.

The compare digest baseline is re-recorded: the redline's shape changes wherever a comparison removes the paragraphs a container ends with.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document comparison now preserves the final paragraph mark in document bodies, table cells, headers, footnotes and text boxes.
  * Removing trailing paragraphs retains a valid carrier paragraph and preserves its formatting.
  * Invalid final paragraph-mark deletions are now reported as a clear comparison error instead of producing an unusable document.

* **New Features**
  * Added public error and diagnostic information for final paragraph-mark deletion issues.
  * Comparison refusal reporting now categorises these cases separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->