### PR TITLE
fix(core): unique revision ids, row placement and hyperlink nesting in compare output

### DIFF
--- a/.changeset/wide-mugs-punch.md
+++ b/.changeset/wide-mugs-punch.md
@@ -4,9 +4,9 @@
 
 Emit schema-valid OOXML for compared packages, and date them from the comparison.
 
-Three shapes a compared package could carry were not shapes the content model
-allows, and the round-trip self-check could not see any of them: it reads which
-words a view resolves to, and all three parse back to the right words.
+Four shapes a compared package could carry were not shapes the schema allows,
+and the round-trip self-check could not see any of them: it reads which words a
+view resolves to, and all four parse back to the right words.
 
 - **A revision `w:id` is unique across the package.** One logical change
   serializes as several physical wrappers — a word-level redline cut around the
@@ -26,6 +26,15 @@ words a view resolves to, and all three parse back to the right words.
   inserting linked text now emits
   `<w:hyperlink><w:del><w:r><w:delText>…`, splitting the revision at each link
   boundary, and reading such a package back restores the same model.
+- **A paragraph id is 31-bit.** `w14:paraId`, `w14:textId` and the comment-part
+  ids that reference a paragraph are `ST_LongHexNumber` with a maximum below
+  `0x80000000`. Producers exist that ignore the bound, and folio preserves the
+  ids a document arrives with, so an out-of-range id travelled straight through
+  a save. One mapping, a pure function of the id, now brings such a value into
+  range — applied when a paragraph is parsed and again across every part of the
+  package on the way out, so a paragraph and every reference to it move
+  together and a document's identity does not shift between reading and
+  writing.
 
 `compareDocx` also restamps `dcterms:modified` in `docProps/core.xml` from its
 `timestamp` option. The save wrote the wall clock there, so two runs over

--- a/.changeset/wide-mugs-punch.md
+++ b/.changeset/wide-mugs-punch.md
@@ -1,0 +1,33 @@
+---
+"@stll/folio-core": patch
+---
+
+Emit schema-valid OOXML for compared packages, and date them from the comparison.
+
+Three shapes a compared package could carry were not shapes the content model
+allows, and the round-trip self-check could not see any of them: it reads which
+words a view resolves to, and all three parse back to the right words.
+
+- **A revision `w:id` is unique across the package.** One logical change
+  serializes as several physical wrappers — a word-level redline cut around the
+  words that survived — and the pass that gives each its own id ran only on the
+  full repack. The selective save, which rewrites the changed paragraphs and
+  re-emits every other part verbatim, exited past it, so a paragraph-local edit
+  shipped several revisions under one id. Both exits now run the pass, and every
+  id it lets stand or mints goes through one choke point that refuses a
+  duplicate.
+- **`w:tbl` is `w:tblPr`, `w:tblGrid`, then rows.** Both are required and both
+  precede every row; they were emitted only when the model had something to put
+  in them, so a table the comparison creates — no authored properties, no
+  measured column widths — opened with its first `w:tr`. They are now always
+  written, with a grid column per column the widest row spans.
+- **`w:hyperlink` wraps a revision, not the other way round.** Run-level
+  `w:ins`/`w:del` take run-level content, which a hyperlink is not. Deleting or
+  inserting linked text now emits
+  `<w:hyperlink><w:del><w:r><w:delText>…`, splitting the revision at each link
+  boundary, and reading such a package back restores the same model.
+
+`compareDocx` also restamps `dcterms:modified` in `docProps/core.xml` from its
+`timestamp` option. The save wrote the wall clock there, so two runs over
+identical inputs with identical options differed in that part alone — the last
+clock in a call whose whole contract is that it has none.

