### PR TITLE
perf(core): format the final-mark guard's path only where it finds something

### DIFF
--- a/.changeset/final-mark-guard-path-cost.md
+++ b/.changeset/final-mark-guard-path-cost.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Format the final-paragraph-mark guard's container path only where it finds one, so the walk costs no more than the projection beside it.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -260,6 +260,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
 * Delete the whole block. A block with words loses them and its paragraph
 * mark; a BLANK block has only a paragraph mark to lose, and loses it, so
 * the empty line goes away rather than the operation doing nothing.
+*
+* The block that ENDS its container is the exception, in both modes: a
+* body, a cell, a header or footer, a note and a text box each end with a
+* paragraph, and a deleted mark there would say "join with the paragraph
+* after this one" where there is none. It loses its words and keeps its
+* place. To remove it, delete the mark of the block BEFORE it, which
+* merges forward into it.
 */
     {
     id: string;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -892,6 +892,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
 * Delete the whole block. A block with words loses them and its paragraph
 * mark; a BLANK block has only a paragraph mark to lose, and loses it, so
 * the empty line goes away rather than the operation doing nothing.
+*
+* The block that ENDS its container is the exception, in both modes: a
+* body, a cell, a header or footer, a note and a text box each end with a
+* paragraph, and a deleted mark there would say "join with the paragraph
+* after this one" where there is none. It loses its words and keeps its
+* place. To remove it, delete the mark of the block BEFORE it, which
+* merges forward into it.
 */
     {
     id: string;

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -892,6 +892,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
 * Delete the whole block. A block with words loses them and its paragraph
 * mark; a BLANK block has only a paragraph mark to lose, and loses it, so
 * the empty line goes away rather than the operation doing nothing.
+*
+* The block that ENDS its container is the exception, in both modes: a
+* body, a cell, a header or footer, a note and a text box each end with a
+* paragraph, and a deleted mark there would say "join with the paragraph
+* after this one" where there is none. It loses its words and keeps its
+* place. To remove it, delete the mark of the block BEFORE it, which
+* merges forward into it.
 */
     {
     id: string;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -606,6 +606,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
 * Delete the whole block. A block with words loses them and its paragraph
 * mark; a BLANK block has only a paragraph mark to lose, and loses it, so
 * the empty line goes away rather than the operation doing nothing.
+*
+* The block that ENDS its container is the exception, in both modes: a
+* body, a cell, a header or footer, a note and a text box each end with a
+* paragraph, and a deleted mark there would say "join with the paragraph
+* after this one" where there is none. It loses its words and keeps its
+* place. To remove it, delete the mark of the block BEFORE it, which
+* merges forward into it.
 */
     {
     id: string;

--- a/benchmarks/compare/README.md
+++ b/benchmarks/compare/README.md
@@ -95,12 +95,18 @@ Timings mean nothing without these, so a failing invariant fails the run.
 any that moved. That is how a performance change proves it altered nothing.
 
 A digest that moves needs a reason in the pull request that moves it. The
-recorded set was last re-taken when blank paragraphs became blocks: the
-generated documents themselves changed, because a body may not end with a
-table and the classes that ended on one now carry the paragraph the format
-requires; and the redline's shape changed where a paragraph is appended at a
-container's edge, where a deleted block held an image, and wherever a revision
-used to land on a zero-width anchor.
+recorded set was last re-taken after a run of fixes that each changed the
+bytes a comparison writes: a container's final paragraph mark carries no
+revision in either direction, so removals at a container's edge merge forward
+into a carrier and an appended run's break rotates one paragraph back (#730,
+#734); every revision id is claimed package-wide on both save exits, a
+hyperlink wraps its revision marks, and paragraph ids stay in the range the
+schema gives them (#731); inserted and deleted tables carry their table, row
+and cell properties, and paired ones record property changes (#735); a table's
+properties a save did not touch come back as they arrived (#738); the
+application version in the extended properties is written in the form the
+schema fixes (#737); and every rebuilt part declares every namespace prefix it
+uses (#740).
 
 ## An external corpus (local only)
 

--- a/benchmarks/compare/digests.json
+++ b/benchmarks/compare/digests.json
@@ -1,10 +1,10 @@
 {
   "fields/l/churn": {
-    "buffer": "90a33c540e23f2f3ea07d9322c93f4a24d958370110a4fa36d25a9bc62884a72",
+    "buffer": "e3191913cbece907370399f6a4eaab80111f977c79ca2e00199433c509990ac2",
     "changes": "49e3cd765ac3d95e4a088e22c793ec914e732169f684ab9789108251b3291611"
   },
   "fields/l/heavy": {
-    "buffer": "dbcfc941a7b08680b5803369d6bcea3ea0f78db4cd493f1e903b6fb49e9900a4",
+    "buffer": "8e26d6d86378817635872be948b7895d1aa37a95ce74df81bf41d21c82207a2f",
     "changes": "e877878823945f249b8bf28288f7d9124bffdf064d952c5c80d01dac0e65db83"
   },
   "fields/l/identical": {
@@ -12,27 +12,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "fields/l/light": {
-    "buffer": "d1d76352e7801eb4fc07038f35a0323deda64b09ef3860644b01a23cc1355cdd",
+    "buffer": "f4ca022d0762a315d4ffd39d215a6dc85f6f7046989f230993da893dbb22a384",
     "changes": "280bd52b20384485b64c78de7066ef21af6d467963b4ece5c2a4225df5828009"
   },
   "fields/l/reorder": {
-    "buffer": "efb5996865ab7d8742f238844250b8f5cae3bee4173510b58ce6f6e1670ec751",
+    "buffer": "1b0526499c921f1ad203fb40e409b4c8bd25ccd5878add724f3f82246359b447",
     "changes": "e1e102c15f38957c285e0c1f2cc8aeca461c0ea190da702df31e749da746cb41"
   },
   "fields/l/rewrite": {
-    "buffer": "b209ebab14efab07040f7bf1c240671be544526a9fc1b8b5c89554c57b3d0c8c",
+    "buffer": "500f94192497534e7a9c34b7381855531c17b7e0868431fbf263fffc8bda84ad",
     "changes": "0199582b63e5b5071775558d530433352c55db17fcb1322073342f6b6a275c37"
   },
   "fields/l/structural": {
-    "buffer": "fcb6390c4f4bd2bdac00ff952acc7183da056880d702f32b19a64036d914b4cf",
+    "buffer": "58f2f9f4b9c2d66d8f4e5fdd910c79305151d453a6f8bf7e44ff4d16a1ca9572",
     "changes": "b3e76ae2c379980f562bdb387c6a3ed7c85ce9833f2b46f7d79c958de19ff3a8"
   },
   "fields/m/churn": {
-    "buffer": "9925237a259a5e03b5cd2424346b4da635aeb7083c638ce213ab89508fd161c1",
+    "buffer": "506053548e885c500d37e5edb36abc867d14cc992cb5ab3ae7b5235eca4fd76b",
     "changes": "25bcc8e02cc21daa757c4481b2586e87756ce1c99c4b59c39b733bf898b1749f"
   },
   "fields/m/heavy": {
-    "buffer": "a460b1061cc9baf4335db6222eb06239aea73335b690656b107c5a04ecd357a2",
+    "buffer": "d0b5010ca2c4988fa7d1ee7477efc75f4908f13d8b96793f1855d7e87dbacdbf",
     "changes": "e173e71cc66fb25fb19ccc8ec48f929d788260e100e54cbde283c1bdaa5407cb"
   },
   "fields/m/identical": {
@@ -40,27 +40,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "fields/m/light": {
-    "buffer": "f7e929fc5150debd9a0551d5a4aa718938fc61820938e7cf3ecd968feb2aa53f",
+    "buffer": "76e7848c14db5886f3c47f3bc99f480b8babf652d94b8eed8ac3c3caed7a2b5b",
     "changes": "ff7c22007215ec0cfc019cc7f1f71c0ab44dcc9e01318801b0623a7e5337cc27"
   },
   "fields/m/reorder": {
-    "buffer": "58494dda8a1a05644c1933d60e4f395e7a91d62af6e2d58e9774b4419573d548",
+    "buffer": "bd3cc9ce526a3eeb58eeb78f0a1822caa9eb8ca4ef831d54cc68eeb16a1a41c9",
     "changes": "af0aa47ffd39fad8c1229ad20bf09e1e843dc89fde1467f06f288eca4af4b2f8"
   },
   "fields/m/rewrite": {
-    "buffer": "d91145dfd0bf881aa4a11dc90e06a905d28eb65ca79937b8908b2222a47b135f",
+    "buffer": "027db0aedb198c27189b08d9fb6b81baa923decd69f0a12b3ff6985b44c35745",
     "changes": "36eaab01d650540a5492c74be1c1c24fe263d60ebb42fffa18094e194e2a7f5f"
   },
   "fields/m/structural": {
-    "buffer": "8f81596f7528ab320fc5a706ecba5162dac42d9ef565219a970f46d7a6599349",
+    "buffer": "83485ad417e0ee8d4f4d6a209da71171eb6ca6c3f16ef09839fc449e648a4190",
     "changes": "1f878b731267abf637a2ba8a3686ec407fac38eee9214cbbfcc37e4fcfe66952"
   },
   "fields/s/churn": {
-    "buffer": "ad27f590e265d858856bb74dd15669fdda28e83fe0bf5826d7351c988386e463",
+    "buffer": "2c05af9f78d2973cfd2d553084ec457bcae6df640bd3ca17df26aa1afffe34e8",
     "changes": "74e79d3bbe6f31db574bbdaa66c561e283be77d5c33a001a4a95461ccb91ae1f"
   },
   "fields/s/heavy": {
-    "buffer": "b33a9929037e53f4a0deb4799f9901666814d29b3e00fd94793018c13cec65e6",
+    "buffer": "001b1f14119ed5ff451542a30302f3679e31a47d8e55bf60d2a3a595fe60c24c",
     "changes": "a216ce6d3fd2cd164deb0082b3c9095380d278c4016e8e238a250b6de6bf431d"
   },
   "fields/s/identical": {
@@ -68,27 +68,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "fields/s/light": {
-    "buffer": "4d091dd61dab4c055859ce619e51af8ab01a087f843dc0dd1d27bc4f36491054",
+    "buffer": "0fdf1077e28765f219785a1e5509bdcf74c331d6a539e46741c5890ea0af7583",
     "changes": "28daf17b145f40796260b947b672f14420b880b799e12be9045070e828b13468"
   },
   "fields/s/reorder": {
-    "buffer": "32527ceba4d849af61e416bb5e7e627afb6f48e90816bbdccea4b892df6dce10",
+    "buffer": "0ac409fce393bc8a18ef02bb6b1427a12a284ea149b7771dff08f72e11105cfc",
     "changes": "7aa9d59e5988781104381896daf308f9fe7b2bfc15cc3e4f0dd2ecbca1df84a8"
   },
   "fields/s/rewrite": {
-    "buffer": "dd8fa544ba4585245f48f0d4d2f9f744eea5a886aaf4cb110e2b8fe19b5078f7",
+    "buffer": "94a301f93858f5584bbdedfc28137dfc5f616478cdadd4fc975a7e59e94a1226",
     "changes": "799bab06f66ef944e38074616bd32ac9d8f186a872b23ae0c44231cb98947b47"
   },
   "fields/s/structural": {
-    "buffer": "a8cd17b9cd24670a12b7fb21432b3246453c2e30cb2e22bdadc52895d2ba4664",
+    "buffer": "5ba5dbb5887aecb5f1effd2e478d3fb2448c2cdb977110d131d51cedea2fd5bc",
     "changes": "4ce57e683684226a619cec843ed65e33adac599b044b84ee0bad2bf1661fa9c8"
   },
   "graphics/l/churn": {
-    "buffer": "7e4263a39734e939c25d95984b258f15b9dfb0bd1d1159b8ad5aabe6ee2aa841",
+    "buffer": "d5a9d3a3fdb66159c73833bb7c553a80bf2fa89abd250d22a2311a132ebc3c5d",
     "changes": "39495457dfd59f74a07d9ed1625e4ed6421b1212fd09e370f85236345734123d"
   },
   "graphics/l/heavy": {
-    "buffer": "90ff422f348f01ae5f0423db8d82c1b540785c4f1859f1cc27099a770bc2e489",
+    "buffer": "8ab0c60f954179b223df016440a66840b8bd00e0b95fa20adf84e5d8c27dc4dd",
     "changes": "6b05ea843a8321fdac11ecc4f00da2bc23ba338a381d6497311af47893db1aba"
   },
   "graphics/l/identical": {
@@ -96,27 +96,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "graphics/l/light": {
-    "buffer": "1062e7c677cf512b908248707a23826d67f0e369e8ebf364f91fbde05e218f78",
+    "buffer": "32072994a282b3b732846f92c743a4ce054d5cea7cfadeb58c77e6385548c1dc",
     "changes": "d73d5b2e737da5c8bdb4f5eef44466b4d5f9a461fb6c59ef017bc8dcdc043688"
   },
   "graphics/l/reorder": {
-    "buffer": "32c5a2e155d0625ee95df0f5a690aa0672fc6a211464ece5e1f8ff11e4261380",
+    "buffer": "8f7fe056ca905a1dd81e9620f071e6988e5260c618dac965b4a3e459b857ce8a",
     "changes": "4b9d3839953182ef280f6b7dfa3b25137e0083f068b58aa100471c1d9aba095c"
   },
   "graphics/l/rewrite": {
-    "buffer": "a9e454597cdf206c6937ca7789b1e973aeaeff98248573e3e270496c60b1b801",
+    "buffer": "da0d6badaf527439f86d1eaea067f013997cdf35bc3eadd16af5c123311e351d",
     "changes": "1781b3785c2afb9a30d1fc262084a7bfbbb24203ade87b035458aa002db3cf60"
   },
   "graphics/l/structural": {
-    "buffer": "515fc2be129c856d2cdcba42a746da842160fb066664d5df84b9fef5452120b0",
+    "buffer": "27ca892ff37a53895dba30739f5d0d51af9037a026b9dabb1342083a7a2462ff",
     "changes": "add2a662ff633c937bf3052d55e0bcdf1e6fbe1244dfe23165eb96cdadd42d46"
   },
   "graphics/m/churn": {
-    "buffer": "5a9a9491749ed0d4a1a5ec6dcfa8cef8cb35eac7d5fe22e630046e6f802f9593",
+    "buffer": "1c51d78d6eef7b87b48e2c86d90aa7a9970bd470dc501fefc1cfb33dc1d669b9",
     "changes": "9bc9d22caf2f4e6eac0e4663fbb8c93ab7fb813b096e338654aa0925c41c02cb"
   },
   "graphics/m/heavy": {
-    "buffer": "c99a2270adbf6974bb95768117dd75a29e533d80ffba8f9dbcceb44a52eee6a2",
+    "buffer": "6e47c21a591d396fe2cf0826ddbb1d31f49b9ff78594258e101c2d3f5a8377a7",
     "changes": "91f5ce0cae4d063007a123821b0fd3056593df9f3984acdc317ee854d8b6ebb4"
   },
   "graphics/m/identical": {
@@ -124,27 +124,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "graphics/m/light": {
-    "buffer": "2df998cd5bd402fe9294c6549163805002f1a28525e306218a963cb9a34d6d7c",
+    "buffer": "fcd59df5aaf9b034153018cd8792ff97d5d27b8ab16ad8c8fd88f9a5ae4fa98a",
     "changes": "8a97da5bfe12c904b6bbff80c1552ce1dda6046f9a5f72b1ca60e155ab97bc96"
   },
   "graphics/m/reorder": {
-    "buffer": "3b2f9157165acc15b6c0c08a7d7714302dfdae9cebc9b9eb7570e08f8f2268f3",
+    "buffer": "5050ecc99c49c97621b35d7b6cfd73f7dbc5548bd9c64a42fcb5fd1ae88c2069",
     "changes": "a0c27ff6b07d68a4c41ec45e0f015dcad37a7dc8800e65c0436acc92b65428e1"
   },
   "graphics/m/rewrite": {
-    "buffer": "ab47de0d4591d45b7ede9133c4a79a3648b7b3f283a4f26270111bf485c72c5e",
+    "buffer": "dba707a3fefee3bd83edd19714240a9fdf23e9f4a95d32ea3b9abdb55ccaeb8a",
     "changes": "151af65271daec11287c22ebf18000ec9c6e61fbc29050be1902f3b012d1d052"
   },
   "graphics/m/structural": {
-    "buffer": "d4de7667532251c0659254cc3a9a22114b2d12398608611d15814bcdbadb0728",
+    "buffer": "d4d57bace4c5c98a2aadc44a3136fe029b61cfb936973aef303d505ac1539e55",
     "changes": "b13a0f89849097be4c8453ede023f7002c57e7b8b277c79e1d05d1d305f35824"
   },
   "graphics/s/churn": {
-    "buffer": "a3f458d3af5518928d39bba1677526855e5fe2f31d1361a53858e0a6bc6dc930",
+    "buffer": "3276fc1bfc7095a23977ab9d8de9cc9d58eb41bcd9915c2350a11ef8fb6a32cb",
     "changes": "65a55bcb089a5ba77a54262bb8b6cbe9e896c4ef4d4abe6434389c498084c13d"
   },
   "graphics/s/heavy": {
-    "buffer": "fe6cadae329efab30a27dc345df37c0ec0cc2d4ab5568aa1d1e0e3f8f79b78e9",
+    "buffer": "844f9189195ec40857d755fd997eef92c9479443cffbd4e715348a5e8c7a5dad",
     "changes": "1957ec65add47a02ccc945d632a84a69fe97f484548ed60446114d1f240f1c39"
   },
   "graphics/s/identical": {
@@ -152,27 +152,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "graphics/s/light": {
-    "buffer": "1782348993c7cd8f9e64225babc0554e5144fc5c30ebee1e8c50b25c67ea55f1",
+    "buffer": "65642e1b916dbb485ee491ff8c0f1e0d190bf1be0ae3f6149618c7eaf74b5a49",
     "changes": "c597f1c3807ea58c1d29530701d82cad97c48befb64ebdb74bf28086925ed4ad"
   },
   "graphics/s/reorder": {
-    "buffer": "779d183ea435e1d6c23f43265fb37f4b842c425e973147f3e2bad29304e1c505",
+    "buffer": "3ac85b45b4f0a07a034cf8d05dd4a6c83e0594450258b727f9aadc91e1dd3dc4",
     "changes": "2e8ae414b596fc96d6bf158c7b104fefcbc1a808d24b7424bc1e1d5bb2fc859b"
   },
   "graphics/s/rewrite": {
-    "buffer": "1478dfdaeb0d4a7ce0d58c1d9852d4b91c5d40a975d44ddb9dbcb60825774e11",
+    "buffer": "854e4aa923dc704a732a13f252a463885cffd56e10ee5b5336e0f98f3a1b101f",
     "changes": "786b0cb13601a366eb4c3c9d93eff1d7c04722f153ed0de844c5fec0ba5f4d60"
   },
   "graphics/s/structural": {
-    "buffer": "bc1869b7d0be98d948f0324e3810a1d57cb041604b90d7013a33a69209e79ec0",
+    "buffer": "8e33bd6ca292aaf6b8b6e3b1ab96a41cbb42e4c2d0a0ba8463fe891e758a5795",
     "changes": "8fa5d8ccf271619f4709f2e62fcde684214342b6d4b84315be5fb4b0840aff2b"
   },
   "lists/l/churn": {
-    "buffer": "66a83753bbb7b1cac9fa68382dc2a921d7a0cc8b91aa674786a4b1f796dea940",
+    "buffer": "a3489532fca8d1c3bce689b476fd48b36d23069214f730c6a91e2df7cbfe37f2",
     "changes": "d75cfa281197ee2c8f7b99eccd349e6f907799007735caa40b846403ec98eff7"
   },
   "lists/l/heavy": {
-    "buffer": "013e0e5febf6fb4ce063c8ddb8118d4b2e28da3d1f2116778b2456c74ab57cdd",
+    "buffer": "e8c418b79d7edafb92aedec5fb319d1a521d314e6db1f040e52b873fcc0c410c",
     "changes": "7d10c68acb79859050b31b4490c8f84447765ec7ec5063bcd60a7af2d72268db"
   },
   "lists/l/identical": {
@@ -180,7 +180,7 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "lists/l/light": {
-    "buffer": "5d3eb599fdc31bc9f1c5c080cc7993c8d71c62d23d40de1d441f36c4f8a96656",
+    "buffer": "268170b8f7ef23ad4536c5ffaae3b944625385b92f3ab2bbe570e1d8f078db2a",
     "changes": "e08f2c623626b1dfad84359aa082f0c6fa04d859c40f3e2084268093ff4cc0b0"
   },
   "lists/l/numbering": {
@@ -188,23 +188,23 @@
     "changes": "e28188b324e0ca834432ef770a32d7b5802a04f4a5ecf45c3cb3e8cac07fe86c"
   },
   "lists/l/reorder": {
-    "buffer": "564a29e13493838973f0b89f62517707c3227f04fbb6d81a88b90992caa230e0",
+    "buffer": "12238e881c850cdf57ec2fff21e0e208a4224d392ea156b1648e7a760612fee8",
     "changes": "e105597f305855f918c4feb651300d722e5c5c7a6a4eb3670003a678bc9fb8d4"
   },
   "lists/l/rewrite": {
-    "buffer": "4e41577b027db917b17dfb026eb09f83c16543da8d518a296b1053171a4b6491",
+    "buffer": "2ab358e78ab5f4ed7aaa0830620e433c2aba205eebc3e455c436e780da43c969",
     "changes": "18087e137c3ea2396dbc6cb2d31e3ad32dac376cd0fc53a501acccafdeddc968"
   },
   "lists/l/structural": {
-    "buffer": "aeb95059025d53c9394141cc98a04add9add1a2d288b3a572726147befa627cf",
+    "buffer": "0c47310219c2f595d97df6e3e7e09ad99b827730a8e0e868011e79e4e725c9f0",
     "changes": "5bbbded9e8beaa78b47951946a30276729b1cbb573c671b69fdf1440f7cd0e18"
   },
   "lists/m/churn": {
-    "buffer": "347663b24099727ed1aa2990e649219bc34dc5b9e8e8d39028e92bc2117d21b9",
+    "buffer": "d1cca4f1801b41fc1867f2150c5d86bc04e2e834c1878c2c581f5968f985d881",
     "changes": "89e426c230ae9fc4965184118202bef6ba6789ae6363233651d27b23b567227a"
   },
   "lists/m/heavy": {
-    "buffer": "278d5b730fbd1fe0b9080a44c74357091edf59fdcb71df10f8f7ebad4f67c0d3",
+    "buffer": "1fdedfe5ade4a8ed1662c148ab1c22ccc93640eb85f8d0ebdef5a8791bb7980f",
     "changes": "e693bd16b03677da40a834802d822c373e3335042fafb56a78a7b2acde9ae6ea"
   },
   "lists/m/identical": {
@@ -212,7 +212,7 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "lists/m/light": {
-    "buffer": "3bd74b9eb8938fe0e2e3227531e571057d999809b53df3b6ea2b98063d4dea25",
+    "buffer": "ff81e561a53f0feb5a3020e1143fda335812b99a9e06d04509d46b00a36cb9d9",
     "changes": "c0f9546fb3a6081b2245125b8af414a8b0fa0860bd85f67e1dd9f9be1ce3c174"
   },
   "lists/m/numbering": {
@@ -220,23 +220,23 @@
     "changes": "e28188b324e0ca834432ef770a32d7b5802a04f4a5ecf45c3cb3e8cac07fe86c"
   },
   "lists/m/reorder": {
-    "buffer": "7837bb9801aff3e6d4b1aabe6fa3c7da6176966b4ae76c3550d7f344d39ad059",
+    "buffer": "db19a30e5f72e1bd01ffa691ed6a2ee50c3b7472310806d0141ec453aea24e09",
     "changes": "72bbb957f11201a145d8ea8ca1f8191de586c42f561bd8b707f0805f2df2b127"
   },
   "lists/m/rewrite": {
-    "buffer": "82979ea150c4cd07d9f13643a2e964b41890f48c207be2417846d523d0dd8cb4",
+    "buffer": "bdb7d1f0cc55cb0a522f81269458ed412a0809f977739936e1659d85e8523ebe",
     "changes": "c983c291e9aae0336ec6846af613e6f8c52a7226b65abf92328da5395fffddc2"
   },
   "lists/m/structural": {
-    "buffer": "aca893225e2a8af24a7e67f25381862427d0e0f208d6c39ff69bcf9993da0b58",
+    "buffer": "cb855c59ed2a9ecd5fad8d5e15f3e876f2b52ccc5f6782b484b0d06a3db540c4",
     "changes": "20607800e8827b6d0a3976204cab9fd4c822de74a57adb9854359954aa2ee1c0"
   },
   "lists/s/churn": {
-    "buffer": "dd417d275c78d6bce979575c7722236262de82559e69245ab7045d8e45a1dbdc",
+    "buffer": "d193968a5fc5a8b7168f36e9325f25f6a26a4dd28ad8949f8d86e0b3140ed5bb",
     "changes": "a5a20e90b4ebd6083429c3e6d50f1e41651587191e595c8dd66926b7356c055b"
   },
   "lists/s/heavy": {
-    "buffer": "44fb68f9f01e652393186bfdb2c2e3daaf2060135f8ab0e17af6da6adb274da8",
+    "buffer": "4a3fbc0d5962b01dcb8ccad702bcb105a38d4127d67e09aef3ab88f2cb022e5a",
     "changes": "a3a33ce9b1a72b02e5f5672666799e0dba5d78a63ea222cbadd57b6f1a671ae4"
   },
   "lists/s/identical": {
@@ -244,7 +244,7 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "lists/s/light": {
-    "buffer": "ae35a017a03af94edcf7d4ea214f63ba5ed08ccb40a73c206bfb2db00e47cc32",
+    "buffer": "4ae67f722c04c8dfaf92f3f8807a1ee2a8de516cb7dbf09cad0831f0ed987ea5",
     "changes": "072dfea0e9c138fc5070b2061f5760719df156340ed13ee5eb48746f4e4241e9"
   },
   "lists/s/numbering": {
@@ -252,23 +252,23 @@
     "changes": "e28188b324e0ca834432ef770a32d7b5802a04f4a5ecf45c3cb3e8cac07fe86c"
   },
   "lists/s/reorder": {
-    "buffer": "ef7b929731216885b93b9f352ffa2bafa199ed64b35bb82067c47cbde67269bb",
+    "buffer": "869697c4adbf9a1900b7fe7e5d4ab36c420c6ece60e8006c305be75959d5643a",
     "changes": "650365d977bdddeb4b4ab51735d117d63ddbd18ea1539c80f76fdd23c52cea66"
   },
   "lists/s/rewrite": {
-    "buffer": "8d8b4b6b10e62087deab663b0e35f557c65282d5a6e10b8d2a0d3f70c049705e",
+    "buffer": "4c654f9aa5e8b2836f97371b0cbd3d412783bfcc9e9665ca59f345b10dd28f9f",
     "changes": "188970cf6b8280f11a0264794d2795dec04fe3785bf7966d34022d9a5120e176"
   },
   "lists/s/structural": {
-    "buffer": "daaaa850a93f9e225942b444808b47f10ab561a2fb90e2a40c727719fd583073",
+    "buffer": "3bee1e68b465ac34c2a23080009a4cf2a75aabcffaa1160dc777ffe4be1a8a4e",
     "changes": "cc2576068da990111cdd85ac7a1478e7d894718c7effca348ee019bdc2892b4a"
   },
   "multiscript/l/churn": {
-    "buffer": "3d8011a5d104621fecda97c8d3318d44476904b8bb85ff73a383038f557f03f2",
+    "buffer": "4ae991da6eebe6caba654f4f946b4ead9804d8d1140ec11fa3223900e81bfd4b",
     "changes": "34cc10badeae798041fa44dcb287161dc636bb50240c6b750be6c3b9938b5ed1"
   },
   "multiscript/l/heavy": {
-    "buffer": "30a831767bebf1ac638ee8c3f865cfdad7935c02620c5cb9781b12417c6b9448",
+    "buffer": "241c8948afd313008bf3b03ce156efd470ebdf6efd99da2e33c840d98108493c",
     "changes": "08386b0e70fbd875857af9421e525b6f33b3f735c9f8578db33638eecf07f14e"
   },
   "multiscript/l/identical": {
@@ -276,27 +276,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "multiscript/l/light": {
-    "buffer": "bd69fd155905b69530fd1784c3d2ba84eb1f15251f69b199609a864d6c9c69a0",
+    "buffer": "a751a22fc2f58add5d12b65019f2c5e400e12338a7b3b076429c95fe230d7fe6",
     "changes": "ce821cd0b16dd86d52a579bc8384b4743856ac1d3695170e8d9ac3b8e86a0624"
   },
   "multiscript/l/reorder": {
-    "buffer": "61c791051af528024cb6abf8c3ca3867a4ea9658b46a57c91dd27079d29ed38e",
+    "buffer": "0da601e38f4697909cfa860515d7f4b5b4f64f0f07d563a916b83ece7328a10c",
     "changes": "7a00e888ecb81b54df82dd5690b7e437091f9ffbb987e9df7dc5a93bf6a4555f"
   },
   "multiscript/l/rewrite": {
-    "buffer": "3b3041ffd45408256890ed93c5b22eb0480d7fbf2f956907d70c382ebbc46fcb",
+    "buffer": "55f3435d0c5fc27f1f61a5d5e042170f5741464883e2b53900a999be1de374c7",
     "changes": "1acdeec0f657e6019aa87118c19f80fa92a4cbde57e1de1b73190cf1564d6c89"
   },
   "multiscript/l/structural": {
-    "buffer": "f253548529ecbb304a8c0440c7e1d54f2b06b3598577ded2e748dc6b0dd5e448",
+    "buffer": "c326896dac03b0efea37707a47867b21d37c7d2dba7492c450a7dd90310c5bd9",
     "changes": "621797665ec305584d416580d987e3690c81775820ae4322daa8ee3a53305888"
   },
   "multiscript/m/churn": {
-    "buffer": "979126135a126f4a0fa73a05991ec7ab9e1e9b616e30ab2263898bf91aa5d833",
+    "buffer": "e8046d753e7b18d5c1653ac0f005027e1186fe42f2d3f6aac18ee6391ec06f29",
     "changes": "cf8910865d5a7a42287c8c3c0698787f76d7cfb63ab4d4ccec6a118fd4d64457"
   },
   "multiscript/m/heavy": {
-    "buffer": "8e61f9546747e9bc33518292a0752fbc88fb175c6b83c5f28bf9d7105eb7184c",
+    "buffer": "dd80b11cb7c4a032e1d12b94ac77f64c4efae1ec31b04db27c81d49b336ca1b1",
     "changes": "714b372b57576eff051ae515a70f153bafc5fa9bcc2eaf3884c95d5adfc81b3c"
   },
   "multiscript/m/identical": {
@@ -304,27 +304,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "multiscript/m/light": {
-    "buffer": "aa231732707c40673b4bd61f27fbcc69fbdbd0431d29fb1e73cf111d338dfb57",
+    "buffer": "e890f12a3a0920f4ac718ccd1c3ab31c77f773eca81d7c402f8b9efc996c1d15",
     "changes": "f27f75498095a08dff8de4fe150defa5b6804a23f5950809f461a4b0c2291b33"
   },
   "multiscript/m/reorder": {
-    "buffer": "74d3a46a0b9e2d731f916cb0b76013fb6e0945e2d87516d99c0319f2b02a85dc",
+    "buffer": "6ec84afb5b3037333fa6807d0fe09ef4989efe4e4d67bb856bf5495f1e3b986e",
     "changes": "af9c61e85547b82e56dfa70033598659546cd2b81717929b0cedab303c54072b"
   },
   "multiscript/m/rewrite": {
-    "buffer": "868a447865c0877766d4e99b8dc16c8624e1b36d2ce28bcda64f8e66bcb8f0de",
+    "buffer": "26811052f82b8249cec853c06019b30150002fa6bdbd6b716d3efdd3cdbd66cb",
     "changes": "1262b068b7194f8a3941be772d4d6b3ef10e2b8239451817a2338965f7dc754b"
   },
   "multiscript/m/structural": {
-    "buffer": "2d26cf7f4271666ef7aef32db240f29c75cc736aa32a253e850b3671ee806b86",
+    "buffer": "111c4424d1a45559eda77540a814f7291fff6393c86e2db9cd614be65fbe2670",
     "changes": "1f9aaf0e046d8d66b1b66546970d514e08edb9eca710b15b77626431b1dd8ae8"
   },
   "multiscript/s/churn": {
-    "buffer": "26364d9718734ac004f0e40fc5a377cc5b1e0ddc9c2c647e91de97026f21cba3",
+    "buffer": "323c69dc537face701da7c881e9410174d725383ee113a1fdee641cc180c9cc3",
     "changes": "37c59b521f44180630c1a6fca999bd1dc2e170a1f8e26c2e34cf9d6c87961507"
   },
   "multiscript/s/heavy": {
-    "buffer": "04bf09804cbbc89a692e4fd17b959a697a8cf657c5f369ffd451afa4398599cd",
+    "buffer": "a28f352a96dc1ba7eeac04558919102719f23f332078b700fb7b122c1ed41d11",
     "changes": "45423e8b063637648950ba8c004c20ef1e7dee52309332eb16dfa354dd04cbd7"
   },
   "multiscript/s/identical": {
@@ -332,31 +332,31 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "multiscript/s/light": {
-    "buffer": "6bd44f1035880f58f547a65d5bf4edaa76f2649874aeca64d65e6b8a65f9a7de",
+    "buffer": "2508c3256e92abf5ee18699f3a52b9370600492f0746cc32125895aa5729f244",
     "changes": "73e48099521cb5c01d16d10975276debaa0091af227805214534fc7b88947157"
   },
   "multiscript/s/reorder": {
-    "buffer": "193bd4be8484ea4f4f1b58b64ba8122fd0c7f2a35f51b9d15cdfe63ccc87c4c2",
+    "buffer": "16e827d6c25bf8c31f5bec7c49eedb43023fe5605b8da0ee314efbe79fc953d9",
     "changes": "d60b51be02ec3bcb9fc7eb656ba1d18081bf2f5cec3a6d7025e84317d203dbf7"
   },
   "multiscript/s/rewrite": {
-    "buffer": "c8080c29c7d26930e2c828a6bd11771c4d338b18c45ab835dc17a17adf94c6ec",
+    "buffer": "1ff7a7508000c814d0b99fbcaf9f0e59025db95ec33ddda7c86e4e45b60dd23a",
     "changes": "5b95f47a6b6a5a289869c34dfebe937d34313e23fd5d82850a379d2d92de3fbd"
   },
   "multiscript/s/structural": {
-    "buffer": "fb07fe8ec814884cda5447f712bb441d4465d0fd08f9557ec8f1cc067bd19980",
+    "buffer": "dc9a1929845e517df54ab2f27979f2a0952aec85aceef04e484501bb198495fb",
     "changes": "3d0bd4ce2885e6bc4373462ea80d298760f812f2f37a4aecc698817e67a3cf22"
   },
   "notes/l/churn": {
-    "buffer": "4cb4e3d5262ca9710b1b862062f9c717b88585f06dc6763cdfe3b873ed23dca3",
+    "buffer": "bae0c6f343f447d10d9bd633b5ce1cfbeb5c5d3795ea746d460a4895e0b3fcc2",
     "changes": "e68451a7f694b4219561b0c5c942d5dfa01ffe9bdc5a631f336524ab5b3fd799"
   },
   "notes/l/everywhere": {
-    "buffer": "70bf27150ee9d32498972f3e36aa01ef0570b105facc55134de0421a3ef12d36",
+    "buffer": "f194c856e824a5a8f9160218b6d3110f66a8e53942d60da12c1109a16a5aaebd",
     "changes": "6ee50637c6784d6cfc6da888e9becfe9a28feb0e8f8aba850e5912909bf9fac1"
   },
   "notes/l/heavy": {
-    "buffer": "66c30317d663c50f2b169bd22eb6b81c9a4643aa9fc191f1d5417a49b33ccc04",
+    "buffer": "8bbdf1f58d4f95d86cce3c25105db6afa6d747da7b1b18889bafc2aec85ec53c",
     "changes": "39172edbf980134c3e15a5ff00a078974af42d98a519594d7309034f5d91cadb"
   },
   "notes/l/identical": {
@@ -364,35 +364,35 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "notes/l/light": {
-    "buffer": "bb6f97b69329c55c7c8b6d16d5383c1c26cf68f252deb2eaf9ceceba17fb90d0",
+    "buffer": "4206f8dafa3dc4cc85a72ff47e45da3474fa8fe2a6e0ce4f69f4139f67e3ca23",
     "changes": "984c0ab72c5aa2d46409ec38a554482e3fae900152acc43aa05f72ad311080da"
   },
   "notes/l/notes": {
-    "buffer": "b31a4c82f7a3b34a3e9fc82d56b9b6ffbfbeade0f54b713bb61a42c0b0b0920c",
+    "buffer": "23503b91ed56c3912b6606710d480a90c6fe9a91f92a2f8f955afd2346314910",
     "changes": "9ffe302a9b261df2859cd37dc75ef615f4fcdfce4aab1f17f056fea841132ffc"
   },
   "notes/l/reorder": {
-    "buffer": "7f5d62c37bb60b946ea04baa55e6f2ec6c7a049f28ff024850612dc18a199477",
+    "buffer": "999d9e2efa2a661459237a46e3f4c9199b0e16ddaa4bc0c0248a5278b34a35dd",
     "changes": "6d49211b70bf6d8e63e2cda03b2f1d9abf06b98d3aac047a3434df75b1fcbd15"
   },
   "notes/l/rewrite": {
-    "buffer": "1f1ea1e2fd9f2a20bb883419e2a2ef5043348232f2346de21a273845e53ec3d9",
+    "buffer": "639a2a1487f2b11380ef5f01d0e22cb3c7f6ab93527bc43d8f915533f59a98dd",
     "changes": "917310f30505564e49b9b69f9c71fbbbdeffa0bba69314af61da49cd5ab43486"
   },
   "notes/l/structural": {
-    "buffer": "cbdfb36e0bc96ef755d84a77be34f021c1a357bd320e3a26d71b88718edd1a4b",
+    "buffer": "44b14f963a67fb945a34c545fc59d45dca917ea36ff3e6cf8415bb46c0f58634",
     "changes": "27e26e57f13d87eec1e506653a6106cb6db3bcff9aa5ec6030bab92273dba5f7"
   },
   "notes/m/churn": {
-    "buffer": "688b09036de5f6987b3b7e2a8b622cf636200be9301cdb42ca6d035925b0a8c7",
+    "buffer": "d88c394d50f9dbeed909dd65e4fe5f5b42b22ac7f4d61a7da0d216a6b1c82685",
     "changes": "18bd97c39cbfd969985e927e7117a6de8e4752d210450216d06b9c9d5eaa027d"
   },
   "notes/m/everywhere": {
-    "buffer": "16050283ea2f529bc97c4757930b7e60c497ffcd5081b6412a53bda0a3e4901b",
+    "buffer": "d4281310f00ac61473c652553bd9c64fdd359670342a7945696e4bb9b127f169",
     "changes": "aec851444c45e5567ed112e3d54f7c2863db68aafcb8d6f190830808f6b3b45b"
   },
   "notes/m/heavy": {
-    "buffer": "6ff8657dc9a096de082e4cd3137f9e1cda7f25eb4d6df68952763f01bdcc844d",
+    "buffer": "ff2c92bc4c8ef7147c9abc0fcef4c3eaba9f308abba5db38d292be8d2c410a40",
     "changes": "7e73b89e5c5c9d1f9f633b3b81392884032e75480bfef2e508348e9aba04833e"
   },
   "notes/m/identical": {
@@ -400,35 +400,35 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "notes/m/light": {
-    "buffer": "fb75c91c1cd545a0bcca55f573c7e0b9fa76ecec772cdc721d9f7ba708005979",
+    "buffer": "fb4cb494d60e9eeb4439c64a96f4e28e6c50119ba686413d108ea3e3a7012c52",
     "changes": "98ef543df95a3c6caed73a16bc7bd9cb768447387b601ca9b5168184a6d2f5a6"
   },
   "notes/m/notes": {
-    "buffer": "ce194dac0d888ccaec074ebdaa13e00697278f3798038144be60a9a83940959d",
+    "buffer": "b57da582efd57952611fda9cbc9962c2888ab376f0ed25212334367b416fcc32",
     "changes": "d0b6caef62acf5826056793774cad08539797301f00b7f98f938cf821c9e14da"
   },
   "notes/m/reorder": {
-    "buffer": "e663a803809dabb0cf046ed266b1f7dcc2b4d0d762fa211a27558bcc9549980f",
+    "buffer": "89723721a5a3a3f83749ba784c8647ab84ab4429b5302b99cc99cee2636e72be",
     "changes": "43ad99e123d077f48d99982b7fdfee255ab9ad9287cc7a78bdc5b3d17457b9a4"
   },
   "notes/m/rewrite": {
-    "buffer": "00e4e9d851a843363c85ecc2d136e282ec18a09bb44198b3b2d27f3b75603319",
+    "buffer": "454e8a82191004499620c0e123cf504de77d56c07a47d0674c1c40f787effb8d",
     "changes": "5f1b6bbce2eb2cee2f3c72c2d82b0896deb7e59cfc326e8ec3e28ddb18d37902"
   },
   "notes/m/structural": {
-    "buffer": "2d25ee349822cadc75d486ecded1143eb150181ea164660c6acf5891bf237a79",
+    "buffer": "f9e50e1e5785772174c831a749e63d8fd97241d8adc4c4c277687ab29d1470e6",
     "changes": "8aed1ff66ac41ecf3cd032a93ea4089d8288462b06202534dfc1b8e9dde200dd"
   },
   "notes/s/churn": {
-    "buffer": "98c00a57f1e6ad18486e1b2b00aa97b416a33a847d44f15d4826ef505bf4318a",
+    "buffer": "bab86e7acc8625739d6ca440259de9b7a56b00e74402897553ecb229480005db",
     "changes": "e12970f57ab2fa22a9dc4beb59b722a9d5db2a9abb3b6d0df4d6a427d61a912d"
   },
   "notes/s/everywhere": {
-    "buffer": "bc95f3083fee2e83a8982998c9eaefe1ceb5b913f5ab61a68d5c9c696eb03ce8",
+    "buffer": "129840f5e24f6def5b5e06fb41a08f424c352d581918855f58cf489bfaf056c1",
     "changes": "63082bfeb8f62ca447a94be36648e4478e0490f482100914bd2cc8e907f6518d"
   },
   "notes/s/heavy": {
-    "buffer": "5e23250f2c36627ad5af25679ecd6c8c6bba2e16baaf22bcf3f2e33a10fe9452",
+    "buffer": "c93fd651b7bf3e60011d440b2820a20b410894f5242ad1437ea56da7208dc124",
     "changes": "c90258a012e876f9877ada73e9b632dc8b5385cadc470379a20dfb7e42eb6564"
   },
   "notes/s/identical": {
@@ -436,31 +436,31 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "notes/s/light": {
-    "buffer": "2156a09e999431fc99113e9cc5464d58bbb3d77abb4f11b3d73c3f2384eed415",
+    "buffer": "fce364a693038e999bbdcd3971d1ef32e55eab16302ac475ad304820653e8fc8",
     "changes": "74ddf0136f7c04d764bfc19ef9da3625808035192852378e191f9daca7d3c83b"
   },
   "notes/s/notes": {
-    "buffer": "5b64997ecb6c591bb306eb8690ce82d128a17276882c841bd6293e83298b167a",
+    "buffer": "17d534eeab89a9d53b76b2cfff7aab7fcb522f00f37854f1bdc43b49673856c9",
     "changes": "17953a14335bf912b9e7b5d63b12e5ca560c6a591998ee8f449ce1a49dfb99f1"
   },
   "notes/s/reorder": {
-    "buffer": "616e282a6c9571e3ebdf0c9033141f05865d3fc842fcb6986b0f5eadfede517b",
+    "buffer": "fcc102da82ad61f692ec91cd6d851fb0b5edc8644ee27b9725b1737f130fe5fd",
     "changes": "12ef276c9a5b33e1084bf9dde9721d90f94074e6551033ee3bbe67b3eaa7c3ee"
   },
   "notes/s/rewrite": {
-    "buffer": "17db24d21da345d89a0c6e7271b34cd2320f59f601f90698080ea0c489889a3a",
+    "buffer": "804ad3e6626d682ef13a29872e6d2a5b323675ebd968cab274dbb824916925ab",
     "changes": "04189a0a2f1983874989d11a4b082921dece36ed461fdb21512aad392716d6e1"
   },
   "notes/s/structural": {
-    "buffer": "77fad06a9bc797cee4b41ed0edc1cfc009a9dd1485888606ec7bff679fb98053",
+    "buffer": "70bd3c71ef1eac80cbd2dfb8011c5f5a7f9a84851597cef77aad7ff9d5c31363",
     "changes": "07bfecf0b870f113431dc62a6d5402a9fcdf0c465e107ef6c46e8ff42647a891"
   },
   "prose/l/churn": {
-    "buffer": "50ca7e7289dfacd9c43d661f2196c29dcccf76f9e782083720d3fe49b86b6e7f",
+    "buffer": "f276952b1172e7709af223ac023574614e3ddc92e39dff7e7b2f80b982c73ce4",
     "changes": "233d3ee8d9a256b35880fc5690ff60a6d778bb4b94ef5a1d00d87e6720a0812e"
   },
   "prose/l/heavy": {
-    "buffer": "ff12a988262c5ad309e6ef43ce657b2ef80b6d11ce73302826cc20ad39e1b219",
+    "buffer": "dd47036faa6d0bf6cc0bdfd27ad01ac8dd3a4718fbc69fe7bbe8f3187e49b80a",
     "changes": "07ae005019ec4858e9cf8ac3bf55d6cfeaa98b5074eeb18ea57d9e8d101ebf2f"
   },
   "prose/l/identical": {
@@ -468,27 +468,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "prose/l/light": {
-    "buffer": "9ea308bed4d91778953925c2c26bfb9db5bacc11b9473e71a75d8ec3d2d51ef4",
+    "buffer": "281a86adea8228e127038a3f412f98b2df3b26ded5e4d0e9478deb19fddf9ac3",
     "changes": "519b38d80ee1efc7c281fbc6cb4bd8d7e8b32c479addcf83f89c03b412d94a4a"
   },
   "prose/l/reorder": {
-    "buffer": "d024320bbb754e7b985647fb15ea0fa132ae7a59f9551ca96a1991b7e4ed0af3",
+    "buffer": "20fb0eb86dd700df95c3b2974172add8483b0426e186148278d428e5d8e5c49f",
     "changes": "e7cbd1e7b8df9351d962be192a037e4f503131ce49a0eddf23d7d7fe798e56b5"
   },
   "prose/l/rewrite": {
-    "buffer": "6cef271b15d30a5ebcccc5280382e7bd7c1a0cf4031684bba7023b281d9f3666",
+    "buffer": "eac88cd61a2a6bfac66cbab5cef26662cb5276b788809cb49fe3b30012b5f04c",
     "changes": "794845c60425e90d1547dcdc4464776c56f455f88749088c74ad8170dc4acc8d"
   },
   "prose/l/structural": {
-    "buffer": "07a48492d0d6d11f8e7f06e73269228f6be63c3cda12396e3d82a89a109af5e7",
+    "buffer": "d2012576830cedb5dae270dceda3472477d08c7f4fd95d4af864f4bc5da62bbe",
     "changes": "8d8beac6524112a1095ee85f99ba8e5dec1042f1a84156b4601c1c3dd22d71e4"
   },
   "prose/m/churn": {
-    "buffer": "59cedf47d63bc0c01d9756f42e83e805896940063e809a40454e86127020b316",
+    "buffer": "ad2e0392afe0487e7b1bb9d13836686da35bd3a70990928d9059625566114911",
     "changes": "e2977575ba28ee073cb3389f4a4e8b55af73e2b3050fd535ea651af52070fc6d"
   },
   "prose/m/heavy": {
-    "buffer": "abc7801504f5f8b6f0515fa1fb64187aeb33405296a24a05f7cb2cba4e85716d",
+    "buffer": "bf107c26d8a715e4a742d5218a4e436fe6588276f6a4180695143bf9bf9590cb",
     "changes": "e623e75f9f79d92a625c9161b64be9130a38ba842bf85d137333ff2e355396ba"
   },
   "prose/m/identical": {
@@ -496,27 +496,27 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "prose/m/light": {
-    "buffer": "1ad1b4be9e9d573d0333d233a93cd651b8ea10f1716af1fbb33462d93d586418",
+    "buffer": "7ab2a6635804f2f08b6044c090fbaf002eaf21347b93d1652f02a3f2cf2f760e",
     "changes": "319532f55269786d865f3ac508dfa069bbd017640678207d630fd1d19df6a571"
   },
   "prose/m/reorder": {
-    "buffer": "70ba5a49067f4b73f70f4f129e51289a2c56639439616e6364a502a498f2f6a7",
+    "buffer": "89ab1ea8e96d0aa925717d3fa334213b2b7392cc72e3400541cc985c75a7be00",
     "changes": "2970d10fddea492c79c0c3f36beb269f01d1759af4897a72a8c3c8fba3b8ba1e"
   },
   "prose/m/rewrite": {
-    "buffer": "73c08534f3eadfb51a6d76f7f6ce4e28dccb51ce70a8eb87fbc8e07ede09bce0",
+    "buffer": "25134914676572aa63e679bd32cba05aeb1282ea8348f38d0975f619586b73c9",
     "changes": "f21907120f955d0f551c2759425bc26820c508960d765a3a681ee2a4c3b9c3f0"
   },
   "prose/m/structural": {
-    "buffer": "12509bdbd289ef0227089c5ee7caa5e753ccfa740b0ba1349d1432f9cb7730d6",
+    "buffer": "f05d275438534bea33854716223e430af0b399e37901b70ce900b308888edbec",
     "changes": "11f106933225a87f59afd63d888924588635a7baab0f48548c29cd42e37c96e6"
   },
   "prose/s/churn": {
-    "buffer": "e01c6aaa3cf3bb6c0901ccde80a85c24bb52bd8f3b161b6a4d53ef0761f2b121",
+    "buffer": "ce953e7f92673fbcdad7bf45cb423e96fae323df9d752141a5a614d30336b7cf",
     "changes": "9fdd7a4e4393977c02edcf6b6f83dccef394e0dc6e96f1d4dd72843337fe0dbe"
   },
   "prose/s/heavy": {
-    "buffer": "f7aa9c3143d96a4302aea61219c5010c8774396708f4225e75c560e43aa32d53",
+    "buffer": "d44fa117223daa88c7c3a5d9692674cae50e5c44270921d95922903ea67977ee",
     "changes": "d393f64a600012f65aac74626c765e9341c42a07b4726bea5b7957b34f1f3d9b"
   },
   "prose/s/identical": {
@@ -524,119 +524,119 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "prose/s/light": {
-    "buffer": "1bd69de9d13b498974491281bde682b74184c87477865117505a3667688c960b",
+    "buffer": "a3e84c827b7315b9ba20cc755beac2726d7b3a8e0fce00c99ec16d7b4a51f4a8",
     "changes": "a894ca2ebbcc806035ef3a84c77f275aa287a652b0d925ba79d5d60a743bc235"
   },
   "prose/s/reorder": {
-    "buffer": "0c026a0920cfce0b7273dac41d248e66383242af8bcc2747474c26a459349be8",
+    "buffer": "9eb1a81d2cdcd7dc94703d646325011e592e03735063c638802ecc4f7358ee7a",
     "changes": "e9bb627e0f3aad4fb5486841e4dc3fec42121607dc30c6e932ede56382e6422d"
   },
   "prose/s/rewrite": {
-    "buffer": "7c5acb4e06fc24edff9563f5b6fc6db055676eb280df5fdb705972e526f6d6c3",
+    "buffer": "cd74237b8e1591d4ad5ea0b0827d29d8227ba973f3dc5d99b7c68ad117432b95",
     "changes": "0f2caf9532a9d30477357847b8c21588b189e1bc34e74bc4e3535e3c409db3ee"
   },
   "prose/s/structural": {
-    "buffer": "751f24aaee65c59bfa6ec7c170ce99cef390b995c215fc7eb7eca00233c4e929",
+    "buffer": "eb2016c67afef167a4e0e65631b654e110d096a14aaf6145a4bf61e2221deeb5",
     "changes": "a966546d9cff5723a64cb382431fe9bd0ca10dfbbb4705c74d5c1218fcc5102b"
   },
   "revised/l/churn": {
-    "buffer": "55a72712d81a05fca905974520184012dec10842a727c67427314c1db7649cf5",
+    "buffer": "344f7a0939dccc03cba7580a9f1e5946ec37c6af812b5ebaf16d1d45b6d31332",
     "changes": "4334478e4c1b8d9ad52aeb851ff23e5efcc3aecdd1c1f78b8a3118df81f1e9c5"
   },
   "revised/l/heavy": {
-    "buffer": "6506825179d78653d89839dc5f7ee5c642f49e9bb77f2eed44791a4dff4e462e",
+    "buffer": "5de8e8388a87cf86d70acccf160636bd4a6d60ab58206b55e3449f3d21b0cf9c",
     "changes": "480f76727750c72f2b6cca8b5c7bb13d5ae6c86925eb3c49a42d010482b5ae1a"
   },
   "revised/l/identical": {
-    "buffer": "171645c91de2036577135b0087694de00acca1d5b004653cbbaed45a81883af6",
+    "buffer": "4dbecd044e42c8d7c0b85a309f099fcfbe7539e6e900d4d6bfed137998e661f4",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "revised/l/light": {
-    "buffer": "65417627b829457737fafbb60ae5136f4a91721224cace39f67cef0f7be5e26f",
+    "buffer": "8e6932dc9f969cdb275048a9fea8014c8780fd77b6f0429fea7871ed8a384047",
     "changes": "aa3fc2be3f7e9e5f91d8c4920845e20f5e0d2c2d50b07f0d67d276844387a3ae"
   },
   "revised/l/reorder": {
-    "buffer": "508a8c343a12ce457536a9f9e0ff3cd58f1a20721e4f84524b4418d2e1c032dd",
+    "buffer": "fd6a807c3dd032472c16164a4c333118467ca3dcc11cfe8ec679748d9b803d46",
     "changes": "842f0aae6644aa5f943dafdcf8df70bde9eb425c045fd73884708cf5447d40e9"
   },
   "revised/l/rewrite": {
-    "buffer": "aa8d451e3efe26f0303a57933d3539bf5bde89ed2e04d1425fc33eacb74a0eca",
+    "buffer": "b4e6ce70208ab7a3acd3b08518f57b900c02324c6a4ce645481acc115ced10bf",
     "changes": "5a387649671d6f7812bcaef6079ebbc2b44bfe25d051cc9885041db2a6397aed"
   },
   "revised/l/structural": {
-    "buffer": "b21c48992de2dde4d21ba103bc69df096817e3f23974062494ff2edfbc05fd68",
+    "buffer": "3e7d41156e9d6d96d7e4ebd31de1846a519f1cf0dfd618bfd14f58775d1974a6",
     "changes": "33c6cb2e9c066af1b0dd0366670a3930f3d761586a4b0e5d8a84be04e2db0c24"
   },
   "revised/m/churn": {
-    "buffer": "fb6178800e8c24f5fecaf74e39b03b0073faa38cac5669ca32152785c0ac7282",
+    "buffer": "ccc62e244021e4c73bc9a494f1ecf1a064cfe1e104de17dc851e1a1fc4e4ec29",
     "changes": "22c1dd3adbafebc7af215adec9dbafd950c1378e8c0c740b2f8172d573ad7639"
   },
   "revised/m/heavy": {
-    "buffer": "f0ec0a714ad248d9092876900f1804c30b4c3f9d8caf9f543393673d06ded9ad",
+    "buffer": "c8bbfd2fadccff8fc609c9754692ef79ba44b7a4a93690abf15ade26a26542d0",
     "changes": "a19f7cb12f52033d3b3bdb26e042183f1dfbf5b45bbb30f00b9a9eb37f2cf540"
   },
   "revised/m/identical": {
-    "buffer": "f981e4111c4f8f8838b2e47a0f8aac8116fb30d7b5a2ee32b53a52691e53060a",
+    "buffer": "f7018e9ce04967937f05808d4ecbb4290707aa4236e93f602dc63ddefaffc9d0",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "revised/m/light": {
-    "buffer": "68f79ae3066e7ab7a9e66343cfb8b518e13c58a8109c16af24d193e89526920d",
+    "buffer": "6c00fbdf7b5296fbc54b7458bc284f74abbd87e5bbed6f79af07a526ea5b41e7",
     "changes": "acdd58580c0daf4073ed9038a49f12487c7cafe1fce5de6ddc2257e6de0d0281"
   },
   "revised/m/reorder": {
-    "buffer": "3d80cb5787f3c4c59815b414218b9eb327765f036aac7f586f921d2a92f29995",
+    "buffer": "fdf48d252bcfd5df94b87e3b276e0feab8a1ee8b08deb6d32578c68848da14dc",
     "changes": "d8c69824080968383ac708bd4e125e362136b3f8177b61c9f59eaa6342006ce2"
   },
   "revised/m/rewrite": {
-    "buffer": "c10e3ea5c78d403cf49eaed2c678a7e39a78896675e374d4844cba0db3a01cc4",
+    "buffer": "33af7215d01e5ab995231737aef0c4402feca7ca569362223c141e564adb98bf",
     "changes": "e984445df70a8673a45aebc192f0b8f34d074eb678c9bedbd3a399aea626dde2"
   },
   "revised/m/structural": {
-    "buffer": "7c9cefe513f9cb4f7f31622e07c363de6abf08236ce531eed4c037d47e44362c",
+    "buffer": "076fcc310f9892c472b00f2924d6b84bb761ef338895101a2c877f0ce5739abe",
     "changes": "2b77b79047def70666ce38c0cc711fc8711565e0d38d6942838b1934590d92b4"
   },
   "revised/s/churn": {
-    "buffer": "4352c8167a9a94e074e6feef0605ade47136a6ed13b1e9b2105ee0ad52279e61",
+    "buffer": "f51be84318800706d0c391d3dd895832442ba48e8b90d381d9cac79625c1b530",
     "changes": "242000d40e0e70f53d30a7086d17ffd774b0633343b33330f88ee17319468285"
   },
   "revised/s/heavy": {
-    "buffer": "11bc4ef4899b5cbc20405f6f7a92e0b0253f00843c420edb9a9deae66ac40a76",
+    "buffer": "22326eb6c1394b6aa7a43cf46ac50d470734494f58a72502ccd43656c89788b6",
     "changes": "687887f7d712f5ac4b76a11b8eae60625539299275630fbb7cfef55aa2a6a096"
   },
   "revised/s/identical": {
-    "buffer": "99755c6de58b2cbef5373d5b0335d65f973c25b165155f4e593111276f5ce4db",
+    "buffer": "b96ec7873f7d1545201ab0abf0d0751b691fa40c49ed0deef909f6afdc3291b7",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "revised/s/light": {
-    "buffer": "59f0c37c415b96de5fa5cdaad2c3419f9e6e22d2d87e97244e9c3ec2d58de6f8",
+    "buffer": "0d2d3366b0cc19b6f44b6ce58f4bf85b79241e30b2cfcf3bb71d0aa6879279e5",
     "changes": "51305d8b3f1f45e6e052cc26106d30982729b8889f7cb9e0a4e13c21d88d4692"
   },
   "revised/s/reorder": {
-    "buffer": "117d9aaec13137f403807f2eab6895e078f00669f64b7850b5fee0406d0844d2",
+    "buffer": "7d055fd0bce467d35de136786a8cdef4ea0bf975035f4933eac9def4c73172c5",
     "changes": "ee9607cc23fcc29b8cf1b29c47924bc4ca75cdc2ac35185254fd04387481e6b1"
   },
   "revised/s/rewrite": {
-    "buffer": "1c71e7a85fd2f5675631c080ae58b78ce98c87e0ada3fc6d3842730ec8ada778",
+    "buffer": "31b0b37a00a8a5c9b99bb7e48a7be7794ac83f3903c2d91ca86c4ab831c7b4fb",
     "changes": "e4082fff909f5af4f5725fdce58e8c2848ae3d78c86f9234597f448ff7a62ebd"
   },
   "revised/s/structural": {
-    "buffer": "1185bdd2121c419fc9e5aace576b211349ed6579f6712c48ebaa4af7adc3f2a7",
+    "buffer": "264f9ab14a0083ffaba26a9f994f448829eaabdf49072789f2d791462ce1381b",
     "changes": "175e2d69ab6b0e40acef50c7773d5be6cbd9118b02c8b1ea157bbc2bfa680dba"
   },
   "sections/l/churn": {
-    "buffer": "d444b91c1324f9eddce211d5cf5f096de8d68fa38bba66e5eaa18a8f305a3b67",
+    "buffer": "6dda2ee3d43b1cf1cdf5266ffef68d69f0e50dfe2502d077a012340a577ad9e2",
     "changes": "4936ba56de6d956af0095332d87879841f0306e119a3f92959c7c2013977a39e"
   },
   "sections/l/everywhere": {
-    "buffer": "a7f4beddb19c197eb7a9bda2b44c7dcc91a4ba5ea8eb449e27a3ff1936c4158f",
+    "buffer": "27c950fbeafe051cb36a1efd7cbb0ed30edc39edc4db5cbbd10e60a68b3834ca",
     "changes": "f1297feefa6c19cfd213deb1adf8b3a042242fa5a3384d250668807610518715"
   },
   "sections/l/headers": {
-    "buffer": "afeb3350554a23c7d1ebdb3f55162ba9be1d0003c0e51212cbb0d90a06cb7c47",
+    "buffer": "8fbeed9d862089b66517f10e62c396c5b436cc3d0c974b660be7dfff4d56c3e7",
     "changes": "27be325b4d66b41ffdb793ef2cd3ba48e15a6cff68d8031c9f9552918096932e"
   },
   "sections/l/heavy": {
-    "buffer": "6694c2a51bc7df0cecb3f10d539bc6a875d6e9dc3f29386b1986d41712f73ff5",
+    "buffer": "bd4832201cb1a3e7b06707e0cdec6c2ec89b61f77a9134df8641cb2ea9b7e31b",
     "changes": "6a04e770baed5df33ca1a3eff408b63808b739e918d6e7c0bf92604f5899673b"
   },
   "sections/l/identical": {
@@ -644,35 +644,35 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "sections/l/light": {
-    "buffer": "5068f65324ba8dfdf06698a5d14cc2dedb8bd548b7894b2914132bfdb3f8e678",
+    "buffer": "e21643f51a75844a82f7312908aef2b2937c21cc75129f019047d606398a6286",
     "changes": "e9a9c885a19c25f57bda9b4c36a44d0778d1ae23c96a81760d877e284f448dc7"
   },
   "sections/l/reorder": {
-    "buffer": "183b0a407fef8c08d022d0948722e784f543092b1a731be44592c15735b8def8",
+    "buffer": "87ab34b08c0a5ea4d098aba57d57f9ca1c72cb64d0acc7a525fc9a02ad8564bf",
     "changes": "931bce4969d3af413fc9b05b4cf019840d8f88d7fc5ff39e4f05eb4e9f3d0c28"
   },
   "sections/l/rewrite": {
-    "buffer": "094e432e75b80ff3b15c7f59e5927b56c16a06a7b74a8640c75c68c6c9f01d29",
+    "buffer": "ac4980a21dde673c43b599f4ac474934398b5a17ff3fe490dd4e18de799a1e8e",
     "changes": "ed56a3e9f2d9edb098040462cd2af68ea7e87174767385583916faf7f70df4d6"
   },
   "sections/l/structural": {
-    "buffer": "af1378196c455a0c7ddd33429176e9b170fe8332d5aa93f6a327b879ca61d67d",
+    "buffer": "888ed61f32cf4cd9f8330f0c54aa9263afa291792bce12ac7a918fbdc84d4db1",
     "changes": "a905962916a112fd5bf95e4cddac26406c58959a8e6689b5b07a2901194b5b89"
   },
   "sections/m/churn": {
-    "buffer": "6b564020157df4bf756a1c22e2cec58eb37600f1885a154d9240e4882f16a6bb",
+    "buffer": "061314c80404e88a0d10f6fde495059ad433d17b6901089d45759a8c0667bc1d",
     "changes": "f88c4e72810b9aa37c3c9a501301d24365a5f2e592387b48275bf23146464151"
   },
   "sections/m/everywhere": {
-    "buffer": "ccfeda45f4dec1060b761f2fa09ac4fdb50fa52bf38e24c02ad5ec7eed8a77e5",
+    "buffer": "8e613a87ac3b7413780ddd50912dac09cef1523b21594ccb275ccd78664b86c0",
     "changes": "215463c8272bb3c04de6cab04aa644dde784c5b46e3c58e0886e27ae9096915a"
   },
   "sections/m/headers": {
-    "buffer": "1da138b69a24c7e2189683f74fefecbb8a81c01e76487142577436520e08a411",
+    "buffer": "f3c18eedf9ba543484bdaa52f3aab63d16567bcf94e1a664f575b0feaeddf09f",
     "changes": "27be325b4d66b41ffdb793ef2cd3ba48e15a6cff68d8031c9f9552918096932e"
   },
   "sections/m/heavy": {
-    "buffer": "eae2568cb0a4e61f1916110da9f4f9843a89b52b85d1da7eeba80532ecdd61e2",
+    "buffer": "de01af90ac08064c46b21f953dd3e548f0813f656a1b17e4848c0e93358ba171",
     "changes": "647b8c6beeeb5ab1ae9b6d90c5a5a226a499d114f4482b0c5737b82fe40e1537"
   },
   "sections/m/identical": {
@@ -680,35 +680,35 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "sections/m/light": {
-    "buffer": "04996b0bca863fc365afc03e62046142c43a4bc252d3e024c2000a6fdea9a55e",
+    "buffer": "303d70fc5f2f8a2e500b5dd8cc931a09b46ce2830f86ba6e5962b7dc6baa18b6",
     "changes": "a58f655a9b284b870a749643bdfd4bcd6e1b86fa8f17a58777a3c6ad57b92110"
   },
   "sections/m/reorder": {
-    "buffer": "1ba7537b4f7b231783a76eeb224e820dceedd26b921f496e2ba428b7085efa40",
+    "buffer": "f90f52f1416c6d5b22c86f2c60eed334911029f8e31f40b371230d3ee712a5a6",
     "changes": "6b165c93bd68ee00747f89f15023ab12f71f6afd8b76d3436445d5a6be90d717"
   },
   "sections/m/rewrite": {
-    "buffer": "4828b18d559b22b05a97086794946fb0de9c0515ebb8dbaa373cee8e61f212f0",
+    "buffer": "f9d9a7ac0a2ccaa14f12bf4d90821c3a05583a4553e56aa713749c2661159263",
     "changes": "cfe0b043cf17d97bac892ebeae37027a7f47ca820eb187ccf63937a01486756d"
   },
   "sections/m/structural": {
-    "buffer": "ffbdf320e1dacb5f3c060016886c10b92c9df1d116e0bdcb39b7088de45e3e4b",
+    "buffer": "bb6f7defd43e61f4db7807d149d9bbf368b425917d55931c4ce92258819f7c9f",
     "changes": "ea65b1878ca292fd0ae55808dd1cb437a1da2e9690b50a676caa03d06b5a9775"
   },
   "sections/s/churn": {
-    "buffer": "b02e64396474d1f7bbe3fe434bcaffc313d07529b2e386d50ac5f21b69435130",
+    "buffer": "6b8d53a1451cf6fb1f16d67715cc9d29e0b25f983f9ddef99ab59be657ae369c",
     "changes": "3fd37a0fcd6fc81195c18e677abde2e72ea7504cb12ab21e86fc6b6ad1a56467"
   },
   "sections/s/everywhere": {
-    "buffer": "8fc2e1c357adeebc294e3ac02c27fd05568ad8d1c4513f3fd7a09d77c508e672",
+    "buffer": "44c338e14b8c8a316812bbdee7223650c4adf253286b171622207122c30bd6ad",
     "changes": "0d74b0276525b7baf2121c08654589ff150d4920cef9bb2aa31757f21bf4d853"
   },
   "sections/s/headers": {
-    "buffer": "463477db3e7386f2402c46f95991bbc0774adb0c04cfbfbf5bf345f0b67f830c",
+    "buffer": "ce56b6fa3cce8394aac17b2608fb444804703510401a7f961f9c9586a681d96e",
     "changes": "27be325b4d66b41ffdb793ef2cd3ba48e15a6cff68d8031c9f9552918096932e"
   },
   "sections/s/heavy": {
-    "buffer": "8f2d901db62d3e1ec3b630247dd746c4f9da7a9ae60a7b6c5357203e2bc2fb92",
+    "buffer": "b8e7397eebcba52ade6a881336843e8dd470f0eddf6791f806b037a1c7851841",
     "changes": "1385382d119cc9c481d018ee59954be66d7b3c7d47ae3e9ff5d790fe3b12be82"
   },
   "sections/s/identical": {
@@ -716,115 +716,115 @@
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "sections/s/light": {
-    "buffer": "fa1a118fd853e9003e03a4d6e4eb7b7aac20723d0cd8c9939328de2a687eca00",
+    "buffer": "88c63dfbf6b0b2ea4685e7f1770e57d3a18c49c71e635f975af17805b2876072",
     "changes": "a25412306510cd5d5cfccedf72d203f2dc7964299ff81c5686e8af597a188d66"
   },
   "sections/s/reorder": {
-    "buffer": "4dd5fd5a426a39e0c9b8e49d6f57b90f7b344e133125e0093ee1b297a345a7e9",
+    "buffer": "fd18d38f8609fa9b1e898ca3d5f89cc7ffd0853e815fdfb493f69cdfc060a73c",
     "changes": "a3a8c2d28d89e445fe2e89669682922098b2925d833985af4b6d88e18f3fd15f"
   },
   "sections/s/rewrite": {
-    "buffer": "2e096f4f59beae54e93e34f2a5d894fd56b11f913a2aee28cfc5583a16371c13",
+    "buffer": "2bdf94f4feda8183c288ab01b23a99e8e70a74f331b00dbe575331e9cc00abd4",
     "changes": "fb46580d321a6babdafcb8230b80efc07dbee4a252ecc7f07b030fb6327a021a"
   },
   "sections/s/structural": {
-    "buffer": "aff13484b01a14ca87d73b3224e3e78e9997321f00d042c9a759741c471b69b1",
+    "buffer": "161a2819c58ac4a4f469be37c03eed6968d83500e40ff70a3110e64378e6e292",
     "changes": "f607fa2b5fee2ce4cf85dd41814fee63dc8c9f1b5658592d36679b925b9d994e"
   },
   "tables/l/churn": {
-    "buffer": "b806d7863b8d7ada4ad0090052d43941000b95a166e8edc683363eca3ca49093",
+    "buffer": "e44cc3f7260b012e151363e28ffc4c7f919e1dd7614f1baaeb321703dc911491",
     "changes": "abc65d411d978a194d2680c4c6fc7ba2e949039711529342906ecb43579a4ea0"
   },
   "tables/l/heavy": {
-    "buffer": "eedf874809f1cca0299368600d590bb45aa5a0145317e7c57ed29aff86a84116",
-    "changes": "de86966a971c75aa615488091250cb874b4f4be02f405ad0dabd15ad2bd3e2d3"
+    "buffer": "693f4926216b511ed26fa054f4e961cefae75351b47fa54a2cd434399e6a72db",
+    "changes": "2ed6710528b8e35a5c0faecee1da9d9e3c554b92837e4de4297f2d91d9d826a3"
   },
   "tables/l/identical": {
     "buffer": "1d164280ed55f5c3a0b89e4ea80eb504a0df9e68abd1df9d4e6899d84fd39c7d",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "tables/l/light": {
-    "buffer": "ef3e08715332fc464d332bbb8b424b10fa2f5877c2a55f2e59c72a7b0c483697",
-    "changes": "3e8bc914c629c5d25ac0153ad551ca666bc46e776404205b5cc86acdde3cbc5b"
+    "buffer": "499f0b1903d648a8690d42da64b976a4311a58e805708c358ed12e67953449e0",
+    "changes": "201bc217cfa7edf07466a278adedb1ac6234b5dc8801c5003742ed5684801039"
   },
   "tables/l/reorder": {
-    "buffer": "6f55c4ce0ca2d24b8f27d701b76a1ead8907320ddf44cd40fcce1f2c19400223",
+    "buffer": "67a6a1abd7cff38f885579b85158d2cd146b40d91585bea8fa4726dafd6dadb8",
     "changes": "78787198e8e340ef5269c9611f4d24d20d0039d1b5d9c842e4ecaa5d8b6afee6"
   },
   "tables/l/rewrite": {
-    "buffer": "6c2ba4ea92d518befc7a24c939244c79ab4188d3a8871d273426f8c3d5f25c19",
-    "changes": "f9b0a9dd3dff43b4472ed81e776edacfb5799ca7aea3f4375aa0bea1517b6745"
+    "buffer": "bfb056e967f5e6a7763bdde2f6110f98ef5d876c1819989d7808e797624a257c",
+    "changes": "0fd77d18db7dd0f340eeacfc3b6239bc1262c79faa0014427d58e2bebeac6660"
   },
   "tables/l/structural": {
-    "buffer": "3070c463b6e4213667968073bc4bdf9eda38a294e7b4beeb5f241951218d01dc",
-    "changes": "887480d080be05d0f418cde69e371686e918e90deee4c23dc025d7045b7896e8"
+    "buffer": "efe6b6b91da53063b024b80c0b9a971677d16cc089c337dbef20895b26012b2f",
+    "changes": "165823e2765948d1c58dc2b36c737e4d5ec37bc5b30bd7a2aa9ed7060290548c"
   },
   "tables/l/tablecount": {
-    "buffer": "ab5ecb589960acac70ef83fe925364d381bae5a375dda53563a04c27d9ffe6f1",
-    "changes": "7a5b9678aa325144b20236d6e63d6398e8d0cacb7eac90eae2df8f1403b894bf"
+    "buffer": "cbd44c66e03c551ca34cf7974b1ac8c8b4f73335a60001d29efcd0ede432356b",
+    "changes": "e67d78223d7db2fb9c74724c25b707114868246f9f6ad41f7b0b763a38cf92d3"
   },
   "tables/m/churn": {
-    "buffer": "95e1656768a4626fbcfea319ed3016a784f09f6f0061b520bf72337dd94d097a",
+    "buffer": "8e76e0825caf441ae1f09c4bfbef5fec0d866434ffe1eede3b5a352092963c98",
     "changes": "652352e4748de4f720fc62c6c4c4e820b3277b5cfbd5f34e941ac28f231206f3"
   },
   "tables/m/heavy": {
-    "buffer": "df2892de9ae9688fc19d6facfac5bc8d68d76bed26b010054ddfaf5be7b506f0",
-    "changes": "c0594fbc0f0aeec535c097874b99833d7fe4a0b6e36174f525bed505dabf41b1"
+    "buffer": "9cffaa8e75430d15c861ed51ec2b43b82c8f164bf08f51392e451cd299b427df",
+    "changes": "8e1ba50657d4b47e43693ef85e76ec3bcedaefd0050ed4e1370eec602251759e"
   },
   "tables/m/identical": {
     "buffer": "09de3e600bda4d7eebf070c2aa4a6f424a3661dc2905aef94c3662e3f8ce8b85",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "tables/m/light": {
-    "buffer": "3ace2672f18430921c18090bece8946344f38b73c5cd815d0d3ff725c56ace67",
-    "changes": "36a065a2ed2429f9844f30a4df7b0f7dbf16c8836281f65301b7c4cf0d61cc8c"
+    "buffer": "15adfa854b1e01c8bb8858032ccd6dc9af46e2dcec004100afdd21d4b5758c84",
+    "changes": "95bcac2d020cd47fb3aea9b4a4b3c2748aebab15b23b0902f266ad92602a057d"
   },
   "tables/m/reorder": {
-    "buffer": "250592a51467309b089420d7998e4a59fdb2636ddf118aac16800863ad5a1efc",
+    "buffer": "617875e23073da0ba8e75281cd079ee96198b3f493d04ad5ec2e83610c0ce27b",
     "changes": "8a363d3232c0acaf0aef98d57fcf6137490e96a80f348ee2f59c5093e242558d"
   },
   "tables/m/rewrite": {
-    "buffer": "26a7e5994c779c8ad0475a894f37efd04eee2035d32079ca406d1748501454a8",
-    "changes": "0012a833e4206634e1f6d6657a2c7a181e71efb8195fe947231df33dcfce46f3"
+    "buffer": "0f820185b0d75845c732820e2b8158b50aacc2b0998dd60204543abf28c2f606",
+    "changes": "5a3fbb621dda7f4730348b1daaf72eebd72bf268300791d45479858681167f99"
   },
   "tables/m/structural": {
-    "buffer": "b3fa623d97b20c26c86547d6baacc629f25082e13e74bbb3d97405ebac070322",
-    "changes": "b0da7e59c153b8a827a698c687d2da04ed6070c27eb868f2230061acfb4e1f71"
+    "buffer": "b22ed233331f62a72a44989a808261e731374ad03f952527df42f52ffeb0f8de",
+    "changes": "87f228e43a83e6a6f9847d45f8a49682b1dbfe2c8f41f42abbe046f7c77b5113"
   },
   "tables/m/tablecount": {
-    "buffer": "4198cb8623f0c1eeaebacd238ba9d65ce323957c94b80adeaf944f6528631a98",
-    "changes": "41593ccc943a24045bf07ef077d6b48e92aa40bc7fa16bb13682339681b3cd42"
+    "buffer": "309fb61373f1138214fd88ebb11b4dba37815ace994e2924a46b79f623ff7464",
+    "changes": "abf3368f2bc1480dd03f6d82ee02301902d100bb68dd4ce9fa21fb2df360a918"
   },
   "tables/s/churn": {
-    "buffer": "41eab46e8b1becef5be399a71698e1913eb07098555a1f4111fca80204fae6c6",
+    "buffer": "d123ec06fbc7cd45da16cf7f5ac95253856ce13324415e5fd2acc611f783eb73",
     "changes": "bb39f4d2cbc540a89b75b1027460fcbad3b7d120affa6476a22c0c9a302fe290"
   },
   "tables/s/heavy": {
-    "buffer": "90c207995695b3ee813bfb1d3f52d46194045c6c6104943b525473b14385b1dc",
-    "changes": "45b89ff808f0e203814b4e97ca85cc3038ae673e5eb7ba11cf8989ba8c332e62"
+    "buffer": "27c7dce76f30f4d42f06656900fcf1b973604e3792afdfb6175f959b12a0469a",
+    "changes": "5a94e602eff094a753453b137620b3b058e396f506d1859887fe76f6201dd77e"
   },
   "tables/s/identical": {
     "buffer": "3f1a3a0605f967da3c9952e4987f6a039f7d924ce754052449df55d32e24ca69",
     "changes": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   },
   "tables/s/light": {
-    "buffer": "6f205386525df5eb5631f0374df7db4986075db656d55f87627fa7ec5e4a6ab4",
-    "changes": "57453737ee5a3007a610c1c0ee53f533524b57d8826f0cfc87a74e2127cd17d8"
+    "buffer": "1e2743a8582f928a38404502031aec6ebddaa57d2bb0ad8a52af620c56941a7b",
+    "changes": "95a2af90c788c46c5b41e0b702d03bd801a949c4373f2ae1bc1d7dc0a9fc87dc"
   },
   "tables/s/reorder": {
-    "buffer": "84ca36c44bf3cff415fe84edb81a63669c4f723aa5dc9695abab3c19c79e7a6d",
+    "buffer": "fdef1f3dc1120fdd4f65bebae38c88df55fb9f49cdc8d5c59c3e7581b4900682",
     "changes": "3a986a4fbc570d0f56640e9e71a44853f0bdac0a42f1dc2e68f9e67bb5a2dbdf"
   },
   "tables/s/rewrite": {
-    "buffer": "b6a979fa960a2f9428e47d6f5add64cdb5754eacf17a43d3434e4e8eddaf6c8c",
-    "changes": "c0c5d5d764148195c04e13f8ebbe302062d3429bfe989ab349056f1e5f136312"
+    "buffer": "a79c4eb3a7b4d68ca8b2b65cef9e3c75806fb04db0432b0c2934d62314c2f24a",
+    "changes": "7ebb52f1204f3b38891736ab2cc76b89277e43796b229a3767d98936151e6557"
   },
   "tables/s/structural": {
-    "buffer": "d73aaabac70160e0da561acee3082fb0fdb33f73272aa95a7a442df217e99db5",
-    "changes": "e5c66d310a500c4ee7f9f0a9fad8ef1d08eee6b0489e492474c5e2aedbf1136d"
+    "buffer": "5ba17ef841d006fc28f5776fad9734e94272a40bffcade4ae8f2b0fa87746f42",
+    "changes": "55b5b7968b8d9b19516f784d7c9b5595f3e5de2d0856ed3b34e07a48446056ec"
   },
   "tables/s/tablecount": {
-    "buffer": "999bb58602523567b817c66f778aabba4d330253e1f057e7ada6caaef8b32bdd",
-    "changes": "8958499f48b56da1a6e43751cdbff7a26dc75d3eed6823413545c984832bc1df"
+    "buffer": "f0fc3b3dee960af7fad503a2fbcaa479dd4c7f6fe6d0b6fdb1e3d74d11fa0f0a",
+    "changes": "a7ac41b2de87a242b1cb72c537b806c62676be41603df14b9b4c07db5fee1b68"
   }
 }

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -295,6 +295,13 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
      * Delete the whole block. A block with words loses them and its paragraph
      * mark; a BLANK block has only a paragraph mark to lose, and loses it, so
      * the empty line goes away rather than the operation doing nothing.
+     *
+     * The block that ENDS its container is the exception, in both modes: a
+     * body, a cell, a header or footer, a note and a text box each end with a
+     * paragraph, and a deleted mark there would say "join with the paragraph
+     * after this one" where there is none. It loses its words and keeps its
+     * place. To remove it, delete the mark of the block BEFORE it, which
+     * merges forward into it.
      */
     | {
         id: string;

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -129,9 +129,13 @@ say it went.
   A paragraph's properties live on its mark, so the carrier's become the
   target's, written as `w:pPrChange` — that is bookkeeping for the merge and
   adds no entry to the change list, which says what it should say: the
-  paragraphs were removed. A carrier with no words to lose is not deleted at
-  all: the removal is entirely the marks in front of it, and an operation that
-  would write no revision is left out of the plan.
+  paragraphs were removed. "Its properties" means the ones the comparison
+  compares at all, the paragraph style and the list level; a property outside
+  that set is not read on either side, so the carrier keeps its own, and a
+  reader accepting the redline sees the carrier's alignment or spacing rather
+  than the surviving paragraph's. A carrier with no words to lose is not
+  deleted at all: the removal is entirely the marks in front of it, and an
+  operation that would write no revision is left out of the plan.
 - **Paragraphs ADDED where the removed ones were land in the carrier.** The
   last of them is written into it as inserted runs before its kept mark; the
   rest become inserted paragraphs, marks and all, in front of it. So

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Twelve labelled single mutations, one probe each.
+ * Labelled single mutations, one probe each.
  *
  * The property tests generate scripts and pin what must hold for all of them.
  * These pin the opposite thing: for one named edit a reviewer would recognize,

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -380,7 +380,19 @@ export const revisedFinalParagraphMarks = (
   { since = 0 }: { since?: number } = {},
 ): FinalParagraphMarkRevision[] => {
   const found: FinalParagraphMarkRevision[] = [];
-  const visit = (value: unknown, path: string, insideADeletedRow: boolean): void => {
+  // The path is kept as a stack of raw keys and formatted only where something
+  // is found. Building the string at every node instead made the walk cost
+  // more than the serialization it guards, on a package where it never has
+  // anything to report.
+  const trail: (string | number)[] = ["package"];
+  const pathOf = (): string => {
+    let path = "";
+    for (const segment of trail) {
+      path += typeof segment === "number" ? `[${String(segment)}]` : `.${segment}`;
+    }
+    return path.slice(1);
+  };
+  const visit = (value: unknown, insideADeletedRow: boolean): void => {
     if (Array.isArray(value)) {
       const last: unknown = value.at(-1);
       const mark = isParagraph(last) ? last["pPrMark"] : undefined;
@@ -389,16 +401,20 @@ export const revisedFinalParagraphMarks = (
       const revisionId = isRecord(info) ? info["id"] : undefined;
       const isOurs = typeof revisionId === "number" ? revisionId >= since : true;
       if (isAParagraphMarkChangeKind(kind) && isOurs && !insideADeletedRow) {
-        found.push({ container: path, paragraphIndex: value.length - 1, kind });
+        found.push({ container: pathOf(), paragraphIndex: value.length - 1, kind });
       }
       for (const [index, item] of value.entries()) {
-        visit(item, `${path}[${String(index)}]`, insideADeletedRow);
+        trail.push(index);
+        visit(item, insideADeletedRow);
+        trail.pop();
       }
       return;
     }
     if (value instanceof Map) {
       for (const [key, item] of value) {
-        visit(item, `${path}.${String(key)}`, insideADeletedRow);
+        trail.push(String(key));
+        visit(item, insideADeletedRow);
+        trail.pop();
       }
       return;
     }
@@ -407,9 +423,11 @@ export const revisedFinalParagraphMarks = (
     }
     const inADeletedRow = insideADeletedRow || isADeletedTableRow(value);
     for (const [key, item] of Object.entries(value)) {
-      visit(item, `${path}.${key}`, inADeletedRow);
+      trail.push(key);
+      visit(item, inADeletedRow);
+      trail.pop();
     }
   };
-  visit(packageModel, "package", false);
+  visit(packageModel, false);
   return found;
 };


### PR DESCRIPTION
Follow-up to #730, which landed the rule that a container's final paragraph mark is never deleted.

## The guard's cost

The guard walks the package model before the package is written. It built a path string at every node, which cost more than the serialization it guards on a package where it has nothing to report: about 60ms against a 175ms serialize on the largest generated document. The path is now a stack of raw keys, formatted only where something is found, which brings the walk down to roughly the cost of the model projection beside it.

## Documentation

The container-edge rule is stated where `deleteBlock` is defined: the operation vocabulary is where a caller reads what a deletion does, and the rule that the paragraph ending a container keeps its mark belongs there rather than only in the compare notes.

The compare README now also says which properties travel to the carrier — the ones the comparison compares, a paragraph style and a list level — so a reader is not left expecting alignment or spacing to move with them.

## Digests

`benchmarks/compare/digests.json` re-recorded: 195 of 207 move. The bytes a comparison writes changed with #730, #731, #734, #735, #737, #738 and #740; the README names each reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency when checking changes involving final paragraph marks, with path details calculated only when relevant findings are present.

* **Documentation**
  * Clarified how block deletion behaves at the end of containers.
  * Expanded comparison guidance covering paragraph styles, list levels, and formatting when paragraphs are removed.
  * Simplified wording in comparison test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