--- a/packages/core/src/__tests__/textBoxTableDocument.ts
+++ b/packages/core/src/__tests__/textBoxTableDocument.ts
@@ -8,7 +8,7 @@ export const buildTextBoxTableDocument = async (cellText = "Cell value"): Promis
   document.package.document.content = [
     {
       type: "paragraph",
-      paraId: "A2000001",
+      paraId: "22000001",
       content: [
         {
           type: "run",
@@ -25,7 +25,7 @@ export const buildTextBoxTableDocument = async (cellText = "Cell value"): Promis
                   content: [
                     {
                       type: "paragraph",
-                      paraId: "A2000002",
+                      paraId: "22000002",
                       content: [{ type: "run", content: [{ type: "text", text: "Before table" }] }],
                     },
                     {
@@ -39,7 +39,7 @@ export const buildTextBoxTableDocument = async (cellText = "Cell value"): Promis
                               content: [
                                 {
                                   type: "paragraph",
-                                  paraId: "A2000003",
+                                  paraId: "22000003",
                                   content: [
                                     {
                                       type: "run",
@@ -55,7 +55,7 @@ export const buildTextBoxTableDocument = async (cellText = "Cell value"): Promis
                     },
                     {
                       type: "paragraph",
-                      paraId: "A2000004",
+                      paraId: "22000004",
                       content: [{ type: "run", content: [{ type: "text", text: "After table" }] }],
                     },
                   ],

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -62,10 +62,10 @@ const makeHeaderFooterBaseline = async (): Promise<ArrayBuffer> => {
   const source = await createEmptyDocx();
   const document = await parseDocx(source, { detectVariables: false, preloadFonts: false });
   document.package.headers = new Map([
-    [HEADER_RELATIONSHIP_ID, textStory("header", "Header text", "A1000001")],
+    [HEADER_RELATIONSHIP_ID, textStory("header", "Header text", "21000001")],
   ]);
   document.package.footers = new Map([
-    [FOOTER_RELATIONSHIP_ID, textStory("footer", "Footer text", "A1000002")],
+    [FOOTER_RELATIONSHIP_ID, textStory("footer", "Footer text", "21000002")],
   ]);
   document.package.document.finalSectionProperties = {
     ...document.package.document.finalSectionProperties,
@@ -1646,13 +1646,13 @@ describe("headless docx review round-trip", () => {
       story: { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const,
       part: "word/header1.xml",
       originalText: "Header text",
-      paraId: "A1000001",
+      paraId: "21000001",
     },
     {
       story: { type: "footer", relationshipId: FOOTER_RELATIONSHIP_ID } as const,
       part: "word/footer1.xml",
       originalText: "Footer text",
-      paraId: "A1000002",
+      paraId: "21000002",
     },
   ])(
     "persists insertion, deletion, and move resolution in a paraId-less $story.type",
@@ -2704,12 +2704,12 @@ const readNotesFixture = async (): Promise<ArrayBuffer> => {
   const footnotesXml = await footnotesFile.async("text");
   const injected = footnotesXml.replace(
     "</w:footnotes>",
-    '<w:footnote w:id="2"><w:p w14:paraId="B2000001"><w:r><w:t>Injected footnote body text.</w:t></w:r></w:p></w:footnote></w:footnotes>',
+    '<w:footnote w:id="2"><w:p w14:paraId="32000001"><w:r><w:t>Injected footnote body text.</w:t></w:r></w:p></w:footnote></w:footnotes>',
   );
   zip.file("word/footnotes.xml", injected);
   zip.file(
     "word/endnotes.xml",
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="B2000002"><w:r><w:t>Injected endnote body text.</w:t></w:r></w:p></w:endnote></w:endnotes>',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="32000002"><w:r><w:t>Injected endnote body text.</w:t></w:r></w:p></w:endnote></w:endnotes>',
   );
   return zip.generateAsync({ type: "arraybuffer" });
 };
@@ -2726,7 +2726,7 @@ const readRichNotesFixture = async (): Promise<ArrayBuffer> => {
     footnotesXml.replace(
       /<w:footnote w:id="2">.*?<\/w:footnote>/u,
       `<w:footnote w:id="2">
-        <w:p w14:paraId="B2000001">
+        <w:p w14:paraId="32000001">
           <w:r><w:t xml:space="preserve">See </w:t></w:r>
           <w:ins w:id="1" w:author="Reviewer"><w:r><w:t xml:space="preserve">INSERTED </w:t></w:r></w:ins>
           <w:del w:id="2" w:author="Reviewer"><w:r><w:delText xml:space="preserve">DELETED </w:delText></w:r></w:del>
@@ -2741,13 +2741,13 @@ const readRichNotesFixture = async (): Promise<ArrayBuffer> => {
           <w:r><w:fldChar w:fldCharType="end"/></w:r>
           <w:sdt><w:sdtPr/><w:sdtContent><w:r><w:t>SDT.</w:t></w:r></w:sdtContent></w:sdt>
         </w:p>
-        <w:tbl><w:tr><w:tc><w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
+        <w:tbl><w:tr><w:tc><w:p w:rsidR="700D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
       </w:footnote>`,
     ),
   );
   zip.file(
     "word/endnotes.xml",
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="B2000002"><w:r><w:t xml:space="preserve">Endnote </w:t></w:r><w:ins w:id="5" w:author="Reviewer"><w:r><w:t>INSERTED</w:t></w:r></w:ins><w:del w:id="6" w:author="Reviewer"><w:r><w:delText>DELETED</w:delText></w:r></w:del><w:moveFrom w:id="7" w:author="Reviewer"><w:r><w:t xml:space="preserve"> MOVED FROM </w:t></w:r></w:moveFrom><w:moveTo w:id="8" w:author="Reviewer"><w:r><w:t xml:space="preserve"> MOVED TO </w:t></w:r></w:moveTo></w:p><w:tbl><w:tr><w:tc><w:p w:rsidR="E00D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:endnote></w:endnotes>',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="32000002"><w:r><w:t xml:space="preserve">Endnote </w:t></w:r><w:ins w:id="5" w:author="Reviewer"><w:r><w:t>INSERTED</w:t></w:r></w:ins><w:del w:id="6" w:author="Reviewer"><w:r><w:delText>DELETED</w:delText></w:r></w:del><w:moveFrom w:id="7" w:author="Reviewer"><w:r><w:t xml:space="preserve"> MOVED FROM </w:t></w:r></w:moveFrom><w:moveTo w:id="8" w:author="Reviewer"><w:r><w:t xml:space="preserve"> MOVED TO </w:t></w:r></w:moveTo></w:p><w:tbl><w:tr><w:tc><w:p w:rsidR="600D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:endnote></w:endnotes>',
   );
   return zip.generateAsync({ type: "arraybuffer" });
 };
@@ -2769,18 +2769,18 @@ describe("headless docx review notes read surface", () => {
     {
       story: { type: "footnote", noteId: 2 } as const,
       part: "word/footnotes.xml",
-      removedParaId: "B2000001",
+      removedParaId: "32000001",
       idProfile: "without paragraph ids",
       expectedText: "See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT.TABLE CELL",
-      preservedParagraph: '<w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
+      preservedParagraph: '<w:p w:rsidR="700D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
     },
     {
       story: { type: "endnote", noteId: 3 } as const,
       part: "word/endnotes.xml",
-      removedParaId: "B2000002",
+      removedParaId: "32000002",
       idProfile: "without paragraph ids",
       expectedText: "Endnote INSERTED MOVED TO ENDNOTE CELL",
-      preservedParagraph: '<w:p w:rsidR="E00D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p>',
+      preservedParagraph: '<w:p w:rsidR="600D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p>',
     },
     {
       story: { type: "footnote", noteId: 2 } as const,
@@ -2788,7 +2788,7 @@ describe("headless docx review notes read surface", () => {
       removedParaId: null,
       idProfile: "with paragraph ids",
       expectedText: "See INSERTED MOVED TO LINK SIMPLE COMPLEX SDT.TABLE CELL",
-      preservedParagraph: '<w:p w:rsidR="F00D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
+      preservedParagraph: '<w:p w:rsidR="700D0002"><w:r><w:t>TABLE CELL</w:t></w:r></w:p>',
     },
     {
       story: { type: "endnote", noteId: 3 } as const,
@@ -2796,7 +2796,7 @@ describe("headless docx review notes read surface", () => {
       removedParaId: null,
       idProfile: "with paragraph ids",
       expectedText: "Endnote INSERTED MOVED TO ENDNOTE CELL",
-      preservedParagraph: '<w:p w:rsidR="E00D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p>',
+      preservedParagraph: '<w:p w:rsidR="600D0003"><w:r><w:t>ENDNOTE CELL</w:t></w:r></w:p>',
     },
   ])(
     "persists a resolved final $story.type $idProfile",

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -283,7 +283,8 @@ carries the current numbers and the failing cases.
   container's final paragraph mark. Pure.
 - `formatting.ts` — the inline-formatting diff, shared with the redline
   generator.
-- `reproducible-package.ts` — ZIP entry-date restamping.
+- `reproducible-package.ts` — the clocks outside the document body: ZIP entry
+  dates and `dcterms:modified`.
 - `scenario.ts` — the edit-script DSL the property tests build targets with.
 - `plan.test.ts` — the judgement calls the corpus does not reach: the move
   similarity threshold, and row pairing when a table's row count changed.

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -35,7 +35,10 @@ random source:
 - `w14:paraId`s for paragraphs the comparison creates are derived from the
   stamp instead of `Math.random()`;
 - ZIP entry dates are restamped from the same timestamp, because JSZip
-  otherwise writes the current time into every part it rewrites.
+  otherwise writes the current time into every part it rewrites;
+- `dcterms:modified` in `docProps/core.xml` is restamped from it too, because
+  the save otherwise dates the package from the second it happened to run and
+  two runs then differ in that part alone.
 
 Two runs over the same inputs therefore produce byte-identical buffers and
 deeply equal change lists. `compare.property.test.ts` holds this as a property,

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -108,13 +108,17 @@ const inlineXml = (inline: ParagraphInline, { links }: BodyContext): string =>
  * holds for a blank line or an empty cell. It is not the same thing as a
  * paragraph whose run carries an empty string, and both shapes occur.
  */
+/** A blank line carries no run at all, so an empty string is no inline. */
+const nonEmptyInlines = (text: string): readonly ParagraphInline[] =>
+  text.length === 0 ? [] : [text];
+
 const paragraph = (
   text: string | readonly ParagraphInline[],
   context: BodyContext,
   styleId?: string,
 ): string => {
   const properties = styleId === undefined ? "" : `<w:pPr><w:pStyle w:val="${styleId}"/></w:pPr>`;
-  const inlines = typeof text === "string" ? (text.length === 0 ? [] : [text]) : text;
+  const inlines = typeof text === "string" ? nonEmptyInlines(text) : text;
   const content = inlines
     .map((inline) => (typeof inline === "string" ? inline : inline.text))
     .join("");
@@ -169,7 +173,10 @@ const cellXml = (content: CellContent, context: BodyContext): string =>
 
 /** `w:tbl` is `w:tblPr, w:tblGrid, rows`: a fixture without the grid is not one. */
 const tableGrid = (rows: readonly (readonly CellContent[])[]): string => {
-  const columns = rows.reduce((widest, cells) => Math.max(widest, cells.length), 0);
+  let columns = 0;
+  for (const cells of rows) {
+    columns = Math.max(columns, cells.length);
+  }
   return `<w:tblGrid>${`<w:gridCol w:w="2000"/>`.repeat(columns)}</w:tblGrid>`;
 };
 

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -13,6 +13,10 @@ const NAMESPACE = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 const RELATIONSHIPS = "http://schemas.openxmlformats.org/package/2006/relationships";
 const OFFICE_RELATIONSHIPS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 const WORDPROCESSING = "application/vnd.openxmlformats-officedocument.wordprocessingml";
+const MARKUP_COMPATIBILITY = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+const PACKAGE_RELATIONSHIPS = "http://schemas.openxmlformats.org/package/2006";
+const CORE_PROPERTIES_TYPE = "application/vnd.openxmlformats-package.core-properties+xml";
+const WORDML_2010 = "http://schemas.microsoft.com/office/word/2010/wordml";
 
 /** Pinned so two builds of the fixture produce identical bytes. */
 const FIXED_ZIP_DATE = new Date(Date.UTC(2000, 0, 1));
@@ -30,9 +34,17 @@ const ZIP_ENTRY_OPTIONS = { date: FIXED_ZIP_DATE, createFolders: false } as cons
  */
 export type CellContent = string | readonly BodyItem[];
 
+/**
+ * One inline of a paragraph: plain text, or text carrying an external
+ * hyperlink. A link is the case where a revision wrapper and the linked runs
+ * have to nest one inside the other, so the fixture has to be able to author
+ * one.
+ */
+export type ParagraphInline = string | { text: string; href: string };
+
 /** One body-level item: a paragraph, or a table given row by row. */
 export type BodyItem =
-  | { kind: "paragraph"; text: string; styleId?: string }
+  | { kind: "paragraph"; text: string | readonly ParagraphInline[]; styleId?: string }
   | {
       kind: "table";
       rows: readonly (readonly CellContent[])[];
@@ -45,15 +57,95 @@ export type BodyItem =
     };
 
 /**
+ * What the body writer carries down the tree: the relationship id each
+ * authored href was written under, and the `w14:paraId` allocator.
+ *
+ * A real package identifies its paragraphs. A fixture that did not would make
+ * every save rewrite the whole package instead of splicing the paragraphs that
+ * changed, which is a different code path from the one a document exercises.
+ */
+type BodyContext = {
+  links: ReadonlyMap<string, string>;
+  paraId: (content: string) => string;
+};
+
+/**
+ * A paragraph's id is derived from its own content, not from its position.
+ *
+ * Two packages authored from two descriptions are a base and a target, and a
+ * paragraph that appears in both is the same paragraph. Numbering the ids in
+ * document order would instead give the same id to the paragraph that happens
+ * to sit at the same index, which is how the fixture would tell a comparison
+ * that a removed paragraph was a rewrite of the one after it.
+ */
+const createParaIdAllocator = (): ((content: string) => string) => {
+  const taken = new Set<string>();
+  return (content) => {
+    let hash = 0x811c_9dc5;
+    for (let index = 0; index < content.length; index += 1) {
+      hash = Math.imul(hash ^ content.charCodeAt(index), 0x0100_0193) >>> 0;
+    }
+    // `00000000` and `FFFFFFFF` are reserved, and an id is unique per package.
+    let candidate = hash % 0xffff_fffe;
+    while (taken.has((candidate + 1).toString(16).toUpperCase().padStart(8, "0"))) {
+      candidate = (candidate + 1) % 0xffff_fffe;
+    }
+    const paraId = (candidate + 1).toString(16).toUpperCase().padStart(8, "0");
+    taken.add(paraId);
+    return paraId;
+  };
+};
+
+const run = (text: string): string => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
+
+const inlineXml = (inline: ParagraphInline, { links }: BodyContext): string =>
+  typeof inline === "string"
+    ? run(inline)
+    : `<w:hyperlink r:id="${links.get(inline.href) ?? ""}">${run(inline.text)}</w:hyperlink>`;
+
+/**
  * An empty paragraph is a `w:p` with no run at all, which is what a package
  * holds for a blank line or an empty cell. It is not the same thing as a
  * paragraph whose run carries an empty string, and both shapes occur.
  */
-const paragraph = (text: string, styleId?: string): string => {
+const paragraph = (
+  text: string | readonly ParagraphInline[],
+  context: BodyContext,
+  styleId?: string,
+): string => {
   const properties = styleId === undefined ? "" : `<w:pPr><w:pStyle w:val="${styleId}"/></w:pPr>`;
-  return text.length === 0
-    ? `<w:p>${properties}</w:p>`
-    : `<w:p>${properties}<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+  const inlines = typeof text === "string" ? (text.length === 0 ? [] : [text]) : text;
+  const content = inlines
+    .map((inline) => (typeof inline === "string" ? inline : inline.text))
+    .join("");
+  return (
+    `<w:p w14:paraId="${context.paraId(`${styleId ?? ""}|${content}`)}">${properties}` +
+    `${inlines.map((inline) => inlineXml(inline, context)).join("")}</w:p>`
+  );
+};
+
+/** Every href the body carries, in document order, so the ids are stable. */
+const collectHrefs = (items: readonly BodyItem[], hrefs: string[]): void => {
+  for (const item of items) {
+    if (item.kind === "paragraph") {
+      if (typeof item.text === "string") {
+        continue;
+      }
+      for (const inline of item.text) {
+        if (typeof inline !== "string" && !hrefs.includes(inline.href)) {
+          hrefs.push(inline.href);
+        }
+      }
+      continue;
+    }
+    for (const row of item.rows) {
+      for (const cell of row) {
+        if (typeof cell !== "string") {
+          collectHrefs(cell, hrefs);
+        }
+      }
+    }
+  }
 };
 
 const EMPTY_PARAGRAPH = { kind: "paragraph", text: "" } as const satisfies BodyItem;
@@ -70,20 +162,29 @@ const closedSequence = (items: readonly BodyItem[]): readonly BodyItem[] => {
 };
 
 /** A cell must also contain a paragraph, which the empty sequence supplies. */
-const cellXml = (content: CellContent): string =>
-  typeof content === "string" ? paragraph(content) : itemsXml(closedSequence(content));
+const cellXml = (content: CellContent, context: BodyContext): string =>
+  typeof content === "string"
+    ? paragraph(content, context)
+    : itemsXml(closedSequence(content), context);
 
-const table = (item: Extract<BodyItem, { kind: "table" }>): string => {
+/** `w:tbl` is `w:tblPr, w:tblGrid, rows`: a fixture without the grid is not one. */
+const tableGrid = (rows: readonly (readonly CellContent[])[]): string => {
+  const columns = rows.reduce((widest, cells) => Math.max(widest, cells.length), 0);
+  return `<w:tblGrid>${`<w:gridCol w:w="2000"/>`.repeat(columns)}</w:tblGrid>`;
+};
+
+const table = (item: Extract<BodyItem, { kind: "table" }>, context: BodyContext): string => {
   const hidden = new Set(item.hiddenRows ?? []);
   return (
     `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
+    tableGrid(item.rows) +
     item.rows
       .map(
         (cells, rowIndex) =>
           `<w:tr>${hidden.has(rowIndex) ? `<w:trPr><w:hidden/></w:trPr>` : ""}${cells
             .map(
               (content) =>
-                `<w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>${cellXml(content)}</w:tc>`,
+                `<w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>${cellXml(content, context)}</w:tc>`,
             )
             .join("")}</w:tr>`,
       )
@@ -92,12 +193,17 @@ const table = (item: Extract<BodyItem, { kind: "table" }>): string => {
   );
 };
 
-const itemsXml = (items: readonly BodyItem[]): string =>
+const itemsXml = (items: readonly BodyItem[], context: BodyContext): string =>
   items
-    .map((item) => (item.kind === "paragraph" ? paragraph(item.text, item.styleId) : table(item)))
+    .map((item) =>
+      item.kind === "paragraph"
+        ? paragraph(item.text, context, item.styleId)
+        : table(item, context),
+    )
     .join("");
 
-const bodyXml = (items: readonly BodyItem[]): string => itemsXml(closedSequence(items));
+const bodyXml = (items: readonly BodyItem[], context: BodyContext): string =>
+  itemsXml(closedSequence(items), context);
 
 /** The relationship id the default header takes when a fixture asks for one. */
 const HEADER_RELATIONSHIP_ID = "rId2";
@@ -115,6 +221,25 @@ export const buildBodySequenceDocx = async (
   items: readonly BodyItem[],
   { header }: BodySequenceOptions = {},
 ): Promise<ArrayBuffer> => {
+  const hrefs: string[] = [];
+  collectHrefs(closedSequence(items), hrefs);
+  collectHrefs(closedSequence(header ?? []), hrefs);
+  // rId1 is the style part and rId2 the header when there is one; hyperlink
+  // relationships follow them in document order.
+  const firstLinkRelationship = header ? 3 : 2;
+  const links = new Map(
+    hrefs.map((href, index) => [href, `rId${index + firstLinkRelationship}`]),
+  );
+  const linkRelationships = hrefs
+    .map(
+      (href, index) =>
+        `<Relationship Id="rId${index + firstLinkRelationship}" ` +
+        `Type="${OFFICE_RELATIONSHIPS}/hyperlink" ` +
+        `Target="${href}" TargetMode="External"/>`,
+    )
+    .join("");
+  const paraId = createParaIdAllocator();
+
   const parts: Record<string, string> = {
     "[Content_Types].xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -126,12 +251,25 @@ export const buildBodySequenceDocx = async (
       (header
         ? `<Override PartName="/word/header1.xml" ContentType="${WORDPROCESSING}.header+xml"/>`
         : "") +
+      `<Override PartName="/docProps/core.xml" ContentType="${CORE_PROPERTIES_TYPE}"/>` +
       `</Types>`,
     "_rels/.rels":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<Relationships xmlns="${RELATIONSHIPS}">` +
       `<Relationship Id="rId1" Type="${OFFICE_RELATIONSHIPS}/officeDocument" Target="word/document.xml"/>` +
+      `<Relationship Id="rId2" Type="${PACKAGE_RELATIONSHIPS}/metadata/core-properties" Target="docProps/core.xml"/>` +
       `</Relationships>`,
+    // A real package dates itself. Without this part nothing would prove that
+    // the comparison stamps `dcterms:modified` from its own timestamp rather
+    // than from the second the save happened to run.
+    "docProps/core.xml":
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<cp:coreProperties xmlns:cp="${PACKAGE_RELATIONSHIPS}/metadata/core-properties" ` +
+      `xmlns:dcterms="http://purl.org/dc/terms/" ` +
+      `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">` +
+      `<dcterms:created xsi:type="dcterms:W3CDTF">2000-01-01T00:00:00Z</dcterms:created>` +
+      `<dcterms:modified xsi:type="dcterms:W3CDTF">2000-01-01T00:00:00Z</dcterms:modified>` +
+      `</cp:coreProperties>`,
     "word/_rels/document.xml.rels":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<Relationships xmlns="${RELATIONSHIPS}">` +
@@ -139,6 +277,7 @@ export const buildBodySequenceDocx = async (
       (header
         ? `<Relationship Id="${HEADER_RELATIONSHIP_ID}" Type="${OFFICE_RELATIONSHIPS}/header" Target="header1.xml"/>`
         : "") +
+      linkRelationships +
       `</Relationships>`,
     "word/styles.xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -148,8 +287,10 @@ export const buildBodySequenceDocx = async (
       `</w:styles>`,
     "word/document.xml":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-      `<w:document xmlns:w="${NAMESPACE}" xmlns:r="${OFFICE_RELATIONSHIPS}"><w:body>` +
-      bodyXml(items) +
+      `<w:document xmlns:w="${NAMESPACE}" xmlns:r="${OFFICE_RELATIONSHIPS}" ` +
+      `xmlns:mc="${MARKUP_COMPATIBILITY}" xmlns:w14="${WORDML_2010}" mc:Ignorable="w14">` +
+      `<w:body>` +
+      bodyXml(items, { links, paraId }) +
       `<w:sectPr>` +
       (header ? `<w:headerReference w:type="default" r:id="${HEADER_RELATIONSHIP_ID}"/>` : "") +
       `<w:pgSz w:w="12240" w:h="15840"/>` +
@@ -159,7 +300,9 @@ export const buildBodySequenceDocx = async (
       ? {
           "word/header1.xml":
             `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-            `<w:hdr xmlns:w="${NAMESPACE}">${itemsXml(closedSequence(header))}</w:hdr>`,
+            `<w:hdr xmlns:w="${NAMESPACE}" xmlns:r="${OFFICE_RELATIONSHIPS}" ` +
+            `xmlns:mc="${MARKUP_COMPATIBILITY}" xmlns:w14="${WORDML_2010}" mc:Ignorable="w14">` +
+            `${itemsXml(closedSequence(header), { links, paraId })}</w:hdr>`,
         }
       : {}),
   };

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -250,9 +250,7 @@ export const buildBodySequenceDocx = async (
   // rId1 is the style part and rId2 the header when there is one; hyperlink
   // relationships follow them in document order.
   const firstLinkRelationship = header ? 3 : 2;
-  const links = new Map(
-    hrefs.map((href, index) => [href, `rId${index + firstLinkRelationship}`]),
-  );
+  const links = new Map(hrefs.map((href, index) => [href, `rId${index + firstLinkRelationship}`]));
   const linkRelationships = hrefs
     .map(
       (href, index) =>

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -44,7 +44,16 @@ export type ParagraphInline = string | { text: string; href: string };
 
 /** One body-level item: a paragraph, or a table given row by row. */
 export type BodyItem =
-  | { kind: "paragraph"; text: string | readonly ParagraphInline[]; styleId?: string }
+  | {
+      kind: "paragraph";
+      text: string | readonly ParagraphInline[];
+      styleId?: string;
+      /**
+       * An authored `w14:paraId`, for a package whose ids a producer wrote
+       * without respecting the 31-bit bound the schema puts on them.
+       */
+      paraId?: string;
+    }
   | {
       kind: "table";
       rows: readonly (readonly CellContent[])[];
@@ -85,10 +94,11 @@ const createParaIdAllocator = (): ((content: string) => string) => {
     for (let index = 0; index < content.length; index += 1) {
       hash = Math.imul(hash ^ content.charCodeAt(index), 0x0100_0193) >>> 0;
     }
-    // `00000000` and `FFFFFFFF` are reserved, and an id is unique per package.
-    let candidate = hash % 0xffff_fffe;
+    // A paragraph id is 31-bit, `00000000` is the reserved "no id", and an id
+    // is unique per package.
+    let candidate = hash % 0x7fff_fffe;
     while (taken.has((candidate + 1).toString(16).toUpperCase().padStart(8, "0"))) {
-      candidate = (candidate + 1) % 0xffff_fffe;
+      candidate = (candidate + 1) % 0x7fff_fffe;
     }
     const paraId = (candidate + 1).toString(16).toUpperCase().padStart(8, "0");
     taken.add(paraId);
@@ -112,18 +122,21 @@ const inlineXml = (inline: ParagraphInline, { links }: BodyContext): string =>
 const nonEmptyInlines = (text: string): readonly ParagraphInline[] =>
   text.length === 0 ? [] : [text];
 
+type ParagraphOptions = { styleId?: string; paraId?: string };
+
 const paragraph = (
   text: string | readonly ParagraphInline[],
   context: BodyContext,
-  styleId?: string,
+  { styleId, paraId }: ParagraphOptions = {},
 ): string => {
   const properties = styleId === undefined ? "" : `<w:pPr><w:pStyle w:val="${styleId}"/></w:pPr>`;
   const inlines = typeof text === "string" ? nonEmptyInlines(text) : text;
   const content = inlines
     .map((inline) => (typeof inline === "string" ? inline : inline.text))
     .join("");
+  const id = paraId ?? context.paraId(`${styleId ?? ""}|${content}`);
   return (
-    `<w:p w14:paraId="${context.paraId(`${styleId ?? ""}|${content}`)}">${properties}` +
+    `<w:p w14:paraId="${id}" w14:textId="${id}">${properties}` +
     `${inlines.map((inline) => inlineXml(inline, context)).join("")}</w:p>`
   );
 };
@@ -204,7 +217,10 @@ const itemsXml = (items: readonly BodyItem[], context: BodyContext): string =>
   items
     .map((item) =>
       item.kind === "paragraph"
-        ? paragraph(item.text, context, item.styleId)
+        ? paragraph(item.text, context, {
+            ...(item.styleId === undefined ? {} : { styleId: item.styleId }),
+            ...(item.paraId === undefined ? {} : { paraId: item.paraId }),
+          })
         : table(item, context),
     )
     .join("");

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
+import JSZip from "jszip";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -81,6 +82,33 @@ const withPriorRevisions = async (buffer: ArrayBuffer): Promise<ArrayBuffer> => 
     },
   );
   return await reviewer.toBuffer();
+};
+
+const REVISION_ELEMENT_ID =
+  /<w:(?:ins|del|moveFrom|moveTo|rPrChange|pPrChange|tblPrChange|trPrChange|tcPrChange|cellIns|cellDel|cellMerge)\b[^>]*\bw:id="(\d+)"/gu;
+
+/**
+ * Every revision `w:id` the package carries, across every part.
+ *
+ * A `w:id` is unique package-wide rather than part-wide, and one logical change
+ * can serialize as several wrappers — a redline cut around the words that
+ * survived, a revision split around a hyperlink — so the ids only stay distinct
+ * if something checks them all together.
+ */
+const revisionIdsInPackage = async (buffer: ArrayBuffer): Promise<string[]> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const ids: string[] = [];
+  for (const [path, file] of Object.entries(zip.files)) {
+    if (file.dir || !path.startsWith("word/") || !path.endsWith(".xml")) {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- the parts share one id space, so they are read together
+    const xml = await file.async("text");
+    for (const [, id] of xml.matchAll(REVISION_ELEMENT_ID)) {
+      ids.push(id ?? "");
+    }
+  }
+  return ids;
 };
 
 const authorsOfChanges = async (buffer: ArrayBuffer): Promise<string[]> => {
@@ -454,6 +482,25 @@ describe("compareDocx", () => {
             expect(first.changes).toEqual(second.changes);
           }),
           propertyConfig({ numRuns: 8 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
+
+    test(
+      `every revision id in the package is claimed once (${name})`,
+      async () => {
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const { buffer } = await compareOrThrow(base, scripted.value.buffer);
+            const ids = await revisionIdsInPackage(buffer);
+            expect(new Set(ids).size).toBe(ids.length);
+          }),
+          propertyConfig({ numRuns: 10 }),
         );
       },
       propertyTestTimeout(120_000),

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -111,6 +111,30 @@ const revisionIdsInPackage = async (buffer: ArrayBuffer): Promise<string[]> => {
   return ids;
 };
 
+const PARAGRAPH_ID_ATTRIBUTE =
+  /\b(?:w|w14|w15|w16cid):(?:paraId|paraIdParent|textId)="([0-9A-Fa-f]{8})"/gu;
+
+/**
+ * Every paragraph id and text-revision marker the package carries. They are
+ * `ST_LongHexNumber` with a maximum, so the values are 31-bit, and a package
+ * carrying a larger one is a package a consumer refuses.
+ */
+const paragraphIdsInPackage = async (buffer: ArrayBuffer): Promise<string[]> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const ids: string[] = [];
+  for (const [partPath, file] of Object.entries(zip.files)) {
+    if (file.dir || !partPath.startsWith("word/") || !partPath.endsWith(".xml")) {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- the parts share one id space, so they are read together
+    const xml = await file.async("text");
+    for (const [, id] of xml.matchAll(PARAGRAPH_ID_ATTRIBUTE)) {
+      ids.push(id ?? "");
+    }
+  }
+  return ids;
+};
+
 const authorsOfChanges = async (buffer: ArrayBuffer): Promise<string[]> => {
   const reviewer = await FolioDocxReviewer.fromBuffer(buffer);
   return [...new Set(reviewer.getChanges().map(({ author }) => author))].toSorted();
@@ -499,6 +523,25 @@ describe("compareDocx", () => {
             const { buffer } = await compareOrThrow(base, scripted.value.buffer);
             const ids = await revisionIdsInPackage(buffer);
             expect(new Set(ids).size).toBe(ids.length);
+          }),
+          propertyConfig({ numRuns: 10 }),
+        );
+      },
+      propertyTestTimeout(120_000),
+    );
+
+    test(
+      `every paragraph id in the package fits the 31-bit range (${name})`,
+      async () => {
+        await fc.assert(
+          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+            const scripted = await applyEditScript(base, script);
+            if (scripted.isErr()) {
+              throw scripted.error;
+            }
+            const { buffer } = await compareOrThrow(base, scripted.value.buffer);
+            const ids = await paragraphIdsInPackage(buffer);
+            expect(ids.every((id) => Number.parseInt(id, 16) < 0x8000_0000)).toBe(true);
           }),
           propertyConfig({ numRuns: 10 }),
         );

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -98,8 +98,8 @@ const REVISION_ELEMENT_ID =
 const revisionIdsInPackage = async (buffer: ArrayBuffer): Promise<string[]> => {
   const zip = await JSZip.loadAsync(buffer);
   const ids: string[] = [];
-  for (const [path, file] of Object.entries(zip.files)) {
-    if (file.dir || !path.startsWith("word/") || !path.endsWith(".xml")) {
+  for (const [partPath, file] of Object.entries(zip.files)) {
+    if (file.dir || !partPath.startsWith("word/") || !partPath.endsWith(".xml")) {
       continue;
     }
     // oxlint-disable-next-line no-await-in-loop -- the parts share one id space, so they are read together

--- a/packages/core/src/compare/package-shape.test.ts
+++ b/packages/core/src/compare/package-shape.test.ts
@@ -17,14 +17,25 @@ import { compareDocx } from "./compare";
 
 const OPTIONS = { author: "compare", timestamp: "2024-03-01T00:00:00.000Z" } as const;
 
+type ComparedDocumentOptions = {
+  /**
+   * Take the redline the comparison could build even when its round trip is
+   * not proven. Only for a pair whose round trip is a known gap: the markup
+   * these assertions read is still the markup the engine emits, and the round
+   * trip itself belongs to the property tests.
+   */
+  onUnverified?: "emit";
+};
+
 const comparedDocumentXml = async (
   base: readonly BodyItem[],
   target: readonly BodyItem[],
+  { onUnverified }: ComparedDocumentOptions = {},
 ): Promise<string> => {
   const result = await compareDocx(
     await buildBodySequenceDocx(base),
     await buildBodySequenceDocx(target),
-    OPTIONS,
+    { ...OPTIONS, ...(onUnverified === undefined ? {} : { onUnverified }) },
   );
   if (result.isErr()) {
     throw result.error;
@@ -135,13 +146,31 @@ describe("table placement", () => {
   test.each([
     {
       name: "an added table",
-      base: [{ kind: "paragraph", text: "before" }] satisfies BodyItem[],
-      target: [{ kind: "paragraph", text: "before" }, TABLE] satisfies BodyItem[],
+      base: [
+        { kind: "paragraph", text: "before" },
+        { kind: "paragraph", text: "after" },
+      ] satisfies BodyItem[],
+      target: [
+        { kind: "paragraph", text: "before" },
+        TABLE,
+        { kind: "paragraph", text: "after" },
+      ] satisfies BodyItem[],
     },
     {
       name: "a removed table",
-      base: [{ kind: "paragraph", text: "before" }, TABLE] satisfies BodyItem[],
-      target: [{ kind: "paragraph", text: "before" }] satisfies BodyItem[],
+      base: [
+        { kind: "paragraph", text: "before" },
+        TABLE,
+        { kind: "paragraph", text: "after" },
+      ] satisfies BodyItem[],
+      target: [
+        { kind: "paragraph", text: "before" },
+        { kind: "paragraph", text: "after" },
+      ] satisfies BodyItem[],
+      // Removing a whole table leaves one blank paragraph behind, so the
+      // comparison cannot prove the round trip; what it emits for the table
+      // it keeps is still what this asserts.
+      onUnverified: { onUnverified: "emit" } as const,
     },
     {
       name: "a row added at the top",
@@ -175,18 +204,21 @@ describe("table placement", () => {
       base: [TABLE] satisfies BodyItem[],
       target: [{ kind: "table", rows: TABLE.rows.slice(0, 2) }] satisfies BodyItem[],
     },
-  ])("$name keeps every row after the table's properties and grid", async ({ base, target }) => {
-    const xml = await comparedDocumentXml(base, target);
-    const tables = tableChildNames(xml);
-    expect(tables.length).toBeGreaterThan(0);
-    for (const children of tables) {
-      expect(children.slice(0, 2)).toEqual(["w:tblPr", "w:tblGrid"]);
-      expect(children.slice(2).every((name) => name === "w:tr")).toBe(true);
-    }
-    // A tracked row is marked inside its own `w:trPr`, never by wrapping the
-    // row in a revision element.
-    expect(/<w:(?:ins|del)\b[^>]*>\s*<w:tr\b/u.test(xml)).toBe(false);
-  });
+  ])(
+    "$name keeps every row after the table's properties and grid",
+    async ({ base, target, onUnverified }) => {
+      const xml = await comparedDocumentXml(base, target, { ...onUnverified });
+      const tables = tableChildNames(xml);
+      expect(tables.length).toBeGreaterThan(0);
+      for (const children of tables) {
+        expect(children.slice(0, 2)).toEqual(["w:tblPr", "w:tblGrid"]);
+        expect(children.slice(2).every((name) => name === "w:tr")).toBe(true);
+      }
+      // A tracked row is marked inside its own `w:trPr`, never by wrapping the
+      // row in a revision element.
+      expect(/<w:(?:ins|del)\b[^>]*>\s*<w:tr\b/u.test(xml)).toBe(false);
+    },
+  );
 });
 
 describe("hyperlink nesting", () => {

--- a/packages/core/src/compare/package-shape.test.ts
+++ b/packages/core/src/compare/package-shape.test.ts
@@ -1,0 +1,251 @@
+/**
+ * The shapes a compared package has to have, read off its own XML.
+ *
+ * The round-trip self-check reads content: which words a view resolves to,
+ * which cell they sit in. It cannot see a package that carries the right words
+ * in markup the format does not allow — a row before the table's grid, a
+ * hyperlink inside a revision, two revisions under one id — because parsing it
+ * back gives the same content either way. These assertions look at the markup
+ * instead.
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { buildBodySequenceDocx, type BodyItem } from "./__fixtures__/body-sequence";
+import { compareDocx } from "./compare";
+
+const OPTIONS = { author: "compare", timestamp: "2024-03-01T00:00:00.000Z" } as const;
+
+const comparedDocumentXml = async (
+  base: readonly BodyItem[],
+  target: readonly BodyItem[],
+): Promise<string> => {
+  const result = await compareDocx(
+    await buildBodySequenceDocx(base),
+    await buildBodySequenceDocx(target),
+    OPTIONS,
+  );
+  if (result.isErr()) {
+    throw result.error;
+  }
+  const zip = await JSZip.loadAsync(result.value.buffer);
+  return (await zip.file("word/document.xml")?.async("text")) ?? "";
+};
+
+const REVISION_ELEMENT =
+  /<w:(ins|del|moveFrom|moveTo|rPrChange|pPrChange|tblPrChange|trPrChange|tcPrChange|cellIns|cellDel|cellMerge)\b[^>]*\bw:id="(\d+)"/gu;
+
+const revisionIdsOf = (xml: string): string[] =>
+  [...xml.matchAll(REVISION_ELEMENT)].map(([, , id]) => id ?? "");
+
+const TAG = /<(\/?)([A-Za-z0-9_:.-]+)((?:"[^"]*"|'[^']*'|[^>"'])*?)(\/?)>/gu;
+
+/** The element names directly under each `w:tbl`, outermost tables first. */
+const tableChildNames = (xml: string): string[][] => {
+  const stack: { name: string; children: string[] }[] = [];
+  const tables: string[][] = [];
+  for (const match of xml.matchAll(TAG)) {
+    const [, closing, name = "", , selfClosing] = match;
+    if (closing) {
+      if (stack.at(-1)?.name === name) {
+        stack.pop();
+      }
+      continue;
+    }
+    if (stack.at(-1)?.name === "w:tbl") {
+      stack.at(-1)?.children.push(name);
+    }
+    if (selfClosing) {
+      continue;
+    }
+    const frame = { name, children: [] as string[] };
+    if (name === "w:tbl") {
+      tables.push(frame.children);
+    }
+    stack.push(frame);
+  }
+  return tables;
+};
+
+/** Ancestor element names of every `w:hyperlink`, innermost last. */
+const hyperlinkAncestors = (xml: string): string[][] => {
+  const stack: string[] = [];
+  const ancestors: string[][] = [];
+  for (const match of xml.matchAll(TAG)) {
+    const [, closing, name = "", , selfClosing] = match;
+    if (closing) {
+      if (stack.at(-1) === name) {
+        stack.pop();
+      }
+      continue;
+    }
+    if (name === "w:hyperlink") {
+      ancestors.push([...stack]);
+    }
+    if (!selfClosing) {
+      stack.push(name);
+    }
+  }
+  return ancestors;
+};
+
+const LINK = { text: "the guide", href: "https://example.invalid/guide" } as const;
+
+const TABLE: BodyItem = {
+  kind: "table",
+  rows: [
+    ["a1", "a2"],
+    ["b1", "b2"],
+    ["c1", "c2"],
+  ],
+};
+
+describe("revision ids", () => {
+  test("a word-level redline gives every emitted wrapper its own id", async () => {
+    // One `replaceInBlock` allocates one id for its deletions and one for its
+    // insertions, and the redline cuts each into several wrappers around the
+    // words that survived. Every wrapper still needs an id of its own.
+    const xml = await comparedDocumentXml(
+      [{ kind: "paragraph", text: "alpha beta gamma delta epsilon zeta" }],
+      [{ kind: "paragraph", text: "alpha BETA gamma delta EPSILON zeta" }],
+    );
+    const ids = revisionIdsOf(xml);
+    expect(ids.length).toBeGreaterThan(2);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("table placement", () => {
+  test.each([
+    {
+      name: "an added table",
+      base: [{ kind: "paragraph", text: "before" }] satisfies BodyItem[],
+      target: [{ kind: "paragraph", text: "before" }, TABLE] satisfies BodyItem[],
+    },
+    {
+      name: "a removed table",
+      base: [{ kind: "paragraph", text: "before" }, TABLE] satisfies BodyItem[],
+      target: [{ kind: "paragraph", text: "before" }] satisfies BodyItem[],
+    },
+    {
+      name: "a row added at the top",
+      base: [TABLE] satisfies BodyItem[],
+      target: [{ kind: "table", rows: [["new1", "new2"], ...TABLE.rows] }] satisfies BodyItem[],
+    },
+    {
+      name: "a row added in the middle",
+      base: [TABLE] satisfies BodyItem[],
+      target: [
+        {
+          kind: "table",
+          rows: [TABLE.rows[0] ?? [], ["new1", "new2"], ...TABLE.rows.slice(1)],
+        },
+      ] satisfies BodyItem[],
+    },
+    {
+      name: "a row added at the end",
+      base: [TABLE] satisfies BodyItem[],
+      target: [{ kind: "table", rows: [...TABLE.rows, ["new1", "new2"]] }] satisfies BodyItem[],
+    },
+    {
+      name: "a row removed from the middle",
+      base: [TABLE] satisfies BodyItem[],
+      target: [
+        { kind: "table", rows: [TABLE.rows[0] ?? [], TABLE.rows[2] ?? []] },
+      ] satisfies BodyItem[],
+    },
+    {
+      name: "the last row removed",
+      base: [TABLE] satisfies BodyItem[],
+      target: [{ kind: "table", rows: TABLE.rows.slice(0, 2) }] satisfies BodyItem[],
+    },
+  ])("$name keeps every row after the table's properties and grid", async ({ base, target }) => {
+    const xml = await comparedDocumentXml(base, target);
+    const tables = tableChildNames(xml);
+    expect(tables.length).toBeGreaterThan(0);
+    for (const children of tables) {
+      expect(children.slice(0, 2)).toEqual(["w:tblPr", "w:tblGrid"]);
+      expect(children.slice(2).every((name) => name === "w:tr")).toBe(true);
+    }
+    // A tracked row is marked inside its own `w:trPr`, never by wrapping the
+    // row in a revision element.
+    expect(/<w:(?:ins|del)\b[^>]*>\s*<w:tr\b/u.test(xml)).toBe(false);
+  });
+});
+
+describe("hyperlink nesting", () => {
+  const LINKED_PARAGRAPH = {
+    kind: "paragraph",
+    text: ["see ", LINK, " for details"],
+  } as const satisfies BodyItem;
+
+  test.each([
+    {
+      name: "a deleted hyperlink",
+      base: [{ kind: "paragraph", text: "keep" }, LINKED_PARAGRAPH] satisfies BodyItem[],
+      target: [{ kind: "paragraph", text: "keep" }] satisfies BodyItem[],
+    },
+    {
+      name: "an inserted hyperlink",
+      base: [{ kind: "paragraph", text: "keep" }] satisfies BodyItem[],
+      target: [{ kind: "paragraph", text: "keep" }, LINKED_PARAGRAPH] satisfies BodyItem[],
+    },
+    {
+      name: "text edited around a hyperlink",
+      base: [LINKED_PARAGRAPH] satisfies BodyItem[],
+      target: [{ kind: "paragraph", text: ["read ", LINK, " for more"] }] satisfies BodyItem[],
+    },
+  ])("$name keeps the revision inside the link", async ({ base, target }) => {
+    const xml = await comparedDocumentXml(base, target);
+    for (const ancestors of hyperlinkAncestors(xml)) {
+      expect(ancestors).not.toContain("w:ins");
+      expect(ancestors).not.toContain("w:del");
+      expect(ancestors).not.toContain("w:moveFrom");
+      expect(ancestors).not.toContain("w:moveTo");
+    }
+  });
+
+  test("a deleted hyperlink's runs carry deleted text", async () => {
+    const xml = await comparedDocumentXml(
+      [{ kind: "paragraph", text: "keep" }, LINKED_PARAGRAPH],
+      [{ kind: "paragraph", text: "keep" }],
+    );
+    expect(xml).toContain(`<w:hyperlink r:id="rId2"><w:del`);
+    expect(/<w:hyperlink[^>]*><w:del\b[^>]*>(?:(?!<\/w:del>).)*<w:delText/su.test(xml)).toBe(true);
+  });
+});
+
+describe("determinism", () => {
+  test("two runs over the same inputs produce byte-identical packages", async () => {
+    // `dcterms:modified` is the last clock the package holds: a save stamps it
+    // from the wall clock, which makes two otherwise identical runs differ in
+    // that part alone.
+    const base = await buildBodySequenceDocx([
+      { kind: "paragraph", text: "alpha beta gamma" },
+      TABLE,
+      { kind: "paragraph", text: ["see ", LINK, " for details"] },
+    ]);
+    const target = await buildBodySequenceDocx([
+      { kind: "paragraph", text: "alpha BETA gamma" },
+      TABLE,
+      { kind: "paragraph", text: ["read ", LINK, " for more"] },
+    ]);
+    const [first, second] = await Promise.all([
+      compareDocx(base, target, OPTIONS),
+      compareDocx(base, target, OPTIONS),
+    ]);
+    if (first.isErr()) {
+      throw first.error;
+    }
+    if (second.isErr()) {
+      throw second.error;
+    }
+    expect(new Uint8Array(second.value.buffer)).toEqual(new Uint8Array(first.value.buffer));
+
+    const zip = await JSZip.loadAsync(first.value.buffer);
+    expect(await zip.file("docProps/core.xml")?.async("text")).toContain(
+      `<dcterms:modified xsi:type="dcterms:W3CDTF">${OPTIONS.timestamp}</dcterms:modified>`,
+    );
+  });
+});

--- a/packages/core/src/compare/package-shape.test.ts
+++ b/packages/core/src/compare/package-shape.test.ts
@@ -90,6 +90,21 @@ const hyperlinkAncestors = (xml: string): string[][] => {
   return ancestors;
 };
 
+const PARAGRAPH_ID = /\b(?:w|w14|w15|w16cid):(?:paraId|paraIdParent|textId)="([0-9A-Fa-f]{8})"/gu;
+
+/** A paragraph id is `ST_LongHexNumber` with a maximum: the values are 31-bit. */
+const isParagraphIdInRange = (id: string): boolean => Number.parseInt(id, 16) < 0x8000_0000;
+
+const paragraphIdsOf = (xml: string): string[] =>
+  [...xml.matchAll(PARAGRAPH_ID)].map(([, id]) => id ?? "");
+
+/**
+ * Only the ids that identify a paragraph. `w14:textId` is a text-revision
+ * marker written beside one, not identity, and two paragraphs may share it.
+ */
+const paraIdsOf = (xml: string): string[] =>
+  [...xml.matchAll(/\bw(?:14)?:paraId="([0-9A-Fa-f]{8})"/gu)].map(([, id]) => id ?? "");
+
 const LINK = { text: "the guide", href: "https://example.invalid/guide" } as const;
 
 const TABLE: BodyItem = {
@@ -247,5 +262,41 @@ describe("determinism", () => {
     expect(await zip.file("docProps/core.xml")?.async("text")).toContain(
       `<dcterms:modified xsi:type="dcterms:W3CDTF">${OPTIONS.timestamp}</dcterms:modified>`,
     );
+  });
+});
+
+describe("paragraph ids", () => {
+  const OUT_OF_RANGE = ["FFAABBC1", "C0DEC0DE", "80000000"] as const;
+
+  test("brings an input's out-of-range ids into the 31-bit range", async () => {
+    // A producer can write eight hex digits without the type's maximum, and
+    // folio preserves the ids a document arrives with, so an untouched
+    // paragraph would carry the invalid id straight through.
+    const base: BodyItem[] = [
+      { kind: "paragraph", text: "untouched", paraId: OUT_OF_RANGE[0] },
+      { kind: "paragraph", text: "alpha beta gamma", paraId: OUT_OF_RANGE[1] },
+      { kind: "paragraph", text: "trailing", paraId: OUT_OF_RANGE[2] },
+    ];
+    const target: BodyItem[] = [
+      { kind: "paragraph", text: "untouched", paraId: OUT_OF_RANGE[0] },
+      { kind: "paragraph", text: "alpha BETA gamma", paraId: OUT_OF_RANGE[1] },
+      { kind: "paragraph", text: "trailing", paraId: OUT_OF_RANGE[2] },
+    ];
+
+    const xml = await comparedDocumentXml(base, target);
+
+    const ids = paragraphIdsOf(xml);
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids.every(isParagraphIdInRange)).toBe(true);
+    const paraIds = paraIdsOf(xml);
+    expect(new Set(paraIds).size).toBe(paraIds.length);
+  });
+
+  test("gives an out-of-range id the same replacement on every run", async () => {
+    const pair: [BodyItem[], BodyItem[]] = [
+      [{ kind: "paragraph", text: "alpha beta", paraId: OUT_OF_RANGE[1] }],
+      [{ kind: "paragraph", text: "alpha BETA", paraId: OUT_OF_RANGE[1] }],
+    ];
+    expect(await comparedDocumentXml(...pair)).toBe(await comparedDocumentXml(...pair));
   });
 });

--- a/packages/core/src/compare/reproducible-package.ts
+++ b/packages/core/src/compare/reproducible-package.ts
@@ -1,5 +1,5 @@
 /**
- * The last clock in the compare path is the ZIP container itself.
+ * The last two clocks in the compare path are outside the document body.
  *
  * Every part the serializer rewrites is stored with JSZip's default entry
  * date, which is `new Date()`. The XML is identical between two runs, but the
@@ -7,8 +7,12 @@
  * both runs land in the same two-second bucket — so the packages match most of
  * the time and differ occasionally, which is worse than differing always.
  *
- * Restamping every entry from the comparison's own timestamp removes it. It
- * also states the truth about the package: a generated redline is dated by the
+ * The save also stamps `dcterms:modified` in `docProps/core.xml` from the wall
+ * clock, which is the same failure one part deeper: two runs over identical
+ * inputs differ in that part alone.
+ *
+ * Restamping both from the comparison's own timestamp removes them. It also
+ * states the truth about the package: a generated redline is dated by the
  * comparison that produced it, not by the second it happened to be written.
  */
 
@@ -17,11 +21,33 @@ import JSZip from "jszip";
 /** JSZip deflate level `repackDocx` writes DOCX parts at. */
 const DOCX_COMPRESSION_LEVEL = 6;
 
+const CORE_PROPERTIES_PATH = "docProps/core.xml";
+
+const MODIFIED_ELEMENT = /<dcterms:modified[^<>]*>[^<]*<\/dcterms:modified>/u;
+
+/**
+ * Rewrite `dcterms:modified` where the save already wrote one. An absent
+ * element stays absent: the comparison edits the document it was handed, and
+ * synthesizing metadata the input never carried is a different decision.
+ */
+const withFixedModifiedDate = (corePropsXml: string, date: Date): string =>
+  corePropsXml.replace(
+    MODIFIED_ELEMENT,
+    `<dcterms:modified xsi:type="dcterms:W3CDTF">${date.toISOString()}</dcterms:modified>`,
+  );
+
 export const withFixedPackageDates = async (
   buffer: ArrayBuffer,
   date: Date,
 ): Promise<ArrayBuffer> => {
   const zip = await JSZip.loadAsync(buffer);
+  const coreProps = zip.file(CORE_PROPERTIES_PATH);
+  if (coreProps) {
+    zip.file(CORE_PROPERTIES_PATH, withFixedModifiedDate(await coreProps.async("text"), date), {
+      compression: "DEFLATE",
+      compressionOptions: { level: DOCX_COMPRESSION_LEVEL },
+    });
+  }
   zip.forEach((_path, file) => {
     file.date = date;
   });

--- a/packages/core/src/docx/commentReplyThreads.test.ts
+++ b/packages/core/src/docx/commentReplyThreads.test.ts
@@ -27,10 +27,10 @@ import {
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const BODY_PARA_ID = "B0000001";
-const PARENT_PARA_ID = "AAAA0001";
-const REPLY1_PARA_ID = "AAAA0002";
-const REPLY2_PARA_ID = "AAAA0003";
+const BODY_PARA_ID = "30000001";
+const PARENT_PARA_ID = "2AAA0001";
+const REPLY1_PARA_ID = "2AAA0002";
+const REPLY2_PARA_ID = "2AAA0003";
 
 const PARENT_ID = 1;
 const REPLY1_ID = 2;

--- a/packages/core/src/docx/hyperlinkParser.ts
+++ b/packages/core/src/docx/hyperlinkParser.ts
@@ -171,31 +171,43 @@ export function parseHyperlink(
   // VML `w:pict` inside a run resolves a non-canonical prefix scoped on the
   // `w:hyperlink` wrapper itself.
   const inScopeXmlns = mergeXmlnsDeclarations(rootXmlns, node);
-  const children = getChildElements(node);
-  for (const child of children) {
-    const localName = getLocalName(child.name);
-
-    switch (localName) {
-      case "r":
-        hyperlink.children.push(parseRun(child, styles, theme, rels, media, inScopeXmlns));
-        break;
-
-      case "bookmarkStart":
-        hyperlink.children.push(parseBookmarkStart(child));
-        break;
-
-      case "bookmarkEnd":
-        hyperlink.children.push(parseBookmarkEnd(child));
-        break;
-
-      // Note: hyperlinks can technically contain other elements like
-      // fldSimple, but these are rare. Add support as needed.
-      default:
-        break;
+  for (const child of getChildElements(node)) {
+    const parsed = parseHyperlinkChild(child, styles, theme, rels, media, inScopeXmlns);
+    if (parsed) {
+      hyperlink.children.push(parsed);
     }
   }
 
   return hyperlink;
+}
+
+/**
+ * One `w:hyperlink` child, or `null` for markup the model does not carry.
+ *
+ * Exposed so a caller that has to segment a hyperlink — one holding revision
+ * wrappers, which the model nests the other way round — parses its plain
+ * children exactly as {@link parseHyperlink} does.
+ */
+export function parseHyperlinkChild(
+  node: XmlElement,
+  styles: StyleMap | null,
+  theme: Theme | null,
+  rels: RelationshipMap | null,
+  media: Map<string, MediaFile> | null,
+  inScopeXmlns: Record<string, string>,
+): Hyperlink["children"][number] | null {
+  switch (getLocalName(node.name)) {
+    case "r":
+      return parseRun(node, styles, theme, rels, media, inScopeXmlns);
+    case "bookmarkStart":
+      return parseBookmarkStart(node);
+    case "bookmarkEnd":
+      return parseBookmarkEnd(node);
+    // Note: hyperlinks can technically contain other elements like
+    // fldSimple, but these are rare. Add support as needed.
+    default:
+      return null;
+  }
 }
 
 // ============================================================================

--- a/packages/core/src/docx/noteSave.test.ts
+++ b/packages/core/src/docx/noteSave.test.ts
@@ -29,7 +29,7 @@ const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 // followed by one normal note whose paragraph carries a paraId so the selective
 // patch can target it. `ORIGINAL_FOOTNOTE_TEXT` is the editable body text.
 const ORIGINAL_FOOTNOTE_TEXT = "Original footnote body";
-const FOOTNOTE_PARA_ID = "F1000001";
+const FOOTNOTE_PARA_ID = "71000001";
 const FOOTNOTE_SEPARATORS =
   '<w:footnote w:type="separator" w:id="-1"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:separator/></w:r></w:p></w:footnote>' +
   '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>';
@@ -41,7 +41,7 @@ const footnotesXml = `${XML_DECLARATION}
 <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${FOOTNOTE_SEPARATORS}<w:footnote w:id="1"><w:p w14:paraId="${FOOTNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r><w:r><w:t xml:space="preserve">${ORIGINAL_FOOTNOTE_TEXT}</w:t></w:r></w:p></w:footnote></w:footnotes>`;
 
 const ORIGINAL_ENDNOTE_TEXT = "Original endnote body";
-const ENDNOTE_PARA_ID = "E1000001";
+const ENDNOTE_PARA_ID = "61000001";
 const ENDNOTE_SEPARATORS =
   '<w:endnote w:type="separator" w:id="-1"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:separator/></w:r></w:p></w:endnote>' +
   '<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>';
@@ -49,7 +49,7 @@ const ENDNOTE_SEPARATORS =
 const endnotesXml = `${XML_DECLARATION}
 <w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">${ENDNOTE_SEPARATORS}<w:endnote w:id="1"><w:p w14:paraId="${ENDNOTE_PARA_ID}"><w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr><w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteRef/></w:r><w:r><w:t xml:space="preserve">${ORIGINAL_ENDNOTE_TEXT}</w:t></w:r></w:p></w:endnote></w:endnotes>`;
 
-const BODY_PARA_ID = "B0000001";
+const BODY_PARA_ID = "30000001";
 const documentXml = `${XML_DECLARATION}
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <w:body>
@@ -390,7 +390,7 @@ describe("footnote / endnote body write path (full repack)", () => {
     if (paragraph?.type !== "paragraph") {
       throw new Error("expected a footnote paragraph");
     }
-    const generatedParaId = "F2000001";
+    const generatedParaId = "72000001";
     paragraph.paraId = generatedParaId;
     const editedText = "Edited paraId-less footnote via raw repack";
     setFirstNoteText(footnote, editedText);
@@ -405,7 +405,7 @@ describe("footnote / endnote body write path (full repack)", () => {
   });
 
   test("raw repack ignores a dirty paragraph id removed by a note merge", async () => {
-    const removedParaId = "F1000002";
+    const removedParaId = "71000002";
     const twoParagraphFootnotesXml = footnotesXml.replace(
       "</w:p></w:footnote></w:footnotes>",
       `</w:p><w:p w14:paraId="${removedParaId}"><w:r><w:t>Second paragraph</w:t></w:r></w:p></w:footnote></w:footnotes>`,

--- a/packages/core/src/docx/numberingSave.test.ts
+++ b/packages/core/src/docx/numberingSave.test.ts
@@ -66,12 +66,12 @@ const numberingXml =
   `<w:num w:numId="2"><w:abstractNumId w:val="${UNTOUCHED_ABSTRACT_ID}"/></w:num>` +
   "</w:numbering>";
 
-const BODY_PARA_ID = "B0000001";
+const BODY_PARA_ID = "30000001";
 const documentXml = `${XML_DECLARATION}
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <w:body>
     <w:p w14:paraId="${BODY_PARA_ID}"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${EDITED_NUM_ID}"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">First item</w:t></w:r></w:p>
-    <w:p w14:paraId="B0000002"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">Bullet item</w:t></w:r></w:p>
+    <w:p w14:paraId="30000002"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">Bullet item</w:t></w:r></w:p>
     <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
   </w:body>
 </w:document>`;
@@ -350,7 +350,7 @@ describe("numbering-definition write path (full repack)", () => {
 const singleListDocumentXml = (numId: number) => `${XML_DECLARATION}
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <w:body>
-    <w:p w14:paraId="C0000001"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">Item</w:t></w:r></w:p>
+    <w:p w14:paraId="40000001"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/></w:numPr></w:pPr><w:r><w:t xml:space="preserve">Item</w:t></w:r></w:p>
     <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
   </w:body>
 </w:document>`;

--- a/packages/core/src/docx/paraIdRangeNormalization.test.ts
+++ b/packages/core/src/docx/paraIdRangeNormalization.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+
+import { normalizeParaIdRangeInXmlParts, paraIdInRange } from "./paraIdRangeNormalization";
+
+const PARA_ID = /\b(?:w|w14|w15|w16cid):(?:paraId|paraIdParent|textId)="([0-9A-Fa-f]{8})"/gu;
+
+const paraIdsOf = (xml: string): string[] => [...xml.matchAll(PARA_ID)].map(([, id]) => id ?? "");
+
+const inRange = (id: string): boolean => Number.parseInt(id, 16) < 0x8000_0000;
+
+test("leaves a package whose ids already fit byte-identical", () => {
+  const parts = new Map([
+    ["word/document.xml", `<w:p w14:paraId="12AB34CD" w14:textId="12AB34CD"/>`],
+  ]);
+  expect(normalizeParaIdRangeInXmlParts(parts)).toEqual(parts);
+});
+
+test("brings an out-of-range paragraph id inside the 31-bit range", () => {
+  const normalized = normalizeParaIdRangeInXmlParts(
+    new Map([["word/document.xml", `<w:p w14:paraId="FFAABBCC" w14:textId="FFAABBCC"/>`]]),
+  ).get("word/document.xml");
+
+  const ids = paraIdsOf(normalized ?? "");
+  expect(ids).toHaveLength(2);
+  expect(ids.every(inRange)).toBe(true);
+  // The text marker a paragraph carries beside its id stays equal to it.
+  expect(new Set(ids).size).toBe(1);
+});
+
+test("rewrites a paragraph and every reference to it the same way", () => {
+  const normalized = normalizeParaIdRangeInXmlParts(
+    new Map([
+      [
+        "word/comments.xml",
+        `<w:p w14:paraId="A0000001"/><w:p w14:paraId="FFFFFFF0"/><w:p w14:paraId="FFFFFFF1"/>`,
+      ],
+      [
+        "word/commentsExtended.xml",
+        `<w15:commentEx w15:paraId="FFFFFFF1" w15:paraIdParent="FFFFFFF0"/>`,
+      ],
+      ["word/commentsIds.xml", `<w16cid:commentId w16cid:paraId="FFFFFFF1"/>`],
+    ]),
+  );
+
+  const comments = paraIdsOf(normalized.get("word/comments.xml") ?? "");
+  const extended = paraIdsOf(normalized.get("word/commentsExtended.xml") ?? "");
+  const durable = paraIdsOf(normalized.get("word/commentsIds.xml") ?? "");
+  expect(comments.every(inRange)).toBe(true);
+  // The reply still points at the comment it pointed at, and at its parent.
+  expect(extended).toEqual([comments[2] ?? "", comments[1] ?? ""]);
+  expect(durable).toEqual([comments[2] ?? ""]);
+});
+
+test("maps one value to one id wherever it is read", () => {
+  expect(paraIdInRange("12AB34CD")).toBe("12AB34CD");
+  expect(inRange(paraIdInRange("FFFFFFF0"))).toBe(true);
+  expect(paraIdInRange("FFFFFFF0")).toBe(paraIdInRange("FFFFFFF0"));
+  expect(paraIdInRange("FFFFFFF0")).not.toBe(paraIdInRange("FFFFFFF1"));
+});
+
+test("is idempotent", () => {
+  const parts = new Map([
+    ["word/document.xml", `<w:p w14:paraId="FFFFFFF0"/><w:p w14:paraId="F0000000"/>`],
+  ]);
+  const once = normalizeParaIdRangeInXmlParts(parts);
+  expect(normalizeParaIdRangeInXmlParts(once)).toEqual(once);
+});

--- a/packages/core/src/docx/paraIdRangeNormalization.ts
+++ b/packages/core/src/docx/paraIdRangeNormalization.ts
@@ -1,0 +1,78 @@
+/**
+ * Keep every paragraph id a package carries inside the range the schema gives
+ * it.
+ *
+ * `w14:paraId`, `w14:textId` and the comment-part ids that reference a
+ * paragraph are `ST_LongHexNumber` with a maximum: the value has to be below
+ * `0x80000000`, so the ids are 31-bit. Producers exist that write eight hex
+ * digits without that bound, and folio preserves the ids a document arrives
+ * with — so a package can carry an out-of-range id in, and a save that copies
+ * it through hands a consumer a package it will refuse.
+ *
+ * {@link paraIdInRange} is the one mapping, and it is a pure function of the
+ * value alone. That is what lets the parser and the save agree without
+ * consulting each other: a paragraph's id in the model is the id the file gets,
+ * so bringing an id into range does not make a document's own identity move
+ * under it between reading and writing. The package pass below is the same
+ * mapping applied to every attribute that carries such an id, so a paragraph
+ * and every reference to it move together.
+ */
+
+import { deterministicHexId } from "../utils/hexId";
+
+/** Exclusive upper bound on a paragraph id: the values are 31-bit. */
+const MAX_PARA_ID_EXCLUSIVE = 0x8000_0000;
+
+/**
+ * Every attribute that carries a paragraph id or the text-revision marker
+ * written beside one: the paragraph's own `w14:paraId` / `w14:textId` (the
+ * parser accepts a `w:` prefix too), the comment part's `w15:paraId` and the
+ * `w15:paraIdParent` that links a reply to its thread, and the durable-comment
+ * part's `w16cid:paraId`.
+ */
+const PARA_ID_ATTRIBUTE =
+  /\b(w|w14|w15|w16cid):(paraId|paraIdParent|textId)=(?<quote>["'])([0-9A-Fa-f]{8})\k<quote>/gu;
+
+/** A candidate part is one that mentions any of those attributes at all. */
+const PARA_ID_CANDIDATE = /\b(?:w|w14|w15|w16cid):(?:paraId|paraIdParent|textId)=/u;
+
+/**
+ * `value` when it already fits, and a value derived from it when it does not.
+ *
+ * The replacement is derived from the id being replaced and from nothing else.
+ * A package-aware search for a free id would read better here and would be
+ * wrong: the parser has no package to search, and an id that means one
+ * paragraph while reading and another while writing is worse than the
+ * vanishing chance of two rewritten ids landing on one value, which is a
+ * duplicate rather than a package a consumer refuses.
+ */
+export const paraIdInRange = (value: string): string =>
+  Number.parseInt(value, 16) < MAX_PARA_ID_EXCLUSIVE ? value : deterministicHexId(value);
+
+/**
+ * Rewrite out-of-range paragraph ids across a whole package.
+ *
+ * Returns the parts unchanged when every id already fits, so a save of a
+ * document that never carried one is byte-identical.
+ */
+export const normalizeParaIdRangeInXmlParts = (
+  parts: ReadonlyMap<string, string>,
+): Map<string, string> => {
+  const normalized = new Map(parts);
+  for (const [path, xml] of parts) {
+    if (!PARA_ID_CANDIDATE.test(xml)) {
+      continue;
+    }
+    const rewritten = xml.replaceAll(
+      PARA_ID_ATTRIBUTE,
+      (whole: string, prefix: string, name: string, quote: string, value: string) => {
+        const replacement = paraIdInRange(value);
+        return replacement === value ? whole : `${prefix}:${name}=${quote}${replacement}${quote}`;
+      },
+    );
+    if (rewritten !== xml) {
+      normalized.set(path, rewritten);
+    }
+  }
+  return normalized;
+};

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -45,7 +45,7 @@ import {
   parseBookmarkEnd as parseBookmarkEndFromModule,
 } from "./bookmarkParser";
 import { parseFieldType } from "./fieldParser";
-import { parseHyperlink as parseHyperlinkFromModule } from "./hyperlinkParser";
+import { parseHyperlinkChild, parseHyperlink as parseHyperlinkFromModule } from "./hyperlinkParser";
 import { markerFormattingFromLevel } from "./numberingParser";
 import type { NumberingMap } from "./numberingParser";
 import {
@@ -1220,6 +1220,119 @@ function parseHyperlink(
   return parseHyperlinkFromModule(node, rels, styles, theme, media, rootXmlns);
 }
 
+/** The revision wrapper a `w:hyperlink` child is, when it is one. */
+const hyperlinkRevisionWrapperType = (node: XmlElement): TrackedChangeWrapperType | undefined => {
+  switch (getLocalName(node.name)) {
+    case "ins":
+      return "insertion";
+    case "del":
+      return "deletion";
+    case "moveFrom":
+      return "moveFrom";
+    case "moveTo":
+      return "moveTo";
+    default:
+      return undefined;
+  }
+};
+
+const isHyperlinkChildContent = (
+  content: ParagraphContent,
+): content is Hyperlink["children"][number] =>
+  content.type === "run" || content.type === "bookmarkStart" || content.type === "bookmarkEnd";
+
+/**
+ * A `w:hyperlink` as paragraph content, with any revision wrapper it holds
+ * hoisted around it.
+ *
+ * OOXML nests `w:ins`/`w:del` INSIDE `w:hyperlink`; the model nests the
+ * hyperlink inside the revision, because a revision is the unit a redline
+ * reads and a link that is half deleted is two links to it. This is the exact
+ * inverse of what the serializer writes, so a package survives the round trip.
+ */
+function parseHyperlinkParagraphContents(
+  node: XmlElement,
+  rels: RelationshipMap | null,
+  styles: StyleMap | null,
+  theme: Theme | null,
+  media: Map<string, MediaFile> | null,
+  rootXmlns: Record<string, string>,
+): ParagraphContent[] {
+  const children = getChildElements(node);
+  if (!children.some((child) => hyperlinkRevisionWrapperType(child) !== undefined)) {
+    return [parseHyperlink(node, rels, styles, theme, media, rootXmlns)];
+  }
+
+  const inScopeXmlns = mergeXmlnsDeclarations(rootXmlns, node);
+  const shell = parseHyperlink(node, rels, styles, theme, media, rootXmlns);
+  const linkOver = (linkChildren: readonly Hyperlink["children"][number][]): Hyperlink => ({
+    ...shell,
+    children: [...linkChildren],
+  });
+
+  const contents: ParagraphContent[] = [];
+  let plain: Hyperlink["children"][number][] = [];
+  const flushPlain = (): void => {
+    if (plain.length > 0) {
+      contents.push(linkOver(plain));
+      plain = [];
+    }
+  };
+
+  for (const child of children) {
+    const wrapperType = hyperlinkRevisionWrapperType(child);
+    if (wrapperType === undefined) {
+      const parsed = parseHyperlinkChild(child, styles, theme, rels, media, inScopeXmlns);
+      if (parsed) {
+        plain.push(parsed);
+      }
+      continue;
+    }
+    flushPlain();
+    const wrapped = parseParagraphContents(
+      child,
+      styles,
+      theme,
+      null,
+      rels,
+      media,
+      wrapperType === "deletion" || wrapperType === "moveFrom" ? "deletion" : "default",
+      inScopeXmlns,
+    );
+    // Group the runs the wrapper holds back under the link; anything else it
+    // carries stays where it sits rather than being dropped.
+    const content: TrackedRunChange["content"][number][] = [];
+    let linked: Hyperlink["children"][number][] = [];
+    const flushLinked = (): void => {
+      if (linked.length > 0) {
+        content.push(linkOver(linked));
+        linked = [];
+      }
+    };
+    for (const item of wrapped) {
+      if (isHyperlinkChildContent(item)) {
+        linked.push(item);
+        continue;
+      }
+      flushLinked();
+      if (isTrackedChangeWrapperChild(item)) {
+        content.push(item);
+      }
+    }
+    flushLinked();
+    pushTrackedChangeWrapper({
+      contents,
+      type: wrapperType,
+      info: parseTrackedChangeInfo(child),
+      content,
+      preserveEmpty: true,
+    });
+  }
+  flushPlain();
+
+  return contents;
+}
+
 /**
  * Parse bookmark start (w:bookmarkStart)
  * Delegates to bookmarkParser module.
@@ -1502,7 +1615,9 @@ function parseParagraphContents(
       }
 
       case "hyperlink":
-        contents.push(parseHyperlink(child, rels, styles, theme, media, inScopeXmlns));
+        contents.push(
+          ...parseHyperlinkParagraphContents(child, rels, styles, theme, media, inScopeXmlns),
+        );
         break;
 
       case "bookmarkStart":

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -40,6 +40,7 @@ import type {
 import { normalizeRevisionId, PARAGRAPH_MARK_CHANGE_KINDS } from "@stll/docx-core/model";
 import { panic } from "better-result";
 import { isValidHexId } from "../utils/hexId";
+import { paraIdInRange } from "./paraIdRangeNormalization";
 import {
   parseBookmarkStart as parseBookmarkStartFromModule,
   parseBookmarkEnd as parseBookmarkEndFromModule,
@@ -1892,14 +1893,16 @@ export function parseParagraph(
   // threading, XML serialization) must not trust it as one. Drop it rather
   // than store a malformed value — comment threading already re-derives a
   // fresh id when one is missing (see ensureThreadedCommentParaIds).
+  // An id above the type's maximum is brought into range here rather than at
+  // save, so the id this paragraph answers to is the id the file will carry.
   const paraId = getAttribute(node, "w14", "paraId") ?? getAttribute(node, "w", "paraId");
   if (paraId && isValidHexId(paraId)) {
-    paragraph.paraId = paraId;
+    paragraph.paraId = paraIdInRange(paraId);
   }
 
   const textId = getAttribute(node, "w14", "textId") ?? getAttribute(node, "w", "textId");
   if (textId && isValidHexId(textId)) {
-    paragraph.textId = textId;
+    paragraph.textId = paraIdInRange(textId);
   }
 
   if (!options?.inHeaderFooter && paragraphStartsWithRenderedPageBreak(node)) {

--- a/packages/core/src/docx/revisionIdNormalization.test.ts
+++ b/packages/core/src/docx/revisionIdNormalization.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test";
 
-import { normalizeRevisionIdsInXmlParts, REVISION_ELEMENT_NAMES } from "./revisionIdNormalization";
+import {
+  normalizeRevisionIdsInXmlParts,
+  RevisionIdCollisionError,
+  REVISION_ELEMENT_NAMES,
+} from "./revisionIdNormalization";
 
 const W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
@@ -49,4 +53,23 @@ test("respects Strict namespaces and nested prefix rebinding", () => {
   expect(normalized.get("word/document.xml")).toBe(
     xml.replace('<w:del w:id="8"/></w:document>', '<w:del w:id="0"/></w:document>'),
   );
+});
+
+// Every id the pass lets stand or mints goes through one choke point, which
+// throws rather than emit a package where two revisions answer to one `w:id`.
+test("claims every id once when every part repeats the same one", () => {
+  const parts = new Map(
+    ["word/document.xml", "word/header1.xml", "word/footnotes.xml"].map((path) => [
+      path,
+      `<w:root xmlns:w="${W}"><w:del w:id="3"/><w:ins w:id="3"/><w:rPrChange w:id="3"/></w:root>`,
+    ]),
+  );
+
+  expect(() => normalizeRevisionIdsInXmlParts(parts)).not.toThrow(RevisionIdCollisionError);
+
+  const ids = [...normalizeRevisionIdsInXmlParts(parts).values()].flatMap((xml) =>
+    [...xml.matchAll(/w:id="(\d+)"/gu)].map((match) => match[1]),
+  );
+  expect(ids).toHaveLength(9);
+  expect(new Set(ids).size).toBe(ids.length);
 });

--- a/packages/core/src/docx/revisionIdNormalization.ts
+++ b/packages/core/src/docx/revisionIdNormalization.ts
@@ -1,3 +1,5 @@
+import { TaggedError } from "better-result";
+
 import {
   findAttributeByNamespaceUri,
   getLocalName,
@@ -7,6 +9,20 @@ import {
 } from "./xmlParser";
 import { rewriteStreamingXmlDecimalAttributes } from "./streamingXmlParser";
 import { assertXmlResourceLimits, XmlResourceLimitError } from "./xmlResourceLimits";
+
+/**
+ * Two revision elements in one package claimed the same `w:id`.
+ *
+ * `w:id` on a revision element is unique across the package, so a collision is
+ * a package a consumer may reject rather than a cosmetic detail. The
+ * normalization below hands every id it emits to one choke point, which throws
+ * this rather than letting the duplicate reach the ZIP.
+ */
+export class RevisionIdCollisionError extends TaggedError("RevisionIdCollisionError")<{
+  message: string;
+  revisionId: number;
+  part: string;
+}> {}
 
 export const REVISION_ELEMENT_NAMES = new Set([
   "cellDel",
@@ -114,9 +130,22 @@ export const normalizeRevisionIdsInXmlParts = (
     if (!ids) {
       continue;
     }
+    // Every id this pass lets stand or mints goes through `claim`, so a shape
+    // the branches below did not anticipate surfaces as a typed error instead
+    // of a package carrying two revisions under one id.
+    const claim = (id: number): void => {
+      if (seen.has(id)) {
+        throw new RevisionIdCollisionError({
+          message: `Revision id ${String(id)} is claimed twice in ${path}`,
+          revisionId: id,
+          part: path,
+        });
+      }
+      seen.add(id);
+    };
     if (!repeatedPaths.has(path) && ids.every((id) => !seen.has(id))) {
       for (const id of ids) {
-        seen.add(id);
+        claim(id);
       }
       continue;
     }
@@ -126,11 +155,11 @@ export const normalizeRevisionIdsInXmlParts = (
         return null;
       }
       if (!seen.has(attribute.id)) {
-        seen.add(attribute.id);
+        claim(attribute.id);
         return null;
       }
       const replacement = allocate();
-      seen.add(replacement);
+      claim(replacement);
       return new Map([[attribute.name, String(replacement)]]);
     });
     if (rewritten.status === "unsupported") {

--- a/packages/core/src/docx/revisionIdNormalization.ts
+++ b/packages/core/src/docx/revisionIdNormalization.ts
@@ -48,14 +48,6 @@ const REVISION_ELEMENT_CANDIDATE = new RegExp(
   "u",
 );
 
-/**
- * Whether an XML part could hold a revision element at all. A save that wrote
- * none cannot have created a collision, so this is what lets an exit skip the
- * pass instead of reading every part of the package to prove nothing changed.
- */
-export const containsRevisionElement = (xml: string): boolean =>
-  REVISION_ELEMENT_CANDIDATE.test(xml);
-
 type RevisionAttribute = { name: string; id: number };
 
 const revisionAttribute = (element: XmlElement): RevisionAttribute | null => {

--- a/packages/core/src/docx/revisionIdNormalization.ts
+++ b/packages/core/src/docx/revisionIdNormalization.ts
@@ -48,6 +48,14 @@ const REVISION_ELEMENT_CANDIDATE = new RegExp(
   "u",
 );
 
+/**
+ * Whether an XML part could hold a revision element at all. A save that wrote
+ * none cannot have created a collision, so this is what lets an exit skip the
+ * pass instead of reading every part of the package to prove nothing changed.
+ */
+export const containsRevisionElement = (xml: string): boolean =>
+  REVISION_ELEMENT_CANDIDATE.test(xml);
+
 type RevisionAttribute = { name: string; id: number };
 
 const revisionAttribute = (element: XmlElement): RevisionAttribute | null => {

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -257,7 +257,7 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
     `${XML_DECLARATION}
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <w:body>
-    <w:p w14:paraId="AAA00001">
+    <w:p w14:paraId="2AA00001">
       <w:r><w:t>First section text</w:t></w:r>
       <w:pPr>
         <w:sectPr>
@@ -266,7 +266,7 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
         </w:sectPr>
       </w:pPr>
     </w:p>
-    <w:p w14:paraId="BBB00001"><w:r><w:t>Second section text</w:t></w:r></w:p>
+    <w:p w14:paraId="3BB00001"><w:r><w:t>Second section text</w:t></w:r></w:p>
     <w:sectPr>
       <w:headerReference w:type="default" r:id="rId12"/>
     </w:sectPr>

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -97,7 +97,8 @@ import {
   WORDPROCESSINGML_NAMESPACE_URIS,
   type XmlElement,
 } from "./xmlParser";
-import { containsRevisionElement, normalizeRevisionIdsInXmlParts } from "./revisionIdNormalization";
+import { normalizeParaIdRangeInXmlParts } from "./paraIdRangeNormalization";
+import { normalizeRevisionIdsInXmlParts } from "./revisionIdNormalization";
 import { assertXmlResourceLimits } from "./xmlResourceLimits";
 import { isAllowedExternalWatermarkImageUrl } from "../watermark";
 
@@ -773,23 +774,26 @@ export type RepackOptions = {
 };
 
 /**
- * Give every revision element in the package its own `w:id`.
+ * Bring the ids a package addresses itself by inside the bounds the format
+ * gives them.
  *
- * One logical revision can serialize as several physical wrappers — a word
- * diff cut around unchanged words, a revision split around a hyperlink — and
- * `w:id` is unique across the package, not within a part. The pass therefore
- * has to see every `word/*.xml` part, including the ones the save left
- * untouched, so it runs at the exits rather than at the serializers.
+ * Both bounds belong to the package rather than to a part, and neither is
+ * something one serializer can see on its own. A revision `w:id` is unique
+ * across the package, and one logical revision serializes as several physical
+ * wrappers — a word diff cut around unchanged words, a revision split around a
+ * hyperlink. A paragraph id is 31-bit, and a paragraph is referenced by id
+ * from parts other than the one it lives in. So the passes run at the exits,
+ * over every `word/*.xml` part including the ones a save left untouched.
  */
-const normalizeRevisionIdsInZip = async (zip: JSZip, compressionLevel: number): Promise<void> => {
+const normalizePackageIdsInZip = async (zip: JSZip, compressionLevel: number): Promise<void> => {
   const xmlParts = new Map<string, string>();
   for (const [path, file] of Object.entries(zip.files)) {
     if (!file.dir && path.startsWith("word/") && path.endsWith(".xml")) {
-      // oxlint-disable-next-line no-await-in-loop -- package parts share one revision-id namespace and must be collected before rewriting
+      // oxlint-disable-next-line no-await-in-loop -- package parts share one id space and must be collected before rewriting
       xmlParts.set(path, await file.async("text"));
     }
   }
-  const normalizedParts = normalizeRevisionIdsInXmlParts(xmlParts);
+  const normalizedParts = normalizeParaIdRangeInXmlParts(normalizeRevisionIdsInXmlParts(xmlParts));
   for (const [path, xml] of normalizedParts) {
     if (xml !== xmlParts.get(path)) {
       zip.file(path, xml, {
@@ -807,7 +811,7 @@ const normalizeRevisionIdsInZip = async (zip: JSZip, compressionLevel: number): 
  */
 const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> => {
   await reconcilePackageReferences(zip, compressionLevel);
-  await normalizeRevisionIdsInZip(zip, compressionLevel);
+  await normalizePackageIdsInZip(zip, compressionLevel);
   return zip.generateAsync({
     type: "arraybuffer",
     compression: "DEFLATE",
@@ -1410,12 +1414,11 @@ export async function updateMultipleFiles(
  * Apply file updates to an already-loaded JSZip instance and generate the output.
  * Use this when the zip is already loaded to avoid a redundant decompression pass.
  *
- * This is the selective save's exit, so it owes the package the same revision-id
- * pass {@link generateDocxZip} runs: a save that rewrites only the changed
- * paragraphs still has to see the parts it left alone before it can say an id
- * is free. It runs only when an update carries a revision element, so a save
- * that wrote none keeps the whole point of the selective path — reading no part
- * it did not have to.
+ * This is the selective save's exit, so it owes the package the same id passes
+ * {@link generateDocxZip} runs: a save that rewrites only the changed
+ * paragraphs still has to see the parts it left alone, both to know which
+ * revision ids are free and because an out-of-range paragraph id can sit in a
+ * part it never touched.
  */
 export async function applyUpdatesToZip(
   zip: JSZip,
@@ -1424,18 +1427,14 @@ export async function applyUpdatesToZip(
 ): Promise<ArrayBuffer> {
   const { compressionLevel = 6 } = options;
 
-  let wroteRevisions = false;
   for (const [path, content] of updates) {
     zip.file(path, content, {
       compression: "DEFLATE",
       compressionOptions: { level: compressionLevel },
     });
-    wroteRevisions ||= typeof content === "string" && containsRevisionElement(content);
   }
 
-  if (wroteRevisions) {
-    await normalizeRevisionIdsInZip(zip, compressionLevel);
-  }
+  await normalizePackageIdsInZip(zip, compressionLevel);
 
   return await zip.generateAsync({
     type: "arraybuffer",

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -773,12 +773,15 @@ export type RepackOptions = {
 };
 
 /**
- * The single exit for a repacked package. Reconciliation runs here rather than
- * at each caller so no save path can emit a package whose relationships or
- * content types name a part it does not hold.
+ * Give every revision element in the package its own `w:id`.
+ *
+ * One logical revision can serialize as several physical wrappers — a word
+ * diff cut around unchanged words, a revision split around a hyperlink — and
+ * `w:id` is unique across the package, not within a part. The pass therefore
+ * has to see every `word/*.xml` part, including the ones the save left
+ * untouched, so it runs at the exits rather than at the serializers.
  */
-const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> => {
-  await reconcilePackageReferences(zip, compressionLevel);
+const normalizeRevisionIdsInZip = async (zip: JSZip, compressionLevel: number): Promise<void> => {
   const xmlParts = new Map<string, string>();
   for (const [path, file] of Object.entries(zip.files)) {
     if (!file.dir && path.startsWith("word/") && path.endsWith(".xml")) {
@@ -795,6 +798,16 @@ const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<Ar
       });
     }
   }
+};
+
+/**
+ * The single exit for a repacked package. Reconciliation runs here rather than
+ * at each caller so no save path can emit a package whose relationships or
+ * content types name a part it does not hold.
+ */
+const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> => {
+  await reconcilePackageReferences(zip, compressionLevel);
+  await normalizeRevisionIdsInZip(zip, compressionLevel);
   return zip.generateAsync({
     type: "arraybuffer",
     compression: "DEFLATE",
@@ -1396,8 +1409,13 @@ export async function updateMultipleFiles(
 /**
  * Apply file updates to an already-loaded JSZip instance and generate the output.
  * Use this when the zip is already loaded to avoid a redundant decompression pass.
+ *
+ * This is the selective save's exit, so it owes the package the same revision-id
+ * pass {@link generateDocxZip} runs: a save that rewrites only the changed
+ * paragraphs still has to see the parts it left alone before it can say an id
+ * is free.
  */
-export function applyUpdatesToZip(
+export async function applyUpdatesToZip(
   zip: JSZip,
   updates: Map<string, string | ArrayBuffer>,
   options: RepackOptions = {},
@@ -1411,7 +1429,9 @@ export function applyUpdatesToZip(
     });
   }
 
-  return zip.generateAsync({
+  await normalizeRevisionIdsInZip(zip, compressionLevel);
+
+  return await zip.generateAsync({
     type: "arraybuffer",
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -97,7 +97,7 @@ import {
   WORDPROCESSINGML_NAMESPACE_URIS,
   type XmlElement,
 } from "./xmlParser";
-import { normalizeRevisionIdsInXmlParts } from "./revisionIdNormalization";
+import { containsRevisionElement, normalizeRevisionIdsInXmlParts } from "./revisionIdNormalization";
 import { assertXmlResourceLimits } from "./xmlResourceLimits";
 import { isAllowedExternalWatermarkImageUrl } from "../watermark";
 
@@ -1413,7 +1413,9 @@ export async function updateMultipleFiles(
  * This is the selective save's exit, so it owes the package the same revision-id
  * pass {@link generateDocxZip} runs: a save that rewrites only the changed
  * paragraphs still has to see the parts it left alone before it can say an id
- * is free.
+ * is free. It runs only when an update carries a revision element, so a save
+ * that wrote none keeps the whole point of the selective path — reading no part
+ * it did not have to.
  */
 export async function applyUpdatesToZip(
   zip: JSZip,
@@ -1422,14 +1424,18 @@ export async function applyUpdatesToZip(
 ): Promise<ArrayBuffer> {
   const { compressionLevel = 6 } = options;
 
+  let wroteRevisions = false;
   for (const [path, content] of updates) {
     zip.file(path, content, {
       compression: "DEFLATE",
       compressionOptions: { level: compressionLevel },
     });
+    wroteRevisions ||= typeof content === "string" && containsRevisionElement(content);
   }
 
-  await normalizeRevisionIdsInZip(zip, compressionLevel);
+  if (wroteRevisions) {
+    await normalizeRevisionIdsInZip(zip, compressionLevel);
+  }
 
   return await zip.generateAsync({
     type: "arraybuffer",

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -446,3 +446,52 @@ describe("serializeParagraph native frame geometry", () => {
     );
   });
 });
+
+describe("serializeParagraph revision nesting around a hyperlink", () => {
+  const NAMESPACES =
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"';
+
+  const parseBody = (inner: string): Paragraph => {
+    const element = parseXmlDocument(`<w:p ${NAMESPACES}>${inner}</w:p>`);
+    if (!element) {
+      throw new Error("failed to parse the hyperlink revision fixture");
+    }
+    return parseParagraph(element, null, null, null, null, null);
+  };
+
+  // `w:del` at run level takes run-level content, and `w:hyperlink` is not in
+  // that set: the legal nesting is the link around the revision. The model
+  // nests the other way, because a revision is the unit a redline reads, so
+  // parsing and serializing have to be inverses of one another.
+  test.each(["del", "ins"] as const)(
+    "wraps the link around a w:%s rather than the other way round",
+    (tag) => {
+      const text = tag === "del" ? "<w:delText>linked</w:delText>" : "<w:t>linked</w:t>";
+      const paragraph = parseBody(
+        `<w:hyperlink r:id="rId7"><w:${tag} w:id="3" w:author="Reviewer">` +
+          `<w:r>${text}</w:r></w:${tag}></w:hyperlink>`,
+      );
+
+      const xml = serializeParagraph(paragraph);
+
+      expect(xml).toContain(`<w:hyperlink r:id="rId7"><w:${tag} w:id="3"`);
+      expect(new RegExp(`<w:${tag}\\b[^>]*><w:hyperlink`, "u").test(xml)).toBe(false);
+    },
+  );
+
+  test("splits one revision into a wrapper per link boundary", () => {
+    const paragraph = parseBody(
+      `<w:del w:id="9" w:author="Reviewer"><w:r><w:delText>before </w:delText></w:r></w:del>` +
+        `<w:hyperlink r:id="rId7"><w:del w:id="9" w:author="Reviewer">` +
+        `<w:r><w:delText>linked</w:delText></w:r></w:del></w:hyperlink>` +
+        `<w:del w:id="9" w:author="Reviewer"><w:r><w:delText> after</w:delText></w:r></w:del>`,
+    );
+
+    const xml = serializeParagraph(paragraph);
+
+    expect(xml.match(/<w:del\b/gu)).toHaveLength(3);
+    expect(xml.match(/<w:hyperlink\b/gu)).toHaveLength(1);
+    expect(xml).not.toContain("<w:t>");
+  });
+});

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -573,10 +573,8 @@ function serializeParagraphPropertyChange(change: ParagraphPropertyChange): stri
 // CONTENT SERIALIZATION
 // ============================================================================
 
-/**
- * Serialize a hyperlink (w:hyperlink)
- */
-function serializeHyperlink(hyperlink: Hyperlink): string {
+/** The attribute list of a `w:hyperlink`, without its children. */
+function hyperlinkAttributes(hyperlink: Hyperlink): string {
   const attrs: string[] = [];
 
   if (hyperlink.rId) {
@@ -608,21 +606,30 @@ function serializeHyperlink(hyperlink: Hyperlink): string {
     attrs.push(`w:docLocation="${escapeXml(hyperlink.docLocation)}"`);
   }
 
-  // Serialize children
-  const childrenXml = hyperlink.children
-    .map((child) => {
-      if (child.type === "run") {
-        return serializeRun(child);
-      }
-      if (child.type === "bookmarkStart") {
-        return serializeBookmarkStart(child);
-      }
-      return serializeBookmarkEnd(child);
-    })
-    .join("");
+  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+}
 
-  const attrsStr = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
-  return `<w:hyperlink${attrsStr}>${childrenXml}</w:hyperlink>`;
+/** One `w:hyperlink` child, with the caller deciding how a run is written. */
+function serializeHyperlinkChild(
+  child: Hyperlink["children"][number],
+  serializeChildRun: (run: Run) => string,
+): string {
+  if (child.type === "run") {
+    return serializeChildRun(child);
+  }
+  return child.type === "bookmarkStart"
+    ? serializeBookmarkStart(child)
+    : serializeBookmarkEnd(child);
+}
+
+/**
+ * Serialize a hyperlink (w:hyperlink)
+ */
+function serializeHyperlink(hyperlink: Hyperlink): string {
+  const childrenXml = hyperlink.children
+    .map((child) => serializeHyperlinkChild(child, serializeRun))
+    .join("");
+  return `<w:hyperlink${hyperlinkAttributes(hyperlink)}>${childrenXml}</w:hyperlink>`;
 }
 
 /**
@@ -976,42 +983,78 @@ function serializeTrackedChange(
       .join("");
   };
 
-  const contentXml = change.content
-    .map((item) => {
-      if (item.type === "run") {
-        // A deleted drawing/shape run keeps its content verbatim: a picture
-        // has no `<w:t>`, and a shape's nested textbox text
-        // (`<w:txbxContent><w:t>`) must NOT be rewritten to `<w:delText>` —
-        // that markup belongs only to a run's own deleted text, not to a
-        // nested textbox document. eigenpal #641.
-        if (tag === "del" || tag === "moveFrom") {
-          return serializeDeletedRun(item);
-        }
-        return serializeRun(item);
-      }
-      if (item.type === "hyperlink") {
-        return serializeHyperlink(item);
-      }
-      if (item.type === "simpleField" || item.type === "complexField") {
-        const xml =
-          item.type === "simpleField" ? serializeSimpleField(item) : serializeComplexField(item);
-        return tag === "del" || tag === "moveFrom" ? rewriteRunTextAsDeleted(xml) : xml;
-      }
-      if (
-        item.type === "insertion" ||
-        item.type === "deletion" ||
-        item.type === "moveFrom" ||
-        item.type === "moveTo"
-      ) {
-        return serializeTrackedChange(trackedChangeTag(item), item);
-      }
-      return item.type === "bookmarkStart"
-        ? serializeBookmarkStart(item)
-        : serializeBookmarkEnd(item);
-    })
-    .join("");
+  const serializeContentRun = (run: Run): string =>
+    // A deleted drawing/shape run keeps its content verbatim: a picture
+    // has no `<w:t>`, and a shape's nested textbox text
+    // (`<w:txbxContent><w:t>`) must NOT be rewritten to `<w:delText>` —
+    // that markup belongs only to a run's own deleted text, not to a
+    // nested textbox document. eigenpal #641.
+    tag === "del" || tag === "moveFrom" ? serializeDeletedRun(run) : serializeRun(run);
 
-  return `<w:${tag} ${attrs.join(" ")}>${contentXml}</w:${tag}>`;
+  const serializeWrappedItem = (item: (typeof change.content)[number]): string => {
+    if (item.type === "run") {
+      return serializeContentRun(item);
+    }
+    if (item.type === "simpleField" || item.type === "complexField") {
+      const xml =
+        item.type === "simpleField" ? serializeSimpleField(item) : serializeComplexField(item);
+      return tag === "del" || tag === "moveFrom" ? rewriteRunTextAsDeleted(xml) : xml;
+    }
+    if (
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
+      return serializeTrackedChange(trackedChangeTag(item), item);
+    }
+    return item.type === "bookmarkStart"
+      ? serializeBookmarkStart(item)
+      : serializeBookmarkEnd(item);
+  };
+
+  const open = `<w:${tag} ${attrs.join(" ")}>`;
+  const close = `</w:${tag}>`;
+  const wrap = (inner: string): string => (inner.length === 0 ? "" : `${open}${inner}${close}`);
+
+  // An empty wrapper is a marker in its own right (a paragraph mark's
+  // revision, a move end), so it survives the segmentation below.
+  if (change.content.length === 0) {
+    return `${open}${close}`;
+  }
+
+  // `w:hyperlink` may not appear inside a revision wrapper; the nesting runs
+  // the other way, with the wrapper opened again around the linked runs. So a
+  // revision spanning a hyperlink is emitted as several wrappers — text
+  // before, the hyperlink carrying its own, text after — which the package's
+  // revision-id pass then gives distinct `w:id`s.
+  const segments: string[] = [];
+  const pending: string[] = [];
+  const flushPending = (): void => {
+    if (pending.length > 0) {
+      segments.push(wrap(pending.join("")));
+      pending.length = 0;
+    }
+  };
+  for (const item of change.content) {
+    if (item.type === "hyperlink") {
+      flushPending();
+      const childrenXml = item.children
+        .map((child) => serializeHyperlinkChild(child, serializeContentRun))
+        .join("");
+      // Always the full wrapper, never `wrap`: a linked run range that is
+      // empty still has to say it was inserted or deleted, or reopening the
+      // package finds a plain hyperlink.
+      segments.push(
+        `<w:hyperlink${hyperlinkAttributes(item)}>${open}${childrenXml}${close}</w:hyperlink>`,
+      );
+      continue;
+    }
+    pending.push(serializeWrappedItem(item));
+  }
+  flushPending();
+
+  return segments.join("");
 }
 
 /** Emit the `<w:commentReference>` run Word places after a comment range end. */

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -991,7 +991,12 @@ function serializeTrackedChange(
     // nested textbox document. eigenpal #641.
     tag === "del" || tag === "moveFrom" ? serializeDeletedRun(run) : serializeRun(run);
 
-  const serializeWrappedItem = (item: (typeof change.content)[number]): string => {
+  // A hyperlink is not written inside the wrapper at all, so it is not one of
+  // the items this writes: the loop below opens the wrapper inside the link
+  // instead.
+  type WrappedItem = Exclude<(typeof change.content)[number], Hyperlink>;
+
+  const serializeWrappedItem = (item: WrappedItem): string => {
     if (item.type === "run") {
       return serializeContentRun(item);
     }

--- a/packages/core/src/docx/serializer/tableSerializer.test.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Table } from "../../types/document";
+import { serializeTable } from "./tableSerializer";
+
+const serializeParagraph = (): string => "<w:p/>";
+
+const cell = (gridSpan?: number) =>
+  ({
+    type: "tableCell",
+    ...(gridSpan === undefined ? {} : { formatting: { gridSpan } }),
+    content: [{ type: "paragraph", content: [] }],
+  }) as const satisfies Table["rows"][number]["cells"][number];
+
+// `w:tbl` is `w:tblPr, w:tblGrid, (rows)*`: both are required and both precede
+// every row. A table the model carries no properties or measured widths for —
+// the shape a tracked table insertion produces — used to open with its first
+// `w:tr`, which the content model has no place for.
+describe("serializeTable required children", () => {
+  test("opens with the properties and grid even when the model carries neither", () => {
+    const table: Table = {
+      type: "table",
+      rows: [
+        { type: "tableRow", cells: [cell(), cell()] },
+        { type: "tableRow", cells: [cell(), cell()] },
+      ],
+    };
+
+    const xml = serializeTable(table, serializeParagraph);
+
+    expect(xml.startsWith("<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/><w:gridCol/></w:tblGrid>")).toBe(
+      true,
+    );
+  });
+
+  test("declares a grid column for every column the widest row spans", () => {
+    const table: Table = {
+      type: "table",
+      rows: [
+        { type: "tableRow", cells: [cell(3)] },
+        { type: "tableRow", cells: [cell(), cell(), cell()] },
+      ],
+    };
+
+    const xml = serializeTable(table, serializeParagraph);
+
+    expect(xml.match(/<w:gridCol\b/gu)).toHaveLength(3);
+  });
+
+  test("keeps authored column widths when the model has them", () => {
+    const table: Table = {
+      type: "table",
+      columnWidths: [2000, 3000],
+      rows: [{ type: "tableRow", cells: [cell(), cell()] }],
+    };
+
+    const xml = serializeTable(table, serializeParagraph);
+
+    expect(xml).toContain('<w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="3000"/></w:tblGrid>');
+  });
+});

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -755,16 +755,37 @@ function serializeTableCellPropertyChange(change: TableCellPropertyChange): stri
 // ============================================================================
 
 /**
- * Serialize table grid (w:tblGrid)
+ * Columns the grid has to declare: the widest row's span total, because a grid
+ * narrower than a row leaves cells with no column to sit in.
  */
-function serializeTableGrid(columnWidths: number[] | undefined): string {
-  if (!columnWidths || columnWidths.length === 0) {
-    return "";
+function gridColumnCount(table: Table): number {
+  return table.rows.reduce(
+    (widest, row) =>
+      Math.max(
+        widest,
+        row.cells.reduce((count, cell) => count + (cell.formatting?.gridSpan ?? 1), 0),
+      ),
+    0,
+  );
+}
+
+/**
+ * Serialize table grid (w:tblGrid).
+ *
+ * `w:tblGrid` is required on every `w:tbl` and `w:w` is optional on a
+ * `w:gridCol`, so a table whose column widths were never measured — one the
+ * comparison creates, say — still declares a grid, just without widths.
+ */
+function serializeTableGrid(table: Table): string {
+  const columnWidths = table.columnWidths;
+  if (columnWidths && columnWidths.length > 0) {
+    return `<w:tblGrid>${columnWidths.map((w) => `<w:gridCol w:w="${intAttr(w)}"/>`).join("")}</w:tblGrid>`;
   }
 
-  const cols = columnWidths.map((w) => `<w:gridCol w:w="${intAttr(w)}"/>`);
-
-  return `<w:tblGrid>${cols.join("")}</w:tblGrid>`;
+  const columns = gridColumnCount(table);
+  return columns === 0
+    ? "<w:tblGrid/>"
+    : `<w:tblGrid>${"<w:gridCol/>".repeat(columns)}</w:tblGrid>`;
 }
 
 // ============================================================================
@@ -864,21 +885,15 @@ export function serializeTableRow(row: TableRow, serializeParagraph: ParagraphSe
  * @returns XML string for the table
  */
 export function serializeTable(table: Table, serializeParagraph: ParagraphSerializer): string {
-  const parts: string[] = [];
+  // `w:tbl` is `w:tblPr, w:tblGrid, (rows)*`: both properties and grid are
+  // required and precede every row. Emitting them only when the model carried
+  // something to put in them made a table with neither — the shape a tracked
+  // table insertion produces — open with a `w:tr` the content model has no
+  // place for. Empty elements are the valid way to say "nothing here".
+  const tblPrXml =
+    serializeTableFormatting(table.formatting, table.propertyChanges) || "<w:tblPr/>";
+  const parts: string[] = [tblPrXml, serializeTableGrid(table)];
 
-  // Table properties
-  const tblPrXml = serializeTableFormatting(table.formatting, table.propertyChanges);
-  if (tblPrXml) {
-    parts.push(tblPrXml);
-  }
-
-  // Table grid
-  const tblGridXml = serializeTableGrid(table.columnWidths);
-  if (tblGridXml) {
-    parts.push(tblGridXml);
-  }
-
-  // Rows
   for (const row of table.rows) {
     parts.push(serializeTableRow(row, serializeParagraph));
   }

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -759,14 +759,15 @@ function serializeTableCellPropertyChange(change: TableCellPropertyChange): stri
  * narrower than a row leaves cells with no column to sit in.
  */
 function gridColumnCount(table: Table): number {
-  return table.rows.reduce(
-    (widest, row) =>
-      Math.max(
-        widest,
-        row.cells.reduce((count, cell) => count + (cell.formatting?.gridSpan ?? 1), 0),
-      ),
-    0,
-  );
+  let widest = 0;
+  for (const row of table.rows) {
+    let columns = 0;
+    for (const cell of row.cells) {
+      columns += cell.formatting?.gridSpan ?? 1;
+    }
+    widest = Math.max(widest, columns);
+  }
+  return widest;
 }
 
 /**

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -151,11 +151,11 @@ const buildStoryDocument = async ({
   footnoteText,
   endnoteText,
 }: StoryDocumentOptions): Promise<ArrayBuffer> => {
-  const source = await buildDocxBuffer([{ text: bodyText, paraId: "A1000001" }]);
+  const source = await buildDocxBuffer([{ text: bodyText, paraId: "21000001" }]);
   const document = await parseDocx(source, { detectVariables: false, preloadFonts: false });
   if (headerText !== undefined) {
     document.package.headers = new Map([
-      ["rIdHeader", headerFooterStory("header", headerText, "B1000001")],
+      ["rIdHeader", headerFooterStory("header", headerText, "31000001")],
     ]);
     document.package.document.finalSectionProperties = {
       ...document.package.document.finalSectionProperties,
@@ -164,7 +164,7 @@ const buildStoryDocument = async ({
   }
   if (footerText !== undefined) {
     document.package.footers = new Map([
-      ["rIdFooter", headerFooterStory("footer", footerText, "C1000001")],
+      ["rIdFooter", headerFooterStory("footer", footerText, "41000001")],
     ]);
     document.package.document.finalSectionProperties = {
       ...document.package.document.finalSectionProperties,
@@ -211,13 +211,13 @@ const buildStoryDocument = async ({
   if (footnoteText !== undefined) {
     zip.file(
       "word/footnotes.xml",
-      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:footnote w:id="2"><w:p w14:paraId="D1000001"><w:r><w:t>${footnoteText}</w:t></w:r></w:p></w:footnote></w:footnotes>`,
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:footnote w:id="2"><w:p w14:paraId="51000001"><w:r><w:t>${footnoteText}</w:t></w:r></w:p></w:footnote></w:footnotes>`,
     );
   }
   if (endnoteText !== undefined) {
     zip.file(
       "word/endnotes.xml",
-      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="E1000001"><w:r><w:t>${endnoteText}</w:t></w:r></w:p></w:endnote></w:endnotes>`,
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:endnote w:id="3"><w:p w14:paraId="61000001"><w:r><w:t>${endnoteText}</w:t></w:r></w:p></w:endnote></w:endnotes>`,
     );
   }
   return zip.generateAsync({ type: "arraybuffer" });
@@ -266,7 +266,7 @@ describe("generateRedlineDocx", () => {
     expect(new Uint8Array(revised)).toEqual(revisedBytes);
 
     const acceptView = await FolioDocxReviewer.fromBuffer(result.buffer);
-    expect(acceptView.snapshot().blocks.find(({ id }) => id === "A2000003")?.text).toBe(
+    expect(acceptView.snapshot().blocks.find(({ id }) => id === "22000003")?.text).toBe(
       "Revised cell value",
     );
     expect(acceptView.getChanges().length).toBeGreaterThan(0);
@@ -291,7 +291,7 @@ describe("generateRedlineDocx", () => {
 
     const rejectView = await FolioDocxReviewer.fromBuffer(result.buffer);
     rejectView.rejectAll();
-    expect(rejectView.snapshot().blocks.find(({ id }) => id === "A2000003")?.text).toBe(
+    expect(rejectView.snapshot().blocks.find(({ id }) => id === "22000003")?.text).toBe(
       "Original cell value",
     );
   });

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -146,10 +146,10 @@ const buildStoryDocument = async ({
   footnoteText,
   footerText,
 }: StoryDocumentOptions): Promise<ArrayBuffer> => {
-  const source = await buildDocxBuffer([{ text: bodyText, paraId: "A1000001" }]);
+  const source = await buildDocxBuffer([{ text: bodyText, paraId: "21000001" }]);
   const document = await parseDocx(source, { detectVariables: false, preloadFonts: false });
   document.package.headers = new Map([
-    ["rIdHeader", headerFooterStory("header", headerText, "B1000001")],
+    ["rIdHeader", headerFooterStory("header", headerText, "31000001")],
   ]);
   document.package.document.finalSectionProperties = {
     ...document.package.document.finalSectionProperties,
@@ -157,7 +157,7 @@ const buildStoryDocument = async ({
   };
   if (footerText !== undefined) {
     document.package.footers = new Map([
-      ["rIdFooter", headerFooterStory("footer", footerText, "D1000001")],
+      ["rIdFooter", headerFooterStory("footer", footerText, "51000001")],
     ]);
     document.package.document.finalSectionProperties.footerReferences = [
       { type: "default", rId: "rIdFooter" },
@@ -188,7 +188,7 @@ const buildStoryDocument = async ({
   );
   zip.file(
     "word/footnotes.xml",
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:footnote w:id="2"><w:p w14:paraId="C1000001"><w:r><w:t>${footnoteText}</w:t></w:r></w:p></w:footnote></w:footnotes>`,
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:footnote w:id="2"><w:p w14:paraId="41000001"><w:r><w:t>${footnoteText}</w:t></w:r></w:p></w:footnote></w:footnotes>`,
   );
   return zip.generateAsync({ type: "arraybuffer" });
 };
@@ -213,9 +213,9 @@ describe("compareDocxVersions: real w14:paraId alignment", () => {
     const change = diff.changes.at(0);
     expect(change).toMatchObject({
       type: "modified",
-      blockId: "A2000003",
-      baseHandle: { story: { type: "main" }, blockId: "A2000003" },
-      revisedHandle: { story: { type: "main" }, blockId: "A2000003" },
+      blockId: "22000003",
+      baseHandle: { story: { type: "main" }, blockId: "22000003" },
+      revisedHandle: { story: { type: "main" }, blockId: "22000003" },
     });
     if (change?.type !== "modified") {
       throw new Error("expected a modified cell paragraph");
@@ -323,11 +323,11 @@ describe("compareDocxVersions: document stories", () => {
     }
     expect(headerChange.baseHandle).toEqual({
       story: { type: "header", relationshipId: "rIdHeader" },
-      blockId: "B1000001",
+      blockId: "31000001",
     });
     expect(headerChange.revisedHandle).toEqual({
       story: { type: "header", relationshipId: "rIdHeader" },
-      blockId: "B1000001",
+      blockId: "31000001",
     });
 
     const footer = diff.stories.find(({ revisedStory }) => revisedStory?.type === "footer");
@@ -339,7 +339,7 @@ describe("compareDocxVersions: document stories", () => {
     }
     expect(footerChange.revisedHandle).toEqual({
       story: { type: "footer", relationshipId: "rIdFooter" },
-      blockId: "D1000001",
+      blockId: "51000001",
     });
   });
 });


### PR DESCRIPTION
Four shapes a compared package could carry are not shapes the OOXML schema
allows. The compare round-trip self-check reads which words a view resolves to
and which cell they sit in, so it saw none of them: all four parse back to the
right words.

### A revision `w:id` is unique across the package

One logical change serializes as several physical wrappers — a word-level
redline cut around the words that survived — and the pass that gives each
wrapper its own id ran only on the full repack. The selective save, which
rewrites the changed paragraphs and re-emits every other part verbatim, exited
past it, so a paragraph-local edit shipped several revisions under one id.

Both exits run the pass now. It has to see every `word/*.xml` part, including
the ones a save left untouched, because the id space is the package's rather
than the part's. Every id it lets stand or mints goes through one choke point
that refuses a duplicate with a typed error, so a branch that did not
anticipate a shape fails loudly instead of emitting the collision.

### `w:tbl` is `w:tblPr`, `w:tblGrid`, then rows

Both are required and both precede every row. They were emitted only when the
model had something to put in them, so a table the comparison creates — no
authored properties, no measured column widths — opened with its first `w:tr`,
where the content model has no place for one. Both are now always written; the
grid declares one column per column the widest row spans, and `w:w` is optional
on `w:gridCol` so an unmeasured table still declares a valid grid.

A tracked row remains marked in its own `w:trPr`, never wrapped in a revision
element; the scenario tests assert that alongside the ordering.

### `w:hyperlink` wraps a revision, not the other way round

Run-level `w:ins` and `w:del` take run-level content, and `w:hyperlink` is not
in that set. Deleting or inserting linked text now emits
`<w:hyperlink><w:del><w:r><w:delText>…`, splitting the revision at each link
boundary; the runs inside also get `w:delText` rather than `w:t`, which the
previous nesting skipped. The model keeps the opposite nesting — a revision is
the unit a redline reads — so the parser hoists the OOXML shape back to it and
the two stay exact inverses, leaving the package unchanged across a round trip.

### A paragraph id is 31-bit

`w14:paraId`, `w14:textId` and the comment-part ids that reference a paragraph
are `ST_LongHexNumber` with a maximum: the value has to be below `0x80000000`.
Producers exist that write eight hex digits without that bound, and folio
preserves the ids a document arrives with, so an out-of-range id travelled
straight through a save.

`paraIdInRange` is the one mapping, and it is a pure function of the value
alone. That is what lets the parser and the save agree without consulting each
other: a paragraph's id in the model is the id the file gets, so bringing an id
into range does not make a document's own identity move under it between
reading and writing. A package-aware search for a free id would read better and
would be wrong, because the parser has no package to search. The package pass
applies the same mapping to every attribute that carries such an id — the
paragraph's own, `w15:paraId`, the `w15:paraIdParent` that links a reply to its
thread, `w16cid:paraId` — so a paragraph and every reference to it move
together.

Fixture ids in the tests that authored values above the bound are brought below
it; they were writing ids the format does not allow.

### Determinism

`compareDocx` requires an explicit `timestamp` and reads no clock, but the save
stamped `dcterms:modified` in `docProps/core.xml` from the wall clock: two runs
over identical inputs with identical options differed in that part alone. It is
restamped from the same timestamp as the ZIP entry dates.

### Tests

- `packages/core/src/compare/package-shape.test.ts` reads the compared
  package's own XML: unique revision ids across a word-level redline; table and
  row insert/delete at the start, middle and end of a table; a hyperlink
  deleted, inserted, and edited around; an input whose paragraph ids overflow
  the range; and byte-identical output across two runs.
- `compare.property.test.ts` gains "every revision id in the package is claimed
  once" and "every paragraph id in the package fits the 31-bit range" over the
  existing edit-script arbitraries.
- Serializer units for the link nesting and the required table children, and a
  normalization unit for the choke point.
- The body-sequence fixture gains hyperlinks, `w14:paraId`s derived from a
  paragraph's own content, a `w:tblGrid`, and a core-properties part, so it can
  author these pairs and reaches the selective save path a real package
  reaches. The missing grid was a defect in the fixture itself.

Verified against an Open XML SDK validation of the compared packages: the four
message classes are present before the change and absent after it.

`benchmarks/compare/digests.json` is not re-recorded here. The recorded product
digests do change — `w:tblPr` and `w:tblGrid` are now always present, a
revision spanning a hyperlink is several wrappers, and `dcterms:modified` moves
with the timestamp — but `bun benchmarks/compare/run.ts --baseline` writes only
the configurations it measured, so it has to be a full run on a quiet machine
rather than a partial one folded in here.
